### PR TITLE
fix: tx_only meters must not be re-polled during RX via reconciliation (MOR-1531)

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -507,6 +507,7 @@ class AcquisitionScheduler:
         "_prime_cursor",
         "_profile",
         "_requests_by_key",
+        "_tx_active",
     )
 
     def __init__(
@@ -536,6 +537,14 @@ class AcquisitionScheduler:
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
         self._external_cat_reason = ""
+        # MOR-1531: last ``tx_active`` observed by ``due_requests`` (the
+        # poller's cadence-drain call). ``pending_requests`` reads this same
+        # cached value to gate RECONCILIATION-priority requests for
+        # ``tx_only``-policy fields -- see that method's docstring. Defaults
+        # to True (no gating) so a scheduler whose caller never calls
+        # ``due_requests`` at all (e.g. rigctld's own drain loop, MOR-1531)
+        # keeps its pre-existing, unfiltered reconciliation behavior.
+        self._tx_active = True
 
     @property
     def provider(self) -> str:
@@ -634,11 +643,42 @@ class AcquisitionScheduler:
         )
 
     def pending_requests(self) -> tuple[AcquisitionRequest, ...]:
-        """Return queued backend acquisition requests in execution order."""
+        """Return queued backend acquisition requests in execution order.
 
+        MOR-1531: while the last ``tx_active`` reported to ``due_requests``
+        is False, ``RECONCILIATION``-priority requests for ``tx_only``-
+        policy fields are withheld from the returned tuple (root cause of
+        the live SWR-flap, MOR-1525). ``StateStore.mark_stale_due`` has no
+        notion of ``tx_only`` and emits a "stale" reconciliation hint for
+        ANY field that ages past its ``freshness_ttl_seconds``, regardless
+        of TX state; ``ensure_fresh`` queues that hint just like any other
+        request. Filtering here -- at drain time, not enqueue time -- means
+        a hint queued while TX was active but drained after de-key does not
+        fire, while a de-key/re-key race can never permanently lose it: the
+        request stays in ``_requests_by_key`` (not deleted, just withheld)
+        until a drain observes ``tx_active=True`` again. This does not
+        touch freshness decay itself -- ``mark_stale_due`` has already
+        transitioned the field to STALE in the published state before the
+        scheduler is ever consulted, so decay/unobserve keeps working
+        exactly as before; only the resulting re-poll is suppressed.
+
+        Other priorities (e.g. an explicit USER-triggered read of a
+        ``tx_only`` field) are never gated here -- see
+        ``AcquisitionPolicy.tx_only``'s docstring: only the automatic
+        reconciliation-on-stale hint is in scope for this gate, not
+        caller-triggered acquisition.
+        """
+
+        eligible = (
+            request
+            for request in self._requests_by_key.values()
+            if self._tx_active
+            or request.priority is not AcquisitionPriority.RECONCILIATION
+            or not request.policy.tx_only
+        )
         return tuple(
             sorted(
-                self._requests_by_key.values(),
+                eligible,
                 key=lambda request: (
                     -_PRIORITY_RANK[request.priority],
                     request.deadline_monotonic,
@@ -663,6 +703,17 @@ class AcquisitionScheduler:
         opinion on where that comes from.
         """
 
+        # MOR-1531: remember the caller's tx_active for this drain cycle so
+        # pending_requests() -- called immediately afterward by the web
+        # radio_poller's drain loop, the one known caller of due_requests()
+        # -- can gate RECONCILIATION requests for tx_only fields using the
+        # exact same value, without a second tx_active source of truth.
+        # rigctld's own drain loop never calls due_requests() at all (it has
+        # no cadence-poll concept of its own), so its scheduler instance
+        # keeps the __init__ default (_tx_active=True, no gating) forever --
+        # unaffected by this change. See pending_requests()'s docstring for
+        # why filtering happens there and not at enqueue time.
+        self._tx_active = tx_active
         timestamp = self._clock.now() if now is None else now
         groups = self._due_poll_groups(timestamp, tx_active=tx_active)
         queued: list[AcquisitionRequest] = []

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1351,6 +1351,184 @@ def test_due_polling_tx_only_does_not_gate_non_tx_only_meter_in_same_call() -> N
     assert requests[0].paths == (vd,)
 
 
+def test_reconciliation_of_tx_only_field_suppressed_while_tx_inactive() -> None:
+    """MOR-1531: reconciliation drain must honor ``tx_only`` like ``due_requests``.
+
+    Reproduces the live SWR-flap loop (MOR-1525): ``mark_stale_due`` emits a
+    "stale" ``ReconciliationRequest`` the moment a ``tx_only`` field (e.g.
+    ``global.meters.swr``) crosses its ``freshness_ttl_seconds`` -- even
+    though it was only ever observed once (an earlier TX, or a rigctld
+    one-shot read). Pre-fix, ``AcquisitionScheduler.ensure_fresh`` queued
+    that hint at ``RECONCILIATION`` priority with no ``tx_only`` check, and
+    ``pending_requests()`` handed it straight to the poller regardless of
+    ``tx_active`` -- the poller answered it, the field went FRESH again, and
+    it went STALE again exactly ``freshness_ttl_seconds`` later: a
+    self-sustaining poll<->decay loop in pure RX. This field is observed
+    exactly once (never re-applied here), so if the fix holds it can never
+    be drained and must simply stay STALE. A non-``tx_only`` field with the
+    identical TTL is the control: it must keep getting reconciled normally.
+    """
+
+    clock = FreshnessClock(start=500.0)
+    swr = FieldPath.global_("meters", "swr")
+    vd = FieldPath.global_("meters", "vd")
+    profile = _profile(
+        [swr, vd],
+        field_policies={
+            swr: AcquisitionPolicy(
+                cadence_seconds=None,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+            vd: AcquisitionPolicy(
+                cadence_seconds=None,
+                freshness_ttl_seconds=2.0,
+            ),
+        },
+    )
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=1.0
+    )
+
+    # Both fields observed exactly once (swr as if from an earlier TX or a
+    # rigctld one-shot cmd15 read); TX never happens again during the loop.
+    store.apply(_observation(swr, 1, at=clock.now(), max_age=2.0))
+    store.apply(_observation(vd, 130, at=clock.now(), max_age=2.0))
+
+    saw_swr_stale_transition = False
+    vd_reconciled_count = 0
+    for i in range(5):
+        clock.advance(2.1)
+        delta = service.tick(now=clock.now())
+        scheduler.due_requests(now=clock.now(), tx_active=False)
+        pending = scheduler.pending_requests()
+
+        swr_requests = [
+            r
+            for r in pending
+            if swr in r.paths and r.priority is AcquisitionPriority.RECONCILIATION
+        ]
+        assert swr_requests == [], (
+            f"iteration {i}: tx_only field re-polled via reconciliation "
+            "while TX inactive -- this is the MOR-1525 SWR-flap loop"
+        )
+
+        for transition in delta.freshness:
+            if transition.path == swr and transition.current is FreshnessState.STALE:
+                saw_swr_stale_transition = True
+
+        vd_requests = [
+            r
+            for r in pending
+            if vd in r.paths and r.priority is AcquisitionPriority.RECONCILIATION
+        ]
+        if vd_requests:
+            vd_reconciled_count += 1
+            change = store.apply(_observation(vd, 130 + i, at=clock.now(), max_age=2.0))
+            scheduler.record_acquisition_result(vd_requests[0], change)
+
+    assert saw_swr_stale_transition, (
+        "decay must still publish STALE for the tx_only field even though "
+        "its re-poll is suppressed (constraint 3)"
+    )
+    assert vd_reconciled_count >= 1, (
+        "control field (non-tx_only, same TTL) must keep getting reconciled"
+    )
+
+
+def test_reconciliation_of_tx_only_field_still_fires_while_tx_active() -> None:
+    """MOR-1531 constraint 2: TX-active reconciliation of tx_only fields is unchanged."""
+
+    clock = FreshnessClock(start=700.0)
+    swr = FieldPath.global_("meters", "swr")
+    profile = _profile(
+        [swr],
+        field_policies={
+            swr: AcquisitionPolicy(
+                cadence_seconds=None,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+        },
+    )
+    store = StateStore(freshness_clock=clock)
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    service = StateFreshnessService(
+        store=store, scheduler=scheduler, interval_seconds=1.0
+    )
+
+    store.apply(_observation(swr, 1, at=clock.now(), max_age=2.0))
+
+    clock.advance(2.1)
+    delta = service.tick(now=clock.now())
+    scheduler.due_requests(now=clock.now(), tx_active=True)
+    pending = scheduler.pending_requests()
+
+    assert delta.reconciliation_requests
+    assert any(
+        swr in r.paths and r.priority is AcquisitionPriority.RECONCILIATION
+        for r in pending
+    ), "reconciliation of a tx_only field must still fire while TX is active"
+
+
+def test_reconciliation_queued_during_tx_but_drained_after_dekey_is_deferred_not_lost() -> (
+    None
+):
+    """MOR-1531 constraint 1: drain-time consistency, not enqueue-time.
+
+    A ``RECONCILIATION`` request enqueued while the scheduler's cached
+    ``tx_active`` was True (from the same drain cycle's ``due_requests``
+    call) must not fire on the immediately following drain if TX has ended
+    by then -- the gate reads ``tx_active`` at drain time, not whatever was
+    true when the request was queued. It also must not be permanently
+    dropped: once TX resumes, the same still-queued request fires on the
+    very next drain.
+    """
+
+    clock = FreshnessClock(start=600.0)
+    swr = FieldPath.global_("meters", "swr")
+    profile = _profile(
+        [swr],
+        field_policies={
+            swr: AcquisitionPolicy(
+                cadence_seconds=None,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+
+    # Drain cycle #1: TX active -> due_requests caches tx_active=True, then a
+    # stale-reconciliation hint arrives (as StateFreshnessService would emit
+    # it) while that cached value is still True.
+    scheduler.due_requests(now=clock.now(), tx_active=True)
+    result = scheduler.ensure_fresh(
+        swr,
+        max_age=2.0,
+        priority=AcquisitionPriority.RECONCILIATION,
+        reason="stale",
+    )
+    assert result.status is AcquisitionStatus.QUEUED
+
+    # TX ends before the next drain reads pending_requests().
+    clock.advance(0.1)
+    scheduler.due_requests(now=clock.now(), tx_active=False)
+    assert scheduler.pending_requests() == (), (
+        "a reconciliation queued during TX must not fire once drained after de-key"
+    )
+
+    # TX resumes: the same still-queued request must fire -- not lost.
+    clock.advance(0.1)
+    scheduler.due_requests(now=clock.now(), tx_active=True)
+    resumed = scheduler.pending_requests()
+    assert len(resumed) == 1
+    assert resumed[0].paths == (swr,)
+    assert resumed[0].priority is AcquisitionPriority.RECONCILIATION
+
+
 def test_prime_unobserved_queues_background_read_for_never_observed_policy_field() -> (
     None
 ):


### PR DESCRIPTION
## Root cause

`tx_only` field policy was enforced in exactly one place — `_due_poll_groups` (`src/rigplane/core/acquisition_scheduler.py`, the cadence-poll path, MOR-1485). The reconciliation path bypassed it entirely:

`StateStore.mark_stale_due` (`src/rigplane/core/state_store.py:759-800`) has no notion of `tx_only` at all: it emits a `ReconciliationRequest(reason="stale")` for **any** FRESH field that ages past its `freshness_ttl_seconds`, regardless of TX state → `StateFreshnessService._queue_reconciliation` (`acquisition_scheduler.py`) forwards that hint into `AcquisitionScheduler.ensure_fresh(..., priority=RECONCILIATION)` with no `tx_only` check either → `AcquisitionScheduler.pending_requests()` handed it to the poller's `_send_scheduler_requests` (`web/radio_poller.py`) drain unconditionally.

Once a `tx_only` meter (e.g. `global.meters.swr`, `max_age=2.0`) had been observed FRESH even once — an earlier TX, or a rigctld one-shot `cmd15` read — this let it self-sustain a poll↔decay loop in pure RX at exactly its `freshness_ttl_seconds` period: FRESH → (2s) → STALE → reconciliation queued → poller answers it → FRESH again → (2s) → STALE → ... This is the operator-visible SWR readout flap 0↔1 without TX (MOR-1525).

## Mechanism trace

1. `mark_stale_due` transitions the field FRESH→STALE and emits `ReconciliationRequest(reason="stale")` — no `tx_only` awareness.
2. `StateFreshnessService.tick` → `_queue_reconciliation` → `scheduler.ensure_fresh(path, priority=RECONCILIATION, reason="stale")` — no `tx_only` check.
3. `AcquisitionScheduler.pending_requests()` returned every queued request unconditionally, including this one.
4. `RadioPoller._send_scheduler_requests` drains `pending_requests()` and sends the wire query via the executor — refreshing the field to FRESH and restarting the cycle 2s later.

Meanwhile `due_requests()` → `_due_poll_groups` *already* correctly skips `tx_only` cadence-poll groups while `tx_active=False` (MOR-1485) — but that only stops the *periodic* cadence poll, not the one-shot reconciliation hint triggered by decay, which shares the same eventual sink (`pending_requests()`) but reached it through a completely separate code path with no gate.

## Fix seat and why

Added a small `_tx_active` cache to `AcquisitionScheduler`, set by `due_requests()` (the poller's cadence-drain call, which already computes/passes `tx_active` every drain cycle — including on `codex/mor-1525-tx-active-canonical` / PR #2438, which changes *how* that value is derived but not this call shape) and read by `pending_requests()` to withhold `RECONCILIATION`-priority requests for `tx_only`-policy fields while `tx_active` is `False`.

This keeps `pending_requests()` and `due_requests()` reading the *identical* `tx_active` value for a given drain cycle — no second source of truth — without touching `web/radio_poller.py` at all, since that file is owned by the disjoint, currently-open PR #2438.

`rigctld`'s own drain loop (`rigctld/server.py`) never calls `due_requests()` (it has no cadence-poll concept of its own), so its scheduler instance never updates `_tx_active` away from the `__init__` default of `True` (no gating) — zero behavior change there, matching the ticket's web-only repro scope.

## How each design constraint is honored

1. **Drain-time consistency.** The gate reads `self._tx_active` inside `pending_requests()` (drain time), not anything baked into the request at `ensure_fresh()`/enqueue time. A request queued while `_tx_active` was cached `True` (mid-TX) is withheld the moment a later drain caches `_tx_active=False` (post-de-key) — it is never deleted, just excluded from the returned tuple, so a subsequent drain with `_tx_active=True` again (re-key) returns it normally. Covered by `test_reconciliation_queued_during_tx_but_drained_after_dekey_is_deferred_not_lost`.
2. **During TX unchanged.** The filter only applies `if not self._tx_active`; while `True`, `RECONCILIATION` requests for `tx_only` fields flow through exactly as before. Covered by `test_reconciliation_of_tx_only_field_still_fires_while_tx_active`.
3. **Decay preserved.** The gate lives entirely in `pending_requests()`/`AcquisitionScheduler`; `StateStore.mark_stale_due` (which performs the FRESH→STALE transition published to the UI) is untouched — the field still goes STALE and decays/unobserves normally, only the resulting re-poll is suppressed. Covered by the `saw_swr_stale_transition` assertion in `test_reconciliation_of_tx_only_field_suppressed_while_tx_inactive`.
4. **Generic mechanism.** The gate keys off `AcquisitionPolicy.tx_only` (already used by `_due_poll_groups`/MOR-1485) and `AcquisitionRequest.priority is RECONCILIATION` — no field names hardcoded anywhere in the change.

Other request priorities (e.g. an explicit `USER`-triggered read of a `tx_only` field) are unaffected — this matches `AcquisitionPolicy.tx_only`'s existing documented contract ("Honored by `due_requests`'s `tx_active` gate, not by `ensure_fresh`... an explicit caller-triggered read is never blocked by this flag"). The new gate only touches the automatic `RECONCILIATION`-priority hint, which is the sole caller of that priority in the codebase.

## Tests (all in `tests/test_acquisition_scheduler.py`)

- `test_reconciliation_of_tx_only_field_suppressed_while_tx_inactive` — reproduces the verifier's loop: a `tx_only` field is observed exactly once, `tx_active=False` throughout, clock advances past `freshness_ttl_seconds` across 5 iterations. Asserts **zero** `RECONCILIATION` requests ever appear for the `tx_only` field (zero wire re-reads), while a non-`tx_only` control field with the identical TTL keeps getting reconciled normally, and the `tx_only` field still transitions to STALE in the published delta.
- `test_reconciliation_of_tx_only_field_still_fires_while_tx_active` — constraint 2: reconciliation of a `tx_only` field while `tx_active=True` throughout is unaffected.
- `test_reconciliation_queued_during_tx_but_drained_after_dekey_is_deferred_not_lost` — constraint 1: a request enqueued while the cached `tx_active` was `True` does not fire on the next drain if `tx_active` is now `False`, but is *not* lost — it fires on the drain after `tx_active` returns to `True`.

**Red-first evidence:** ran the first and third tests against unmodified `origin/main` before implementing the fix — both failed exactly as expected:
```
FAILED test_reconciliation_of_tx_only_field_suppressed_while_tx_inactive
  AssertionError: iteration 0: tx_only field re-polled via reconciliation
  while TX inactive -- this is the MOR-1525 SWR-flap loop

FAILED test_reconciliation_queued_during_tx_but_drained_after_dekey_is_deferred_not_lost
  AssertionError: a reconciliation queued during TX must not fire once
  drained after de-key
```
The second test (`..._still_fires_while_tx_active`) passed unmodified on `main`, as expected since that behavior was never broken. All three pass after the fix; full `tests/test_acquisition_scheduler.py` (81 tests) plus `test_state_store.py`, `test_radio_poller_coverage.py`, `test_rigctld_handler.py`, `test_rigctld_server.py`, `test_civ_rx_coverage.py` (1111 tests total) pass with zero regressions. `ruff check`/`ruff format --check` clean, `lint-imports` clean, `mypy src/` unchanged at 13 pre-existing errors (none in touched files).

Closes MOR-1531
Refs MOR-1525
