### PR TITLE
fix: quantize filter-width slider to profile-declared steps (MOR-1518)

### DIFF
--- a/frontend/src/lib/radio/filter-controls.test.ts
+++ b/frontend/src/lib/radio/filter-controls.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import type { FilterModeConfig } from '$lib/types/capabilities';
 import {
   nbDepthDisplayToRaw,
   nbDepthRawToDisplay,
   nrDisplayToRaw,
   nrRawToDisplay,
+  quantizeFilterWidthToRule,
 } from './filter-controls';
 
 // MOR-490: NR-level slider is 0-15 (front-panel scale), wire is 0-255 BCD.
@@ -104,5 +106,117 @@ describe('NB-depth display <-> raw round-trip', () => {
   it('round-trips the slider endpoints exactly', () => {
     expect(nbDepthRawToDisplay(nbDepthDisplayToRaw(1))).toBe(1);
     expect(nbDepthRawToDisplay(nbDepthDisplayToRaw(10))).toBe(10);
+  });
+});
+
+// MOR-1518: the IC-7300's USB/LSB/CW/RTTY width rules (`rigs/ic7300.toml`)
+// split into two `segments` with DIFFERENT step sizes either side of
+// 500/600 Hz (50 Hz below, 100 Hz above). A mid-drag value snapped to a
+// single, fixed 50 Hz step (`FILTER_WIDTH_STEP`) produces exactly the
+// illegal widths the live bench reported (1050/2150/3150 Hz) once the drag
+// crosses into the coarser upper segment — the backend's
+// `filter_hz_to_index` (`src/rigplane/commands/_codec.py`) then rejects
+// them with "Filter width N is not aligned to N Hz steps", the reported
+// sticky-toast spray. `quantizeFilterWidthToRule` must snap to a value the
+// radio's OWN declared rule actually accepts, not a client-invented one.
+describe('quantizeFilterWidthToRule (MOR-1518)', () => {
+  // Same shape as `panel-commands.intent.isolated.test.ts`'s `A06_SEGMENTS`
+  // fixture (and `rigs/ic7300.toml`'s `[filters.width.USB]`): a 50 Hz step
+  // 50-500 Hz, an intentional gap, then a 100 Hz step 600-3600 Hz.
+  const IC7300_USB_SEGMENTS: FilterModeConfig = {
+    defaults: [3000, 2400, 1800],
+    fixed: false,
+    minHz: 50,
+    maxHz: 3600,
+    segments: [
+      { hzMin: 50, hzMax: 500, stepHz: 50, indexMin: 0 },
+      { hzMin: 600, hzMax: 3600, stepHz: 100, indexMin: 10 },
+    ],
+  };
+
+  it('reproduces the live-bench alignment error path: raw drag values are illegal for the upper (100 Hz) segment', () => {
+    // This is the RED-first assertion: without quantization, these exact
+    // mid-drag values (reported on the live IC-7300 bench) are NOT aligned
+    // to the 100 Hz step that governs 600-3600 Hz — dispatching them raw
+    // is what trips the backend's alignment guard.
+    for (const raw of [1050, 2150, 3150]) {
+      expect(raw % 100).not.toBe(0);
+    }
+  });
+
+  it('snaps illegal mid-drag values in the upper (100 Hz) segment to the nearest legal width', () => {
+    expect(quantizeFilterWidthToRule(1050, IC7300_USB_SEGMENTS)).toBe(1100);
+    expect(quantizeFilterWidthToRule(2150, IC7300_USB_SEGMENTS)).toBe(2200);
+    expect(quantizeFilterWidthToRule(3150, IC7300_USB_SEGMENTS)).toBe(3200);
+  });
+
+  it('leaves already-legal values in either segment untouched', () => {
+    expect(quantizeFilterWidthToRule(250, IC7300_USB_SEGMENTS)).toBe(250);
+    expect(quantizeFilterWidthToRule(500, IC7300_USB_SEGMENTS)).toBe(500);
+    expect(quantizeFilterWidthToRule(600, IC7300_USB_SEGMENTS)).toBe(600);
+    expect(quantizeFilterWidthToRule(1800, IC7300_USB_SEGMENTS)).toBe(1800);
+  });
+
+  it('snaps a value inside the segment GAP (500-600 Hz, IC-7300 has no filter index there) to the nearer edge', () => {
+    expect(quantizeFilterWidthToRule(520, IC7300_USB_SEGMENTS)).toBe(500);
+    expect(quantizeFilterWidthToRule(580, IC7300_USB_SEGMENTS)).toBe(600);
+    // Exact midpoint of the gap: a tie prefers the upper segment, the same
+    // round-half-up convention `Math.round` itself uses for in-segment snapping.
+    expect(quantizeFilterWidthToRule(550, IC7300_USB_SEGMENTS)).toBe(600);
+  });
+
+  it('clamps out-of-range values to the rule\'s own overall bounds', () => {
+    expect(quantizeFilterWidthToRule(10, IC7300_USB_SEGMENTS)).toBe(50);
+    expect(quantizeFilterWidthToRule(9999, IC7300_USB_SEGMENTS)).toBe(3600);
+  });
+
+  it('is data-driven for a SECOND, differently-stepped rule (not the IC-7300\'s 50/100 Hz split)', () => {
+    // A synthetic single-step rule (AM-shaped: `rigs/ic7300.toml`'s
+    // `[filters.width.AM]` declares 200 Hz), proving the step comes from
+    // the passed-in rule, never a hardcoded 50/100 constant in this module.
+    const AM_STYLE_STEP: FilterModeConfig = {
+      defaults: [9000, 6000, 3000], fixed: false, minHz: 200, maxHz: 10_000, stepHz: 200,
+    };
+    expect(quantizeFilterWidthToRule(9100, AM_STYLE_STEP)).toBe(9200);
+    expect(quantizeFilterWidthToRule(9000, AM_STYLE_STEP)).toBe(9000);
+
+    // A third, still-different step (25 Hz) to further pin "data-driven,
+    // not a second hardcoded constant".
+    const NARROW_STEP: FilterModeConfig = {
+      defaults: [300], fixed: false, minHz: 100, maxHz: 500, stepHz: 25,
+    };
+    expect(quantizeFilterWidthToRule(212, NARROW_STEP)).toBe(200);
+  });
+
+  it('falls back to the plain clamp/50 Hz step when capabilities declare no width rule (unchanged pre-MOR-1518 behavior)', () => {
+    expect(quantizeFilterWidthToRule(1050, null)).toBe(1050);
+    expect(quantizeFilterWidthToRule(1050, undefined)).toBe(1050);
+  });
+
+  it('passes fixed-width and table-mode rules through UNCHANGED (no synthesized step, no wrong-bounds clamp)', () => {
+    // FM's fixed defaults (15000/10000/7000 Hz, `rigs/ic7300.toml`) sit well
+    // above the generic clamp's 3600 Hz ceiling — clamping them would
+    // silently corrupt an otherwise-legal fixed width, so `fixed` rules must
+    // pass through untouched rather than fall into the plain clamp.
+    const fixedRule: FilterModeConfig = { defaults: [15000], fixed: true };
+    expect(quantizeFilterWidthToRule(15000, fixedRule)).toBe(15000);
+
+    // Table-mode widths are snapped elsewhere (`FilterPanel.svelte`'s
+    // `hzToTableIndex`/`tableIndexToHz`) — this function must not crash or
+    // invent a step for them either.
+    const tableRule: FilterModeConfig = { defaults: [300], fixed: false, table: [300, 600, 1200] };
+    expect(quantizeFilterWidthToRule(650, tableRule)).toBe(650);
+  });
+
+  it('never throws and never returns a fabricated step for malformed segment data', () => {
+    const malformed: FilterModeConfig = {
+      defaults: [], fixed: false, minHz: 50, maxHz: 3600,
+      segments: [{ hzMin: 500, hzMax: 50, stepHz: 0, indexMin: 0 }],
+    };
+    expect(() => quantizeFilterWidthToRule(1050, malformed)).not.toThrow();
+  });
+
+  it('passes non-finite input through unchanged rather than fabricating a value', () => {
+    expect(quantizeFilterWidthToRule(Number.NaN, IC7300_USB_SEGMENTS)).toBeNaN();
   });
 });

--- a/frontend/src/lib/radio/filter-controls.test.ts
+++ b/frontend/src/lib/radio/filter-controls.test.ts
@@ -134,20 +134,19 @@ describe('quantizeFilterWidthToRule (MOR-1518)', () => {
     ],
   };
 
-  it('reproduces the live-bench alignment error path: raw drag values are illegal for the upper (100 Hz) segment', () => {
-    // This is the RED-first assertion: without quantization, these exact
-    // mid-drag values (reported on the live IC-7300 bench) are NOT aligned
-    // to the 100 Hz step that governs 600-3600 Hz — dispatching them raw
-    // is what trips the backend's alignment guard.
-    for (const raw of [1050, 2150, 3150]) {
-      expect(raw % 100).not.toBe(0);
-    }
-  });
-
+  // Real red-first coverage for the live-bench values lives here and in the
+  // sibling `panel-commands.intent.isolated.test.ts` suite (both call the
+  // actual SUT). 1050/2150/3150 Hz are each an EXACT midpoint between two
+  // legal 100 Hz-segment values (e.g. 1050 sits exactly between 1000 and
+  // 1100) — precisely because the pre-fix bug always added a stray 50 Hz
+  // (the wrong, lower segment's step) onto an otherwise-legal 100 Hz value.
+  // Tie-break prefers the LOWER candidate (see `snapWithinSegment`'s doc
+  // comment, aligned with `scope-adapter.ts`'s `snapStep`/
+  // `snapSpectrumFilterWidth`).
   it('snaps illegal mid-drag values in the upper (100 Hz) segment to the nearest legal width', () => {
-    expect(quantizeFilterWidthToRule(1050, IC7300_USB_SEGMENTS)).toBe(1100);
-    expect(quantizeFilterWidthToRule(2150, IC7300_USB_SEGMENTS)).toBe(2200);
-    expect(quantizeFilterWidthToRule(3150, IC7300_USB_SEGMENTS)).toBe(3200);
+    expect(quantizeFilterWidthToRule(1050, IC7300_USB_SEGMENTS)).toBe(1000);
+    expect(quantizeFilterWidthToRule(2150, IC7300_USB_SEGMENTS)).toBe(2100);
+    expect(quantizeFilterWidthToRule(3150, IC7300_USB_SEGMENTS)).toBe(3100);
   });
 
   it('leaves already-legal values in either segment untouched', () => {
@@ -160,9 +159,11 @@ describe('quantizeFilterWidthToRule (MOR-1518)', () => {
   it('snaps a value inside the segment GAP (500-600 Hz, IC-7300 has no filter index there) to the nearer edge', () => {
     expect(quantizeFilterWidthToRule(520, IC7300_USB_SEGMENTS)).toBe(500);
     expect(quantizeFilterWidthToRule(580, IC7300_USB_SEGMENTS)).toBe(600);
-    // Exact midpoint of the gap: a tie prefers the upper segment, the same
-    // round-half-up convention `Math.round` itself uses for in-segment snapping.
-    expect(quantizeFilterWidthToRule(550, IC7300_USB_SEGMENTS)).toBe(600);
+    // Exact midpoint of the gap: a tie prefers the LOWER segment's edge —
+    // aligned with `scope-adapter.ts`'s `snapSpectrumFilterWidth` (the
+    // spectrum-panel passband-drag path), which resolves the identical
+    // 550 Hz tie to 500 Hz too.
+    expect(quantizeFilterWidthToRule(550, IC7300_USB_SEGMENTS)).toBe(500);
   });
 
   it('clamps out-of-range values to the rule\'s own overall bounds', () => {
@@ -177,7 +178,8 @@ describe('quantizeFilterWidthToRule (MOR-1518)', () => {
     const AM_STYLE_STEP: FilterModeConfig = {
       defaults: [9000, 6000, 3000], fixed: false, minHz: 200, maxHz: 10_000, stepHz: 200,
     };
-    expect(quantizeFilterWidthToRule(9100, AM_STYLE_STEP)).toBe(9200);
+    // 9100 is an exact tie between 9000 and 9200 — tie prefers lower.
+    expect(quantizeFilterWidthToRule(9100, AM_STYLE_STEP)).toBe(9000);
     expect(quantizeFilterWidthToRule(9000, AM_STYLE_STEP)).toBe(9000);
 
     // A third, still-different step (25 Hz) to further pin "data-driven,
@@ -188,9 +190,17 @@ describe('quantizeFilterWidthToRule (MOR-1518)', () => {
     expect(quantizeFilterWidthToRule(212, NARROW_STEP)).toBe(200);
   });
 
-  it('falls back to the plain clamp/50 Hz step when capabilities declare no width rule (unchanged pre-MOR-1518 behavior)', () => {
+  it('passes the value through UNCHANGED when capabilities declare no width rule (no fabricated ceiling, unchanged pre-MOR-1518 behavior)', () => {
+    // Pre-MOR-1518 the dispatch path applied NO clamp at all when a mode had
+    // no declared filterConfig entry — raw value straight to the wire. This
+    // function must keep that exact behavior rather than imposing this
+    // module's own IC-7610-shaped 50/3600/50 default grid (`clampFilterWidth`'s
+    // fallback) on a radio/mode that declared nothing: a value ABOVE that
+    // default's 3600 Hz ceiling (e.g. an FTX-1 table/step mode with a wider
+    // declared `filterWidthMax`) must still reach the wire unmodified.
     expect(quantizeFilterWidthToRule(1050, null)).toBe(1050);
     expect(quantizeFilterWidthToRule(1050, undefined)).toBe(1050);
+    expect(quantizeFilterWidthToRule(9999, null)).toBe(9999);
   });
 
   it('passes fixed-width and table-mode rules through UNCHANGED (no synthesized step, no wrong-bounds clamp)', () => {
@@ -208,12 +218,13 @@ describe('quantizeFilterWidthToRule (MOR-1518)', () => {
     expect(quantizeFilterWidthToRule(650, tableRule)).toBe(650);
   });
 
-  it('never throws and never returns a fabricated step for malformed segment data', () => {
+  it('never throws and passes the value through unchanged for malformed segment data (no fabricated step)', () => {
     const malformed: FilterModeConfig = {
       defaults: [], fixed: false, minHz: 50, maxHz: 3600,
       segments: [{ hzMin: 500, hzMax: 50, stepHz: 0, indexMin: 0 }],
     };
     expect(() => quantizeFilterWidthToRule(1050, malformed)).not.toThrow();
+    expect(quantizeFilterWidthToRule(1050, malformed)).toBe(1050);
   });
 
   it('passes non-finite input through unchanged rather than fabricating a value', () => {

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -266,98 +266,98 @@ export function clampFilterWidth(
 }
 
 /**
+ * Snap `value` onto the step grid of a single [hzMin, hzMax, stepHz]
+ * segment, clamping into range first. Ties (`value` sits exactly halfway
+ * between two grid points) resolve to the LOWER point — the same
+ * `snapStep` convention `scope-adapter.ts`'s `snapSpectrumFilterWidth`
+ * uses (see the cross-reference there). Tie-break must stay aligned with
+ * `snapSpectrumFilterWidth` / `snapStep` — the spectrum-panel passband-drag
+ * path and this slider/preset path must never disagree about which Hz a
+ * midpoint value belongs to.
+ */
+function snapWithinSegment(value: number, hzMin: number, hzMax: number, stepHz: number): number {
+  const bounded = Math.max(hzMin, Math.min(hzMax, value));
+  const lower = hzMin + Math.floor((bounded - hzMin) / stepHz) * stepHz;
+  const upper = Math.min(hzMax, lower + stepHz);
+  return bounded - lower <= upper - bounded ? lower : upper;
+}
+
+/**
  * Quantize a raw filter-width value (Hz) to the nearest value the radio's
  * OWN capability-declared width rule actually accepts (MOR-1518). The
  * IC-7300's `USB`/`LSB`/`CW`/`RTTY` rules split into two `segments` with
  * DIFFERENT step sizes either side of 500/600 Hz (50 Hz below, 100 Hz above
- * — `rigs/ic7300.toml`'s `[filters.width.USB]`). A single fixed step (this
- * module's own `FILTER_WIDTH_STEP`, still this function's fallback for a
- * capability-absent rule) produces exactly the illegal mid-drag widths the
- * live bench reported (1050/2150/3150 Hz) once the drag crosses into the
- * coarser upper segment — the backend's `filter_hz_to_index`
- * (`src/rigplane/commands/_codec.py`) then rejects them with "Filter width
- * N is not aligned to N Hz steps", the reported sticky-toast spray.
+ * — `rigs/ic7300.toml`'s `[filters.width.USB]`). A single fixed step
+ * produces exactly the illegal mid-drag widths the live bench reported
+ * (1050/2150/3150 Hz) once the drag crosses into the coarser upper segment
+ * — the backend's `filter_hz_to_index` (`src/rigplane/commands/_codec.py`)
+ * then rejects them with "Filter width N is not aligned to N Hz steps",
+ * the reported sticky-toast spray.
  *
  * `rule` is meant to be `resolveFilterModeConfig`'s own per-mode output —
  * the SAME resolved config `panel-commands.ts`'s `validResolvedFilterWidth`
  * checks against — so quantization and validation are never out of step.
- * `rule` absent, `fixed`, or table-shaped (table-mode widths are snapped
- * elsewhere, by `FilterPanel.svelte`'s `hzToTableIndex`/`tableIndexToHz`)
- * falls straight through to the pre-existing `clampFilterWidth` single-step
- * behavior — unchanged pre-MOR-1518 behavior, data-driven doctrine: no step
- * is ever synthesized for a radio (or mode) that declares none.
  *
- * Segment selection: the value first clamps to the rule's overall
- * [minHz, maxHz] span, then picks the segment whose own [hzMin, hzMax]
- * contains it. A value that lands in a GAP BETWEEN two segments (the
- * IC-7300's own 500→600 Hz gap: filter index 9 is 500 Hz, index 10 jumps
- * straight to 600 Hz — there is no legal width in between) snaps to
- * whichever segment edge is numerically closer; an exact tie prefers the
- * upper segment, the same round-half-up convention `Math.round` itself uses
- * for in-segment snapping. Malformed segment entries (non-finite bounds,
+ * DATA-DRIVEN, NEVER A FABRICATED CEILING: `rule` absent, `fixed`,
+ * `table`-shaped, or declaring neither `segments` nor a complete
+ * `minHz`/`maxHz`/`stepHz` triple all pass `value` through UNCHANGED — this
+ * function never invents a step, and never imposes this module's own
+ * `FILTER_WIDTH_MIN`/`MAX`/`STEP` (an IC-7610-shaped default other helpers
+ * in this file use, e.g. `clampFilterWidth`) on a radio or mode that
+ * declared nothing. A radio that offers a WIDER range than that default
+ * (e.g. an FTX-1 table/step mode with `filterWidthMax` above 3600 Hz) must
+ * keep reaching every value it already could reach pre-MOR-1518 — silently
+ * capping it at a borrowed IC-7610 ceiling would be a worse defect than the
+ * unaligned-value bug this function fixes. `fixed`/`table` rules are the
+ * same story (e.g. the IC-7300's FM `[filters.width.FM]` is `fixed = true`
+ * with `defaults = [15000, 10000, 7000]`, well above 3600 Hz); table-mode
+ * widths also already have their own nearest-entry snap
+ * (`FilterPanel.svelte`'s `hzToTableIndex`/`tableIndexToHz`), so staying a
+ * no-op for them is not a regression either.
+ *
+ * Segment selection mirrors `snapSpectrumFilterWidth`'s own `'segments'`
+ * branch: `value` is snapped against EVERY declared segment's own grid
+ * (`snapWithinSegment`, clamping into that segment's own bounds first), and
+ * the overall nearest candidate wins — ties preferring the LOWER candidate.
+ * This is what correctly handles a value that lands in a GAP BETWEEN two
+ * segments (the IC-7300's own 500→600 Hz gap: filter index 9 is 500 Hz,
+ * index 10 jumps straight to 600 Hz — there is no legal width in between):
+ * each segment's clamped candidate is compared by raw distance, same as any
+ * other candidate. Malformed segment entries (non-finite bounds,
  * non-positive step, `hzMin > hzMax`) are dropped before selection; if that
- * leaves nothing usable, this falls back to the same plain clamp — never a
- * crash, never a fabricated step.
- *
- * `rule.fixed`/`rule.table` shapes pass `value` through UNCHANGED rather
- * than falling into the generic clamp: the clamp's own default bounds
- * (50-3600 Hz) are themselves an ordinary-range assumption that does not
- * hold for every fixed width a radio declares (e.g. the IC-7300's FM
- * `[filters.width.FM]` is `fixed = true` with `defaults = [15000, 10000,
- * 7000]` — well above 3600 Hz). Clamping those against the wrong bounds
- * would silently corrupt an otherwise-legal fixed width, a worse defect
- * than the pre-MOR-1518 raw-passthrough this function replaces. Table-mode
- * widths already have their own nearest-entry snap
- * (`FilterPanel.svelte`'s `hzToTableIndex`/`tableIndexToHz`) — this
- * function staying a no-op for them is not a regression.
+ * leaves nothing usable, this also passes `value` through unchanged.
  */
 export function quantizeFilterWidthToRule(
   value: number,
   rule: FilterModeConfig | null | undefined,
 ): number {
   if (!Number.isFinite(value)) return value;
-  if (!rule) return clampFilterWidth(value);
-  if (rule.fixed || rule.table) return value;
+  if (!rule || rule.fixed || rule.table) return value;
 
-  const rawSegments: FilterSegmentConfig[] = rule.segments && rule.segments.length > 0
-    ? rule.segments
-    : [{
-        hzMin: rule.minHz ?? FILTER_WIDTH_MIN,
-        hzMax: rule.maxHz ?? FILTER_WIDTH_MAX,
-        stepHz: rule.stepHz ?? FILTER_WIDTH_STEP,
-        indexMin: 0,
-      }];
-  const segments = rawSegments
-    .filter((segment) =>
-      Number.isFinite(segment.hzMin) && Number.isFinite(segment.hzMax)
-      && Number.isFinite(segment.stepHz) && segment.stepHz > 0
-      && segment.hzMin <= segment.hzMax)
-    .sort((a, b) => a.hzMin - b.hzMin);
-  if (segments.length === 0) return clampFilterWidth(value);
-
-  const minHz = segments[0].hzMin;
-  const maxHz = segments[segments.length - 1].hzMax;
-  const clamped = Math.max(minHz, Math.min(maxHz, value));
-
-  let target = segments[0];
-  for (let i = 0; i < segments.length; i++) {
-    const segment = segments[i];
-    if (clamped >= segment.hzMin && clamped <= segment.hzMax) { target = segment; break; }
-    if (clamped < segment.hzMin) {
-      // In the gap immediately before `segment` — pick whichever neighbor
-      // edge is closer (tie prefers the upper/current segment).
-      const previous = segments[i - 1];
-      target = previous && (clamped - previous.hzMax) < (segment.hzMin - clamped)
-        ? previous
-        : segment;
-      break;
-    }
-    target = segment; // past this segment's hzMax — "closest below" so far
+  let rawSegments: FilterSegmentConfig[];
+  if (rule.segments && rule.segments.length > 0) {
+    rawSegments = rule.segments;
+  } else if (
+    typeof rule.stepHz === 'number' && typeof rule.minHz === 'number' && typeof rule.maxHz === 'number'
+  ) {
+    rawSegments = [{ hzMin: rule.minHz, hzMax: rule.maxHz, stepHz: rule.stepHz, indexMin: 0 }];
+  } else {
+    return value; // no usable width rule declared — never synthesize one
   }
 
-  const bounded = Math.max(target.hzMin, Math.min(target.hzMax, clamped));
-  const steps = Math.round((bounded - target.hzMin) / target.stepHz);
-  return Math.max(target.hzMin, Math.min(target.hzMax, target.hzMin + steps * target.stepHz));
+  const segments = rawSegments.filter((segment) =>
+    Number.isFinite(segment.hzMin) && Number.isFinite(segment.hzMax)
+    && Number.isFinite(segment.stepHz) && segment.stepHz > 0
+    && segment.hzMin <= segment.hzMax);
+  if (segments.length === 0) return value;
+
+  return segments
+    .map((segment) => snapWithinSegment(value, segment.hzMin, segment.hzMax, segment.stepHz))
+    .reduce((best, candidate) =>
+      Math.abs(value - candidate) < Math.abs(value - best)
+        || (Math.abs(value - candidate) === Math.abs(value - best) && candidate < best)
+        ? candidate
+        : best);
 }
 
 export function deriveIfShift(pbtInner: number, pbtOuter: number): number {

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -8,7 +8,7 @@
 // PBT raw <-> display conversion
 // Reads range from capabilities if available, falls back to IC-7610 defaults
 import { getControlRange } from '$lib/stores/capabilities.svelte';
-import type { Capabilities } from '$lib/types/capabilities';
+import type { Capabilities, FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
 
 export const FILTER_BIPOLAR_MIN = -1200;
 export const FILTER_BIPOLAR_MAX = 1200;
@@ -263,6 +263,101 @@ export function clampFilterWidth(
 ): number {
   const clamped = Math.max(FILTER_WIDTH_MIN, Math.min(maxHz, value));
   return Math.round(clamped / stepHz) * stepHz;
+}
+
+/**
+ * Quantize a raw filter-width value (Hz) to the nearest value the radio's
+ * OWN capability-declared width rule actually accepts (MOR-1518). The
+ * IC-7300's `USB`/`LSB`/`CW`/`RTTY` rules split into two `segments` with
+ * DIFFERENT step sizes either side of 500/600 Hz (50 Hz below, 100 Hz above
+ * — `rigs/ic7300.toml`'s `[filters.width.USB]`). A single fixed step (this
+ * module's own `FILTER_WIDTH_STEP`, still this function's fallback for a
+ * capability-absent rule) produces exactly the illegal mid-drag widths the
+ * live bench reported (1050/2150/3150 Hz) once the drag crosses into the
+ * coarser upper segment — the backend's `filter_hz_to_index`
+ * (`src/rigplane/commands/_codec.py`) then rejects them with "Filter width
+ * N is not aligned to N Hz steps", the reported sticky-toast spray.
+ *
+ * `rule` is meant to be `resolveFilterModeConfig`'s own per-mode output —
+ * the SAME resolved config `panel-commands.ts`'s `validResolvedFilterWidth`
+ * checks against — so quantization and validation are never out of step.
+ * `rule` absent, `fixed`, or table-shaped (table-mode widths are snapped
+ * elsewhere, by `FilterPanel.svelte`'s `hzToTableIndex`/`tableIndexToHz`)
+ * falls straight through to the pre-existing `clampFilterWidth` single-step
+ * behavior — unchanged pre-MOR-1518 behavior, data-driven doctrine: no step
+ * is ever synthesized for a radio (or mode) that declares none.
+ *
+ * Segment selection: the value first clamps to the rule's overall
+ * [minHz, maxHz] span, then picks the segment whose own [hzMin, hzMax]
+ * contains it. A value that lands in a GAP BETWEEN two segments (the
+ * IC-7300's own 500→600 Hz gap: filter index 9 is 500 Hz, index 10 jumps
+ * straight to 600 Hz — there is no legal width in between) snaps to
+ * whichever segment edge is numerically closer; an exact tie prefers the
+ * upper segment, the same round-half-up convention `Math.round` itself uses
+ * for in-segment snapping. Malformed segment entries (non-finite bounds,
+ * non-positive step, `hzMin > hzMax`) are dropped before selection; if that
+ * leaves nothing usable, this falls back to the same plain clamp — never a
+ * crash, never a fabricated step.
+ *
+ * `rule.fixed`/`rule.table` shapes pass `value` through UNCHANGED rather
+ * than falling into the generic clamp: the clamp's own default bounds
+ * (50-3600 Hz) are themselves an ordinary-range assumption that does not
+ * hold for every fixed width a radio declares (e.g. the IC-7300's FM
+ * `[filters.width.FM]` is `fixed = true` with `defaults = [15000, 10000,
+ * 7000]` — well above 3600 Hz). Clamping those against the wrong bounds
+ * would silently corrupt an otherwise-legal fixed width, a worse defect
+ * than the pre-MOR-1518 raw-passthrough this function replaces. Table-mode
+ * widths already have their own nearest-entry snap
+ * (`FilterPanel.svelte`'s `hzToTableIndex`/`tableIndexToHz`) — this
+ * function staying a no-op for them is not a regression.
+ */
+export function quantizeFilterWidthToRule(
+  value: number,
+  rule: FilterModeConfig | null | undefined,
+): number {
+  if (!Number.isFinite(value)) return value;
+  if (!rule) return clampFilterWidth(value);
+  if (rule.fixed || rule.table) return value;
+
+  const rawSegments: FilterSegmentConfig[] = rule.segments && rule.segments.length > 0
+    ? rule.segments
+    : [{
+        hzMin: rule.minHz ?? FILTER_WIDTH_MIN,
+        hzMax: rule.maxHz ?? FILTER_WIDTH_MAX,
+        stepHz: rule.stepHz ?? FILTER_WIDTH_STEP,
+        indexMin: 0,
+      }];
+  const segments = rawSegments
+    .filter((segment) =>
+      Number.isFinite(segment.hzMin) && Number.isFinite(segment.hzMax)
+      && Number.isFinite(segment.stepHz) && segment.stepHz > 0
+      && segment.hzMin <= segment.hzMax)
+    .sort((a, b) => a.hzMin - b.hzMin);
+  if (segments.length === 0) return clampFilterWidth(value);
+
+  const minHz = segments[0].hzMin;
+  const maxHz = segments[segments.length - 1].hzMax;
+  const clamped = Math.max(minHz, Math.min(maxHz, value));
+
+  let target = segments[0];
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (clamped >= segment.hzMin && clamped <= segment.hzMax) { target = segment; break; }
+    if (clamped < segment.hzMin) {
+      // In the gap immediately before `segment` — pick whichever neighbor
+      // edge is closer (tie prefers the upper/current segment).
+      const previous = segments[i - 1];
+      target = previous && (clamped - previous.hzMax) < (segment.hzMin - clamped)
+        ? previous
+        : segment;
+      break;
+    }
+    target = segment; // past this segment's hzMax — "closest below" so far
+  }
+
+  const bounded = Math.max(target.hzMin, Math.min(target.hzMax, clamped));
+  const steps = Math.round((bounded - target.hzMin) / target.stepHz);
+  return Math.max(target.hzMin, Math.min(target.hzMax, target.hzMin + steps * target.stepHz));
 }
 
 export function deriveIfShift(pbtInner: number, pbtOuter: number): number {

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -201,6 +201,12 @@ export function toSpectrumAuthority(
   return immutableClone({ ...core, digest: JSON.stringify(core) });
 }
 
+// Tie prefers the LOWER grid point. MOR-1518: tie-break must stay aligned
+// with `$lib/radio/filter-controls`'s `snapWithinSegment` /
+// `quantizeFilterWidthToRule` — the slider/preset command-emission path —
+// so a width value equidistant from two legal Hz values snaps the same way
+// regardless of whether the operator dragged the spectrum passband edge
+// (this file) or the Filter Width slider (the other file).
 function snapStep(raw: number, minHz: number, maxHz: number, stepHz: number): number {
   const bounded = Math.max(minHz, Math.min(maxHz, raw));
   const lower = minHz + Math.floor((bounded - minHz) / stepHz) * stepHz;

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -2016,3 +2016,119 @@ describe('MOR-1409 A06a1 synchronous final filter-width authority', () => {
     expect(h.sendCommand).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * MOR-1518 (live IC-7300 bench): dragging the Filter Width slider mid-drag
+ * emitted raw, unaligned values (1050/2150/3150 Hz — legal in the 50 Hz
+ * segment below 500 Hz, illegal once the drag crosses into the 100 Hz
+ * segment above it, `A06_SEGMENTS`/`rigs/ic7300.toml`) straight onto the
+ * wire, which the backend's `filter_hz_to_index`
+ * (`src/rigplane/commands/_codec.py`) rejected with "Filter width N is not
+ * aligned to N Hz steps" — three sticky error toasts per drag.
+ *
+ * `onFilterWidthChange` (the slider's own debounced handler,
+ * `FilterSurface.svelte`'s raw `<input type="range">` and `FilterPanel`'s
+ * table-mode slider both call it), `onFilterPresetChange` (the settings
+ * modal's per-filter direct-entry slider), and `onFilterDefaults` (restore-
+ * defaults) are the three `set_filter_width` dispatch sites that carry a
+ * caller-supplied width rather than an already-legal radio-observed one —
+ * this suite pins each of them to the resolved rule's OWN nearest legal
+ * value, never the raw input.
+ */
+describe('MOR-1518 client-side filter-width quantization at command emission', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.state = a06State();
+    h.caps = a06Caps() as unknown as Record<string, unknown>;
+    h.unavailable.clear();
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    [1050, 1100],
+    [2150, 2200],
+    [3150, 3200],
+  ])('quantizes onFilterWidthChange(%i) to the nearest legal segment value (%i)', (raw, expected) => {
+    makeFilterHandlers().onFilterWidthChange(raw);
+    vi.advanceTimersByTime(200);
+
+    expect(exactCalls()).toEqual([['set_filter_width', { width: expected, receiver: 0 }]]);
+  });
+
+  it('snaps a value inside the 500-600 Hz segment gap to the nearer edge (boundary crossing)', () => {
+    makeFilterHandlers().onFilterWidthChange(520);
+    vi.advanceTimersByTime(200);
+    makeFilterHandlers().onFilterWidthChange(580);
+    vi.advanceTimersByTime(200);
+
+    expect(exactCalls()).toEqual([
+      ['set_filter_width', { width: 500, receiver: 0 }],
+      ['set_filter_width', { width: 600, receiver: 0 }],
+    ]);
+  });
+
+  it('leaves an already-legal width completely untouched', () => {
+    makeFilterHandlers().onFilterWidthChange(1800);
+    vi.advanceTimersByTime(200);
+
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 1800, receiver: 0 }]]);
+  });
+
+  it('quantizes the modal preset (direct-entry) path the same way as the slider', () => {
+    // Active filter is 2 (`a06State`'s fixture); targeting preset slot 1
+    // makes the handler's own pre-existing filter-switch dance (select 1,
+    // write its width, restore 2) fire around the width write — the MOR-1518
+    // assertion is that the WIDTH itself is quantized (1100, not the raw
+    // 1050), not the unrelated filter-switch sequencing.
+    makeFilterHandlers().onFilterPresetChange(1, 1050);
+    vi.advanceTimersByTime(200);
+
+    expect(exactCalls()).toEqual([
+      ['set_filter', { filter: 1, receiver: 0 }],
+      ['set_filter_width', { width: 1100, receiver: 0 }],
+      ['set_filter', { filter: 2, receiver: 0 }],
+    ]);
+  });
+
+  it('quantizes restore-defaults widths too, even though profile defaults are normally already legal', () => {
+    // Active filter is already 1 (matches `defaults[0]`'s slot). A
+    // deliberately-misaligned "defaults" array proves `onFilterDefaults` is
+    // not exempt just because real profile defaults are pre-validated; the
+    // trailing `set_filter` restore is `onFilterDefaults`'s own pre-existing
+    // behavior, unrelated to this fix.
+    const withFilter1 = a06State();
+    h.state = { ...withFilter1, main: { ...withFilter1.main, filter: 1 } } as ServerState;
+    makeFilterHandlers().onFilterDefaults([1050]);
+
+    expect(exactCalls()).toEqual([
+      ['set_filter_width', { width: 1100, receiver: 0 }],
+      ['set_filter', { filter: 1, receiver: 0 }],
+    ]);
+  });
+
+  it('quantizes against a SECOND, differently-stepped mode rule on the same fixture set (data-driven, not IC-7300-specific)', () => {
+    h.caps = {
+      ...a06Caps(A06_STEP), // minHz: 250, maxHz: 3550, stepHz: 100
+    } as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthChange(1836);
+    vi.advanceTimersByTime(200);
+
+    // Anchored at minHz=250: round((1836-250)/100)=16 -> 250+1600=1850.
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 1850, receiver: 0 }]]);
+  });
+
+  it('falls back to the pre-MOR-1518 default 50 Hz clamp when the mode has no declared width rule at all', () => {
+    h.caps = { ...a06Caps(), filterConfig: {} } as unknown as Record<string, unknown>;
+    makeFilterHandlers().onFilterWidthChange(1055);
+    vi.advanceTimersByTime(200);
+
+    // clampFilterWidth's own pre-existing default: round(1055/50)*50 = 1050.
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 1050, receiver: 0 }]]);
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -2019,12 +2019,14 @@ describe('MOR-1409 A06a1 synchronous final filter-width authority', () => {
 
 /**
  * MOR-1518 (live IC-7300 bench): dragging the Filter Width slider mid-drag
- * emitted raw, unaligned values (1050/2150/3150 Hz — legal in the 50 Hz
- * segment below 500 Hz, illegal once the drag crosses into the 100 Hz
- * segment above it, `A06_SEGMENTS`/`rigs/ic7300.toml`) straight onto the
- * wire, which the backend's `filter_hz_to_index`
- * (`src/rigplane/commands/_codec.py`) rejected with "Filter width N is not
- * aligned to N Hz steps" — three sticky error toasts per drag.
+ * emitted raw, unaligned values (1050/2150/3150 Hz) straight onto the wire.
+ * Each is a multiple of the WRONG segment's step — the slider's own fixed
+ * step assumption (50 Hz, `A06_SEGMENTS`'s lower segment) rather than the
+ * 100 Hz step that actually governs 600-3600 Hz where these values fall
+ * (`rigs/ic7300.toml`) — so the backend's `filter_hz_to_index`
+ * (`src/rigplane/commands/_codec.py`) correctly rejected them with "Filter
+ * width N is not aligned to N Hz steps" — three sticky error toasts per
+ * drag.
  *
  * `onFilterWidthChange` (the slider's own debounced handler,
  * `FilterSurface.svelte`'s raw `<input type="range">` and `FilterPanel`'s
@@ -2050,10 +2052,15 @@ describe('MOR-1518 client-side filter-width quantization at command emission', (
     vi.useRealTimers();
   });
 
+  // 1050/2150/3150 are each an EXACT midpoint between two legal 100 Hz-step
+  // values (e.g. 1050 sits exactly between 1000 and 1100) — tie-break
+  // prefers the LOWER value, aligned with `scope-adapter.ts`'s
+  // `snapSpectrumFilterWidth` (see `filter-controls.ts`'s
+  // `snapWithinSegment` doc comment).
   it.each([
-    [1050, 1100],
-    [2150, 2200],
-    [3150, 3200],
+    [1050, 1000],
+    [2150, 2100],
+    [3150, 3100],
   ])('quantizes onFilterWidthChange(%i) to the nearest legal segment value (%i)', (raw, expected) => {
     makeFilterHandlers().onFilterWidthChange(raw);
     vi.advanceTimersByTime(200);
@@ -2084,14 +2091,15 @@ describe('MOR-1518 client-side filter-width quantization at command emission', (
     // Active filter is 2 (`a06State`'s fixture); targeting preset slot 1
     // makes the handler's own pre-existing filter-switch dance (select 1,
     // write its width, restore 2) fire around the width write — the MOR-1518
-    // assertion is that the WIDTH itself is quantized (1100, not the raw
-    // 1050), not the unrelated filter-switch sequencing.
+    // assertion is that the WIDTH itself is quantized (1000, not the raw
+    // 1050 — an exact tie between 1000/1100, tie-break prefers lower), not
+    // the unrelated filter-switch sequencing.
     makeFilterHandlers().onFilterPresetChange(1, 1050);
     vi.advanceTimersByTime(200);
 
     expect(exactCalls()).toEqual([
       ['set_filter', { filter: 1, receiver: 0 }],
-      ['set_filter_width', { width: 1100, receiver: 0 }],
+      ['set_filter_width', { width: 1000, receiver: 0 }],
       ['set_filter', { filter: 2, receiver: 0 }],
     ]);
   });
@@ -2101,13 +2109,14 @@ describe('MOR-1518 client-side filter-width quantization at command emission', (
     // deliberately-misaligned "defaults" array proves `onFilterDefaults` is
     // not exempt just because real profile defaults are pre-validated; the
     // trailing `set_filter` restore is `onFilterDefaults`'s own pre-existing
-    // behavior, unrelated to this fix.
+    // behavior, unrelated to this fix. 1050 is an exact tie between 1000 and
+    // 1100 — tie-break prefers lower.
     const withFilter1 = a06State();
     h.state = { ...withFilter1, main: { ...withFilter1.main, filter: 1 } } as ServerState;
     makeFilterHandlers().onFilterDefaults([1050]);
 
     expect(exactCalls()).toEqual([
-      ['set_filter_width', { width: 1100, receiver: 0 }],
+      ['set_filter_width', { width: 1000, receiver: 0 }],
       ['set_filter', { filter: 1, receiver: 0 }],
     ]);
   });
@@ -2119,16 +2128,22 @@ describe('MOR-1518 client-side filter-width quantization at command emission', (
     makeFilterHandlers().onFilterWidthChange(1836);
     vi.advanceTimersByTime(200);
 
-    // Anchored at minHz=250: round((1836-250)/100)=16 -> 250+1600=1850.
+    // Anchored at minHz=250, not a tie: floor((1836-250)/100)=15 -> lower
+    // 1750, upper 1850; 1836 is closer to 1850 (bounded-lower=86 >
+    // upper-bounded=14) -> 1850.
     expect(exactCalls()).toEqual([['set_filter_width', { width: 1850, receiver: 0 }]]);
   });
 
-  it('falls back to the pre-MOR-1518 default 50 Hz clamp when the mode has no declared width rule at all', () => {
+  it('passes the value through UNCHANGED (no fabricated ceiling) when the mode has no declared width rule at all', () => {
+    // F1 (verify round 1): pre-MOR-1518 the dispatch path applied NO clamp
+    // when a mode had no declared filterConfig entry — raw value straight to
+    // the wire. `quantizeFilterWidthToRule` must keep that exact behavior
+    // rather than imposing this module's own IC-7610-shaped 50 Hz default
+    // grid on a radio/mode that declared nothing.
     h.caps = { ...a06Caps(), filterConfig: {} } as unknown as Record<string, unknown>;
     makeFilterHandlers().onFilterWidthChange(1055);
     vi.advanceTimersByTime(200);
 
-    // clampFilterWidth's own pre-existing default: round(1055/50)*50 = 1050.
-    expect(exactCalls()).toEqual([['set_filter_width', { width: 1050, receiver: 0 }]]);
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 1055, receiver: 0 }]]);
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -29,6 +29,7 @@ import type { FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilit
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import {
   mapIfShiftToPbt, nbDepthDisplayToRaw, nrDisplayToRaw, pbtHzToRaw, pbtRangeFromCaps,
+  quantizeFilterWidthToRule,
 } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
@@ -734,6 +735,24 @@ function validResolvedFilterWidth(width: number, rule: FilterModeConfig | null):
     && (width - rule.minHz) % rule.stepHz === 0;
 }
 
+/**
+ * The active filter-width rule for `receiver` (MOR-1518) — the SAME
+ * `resolveFilterModeConfig(caps, mode, dataMode)` resolution
+ * `onFilterWidthCommit` already reads via its own `currentA03cContext()`
+ * (below), but usable from the debounced/preset handlers, which key off
+ * `knownActiveReceiver` rather than the stricter A06a1 context. `null` when
+ * state/caps are unavailable or the mode has no declared rule — the
+ * capability-absent case `quantizeFilterWidthToRule` itself falls back to
+ * the plain clamp for.
+ */
+function activeFilterRule(receiver: Receiver): FilterModeConfig | null {
+  const state = getRadioState();
+  const caps = getCapabilities();
+  if (!state || !caps) return null;
+  const rx = receiver === 1 ? state.sub : state.main;
+  return resolveFilterModeConfig(caps, rx?.mode, rx?.dataMode);
+}
+
 export function makeFilterHandlers() {
   return {
     onFilterChange: (filter: number) => {
@@ -741,6 +760,16 @@ export function makeFilterHandlers() {
       if (receiver === null) return;
       dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver } });
     },
+    // MOR-1518: `width` here is a raw, possibly mid-drag or mid-keystroke
+    // slider value — the native `<input type="range">` in `FilterSurface`/
+    // `FilterPanel` steps by a single fixed increment that cannot match
+    // every mode's radio-declared step (the IC-7300's own USB/LSB/CW/RTTY
+    // rules widen from 50 Hz to 100 Hz above 500 Hz, `rigs/ic7300.toml`).
+    // `quantizeFilterWidthToRule` snaps to a value the resolved per-mode
+    // rule actually accepts BEFORE it reaches the wire — the "command-
+    // emission point", not just a display-layer clamp — so this handler
+    // never dispatches the alignment-error-triggering values the live
+    // bench reported (1050/2150/3150 Hz).
     onFilterWidthChange: (() => {
       let timer: ReturnType<typeof setTimeout> | null = null;
       return (width: number) => {
@@ -749,7 +778,9 @@ export function makeFilterHandlers() {
         timer = setTimeout(() => {
           timer = null;
           const receiver = knownActiveReceiver('filterWidth');
-          if (receiver !== null) dispatchRadioIntent({ name: 'set_filter_width', params: { width, receiver } });
+          if (receiver === null) return;
+          const quantized = quantizeFilterWidthToRule(width, activeFilterRule(receiver));
+          dispatchRadioIntent({ name: 'set_filter_width', params: { width: quantized, receiver } });
         }, 200);
       };
     })(),
@@ -795,6 +826,12 @@ export function makeFilterHandlers() {
       if (receiver === null) return;
       dispatchRadioIntent({ name: 'set_filter_shape', params: { shape, receiver } });
     },
+    // MOR-1518: `width` is a direct-entry value from the filter-settings
+    // modal's per-preset slider (`FilterPanel.svelte`'s `handlePresetChange`)
+    // — the same "any direct-entry path into the width command" the ticket
+    // calls out. Quantized against the CURRENT receiver's resolved rule at
+    // fire time (not the rule captured when the drag started), matching
+    // `currentReceiver`/`currentActive` already being re-read fresh below.
     onFilterPresetChange: (() => {
       let timer: ReturnType<typeof setTimeout> | null = null;
       return (filter: number, width: number) => {
@@ -807,10 +844,11 @@ export function makeFilterHandlers() {
           const currentReceiver = knownActiveReceiver('filter');
           const currentActive = currentReceiver === null ? null : getActiveReceiver()?.filter;
           if (currentReceiver === null || !Number.isSafeInteger(currentActive)) return;
+          const quantized = quantizeFilterWidthToRule(width, activeFilterRule(currentReceiver));
           if (filter !== currentActive) {
             dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver: currentReceiver } });
           }
-          dispatchRadioIntent({ name: 'set_filter_width', params: { width, receiver: currentReceiver } });
+          dispatchRadioIntent({ name: 'set_filter_width', params: { width: quantized, receiver: currentReceiver } });
           if (filter !== currentActive) {
             dispatchRadioIntent({ name: 'set_filter', params: { filter: currentActive as number, receiver: currentReceiver } });
           }
@@ -821,12 +859,16 @@ export function makeFilterHandlers() {
       const receiver = knownActiveReceiver('filterWidth');
       const activeFilter = receiver === null ? null : getActiveReceiver()?.filter;
       if (receiver === null || !Number.isSafeInteger(activeFilter)) return;
+      const rule = activeFilterRule(receiver);
       for (let i = 0; i < defaults.length; i++) {
         const filter = i + 1;
         if (filter !== activeFilter) {
           dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver } });
         }
-        dispatchRadioIntent({ name: 'set_filter_width', params: { width: defaults[i], receiver } });
+        dispatchRadioIntent({
+          name: 'set_filter_width',
+          params: { width: quantizeFilterWidthToRule(defaults[i], rule), receiver },
+        });
       }
       if ((activeFilter as number) <= defaults.length) {
         dispatchRadioIntent({ name: 'set_filter', params: { filter: activeFilter as number, receiver } });


### PR DESCRIPTION
## Summary

Dragging the Filter Width control on the live IC-7300 bench emitted raw, unaligned values (1050/2150/3150 Hz) straight onto the wire, tripping the backend's alignment validation and producing three sticky "Command failed: Filter width N is not aligned to 100 Hz steps" toasts per drag.

**Root cause**: the IC-7300's `USB`/`LSB`/`CW`/`RTTY` width rules (`rigs/ic7300.toml`'s `[filters.width.USB]` etc.) split into two `segments` with *different* step sizes either side of 500/600 Hz — 50 Hz below, 100 Hz above. The Filter Width control (`FilterSurface.svelte`'s raw `<input type="range">`, and `FilterPanel.svelte`'s table-mode slider) forwards whatever value the browser range input produces with no per-segment awareness, straight to `onFilterWidthChange` → `set_filter_width` on the wire. The backend's `filter_hz_to_index` (`src/rigplane/commands/_codec.py`) correctly rejects any value not aligned to its segment's step — that rejection is working as designed; the bug is client-side, emitting values the radio was never going to accept.

**Capability-data source**: this data was already flowing to the frontend — no backend or schema change needed. `GET /api/v1/capabilities`'s `filterConfig[mode]` (serialized by `_serialize_filter_config` in `src/rigplane/web/server.py`) already includes a `segments: [{hzMin, hzMax, stepHz, indexMin}]` array for exactly this shape, and `resolveFilterModeConfig` (`frontend/src/lib/runtime/props/panel-props.ts`) already resolves the per-mode rule from it. What was missing was a client-side quantizer that actually used `segments`/`stepHz` before dispatch.

**Fix**: `quantizeFilterWidthToRule` (`frontend/src/lib/radio/filter-controls.ts`) is a pure, data-driven quantizer that snaps a raw width to the nearest value the radio's own `filterConfig` rule accepts:
- segmented per-range steps: `value` is snapped against **every** declared segment's own step grid (`snapWithinSegment`, clamping into that segment's own bounds first), and the overall nearest candidate wins — this is what correctly handles a value landing in a segment *gap* (e.g. the IC-7300's own 500→600 Hz gap — filter index 9 is 500 Hz, index 10 jumps straight to 600 Hz, there is no legal width in between);
- a single `stepHz`/`minHz`/`maxHz` rule (treated as one implicit segment);
- a straight pass-through for `fixed`/`table`-shaped rules, and **also** for a rule that declares neither `segments` nor a complete `minHz`/`maxHz`/`stepHz` triple, and for a capability-absent mode (`rule` is `null`/`undefined`) — no step, ceiling, or bound is ever synthesized (see the R1 section below — this replaced an earlier, incorrect clamp fallback).

It's wired in at the **command-emission point** (`frontend/src/lib/runtime/commands/panel-commands.ts`), not just display, at the three `set_filter_width` dispatch sites that carry a caller-supplied (not already-legal) width:
- `onFilterWidthChange` — the slider's own debounced handler, shared by `FilterSurface.svelte`'s raw range input (covers both drag and keyboard, since a native range input fires the same `input` event for either) and `FilterPanel.svelte`'s table-mode slider;
- `onFilterPresetChange` — the settings modal's direct-entry preset slider;
- `onFilterDefaults` — restore-defaults.

`onFilterWidthCommit` (the spectrum-panel drag-to-set-passband path) already validates-and-drops invalid widths via the existing `validResolvedFilterWidth` and is left untouched — it never emitted an unaligned value in the first place, so there was nothing to quantize there.

## Red-first evidence

- `frontend/src/lib/radio/filter-controls.test.ts` reproduces the exact live-bench values (1050/2150/3150 Hz) against an IC-7300-shaped segment fixture, asserting `quantizeFilterWidthToRule` snaps each to its nearest legal width (1000/2100/3100 — see the R1 tie-break note below). A second and third differently-stepped rule (200 Hz, 25 Hz — not IC-7300's 50/100 split) prove the step is read from capability data, not hardcoded. Segment-gap boundary crossing (520/580/550 Hz around the 500/600 Hz gap), the capability-absent fallback (including a value above the old, now-removed fallback ceiling), and fixed/table pass-through are all covered.
- `frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` adds an integration suite (`MOR-1518 client-side filter-width quantization at command emission`) pinning quantization at each of the three dispatch sites, reusing the existing `A06_SEGMENTS`/`a06Caps`/`a06State` fixtures already established by the MOR-1409 A06a1 suite (the exact same segment shape as the live IC-7300 profile).
- Before the implementation existed, both files' new tests failed with `quantizeFilterWidthToRule is not a function` / raw-value assertions; after implementing, all pass.

## R1 review fixes

An independent verifier reviewed the initial version of this PR and ruled BLOCKED on two findings, plus two coordinator-directed alignment rulings. All four are applied in the second commit:

**F1 (blocking) — fabricated ceiling on capability-absent widths.** The original fallback for a rule-absent (or otherwise unusable) width rule called `clampFilterWidth(value)`, which imposes this module's own IC-7610-shaped 50/3600/50 Hz grid. Pre-MOR-1518 the dispatch path applied **no** clamp at all in that case — raw value straight to the wire. A radio/mode with a wider declared range than 3600 Hz (e.g. an FTX-1 table/step mode) would have had an otherwise-legal wide value silently truncated by this fix. `quantizeFilterWidthToRule` now passes `value` through **unchanged** whenever `rule` is absent, `fixed`, `table`-shaped, or declares neither `segments` nor a complete `minHz`/`maxHz`/`stepHz` triple — matching pre-MOR-1518 behavior exactly, no step or ceiling is ever synthesized for a radio/mode that declared none.

**F2 (blocking, cheap) — stale/self-contradicting doc comment.** The doc comment described a clamp fallback for `fixed`/`table` rules the code never actually took, and claimed "unchanged pre-MOR-1518 behavior" for the rule-absent case — false before the F1 fix. Rewritten to match the corrected code.

**Coordinator ruling 1 — tie-break alignment with the spectrum-drag path.** `snapSpectrumFilterWidth` (`frontend/src/lib/runtime/adapters/scope-adapter.ts`, wired to `SpectrumPanel`'s passband-edge drag) resolves an exact-midpoint tie to the **lower** grid point via its `snapStep` helper. The slider/preset quantizer previously preferred the upper candidate — so the same 550 Hz value would snap to 500 Hz via a spectrum drag but 600 Hz via the Filter Width slider, an inconsistency an operator could actually observe. `quantizeFilterWidthToRule`'s segment selection is reimplemented to mirror `snapSpectrumFilterWidth`'s own algorithm exactly (snap `value` against every segment's own step grid via the new `snapWithinSegment` helper, pick the overall nearest candidate, ties prefer lower) without merging the two helpers into one (an out-of-scope cross-layer refactor, per the coordinator) — cross-referencing comments were added in both `filter-controls.ts` and `scope-adapter.ts` so the tie-break convention stays visibly coupled. This also means the three live-bench values (1050/2150/3150 Hz) are each an *exact* midpoint tie between two legal 100 Hz-step values (e.g. 1050 sits exactly between 1000 and 1100) — makes sense, since the pre-fix bug always added a stray 50 Hz, the wrong segment's step, onto an otherwise-legal 100 Hz value — so they now snap to 1000/2100/3100, not 1100/2200/3200.

**Coordinator ruling 2 — removed a tautology test.** One test asserted `raw % 100 !== 0` for the reported values without calling `quantizeFilterWidthToRule` at all — not real coverage. Removed; the sibling assertions and the panel-commands integration suite already call the actual SUT.

## Verification

- `npx vitest run` on all 4 touched test files (`filter-controls.test.ts`, `panel-commands.intent.isolated.test.ts`, `scope-adapter.authority.isolated.test.ts`, `SpectrumPanel.component.test.ts`) — 259/259 passing
- Broader filter-adjacent suite (`FilterPanel.isolated.test.ts`, `FilterSurface.test.ts`, IC-7300 conformance) — 127/127 passing, no regressions
- `npx eslint` on all 5 changed files — clean
- `npm run lint:boundaries` — clean
- `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings

## Flagged, not fixed (out of scope for this ticket)

- The native `<input type="range">` in `FilterSurface.svelte` still has a hardcoded `step={50}` — the browser's own thumb position mid-drag can visually pass through a value that isn't legal for the current segment, even though the value actually dispatched is always quantized. The *displayed, confirmed* readout (bound to radio-observed state, not the live thumb position) is always legal, and no invalid command ever reaches the wire, so behavior matches the acceptance criteria — but a fully segment-aware visual snap during drag would need `ModeFilterViewModel`/`resolveFilterModeConfig` step data threaded further into the semantic view model, which is a larger v3-vocabulary change than this fix's guardrails allow.
- `FilterSurface.svelte` does not currently special-case `filterConfig.fixed`/`.table` shapes at all (unlike `FilterPanel.svelte`, which does) — a pre-existing gap, unrelated to MOR-1518, not touched here.

Closes MOR-1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
