### PR TITLE
fix: PREAMP domains from profile data + enumerated-control audit (MOR-1523)

### DIFF
--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -732,6 +732,33 @@ describe('A11 — batch-A projections do not fabricate defaults (MOR-1409)', () 
       expect(props.antennaCount).toBe(2);
     });
   });
+
+  describe('toRfFrontEndProps — preOptions (MOR-1523 R1)', () => {
+    it('does not invent a 3-level [0,1,2] preamp catalog without a declared preValues domain', () => {
+      // Last un-converted twin of A11's `toAgcProps` fix: pre-fix this
+      // fabricated an IC-7300-shaped [0,1,2] PRE button group even for a
+      // profile (or an entirely absent capabilities payload) that never
+      // declared it — an X6200 (declared [0,1], no P.AMP2 stage) would get
+      // an option it can't honor.
+      const props = toRfFrontEndProps(makeState(), {
+        capabilities: ['preamp'],
+      } as any);
+      expect(props.preValues).toEqual([]);
+      expect(props.preOptions).toEqual([]);
+    });
+
+    it('still reports the real declared preamp option set', () => {
+      const props = toRfFrontEndProps(makeState(), {
+        capabilities: ['preamp'],
+        preValues: [0, 1],
+      } as any);
+      expect(props.preValues).toEqual([0, 1]);
+      expect(props.preOptions).toEqual([
+        { value: 0, label: 'OFF' },
+        { value: 1, label: 'P1' },
+      ]);
+    });
+  });
 });
 
 /**

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -244,7 +244,12 @@ export function toRfFrontEndProps(
   const rx = state ? activeRx(state) : null;
   const attValues = caps?.attValues ?? [0, 6, 12, 18];
   const attLabels = caps?.attLabels ?? {};
-  const preValues = caps?.preValues ?? [0, 1, 2];
+  // MOR-1409 A11: an unknown/unobserved preamp capability must not present a
+  // fabricated 3-level [0, 1, 2] IC-7300-shaped catalog — an X6200 profile
+  // (declared [0, 1], no P.AMP2 stage) would otherwise get an invented
+  // option it can't honor. Mirrors `toAgcProps`'s `agcModes: caps?.agcModes
+  // ?? []` (MOR-1523 R1: this was the last un-converted twin of that fix).
+  const preValues = caps?.preValues ?? [];
   const preLabels = caps?.preLabels ?? {};
   const rfGainAvailable = activeFieldShown(state, 'rfGain');
   const squelchAvailable = activeFieldShown(state, 'squelch');

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1270,10 +1270,21 @@ class YaesuCatRadio:
         """Set preamp setting.
 
         Args:
-            level: Preamp level (0–2).
+            level: Preamp level, must be one of the profile's declared
+                ``[preamp] values`` (e.g. FTX-1 declares 0/1/2 = IPO/AMP1/AMP2).
             receiver: Ignored (FTX-1 single preamp path). Present for protocol compat.
             band: 0 = HF/50 MHz, 1 = VHF, 2 = UHF.
+
+        Raises:
+            CommandError: If ``level`` is not in the profile's declared
+                preamp domain (MOR-1523, mirrors MOR-1522's AGC fix).
         """
+        pre_values = self._config.pre_values
+        if pre_values is not None and level not in pre_values:
+            raise CommandError(
+                f"Preamp level must be one of {sorted(pre_values)} for "
+                f"{self._config.model!r}, got {level}"
+            )
         await self._write("set_preamp", band=str(band), value=str(level))
 
     # -- D3: DSP (NB/NR/Notch) ----------------------------------------------

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3971,13 +3971,20 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         raise CommandError("Radio returned empty preamp response")
 
     async def set_preamp(self, level: int = 1, receiver: int = RECEIVER_MAIN) -> None:
-        """Set preamp level (0=off, 1=PREAMP1, 2=PREAMP2) (Command29-aware).
+        """Set preamp level (Command29-aware).
+
+        Valid values are declared per radio by the profile's ``[preamp]
+        values`` (e.g. IC-7300 offers OFF/P.AMP1/P.AMP2 = 0/1/2; the X6200
+        only declares OFF/P.AMP1 = 0/1 — it has no second preamp stage).
 
         Args:
-            level: 0=off, 1=PREAMP1, 2=PREAMP2.
+            level: preamp level, must be one of the profile's declared
+                ``[preamp] values``.
             receiver: RECEIVER_MAIN (0) or RECEIVER_SUB (1).
 
         Raises:
+            ValueError: If ``level`` is not in the profile's declared
+                preamp domain.
             CommandError: If DIGI-SEL (IP+) is enabled. On IC-7610, PREAMP and
                 DIGI-SEL are mutually exclusive — disable DIGI-SEL first.
         """
@@ -3990,6 +3997,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_preamp",
         )
+        pre_values = self._profile.pre_values
+        if pre_values is not None and level not in pre_values:
+            raise ValueError(
+                f"Preamp level must be one of {sorted(pre_values)} for "
+                f"{self._profile.model}, got {level}"
+            )
 
         # Pre-flight: check DIGI-SEL / PREAMP mutual exclusion
         if level > 0 and "digisel" in self.capabilities:

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -501,6 +501,18 @@ async def test_set_preamp(connected_radio):
     connected_radio._transport.write.assert_called_once_with("PA02;")
 
 
+@pytest.mark.parametrize("level", [-1, 3, 99])
+@pytest.mark.asyncio
+async def test_set_preamp_rejects_out_of_domain_value(connected_radio, level):
+    """MOR-1523: FTX-1 declares preamp levels 0-2 (IPO/AMP1/AMP2) in
+    ``[preamp] values``; a value outside that domain must raise instead of
+    being written to the radio unchecked (mirrors MOR-1522's AGC fix)."""
+    connected_radio._transport.write = AsyncMock()
+    with pytest.raises(CommandError):
+        await connected_radio.set_preamp(level)
+    connected_radio._transport.write.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # D3: DSP (NB/NR/Notch)
 # ---------------------------------------------------------------------------

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2695,6 +2695,71 @@ class TestAgcDomainValidation:
         radio._connected = False
 
 
+class TestPreampDomainValidation:
+    """MOR-1523: the preamp level domain is profile data, not a universal
+    3-state enum.
+
+    IC-7300 declares OFF/P.AMP1/P.AMP2 (0/1/2); the X6200 only declares
+    OFF/P.AMP1 (0/1) — it has no second preamp stage. ``set_preamp`` must
+    accept exactly what the profile declares for that radio and reject
+    anything else with a visible error, not a silent write of an illegal
+    byte (mirrors MOR-1522's ``set_agc`` fix).
+    """
+
+    @pytest.mark.asyncio
+    async def test_ic7300_rejects_value_outside_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"Preamp level must be one of"):
+            await radio.set_preamp(3)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7300_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7300")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        for legal in (0, 1, 2):
+            await radio.set_preamp(legal)
+        assert len(mock_transport.sent_packets) == 3
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        await radio.set_preamp(1)
+        assert mock_transport.sent_packets[-1].endswith(b"\x16\x02\x01\xfd")
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_rejects_second_preamp_stage_that_ic7300_has(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """The X6200 has no P.AMP2 hardware stage — its declared domain is
+        [0, 1], unlike IC-7300's [0, 1, 2]. Level 2 must be rejected."""
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"Preamp level must be one of"):
+            await radio.set_preamp(2)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+
 class TestBreakInModeRoundTrip:
     """Issue #1100 — CwControlCapable.get_break_in/set_break_in type contract.
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1200,3 +1200,82 @@ class TestAgcDomainDeclaredOrCapabilityAbsent:
             rig = load_rig(RIGS_DIR / f"{name}.toml")
             assert "agc" not in rig.capabilities
             assert rig.agc_modes is None
+
+
+# ── Preamp domain declaration, table-driven over every shipped profile ───
+# (MOR-1523, mirrors MOR-1522's AGC table above). Reuses _SHIPPED_RIG_TOMLS.
+
+
+class TestPreampDomainDeclaredOrCapabilityAbsent:
+    """Every shipped profile must land on one of exactly two sides:
+
+    (a) it does not declare the ``preamp`` capability at all — the
+        capability-absent selector-hiding pattern (MOR-1494) — or
+    (b) it declares ``preamp`` AND a non-empty ``[preamp] values`` domain
+        that every declared value can be encoded into a legal wire command.
+
+    No profile may declare the capability without a domain, or a domain
+    without the capability.
+    """
+
+    @pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+    def test_preamp_capability_and_domain_agree(self, toml_path):
+        rig = load_rig(toml_path)
+        has_preamp_capability = "preamp" in rig.capabilities
+
+        if not has_preamp_capability:
+            assert rig.pre_values is None, (
+                f"{toml_path.name}: declares [preamp] values without the "
+                f"'preamp' capability feature"
+            )
+            return
+
+        assert rig.pre_values, (
+            f"{toml_path.name}: declares the 'preamp' capability but no "
+            f"(or an empty) [preamp] values domain"
+        )
+
+    @pytest.mark.parametrize(
+        "toml_path",
+        [p for p in _SHIPPED_RIG_TOMLS if load_rig(p).protocol_type == "civ"],
+        ids=lambda p: p.stem,
+    )
+    def test_civ_preamp_values_encode_to_a_legal_command(self, toml_path):
+        """Every declared level for a CI-V family radio must round-trip
+        through the real wire-command builder without raising — the
+        profile's domain must map to a legal command, not just a legal
+        Python int (MOR-1523)."""
+        from rigplane.commands.dsp import set_preamp
+
+        rig = load_rig(toml_path)
+        if rig.pre_values is None:
+            pytest.skip(f"{toml_path.name}: no preamp capability")
+        for level in rig.pre_values:
+            civ = set_preamp(level, to_addr=rig.civ_addr)
+            # All shipped preamp domains are single-digit (0-9), so the BCD
+            # byte equals the raw level value.
+            assert civ.endswith(bytes([0x16, 0x02, level, 0xFD])), (
+                f"{toml_path.name}: level {level} did not encode to the "
+                f"expected 0x16 0x02 {level:#04x} wire command"
+            )
+
+    def test_ic7300_declares_off_amp1_amp2(self):
+        """IC-7300 P.AMP: 0=OFF, 1=P.AMP1, 2=P.AMP2 (CI-V 0x16 0x02, per
+        rigs/ic7300.toml's [preamp] comment)."""
+        rig = load_rig(RIGS_DIR / "ic7300.toml")
+        assert rig.pre_values == (0, 1, 2)
+
+    def test_x6200_has_no_second_preamp_stage(self):
+        """The X6200 declares only [0, 1] — it has no P.AMP2 hardware stage,
+        unlike the IC-7300 family's [0, 1, 2]. Domain-shape difference the
+        validation seat must honor, not flatten to a universal 3-state
+        enum."""
+        rig = load_rig(RIGS_DIR / "x6200.toml")
+        assert rig.pre_values == (0, 1)
+
+    def test_ftx1_declares_ipo_amp1_amp2_with_labels(self):
+        """FTX-1 (live bench hardware) declares [preamp] values = [0, 1, 2]
+        with IPO/AMP1/AMP2 labels (rigs/ftx1.toml:430-436)."""
+        rig = load_rig(RIGS_DIR / "ftx1.toml")
+        assert rig.pre_values == (0, 1, 2)
+        assert rig.pre_labels == {"0": "IPO", "1": "AMP1", "2": "AMP2"}

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -2798,6 +2798,31 @@ async def test_set_level_preamp_20db(
 
 
 @pytest.mark.asyncio
+async def test_set_level_preamp_out_of_domain_returns_einval_not_a_write(
+    handler: RigctldHandler, mock_radio: AsyncMock
+) -> None:
+    """MOR-1523 R1: this legacy Icom fallback path (used whenever
+    ``create_routing()`` returns ``None`` — every Icom radio, since none of
+    them implement ``RigctldRoutable``) snaps ``L PREAMP 20`` to the nearest
+    of the hardcoded ``_PREAMP_IDX_TO_DB = [0, 12, 20]`` table (idx=2), then
+    calls ``radio.set_preamp(2)`` unconditionally — it has no idea whether
+    the connected profile's declared ``[preamp] values`` domain actually
+    includes 2. An X6200 declares only ``[0, 1]`` (no second preamp stage);
+    MOR-1523's new ``IcomRadio.set_preamp()`` validation seat now raises
+    ``ValueError`` for that radio's idx=2, and this test proves the raise
+    reaches the rigctl client as ``RPRT`` ``EINVAL`` (via the handler's
+    top-level ``except ValueError`` mapping) instead of the byte silently
+    reaching the transport, which is what happened before this PR."""
+    mock_radio.set_preamp = AsyncMock(
+        side_effect=ValueError("Preamp level must be one of [0, 1] for X6200, got 2")
+    )
+    resp = await handler.execute(set_cmd("set_level", "PREAMP", "20"))
+    assert not resp.ok
+    assert resp.error == HamlibError.EINVAL
+    mock_radio.set_preamp.assert_awaited_once_with(2)
+
+
+@pytest.mark.asyncio
 async def test_set_level_att(handler: RigctldHandler, mock_radio: AsyncMock) -> None:
     resp = await handler.execute(set_cmd("set_level", "ATT", "18"))
     assert resp.ok


### PR DESCRIPTION
## Summary

Sibling of MOR-1522 (AGC, merged as #2437). PREAMP has the exact same
disease AGC had: `set_preamp()` accepted any int and wrote it straight to
the radio, with no reference to the profile's declared `[preamp] values`
domain. Owner ruling carried over unchanged: the preamp level set is
radio-specific **profile data**; the UI renders only declared options, and
the backend enforces the same declared domain on every write path.

**Correction (R1):** the original version of this section claimed the
frontend had no synthesis bug at all. That was wrong — see the R1 section
near the bottom for the actual finding and fix (`panel-props.ts`'s
`toRfFrontEndProps` did fabricate a `[0, 1, 2]` catalog). The
`RfFrontEndSurface.svelte`/`rf-front-end-adapter.ts` path (the
`components-v2/wiring` → `semantic` surface used by the desktop-v2/mobile
skins' RF front-end panel) genuinely was clean; `panel-props.ts` (a
parallel, `lib/runtime`-owned prop mapper feeding `components-v2/panels/RfFrontEnd.svelte`
directly, live in the desktop-v2 `RadioLayout`/`LeftSidebar` and mobile
`MobileRadioLayout`) was not.

The backend side had the disease described below regardless: both
`IcomRadio.set_preamp()` (`src/rigplane/runtime/radio.py`) and
`YaesuCatRadio.set_preamp()` (`src/rigplane/backends/yaesu_cat/radio.py`)
took a plain `level: int` with **zero** domain validation — any int, in or
out of the profile's declared range, was written to the radio unchecked.
(Preamp never had AGC's second bug either — there is no universal
`PreampMode` enum anywhere in this codebase gating the value; it was simply
unchecked, not miscast.)

One more caveat on "no hardcoded option list": `AmberCockpit.svelte:213-216`
and `AmberScope.svelte:130-133` (amber-lcd skin) hardcode an IPO/AMP1/AMP2
ternary for the preamp status readout. Same precedent as #2437's
`AGC_LABELS` finding — it's a **read-only** display token, not a
write-capable selector, so it can't offer an illegal SET option; left alone
here, already tracked under **MOR-1529**.

## Single validation seat per radio family

Same shape as MOR-1522: every PREAMP write path converges on
`radio.set_preamp()` per radio class before this diff, and still does after
it — no new seat was invented, the existing one/two seats were just given
teeth:

- `IcomRadio.set_preamp()` (`runtime/radio.py`) — covers
  ic7300/ic7610/ic705/ic9700/x6200 (shared CI-V code path).
- `YaesuCatRadio.set_preamp()` (`backends/yaesu_cat/radio.py`) — covers
  ftx1.

`commands.dsp.set_preamp()` (the raw wire-command builder) was already
permissive before this diff — it only bounds the wire format's single BCD
byte (0-99) via `_bcd_byte()`, no enum/range cast. No change needed there.

### rigctld path (checked, not Yaesu-only this time)

Unlike AGC (which only had a Yaesu `FUNC` boolean toggle in rigctld),
PREAMP has a real numeric `RIG_LEVEL_PREAMP` rigctl level on **both**
routing paths, and both converge on the same `radio.set_preamp()` seat:

- `rigctld/routing.py`'s `YaesuRouting.set_level("PREAMP", …)` → FTX-1 only
  → `radio.set_preamp(round(value))`.
- `rigctld/handler.py`'s legacy `_execute_set_level` (used when
  `create_routing()` returns `None`, i.e. every Icom radio — Icom has no
  dedicated `RigctldRouting` implementation, confirmed via
  `RigctldRoutable`/`create_routing()`) → snaps the requested dB to the
  nearest of a hardcoded `_PREAMP_IDX_TO_DB = [0, 12, 20]` table, then calls
  `radio.set_preamp(idx)` with `idx` bounded to `range(len(_PREAMP_IDX_TO_DB))`
  = 0/1/2.

Both paths call into the same now-validated seat, so no PREAMP write can
bypass the domain check via rigctld — but note that means the seat can now
**reject** a legacy-path request it previously wrote unchecked, and that is
a real, previously-unannounced behavior change on a live path (corrected in
R1 below): `_PREAMP_IDX_TO_DB = [0, 12, 20]` maps any dB ≥ 16 to idx=2, and
on an X6200 or X6100 profile (both declare `[0, 1]` — no second preamp
stage) `L PREAMP 20` now raises `ValueError` inside `IcomRadio.set_preamp()`
instead of writing an illegal preamp-2 byte to hardware that doesn't have a
second stage. The new behavior is correct (rejecting is strictly better
than silently commanding a nonexistent hardware state), but it is a
behavior change worth calling out explicitly rather than asserting the
`idx` output "already always lands inside every domain" — it does not, for
the two-level profiles. Pinned by
`tests/test_rigctld_handler.py::test_set_level_preamp_out_of_domain_returns_einval_not_a_write`.

A third seat exists and is explicitly **not** covered by this fix — see the
audit sweep's `rigctld_client` row below; the convergence claim above holds
for the two radio classes with a `RigProfile`, not for every `Radio`
protocol implementer in the codebase.

## Per-profile PREAMP domain table

| Profile | `preamp` capability | `[preamp] values` | Source | Notes |
|---|---|---|---|---|
| **ic7300** | yes | `[0,1,2]` OFF/P.AMP1/P.AMP2 | `rigs/ic7300.toml:516-518`, comment cites CI-V `0x16 0x02`; audit row `docs/validation/cat-audits/ic7300.md:50` (`16 02 \| preamp 0/1/2 \| get_/set_preamp \| preamp \| preamp.set RMVR`) | **Not live-validated** — `ic7300.md:4` states explicitly: *"Live run: none — this is a template/static audit. No `/tmp/ic7300.live.json` hardware run was performed"* — despite IC-7300 being physical live-bench hardware today, this audit document itself was never executed live. Neither the accept-path domain nor this PR's new reject-path has hardware evidence. |
| **ic7610** | yes | `[0,1,2]` OFF/P.AMP1/P.AMP2 | `rigs/ic7610.toml:655-657`, CI-V `0x16 0x02` comment; audit row `docs/validation/cat-audits/ic7610.md:52` (`16 02 preamp \| S/R \| get/set_preamp \| preamp cap \| preamp.set RMVR ✅`) | **Partially live-validated, historically.** `ic7610.md`'s header cites a real pre-retirement hardware run (`/tmp/ic7610.live.json`, 59 pass · 3 fail, none of the 3 failures were preamp-related) — the ✅ means the declared accept-path domain round-tripped on real hardware before the 2026-08-04 retirement. That evidence predates this PR: the out-of-domain **reject** behavior this PR adds did not exist during that run and has no live evidence (hardware is retired, cannot be re-run). Also has the DIGI-SEL/PREAMP mutex documented at `rigs/ic7610.toml:1471-1477` (`disables = ["preamp"]` while DIGI-SEL is on) — pre-existing, unrelated to this domain fix, left alone. |
| **ic705** | yes | `[0,1,2]` OFF/P.AMP1/P.AMP2 | `rigs/ic705.toml:110-112`, CI-V `0x16 0x02` comment | Not on live bench; declaration unchanged, not live-validated (no cat-audit doc exists for ic705 in this sweep). |
| **ic9700** | yes | `[0,1,2]` OFF/P.AMP1/P.AMP2 | `rigs/ic9700.toml:110-112`, CI-V `0x16 0x02` comment | Not on live bench; declaration unchanged, not live-validated (no cat-audit doc exists for ic9700 in this sweep). |
| **x6200** | yes | `[0,1]` OFF/P.AMP1 only | `rigs/x6200.toml:223-224`; audit row `docs/validation/cat-audits/x6200.md:29` (`0x16 0x02 preamp \| ✅ \| get/set_preamp \| preamp; get/set_preamp=[0x16,0x02] \| preamp.set RMVR · not run`) | **No second preamp stage** — domain shape genuinely differs from the IC-7300 family (`[0,1]` vs `[0,1,2]`). `x6200.md:6` states the whole audit's *"Live run: not run — live serial access unavailable to this audit"* — the row's ✅ is a doc/code-declaration checkmark, not a hardware-pass checkmark; **not live-validated**. Pre-fix, `set_preamp(2)` would have been sent to the radio unchecked; now rejected. |
| **x6100** | yes | `[0,1]` | `rigs/x6100.toml:83-84` | No backend/CAT implementation for x6100 found in `runtime/`/`backends/` (no `[commands]` preamp wire mapping in the profile either) — capability+domain declared in TOML but this radio family has no live driver exercising `set_preamp`; validation seat is in place for if/when one exists. Not live-validated (no hardware, no cat-audit doc). |
| **ftx1** | yes | `[0,1,2]` IPO/AMP1/AMP2 | `rigs/ftx1.toml:430-436` (`[preamp]`/`[preamp.labels]`) | Live bench hardware, but `docs/validation/cat-audits/ftx1.md` has **zero preamp content** (verified: no `preamp`/`IPO`/`AMP1`/`AMP2` hits anywhere in that file) — exactly the same gap MOR-1522 found for FTX-1's AGC row. **Not live-validated**, TOML-sourced only. Pre-fix, `set_preamp()` had **zero** validation of any kind (no enum either) — fixed here. |
| **tx500** | yes | `[0,1]` OFF/ON | `rigs/tx500.toml:84-86` (`[preamp]`, `PA` CAT command) | No live bench hardware; Kenwood-style CAT `PA;`/`PA{val};` mapping exists in `[commands]` (`rigs/tx500.toml:215-216`) but this radio backend is not implemented in this codebase's runtime/backends layer (no TX-500 driver class was found), so the validation seat has no live caller for this profile today — declared correctly regardless, consistent with the "declare it right even if unimplemented" pattern already used for tx500's other domains. |

Table-driven test (`tests/test_rig_loader.py::TestPreampDomainDeclaredOrCapabilityAbsent`)
globs the actual `rigs/*.toml` directory listing (mirrors MOR-1522's
`TestAgcDomainDeclaredOrCapabilityAbsent`) and asserts every profile lands
on exactly one of the two valid sides — capability+domain together, or
neither. Every shipped profile already lands on the "capability+domain"
side for preamp (no gap found, unlike AGC's x6100 which had neither) — the
test exists as a regression guard against a future profile forgetting to
declare one side, not because a gap was found today.

## Before / after behavior

- **Before**: `IcomRadio.set_preamp(9)` on an IC-7300 (domain `[0,1,2]`)
  sent CI-V `16 02 09 FD` to the radio unchecked. `YaesuCatRadio.set_preamp(99)`
  on the FTX-1 (domain `[0,1,2]`) sent `PA099;` unchecked. `IcomRadio.set_preamp(2)`
  on an X6200 (domain `[0,1]`, no second preamp stage) also went out
  unchecked — silently asking hardware that doesn't have a P.AMP2 stage to
  select one.
- **After**: all three now raise (`ValueError` for Icom radios,
  `CommandError` for the Yaesu FTX-1) before anything is sent to the
  transport, listing the profile's actual declared domain in the message.
  In-domain values are unaffected — behavior for every legal preamp write
  that existed before this diff is unchanged (verified by the accept-path
  tests below).
- **After, rigctld-specific (R1 addition)**: an `L PREAMP 20` request over
  rigctld against an X6200 or X6100 (both declare `[0, 1]`) now returns
  `RPRT` `EINVAL` instead of silently writing the illegal preamp-2 byte —
  `rigctld/handler.py`'s legacy Icom fallback path snaps dB≥16 to idx=2 via
  the hardcoded `_PREAMP_IDX_TO_DB` table regardless of the connected
  profile's actual domain, then calls the now-validated `set_preamp(2)`,
  whose `ValueError` is caught by the handler's top-level `except
  ValueError` and mapped to `EINVAL`. This is a genuine, previously-silent
  behavior change on a live rigctld path, not just an in-process one —
  correct (rejecting beats commanding a nonexistent hardware stage), but
  worth calling out explicitly. Pinned by
  `test_set_level_preamp_out_of_domain_returns_einval_not_a_write`.

## Tests (red-first)

All four new/changed test files were run red-first: the four
reject-path tests below failed with "DID NOT RAISE" before the seat was
added, and passed immediately after — no other test in the touched files
changed status.

- `tests/test_radio.py::TestPreampDomainValidation` (new) —
  `test_ic7300_rejects_value_outside_its_declared_domain` (level=3, RED → GREEN),
  `test_ic7300_accepts_its_declared_domain` (0/1/2, always green — accept-path pin),
  `test_x6200_accepts_its_declared_domain` (level=1, always green — accept-path pin
  + wire-byte pin `\x16\x02\x01\xfd`),
  `test_x6200_rejects_second_preamp_stage_that_ic7300_has` (level=2, RED → GREEN).
- `tests/test_ftx1_radio.py::test_set_preamp_rejects_out_of_domain_value`
  (new, parametrized `[-1, 3, 99]`) — RED → GREEN for all three.
- `tests/test_rig_loader.py::TestPreampDomainDeclaredOrCapabilityAbsent`
  (new) — table-driven capability/domain-agreement test over every shipped
  profile (always green, regression guard), CI-V wire round-trip test for
  every declared preamp value on every CI-V profile (always green), plus
  three named regression pins (`test_ic7300_declares_off_amp1_amp2`,
  `test_x6200_has_no_second_preamp_stage`,
  `test_ftx1_declares_ipo_amp1_amp2_with_labels`).

### R1 additions

- `frontend/src/lib/runtime/props/__tests__/panel-props.test.ts::toRfFrontEndProps — preOptions (MOR-1523 R1)`
  (new) — `'does not invent a 3-level [0,1,2] preamp catalog without a
  declared preValues domain'` (`preamp` in `capabilities`, no `preValues`)
  RED (asserted `[]`, got `[0, 1, 2]`) → GREEN after `panel-props.ts:252`'s
  fallback changed from `?? [0, 1, 2]` to `?? []`; a companion accept-path
  pin (`preValues: [0, 1]` → `preOptions` renders exactly those two,
  labeled `OFF`/`P1`) stays green throughout. Verified red by temporarily
  reverting the fallback and re-running (`AssertionError: expected [0, 1,
  2] to deeply equal []`), then restoring it.
- `tests/test_rigctld_handler.py::test_set_level_preamp_out_of_domain_returns_einval_not_a_write`
  (new) — pin, not a red/green TDD case (the `handler.py` `except
  ValueError → EINVAL` mapping this exercises is pre-existing
  infrastructure, unchanged by this PR): proves the new backend seat's
  raise reaches a rigctld client as `RPRT` `EINVAL`, not a silent write,
  via the legacy Icom fallback path.

## Verification

- `uv run pytest tests/test_radio.py tests/test_ftx1_radio.py
  tests/test_rig_loader.py tests/test_commands.py
  tests/test_operator_toggles.py -q --tb=short` — 1098 passed, 1 skipped.
- Broader regression pass (all files touching `set_preamp`/`get_preamp`
  outside the three primary test files above — rigctld handler/routing,
  radio pollers, command service, web server, CLI, mock integration, etc.,
  `--ignore=tests/integration`) — 1730 passed, 2 skipped.
- `uv run ruff check src/ tests/` — clean. `uv run ruff format --check
  src/ tests/` — clean (657 files already formatted).
- `uv run lint-imports` — 5 contracts kept, 0 broken.
- `uv run mypy src/` — 13 pre-existing errors (identical set/count to
  MOR-1522's baseline), none in touched files.

### R1 additions (frontend now touched)

- `uv run pytest tests/test_radio.py tests/test_ftx1_radio.py
  tests/test_rig_loader.py tests/test_rigctld_handler.py -q` — 1062 passed,
  1 skipped.
- `npx eslint src/lib/runtime/props/panel-props.ts
  src/lib/runtime/props/__tests__/panel-props.test.ts` — clean.
- `npm run lint:boundaries` (`eslint src/components-v2/panels/
  src/components-v2/layout/ src/presentation/`) — clean.
- `npx svelte-check --tsconfig ./tsconfig.app.json` — 4547 files, 0 errors,
  0 warnings.
- `npx vitest run` on `panel-props.test.ts`, `RfFrontEndSurface.test.ts`,
  `RfFrontEnd.component.test.ts`, `RfFrontEnd.test.ts`,
  `MobileRadioLayout.honesty.isolated.test.ts`,
  `RadioLayout.command-bus-migration.isolated.test.ts`,
  `RadioLayout.isolated.test.ts`, `MobileRadioLayout.component.svelte.test.ts`,
  `LeftSidebar.test.ts` (the direct consumers plus the desktop-v2/mobile
  layout files the coordinator named as live usage sites) — 286 passed, 0
  failed across the two runs.

## Domain audit sweep

Full enumeration of every discrete-option ("pick one of N declared
values") control found in this codebase, per the coordinator's request.
"Bypass" below means: a live code path can write a value the profile's
domain doesn't declare (or would declare, if the domain were wired at
all), without going through the profile's data.

| Control | Profile-declared? | Bypass found? | Status |
|---|---|---|---|
| **att** (attenuator dB steps) | Yes — `[attenuator] values`/`labels` → `att_values`/`att_labels`, parsed by `rig_loader.py` | No — `set_attenuator_level()` validates against `att_values` | Fixed (MOR-1445, #2389) |
| **agc** (AGC mode) | Yes — `[agc] modes`/`labels`, parsed by `rig_loader.py` | No — `IcomRadio.set_agc()` / `YaesuCatRadio.set_agc()` both validate | Fixed (MOR-1522, #2437) |
| **preamp** (preamp level, `CoreRadio`/`YaesuCatRadio` seats) | Yes — `[preamp] values`/`labels`, parsed by `rig_loader.py` (already true before this PR, per MOR-1445's shared att/preamp loader work) | Was yes on three fronts: zero validation in either backend seat, AND `panel-props.ts`'s `toRfFrontEndProps` fabricated a `[0, 1, 2]` catalog when `caps.preValues` was absent — **all three fixed by this PR (R1)** | Fixed (MOR-1523, this PR) |
| **preamp** (`RigctldClientRadio.set_preamp`, third seat) | **No** — this class (`backends/rigctld_client/radio.py`, a `Radio` adapter that proxies an *external* Hamlib `rigctld` server) has no `RigProfile`/`RigConfig` at all, so there is no profile domain to declare | **Yes** — `set_preamp()` (:645-647) builds `L PREAMP {db}` with no domain check, and `_preamp_level_to_db()` (:744-746) **silently coerces** any level not in `{0, 1, 2}` to `"0"` (OFF) via `.get(level, "0")` — a worse failure mode than "unchecked passthrough": an out-of-domain request doesn't error, it silently becomes a different, wrong, valid-looking command | **Not fixed here** — different disease (no profile to validate against at all), flagged for a future ticket; the "single seat" convergence claim above holds only for the two profile-driven radio classes, not this one |
| **preamp** (CLI narrowing, `cli/__init__.py:3123`) | N/A | No — `_cmd_preamp` pre-filters to `level in (0, 1, 2)` before calling `radio.set_preamp()`; this is a **narrower** hardcoded check than some profiles' real domain requires (e.g. rejects nothing an X6200's `[0, 1]` domain wouldn't also reject, but would incorrectly *allow* level=2 through to the now-validated seat, which correctly rejects it for X6200) — not a bypass, just an imprecise pre-filter now backed by a real seat | Informational — not a bypass, not fixed, not flagged as urgent |
| **ssb_tx_bw** (SSB TX bandwidth, WIDE/MID/NAR) | **Declared in TOML but dead** — `[ssb_tx_bw] values`/`labels` exists in `rigs/{ic7300,ic7610,ic705,ic9700}.toml`, but `rig_loader.py` never reads the `"ssb_tx_bw"` key at all (confirmed: zero references to `ssb_tx_bw`/`SsbTxBandwidth` domain in `rig_loader.py` or `profiles/__init__.py`) | **Yes** — `IcomRadio.set_ssb_tx_bandwidth()` (`runtime/radio.py`) unconditionally casts through the hardcoded `SsbTxBandwidth` enum (`WIDE=0/MID=1/NAR=2`, `core/types.py:124`) for every profile with the capability, never consulting the TOML values it happens to shadow | **Not fixed here** — flagged for a future ticket |
| **break_in** (keyer break-in mode, OFF/SEMI/FULL) | **Partially declared, partially dead** — `[break_in] values`/`labels` exists in `rigs/{ic7300,ic7610,ic705,ic9700}.toml` but is never parsed by `rig_loader.py` (same gap as ssb_tx_bw); **x6200 declares the `break_in` capability with no `[break_in]` section at all** — the exact "capability present, no domain, anywhere" shape MOR-1522 fixed for AGC | **Yes** — both `IcomRadio.set_break_in()` and `YaesuCatRadio.set_break_in()` cast through the hardcoded `BreakInMode` enum (`OFF=0/SEMI=1/FULL=2`, `core/types.py:109`) unconditionally; x6200's actual break-in domain is undocumented anywhere in this codebase, so there's no way today to know if 3-state OFF/SEMI/FULL is even correct for it | **Not fixed here** — flagged for a future ticket, this is the closest analog to AGC's original bug shape found in this sweep |
| **manual notch width** (WIDE/MID/NAR) | **Declared in TOML but dead** — `[notch] width_values`/`width_labels` exists in `rigs/{ic7300,ic7610,ic705,ic9700}.toml`, never parsed by `rig_loader.py` | **Yes, and the widest-open one found** — `IcomRadio.set_manual_notch_width(value: int)` (`runtime/radio.py:3281`) has **no validation at all**, not even a hardcoded enum — any int is BCD-encoded and sent straight to the radio | **Not fixed here** — flagged; this is a strictly worse bypass shape than the hardcoded-enum cases (no ceiling of any kind, not even an accidentally-correct universal one) |
| **filter_shape** (DSP IF filter shape, SHARP/SOFT) | **No** — no `[filter_shape]` TOML section exists in any shipped profile; capability presence alone gates UI visibility (MOR-1502, #2433 — correctly hides the control on radios without the capability) | Not applicable in the "profile-declared-but-bypassed" sense — there's no profile domain to bypass. `set_filter_shape()` casts through the hardcoded 2-value `FilterShape` enum (`SHARP=0/SOFT=1`) universally for every capability-having profile | **Not fixed here** — flagged; unlike ssb_tx_bw/break_in there's no TOML domain sitting unused, so this would need a new `[filter_shape]` section added before a validation seat is meaningful |
| **auto notch** (on/off) | N/A — plain boolean toggle (`notch` capability), not an enumerated multi-value domain | N/A | Out of category — no finding |
| **nb depth / nb width / nb level** | `[nb] depth_min/depth_max/width_min/width_max` are continuous **ranges**, not discrete enumerated domains | N/A | Out of category (continuous, not enumerated) — no finding |
| **antenna selectors** (`set_antenna_1`/`set_antenna_2`) | `[antenna]` TOML section only carries `tx_count`/`has_rx_ant` counts; the actual controls are independent per-port booleans, not a "pick 1 of N" enumerated domain | N/A | Out of category — no finding |
| **keyer type / paddle mode** | No such control exists anywhere in this codebase (searched `iambic`/`keyer_type`/`dot_dash`/`paddle` across `src/` and `rigs/*.toml` — zero hits) | N/A | Doesn't exist — the only enumerated keyer-adjacent control is `break_in` (above); key speed/pitch are continuous ranges |
| **data_mode** (DATA1/DATA2/…) | Partial — `[data_mode] count`/`labels` parsed by `rig_loader.py` into `data_mode_count`/`data_mode_labels`, but shape differs (a count + generated labels, not a `values` list) | `IcomRadio.set_data_mode()`/`YaesuCatRadio.set_data_mode()` take `int \| bool` with no domain check against `data_mode_count` | Noted for completeness, not deeply investigated this sweep — flag if a future ticket wants it |

Three concrete follow-up tickets worth filing from this sweep, roughly in
priority order: **break_in** (closest to AGC's exact original bug —
x6200 has capability with zero domain anywhere), **manual notch width**
(zero validation of any kind, not even an accidentally-correct enum), and
**ssb_tx_bw** (TOML domain data sitting dead, same shape as break_in
minus the x6200 capability-without-domain wrinkle). `filter_shape` is a
smaller, differently-shaped follow-up (no TOML domain exists yet to wire
up). Add a fourth, smaller one from R1: **`RigctldClientRadio.set_preamp`**
silently coercing out-of-domain levels to OFF instead of erroring.

## R1 (post-verifier fixes)

Independent verifier ruled BLOCKED on the initial head (`96346262`). Held
up under review: seats, domain table honesty, all 5 reject-path witnesses
(DID NOT RAISE before the fix), exception handling — all confirmed clean.
Two findings, both applied, new head below:

- **B1 (code fix):** the "frontend was already profile-driven" claim was
  false. `frontend/src/lib/runtime/props/panel-props.ts:247`
  (`toRfFrontEndProps`) had `const preValues = caps?.preValues ?? [0, 1,
  2];` — the last un-converted twin of the MOR-1409 A11 doctrine already
  applied to `toAgcProps` (`agcModes: caps?.agcModes ?? []`) in the same
  file. This is a *parallel* prop mapper to the `RfFrontEndSurface.svelte`
  path I'd checked (which genuinely is clean) — it feeds
  `components-v2/panels/RfFrontEnd.svelte` directly and is live in the
  desktop-v2 `RadioLayout`/`LeftSidebar` and mobile `MobileRadioLayout`.
  Fixed: `preValues` now falls back to `[]`, matching the "unknown
  capabilities means an empty, not invented, catalog" doctrine. New pin in
  `panel-props.test.ts` (`toRfFrontEndProps — preOptions (MOR-1523 R1)`),
  verified red by temporarily reverting the fallback.
- **B2 (PR body corrections, no other code change):**
  1. The `_PREAMP_IDX_TO_DB` claim ("idx always lands inside every Icom
     domain") was wrong — X6200/X6100 declare `[0, 1]`, and dB≥16 maps to
     idx=2 via the hardcoded `[0, 12, 20]` table. `L PREAMP 20` on an X6200
     over rigctld's legacy Icom fallback path now raises inside
     `IcomRadio.set_preamp()` and surfaces as `RPRT` `EINVAL` — correct,
     but a real, previously-unannounced behavior change on a live path.
     Corrected the summary/rigctld-path/before-after sections above; added
     `test_set_level_preamp_out_of_domain_returns_einval_not_a_write`.
  2. Added the missing third seat to the audit table:
     `backends/rigctld_client/radio.py` (`RigctldClientRadio`, an external-
     `rigctld`-proxying `Radio` adapter with no profile at all) builds `L
     PREAMP <db>` unchecked, and `_preamp_level_to_db()` silently coerces
     any out-of-domain level to `"0"` — a different disease (no profile to
     validate against), flagged not fixed; the "single seat" convergence
     claim now explicitly scopes to the two profile-driven radio classes.
     Also added a row for `cli/__init__.py:3123`'s hardcoded `(0, 1, 2)`
     range check (a narrowing pre-filter, not a bypass).
  3. Softened the "no hardcoded option list anywhere" phrasing and cited
     `AmberCockpit.svelte:213-216`/`AmberScope.svelte:130-133`'s read-only
     IPO/AMP1/AMP2 ternary — same precedent as #2437's `AGC_LABELS`
     finding, tracked under MOR-1529, left alone.

Verified after R1: `uv run pytest tests/test_radio.py
tests/test_ftx1_radio.py tests/test_rig_loader.py
tests/test_rigctld_handler.py -q` — 1062 passed, 1 skipped. Frontend:
`eslint`/`lint:boundaries`/`svelte-check` clean; targeted `vitest` — 286
passed across the direct-consumer and named layout test files. `ruff
check`/`ruff format --check` on Python — clean. Boundary grep over diff —
clean.

Closes MOR-1523.
