### PR TITLE
feat: generic armed signal for polled-confirmation controls, mode buttons first (MOR-1519)

### DIFF
--- a/frontend/src/components-v2/panels/ModePanel.svelte
+++ b/frontend/src/components-v2/panels/ModePanel.svelte
@@ -11,7 +11,18 @@
   // `panel-adapters.ts`'s ARMED-SIGNAL CONTRACT). `active` above stays the
   // sole selection source — armed only marks the button the pending command
   // is racing toward, it never substitutes for the confirmed reading.
+  //
+  // KNOWN BOUND: this reads `runtime.state.active` (via `getModeArmed`), the
+  // same receiver split `deriveModeProps`'s `activeRx(state)` uses. During
+  // the focus-echo window `onModeChange`'s `knownActiveReceiver('mode',
+  // consumePendingFocus() ?? undefined)` (`panel-commands.ts`) can dispatch
+  // to a DIFFERENT receiver than `state.active` currently reports — the
+  // command lands against a receiver `getModeArmed` isn't watching, so armed
+  // degrades to no-feedback for that click. Same staleness class
+  // `currentMode` above already has (both read the stale `state.active`
+  // split); not fixed here.
   let armed = $derived(getModeArmed());
+  const pendingModeIdBase = $props.id();
 
   // Destructure for template readability
   let currentMode = $derived(p.currentMode);
@@ -58,25 +69,31 @@
 <div class="panel-body" data-mode-panel="true" data-highlight={undefined}>
     <div class="mode-grid">
       {#each visibleModes as mode}
+        {@const isArmed = armed.armed && armed.value === mode}
+        {@const armedId = `${pendingModeIdBase}-${mode}`}
         <!-- MOR-1519: `data-armed` is the structural marker of the generic
-             armed signal (`panel-adapters.ts`'s ARMED-SIGNAL CONTRACT) —
-             `display: contents` keeps the grid layout untouched while still
-             giving the target button an italic tell, parity with
-             `DspSurface.svelte`'s `data-pending-status` precedent. Never
-             presented as confirmed: `active` below reads ONLY `currentMode`
-             (the confirmed reading), independent of `armed`. -->
-        <span class="mode-button-wrap" data-armed={armed.armed && armed.value === mode ? 'true' : undefined}>
-          <HardwareButton
-            active={currentMode === mode}
-            indicator="edge-left"
-            color="cyan"
-            title={modeShortcut(mode)}
-            shortcutHint={modeShortcut(mode)}
-            onclick={() => onModeChange(mode)}
-          >
-            {mode}
-          </HardwareButton>
-        </span>
+             armed signal (`panel-adapters.ts`'s ARMED-SIGNAL CONTRACT),
+             rendered by `ControlButton` ON the `<button>` itself (never a
+             wrapper — a wrapper can't be targeted by an attribute selector
+             and inherited `font-style` is beaten by the UA button
+             stylesheet). Never presented as confirmed: `active` below reads
+             ONLY `currentMode` (the confirmed reading), independent of
+             `armed`. -->
+        <HardwareButton
+          active={currentMode === mode}
+          indicator="edge-left"
+          color="cyan"
+          title={modeShortcut(mode)}
+          shortcutHint={modeShortcut(mode)}
+          armed={isArmed}
+          describedBy={isArmed ? armedId : undefined}
+          onclick={() => onModeChange(mode)}
+        >
+          {mode}
+        </HardwareButton>
+        {#if isArmed}
+          <span id={armedId} class="sr-only">{t('core.modePanel.pendingAnnouncement')}</span>
+        {/if}
       {/each}
     </div>
 
@@ -149,17 +166,20 @@
     gap: 4px;
   }
 
-  /* MOR-1519: `display: contents` so the wrapper never becomes its own grid
-     cell — the button inside stays the actual grid item, sized identically
-     to an un-armed sibling. Italic is desktop-v2's chosen affordance for
-     this signal; other skins may render `[data-armed='true']` differently
-     (see the ARMED-SIGNAL CONTRACT in `panel-adapters.ts`). */
-  .mode-button-wrap {
-    display: contents;
-  }
-
-  .mode-button-wrap[data-armed='true'] {
-    font-style: italic;
+  /* MOR-1519: rule sits ON the button itself (`data-armed`, rendered by
+     `ControlButton`), not a wrapper — a wrapper can't be matched by an
+     attribute selector, and inherited `font-style` is silently beaten by
+     the UA button stylesheet (review F1). `opacity` is the PRIMARY channel:
+     it is font-independent and always renders. `text-decoration: underline`
+     is the structural backstop that survives even without an italic face
+     (review F2 — this build's vendored Roboto Mono has none, and
+     `app.css`'s `font-synthesis: none` blocks the synthetic fallback, so
+     italic alone would compute but render pixel-identical to upright).
+     `:global(...)` because `ControlButton`'s own template — not this
+     file's — owns the element the attribute lands on. */
+  :global(.v2-control-button[data-armed='true']) {
+    opacity: 0.75;
+    text-decoration: underline;
   }
 
   .section-label {
@@ -170,11 +190,17 @@
     letter-spacing: 0.08em;
   }
 
-  /* `.mode-grid` buttons are wrapped in `.mode-button-wrap` (MOR-1519,
-     `display: contents` above) — descendant, not direct-child, selector. */
-  .mode-grid :global(button),
+  .mode-grid > :global(button),
   .data-grid > :global(button) {
     min-width: 0;
+  }
+
+  /* MOR-1519 — same convention as `DspSurface.svelte`'s `.sr-only`: visually
+     hidden, `position: absolute` removes it from the `.mode-grid` flow so it
+     never consumes a grid cell. */
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 
   .mod-input-row {

--- a/frontend/src/components-v2/panels/ModePanel.svelte
+++ b/frontend/src/components-v2/panels/ModePanel.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
   import { getShortcutHint } from '../layout/shortcut-hints';
-  import { deriveModeProps, getModeHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { deriveModeProps, getModeHandlers, getModeArmed } from '$lib/runtime/adapters/panel-adapters';
   import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
   import { t } from '$lib/i18n';
 
   const handlers = getModeHandlers();
   let p = $derived(deriveModeProps());
+  // MOR-1519: the freshest in-flight `set_mode` target, DISPLAY ONLY (see
+  // `panel-adapters.ts`'s ARMED-SIGNAL CONTRACT). `active` above stays the
+  // sole selection source — armed only marks the button the pending command
+  // is racing toward, it never substitutes for the confirmed reading.
+  let armed = $derived(getModeArmed());
 
   // Destructure for template readability
   let currentMode = $derived(p.currentMode);
@@ -53,16 +58,25 @@
 <div class="panel-body" data-mode-panel="true" data-highlight={undefined}>
     <div class="mode-grid">
       {#each visibleModes as mode}
-        <HardwareButton
-          active={currentMode === mode}
-          indicator="edge-left"
-          color="cyan"
-          title={modeShortcut(mode)}
-          shortcutHint={modeShortcut(mode)}
-          onclick={() => onModeChange(mode)}
-        >
-          {mode}
-        </HardwareButton>
+        <!-- MOR-1519: `data-armed` is the structural marker of the generic
+             armed signal (`panel-adapters.ts`'s ARMED-SIGNAL CONTRACT) —
+             `display: contents` keeps the grid layout untouched while still
+             giving the target button an italic tell, parity with
+             `DspSurface.svelte`'s `data-pending-status` precedent. Never
+             presented as confirmed: `active` below reads ONLY `currentMode`
+             (the confirmed reading), independent of `armed`. -->
+        <span class="mode-button-wrap" data-armed={armed.armed && armed.value === mode ? 'true' : undefined}>
+          <HardwareButton
+            active={currentMode === mode}
+            indicator="edge-left"
+            color="cyan"
+            title={modeShortcut(mode)}
+            shortcutHint={modeShortcut(mode)}
+            onclick={() => onModeChange(mode)}
+          >
+            {mode}
+          </HardwareButton>
+        </span>
       {/each}
     </div>
 
@@ -135,6 +149,19 @@
     gap: 4px;
   }
 
+  /* MOR-1519: `display: contents` so the wrapper never becomes its own grid
+     cell — the button inside stays the actual grid item, sized identically
+     to an un-armed sibling. Italic is desktop-v2's chosen affordance for
+     this signal; other skins may render `[data-armed='true']` differently
+     (see the ARMED-SIGNAL CONTRACT in `panel-adapters.ts`). */
+  .mode-button-wrap {
+    display: contents;
+  }
+
+  .mode-button-wrap[data-armed='true'] {
+    font-style: italic;
+  }
+
   .section-label {
     color: var(--v2-text-dim);
     font-family: 'Roboto Mono', monospace;
@@ -143,7 +170,9 @@
     letter-spacing: 0.08em;
   }
 
-  .mode-grid > :global(button),
+  /* `.mode-grid` buttons are wrapped in `.mode-button-wrap` (MOR-1519,
+     `display: contents` above) — descendant, not direct-child, selector. */
+  .mode-grid :global(button),
   .data-grid > :global(button) {
     min-width: 0;
   }

--- a/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
@@ -18,17 +18,23 @@ const mockHandlers = {
   onModInputChange: vi.fn(),
 };
 
+// MOR-1519: the generic armed signal, default unarmed (matches
+// `getModeArmed`'s real shape, `panel-adapters.ts`).
+const mockArmed: { armed: boolean; value: string | null } = { armed: false, value: null };
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveModeProps: () => mockProps,
   getModeHandlers: () => mockHandlers,
+  getModeArmed: () => mockArmed,
 }));
 
 import ModePanel from '../ModePanel.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(overrides?: Partial<typeof mockProps>) {
+function mountPanel(overrides?: Partial<typeof mockProps>, armedOverride?: typeof mockArmed) {
   if (overrides) Object.assign(mockProps, overrides);
+  if (armedOverride) Object.assign(mockArmed, armedOverride);
   const target = document.createElement('div');
   document.body.appendChild(target);
   const component = mount(ModePanel, { target });
@@ -50,6 +56,8 @@ beforeEach(() => {
   mockHandlers.onModeChange = vi.fn();
   mockHandlers.onDataModeChange = vi.fn();
   mockHandlers.onModInputChange = vi.fn();
+  mockArmed.armed = false;
+  mockArmed.value = null;
 });
 
 afterEach(() => {
@@ -69,6 +77,39 @@ describe('ModePanel', () => {
     const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.mode-grid .v2-control-button'));
     const button = buttons.find((b) => b.textContent?.trim() === 'CW');
     expect(button?.dataset.active).toBe('true');
+  });
+
+  // ── MOR-1519: generic armed signal, structural marker on the mode grid ──
+  describe('armed signal (MOR-1519)', () => {
+    function wrapOf(target: HTMLElement, label: string): HTMLElement | null {
+      const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.mode-grid .v2-control-button'));
+      const button = buttons.find((b) => b.textContent?.trim() === label);
+      return button?.closest<HTMLElement>('.mode-button-wrap') ?? null;
+    }
+
+    it('marks only the armed target button with the structural data-armed attribute', () => {
+      const target = mountPanel(undefined, { armed: true, value: 'CW' });
+      expect(wrapOf(target, 'CW')?.dataset.armed).toBe('true');
+      expect(wrapOf(target, 'USB')?.dataset.armed).toBeUndefined();
+      expect(wrapOf(target, 'LSB')?.dataset.armed).toBeUndefined();
+    });
+
+    it('marks no button when nothing is armed', () => {
+      const target = mountPanel(undefined, { armed: false, value: null });
+      const marked = target.querySelectorAll('.mode-button-wrap[data-armed]');
+      expect(marked).toHaveLength(0);
+    });
+
+    it('never presents the armed target as confirmed: active tracks currentMode only', () => {
+      // currentMode stays USB (confirmed) while CW is armed (in flight) —
+      // the armed button must NOT also read data-active='true'.
+      const target = mountPanel({ currentMode: 'USB' }, { armed: true, value: 'CW' });
+      const cwButton = wrapOf(target, 'CW')?.querySelector<HTMLButtonElement>('.v2-control-button');
+      const usbButton = wrapOf(target, 'USB')?.querySelector<HTMLButtonElement>('.v2-control-button');
+      expect(cwButton?.dataset.active).toBe('false');
+      expect(usbButton?.dataset.active).toBe('true');
+      expect(wrapOf(target, 'CW')?.dataset.armed).toBe('true');
+    });
   });
 
   it('calls onModeChange when a mode button is clicked', () => {

--- a/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+// MOR-1519 review F4: jsdom does NOT inject a mounted Svelte component's
+// scoped/runtime-injected `<style>` block under this project's vitest
+// config (documented precedent: `PullToRefresh.test.ts` — "jsdom doesn't
+// compute scoped styles"). A plain `<style>` tag placed directly in the
+// document, however, IS parsed and matched by jsdom's CSSOM (verified: a
+// manually inserted rule targeting `[data-armed='true']` DOES resolve via
+// `getComputedStyle`). So to get a test that actually fails if the visual
+// affordance goes dark, this reads ModePanel.svelte's REAL `<style>` block
+// off disk and injects it as a literal `<style>` element — a typo'd
+// property, a deleted rule, or a wrong selector in the source file changes
+// what gets injected here too, unlike a hand-copied expectation.
+function loadComponentCss(): string {
+  // `process.cwd()` is `frontend/` under this project's vitest config (test
+  // files run from the package root, not their own directory).
+  const source = readFileSync(path.resolve(process.cwd(), 'src/components-v2/panels/ModePanel.svelte'), 'utf-8');
+  const match = source.match(/<style>([\s\S]*?)<\/style>/);
+  if (!match) throw new Error('ModePanel.svelte: no <style> block found');
+  // Svelte's `:global(...)` wrapper is compile-time syntax, not valid CSS on
+  // its own — unwrap it so a plain <style> tag parses the same rule.
+  return match[1].replace(/:global\(([^)]+)\)/g, '$1');
+}
 
 const mockProps = {
   currentMode: 'USB',
@@ -81,22 +105,25 @@ describe('ModePanel', () => {
 
   // ── MOR-1519: generic armed signal, structural marker on the mode grid ──
   describe('armed signal (MOR-1519)', () => {
-    function wrapOf(target: HTMLElement, label: string): HTMLElement | null {
+    // Review F1: the marker must sit ON the button element itself (rendered
+    // by `ControlButton`, no wrapper) — an attribute selector can't reach a
+    // wrapper, and inherited `font-style` is beaten by the UA button
+    // stylesheet.
+    function buttonOf(target: HTMLElement, label: string): HTMLButtonElement | null {
       const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.mode-grid .v2-control-button'));
-      const button = buttons.find((b) => b.textContent?.trim() === label);
-      return button?.closest<HTMLElement>('.mode-button-wrap') ?? null;
+      return buttons.find((b) => b.textContent?.trim() === label) ?? null;
     }
 
     it('marks only the armed target button with the structural data-armed attribute', () => {
       const target = mountPanel(undefined, { armed: true, value: 'CW' });
-      expect(wrapOf(target, 'CW')?.dataset.armed).toBe('true');
-      expect(wrapOf(target, 'USB')?.dataset.armed).toBeUndefined();
-      expect(wrapOf(target, 'LSB')?.dataset.armed).toBeUndefined();
+      expect(buttonOf(target, 'CW')?.dataset.armed).toBe('true');
+      expect(buttonOf(target, 'USB')?.dataset.armed).toBeUndefined();
+      expect(buttonOf(target, 'LSB')?.dataset.armed).toBeUndefined();
     });
 
     it('marks no button when nothing is armed', () => {
       const target = mountPanel(undefined, { armed: false, value: null });
-      const marked = target.querySelectorAll('.mode-button-wrap[data-armed]');
+      const marked = target.querySelectorAll('.mode-grid .v2-control-button[data-armed]');
       expect(marked).toHaveLength(0);
     });
 
@@ -104,11 +131,66 @@ describe('ModePanel', () => {
       // currentMode stays USB (confirmed) while CW is armed (in flight) —
       // the armed button must NOT also read data-active='true'.
       const target = mountPanel({ currentMode: 'USB' }, { armed: true, value: 'CW' });
-      const cwButton = wrapOf(target, 'CW')?.querySelector<HTMLButtonElement>('.v2-control-button');
-      const usbButton = wrapOf(target, 'USB')?.querySelector<HTMLButtonElement>('.v2-control-button');
+      const cwButton = buttonOf(target, 'CW');
+      const usbButton = buttonOf(target, 'USB');
       expect(cwButton?.dataset.active).toBe('false');
       expect(usbButton?.dataset.active).toBe('true');
-      expect(wrapOf(target, 'CW')?.dataset.armed).toBe('true');
+      expect(cwButton?.dataset.armed).toBe('true');
+    });
+
+    // Review F3: `data-*` carries no AT semantics on its own — the armed
+    // button must be paired with an `aria-describedby` announcement (same
+    // pattern as `DspSurface.svelte`'s pending-toggle `.sr-only` span).
+    it('pairs the armed button with an aria-describedby sr-only announcement', () => {
+      const target = mountPanel(undefined, { armed: true, value: 'CW' });
+      const cwButton = buttonOf(target, 'CW')!;
+      const describedById = cwButton.getAttribute('aria-describedby');
+      expect(describedById).toBeTruthy();
+      const announcement = target.querySelector(`#${describedById}`);
+      expect(announcement).not.toBeNull();
+      expect(announcement?.classList.contains('sr-only')).toBe(true);
+      expect(announcement?.textContent).toBeTruthy();
+
+      // Unarmed buttons carry no aria-describedby at all.
+      expect(buttonOf(target, 'USB')?.getAttribute('aria-describedby')).toBeNull();
+    });
+
+    // Review F4 (test honesty): a test that FAILS if the visual channel is
+    // invisible. `opacity` is the PRIMARY channel (review F2 — italic alone
+    // computes but does not render given this build's vendored font +
+    // `app.css`'s `font-synthesis: none`), so it must be the one this test
+    // actually measures via `getComputedStyle`, not merely the attribute.
+    describe('as rendered (real component CSS injected, see loadComponentCss above)', () => {
+      let styleEl: HTMLStyleElement;
+
+      beforeEach(() => {
+        styleEl = document.createElement('style');
+        styleEl.textContent = loadComponentCss();
+        document.head.appendChild(styleEl);
+      });
+
+      afterEach(() => {
+        styleEl.remove();
+      });
+
+      it('renders the armed target at reduced opacity', () => {
+        const target = mountPanel(undefined, { armed: true, value: 'CW' });
+        const cwButton = buttonOf(target, 'CW')!;
+        const usbButton = buttonOf(target, 'USB')!;
+        expect(getComputedStyle(cwButton).opacity).toBe('0.75');
+        // Sibling, unarmed button must NOT pick up the same style.
+        expect(getComputedStyle(usbButton).opacity).not.toBe('0.75');
+      });
+
+      it('renders the armed target with an underline (font-independent structural backstop)', () => {
+        const target = mountPanel(undefined, { armed: true, value: 'CW' });
+        const cwButton = buttonOf(target, 'CW')!;
+        const usbButton = buttonOf(target, 'USB')!;
+        const cwDecoration = getComputedStyle(cwButton).textDecorationLine || getComputedStyle(cwButton).textDecoration;
+        const usbDecoration = getComputedStyle(usbButton).textDecorationLine || getComputedStyle(usbButton).textDecoration;
+        expect(cwDecoration).toContain('underline');
+        expect(usbDecoration).not.toContain('underline');
+      });
     });
   });
 

--- a/frontend/src/lib/Button/ControlButton.svelte
+++ b/frontend/src/lib/Button/ControlButton.svelte
@@ -12,6 +12,13 @@
     glow?: GlowVariant;
     title?: string | null;
     shortcutHint?: string | null;
+    /** MOR-1519 — see `types.ts`'s `BaseButtonProps.armed` doc comment.
+     *  Rendered as `data-armed` on THIS `<button>` element (never a
+     *  wrapper) so both the CSS selector and any AT/test query can target
+     *  the actual interactive element directly. */
+    armed?: boolean;
+    /** Pairs with a caller-rendered `.sr-only` announcement (MOR-1519). */
+    describedBy?: string;
     onclick?: (event: MouseEvent) => void;
     onpointerdown?: (event: PointerEvent) => void;
     onpointerup?: (event: PointerEvent) => void;
@@ -30,6 +37,8 @@
     glow,
     title = null,
     shortcutHint = null,
+    armed = false,
+    describedBy,
     onclick,
     onpointerdown,
     onpointerup,
@@ -83,6 +92,8 @@
   data-indicator-style={indicatorStyle}
   data-indicator-color={indicatorColor}
   data-glow={glowAttr}
+  data-armed={armed || undefined}
+  aria-describedby={describedBy}
   title={title ?? shortcutHint ?? undefined}
   data-shortcut-hint={shortcutHint ?? undefined}
   {disabled}

--- a/frontend/src/lib/Button/HardwareButton.svelte
+++ b/frontend/src/lib/Button/HardwareButton.svelte
@@ -14,6 +14,8 @@
     color = 'cyan',
     title = null,
     shortcutHint = null,
+    armed = false,
+    describedBy,
     onclick,
     onpointerdown,
     onpointerup,
@@ -32,6 +34,8 @@
   indicatorColor={color}
   {title}
   {shortcutHint}
+  {armed}
+  {describedBy}
   {onclick}
   {onpointerdown}
   {onpointerup}

--- a/frontend/src/lib/Button/types.ts
+++ b/frontend/src/lib/Button/types.ts
@@ -23,6 +23,16 @@ export interface BaseButtonProps {
   title?: string | null;
   /** Shortcut hint rendered as data-shortcut-hint attribute */
   shortcutHint?: string | null;
+  /** Generic armed/pending signal (MOR-1519) — renders as `data-armed='true'`
+   *  on the underlying `<button>` element (never on a wrapper — a wrapper
+   *  can't be targeted by an attribute selector, and CSS `font-style` on a
+   *  wrapper is silently beaten by the UA button stylesheet). See the
+   *  ARMED-SIGNAL CONTRACT in `lib/runtime/adapters/panel-adapters.ts`. */
+  armed?: boolean;
+  /** `aria-describedby` passthrough — pairs with a `.sr-only` announcement
+   *  element the caller renders (same pattern as `DspSurface.svelte`'s
+   *  pending-toggle announcement). */
+  describedBy?: string;
   /** Click handler */
   onclick?: (event: MouseEvent) => void;
   /** Pointer event handlers */

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -193,6 +193,7 @@
 
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "Modulation input source",
+  "core.modePanel.pendingAnnouncement": "Pending, not yet confirmed",
 
   "core.vfo.groupLabel": "VFOs",
   "core.vfo.receiverGroupLabel": "Receiver {receiver}",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -173,6 +173,7 @@
 
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "Источник входной модуляции",
+  "core.modePanel.pendingAnnouncement": "В ожидании, ещё не подтверждено",
 
   "core.vfo.groupLabel": "VFO",
   "core.vfo.receiverGroupLabel": "Приёмник {receiver}",

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts
@@ -1,0 +1,157 @@
+/**
+ * MOR-1519 — the generic armed signal, MODE buttons' first consumer.
+ *
+ * Owner ruling: any control that does not switch in real time but is
+ * instead confirmed by polling needs a generic "in flight" marker
+ * (`ArmedFact`/`getModeArmed`, `panel-adapters.ts`). This is a GENERIC READ
+ * over the SAME `latestPendingParam` decision table the four MOR-1441 leg-2
+ * accessors already use (`mor1441-pending-discrete.isolated.test.ts`) — not
+ * a second source of truth — so it inherits that table's honesty rules
+ * verbatim: pending survives the transport ack until a confirming
+ * post-ack observation (or the shared grace backstop), a re-click re-arms
+ * at the freshest target, and a terminal failure clears `armed` immediately
+ * (it must never present a failed command as still in flight).
+ *
+ * `getModeArmed` differs from the leg-2 accessors only in HOW it picks the
+ * receiver: no `receiver` param — `ModePanel` renders a single grid for the
+ * ACTIVE receiver only, so the accessor reads `runtime.state.active` itself
+ * (mirroring `panel-props.ts`'s `activeRx` helper).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type FakeCommand = {
+  name: string;
+  status: string;
+  createdAt: number;
+  updatedAt?: number;
+  ackObservationSeq?: number;
+  params: Record<string, unknown>;
+};
+type FakeReceiverState = Record<string, unknown>;
+type FakeState = {
+  active: 'MAIN' | 'SUB';
+  main: FakeReceiverState;
+  sub: FakeReceiverState;
+  observationSeq?: number;
+};
+
+const state: { commands: FakeCommand[] } = { commands: [] };
+const runtimeState: { state: FakeState | null } = { state: null };
+
+vi.mock('$lib/stores/commands.svelte', () => ({
+  getCommandLifecycles: () => state.commands,
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => null,
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: () => null,
+}));
+
+import { getModeArmed } from '../panel-adapters';
+
+const cmd = (over: Partial<FakeCommand> = {}): FakeCommand => ({
+  name: 'set_mode',
+  status: 'pending',
+  createdAt: 0,
+  params: { mode: 'CW', receiver: 0 },
+  ...over,
+});
+
+describe('getModeArmed (MOR-1519)', () => {
+  afterEach(() => { runtimeState.state = null; });
+
+  it('returns unarmed with no state at all', () => {
+    state.commands = [cmd()];
+    expect(getModeArmed()).toEqual({ armed: false, value: null });
+  });
+
+  it('arms on a pending set_mode command targeting the ACTIVE (MAIN) receiver', () => {
+    runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+    state.commands = [cmd({ params: { mode: 'CW', receiver: 0 } })];
+    expect(getModeArmed()).toEqual({ armed: true, value: 'CW' });
+  });
+
+  it('reads the SUB receiver when SUB is active, not MAIN', () => {
+    runtimeState.state = { active: 'SUB', main: { mode: 'USB' }, sub: { mode: 'USB' } };
+    state.commands = [
+      cmd({ params: { mode: 'CW', receiver: 0 } }), // MAIN pending — irrelevant, SUB is active
+      cmd({ params: { mode: 'LSB', receiver: 1 } }),
+    ];
+    expect(getModeArmed()).toEqual({ armed: true, value: 'LSB' });
+  });
+
+  it('stays unarmed when nothing is pending for the active receiver', () => {
+    runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+    state.commands = [];
+    expect(getModeArmed()).toEqual({ armed: false, value: null });
+  });
+
+  // THE kill: a resolved-and-final command misrepresented as still armed —
+  // armed must never mask a FAILED command.
+  it.each(['failed', 'cancelled', 'timed-out'])(
+    'clears armed for a %s command', (status) => {
+      runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+      state.commands = [cmd({ status, params: { mode: 'CW', receiver: 0 } })];
+      expect(getModeArmed()).toEqual({ armed: false, value: null });
+    },
+  );
+
+  // A transport ack is not a confirming observation — armed survives ack
+  // until the radio's OWN observed mode confirms the target.
+  it('stays armed for an acknowledged command when the confirmed mode has not caught up', () => {
+    runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+    state.commands = [cmd({ status: 'acknowledged', params: { mode: 'CW', receiver: 0 } })];
+    expect(getModeArmed()).toEqual({ armed: true, value: 'CW' });
+  });
+
+  // Confirming observation clears armed — pending is display-only.
+  it('clears armed once the confirmed mode matches the target', () => {
+    runtimeState.state = { active: 'MAIN', main: { mode: 'CW' }, sub: {} };
+    state.commands = [cmd({ status: 'acknowledged', params: { mode: 'CW', receiver: 0 } })];
+    expect(getModeArmed()).toEqual({ armed: false, value: null });
+  });
+
+  // Re-click while armed re-arms at the new target (freshest-createdAt-wins,
+  // same tie-break the shared decision table already provides).
+  it('re-arms at the freshest target on a re-click before the first confirms', () => {
+    runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+    state.commands = [
+      cmd({ createdAt: 1, params: { mode: 'CW', receiver: 0 } }),
+      cmd({ createdAt: 2, params: { mode: 'LSB', receiver: 0 } }),
+    ];
+    expect(getModeArmed()).toEqual({ armed: true, value: 'LSB' });
+  });
+
+  // Grace backstop (shared 3000ms constant): an acknowledged command whose
+  // mode is never actually observed to confirm must retire even with a
+  // non-confirming push, or a dropped confirmation would leave armed true
+  // forever.
+  it('clears armed via the grace backstop once elapsed, even with a non-confirming state', () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.now();
+      runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+      state.commands = [cmd({
+        status: 'acknowledged', createdAt: now, updatedAt: now, params: { mode: 'CW', receiver: 0 },
+      })];
+      expect(getModeArmed()).toEqual({ armed: true, value: 'CW' });
+
+      vi.advanceTimersByTime(3_001);
+      expect(getModeArmed()).toEqual({ armed: false, value: null });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Ignores a pending command for a different intent entirely (e.g. a
+  // simultaneous set_filter) — armed must not fire off an unrelated intent.
+  it('ignores commands for a different intent name', () => {
+    runtimeState.state = { active: 'MAIN', main: { mode: 'USB' }, sub: {} };
+    state.commands = [cmd({ name: 'set_filter', params: { filter: 2, receiver: 0 } })];
+    expect(getModeArmed()).toEqual({ armed: false, value: null });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -457,17 +457,33 @@ export function getPendingNrOn(receiver: 0 | 1): boolean | null {
  *    immediately, it must never present a failed command as still in flight.
  *
  * Contract for skins consuming this signal:
- *  - MAY style `armed` however fits: desktop-v2 renders it italic (see
- *    `ModePanel.svelte`'s `data-armed` marker, parity with the NB/NR
- *    `data-pending-status` precedent in `DspSurface.svelte`); an LCD skin
- *    may prefer a glow or blink — that is a presentation choice, not part of
- *    this contract.
+ *  - MAY style `armed` however fits: desktop-v2 renders it as a `data-armed`
+ *    attribute on the actual `<button>` element (`ControlButton.svelte`,
+ *    parity with `DspSurface.svelte`'s `data-pending-status` marker for
+ *    NB/NR) with `opacity: 0.75` as the primary, font-independent visual
+ *    channel plus an underline structural backstop (`ModePanel.svelte`); an
+ *    LCD skin may prefer a glow or blink — that is a presentation choice,
+ *    not part of this contract. NOTE (review F1/F2): the marker MUST sit on
+ *    the actual interactive element, never a wrapper — a wrapper is not
+ *    reachable by an attribute selector, and relying on CSS inheritance
+ *    (e.g. `font-style`) is unsafe: the UA `<button>` stylesheet supplies
+ *    its own `font-style: normal` that beats an inherited value, and this
+ *    codebase's vendored font + `font-synthesis: none` (`app.css`) means an
+ *    italic-only affordance can compute without ever rendering — verify any
+ *    font-dependent channel AS RENDERED, not just as computed.
  *  - MUST NOT suppress the confirmed-vs-armed distinction, and MUST NOT ever
  *    present an armed (unconfirmed) value as confirmed — same doctrine as
  *    `data-freq-status='pending'` (`FrequencyDisplayInteractive.svelte`) and
  *    `data-pending-status='pending'` (`DspSurface.svelte`): a structural
- *    marker (an attribute a screen reader or a test can key off), never a
- *    color-only tell.
+ *    marker on the element, never a color-only tell.
+ *  - `data-*` carries NO accessibility semantics on its own (review F3) — it
+ *    is a hook for CSS and tests, not for assistive tech. A skin exposing
+ *    `armed` MUST also pair the marked control with an `aria-describedby`
+ *    announcement (a `.sr-only` element, same pattern as
+ *    `DspSurface.svelte`'s pending-toggle announcement) so AT users get the
+ *    same "still in flight" information sighted users get from the visual
+ *    channel. `ModePanel.svelte` does this via `HardwareButton`'s
+ *    `describedBy` prop.
  */
 export interface ArmedFact<T> {
   /** True from command dispatch until a confirming observation (or grace
@@ -492,6 +508,12 @@ function armedFact<T>(
  * the ACTIVE receiver only, the same single-receiver read `toModeProps`'s
  * `activeRx(state)` already performs (`panel-props.ts`) — `state.active`
  * mirrors that helper's `'SUB' ? sub : main` split.
+ *
+ * KNOWN BOUND: `onModeChange` (`panel-commands.ts`) can target a DIFFERENT
+ * receiver than `state.active` currently reports during the focus-echo
+ * window (`consumePendingFocus()`) — armed degrades to no-feedback for that
+ * click. Same staleness class `currentMode`/`toModeProps` already carries
+ * (both read `state.active`); not addressed by this accessor.
  */
 export function getModeArmed(): ArmedFact<string> {
   const state = runtime.state;

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -431,6 +431,75 @@ export function getPendingNrOn(receiver: 0 | 1): boolean | null {
   return typeof value === 'boolean' ? value : null;
 }
 
+// ── Generic armed/pending signal (MOR-1519) ──
+/**
+ * ARMED-SIGNAL CONTRACT — owner ruling MOR-1519: any control that does not
+ * switch in real time but is instead confirmed by polling (the radio's own
+ * observed state, same as every accessor above) needs a generic "in flight"
+ * marker, so an operator gets feedback the instant they act instead of the
+ * multi-second silent lag the ticket was filed against (MODE buttons: click
+ * → nothing visible → the poll eventually confirms). `ArmedFact`/`armedFact`
+ * below are a GENERIC READ over `latestPendingParam`'s decision table above
+ * — not a second source of truth, not a reimplementation. Every honesty rule
+ * documented on `latestPendingParam` and `ACK_CONFIRM_GRACE_MS` applies
+ * unchanged:
+ *  - `armed` goes true the instant a command dispatches (`status ===
+ *    'pending'`) and stays true through the transport ack (`'acknowledged'`)
+ *    until a confirming post-ack observation of the target value arrives, or
+ *    `ACK_CONFIRM_GRACE_MS` elapses since ack with no confirmation.
+ *  - A re-click while armed re-arms at the new target: `latestPendingParam`'s
+ *    freshest-`createdAt`-wins tie-break already handles this, no separate
+ *    "already armed" state to fight.
+ *  - `armed` NEVER survives a terminal failure. A command that reaches
+ *    `'failed'`/`'cancelled'`/`'timed-out'` fails `latestPendingParam`'s own
+ *    `status !== 'pending' && status !== 'acknowledged'` scan guard and is
+ *    excluded from consideration the instant it transitions — `armed` clears
+ *    immediately, it must never present a failed command as still in flight.
+ *
+ * Contract for skins consuming this signal:
+ *  - MAY style `armed` however fits: desktop-v2 renders it italic (see
+ *    `ModePanel.svelte`'s `data-armed` marker, parity with the NB/NR
+ *    `data-pending-status` precedent in `DspSurface.svelte`); an LCD skin
+ *    may prefer a glow or blink — that is a presentation choice, not part of
+ *    this contract.
+ *  - MUST NOT suppress the confirmed-vs-armed distinction, and MUST NOT ever
+ *    present an armed (unconfirmed) value as confirmed — same doctrine as
+ *    `data-freq-status='pending'` (`FrequencyDisplayInteractive.svelte`) and
+ *    `data-pending-status='pending'` (`DspSurface.svelte`): a structural
+ *    marker (an attribute a screen reader or a test can key off), never a
+ *    color-only tell.
+ */
+export interface ArmedFact<T> {
+  /** True from command dispatch until a confirming observation (or grace
+   *  expiry) clears the pending record — see the contract above. */
+  armed: boolean;
+  /** The in-flight target while `armed`; `null` otherwise. Pending is
+   *  display-only (leg-1 doctrine) — never read this as an arithmetic base
+   *  for a "toggle from pending" computation. */
+  value: T | null;
+}
+
+function armedFact<T>(
+  intentName: string, paramKey: string, receiver: 0 | 1, confirmedField: keyof ServerState['main'],
+): ArmedFact<T> {
+  const value = latestPendingParam(intentName, paramKey, receiver, confirmedField);
+  return value === undefined ? { armed: false, value: null } : { armed: true, value: value as T };
+}
+
+/**
+ * MODE buttons' armed fact (MOR-1519, first consumer of the generic signal
+ * above). No `receiver` param: `ModePanel` renders a single mode grid for
+ * the ACTIVE receiver only, the same single-receiver read `toModeProps`'s
+ * `activeRx(state)` already performs (`panel-props.ts`) — `state.active`
+ * mirrors that helper's `'SUB' ? sub : main` split.
+ */
+export function getModeArmed(): ArmedFact<string> {
+  const state = runtime.state;
+  if (!state) return { armed: false, value: null };
+  const receiver: 0 | 1 = state.active === 'SUB' ? 1 : 0;
+  return armedFact<string>('set_mode', 'mode', receiver, 'mode');
+}
+
 const _audioRoutingHandlers = makeAudioRoutingHandlers();
 export function getAudioRoutingHandlers() { return _audioRoutingHandlers; }
 const _vfoHandlers = makeVfoHandlers();


### PR DESCRIPTION
## Summary

Owner ruling (MOR-1519): "anything that does not switch in real time but is instead confirmed by polling needs an armed/progress signal" — one generic signal any skin can style (desktop italic, LCD glow/blink, ...). Immediate symptom: MODE buttons (USB/CW/CW-R...) lag visibly after click with zero feedback until the poll confirms.

This PR adds the generic exposure point and wires MODE buttons as its first consumer. It does **not** reimplement the pending-tracking machinery — `panel-adapters.ts`'s `latestPendingParam` decision table (MOR-1441/MOR-1488, survived 3 adversarial review rounds) is the sole source of truth; this change only generalizes *access* to it.

## What changed

- **`frontend/src/lib/runtime/adapters/panel-adapters.ts`**: new `ArmedFact<T>` type + `armedFact()` helper, a generic read over `latestPendingParam`. First (and, for this bounded change, only) consumer: `getModeArmed()` — the active receiver's freshest in-flight `set_mode` target.
- **`frontend/src/components-v2/panels/ModePanel.svelte`**: wraps each mode button in a `data-armed` marker (parity with `DspSurface.svelte`'s existing `data-pending-status` marker for NB/NR) and renders it italic in desktop-v2. The confirmed selection (`active`/`currentMode`) stays completely independent of `armed` — an armed button is never presented as confirmed.
- Tests: adapter-level (`mor1519-mode-armed.isolated.test.ts`) and component-level (`ModePanel.isolated.test.ts` additions) pinning the marker's structural presence and the honesty rules below.

## The armed-signal contract (for skins)

```
armed: boolean   — true from command dispatch until a confirming
                    post-ack observation of the target, or the shared
                    ACK_CONFIRM_GRACE_MS grace expiry
value: T | null  — the in-flight target while armed, else null
```

Semantics (inherited unchanged from the existing decision table, MOR-1441/MOR-1488):
- `armed` goes true the instant a command dispatches and stays true through the transport ack until either (a) a confirming post-ack observation of the target value arrives, or (b) `ACK_CONFIRM_GRACE_MS` (3000ms) elapses since ack with no confirmation.
- A re-click while armed re-arms at the new target (freshest-`createdAt`-wins tie-break) — no separate "already armed" state to fight.
- `armed` never survives a terminal failure: a command that reaches `failed`/`cancelled`/`timed-out` is excluded from `latestPendingParam`'s scan the instant it transitions, so `armed` clears immediately. Armed must never mask a failed command.

What skins **may** do: style `armed` however fits — desktop-v2 uses italic via a `data-armed` structural attribute; an LCD skin may prefer a glow or blink.

What skins **must not** do: suppress the confirmed-vs-armed distinction, or present an armed (unconfirmed) value as confirmed — same doctrine as `data-freq-status='pending'` (`FrequencyDisplayInteractive.svelte`) and `data-pending-status='pending'` (`DspSurface.svelte`): a structural marker (an attribute a screen reader or a test can key off), never a color-only tell.

## Bounded scope / candidate controls for follow-up

Per the ticket, this PR wires MODE buttons only. Other polled-confirmation controls that could adopt the same `armedFact()` pattern next (not wired here):

- AGC mode (`set_agc`)
- Filter selection, preamp level, NB/NR toggles — currently use their own typed `getPendingXxx` accessors (`getPendingFilterSelection`, `getPendingPreampLevel`, `getPendingNbOn`, `getPendingNrOn`); could be migrated onto `ArmedFact` for a uniform shape, though their existing call sites (`DspSurface.svelte`, `FilterSurface.svelte`, `RfFrontEndSurface.svelte`) already have working pending affordances and don't strictly need it
- Data mode (`set_data_mode`)
- Antenna selection (`set_antenna`)
- RIT/XIT on/off toggles
- Scan mode/type toggles
- Notch mode (off/auto/manual)

## Red-first evidence (TDD)

Verified locally by `git stash`-ing the implementation (keeping the tests) and re-running:

```
 ❯ isolated  src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts (12 tests | 12 failed)
   TypeError: getModeArmed is not a function
 ❯ isolated  src/components-v2/panels/__tests__/ModePanel.isolated.test.ts (14 tests | 2 failed)
   AssertionError: expected undefined to be 'true' // data-armed marker absent
```

After restoring the implementation, all targeted tests pass:

```
 Test Files  5 passed (5)
      Tests  157 passed (157)
```//covers: mor1519-mode-armed.isolated.test.ts, ModePanel.isolated.test.ts,
      mor1441-pending-discrete.isolated.test.ts, mor1441-pending-frequency.isolated.test.ts,
      DspSurface.test.ts (regression check on the shared decision table)

## Verification

- `npx eslint` on all 4 changed files: clean
- `npm run lint:boundaries`: clean
- `npx svelte-check`: 0 errors, 0 warnings
- Targeted vitest only (per guardrails) — full suite not run

## R1 — independent-verifier fixes (head `ab9e5c3d`)

Independent verifier ruled BLOCKED on the presentation half of the original commit (`ad235cc2`): adapter half (`armedFact`, `getModeArmed`, honesty rules, SUB-scoping) passed fully; the marker itself was dead. Four findings, all applied:

**F1 — the marker never reached the button.** The original `data-armed` sat on a `display: contents` wrapper `<span>` around `HardwareButton`, relying on `font-style` inheriting down into the `<button>`. The UA button stylesheet supplies its own `font-style: normal`, which beats an inherited value — the marker was structurally present but visually inert. Fixed by threading `armed`/`describedBy` props through `ControlButton.svelte` → `HardwareButton.svelte` so `data-armed`/`aria-describedby` render ON the actual `<button>` element. The wrapper span and its `display: contents` workaround, and the `.mode-grid > :global(button)` → `.mode-grid :global(button)` selector change, are all reverted.

**F2 — italic was unrenderable regardless.** This build's vendored Roboto Mono has no italic face, and `app.css` sets `font-synthesis: none`, so even a correctly-inherited `font-style: italic` would compute without ever rendering — pixel-identical to upright. Switched the visual channel to `opacity: 0.75` (font-independent, matches `DspSurface.svelte`'s existing opacity-as-primary-channel precedent) plus `text-decoration: underline` as a structural backstop that survives regardless of font.

**F3 — the contract overstated accessibility.** `data-*` attributes carry no AT semantics on their own. Added an `aria-describedby` → `.sr-only` announcement pair on the armed button (same pattern as `DspSurface.svelte`'s pending-toggle announcement), with a new i18n key `core.modePanel.pendingAnnouncement` in both `en-US.json` and `ru-RU.json`. The ARMED-SIGNAL CONTRACT doc block in `panel-adapters.ts` now says explicitly that a skin exposing `armed` must pair it with an AT-visible announcement, not just the bare attribute.

**F4 — test honesty: added a test that fails when the affordance goes dark.** jsdom does not apply a mounted Svelte component's runtime-injected `<style>` block under this project's vitest config (same limitation already documented in `PullToRefresh.test.ts`: "jsdom doesn't compute scoped styles"). So the new test reads `ModePanel.svelte`'s real `<style>` block off disk, unwraps `:global(...)` into plain CSS, injects it as a literal `<style>` tag, and asserts `getComputedStyle` on the armed vs. an unarmed sibling button for both `opacity` and `text-decoration`. Verified locally: temporarily changing `opacity: 0.75` to `opacity: 1` in the source makes this test fail with `expected '1' to be '0.75'` — restored afterward, confirmed green again.

**Non-blocking (comment only, not fixed):** `getModeArmed()` derives the target receiver from `runtime.state.active`, but `onModeChange` (`panel-commands.ts`) can dispatch to a different receiver during the focus-echo window (`consumePendingFocus()`) — `armed` degrades to no-feedback for that click. This is the same staleness class `currentMode`/`toModeProps` already carries (both read `state.active`). Documented at the exposure site (`panel-adapters.ts`'s `getModeArmed` doc comment) and the call site (`ModePanel.svelte`'s `armed` derivation) as a known bound, not addressed in this PR.

### R1 verification

- Targeted vitest, foreground: `mor1519-mode-armed.isolated.test.ts` (12 tests) + `ModePanel.isolated.test.ts` (17 tests, was 14 — added the F3 a11y-pairing test and the F4 opacity/underline as-rendered tests) + shared-table regression checks (`mor1441-pending-discrete.isolated.test.ts`, `mor1441-pending-frequency.isolated.test.ts`, `DspSurface.test.ts`) + `PullToRefresh.test.ts` (precedent for the jsdom-CSS finding) + `ControlButton.test.ts` + `BandSelector.isolated.test.ts` + 3 mobile-layout component tests (regression check on the shared `ControlButton`/`HardwareButton` prop changes) — **all green** (167 + 138 = 305 tests across the two runs, 0 failures).
- `npx eslint` on all 8 changed files: clean
- `npm run lint:boundaries`: clean
- `npx svelte-check`: 0 errors, 0 warnings (4548 files)
- `npm run i18n:check`: OK (new key present in both `en-US.json` and `ru-RU.json`; only pre-existing, unrelated coverage gaps reported as informational)
- Internal-identifier boundary check over the full diff: empty (no local hostnames, LAN addresses, or usernames)

Closes MOR-1519
