### PR TITLE
fix: clear waterfall history on span change (MOR-1479)

### DIFF
--- a/frontend/src/lib/renderers/__tests__/waterfall-renderer.test.ts
+++ b/frontend/src/lib/renderers/__tests__/waterfall-renderer.test.ts
@@ -134,6 +134,84 @@ describe('updateOptions', () => {
   });
 });
 
+// ── history clearing on confirmed span change (MOR-1479) ─────────────────────
+//
+// SPAN change remaps every waterfall row's pixel→frequency (pixelToFreq uses
+// options.spanHz directly), so old rows drawn under the previous span bend/
+// jump at the seam. Owner ruling: clear the backlog on SPAN change only —
+// center-frequency retunes are explicitly out of scope (separate ruling).
+
+describe('history clearing on confirmed span change', () => {
+  it('does not clear on the very first span observation (initial fill)', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ spanHz: 100_000 });
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears history when the confirmed span changes', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // establish baseline (first observation)
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ spanHz: 200_000 });
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear when the reported span is unchanged (no-op observation)', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // baseline
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ spanHz: 100_000 });
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not clear when an unrelated option changes (spanHz omitted)', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // baseline
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ refLevel: 5 });
+    r.updateOptions({ colorScheme: 'thermal' });
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears on each step of a rapid double span change', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // baseline
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ spanHz: 200_000 });
+    r.updateOptions({ spanHz: 300_000 });
+    expect(clearSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('holds/pauses without clearing: repeated same-span pushes stay quiet', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // baseline
+    const clearSpy = vi.spyOn(r, 'clear');
+    for (let i = 0; i < 5; i++) {
+      r.updateOptions({ spanHz: 100_000 });
+    }
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not clear across a disconnect/reconnect gap that returns to the same span', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // baseline
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ spanHz: 0 }); // disconnect / no-data placeholder
+    r.updateOptions({ spanHz: 100_000 }); // reconnect, same span as before
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears when the span differs from before a disconnect gap', () => {
+    const r = makeRenderer(100, 50, { spanHz: 0 });
+    r.updateOptions({ spanHz: 100_000 }); // baseline
+    const clearSpy = vi.spyOn(r, 'clear');
+    r.updateOptions({ spanHz: 0 }); // disconnect
+    r.updateOptions({ spanHz: 150_000 }); // reconnect with a different span
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 // ── resize ───────────────────────────────────────────────────────────────────
 
 describe('resize', () => {

--- a/frontend/src/lib/renderers/waterfall-renderer.ts
+++ b/frontend/src/lib/renderers/waterfall-renderer.ts
@@ -100,6 +100,13 @@ export class WaterfallRenderer {
   private rowBuf: ImageData | null = null;
   private rowData: Uint8ClampedArray | null = null;
   private destroyed = false;
+  // Last confirmed (non-zero) spanHz we've rendered rows under. Used to
+  // detect a genuine SPAN change (MOR-1479) vs. a same-value re-observation
+  // or the initial 0→real transition (first frame / reconnect), neither of
+  // which should clear the backlog. Kept separate from `options.spanHz` so
+  // a transient 0 (disconnect / not-yet-observed) doesn't get treated as a
+  // "real" span and doesn't erase the baseline used for comparison.
+  private lastConfirmedSpanHz: number | null = null;
 
   constructor(canvas: HTMLCanvasElement, options: WaterfallOptions) {
     const ctx = canvas.getContext('2d');
@@ -206,6 +213,25 @@ export class WaterfallRenderer {
       // NOTE: Existing canvas pixels retain the old color mapping. A proper fix
       // requires a ring buffer of raw amplitude rows to re-render with the new LUT.
       // For now, new rows will use the new scheme and old rows will fade out naturally.
+    }
+    // MOR-1479: SPAN change remaps every row's pixel→frequency (pixelToFreq
+    // reads options.spanHz directly), so rows drawn under the old span would
+    // bend/jump at the seam once a new span applies. Owner ruling: clear the
+    // backlog on a genuine SPAN change so every visible row shares the
+    // current mapping. `opts.spanHz` here is the CONFIRMED value the caller
+    // (SpectrumPanel) derives from the actual scope frame's startFreq/
+    // endFreq — the same value pixelToFreq uses — not a pending/optimistic
+    // one, so this can't double-clear on armed-then-confirmed span changes.
+    //
+    // A momentary 0 (no data yet / disconnected) is not a "real" span and is
+    // ignored on both sides of the comparison: it neither triggers a clear
+    // nor overwrites the last confirmed span, so the first real observation
+    // and a reconnect-to-the-same-span both stay quiet.
+    if (opts.spanHz !== undefined && opts.spanHz > 0) {
+      if (this.lastConfirmedSpanHz !== null && this.lastConfirmedSpanHz !== opts.spanHz) {
+        this.clear();
+      }
+      this.lastConfirmedSpanHz = opts.spanHz;
     }
   }
 


### PR DESCRIPTION
## Summary

- SPAN changes remap pixel->frequency for every visible waterfall row (`WaterfallRenderer.pixelToFreq` reads `options.spanHz` directly). Rows drawn under the old span kept scrolling at the OLD mapping, so signals bent/jumped at the seam once a new span took effect.
- Owner ruling: on SPAN change, clear the waterfall backlog (blank the history) so every visible row shares the current mapping.
- `WaterfallRenderer.updateOptions` now tracks the last confirmed (non-zero) `spanHz` and calls `clear()` only when a new non-zero `spanHz` differs from it.

## Which value it watches, and why

The renderer clears on the exact value it already uses for `pixelToFreq`: `options.spanHz`, which `SpectrumPanel.svelte` derives from the live scope frame's `startFreq`/`endFreq` (`spanHz = endFreq - startFreq`), i.e. the **confirmed** span reported by actual hardware scope frames — not a pending/optimistic UI value (there is no separate optimistic span state in this codebase; the toolbar's SPAN control only dispatches a command, it doesn't locally preview a span). Watching the confirmed value means an armed-then-confirmed span change cannot double-clear, and the display remaps exactly when the confirmed data changes, not before.

## Edge cases covered (see tests)

- **Initial fill / first observation**: momentary `spanHz === 0` (no data yet) is ignored on both sides of the comparison, so the first real span observed after mount does not clear.
- **Same-value re-observation**: repeated `updateOptions` calls with an unchanged span (including while paused/held, since paused frames simply stop arriving and the span value doesn't change) never clear.
- **Rapid double span change**: each genuine change clears exactly once, in order.
- **Disconnect/reconnect**: a transient `0` (disconnect / not-yet-observed) doesn't get treated as a "real" span and doesn't overwrite the baseline, so reconnecting to the *same* span stays quiet, while reconnecting to a *different* span still clears.
- Unrelated option changes (`refLevel`, `colorScheme`) never trigger a clear.

## Scope (explicitly out of scope per the ruling)

- **Center-frequency retunes are NOT covered here.** They don't change the frontend's `spanHz`, so no clear is triggered by a retune with this change. Whether center retunes should also clear (or partially shift) the waterfall needs a **separate ruling** — not addressed in this PR.
- **Spectrum line display is untouched** — it has no history/backlog to clear (single-frame line renderer, no scrolling buffer).
- Frontend rendering only; no protocol/backend change.

## Files changed

- `frontend/src/lib/renderers/waterfall-renderer.ts` — clear-on-span-change logic in `updateOptions`.
- `frontend/src/lib/renderers/__tests__/waterfall-renderer.test.ts` — new `describe('history clearing on confirmed span change')` block (7 cases), TDD red-first against the unmodified renderer.

## Test plan

- [x] New tests confirmed **red** on main (`clears history when the confirmed span changes`, `clears on each step of a rapid double span change`, `clears when the span differs from before a disconnect gap` all failed — 0 calls to `clear()` — before the fix).
- [x] All 7 new tests + existing 23 in the file pass after the fix (`npx vitest run src/lib/renderers/__tests__/waterfall-renderer.test.ts` — 30/30 passed).
- [x] Full `src/components/spectrum` + `src/lib/renderers` suite green (419/419 passed) — no regressions in SpectrumPanel/WaterfallCanvas consumers.
- [x] `npx eslint` on changed files — clean.
- [x] `npm run lint:boundaries` — clean (unaffected paths).
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings.

Closes MOR-1479