### PR TITLE
fix: require cmd29 route for tone and filter_width receiver targeting (MOR-1528)

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2201,7 +2201,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         Hz is translated to a profile-defined index and wrapped via cmd29 only
         when the profile lists ``[0x1A, 0x03]`` in its cmd29 routes
         (IC-7610). The profile must declare a ``set_filter_width`` command
-        before the runtime sends a write.
+        before the runtime sends a write. On dual-RX profiles that do not
+        list the cmd29 route (IC-9700), ``receiver=1`` (SUB) raises
+        ``CommandError`` instead of silently writing MAIN.
 
         Args:
             width_hz: Filter width in Hz. Bounds and step depend on the
@@ -2214,6 +2216,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             raise CommandError(
                 f"set_filter_width is unsupported by profile {self._profile.model}"
             )
+        self._require_cmd29_route(
+            0x1A,
+            0x03,
+            receiver=receiver,
+            operation="set_filter_width",
+        )
 
         target = self._radio_state.receiver("SUB" if receiver else "MAIN")
         mode_name = getattr(target, "mode", None)
@@ -2249,7 +2257,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         bcd_index_byte = bcd_encode_value(payload_value, byte_count=1)
         # CI-V 1A 03: 1-byte BCD index (wfview-confirmed). cmd29-wrapped
         # for receiver routing on dual-RX rigs (IC-7610), direct on single-RX
-        # (IC-705) and on dual-RX rigs without cmd29 support (IC-9700).
+        # (IC-705) and on MAIN for dual-RX rigs without cmd29 support
+        # (IC-9700). SUB on a dual-RX rig without cmd29 support is rejected
+        # above by ``_require_cmd29_route`` rather than sent to MAIN.
         if self._profile.supports_cmd29(0x1A, 0x03):
             await self.send_civ(
                 0x29,
@@ -2267,7 +2277,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         The response encoding is profile-driven. Icom profiles use a 1-byte
         BCD segmented index; Xiegu X6200 uses a single raw byte index. The
         request is cmd29-wrapped only when the profile lists ``[0x1A, 0x03]``
-        in its cmd29 routes.
+        in its cmd29 routes. On dual-RX profiles that do not list the
+        route (IC-9700), ``receiver=1`` (SUB) raises ``CommandError``
+        instead of silently reading MAIN.
 
         Args:
             receiver: 0=MAIN, 1=SUB.
@@ -2277,10 +2289,17 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         self._require_receiver(receiver, operation="get_filter_width")
+        self._require_cmd29_route(
+            0x1A,
+            0x03,
+            receiver=receiver,
+            operation="get_filter_width",
+        )
 
         # CI-V 1A 03: 1-byte BCD index for every Icom rig (wfview-confirmed).
         # cmd29-wrapped only for receiver routing on dual-RX rigs that list
-        # the route (IC-7610). IC-705/IC-9700 send the request directly.
+        # the route (IC-7610). IC-705/IC-9700 send the request directly on
+        # MAIN; SUB without a cmd29 route is rejected above.
         if self._profile.supports_cmd29(0x1A, 0x03):
             civ = get_filter_width(to_addr=self._radio_addr, receiver=receiver)
         else:
@@ -4133,6 +4152,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def get_repeater_tone(self, receiver: int = 0) -> bool:
         """Read repeater tone status (0x16 0x42)."""
+        self._require_cmd29_route(
+            0x16, _SUB_REPEATER_TONE, receiver=receiver, operation="get_repeater_tone"
+        )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TONE)
         civ = _get_repeater_tone_cmd(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
@@ -4143,6 +4165,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_repeater_tone(self, on: bool, receiver: int = 0) -> None:
         """Set repeater tone on/off (0x16 0x42)."""
+        self._require_cmd29_route(
+            0x16, _SUB_REPEATER_TONE, receiver=receiver, operation="set_repeater_tone"
+        )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TONE)
         await self._send_fire_and_forget(
             _set_repeater_tone_cmd(
@@ -4152,6 +4177,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def get_repeater_tsql(self, receiver: int = 0) -> bool:
         """Read repeater TSQL status (0x16 0x43)."""
+        self._require_cmd29_route(
+            0x16, _SUB_REPEATER_TSQL, receiver=receiver, operation="get_repeater_tsql"
+        )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TSQL)
         civ = _get_repeater_tsql_cmd(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
@@ -4162,6 +4190,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_repeater_tsql(self, on: bool, receiver: int = 0) -> None:
         """Set repeater TSQL on/off (0x16 0x43)."""
+        self._require_cmd29_route(
+            0x16, _SUB_REPEATER_TSQL, receiver=receiver, operation="set_repeater_tsql"
+        )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TSQL)
         await self._send_fire_and_forget(
             _set_repeater_tsql_cmd(
@@ -4172,6 +4203,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_tone_freq(self, receiver: int = 0) -> float:
         """Read CTCSS tone frequency in Hz (0x1B 0x00)."""
         self._check_connected()
+        self._require_cmd29_route(
+            0x1B, 0x00, receiver=receiver, operation="get_tone_freq"
+        )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         civ = _get_tone_freq_cmd(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
@@ -4182,6 +4216,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_tone_freq(self, freq_hz: float, receiver: int = 0) -> None:
         """Set CTCSS tone frequency in Hz (0x1B 0x00)."""
+        self._require_cmd29_route(
+            0x1B, 0x00, receiver=receiver, operation="set_tone_freq"
+        )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         await self._send_fire_and_forget(
             _set_tone_freq_cmd(
@@ -4192,6 +4229,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_tsql_freq(self, receiver: int = 0) -> float:
         """Read TSQL frequency in Hz (0x1B 0x01)."""
         self._check_connected()
+        self._require_cmd29_route(
+            0x1B, 0x01, receiver=receiver, operation="get_tsql_freq"
+        )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         civ = _get_tsql_freq_cmd(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
@@ -4202,6 +4242,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_tsql_freq(self, freq_hz: float, receiver: int = 0) -> None:
         """Set TSQL frequency in Hz (0x1B 0x01)."""
+        self._require_cmd29_route(
+            0x1B, 0x01, receiver=receiver, operation="set_tsql_freq"
+        )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         await self._send_fire_and_forget(
             _set_tsql_freq_cmd(

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -340,6 +340,46 @@ class TestIcomGetFilterWidthRouting:
         hz = await radio.get_filter_width(receiver=0)
         assert hz == 6000
 
+    @pytest.mark.asyncio
+    async def test_ic9700_sub_receiver_raises_without_cmd29_route(self) -> None:
+        """MOR-1528: IC-9700 SUB (receiver=1) must not silently read MAIN.
+
+        IC-9700 is dual-RX (receiver_count=2) but declares no cmd29 routes.
+        Before this fix, ``get_filter_width(receiver=1)`` built the same
+        direct (receiver-unaware) frame as ``receiver=0`` and returned
+        whatever the radio happened to report for its currently-addressed
+        receiver — attributed to SUB. This must now raise instead.
+        """
+        from rigplane.exceptions import CommandError
+
+        radio = _connected_icom(model="IC-9700")
+        radio._send_civ_expect = AsyncMock()  # type: ignore[method-assign]
+        radio._radio_state.sub.mode = "USB"
+
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await radio.get_filter_width(receiver=1)
+
+        radio._send_civ_expect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ic7610_sub_receiver_still_cmd29_wrapped(self) -> None:
+        """IC-7610 declares the cmd29 route: SUB stays wrapped, unaffected."""
+        radio = _connected_icom(model="IC-7610")
+        captured: dict[str, bytes] = {}
+
+        async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+            captured["civ"] = civ
+            return CivFrame(
+                to_addr=0xE0, from_addr=0x98, command=0x1A, sub=0x03, data=b"\x20"
+            )
+
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+        radio._radio_state.sub.mode = "USB"
+
+        hz = await radio.get_filter_width(receiver=1)
+        assert captured["civ"].hex() == "fefe98e029011a03fd"
+        assert hz == 1600
+
 
 class TestIcomSetFilterWidthRouting:
     """set_filter_width: unified 1-byte BCD segmented index for all Icom rigs.
@@ -388,6 +428,39 @@ class TestIcomSetFilterWidthRouting:
 
         radio.send_civ.assert_awaited_once_with(
             0x1A, sub=0x03, data=b"\x29", wait_response=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_ic9700_sub_receiver_raises_without_cmd29_route(self) -> None:
+        """MOR-1528: IC-9700 SUB (receiver=1) must not silently write MAIN.
+
+        IC-9700 is dual-RX (receiver_count=2) but declares no cmd29 routes.
+        Before this fix, ``set_filter_width(receiver=1)`` sent the same
+        direct (receiver-unaware) frame as ``receiver=0``, writing MAIN's
+        filter width while the caller believed SUB was targeted.
+        """
+        from rigplane.exceptions import CommandError
+
+        radio = _connected_icom(model="IC-9700")
+        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+        radio._radio_state.sub.mode = "USB"
+
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await radio.set_filter_width(2400, receiver=1)
+
+        radio.send_civ.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ic7610_sub_receiver_still_cmd29_wrapped(self) -> None:
+        """IC-7610 declares the cmd29 route: SUB stays wrapped, unaffected."""
+        radio = _connected_icom(model="IC-7610")
+        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+        radio._radio_state.sub.mode = "USB"
+
+        await radio.set_filter_width(1500, receiver=1)
+
+        radio.send_civ.assert_awaited_once_with(
+            0x29, data=b"\x01\x1a\x03\x19", wait_response=False
         )
 
 

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2916,6 +2916,89 @@ class TestToneTsqlParity:
         )
 
 
+class TestToneTsqlDualRxCmd29Guard:
+    """MOR-1528: tone/TSQL methods must reject SUB routing without cmd29.
+
+    IC-9700 is dual-RX (``receiver_count=2``) but declares no cmd29 routes
+    (``[cmd29] routes = []``). Before this fix, ``receiver=1`` calls on the
+    four tone/TSQL method pairs built a direct, receiver-unaware CI-V frame
+    instead of raising — silently writing/reading MAIN while the caller
+    believed it was targeting SUB. Sibling guarded commands (e.g.
+    ``set_rf_gain``) already raise via ``_require_cmd29_route``; these
+    methods now match that contract. ``receiver=0`` (MAIN) and IC-7610 (has
+    cmd29 routes) behavior must stay byte-identical — see
+    ``TestToneTsqlParity`` above, which exercises the IC-7610 fixture on
+    both receivers and stays green.
+    """
+
+    @pytest.fixture
+    def ic9700_radio(self, mock_transport: MockTransport):
+        r = IcomRadio("192.168.1.102", timeout=0.05, model="IC-9700")
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        yield r
+        r._connected = False  # reset _conn_state so __del__ stays quiet
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("get_repeater_tone", ()),
+            ("set_repeater_tone", (True,)),
+            ("get_repeater_tsql", ()),
+            ("set_repeater_tsql", (True,)),
+            ("get_tone_freq", ()),
+            ("set_tone_freq", (88.5,)),
+            ("get_tsql_freq", ()),
+            ("set_tsql_freq", (110.9,)),
+        ],
+    )
+    async def test_sub_receiver_raises_without_cmd29_route(
+        self,
+        ic9700_radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        args: tuple,
+    ) -> None:
+        method = getattr(ic9700_radio, method_name)
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await method(*args, receiver=1)
+        # No wire write occurred — the guard must fire before any send.
+        assert mock_transport.sent_packets == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args", "expected_tail"),
+        [
+            ("set_repeater_tone", (True,), b"\x16\x42\x01\xfd"),
+            ("set_repeater_tsql", (True,), b"\x16\x43\x01\xfd"),
+            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x88\x05\xfd"),
+            ("set_tsql_freq", (110.9,), b"\x1b\x01\x01\x10\x09\xfd"),
+        ],
+    )
+    async def test_main_receiver_still_sends_direct_frame(
+        self,
+        ic9700_radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        args: tuple,
+        expected_tail: bytes,
+    ) -> None:
+        method = getattr(ic9700_radio, method_name)
+        await method(*args, receiver=0)
+        assert mock_transport.sent_packets[-1].endswith(expected_tail)
+
+    @pytest.mark.asyncio
+    async def test_main_receiver_get_repeater_tone_still_works(
+        self, ic9700_radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        civ = build_civ_frame(CONTROLLER_ADDR, 0xA2, 0x16, sub=0x42, data=b"\x01")
+        mock_transport.queue_response(_wrap_civ_in_udp(civ))
+        assert await ic9700_radio.get_repeater_tone(receiver=0) is True
+        assert mock_transport.sent_packets[-1].endswith(b"\x16\x42\xfd")
+
+
 class TestCodecProfileOverride:
     """Per-profile codec_preference overrides the global default (#797)."""
 


### PR DESCRIPTION
## Summary

Closes MOR-1528

On dual-RX profiles without cmd29 routes (IC-9700: `receiver_count=2`, `[cmd29] routes = []`), 15 guarded commands correctly raise via `_require_cmd29_route` for `receiver=1`, but 10 methods lacked the guard and silently mistargeted MAIN instead of raising:

- `get_repeater_tone` / `set_repeater_tone`
- `get_repeater_tsql` / `set_repeater_tsql`
- `get_tone_freq` / `set_tone_freq`
- `get_tsql_freq` / `set_tsql_freq`
- `get_filter_width` / `set_filter_width`

These 10 methods now call `_require_cmd29_route` before building/sending any CI-V frame, matching the pattern already used by sibling guarded commands (e.g. `set_rf_gain`, `set_af_mute`). `receiver=1` on a cmd29-less dual-RX profile now raises `CommandError` with no wire write, instead of silently writing/reading MAIN while the caller believes SUB is targeted.

Also updated the `set_filter_width`/`get_filter_width` doc comments, which previously documented the silent direct-send-on-cmd29-less-dual-RX behavior as intended.

`receiver=0` (MAIN) and IC-7610 (which declares the cmd29 routes) behavior are byte-identical — unchanged for both receivers.

## Test plan

TDD red-first: reverted the source change and confirmed all 10 new "IC-9700 receiver=1 raises" tests failed (some via `TimeoutError` from an actual attempted wire write, one via a type error reaching deep into response parsing — all confirming the guard was previously absent). Reapplied the fix and reran green.

- [x] `uv run pytest tests/test_radio.py tests/test_dsp_filter_family.py -q --tb=short` — 298 passed
- [x] `uv run ruff check src/rigplane/runtime/radio.py tests/test_radio.py tests/test_dsp_filter_family.py` — clean
- [x] `uv run ruff format --check` on the same files — already formatted
- [x] `uv run lint-imports` — 5 kept, 0 broken
- [x] `uv run mypy src/rigplane/runtime/radio.py` — no issues
- [x] `uv run mypy src/` — 13 pre-existing errors in 4 unrelated files (baseline, not touched by this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)