### PR TITLE
fix: s-meter raw honesty + gauge truncation guard + fixture sync (MOR-1535)

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -5,7 +5,7 @@
     prefersReducedMotion,
     onReducedMotionChange,
   } from '$lib/utils/smoothing.svelte';
-  import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor } from './bar-gauge-utils';
+  import { DEFAULT_ZONES, valueToSegments, getSegmentZone, dimColor, valueFontSize } from './bar-gauge-utils';
   import type { Zone } from './bar-gauge-utils';
   import { updatePeakHold, peakHoldDisplay, PEAK_DECAY_MS, type PeakHoldState } from '../panels/meter-utils';
 
@@ -42,7 +42,10 @@
   const TRACK_H     = $derived(compact ? 10 : 14);
   const TOTAL_HEIGHT = $derived(compact ? 22 : 30);
   const LABEL_FS    = $derived(compact ? 7  : 8);
-  const VALUE_FS    = $derived(compact ? 9  : 11);
+  // MOR-1535: steps down from the base size when `displayValue` is too long
+  // to fit the fixed value column at that size (e.g. "158 raw") — SVG text
+  // clips silently on overflow rather than wrapping or ellipsizing.
+  const VALUE_FS    = $derived(valueFontSize(displayValue, compact ? 9 : 11));
   const TEXT_Y      = $derived(TRACK_Y + TRACK_H / 2);
 
   // ── Smoother ────────────────────────────────────────────────────────────────

--- a/frontend/src/components-v2/meters/__tests__/BarGauge.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/BarGauge.test.ts
@@ -4,6 +4,7 @@ import {
   valueToSegments,
   getSegmentZone,
   dimColor,
+  valueFontSize,
 } from '../bar-gauge-utils';
 import type { Zone } from '../bar-gauge-utils';
 
@@ -178,5 +179,42 @@ describe('DEFAULT_ZONES', () => {
 
   it('last zone ends at 1.0', () => {
     expect(DEFAULT_ZONES[DEFAULT_ZONES.length - 1].end).toBe(1.0);
+  });
+});
+
+// ── valueFontSize (MOR-1535) ─────────────────────────────────────────────────
+//
+// `displayValue` renders as SVG text at x=260 in a 0-300 viewBox (a fixed
+// ~40px column) — SVG text clips silently rather than wrapping or
+// ellipsizing when it overflows. At the non-compact VALUE_FS=11 the budget
+// is ~6 characters; MOR-1527's own "NNN raw" honesty tag is 7 characters
+// and would clip on MeterPanel.svelte, BarGauge's sole non-compact consumer
+// (dead code per MOR-1535's audit, but not deleted here — no hollowing
+// without an owner call).
+
+describe('valueFontSize', () => {
+  it('keeps the base font size for text within the ~6-char budget', () => {
+    expect(valueFontSize('35W', 11)).toBe(11);
+    expect(valueFontSize('S9+40', 11)).toBe(11);
+  });
+
+  it('steps the font size down below the base for text past the budget', () => {
+    const fs = valueFontSize('158 raw', 11);
+    expect(fs).toBeLessThan(11);
+  });
+
+  it('never steps size up past the base font size', () => {
+    expect(valueFontSize('1', 11)).toBeLessThanOrEqual(11);
+  });
+
+  it('never steps down below a legible floor even for very long text', () => {
+    const fs = valueFontSize('a very long display value indeed', 11);
+    expect(fs).toBeGreaterThanOrEqual(6);
+  });
+
+  it('compact base (9) also steps down once text exceeds its own budget', () => {
+    const base = valueFontSize('35W', 9);
+    const stepped = valueFontSize('a much longer value', 9);
+    expect(stepped).toBeLessThan(base);
   });
 });

--- a/frontend/src/components-v2/meters/bar-gauge-utils.ts
+++ b/frontend/src/components-v2/meters/bar-gauge-utils.ts
@@ -46,6 +46,35 @@ export function getSegmentZone(
  * @param hex    - Source color, e.g. '#14A665'
  * @param blend  - Fraction of source color to keep (default 0.12)
  */
+/** Width of the `displayValue` SVG-text column, in the 0-300 viewBox
+ *  (VALUE_X=260 in `BarGauge.svelte`, budget runs to the viewBox edge). */
+const VALUE_COLUMN_WIDTH = 40;
+
+/** Approximate glyph width of the Roboto Mono value text, as a fraction of
+ *  its font-size — used only to size the step-down guard below, not for
+ *  pixel-perfect layout. */
+const CHAR_WIDTH_EM = 0.6;
+
+/** Smallest step-down font size before text stops being legible. */
+const MIN_VALUE_FONT_SIZE = 6;
+
+/**
+ * Font size for `BarGauge`'s `displayValue` text, stepped down from
+ * `baseFontSize` when the string is too long to fit the fixed ~40px value
+ * column at that size (MOR-1535). SVG text neither wraps nor ellipsizes on
+ * overflow — it clips silently — so a value like MOR-1527's raw-tagged
+ * fallback ("158 raw", 7 chars) would otherwise lose characters at the
+ * non-compact VALUE_FS=11 (~6-char budget). Short strings (the common
+ * case: "35W", "S9+40") are unaffected — this only ever shrinks text that
+ * would have clipped, never grows it past `baseFontSize`.
+ */
+export function valueFontSize(displayValue: string, baseFontSize: number): number {
+  const chars = displayValue.length;
+  if (chars === 0) return baseFontSize;
+  const fitted = VALUE_COLUMN_WIDTH / (chars * CHAR_WIDTH_EM);
+  return Math.max(MIN_VALUE_FONT_SIZE, Math.min(baseFontSize, fitted));
+}
+
 export function dimColor(hex: string, blend = 0.12): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
@@ -447,6 +448,53 @@ describe('TX meters — IC-7300 profile anchors (MOR-1527)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cal-fixture sync guard (MOR-1535) — `IC7300_TX_METER_CALS.power` above
+// mirrors only 4 of `rigs/ic7300.toml`'s 13 real `[[meters.power.calibration]]`
+// knots (raw 0/143/213/255), with nothing previously catching that mirror
+// drifting from the TOML if a future profile edit changes one of those 4
+// anchors. This reads the real TOML directly rather than inventing a new
+// generated-fixture pipeline — a minimal inline parser for the tables'
+// uniform `raw = N` / `actual = N` / `label = "..."` knot format.
+// ---------------------------------------------------------------------------
+
+interface TomlCalKnot {
+  raw: number;
+  actual: number;
+  label: string;
+}
+
+function parseTomlCalibrationTable(tomlSource: string, meterKey: string): TomlCalKnot[] {
+  const header = `[[meters.${meterKey}.calibration]]`;
+  return tomlSource
+    .split(header)
+    .slice(1)
+    .map((block) => {
+      const body = block.split(/\n\[/)[0];
+      const raw = body.match(/raw\s*=\s*(-?\d+)/)?.[1];
+      const actual = body.match(/actual\s*=\s*(-?[\d.]+)/)?.[1];
+      const label = body.match(/label\s*=\s*"([^"]*)"/)?.[1];
+      if (raw === undefined || actual === undefined || label === undefined) {
+        throw new Error(`Unparseable [[meters.${meterKey}.calibration]] knot while reading rigs/ic7300.toml`);
+      }
+      return { raw: Number(raw), actual: Number(actual), label };
+    });
+}
+
+describe('IC7300_TX_METER_CALS.power sync guard (MOR-1535)', () => {
+  it('every mirrored power knot matches its real rigs/ic7300.toml anchor exactly', () => {
+    const tomlSource = readFileSync('../rigs/ic7300.toml', 'utf8');
+    const realKnots = parseTomlCalibrationTable(tomlSource, 'power');
+    expect(realKnots.length).toBeGreaterThanOrEqual(IC7300_TX_METER_CALS.power.length);
+
+    for (const mirrored of IC7300_TX_METER_CALS.power) {
+      const real = realKnots.find((k) => k.raw === mirrored.raw);
+      expect(real, `no real anchor at raw=${mirrored.raw} in rigs/ic7300.toml`).toBeDefined();
+      expect(mirrored).toEqual(real);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // S-meter (unchanged by MOR-1470 — pinned here against regressions)
 // ---------------------------------------------------------------------------
 
@@ -473,8 +521,8 @@ describe('formatSMeter / sLevel — uncalibrated fallback (MOR-1451)', () => {
     setCapabilities(makeCaps({ model: 'X6200' }));
   });
 
-  it('formatSMeter renders the plain raw number, not a fabricated S-unit', () => {
-    expect(formatSMeter(53)).toBe('53');
+  it('formatSMeter renders the raw-tagged number, not a fabricated S-unit and not a naked number (MOR-1535: the same honesty gap MOR-1527 fixed for the other six formatters)', () => {
+    expect(formatSMeter(53)).toBe('53 raw');
   });
 
   it('sLevel degrades to a neutral raw-proportional bar position', () => {

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -240,13 +240,16 @@ function calibratedSmeterToRaw(actual: number): number {
 
 /**
  * Formats calibrated S-meter value (dB relative to S9) as an S-unit string.
- * Falls back to the plain raw-scale number (no "S" claim) when the radio
- * has no s_meter calibration table — never a reading borrowed from a
- * different radio's curve (MOR-1451).
+ * Falls back to the honest raw-tagged reading (`formatRaw`, e.g. "53 raw";
+ * MOR-1527) when the radio has no s_meter calibration table — never a
+ * reading borrowed from a different radio's curve (MOR-1451), and never a
+ * naked number indistinguishable from a real S-unit claim (MOR-1535: this
+ * was the last of the seven meter formatters still returning the naked
+ * pre-MOR-1527 fallback).
  */
 export function formatSMeter(actual: number): string {
   if (!isSmeterCalibrated()) {
-    return String(Math.round(Math.max(0, Math.min(RAW_SCALE_MAX, actual))));
+    return formatRaw(actual);
   }
   const knots = getSmeterKnots();
   const minActual = knots[0][1];

--- a/frontend/src/lib/runtime/adapters/capabilities-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/capabilities-adapter.ts
@@ -33,8 +33,9 @@ export interface MeterCalPoint {
 /**
  * Calibration knot points for a meter (e.g. `'s_meter'`, `'power'`,
  * `'swr'`). Returns `null` when capabilities haven't loaded or when the
- * radio doesn't expose calibration for this meter — callers should fall
- * back to hardcoded IC-7610 defaults in that case.
+ * radio doesn't expose calibration for this meter — callers degrade to an
+ * honest raw-scale reading (`meter-utils.ts`'s `formatRaw`), never a
+ * hardcoded fallback curve borrowed from another radio (MOR-1291/MOR-1451).
  */
 export function getMeterCalibration(meterType: string): MeterCalPoint[] | null {
   return _getMeterCalibration(meterType);
@@ -42,7 +43,8 @@ export function getMeterCalibration(meterType: string): MeterCalPoint[] | null {
 
 /**
  * Redline raw value for a meter (e.g. `'alc'`). Returns `null` when no
- * capability data is available — callers fall back to hardcoded defaults.
+ * capability data is available — callers degrade to an honest raw-scale
+ * reading, never a hardcoded fallback (MOR-1291).
  */
 export function getMeterRedline(meterType: string): number | null {
   return _getMeterRedline(meterType);

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -449,8 +449,12 @@ class TestPaMeterCalibration:
     @pytest.mark.parametrize("meter_key,raw,expected_actual", _PA_METER_ANCHORS)
     def test_anchor_round_trip(self, rig, meter_key, raw, expected_actual):
         """Interpolating at a documented hamlib anchor returns that
-        anchor's engineering value — table-driven directly against
-        ``rig.meter_calibrations``, not a hand-copied expectation."""
+        anchor's engineering value. ``_PA_METER_ANCHORS`` hand-transcribes
+        each anchor from ``rigs/ic7300.toml`` (by design, as a regression
+        pin -- not read dynamically from the TOML), but the interpolation
+        itself runs through the real ``rig.meter_calibrations`` parsed from
+        that same file, so a profile edit that drifts from these literals
+        is what this parametrization catches."""
         actual, calibrated = interpolate_meter(raw, rig.meter_calibrations, meter_key)
         assert calibrated is True
         assert actual == pytest.approx(expected_actual)


### PR DESCRIPTION
## Summary

Verifier follow-ups flagged on PR #2443 (MOR-1527), addressed here:

1. **formatSMeter naked-raw honesty gap** (`meter-utils.ts:247`) — the uncalibrated fallback returned a naked number (e.g. `"53"`), the exact bug #2443 fixed for the other six meter formatters. Now routes through the same `formatRaw` tag (`"53 raw"`). The calibrated path is byte-identical (untouched).

   **Which radios can actually hit this fallback:** checked every shipped profile's `[meters.s_meter]` table. `ic7300.toml`, `ic7610.toml`, `ftx1.toml`, and `tx500.toml` all declare a calibration table. `x6200.toml`, `ic705.toml`, and `ic9700.toml` declare **no** `[meters.s_meter]` calibration table at all — so this fallback is live-reachable today on those three, and X6200 is one of the two live bench radios. `x6100.toml` also has none (doc/hamlib-only profile, no live hardware per current bench state).

2. **BarGauge truncation guard** — `displayValue` renders as SVG text at x=260 in a 0-300 viewBox (~40px column, ~6-char budget at the non-compact `VALUE_FS=11`); SVG text clips silently on overflow rather than wrapping/ellipsizing, and `"NNN raw"` (7 chars) would clip. Added `valueFontSize()` to `bar-gauge-utils.ts` — a minimal step-down guard that only ever shrinks text that would have overflowed the column, never grows it past the base size. Wired into `BarGauge.svelte`'s `VALUE_FS`.

   **`MeterPanel.svelte`** is BarGauge's only non-compact consumer, and appears to be dead code — it isn't imported anywhere outside its own file and its own tests (the live mobile dock uses `DockMeterPanel.svelte`, a different component). Per the open-core no-hollowing-out policy this needs an owner call, not a unilateral delete, so it's left in place; the guard is applied to `BarGauge` itself instead, which protects any future non-compact consumer too.

3. **Cal-fixture sync guard** — `IC7300_TX_METER_CALS.power` in `meter-utils.test.ts` mirrors 4 of `rigs/ic7300.toml`'s 13 real `[[meters.power.calibration]]` knots with nothing catching drift. Added a lightweight guard that reads the real TOML directly (a small inline regex parser for the tables' uniform `raw = N` / `actual = N` / `label = "..."` format — no generated-fixture pipeline invented) and asserts each mirrored knot still matches its real anchor exactly.

4. **Stale comment** (`capabilities-adapter.ts:37`, and the matching one on `getMeterRedline` two lines below) — corrected "callers should fall back to hardcoded IC-7610 defaults" to describe what MOR-1291 actually left in place: callers degrade to an honest raw reading, never a hardcoded curve.

5. **Docstring nit** (`tests/test_rig_ic7300.py`, `test_anchor_round_trip`) — reworded away from "not a hand-copied expectation" (it is, by design — `_PA_METER_ANCHORS` hand-transcribes the TOML anchors as a regression pin) to describe accurately what the test actually catches.

## Red-first evidence

- `formatSMeter` test (`meter-utils.test.ts`): before the fix, `expect(formatSMeter(53)).toBe('53 raw')` failed with `expected '53' to be '53 raw'`.
- `valueFontSize` tests (`BarGauge.test.ts`, 5 new cases): before the fix, all 5 failed with `TypeError: valueFontSize is not a function` (function didn't exist).
- Cal-fixture sync guard: passes as written (it's a regression guard against future drift, not a currently-failing bug — the mirrored subset is in sync today).
- `tests/test_rig_ic7300.py::TestPaMeterCalibration::test_anchor_round_trip` (101 tests in the file): all green after the docstring reword (behavior-neutral change).

All 5 new/changed assertions pass after the fix; full targeted run: `npx vitest run` across `meter-utils.test.ts`, `BarGauge.test.ts` + its 3 sibling BarGauge test files, `MeterPanel`/`MetersDockPanel`, and `src/semantic` — 42 files, 1414 tests, all green. `uv run pytest tests/test_rig_ic7300.py -q` — 101 passed. `npm run lint`, `npm run lint:boundaries`, `npm run check` (svelte-check + tsc) all clean. `uv run ruff check tests/test_rig_ic7300.py` clean.

## Baseline impact

**Correction (verifier-caught, see review thread):** an earlier version of this note incorrectly assumed the fixture harness renders s_meter uncalibrated, the way #2443's fixtures once did. That's stale — MOR-1451 already fixed it: `frontend/fixtures/catalog.ts:247-265` hand-declares a real `S_METER_CAL` table (`baseCaps()`'s `meterCalibrations: { s_meter: S_METER_CAL }`, spread into every caps variant), and `frontend/fixtures/main.ts:90` applies it via a real `setCapabilities()` call into the actual `$lib/stores/capabilities.svelte` singleton — not the stubbed `runtime.caps` seam. So every baseline scene's S-meter already renders through the **calibrated** S-unit path, which item 1 does not touch (the calibrated branch of `formatSMeter` is byte-identical before/after this PR — only the uncalibrated fallback changed).

Item 2 (`valueFontSize`) is also a no-op for every baseline scene: `BarGauge`'s only non-compact consumer is `MeterPanel.svelte`, which is dead code and is not rendered by any fixture (confirmed: no fixture file references `MeterPanel`). Every `BarGauge` instance the fixtures actually render goes through `compact` mode, where typical display strings ("35W", "1.2", etc.) never cross the step-down threshold.

**Expected result: the visual gate stays GREEN, zero baseline re-pins needed.** If it comes back red, that is not expected churn from this diff — it's an anomaly and should be investigated (not re-pinned) before merge.

## Test plan

- [x] `npx vitest run` targeted meter/gauge/adapter test files — 1414 passed
- [x] `uv run pytest tests/test_rig_ic7300.py -q --tb=short` — 101 passed
- [x] `npm run lint`, `npm run lint:boundaries`, `npm run check` — clean
- [x] `uv run ruff check tests/test_rig_ic7300.py` — clean
- [x] Boundary grep (`192\.168|\bmoroz\b|\bmini\b|preview-mor`) over the diff — empty
- [ ] CI (not watched per instructions)
- [ ] Visual baseline gate — expected GREEN with zero re-pins (see Baseline impact above); a red result is an anomaly to investigate, not a re-pin trigger

## Follow-ups (non-blocking, from independent verifier review)

- The cal-fixture sync guard (item 3) covers `power` only. `alc`/`comp`/`vd`/`id` in `IC7300_TX_METER_CALS` are equally hand-mirrored from `rigs/ic7300.toml` and are in sync today, but have no guard — extending the same check to loop over all five meter keys is a ~3-line change if wanted.
- `parseTomlCalibrationTable` (added for item 3) is not comment-anchored: a commented-out `[[meters.power.calibration]]` knot in the TOML would still be picked up by the regex. Not a real risk today (no commented-out knots exist in `rigs/ic7300.toml`), but worth knowing if the TOML ever grows one.
- `MeterPanel.svelte`'s deletion (flagged as dead code in item 2's writeup) still needs an explicit owner call per the no-hollowing-out policy — this PR guards it rather than removing it.

Closes MOR-1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)
