### PR TITLE
fix: rigctld tx_active source + scheduler credit-path split (MOR-1532, MOR-1533)

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -537,13 +537,15 @@ class AcquisitionScheduler:
         self._external_cat_paused = False
         self._external_cat_owner: str | None = None
         self._external_cat_reason = ""
-        # MOR-1531: last ``tx_active`` observed by ``due_requests`` (the
-        # poller's cadence-drain call). ``pending_requests`` reads this same
-        # cached value to gate RECONCILIATION-priority requests for
-        # ``tx_only``-policy fields -- see that method's docstring. Defaults
-        # to True (no gating) so a scheduler whose caller never calls
-        # ``due_requests`` at all (e.g. rigctld's own drain loop, MOR-1531)
-        # keeps its pre-existing, unfiltered reconciliation behavior.
+        # MOR-1531: last ``tx_active`` observed by ``due_requests`` (the web
+        # poller's cadence-drain call) or ``note_tx_active`` (rigctld's own
+        # drain, MOR-1532). ``dispatchable_requests()`` reads this cached
+        # value to gate RECONCILIATION-priority requests for
+        # ``tx_only``-policy fields -- see that method's docstring;
+        # ``pending_requests()`` (unfiltered, MOR-1533) never reads it.
+        # Defaults to True (no gating) so a scheduler whose caller never
+        # calls either update method keeps its pre-existing, unfiltered
+        # reconciliation behavior.
         self._tx_active = True
 
     @property
@@ -643,30 +645,60 @@ class AcquisitionScheduler:
         )
 
     def pending_requests(self) -> tuple[AcquisitionRequest, ...]:
-        """Return queued backend acquisition requests in execution order.
+        """Return ALL queued backend acquisition requests, unfiltered.
+
+        MOR-1533: this is the *lookup* view -- every request currently
+        queued in ``_requests_by_key``, regardless of the ``tx_active``
+        dispatch gate (MOR-1531) applied by :meth:`dispatchable_requests`.
+        Callers that credit an already-sent request against an incoming
+        observation (e.g. ``runtime._civ_rx``) must use THIS method: a
+        ``tx_only`` RECONCILIATION request dispatched during TX can have its
+        answer land after de-key, once the cached ``tx_active`` has already
+        flipped False. Before this split, dispatch and lookup shared one
+        filtered method, so such an answer became invisible to the credit
+        loop and the request lingered in ``_requests_by_key`` forever.
+
+        Callers that DISPATCH (send a wire read) must use
+        :meth:`dispatchable_requests` instead.
+        """
+
+        return tuple(
+            sorted(
+                self._requests_by_key.values(),
+                key=lambda request: (
+                    -_PRIORITY_RANK[request.priority],
+                    request.deadline_monotonic,
+                    request.requested_at_monotonic,
+                    request.id,
+                ),
+            )
+        )
+
+    def dispatchable_requests(self) -> tuple[AcquisitionRequest, ...]:
+        """Return queued requests eligible for dispatch, in execution order.
 
         MOR-1531: while the last ``tx_active`` reported to ``due_requests``
-        is False, ``RECONCILIATION``-priority requests for ``tx_only``-
-        policy fields are withheld from the returned tuple (root cause of
-        the live SWR-flap, MOR-1525). ``StateStore.mark_stale_due`` has no
-        notion of ``tx_only`` and emits a "stale" reconciliation hint for
-        ANY field that ages past its ``freshness_ttl_seconds``, regardless
-        of TX state; ``ensure_fresh`` queues that hint just like any other
-        request. Filtering here -- at drain time, not enqueue time -- means
-        a hint queued while TX was active but drained after de-key does not
-        fire, while a de-key/re-key race can never permanently lose it: the
-        request stays in ``_requests_by_key`` (not deleted, just withheld)
-        until a drain observes ``tx_active=True`` again. This does not
-        touch freshness decay itself -- ``mark_stale_due`` has already
-        transitioned the field to STALE in the published state before the
-        scheduler is ever consulted, so decay/unobserve keeps working
-        exactly as before; only the resulting re-poll is suppressed.
+        (the web poller's cadence-drain call) or ``note_tx_active`` (rigctld's
+        own drain, MOR-1532) is False, ``RECONCILIATION``-priority requests
+        for ``tx_only``-policy fields are withheld from the returned tuple
+        (root cause of the live SWR-flap, MOR-1525). ``StateStore.
+        mark_stale_due`` has no notion of ``tx_only`` and emits a "stale"
+        hint for ANY field past its ``freshness_ttl_seconds``, regardless of
+        TX state; filtering here -- at drain time, not enqueue time -- means
+        a hint queued during TX but drained after de-key does not fire,
+        while a de-key/re-key race can never permanently lose it: the
+        request stays in ``_requests_by_key`` (withheld, not deleted) until
+        a drain observes ``tx_active=True`` again. Decay is untouched --
+        ``mark_stale_due`` has already transitioned the field to STALE
+        before the scheduler is consulted; only the resulting re-poll is
+        suppressed.
 
         Other priorities (e.g. an explicit USER-triggered read of a
         ``tx_only`` field) are never gated here -- see
-        ``AcquisitionPolicy.tx_only``'s docstring: only the automatic
-        reconciliation-on-stale hint is in scope for this gate, not
-        caller-triggered acquisition.
+        ``AcquisitionPolicy.tx_only``'s docstring.
+
+        MOR-1533: this is the *dispatch* view -- backend executors/pollers
+        must call this, not :meth:`pending_requests` (unfiltered lookup).
         """
 
         eligible = (
@@ -688,6 +720,28 @@ class AcquisitionScheduler:
             )
         )
 
+    def note_tx_active(self, tx_active: bool) -> None:
+        """Update the cached ``tx_active`` gate without driving cadence polling.
+
+        MOR-1532: standalone rigctld has no cadence-poll concept of its own
+        -- it never calls :meth:`due_requests` -- so a scheduler instance
+        owned by a standalone rigctld server never updated ``_tx_active``
+        away from the ``__init__`` default of ``True``, leaving
+        :meth:`dispatchable_requests`'s ``tx_only`` gate (MOR-1531)
+        permanently open in that mode. rigctld's drain calls this every
+        cycle with ``tx_active`` derived the same way the web poller does
+        (canonical ``global.tx_state.ptt``, FRESH-gated).
+
+        In combined (``rigplane web --rigctld``) mode the two servers share
+        this scheduler instance, and ``due_requests()`` (driven by the web
+        poller) already keeps ``_tx_active`` current every cycle; rigctld
+        calling this method too changes nothing, since both derive
+        ``tx_active`` from the identical canonical fact -- no second source
+        of truth, no fight over the cached value.
+        """
+
+        self._tx_active = tx_active
+
     def due_requests(
         self, *, now: float | None = None, tx_active: bool = False
     ) -> tuple[AcquisitionRequest, ...]:
@@ -704,15 +758,20 @@ class AcquisitionScheduler:
         """
 
         # MOR-1531: remember the caller's tx_active for this drain cycle so
-        # pending_requests() -- called immediately afterward by the web
-        # radio_poller's drain loop, the one known caller of due_requests()
-        # -- can gate RECONCILIATION requests for tx_only fields using the
-        # exact same value, without a second tx_active source of truth.
-        # rigctld's own drain loop never calls due_requests() at all (it has
-        # no cadence-poll concept of its own), so its scheduler instance
-        # keeps the __init__ default (_tx_active=True, no gating) forever --
-        # unaffected by this change. See pending_requests()'s docstring for
-        # why filtering happens there and not at enqueue time.
+        # dispatchable_requests() -- called immediately afterward by the web
+        # radio_poller's drain loop, the one caller of due_requests() -- can
+        # gate RECONCILIATION requests for tx_only fields using the exact
+        # same value, without a second tx_active source of truth.
+        #
+        # rigctld never calls due_requests() itself (it has no cadence-poll
+        # concept of its own). In STANDALONE mode its scheduler is its own;
+        # its drain calls note_tx_active() every cycle instead (MOR-1532),
+        # so it does NOT keep the __init__ default forever -- correcting an
+        # earlier claim here that it did. In COMBINED (`rigplane web
+        # --rigctld`) mode the two servers share this exact scheduler
+        # instance, so this due_requests() call already keeps _tx_active
+        # current for both drains; see note_tx_active()'s docstring for why
+        # rigctld also calling it there can never disagree.
         self._tx_active = tx_active
         timestamp = self._clock.now() if now is None else now
         groups = self._due_poll_groups(timestamp, tx_active=tx_active)
@@ -1077,6 +1136,7 @@ class AcquisitionScheduler:
     def diagnostics(self) -> dict[str, Any]:
         """Return a JSON-safe scheduler projection for diagnostics surfaces."""
 
+        dispatchable_count = len(self.dispatchable_requests())
         now = self._clock.now()
         cadence_by_path: dict[str, dict[str, Any]] = {}
         cadence_by_group: dict[str, dict[str, Any]] = {}
@@ -1103,6 +1163,10 @@ class AcquisitionScheduler:
 
         return {
             "queuedRequestCount": len(self._requests_by_key),
+            # MOR-1533 (3): the subset of queuedRequestCount currently
+            # withheld by the MOR-1531 tx_only/tx_active gate -- see
+            # dispatchable_requests() -- distinguished from "backlog".
+            "withheldRequestCount": len(self._requests_by_key) - dispatchable_count,
             "deferredRequestCount": len(self._deferred),
             "failedRequestCount": self._failed_request_count,
             "failureCountByReason": dict(self._failure_count_by_reason),

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -718,7 +718,11 @@ class RigctldServer:
                     "rigctld.server",
                     request_id=request.id,
                     paths=[str(path) for path in newly_sent],
-                    pending_request_count=len(scheduler.pending_requests()),
+                    # MOR-1533: dispatchable_requests(), matching this
+                    # drain's own dispatch view -- not the unfiltered
+                    # pending_requests(), which would also count entries
+                    # this drain will never send (withheld tx_only hints).
+                    pending_request_count=len(scheduler.dispatchable_requests()),
                 )
 
     async def start(self) -> None:

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -35,7 +35,7 @@ from ..core.acquisition_scheduler import (
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_pipeline_contracts import FieldPath
 from ..core.state_acquisition_policy import RadioAcquisitionProfile
-from ..core.state_store import StateStore
+from ..core.state_store import FreshnessState, StateStore
 from ..radio_protocol import (
     CivCommandCapable,
     StateModelCapable,
@@ -570,12 +570,44 @@ class RigctldServer:
             link_healthy=False,
         )
 
+    def _derive_tx_active(self) -> bool:
+        """Derive the canonical tx_active fact for the scheduler's dispatch gate.
+
+        MOR-1532: standalone rigctld never calls
+        ``AcquisitionScheduler.due_requests()`` (it has no cadence-poll
+        concept of its own), so its scheduler's cached ``_tx_active`` never
+        left the ``__init__`` default of ``True`` -- the MOR-1531
+        ``tx_only`` reconciliation gate stayed permanently open in that
+        mode. Derived identically to the web poller (MOR-1525 / PR #2438):
+        the canonical ``global.tx_state.ptt`` observation, FRESH-gated. Fail
+        closed: unobserved/stale/unknown ptt -> tx_active False, the honest
+        direction when the fact isn't known.
+        """
+
+        store = self._state_store
+        if store is None:
+            return False
+        try:
+            ptt_field = store.snapshot().field(FieldPath.global_("tx_state", "ptt"))
+        except KeyError:
+            return False
+        return ptt_field.freshness is FreshnessState.FRESH and bool(ptt_field.value)
+
     async def _drain_state_acquisition_once(self) -> None:
         scheduler = self._acquisition_scheduler
         if scheduler is None:
             return
         now = time.monotonic()
-        pending = scheduler.pending_requests()
+        # MOR-1532: keep the scheduler's tx_active cache current on this
+        # drain path too -- see note_tx_active()'s docstring for why calling
+        # it here can never disagree with the web poller's due_requests()
+        # call in combined (shared-scheduler) mode.
+        scheduler.note_tx_active(self._derive_tx_active())
+        # MOR-1533: dispatch must use the tx_active-gated view; crediting an
+        # already-sent answer (runtime._civ_rx, driven by this radio's own
+        # CI-V pump) uses the unfiltered pending_requests() instead, so an
+        # answer landing after de-key is never blinded by this gate.
+        pending = scheduler.dispatchable_requests()
         pending_ids = {request.id for request in pending}
         for request_id in tuple(self._acquisition_in_flight):
             if request_id not in pending_ids:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3301,7 +3301,11 @@ class RadioPoller:
                     "web.radio_poller",
                     request_id=request.id,
                     paths=[str(path) for path in newly_sent],
-                    pending_request_count=len(scheduler.pending_requests()),
+                    # MOR-1533: dispatchable_requests(), matching this
+                    # drain's own dispatch view -- not the unfiltered
+                    # pending_requests(), which would also count entries
+                    # this drain will never send (withheld tx_only hints).
+                    pending_request_count=len(scheduler.dispatchable_requests()),
                 )
 
     async def _send_query(self) -> None:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3167,7 +3167,12 @@ class RadioPoller:
                 ptt_field.value
             )
         scheduler.due_requests(now=now, tx_active=tx_active)
-        pending = scheduler.pending_requests()
+        # MOR-1533: dispatch must use the tx_active-gated view. Crediting an
+        # already-sent answer (runtime._civ_rx) uses the unfiltered
+        # pending_requests() instead, so an answer landing after de-key is
+        # never blinded by this gate -- see dispatchable_requests()'s
+        # docstring.
+        pending = scheduler.dispatchable_requests()
         pending_ids = {request.id for request in pending}
         for request_id in tuple(self._acquisition_in_flight):
             if request_id not in pending_ids:

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -1403,7 +1403,7 @@ def test_reconciliation_of_tx_only_field_suppressed_while_tx_inactive() -> None:
         clock.advance(2.1)
         delta = service.tick(now=clock.now())
         scheduler.due_requests(now=clock.now(), tx_active=False)
-        pending = scheduler.pending_requests()
+        pending = scheduler.dispatchable_requests()
 
         swr_requests = [
             r
@@ -1464,7 +1464,7 @@ def test_reconciliation_of_tx_only_field_still_fires_while_tx_active() -> None:
     clock.advance(2.1)
     delta = service.tick(now=clock.now())
     scheduler.due_requests(now=clock.now(), tx_active=True)
-    pending = scheduler.pending_requests()
+    pending = scheduler.dispatchable_requests()
 
     assert delta.reconciliation_requests
     assert any(
@@ -1513,20 +1513,59 @@ def test_reconciliation_queued_during_tx_but_drained_after_dekey_is_deferred_not
     )
     assert result.status is AcquisitionStatus.QUEUED
 
-    # TX ends before the next drain reads pending_requests().
+    # TX ends before the next drain reads dispatchable_requests().
     clock.advance(0.1)
     scheduler.due_requests(now=clock.now(), tx_active=False)
-    assert scheduler.pending_requests() == (), (
+    assert scheduler.dispatchable_requests() == (), (
         "a reconciliation queued during TX must not fire once drained after de-key"
     )
+    # It is not lost either -- pending_requests() (unfiltered, MOR-1533)
+    # still finds it, so an in-flight answer can still be credited.
+    assert len(scheduler.pending_requests()) == 1
 
     # TX resumes: the same still-queued request must fire -- not lost.
     clock.advance(0.1)
     scheduler.due_requests(now=clock.now(), tx_active=True)
-    resumed = scheduler.pending_requests()
+    resumed = scheduler.dispatchable_requests()
     assert len(resumed) == 1
     assert resumed[0].paths == (swr,)
     assert resumed[0].priority is AcquisitionPriority.RECONCILIATION
+
+
+def test_user_priority_read_of_tx_only_field_is_never_gated_by_tx_active() -> None:
+    """MOR-1532 acceptance note: rigctld's own USER-priority reads (e.g. its
+    ``l SWR`` one-shot) must stay ungated by the MOR-1531 tx_active gate --
+    only the automatic RECONCILIATION-priority hint is in scope for it (see
+    ``AcquisitionPolicy.tx_only``'s docstring and
+    ``dispatchable_requests()``'s docstring).
+    """
+
+    clock = FreshnessClock(start=800.0)
+    swr = FieldPath.global_("meters", "swr")
+    profile = _profile(
+        [swr],
+        field_policies={
+            swr: AcquisitionPolicy(
+                cadence_seconds=None,
+                freshness_ttl_seconds=2.0,
+                tx_only=True,
+            ),
+        },
+    )
+    scheduler = AcquisitionScheduler(profile=profile, clock=clock)
+    scheduler.due_requests(now=clock.now(), tx_active=False)
+
+    result = scheduler.ensure_fresh(
+        swr,
+        max_age=2.0,
+        priority=AcquisitionPriority.USER,
+        reason="rigctld.get_level",
+    )
+
+    assert result.status is AcquisitionStatus.QUEUED
+    dispatchable = scheduler.dispatchable_requests()
+    assert len(dispatchable) == 1
+    assert dispatchable[0].priority is AcquisitionPriority.USER
 
 
 def test_prime_unobserved_queues_background_read_for_never_observed_policy_field() -> (

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -43,7 +43,9 @@ from rigplane.runtime._civ_rx import CIV_HEADER_SIZE
 from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
 from rigplane.commands.tone import _encode_tone_freq
 from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
     AcquisitionScheduler,
+    AcquisitionStatus,
     MeterObservationCoalescer,
 )
 from rigplane.core.state_acquisition_policy import (
@@ -2180,6 +2182,65 @@ def test_update_state_cache_records_scheduler_result_for_matching_pending_reques
 
     assert scheduler.recorded_count == 1
     assert scheduler.pending_requests() == ()
+
+
+def test_reconciliation_answer_landing_after_dekey_still_credits_pending_request(
+    radio: IcomRadio,
+) -> None:
+    """MOR-1533 (1): the dispatch gate must not blind the credit path.
+
+    A ``tx_only`` RECONCILIATION request queued while TX was active (the
+    scheduler's cached ``tx_active`` from a ``due_requests`` drain) whose
+    answer lands after de-key must still be credited by
+    ``_record_scheduler_result_for_observation``. MOR-1531 gated
+    RECONCILIATION/tx_only entries out of ``pending_requests()`` while
+    ``tx_active`` is False; since ``_civ_rx.py`` used that same method to
+    look up the request an incoming answer completes, the answer became
+    invisible to the credit loop once TX ended and the request lingered in
+    ``_requests_by_key`` forever. The fix splits dispatch
+    (``dispatchable_requests()``, filtered) from lookup
+    (``pending_requests()``, unfiltered).
+    """
+
+    swr = FieldPath.global_("meters", "swr")
+    policy = AcquisitionPolicy(
+        cadence_seconds=None,
+        freshness_ttl_seconds=2.0,
+        tx_only=True,
+    )
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(swr, policy=policy))
+    radio._acquisition_scheduler = scheduler
+
+    # Drain cycle while TX active: caches tx_active=True, then a
+    # stale-reconciliation hint (as StateFreshnessService would emit it) is
+    # queued and sent to the radio.
+    scheduler.due_requests(now=100.0, tx_active=True)
+    result = scheduler.ensure_fresh(
+        swr,
+        max_age=2.0,
+        priority=AcquisitionPriority.RECONCILIATION,
+        reason="stale",
+    )
+    assert result.status is AcquisitionStatus.QUEUED
+
+    # De-key before the answer arrives: the next drain caches tx_active=False.
+    scheduler.due_requests(now=100.5, tx_active=False)
+
+    # The radio's answer to the still-outstanding request lands now, after
+    # de-key.
+    radio._civ_runtime._apply_state_store_observations(
+        _make_frame(cmd=0x15, sub=0x12, data=_bcd2(48))
+    )
+
+    # pending_requests() is unfiltered by design (MOR-1533), so it already
+    # proves crediting on its own; re-affirming tx_active=True here just
+    # confirms nothing resurfaces once the tx_only gate reopens either.
+    scheduler.due_requests(now=101.0, tx_active=True)
+    assert scheduler.pending_requests() == (), (
+        "answer landing after de-key must have credited the outstanding "
+        "tx_only reconciliation request -- instead it lingered in "
+        "_requests_by_key and resurfaced once TX resumed"
+    )
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -15,6 +15,7 @@ import pytest
 from rigplane.commands.commander import IcomCommander, Priority
 from rigplane.core.capabilities import CAP_SCOPE
 from rigplane.core.acquisition_scheduler import (
+    AcquisitionPriority,
     AcquisitionScheduler,
     MeterObservationCoalescer,
 )
@@ -3612,6 +3613,78 @@ async def test_tx_active_stops_tx_only_group_when_canonical_ptt_de_keys() -> Non
     await poller._send_scheduler_requests()  # noqa: SLF001
     assert scheduler.tx_active_calls == [True, False]
     assert len(executor.calls) == 1  # unchanged -- no re-send while de-keyed
+
+
+@pytest.mark.asyncio
+async def test_drain_withholds_tx_only_reconciliation_when_canonical_ptt_is_rx() -> (
+    None
+):
+    """MOR-1533 web-path regression guard for the dispatch/lookup split.
+
+    ``_send_scheduler_requests`` must dispatch through
+    ``AcquisitionScheduler.dispatchable_requests()`` (tx_active-gated), not
+    the now-unfiltered ``pending_requests()``. The MOR-1525 tests above only
+    exercise ``due_requests()``'s cadence-group skip (BACKGROUND priority);
+    none of them queue a RECONCILIATION-priority ``tx_only`` request through
+    the real drain, so none would catch a regression here -- this test
+    reproduces the exact MOR-1531 shape (a stale-reconciliation hint, as
+    ``StateFreshnessService`` would emit it) through the real web drain.
+    """
+    radio = _make_radio(active="MAIN")
+    power = FieldPath.global_("meters", "power")
+    scheduler = AcquisitionScheduler(profile=_tx_only_profile(power))
+    radio._acquisition_scheduler = scheduler
+    executor = _InjectedAcquisitionExecutor()
+
+    store = StateStore()
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=False,
+            source=SourceMetadata(source="poll_response", provider="icom_civ"),
+            timestamp_monotonic=time.monotonic(),
+        )
+    )
+    state = RadioState()
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=state,
+        state_store=store,
+        acquisition_executor=executor,
+    )
+
+    scheduler.ensure_fresh(
+        power,
+        max_age=2.0,
+        priority=AcquisitionPriority.RECONCILIATION,
+        reason="stale",
+    )
+
+    await poller._send_scheduler_requests()  # noqa: SLF001
+
+    assert executor.calls == [], (
+        "tx_only RECONCILIATION request reached the wire while canonical "
+        "ptt is FRESH False -- the MOR-1525 SWR-flap loop, reopened"
+    )
+    assert poller._acquisition_in_flight == {}  # noqa: SLF001
+
+    # Mirror leg: TX active -- the same request must now be dispatched.
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=True,
+            source=SourceMetadata(source="poll_response", provider="icom_civ"),
+            timestamp_monotonic=time.monotonic(),
+        )
+    )
+    await poller._send_scheduler_requests()  # noqa: SLF001
+
+    assert any(
+        power in call[0].paths
+        and call[0].priority is AcquisitionPriority.RECONCILIATION
+        for call in executor.calls
+    ), "RECONCILIATION request must dispatch once TX is active"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -13,6 +13,7 @@ Strategy
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import AsyncIterator
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -276,6 +277,19 @@ def _unavailable_profile(path: FieldPath) -> RadioAcquisitionProfile:
             ),
         ),
         default_policy=AcquisitionPolicy(),
+    )
+
+
+def _tx_only_swr_profile(swr: FieldPath) -> RadioAcquisitionProfile:
+    """MOR-1531/1532 fixture: one reconciliation-only tx_only global meter."""
+    return RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(FieldCapability(path=swr, command_response_observable=True),),
+        field_policies={
+            swr: AcquisitionPolicy(
+                cadence_seconds=None, freshness_ttl_seconds=2.0, tx_only=True
+            ),
+        },
     )
 
 
@@ -738,6 +752,149 @@ class TestLifecycle:
                 )
             finally:
                 await srv.stop()
+
+    async def test_standalone_drain_derives_tx_active_and_suppresses_tx_only_reconciliation(
+        self, cfg: RigctldConfig
+    ) -> None:
+        """MOR-1532: standalone rigctld's drain must feed the scheduler a
+        canonical ``tx_active`` source.
+
+        Standalone rigctld never calls ``AcquisitionScheduler.due_requests()``
+        (no cadence-poll concept of its own), so pre-fix its scheduler's
+        cached ``_tx_active`` stays at the ``__init__`` default of ``True``
+        forever -- the MOR-1531 ``tx_only`` gate never engages in this mode.
+        Reproduces the MOR-1525 SWR-flap loop for standalone rigctld: a
+        ``tx_only`` meter observed once (e.g. a rigctld one-shot ``l SWR``
+        read) keeps getting reconciled/re-sent forever, even with the
+        canonical ``global.tx_state.ptt`` observation FRESH and False
+        throughout.
+        """
+
+        swr = FieldPath.global_("meters", "swr")
+        ptt = FieldPath.global_("tx_state", "ptt")
+        radio = _ProfiledStandaloneRadio(
+            profile=type(
+                "Profile", (), {"state_acquisition": _tx_only_swr_profile(swr)}
+            )()
+        )
+
+        class _ReapplyingExecutor:
+            """Re-observes the field with its own answer, like a real radio."""
+
+            def __init__(self) -> None:
+                self.calls: list[AcquisitionRequest] = []
+
+            async def execute(
+                self,
+                request: AcquisitionRequest,
+                *,
+                already_sent_paths: frozenset[FieldPath],
+            ) -> AcquisitionExecutionResult:
+                self.calls.append(request)
+                store = radio._state_store
+                scheduler = radio._acquisition_scheduler
+                change_set = store.apply(
+                    Observation(
+                        path=request.paths[0],
+                        value=1,
+                        source=SourceMetadata(
+                            source="poll_response",
+                            provider=request.provider,
+                            native_id="fake-provider-read",
+                        ),
+                        timestamp_monotonic=time.monotonic(),
+                        max_age=request.policy.freshness_ttl_seconds,
+                        provider_generation=store.provider_generation,
+                    )
+                )
+                scheduler.record_acquisition_result(request, change_set)
+                return AcquisitionExecutionResult(sent_paths=request.paths)
+
+        executor = _ReapplyingExecutor()
+        radio._acquisition_executor = executor
+
+        fake_now = [1000.0]
+        with patch("time.monotonic", side_effect=lambda: fake_now[0]):
+            srv = RigctldServer(radio, cfg)
+            # Bootstrap directly (no real background loop tasks) so time can
+            # be driven deterministically across several drain cycles.
+            srv._bootstrap_state_acquisition()
+            assert isinstance(srv._state_store, StateStore)
+            assert isinstance(srv._acquisition_scheduler, AcquisitionScheduler)
+            assert isinstance(srv._state_freshness_service, StateFreshnessService)
+
+            # Canonical PTT: FRESH and False (confirmed RX) throughout. SWR
+            # observed exactly once, as if from an earlier TX or a rigctld
+            # one-shot cmd15 read.
+            _apply_store_value(srv._state_store, ptt, False, max_age=1000.0)
+            _apply_store_value(srv._state_store, swr, 1, max_age=2.0)
+
+            for _ in range(5):
+                fake_now[0] += 2.1
+                srv._state_freshness_service.tick(now=fake_now[0])
+                await srv._drain_state_acquisition_once()
+
+        assert executor.calls == [], (
+            "tx_only field re-polled via reconciliation while "
+            "global.tx_state.ptt is FRESH and False -- this is the "
+            "MOR-1525 SWR-flap loop, reachable in standalone rigctld mode "
+            "(MOR-1532)"
+        )
+
+    async def test_combined_mode_rigctld_drain_never_flips_shared_scheduler_tx_active(
+        self, cfg: RigctldConfig
+    ) -> None:
+        """MOR-1532: combined (`rigplane web --rigctld`) mode shares one
+        scheduler. Both ``due_requests()`` (driven by the web poller) and
+        rigctld's own drain derive ``tx_active`` from the identical
+        canonical ``global.tx_state.ptt`` fact, so rigctld's drain must
+        never spuriously flip the cached value the web poller just set --
+        same source, same value, no fight.
+        """
+
+        swr = FieldPath.global_("meters", "swr")
+        ptt = FieldPath.global_("tx_state", "ptt")
+        profile = _tx_only_swr_profile(swr)
+        store = StateStore()
+        scheduler = AcquisitionScheduler(profile=profile)
+        model_service = _RecordingStateModelService()
+
+        class _SharedSchedulerRadio:
+            def __init__(self) -> None:
+                self.profile = type("Profile", (), {"state_acquisition": profile})()
+                self.connected = True
+                self.radio_ready = True
+                self.control_connected = True
+                self.state_store = store
+                self.state_model_service = model_service
+                self._acquisition_scheduler = scheduler
+                self._state_store = store
+
+        radio = _SharedSchedulerRadio()
+        srv = RigctldServer(radio, cfg)
+        srv._bootstrap_state_acquisition()
+        assert srv._acquisition_scheduler is scheduler, (
+            "combined mode must reuse the radio's already-attached "
+            "scheduler, not create a second one"
+        )
+
+        # Canonical PTT fact: FRESH and False (confirmed RX).
+        _apply_store_value(store, ptt, False, max_age=1000.0)
+
+        # Web poller's drain runs first: due_requests() caches
+        # tx_active=False.
+        scheduler.due_requests(now=0.0, tx_active=False)
+
+        # rigctld's own drain runs next, deriving tx_active from the same
+        # canonical fact -- must not flip the cache.
+        derived = srv._derive_tx_active()
+        assert derived is False
+        scheduler.note_tx_active(derived)
+
+        assert scheduler.dispatchable_requests() == (), (
+            "rigctld's drain must not spuriously re-enable the tx_only "
+            "gate the web poller's drain just closed"
+        )
 
     async def test_standalone_drain_records_executor_missing_failure(
         self, cfg: RigctldConfig

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -26,6 +26,7 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionRequest,
     AcquisitionScheduler,
+    AcquisitionStatus,
     RadioStateModelService,
     StateFreshnessService,
 )
@@ -878,8 +879,19 @@ class TestLifecycle:
             "scheduler, not create a second one"
         )
 
-        # Canonical PTT fact: FRESH and False (confirmed RX).
+        # Canonical PTT fact: FRESH and False (confirmed RX). A real
+        # RECONCILIATION request is queued -- without this, the RX-leg
+        # ``dispatchable_requests() == ()`` assertion below would be
+        # vacuous (an empty scheduler is trivially "gated").
         _apply_store_value(store, ptt, False, max_age=1000.0)
+        result = scheduler.ensure_fresh(
+            swr,
+            max_age=2.0,
+            priority=AcquisitionPriority.RECONCILIATION,
+            reason="stale",
+        )
+        assert result.status is AcquisitionStatus.QUEUED
+        assert len(scheduler.pending_requests()) == 1
 
         # Web poller's drain runs first: due_requests() caches
         # tx_active=False.
@@ -895,6 +907,17 @@ class TestLifecycle:
             "rigctld's drain must not spuriously re-enable the tx_only "
             "gate the web poller's drain just closed"
         )
+
+        # TX leg: canonical PTT flips FRESH True -- both due_requests()
+        # (web) and _derive_tx_active() (rigctld) must agree, and the
+        # still-queued request must now be dispatchable.
+        _apply_store_value(store, ptt, True, max_age=1000.0)
+        scheduler.due_requests(now=1.0, tx_active=True)
+        derived = srv._derive_tx_active()
+        assert derived is True
+        scheduler.note_tx_active(derived)
+
+        assert len(scheduler.dispatchable_requests()) == 1
 
     async def test_standalone_drain_records_executor_missing_failure(
         self, cfg: RigctldConfig


### PR DESCRIPTION
## Root cause

Two sibling follow-ups to PR #2439 (MOR-1531), same domain, same files.

**MOR-1532.** PR #2439 gated `AcquisitionScheduler.pending_requests()`'s tx_only RECONCILIATION entries on a cached `_tx_active` flag, updated only by `due_requests()` -- the web poller's cadence-drain call. Standalone rigctld never calls `due_requests()` (it has no cadence-poll concept of its own), so its scheduler instance's `_tx_active` stays at the `__init__` default of `True` forever: the gate never actually engages in that mode. This leaves the MOR-1525 SWR-flap loop reachable via rigctld's own one-shot `l SWR` reads (`_OBSERVABLE_CMD15_FIELDS`) plus `mark_stale_due`.

**MOR-1533.** Three smaller follow-ups:
1. `runtime/_civ_rx.py`'s `_record_scheduler_result_for_observation` used `pending_requests()` (filtered by MOR-1531) to credit incoming answers against outstanding requests. A `tx_only` RECONCILIATION request sent during TX whose answer lands after de-key becomes invisible to that filtered view once `tx_active` flips False -- the request lingers in `_requests_by_key` forever, never removed, never re-sent.
2. The comment at `acquisition_scheduler.py:710-713` claimed rigctld's scheduler "keeps the `__init__` default forever" -- true only for standalone mode; wrong for combined (shared-scheduler) mode, where the web poller's `due_requests()` already updates it.
3. `diagnostics()`'s `queuedRequestCount` conflated ordinary backlog with entries currently withheld by the tx_only gate.

## Fix

- **`AcquisitionScheduler.pending_requests()`** is now the unfiltered *lookup* view (every queued request, regardless of the tx_active gate) -- used by `runtime/_civ_rx.py` to credit answers.
- **`AcquisitionScheduler.dispatchable_requests()`** (new) is the tx_active-gated *dispatch* view (the old `pending_requests()` filtering logic) -- used by both drains (web `radio_poller.py` and rigctld `server.py`) to decide what to actually send.
- **`AcquisitionScheduler.note_tx_active()`** (new) updates the cached `_tx_active` gate without driving cadence polling -- for callers with no cadence-poll concept of their own.
- **`RigctldServer._derive_tx_active()`** (new) derives `tx_active` identically to the web poller (canonical `global.tx_state.ptt`, FRESH-gated, fail-closed) and feeds it to `scheduler.note_tx_active()` on every `_drain_state_acquisition_once()` cycle.
- In combined (`rigplane web --rigctld`) mode the two servers share one scheduler instance (`rigctld/server.py:398`). Since both `due_requests()` (web) and `note_tx_active()` (rigctld) derive `tx_active` from the identical canonical fact every cycle, they can never disagree -- no second source of truth, no fight over the cached value.
- Fixed the stale comment at `acquisition_scheduler.py`'s `due_requests()`.
- Added `diagnostics()["withheldRequestCount"]`.
- rigctld's own USER-priority reads (e.g. `l SWR`) were already ungated by the tx_only filter (only RECONCILIATION priority is in scope) -- confirmed with `test_user_priority_read_of_tx_only_field_is_never_gated_by_tx_active`.

## Red-first evidence

Both new regression tests were run against unmodified `origin/main` before implementing and failed as expected:

```
FAILED tests/test_rigctld_server.py::TestLifecycle::test_standalone_drain_derives_tx_active_and_suppresses_tx_only_reconciliation
  AssertionError: tx_only field re-polled via reconciliation while global.tx_state.ptt
  is FRESH and False -- this is the MOR-1525 SWR-flap loop, reachable in standalone
  rigctld mode (MOR-1532)

FAILED tests/test_civ_rx_coverage.py::test_reconciliation_answer_landing_after_dekey_still_credits_pending_request
  AssertionError: answer landing after de-key must have credited the outstanding
  tx_only reconciliation request -- instead it lingered in _requests_by_key and
  resurfaced once TX resumed
```

Both pass after the fix. Three pre-existing MOR-1531 tests in `test_acquisition_scheduler.py` were updated to assert against `dispatchable_requests()` (the now-filtered method) instead of `pending_requests()` (now unfiltered).

## R1: independent review follow-ups

An independent verifier reviewed head `7da0a303` and ruled the production code sound on every adversarial axis checked (derivations token-identical between web and rigctld, shared-store divergence structurally unreachable, credit-path split has zero orphaned callers, the MOR-1531 property and USER-priority ungating both hold, hygiene clean, scope accepted) but flagged the *coverage* as insufficient on two points, plus two smaller notes. All four addressed at head `8bce034e`:

**F1 (blocking, fixed).** The web drain (`radio_poller.py:_send_scheduler_requests`) had no test that actually pushed a RECONCILIATION-priority `tx_only` request through the real drain -- the pre-existing MOR-1525 tests only exercise `due_requests()`'s cadence-group skip (BACKGROUND priority), which stays green even if the dispatch call at `:3175` is reverted to the (now unfiltered) `pending_requests()`. Verifier confirmed the full non-integration suite (9334 tests) stayed green under that mutation. Added `test_drain_withholds_tx_only_reconciliation_when_canonical_ptt_is_rx` to `tests/test_radio_poller_coverage.py`, reusing the existing `_TxActiveSpyScheduler`/`_tx_only_profile` harness. Mutated `:3175` back to `pending_requests()`, captured red, reverted via `git diff`-then-`git checkout` (no stash, to avoid the shared-stash-across-worktrees incident from earlier this session):

```
tests/test_radio_poller_coverage.py:3666: in test_drain_withholds_tx_only_reconciliation_when_canonical_ptt_is_rx
    assert executor.calls == [], (
E   AssertionError: tx_only RECONCILIATION request reached the wire while canonical ptt is FRESH False -- the MOR-1525 SWR-flap loop, reopened
E   assert [(Acquisition... frozenset())] == []
E
E   Left contains one more item: (AcquisitionRequest(id='acq-1', paths=(FieldPath(scope=<FieldScope.GLOBAL: 'global'>, family=<FieldFamily.METERS: 'met...external_cat_owner=None, source_metadata={'provider': 'icom_civ', 'capabilityId': 'global.meters.power'}), frozenset())
=========================== short test summary info ============================
FAILED tests/test_radio_poller_coverage.py::test_drain_withholds_tx_only_reconciliation_when_canonical_ptt_is_rx
============================== 1 failed in 0.25s ===============================
```

Passes again after restoring `:3175`.

**F2 (blocking, fixed).** `test_combined_mode_rigctld_drain_never_flips_shared_scheduler_tx_active`'s headline `assert scheduler.dispatchable_requests() == ()` was vacuous -- the scheduler's queue was empty at that point, so the assertion held regardless of gating (verifier's probe: `len(pending_requests()) > 0` failed `0 > 0`). Corrected description of what this test actually pins now: it queues a real RECONCILIATION request for the `tx_only` field first (asserting `len(pending_requests()) == 1`, making the RX-leg `dispatchable_requests() == ()` load-bearing), then adds a TX-active leg -- re-applying canonical `ptt` FRESH True, driving both `due_requests()` and `_derive_tx_active()`, and asserting the same request becomes `len(dispatchable_requests()) == 1` once both agree TX is active. It now actually exercises both halves of the gate, not just the empty-queue trivial case.

**F3 (fixed).** The `acquisition_request_sent` diagnostic's `pending_request_count` (`radio_poller.py`, `rigctld/server.py`) silently changed meaning when `pending_requests()` became unfiltered -- it would have started counting gate-withheld entries this drain will never actually send. Switched both call sites to `dispatchable_requests()` so the diagnostic keeps reporting real dispatch backlog, consistent with the new `diagnostics()["withheldRequestCount"]` distinguishing "backlog" from "intentionally held back while RX".

**F4 (noted).** In **standalone** rigctld, the tx_active gate is closed for practically the entire duration of a real transmission: the canonical `ptt` field's freshness TTL is short (~1.0s in the shipped profile) and standalone rigctld has no cadence refresh of its own to keep re-observing it mid-TX, so the `tx_active=True` branch of `dispatchable_requests()`'s gate is essentially unexercised on live standalone hardware -- this is acceptable because standalone rigctld's own client reads (e.g. `l SWR`) are USER-priority and were never subject to this gate in the first place (see `test_user_priority_read_of_tx_only_field_is_never_gated_by_tx_active`); only the RECONCILIATION-priority hint path is affected, and it correctly stays closed rather than racing a stale `ptt` read.

## Tests

`tests/test_acquisition_scheduler.py`, `tests/test_rigctld_server.py`, `tests/test_civ_rx_coverage.py`, `tests/test_rigctld_handler.py`, `tests/test_radio_poller_coverage.py` -- 1083 tests, zero failures.

`ruff check`/`ruff format --check` clean, `lint-imports` clean (5/5 contracts kept), `mypy src/` unchanged at 13 pre-existing errors (none in touched files).

## Test plan

- [x] Red-first repro for MOR-1532 failed on unmodified main, passes after fix
- [x] Red-first repro for MOR-1533 (1) failed on unmodified main, passes after fix
- [x] R1/F1: new web-drain regression test fails when `radio_poller.py:3175` is reverted to `pending_requests()`, passes restored (red output above)
- [x] R1/F2: combined-mode test's `== ()` assertion is now load-bearing (queue non-empty beforehand) with a TX-active mirror leg added
- [x] `uv run pytest tests/test_acquisition_scheduler.py tests/test_rigctld_server.py tests/test_rigctld_handler.py tests/test_civ_rx_coverage.py tests/test_radio_poller_coverage.py -q` -- 1083 passed
- [x] `uv run ruff check src/ tests/` and `ruff format --check`
- [x] `uv run lint-imports`
- [x] `uv run mypy src/` -- no new errors

Closes MOR-1532
Closes MOR-1533
Refs MOR-1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
