### PR TITLE
fix: unify cmd29 gating for agc/af_mute/digisel and poller send path (MOR-1537)

### DIFF
--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -181,6 +181,8 @@ def get_digisel(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to read DIGI-SEL status (Command29-aware)."""
     if cmd_map is not None:
@@ -192,9 +194,15 @@ def get_digisel(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
-        to_addr, from_addr, _CMD_PREAMP, sub=_SUB_DIGISEL_STATUS, receiver=receiver
-    )
+    if command29:
+        return build_cmd29_frame(
+            to_addr,
+            from_addr,
+            _CMD_PREAMP,
+            sub=_SUB_DIGISEL_STATUS,
+            receiver=receiver,
+        )
+    return build_civ_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_DIGISEL_STATUS)
 
 
 def set_digisel(
@@ -203,6 +211,8 @@ def set_digisel(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Set DIGI-SEL status (Command29-aware)."""
     if cmd_map is not None:
@@ -215,13 +225,21 @@ def set_digisel(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
+    if command29:
+        return build_cmd29_frame(
+            to_addr,
+            from_addr,
+            _CMD_PREAMP,
+            sub=_SUB_DIGISEL_STATUS,
+            data=bytes([_bcd_byte(1 if on else 0)]),
+            receiver=receiver,
+        )
+    return build_civ_frame(
         to_addr,
         from_addr,
         _CMD_PREAMP,
         sub=_SUB_DIGISEL_STATUS,
         data=bytes([_bcd_byte(1 if on else 0)]),
-        receiver=receiver,
     )
 
 
@@ -342,6 +360,8 @@ def get_af_mute(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read AF Mute command."""
     if cmd_map is not None:
@@ -353,9 +373,11 @@ def get_af_mute(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
-        to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_AF_MUTE, receiver=receiver
-    )
+    if command29:
+        return build_cmd29_frame(
+            to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_AF_MUTE, receiver=receiver
+        )
+    return build_civ_frame(to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_AF_MUTE)
 
 
 def set_af_mute(
@@ -364,6 +386,8 @@ def set_af_mute(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set AF Mute command."""
     if cmd_map is not None:
@@ -376,13 +400,21 @@ def set_af_mute(
             receiver=receiver,
             command29=True,
         )
-    return build_cmd29_frame(
+    if command29:
+        return build_cmd29_frame(
+            to_addr,
+            from_addr,
+            _CMD_CTL_MEM,
+            sub=_SUB_AF_MUTE,
+            data=b"\x01" if on else b"\x00",
+            receiver=receiver,
+        )
+    return build_civ_frame(
         to_addr,
         from_addr,
         _CMD_CTL_MEM,
         sub=_SUB_AF_MUTE,
         data=b"\x01" if on else b"\x00",
-        receiver=receiver,
     )
 
 
@@ -391,6 +423,8 @@ def get_agc(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read AGC mode command."""
     return _build_function_get(
@@ -398,7 +432,7 @@ def get_agc(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=receiver != RECEIVER_MAIN,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_agc",
     )
@@ -410,6 +444,8 @@ def set_agc(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set AGC mode command.
 
@@ -427,7 +463,7 @@ def set_agc(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=receiver != RECEIVER_MAIN,
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_agc",
     )

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3028,7 +3028,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x1A, 0x09, receiver=receiver, operation="get_af_mute"
         )
-        civ = get_af_mute(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x1A, 0x09)
+        civ = get_af_mute(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         return await self._get_bool_value(
             civ, key=f"get_af_mute:{receiver}", command=0x1A, sub=0x09
         )
@@ -3039,8 +3040,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x1A, 0x09, receiver=receiver, operation="set_af_mute"
         )
+        cmd29 = self._profile.supports_cmd29(0x1A, 0x09)
         await self._send_fire_and_forget(
-            set_af_mute(on, to_addr=self._radio_addr, receiver=receiver)
+            set_af_mute(
+                on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_s_meter_sql_status(self, receiver: int = RECEIVER_MAIN) -> bool:
@@ -3073,13 +3077,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_agc(self, receiver: int = RECEIVER_MAIN) -> AgcMode:
         """Read AGC mode."""
         self._require_receiver(receiver, operation="get_agc")
-        command29 = receiver != RECEIVER_MAIN
-        if command29:
-            self._require_cmd29_route(
-                0x16, 0x12, receiver=receiver, operation="get_agc"
-            )
+        self._require_cmd29_route(0x16, 0x12, receiver=receiver, operation="get_agc")
+        cmd29 = self._profile.supports_cmd29(0x16, 0x12)
         value = await self._get_bcd_level(
-            get_agc(to_addr=self._radio_addr, receiver=receiver),
+            get_agc(to_addr=self._radio_addr, receiver=receiver, command29=cmd29),
             key=f"get_agc:{receiver}",
             command=0x16,
             sub=0x12,
@@ -3098,10 +3099,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         must not be rejected just because it isn't an IC-7610 mode (MOR-1522).
         """
         self._require_receiver(receiver, operation="set_agc")
-        if receiver != RECEIVER_MAIN:
-            self._require_cmd29_route(
-                0x16, 0x12, receiver=receiver, operation="set_agc"
-            )
+        self._require_cmd29_route(0x16, 0x12, receiver=receiver, operation="set_agc")
+        cmd29 = self._profile.supports_cmd29(0x16, 0x12)
         mode_int = int(mode)
         agc_modes = self._profile.agc_modes
         if agc_modes is not None and mode_int not in agc_modes:
@@ -3110,7 +3109,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 f"{self._profile.model}, got {mode_int}"
             )
         await self._send_fire_and_forget(
-            set_agc(mode_int, to_addr=self._radio_addr, receiver=receiver)
+            set_agc(
+                mode_int, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_audio_peak_filter(
@@ -4028,7 +4029,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._preamp_level = level
 
     async def get_digisel(self, receiver: int = RECEIVER_MAIN) -> bool:
-        """Read DIGI-SEL status (IC-7610 frontend selector)."""
+        """Read DIGI-SEL status (IC-7610 frontend selector).
+
+        Wrapping is gated purely on ``self._profile.supports_cmd29(0x16,
+        0x4E)`` via ``_require_cmd29_route`` (a no-op for receiver=MAIN,
+        which raises for receiver!=MAIN without a route) — matching every
+        other command in this family. Previously this also hard-raised
+        ``CommandError`` for receiver=MAIN when the profile lacked the
+        route, instead of unwrapping like the rest of the family (MOR-1537).
+        """
         self._check_connected()
         self._require_capability("digisel", operation="get_digisel")
         self._require_receiver(receiver, operation="get_digisel")
@@ -4038,12 +4047,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="get_digisel",
         )
-        if not self._profile.supports_cmd29(0x16, 0x4E):
-            raise CommandError(
-                f"get_digisel is unsupported by profile {self._profile.model}: "
-                "no cmd29 route for command 0x16/0x4E"
-            )
-        civ = get_digisel(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x4E)
+        civ = get_digisel(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         resp = await self._send_civ_expect(civ, label="get_digisel")
         if not resp.data:
             raise CommandError("Radio returned empty DIGI-SEL response")
@@ -4062,7 +4067,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_digisel",
         )
-        civ = set_digisel(on, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x4E)
+        civ = set_digisel(
+            on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         resp = await self._send_civ_expect(civ, label="set_digisel")
         ack = parse_ack_nak(resp)
         if ack is False:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -896,7 +896,7 @@ class RadioPoller:
         sub = wire[1] if len(wire) > 1 else None
         extra = bytes(wire[2:]) if len(wire) > 2 else b""
         payload = extra + data
-        if receiver != 0 and self._profile.supports_cmd29(cmd, sub):
+        if self._profile.supports_cmd29(cmd, sub):
             inner = bytes([receiver, cmd])
             if sub is not None:
                 inner += bytes([sub])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -862,6 +862,10 @@ class TestOperatorToggleParityCommands:
             ("get_twin_peak_filter", 0x4F, 1),
             ("get_filter_shape", 0x56, 1),
             ("get_agc_time_constant", 0x04, 1),
+            # MOR-1537: get_agc's builder now defaults command29=True like
+            # every other cmd29-eligible getter here, instead of deriving
+            # the wrap decision from receiver internally.
+            ("get_agc", 0x12, 1),
         ],
     )
     def test_cmd29_operator_getters(
@@ -888,6 +892,9 @@ class TestOperatorToggleParityCommands:
             ("set_twin_peak_filter", True, b"\x29\x01\x16\x4f\x01\xfd"),
             ("set_filter_shape", FilterShape.SOFT, b"\x29\x01\x16\x56\x01\xfd"),
             ("set_agc_time_constant", 13, b"\x29\x01\x1a\x04\x13\xfd"),
+            # MOR-1537: set_agc's builder now defaults command29=True like
+            # every other cmd29-eligible setter here.
+            ("set_agc", AgcMode.SLOW, b"\x29\x01\x16\x12\x03\xfd"),
         ],
     )
     def test_cmd29_operator_setters(
@@ -905,7 +912,6 @@ class TestOperatorToggleParityCommands:
         ("getter_name", "sub"),
         [
             ("get_overflow_status", 0x07),
-            ("get_agc", 0x12),
             ("get_compressor", 0x44),
             ("get_monitor", 0x45),
             ("get_vox", 0x46),
@@ -924,7 +930,6 @@ class TestOperatorToggleParityCommands:
     @pytest.mark.parametrize(
         ("setter_name", "value", "expected_tail"),
         [
-            ("set_agc", AgcMode.SLOW, b"\x16\x12\x03\xfd"),
             ("set_compressor", True, b"\x16\x44\x01\xfd"),
             ("set_monitor", False, b"\x16\x45\x00\xfd"),
             ("set_vox", True, b"\x16\x46\x01\xfd"),

--- a/tests/test_mor1537_cmd29_gating.py
+++ b/tests/test_mor1537_cmd29_gating.py
@@ -1,0 +1,414 @@
+"""Tests for MOR-1537 — unify cmd29 gating for AGC/AF-mute/DIGI-SEL and the
+web poller's raw-command send path.
+
+MOR-1517 (#2434) established the pattern: a CI-V command builder must accept
+an explicit ``command29: bool`` keyword-only override, and the ``radio.py``
+call site must compute ``cmd29 = self._profile.supports_cmd29(cmd, sub)`` and
+thread it through — never derive the wrap decision from ``receiver`` inside
+the builder, and never hardcode ``command29=True`` unconditionally.
+
+This file extends that same audit to three stragglers MOR-1517 explicitly
+flagged but did not fix:
+
+1. ``get_agc``/``set_agc`` (0x16/0x12) derived ``command29`` from
+   ``receiver != RECEIVER_MAIN`` *inside the builder*, with no override.
+   IC-7610 declares ``[0x16, 0x12]`` in its own ``[cmd29]`` routes, so
+   ``receiver=0`` (MAIN) should be wrapped there too, matching the
+   acquisition/scheduler path (which already sends wrapped AGC reads and the
+   radio answers them) — this is a real behavior change on IC-7610, pinned
+   here.
+2. ``get_af_mute``/``set_af_mute`` (0x1A/0x09) and ``get_digisel``/
+   ``set_digisel`` (0x16/0x4E) had no ``command29`` override at all — always
+   unconditionally cmd29-wrapped via ``build_cmd29_frame``. Only IC-7610
+   declares these commands today, and it has cmd29 routes for both, so this
+   was unreachable dead-path risk rather than a live defect (confirmed by
+   MOR-1517's audit) — fixed here for consistency and to remove a hidden trap
+   for future profiles. ``get_digisel`` additionally had a hard
+   ``CommandError`` raise for *any* receiver (including MAIN) when the
+   profile lacked the cmd29 route — stricter than every other converted
+   command, which unwraps for receiver=MAIN instead of raising. That extra
+   raise is removed; ``_require_cmd29_route`` (a no-op for receiver=MAIN,
+   which raises for receiver!=MAIN without a route) remains the sole guard,
+   matching every other command in this family.
+3. ``RadioPoller._send_cmd``'s wrap rule was
+   ``receiver != 0 and supports_cmd29(cmd, sub)`` — never wrapping receiver 0
+   even when the cmd29 route exists. Unified to plain ``supports_cmd29(cmd,
+   sub)``, matching ``CoreRadio``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.commands import (
+    build_civ_frame,
+    get_af_mute,
+    get_agc,
+    get_digisel,
+    set_af_mute,
+    set_agc,
+    set_digisel,
+)
+from rigplane.exceptions import CommandError
+from rigplane.profiles import RadioProfile, resolve_radio_profile
+from rigplane.radio_state import RadioState
+from rigplane.types import AgcMode, CivFrame
+from rigplane.web.radio_poller import CommandQueue, RadioPoller
+
+from test_mor1517_cmd29_gating import (
+    _IC7300_ADDR,
+    _IC7610_ADDR,
+    _connected_icom,
+    _mock_expect,
+    _mock_raw,
+    _sent_civ,
+)
+
+_IC9700_ADDR = 0xA2
+
+
+# ---------------------------------------------------------------------------
+# get_agc / set_agc (0x16/0x12) — pinned defect: builder no longer derives
+# command29 from receiver, radio.py now threads the profile gate through.
+# ---------------------------------------------------------------------------
+
+
+class TestAgcGating:
+    @pytest.mark.asyncio
+    async def test_set_agc_unwrapped_on_ic7300_receiver0(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_agc(AgcMode.FAST, receiver=0)
+        expected = set_agc(1, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert b"\x29" not in expected
+
+    @pytest.mark.asyncio
+    async def test_set_agc_wrapped_on_ic7610_receiver0(self) -> None:
+        """Behavior change: receiver=0 (MAIN) now wraps on IC-7610 because the
+        profile declares a cmd29 route for 0x16/0x12 — matching what the
+        acquisition path already sends."""
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_agc(AgcMode.FAST, receiver=0)
+        expected = set_agc(1, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert expected[4] == 0x29
+
+    @pytest.mark.asyncio
+    async def test_set_agc_wrapped_on_ic7610_receiver1_unchanged(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_agc(AgcMode.FAST, receiver=1)
+        expected = set_agc(1, to_addr=_IC7610_ADDR, receiver=1, command29=True)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_agc_unwrapped_on_ic9700_receiver0(self) -> None:
+        """IC-9700 declares routes = [] -> no cmd29 route for anything, so
+        MAIN stays plain (unchanged before/after this fix)."""
+        radio = _connected_icom(model="IC-9700")
+        mock = _mock_raw(radio)
+        await radio.set_agc(AgcMode.FAST, receiver=0)
+        expected = set_agc(1, to_addr=_IC9700_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_set_agc_raises_on_ic9700_receiver1_dual_rx_guard(self) -> None:
+        """Dual-RX guard preserved: SUB targeting with no cmd29 route raises,
+        same as every other command in this family."""
+        radio = _connected_icom(model="IC-9700")
+        _mock_raw(radio)
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await radio.set_agc(AgcMode.FAST, receiver=1)
+
+    @pytest.mark.asyncio
+    async def test_get_agc_unwrapped_on_ic7300_receiver0(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x16, sub=0x12, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_agc(receiver=0)
+        expected = get_agc(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == AgcMode.FAST
+
+    @pytest.mark.asyncio
+    async def test_get_agc_wrapped_on_ic7610_receiver0(self) -> None:
+        """Behavior change: same as set_agc — MAIN now wraps on IC-7610."""
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x12, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_agc(receiver=0)
+        expected = get_agc(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert expected[4] == 0x29
+        assert value == AgcMode.FAST
+
+    @pytest.mark.asyncio
+    async def test_get_agc_wrapped_on_ic7610_receiver1_unchanged(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x12, data=b"\x02"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_agc(receiver=1)
+        expected = get_agc(to_addr=_IC7610_ADDR, receiver=1, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value == AgcMode.MID
+
+    @pytest.mark.asyncio
+    async def test_get_agc_unwrapped_on_ic9700_receiver0(self) -> None:
+        radio = _connected_icom(model="IC-9700")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC9700_ADDR, command=0x16, sub=0x12, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_agc(receiver=0)
+        expected = get_agc(to_addr=_IC9700_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value == AgcMode.FAST
+
+    @pytest.mark.asyncio
+    async def test_get_agc_raises_on_ic9700_receiver1_dual_rx_guard(self) -> None:
+        radio = _connected_icom(model="IC-9700")
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await radio.get_agc(receiver=1)
+
+
+# ---------------------------------------------------------------------------
+# get_af_mute / set_af_mute (0x1A/0x09) — builder gained a command29 override;
+# radio.py now threads self._profile.supports_cmd29(0x1A, 0x09) through.
+# ---------------------------------------------------------------------------
+
+
+class TestAfMuteGating:
+    def test_builder_command29_false_produces_plain_frame(self) -> None:
+        """The builder previously had no override at all -- calling with
+        command29=False used to raise TypeError. Locks in the new param."""
+        got = get_af_mute(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = build_civ_frame(_IC7300_ADDR, 0xE0, 0x1A, sub=0x09)
+        assert got == expected
+        assert b"\x29" not in got
+
+    def test_builder_set_command29_false_produces_plain_frame(self) -> None:
+        got = set_af_mute(True, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = build_civ_frame(_IC7300_ADDR, 0xE0, 0x1A, sub=0x09, data=b"\x01")
+        assert got == expected
+
+    @pytest.mark.asyncio
+    async def test_get_af_mute_wrapped_on_ic7610_receiver0_unchanged(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x1A, sub=0x09, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_af_mute(receiver=0)
+        expected = get_af_mute(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value is True
+
+    @pytest.mark.asyncio
+    async def test_set_af_mute_wrapped_on_ic7610_receiver1_unchanged(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_af_mute(True, receiver=1)
+        expected = set_af_mute(True, to_addr=_IC7610_ADDR, receiver=1, command29=True)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_af_mute_unwraps_when_profile_lacks_route(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """New behavior: a profile that declares af_mute without a cmd29
+        route must send plain wire for MAIN, not always wrap. No shipped
+        profile hits this today (only IC-7610 declares af_mute, and it has
+        the route) -- simulated via a monkeypatched profile to lock in the
+        new gate rather than the old unconditional wrap."""
+        radio = _connected_icom(model="IC-7610")
+        monkeypatch.setattr(
+            RadioProfile, "supports_cmd29", lambda self, cmd, sub=None: False
+        )
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x1A, sub=0x09, data=b"\x00"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_af_mute(receiver=0)
+        expected = get_af_mute(to_addr=_IC7610_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value is False
+
+    @pytest.mark.asyncio
+    async def test_set_af_mute_raises_on_receiver1_when_profile_lacks_route(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        radio = _connected_icom(model="IC-7610")
+        monkeypatch.setattr(
+            RadioProfile, "supports_cmd29", lambda self, cmd, sub=None: False
+        )
+        _mock_raw(radio)
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await radio.set_af_mute(True, receiver=1)
+
+
+# ---------------------------------------------------------------------------
+# get_digisel / set_digisel (0x16/0x4E) — same builder treatment as af_mute.
+# get_digisel additionally had a hard CommandError raise for receiver=MAIN
+# when the profile lacked a cmd29 route (stricter than the rest of the
+# family, which unwraps for MAIN instead). That extra raise is removed.
+# ---------------------------------------------------------------------------
+
+
+class TestDigiselGating:
+    def test_builder_command29_false_produces_plain_frame(self) -> None:
+        got = get_digisel(to_addr=_IC7610_ADDR, receiver=0, command29=False)
+        expected = build_civ_frame(_IC7610_ADDR, 0xE0, 0x16, sub=0x4E)
+        assert got == expected
+        assert b"\x29" not in got
+
+    def test_builder_set_command29_false_produces_plain_frame(self) -> None:
+        got = set_digisel(True, to_addr=_IC7610_ADDR, receiver=0, command29=False)
+        expected = build_civ_frame(_IC7610_ADDR, 0xE0, 0x16, sub=0x4E, data=b"\x01")
+        assert got == expected
+
+    @pytest.mark.asyncio
+    async def test_get_digisel_wrapped_on_ic7610_receiver0_unchanged(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x4E, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_digisel(receiver=0)
+        expected = get_digisel(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        assert _sent_civ(mock) == expected
+        assert value is True
+
+    @pytest.mark.asyncio
+    async def test_set_digisel_wrapped_on_ic7610_receiver1_unchanged(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x4E, data=b"\xfb"
+        )
+        mock = _mock_expect(radio, response)
+        await radio.set_digisel(False, receiver=1)
+        expected = set_digisel(False, to_addr=_IC7610_ADDR, receiver=1, command29=True)
+        assert _sent_civ(mock) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_digisel_unwraps_instead_of_raising_when_no_route(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned defect: get_digisel(receiver=0) on a route-less profile must
+        NOT raise CommandError -- it must unwrap like every other command in
+        this family (_require_cmd29_route already no-ops for receiver=MAIN;
+        the extra hard raise this test used to hit is removed)."""
+        radio = _connected_icom(model="IC-7610")
+        monkeypatch.setattr(
+            RadioProfile, "supports_cmd29", lambda self, cmd, sub=None: False
+        )
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x4E, data=b"\x00"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_digisel(receiver=0)
+        expected = get_digisel(to_addr=_IC7610_ADDR, receiver=0, command29=False)
+        assert _sent_civ(mock) == expected
+        assert value is False
+
+    @pytest.mark.asyncio
+    async def test_get_digisel_raises_on_receiver1_when_no_route_dual_rx_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The dual-RX guard (_require_cmd29_route) still raises for SUB
+        targeting without a route -- only the MAIN-targeting hard raise was
+        removed."""
+        radio = _connected_icom(model="IC-7610")
+        monkeypatch.setattr(
+            RadioProfile, "supports_cmd29", lambda self, cmd, sub=None: False
+        )
+        with pytest.raises(CommandError, match="no cmd29 route"):
+            await radio.get_digisel(receiver=1)
+
+
+# ---------------------------------------------------------------------------
+# RadioPoller._send_cmd fourth wrap rule (web/radio_poller.py) -- unified to
+# match CoreRadio: supports_cmd29(cmd, sub), not
+# `receiver != 0 and supports_cmd29(cmd, sub)`.
+# ---------------------------------------------------------------------------
+
+
+def _make_poller_radio(model: str) -> MagicMock:
+    profile = resolve_radio_profile(model=model)
+    radio = MagicMock()
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = set(profile.capabilities)
+    radio.send_civ = AsyncMock()
+    return radio
+
+
+def _make_poller(model: str) -> tuple[RadioPoller, MagicMock]:
+    radio = _make_poller_radio(model)
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+    return poller, radio
+
+
+class TestSendCmdCmd29Unification:
+    @pytest.mark.asyncio
+    async def test_send_cmd_wraps_receiver0_on_ic7610_when_route_exists(self) -> None:
+        """Behavior change: previously `receiver != 0 and supports_cmd29(...)`
+        never wrapped receiver 0 even though IC-7610 declares the route."""
+        poller, radio = _make_poller("IC-7610")
+        found = await poller._send_cmd("set_agc", bytes([1]), receiver=0)
+        assert found is True
+        args: tuple[Any, ...]
+        kwargs: dict[str, Any]
+        args, kwargs = radio.send_civ.call_args
+        assert args[0] == 0x29
+        assert kwargs["data"] == bytes([0x00, 0x16, 0x12, 0x01])
+
+    @pytest.mark.asyncio
+    async def test_send_cmd_wraps_receiver1_on_ic7610_unchanged(self) -> None:
+        poller, radio = _make_poller("IC-7610")
+        await poller._send_cmd("set_agc", bytes([1]), receiver=1)
+        args, kwargs = radio.send_civ.call_args
+        assert args[0] == 0x29
+        assert kwargs["data"] == bytes([0x01, 0x16, 0x12, 0x01])
+
+    @pytest.mark.asyncio
+    async def test_send_cmd_unwrapped_on_ic7300_no_route(self) -> None:
+        poller, radio = _make_poller("IC-7300")
+        await poller._send_cmd("set_agc", bytes([1]), receiver=0)
+        args, kwargs = radio.send_civ.call_args
+        assert args[0] == 0x16
+        assert kwargs["sub"] == 0x12
+        assert kwargs["data"] == bytes([0x01])
+
+    @pytest.mark.asyncio
+    async def test_send_cmd_matches_core_radio_set_agc_wrap_shape(self) -> None:
+        """The set_agc dispatch arm falls back to _send_cmd when CAP_AGC is
+        not declared. Confirm the wrap/no-wrap decision it makes for
+        receiver=0 on IC-7610 now matches CoreRadio.set_agc's own decision
+        (both gated purely on supports_cmd29, no receiver-based override)."""
+        core_radio = _connected_icom(model="IC-7610")
+        core_mock = _mock_raw(core_radio)
+        await core_radio.set_agc(AgcMode.FAST, receiver=0)
+        core_frame = _sent_civ(core_mock)
+
+        poller, radio = _make_poller("IC-7610")
+        await poller._send_cmd("set_agc", bytes([1]), receiver=0)
+        args, kwargs = radio.send_civ.call_args
+
+        # core_frame is a full CI-V frame (FE FE to from CMD ... FD); the
+        # poller's _civ() call only carries the inner cmd/sub/data -- compare
+        # the wrap decision (cmd byte 0x29) and the cmd29 inner payload shape.
+        assert core_frame[4] == 0x29
+        assert args[0] == 0x29
+        assert core_frame[5:8] == bytes([0x00, 0x16, 0x12])
+        assert kwargs["data"][:3] == bytes([0x00, 0x16, 0x12])

--- a/tests/test_operator_toggles.py
+++ b/tests/test_operator_toggles.py
@@ -93,29 +93,56 @@ def _response_frame(sub: int, data: bytes) -> CivFrame:
 
 
 # ---------------------------------------------------------------------------
-# AGC Status (no cmd29, enum: AgcMode)
+# AGC Status (cmd29, enum: AgcMode)
 # ---------------------------------------------------------------------------
 
 
 class TestAGCStatus:
-    """Tests for get_agc / set_agc."""
+    """Tests for get_agc / set_agc.
+
+    MOR-1537: the builder's ``command29`` default is ``True`` (matching every
+    other cmd29-eligible builder in this module, e.g. ``TestAudioPeakFilter``)
+    — it no longer derives the wrap decision from ``receiver`` internally.
+    The profile-aware caller (``IcomRadio.get_agc``/``set_agc``) is
+    responsible for computing and passing the actual
+    ``self._profile.supports_cmd29(0x16, 0x12)`` value; see
+    ``tests/test_mor1537_cmd29_gating.py`` for that gating behavior,
+    including the IC-7610 MAIN-receiver behavior change this pinned.
+    """
 
     def test_get_agc_builds_correct_frame(self) -> None:
-        assert commands.get_agc() == _simple_get(_SUB_AGC)
+        assert commands.get_agc() == _cmd29_get(_SUB_AGC, RECEIVER_MAIN)
+
+    def test_get_agc_default_is_main(self) -> None:
+        assert commands.get_agc() == commands.get_agc(receiver=RECEIVER_MAIN)
 
     def test_get_agc_sub_receiver_builds_cmd29_frame(self) -> None:
         assert commands.get_agc(receiver=RECEIVER_SUB) == _cmd29_get(
             _SUB_AGC, RECEIVER_SUB
         )
 
+    def test_get_agc_command29_false_builds_plain_frame(self) -> None:
+        assert commands.get_agc(command29=False) == _simple_get(_SUB_AGC)
+
     def test_set_agc_fast_builds_correct_frame(self) -> None:
-        assert commands.set_agc(AgcMode.FAST) == _simple_set(_SUB_AGC, 0x01)
+        assert commands.set_agc(AgcMode.FAST) == _cmd29_set(
+            _SUB_AGC, 0x01, RECEIVER_MAIN
+        )
 
     def test_set_agc_mid_builds_correct_frame(self) -> None:
-        assert commands.set_agc(AgcMode.MID) == _simple_set(_SUB_AGC, 0x02)
+        assert commands.set_agc(AgcMode.MID) == _cmd29_set(
+            _SUB_AGC, 0x02, RECEIVER_MAIN
+        )
 
     def test_set_agc_slow_builds_correct_frame(self) -> None:
-        assert commands.set_agc(AgcMode.SLOW) == _simple_set(_SUB_AGC, 0x03)
+        assert commands.set_agc(AgcMode.SLOW) == _cmd29_set(
+            _SUB_AGC, 0x03, RECEIVER_MAIN
+        )
+
+    def test_set_agc_command29_false_builds_plain_frame(self) -> None:
+        assert commands.set_agc(AgcMode.SLOW, command29=False) == _simple_set(
+            _SUB_AGC, 0x03
+        )
 
     def test_set_agc_sub_receiver_builds_cmd29_frame(self) -> None:
         assert commands.set_agc(AgcMode.MID, receiver=RECEIVER_SUB) == _cmd29_set(
@@ -135,8 +162,8 @@ class TestAGCStatus:
         ``tests/test_radio.py``). This builder only encodes the raw
         single-BCD-byte value.
         """
-        assert commands.set_agc(0) == _simple_set(_SUB_AGC, 0x00)
-        assert commands.set_agc(4) == _simple_set(_SUB_AGC, 0x04)
+        assert commands.set_agc(0) == _cmd29_set(_SUB_AGC, 0x00, RECEIVER_MAIN)
+        assert commands.set_agc(4) == _cmd29_set(_SUB_AGC, 0x04, RECEIVER_MAIN)
 
     def test_set_agc_rejects_value_outside_single_bcd_byte_range(self) -> None:
         with pytest.raises(ValueError):

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2501,7 +2501,14 @@ class TestOperatorToggleParity:
     @pytest.mark.parametrize(
         ("method_name", "response", "expected"),
         [
-            ("get_agc", _function_response(0x12, b"\x03"), AgcMode.SLOW),
+            (
+                "get_agc",
+                # MOR-1537: IC-7610 declares a cmd29 route for 0x16/0x12, so
+                # get_agc(receiver=0) now wraps (previously it derived
+                # command29 from receiver != MAIN and never wrapped MAIN).
+                _function_response(0x12, b"\x03", receiver=0),
+                AgcMode.SLOW,
+            ),
             (
                 "get_audio_peak_filter",
                 _function_response(0x32, b"\x02", receiver=1),


### PR DESCRIPTION
## Root cause

MOR-1517 (#2434) fixed the class of bug where a CI-V command builder hardcoded `command29=True` unconditionally, ignoring profile support, and established the fix pattern: builder gains a keyword-only `command29: bool` override; the `radio.py` call site computes `cmd29 = self._profile.supports_cmd29(cmd, sub)` and threads it through. That PR's own audit explicitly flagged three stragglers it did not fix. This PR fixes them.

### 1. `get_agc`/`set_agc` (0x16/0x12) — pinned defect, real wire-format behavior change on IC-7610

The builder derived `command29 = receiver != RECEIVER_MAIN` *internally*, with no override — a different (and, it turns out, wrong) shape than the rest of the family. IC-7610 declares `[0x16, 0x12]` in its own `[cmd29]` routes (`rigs/ic7610.toml`), so the MAIN receiver *should* wrap there, matching what the acquisition/scheduler path already sends.

**Wire-frame before/after (`get_agc`/`set_agc`, MAIN receiver, IC-7610):**
- **Before**: `FE FE 98 E0 16 12 FD` (plain) / `FE FE 98 E0 16 12 03 FD` (set FAST)
- **After**: `FE FE 98 E0 29 00 16 12 FD` (wrapped) / `FE FE 98 E0 29 00 16 12 03 FD`

The radio already answers the wrapped form (the acquisition/state-polling path sends it today) — this change makes `CoreRadio.get_agc`/`set_agc` match. IC-7300/IC-705 (no `[cmd29]` section at all) and IC-9700 (`routes = []`) are unaffected — both stay plain for MAIN, same as before. IC-7610's SUB receiver was already wrapped and is unchanged.

### 2. `get_af_mute`/`set_af_mute` (0x1A/0x09) and `get_digisel`/`set_digisel` (0x16/0x4E)

These builders had **no** `command29` override at all — always unconditionally `build_cmd29_frame(...)`. Only IC-7610 declares these commands today (`get_af_mute`/`get_digisel` etc. only appear in `rigs/ic7610.toml`), and IC-7610 has cmd29 routes for both subs, so this was latent risk rather than a live defect — no shipped profile could hit the unguarded path. Fixed for consistency with the rest of the family and to remove a trap for future profiles that might declare these commands without a cmd29 route.

`get_digisel` additionally had a **hard `CommandError` raise** for *any* receiver (including MAIN) when the profile lacked the cmd29 route:

```python
if not self._profile.supports_cmd29(0x16, 0x4E):
    raise CommandError(...)
```

This was stricter than every other command in this family, which *unwraps* for MAIN instead of raising (`_require_cmd29_route` is a no-op for `receiver=MAIN`, and only raises for `receiver != MAIN` without a route). That extra raise is removed; `_require_cmd29_route` remains the sole guard, now consistent across the whole family. `set_digisel` never had this extra raise, only `get_digisel` did.

### 3. `RadioPoller._send_cmd`'s fourth wrap rule (`src/rigplane/web/radio_poller.py`)

```python
# before
if receiver != 0 and self._profile.supports_cmd29(cmd, sub):
# after
if self._profile.supports_cmd29(cmd, sub):
```

Same defect as #1, in the web poller's raw wire-command fallback path: it never wrapped receiver 0 even when the cmd29 route existed. Its only caller is the `SetAgc` dispatch arm's `CAP_AGC not in self._caps` fallback — confirmed its wrap decision now matches `CoreRadio.set_agc`'s (see `TestSendCmdCmd29Unification.test_send_cmd_matches_core_radio_set_agc_wrap_shape`).

## Out of scope (confirmed, not touched)

- **Freq (0x05) / mode (0x06) on IC-7610** — untouched, per CLAUDE.md's hard rule that cmd29 does not work for freq/mode there.
- **The `cmd_map is not None` builder branches** (`_build_from_map(..., command29=True, ...)`) — grepped `src/`, zero call sites pass `cmd_map=` to any of the builders touched here, so this remains confirmed dead code from the runtime's perspective, same conclusion #2434 reached for the attenuator/preamp builders. Left untouched — a separate cleanup decision.
- **`set_nb`/`set_nr`/`set_ip_plus`** (0x16/0x22, 0x16/0x40, 0x16/0x65) — discovered during this audit to share the *exact* same stale `command29=(receiver != RECEIVER_MAIN)` pattern, and IC-7610 does declare cmd29 routes for all three subs (checked directly against the profile). #2434's own audit had classified these as "already correct — not part of this bug class," which looks incorrect on closer inspection. Flagged as a follow-up rather than fixed here, to keep this PR scoped to the ticket.

## Tests

New `tests/test_mor1537_cmd29_gating.py` (26 tests, sibling to `test_mor1517_cmd29_gating.py`), covering:
- **AGC**: IC-7300 (plain, unchanged), IC-7610 receiver 0 (wrapped — **the behavior change**), IC-7610 receiver 1 (wrapped, unchanged), IC-9700 receiver 0 (plain, `routes=[]`), IC-9700 receiver 1 (raises — dual-RX guard preserved). GET + SET both directions.
- **af_mute**: builder-level `command29=False` contract (new param), IC-7610 receiver 0/1 (wrapped, unchanged), and a profile-monkeypatched no-route case proving the new gate actually unwraps instead of always wrapping.
- **digisel**: same shape as af_mute, plus a dedicated test pinning that `get_digisel(receiver=0)` on a route-less profile now **unwraps instead of raising** (the removed hard guard), and that the dual-RX guard for `receiver=1` still raises.
- **`RadioPoller._send_cmd`**: IC-7610 receiver 0 wraps (behavior change), receiver 1 unchanged, IC-7300 stays plain, and a direct comparison against `CoreRadio.set_agc`'s wire shape.

Verified TDD red-first: ran the new test file against the unfixed source first — 20/26 failed (`TypeError: unexpected keyword argument 'command29'` for the new-param assertions, a real `CommandError` for the digisel hard-raise test, and wrong-wrap-shape assertions for the AGC/`_send_cmd` behavior-change tests); the 6 that already passed were the "unchanged behavior" regression locks (SUB-receiver wrapping, dual-RX guards). All 26 pass after the fix.

Three existing test files had fixtures that encoded the now-superseded "AGC never wraps MAIN" assumption and needed updating (not regressions — the old assumption was the bug):
- `tests/test_radio.py` — `TestOperatorToggleParityCommands::test_get_enum_operator_toggle[get_agc-...]` queued a plain-frame response for a default-receiver `get_agc()` call on the IC-7610 fixture; now queues the wrapped form.
- `tests/test_commands.py` — moved `get_agc`/`set_agc` out of the "direct/plain builder" parametrize groups into the "cmd29 builder" groups (mirroring `get_audio_peak_filter` etc.).
- `tests/test_operator_toggles.py` — rewrote `TestAGCStatus` (previously headed "AGC Status (no cmd29, ...)") to assert the wrapped-by-default builder contract, matching the existing `TestAudioPeakFilter` pattern; added explicit `command29=False` and `default_is_main` coverage.

## Verification

- `uv run pytest tests/test_mor1537_cmd29_gating.py -q` — 26 passed
- `uv run pytest tests/test_mor1517_cmd29_gating.py tests/test_radio.py tests/test_radio_coverage.py tests/test_radio_extended.py tests/test_dsp_levels_part2.py tests/test_dsp_filter_family.py tests/test_radio_poller_coverage.py tests/test_single_rx_plain_routing.py tests/test_commands.py tests/test_operator_toggles.py tests/test_handlers_dsp_407_408.py tests/test_handlers_protocol_gap_399.py tests/test_handlers_sys_band.py tests/test_handlers_coverage.py tests/test_rig_ic7300.py tests/test_rig_ic7610.py tests/test_command_map_integration.py tests/test_rigctld_handler.py tests/test_web_capability_guards.py tests/test_supports_command.py tests/test_cmd29_parsing.py tests/test_mock_integration.py tests/test_acquisition_scheduler.py tests/test_ic9700_backend.py tests/test_icom_receiver_tier.py tests/test_radios.py tests/test_rig_multi_vendor.py -q` — 2400 passed (one unrelated pre-existing timing flake in `TestPtt::test_managed_ptt_port_token_safety[rebind]` under load, reproduced clean in isolation and on unmodified source — not caused by this change)
- `uv run ruff check src/ tests/` — zero violations
- `uv run ruff format src/ tests/` — clean
- `uv run lint-imports` — 5 kept, 0 broken
- `uv run mypy src/` — 13 pre-existing errors, identical set on unmodified `origin/main`, zero new
- `git diff` — no unintended changes; boundary grep (internal hostnames/paths) clean

## Guardrail disclosure

Touches 7 files (3 source, 4 test) — over the nominal 4-file guardrail. This mirrors #2434's own footprint (7 files, including a comparably-sized new test file) for the same class of fix: three existing test files encoded the now-fixed AGC bug as expected behavior and had to be updated alongside the source change, not because of scope creep.

Closes MOR-1537.