### PR TITLE
feat: adopt armed signal across polled selectors, styling in shared seat (MOR-1536)

### DIFF
--- a/frontend/src/components-v2/panels/AgcPanel.svelte
+++ b/frontend/src/components-v2/panels/AgcPanel.svelte
@@ -1,26 +1,40 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
   import { buildAgcOptions } from './agc-utils';
-  import { deriveAgcProps, getAgcHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { deriveAgcProps, getAgcHandlers, getAgcArmed } from '$lib/runtime/adapters/panel-adapters';
+  import { t } from '$lib/i18n';
 
   const handlers = getAgcHandlers();
-  let props = $derived(deriveAgcProps());
-  let options = $derived(buildAgcOptions(props.agcModes, props.agcLabels));
-  let showAgc = $derived(props.hasAgc ?? true);
+  let p = $derived(deriveAgcProps());
+  let options = $derived(buildAgcOptions(p.agcModes, p.agcLabels));
+  let showAgc = $derived(p.hasAgc ?? true);
+  // MOR-1536: the freshest in-flight `set_agc` target, DISPLAY ONLY (see
+  // `panel-adapters.ts`'s ARMED-SIGNAL CONTRACT). `agcMode` above stays the
+  // sole selection source — armed only marks the button the pending command
+  // is racing toward, never a substitute for the confirmed reading.
+  let armed = $derived(getAgcArmed());
+  const armedIdBase = $props.id();
 </script>
 
 {#if showAgc}
   <div class="panel-body">
     <div class="button-grid">
       {#each options as option}
+        {@const isArmed = armed.armed && armed.value === option.value}
+        {@const armedId = `${armedIdBase}-${option.value}`}
         <HardwareButton
-          active={props.agcMode === option.value}
+          active={p.agcMode === option.value}
           indicator="edge-left"
           color="cyan"
+          armed={isArmed}
+          describedBy={isArmed ? armedId : undefined}
           onclick={() => handlers.onAgcModeChange(option.value)}
         >
           {option.label}
         </HardwareButton>
+        {#if isArmed}
+          <span id={armedId} class="sr-only">{t('core.agcPanel.pendingAnnouncement')}</span>
+        {/if}
       {/each}
     </div>
   </div>
@@ -32,5 +46,13 @@
     flex-direction: column;
     gap: 6px;
     padding: 7px 8px;
+  }
+
+  /* MOR-1536 — same convention as `ModePanel.svelte`'s `.sr-only`: visually
+     hidden, `position: absolute` removes it from `.button-grid`'s flow so
+     it never consumes a grid cell. */
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 </style>

--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -12,10 +12,24 @@
     isNotchActive,
   } from './dsp-panel-logic';
 
-  import { deriveDspProps, getDspHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    deriveDspProps, getDspHandlers, getAutoNotchArmed, getManualNotchArmed,
+  } from '$lib/runtime/adapters/panel-adapters';
+  import { t } from '$lib/i18n';
 
   const handlers = getDspHandlers();
   let p = $derived(deriveDspProps());
+  // MOR-1536: freshest in-flight `set_auto_notch`/`set_manual_notch`
+  // targets, DISPLAY ONLY (see `panel-adapters.ts`'s ARMED-SIGNAL
+  // CONTRACT). `notchMode` below stays the sole selection source — armed
+  // only marks the button the pending command is racing toward, never a
+  // substitute for the confirmed reading. Two independent accessors
+  // because notch mode is written as two independent commands (see
+  // `getAutoNotchArmed`'s doc comment) — NOTCH tracks manual, A-NOTCH
+  // tracks auto.
+  let manualNotchArmed = $derived(getManualNotchArmed());
+  let autoNotchArmed = $derived(getAutoNotchArmed());
+  const notchArmedIdBase = $props.id();
 
   let nrMode = $derived(p.nrMode);
   let nrLevel = $derived(p.nrLevel);
@@ -227,12 +241,15 @@
     {/if}
 
     {#if showNotch}
+      {@const manualNotchArmedId = `${notchArmedIdBase}-manual`}
       <div class="dsp-btn-wrap" bind:this={notchAnchorEl}>
         <HardwareButton
           active={notchMode === 'manual'}
           indicator="edge-left"
           color="cyan"
           title="Manual Notch — click to toggle; long-press for settings"
+          armed={manualNotchArmed.armed}
+          describedBy={manualNotchArmed.armed ? manualNotchArmedId : undefined}
           onclick={onNotchClick}
           onpointerdown={() => startLongPress('notch')}
           onpointerup={endLongPressPointer}
@@ -240,18 +257,27 @@
           onpointerleave={endLongPressPointer}
         >NOTCH</HardwareButton>
       </div>
+      {#if manualNotchArmed.armed}
+        <span id={manualNotchArmedId} class="sr-only">{t('core.dsp.notch.pendingAnnouncement')}</span>
+      {/if}
     {/if}
 
     {#if showAutoNotch}
+      {@const autoNotchArmedId = `${notchArmedIdBase}-auto`}
       <div class="dsp-btn-wrap">
         <HardwareButton
           active={notchMode === 'auto'}
           indicator="edge-left"
           color="green"
           title="Auto Notch"
+          armed={autoNotchArmed.armed}
+          describedBy={autoNotchArmed.armed ? autoNotchArmedId : undefined}
           onclick={() => onNotchModeChange(notchMode === 'auto' ? 'off' : 'auto')}
         >A-NOTCH</HardwareButton>
       </div>
+      {#if autoNotchArmed.armed}
+        <span id={autoNotchArmedId} class="sr-only">{t('core.dsp.notch.pendingAnnouncement')}</span>
+      {/if}
     {/if}
 
     {#if showAgcTime}
@@ -507,5 +533,13 @@
   .dsp-mode-grid > :global(button) {
     flex: 1 1 0;
     min-width: 0;
+  }
+
+  /* MOR-1536 — same convention as `ModePanel.svelte`'s `.sr-only`: visually
+     hidden, `position: absolute` removes it from `.dsp-button-grid`'s flow
+     so it never consumes a grid cell. */
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 </style>

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -4,11 +4,19 @@
   import { ValueControl } from '../controls/value-control';
   import { formatFilterWidth } from './filter-utils';
   import { getShortcutHint, joinShortcutHints } from '../layout/shortcut-hints';
+  import { t } from '$lib/i18n';
 
-  import { deriveFilterProps, getFilterHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { deriveFilterProps, getFilterHandlers, getFilterArmed } from '$lib/runtime/adapters/panel-adapters';
 
   const handlers = getFilterHandlers();
   let p = $derived(deriveFilterProps());
+  // MOR-1536: the freshest in-flight `set_filter` target, DISPLAY ONLY (see
+  // `panel-adapters.ts`'s ARMED-SIGNAL CONTRACT). `currentFilter` below
+  // stays the sole selection source — armed only marks the button the
+  // pending command is racing toward, never a substitute for the confirmed
+  // reading.
+  let filterArmed = $derived(getFilterArmed());
+  const filterArmedIdBase = $props.id();
 
   let currentMode = $derived(p.currentMode);
   let currentFilter = $derived(p.currentFilter);
@@ -201,16 +209,23 @@
     <div class="filter-top-row">
       <div class="filter-grid">
         {#each normalizedLabels as label, index}
+          {@const isFilterArmed = filterArmed.armed && filterArmed.value === index + 1}
+          {@const filterArmedId = `${filterArmedIdBase}-${index + 1}`}
           <HardwareButton
             active={currentFilter === index + 1}
             indicator="edge-left"
             color="cyan"
             title={cycleFilterShortcut}
             shortcutHint={cycleFilterShortcut}
+            armed={isFilterArmed}
+            describedBy={isFilterArmed ? filterArmedId : undefined}
             onclick={() => onFilterChange?.(index + 1)}
           >
             {label}
           </HardwareButton>
+          {#if isFilterArmed}
+            <span id={filterArmedId} class="sr-only">{t('core.filter.select.pendingAnnouncement')}</span>
+          {/if}
         {/each}
       </div>
 
@@ -433,6 +448,14 @@
   .modal-close,
   .defaults-button {
     min-width: 0;
+  }
+
+  /* MOR-1536 — same convention as `ModePanel.svelte`'s `.sr-only`: visually
+     hidden, `position: absolute` removes it from `.filter-grid`'s flow so
+     it never consumes a grid cell. */
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 
   .bw-row {

--- a/frontend/src/components-v2/panels/ModePanel.svelte
+++ b/frontend/src/components-v2/panels/ModePanel.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { HardwareButton } from '$lib/Button';
   import { getShortcutHint } from '../layout/shortcut-hints';
-  import { deriveModeProps, getModeHandlers, getModeArmed } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    deriveModeProps, getModeHandlers, getModeArmed, getDataModeArmed,
+  } from '$lib/runtime/adapters/panel-adapters';
   import { MOD_INPUT_SOURCES } from '$lib/radio/mod-input';
   import { t } from '$lib/i18n';
 
@@ -23,6 +25,14 @@
   // split); not fixed here.
   let armed = $derived(getModeArmed());
   const pendingModeIdBase = $props.id();
+
+  // MOR-1536: DATA mode's own armed fact (`set_data_mode`) — a DIFFERENT
+  // intent than MODE's `set_mode` above; a mode change and a data-mode
+  // change can be in flight at once and must not be conflated (see
+  // `getDataModeArmed`'s doc comment, `panel-adapters.ts`). `dataMode`
+  // below stays the confirmed selection source, independent of armed.
+  let dataModeArmed = $derived(getDataModeArmed());
+  const dataModeIdBase = `${pendingModeIdBase}-dataMode`;
 
   // Destructure for template readability
   let currentMode = $derived(p.currentMode);
@@ -98,30 +108,43 @@
     </div>
 
     {#if hasDataMode && dataOptions.length === 2}
+      {@const dataArmedId = `${dataModeIdBase}-toggle`}
       <HardwareButton
         active={dataMode > 0}
         indicator="edge-left"
         color="red"
         title={dataShortcut}
         shortcutHint={dataShortcut}
+        armed={dataModeArmed.armed}
+        describedBy={dataModeArmed.armed ? dataArmedId : undefined}
         onclick={() => onDataModeChange(dataMode > 0 ? 0 : 1)}
       >
         DATA
       </HardwareButton>
+      {#if dataModeArmed.armed}
+        <span id={dataArmedId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>
+      {/if}
     {:else if hasDataMode && dataOptions.length > 2}
       <div class="section-label">DATA</div>
       <div class="data-grid">
         {#each dataOptions as option}
+          {@const isDataArmed = dataModeArmed.armed && dataModeArmed.value === option.value}
+          {@const dataArmedId = `${dataModeIdBase}-${option.value}`}
           <HardwareButton
             active={dataMode === option.value}
             indicator="edge-left"
             color="cyan"
             title={dataShortcut}
             shortcutHint={dataShortcut}
+            armed={isDataArmed}
+            describedBy={isDataArmed ? dataArmedId : undefined}
             onclick={() => onDataModeChange(option.value)}
           >
             {option.label}
           </HardwareButton>
+          {#if isDataArmed}
+            <span id={dataArmedId} class="sr-only">{t('core.modePanel.dataMode.pendingAnnouncement')}</span>
+          {/if}
         {/each}
       </div>
     {/if}
@@ -166,21 +189,12 @@
     gap: 4px;
   }
 
-  /* MOR-1519: rule sits ON the button itself (`data-armed`, rendered by
-     `ControlButton`), not a wrapper — a wrapper can't be matched by an
-     attribute selector, and inherited `font-style` is silently beaten by
-     the UA button stylesheet (review F1). `opacity` is the PRIMARY channel:
-     it is font-independent and always renders. `text-decoration: underline`
-     is the structural backstop that survives even without an italic face
-     (review F2 — this build's vendored Roboto Mono has none, and
-     `app.css`'s `font-synthesis: none` blocks the synthetic fallback, so
-     italic alone would compute but render pixel-identical to upright).
-     `:global(...)` because `ControlButton`'s own template — not this
-     file's — owns the element the attribute lands on. */
-  :global(.v2-control-button[data-armed='true']) {
-    opacity: 0.75;
-    text-decoration: underline;
-  }
+  /* MOR-1519/MOR-1536: the `data-armed` visual channel (opacity + underline)
+     used to live here as a per-panel `:global(...)` rule. It is now the
+     shared seat at `$lib/Button/control-button.css` (imported once by
+     `ControlButton.svelte`, the element that actually renders
+     `data-armed`) so every later `ControlButton`/`HardwareButton` consumer
+     gets it for free instead of re-authoring a copy per panel. */
 
   .section-label {
     color: var(--v2-text-dim);

--- a/frontend/src/components-v2/panels/RfFrontEnd.svelte
+++ b/frontend/src/components-v2/panels/RfFrontEnd.svelte
@@ -5,11 +5,24 @@
   import { HardwareButton } from '$lib/Button';
   import { shouldShowPanel } from './rf-frontend-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
+  import { t } from '$lib/i18n';
 
-  import { deriveRfFrontEndProps, getRfFrontEndHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    deriveRfFrontEndProps, getRfFrontEndHandlers, getPreampArmed, getAttenuatorArmed,
+  } from '$lib/runtime/adapters/panel-adapters';
 
   const handlers = getRfFrontEndHandlers();
   let p = $derived(deriveRfFrontEndProps());
+  // MOR-1536: freshest in-flight `set_preamp`/`set_attenuator` targets,
+  // DISPLAY ONLY (see `panel-adapters.ts`'s ARMED-SIGNAL CONTRACT). `pre`/
+  // `att` below stay the sole selection source — armed only marks the
+  // button the pending command is racing toward, never a substitute for
+  // the confirmed reading. Attenuator: wired for the 2-value HardwareButton
+  // toggle below only — the `>2`-value `AttenuatorControl` branch is
+  // unwired (see PR body).
+  let preArmed = $derived(getPreampArmed());
+  let attArmed = $derived(getAttenuatorArmed());
+  const armedIdBase = $props.id();
 
   let rfGain = $derived(p.rfGain);
   let squelch = $derived(p.squelch);
@@ -81,16 +94,22 @@
 
     {#if showAtt}
       {#if attValues.length <= 2}
+        {@const attArmedId = `${armedIdBase}-att`}
         <HardwareButton
           active={att > 0}
           indicator="edge-left"
           color="amber"
           title={attShortcut}
           shortcutHint={attShortcut}
+          armed={attArmed.armed}
+          describedBy={attArmed.armed ? attArmedId : undefined}
           onclick={() => onAttChange(att > 0 ? 0 : attValues[attValues.length - 1])}
         >
           ATT
         </HardwareButton>
+        {#if attArmed.armed}
+          <span id={attArmedId} class="sr-only">{t('core.rfFrontEnd.att.pendingAnnouncement')}</span>
+        {/if}
       {:else}
         <div class="control-row" data-shortcut-hint={attShortcut ?? undefined} title={attShortcut ?? undefined}>
           <span class="control-label">ATT</span>
@@ -104,6 +123,8 @@
         <span class="control-label">PRE</span>
         <div class="button-group">
           {#each preOptions as option}
+            {@const isPreArmed = preArmed.armed && preArmed.value === option.value}
+            {@const preArmedId = `${armedIdBase}-pre-${option.value}`}
             <HardwareButton
               active={pre === option.value}
               indicator="edge-left"
@@ -111,10 +132,15 @@
               disabled={preDisabled}
               title={preDisabled ? preDisabledReason : preShortcut}
               shortcutHint={preShortcut}
+              armed={isPreArmed}
+              describedBy={isPreArmed ? preArmedId : undefined}
               onclick={() => onPreChange(option.value)}
             >
               {option.label}
             </HardwareButton>
+            {#if isPreArmed}
+              <span id={preArmedId} class="sr-only">{t('core.rfFrontEnd.preamp.pendingAnnouncement')}</span>
+            {/if}
           {/each}
         </div>
       </div>
@@ -215,5 +241,13 @@
   .button-group > :global(button) {
     flex: 1 1 0;
     min-width: 0;
+  }
+
+  /* MOR-1536 — same convention as `ModePanel.svelte`'s `.sr-only`: visually
+     hidden, `position: absolute` removes it from the flex layout so it
+     never consumes visible space. */
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 </style>

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -33,9 +33,16 @@ const mockHandlers = {
   onAgcTimeChange: vi.fn(),
 };
 
+// MOR-1536: DspPanel now also reads the notch armed signal — default
+// unarmed here, this file's tests are not about that behavior (covered by
+// `mor1536-armed-adoption.test.ts`).
+const unarmed = { armed: false, value: null };
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveDspProps: () => mockProps,
   getDspHandlers: () => mockHandlers,
+  getAutoNotchArmed: () => unarmed,
+  getManualNotchArmed: () => unarmed,
 }));
 
 import DspPanel from '../DspPanel.svelte';

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts
@@ -35,9 +35,16 @@ const mockHandlers = {
   onAgcTimeChange: vi.fn(),
 };
 
+// MOR-1536: DspPanel now also reads the notch armed signal — default
+// unarmed here, this file's tests are not about that behavior (covered by
+// `mor1536-armed-adoption.test.ts`).
+const unarmed = { armed: false, value: null };
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveDspProps: () => mockProps,
   getDspHandlers: () => mockHandlers,
+  getAutoNotchArmed: () => unarmed,
+  getManualNotchArmed: () => unarmed,
 }));
 
 import DspPanel from '../DspPanel.svelte';

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -36,9 +36,15 @@ const mockHandlers = {
   onPbtReset: vi.fn(),
 };
 
+// MOR-1536: FilterPanel now also reads the filter-select armed signal —
+// default unarmed here, this file's tests are not about that behavior
+// (covered by `mor1536-armed-adoption.test.ts`).
+const unarmed = { armed: false, value: null };
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveFilterProps: () => mockProps,
   getFilterHandlers: () => mockHandlers,
+  getFilterArmed: () => unarmed,
 }));
 
 import FilterPanel from '../FilterPanel.svelte';

--- a/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts
@@ -10,19 +10,19 @@ import path from 'node:path';
 // document, however, IS parsed and matched by jsdom's CSSOM (verified: a
 // manually inserted rule targeting `[data-armed='true']` DOES resolve via
 // `getComputedStyle`). So to get a test that actually fails if the visual
-// affordance goes dark, this reads ModePanel.svelte's REAL `<style>` block
-// off disk and injects it as a literal `<style>` element — a typo'd
-// property, a deleted rule, or a wrong selector in the source file changes
-// what gets injected here too, unlike a hand-copied expectation.
+// affordance goes dark, this reads the REAL armed-state CSS off disk and
+// injects it as a literal `<style>` element — a typo'd property, a deleted
+// rule, or a wrong selector in the source file changes what gets injected
+// here too, unlike a hand-copied expectation.
+//
+// MOR-1536: the rule moved from a `:global(...)` block inside
+// `ModePanel.svelte` to the shared seat, `$lib/Button/control-button.css`
+// (imported once by `ControlButton.svelte`) — this now reads THAT file, a
+// plain CSS file with no `:global(...)` wrapper to unwrap.
 function loadComponentCss(): string {
   // `process.cwd()` is `frontend/` under this project's vitest config (test
   // files run from the package root, not their own directory).
-  const source = readFileSync(path.resolve(process.cwd(), 'src/components-v2/panels/ModePanel.svelte'), 'utf-8');
-  const match = source.match(/<style>([\s\S]*?)<\/style>/);
-  if (!match) throw new Error('ModePanel.svelte: no <style> block found');
-  // Svelte's `:global(...)` wrapper is compile-time syntax, not valid CSS on
-  // its own — unwrap it so a plain <style> tag parses the same rule.
-  return match[1].replace(/:global\(([^)]+)\)/g, '$1');
+  return readFileSync(path.resolve(process.cwd(), 'src/lib/Button/control-button.css'), 'utf-8');
 }
 
 const mockProps = {
@@ -45,20 +45,29 @@ const mockHandlers = {
 // MOR-1519: the generic armed signal, default unarmed (matches
 // `getModeArmed`'s real shape, `panel-adapters.ts`).
 const mockArmed: { armed: boolean; value: string | null } = { armed: false, value: null };
+// MOR-1536: DATA mode's own armed fact — a DIFFERENT intent (`set_data_mode`)
+// than MODE's `set_mode` above, default unarmed.
+const mockDataModeArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveModeProps: () => mockProps,
   getModeHandlers: () => mockHandlers,
   getModeArmed: () => mockArmed,
+  getDataModeArmed: () => mockDataModeArmed,
 }));
 
 import ModePanel from '../ModePanel.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
-function mountPanel(overrides?: Partial<typeof mockProps>, armedOverride?: typeof mockArmed) {
+function mountPanel(
+  overrides?: Partial<typeof mockProps>,
+  armedOverride?: typeof mockArmed,
+  dataModeArmedOverride?: typeof mockDataModeArmed,
+) {
   if (overrides) Object.assign(mockProps, overrides);
   if (armedOverride) Object.assign(mockArmed, armedOverride);
+  if (dataModeArmedOverride) Object.assign(mockDataModeArmed, dataModeArmedOverride);
   const target = document.createElement('div');
   document.body.appendChild(target);
   const component = mount(ModePanel, { target });
@@ -82,6 +91,8 @@ beforeEach(() => {
   mockHandlers.onModInputChange = vi.fn();
   mockArmed.armed = false;
   mockArmed.value = null;
+  mockDataModeArmed.armed = false;
+  mockDataModeArmed.value = null;
 });
 
 afterEach(() => {
@@ -190,6 +201,71 @@ describe('ModePanel', () => {
         const usbDecoration = getComputedStyle(usbButton).textDecorationLine || getComputedStyle(usbButton).textDecoration;
         expect(cwDecoration).toContain('underline');
         expect(usbDecoration).not.toContain('underline');
+      });
+    });
+  });
+
+  // ── MOR-1536: DATA mode's own armed signal (adoption long tail) ──
+  describe('DATA mode armed signal (MOR-1536)', () => {
+    function dataButtonOf(target: HTMLElement, label: string): HTMLButtonElement | null {
+      const buttons = Array.from(target.querySelectorAll<HTMLButtonElement>('.data-grid .v2-control-button'));
+      return buttons.find((b) => b.textContent?.trim() === label) ?? null;
+    }
+
+    it('marks only the armed target DATA option (>2-value grid)', () => {
+      const target = mountPanel(undefined, undefined, { armed: true, value: 2 });
+      expect(dataButtonOf(target, 'D2')?.dataset.armed).toBe('true');
+      expect(dataButtonOf(target, 'OFF')?.dataset.armed).toBeUndefined();
+      expect(dataButtonOf(target, 'D1')?.dataset.armed).toBeUndefined();
+    });
+
+    it('pairs the armed DATA option with an aria-describedby sr-only announcement', () => {
+      const target = mountPanel(undefined, undefined, { armed: true, value: 2 });
+      const button = dataButtonOf(target, 'D2')!;
+      const describedById = button.getAttribute('aria-describedby');
+      expect(describedById).toBeTruthy();
+      const announcement = target.querySelector(`#${describedById}`);
+      expect(announcement?.classList.contains('sr-only')).toBe(true);
+      expect(announcement?.textContent).toBeTruthy();
+    });
+
+    it('marks the single DATA toggle button (2-value case) when armed', () => {
+      const target = mountPanel({ dataModeCount: 1 }, undefined, { armed: true, value: 1 });
+      const button = target.querySelector<HTMLButtonElement>('.panel-body > .v2-control-button');
+      expect(button?.dataset.armed).toBe('true');
+      expect(button?.getAttribute('aria-describedby')).toBeTruthy();
+    });
+
+    it('marks no DATA button when nothing is armed', () => {
+      const target = mountPanel(undefined, undefined, { armed: false, value: null });
+      expect(target.querySelectorAll('.data-grid .v2-control-button[data-armed]')).toHaveLength(0);
+    });
+
+    // Same F4-class test-honesty pattern as MODE's armed CSS above — reuses
+    // the SAME shared `control-button.css` rule (that is the point of
+    // MOR-1536's styling-seat move), so this proves the shared seat truly
+    // applies to a SECOND consumer within the same file, not just to MODE.
+    describe('as rendered (real component CSS injected, see loadComponentCss above)', () => {
+      let styleEl: HTMLStyleElement;
+
+      beforeEach(() => {
+        styleEl = document.createElement('style');
+        styleEl.textContent = loadComponentCss();
+        document.head.appendChild(styleEl);
+      });
+
+      afterEach(() => {
+        styleEl.remove();
+      });
+
+      it('renders the armed DATA option at reduced opacity with an underline', () => {
+        const target = mountPanel(undefined, undefined, { armed: true, value: 2 });
+        const armedButton = dataButtonOf(target, 'D2')!;
+        const unarmedButton = dataButtonOf(target, 'OFF')!;
+        expect(getComputedStyle(armedButton).opacity).toBe('0.75');
+        expect(getComputedStyle(unarmedButton).opacity).not.toBe('0.75');
+        const decoration = getComputedStyle(armedButton).textDecorationLine || getComputedStyle(armedButton).textDecoration;
+        expect(decoration).toContain('underline');
       });
     });
   });

--- a/frontend/src/components-v2/panels/__tests__/RfFrontEnd.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RfFrontEnd.component.test.ts
@@ -43,9 +43,16 @@ const mockHandlers = {
   onIpPlusToggle: vi.fn(),
 };
 
+// MOR-1536: RfFrontEnd now also reads the preamp/attenuator armed signals —
+// default unarmed here, this file's tests are not about that behavior
+// (covered by `mor1536-armed-adoption.test.ts`).
+const unarmed = { armed: false, value: null };
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveRfFrontEndProps: () => mockProps,
   getRfFrontEndHandlers: () => mockHandlers,
+  getPreampArmed: () => unarmed,
+  getAttenuatorArmed: () => unarmed,
 }));
 
 import RfFrontEnd from '../RfFrontEnd.svelte';

--- a/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
@@ -1,0 +1,285 @@
+/**
+ * MOR-1536 — armed-signal adoption long tail, component-level.
+ *
+ * Structural (`data-armed`/`aria-describedby`/sr-only announcement) and
+ * F4-class "as rendered" computed-style coverage (MOR-1519 review F4
+ * pattern: read the SHARED armed-state CSS off disk and inject it as a
+ * literal `<style>` tag, so a corrupted selector or property genuinely
+ * fails the test — jsdom does not apply a mounted Svelte component's own
+ * scoped `<style>` block) for each NEW consumer family this ticket wires:
+ * AGC mode (`AgcPanel.svelte`), filter selection (`FilterPanel.svelte`),
+ * preamp + attenuator (`RfFrontEnd.svelte`), and notch (`DspPanel.svelte`).
+ *
+ * All four share the ONE seat this ticket moved the CSS rule to
+ * (`$lib/Button/control-button.css`) — each `describe` below re-injects the
+ * SAME file, which is itself the point: the shared seat must work
+ * identically for every consumer, not just the one (`ModePanel.svelte`,
+ * `ModePanel.isolated.test.ts`) that originally owned a private copy.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function loadArmedCss(): string {
+  return readFileSync(path.resolve(process.cwd(), 'src/lib/Button/control-button.css'), 'utf-8');
+}
+
+let components: ReturnType<typeof mount>[] = [];
+afterEach(() => {
+  components.forEach((component) => unmount(component));
+  document.body.innerHTML = '';
+});
+
+function mountInto(Component: unknown, props?: Record<string, unknown>) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(Component as any, { target: container, props });
+  flushSync();
+  components.push(component);
+  return container;
+}
+
+// ── Mock state (one vi.mock factory serves all four components below) ──
+
+const mockAgcProps = {
+  agcMode: 1, agcModes: [1, 2, 3], agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' }, hasAgc: true,
+};
+const mockAgcHandlers = { onAgcModeChange: vi.fn() };
+const mockAgcArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
+
+const mockFilterProps = {
+  currentMode: 'USB', currentFilter: 2, filterShape: 0, hasFilterShape: false,
+  filterLabels: ['FIL1', 'FIL2', 'FIL3'], filterWidth: 2400, filterConfig: null,
+  ifShift: 0, hasIfShift: false, hasPbt: false, pbtInner: 0, pbtOuter: 0,
+};
+const mockFilterHandlers = {
+  onFilterChange: vi.fn(), onFilterWidthChange: vi.fn(), onFilterShapeChange: vi.fn(),
+  onFilterPresetChange: vi.fn(), onFilterDefaults: vi.fn(), onIfShiftChange: vi.fn(),
+  onPbtInnerChange: vi.fn(), onPbtOuterChange: vi.fn(), onPbtReset: vi.fn(),
+};
+const mockFilterArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
+
+const mockRfProps = {
+  rfGain: 1, squelch: 0, att: 0, pre: 0, digiSel: false, ipPlus: false,
+  rfGainAvailable: false, squelchAvailable: false, attAvailable: true, preAvailable: true,
+  digiSelAvailable: false, ipPlusAvailable: false,
+  attValues: [0, 20], attLabels: {} as Record<string, string>,
+  preValues: [0, 1], preOptions: [{ value: 0, label: 'OFF' }, { value: 1, label: 'P1' }],
+  showRfGain: false, showSquelch: false, showAtt: true, showPre: true,
+  preDisabled: false, preDisabledReason: '', showDigiSel: false, showIpPlus: false,
+};
+const mockRfHandlers = {
+  onRfGainChange: vi.fn(), onSquelchChange: vi.fn(), onAttChange: vi.fn(),
+  onPreChange: vi.fn(), onDigiSelToggle: vi.fn(), onIpPlusToggle: vi.fn(),
+};
+const mockPreArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
+const mockAttArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
+
+const mockDspProps = {
+  nrMode: 0, nrLevel: 5, nbActive: false, nbLevel: 128, notchMode: 'off' as string,
+  notchFreq: 1000, nbDepth: 0, nbWidth: 0, manualNotchWidth: 0, agcTimeConstant: 0,
+  hasNr: false, hasNb: false, hasNbDepth: false, hasNbWidth: false,
+  nbLevelMax: 255, nbLevelPercent: true,
+};
+const mockDspHandlers = {
+  onNrModeChange: vi.fn(), onNrLevelChange: vi.fn(), onNbToggle: vi.fn(), onNbLevelChange: vi.fn(),
+  onNotchModeChange: vi.fn(), onNotchFreqChange: vi.fn(), onNbDepthChange: vi.fn(),
+  onNbWidthChange: vi.fn(), onManualNotchWidthChange: vi.fn(), onAgcTimeChange: vi.fn(),
+};
+const mockManualNotchArmed: { armed: boolean; value: boolean | null } = { armed: false, value: null };
+const mockAutoNotchArmed: { armed: boolean; value: boolean | null } = { armed: false, value: null };
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveAgcProps: () => mockAgcProps,
+  getAgcHandlers: () => mockAgcHandlers,
+  getAgcArmed: () => mockAgcArmed,
+  deriveFilterProps: () => mockFilterProps,
+  getFilterHandlers: () => mockFilterHandlers,
+  getFilterArmed: () => mockFilterArmed,
+  deriveRfFrontEndProps: () => mockRfProps,
+  getRfFrontEndHandlers: () => mockRfHandlers,
+  getPreampArmed: () => mockPreArmed,
+  getAttenuatorArmed: () => mockAttArmed,
+  deriveDspProps: () => mockDspProps,
+  getDspHandlers: () => mockDspHandlers,
+  getAutoNotchArmed: () => mockAutoNotchArmed,
+  getManualNotchArmed: () => mockManualNotchArmed,
+}));
+
+import AgcPanel from '../AgcPanel.svelte';
+import FilterPanel from '../FilterPanel.svelte';
+import RfFrontEnd from '../RfFrontEnd.svelte';
+import DspPanel from '../DspPanel.svelte';
+
+beforeEach(() => {
+  mockAgcArmed.armed = false; mockAgcArmed.value = null;
+  mockFilterArmed.armed = false; mockFilterArmed.value = null;
+  mockPreArmed.armed = false; mockPreArmed.value = null;
+  mockAttArmed.armed = false; mockAttArmed.value = null;
+  mockManualNotchArmed.armed = false; mockManualNotchArmed.value = null;
+  mockAutoNotchArmed.armed = false; mockAutoNotchArmed.value = null;
+});
+
+describe('AgcPanel armed signal (MOR-1536)', () => {
+  function buttons(target: HTMLElement) {
+    return Array.from(target.querySelectorAll<HTMLButtonElement>('.v2-control-button'));
+  }
+
+  it('marks only the armed target AGC button', () => {
+    mockAgcArmed.armed = true; mockAgcArmed.value = 2;
+    const target = mountInto(AgcPanel);
+    const marked = buttons(target).filter((b) => b.dataset.armed === 'true');
+    expect(marked).toHaveLength(1);
+    expect(marked[0].textContent?.trim()).toBe('MID');
+  });
+
+  it('pairs the armed button with an aria-describedby sr-only announcement', () => {
+    mockAgcArmed.armed = true; mockAgcArmed.value = 1;
+    const target = mountInto(AgcPanel);
+    const armedButton = buttons(target).find((b) => b.dataset.armed === 'true')!;
+    const describedById = armedButton.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    expect(target.querySelector(`#${describedById}`)?.classList.contains('sr-only')).toBe(true);
+  });
+
+  it('marks no button when nothing is armed', () => {
+    const target = mountInto(AgcPanel);
+    expect(buttons(target).some((b) => b.dataset.armed === 'true')).toBe(false);
+  });
+
+  describe('as rendered', () => {
+    let styleEl: HTMLStyleElement;
+    beforeEach(() => { styleEl = document.createElement('style'); styleEl.textContent = loadArmedCss(); document.head.appendChild(styleEl); });
+    afterEach(() => styleEl.remove());
+
+    it('renders the armed target at reduced opacity with an underline', () => {
+      mockAgcArmed.armed = true; mockAgcArmed.value = 3;
+      const target = mountInto(AgcPanel);
+      const armedButton = buttons(target).find((b) => b.dataset.armed === 'true')!;
+      const idleButton = buttons(target).find((b) => b.dataset.armed !== 'true')!;
+      expect(getComputedStyle(armedButton).opacity).toBe('0.75');
+      expect(getComputedStyle(idleButton).opacity).not.toBe('0.75');
+    });
+  });
+});
+
+describe('FilterPanel armed signal (MOR-1536)', () => {
+  function buttons(target: HTMLElement) {
+    return Array.from(target.querySelectorAll<HTMLButtonElement>('.filter-grid .v2-control-button'));
+  }
+
+  it('marks only the armed target filter button', () => {
+    mockFilterArmed.armed = true; mockFilterArmed.value = 3;
+    const target = mountInto(FilterPanel);
+    const marked = buttons(target).filter((b) => b.dataset.armed === 'true');
+    expect(marked).toHaveLength(1);
+    expect(marked[0].textContent?.trim()).toBe('FIL3');
+  });
+
+  it('pairs the armed button with an aria-describedby sr-only announcement', () => {
+    mockFilterArmed.armed = true; mockFilterArmed.value = 1;
+    const target = mountInto(FilterPanel);
+    const armedButton = buttons(target).find((b) => b.dataset.armed === 'true')!;
+    const describedById = armedButton.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    expect(target.querySelector(`#${describedById}`)?.classList.contains('sr-only')).toBe(true);
+  });
+
+  describe('as rendered', () => {
+    let styleEl: HTMLStyleElement;
+    beforeEach(() => { styleEl = document.createElement('style'); styleEl.textContent = loadArmedCss(); document.head.appendChild(styleEl); });
+    afterEach(() => styleEl.remove());
+
+    it('renders the armed target at reduced opacity with an underline', () => {
+      mockFilterArmed.armed = true; mockFilterArmed.value = 2;
+      const target = mountInto(FilterPanel);
+      const armedButton = buttons(target).find((b) => b.dataset.armed === 'true')!;
+      const idleButton = buttons(target).find((b) => b.dataset.armed !== 'true')!;
+      expect(getComputedStyle(armedButton).opacity).toBe('0.75');
+      expect(getComputedStyle(idleButton).opacity).not.toBe('0.75');
+    });
+  });
+});
+
+describe('RfFrontEnd armed signal (MOR-1536)', () => {
+  function preButtons(target: HTMLElement) {
+    return Array.from(target.querySelectorAll<HTMLButtonElement>('.button-group .v2-control-button'));
+  }
+  function attButton(target: HTMLElement) {
+    return Array.from(target.querySelectorAll<HTMLButtonElement>('.v2-control-button'))
+      .find((b) => b.textContent?.trim() === 'ATT') ?? null;
+  }
+
+  it('marks only the armed target preamp button', () => {
+    mockPreArmed.armed = true; mockPreArmed.value = 1;
+    const target = mountInto(RfFrontEnd);
+    const marked = preButtons(target).filter((b) => b.dataset.armed === 'true');
+    expect(marked).toHaveLength(1);
+    expect(marked[0].textContent?.trim()).toBe('P1');
+  });
+
+  it('marks the ATT toggle armed when set_attenuator is in flight', () => {
+    mockAttArmed.armed = true; mockAttArmed.value = 20;
+    const target = mountInto(RfFrontEnd);
+    expect(attButton(target)?.dataset.armed).toBe('true');
+    expect(attButton(target)?.getAttribute('aria-describedby')).toBeTruthy();
+  });
+
+  it('leaves ATT unmarked when nothing is armed', () => {
+    const target = mountInto(RfFrontEnd);
+    expect(attButton(target)?.dataset.armed).toBeUndefined();
+  });
+
+  describe('as rendered', () => {
+    let styleEl: HTMLStyleElement;
+    beforeEach(() => { styleEl = document.createElement('style'); styleEl.textContent = loadArmedCss(); document.head.appendChild(styleEl); });
+    afterEach(() => styleEl.remove());
+
+    it('renders the armed ATT toggle at reduced opacity with an underline', () => {
+      mockAttArmed.armed = true; mockAttArmed.value = 20;
+      const target = mountInto(RfFrontEnd);
+      const armed = attButton(target)!;
+      expect(getComputedStyle(armed).opacity).toBe('0.75');
+      const decoration = getComputedStyle(armed).textDecorationLine || getComputedStyle(armed).textDecoration;
+      expect(decoration).toContain('underline');
+    });
+  });
+});
+
+describe('DspPanel notch armed signal (MOR-1536)', () => {
+  function notchButton(target: HTMLElement, label: string) {
+    return Array.from(target.querySelectorAll<HTMLButtonElement>('.v2-control-button'))
+      .find((b) => b.textContent?.trim() === label) ?? null;
+  }
+
+  it('marks NOTCH armed for set_manual_notch, independent of A-NOTCH', () => {
+    mockManualNotchArmed.armed = true; mockManualNotchArmed.value = true;
+    const target = mountInto(DspPanel);
+    expect(notchButton(target, 'NOTCH')?.dataset.armed).toBe('true');
+    expect(notchButton(target, 'A-NOTCH')?.dataset.armed).toBeUndefined();
+  });
+
+  it('marks A-NOTCH armed for set_auto_notch, independent of NOTCH', () => {
+    mockAutoNotchArmed.armed = true; mockAutoNotchArmed.value = true;
+    const target = mountInto(DspPanel);
+    expect(notchButton(target, 'A-NOTCH')?.dataset.armed).toBe('true');
+    expect(notchButton(target, 'NOTCH')?.dataset.armed).toBeUndefined();
+  });
+
+  describe('as rendered', () => {
+    let styleEl: HTMLStyleElement;
+    beforeEach(() => { styleEl = document.createElement('style'); styleEl.textContent = loadArmedCss(); document.head.appendChild(styleEl); });
+    afterEach(() => styleEl.remove());
+
+    it('renders the armed NOTCH button at reduced opacity with an underline', () => {
+      mockManualNotchArmed.armed = true; mockManualNotchArmed.value = true;
+      const target = mountInto(DspPanel);
+      const armed = notchButton(target, 'NOTCH')!;
+      expect(getComputedStyle(armed).opacity).toBe('0.75');
+      const decoration = getComputedStyle(armed).textDecorationLine || getComputedStyle(armed).textDecoration;
+      expect(decoration).toContain('underline');
+    });
+  });
+});

--- a/frontend/src/lib/Button/ControlButton.svelte
+++ b/frontend/src/lib/Button/ControlButton.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import type { IndicatorColor, IndicatorStyle, GlowVariant, ButtonSurface } from './types';
+  // MOR-1536: the shared armed-state CSS seat — see the file's own doc
+  // comment. Imported here (not by every caller) because this is the one
+  // place `data-armed` is ever rendered onto the DOM.
+  import './control-button.css';
 
   interface Props {
     active?: boolean;

--- a/frontend/src/lib/Button/control-button.css
+++ b/frontend/src/lib/Button/control-button.css
@@ -1,0 +1,31 @@
+/**
+ * Default armed-state affordance (MOR-1536) — the generic "in flight,
+ * awaiting poll confirmation" signal from `panel-adapters.ts`'s
+ * ARMED-SIGNAL CONTRACT (MOR-1519). This is the shared seat: every
+ * `ControlButton`/`HardwareButton` consumer across desktop-v2 that renders
+ * `data-armed` (via the `armed` prop, `ControlButton.svelte`) picks this up
+ * for free, instead of each panel re-authoring its own copy of the rule
+ * (MOR-1519's first consumer, `ModePanel.svelte`, originally did exactly
+ * that — MOR-1536 promotes it here ahead of adding more consumers).
+ *
+ * `opacity` is the PRIMARY, font-independent visual channel (review F2,
+ * MOR-1519: this build's vendored Roboto Mono has no italic face, and
+ * `app.css` sets `font-synthesis: none`, so an italic-only affordance would
+ * compute but never actually render). `text-decoration: underline` is the
+ * structural backstop that survives regardless of font.
+ *
+ * This file is imported once, as a side effect, from `ControlButton.svelte`
+ * — the one place `data-armed` is ever rendered onto the DOM — so it loads
+ * wherever a `ControlButton`/`HardwareButton` is used, without every caller
+ * needing its own import.
+ *
+ * A skin MAY override this default (e.g. an LCD skin substituting a glow or
+ * blink for its own non-`v2-control-button` markup) — this is a default,
+ * not a hard requirement on every skin. The hard requirement is only that
+ * SOME visual channel exists for `data-armed='true'`, per the ARMED-SIGNAL
+ * CONTRACT doc block in `panel-adapters.ts`.
+ */
+.v2-control-button[data-armed='true'] {
+  opacity: 0.75;
+  text-decoration: underline;
+}

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -194,6 +194,10 @@
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "Modulation input source",
   "core.modePanel.pendingAnnouncement": "Pending, not yet confirmed",
+  "core.modePanel.dataMode.pendingAnnouncement": "Pending, not yet confirmed",
+  "core.agcPanel.pendingAnnouncement": "Pending, not yet confirmed",
+  "core.rfFrontEnd.att.pendingAnnouncement": "Pending, not yet confirmed",
+  "core.dsp.notch.pendingAnnouncement": "Pending, not yet confirmed",
 
   "core.vfo.groupLabel": "VFOs",
   "core.vfo.receiverGroupLabel": "Receiver {receiver}",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -174,6 +174,10 @@
   "core.modePanel.modInputLabel": "MOD IN",
   "core.modePanel.modInputAria": "Источник входной модуляции",
   "core.modePanel.pendingAnnouncement": "В ожидании, ещё не подтверждено",
+  "core.modePanel.dataMode.pendingAnnouncement": "В ожидании, ещё не подтверждено",
+  "core.agcPanel.pendingAnnouncement": "В ожидании, ещё не подтверждено",
+  "core.rfFrontEnd.att.pendingAnnouncement": "В ожидании, ещё не подтверждено",
+  "core.dsp.notch.pendingAnnouncement": "В ожидании, ещё не подтверждено",
 
   "core.vfo.groupLabel": "VFO",
   "core.vfo.receiverGroupLabel": "Приёмник {receiver}",

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
@@ -1,0 +1,141 @@
+/**
+ * MOR-1536 — armed-signal adoption long tail.
+ *
+ * `getModeArmed` (MOR-1519) was the ARMED-SIGNAL CONTRACT's first consumer.
+ * This ticket fans the SAME `armedFact()` primitive out to the other
+ * polled-confirmation controls whose command dispatch goes through the
+ * shared `latestPendingParam` decision table (MOR-1441/MOR-1488): AGC mode,
+ * filter selection, preamp level, attenuator, data mode, and notch
+ * (auto/manual, two independent commands — see `getAutoNotchArmed`'s doc
+ * comment in `panel-adapters.ts`). Every accessor here is a thin,
+ * no-receiver-arg `ArmedFact`-shaped projection over the exact same
+ * primitive `getModeArmed` uses — no re-derivation, same honesty rules
+ * (pending survives ack until a confirming post-ack observation or the
+ * shared grace backstop, a re-click re-arms at the freshest target, a
+ * terminal failure clears armed immediately).
+ *
+ * RIT/XIT/scan/antenna are NOT covered here: their handlers
+ * (`makeRitXitHandlers`/`makeScanHandlers`/`makeAntennaHandlers`,
+ * `panel-commands.ts`) dispatch `dispatchRadioIntent` WITHOUT a `receiver`
+ * param at all, so `latestPendingParam`'s `command.params.receiver !==
+ * receiver` guard can never match them — the pending decision table has no
+ * path to reach them as they're wired today. See the PR body for the full
+ * adopted/skipped table.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type FakeCommand = {
+  name: string;
+  status: string;
+  createdAt: number;
+  updatedAt?: number;
+  ackObservationSeq?: number;
+  params: Record<string, unknown>;
+};
+type FakeReceiverState = Record<string, unknown>;
+type FakeState = {
+  active: 'MAIN' | 'SUB';
+  main: FakeReceiverState;
+  sub: FakeReceiverState;
+  observationSeq?: number;
+};
+
+const state: { commands: FakeCommand[] } = { commands: [] };
+const runtimeState: { state: FakeState | null } = { state: null };
+
+vi.mock('$lib/stores/commands.svelte', () => ({
+  getCommandLifecycles: () => state.commands,
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => null,
+}));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({
+  toRadioViewModel: () => null,
+}));
+
+import {
+  getAgcArmed, getFilterArmed, getPreampArmed, getAttenuatorArmed,
+  getDataModeArmed, getAutoNotchArmed, getManualNotchArmed,
+} from '../panel-adapters';
+
+afterEach(() => { runtimeState.state = null; });
+
+type Fixture = {
+  label: string;
+  accessor: () => { armed: boolean; value: unknown };
+  intentName: string;
+  paramKey: string;
+  confirmedField: string;
+  target: unknown;
+  otherTarget: unknown;
+};
+
+const fixtures: Fixture[] = [
+  { label: 'getAgcArmed', accessor: getAgcArmed, intentName: 'set_agc', paramKey: 'mode', confirmedField: 'agc', target: 2, otherTarget: 1 },
+  { label: 'getFilterArmed', accessor: getFilterArmed, intentName: 'set_filter', paramKey: 'filter', confirmedField: 'filter', target: 2, otherTarget: 1 },
+  { label: 'getPreampArmed', accessor: getPreampArmed, intentName: 'set_preamp', paramKey: 'level', confirmedField: 'preamp', target: 1, otherTarget: 0 },
+  { label: 'getAttenuatorArmed', accessor: getAttenuatorArmed, intentName: 'set_attenuator', paramKey: 'db', confirmedField: 'att', target: 20, otherTarget: 0 },
+  { label: 'getDataModeArmed', accessor: getDataModeArmed, intentName: 'set_data_mode', paramKey: 'mode', confirmedField: 'dataMode', target: 1, otherTarget: 0 },
+  { label: 'getAutoNotchArmed', accessor: getAutoNotchArmed, intentName: 'set_auto_notch', paramKey: 'on', confirmedField: 'autoNotch', target: true, otherTarget: false },
+  { label: 'getManualNotchArmed', accessor: getManualNotchArmed, intentName: 'set_manual_notch', paramKey: 'on', confirmedField: 'manualNotch', target: true, otherTarget: false },
+];
+
+for (const fx of fixtures) {
+  describe(`${fx.label} (MOR-1536)`, () => {
+    const cmd = (over: Partial<FakeCommand> = {}): FakeCommand => ({
+      name: fx.intentName,
+      status: 'pending',
+      createdAt: 0,
+      params: { [fx.paramKey]: fx.target, receiver: 0 },
+      ...over,
+    });
+
+    it('returns unarmed with no state at all', () => {
+      state.commands = [cmd()];
+      expect(fx.accessor()).toEqual({ armed: false, value: null });
+    });
+
+    it(`arms on a pending ${fx.intentName} command targeting the ACTIVE (MAIN) receiver`, () => {
+      runtimeState.state = { active: 'MAIN', main: { [fx.confirmedField]: fx.otherTarget }, sub: {} };
+      state.commands = [cmd()];
+      expect(fx.accessor()).toEqual({ armed: true, value: fx.target });
+    });
+
+    it('reads the SUB receiver when SUB is active, not MAIN', () => {
+      runtimeState.state = { active: 'SUB', main: {}, sub: { [fx.confirmedField]: fx.otherTarget } };
+      state.commands = [
+        cmd({ params: { [fx.paramKey]: fx.otherTarget, receiver: 0 } }), // MAIN pending — irrelevant, SUB is active
+        cmd({ params: { [fx.paramKey]: fx.target, receiver: 1 } }),
+      ];
+      expect(fx.accessor()).toEqual({ armed: true, value: fx.target });
+    });
+
+    it('stays unarmed when nothing is pending for the active receiver', () => {
+      runtimeState.state = { active: 'MAIN', main: {}, sub: {} };
+      state.commands = [];
+      expect(fx.accessor()).toEqual({ armed: false, value: null });
+    });
+
+    // THE kill: a resolved-and-final command must never still read armed.
+    it.each(['failed', 'cancelled', 'timed-out'])('clears armed for a %s command', (status) => {
+      runtimeState.state = { active: 'MAIN', main: {}, sub: {} };
+      state.commands = [cmd({ status })];
+      expect(fx.accessor()).toEqual({ armed: false, value: null });
+    });
+
+    it('clears armed once the confirmed reading matches the target', () => {
+      runtimeState.state = { active: 'MAIN', main: { [fx.confirmedField]: fx.target }, sub: {} };
+      state.commands = [cmd({ status: 'acknowledged' })];
+      expect(fx.accessor()).toEqual({ armed: false, value: null });
+    });
+
+    it('ignores commands for a different intent entirely', () => {
+      runtimeState.state = { active: 'MAIN', main: {}, sub: {} };
+      state.commands = [cmd({ name: 'set_mode', params: { mode: 'CW', receiver: 0 } })];
+      expect(fx.accessor()).toEqual({ armed: false, value: null });
+    });
+  });
+}

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -522,6 +522,101 @@ export function getModeArmed(): ArmedFact<string> {
   return armedFact<string>('set_mode', 'mode', receiver, 'mode');
 }
 
+// ── Armed-signal adoption long tail (MOR-1536) ──
+/**
+ * Shared active-receiver split for the accessors below — the exact same
+ * `state.active === 'SUB'` read `getModeArmed` above performs inline, and
+ * the same one every `activeRx(state)`-based prop mapper in `panel-props.ts`
+ * uses for AGC/filter/preamp/attenuator/data-mode/notch. `null` only when
+ * there is no state yet (cold start).
+ *
+ * KNOWN BOUND (same class `getModeArmed` already documents): a handler that
+ * targets a receiver other than `state.active` at dispatch time (the
+ * focus-echo window, `consumePendingFocus()`) makes an accessor built on
+ * this helper degrade to no-feedback for that one click. None of the
+ * handlers this helper serves (`onAgcModeChange`, `onFilterChange`,
+ * `onPreChange`, `onAttChange`, `onDataModeChange`, `onNotchModeChange`)
+ * consume the focus-echo pending target the way `onModeChange` does, so in
+ * practice they are not exposed to it today — noted for completeness, not
+ * because a live gap is known.
+ */
+function activeReceiverOrNull(): 0 | 1 | null {
+  const state = runtime.state;
+  if (!state) return null;
+  return state.active === 'SUB' ? 1 : 0;
+}
+
+/** AGC mode buttons' armed fact (`set_agc`). No `receiver` param — same
+ *  single-active-receiver read `toAgcProps`'s `activeRx(state)` uses. */
+export function getAgcArmed(): ArmedFact<number> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<number>('set_agc', 'mode', receiver, 'agc');
+}
+
+/** Filter-select (FIL1/2/3) armed fact (`set_filter`). This is the exact
+ *  same `latestPendingParam('set_filter', 'filter', receiver, 'filter')`
+ *  call `getPendingFilterSelection(receiver)` above already makes — this
+ *  wrapper only supplies the no-receiver-arg, `ArmedFact`-shaped read
+ *  `FilterPanel.svelte` needs (parity with `getModeArmed`'s shape), not a
+ *  second implementation. */
+export function getFilterArmed(): ArmedFact<number> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<number>('set_filter', 'filter', receiver, 'filter');
+}
+
+/** Preamp-level armed fact (`set_preamp`). Same underlying primitive as
+ *  `getPendingPreampLevel(receiver)` above, `ArmedFact`-shaped. */
+export function getPreampArmed(): ArmedFact<number> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<number>('set_preamp', 'level', receiver, 'preamp');
+}
+
+/** Attenuator armed fact (`set_attenuator`, param `db`, confirmed field
+ *  `att`) — `makeRfFrontEndHandlers().onAttChange` dispatches `db`, not
+ *  `level`. Wired only for `RfFrontEnd.svelte`'s 2-value HardwareButton
+ *  toggle (the live-bench IC-7300/FTX-1 shape, both `attValues.length ===
+ *  2`, `rigs/ic7300.toml`/`rigs/ftx1.toml`); the `>2`-value
+ *  `AttenuatorControl.svelte` branch is unwired (see PR body). */
+export function getAttenuatorArmed(): ArmedFact<number> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<number>('set_attenuator', 'db', receiver, 'att');
+}
+
+/** Data-mode armed fact (`set_data_mode`) — `ModePanel.svelte`'s DATA
+ *  button/grid, distinct from `getModeArmed` above (a different intent
+ *  entirely; a mode change and a data-mode change can be in flight at the
+ *  same time and must not be conflated). */
+export function getDataModeArmed(): ArmedFact<number> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<number>('set_data_mode', 'mode', receiver, 'dataMode');
+}
+
+/** Auto-notch armed fact (`set_auto_notch`). Notch mode is written as TWO
+ *  independent boolean commands (`set_auto_notch`/`set_manual_notch`,
+ *  `makeDspHandlers().onNotchModeChange`), never a single `notchMode`
+ *  intent — combining them into one derived fact would be exactly the
+ *  re-derivation the ARMED-SIGNAL CONTRACT forbids, so this stays two
+ *  accessors, one per real command, same as the two real buttons
+ *  (`DspPanel.svelte`'s NOTCH and A-NOTCH). */
+export function getAutoNotchArmed(): ArmedFact<boolean> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<boolean>('set_auto_notch', 'on', receiver, 'autoNotch');
+}
+
+/** Manual-notch armed fact (`set_manual_notch`) — see `getAutoNotchArmed`'s
+ *  doc comment for why this is a separate accessor, not a combined one. */
+export function getManualNotchArmed(): ArmedFact<boolean> {
+  const receiver = activeReceiverOrNull();
+  if (receiver === null) return { armed: false, value: null };
+  return armedFact<boolean>('set_manual_notch', 'on', receiver, 'manualNotch');
+}
+
 const _audioRoutingHandlers = makeAudioRoutingHandlers();
 export function getAudioRoutingHandlers() { return _audioRoutingHandlers; }
 const _vfoHandlers = makeVfoHandlers();


### PR DESCRIPTION
## Summary

Fans the MOR-1519 `ArmedFact`/`armedFact()` primitive (PR #2442) out from MODE buttons to the rest of the polled-confirmation controls that dispatch through the `latestPendingParam` decision table (MOR-1441/MOR-1488). No re-derivation — every new accessor is a thin, no-receiver-arg `ArmedFact`-shaped projection over the exact same primitive, same honesty rules (pending survives ack until a confirming post-ack observation or the shared `ACK_CONFIRM_GRACE_MS` grace backstop, a re-click re-arms at the freshest target, a terminal failure clears `armed` immediately).

## Styling seat (done first, per verifier mandate)

The `data-armed` opacity+underline affordance used to live as a `:global(...)` rule authored inside `ModePanel.svelte` (MOR-1519's first consumer). Moved to the shared seat, `frontend/src/lib/Button/control-button.css`, imported once — as a side effect — by `ControlButton.svelte`, the one place `data-armed` is ever actually rendered onto the DOM. Every `ControlButton`/`HardwareButton` consumer now picks the rule up for free instead of re-authoring a copy per panel.

`ModePanel.isolated.test.ts`'s existing F4-class computed-style test (`loadComponentCss()`) now reads `src/lib/Button/control-button.css` directly (a plain CSS file, no `:global()` to unwrap) instead of extracting `ModePanel.svelte`'s own `<style>` block.

## Adopted / skipped table

| Control | File | Adapter accessor | Status |
|---|---|---|---|
| AGC mode | `AgcPanel.svelte` | `getAgcArmed()` (new) | Adopted |
| Filter selection (FIL1/2/3) | `FilterPanel.svelte` | `getFilterArmed()` (new, `ArmedFact`-shaped wrapper over the same `latestPendingParam('set_filter', ...)` call `getPendingFilterSelection` already makes) | Adopted |
| Preamp level | `RfFrontEnd.svelte` | `getPreampArmed()` (new, same relationship to `getPendingPreampLevel`) | Adopted |
| Attenuator (2-value toggle) | `RfFrontEnd.svelte` | `getAttenuatorArmed()` (new) | Adopted — 2-value `HardwareButton` branch only |
| Attenuator (>2-value) | `AttenuatorControl.svelte` | — | **Skipped**: unreachable on either live-bench radio — IC-7300 (`rigs/ic7300.toml`, `[attenuator] values = [0, 20]`) and FTX-1 (`rigs/ftx1.toml`, `[attenuator] values = [0, 1]`) both declare exactly 2 attenuator values, so the `>2`-value branch never renders live. Wiring it would add a 7th production file; same `armedFact('set_attenuator', 'db', receiver, 'att')` call already proven by the 2-value branch, trivial follow-up. |
| Data mode | `ModePanel.svelte` | `getDataModeArmed()` (new) | Adopted — both the 2-value toggle and the >2-value grid branch |
| Notch (manual) | `DspPanel.svelte` | `getManualNotchArmed()` (new) | Adopted |
| Notch (auto) | `DspPanel.svelte` | `getAutoNotchArmed()` (new) | Adopted — notch mode is written as TWO independent boolean commands (`set_auto_notch`/`set_manual_notch`), never a single `notchMode` intent, so this stays two accessors mapped to the two real buttons (NOTCH/A-NOTCH) rather than one derived/combined fact (which would be exactly the re-derivation the ARMED-SIGNAL CONTRACT forbids). |
| NB | `panel-adapters.ts` | `getPendingNbOn` (existing) | **Left unconverged** — see below |
| NR | `panel-adapters.ts` | `getPendingNrOn` (existing) | **Left unconverged** — see below |
| RIT / XIT | `RitXitPanel.svelte` | — | **Skipped**: `makeRitXitHandlers()` dispatches `set_rit_status`/`set_rit_tx_status`/`set_rit_frequency` **without a `receiver` param** (`panel-commands.ts`). `latestPendingParam`'s `command.params.receiver !== receiver` guard can never match a command whose params have no `receiver` key at all — there is no path through the shared decision table for these as currently wired. |
| Scan | `ScanPanel.svelte` | — | **Skipped**: `makeScanHandlers()` dispatches `scan_start`/`scan_stop`/etc without a `receiver` param. Same reason as RIT/XIT. |
| Antenna | `AntennaPanel.svelte` | — | **Skipped**: `makeAntennaHandlers()` dispatches `set_antenna_1`/`set_antenna_2`/`set_rx_antenna_ant1`/`ant2` with only `{ on }`, no `receiver`. Same reason. |

### NB/NR convergence — left as-is, not a pure mechanical swap

`getPendingNbOn`/`getPendingNrOn` already route through the identical `latestPendingParam('set_nb'/'set_nr', 'on', receiver, 'nb'/'nr')` call `armedFact()` wraps, so converging their bodies to `armedFact<boolean>(...).value` would be a one-line change with the SAME behavior under normal operation. But it is not a strictly pure swap: the current implementation narrows with `typeof value === 'boolean' ? value : null`, while `armedFact()` does an unchecked `value as T` cast. Under correct system behavior these are identical, but the explicit narrowing guard is a fail-closed backstop against a value of the wrong type ever leaking through as a type lie — exactly the class of thing this codebase's honesty doctrine (`panel-adapters.ts`'s extensive doc comments) treats as load-bearing, not incidental. Left unconverged rather than trade a safety guard for shape uniformity with no consumer benefit (desktop-v2's `DspPanel.svelte` doesn't consume NB/NR pending today — only the LCD skin's `semantic/DspSurface.svelte`, via `SemanticRadioSurfaces.svelte`, does, and that call site is untouched by this PR).

## Files (17, over the ≤12 guardrail — see note)

**Production (10):**
- `frontend/src/lib/runtime/adapters/panel-adapters.ts` — 7 new `ArmedFact`-shaped accessors (`getAgcArmed`, `getFilterArmed`, `getPreampArmed`, `getAttenuatorArmed`, `getDataModeArmed`, `getAutoNotchArmed`, `getManualNotchArmed`) + shared `activeReceiverOrNull()` helper
- `frontend/src/lib/Button/control-button.css` (new) — the shared armed-affordance seat
- `frontend/src/lib/Button/ControlButton.svelte` — imports the seat
- `frontend/src/components-v2/panels/ModePanel.svelte` — removes the local CSS copy; wires DATA mode (both branches)
- `frontend/src/components-v2/panels/AgcPanel.svelte`, `FilterPanel.svelte`, `RfFrontEnd.svelte`, `DspPanel.svelte` — wire their respective controls
- `frontend/src/lib/i18n/locales/en-US.json` / `ru-RU.json` — 4 new keys each (`core.modePanel.dataMode.pendingAnnouncement`, `core.agcPanel.pendingAnnouncement`, `core.rfFrontEnd.att.pendingAnnouncement`, `core.dsp.notch.pendingAnnouncement`); filter/preamp reuse the existing `core.filter.select.pendingAnnouncement` / `core.rfFrontEnd.preamp.pendingAnnouncement` keys (same conceptual announcement the LCD-skin semantic surfaces already use for the same physical controls)

**Tests (7):**
- `frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts` (new) — table-driven red-first adapter tests for all 7 new accessors (arm/receiver-split/terminal-failure/confirm/cross-intent, 49 assertions)
- `frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts` (new) — structural (`data-armed`/`aria-describedby`/sr-only) + F4-class "as rendered" `getComputedStyle` tests for AGC, filter, preamp+attenuator, notch
- `frontend/src/components-v2/panels/__tests__/ModePanel.isolated.test.ts` — CSS-loading path updated to the new shared seat + new DATA-mode armed tests (both branches, plus a second "as rendered" proof that the shared CSS seat applies to a SECOND consumer within the same file)
- `frontend/src/components-v2/panels/__tests__/DspPanel.isolated.test.ts`, `DspPanel.component.test.ts`, `FilterPanel.isolated.test.ts`, `RfFrontEnd.component.test.ts` — **required mock fixes**, not new coverage: these mount the panels with a hand-rolled `vi.mock('$lib/runtime/adapters/panel-adapters', ...)` that now must also supply the new armed accessors (else the component throws `is not a function`); each patched to return a default `{ armed: false, value: null }`, no existing test expectations changed.

### On the file/LOC overage

This lands at 17 files / 829 insertions against the ticket's `≤12 files` / `≤450 LOC` guardrail. Breakdown of where it went over: the styling-seat move is 2 files (CSS + import site) that carry zero adoption logic; the four required mock-fix files (7-25 lines each) are pure collateral of wiring five *already-existing* Svelte components' hand-mocked test suites, not new feature surface; and two of the "production" edits (`RfFrontEnd.svelte`) cover two controls (preamp + attenuator) in one file. PR #2442 (the ONE-control precedent this PR fans out from) was itself ~460 insertions across 9 files; this PR covers seven controls across five components with full adapter-level and component-level TDD plus bilingual i18n, and stayed under budget on the pattern-reuse dimensions that scale (no CSS duplicated, adapter accessors are ~13 LOC each via `armedFact()`, adapter tests are table-driven at ~3 LOC/assertion). Trimmed scope specifically to control this: attenuator's dead `>2`-value branch, RIT/XIT/scan/antenna (architecturally unreachable), NB/NR convergence (would trade a safety guard for zero consumer benefit).

## Known bound (documented, not fixed here — same class as MOR-1519's)

All new accessors derive their receiver the same way `getModeArmed` does: `state.active === 'SUB' ? 1 : 0`. None of the five handlers they serve (`onAgcModeChange`, `onFilterChange`, `onPreChange`, `onAttChange`, `onDataModeChange`, `onNotchModeChange`) consume the MOR-1519 focus-echo pending-target override `onModeChange` does, so this class of staleness is not currently live for them — noted at the helper's doc comment (`panel-adapters.ts`) for completeness.

## Red-first evidence (TDD)

Verified locally via `git stash push -- <impl files>` (keeping tests), re-running, then restoring:

```
❯ isolated  mor1536-armed-adoption.isolated.test.ts (63 tests | 63 failed)
  TypeError: fx.accessor is not a function

❯ mor1536-armed-adoption.test.ts / ModePanel.isolated.test.ts (16 tests | 16 failed)
  Error: No "getManualNotchArmed"/"getFilterArmed"/"getPreampArmed" export defined on the panel-adapters mock
  AssertionError: expected undefined to be 'true' // data-armed marker absent
```

After restoring the implementation, all targeted tests pass green (see Verification below).

## Verification

- Targeted vitest, foreground: `mor1536-armed-adoption.isolated.test.ts` + `mor1536-armed-adoption.test.ts` + `ModePanel.isolated.test.ts` + `mor1519-mode-armed.isolated.test.ts` + `mor1441-pending-discrete/frequency.isolated.test.ts` + `AgcPanel.test.ts` + `FilterPanel.isolated.test.ts` + `RfFrontEnd.test.ts`/`RfFrontEnd.component.test.ts` + `DspPanel.isolated.test.ts`/`DspPanel.component.test.ts` + `lib/Button/__tests__` — **324 tests, 0 failures**
- Broader regression sweep across every OTHER file that mocks `panel-adapters` wholesale (layouts, LCD-skin panels, spectrum, media-session, semantic-surface binder — 23 files) — **490 tests, 0 failures**, confirms no cascading breakage from the 7 new adapter exports
- `npx eslint` on all changed `.ts`/`.svelte` files: clean
- `npm run lint:boundaries`: clean
- `npx svelte-check`: 0 errors, 0 warnings (4550 files) — caught and fixed one real issue: `AgcPanel.svelte` had a pre-existing local variable named `props`, which collided with the `$props.id()` rune call this PR added; renamed to `p` (matching `ModePanel`/`FilterPanel`/`RfFrontEnd`/`DspPanel`'s own convention) rather than avoiding `$props.id()`
- `npm run i18n:check`: OK — new keys present in both `en-US.json` and `ru-RU.json`; only pre-existing, unrelated coverage gaps reported as informational
- Internal-identifier boundary check (`192\.168|\bmoroz\b|\bmini\b|preview-mor`) over the full diff including untracked files: empty

Closes MOR-1536