### PR TITLE
fix: repair focus_target selectors and honest fallback for dead shortcuts (MOR-1456)

### DIFF
--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -479,7 +479,20 @@
   onpointercancel={(e) => { handleResizeCancel(e); handleDragCancel(e); }}
 />
 
-<div class="spectrum-panel" class:fullscreen onwheel={handleWheel}>
+<!--
+  MOR-1456: `data-waterfall` + `tabindex="-1"` make this region a real,
+  program-focusable landing spot for the "Go to Waterfall" (`g w`) keyboard
+  shortcut (`panel-commands.ts`'s `focus_target` dispatch). Neither the
+  spectrum `<canvas>` nor the waterfall `<canvas>` (`WaterfallCanvas.svelte`)
+  is natively focusable, and `ScopeDisplaySurface.svelte` is a bare readout
+  with ZERO focusable elements by construction (MOR-1069) — this panel root
+  is the one stable anchor the shortcut can jump to. `tabindex="-1"` keeps it
+  OUT of normal Tab order (it is a jump target, not a tab stop) — unlike the
+  other `g <key>` targets, which land on a real form control that was already
+  in the tab order.
+-->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div class="spectrum-panel" class:fullscreen data-waterfall tabindex="-1" onwheel={handleWheel}>
   <SpectrumToolbar bind:enableAvg bind:enablePeakHold bind:brtLevel bind:colorScheme bind:fullscreen bind:showBandPlan bind:hiddenLayers bind:showEiBi {scopeDemandOn} onScopeDemandChange={setScopeDemand} {hideSourceControls} {hideScopeControls} {hideAutoStepToggle} />
   <div class="spectrum-with-scales">
     <div class="db-scale">

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -79,6 +79,10 @@ globalThis.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
   return setTimeout(() => cb(performance.now()), 0) as unknown as number;
 });
 globalThis.cancelAnimationFrame = vi.fn((id: number) => clearTimeout(id));
+
+// jsdom does not implement `Element.scrollIntoView` at all; MOR-1456's
+// `focus_target` dispatch calls it unconditionally after `.focus()`.
+Element.prototype.scrollIntoView = vi.fn();
 HTMLElement.prototype.setPointerCapture = vi.fn();
 HTMLElement.prototype.releasePointerCapture = vi.fn();
 
@@ -1073,6 +1077,29 @@ describe('SpectrumPanel hideScopeControls pass-through (MOR-1369, S6b-1)', () =>
     // the view-options half is unaffected by the forwarded prop
     expect(labels).toContain('AVG');
     expect(labels).toContain('PEAK');
+  });
+});
+
+// MOR-1456 — the "Go to Waterfall" (`g w`) keyboard shortcut. Neither the
+// spectrum `<canvas>` nor the waterfall `<canvas>` (`WaterfallCanvas.svelte`)
+// is natively focusable, and `ScopeDisplaySurface.svelte` (the semantic
+// scope-display readout) is a bare readout with ZERO focusable elements by
+// construction (MOR-1069) — the panel root's own `data-waterfall`/
+// `tabindex="-1"` is the one stable anchor `focus_target` can resolve to.
+// Lives here, not alongside the other `focus_target` shortcuts in
+// `panel-commands/__tests__/focus-target-resolution.component.test.ts`,
+// because only THIS file already carries the canvas/ResizeObserver/rAf
+// mocking a real `SpectrumPanel` mount needs.
+describe('"waterfall" focus_target shortcut resolves to the real SpectrumPanel root (MOR-1456)', () => {
+  it('"g w" focuses the spectrum panel root', async () => {
+    const { makeKeyboardHandlers } = await import('$lib/runtime/commands/panel-commands');
+    const target = mountPanel();
+    const root = target.querySelector('[data-waterfall]');
+    expect(root).not.toBeNull();
+
+    makeKeyboardHandlers().dispatch({ action: 'focus_target', params: { target: 'waterfall' } });
+
+    expect(document.activeElement).toBe(root);
   });
 });
 

--- a/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts
@@ -1,0 +1,200 @@
+/**
+ * MOR-1456 — `focus_target` keyboard-shortcut resolution ("Go to X",
+ * `g <key>` in `rigs/_keyboard-default.toml`).
+ *
+ * Red-first history: on `main` before this fix, EVERY selector in
+ * `panel-commands.ts`'s `focus_target` dispatch pointed at legacy
+ * `[data-panel="..."]`/`[data-control="..."]` markup that the v3-rework
+ * (`desktop-declarations.ts`'s `filter`/`rfFrontEnd`/`rx-audio` zones)
+ * retired in favour of the semantic surfaces below — every one of these
+ * `it()`s failed with `document.activeElement` unchanged (`document.body`)
+ * against the OLD selectors, most visibly `vfo` (`g v`, "Go to VFO"), the
+ * dead shortcut the ticket named.
+ *
+ * This file mounts the REAL production semantic surfaces the desktop-v2
+ * composition actually renders (`RxAudioSurface`/`RfFrontEndSurface`/
+ * `FilterSurface`/`VfoSurface`), fully observed via the SAME topology
+ * fixtures each surface's own unit test (`semantic/__tests__/*.test.ts`)
+ * uses, and drives them through the REAL `makeKeyboardHandlers().dispatch`
+ * from `panel-commands.ts` — never a stand-in selector map. Every advertised
+ * `g <key>` binding is proven here except `waterfall`, which needs
+ * `SpectrumPanel`'s heavier canvas/runtime mocking and is instead pinned
+ * alongside that component's own suite
+ * (`components/spectrum/__tests__/SpectrumPanel.component.test.ts`).
+ *
+ * `*.component.test.ts` naming puts this in the ISOLATED pool (MOR-1272
+ * doctrine) — required because this file `vi.mock`s several of
+ * `panel-commands.ts`'s own store/transport dependencies so the REAL module
+ * imports cleanly with no live radio behind it. `focus_target` itself never
+ * touches any of them (`dispatchKeyboardRadioAction` returns immediately —
+ * it is not one of the `KEYBOARD_RADIO_ACTIONS`), so every mock below is a
+ * safe, inert stand-in, not a behavior the tests below depend on.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount, flushSync, type Component } from 'svelte';
+
+// jsdom does not implement `Element.scrollIntoView` at all; the production
+// `focus_target` dispatch calls it unconditionally after `.focus()`.
+Element.prototype.scrollIntoView = vi.fn();
+
+const h = vi.hoisted(() => ({ setAudioConfig: vi.fn() }));
+
+vi.mock('$lib/transport/ws-client', () => ({
+  getControlSession: vi.fn(() => ({ state: 'connected', epoch: 1 })),
+  onCommandDelivery: vi.fn(() => () => undefined),
+  onControlSessionTransition: vi.fn(() => () => undefined),
+  sendCommand: vi.fn(() => true),
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getActiveReceiver: vi.fn(() => null),
+  getRadioState: vi.fn(() => null),
+  isRadioFieldAvailable: vi.fn(() => false),
+  patchActiveReceiver: vi.fn(),
+  patchRadioState: vi.fn(),
+  patchReceiver: vi.fn(),
+}));
+vi.mock('$lib/state/field-status', () => ({
+  getFieldStatus: vi.fn(() => undefined),
+  isFieldAvailable: vi.fn(() => false),
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => null),
+  capabilitiesMatchGeneration: vi.fn(() => false),
+  getControlRange: vi.fn(() => null),
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get rxEnabled() { return false; },
+    setMuted: vi.fn(), setRxLive: vi.fn(), setRxVolume: vi.fn(), setVolume: vi.fn(),
+  },
+}));
+vi.mock('$lib/audio/audio-manager', () => ({
+  audioManager: { setAudioConfig: h.setAudioConfig },
+}));
+vi.mock('$lib/stores/tuning.svelte', () => ({
+  getTuningStep: vi.fn(() => 1_000),
+  adjustTuningStep: vi.fn(),
+}));
+
+import { makeKeyboardHandlers } from '../panel-commands';
+import RxAudioSurface from '../../../../semantic/RxAudioSurface.svelte';
+import RfFrontEndSurface from '../../../../semantic/RfFrontEndSurface.svelte';
+import FilterSurface from '../../../../semantic/FilterSurface.svelte';
+import VfoSurface from '../../../../semantic/VfoSurface.svelte';
+import {
+  topologyFixtures, withRxAudio, withModeFilter, withFilterPassband, withRfFrontEnd,
+} from '../../../../semantic/fixtures/topologies';
+
+let mounted: ReturnType<typeof mount>[] = [];
+
+function render<P extends Record<string, unknown>>(component: Component<P>, props: P): void {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  mounted.push(mount(component, { target, props }));
+  flushSync();
+}
+
+function dispatchFocusTarget(target: string): void {
+  makeKeyboardHandlers().dispatch({ action: 'focus_target', params: { target } });
+}
+
+beforeEach(() => {
+  mounted = [];
+});
+
+afterEach(() => {
+  mounted.forEach((c) => unmount(c));
+  mounted = [];
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('focus_target dispatch resolves to a real, focusable anchor in the production DOM (MOR-1456)', () => {
+  it('"af" focuses the AF-gain slider in RxAudioSurface (rx-audio zone)', () => {
+    render(RxAudioSurface, { view: withRxAudio(topologyFixtures['1/single']) });
+    const input = document.querySelector('[data-testid="rx-audio-af"] input');
+    expect(input).not.toBeNull();
+
+    dispatchFocusTarget('af');
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('"rf" focuses the RF-gain slider in RfFrontEndSurface (rfFrontEnd zone)', () => {
+    render(RfFrontEndSurface, { view: withRfFrontEnd(topologyFixtures['1/single']) });
+    const input = document.querySelector('[data-testid="rf-front-end-rfGain"] input');
+    expect(input).not.toBeNull();
+
+    dispatchFocusTarget('rf');
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('"mode" focuses the first mode choice in FilterSurface (filter zone)', () => {
+    render(FilterSurface, { view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])) });
+    const button = document.querySelector('[data-testid="filter-mode"] button');
+    expect(button).not.toBeNull();
+
+    dispatchFocusTarget('mode');
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('"filter" focuses the first filter choice in FilterSurface (filter zone)', () => {
+    render(FilterSurface, { view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])) });
+    const button = document.querySelector('[data-testid="filter-select"] button');
+    expect(button).not.toBeNull();
+
+    dispatchFocusTarget('filter');
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('"pbt" focuses the PBT-inner slider in FilterSurface (filter zone)', () => {
+    render(FilterSurface, { view: withFilterPassband(withModeFilter(topologyFixtures['1/single'])) });
+    const input = document.querySelector('[data-testid="filter-pbtInner"] input');
+    expect(input).not.toBeNull();
+
+    dispatchFocusTarget('pbt');
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('"vfo" focuses the active receiver\'s tunable frequency display in VfoSurface (receiver-deck zone)', () => {
+    render(VfoSurface, { viewModel: topologyFixtures['1/single'], onTuneFrequency: vi.fn() });
+    const tile = document.querySelector('[data-vfo-tile][data-vfo-active="true"]');
+    const anchor = tile?.querySelector('[data-vfo-freq] [tabindex]');
+    expect(anchor).not.toBeNull();
+
+    dispatchFocusTarget('vfo');
+
+    expect(document.activeElement).toBe(anchor);
+  });
+});
+
+describe('focus_target resolution failure surfaces honestly, never a silent no-op (MOR-1456)', () => {
+  it('warns and leaves focus untouched when the target has no focusable anchor in the current layout', () => {
+    // Nothing mounted this describe's afterEach already cleared the DOM, so
+    // "vfo" (a real, mapped target) resolves to no element — the shape a
+    // dial-locked/disabled active receiver produces in production.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const before = document.activeElement;
+
+    dispatchFocusTarget('vfo');
+
+    expect(document.activeElement).toBe(before);
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining('focus_target "vfo" has no focusable anchor'),
+    );
+  });
+
+  it('warns for a target string with no known selector at all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    dispatchFocusTarget('nonexistent');
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining('focus_target "nonexistent" has no focusable anchor'),
+    );
+  });
+});

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1590,22 +1590,43 @@ export function makeKeyboardHandlers() {
         case 'focus_target': {
           const target = action.params?.target;
           if (typeof target === 'string') {
+            // MOR-1456: every selector below is verified against the ACTUAL
+            // rendered desktop-v2 composition, not the pre-v3-rework legacy
+            // panels (`LeftSidebar`'s `RfFrontEnd`/`ModePanel`/`FilterPanel`
+            // are suppressed there — see `desktop-declarations.ts`'s
+            // `filter`/`rfFrontEnd`/`rx-audio` zones). Each entry points at
+            // the semantic surface that actually mounts, reusing its existing
+            // `data-testid` hooks rather than inventing a parallel
+            // `data-panel`/`data-control` vocabulary no component emits.
             const selectors: Record<string, string> = {
-              af: '[data-panel="rf-frontend"] [data-control="af-gain"]',
-              rf:
-                '[data-panel="rf-frontend"] [data-control="rf-sql-dual"], [data-panel="rf-frontend"] [data-control="rf-gain"]',
-              filter: '[data-panel="filter"]',
-              squelch:
-                '[data-panel="rf-frontend"] [data-control="rf-sql-dual"], [data-panel="rf-frontend"] [data-control="squelch"]',
-              mode: '[data-panel="mode"]',
-              pbt: '[data-panel="filter"] [data-control="pbt-inner"]',
+              af: '[data-testid="rx-audio-af"] input',
+              rf: '[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-rfGain"] input',
+              squelch: '[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-squelch"] input',
+              filter: '[data-testid="filter-select"] button',
+              mode: '[data-testid="filter-mode"] button',
+              pbt: '[data-testid="filter-pbtInner"] input',
               waterfall: '[data-waterfall]',
-              vfo: '[data-vfo="main"] .freq-display',
+              // The active receiver's tunable frequency tile: `data-vfo-freq`
+              // marks the region (`VfoSurface.svelte`, MOR-1480), but the
+              // actual focusable node is `FrequencyDisplayInteractive`'s
+              // `tabindex="0"` root nested inside it (`vfoFreqHook={false}`
+              // there deliberately keeps the attribute off that inner node —
+              // see `keyboard-map.ts`'s `isFrequencyDisplayFocused` for the
+              // same closest()-based hook this selector mirrors).
+              vfo: '[data-vfo-tile][data-vfo-active="true"] [data-vfo-freq] [tabindex]',
             };
-            const el = document.querySelector(selectors[target] ?? `[data-panel="${target}"]`);
+            const selector = selectors[target];
+            const el = selector ? document.querySelector(selector) : null;
             if (el instanceof HTMLElement) {
               el.focus();
               el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            }
+            // Honest failure (MOR-1456): a dead selector must never look like
+            // a no-op keypress. `document.activeElement !== el` also catches
+            // an element that resolved but couldn't actually take focus (e.g.
+            // disabled or not currently rendered).
+            if (!(el instanceof HTMLElement) || document.activeElement !== el) {
+              console.warn(`[keyboard] focus_target "${target}" has no focusable anchor in the current layout`);
             }
           }
           return;


### PR DESCRIPTION
Closes MOR-1456

## Problem

The `focus_target` keyboard-shortcut dispatch in `panel-commands.ts` (the `g <key>` "Go to X" shortcuts advertised in the `?` help overlay) resolved every target against pre-v3-rework legacy `[data-panel="..."]`/`[data-control="..."]` markup. The v3-rework's zone declarations (`desktop-declarations.ts`'s `filter`/`rfFrontEnd`/`rx-audio` zones) suppress those legacy panels on the shipping `desktop-v2` composition in favour of the semantic surfaces (`RxAudioSurface`/`RfFrontEndSurface`/`FilterSurface`/`VfoSurface`), so every selector was dead — every advertised shortcut except (accidentally) none of them worked, most visibly `g v` ("Go to VFO"), the shortcut named in the ticket. Same operator-facing-lie class as the dead "Swap VFO: Tab" entry removed in #2388.

## Fix

Audited all 8 `focus_target` selectors against the actual rendered `desktop-v2` composition and pointed each at a real, stable anchor — reusing existing `data-testid` hooks on the semantic surfaces rather than inventing a new `data-panel`/`data-control` vocabulary no component emits, per the ticket's data-attribute preference. `waterfall` had no focusable anchor at all (neither the spectrum/waterfall `<canvas>` nor `ScopeDisplaySurface` — a bare readout with zero focusable elements by construction — can take focus), so `SpectrumPanel.svelte`'s root now carries `data-waterfall tabindex="-1"` as the landing spot.

A selector that still can't resolve (or resolves to something that can't actually take focus) now `console.warn`s instead of doing nothing — chosen over a toast because no frontend-callable API exists to raise a local toast — `Toast.svelte`'s `addToast` is component-scoped and driven by server `onMessage`; exporting one is out of scope here.warn` in the same dispatch's `default:` case for unhandled actions. Least-invasive option per the ticket.

## Audit table

| Shortcut | `g <key>` | Old selector (dead) | New selector | Where it lives now |
|---|---|---|---|---|
| `af` | `g a` | `[data-panel="rf-frontend"] [data-control="af-gain"]` | `[data-testid="rx-audio-af"] input` | `RxAudioSurface` (`rx-audio` zone) |
| `rf` | `g r` | `[data-panel="rf-frontend"] [data-control="rf-sql-dual"], ...rf-gain]` | `[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-rfGain"] input` | `RfFrontEndSurface` (`rfFrontEnd` zone) |
| `squelch` *(mapped, not currently bound by any keyboard binding)* | — | `...rf-sql-dual, ...squelch]` | `[data-testid="rf-front-end-rf-sql"] input, [data-testid="rf-front-end-squelch"] input` | `RfFrontEndSurface` |
| `filter` | `g f` | `[data-panel="filter"]` | `[data-testid="filter-select"] button` | `FilterSurface` (`filter` zone) |
| `mode` | `g m` | `[data-panel="mode"]` | `[data-testid="filter-mode"] button` | `FilterSurface` (`filter` zone — mode+filter share one surface post-rework) |
| `pbt` | `g p` | `[data-panel="filter"] [data-control="pbt-inner"]` | `[data-testid="filter-pbtInner"] input` | `FilterSurface` |
| `waterfall` | `g w` | `[data-waterfall]` (attribute never emitted anywhere) | `[data-waterfall]` (now emitted, + `tabindex="-1"`) | `SpectrumPanel` root |
| `vfo` | `g v` | `[data-vfo="main"] .freq-display` (neither attribute nor class exists) | `[data-vfo-tile][data-vfo-active="true"] [data-vfo-freq] [tabindex]` | `VfoSurface`'s active tile → `FrequencyDisplayInteractive`'s focusable root |

No help-overlay entries were removed — all 7 bound shortcuts (`rigs/_keyboard-default.toml`'s `focus-*` bindings) now resolve to a real, focusable element in the shipping composition.

## Tests (red-first)

- `frontend/src/lib/runtime/commands/__tests__/focus-target-resolution.component.test.ts` (new) — mounts the real production semantic surfaces (`RxAudioSurface`/`RfFrontEndSurface`/`FilterSurface`/`VfoSurface`), fully observed via the same `topologyFixtures`/`withRxAudio`/`withModeFilter`/`withFilterPassband`/`withRfFrontEnd` fixtures each surface's own unit tests use, and drives them through the real `makeKeyboardHandlers().dispatch(...)`. One test per shortcut (af/rf/mode/filter/pbt/vfo) asserting `document.activeElement`, plus two pinning the resolution-failure `console.warn` fallback (a real mapped target with nothing mounted, and an unmapped target string).
- `frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts` — added the `waterfall` shortcut test alongside that component's own existing canvas/runtime mocking harness (lives here rather than in the new file because only this file already carries the heavier mocking a real `SpectrumPanel` mount needs).
- Verified red-first: reverted `panel-commands.ts`/`SpectrumPanel.svelte` locally and reran — all 6 non-fallback shortcut tests failed with `document.activeElement` unchanged (the exact silent-no-op the ticket describes), including `vfo`/`g v`.

Ran locally (not full suite): the two new/touched test files (92 tests), plus `KeyboardHandler.test.ts`, `VfoSurface.test.ts`, `RfFrontEndSurface.test.ts`, `panel-commands.intent.isolated.test.ts`, and `semantic-desktop-migration.component.test.ts` as a regression check (475 tests total, all green). `eslint`, `lint:boundaries`, and `svelte-check` all clean on the touched files.

## Scope

2 production files (`panel-commands.ts` +34 net LOC, `SpectrumPanel.svelte` +15/-1 LOC), 2 test files. No changes to `rigs/_keyboard-default.toml` — every existing binding now resolves correctly with no additions/removals needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
