### PR TITLE
fix: parse and validate break_in/notch-width/ssb_tx_bw/filter_shape domains from profile data (MOR-1534)

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -136,6 +136,15 @@ width_labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 values = [0, 1, 2]
 labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 
+[filter_shape]
+# CI-V 0x16 0x56: DSP IF filter type. No dedicated IC-705 cat-audit exists
+# in-repo; SHARP/SOFT = 0/1 is the same domain the runtime's shared
+# `FilterShape` enum (src/rigplane/core/types.py) has always assumed for
+# this command across the whole IC-7610-family profile set, IC-705 included
+# (MOR-1534 — not independently live-verified for this specific profile).
+values = [0, 1]
+labels = { "0" = "SHARP", "1" = "SOFT" }
+
 [break_in]
 # CI-V 0x16 0x47: wfview IC-705 Max=2 (IC-7300.rig Max=1 — 705 adds full break-in)
 values = [0, 1, 2]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -545,6 +545,14 @@ width_labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 values = [0, 1, 2]
 labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 
+[filter_shape]
+# CI-V 0x16 0x56: DSP IF filter type (docs/validation/cat-audits/ic7300.md
+# "16 56 DSP filter type" — presence-confirmed; SHARP/SOFT values come from
+# the shared IC-7610/IC-7300-family command table, same basis as the
+# [commands] get/set_filter_shape entry below) (MOR-1534).
+values = [0, 1]
+labels = { "0" = "SHARP", "1" = "SOFT" }
+
 [break_in]
 # CI-V 0x16 0x47: 0=OFF, 1=Semi, 2=Full (wfview rig lists Max=1; CI-V supports three levels)
 values = [0, 1, 2]

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -690,6 +690,15 @@ width_labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 values = [0, 1, 2]
 labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 
+[filter_shape]
+# CI-V 0x16 0x56: DSP IF filter type (docs/validation/cat-audits/ic7610.md
+# "16 56 DSP IF filter type" S/R; the [commands] get/set_filter_shape entry
+# below carries the same 0=SHARP/1=SOFT comment). IC-7610 hardware retired
+# 2026-08-04 — no live verification possible, same disclosure basis as the
+# [agc] note above (MOR-1534).
+values = [0, 1]
+labels = { "0" = "SHARP", "1" = "SOFT" }
+
 [break_in]
 # CI-V 0x16 0x47: 0=OFF, 1=Semi, 2=Full
 values = [0, 1, 2]

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -139,6 +139,15 @@ width_labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 values = [0, 1, 2]
 labels = { "0" = "WIDE", "1" = "MID", "2" = "NAR" }
 
+[filter_shape]
+# CI-V 0x16 0x56: DSP IF filter type. No dedicated IC-9700 cat-audit exists
+# in-repo; SHARP/SOFT = 0/1 is the same domain the runtime's shared
+# `FilterShape` enum (src/rigplane/core/types.py) has always assumed for
+# this command across the whole IC-7610-family profile set, IC-9700 included
+# (MOR-1534 — not independently live-verified for this specific profile).
+values = [0, 1]
+labels = { "0" = "SHARP", "1" = "SOFT" }
+
 [break_in]
 # CI-V 0x16 0x47: 0=OFF, 1=Semi, 2=Full (wfview rig lists Max=1; CI-V supports three levels)
 values = [0, 1, 2]

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -43,6 +43,16 @@ address = 0x70
 # over-declaration the validation harness exists to catch. These three are
 # dropped here BY INFERENCE, not by a direct X6100 capture — do NOT relabel
 # them "live confirmed" for the X6100 until a real X6100 is actually probed.
+#
+# NOTE: ``break_in`` KEEPS the capability tag but intentionally declares NO
+# ``[break_in]`` domain (MOR-1534). There is no X6100 cat-audit in this repo
+# at all (no X6100 hardware to capture — see above) and the shared-firmware
+# inference that justifies dropping tone/pbt doesn't apply here: the X6200's
+# own audit found its break-in opcode isn't in the X6200 CI-V table either,
+# so inferring an X6100 value domain from X6200 data would compound one
+# unconfirmed guess on top of another. No trustworthy in-repo source exists
+# for an OFF/SEMI/FULL domain on this radio, so ``CoreRadio.set_break_in``
+# refuses (fails loud) rather than validate against a guessed table.
 features = [
     "audio",
     "af_level",

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -75,6 +75,15 @@ codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 #     mismatch), and Hamlib marks ``x1ax03_supported = 0``. The cap stays
 #     UNDECLARED pending a setter units fix + a clean live round-trip
 #     (MOR-683 defers; tracked as a filter_width follow-up).
+#   - ``break_in`` KEEPS the capability tag but intentionally declares NO
+#     ``[break_in]`` domain (MOR-1534). docs/validation/cat-audits/x6200.md
+#     (lines 56/109/128/132) found the backend's ``get/set_break_in`` opcode
+#     (``0x16 0x47``, IC-7610's CW BK-IN mode register) is NOT in the X6200's
+#     documented CI-V table at all — the X6200 PDF only documents QSK hang
+#     time (``0x14 0x0F``, already covered by ``break_in_delay``), not a
+#     BK-IN-mode register. There is no trustworthy in-repo source for an
+#     OFF/SEMI/FULL value domain on this radio, so ``CoreRadio.set_break_in``
+#     refuses (fails loud) rather than validate against a guessed table.
 features = [
     "audio",
     "af_level",

--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -621,11 +621,21 @@ def set_break_in(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
+    """Build a set break-in mode command.
+
+    Encodes the raw single-BCD-byte break-in value. Which values are legal
+    for a given radio (the documented OFF/SEMI/FULL domain on IC-705/
+    IC-7300/IC-9700/IC-7610 vs. the X6100/X6200, which have no confirmed
+    domain at all) is a per-profile question, not a universal one — this
+    builder only enforces the wire-format's single-BCD-byte range and
+    leaves domain validation to the profile-aware caller (MOR-1534, mirrors
+    MOR-1522's ``set_agc`` fix).
+    """
     return _build_function_value_set(
         _SUB_BREAK_IN,
-        int(BreakInMode(mode)),
-        minimum=int(BreakInMode.OFF),
-        maximum=int(BreakInMode.FULL),
+        int(mode),
+        minimum=0,
+        maximum=99,
         to_addr=to_addr,
         from_addr=from_addr,
         cmd_map=cmd_map,

--- a/src/rigplane/commands/mode.py
+++ b/src/rigplane/commands/mode.py
@@ -213,12 +213,19 @@ def set_filter_shape(
     *,
     command29: bool = True,
 ) -> bytes:
-    """Build a set DSP IF filter shape command."""
+    """Build a set DSP IF filter shape command.
+
+    Encodes the raw single-BCD-byte filter-shape value. Which values are
+    legal is a per-profile ``[filter_shape] values`` domain, not a universal
+    enum — this builder only enforces the wire-format's single-BCD-byte
+    range and leaves domain validation to the profile-aware caller
+    (MOR-1534, mirrors MOR-1522's ``set_agc`` fix).
+    """
     return _build_function_value_set(
         _SUB_FILTER_SHAPE,
-        int(FilterShape(shape)),
-        minimum=int(FilterShape.SHARP),
-        maximum=int(FilterShape.SOFT),
+        int(shape),
+        minimum=0,
+        maximum=99,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
@@ -306,12 +313,19 @@ def set_ssb_tx_bandwidth(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Build a set SSB TX bandwidth preset command."""
+    """Build a set SSB TX bandwidth preset command.
+
+    Encodes the raw single-BCD-byte bandwidth value. Which values are legal
+    is a per-profile ``[ssb_tx_bw] values`` domain, not a universal enum —
+    this builder only enforces the wire-format's single-BCD-byte range and
+    leaves domain validation to the profile-aware caller (MOR-1534, mirrors
+    MOR-1522's ``set_agc`` fix).
+    """
     return _build_function_value_set(
         _SUB_SSB_TX_BANDWIDTH,
-        int(SsbTxBandwidth(bandwidth)),
-        minimum=int(SsbTxBandwidth.WIDE),
-        maximum=int(SsbTxBandwidth.NAR),
+        int(bandwidth),
+        minimum=0,
+        maximum=99,
         to_addr=to_addr,
         from_addr=from_addr,
         cmd_map=cmd_map,

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -173,6 +173,20 @@ class RadioProfile:
     pre_labels: dict[str, str] | None = None
     agc_modes: tuple[int, ...] | None = None
     agc_labels: dict[str, str] | None = None
+    # MOR-1534: enumerated-domain controls that were declared in TOML but
+    # never parsed/validated (break_in, notch width) or hardcoded via an
+    # IC-7610-specific enum with no profile domain to check against
+    # (ssb_tx_bw, filter_shape). ``None`` means the profile declared no
+    # domain — see each ``CoreRadio`` setter's docstring for what that means
+    # for that specific control (some fail loud, some are permissive).
+    break_in_modes: tuple[int, ...] | None = None
+    break_in_labels: dict[str, str] | None = None
+    notch_width_values: tuple[int, ...] | None = None
+    notch_width_labels: dict[str, str] | None = None
+    ssb_tx_bw_values: tuple[int, ...] | None = None
+    ssb_tx_bw_labels: dict[str, str] | None = None
+    filter_shape_values: tuple[int, ...] | None = None
+    filter_shape_labels: dict[str, str] | None = None
     # MOR-1447 leg 2: "separate" (default, two independent controls) or
     # "combined" (Icom-style single RF/SQL knob). Data-driven from
     # ``[capabilities].rf_sql_control_model`` in the rig TOML — never a

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -102,6 +102,14 @@ class RigConfig:
     pre_labels: dict[str, str] | None
     agc_modes: tuple[int, ...] | None
     agc_labels: dict[str, str] | None
+    break_in_modes: tuple[int, ...] | None = None
+    break_in_labels: dict[str, str] | None = None
+    notch_width_values: tuple[int, ...] | None = None
+    notch_width_labels: dict[str, str] | None = None
+    ssb_tx_bw_values: tuple[int, ...] | None = None
+    ssb_tx_bw_labels: dict[str, str] | None = None
+    filter_shape_values: tuple[int, ...] | None = None
+    filter_shape_labels: dict[str, str] | None = None
     # MOR-1447 leg 2: "separate" (default) or "combined" (Icom-style single
     # RF/SQL knob — see ``VALID_RF_SQL_CONTROL_MODELS``).
     rf_sql_control_model: str = "separate"
@@ -204,6 +212,14 @@ class RigConfig:
             pre_labels=self.pre_labels,
             agc_modes=self.agc_modes,
             agc_labels=self.agc_labels,
+            break_in_modes=self.break_in_modes,
+            break_in_labels=self.break_in_labels,
+            notch_width_values=self.notch_width_values,
+            notch_width_labels=self.notch_width_labels,
+            ssb_tx_bw_values=self.ssb_tx_bw_values,
+            ssb_tx_bw_labels=self.ssb_tx_bw_labels,
+            filter_shape_values=self.filter_shape_values,
+            filter_shape_labels=self.filter_shape_labels,
             rf_sql_control_model=self.rf_sql_control_model,
             data_mode_count=self.data_mode_count,
             data_mode_labels=self.data_mode_labels,
@@ -552,6 +568,50 @@ def _reject_unknown_keys(
             f"{filename}: {section} unknown key {unknown[0]!r}. "
             f"Valid keys: {sorted(allowed)}"
         )
+
+
+def _parse_enumerated_domain(
+    filename: str,
+    section: str,
+    raw_section: dict[str, Any],
+    *,
+    values_key: str = "values",
+    labels_key: str = "labels",
+) -> tuple[tuple[int, ...] | None, dict[str, str] | None]:
+    """Parse a ``[section] <values_key>/<labels_key>`` enumerated-domain
+    declaration, generalizing the ``[agc] modes/labels`` fail-loud pattern
+    (MOR-1522) to the other per-radio enumerated controls (MOR-1534:
+    break_in, notch width, ssb_tx_bw, filter_shape). Rejects unknown keys,
+    non-integer/empty value lists, orphan label keys, and — the MOR-1522 R1
+    (B2) hole class — labels declared without a matching values list, which
+    would otherwise load silently as a capability-present control with an
+    empty domain.
+    """
+    if raw_section:
+        _reject_unknown_keys(
+            filename, section, raw_section, frozenset({values_key, labels_key})
+        )
+    values = tuple(raw_section[values_key]) if values_key in raw_section else None
+    if values is not None and (
+        not values or any(isinstance(v, bool) or not isinstance(v, int) for v in values)
+    ):
+        raise RigLoadError(
+            f"{filename}: {section}.{values_key} must be a non-empty list of integers"
+        )
+    labels = dict(raw_section[labels_key]) if labels_key in raw_section else None
+    if labels is not None and values is None:
+        raise RigLoadError(
+            f"{filename}: {section}.{labels_key} declared without {section}.{values_key}"
+        )
+    if labels is not None and values is not None:
+        declared = {str(v) for v in values}
+        orphan_labels = sorted(set(labels) - declared)
+        if orphan_labels:
+            raise RigLoadError(
+                f"{filename}: {section}.{labels_key} key {orphan_labels[0]!r} has no "
+                f"matching entry in {section}.{values_key} {sorted(values)}"
+            )
+    return values, labels
 
 
 def _strict_policy_bool(
@@ -1232,6 +1292,27 @@ def load_rig(path: Path) -> RigConfig:
                 f"matching entry in [agc].modes {sorted(agc_modes)}"
             )
 
+    # Parse break_in/notch-width/ssb_tx_bw/filter_shape enumerated domains
+    # (MOR-1534). Each was declared in TOML (or, for filter_shape, nowhere
+    # at all) but never parsed/validated at load time — see rig_loader
+    # tests + CoreRadio's setters for the per-control validation seat.
+    break_in_modes, break_in_labels = _parse_enumerated_domain(
+        filename, "[break_in]", data.get("break_in", {})
+    )
+    notch_width_values, notch_width_labels = _parse_enumerated_domain(
+        filename,
+        "[notch]",
+        data.get("notch", {}),
+        values_key="width_values",
+        labels_key="width_labels",
+    )
+    ssb_tx_bw_values, ssb_tx_bw_labels = _parse_enumerated_domain(
+        filename, "[ssb_tx_bw]", data.get("ssb_tx_bw", {})
+    )
+    filter_shape_values, filter_shape_labels = _parse_enumerated_domain(
+        filename, "[filter_shape]", data.get("filter_shape", {})
+    )
+
     # Parse [data_mode] (optional)
     # If data_mode is in features but no [data_mode] section, default to 1 mode (OFF/DATA)
     data_mode_section = data.get("data_mode", {})
@@ -1467,6 +1548,14 @@ def load_rig(path: Path) -> RigConfig:
         pre_labels=pre_labels,
         agc_modes=agc_modes,
         agc_labels=agc_labels,
+        break_in_modes=break_in_modes,
+        break_in_labels=break_in_labels,
+        notch_width_values=notch_width_values,
+        notch_width_labels=notch_width_labels,
+        ssb_tx_bw_values=ssb_tx_bw_values,
+        ssb_tx_bw_labels=ssb_tx_bw_labels,
+        filter_shape_values=filter_shape_values,
+        filter_shape_labels=filter_shape_labels,
         rf_sql_control_model=rf_sql_control_model,
         data_mode_count=data_mode_count,
         data_mode_labels=data_mode_labels,

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3243,10 +3243,35 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         return BreakInMode(value)
 
     async def set_break_in(self, mode: BreakInMode | int) -> None:
-        """Set break-in mode."""
-        break_in = BreakInMode(mode)
+        """Set break-in mode.
+
+        Valid values are declared per radio by the profile's ``[break_in]
+        values`` (e.g. IC-705/IC-7300/IC-9700/IC-7610 all offer OFF/SEMI/
+        FULL). Unlike ``set_agc``/``set_preamp`` (MOR-1522/MOR-1523), a
+        missing domain here is NOT treated as "unvalidated, pass through" —
+        some profiles (X6100/X6200) advertise the ``break_in`` capability
+        but have no trustworthy in-repo source for a value domain (see the
+        ``rigs/x6200.toml``/``rigs/x6100.toml`` ``[capabilities]`` notes),
+        so this refuses any value rather than guess (MOR-1534).
+
+        Raises:
+            ValueError: If the profile declares no break-in domain, or if
+                ``mode`` is not in the profile's declared domain.
+        """
+        mode_int = int(mode)
+        break_in_modes = self._profile.break_in_modes
+        if break_in_modes is None:
+            raise ValueError(
+                f"No break-in value domain declared for {self._profile.model}; "
+                "refusing to set an unvalidated break-in mode"
+            )
+        if mode_int not in break_in_modes:
+            raise ValueError(
+                f"Break-in mode must be one of {sorted(break_in_modes)} for "
+                f"{self._profile.model}, got {mode_int}"
+            )
         await self._send_fire_and_forget(
-            set_break_in(break_in, to_addr=self._radio_addr)
+            set_break_in(mode_int, to_addr=self._radio_addr)
         )
 
     async def get_manual_notch(self, receiver: int = RECEIVER_MAIN) -> bool:
@@ -3300,11 +3325,30 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def set_manual_notch_width(
         self, value: int, receiver: int = RECEIVER_MAIN
     ) -> None:
-        """Set manual notch width (0=WIDE, 1=MID, 2=NAR)."""
+        """Set manual notch width.
+
+        Valid values are declared per radio by the profile's ``[notch]
+        width_values`` (e.g. IC-705/IC-7300/IC-9700/IC-7610 all declare
+        0=WIDE/1=MID/2=NAR). A profile that declares no width domain is
+        unvalidated here (permissive), mirroring ``set_agc``/``set_preamp``
+        (MOR-1522/MOR-1523) — the ``notch`` capability covers auto-notch
+        too, so its absence does not by itself mean this control is wrong
+        to call (MOR-1534).
+
+        Raises:
+            ValueError: If the profile declares a width domain and
+                ``value`` is not in it.
+        """
         self._require_receiver(receiver, operation="set_manual_notch_width")
         self._require_cmd29_route(
             0x16, 0x57, receiver=receiver, operation="set_manual_notch_width"
         )
+        notch_width_values = self._profile.notch_width_values
+        if notch_width_values is not None and value not in notch_width_values:
+            raise ValueError(
+                f"Manual notch width must be one of {sorted(notch_width_values)} "
+                f"for {self._profile.model}, got {value}"
+            )
         cmd29 = self._profile.supports_cmd29(0x16, 0x57)
         await self._send_fire_and_forget(
             set_manual_notch_width(
@@ -3378,16 +3422,35 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         shape: FilterShape | int,
         receiver: int = RECEIVER_MAIN,
     ) -> None:
-        """Set DSP IF filter shape."""
+        """Set DSP IF filter shape.
+
+        Valid values are declared per radio by the profile's
+        ``[filter_shape] values`` (IC-705/IC-7300/IC-9700/IC-7610 all
+        declare 0=SHARP/1=SOFT). A profile that declares no domain at all
+        (every radio outside that family) is unvalidated here (permissive),
+        mirroring ``set_agc``/``set_preamp`` (MOR-1522/MOR-1523) — none of
+        those radios advertise the ``filter_shape`` capability, so this
+        path is unreachable for them today (MOR-1534).
+
+        Raises:
+            ValueError: If the profile declares a domain and ``shape`` is
+                not in it.
+        """
         self._require_receiver(receiver, operation="set_filter_shape")
         self._require_cmd29_route(
             0x16, 0x56, receiver=receiver, operation="set_filter_shape"
         )
+        shape_int = int(shape)
+        filter_shape_values = self._profile.filter_shape_values
+        if filter_shape_values is not None and shape_int not in filter_shape_values:
+            raise ValueError(
+                f"Filter shape must be one of {sorted(filter_shape_values)} for "
+                f"{self._profile.model}, got {shape_int}"
+            )
         cmd29 = self._profile.supports_cmd29(0x16, 0x56)
-        filter_shape = FilterShape(shape)
         await self._send_fire_and_forget(
             set_filter_shape(
-                filter_shape,
+                shape_int,
                 to_addr=self._radio_addr,
                 receiver=receiver,
                 command29=cmd29,
@@ -3406,10 +3469,29 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         return SsbTxBandwidth(value)
 
     async def set_ssb_tx_bandwidth(self, bandwidth: SsbTxBandwidth | int) -> None:
-        """Set SSB transmit bandwidth preset."""
-        ssb_tx_bandwidth = SsbTxBandwidth(bandwidth)
+        """Set SSB transmit bandwidth preset.
+
+        Valid values are declared per radio by the profile's
+        ``[ssb_tx_bw] values`` (IC-705/IC-7300/IC-9700/IC-7610 all declare
+        0=WIDE/1=MID/2=NAR). A profile that declares no domain at all
+        (every radio outside that family) is unvalidated here (permissive),
+        mirroring ``set_agc``/``set_preamp`` (MOR-1522/MOR-1523) — none of
+        those radios advertise the ``ssb_tx_bw`` capability, so this path
+        is unreachable for them today (MOR-1534).
+
+        Raises:
+            ValueError: If the profile declares a domain and ``bandwidth``
+                is not in it.
+        """
+        bandwidth_int = int(bandwidth)
+        ssb_tx_bw_values = self._profile.ssb_tx_bw_values
+        if ssb_tx_bw_values is not None and bandwidth_int not in ssb_tx_bw_values:
+            raise ValueError(
+                f"SSB TX bandwidth must be one of {sorted(ssb_tx_bw_values)} for "
+                f"{self._profile.model}, got {bandwidth_int}"
+            )
         await self._send_fire_and_forget(
-            set_ssb_tx_bandwidth(ssb_tx_bandwidth, to_addr=self._radio_addr)
+            set_ssb_tx_bandwidth(bandwidth_int, to_addr=self._radio_addr)
         )
 
     async def get_main_sub_tracking(self) -> bool:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1923,14 +1923,14 @@ class RadioPoller:
                     )
             case SetFilterShape(shape=shape, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_filter_shape")
-                if shape not in (0, 1):
-                    raise CommandError(
-                        f"set_filter_shape value must be 0 or 1, got {shape}"
-                    )
                 if CAP_FILTER_SHAPE not in self._caps:
                     raise CommandError(
                         "set_filter_shape is not supported by this backend"
                     )
+                # Domain legality (which shape values are valid for THIS
+                # profile) is CoreRadio.set_filter_shape's job — the single
+                # validation seat, not a hardcoded 0/1 duplicate here
+                # (MOR-1534, mirrors the set_agc/set_preamp precedent).
                 await radio.set_filter_shape(shape, receiver=rx)
                 if self._radio_state:
                     target = (

--- a/tests/test_dsp_levels_part2.py
+++ b/tests/test_dsp_levels_part2.py
@@ -330,9 +330,19 @@ class TestFilterShape:
         with pytest.raises(ValueError):
             commands.set_filter_shape(999, receiver=RECEIVER_MAIN)
 
-    def test_set_filter_shape_rejects_two(self) -> None:
-        with pytest.raises(ValueError):
-            commands.set_filter_shape(2, receiver=RECEIVER_MAIN)
+    def test_set_filter_shape_builder_accepts_values_outside_the_sharp_soft_enum(
+        self,
+    ) -> None:
+        """MOR-1534: the raw wire-command builder no longer polices the
+        IC-7610 SHARP/SOFT enum's range — which filter-shape values are
+        legal is a per-profile ``[filter_shape] values`` domain, enforced
+        one layer up in ``CoreRadio.set_filter_shape`` (see
+        ``TestFilterShapeDomainValidation`` in ``tests/test_radio.py``).
+        This builder only encodes the raw single-BCD-byte value.
+        """
+        assert commands.set_filter_shape(2, receiver=RECEIVER_MAIN) == _cmd29_set(
+            _CMD_PREAMP, _SUB_FILTER_SHAPE, 0x02, receiver=RECEIVER_MAIN
+        )
 
     def test_parse_filter_shape_sharp(self) -> None:
         frame = _response_frame(_CMD_PREAMP, _SUB_FILTER_SHAPE, b"\x00")
@@ -396,9 +406,19 @@ class TestSsbTxBandwidth:
         with pytest.raises(ValueError):
             commands.set_ssb_tx_bandwidth(999)
 
-    def test_set_ssb_tx_bandwidth_rejects_three(self) -> None:
-        with pytest.raises(ValueError):
-            commands.set_ssb_tx_bandwidth(3)
+    def test_set_ssb_tx_bandwidth_builder_accepts_values_outside_the_wide_mid_nar_enum(
+        self,
+    ) -> None:
+        """MOR-1534: the raw wire-command builder no longer polices the
+        IC-7610 WIDE/MID/NAR enum's range — which bandwidth values are
+        legal is a per-profile ``[ssb_tx_bw] values`` domain, enforced one
+        layer up in ``CoreRadio.set_ssb_tx_bandwidth`` (see
+        ``TestSsbTxBandwidthDomainValidation`` in ``tests/test_radio.py``).
+        This builder only encodes the raw single-BCD-byte value.
+        """
+        assert commands.set_ssb_tx_bandwidth(3) == _simple_set(
+            _CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x03
+        )
 
     def test_parse_ssb_tx_bandwidth_wide(self) -> None:
         frame = _response_frame(_CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, b"\x00")

--- a/tests/test_operator_toggles.py
+++ b/tests/test_operator_toggles.py
@@ -408,9 +408,17 @@ class TestBreakIn:
     def test_set_break_in_accepts_int(self) -> None:
         assert commands.set_break_in(0) == commands.set_break_in(BreakInMode.OFF)
 
-    def test_set_break_in_rejects_value_above_maximum(self) -> None:
-        with pytest.raises(ValueError):
-            commands.set_break_in(3)
+    def test_set_break_in_builder_accepts_values_outside_the_off_semi_full_enum(
+        self,
+    ) -> None:
+        """MOR-1534: the raw wire-command builder no longer polices the
+        IC-7610 OFF/SEMI/FULL enum's range — which break-in values are
+        legal is a per-profile ``[break_in] values`` domain, enforced one
+        layer up in ``CoreRadio.set_break_in`` (see
+        ``TestBreakInDomainValidation`` in ``tests/test_radio.py``). This
+        builder only encodes the raw single-BCD-byte value.
+        """
+        assert commands.set_break_in(3) == _simple_set(_SUB_BREAK_IN, 0x03)
 
     def test_set_break_in_rejects_invalid_enum_int(self) -> None:
         with pytest.raises(ValueError):

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2815,6 +2815,172 @@ class TestBreakInModeRoundTrip:
         )
 
 
+class TestBreakInDomainValidation:
+    """MOR-1534: the break-in domain is profile data, not a universal enum.
+
+    Unlike set_agc/set_preamp (MOR-1522/MOR-1523), a MISSING domain here is
+    NOT permissive — X6100/X6200 advertise the ``break_in`` capability but
+    have no trustworthy in-repo value-domain source (see the
+    rigs/x6100.toml / rigs/x6200.toml [capabilities] notes), so
+    ``set_break_in`` must refuse rather than guess.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ic7610_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        for legal in (0, 1, 2):
+            await radio.set_break_in(legal)
+        assert len(mock_transport.sent_packets) == 3
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7610_rejects_value_outside_its_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"Break-in mode must be one of"):
+            await radio.set_break_in(9)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["X6100", "X6200"])
+    async def test_no_domain_declared_fails_loud_not_permissive(
+        self, mock_transport: MockTransport, model: str
+    ) -> None:
+        """X6100/X6200 declare the break_in capability but no domain — this
+        must NOT silently pass any value through (contrast with set_agc's
+        permissive-when-absent behavior for genuinely capability-absent
+        radios)."""
+        radio = IcomRadio("192.168.1.100", model=model)
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"No break-in value domain declared"):
+            await radio.set_break_in(0)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+
+class TestManualNotchWidthDomainValidation:
+    """MOR-1534: [notch] width_values was declared in TOML but never
+    parsed/validated — set_manual_notch_width had ZERO domain checking."""
+
+    @pytest.mark.asyncio
+    async def test_ic7610_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        for legal in (0, 1, 2):
+            await radio.set_manual_notch_width(legal)
+        assert len(mock_transport.sent_packets) == 3
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7610_rejects_value_outside_its_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"Manual notch width must be one of"):
+            await radio.set_manual_notch_width(9)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_permissive_when_no_width_domain_declared(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """X6200 declares 'notch' (auto-notch) but no manual notch WIDTH
+        domain — unlike break_in, this is permissive-pass-through, matching
+        the set_agc/set_preamp precedent (the 'notch' capability legitimately
+        covers auto-notch-only radios, not just manual-width ones)."""
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        await radio.set_manual_notch_width(1)
+        assert mock_transport.sent_packets
+        radio._connected = False
+
+
+class TestFilterShapeDomainValidation:
+    """MOR-1534: filter_shape had NO TOML domain at all before this ticket;
+    set_filter_shape cast every value through the hardcoded IC-7610
+    ``FilterShape`` enum instead of a profile-declared domain."""
+
+    @pytest.mark.asyncio
+    async def test_ic7610_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        for legal in (0, 1):
+            await radio.set_filter_shape(legal)
+        assert len(mock_transport.sent_packets) == 2
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7610_rejects_value_outside_its_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"Filter shape must be one of"):
+            await radio.set_filter_shape(9)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+
+class TestSsbTxBandwidthDomainValidation:
+    """MOR-1534: [ssb_tx_bw] values was declared in TOML but never parsed;
+    set_ssb_tx_bandwidth cast every value through the hardcoded IC-7610
+    ``SsbTxBandwidth`` enum instead."""
+
+    @pytest.mark.asyncio
+    async def test_ic7610_accepts_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        for legal in (0, 1, 2):
+            await radio.set_ssb_tx_bandwidth(legal)
+        assert len(mock_transport.sent_packets) == 3
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_ic7610_rejects_value_outside_its_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        with pytest.raises(ValueError, match=r"SSB TX bandwidth must be one of"):
+            await radio.set_ssb_tx_bandwidth(9)
+        assert mock_transport.sent_packets == []
+        radio._connected = False
+
+
 class TestToneTsqlParity:
     """Test high-level tone/TSQL parity methods (#134)."""
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1278,4 +1278,322 @@ class TestPreampDomainDeclaredOrCapabilityAbsent:
         with IPO/AMP1/AMP2 labels (rigs/ftx1.toml:430-436)."""
         rig = load_rig(RIGS_DIR / "ftx1.toml")
         assert rig.pre_values == (0, 1, 2)
-        assert rig.pre_labels == {"0": "IPO", "1": "AMP1", "2": "AMP2"}
+
+
+# ── MOR-1534: break_in/notch-width/ssb_tx_bw/filter_shape were each either
+# declared in TOML but never parsed (break_in, notch width), hardcoded via
+# an IC-7610-specific enum with no profile domain at all (ssb_tx_bw), or had
+# no TOML domain to begin with (filter_shape). All four now route through
+# ``_parse_enumerated_domain`` — the same shared fail-loud contract
+# ``[agc] modes/labels`` (MOR-1522) established, generalized rather than
+# copy-pasted four times.
+
+
+class TestEnumeratedDomainMalformedDeclarations:
+    """One shared parametrized suite over all four [section] value/label
+    pairs, instead of four near-identical malformed-declaration classes —
+    they all share the same ``_parse_enumerated_domain`` implementation."""
+
+    _SECTIONS = [
+        ("break_in", "values", "labels"),
+        ("notch", "width_values", "width_labels"),
+        ("ssb_tx_bw", "values", "labels"),
+        ("filter_shape", "values", "labels"),
+    ]
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_values_and_labels_load(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[{section}]
+{values_key} = [0, 1, 2]
+{labels_key} = {{ "0" = "A", "1" = "B", "2" = "C" }}
+""",
+        )
+        rig = load_rig(p)
+        values_attr = {
+            "break_in": "break_in_modes",
+            "notch": "notch_width_values",
+            "ssb_tx_bw": "ssb_tx_bw_values",
+            "filter_shape": "filter_shape_values",
+        }[section]
+        labels_attr = {
+            "break_in": "break_in_labels",
+            "notch": "notch_width_labels",
+            "ssb_tx_bw": "ssb_tx_bw_labels",
+            "filter_shape": "filter_shape_labels",
+        }[section]
+        assert getattr(rig, values_attr) == (0, 1, 2)
+        assert getattr(rig, labels_attr) == {"0": "A", "1": "B", "2": "C"}
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_rejects_unknown_key(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[{section}]
+bogus = [0, 1]
+""",
+        )
+        with pytest.raises(RigLoadError, match=rf"\[{section}\].*unknown key"):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_rejects_empty_values_list(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[{section}]
+{values_key} = []
+""",
+        )
+        with pytest.raises(RigLoadError, match=rf"\[{section}\]\.{values_key}"):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_rejects_non_integer_entries(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[{section}]
+{values_key} = [0, "WIDE", 2]
+""",
+        )
+        with pytest.raises(RigLoadError, match=rf"\[{section}\]\.{values_key}"):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_rejects_orphan_label_key(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[{section}]
+{values_key} = [0, 1, 2]
+{labels_key} = {{ "0" = "A", "1" = "B", "2" = "C", "9" = "PHANTOM" }}
+""",
+        )
+        with pytest.raises(RigLoadError, match=rf"\[{section}\]\.{labels_key}.*9"):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_rejects_labels_declared_without_values(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        """MOR-1522 R1 (B2) hole class, generalized: labels with no values
+        must not load silently — that would yield a capability-present
+        control with an empty domain, short-circuiting the runtime
+        validation seat's ``is not None`` guard into a permissive no-op."""
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[{section}]
+{labels_key} = {{ "0" = "A", "1" = "B", "2" = "C" }}
+""",
+        )
+        with pytest.raises(
+            RigLoadError,
+            match=rf"\[{section}\]\.{labels_key} declared without \[{section}\]\.{values_key}",
+        ):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("section", "values_key", "labels_key"), _SECTIONS, ids=lambda t: t
+    )
+    def test_domain_absent_when_section_absent(
+        self, tmp_path, section, values_key, labels_key
+    ):
+        p = _write_toml(tmp_path, _MINIMAL_TOML)
+        rig = load_rig(p)
+        values_attr = {
+            "break_in": "break_in_modes",
+            "notch": "notch_width_values",
+            "ssb_tx_bw": "ssb_tx_bw_values",
+            "filter_shape": "filter_shape_values",
+        }[section]
+        assert getattr(rig, values_attr) is None
+
+
+class TestBreakInDomainDeclaredOrDocumentedAbsent:
+    """Every shipped profile must land on one of exactly two sides:
+
+    (a) it does not declare the ``break_in`` capability at all, or
+    (b) it declares ``break_in`` AND a non-empty ``[break_in] values``
+        domain — UNLESS it is one of the documented exceptions below, each
+        of which declares the capability without a domain for its own
+        reason (not an oversight):
+
+        - ``ftx1``: Yaesu CAT break-in is boolean on/off, not an enumerated
+          OFF/SEMI/FULL register — ``YaesuCatRadio.set_break_in`` collapses
+          any non-OFF value to ON by design (issue #1100), no TOML domain
+          needed.
+        - ``x6100``/``x6200``: advertise the capability but the backend's
+          break-in opcode (0x16 0x47, IC-7610's CW BK-IN register) is not
+          confirmed in either radio's documented CI-V table
+          (docs/validation/cat-audits/x6200.md lines 56/109/128/132; no
+          X6100 cat-audit exists at all). No trustworthy in-repo source for
+          a value domain — ``CoreRadio.set_break_in`` fails loud instead.
+    """
+
+    _NO_DOMAIN_BY_DESIGN = frozenset({"ftx1", "x6100", "x6200"})
+
+    @pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+    def test_break_in_capability_and_domain_agree(self, toml_path):
+        rig = load_rig(toml_path)
+        has_break_in_capability = "break_in" in rig.capabilities
+
+        if not has_break_in_capability:
+            assert rig.break_in_modes is None, (
+                f"{toml_path.name}: declares [break_in] values without the "
+                f"'break_in' capability feature"
+            )
+            return
+
+        if toml_path.stem in self._NO_DOMAIN_BY_DESIGN:
+            assert rig.break_in_modes is None, (
+                f"{toml_path.name}: now declares a [break_in] domain — "
+                "update TestBreakInDomainDeclaredOrDocumentedAbsent's "
+                "_NO_DOMAIN_BY_DESIGN exception list to match"
+            )
+            return
+
+        assert rig.break_in_modes, (
+            f"{toml_path.name}: declares the 'break_in' capability but no "
+            f"(or an empty) [break_in] values domain"
+        )
+
+    def test_ic7610_family_declares_off_semi_full(self):
+        """IC-705/IC-7300/IC-9700/IC-7610 all declare the same CI-V 0x16
+        0x47 domain: 0=OFF, 1=SEMI, 2=FULL."""
+        for name in ("ic705", "ic7300", "ic9700", "ic7610"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert rig.break_in_modes == (0, 1, 2), name
+            assert rig.break_in_labels == {
+                "0": "OFF",
+                "1": "SEMI",
+                "2": "FULL",
+            }, name
+
+    def test_documented_exceptions_declare_capability_without_domain(self):
+        for name in ("ftx1", "x6100", "x6200"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert "break_in" in rig.capabilities, name
+            assert rig.break_in_modes is None, name
+
+
+class TestNotchWidthDomain:
+    """'notch' is a broader capability than manual notch WIDTH — a radio
+    can have auto-notch with no manual-notch-width command at all (IC-705
+    has no CI-V 0x16 0x57 mapping yet still declares width_values "for UI
+    parity"; X6100/X6200 have neither the mapping nor a width domain). So,
+    unlike ssb_tx_bw/filter_shape below, this is NOT a strict
+    capability-implies-domain invariant — just direct regression pins."""
+
+    def test_ic7610_family_declares_wide_mid_nar(self):
+        for name in ("ic705", "ic7300", "ic9700", "ic7610"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert rig.notch_width_values == (0, 1, 2), name
+            assert rig.notch_width_labels == {
+                "0": "WIDE",
+                "1": "MID",
+                "2": "NAR",
+            }, name
+
+    def test_x6100_x6200_declare_notch_without_a_width_domain(self):
+        for name in ("x6100", "x6200"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert "notch" in rig.capabilities, name
+            assert rig.notch_width_values is None, name
+
+
+class TestSsbTxBwDomainDeclaredOrCapabilityAbsent:
+    @pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+    def test_ssb_tx_bw_capability_and_domain_agree(self, toml_path):
+        rig = load_rig(toml_path)
+        has_capability = "ssb_tx_bw" in rig.capabilities
+
+        if not has_capability:
+            assert rig.ssb_tx_bw_values is None, (
+                f"{toml_path.name}: declares [ssb_tx_bw] values without "
+                f"the 'ssb_tx_bw' capability feature"
+            )
+            return
+
+        assert rig.ssb_tx_bw_values, (
+            f"{toml_path.name}: declares the 'ssb_tx_bw' capability but no "
+            f"(or an empty) [ssb_tx_bw] values domain"
+        )
+
+    def test_ic7610_family_declares_wide_mid_nar(self):
+        for name in ("ic705", "ic7300", "ic9700", "ic7610"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert rig.ssb_tx_bw_values == (0, 1, 2), name
+
+
+class TestFilterShapeDomainDeclaredOrCapabilityAbsent:
+    """MOR-1534: filter_shape had NO TOML domain at all before this ticket
+    (unlike the other three, which were declared-but-dead). Added here for
+    the exact four profiles that already declare the ``filter_shape``
+    capability, sourced from docs/validation/cat-audits/{ic7300,ic7610}.md
+    (S/R-confirmed for those two) and, for ic705/ic9700 (no dedicated
+    cat-audit in-repo), from the shared runtime ``FilterShape`` enum's
+    pre-existing SHARP=0/SOFT=1 assumption for the same CI-V 0x16 0x56
+    command — see each profile's ``[filter_shape]`` TOML comment for the
+    exact provenance."""
+
+    @pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+    def test_filter_shape_capability_and_domain_agree(self, toml_path):
+        rig = load_rig(toml_path)
+        has_capability = "filter_shape" in rig.capabilities
+
+        if not has_capability:
+            assert rig.filter_shape_values is None, (
+                f"{toml_path.name}: declares [filter_shape] values without "
+                f"the 'filter_shape' capability feature"
+            )
+            return
+
+        assert rig.filter_shape_values, (
+            f"{toml_path.name}: declares the 'filter_shape' capability but "
+            f"no (or an empty) [filter_shape] values domain"
+        )
+
+    def test_ic7610_family_declares_sharp_soft(self):
+        for name in ("ic705", "ic7300", "ic9700", "ic7610"):
+            rig = load_rig(RIGS_DIR / f"{name}.toml")
+            assert rig.filter_shape_values == (0, 1), name
+            assert rig.filter_shape_labels == {"0": "SHARP", "1": "SOFT"}, name


### PR DESCRIPTION
Closes MOR-1534

## Summary

Four enumerated-domain controls violated the data-driven doctrine that MOR-1522 (AGC, #2437) and MOR-1523 (preamp, #2441) established — audit findings from #2441's sweep:

1. **break_in** (OFF/SEMI/FULL) — `[break_in]` declared in 4 Icom profiles but never parsed by `rig_loader.py`; `CoreRadio.set_break_in` cast every value through the hardcoded `BreakInMode` enum instead of a profile domain.
2. **manual notch width** (WIDE/MID/NAR) — `[notch] width_values` declared but dead; `set_manual_notch_width` had **zero** validation.
3. **ssb_tx_bw** (WIDE/MID/NAR) — declared-but-dead TOML; hardcoded `SsbTxBandwidth` enum cast.
4. **filter_shape** (SHARP/SOFT) — no TOML domain existed at all; hardcoded 2-value `FilterShape` enum cast.

All four now route through a single `_parse_enumerated_domain()` loader helper (generalizing `[agc]`'s fail-loud contract, including the MOR-1522 R1/B2 "labels without values" hole class) and a single per-control validation seat in `CoreRadio` (`runtime/radio.py`). Three of the four command builders in `commands/dsp.py`/`commands/mode.py` (`set_break_in`, `set_filter_shape`, `set_ssb_tx_bandwidth`) no longer enforce a hardcoded enum range — they only bound the wire format's single-BCD-byte range, mirroring `set_agc`'s MOR-1522 fix; domain legality is the profile-aware caller's job. `set_manual_notch_width` deliberately keeps its 0-2 bound for now: every shipped width domain is exactly (0,1,2) today, and loosening it to wire bounds is tracked as a follow-up together with folding `[agc]` into `_parse_enumerated_domain`.

## Per-control domain table (honest provenance)

| Control | Profile | Domain | Provenance | Live-validated? |
|---|---|---|---|---|
| break_in | ic705/ic7300/ic9700/ic7610 | `[0,1,2]` OFF/SEMI/FULL | Pre-existing TOML `[break_in]` (CI-V 0x16 0x47); IC-7610 hardware retired 2026-08-04, no cat-audit line item — rides the documented command table only | No |
| break_in | x6100, x6200 | **undeclared** (`set_break_in` fails loud) | `docs/validation/cat-audits/x6200.md` lines 56/109/128/132: the backend's opcode (0x16 0x47, IC-7610's BK-IN register) is **not** in the X6200's documented CI-V table at all — the X6200 PDF documents only QSK hang time (0x14 0x0F). No X6100 cat-audit exists in-repo (no X6100 hardware ever captured). No trustworthy source for either → left undeclared, `CoreRadio.set_break_in` refuses any value instead of guessing | No — explicitly refused |
| break_in | ftx1 | **undeclared** (by design) | Yaesu CAT break-in is boolean on/off (`BI` command), not an enumerated register; `YaesuCatRadio.set_break_in` collapses any non-OFF value to ON — issue #1100, untouched by this PR | N/A (different control shape) |
| notch width | ic705/ic7300/ic9700/ic7610 | `[0,1,2]` WIDE/MID/NAR | Pre-existing TOML `[notch] width_values` (CI-V 0x16 0x57) | No |
| notch width | x6100, x6200 | **undeclared** (permissive passthrough) | Neither radio has a `get/set_manual_notch_width` command mapped at all; `notch` capability covers auto-notch, not necessarily manual width — not a doctrine violation, just an absent sub-control | No |
| ssb_tx_bw | ic705/ic7300/ic9700/ic7610 | `[0,1,2]` WIDE/MID/NAR | Pre-existing TOML `[ssb_tx_bw]` (CI-V 0x16 0x58) | No |
| ssb_tx_bw | all others | **undeclared** (capability not declared) | Capability absent — no `[ssb_tx_bw]` needed | N/A |
| filter_shape | ic7300, ic7610 | `[0,1]` SHARP/SOFT | **New** TOML section, sourced from `docs/validation/cat-audits/ic7300.md`/`ic7610.md` — both S/R-confirm CI-V 0x16 0x56 "DSP filter type" | No — audits confirm presence/S-R, not a live SET/GET round-trip |
| filter_shape | ic705, ic9700 | `[0,1]` SHARP/SOFT | **New** TOML section — no dedicated cat-audit exists for either profile in-repo; domain sourced from the shared runtime `FilterShape` enum's pre-existing SHARP=0/SOFT=1 assumption for the same CI-V 0x16 0x56 command, already applied to these profiles by the previously-shared enum cast | No |
| filter_shape | all others | **undeclared** (capability not declared) | Capability absent | N/A |

Nothing in this table is claimed "live-validated" unless a cat-audit explicitly documents a live capture — ic7300/ic7610's filter_shape rows cite S/R-confirmed **presence**, not a live round-trip of the SET path.

## Validation-seat design (why break_in differs from the other three)

- **break_in**: domain `None` → **fails loud** (`ValueError`). This is a deliberate departure from the AGC/preamp "permissive when absent" precedent, because X6100/X6200 advertise the `break_in` *capability* while having no confirmed value domain — silently passing any value through would risk writing an undocumented register. Documented in both TOML files' `[capabilities]` notes and the setter's docstring.
- **notch width / ssb_tx_bw / filter_shape**: domain `None` → permissive passthrough, matching `set_agc`/`set_preamp` exactly. For notch width this is legitimate because `notch` covers auto-notch-only radios too; for the other two, no profile declares the capability without a domain today, so the permissive branch is currently unreachable.

## Frontend

No frontend changes for break_in/notch-width/ssb_tx_bw:
- break_in's `CwPanel.svelte` renders two hardcoded buttons (SEMI/FULL), not a synthesized option list from a domain array — and its values already match every profile that declares a domain.
- notch width's `DspSurface.svelte` renders a hardcoded 0–2 slider with `NOTCH_WIDTH_LABELS` — same story, no per-profile divergence exists today to fix.
- ssb_tx_bw has no UI at all (`ssbTxBandwidth` is a dead state field).

**filter_shape is flagged as a follow-up.** `FilterSurface.svelte`'s `FILTER_SHAPES = [[0,'SHARP'],[1,'SOFT']]` genuinely is a hardcoded option-list synthesis (the same bug class `buildAgcOptions` had before MOR-1522) and per the A11 doctrine should render from declared caps instead. Backend-only fix landed here because wiring the frontend correctly needs new caps fields threaded through `web/server.py`'s two capability-serialization call sites, the `Capabilities` TS type, `panel-props.ts`, `radio-view-model-adapter.ts`, and `radio-view-model.ts` before `FilterSurface.svelte` can consume them — a project on its own, and today's domain is uniform across all four declaring profiles (no live divergence bug to fix urgently, unlike AGC/preamp where wrong options were actually rendered).

## Red-first evidence

New tests were run against the pre-patch code (git-stashed implementation, tests kept) before implementing:

```
64 failed, 22 passed, 381 deselected in 1.46s
```

Representative failures against the old code:
- `ValueError: 9 is not a valid BreakInMode` (wrong message, no profile-domain check)
- `AttributeError: 'RigConfig' object has no attribute 'filter_shape_values'` (field didn't exist)
- `Failed: DID NOT RAISE <class 'ValueError'>` (X6100/X6200 previously accepted any break-in value)
- `ValueError: Value must be 0-2, got 9` (wire-format-only error, no domain message)

After implementation, the same tests are green (see Test plan).

## Test plan

- [x] `uv run pytest tests/test_rig_loader.py tests/test_radio.py tests/test_ftx1_radio.py tests/test_commands.py tests/test_radio_poller_coverage.py tests/test_dsp_filter_family.py -q` — 1321 passed, 1 skipped
- [x] `uv run ruff check src/ tests/` — zero violations
- [x] `uv run ruff format --check src/ tests/` — all formatted
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `uv run mypy` on all touched files not already carrying pre-existing baseline errors — zero new issues (`commands/dsp.py`/`commands/mode.py` carry 79 pre-existing `no-any-return` errors from `_build_function_value_set`, confirmed identical count against the pre-patch HEAD copy — none introduced by this change)
- [x] All 8 shipped profiles (`ic7300/ic705/ic9700/ic7610/x6100/x6200/ftx1/tx500`) load cleanly via `load_rig()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


