### PR TITLE
fix: profile-gated cmd29 for NB/NR/IP+ builders (MOR-1537 follow-up)

### DIFF
--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -226,11 +226,23 @@ def set_digisel(
 
 
 def get_nb(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to read NB status."""
     if cmd_map is not None:
-        return _build_from_map(cmd_map, "get_nb", to_addr=to_addr, from_addr=from_addr)
+        return _build_from_map(
+            cmd_map,
+            "get_nb",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            command29=command29,
+        )
+    if command29:
+        return build_cmd29_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_NB)
     return build_civ_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_NB)
 
 
@@ -240,20 +252,22 @@ def set_nb(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Set Noise Blanker on/off."""
+    data = bytes([0x01 if on else 0x00])
     if cmd_map is not None:
         return _build_from_map(
             cmd_map,
             "set_nb",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=bytes([0x01 if on else 0x00]),
+            data=data,
             receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
+            command29=command29,
         )
-    data = bytes([0x01 if on else 0x00])
-    if receiver != RECEIVER_MAIN:
+    if command29:
         return build_cmd29_frame(
             to_addr, from_addr, _CMD_PREAMP, sub=_SUB_NB, data=data, receiver=receiver
         )
@@ -261,11 +275,23 @@ def set_nb(
 
 
 def get_nr(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to read NR status."""
     if cmd_map is not None:
-        return _build_from_map(cmd_map, "get_nr", to_addr=to_addr, from_addr=from_addr)
+        return _build_from_map(
+            cmd_map,
+            "get_nr",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            command29=command29,
+        )
+    if command29:
+        return build_cmd29_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_NR)
     return build_civ_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_NR)
 
 
@@ -275,20 +301,22 @@ def set_nr(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Set Noise Reduction on/off."""
+    data = bytes([0x01 if on else 0x00])
     if cmd_map is not None:
         return _build_from_map(
             cmd_map,
             "set_nr",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=bytes([0x01 if on else 0x00]),
+            data=data,
             receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
+            command29=command29,
         )
-    data = bytes([0x01 if on else 0x00])
-    if receiver != RECEIVER_MAIN:
+    if command29:
         return build_cmd29_frame(
             to_addr, from_addr, _CMD_PREAMP, sub=_SUB_NR, data=data, receiver=receiver
         )
@@ -296,13 +324,23 @@ def set_nr(
 
 
 def get_ip_plus(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build CI-V command to read IP+ status."""
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_ip_plus", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_ip_plus",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            command29=command29,
         )
+    if command29:
+        return build_cmd29_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_IP_PLUS)
     return build_civ_frame(to_addr, from_addr, _CMD_PREAMP, sub=_SUB_IP_PLUS)
 
 
@@ -312,20 +350,22 @@ def set_ip_plus(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Set IP+ on/off."""
+    data = bytes([0x01 if on else 0x00])
     if cmd_map is not None:
         return _build_from_map(
             cmd_map,
             "set_ip_plus",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=bytes([0x01 if on else 0x00]),
+            data=data,
             receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
+            command29=command29,
         )
-    data = bytes([0x01 if on else 0x00])
-    if receiver != RECEIVER_MAIN:
+    if command29:
         return build_cmd29_frame(
             to_addr,
             from_addr,

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -4090,7 +4090,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_nb(self) -> bool:
         """Read Noise Blanker status."""
         self._check_connected()
-        civ = get_nb(to_addr=self._radio_addr)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x22)
+        civ = get_nb(to_addr=self._radio_addr, command29=cmd29)
         resp = await self._send_civ_expect(civ, label="get_nb")
         return resp.data[0] == 0x01 if resp.data else False
 
@@ -4105,13 +4106,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_nb",
         )
-        civ = set_nb(on, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x22)
+        civ = set_nb(on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_nr(self) -> bool:
         """Read Noise Reduction status."""
         self._check_connected()
-        civ = get_nr(to_addr=self._radio_addr)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x40)
+        civ = get_nr(to_addr=self._radio_addr, command29=cmd29)
         resp = await self._send_civ_expect(civ, label="get_nr")
         return resp.data[0] == 0x01 if resp.data else False
 
@@ -4126,13 +4129,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_nr",
         )
-        civ = set_nr(on, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x40)
+        civ = set_nr(on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_ip_plus(self) -> bool:
         """Read IP+ status."""
         self._check_connected()
-        civ = get_ip_plus(to_addr=self._radio_addr)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x65)
+        civ = get_ip_plus(to_addr=self._radio_addr, command29=cmd29)
         resp = await self._send_civ_expect(civ, label="get_ip_plus")
         return resp.data[0] == 0x01 if resp.data else False
 
@@ -4147,7 +4152,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_ip_plus",
         )
-        civ = set_ip_plus(on, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x16, 0x65)
+        civ = set_ip_plus(
+            on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_repeater_tone(self, receiver: int = 0) -> bool:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -602,10 +602,22 @@ class TestCmd29ReceiverRouting:
         assert frame[6] == 0x14
         assert frame[7] == 0x03  # SQL sub
 
-    def test_set_nb_main_no_cmd29(self) -> None:
+    def test_set_nb_main_wrapped_by_default(self) -> None:
+        # MOR-1537 follow-up: set_nb's builder now defaults command29=True
+        # like every other cmd29-eligible setter, instead of deriving the
+        # wrap decision from receiver internally.
         from rigplane.commands import RECEIVER_MAIN, set_nb
 
         frame = set_nb(True, receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x16
+        assert frame[7] == 0x22  # NB sub
+
+    def test_set_nb_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, set_nb
+
+        frame = set_nb(True, receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x16  # Direct cmd, no cmd29
         assert frame[5] == 0x22  # NB sub
 
@@ -619,10 +631,19 @@ class TestCmd29ReceiverRouting:
         assert frame[7] == 0x22  # NB sub
         assert frame[8] == 0x01  # on=True
 
-    def test_set_nr_main_no_cmd29(self) -> None:
+    def test_set_nr_main_wrapped_by_default(self) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_nr
 
         frame = set_nr(False, receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x16
+        assert frame[7] == 0x40  # NR sub
+
+    def test_set_nr_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, set_nr
+
+        frame = set_nr(False, receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x16
         assert frame[5] == 0x40  # NR sub
 
@@ -636,10 +657,19 @@ class TestCmd29ReceiverRouting:
         assert frame[7] == 0x40  # NR sub
         assert frame[8] == 0x00  # on=False
 
-    def test_set_ip_plus_main_no_cmd29(self) -> None:
+    def test_set_ip_plus_main_wrapped_by_default(self) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_ip_plus
 
         frame = set_ip_plus(True, receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x16
+        assert frame[7] == 0x65  # IP+ sub
+
+    def test_set_ip_plus_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, set_ip_plus
+
+        frame = set_ip_plus(True, receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x16
         assert frame[5] == 0x65  # IP+ sub
 
@@ -682,9 +712,11 @@ class TestCmd29ReceiverRouting:
         assert set_rf_gain(128)[4] == 0x14
         assert set_af_level(200)[4] == 0x14
         assert set_squelch(50)[4] == 0x14
-        assert set_nb(True)[4] == 0x16
-        assert set_nr(True)[4] == 0x16
-        assert set_ip_plus(True)[4] == 0x16
+        # MOR-1537 follow-up: nb/nr/ip_plus builders now default
+        # command29=True; no receiver arg still targets MAIN (0x00).
+        assert set_nb(True)[4:6] == b"\x29\x00"
+        assert set_nr(True)[4:6] == b"\x29\x00"
+        assert set_ip_plus(True)[4:6] == b"\x29\x00"
 
 
 class TestDspLevelParityCommands:

--- a/tests/test_mor1537_followup_cmd29_gating.py
+++ b/tests/test_mor1537_followup_cmd29_gating.py
@@ -1,0 +1,283 @@
+"""Tests for the MOR-1537 follow-up — profile-gated cmd29 for NB/NR/IP+.
+
+MOR-1517 (#2434) established the pattern and MOR-1537 (#2451) extended it to
+AGC/AF-mute/DIGI-SEL: a CI-V command builder must accept an explicit
+``command29: bool`` keyword-only override, and the ``radio.py`` call site must
+compute ``cmd29 = self._profile.supports_cmd29(cmd, sub)`` and thread it
+through — never derive the wrap decision from ``receiver`` inside the builder.
+
+Auditing that bug class found three more commands with the exact stale shape
+in ``commands/dsp.py``:
+
+- ``set_nb`` (0x16/0x22), ``set_nr`` (0x16/0x40), ``set_ip_plus`` (0x16/0x65)
+  computed ``command29=(receiver != RECEIVER_MAIN)`` internally with no
+  override parameter, and their GET twins (``get_nb``/``get_nr``/
+  ``get_ip_plus``) were always-plain with no override at all.
+
+IC-7610 declares ``[cmd29]`` routes for all three subs, so
+``set_nb(on, receiver=0)`` on IC-7610 sent a PLAIN frame for the MAIN
+receiver even though the profile declares a cmd29 route — the same shape
+mismatch against the acquisition/scheduler path that MOR-1537 fixed for AGC.
+(MOR-1517's audit classified these three as "already correct" without
+checking IC-7610's route table; that classification was wrong.)
+
+IC-7300 declares no ``[cmd29]`` section at all -> every frame must remain
+bare/unwrapped there, byte-for-byte identical to the pre-fix behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.types import CivFrame
+
+from test_mor1517_cmd29_gating import (
+    _connected_icom,
+    _mock_expect,
+    _mock_raw,
+    _sent_civ,
+)
+
+_IC7300_ADDR = 0x94
+_IC7610_ADDR = 0x98
+
+
+# ---------------------------------------------------------------------------
+# Route-table sanity: the whole point of the fix is that IC-7610 *does*
+# declare cmd29 routes for these subs (contrary to MOR-1517's classification).
+# ---------------------------------------------------------------------------
+
+
+class TestRouteTableSanity:
+    @pytest.mark.parametrize("sub", [0x22, 0x40, 0x65])
+    def test_ic7610_declares_route(self, sub: int) -> None:
+        radio = _connected_icom(model="IC-7610")
+        assert radio._profile.supports_cmd29(0x16, sub) is True
+
+    @pytest.mark.parametrize("sub", [0x22, 0x40, 0x65])
+    def test_ic7300_declares_no_route(self, sub: int) -> None:
+        radio = _connected_icom(model="IC-7300")
+        assert radio._profile.supports_cmd29(0x16, sub) is False
+
+
+# ---------------------------------------------------------------------------
+# Builder-level: explicit command29 override, receiver no longer decides.
+# Expected frames are raw byte literals on purpose — they pin the wire format
+# independently of the builder under test.
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderOverride:
+    def test_set_nb_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_nb
+
+        frame = set_nb(True, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e02900162201fd")
+
+    def test_set_nb_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_nb
+
+        frame = set_nb(True, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e0162201fd")
+
+    def test_set_nr_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_nr
+
+        frame = set_nr(False, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e02900164000fd")
+
+    def test_set_nr_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_nr
+
+        frame = set_nr(False, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e0164000fd")
+
+    def test_set_ip_plus_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_ip_plus
+
+        frame = set_ip_plus(True, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e02900166501fd")
+
+    def test_set_ip_plus_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_ip_plus
+
+        frame = set_ip_plus(True, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e0166501fd")
+
+    def test_get_nb_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_nb
+
+        frame = get_nb(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e029001622fd")
+
+    def test_get_nb_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_nb
+
+        frame = get_nb(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e01622fd")
+
+    def test_get_nr_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_nr
+
+        frame = get_nr(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e029001640fd")
+
+    def test_get_nr_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_nr
+
+        frame = get_nr(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e01640fd")
+
+    def test_get_ip_plus_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_ip_plus
+
+        frame = get_ip_plus(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e029001665fd")
+
+    def test_get_ip_plus_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_ip_plus
+
+        frame = get_ip_plus(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e01665fd")
+
+
+# ---------------------------------------------------------------------------
+# Runtime call sites: cmd29 must come from the profile, not from receiver.
+# The pinned defect is the IC-7610 receiver=0 (MAIN) case: it must now go
+# out 0x29-wrapped because the profile declares the route.
+# ---------------------------------------------------------------------------
+
+
+class TestNbGating:
+    @pytest.mark.asyncio
+    async def test_set_nb_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_nb(True, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02900162201fd")
+
+    @pytest.mark.asyncio
+    async def test_set_nb_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_nb(True, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02901162201fd")
+
+    @pytest.mark.asyncio
+    async def test_set_nb_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_nb(True, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e0162201fd")
+
+    @pytest.mark.asyncio
+    async def test_get_nb_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x22, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_nb()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e029001622fd")
+        assert value is True
+
+    @pytest.mark.asyncio
+    async def test_get_nb_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x16, sub=0x22, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_nb()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e01622fd")
+        assert value is True
+
+
+class TestNrGating:
+    @pytest.mark.asyncio
+    async def test_set_nr_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_nr(False, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02900164000fd")
+
+    @pytest.mark.asyncio
+    async def test_set_nr_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_nr(True, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02901164001fd")
+
+    @pytest.mark.asyncio
+    async def test_set_nr_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_nr(True, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e0164001fd")
+
+    @pytest.mark.asyncio
+    async def test_get_nr_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x40, data=b"\x00"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_nr()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e029001640fd")
+        assert value is False
+
+    @pytest.mark.asyncio
+    async def test_get_nr_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x16, sub=0x40, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_nr()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e01640fd")
+        assert value is True
+
+
+class TestIpPlusGating:
+    @pytest.mark.asyncio
+    async def test_set_ip_plus_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_ip_plus(True, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02900166501fd")
+
+    @pytest.mark.asyncio
+    async def test_set_ip_plus_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_ip_plus(True, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02901166501fd")
+
+    @pytest.mark.asyncio
+    async def test_set_ip_plus_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_ip_plus(True, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e0166501fd")
+
+    @pytest.mark.asyncio
+    async def test_get_ip_plus_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7610_ADDR, command=0x16, sub=0x65, data=b"\x01"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_ip_plus()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e029001665fd")
+        assert value is True
+
+    @pytest.mark.asyncio
+    async def test_get_ip_plus_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0, from_addr=_IC7300_ADDR, command=0x16, sub=0x65, data=b"\x00"
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_ip_plus()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e01665fd")
+        assert value is False

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -63,15 +63,27 @@ def _data_mode_response(on: bool) -> bytes:
     return _wrap_civ_in_udp(civ)
 
 
-def _bool_response(cmd: int, sub: int | None, value: bool) -> bytes:
+def _bool_response(
+    cmd: int, sub: int | None, value: bool, *, receiver: int | None = None
+) -> bytes:
     """CI-V response with a single bool byte for NB/NR/IP+ etc."""
-    civ = build_civ_frame(
-        CONTROLLER_ADDR,
-        IC_7610_ADDR,
-        cmd,
-        sub=sub,
-        data=bytes([0x01 if value else 0x00]),
-    )
+    if receiver is None:
+        civ = build_civ_frame(
+            CONTROLLER_ADDR,
+            IC_7610_ADDR,
+            cmd,
+            sub=sub,
+            data=bytes([0x01 if value else 0x00]),
+        )
+    else:
+        civ = build_cmd29_frame(
+            CONTROLLER_ADDR,
+            IC_7610_ADDR,
+            cmd,
+            sub=sub,
+            data=bytes([0x01 if value else 0x00]),
+            receiver=receiver,
+        )
     return _wrap_civ_in_udp(civ)
 
 
@@ -724,8 +736,9 @@ async def test_set_digisel_succeeds_on_ack(
 async def test_get_nb_returns_true(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
-    # NB command is 0x16, sub 0x22 (typical IC-7610)
-    mock_transport.queue_response(_bool_response(0x16, 0x22, True))
+    # NB command is 0x16, sub 0x22 — IC-7610 declares a cmd29 route, so
+    # the request and the radio's reply are both 0x29-wrapped (MOR-1537).
+    mock_transport.queue_response(_bool_response(0x16, 0x22, True, receiver=0))
     result = await radio.get_nb()
     assert result is True
 
@@ -745,7 +758,7 @@ async def test_set_nb_sends_command(
 async def test_get_nr_returns_false(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
-    mock_transport.queue_response(_bool_response(0x16, 0x40, False))
+    mock_transport.queue_response(_bool_response(0x16, 0x40, False, receiver=0))
     result = await radio.get_nr()
     assert result is False
 
@@ -765,7 +778,7 @@ async def test_set_nr_sends_command(
 async def test_get_ip_plus_returns_true(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
-    mock_transport.queue_response(_bool_response(0x16, 0x65, True))
+    mock_transport.queue_response(_bool_response(0x16, 0x65, True, receiver=0))
     result = await radio.get_ip_plus()
     assert result is True
 
@@ -2128,7 +2141,7 @@ async def test_get_nb_returns_false_on_empty_data(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """get_nb() returns False when response has no data (line 1462)."""
-    civ = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x22)
+    civ = build_cmd29_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x22)
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
     result = await radio.get_nb()
     assert result is False
@@ -2138,7 +2151,7 @@ async def test_get_nr_returns_true_on_data(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """get_nr() returns True when response data byte is 0x01 (line 1475)."""
-    civ = build_civ_frame(
+    civ = build_cmd29_frame(
         CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x40, data=bytes([0x01])
     )
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
@@ -2150,7 +2163,7 @@ async def test_get_nr_returns_false_on_empty_data(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """get_nr() returns False when response has no data (line 1475 else branch)."""
-    civ = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x40)
+    civ = build_cmd29_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x40)
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
     result = await radio.get_nr()
     assert result is False
@@ -2160,7 +2173,7 @@ async def test_get_ip_plus_returns_true_on_data(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """get_ip_plus() returns True when response data byte is 0x01 (line 1490)."""
-    civ = build_civ_frame(
+    civ = build_cmd29_frame(
         CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x65, data=bytes([0x01])
     )
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
@@ -2172,7 +2185,7 @@ async def test_get_ip_plus_returns_false_on_empty_data(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """get_ip_plus() returns False when response has no data (line 1490 else branch)."""
-    civ = build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x65)
+    civ = build_cmd29_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0x16, sub=0x65)
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
     result = await radio.get_ip_plus()
     assert result is False


### PR DESCRIPTION
## Summary

Audit follow-up to MOR-1537 (#2451). Three more commands in `src/rigplane/commands/dsp.py` carried the exact stale pattern MOR-1537 fixed for AGC/AF-mute/DIGI-SEL:

- `set_nb` (0x16/0x22), `set_nr` (0x16/0x40), `set_ip_plus` (0x16/0x65) computed `command29=(receiver != RECEIVER_MAIN)` inside the builder with no override parameter.
- Their GET twins (`get_nb`/`get_nr`/`get_ip_plus`) were always-plain with no override at all.

IC-7610 declares `[cmd29]` routes for all three subs, so `set_nb(on, receiver=0)` etc. sent a **plain** frame for the MAIN receiver even though the profile declares a cmd29 route — the same shape mismatch against the acquisition/scheduler path that MOR-1537 fixed for AGC. PR #2434 (MOR-1517)'s audit classified these three as "already correct — not part of this bug class" without checking IC-7610's route table; this PR corrects that classification.

## Changes

- `commands/dsp.py`: the six builders now accept a keyword-only `command29: bool = True` override (direct and `cmd_map` paths both honor it); the receiver-derived wrap decision is gone.
- `runtime/radio.py`: `get_nb`/`set_nb`, `get_nr`/`set_nr`, `get_ip_plus`/`set_ip_plus` thread `cmd29 = self._profile.supports_cmd29(0x16, sub)` through, mirroring how MOR-1537 fixed `get_af_mute`/`set_af_mute`. Existing `_require_capability` / `_require_receiver` / `_require_cmd29_route` gating at the setters is unchanged.
- `tests/test_mor1537_followup_cmd29_gating.py` (new, TDD): raw byte-literal frame pins for all six builders and all six runtime call sites on IC-7610 (wrapped, incl. MAIN) and IC-7300 (unwrapped), plus route-table sanity checks. 18 of these tests failed before the fix.
- `tests/test_commands.py`, `tests/test_radio_coverage.py`: updated pins that encoded the stale receiver-derived behavior (coverage-test responses now cmd29-wrapped to match what an IC-7610 actually returns to a wrapped read, same as the existing digisel tests in that file).

## Behavior change matrix

| Profile | receiver | Before | After |
|---|---|---|---|
| IC-7610 | 0 (MAIN) | plain 0x16 xx | **0x29 0x00 wrapped** (profile declares route) |
| IC-7610 | 1 (SUB) | wrapped | wrapped (unchanged) |
| IC-7300 | 0 | plain | plain (byte-for-byte unchanged) |

## Verification

- `uv run pytest tests/ -q --ignore=tests/integration` — 9383 passed, 0 failed
- `uv run ruff check src/ tests/` + `ruff format --check` — clean
- `uv run mypy src/` — identical 13-error baseline as main (none in touched files)

Note: no dedicated MOR ticket — Linear write access was unavailable in this session; this is tracked as a follow-up under MOR-1537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)