### PR TITLE
fix: ic705 no longer over-declares digisel (MOR-1540)

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -45,7 +45,16 @@ features = [
     # RF front end
     "attenuator",
     "preamp",
-    "digisel",       # wfview: DIGI-SEL Shift (0x14 0x13) only — no 0x16 0x4E toggle in IC-705.rig
+    # NOTE: no "digisel" capability (0x16 0x4E DIGI-SEL toggle) on IC-705 —
+    # wfview's IC-705.rig only exposes DIGI-SEL Shift (0x14 0x13, see
+    # get_digisel_shift/set_digisel_shift in [commands] below), never the
+    # 0x16 0x4E on/off command this capability string gates. Declaring
+    # "digisel" here made IcomRadio.set_preamp(level>0) run a get_digisel()
+    # pre-flight that sent an unanswerable 0x16 0x4E frame and blocked for
+    # a full CI-V timeout on every call (MOR-1540). Provenance: wfview/
+    # hamlib-doc-sourced (repo's ic705-research.md is no longer vendored
+    # here) — IC-705 is NOT on the live bench, so this is doc-level
+    # confidence, not live-validated.
     # Antenna
     "antenna",
     "rx_antenna",    # wfview: RX Antenna 0x16 0x53 (IC-7300.rig omits this command)

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -4056,6 +4056,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         other command in this family. Previously this also hard-raised
         ``CommandError`` for receiver=MAIN when the profile lacked the
         route, instead of unwrapping like the rest of the family (MOR-1537).
+
+        That earlier raise was NOT purely redundant, contrary to MOR-1537's
+        framing: it was the only thing turning a profile that over-declares
+        the ``"digisel"`` capability without a matching cmd29 route/command
+        into a fast, explicit ``CommandError`` instead of a live, always-
+        0x16/0x4E CI-V send that blocks for a full timeout because the
+        radio never answers (MOR-1540 hit this on IC-705). The fix for that
+        class of bug is correcting the capability declaration at the source
+        (``rigs/<model>.toml``), not restoring the raise here — this method
+        still unwraps for MAIN as documented above.
         """
         self._check_connected()
         self._require_capability("digisel", operation="get_digisel")

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1472,7 +1472,10 @@ async def test_relative_vfo_epoch_reset_discards_vfo_facts_but_not_ptt() -> None
 
 @pytest.mark.parametrize(
     ("model", "expected_seconds"),
-    (("IC-7300", 8.0), ("IC-705", 11.1)),
+    # IC-705 dropped from 11.1s to 11.0s (one fewer query per rotation) when
+    # MOR-1540 removed the over-declared "digisel" capability, which had
+    # been adding an unanswerable 0x16/0x4E poll to every rotation.
+    (("IC-7300", 8.0), ("IC-705", 11.0)),
 )
 def test_relative_vfo_retention_window_follows_provider_poll_cadence(
     model: str,

--- a/tests/test_rig_ic705_mor1540.py
+++ b/tests/test_rig_ic705_mor1540.py
@@ -1,0 +1,99 @@
+"""MOR-1540: IC-705 must not over-declare the ``digisel`` capability.
+
+``rigs/ic705.toml`` declared the ``"digisel"`` capability (0x16 0x4E DIGI-SEL
+toggle) with its own comment admitting IC-705 has no 0x16 0x4E command —
+only DIGI-SEL Shift (0x14 0x13, ``get_digisel_shift``/``set_digisel_shift``).
+Because ``IcomRadio.set_preamp(level>0)`` runs a DIGI-SEL pre-flight gated
+purely on ``"digisel" in self.capabilities``, and the CI-V builder for
+``get_digisel``/``set_digisel`` unconditionally targets 0x16/0x4E regardless
+of whether the profile declares the command, every ``set_preamp(level>0)``
+call on IC-705 sent an unanswerable CI-V frame and blocked for a full
+timeout.
+
+TDD red-first: written against the unfixed ``rigs/ic705.toml`` (before this
+ticket's edit), every test below fails/hangs. After removing "digisel" from
+IC-705's declared capabilities, they pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rigplane.radio import IcomRadio
+from rigplane.rig_loader import load_rig
+from rigplane.runtime._state_queries import build_state_queries
+from test_radio import MockTransport
+
+RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+IC705_PATH = RIGS_DIR / "ic705.toml"
+
+
+@pytest.fixture()
+def rig():
+    return load_rig(IC705_PATH)
+
+
+@pytest.fixture()
+def profile(rig):
+    return rig.to_profile()
+
+
+@pytest.fixture()
+def cmdmap(rig):
+    return rig.to_command_map()
+
+
+@pytest.fixture()
+def mock_transport() -> MockTransport:
+    return MockTransport()
+
+
+class TestDigiselCapabilityRemoved:
+    """Profile-level: "digisel" (0x16 0x4E toggle) is not declared."""
+
+    def test_no_digisel_capability(self, profile) -> None:
+        assert "digisel" not in profile.capabilities
+
+    def test_no_digisel_toggle_commands(self, cmdmap) -> None:
+        assert not cmdmap.has("get_digisel")
+        assert not cmdmap.has("set_digisel")
+
+    def test_digisel_shift_commands_still_present(self, cmdmap) -> None:
+        """DIGI-SEL *Shift* (0x14 0x13) is real on IC-705 and must survive."""
+        assert cmdmap.has("get_digisel_shift")
+        assert cmdmap.has("set_digisel_shift")
+
+
+class TestPollerSkipsDigiselQuery:
+    """Cascade: the per-receiver state-query builder follows the capability."""
+
+    def test_no_0x16_0x4e_query_for_ic705(self, profile) -> None:
+        caps = set(profile.capabilities)
+        queries = build_state_queries(profile, caps, is_serial=False)
+        digisel_queries = [q for q in queries if q[0] == 0x16 and q[1] == 0x4E]
+        assert digisel_queries == []
+
+
+class TestSetPreampSkipsDigiselPreflight:
+    """Cascade: set_preamp(level>0) no longer probes DIGI-SEL on IC-705."""
+
+    @pytest.mark.asyncio
+    async def test_set_preamp_sends_no_digisel_frame(
+        self, mock_transport: MockTransport
+    ) -> None:
+        radio = IcomRadio("192.168.1.100", model="IC-705", timeout=0.05)
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        try:
+            await radio.set_preamp(1)
+        finally:
+            radio._connected = False
+
+        # No get_digisel pre-flight frame (opcode 0x16 sub 0x4E) may appear
+        # anywhere on the wire -- before the fix this frame was sent and the
+        # call blocked for the full CI-V timeout waiting on a reply that
+        # never comes.
+        assert not any(b"\x16\x4e" in pkt for pkt in mock_transport.sent_packets)


### PR DESCRIPTION
## Summary

`rigs/ic705.toml` declared the `"digisel"` capability (0x16 0x4E DIGI-SEL toggle) with its own comment admitting IC-705 has no 0x16 0x4E command in wfview's IC-705.rig — only DIGI-SEL *Shift* (0x14 0x13, unaffected by this fix, still declared via `get_digisel_shift`/`set_digisel_shift`). Because `IcomRadio.set_preamp(level>0)` runs a DIGI-SEL pre-flight gated purely on `"digisel" in self.capabilities`, and the `get_digisel`/`set_digisel` CI-V builders unconditionally target 0x16/0x4E regardless of whether the profile declares the command, **every `set_preamp(level>0)` call on IC-705 sent an unanswerable CI-V frame and blocked for a full timeout**.

- Removed `"digisel"` from `rigs/ic705.toml`'s declared capabilities, with a provenance comment.
- Corrected the `get_digisel()` docstring added in MOR-1537/#2451, which characterized the removed hard-raise as purely redundant — it was the only thing converting an over-declared-capability profile into a fast explicit error instead of a live CI-V send that blocks for a timeout (exactly this bug). The fix is correcting the declaration at the source, not restoring the raise.
- Verified (not assumed) the cascade:
  - The legacy per-receiver poller (`build_state_queries`) already gates each query on `cap in capabilities` — IC-705 has no `[state_acquisition]` block so it never runs the new `AcquisitionScheduler`. Removing the capability alone stops the wasted 0x16/0x4E poll; no separate poller gating bug.
  - The frontend already hides DIGI-SEL controls when the capability is absent (existing `rf-front-end-adapter` tests) — no frontend changes needed.

## Provenance disclosure

IC-705 is **not** on the live bench. The capability removal is based on the TOML's own existing comment plus wfview/hamlib documentation-level confidence — not live-validated. No `references/wfview` tree or `ic705-research.md` are currently vendored in this repo to re-derive the claim independently, so this fix trusts the prior researcher's documented finding rather than re-proving it from a primary source.

## Flagged, not fixed here (out of guardrail scope)

`web/handlers/control.py` gates `set_digisel_shift` on the same `"digisel"` capability string used for the unrelated 0x16/0x4E toggle. `CoreRadio.set_digisel_shift` itself is **not** capability-gated (works fine at the runtime layer), but a web client explicitly invoking `set_digisel_shift` on IC-705 will now be rejected by that shared web-layer gate, even though the underlying 0x14/0x13 command is real and supported on IC-705. No UI currently renders a DIGI-SEL Shift control for any radio (grepped), so this is latent, not observed. Recommend a follow-up ticket introducing a distinct `digisel_shift` capability key rather than reusing `"digisel"`.

## Test plan

- [x] TDD red-first: `tests/test_rig_ic705_mor1540.py`, run against the unfixed TOML (reverted via patch, not stash), fails 3/5 (capability present, poller still queries 0x16/0x4E, `set_preamp` still sends the DIGI-SEL frame). Passes 5/5 after the fix.
- [x] `tests/test_radio_poller_coverage.py`'s IC-705 poll-cadence fixture updated (11.1s → 11.0s) — a direct, correct consequence of one fewer per-rotation query.
- [x] Broad regression pass: `test_ic705*.py`, `test_rig_ic7300.py`, `test_rig_multi_vendor.py`, `test_mor1517_cmd29_gating.py`, `test_mor1537_cmd29_gating.py`, `test_radio_coverage.py`, `test_radio.py`, `test_radio_poller_coverage.py`, `test_web_capability_guards.py`, `test_handlers_dsp_407_408.py`, `test_state_pipeline_contracts.py`, `test_acquisition_scheduler.py`, `test_web_server.py`, `test_radios.py`, `test_backend_factory.py`, `test_profiles_runtime.py` — 1460 passed, 2 skipped.
- [x] `uv run ruff check` / `uv run ruff format --check` clean on changed files.
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken.
- [x] `uv run mypy src/` — 13 pre-existing baseline errors, none in changed files (no new errors).

Closes MOR-1540.