### PR TITLE
feat: VFO-select fallback for tone/filter_width on cmd29-less dual-RX rigs (MOR-1538)

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2202,7 +2202,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         when the profile lists ``[0x1A, 0x03]`` in its cmd29 routes
         (IC-7610). The profile must declare a ``set_filter_width`` command
         before the runtime sends a write. On dual-RX profiles that do not
-        list the cmd29 route (IC-9700), ``receiver=1`` (SUB) raises
+        list the cmd29 route but do declare VFO select codes (IC-9700),
+        ``receiver=1`` (SUB) is reached by temporarily selecting SUB via
+        CI-V 0x07, sending the plain (non-cmd29) frame, then restoring the
+        previously active receiver — mirroring :meth:`set_freq`. Profiles
+        with neither a cmd29 route nor VFO select codes still raise
         ``CommandError`` instead of silently writing MAIN.
 
         Args:
@@ -2216,12 +2220,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             raise CommandError(
                 f"set_filter_width is unsupported by profile {self._profile.model}"
             )
-        self._require_cmd29_route(
-            0x1A,
-            0x03,
-            receiver=receiver,
-            operation="set_filter_width",
-        )
 
         target = self._radio_state.receiver("SUB" if receiver else "MAIN")
         mode_name = getattr(target, "mode", None)
@@ -2258,8 +2256,25 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # CI-V 1A 03: 1-byte BCD index (wfview-confirmed). cmd29-wrapped
         # for receiver routing on dual-RX rigs (IC-7610), direct on single-RX
         # (IC-705) and on MAIN for dual-RX rigs without cmd29 support
-        # (IC-9700). SUB on a dual-RX rig without cmd29 support is rejected
-        # above by ``_require_cmd29_route`` rather than sent to MAIN.
+        # (IC-9700). SUB on a dual-RX rig without cmd29 support but with VFO
+        # select codes (IC-9700) is reached via the VFO-select fallback
+        # instead of sent to MAIN; SUB with neither raises below.
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1A, 0x03):
+            await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="set_filter_width",
+                action=lambda: self.send_civ(
+                    0x1A, sub=0x03, data=bcd_index_byte, wait_response=False
+                ),
+            )
+            return
+
+        self._require_cmd29_route(
+            0x1A,
+            0x03,
+            receiver=receiver,
+            operation="set_filter_width",
+        )
         if self._profile.supports_cmd29(0x1A, 0x03):
             await self.send_civ(
                 0x29,
@@ -2278,8 +2293,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         BCD segmented index; Xiegu X6200 uses a single raw byte index. The
         request is cmd29-wrapped only when the profile lists ``[0x1A, 0x03]``
         in its cmd29 routes. On dual-RX profiles that do not list the
-        route (IC-9700), ``receiver=1`` (SUB) raises ``CommandError``
-        instead of silently reading MAIN.
+        route but do declare VFO select codes (IC-9700), ``receiver=1``
+        (SUB) is reached via the VFO-select fallback (mirroring
+        :meth:`set_freq`) instead of silently reading MAIN. Profiles with
+        neither a cmd29 route nor VFO select codes still raise
+        ``CommandError``.
 
         Args:
             receiver: 0=MAIN, 1=SUB.
@@ -2289,28 +2307,46 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         self._require_receiver(receiver, operation="get_filter_width")
-        self._require_cmd29_route(
-            0x1A,
-            0x03,
-            receiver=receiver,
-            operation="get_filter_width",
-        )
 
         # CI-V 1A 03: 1-byte BCD index for every Icom rig (wfview-confirmed).
         # cmd29-wrapped only for receiver routing on dual-RX rigs that list
         # the route (IC-7610). IC-705/IC-9700 send the request directly on
-        # MAIN; SUB without a cmd29 route is rejected above.
-        if self._profile.supports_cmd29(0x1A, 0x03):
-            civ = get_filter_width(to_addr=self._radio_addr, receiver=receiver)
-        else:
-            civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
+        # MAIN; SUB without a cmd29 route uses the VFO-select fallback when
+        # available, else is rejected below.
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1A, 0x03):
 
-        resp = await self._send_civ_expect(
-            civ,
-            key=f"get_filter_width:{receiver}",
-            dedupe=True,
-            label="get_filter_width",
-        )
+            async def _action() -> CivFrame:
+                civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
+                return await self._send_civ_expect(
+                    civ,
+                    key=f"get_filter_width:{receiver}",
+                    dedupe=True,
+                    label="get_filter_width",
+                )
+
+            resp = await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="get_filter_width",
+                action=_action,
+            )
+        else:
+            self._require_cmd29_route(
+                0x1A,
+                0x03,
+                receiver=receiver,
+                operation="get_filter_width",
+            )
+            if self._profile.supports_cmd29(0x1A, 0x03):
+                civ = get_filter_width(to_addr=self._radio_addr, receiver=receiver)
+            else:
+                civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
+
+            resp = await self._send_civ_expect(
+                civ,
+                key=f"get_filter_width:{receiver}",
+                dedupe=True,
+                label="get_filter_width",
+            )
         if resp.command != 0x1A or resp.sub != 0x03:
             raise ValueError(
                 f"Not a filter-width response: command 0x{resp.command:02x} "
@@ -4168,6 +4204,32 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def get_repeater_tone(self, receiver: int = 0) -> bool:
         """Read repeater tone status (0x16 0x42)."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="get_repeater_tone")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(
+            0x16, _SUB_REPEATER_TONE
+        ):
+
+            async def _action() -> bool:
+                civ = _get_repeater_tone_cmd(
+                    to_addr=self._radio_addr,
+                    receiver=RECEIVER_MAIN,
+                    command29=False,
+                )
+                return await self._get_bool_value(
+                    civ,
+                    key="get_repeater_tone",
+                    command=0x16,
+                    sub=_SUB_REPEATER_TONE,
+                )
+
+            return await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="get_repeater_tone",
+                action=_action,
+            )
+
         self._require_cmd29_route(
             0x16, _SUB_REPEATER_TONE, receiver=receiver, operation="get_repeater_tone"
         )
@@ -4181,6 +4243,30 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_repeater_tone(self, on: bool, receiver: int = 0) -> None:
         """Set repeater tone on/off (0x16 0x42)."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="set_repeater_tone")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(
+            0x16, _SUB_REPEATER_TONE
+        ):
+
+            async def _action() -> None:
+                await self._send_fire_and_forget(
+                    _set_repeater_tone_cmd(
+                        on,
+                        to_addr=self._radio_addr,
+                        receiver=RECEIVER_MAIN,
+                        command29=False,
+                    )
+                )
+
+            await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="set_repeater_tone",
+                action=_action,
+            )
+            return
+
         self._require_cmd29_route(
             0x16, _SUB_REPEATER_TONE, receiver=receiver, operation="set_repeater_tone"
         )
@@ -4193,6 +4279,32 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def get_repeater_tsql(self, receiver: int = 0) -> bool:
         """Read repeater TSQL status (0x16 0x43)."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="get_repeater_tsql")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(
+            0x16, _SUB_REPEATER_TSQL
+        ):
+
+            async def _action() -> bool:
+                civ = _get_repeater_tsql_cmd(
+                    to_addr=self._radio_addr,
+                    receiver=RECEIVER_MAIN,
+                    command29=False,
+                )
+                return await self._get_bool_value(
+                    civ,
+                    key="get_repeater_tsql",
+                    command=0x16,
+                    sub=_SUB_REPEATER_TSQL,
+                )
+
+            return await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="get_repeater_tsql",
+                action=_action,
+            )
+
         self._require_cmd29_route(
             0x16, _SUB_REPEATER_TSQL, receiver=receiver, operation="get_repeater_tsql"
         )
@@ -4206,6 +4318,30 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_repeater_tsql(self, on: bool, receiver: int = 0) -> None:
         """Set repeater TSQL on/off (0x16 0x43)."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="set_repeater_tsql")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(
+            0x16, _SUB_REPEATER_TSQL
+        ):
+
+            async def _action() -> None:
+                await self._send_fire_and_forget(
+                    _set_repeater_tsql_cmd(
+                        on,
+                        to_addr=self._radio_addr,
+                        receiver=RECEIVER_MAIN,
+                        command29=False,
+                    )
+                )
+
+            await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="set_repeater_tsql",
+                action=_action,
+            )
+            return
+
         self._require_cmd29_route(
             0x16, _SUB_REPEATER_TSQL, receiver=receiver, operation="set_repeater_tsql"
         )
@@ -4219,6 +4355,26 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_tone_freq(self, receiver: int = 0) -> float:
         """Read CTCSS tone frequency in Hz (0x1B 0x00)."""
         self._check_connected()
+        self._require_receiver(receiver, operation="get_tone_freq")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x00):
+
+            async def _action() -> float:
+                civ = _get_tone_freq_cmd(
+                    to_addr=self._radio_addr,
+                    receiver=RECEIVER_MAIN,
+                    command29=False,
+                )
+                resp = await self._send_civ_expect(civ, label="get_tone_freq")
+                _, freq = parse_tone_freq_response(resp)
+                return freq
+
+            return await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="get_tone_freq",
+                action=_action,
+            )
+
         self._require_cmd29_route(
             0x1B, 0x00, receiver=receiver, operation="get_tone_freq"
         )
@@ -4232,6 +4388,28 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_tone_freq(self, freq_hz: float, receiver: int = 0) -> None:
         """Set CTCSS tone frequency in Hz (0x1B 0x00)."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="set_tone_freq")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x00):
+
+            async def _action() -> None:
+                await self._send_fire_and_forget(
+                    _set_tone_freq_cmd(
+                        freq_hz,
+                        to_addr=self._radio_addr,
+                        receiver=RECEIVER_MAIN,
+                        command29=False,
+                    )
+                )
+
+            await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="set_tone_freq",
+                action=_action,
+            )
+            return
+
         self._require_cmd29_route(
             0x1B, 0x00, receiver=receiver, operation="set_tone_freq"
         )
@@ -4245,6 +4423,26 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_tsql_freq(self, receiver: int = 0) -> float:
         """Read TSQL frequency in Hz (0x1B 0x01)."""
         self._check_connected()
+        self._require_receiver(receiver, operation="get_tsql_freq")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x01):
+
+            async def _action() -> float:
+                civ = _get_tsql_freq_cmd(
+                    to_addr=self._radio_addr,
+                    receiver=RECEIVER_MAIN,
+                    command29=False,
+                )
+                resp = await self._send_civ_expect(civ, label="get_tsql_freq")
+                _, freq = parse_tsql_freq_response(resp)
+                return freq
+
+            return await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="get_tsql_freq",
+                action=_action,
+            )
+
         self._require_cmd29_route(
             0x1B, 0x01, receiver=receiver, operation="get_tsql_freq"
         )
@@ -4258,6 +4456,28 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def set_tsql_freq(self, freq_hz: float, receiver: int = 0) -> None:
         """Set TSQL frequency in Hz (0x1B 0x01)."""
+        self._check_connected()
+        self._require_receiver(receiver, operation="set_tsql_freq")
+
+        if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x01):
+
+            async def _action() -> None:
+                await self._send_fire_and_forget(
+                    _set_tsql_freq_cmd(
+                        freq_hz,
+                        to_addr=self._radio_addr,
+                        receiver=RECEIVER_MAIN,
+                        command29=False,
+                    )
+                )
+
+            await self._run_with_receiver_vfo_fallback(
+                receiver=receiver,
+                operation="set_tsql_freq",
+                action=_action,
+            )
+            return
+
         self._require_cmd29_route(
             0x1B, 0x01, receiver=receiver, operation="set_tsql_freq"
         )

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -341,25 +341,40 @@ class TestIcomGetFilterWidthRouting:
         assert hz == 6000
 
     @pytest.mark.asyncio
-    async def test_ic9700_sub_receiver_raises_without_cmd29_route(self) -> None:
-        """MOR-1528: IC-9700 SUB (receiver=1) must not silently read MAIN.
+    async def test_ic9700_sub_receiver_uses_vfo_select_fallback(self) -> None:
+        """MOR-1538: IC-9700 SUB (receiver=1) reaches SUB via VFO-select.
 
-        IC-9700 is dual-RX (receiver_count=2) but declares no cmd29 routes.
-        Before this fix, ``get_filter_width(receiver=1)`` built the same
-        direct (receiver-unaware) frame as ``receiver=0`` and returned
-        whatever the radio happened to report for its currently-addressed
-        receiver — attributed to SUB. This must now raise instead.
+        IC-9700 is dual-RX (receiver_count=2) with no cmd29 routes but does
+        declare ``vfo.main_select``/``sub_select`` (0x07 0xD0/0xD1).
+        ``get_filter_width(receiver=1)`` now temporarily selects SUB, sends
+        the plain (non-cmd29) 0x1A 0x03 GET, then restores MAIN — mirroring
+        :meth:`set_freq`'s fallback — instead of raising ``CommandError``.
         """
-        from rigplane.exceptions import CommandError
-
         radio = _connected_icom(model="IC-9700")
-        radio._send_civ_expect = AsyncMock()  # type: ignore[method-assign]
         radio._radio_state.sub.mode = "USB"
+        frames: list[bytes] = []
 
-        with pytest.raises(CommandError, match="no cmd29 route"):
-            await radio.get_filter_width(receiver=1)
+        async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+            frames.append(civ)
+            if civ[4] == 0x07:
+                # VFO select/restore ACK.
+                return CivFrame(
+                    to_addr=0xE0, from_addr=0xA2, command=0xFB, sub=None, data=b""
+                )
+            # 1-byte BCD 0x20 = decimal 20 = USB segment index 20 → 1600 Hz.
+            return CivFrame(
+                to_addr=0xE0, from_addr=0xA2, command=0x1A, sub=0x03, data=b"\x20"
+            )
 
-        radio._send_civ_expect.assert_not_awaited()
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+
+        hz = await radio.get_filter_width(receiver=1)
+
+        assert frames[0].hex() == "fefea2e007d1fd"  # select SUB
+        get_idx = next(i for i, f in enumerate(frames) if f[4] == 0x1A)
+        assert frames[get_idx].hex() == "fefea2e01a03fd"  # plain GET, no cmd29
+        assert frames[-1].hex() == "fefea2e007d0fd"  # restore MAIN
+        assert hz == 1600
 
     @pytest.mark.asyncio
     async def test_ic7610_sub_receiver_still_cmd29_wrapped(self) -> None:
@@ -431,24 +446,35 @@ class TestIcomSetFilterWidthRouting:
         )
 
     @pytest.mark.asyncio
-    async def test_ic9700_sub_receiver_raises_without_cmd29_route(self) -> None:
-        """MOR-1528: IC-9700 SUB (receiver=1) must not silently write MAIN.
+    async def test_ic9700_sub_receiver_uses_vfo_select_fallback(self) -> None:
+        """MOR-1538: IC-9700 SUB (receiver=1) reaches SUB via VFO-select.
 
-        IC-9700 is dual-RX (receiver_count=2) but declares no cmd29 routes.
-        Before this fix, ``set_filter_width(receiver=1)`` sent the same
-        direct (receiver-unaware) frame as ``receiver=0``, writing MAIN's
-        filter width while the caller believed SUB was targeted.
+        IC-9700 is dual-RX (receiver_count=2) with no cmd29 routes but does
+        declare ``vfo.main_select``/``sub_select`` (0x07 0xD0/0xD1).
+        ``set_filter_width(receiver=1)`` now temporarily selects SUB, sends
+        the plain (non-cmd29) 0x1A 0x03 SET, then restores MAIN — mirroring
+        :meth:`set_freq`'s fallback — instead of raising ``CommandError``.
         """
-        from rigplane.exceptions import CommandError
-
         radio = _connected_icom(model="IC-9700")
-        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
         radio._radio_state.sub.mode = "USB"
+        select_frames: list[bytes] = []
 
-        with pytest.raises(CommandError, match="no cmd29 route"):
-            await radio.set_filter_width(2400, receiver=1)
+        async def fake_expect(civ: bytes, **_: object) -> CivFrame:
+            select_frames.append(civ)
+            return CivFrame(
+                to_addr=0xE0, from_addr=0xA2, command=0xFB, sub=None, data=b""
+            )
 
-        radio.send_civ.assert_not_awaited()
+        radio._send_civ_expect = fake_expect  # type: ignore[method-assign]
+        radio.send_civ = AsyncMock()  # type: ignore[method-assign]
+
+        await radio.set_filter_width(2400, receiver=1)
+
+        assert select_frames[0].hex() == "fefea2e007d1fd"  # select SUB
+        assert select_frames[-1].hex() == "fefea2e007d0fd"  # restore MAIN
+        radio.send_civ.assert_awaited_once_with(
+            0x1A, sub=0x03, data=b"\x28", wait_response=False
+        )
 
     @pytest.mark.asyncio
     async def test_ic7610_sub_receiver_still_cmd29_wrapped(self) -> None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2924,18 +2924,23 @@ class TestToneTsqlParity:
 
 
 class TestToneTsqlDualRxCmd29Guard:
-    """MOR-1528: tone/TSQL methods must reject SUB routing without cmd29.
+    """MOR-1528/MOR-1538: tone/TSQL receiver=1 routing on cmd29-less dual-RX.
 
     IC-9700 is dual-RX (``receiver_count=2``) but declares no cmd29 routes
-    (``[cmd29] routes = []``). Before this fix, ``receiver=1`` calls on the
+    (``[cmd29] routes = []``). Before MOR-1528, ``receiver=1`` calls on the
     four tone/TSQL method pairs built a direct, receiver-unaware CI-V frame
     instead of raising — silently writing/reading MAIN while the caller
-    believed it was targeting SUB. Sibling guarded commands (e.g.
-    ``set_rf_gain``) already raise via ``_require_cmd29_route``; these
-    methods now match that contract. ``receiver=0`` (MAIN) and IC-7610 (has
-    cmd29 routes) behavior must stay byte-identical — see
-    ``TestToneTsqlParity`` above, which exercises the IC-7610 fixture on
-    both receivers and stays green.
+    believed it was targeting SUB. MOR-1528 made these raise, matching
+    ``_require_cmd29_route``-guarded siblings (e.g. ``set_rf_gain``).
+
+    MOR-1538 upgrades the raise to a working path: IC-9700 also declares
+    ``vfo.main_select``/``sub_select`` (0x07 0xD0/0xD1), so ``receiver=1``
+    now reaches SUB via the same VFO-switch fallback already used by
+    ``set_freq``/``set_mode``/``set_data_mode`` (select SUB, run the plain
+    non-cmd29 command, restore the previously active receiver) instead of
+    raising. ``receiver=0`` (MAIN) and IC-7610 (has cmd29 routes) behavior
+    stay byte-identical — see ``TestToneTsqlParity`` above, which exercises
+    the IC-7610 fixture on both receivers and stays green.
     """
 
     @pytest.fixture
@@ -2949,30 +2954,103 @@ class TestToneTsqlDualRxCmd29Guard:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("method_name", "args"),
+        ("method_name", "request_tail", "response_civ", "expected"),
         [
-            ("get_repeater_tone", ()),
-            ("set_repeater_tone", (True,)),
-            ("get_repeater_tsql", ()),
-            ("set_repeater_tsql", (True,)),
-            ("get_tone_freq", ()),
-            ("set_tone_freq", (88.5,)),
-            ("get_tsql_freq", ()),
-            ("set_tsql_freq", (110.9,)),
+            (
+                "get_repeater_tone",
+                b"\x16\x42\xfd",
+                build_civ_frame(CONTROLLER_ADDR, 0xA2, 0x16, sub=0x42, data=b"\x01"),
+                True,
+            ),
+            (
+                "get_repeater_tsql",
+                b"\x16\x43\xfd",
+                build_civ_frame(CONTROLLER_ADDR, 0xA2, 0x16, sub=0x43, data=b"\x00"),
+                False,
+            ),
+            (
+                "get_tone_freq",
+                b"\x1b\x00\xfd",
+                build_civ_frame(
+                    CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x00, data=b"\x00\x88\x05"
+                ),
+                88.5,
+            ),
+            (
+                "get_tsql_freq",
+                b"\x1b\x01\xfd",
+                build_civ_frame(
+                    CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x01, data=b"\x01\x10\x09"
+                ),
+                110.9,
+            ),
         ],
     )
-    async def test_sub_receiver_raises_without_cmd29_route(
+    async def test_sub_receiver_get_uses_vfo_select_fallback(
+        self,
+        ic9700_radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        request_tail: bytes,
+        response_civ: bytes,
+        expected: bool | float,
+    ) -> None:
+        """MOR-1538: SUB GETs reach SUB via VFO-select instead of raising."""
+        ack = _wrap_civ_in_udp(build_civ_frame(CONTROLLER_ADDR, 0xA2, _CMD_ACK))
+        mock_transport.queue_response_on_send(1, ack)
+        mock_transport.queue_response_on_send(2, _wrap_civ_in_udp(response_civ))
+        mock_transport.queue_response_on_send(3, ack)
+
+        method = getattr(ic9700_radio, method_name)
+        result = await method(receiver=1)
+
+        if isinstance(expected, float):
+            assert result == pytest.approx(expected)
+        else:
+            assert result is expected
+
+        frames = mock_transport.sent_packets
+        assert frames[0].endswith(b"\x07\xd1\xfd")  # select SUB
+        assert frames[1].endswith(request_tail)  # plain GET, no cmd29/receiver byte
+        assert frames[2].endswith(b"\x07\xd0\xfd")  # restore MAIN
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args", "expected_tail"),
+        [
+            ("set_repeater_tone", (True,), b"\x16\x42\x01\xfd"),
+            ("set_repeater_tsql", (True,), b"\x16\x43\x01\xfd"),
+            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x88\x05\xfd"),
+            ("set_tsql_freq", (110.9,), b"\x1b\x01\x01\x10\x09\xfd"),
+        ],
+    )
+    async def test_sub_receiver_set_uses_vfo_select_fallback(
         self,
         ic9700_radio: IcomRadio,
         mock_transport: MockTransport,
         method_name: str,
         args: tuple,
+        expected_tail: bytes,
     ) -> None:
+        """MOR-1538: SUB SETs reach SUB via VFO-select instead of raising.
+
+        Per-send ACK release — see
+        ``test_icom_receiver_tier.TestSetVfoSlot.
+        test_ic9700_sub_uses_select_restore_pattern`` for the 3.11-vs-3.12+
+        scheduling rationale (release each ACK only after its own send).
+        """
+        ack = _wrap_civ_in_udp(build_civ_frame(CONTROLLER_ADDR, 0xA2, _CMD_ACK))
+        mock_transport.queue_response_on_send(1, ack)
+        mock_transport.queue_response_on_send(2, ack)
+        mock_transport.queue_response_on_send(3, ack)
+
         method = getattr(ic9700_radio, method_name)
-        with pytest.raises(CommandError, match="no cmd29 route"):
-            await method(*args, receiver=1)
-        # No wire write occurred — the guard must fire before any send.
-        assert mock_transport.sent_packets == []
+        await method(*args, receiver=1)
+
+        frames = mock_transport.sent_packets
+        assert frames[0].endswith(b"\x07\xd1\xfd")  # select SUB
+        assert frames[1].endswith(expected_tail)  # plain SET, no cmd29/receiver byte
+        assert frames[2].endswith(b"\x07\xd0\xfd")  # restore MAIN
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes MOR-1538

MOR-1528 (#2446) added `_require_cmd29_route` guards to the 10 tone/TSQL/filter_width methods that were missing them, making `receiver=1` raise `CommandError` on cmd29-less dual-RX profiles (IC-9700) instead of silently mistargeting MAIN. That was correct but incomplete: IC-9700 declares `vfo.main_select`/`sub_select` (`0x07 0xD0`/`0xD1`) -- the same VFO-switch fallback already used by `set_freq`/`set_mode`/`set_data_mode` for exactly this situation.

This PR extends that fallback to the remaining 10 methods:

- `get/set_repeater_tone`
- `get/set_repeater_tsql`
- `get/set_tone_freq`
- `get/set_tsql_freq`
- `get/set_filter_width`

When a profile has no cmd29 route for the command but does declare VFO select codes, `receiver=1` now temporarily selects SUB, runs the plain (non-cmd29) command, and restores the previously active receiver -- mirroring `set_freq`'s read-modify-restore pattern exactly, including its failure path (a failed select aborts before the command runs against the wrong receiver; no poller-pause mechanism is introduced -- none exists for the precedent methods either). Profiles with **neither** a cmd29 route **nor** VFO select codes still raise `CommandError` (the MOR-1528 guard is the fallback-of-last-resort). `receiver=0` (MAIN) and IC-7610 (has cmd29 routes) behavior stay byte-identical.

Also adds the missing `_require_receiver` call (paired before `_require_cmd29_route`, matching the 15 sibling guarded commands) to all 8 tone/TSQL methods, so a single-RX profile now reports an accurate "does not support receiver=1 (receivers=1)" instead of the cmd29-route message.

**Not live-validated: IC-9700 is not on the bench (never procured — see docs/PROJECT.md M5.3 "hardware not yet procured").** This PR is byte-level/unit-tested only -- wire-frame assertions against a `MockTransport`, not verified against real hardware.

## Test plan

TDD, red-first:
- Reverted `src/rigplane/runtime/radio.py` to HEAD and confirmed all 10 updated/new "IC-9700 receiver=1" tests failed with the old `"no cmd29 route"` `CommandError`, then reapplied the fix and reran green.
- [x] `uv run pytest tests/test_radio.py tests/test_dsp_filter_family.py -q --tb=short` -- 298 passed
- [x] `uv run pytest tests/ -q --tb=short --ignore=tests/integration -k "tone or tsql or filter_width or ic9700 or IC-9700 or vfo"` -- 842 passed, 2 xfailed (pre-existing)
- [x] `uv run ruff check` / `ruff format --check` on the 3 changed files -- clean
- [x] `uv run lint-imports` -- 5 kept, 0 broken
- [x] `uv run mypy src/` -- 13 pre-existing errors in 4 unrelated files (baseline, not touched by this diff); 0 in `radio.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
