### PR TITLE
feat: post-write readback priority + data-driven cadence tightening (MOR-1484)

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -264,15 +264,32 @@ adaptive_decay = false
 # MOR-1484: bench-measured cadence tightening for the ACTIVE-VFO freq/mode
 # pair and the RF-gain/squelch sliders -- the fields the ticket's live IC-7300
 # probe (serial @115200) found trailing the operator most (medians 1.30s/
-# 2.16s/1.33s/2.22s, worst case up to 2.92s) because they shared the profile's
-# 17-field default 1.5s round-robin tier. Pulled into their own 1.0s/2.0s
-# tier: moves the cadence from 1.5s -> 1.0s AND shrinks the round-robin
-# population each shares from 17 down to 4, which cuts the worst-case gap
-# between successive polls of any one of them by far more than the cadence
-# ratio alone. Deliberately NOT 0.5-0.8s: MOR-1484's post-write readback
-# mechanism (``RadioPoller._request_post_write_readback``, USER priority)
-# already gives the operator's OWN write an immediate confirmed readback --
-# this tier only has to catch up a front-panel/other-CAT-client change or the
+# 2.16s/1.33s/2.22s, worst case up to 2.92s).
+#
+# Mechanism (MOR-1484 review R1 correction): AcquisitionScheduler groups
+# pollable fields by (scope, family, receiver_id, slot, policy) --
+# ``_AcquisitionRequestKey`` / ``_poll_cadence_groups`` in
+# acquisition_scheduler.py -- and each group gets its OWN independent cadence
+# clock; there is no single flat round-robin across every default-tier field.
+# freq_hz(active)/mode(active) (family ``freq_mode``) were ALREADY their own
+# isolated 2-field group before this PR, sharing a clock with nothing else,
+# so their gain here is purely the 1.5s -> 1.0s cadence-ratio speedup (a
+# ~33% shorter worst-case gap between polls of that pair), not a change in
+# how many fields they share a clock with. rf_gain/squelch (family
+# ``operator_controls``, same scope/receiver/slot) DID share a larger group
+# pre-PR -- {af_level, rf_gain, squelch, att, preamp, agc}, 6 fields, one
+# clock -- so pulling them into their own 2-field group has a genuine but
+# SECOND-ORDER extra benefit on top of the cadence-ratio gain: when that
+# clock fires, the executor no longer has to clear up to 4 other same-tick
+# siblings' frames through the ~20 q/s serial rate limiter
+# (_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS, 50ms/frame) before rf_gain/squelch's
+# own frames go out -- worth roughly 100-200ms off the worst case, not
+# several seconds.
+#
+# Deliberately NOT 0.5-0.8s: MOR-1484's post-write readback mechanism
+# (``RadioPoller._request_post_write_readback``, USER priority) already
+# gives the operator's OWN write an immediate confirmed readback -- this
+# tier only has to catch up a front-panel/other-CAT-client change or the
 # very first poll after connect, so 1.0s is a modest, budget-conservative
 # choice (see the serial-budget accounting at the bottom of this file), not
 # an attempt to match the post-write path's latency. unselectedVfo (measured
@@ -356,10 +373,15 @@ adaptive_decay = false
 # mic_gain populate (slow front-panel knob rotation, not a rigplane write —
 # nothing this profile owns can accelerate that with a post-write readback)
 # at 10.73s median / 16.25s worst case against this 15.0s-cadence tier's
-# "<=15s populate" intent — the round-robin-shared worst case can exceed the
-# nominal cadence itself. 10.0s/15.0s tightens the cadence with margin (a
-# fresh value is now due within 10s, not 15s, cutting the plausible worst
-# case well clear of the 15s target) at a modest added cost: 4 fields /
+# "<=15s populate" intent — these 4 fields share ONE cadence clock/group
+# (same scope/family/receiver/policy, see the mechanism note above the
+# freq/mode/rf_gain/squelch tier) and fire together each time it is due, but
+# the resulting frames still have to clear the ~20 q/s whole-lane serial rate
+# limiter alongside every OTHER group's traffic due around the same moment —
+# that contention, not anything internal to this group, is why the observed
+# worst case exceeds the nominal cadence. 10.0s/15.0s tightens the cadence
+# with margin (a fresh value is now due within 10s, not 15s, cutting the
+# plausible worst case well clear of the 15s target) at a modest added cost: 4 fields /
 # 10.0s = 0.4 q/s vs the previous 4/15.0 = 0.267 q/s, +0.133 q/s. The budget
 # accounting comment above the freq/mode/rf_gain/squelch tier (this file,
 # above) shows where that -- and the freq/mode/rf_gain/squelch tightening's

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -261,6 +261,84 @@ cadence_seconds = 0.3
 freshness_ttl_seconds = 1.0
 adaptive_decay = false
 
+# MOR-1484: bench-measured cadence tightening for the ACTIVE-VFO freq/mode
+# pair and the RF-gain/squelch sliders -- the fields the ticket's live IC-7300
+# probe (serial @115200) found trailing the operator most (medians 1.30s/
+# 2.16s/1.33s/2.22s, worst case up to 2.92s) because they shared the profile's
+# 17-field default 1.5s round-robin tier. Pulled into their own 1.0s/2.0s
+# tier: moves the cadence from 1.5s -> 1.0s AND shrinks the round-robin
+# population each shares from 17 down to 4, which cuts the worst-case gap
+# between successive polls of any one of them by far more than the cadence
+# ratio alone. Deliberately NOT 0.5-0.8s: MOR-1484's post-write readback
+# mechanism (``RadioPoller._request_post_write_readback``, USER priority)
+# already gives the operator's OWN write an immediate confirmed readback --
+# this tier only has to catch up a front-panel/other-CAT-client change or the
+# very first poll after connect, so 1.0s is a modest, budget-conservative
+# choice (see the serial-budget accounting at the bottom of this file), not
+# an attempt to match the post-write path's latency. unselectedVfo (measured
+# 1.18s/2.54s) and af_level are deliberately left on the default 1.5s tier --
+# the ticket's operator-felt symptoms (pending-frequency echo, slider trail)
+# are about the ACTIVE vfo and rf_gain/squelch specifically; widening this
+# tier further would eat into the budget freed below for no measured gain.
+[state_acquisition.field_policies."receiver.main.active.freq_mode.freq_hz"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.active.freq_mode.mode"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.rf_gain"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.squelch"]
+cadence_seconds = 1.0
+freshness_ttl_seconds = 2.0
+adaptive_decay = false
+
+# MOR-1484: this profile's ~20 q/s serial floor (see the accounting at the
+# bottom of this file) has essentially no free headroom for the 1.0s tier
+# above without giving something back. These six fields are settings an
+# operator changes rarely mid-QSO (tuner match, RF power level, compressor
+# on/level, attenuator, preamp) rather than continuously-live readouts like
+# freq/mode/rf_gain/squelch/s_meter/ptt, and none of them appear in the
+# ticket's measured or operator-felt symptom list -- 3.0s/6.0s trades a cheap,
+# low-stakes cadence give-back on these for real headroom to spend on the
+# fields that were actually measured trailing the operator.
+[state_acquisition.field_policies."global.operator_controls.tuner_status"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 6.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.power_level"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 6.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.tx_state.compressor_on"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 6.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."global.operator_controls.compressor_level"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 6.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.att"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 6.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.preamp"]
+cadence_seconds = 3.0
+freshness_ttl_seconds = 6.0
+adaptive_decay = false
+
 # MOR-1452 (review fix): mic/monitor/VOX/anti-VOX gain. IC-7610 polls these
 # same 4 fields at 3.0s/5.0s (rigs/ic7610.toml), but IC-7610 is LAN — IC-7300
 # is SERIAL, sharing one ~20 transactions/s software floor
@@ -270,28 +348,40 @@ adaptive_decay = false
 # pre-existing ~19.667 q/s demand (freq/mode/keep-alive/af/rf/squelch/
 # att/preamp/agc/nb/nr/power/compressor/ptt/tuner/split, each 1/cadence) —
 # 21.0 q/s, structurally over the 20 q/s ceiling, degrading cadence on EVERY
-# polled field including PTT (0.3s) and freq/mode (1.5s). 15.0s/25.0s instead
-# adds only 4/15.0 = 0.267 q/s -> 19.933 q/s, leaving real headroom rather
-# than sitting exactly on the boundary. A live bench measurement at the gate
-# may justify tightening this later (tracked as a bench follow-up item).
+# polled field including PTT (0.3s) and freq/mode (1.5s). 15.0s/25.0s was
+# chosen instead to leave real headroom rather than sitting exactly on the
+# boundary.
+#
+# MOR-1484 (bench-measured follow-up): the ticket's live probe measured
+# mic_gain populate (slow front-panel knob rotation, not a rigplane write —
+# nothing this profile owns can accelerate that with a post-write readback)
+# at 10.73s median / 16.25s worst case against this 15.0s-cadence tier's
+# "<=15s populate" intent — the round-robin-shared worst case can exceed the
+# nominal cadence itself. 10.0s/15.0s tightens the cadence with margin (a
+# fresh value is now due within 10s, not 15s, cutting the plausible worst
+# case well clear of the 15s target) at a modest added cost: 4 fields /
+# 10.0s = 0.4 q/s vs the previous 4/15.0 = 0.267 q/s, +0.133 q/s. The budget
+# accounting comment above the freq/mode/rf_gain/squelch tier (this file,
+# above) shows where that -- and the freq/mode/rf_gain/squelch tightening's
+# larger cost -- comes from.
 [state_acquisition.field_policies."global.operator_controls.mic_gain"]
-cadence_seconds = 15.0
-freshness_ttl_seconds = 25.0
+cadence_seconds = 10.0
+freshness_ttl_seconds = 15.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.monitor_gain"]
-cadence_seconds = 15.0
-freshness_ttl_seconds = 25.0
+cadence_seconds = 10.0
+freshness_ttl_seconds = 15.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.vox_gain"]
-cadence_seconds = 15.0
-freshness_ttl_seconds = 25.0
+cadence_seconds = 10.0
+freshness_ttl_seconds = 15.0
 adaptive_decay = false
 
 [state_acquisition.field_policies."global.operator_controls.anti_vox_gain"]
-cadence_seconds = 15.0
-freshness_ttl_seconds = 25.0
+cadence_seconds = 10.0
+freshness_ttl_seconds = 15.0
 adaptive_decay = false
 
 # MOR-1485 (TX/PA meters dead on serial): owner ruling splits the six 0x15
@@ -303,8 +393,9 @@ adaptive_decay = false
 # is chosen for TX-window responsiveness, matching this profile's own
 # 1.5s-or-faster tier for everything else that matters live; it only ever
 # fires during a TX segment, transiently adding 4 fields / 1.0s = 4.0 q/s on
-# top of this profile's ~19.967 q/s RX-state demand (see vd/id below) for as
-# long as the key is down -- an accepted, TX-scoped tradeoff, not a
+# top of this profile's RX-state demand (see vd/id below; 19.967 q/s when
+# this was written, 19.433 q/s after the MOR-1484 cadence tightening above)
+# for as long as the key is down -- an accepted, TX-scoped tradeoff, not a
 # steady-state regression of the MOR-1484 serial medians.
 [state_acquisition.field_policies."global.meters.power"]
 cadence_seconds = 1.0
@@ -341,7 +432,9 @@ tx_only = true
 # to the MOR-1484 medians. 60.0s spends under half of that remaining headroom
 # (2 fields / 60.0s = 0.033 q/s, 19.933 -> 19.967 q/s) while still refreshing
 # a slowly-varying supply rail/current reading roughly once a minute --
-# "live", just not fast.
+# "live", just not fast. (These 19.933/19.967 figures predate the MOR-1484
+# cadence tightening above/below this block -- see that block's comment for
+# the current total, 19.433 q/s.)
 [state_acquisition.field_policies."global.meters.vd"]
 cadence_seconds = 60.0
 freshness_ttl_seconds = 90.0

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -507,6 +507,28 @@ _POST_WRITE_READBACK_FIELDS: dict[type, Callable[[Any], tuple[FieldPath, ...]]] 
             _post_write_receiver_id(cmd), "operator_controls", "squelch"
         ),
     ),
+    # MOR-1484 review R1: att/preamp carry the #2452 armed affordance, whose
+    # ONLY confirming path back to the StateStore is this cadence poll --
+    # ``PendingOverlay`` has no web consumer and the CI-V own-frame/transceive
+    # echo this profile relies on for other fields does not reliably cover
+    # these two (see the "read-after-write via overlays + ... observation"
+    # comments on the ``SetAttenuator``/``SetPreamp`` case arms below, which
+    # describe the mechanism but not its actual reach on this profile). This
+    # PR ALSO slows att/preamp's cadence tier from 1.5s to 3.0s
+    # (rigs/ic7300.toml) to fund the freq/mode/rf_gain/squelch tightening
+    # above -- without this entry that give-back alone would widen the
+    # armed-affordance confirm window past the 3000ms ACK_CONFIRM_GRACE for a
+    # slice of clicks (grace expires, armed clears, the button shows the
+    # stale value until the next cadence tick -- the MOR-1478 stale-flash
+    # symptom, reintroduced on a new affordance). Table entries here make the
+    # 1.5s->3.0s give-back free for the operator's own write: confirmation no
+    # longer depends on the slowed cadence tier at all.
+    SetAttenuator: lambda cmd: (
+        FieldPath.receiver(_post_write_receiver_id(cmd), "operator_controls", "att"),
+    ),
+    SetPreamp: lambda cmd: (
+        FieldPath.receiver(_post_write_receiver_id(cmd), "operator_controls", "preamp"),
+    ),
 }
 
 # ``ensure_fresh``'s ``max_age`` asks "how old may the CURRENT StateStore

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -78,6 +78,7 @@ from ..core.command_service import (
 )
 from ..core.acquisition_scheduler import (
     AcquisitionExecutor,
+    AcquisitionPriority,
     AcquisitionRequest,
     AcquisitionScheduler,
     MeterObservationCoalescer,
@@ -449,6 +450,71 @@ from .._poller_types import (  # noqa: E402
     VfoEqualize,
     VfoSwap,
 )
+
+
+# ------------------------------------------------------------------
+# MOR-1484: post-write readback jump-queue
+# ------------------------------------------------------------------
+#
+# Forces a fresh readback of the field(s) a write command just changed
+# instead of waiting out that field's normal poll cadence -- the "pending
+# frequency echo" / "slider readouts trail ~1s" symptom the ticket measured
+# on freq/mode/rfGain/squelch. These are the operator-facing writes in this
+# dispatch that carry no ``CommandService`` optimistic-overlay + confirming-
+# observation path the way nb/nr/att/preamp/agc/mic_gain/etc already do (see
+# the "read-after-write via overlays + ... observation" comments on those
+# ``case`` arms below) -- without a forced readback they only refresh on the
+# field's normal cadence tick.
+#
+# Table-driven so covering another command later is a new entry here, not a
+# new call site: ``_request_post_write_readback`` (called once, generically,
+# at the end of ``_execute`` below) looks up ``type(cmd)`` and, on a hit,
+# builds the written ``FieldPath`` set and calls
+# ``AcquisitionScheduler.ensure_fresh`` at ``USER`` priority -- the
+# scheduler's highest rank (``_PRIORITY_RANK`` in ``acquisition_scheduler.py``)
+# -- so the request jumps ahead of whatever BACKGROUND/RECONCILIATION/
+# NORMAL-tier cadence work is already queued and is picked up by the very
+# next ``_send_scheduler_requests`` drain, instead of waiting out the
+# field's own cadence.
+def _post_write_receiver_id(cmd: Any) -> str:
+    """Return the ``main``/``sub`` receiver_id spelling.
+
+    This is the spelling ``field_policies`` TOML keys and the scheduler's
+    cadence-driven requests already use (``rigs/*.toml``, e.g.
+    ``[state_acquisition.field_policies."receiver.main..."]``), so a
+    post-write request coalesces into any already-pending same-field request
+    (``_AcquisitionRequestKey`` groups by exact ``receiver_id`` string)
+    instead of racing it as a second, differently-keyed entry.
+    """
+
+    return "sub" if getattr(cmd, "receiver", 0) == 1 else "main"
+
+
+_POST_WRITE_READBACK_FIELDS: dict[type, Callable[[Any], tuple[FieldPath, ...]]] = {
+    SetFreq: lambda cmd: (
+        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "freq_hz"),
+    ),
+    SetMode: lambda cmd: (
+        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "mode"),
+    ),
+    SetRfGain: lambda cmd: (
+        FieldPath.receiver(
+            _post_write_receiver_id(cmd), "operator_controls", "rf_gain"
+        ),
+    ),
+    SetSquelch: lambda cmd: (
+        FieldPath.receiver(
+            _post_write_receiver_id(cmd), "operator_controls", "squelch"
+        ),
+    ),
+}
+
+# ``ensure_fresh``'s ``max_age`` asks "how old may the CURRENT StateStore
+# observation be and still count as fresh". A write always invalidates
+# whatever confirmed observation predates it, so this is deliberately far
+# below any real cadence/ttl -- the point is to force a request every time,
+# never take the ``FRESH`` short-circuit against a pre-write value.
+_POST_WRITE_READBACK_MAX_AGE: float = 1e-9
 
 
 # ------------------------------------------------------------------
@@ -1141,6 +1207,37 @@ class RadioPoller:
             )
         except Exception:
             logger.debug("radio-poller: %s reconfirm failed", label, exc_info=True)
+
+    def _request_post_write_readback(self, cmd: Command) -> None:
+        """Jump the scheduler queue for the field(s) ``cmd`` just wrote (MOR-1484).
+
+        Table-driven counterpart to :meth:`_reconfirm_scope_field` for
+        non-scope fields: looks ``type(cmd)`` up in
+        ``_POST_WRITE_READBACK_FIELDS`` and, on a hit, calls
+        ``AcquisitionScheduler.ensure_fresh`` at ``AcquisitionPriority.USER``
+        (the scheduler's highest rank) for the FieldPath(s) it names. Fire-
+        and-queue like ``ensure_fresh`` itself — this never awaits a backend
+        read; it only ensures the request is queued ahead of any pending
+        BACKGROUND/RECONCILIATION/NORMAL-tier cadence work so the next
+        ``_send_scheduler_requests`` drain fetches a confirmed value instead
+        of waiting out the field's normal cadence. A miss (command not in
+        the table, or no scheduler attached) is a silent no-op.
+        """
+        scheduler = self._acquisition_scheduler
+        if scheduler is None:
+            return
+        build_paths = _POST_WRITE_READBACK_FIELDS.get(type(cmd))
+        if build_paths is None:
+            return
+        paths = build_paths(cmd)
+        if not paths:
+            return
+        scheduler.ensure_fresh(
+            paths,
+            max_age=_POST_WRITE_READBACK_MAX_AGE,
+            priority=AcquisitionPriority.USER,
+            reason="post_write_readback",
+        )
 
     def _apply_global_control_observation(
         self,
@@ -3059,6 +3156,15 @@ class RadioPoller:
                         self._on_state_event("split_changed", {"on": True})
             case Speak(mode=what):
                 await _r.get_speech(what)
+
+        # MOR-1484: jump the scheduler queue for whatever field(s) this
+        # write just changed (table-driven no-op for any command not in
+        # ``_POST_WRITE_READBACK_FIELDS``). Placed after the match rather
+        # than per-case so covering another command is a table entry, not a
+        # new call site; safe here because none of the mapped commands
+        # (``SetFreq``/``SetMode``/``SetRfGain``/``SetSquelch``) return early
+        # out of the match above.
+        self._request_post_write_readback(cmd)
 
     # Fast: meters (polled on even cycles)
     # wfview: Priority=Highest, queue interval 25ms for LAN (HasFDComms)

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -17,6 +17,7 @@ from rigplane.core.capabilities import CAP_SCOPE
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
+    AcquisitionStatus,
     MeterObservationCoalescer,
 )
 from rigplane.core.state_acquisition_policy import (
@@ -961,6 +962,117 @@ async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
         wait_dispatch=False,
     )
     assert scheduler.pending_requests()[0].paths == (path,)
+
+
+# ---------------------------------------------------------------------------
+# MOR-1484: post-write readback jumps the scheduler queue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("cmd", "path"),
+    [
+        (
+            SetFreq(14_250_000, receiver=0),
+            FieldPath.active("main", "freq_mode", "freq_hz"),
+        ),
+        (SetMode("USB", receiver=0), FieldPath.active("main", "freq_mode", "mode")),
+        (
+            SetFreq(7_100_000, receiver=1),
+            FieldPath.active("sub", "freq_mode", "freq_hz"),
+        ),
+        (
+            SetRfGain(128, receiver=0),
+            FieldPath.receiver("main", "operator_controls", "rf_gain"),
+        ),
+        (
+            SetSquelch(64, receiver=0),
+            FieldPath.receiver("main", "operator_controls", "squelch"),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_execute_write_requests_immediate_readback_at_user_priority(
+    cmd: Any, path: FieldPath
+) -> None:
+    """A successful write must jump the scheduler queue for an immediate
+    readback of the field it just changed, at USER priority (the scheduler's
+    highest rank) -- instead of waiting out that field's normal poll cadence.
+    This is the fix for the "pending frequency echo" / "slider readouts trail
+    ~1s" symptom MOR-1484 measured on freq/mode/rfGain/squelch.
+    """
+    radio = _make_radio(active="MAIN")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._execute(cmd)  # noqa: SLF001
+
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    assert pending[0].paths == (path,)
+    assert pending[0].priority is AcquisitionPriority.USER
+
+
+@pytest.mark.asyncio
+async def test_execute_set_freq_readback_coalesces_with_pending_cadence_request() -> (
+    None
+):
+    """A post-write readback for a field with an already-queued BACKGROUND/
+    RECONCILIATION-tier cadence request must coalesce into that SAME request
+    (upgraded to USER priority) rather than racing it as a second, separately
+    -tracked entry -- the coalescing MOR-1484 requires so the forced readback
+    never doubles the serial traffic for a field already about to be polled.
+    """
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    pending_before = scheduler.ensure_fresh(
+        (path,),
+        max_age=1.5,
+        priority=AcquisitionPriority.BACKGROUND,
+        reason="cadence",
+    )
+    assert pending_before.status == AcquisitionStatus.QUEUED
+    assert len(scheduler.pending_requests()) == 1
+
+    await poller._execute(SetFreq(14_250_000, receiver=0))  # noqa: SLF001
+
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1  # coalesced, not a second entry
+    assert pending[0].priority is AcquisitionPriority.USER
+
+
+@pytest.mark.asyncio
+async def test_execute_unmapped_write_does_not_queue_a_readback() -> None:
+    """A write command with no entry in ``_POST_WRITE_READBACK_FIELDS`` (e.g.
+    ``SetPower``) must be a silent no-op for this mechanism -- it must not
+    queue any acquisition request."""
+    radio = _make_radio(active="MAIN")
+    path = FieldPath.global_("operator_controls", "power_level")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._execute(SetPower(200))  # noqa: SLF001
+
+    assert scheduler.pending_requests() == ()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_freq_without_scheduler_does_not_raise() -> None:
+    """A backend with no acquisition scheduler attached (``_acquisition_scheduler``
+    is ``None``) must not error when a mapped write command executes."""
+    radio = _make_radio(active="MAIN")
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+    assert poller._acquisition_scheduler is None  # noqa: SLF001
+
+    await poller._execute(SetFreq(14_250_000, receiver=0))  # noqa: SLF001
+
+    radio.set_freq.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -989,6 +989,14 @@ async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
             SetSquelch(64, receiver=0),
             FieldPath.receiver("main", "operator_controls", "squelch"),
         ),
+        (
+            SetAttenuator(10, receiver=0),
+            FieldPath.receiver("main", "operator_controls", "att"),
+        ),
+        (
+            SetPreamp(1, receiver=0),
+            FieldPath.receiver("main", "operator_controls", "preamp"),
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -999,7 +1007,14 @@ async def test_execute_write_requests_immediate_readback_at_user_priority(
     readback of the field it just changed, at USER priority (the scheduler's
     highest rank) -- instead of waiting out that field's normal poll cadence.
     This is the fix for the "pending frequency echo" / "slider readouts trail
-    ~1s" symptom MOR-1484 measured on freq/mode/rfGain/squelch.
+    ~1s" symptom MOR-1484 measured on freq/mode/rfGain/squelch. att/preamp
+    are included (MOR-1484 review R1): both carry the #2452 armed affordance
+    whose only confirming path back to the StateStore is this cadence poll,
+    and this PR ALSO slows their cadence tier 1.5s -> 3.0s (rigs/ic7300.toml)
+    to fund the tightening above -- without this entry that give-back would
+    widen the armed-affordance confirm window past the 3000ms
+    ACK_CONFIRM_GRACE for a slice of clicks (the MOR-1478 stale-flash
+    symptom, reintroduced on a new affordance).
     """
     radio = _make_radio(active="MAIN")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
@@ -1011,6 +1026,42 @@ async def test_execute_write_requests_immediate_readback_at_user_priority(
     pending = scheduler.pending_requests()
     assert len(pending) == 1
     assert pending[0].paths == (path,)
+    assert pending[0].priority is AcquisitionPriority.USER
+
+
+@pytest.mark.asyncio
+async def test_execute_set_attenuator_readback_does_not_depend_on_slowed_cadence_tier() -> (
+    None
+):
+    """MOR-1484 review R1: att's confirming readback after a write must be
+    immediate regardless of this profile's OWN (now 3.0s, slowed to fund the
+    freq/mode/rf_gain/squelch tightening) cadence tier for that field -- the
+    armed #2452 affordance's confirm can never be left depending on that slow
+    tier, or a slice of clicks would grace-expire (3000ms ACK_CONFIRM_GRACE)
+    before the field is ever re-polled. Uses the REAL ic7300 profile (not a
+    synthetic one) so this pins the actual shipped cadence, not an assumption
+    about it.
+    """
+    profile = resolve_radio_profile(model="IC-7300")
+    assert profile.state_acquisition is not None
+    att_path = FieldPath.receiver("main", "operator_controls", "att")
+    att_policy = profile.state_acquisition.policy_for(att_path)
+    assert att_policy.cadence_seconds == 3.0  # the slowed give-back tier
+
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._execute(SetAttenuator(10, receiver=0))  # noqa: SLF001
+
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    assert pending[0].paths == (att_path,)
+    # USER outranks every cadence-driven priority (BACKGROUND/RECONCILIATION/
+    # NORMAL) regardless of the field's own (slow) cadence_seconds -- the
+    # confirming read is dispatched on the very next drain, not gated by the
+    # 3.0s tier at all.
     assert pending[0].priority is AcquisitionPriority.USER
 
 

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -574,12 +574,15 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     ):
         assert acquisition.capability_for(path).command_response_observable is True
 
-    # MOR-1452 (review fix): the 4 newly-polled fields sit at 15.0s/25.0s, NOT
-    # IC-7610's 3.0s/5.0s for the same fields (rigs/ic7610.toml) — IC-7610 is
-    # LAN, IC-7300 is serial and shares one ~20 q/s software floor across
-    # every poll, operator command, and keep-alive on the same lane (see the
+    # MOR-1452 (review fix) / MOR-1484 (bench-measured tightening): the 4
+    # mic/monitor/VOX/anti-VOX gain fields sit at 10.0s/15.0s, NOT IC-7610's
+    # 3.0s/5.0s for the same fields (rigs/ic7610.toml) — IC-7610 is LAN,
+    # IC-7300 is serial and shares one ~20 q/s software floor across every
+    # poll, operator command, and keep-alive on the same lane (see the
     # serial-budget assertion below for the exact arithmetic that rules out
-    # 3.0s here).
+    # 3.0s here). MOR-1484 tightened these from 15.0s/25.0s after the
+    # ticket's bench probe measured mic_gain populate (slow front-panel
+    # rotation) at 10.73s/16.25s against this tier's "<=15s populate" intent.
     for path in (
         FieldPath.global_("operator_controls", "mic_gain"),
         FieldPath.global_("operator_controls", "monitor_gain"),
@@ -587,14 +590,45 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("operator_controls", "anti_vox_gain"),
     ):
         policy = acquisition.policy_for(path)
-        assert policy.cadence_seconds == 15.0
-        assert policy.freshness_ttl_seconds == 25.0
+        assert policy.cadence_seconds == 10.0
+        assert policy.freshness_ttl_seconds == 15.0
 
-    fast_tier_ttl = acquisition.policy_for(
-        FieldPath.active("main", "freq_mode", "freq_hz")
-    ).freshness_ttl_seconds
-    assert fast_tier_ttl == acquisition.default_policy.freshness_ttl_seconds
-    assert fast_tier_ttl < 25.0
+    # MOR-1484: freq_hz/mode (active VFO) and rf_gain/squelch were pulled out
+    # of the profile's shared 1.5s/3.0s default tier into their own 1.0s/2.0s
+    # tier — the bench probe's most-measured "pending frequency echo" /
+    # "slider trail" symptoms — so they no longer share the default policy's
+    # freshness TTL.
+    for path in (
+        FieldPath.active("main", "freq_mode", "freq_hz"),
+        FieldPath.active("main", "freq_mode", "mode"),
+        FieldPath.receiver("main", "operator_controls", "rf_gain"),
+        FieldPath.receiver("main", "operator_controls", "squelch"),
+    ):
+        policy = acquisition.policy_for(path)
+        assert policy.cadence_seconds == 1.0
+        assert policy.freshness_ttl_seconds == 2.0
+    assert (
+        acquisition.policy_for(
+            FieldPath.active("main", "freq_mode", "freq_hz")
+        ).freshness_ttl_seconds
+        < acquisition.default_policy.freshness_ttl_seconds
+    )
+
+    # MOR-1484: budget freed for the tier above by giving back cadence on six
+    # rarely-touched settings (tuner match, RF power level, compressor
+    # on/level, attenuator, preamp) — none in the ticket's measured or
+    # operator-felt symptom list.
+    for path in (
+        FieldPath.global_("operator_controls", "tuner_status"),
+        FieldPath.global_("operator_controls", "power_level"),
+        FieldPath.global_("tx_state", "compressor_on"),
+        FieldPath.global_("operator_controls", "compressor_level"),
+        FieldPath.receiver("main", "operator_controls", "att"),
+        FieldPath.receiver("main", "operator_controls", "preamp"),
+    ):
+        policy = acquisition.policy_for(path)
+        assert policy.cadence_seconds == 3.0
+        assert policy.freshness_ttl_seconds == 6.0
 
     # MOR-1452 (review fix): pin the actual serial-lane arithmetic, not just
     # the cadence numbers, so a future "just speed this field up a bit" edit
@@ -616,8 +650,8 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     # test_acquisition_scheduler.py's due_polling_*tx_only* coverage for the
     # gating behavior itself). The RX-state share is what MOR-1484's live
     # medians (s_meter/ptt/freq) were measured against, so THAT figure is the
-    # one that must stay near the pre-existing ~19.933 q/s baseline -- not
-    # the transient TX-window total.
+    # one that must stay near the MOR-1484 baseline below -- not the
+    # transient TX-window total.
     rx_state_demand_hz = sum(
         1.0 / acquisition.policy_for(path).cadence_seconds
         for path in acquisition.pollable_paths()
@@ -628,21 +662,25 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         for path in acquisition.pollable_paths()
         if acquisition.policy_for(path).tx_only
     )
-    # Pre-existing baseline (MOR-1452) was 19.933 q/s, already only 0.067 q/s
-    # below the 20 q/s ceiling. MOR-1485 adds only Vd/Id (2 fields / 60.0s =
-    # 0.033 q/s) to the always-on RX-state total, spending under half of that
-    # remaining headroom (19.933 -> 19.967 q/s) and staying BELOW the
+    # MOR-1484 baseline: pre-MOR-1484 total was 19.967 q/s. This PR moves
+    # freq_hz(active)/mode(active)/rf_gain/squelch (4 fields) from the 1.5s
+    # default tier to a dedicated 1.0s tier (+2.667 -> +4.0 = +1.333 q/s) and
+    # mic/monitor/VOX/anti-VOX gain (4 fields) from 15.0s to 10.0s (+0.267 ->
+    # +0.4 = +0.133 q/s), funded by giving six rarely-touched settings
+    # (tuner_status, power_level, compressor_on/level, att, preamp; 6 fields)
+    # back from 1.5s to 3.0s (-4.0 -> -2.0 = -2.0 q/s). Net:
+    # 19.967 + 1.333 + 0.133 - 2.0 = 19.433 q/s, comfortably BELOW the 20 q/s
     # ceiling — required, not just desirable, since exceeding it would
     # necessarily slow every other polled field's real throughput and risk
-    # regressing the MOR-1484 medians this profile is measured against.
-    assert rx_state_demand_hz == pytest.approx(19.967, abs=0.001)
+    # regressing the very medians this tightening is meant to improve.
+    assert rx_state_demand_hz == pytest.approx(19.433, abs=0.001)
     assert rx_state_demand_hz < serial_ceiling_hz
     # Po/SWR/ALC/COMP: 4 fields / 1.0s = 4.0 q/s, ONLY while tx_only gating
     # lets them through (PTT observed true) — a transient TX-window cost, not
-    # a steady-state one.
+    # a steady-state one. Untouched by MOR-1484.
     assert tx_only_demand_hz == pytest.approx(4.0, abs=0.001)
     total_during_tx_hz = rx_state_demand_hz + tx_only_demand_hz
-    assert total_during_tx_hz == pytest.approx(23.967, abs=0.001)
+    assert total_during_tx_hz == pytest.approx(23.433, abs=0.001)
 
     assert (
         acquisition.capability_for(


### PR DESCRIPTION
## Summary

Closes MOR-1484.

Bench-measured evidence (live IC-7300, serial @115200) showed the median/max
seconds between observations for freqHz (1.30/2.64), unselectedVfo
(1.18/2.54), mode (2.16/2.92), rfGain (1.33/2.68), squelch (2.22/2.82),
sMeter (0.36/1.03), ptt (0.46/1.04), and micGain slow-rotation (10.73/16.25).
Operator-felt: slider readouts trail ~1s while the radio reacts instantly,
and the pending-frequency echo rides the ~1.3s freq confirm. Two independent
fixes address this, prioritized per the ticket (freq echo > sliders >
tx-aux populate):

### 1. Readback-after-write jumps the queue

`AcquisitionScheduler.ensure_fresh` with `USER`/`RECONCILIATION` priority
already existed, and the scope-control write path already had an equivalent
(`RadioPoller._reconfirm_scope_field`) — but no such hook existed for
freq/mode/levels, which is exactly the gap behind the "pending frequency
echo" / "slider trails ~1s" symptom: `SetFreq`/`SetMode`/`SetRfGain`/
`SetSquelch` only mutated the legacy `RadioState` mirror and waited for the
field's normal poll cadence to confirm the write.

Added a **minimal, data-driven** mechanism in `src/rigplane/web/radio_poller.py`:
`_POST_WRITE_READBACK_FIELDS` maps each write-command type to the
`FieldPath`(s) it writes; `_request_post_write_readback` (called once,
generically, at the end of `_execute`) looks the command up and calls
`AcquisitionScheduler.ensure_fresh(paths, priority=AcquisitionPriority.USER,
...)` — the scheduler's highest rank — so the request jumps ahead of
whatever BACKGROUND/RECONCILIATION/NORMAL-tier cadence work is already
queued and is picked up by the very next `_send_scheduler_requests` drain.
Covering another command later is a new table entry, not a new call site.

Coalescing: the `FieldPath` receiver_id is built as `"main"`/`"sub"` — the
same spelling `field_policies` TOML keys and cadence-driven requests already
use — so a post-write request coalesces into any already-pending same-field
request via the scheduler's own `_AcquisitionRequestKey` grouping (upgrading
it to USER priority) instead of racing it as a second, differently-keyed
entry. No new coalescing mechanism was needed; the existing scheduler-level
dedup already provides it.

`micGain`'s slow-rotation symptom is a *different* shape (a front-panel
knob turn, not a rigplane-initiated write — nothing this profile owns can
accelerate that with a post-write readback) and is addressed by cadence
tightening below instead.

### 2. Data-driven cadence tightening (`rigs/ic7300.toml`)

All changes live in `[state_acquisition.field_policies]` — no hardcoded
cadence in code.

- `freq_hz`(active)/`mode`(active)/`rf_gain`/`squelch`: moved off the shared
  1.5s/3.0s default tier onto a dedicated **1.0s/2.0s** tier (not 0.5-0.8s —
  the post-write readback above already gives the operator's own write an
  immediate confirmed readback, so this tier only has to catch up a
  front-panel/other-CAT-client change or the first poll after connect).
  `freq_hz`(active)/`mode`(active) were already their own isolated 2-field
  cadence group before this PR (the scheduler groups fields by
  `(scope, family, receiver_id, slot, policy)`, each group with its own
  independent clock — there is no flat round-robin across every default-tier
  field), so their gain here is purely the 1.5s→1.0s ratio. `rf_gain`/
  `squelch` DID share a larger 6-field group pre-PR (`af_level`, `rf_gain`,
  `squelch`, `att`, `preamp`, `agc`), so isolating them has a genuine but
  second-order ~100-200ms smaller-batch benefit on top of the ratio gain
  (fewer same-tick sibling frames ahead of theirs through the ~20 q/s serial
  rate limiter) — not a 17→4 population effect.
- `mic_gain`/`monitor_gain`/`vox_gain`/`anti_vox_gain`: tightened from
  15.0s/25.0s to **10.0s/15.0s** (worst-case populate was measured at
  16.25s against a "<=15s" intent — 10.0s cadence gives real margin under
  that bound).
- `unselectedVfo` and `af_level` deliberately left untouched — not in the
  ticket's operator-felt symptom list (which is about the ACTIVE vfo and
  rf_gain/squelch specifically).

**Serial budget (20 q/s ceiling, tx_only group idle):**

Pre-existing RX-state demand was 19.967 q/s (MOR-1485 baseline). This PR:

| Change | Fields | Before | After | Delta |
|---|---|---|---|---|
| freq/mode(active)+rf_gain+squelch: 1.5s -> 1.0s | 4 | 4/1.5=2.667 | 4/1.0=4.000 | +1.333 |
| mic/monitor/vox/anti-vox gain: 15.0s -> 10.0s | 4 | 4/15.0=0.267 | 4/10.0=0.400 | +0.133 |
| tuner_status/power_level/compressor_on/level/att/preamp: 1.5s -> 3.0s | 6 | 6/1.5=4.000 | 6/3.0=2.000 | -2.000 |

Net: 19.967 + 1.333 + 0.133 - 2.000 = **19.433 q/s**, comfortably under the
20 q/s ceiling (0.567 q/s headroom, up from the pre-existing 0.033 q/s).
tx_only TX/PA-meter demand (4.0 q/s while transmitting) is untouched.
Full narrative accounting is in the `rigs/ic7300.toml` comments; the
executable assertion is in `tests/test_state_acquisition_policy.py`
(`test_ic7300_profile_enrolls_exact_supported_observation_rows`).

### Not in this PR

The before/after cadence probe re-run on the bench is owner-side (the
cadence probe from the ticket, run on the physical stand) and folds into
MOR-1410 — this PR's evidence is the demand math above plus the tests
below.

### Review R1 fixes

Two findings from independent review, both addressed:

- **F1 (blocking):** `att`/`preamp` carry the #2452 armed affordance, whose
  only confirming path back to the StateStore is the cadence poll —
  `PendingOverlay` has no web consumer and the CI-V own-frame/transceive
  echo this profile relies on for other fields does not reliably cover these
  two. This PR already slows `att`/`preamp`'s cadence 1.5s → 3.0s (table
  above) to fund the tightening elsewhere; without a post-write readback
  that give-back alone would widen the armed-affordance confirm window past
  the 3000ms `ACK_CONFIRM_GRACE` for a slice of clicks (grace expires,
  armed clears, the button shows the stale value until the next cadence
  tick — the MOR-1478 stale-flash symptom, reintroduced on a new
  affordance). Added `SetAttenuator`/`SetPreamp` to
  `_POST_WRITE_READBACK_FIELDS` — this makes the 1.5s→3.0s give-back
  genuinely *free* for the operator's own write: confirmation no longer
  depends on the slowed cadence tier at all, only on the front-panel/other-
  CAT-client-change case the cadence tier still has to catch.
- **F2:** corrected the `rigs/ic7300.toml` comment (and PR body above) that
  described a "17-field flat round-robin" — the scheduler actually groups
  fields by `(scope, family, receiver_id, slot, policy)` into independent
  cadence-clocked groups; see the corrected reasoning in section 2 above.

## Test plan

TDD red-first for the readback-after-write behavior change:
`tests/test_radio_poller_coverage.py` — all new/extended tests confirmed RED
against the pre-fix `radio_poller.py` in each case, then GREEN after the fix:

- `test_execute_write_requests_immediate_readback_at_user_priority`
  (parametrized over SetFreq/SetMode on main+sub, SetRfGain, SetSquelch,
  SetAttenuator, SetPreamp)
- `test_execute_set_attenuator_readback_does_not_depend_on_slowed_cadence_tier`
  (R1 F1: pins against the REAL ic7300 profile that att's readback is
  immediate/USER-priority regardless of its own slowed 3.0s cadence)
- `test_execute_set_freq_readback_coalesces_with_pending_cadence_request`
- `test_execute_unmapped_write_does_not_queue_a_readback`
- `test_execute_set_freq_without_scheduler_does_not_raise`

`tests/test_state_acquisition_policy.py` updated to the new cadence numbers
and the tightened serial-budget assertion (19.433 q/s).

- [x] `uv run pytest tests/test_radio_poller_coverage.py
  tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py
  tests/test_mor1427_rate_limiter_coalesce.py tests/test_mor1499_coalesce_keys.py
  tests/test_rig_ic7300.py tests/test_rig_loader.py tests/test_rig_multi_vendor.py
  tests/test_ic7300_backend.py tests/test_poller_poll_priority.py
  tests/test_civ_rx_coverage.py tests/test_selected_freq_mode.py -q` — 1023
  passed, 1 skipped (post-R1 fixes)
- [x] `uv run pytest tests/test_radio_poller_coverage.py
  tests/test_acquisition_scheduler.py tests/test_state_acquisition_policy.py
  tests/test_mor1427_rate_limiter_coalesce.py tests/test_mor1499_coalesce_keys.py
  tests/test_rig_ic7300.py tests/test_rig_loader.py tests/test_rig_multi_vendor.py
  tests/test_ic7300_backend.py tests/test_poller_poll_priority.py
  tests/test_civ_rx_coverage.py tests/test_selected_freq_mode.py
  tests/test_web_server.py tests/test_web_server_coverage.py -q` (pre-R1) —
  1344 passed (1 unrelated transient socket-timeout flake reproduced as a
  pass in isolation and on a full `test_web_server.py` re-run)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy src/rigplane/web/radio_poller.py` — clean; full `src/`
  mypy baseline unchanged (13 pre-existing errors in unrelated files)
- [x] `uv run lint-imports` — 5 kept, 0 broken

Refs MOR-1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
