### PR TITLE
fix: AGC/preamp read paths and labels from profile data (MOR-1529)

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -5,7 +5,7 @@
   } from '$lib/runtime/adapters/panel-adapters';
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toMeterProps,
-    toDspProps, toFilterProps,
+    toDspProps, toFilterProps, formatPreLabel,
   } from '$lib/runtime/props/panel-props';
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberSmeter from './AmberSmeter.svelte';
@@ -160,12 +160,6 @@
   let fftPush: ((data: Uint8Array) => void) | null = null;
   let showFft = $derived(cockpitProps.hasAudioFft);
 
-  // FTX-1 AGC: 0=OFF, 1=FAST, 2=MID, 3=SLOW, 4=AUTO-F, 5=AUTO-M, 6=AUTO-S
-  const AGC_LABELS: Record<number, string> = {
-    0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW',
-    4: 'A-F', 5: 'A-M', 6: 'A-S',
-  };
-
   // ── Indicator token arrays ──
   // globalTokens: radio-wide status indicators for the top global strip
   let globalTokens = $derived<IndToken[]>([
@@ -195,9 +189,13 @@
     }] : []),
   ]);
 
-  // Helper: AGC label from raw AGC mode number
+  // MOR-1529: AGC mode labels come from the profile-declared capabilities
+  // payload (`[agc].labels` per radio, e.g. ic7300/ic7610 FAST/MID/SLOW vs
+  // X6200 OFF/FAST/SLOW/AUTO — index 2/3 differ from the IC-7610 shape this
+  // file used to hardcode unconditionally, mirrors AmberScope). Falls back
+  // to the plain numeric value when the profile declares no label for it.
   function agcLabelFor(agcMode: number): string {
-    return AGC_LABELS[agcMode] ?? `${agcMode}`;
+    return caps?.agcLabels?.[String(agcMode)] ?? `${agcMode}`;
   }
 
   // Per-receiver token builder — gates every indicator on fieldStatus
@@ -212,8 +210,12 @@
       }] : []),
       ...(hasCap('preamp') && rxAvailable(rxKey, 'preamp') ? [{
         id: 'pre' as const,
-        label: (rxState?.preamp ?? 0) === 0 ? 'IPO'
-             : (rxState?.preamp ?? 0) === 1 ? 'AMP1' : 'AMP2',
+        // MOR-1529: profile-declared `[preamp].labels` (e.g. FTX-1's
+        // IPO/AMP1) instead of hardcoding that Yaesu vocabulary for every
+        // radio — most Icom profiles declare no preamp labels at all, so
+        // this falls back to `formatPreLabel`'s generic OFF/P{n}, matching
+        // `toRfFrontEndProps`'s `preOptions` for the same radios.
+        label: formatPreLabel(rxState?.preamp ?? 0, caps?.preLabels ?? {}),
         active: true,
       }] : []),
       ...(hasCap('digisel') && rxAvailable(rxKey, 'digisel') ? [{

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -2,6 +2,7 @@
   import { deriveAmberScopeProps } from '$lib/runtime/adapters/panel-adapters';
   import {
     toTxProps, toRitXitProps, toVfoOpsProps, toDspProps, toFilterProps,
+    formatPreLabel,
   } from '$lib/runtime/props/panel-props';
   import AmberFrequency from './AmberFrequency.svelte';
   import AmberAfScope from './AmberAfScope.svelte';
@@ -40,19 +41,19 @@
     return '';
   }
 
-  // AGC mode labels (mirrors AmberCockpit)
-  const AGC_LABELS: Record<number, string> = {
-    0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW',
-    4: 'A-F', 5: 'A-M', 6: 'A-S',
-  };
-  function agcLabelFor(agcMode: number): string {
-    return AGC_LABELS[agcMode] ?? `${agcMode}`;
-  }
-
   let scopeProps = $derived(deriveAmberScopeProps());
   let radioState = $derived(scopeProps.radioState);
   let caps = $derived(scopeProps.caps);
   let hasCap = $derived(scopeProps.hasCapability);
+
+  // MOR-1529: AGC mode labels come from the profile-declared capabilities
+  // payload (`[agc].labels` per radio, e.g. ic7300/ic7610 FAST/MID/SLOW vs
+  // X6200 OFF/FAST/SLOW/AUTO — index 2/3 differ from the IC-7610 shape this
+  // file used to hardcode unconditionally, mirrors AmberCockpit). Falls back
+  // to the plain numeric value when the profile declares no label for it.
+  function agcLabelFor(agcMode: number): string {
+    return caps?.agcLabels?.[String(agcMode)] ?? `${agcMode}`;
+  }
 
   let tx = $derived(toTxProps(radioState, null));
   let ritXit = $derived(toRitXitProps(radioState, null));
@@ -129,8 +130,12 @@
     }] : []),
     ...(hasCap('preamp') && rxAvailable('preamp') ? [{
       id: 'pre' as const,
-      label: (rx?.preamp ?? 0) === 0 ? 'IPO'
-           : (rx?.preamp ?? 0) === 1 ? 'AMP1' : 'AMP2',
+      // MOR-1529: profile-declared `[preamp].labels` (e.g. FTX-1's
+      // IPO/AMP1) instead of hardcoding that Yaesu vocabulary for every
+      // radio — most Icom profiles declare no preamp labels at all, so
+      // this falls back to `formatPreLabel`'s generic OFF/P{n}, matching
+      // `toRfFrontEndProps`'s `preOptions` for the same radios.
+      label: formatPreLabel(rx?.preamp ?? 0, caps?.preLabels ?? {}),
       active: true,
     }] : []),
   ]);

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberCockpit.agc-preamp-labels.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberCockpit.agc-preamp-labels.isolated.test.ts
@@ -1,0 +1,114 @@
+/**
+ * AmberCockpit AGC / preamp indicator label sourcing (MOR-1529).
+ *
+ * Smoke-test companion to `AmberLabels.profile-data.isolated.test.ts`
+ * (AmberScope): proves the same profile-data label fix was applied to
+ * `AmberCockpit`'s per-VFO indicator strip, not just its AmberScope twin.
+ * `panel-props` and `$lib/state/field-status` are left real (mirrors
+ * `AmberCockpit.qsy-authority.isolated.test.ts`'s mocking style); only the
+ * runtime/adapter seams are mocked to feed a controlled `radioState`/`caps`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+
+const h = vi.hoisted(() => ({
+  props: {
+    radioState: null as unknown,
+    caps: null as Capabilities | null,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+    hasCapability: (_name: string) => true,
+  } as Record<string, unknown>,
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveAmberCockpitProps: () => h.props,
+  deriveAmberTelemetryProps: () => ({ vdRaw: null, idRaw: null }),
+  getAmberCockpitHandlers: () => ({ onTuningChange: vi.fn() }),
+  getVfoHandlers: () => ({ onFreqChange: vi.fn(), onModeChange: vi.fn() }),
+  bindVfoTunerContext: () => Object.freeze({ read: vi.fn(() => ({ view: null })) }),
+}));
+
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  presentationResources: { acquire: vi.fn(), release: vi.fn() },
+  runtime: {
+    scope: { registerPresentationDriver: vi.fn(), subscribe: vi.fn(() => vi.fn()) },
+  },
+}));
+
+import AmberCockpit from '../AmberCockpit.svelte';
+
+let component: ReturnType<typeof mount> | undefined;
+let target: HTMLDivElement;
+
+function baseReceiver() {
+  return {
+    freqHz: 14_074_000, mode: 'USB', filter: 1, dataMode: 0, sMeter: 0,
+    att: 0, preamp: 1, nb: false, nr: false, afLevel: 128, rfGain: 255,
+    squelch: 0, agc: 3,
+  };
+}
+
+function mountCockpit(caps: Capabilities | null) {
+  h.props = {
+    radioState: {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      fieldStatus: {
+        'main.agc': {
+          storePath: 'receiver.main.operator_controls.agc',
+          observed: true, freshness: 'fresh', availability: 'available',
+        },
+        'main.preamp': {
+          storePath: 'receiver.main.operator_controls.preamp',
+          observed: true, freshness: 'fresh', availability: 'available',
+        },
+      },
+    },
+    caps,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+    hasCapability: () => true,
+  };
+  component = mount(AmberCockpit, { target });
+  flushSync();
+}
+
+function indChip(text: string): HTMLElement | undefined {
+  return Array.from(target.querySelectorAll<HTMLElement>('.lcd-ind'))
+    .find((el) => el.textContent?.trim().startsWith(text));
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  target.remove();
+});
+
+describe('AmberCockpit AGC/preamp label sourcing (MOR-1529)', () => {
+  it('labels X6200 AGC=3 as AUTO from profile data, not the hardcoded SLOW', () => {
+    const caps = {
+      agcLabels: { '0': 'OFF', '1': 'FAST', '2': 'SLOW', '3': 'AUTO' },
+    } as unknown as Capabilities;
+    mountCockpit(caps);
+    const chip = indChip('AGC');
+    expect(chip?.textContent?.trim()).toBe('AGC AUTO');
+  });
+
+  it('renders a profile-declared preamp label instead of the hardcoded AMP1', () => {
+    const caps = {
+      preLabels: { '0': 'OFF', '1': 'BOOST' },
+    } as unknown as Capabilities;
+    mountCockpit(caps);
+    const chip = Array.from(target.querySelectorAll<HTMLElement>('.lcd-ind'))
+      .find((el) => el.textContent?.trim() === 'BOOST');
+    expect(chip).toBeDefined();
+  });
+});

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberLabels.profile-data.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberLabels.profile-data.isolated.test.ts
@@ -1,0 +1,191 @@
+/**
+ * AGC / preamp indicator label sourcing (MOR-1529).
+ *
+ * `AmberCockpit`/`AmberScope` (amber-lcd skin) previously hardcoded an
+ * FTX-1-shaped AGC_LABELS dict (0=OFF/1=FAST/2=MID/3=SLOW/4-6=A-F/A-M/A-S)
+ * and an IPO/AMP1/AMP2 preamp ternary, applied to every radio regardless of
+ * its declared domain. A live X6200 (whose real AGC domain is
+ * OFF/FAST/SLOW/AUTO — index 2 = SLOW not MID, index 3 = AUTO not SLOW,
+ * per `rigs/x6200.toml`) would show a mislabeled AGC status token.
+ *
+ * The fix resolves both labels from the profile-declared capabilities
+ * payload (`caps.agcLabels` / `caps.preLabels`, already threaded per
+ * MOR-1522/#2437 and MOR-1523/#2441) instead of a hardcoded vendor dict.
+ * `AmberScope` is mounted with the real `$lib/state/field-status` resolver
+ * and the real `AmberIndStrip` renderer; only the runtime/adapter seams and
+ * the state-dependent slice of `panel-props` are mocked (`formatPreLabel`,
+ * the function under test for preamp, is left as the real implementation).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ServerState } from '$lib/types/state';
+import type { Capabilities } from '$lib/types/capabilities';
+
+// ── Controlled adapter output ───────────────────────────────────────────────
+
+const scopeProps = vi.hoisted(() => ({
+  value: {
+    radioState: null as ServerState | null,
+    caps: null as Capabilities | null,
+    hasCapability: (_name: string) => true,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+  },
+}));
+
+vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
+  deriveAmberScopeProps: () => scopeProps.value,
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    scope: { subscribe: vi.fn(() => vi.fn()), hardwareScopeConnected: false },
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+  },
+}));
+
+// Only the state-dependent projections are stubbed; `formatPreLabel` (the
+// function under test for the preamp label) keeps its real implementation
+// via `importOriginal` so this test exercises production code, not a copy.
+vi.mock('$lib/runtime/props/panel-props', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/props/panel-props')>();
+  return {
+    ...actual,
+    toTxProps: () => ({
+      txActive: false, voxActive: false, compActive: false, compLevel: 0,
+      atuActive: false, atuTuning: false, hasTx: false, hasTuner: false, hasMonitor: false,
+    }),
+    toRitXitProps: () => ({
+      ritActive: false, xitActive: false,
+      ritOffset: Number.NaN, xitOffset: Number.NaN,
+      hasRit: true, hasXit: true,
+    }),
+    toVfoOpsProps: () => ({ splitActive: false }),
+    toDspProps: () => ({ notchMode: 'off', notchFreq: 0 }),
+    toFilterProps: () => ({ filterWidth: Number.NaN, filterWidthMax: 9999, ifShift: 0 }),
+  };
+});
+
+import AmberScope from '../AmberScope.svelte';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+let components: ReturnType<typeof mount>[] = [];
+
+function baseReceiver() {
+  return {
+    freqHz: 14_074_000, mode: 'USB', filter: 1, dataMode: 0, sMeter: 0,
+    att: 0, preamp: 0, nb: false, nr: false, afLevel: 128, rfGain: 255,
+    squelch: 0, agc: 2,
+  };
+}
+
+function mountScope(state: ServerState | null, caps: Capabilities | null = null) {
+  scopeProps.value = {
+    radioState: state,
+    caps,
+    hasCapability: () => true,
+    hasAudioFft: false,
+    hasDualReceiver: false,
+  };
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(AmberScope, { target });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+function agcChip(target: HTMLElement): HTMLElement | undefined {
+  return Array.from(target.querySelectorAll<HTMLElement>('.lcd-ind'))
+    .find((el) => el.textContent?.trim().startsWith('AGC'));
+}
+
+function preChip(target: HTMLElement): HTMLElement | undefined {
+  return Array.from(target.querySelectorAll<HTMLElement>('.lcd-ind'))
+    .find((el) => {
+      const text = el.textContent?.trim() ?? '';
+      return text === 'IPO' || text === 'OFF' || /^(AMP|P)\d/.test(text)
+        || text === 'BOOST'; // custom label used by one test below
+    });
+}
+
+function stateWithAgc(agc: number, preamp = 0): ServerState {
+  return {
+    active: 'MAIN',
+    main: { ...baseReceiver(), agc, preamp },
+    sub: baseReceiver(),
+    fieldStatus: {
+      'main.agc': {
+        storePath: 'receiver.main.operator_controls.agc',
+        observed: true, freshness: 'fresh', availability: 'available',
+      },
+      'main.preamp': {
+        storePath: 'receiver.main.operator_controls.preamp',
+        observed: true, freshness: 'fresh', availability: 'available',
+      },
+    },
+  } as unknown as ServerState;
+}
+
+const X6200_AGC_LABELS = { '0': 'OFF', '1': 'FAST', '2': 'SLOW', '3': 'AUTO' };
+
+beforeEach(() => {
+  components = [];
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('AmberScope AGC label sourcing (MOR-1529)', () => {
+  it('labels X6200 AGC=3 as AUTO (profile data), not the hardcoded SLOW', () => {
+    const caps = { agcLabels: X6200_AGC_LABELS } as unknown as Capabilities;
+    const target = mountScope(stateWithAgc(3), caps);
+    const chip = agcChip(target);
+    expect(chip?.textContent?.trim()).toBe('AGC AUTO');
+  });
+
+  it('labels X6200 AGC=2 as SLOW (profile data), not the hardcoded MID', () => {
+    const caps = { agcLabels: X6200_AGC_LABELS } as unknown as Capabilities;
+    const target = mountScope(stateWithAgc(2), caps);
+    const chip = agcChip(target);
+    expect(chip?.textContent?.trim()).toBe('AGC SLOW');
+  });
+
+  it('falls back to the plain numeric value when no label is declared', () => {
+    const caps = { agcLabels: {} } as unknown as Capabilities;
+    const target = mountScope(stateWithAgc(9), caps);
+    const chip = agcChip(target);
+    expect(chip?.textContent?.trim()).toBe('AGC 9');
+  });
+});
+
+describe('AmberScope preamp label sourcing (MOR-1529)', () => {
+  it('renders a profile-declared preamp label instead of the hardcoded IPO/AMP1/AMP2', () => {
+    const caps = {
+      preLabels: { '0': 'OFF', '1': 'BOOST' },
+    } as unknown as Capabilities;
+    const target = mountScope(stateWithAgc(2, 1), caps);
+    const chip = preChip(target);
+    expect(chip?.textContent?.trim()).toBe('BOOST');
+  });
+
+  it('does not fabricate Yaesu IPO/AMP1/AMP2 vocabulary for a radio with no declared preamp labels', () => {
+    // ic7300/ic7610/x6200 declare no [preamp.labels] section today — the
+    // fallback must be the same generic OFF/P{n} used elsewhere in the
+    // codebase (panel-props.ts's formatPreLabel), not the FTX-1-specific
+    // "IPO"/"AMP1" vocabulary this file used to hardcode unconditionally.
+    const caps = { preLabels: {} } as unknown as Capabilities;
+    const target = mountScope(stateWithAgc(2, 1), caps);
+    const chip = preChip(target);
+    expect(chip?.textContent?.trim()).toBe('P1');
+  });
+});

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-availability.isolated.test.ts
@@ -68,6 +68,13 @@ vi.mock('$lib/runtime/props/panel-props', () => ({
   toVfoOpsProps: () => ({ splitActive: false }),
   toDspProps: () => ({ notchMode: 'off', notchFreq: 0 }),
   toFilterProps: () => ({ filterWidth: Number.NaN, filterWidthMax: 9999, ifShift: 0 }),
+  // MOR-1529: AmberScope's preamp indicator now calls the real
+  // `formatPreLabel` (profile-data label lookup, falling back to
+  // OFF/P{n}) — this file's tests don't assert on the preamp chip, so a
+  // faithful-shape stub is enough; the real implementation is covered by
+  // AmberLabels.profile-data.isolated.test.ts.
+  formatPreLabel: (level: number, labels: Record<string, string>) =>
+    labels[String(level)] ?? (level === 0 ? 'OFF' : `P${level}`),
 }));
 
 import AmberScope from '../AmberScope.svelte';

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -231,7 +231,12 @@ export interface RfFrontEndProps {
   showIpPlus: boolean;
 }
 
-function formatPreLabel(level: number, labels: Record<string, string>): string {
+// MOR-1529: exported so `AmberCockpit`/`AmberScope` (amber-lcd skin) can
+// resolve their read-only preamp status token from the same profile-declared
+// `[preamp.labels]` data this file already uses for `toRfFrontEndProps`'
+// `preOptions`, instead of duplicating (or worse, re-hardcoding) the
+// fallback logic.
+export function formatPreLabel(level: number, labels: Record<string, string>): string {
   const key = String(level);
   if (key in labels) return labels[key];
   return level === 0 ? 'OFF' : `P${level}`;

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -742,8 +742,18 @@ def _parse_func(line: str, name: str) -> bool:
 
 
 def _preamp_level_to_db(level: int) -> str:
-    """Map a RigPlane preamp level (0/1/2) to a rigctl dB string."""
-    return {0: "0", 1: "10", 2: "20"}.get(int(level), "0")
+    """Map a RigPlane preamp level (0/1/2) to a rigctl dB string.
+
+    Raises ``ValueError`` for any other level. This backend talks to an
+    already-running external rigctld daemon and has no ``RigProfile`` to
+    validate against (unlike ``IcomRadio``/``YaesuCatRadio``, MOR-1522/
+    MOR-1523) — an unrecognized level must fail loud, not be silently
+    misrepresented on the wire as "preamp off" (MOR-1529).
+    """
+    table = {0: "0", 1: "10", 2: "20"}
+    if int(level) not in table:
+        raise ValueError(f"preamp level must be one of {sorted(table)}, got {level}")
+    return table[int(level)]
 
 
 def _preamp_db_to_level(db: int) -> int:

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3093,8 +3093,18 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             sub=0x07,
         )
 
-    async def get_agc(self, receiver: int = RECEIVER_MAIN) -> AgcMode:
-        """Read AGC mode."""
+    async def get_agc(self, receiver: int = RECEIVER_MAIN) -> int:
+        """Read AGC mode.
+
+        Returns the raw profile-declared value (see the radio's ``[agc]
+        modes`` in its TOML profile), not an ``AgcMode`` enum member.
+        ``AgcMode`` is the IC-7610/generic Icom FAST/MID/SLOW shape — a
+        radio with a differently-shaped domain (e.g. the X6200's
+        OFF=0/FAST=1/SLOW=2/AUTO=3) would otherwise raise on OFF (0 is not
+        a member) or be silently mislabeled for SLOW/AUTO (index 2/3 mean
+        something else there). Label mapping is data-side (``[agc]
+        labels``), mirroring ``set_agc``'s MOR-1522 fix (MOR-1529).
+        """
         self._require_receiver(receiver, operation="get_agc")
         self._require_cmd29_route(0x16, 0x12, receiver=receiver, operation="get_agc")
         cmd29 = self._profile.supports_cmd29(0x16, 0x12)
@@ -3105,7 +3115,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             sub=0x12,
             bcd_bytes=1,
         )
-        return AgcMode(value)
+        agc_modes = self._profile.agc_modes
+        if agc_modes is not None and value not in agc_modes:
+            raise ValueError(
+                f"AGC mode {value} reported by radio is not in declared domain "
+                f"{sorted(agc_modes)} for {self._profile.model}"
+            )
+        return value
 
     async def set_agc(self, mode: AgcMode | int, receiver: int = RECEIVER_MAIN) -> None:
         """Set AGC mode.

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1772,6 +1772,24 @@ async def _check_nr_set(
     )
 
 
+def _declared_agc_modes(radio: Radio) -> tuple[int, ...] | None:
+    """Best-effort read of the connected radio's declared ``[agc] modes``.
+
+    Mirrors the private attribute both validated seats already read
+    internally (``IcomRadio._profile.agc_modes`` / ``YaesuCatRadio.
+    _config.agc_modes``, MOR-1522) — there is no public cross-vendor
+    accessor for a capability's declared domain today. Returns ``None``
+    (domain unknown) rather than raising, matching this module's
+    best-effort style for every other optional lookup (MOR-1529).
+    """
+    for attr in ("_profile", "_config"):
+        holder = getattr(radio, attr, None)
+        modes = getattr(holder, "agc_modes", None)
+        if modes:
+            return tuple(modes)
+    return None
+
+
 async def _check_agc_set(
     radio: Radio,
     entry: CapabilityDeclarationEntry,
@@ -1783,14 +1801,30 @@ async def _check_agc_set(
     if gate is not None:
         return gate
     dsp = cast(DspControlCapable, radio)
+
+    def _make_changed(current: int) -> int:
+        # MOR-1529: derive the probe from the radio's OWN declared domain
+        # when discoverable, instead of always assuming the IC-7610-shaped
+        # AgcMode.FAST/SLOW constants (1/3) are legal for every radio —
+        # true for every currently-shipped profile by coincidence, but not
+        # by design (e.g. would break for a hypothetical profile whose
+        # domain excludes both).
+        modes = _declared_agc_modes(radio)
+        if modes:
+            for candidate in modes:
+                if candidate != current:
+                    return candidate
+        # No declared domain reachable (e.g. a bare test double) — fall
+        # back to the two values every currently-shipped ``[agc] modes``
+        # table happens to include.
+        return int(AgcMode.SLOW) if current != AgcMode.SLOW else int(AgcMode.FAST)
+
     return await _read_modify_verify_restore(
         radio,
         entry,
         read=lambda: dsp.get_agc(0),
         write=lambda value: dsp.set_agc(value, 0),
-        make_changed=lambda m: (
-            int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
-        ),
+        make_changed=_make_changed,
         per_check_timeout=per_check_timeout,
     )
 

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1809,11 +1809,22 @@ async def _check_agc_set(
         # true for every currently-shipped profile by coincidence, but not
         # by design (e.g. would break for a hypothetical profile whose
         # domain excludes both).
+        #
+        # R1: prefer a non-OFF (0) candidate. The live FTX-1 declares
+        # ``[agc] modes = [0..6]`` — picking the first declared value
+        # != current would land on 0 (AGC OFF) for every current value
+        # except 0 itself. This RMVR probe is documented non-destructive/
+        # RX-safe (MOR-659): momentarily disabling AGC on a bench radio is
+        # audible and operator-affecting, unlike flipping between two
+        # settable AGC speeds (the old hardcoded SLOW/FAST probe never did
+        # this). Landing on 1 (FAST) instead keeps the probe inside
+        # "change AGC speed", never "turn AGC off".
         modes = _declared_agc_modes(radio)
         if modes:
-            for candidate in modes:
-                if candidate != current:
-                    return candidate
+            candidates = [m for m in modes if m != current]
+            non_off = [m for m in candidates if m != 0]
+            if candidates:
+                return (non_off or candidates)[0]
         # No declared domain reachable (e.g. a bare test double) — fall
         # back to the two values every currently-shipped ``[agc] modes``
         # table happens to include.

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -2702,6 +2702,79 @@ class TestAgcDomainValidation:
         radio._connected = False
 
 
+_X6200_ADDR = 0xA4
+
+
+def _x6200_function_response(sub: int, payload: bytes) -> bytes:
+    """Build a plain (no cmd29) CI-V 0x16 response from an X6200.
+
+    X6200 declares no ``[cmd29]`` routes, so its responses (unlike the
+    IC-7610 fixture's) come from ``civ_addr = 0xA4``, not ``IC_7610_ADDR``
+    — the receive path drops any frame whose ``from_addr`` doesn't match
+    the connected radio's own address.
+    """
+    civ = build_civ_frame(CONTROLLER_ADDR, _X6200_ADDR, 0x16, sub=sub, data=payload)
+    return _wrap_civ_in_udp(civ)
+
+
+class TestAgcReadPath:
+    """MOR-1529: ``get_agc`` must not cast the read value through the
+    IC-7610-shaped ``AgcMode`` enum (FAST=1/MID=2/SLOW=3).
+
+    The X6200 declares a different domain (OFF=0/FAST=1/SLOW=2/AUTO=3) —
+    ``AgcMode(0)`` raises ``ValueError`` (0 is not a member) and
+    ``AgcMode(2)``/``AgcMode(3)`` silently mislabel X6200's SLOW/AUTO as the
+    IC-7610's MID/SLOW. The fix returns the raw profile-validated int;
+    label mapping is data-side (``[agc].labels``), not a hardcoded enum cast.
+    """
+
+    @pytest.mark.asyncio
+    async def test_x6200_reports_declared_off_without_raising(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """AgcMode has no OFF member — casting X6200's real OFF=0 reading
+        through it would raise, even though OFF is a legal X6200 value."""
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        mock_transport.queue_response(_x6200_function_response(0x12, b"\x00"))
+        assert await radio.get_agc() == 0
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_reports_declared_auto_as_plain_int_not_mislabeled(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """X6200 index 3 means AUTO, not the IC-7610's SLOW — the return
+        must be the raw int 3, not an ``AgcMode.SLOW`` enum member (whose
+        ``.name`` would present the wrong label downstream)."""
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        mock_transport.queue_response(_x6200_function_response(0x12, b"\x03"))
+        result = await radio.get_agc()
+        assert result == 3
+        assert type(result) is int
+        radio._connected = False
+
+    @pytest.mark.asyncio
+    async def test_x6200_rejects_reading_outside_its_declared_domain(
+        self, mock_transport: MockTransport
+    ) -> None:
+        """A raw value the radio reports that falls outside the profile's
+        declared ``[agc] modes`` must raise, not be silently returned."""
+        radio = IcomRadio("192.168.1.100", model="X6200")
+        radio._civ_transport = mock_transport
+        radio._ctrl_transport = mock_transport
+        radio._connected = True
+        mock_transport.queue_response(_x6200_function_response(0x12, b"\x09"))
+        with pytest.raises(ValueError, match=r"AGC mode.*not in declared domain"):
+            await radio.get_agc()
+        radio._connected = False
+
+
 class TestPreampDomainValidation:
     """MOR-1523: the preamp level domain is profile data, not a universal
     3-state enum.

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -13,6 +13,7 @@ from rigplane.backends.rigctld_client import RigctldClientRadio, RigctldTranspor
 from rigplane.backends.rigctld_client.radio import (
     _float_to_level_255,
     _level_255_to_float,
+    _preamp_level_to_db,
 )
 from rigplane.exceptions import CommandError
 from rigplane.exceptions import ConnectionError as RadioConnectionError
@@ -252,6 +253,30 @@ async def test_rigctld_preamp_attenuator_nb_nr() -> None:
             assert await radio.get_nr() is False
             await radio.set_nr(True)
             assert await radio.get_nr() is True
+        finally:
+            await radio.disconnect()
+
+
+def test_preamp_level_to_db_rejects_out_of_domain_level() -> None:
+    """MOR-1529: an unrecognized preamp level must fail loud, not be
+    silently coerced to OFF (0 dB) — this backend has no ``RigProfile`` to
+    validate against (it talks to an already-running external rigctld
+    daemon), so its own fixed 0/1/2 mapping must reject anything else."""
+    for legal in (0, 1, 2):
+        assert _preamp_level_to_db(legal) in {"0", "10", "20"}
+    with pytest.raises(ValueError, match=r"preamp level must be one of"):
+        _preamp_level_to_db(3)
+    with pytest.raises(ValueError, match=r"preamp level must be one of"):
+        _preamp_level_to_db(-1)
+
+
+async def test_rigctld_set_preamp_out_of_domain_raises_not_silently_off() -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            with pytest.raises(ValueError, match=r"preamp level must be one of"):
+                await radio.set_preamp(3)
         finally:
             await radio.disconnect()
 

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from rigplane.core.exceptions import TimeoutError as RigTimeoutError
@@ -114,6 +115,55 @@ def _stateful_preamp_mock(*, start: int = 0):
     radio.get_preamp = AsyncMock(side_effect=_get)
     radio.set_preamp = AsyncMock(side_effect=_set)
     return radio, store
+
+
+def _stateful_agc_mock(*, start: int, domain: tuple[int, ...]):
+    """A MagicMock(spec=Radio) whose AGC set/get round-trips via a closure
+    and enforces ``domain`` exactly like the real validated seat
+    (``IcomRadio.set_agc``/``YaesuCatRadio.set_agc``, MOR-1522) — an
+    out-of-domain probe raises, just like it would against real hardware.
+    ``radio._profile.agc_modes`` mirrors what ``IcomRadio`` exposes so the
+    harness's domain-derived probe (MOR-1529) can discover it.
+    """
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FAKE"
+    radio.capabilities = {"agc"}
+    radio._profile = SimpleNamespace(agc_modes=domain, model="FAKE")
+    store = {"value": start}
+
+    async def _get(receiver: int = 0) -> int:
+        return store["value"]
+
+    async def _set(value: int, receiver: int = 0) -> None:
+        if value not in domain:
+            raise ValueError(f"AGC mode must be one of {sorted(domain)}, got {value}")
+        store["value"] = value
+
+    radio.get_agc = AsyncMock(side_effect=_get)
+    radio.set_agc = AsyncMock(side_effect=_set)
+    return radio, store
+
+
+async def test_agc_set_probe_derives_from_declared_domain_not_hardcoded_fast_slow():
+    """MOR-1529: the AGC RMVR probe must derive its mutation value from the
+    connected radio's own declared ``[agc] modes``, not hardcoded IC-7610
+    ``AgcMode.FAST``/``AgcMode.SLOW`` constants (1/3) — a radio whose domain
+    excludes both would otherwise get an illegal probe value and FAIL a
+    control that actually works fine.
+    """
+    radio, store = _stateful_agc_mock(start=5, domain=(5, 7))
+    template = _single_entry_template(check_id="agc.set", capability="agc")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["agc.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["original"] == 5
+    assert check.evidence["changed"] == 7
+    assert check.evidence["readback"] == 7
+    assert check.evidence["restored"] is True
+    assert store["value"] == 5
 
 
 def _digisel_preamp_mock(*, preamp_start: int = 0, digisel_on: bool = True):

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -166,6 +166,28 @@ async def test_agc_set_probe_derives_from_declared_domain_not_hardcoded_fast_slo
     assert store["value"] == 5
 
 
+async def test_agc_set_probe_never_lands_on_off_for_a_domain_that_declares_it():
+    """MOR-1529 R1: the domain-derived probe must never pick 0 (AGC OFF)
+    just because it's the first declared mode != current.
+
+    The live FTX-1 declares ``[agc] modes = [0..6]`` — picking the first
+    declared value != current would land on 0 for every current value
+    except 0 itself. This RMVR probe is documented non-destructive/RX-safe
+    (MOR-659): momentarily disabling AGC on a bench radio is audible and
+    operator-affecting, unlike flipping between two settable AGC speeds.
+    The probe must prefer a non-OFF candidate (landing FTX-1 on 1=FAST).
+    """
+    radio, _store = _stateful_agc_mock(start=3, domain=(0, 1, 2, 3))
+    template = _single_entry_template(check_id="agc.set", capability="agc")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["agc.set"]
+    assert check.status is CheckStatus.PASS
+    assert check.evidence["changed"] != 0
+    assert check.evidence["changed"] == 1
+
+
 def _digisel_preamp_mock(*, preamp_start: int = 0, digisel_on: bool = True):
     """A stateful preamp mock that ALSO exposes get/set_digisel.
 


### PR DESCRIPTION
## Summary

Four read/label-path AGC+preamp hardcodes left over from MOR-1522 (#2437)
and MOR-1523 (#2441) — both of those PRs explicitly flagged these as
MOR-1529 follow-ups rather than fixing them in-scope.

## Item 1 — `IcomRadio.get_agc()` cast through the IC-7610 `AgcMode` enum

`runtime/radio.py`'s `get_agc()` returned `AgcMode(value)`. `AgcMode` is
IC-7610-shaped (FAST=1/MID=2/SLOW=3, no OFF). The X6200 declares a
different domain (`rigs/x6200.toml`: OFF=0/FAST=1/SLOW=2/AUTO=3):
- reading OFF=0 would raise (`0 is not a valid AgcMode`)
- reading SLOW=2/AUTO=3 would silently return `AgcMode.MID`/`AgcMode.SLOW`
  — a real value mislabeled as the IC-7610's vocabulary.

**Fix**: return the raw value, validated against the profile's declared
`[agc] modes` domain (symmetric with `set_agc`'s MOR-1522 fix). Label
mapping stays entirely data-side.

**Consumer check**: the only production call to a generic `get_agc()` is
`rigctld/routing.py`'s `YaesuRouting.get_func("AGC")`, which is defined
inside the `YaesuRouting` class — `create_routing()` returns `None` for
every Icom radio (confirmed via `RigctldRoutable`), so this call never
reaches `IcomRadio.get_agc()`. `IcomRadio.get_agc()` has no production
caller today (state acquisition reads AGC generically via overlays, per
#2437's own note) — only tests call it directly.

**Red-first** (`tests/test_radio.py::TestAgcReadPath`):
```
FAILED test_x6200_reports_declared_off_without_raising
  ValueError: 0 is not a valid AgcMode
FAILED test_x6200_reports_declared_auto_as_plain_int_not_mislabeled
  AssertionError: assert <enum 'AgcMode'> is int
FAILED test_x6200_rejects_reading_outside_its_declared_domain
  ValueError: 9 is not a valid AgcMode  (wrong message — pre-fix code
  can't express "not in declared domain", it can only express "not a
  valid AgcMode")
```
All three pass after the fix; existing `test_get_enum_operator_toggle`
(which asserts `get_agc() == AgcMode.SLOW` for the IC-7610 fixture)
**still passes unmodified** — `3 == AgcMode.SLOW` holds for a plain `int`
via `IntEnum`'s int-equality, so no consumer contract broke.

## Items 2+3 — `AmberCockpit.svelte` / `AmberScope.svelte` hardcoded labels

Both amber-lcd files hardcoded an FTX-1-shaped `AGC_LABELS` dict
(0=OFF/1=FAST/2=MID/3=SLOW/4-6=A-F/A-M/A-S) for the read-only AGC status
token, and an IPO/AMP1/AMP2 ternary (also FTX-1's vocabulary,
`rigs/ftx1.toml`'s `[preamp.labels]`) for the preamp token — applied to
every radio regardless of its own declared domain/labels.

**Fix**: both now resolve from the profile-declared capabilities payload:
- AGC: `caps.agcLabels[String(mode)]` (already threaded per #2437),
  falling back to the plain numeric value if undeclared.
- Preamp: `formatPreLabel(value, caps.preLabels)` (already in the payload
  per #2441) — `formatPreLabel` was `panel-props.ts`-private, now exported
  for reuse instead of a third hand-written copy. Its fallback (`OFF`/
  `P{n}`) is the same generic one `toRfFrontEndProps`'s `preOptions`
  already uses for radios (ic7300/ic7610/x6200) that declare no
  `[preamp.labels]` section — this actually *fixes* a cross-skin label
  inconsistency (amber-lcd showed "IPO"/"AMP1" for these radios while
  desktop-v2/mobile already showed "OFF"/"P1"), not just the X6200
  mislabeling.

**Red-first** (`AmberLabels.profile-data.isolated.test.ts`, mounts the
real `AmberScope` + real `AmberIndStrip`/field-status resolver):
```
✗ labels X6200 AGC=3 as AUTO … expected 'AGC SLOW' to be 'AGC AUTO'
✗ labels X6200 AGC=2 as SLOW … expected 'AGC MID' to be 'AGC SLOW'
✗ renders a profile-declared preamp label … expected 'AMP1' to be 'BOOST'
✗ does not fabricate Yaesu vocabulary … expected 'AMP1' to be 'P1'
```
`AmberCockpit.agc-preamp-labels.isolated.test.ts` reproduces the same two
findings against the real `AmberCockpit` (verified red by reverting just
that file via `git diff > patch && git checkout -- … && git apply patch`,
not stash) before being folded into the same commit as the fix.

## Item 4 — `validation/hardware.py` + `rigctld_client/radio.py`

**4a — `_check_agc_set`'s RMVR probe.** Investigation: the local `dsp =
cast(DspControlCapable, radio)` in this function is `radio` itself
(`typing.cast` is a no-op at runtime) — `dsp.set_agc(value, 0)` already
calls the MOR-1522-validated `IcomRadio.set_agc()`/`YaesuCatRadio.set_agc()`
seat, so this call site does **not** bypass profile validation as the
ticket's premise suggested (that read is a false positive, most likely
from the `dsp` variable name colliding with the unrelated `commands.dsp`
raw-builder module `#2437` widened to 0-99). The real, narrower gap:
`make_changed` hardcoded `AgcMode.SLOW`/`AgcMode.FAST` (3/1) as the
mutation probe — safe today only by coincidence (every currently-shipped
`[agc] modes` domain happens to include both 1 and 3), not by design.

**Fix**: derive the probe from the connected radio's own declared
`agc_modes` (new `_declared_agc_modes()` helper, best-effort
`_profile`/`_config` read mirroring what the two validated seats already
do internally), falling back to the old constants only when no domain is
discoverable (preserves the existing FTX-1 mock fixture in
`test_hardware_ftx1.py`, which has neither attribute, unchanged).

**Red-first** (`tests/validation/test_hardware.py`, stateful mock with
`_profile.agc_modes = (5, 7)` — deliberately excludes 1 and 3):
```
FAILED test_agc_set_probe_derives_from_declared_domain_not_hardcoded_fast_slow
AssertionError: assert <CheckStatus.FAIL> is <CheckStatus.PASS>
error='AGC mode must be one of [5, 7], got 3'
```
PASS after the fix (probe correctly picks `7`, the other declared mode).

**4b — `rigctld_client/radio.py`'s `_preamp_level_to_db`.** Silently
coerced any level outside `{0,1,2}` to `"0"` (OFF) via `dict.get(..., "0")`
— confirmed this backend has no `RigProfile` to validate against (per
#2441's own "third seat, explicitly not covered" note), so it's not a
profile-domain-validation gap, just an ungoverned dict-default footgun on
its own fixed 3-level mapping.

**Fix**: raise `ValueError` for anything outside `{0,1,2}`.

**Red-first** (`tests/test_rigctld_client_backend.py`):
```
FAILED test_preamp_level_to_db_rejects_out_of_domain_level
  Failed: DID NOT RAISE <class 'ValueError'>
FAILED test_rigctld_set_preamp_out_of_domain_raises_not_silently_off
  Failed: DID NOT RAISE <class 'ValueError'>
```
Both pass after the fix.

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9328
  passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed. Zero failures.
- `uv run ruff check src/ tests/` / `ruff format --check` — clean.
- `uv run lint-imports` — 5 contracts kept, 0 broken.
- `uv run mypy src/` — identical 13 pre-existing errors (verified against
  unmodified `origin/main`), zero new, none in touched files.
- `frontend`: `npx vitest run` on all touched/related suites (lcd panels,
  panel-props, DspSurface/rf-front-end semantic surfaces) — 318 passed.
- `npx eslint` (touched files + `npm run lint:boundaries`) — clean.
- `npx svelte-check` — 0 errors, 0 warnings across 4553 files.
- Boundary grep (`192\.168|\bmoroz\b|\bmini\b|preview-mor`) over the full
  diff — only pre-existing `192.168.1.100` (a generic RFC1918 test
  fixture IP already used 46× throughout `test_radio.py`, not a leaked
  internal address).

## Guardrail disclosure

Touches 12 files (6 source, 6 test/new-test) and ~560 LOC — over the
nominal 8-file/350-LOC guardrail for this ticket. Mirrors #2437/#2451's
own footprint for the same class of fix: four independently-diagnosed
defects across two backend files, two frontend components (plus one
shared `panel-props.ts` export), and a validation-harness fixture, each
requiring its own red-first test per the ticket's TDD instruction — not
scope creep.

Closes MOR-1529.

## R1 (post-verifier fix)

Independent verifier ruled BLOCKED on the initial head (`7657cf44`). Items
1-3 and 4b held up under review (protocol already declares `get_agc` as
`-> int`, so the item-1 change *removes* a type divergence rather than
introducing one; no production caller of `IcomRadio.get_agc()` confirmed;
`formatPreLabel` is a pure export; fallbacks are honest; all 4 red-first
witnesses reproduced). One blocking finding on item 4a, new head
`9b01b54c`:

**F1:** `_make_changed` in `validation/hardware.py` picked the *first*
declared AGC mode `!= current`. On the live FTX-1 (`[agc] modes = [0..6]`)
that's `0` = AGC OFF for every current value except `0` itself — the RMVR
probe (documented non-destructive/RX-safe, MOR-659) would momentarily
disable AGC on a bench radio: audible and operator-affecting. The old
hardcoded `SLOW`/`FAST` probe never did this. The R1-flagged test used
`domain=(5, 7)` (no `0` present) and the existing FTX-1 mock fixture in
`test_hardware_ftx1.py` is a bare `MagicMock` with no `_config`, so nothing
in the original diff pinned the live-FTX-1 probe shape, and the PR body's
"FTX-1 mock unchanged" phrasing read as "FTX-1 unaffected" when the real
probe value had in fact changed for that radio.

**Fix:** prefer a non-OFF candidate; fall back to any other declared mode
only when OFF is the sole alternative:
```python
modes = _declared_agc_modes(radio)
if modes:
    candidates = [m for m in modes if m != current]
    non_off = [m for m in candidates if m != 0]
    if candidates:
        return (non_off or candidates)[0]
```
**Live-FTX-1 probe value — before/after:** old (pre-#2460, hardcoded):
`3`/`1` (SLOW/FAST, accidentally never OFF). New (post-R1): `1` (FAST,
never OFF, by design — the SET side collapses any AUTO pseudo-value 4/5/6
to `GT04;`, so landing on a manual mode also avoids that ambiguity).

**Red-first** (`tests/validation/test_hardware.py`, domain `(0, 1, 2, 3)`,
`start=3`):
```
FAILED test_agc_set_probe_never_lands_on_off_for_a_domain_that_declares_it
assert check.evidence["changed"] != 0
AssertionError: assert 0 != 0
```
Passes after the fix (`changed == 1`).

Verified after R1: `uv run pytest tests/validation/ tests/test_radio.py -q`
— 534 passed. `uv run ruff check` / `ruff format --check` — clean.
`uv run mypy src/rigplane/validation/hardware.py` — no issues. `uv run
lint-imports` — 5 kept, 0 broken. Boundary grep — clean.
