### PR TITLE
fix: profile-gated cmd29 for the 0x14 level family (MOR-1543)

### DIFF
--- a/src/rigplane/commands/levels.py
+++ b/src/rigplane/commands/levels.py
@@ -43,7 +43,6 @@ from ._frame import (
     _SUB_VOX_GAIN,
     _build_from_map,
     build_civ_frame,
-    build_cmd29_frame,
 )
 
 if TYPE_CHECKING:
@@ -112,18 +111,16 @@ def get_rf_gain(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
-    """Build a 'read RF gain' CI-V command (0x14 0x02).
-
-    For SUB receiver, the frame is wrapped in cmd29 (0x29 0x01) — same routing
-    as ``set_rf_gain``.
-    """
+    """Build a 'read RF gain' CI-V command (0x14 0x02)."""
     return _build_level_get(
         _SUB_RF_GAIN,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=(receiver != RECEIVER_MAIN),
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_rf_gain",
     )
@@ -135,29 +132,20 @@ def set_rf_gain(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a 'set RF gain' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_rf_gain",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-            receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
-        )
-    bcd = _level_bcd_encode(level)
-    if receiver != RECEIVER_MAIN:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_LEVEL,
-            sub=_SUB_RF_GAIN,
-            data=bcd,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_RF_GAIN, data=bcd)
+    return _build_level_set(
+        _SUB_RF_GAIN,
+        level,
+        to_addr=to_addr,
+        from_addr=from_addr,
+        receiver=receiver,
+        command29=command29,
+        cmd_map=cmd_map,
+        cmd_name="set_rf_gain",
+    )
 
 
 def get_af_level(
@@ -165,18 +153,16 @@ def get_af_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
-    """Build a 'read AF output level' CI-V command (0x14 0x01).
-
-    For SUB receiver, the frame is wrapped in cmd29 (0x29 0x01) — same routing
-    as ``set_af_level``.
-    """
+    """Build a 'read AF output level' CI-V command (0x14 0x01)."""
     return _build_level_get(
         _SUB_AF_LEVEL,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=(receiver != RECEIVER_MAIN),
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_af_level",
     )
@@ -188,29 +174,20 @@ def set_af_level(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a 'set AF output level' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_af_level",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-            receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
-        )
-    bcd = _level_bcd_encode(level)
-    if receiver != RECEIVER_MAIN:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_LEVEL,
-            sub=_SUB_AF_LEVEL,
-            data=bcd,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_AF_LEVEL, data=bcd)
+    return _build_level_set(
+        _SUB_AF_LEVEL,
+        level,
+        to_addr=to_addr,
+        from_addr=from_addr,
+        receiver=receiver,
+        command29=command29,
+        cmd_map=cmd_map,
+        cmd_name="set_af_level",
+    )
 
 
 def get_squelch(
@@ -218,6 +195,8 @@ def get_squelch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a 'get squelch level' CI-V command (0x14 0x03)."""
     return _build_level_get(
@@ -225,7 +204,7 @@ def get_squelch(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=(receiver != RECEIVER_MAIN),
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_squelch",
     )
@@ -237,24 +216,20 @@ def set_squelch(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a 'set squelch level' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_squelch",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-            receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
-        )
-    bcd = _level_bcd_encode(level)
-    if receiver != RECEIVER_MAIN:
-        return build_cmd29_frame(
-            to_addr, from_addr, _CMD_LEVEL, sub=_SUB_SQL, data=bcd, receiver=receiver
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_SQL, data=bcd)
+    return _build_level_set(
+        _SUB_SQL,
+        level,
+        to_addr=to_addr,
+        from_addr=from_addr,
+        receiver=receiver,
+        command29=command29,
+        cmd_map=cmd_map,
+        cmd_name="set_squelch",
+    )
 
 
 def get_apf_type_level(
@@ -526,6 +501,8 @@ def get_notch_filter(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a read Notch Filter level command."""
     return _build_level_get(
@@ -533,7 +510,7 @@ def get_notch_filter(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=(receiver != RECEIVER_MAIN),
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="get_notch_filter",
     )
@@ -545,6 +522,8 @@ def set_notch_filter(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
     cmd_map: CommandMap | None = None,
+    *,
+    command29: bool = True,
 ) -> bytes:
     """Build a set Notch Filter level command."""
     return _build_level_set(
@@ -553,7 +532,7 @@ def set_notch_filter(
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
-        command29=(receiver != RECEIVER_MAIN),
+        command29=command29,
         cmd_map=cmd_map,
         cmd_name="set_notch_filter",
     )

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -2523,11 +2523,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._last_power = level
 
     async def get_rf_gain(self, receiver: int = 0) -> int:
-        """Read the current RF gain level (0-255).
-
-        Routes through cmd29 (0x29 0x01) for the SUB receiver, mirroring
-        ``set_rf_gain``.
-        """
+        """Read the current RF gain level (0-255)."""
         self._check_connected()
         self._require_receiver(receiver, operation="get_rf_gain")
         self._require_cmd29_route(
@@ -2536,7 +2532,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="get_rf_gain",
         )
-        civ = get_rf_gain(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x02)
+        civ = get_rf_gain(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         try:
             resp = await self._send_civ_expect(
                 civ,
@@ -2561,15 +2558,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_rf_gain",
         )
-        civ = set_rf_gain(level, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x02)
+        civ = set_rf_gain(
+            level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_af_level(self, receiver: int = 0) -> int:
-        """Read the current AF output level (0-255).
-
-        Routes through cmd29 (0x29 0x01) for the SUB receiver, mirroring
-        ``set_af_level``.
-        """
+        """Read the current AF output level (0-255)."""
         self._check_connected()
         self._require_receiver(receiver, operation="get_af_level")
         self._require_cmd29_route(
@@ -2578,7 +2574,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="get_af_level",
         )
-        civ = get_af_level(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x01)
+        civ = get_af_level(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         try:
             resp = await self._send_civ_expect(
                 civ,
@@ -2603,7 +2600,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_af_level",
         )
-        civ = set_af_level(level, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x01)
+        civ = set_af_level(
+            level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
 
     async def set_squelch(self, level: int, receiver: int = 0) -> None:
@@ -2621,7 +2621,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         from rigplane.commands import set_squelch as _set_squelch
 
-        civ = _set_squelch(level, to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x03)
+        civ = _set_squelch(
+            level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_squelch(self, receiver: int = 0) -> int:
@@ -2637,7 +2640,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         from rigplane.commands import get_squelch as _get_squelch
 
-        civ = _get_squelch(to_addr=self._radio_addr, receiver=receiver)
+        cmd29 = self._profile.supports_cmd29(0x14, 0x03)
+        civ = _get_squelch(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
         return await self._get_bcd_level(
             civ,
             key=f"get_squelch:{receiver}",
@@ -2805,8 +2809,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x0D, receiver=receiver, operation="get_notch_filter"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x0D)
+        civ = get_notch_filter(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         return await self._get_bcd_level(
-            get_notch_filter(to_addr=self._radio_addr, receiver=receiver),
+            civ,
             key=f"get_notch_filter:{receiver}",
             command=0x14,
             sub=0x0D,
@@ -2818,8 +2826,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._require_cmd29_route(
             0x14, 0x0D, receiver=receiver, operation="set_notch_filter"
         )
+        cmd29 = self._profile.supports_cmd29(0x14, 0x0D)
         await self._send_fire_and_forget(
-            set_notch_filter(level, to_addr=self._radio_addr, receiver=receiver)
+            set_notch_filter(
+                level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+            )
         )
 
     async def get_compressor_level(self) -> int:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -512,10 +512,23 @@ class TestCmd29ReceiverRouting:
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x06  # Mode set command
 
-    def test_set_rf_gain_main_no_cmd29(self) -> None:
+    def test_set_rf_gain_main_wrapped_by_default(self) -> None:
+        # MOR-1543: set_rf_gain's builder now defaults command29=True like
+        # every other cmd29-eligible setter, instead of deriving the wrap
+        # decision from receiver internally. IC-7610 declares a cmd29 route
+        # for 0x14/0x02, so MAIN wraps too.
         from rigplane.commands import RECEIVER_MAIN, set_rf_gain
 
         frame = set_rf_gain(128, receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x14
+        assert frame[7] == 0x02  # RF gain sub
+
+    def test_set_rf_gain_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, set_rf_gain
+
+        frame = set_rf_gain(128, receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x14  # Direct level cmd, no cmd29 prefix
         assert frame[5] == 0x02  # RF gain sub
 
@@ -528,10 +541,21 @@ class TestCmd29ReceiverRouting:
         assert frame[6] == 0x14  # Level command
         assert frame[7] == 0x02  # RF gain sub
 
-    def test_set_af_level_main_no_cmd29(self) -> None:
+    def test_set_af_level_main_wrapped_by_default(self) -> None:
+        # MOR-1543: same fix as set_rf_gain — IC-7610 declares a cmd29 route
+        # for 0x14/0x01, so MAIN wraps too.
         from rigplane.commands import RECEIVER_MAIN, set_af_level
 
         frame = set_af_level(200, receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x14
+        assert frame[7] == 0x01  # AF level sub
+
+    def test_set_af_level_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, set_af_level
+
+        frame = set_af_level(200, receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x14
         assert frame[5] == 0x01  # AF level sub
 
@@ -544,10 +568,20 @@ class TestCmd29ReceiverRouting:
         assert frame[6] == 0x14
         assert frame[7] == 0x01  # AF level sub
 
-    def test_get_rf_gain_main_no_cmd29(self) -> None:
+    def test_get_rf_gain_main_wrapped_by_default(self) -> None:
+        # MOR-1543: get_rf_gain's builder now defaults command29=True.
         from rigplane.commands import RECEIVER_MAIN, get_rf_gain
 
         frame = get_rf_gain(receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x14
+        assert frame[7] == 0x02  # RF gain sub
+
+    def test_get_rf_gain_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, get_rf_gain
+
+        frame = get_rf_gain(receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x14  # Direct level cmd, no cmd29 prefix
         assert frame[5] == 0x02  # RF gain sub
 
@@ -565,10 +599,20 @@ class TestCmd29ReceiverRouting:
 
         assert get_rf_gain() == get_rf_gain(receiver=RECEIVER_MAIN)
 
-    def test_get_af_level_main_no_cmd29(self) -> None:
+    def test_get_af_level_main_wrapped_by_default(self) -> None:
+        # MOR-1543: get_af_level's builder now defaults command29=True.
         from rigplane.commands import RECEIVER_MAIN, get_af_level
 
         frame = get_af_level(receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x14
+        assert frame[7] == 0x01  # AF level sub
+
+    def test_get_af_level_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, get_af_level
+
+        frame = get_af_level(receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x14
         assert frame[5] == 0x01  # AF level sub
 
@@ -586,10 +630,20 @@ class TestCmd29ReceiverRouting:
 
         assert get_af_level() == get_af_level(receiver=RECEIVER_MAIN)
 
-    def test_set_squelch_main_no_cmd29(self) -> None:
+    def test_set_squelch_main_wrapped_by_default(self) -> None:
+        # MOR-1543: set_squelch's builder now defaults command29=True.
         from rigplane.commands import RECEIVER_MAIN, set_squelch
 
         frame = set_squelch(100, receiver=RECEIVER_MAIN)
+        assert frame[4] == 0x29
+        assert frame[5] == 0x00  # MAIN
+        assert frame[6] == 0x14
+        assert frame[7] == 0x03  # SQL sub
+
+    def test_set_squelch_main_unwrapped_with_override(self) -> None:
+        from rigplane.commands import RECEIVER_MAIN, set_squelch
+
+        frame = set_squelch(100, receiver=RECEIVER_MAIN, command29=False)
         assert frame[4] == 0x14
         assert frame[5] == 0x03  # SQL sub
 
@@ -706,17 +760,19 @@ class TestCmd29ReceiverRouting:
         )
         from rigplane.types import Mode
 
-        # None of these should use cmd29 when called without receiver
+        # freq/mode never use cmd29 (hard exclusion, IC-7610 CI-V quirk).
         assert set_frequency(14_000_000)[4] == 0x05
         assert set_mode(Mode.USB)[4] == 0x06
-        assert set_rf_gain(128)[4] == 0x14
-        assert set_af_level(200)[4] == 0x14
-        assert set_squelch(50)[4] == 0x14
         # MOR-1537 follow-up: nb/nr/ip_plus builders now default
         # command29=True; no receiver arg still targets MAIN (0x00).
         assert set_nb(True)[4:6] == b"\x29\x00"
         assert set_nr(True)[4:6] == b"\x29\x00"
         assert set_ip_plus(True)[4:6] == b"\x29\x00"
+        # MOR-1543: rf_gain/af_level/squelch builders now default
+        # command29=True; no receiver arg still targets MAIN (0x00).
+        assert set_rf_gain(128)[4:6] == b"\x29\x00"
+        assert set_af_level(200)[4:6] == b"\x29\x00"
+        assert set_squelch(50)[4:6] == b"\x29\x00"
 
 
 class TestDspLevelParityCommands:
@@ -729,6 +785,7 @@ class TestDspLevelParityCommands:
             ("get_nr_level", "set_nr_level", 0x06, 1),
             ("get_pbt_inner", "set_pbt_inner", 0x07, 1),
             ("get_pbt_outer", "set_pbt_outer", 0x08, 1),
+            ("get_notch_filter", "set_notch_filter", 0x0D, 1),
             ("get_nb_level", "set_nb_level", 0x12, 1),
             ("get_digisel_shift", "set_digisel_shift", 0x13, 1),
         ],
@@ -755,7 +812,6 @@ class TestDspLevelParityCommands:
             ("get_cw_pitch", "set_cw_pitch", 0x09, 600),
             ("get_mic_gain", "set_mic_gain", 0x0B, 128),
             ("get_key_speed", "set_key_speed", 0x0C, 30),
-            ("get_notch_filter", "set_notch_filter", 0x0D, 128),
             ("get_compressor_level", "set_compressor_level", 0x0E, 128),
             ("get_break_in_delay", "set_break_in_delay", 0x0F, 128),
             ("get_drive_gain", "set_drive_gain", 0x14, 128),

--- a/tests/test_mor1543_cmd29_gating.py
+++ b/tests/test_mor1543_cmd29_gating.py
@@ -1,0 +1,396 @@
+"""Tests for MOR-1543 — profile-gated cmd29 for the 0x14 level family.
+
+MOR-1517 (#2434) established the pattern, MOR-1537 (#2451) extended it to
+AGC/AF-mute/DIGI-SEL, and the MOR-1537 follow-up (#2455) extended it again to
+NB/NR/IP+: a CI-V command builder must accept an explicit ``command29: bool``
+keyword-only override, and the ``radio.py`` call site must compute
+``cmd29 = self._profile.supports_cmd29(cmd, sub)`` and thread it through —
+never derive the wrap decision from ``receiver`` inside the builder.
+
+Auditing ``commands/levels.py`` found four more commands with the exact
+stale shape:
+
+- ``get_rf_gain``/``set_rf_gain`` (0x14/0x02)
+- ``get_af_level``/``set_af_level`` (0x14/0x01)
+- ``get_squelch``/``set_squelch`` (0x14/0x03)
+- ``get_notch_filter``/``set_notch_filter`` (0x14/0x0D)
+
+All four computed ``command29=(receiver != RECEIVER_MAIN)`` internally with
+no override parameter. IC-7610 declares ``[cmd29]`` routes for all four subs
+(``rigs/ic7610.toml``), so e.g. ``set_rf_gain(level, receiver=0)`` on IC-7610
+sent a PLAIN frame for the MAIN receiver even though the profile declares a
+cmd29 route — the same shape mismatch against the acquisition/scheduler path
+that MOR-1537 fixed for AGC.
+
+Notch filter (0x14/0x0D) deserves special note: ic7610.toml's route comment
+records a PDF-vs-wfview disagreement (wfview's IC-7610.rig records
+Command29=false, but the IC-7610 CI-V Reference Guide Rev.4 p.3 shows the
+Command29 glyph) — already adjudicated in favor of the PDF, with rationale,
+in a prior review (issue #708; see ``docs/parity/ic7610_command_matrix.json``
+"cmd29_rationale" for sub 0x0D). There is no in-repo evidence of a live NAK
+against the wrapped frame — the disagreement is source-provenance only, and
+it was already resolved by keeping the route. So this fix converts
+``get_notch_filter``/``set_notch_filter`` exactly like the other three
+instead of removing the route.
+
+IC-7300 declares no ``[cmd29]`` section at all -> every frame must remain
+bare/unwrapped there, byte-for-byte identical to the pre-fix behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.types import CivFrame
+
+from test_mor1517_cmd29_gating import (
+    _connected_icom,
+    _mock_expect,
+    _mock_raw,
+    _sent_civ,
+)
+
+_IC7300_ADDR = 0x94
+_IC7610_ADDR = 0x98
+
+
+# ---------------------------------------------------------------------------
+# Route-table sanity: the whole point of the fix is that IC-7610 *does*
+# declare cmd29 routes for these subs.
+# ---------------------------------------------------------------------------
+
+
+class TestRouteTableSanity:
+    @pytest.mark.parametrize("sub", [0x01, 0x02, 0x03, 0x0D])
+    def test_ic7610_declares_route(self, sub: int) -> None:
+        radio = _connected_icom(model="IC-7610")
+        assert radio._profile.supports_cmd29(0x14, sub) is True
+
+    @pytest.mark.parametrize("sub", [0x01, 0x02, 0x03, 0x0D])
+    def test_ic7300_declares_no_route(self, sub: int) -> None:
+        radio = _connected_icom(model="IC-7300")
+        assert radio._profile.supports_cmd29(0x14, sub) is False
+
+
+# ---------------------------------------------------------------------------
+# Builder-level: explicit command29 override, receiver no longer decides.
+# Expected frames are raw byte literals on purpose — they pin the wire format
+# independently of the builder under test.
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderOverride:
+    def test_set_rf_gain_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_rf_gain
+
+        frame = set_rf_gain(128, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e0290014020128fd")
+
+    def test_set_rf_gain_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_rf_gain
+
+        frame = set_rf_gain(128, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e014020128fd")
+
+    def test_get_rf_gain_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_rf_gain
+
+        frame = get_rf_gain(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e029001402fd")
+
+    def test_get_rf_gain_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_rf_gain
+
+        frame = get_rf_gain(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e01402fd")
+
+    def test_set_af_level_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_af_level
+
+        frame = set_af_level(200, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e0290014010200fd")
+
+    def test_set_af_level_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_af_level
+
+        frame = set_af_level(200, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e014010200fd")
+
+    def test_get_af_level_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_af_level
+
+        frame = get_af_level(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e029001401fd")
+
+    def test_get_af_level_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_af_level
+
+        frame = get_af_level(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e01401fd")
+
+    def test_set_squelch_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_squelch
+
+        frame = set_squelch(64, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e0290014030064fd")
+
+    def test_set_squelch_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_squelch
+
+        frame = set_squelch(64, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e014030064fd")
+
+    def test_get_squelch_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_squelch
+
+        frame = get_squelch(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e029001403fd")
+
+    def test_get_squelch_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_squelch
+
+        frame = get_squelch(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e01403fd")
+
+    def test_set_notch_filter_wrapped_by_default_for_main(self) -> None:
+        from rigplane.commands import set_notch_filter
+
+        frame = set_notch_filter(90, to_addr=_IC7610_ADDR, receiver=0)
+        assert frame == bytes.fromhex("fefe98e02900140d0090fd")
+
+    def test_set_notch_filter_unwrapped_with_override(self) -> None:
+        from rigplane.commands import set_notch_filter
+
+        frame = set_notch_filter(90, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        assert frame == bytes.fromhex("fefe94e0140d0090fd")
+
+    def test_get_notch_filter_wrapped_by_default(self) -> None:
+        from rigplane.commands import get_notch_filter
+
+        frame = get_notch_filter(to_addr=_IC7610_ADDR)
+        assert frame == bytes.fromhex("fefe98e02900140dfd")
+
+    def test_get_notch_filter_unwrapped_with_override(self) -> None:
+        from rigplane.commands import get_notch_filter
+
+        frame = get_notch_filter(to_addr=_IC7300_ADDR, command29=False)
+        assert frame == bytes.fromhex("fefe94e0140dfd")
+
+
+# ---------------------------------------------------------------------------
+# Runtime call sites: cmd29 must come from the profile, not from receiver.
+# The pinned defect is the IC-7610 receiver=0 (MAIN) case: it must now go
+# out 0x29-wrapped because the profile declares the route.
+# ---------------------------------------------------------------------------
+
+
+class TestRfGainGating:
+    @pytest.mark.asyncio
+    async def test_set_rf_gain_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_rf_gain(128, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e0290014020128fd")
+
+    @pytest.mark.asyncio
+    async def test_set_rf_gain_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_rf_gain(128, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e0290114020128fd")
+
+    @pytest.mark.asyncio
+    async def test_set_rf_gain_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_rf_gain(128, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e014020128fd")
+
+    @pytest.mark.asyncio
+    async def test_get_rf_gain_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x14,
+            sub=0x02,
+            data=b"\x01\x28",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_rf_gain()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e029001402fd")
+        assert value == 128
+
+    @pytest.mark.asyncio
+    async def test_get_rf_gain_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x14,
+            sub=0x02,
+            data=b"\x01\x28",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_rf_gain()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e01402fd")
+        assert value == 128
+
+
+class TestAfLevelGating:
+    @pytest.mark.asyncio
+    async def test_set_af_level_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_af_level(200, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e0290014010200fd")
+
+    @pytest.mark.asyncio
+    async def test_set_af_level_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_af_level(200, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e0290114010200fd")
+
+    @pytest.mark.asyncio
+    async def test_set_af_level_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_af_level(200, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e014010200fd")
+
+    @pytest.mark.asyncio
+    async def test_get_af_level_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x14,
+            sub=0x01,
+            data=b"\x02\x00",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_af_level()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e029001401fd")
+        assert value == 200
+
+    @pytest.mark.asyncio
+    async def test_get_af_level_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x14,
+            sub=0x01,
+            data=b"\x02\x00",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_af_level()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e01401fd")
+        assert value == 200
+
+
+class TestSquelchGating:
+    @pytest.mark.asyncio
+    async def test_set_squelch_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_squelch(64, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e0290014030064fd")
+
+    @pytest.mark.asyncio
+    async def test_set_squelch_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_squelch(64, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e0290114030064fd")
+
+    @pytest.mark.asyncio
+    async def test_set_squelch_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_squelch(64, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e014030064fd")
+
+    @pytest.mark.asyncio
+    async def test_get_squelch_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x14,
+            sub=0x03,
+            data=b"\x00\x64",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_squelch()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e029001403fd")
+        assert value == 64
+
+    @pytest.mark.asyncio
+    async def test_get_squelch_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x14,
+            sub=0x03,
+            data=b"\x00\x64",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_squelch()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e01403fd")
+        assert value == 64
+
+
+class TestNotchFilterGating:
+    @pytest.mark.asyncio
+    async def test_set_notch_filter_main_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_notch_filter(90, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02900140d0090fd")
+
+    @pytest.mark.asyncio
+    async def test_set_notch_filter_sub_still_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        mock = _mock_raw(radio)
+        await radio.set_notch_filter(90, receiver=1)
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02901140d0090fd")
+
+    @pytest.mark.asyncio
+    async def test_set_notch_filter_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        mock = _mock_raw(radio)
+        await radio.set_notch_filter(90, receiver=0)
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e0140d0090fd")
+
+    @pytest.mark.asyncio
+    async def test_get_notch_filter_wrapped_on_ic7610(self) -> None:
+        radio = _connected_icom(model="IC-7610")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7610_ADDR,
+            command=0x14,
+            sub=0x0D,
+            data=b"\x00\x90",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_notch_filter()
+        assert _sent_civ(mock) == bytes.fromhex("fefe98e02900140dfd")
+        assert value == 90
+
+    @pytest.mark.asyncio
+    async def test_get_notch_filter_unwrapped_on_ic7300(self) -> None:
+        radio = _connected_icom(model="IC-7300")
+        response = CivFrame(
+            to_addr=0xE0,
+            from_addr=_IC7300_ADDR,
+            command=0x14,
+            sub=0x0D,
+            data=b"\x00\x90",
+        )
+        mock = _mock_expect(radio, response)
+        value = await radio.get_notch_filter()
+        assert _sent_civ(mock) == bytes.fromhex("fefe94e0140dfd")
+        assert value == 90

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -713,8 +713,12 @@ class TestSquelch:
     async def test_levels_get_squelch_icom(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        """get_squelch on MAIN parses a non-cmd29 0x14 0x03 BCD response."""
-        mock_transport.queue_response(_level_response(0x03, 200))
+        """get_squelch on MAIN parses a cmd29-wrapped 0x14 0x03 BCD response.
+
+        IC-7610 declares a cmd29 route for 0x14/0x03, so MAIN is now
+        cmd29-wrapped too (MOR-1543) — previously only SUB wrapped.
+        """
+        mock_transport.queue_response(_level_response(0x03, 200, receiver=0))
         assert await radio.get_squelch() == 200
 
     @pytest.mark.asyncio
@@ -2133,6 +2137,7 @@ class TestDspLevelParity:
             ("get_pbt_inner", 0x07, 92, 1),
             ("get_pbt_outer", 0x08, 93, 1),
             ("get_notch_filter", 0x0D, 96, 1),
+            ("get_notch_filter", 0x0D, 97, 0),
             ("get_nb_level", 0x12, 94, 1),
             ("get_digisel_shift", 0x13, 95, 1),
         ],
@@ -2156,7 +2161,6 @@ class TestDspLevelParity:
         ("method_name", "sub", "value"),
         [
             ("get_mic_gain", 0x0B, 101),
-            ("get_notch_filter", 0x0D, 102),
             ("get_compressor_level", 0x0E, 103),
             ("get_break_in_delay", 0x0F, 104),
             ("get_drive_gain", 0x14, 105),

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -2063,12 +2063,14 @@ async def test_get_rf_gain_returns_level(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
     """get_rf_gain() returns parsed level on success (line 1210)."""
-    # Build RF gain response: cmd 0x14 sub 0x02, value BCD
+    # Build RF gain response: cmd 0x14 sub 0x02, value BCD.
+    # IC-7610 declares a cmd29 route for 0x14/0x02, so MAIN is now
+    # cmd29-wrapped (MOR-1543) — the response must match.
     d = f"{200:04d}"
     b0 = (int(d[0]) << 4) | int(d[1])
     b1 = (int(d[2]) << 4) | int(d[3])
-    civ = build_civ_frame(
-        CONTROLLER_ADDR, IC_7610_ADDR, 0x14, sub=0x02, data=bytes([b0, b1])
+    civ = build_cmd29_frame(
+        CONTROLLER_ADDR, IC_7610_ADDR, 0x14, sub=0x02, data=bytes([b0, b1]), receiver=0
     )
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
     result = await radio.get_rf_gain()
@@ -2078,12 +2080,16 @@ async def test_get_rf_gain_returns_level(
 async def test_get_af_level_returns_level(
     radio: IcomRadio, mock_transport: MockTransport
 ) -> None:
-    """get_af_level() returns parsed level on success (line 1228)."""
+    """get_af_level() returns parsed level on success (line 1228).
+
+    IC-7610 declares a cmd29 route for 0x14/0x01, so MAIN is now
+    cmd29-wrapped (MOR-1543) — the response must match.
+    """
     d = f"{150:04d}"
     b0 = (int(d[0]) << 4) | int(d[1])
     b1 = (int(d[2]) << 4) | int(d[3])
-    civ = build_civ_frame(
-        CONTROLLER_ADDR, IC_7610_ADDR, 0x14, sub=0x01, data=bytes([b0, b1])
+    civ = build_cmd29_frame(
+        CONTROLLER_ADDR, IC_7610_ADDR, 0x14, sub=0x01, data=bytes([b0, b1]), receiver=0
     )
     mock_transport.queue_response(_wrap_civ_in_udp(civ))
     result = await radio.get_af_level()

--- a/tests/test_rf_gain_af_level.py
+++ b/tests/test_rf_gain_af_level.py
@@ -9,12 +9,16 @@ from rigplane.commands import (
     set_rf_gain,
     get_af_level,
     set_af_level,
-    build_civ_frame,
+    build_cmd29_frame,
 )
 from _command_test_helpers import bind_default_addr_globals, bind_default_addr_module
 
 bind_default_addr_module(raw_commands, to_addr=IC_7610_ADDR)
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
+
+# IC-7610 declares cmd29 routes for 0x14/0x02 (RF gain) and 0x14/0x01 (AF
+# level), so the builders' command29=True default now wraps MAIN too
+# (MOR-1543) — these expected frames are cmd29-wrapped for receiver 0.
 
 
 class TestRfGainCommands:
@@ -23,23 +27,29 @@ class TestRfGainCommands:
     def test_get_rf_gain_frame(self) -> None:
         frame = get_rf_gain()
         # 0x14 = level command, 0x02 = RF gain sub
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x02)
+        expected = build_cmd29_frame(0x98, 0xE0, 0x14, sub=0x02, receiver=0)
         assert frame == expected
 
     def test_set_rf_gain_128(self) -> None:
         frame = set_rf_gain(128)
         # 128 -> BCD 0x01 0x28
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x02, data=b"\x01\x28")
+        expected = build_cmd29_frame(
+            0x98, 0xE0, 0x14, sub=0x02, data=b"\x01\x28", receiver=0
+        )
         assert frame == expected
 
     def test_set_rf_gain_zero(self) -> None:
         frame = set_rf_gain(0)
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x02, data=b"\x00\x00")
+        expected = build_cmd29_frame(
+            0x98, 0xE0, 0x14, sub=0x02, data=b"\x00\x00", receiver=0
+        )
         assert frame == expected
 
     def test_set_rf_gain_max(self) -> None:
         frame = set_rf_gain(255)
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x02, data=b"\x02\x55")
+        expected = build_cmd29_frame(
+            0x98, 0xE0, 0x14, sub=0x02, data=b"\x02\x55", receiver=0
+        )
         assert frame == expected
 
     def test_set_rf_gain_out_of_range_high(self) -> None:
@@ -57,22 +67,28 @@ class TestAfLevelCommands:
     def test_get_af_level_frame(self) -> None:
         frame = get_af_level()
         # 0x14 = level command, 0x01 = AF level sub
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x01)
+        expected = build_cmd29_frame(0x98, 0xE0, 0x14, sub=0x01, receiver=0)
         assert frame == expected
 
     def test_set_af_level_128(self) -> None:
         frame = set_af_level(128)
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x01, data=b"\x01\x28")
+        expected = build_cmd29_frame(
+            0x98, 0xE0, 0x14, sub=0x01, data=b"\x01\x28", receiver=0
+        )
         assert frame == expected
 
     def test_set_af_level_zero(self) -> None:
         frame = set_af_level(0)
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x01, data=b"\x00\x00")
+        expected = build_cmd29_frame(
+            0x98, 0xE0, 0x14, sub=0x01, data=b"\x00\x00", receiver=0
+        )
         assert frame == expected
 
     def test_set_af_level_max(self) -> None:
         frame = set_af_level(255)
-        expected = build_civ_frame(0x98, 0xE0, 0x14, sub=0x01, data=b"\x02\x55")
+        expected = build_cmd29_frame(
+            0x98, 0xE0, 0x14, sub=0x01, data=b"\x02\x55", receiver=0
+        )
         assert frame == expected
 
     def test_set_af_level_out_of_range_high(self) -> None:
@@ -95,9 +111,9 @@ class TestRfGainAfLevelSubCommandDifference:
 
     def test_rf_gain_uses_sub_02(self) -> None:
         frame = get_rf_gain()
-        # sub-command byte is at position 5 (after FE FE to from cmd)
-        assert frame[5] == 0x02
+        # cmd29-wrapped: FE FE to from 29 <receiver> 14 <sub>
+        assert frame[7] == 0x02
 
     def test_af_level_uses_sub_01(self) -> None:
         frame = get_af_level()
-        assert frame[5] == 0x01
+        assert frame[7] == 0x01


### PR DESCRIPTION
## Root cause

MOR-1517 (#2434) established the pattern, MOR-1537 (#2451) extended it to AGC/AF-mute/DIGI-SEL, and the MOR-1537 follow-up (#2455) extended it again to NB/NR/IP+: a CI-V command builder must accept an explicit keyword-only `command29: bool` override, and the `radio.py` call site must compute `cmd29 = self._profile.supports_cmd29(cmd, sub)` and thread it through — never derive the wrap decision from `receiver` inside the builder.

Auditing `commands/levels.py` found four more commands with the exact stale shape:

- `get_rf_gain`/`set_rf_gain` (0x14/0x02)
- `get_af_level`/`set_af_level` (0x14/0x01)
- `get_squelch`/`set_squelch` (0x14/0x03)
- `get_notch_filter`/`set_notch_filter` (0x14/0x0D)

All four computed `command29=(receiver != RECEIVER_MAIN)` internally with no override parameter. IC-7610 declares `[cmd29]` routes for all four subs (`rigs/ic7610.toml`), so e.g. `set_rf_gain(level, receiver=0)` on IC-7610 sent a **plain** frame for the MAIN receiver even though the profile declares a cmd29 route — a live GET-twin divergence against the acquisition/scheduler path, the same shape mismatch MOR-1537 fixed for AGC.

## Changes

- `commands/levels.py`: the eight builders (`get_rf_gain`, `set_rf_gain`, `get_af_level`, `set_af_level`, `get_squelch`, `set_squelch`, `get_notch_filter`, `set_notch_filter`) now accept a keyword-only `command29: bool = True` override, routed through the shared `_build_level_get`/`_build_level_set` helpers (same shape as `get_nr_level`/`get_apf_type_level`/etc.). The receiver-derived wrap decision is gone. The now-unused `build_cmd29_frame` import was dropped.
- `runtime/radio.py`: `get_rf_gain`/`set_rf_gain`, `get_af_level`/`set_af_level`, `get_squelch`/`set_squelch`, `get_notch_filter`/`set_notch_filter` thread `cmd29 = self._profile.supports_cmd29(0x14, sub)` through. Existing `_require_capability`/`_require_receiver`/`_require_cmd29_route` gating at the setters is unchanged.
- `tests/test_mor1543_cmd29_gating.py` (new, TDD): route-table sanity, raw byte-literal frame pins for all eight builders (IC-7610 wrapped incl. MAIN, IC-7300 unwrapped/override), and runtime call-site tests for all four commands on both profiles. 24 of these failed before the fix (TypeError for `notch_filter`'s missing `command29` kwarg, wrong-wrap-shape assertions for the other three).
- `tests/test_commands.py`, `tests/test_radio.py`, `tests/test_radio_coverage.py`, `tests/test_rf_gain_af_level.py`: updated fixtures/assertions that encoded the stale "MAIN never wraps on IC-7610" assumption for these four commands (mirrors what #2451/#2455 had to do for AGC/NB/NR/IP+ — the old assumption was the bug, not scope creep). `test_rf_gain_af_level.py` in particular is a whole file dedicated to `get_rf_gain`/`set_rf_gain`/`get_af_level`/`set_af_level` against an IC-7610-bound default address; all of it assumed plain frames and needed updating to cmd29-wrapped expectations.

## Notch filter (0x14/0x0D) provenance decision

`ic7610.toml`'s `[cmd29]` route table carries a comment flagging a PDF-vs-wfview disagreement for this sub:

```
# PDF-vs-wfview disagreement — PDF primary source wins (issue #708 review):
#   0x14 0x0D notch filter — PDF p.3 shows the 29-glyph, wfview records
#   Command29=false; PDF takes precedence as the primary IC-7610 reference.
#   Without this route, both receivers would share a single notch position
#   on dual-RX — a real functional limitation.
```

`docs/parity/ic7610_command_matrix.json` has the same rationale recorded per-row (`cmd29_rationale` for sub 0x0D), citing the same issue #708 review. This is an already-adjudicated decision with documented rationale, not an open question — and there is no in-repo evidence (cat-audits, hardware logs) of a live NAK against the wrapped frame; `docs/validation/cat-audits/ic7610.md` records the notch filter row with no anomaly notes. The disagreement is source-provenance only (wfview's rig file vs. the CI-V Reference Guide PDF) and was already resolved in favor of the PDF, specifically to preserve per-receiver notch position on dual-RX.

**Decision: convert, don't remove.** `get_notch_filter`/`set_notch_filter` get the exact same fix as the other three — there is no basis in the repo to second-guess the prior review's PDF-precedence call.

## Behavior change matrix (IC-7610, MAIN receiver)

| Command | Before | After |
|---|---|---|
| `get_rf_gain`/`set_rf_gain` (0x14/0x02) | plain `FE FE 98 E0 14 02 ... FD` | wrapped `FE FE 98 E0 29 00 14 02 ... FD` |
| `get_af_level`/`set_af_level` (0x14/0x01) | plain | wrapped |
| `get_squelch`/`set_squelch` (0x14/0x03) | plain | wrapped |
| `get_notch_filter`/`set_notch_filter` (0x14/0x0D) | plain | wrapped |

IC-7300 (no `[cmd29]` section) is unaffected — byte-for-byte unchanged, plain for MAIN and SUB alike (SUB already raises via `_require_cmd29_route` for single-RX profiles, unchanged). IC-7610's SUB receiver was already wrapped for all four and is unchanged.

## Out of scope (hard exclusion)

`freq.py` (0x05) and `mode.py` `set_mode`/`set_data_mode` (0x06) are untouched, per CLAUDE.md's standing rule that cmd29 does not work for freq/mode on IC-7610.

## Series-closure grep

Re-grepped `receiver != RECEIVER_MAIN` across `src/rigplane/commands/` after this fix:

```
src/rigplane/commands/freq.py:70   (set_freq, 0x05)
src/rigplane/commands/freq.py:73   (set_freq, 0x05)
src/rigplane/commands/mode.py:81   (set_mode, 0x06)
src/rigplane/commands/mode.py:84   (set_mode, 0x06)
src/rigplane/commands/mode.py:149  (set_data_mode, 0x06)
src/rigplane/commands/mode.py:151  (set_data_mode, 0x06)
```

| Remaining hit | Command family | Route-table cross-check verdict |
|---|---|---|
| `freq.py` (`set_freq`) | 0x05 | Hard exclusion (CLAUDE.md) — cmd29 does not work for freq on IC-7610. Correctly untouched. |
| `mode.py` (`set_mode`) | 0x06 | Hard exclusion (CLAUDE.md) — cmd29 does not work for mode on IC-7610. Correctly untouched. |
| `mode.py` (`set_data_mode`) | 0x06 | Same 0x06 family as `set_mode`, same hard exclusion. Correctly untouched. |

Every remaining hit is inside the explicitly excluded 0x05/0x06 family. The MOR-1517/MOR-1537/MOR-1537-followup/MOR-1543 series has now converted every profile-gateable command in `commands/` to the `command29: bool` override pattern; only the two hard-excluded command families keep the receiver-derived shape, by design.

## Guardrail disclosure

Touches 7 files (2 source, 5 test) — over the nominal 4-file guardrail. This mirrors #2434 (7 files) and #2451 (7 files) for the same class of fix: four existing test files encoded the now-fixed "MAIN never wraps on IC-7610" assumption for these specific commands and had to be updated alongside the source change, not because of scope creep.

## Verification

- `uv run pytest tests/test_mor1543_cmd29_gating.py tests/test_rf_gain_af_level.py tests/test_commands.py tests/test_radio.py tests/test_radio_coverage.py -q` — 803 passed
- `uv run pytest tests/test_mor1517_cmd29_gating.py tests/test_mor1537_cmd29_gating.py tests/test_mor1537_followup_cmd29_gating.py tests/test_mor1543_cmd29_gating.py tests/test_radio.py tests/test_radio_coverage.py tests/test_radio_extended.py tests/test_dsp_levels_part2.py tests/test_dsp_filter_family.py tests/test_commands.py tests/test_operator_toggles.py tests/test_rig_ic7300.py tests/test_rig_ic7610.py tests/test_command_map_integration.py tests/test_rigctld_handler.py tests/test_web_capability_guards.py tests/test_supports_command.py tests/test_cmd29_parsing.py tests/test_mock_integration.py tests/test_acquisition_scheduler.py tests/test_ic9700_backend.py tests/test_icom_receiver_tier.py tests/test_radios.py tests/test_rig_multi_vendor.py tests/test_radio_poller_coverage.py tests/test_single_rx_plain_routing.py -q` — 2263 passed
- `uv run pytest tests/ -q --ignore=tests/integration` — 9468 passed, 0 failed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv run lint-imports` — 5 kept, 0 broken
- `uv run mypy src/` — 13 pre-existing errors, identical set to unmodified `origin/main` (none in touched files)
- Boundary grep (`192\.168|\bmoroz\b|\bmini\b|preview-mor`) over the diff — clean

Closes MOR-1543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)