### PR TITLE
chore: fold agc into generic domain parser, loosen notch-width builder (MOR-1542)

### DIFF
--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -788,12 +788,21 @@ def set_manual_notch_width(
     *,
     command29: bool = True,
 ) -> bytes:
-    """Build a 'set manual notch width' CI-V command (0x16 0x57). 0=WIDE, 1=MID, 2=NAR."""
+    """Build a 'set manual notch width' CI-V command (0x16 0x57).
+
+    Encodes the raw single-BCD-byte notch-width value. Which values are
+    legal is a per-profile ``[notch] width_values`` domain, not a fixed
+    0/1/2 (WIDE/MID/NAR) enum on every radio — this builder only enforces
+    the wire-format's single-BCD-byte range and leaves domain validation
+    to the profile-aware caller (MOR-1542, mirrors set_break_in/
+    set_filter_shape/set_ssb_tx_bandwidth's MOR-1534 fix; CoreRadio keeps
+    the domain-legality seat).
+    """
     return _build_function_value_set(
         _SUB_MANUAL_NOTCH_WIDTH,
         width,
         minimum=0,
-        maximum=2,
+        maximum=99,
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1267,30 +1267,9 @@ def load_rig(path: Path) -> RigConfig:
     pre_values = tuple(pre_section["values"]) if "values" in pre_section else None
     pre_labels = dict(pre_section["labels"]) if "labels" in pre_section else None
 
-    agc_section = data.get("agc", {})
-    if agc_section:
-        _reject_unknown_keys(
-            filename, "[agc]", agc_section, frozenset({"modes", "labels"})
-        )
-    agc_modes = tuple(agc_section["modes"]) if "modes" in agc_section else None
-    if agc_modes is not None and (
-        not agc_modes
-        or any(isinstance(m, bool) or not isinstance(m, int) for m in agc_modes)
-    ):
-        raise RigLoadError(
-            f"{filename}: [agc].modes must be a non-empty list of integers"
-        )
-    agc_labels = dict(agc_section["labels"]) if "labels" in agc_section else None
-    if agc_labels is not None and agc_modes is None:
-        raise RigLoadError(f"{filename}: [agc].labels declared without [agc].modes")
-    if agc_labels is not None and agc_modes is not None:
-        declared = {str(m) for m in agc_modes}
-        orphan_labels = sorted(set(agc_labels) - declared)
-        if orphan_labels:
-            raise RigLoadError(
-                f"{filename}: [agc].labels key {orphan_labels[0]!r} has no "
-                f"matching entry in [agc].modes {sorted(agc_modes)}"
-            )
+    agc_modes, agc_labels = _parse_enumerated_domain(
+        filename, "[agc]", data.get("agc", {}), values_key="modes"
+    )
 
     # Parse break_in/notch-width/ssb_tx_bw/filter_shape enumerated domains
     # (MOR-1534). Each was declared in TOML (or, for filter_shape, nowhere

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -936,6 +936,19 @@ class TestDspLevelParityCommands:
         with pytest.raises(ValueError, match="0-255"):
             set_nb_width(256)
 
+    def test_set_manual_notch_width_wire_bounds_match_siblings(self) -> None:
+        """MOR-1542: set_manual_notch_width hardcoded minimum=0/maximum=2 —
+        the currently-known WIDE/MID/NAR domain — instead of the wire-format
+        single-BCD-byte range (0-99) its three siblings (set_break_in,
+        set_filter_shape, set_ssb_tx_bandwidth) leave to the profile-aware
+        caller (MOR-1534). Domain legality stays enforced at the CoreRadio
+        seat (see TestManualNotchWidthDomainValidation in test_radio.py)."""
+        from rigplane.commands import set_manual_notch_width
+
+        assert set_manual_notch_width(3).endswith(b"\x03\xfd")
+        with pytest.raises(ValueError, match="0-99"):
+            set_manual_notch_width(100)
+
 
 class TestOperatorToggleParityCommands:
     """Test IC-7610 operator toggle/status parity command builders."""

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1830,6 +1830,43 @@ async def test_execute_set_filter_shape_updates_sub_receiver_state_and_radio_cal
 
 
 @pytest.mark.asyncio
+async def test_execute_set_filter_shape_out_of_domain_surfaces_as_command_failure() -> (
+    None
+):
+    """MOR-1542: domain legality is CoreRadio.set_filter_shape's single
+    validation seat (MOR-1534) — the poller must not swallow the ValueError
+    it raises for an out-of-domain shape. ``_execute`` propagates it
+    unchanged, which is what lets the queue-drain loop's generic
+    ``except Exception as exc: self._mark_queued_command_failed(entry, exc)``
+    (radio_poller.py) turn it into a command failure instead of a silently
+    accepted write or a crashed poller."""
+    events: list[tuple[str, dict]] = []
+    radio = _make_radio(active="MAIN")
+    radio.set_filter_shape.side_effect = ValueError(
+        "Filter shape must be one of [0, 1, 2], got 9"
+    )
+    state = RadioState()
+    state.main.filter_shape = 0
+    state.sub.filter_shape = 0
+    poller = RadioPoller(
+        radio,
+        StateCache(),
+        CommandQueue(),
+        on_state_event=lambda name, data: events.append((name, data)),
+        radio_state=state,
+    )
+
+    with pytest.raises(ValueError, match="Filter shape must be one of"):
+        await poller._execute(SetFilterShape(9, receiver=1))  # noqa: SLF001
+
+    radio.set_filter_shape.assert_awaited_once_with(9, receiver=1)
+    # Rejected before any state/UI side effect is applied.
+    assert state.main.filter_shape == 0
+    assert state.sub.filter_shape == 0
+    assert events == []
+
+
+@pytest.mark.asyncio
 async def test_execute_set_agc_sends_wire_value_without_legacy_mirror() -> None:
     # agc is observation-backed (0x16 0x12); the legacy RadioState mirror was
     # removed (MOR-437). The poller routes the wire command and emits the event


### PR DESCRIPTION
## Summary

Three loader/builder housekeeping items surfaced by the PR #2454 verifier for MOR-1522/MOR-1534's enumerated-domain generalization:

1. **Fold `[agc]` parsing into `_parse_enumerated_domain`.** `rig_loader.py` kept a byte-identical hand-rolled copy of the `[agc] modes/labels` fail-loud contract right next to the generic helper it inspired (introduced for MOR-1534). Pure deletion — routed through `_parse_enumerated_domain(filename, "[agc]", data.get("agc", {}), values_key="modes")`, which produces the exact same error strings. The existing malformed-`[agc]` tests in `test_rig_loader.py` pass unmodified — they're the witness that the strings didn't drift.

2. **Loosen `set_manual_notch_width`'s wire bound.** The builder hardcoded `minimum=0, maximum=2` (the currently-known WIDE/MID/NAR domain) instead of the wire-format's single-BCD-byte range (0-99) that its three siblings — `set_break_in`, `set_filter_shape`, `set_ssb_tx_bandwidth` — already use, per the MOR-1534 precedent (domain legality belongs at the profile-aware `CoreRadio` seat added in #2454, not baked into the builder). Red-first: added `test_set_manual_notch_width_wire_bounds_match_siblings` in `test_commands.py`, confirmed it failed on `set_manual_notch_width(3)` with `ValueError: Value must be 0-2, got 3` before the fix, passes after.

3. **Poller-level pin for `SetFilterShape` out-of-domain.** Added `test_execute_set_filter_shape_out_of_domain_surfaces_as_command_failure` in `test_radio_poller_coverage.py`, confirming a `ValueError` raised by `CoreRadio.set_filter_shape` (domain violation) propagates unchanged through `RadioPoller._execute` — which is what lets the queue-drain loop's generic exception handler turn it into a command failure instead of a silently accepted write or a swallowed exception. This didn't need new harness work — it reuses the existing `_make_radio`/`RadioPoller` fixture pattern already used by the adjacent `test_execute_set_filter_shape_updates_sub_receiver_state_and_radio_call`.

## Test plan

- [x] `uv run pytest tests/test_rig_loader.py tests/test_commands.py tests/test_radio_poller_coverage.py tests/test_radio.py -q` — 1038 passed, 1 skipped (pre-existing)
- [x] Red-first confirmed for item 2 (`ValueError: Value must be 0-2, got 3` before the fix)
- [x] `uv run ruff check` / `ruff format --check` on changed files — clean
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `uv run mypy src/` — 13 pre-existing errors, none in changed files (0 new)
- [x] `git diff` — 4 files, 64 net LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)