### PR TITLE
fix: distinct digisel_shift capability key (MOR-1544)

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -55,6 +55,13 @@ features = [
     # hamlib-doc-sourced (repo's ic705-research.md is no longer vendored
     # here) — IC-705 is NOT on the live bench, so this is doc-level
     # confidence, not live-validated.
+    # "digisel_shift" IS real on IC-705 (0x14 0x13 cmd29 level — see
+    # get_digisel_shift/set_digisel_shift in [commands] below) and is a
+    # distinct CI-V command from the 0x16 0x4E toggle above. Web/API
+    # callers were rejected at the control-handler layer because it gated
+    # set_digisel_shift on the shared "digisel" tag, which IC-705
+    # deliberately omits (MOR-1544).
+    "digisel_shift",
     # Antenna
     "antenna",
     "rx_antenna",    # wfview: RX Antenna 0x16 0x53 (IC-7300.rig omits this command)

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -62,6 +62,12 @@ features = [
     "attenuator",
     "preamp",
     "digisel",
+    # DIGI-SEL Shift (0x14 0x13 cmd29 level) is a distinct CI-V command from
+    # the 0x16 0x4E toggle above — IC-7610 has both (see get_digisel_shift/
+    # set_digisel_shift in [commands] below). Declared separately so the
+    # control handler can gate set_digisel_shift on its own tag instead of
+    # the shared "digisel" one (MOR-1544).
+    "digisel_shift",
     "ip_plus",
     # Antenna
     "antenna",

--- a/src/rigplane/core/capabilities.py
+++ b/src/rigplane/core/capabilities.py
@@ -17,6 +17,7 @@ __all__ = [
     "CAP_ATTENUATOR",
     "CAP_PREAMP",
     "CAP_DIGISEL",
+    "CAP_DIGISEL_SHIFT",
     "CAP_IP_PLUS",
     "CAP_ANTENNA",
     "CAP_RX_ANTENNA",
@@ -93,6 +94,12 @@ CAP_LAN_DUAL_RX_AUDIO_ROUTING = "lan_dual_rx_audio_routing"
 CAP_ATTENUATOR = "attenuator"
 CAP_PREAMP = "preamp"
 CAP_DIGISEL = "digisel"
+# DIGI-SEL Shift level (0x14 0x13 cmd29 level, ``get_digisel_shift``/
+# ``set_digisel_shift``) is a distinct CI-V command from the DIGI-SEL on/off
+# toggle (0x16 0x4E, ``CAP_DIGISEL``) — some profiles (IC-705) expose the
+# shift level without the toggle. Gating ``set_digisel_shift`` on
+# ``CAP_DIGISEL`` rejected valid IC-705 calls at the web layer (MOR-1544).
+CAP_DIGISEL_SHIFT = "digisel_shift"
 CAP_IP_PLUS = "ip_plus"
 
 # Antenna
@@ -196,6 +203,7 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset(
         CAP_ATTENUATOR,
         CAP_PREAMP,
         CAP_DIGISEL,
+        CAP_DIGISEL_SHIFT,
         CAP_IP_PLUS,
         # Antenna
         CAP_ANTENNA,

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -2084,7 +2084,10 @@ class ControlHandler:
             case "set_digisel_shift":
                 level = int(params["level"])
                 rx = int(params.get("receiver", 0))
-                self._ensure_capability("digisel", "set_digisel_shift")
+                # Distinct from "digisel" (0x16/0x4E toggle): DIGI-SEL Shift
+                # is 0x14/0x13 and some profiles (IC-705) expose it without
+                # the toggle (MOR-1544).
+                self._ensure_capability("digisel_shift", "set_digisel_shift")
                 self._ensure_receiver_supported(rx)
                 q.put(SetDigiselShift(level, receiver=rx))
                 return {"level": level, "receiver": rx}

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -49,6 +49,7 @@ from ..capabilities import (
     CAP_CW,
     CAP_DATA_MODE,
     CAP_DIGISEL,
+    CAP_DIGISEL_SHIFT,
     CAP_DUAL_RX,
     CAP_DUAL_WATCH,
     CAP_FILTER_SHAPE,
@@ -3125,7 +3126,10 @@ class RadioPoller:
                     await radio.set_audio_peak_filter(int(on), receiver=rx)
             case SetDigiselShift(level=level, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_digisel_shift")
-                if CAP_DIGISEL in self._caps:
+                # Distinct capability from CAP_DIGISEL (0x16/0x4E toggle):
+                # DIGI-SEL Shift is 0x14/0x13 and IC-705 exposes it without
+                # the toggle (MOR-1544).
+                if CAP_DIGISEL_SHIFT in self._caps:
                     await radio.set_digisel_shift(level, receiver=rx)
             case SetRefAdjust(value=value):
                 await _r.set_ref_adjust(value)

--- a/tests/_caps.py
+++ b/tests/_caps.py
@@ -1,4 +1,12 @@
-# Full IC-7610 capability tag set — shared across tests to avoid duplication.
+# A broad Icom capability tag superset shared across web-handler tests to
+# enable capability gates without duplicating a full list per test. NOT a
+# literal, exact copy of any one profile's declared capabilities — e.g. it
+# carries "repeater_tone"/"tsql" which the real IC-7610 profile omits
+# (MOR-661). The authoritative exact-match check for IC-7610's declared
+# capability set is ``tests/test_rig_ic7610.py::TestProfileParity::
+# test_capabilities_exact`` against the real TOML-loaded profile — update
+# that test, not (only) this fixture, when ic7610.toml's [capabilities]
+# list changes.
 FULL_ICOM_CAPS: frozenset[str] = frozenset(
     {
         "audio",
@@ -21,6 +29,7 @@ FULL_ICOM_CAPS: frozenset[str] = frozenset(
         "nr",
         "ip_plus",
         "digisel",
+        "digisel_shift",
         "vox",
         "compressor",
         "break_in",

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -98,6 +98,11 @@
       "declaration": "unsupported_pending_evidence"
     },
     {
+      "check_id": "digisel_shift.presence",
+      "status": "pass",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "discovery.identify",
       "status": "skip",
       "declaration": "supported"

--- a/tests/test_mor1544_digisel_shift_cap.py
+++ b/tests/test_mor1544_digisel_shift_cap.py
@@ -1,0 +1,146 @@
+"""MOR-1544: ``set_digisel_shift`` must gate on its own capability tag.
+
+``web/handlers/control.py`` and ``web/radio_poller.py`` both gated
+``set_digisel_shift`` on the shared ``"digisel"`` capability (the 0x16/0x4E
+DIGI-SEL on/off toggle). After MOR-1540 removed the over-declared "digisel"
+tag from ``rigs/ic705.toml`` (IC-705 has DIGI-SEL *Shift*, 0x14/0x13, but not
+the 0x16/0x4E toggle), a web/API client calling ``set_digisel_shift`` on
+IC-705 was rejected at the web layer even though
+``CoreRadio.set_digisel_shift`` itself has no such capability check — it
+only requires the cmd29 route for 0x14/0x13, which IC-705 has.
+
+Fix: a distinct ``"digisel_shift"`` capability tag, declared in the TOML
+profiles whose ``[commands]`` table actually carries
+``get_digisel_shift``/``set_digisel_shift`` (IC-705, IC-7610), gating
+``set_digisel_shift`` at both the control-handler (web-socket command
+dispatch) and radio-poller (command execution) layers.
+
+TDD red-first: written against the unfixed code (before this ticket's
+edits to ``capabilities.py``, ``control.py``, ``radio_poller.py``,
+``rigs/ic705.toml``), the IC-705-acceptance tests below fail:
+``TestControlHandlerGate.test_ic705_set_digisel_shift_passes_web_gate`` and
+``TestPollerExecutionGate.test_ic705_poller_executes_digisel_shift`` raise
+``ValueError`` / silently skip because "digisel_shift" is not yet a known
+capability and IC-705 does not declare "digisel". After the fix, they pass.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.profiles import resolve_radio_profile
+from rigplane.rigctld.state_cache import StateCache
+from rigplane.web.handlers import ControlHandler
+from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetDigiselShift
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _QueueRecorder:
+    def __init__(self) -> None:
+        self.items: list[object] = []
+
+    def put(self, item: object) -> None:
+        self.items.append(item)
+
+
+def _profile_radio(model: str) -> SimpleNamespace:
+    """A radio double whose capabilities come straight from the real TOML
+    profile — not a hand-picked test fixture — so this exercises exactly
+    what ships to /api/v1/capabilities.
+    """
+    profile = resolve_radio_profile(model=model)
+    return SimpleNamespace(
+        capabilities=set(profile.capabilities),
+        profile=profile,
+        set_digisel=AsyncMock(),
+        set_digisel_shift=AsyncMock(),
+    )
+
+
+def _handler(radio: object, server: object) -> ControlHandler:
+    ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    return ControlHandler(ws, radio, "9.9.9", "test", server=server)
+
+
+def _server() -> tuple[SimpleNamespace, _QueueRecorder]:
+    q = _QueueRecorder()
+    return SimpleNamespace(command_queue=q), q
+
+
+# ---------------------------------------------------------------------------
+# Web layer (ControlHandler._enqueue_command)
+# ---------------------------------------------------------------------------
+
+
+class TestControlHandlerGate:
+    @pytest.mark.asyncio
+    async def test_ic705_set_digisel_shift_passes_web_gate(self) -> None:
+        """IC-705 has get/set_digisel_shift [0x14, 0x13] in [commands] but no
+        digisel [0x16, 0x4E] toggle — the web gate must key off
+        "digisel_shift", not "digisel" (MOR-1544)."""
+        srv, q = _server()
+        h = _handler(_profile_radio("IC-705"), srv)
+        result = await h._enqueue_command("set_digisel_shift", {"level": 128})
+        assert result == {"level": 128, "receiver": 0}
+        assert len(q.items) == 1
+        assert isinstance(q.items[0], SetDigiselShift)
+        assert q.items[0].level == 128
+
+    @pytest.mark.asyncio
+    async def test_ic7300_set_digisel_shift_rejected(self) -> None:
+        """IC-7300 has neither digisel nor digisel_shift commands — must
+        still be rejected under the new capability key."""
+        srv, _ = _server()
+        h = _handler(_profile_radio("IC-7300"), srv)
+        with pytest.raises(ValueError, match="digisel_shift"):
+            await h._enqueue_command("set_digisel_shift", {"level": 100})
+
+    @pytest.mark.asyncio
+    async def test_ic705_set_digisel_toggle_still_rejected(self) -> None:
+        """digisel (0x16/0x4E) gating is unchanged: IC-705 still has no
+        "digisel" capability, so set_digisel must still be rejected."""
+        srv, _ = _server()
+        h = _handler(_profile_radio("IC-705"), srv)
+        with pytest.raises(ValueError, match="digisel"):
+            await h._enqueue_command("set_digisel", {"on": True})
+
+    @pytest.mark.asyncio
+    async def test_ic7610_set_digisel_and_shift_both_accepted(self) -> None:
+        """Regression guard: IC-7610 declares both digisel and
+        digisel_shift (it has both CI-V commands) — neither gate must
+        regress for a radio that legitimately has both."""
+        srv, q = _server()
+        h = _handler(_profile_radio("IC-7610"), srv)
+        await h._enqueue_command("set_digisel", {"on": True})
+        await h._enqueue_command("set_digisel_shift", {"level": 50})
+        assert len(q.items) == 2
+
+
+# ---------------------------------------------------------------------------
+# Execution layer (RadioPoller._execute)
+# ---------------------------------------------------------------------------
+
+
+class TestPollerExecutionGate:
+    @pytest.mark.asyncio
+    async def test_ic705_poller_executes_digisel_shift(self) -> None:
+        radio = _profile_radio("IC-705")
+        poller = RadioPoller(radio, StateCache(), CommandQueue())
+        await poller._execute(SetDigiselShift(level=200, receiver=0))  # noqa: SLF001
+        radio.set_digisel_shift.assert_awaited_once_with(200, receiver=0)
+
+    @pytest.mark.asyncio
+    async def test_ic7300_poller_skips_digisel_shift(self) -> None:
+        """IC-7300 lacks digisel_shift — the poller must not forward the
+        command to the radio backend at all."""
+        radio = _profile_radio("IC-7300")
+        poller = RadioPoller(radio, StateCache(), CommandQueue())
+        await poller._execute(SetDigiselShift(level=200, receiver=0))  # noqa: SLF001
+        radio.set_digisel_shift.assert_not_awaited()

--- a/tests/test_rig_ic7610.py
+++ b/tests/test_rig_ic7610.py
@@ -67,6 +67,7 @@ class TestProfileParity:
                 "attenuator",
                 "preamp",
                 "digisel",
+                "digisel_shift",
                 "ip_plus",
                 # Antenna
                 "antenna",
@@ -126,7 +127,8 @@ class TestProfileParity:
     def test_capabilities_count(self, profile):
         # MOR-661: dropped repeater_tone + tsql (48 → 46).
         # MOR-678: added mod_input_routing (46 → 47).
-        assert len(profile.capabilities) == 47
+        # MOR-1544: added digisel_shift (47 → 48).
+        assert len(profile.capabilities) == 48
 
     def test_cmd29_routes_exact(self, profile):
         expected = frozenset(


### PR DESCRIPTION
Closes MOR-1544

## Problem

`web/handlers/control.py` gated `set_digisel_shift` on the shared `"digisel"` capability string — the tag for the 0x16/0x4E DIGI-SEL on/off toggle. After #2457 (MOR-1540) correctly removed the over-declared `"digisel"` tag from `rigs/ic705.toml` (IC-705 has no 0x16/0x4E command), a web/API client calling `set_digisel_shift` on IC-705 was rejected at the web layer with `ValueError: missing capability: digisel` — even though `CoreRadio.set_digisel_shift` (0x14/0x13) has no such capability check and works fine on IC-705.

A second instance of the same bug was in `web/radio_poller.py`'s execution-layer dispatch: it also gated `SetDigiselShift` on `CAP_DIGISEL`, so even a client that got past a hypothetically-fixed web gate would have the command silently dropped before it ever reached `radio.set_digisel_shift`.

## Fix

Introduced a distinct `"digisel_shift"` capability (`CAP_DIGISEL_SHIFT` in `core/capabilities.py`), declared only on profiles whose `[commands]` table actually carries `get_digisel_shift`/`set_digisel_shift`. Both `control.py` (web-socket command gate) and `radio_poller.py` (execution gate) now key off `"digisel_shift"` instead of `"digisel"`. `set_digisel`/DIGI-SEL toggle gating (0x16/0x4E) is untouched.

`/api/v1/capabilities` serialization needed no separate change — it reads `radio.capabilities`, which is populated straight from the TOML `[capabilities].features` list, so the new tag surfaces automatically.

Checked the frontend for a `digiselShift`-availability consumer per the ticket's ask: the `digiselShift` state field exists (`frontend/src/lib/types/state.ts`) but nothing gates a control on a `digisel_shift`/`digiselShift` capability — no UI to update, none added.

## Provenance (per-profile, from `[commands]` tables)

| Profile | `get/set_digisel` (0x16/0x4E toggle) | `get/set_digisel_shift` (0x14/0x13) | `"digisel_shift"` cap added? |
|---|---|---|---|
| `ic705.toml` | absent (MOR-1540) | `[0x14, 0x13]` present | **yes** |
| `ic7610.toml` | `[0x16, 0x4E]` present | `[0x14, 0x13]` present | **yes** |
| `ic7300.toml` | absent | absent | no |
| `ic9700.toml` | absent | absent | no |
| `x6100.toml`, `x6200.toml`, `ftx1.toml`, `tx500.toml` | n/a (no CI-V digisel commands) | n/a | no |

## Known asymmetry (flagged by independent review, recorded here — no code change made for it)

`digisel_shift` currently gates only the **SET path** (the control-handler command dispatch and the poller's command-execution `case SetDigiselShift`). The **GET/poll path** (state readback for `operator_controls.digisel_shift`) does not consult this capability at all — it rides the state-acquisition field-policy / cmd29-route machinery (`state_pipeline_contracts.py`, `acquisition_scheduler.py`) independently of the `[capabilities]` tag list. Today that's harmless: the read path already has its own correct gating via cmd29 routes per profile, and nothing in the frontend or backend currently branches on a `digisel_shift`/`digiselShift` *capability* fact for availability display (checked — see above). But if a future frontend/adapter change ever wires an availability gate to the `digisel_shift` capability expecting it to describe both read and write support symmetrically the way most other tags do, the read path won't match that assumption — it was never conditioned on this tag before this PR and still isn't. Worth a second look at issue time if that wiring is ever added; out of scope here since no such consumer exists yet.

## Red-first evidence

Wrote `tests/test_mor1544_digisel_shift_cap.py` against a throwaway worktree at pre-fix `origin/main` (57fd61ea) — 2 of 6 tests failed exactly as expected, the other 4 already passed (they describe behavior the bug didn't touch):

- `TestControlHandlerGate::test_ic705_set_digisel_shift_passes_web_gate` — FAILED (`ValueError: missing capability: digisel`)
- `TestPollerExecutionGate::test_ic705_poller_executes_digisel_shift` — FAILED (radio.set_digisel_shift never awaited)
- `test_ic7300_set_digisel_shift_rejected`, `test_ic705_set_digisel_toggle_still_rejected`, `test_ic7610_set_digisel_and_shift_both_accepted`, `test_ic7300_poller_skips_digisel_shift` — already passing pre-fix (unaffected behavior)

After the fix, all 6 pass.

## Independent review round 2

First-round review (BLOCKED) confirmed the fix itself was correct end-to-end (both gates, provenance, payload flow) but caught that adding `"digisel_shift"` to `ic7610.toml`'s declared capabilities made three pre-existing fixtures stale, which a family-scoped test sweep had missed:

- `tests/test_rig_ic7610.py`: `test_capabilities_exact` (missing the new tag), `test_capabilities_count` (47 → 48)
- `tests/golden/validation/ic7610.dry-run.json`: missing the new `digisel_shift.presence` check entry
- `tests/_caps.py`: `FULL_ICOM_CAPS` fixture + its docstring, identified as part of why the sweep missed the above (it's used as a stand-in "full" capability set in several web-handler tests, so it not being kept in sync silently produced no failures until the profile-parity tests were actually run)

All three fixed; verified with the exact targeted set plus a full non-integration suite run this time (`pytest tests/ --ignore=tests/integration`): **9566 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed, 0 failed.**

## Verification

- `uv run pytest tests/test_rig_ic7610.py tests/test_validation_gating.py tests/test_mor1544_digisel_shift_cap.py -q` — 91 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9566 passed, 0 failed
- `uv run ruff check` / `ruff format --check` on all changed files — clean
- `uv run lint-imports` — 5 contracts kept, 0 broken
- `uv run mypy src/` — same 13 pre-existing baseline errors as `origin/main` (none in changed files/lines)
- Boundary grep (`192\.168|\bmoroz\b|\bmini\b|preview-mor`) over the full branch diff and the follow-up commit — empty

## Guardrail note (revised)

This touches **9 files**, not the `≤5 files` originally targeted: 5 production (`capabilities.py`, `control.py`, `radio_poller.py`, `ic705.toml`, `ic7610.toml`) + 4 test/fixture files. Of the 4 test files, 1 (`test_mor1544_digisel_shift_cap.py`) is new red-first coverage and the other 3 (`test_rig_ic7610.py`, the ic7610 golden, `tests/_caps.py`) are mandatory upkeep — they were stale fixtures that a scoped-family test sweep missed and an independent review caught; leaving them unfixed would have shipped a red suite. Both `control.py` and `radio_poller.py` needed the same rename — fixing only the web gate and leaving the poller's execution gate on `CAP_DIGISEL` would have left `set_digisel_shift` accepted by the API but silently dropped before reaching the radio, which is the same bug moved one layer down rather than fixed.

Head SHA: `5a533e352019c864b253c5e0e520e28d90c42de9`