### PR TITLE
fix: remaining AGC hardcodes and amber chip width (MOR-1547)

### DIFF
--- a/frontend/src/components-v2/panels/__tests__/AgcPanel.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/AgcPanel.test.ts
@@ -101,6 +101,15 @@ describe('buildAgcOptions', () => {
   });
 
   it('FTX-1: full 7-value domain including manual OFF/FAST/MID/SLOW and auto variants', () => {
+    // MOR-1547: mirrors rigs/ftx1.toml's real [agc.labels] — the auto-mode
+    // labels (4/5/6) are the short "A-F"/"A-M"/"A-S" form, not
+    // "A-FAST"/"A-MID"/"A-SLOW" (shortened to keep the amber-lcd skin's
+    // "AGC "-prefixed status chip within its established single-row width
+    // budget, see AmberIndStrip.svelte:68-128 and
+    // tests/test_rig_loader.py::test_ftx1_agc_auto_labels_are_short_form for
+    // the real-profile witness). Asserting every option here (not just
+    // length + options[0]) so this stays a real regression pin instead of a
+    // stale document that silently drifts from the profile data.
     const options = buildAgcOptions(
       [0, 1, 2, 3, 4, 5, 6],
       {
@@ -108,12 +117,19 @@ describe('buildAgcOptions', () => {
         '1': 'FAST',
         '2': 'MID',
         '3': 'SLOW',
-        '4': 'A-FAST',
-        '5': 'A-MID',
-        '6': 'A-SLOW',
+        '4': 'A-F',
+        '5': 'A-M',
+        '6': 'A-S',
       },
     );
-    expect(options).toHaveLength(7);
-    expect(options[0]).toEqual({ value: 0, label: 'OFF' });
+    expect(options).toEqual([
+      { value: 0, label: 'OFF' },
+      { value: 1, label: 'FAST' },
+      { value: 2, label: 'MID' },
+      { value: 3, label: 'SLOW' },
+      { value: 4, label: 'A-F' },
+      { value: 5, label: 'A-M' },
+      { value: 6, label: 'A-S' },
+    ]);
   });
 });

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberLabels.profile-data.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberLabels.profile-data.isolated.test.ts
@@ -133,6 +133,28 @@ function stateWithAgc(agc: number, preamp = 0): ServerState {
 
 const X6200_AGC_LABELS = { '0': 'OFF', '1': 'FAST', '2': 'SLOW', '3': 'AUTO' };
 
+// MOR-1547 — mirrors `rigs/ftx1.toml`'s `[agc.labels]`. Modes 4/5/6 (the
+// auto-selected speeds) were shortened from "A-FAST"/"A-MID"/"A-SLOW" to
+// "A-F"/"A-M"/"A-S": the 6-character body pushed the "AGC "-prefixed
+// `AmberIndStrip` chip to 10 characters — wider than any other chip sharing
+// the strip (the next-widest, "DIGI-SEL", has no "AGC "-style prefix and
+// tops out at 8) — which wrapped the DSP zone to a second row that the
+// strip's `overflow: hidden` then clipped. "A-F"/"A-M"/"A-S" keeps the
+// "Auto-" disambiguator (avoids colliding with the overloaded ham-radio
+// abbreviations AM = Amplitude Modulation / AF = Audio Frequency that a bare
+// "AF"/"AM"/"AS" would invite) while landing the widest FTX-1 label body at
+// 3 characters — inside the existing FAST/SLOW (4-character body) budget
+// every other shipped `[agc.labels]` table already fits within.
+const FTX1_AGC_LABELS = {
+  '0': 'OFF',
+  '1': 'FAST',
+  '2': 'MID',
+  '3': 'SLOW',
+  '4': 'A-F',
+  '5': 'A-M',
+  '6': 'A-S',
+};
+
 beforeEach(() => {
   components = [];
   vi.clearAllMocks();
@@ -165,6 +187,34 @@ describe('AmberScope AGC label sourcing (MOR-1529)', () => {
     const target = mountScope(stateWithAgc(9), caps);
     const chip = agcChip(target);
     expect(chip?.textContent?.trim()).toBe('AGC 9');
+  });
+});
+
+describe('AmberScope AGC chip width budget (MOR-1547)', () => {
+  // AmberIndStrip's DSP-zone strip is a `flex-wrap: wrap` row with
+  // `overflow: hidden` (AmberIndStrip.svelte:68-128) — a chip wide enough to
+  // push the strip past its available width wraps a second row that
+  // `overflow: hidden` then silently clips. "AGC FAST"/"AGC SLOW" (8
+  // characters) is the established budget every currently-shipped
+  // `[agc.labels]` table (ic7300/ic7610/ic705/ic9700/x6200/ftx1 modes 0-3)
+  // already renders inside without wrapping; this pins that FTX-1's own
+  // auto-mode labels (4/5/6) stay within it too.
+  it.each([0, 1, 2, 3, 4, 5, 6])(
+    'keeps the AGC chip for FTX-1 mode %i within the single-row width budget',
+    (mode) => {
+      const caps = { agcLabels: FTX1_AGC_LABELS } as unknown as Capabilities;
+      const target = mountScope(stateWithAgc(mode), caps);
+      const chip = agcChip(target);
+      const text = chip?.textContent?.trim() ?? '';
+      expect(text.length).toBeLessThanOrEqual('AGC FAST'.length);
+    },
+  );
+
+  it('renders the exact shortened auto-mode labels (A-F/A-M/A-S), not the old A-FAST/A-MID/A-SLOW', () => {
+    const caps = { agcLabels: FTX1_AGC_LABELS } as unknown as Capabilities;
+    expect(agcChip(mountScope(stateWithAgc(4), caps))?.textContent?.trim()).toBe('AGC A-F');
+    expect(agcChip(mountScope(stateWithAgc(5), caps))?.textContent?.trim()).toBe('AGC A-M');
+    expect(agcChip(mountScope(stateWithAgc(6), caps))?.textContent?.trim()).toBe('AGC A-S');
   });
 });
 

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -701,6 +701,30 @@ describe('A11 — batch-A projections do not fabricate defaults (MOR-1409)', () 
       expect(props.agcModes).toEqual([1, 3]);
     });
 
+    it('does not fabricate an IC-7610-shaped FAST/MID/SLOW label dict when the profile declares no agcLabels (MOR-1547)', () => {
+      // Companion to the `agcModes` fabrication fix above: `agcLabels`
+      // carried the same IC-7610-shaped hardcode
+      // `{ '1': 'FAST', '2': 'MID', '3': 'SLOW' }` as its fallback, applied
+      // to every radio's numeric AGC modes regardless of what that radio
+      // actually declares — a radio whose modes 1/2/3 mean something else
+      // (or a capabilities payload with no `agcLabels` at all) would get a
+      // plausible-looking but wrong label. `buildAgcOptions`
+      // (agc-utils.ts) already falls back to the raw mode number
+      // (`String(mode)`) per-entry when a label is missing — the honest
+      // behavior this fallback must defer to instead of inventing labels.
+      const props = toAgcProps(makeState(), { capabilities: ['agc'], agcModes: [1, 3] } as any);
+      expect(props.agcLabels).toEqual({});
+    });
+
+    it('still reports the real declared agcLabels from capabilities', () => {
+      const props = toAgcProps(makeState(), {
+        capabilities: ['agc'],
+        agcModes: [1, 3],
+        agcLabels: { '1': 'FAST', '3': 'SLOW' },
+      } as any);
+      expect(props.agcLabels).toEqual({ '1': 'FAST', '3': 'SLOW' });
+    });
+
     it('reports the real observed agcMode value when the field IS available (symmetric positive pin)', () => {
       // Companion to 'does not present missing AGC as the default MID mode':
       // that test proves the missing-field side (agcAvailable === false =>

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -444,7 +444,12 @@ export function toAgcProps(
   return {
     agcMode: agcAvailable ? (rx?.agc ?? Number.NaN) : Number.NaN,
     agcModes: caps?.agcModes ?? [],
-    agcLabels: caps?.agcLabels ?? { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
+    // MOR-1547: no fabricated IC-7610-shaped FAST/MID/SLOW dict when the
+    // profile declares no agcLabels — `{}` lets `buildAgcOptions`
+    // (agc-utils.ts) fall back to the honest raw mode number per-entry,
+    // the same "no invented label" contract it already applies whenever a
+    // caps-provided `agcLabels` is missing an individual entry.
+    agcLabels: caps?.agcLabels ?? {},
     hasAgc: hasCap(caps, 'agc') && agcAvailable,
   };
 }

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -667,14 +667,24 @@ label = "S9+40"
 [agc]
 modes = [0, 1, 2, 3, 4, 5, 6]
 
+# MOR-1547: modes 4-6 (auto-selected speeds) use the short "A-F"/"A-M"/"A-S"
+# form, not "A-FAST"/"A-MID"/"A-SLOW". The 6-character body pushed the
+# "AGC "-prefixed status chip in AmberIndStrip (amber-lcd skin) to 10
+# characters — wider than every other chip sharing its flex-wrap strip —
+# which wrapped the DSP zone to a second row that the strip's
+# `overflow: hidden` then silently clipped. "A-F"/"A-M"/"A-S" keeps the
+# "Auto-" disambiguator (a bare "AF"/"AM"/"AS" would collide with the
+# overloaded ham-radio abbreviations AF = Audio Frequency / AM = Amplitude
+# Modulation) while landing at a 3-character body, inside the 4-character
+# FAST/SLOW budget every other shipped [agc.labels] table already fits.
 [agc.labels]
 "0" = "OFF"
 "1" = "FAST"
 "2" = "MID"
 "3" = "SLOW"
-"4" = "A-FAST"
-"5" = "A-MID"
-"6" = "A-SLOW"
+"4" = "A-F"
+"5" = "A-M"
+"6" = "A-S"
 
 [commands]
 # ── Frequency / Mode ──

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1904,13 +1904,16 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.STEP_LEVEL_255: 100,
     ValueRule.NUDGE_FILTER: 2800,
     ValueRule.PREAMP_CYCLE: 1,
-    # MOR-1547: radio-unaware fallback only — reachable when a connected
-    # radio's declared ``[agc] modes`` domain cannot be discovered at all
-    # (e.g. a bare test double with no ``_profile``/``_config``). When a
-    # domain IS discoverable, ``_set_and_observe`` overrides this with
-    # ``_agc_probe_value`` (MOR-1529's non-OFF-preferring derivation) before
-    # ever consulting this dict, mirroring the ``STEP_LEVEL_255`` range
-    # override just below.
+    # MOR-1547: dead in practice for AGC_FLIP — ``_set_and_observe``
+    # unconditionally overrides this entry with ``_agc_probe_value``
+    # (MOR-1529's non-OFF-preferring domain derivation) regardless of
+    # whether a domain is discoverable; the dict is still consulted first
+    # (``.get()`` below) but its result is always discarded for this rule,
+    # mirroring the ``STEP_LEVEL_255`` range override further down. Retained
+    # for documentation of the historical fallback value; when
+    # ``_agc_probe_value`` itself cannot discover a domain, its own internal
+    # fallback happens to equal this same constant — a coincidence of the
+    # chosen value, not a shared code path.
     ValueRule.AGC_FLIP: int(AgcMode.FAST),
     ValueRule.TONE_FREQ_CYCLE: 88.5,
     ValueRule.VFO_AB_FLIP: "A",
@@ -1946,11 +1949,13 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ValueRule.STEP_LEVEL_255: lambda v: 200 if v < 128 else 50,
     ValueRule.NUDGE_FILTER: _nudge_filter,
     ValueRule.PREAMP_CYCLE: lambda v: 1 if v == 0 else 0,
-    # MOR-1547: radio-unaware fallback only — unreachable for check_id
-    # "agc.set" today (the named ``_check_agc_set`` handler always wins) and
-    # overridden by ``_check_from_spec`` with ``_agc_probe_value`` whenever a
-    # connected radio's declared ``[agc] modes`` domain IS discoverable, same
-    # override pattern as the ``STEP_LEVEL_255`` range branch below.
+    # MOR-1547: dead in practice for AGC_FLIP — unreachable for check_id
+    # "agc.set" today (the named ``_check_agc_set`` handler always wins), and
+    # ``_check_from_spec`` unconditionally overrides this entry with
+    # ``_agc_probe_value`` for any OTHER check_id sharing this value_rule,
+    # regardless of whether a domain is discoverable (same override pattern
+    # as the ``STEP_LEVEL_255`` range branch below). Retained for
+    # documentation of the historical fallback value only.
     ValueRule.AGC_FLIP: lambda m: (
         int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
     ),
@@ -2023,9 +2028,15 @@ async def _set_and_observe(
     test_value = _WRITE_ONLY_TEST_VALUES.get(spec.value_rule)
     if spec.value_rule == ValueRule.AGC_FLIP:
         # MOR-1547: derive from the connected radio's own declared domain
-        # instead of the hardcoded IC-7610 ``AgcMode.FAST`` fallback above —
-        # reachable whenever a profile's ``[validation] write_only_controls``
-        # includes "agc" (only X6200 declares that section today).
+        # instead of the hardcoded IC-7610 ``AgcMode.FAST`` dict entry above
+        # — purely defensive today: no shipped profile's
+        # ``[validation] write_only_controls`` actually includes "agc" (the
+        # only radio that declares that section at all, X6200, lists
+        # ``["rit", "xit", "notch"]``, per ``rigs/x6200.toml``), so this
+        # branch is currently unreachable in production. Fixed anyway so a
+        # future profile that DOES route "agc" through write-only
+        # classification does not inherit the same hazard MOR-1529 fixed for
+        # the named RMVR handler.
         test_value = _agc_probe_value(radio, avoid=None)
     if test_value is None:
         return _base_result(

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -1790,6 +1790,45 @@ def _declared_agc_modes(radio: Radio) -> tuple[int, ...] | None:
     return None
 
 
+def _agc_probe_value(radio: Radio, *, avoid: int | None) -> int:
+    """Derive a safe, non-OFF AGC probe value from the radio's OWN declared
+    ``[agc] modes`` domain when discoverable, instead of always assuming the
+    IC-7610-shaped ``AgcMode.FAST``/``SLOW`` constants (1/3) are legal for
+    every radio — true for every currently-shipped profile by coincidence,
+    but not by design (e.g. would break for a hypothetical profile whose
+    domain excludes both). Shared by every AGC-mutation probe: the named
+    RMVR handler (``_check_agc_set``), the generic RMVR dispatch fallback,
+    and the write-only set-and-observe fallback (MOR-1529 / MOR-1547).
+
+    ``avoid``, when given, is the current value the probe must differ from
+    (an RMVR flip); ``None`` means there is no current reading to avoid (a
+    write-only probe with no read-first).
+
+    R1: prefers a non-OFF (0) candidate over ``avoid`` regardless. The live
+    FTX-1 declares ``[agc] modes = [0..6]`` — picking the first declared
+    value != current would land on 0 (AGC OFF) for every current value
+    except 0 itself. This probe is documented non-destructive/RX-safe
+    (MOR-659): momentarily disabling AGC on a bench radio is audible and
+    operator-affecting, unlike flipping between two settable AGC speeds (the
+    old hardcoded SLOW/FAST probe never did this). Landing on FAST instead
+    keeps the probe inside "change AGC speed", never "turn AGC off".
+    """
+    modes = _declared_agc_modes(radio)
+    if modes:
+        candidates = (
+            [m for m in modes if m != avoid] if avoid is not None else list(modes)
+        )
+        non_off = [m for m in candidates if m != 0]
+        if candidates:
+            return (non_off or candidates)[0]
+    # No declared domain reachable (e.g. a bare test double) — fall back to
+    # the two values every currently-shipped ``[agc] modes`` table happens
+    # to include.
+    if avoid is None:
+        return int(AgcMode.FAST)
+    return int(AgcMode.SLOW) if avoid != AgcMode.SLOW else int(AgcMode.FAST)
+
+
 async def _check_agc_set(
     radio: Radio,
     entry: CapabilityDeclarationEntry,
@@ -1801,41 +1840,12 @@ async def _check_agc_set(
     if gate is not None:
         return gate
     dsp = cast(DspControlCapable, radio)
-
-    def _make_changed(current: int) -> int:
-        # MOR-1529: derive the probe from the radio's OWN declared domain
-        # when discoverable, instead of always assuming the IC-7610-shaped
-        # AgcMode.FAST/SLOW constants (1/3) are legal for every radio —
-        # true for every currently-shipped profile by coincidence, but not
-        # by design (e.g. would break for a hypothetical profile whose
-        # domain excludes both).
-        #
-        # R1: prefer a non-OFF (0) candidate. The live FTX-1 declares
-        # ``[agc] modes = [0..6]`` — picking the first declared value
-        # != current would land on 0 (AGC OFF) for every current value
-        # except 0 itself. This RMVR probe is documented non-destructive/
-        # RX-safe (MOR-659): momentarily disabling AGC on a bench radio is
-        # audible and operator-affecting, unlike flipping between two
-        # settable AGC speeds (the old hardcoded SLOW/FAST probe never did
-        # this). Landing on 1 (FAST) instead keeps the probe inside
-        # "change AGC speed", never "turn AGC off".
-        modes = _declared_agc_modes(radio)
-        if modes:
-            candidates = [m for m in modes if m != current]
-            non_off = [m for m in candidates if m != 0]
-            if candidates:
-                return (non_off or candidates)[0]
-        # No declared domain reachable (e.g. a bare test double) — fall
-        # back to the two values every currently-shipped ``[agc] modes``
-        # table happens to include.
-        return int(AgcMode.SLOW) if current != AgcMode.SLOW else int(AgcMode.FAST)
-
     return await _read_modify_verify_restore(
         radio,
         entry,
         read=lambda: dsp.get_agc(0),
         write=lambda value: dsp.set_agc(value, 0),
-        make_changed=_make_changed,
+        make_changed=lambda current: _agc_probe_value(radio, avoid=current),
         per_check_timeout=per_check_timeout,
     )
 
@@ -1894,6 +1904,13 @@ _WRITE_ONLY_TEST_VALUES: dict[str, Any] = {
     ValueRule.STEP_LEVEL_255: 100,
     ValueRule.NUDGE_FILTER: 2800,
     ValueRule.PREAMP_CYCLE: 1,
+    # MOR-1547: radio-unaware fallback only — reachable when a connected
+    # radio's declared ``[agc] modes`` domain cannot be discovered at all
+    # (e.g. a bare test double with no ``_profile``/``_config``). When a
+    # domain IS discoverable, ``_set_and_observe`` overrides this with
+    # ``_agc_probe_value`` (MOR-1529's non-OFF-preferring derivation) before
+    # ever consulting this dict, mirroring the ``STEP_LEVEL_255`` range
+    # override just below.
     ValueRule.AGC_FLIP: int(AgcMode.FAST),
     ValueRule.TONE_FREQ_CYCLE: 88.5,
     ValueRule.VFO_AB_FLIP: "A",
@@ -1929,6 +1946,11 @@ _VALUE_RULE_FNS: dict[str, Callable[[Any], Any]] = {
     ValueRule.STEP_LEVEL_255: lambda v: 200 if v < 128 else 50,
     ValueRule.NUDGE_FILTER: _nudge_filter,
     ValueRule.PREAMP_CYCLE: lambda v: 1 if v == 0 else 0,
+    # MOR-1547: radio-unaware fallback only — unreachable for check_id
+    # "agc.set" today (the named ``_check_agc_set`` handler always wins) and
+    # overridden by ``_check_from_spec`` with ``_agc_probe_value`` whenever a
+    # connected radio's declared ``[agc] modes`` domain IS discoverable, same
+    # override pattern as the ``STEP_LEVEL_255`` range branch below.
     ValueRule.AGC_FLIP: lambda m: (
         int(AgcMode.SLOW) if m != AgcMode.SLOW else int(AgcMode.FAST)
     ),
@@ -1999,6 +2021,12 @@ async def _set_and_observe(
         )
 
     test_value = _WRITE_ONLY_TEST_VALUES.get(spec.value_rule)
+    if spec.value_rule == ValueRule.AGC_FLIP:
+        # MOR-1547: derive from the connected radio's own declared domain
+        # instead of the hardcoded IC-7610 ``AgcMode.FAST`` fallback above —
+        # reachable whenever a profile's ``[validation] write_only_controls``
+        # includes "agc" (only X6200 declares that section today).
+        test_value = _agc_probe_value(radio, avoid=None)
     if test_value is None:
         return _base_result(
             entry,
@@ -2125,6 +2153,16 @@ async def _check_from_spec(
             "value_rule": str(spec.value_rule),
             "kind": str(spec.kind),
         }
+        # MOR-1547 — AGC_FLIP must derive from the connected radio's own
+        # declared ``[agc] modes`` domain instead of the hardcoded IC-7610
+        # SLOW/FAST fallback in ``_VALUE_RULE_FNS`` above. Unreachable for
+        # check_id "agc.set" today (the named ``_check_agc_set`` handler
+        # always wins) but latent for any other check_id sharing this
+        # value_rule, same hazard class MOR-1529 fixed for the named handler.
+        if spec.value_rule == ValueRule.AGC_FLIP:
+            make_changed = lambda current: _agc_probe_value(  # noqa: E731
+                radio, avoid=current
+            )
         # MOR-695 — level controls (STEP_LEVEL_255) must nudge inside the
         # control's settable band, not the fixed 0-255 ICOM scale. Resolve the
         # band from the radio profile and SKIP an out-of-band original rather

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1192,6 +1192,29 @@ class TestAgcDomainDeclaredOrCapabilityAbsent:
         assert 0 in rig.agc_modes
         assert rig.agc_labels["0"] == "OFF"
 
+    def test_ftx1_agc_auto_labels_are_short_form(self):
+        """MOR-1547: FTX-1's auto-selected AGC modes (4/5/6) must declare the
+        short "A-F"/"A-M"/"A-S" form, not "A-FAST"/"A-MID"/"A-SLOW".
+
+        The long form's 6-character body, prefixed "AGC " by the amber-lcd
+        skin's AmberCockpit/AmberScope status chip, produced a 10-character
+        chip wider than any sibling chip sharing AmberIndStrip's
+        flex-wrap + overflow:hidden row (AmberIndStrip.svelte:68-128) — the
+        wrapped second row was silently clipped. This is the real-profile
+        witness for that fix (a hand-copied constant in a frontend component
+        test cannot catch a regression to the TOML itself — reverting these
+        three lines must fail THIS test).
+        """
+        rig = load_rig(RIGS_DIR / "ftx1.toml")
+        assert rig.agc_labels["4"] == "A-F"
+        assert rig.agc_labels["5"] == "A-M"
+        assert rig.agc_labels["6"] == "A-S"
+        # The amber-chip width invariant itself: every declared FTX-1 AGC
+        # label body must fit inside the 4-character FAST/SLOW budget every
+        # other shipped [agc.labels] table (ic7300/ic7610/ic705/ic9700/x6200)
+        # already renders inside without wrapping the AmberIndStrip row.
+        assert max(len(v) for v in rig.agc_labels.values()) <= 4
+
     def test_x6100_and_tx500_declare_no_agc_capability(self):
         """Neither has AGC wired at all today (X6100: no confirmed hardware
         capture; TX-500: no backend/CAT implementation at all) — capability-

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -190,14 +190,20 @@ async def test_agc_set_probe_never_lands_on_off_for_a_domain_that_declares_it():
 
 async def test_write_only_agc_probe_derives_from_declared_domain_not_hardcoded_fast():
     """MOR-1547: ``_WRITE_ONLY_TEST_VALUES[AGC_FLIP]`` hardcoded IC-7610
-    ``AgcMode.FAST`` (1) as the write-only probe value, reachable whenever a
-    profile's ``[validation] write_only_controls`` includes "agc" (only
-    X6200 declares that section today, MOR-208). A domain that excludes 1
-    (e.g. X6200's real ``[agc] modes`` OFF/FAST/SLOW/AUTO = 0/1/2/3 happens
-    to include 1, so use a synthetic domain that does not, mirroring the R1
-    regression fixture) would get an illegal write under the old hardcode.
-    The probe must derive from the radio's own declared domain (mirroring
-    ``_check_agc_set``'s MOR-1529 fix) and must never land on OFF (0).
+    ``AgcMode.FAST`` (1) as the write-only probe value. This path is purely
+    defensive today — no shipped profile's ``[validation]
+    write_only_controls`` actually includes "agc" (the only radio that
+    declares that section at all, X6200, lists ``["rit", "xit", "notch"]``,
+    MOR-208) — but would be reachable for any future profile that does route
+    "agc" through write-only classification, exercised here directly via
+    ``_check_from_spec`` + ``CheckKind.WRITE_ONLY_OBSERVE`` rather than
+    through that (currently nonexistent) profile wiring. A domain that
+    excludes 1 (e.g. X6200's real ``[agc] modes`` OFF/FAST/SLOW/AUTO =
+    0/1/2/3 happens to include 1, so use a synthetic domain that does not,
+    mirroring the R1 regression fixture) would get an illegal write under
+    the old hardcode. The probe must derive from the radio's own declared
+    domain (mirroring ``_check_agc_set``'s MOR-1529 fix) and must never land
+    on OFF (0).
     """
     from rigplane.validation.hardware import _check_from_spec
 

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -188,6 +188,86 @@ async def test_agc_set_probe_never_lands_on_off_for_a_domain_that_declares_it():
     assert check.evidence["changed"] == 1
 
 
+async def test_write_only_agc_probe_derives_from_declared_domain_not_hardcoded_fast():
+    """MOR-1547: ``_WRITE_ONLY_TEST_VALUES[AGC_FLIP]`` hardcoded IC-7610
+    ``AgcMode.FAST`` (1) as the write-only probe value, reachable whenever a
+    profile's ``[validation] write_only_controls`` includes "agc" (only
+    X6200 declares that section today, MOR-208). A domain that excludes 1
+    (e.g. X6200's real ``[agc] modes`` OFF/FAST/SLOW/AUTO = 0/1/2/3 happens
+    to include 1, so use a synthetic domain that does not, mirroring the R1
+    regression fixture) would get an illegal write under the old hardcode.
+    The probe must derive from the radio's own declared domain (mirroring
+    ``_check_agc_set``'s MOR-1529 fix) and must never land on OFF (0).
+    """
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio, store = _stateful_agc_mock(start=5, domain=(0, 2, 4, 5, 6))
+    entry = CapabilityDeclarationEntry(
+        check_id="agc.set",
+        capability="agc",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="write-only agc probe",
+    )
+    spec = CheckSpec(
+        check_id="agc.set",
+        capability="agc",
+        kind=CheckKind.WRITE_ONLY_OBSERVE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="write-only agc probe",
+        set_op="set_agc",
+        value_rule=ValueRule.AGC_FLIP,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.PASS
+    assert store["value"] != int(AgcMode.FAST)  # 1 not in domain
+    assert store["value"] in (0, 2, 4, 5, 6)
+    assert store["value"] != 0  # non-OFF preference (MOR-1529 R1 hazard)
+
+
+async def test_generic_rmvr_agc_flip_derives_from_declared_domain_not_hardcoded_slow():
+    """MOR-1547: ``_VALUE_RULE_FNS[AGC_FLIP]`` hardcoded IC-7610
+    ``AgcMode.SLOW``/``FAST`` (3/1) as the generic RMVR mutation, unreachable
+    for check_id "agc.set" today (the named ``_check_agc_set`` handler always
+    wins) but latent for any other check_id sharing this value_rule — same
+    hazard class MOR-1529 fixed for the named handler. A domain that excludes
+    3 must not get an illegal probe when reached through the generic
+    ``_check_from_spec`` RMVR path.
+    """
+    from rigplane.validation.hardware import _check_from_spec
+
+    radio, store = _stateful_agc_mock(start=5, domain=(0, 2, 4, 5, 6))
+    entry = CapabilityDeclarationEntry(
+        check_id="agc_alt.set",
+        capability="agc",
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        declaration=CapabilityDeclaration.SUPPORTED,
+        summary="generic agc flip",
+    )
+    spec = CheckSpec(
+        check_id="agc_alt.set",
+        capability="agc",
+        kind=CheckKind.RMVR_SAFE_WRITE,
+        level=ValidationLevel.CAPABILITY_MATRIX,
+        failure_domain=FailureDomain.READBACK,
+        summary="generic agc flip",
+        get_op="get_agc",
+        set_op="set_agc",
+        value_rule=ValueRule.AGC_FLIP,
+    )
+    result = await _check_from_spec(
+        radio, entry, spec, allow_writes=True, per_check_timeout=5.0
+    )
+    assert result.status is CheckStatus.PASS
+    assert result.evidence["changed"] != int(AgcMode.SLOW)  # 3 not in domain
+    assert result.evidence["changed"] in (0, 2, 4, 6)  # candidates != current(5)
+    assert result.evidence["changed"] != 0  # non-OFF preference
+    assert store["value"] == 5  # restored
+
+
 def _digisel_preamp_mock(*, preamp_start: int = 0, digisel_on: bool = True):
     """A stateful preamp mock that ALSO exposes get/set_digisel.
 


### PR DESCRIPTION
## Summary

Three PR #2460 follow-ups (item 4/O1 deliberately excluded — owner-doctrine question, not a mechanical fix):

1. **`validation/hardware.py` generic-dispatch AGC hardcodes** — `_WRITE_ONLY_TEST_VALUES[AGC_FLIP]` and `_VALUE_RULE_FNS[AGC_FLIP]` both hardcoded IC-7610-shaped `AgcMode.FAST`/`SLOW` (1/3), the same hazard class #2460 fixed for the named `_check_agc_set` RMVR handler. Both are latent today: the named handler always wins for `check_id == "agc.set"`, and the write-only path is purely defensive (X6200 is the only profile declaring `[validation] write_only_controls` at all, and its list is `["rit", "xit", "notch"]` — "agc" is not in it on any shipped profile). Fixed anyway so a future profile that DOES route "agc" through either path does not inherit the hazard: an out-of-domain write, or worse, landing on AGC OFF (audible/operator-affecting, MOR-659). Extracted #2460's non-OFF-preferring closure into a shared `_agc_probe_value()` helper reused by `_check_agc_set` (refactor, no behavior change) plus new radio-aware overrides in `_set_and_observe` and `_check_from_spec`'s RMVR path.

2. **`panel-props.ts`'s `toAgcProps`** fell back to a hardcoded `{ '1': 'FAST', '2': 'MID', '3': 'SLOW' }` label dict when a profile declares no `agcLabels` — fabricating IC-7610-shaped labels for any radio's numeric AGC modes. `buildAgcOptions` (`agc-utils.ts`) already falls back to the honest raw mode number per-entry when a label is missing; `toAgcProps` now defers to that (`{}` fallback) instead of inventing labels itself.
   - The identical hardcode also exists in `components-v2/wiring/SemanticRadioSurfaces.svelte:234`, feeding a different UI path. Left untouched — out of this ticket's named scope and the file-count guardrail — and flagged separately as a follow-up (spawned task, not yet started).

3. **Amber AGC chip width** — `AmberIndStrip`'s DSP-zone strip (`flex-wrap` + `overflow: hidden`) silently clips a wrapped second row. FTX-1's `[agc.labels]` for the auto-selected modes (4/5/6) declared `"A-FAST"`/`"A-MID"`/`"A-SLOW"` — a 6-character body that, prefixed `"AGC "`, produced a 10-character chip wider than any sibling chip in the strip. Shortened to `"A-F"`/`"A-M"`/`"A-S"`: keeps the "Auto-" disambiguator (a bare `"AF"`/`"AM"`/`"AS"` would collide with the overloaded ham-radio abbreviations AF = Audio Frequency / AM = Amplitude Modulation) and lands at a 3-character body — inside the 4-character `FAST`/`SLOW` budget every other shipped `[agc.labels]` table already fits. No component code changed; this is a profile-data fix.

TDD red-first for all three — each has a failing-before/passing-after test pinned to the exact defect.

### Item 3 disclosure (raised by the independent verifier, coordinator ruling: keep the data fix — see R1 below)

- **Surface impact**: `[agc.labels]` feeds every FTX-1 AGC-choice surface, not just the amber-lcd skin — `AgcPanel.svelte` (desktop + mobile layouts, via `toAgcProps`), `DspSurface.svelte`/`SemanticRadioSurfaces.svelte`, and `AmberCockpit.svelte`/`AmberScope.svelte`. All of those now render `A-F`/`A-M`/`A-S` for FTX-1's auto-selected AGC modes, including the desktop and mobile `AgcPanel` surfaces, which had room to display the long form and did not need shortening on their own.
- **Alternative considered and rejected**: truncating/ellipsis-ing the label at the `AmberIndStrip` chip (CSS `max-width` + `text-overflow: ellipsis`), keeping the vendor-shaped `"A-FAST"`/`"A-MID"`/`"A-SLOW"` labels everywhere else. Rejected in favor of the single profile-data fix: one source of truth for what the label *is* beats a per-skin display-only truncation that would silently clip real characters the operator can't recover (this codebase's operator-legibility precedent, e.g. MOR-1409/A11's "no fabricated/no-clipped reading" doctrine) and would still need the desktop/mobile `AgcPanel` surfaces to independently decide whether to also truncate or not. This is reversible: an owner can re-lengthen the profile labels and add a skin-side truncation/ellipsis fix later without touching this commit's mechanism.
- **Known naming divergence, recorded for owner attention**: `src/rigplane/backends/yaesu_cat/radio.py:2329`'s `set_agc`/`get_agc` docstrings document the wire semantics as "AUTO-F"/"AUTO-M"/"AUTO-S" (0-6 = OFF/FAST/MID/SLOW/AUTO-F/AUTO-M/AUTO-S) — that internal documentation now differs textually from the display labels `A-F`/`A-M`/`A-S` in `rigs/ftx1.toml`. Not changed here (it's an accurate description of the CAT protocol, not a UI label, and "AUTO-F" is the same 6-character width as the old "A-FAST" — renaming it would not have helped the chip-width defect). Flagged for the owner in case a single consistent short-form vocabulary is wanted across both.

Guardrail disclosure: this PR has grown to 8 files total (6 in the original commit + 2 more in the R1 remediation below) / 325 insertions + 62 deletions, over the nominal 6-file/250-LOC budget — matches this repo's established precedent (#2460/#2461) of disclosing an overage driven by verifier-mandated red-first coverage rather than dropping it.

## R1 — independent verifier findings addressed (head `05af8b3f`)

The independent verifier ruled BLOCKED on the first push (head `200d1801`) — items 1-2 passed outright; three deltas required on item 3 plus a comment-accuracy nit:

- **F1** (no real witness for item 3): the amber chip-width test pinned a hand-copied local constant (`FTX1_AGC_LABELS` in the isolated component test) — reverting the 3 changed `rigs/ftx1.toml` lines left the whole suite green, so the original "red-first" was circular. Added `tests/test_rig_loader.py::test_ftx1_agc_auto_labels_are_short_form`, extending the existing real-profile-load test class (`TestAgcDomainDeclaredOrCapabilityAbsent`) to load the actual `ftx1.toml` and assert `rig.agc_labels["4"/"5"/"6"] == "A-F"/"A-M"/"A-S"` plus the amber-chip width invariant itself (`max(len(v) for v in rig.agc_labels.values()) <= 4`). Confirmed genuinely red: reverted the 3 `ftx1.toml` lines back to `A-FAST`/`A-MID`/`A-SLOW`, reran — `AssertionError: assert 'A-FAST' == 'A-F'` — then restored and reran green.
- **F2** (stale test mirror): `frontend/src/components-v2/panels/__tests__/AgcPanel.test.ts:111-113` still declared `'A-FAST'/'A-MID'/'A-SLOW'` for its FTX-1 fixture — false versus the TOML since the original commit, staying green only because it asserted `options.length` + `options[0]`, not the auto-mode entries. Updated to `'A-F'/'A-M'/'A-S'` and strengthened the assertion to the full 7-entry option list so it can no longer silently drift from the profile data.
- **F5** (comment accuracy): two `hardware.py` comments overstated the `AGC_FLIP` override as conditional ("when a domain IS discoverable ... before ever consulting this dict") when it is actually unconditional — the dict is always consulted (`.get()`) and its result is then always discarded for `AGC_FLIP`; the two paths only coincide in fallback *value*, not in mechanism. Also corrected the write-only path's reachability claim from "reachable ... only X6200 declares that section" (implying "agc" might be in X6200's list) to the accurate statement: X6200's declared `write_only_controls` is `["rit", "xit", "notch"]` — "agc" is not on any shipped profile's list, so that branch is purely defensive today.

New head SHA: `05af8b3f2397bee348e782c11f005a2ad8826275`.

## Test plan

- [x] `uv run pytest tests/validation/test_hardware.py tests/validation/test_hardware_ftx1.py tests/test_rig_loader.py -q` — 278 passed, 1 skipped
- [x] `uv run ruff check src/ tests/` / `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/rigplane/validation/hardware.py` — clean (repo-wide `mypy src/` has 13 pre-existing errors in 4 unrelated files, confirmed untouched by this diff)
- [x] `uv run lint-imports` — 5/5 contracts kept
- [x] `npx vitest run` on all four touched frontend test files — 100/100 passed (targeted run) / full suites for the three original files — 254/254 passed
- [x] `npx eslint src/` (frontend, full) — clean
- [x] `npm run lint:boundaries` — clean
- [x] Red-first confirmed for every item, including the R1 fix for item 3, by temporarily reverting the fix in place and re-running the new/updated tests (all failed as expected, then passed after restoring the fix)

Closes MOR-1547.
