### PR TITLE
fix: confirming-observation path for data-mode and filter armed facts (MOR-1546)

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -206,6 +206,17 @@ command_response_observable = [
     "global.operator_controls.vox_delay",
     # MOR-1491 (field-policy membership wave, leg 2): filter/PBT facts.
     "receiver.main.active.freq_mode.filter_width",
+    # MOR-1546: filter-select (filter_num) and DATA-mode carry the #2452
+    # armed affordance but had NO acquisition capability declared at all --
+    # ``_availability_for`` (acquisition_scheduler.py) rejects any
+    # ``ensure_fresh`` request for a path with no declared capability
+    # (UNKNOWN availability), so their armed confirm could not even reach
+    # the post-write-readback table added here (``_POST_WRITE_READBACK_FIELDS``
+    # in radio_poller.py) without this. Same event-driven-only shape as
+    # ``filter_width`` above -- no periodic cadence, so this adds nothing to
+    # the standing serial budget accounted at the bottom of this file.
+    "receiver.main.active.freq_mode.filter_num",
+    "receiver.main.active.freq_mode.data_mode",
     "receiver.main.operator_controls.filter_shape",
     "receiver.main.operator_controls.pbt_inner",
     "receiver.main.operator_controls.pbt_outer",

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -410,6 +410,25 @@ class IcomCivAcquisitionExecutor:
                 if slot == "unselected":
                     return None
                 return (0x1A, 0x03, receiver)
+            if path.name == "filter_num":
+                # MOR-1546: no dedicated CI-V read for the filter-selection
+                # fact -- it rides the SAME 0x26 selected/unselected mode
+                # readback as ``mode`` above (``frame.data[3]``, see
+                # ``parse_selected_mode_response`` / ``_civ_rx.py``'s cmd
+                # 0x26 observation branch, which already emits a
+                # ``filter_num`` observation alongside ``mode``/``data_mode``
+                # from that one response). Same selector, same command --
+                # this is an observation-side mapping, not a new query.
+                return (0x26, None, selector)
+            if path.name == "data_mode":
+                # MOR-1546: unlike filter_num, DATA mode has its own
+                # dedicated read (CI-V 0x1A 0x06, ``get_data_mode`` in every
+                # profile's ``[commands]`` table) -- no VFO-selector variant,
+                # so (like filter_width) only the selected/active slot is
+                # queryable.
+                if slot == "unselected":
+                    return None
+                return (0x1A, 0x06, receiver)
             return None
         if path.scope.value == "receiver" and path.family.value == "meters":
             if path.name == "s_meter":

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -529,6 +529,47 @@ _POST_WRITE_READBACK_FIELDS: dict[type, Callable[[Any], tuple[FieldPath, ...]]] 
     SetPreamp: lambda cmd: (
         FieldPath.receiver(_post_write_receiver_id(cmd), "operator_controls", "preamp"),
     ),
+    # MOR-1546: filter-select and DATA-mode carry the #2452 armed affordance.
+    # Both were ALREADY confirmed incidentally: ``mode``'s own 1.0s cadence
+    # poll (CI-V 0x26 selected/unselected mode readback,
+    # [state_acquisition.field_policies] in rigs/ic7300.toml) returns
+    # ``(mode, data_mode, filter)`` in one frame, and ``_civ_rx.py``'s cmd
+    # 0x26 observation branch already emits ``data_mode``/``filter_num``
+    # observations alongside ``mode`` from that same answer -- so armed was
+    # already clearing via a genuine observation within that cadence's
+    # worst case (~1.0s), comfortably inside the 3000ms ACK_CONFIRM_GRACE.
+    # What was actually missing:
+    #  (1) a DEDICATED event-driven confirm at write time, so the
+    #      operator's own click doesn't have to wait out even the 1.0s
+    #      cadence tick before confirming -- the same class of latency win
+    #      freq/mode/rf_gain/squelch/att/preamp already get from this table;
+    #  (2) an acquisition CAPABILITY declaration for these two paths
+    #      (rigs/ic7300.toml) -- without one, ``ensure_fresh`` rejects the
+    #      path as UNAVAILABLE before it ever reaches the executor, so
+    #      these table entries alone would still be unreachable.
+    # Neither entry funds or is funded by a cadence give-back -- there is no
+    # new cadence here, zero standing budget added either way.
+    #
+    # filter_num has no dedicated CI-V read; it rides the SAME 0x26
+    # selected/unselected mode readback ``SetMode`` above already requests,
+    # as the filter byte in that response (``query_for_path`` in
+    # ``acquisition_scheduler.py``, ``_civ_rx.py``'s cmd 0x26 observation
+    # branch) -- requesting the ``filter_num`` path here still costs exactly
+    # one 0x26 query, identical to what a `mode` post-write readback would
+    # send. This entry fires unconditionally for every ``SetFilter``,
+    # including on a backend without ``CAP_FILTER_WIDTH`` (whose ``case
+    # SetFilter`` arm above never calls ``radio.set_filter`` at all) --
+    # harmless, one extra 0x26 query per click on a filterless backend, not
+    # a wire write.
+    SetFilter: lambda cmd: (
+        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "filter_num"),
+    ),
+    # data_mode DOES have its own dedicated read (CI-V 0x1A 0x06,
+    # ``get_data_mode`` in every profile's ``[commands]`` table), so it gets
+    # its own one-query readback rather than piggybacking on ``mode``.
+    SetDataMode: lambda cmd: (
+        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "data_mode"),
+    ),
 }
 
 # ``ensure_fresh``'s ``max_age`` asks "how old may the CURRENT StateStore

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -2829,6 +2829,77 @@ def test_ic7610_real_profile_filter_width_query_for_path() -> None:
     assert executor.query_for_path(mode) == (0x26, None, 0)
 
 
+def test_filter_num_and_data_mode_query_for_path() -> None:
+    """MOR-1546: filter-select (filter_num) piggybacks on the SAME 0x26
+    selected/unselected mode readback ``mode`` already uses -- the filter
+    byte in that response (``parse_selected_mode_response`` /
+    ``_civ_rx.py``'s cmd 0x26 observation branch already emits a
+    ``filter_num`` observation alongside ``mode``/``data_mode`` from that one
+    response, this only teaches the executor how to REQUEST it). data_mode
+    has its own dedicated read (CI-V 0x1A 0x06, ``get_data_mode`` in every
+    profile's ``[commands]`` table), matching ``filter_width``'s
+    selected-only (no "unselected") shape rather than ``mode``'s.
+    """
+    sent: list[tuple[int, int | None, int | None]] = []
+
+    async def send_query(
+        command: int,
+        sub: int | None,
+        receiver: int | None,
+    ) -> None:
+        sent.append((command, sub, receiver))
+
+    executor = IcomCivAcquisitionExecutor(send_query)
+
+    filter_num_main = FieldPath.active("main", "freq_mode", "filter_num")
+    filter_num_sub = FieldPath.active("sub", "freq_mode", "filter_num")
+    assert executor.query_for_path(filter_num_main) == (0x26, None, 0)
+    assert executor.query_for_path(filter_num_sub) == (0x26, None, 1)
+
+    data_mode_main = FieldPath.active("main", "freq_mode", "data_mode")
+    data_mode_sub = FieldPath.active("sub", "freq_mode", "data_mode")
+    assert executor.query_for_path(data_mode_main) == (0x1A, 0x06, 0)
+    assert executor.query_for_path(data_mode_sub) == (0x1A, 0x06, 1)
+
+    # filter_num follows mode's selector scheme for the unselected slot
+    # (0x26 answers for either VFO); data_mode has no VFO-selector read at
+    # all, same as filter_width.
+    filter_num_unselected = FieldPath.unselected("main", "freq_mode", "filter_num")
+    data_mode_unselected = FieldPath.unselected("main", "freq_mode", "data_mode")
+    assert executor.query_for_path(filter_num_unselected) == (0x26, None, 1)
+    assert executor.query_for_path(data_mode_unselected) is None
+
+
+def test_ic7300_real_profile_filter_num_and_data_mode_have_capability() -> None:
+    """MOR-1546: without a declared acquisition capability, ``ensure_fresh``
+    rejects the path as UNAVAILABLE before it ever reaches the executor
+    (``AcquisitionScheduler._availability_for``) -- so the post-write
+    readback table entries alone are not sufficient, the profile must also
+    declare these two fields. Both are command_response_observable-only
+    (event-driven, like ``filter_width``), not ``polling_only`` -- neither
+    field is ever added to ``[state_acquisition.field_policies]``, so this
+    adds nothing to the standing serial budget accounted for at the bottom
+    of ``rigs/ic7300.toml``.
+    """
+    profile = get_radio_profile("IC-7300")
+    acquisition = profile.state_acquisition
+    assert acquisition is not None
+
+    filter_num = FieldPath.active("main", "freq_mode", "filter_num")
+    data_mode = FieldPath.active("main", "freq_mode", "data_mode")
+
+    filter_cap = acquisition.capability_for(filter_num)
+    data_mode_cap = acquisition.capability_for(data_mode)
+    assert filter_cap.command_response_observable is True
+    assert filter_cap.polling is False
+    assert data_mode_cap.command_response_observable is True
+    assert data_mode_cap.polling is False
+
+    # Event-driven only: neither field is in the cadence sweep.
+    assert filter_num not in acquisition.field_policies
+    assert data_mode not in acquisition.field_policies
+
+
 def test_ic7610_real_profile_filter_width_pollable_and_emit_reads() -> None:
     acquisition = load_rig(RIGS_DIR / "ic7610.toml").to_profile().state_acquisition
     assert acquisition is not None

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -66,6 +66,7 @@ from rigplane.web.radio_poller import (
     SetData1ModInput,
     SetDataMode,
     SetDigiSel,
+    SetFilter,
     SetFilterShape,
     SetFilterWidth,
     SetFreq,
@@ -997,6 +998,14 @@ async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
             SetPreamp(1, receiver=0),
             FieldPath.receiver("main", "operator_controls", "preamp"),
         ),
+        (
+            SetFilter(2, receiver=0),
+            FieldPath.active("main", "freq_mode", "filter_num"),
+        ),
+        (
+            SetDataMode(1, receiver=0),
+            FieldPath.active("main", "freq_mode", "data_mode"),
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -1015,6 +1024,21 @@ async def test_execute_write_requests_immediate_readback_at_user_priority(
     widen the armed-affordance confirm window past the 3000ms
     ACK_CONFIRM_GRACE for a slice of clicks (the MOR-1478 stale-flash
     symptom, reintroduced on a new affordance).
+
+    filter_num/data_mode are included (MOR-1546): both carry the same #2452
+    armed affordance and were ALREADY confirmed incidentally by ``mode``'s
+    own 1.0s cadence poll (CI-V 0x26 already returns ``(mode, data_mode,
+    filter)`` in one frame, and ``_civ_rx.py`` already decodes all three) --
+    so armed was already clearing via a genuine observation well inside the
+    3000ms grace, not only via timeout. What was missing was a DEDICATED
+    event-driven confirm at write time (this table entry) so the operator's
+    own click doesn't wait out even that 1.0s cadence tick, plus an
+    acquisition capability declaration for ``ensure_fresh`` reachability
+    (rigs/ic7300.toml) -- without it this table entry alone is rejected as
+    UNAVAILABLE before it ever reaches the executor. Zero cadence give-back
+    needed here: neither field is (or ever was) in any
+    [state_acquisition.field_policies] cadence tier, so this is pure
+    additional confirm-latency improvement with no existing budget to fund.
     """
     radio = _make_radio(active="MAIN")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))


### PR DESCRIPTION
Closes MOR-1546.

## Investigation

`getDataModeArmed`/`getFilterArmed` (the #2452 armed wave) — both `data_mode`
and filter-select (`filter_num`) have a real CI-V read on IC-7300. Checked
what the MODE readback (CI-V `0x26`, `get_selected_mode`) already carries:
`parse_selected_mode_response` returns `(receiver, mode, data_mode, filter)`
— all four in one response — and `_civ_rx.py`'s existing cmd `0x26`
observation branch already emits `mode`, `data_mode`, **and** `filter_num`
observations from that single frame.

`receiver.main.active.freq_mode.mode` is polled at 1.0s cadence via that
same `0x26` command (`rigs/ic7300.toml` field_policies). So both facts were
**already confirmed incidentally** by `mode`'s own cadence poll — armed was
already clearing via a genuine observation within that cadence's worst case
(~1.0s), comfortably inside the 3000ms `ACK_CONFIRM_GRACE`, not only via
grace timeout. (A silently-failed write also does not "clear armed with the
wrong state showing" — it produces a *mismatching* observation, which
`latestPendingParam` correctly keeps armed for, not cleared.)

What was actually missing:

1. A **dedicated event-driven confirm at write time**, so the operator's own
   click doesn't have to wait out even the 1.0s cadence tick before
   confirming — the same class of latency win the `#2459`
   post-write-readback table already gives freq/mode/rf_gain/squelch/att/
   preamp.
2. An **acquisition capability declaration** for these two paths — without
   one, `AcquisitionScheduler._availability_for` rejects any `ensure_fresh`
   request for the path as `UNAVAILABLE` before it ever reaches the
   executor, so a post-write-readback table entry alone would still be
   unreachable.

## Disposition: post-write readback, not cadence

Per the ticket's preference, both are enrolled through the `#2459`
post-write-readback table (`_POST_WRITE_READBACK_FIELDS` in
`radio_poller.py`) — event-driven confirm, **zero standing cadence
budget** — rather than a new cadence-poll entry:

- `src/rigplane/core/acquisition_scheduler.py` —
  `IcomCivAcquisitionExecutor.query_for_path` gained two mappings in the
  `freq_mode` family: `filter_num` → `(0x26, None, selector)` (same
  command `mode` already uses — an observation-side mapping, not a new
  query), and `data_mode` → `(0x1A, 0x06, receiver)` (its own dedicated
  read, no VFO-selector variant — same selected-only shape as
  `filter_width`).
- `src/rigplane/web/radio_poller.py` — `SetFilter` and `SetDataMode` added
  to `_POST_WRITE_READBACK_FIELDS`, requesting `freq_mode.filter_num` and
  `freq_mode.data_mode` respectively at `USER` priority (jumps the
  scheduler queue, same mechanism `SetFreq`/`SetMode`/`SetRfGain`/
  `SetSquelch`/`SetAttenuator`/`SetPreamp` already use). Note: the
  `SetFilter` entry fires unconditionally per write, including on a
  backend without `CAP_FILTER_WIDTH` (whose `case SetFilter` arm never
  calls `radio.set_filter` at all) — harmless, one extra `0x26` query per
  click on a filterless backend, not a wire write.
- `rigs/ic7300.toml` — both fields added to
  `[state_acquisition.capabilities].command_response_observable` (**not**
  `polling_only`). Same event-driven-only shape as `filter_width`'s
  existing entry (no cadence, no cadence give-back needed).

## Budget math

Neither field is (or becomes) part of any cadence sweep — both stay
entirely out of `[state_acquisition.field_policies]`, matching
`filter_width`'s precedent. The only added CI-V traffic is one query per
operator `set_filter`/`set_data_mode` write, bounded by operator action
rate, not polling cadence.

**Net added steady-state serial demand: 0.0 q/s.**

## Red-first

- `tests/test_radio_poller_coverage.py` —
  `test_execute_write_requests_immediate_readback_at_user_priority`
  extended with `SetFilter`/`SetDataMode` parametrize cases.
- `tests/test_acquisition_scheduler.py` — new
  `test_filter_num_and_data_mode_query_for_path` (executor mapping) and
  `test_ic7300_real_profile_filter_num_and_data_mode_have_capability`
  (real shipped profile capability + confirms neither field is in the
  cadence sweep).

Verified via patch revert/reapply (no `git stash`, per repo convention)
that all three fail against the pre-fix tree (`AssertionError`s shown
below) and pass against the fix:

```
tests/test_acquisition_scheduler.py::test_filter_num_and_data_mode_query_for_path FAILED
tests/test_acquisition_scheduler.py::test_ic7300_real_profile_filter_num_and_data_mode_have_capability FAILED
tests/test_radio_poller_coverage.py::test_execute_write_requests_immediate_readback_at_user_priority[cmd7-path7] FAILED
tests/test_radio_poller_coverage.py::test_execute_write_requests_immediate_readback_at_user_priority[cmd8-path8] FAILED
```

## Verification

- `uv run pytest tests/test_acquisition_scheduler.py tests/test_radio_poller_coverage.py tests/test_state_acquisition_policy.py tests/test_rig_ic7300.py tests/test_ic7300_backend.py tests/test_rig_loader.py tests/test_radios.py tests/test_command_spec.py -q` — all pass (619 total across these files)
- `uv run ruff check` / `ruff format --check` on touched files — clean
- `uv run mypy src/rigplane/core/acquisition_scheduler.py src/rigplane/web/radio_poller.py` — clean
- `uv run lint-imports` — all 5 contracts kept

## Test plan

- [ ] CI: quick.yml (unit tests + ruff + import-linter)
- [ ] Optional: live IC-7300 bench validation of the `getDataModeArmed`/`getFilterArmed` confirm-latency improvement (no hardware access in this session)

## Review note

Addressed independent-verifier findings F1 (corrected the "no confirming
observation" premise — the real win is confirm-latency + capability
declaration, not creating confirmation from nothing), F2 (removed an
incorrect "prime_unobserved" budget-math claim — prime only iterates
`field_policies`, and these fields deliberately have no entry there, so
they are never primed), and N1 (documented the harmless SetFilter
readback fire on CAP_FILTER_WIDTH-less backends). Amended in place
(`--force-with-lease`, single-author branch tip only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)