### PR TITLE
fix: receiver-scoped tone dedupe keys + VFO-fallback failure-path tests (MOR-1545)

### DIFF
--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -4338,7 +4338,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 )
                 return await self._get_bool_value(
                     civ,
-                    key="get_repeater_tone",
+                    key=f"get_repeater_tone:{receiver}",
                     command=0x16,
                     sub=_SUB_REPEATER_TONE,
                 )
@@ -4357,7 +4357,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         return await self._get_bool_value(
-            civ, key="get_repeater_tone", command=0x16, sub=_SUB_REPEATER_TONE
+            civ,
+            key=f"get_repeater_tone:{receiver}",
+            command=0x16,
+            sub=_SUB_REPEATER_TONE,
         )
 
     async def set_repeater_tone(self, on: bool, receiver: int = 0) -> None:
@@ -4413,7 +4416,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 )
                 return await self._get_bool_value(
                     civ,
-                    key="get_repeater_tsql",
+                    key=f"get_repeater_tsql:{receiver}",
                     command=0x16,
                     sub=_SUB_REPEATER_TSQL,
                 )
@@ -4432,7 +4435,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         return await self._get_bool_value(
-            civ, key="get_repeater_tsql", command=0x16, sub=_SUB_REPEATER_TSQL
+            civ,
+            key=f"get_repeater_tsql:{receiver}",
+            command=0x16,
+            sub=_SUB_REPEATER_TSQL,
         )
 
     async def set_repeater_tsql(self, on: bool, receiver: int = 0) -> None:

--- a/tests/test_mor1545_vfo_fallback_failure_paths.py
+++ b/tests/test_mor1545_vfo_fallback_failure_paths.py
@@ -1,0 +1,165 @@
+"""MOR-1545 (PR #2458 follow-up 2): failure-path coverage for
+``_run_with_receiver_vfo_fallback`` (``_dual_rx_runtime.py:102-147``).
+
+13 call sites route through this one helper (VFO-select receiver targeting
+on cmd29-less dual-RX profiles, e.g. IC-9700), yet it had zero direct tests
+-- existing tests only exercise the happy path via public tone/TSQL methods.
+These call the private helper directly with a stubbed ``_set_vfo_wire`` to
+pin the failure branches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.exceptions import TimeoutError
+from rigplane.radio import IcomRadio
+
+
+@pytest.fixture
+def ic9700_radio() -> IcomRadio:
+    """Dual-RX profile with VFO select codes but no cmd29 route -- the
+    profile shape ``_run_with_receiver_vfo_fallback`` exists for."""
+    r = IcomRadio("192.168.1.102", timeout=0.05, model="IC-9700")
+    r._connected = True
+    yield r
+    r._connected = False
+
+
+class TestActionRaisesMidSwap:
+    """(a) action raises mid-swap -> VFO restored via finally."""
+
+    @pytest.mark.asyncio
+    async def test_restores_vfo_before_propagating(
+        self, ic9700_radio: IcomRadio
+    ) -> None:
+        calls: list[str] = []
+
+        async def fake_set_vfo_wire(vfo: str) -> None:
+            calls.append(vfo)
+
+        ic9700_radio._set_vfo_wire = fake_set_vfo_wire  # type: ignore[method-assign]
+
+        async def failing_action() -> None:
+            raise ValueError("boom mid-swap")
+
+        with pytest.raises(ValueError, match="boom mid-swap"):
+            await ic9700_radio._run_with_receiver_vfo_fallback(
+                receiver=1, operation="test_op", action=failing_action
+            )
+
+        # select SUB, run the (failing) action, restore MAIN regardless.
+        assert calls == ["SUB", "MAIN"]
+        assert ic9700_radio._radio_state.active == "MAIN"
+
+
+class TestTimeoutRetryOnRestore:
+    """(b) TimeoutError retry branch on the restore-back call."""
+
+    @pytest.mark.asyncio
+    async def test_first_restore_times_out_retry_succeeds(
+        self, ic9700_radio: IcomRadio
+    ) -> None:
+        calls: list[str] = []
+
+        async def flaky_restore(vfo: str) -> None:
+            calls.append(vfo)
+            if vfo == "MAIN" and calls.count("MAIN") == 1:
+                raise TimeoutError("restore timed out")
+
+        ic9700_radio._set_vfo_wire = flaky_restore  # type: ignore[method-assign]
+
+        async def action() -> str:
+            return "action-result"
+
+        result = await ic9700_radio._run_with_receiver_vfo_fallback(
+            receiver=1, operation="test_op", action=action
+        )
+
+        assert result == "action-result"
+        # select SUB, first restore attempt (times out), retry (succeeds).
+        assert calls == ["SUB", "MAIN", "MAIN"]
+        assert ic9700_radio._radio_state.active == "MAIN"
+
+    @pytest.mark.asyncio
+    async def test_retried_restore_also_fails_propagates(
+        self, ic9700_radio: IcomRadio
+    ) -> None:
+        """Retry is attempted exactly once: if it also times out, the
+        second TimeoutError propagates uncaught (no second retry)."""
+        calls: list[str] = []
+
+        async def always_timeout_restore(vfo: str) -> None:
+            calls.append(vfo)
+            if vfo == "MAIN":
+                raise TimeoutError("restore timed out")
+
+        ic9700_radio._set_vfo_wire = always_timeout_restore  # type: ignore[method-assign]
+
+        async def action() -> str:
+            return "action-result"
+
+        with pytest.raises(TimeoutError, match="restore timed out"):
+            await ic9700_radio._run_with_receiver_vfo_fallback(
+                receiver=1, operation="test_op", action=action
+            )
+
+        assert calls == ["SUB", "MAIN", "MAIN"]
+
+
+class TestSelectBackFailureSemantics:
+    """(c) Pin -- not change -- what the ``finally`` does when the restore
+    itself fails outright (both attempts time out)."""
+
+    @pytest.mark.asyncio
+    async def test_active_receiver_left_on_switched_target_when_restore_fails(
+        self, ic9700_radio: IcomRadio
+    ) -> None:
+        """``_radio_state.active`` only updates on a successful restore;
+        when both attempts fail it stays on the switched-to receiver (SUB).
+        As-built behavior -- documented here, not endorsed or changed."""
+
+        async def always_timeout_restore(vfo: str) -> None:
+            if vfo == "MAIN":
+                raise TimeoutError("restore timed out")
+
+        ic9700_radio._set_vfo_wire = always_timeout_restore  # type: ignore[method-assign]
+
+        async def action() -> str:
+            return "action-result"
+
+        with pytest.raises(TimeoutError):
+            await ic9700_radio._run_with_receiver_vfo_fallback(
+                receiver=1, operation="test_op", action=action
+            )
+
+        assert ic9700_radio._radio_state.active == "SUB"
+
+    @pytest.mark.asyncio
+    async def test_action_exception_is_masked_by_retried_restore_failure(
+        self, ic9700_radio: IcomRadio
+    ) -> None:
+        """When BOTH action and retried restore raise, the caller sees the
+        restore's TimeoutError, not the action's exception -- preserved
+        only as ``__context__`` (two hops: retry -> first attempt -> the
+        action's ValueError). Pinned, not endorsed."""
+
+        async def always_timeout_restore(vfo: str) -> None:
+            if vfo == "MAIN":
+                raise TimeoutError("restore timed out")
+
+        ic9700_radio._set_vfo_wire = always_timeout_restore  # type: ignore[method-assign]
+
+        async def failing_action() -> None:
+            raise ValueError("original action failure")
+
+        with pytest.raises(TimeoutError) as excinfo:
+            await ic9700_radio._run_with_receiver_vfo_fallback(
+                receiver=1, operation="test_op", action=failing_action
+            )
+
+        first_restore_failure = excinfo.value.__context__
+        assert isinstance(first_restore_failure, TimeoutError)
+        original_action_failure = first_restore_failure.__context__
+        assert isinstance(original_action_failure, ValueError)
+        assert str(original_action_failure) == "original action failure"

--- a/tests/test_mor1545_vfo_fallback_failure_paths.py
+++ b/tests/test_mor1545_vfo_fallback_failure_paths.py
@@ -10,10 +10,22 @@ pin the failure branches.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
 from rigplane.exceptions import TimeoutError
 from rigplane.radio import IcomRadio
+
+from test_radio import MockTransport, _wrap_civ_in_udp
+
+_IC9700_ADDR = 0xA2
+
+
+@pytest.fixture
+def mock_transport() -> MockTransport:
+    return MockTransport()
 
 
 @pytest.fixture
@@ -163,3 +175,55 @@ class TestSelectBackFailureSemantics:
         original_action_failure = first_restore_failure.__context__
         assert isinstance(original_action_failure, ValueError)
         assert str(original_action_failure) == "original action failure"
+
+
+class TestVfoFallbackReadDedupeKeyReceiverScoped:
+    """MOR-1545 F1: the receiver-scoped dedupe-key fix also covers the
+    VFO-fallback read call sites (radio.py ~4341/4419), not just the direct
+    cmd29 path (test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped). On
+    IC-9700 (no cmd29 route) a MAIN direct read and a SUB fallback read
+    build byte-identical request frames -- only the dedupe key can tell
+    them apart. ``_set_vfo_wire`` is stubbed to an instant no-op so the SUB
+    fallback path reaches its own dedupe check before the single-worker
+    commander finishes dispatching MAIN's read, reproducing the coalescing
+    race deterministically (pre-fix: SUB sends zero read frames of its own
+    and returns MAIN's stale answer)."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_main_direct_and_sub_fallback_reads_do_not_coalesce(
+        self, ic9700_radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        ic9700_radio._civ_transport = mock_transport
+        ic9700_radio._ctrl_transport = mock_transport
+
+        async def instant_select(vfo: str) -> None:
+            return None
+
+        ic9700_radio._set_vfo_wire = instant_select  # type: ignore[method-assign]
+        ic9700_radio._civ_runtime.start_worker()
+        try:
+            mock_transport.queue_response_on_send(
+                1,
+                _wrap_civ_in_udp(
+                    build_civ_frame(
+                        CONTROLLER_ADDR, _IC9700_ADDR, 0x16, sub=0x42, data=b"\x01"
+                    )
+                ),
+            )
+            mock_transport.queue_response_on_send(
+                2,
+                _wrap_civ_in_udp(
+                    build_civ_frame(
+                        CONTROLLER_ADDR, _IC9700_ADDR, 0x16, sub=0x42, data=b"\x00"
+                    )
+                ),
+            )
+            main_result, sub_result = await asyncio.gather(
+                ic9700_radio.get_repeater_tone(receiver=0),
+                ic9700_radio.get_repeater_tone(receiver=1),
+            )
+            assert main_result is True
+            assert sub_result is False
+            assert len(mock_transport.sent_packets) == 2
+        finally:
+            await ic9700_radio._civ_runtime.stop_worker()

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -3327,6 +3327,123 @@ class TestToneTsqlDualRxCmd29Guard:
         assert mock_transport.sent_packets[-1].endswith(b"\x16\x42\xfd")
 
 
+class TestRepeaterToneDedupeKeyReceiverScoped:
+    """MOR-1545 (PR #2458 follow-up 1): get_repeater_tone/get_repeater_tsql
+    deduped GETs on a bare ``key="get_repeater_tone"`` shared across
+    MAIN/SUB (``IcomCommander._pending_by_key`` in
+    ``commands/commander.py``, see ``send()`` lines ~151-156). A concurrent
+    in-flight MAIN read could coalesce a SUB caller onto MAIN's answer.
+    Fixed to receiver-scope the key (``key=f"get_repeater_tone:{receiver}"``),
+    mirroring ``get_filter_width``'s precedent (MOR-1538/#2458).
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "sub"),
+        [("get_repeater_tone", 0x42), ("get_repeater_tsql", 0x43)],
+    )
+    async def test_concurrent_main_and_sub_reads_do_not_coalesce(
+        self,
+        radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        sub: int,
+    ) -> None:
+        """Two receivers in flight at once must each get their own wire
+        read and their own answer -- not one coalesced onto the other."""
+        radio._civ_runtime.start_worker()
+        try:
+            mock_transport.queue_response_on_send(
+                1, _function_response(sub, b"\x01", receiver=0)
+            )
+            mock_transport.queue_response_on_send(
+                2, _function_response(sub, b"\x00", receiver=1)
+            )
+            method = getattr(radio, method_name)
+            main_result, sub_result = await asyncio.gather(
+                method(receiver=0), method(receiver=1)
+            )
+            assert main_result is True
+            assert sub_result is False
+            assert len(mock_transport.sent_packets) == 2
+        finally:
+            await radio._civ_runtime.stop_worker()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_receiver_reads_still_dedupe(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """Two concurrent reads for the SAME receiver must still coalesce
+        onto a single wire read (the dedupe mechanism itself is not being
+        removed, only receiver-scoped)."""
+        radio._civ_runtime.start_worker()
+        try:
+            mock_transport.queue_response_on_send(
+                1, _function_response(0x42, b"\x01", receiver=0)
+            )
+            first, second = await asyncio.gather(
+                radio.get_repeater_tone(receiver=0),
+                radio.get_repeater_tone(receiver=0),
+            )
+            assert first is True
+            assert second is True
+            assert len(mock_transport.sent_packets) == 1
+        finally:
+            await radio._civ_runtime.stop_worker()
+
+
+class TestRequireReceiverToneMethodsPin:
+    """MOR-1545 (PR #2458 follow-up 3): pin ``_require_receiver``'s accurate
+    ``receivers=1`` message across all 8 tone/TSQL methods (get/set x
+    repeater_tone, repeater_tsql, tone_freq, tsql_freq) on a single-RX
+    profile. MOR-1538 added the ``_require_receiver`` call to these 8
+    methods but only ``TestToneTsqlDualRxCmd29Guard`` (dual-RX, cmd29-less)
+    exercises the follow-on cmd29/VFO-fallback branches -- no test pins the
+    single-RX rejection message itself.
+    """
+
+    @pytest.fixture
+    def single_rx_radio(self, mock_transport: MockTransport):
+        r = IcomRadio("192.168.1.104", timeout=0.05, model="IC-7300")
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        yield r
+        r._connected = False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("get_repeater_tone", ()),
+            ("set_repeater_tone", (True,)),
+            ("get_repeater_tsql", ()),
+            ("set_repeater_tsql", (True,)),
+            ("get_tone_freq", ()),
+            ("set_tone_freq", (88.5,)),
+            ("get_tsql_freq", ()),
+            ("set_tsql_freq", (110.9,)),
+        ],
+    )
+    async def test_single_rx_receiver_1_reports_accurate_receiver_count(
+        self,
+        single_rx_radio: IcomRadio,
+        mock_transport: MockTransport,
+        method_name: str,
+        args: tuple,
+    ) -> None:
+        method = getattr(single_rx_radio, method_name)
+        with pytest.raises(
+            CommandError,
+            match=(
+                rf"{method_name} does not support receiver=1 for profile "
+                r"IC-7300 \(receivers=1\)"
+            ),
+        ):
+            await method(*args, receiver=1)
+        assert mock_transport.sent_packets == []
+
+
 class TestCodecProfileOverride:
     """Per-profile codec_preference overrides the global default (#797)."""
 


### PR DESCRIPTION
Closes MOR-1545

## Summary

Three PR #2458 follow-ups:

1. **Receiver-scope the 4 tone GET dedupe keys.** `get_repeater_tone`/
   `get_repeater_tsql` deduped GETs (`_get_bool_value` -> `IcomCommander.
   _pending_by_key`, `commands/commander.py` `send()` lines ~151-156) shared
   one bare key across MAIN/SUB, at 2 call sites per method (the direct
   cmd29 path and the VFO-fallback path) -- 4 key literals total. A
   concurrent in-flight MAIN read could coalesce a SUB caller onto MAIN's
   answer. Fixed per the `get_filter_width` precedent:
   `key=f"get_repeater_tone:{receiver}"` (and the `_tsql` sibling), at all
   4 call sites. **Excluded, correctly:** `get_tone_freq`/`get_tsql_freq`
   read via `_send_civ_expect` with `key=None`/`dedupe=False`
   (radio.py:4493, 4510, 4561, 4578) -- they never enter
   `_pending_by_key`, so there is no coalescing to scope. That's what the
   ticket's "4" refers to: 4 key literals across 2 methods x 2 call sites
   each, not 4 methods.

2. **Failure-path tests for `_run_with_receiver_vfo_fallback`**
   (`_dual_rx_runtime.py:102-147`, 13 call sites, previously zero direct
   tests): action raising mid-swap still restores the VFO via `finally`;
   the restore-timeout retry-once branch (succeeds, and fails); and the
   double-restore-failure semantics (exception chaining, cached
   active-receiver left on the switched-to target) -- pinned as-built, not
   changed.

3. **Parametrized pin for `_require_receiver`** on the 8 tone/TSQL methods
   on a single-RX profile (IC-7300, receiver=1) -- the accurate
   `receivers=1` message.

## Red-first evidence

**Direct-path site** (`test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped`,
default IC-7610/cmd29 fixture -- both MAIN and SUB route through the same
direct-path key literal on this profile): reverted the `radio.py` key fix
(`git apply -R` on the isolated diff, no stash) and reran:

```
FAILED test_concurrent_main_and_sub_reads_do_not_coalesce[get_repeater_tone-66]
FAILED test_concurrent_main_and_sub_reads_do_not_coalesce[get_repeater_tsql-67]
E   assert True is False
2 failed, 1 passed
```

These 2 failures are evidence for the DIRECT/cmd29 site only.

**VFO-fallback-path site** (`test_mor1545_vfo_fallback_failure_paths.py::
TestVfoFallbackReadDedupeKeyReceiverScoped`, IC-9700/cmd29-less fixture --
MAIN uses the direct path, SUB uses the VFO-fallback path, and the two
sites' key literals must BOTH be unscoped to collide): an independent
verifier flagged that the original evidence never exercised this site --
reverting only the fallback-path literals (radio.py line 4341/4419) left
all 297 pre-existing tests green, because the direct-path key stayed
receiver-scoped and the two keys simply became different strings ("get_
repeater_tone" vs "get_repeater_tone:0"), so no coalescing occurred
regardless. **Reverting a single site is not a valid witness for this
collision.** The valid witness reverts BOTH the fallback-path (4341) and
direct-path (4361) literals for the same method together:

```
FAILED test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped::test_concurrent_main_and_sub_reads_do_not_coalesce[get_repeater_tone-66]
FAILED test_mor1545_vfo_fallback_failure_paths.py::TestVfoFallbackReadDedupeKeyReceiverScoped::test_concurrent_main_direct_and_sub_fallback_reads_do_not_coalesce
E   assert True is False
2 failed, 2 passed
```

Reapplied the fix; reran green (344 passed) in both cases.

## Test plan

- `uv run pytest tests/test_radio.py tests/test_mor1545_vfo_fallback_failure_paths.py tests/test_dsp_filter_family.py tests/test_commander.py -q --tb=short` -- 344 passed
- `uv run ruff check` / `ruff format --check` on the 3 changed files -- clean
- `uv run mypy src/rigplane/runtime/radio.py` -- 0 issues
- `uv run lint-imports` -- 5 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)