### PR TITLE
fix: honest AGC label fallback in SemanticRadioSurfaces seam (MOR-1547 follow-up)

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -230,8 +230,12 @@
    * straight off `runtime.caps` here, at the one seam that already holds it
    * for the `toRadioViewModel` call below, verbatim `toDspProps`'s own
    * fallbacks (`lib/runtime/props/panel-props.ts`).
+   *
+   * MOR-1547: no fabricated IC-7610-shaped FAST/MID/SLOW dict when the
+   * profile declares no agcLabels — `{}` lets `buildAgcOptions`
+   * (agc-utils.ts) fall back to the honest raw mode number per-entry.
    */
-  let agcLabels = $derived(runtime.caps?.agcLabels ?? { '1': 'FAST', '2': 'MID', '3': 'SLOW' });
+  let agcLabels = $derived(runtime.caps?.agcLabels ?? {});
   let nbLevelRange = $derived(runtime.caps?.controls?.nb_level ?? null);
   let nbLevelMax = $derived(nbLevelRange?.raw_max ?? 10);
   let nbLevelPercent = $derived(nbLevelRange !== null);

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -396,6 +396,18 @@ describe('carry-forward (1): caps-echo display metadata is read at this seam', (
     const input = q<HTMLInputElement>('[data-testid="dsp-nbLevel"] input')!;
     expect(input.max).toBe('10');
   });
+
+  it('does not fabricate FAST/MID/SLOW labels when caps declares no agcLabels (MOR-1547 follow-up)', () => {
+    // Mirror of the toAgcProps fix in lib/runtime/props/panel-props.ts
+    // (MOR-1547): this seam carried the same hardcoded IC-7610-shaped
+    // `{ '1': 'FAST', '2': 'MID', '3': 'SLOW' }` fallback, fabricating
+    // plausible-looking labels for radios whose numeric AGC modes mean
+    // something different. With no declared `agcLabels`, `buildAgcOptions`
+    // (agc-utils.ts) must fall back to the honest raw mode number instead.
+    h.caps = { ...liveCaps(true), agcLabels: undefined } as unknown as Capabilities;
+    render();
+    expect(q('[data-testid="dsp-agcMode-1"]')!.textContent).toBe('1');
+  });
 });
 
 describe('desktop-v2 declares a real dsp zone; the cockpit does not (MOR-1368, S9, F1)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #2464 (MOR-1547), which fixed `toAgcProps` in `frontend/src/lib/runtime/props/panel-props.ts` and explicitly flagged the identical hardcode left at `frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte:234` as out of that ticket's named scope and file-count guardrail.

That seam fed `semantic/DspSurface.svelte`'s `buildAgcOptions` call via the SemanticRadioSurfaces wiring path (a different UI path than panel-props/AgcPanel) and still fabricated an IC-7610-shaped `{ '1': 'FAST', '2': 'MID', '3': 'SLOW' }` label dict whenever `runtime.caps.agcLabels` was absent — plausible-looking but wrong labels for radios whose numeric AGC modes mean something different.

The fallback is now `{}`, letting `buildAgcOptions` (`components-v2/panels/agc-utils.ts`) fall back to the honest raw mode number per-entry — the same fix and rationale as #2464's panel-props change.

## Test plan

- **TDD red-first**: new test in `semantic-dsp-wiring.component.test.ts` renders `SemanticRadioSurfaces` with caps declaring `agcModes: [1,2,3]` but no `agcLabels`, pinning the AGC segment button text to the raw `'1'`. Failed with `'FAST'` before the fix, passes after.
- Checked `semantic-dsp-wiring.component.test.ts` and `DualReceiverCockpit.component.test.ts` for assertions on the old fabricated behavior: both declare `agcLabels` explicitly in their caps fixtures, so neither pinned the fallback — no updates needed, all stay green unchanged.
- Full frontend suite: 7196 tests, 1 pre-existing flake (`fixture-capture-root-cwd.test.ts` subprocess timeout under full-suite load; passes in isolation), everything else green.
- `npm run lint` and `npm run check` (svelte-check + tsc): zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)