### PR TITLE
chore: notch width domains declared where sourced (MOR-1551)

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -29,6 +29,19 @@ rx_audio_channel = "left"
 max_watts = 100
 
 [capabilities]
+# NOTE: ``notch`` KEEPS the capability tag but intentionally declares NO
+# ``[notch] width_values`` domain (MOR-1551). The FTX-1's manual notch is a
+# Yaesu CAT ``BP`` pair: ``BP00`` toggles it on/off and ``BP01`` selects a
+# frequency index (0-255, see ``get/set_manual_notch_freq`` below) — neither
+# the wfview FTX-1.rig source nor the Yaesu FT-X1 CAT manual this profile is
+# sourced from documents a separate WIDTH register for it. Independently,
+# ``YaesuCatRadio.set_manual_notch_width``/``get_manual_notch_width``
+# (src/rigplane/backends/yaesu_cat/radio.py) already raise
+# ``NotImplementedError`` unconditionally on every Yaesu CAT radio, so no
+# wire encoding is possible for this control regardless of what the TOML
+# declares — this comment records the provenance, it does not change
+# behavior. Closing evidence: a CAT manual revision or wfview update that
+# documents an FTX-1 notch-width register.
 features = [
     "audio",
     "dual_rx",

--- a/rigs/tx500.toml
+++ b/rigs/tx500.toml
@@ -37,6 +37,15 @@ type = "kenwood_cat"
 variant = "lab599"
 
 [capabilities]
+# NOTE: ``notch`` KEEPS the capability tag but intentionally declares NO
+# ``[notch] width_values`` domain (MOR-1551). Per the Lab599 CAT Protocol
+# rev. 2 (docs/validation/cat-audits/tx500.md line 37), ``NT`` is a single
+# 0=OFF/1=Auto toggle — auto-notch only, with no manual notch and therefore
+# no width parameter documented anywhere in the protocol doc. This is the
+# "auto-notch-only rig" case the MOR-1551 invariant is designed to leave
+# alone. (The TX-500 also has no backend yet — see the file header — so
+# this control is not runtime-reachable at all today.) Closing evidence: a
+# Lab599 protocol revision documenting a manual-notch/width register.
 features = [
     "audio",
     "af_level",      # AG  000-250

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -53,6 +53,21 @@ address = 0x70
 # unconfirmed guess on top of another. No trustworthy in-repo source exists
 # for an OFF/SEMI/FULL domain on this radio, so ``CoreRadio.set_break_in``
 # refuses (fails loud) rather than validate against a guessed table.
+#
+# NOTE: ``notch`` likewise KEEPS the capability tag but intentionally
+# declares NO ``[notch] width_values`` domain (MOR-1551). There is no
+# X6100 cat-audit in this repo (no hardware to capture), so this leans on
+# the same shared-firmware inference as ``break_in`` above: the X6200's own
+# audit found its manual-notch opcode (``0x16 0x48``) isn't in the X6200
+# CI-V table either — the X6200's actual notch mechanism is a DNF on/off
+# toggle (``0x16 0x41``) plus a center-frequency register (``0x14 0x0D``),
+# with no WIDE/MID/NAR-style width register documented anywhere. Inferring
+# an X6100 width domain from X6200 data would compound one unconfirmed
+# guess on top of another, so ``CoreRadio.set_manual_notch_width`` stays
+# unvalidated (permissive, mirrors ``set_agc``/``set_preamp``) rather than
+# fabricate a table. Closing evidence: a live X6100 CI-V capture (no
+# hardware currently available) or a firmware/wfview doc update that
+# documents an X6100/X6200 notch-width register.
 features = [
     "audio",
     "af_level",

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -84,6 +84,21 @@ codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 #     BK-IN-mode register. There is no trustworthy in-repo source for an
 #     OFF/SEMI/FULL value domain on this radio, so ``CoreRadio.set_break_in``
 #     refuses (fails loud) rather than validate against a guessed table.
+#   - ``notch`` likewise KEEPS the capability tag but intentionally declares
+#     NO ``[notch] width_values`` domain (MOR-1551). docs/validation/
+#     cat-audits/x6200.md (lines 55/95/107) found the ``notch`` cap
+#     currently routes to ``set_manual_notch`` (``0x16 0x48``, Icom
+#     manual-notch on/off) which is ALSO not in the X6200's documented CI-V
+#     table — the X6200's real notch mechanism is the digital notch filter
+#     (DNF) toggle at ``0x16 0x41`` plus its center frequency at
+#     ``0x14 0x0D`` (confirmed-correct opcode, 100-3000 Hz). Neither the PDF
+#     Table 1 nor Hamlib's ``x6100_priv_caps`` document a WIDE/MID/NAR-style
+#     width register for this radio at all, so there is no trustworthy
+#     in-repo source for a width domain — ``CoreRadio.set_manual_notch_width``
+#     stays unvalidated (permissive, mirrors ``set_agc``/``set_preamp``)
+#     rather than fabricate one. Closing evidence: a live X6200 CI-V capture
+#     of ``0x16 0x57`` GET/SET (NAK vs. ACK), or discovery of an actual DNF
+#     width register via a wfview/hamlib update or firmware doc revision.
 features = [
     "audio",
     "af_level",

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1519,9 +1519,16 @@ class TestNotchWidthDomain:
     """'notch' is a broader capability than manual notch WIDTH — a radio
     can have auto-notch with no manual-notch-width command at all (IC-705
     has no CI-V 0x16 0x57 mapping yet still declares width_values "for UI
-    parity"; X6100/X6200 have neither the mapping nor a width domain). So,
-    unlike ssb_tx_bw/filter_shape below, this is NOT a strict
-    capability-implies-domain invariant — just direct regression pins."""
+    parity"; X6100/X6200/FTX-1/TX-500 have neither the mapping nor a width
+    domain). So, unlike ssb_tx_bw/filter_shape below, this is NOT a strict
+    capability-implies-domain invariant — just direct regression pins.
+
+    MOR-1551 audited the four profiles below (none had a ``[notch]
+    width_values`` domain) against in-repo sources and found no trustworthy
+    evidence of an actual manual-notch WIDTH control on any of them — see
+    the per-profile ``[capabilities]`` comments in each ``.toml`` for the
+    full provenance. This class pins that "undeclared" is the correct,
+    audited state, not an oversight."""
 
     def test_ic7610_family_declares_wide_mid_nar(self):
         for name in ("ic705", "ic7300", "ic9700", "ic7610"):
@@ -1534,10 +1541,36 @@ class TestNotchWidthDomain:
             }, name
 
     def test_x6100_x6200_declare_notch_without_a_width_domain(self):
+        """X6200's own cat-audit (docs/validation/cat-audits/x6200.md lines
+        55/95/107) found no WIDE/MID/NAR-style width register anywhere in
+        the documented CI-V table — its real notch is a DNF toggle
+        (0x16 0x41) + center frequency (0x14 0x0D). X6100 has no hardware
+        to audit directly and leans on X6100/X6200 shared-firmware
+        inference (same basis as the existing break_in exception)."""
         for name in ("x6100", "x6200"):
             rig = load_rig(RIGS_DIR / f"{name}.toml")
             assert "notch" in rig.capabilities, name
             assert rig.notch_width_values is None, name
+
+    def test_ftx1_declares_notch_without_a_width_domain(self):
+        """FTX-1's manual notch is a Yaesu CAT BP00 (on/off) + BP01
+        (frequency index 0-255) pair — no separate WIDTH register is
+        documented in wfview's FTX-1.rig or the Yaesu FT-X1 CAT manual.
+        YaesuCatRadio.set_manual_notch_width/get_manual_notch_width also
+        raise NotImplementedError unconditionally, so this control is not
+        wire-reachable on this backend regardless of the TOML domain."""
+        rig = load_rig(RIGS_DIR / "ftx1.toml")
+        assert "notch" in rig.capabilities
+        assert rig.notch_width_values is None
+
+    def test_tx500_declares_notch_without_a_width_domain(self):
+        """TX-500's NT command is a single 0=OFF/1=Auto toggle per the
+        Lab599 CAT Protocol rev. 2 (docs/validation/cat-audits/tx500.md
+        line 37) — auto-notch only, no manual notch and therefore no width
+        parameter documented anywhere in the protocol doc."""
+        rig = load_rig(RIGS_DIR / "tx500.toml")
+        assert "notch" in rig.capabilities
+        assert rig.notch_width_values is None
 
 
 class TestSsbTxBwDomainDeclaredOrCapabilityAbsent:


### PR DESCRIPTION
Closes MOR-1551

## Summary

`ftx1`, `tx500`, `x6100`, `x6200` declare the `notch` capability with no `[notch] width_values` domain. After MOR-1542's builder-bound loosening (`set_manual_notch_width` accepts a raw 0-99 BCD value with domain validation left to the profile), an unvalidated `[notch] width_values` on a CI-V profile means whatever value a caller passes BCD-encodes straight to the wire.

This PR audits all four profiles against in-repo sources ONLY (cat-audits, wfview references, backend implementations — no invented data) to see whether a trustworthy WIDTH domain exists. **Conclusion: none of the four have one.** This is a documentation-only PR — no domain gets declared for any profile, and no runtime behavior changes. Each profile gets a provenance comment recording what was checked and what would close the gap, plus per-profile regression pins in `tests/test_rig_loader.py::TestNotchWidthDomain`.

## Per-profile provenance

| Profile | Verdict | Evidence |
|---|---|---|
| **ftx1** (Yaesu) | No width control exists | Manual notch is a Yaesu CAT `BP` pair: `BP00` (on/off) + `BP01` (frequency index 0-255) — no separate width register in wfview's `FTX-1.rig` or the Yaesu FT-X1 CAT manual. Independently, `YaesuCatRadio.set_manual_notch_width`/`get_manual_notch_width` (`src/rigplane/backends/yaesu_cat/radio.py`) already raise `NotImplementedError` unconditionally, so this control is not wire-reachable regardless of the TOML domain. Capability tag kept — it still covers auto-notch + manual-notch on/off + notch frequency, which are real. |
| **tx500** (Lab599) | No manual notch at all | `NT` is a single `0=OFF`/`1=Auto` toggle per the Lab599 CAT Protocol rev. 2 (`docs/validation/cat-audits/tx500.md` line 37) — auto-notch-only, the legitimate case the MOR-1551 invariant explicitly excludes. TX-500 also has no backend yet, so nothing here is runtime-reachable today either way. |
| **x6200** (Xiegu) | No width register documented; existing routing bug (out of scope) | `docs/validation/cat-audits/x6200.md` (lines 55/95/107) shows the `notch` cap currently mis-routes to Icom's `set_manual_notch` (`0x16 0x48`), which is **also not** in the X6200's documented CI-V table. The X6200's real notch mechanism is a DNF on/off toggle (`0x16 0x41`) + center frequency (`0x14 0x0D`, confirmed-correct opcode). Neither the Radioddity PDF nor Hamlib's `x6100_priv_caps` document a WIDE/MID/NAR-style width register for this radio at all. (The mis-routing itself is a pre-existing, already-documented finding — not addressed here, out of scope for a width-domain ticket.) |
| **x6100** (Xiegu) | No hardware/audit; inference from x6100/x6200 shared firmware | No X6100 cat-audit exists (no hardware to capture). Leans on the same shared-firmware inference already used for `break_in` in `x6100.toml`: since X6200's own audit found no width register, inferring an X6100 domain from X6200 data would compound one unconfirmed guess on top of another — so none is fabricated. |

## Changes

- `rigs/ftx1.toml`, `rigs/tx500.toml`, `rigs/x6100.toml`, `rigs/x6200.toml`: provenance comments in `[capabilities]`, no `[notch]` section added, no behavior change.
- `tests/test_rig_loader.py`: `TestNotchWidthDomain` extended with dedicated pins for `ftx1` and `tx500` (previously only `x6100`/`x6200` were pinned), each asserting `notch` capability present + `notch_width_values is None`, with the audit rationale in the docstring.

## Test plan

- [x] `uv run pytest tests/test_rig_loader.py tests/test_ftx1_audio.py tests/test_ftx1_radio.py tests/test_x6200_rx_audio_mor236.py -q` — 512 passed, 1 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken