### PR TITLE
fix: thread receiver through the set_notch_filter write path

### DIFF
--- a/docs/api/command-catalog.md
+++ b/docs/api/command-catalog.md
@@ -106,7 +106,7 @@ Use `set_freq` directly for bands that have no `bsrCode` in capabilities.
 | `set_nb_width` | `level: int`, `receiver?: int=0` | `nb` | Yes | |
 | `set_auto_notch` | `on?: bool=false`, `receiver?: int=0` | `notch` | Yes | |
 | `set_manual_notch` | `on?: bool=false`, `receiver?: int=0` | `notch` | Yes | |
-| `set_notch_filter` | `value: int` | `notch` | Yes | No `receiver` param. |
+| `set_notch_filter` | `value: int`, `receiver?: int=0` | `notch` | Yes | |
 | `set_manual_notch_width` | `value: int`, `receiver?: int=0` | `notch` | Yes | |
 | `set_digisel` | `on?: bool=false`, `receiver?: int=0` | `digisel` | Yes | IC-7610 DIGI-SEL on/off. |
 | `set_digisel_shift` | `level: int`, `receiver?: int=0` | `digisel` | Yes | |

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -301,6 +301,7 @@ class SetManualNotch:
 @dataclass(frozen=True, slots=True)
 class SetNotchFilter:
     level: int
+    receiver: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -2064,9 +2064,11 @@ class ControlHandler:
                 return {"on": on, "receiver": rx}
             case "set_notch_filter":
                 level = int(params["value"])
+                rx = int(params.get("receiver", 0))
                 self._ensure_capability("notch", "set_notch_filter")
-                q.put(SetNotchFilter(level))
-                return {"value": level}
+                self._ensure_receiver_supported(rx)
+                q.put(SetNotchFilter(level, receiver=rx))
+                return {"value": level, "receiver": rx}
             case "set_manual_notch_width":
                 value = int(params["value"])
                 rx = int(params.get("receiver", 0))

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2358,10 +2358,11 @@ class RadioPoller:
             case SetManualNotch(on=on, receiver=rx):
                 # manual_notch read-after-write via overlays + 0x16 0x48 observation.
                 await _r.set_manual_notch(on, receiver=rx)
-            case SetNotchFilter(level=level):
-                await _r.set_notch_filter(level)
-                if self._radio_state:
-                    self._radio_state.notch_filter = level
+            case SetNotchFilter(level=level, receiver=rx):
+                # notch_filter read-after-write via overlays + 0x14 0x0D
+                # observation (receiver-scoped since MOR-1548); the legacy
+                # global-scalar mirror write is gone with it.
+                await _r.set_notch_filter(level, receiver=rx)
             case SetAgcTimeConstant(value=value, receiver=rx):
                 # agc_time_constant read-after-write via overlays + 0x1A 0x04
                 # StateStore observation (MOR-437).

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -483,10 +483,10 @@ def _scope_frame() -> ScopeFrame:
         ),
         (
             "set_notch_filter",
-            {"value": 91},
+            {"value": 91, "receiver": 1},
             SetNotchFilter,
-            {"level": 91},
-            {"value": 91},
+            {"level": 91, "receiver": 1},
+            {"value": 91, "receiver": 1},
         ),
         (
             "set_digisel",

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3744,8 +3744,12 @@ class TestSwitchScopeReceiver:
         assert poller._radio_state is not None
         assert poller._radio_state.main.manual_notch is False  # no legacy mirror write
 
-    async def test_set_notch_filter_updates_radio_and_state(self) -> None:
-        """SetNotchFilter(level) calls radio.set_notch_filter and updates RadioState.notch_filter."""
+    async def test_set_notch_filter_sends_wire_without_legacy_mirror(self) -> None:
+        """SetNotchFilter threads receiver; notch_filter is observation-backed (0x14 0x0D).
+
+        The legacy global-scalar mirror write was removed alongside the
+        MOR-1548 receiver-scoped readback reclassification.
+        """
         from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetNotchFilter
 
         radio = self._make_radio()
@@ -3754,13 +3758,13 @@ class TestSwitchScopeReceiver:
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
 
         poller.start()
-        queue.put(SetNotchFilter(91))
+        queue.put(SetNotchFilter(91, receiver=1))
         await asyncio.sleep(0.03)
         poller.stop()
 
-        radio.set_notch_filter.assert_awaited_once_with(91)
+        radio.set_notch_filter.assert_awaited_once_with(91, receiver=1)
         assert poller._radio_state is not None
-        assert poller._radio_state.notch_filter == 91
+        assert poller._radio_state.notch_filter == 0  # no legacy mirror write
 
     async def test_set_agc_time_constant_sends_wire_without_legacy_mirror(self) -> None:
         """SetAgcTimeConstant sends the wire command; agc_time_constant is observation-backed (0x1A 0x04).


### PR DESCRIPTION
## Summary

Write-path counterpart of MOR-1548 (#2466, read path). `SetNotchFilter` carried no `receiver` field, so:

- `web/handlers/control.py`'s `set_notch_filter` case read only `params["value"]` and silently dropped the `receiver` the frontend already sends (`radio-intents.ts` registers `{ value, receiver }`, `panel-commands.ts` dispatches both);
- `web/radio_poller.py` always called `await _r.set_notch_filter(level)`, so `IcomRadio.set_notch_filter(..., receiver=RECEIVER_MAIN)` always defaulted to MAIN.

On a dual-RX radio (IC-7610-class), adjusting SUB's notch filter always moved MAIN's.

## Fix (sibling pattern: `SetManualNotch` / `SetAgcTimeConstant`)

- `runtime/_poller_types.py`: `SetNotchFilter` gains `receiver: int = 0`
- `web/handlers/control.py`: reads `params["receiver"]`, calls `_ensure_receiver_supported(rx)`, threads it through and echoes it in the result
- `web/radio_poller.py`: `await _r.set_notch_filter(level, receiver=rx)`; the legacy global-scalar `RadioState.notch_filter` mirror write is removed — notch_filter is observation-backed (0x14 0x0D; receiver-scoped read path lands with MOR-1548 #2466), matching the MOR-437 sibling comment pattern

Yaesu (`backends/yaesu_cat/poller.py`) keeps its own dispatch unchanged — FTX-1 is single-RX and that file's DSP arms consistently omit `receiver`; the defaulted field keeps its pattern match valid. `yaesu_cat/radio.py`'s cross-vendor alias already accepts and forwards `receiver`.

File-disjoint from #2466; no merge ordering required.

## Tests

- `tests/test_web_server.py`: dispatch test now asserts `set_notch_filter(91, receiver=1)` and no legacy mirror write (modeled on the AGC sibling test)
- `tests/test_handlers_coverage.py`: parametrized handler case now covers `receiver: 1` threading and echo

## Verification

- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9572 passed, 13 skipped, 14 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — clean; format clean
- `uv run mypy src/` — 13 errors, byte-identical to baseline (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)