### PR TITLE
fix: abort startup when a declared listener cannot bind (MOR-1437)

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1683,18 +1683,26 @@ def _find_port_pid(port: int) -> str | None:
         return None
 
 
-def check_ports_available(ports: list[int]) -> None:
-    """Check that each port can be bound; raise RuntimeError with details if not.
+def check_ports_available(bindings: list[tuple[str, int]]) -> None:
+    """Check that each (host, port) binding can be bound; raise RuntimeError if not.
 
     Args:
-        ports: List of TCP port numbers to check.
+        bindings: List of (host, port) pairs to probe. The probed host MUST
+            match the host the real listener will bind to — on some
+            platforms a wildcard ("0.0.0.0") probe with SO_REUSEADDR can
+            false-negative (bind succeeds) against an orphan already bound
+            to a specific interface such as "127.0.0.1", and vice versa
+            (MOR-1437 review, measured on macOS). When a listener's real
+            bind host can vary by mode, probe every host it could use — a
+            hit on any one aborts.
 
     Raises:
-        RuntimeError: If any port is already in use, with PID info when available.
+        RuntimeError: If any binding is already in use, with PID info when
+            available.
     """
     import socket as _sock
 
-    for port in ports:
+    for host, port in bindings:
         with _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM) as s:
             # Allow binding even if port is in TIME_WAIT from a recent shutdown.
             # Only fail if another process is actively listening.
@@ -1702,12 +1710,13 @@ def check_ports_available(ports: list[int]) -> None:
             if hasattr(_sock, "SO_REUSEPORT"):
                 s.setsockopt(_sock.SOL_SOCKET, _sock.SO_REUSEPORT, 1)
             try:
-                s.bind(("", port))
+                s.bind((host, port))
             except OSError:
                 pid = _find_port_pid(port)
                 pid_info = f" (PID {pid})" if pid else ""
+                host_label = host or "0.0.0.0"
                 raise RuntimeError(
-                    f"Port {port} already in use{pid_info}. "
+                    f"Port {port} already in use{pid_info} (bind host {host_label}). "
                     f"Run `lsof -i :{port}` to find the process holding it."
                 )
 
@@ -1884,20 +1893,30 @@ async def _run(args: argparse.Namespace) -> int:
     if args.command in ("web", "station"):
         # Declared listeners are checked before the radio connects (MOR-1437):
         # a bind failure here must abort before any serial/LAN session or
-        # poller starts. rigctld is included whenever it is enabled (the
-        # default) — `--no-rigctld` is the explicit opt-out that skips its
-        # port entirely.
-        ports_to_check = [args.web_port]
+        # poller starts. Each probe binds the SAME host the real listener
+        # will use — a host-mismatched probe can false-negative on some
+        # platforms and let an orphan slip through undetected (see
+        # check_ports_available docstring). rigctld is included whenever it
+        # is enabled (the default) — `--no-rigctld` is the explicit opt-out
+        # for `web` that skips its port entirely (station has no such flag —
+        # rigctld is always on there; see _cmd_web). rigctld's real bind
+        # host depends on managed_runtime ("127.0.0.1" vs "0.0.0.0",
+        # mirroring _cmd_web's `rigctld_host`) — but an orphan could be
+        # squatting on either host regardless of this run's mode, so both
+        # are probed and a hit on either aborts.
+        bindings: list[tuple[str, int]] = [(args.web_host, args.web_port)]
         if getattr(args, "web_rigctld", False):
-            ports_to_check.append(getattr(args, "web_rigctld_port", 4532))
+            rigctld_port = getattr(args, "web_rigctld_port", 4532)
+            bindings.append(("0.0.0.0", rigctld_port))
+            bindings.append(("127.0.0.1", rigctld_port))
         try:
-            check_ports_available(ports_to_check)
+            check_ports_available(bindings)
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
     elif args.command == "serve":
         try:
-            check_ports_available([args.serve_port])
+            check_ports_available([(args.serve_host, args.serve_port)])
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
@@ -3785,8 +3804,18 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
     # Start rigctld if requested. MOR-1437: any bind failure (including a
     # busy port — the common orphaned-instance case) aborts startup rather
     # than degrading silently, since starting anyway risks serial
-    # multiple-access with whatever already holds the port. `--no-rigctld`
-    # remains the explicit opt-out.
+    # multiple-access with whatever already holds the port. `web` has the
+    # explicit `--no-rigctld` opt-out; `station` does not — it always runs
+    # rigctld (see `_apply_managed_runtime_defaults`), so its only lever is
+    # relocating the port with `--rigctld-port` or stopping the other
+    # process (a `--no-rigctld` for `station` is a scope decision for a
+    # follow-up, not added here).
+    rigctld_opt_out_hint = (
+        "station has no --no-rigctld opt-out; relocate the port with "
+        "--rigctld-port, or stop the other process"
+        if getattr(args, "command", None) == "station"
+        else "pass --no-rigctld to disable the embedded server"
+    )
     rigctld_server = None
     rigctld_addr: str | None = None
     if getattr(args, "web_rigctld", False):
@@ -3824,12 +3853,12 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
                     "rigctld failed to bind %s:%d: %s "
                     "(another rigctld — likely an orphaned rigplane instance — "
                     "is probably already running; run `lsof -i :%d` to find it, "
-                    "or pass --no-rigctld to disable the embedded server). "
-                    "Startup aborted.",
+                    "or %s). Startup aborted.",
                     rigctld_host,
                     rigctld_port,
                     exc,
                     rigctld_port,
+                    rigctld_opt_out_hint,
                 )
             else:
                 logger.error(

--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1706,7 +1706,10 @@ def check_ports_available(ports: list[int]) -> None:
             except OSError:
                 pid = _find_port_pid(port)
                 pid_info = f" (PID {pid})" if pid else ""
-                raise RuntimeError(f"Port {port} already in use{pid_info}")
+                raise RuntimeError(
+                    f"Port {port} already in use{pid_info}. "
+                    f"Run `lsof -i :{port}` to find the process holding it."
+                )
 
 
 async def _build_backend_config(
@@ -1879,10 +1882,16 @@ async def _run(args: argparse.Namespace) -> int:
     radio = create_radio(config)
 
     if args.command in ("web", "station"):
-        # Only the web port is required. rigctld is best-effort: if its port
-        # is busy we log a warning and continue (handled in _cmd_web).
+        # Declared listeners are checked before the radio connects (MOR-1437):
+        # a bind failure here must abort before any serial/LAN session or
+        # poller starts. rigctld is included whenever it is enabled (the
+        # default) — `--no-rigctld` is the explicit opt-out that skips its
+        # port entirely.
+        ports_to_check = [args.web_port]
+        if getattr(args, "web_rigctld", False):
+            ports_to_check.append(getattr(args, "web_rigctld_port", 4532))
         try:
-            check_ports_available([args.web_port])
+            check_ports_available(ports_to_check)
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
@@ -3773,8 +3782,11 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
     if bridge_device is None:
         loopback_hint = _detect_loopback_hint()
 
-    # Start rigctld if requested. Failure (e.g. port already in use) is
-    # logged as a warning and skipped — the web server keeps serving.
+    # Start rigctld if requested. MOR-1437: any bind failure (including a
+    # busy port — the common orphaned-instance case) aborts startup rather
+    # than degrading silently, since starting anyway risks serial
+    # multiple-access with whatever already holds the port. `--no-rigctld`
+    # remains the explicit opt-out.
     rigctld_server = None
     rigctld_addr: str | None = None
     if getattr(args, "web_rigctld", False):
@@ -3800,30 +3812,33 @@ async def _cmd_web(radio: Radio, args: argparse.Namespace) -> int:
         try:
             await candidate.start()
         except OSError as exc:
-            # Only port-busy (EADDRINUSE) is treated as graceful degrade —
-            # another rigctld is likely already running. Other errno values
-            # (EACCES on privileged ports, EMFILE on fd exhaustion,
-            # ENETUNREACH, etc.) indicate a misconfigured environment and
-            # must surface so the operator can fix it.
+            # MOR-1437: every declared-listener bind failure aborts startup —
+            # a busy port most often means an orphaned rigplane instance is
+            # already holding the radio session, and starting anyway risks
+            # serial multiple-access. EACCES (privileged ports), EMFILE (fd
+            # exhaustion), etc. are equally a misconfigured environment that
+            # must surface, not be masked.
+            server._runtime_last_error = f"rigctld bind failed: {exc}"
             if exc.errno == errno.EADDRINUSE:
-                server._runtime_last_error = f"rigctld bind failed: {exc}"
-                logger.warning(
-                    "rigctld disabled: failed to bind %s:%d: %s "
-                    "(another rigctld may already be running; pass --no-rigctld to silence)",
+                logger.error(
+                    "rigctld failed to bind %s:%d: %s "
+                    "(another rigctld — likely an orphaned rigplane instance — "
+                    "is probably already running; run `lsof -i :%d` to find it, "
+                    "or pass --no-rigctld to disable the embedded server). "
+                    "Startup aborted.",
                     rigctld_host,
                     rigctld_port,
                     exc,
+                    rigctld_port,
                 )
-                rigctld_server = None
             else:
-                server._runtime_last_error = f"rigctld bind failed: {exc}"
                 logger.error(
                     "rigctld failed to start on port %d: %s (errno=%s)",
                     rigctld_port,
                     exc,
                     exc.errno,
                 )
-                raise
+            raise
         else:
             rigctld_server = candidate
             rigctld_addr = f"{rigctld_host}:{rigctld_port}"

--- a/src/rigplane/web/discovery.py
+++ b/src/rigplane/web/discovery.py
@@ -160,6 +160,14 @@ class DiscoveryResponder:
                 self._discovery_port,
             )
         except OSError as exc:
+            # MOR-1437 disposition: unlike rigctld (an exclusive TCP listener
+            # guarding the single serial/LAN radio session), this UDP socket
+            # opts into SO_REUSEPORT (`_reuse_port_supported()`) precisely so
+            # multiple co-located rigplane instances can each announce their
+            # own radio on the shared discovery port. A bind failure here is
+            # not a reliable signal of a duplicate process holding the radio
+            # the way a rigctld EADDRINUSE is, so it stays best-effort: warn
+            # and continue without discovery rather than aborting startup.
             logger.warning(
                 "discovery: failed to bind %s:%d — %s (discovery disabled)",
                 self._bind_host,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1611,7 +1611,7 @@ class TestCheckPortsAvailable:
             s.bind(("", 0))
             port = s.getsockname()[1]
         # Port is free now — should not raise.
-        check_ports_available([port])
+        check_ports_available([("", port)])
 
     def test_occupied_port_raises_runtime_error(self):
         import socket
@@ -1624,7 +1624,7 @@ class TestCheckPortsAvailable:
             with pytest.raises(
                 RuntimeError, match=f"Port {occupied_port} already in use"
             ):
-                check_ports_available([occupied_port])
+                check_ports_available([("", occupied_port)])
 
     def test_error_message_includes_port_number(self):
         import socket
@@ -1635,7 +1635,7 @@ class TestCheckPortsAvailable:
             s.listen(1)
             port = s.getsockname()[1]
             try:
-                check_ports_available([port])
+                check_ports_available([("", port)])
             except RuntimeError as exc:
                 assert str(port) in str(exc)
             else:
@@ -1654,8 +1654,26 @@ class TestCheckPortsAvailable:
             s.listen(1)
             port = s.getsockname()[1]
             with pytest.raises(RuntimeError, match="lsof") as exc_info:
-                check_ports_available([port])
+                check_ports_available([("", port)])
             assert f"lsof -i :{port}" in str(exc_info.value)
+
+    def test_host_mismatched_probe_does_not_false_negative(self):
+        """MOR-1437 R1: a probe must bind the SAME host as the real orphan,
+        or a wildcard probe can succeed over a loopback-bound listener
+        (measured on macOS) — the wildcard-vs-127.0.0.1 case that let a
+        station instance connect to the radio in the pre-fix code.
+        """
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", 0))
+            s.listen(1)
+            port = s.getsockname()[1]
+
+            # Host-matched probe correctly detects the conflict.
+            with pytest.raises(RuntimeError, match=f"Port {port} already in use"):
+                check_ports_available([("127.0.0.1", port)])
 
     def test_web_command_preflight_blocks_on_occupied_port(self, capsys):
         """_run() exits 1 with error before connecting to radio when port is occupied."""
@@ -1785,3 +1803,63 @@ class TestCheckPortsAvailable:
         assert result == 0
         mock_radio.__aenter__.assert_called_once()
         cmd_web.assert_awaited_once_with(mock_radio, args)
+
+    def test_station_preflight_blocks_on_occupied_rigctld_port_at_managed_host(
+        self, capsys
+    ):
+        """MOR-1437 R1: station always runs managed (web_host forced to
+        127.0.0.1, rigctld always on, no --no-rigctld opt-out) — the real
+        rigctld listener binds 127.0.0.1 in this mode (see _cmd_web's
+        ``rigctld_host``). A wildcard-only preflight probe can
+        false-negative against an orphan already bound to 127.0.0.1 (macOS
+        SO_REUSEADDR quirk), letting the radio connect anyway — exactly the
+        serial multiple-access window this ticket exists to close. The
+        preflight must probe the host the real listener will actually use
+        (and the other host too, since an orphan could be on either).
+        """
+        import asyncio
+        import socket
+
+        from rigplane.cli import _run
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as free_probe:
+            free_probe.bind(("127.0.0.1", 0))
+            free_web_port = free_probe.getsockname()[1]
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", 0))
+            s.listen(1)
+            occupied_rigctld_port = s.getsockname()[1]
+
+            args = _build_parser().parse_args(
+                [
+                    "--host",
+                    "1.2.3.4",
+                    "station",
+                    "--port",
+                    str(free_web_port),
+                    "--rigctld-port",
+                    str(occupied_rigctld_port),
+                    # Sidestep the unrelated managed-mode auth requirement so
+                    # this test isolates the preflight/port-check path.
+                    "--auth-token",
+                    "test-token",
+                ]
+            )
+            assert args.web_host == "127.0.0.1"
+            assert args.web_rigctld is True
+
+            mock_radio = MagicMock()
+            mock_radio.__aenter__ = AsyncMock(return_value=mock_radio)
+            mock_radio.__aexit__ = AsyncMock(return_value=False)
+            with patch("rigplane.cli.create_radio", return_value=mock_radio):
+                result = asyncio.run(_run(args))
+
+        # No serial/LAN session and no pollers — radio never connected.
+        mock_radio.__aenter__.assert_not_called()
+        mock_radio.__aexit__.assert_not_called()
+        assert result == 1
+        captured = capsys.readouterr()
+        assert str(occupied_rigctld_port) in captured.err
+        assert "lsof" in captured.err.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1333,9 +1333,14 @@ class TestWebRigctldDefault:
         out = capsys.readouterr().out
         assert "rigctld:" not in out
 
-    async def test_cli_web_rigctld_port_busy_graceful(self, caplog, capsys):
-        """EADDRINUSE on rigctld logs warning and continues serving the web."""
-        import asyncio
+    async def test_cli_web_rigctld_port_busy_aborts_startup(self, caplog):
+        """MOR-1437: EADDRINUSE on rigctld aborts startup — no silent degrade.
+
+        A busy rigctld port most often means an orphaned rigplane instance is
+        already holding the radio session; starting anyway risks serial
+        multiple-access. The owner ruling is that the application must NOT
+        start in this case (``--no-rigctld`` remains the explicit opt-out).
+        """
         import errno
         import logging
 
@@ -1354,12 +1359,12 @@ class TestWebRigctldDefault:
             async def stop(self):  # pragma: no cover - never called
                 pass
 
-        class FakeWebServer:
+        class FakeWebServer:  # pragma: no cover - web must not start
             def __init__(self, _radio, _cfg):
                 pass
 
             async def serve_forever(self):
-                raise asyncio.CancelledError
+                raise AssertionError("web must not start when rigctld fails hard")
 
         p = _build_parser()
         args = p.parse_args(["--host", "1.2.3.4", "web"])
@@ -1367,21 +1372,22 @@ class TestWebRigctldDefault:
         with (
             patch("rigplane.web.server.WebServer", FakeWebServer),
             patch("rigplane.rigctld.server.RigctldServer", BusyRigctldServer),
-            caplog.at_level(logging.WARNING, logger="rigplane.cli"),
+            caplog.at_level(logging.ERROR, logger="rigplane.cli"),
         ):
-            rc = await _cmd_web(radio, args)
+            with pytest.raises(OSError) as exc_info:
+                await _cmd_web(radio, args)
 
-        assert rc == 0, "web must keep running even if rigctld port is busy"
-        # Warning must mention the port and surface the problem.
+        assert exc_info.value.errno == errno.EADDRINUSE
+        # ERROR-level log must name the remedy — lsof and --no-rigctld.
+        messages = [
+            rec.message for rec in caplog.records if rec.levelno >= logging.ERROR
+        ]
         assert any(
-            "rigctld" in rec.message.lower() and "4532" in rec.message
-            for rec in caplog.records
-        ), (
-            f"expected rigctld port-busy warning, got {[r.message for r in caplog.records]}"
-        )
-        out = capsys.readouterr().out
-        assert "rigctld:" not in out, (
-            "banner must not advertise rigctld when bind failed"
+            "rigctld" in msg.lower() and "4532" in msg and "lsof" in msg.lower()
+            for msg in messages
+        ), f"expected actionable ERROR log naming lsof remedy, got {messages}"
+        assert any("--no-rigctld" in msg for msg in messages), (
+            f"expected the --no-rigctld opt-out to be named, got {messages}"
         )
 
     async def test_cli_web_rigctld_eacces_surfaces(self, caplog):
@@ -1638,6 +1644,19 @@ class TestCheckPortsAvailable:
     def test_empty_list_does_not_raise(self):
         check_ports_available([])
 
+    def test_error_message_names_lsof_remedy(self):
+        """MOR-1437: the bind-failure message must be actionable."""
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("", 0))
+            s.listen(1)
+            port = s.getsockname()[1]
+            with pytest.raises(RuntimeError, match="lsof") as exc_info:
+                check_ports_available([port])
+            assert f"lsof -i :{port}" in str(exc_info.value)
+
     def test_web_command_preflight_blocks_on_occupied_port(self, capsys):
         """_run() exits 1 with error before connecting to radio when port is occupied."""
         import asyncio
@@ -1672,3 +1691,97 @@ class TestCheckPortsAvailable:
         assert result == 1
         captured = capsys.readouterr()
         assert str(occupied_port) in captured.err
+
+    def test_rigctld_preflight_blocks_on_occupied_port_default_flags(self, capsys):
+        """MOR-1437: occupied rigctld port + default flags aborts before the
+        radio connects — no serial open, no pollers, actionable error naming
+        the lsof remedy.
+        """
+        import asyncio
+        import socket
+
+        from rigplane.cli import _run
+
+        # A free web port (released before use — same pattern as the
+        # existing web-port preflight test above).
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as free_probe:
+            free_probe.bind(("", 0))
+            free_web_port = free_probe.getsockname()[1]
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("", 0))
+            s.listen(1)
+            occupied_rigctld_port = s.getsockname()[1]
+
+            args = _build_parser().parse_args(
+                [
+                    "--host",
+                    "1.2.3.4",
+                    "web",
+                    "--port",
+                    str(free_web_port),
+                    "--rigctld-port",
+                    str(occupied_rigctld_port),
+                ]
+            )
+
+            mock_radio = MagicMock()
+            mock_radio.__aenter__ = AsyncMock(return_value=mock_radio)
+            mock_radio.__aexit__ = AsyncMock(return_value=False)
+            with patch("rigplane.cli.create_radio", return_value=mock_radio):
+                result = asyncio.run(_run(args))
+
+        # No serial/LAN session and no pollers — radio never connected.
+        mock_radio.__aenter__.assert_not_called()
+        mock_radio.__aexit__.assert_not_called()
+        assert result == 1
+        captured = capsys.readouterr()
+        assert str(occupied_rigctld_port) in captured.err
+        assert "lsof" in captured.err.lower()
+
+    def test_no_rigctld_flag_skips_busy_rigctld_port_preflight(self):
+        """MOR-1437: --no-rigctld opts out of the rigctld port check entirely —
+        a busy rigctld port must not block a clean web-only start.
+        """
+        import asyncio
+        import socket
+
+        from rigplane.cli import _run
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as free_probe:
+            free_probe.bind(("", 0))
+            free_web_port = free_probe.getsockname()[1]
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("", 0))
+            s.listen(1)
+            busy_rigctld_port = s.getsockname()[1]
+
+            args = _build_parser().parse_args(
+                [
+                    "--host",
+                    "1.2.3.4",
+                    "web",
+                    "--no-rigctld",
+                    "--port",
+                    str(free_web_port),
+                    "--rigctld-port",
+                    str(busy_rigctld_port),
+                ]
+            )
+
+            mock_radio = MagicMock()
+            mock_radio.__aenter__ = AsyncMock(return_value=mock_radio)
+            mock_radio.__aexit__ = AsyncMock(return_value=False)
+            with (
+                patch("rigplane.cli.create_radio", return_value=mock_radio),
+                patch("rigplane.cli._cmd_web", new_callable=AsyncMock) as cmd_web,
+            ):
+                cmd_web.return_value = 0
+                result = asyncio.run(_run(args))
+
+        assert result == 0
+        mock_radio.__aenter__.assert_called_once()
+        cmd_web.assert_awaited_once_with(mock_radio, args)

--- a/tests/test_discovery_responder.py
+++ b/tests/test_discovery_responder.py
@@ -91,6 +91,39 @@ class TestDiscoveryResponder:
 
         assert calls[0]["reuse_port"] is False
 
+    async def test_start_bind_failure_degrades_gracefully_by_design(
+        self, monkeypatch, caplog
+    ) -> None:
+        """MOR-1437: a discovery bind failure does NOT abort startup — by design.
+
+        Unlike rigctld (an exclusive TCP listener guarding the single
+        serial/LAN radio session), this responder opts into SO_REUSEPORT
+        (see ``_reuse_port_supported()``) specifically so multiple
+        co-located rigplane instances can each announce their own radio on
+        the shared discovery port. A bind failure here is therefore not a
+        reliable signal of a duplicate process holding the radio the way an
+        rigctld EADDRINUSE is, so it stays best-effort: log a warning and
+        continue without discovery, rather than aborting the whole server.
+        """
+        import logging
+
+        class FailingLoop:
+            async def create_datagram_endpoint(self, _factory, **_kwargs: object):
+                raise OSError(48, "Address already in use")
+
+        monkeypatch.setattr(asyncio, "get_running_loop", lambda: FailingLoop())
+        responder = DiscoveryResponder(web_port=8080, discovery_port=8470)
+
+        with caplog.at_level(logging.WARNING, logger="rigplane.web.discovery"):
+            await responder.start()  # must not raise
+
+        assert any(
+            "discovery" in rec.message.lower() and "disabled" in rec.message.lower()
+            for rec in caplog.records
+        ), (
+            f"expected a graceful-degrade warning, got {[r.message for r in caplog.records]}"
+        )
+
     async def test_valid_request_returns_json(
         self, responder: DiscoveryResponder
     ) -> None:


### PR DESCRIPTION
## Summary

A busy rigctld port (`[Errno 48] Address already in use`) previously logged a WARNING and let the web server start anyway. Per owner ruling, this degraded start masks a second orphaned instance and risks serial multiple-access — the application must not start in that case.

- `check_ports_available()` (used by `web`/`station` startup, in `_run()`) now also checks the rigctld port whenever it's enabled, **before the radio connects** — a bind conflict there aborts before any serial/LAN session or poller starts. `web` has the explicit `--no-rigctld` opt-out that skips the check entirely; `station` has no such flag (rigctld is unconditionally on there — see R1 below). The error message now names the `lsof -i :<port>` remedy.
- `_cmd_web()`'s rigctld `OSError` handler no longer treats `EADDRINUSE` as a graceful degrade (defense-in-depth for the TOCTOU race between preflight and actual bind) — every bind failure now raises and aborts startup, with an ERROR log naming the remedy.
- Verified the web port already fails hard via the pre-existing `_run()` preflight check; pinned it with a regression test.
- Investigated the UDP discovery responder's bind-failure handling: it deliberately opts into `SO_REUSEPORT` so multiple co-located rigplane instances can each announce their own radio on the shared discovery port. A bind failure there is therefore not a reliable multi-instance signal the way rigctld's `EADDRINUSE` is (rigctld does *not* use `SO_REUSEPORT` — its bind is exclusive by design). Left the graceful degrade in place, documented the rationale in a comment, and pinned current behavior with a test.

TDD red-first: the rewritten/added assertions were run against the pre-fix code and confirmed failing before the production changes landed.

## R1: independent review findings (applied)

An independent reviewer ruled BLOCKED on the first version of this PR (head `37b7588b`) and confirmed the web-port path and the discovery disposition were clean. Two blocking findings on the rigctld preflight, plus two lower-severity notes:

**F1 — preflight probe host mismatch.** The preflight probed the wildcard address (`""`, i.e. `0.0.0.0`) regardless of which host the real rigctld listener would use. `station` always forces `managed_runtime = True`, and `_cmd_web` binds rigctld to `127.0.0.1` whenever `managed_runtime` is set — so a wildcard probe was checking the wrong interface for `station`. Measured on the bench platform (macOS), binding a wildcard socket with `SO_REUSEADDR`(+`SO_REUSEPORT`) over a port already held by a specific-interface listener **succeeds** (false negative):

| Orphan already bound to | Probe binds | Result |
|---|---|---|
| `127.0.0.1` | `0.0.0.0` (wildcard) | **PASS — bind succeeds (false negative)** |
| `127.0.0.1` | `127.0.0.1` | RAISE `OSError(48, Address already in use)` — correct |
| `0.0.0.0` | `127.0.0.1` | **PASS — bind succeeds (false negative)** |
| `0.0.0.0` | `0.0.0.0` (wildcard) | RAISE `OSError(48, ...)` — correct |

End-to-end, this meant: `station` + an rigctld port already held on `127.0.0.1` → `_run()` returned `rc=0` and `radio.__aenter__` was **called** — the exact serial multiple-access window this ticket exists to close, reproduced on the bench platform. A red-first regression test (`test_station_preflight_blocks_on_occupied_rigctld_port_at_managed_host`) confirmed this against the pre-fix code before the fix landed (see below).

**F2 — mixed-host orphans (subsumes F1's probing half).** The table above shows the failure is symmetric: whichever single host the probe uses, an orphan on the *other* host is invisible to it. Two real rigctld processes on different hosts (one `0.0.0.0`, one later trying `127.0.0.1`, or vice versa) can each successfully bind — no abort, two rigctlds live at once.

*Fix (shared delta for F1+F2):* `check_ports_available()` is now host-aware — it takes `(host, port)` bindings instead of bare ports, and binds the *same* host per pair (kept `SO_REUSEADDR`; the TIME_WAIT rationale was sound and host-matched probing still detects correctly with it). `_run()` now probes `args.web_host` for the web port (the exact host `_cmd_web` hands to `WebConfig`) and probes **both** `"0.0.0.0"` and `"127.0.0.1"` for the rigctld port — a hit on either aborts, regardless of this run's `managed_runtime` mode. `_cmd_serve()`'s preflight now probes `args.serve_host` instead of the wildcard too, for consistency.

**F3 — inaccurate `--no-rigctld` claim.** The original PR body and in-code comments claimed `--no-rigctld` is "the explicit opt-out" without qualification. `station`'s argparse subparser has no `--no-rigctld` — only `--rigctld` (`store_true`, normalized to `True` by `_apply_managed_runtime_defaults`) and `--rigctld-port`. Corrected the comments and the rigctld-bind-failure log message to be command-aware: for `station` it now names the real levers (relocate the port with `--rigctld-port`, or stop the other process) instead of suggesting a flag that doesn't exist. Whether `station` should gain its own `--no-rigctld` is a scope decision left for a follow-up — not added here.

**F4 — late-abort leaves the audio bridge running (noted, not fixed).** If `--bridge` was already started before rigctld's bind attempt and rigctld then aborts, the exception propagates out of `_cmd_web` without the `WebServer` instance's `stop()` ever running, so an already-started audio bridge is not torn down before process exit. This is a pre-existing shape — the `EACCES`/`EMFILE` hard-fail paths had exactly the same gap since this code was written — it is simply newly *reachable* via `EADDRINUSE` now that the graceful degrade is gone. Named honestly here rather than silently fixed; a proper fix (e.g. wrapping the rigctld-start block so any raise tears down whatever `_cmd_web` already started) is its own change and out of scope for this ticket.

Red-first evidence for the R1 fix: ran `test_station_preflight_blocks_on_occupied_rigctld_port_at_managed_host` against pre-fix head `37b7588b` — `mock_radio.__aenter__.assert_not_called()` failed with `Called 1 times.`, confirming the false negative. After the fix (head `92fbd165`), the same test passes.

## Test plan

- [x] `uv run pytest tests/test_cli.py tests/test_cli_coverage.py tests/test_discovery_responder.py tests/test_rigctld_server.py tests/test_rigctld_server_coverage.py tests/test_rigctld_init_coverage.py tests/test_web_server.py tests/test_web_server_coverage.py -q` — 611 passed, 2 skipped
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run ruff format --check` on changed files — clean
- [x] `uv run lint-imports` — 5 kept, 0 broken
- [x] `uv run mypy src/rigplane/cli/__init__.py src/rigplane/web/discovery.py` — 2 pre-existing findings, both unrelated to this diff (verified identical against `origin/main`); no new findings

Closes MOR-1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
