### PR TITLE
fix: audio capture open runs off the event loop with bounded timeout (MOR-1438)

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -1499,6 +1499,7 @@ class FakeRxStream:
         *,
         device: int | None = None,
         exclusive: dict[int, object] | None = None,
+        block_open: Callable[[], None] | None = None,
     ) -> None:
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
@@ -1509,6 +1510,12 @@ class FakeRxStream:
         self.heartbeat_count = 0
         self.fail_on_inject: Exception | None = None
         self._capture_health = _CaptureHealthTracker()
+        # MOR-1438: a synchronous hook invoked (on whatever thread calls
+        # ``start()``) before the stream is marked running. Lets tests model
+        # a genuinely blocking OS-level open (e.g. ``threading.Event.wait``)
+        # without touching PortAudio, so ``UsbAudioDriver``'s off-loop
+        # timeout handling can be exercised deterministically.
+        self.block_open = block_open
 
     @property
     def running(self) -> bool:
@@ -1521,6 +1528,8 @@ class FakeRxStream:
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self._running:
             raise RuntimeError("FakeRxStream already running.")
+        if self.block_open is not None:
+            self.block_open()
         _claim_exclusive_device(self._exclusive, self._device, self)
         self._callback = callback
         self._running = True
@@ -1588,6 +1597,7 @@ class FakeTxStream:
         *,
         device: int | None = None,
         exclusive: dict[int, object] | None = None,
+        block_open: Callable[[], None] | None = None,
     ) -> None:
         self._running = False
         self._device = device
@@ -1598,6 +1608,8 @@ class FakeTxStream:
         self.fail_on_write: OSError | None = None
         self.write_failures = 0
         self.last_error: str | None = None
+        # MOR-1438: see FakeRxStream.block_open.
+        self.block_open = block_open
 
     @property
     def running(self) -> bool:
@@ -1618,6 +1630,8 @@ class FakeTxStream:
     async def start(self) -> None:
         if self._running:
             raise RuntimeError("FakeTxStream already running.")
+        if self.block_open is not None:
+            self.block_open()
         _claim_exclusive_device(self._exclusive, self._device, self)
         self._running = True
         self.started_count += 1
@@ -1760,6 +1774,12 @@ class FakeAudioBackend:
         self.rx_streams: list[FakeRxStream] = []
         self.tx_streams: list[FakeTxStream] = []
         self.duplex_streams: list[FakeDuplexStream] = []
+        # MOR-1438: applied to every stream opened from here on — lets tests
+        # model a genuinely blocking RX/TX open (e.g. a macOS TCC
+        # microphone-consent prompt that never renders) without a real
+        # backend. ``None`` (default) behaves exactly as before.
+        self.block_rx_open: Callable[[], None] | None = None
+        self.block_tx_open: Callable[[], None] | None = None
 
     def _strict_stream_kwargs(self, device: AudioDeviceId) -> dict[str, Any]:
         """Strict-mode plumbing for a new fake stream (MOR-566).
@@ -1811,7 +1831,9 @@ class FakeAudioBackend:
         # ``deliver_channels`` selects the software downmix in the real
         # PortAudio stream; FakeRxStream is a verbatim pass-through, so it only
         # records what it was opened at for assertions.
-        stream = FakeRxStream(**self._strict_stream_kwargs(device))
+        stream = FakeRxStream(
+            block_open=self.block_rx_open, **self._strict_stream_kwargs(device)
+        )
         self.rx_streams.append(stream)
         return stream
 
@@ -1825,7 +1847,9 @@ class FakeAudioBackend:
     ) -> FakeTxStream:
         if not any(d.id == device for d in self._devices):
             raise ValueError(f"Unknown device id {device}")
-        stream = FakeTxStream(**self._strict_stream_kwargs(device))
+        stream = FakeTxStream(
+            block_open=self.block_tx_open, **self._strict_stream_kwargs(device)
+        )
         self.tx_streams.append(stream)
         return stream
 

--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -1516,6 +1516,10 @@ class FakeRxStream:
         # without touching PortAudio, so ``UsbAudioDriver``'s off-loop
         # timeout handling can be exercised deterministically.
         self.block_open = block_open
+        # MOR-1438 (F2 coverage): records which thread called ``stop()``, so
+        # tests can assert a late/abandoned handle was closed off the event
+        # loop rather than by a synchronous await on the loop thread.
+        self.stop_thread_ident: int | None = None
 
     @property
     def running(self) -> bool:
@@ -1536,6 +1540,7 @@ class FakeRxStream:
         self.started_count += 1
 
     async def stop(self) -> None:
+        self.stop_thread_ident = threading.get_ident()
         _release_exclusive_device(self._exclusive, self._device, self)
         self._running = False
         self._callback = None
@@ -1610,6 +1615,8 @@ class FakeTxStream:
         self.last_error: str | None = None
         # MOR-1438: see FakeRxStream.block_open.
         self.block_open = block_open
+        # MOR-1438 (F2 coverage): see FakeRxStream.stop_thread_ident.
+        self.stop_thread_ident: int | None = None
 
     @property
     def running(self) -> bool:
@@ -1637,6 +1644,7 @@ class FakeTxStream:
         self.started_count += 1
 
     async def stop(self) -> None:
+        self.stop_thread_ident = threading.get_ident()
         _release_exclusive_device(self._exclusive, self._device, self)
         self._running = False
         self.stopped_count += 1

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, Literal
 
@@ -112,37 +113,35 @@ _DEFAULT_SAMPLE_RATE_CANDIDATES: tuple[int, ...] = (48_000, 24_000, 16_000, 8_00
 _CAPTURE_OPEN_TIMEOUT_S = 8.0
 """Default bound (seconds) on an RX/TX stream open, see ``_open_stream``."""
 
+_CAPTURE_OPEN_MAX_WORKERS = 8
+"""Size of the driver-owned open/close thread pool (MOR-1438, F3).
+
+A DEDICATED pool, not ``loop.run_in_executor(None, ...)``'s process-wide
+default executor: that pool is shared with the web server, eibi lookups,
+diagnostics, and discovery, so a single wedged capture open would
+permanently eat one of its threads and, given enough stuck opens, starve
+those unrelated subsystems too. Sized for a couple of concurrent RX/TX
+opens plus a couple of abandoned-handle closes running at once; it does
+not need to scale with subscriber count since ``_rx_lock``/``_tx_lock``
+serialize new opens.
+"""
+
 
 def _drive_stream_open(coro: "Coroutine[Any, Any, None]") -> None:
-    """Run a stream's ``start()`` coroutine to completion on this thread.
+    """Run a stream's ``start()``/``stop()`` coroutine to completion here.
 
     ``RxStream``/``TxStream`` implementations (PortAudio, Fake) perform no
-    genuine async I/O inside ``start()`` — the real device open is a
-    synchronous CoreAudio/PortAudio call made from an ``async def`` only
-    for Protocol conformance — so driving the coroutine via a private event
-    loop on a worker thread (MOR-1438) safely moves any blocking work off
-    the caller's loop without changing the ``RxStream``/``TxStream``
-    contract.
+    genuine async I/O inside ``start()``/``stop()`` — the real device open
+    and close are synchronous CoreAudio/PortAudio calls made from an
+    ``async def`` only for Protocol conformance — so driving the coroutine
+    via a private event loop on a worker thread (MOR-1438) safely moves
+    any blocking work off the caller's loop without changing the
+    ``RxStream``/``TxStream`` contract. Reused for BOTH the initial open
+    (:meth:`UsbAudioDriver._open_stream`) and a late/abandoned handle's
+    close (:meth:`UsbAudioDriver._close_late_stream`, F2) — a wedged
+    device can block its ``stop()`` exactly as it blocked its ``start()``.
     """
     asyncio.run(coro)
-
-
-async def _close_quietly(
-    stream: "RxStream | TxStream | DuplexStream", direction: str
-) -> None:
-    """Stop a late-arriving stream handle, swallowing close-time errors.
-
-    Fire-and-forget task target for :meth:`UsbAudioDriver._close_late_stream`
-    — nobody is awaiting this handle's lifecycle any more, so a failure
-    here must not surface as an "unretrieved task exception"; it is logged
-    at DEBUG instead (MOR-1438).
-    """
-    try:
-        await stream.stop()
-    except Exception:
-        logger.debug(
-            "usb-audio: failed to close late %s handle", direction, exc_info=True
-        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -624,6 +623,16 @@ class UsbAudioDriver:
         # tests can shrink it well below ``_CAPTURE_OPEN_TIMEOUT_S`` without
         # a real multi-second wait.
         self._capture_open_timeout = capture_open_timeout
+        # MOR-1438 (F3): dedicated pool for stream opens/closes, isolated
+        # from the process-wide default executor other subsystems share.
+        # Non-daemon threads (stdlib default): a permanently wedged open
+        # leaves a live thread that ``atexit`` will try to join, which can
+        # delay process exit — the same failure mode the frozen event loop
+        # already caused pre-fix, not a new regression.
+        self._open_executor = ThreadPoolExecutor(
+            max_workers=_CAPTURE_OPEN_MAX_WORKERS,
+            thread_name_prefix="rigplane-audio-open",
+        )
 
         self._selected_rx: UsbAudioDevice | None = None
         self._selected_tx: UsbAudioDevice | None = None
@@ -963,18 +972,32 @@ class UsbAudioDriver:
         flag is introduced here. The background open keeps running after
         this gives up on it; see :meth:`_close_late_stream` for the
         late-arriving-handle cleanup.
+
+        Cancellation of the AWAITING coroutine (e.g. a WS session torn
+        down mid-open) is handled the SAME way (MOR-1438 F1): before this
+        fix the frozen event loop could never actually deliver a cancel
+        here, so the path was unreachable; now the caller can sit
+        suspended up to ``_capture_open_timeout`` inside a routinely
+        cancelled code path (an operator reloading the browser tab
+        mid-open is exactly the incident scenario). ``asyncio.wait``
+        never cancels the futures it was given, so the background open
+        survives a cancelled wait untouched — it must be abandoned the
+        same way a timed-out one is, or it leaves a live, un-stoppable
+        stream with no consumer.
         """
         loop = asyncio.get_running_loop()
-        future = loop.run_in_executor(None, _drive_stream_open, start_coro)
-        _done, pending = await asyncio.wait(
-            {future}, timeout=self._capture_open_timeout
+        future = loop.run_in_executor(
+            self._open_executor, _drive_stream_open, start_coro
         )
+        try:
+            _done, pending = await asyncio.wait(
+                {future}, timeout=self._capture_open_timeout
+            )
+        except asyncio.CancelledError:
+            self._abandon_open(future, stream, direction)
+            raise
         if future in pending:
-
-            def _on_late_open(late_future: "asyncio.Future[None]") -> None:
-                self._close_late_stream(late_future, stream, direction)
-
-            future.add_done_callback(_on_late_open)
+            self._abandon_open(future, stream, direction)
             logger.warning(
                 "usb-audio: %s capture open timed out after %.0fs — likely "
                 "blocked on OS capture-permission consent (macOS TCC "
@@ -991,29 +1014,82 @@ class UsbAudioDriver:
             )
         future.result()  # re-raise the open's own exception, if any
 
+    def _abandon_open(
+        self,
+        future: "asyncio.Future[None]",
+        stream: RxStream | TxStream | DuplexStream,
+        direction: str,
+    ) -> None:
+        """Detach from a still-running background open (MOR-1438, F1).
+
+        Used on BOTH the timeout branch and caller-cancellation: either
+        way, nobody is going to await *future* to completion any more, so
+        its eventual result must not be silently dropped. Without this, a
+        stream that finishes opening late flips ``running`` True with no
+        consumer and no callback wired up — every later subscriber trips
+        ``AudioAlreadyStartedError`` and the bus can't self-heal (
+        ``rx_active``/``tx_active`` never got set, so
+        ``AudioBus._remove_subscriber`` never runs the ``stop()`` it would
+        take to recover) until process restart.
+
+        Handles the (rare) race where *future* already finished right as
+        cancellation landed: closes it immediately via
+        :meth:`_close_late_stream` instead of registering a callback that
+        would never fire.
+        """
+        if future.done():
+            self._close_late_stream(future, stream, direction)
+            return
+
+        def _on_late_open(late_future: "asyncio.Future[None]") -> None:
+            self._close_late_stream(late_future, stream, direction)
+
+        future.add_done_callback(_on_late_open)
+
     def _close_late_stream(
         self,
         future: "asyncio.Future[None]",
         stream: RxStream | TxStream | DuplexStream,
         direction: str,
     ) -> None:
-        """Close a stream handle that finished opening after its timeout fired.
+        """Close a stream handle that finished opening after it was abandoned.
 
-        Runs as an asyncio done-callback on the event-loop thread (never
-        the worker thread that ran the open). The caller already gave up
-        and moved on when the timeout fired, so a late-arriving handle
-        would otherwise hold the OS device open forever — the
+        Fires as an asyncio done-callback ON THE EVENT-LOOP THREAD — but a
+        real ``stream.stop()`` is the SAME kind of synchronous
+        Pa_StopStream/Pa_CloseStream call this ticket exists to keep off
+        that thread (MOR-1438, F2): a wedged device can block its close
+        exactly as it blocked its open. So the close itself is driven
+        through the same off-loop helper (:func:`_drive_stream_open`) as
+        the original open, never awaited directly here. The caller already
+        gave up and moved on (timeout or cancellation), so a late-arriving
+        handle would otherwise hold the OS device open forever — the
         ResourceDemand handle-identity lesson applies here too: a handle
         nobody stops leaks a binding.
         """
         if future.cancelled() or future.exception() is not None:
             return
         logger.warning(
-            "usb-audio: %s capture open completed after its timeout had "
-            "already fired — closing the late handle instead of leaking it",
+            "usb-audio: %s capture open completed after it was abandoned "
+            "— closing the late handle instead of leaking it",
             direction.upper(),
         )
-        asyncio.ensure_future(_close_quietly(stream, direction))
+        loop = asyncio.get_running_loop()
+        close_future = loop.run_in_executor(
+            self._open_executor, _drive_stream_open, stream.stop()
+        )
+
+        def _on_close_done(done_future: "asyncio.Future[None]") -> None:
+            if done_future.cancelled():
+                return
+            exc = done_future.exception()
+            if exc is not None:
+                logger.debug(
+                    "usb-audio: failed to close late %s handle",
+                    direction,
+                    exc_info=exc,
+                )
+
+        close_future.add_done_callback(_on_close_done)
 
     def _store_stream_contract(self, contract: UsbAudioStreamContract) -> None:
         if contract.direction == "rx":
@@ -1099,11 +1175,13 @@ class UsbAudioDriver:
                     stream.start(self._silence_watchdog(callback, fm)),
                     direction="rx",
                 )
-            except AudioCaptureOpenTimeoutError:
+            except (AudioCaptureOpenTimeoutError, asyncio.CancelledError):
                 # Never leave a stuck-open handle wired up as "the" RX
                 # stream (MOR-1438): the next start_rx() must create a
                 # fresh one rather than observe this abandoned attempt
-                # flip ``running`` True behind its back.
+                # flip ``running`` True behind its back. Cancellation
+                # (F1) gets the same treatment as a timeout — both leave
+                # the background open running unattended.
                 self._rx_stream = None
                 raise
             self._store_stream_contract(contract)
@@ -1164,7 +1242,7 @@ class UsbAudioDriver:
                 # (MOR-1438), even though the specific bench trigger — a
                 # macOS TCC microphone-consent prompt — is RX/input-only.
                 await self._open_stream(stream, stream.start(), direction="tx")
-            except AudioCaptureOpenTimeoutError:
+            except (AudioCaptureOpenTimeoutError, asyncio.CancelledError):
                 self._tx_stream = None
                 raise
             self._store_stream_contract(contract)

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -15,7 +15,7 @@ import asyncio
 import logging
 import sys
 from dataclasses import dataclass
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Coroutine, Literal
 
 from .backend import (
     AudioBackend,
@@ -89,7 +89,60 @@ class AudioNotStartedError(AudioDriverLifecycleError):
     """
 
 
+class AudioCaptureOpenTimeoutError(AudioDriverLifecycleError):
+    """Raised when an RX/TX stream open did not finish within the bound.
+
+    Bench-observed (2026-08-11, MOR-1438): a macOS TCC microphone-consent
+    prompt that never renders leaves the blocking CoreAudio open call
+    hanging forever. The open now runs off the event loop (see
+    ``UsbAudioDriver._open_stream``) and is bounded by
+    ``capture_open_timeout``; a stuck open raises this instead of hanging
+    the caller (and, before this fix, the whole event loop). Subclasses
+    :class:`AudioDriverLifecycleError` so it flows through the SAME
+    honest-downgrade path other lifecycle failures already use (MOR-582,
+    ADR Sec3.4): the exception propagates to :class:`~rigplane.audio.bus.AudioBus`,
+    which keeps ``rx_active``/``tx_active`` false and surfaces the failure
+    to WS clients — no bespoke availability flag. The next subscriber
+    attempt opens a fresh stream from scratch.
+    """
+
+
 _DEFAULT_SAMPLE_RATE_CANDIDATES: tuple[int, ...] = (48_000, 24_000, 16_000, 8_000)
+
+_CAPTURE_OPEN_TIMEOUT_S = 8.0
+"""Default bound (seconds) on an RX/TX stream open, see ``_open_stream``."""
+
+
+def _drive_stream_open(coro: "Coroutine[Any, Any, None]") -> None:
+    """Run a stream's ``start()`` coroutine to completion on this thread.
+
+    ``RxStream``/``TxStream`` implementations (PortAudio, Fake) perform no
+    genuine async I/O inside ``start()`` — the real device open is a
+    synchronous CoreAudio/PortAudio call made from an ``async def`` only
+    for Protocol conformance — so driving the coroutine via a private event
+    loop on a worker thread (MOR-1438) safely moves any blocking work off
+    the caller's loop without changing the ``RxStream``/``TxStream``
+    contract.
+    """
+    asyncio.run(coro)
+
+
+async def _close_quietly(
+    stream: "RxStream | TxStream | DuplexStream", direction: str
+) -> None:
+    """Stop a late-arriving stream handle, swallowing close-time errors.
+
+    Fire-and-forget task target for :meth:`UsbAudioDriver._close_late_stream`
+    — nobody is awaiting this handle's lifecycle any more, so a failure
+    here must not surface as an "unretrieved task exception"; it is logged
+    at DEBUG instead (MOR-1438).
+    """
+    try:
+        await stream.stop()
+    except Exception:
+        logger.debug(
+            "usb-audio: failed to close late %s handle", direction, exc_info=True
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -536,6 +589,7 @@ class UsbAudioDriver:
         frame_ms: int = 20,
         backend: AudioBackend | None = None,
         rx_audio_channel: str = "mix",
+        capture_open_timeout: float = _CAPTURE_OPEN_TIMEOUT_S,
     ) -> None:
         # ONE per-device config carrier (MOR-578). Callers either hand a
         # ready-made :class:`AudioDeviceConfig` or use the historical keyword
@@ -565,6 +619,11 @@ class UsbAudioDriver:
         )
         self._serial_port = serial_port
         self._backend: AudioBackend = backend or PortAudioBackend()
+        # MOR-1438: bound on how long an RX/TX stream open may block before
+        # it is treated as stuck (see ``_open_stream``). Overridable so
+        # tests can shrink it well below ``_CAPTURE_OPEN_TIMEOUT_S`` without
+        # a real multi-second wait.
+        self._capture_open_timeout = capture_open_timeout
 
         self._selected_rx: UsbAudioDevice | None = None
         self._selected_tx: UsbAudioDevice | None = None
@@ -880,6 +939,82 @@ class UsbAudioDriver:
 
         return _watchdog
 
+    async def _open_stream(
+        self,
+        stream: RxStream | TxStream | DuplexStream,
+        start_coro: "Coroutine[Any, Any, None]",
+        *,
+        direction: str,
+    ) -> None:
+        """Open *stream* off the event loop, bounded by ``_capture_open_timeout``.
+
+        Moves the stream's ``start()`` — a genuinely blocking OS-level
+        device open on the real PortAudio backend — to a worker thread
+        (:func:`_drive_stream_open`) so a stuck open (bench-observed: a
+        macOS TCC microphone-consent prompt that never renders, MOR-1420)
+        cannot freeze the caller's event loop (MOR-1438).
+
+        On timeout: logs one actionable warning and raises
+        :class:`AudioCaptureOpenTimeoutError`. The caller's existing
+        failure path (:class:`~rigplane.audio.bus.AudioBus`, MOR-582)
+        already treats a raised start as an honest capability downgrade —
+        ``rx_active``/the session's audio availability stays false and the
+        failure is surfaced to subscribers — so no bespoke "unavailable"
+        flag is introduced here. The background open keeps running after
+        this gives up on it; see :meth:`_close_late_stream` for the
+        late-arriving-handle cleanup.
+        """
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(None, _drive_stream_open, start_coro)
+        _done, pending = await asyncio.wait(
+            {future}, timeout=self._capture_open_timeout
+        )
+        if future in pending:
+
+            def _on_late_open(late_future: "asyncio.Future[None]") -> None:
+                self._close_late_stream(late_future, stream, direction)
+
+            future.add_done_callback(_on_late_open)
+            logger.warning(
+                "usb-audio: %s capture open timed out after %.0fs — likely "
+                "blocked on OS capture-permission consent (macOS TCC "
+                "microphone-consent prompt that never rendered, see "
+                "MOR-1420); marking %s audio unavailable for this session, "
+                "will retry on the next subscriber",
+                direction.upper(),
+                self._capture_open_timeout,
+                direction,
+            )
+            raise AudioCaptureOpenTimeoutError(
+                f"{direction.upper()} capture open timed out after "
+                f"{self._capture_open_timeout}s."
+            )
+        future.result()  # re-raise the open's own exception, if any
+
+    def _close_late_stream(
+        self,
+        future: "asyncio.Future[None]",
+        stream: RxStream | TxStream | DuplexStream,
+        direction: str,
+    ) -> None:
+        """Close a stream handle that finished opening after its timeout fired.
+
+        Runs as an asyncio done-callback on the event-loop thread (never
+        the worker thread that ran the open). The caller already gave up
+        and moved on when the timeout fired, so a late-arriving handle
+        would otherwise hold the OS device open forever — the
+        ResourceDemand handle-identity lesson applies here too: a handle
+        nobody stops leaks a binding.
+        """
+        if future.cancelled() or future.exception() is not None:
+            return
+        logger.warning(
+            "usb-audio: %s capture open completed after its timeout had "
+            "already fired — closing the late handle instead of leaking it",
+            direction.upper(),
+        )
+        asyncio.ensure_future(_close_quietly(stream, direction))
+
     def _store_stream_contract(self, contract: UsbAudioStreamContract) -> None:
         if contract.direction == "rx":
             self._usb_audio_contract = UsbAudioContract(
@@ -949,7 +1084,7 @@ class UsbAudioDriver:
                 fm,
                 selected_rx.input_channels,
             )
-            self._rx_stream = self._backend.open_rx(
+            stream = self._backend.open_rx(
                 AudioDeviceId(selected_rx.index),
                 sample_rate=contract.sample_rate_hz,
                 channels=contract.effective_open_channels,
@@ -957,7 +1092,20 @@ class UsbAudioDriver:
                 deliver_channels=contract.channels,
                 rx_audio_channel=self._config.rx_audio_channel,
             )
-            await self._rx_stream.start(self._silence_watchdog(callback, fm))
+            self._rx_stream = stream
+            try:
+                await self._open_stream(
+                    stream,
+                    stream.start(self._silence_watchdog(callback, fm)),
+                    direction="rx",
+                )
+            except AudioCaptureOpenTimeoutError:
+                # Never leave a stuck-open handle wired up as "the" RX
+                # stream (MOR-1438): the next start_rx() must create a
+                # fresh one rather than observe this abandoned attempt
+                # flip ``running`` True behind its back.
+                self._rx_stream = None
+                raise
             self._store_stream_contract(contract)
             logger.info(
                 "usb-audio: RX capture running — device=[%d] %s",
@@ -1002,13 +1150,23 @@ class UsbAudioDriver:
                 frame_ms=fm,
                 allow_sample_rate_fallback=allow_sample_rate_fallback,
             )
-            self._tx_stream = self._backend.open_tx(
+            stream = self._backend.open_tx(
                 AudioDeviceId(selected_tx.index),
                 sample_rate=contract.sample_rate_hz,
                 channels=contract.channels,
                 frame_ms=fm,
             )
-            await self._tx_stream.start()
+            self._tx_stream = stream
+            try:
+                # TX opens share the RX blocking-open shape (a synchronous
+                # OutputStream construct + .start() on the real backend) so
+                # they get the same off-loop + bounded-timeout treatment
+                # (MOR-1438), even though the specific bench trigger — a
+                # macOS TCC microphone-consent prompt — is RX/input-only.
+                await self._open_stream(stream, stream.start(), direction="tx")
+            except AudioCaptureOpenTimeoutError:
+                self._tx_stream = None
+                raise
             self._store_stream_contract(contract)
 
     async def start_duplex(
@@ -1136,6 +1294,7 @@ class UsbAudioDriver:
 
 __all__ = [
     "AudioAlreadyStartedError",
+    "AudioCaptureOpenTimeoutError",
     "AudioDeviceConfig",
     "AudioDeviceSelectionError",
     "AudioDriverLifecycleError",

--- a/tests/test_usb_audio_capture_open_timeout_mor1438.py
+++ b/tests/test_usb_audio_capture_open_timeout_mor1438.py
@@ -1,0 +1,199 @@
+"""MOR-1438 — RX/TX capture open must never block the event loop.
+
+Bench incident (2026-08-11, reproduced twice): the first audio subscriber
+triggers ``UsbAudioDriver.start_rx``, which opened the CoreAudio capture
+stream directly on the event-loop thread. A macOS TCC microphone-consent
+prompt that never rendered left that open blocked forever, freezing
+web/WS/scope -- the ENTIRE server -- for minutes (see MOR-1420 for the TCC
+mic-consent freeze this class of bug traces back to).
+
+``UsbAudioDriver.start_rx``/``start_tx`` now drive the stream's ``start()``
+off the event loop (a worker thread) and bound the wait with a configurable
+capture-open timeout. On timeout: exactly one actionable WARNING is logged,
+the exception (``AudioCaptureOpenTimeoutError``) propagates through the
+EXISTING AudioBus/web failure path (MOR-582, ADR Sec3.4) instead of a
+bespoke availability flag, and a late-arriving handle (the background open
+eventually completing after the timeout fired) is closed rather than
+leaked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
+from rigplane.audio.usb_driver import AudioCaptureOpenTimeoutError, UsbAudioDriver
+
+_LOGGER_NAME = "rigplane.audio.usb_driver"
+# Tiny relative to the production default -- keeps this suite fast while
+# still exercising the real asyncio.wait()-based bound.
+_TEST_TIMEOUT_S = 0.05
+
+
+def _fake_devices() -> list[AudioDeviceInfo]:
+    return [
+        AudioDeviceInfo(
+            id=AudioDeviceId(1),
+            name="USB Audio CODEC",
+            input_channels=1,
+            output_channels=1,
+            default_samplerate=48_000,
+            is_default_input=True,
+            is_default_output=True,
+        ),
+    ]
+
+
+def _make_driver(
+    backend: FakeAudioBackend | None = None,
+) -> tuple[UsbAudioDriver, FakeAudioBackend]:
+    backend = backend or FakeAudioBackend(_fake_devices())
+    driver = UsbAudioDriver(backend=backend, capture_open_timeout=_TEST_TIMEOUT_S)
+    return driver, backend
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.name == _LOGGER_NAME and r.levelno == logging.WARNING
+    ]
+
+
+@pytest.mark.timeout(10)
+async def test_rx_open_timeout_keeps_event_loop_free(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stuck RX open must not stall other coroutines on the same loop."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait  # blocks a WORKER thread, never the loop
+
+    progressed = 0
+    stop = asyncio.Event()
+
+    async def _ticker() -> None:
+        nonlocal progressed
+        while not stop.is_set():
+            progressed += 1
+            await asyncio.sleep(0.005)
+
+    ticker = asyncio.create_task(_ticker())
+    try:
+        with pytest.raises(AudioCaptureOpenTimeoutError):
+            await driver.start_rx(lambda _frame: None)
+    finally:
+        stop.set()
+        await ticker
+
+    assert progressed >= 3, (
+        "event loop should keep making progress while the open is stuck"
+    )
+    assert driver.rx_running is False
+
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1, "exactly one actionable warning on timeout"
+    message = warnings[0].getMessage()
+    assert "MOR-1420" in message
+    assert "consent" in message.lower()
+
+    gate.set()  # release the stuck background open so the thread can exit
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.timeout(10)
+async def test_rx_open_late_return_closes_handle_not_leaked(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A background open that finishes AFTER the timeout must be closed."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait
+
+    with pytest.raises(AudioCaptureOpenTimeoutError):
+        await driver.start_rx(lambda _frame: None)
+
+    late_stream = backend.rx_streams[-1]
+    assert late_stream.stopped_count == 0
+
+    gate.set()  # let the abandoned background open finally complete
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if late_stream.stopped_count:
+            break
+
+    assert late_stream.started_count == 1
+    assert late_stream.stopped_count == 1, "late handle must be closed, not leaked"
+
+
+@pytest.mark.timeout(10)
+async def test_rx_open_recovers_on_next_subscriber(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A later subscriber (e.g. consent granted) must be able to open RX again."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait
+
+    with pytest.raises(AudioCaptureOpenTimeoutError):
+        await driver.start_rx(lambda _frame: None)
+    assert driver.rx_running is False
+
+    gate.set()
+    await asyncio.sleep(0.05)  # let the abandoned attempt's cleanup settle
+
+    backend.block_rx_open = None  # simulate consent granted for the retry
+    await driver.start_rx(lambda _frame: None)
+    assert driver.rx_running is True
+
+
+@pytest.mark.timeout(10)
+async def test_normal_rx_open_timing_unaffected() -> None:
+    """A well-behaved (non-blocking) open must not pay a meaningful penalty."""
+    driver, _backend = _make_driver()
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    await driver.start_rx(lambda _frame: None)
+    elapsed = loop.time() - start
+
+    assert driver.rx_running is True
+    assert elapsed < 0.5
+
+
+@pytest.mark.timeout(10)
+async def test_tx_open_timeout_shares_the_same_treatment(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """TX opens use the same off-loop + bounded-timeout treatment as RX."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_tx_open = gate.wait
+
+    with pytest.raises(AudioCaptureOpenTimeoutError):
+        await driver.start_tx()
+
+    assert driver.tx_running is False
+    assert len(_warnings(caplog)) == 1
+
+    gate.set()
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.timeout(10)
+async def test_normal_tx_open_timing_unaffected() -> None:
+    driver, _backend = _make_driver()
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    await driver.start_tx()
+    elapsed = loop.time() - start
+
+    assert driver.tx_running is True
+    assert elapsed < 0.5

--- a/tests/test_usb_audio_capture_open_timeout_mor1438.py
+++ b/tests/test_usb_audio_capture_open_timeout_mor1438.py
@@ -8,13 +8,24 @@ web/WS/scope -- the ENTIRE server -- for minutes (see MOR-1420 for the TCC
 mic-consent freeze this class of bug traces back to).
 
 ``UsbAudioDriver.start_rx``/``start_tx`` now drive the stream's ``start()``
-off the event loop (a worker thread) and bound the wait with a configurable
-capture-open timeout. On timeout: exactly one actionable WARNING is logged,
-the exception (``AudioCaptureOpenTimeoutError``) propagates through the
-EXISTING AudioBus/web failure path (MOR-582, ADR Sec3.4) instead of a
-bespoke availability flag, and a late-arriving handle (the background open
-eventually completing after the timeout fired) is closed rather than
-leaked.
+off the event loop (a dedicated worker thread pool) and bound the wait with
+a configurable capture-open timeout. On timeout: exactly one actionable
+WARNING is logged, the exception (``AudioCaptureOpenTimeoutError``)
+propagates through the EXISTING AudioBus/web failure path (MOR-582, ADR
+Sec3.4) instead of a bespoke availability flag, and a late-arriving handle
+(the background open eventually completing after it was abandoned) is
+closed rather than leaked.
+
+Independent-review follow-ups (same ticket):
+
+- F1: cancelling the *caller* mid-open (e.g. a WS session torn down while
+  the open is in flight) must abandon the background open the SAME way a
+  timeout does -- not leave it to flip ``running`` True with no consumer.
+- F2: closing a late/abandoned handle must ALSO run off the event loop --
+  a wedged device can block its ``stop()`` exactly as it blocked its
+  ``start()``.
+- F3: the open/close work runs on a driver-owned thread pool, not the
+  process-wide default executor shared with unrelated subsystems.
 """
 
 from __future__ import annotations
@@ -197,3 +208,103 @@ async def test_normal_tx_open_timing_unaffected() -> None:
 
     assert driver.tx_running is True
     assert elapsed < 0.5
+
+
+@pytest.mark.timeout(10)
+async def test_rx_open_cancelled_mid_open_closes_late_handle_and_recovers() -> None:
+    """F1: cancelling start_rx mid-open must not orphan a live stream.
+
+    Before this fix, only the timeout branch abandoned the background
+    open. A caller cancellation (e.g. a WS session torn down while the
+    open is in flight — the actual incident behavior: an operator
+    reloading the tab mid-freeze) propagated CancelledError past the
+    ``except AudioCaptureOpenTimeoutError`` clause untouched: no
+    done-callback attached, no ``self._rx_stream`` reset. The abandoned
+    open would eventually flip ``running`` True with no consumer, every
+    later subscriber would trip ``AudioAlreadyStartedError``, and the bus
+    could never self-heal (``rx_active`` never got set, so
+    ``_remove_subscriber`` never fires the stop that would recover) --
+    RX dead until process restart.
+    """
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait
+
+    task = asyncio.create_task(driver.start_rx(lambda _frame: None))
+    await asyncio.sleep(0.01)  # let it reach the blocked open
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert driver.rx_running is False
+
+    late_stream = backend.rx_streams[-1]
+    gate.set()  # release the background open so it can finally complete
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if late_stream.stopped_count:
+            break
+
+    assert late_stream.started_count == 1
+    assert late_stream.stopped_count == 1, (
+        "cancelled-mid-open handle must be closed, not leaked"
+    )
+
+    # The bus-level self-heal check: a fresh subscriber must be able to
+    # open RX again, not trip AudioAlreadyStartedError forever.
+    backend.block_rx_open = None
+    await driver.start_rx(lambda _frame: None)
+    assert driver.rx_running is True
+
+
+@pytest.mark.timeout(10)
+async def test_late_close_runs_off_the_loop_thread() -> None:
+    """F2: closing an abandoned handle must not block the loop either.
+
+    A real ``stream.stop()`` is the same kind of synchronous
+    Pa_StopStream/Pa_CloseStream call as ``start()`` -- a wedged device
+    can block its close exactly as it blocked its open. Asserts the
+    close actually executes on a DIFFERENT thread than the one running
+    this test's event loop (a stronger, more direct proof than timing
+    heuristics).
+    """
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait
+    loop_thread_ident = threading.get_ident()
+
+    with pytest.raises(AudioCaptureOpenTimeoutError):
+        await driver.start_rx(lambda _frame: None)
+
+    late_stream = backend.rx_streams[-1]
+    gate.set()
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if late_stream.stopped_count:
+            break
+
+    assert late_stream.stopped_count == 1
+    assert late_stream.stop_thread_ident is not None
+    assert late_stream.stop_thread_ident != loop_thread_ident, (
+        "late close must run off the event-loop thread"
+    )
+
+
+@pytest.mark.timeout(10)
+async def test_frame_delivered_after_off_loop_open() -> None:
+    """Loop-affinity regression guard (coverage gap closed per review).
+
+    The central risk this whole ticket introduces is a loop-affinity bug:
+    frames delivered by a stream that was opened off-loop must still
+    reach the original caller's callback. A regression here would mean
+    RX silently stops delivering audio even though ``start_rx()`` reports
+    success.
+    """
+    driver, backend = _make_driver()
+    received: list[bytes] = []
+
+    await driver.start_rx(received.append)
+    assert driver.rx_running is True
+
+    backend.rx_streams[-1].inject_frame(b"\x01\x02")
+    assert received == [b"\x01\x02"]


### PR DESCRIPTION
## Summary

- The first audio subscriber's `UsbAudioDriver.start_rx` opened the CoreAudio capture stream synchronously on the event-loop thread. A macOS TCC microphone-consent prompt that never rendered left that open blocked forever, freezing the ENTIRE server (web/WS/scope) for minutes -- bench-reproduced twice on 2026-08-11.
- `start_rx`/`start_tx` now drive the stream's `start()` off the event loop via a worker thread (`_drive_stream_open`), bounded by a named, configurable timeout (`_CAPTURE_OPEN_TIMEOUT_S = 8.0`).
- On timeout: exactly one actionable WARNING (citing the MOR-1420 TCC-consent context) and `AudioCaptureOpenTimeoutError` is raised. It flows through the **existing** `AudioBus`/web failure path (MOR-582, ADR Sec3.4) -- `rx_active`/`tx_active` stay `False` and WS clients are notified of the failure -- so audio degrades honestly with no bespoke "unavailable" flag. The next subscriber attempt opens a fresh stream from scratch.
- A background open that finishes **after** it was abandoned (timeout or cancellation, see R1 below) has its late handle closed (not leaked).
- TX opens (`start_tx`) share the same treatment: `_PortAudioTxStream.start()` has the identical blocking shape (synchronous `OutputStream()` construct + `.start()`), so it gets the same off-loop + bounded-timeout wrapper for defense in depth, even though the specific bench trigger (TCC mic consent) is RX/input-only.
- `start_duplex()` (single full-duplex stream, same-device RX+TX) is currently unused by any production call site -- left untouched to keep this change tightly scoped.
- `FakeAudioBackend` gains an optional `block_rx_open`/`block_tx_open` hook (defaults `None`, fully backward compatible) so tests can model a genuinely blocking open (`threading.Event.wait`) without touching PortAudio, per the audio-test doctrine (FakeAudioBackend only, no one-off mocks).

## Design notes

- Offloading runs the stream's `start()` coroutine to completion on a private event loop in a worker thread (`asyncio.run(coro)` inside `loop.run_in_executor`). Existing `RxStream`/`TxStream` implementations (PortAudio, Fake) do no genuine async I/O inside `start()` -- the real device open is a synchronous CoreAudio/PortAudio call wrapped in `async def` only for Protocol conformance -- so this is safe and backend-agnostic.
- Uses `asyncio.wait({future}, timeout=...)` rather than `asyncio.wait_for`/`shield`, specifically so a timed-out future is never cancelled: the underlying executor thread keeps running (you cannot forcibly stop a running OS thread), and we explicitly attach a done-callback to close a late-arriving handle instead of fighting cancellation semantics.
- On timeout, `self._rx_stream`/`self._tx_stream` is reset to `None` immediately -- never left pointing at an abandoned, possibly-still-opening handle (the ResourceDemand handle-identity lesson: a reused/unstopped handle leaks a binding). The late-close callback closes over its own `stream` reference, decoupled from the driver's current field.

## R1: independent-review follow-ups (BLOCKED -> addressed)

An independent verifier ran a review pass and ruled BLOCKED with two blockers and one should-fix. The central loop-affinity risk was already clean (frames marshal correctly; PortAudio's real `start()` touches no asyncio). All three are now fixed on this branch:

**F1 (blocker) -- cancellation mid-open orphaned a live stream permanently.** Only the timeout branch attached the late-close callback and reset the stream ref; `CancelledError` propagated past `except AudioCaptureOpenTimeoutError` untouched -- no callback, no reset -- so a background open that finished after a caller cancellation would flip `running` True with no consumer. Every later subscriber would then trip `AudioAlreadyStartedError`, and `AudioBus` could never self-heal (`rx_active` never got set, so `_remove_subscriber` never fires the `stop()` that would recover) -- RX dead until process restart. This PR's off-loop change is *what made the path reachable*: pre-fix, the frozen loop could never actually deliver a cancel here; now the caller can sit suspended up to `_capture_open_timeout` inside a routinely-cancelled code path (an operator reloading the browser tab mid-open is exactly the incident behavior). Fixed by extracting `_abandon_open(future, stream, direction)` (shared by both the timeout branch and a new `except asyncio.CancelledError:` wrapping the wait), and widening the `start_rx`/`start_tx` reset to cover `CancelledError` too.

**F2 (blocker) -- `_close_late_stream` awaited `stream.stop()` directly on the loop thread.** That's the same kind of synchronous `Pa_StopStream`/`Pa_CloseStream` call this ticket exists to keep off the event loop -- a wedged device can block its close exactly as it blocked its open. Fixed by routing the late close through the same off-loop helper (`_drive_stream_open`) used for the original open, instead of a bare `asyncio.ensure_future(stream.stop())`.

**F3 (should-fix) -- the open used `loop.run_in_executor(None, ...)`, the process-wide default executor** shared with the web server, eibi lookups, diagnostics, and discovery; each stuck open would permanently eat one of its threads, and enough stuck opens could starve unrelated subsystems. Fixed with a driver-owned `ThreadPoolExecutor(thread_name_prefix="rigplane-audio-open")`, used for both the open and the late close.
  - **Caveat (not a regression):** `ThreadPoolExecutor` threads are non-daemon by default and this executor is never explicitly shut down. A permanently wedged open leaves a live worker thread that Python's `atexit` handling will try to join, which can delay process exit. This is the same failure mode the frozen event loop already caused pre-fix (the process couldn't exit cleanly either way) -- not a new regression -- so no `shutdown()`/lifecycle wiring was added, to keep this fix scoped to the reviewer's findings.

**Coverage gap closed:** a new test (`test_frame_delivered_after_off_loop_open`) opens RX normally, then injects a frame through the resulting stream and asserts it reaches the original caller's callback -- the loop-affinity regression that would matter most (frames silently stop flowing even though `start_rx()` reports success) was previously undetected.

`FakeRxStream`/`FakeTxStream` gain `stop_thread_ident` (records which thread called `stop()`) so tests can assert a late close ran off the loop thread rather than on it.

### Red-first evidence for F1/F2

Verified by temporarily reverting each fix in place, running the corresponding new test, confirming failure, then restoring the fix:

**F1** (`test_rx_open_cancelled_mid_open_closes_late_handle_and_recovers`), with the `except asyncio.CancelledError` wrapper removed:
```
FAILED tests/test_usb_audio_capture_open_timeout_mor1438.py::test_rx_open_cancelled_mid_open_closes_late_handle_and_recovers
AssertionError: cancelled-mid-open handle must be closed, not leaked
assert 0 == 1
 +  where 0 = <rigplane.audio.backend.FakeRxStream object at 0x10b442a50>.stopped_count
```

**F2** (`test_late_close_runs_off_the_loop_thread`), with `_close_late_stream` reverted to a bare `asyncio.ensure_future(stream.stop())`:
```
FAILED tests/test_usb_audio_capture_open_timeout_mor1438.py::test_late_close_runs_off_the_loop_thread
AssertionError: late close must run off the event-loop thread
assert 8353620096 != 8353620096
 +  where 8353620096 = <rigplane.audio.backend.FakeRxStream object at 0x109863b60>.stop_thread_ident
```

Both pass after restoring the fix; full new-file run below.

## Test plan

- [x] TDD red-first (initial fix): new test file failed on `ImportError` before the fix (no `AudioCaptureOpenTimeoutError`, no `capture_open_timeout`).
- [x] TDD red-first (R1 fixes): F1 and F2 each independently verified red before / green after, see evidence above.
- [x] `uv run pytest tests/test_usb_audio_capture_open_timeout_mor1438.py -q` -- 9/9 tests green, ~0.6s (timeout constant is test-overridable so no real multi-second waits):
  - stuck RX open keeps the event loop free (concurrent ticker task keeps progressing)
  - exactly one WARNING logged on timeout, citing MOR-1420
  - a late-returning open's handle is closed, not leaked
  - a later subscriber recovers (fresh open succeeds after a prior timeout)
  - normal (non-blocking) open timing is unaffected
  - TX open shares the same timeout treatment
  - **F1:** cancelling `start_rx` mid-open closes the late handle and a later subscriber still recovers
  - **F2:** the late close runs off the event-loop thread
  - **coverage gap:** a frame delivered through an off-loop-opened stream reaches the caller
- [x] `uv run pytest tests/ -q --tb=short -k audio --ignore=tests/integration` -- 1376 passed, 6 skipped, 0 failed (full audio-related suite, includes the new tests)
- [x] `uv run ruff check src/ tests/` -- all checks passed
- [x] `uv run ruff format --check src/ tests/` -- all files formatted
- [x] `uv run mypy src/` -- 13 pre-existing errors (verified identical on `origin/main`), zero new
- [x] `uv run lint-imports` -- 5 kept, 0 broken
- [x] Boundary grep (`web`/`rigctld`/transport imports in the audio driver) -- empty
- [x] `git diff --stat` -- same 3 files (usb_driver.py, backend.py, test file); R1 delta alone is 249 insertions / 52 deletions

Closes MOR-1438
