### PR TITLE
fix: drop reuse_port on TCP web listener (MOR-1572)

### DIFF
--- a/src/rigplane/web/web_startup.py
+++ b/src/rigplane/web/web_startup.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -33,10 +32,6 @@ __all__ = ["start_web_server", "stop_web_server"]
 logger = logging.getLogger(__name__)
 
 _SHUTDOWN_SCOPE_RESTORE_TIMEOUT_S = 1.0
-
-
-def _reuse_port_supported() -> bool:
-    return sys.platform != "win32"
 
 
 def _supports_scope_local(server: WebServer) -> bool:
@@ -86,7 +81,19 @@ async def start_web_server(server: WebServer) -> None:
         port=server._config.port,
         ssl=ssl_ctx,
         reuse_address=True,
-        reuse_port=_reuse_port_supported(),
+        # MOR-1572: deliberately NOT reuse_port. This is an exclusive TCP
+        # listener guarding a single radio session (same rationale as
+        # rigctld's listener, see rigctld/server.py) — SO_REUSEPORT let a
+        # second rigplane instance silently bind the same web port on
+        # macOS/BSD, so two instances raced for the same radio with no
+        # error and the operator saw a half-dead UI. It also undermined the
+        # check_ports_available() preflight (MOR-1437): an orphan holding
+        # the port with SO_REUSEPORT set could let the preflight probe bind
+        # successfully right alongside it. Contrast with the UDP discovery
+        # responder (web/discovery.py), which legitimately opts into
+        # SO_REUSEPORT so multiple co-located instances can each announce
+        # their own radio on the shared discovery port — that is a
+        # best-effort broadcast responder, not an exclusive session guard.
     )
     server._server_was_running = True
     addr = server._server.sockets[0].getsockname()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import errno
 import hashlib
 import json
 import logging
@@ -1401,6 +1402,38 @@ class TestServerConfig:
         assert cfg.host == "0.0.0.0"
         assert cfg.port == 8080
         assert cfg.max_clients == 100
+
+    async def test_second_web_server_cannot_bind_same_port(self) -> None:
+        """MOR-1572 red-first: a second rigplane instance must not silently
+        share the first instance's web port.
+
+        Before this fix the listener opted into SO_REUSEPORT, so on
+        macOS/BSD a *second full WebServer* using the exact same production
+        start-up path could bind the same (host, port) with no error at
+        all — the two instances then raced for the same radio while the
+        operator saw a half-dead UI (verified locally: reproduces 100% on
+        darwin prior to the fix). On Linux, SO_REUSEPORT requires every
+        participating socket to opt in, so the second start may already
+        fail there for an unrelated reason. Either way, the invariant this
+        test protects is host-independent: starting a second listener on
+        the same (host, port) while the first is still running MUST fail
+        with EADDRINUSE, everywhere.
+        """
+        config = WebConfig(host="127.0.0.1", port=0)
+        srv1 = WebServer(None, config)
+        await srv1.start()
+        srv2: WebServer | None = None
+        try:
+            port = srv1.port
+            srv2 = WebServer(None, WebConfig(host="127.0.0.1", port=port))
+            with pytest.raises(OSError) as exc_info:
+                await srv2.start()
+            assert exc_info.value.errno == errno.EADDRINUSE
+        finally:
+            if srv2 is not None:
+                with contextlib.suppress(Exception):
+                    await srv2.stop()
+            await srv1.stop()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -653,21 +653,26 @@ def test_state_store_freshness_refresh_broadcasts_without_semantic_change() -> N
 
 
 @pytest.mark.asyncio
-async def test_start_disables_reuse_port_on_windows() -> None:
+async def test_start_never_requests_reuse_port() -> None:
+    """MOR-1572: the web listener must never opt into SO_REUSEPORT.
+
+    Unlike the UDP discovery responder (best-effort, meant to be shared by
+    co-located instances), this TCP listener guards an exclusive radio
+    session — a second rigplane instance silently sharing the port (as
+    SO_REUSEPORT allowed on macOS/BSD) means two instances race for the
+    same radio with no error. Guard against the kwarg being reintroduced.
+    """
     srv = WebServer(None, WebConfig(host="127.0.0.1", port=0, discovery=False))
     fake_server = _FakeAsyncServer()
 
-    with (
-        patch("rigplane.web.web_startup.sys.platform", "win32"),
-        patch(
-            "rigplane.web.web_startup.asyncio.start_server",
-            new=AsyncMock(return_value=fake_server),
-        ) as start_server,
-    ):
+    with patch(
+        "rigplane.web.web_startup.asyncio.start_server",
+        new=AsyncMock(return_value=fake_server),
+    ) as start_server:
         await srv.start()
         await srv.stop()
 
-    assert start_server.await_args.kwargs["reuse_port"] is False
+    assert "reuse_port" not in start_server.await_args.kwargs
 
 
 def test_shutdown_signal_handler_falls_back_when_loop_does_not_support_signals(


### PR DESCRIPTION
## Summary

The web server's `asyncio.start_server()` call passed `reuse_port=True`
(gated only on `sys.platform != "win32"`). On macOS/BSD, `SO_REUSEPORT`
lets a **second** rigplane instance silently bind the **same** web port,
so two instances end up racing for the same radio while the operator
sees a half-dead UI with no error at all. It also undermined the port
preflight from MOR-1437 / #2472 (`check_ports_available()`): an orphan
holding the port with `SO_REUSEPORT` set could let the preflight probe
bind alongside it, so the abort-on-conflict guarantee wasn't reliable.

Closes MOR-1572.

## What changed

- `src/rigplane/web/web_startup.py`: removed `reuse_port=_reuse_port_supported()`
  (and the now-unused helper + `sys` import) from the web listener's
  `asyncio.start_server()` call. `reuse_address=True` is untouched — that's
  the standard TIME_WAIT-reuse behavior for server restarts and is not the
  same thing as `SO_REUSEPORT`.
- `tests/test_web_server.py`: new red-first regression test
  (`test_second_web_server_cannot_bind_same_port`) — starts a real
  `WebServer` on an ephemeral port, then starts a second real `WebServer`
  on the same `(host, port)` and asserts it raises `OSError` with
  `errno.EADDRINUSE`. Verified locally that this **reproduces the bug
  100% on darwin before the fix** (second `WebServer.start()` succeeded
  silently) and is green after. The assertion is host-independent by
  design — on Linux, `SO_REUSEPORT` already requires every participating
  socket to opt in, so a second bind may already fail there for an
  unrelated reason; either way the invariant (second bind must fail) holds
  everywhere after this fix.
- `tests/test_web_server_coverage.py`: updated the existing
  `reuse_port`-kwarg coverage test (was
  `test_start_disables_reuse_port_on_windows`, which asserted
  `kwargs["reuse_port"] is False` on a mocked Windows platform) to
  `test_start_never_requests_reuse_port`, asserting the `reuse_port` kwarg
  is not passed to `asyncio.start_server` at all, on any platform — guards
  against the option being silently reintroduced.

## Audit of all `reuse_port` sites in `src/` (per ticket scope: TCP server listeners only)

| Site | Kind | Disposition |
|---|---|---|
| `src/rigplane/web/web_startup.py` (web HTTP/WS listener, `asyncio.start_server`) | TCP | **Fixed** — `reuse_port` removed, this PR |
| `src/rigplane/rigctld/server.py` (`asyncio.start_server`, line ~764) | TCP | Already correct — no `reuse_port` kwarg present, left as-is |
| `src/rigplane/web/discovery.py` (`loop.create_datagram_endpoint`, UDP discovery responder) | UDP multicast/broadcast | **Left as-is, intentionally.** This is a best-effort broadcast responder, not an exclusive session guard: `SO_REUSEPORT` is the correct choice here so multiple co-located rigplane instances can each announce their own radio on the shared discovery port (see the existing MOR-1437-disposition comment already in that file, right above the `reuse_port=_reuse_port_supported()` call, which documents this same reasoning). Out of scope per the ticket's own carve-out for multicast/UDP discovery sockets. |
| `src/rigplane/cli/__init__.py` `check_ports_available()` (short-lived raw-socket preflight probe, sets both `SO_REUSEADDR` and `SO_REUSEPORT` on the probe socket before `bind()`, never calls `listen()`) | TCP, but not a listener | **Left as-is.** This isn't a server listener — it's a bind-and-immediately-close preflight probe. `SO_REUSEADDR` is there deliberately so the probe doesn't false-positive against a TIME_WAIT socket from the process's own prior shutdown (per the existing docstring). Its conditional `SO_REUSEPORT` is now inert for the failure mode this ticket cares about: `SO_REUSEPORT` requires every socket sharing a `(host, port)` to opt in, and the real web listener no longer does, so an orphan web listener will make this probe's `bind()` fail regardless of the probe's own flag. Not touched, to keep this PR scoped to actual listeners as directed.

## Test plan

- [x] Red-first: confirmed `test_second_web_server_cannot_bind_same_port` **fails** against the pre-fix source (`DID NOT RAISE <class 'OSError'>`) — reproduces the exact bug on this darwin host.
- [x] Green after the fix: same test passes.
- [x] `uv run pytest tests/test_web_server.py tests/test_web_server_coverage.py tests/test_discovery_responder.py -q --tb=short` — 339 passed, 2 skipped (skips are the pre-existing frontend-build-missing guard, unrelated).
- [x] `uv run ruff check` + `uv run ruff format --check` on the 3 touched files — clean.
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken.
- [x] `uv run mypy src/rigplane/web/web_startup.py` — clean. (`uv run mypy src/` has 13 pre-existing errors in 4 unrelated files — `yaesu_cat/poller.py`, `runtime/_control_phase.py`, `runtime/_audio_runtime_mixin.py`, `web/radio_poller.py` — none touched by this change, none introduced by it.)
- Full suite / CI: left to `quick.yml` per repo convention (targeted tests only per guardrails).
