### PR TITLE
test: conformance completeness ledger (MOR-1556)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -6,8 +6,13 @@
  * in a `*-conformance.isolated.test.ts` file, per `./harness.ts`). This
  * file is that registry — the completeness meta-test
  * (`../../../commands/__tests__/panel-commands-completeness.test.ts`) unions
- * it with `./waived.ts` and asserts every intent `panel-commands.ts` can
- * emit falls in exactly one of the two sets.
+ * it with `./waived.ts` and asserts every LITERAL-NAMED intent
+ * `panel-commands.ts` dispatches (i.e. every `dispatchRadioIntent({ name:
+ * '<literal>', ... })` call site) falls in exactly one of the two sets.
+ * The 4 `modInputCommand(...)`-derived names are real emissions outside
+ * this 87-name literal universe — see `./waived.ts`'s header and the
+ * meta-test's "dynamic mod-input call site" block for how those are
+ * tracked instead.
  *
  * Convention for future family walks (C6-C13, MOR-1560..1567): when a walk
  * adds real `expectFrames` assertions for a previously-waived intent, add

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -1,0 +1,57 @@
+/**
+ * MOR-1556 — completeness ledger: CLAIMED intent registry.
+ *
+ * An intent name is "claimed" when a conformance case asserts the exact WS
+ * frame `panel-commands.ts` dispatches for it (an `expectFrames(...)` call
+ * in a `*-conformance.isolated.test.ts` file, per `./harness.ts`). This
+ * file is that registry — the completeness meta-test
+ * (`../../../commands/__tests__/panel-commands-completeness.test.ts`) unions
+ * it with `./waived.ts` and asserts every intent `panel-commands.ts` can
+ * emit falls in exactly one of the two sets.
+ *
+ * Convention for future family walks (C6-C13, MOR-1560..1567): when a walk
+ * adds real `expectFrames` assertions for a previously-waived intent, add
+ * its name here (one line) and DELETE the matching entry from
+ * `WAIVED_INTENTS` in `./waived.ts` — the completeness test enforces both
+ * (an intent claimed AND waived at once fails, same as one claimed nowhere).
+ *
+ * CLAIMED_INTENTS below are exactly the 20 distinct `sendCommand` frame
+ * names asserted by `expectFrames` calls in
+ * `../mor1428-ic7300-conformance.isolated.test.ts` (MOR-1428) as of this
+ * writing — read off that file's `describe('... handler dispatch ...')`
+ * block, not guessed.
+ */
+
+/** Intent names claimed by MOR-1428's IC-7300 fixture conformance suite. */
+export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
+  'set_mode',
+  'set_filter',
+  'set_band',
+  'set_attenuator',
+  'set_preamp',
+  'set_rf_gain',
+  'set_squelch',
+  'set_agc',
+  'set_nb',
+  'set_nr',
+  'set_af_level',
+  'set_memory_mode',
+  'memory_to_vfo',
+  'memory_write',
+  'set_split',
+  'set_vfo',
+  'set_freq',
+  'set_scope_span',
+  'set_scope_speed',
+  'set_scope_ref',
+]);
+
+/**
+ * `dispatchKeyboardRadioAction` case labels claimed by a conformance case.
+ * Only `toggle_split` is asserted today (MOR-1428's "keyboard context"
+ * case, over `dispatchKeyboardRadioAction({ action: 'toggle_split' })`).
+ * MOR-1563 (C9) walks the remaining 28.
+ */
+export const CLAIMED_KEYBOARD_ACTIONS: ReadonlySet<string> = new Set([
+  'toggle_split',
+]);

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -1,0 +1,136 @@
+/**
+ * MOR-1556 — completeness ledger: explicit WAIVED registries.
+ *
+ * Every intent `panel-commands.ts` can dispatch, and every
+ * `dispatchKeyboardRadioAction` case label, must be either claimed
+ * (`./claimed.ts`) or waived (here) — the completeness meta-test
+ * (`../../../commands/__tests__/panel-commands-completeness.test.ts`)
+ * enforces that split, so a name that is neither claimed nor waived (e.g.
+ * a newly-added intent) fails vitest.
+ *
+ * THIS MAP IS THE BURN-DOWN. When a family walk (C6-C13, MOR-1560..1567)
+ * lands real `expectFrames` coverage for a waived intent: delete it from
+ * the matching `tag([...])` call below, add the name to `CLAIMED_INTENTS`
+ * in `./claimed.ts`, and update the matching `*_COUNT` pin in the same
+ * diff — pinned as a literal so a removal (or a silent re-add) shows up
+ * as a diff / count-assertion break.
+ *
+ * Provenance: family assignment comes from the MOR-1426 decomposition's
+ * per-family "Work" lists (session 19, 2026-08-13), cross-checked against
+ * the actual `dispatchRadioIntent` call sites grouped by factory. One gap:
+ * `makeRitXitHandlers`' 3 intents (`set_rit_status`/`set_rit_tx_status`/
+ * `set_rit_frequency`) aren't named in ANY of MOR-1560..1567's prose — the
+ * family table has a genuine hole there, not a parsing mistake (C6+C7+
+ * C10+C11+C12+C13's own itemized 16 sum to 64, 3 short of 67). They land
+ * on MOR-1567 here because C13 is explicitly the closing sweeper — its own
+ * acceptance criterion is "C2's waiver map is EMPTY ... after this lands".
+ *
+ * ONE DELIBERATE EXCLUSION (full account in the completeness meta-test's
+ * header): `onModInputChange` builds its intent name at runtime via
+ * `modInputCommand(dataMode)`, not a `name: '<literal>'`, so it can't
+ * appear in a source-literal parse and is NOT one of the 67 below — its
+ * 4-value domain is pinned separately by `$lib/radio/mod-input.test.ts`.
+ * MOR-1567's prose calls out "the mod-input command" as in its scope, so
+ * add a case for it there — do not fold it into this map, which would
+ * perturb the pinned 87/67/20 baseline MOR-1426 measured.
+ */
+
+/** One-line justification for an unclaimed intent or keyboard action. */
+export interface Waiver {
+  /** Why no conformance case exists yet. */
+  readonly reason: string;
+  /** Linear ticket id that owns closing this waiver. */
+  readonly owner: string;
+}
+
+/** Tags every name in `names` with the same waiver — one family, one call. */
+function tag(names: readonly string[], waiver: Waiver): Record<string, Waiver> {
+  return Object.fromEntries(names.map((name) => [name, waiver]));
+}
+
+const DSP = { reason: 'DSP family walk not yet landed', owner: 'MOR-1560' } as const;
+const FILTER = { reason: 'Filter/PBT family walk not yet landed', owner: 'MOR-1561' } as const;
+const TX = { reason: 'TX-chain family walk not yet landed', owner: 'MOR-1564' } as const;
+const VOX_CW = { reason: 'VOX/CW family walk not yet landed', owner: 'MOR-1565' } as const;
+const SCOPE_VFO = { reason: 'Scope-remainder/VFO-topology family walk not yet landed', owner: 'MOR-1566' } as const;
+const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner: 'MOR-1567' } as const;
+const KEYBOARD = { reason: 'Keyboard action-fan-out walk not yet landed', owner: 'MOR-1563' } as const;
+
+/**
+ * The 67 intents with no conformance assertion, tagged with the family
+ * child that owns closing them. MOR-1562 (C8, adapter-seam parity)
+ * intentionally claims ZERO entries here — its scope is
+ * `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
+ */
+export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
+  // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — 9
+  ...tag([
+    'set_nr_level', 'set_nb_level', 'set_nb_depth', 'set_nb_width',
+    'set_auto_notch', 'set_manual_notch', 'set_manual_notch_width',
+    'set_notch_filter', 'set_agc_time_constant',
+  ], DSP),
+  // MOR-1561 (C7) — Filter, PBT and IF-shift — 5
+  ...tag([
+    'set_filter_width', 'set_filter_shape', 'set_if_shift',
+    'set_pbt_inner', 'set_pbt_outer',
+  ], FILTER),
+  // MOR-1564 (C10) — TX chain — 8
+  ...tag([
+    'set_rf_power', 'set_mic_gain', 'set_compressor', 'set_compressor_level',
+    'set_monitor', 'set_monitor_gain', 'set_drive_gain', 'set_tuner_status',
+  ], TX),
+  // MOR-1565 (C11) — VOX + CW — 12
+  ...tag([
+    'set_vox', 'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
+    'set_cw_pitch', 'set_key_speed', 'set_break_in', 'set_break_in_delay',
+    'set_apf', 'set_twin_peak', 'cw_auto_tune', 'set_dash_ratio',
+  ], VOX_CW),
+  // MOR-1566 (C12) — scope remainder + VFO topology — 15
+  ...tag([
+    'set_scope_mode', 'set_scope_edge', 'set_scope_hold', 'set_scope_dual',
+    'set_scope_during_tx', 'set_scope_center_type', 'set_scope_vbw',
+    'set_scope_rbw', 'switch_scope_receiver', 'vfo_swap', 'vfo_equalize',
+    'set_dual_watch', 'set_main_sub_tracking', 'quick_dualwatch', 'quick_split',
+  ], SCOPE_VFO),
+  // MOR-1567 (C13) — sweeper — 15 named in its own prose + 3 orphaned
+  // RIT/XIT (see file header) — 18
+  ...tag([
+    'scan_start', 'scan_stop', 'scan_set_df_span', 'scan_set_resume',
+    'set_dial_lock', 'set_powerstat', 'speak', 'set_antenna_1', 'set_antenna_2',
+    'set_rx_antenna_ant1', 'set_rx_antenna_ant2', 'set_data_mode',
+    'set_digisel', 'set_ip_plus', 'memory_clear',
+    'set_rit_status', 'set_rit_tx_status', 'set_rit_frequency',
+  ], SWEEPER),
+};
+
+/** Pinned so a removal (or an undocumented addition) shows up in review. */
+export const WAIVED_INTENTS_COUNT = 67;
+
+/**
+ * The 28 `dispatchKeyboardRadioAction` case labels with no conformance
+ * assertion (only `toggle_split` is claimed — see `./claimed.ts`).
+ *
+ * ON THE PARENT TICKET'S "32 actions" FIGURE: MOR-1563 (written at the
+ * MOR-1426 decomposition) states 32; recounting the actual
+ * `KEYBOARD_RADIO_ACTIONS` set / switch cases in `panel-commands.ts` as of
+ * this ledger lands exactly 29 (28 waived + 1 claimed) — reflecting the
+ * CURRENT source, not the ticket's count at authoring time, per this
+ * program's own honesty doctrine. `adjust_tuning_step`,
+ * `open_filter_settings` and `focus_target` are real keyboard actions but
+ * live in a DIFFERENT switch (`makeKeyboardHandlers().dispatch`,
+ * panel-commands.ts:1588) that `dispatchKeyboardRadioAction` falls through
+ * to on `false` — out of this ledger's scope and absent from
+ * `KEYBOARD_RADIO_ACTIONS`.
+ */
+export const WAIVED_KEYBOARD_ACTIONS: Readonly<Record<string, Waiver>> = tag([
+  'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
+  'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
+  'toggle_auto_notch', 'toggle_ip_plus', 'toggle_rit', 'toggle_xit',
+  'clear_rit_xit', 'adjust_af_level', 'adjust_rf_gain', 'toggle_monitor',
+  'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
+  'toggle_dial_lock', 'scope_span_step', 'scope_ref_step',
+  'scope_toggle_hold', 'scope_toggle_dual', 'scope_toggle_fst',
+], KEYBOARD);
+
+/** Pinned so a removal (or an undocumented addition) shows up in review. */
+export const WAIVED_KEYBOARD_ACTIONS_COUNT = 28;

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -20,10 +20,12 @@
  * the actual `dispatchRadioIntent` call sites grouped by factory. One gap:
  * `makeRitXitHandlers`' 3 intents (`set_rit_status`/`set_rit_tx_status`/
  * `set_rit_frequency`) aren't named in ANY of MOR-1560..1567's prose — the
- * family table has a genuine hole there, not a parsing mistake (C6+C7+
- * C10+C11+C12+C13's own itemized 16 sum to 64, 3 short of 67). They land
- * on MOR-1567 here because C13 is explicitly the closing sweeper — its own
- * acceptance criterion is "C2's waiver map is EMPTY ... after this lands".
+ * family table has a genuine hole there, not a parsing mistake: C6(9) +
+ * C7(5) + C10(8) + C11(12) + C12(15) + 15 literal of C13's own itemized 16
+ * (its 16th is the dynamic mod-input call, tracked separately — see
+ * below) sum to 64, exactly 3 short of 67. They land on MOR-1567 here
+ * because C13 is explicitly the closing sweeper — its own acceptance
+ * criterion is "C2's waiver map is EMPTY ... after this lands".
  *
  * ONE DELIBERATE EXCLUSION (full account in the completeness meta-test's
  * header): `onModInputChange` builds its intent name at runtime via
@@ -110,17 +112,17 @@ export const WAIVED_INTENTS_COUNT = 67;
  * The 28 `dispatchKeyboardRadioAction` case labels with no conformance
  * assertion (only `toggle_split` is claimed — see `./claimed.ts`).
  *
- * ON THE PARENT TICKET'S "32 actions" FIGURE: MOR-1563 (written at the
- * MOR-1426 decomposition) states 32; recounting the actual
- * `KEYBOARD_RADIO_ACTIONS` set / switch cases in `panel-commands.ts` as of
- * this ledger lands exactly 29 (28 waived + 1 claimed) — reflecting the
- * CURRENT source, not the ticket's count at authoring time, per this
- * program's own honesty doctrine. `adjust_tuning_step`,
- * `open_filter_settings` and `focus_target` are real keyboard actions but
- * live in a DIFFERENT switch (`makeKeyboardHandlers().dispatch`,
- * panel-commands.ts:1588) that `dispatchKeyboardRadioAction` falls through
- * to on `false` — out of this ledger's scope and absent from
- * `KEYBOARD_RADIO_ACTIONS`.
+ * ON THE PARENT TICKET'S "32 actions" FIGURE: MOR-1563 states 32 — that is
+ * correct, not stale. It is 29 radio-family cases in
+ * `dispatchKeyboardRadioAction` (28 waived here + 1 claimed) PLUS 3
+ * non-radio actions (`adjust_tuning_step`, `open_filter_settings`,
+ * `focus_target`) that live in a DIFFERENT switch
+ * (`makeKeyboardHandlers().dispatch`, panel-commands.ts:1588) which
+ * `dispatchKeyboardRadioAction` falls through to on `false`. This ledger
+ * (MOR-1556) names `dispatchKeyboardRadioAction` specifically, so those 3
+ * are a deliberate SCOPE BOUNDARY, not a count discrepancy — they are
+ * absent from `KEYBOARD_RADIO_ACTIONS` and out of scope here by design,
+ * not because they were miscounted.
  */
 export const WAIVED_KEYBOARD_ACTIONS: Readonly<Record<string, Waiver>> = tag([
   'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
@@ -1,0 +1,188 @@
+/**
+ * MOR-1556 (C2) — conformance completeness ledger.
+ *
+ * 67 of panel-commands.ts's 87 distinct dispatched intent names have no
+ * conformance assertion (MOR-1428/MOR-1555 claims 20), and nothing made
+ * that visible — the exact failure shape the whole MOR-1426 program exists
+ * to kill (green tests, dead controls). This meta-test is the visibility:
+ * every intent name the command layer can emit, and every
+ * `dispatchKeyboardRadioAction` case label, must be either claimed
+ * (`../../adapters/__tests__/conformance/claimed.ts`) or explicitly waived
+ * with an owning ticket (`.../conformance/waived.ts`) — adding a new
+ * intent or case label without touching one of those two files fails.
+ *
+ * SOURCE PARSING, AND ITS FRAGILITY: an exported runtime registry
+ * (panel-commands.ts declaring its own intent list) was rejected — every
+ * intent is already a literal at its one call site, so a second list
+ * would exist only to satisfy this test. Instead this file parses the
+ * SOURCE TEXT (`fs.readFileSync`, never imported/executed) for two shapes:
+ *
+ *   1. `dispatchRadioIntent({ name: '<intent>', ... })` — `INTENT_CALL_RE`.
+ *      Requires `name:` to be the FIRST property (true at all 119 literal
+ *      call sites today, including the multi-line one at ~line 877-880) —
+ *      a call putting `params` before `name` would silently NOT match.
+ *      Handles both quote styles and any whitespace/newlines before the
+ *      string (`\s` is newline-inclusive).
+ *
+ *   2. `case '<action>':` inside `dispatchKeyboardRadioAction`'s switch
+ *      body only — sliced between that function and the next
+ *      `export function` (`makeKeyboardHandlers`), so that function's OWN
+ *      switch (`adjust_tuning_step`/`open_filter_settings`/`focus_target`)
+ *      is deliberately excluded — see `waived.ts`'s header.
+ *
+ * DYNAMIC NAME, VERIFIED AND HANDLED EXPLICITLY: one call site,
+ * `onModInputChange`, computes its name at runtime via
+ * `modInputCommand(dataMode)` — not a literal, so `INTENT_CALL_RE`
+ * correctly skips it and it is not counted toward 87/67/20. Its 4-value
+ * domain is pinned separately by `$lib/radio/mod-input.test.ts`; the
+ * `describe('dynamic mod-input call site...')` block below asserts the
+ * source still contains EXACTLY one such non-literal call, so a second
+ * one introduced later fails loudly instead of silently escaping both
+ * this parse and mod-input.test.ts's coverage.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  CLAIMED_INTENTS,
+  CLAIMED_KEYBOARD_ACTIONS,
+} from '../../adapters/__tests__/conformance/claimed';
+import {
+  WAIVED_INTENTS,
+  WAIVED_INTENTS_COUNT,
+  WAIVED_KEYBOARD_ACTIONS,
+  WAIVED_KEYBOARD_ACTIONS_COUNT,
+} from '../../adapters/__tests__/conformance/waived';
+
+// `import.meta.url` isn't a reliable `file://` URL under every vitest
+// transform pipeline in this repo — resolve from the repo-relative path
+// instead, anchored on `process.cwd()` (always `frontend/` for this suite).
+const PANEL_COMMANDS_PATH = resolve(process.cwd(), 'src/lib/runtime/commands/panel-commands.ts');
+const SOURCE = readFileSync(PANEL_COMMANDS_PATH, 'utf8');
+
+/** Every `dispatchRadioIntent({ name: '<literal>', ... })` call site. */
+const INTENT_CALL_RE = /dispatchRadioIntent\(\s*\{\s*name:\s*(['"])([A-Za-z0-9_]+)\1/g;
+
+/**
+ * `dispatchRadioIntent({ name:` header, without requiring what follows —
+ * walked by hand below to classify literal vs. dynamic call sites. (A
+ * single regex with a `(?!['"])` lookahead was tried first and rejected:
+ * `\s*` before the lookahead backtracks to a zero-width match, so the
+ * lookahead sees a plain space instead of the quote and false-positives on
+ * every literal call — a backtracking pitfall worth documenting.)
+ */
+const INTENT_CALL_HEADER_RE = /dispatchRadioIntent\(\s*\{\s*name:/g;
+
+function extractSourceIntents(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of source.matchAll(INTENT_CALL_RE)) names.add(match[2]);
+  return names;
+}
+
+/** Call sites whose `name:` value is not a plain quoted string literal. */
+function findDynamicIntentCalls(source: string): number[] {
+  const indices: number[] = [];
+  for (const match of source.matchAll(INTENT_CALL_HEADER_RE)) {
+    let i = match.index + match[0].length;
+    while (i < source.length && /\s/.test(source[i])) i++;
+    if (source[i] !== "'" && source[i] !== '"') indices.push(match.index);
+  }
+  return indices;
+}
+
+/** Slice bounding `dispatchKeyboardRadioAction`'s body — see file header. */
+function extractKeyboardActionBody(source: string): string {
+  const start = source.indexOf('export function dispatchKeyboardRadioAction');
+  if (start === -1) throw new Error('dispatchKeyboardRadioAction not found — renamed or removed?');
+  const nextFn = source.indexOf('\nexport function ', start + 1);
+  if (nextFn === -1) throw new Error('no end boundary (next export function) after dispatchKeyboardRadioAction');
+  return source.slice(start, nextFn);
+}
+
+const CASE_LABEL_RE = /case\s+(['"])([A-Za-z0-9_]+)\1\s*:/g;
+
+function extractKeyboardActions(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of extractKeyboardActionBody(source).matchAll(CASE_LABEL_RE)) names.add(match[2]);
+  return names;
+}
+
+/**
+ * Shared completeness assertions, parameterized over intents vs. keyboard
+ * case labels — the same seven checks both ledgers need (see MOR-1556's
+ * acceptance criteria): every source name accounted for, no double-booking,
+ * no stale waivers/claims, and both `*_COUNT` pins verified.
+ */
+function completenessSuite(opts: {
+  label: string;
+  sourceNames: Set<string>;
+  claimed: ReadonlySet<string>;
+  waived: Readonly<Record<string, unknown>>;
+  waivedCount: number;
+  claimedCount: number;
+}): void {
+  const { label, sourceNames, claimed, waived, waivedCount, claimedCount } = opts;
+  const claimedAndWaived = new Set([...claimed, ...Object.keys(waived)]);
+
+  describe(label, () => {
+    it('extracted at least one name — parse sanity (zero means the regex broke)', () => {
+      expect(sourceNames.size).toBeGreaterThan(0);
+    });
+
+    it('every name in the source is claimed or waived', () => {
+      expect([...sourceNames].filter((n) => !claimedAndWaived.has(n))).toEqual([]);
+    });
+
+    it('no name is both claimed and waived (a landed walk must delete the waiver)', () => {
+      expect([...claimed].filter((n) => n in waived)).toEqual([]);
+    });
+
+    it('every waived name still exists in source (no stale waivers)', () => {
+      expect(Object.keys(waived).filter((n) => !sourceNames.has(n))).toEqual([]);
+    });
+
+    it('every claimed name still exists in source', () => {
+      expect([...claimed].filter((n) => !sourceNames.has(n))).toEqual([]);
+    });
+
+    it('pinned waiver/claimed counts — a removal or undocumented addition shows in the diff', () => {
+      expect(Object.keys(waived)).toHaveLength(waivedCount);
+      expect(claimed.size).toBe(claimedCount);
+    });
+
+    it('claimed + waived accounts for every name, with no extras either side', () => {
+      expect(claimedAndWaived.size).toBe(sourceNames.size);
+    });
+  });
+}
+
+completenessSuite({
+  label: 'panel-commands.ts intent completeness ledger (MOR-1556)',
+  sourceNames: extractSourceIntents(SOURCE),
+  claimed: CLAIMED_INTENTS,
+  waived: WAIVED_INTENTS,
+  waivedCount: WAIVED_INTENTS_COUNT,
+  claimedCount: 20,
+});
+
+completenessSuite({
+  label: 'dispatchKeyboardRadioAction case-label completeness ledger (MOR-1556, owner MOR-1563)',
+  sourceNames: extractKeyboardActions(SOURCE),
+  claimed: CLAIMED_KEYBOARD_ACTIONS,
+  waived: WAIVED_KEYBOARD_ACTIONS,
+  waivedCount: WAIVED_KEYBOARD_ACTIONS_COUNT,
+  claimedCount: 1,
+});
+
+describe('dynamic mod-input call site (verified, handled explicitly — MOR-1567 scope)', () => {
+  const dynamicCalls = findDynamicIntentCalls(SOURCE);
+
+  it('exactly one dispatchRadioIntent call has a non-literal name', () => {
+    expect(dynamicCalls).toHaveLength(1);
+  });
+
+  it('that one dynamic call site is onModInputChange\'s modInputCommand(...) construction', () => {
+    const [start] = dynamicCalls;
+    expect(SOURCE.slice(start, start + 120)).toContain('modInputCommand(dataMode as number)');
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
@@ -20,15 +20,27 @@
  *   1. `dispatchRadioIntent({ name: '<intent>', ... })` — `INTENT_CALL_RE`.
  *      Requires `name:` to be the FIRST property (true at all 119 literal
  *      call sites today, including the multi-line one at ~line 877-880) —
- *      a call putting `params` before `name` would silently NOT match.
- *      Handles both quote styles and any whitespace/newlines before the
- *      string (`\s` is newline-inclusive).
+ *      a call putting `params` before `name` (`{ params: {...}, name: 'x'
+ *      }`) does NOT match this regex, or `INTENT_CALL_HEADER_RE` below.
+ *      That shape is NOT silently invisible, though: the "total
+ *      accounting" describe block asserts every `dispatchRadioIntent(`
+ *      occurrence in the file is either a literal match or a known-dynamic
+ *      call, so a params-first (or any other unparseable) call site fails
+ *      that check loudly instead of slipping past every other assertion
+ *      unclaimed and unwaived. Handles both quote styles and any
+ *      whitespace/newlines before the string (`\s` is newline-inclusive).
  *
  *   2. `case '<action>':` inside `dispatchKeyboardRadioAction`'s switch
  *      body only — sliced between that function and the next
  *      `export function` (`makeKeyboardHandlers`), so that function's OWN
  *      switch (`adjust_tuning_step`/`open_filter_settings`/`focus_target`)
- *      is deliberately excluded — see `waived.ts`'s header.
+ *      is deliberately excluded — see `waived.ts`'s header. The
+ *      `KEYBOARD_RADIO_ACTIONS` set literal (the dispatcher's actual entry
+ *      gate) is parsed independently and checked for set-equality against
+ *      these case labels, so an action added to the set with no matching
+ *      `case` — a silent dead control, since the gate passes and the
+ *      switch falls to `default` — fails loudly instead of never
+ *      surfacing (it would produce no `case` label to claim or waive).
  *
  * DYNAMIC NAME, VERIFIED AND HANDLED EXPLICITLY: one call site,
  * `onModInputChange`, computes its name at runtime via
@@ -39,6 +51,16 @@
  * source still contains EXACTLY one such non-literal call, so a second
  * one introduced later fails loudly instead of silently escaping both
  * this parse and mod-input.test.ts's coverage.
+ *
+ * KNOWN OVER-STRICT FALSE POSITIVES (would fail this suite even though
+ * production behavior is fine — none exist in the source today, but both
+ * are plain string/regex parsing against text, not an AST, so neither is
+ * filtered): a `dispatchRadioIntent(...)` call sitting inside a `//` or
+ * `/* * /` comment counts toward the total in the "total accounting"
+ * check; and a `case '<label>':` inside a SECOND, nested `switch`
+ * statement within `dispatchKeyboardRadioAction`'s body (there isn't one
+ * today) would count toward `extractKeyboardActions` and
+ * `KEYBOARD_RADIO_ACTIONS` set-equality as if it were a top-level case.
  */
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -104,6 +126,24 @@ const CASE_LABEL_RE = /case\s+(['"])([A-Za-z0-9_]+)\1\s*:/g;
 function extractKeyboardActions(source: string): Set<string> {
   const names = new Set<string>();
   for (const match of extractKeyboardActionBody(source).matchAll(CASE_LABEL_RE)) names.add(match[2]);
+  return names;
+}
+
+/**
+ * The `KEYBOARD_RADIO_ACTIONS` set literal that gates
+ * `dispatchKeyboardRadioAction`'s entry (`if (!KEYBOARD_RADIO_ACTIONS.has(
+ * action)) return false;`) — parsed independently of the `case` labels so a
+ * name added to the set with no matching `case` (a silent dead control:
+ * the gate passes, the switch falls to `default`, nothing dispatches) is
+ * detectable by set-equality against `extractKeyboardActions` below.
+ */
+function extractKeyboardRadioActionsSet(source: string): Set<string> {
+  const start = source.indexOf('const KEYBOARD_RADIO_ACTIONS = new Set([');
+  if (start === -1) throw new Error('KEYBOARD_RADIO_ACTIONS not found — renamed or removed?');
+  const end = source.indexOf(']);', start);
+  if (end === -1) throw new Error('KEYBOARD_RADIO_ACTIONS literal not closed with ]);');
+  const names = new Set<string>();
+  for (const match of source.slice(start, end).matchAll(/(['"])([A-Za-z0-9_]+)\1/g)) names.add(match[2]);
   return names;
 }
 
@@ -184,5 +224,37 @@ describe('dynamic mod-input call site (verified, handled explicitly — MOR-1567
   it('that one dynamic call site is onModInputChange\'s modInputCommand(...) construction', () => {
     const [start] = dynamicCalls;
     expect(SOURCE.slice(start, start + 120)).toContain('modInputCommand(dataMode as number)');
+  });
+});
+
+describe('total accounting (no unparseable dispatchRadioIntent shape slips through)', () => {
+  // A call written `{ params: {...}, name: 'x' }` (params before name)
+  // matches neither `INTENT_CALL_RE` (requires `name:` first) nor
+  // `INTENT_CALL_HEADER_RE` (same requirement) — it would silently vanish
+  // from BOTH the literal parse and the dynamic-call count, passing every
+  // completeness assertion above while never being claimed or waived. This
+  // is the total-accounting invariant that catches that shape (and any
+  // other unparseable one): every `dispatchRadioIntent(` occurrence in the
+  // file must be EITHER a literal match OR a known-dynamic call — no third
+  // category.
+  it('every call site is either a literal match or a known dynamic call', () => {
+    const total = [...SOURCE.matchAll(/dispatchRadioIntent\(/g)].length;
+    const literal = [...SOURCE.matchAll(INTENT_CALL_RE)].length;
+    const dynamic = findDynamicIntentCalls(SOURCE).length;
+    expect(total).toBe(literal + dynamic);
+  });
+});
+
+describe('KEYBOARD_RADIO_ACTIONS set vs. case labels (no case-less dead control)', () => {
+  // The dispatcher's entry gate is `KEYBOARD_RADIO_ACTIONS.has(action)` —
+  // an action added to that set with no matching `case` passes the gate,
+  // falls through the switch to `default`, and silently no-ops forever.
+  // Set-equality against the parsed `case` labels catches it (and the
+  // inverse: a `case` with no matching set entry, which is unreachable
+  // since the gate would already have returned `false`).
+  it('KEYBOARD_RADIO_ACTIONS and the switch\'s case labels are set-equal', () => {
+    const declared = [...extractKeyboardRadioActionsSet(SOURCE)].sort();
+    const cased = [...extractKeyboardActions(SOURCE)].sort();
+    expect(declared).toEqual(cased);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a meta-test enumerating every intent name `panel-commands.ts`'s `dispatchRadioIntent` calls can emit, plus every `dispatchKeyboardRadioAction` case label, and requires each to be either **claimed** by a conformance case or explicitly **waived** with an owning ticket.
- `CLAIMED_INTENTS`/`CLAIMED_KEYBOARD_ACTIONS` (`frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts`): the 20 intents + 1 keyboard action (`toggle_split`) MOR-1428's `expectFrames` calls already assert.
- `WAIVED_INTENTS`/`WAIVED_KEYBOARD_ACTIONS` (`frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts`): the 67 uncovered intents tagged to their MOR-1560..1567 family-walk child, and 28 uncovered keyboard actions tagged to MOR-1563. Both maps pin a literal count (**67** and **28**) so a removal or an undocumented addition shows up in review.
- The meta-test (`frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts`) source-parses `panel-commands.ts` rather than adding a new production-code registry; the parse's fragility, and the one dynamic call site (`onModInputChange`'s `modInputCommand(...)`) that is verified and explicitly excluded from the literal parse, are documented in the file headers.

**Pinned counts:** 87 total distinct literal intents = 20 claimed + 67 waived. 29 total `dispatchKeyboardRadioAction` case labels = 1 claimed + 28 waived (the parent ticket MOR-1563's "32 actions" is correct, not stale — it's 29 radio-family cases + 3 non-radio actions living in a different switch, `makeKeyboardHandlers().dispatch`; a deliberate scope boundary, documented in `waived.ts`).

One genuine family-table gap found and documented: `makeRitXitHandlers`' 3 intents (`set_rit_status`/`set_rit_tx_status`/`set_rit_frequency`) aren't named in any of MOR-1560..1567's prose. Assigned to MOR-1567 (C13, the closing sweeper) per its own acceptance criterion ("waiver map is EMPTY ... after this lands").

### Independent review follow-up (2 blockers + 4 nits, this push)

An independent review found two shapes that would pass every original assertion while never actually being claimed or waived:

- **Total-accounting guard** (`describe('total accounting ...')`): a `dispatchRadioIntent` call written params-first (`{ params: {...}, name: 'x' }`) matches neither the literal-name regex nor the dynamic-call header regex, so it silently vanished from both counts. Now asserts every `dispatchRadioIntent(` occurrence in the source is either a literal match or a known dynamic call — no third, unparseable category.
- **`KEYBOARD_RADIO_ACTIONS` set-equality guard** (`describe('KEYBOARD_RADIO_ACTIONS set vs. case labels ...')`): an action added to the `KEYBOARD_RADIO_ACTIONS` set with no matching `case` passes the dispatcher's entry gate and silently no-ops (falls to `default`) — it produces no `case` label, so it was invisible to the claimed/waived accounting. Now parses the set literal independently and asserts set-equality against the parsed `case` labels.

Plus 4 honesty nits: corrected the 29-vs-32 explanation (scope boundary, not a stale count), fixed the C13 sum arithmetic (15 literal of its 16 itemized intents — the 16th is the dynamic mod-input call), narrowed `claimed.ts`'s "every intent" to "every literal-named intent", and documented two known over-strict false positives (a commented-out dispatch call, a hypothetical nested switch) in the meta-test header.

Closes MOR-1556

## Test plan

- [x] `npx vitest run src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts` — 18/18 pass
- [x] Red-first (original): temporarily added a fake intent (`mor_1556_scratch_fake_intent`) to `panel-commands.ts`, confirmed the meta-test fails, reverted (clean `git diff`)
- [x] Red-first (review blockers): (a) added `dispatchRadioIntent({ params: {}, name: 'probe_paramsfirst' })` — total-accounting assertion failed (121 vs 120); (b) added case-less `'probe_set_only_action'` to `KEYBOARD_RADIO_ACTIONS` — set-equality assertion failed (29 vs 28); both reverted, clean `git diff` on `panel-commands.ts` confirmed before each commit
- [x] Targeted suite (completeness + MOR-1428 conformance + panel-commands intent + keyboard delegation + mod-input): 160/160 pass
- [x] Full frontend `npx vitest run` (first push): 338 files / 7223 tests pass (no regressions)
- [x] `eslint` on the 3 changed files + `npm run lint` (full `src/`) — clean
- [x] `npm run lint:boundaries` — clean; boundary grep (`$lib/transport`/`audio-manager` in panels/layouts, and internal-identifier boundary grep on the diff) — empty
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- [x] `git diff` — no unintended changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

