### PR TITLE
test: fixture provenance sidecar + staleness guard (MOR-1557)

### DIFF
--- a/frontend/scripts/capture-profile.mjs
+++ b/frontend/scripts/capture-profile.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Live radio-profile capture (MOR-1428).
+ * Live radio-profile capture (MOR-1428, sidecar provenance MOR-1557).
  *
  * Fetches `/api/v1/state` and `/api/v1/capabilities` from a running
  * rigplane-core web server and writes them into the fixture pair a
@@ -16,23 +16,27 @@
  *
  * Usage
  * -----
- *   node scripts/capture-profile.mjs <baseUrl> <name> [outDir]
+ *   node scripts/capture-profile.mjs <baseUrl> <name> [outDir] [--backend-sha <sha>]
  *
  * `<baseUrl>` is required — there is no default — and must point at a
  * reachable rigplane-core web server, e.g.:
  *
  *   node scripts/capture-profile.mjs http://localhost:8099 ic7300
  *   node scripts/capture-profile.mjs http://localhost:8099 ic7300 \
- *     src/lib/runtime/adapters/__tests__/fixtures
+ *     src/lib/runtime/adapters/__tests__/fixtures --backend-sha e0b19814
  *
- * Writes `<outDir>/<name>-state.json` and `<outDir>/<name>-capabilities.json`
- * (default `outDir`: `src/lib/runtime/adapters/__tests__/fixtures`, relative
- * to `frontend/`). Keys are recursively sorted so successive captures of an
- * unchanged radio diff cleanly. Each file's top-level `_provenance` sibling
- * fields are NOT embedded in the JSON itself (the payload must stay a
- * byte-faithful capture of the real API response) — provenance (base URL,
- * capture date, radio model, backend HEAD SHA) is printed to stdout for the
- * caller to record in the fixture loader's header comment and the PR body.
+ * The backend HEAD SHA can also be passed via `RIGPLANE_BACKEND_SHA` env
+ * (the `--backend-sha` flag wins if both are given); recorded verbatim,
+ * never derived by shelling out to git here.
+ *
+ * Writes `<outDir>/<name>-state.json`, `<outDir>/<name>-capabilities.json`
+ * (default `outDir`: `src/lib/runtime/adapters/__tests__/fixtures`, keys
+ * recursively sorted, byte-faithful and metadata-free), plus a sidecar
+ * `<outDir>/<name>-provenance.json` carrying the capture metadata instead:
+ * capture timestamp, radio model, receivers, stateContractVersion,
+ * providerGeneration, backend HEAD SHA. PUBLIC BOUNDARY: the sidecar NEVER
+ * records the bench host/IP/URL — `source` is always the fixed string
+ * `"local bench instance"`, regardless of what `<baseUrl>` was.
  */
 
 import { mkdir, writeFile } from 'node:fs/promises';
@@ -62,15 +66,36 @@ async function fetchJson(baseUrl, path) {
   return { url, body: await response.json() };
 }
 
+/** Splits `--backend-sha <sha>` / `--backend-sha=<sha>` out of the positional args. */
+function parseArgs(argv) {
+  const positional = [];
+  let backendSha;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--backend-sha') {
+      backendSha = argv[++i];
+    } else if (arg.startsWith('--backend-sha=')) {
+      backendSha = arg.slice('--backend-sha='.length);
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { positional, backendSha };
+}
+
 async function main() {
-  const [baseUrlArg, name, outDirArg] = process.argv.slice(2);
+  const { positional, backendSha: backendShaFlag } = parseArgs(process.argv.slice(2));
+  const [baseUrlArg, name, outDirArg] = positional;
   if (!baseUrlArg || !name) {
-    console.error('Usage: node scripts/capture-profile.mjs <baseUrl> <name> [outDir]');
+    console.error(
+      'Usage: node scripts/capture-profile.mjs <baseUrl> <name> [outDir] [--backend-sha <sha>]',
+    );
     process.exitCode = 1;
     return;
   }
   const baseUrl = baseUrlArg.replace(/\/+$/, '');
   const outDir = resolve(FRONTEND_ROOT, outDirArg ?? DEFAULT_OUT_DIR);
+  const backendHeadSha = backendShaFlag ?? process.env.RIGPLANE_BACKEND_SHA ?? null;
 
   const [state, capabilities] = await Promise.all([
     fetchJson(baseUrl, '/api/v1/state'),
@@ -80,22 +105,37 @@ async function main() {
   await mkdir(outDir, { recursive: true });
   const statePath = join(outDir, `${name}-state.json`);
   const capsPath = join(outDir, `${name}-capabilities.json`);
+  const provenancePath = join(outDir, `${name}-provenance.json`);
   await writeFile(statePath, `${JSON.stringify(sortKeysDeep(state.body), null, 2)}\n`, 'utf8');
   await writeFile(capsPath, `${JSON.stringify(sortKeysDeep(capabilities.body), null, 2)}\n`, 'utf8');
 
   const capturedAt = new Date().toISOString();
+  // PUBLIC BOUNDARY (absolute rule): never record the bench host/IP/URL here
+  // — `source` is always this fixed string, regardless of `baseUrl`.
+  const provenance = {
+    capturedAt,
+    radioModel: capabilities.body.model ?? null,
+    receivers: capabilities.body.receivers ?? null,
+    stateContractVersion: state.body.stateContractVersion ?? null,
+    providerGeneration: state.body.providerGeneration ?? null,
+    backendHeadSha,
+    source: 'local bench instance',
+  };
+  await writeFile(provenancePath, `${JSON.stringify(provenance, null, 2)}\n`, 'utf8');
+
   console.log('Captured profile:');
-  console.log(`  model:        ${capabilities.body.model ?? '(unknown)'}`);
-  console.log(`  receivers:    ${capabilities.body.receivers ?? '(unknown)'}`);
-  console.log(`  base URL:     ${baseUrl}`);
+  console.log(`  model:        ${provenance.radioModel ?? '(unknown)'}`);
+  console.log(`  receivers:    ${provenance.receivers ?? '(unknown)'}`);
   console.log(`  captured at:  ${capturedAt}`);
+  console.log(`  backend SHA:  ${backendHeadSha ?? '(not provided — pass --backend-sha)'}`);
   console.log(`  state ->      ${statePath}`);
   console.log(`  caps  ->      ${capsPath}`);
+  console.log(`  provenance -> ${provenancePath}`);
   console.log('');
-  console.log('Record base URL / capture date / radio model / backend HEAD SHA');
-  console.log('in the fixture loader\'s header comment and the PR body — the raw');
-  console.log('JSON payloads intentionally carry no provenance metadata of their');
-  console.log('own (they must stay a byte-faithful capture of the real API).');
+  console.log('The state/capabilities JSON stay byte-faithful and metadata-free —');
+  console.log('capture provenance now lives only in the sidecar above (never the');
+  console.log('bench host/IP/URL — update the fixture loader\'s header comment and');
+  console.log('the PR body by hand to describe the bench in prose if useful).');
 }
 
 main().catch((error) => {

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts
@@ -1,0 +1,258 @@
+/**
+ * MOR-1557 — fixture provenance staleness guard.
+ *
+ * MOR-1553 item 1 found, by hand, that `ic7300-state.json` still carries the
+ * PRE-MOR-1548 shape for `notch_filter`: a top-level `notchFilter` field
+ * (plus its `fieldStatus.notchFilter` entry), even though `state.ts`
+ * reclassified it as receiver-scoped (`main.notchFilter`) when the notch
+ * readback was fixed to stop clobbering MAIN with SUB's fact (MOR-1548, PR
+ * #2466). Nothing detected that drift automatically — this is the automatic
+ * version, run for every profile in `conformance/profiles.ts` against the
+ * CURRENT `ServerStatePublic`/`ReceiverStatePublic`/`Capabilities`
+ * interfaces (parsed straight from `state.ts`/`capabilities.ts` via the TS
+ * compiler API, so the guard can't itself drift from the real type).
+ *
+ * `fieldStatus` keys are checked against the UNION of two sources, since
+ * neither alone is complete: `empty-store-field-status.json` (the backend's
+ * CI-gated default-seed registry — covers reserved paths with no TS
+ * counterpart, e.g. `main.antiVoxGain`) and a structural walk of the SAME
+ * parsed interfaces (covers `connection.*`/`radioHealth.*`/`scopeControls.*`,
+ * which only get a status once actually observed, so the empty-snapshot
+ * registry never seeds them). `notchFilter` (dotless) fails both checks —
+ * exactly the drift this guard exists to catch.
+ *
+ * A fixture with a top-level/receiver/fieldStatus field the current schema
+ * no longer defines, or missing a newly-required field, fails here — UNLESS
+ * allow-listed in `KNOWN_STALE_FIELDS` (used only for the one documented,
+ * tracked drift; MOR-1553/MOR-1558).
+ *
+ * A second block cross-checks the retroactive `<name>-provenance.json`
+ * sidecar (item 4) against the loader header's documented capture facts.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+import emptyFieldStatus from '$lib/state/__tests__/fixtures/empty-store-field-status.json';
+import { PROFILES } from './profiles';
+
+// process.cwd() (vitest's project root, `frontend/`), not import.meta.url —
+// a sibling JSON import in this same file rewires import.meta.url to a
+// virtual dev-server origin under the jsdom `fast` project, breaking
+// fileURLToPath. process.cwd() is stable regardless.
+const CONFORMANCE_DIR = resolve(process.cwd(), 'src/lib/runtime/adapters/__tests__/conformance');
+const STATE_TS_PATH = resolve(process.cwd(), 'src/lib/types/state.ts');
+const CAPABILITIES_TS_PATH = resolve(process.cwd(), 'src/lib/types/capabilities.ts');
+const FIXTURES_DIR = resolve(CONFORMANCE_DIR, '../fixtures');
+
+// Known-stale fixture fields, allow-listed pending re-capture (MOR-1558, C4
+// of MOR-1426). Remove an entry ONLY once the fixture is genuinely
+// re-captured — removing it while the fixture is unchanged must turn this
+// guard red again (see PR body for the reproduction).
+const KNOWN_STALE_FIELDS: Record<string, { stateTopLevel: string[]; fieldStatus: string[] }> = {
+  ic7300: { stateTopLevel: ['notchFilter'], fieldStatus: ['notchFilter'] },
+};
+
+interface FieldInfo {
+  name: string;
+  required: boolean;
+}
+
+interface InterfaceInfo {
+  fields: FieldInfo[];
+  hasIndexSignature: boolean;
+}
+
+/** Extracts `PropertySignature` members of a top-level `interface <name>` via the TS AST. */
+function parseInterfaceFields(sourceFile: ts.SourceFile, interfaceName: string): InterfaceInfo {
+  let found: ts.InterfaceDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
+      found = node;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`interface ${interfaceName} not found in ${sourceFile.fileName}`);
+  }
+  const fields: FieldInfo[] = [];
+  let hasIndexSignature = false;
+  for (const member of found.members) {
+    if (ts.isPropertySignature(member) && ts.isIdentifier(member.name)) {
+      fields.push({ name: member.name.text, required: !member.questionToken });
+    } else if (ts.isIndexSignatureDeclaration(member)) {
+      hasIndexSignature = true;
+    }
+  }
+  return { fields, hasIndexSignature };
+}
+
+const stateSourceFile = ts.createSourceFile(
+  STATE_TS_PATH,
+  readFileSync(STATE_TS_PATH, 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+);
+const capabilitiesSourceFile = ts.createSourceFile(
+  CAPABILITIES_TS_PATH,
+  readFileSync(CAPABILITIES_TS_PATH, 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+);
+
+const INTERFACE_CACHE = new Map<string, InterfaceInfo>();
+function stateInterface(name: string): InterfaceInfo {
+  let info = INTERFACE_CACHE.get(name);
+  if (!info) {
+    info = parseInterfaceFields(stateSourceFile, name);
+    INTERFACE_CACHE.set(name, info);
+  }
+  return info;
+}
+
+const SERVER_STATE = stateInterface('ServerStatePublic');
+const RECEIVER_STATE = stateInterface('ReceiverStatePublic');
+const CAPABILITIES = parseInterfaceFields(capabilitiesSourceFile, 'Capabilities');
+
+// Hand-written addition on top of the generated `ServerStatePublic` block
+// (state.ts's own "Hand-written UI section") — not schema drift.
+const HAND_WRITTEN_STATE_KEYS = ['transportSeq'];
+
+const SERVER_STATE_NAMES = new Set([
+  ...SERVER_STATE.fields.map((f) => f.name),
+  ...HAND_WRITTEN_STATE_KEYS,
+]);
+const RECEIVER_STATE_NAMES = new Set(RECEIVER_STATE.fields.map((f) => f.name));
+const REGISTERED_FIELD_STATUS_PATHS = new Set(Object.keys(emptyFieldStatus));
+
+// `fieldStatus` dotted-path containers: a top-level field whose value is an
+// object (e.g. `connection`, `main`) gets its own leaf entries
+// (`connection.rigConnected`, `main.afLevel`). Maps the field name to the
+// `state.ts` interface describing its members.
+const FIELD_STATUS_CONTAINERS: Record<string, string> = {
+  connection: 'ConnectionPublic',
+  radioDetail: 'RadioDetailPublic',
+  radioHealth: 'RadioHealthPublic',
+  scopeControls: 'ScopeControlsPublic',
+  main: 'ReceiverStatePublic',
+  sub: 'ReceiverStatePublic',
+};
+// One level deeper: `main.vfoA.freqHz` / `main.unselectedVfo.mode`.
+const RECEIVER_SUB_CONTAINERS: Record<string, string> = {
+  vfoA: 'VfoSlotPublic',
+  vfoB: 'VfoSlotPublic',
+  unselectedVfo: 'VfoSlotPublic',
+};
+
+/** True if `path` is seeded by the backend's default field-status registry (see module doc). */
+function isRegisteredFieldStatusPath(path: string): boolean {
+  return REGISTERED_FIELD_STATUS_PATHS.has(path);
+}
+
+/** Structurally validates a `fieldStatus` dotted key path against the current `state.ts` types. */
+function isStructurallyValidFieldStatusPath(path: string): boolean {
+  const segments = path.split('.');
+  const [head, ...rest] = segments;
+  if (!SERVER_STATE_NAMES.has(head)) return false;
+  if (rest.length === 0) return true;
+
+  const containerName = FIELD_STATUS_CONTAINERS[head];
+  if (!containerName) return false; // e.g. a scalar top-level field can't have a dotted child.
+  const container = stateInterface(containerName);
+  const [second, ...tail] = rest;
+  if (!container.fields.some((f) => f.name === second)) return false;
+  if (tail.length === 0) return true;
+
+  if (containerName !== 'ReceiverStatePublic' || tail.length !== 1) return false;
+  const subContainerName = RECEIVER_SUB_CONTAINERS[second];
+  if (!subContainerName) return false;
+  const subContainer = stateInterface(subContainerName);
+  return subContainer.fields.some((f) => f.name === tail[0]);
+}
+
+function driftMessage(profileName: string, section: string, verb: string, fields: string[]): string {
+  return (
+    `Fixture '${profileName}' ${section} ${verb} field(s) [${fields.join(', ')}] — `
+    + 're-capture required — see MOR-1410 bench session.'
+  );
+}
+
+describe('fixture provenance staleness guard (MOR-1557)', () => {
+  for (const [profileName, profile] of Object.entries(PROFILES)) {
+    const allow = KNOWN_STALE_FIELDS[profileName] ?? { stateTopLevel: [], fieldStatus: [] };
+
+    describe(profileName, () => {
+      it('state: carries no top-level field ServerStatePublic no longer defines', () => {
+        const extra = Object.keys(profile.state).filter(
+          (key) => !SERVER_STATE_NAMES.has(key) && !allow.stateTopLevel.includes(key),
+        );
+        expect(extra, driftMessage(profileName, 'state', 'carries stale', extra)).toEqual([]);
+      });
+
+      it('state: has every field ServerStatePublic now requires', () => {
+        const missing = SERVER_STATE.fields
+          .filter((f) => f.required)
+          .map((f) => f.name)
+          .filter((name) => !(name in profile.state));
+        expect(missing, driftMessage(profileName, 'state', 'is missing required', missing)).toEqual([]);
+      });
+
+      it.each(['main', 'sub'] as const)(
+        'state.%s: carries no receiver field ReceiverStatePublic no longer defines',
+        (slot) => {
+          const receiver = profile.state[slot];
+          if (!receiver) return;
+          const extra = Object.keys(receiver).filter((key) => !RECEIVER_STATE_NAMES.has(key));
+          expect(extra, driftMessage(profileName, `state.${slot}`, 'carries stale', extra)).toEqual([]);
+        },
+      );
+
+      it('state.fieldStatus: carries no key path the current schema no longer defines', () => {
+        const actual = Object.keys(profile.state.fieldStatus ?? {});
+        const extra = actual.filter(
+          (key) => !isRegisteredFieldStatusPath(key)
+            && !isStructurallyValidFieldStatusPath(key)
+            && !allow.fieldStatus.includes(key),
+        );
+        expect(extra, driftMessage(profileName, 'state.fieldStatus', 'carries stale', extra)).toEqual([]);
+      });
+
+      it('capabilities: has every field Capabilities now requires', () => {
+        expect(CAPABILITIES.hasIndexSignature).toBe(true); // Capabilities is intentionally extensible.
+        const missing = CAPABILITIES.fields
+          .filter((f) => f.required)
+          .map((f) => f.name)
+          .filter((name) => !(name in profile.caps));
+        expect(missing, driftMessage(profileName, 'capabilities', 'is missing required', missing)).toEqual([]);
+      });
+    });
+  }
+});
+
+describe('retroactive provenance sidecar cross-check (MOR-1557 item 4)', () => {
+  it('ic7300-provenance.json matches the loader header\'s documented capture facts', () => {
+    const headerSource = readFileSync(resolve(FIXTURES_DIR, 'ic7300-profile.ts'), 'utf8');
+    const provenance = JSON.parse(
+      readFileSync(resolve(FIXTURES_DIR, 'ic7300-provenance.json'), 'utf8'),
+    ) as {
+      capturedAt: string;
+      backendHeadSha: string;
+      radioModel: string;
+      receivers: number;
+      retroactive: boolean;
+    };
+
+    const capturedMatch = headerSource.match(/Captured:\s*(\S+)/);
+    const backendShaMatch = headerSource.match(/Backend SHA:\s*(\S+)/);
+
+    expect(provenance.retroactive).toBe(true);
+    expect(capturedMatch?.[1]).toBe(provenance.capturedAt);
+    expect(backendShaMatch?.[1]).toBe(provenance.backendHeadSha);
+    // model/receivers in the sidecar come from the capabilities fixture
+    // itself (MOR-1557 item 4), not the header prose — cross-check them
+    // against the live PROFILES-loaded capabilities object too.
+    expect(provenance.radioModel).toBe(PROFILES.ic7300.caps.model);
+    expect(provenance.receivers).toBe(PROFILES.ic7300.caps.receivers);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-provenance.json
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-provenance.json
@@ -1,0 +1,11 @@
+{
+  "capturedAt": "2026-08-11",
+  "radioModel": "IC-7300",
+  "receivers": 1,
+  "stateContractVersion": 1,
+  "providerGeneration": 1,
+  "backendHeadSha": "e0b19814",
+  "source": "local bench instance",
+  "retroactive": true,
+  "retroactiveNote": "retroactive — reconstructed from the loader provenance header in ic7300-profile.ts, not emitted at capture time (MOR-1557; capture-profile.mjs did not yet write a sidecar when this fixture was captured)"
+}


### PR DESCRIPTION
## Summary

C3 of MOR-1426. The ic7300 conformance fixture's provenance lived only in a prose header comment (`fixtures/ic7300-profile.ts`), and nothing detected drift between the fixture and the current schema — MOR-1553 item 1 found the `notchFilter` staleness by hand, after the MOR-1548 receiver-scoping migration moved `notch_filter` from a top-level `ServerStatePublic` field to a receiver-scoped one (`main.notchFilter`).

- **`frontend/scripts/capture-profile.mjs`**: now emits a sidecar `<name>-provenance.json` alongside the existing byte-faithful, metadata-free `state`/`capabilities` JSON pair — capture timestamp, radio model, receivers, `stateContractVersion`, `providerGeneration`, backend HEAD SHA (new `--backend-sha` flag / `RIGPLANE_BACKEND_SHA` env var). **PUBLIC BOUNDARY**: `source` is always the fixed string `"local bench instance"` — never the bench host/IP/URL, regardless of `baseUrl`.
- **`frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts`** (new): for every profile in `conformance/profiles.ts`, type-checks the fixture against the CURRENT `ServerStatePublic`/`ReceiverStatePublic`/`Capabilities` interfaces — parsed straight from `state.ts`/`capabilities.ts` via the TypeScript compiler API (no hand-maintained field list to drift from the real type). `fieldStatus` keys are validated against the union of the backend's `empty-store-field-status.json` registry and a structural walk of the same parsed interfaces (neither alone is complete — see file header comment for why). Failure messages name the field and say "re-capture required — see MOR-1410 bench session", never "edit the JSON".
- The known `notchFilter` drift is allow-listed in `KNOWN_STALE_FIELDS`, citing MOR-1553/MOR-1558 (C4 of MOR-1426).
- **`frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-provenance.json`** (new): a retroactive sidecar for the already-committed capture (predates this script change), reconstructed from the loader header's documented facts (capture date 2026-08-11, backend `e0b19814`; model/receivers from the capabilities fixture itself), explicitly marked `"retroactive": true`. The guard test cross-checks the sidecar's `capturedAt`/`backendHeadSha` against the header prose, and its `radioModel`/`receivers` against the live capabilities fixture.

## Guard reproduces MOR-1553 item 1 (red output)

With the `KNOWN_STALE_FIELDS.ic7300` allow-list entry temporarily removed (fixture JSON untouched):

```
 × fixture provenance staleness guard (MOR-1557) > ic7300 > state: carries no top-level field ServerStatePublic no longer defines
   → Fixture 'ic7300' state carries stale field(s) [notchFilter] — re-capture required — see MOR-1410 bench session.: expected [ 'notchFilter' ] to deeply equal []

 × fixture provenance staleness guard (MOR-1557) > ic7300 > state.fieldStatus: carries no key path the current schema no longer defines
   → Fixture 'ic7300' state.fieldStatus carries stale field(s) [notchFilter] — re-capture required — see MOR-1410 bench session.: expected [ 'notchFilter' ] to deeply equal []

 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```

Allow-list entry restored afterward (no hand-edit of the fixture JSON at any point) — full suite is green again (7/7).

## Guardrail note

329 net LOC across 3 files, slightly over the nominal 300-LOC target. The overrun is measured: two real false-positive classes were found and fixed during investigation (fieldStatus entries for `connection`/`radioHealth`/`scopeControls` that are only conditionally seeded, and backend-reserved receiver-scoped paths like `main.antiVoxGain` with no TS-type counterpart) — each needed a few lines of handling plus an explanatory comment, not extra abstraction.

## Test plan

- [x] `npx vitest run src/lib/runtime/adapters/__tests__/ src/lib/state/__tests__/field-status.test.ts` — 34 files / 825 tests passed
- [x] `npx eslint src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts` — clean
- [x] `npm run lint:boundaries` — clean (unaffected, files outside scope)
- [x] `npx svelte-check --tsconfig ./tsconfig.app.json` — 0 errors, 0 warnings
- [x] `npx tsc -p tsconfig.node.json` — clean
- [x] `node --check scripts/capture-profile.mjs` — syntax OK
- [x] Manually verified guard goes RED when the allow-list entry is removed, then GREEN again once restored (fixture JSON never touched)
- [x] Public boundary self-check: `grep -inE '192\.168|\bmoroz\b|\bmini\b|:8099|preview-mor'` over the diff's added lines — empty

Closes MOR-1557