### PR TITLE
fix: audio-open pool saturation fail-fast + observability follow-ups (MOR-1573)

### DIFF
--- a/src/rigplane/audio/backend.py
+++ b/src/rigplane/audio/backend.py
@@ -1674,6 +1674,7 @@ class FakeDuplexStream:
         *,
         device: int | None = None,
         exclusive: dict[int, object] | None = None,
+        block_open: Callable[[], None] | None = None,
     ) -> None:
         self._running = False
         self._callback: Callable[[bytes], None] | None = None
@@ -1683,6 +1684,12 @@ class FakeDuplexStream:
         self.stopped_count = 0
         self.written_frames: list[bytes] = []
         self._capture_health = _CaptureHealthTracker()
+        # MOR-1573: see FakeRxStream.block_open — lets tests model a
+        # genuinely blocking duplex open so UsbAudioDriver.start_duplex's
+        # off-loop timeout handling can be exercised deterministically.
+        self.block_open = block_open
+        # MOR-1573: see FakeRxStream.stop_thread_ident.
+        self.stop_thread_ident: int | None = None
 
     @property
     def running(self) -> bool:
@@ -1702,12 +1709,15 @@ class FakeDuplexStream:
     async def start(self, callback: Callable[[bytes], None]) -> None:
         if self._running:
             raise RuntimeError("FakeDuplexStream already running.")
+        if self.block_open is not None:
+            self.block_open()
         _claim_exclusive_device(self._exclusive, self._device, self)
         self._callback = callback
         self._running = True
         self.started_count += 1
 
     async def stop(self) -> None:
+        self.stop_thread_ident = threading.get_ident()
         _release_exclusive_device(self._exclusive, self._device, self)
         self._running = False
         self._callback = None
@@ -1788,6 +1798,9 @@ class FakeAudioBackend:
         # backend. ``None`` (default) behaves exactly as before.
         self.block_rx_open: Callable[[], None] | None = None
         self.block_tx_open: Callable[[], None] | None = None
+        # MOR-1573: same purpose as block_rx_open/block_tx_open, for the
+        # same-device full-duplex open path (UsbAudioDriver.start_duplex).
+        self.block_duplex_open: Callable[[], None] | None = None
 
     def _strict_stream_kwargs(self, device: AudioDeviceId) -> dict[str, Any]:
         """Strict-mode plumbing for a new fake stream (MOR-566).
@@ -1874,7 +1887,9 @@ class FakeAudioBackend:
     ) -> FakeDuplexStream:
         if not any(d.id == device for d in self._devices):
             raise ValueError(f"Unknown device id {device}")
-        stream = FakeDuplexStream(**self._strict_stream_kwargs(device))
+        stream = FakeDuplexStream(
+            block_open=self.block_duplex_open, **self._strict_stream_kwargs(device)
+        )
         self.duplex_streams.append(stream)
         return stream
 

--- a/src/rigplane/audio/usb_driver.py
+++ b/src/rigplane/audio/usb_driver.py
@@ -121,9 +121,18 @@ default executor: that pool is shared with the web server, eibi lookups,
 diagnostics, and discovery, so a single wedged capture open would
 permanently eat one of its threads and, given enough stuck opens, starve
 those unrelated subsystems too. Sized for a couple of concurrent RX/TX
-opens plus a couple of abandoned-handle closes running at once; it does
-not need to scale with subscriber count since ``_rx_lock``/``_tx_lock``
-serialize new opens.
+opens plus a couple of abandoned-handle closes running at once.
+
+``_rx_lock``/``_tx_lock`` serialize CONCURRENT opens, NOT the pool's worker
+budget (MOR-1573 correction of an earlier, wrong claim here): a wedged
+open is abandoned (see ``_open_stream``) so the NEXT sequential open can
+start while the stuck one's worker keeps running unattended in the
+background. Enough sequential wedged opens against an otherwise-healthy
+device still exhausts this pool one worker at a time. The saturation
+check in ``_open_stream`` catches that case and fails fast with an honest
+"pool saturated" error instead of letting the new open queue behind the
+stuck ones and burn the full ``capture_open_timeout`` for an unrelated
+reason.
 """
 
 
@@ -633,6 +642,12 @@ class UsbAudioDriver:
             max_workers=_CAPTURE_OPEN_MAX_WORKERS,
             thread_name_prefix="rigplane-audio-open",
         )
+        # MOR-1573: count of submitted-but-unfinished _drive_stream_open
+        # open calls (close calls are not counted — see _open_stream). An
+        # abandoned (timed-out or cancelled) open stays counted until its
+        # future actually resolves, so this tracks REAL worker-pool
+        # pressure, not just calls currently being awaited.
+        self._inflight_opens = 0
 
         self._selected_rx: UsbAudioDevice | None = None
         self._selected_tx: UsbAudioDevice | None = None
@@ -984,11 +999,49 @@ class UsbAudioDriver:
         survives a cancelled wait untouched — it must be abandoned the
         same way a timed-out one is, or it leaves a live, un-stoppable
         stream with no consumer.
+
+        Pool-saturation fail-fast (MOR-1573): before submitting anything,
+        checks whether ``_inflight_opens`` already meets
+        ``_CAPTURE_OPEN_MAX_WORKERS``. Sequential wedged opens each leave a
+        worker permanently occupied (see the correction on
+        ``_CAPTURE_OPEN_MAX_WORKERS`` above), so enough of them exhaust the
+        pool even though ``_rx_lock``/``_tx_lock`` only ever allow one open
+        in flight at a time. Without this check, a new open against a
+        perfectly healthy device would silently queue behind the stuck
+        workers, burn the full ``_capture_open_timeout``, and raise the
+        SAME "likely blocked on OS capture-permission consent" message —
+        actively misattributing the cause. Only fires when saturation is
+        real (count >= max workers); a healthy pool is never fast-failed.
+        The caller already constructed *start_coro* (e.g.
+        ``stream.start(...)``) before this method ever runs, so the
+        fail-fast path closes it explicitly — otherwise it is dropped
+        unawaited, which triggers Python's "coroutine was never awaited"
+        warning and skips any cleanup the coroutine itself would run.
         """
+        if self._inflight_opens >= _CAPTURE_OPEN_MAX_WORKERS:
+            logger.warning(
+                "usb-audio: %s capture open worker pool saturated by %d "
+                "stuck open(s) — failing fast instead of queuing behind "
+                "them",
+                direction.upper(),
+                self._inflight_opens,
+            )
+            start_coro.close()
+            raise AudioCaptureOpenTimeoutError(
+                f"{direction.upper()} capture open worker pool saturated "
+                f"by {self._inflight_opens} stuck open(s)."
+            )
+
         loop = asyncio.get_running_loop()
         future = loop.run_in_executor(
             self._open_executor, _drive_stream_open, start_coro
         )
+        self._inflight_opens += 1
+
+        def _on_open_settled(_future: "asyncio.Future[None]") -> None:
+            self._inflight_opens -= 1
+
+        future.add_done_callback(_on_open_settled)
         try:
             _done, pending = await asyncio.wait(
                 {future}, timeout=self._capture_open_timeout
@@ -999,7 +1052,7 @@ class UsbAudioDriver:
         if future in pending:
             self._abandon_open(future, stream, direction)
             logger.warning(
-                "usb-audio: %s capture open timed out after %.0fs — likely "
+                "usb-audio: %s capture open timed out after %.1fs — likely "
                 "blocked on OS capture-permission consent (macOS TCC "
                 "microphone-consent prompt that never rendered, see "
                 "MOR-1420); marking %s audio unavailable for this session, "
@@ -1065,8 +1118,23 @@ class UsbAudioDriver:
         handle would otherwise hold the OS device open forever — the
         ResourceDemand handle-identity lesson applies here too: a handle
         nobody stops leaks a binding.
+
+        MOR-1573: an abandoned open that later resolves with an EXCEPTION
+        (as opposed to a late-but-successful open) previously returned
+        here silently — zero trace of the failure ever reached the logs.
+        Now logged as its own WARNING with the exception attached, since
+        there is no stream handle to close in that case.
         """
-        if future.cancelled() or future.exception() is not None:
+        if future.cancelled():
+            return
+        exc = future.exception()
+        if exc is not None:
+            logger.warning(
+                "usb-audio: %s capture open abandoned and later failed: %s",
+                direction.upper(),
+                exc,
+                exc_info=exc,
+            )
             return
         logger.warning(
             "usb-audio: %s capture open completed after it was abandoned "
@@ -1322,7 +1390,7 @@ class UsbAudioDriver:
                 tx_contract.channels,
                 fm,
             )
-            self._duplex_stream = self._backend.open_duplex(
+            stream = self._backend.open_duplex(
                 AudioDeviceId(selected_rx.index),
                 sample_rate=rx_contract.sample_rate_hz,
                 channels=rx_contract.effective_open_channels,
@@ -1331,7 +1399,20 @@ class UsbAudioDriver:
                 rx_audio_channel=self._config.rx_audio_channel,
                 tx_channels=tx_contract.channels,
             )
-            await self._duplex_stream.start(callback)
+            self._duplex_stream = stream
+            try:
+                # MOR-1573: duplex opens get the SAME off-loop + bounded-
+                # timeout treatment as RX/TX (MOR-1438) — a stuck duplex
+                # open is the same blocking OS-level device open as either
+                # single-direction stream, just on the shared CODEC.
+                await self._open_stream(
+                    stream, stream.start(callback), direction="duplex"
+                )
+            except (AudioCaptureOpenTimeoutError, asyncio.CancelledError):
+                # Never leave a stuck-open handle wired up as "the" duplex
+                # stream: the next start_duplex() must create a fresh one.
+                self._duplex_stream = None
+                raise
             self._store_stream_contract(rx_contract)
             self._store_stream_contract(tx_contract)
             logger.info(

--- a/tests/test_usb_audio_capture_open_timeout_mor1438.py
+++ b/tests/test_usb_audio_capture_open_timeout_mor1438.py
@@ -308,3 +308,182 @@ async def test_frame_delivered_after_off_loop_open() -> None:
 
     backend.rx_streams[-1].inject_frame(b"\x01\x02")
     assert received == [b"\x01\x02"]
+
+
+# ---------------------------------------------------------------------------
+# MOR-1573 — independent-review follow-ups on top of MOR-1438
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(10)
+async def test_timeout_warning_reports_sub_second_timeout_with_one_decimal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Item 3: a sub-second timeout must not render as the misleading "0s".
+
+    ``_TEST_TIMEOUT_S`` (0.05s) previously formatted via ``%.0f`` as "0s",
+    which reads as "no timeout configured" rather than the true 50ms bound.
+    """
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait
+
+    try:
+        with pytest.raises(AudioCaptureOpenTimeoutError):
+            await driver.start_rx(lambda _frame: None)
+
+        warnings = _warnings(caplog)
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "0.1s" in message, (
+            f"expected one-decimal timeout in message: {message!r}"
+        )
+        assert "0s" not in message.replace("0.1s", ""), (
+            f"stale zero-second rendering leaked into message: {message!r}"
+        )
+    finally:
+        # MUST run even if an assertion above fails: the background open is
+        # blocked on a non-daemon worker thread that would otherwise wedge
+        # process exit forever (the exact failure mode this ticket exists
+        # to prevent in production).
+        gate.set()
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.timeout(15)
+async def test_pool_saturation_fails_fast_instead_of_queuing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Item 1: enough sequential wedged opens must fail the NEXT one fast.
+
+    ``_rx_lock`` only serializes concurrent opens; it does not bound how
+    many abandoned (still-running-in-background) opens pile up across
+    SEQUENTIAL start_rx() calls. Each timed-out-and-abandoned open leaves
+    its worker thread permanently blocked on ``gate.wait()``, so eight
+    sequential stuck opens exhaust the whole driver-owned pool
+    (``_CAPTURE_OPEN_MAX_WORKERS`` == 8). The NEXT open against a healthy
+    device must recognize the pool is saturated and fail immediately with
+    an honest "pool saturated" error — NOT queue behind the stuck workers
+    and burn the full timeout while misreporting TCC consent as the cause.
+    """
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    backend.block_rx_open = gate.wait
+
+    try:
+        # Saturate every worker in the driver-owned pool with abandoned,
+        # permanently-blocked opens (max_workers == 8, see usb_driver.py).
+        for _ in range(8):
+            with pytest.raises(AudioCaptureOpenTimeoutError):
+                await driver.start_rx(lambda _frame: None)
+
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        with pytest.raises(AudioCaptureOpenTimeoutError) as exc_info:
+            await driver.start_rx(lambda _frame: None)
+        elapsed = loop.time() - start
+
+        assert elapsed < _TEST_TIMEOUT_S / 2, (
+            "saturated pool must fail IMMEDIATELY, not queue for the full "
+            f"capture-open timeout (elapsed={elapsed:.3f}s)"
+        )
+        assert "saturated" in str(exc_info.value).lower(), (
+            f"expected an honest pool-saturation message, got: {exc_info.value!r}"
+        )
+    finally:
+        gate.set()  # release every stuck worker so the pool can drain
+        await asyncio.sleep(0.2)
+
+
+@pytest.mark.timeout(10)
+async def test_abandoned_open_that_later_fails_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Item 2: a late-resolving abandoned open must log its exception.
+
+    Before this fix, ``_close_late_stream`` silently swallowed a late
+    background open that finished with an EXCEPTION (as opposed to a
+    successful-but-late open, or a cancellation) -- zero trace of the
+    failure ever reached the logs.
+    """
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    failure = RuntimeError("late device init failure")
+
+    def _block_then_fail() -> None:
+        gate.wait()
+        raise failure
+
+    driver, backend = _make_driver()
+    backend.block_rx_open = _block_then_fail
+
+    try:
+        with pytest.raises(AudioCaptureOpenTimeoutError):
+            await driver.start_rx(lambda _frame: None)
+    finally:
+        # MUST run even if the assertion above fails: releases the
+        # non-daemon worker thread blocked in _block_then_fail so it
+        # cannot wedge process exit.
+        gate.set()
+
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        warnings = _warnings(caplog)
+        if any("late device init failure" in r.getMessage() for r in warnings):
+            break
+
+    warnings = _warnings(caplog)
+    matches = [r for r in warnings if "late device init failure" in r.getMessage()]
+    assert matches, (
+        f"expected a WARNING logging the late open's exception, got: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
+    assert matches[0].exc_info is not None, "exception traceback should be attached"
+
+
+@pytest.mark.timeout(10)
+async def test_duplex_open_routes_off_loop_and_times_out(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Item 4: start_duplex must get the SAME off-loop bounded-open treatment.
+
+    Before this fix, ``start_duplex`` awaited ``DuplexStream.start()``
+    directly instead of through :meth:`UsbAudioDriver._open_stream`, so a
+    stuck duplex open would freeze the event loop exactly like the
+    pre-MOR-1438 RX/TX opens did.
+    """
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    gate = threading.Event()
+    driver, backend = _make_driver()
+    # Bounded even in the not-yet-fixed case: a direct (on-loop) call would
+    # otherwise block this test's entire event loop for as long as the gate
+    # stays unset. Once routed off-loop, the driver's own capture-open
+    # timeout (0.05s) fires long before this 1s bound is reached.
+    backend.block_duplex_open = lambda: gate.wait(timeout=1.0)
+
+    progressed = 0
+    stop = asyncio.Event()
+
+    async def _ticker() -> None:
+        nonlocal progressed
+        while not stop.is_set():
+            progressed += 1
+            await asyncio.sleep(0.005)
+
+    ticker = asyncio.create_task(_ticker())
+    try:
+        with pytest.raises(AudioCaptureOpenTimeoutError):
+            await driver.start_duplex(lambda _frame: None)
+    finally:
+        stop.set()
+        await ticker
+        gate.set()
+        await asyncio.sleep(0.05)
+
+    assert progressed >= 3, (
+        "event loop should keep making progress while the duplex open is stuck"
+    )
+    assert driver.rx_running is False
+    assert driver.tx_running is False


### PR DESCRIPTION
## Summary

Closes MOR-1573.

Four bounded independent-review follow-ups on top of the MOR-1438 off-loop
audio-open fix (PR #2473, `src/rigplane/audio/usb_driver.py`), all confirmed
empirically before this fix:

1. **Pool saturation fail-fast + wrong comment.** `_rx_lock`/`_tx_lock` only
   serialize CONCURRENT opens — they do not bound how many WEDGED opens
   accumulate across SEQUENTIAL `start_rx()`/`start_tx()` calls, since each
   timed-out-and-abandoned open leaves its worker thread permanently
   occupied. After enough stuck opens, a NEW open against a perfectly
   healthy device would silently queue behind them, burn the full
   `capture_open_timeout`, and raise a warning that misattributes the cause
   to TCC consent. `_open_stream` now tracks in-flight open calls
   (`_inflight_opens`) and fails fast with an honest
   `"<DIRECTION> capture open worker pool saturated by N stuck open(s)"`
   error the moment the pool is genuinely full (count >= max workers) —
   never before that. Also corrects the `_CAPTURE_OPEN_MAX_WORKERS`
   docstring, which claimed the locks made pool exhaustion impossible.
   The fail-fast path also explicitly closes the caller's
   already-constructed `start_coro` to avoid an unawaited-coroutine leak
   (caught via `RuntimeWarning` during test development).
2. **Abandoned-open observability.** `_close_late_stream` previously
   returned silently when an abandoned future resolved with an exception —
   zero trace of the failure ever reached the logs. It now logs a WARNING
   with the exception attached.
3. **`%.0f` cosmetic fix.** The timeout warning rendered sub-second
   timeouts as the misleading `"0s"`; now `%.1f`.
4. **Duplex routing.** `start_duplex` now routes its stream open through
   the same off-loop, bounded-timeout `_open_stream` path RX/TX already
   use (the type union already accepted `DuplexStream`). Zero production
   call sites today — this is symmetry/future-proofing, kept minimal.

`FakeDuplexStream`/`FakeAudioBackend` (in `src/rigplane/audio/backend.py`)
gained `block_open`/`block_duplex_open` support, mirroring the existing
`FakeRxStream`/`FakeTxStream` pattern, so item 4 could be exercised without
PortAudio.

## Test plan

- [x] Red-first: all four new tests in
      `tests/test_usb_audio_capture_open_timeout_mor1438.py` were run against
      the unmodified code first and failed for the expected reason (verified
      individually with a hard subprocess timeout to avoid any risk of a
      real hang from a wedged non-daemon thread).
- [x] `uv run pytest tests/test_usb_audio_capture_open_timeout_mor1438.py -q` — 13 passed
- [x] `uv run pytest tests/ -q -k audio --ignore=tests/integration` — 1380 passed, 6 skipped
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `uv run mypy src/rigplane/audio/` — 1 pre-existing `unused-ignore` error at
      `usb_driver.py:763`, confirmed present on unmodified `origin/main` too
      (not introduced by this change)
- [x] Boundary grep on the diff for internal identifiers — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)