### PR TITLE
test: adapter-seam conformance walk (MOR-1562)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/harness.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/harness.ts
@@ -21,6 +21,20 @@
  * loaders, and three assertion primitives (`expectFrames`, `expectRefusal`,
  * `expectIntentTransport`). No profile-specific literal belongs here — see
  * `profiles.ts` for per-radio fixture data.
+ *
+ * MOR-1562 (C8) extension: `panel-adapters.ts`'s `derive*Props` seams read
+ * `runtime.state`/`runtime.caps` (the `FrontendRuntime` singleton,
+ * `../frontend-runtime`), not the `getRadioState()`/`getCapabilities()`
+ * store accessors the six mocks above already cover — the pre-C8 harness
+ * stubbed only `rxEnabled`/`setMuted`/`setRxLive`/`setRxVolume`/`setVolume`
+ * on that mock (audio-panel seam needs), so `deriveXxxProps()` calls would
+ * have thrown on `undefined.state`. `get state()`/`get caps()` are added
+ * below, mirroring the real `FrontendRuntime` getters
+ * (`radio.current`/`getCapabilities()`) exactly but sourced from `h.state`/
+ * `h.caps` like every other mock here. Also adds `getMeterCalibration`/
+ * `getMeterRedline` to the capabilities-store mock — `capabilities-adapter.ts`
+ * imports both alongside the already-mocked `getControlRange`, and omitting
+ * them would leave two of that adapter's four exports uncallable.
  */
 import { expect, vi } from 'vitest';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -78,6 +92,14 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
     && h.caps?.providerGeneration === providerGeneration),
   getControlRange: vi.fn((name: string) =>
     (h.caps?.controls as Record<string, unknown> | undefined)?.[name] ?? null),
+  // MOR-1562: mirrors the real `capabilities.svelte.ts` implementations
+  // (`capabilities?.meterCalibrations?.[x] ?? null` / `...meterRedlines...`)
+  // exactly — `capabilities-adapter.ts`'s `getMeterCalibration`/
+  // `getMeterRedline` are thin passthroughs to these two.
+  getMeterCalibration: vi.fn((meterType: string) =>
+    (h.caps?.meterCalibrations as Record<string, unknown> | undefined)?.[meterType] ?? null),
+  getMeterRedline: vi.fn((meterType: string) =>
+    (h.caps?.meterRedlines as Record<string, unknown> | undefined)?.[meterType] ?? null),
 }));
 
 vi.mock('$lib/runtime/frontend-runtime', () => ({
@@ -87,6 +109,13 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
     setRxLive: h.setRxLive,
     setRxVolume: h.setRxVolume,
     setVolume: h.setVolume,
+    // MOR-1562: `panel-adapters.ts`'s `derive*Props` seams read these two
+    // directly off the runtime singleton — sourced from the same `h.state`/
+    // `h.caps` every other seam in this harness reads, so a test setting
+    // `h.state`/`h.caps` (the existing `fixtureState`/`fixtureCaps` pattern)
+    // covers this seam with no separate setup.
+    get state() { return h.state; },
+    get caps() { return h.caps; },
   },
 }));
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
@@ -29,10 +29,11 @@
  * a byte-faithful capture. `deriveModeProps`/`deriveAgcProps`/
  * `deriveRfFrontEndProps`/`deriveFilterProps`/`deriveBandSelectorProps`/
  * `deriveDspProps`/`deriveTxProps`/`deriveAntennaProps`/`deriveScanProps`/
- * `deriveCwProps`, and the entire `capabilities-adapter.ts` surface, had
- * literally no test importing them before this file (verified by grep —
- * see PR body). `presentation-capabilities.ts` has a synthetic-fixture unit
- * test but had never run over the live ic7300 caps either.
+ * `deriveCwProps`/`deriveRitXitProps`, and the entire `capabilities-
+ * adapter.ts` surface, had literally no test importing them before this
+ * file (verified by grep — see PR body). `presentation-capabilities.ts` has
+ * a synthetic-fixture unit test but had never run over the live ic7300
+ * caps either.
  *
  * HARNESS EXTENSION (see `./conformance/harness.ts`'s own MOR-1562 comment):
  * `derive*Props` reads `runtime.state`/`runtime.caps` (the
@@ -57,25 +58,22 @@
  * wrapper with real logic — MOR-1447's normalized-to-raw conversion) is
  * already fully covered by MOR-1428 and not repeated here.
  *
- * DEFERRED (explicit follow-up scope, not silent gaps — see PR body for the
- * full accounting against `panel-adapters.ts`'s ~50 exports): RitXit/Scan/
- * Cw/Antenna/Vfo/Memory/AudioRouting/Preset/Keyboard/System get*Handlers
- * (bare passthroughs, see SCOPE DECISION above); the armed-signal family
- * beyond none needed here (fully covered by `mor1536-armed-adoption` +
- * `mor1519-mode-armed`, just not against this fixture); getPendingXxx
- * (covered by `mor1441-pending-*`); getActiveFrequencyHz (covered by
- * `mor1409-a15-active-frequency`); bindSemanticSurfaceHandlers/
- * bindVfoTunerContext (covered by `semantic-surface-handler-binder`);
- * deriveAmberScopeProps/deriveAmberCockpitProps/getAmberCockpitHandlers
- * (need a THIRD harness extension — `hasAudioFft`/`hasDualReceiver`/
- * `hasCapability` from `$lib/stores/capabilities.svelte` are not mocked at
- * all today — out of scope to avoid growing the harness beyond what this
- * walk strictly needs); deriveMemoryPanelProps/deriveVfoControlProps/
+ * DEFERRED (explicit follow-up scope, not silent gaps — full accounting in
+ * PR body): RitXit/Scan/Cw/Antenna/Vfo/Memory/AudioRouting/Preset/Keyboard/
+ * System `get*Handlers` ONLY — not `derive*Props`, `deriveRitXitProps` IS
+ * covered below (bare passthroughs, see SCOPE DECISION above); the
+ * armed-signal family (fully covered by `mor1536-armed-adoption` +
+ * `mor1519-mode-armed`, just not this fixture); getPendingXxx
+ * (`mor1441-pending-*`); getActiveFrequencyHz (`mor1409-a15-active-
+ * frequency`); bindSemanticSurfaceHandlers/bindVfoTunerContext
+ * (`semantic-surface-handler-binder`); deriveAmberScopeProps/
+ * deriveAmberCockpitProps/getAmberCockpitHandlers (need a THIRD harness
+ * extension — `hasAudioFft`/`hasDualReceiver`/`hasCapability` are unmocked
+ * today, out of scope); deriveMemoryPanelProps/deriveVfoControlProps/
  * deriveAudioSpectrumProps/deriveAmberTelemetryProps; every non-panel-
  * adapters seam (audio-adapter.ts, qsy-history-adapter.ts, vfo-adapter.ts,
  * tx-adapter.ts, tx-capabilities.ts, lcd-chrome-adapter.ts, mod-input-*,
- * scope-adapter.ts — scope-adapter's `toSpectrumAuthority` is already
- * walked by MOR-1428 directly).
+ * scope-adapter.ts — its `toSpectrumAuthority` is walked by MOR-1428).
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -98,6 +96,7 @@ import {
   deriveAntennaProps,
   deriveScanProps,
   deriveCwProps,
+  deriveRitXitProps,
 } from '../panel-adapters';
 import {
   getMeterCalibration, getMeterRedline, getControlRange, getReceiverLabel,
@@ -306,6 +305,20 @@ describe('panel-adapters.ts derive*Props over the live ic7300 fixture (MOR-1562)
       hasBreakIn: true,
       hasApf: true,
       hasTwinPeak: true,
+    });
+  });
+
+  // MOR-1574 (filed off this walk): unlike toAgcProps/toRfFrontEndProps,
+  // `toRitXitProps` (panel-props.ts:482-494) has NO fieldStatus gate on
+  // ritOn/ritFreq/ritTx — pinned CURRENT baseline, not an endorsement;
+  // update once MOR-1574 lands.
+  it('deriveRitXitProps: pins the current un-gated reading — production honesty gap tracked as MOR-1574', () => {
+    expect(IC7300_STATE.fieldStatus?.ritOn?.observed).toBe(false);
+    expect(IC7300_STATE.fieldStatus?.ritFreq?.observed).toBe(false);
+    expect(IC7300_STATE.fieldStatus?.ritTx?.observed).toBe(false);
+    expect(deriveRitXitProps()).toEqual({
+      ritActive: false, ritOffset: 0, xitActive: false, xitOffset: 0,
+      hasRit: true, hasXit: true,
     });
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
@@ -1,0 +1,358 @@
+/**
+ * MOR-1562 (C8) — adapter-seam conformance walk over the live IC-7300
+ * fixture.
+ *
+ * MOR-1426's family walks (C6-C13) split `panel-commands.ts`'s intent
+ * surface across tickets; C8 is the ONE family that does not walk intents
+ * at all. It walks the ADAPTER SEAMS one layer up — the `derive*Props`/
+ * `get*Handlers` exports in `lib/runtime/adapters/` that panels actually
+ * call (`$derived(deriveModeProps())`, `getModeHandlers()` once at init,
+ * per `panel-adapters.ts`'s own header) — against the SAME live-captured
+ * `ic7300-{state,capabilities}.json` fixture `mor1428-ic7300-conformance.
+ * isolated.test.ts` established, via the shared `./conformance/harness.ts`.
+ * This is why `claimed.ts` gains ZERO new entries here (see its own
+ * comment) — every intent this file's `expectFrames`/`expectRefusal` calls
+ * exercise was already claimed by MOR-1428 through the same
+ * `dispatchRadioIntent` factories; C8's contribution is proving the panel
+ * adapter SEAM around them, not a new WS frame.
+ *
+ * WHY THESE SEAMS WERE ZERO-COVERAGE BEFORE THIS FILE: every existing
+ * `panel-adapters.ts` consumer test (`mor1519-mode-armed`,
+ * `mor1536-armed-adoption`, `mor1441-pending-*`, `mor1409-a15-active-
+ * frequency`, `memory-handler-binder`, `keyboard-system-accessors`,
+ * `semantic-surface-handler-binder`) builds its OWN synthetic per-test
+ * state via a private `vi.mock`, never the committed live fixture. And the
+ * `to*Props`-level unit tests (`rf-front-end-adapter.test.ts`,
+ * `mode-filter-adapter.test.ts`, etc.) call `toXxxProps` directly with
+ * hand-built `ServerState`/`Capabilities` literals — never through the
+ * `derive*Props()` wrapper a real panel actually calls, and never against
+ * a byte-faithful capture. `deriveModeProps`/`deriveAgcProps`/
+ * `deriveRfFrontEndProps`/`deriveFilterProps`/`deriveBandSelectorProps`/
+ * `deriveDspProps`/`deriveTxProps`/`deriveAntennaProps`/`deriveScanProps`/
+ * `deriveCwProps`, and the entire `capabilities-adapter.ts` surface, had
+ * literally no test importing them before this file (verified by grep —
+ * see PR body). `presentation-capabilities.ts` has a synthetic-fixture unit
+ * test but had never run over the live ic7300 caps either.
+ *
+ * HARNESS EXTENSION (see `./conformance/harness.ts`'s own MOR-1562 comment):
+ * `derive*Props` reads `runtime.state`/`runtime.caps` (the
+ * `FrontendRuntime` singleton), a seam the pre-C8 harness never stubbed —
+ * extended with two getters backed by the same `h.state`/`h.caps` every
+ * other mock here reads. `capabilities-adapter.ts` also needed
+ * `getMeterCalibration`/`getMeterRedline` added to the capabilities-store
+ * mock (only `getControlRange` existed). Both extensions mirror the real
+ * implementations exactly — no new behavior invented, see the harness
+ * comment for the line-by-line justification.
+ *
+ * SCOPE DECISION — get*Handlers WIRING: most `get*Handlers` exports in
+ * `panel-adapters.ts` are bare singletons (`const _x = makeXHandlers();
+ * export function getXHandlers() { return _x; }`) with no adapter logic of
+ * their own — dispatch-testing them is not meaningfully different from
+ * testing `makeXHandlers()` directly (already exhaustively done for 10+
+ * families by MOR-1428). This file's handler-dispatch section covers only
+ * the seam objects with genuinely NO prior get*Handlers-level coverage
+ * anywhere (Mode/AGC/Filter/Band/DSP dispatch, TX honest refusal) — proving
+ * the exact object a panel imports wires correctly, not re-deriving
+ * MOR-1428's frame-shape assertions. `getRfFrontEndHandlers` (the one
+ * wrapper with real logic — MOR-1447's normalized-to-raw conversion) is
+ * already fully covered by MOR-1428 and not repeated here.
+ *
+ * DEFERRED (explicit follow-up scope, not silent gaps — see PR body for the
+ * full accounting against `panel-adapters.ts`'s ~50 exports): RitXit/Scan/
+ * Cw/Antenna/Vfo/Memory/AudioRouting/Preset/Keyboard/System get*Handlers
+ * (bare passthroughs, see SCOPE DECISION above); the armed-signal family
+ * beyond none needed here (fully covered by `mor1536-armed-adoption` +
+ * `mor1519-mode-armed`, just not against this fixture); getPendingXxx
+ * (covered by `mor1441-pending-*`); getActiveFrequencyHz (covered by
+ * `mor1409-a15-active-frequency`); bindSemanticSurfaceHandlers/
+ * bindVfoTunerContext (covered by `semantic-surface-handler-binder`);
+ * deriveAmberScopeProps/deriveAmberCockpitProps/getAmberCockpitHandlers
+ * (need a THIRD harness extension — `hasAudioFft`/`hasDualReceiver`/
+ * `hasCapability` from `$lib/stores/capabilities.svelte` are not mocked at
+ * all today — out of scope to avoid growing the harness beyond what this
+ * walk strictly needs); deriveMemoryPanelProps/deriveVfoControlProps/
+ * deriveAudioSpectrumProps/deriveAmberTelemetryProps; every non-panel-
+ * adapters seam (audio-adapter.ts, qsy-history-adapter.ts, vfo-adapter.ts,
+ * tx-adapter.ts, tx-capabilities.ts, lcd-chrome-adapter.ts, mod-input-*,
+ * scope-adapter.ts — scope-adapter's `toSpectrumAuthority` is already
+ * walked by MOR-1428 directly).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  expectFrames,
+  expectRefusal,
+  fixtureCaps,
+  fixtureState,
+  h,
+} from './conformance/harness';
+import { PROFILES } from './conformance/profiles';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import {
+  deriveModeProps, getModeHandlers,
+  deriveAgcProps, getAgcHandlers,
+  deriveRfFrontEndProps,
+  deriveFilterProps, getFilterHandlers,
+  deriveBandSelectorProps, getBandHandlers,
+  deriveDspProps, getDspHandlers,
+  deriveTxProps, getTxHandlers,
+  deriveAntennaProps,
+  deriveScanProps,
+  deriveCwProps,
+} from '../panel-adapters';
+import {
+  getMeterCalibration, getMeterRedline, getControlRange, getReceiverLabel,
+} from '../capabilities-adapter';
+import { derivePresentationCapabilities } from '../presentation-capabilities';
+
+const profile = PROFILES.ic7300;
+const IC7300_STATE = profile.state;
+const IC7300_CAPABILITIES = profile.caps;
+
+beforeEach(() => {
+  h.state = fixtureState(profile);
+  h.caps = fixtureCaps(profile);
+  h.sendCommand.mockClear();
+});
+
+afterEach(() => {
+  resetCommandLifecycle();
+});
+
+/* ── capabilities-adapter.ts — full 4-export surface, zero prior coverage ── */
+
+describe('capabilities-adapter.ts over the live ic7300 caps (MOR-1562)', () => {
+  it('getMeterCalibration: exact swr knot points from the live capture', () => {
+    expect(IC7300_CAPABILITIES.meterCalibrations?.swr).toBeDefined();
+    expect(getMeterCalibration('swr')).toEqual(IC7300_CAPABILITIES.meterCalibrations!.swr);
+  });
+
+  it('getMeterCalibration: honest null — this profile declares no ALC calibration (capability-not-declared refusal)', () => {
+    expect(IC7300_CAPABILITIES.meterCalibrations?.alc).toBeUndefined();
+    expect(getMeterCalibration('alc')).toBeNull();
+  });
+
+  it('getMeterRedline: exact swr redline', () => {
+    expect(getMeterRedline('swr')).toBe(120);
+  });
+
+  it('getMeterRedline: honest null for ALC', () => {
+    expect(getMeterRedline('alc')).toBeNull();
+  });
+
+  it('getControlRange: exact af_level raw range', () => {
+    expect(getControlRange('af_level')).toEqual({ raw_min: 0, raw_max: 255 });
+  });
+
+  it('getControlRange: honest null — nb_depth control is not declared on this profile', () => {
+    expect(IC7300_CAPABILITIES.controls?.nb_depth).toBeUndefined();
+    expect(getControlRange('nb_depth')).toBeNull();
+  });
+
+  it.each(['MAIN', 'SUB'] as const)('getReceiverLabel(%s): passthrough contract', (id) => {
+    expect(getReceiverLabel(id)).toBe(id);
+  });
+});
+
+/* ── presentation-capabilities.ts — over the live caps, zero prior live
+ * coverage (existing unit test uses synthetic caps only). */
+
+describe('presentation-capabilities.ts over the live ic7300 caps (MOR-1562)', () => {
+  it('resolves a clean single-RX A/B topology with zero diagnostics', () => {
+    expect(derivePresentationCapabilities(IC7300_CAPABILITIES)).toEqual({
+      topology: {
+        scheme: 'ab',
+        structuralCount: 1,
+        structuralReceivers: ['MAIN'],
+        operationalReceivers: ['MAIN'],
+        slots: { MAIN: ['A', 'B'] },
+      },
+      scope: {
+        hardwareScopeAvailable: true,
+        audioFftAvailable: true,
+        availableSources: ['hardware', 'audio_fft'],
+        defaultSource: 'hardware',
+      },
+      diagnostics: [],
+    });
+  });
+
+  it('flags scope-capability-contradiction when scope tag and caps.scope disagree', () => {
+    const contradictory = { ...IC7300_CAPABILITIES, scope: false };
+    expect(derivePresentationCapabilities(contradictory).diagnostics)
+      .toContain('scope-capability-contradiction');
+  });
+});
+
+/* ── panel-adapters.ts derive*Props against the live fixture — exact
+ * values, zero prior coverage of this seam (see file header). */
+
+describe('panel-adapters.ts derive*Props over the live ic7300 fixture (MOR-1562)', () => {
+  it('deriveModeProps: exact mode/catalog/data-mode reading', () => {
+    expect(deriveModeProps()).toMatchObject({
+      currentMode: 'USB',
+      modes: IC7300_CAPABILITIES.modes,
+      dataMode: 0,
+      hasDataMode: true,
+    });
+  });
+
+  it('deriveAgcProps: exact AGC reading + capability-derived catalog', () => {
+    expect(deriveAgcProps()).toEqual({
+      agcMode: 3,
+      agcModes: [1, 2, 3],
+      agcLabels: { '1': 'FAST', '2': 'MID', '3': 'SLOW' },
+      hasAgc: true,
+    });
+  });
+
+  it('deriveRfFrontEndProps: exact rf-chain reading, honest ipPlus/digiSel refusal (two flavors)', () => {
+    // ip_plus IS a declared capability, but this session never observed the
+    // field — unobserved-field refusal (mirrors MOR-1428's RIT case).
+    expect(IC7300_CAPABILITIES.capabilities).toContain('ip_plus');
+    expect(IC7300_STATE.fieldStatus?.['main.ipplus']?.observed).toBe(false);
+    // digisel is NOT a declared capability on this profile at all —
+    // capability-not-declared refusal, a different flavor from the above.
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('digisel');
+
+    expect(deriveRfFrontEndProps()).toMatchObject({
+      rfGain: 0.8196078431372549,
+      squelch: 0,
+      att: 0,
+      pre: 0,
+      showRfGain: true,
+      showSquelch: true,
+      showAtt: true,
+      showPre: true,
+      attValues: [0, 20],
+      preOptions: [
+        { value: 0, label: 'OFF' },
+        { value: 1, label: 'P1' },
+        { value: 2, label: 'P2' },
+      ],
+      showIpPlus: false,
+      showDigiSel: false,
+    });
+  });
+
+  it('deriveFilterProps: exact filter selection + honest if_shift/pbt capability split', () => {
+    // 'if_shift' is not declared at all (Icom PBT-only radio); 'pbt' is.
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('if_shift');
+    expect(IC7300_CAPABILITIES.capabilities).toContain('pbt');
+
+    expect(deriveFilterProps()).toMatchObject({
+      currentMode: 'USB',
+      currentFilter: 1,
+      hasFilterShape: true,
+      hasIfShift: false,
+      hasPbt: true,
+    });
+  });
+
+  it('deriveBandSelectorProps: exact active-VFO frequency', () => {
+    expect(deriveBandSelectorProps()).toEqual({ currentFreq: 14_188_000 });
+  });
+
+  it('deriveDspProps: exact NB/NR reading, honest nb-depth/notch/agc-time refusal (two flavors)', () => {
+    // nb_depth control range is NOT declared on this profile at all —
+    // capability-not-declared refusal.
+    expect(IC7300_CAPABILITIES.controls?.nb_depth).toBeUndefined();
+    // 'notch' IS a declared capability, but manualNotch/autoNotch/
+    // agcTimeConstant were never observed this session — unobserved-field
+    // refusal, the other flavor.
+    expect(IC7300_CAPABILITIES.capabilities).toContain('notch');
+    expect(IC7300_STATE.fieldStatus?.['main.manualNotch']?.observed).toBe(false);
+
+    expect(deriveDspProps()).toMatchObject({
+      nrMode: 1,
+      nbActive: true,
+      hasNr: true,
+      hasNb: true,
+      hasNbDepth: false,
+      hasNbWidth: false,
+      nbLevelPercent: true,
+      nbLevelMax: 255,
+      notchMode: 'off',
+      hasNotch: false,
+      hasAutoNotch: false,
+      hasAgcTime: false,
+    });
+  });
+
+  it('deriveTxProps: honest micGain refusal — capability declared, field never observed on this stand', () => {
+    expect(IC7300_STATE.fieldStatus?.micGain?.observed).toBe(false);
+    expect(deriveTxProps()).toMatchObject({
+      hasTx: true,
+      micGainAvailable: false,
+    });
+  });
+
+  it('deriveAntennaProps: honest rx_antenna refusal — capability-not-declared', () => {
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('rx_antenna');
+    expect(deriveAntennaProps()).toEqual({
+      txAntenna: 1, rxAnt: false, antennaCount: 1, hasRxAntenna: false,
+    });
+  });
+
+  it('deriveScanProps: exact idle-scan reading', () => {
+    expect(deriveScanProps()).toEqual({ scanning: false, scanType: 0, scanResumeMode: 0 });
+  });
+
+  it('deriveCwProps: mode-gated APF/TPF disable + full capability catalog for the live USB reading', () => {
+    expect(deriveCwProps()).toMatchObject({
+      currentMode: 'USB',
+      apfDisabled: true, // active mode is USB, not CW/CW-R
+      tpfDisabled: true, // active mode is USB, not RTTY/RTTY-R
+      hasCw: true,
+      hasBreakIn: true,
+      hasApf: true,
+      hasTwinPeak: true,
+    });
+  });
+});
+
+/* ── panel-adapters.ts get*Handlers wiring — the exact singleton object a
+ * panel imports, for seams with zero prior get*Handlers-level coverage (see
+ * SCOPE DECISION in the file header for why most families stop at
+ * derive*Props above). */
+
+describe('panel-adapters.ts get*Handlers dispatch through the real seam (MOR-1562)', () => {
+  it('getModeHandlers: dispatches set_mode on receiver 0', () => {
+    expectFrames(
+      () => getModeHandlers().onModeChange('CW'),
+      [['set_mode', { mode: 'CW', receiver: 0 }]],
+    );
+  });
+
+  it('getAgcHandlers: dispatches set_agc on receiver 0', () => {
+    expectFrames(
+      () => getAgcHandlers().onAgcModeChange(2),
+      [['set_agc', { mode: 2, receiver: 0 }]],
+    );
+  });
+
+  it('getFilterHandlers: dispatches set_filter on receiver 0', () => {
+    expectFrames(
+      () => getFilterHandlers().onFilterChange(2),
+      [['set_filter', { filter: 2, receiver: 0 }]],
+    );
+  });
+
+  it('getBandHandlers: dispatches set_band from a BSR-coded band select', () => {
+    expectFrames(
+      () => getBandHandlers().onBandSelect('20m', 14_225_000, 5),
+      [['set_band', { band: 5 }]],
+    );
+  });
+
+  it('getDspHandlers: dispatches set_nb on receiver 0', () => {
+    expectFrames(
+      () => getDspHandlers().onNbToggle(false),
+      [['set_nb', { on: false, receiver: 0 }]],
+    );
+  });
+
+  it('getTxHandlers: REFUSES onMicGainChange — same doctrine as MOR-1428, through the untested singleton seam', () => {
+    expect(IC7300_STATE.fieldStatus?.micGain?.observed).toBe(false);
+    expectRefusal(() => getTxHandlers().onMicGainChange(100));
+  });
+});


### PR DESCRIPTION
Closes MOR-1562

## Summary

C8 of the MOR-1426 Tier-2 conformance program. Unlike C6/C7/C9-C13 (which
walk `panel-commands.ts` intents), C8 walks the **ADAPTER SEAMS one layer
up** — the `derive*Props()`/`get*Handlers()` exports in
`lib/runtime/adapters/panel-adapters.ts`, plus `capabilities-adapter.ts` and
`presentation-capabilities.ts` — against the same live-captured
`ic7300-{state,capabilities}.json` fixture `mor1428-ic7300-conformance.
isolated.test.ts` established. It claims **zero** new entries in the intent
ledger (`claimed.ts`) by design — `waived.ts` already documents this
("MOR-1562 (C8, adapter-seam parity) intentionally claims ZERO entries here
— its scope is `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new
intent names").

Verified by grep before writing: none of the covered `derive*Props`/
`get*Handlers` exports, nor any of `capabilities-adapter.ts`'s four exports,
had a single test importing them anywhere in the repo before this PR.
`presentation-capabilities.ts` has a synthetic-fixture unit test but had
never run against the live IC-7300 capabilities.

## Harness extension (strictly necessary, noted per constraint)

`conformance/harness.ts`'s pre-existing `$lib/runtime/frontend-runtime` mock
only stubbed `rxEnabled`/`setMuted`/`setRxLive`/`setRxVolume`/`setVolume` —
the audio-panel seam's needs. `panel-adapters.ts`'s `derive*Props` functions
read `runtime.state`/`runtime.caps` (the `FrontendRuntime` singleton), a
completely different seam that would have thrown on `undefined.state`.
Added two getters, `get state()`/`get caps()`, backed by the same `h.state`/
`h.caps` every other harness mock reads — mirrors the real
`FrontendRuntime.state`/`.caps` getters exactly (`radio.current` /
`getCapabilities()`).

Also added `getMeterCalibration`/`getMeterRedline` to the
`$lib/stores/capabilities.svelte` mock (only `getControlRange` existed) —
`capabilities-adapter.ts` imports all three, and two of its four exports
would have been uncallable otherwise. Both additions are byte-for-byte
mirrors of the real store implementations (`capabilities?.meterCalibrations
?.[x] ?? null`, etc.) — no invented behavior.

## Per-seam coverage

| Module | Seam | Coverage |
|---|---|---|
| `capabilities-adapter.ts` | `getMeterCalibration` | exact swr knots + honest null for undeclared `alc` |
| | `getMeterRedline` | exact swr redline (120) + honest null for `alc` |
| | `getControlRange` | exact `af_level` range + honest null for undeclared `nb_depth` |
| | `getReceiverLabel` | passthrough contract, both receiver ids |
| `presentation-capabilities.ts` | `derivePresentationCapabilities` | exact topology/scope/diagnostics over live caps (clean, zero diagnostics) + a contradiction-detection case |
| `panel-adapters.ts` | `deriveModeProps` | exact mode/catalog/data-mode |
| | `deriveAgcProps` | exact AGC reading + catalog (full-object `toEqual`) |
| | `deriveRfFrontEndProps` | exact rf-chain reading + honest ipPlus (unobserved-field) and digiSel (capability-not-declared) refusal |
| | `deriveFilterProps` | exact filter selection + honest if_shift/pbt capability split |
| | `deriveBandSelectorProps` | exact active-VFO frequency (RED-FIRST case) |
| | `deriveDspProps` | exact NB/NR reading + honest nb-depth (capability-not-declared) and notch/agc-time (unobserved-field) refusal |
| | `deriveTxProps` | honest micGain refusal |
| | `deriveAntennaProps` | honest rx_antenna refusal (capability-not-declared) |
| | `deriveScanProps` | exact idle-scan reading |
| | `deriveCwProps` | mode-gated APF/TPF disable + full capability catalog |
| | `deriveRitXitProps` | pins the CURRENT un-gated reading over the fixture — production honesty gap, tracked as **MOR-1574** (see review delta below) |
| | `getModeHandlers`/`getAgcHandlers`/`getFilterHandlers`/`getBandHandlers`/`getDspHandlers` | dispatch wiring through the exact singleton seam |
| | `getTxHandlers` | honest refusal (RED-FIRST case) through the untested singleton wrapper |

## Review delta (BLOCKED → fixed)

Independent review flagged a silent-truncation gap: `deriveRitXitProps`
(`panel-adapters.ts:106`) was the only `derive*Props`/`get*` export in
neither the covered set nor the deferred list — the header's "RitXit"
mention was about `getRitXitHandlers`, a different export. Fixed by adding
a `deriveRitXitProps` case (head SHA `934a9429831b30ab60485a7a17d51ca4a5b1190d`):
`toRitXitProps` (`panel-props.ts:482-494`) has **no fieldStatus gate** on
`ritOn`/`ritFreq`/`ritTx` — unlike `toAgcProps`/`toRfFrontEndProps`, it
hands back the raw state value whether or not the field was ever observed.
On this fixture all three read `observed:false`/`availability:'missing'`,
yet the adapter still returns `{ritActive:false, ritOffset:0,
xitActive:false, xitOffset:0, hasRit:true, hasXit:true}` as if confirmed.
The new test pins that CURRENT behavior as an honest baseline (not an
endorsement) and cites the newly-filed **MOR-1574** ("toRitXitProps
fabricates readings: no fieldStatus gate on ritOn/ritFreq/ritTx") — the
assertion will need updating to the fieldStatus-gated shape once MOR-1574
lands. Also updated the file-header coverage enumeration and trimmed
adjacent prose to hold the file at exactly the 400 LOC cap.

## Explicitly deferred (not silent gaps)

- `panel-adapters.ts`'s remaining bare-passthrough `get*Handlers` (RitXit,
  Scan, Cw, Antenna, Vfo, Memory, AudioRouting, Preset, Keyboard, System) —
  no adapter logic of their own beyond `makeXHandlers()`, already
  exhaustively dispatch-tested at the factory level by MOR-1428; walking the
  passthrough wrapper doesn't discriminate anything new. `getRfFrontEndHandlers`
  (the one wrapper with real logic, MOR-1447's normalized-to-raw conversion)
  is fully covered by MOR-1428 already. (Note: this bullet is `get*Handlers`
  only — `deriveRitXitProps` is covered above, see review delta.)
- Armed-signal family (`getAgcArmed`/`getFilterArmed`/`getPreampArmed`/
  `getAttenuatorArmed`/`getDataModeArmed`/`getAutoNotchArmed`/
  `getManualNotchArmed`) — fully covered by `mor1536-armed-adoption.isolated.test.ts`;
  `getModeArmed` by `mor1519-mode-armed.isolated.test.ts`. Neither runs
  against this fixture, but both are exhaustively covered against synthetic
  ones.
- `getPendingFrequencyHz`/discrete pending accessors — covered by
  `mor1441-pending-frequency`/`mor1441-pending-discrete`.
- `getActiveFrequencyHz` — covered by `mor1409-a15-active-frequency`.
- `bindSemanticSurfaceHandlers`/`bindVfoTunerContext` — covered by
  `semantic-surface-handler-binder`.
- `deriveAmberScopeProps`/`deriveAmberCockpitProps`/`getAmberCockpitHandlers` —
  need a THIRD harness extension (`hasAudioFft`/`hasDualReceiver`/
  `hasCapability` from `$lib/stores/capabilities.svelte` are not mocked at
  all today); left out to avoid growing the harness beyond what this walk
  strictly needs.
- `deriveMemoryPanelProps`/`deriveVfoControlProps`/`deriveAudioSpectrumProps`/
  `deriveAmberTelemetryProps` — zero coverage, genuine gap, follow-up scope.
- Every non-`panel-adapters` seam beyond the three modules above:
  `audio-adapter.ts`, `qsy-history-adapter.ts`, `vfo-adapter.ts`,
  `tx-adapter.ts`, `tx-capabilities.ts`, `lcd-chrome-adapter.ts`,
  `mod-input-*.svelte.ts`. `scope-adapter.ts`'s `toSpectrumAuthority` is
  already walked directly by MOR-1428.

## Red-first discrimination (2 cases, both reverted with `git checkout --`, no stash)

1. Fixture-value flip: temporarily edited `ic7300-capabilities.json`'s
   `meterRedlines.swr` from `120` to `999` — `getMeterRedline: exact swr
   redline` failed with `expected 999 to be 120`. Reverted.
2. Adapter-output flip: temporarily edited `panel-props.ts`'s
   `toBandSelectorProps` to add `+ 1` to the computed frequency —
   `deriveBandSelectorProps: exact active-VFO frequency` failed with
   `expected { currentFreq: 14188001 } to deeply equal { currentFreq:
   14188000 }`. Reverted.

## Test plan

- [x] `npx vitest run` targeted: the new file + `conformance/` dir +
      `panel-commands-completeness.test.ts` + `presentation-capabilities.test.ts`
      — **70 passed** (new file alone: 27, was 26 before the
      `deriveRitXitProps` addition)
- [x] Regression check: `mor1428`, `mor1536`, `mor1519`, `mor1441` (×2),
      `mor1409-a15`, `semantic-surface-handler-binder`,
      `memory-handler-binder`, `keyboard-system-accessors` — 178 passed, no
      regressions
- [x] `eslint` on the touched file — clean
- [x] `lint:boundaries` — clean (unaffected)
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] Boundary grep (`192\.168|\bmoroz\b|\bmini\b|:8099|preview-mor`) over
      the diff — empty
- [x] Total diff vs `main`: 2 files, exactly 400 insertions (hard cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
