### PR TITLE
test: DSP intent family conformance walk (MOR-1560)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -27,7 +27,18 @@
  * block, not guessed.
  */
 
-/** Intent names claimed by MOR-1428's IC-7300 fixture conformance suite. */
+/**
+ * Intent names claimed by MOR-1428's IC-7300 fixture conformance suite,
+ * plus MOR-1560's (C6) DSP family walk
+ * (`../mor1560-dsp-family-conformance.isolated.test.ts`) — 9 intents:
+ * `set_nr_level`, `set_nb_level`, `set_nb_depth`, `set_nb_width`,
+ * `set_auto_notch`, `set_manual_notch`, `set_manual_notch_width`,
+ * `set_notch_filter`, `set_agc_time_constant`. Every one of the 9 is
+ * claimed via `expectRefusal` (not `expectFrames`) — the real IC-7300
+ * fixture never observed any of these DSP sub-parameter leaves, so honest
+ * fail-closed refusal IS the conformant behavior on this profile (see that
+ * file's header for the fixture-derived evidence per intent).
+ */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',
   'set_filter',
@@ -49,6 +60,16 @@ export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_scope_span',
   'set_scope_speed',
   'set_scope_ref',
+  // MOR-1560 (C6) — DSP family walk
+  'set_nr_level',
+  'set_nb_level',
+  'set_nb_depth',
+  'set_nb_width',
+  'set_auto_notch',
+  'set_manual_notch',
+  'set_manual_notch_width',
+  'set_notch_filter',
+  'set_agc_time_constant',
 ]);
 
 /**

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -50,7 +50,6 @@ function tag(names: readonly string[], waiver: Waiver): Record<string, Waiver> {
   return Object.fromEntries(names.map((name) => [name, waiver]));
 }
 
-const DSP = { reason: 'DSP family walk not yet landed', owner: 'MOR-1560' } as const;
 const FILTER = { reason: 'Filter/PBT family walk not yet landed', owner: 'MOR-1561' } as const;
 const TX = { reason: 'TX-chain family walk not yet landed', owner: 'MOR-1564' } as const;
 const VOX_CW = { reason: 'VOX/CW family walk not yet landed', owner: 'MOR-1565' } as const;
@@ -59,18 +58,17 @@ const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner:
 const KEYBOARD = { reason: 'Keyboard action-fan-out walk not yet landed', owner: 'MOR-1563' } as const;
 
 /**
- * The 67 intents with no conformance assertion, tagged with the family
- * child that owns closing them. MOR-1562 (C8, adapter-seam parity)
+ * The (67 - 9 = 58) intents with no conformance assertion, tagged with the
+ * family child that owns closing them. MOR-1562 (C8, adapter-seam parity)
  * intentionally claims ZERO entries here — its scope is
  * `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
+ *
+ * MOR-1560 (C6)'s 9 DSP intents landed and were moved to `CLAIMED_INTENTS`
+ * in `./claimed.ts` — see `../mor1560-dsp-family-conformance.isolated.test.ts`.
  */
 export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
-  // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — 9
-  ...tag([
-    'set_nr_level', 'set_nb_level', 'set_nb_depth', 'set_nb_width',
-    'set_auto_notch', 'set_manual_notch', 'set_manual_notch_width',
-    'set_notch_filter', 'set_agc_time_constant',
-  ], DSP),
+  // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — CLAIMED, see
+  // `./claimed.ts` and `../mor1560-dsp-family-conformance.isolated.test.ts`.
   // MOR-1561 (C7) — Filter, PBT and IF-shift — 5
   ...tag([
     'set_filter_width', 'set_filter_shape', 'set_if_shift',
@@ -106,7 +104,7 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
 };
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const WAIVED_INTENTS_COUNT = 67;
+export const WAIVED_INTENTS_COUNT = 58;
 
 /**
  * The 28 `dispatchKeyboardRadioAction` case labels with no conformance

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts
@@ -1,0 +1,202 @@
+/**
+ * MOR-1560 (C6) — DSP intent family conformance walk, over the same
+ * profile-parameterized harness MOR-1428/MOR-1555 established
+ * (`./conformance/harness.ts`, `./conformance/profiles.ts`).
+ *
+ * Family (per `waived.ts`'s MOR-1560 tag, 9 intents): `set_nr_level`,
+ * `set_nb_level`, `set_nb_depth`, `set_nb_width`, `set_auto_notch`,
+ * `set_manual_notch`, `set_manual_notch_width`, `set_notch_filter`,
+ * `set_agc_time_constant` — all dispatched from `makeDspHandlers()` in
+ * `panel-commands.ts`.
+ *
+ * FINDING: every one of the 9 REFUSES on the real IC-7300 fixture, not
+ * because a capability is undeclared (the base `nr`/`nb`/`notch`/`agc`
+ * flags are all present in `IC7300_CAPABILITIES.capabilities`) but because
+ * the live capture session's `fieldStatus` never confirmed any of these
+ * FINE-GRAINED sub-parameters — only the coarse on/off toggles
+ * (`main.nr`/`main.nb`) were ever queried on the bench. This is the exact
+ * MOR-988 §3.2 fail-closed shape the exemplar's Section 3 already pins for
+ * `micGain`/`nbLevel`/`ritOn` — this walk is the same doctrine applied to
+ * the rest of the DSP family, not a deviation from it. Each case below
+ * names the SPECIFIC field/gate that blocks it, verified against the
+ * fixture's own `fieldStatus`/`capabilities.controls` data (never invented).
+ *
+ * TWO INTENTS (`set_nr_level`, `set_nb_level`) have a capability-declared
+ * numeric domain (`IC7300_CAPABILITIES.controls.nr_level` /
+ * `.nb_level`) and are walked at representative min/mid/max boundary
+ * inputs from that domain — proving the refusal holds across the whole
+ * range, not just one lucky value. The remaining 7 have NO declared range
+ * on this profile (verified via `expect(...controls.X).toBeUndefined()`
+ * below) — those get one representative case, using either the profile's
+ * own generic fallback range (`controlRangeFromCapsOrDefault`, the same
+ * fallback production code would apply, not a test-invented number) or the
+ * fixture's own captured value for that leaf.
+ *
+ * RED-FIRST EVIDENCE (MOR-1560 build process, not part of this diff): the
+ * first case below (`set_nr_level`) was authored as
+ * `expectFrames(() => makeDspHandlers().onNrLevelChange(0), [['set_nr_level',
+ * { level: 999, receiver: 0 }]])` — a deliberately wrong claim that the
+ * intent dispatches. `vitest run` on that version failed with
+ * `expected [] to deeply equal [ [ 'set_nr_level', …(1) ] ]` (RED — no
+ * frame was ever sent, proving the wrong claim false). Replacing it with
+ * `expectRefusal(...)` (the real, fixture-derived behavior) turned it GREEN.
+ *
+ * DISCRIMINATION EVIDENCE (MOR-1560 build process, not part of this diff):
+ * to prove the `set_agc_time_constant` refusal below isn't vacuous, its
+ * gate was scratch-flipped locally — `h.state.fieldStatus['main.agcTimeConstant']`
+ * temporarily set to `{ availability: 'available', observed: true, ... }`
+ * before calling `onAgcTimeChange` — and the refusal assertion then FAILED
+ * (the handler dispatched `set_agc_time_constant` with the fixture's own
+ * captured value), confirming the assertion genuinely depends on that one
+ * field-status gate. The scratch edit was reverted with `git checkout --`
+ * before this file was committed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  expectRefusal,
+  fixtureCaps,
+  fixtureState,
+  h,
+} from './conformance/harness';
+import { PROFILES } from './conformance/profiles';
+import { makeDspHandlers } from '../../commands/panel-commands';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import { controlRangeFromCapsOrDefault } from '$lib/radio/filter-controls';
+
+const profile = PROFILES.ic7300;
+const IC7300_STATE = profile.state;
+const IC7300_CAPABILITIES = profile.caps;
+
+describe('IC-7300 fixture — DSP family conformance (MOR-1560)', () => {
+  beforeEach(() => {
+    h.state = fixtureState(profile);
+    h.caps = fixtureCaps(profile);
+    h.sendCommand.mockClear();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  describe('set_nr_level — boundary walk over the declared nr_level range', () => {
+    // RED-FIRST: see file header. The declared wire range comes straight
+    // from the fixture (`raw_min`/`raw_max`); no `display_min`/`display_max`
+    // is declared, so the display domain is the SAME generic fallback
+    // `nrDisplayToRaw` itself would fall back to at runtime
+    // (`controlRangeFromCapsOrDefault`) — not a test-invented number.
+    const { displayMin, displayMax } = controlRangeFromCapsOrDefault('nr_level', IC7300_CAPABILITIES);
+    const mid = Math.round((displayMin + displayMax) / 2);
+
+    it('nr_level declares a wire range (raw_min/raw_max) but no display range on this profile', () => {
+      expect(IC7300_CAPABILITIES.controls?.nr_level).toEqual({ raw_min: 0, raw_max: 255 });
+    });
+
+    for (const level of [displayMin, mid, displayMax]) {
+      it(`level=${level} (display domain [${displayMin},${displayMax}]): REFUSES — main.nrLevel is unobserved (main.nr IS observed)`, () => {
+        expect(IC7300_CAPABILITIES.capabilities).toContain('nr');
+        expect(IC7300_STATE.fieldStatus?.['main.nrLevel']?.observed).toBe(false);
+        expect(IC7300_STATE.fieldStatus?.['main.nr']?.observed).toBe(true);
+        expectRefusal(() => makeDspHandlers().onNrLevelChange(level));
+      });
+    }
+  });
+
+  describe('set_nb_level — boundary walk over the declared nb_level range (direct wire passthrough, no display scaling)', () => {
+    const rawMin = IC7300_CAPABILITIES.controls!.nb_level!.raw_min;
+    const rawMax = IC7300_CAPABILITIES.controls!.nb_level!.raw_max;
+    const mid = Math.round((rawMin + rawMax) / 2);
+
+    it('nb_level declares a wire range on this profile', () => {
+      expect(IC7300_CAPABILITIES.controls?.nb_level).toEqual({ raw_min: 0, raw_max: 255 });
+    });
+
+    for (const level of [rawMin, mid, rawMax]) {
+      it(`level=${level} (wire domain [${rawMin},${rawMax}]): REFUSES — main.nbLevel is unobserved (main.nb IS observed)`, () => {
+        expect(IC7300_CAPABILITIES.capabilities).toContain('nb');
+        expect(IC7300_STATE.fieldStatus?.['main.nbLevel']?.observed).toBe(false);
+        expect(IC7300_STATE.fieldStatus?.['main.nb']?.observed).toBe(true);
+        expectRefusal(() => makeDspHandlers().onNbLevelChange(level));
+      });
+    }
+  });
+
+  describe('set_nb_depth — no declared range on this profile; boundary walk over the generic fallback', () => {
+    // This profile's `capabilities.controls` has NO `nb_depth` entry at
+    // all — verified below — so `onNbDepthChange`'s OWN capability gate
+    // (`getCapabilities()?.controls?.nb_depth`) already refuses before any
+    // value is examined. The walked domain is the same generic
+    // `CONTROL_DEFAULTS.nb_depth` fallback `nbDepthDisplayToRaw` would use
+    // if the gate ever passed — not a number invented for this test.
+    const { displayMin, displayMax } = controlRangeFromCapsOrDefault('nb_depth', IC7300_CAPABILITIES);
+    const mid = Math.round((displayMin + displayMax) / 2);
+
+    it('nb_depth is not a declared control on this profile', () => {
+      expect(IC7300_CAPABILITIES.controls?.nb_depth).toBeUndefined();
+    });
+
+    for (const level of [displayMin, mid, displayMax]) {
+      it(`level=${level}: REFUSES — nb_depth is not a declared control on this profile`, () => {
+        expectRefusal(() => makeDspHandlers().onNbDepthChange(level));
+      });
+    }
+  });
+
+  it('set_nb_width: REFUSES — gated on the same undeclared nb_depth control, and topLevel nbWidth is unobserved', () => {
+    // `onNbWidthChange` shares `onNbDepthChange`'s capability gate
+    // (`controls?.nb_depth`, not its own `nb_width` key — panel-commands.ts
+    // reads it that way) and has no display/raw scaling of its own, so
+    // there is no declared domain to walk here at all. One representative
+    // case, using the fixture's own captured top-level value.
+    expect(IC7300_CAPABILITIES.controls?.nb_depth).toBeUndefined();
+    expect(IC7300_STATE.fieldStatus?.nbWidth?.observed).toBe(false);
+    expectRefusal(() => makeDspHandlers().onNbWidthChange(IC7300_STATE.nbWidth as number));
+  });
+
+  describe('set_auto_notch / set_manual_notch — walked across onNotchModeChange\'s full mode enum, plus onAutoNotchToggle', () => {
+    for (const mode of ['auto', 'manual', 'off'] as const) {
+      it(`onNotchModeChange('${mode}'): REFUSES — main.autoNotch is unobserved`, () => {
+        expect(IC7300_CAPABILITIES.capabilities).toContain('notch');
+        expect(IC7300_STATE.fieldStatus?.['main.autoNotch']?.observed).toBe(false);
+        expect(IC7300_STATE.fieldStatus?.['main.manualNotch']?.observed).toBe(false);
+        expectRefusal(() => makeDspHandlers().onNotchModeChange(mode));
+      });
+    }
+
+    it("onAutoNotchToggle: REFUSES — same main.autoNotch gate, independent call site for set_auto_notch", () => {
+      expect(IC7300_STATE.fieldStatus?.['main.autoNotch']?.observed).toBe(false);
+      expectRefusal(() => makeDspHandlers().onAutoNotchToggle());
+    });
+  });
+
+  it('set_notch_filter: REFUSES — main.notchFilter does not exist as a per-receiver field on this profile (onNotchFreqChange is receiver-scoped)', () => {
+    // MOR-1548 reclassified `onNotchFreqChange` as receiver-scoped
+    // (`knownReceiverField('notchFilter')`, i.e. it reads `main.notchFilter`)
+    // but this fixture's `main` object has no `notchFilter` key at all.
+    // `knownReceiverField` returns null because the per-receiver VALUE is
+    // undefined, independent of fieldStatus availability — so no declared
+    // input domain exists here; the input value below is a neutral literal
+    // (same convention as the exemplar's `onMicGainChange(100)` refusal
+    // case), not a fixture- or radio-derived number.
+    expect(IC7300_CAPABILITIES.capabilities).toContain('notch');
+    expect(IC7300_STATE.main).not.toHaveProperty('notchFilter');
+    expectRefusal(() => makeDspHandlers().onNotchFreqChange(0));
+  });
+
+  it('set_manual_notch_width: REFUSES — main.manualNotchWidth is unobserved, no declared control range on this profile', () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('notch');
+    expect(IC7300_CAPABILITIES.controls?.manual_notch_width).toBeUndefined();
+    expect(IC7300_STATE.fieldStatus?.['main.manualNotchWidth']?.observed).toBe(false);
+    expectRefusal(
+      () => makeDspHandlers().onManualNotchWidthChange(IC7300_STATE.main!.manualNotchWidth as number),
+    );
+  });
+
+  it('set_agc_time_constant: REFUSES — main.agcTimeConstant is unobserved, no declared control range on this profile (discrimination case, see file header)', () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('agc');
+    expect(IC7300_CAPABILITIES.controls?.agc_time_constant).toBeUndefined();
+    expect(IC7300_STATE.fieldStatus?.['main.agcTimeConstant']?.observed).toBe(false);
+    expectRefusal(
+      () => makeDspHandlers().onAgcTimeChange(IC7300_STATE.main!.agcTimeConstant as number),
+    );
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
@@ -202,7 +202,7 @@ completenessSuite({
   claimed: CLAIMED_INTENTS,
   waived: WAIVED_INTENTS,
   waivedCount: WAIVED_INTENTS_COUNT,
-  claimedCount: 20,
+  claimedCount: 29,
 });
 
 completenessSuite({


### PR DESCRIPTION
## Summary

- Tier-2 family walk (C6 of the MOR-1426 conformance program): drives the 9 MOR-1560-tagged DSP intents through the existing profile-parameterized harness (`frontend/src/lib/runtime/adapters/__tests__/conformance/harness.ts`, `profiles.ts`) against the registered `ic7300` fixture, in a new `mor1560-dsp-family-conformance.isolated.test.ts`.
- Moves all 9 intents from `WAIVED_INTENTS` to `CLAIMED_INTENTS` (`conformance/claimed.ts` / `conformance/waived.ts`); decrements the pinned `WAIVED_INTENTS_COUNT` 67 -> 58.
- Updates `panel-commands-completeness.test.ts`'s pinned `claimedCount` 20 -> 29 (a 4th file — see note below).

## Finding

All 9 intents **refuse** on the real, live-captured IC-7300 fixture. The base `nr`/`nb`/`notch`/`agc` capability flags are all declared true (`IC7300_CAPABILITIES.capabilities`), but the bench-captured session's `fieldStatus` only ever confirmed the coarse on/off toggles (`main.nr`, `main.nb`) — none of these finer-grained sub-parameters (level, depth, width, notch sub-modes, AGC time constant) were ever queried, so every one is genuinely `observed: false`. Per MOR-988 sec3.2 (fail-closed doctrine, already established in the MOR-1428 exemplar for `ritOn`/`micGain`/`nbLevel`), honest refusal is the conformant behavior here, not a fabricated dispatch.

## Per-intent coverage

| Intent | Outcome | Cases | Source of expected values |
|---|---|---|---|
| `set_nr_level` | refusal | 3 (boundary: display 0/8/15) | `main.nrLevel` fieldStatus `observed:false` (contrast: `main.nr` `observed:true`); domain from `IC7300_CAPABILITIES.controls.nr_level` (raw range) via the production `controlRangeFromCapsOrDefault` fallback (no `display_min`/`display_max` declared on this profile) |
| `set_nb_level` | refusal | 3 (boundary: wire 0/128/255) | `main.nbLevel` fieldStatus `observed:false` (contrast: `main.nb` `observed:true`); domain from `IC7300_CAPABILITIES.controls.nb_level.raw_min/raw_max` directly (no display scaling in code) |
| `set_nb_depth` | refusal | 3 (boundary: display 1/6/10) | `IC7300_CAPABILITIES.controls.nb_depth` is undeclared on this profile (capability gate fails before any value is examined); domain from the same generic `CONTROL_DEFAULTS.nb_depth` fallback `nbDepthDisplayToRaw` would use |
| `set_nb_width` | refusal | 1 | Shares `nb_depth`'s undeclared capability gate; top-level `nbWidth` fieldStatus `observed:false` |
| `set_auto_notch` | refusal | 4 (`onNotchModeChange('auto'/'manual'/'off')` + `onAutoNotchToggle`, two independent call sites) | `main.autoNotch` fieldStatus `observed:false` |
| `set_manual_notch` | refusal | covered by the same mode-enum walk (`'manual'`/`'off'` branches) | `main.manualNotch` fieldStatus `observed:false` |
| `set_notch_filter` | refusal | 1 | `main.notchFilter` does not exist as a per-receiver value at all on this fixture (structural gap between MOR-1548's receiver-scoped reclassification and the captured state shape) |
| `set_manual_notch_width` | refusal | 1 | `main.manualNotchWidth` fieldStatus `observed:false`; no declared `controls.manual_notch_width` range on this profile |
| `set_agc_time_constant` | refusal | 1 (discrimination-verified, see below) | `main.agcTimeConstant` fieldStatus `observed:false`; no declared `controls.agc_time_constant` range on this profile |

20 test cases total across the 9 intents.

## Red-first evidence

`set_nr_level` was authored first with a deliberately wrong claim:
```ts
expectFrames(
  () => makeDspHandlers().onNrLevelChange(0),
  [['set_nr_level', { level: 999, receiver: 0 }]],
);
```
`vitest run` on that version:
```
AssertionError: expected [] to deeply equal [ [ 'set_nr_level', …(1) ] ]
- Expected: [ [ "set_nr_level", { "level": 999, "receiver": 0 } ] ]
+ Received: []
```
(RED — no frame was ever dispatched, disproving the wrong claim.) Replacing it with `expectRefusal(() => makeDspHandlers().onNrLevelChange(0))` (the real, fixture-derived behavior) turned the test **GREEN**.

## Discrimination evidence

To prove the `set_agc_time_constant` refusal isn't vacuous, its gate was scratch-flipped locally: `h.state.fieldStatus['main.agcTimeConstant']` was temporarily set to `{ observed: true, availability: 'available', ... }` before calling `onAgcTimeChange`. The refusal assertion then **failed**:
```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
1st vi.fn() call:
  [ "set_agc_time_constant", { "receiver": 0, "value": 0 }, "<uuid>" ]
```
confirming the assertion genuinely depends on that one field-status gate (and incidentally confirming the exact frame that WOULD be dispatched if this leaf were ever observed). The scratch edit was reverted (`git status` shows only the new test file before staging the ledger updates) — no scratch code is present in this diff.

## Note on file count

The task scope named 3 files (test file + `claimed.ts` + `waived.ts`). `panel-commands-completeness.test.ts` pins `claimedCount: 20` as a literal argument inside the file itself (not imported from `claimed.ts`), so keeping that meta-test green after claiming 9 more intents required updating it too — a 1-line change. Total diff: 4 files, 233 insertions / 12 deletions, well under the 400 LOC guardrail.

## Test plan

- [x] `npx vitest run src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts` — 20/20 green
- [x] `npx vitest run src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts` — green (completeness ledger consistent)
- [x] `npx vitest run src/lib/runtime/adapters/__tests__/mor1428-ic7300-conformance.isolated.test.ts` — green (regression, unaffected)
- [x] `npm run lint` (eslint) — clean
- [x] `npm run lint:boundaries` — clean
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- [x] Boundary grep (`192\.168|\bmoroz\b|\bmini\b|:8099|preview-mor`) over the full diff — no matches

Closes MOR-1560