### PR TITLE
test: filter/PBT intent family conformance walk (MOR-1561)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -38,6 +38,18 @@
  * fixture never observed any of these DSP sub-parameter leaves, so honest
  * fail-closed refusal IS the conformant behavior on this profile (see that
  * file's header for the fixture-derived evidence per intent).
+ *
+ * Plus MOR-1561's (C7) filter/PBT family walk
+ * (`../mor1561-filter-pbt-family-conformance.isolated.test.ts`) — 5 intents:
+ * `set_filter_width`, `set_filter_shape`, `set_if_shift`, `set_pbt_inner`,
+ * `set_pbt_outer`. NOT uniform like C6: `set_filter_shape`/`set_if_shift`/
+ * `set_pbt_inner`/`set_pbt_outer` are claimed via `expectRefusal` (each
+ * genuinely unobserved/undeclared on this fixture), but `set_filter_width`
+ * is claimed via a real `expectFrames` — `onFilterPresetChange` dispatches
+ * it on this fixture through a gate (`main.filter`, observed) that is
+ * DIFFERENT from the field the intent itself writes (`main.filterWidth`,
+ * unobserved) — see that file's header for the full finding and red-first
+ * evidence.
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',
@@ -70,7 +82,16 @@ export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_manual_notch_width',
   'set_notch_filter',
   'set_agc_time_constant',
+  // MOR-1561 (C7) — Filter, PBT and IF-shift family walk
+  'set_filter_width',
+  'set_filter_shape',
+  'set_if_shift',
+  'set_pbt_inner',
+  'set_pbt_outer',
 ]);
+
+/** Pinned so a removal (or an undocumented addition) shows up in review. */
+export const CLAIMED_INTENTS_COUNT = 34;
 
 /**
  * `dispatchKeyboardRadioAction` case labels claimed by a conformance case.

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -50,7 +50,6 @@ function tag(names: readonly string[], waiver: Waiver): Record<string, Waiver> {
   return Object.fromEntries(names.map((name) => [name, waiver]));
 }
 
-const FILTER = { reason: 'Filter/PBT family walk not yet landed', owner: 'MOR-1561' } as const;
 const TX = { reason: 'TX-chain family walk not yet landed', owner: 'MOR-1564' } as const;
 const VOX_CW = { reason: 'VOX/CW family walk not yet landed', owner: 'MOR-1565' } as const;
 const SCOPE_VFO = { reason: 'Scope-remainder/VFO-topology family walk not yet landed', owner: 'MOR-1566' } as const;
@@ -58,22 +57,21 @@ const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner:
 const KEYBOARD = { reason: 'Keyboard action-fan-out walk not yet landed', owner: 'MOR-1563' } as const;
 
 /**
- * The (67 - 9 = 58) intents with no conformance assertion, tagged with the
- * family child that owns closing them. MOR-1562 (C8, adapter-seam parity)
- * intentionally claims ZERO entries here — its scope is
+ * The (67 - 9 - 5 = 53) intents with no conformance assertion, tagged with
+ * the family child that owns closing them. MOR-1562 (C8, adapter-seam
+ * parity) intentionally claims ZERO entries here — its scope is
  * `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
  *
- * MOR-1560 (C6)'s 9 DSP intents landed and were moved to `CLAIMED_INTENTS`
- * in `./claimed.ts` — see `../mor1560-dsp-family-conformance.isolated.test.ts`.
+ * MOR-1560 (C6)'s 9 DSP intents and MOR-1561 (C7)'s 5 filter/PBT intents
+ * landed and were moved to `CLAIMED_INTENTS` in `./claimed.ts` — see
+ * `../mor1560-dsp-family-conformance.isolated.test.ts` and
+ * `../mor1561-filter-pbt-family-conformance.isolated.test.ts`.
  */
 export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
   // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — CLAIMED, see
   // `./claimed.ts` and `../mor1560-dsp-family-conformance.isolated.test.ts`.
-  // MOR-1561 (C7) — Filter, PBT and IF-shift — 5
-  ...tag([
-    'set_filter_width', 'set_filter_shape', 'set_if_shift',
-    'set_pbt_inner', 'set_pbt_outer',
-  ], FILTER),
+  // MOR-1561 (C7) — Filter, PBT and IF-shift — CLAIMED, see `./claimed.ts`
+  // and `../mor1561-filter-pbt-family-conformance.isolated.test.ts`.
   // MOR-1564 (C10) — TX chain — 8
   ...tag([
     'set_rf_power', 'set_mic_gain', 'set_compressor', 'set_compressor_level',
@@ -104,7 +102,7 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
 };
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const WAIVED_INTENTS_COUNT = 58;
+export const WAIVED_INTENTS_COUNT = 53;
 
 /**
  * The 28 `dispatchKeyboardRadioAction` case labels with no conformance

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1561-filter-pbt-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1561-filter-pbt-family-conformance.isolated.test.ts
@@ -1,0 +1,164 @@
+/**
+ * MOR-1561 (C7) — Filter/PBT/IF-shift intent family conformance walk, over
+ * the same profile-parameterized harness MOR-1428/MOR-1555 established
+ * (`./conformance/harness.ts`, `./conformance/profiles.ts`).
+ *
+ * Family (per `waived.ts`'s MOR-1561 tag, 5 intents): `set_filter_width`,
+ * `set_filter_shape`, `set_if_shift`, `set_pbt_inner`, `set_pbt_outer` — all
+ * dispatched from `makeFilterHandlers()` in `panel-commands.ts`.
+ *
+ * UNLIKE MOR-1560's DSP walk (9/9 uniform refusals), this family is NOT
+ * uniform: `set_filter_width` has FOUR distinct dispatch sites
+ * (`onFilterWidthChange`, `onFilterWidthCommit`, `onFilterPresetChange`,
+ * `onFilterDefaults`), and they do not all gate on the same field.
+ * `onFilterWidthChange`/`onFilterDefaults` gate on `knownActiveReceiver('filterWidth')`
+ * — `main.filterWidth` is unobserved on this fixture, so both refuse.
+ * `onFilterPresetChange` gates on `knownActiveReceiver('filter')` instead
+ * (`panel-commands.ts`'s own choice — it only needs to know the CURRENT
+ * active filter slot to decide whether a `set_filter` bracket is needed, not
+ * whether `filterWidth` itself was ever confirmed) — `main.filter` IS
+ * observed on this fixture, so this path genuinely dispatches
+ * `set_filter_width`. This is a real, profile-derived finding, not a test
+ * artifact: the same live IC-7300 session that never confirmed
+ * `filterWidth` readback still lets an operator push a width through the
+ * settings-modal preset path today. `set_filter_shape`/`set_if_shift`/
+ * `set_pbt_inner`/`set_pbt_outer` have no such split — each refuses through
+ * its own single gate, named per case below and verified against the
+ * fixture's own `fieldStatus`/`capabilities.controls` data (never invented).
+ *
+ * RED-FIRST EVIDENCE (MOR-1561 build process, not part of this diff): the
+ * `onFilterPresetChange` case below was first authored as
+ * `expectFrames(() => { makeFilterHandlers().onFilterPresetChange(1, 3000);
+ * vi.advanceTimersByTime(200); }, [['set_filter_width', { width: 9999,
+ * receiver: 1 }]])` — deliberately wrong width/receiver. `vitest run` on
+ * that version failed with `expected [ [ 'set_filter_width', { width: 3000,
+ * receiver: 0 } ] ] to deeply equal [ [ 'set_filter_width', { width: 9999,
+ * receiver: 1 } ] ]` (RED — the real dispatch is 3000/receiver 0, not the
+ * fabricated 9999/1). Replacing the claim with the real fixture-derived
+ * values (`IC7300_STATE.main.filter === 1`, `filterConfig.USB.defaults[0]
+ * === 3000`, already on-grid so `quantizeFilterWidthToRule` is a no-op)
+ * turned it GREEN.
+ *
+ * DISCRIMINATION EVIDENCE (MOR-1561 build process, not part of this diff):
+ * to prove the `set_pbt_inner` refusal below isn't vacuous, its gate was
+ * scratch-flipped locally — `h.state.fieldStatus['main.pbtInner']`
+ * temporarily set to `{ availability: 'available', observed: true, ... }`
+ * before calling `onPbtInnerChange` — and the refusal assertion then FAILED
+ * (the handler dispatched `set_pbt_inner` with the fixture's own raw-mapped
+ * value), confirming the assertion genuinely depends on that one
+ * field-status gate. The scratch edit was staged (`git add`) in its clean
+ * form first, then reverted with `git checkout --` (not `git stash`) after
+ * observing the failure, restoring the green state before this file was
+ * committed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  expectFrames,
+  expectRefusal,
+  fixtureCaps,
+  fixtureState,
+  h,
+} from './conformance/harness';
+import { PROFILES } from './conformance/profiles';
+import { makeFilterHandlers } from '../../commands/panel-commands';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+import { pbtRangeFromCaps } from '$lib/radio/filter-controls';
+
+const profile = PROFILES.ic7300;
+const IC7300_STATE = profile.state;
+const IC7300_CAPABILITIES = profile.caps;
+
+describe('IC-7300 fixture — filter/PBT family conformance (MOR-1561)', () => {
+  beforeEach(() => {
+    h.state = fixtureState(profile);
+    h.caps = fixtureCaps(profile);
+    h.sendCommand.mockClear();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  describe('set_filter_width — divergent call-site gates on this profile (see file header)', () => {
+    it('onFilterWidthChange: REFUSES — main.filterWidth is unobserved (checked before the 200ms debounce even starts)', () => {
+      expect(IC7300_CAPABILITIES.capabilities).toContain('filter_width');
+      expect(IC7300_STATE.fieldStatus?.['main.filterWidth']?.observed).toBe(false);
+      expectRefusal(() => makeFilterHandlers().onFilterWidthChange(1800));
+    });
+
+    it('onFilterDefaults: REFUSES — same knownActiveReceiver(\'filterWidth\') gate as onFilterWidthChange', () => {
+      expect(IC7300_STATE.fieldStatus?.['main.filterWidth']?.observed).toBe(false);
+      expectRefusal(() => makeFilterHandlers().onFilterDefaults([3000, 2400, 1800]));
+    });
+
+    it('onFilterPresetChange: CLAIMS — gated only on knownActiveReceiver(\'filter\') (main.filter IS observed), not on filterWidth at all (RED-FIRST evidence in file header)', () => {
+      expect(IC7300_STATE.fieldStatus?.['main.filter']?.observed).toBe(true);
+      expect(IC7300_STATE.main!.filter).toBe(1);
+      // Fixture's own USB filter-width rule (rigs/ic7300.toml via
+      // filterConfig.USB) — 3000 Hz is its first declared default AND
+      // already sits on the declared 100 Hz-step segment grid (600-3600),
+      // so quantizeFilterWidthToRule is a no-op here, not a coincidence.
+      expect(IC7300_CAPABILITIES.filterConfig?.USB?.defaults?.[0]).toBe(3000);
+      vi.useFakeTimers();
+      try {
+        // filter=1 equals the fixture's own active filter (main.filter===1),
+        // so no bracketing set_filter calls fire — exactly one frame.
+        expectFrames(() => {
+          makeFilterHandlers().onFilterPresetChange(1, 3000);
+          vi.advanceTimersByTime(200);
+        }, [['set_filter_width', { width: 3000, receiver: 0 }]]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it('set_filter_shape: REFUSES — main.filterShape is unobserved (onFilterShapeChange is the only dispatch site)', () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('filter_shape');
+    expect(IC7300_CAPABILITIES.controls?.filter_shape).toBeUndefined();
+    expect(IC7300_STATE.fieldStatus?.['main.filterShape']?.observed).toBe(false);
+    expectRefusal(() => makeFilterHandlers().onFilterShapeChange(IC7300_STATE.main!.filterShape as number));
+  });
+
+  it('set_if_shift: REFUSES — if_shift is not a declared capability on this profile, so onIfShiftChange never enters its if_shift branch at all; it falls through to the pbt branch, which itself refuses (main.pbtInner unobserved)', () => {
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('if_shift');
+    expect(IC7300_CAPABILITIES.capabilities).toContain('pbt');
+    expect(IC7300_STATE.fieldStatus?.['main.pbtInner']?.observed).toBe(false);
+    expectRefusal(() => makeFilterHandlers().onIfShiftChange(0));
+  });
+
+  describe('set_pbt_inner — boundary walk over the declared pbt range (discrimination case, see file header)', () => {
+    const pbtRange = pbtRangeFromCaps(IC7300_CAPABILITIES)!;
+
+    it('pbt_inner declares a usable range on this profile', () => {
+      expect(IC7300_CAPABILITIES.controls?.pbt_inner).toEqual({
+        raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200, display_unit: 'Hz',
+      });
+      expect(pbtRange).toEqual({ rawCenter: 128, displayMin: -1200, displayMax: 1200 });
+    });
+
+    for (const hz of [pbtRange.displayMin, 0, pbtRange.displayMax]) {
+      it(`value=${hz} Hz (declared domain [${pbtRange.displayMin},${pbtRange.displayMax}]): REFUSES — main.pbtInner is unobserved`, () => {
+        expect(IC7300_STATE.fieldStatus?.['main.pbtInner']?.observed).toBe(false);
+        expectRefusal(() => makeFilterHandlers().onPbtInnerChange(hz));
+      });
+    }
+  });
+
+  describe('set_pbt_outer — boundary walk over the declared pbt range (same domain and gate shape as pbt_inner)', () => {
+    const pbtRange = pbtRangeFromCaps(IC7300_CAPABILITIES)!;
+
+    it('pbt_outer declares a usable range on this profile', () => {
+      expect(IC7300_CAPABILITIES.controls?.pbt_outer).toEqual({
+        raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200, display_unit: 'Hz',
+      });
+    });
+
+    for (const hz of [pbtRange.displayMin, 0, pbtRange.displayMax]) {
+      it(`value=${hz} Hz (declared domain [${pbtRange.displayMin},${pbtRange.displayMax}]): REFUSES — main.pbtOuter is unobserved`, () => {
+        expect(IC7300_STATE.fieldStatus?.['main.pbtOuter']?.observed).toBe(false);
+        expectRefusal(() => makeFilterHandlers().onPbtOuterChange(hz));
+      });
+    }
+  });
+});

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
@@ -1,10 +1,15 @@
 /**
  * MOR-1556 (C2) — conformance completeness ledger.
  *
- * 67 of panel-commands.ts's 87 distinct dispatched intent names have no
- * conformance assertion (MOR-1428/MOR-1555 claims 20), and nothing made
- * that visible — the exact failure shape the whole MOR-1426 program exists
- * to kill (green tests, dead controls). This meta-test is the visibility:
+ * A large share of panel-commands.ts's distinct dispatched intent names
+ * have no conformance assertion — see `WAIVED_INTENTS_COUNT` (waived) and
+ * `CLAIMED_INTENTS_COUNT` (claimed) in the two ledger files below for the
+ * CURRENT split; their sum is the total distinct intent-name universe this
+ * suite enforces, so it never needs a hardcoded figure here that a future
+ * family walk would make stale. Until MOR-1560/1561 landed, nothing made
+ * that gap visible — the exact failure shape the whole MOR-1426 program
+ * exists to kill (green tests, dead controls). This meta-test is the
+ * visibility:
  * every intent name the command layer can emit, and every
  * `dispatchKeyboardRadioAction` case label, must be either claimed
  * (`../../adapters/__tests__/conformance/claimed.ts`) or explicitly waived
@@ -45,8 +50,9 @@
  * DYNAMIC NAME, VERIFIED AND HANDLED EXPLICITLY: one call site,
  * `onModInputChange`, computes its name at runtime via
  * `modInputCommand(dataMode)` — not a literal, so `INTENT_CALL_RE`
- * correctly skips it and it is not counted toward 87/67/20. Its 4-value
- * domain is pinned separately by `$lib/radio/mod-input.test.ts`; the
+ * correctly skips it and it is not counted toward the claimed/waived totals
+ * below. Its 4-value domain is pinned separately by
+ * `$lib/radio/mod-input.test.ts`; the
  * `describe('dynamic mod-input call site...')` block below asserts the
  * source still contains EXACTLY one such non-literal call, so a second
  * one introduced later fails loudly instead of silently escaping both
@@ -67,6 +73,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
   CLAIMED_INTENTS,
+  CLAIMED_INTENTS_COUNT,
   CLAIMED_KEYBOARD_ACTIONS,
 } from '../../adapters/__tests__/conformance/claimed';
 import {
@@ -202,7 +209,7 @@ completenessSuite({
   claimed: CLAIMED_INTENTS,
   waived: WAIVED_INTENTS,
   waivedCount: WAIVED_INTENTS_COUNT,
-  claimedCount: 29,
+  claimedCount: CLAIMED_INTENTS_COUNT,
 });
 
 completenessSuite({


### PR DESCRIPTION
## Summary

C7 of the MOR-1426 conformance program: walks the 5 MOR-1561-tagged filter/PBT intents through `conformance/harness.ts` against the registered `ic7300` profile, following the #2480 (MOR-1560/C6) pattern — checking the handler's actual gates (`fieldStatus`, `capabilities.controls`, value presence) rather than assuming uniform outcomes.

New: `frontend/src/lib/runtime/adapters/__tests__/mor1561-filter-pbt-family-conformance.isolated.test.ts`

## Per-intent table

| Intent | Outcome | Gate / frame source |
|---|---|---|
| `set_filter_shape` | REFUSES | `main.filterShape` unobserved on the live fixture (`onFilterShapeChange`'s only dispatch site, gated on `knownActiveReceiver('filterShape')`) |
| `set_if_shift` | REFUSES | `if_shift` is not a declared capability on this profile — `onIfShiftChange` never enters its `if_shift` branch; falls through to the `pbt` branch, which itself refuses (`main.pbtInner` unobserved) |
| `set_pbt_inner` | REFUSES (boundary walk: min/mid/max of the declared `[-1200, 1200]` Hz domain) | `main.pbtInner` unobserved on this fixture (`pbtRangeFromCaps` itself succeeds — the range IS declared; the field-observation gate is what blocks) |
| `set_pbt_outer` | REFUSES (same boundary walk) | `main.pbtOuter` unobserved on this fixture, same gate shape as `pbt_inner` |
| `set_filter_width` | **CLAIMED — frames-pinned**, `['set_filter_width', { width: 3000, receiver: 0 }]` | Divergent call-site gates (not uniform, see file header): `onFilterWidthChange`/`onFilterDefaults` gate on `knownActiveReceiver('filterWidth')` and REFUSE (`main.filterWidth` unobserved); `onFilterPresetChange` gates on `knownActiveReceiver('filter')` instead (`main.filter` IS observed) and genuinely dispatches — a real, profile-derived finding, not a test artifact |

Ledger: `waived.ts` 58 → 53, `claimed.ts` 29 → 34.

## Ledger cleanup (MOR-1560/#2480 verifier follow-up, same PR since the ledger is touched anyway)

1. Added `CLAIMED_INTENTS_COUNT` to `claimed.ts` mirroring `WAIVED_INTENTS_COUNT`; `panel-commands-completeness.test.ts` now imports both pins instead of a local `claimedCount: 29` literal.
2. Reworded the completeness test's stale header prose (previously hardcoded "67 of ... 87 ... claims 20") to reference the living `WAIVED_INTENTS_COUNT`/`CLAIMED_INTENTS_COUNT` pins instead, so it can't go stale on a future walk.

## Red-first evidence

`onFilterPresetChange` case first authored with deliberately-wrong bytes:

```
expectFrames(() => {
  makeFilterHandlers().onFilterPresetChange(1, 3000);
  vi.advanceTimersByTime(200);
}, [['set_filter_width', { width: 9999, receiver: 1 }]]);
```

RED:
```
AssertionError: expected [ [ 'set_filter_width', …(1) ] ] to deeply equal [ [ 'set_filter_width', …(1) ] ]
- Expected
+ Received
    [
      [
        "set_filter_width",
        {
-       "receiver": 1,
-       "width": 9999,
+       "receiver": 0,
+       "width": 3000,
      },
    ],
  ]
```

Fixed to the fixture-derived truth (`main.filter === 1`, `filterConfig.USB.defaults[0] === 3000`, already on-grid):

```
expectFrames(() => {
  makeFilterHandlers().onFilterPresetChange(1, 3000);
  vi.advanceTimersByTime(200);
}, [['set_filter_width', { width: 3000, receiver: 0 }]]);
```

GREEN — full file: 13/13 passed.

## Discrimination evidence

Scratch-flipped `set_pbt_inner`'s gate (temporarily set `h.state.fieldStatus['main.pbtInner']` to `observed: true`) — the refusal assertion then FAILED, with the handler actually dispatching `['set_pbt_inner', { receiver: 0, value: 128 }, <id>]`, confirming the assertion genuinely depends on that one field-status gate. Reverted with `git checkout --` (not `git stash`); full file re-confirmed green (13/13) afterward.

## Test plan

- [x] `npx vitest run` on the new file + `panel-commands-completeness.test.ts` + `mor1428-ic7300-conformance.isolated.test.ts` + `mor1560-dsp-family-conformance.isolated.test.ts` — 80/80 passed
- [x] `npx eslint` on the 4 touched files — clean
- [x] `npm run lint:boundaries` — clean
- [x] `npx svelte-check` — 0 errors, 0 warnings
- [x] `git diff` — exactly the 4 intended files, 209 insertions / 19 deletions

Closes MOR-1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)