### PR TITLE
test: keyboard action fan-out conformance walk (MOR-1563)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -50,6 +50,16 @@
  * DIFFERENT from the field the intent itself writes (`main.filterWidth`,
  * unobserved) — see that file's header for the full finding and red-first
  * evidence.
+ *
+ * Plus 4 intents claimed by MOR-1563's (C9) keyboard action fan-out walk
+ * (`../mor1563-keyboard-fanout-conformance.isolated.test.ts`) — per
+ * `./waived.ts`'s own convention (a landed `expectFrames` moves the intent
+ * here even when the claiming test isn't that intent's OWN family walk):
+ * `set_data_mode` (`cycle_data_mode` keyboard case), `vfo_swap`/
+ * `vfo_equalize` (their own like-named keyboard cases), `set_scope_hold`
+ * (`scope_toggle_hold` keyboard case). Removed from the MOR-1566/MOR-1567
+ * waiver tags in `./waived.ts` — those family walks extend coverage on
+ * these four (more call sites, more profiles), they do not initiate it.
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',
@@ -88,21 +98,27 @@ export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_if_shift',
   'set_pbt_inner',
   'set_pbt_outer',
+  // MOR-1563 (C9) — keyboard action fan-out walk (see comment above)
+  'set_data_mode',
+  'vfo_swap',
+  'vfo_equalize',
+  'set_scope_hold',
 ]);
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const CLAIMED_INTENTS_COUNT = 34;
+export const CLAIMED_INTENTS_COUNT = 38;
 
 /**
  * `dispatchKeyboardRadioAction` case labels claimed by a conformance case.
  * `toggle_split` was claimed by MOR-1428's "keyboard context" case (over
  * `dispatchKeyboardRadioAction({ action: 'toggle_split' })`). MOR-1563 (C9)
  * walked the remaining 28 in
- * `../mor1563-keyboard-fanout-conformance.isolated.test.ts` — 18 genuinely
- * DISPATCH on this fixture, 10 REFUSE (each case names its firing gate; see
- * that file's header for the full per-action table and the MOR-1454-related
- * findings on the cycle/step cases). `WAIVED_KEYBOARD_ACTIONS` in
- * `./waived.ts` is now empty — this ledger's keyboard half is closed.
+ * `../mor1563-keyboard-fanout-conformance.isolated.test.ts` — 17 genuinely
+ * DISPATCH on this fixture, 11 REFUSE (each case names its firing gate; see
+ * that file's header for the full per-action table, the MOR-1577 finding
+ * on adjust_af_level/adjust_rf_gain, and the MOR-1454/MOR-1578-related
+ * notes elsewhere in the table). `WAIVED_KEYBOARD_ACTIONS` in `./waived.ts`
+ * is now empty — this ledger's keyboard half is closed.
  */
 export const CLAIMED_KEYBOARD_ACTIONS: ReadonlySet<string> = new Set([
   'toggle_split',

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -95,10 +95,26 @@ export const CLAIMED_INTENTS_COUNT = 34;
 
 /**
  * `dispatchKeyboardRadioAction` case labels claimed by a conformance case.
- * Only `toggle_split` is asserted today (MOR-1428's "keyboard context"
- * case, over `dispatchKeyboardRadioAction({ action: 'toggle_split' })`).
- * MOR-1563 (C9) walks the remaining 28.
+ * `toggle_split` was claimed by MOR-1428's "keyboard context" case (over
+ * `dispatchKeyboardRadioAction({ action: 'toggle_split' })`). MOR-1563 (C9)
+ * walked the remaining 28 in
+ * `../mor1563-keyboard-fanout-conformance.isolated.test.ts` — 18 genuinely
+ * DISPATCH on this fixture, 10 REFUSE (each case names its firing gate; see
+ * that file's header for the full per-action table and the MOR-1454-related
+ * findings on the cycle/step cases). `WAIVED_KEYBOARD_ACTIONS` in
+ * `./waived.ts` is now empty — this ledger's keyboard half is closed.
  */
 export const CLAIMED_KEYBOARD_ACTIONS: ReadonlySet<string> = new Set([
   'toggle_split',
+  // MOR-1563 (C9) — keyboard action fan-out walk, 28 actions
+  'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
+  'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
+  'toggle_auto_notch', 'toggle_ip_plus', 'toggle_rit', 'toggle_xit',
+  'clear_rit_xit', 'adjust_af_level', 'adjust_rf_gain', 'toggle_monitor',
+  'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
+  'toggle_dial_lock', 'scope_span_step', 'scope_ref_step',
+  'scope_toggle_hold', 'scope_toggle_dual', 'scope_toggle_fst',
 ]);
+
+/** Pinned so a removal (or an undocumented addition) shows up in review. */
+export const CLAIMED_KEYBOARD_ACTIONS_COUNT = 29;

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -56,15 +56,22 @@ const SCOPE_VFO = { reason: 'Scope-remainder/VFO-topology family walk not yet la
 const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner: 'MOR-1567' } as const;
 
 /**
- * The (67 - 9 - 5 = 53) intents with no conformance assertion, tagged with
- * the family child that owns closing them. MOR-1562 (C8, adapter-seam
+ * The (67 - 9 - 5 - 4 = 49) intents with no conformance assertion, tagged
+ * with the family child that owns closing them. MOR-1562 (C8, adapter-seam
  * parity) intentionally claims ZERO entries here — its scope is
  * `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
  *
  * MOR-1560 (C6)'s 9 DSP intents and MOR-1561 (C7)'s 5 filter/PBT intents
  * landed and were moved to `CLAIMED_INTENTS` in `./claimed.ts` — see
  * `../mor1560-dsp-family-conformance.isolated.test.ts` and
- * `../mor1561-filter-pbt-family-conformance.isolated.test.ts`.
+ * `../mor1561-filter-pbt-family-conformance.isolated.test.ts`. MOR-1563
+ * (C9)'s keyboard walk additionally landed the FIRST real coverage for 4
+ * intents that otherwise belong to MOR-1566/MOR-1567's still-unwalked
+ * families (`set_data_mode`, `vfo_swap`, `vfo_equalize`, `set_scope_hold`)
+ * — moved out of those two families' tags below per this file's own
+ * burn-down rule (a landed `expectFrames` claims the intent regardless of
+ * which walk lands it first); MOR-1566/MOR-1567 will extend coverage on
+ * these four (more call sites, more profiles), not initiate it.
  */
 export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
   // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — CLAIMED, see
@@ -82,32 +89,36 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
     'set_cw_pitch', 'set_key_speed', 'set_break_in', 'set_break_in_delay',
     'set_apf', 'set_twin_peak', 'cw_auto_tune', 'set_dash_ratio',
   ], VOX_CW),
-  // MOR-1566 (C12) — scope remainder + VFO topology — 15
+  // MOR-1566 (C12) — scope remainder + VFO topology — 12 (set_scope_hold/
+  // vfo_swap/vfo_equalize CLAIMED by MOR-1563's keyboard walk, see above)
   ...tag([
-    'set_scope_mode', 'set_scope_edge', 'set_scope_hold', 'set_scope_dual',
+    'set_scope_mode', 'set_scope_edge', 'set_scope_dual',
     'set_scope_during_tx', 'set_scope_center_type', 'set_scope_vbw',
-    'set_scope_rbw', 'switch_scope_receiver', 'vfo_swap', 'vfo_equalize',
+    'set_scope_rbw', 'switch_scope_receiver',
     'set_dual_watch', 'set_main_sub_tracking', 'quick_dualwatch', 'quick_split',
   ], SCOPE_VFO),
-  // MOR-1567 (C13) — sweeper — 15 named in its own prose + 3 orphaned
-  // RIT/XIT (see file header) — 18
+  // MOR-1567 (C13) — sweeper — 14 named in its own prose (set_data_mode
+  // CLAIMED by MOR-1563's keyboard walk, see above) + 3 orphaned RIT/XIT
+  // (see file header) — 17
   ...tag([
     'scan_start', 'scan_stop', 'scan_set_df_span', 'scan_set_resume',
     'set_dial_lock', 'set_powerstat', 'speak', 'set_antenna_1', 'set_antenna_2',
-    'set_rx_antenna_ant1', 'set_rx_antenna_ant2', 'set_data_mode',
+    'set_rx_antenna_ant1', 'set_rx_antenna_ant2',
     'set_digisel', 'set_ip_plus', 'memory_clear',
     'set_rit_status', 'set_rit_tx_status', 'set_rit_frequency',
   ], SWEEPER),
 };
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const WAIVED_INTENTS_COUNT = 53;
+export const WAIVED_INTENTS_COUNT = 49;
 
 /**
  * `dispatchKeyboardRadioAction` case labels with no conformance assertion.
- * MOR-1563 (C9) walked and CLAIMED all 28 that were waived here — see
- * `./claimed.ts`'s `CLAIMED_KEYBOARD_ACTIONS` and
- * `../mor1563-keyboard-fanout-conformance.isolated.test.ts`. This map is
+ * MOR-1563 (C9) walked and CLAIMED all 28 that were waived here (17
+ * dispatch, 11 refuse on the IC-7300 fixture — see `./claimed.ts`'s
+ * `CLAIMED_KEYBOARD_ACTIONS` and
+ * `../mor1563-keyboard-fanout-conformance.isolated.test.ts`, including the
+ * MOR-1577 finding on `adjust_af_level`/`adjust_rf_gain`). This map is
  * now empty; kept (rather than deleted) as the live burn-down target for
  * any future keyboard action this ledger's completeness test would
  * otherwise fail on.

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -54,7 +54,6 @@ const TX = { reason: 'TX-chain family walk not yet landed', owner: 'MOR-1564' } 
 const VOX_CW = { reason: 'VOX/CW family walk not yet landed', owner: 'MOR-1565' } as const;
 const SCOPE_VFO = { reason: 'Scope-remainder/VFO-topology family walk not yet landed', owner: 'MOR-1566' } as const;
 const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner: 'MOR-1567' } as const;
-const KEYBOARD = { reason: 'Keyboard action-fan-out walk not yet landed', owner: 'MOR-1563' } as const;
 
 /**
  * The (67 - 9 - 5 = 53) intents with no conformance assertion, tagged with
@@ -105,14 +104,18 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
 export const WAIVED_INTENTS_COUNT = 53;
 
 /**
- * The 28 `dispatchKeyboardRadioAction` case labels with no conformance
- * assertion (only `toggle_split` is claimed — see `./claimed.ts`).
+ * `dispatchKeyboardRadioAction` case labels with no conformance assertion.
+ * MOR-1563 (C9) walked and CLAIMED all 28 that were waived here — see
+ * `./claimed.ts`'s `CLAIMED_KEYBOARD_ACTIONS` and
+ * `../mor1563-keyboard-fanout-conformance.isolated.test.ts`. This map is
+ * now empty; kept (rather than deleted) as the live burn-down target for
+ * any future keyboard action this ledger's completeness test would
+ * otherwise fail on.
  *
- * ON THE PARENT TICKET'S "32 actions" FIGURE: MOR-1563 states 32 — that is
- * correct, not stale. It is 29 radio-family cases in
- * `dispatchKeyboardRadioAction` (28 waived here + 1 claimed) PLUS 3
- * non-radio actions (`adjust_tuning_step`, `open_filter_settings`,
- * `focus_target`) that live in a DIFFERENT switch
+ * ON THE PARENT TICKET'S "32 actions" FIGURE (still relevant context): it
+ * is 29 radio-family cases in `dispatchKeyboardRadioAction` (all 29 now
+ * claimed) PLUS 3 non-radio actions (`adjust_tuning_step`,
+ * `open_filter_settings`, `focus_target`) that live in a DIFFERENT switch
  * (`makeKeyboardHandlers().dispatch`, panel-commands.ts:1588) which
  * `dispatchKeyboardRadioAction` falls through to on `false`. This ledger
  * (MOR-1556) names `dispatchKeyboardRadioAction` specifically, so those 3
@@ -120,15 +123,7 @@ export const WAIVED_INTENTS_COUNT = 53;
  * absent from `KEYBOARD_RADIO_ACTIONS` and out of scope here by design,
  * not because they were miscounted.
  */
-export const WAIVED_KEYBOARD_ACTIONS: Readonly<Record<string, Waiver>> = tag([
-  'tune', 'band_select', 'mode_select', 'cycle_data_mode', 'cycle_filter',
-  'cycle_preamp', 'cycle_att', 'cycle_agc', 'toggle_nr', 'toggle_nb',
-  'toggle_auto_notch', 'toggle_ip_plus', 'toggle_rit', 'toggle_xit',
-  'clear_rit_xit', 'adjust_af_level', 'adjust_rf_gain', 'toggle_monitor',
-  'vfo_swap', 'vfo_equalize', 'switch_active_vfo', 'set_active_vfo',
-  'toggle_dial_lock', 'scope_span_step', 'scope_ref_step',
-  'scope_toggle_hold', 'scope_toggle_dual', 'scope_toggle_fst',
-], KEYBOARD);
+export const WAIVED_KEYBOARD_ACTIONS: Readonly<Record<string, Waiver>> = {};
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const WAIVED_KEYBOARD_ACTIONS_COUNT = 28;
+export const WAIVED_KEYBOARD_ACTIONS_COUNT = 0;

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -38,6 +38,12 @@
  * 17/11 split) — they prove the handler body itself dispatches fine given
  * the shape it actually reads, which is what makes the declared-binding
  * refusal a genuine wiring bug rather than defensive fail-closed design.
+ * STRENGTHENED (round-2 review): `af-level-up`/`rf-level-up` carry
+ * `modifiers: ['CTRL']`/`['CTRL','SHIFT']` — `keyboard-map.ts`'s
+ * `modifiersMatch()` (line ~206) resolves plain ArrowUp to `step-up`
+ * (`adjust_tuning_step`) and only Ctrl+ArrowUp reaches `af-level-up`, so
+ * this is a genuinely reachable, user-visible dead control on this
+ * profile: press Ctrl+ArrowUp and nothing is sent, not a theoretical gap.
  *
  * MOR-1578 (filed, cited below where this walk's own rows happen to touch
  * it — not this walk's finding, no production code changed here): (1)
@@ -45,15 +51,23 @@
  * field-observation gate at all (confirmed by the two cases below); (2)
  * `switch_active_vfo` reads `context.state.active` RAW, bypassing the
  * observation-gated tautological-MAIN resolution every other action here
- * goes through; (3) `af-level-up`/`rf-level-up` both bind `ArrowUp` (and
- * `-down` both bind `ArrowDown`), alongside `adjust_tuning_step`'s
- * `step-up`/`step-down` — a three-way shadow on the same physical keys;
- * `scope_toggle_fst` (`F`) shadows `open_filter_settings`; (4)
- * `mode-psk`/`mode-pskr` bindings declare `{ mode: 'PSK' }`/`{ mode:
- * 'PSK-R' }`, but this fixture's `caps.modes` is `['USB','LSB','CW',
- * 'CW-R','AM','FM','RTTY','RTTY-R']` — no PSK/PSK-R — so those two
+ * goes through; (3) `mode-psk`/`mode-pskr` bindings declare `{ mode: 'PSK'
+ * }`/`{ mode: 'PSK-R' }`, but this fixture's `caps.modes` is `['USB','LSB',
+ * 'CW','CW-R','AM','FM','RTTY','RTTY-R']` — no PSK/PSK-R — so those two
  * refuse here too, adjacent to (not the same case as) `mode_select` below,
  * which deliberately uses the declared-and-supported `LSB` binding.
+ * RETRACTED (round-2 review, runtime-verified): an earlier draft of this
+ * walk claimed `af-level-up`/`rf-level-up`/`step-up` share `ArrowUp` as a
+ * three-way shadow, and that `scope_toggle_fst` (`F`) shadows
+ * `open_filter_settings` — both FALSE. Every one of those bindings also
+ * declares a `modifiers` array (`step-up`: none, `af-level-up`: `['CTRL']`,
+ * `rf-level-up`: `['CTRL','SHIFT']`; `open-filter-settings`: none,
+ * `scope-toggle-fst`: `['SHIFT']`) that `modifiersMatch()` discriminates
+ * on exactly — each key+modifier combination resolves to its own single
+ * binding, with no shadow. The direction in the original claim was also
+ * backwards (plain `F` → `open-filter-settings`, Shift+`F` →
+ * `scope-toggle-fst`, not the reverse). MOR-1578 has been amended to drop
+ * this leg; the PSK/PSK-R leg above is unaffected and remains true.
  *
  * MOR-1454 ANGLE (the cycle family): `cycle_preamp`/`cycle_att`/
  * `cycle_agc` each wrap over a FIXTURE-DECLARED option list
@@ -211,7 +225,7 @@ const CASES: readonly KeyboardCase[] = [
   { action: 'scope_toggle_dual', frames: [],
     gate: 'single receiver / no dual_rx / no sub — hasPhysicalSub-equivalent gate fails' },
   { action: 'scope_toggle_fst', frames: [['set_scope_speed', { speed: scope.speed === 0 ? 1 : 0 }]],
-    gate: 'scopeControls.speed observed (MOR-1578: F key shadows open_filter_settings)' },
+    gate: 'scopeControls.speed observed' },
 ];
 
 describe('IC-7300 fixture — keyboard action fan-out conformance (MOR-1563)', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -1,0 +1,186 @@
+/**
+ * MOR-1563 (C9) — Keyboard action fan-out conformance walk, over the same
+ * profile-parameterized harness MOR-1428/MOR-1555 established
+ * (`./conformance/harness.ts`, `./conformance/profiles.ts`).
+ *
+ * SCOPE: `dispatchKeyboardRadioAction` in `panel-commands.ts` has 29 radio
+ * case labels. `toggle_split` was already claimed by MOR-1428's "keyboard
+ * context" case. This walk claims the remaining 28 (`WAIVED_KEYBOARD_ACTIONS`
+ * in `./conformance/waived.ts`, now empty — see `./conformance/claimed.ts`
+ * for the landed 29-name `CLAIMED_KEYBOARD_ACTIONS`). The 3 non-radio
+ * actions (`adjust_tuning_step`/`open_filter_settings`/`focus_target`) live
+ * in a DIFFERENT switch (`makeKeyboardHandlers().dispatch`) and are a
+ * deliberate scope boundary per `waived.ts`'s header, not covered here.
+ *
+ * FINDING (fixture-derived split): of the 28, 18 genuinely DISPATCH on this
+ * IC-7300 fixture and 10 genuinely REFUSE. Every refusal below is an
+ * honest fail-closed gate (an unobserved top-level or receiver field, or a
+ * single-receiver/no-dual_rx structural gate) — never a test artifact. Each
+ * case's `gate` string names the exact reason, cross-checked against the
+ * fixture's own `fieldStatus`/`capabilities` data below, never invented.
+ *
+ * MOR-1454 ANGLE (the cycle/step family): `cycle_preamp`/`cycle_att`/
+ * `cycle_agc` each wrap over a FIXTURE-DECLARED option list
+ * (`caps.preValues`/`attValues`/`agcModes`) via the shared `keyboardCycle`
+ * helper — this walk asserts the wrap target by indexing into those SAME
+ * declared arrays (see `wrap()` below), never a hardcoded list, and on this
+ * profile the current implementation correctly honors them (no MOR-1454
+ * violation found on these three). `cycle_filter` wraps by INDEX COUNT
+ * (`caps.filters.length`), not a value list, so MOR-1454 doesn't apply to
+ * it the same way. `cycle_data_mode` has a domain of size 1
+ * (`caps.dataModeCount === 1`) — the wrap target equals the current value,
+ * which is the mathematically correct result of modulo-1, not evidence of
+ * MOR-1454's "ignores declared options" failure mode. `adjust_af_level`/
+ * `adjust_rf_gain` and `scope_span_step`/`scope_ref_step` use a FIXED step
+ * (5%, or 1/5 units) and FIXED clamp bounds hardcoded in
+ * `dispatchKeyboardRadioAction` itself — this profile declares no
+ * step-size or scope-range capability to check them against, so there is
+ * no fixture-declared domain for these four to honor or violate; noted as
+ * an honest baseline, not a finding.
+ *
+ * RED-FIRST EVIDENCE (MOR-1563 build process, not part of this diff): the
+ * `cycle_filter` case below was first authored with a deliberately wrong
+ * literal claim, `frames: [['set_filter', { filter: 3, receiver: 0 }]]`
+ * (guessing the wrap wrong). `vitest run` on that version failed with
+ * `expected [ [ 'set_filter', { filter: 2, receiver: 0 } ] ] to deeply
+ * equal [ [ 'set_filter', { filter: 3, receiver: 0 } ] ]` (RED — the real
+ * dispatch is filter 2, not the guessed 3). Replacing the literal with the
+ * fixture-derived expression below (`main.filter=1`,
+ * `caps.filters.length=3` → `(((1-1)+1+3)%3)+1 === 2`) turned it GREEN.
+ *
+ * DISCRIMINATION EVIDENCE (MOR-1563 build process, not part of this diff):
+ * to prove the `toggle_rit` refusal below isn't vacuous, its gate was
+ * scratch-flipped locally — `h.state.fieldStatus['ritOn']` temporarily set
+ * to `{ availability: 'available', observed: true, ... }` before calling
+ * `dispatchKeyboardRadioAction({ action: 'toggle_rit' })` — and the refusal
+ * assertion then FAILED (the handler dispatched `set_rit_status` with
+ * `{ on: true }`, the fixture's own `ritOn === false` negated), confirming
+ * the assertion genuinely depends on that one field-status gate. The
+ * scratch edit was reverted with `git checkout --` (not `git stash`) after
+ * observing the failure, restoring the green state before this file was
+ * committed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  expectFrames,
+  expectRefusal,
+  fixtureCaps,
+  fixtureState,
+  h,
+} from './conformance/harness';
+import { PROFILES } from './conformance/profiles';
+import { dispatchKeyboardRadioAction } from '../../commands/panel-commands';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+
+const profile = PROFILES.ic7300;
+const IC7300_STATE = profile.state;
+const IC7300_CAPABILITIES = profile.caps;
+const main = IC7300_STATE.main!;
+const scope = IC7300_STATE.scopeControls!;
+const preValues = IC7300_CAPABILITIES.preValues!;
+const attValues = IC7300_CAPABILITIES.attValues!;
+const agcModes = IC7300_CAPABILITIES.agcModes!;
+const filterCount = IC7300_CAPABILITIES.filters.length;
+const dataModeCount = IC7300_CAPABILITIES.dataModeCount!;
+
+/** Wraps `current` to the NEXT entry in a fixture-declared option list. */
+function wrap(values: number[], current: number): number {
+  return values[(values.indexOf(current) + 1) % values.length];
+}
+
+interface KeyboardCase {
+  readonly action: string;
+  readonly params?: Record<string, unknown>;
+  /** Empty = REFUSES. Non-empty = exact frames dispatched, in order. */
+  readonly frames: Array<[string, Record<string, unknown>]>;
+  /** Names the exact gate that produced the outcome above. */
+  readonly gate: string;
+}
+
+const CASES: readonly KeyboardCase[] = [
+  { action: 'tune', frames: [],
+    gate: 'no direction/deltaHz in params — argument-shape gate, never reaches the tuning accumulator' },
+  { action: 'band_select', params: { index: 5 }, frames: [['set_band', { band: 5 }]],
+    gate: 'bsr capability declared + main.freqHz observed' },
+  { action: 'mode_select', params: { mode: 'LSB' }, frames: [['set_mode', { mode: 'LSB', receiver: 0 }]],
+    gate: 'main.mode observed + LSB in caps.modes' },
+  { action: 'cycle_data_mode',
+    frames: [['set_data_mode', { mode: (main.dataMode + 1) % dataModeCount, receiver: 0 }]],
+    gate: 'main.dataMode observed; dataModeCount=1 (see MOR-1454 note above)' },
+  { action: 'cycle_filter', params: { step: 1 },
+    frames: [['set_filter', { filter: (((main.filter! - 1) + 1 + filterCount) % filterCount) + 1, receiver: 0 }]],
+    gate: 'main.filter observed; wraps over caps.filters.length (fixture-declared)' },
+  { action: 'cycle_preamp', frames: [['set_preamp', { level: wrap(preValues, main.preamp), receiver: 0 }]],
+    gate: 'main.preamp observed; wraps over caps.preValues (fixture-declared, MOR-1454 angle: honored)' },
+  { action: 'cycle_att', frames: [['set_attenuator', { db: wrap(attValues, main.att), receiver: 0 }]],
+    gate: 'main.att observed; wraps over caps.attValues (fixture-declared, MOR-1454 angle: honored)' },
+  { action: 'cycle_agc', frames: [['set_agc', { mode: wrap(agcModes, main.agc!), receiver: 0 }]],
+    gate: 'main.agc observed; wraps over caps.agcModes (fixture-declared, MOR-1454 angle: honored)' },
+  { action: 'toggle_nr', frames: [['set_nr', { on: !main.nr, receiver: 0 }]], gate: 'main.nr observed boolean' },
+  { action: 'toggle_nb', frames: [['set_nb', { on: !main.nb, receiver: 0 }]], gate: 'main.nb observed boolean' },
+  { action: 'toggle_auto_notch', frames: [], gate: 'main.autoNotch unobserved (notch capability IS declared)' },
+  { action: 'toggle_ip_plus', frames: [], gate: 'main.ipplus unobserved (ip_plus capability IS declared)' },
+  { action: 'toggle_rit', frames: [], gate: 'top-level ritOn unobserved (see discrimination evidence above)' },
+  { action: 'toggle_xit', frames: [], gate: 'top-level ritTx unobserved' },
+  { action: 'clear_rit_xit', frames: [], gate: 'top-level ritFreq unobserved' },
+  { action: 'adjust_af_level', params: { direction: 'up' },
+    frames: [['set_af_level', { level: Math.max(0, Math.min(1, main.afLevel + 0.05)), receiver: 0 }]],
+    gate: 'main.afLevel observed; fixed 5% step (no declared step-size domain, see MOR-1454 note)' },
+  { action: 'adjust_rf_gain', params: { direction: 'down' },
+    frames: [['set_rf_gain', { level: Math.round(Math.max(0, Math.min(1, main.rfGain - 0.05)) * 255), receiver: 0 }]],
+    gate: 'main.rfGain observed; fixed 5% step, hardcoded *255 scale (see MOR-1454 note)' },
+  { action: 'toggle_monitor', frames: [], gate: 'top-level monitorOn unobserved' },
+  { action: 'vfo_swap', frames: [['vfo_swap', {}]],
+    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all' },
+  { action: 'vfo_equalize', frames: [['vfo_equalize', {}]],
+    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all' },
+  { action: 'switch_active_vfo', frames: [],
+    gate: 'single receiver / no dual_rx — active is tautologically MAIN so target computes to SUB, nothing to switch to' },
+  { action: 'set_active_vfo', params: { vfo: 'MAIN' }, frames: [['set_vfo', { vfo: 'MAIN' }]],
+    gate: 'state.main exists — activateReceiver dispatches unconditionally once the receiver resolves' },
+  { action: 'toggle_dial_lock', frames: [], gate: 'top-level dialLock unobserved' },
+  { action: 'scope_span_step', params: { direction: 'up' },
+    frames: [['set_scope_span', { span: Math.max(0, Math.min(7, scope.span + 1)) }]],
+    gate: 'scopeControls.span observed; clamp bounds (0-7) are hardcoded, not caps-declared' },
+  { action: 'scope_ref_step', params: { direction: 'up' },
+    frames: [['set_scope_ref', { ref: Math.max(-30, Math.min(10, scope.refDb + 5)) }]],
+    gate: 'scopeControls.refDb observed; clamp bounds (-30..10) are hardcoded, not caps-declared' },
+  { action: 'scope_toggle_hold', frames: [['set_scope_hold', { on: !scope.hold }]],
+    gate: 'scopeControls.hold observed boolean' },
+  { action: 'scope_toggle_dual', frames: [],
+    gate: 'single receiver / no dual_rx / no sub — hasPhysicalSub-equivalent gate fails' },
+  { action: 'scope_toggle_fst', frames: [['set_scope_speed', { speed: scope.speed === 0 ? 1 : 0 }]],
+    gate: 'scopeControls.speed observed' },
+];
+
+describe('IC-7300 fixture — keyboard action fan-out conformance (MOR-1563)', () => {
+  beforeEach(() => {
+    h.state = fixtureState(profile);
+    h.caps = fixtureCaps(profile);
+    h.sendCommand.mockClear();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  it('covers exactly the 28 waived dispatchKeyboardRadioAction actions', () => {
+    expect(CASES).toHaveLength(28);
+  });
+
+  for (const c of CASES) {
+    const outcome = c.frames.length > 0 ? 'DISPATCHES' : 'REFUSES';
+    it(`${c.action}: ${outcome} — ${c.gate}`, () => {
+      let handled: boolean | undefined;
+      const run = () => {
+        handled = dispatchKeyboardRadioAction({ action: c.action, params: c.params });
+      };
+      if (c.frames.length > 0) {
+        expectFrames(run, c.frames);
+      } else {
+        expectRefusal(run);
+      }
+      expect(handled).toBe(true);
+    });
+  }
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -12,14 +12,50 @@
  * in a DIFFERENT switch (`makeKeyboardHandlers().dispatch`) and are a
  * deliberate scope boundary per `waived.ts`'s header, not covered here.
  *
- * FINDING (fixture-derived split): of the 28, 18 genuinely DISPATCH on this
- * IC-7300 fixture and 10 genuinely REFUSE. Every refusal below is an
- * honest fail-closed gate (an unobserved top-level or receiver field, or a
- * single-receiver/no-dual_rx structural gate) — never a test artifact. Each
- * case's `gate` string names the exact reason, cross-checked against the
- * fixture's own `fieldStatus`/`capabilities` data below, never invented.
+ * FINDING (fixture-derived split): of the 28, 17 genuinely DISPATCH on this
+ * IC-7300 fixture and 11 genuinely REFUSE. Every refusal below is an honest
+ * fail-closed gate — an unobserved top-level/receiver field, a
+ * single-receiver/no-dual_rx structural gate, or (adjust_af_level/
+ * adjust_rf_gain, MOR-1577 below) a param-shape mismatch between what this
+ * fixture's own keyboard bindings declare and what the handler reads —
+ * never a test artifact. Each case's `gate` string names the exact reason,
+ * cross-checked against the fixture's own `fieldStatus`/
+ * `capabilities.keyboard.bindings` data, never invented.
  *
- * MOR-1454 ANGLE (the cycle/step family): `cycle_preamp`/`cycle_att`/
+ * MOR-1577 (filed this review round): `capabilities.keyboard.bindings`
+ * declares FOUR bindings for `adjust_af_level`/`adjust_rf_gain`
+ * (`af-level-up`/`-down`, `rf-level-up`/`-down`, all on ArrowUp/ArrowDown),
+ * and every one carries `{ delta: 5 }` or `{ delta: -5 }` — never
+ * `direction`. But `dispatchKeyboardRadioAction`'s `adjust_af_level`/
+ * `adjust_rf_gain` cases read ONLY `params.direction`
+ * (`keyboardDirection(safeParams.direction)`) and hardcode a fixed ±5%
+ * step (`* 255` scale for rf_gain); `delta` is never read anywhere in
+ * either case — a source-level dead control on every profile, not
+ * fixture-specific. The two cases below assert that real, declared-shape
+ * REFUSAL as the canonical row for each action. A synthetic-`{direction}`
+ * dispatch is kept further down as two separately-labeled
+ * HANDLER-CAPABILITY PROBES (NOT profile behavior, not counted in the
+ * 17/11 split) — they prove the handler body itself dispatches fine given
+ * the shape it actually reads, which is what makes the declared-binding
+ * refusal a genuine wiring bug rather than defensive fail-closed design.
+ *
+ * MOR-1578 (filed, cited below where this walk's own rows happen to touch
+ * it — not this walk's finding, no production code changed here): (1)
+ * `vfo_swap`/`vfo_equalize` dispatch completely unconditionally, no
+ * field-observation gate at all (confirmed by the two cases below); (2)
+ * `switch_active_vfo` reads `context.state.active` RAW, bypassing the
+ * observation-gated tautological-MAIN resolution every other action here
+ * goes through; (3) `af-level-up`/`rf-level-up` both bind `ArrowUp` (and
+ * `-down` both bind `ArrowDown`), alongside `adjust_tuning_step`'s
+ * `step-up`/`step-down` — a three-way shadow on the same physical keys;
+ * `scope_toggle_fst` (`F`) shadows `open_filter_settings`; (4)
+ * `mode-psk`/`mode-pskr` bindings declare `{ mode: 'PSK' }`/`{ mode:
+ * 'PSK-R' }`, but this fixture's `caps.modes` is `['USB','LSB','CW',
+ * 'CW-R','AM','FM','RTTY','RTTY-R']` — no PSK/PSK-R — so those two
+ * refuse here too, adjacent to (not the same case as) `mode_select` below,
+ * which deliberately uses the declared-and-supported `LSB` binding.
+ *
+ * MOR-1454 ANGLE (the cycle family): `cycle_preamp`/`cycle_att`/
  * `cycle_agc` each wrap over a FIXTURE-DECLARED option list
  * (`caps.preValues`/`attValues`/`agcModes`) via the shared `keyboardCycle`
  * helper — this walk asserts the wrap target by indexing into those SAME
@@ -29,27 +65,38 @@
  * (`caps.filters.length`), not a value list, so MOR-1454 doesn't apply to
  * it the same way. `cycle_data_mode` has a domain of size 1
  * (`caps.dataModeCount === 1`) — the wrap target equals the current value,
- * which is the mathematically correct result of modulo-1, not evidence of
- * MOR-1454's "ignores declared options" failure mode. `adjust_af_level`/
- * `adjust_rf_gain` and `scope_span_step`/`scope_ref_step` use a FIXED step
- * (5%, or 1/5 units) and FIXED clamp bounds hardcoded in
- * `dispatchKeyboardRadioAction` itself — this profile declares no
- * step-size or scope-range capability to check them against, so there is
- * no fixture-declared domain for these four to honor or violate; noted as
- * an honest baseline, not a finding.
+ * the mathematically correct result of modulo-1, not evidence of
+ * MOR-1454's "ignores declared options" failure mode. `scope_span_step`/
+ * `scope_ref_step` use fixed clamp bounds hardcoded in
+ * `dispatchKeyboardRadioAction` itself, with no scope-range capability on
+ * this profile to check them against — an honest baseline, not a finding.
+ * `adjust_af_level`/`adjust_rf_gain` are MOR-1577 above, not this angle:
+ * the fixture DOES declare their domain (`{ delta }`), the handler just
+ * never reads it.
  *
- * RED-FIRST EVIDENCE (MOR-1563 build process, not part of this diff): the
- * `cycle_filter` case below was first authored with a deliberately wrong
- * literal claim, `frames: [['set_filter', { filter: 3, receiver: 0 }]]`
- * (guessing the wrap wrong). `vitest run` on that version failed with
- * `expected [ [ 'set_filter', { filter: 2, receiver: 0 } ] ] to deeply
- * equal [ [ 'set_filter', { filter: 3, receiver: 0 } ] ]` (RED — the real
- * dispatch is filter 2, not the guessed 3). Replacing the literal with the
+ * RED-FIRST EVIDENCE, `cycle_filter` (MOR-1563 build, not part of this
+ * diff): first authored with a deliberately wrong literal claim,
+ * `frames: [['set_filter', { filter: 3, receiver: 0 }]]` (guessing the
+ * wrap wrong). `vitest run` on that version failed with `expected [ [
+ * 'set_filter', { filter: 2, receiver: 0 } ] ] to deeply equal [ [
+ * 'set_filter', { filter: 3, receiver: 0 } ] ]` (RED — the real dispatch
+ * is filter 2, not the guessed 3). Replacing the literal with the
  * fixture-derived expression below (`main.filter=1`,
  * `caps.filters.length=3` → `(((1-1)+1+3)%3)+1 === 2`) turned it GREEN.
  *
- * DISCRIMINATION EVIDENCE (MOR-1563 build process, not part of this diff):
- * to prove the `toggle_rit` refusal below isn't vacuous, its gate was
+ * RED-FIRST EVIDENCE, `tune` (review-round fix, not part of this diff): the
+ * case was rewritten to the real `nudge-right` binding shape (`ArrowRight`,
+ * `{ direction: 'up', fine: false }`) with a deliberately wrong target,
+ * `frames: [['set_freq', { freq: 14_190_000, receiver: 0 }]]`. `vitest
+ * run` failed RED: `expected [ [ 'set_freq', { freq: 14189000, receiver: 0
+ * } ] ] to deeply equal [ [ 'set_freq', { freq: 14190000, receiver: 0 } ]
+ * ]` — the real target is base `main.freqHz` (14188000) plus the harness's
+ * mocked 1000 Hz tuning step = 14189000, not the guessed 14190000. Fixing
+ * the literal to the fixture-derived expression (`main.freqHz + 1000`)
+ * turned it GREEN.
+ *
+ * DISCRIMINATION EVIDENCE (MOR-1563 build, not part of this diff): to
+ * prove the `toggle_rit` refusal below isn't vacuous, its gate was
  * scratch-flipped locally — `h.state.fieldStatus['ritOn']` temporarily set
  * to `{ availability: 'available', observed: true, ... }` before calling
  * `dispatchKeyboardRadioAction({ action: 'toggle_rit' })` — and the refusal
@@ -59,6 +106,20 @@
  * scratch edit was reverted with `git checkout --` (not `git stash`) after
  * observing the failure, restoring the green state before this file was
  * committed.
+ *
+ * TUNING-ACCUMULATOR ISOLATION (review-round fix): `tune`'s dispatch goes
+ * through `makeVfoHandlers()`'s MODULE-SCOPE shared tuning accumulator
+ * (`tuning-accumulator.ts`'s `getSharedTuningAccumulator`), which
+ * `resetCommandLifecycle()` does NOT touch and which
+ * `mor1428-ic7300-conformance.isolated.test.ts` also exercises on receiver
+ * 0 in the same targeted-suite run. Left unreset, a hot burst carried over
+ * from whichever file runs first would make the other's synchronous
+ * `expectFrames` assertion flaky (a hot burst paces its flush via
+ * `setTimeout` instead of emitting inline). This file calls the
+ * already-exported test-only `resetSharedTuningAccumulatorForTests()` in
+ * BOTH `beforeEach` and `afterEach` — the same convention
+ * `tuning-accumulator.test.ts` itself uses — so `tune` always starts cold
+ * here and never leaves hot state behind for a sibling file.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -70,6 +131,7 @@ import {
 } from './conformance/harness';
 import { PROFILES } from './conformance/profiles';
 import { dispatchKeyboardRadioAction } from '../../commands/panel-commands';
+import { resetSharedTuningAccumulatorForTests } from '../../commands/tuning-accumulator';
 import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
 
 const profile = PROFILES.ic7300;
@@ -98,12 +160,13 @@ interface KeyboardCase {
 }
 
 const CASES: readonly KeyboardCase[] = [
-  { action: 'tune', frames: [],
-    gate: 'no direction/deltaHz in params — argument-shape gate, never reaches the tuning accumulator' },
+  { action: 'tune', params: { direction: 'up', fine: false },
+    frames: [['set_freq', { freq: main.freqHz + 1000, receiver: 0 }]],
+    gate: 'declared nudge-right binding (ArrowRight); main.freqHz observed, tuning step > 0' },
   { action: 'band_select', params: { index: 5 }, frames: [['set_band', { band: 5 }]],
     gate: 'bsr capability declared + main.freqHz observed' },
   { action: 'mode_select', params: { mode: 'LSB' }, frames: [['set_mode', { mode: 'LSB', receiver: 0 }]],
-    gate: 'main.mode observed + LSB in caps.modes' },
+    gate: 'main.mode observed + LSB in caps.modes (MOR-1578: mode-psk/mode-pskr bindings declare undeclared modes, adjacent case)' },
   { action: 'cycle_data_mode',
     frames: [['set_data_mode', { mode: (main.dataMode + 1) % dataModeCount, receiver: 0 }]],
     gate: 'main.dataMode observed; dataModeCount=1 (see MOR-1454 note above)' },
@@ -123,19 +186,17 @@ const CASES: readonly KeyboardCase[] = [
   { action: 'toggle_rit', frames: [], gate: 'top-level ritOn unobserved (see discrimination evidence above)' },
   { action: 'toggle_xit', frames: [], gate: 'top-level ritTx unobserved' },
   { action: 'clear_rit_xit', frames: [], gate: 'top-level ritFreq unobserved' },
-  { action: 'adjust_af_level', params: { direction: 'up' },
-    frames: [['set_af_level', { level: Math.max(0, Math.min(1, main.afLevel + 0.05)), receiver: 0 }]],
-    gate: 'main.afLevel observed; fixed 5% step (no declared step-size domain, see MOR-1454 note)' },
-  { action: 'adjust_rf_gain', params: { direction: 'down' },
-    frames: [['set_rf_gain', { level: Math.round(Math.max(0, Math.min(1, main.rfGain - 0.05)) * 255), receiver: 0 }]],
-    gate: 'main.rfGain observed; fixed 5% step, hardcoded *255 scale (see MOR-1454 note)' },
+  { action: 'adjust_af_level', params: { delta: 5 }, frames: [],
+    gate: 'declared af-level-up binding ({delta:5}); handler reads only params.direction, never delta — MOR-1577 dead control (see header; probe below)' },
+  { action: 'adjust_rf_gain', params: { delta: -5 }, frames: [],
+    gate: 'declared rf-level-down binding ({delta:-5}); handler reads only params.direction, never delta — MOR-1577 dead control (see header; probe below)' },
   { action: 'toggle_monitor', frames: [], gate: 'top-level monitorOn unobserved' },
   { action: 'vfo_swap', frames: [['vfo_swap', {}]],
-    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all' },
+    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all (MOR-1578)' },
   { action: 'vfo_equalize', frames: [['vfo_equalize', {}]],
-    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all' },
+    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all (MOR-1578)' },
   { action: 'switch_active_vfo', frames: [],
-    gate: 'single receiver / no dual_rx — active is tautologically MAIN so target computes to SUB, nothing to switch to' },
+    gate: 'single receiver / no dual_rx — target computes to SUB, nothing to switch to (reads context.state.active RAW, MOR-1578)' },
   { action: 'set_active_vfo', params: { vfo: 'MAIN' }, frames: [['set_vfo', { vfo: 'MAIN' }]],
     gate: 'state.main exists — activateReceiver dispatches unconditionally once the receiver resolves' },
   { action: 'toggle_dial_lock', frames: [], gate: 'top-level dialLock unobserved' },
@@ -150,7 +211,7 @@ const CASES: readonly KeyboardCase[] = [
   { action: 'scope_toggle_dual', frames: [],
     gate: 'single receiver / no dual_rx / no sub — hasPhysicalSub-equivalent gate fails' },
   { action: 'scope_toggle_fst', frames: [['set_scope_speed', { speed: scope.speed === 0 ? 1 : 0 }]],
-    gate: 'scopeControls.speed observed' },
+    gate: 'scopeControls.speed observed (MOR-1578: F key shadows open_filter_settings)' },
 ];
 
 describe('IC-7300 fixture — keyboard action fan-out conformance (MOR-1563)', () => {
@@ -158,10 +219,12 @@ describe('IC-7300 fixture — keyboard action fan-out conformance (MOR-1563)', (
     h.state = fixtureState(profile);
     h.caps = fixtureCaps(profile);
     h.sendCommand.mockClear();
+    resetSharedTuningAccumulatorForTests();
   });
 
   afterEach(() => {
     resetCommandLifecycle();
+    resetSharedTuningAccumulatorForTests();
   });
 
   it('covers exactly the 28 waived dispatchKeyboardRadioAction actions', () => {
@@ -183,4 +246,23 @@ describe('IC-7300 fixture — keyboard action fan-out conformance (MOR-1563)', (
       expect(handled).toBe(true);
     });
   }
+
+  // MOR-1577 handler-capability probes: NOT this profile's declared binding
+  // shape (real bindings send `{ delta }`, asserted as REFUSAL above) — these
+  // prove the handler body itself dispatches fine given `{ direction }`,
+  // establishing that the declared-shape refusal above is a genuine dead
+  // control (delta never read) rather than the handler being broken outright.
+  it('HANDLER-CAPABILITY PROBE (not profile behavior, MOR-1577): adjust_af_level dispatches set_af_level given {direction}', () => {
+    expectFrames(
+      () => dispatchKeyboardRadioAction({ action: 'adjust_af_level', params: { direction: 'up' } }),
+      [['set_af_level', { level: Math.max(0, Math.min(1, main.afLevel + 0.05)), receiver: 0 }]],
+    );
+  });
+
+  it('HANDLER-CAPABILITY PROBE (not profile behavior, MOR-1577): adjust_rf_gain dispatches set_rf_gain given {direction}', () => {
+    expectFrames(
+      () => dispatchKeyboardRadioAction({ action: 'adjust_rf_gain', params: { direction: 'down' } }),
+      [['set_rf_gain', { level: Math.round(Math.max(0, Math.min(1, main.rfGain - 0.05)) * 255), receiver: 0 }]],
+    );
+  });
 });

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands-completeness.test.ts
@@ -75,6 +75,7 @@ import {
   CLAIMED_INTENTS,
   CLAIMED_INTENTS_COUNT,
   CLAIMED_KEYBOARD_ACTIONS,
+  CLAIMED_KEYBOARD_ACTIONS_COUNT,
 } from '../../adapters/__tests__/conformance/claimed';
 import {
   WAIVED_INTENTS,
@@ -213,12 +214,12 @@ completenessSuite({
 });
 
 completenessSuite({
-  label: 'dispatchKeyboardRadioAction case-label completeness ledger (MOR-1556, owner MOR-1563)',
+  label: 'dispatchKeyboardRadioAction case-label completeness ledger (MOR-1556, landed MOR-1563)',
   sourceNames: extractKeyboardActions(SOURCE),
   claimed: CLAIMED_KEYBOARD_ACTIONS,
   waived: WAIVED_KEYBOARD_ACTIONS,
   waivedCount: WAIVED_KEYBOARD_ACTIONS_COUNT,
-  claimedCount: 1,
+  claimedCount: CLAIMED_KEYBOARD_ACTIONS_COUNT,
 });
 
 describe('dynamic mod-input call site (verified, handled explicitly — MOR-1567 scope)', () => {


### PR DESCRIPTION
## Summary

C9 of the MOR-1426 conformance program: walks the remaining 28
`dispatchKeyboardRadioAction` case labels over the registered IC-7300
fixture through the MOR-1555 harness (`toggle_split` was already claimed
by MOR-1428). `dispatchKeyboardRadioAction` has 29 radio-family case
labels total; the 3 non-radio actions (`adjust_tuning_step`,
`open_filter_settings`, `focus_target`) live in a different switch
(`makeKeyboardHandlers().dispatch`) and are out of scope by design (see
`waived.ts`'s header).

- Adds `mor1563-keyboard-fanout-conformance.isolated.test.ts`: table-driven,
  one canonical case per action, each asserting the exact frame(s)
  dispatched or the honest refusal with the firing gate named, plus two
  separately-labeled handler-capability probes (see review follow-up below).
- Moves all 28 from `WAIVED_KEYBOARD_ACTIONS` to `CLAIMED_KEYBOARD_ACTIONS`
  in `waived.ts`/`claimed.ts`.
- Adds `CLAIMED_KEYBOARD_ACTIONS_COUNT` (29) mirroring the intent-ledger
  pins, and wires `panel-commands-completeness.test.ts`'s keyboard suite to
  import it instead of the hardcoded `claimedCount: 1` literal (the
  symmetry cleanup deferred from C7).
- Moves 4 intents that got their first real `expectFrames` coverage here
  (`set_data_mode`, `vfo_swap`, `vfo_equalize`, `set_scope_hold`) from
  `WAIVED_INTENTS` to `CLAIMED_INTENTS` per `waived.ts`'s own burn-down
  rule (see review follow-up below).

## Review follow-up (independent review round, BLOCKED -> addressed)

An independent review found three honesty/ledger issues, all fixed in a
follow-up commit:

1. **False MOR-1454 verdict on `adjust_af_level`/`adjust_rf_gain`.** The
   fixture's `capabilities.keyboard.bindings` DOES declare their domain —
   `af-level-up`/`-down` and `rf-level-up`/`-down` all carry `{ delta: 5 }`
   / `{ delta: -5 }` — but `dispatchKeyboardRadioAction` reads only
   `params.direction` and never `delta`, hardcoding a fixed step instead.
   Under the profile's own declared param shape, all four bindings
   dispatch **nothing** — a dead control on every profile, not
   fixture-specific. Filed as **MOR-1577**. The canonical table rows for
   these two actions now assert the real declared-shape REFUSAL; the
   original synthetic-`{direction}` dispatch claim is kept as two
   separately-labeled **HANDLER-CAPABILITY PROBES** (clearly marked "not
   profile behavior") proving the handler body itself isn't broken.
2. **`tune` row was a test artifact.** The refusal only held because the
   case passed no params; all four declared `tune` bindings carry
   `direction`/`deltaHz` and dispatch for real. Replaced with a genuine
   dispatch using the declared `nudge-right` binding shape
   (`{ direction: 'up', fine: false }`, `ArrowRight`) -> `set_freq
   { freq: 14189000, receiver: 0 }`, red-first verified (see below).
   Isolated via the already-exported test-only
   `resetSharedTuningAccumulatorForTests()` in `beforeEach`/`afterEach`
   (same convention `tuning-accumulator.test.ts` itself uses), so this
   file's `tune` case and `mor1428`'s `onMainFreqChange` case never see
   each other's shared-accumulator state regardless of run order (verified
   with the targeted suite run in both file orders, 3x each, all green).
3. **Ledger convention break.** This walk landed the first real
   `expectFrames` coverage for 4 intents that were still tagged waived
   under MOR-1566/MOR-1567: `set_data_mode`, `vfo_swap`, `vfo_equalize`,
   `set_scope_hold`. Moved to `CLAIMED_INTENTS` (34 -> 38), removed from
   their family tags in `WAIVED_INTENTS` (53 -> 49), with a note that
   MOR-1566/MOR-1567 extend coverage on these four rather than initiate it.

**New counts:** `CLAIMED_INTENTS_COUNT` 34 -> 38, `WAIVED_INTENTS_COUNT`
53 -> 49, `CLAIMED_KEYBOARD_ACTIONS_COUNT` 29 (unchanged), split within the
28 keyboard actions **17 dispatch / 11 refuse** (was 18/10).

## Round-2 review follow-up (one further finding, addressed)

Round-2 review found one new issue: the "key shadowing" claim attached to
`scope_toggle_fst`/`adjust_af_level`/`adjust_rf_gain` in round-1's fixes
(itself introduced by round-1 review, now retracted with runtime evidence)
was **false**. The fixture's keyboard bindings carry a `modifiers` array
that `keyboard-map.ts`'s `modifiersMatch()` (line ~206) discriminates on
exactly: plain `ArrowUp` -> `step-up` (`adjust_tuning_step`), Ctrl+ArrowUp
-> `af-level-up` (`adjust_af_level`), Ctrl+Shift+ArrowUp -> `rf-level-up`
(`adjust_rf_gain`); plain `F` -> `open-filter-settings`, Shift+`F` ->
`scope-toggle-fst`. Every combination resolves to its own single binding
-- there is no shadow, and the claimed direction for the F-key pair was
also backwards.

Fixed (prose-only, no assertion changes): removed the false leg from the
MOR-1578 citation in the test file header and the table row above; kept
the true PSK/PSK-R-undeclared-modes leg (`mode_select` row); strengthened
MOR-1577 with the runtime-verified fact that Ctrl+ArrowUp genuinely
reaches `adjust_af_level` as a user-visible dead control, not a
theoretical gap. Re-ran the walk file + completeness test (49/49 passing,
unchanged) and `eslint` on the file (clean) to confirm nothing else moved.

## Per-action outcome table (IC-7300 fixture, post-review)

| Action | Outcome | Firing gate |
|---|---|---|
| `tune` | DISPATCHES `set_freq` | declared nudge-right binding (ArrowRight, `{direction:'up',fine:false}`); main.freqHz observed, tuning step > 0 |
| `band_select` | DISPATCHES `set_band` | bsr capability declared + main.freqHz observed |
| `mode_select` | DISPATCHES `set_mode` | main.mode observed + LSB in caps.modes (MOR-1578: mode-psk/mode-pskr bindings declare undeclared modes, adjacent) |
| `cycle_data_mode` | DISPATCHES `set_data_mode` | main.dataMode observed; dataModeCount=1 (MOR-1454 note: correct modulo-1 result, not a bug) |
| `cycle_filter` | DISPATCHES `set_filter` | main.filter observed; wraps over caps.filters.length (fixture-declared) |
| `cycle_preamp` | DISPATCHES `set_preamp` | main.preamp observed; wraps over caps.preValues (fixture-declared, MOR-1454: honored) |
| `cycle_att` | DISPATCHES `set_attenuator` | main.att observed; wraps over caps.attValues (fixture-declared, MOR-1454: honored) |
| `cycle_agc` | DISPATCHES `set_agc` | main.agc observed; wraps over caps.agcModes (fixture-declared, MOR-1454: honored) |
| `toggle_nr` | DISPATCHES `set_nr` | main.nr observed boolean |
| `toggle_nb` | DISPATCHES `set_nb` | main.nb observed boolean |
| `toggle_auto_notch` | REFUSES | main.autoNotch unobserved (notch capability IS declared) |
| `toggle_ip_plus` | REFUSES | main.ipplus unobserved (ip_plus capability IS declared) |
| `toggle_rit` | REFUSES | top-level ritOn unobserved (discrimination-verified) |
| `toggle_xit` | REFUSES | top-level ritTx unobserved |
| `clear_rit_xit` | REFUSES | top-level ritFreq unobserved |
| `adjust_af_level` | **REFUSES** | declared af-level-up binding (`{delta:5}`); handler reads only `params.direction`, never `delta` — **MOR-1577** |
| `adjust_rf_gain` | **REFUSES** | declared rf-level-down binding (`{delta:-5}`); handler reads only `params.direction`, never `delta` — **MOR-1577** |
| `toggle_monitor` | REFUSES | top-level monitorOn unobserved |
| `vfo_swap` | DISPATCHES `vfo_swap` | vfoScheme !== "single" — unconditional, no field-observation gate at all (MOR-1578) |
| `vfo_equalize` | DISPATCHES `vfo_equalize` | vfoScheme !== "single" — unconditional, no field-observation gate at all (MOR-1578) |
| `switch_active_vfo` | REFUSES | single receiver / no dual_rx — target computes to SUB, nothing to switch to (reads `context.state.active` RAW, MOR-1578) |
| `set_active_vfo` | DISPATCHES `set_vfo` | state.main exists — activateReceiver dispatches unconditionally |
| `toggle_dial_lock` | REFUSES | top-level dialLock unobserved |
| `scope_span_step` | DISPATCHES `set_scope_span` | scopeControls.span observed; clamp bounds hardcoded, not caps-declared |
| `scope_ref_step` | DISPATCHES `set_scope_ref` | scopeControls.refDb observed; clamp bounds hardcoded, not caps-declared |
| `scope_toggle_hold` | DISPATCHES `set_scope_hold` | scopeControls.hold observed boolean |
| `scope_toggle_dual` | REFUSES | single receiver / no dual_rx / no sub |
| `scope_toggle_fst` | DISPATCHES `set_scope_speed` | scopeControls.speed observed |

**Totals: 17 dispatch, 11 refuse.**

Plus 2 separately-labeled, non-canonical **handler-capability probes**
(not counted above): `adjust_af_level`/`adjust_rf_gain` given synthetic
`{direction}` params dispatch `set_af_level`/`set_rf_gain` fine — proving
MOR-1577 is a dead-control wiring bug (declared shape ignored), not the
handler being broken outright.

## MOR-1454-related findings (corrected)

- `cycle_preamp`/`cycle_att`/`cycle_agc` each wrap over a fixture-declared
  option list (`caps.preValues`/`attValues`/`agcModes`) via the shared
  `keyboardCycle` helper, asserted by indexing into those same declared
  arrays — no MOR-1454 violation found on these three.
- `cycle_filter` wraps by index count (`caps.filters.length`), not a value
  list, so MOR-1454 doesn't apply the same way.
- `cycle_data_mode`'s domain-size-1 self-wrap is the mathematically
  correct modulo-1 result, not evidence of MOR-1454's failure mode.
- `adjust_af_level`/`adjust_rf_gain` are **not** a "no declared domain"
  case as originally claimed — that was wrong. The fixture DOES declare
  their domain (`{ delta }`); the handler just never reads it. Filed as
  **MOR-1577**, not folded into MOR-1454 since it's a param-shape mismatch,
  not an "ignores the option list" bug.
- `scope_span_step`/`scope_ref_step` use fixed clamp bounds hardcoded in
  `dispatchKeyboardRadioAction` itself, with no scope-range capability on
  this profile to check against — an honest baseline, not a finding.

## Red-first evidence

`cycle_filter` was first authored with a deliberately wrong literal claim
(`filter: 3`). RED:

```
AssertionError: expected [ [ 'set_filter', …(1) ] ] to deeply equal [ [ 'set_filter', …(1) ] ]
- Expected
+ Received
    {
-     "filter": 3,
+     "filter": 2,
      "receiver": 0,
    },
```

Fixed to the fixture-derived expression (`main.filter=1`,
`caps.filters.length=3` -> `(((1-1)+1+3)%3)+1 === 2`) -> GREEN.

`tune` (review-round fix) was rewritten to the real `nudge-right` binding
shape with a deliberately wrong target (`freq: 14_190_000`). RED:

```
AssertionError: expected [ [ 'set_freq', …(1) ] ] to deeply equal [ [ 'set_freq', …(1) ] ]
- Expected
+ Received
    {
-     "freq": 14190000,
+     "freq": 14189000,
      "receiver": 0,
    },
```

Fixed to the fixture-derived expression (`main.freqHz + 1000` = base
14188000 + the harness's mocked 1000 Hz tuning step = 14189000) -> GREEN.

## Discrimination evidence

To prove the `toggle_rit` refusal isn't vacuous, its gate
(`h.state.fieldStatus['ritOn']`) was scratch-flipped to `observed: true`
locally, and the refusal claim (`expectRefusal`) was re-run against it —
it genuinely FAILED (`set_rit_status` with `{on: true}` was dispatched),
confirming the assertion depends on that one field-status gate. The clean
file was staged with `git add` first, the scratch edit was reverted with
`git checkout --` (not `git stash`) after observing the failure.

## Test plan

- [x] `vitest run` on the new file + `panel-commands-completeness.test.ts`
      + `keyboard-radio-delegation.isolated.test.ts` +
      `mor1428-ic7300-conformance.isolated.test.ts` — 80/80 passing,
      re-verified in both file orders x3 for tuning-accumulator isolation
- [x] `eslint` on the 4 changed files (clean) + full `npm run lint` (clean)
- [x] `npm run lint:boundaries` (clean, unaffected)
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings

Closes MOR-1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
