### PR TITLE
test: TX intent family conformance walk (MOR-1564)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -60,6 +60,26 @@
  * (`scope_toggle_hold` keyboard case). Removed from the MOR-1566/MOR-1567
  * waiver tags in `./waived.ts` — those family walks extend coverage on
  * these four (more call sites, more profiles), they do not initiate it.
+ *
+ * Plus MOR-1564's (C10) TX-chain family walk
+ * (`../mor1564-tx-family-conformance.isolated.test.ts`) — 8 intents:
+ * `set_rf_power`, `set_mic_gain`, `set_compressor`, `set_compressor_level`,
+ * `set_monitor`, `set_monitor_gain`, `set_drive_gain`, `set_tuner_status`.
+ * NOT uniform: `set_rf_power`/`set_compressor`/`set_compressor_level`/
+ * `set_tuner_status` genuinely DISPATCH on the real IC-7300 fixture
+ * (`powerLevel`/`compressorOn`/`compressorLevel`/`tunerStatus` are all
+ * observed); `set_mic_gain`/`set_monitor`/`set_monitor_gain`/
+ * `set_drive_gain` REFUSE (unobserved field status, or for `drive_gain`,
+ * a capability this profile never declares at all). Two SAFETY findings
+ * pinned, not fixed, in that file's header: (1) `onRfPowerChange`/
+ * `onCompLevelChange` dispatch their `level` param verbatim with no bound
+ * check beyond `Number.isFinite`/`Number.isSafeInteger` — no clamp against
+ * either the declared wire range or `TxPanel.svelte`'s own slider domain;
+ * (2) `set_monitor_gain` has two call sites (`makeTxHandlers().onMonLevelChange`
+ * and `makeCwPanelHandlers().onSidetoneLevelChange`) gated on DIFFERENT
+ * capability sets for the identical wire intent — a MOR-1576-class
+ * inconsistency, demonstrated via a capability-withdrawal discrimination
+ * case in that file.
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',
@@ -103,10 +123,19 @@ export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'vfo_swap',
   'vfo_equalize',
   'set_scope_hold',
+  // MOR-1564 (C10) — TX-chain family walk
+  'set_rf_power',
+  'set_mic_gain',
+  'set_compressor',
+  'set_compressor_level',
+  'set_monitor',
+  'set_monitor_gain',
+  'set_drive_gain',
+  'set_tuner_status',
 ]);
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const CLAIMED_INTENTS_COUNT = 38;
+export const CLAIMED_INTENTS_COUNT = 46;
 
 /**
  * `dispatchKeyboardRadioAction` case labels claimed by a conformance case.

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -70,16 +70,23 @@
  * (`powerLevel`/`compressorOn`/`compressorLevel`/`tunerStatus` are all
  * observed); `set_mic_gain`/`set_monitor`/`set_monitor_gain`/
  * `set_drive_gain` REFUSE (unobserved field status, or for `drive_gain`,
- * a capability this profile never declares at all). Two SAFETY findings
- * pinned, not fixed, in that file's header: (1) `onRfPowerChange`/
+ * a capability this profile never declares at all). Two findings pinned,
+ * not fixed, in that file's header — both Low severity, verified against
+ * the real backend chain, not live safety issues: (1) `onRfPowerChange`/
  * `onCompLevelChange` dispatch their `level` param verbatim with no bound
- * check beyond `Number.isFinite`/`Number.isSafeInteger` — no clamp against
- * either the declared wire range or `TxPanel.svelte`'s own slider domain;
- * (2) `set_monitor_gain` has two call sites (`makeTxHandlers().onMonLevelChange`
- * and `makeCwPanelHandlers().onSidetoneLevelChange`) gated on DIFFERENT
+ * check beyond `Number.isFinite`/`Number.isSafeInteger` at the FRONTEND
+ * handler layer — a defense-in-depth/UI-hygiene gap only, since the
+ * backend's BCD encoder hard-rejects true out-of-0-255 values; the actual
+ * TX-power semantic hazard (a normalized-vs-raw domain switch with a
+ * boundary trap at the value `1`) is filed separately as MOR-1579
+ * (Medium); (2) `set_monitor_gain` has two call sites
+ * (`makeTxHandlers().onMonLevelChange` and
+ * `makeCwPanelHandlers().onSidetoneLevelChange`) gated on DIFFERENT
  * capability sets for the identical wire intent — a MOR-1576-class
  * inconsistency, demonstrated via a capability-withdrawal discrimination
- * case in that file.
+ * case in that file, but LATENT: `onSidetoneLevelChange` has no UI caller
+ * in this codebase today, and the backend independently re-gates the same
+ * capability for `set_monitor_gain` regardless of call site.
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -50,16 +50,15 @@ function tag(names: readonly string[], waiver: Waiver): Record<string, Waiver> {
   return Object.fromEntries(names.map((name) => [name, waiver]));
 }
 
-const TX = { reason: 'TX-chain family walk not yet landed', owner: 'MOR-1564' } as const;
 const VOX_CW = { reason: 'VOX/CW family walk not yet landed', owner: 'MOR-1565' } as const;
 const SCOPE_VFO = { reason: 'Scope-remainder/VFO-topology family walk not yet landed', owner: 'MOR-1566' } as const;
 const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner: 'MOR-1567' } as const;
 
 /**
- * The (67 - 9 - 5 - 4 = 49) intents with no conformance assertion, tagged
- * with the family child that owns closing them. MOR-1562 (C8, adapter-seam
- * parity) intentionally claims ZERO entries here — its scope is
- * `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
+ * The (67 - 9 - 5 - 4 - 8 = 41) intents with no conformance assertion,
+ * tagged with the family child that owns closing them. MOR-1562 (C8,
+ * adapter-seam parity) intentionally claims ZERO entries here — its scope
+ * is `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
  *
  * MOR-1560 (C6)'s 9 DSP intents and MOR-1561 (C7)'s 5 filter/PBT intents
  * landed and were moved to `CLAIMED_INTENTS` in `./claimed.ts` — see
@@ -72,17 +71,17 @@ const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner:
  * burn-down rule (a landed `expectFrames` claims the intent regardless of
  * which walk lands it first); MOR-1566/MOR-1567 will extend coverage on
  * these four (more call sites, more profiles), not initiate it.
+ *
+ * MOR-1564 (C10)'s TX-chain walk landed all 8 of its intents — see
+ * `./claimed.ts` and `../mor1564-tx-family-conformance.isolated.test.ts`.
  */
 export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
   // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — CLAIMED, see
   // `./claimed.ts` and `../mor1560-dsp-family-conformance.isolated.test.ts`.
   // MOR-1561 (C7) — Filter, PBT and IF-shift — CLAIMED, see `./claimed.ts`
   // and `../mor1561-filter-pbt-family-conformance.isolated.test.ts`.
-  // MOR-1564 (C10) — TX chain — 8
-  ...tag([
-    'set_rf_power', 'set_mic_gain', 'set_compressor', 'set_compressor_level',
-    'set_monitor', 'set_monitor_gain', 'set_drive_gain', 'set_tuner_status',
-  ], TX),
+  // MOR-1564 (C10) — TX chain — CLAIMED, see `./claimed.ts` and
+  // `../mor1564-tx-family-conformance.isolated.test.ts`.
   // MOR-1565 (C11) — VOX + CW — 12
   ...tag([
     'set_vox', 'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
@@ -110,7 +109,7 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
 };
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const WAIVED_INTENTS_COUNT = 49;
+export const WAIVED_INTENTS_COUNT = 41;
 
 /**
  * `dispatchKeyboardRadioAction` case labels with no conformance assertion.

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1564-tx-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1564-tx-family-conformance.isolated.test.ts
@@ -1,0 +1,208 @@
+/**
+ * MOR-1564 (C10) — TX-chain intent family conformance walk, over the same
+ * profile-parameterized harness MOR-1428/MOR-1555 established
+ * (`./conformance/harness.ts`, `./conformance/profiles.ts`).
+ *
+ * Family (per `waived.ts`'s MOR-1564 tag, 8 intents): `set_rf_power`,
+ * `set_mic_gain`, `set_compressor`, `set_compressor_level`, `set_monitor`,
+ * `set_monitor_gain`, `set_drive_gain`, `set_tuner_status` — all dispatched
+ * from `makeTxHandlers()` in `panel-commands.ts`, except `set_monitor_gain`,
+ * which ALSO has a second dispatch site in `makeCwPanelHandlers()`
+ * (`onSidetoneLevelChange` — the CW sidetone-level slider happens to write
+ * the same wire field as the TX monitor-gain slider). SAFETY NOTE: this
+ * family is TX-chain (RF power, mic gain, compressor, monitor, ATU), so
+ * every refusal/dispatch below is read directly off the real IC-7300
+ * fixture's `fieldStatus`/`capabilities`, never invented.
+ *
+ * NOT UNIFORM (4 dispatch, 4 refuse on this fixture): `powerLevel`,
+ * `compressorOn`, `compressorLevel`, `tunerStatus` are all OBSERVED on the
+ * real bench capture, so `set_rf_power`/`set_compressor`/
+ * `set_compressor_level`/`set_tuner_status` genuinely dispatch. `micGain`,
+ * `monitorOn`, `monitorGain`, `driveGain` are unobserved (or, for
+ * `driveGain`, gated on a capability this profile never declares at all),
+ * so `set_mic_gain`/`set_monitor`/`set_monitor_gain`/`set_drive_gain`
+ * refuse — the same MOR-988 §3.2 fail-closed doctrine the exemplar's
+ * `onMicGainChange(100)` case already established for this exact field.
+ *
+ * FINDING 1 (SAFETY, "does tx_power dispatch blind?"): `onRfPowerChange`
+ * has no bound check beyond `Number.isFinite` — no reference to
+ * `IC7300_CAPABILITIES.controls.rf_power` (the WIRE-side raw 0-255 range;
+ * irrelevant here, see below) or to `TxPanel.svelte`'s own slider domain
+ * (`min={0} max={1} step={0.01}`, confirmed by reading that component
+ * directly). The same shape repeats for `onCompLevelChange` (dispatches
+ * `compressor_level` verbatim, no reference to its own declared 0-255
+ * range) — `radio-intents.ts`'s own `dispatchRadioIntent` validation adds
+ * no additional bound either (`set_rf_power`'s spec is `{ level: 'number'
+ * }`, i.e. "any finite number", not the `'normalized'` kind `set_af_level`
+ * uses for its own 0-1 domain). The "blind" probe below (`level=5`, past
+ * both the UI's own max=1 AND the wire's declared raw_max=255) proves this
+ * concretely: the handler dispatches it verbatim. This is a real gap in
+ * defense-in-depth at the handler layer, not a fixture artifact — pinned
+ * here per this ticket's instruction to report, not fix.
+ *
+ * FINDING 2 (SAFETY, MOR-1576 inconsistency class — "same intent alive on
+ * one path, dead on another"): `set_monitor_gain` has two call sites with
+ * DIFFERENT capability gates for the identical wire intent.
+ * `onMonLevelChange` (TX family) requires `hasCapability('tx') &&
+ * hasCapability('monitor')`; `onSidetoneLevelChange` (CW family,
+ * `panel-commands.ts:544-547`) requires only `hasCapability('cw')` — it
+ * never checks `monitor` at all. On the REAL IC-7300 fixture both refuse
+ * for the same reason (`monitorGain` itself is unobserved), so the
+ * divergence is invisible today — but the two gates are provably different
+ * code paths: the discrimination case below removes only the `monitor`
+ * capability (keeping `cw`) and marks `monitorGain` observed, and the CW
+ * path DISPATCHES while the TX path still REFUSES. On a profile that
+ * declares `cw` but not `monitor` (plausible — they gate unrelated
+ * hardware) an operator could push a monitor-gain change through the CW
+ * sidetone slider while the TX panel's own monitor-gain control stays
+ * correctly dark. Pinned per this ticket's instruction to report, not fix.
+ *
+ * RED-FIRST EVIDENCE (MOR-1564 build process, not part of this diff): the
+ * `set_rf_power` `level=0.5` case below was first authored as
+ * `expectFrames(() => makeTxHandlers().onRfPowerChange(0.5), [['set_rf_power',
+ * { level: 999 }]])` — a deliberately wrong claimed dispatch value.
+ * `vitest run` on that version failed with `expected [ [ 'set_rf_power', {
+ * level: 0.5 } ] ] to deeply equal [ [ 'set_rf_power', { level: 999 } ] ]`
+ * (RED — the real dispatch carries 0.5, the fixture/production value, not
+ * the fabricated 999). Replacing the claim with `{ level: 0.5 }` turned it
+ * GREEN.
+ *
+ * DISCRIMINATION EVIDENCE (MOR-1564 build process, not part of this diff):
+ * to prove the `set_mic_gain` refusal below isn't vacuous, its gate was
+ * scratch-flipped locally — `h.state.fieldStatus.micGain` temporarily set
+ * to `{ availability: 'available', observed: true, freshness: 'fresh' }`
+ * before calling `onMicGainChange(128)` — and the refusal assertion then
+ * FAILED (the handler dispatched `set_mic_gain` with `{ level: 128 }`),
+ * confirming the assertion genuinely depends on that one field-status gate.
+ * The scratch edit was staged (`git add`) in its clean form first, then
+ * reverted with `git checkout --` (not `git stash`) after observing the
+ * failure, restoring the green state before this file was committed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  expectFrames,
+  expectRefusal,
+  fixtureCaps,
+  fixtureState,
+  h,
+} from './conformance/harness';
+import { PROFILES } from './conformance/profiles';
+import { makeCwPanelHandlers, makeTxHandlers } from '../../commands/panel-commands';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+
+const profile = PROFILES.ic7300;
+const IC7300_STATE = profile.state;
+const IC7300_CAPABILITIES = profile.caps;
+
+describe('IC-7300 fixture — TX-chain family conformance (MOR-1564)', () => {
+  beforeEach(() => {
+    h.state = fixtureState(profile);
+    h.caps = fixtureCaps(profile);
+    h.sendCommand.mockClear();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  describe('set_rf_power — production-domain walk (TxPanel.svelte slider: min=0 max=1 step=0.01), plus a no-clamp SAFETY probe', () => {
+    it('powerLevel IS observed on this fixture; rf_power only declares a WIRE raw range (0-255), which onRfPowerChange never reads', () => {
+      expect(IC7300_CAPABILITIES.capabilities).toContain('tx');
+      expect(IC7300_STATE.fieldStatus?.powerLevel?.observed).toBe(true);
+      expect(IC7300_CAPABILITIES.controls?.rf_power).toEqual({ raw_min: 0, raw_max: 255 });
+    });
+
+    for (const level of [0, 0.5, 1]) {
+      it(`level=${level} (production domain [0,1]): CLAIMS — dispatches set_rf_power verbatim, no scaling (RED-FIRST evidence in file header)`, () => {
+        expectFrames(() => makeTxHandlers().onRfPowerChange(level), [['set_rf_power', { level }]]);
+      });
+    }
+
+    it("SAFETY: level=5 (past TxPanel.svelte's own max=1 AND rf_power's declared wire raw_max=255) still DISPATCHES verbatim — no domain clamp exists at the handler layer (finding 1, see file header)", () => {
+      expectFrames(() => makeTxHandlers().onRfPowerChange(5), [['set_rf_power', { level: 5 }]]);
+    });
+  });
+
+  describe('set_mic_gain — boundary walk over the declared mic_gain range (also TxPanel.svelte\'s own slider domain, min=0 max=255)', () => {
+    it('mic_gain declares a wire range on this profile; micGain itself is unobserved (discrimination case, see file header)', () => {
+      expect(IC7300_CAPABILITIES.controls?.mic_gain).toEqual({ raw_min: 0, raw_max: 255 });
+      expect(IC7300_STATE.fieldStatus?.micGain?.observed).toBe(false);
+    });
+
+    for (const level of [0, 128, 255]) {
+      it(`level=${level}: REFUSES — micGain is unobserved`, () => {
+        expectRefusal(() => makeTxHandlers().onMicGainChange(level));
+      });
+    }
+  });
+
+  it('set_compressor: DISPATCHES — compressorOn IS observed (true on this fixture), toggles off', () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('compressor');
+    expect(IC7300_STATE.fieldStatus?.compressorOn?.observed).toBe(true);
+    expect(IC7300_STATE.compressorOn).toBe(true);
+    expectFrames(() => makeTxHandlers().onCompToggle(), [['set_compressor', { on: false }]]);
+  });
+
+  describe('set_compressor_level — boundary walk over the declared compressor_level range (TxPanel.svelte slider domain, min=0 max=255); same blind-passthrough shape as set_rf_power', () => {
+    it('compressor_level declares a wire range on this profile; compressorLevel IS observed', () => {
+      expect(IC7300_CAPABILITIES.controls?.compressor_level).toEqual({ raw_min: 0, raw_max: 255 });
+      expect(IC7300_STATE.fieldStatus?.compressorLevel?.observed).toBe(true);
+    });
+
+    for (const level of [0, 128, 255]) {
+      it(`level=${level}: DISPATCHES verbatim, no scaling`, () => {
+        expectFrames(() => makeTxHandlers().onCompLevelChange(level), [['set_compressor_level', { level }]]);
+      });
+    }
+  });
+
+  it('set_monitor: REFUSES — monitorOn is unobserved (onMonToggle is the only dispatch site)', () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('monitor');
+    expect(IC7300_STATE.fieldStatus?.monitorOn?.observed).toBe(false);
+    expectRefusal(() => makeTxHandlers().onMonToggle());
+  });
+
+  describe('set_monitor_gain — dual call-site gate asymmetry: makeTxHandlers().onMonLevelChange vs makeCwPanelHandlers().onSidetoneLevelChange (finding 2, see file header)', () => {
+    it('both REFUSE on the real fixture — monitorGain is unobserved (same proximate reason on both call sites today)', () => {
+      expect(IC7300_STATE.fieldStatus?.monitorGain?.observed).toBe(false);
+      expectRefusal(() => makeTxHandlers().onMonLevelChange(120));
+      expectRefusal(() => makeCwPanelHandlers().onSidetoneLevelChange(120));
+    });
+
+    it("MOR-1576 class: with monitorGain observed and only the 'monitor' capability withdrawn (cw kept), the CW sidetone path DISPATCHES set_monitor_gain while the TX path still REFUSES — same wire intent, two different capability gates", () => {
+      h.caps!.capabilities = h.caps!.capabilities.filter((c) => c !== 'monitor');
+      h.state!.fieldStatus!.monitorGain = {
+        ...h.state!.fieldStatus!.monitorGain!,
+        observed: true,
+        availability: 'available',
+        freshness: 'fresh',
+      };
+      expect(h.caps!.capabilities).toContain('cw');
+      expect(h.caps!.capabilities).not.toContain('monitor');
+      expectFrames(() => makeCwPanelHandlers().onSidetoneLevelChange(120), [['set_monitor_gain', { level: 120 }]]);
+      h.sendCommand.mockClear();
+      resetCommandLifecycle();
+      expectRefusal(() => makeTxHandlers().onMonLevelChange(120));
+    });
+  });
+
+  it("set_drive_gain: REFUSES — the 'drive_gain' capability itself is absent from this profile (fires before the driveGain field-status check even runs; TxPanel.svelte still renders a 0-255 slider for it as generic UI chrome)", () => {
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('drive_gain');
+    expect(IC7300_CAPABILITIES.controls?.drive_gain).toBeUndefined();
+    expect(IC7300_STATE.fieldStatus?.driveGain?.observed).toBe(false);
+    expectRefusal(() => makeTxHandlers().onDriveGainChange(IC7300_STATE.driveGain as number));
+  });
+
+  describe('set_tuner_status — two call sites sharing one consistent gate (unlike set_monitor_gain above)', () => {
+    it('onAtuToggle: DISPATCHES — tunerStatus IS observed (value 0 on this fixture), toggles to 1', () => {
+      expect(IC7300_CAPABILITIES.capabilities).toContain('tuner');
+      expect(IC7300_STATE.fieldStatus?.tunerStatus?.observed).toBe(true);
+      expect(IC7300_STATE.tunerStatus).toBe(0);
+      expectFrames(() => makeTxHandlers().onAtuToggle(), [['set_tuner_status', { value: 1 }]]);
+    });
+
+    it('onAtuTune: DISPATCHES — same gate, always requests value=2 (start tune) regardless of the current tunerStatus', () => {
+      expectFrames(() => makeTxHandlers().onAtuTune(), [['set_tuner_status', { value: 2 }]]);
+    });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1564-tx-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1564-tx-family-conformance.isolated.test.ts
@@ -8,10 +8,12 @@
  * `set_monitor_gain`, `set_drive_gain`, `set_tuner_status` — all dispatched
  * from `makeTxHandlers()` in `panel-commands.ts`, except `set_monitor_gain`,
  * which ALSO has a second dispatch site in `makeCwPanelHandlers()`
- * (`onSidetoneLevelChange` — the CW sidetone-level slider happens to write
- * the same wire field as the TX monitor-gain slider). SAFETY NOTE: this
- * family is TX-chain (RF power, mic gain, compressor, monitor, ATU), so
- * every refusal/dispatch below is read directly off the real IC-7300
+ * (`onSidetoneLevelChange` — writes the same wire field as the TX
+ * monitor-gain handler, but per grep has ZERO UI consumers anywhere in this
+ * codebase today: only its own definition at `panel-commands.ts:544`
+ * exists, no CW sidetone-level slider or any other component calls it).
+ * This family is TX-chain (RF power, mic gain, compressor, monitor, ATU),
+ * so every refusal/dispatch below is read directly off the real IC-7300
  * fixture's `fieldStatus`/`capabilities`, never invented.
  *
  * NOT UNIFORM (4 dispatch, 4 refuse on this fixture): `powerLevel`,
@@ -24,24 +26,40 @@
  * refuse — the same MOR-988 §3.2 fail-closed doctrine the exemplar's
  * `onMicGainChange(100)` case already established for this exact field.
  *
- * FINDING 1 (SAFETY, "does tx_power dispatch blind?"): `onRfPowerChange`
- * has no bound check beyond `Number.isFinite` — no reference to
- * `IC7300_CAPABILITIES.controls.rf_power` (the WIRE-side raw 0-255 range;
- * irrelevant here, see below) or to `TxPanel.svelte`'s own slider domain
- * (`min={0} max={1} step={0.01}`, confirmed by reading that component
- * directly). The same shape repeats for `onCompLevelChange` (dispatches
- * `compressor_level` verbatim, no reference to its own declared 0-255
- * range) — `radio-intents.ts`'s own `dispatchRadioIntent` validation adds
- * no additional bound either (`set_rf_power`'s spec is `{ level: 'number'
- * }`, i.e. "any finite number", not the `'normalized'` kind `set_af_level`
- * uses for its own 0-1 domain). The "blind" probe below (`level=5`, past
- * both the UI's own max=1 AND the wire's declared raw_max=255) proves this
- * concretely: the handler dispatches it verbatim. This is a real gap in
- * defense-in-depth at the handler layer, not a fixture artifact — pinned
- * here per this ticket's instruction to report, not fix.
+ * FINDING 1 (defense-in-depth / UI-hygiene gap at the frontend handler
+ * layer — NOT a live safety issue; verified against the real backend
+ * chain): `onRfPowerChange` has no bound check beyond `Number.isFinite` —
+ * no reference to `IC7300_CAPABILITIES.controls.rf_power` (the WIRE-side
+ * raw 0-255 range; irrelevant here, see below) or to `TxPanel.svelte`'s own
+ * slider domain (`min={0} max={1} step={0.01}`, confirmed by reading that
+ * component directly). The same shape repeats for `onCompLevelChange`
+ * (dispatches `compressor_level` verbatim, no reference to its own
+ * declared 0-255 range) — `radio-intents.ts`'s own `dispatchRadioIntent`
+ * validation adds no additional bound either (`set_rf_power`'s spec is `{
+ * level: 'number' }`, i.e. "any finite number", not the `'normalized'`
+ * kind `set_af_level` uses for its own 0-1 domain). BUT the backend closes
+ * this: `src/rigplane/web/handlers/control.py:257
+ * _normalized_or_raw_level` and `src/rigplane/commands/_codec.py:21
+ * _level_bcd_encode` were read directly — the wire-level BCD encoder
+ * hard-REJECTS (raises `ValueError`) any value outside 0-255, so no
+ * out-of-domain byte can ever reach the radio. The probe below (`level=5`)
+ * is also NOT an over-power case: 5 falls outside `[0,1]`, so
+ * `_normalized_or_raw_level` takes its RAW branch and interprets 5 as raw
+ * units directly — raw 5 of 255 ≈ 2% power, a silent UNDER-power
+ * misinterpretation, not an unclamped over-power dispatch. The genuine,
+ * already-filed hazard is the normalized-vs-raw semantic switch itself
+ * (0-1 is treated as normalized, anything else as raw units, with the
+ * value `1` sitting exactly on the boundary between "100% normalized" and
+ * "raw unit 1 ≈ 0.4% power") — see MOR-1579
+ * ("`_normalized_or_raw_level`: silent normalized→raw semantic switch is a
+ * TX-power foot-gun"), which also documents the `(1)→255=full power`
+ * boundary trap. This test's finding is limited to the frontend handler
+ * layer applying no domain clamp of its own — pinned here per this
+ * ticket's instruction to report, not fix.
  *
- * FINDING 2 (SAFETY, MOR-1576 inconsistency class — "same intent alive on
- * one path, dead on another"): `set_monitor_gain` has two call sites with
+ * FINDING 2 (latent adapter-layer gate inconsistency, MOR-1576 class —
+ * "same intent alive on one path, dead on another"; backend-guarded, no
+ * live operator path today): `set_monitor_gain` has two call sites with
  * DIFFERENT capability gates for the identical wire intent.
  * `onMonLevelChange` (TX family) requires `hasCapability('tx') &&
  * hasCapability('monitor')`; `onSidetoneLevelChange` (CW family,
@@ -51,11 +69,17 @@
  * divergence is invisible today — but the two gates are provably different
  * code paths: the discrimination case below removes only the `monitor`
  * capability (keeping `cw`) and marks `monitorGain` observed, and the CW
- * path DISPATCHES while the TX path still REFUSES. On a profile that
- * declares `cw` but not `monitor` (plausible — they gate unrelated
- * hardware) an operator could push a monitor-gain change through the CW
- * sidetone slider while the TX panel's own monitor-gain control stays
- * correctly dark. Pinned per this ticket's instruction to report, not fix.
+ * path DISPATCHES while the TX path still REFUSES. This asymmetry is
+ * LATENT rather than operator-reachable, for two reasons: (1)
+ * `onSidetoneLevelChange` has no UI caller anywhere in this codebase today
+ * (grep finds only its own definition, see the family note above), so no
+ * component can currently reach it; and (2) even if it were wired up, the
+ * backend independently re-gates the SAME capability regardless of which
+ * frontend call site dispatched it (`src/rigplane/web/handlers/control.py`,
+ * `case "set_monitor_gain":` calls `self._ensure_capability("monitor",
+ * "set_monitor_gain")` unconditionally) — a profile lacking `monitor`
+ * would have its `set_monitor_gain` command rejected server-side either
+ * way. Pinned per this ticket's instruction to report, not fix.
  *
  * RED-FIRST EVIDENCE (MOR-1564 build process, not part of this diff): the
  * `set_rf_power` `level=0.5` case below was first authored as
@@ -105,7 +129,7 @@ describe('IC-7300 fixture — TX-chain family conformance (MOR-1564)', () => {
     resetCommandLifecycle();
   });
 
-  describe('set_rf_power — production-domain walk (TxPanel.svelte slider: min=0 max=1 step=0.01), plus a no-clamp SAFETY probe', () => {
+  describe('set_rf_power — production-domain walk (TxPanel.svelte slider: min=0 max=1 step=0.01), plus a no-clamp defense-in-depth probe (backend-guarded, see finding 1)', () => {
     it('powerLevel IS observed on this fixture; rf_power only declares a WIRE raw range (0-255), which onRfPowerChange never reads', () => {
       expect(IC7300_CAPABILITIES.capabilities).toContain('tx');
       expect(IC7300_STATE.fieldStatus?.powerLevel?.observed).toBe(true);
@@ -118,7 +142,7 @@ describe('IC-7300 fixture — TX-chain family conformance (MOR-1564)', () => {
       });
     }
 
-    it("SAFETY: level=5 (past TxPanel.svelte's own max=1 AND rf_power's declared wire raw_max=255) still DISPATCHES verbatim — no domain clamp exists at the handler layer (finding 1, see file header)", () => {
+    it("DEFENSE-IN-DEPTH: level=5 (past TxPanel.svelte's own max=1) still DISPATCHES verbatim — no domain clamp exists at the frontend handler layer, though the backend's BCD encoder hard-rejects true out-of-0-255 values, and 5 itself would be misinterpreted as raw ≈2% power (UNDER-power, not over) under _normalized_or_raw_level's normalized/raw switch — MOR-1579, not a live safety gap here (finding 1, see file header)", () => {
       expectFrames(() => makeTxHandlers().onRfPowerChange(5), [['set_rf_power', { level: 5 }]]);
     });
   });
@@ -169,7 +193,7 @@ describe('IC-7300 fixture — TX-chain family conformance (MOR-1564)', () => {
       expectRefusal(() => makeCwPanelHandlers().onSidetoneLevelChange(120));
     });
 
-    it("MOR-1576 class: with monitorGain observed and only the 'monitor' capability withdrawn (cw kept), the CW sidetone path DISPATCHES set_monitor_gain while the TX path still REFUSES — same wire intent, two different capability gates", () => {
+    it("MOR-1576 class (latent, backend-guarded, no UI caller — see finding 2): with monitorGain observed and only the 'monitor' capability withdrawn (cw kept), the CW-family handler DISPATCHES set_monitor_gain while the TX-family handler still REFUSES — same wire intent, two different frontend capability gates", () => {
       h.caps!.capabilities = h.caps!.capabilities.filter((c) => c !== 'monitor');
       h.state!.fieldStatus!.monitorGain = {
         ...h.state!.fieldStatus!.monitorGain!,


### PR DESCRIPTION
## Summary

Walks the 8 MOR-1564-tagged TX-chain intents through the profile-parameterized
conformance harness (`conformance/harness.ts` / `conformance/profiles.ts`)
against the registered IC-7300 fixture, and moves them from `waived.ts` to
`claimed.ts`.

## Per-intent table

| Intent | Outcome | Gate / frame source |
|---|---|---|
| `set_rf_power` | DISPATCHES (0, 0.5, 1) + defense-in-depth probe (5, unclamped at handler layer; backend-guarded) | `powerLevel` observed; `onRfPowerChange` dispatches `level` verbatim, no bound check beyond `Number.isFinite` |
| `set_mic_gain` | REFUSES (0, 128, 255) | `micGain` unobserved (discrimination-verified gate) |
| `set_compressor` | DISPATCHES | `compressorOn` observed=true -> toggles to `{on:false}` |
| `set_compressor_level` | DISPATCHES (0, 128, 255) | `compressorLevel` observed; verbatim passthrough, same no-clamp shape as `set_rf_power` |
| `set_monitor` | REFUSES | `monitorOn` unobserved |
| `set_monitor_gain` | REFUSES on both call sites today; asymmetric gates proven via discrimination | `monitorGain` unobserved (proximate cause); `onMonLevelChange` (TX) requires `tx`+`monitor` capability, `onSidetoneLevelChange` (CW) requires only `cw` — same wire intent, different gate |
| `set_drive_gain` | REFUSES | `drive_gain` capability absent from this profile entirely (fires before the field-status check) |
| `set_tuner_status` | DISPATCHES via both call sites (consistent gate) | `tunerStatus` observed=0; `onAtuToggle` -> `{value:1}`, `onAtuTune` -> `{value:2}` |

## Findings (pinned, not fixed) — both Low severity, neither a live safety issue

1. **Defense-in-depth / UI-hygiene gap (Low)**: `onRfPowerChange`/
   `onCompLevelChange` forward their `level` param straight into the wire
   frame with no domain clamp AT THE FRONTEND HANDLER LAYER — neither
   against the declared `controls.rf_power`/`controls.compressor_level` wire
   range, nor against the production UI's own slider bounds
   (`TxPanel.svelte`: RF Power `min=0 max=1`, Comp Level `min=0 max=255`).
   `radio-intents.ts`'s own dispatch-time validation only checks the JS
   *type* (`'number'`/`'integer'`), never a value range. This is NOT a live
   safety issue: verified against the real backend chain
   (`control.py:257 _normalized_or_raw_level`, `_codec.py:21
   _level_bcd_encode`) — the wire-level BCD encoder hard-rejects any
   out-of-0-255 value, so no out-of-domain byte reaches the radio. The
   `level=5` probe used to demonstrate the frontend gap is also NOT an
   over-power case: 5 falls outside `[0,1]`, so `_normalized_or_raw_level`
   takes its raw branch and interprets 5 as raw units directly (≈2% power,
   an UNDER-power misinterpretation). The actual TX-power hazard is a
   separate, already-filed issue — **MOR-1579** (Medium): a silent
   normalized-vs-raw semantic switch with a boundary trap at the value `1`
   (`1` → treated as "100% normalized" vs. raw unit 1 ≈ 0.4% power).
2. **MOR-1576-class gate asymmetry (Low, latent)**: `set_monitor_gain` has
   two dispatch sites for the identical wire intent —
   `makeTxHandlers().onMonLevelChange` (TX panel, requires `tx` + `monitor`
   capabilities) and `makeCwPanelHandlers().onSidetoneLevelChange` (CW
   family, requires only `cw`). On the real IC-7300 fixture both refuse for
   the same proximate reason (`monitorGain` unobserved), so the divergence
   is invisible today. A discrimination case (capability list with
   `monitor` withdrawn, `cw` kept, `monitorGain` marked observed) shows one
   handler dispatches while the other still refuses — a real, provable
   asymmetry in the code, not a fixture artifact. It has no live operator
   path, though: `onSidetoneLevelChange` has zero UI consumers anywhere in
   this codebase (grep finds only its own definition), and even if it were
   wired up, the backend re-gates the same capability for
   `set_monitor_gain` unconditionally regardless of call site
   (`control.py`, `case "set_monitor_gain":` calls
   `self._ensure_capability("monitor", ...)`).

## Red-first evidence

Authored `set_rf_power`'s `level=0.5` case with a deliberately wrong claimed
byte first:

```
expectFrames(() => makeTxHandlers().onRfPowerChange(0.5), [['set_rf_power', { level: 999 }]]);
```

RED:
```
AssertionError: expected [ [ 'set_rf_power', { level: 0.5 } ] ] to deeply equal [ [ 'set_rf_power', { level: 999 } ] ]
- Expected
+ Received
  [
    [
      "set_rf_power",
      {
-       "level": 999,
+       "level": 0.5,
      },
    ],
  ]
```

Fixed to the real fixture/production-derived value (`{ level: 0.5 }`) -> GREEN
(20/20 passing).

## Discrimination evidence

Staged the clean file (`git add`), then scratch-flipped `set_mic_gain`'s gate
(`h.state.fieldStatus.micGain` forced to `observed:true, availability:
'available', freshness:'fresh'`) and re-ran the boundary walk. All 3 refusal
assertions failed as expected (the handler now dispatched `set_mic_gain`),
confirming the assertions genuinely depend on that field-status gate.
Reverted with `git checkout --` (not `git stash`), confirmed green again
before committing.

## Counts

- `WAIVED_INTENTS_COUNT`: 49 -> 41
- `CLAIMED_INTENTS_COUNT`: 38 -> 46

## Test plan

- [x] `npx vitest run` on the new file, `panel-commands-completeness.test.ts`,
      `mor1428-ic7300-conformance.isolated.test.ts`, and
      `mor1561-filter-pbt-family-conformance.isolated.test.ts` — 80/80 passing
- [x] `npx eslint` on the 3 touched files — clean
- [x] `npm run lint:boundaries` — clean
- [x] `npm run check` (svelte-check + tsc) — 0 errors
- [x] Boundary grep (internal-hostname / private-IP / preview-URL patterns) over
      the diff — empty

Closes MOR-1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
