### PR TITLE
test: VOX/CW intent family conformance walk (MOR-1565)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -87,6 +87,26 @@
  * case in that file, but LATENT: `onSidetoneLevelChange` has no UI caller
  * in this codebase today, and the backend independently re-gates the same
  * capability for `set_monitor_gain` regardless of call site.
+ *
+ * Plus MOR-1565's (C11) VOX/CW family walk
+ * (`../mor1565-vox-cw-family-conformance.isolated.test.ts`) — 12 intents:
+ * `set_vox`, `set_vox_gain`, `set_anti_vox_gain`, `set_vox_delay`,
+ * `set_cw_pitch`, `set_key_speed`, `set_break_in`, `set_break_in_delay`,
+ * `set_apf`, `set_twin_peak`, `cw_auto_tune`, `set_dash_ratio`. Even more
+ * skewed than MOR-1564's TX-chain split: 11 of the 12 are claimed via
+ * `expectRefusal` (every field this family reads — `voxOn`, `voxGain`,
+ * `antiVoxGain`, `voxDelay`, `cwPitch`, `keySpeed`, `breakIn`,
+ * `breakInDelay`, `main.apfTypeLevel`, `main.twinPeakFilter`, `dashRatio` —
+ * is unobserved on the real IC-7300 fixture, though every base capability
+ * the family needs IS declared); only `cw_auto_tune` genuinely DISPATCHES —
+ * its gate (`hasCapability('cw') && knownActiveReceiver() !== null`) never
+ * inspects any field-status leaf at all, unlike every sibling intent in
+ * this family. Three gate-consistency checks (`set_vox`'s shared
+ * `toggleVox` reference, `set_cw_pitch`'s and `set_key_speed`'s two
+ * byte-identical call sites) are pinned as POSITIVE findings — MOR-1576
+ * class asymmetry checked for and NOT found, unlike `set_monitor_gain`
+ * above (that finding's own CW-sidetone leg, `onSidetoneLevelChange`, is a
+ * different intent and stays claimed via C10, not this walk).
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',
@@ -139,10 +159,23 @@ export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_monitor_gain',
   'set_drive_gain',
   'set_tuner_status',
+  // MOR-1565 (C11) — VOX/CW family walk
+  'set_vox',
+  'set_vox_gain',
+  'set_anti_vox_gain',
+  'set_vox_delay',
+  'set_cw_pitch',
+  'set_key_speed',
+  'set_break_in',
+  'set_break_in_delay',
+  'set_apf',
+  'set_twin_peak',
+  'cw_auto_tune',
+  'set_dash_ratio',
 ]);
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const CLAIMED_INTENTS_COUNT = 46;
+export const CLAIMED_INTENTS_COUNT = 58;
 
 /**
  * `dispatchKeyboardRadioAction` case labels claimed by a conformance case.

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -99,14 +99,26 @@
  * `breakInDelay`, `main.apfTypeLevel`, `main.twinPeakFilter`, `dashRatio` —
  * is unobserved on the real IC-7300 fixture, though every base capability
  * the family needs IS declared); only `cw_auto_tune` genuinely DISPATCHES —
- * its gate (`hasCapability('cw') && knownActiveReceiver() !== null`) never
- * inspects any field-status leaf at all, unlike every sibling intent in
- * this family. Three gate-consistency checks (`set_vox`'s shared
- * `toggleVox` reference, `set_cw_pitch`'s and `set_key_speed`'s two
- * byte-identical call sites) are pinned as POSITIVE findings — MOR-1576
- * class asymmetry checked for and NOT found, unlike `set_monitor_gain`
- * above (that finding's own CW-sidetone leg, `onSidetoneLevelChange`, is a
- * different intent and stays claimed via C10, not this walk).
+ * its gate (`hasCapability('cw') && knownActiveReceiver() !== null`) does
+ * read one field-status leaf (`active`, via `knownActiveReceiver`'s own
+ * `isFieldAvailable(state, 'active')` check), which IS unobserved on this
+ * fixture same as every sibling's leaf — but MOR-1418's single-receiver
+ * carve-out (`caps.receivers === 1`) neutralizes that check on THIS
+ * profile, falling through to a hardcoded `'MAIN'` instead of blocking; on
+ * a dual-RX profile with `active` unobserved the same gate would refuse
+ * (pinned in that walk's own file, not re-derived here). This is a
+ * profile-specific dispatch, not evidence the gate skips field-status
+ * checks — see the walk's own file header for the full correction and the
+ * MOR-1578 leg 4 transmit-causing-action risk finding (`onAutoTune` wired
+ * on `CwPanel.svelte` with no MOR-1244-style guard, unlike
+ * `SemanticRadioSurfaces.svelte`, which deliberately leaves it unwired).
+ * Three gate-consistency checks (`set_vox`'s shared `toggleVox` reference,
+ * `set_cw_pitch`'s and `set_key_speed`'s two byte-identical call sites,
+ * BOTH pinned via `String(...)` source-identity, not refusal-behavior
+ * alone) are pinned as POSITIVE findings — MOR-1576 class asymmetry
+ * checked for and NOT found, unlike `set_monitor_gain` above (that
+ * finding's own CW-sidetone leg, `onSidetoneLevelChange`, is a different
+ * intent and stays claimed via C10, not this walk).
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -50,12 +50,11 @@ function tag(names: readonly string[], waiver: Waiver): Record<string, Waiver> {
   return Object.fromEntries(names.map((name) => [name, waiver]));
 }
 
-const VOX_CW = { reason: 'VOX/CW family walk not yet landed', owner: 'MOR-1565' } as const;
 const SCOPE_VFO = { reason: 'Scope-remainder/VFO-topology family walk not yet landed', owner: 'MOR-1566' } as const;
 const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner: 'MOR-1567' } as const;
 
 /**
- * The (67 - 9 - 5 - 4 - 8 = 41) intents with no conformance assertion,
+ * The (67 - 9 - 5 - 4 - 8 - 12 = 29) intents with no conformance assertion,
  * tagged with the family child that owns closing them. MOR-1562 (C8,
  * adapter-seam parity) intentionally claims ZERO entries here — its scope
  * is `get*Handlers`/`derive*Props`/`get*Armed` SEAMS, not new intent names.
@@ -74,6 +73,9 @@ const SWEEPER = { reason: 'Remainder-sweeper family walk not yet landed', owner:
  *
  * MOR-1564 (C10)'s TX-chain walk landed all 8 of its intents — see
  * `./claimed.ts` and `../mor1564-tx-family-conformance.isolated.test.ts`.
+ *
+ * MOR-1565 (C11)'s VOX/CW walk landed all 12 of its intents — see
+ * `./claimed.ts` and `../mor1565-vox-cw-family-conformance.isolated.test.ts`.
  */
 export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
   // MOR-1560 (C6) — DSP: NR/NB/notch/AGC time constant — CLAIMED, see
@@ -82,12 +84,8 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
   // and `../mor1561-filter-pbt-family-conformance.isolated.test.ts`.
   // MOR-1564 (C10) — TX chain — CLAIMED, see `./claimed.ts` and
   // `../mor1564-tx-family-conformance.isolated.test.ts`.
-  // MOR-1565 (C11) — VOX + CW — 12
-  ...tag([
-    'set_vox', 'set_vox_gain', 'set_anti_vox_gain', 'set_vox_delay',
-    'set_cw_pitch', 'set_key_speed', 'set_break_in', 'set_break_in_delay',
-    'set_apf', 'set_twin_peak', 'cw_auto_tune', 'set_dash_ratio',
-  ], VOX_CW),
+  // MOR-1565 (C11) — VOX + CW — CLAIMED, see `./claimed.ts` and
+  // `../mor1565-vox-cw-family-conformance.isolated.test.ts`.
   // MOR-1566 (C12) — scope remainder + VFO topology — 12 (set_scope_hold/
   // vfo_swap/vfo_equalize CLAIMED by MOR-1563's keyboard walk, see above)
   ...tag([
@@ -109,7 +107,7 @@ export const WAIVED_INTENTS: Readonly<Record<string, Waiver>> = {
 };
 
 /** Pinned so a removal (or an undocumented addition) shows up in review. */
-export const WAIVED_INTENTS_COUNT = 41;
+export const WAIVED_INTENTS_COUNT = 29;
 
 /**
  * `dispatchKeyboardRadioAction` case labels with no conformance assertion.

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1565-vox-cw-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1565-vox-cw-family-conformance.isolated.test.ts
@@ -1,0 +1,272 @@
+/**
+ * MOR-1565 (C11) — VOX/CW intent family conformance walk, over the same
+ * profile-parameterized harness MOR-1428/MOR-1555 established
+ * (`./conformance/harness.ts`, `./conformance/profiles.ts`).
+ *
+ * Family (per `waived.ts`'s MOR-1565 tag, 12 intents): `set_vox`,
+ * `set_vox_gain`, `set_anti_vox_gain`, `set_vox_delay`, `set_cw_pitch`,
+ * `set_key_speed`, `set_break_in`, `set_break_in_delay`, `set_apf`,
+ * `set_twin_peak`, `cw_auto_tune`, `set_dash_ratio` — dispatched from
+ * `makeVoxHandlers()` and `makeCwPanelHandlers()` in `panel-commands.ts`
+ * (plus `toggleVox`, a shared module-level function both `makeTxHandlers()`
+ * and `makeVoxHandlers()` expose as `onVoxToggle`).
+ *
+ * NOT UNIFORM (11 refuse, 1 dispatches — even more skewed than MOR-1560's
+ * DSP walk or MOR-1564's TX-chain walk): every field this family reads is
+ * unobserved on the real IC-7300 bench capture (`voxOn`, `voxGain`,
+ * `antiVoxGain`, `voxDelay`, `cwPitch`, `keySpeed`, `breakIn`,
+ * `breakInDelay`, `main.apfTypeLevel`, `main.twinPeakFilter`, `dashRatio` —
+ * all `fieldStatus.*.observed === false`), even though every base
+ * capability the family needs (`tx`, `vox`, `cw`, `break_in`, `apf`,
+ * `twin_peak`) IS declared on this profile — the same MOR-988 §3.2
+ * fail-closed shape MOR-1560's DSP walk already established: capability
+ * present, sub-parameter never confirmed on the bench, so the handler
+ * refuses. `cw_auto_tune` is the sole exception: `onAutoTune`'s gate
+ * (`hasCapability('cw') && knownActiveReceiver() !== null`) never inspects
+ * ANY field-status leaf at all — it fires on capability + receiver-identity
+ * resolution alone, both of which this profile satisfies
+ * (`vfoScheme: 'ab'`, `receivers: 1`, `state.main` present) — so it
+ * genuinely DISPATCHES. Every refusal/dispatch below is read directly off
+ * the real IC-7300 fixture's `fieldStatus`/`capabilities`, never invented.
+ *
+ * GATE-CONSISTENCY FINDINGS (per this ticket's instruction to pin, not
+ * fix — MOR-1576 class is "same intent alive on one path, dead on
+ * another"; C10's `set_monitor_gain` walk is the precedent for a case that
+ * WAS asymmetric): three intents in this family have two dispatch call
+ * sites each, and unlike `set_monitor_gain`, all three are CONSISTENT —
+ * (1) `set_vox`: `makeTxHandlers().onVoxToggle` and
+ * `makeVoxHandlers().onVoxToggle` are both literally the module-level
+ * `toggleVox` function reference (not two independent closures with
+ * possibly-different gates) — asserted via `toBe` identity below, the
+ * strongest form of "these can never drift apart" a test can state; (2)
+ * `set_cw_pitch`: `onCwPitchChange` (CW panel's own pitch slider) and
+ * `onSidetonePitchChange` (a sidetone-pitch alias) have byte-identical
+ * bodies (`hasCapability('cw') && knownTopLevelField('cwPitch') &&
+ * Number.isSafeInteger(value)`, read off `panel-commands.ts:494-497` and
+ * `:540-543`); (3) `set_key_speed`: `onKeySpeedChange` and `onWpmChange`
+ * (`:498-501`, `:531-534`) are likewise byte-identical. `set_break_in`'s two
+ * call sites (`onBreakInToggle`/`onBreakInModeChange`) share the SAME
+ * capability+field-observation gate (`hasCapability('cw') &&
+ * hasCapability('break_in') && knownTopLevelField('breakIn')`) but differ
+ * in which value they additionally range-check (`onBreakInToggle` checks
+ * the CURRENT state value is a safe integer; `onBreakInModeChange` checks
+ * the CALLER-SUPPLIED mode) — a cosmetic difference only, since on this
+ * fixture `knownTopLevelField('breakIn')` alone already blocks both paths.
+ * `set_monitor_gain`'s own CW-sidetone leg (`onSidetoneLevelChange`, the
+ * ACTUAL MOR-1576-class asymmetry versus its TX-panel sibling) was already
+ * claimed by MOR-1564/C10 — out of this family's 12-intent scope, per
+ * `waived.ts`'s own tag list.
+ *
+ * DECLARED-DOMAIN WALKS: `set_cw_pitch` has a capability-declared numeric
+ * range on this profile (`IC7300_CAPABILITIES.controls.cw_pitch`,
+ * display 300-900 Hz) that happens to match `CwPanel.svelte`'s own pitch
+ * slider domain exactly (`min={300} max={900}`) — walked at its min/mid/max.
+ * `set_vox_gain`/`set_anti_vox_gain`/`set_key_speed`/`set_break_in_delay`
+ * have NO declared range in this profile's `caps.controls` (verified via
+ * `toBeUndefined()` below) and no `CONTROL_DEFAULTS` entry either (that
+ * table only covers `nr_level`/`nb_level`, so `controlRangeFromCapsOrDefault`
+ * would throw for these keys) — each is walked at its own PRODUCTION
+ * fallback domain instead, read directly off the real slider markup:
+ * `VoxPanel.svelte` (`onVoxGainChange`/`onAntiVoxGainChange`: min=0 max=255;
+ * `onVoxDelayChange`: min=0 max=20) and `CwPanel.svelte`
+ * (`onKeySpeedChange`/`onWpmChange`: min=6 max=48;
+ * `onBreakInDelayChange`: min=0 max=255) — never a test-invented number.
+ * `set_apf`/`set_break_in`/`set_dash_ratio` are effectively BINARY
+ * (mode/ratio toggles between two fixed values in their own handler body,
+ * not a UI range slider) and get one representative case each; `set_vox`/
+ * `set_twin_peak` are booleans (one case each); `cw_auto_tune` takes no
+ * params at all.
+ *
+ * RED-FIRST EVIDENCE (MOR-1565 build process, not part of this diff): the
+ * `cw_auto_tune` dispatch case below was first authored as
+ * `expectFrames(() => makeCwPanelHandlers().onAutoTune(), [['cw_auto_tune',
+ * { receiver: 0 }]])` — a deliberately wrong claimed params shape (the real
+ * intent takes no params at all, per `radio-intents.ts`'s own
+ * `{ names: ['cw_auto_tune', ...], params: {} }` spec). `vitest run` on
+ * that version failed with `expected [ [ 'cw_auto_tune', {} ] ] to deeply
+ * equal [ [ 'cw_auto_tune', { receiver: 0 } ] ]` (RED — the real dispatch
+ * carries an empty params object, not the fabricated `{ receiver: 0 }`).
+ * Replacing the claim with `{}` turned it GREEN.
+ *
+ * DISCRIMINATION EVIDENCE (MOR-1565 build process, not part of this diff):
+ * to prove the `set_vox_gain` refusal below isn't vacuous, its gate was
+ * scratch-flipped locally — `h.state.fieldStatus.voxGain` temporarily set
+ * to `{ availability: 'available', observed: true, freshness: 'fresh' }`
+ * before calling `onVoxGainChange(128)` — and the refusal assertion then
+ * FAILED (the handler dispatched `set_vox_gain` with `{ level: 128 }`),
+ * confirming the assertion genuinely depends on that one field-status gate.
+ * The scratch edit was staged (`git add`) in its clean form first, then
+ * reverted with `git checkout --` (not `git stash`) after observing the
+ * failure, restoring the green state before this file was committed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  expectFrames,
+  expectRefusal,
+  fixtureCaps,
+  fixtureState,
+  h,
+} from './conformance/harness';
+import { PROFILES } from './conformance/profiles';
+import { makeCwPanelHandlers, makeTxHandlers, makeVoxHandlers } from '../../commands/panel-commands';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+
+const profile = PROFILES.ic7300;
+const IC7300_STATE = profile.state;
+const IC7300_CAPABILITIES = profile.caps;
+
+describe('IC-7300 fixture — VOX/CW family conformance (MOR-1565)', () => {
+  beforeEach(() => {
+    h.state = fixtureState(profile);
+    h.caps = fixtureCaps(profile);
+    h.sendCommand.mockClear();
+  });
+
+  afterEach(() => {
+    resetCommandLifecycle();
+  });
+
+  describe('set_vox — shared toggleVox function across two call sites (gate-consistency finding 1, see file header)', () => {
+    it("makeTxHandlers().onVoxToggle and makeVoxHandlers().onVoxToggle are the SAME function reference — not a MOR-1576-class split", () => {
+      expect(makeTxHandlers().onVoxToggle).toBe(makeVoxHandlers().onVoxToggle);
+    });
+
+    it('voxOn is unobserved on this fixture: REFUSES via both call sites', () => {
+      expect(IC7300_CAPABILITIES.capabilities).toContain('tx');
+      expect(IC7300_CAPABILITIES.capabilities).toContain('vox');
+      expect(IC7300_STATE.fieldStatus?.voxOn?.observed).toBe(false);
+      expectRefusal(() => makeTxHandlers().onVoxToggle());
+      expectRefusal(() => makeVoxHandlers().onVoxToggle());
+    });
+  });
+
+  describe("set_vox_gain — boundary walk over VoxPanel.svelte's own slider domain (min=0 max=255; no declared caps range on this profile — discrimination case, see file header)", () => {
+    it('vox_gain has no declared caps range on this profile; voxGain itself is unobserved', () => {
+      expect(IC7300_CAPABILITIES.controls?.vox_gain).toBeUndefined();
+      expect(IC7300_STATE.fieldStatus?.voxGain?.observed).toBe(false);
+    });
+
+    for (const level of [0, 128, 255]) {
+      it(`level=${level}: REFUSES`, () => {
+        expectRefusal(() => makeVoxHandlers().onVoxGainChange(level));
+      });
+    }
+  });
+
+  describe("set_anti_vox_gain — boundary walk over VoxPanel.svelte's own slider domain (min=0 max=255; same shape as set_vox_gain)", () => {
+    it('anti_vox_gain has no declared caps range on this profile; antiVoxGain itself is unobserved', () => {
+      expect(IC7300_CAPABILITIES.controls?.anti_vox_gain).toBeUndefined();
+      expect(IC7300_STATE.fieldStatus?.antiVoxGain?.observed).toBe(false);
+    });
+
+    for (const level of [0, 128, 255]) {
+      it(`level=${level}: REFUSES`, () => {
+        expectRefusal(() => makeVoxHandlers().onAntiVoxGainChange(level));
+      });
+    }
+  });
+
+  describe("set_vox_delay — boundary walk over VoxPanel.svelte's own slider domain (min=0 max=20; no declared caps range on this profile)", () => {
+    it('vox_delay has no declared caps range on this profile; voxDelay itself is unobserved', () => {
+      expect(IC7300_CAPABILITIES.controls?.vox_delay).toBeUndefined();
+      expect(IC7300_STATE.fieldStatus?.voxDelay?.observed).toBe(false);
+    });
+
+    for (const level of [0, 10, 20]) {
+      it(`level=${level}: REFUSES`, () => {
+        expectRefusal(() => makeVoxHandlers().onVoxDelayChange(level));
+      });
+    }
+  });
+
+  describe("set_cw_pitch — two call sites (gate-consistency finding 2, see file header), boundary walk over the DECLARED caps domain (matches CwPanel.svelte's own slider exactly)", () => {
+    it('cw_pitch declares a usable range on this profile, matching the production slider domain (300-900 Hz)', () => {
+      expect(IC7300_CAPABILITIES.controls?.cw_pitch).toEqual({
+        raw_min: 0, raw_max: 255, display_min: 300, display_max: 900, display_unit: 'Hz',
+      });
+      expect(IC7300_STATE.fieldStatus?.cwPitch?.observed).toBe(false);
+    });
+
+    for (const value of [300, 600, 900]) {
+      it(`value=${value} Hz: REFUSES via onCwPitchChange`, () => {
+        expectRefusal(() => makeCwPanelHandlers().onCwPitchChange(value));
+      });
+    }
+
+    it('onSidetonePitchChange: REFUSES via the same gate (byte-identical body to onCwPitchChange — not a MOR-1576-class split)', () => {
+      expectRefusal(() => makeCwPanelHandlers().onSidetonePitchChange(600));
+    });
+  });
+
+  describe("set_key_speed — two call sites (gate-consistency finding 3, see file header), boundary walk over CwPanel.svelte's own slider domain (min=6 max=48; no declared caps range on this profile)", () => {
+    it('key_speed has no declared caps range on this profile; keySpeed itself is unobserved', () => {
+      expect(IC7300_CAPABILITIES.controls?.key_speed).toBeUndefined();
+      expect(IC7300_STATE.fieldStatus?.keySpeed?.observed).toBe(false);
+    });
+
+    for (const speed of [6, 27, 48]) {
+      it(`speed=${speed} WPM: REFUSES via onKeySpeedChange`, () => {
+        expectRefusal(() => makeCwPanelHandlers().onKeySpeedChange(speed));
+      });
+    }
+
+    it('onWpmChange: REFUSES via the same gate (byte-identical body to onKeySpeedChange — not a MOR-1576-class split)', () => {
+      expectRefusal(() => makeCwPanelHandlers().onWpmChange(27));
+    });
+  });
+
+  describe('set_break_in — two call sites sharing the same capability+field-observation gate, differing only in which value they additionally range-check (see file header)', () => {
+    it('break_in capability is present; breakIn itself is unobserved: REFUSES via both call sites', () => {
+      expect(IC7300_CAPABILITIES.capabilities).toContain('cw');
+      expect(IC7300_CAPABILITIES.capabilities).toContain('break_in');
+      expect(IC7300_STATE.fieldStatus?.breakIn?.observed).toBe(false);
+      expectRefusal(() => makeCwPanelHandlers().onBreakInToggle());
+      expectRefusal(() => makeCwPanelHandlers().onBreakInModeChange(1));
+    });
+  });
+
+  describe("set_break_in_delay — boundary walk over CwPanel.svelte's own slider domain (min=0 max=255; no declared caps range on this profile)", () => {
+    it('break_in_delay has no declared caps range on this profile; breakInDelay itself is unobserved', () => {
+      expect(IC7300_CAPABILITIES.controls?.break_in_delay).toBeUndefined();
+      expect(IC7300_STATE.fieldStatus?.breakInDelay?.observed).toBe(false);
+    });
+
+    for (const level of [0, 128, 255]) {
+      it(`level=${level}: REFUSES`, () => {
+        expectRefusal(() => makeCwPanelHandlers().onBreakInDelayChange(level));
+      });
+    }
+  });
+
+  it("set_apf: REFUSES — main.apfTypeLevel is unobserved (onApfChange is the only dispatch site; mode is a binary toggle in CwPanel.svelte's own handler, not a range slider)", () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('cw');
+    expect(IC7300_CAPABILITIES.capabilities).toContain('apf');
+    expect(IC7300_STATE.fieldStatus?.['main.apfTypeLevel']?.observed).toBe(false);
+    expectRefusal(() => makeCwPanelHandlers().onApfChange(1));
+  });
+
+  it("set_twin_peak: REFUSES — main.twinPeakFilter is unobserved (onTwinPeakToggle is the only dispatch site for this intent; the CW-sidetone-gain leg of the CW panel, set_monitor_gain via onSidetoneLevelChange, is a DIFFERENT intent already claimed by MOR-1564/C10 — out of this family's scope)", () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('twin_peak');
+    expect(IC7300_STATE.fieldStatus?.['main.twinPeakFilter']?.observed).toBe(false);
+    expectRefusal(() => makeCwPanelHandlers().onTwinPeakToggle());
+  });
+
+  describe('cw_auto_tune — the one genuine DISPATCH in this family (RED-FIRST evidence in file header)', () => {
+    it('gate is capability + receiver-identity ONLY — no field-status leaf is ever checked, unlike every other CW intent in this family', () => {
+      expect(IC7300_CAPABILITIES.capabilities).toContain('cw');
+      expect(IC7300_CAPABILITIES.vfoScheme).toBe('ab');
+      expect(IC7300_CAPABILITIES.receivers).toBe(1);
+      expect(IC7300_STATE.main).toBeTruthy();
+    });
+
+    it('DISPATCHES cw_auto_tune with an empty params object', () => {
+      expectFrames(() => makeCwPanelHandlers().onAutoTune(), [['cw_auto_tune', {}]]);
+    });
+  });
+
+  it("set_dash_ratio: REFUSES — dashRatio is unobserved (onReversePaddleToggle is the only dispatch site; ratio toggles between two fixed values, 0/-1, in its own handler body, not a range slider)", () => {
+    expect(IC7300_CAPABILITIES.capabilities).toContain('cw');
+    expect(IC7300_STATE.fieldStatus?.dashRatio?.observed).toBe(false);
+    expectRefusal(() => makeCwPanelHandlers().onReversePaddleToggle());
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1565-vox-cw-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1565-vox-cw-family-conformance.isolated.test.ts
@@ -22,12 +22,37 @@
  * fail-closed shape MOR-1560's DSP walk already established: capability
  * present, sub-parameter never confirmed on the bench, so the handler
  * refuses. `cw_auto_tune` is the sole exception: `onAutoTune`'s gate
- * (`hasCapability('cw') && knownActiveReceiver() !== null`) never inspects
- * ANY field-status leaf at all — it fires on capability + receiver-identity
- * resolution alone, both of which this profile satisfies
- * (`vfoScheme: 'ab'`, `receivers: 1`, `state.main` present) — so it
- * genuinely DISPATCHES. Every refusal/dispatch below is read directly off
- * the real IC-7300 fixture's `fieldStatus`/`capabilities`, never invented.
+ * (`hasCapability('cw') && knownActiveReceiver() !== null`) genuinely
+ * DISPATCHES on this profile — but NOT because it skips field-status
+ * checks entirely. CORRECTION (verifier-caught, first draft of this file
+ * claimed the gate "never inspects any field-status leaf", which is FALSE):
+ * `knownActiveReceiver()` (`panel-commands.ts:52`) DOES read one leaf —
+ * `isFieldAvailable(state, 'active')` — and `active` is itself unobserved
+ * on this fixture (pinned below). The reason the gate still resolves a
+ * receiver despite that is MOR-1418's single-receiver carve-out
+ * (`panel-commands.ts:44-51`, `:53-55`): with `caps.receivers === 1`, an
+ * unobserved `active` falls through to a hardcoded `'MAIN'` instead of
+ * blocking. This carve-out is profile-specific, not a property of
+ * `cw_auto_tune`'s gate shape — on a dual-RX profile with `active`
+ * unobserved and no explicit target, `knownActiveReceiver()` returns
+ * `undefined` → `null`, and `onAutoTune` REFUSES (verified: with
+ * `caps.receivers = 2` and a `sub` receiver present, keeping `active`
+ * unobserved, `onAutoTune` refuses — not walked as its own case here since
+ * this suite is IC-7300-only, but stated for the record so this profile's
+ * dispatch isn't mistaken for a property of the intent itself).
+ *
+ * RISK (MOR-1578 leg 4): `cw_auto_tune` is a TRANSMIT-CAUSING action.
+ * `SemanticRadioSurfaces.svelte:336-340` deliberately leaves `onAutoTune`
+ * UNWIRED — its own comment cites the MOR-1244 ATU-TUNE precedent for
+ * withholding transmit-causing controls from that surface. `CwPanel.svelte`
+ * (`:130-132`, the `AUTO TUNE` `HardwareButton`) wires it directly with no
+ * such guard. Both paths reach the identical `onAutoTune()` handler and the
+ * identical `cw_auto_tune` gate; the asymmetry is in which UI SURFACE
+ * exposes the control, not in the gate this walk conformance-tests. Pinned
+ * per this ticket's instruction to report, not fix.
+ *
+ * Every refusal/dispatch below is read directly off the real IC-7300
+ * fixture's `fieldStatus`/`capabilities`, never invented.
  *
  * GATE-CONSISTENCY FINDINGS (per this ticket's instruction to pin, not
  * fix — MOR-1576 class is "same intent alive on one path, dead on
@@ -43,8 +68,13 @@
  * `onSidetonePitchChange` (a sidetone-pitch alias) have byte-identical
  * bodies (`hasCapability('cw') && knownTopLevelField('cwPitch') &&
  * Number.isSafeInteger(value)`, read off `panel-commands.ts:494-497` and
- * `:540-543`); (3) `set_key_speed`: `onKeySpeedChange` and `onWpmChange`
- * (`:498-501`, `:531-534`) are likewise byte-identical. `set_break_in`'s two
+ * `:540-543`) — PINNED below via `expect(String(hs.onCwPitchChange)).toBe(
+ * String(hs.onSidetonePitchChange))`, not just matching observed refusal
+ * behavior (a first draft of this file asserted refusal-only here, which
+ * stays green even if the two gates later diverge — verifier-caught); (3)
+ * `set_key_speed`: `onKeySpeedChange` and `onWpmChange` (`:498-501`,
+ * `:531-534`) are likewise byte-identical and likewise PINNED via the same
+ * `String(...)` identity pattern below. `set_break_in`'s two
  * call sites (`onBreakInToggle`/`onBreakInModeChange`) share the SAME
  * capability+field-observation gate (`hasCapability('cw') &&
  * hasCapability('break_in') && knownTopLevelField('breakIn')`) but differ
@@ -64,9 +94,10 @@
  * `set_vox_gain`/`set_anti_vox_gain`/`set_key_speed`/`set_break_in_delay`
  * have NO declared range in this profile's `caps.controls` (verified via
  * `toBeUndefined()` below) and no `CONTROL_DEFAULTS` entry either (that
- * table only covers `nr_level`/`nb_level`, so `controlRangeFromCapsOrDefault`
- * would throw for these keys) — each is walked at its own PRODUCTION
- * fallback domain instead, read directly off the real slider markup:
+ * table only covers `nr_level`/`nb_depth` — `filter-controls.ts:122-125` —
+ * so `controlRangeFromCapsOrDefault` would throw for these keys) — each is
+ * walked at its own PRODUCTION fallback domain instead, read directly off
+ * the real slider markup:
  * `VoxPanel.svelte` (`onVoxGainChange`/`onAntiVoxGainChange`: min=0 max=255;
  * `onVoxDelayChange`: min=0 max=20) and `CwPanel.svelte`
  * (`onKeySpeedChange`/`onWpmChange`: min=6 max=48;
@@ -83,10 +114,12 @@
  * { receiver: 0 }]])` — a deliberately wrong claimed params shape (the real
  * intent takes no params at all, per `radio-intents.ts`'s own
  * `{ names: ['cw_auto_tune', ...], params: {} }` spec). `vitest run` on
- * that version failed with `expected [ [ 'cw_auto_tune', {} ] ] to deeply
- * equal [ [ 'cw_auto_tune', { receiver: 0 } ] ]` (RED — the real dispatch
- * carries an empty params object, not the fabricated `{ receiver: 0 }`).
- * Replacing the claim with `{}` turned it GREEN.
+ * that version failed (verbatim vitest 4 output, not paraphrased):
+ * `AssertionError: expected [ [ 'cw_auto_tune', {} ] ] to deeply equal [
+ * Array(1) ]` followed by a diff showing `- { "receiver": 0 }` / `+ {}` for
+ * the params object (RED — the real dispatch carries an empty params
+ * object, not the fabricated `{ receiver: 0 }`). Replacing the claim with
+ * `{}` turned it GREEN.
  *
  * DISCRIMINATION EVIDENCE (MOR-1565 build process, not part of this diff):
  * to prove the `set_vox_gain` refusal below isn't vacuous, its gate was
@@ -193,8 +226,10 @@ describe('IC-7300 fixture — VOX/CW family conformance (MOR-1565)', () => {
       });
     }
 
-    it('onSidetonePitchChange: REFUSES via the same gate (byte-identical body to onCwPitchChange — not a MOR-1576-class split)', () => {
-      expectRefusal(() => makeCwPanelHandlers().onSidetonePitchChange(600));
+    it('onSidetonePitchChange: REFUSES via the same gate, and its source IS pinned byte-identical to onCwPitchChange (source-string identity, not just matching observed behavior — not a MOR-1576-class split)', () => {
+      const hs = makeCwPanelHandlers();
+      expect(String(hs.onCwPitchChange)).toBe(String(hs.onSidetonePitchChange));
+      expectRefusal(() => hs.onSidetonePitchChange(600));
     });
   });
 
@@ -210,8 +245,10 @@ describe('IC-7300 fixture — VOX/CW family conformance (MOR-1565)', () => {
       });
     }
 
-    it('onWpmChange: REFUSES via the same gate (byte-identical body to onKeySpeedChange — not a MOR-1576-class split)', () => {
-      expectRefusal(() => makeCwPanelHandlers().onWpmChange(27));
+    it('onWpmChange: REFUSES via the same gate, and its source IS pinned byte-identical to onKeySpeedChange (source-string identity, not just matching observed behavior — not a MOR-1576-class split)', () => {
+      const hs = makeCwPanelHandlers();
+      expect(String(hs.onKeySpeedChange)).toBe(String(hs.onWpmChange));
+      expectRefusal(() => hs.onWpmChange(27));
     });
   });
 
@@ -251,12 +288,17 @@ describe('IC-7300 fixture — VOX/CW family conformance (MOR-1565)', () => {
     expectRefusal(() => makeCwPanelHandlers().onTwinPeakToggle());
   });
 
-  describe('cw_auto_tune — the one genuine DISPATCH in this family (RED-FIRST evidence in file header)', () => {
-    it('gate is capability + receiver-identity ONLY — no field-status leaf is ever checked, unlike every other CW intent in this family', () => {
+  describe('cw_auto_tune — the one genuine DISPATCH in this family (RED-FIRST evidence in file header; MOR-1578 leg 4 risk finding, see file header)', () => {
+    it("gate reads exactly one field-status leaf, 'active' — unobserved on this fixture, but MOR-1418's single-receiver carve-out (caps.receivers===1) neutralizes it, so onAutoTune still resolves a receiver and dispatches (see file header CORRECTION — the gate is NOT field-status-check-free)", () => {
       expect(IC7300_CAPABILITIES.capabilities).toContain('cw');
       expect(IC7300_CAPABILITIES.vfoScheme).toBe('ab');
       expect(IC7300_CAPABILITIES.receivers).toBe(1);
       expect(IC7300_STATE.main).toBeTruthy();
+      // Pins the carve-out itself, not just its downstream effect: `active`
+      // genuinely IS unobserved on this fixture — the dispatch below only
+      // happens because MOR-1418's single-receiver fallback bypasses this,
+      // not because the gate has no field-status leaf to check at all.
+      expect(IC7300_STATE.fieldStatus?.active?.observed).toBe(false);
     });
 
     it('DISPATCHES cw_auto_tune with an empty params object', () => {


### PR DESCRIPTION
## Summary

C11 of the MOR-1426 conformance program: walks all 12 MOR-1565-tagged VOX/CW intents through the profile-parameterized harness (`./conformance/harness.ts`) against the registered IC-7300 fixture, following the pattern established by #2479-#2483 (MOR-1560/1561/1563/1564).

Moves the 12 intents from `WAIVED_INTENTS` to `CLAIMED_INTENTS`: **41→29 waived, 46→58 claimed.**

## Per-intent table

| Intent | Call site(s) | Result on IC-7300 fixture | Firing gate |
|---|---|---|---|
| `set_vox` | `makeTxHandlers().onVoxToggle` / `makeVoxHandlers().onVoxToggle` (same `toggleVox` reference) | REFUSE | `voxOn` unobserved |
| `set_vox_gain` | `makeVoxHandlers().onVoxGainChange` | REFUSE (0/128/255 walked) | `voxGain` unobserved |
| `set_anti_vox_gain` | `makeVoxHandlers().onAntiVoxGainChange` | REFUSE (0/128/255 walked) | `antiVoxGain` unobserved |
| `set_vox_delay` | `makeVoxHandlers().onVoxDelayChange` | REFUSE (0/10/20 walked) | `voxDelay` unobserved |
| `set_cw_pitch` | `onCwPitchChange` / `onSidetonePitchChange` (byte-identical gate) | REFUSE (300/600/900 Hz walked — declared caps domain) | `cwPitch` unobserved |
| `set_key_speed` | `onKeySpeedChange` / `onWpmChange` (byte-identical gate) | REFUSE (6/27/48 WPM walked) | `keySpeed` unobserved |
| `set_break_in` | `onBreakInToggle` / `onBreakInModeChange` (same gate, different value source) | REFUSE (both call sites) | `breakIn` unobserved |
| `set_break_in_delay` | `onBreakInDelayChange` | REFUSE (0/128/255 walked) | `breakInDelay` unobserved |
| `set_apf` | `onApfChange` | REFUSE | `main.apfTypeLevel` unobserved |
| `set_twin_peak` | `onTwinPeakToggle` | REFUSE | `main.twinPeakFilter` unobserved |
| `cw_auto_tune` | `onAutoTune` | **DISPATCH** — `['cw_auto_tune', {}]` | reads one field-status leaf (`active`, unobserved on this fixture); MOR-1418's single-receiver carve-out (`caps.receivers === 1`) neutralizes it, falling through to `'MAIN'` instead of refusing — on a dual-RX profile with `active` unobserved the same gate refuses |
| `set_dash_ratio` | `onReversePaddleToggle` | REFUSE | `dashRatio` unobserved |

11 of the 12 refuse (every field this family reads is unobserved on the real bench capture, even though every base capability — `tx`, `vox`, `cw`, `break_in`, `apf`, `twin_peak` — is declared). `cw_auto_tune` is the sole dispatch — **not** because its gate skips field-status checks (an earlier draft of this PR claimed that; corrected below), but because the one leaf it does read is neutralized by a profile-specific carve-out.

**Risk (MOR-1578 leg 4, pinned not fixed):** `cw_auto_tune` is a transmit-causing action. `SemanticRadioSurfaces.svelte:336-340` deliberately leaves `onAutoTune` unwired, citing the MOR-1244 ATU-TUNE precedent for withholding transmit-causing controls from that surface. `CwPanel.svelte:130-132` (the `AUTO TUNE` button) wires it directly with no such guard. Both paths reach the identical handler/gate — the asymmetry is which UI surface exposes the control, not the gate this walk tests.

## Gate-consistency findings (MOR-1576 class, pinned per instruction — not fixed)

Checked all three multi-call-site intents in this family for panel-vs-other-path gate divergence (the class C10's `set_monitor_gain` finding demonstrated). All three are **consistent** here, unlike `set_monitor_gain`:

- `set_vox`: `makeTxHandlers().onVoxToggle` and `makeVoxHandlers().onVoxToggle` are literally the same `toggleVox` function reference — asserted via `toBe` identity.
- `set_cw_pitch`: `onCwPitchChange` and `onSidetonePitchChange` have byte-identical gate bodies — asserted via `expect(String(hs.onCwPitchChange)).toBe(String(hs.onSidetonePitchChange))`.
- `set_key_speed`: `onKeySpeedChange` and `onWpmChange` have byte-identical gate bodies — asserted via the same `String(...)` identity pattern.

`set_monitor_gain`'s own CW-sidetone leg (`onSidetoneLevelChange`) — the actual MOR-1576-class asymmetry versus its TX-panel sibling — is a different intent, already claimed in MOR-1564/C10, out of this family's 12-intent scope.

## Red-first evidence

`cw_auto_tune`'s dispatch case was first authored with a deliberately wrong claimed params shape (`{ receiver: 0 }` instead of the real `{}`). Verbatim vitest 4 output:

```
AssertionError: expected [ [ 'cw_auto_tune', {} ] ] to deeply equal [ Array(1) ]

- Expected
+ Received

  [
    [
      "cw_auto_tune",
-     {
-       "receiver": 0,
-     },
+     {},
    ],
  ]
```

RED — the real dispatch carries an empty params object. Replacing the claim with `{}` turned it GREEN (both runs captured verbatim in the test file's header comment).

## Discrimination evidence

To prove the `set_vox_gain` refusal isn't vacuous, its gate was scratch-flipped locally (`h.state.fieldStatus.voxGain` set to observed/available/fresh) — the refusal assertion then FAILED, confirming genuine dependence on that one field-status gate. Reverted via `git checkout --` (not `git stash`) after staging the clean version first.

## Test plan

- [x] `npx vitest run` on the new file, the completeness meta-test, the MOR-1428 exemplar, and MOR-1564 (prior walk regression) — 101/101 green
- [x] `npx eslint` on all changed files — clean
- [x] `npx eslint` on `lint:boundaries` scope (panels/layout/presentation) — unaffected, clean
- [x] `npx svelte-check` + `tsc -p tsconfig.node.json` — 0 errors
- [x] Boundary grep (internal host/IP/user markers) over the diff — empty

## Review follow-up (independent review, applied same PR)

**B1 — `cw_auto_tune` headline was false.** The original PR claimed the gate "never inspects ANY field-status leaf" in four places (test header, test name, `claimed.ts`, this PR body). Wrong: `knownActiveReceiver()` (`panel-commands.ts:52`) reads `isFieldAvailable(state, 'active')`; `active` is unobserved on this fixture same as every sibling leaf, but MOR-1418's single-receiver carve-out (`caps.receivers === 1`, `panel-commands.ts:53-55`) neutralizes it, falling through to a hardcoded `'MAIN'`. Verified: with `caps.receivers = 2` and a `sub` receiver present (keeping `active` unobserved), `onAutoTune` REFUSES. Reworded all four sites to state the correction, added `expect(IC7300_STATE.fieldStatus?.active?.observed).toBe(false)` to pin the carve-out rather than silently relying on it, and added the MOR-1578 leg 4 risk note (`cw_auto_tune` is transmit-causing; `CwPanel.svelte:130-132` wires it with no MOR-1244-style guard, unlike `SemanticRadioSurfaces.svelte:336-340`, which deliberately leaves it unwired).

**B2 — "byte-identical … pinned as positive findings" wasn't actually pinned for two of the three.** Only `set_vox` had a `toBe` reference-identity assertion; `onSidetonePitchChange`/`onWpmChange` asserted refusal behavior only, which would stay green even if their gates later diverged from `onCwPitchChange`/`onKeySpeedChange`. Added `expect(String(hs.onCwPitchChange)).toBe(String(hs.onSidetonePitchChange))` and `expect(String(hs.onKeySpeedChange)).toBe(String(hs.onWpmChange))` — both pass, genuinely pinning the source-level identity now.

**Non-blocking:** fixed a `CONTROL_DEFAULTS` key typo in the header (`nb_level` → `nb_depth`, matching `filter-controls.ts:122-125`) and replaced the paraphrased RED-FIRST quote above with the verbatim vitest 4 assertion output.

Re-ran the full targeted suite (101/101 green) and eslint (clean) after applying all of the above; boundary grep re-checked clean on the full branch diff.

Closes MOR-1565