### PR TITLE
fix: gate RIT/XIT props on field availability (MOR-1574)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
@@ -308,17 +308,18 @@ describe('panel-adapters.ts derive*Props over the live ic7300 fixture (MOR-1562)
     });
   });
 
-  // MOR-1574 (filed off this walk): unlike toAgcProps/toRfFrontEndProps,
-  // `toRitXitProps` (panel-props.ts:482-494) has NO fieldStatus gate on
-  // ritOn/ritFreq/ritTx — pinned CURRENT baseline, not an endorsement;
-  // update once MOR-1574 lands.
-  it('deriveRitXitProps: pins the current un-gated reading — production honesty gap tracked as MOR-1574', () => {
+  // MOR-1574 (filed off this walk, now landed): `toRitXitProps`
+  // (panel-props.ts) gates `hasRit`/`hasXit` on field availability the same
+  // way `toAgcProps`/`toRfFrontEndProps` already did — an unobserved
+  // ritOn/ritFreq/ritTx (this stand's exact shape) no longer reads back as a
+  // confirmed "RIT/XIT OFF"; the panel now hides instead.
+  it('deriveRitXitProps: honest RIT/XIT refusal — capability declared, fields never observed on this stand', () => {
     expect(IC7300_STATE.fieldStatus?.ritOn?.observed).toBe(false);
     expect(IC7300_STATE.fieldStatus?.ritFreq?.observed).toBe(false);
     expect(IC7300_STATE.fieldStatus?.ritTx?.observed).toBe(false);
     expect(deriveRitXitProps()).toEqual({
-      ritActive: false, ritOffset: 0, xitActive: false, xitOffset: 0,
-      hasRit: true, hasXit: true,
+      ritActive: false, ritOffset: Number.NaN, xitActive: false, xitOffset: Number.NaN,
+      hasRit: false, hasXit: false,
     });
   });
 });

--- a/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/panel-props.test.ts
@@ -831,6 +831,83 @@ describe('A12 — batch-B projections do not fabricate defaults (MOR-1409)', () 
       expect(props.xitActive).toBe(true);
       expect(props.xitOffset).toBe(150);
     });
+
+    // MOR-1574: unlike every other batch-A/batch-B family (`toAgcProps`'
+    // `agcAvailable`, `toRfFrontEndProps`' `digiSelAvailable`/
+    // `ipPlusAvailable`), `toRitXitProps` shipped with NO fieldStatus gate at
+    // all — `hasRit`/`hasXit` checked capability presence only, so a
+    // connected radio that declares the `rit`/`xit` capability but has never
+    // actually reported `ritOn`/`ritFreq`/`ritTx` (the live ic7300 fixture's
+    // exact shape — all three `observed: false`/`availability: "missing"`)
+    // still rendered a confirmed-looking "RIT OFF" reading. Mirrors the
+    // `toAgcProps` fix's own idiom exactly: gate `hasRit`/`hasXit` on field
+    // availability the same way `hasAgc` gates on `agcAvailable`, and gate
+    // the numeric offsets to the standard `NaN` sentinel the same way
+    // `agcMode` does. `ritActive`/`xitActive` keep the plain-`boolean`
+    // non-fabrication contract from the test above (see its own comment for
+    // why the type cannot widen) — they stay protected behind the now-honest
+    // `hasRit`/`hasXit` visibility gate instead.
+    it('does not present an unobserved RIT/XIT as a confirmed reading (MOR-1574)', () => {
+      const props = toRitXitProps(
+        makeState({
+          ritOn: false,
+          ritFreq: 0,
+          ritTx: false,
+          fieldStatus: {
+            ritOn: fieldStatus('missing', false),
+            ritFreq: fieldStatus('missing', false),
+            ritTx: fieldStatus('missing', false),
+          },
+        }),
+        { capabilities: ['rit', 'xit'] } as any,
+      );
+      expect(props.hasRit).toBe(false);
+      expect(props.hasXit).toBe(false);
+      expect(props.ritOffset).toBeNaN();
+      expect(props.xitOffset).toBeNaN();
+    });
+
+    it('discriminates: the SAME capabilities with fieldStatus forced observed reports the real reading (MOR-1574)', () => {
+      const props = toRitXitProps(
+        makeState({
+          ritOn: true,
+          ritFreq: 250,
+          ritTx: true,
+          fieldStatus: {
+            ritOn: fieldStatus('available'),
+            ritFreq: fieldStatus('available'),
+            ritTx: fieldStatus('available'),
+          },
+        }),
+        { capabilities: ['rit', 'xit'] } as any,
+      );
+      expect(props.hasRit).toBe(true);
+      expect(props.hasXit).toBe(true);
+      expect(props.ritActive).toBe(true);
+      expect(props.ritOffset).toBe(250);
+      expect(props.xitActive).toBe(true);
+      expect(props.xitOffset).toBe(250);
+    });
+
+    it('treats a stale RIT/XIT reading as unavailable, same as missing (MOR-1574)', () => {
+      const props = toRitXitProps(
+        makeState({
+          ritOn: true,
+          ritFreq: 250,
+          ritTx: true,
+          fieldStatus: {
+            ritOn: fieldStatus('stale'),
+            ritFreq: fieldStatus('stale'),
+            ritTx: fieldStatus('stale'),
+          },
+        }),
+        { capabilities: ['rit', 'xit'] } as any,
+      );
+      expect(props.hasRit).toBe(false);
+      expect(props.hasXit).toBe(false);
+      expect(props.ritOffset).toBeNaN();
+      expect(props.xitOffset).toBeNaN();
+    });
   });
 
   describe('toModeProps modes catalog', () => {

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -471,6 +471,20 @@ export interface RitXitProps {
   // `mode ?? 'USB'` gate literal (plan §7 LOW item) — never a
   // plausible-looking *on* reading no one confirmed. `ritOffset`/
   // `xitOffset` still fix to the standard `NaN` sentinel.
+  //
+  // MOR-1574: A12 above fixed the fabricated *default* but left NO
+  // fieldStatus gate at all — a radio that declares the `rit`/`xit`
+  // capability but has never actually reported `ritOn`/`ritFreq`/`ritTx`
+  // (the live ic7300 fixture's exact shape) still passed `hasRit`/`hasXit`
+  // on capability presence alone, so the conservative-`false` reading above
+  // rendered as a CONFIRMED "RIT OFF" instead of an honest "unknown".
+  // `hasRit`/`hasXit` now gate on field availability too, mirroring
+  // `toAgcProps`' `hasAgc: hasCap(caps, 'agc') && agcAvailable` exactly —
+  // `ritActive`/`xitActive` stay the same plain-boolean raw values (still
+  // protected by the now-honest visibility gate, same as `digiSel`/
+  // `ipPlus` in `toRfFrontEndProps`), and `ritOffset`/`xitOffset` fix to
+  // `NaN` whenever their backing field is not available, same idiom as
+  // `agcMode`.
   ritActive: boolean;
   ritOffset: number;
   xitActive: boolean;
@@ -483,13 +497,16 @@ export function toRitXitProps(
   state: ServerState | null,
   caps: Capabilities | null,
 ): RitXitProps {
+  const ritOnAvailable = topFieldAvailable(state, 'ritOn');
+  const ritFreqAvailable = topFieldAvailable(state, 'ritFreq');
+  const ritTxAvailable = topFieldAvailable(state, 'ritTx');
   return {
     ritActive: state?.ritOn ?? false,
-    ritOffset: state?.ritFreq ?? Number.NaN,
+    ritOffset: ritFreqAvailable ? (state?.ritFreq ?? Number.NaN) : Number.NaN,
     xitActive: state?.ritTx ?? false,
-    xitOffset: state?.ritFreq ?? Number.NaN,
-    hasRit: hasCap(caps, 'rit'),
-    hasXit: hasCap(caps, 'xit'),
+    xitOffset: ritFreqAvailable ? (state?.ritFreq ?? Number.NaN) : Number.NaN,
+    hasRit: hasCap(caps, 'rit') && ritOnAvailable,
+    hasXit: hasCap(caps, 'xit') && ritTxAvailable,
   };
 }
 


### PR DESCRIPTION
## Summary

`toRitXitProps` (`frontend/src/lib/runtime/props/panel-props.ts`) had NO fieldStatus gate on `ritOn`/`ritFreq`/`ritTx`. Over the committed ic7300 fixture — `fieldStatus.ritOn`/`ritFreq`/`ritTx` all `observed: false` / `availability: "missing"` — it returned `hasRit: true, hasXit: true, ritActive: false, ritOffset: 0`, a confirmed-looking reading nobody had actually observed.

- Gate `hasRit`/`hasXit` on field availability, the same idiom `toAgcProps` already uses for `hasAgc: hasCap(caps, 'agc') && agcAvailable`.
- Fix `ritOffset`/`xitOffset` to the standard `NaN` sentinel whenever their backing `ritFreq` field is unavailable — the same ternary shape `agcMode` already uses.
- `ritActive`/`xitActive` keep their plain-`boolean` contract (unchanged raw expression) — `RitXitPanel.svelte`'s `HardwareButton active={…}` prop is typed `boolean | undefined`, and it is not a consumer this change is scoped to touch. They stay protected by the now-honest `hasRit`/`hasXit` visibility gate, mirroring `toRfFrontEndProps`' `digiSel`/`ipPlus` pattern.

Updates the MOR-1562 conformance pin (`mor1562-adapter-seams-conformance.isolated.test.ts`) that captured the old fabricating baseline over the live ic7300 fixture to the new honest refusal.

Closes MOR-1574

## Test plan

- [x] Red-first: added `panel-props.test.ts` cases proving the honesty gap over an explicitly-missing fieldStatus, ran RED against the pre-fix implementation (`hasRit`/`hasXit` came back `true` instead of the expected `false`)
- [x] Implemented the fix; same tests now GREEN
- [x] Discrimination flip test: same capabilities with fieldStatus forced `available` reports the real `ritActive`/`ritOffset`/`xitActive`/`xitOffset`/`hasRit`/`hasXit` values
- [x] Stale-fieldStatus case treated as unavailable, same as missing
- [x] `panel-props.no-fabricated-defaults.test.ts` (source-text pin gate) — unmodified, still green (the frozen `ritActive`/`xitActive` literal pins are untouched by this fix)
- [x] `mor1562-adapter-seams-conformance.isolated.test.ts` — updated pin, green
- [x] `rit-xit-adapter.test.ts` (semantic view-model parity) — green, unmodified
- [x] `RitXitPanel.isolated.test.ts`, `MobileRadioLayout.component.svelte.test.ts`, `RadioLayout.command-bus-migration.isolated.test.ts`, `AmberCockpit.qsy-authority.isolated.test.ts`, `VfoControlPanel.authority.isolated.test.ts`, `semantic-ritxit-scan-wiring.component.test.ts` — all green (checked every non-test consumer of `toRitXitProps`/`deriveRitXitProps`; none need a code change — `AmberCockpit.svelte` already NaN-guards its offset display via `Number.isFinite`, and every `hasRit`/`hasXit` consumer already treats it as a pure visibility gate)
- [x] `npx eslint` on touched files — clean
- [x] `npm run lint:boundaries` — clean
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings