### PR TITLE
fix: unify set_filter_width gating across call sites (MOR-1576)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1561-filter-pbt-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1561-filter-pbt-family-conformance.isolated.test.ts
@@ -7,24 +7,29 @@
  * `set_filter_shape`, `set_if_shift`, `set_pbt_inner`, `set_pbt_outer` — all
  * dispatched from `makeFilterHandlers()` in `panel-commands.ts`.
  *
- * UNLIKE MOR-1560's DSP walk (9/9 uniform refusals), this family is NOT
- * uniform: `set_filter_width` has FOUR distinct dispatch sites
- * (`onFilterWidthChange`, `onFilterWidthCommit`, `onFilterPresetChange`,
- * `onFilterDefaults`), and they do not all gate on the same field.
- * `onFilterWidthChange`/`onFilterDefaults` gate on `knownActiveReceiver('filterWidth')`
- * — `main.filterWidth` is unobserved on this fixture, so both refuse.
- * `onFilterPresetChange` gates on `knownActiveReceiver('filter')` instead
- * (`panel-commands.ts`'s own choice — it only needs to know the CURRENT
- * active filter slot to decide whether a `set_filter` bracket is needed, not
- * whether `filterWidth` itself was ever confirmed) — `main.filter` IS
- * observed on this fixture, so this path genuinely dispatches
- * `set_filter_width`. This is a real, profile-derived finding, not a test
- * artifact: the same live IC-7300 session that never confirmed
- * `filterWidth` readback still lets an operator push a width through the
- * settings-modal preset path today. `set_filter_shape`/`set_if_shift`/
- * `set_pbt_inner`/`set_pbt_outer` have no such split — each refuses through
- * its own single gate, named per case below and verified against the
- * fixture's own `fieldStatus`/`capabilities.controls` data (never invented).
+ * UNLIKE MOR-1560's DSP walk (9/9 uniform refusals), `set_filter_width` has
+ * FOUR distinct dispatch sites (`onFilterWidthChange`, `onFilterWidthCommit`,
+ * `onFilterPresetChange`, `onFilterDefaults`). Before MOR-1576,
+ * `onFilterWidthChange`/`onFilterDefaults` gated on
+ * `knownActiveReceiver('filterWidth')` — using the WRITTEN field as a
+ * receiver-identity proxy — while `onFilterPresetChange` gated on
+ * `knownActiveReceiver('filter')` instead (`panel-commands.ts`'s own
+ * choice — it only needs to know the CURRENT active filter slot to decide
+ * whether a `set_filter` bracket is needed, not whether `filterWidth` itself
+ * was ever confirmed). On this fixture `main.filterWidth` is unobserved but
+ * `main.filter` IS observed, so the two gates disagreed: the slider and
+ * "restore defaults" paths silently refused while the settings-modal preset
+ * path dispatched fine for the identical write. MOR-1576 (verifier analysis,
+ * PR #2481) relaxed the three strict sites to the preset path's gating —
+ * receiver identity via `knownActiveReceiver('filter')` plus mode/dataMode
+ * to resolve the quantization rule, not a confirmed prior `filterWidth`
+ * reading — so all three now dispatch identically on this fixture (see the
+ * "unified call-site gating" cases below, plus the discrimination case
+ * proving they still correctly refuse when `main.filter` itself is
+ * unobserved too). `set_filter_shape`/`set_if_shift`/`set_pbt_inner`/
+ * `set_pbt_outer` have no such split — each refuses through its own single
+ * gate, named per case below and verified against the fixture's own
+ * `fieldStatus`/`capabilities.controls` data (never invented).
  *
  * RED-FIRST EVIDENCE (MOR-1561 build process, not part of this diff): the
  * `onFilterPresetChange` case below was first authored as
@@ -79,19 +84,42 @@ describe('IC-7300 fixture — filter/PBT family conformance (MOR-1561)', () => {
     resetCommandLifecycle();
   });
 
-  describe('set_filter_width — divergent call-site gates on this profile (see file header)', () => {
-    it('onFilterWidthChange: REFUSES — main.filterWidth is unobserved (checked before the 200ms debounce even starts)', () => {
+  describe('set_filter_width — unified call-site gating on this profile (MOR-1576, see file header)', () => {
+    it('onFilterWidthChange: DISPATCHES — relaxed to knownActiveReceiver(\'filter\') like onFilterPresetChange; main.filterWidth stays unobserved on this fixture but is no longer the gate', () => {
       expect(IC7300_CAPABILITIES.capabilities).toContain('filter_width');
       expect(IC7300_STATE.fieldStatus?.['main.filterWidth']?.observed).toBe(false);
-      expectRefusal(() => makeFilterHandlers().onFilterWidthChange(1800));
+      expect(IC7300_STATE.fieldStatus?.['main.filter']?.observed).toBe(true);
+      // Fixture's own USB filter-width rule (rigs/ic7300.toml via
+      // filterConfig.USB): 1800 Hz already sits on the declared 100 Hz-step
+      // segment grid (600-3600), so quantizeFilterWidthToRule is a no-op.
+      vi.useFakeTimers();
+      try {
+        expectFrames(() => {
+          makeFilterHandlers().onFilterWidthChange(1800);
+          vi.advanceTimersByTime(200);
+        }, [['set_filter_width', { width: 1800, receiver: 0 }]]);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
-    it('onFilterDefaults: REFUSES — same knownActiveReceiver(\'filterWidth\') gate as onFilterWidthChange', () => {
+    it('onFilterDefaults: DISPATCHES — same relaxed knownActiveReceiver(\'filter\') gate as onFilterWidthChange', () => {
       expect(IC7300_STATE.fieldStatus?.['main.filterWidth']?.observed).toBe(false);
-      expectRefusal(() => makeFilterHandlers().onFilterDefaults([3000, 2400, 1800]));
+      expect(IC7300_STATE.fieldStatus?.['main.filter']?.observed).toBe(true);
+      expect(IC7300_STATE.main!.filter).toBe(1);
+      // filter=1 equals the fixture's own active filter, so slot 1 needs no
+      // bracketing set_filter, while slots 2/3 do (bracket-and-restore).
+      expectFrames(() => makeFilterHandlers().onFilterDefaults([3000, 2400, 1800]), [
+        ['set_filter_width', { width: 3000, receiver: 0 }],
+        ['set_filter', { filter: 2, receiver: 0 }],
+        ['set_filter_width', { width: 2400, receiver: 0 }],
+        ['set_filter', { filter: 3, receiver: 0 }],
+        ['set_filter_width', { width: 1800, receiver: 0 }],
+        ['set_filter', { filter: 1, receiver: 0 }],
+      ]);
     });
 
-    it('onFilterPresetChange: CLAIMS — gated only on knownActiveReceiver(\'filter\') (main.filter IS observed), not on filterWidth at all (RED-FIRST evidence in file header)', () => {
+    it('onFilterPresetChange: DISPATCHES — gated on knownActiveReceiver(\'filter\') (main.filter IS observed), not on filterWidth at all (RED-FIRST evidence in file header)', () => {
       expect(IC7300_STATE.fieldStatus?.['main.filter']?.observed).toBe(true);
       expect(IC7300_STATE.main!.filter).toBe(1);
       // Fixture's own USB filter-width rule (rigs/ic7300.toml via
@@ -110,6 +138,29 @@ describe('IC-7300 fixture — filter/PBT family conformance (MOR-1561)', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('discrimination: with main.filter ALSO unobserved, onFilterWidthChange/onFilterDefaults/onFilterPresetChange all still refuse — receiver identity is genuinely unknown, not just filterWidth', () => {
+      expect(IC7300_STATE.fieldStatus?.['main.filter']?.observed).toBe(true);
+      h.state = {
+        ...fixtureState(profile),
+        fieldStatus: {
+          ...IC7300_STATE.fieldStatus,
+          'main.filter': {
+            ...IC7300_STATE.fieldStatus!['main.filter'],
+            observed: false,
+            availability: 'missing',
+            freshness: 'unknown',
+          },
+        },
+      };
+
+      expectRefusal(() => makeFilterHandlers().onFilterWidthChange(1800));
+      expectRefusal(() => makeFilterHandlers().onFilterDefaults([3000, 2400, 1800]));
+      // Both onFilterWidthChange and onFilterPresetChange re-check receiver
+      // identity BEFORE scheduling their 200ms debounce, so the refusal is
+      // synchronous — no fake timers needed to observe it.
+      expectRefusal(() => makeFilterHandlers().onFilterPresetChange(1, 3000));
     });
   });
 

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -1924,22 +1924,37 @@ describe('MOR-1409 A06a1 synchronous final filter-width authority', () => {
     expect(h.sendCommand).not.toHaveBeenCalled();
   });
 
-  it('requires fresh positive current mode, width and supported DATA facts', () => {
+  // MOR-1576: this used to also require fresh positive `main.filterWidth`
+  // (both unavailable and value 0/NaN cases) — that was a receiver-identity
+  // proxy check, not a functional need, since the write never reads a
+  // confirmed prior `filterWidth`; it resolves the quantization rule from
+  // `mode`/`dataMode` alone and validates the passed `width` PARAMETER
+  // (see the separate "rejects ... unsafe candidates" case below, which
+  // still covers `attempt(0)`/`attempt(NaN)` on the parameter itself).
+  it('requires fresh current mode and supported DATA facts; filterWidth observation is no longer required', () => {
     const attempt = () => makeFilterHandlers().onFilterWidthCommit(2400, 0, 31);
-    for (const path of ['main.mode', 'main.filterWidth', 'main.dataMode']) {
+    for (const path of ['main.mode', 'main.dataMode']) {
       h.unavailable.add(path); attempt(); h.unavailable.clear();
     }
     for (const [field, value] of [
-      ['mode', ''], ['filterWidth', 0], ['filterWidth', Number.NaN], ['dataMode', -1],
+      ['mode', ''], ['dataMode', -1],
     ] as const) {
       h.state = { ...a06State(), main: { ...a06State().main, [field]: value } } as ServerState;
       attempt();
     }
+    // main.filterWidth unavailable/stale no longer blocks the commit.
+    h.state = a06State();
+    h.unavailable.add('main.filterWidth');
+    attempt();
+    h.unavailable.clear();
     h.state = a06State();
     h.caps = { ...a06Caps(), capabilities: ['filter_width'] } as unknown as Record<string, unknown>;
     h.unavailable.add('main.dataMode');
     attempt();
-    expect(exactCalls()).toEqual([['set_filter_width', { width: 2400, receiver: 0 }]]);
+    expect(exactCalls()).toEqual([
+      ['set_filter_width', { width: 2400, receiver: 0 }],
+      ['set_filter_width', { width: 2400, receiver: 0 }],
+    ]);
   });
 
   it('rejects missing capability, unresolved/fixed/default-only rules and unsafe candidates', () => {

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -1957,6 +1957,20 @@ describe('MOR-1409 A06a1 synchronous final filter-width authority', () => {
     ]);
   });
 
+  // MOR-1576 review (B2): the removed `positiveSafeInteger(currentWidth)`
+  // check used to reject `main.filterWidth === 0` even though it's fresh
+  // and observed (0 isn't positive). Pin the behavior change directly:
+  // an observed-but-zero `filterWidth` no longer blocks the commit, since
+  // the write never reads it — only `mode`/`dataMode` (to resolve the
+  // quantization rule) and the passed `width` PARAMETER matter now.
+  it('dispatches even when observed main.filterWidth is 0 (MOR-1576: removed the positiveSafeInteger(currentWidth) proxy check)', () => {
+    h.state = { ...a06State(), main: { ...a06State().main, filterWidth: 0 } } as ServerState;
+
+    makeFilterHandlers().onFilterWidthCommit(2400, 0, 31);
+
+    expect(exactCalls()).toEqual([['set_filter_width', { width: 2400, receiver: 0 }]]);
+  });
+
   it('rejects missing capability, unresolved/fixed/default-only rules and unsafe candidates', () => {
     const attempt = (width: number = 2400) => makeFilterHandlers().onFilterWidthCommit(width, 0, 31);
     h.caps = { ...a06Caps(), capabilities: ['data_mode'] } as unknown as Record<string, unknown>; attempt();
@@ -2162,5 +2176,65 @@ describe('MOR-1518 client-side filter-width quantization at command emission', (
     vi.advanceTimersByTime(200);
 
     expect(exactCalls()).toEqual([['set_filter_width', { width: 1055, receiver: 0 }]]);
+  });
+});
+
+/**
+ * MOR-1576 review (B1, PR #2489 BLOCKED finding) — relaxing `onFilterDefaults`
+ * off `knownActiveReceiver('filterWidth')` opened a partial-command +
+ * uncaught-throw path it didn't have before. `quantizeFilterWidthToRule`
+ * passes non-finite input straight through (`filter-controls.ts`'s first
+ * guard, `if (!Number.isFinite(value)) return value;` — see the "no declared
+ * width rule at all" case just above), and `dispatchRadioIntent` THROWS on a
+ * non-safe-integer width. `FilterPanel.svelte`'s `factoryDefaults` falls
+ * back to `Array.from({length}, () => filterWidth)` when `filterConfig` has
+ * no `defaults` array, and `filterWidth` is `Number.NaN` whenever
+ * `main.filterWidth` is unobserved (`panel-props.ts`'s `toFilterProps`) —
+ * exactly the radios that motivated this whole ticket (x6100/tx500 declare
+ * no width tables; several FTX-1 modes resolve no rule at all). Before this
+ * fix, `onFilterDefaults`'s loop would dispatch `set_filter` to bracket into
+ * a non-active slot BEFORE reaching the invalid width and throwing —
+ * leaving the radio parked on the wrong filter slot with the restoring
+ * `set_filter` back to the real active filter never reached.
+ */
+describe('MOR-1576 (review B1) — onFilterDefaults validates the whole array before dispatching anything', () => {
+  beforeEach(() => {
+    h.state = a06State();
+    h.caps = a06Caps() as unknown as Record<string, unknown>;
+    h.unavailable.clear();
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+  });
+
+  it('emits ZERO frames — no partial set_filter bracket, no throw — when a quantized default resolves non-finite', () => {
+    // No declared width rule for the current mode, so
+    // `quantizeFilterWidthToRule` passes `NaN` straight through.
+    // `a06State()`'s active filter is 2 (non-FIL1): the pre-fix loop would
+    // have dispatched `set_filter{filter:1}` to bracket into slot 1 before
+    // ever validating `defaults[0]`.
+    h.caps = { ...a06Caps(), filterConfig: {} } as unknown as Record<string, unknown>;
+    expect(() =>
+      makeFilterHandlers().onFilterDefaults([Number.NaN, 2400, 1800]),
+    ).not.toThrow();
+
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(getCommandLifecycles()).toHaveLength(0);
+  });
+
+  it('still dispatches normally when every quantized default is a valid positive safe integer', () => {
+    // All three already sit on the default A06_SEGMENTS grid (no
+    // quantization needed) — active filter is 2 (a06State's fixture).
+    expect(() =>
+      makeFilterHandlers().onFilterDefaults([3000, 1800, 2400]),
+    ).not.toThrow();
+
+    expect(exactCalls()).toEqual([
+      ['set_filter', { filter: 1, receiver: 0 }],
+      ['set_filter_width', { width: 3000, receiver: 0 }],
+      ['set_filter_width', { width: 1800, receiver: 0 }],
+      ['set_filter', { filter: 3, receiver: 0 }],
+      ['set_filter_width', { width: 2400, receiver: 0 }],
+      ['set_filter', { filter: 2, receiver: 0 }],
+    ]);
   });
 });

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -779,14 +779,23 @@ export function makeFilterHandlers() {
     // emission point", not just a display-layer clamp — so this handler
     // never dispatches the alignment-error-triggering values the live
     // bench reported (1050/2150/3150 Hz).
+    //
+    // MOR-1576: gates on `knownActiveReceiver('filter')`, matching
+    // `onFilterPresetChange` below — NOT `knownActiveReceiver('filterWidth')`
+    // as before. The write only needs receiver identity plus the mode/
+    // dataMode `activeFilterRule` resolves the quantization rule from; it
+    // never reads a confirmed prior `filterWidth` value, so requiring one
+    // as a receiver-identity proxy only produced false refusals on radios
+    // (e.g. the IC-7300 live bench) that never confirm `filterWidth`
+    // readback at all.
     onFilterWidthChange: (() => {
       let timer: ReturnType<typeof setTimeout> | null = null;
       return (width: number) => {
-        if (knownActiveReceiver('filterWidth') === null) return;
+        if (knownActiveReceiver('filter') === null) return;
         if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
           timer = null;
-          const receiver = knownActiveReceiver('filterWidth');
+          const receiver = knownActiveReceiver('filter');
           if (receiver === null) return;
           const quantized = quantizeFilterWidthToRule(width, activeFilterRule(receiver));
           dispatchRadioIntent({ name: 'set_filter_width', params: { width: quantized, receiver } });
@@ -807,21 +816,28 @@ export function makeFilterHandlers() {
       const singleReceiver = context?.caps.receivers === 1;
       const active = context
         && (activeObserved ? context.state.active : singleReceiver ? 'MAIN' : undefined);
+      // MOR-1576: receiver identity is established via `mode` only. The
+      // `filterWidth`-observation checks that used to sit alongside it here
+      // (a `knownA03cReceiver(..., 'filterWidth')` receiver-identity check
+      // plus a `positiveSafeInteger(currentWidth)` freshness check) were a
+      // receiver-identity proxy, not a functional need — the write below
+      // never reads `currentWidth`; it resolves the quantization `rule` from
+      // `mode`/`dataMode` alone and validates the passed `width` PARAMETER
+      // against that rule via `validResolvedFilterWidth`. Dropping them
+      // aligns this site with the other three `set_filter_width` dispatch
+      // sites, all of which already gate on identity + mode/dataMode only.
       if (!context || !Number.isSafeInteger(expectedProviderGeneration)
         || expectedProviderGeneration < 0 || !Number.isSafeInteger(stateGeneration)
         || expectedProviderGeneration !== stateGeneration
         || (active !== 'MAIN' && active !== 'SUB')
         || (active === 'MAIN' ? 0 : 1) !== receiver
         || knownA03cReceiver(context, active, 'mode') !== receiver
-        || knownA03cReceiver(context, active, 'filterWidth') !== receiver
         || !context.caps.capabilities.includes('filter_width')) return;
       const key = receiver === 1 ? 'sub' : 'main';
       const observed = context.state[key];
       const mode = observed?.mode;
-      const currentWidth = observed?.filterWidth;
       if (!observed || !observedAvailableField(context.state, `${key}.mode`)
-        || !observedAvailableField(context.state, `${key}.filterWidth`)
-        || typeof mode !== 'string' || mode.length === 0 || !positiveSafeInteger(currentWidth)) return;
+        || typeof mode !== 'string' || mode.length === 0) return;
       const supportsData = context.caps.capabilities.includes('data_mode');
       const dataMode = supportsData ? observed.dataMode : 0;
       if (supportsData && (!observedAvailableField(context.state, `${key}.dataMode`)
@@ -864,8 +880,12 @@ export function makeFilterHandlers() {
         }, 200);
       };
     })(),
+    // MOR-1576: gates on `knownActiveReceiver('filter')` — same relaxation
+    // as `onFilterWidthChange` above, for the same reason (receiver identity
+    // + mode/dataMode resolve the quantization rule; no confirmed prior
+    // `filterWidth` reading is needed).
     onFilterDefaults: (defaults: number[]) => {
-      const receiver = knownActiveReceiver('filterWidth');
+      const receiver = knownActiveReceiver('filter');
       const activeFilter = receiver === null ? null : getActiveReceiver()?.filter;
       if (receiver === null || !Number.isSafeInteger(activeFilter)) return;
       const rule = activeFilterRule(receiver);

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -884,19 +884,36 @@ export function makeFilterHandlers() {
     // as `onFilterWidthChange` above, for the same reason (receiver identity
     // + mode/dataMode resolve the quantization rule; no confirmed prior
     // `filterWidth` reading is needed).
+    //
+    // MOR-1576 review (B1): `quantizeFilterWidthToRule` passes non-finite
+    // input straight through when no usable rule/segment covers it
+    // (`filter-controls.ts`), and `dispatchRadioIntent` THROWS on a
+    // non-safe-integer width. `FilterPanel.svelte`'s `factoryDefaults`
+    // falls back to the observed `filterWidth` (which is `Number.NaN`
+    // whenever `main.filterWidth` is unobserved — `panel-props.ts`) when
+    // the mode has no declared `defaults` array, so `defaults` here CAN
+    // legitimately arrive carrying NaN — precisely on radios that never
+    // confirm `filterWidth` readback, the case this ticket exists for. The
+    // whole array is validated (quantized-and-checked) BEFORE any command
+    // is dispatched, same MOR-1291 fail-closed shape used elsewhere in this
+    // file — a mid-loop throw would otherwise leave the radio bracketed
+    // into a non-active filter slot with the restoring `set_filter` never
+    // reached.
     onFilterDefaults: (defaults: number[]) => {
       const receiver = knownActiveReceiver('filter');
       const activeFilter = receiver === null ? null : getActiveReceiver()?.filter;
       if (receiver === null || !Number.isSafeInteger(activeFilter)) return;
       const rule = activeFilterRule(receiver);
-      for (let i = 0; i < defaults.length; i++) {
+      const quantizedWidths = defaults.map((width) => quantizeFilterWidthToRule(width, rule));
+      if (!quantizedWidths.every((width) => positiveSafeInteger(width))) return;
+      for (let i = 0; i < quantizedWidths.length; i++) {
         const filter = i + 1;
         if (filter !== activeFilter) {
           dispatchRadioIntent({ name: 'set_filter', params: { filter, receiver } });
         }
         dispatchRadioIntent({
           name: 'set_filter_width',
-          params: { width: quantizeFilterWidthToRule(defaults[i], rule), receiver },
+          params: { width: quantizedWidths[i], receiver },
         });
       }
       if ((activeFilter as number) <= defaults.length) {


### PR DESCRIPTION
Closes MOR-1576

## Summary

`set_filter_width` has four dispatch sites in `panel-commands.ts`. Three of them (`onFilterWidthChange` the slider, `onFilterDefaults`, and `onFilterWidthCommit` the A03c commit) gated on `knownActiveReceiver('filterWidth')` or an explicit observed-`filterWidth` check — using the field being WRITTEN as a receiver-identity proxy. The fourth, `onFilterPresetChange`, gated on `knownActiveReceiver('filter')` instead, since the write only needs receiver identity plus mode/dataMode to resolve the quantization rule (`activeFilterRule`/`resolveFilterModeConfig`), not a confirmed prior width reading.

On the IC-7300 live-captured fixture (`main.filterWidth` unobserved, `main.filter` observed), the three strict *handlers* silently refused a write the settings-modal preset path dispatched fine for the identical mode/rule — a real handler-level inconsistency, not a test artifact. **Correction from an earlier revision of this description:** on this specific profile, the *slider* path (`onFilterWidthChange`) isn't actually reachable through either shipping skin's UI while `filterWidth` is unobserved — `FilterSurface.svelte` gates the call itself behind `usable(modeFilter.filterWidth)` (and disables the control), and `FilterPanel.svelte` only wires its own slider to `onFilterWidthChange` in table mode, which the IC-7300's segment-encoded USB rule never is. The operator-reachable inconsistency on this profile is **Restore Defaults** (`onFilterDefaults`) — see B1 below, where relaxing its handler-level gate turned out to open a real bug on exactly this kind of profile. The `onFilterWidthChange`/`onFilterWidthCommit` handler-level fixes remain correct and are still worth making (other skins/entry points, or future ones, may call these handlers without going through `FilterSurface`'s/`FilterPanel`'s own UI-level `usable()` gates), but the PR's original framing overstated what was reachable in practice on this profile today.

Per the verifier's analysis in PR #2481, this relaxes the three strict sites to the preset path's gating shape.

## Per-site before/after gate table

| Site | Before | After |
|---|---|---|
| `onFilterWidthChange` (slider) | `knownActiveReceiver('filterWidth')` (checked pre-debounce and again on fire) | `knownActiveReceiver('filter')` (same two checkpoints, debounce semantics unchanged) |
| `onFilterDefaults` (restore) | `knownActiveReceiver('filterWidth')` | `knownActiveReceiver('filter')`, plus (B1, see below) upfront whole-array validation before any dispatch |
| `onFilterWidthCommit` (A03c) | generation/context checks + `knownA03cReceiver(context, active, 'mode')` + `knownA03cReceiver(context, active, 'filterWidth')` + `observedAvailableField('filterWidth')` + `positiveSafeInteger(currentWidth)`, all in addition to mode/dataMode-derived rule validation | Same generation/context checks + `knownA03cReceiver(context, active, 'mode')` only; the `filterWidth`-observation checks are dropped (the write never reads `currentWidth` — it only uses `mode`/`dataMode` to resolve `rule` and validates the passed `width` parameter against it via `validResolvedFilterWidth`) |
| `onFilterPresetChange` (settings modal) | `knownActiveReceiver('filter')` (unchanged — this was already the reference shape) | unchanged |

All four sites now gate on receiver identity + mode/dataMode (to resolve the quantization rule), never on a confirmed prior `filterWidth` reading.

## Review fixes (round 2)

Independent review of the first revision found one real blocker and two should-fixes; all three are addressed in this revision.

**B1 (blocker, fixed) — relaxed `onFilterDefaults` opened a partial-command + uncaught-throw path.** `quantizeFilterWidthToRule` passes non-finite input straight through when no rule/segment covers it (`filter-controls.ts`), and `dispatchRadioIntent` THROWS on a non-safe-integer width. `FilterPanel.svelte`'s `factoryDefaults` falls back to `Array.from({length}, () => filterWidth)` when the mode's `filterConfig` has no `defaults` array, and `filterWidth` is `Number.NaN` whenever `main.filterWidth` is unobserved (`panel-props.ts`'s `toFilterProps`) — reachable on radios that declare no width table at all (x6100/tx500) or on FTX-1 modes outside the small USB/LSB/CW-R/RTTY-R resolution set. Before the fix, a NaN-carrying defaults array with a non-FIL1 active filter dispatched `set_filter{filter:1}` (bracketing into slot 1) and only then threw on the invalid width — the restoring `set_filter` back to the real active filter never ran, leaving the radio parked on the wrong filter slot.

Fixed: `onFilterDefaults` now quantizes and validates the *entire* `defaults` array (`positiveSafeInteger` on every entry) up front, before dispatching anything — same MOR-1291 fail-closed shape already used elsewhere in this file. Confirmed RED first: the new pin (`[NaN, 2400, 1800]` with active filter 2) threw `TypeError: Invalid radio intent envelope` against the unfixed code; GREEN after the fix (zero frames, no throw).

**B2 (should-fix, addressed) — the `positiveSafeInteger(currentWidth)` removal on `onFilterWidthCommit` was pinned by nothing.** Added a dedicated test: `main.filterWidth: 0` (fresh, observed, available) — previously rejected by the removed check purely because 0 isn't positive — now dispatches, since the write never reads `currentWidth`.

**B3 (should-fix, addressed) — corrected the overstated "slider unlock" framing** in this Summary (see the correction paragraph above): the genuinely operator-reachable inconsistency on the IC-7300 profile is Restore Defaults, not the slider.

## onPbtReset disposition

`onPbtReset` was also flagged (per the C7 PR discussion) as a "verified-refusing" site with a similar shape: it gates receiver identity via `knownActiveReceiver('pbtInner')` plus an explicit `main.pbtOuter` availability check, even though the actual write value (`pbtHzToRaw(0, pbtRange)`, the range's static center) never reads the currently observed `pbtInner`/`pbtOuter` values.

I left it unchanged. Unlike `filterWidth`, there is no established "preset path" alternative for PBT reset that already anchors receiver identity on a *different*, unrelated field (the way `onFilterPresetChange` anchors on `'filter'` instead of `'filterWidth'`) — `pbtInner`/`pbtOuter` are the only two fields in play, both are directly involved in the write, and there's no third neighboring field with precedent for this purpose. Relaxing it (e.g. to a bare `knownActiveReceiver()` with no field arg) would be a different, unreviewed design decision, not a same-shape one-line fix, so it's left for its own ticket/analysis if wanted.

## Red-first evidence

**Round 1** (the three relaxed gates): wrote the flipped mor1561 assertions (dispatch instead of refusal, for `onFilterWidthChange`/`onFilterDefaults`) against the unmodified code first:

```
FAIL  onFilterDefaults: DISPATCHES ...
AssertionError: expected [] to deeply equal [ [ 'set_filter_width', …(1) ], …(5) ]
- Expected  [...]  + Received  []
```
(`onFilterWidthChange`'s equivalent case failed the same way — empty vs. expected single frame.) 2 failing / 12 passing on `mor1561-filter-pbt-family-conformance.isolated.test.ts` before the implementation change; 14/14 green afterward.

**Round 2** (B1 fix): wrote the fail-closed pin against the round-1 code (which still had the bug) first:

```
FAIL  MOR-1576 (review B1) … emits ZERO frames — no partial set_filter bracket, no throw — when a quantized default resolves non-finite
AssertionError: expected [Function] to not throw an error but 'TypeError: Invalid radio intent envel…' was thrown
+ Received: "TypeError: Invalid radio intent envelope"
```
Green after the upfront-validation fix (0 frames dispatched, no throw); a companion test confirms a fully-valid defaults array still dispatches normally (6 frames, unchanged sequencing).

## Discrimination

Added a test asserting that when `main.filter` is ALSO unobserved on the IC-7300 fixture (in addition to `main.filterWidth`), `onFilterWidthChange`/`onFilterDefaults`/`onFilterPresetChange` all still refuse — proving the relaxed gate isn't vacuous; receiver identity genuinely has to be known from *some* field.

## Files changed

- `frontend/src/lib/runtime/commands/panel-commands.ts` — implementation (four-site gate relaxation + B1 fail-closed fix)
- `frontend/src/lib/runtime/adapters/__tests__/mor1561-filter-pbt-family-conformance.isolated.test.ts` — flipped pins to dispatch expectations + discrimination case
- `frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts` — updated the A06a1 `onFilterWidthCommit` pin, added the B1 fail-closed pin (+ valid-array companion), added the B2 `filterWidth: 0` pin

## Test plan

- [x] `npx vitest run` on the two targeted test files plus `FilterPanel.isolated.test.ts` — 168/168 passing (14 mor1561 + 109 intent + 45 FilterPanel)
- [x] Broader filter-related test sweep (36 files, 1146 tests) — all green
- [x] `npx eslint` on the three changed files — clean
- [x] `npx eslint src/components-v2/panels/ src/components-v2/layout/ src/presentation/` (lint:boundaries) — clean
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
