### PR TITLE
docs: post-sweeper conformance comment cleanup (MOR-1582)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -172,12 +172,14 @@
  * `set_powerstat` on a capability-only gate with no field check (RED-FIRST
  * target, see that file's header). `memory_clear` is the one dispatch
  * resolved through a real multi-field snapshot (`currentMemorySnapshot()`).
- * MOR-1574 is cited (not re-derived) as CONTRAST: the READ-path
- * `toRitXitProps` (MOR-1562/C8) has no fieldStatus gate on `ritOn`/
- * `ritFreq`/`ritTx` at all, while the WRITE-path handlers walked here DO
- * gate on those same three unobserved leaves. Also adds ADDITIVE (uncounted,
- * outside the 87-name universe) coverage of the dynamic mod-input dispatch
- * across all 4 DATA groups on this fixture — see that file's own header.
+ * MOR-1574 is cited (not re-derived) as CONTRAST, now historical: the
+ * READ-path `toRitXitProps` (MOR-1562/C8) HAD no fieldStatus gate on
+ * `ritOn`/`ritFreq`/`ritTx` at all — closed by MOR-1574/PR #2488, which
+ * brought it in line with the WRITE-path handlers walked here, which
+ * always DID gate on those same three unobserved leaves. Also adds
+ * ADDITIVE (uncounted, outside the 87-name universe) coverage of the
+ * dynamic mod-input dispatch across all 4 DATA groups on this fixture —
+ * see that file's own header.
  */
 export const CLAIMED_INTENTS: ReadonlySet<string> = new Set([
   'set_mode',

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts
@@ -8,12 +8,17 @@
  * enforces that split, so a name that is neither claimed nor waived (e.g.
  * a newly-added intent) fails vitest.
  *
- * THIS MAP IS THE BURN-DOWN. When a family walk (C6-C13, MOR-1560..1567)
- * lands real `expectFrames` coverage for a waived intent: delete it from
- * the matching `tag([...])` call below, add the name to `CLAIMED_INTENTS`
- * in `./claimed.ts`, and update the matching `*_COUNT` pin in the same
- * diff — pinned as a literal so a removal (or a silent re-add) shows up
- * as a diff / count-assertion break.
+ * EMPTY-MAP ERA (post MOR-1567): the sweeper walked the last of the
+ * original 67 intents into `CLAIMED_INTENTS`, so both maps below are now
+ * `{}`. This file is no longer a burn-down in progress — it is the
+ * standing gate for anything NEW. If the completeness meta-test fails
+ * because an intent or keyboard action has no conformance case yet,
+ * either (a) add a real `expectFrames`/`expectRefusal` case and list the
+ * name in `CLAIMED_INTENTS` / `CLAIMED_KEYBOARD_ACTIONS` in `./claimed.ts`,
+ * or (b) add an entry directly to `WAIVED_INTENTS` / `WAIVED_KEYBOARD_ACTIONS`
+ * below with a one-line `reason` and an owning `owner` ticket, and bump
+ * the matching `*_COUNT` pin in the same diff — pinned as a literal so any
+ * change shows up as a diff / count-assertion break.
  *
  * Provenance: family assignment came from the MOR-1426 decomposition's
  * per-family "Work" lists, cross-checked against the actual
@@ -25,11 +30,12 @@
  * ONE DELIBERATE EXCLUSION (full account in the completeness meta-test's
  * header): `onModInputChange` builds its intent name at runtime via
  * `modInputCommand(dataMode)`, not a `name: '<literal>'`, so it can't
- * appear in a source-literal parse and is NOT one of the 67 below — its
- * 4-value domain is pinned separately by `$lib/radio/mod-input.test.ts`.
- * MOR-1567's prose calls out "the mod-input command" as in its scope, so
- * add a case for it there — do not fold it into this map, which would
- * perturb the pinned 87/67/20 baseline MOR-1426 measured.
+ * appear in a source-literal parse and was excluded from the original
+ * 67-intent baseline this ledger measured — its 4-value domain is pinned
+ * separately by `$lib/radio/mod-input.test.ts`. MOR-1567's prose calls out
+ * "the mod-input command" as in its scope, so add a case for it there — do
+ * not fold it into this map, which would perturb the pinned 87/67/20
+ * baseline MOR-1426 measured.
  */
 
 /** One-line justification for an unclaimed intent or keyboard action. */
@@ -38,11 +44,6 @@ export interface Waiver {
   readonly reason: string;
   /** Linear ticket id that owns closing this waiver. */
   readonly owner: string;
-}
-
-/** Tags every name in `names` with the same waiver — one family, one call. */
-function tag(names: readonly string[], waiver: Waiver): Record<string, Waiver> {
-  return Object.fromEntries(names.map((name) => [name, waiver]));
 }
 
 /**

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1567-remainder-sweeper-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1567-remainder-sweeper-conformance.isolated.test.ts
@@ -26,13 +26,16 @@
  * SKEWED TOWARD REFUSAL, but for THREE distinct reasons, not one: (1) 8
  * genuinely REFUSE on an unobserved field this fixture never confirmed —
  * `dialLock`, `rxAntenna1`/`rxAntenna2`/`txAntenna` (antenna family, though
- * a STRUCTURAL gate fires first — see below), `main.digisel`,
+ * STRUCTURAL gates fire first — see below), `main.digisel`,
  * `main.ipplus`, `ritOn`, `ritTx`, `ritFreq` — same honest fail-closed shape
  * as C6/C7/C10/C11's walks; (2) `set_antenna_1`/`set_antenna_2`/
  * `set_rx_antenna_ant1`/`set_rx_antenna_ant2` all REFUSE on
  * `caps.antennas === 1 < 2`, a STRUCTURAL gate that fires before the
- * (also-unobserved) field check ever runs — `onToggleRxAnt` is the SOLE
- * call site for both `set_rx_antenna_ant1` and `set_rx_antenna_ant2` (the
+ * (also-unobserved) field check ever runs; `set_rx_antenna_ant1`/
+ * `set_rx_antenna_ant2` additionally sit behind a SECOND, independent
+ * structural gate on this fixture — the `rx_antenna` capability itself is
+ * undeclared (confirmed in `mor1562-adapter-seams-conformance.isolated.test.ts:289`)
+ * — `onToggleRxAnt` is the SOLE call site for both names (the
  * `state.txAntenna` value picks which name it would dispatch), so both
  * names refuse identically here, before that branch is ever reached; (3) 6
  * genuinely DISPATCH: all 4 scan intents and `speak` dispatch UNCONDITIONALLY
@@ -41,24 +44,31 @@
  * ungated shape MOR-1578 already flagged for `vfo_swap`/`vfo_equalize`
  * (leg 1) — cited here as the same class, not re-filed; `set_powerstat`
  * DOES check a capability (`power_control`, declared) but has no field
- * gate either (RED-FIRST target, see below). `memory_clear` is the one
- * DISPATCH that goes through a real multi-field resolution
- * (`currentMemorySnapshot()`, see its own case below).
+ * gate either (RED-FIRST target, see below). `memory_clear` (via
+ * `onClear`) is the one DISPATCH that goes through `currentMemorySnapshot()`'s
+ * structural resolution (receiver/slot identity must resolve), but it only
+ * requires the resolved snapshot object to be non-null — it does NOT
+ * itself check the snapshot's `frequencyHz`/`mode` contents. `onStore` is
+ * the sibling handler that does check those contents (against the
+ * caller's values), see its own case below.
  *
- * MOR-1574 CONTRAST (RIT/XIT, cited per this ticket's instruction): MOR-1574
- * is the ADAPTER-SEAM finding that `toRitXitProps` (the READ path,
- * `panel-props.ts:482`, walked in
- * `mor1562-adapter-seams-conformance.isolated.test.ts:311-323`) has NO
+ * MOR-1574 CONTRAST (RIT/XIT, cited per this ticket's instruction — now
+ * HISTORICAL): MOR-1574 was the ADAPTER-SEAM finding that `toRitXitProps`
+ * (the READ path, `panel-props.ts:496`, walked in
+ * `mor1562-adapter-seams-conformance.isolated.test.ts:311-323`) had NO
  * fieldStatus gate on `ritOn`/`ritFreq`/`ritTx` at all — an honesty gap on
- * the props side. The WRITE path walked here (`makeRitXitHandlers()`) is
- * DIFFERENT: `onRitToggle`/`onXitToggle`/`onRitOffsetChange`/
+ * the props side. That gap is CLOSED by MOR-1574/PR #2488: `hasRit`/
+ * `hasXit` now gate on field availability the same way `toAgcProps`/
+ * `toRfFrontEndProps` already did, so an unobserved `ritOn`/`ritFreq`/
+ * `ritTx` no longer reads back as a confirmed "RIT/XIT OFF". The WRITE
+ * path walked here (`makeRitXitHandlers()`) was always separately honest:
+ * `onRitToggle`/`onXitToggle`/`onRitOffsetChange`/
  * `onXitOffsetChange`/`onClear` all DO check `knownTopLevelField('ritOn'
  * | 'ritTx' | 'ritFreq')` before dispatching — on this fixture all three
  * leaves are genuinely unobserved (confirmed below), so all 3 write-side
- * intents correctly REFUSE. The two paths reach the opposite outcome
- * (read: silently reports stale zeros; write: fails closed) off the SAME
- * unobserved data — MOR-1574 is the read-side half of that asymmetry, not
- * re-derived here.
+ * intents correctly REFUSE. Post-#2488 the two paths now AGREE (both fail
+ * closed / hide on the SAME unobserved data) — MOR-1574 closed what used
+ * to be the read-side half of that asymmetry; not re-derived here.
  *
  * RED-FIRST EVIDENCE (MOR-1567 build process, not part of this diff): the
  * `set_powerstat` case below was first authored with a deliberately wrong
@@ -155,10 +165,10 @@ const CASES: readonly IntentCase[] = [
     gate: 'no gate at all beyond Number.isSafeInteger(mode) (MOR-1578-class)' },
   { label: 'set_dial_lock', run: () => makeSystemHandlers().onDialLock(true),
     frames: [],
-    gate: 'top-level dialLock unobserved (dial_lock capability IS declared) — discrimination evidence in file header' },
+    gate: 'currentA03cContext() resolves (state/caps present, receiver count matches vfoScheme) before the top-level dialLock unobserved gate fires (dial_lock capability IS declared) — discrimination evidence in file header' },
   { label: 'set_powerstat', run: () => makeSystemHandlers().onPowerOff(),
     frames: [['set_powerstat', { on: false }]],
-    gate: 'power_control capability declared; no field-observation gate at all — RED-FIRST target, see file header' },
+    gate: 'currentA03cContext() resolves; power_control capability declared; no field-observation gate beyond that — RED-FIRST target, see file header' },
   { label: 'speak', run: () => makeSystemHandlers().onSpeak(),
     frames: [['speak', { mode: 0 }]],
     gate: 'no gate at all — unconditional, not even a capability check (MOR-1578-class)' },
@@ -170,10 +180,10 @@ const CASES: readonly IntentCase[] = [
     gate: 'caps.antennas=1 < 2 structural gate (fires before the also-unobserved rxAntenna2 field check)' },
   { label: 'set_rx_antenna_ant1', run: () => makeAntennaHandlers().onToggleRxAnt(),
     frames: [],
-    gate: 'caps.antennas=1 < 2 structural gate — SHARED onToggleRxAnt() call site with set_rx_antenna_ant2; fires before the txAntenna branch that would pick between the two names is ever reached' },
+    gate: 'TWO independent structural gates on this fixture: caps.antennas=1 < 2 AND rx_antenna capability undeclared — SHARED onToggleRxAnt() call site with set_rx_antenna_ant2; fires before the txAntenna branch that would pick between the two names is ever reached' },
   { label: 'set_rx_antenna_ant2', run: () => makeAntennaHandlers().onToggleRxAnt(),
     frames: [],
-    gate: 'same shared onToggleRxAnt() call site and gate as set_rx_antenna_ant1 above — see that row' },
+    gate: 'same shared onToggleRxAnt() call site and same two-layer structural gate as set_rx_antenna_ant1 above — see that row' },
   { label: 'set_digisel', run: () => makeRfFrontEndHandlers().onDigiSelToggle(true),
     frames: [],
     gate: "main.digisel unobserved (via knownActiveReceiver('digisel')'s field check)" },


### PR DESCRIPTION
Closes MOR-1582

Prose/comment-only cleanup of the conformance ledger's header rot, now that the MOR-1567 sweeper closed the burn-down. Five documented items:

1. `frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts` — rewrote the file header for the empty-map era: it no longer describes an in-progress burn-down (`delete it from the matching tag([...]) call below`, `the 67 below`), it now describes the standing gate for any NEW unclaimed intent/keyboard action (claim it with a real conformance case, or waive it here with an owning ticket). Removed the now-dead `tag()` helper — confirmed unreferenced anywhere (the only importer, `panel-commands-completeness.test.ts`, only imports the `WAIVED_*`/`*_COUNT` exports, never `tag`), and both maps are already flat `{}` literals, not built via `tag()` calls.
2. `mor1567-remainder-sweeper-conformance.isolated.test.ts`:
   - (a) `set_rx_antenna_ant1`/`set_rx_antenna_ant2` rows and header prose now document the second, independent structural gate on this fixture — the `rx_antenna` capability itself is undeclared (confirmed by `mor1562-adapter-seams-conformance.isolated.test.ts:289`'s `expect(IC7300_CAPABILITIES.capabilities).not.toContain('rx_antenna')`), on top of the `caps.antennas === 1 < 2` gate already documented.
   - (b) softened the `memory_clear` header claim: `onClear` only requires `currentMemorySnapshot()` to resolve to a non-null object (structural resolution), it does not itself check the snapshot's `frequencyHz`/`mode` contents — `onStore` is the sibling handler that does check those contents.
   - (c) added the `currentA03cContext()` precondition to the `set_powerstat`/`set_dial_lock` gate strings — both handlers resolve that context before their own field/capability checks fire.
   - (d) rewrote the MOR-1574 citation past-tense: `toRitXitProps` (panel-props.ts) WAS gated by MOR-1574/PR #2488 (`4247eaaf`/`#2488`, verified in git log), so the "read path has no gate, write path does" asymmetry this file described is now historical — both paths agree post-fix. Fixed the shifted line pin (`panel-props.ts:482` → `:496`, the function's current definition line).
3. `frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts` (~lines 175-180) — same past-tense rewrite of the stale present-tense MOR-1574 claim.

**Diff evidence — zero executable-line changes:** every changed line in the diff is either inside a `/** ... */` JSDoc comment block, or a `gate:` string literal in `mor1567-remainder-sweeper-conformance.isolated.test.ts`'s `CASES` array — that field is used only to build the `it()` test-name label (`` `${c.label}: ${outcome} — ${c.gate}` ``) and never participates in any assertion. The one non-comment deletion is the `tag()` helper function, confirmed dead (unreferenced) before removal.

## Test plan
- [x] `npx vitest run` on the touched test file + `panel-commands-completeness.test.ts` (the meta-test that imports `waived.ts`/`claimed.ts`) + `mor1562-adapter-seams-conformance.isolated.test.ts` (cited by the MOR-1574 rewrite) — 3 files, 70/70 passed, same as main (no assertion logic changed).
- [x] `npx eslint` on all 4 touched/cited files — zero violations.
- [x] Boundary grep on the diff (`192\.168|\bmoroz\b|\bmini\b|:8099|preview-mor`) — no matches.