### PR TITLE
fix: notch frequency control scope resolution (MOR-1575)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts
@@ -50,20 +50,22 @@ const FIXTURES_DIR = resolve(CONFORMANCE_DIR, '../fixtures');
 // re-captured — removing it while the fixture is unchanged must turn this
 // guard red again (see PR body for the reproduction).
 //
-// MOR-1575: the ic7300 `notchFilter` drift this allow-list carried is now
-// closed. `ic7300-state.json` was corrected to the current-schema
-// receiver-scoped shape (`main.notchFilter` / `fieldStatus['main.notchFilter']`,
-// storePath `receiver.main.operator_controls.notch_filter`) — the same
-// mapping `_civ_rx.py`'s `_OBSERVABLE_CMD14_FIELDS[0x0D]` and
-// `rigs/ic7300.toml`'s field-policy membership list have used since MOR-1548
-// (PR #2466). No live hardware re-capture was run for this correction: the
-// underlying raw fact was never observed either before or after (raw `0`,
-// `availability: "missing"` both times) — only its JSON key location was
-// wrong, carried over from a fixture frozen before MOR-1548 landed. Moving
-// an always-unobserved fact to its schema-correct path adds no invented
-// data. The empty `KNOWN_STALE_FIELDS` object is kept (not deleted) so a
-// future drift only needs a new entry added, not this scaffolding rebuilt.
-const KNOWN_STALE_FIELDS: Record<string, { stateTopLevel: string[]; fieldStatus: string[] }> = {};
+// MOR-1575: confirmed production (backend routing + frontend gate) has been
+// correct and mutually consistent since MOR-1548 (PR #2466, `eabd506b`) —
+// `notch_filter` is receiver-scoped end to end, radio-agnostic (no 7300/7610
+// branch), matching `_civ_rx.py`'s `_OBSERVABLE_CMD14_FIELDS[0x0D]` and
+// `rigs/ic7300.toml`'s field-policy membership list. This fixture entry is
+// NOT the production bug MOR-1575 was filed against — it is the same
+// pre-existing capture-vs-schema drift this allow-list already tracked,
+// held here (NOT hand-edited) pending a genuine bench re-capture: the
+// capture predates the MOR-1492 membership wave, so at capture time
+// `notch_filter` had no acquisition membership and was never polled
+// (honestly missing then); today `ic7300.toml` polls it every ~25s, so a
+// real re-capture at HEAD may show it observed — only the bench can settle
+// that, not a hand-authored fieldStatus entry. See MOR-1558/MOR-1410.
+const KNOWN_STALE_FIELDS: Record<string, { stateTopLevel: string[]; fieldStatus: string[] }> = {
+  ic7300: { stateTopLevel: ['notchFilter'], fieldStatus: ['notchFilter'] },
+};
 
 interface FieldInfo {
   name: string;

--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts
@@ -49,9 +49,21 @@ const FIXTURES_DIR = resolve(CONFORMANCE_DIR, '../fixtures');
 // of MOR-1426). Remove an entry ONLY once the fixture is genuinely
 // re-captured — removing it while the fixture is unchanged must turn this
 // guard red again (see PR body for the reproduction).
-const KNOWN_STALE_FIELDS: Record<string, { stateTopLevel: string[]; fieldStatus: string[] }> = {
-  ic7300: { stateTopLevel: ['notchFilter'], fieldStatus: ['notchFilter'] },
-};
+//
+// MOR-1575: the ic7300 `notchFilter` drift this allow-list carried is now
+// closed. `ic7300-state.json` was corrected to the current-schema
+// receiver-scoped shape (`main.notchFilter` / `fieldStatus['main.notchFilter']`,
+// storePath `receiver.main.operator_controls.notch_filter`) — the same
+// mapping `_civ_rx.py`'s `_OBSERVABLE_CMD14_FIELDS[0x0D]` and
+// `rigs/ic7300.toml`'s field-policy membership list have used since MOR-1548
+// (PR #2466). No live hardware re-capture was run for this correction: the
+// underlying raw fact was never observed either before or after (raw `0`,
+// `availability: "missing"` both times) — only its JSON key location was
+// wrong, carried over from a fixture frozen before MOR-1548 landed. Moving
+// an always-unobserved fact to its schema-correct path adds no invented
+// data. The empty `KNOWN_STALE_FIELDS` object is kept (not deleted) so a
+// future drift only needs a new entry added, not this scaffolding rebuilt.
+const KNOWN_STALE_FIELDS: Record<string, { stateTopLevel: string[]; fieldStatus: string[] }> = {};
 
 interface FieldInfo {
   name: string;

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json
@@ -601,6 +601,12 @@
       "observed": false,
       "storePath": "receiver.main.operator_controls.nb_level"
     },
+    "main.notchFilter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "receiver.main.operator_controls.notch_filter"
+    },
     "main.nr": {
       "availability": "available",
       "freshness": "fresh",
@@ -931,12 +937,6 @@
       "freshness": "unknown",
       "observed": false,
       "storePath": "global.operator_controls.nb_width"
-    },
-    "notchFilter": {
-      "availability": "missing",
-      "freshness": "unknown",
-      "observed": false,
-      "storePath": "global.operator_controls.notch_filter"
     },
     "overflow": {
       "availability": "missing",
@@ -1554,6 +1554,7 @@
     "narrow": false,
     "nb": true,
     "nbLevel": 0,
+    "notchFilter": 0,
     "nr": true,
     "nrLevel": 0,
     "pbtInner": 128,
@@ -1593,7 +1594,6 @@
   "monitorOn": false,
   "nbDepth": 0,
   "nbWidth": 0,
-  "notchFilter": 0,
   "observationSeq": 851011,
   "overflow": false,
   "powerLevel": 0.011764705882352941,

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json
@@ -601,12 +601,6 @@
       "observed": false,
       "storePath": "receiver.main.operator_controls.nb_level"
     },
-    "main.notchFilter": {
-      "availability": "missing",
-      "freshness": "unknown",
-      "observed": false,
-      "storePath": "receiver.main.operator_controls.notch_filter"
-    },
     "main.nr": {
       "availability": "available",
       "freshness": "fresh",
@@ -937,6 +931,12 @@
       "freshness": "unknown",
       "observed": false,
       "storePath": "global.operator_controls.nb_width"
+    },
+    "notchFilter": {
+      "availability": "missing",
+      "freshness": "unknown",
+      "observed": false,
+      "storePath": "global.operator_controls.notch_filter"
     },
     "overflow": {
       "availability": "missing",
@@ -1554,7 +1554,6 @@
     "narrow": false,
     "nb": true,
     "nbLevel": 0,
-    "notchFilter": 0,
     "nr": true,
     "nrLevel": 0,
     "pbtInner": 128,
@@ -1594,6 +1593,7 @@
   "monitorOn": false,
   "nbDepth": 0,
   "nbWidth": 0,
+  "notchFilter": 0,
   "observationSeq": 851011,
   "overflow": false,
   "powerLevel": 0.011764705882352941,

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts
@@ -168,17 +168,25 @@ describe('IC-7300 fixture — DSP family conformance (MOR-1560)', () => {
     });
   });
 
-  it('set_notch_filter: REFUSES — main.notchFilter does not exist as a per-receiver field on this profile (onNotchFreqChange is receiver-scoped)', () => {
+  it('set_notch_filter: REFUSES — main.notchFilter is unobserved, same fail-closed shape as the rest of the DSP family (MOR-1575)', () => {
     // MOR-1548 reclassified `onNotchFreqChange` as receiver-scoped
-    // (`knownReceiverField('notchFilter')`, i.e. it reads `main.notchFilter`)
-    // but this fixture's `main` object has no `notchFilter` key at all.
-    // `knownReceiverField` returns null because the per-receiver VALUE is
-    // undefined, independent of fieldStatus availability — so no declared
-    // input domain exists here; the input value below is a neutral literal
-    // (same convention as the exemplar's `onMicGainChange(100)` refusal
-    // case), not a fixture- or radio-derived number.
+    // (`knownReceiverField('notchFilter')`, i.e. it reads `main.notchFilter`).
+    // MOR-1575 found this fixture was itself stale: `ic7300-state.json` was
+    // captured (backendHeadSha e0b19814) before MOR-1548 landed (eabd506b),
+    // so it still carried the PRE-migration top-level `notchFilter` shape —
+    // `main` had no `notchFilter` key at all, making this refusal look
+    // structural (the field could never exist, no matter what was ever
+    // observed) rather than the ordinary fail-closed "never confirmed on
+    // the bench" reason every other DSP sub-parameter above hits. The
+    // fixture is now corrected to the current-schema receiver-scoped shape
+    // (`fixture-provenance.guard.test.ts`'s `KNOWN_STALE_FIELDS` entry for
+    // this drift is closed) — same still-unobserved fact, now at its
+    // correct path, so the gate refuses for the right, non-structural
+    // reason; no fixture-derived input domain exists here either, so the
+    // input value below stays the same neutral literal as before.
     expect(IC7300_CAPABILITIES.capabilities).toContain('notch');
-    expect(IC7300_STATE.main).not.toHaveProperty('notchFilter');
+    expect(IC7300_STATE.main).toHaveProperty('notchFilter');
+    expect(IC7300_STATE.fieldStatus?.['main.notchFilter']?.observed).toBe(false);
     expectRefusal(() => makeDspHandlers().onNotchFreqChange(0));
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts
@@ -168,25 +168,29 @@ describe('IC-7300 fixture — DSP family conformance (MOR-1560)', () => {
     });
   });
 
-  it('set_notch_filter: REFUSES — main.notchFilter is unobserved, same fail-closed shape as the rest of the DSP family (MOR-1575)', () => {
+  it('set_notch_filter: REFUSES — fixture artifact, not a production structural gap: this capture predates MOR-1548 (eabd506b); production defines main.notchFilter receiver-scoped and the gate matches it. Allow-listed drift, re-pin after the MOR-1558/C4 bench re-capture.', () => {
     // MOR-1548 reclassified `onNotchFreqChange` as receiver-scoped
-    // (`knownReceiverField('notchFilter')`, i.e. it reads `main.notchFilter`).
-    // MOR-1575 found this fixture was itself stale: `ic7300-state.json` was
-    // captured (backendHeadSha e0b19814) before MOR-1548 landed (eabd506b),
-    // so it still carried the PRE-migration top-level `notchFilter` shape —
-    // `main` had no `notchFilter` key at all, making this refusal look
-    // structural (the field could never exist, no matter what was ever
-    // observed) rather than the ordinary fail-closed "never confirmed on
-    // the bench" reason every other DSP sub-parameter above hits. The
-    // fixture is now corrected to the current-schema receiver-scoped shape
-    // (`fixture-provenance.guard.test.ts`'s `KNOWN_STALE_FIELDS` entry for
-    // this drift is closed) — same still-unobserved fact, now at its
-    // correct path, so the gate refuses for the right, non-structural
-    // reason; no fixture-derived input domain exists here either, so the
-    // input value below stays the same neutral literal as before.
+    // (`knownReceiverField('notchFilter')`, i.e. it reads `main.notchFilter`)
+    // but this fixture's `main` object has no `notchFilter` key at all.
+    // MOR-1575 confirmed the PRODUCTION mapping (backend routing +
+    // frontend gate) has been correct and consistent since MOR-1548 — this
+    // fixture is simply a byte-faithful capture (backendHeadSha e0b19814)
+    // taken before that fix landed, so it still carries the pre-migration
+    // top-level `notchFilter` shape. This is NOT proof `set_notch_filter`
+    // is structurally dead on real IC-7300 hardware: the capture also
+    // predates the MOR-1492 membership wave, so `notch_filter` had no
+    // acquisition membership at capture time (never polled, honestly
+    // missing) — today `ic7300.toml` polls it every ~25s, so a genuine
+    // bench re-capture at HEAD may show it observed, i.e. the control
+    // DISPATCHES. Only the bench can settle that (see
+    // `fixture-provenance.guard.test.ts`'s `KNOWN_STALE_FIELDS.ic7300`,
+    // held pending MOR-1558/MOR-1410) — this pin must NOT be hand-edited to
+    // assert a different fieldStatus shape in the meantime. The input value
+    // below is a neutral literal (same convention as the exemplar's
+    // `onMicGainChange(100)` refusal case), not a fixture- or radio-derived
+    // number.
     expect(IC7300_CAPABILITIES.capabilities).toContain('notch');
-    expect(IC7300_STATE.main).toHaveProperty('notchFilter');
-    expect(IC7300_STATE.fieldStatus?.['main.notchFilter']?.observed).toBe(false);
+    expect(IC7300_STATE.main).not.toHaveProperty('notchFilter');
     expectRefusal(() => makeDspHandlers().onNotchFreqChange(0));
   });
 


### PR DESCRIPTION
## Summary

MOR-1575 was filed on the premise that `set_notch_filter`/`onNotchFreqChange` is structurally dead on IC-7300: the handler gates on `knownReceiverField('notchFilter')` (reads `state.main.notchFilter`), and a committed fixture appeared to show IC-7300 emitting `notchFilter` as a top-level `global.operator_controls.notch_filter` field with no `main.notchFilter` counterpart.

**Investigation confirms that premise rested on a stale fixture, not on production behavior.** Backend and frontend have been correct and mutually consistent since MOR-1548 — this PR ships no production code change. The one remaining live question (does `main.notchFilter` actually get observed on a real IC-7300 at HEAD, and does the control dispatch) moves to a genuine MOR-1558/MOR-1410 bench re-capture; it is not something a test fixture edit can answer.

## Investigation

1. **Backend (`src/rigplane/runtime/_civ_rx.py`, `rigs/ic7300.toml`, `rigs/ic7610.toml`)**: notch readback (CI-V `0x14 0x0D`) is **already receiver-scoped** for both radios. `_OBSERVABLE_CMD14_FIELDS[0x0D]` maps to `("receiver", "operator_controls", "notch_filter")` — a single, radio-agnostic observation table entry, not a per-radio branch. `rigs/ic7300.toml`'s field-policy membership list explicitly declares `"receiver.main.operator_controls.notch_filter"`. Both routes were fixed together by MOR-1548 (PR #2466, commit `eabd506b`, *"fix: notch readback is receiver-scoped, matching the 7610 route"*), which reclassified the field from global to receiver-scoped for both profiles at once, with a follow-up (`19654350`, #2471) threading `receiver` through the write path too. No per-radio branch exists — 7610 behavior is untouched by this PR and needed no route-table changes.

2. **Frontend schema (`frontend/src/lib/types/state.ts`)**: `notchFilter?: number` is declared **only** inside `ReceiverStatePublic` (line 187) — `ServerStatePublic` has no top-level `notchFilter` at all. The frontend gate in `panel-commands.ts`'s `onNotchFreqChange` (`knownReceiverField('notchFilter')`) already matches this current schema and was already updated as part of the MOR-1548 wave.

3. **The fixture artifact**: `frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json` — the only piece of evidence cited in the ticket — is a frozen live-bench capture (`ic7300-provenance.json`: `backendHeadSha: e0b19814`), which predates `eabd506b` (MOR-1548) by a long stretch of history (confirmed via `git merge-base --is-ancestor`). It still carries the pre-migration top-level `notchFilter` shape. This exact drift was **already known and tracked**: `fixture-provenance.guard.test.ts`'s `KNOWN_STALE_FIELDS` allow-list has an `ic7300: { stateTopLevel: ['notchFilter'], fieldStatus: ['notchFilter'] }` entry with an explicit comment: *"Remove an entry ONLY once the fixture is genuinely re-captured."*

## Disposition: no production bug, fixture left alone pending a genuine bench re-capture

An earlier revision of this PR hand-edited `ic7300-state.json` to relocate `notchFilter` into the receiver-scoped shape. That edit was **reverted** after independent review found it was a doctrine violation with real semantic consequences, not a harmless cleanup:

- `getFieldAvailability` resolves `'available'` for a path with **no own and no ancestor** `fieldStatus` entry. Pre-edit, `main.notchFilter` resolved available-by-absence and the refusal in the `mor1560` pin came from the missing *value*. The hand-edit added an explicit `availability: "missing"` entry, which made the refusal rest on a fabricated status instead — semantics were not preserved, a node that previously resolved available was locked shut by hand.
- The capture predates the **MOR-1492** field-policy membership wave, not just MOR-1548: at capture time `notch_filter` had no acquisition membership at all and was never polled (honestly missing then). Today `ic7300.toml` polls it every ~25s. A genuine bench re-capture at HEAD may show it **observed**, i.e. the control **dispatches** — the opposite of what the hand-edit pinned. The bench is the only authority for that question.
- The hand-edit made `ic7300-provenance.json`'s sidecar dishonest: it claims `backendHeadSha e0b19814`, but the edited content no longer matched anything that backend SHA ever actually emitted, and `ic7300-profile.ts`'s explicit "byte-faithful... no embedded metadata of their own" contract was violated with no way for the sidecar cross-check (no content hash) to catch it.
- `KNOWN_STALE_FIELDS`'s own comment is explicit: close an entry **only** once the fixture is genuinely re-captured from hardware, not hand-patched.

`ic7300-state.json` is now restored to the byte-faithful `origin/main` capture, `KNOWN_STALE_FIELDS.ic7300` is restored (with a note on why it's held, not closed), and the `mor1560` pin is re-worded to correctly frame the refusal as a capture artifact predating MOR-1548/MOR-1492 — not a live production structural gap — while keeping its original, true assertion about this specific capture (`main` has no `notchFilter` key on it).

## Changes (2 net files touched beyond the fixture revert)

- `frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-state.json`: reverted to `origin/main` (byte-faithful capture, unedited).
- `frontend/src/lib/runtime/adapters/__tests__/conformance/fixture-provenance.guard.test.ts`: restored `KNOWN_STALE_FIELDS.ic7300` verbatim, with an added MOR-1575 note explaining production is confirmed correct since `eabd506b` and this entry is held pending the MOR-1558/C4 bench re-capture.
- `frontend/src/lib/runtime/adapters/__tests__/mor1560-dsp-family-conformance.isolated.test.ts`: kept `expect(IC7300_STATE.main).not.toHaveProperty('notchFilter')` (a true statement about this specific capture) and re-worded the test title/comment only, to stop implying a production structural gap.

## Test plan

- [x] `npx vitest run` foreground (timeout 600000): `mor1560-dsp-family-conformance.isolated.test.ts`, `fixture-provenance.guard.test.ts`, `panel-commands-completeness.test.ts` — 45/45 passing
- [x] `npx eslint` on changed files — clean
- [x] No backend files touched — ruff/mypy/lint-imports not applicable
- [x] Boundary grep (`192\.168|\bmoroz\b|\bmini\b|:8099|preview-mor`) on diff and this body — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)