### PR TITLE
fix: explicit normalized-vs-raw level semantics (MOR-1579)

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -643,24 +643,59 @@ def _should_normalize_level_expectation(name: str, path: FieldPath) -> bool:
     return _NORMALIZED_LEVEL_EXPECTATION_COMMANDS.get(name) == path.name
 
 
-def _raw_level_from_param(value: Any) -> int:
-    """Coerce a level command param to the raw 0-255 scale.
+def _raw_int_level_from_param(value: Any) -> int:
+    """Coerce a raw-only level command param (MOR-1579).
 
-    MOR-334 regression fix: ``set_rf_gain``/``set_af_level``/``set_squelch``
-    accept a level either pre-scaled (raw 0-255) or normalized (0.0-1.0, as the
-    web sliders emit). The migration replaced the prior scale-aware coercion
-    with a bare ``int()``, so a normalized slider value (e.g. ``0.98``)
-    collapsed to ``int(0.98) == 0``. The expected/overlay value (used for
-    readback reconciliation) then sat at the opposite end of the scale from the
-    value the radio was actually set to, which surfaced as the control snapping
-    back to ``0`` (left edge) ~1s after a set. Mirror the web control-handler
-    coercion (``_normalized_or_raw_level``) so the StateStore expectation tracks
-    reality. Raw ints (and the boundary ``1.0``) round-trip unchanged.
+    ``set_rf_gain``/``set_sql``/``set_squelch``: both the web frontend
+    (``radio-intents.ts`` declares ``'integer'``) and the documented
+    HTTP/WS command catalog agree the wire value is always a raw 0-255
+    integer, never a normalized float. Dispatch on the JSON *type*, not
+    magnitude — a value in ``[0, 1]`` used to be silently reinterpreted as
+    normalized (MOR-1579's headline bug: raw level ``1`` became raw
+    ``255``). A non-int or an out-of-range int is a caller bug, not an
+    alternate encoding, so it raises instead of being coerced.
+
+    This value feeds both the StateStore readback expectation (via
+    :func:`_expected_value_for_path`) *and*, on the ``public_api`` sync
+    ingress (:mod:`rigplane.runtime.sync`), the actual value sent to the
+    radio (``_SyncCommandExecutor`` reads ``intent.params["squelch"]``
+    directly) — so this function is the actuation path there, not just
+    bookkeeping.
     """
-    numeric = float(value)
-    if 0.0 <= numeric <= 1.0:
-        return max(0, min(255, round(numeric * 255)))
-    return max(0, min(255, int(numeric)))
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"level {value!r} must be a raw integer 0-255, not {type(value).__name__}"
+        )
+    if not (0 <= value <= 255):
+        raise ValueError(f"level {value!r} is out of the raw 0-255 domain")
+    return int(value)
+
+
+def _af_level_from_param(value: Any) -> int:
+    """Coerce ``set_af_level``'s type-dispatched level param (MOR-1579).
+
+    Two documented wire contracts coexist for this one intent: the
+    HTTP/WS command catalog (``docs/api/command-catalog.md``) declares
+    ``level: int`` on the raw 0-255 scale (see the live-hardware
+    validation recipe's ``level:35`` example, which expects raw BCD
+    ``0035``); the web frontend (``radio-intents.ts`` declares
+    ``'normalized'``) sends a JSON float in 0.0-1.0. Dispatch on JSON
+    type, never magnitude: an int is always raw, a float is always
+    normalized, matching MOR-334's original coercion for float input
+    while restoring int input to a true no-op. Out-of-domain values for
+    either type raise rather than being reinterpreted as the other.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"level {value!r} must be an int or a normalized float")
+    if isinstance(value, int):
+        if not (0 <= value <= 255):
+            raise ValueError(f"level {value!r} is out of the raw 0-255 domain")
+        return value
+    if isinstance(value, float):
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
+        return max(0, min(255, round(value * 255)))
+    raise ValueError(f"level {value!r} must be an int or a normalized float")
 
 
 def _normalize_raw_level_value(value: Any) -> Any:
@@ -870,11 +905,11 @@ def command_intent_from_request(
     elif command_name == "ptt_off":
         normalized["ptt"] = False
     elif command_name == "set_rf_gain":
-        normalized["rf_gain"] = _raw_level_from_param(normalized["level"])
+        normalized["rf_gain"] = _raw_int_level_from_param(normalized["level"])
     elif command_name == "set_af_level":
-        normalized["af_level"] = _raw_level_from_param(normalized["level"])
+        normalized["af_level"] = _af_level_from_param(normalized["level"])
     elif command_name in ("set_sql", "set_squelch"):
-        normalized["squelch"] = _raw_level_from_param(normalized["level"])
+        normalized["squelch"] = _raw_int_level_from_param(normalized["level"])
     elif command_name in ("set_att", "set_attenuator", "set_attenuator_level"):
         raw_value = (
             normalized["db"]

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -698,6 +698,44 @@ def _af_level_from_param(value: Any) -> int:
     raise ValueError(f"level {value!r} must be an int or a normalized float")
 
 
+def _power_level_expectation_from_param(value: Any) -> int:
+    """Coerce ``set_rf_power``/``set_power``'s StateStore expectation param.
+
+    MOR-1579 round 3: this used to be a plain ``int(raw_level)``, so a
+    normalized float level (e.g. ``0.4`` from the web power slider —
+    ``control.py``'s ``_level_for_power`` treats ``set_rf_power`` as
+    type-dispatched, same as ``set_af_level``) collapsed to
+    ``int(0.4) == 0``. The StateStore overlay/expectation then sat at 0%
+    for the optimistic-update TTL before jumping to the real readback —
+    the same snap-back class MOR-1579 fixes for ``rf_gain``/``squelch``,
+    reproduced here on every single power-slider move rather than only at
+    a boundary value.
+
+    ``_normalize_raw_level_value`` (below) always divides this value by
+    255 to recover the normalized overlay value, and *both* backends'
+    readbacks normalize to that same fraction ``v`` regardless of unit —
+    Icom CI-V as ``raw / 255``, Yaesu CAT as ``watts / max_watts`` (see
+    ``backends/yaesu_cat/observations.py``'s ``_normalize_power_level``).
+    So for a float input the coherent expectation is always
+    ``round(v * 255)``, independent of ``native_power_unit`` — no radio
+    object needed here (unlike ``control.py``'s ``_level_for_power``,
+    which *does* need ``profile.max_watts`` to compute the correct
+    *actuation* value for a watts radio).
+
+    A bare int is the documented raw/watts wire value (unchanged from
+    before this fix) — dividing it by 255 to form the expectation is only
+    exact for ``raw_255`` radios; for a watts radio this is a known,
+    separate, deferred gap (see the PR body's "Known follow-up"), since
+    the profile needed to convert watts to a fraction isn't reachable
+    from this intent-normalization function.
+    """
+    if isinstance(value, float) and not isinstance(value, bool):
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
+        return max(0, min(255, round(value * 255)))
+    return int(value)
+
+
 def _normalize_raw_level_value(value: Any) -> Any:
     if isinstance(value, bool):
         return value
@@ -948,7 +986,7 @@ def command_intent_from_request(
         raw_level = (
             normalized["level"] if "level" in normalized else normalized["value"]
         )
-        normalized["power_level"] = int(raw_level)
+        normalized["power_level"] = _power_level_expectation_from_param(raw_level)
     elif command_name == "set_split":
         normalized["split"] = bool(normalized.get("on", False))
     elif command_name == "set_rit":

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -716,11 +716,19 @@ def _power_level_expectation_from_param(value: Any) -> int:
     readbacks normalize to that same fraction ``v`` regardless of unit —
     Icom CI-V as ``raw / 255``, Yaesu CAT as ``watts / max_watts`` (see
     ``backends/yaesu_cat/observations.py``'s ``_normalize_power_level``).
-    So for a float input the coherent expectation is always
-    ``round(v * 255)``, independent of ``native_power_unit`` — no radio
-    object needed here (unlike ``control.py``'s ``_level_for_power``,
-    which *does* need ``profile.max_watts`` to compute the correct
-    *actuation* value for a watts radio).
+    So for a float input the coherent expectation is ``round(v * 255)``,
+    independent of ``native_power_unit`` — no radio object needed here
+    (unlike ``control.py``'s ``_level_for_power``, which *does* need
+    ``profile.max_watts`` to compute the correct *actuation* value for a
+    watts radio). This is exact for ``raw_255`` radios; for a ``watts``
+    radio it is accurate to within 1/255 of full scale, since
+    ``round(v * max_watts) / max_watts`` (the real readback's
+    quantization) and ``round(v * 255) / 255`` (this expectation's
+    quantization) are different roundings of the same ``v`` and don't
+    always land on the same value — in practice most float positions on
+    a watts radio simply expire by TTL instead of confirming
+    ``reconciled``, rather than snapping to a visibly wrong overlay (the
+    residual error is bounded at <=0.2% of full scale).
 
     A bare int is the documented raw/watts wire value (unchanged from
     before this fix) — dividing it by 255 to form the expectation is only

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -254,11 +254,41 @@ class _CommandMetadataQueue:
             self.queue.put_ordered(command, future=future)
 
 
-def _normalized_or_raw_level(value: Any) -> int:
+def _level_from_normalized(value: Any) -> int:
+    """Convert a normalized 0.0-1.0 level param to the raw 0-255 wire scale.
+
+    MOR-1579: level params used to be interpreted by *magnitude* — any
+    value in ``[0, 1]`` was assumed normalized, anything else was assumed
+    already raw. That silently misread a legitimate raw value of ``1``
+    (e.g. ``set_rf_gain`` at the bottom of its 0-255 range) as "100%
+    normalized" and drove the radio to full scale. Callers must now
+    declare which wire shape their intent actually uses; this helper is
+    for intents whose frontend contract is a normalized 0.0-1.0 float
+    (``set_rf_power``, ``set_af_level`` — see
+    ``frontend/src/lib/runtime/commands/radio-intents.ts``). An
+    out-of-domain value is a caller bug, not an alternate encoding, so it
+    raises instead of being silently reinterpreted as raw.
+    """
     numeric = float(value)
-    if 0.0 <= numeric <= 1.0:
-        return max(0, min(255, round(numeric * 255)))
-    return int(numeric)
+    if not (0.0 <= numeric <= 1.0):
+        raise ValueError(
+            f"level {numeric!r} is out of the normalized 0.0-1.0 domain "
+            "(this command expects a normalized level, not a raw value)"
+        )
+    return max(0, min(255, round(numeric * 255)))
+
+
+def _level_from_raw(value: Any) -> int:
+    """Coerce an already-raw wire-scale level param.
+
+    MOR-1579: for intents whose frontend contract sends the raw integer
+    directly (``set_rf_gain``, ``set_sql``/``set_squelch`` — see
+    ``frontend/src/lib/runtime/commands/radio-intents.ts``, declared
+    ``'integer'``), the value is used as-is. Range validation is left to
+    the downstream BCD encoder, which already raises on out-of-range
+    raw values.
+    """
+    return int(float(value))
 
 
 class ControlHandler:
@@ -1964,7 +1994,7 @@ class ControlHandler:
                         "command set_rf_power is not supported by this radio "
                         "(radio does not implement PowerControlCapable)"
                     )
-                level = _normalized_or_raw_level(params["level"])
+                level = _level_from_normalized(params["level"])
                 # Tag the unit per radio's wire-level scale. Icom CI-V
                 # backends expose ``native_power_unit = "raw_255"``,
                 # Yaesu CAT exposes ``"watts"`` — see
@@ -2170,7 +2200,7 @@ class ControlHandler:
                         "command set_rf_gain is not supported by this radio "
                         "(missing rf_gain capability)"
                     )
-                level = _normalized_or_raw_level(params["level"])
+                level = _level_from_raw(params["level"])
                 rx = int(params.get("receiver", 0))
                 self._ensure_capability("rf_gain", "set_rf_gain")
                 self._ensure_receiver_supported(rx)
@@ -2184,7 +2214,7 @@ class ControlHandler:
                         "command set_af_level is not supported by this radio "
                         "(missing af_level capability)"
                     )
-                level = _normalized_or_raw_level(params["level"])
+                level = _level_from_normalized(params["level"])
                 rx = int(params.get("receiver", 0))
                 self._ensure_capability("af_level", "set_af_level")
                 self._ensure_receiver_supported(rx)
@@ -2198,7 +2228,7 @@ class ControlHandler:
                         f"command {name!r} is not supported by this radio "
                         "(missing squelch capability)"
                     )
-                level = _normalized_or_raw_level(params["level"])
+                level = _level_from_raw(params["level"])
                 rx = int(params.get("receiver", 0))
                 self._ensure_capability("squelch", name)
                 self._ensure_receiver_supported(rx)

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -13,6 +13,8 @@ from ..._bounded_queue import BoundedQueue
 from ...core.command_service import (
     CommandExecutionResult,
     CommandService,
+    _af_level_from_param,
+    _raw_int_level_from_param,
     command_intent_from_request,
 )
 from ...core.state_pipeline_contracts import CommandIntent, CommandSource
@@ -254,41 +256,41 @@ class _CommandMetadataQueue:
             self.queue.put_ordered(command, future=future)
 
 
-def _level_from_normalized(value: Any) -> int:
-    """Convert a normalized 0.0-1.0 level param to the raw 0-255 wire scale.
+def _level_for_power(value: Any, radio: Any) -> int:
+    """Coerce ``set_rf_power``/``set_power``'s type-dispatched level param.
 
-    MOR-1579: level params used to be interpreted by *magnitude* — any
-    value in ``[0, 1]`` was assumed normalized, anything else was assumed
-    already raw. That silently misread a legitimate raw value of ``1``
-    (e.g. ``set_rf_gain`` at the bottom of its 0-255 range) as "100%
-    normalized" and drove the radio to full scale. Callers must now
-    declare which wire shape their intent actually uses; this helper is
-    for intents whose frontend contract is a normalized 0.0-1.0 float
-    (``set_rf_power``, ``set_af_level`` — see
-    ``frontend/src/lib/runtime/commands/radio-intents.ts``). An
-    out-of-domain value is a caller bug, not an alternate encoding, so it
-    raises instead of being silently reinterpreted as raw.
+    MOR-1579: dispatch on JSON type, never magnitude. A JSON float in
+    ``[0.0, 1.0]`` is normalized — scaled to the radio's native wire
+    range: 0-255 for Icom CI-V (``native_power_unit == "raw_255"``), or
+    0-``max_watts`` for Yaesu CAT (``native_power_unit == "watts"``,
+    using ``radio.profile.max_watts`` — the exact inverse of the ratio
+    :meth:`backends.yaesu_cat.observations.ObservationBuilder._normalize_power_level`
+    applies when reporting watts *back* as a normalized state value). A
+    bare int is already the documented raw/watts value (HTTP/WS command
+    catalog: "0-255 raw (Icom CI-V); watts (Yaesu CAT)") and is used
+    as-is, regardless of unit — this restores ``set_rf_power(level=50)``
+    on a watts radio to 50 W, which the old magnitude heuristic also
+    produced (any value ``> 1`` passed through raw) but by accident of
+    bucketing on magnitude rather than by declared type.
     """
-    numeric = float(value)
-    if not (0.0 <= numeric <= 1.0):
-        raise ValueError(
-            f"level {numeric!r} is out of the normalized 0.0-1.0 domain "
-            "(this command expects a normalized level, not a raw value)"
-        )
-    return max(0, min(255, round(numeric * 255)))
-
-
-def _level_from_raw(value: Any) -> int:
-    """Coerce an already-raw wire-scale level param.
-
-    MOR-1579: for intents whose frontend contract sends the raw integer
-    directly (``set_rf_gain``, ``set_sql``/``set_squelch`` — see
-    ``frontend/src/lib/runtime/commands/radio-intents.ts``, declared
-    ``'integer'``), the value is used as-is. Range validation is left to
-    the downstream BCD encoder, which already raises on out-of-range
-    raw values.
-    """
-    return int(float(value))
+    if isinstance(value, bool):
+        raise ValueError(f"level {value!r} must be an int or a normalized float")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
+        if getattr(radio, "native_power_unit", "raw_255") == "watts":
+            profile = getattr(radio, "profile", None)
+            max_watts = getattr(profile, "max_watts", None)
+            if (
+                isinstance(max_watts, (int, float))
+                and not isinstance(max_watts, bool)
+                and max_watts > 0
+            ):
+                return max(0, min(int(max_watts), round(value * max_watts)))
+        return max(0, min(255, round(value * 255)))
+    raise ValueError(f"level {value!r} must be an int or a normalized float")
 
 
 class ControlHandler:
@@ -1994,7 +1996,7 @@ class ControlHandler:
                         "command set_rf_power is not supported by this radio "
                         "(radio does not implement PowerControlCapable)"
                     )
-                level = _level_from_normalized(params["level"])
+                level = _level_for_power(params["level"], radio)
                 # Tag the unit per radio's wire-level scale. Icom CI-V
                 # backends expose ``native_power_unit = "raw_255"``,
                 # Yaesu CAT exposes ``"watts"`` — see
@@ -2200,7 +2202,7 @@ class ControlHandler:
                         "command set_rf_gain is not supported by this radio "
                         "(missing rf_gain capability)"
                     )
-                level = _level_from_raw(params["level"])
+                level = _raw_int_level_from_param(params["level"])
                 rx = int(params.get("receiver", 0))
                 self._ensure_capability("rf_gain", "set_rf_gain")
                 self._ensure_receiver_supported(rx)
@@ -2214,7 +2216,7 @@ class ControlHandler:
                         "command set_af_level is not supported by this radio "
                         "(missing af_level capability)"
                     )
-                level = _level_from_normalized(params["level"])
+                level = _af_level_from_param(params["level"])
                 rx = int(params.get("receiver", 0))
                 self._ensure_capability("af_level", "set_af_level")
                 self._ensure_receiver_supported(rx)
@@ -2228,7 +2230,7 @@ class ControlHandler:
                         f"command {name!r} is not supported by this radio "
                         "(missing squelch capability)"
                     )
-                level = _level_from_raw(params["level"])
+                level = _raw_int_level_from_param(params["level"])
                 rx = int(params.get("receiver", 0))
                 self._ensure_capability("squelch", name)
                 self._ensure_receiver_supported(rx)

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1622,6 +1622,50 @@ def test_public_api_sync_squelch_actuation_value_is_not_reinterpreted() -> None:
     assert intent.params["squelch"] == 1
 
 
+def test_power_level_float_expectation_matches_readback_scale() -> None:
+    """MOR-1579 round 3 regression (red-first leg): the ``set_rf_power``
+    expectation branch used to do a plain ``int(raw_level)``, so a
+    normalized float level (e.g. ``0.4`` from the web power slider —
+    ``control.py``'s ``_level_for_power`` treats ``set_rf_power`` as
+    type-dispatched, same as ``set_af_level``) collapsed to
+    ``int(0.4) == 0``. The StateStore overlay/expectation then sat at 0%
+    for the optimistic-update TTL on *every single power-slider move*
+    (not just a boundary value like the rf_gain/squelch raw-1 case),
+    before jumping to the real readback — the same snap-back class this
+    PR fixes elsewhere.
+
+    Both backends' readbacks normalize to the same fraction ``v``
+    regardless of unit (Icom CI-V as ``raw / 255``, Yaesu CAT as
+    ``watts / max_watts`` — see
+    ``backends/yaesu_cat/observations.py``'s ``_normalize_power_level``),
+    so the coherent expectation for a float input is ``round(v * 255)``
+    for *both* units, independent of ``native_power_unit`` — no radio
+    object needed here.
+    """
+    intent = command_intent_from_request(
+        "set_rf_power",
+        {"level": 0.4},
+        source="websocket",
+        command_id="ws-set_rf_power",
+        session_id="client-a",
+    )
+    path = FieldPath.global_("operator_controls", "power_level")
+
+    # Param is coerced to the raw scale the radio actually receives — not 0.
+    assert intent.params["power_level"] == 102  # round(0.4 * 255)
+
+    # The expectation/overlay value the readback reconciles against is the
+    # normalized form of that same raw value (~0.4), not 0.0.
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=70.0,
+        provider="test",
+    )
+    assert str(intent.target) == str(path)
+    assert observation.value == pytest.approx(102 / 255)
+    assert observation.value == pytest.approx(0.4, abs=0.01)
+
+
 @pytest.mark.asyncio
 async def test_raw_external_rigctld_level_readback_normalizes_before_reconcile() -> (
     None

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1474,57 +1474,46 @@ async def test_set_squelch_command_response_reconciles_normalized_overlay() -> N
     ]
 
 
-@pytest.mark.parametrize(
-    ("name", "path_name"),
-    [
-        ("set_rf_gain", "rf_gain"),
-        ("set_af_level", "af_level"),
-        ("set_squelch", "squelch"),
-    ],
-)
-def test_normalized_level_command_expectation_matches_radio_scale(
-    name: str,
-    path_name: str,
-) -> None:
+def test_normalized_level_command_expectation_matches_radio_scale() -> None:
     """MOR-334 regression (rf-gain set reverts to 0 / left edge).
 
-    Web level sliders emit a normalized 0.0-1.0 ``level``. The migration
-    coerced the command param with a bare ``int()``, so a slider at 98%
-    (``0.98``) collapsed to ``int(0.98) == 0`` and the StateStore expectation /
-    overlay sat at the *opposite* end of the scale from the value the radio was
-    actually driven to (``round(0.98 * 255) == 250``). The deferred readback
-    (~0.98) then never matched the bogus ``0`` expectation, surfacing as the
-    control snapping back to 0. The expected/overlay value must track the same
-    raw scale the radio is set to via
-    :func:`rigplane.core.command_service._raw_level_from_param`.
+    The web AF-level slider emits a normalized 0.0-1.0 ``level`` — this is
+    ``set_af_level``'s genuine, documented frontend contract (unlike
+    ``set_rf_gain``/``set_squelch``, which are raw-int-only; see MOR-1579
+    below). The migration coerced the command param with a bare ``int()``,
+    so a slider at 98% (``0.98``) collapsed to ``int(0.98) == 0`` and the
+    StateStore expectation/overlay sat at the *opposite* end of the scale
+    from the value the radio was actually driven to
+    (``round(0.98 * 255) == 250``). The deferred readback (~0.98) then
+    never matched the bogus ``0`` expectation, surfacing as the control
+    snapping back to 0. The expected/overlay value must track the same raw
+    scale the radio is set to via
+    :func:`rigplane.core.command_service._af_level_from_param`.
 
-    MOR-1579 note: this StateStore expectation-tracking heuristic is a
-    separate, still-magnitude-based implementation from
-    ``web/handlers/control.py``'s dispatch-time coercion (which MOR-1579
-    replaced with explicit per-intent ``_level_from_normalized`` /
-    ``_level_from_raw`` helpers). ``_raw_level_from_param`` itself was
-    intentionally left untouched by MOR-1579 (out of that fix's file/LOC
-    budget — see the PR body) and still has the same normalized-vs-raw
-    boundary ambiguity; ``0.98`` here is a normalized-domain value that
-    exercises it unchanged, not a claim that ``set_rf_gain``/``set_squelch``
-    web sliders actually emit normalized floats (they emit raw integers,
-    per PR #2491).
+    MOR-1579 follow-up: this test used to also parametrize over
+    ``set_rf_gain``/``set_squelch`` with the same ``0.98`` float, which was
+    itself an instance of the bug this PR fixes — those two intents are
+    raw-int-only (PR #2491), so a float is never valid input for them at
+    all, not "normalized 0.98". See
+    ``test_raw_level_one_expectation_is_not_reinterpreted_as_full_scale``
+    and ``test_squelch_float_level_rejected_not_silently_coerced`` below
+    for their corrected coverage.
     """
-    from rigplane.core.command_service import _raw_level_from_param
+    from rigplane.core.command_service import _af_level_from_param
 
     intent = command_intent_from_request(
-        name,
+        "set_af_level",
         {"level": 0.98, "receiver": 0},
         source="websocket",
-        command_id=f"ws-{name}",
+        command_id="ws-set_af_level",
         session_id="client-a",
     )
-    path = FieldPath.receiver("0", "operator_controls", path_name)
+    path = FieldPath.receiver("0", "operator_controls", "af_level")
 
     # Param is coerced to the raw scale the radio actually receives — not 0.
-    radio_raw = _raw_level_from_param(0.98)
+    radio_raw = _af_level_from_param(0.98)
     assert radio_raw == 250
-    assert intent.params[path_name] == radio_raw
+    assert intent.params["af_level"] == radio_raw
 
     # The expectation/overlay value the readback reconciles against is the
     # normalized form of that same raw value (~0.98), not 0.0.
@@ -1541,12 +1530,96 @@ def test_normalized_level_command_expectation_matches_radio_scale(
 def test_normalized_af_level_fifty_round_trips_to_raw_fifty() -> None:
     """The public AF fixture stays normalized while the server owns raw conversion.
 
-    set_af_level's wire contract is normalized 0.0-1.0 (MOR-1579), so this
-    exercises the control handler's ``_level_from_normalized`` directly.
+    set_af_level's frontend wire contract is normalized 0.0-1.0 (MOR-1579),
+    so a float in that domain exercises ``_af_level_from_param`` directly
+    (shared by both ``web/handlers/control.py``'s dispatch-time coercion
+    and this module's StateStore expectation coercion).
     """
-    from rigplane.web.handlers.control import _level_from_normalized
+    from rigplane.core.command_service import _af_level_from_param
 
-    assert _level_from_normalized(50 / 255) == 50
+    assert _af_level_from_param(50 / 255) == 50
+
+
+@pytest.mark.parametrize(
+    ("name", "path_name"),
+    [
+        ("set_rf_gain", "rf_gain"),
+        ("set_squelch", "squelch"),
+    ],
+)
+def test_raw_level_one_expectation_is_not_reinterpreted_as_full_scale(
+    name: str,
+    path_name: str,
+) -> None:
+    """MOR-1579 regression (red-first leg): the magnitude heuristic used
+    to treat any level in ``[0, 1]`` as normalized, so a legitimate raw
+    level of ``1`` produced a StateStore expectation/overlay of ``1.0``
+    (100%) instead of ``1/255`` (~0.4%) — the *opposite* end of the scale,
+    reproducing the MOR-334 snap-back class in the other direction: the
+    overlay would show 100% for the optimistic-update TTL, then "snap
+    back" to ~0.4% once the real readback landed. ``set_rf_gain`` and
+    ``set_squelch`` are raw-int-only (PR #2491) — an int level of ``1``
+    must expectation-track as raw ``1`` (normalized ``1/255``), never as
+    normalized ``1.0``.
+    """
+    from rigplane.core.command_service import _raw_int_level_from_param
+
+    intent = command_intent_from_request(
+        name,
+        {"level": 1, "receiver": 0},
+        source="websocket",
+        command_id=f"ws-{name}",
+        session_id="client-a",
+    )
+    path = FieldPath.receiver("0", "operator_controls", path_name)
+
+    radio_raw = _raw_int_level_from_param(1)
+    assert radio_raw == 1
+    assert intent.params[path_name] == radio_raw
+
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=70.0,
+        provider="test",
+    )
+    assert str(intent.target) == str(path)
+    assert observation.value == pytest.approx(1 / 255)
+    assert observation.value < 0.01
+
+
+def test_squelch_float_level_rejected_not_silently_coerced() -> None:
+    """MOR-1579: set_squelch is raw-int-only — a float is never a valid
+    encoding for it, even one that superficially looks like a plausible
+    normalized value. Type dispatch, never magnitude.
+    """
+    from rigplane.core.command_service import _raw_int_level_from_param
+
+    with pytest.raises(ValueError, match="raw integer"):
+        _raw_int_level_from_param(0.5)
+
+
+def test_public_api_sync_squelch_actuation_value_is_not_reinterpreted() -> None:
+    """MOR-1579 regression (red-first leg): ``_raw_level_from_param`` was
+    NOT expectation-only — on the ``public_api`` sync ingress
+    (:mod:`rigplane.runtime.sync`), its output is the *actual* value sent
+    to the radio. ``_SyncCommandExecutor.execute`` reads
+    ``intent.params["squelch"]`` directly and calls
+    ``radio.set_squelch(int(params["squelch"]), ...)`` — it never looks at
+    ``intent.params["level"]``. So ``sync.set_squelch(level=1)`` used to
+    build an intent whose ``params["squelch"]`` was ``255`` (the same
+    magnitude-heuristic bug as the wire-level fix, but unfixed on this
+    ingress), driving the radio to full squelch instead of raw level 1.
+    This builds the exact intent ``IcomRadio.set_squelch(1, receiver=0)``
+    constructs and asserts the actuation value ``_SyncCommandExecutor``
+    would read is raw ``1``, not ``255``.
+    """
+    intent = command_intent_from_request(
+        "set_squelch",
+        {"level": 1, "receiver": 0},
+        source="public_api",
+    )
+
+    assert intent.params["squelch"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1495,9 +1495,22 @@ def test_normalized_level_command_expectation_matches_radio_scale(
     actually driven to (``round(0.98 * 255) == 250``). The deferred readback
     (~0.98) then never matched the bogus ``0`` expectation, surfacing as the
     control snapping back to 0. The expected/overlay value must track the same
-    raw scale the radio is set to via ``_normalized_or_raw_level``.
+    raw scale the radio is set to via
+    :func:`rigplane.core.command_service._raw_level_from_param`.
+
+    MOR-1579 note: this StateStore expectation-tracking heuristic is a
+    separate, still-magnitude-based implementation from
+    ``web/handlers/control.py``'s dispatch-time coercion (which MOR-1579
+    replaced with explicit per-intent ``_level_from_normalized`` /
+    ``_level_from_raw`` helpers). ``_raw_level_from_param`` itself was
+    intentionally left untouched by MOR-1579 (out of that fix's file/LOC
+    budget — see the PR body) and still has the same normalized-vs-raw
+    boundary ambiguity; ``0.98`` here is a normalized-domain value that
+    exercises it unchanged, not a claim that ``set_rf_gain``/``set_squelch``
+    web sliders actually emit normalized floats (they emit raw integers,
+    per PR #2491).
     """
-    from rigplane.web.handlers.control import _normalized_or_raw_level
+    from rigplane.core.command_service import _raw_level_from_param
 
     intent = command_intent_from_request(
         name,
@@ -1509,7 +1522,7 @@ def test_normalized_level_command_expectation_matches_radio_scale(
     path = FieldPath.receiver("0", "operator_controls", path_name)
 
     # Param is coerced to the raw scale the radio actually receives — not 0.
-    radio_raw = _normalized_or_raw_level(0.98)
+    radio_raw = _raw_level_from_param(0.98)
     assert radio_raw == 250
     assert intent.params[path_name] == radio_raw
 
@@ -1526,10 +1539,14 @@ def test_normalized_level_command_expectation_matches_radio_scale(
 
 
 def test_normalized_af_level_fifty_round_trips_to_raw_fifty() -> None:
-    """The public AF fixture stays normalized while the server owns raw conversion."""
-    from rigplane.web.handlers.control import _normalized_or_raw_level
+    """The public AF fixture stays normalized while the server owns raw conversion.
 
-    assert _normalized_or_raw_level(50 / 255) == 50
+    set_af_level's wire contract is normalized 0.0-1.0 (MOR-1579), so this
+    exercises the control handler's ``_level_from_normalized`` directly.
+    """
+    from rigplane.web.handlers.control import _level_from_normalized
+
+    assert _level_from_normalized(50 / 255) == 50
 
 
 @pytest.mark.asyncio

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -725,19 +725,35 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     Protocol property added in epic #1322) instead of the legacy
     ``backend_id == "yaesu_cat"`` discriminator.
 
-    MOR-1579: the ``level`` param is normalized 0.0-1.0 regardless of
-    backend (the frontend slider is hardcoded min=0/max=1) — only the
-    *unit tag* attached to the outgoing ``SetPower`` differs by radio.
+    MOR-1579: ``level`` is type-dispatched, not magnitude-dispatched. An
+    int is the documented raw/watts value and passes through unchanged
+    regardless of unit (``level=50`` on a watts radio means 50 W — the
+    HTTP/WS command catalog's documented contract, and also what the
+    pre-1579 magnitude heuristic coincidentally produced for any value
+    ``> 1``). A float in ``[0, 1]`` is normalized, scaled to the radio's
+    native wire range: ``value * profile.max_watts`` for watts radios
+    (the exact inverse of
+    ``backends.yaesu_cat.observations.ObservationBuilder._normalize_power_level``,
+    which reports watts back as ``watts / max_watts``), or ``value *
+    255`` for raw_255 radios.
     """
     queue = _QueueRecorder()
     server = SimpleNamespace(command_queue=queue)
 
     radio = _capable_radio()
     radio.native_power_unit = "watts"
+    assert radio.profile.max_watts == 100
     handler = _control_handler(radio=radio, server=server)
-    await handler._enqueue_command("set_rf_power", {"level": 0.2})
+
+    # int: documented raw/watts value, passed through unchanged.
+    await handler._enqueue_command("set_rf_power", {"level": 50})
     assert isinstance(queue.items[-1], SetPower)
-    assert queue.items[-1].level == 51
+    assert queue.items[-1].level == 50
+    assert queue.items[-1].unit == "watts"
+
+    # float: normalized, scaled by profile.max_watts (not 255).
+    await handler._enqueue_command("set_rf_power", {"level": 0.2})
+    assert queue.items[-1].level == 20
     assert queue.items[-1].unit == "watts"
 
     queue2 = _QueueRecorder()
@@ -745,8 +761,15 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     radio2 = _capable_radio()
     radio2.native_power_unit = "raw_255"
     handler2 = _control_handler(radio=radio2, server=server2)
-    await handler2._enqueue_command("set_rf_power", {"level": 0.8})
+
+    # int: documented raw value, passed through unchanged.
+    await handler2._enqueue_command("set_rf_power", {"level": 200})
     assert isinstance(queue2.items[-1], SetPower)
+    assert queue2.items[-1].level == 200
+    assert queue2.items[-1].unit == "raw_255"
+
+    # float: normalized, scaled by 255 (no max_watts machinery for raw_255).
+    await handler2._enqueue_command("set_rf_power", {"level": 0.8})
     assert queue2.items[-1].level == 204
     assert queue2.items[-1].unit == "raw_255"
 
@@ -755,9 +778,9 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
 @pytest.mark.parametrize(
     ("name", "params", "expected_type", "expected_level"),
     [
-        # MOR-1579: set_rf_power and set_af_level declare a normalized
-        # 0.0-1.0 wire contract (radio-intents.ts) — in-domain values
-        # convert to the raw 0-255 scale.
+        # MOR-1579: set_rf_power and set_af_level are type-dispatched — a
+        # JSON *float* is the frontend's normalized 0.0-1.0 wire contract
+        # (radio-intents.ts) and converts to the raw 0-255 scale.
         ("set_rf_power", {"level": 0.5}, SetPower, 128),
         ("set_af_level", {"level": 0.25, "receiver": 0}, SetAfLevel, 64),
     ],
@@ -783,12 +806,17 @@ async def test_enqueue_normalized_level_controls_convert_to_raw_wire_scale(
 @pytest.mark.parametrize(
     ("name", "params", "expected_type", "expected_level"),
     [
-        # MOR-1579: set_rf_gain and set_squelch declare a raw 0-255 wire
-        # contract (radio-intents.ts declares 'integer', PR #2491
-        # confirmed set_rf_gain sends a raw integer) — values pass through
-        # unchanged, never scaled as if normalized.
+        # MOR-1579: set_rf_gain and set_squelch are raw-int-only — every
+        # int passes through unchanged, never scaled as if normalized
+        # (radio-intents.ts declares 'integer'; PR #2491 confirmed
+        # set_rf_gain sends a raw integer).
         ("set_rf_gain", {"level": 128, "receiver": 0}, SetRfGain, 128),
         ("set_squelch", {"level": 191, "receiver": 0}, SetSquelch, 191),
+        # MOR-1579: set_af_level is type-dispatched — a JSON *int* is the
+        # documented HTTP/WS raw 0-255 contract (docs/api/command-catalog.md,
+        # live-hardware validation recipe's level:35→raw 0035 example) and
+        # also passes through unchanged.
+        ("set_af_level", {"level": 72, "receiver": 0}, SetAfLevel, 72),
     ],
 )
 async def test_enqueue_raw_level_controls_pass_through_unscaled(
@@ -839,28 +867,67 @@ async def test_enqueue_raw_level_one_is_not_reinterpreted_as_full_scale(
     assert queue.items[-1].level == 1
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("name", "params"),
-    [
-        ("set_rf_power", {"level": 5}),
-        ("set_af_level", {"level": 5, "receiver": 0}),
-    ],
-)
-async def test_enqueue_normalized_level_out_of_domain_rejects_loudly(
-    name: str,
-    params: dict[str, object],
-) -> None:
-    """MOR-1579: an out-of-domain value for a normalized-intent level must
-    raise, not be silently reinterpreted as an already-raw value (the old
-    magnitude heuristic's behavior for ``set_af_level(5)`` was to
-    silently treat it as raw ``5`` ~= 2% — a silent meaning switch).
+async def test_enqueue_af_level_int_one_is_raw_but_float_one_is_full_scale() -> None:
+    """MOR-1579: type dispatch, not magnitude — ``int(1)`` and ``float(1.0)``
+    are the *same number* but different JSON types, and set_af_level must
+    treat them differently: an int is always the documented raw 0-255
+    value (``1`` stays raw ``1``, ~0.4%), a float is always normalized
+    0.0-1.0 (``1.0`` is 100%, raw ``255``). No shared magnitude heuristic
+    may reinterpret one as the other.
     """
     queue = _QueueRecorder()
     server = SimpleNamespace(command_queue=queue)
     handler = _control_handler(radio=_capable_radio(), server=server)
 
-    with pytest.raises(ValueError, match="normalized"):
+    result = await handler._enqueue_command("set_af_level", {"level": 1, "receiver": 0})
+    assert result["level"] == 1
+    assert queue.items[-1].level == 1
+
+    result = await handler._enqueue_command(
+        "set_af_level", {"level": 1.0, "receiver": 0}
+    )
+    assert result["level"] == 255
+    assert queue.items[-1].level == 255
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params"),
+    [
+        # set_af_level: out-of-domain for whichever type was sent.
+        ("set_af_level", {"level": 1.5, "receiver": 0}),  # float outside [0, 1]
+        ("set_af_level", {"level": 300, "receiver": 0}),  # int outside 0-255
+        # set_rf_power: out-of-domain normalized float. (A bare int has no
+        # upper bound check here — range validation for the raw/watts int
+        # path is left to the downstream encoder's backstop, same as
+        # set_rf_gain/set_squelch below.)
+        ("set_rf_power", {"level": 1.5}),
+        # set_rf_gain / set_squelch: raw-int-only — a float is *never*
+        # valid, even one that looks like a plausible normalized value.
+        # This is the crux of "type dispatch, never magnitude": 0.5 is
+        # in-domain for a normalized reading but set_rf_gain/set_squelch
+        # never accept normalized input at all.
+        ("set_rf_gain", {"level": 0.5, "receiver": 0}),
+        ("set_rf_gain", {"level": 300, "receiver": 0}),  # int outside 0-255
+        ("set_squelch", {"level": 0.5, "receiver": 0}),
+        ("set_squelch", {"level": 300, "receiver": 0}),  # int outside 0-255
+    ],
+)
+async def test_enqueue_level_type_or_domain_violation_rejects_loudly(
+    name: str,
+    params: dict[str, object],
+) -> None:
+    """MOR-1579: a value that is either the wrong JSON type for its
+    intent's wire contract, or in-type but out of domain, must raise —
+    never be silently reinterpreted as the other encoding (the old
+    magnitude heuristic's behavior for e.g. ``set_af_level(5)`` was to
+    silently treat it as raw ``5`` ~= 2%, a silent meaning switch).
+    """
+    queue = _QueueRecorder()
+    server = SimpleNamespace(command_queue=queue)
+    handler = _control_handler(radio=_capable_radio(), server=server)
+
+    with pytest.raises(ValueError):
         await handler._enqueue_command(name, params)
 
 

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -412,13 +412,20 @@ def _scope_frame() -> ScopeFrame:
         ("ptt", {"state": True}, PttOn, {}, {"state": True}),
         ("ptt", {"state": False}, PttOff, {}, {"state": False}),
         (
+            # MOR-1579: set_rf_power's wire contract is a normalized 0.0-1.0
+            # float (frontend ValueControl min=0/max=1/step=0.01) — 0.4 is
+            # in-domain and must convert to the raw 0-255 scale (round(0.4 *
+            # 255) == 102), not pass through unchanged.
             "set_rf_power",
-            {"level": 88},
+            {"level": 0.4},
             SetPower,
-            {"level": 88, "unit": "raw_255"},
-            {"level": 88},
+            {"level": 102, "unit": "raw_255"},
+            {"level": 102},
         ),
         (
+            # MOR-1579: set_rf_gain's wire contract is already the raw
+            # 0-255 scale (frontend sends integers directly, PR #2491) —
+            # 77 must pass through unchanged.
             "set_rf_gain",
             {"level": 77, "receiver": 1},
             SetRfGain,
@@ -426,11 +433,15 @@ def _scope_frame() -> ScopeFrame:
             {"level": 77, "receiver": 1},
         ),
         (
+            # MOR-1579: set_af_level's wire contract is a normalized 0.0-1.0
+            # float (radio-intents.ts declares 'normalized') — 0.6 is
+            # in-domain and must convert to the raw 0-255 scale (round(0.6 *
+            # 255) == 153), not pass through unchanged.
             "set_af_level",
-            {"level": 66, "receiver": 1},
+            {"level": 0.6, "receiver": 1},
             SetAfLevel,
-            {"level": 66, "receiver": 1},
-            {"level": 66, "receiver": 1},
+            {"level": 153, "receiver": 1},
+            {"level": 153, "receiver": 1},
         ),
         (
             "set_sql",
@@ -713,6 +724,10 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     The handler now reads ``radio.native_power_unit`` (the Capability
     Protocol property added in epic #1322) instead of the legacy
     ``backend_id == "yaesu_cat"`` discriminator.
+
+    MOR-1579: the ``level`` param is normalized 0.0-1.0 regardless of
+    backend (the frontend slider is hardcoded min=0/max=1) — only the
+    *unit tag* attached to the outgoing ``SetPower`` differs by radio.
     """
     queue = _QueueRecorder()
     server = SimpleNamespace(command_queue=queue)
@@ -720,9 +735,9 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     radio = _capable_radio()
     radio.native_power_unit = "watts"
     handler = _control_handler(radio=radio, server=server)
-    await handler._enqueue_command("set_rf_power", {"level": 50})
+    await handler._enqueue_command("set_rf_power", {"level": 0.2})
     assert isinstance(queue.items[-1], SetPower)
-    assert queue.items[-1].level == 50
+    assert queue.items[-1].level == 51
     assert queue.items[-1].unit == "watts"
 
     queue2 = _QueueRecorder()
@@ -730,9 +745,9 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     radio2 = _capable_radio()
     radio2.native_power_unit = "raw_255"
     handler2 = _control_handler(radio=radio2, server=server2)
-    await handler2._enqueue_command("set_rf_power", {"level": 200})
+    await handler2._enqueue_command("set_rf_power", {"level": 0.8})
     assert isinstance(queue2.items[-1], SetPower)
-    assert queue2.items[-1].level == 200
+    assert queue2.items[-1].level == 204
     assert queue2.items[-1].unit == "raw_255"
 
 
@@ -740,10 +755,11 @@ async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
 @pytest.mark.parametrize(
     ("name", "params", "expected_type", "expected_level"),
     [
+        # MOR-1579: set_rf_power and set_af_level declare a normalized
+        # 0.0-1.0 wire contract (radio-intents.ts) — in-domain values
+        # convert to the raw 0-255 scale.
         ("set_rf_power", {"level": 0.5}, SetPower, 128),
-        ("set_rf_gain", {"level": 0.5, "receiver": 0}, SetRfGain, 128),
         ("set_af_level", {"level": 0.25, "receiver": 0}, SetAfLevel, 64),
-        ("set_squelch", {"level": 0.75, "receiver": 0}, SetSquelch, 191),
     ],
 )
 async def test_enqueue_normalized_level_controls_convert_to_raw_wire_scale(
@@ -761,6 +777,91 @@ async def test_enqueue_normalized_level_controls_convert_to_raw_wire_scale(
     assert result["level"] == expected_level
     assert isinstance(queue.items[-1], expected_type)
     assert queue.items[-1].level == expected_level
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "expected_type", "expected_level"),
+    [
+        # MOR-1579: set_rf_gain and set_squelch declare a raw 0-255 wire
+        # contract (radio-intents.ts declares 'integer', PR #2491
+        # confirmed set_rf_gain sends a raw integer) — values pass through
+        # unchanged, never scaled as if normalized.
+        ("set_rf_gain", {"level": 128, "receiver": 0}, SetRfGain, 128),
+        ("set_squelch", {"level": 191, "receiver": 0}, SetSquelch, 191),
+    ],
+)
+async def test_enqueue_raw_level_controls_pass_through_unscaled(
+    name: str,
+    params: dict[str, object],
+    expected_type: type,
+    expected_level: int,
+) -> None:
+    queue = _QueueRecorder()
+    server = SimpleNamespace(command_queue=queue)
+    handler = _control_handler(radio=_capable_radio(), server=server)
+
+    result = await handler._enqueue_command(name, params)
+
+    assert result["level"] == expected_level
+    assert isinstance(queue.items[-1], expected_type)
+    assert queue.items[-1].level == expected_level
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "expected_type"),
+    [
+        ("set_rf_gain", {"level": 1, "receiver": 0}, SetRfGain),
+        ("set_squelch", {"level": 1, "receiver": 0}, SetSquelch),
+    ],
+)
+async def test_enqueue_raw_level_one_is_not_reinterpreted_as_full_scale(
+    name: str,
+    params: dict[str, object],
+    expected_type: type,
+) -> None:
+    """MOR-1579 regression: the magnitude heuristic used to treat any
+    level in ``[0, 1]`` as normalized, so a legitimate raw level of ``1``
+    (e.g. the bottom of RF gain's 0-255 range, reachable via the keyboard
+    delta/direction adjust paths) was silently reinterpreted as 100%
+    normalized and driven the radio to full scale (255) instead of the
+    requested raw value of 1.
+    """
+    queue = _QueueRecorder()
+    server = SimpleNamespace(command_queue=queue)
+    handler = _control_handler(radio=_capable_radio(), server=server)
+
+    result = await handler._enqueue_command(name, params)
+
+    assert result["level"] == 1
+    assert isinstance(queue.items[-1], expected_type)
+    assert queue.items[-1].level == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params"),
+    [
+        ("set_rf_power", {"level": 5}),
+        ("set_af_level", {"level": 5, "receiver": 0}),
+    ],
+)
+async def test_enqueue_normalized_level_out_of_domain_rejects_loudly(
+    name: str,
+    params: dict[str, object],
+) -> None:
+    """MOR-1579: an out-of-domain value for a normalized-intent level must
+    raise, not be silently reinterpreted as an already-raw value (the old
+    magnitude heuristic's behavior for ``set_af_level(5)`` was to
+    silently treat it as raw ``5`` ~= 2% — a silent meaning switch).
+    """
+    queue = _QueueRecorder()
+    server = SimpleNamespace(command_queue=queue)
+    handler = _control_handler(radio=_capable_radio(), server=server)
+
+    with pytest.raises(ValueError, match="normalized"):
+        await handler._enqueue_command(name, params)
 
 
 async def test_enqueue_command_errors() -> None:


### PR DESCRIPTION
## Summary

- `_normalized_or_raw_level` in `src/rigplane/web/handlers/control.py` interpreted its `level` argument by **magnitude**: any value in `[0, 1]` was assumed normalized (scaled ×255), anything else was assumed already raw. That silently misread a legitimate raw level of `1` (e.g. `set_rf_gain` at the bottom of its 0-255 range, reachable via the keyboard delta/direction adjust paths from PR #2491) as "100% normalized" and drove the radio to full scale (255) instead of the requested raw value.
- **Round 1** replaced the wire-dispatch heuristic in `control.py` with per-intent normalized/raw helpers, but left a second, independent copy of the same magnitude heuristic (`_raw_level_from_param` in `src/rigplane/core/command_service.py`) untouched, and got `set_af_level`/`set_rf_power`'s contract wrong (treated as always-normalized). Independent review caught both — see "Round 2" below.
- **Round 2**: replaced *both* copies with **type-based dispatch** (JSON `int` vs `float`), never magnitude, per the coordinator's ruling. `_raw_int_level_from_param` and `_af_level_from_param` now live once in `command_service.py` (core layer) and are imported into `control.py`, so the websocket/HTTP dispatch path and the StateStore expectation/sync-ingress actuation path can't drift apart again the way the two separate heuristics did.
- **Round 3 (this state)**: round 2 flagged `set_rf_power`'s StateStore expectation branch (`command_service.py`, plain `int(raw_level)`) as a deferred follow-up, reasoning it needed the radio object for `native_power_unit`/`profile.max_watts`. Independent review proved that reasoning wrong for the *expectation* value specifically and found a live, every-move bug: a normalized float power-slider level (e.g. `0.4`) collapsed to `int(0.4) == 0`, so the StateStore overlay showed 0% on every single power-slider move before jumping to the real readback — the exact snap-back class this PR fixes for `rf_gain`, but reachable far more often. Fixed with `_power_level_expectation_from_param`: `_normalize_raw_level_value` always divides by 255, and both backends' readbacks normalize to the same fraction regardless of unit (Icom `raw/255`, Yaesu `watts/max_watts`), so the coherent expectation for a float input is `round(value * 255)` for *both* units — no radio object needed for this specific computation.

## Bugs found by independent review (round 1 → round 2)

1. **Overlay/expectation incoherence (real, reachable).** Round 1 fixed the actual wire command (raw `1` stays raw `1`) but not `command_service.py`'s `_raw_level_from_param`, which drives the StateStore readback expectation/overlay via `_expected_value_for_path`. A raw `rf_gain`/`squelch` set of `1` showed the overlay at 100% for the optimistic-update TTL, then snapped to ~0.4% once the real readback landed — the MOR-334 snap-back class, reproduced in the opposite direction.
2. **Sync-ingress actuation (real, unfixed in round 1).** `_raw_level_from_param` is **not** expectation-only. On the `public_api` sync ingress (`rigplane.runtime.sync`), `_SyncCommandExecutor.execute` reads `intent.params["squelch"]` directly as the value sent to the radio (`radio.set_squelch(int(params["squelch"]), ...)`) — it never looks at `intent.params["level"]`. `sync.set_squelch(level=1)` built `radio.set_squelch(255)`: the headline bug, unfixed on that wire.
3. **Documented HTTP/WS contract breakage.** Round 1 made `set_af_level`/`set_rf_power` always-normalized. But `docs/api/command-catalog.md` documents `set_af_level` as `level: int`, "0-255 raw scale", with worked examples (`level:72`, `level:50`, `level:35` — the last one also appears in `docs/internals/radio-state-pipeline-validation.md`'s live-hardware validation recipe, expecting raw BCD `0035`). All of those 400'd under the always-normalized design.
4. **Yaesu watts path broken-only.** Round 1's test change enshrined float `0.2 → 51 W` on a 100 W rig, when int `level=50 → 50 W` was the correct, documented behavior for that ingress.

## Coordinator ruling: type-based dispatch, never magnitude

| Intent | JSON `int` | JSON `float` | Wrong type / out of domain |
|---|---|---|---|
| `set_rf_gain` / `set_sql` / `set_squelch` | raw 0-255, used as-is | **never valid** | `ValueError` |
| `set_af_level` | raw 0-255, used as-is (HTTP/WS command-catalog contract) | normalized `[0,1]` → `round(value * 255)` (frontend `radio-intents.ts` contract) | `ValueError` |
| `set_rf_power` / `set_power` | the documented raw/watts value, used as-is regardless of unit | normalized `[0,1]` → scaled to the radio's native wire range (`value * 255` for `raw_255`; `value * profile.max_watts` for `watts`) | `ValueError` |

`int(1)` and `float(1.0)` are the same number but different JSON types and now give different, correct results for `set_af_level`: `1` stays raw `1` (~0.4%), `1.0` becomes normalized full scale (`255`). No shared magnitude heuristic anywhere.

The watts-scaling formula (`value * profile.max_watts`) is the exact inverse of the ratio `backends/yaesu_cat/observations.py`'s `ObservationBuilder._normalize_power_level` (`watts / max_watts`) applies when reporting a watts readback back to the frontend as a normalized state value — so a normalized `set_rf_power` write and the normalized `powerLevel` state readback now agree on the same scale for watts radios.

## Where each helper lives

- `src/rigplane/core/command_service.py`: `_raw_int_level_from_param` (rf_gain/squelch) and `_af_level_from_param` (af_level) — used both by `command_intent_from_request`'s builder (StateStore expectation *and* `public_api` sync-ingress actuation) and imported into `control.py` for wire dispatch, so both paths share one implementation.
- `src/rigplane/web/handlers/control.py`: `_level_for_power` (rf_power) stays local — it needs the `radio` object (`native_power_unit`, `profile.max_watts`) to compute the correct *wire actuation* value for a watts radio. `command_service.py`'s `_power_level_expectation_from_param` (round 3) does **not** need the radio object — the StateStore *expectation* value is `round(value * 255)` for a float, regardless of unit, computed without a radio handle. This is exact for `raw_255` radios and accurate to within 1/255 of full scale for `watts` radios (see "Known follow-up" below for why that's not user-visible, and for the one remaining case that does need the radio object).
- `rigctld`'s separate `set_level` → `_normalize_level_value` path (`command_service.py`, different lines) is **untouched** — different ingress, different documented contract, explicitly out of this fix's blast radius per the coordinator's ruling.

## Wire-visible changes

Beyond the original `set_rf_gain(level=1)`/`set_squelch(level=1)` fix (raw `1` now stays `1` instead of becoming `255`):

- `set_rf_gain`/`set_squelch` now reject a float outright — previously any float in `[0,1]` silently became a scaled raw value (e.g. `0.5` → `128`); now it raises. No real frontend traffic sends a float to these intents (radio-intents.ts declares `'integer'`), so this only affects malformed/pathological input.
- `set_af_level`/`set_rf_power` reject an out-of-domain int or out-of-domain float instead of silently reinterpreting it as the other encoding.
- A `set_rf_power` float level on a **watts** radio (e.g. FTX-1) now scales by `profile.max_watts` instead of by `255` — this is a genuine behavior *correction*, not a regression: the old magnitude heuristic never had watts-aware scaling for float input at all (it only coincidentally passed ints through unchanged), so a normalized slider value sent to a watts radio was previously being scaled as if it were a 0-255 raw radio, producing a nonsensical (usually far too low) watts value.
- All previously-passing documented HTTP/WS examples (`level:72`, `level:50`, `level:35` for `set_af_level`) now pass unchanged — verified directly (see "Doc verification" below). **No doc edits were needed.**

## Doc verification (Fix 2)

Ran the three cited examples directly against the new helpers:

```
af_level int 72 -> 72
af_level int 50 -> 50
af_level int 35 -> 35
squelch int 0 -> 0
```

All pass through unchanged, confirming `docs/api/command-catalog.md` and `docs/internals/radio-state-pipeline-validation.md`'s live-hardware recipe stay true with zero doc changes.

## Red-first evidence (all legs)

Verified red by temporarily reverting `_raw_int_level_from_param`/`_af_level_from_param` (command_service.py) and `_level_for_power` (control.py) to the old magnitude-heuristic body under the new names/call sites, then restoring byte-identical to the fix (diffed against a pre-revert backup to confirm exact restoration):

**`command_service.py` legs** (overlay expectation + sync-ingress actuation):
```
FAILED test_raw_level_one_expectation_is_not_reinterpreted_as_full_scale[set_rf_gain-rf_gain]
    assert radio_raw == 1
E   assert 255 == 1
FAILED test_raw_level_one_expectation_is_not_reinterpreted_as_full_scale[set_squelch-squelch]
    assert radio_raw == 1
E   assert 255 == 1
FAILED test_squelch_float_level_rejected_not_silently_coerced
    Failed: DID NOT RAISE <class 'ValueError'>
FAILED test_public_api_sync_squelch_actuation_value_is_not_reinterpreted
    assert intent.params["squelch"] == 1
E   assert 255 == 1
```

**`control.py` legs** (af_level type dispatch + watts-aware rf_power):
```
FAILED test_enqueue_set_rf_power_yaesu_tags_watts_unit
    assert queue.items[-1].level == 20
E   AssertionError: assert 51 == 20
FAILED test_enqueue_af_level_int_one_is_raw_but_float_one_is_full_scale
    assert result["level"] == 1
E   assert 255 == 1
FAILED test_enqueue_level_type_or_domain_violation_rejects_loudly[...]  (7 parametrized cases)
    Failed: DID NOT RAISE <class 'ValueError'>
```

Restored the fix; all 710 tests across the touched + regression-swept modules pass green (see Test plan).

**Round 3 leg** (`set_rf_power` StateStore expectation, `test_power_level_float_expectation_matches_readback_scale`): reverted `_power_level_expectation_from_param` back to the plain `int(raw_level)` it replaced, then re-ran just the new test:
```
FAILED test_power_level_float_expectation_matches_readback_scale
    assert intent.params["power_level"] == 102  # round(0.4 * 255)
E   assert 0 == 102
```
Restored the fix (diffed byte-identical against a pre-revert backup); the same test now passes, and the full targeted suite is green at 711 (see Test plan).

## Known follow-up (documented, not fixed — explicitly out of blast radius or scope)

- **The only remaining deferred leg**: the Yaesu **int**-watts StateStore expectation. `_power_level_expectation_from_param`'s int branch is an unchanged `int(raw_level)` pass-through — correct for the actual wire *actuation* value (documented raw/watts contract), but for the StateStore *expectation* on a watts radio it is wrong: e.g. `set_rf_power(level=50)` on a 100 W rig (FTX-1) stores `power_level = 50`, and `_normalize_raw_level_value` divides that by 255 for the overlay (`50 / 255 ≈ 0.196`), while the real readback normalizes as `watts / max_watts` (`50 / 100 = 0.5`) — overlay `0.196` vs readback `0.5`, an expectation/readback mismatch. Fixing this needs `profile.max_watts`, which is **unreachable from `command_intent_from_request`** (a pure intent-normalization function with no radio handle) — it would require plumbing the radio/profile through the intent-building call chain, a materially larger change. This leg has **two exposure surfaces**, not one: the web frontend's power slider only ever sends normalized floats (already fixed above), so it never hits this int branch — but both `POST /api/v1/commands`/`POST /api/v1/commands/batch` with an int `level`, *and* the sync API's `sync.set_rf_power(50)` (`{"value": 50}`, `command_service.py`'s builder reads `normalized["level"] if "level" in normalized else normalized["value"]`, so it enters this same branch and produces the same `power_level = 50` expectation) both reach it. Only the sync API's *actuation* value bypasses this coercion — `runtime/sync.py`'s `_SyncCommandExecutor` reads `intent.params["value"]` directly for the actual `radio.set_rf_power()` call — the actuation is correct regardless; it's the StateStore expectation that's wrong on both surfaces. The follow-up ticket for this needs to cover both. Flagged here for visibility, not fixed.
- `rigctld`'s `_normalize_level_value` (same file, different lines) is untouched per explicit instruction — different ingress, different contract.

## Test plan

- [x] Red-first (rounds 2 and 3): reverted then restored (byte-identical diff check each time) — see evidence above.
- [x] `uv run pytest tests/test_handlers_coverage.py tests/test_command_service.py tests/test_sync_coverage.py tests/test_yaesu_cat_observation_adapter.py tests/test_yaesu_web_projection.py tests/test_yaesu_cat_poller.py tests/test_ftx1_radio.py tests/test_power_unit_extension.py tests/test_rf_gain_af_level.py -q --tb=short` — **711 passed**, foreground, targeted (never full suite)
- [x] `uv run ruff check` / `uv run ruff format --check` on all 4 touched files — clean
- [x] `uv run mypy src/` — 13 pre-existing baseline errors (unrelated files, unchanged by this diff), zero new
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] Internal-identifier boundary check on diff and this body — clean

Closes MOR-1579

