### PR TITLE
fix(web-ui): gate amber indicators by availability (MOR-1586)

### DIFF
--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -418,7 +418,7 @@
       <!-- RIT / XIT offset (inline within cockpit, collapses when inactive) -->
       {#if (ritXit.hasRit && ritXit.ritActive) || (ritXit.hasXit && ritXit.xitActive)}
         <div class="lcd-rit-row">
-          <span class="rit-label">{ritXit.ritActive ? 'RIT' : 'XIT'}</span>
+          <span class="rit-label">{ritXit.hasRit && ritXit.ritActive ? 'RIT' : 'XIT'}</span>
           <span class="rit-value">{ritOffsetLabel}</span>
         </div>
       {/if}

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -65,11 +65,11 @@
   let hasCap = $derived(cockpitProps.hasCapability);
 
   // ── Adapter-derived state ──
-  let tx = $derived(toTxProps(radioState, null));
-  let ritXit = $derived(toRitXitProps(radioState, null));
-  let vfoOps = $derived(toVfoOpsProps(radioState, null));
+  let tx = $derived(toTxProps(radioState, caps));
+  let ritXit = $derived(toRitXitProps(radioState, caps));
+  let vfoOps = $derived(toVfoOpsProps(radioState, caps));
   let meter = $derived(toMeterProps(radioState, caps));
-  let dsp = $derived(toDspProps(radioState, null));
+  let dsp = $derived(toDspProps(radioState, caps));
   let filterProps = $derived(toFilterProps(radioState, caps));
 
   // MOR-1409 A14: `panel-props`' honesty-hardened projections default an
@@ -167,22 +167,25 @@
       id: 'tx', label: 'TX', active: tx.txActive,
       variant: tx.txActive ? 'tx' : undefined,
     },
-    ...(hasCap('vox') ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
-    ...(hasCap('compressor') ? [{
+    ...(hasCap('vox') && tx.voxAvailable
+      ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
+    ...(hasCap('compressor') && tx.compAvailable ? [{
       id: 'proc' as const,
-      label: tx.compActive ? `PROC ${tx.compLevel}` : 'PROC',
+      label: tx.compActive && tx.compLevelAvailable ? `PROC ${tx.compLevel}` : 'PROC',
       active: tx.compActive,
     }] : []),
-    ...(hasCap('tuner') ? [{
+    ...(hasCap('tuner') && tx.atuAvailable ? [{
       id: 'atu' as const,
       label: tx.atuTuning ? 'TUNE' : 'ATU',
       active: tx.atuActive,
       variant: tx.atuTuning ? ('tuning' as const) : undefined,
     }] : []),
-    ...(hasCap('split') ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
-    ...(hasCap('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
+    ...(hasCap('split') && isFieldAvailable(radioState, 'split')
+      ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
+    ...(hasCap('dial_lock') && isFieldAvailable(radioState, 'dialLock')
+      ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
     ...(dataActive ? [{ id: 'data' as const, label: 'DATA', active: true }] : []),
-    ...(hasCap('ip_plus') ? [{
+    ...(hasCap('ip_plus') && rxAvailable(radioState?.active === 'SUB' ? 'sub' : 'main', 'ipplus') ? [{
       // IP+ is a per-receiver setting on IC-7610 (codex P2 on PR #906).
       // Bind to the active RX so SUB's IP+ state is reflected when SUB is active.
       id: 'ipPlus' as const, label: 'IP+', active: rx?.ipplus ?? false,
@@ -260,7 +263,7 @@
   // vfoATokens: per-receiver indicators for VFO A (main)
   let vfoATokens = $derived<IndToken[]>([
     ...vfoTokens('main'),
-    ...(hasCap('rit') ? [{
+    ...(hasCap('rit') && ritXit.hasRit ? [{
       id: 'rit' as const, label: 'RIT', active: ritXit.ritActive,
     }] : []),
   ]);

--- a/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberCockpit.svelte
@@ -163,10 +163,10 @@
   // ── Indicator token arrays ──
   // globalTokens: radio-wide status indicators for the top global strip
   let globalTokens = $derived<IndToken[]>([
-    {
-      id: 'tx', label: 'TX', active: tx.txActive,
-      variant: tx.txActive ? 'tx' : undefined,
-    },
+    ...(tx.txActiveAvailable ? [{
+      id: 'tx' as const, label: 'TX', active: tx.txActive,
+      variant: tx.txActive ? ('tx' as const) : undefined,
+    }] : []),
     ...(hasCap('vox') && tx.voxAvailable
       ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
     ...(hasCap('compressor') && tx.compAvailable ? [{
@@ -416,7 +416,7 @@
       </div>
 
       <!-- RIT / XIT offset (inline within cockpit, collapses when inactive) -->
-      {#if ritXit.ritActive || ritXit.xitActive}
+      {#if (ritXit.hasRit && ritXit.ritActive) || (ritXit.hasXit && ritXit.xitActive)}
         <div class="lcd-rit-row">
           <span class="rit-label">{ritXit.ritActive ? 'RIT' : 'XIT'}</span>
           <span class="rit-value">{ritOffsetLabel}</span>

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -115,10 +115,10 @@
 
   // frontendTokens: TX-chain (TX/VOX/PROC/ATT/PRE)
   let frontendTokens = $derived<IndToken[]>([
-    {
-      id: 'tx', label: 'TX', active: tx.txActive,
-      variant: tx.txActive ? 'tx' : undefined,
-    },
+    ...(tx.txActiveAvailable ? [{
+      id: 'tx' as const, label: 'TX', active: tx.txActive,
+      variant: tx.txActive ? ('tx' as const) : undefined,
+    }] : []),
     ...(hasCap('vox') && tx.voxAvailable
       ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
     ...(hasCap('compressor') && tx.compAvailable ? [{

--- a/frontend/src/components-v2/panels/lcd/AmberScope.svelte
+++ b/frontend/src/components-v2/panels/lcd/AmberScope.svelte
@@ -55,10 +55,10 @@
     return caps?.agcLabels?.[String(agcMode)] ?? `${agcMode}`;
   }
 
-  let tx = $derived(toTxProps(radioState, null));
-  let ritXit = $derived(toRitXitProps(radioState, null));
-  let vfoOps = $derived(toVfoOpsProps(radioState, null));
-  let dsp = $derived(toDspProps(radioState, null));
+  let tx = $derived(toTxProps(radioState, caps));
+  let ritXit = $derived(toRitXitProps(radioState, caps));
+  let vfoOps = $derived(toVfoOpsProps(radioState, caps));
+  let dsp = $derived(toDspProps(radioState, caps));
   let filterProps = $derived(toFilterProps(radioState, caps));
 
   // MOR-1409 A14: `filterProps.filterWidth` is `Number.NaN` when
@@ -119,10 +119,11 @@
       id: 'tx', label: 'TX', active: tx.txActive,
       variant: tx.txActive ? 'tx' : undefined,
     },
-    ...(hasCap('vox') ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
-    ...(hasCap('compressor') ? [{
+    ...(hasCap('vox') && tx.voxAvailable
+      ? [{ id: 'vox' as const, label: 'VOX', active: tx.voxActive }] : []),
+    ...(hasCap('compressor') && tx.compAvailable ? [{
       id: 'proc' as const,
-      label: tx.compActive ? `PROC ${tx.compLevel}` : 'PROC',
+      label: tx.compActive && tx.compLevelAvailable ? `PROC ${tx.compLevel}` : 'PROC',
       active: tx.compActive,
     }] : []),
     ...(hasCap('attenuator') && rxAvailable('att') ? [{
@@ -175,9 +176,11 @@
     ...(hasCap('squelch') && rxAvailable('squelch') ? [{
       id: 'sql' as const, label: 'SQL', active: (rx?.squelch ?? 0) > 0,
     }] : []),
-    ...(hasCap('dial_lock') ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
-    ...(hasCap('split') ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
-    ...(hasCap('rit') ? [{
+    ...(hasCap('dial_lock') && isFieldAvailable(radioState, 'dialLock')
+      ? [{ id: 'lock' as const, label: 'LOCK', active: lockActive }] : []),
+    ...(hasCap('split') && isFieldAvailable(radioState, 'split')
+      ? [{ id: 'split' as const, label: 'SPLIT', active: vfoOps.splitActive }] : []),
+    ...(hasCap('rit') && ritXit.hasRit ? [{
       id: 'rit' as const, label: 'RIT', active: ritXit.ritActive,
     }] : []),
   ]);

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -45,6 +45,10 @@ const scopeProps = vi.hoisted(() => ({
   },
 }));
 
+const amberCaps = {
+  capabilities: ['rit', 'xit'],
+} as any;
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveAmberCockpitProps: () => cockpitProps.value,
   deriveAmberScopeProps: () => scopeProps.value,
@@ -85,11 +89,15 @@ function baseReceiver(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function mountCockpit(state: ServerState | null, hasAudioFft = false) {
+function mountCockpit(
+  state: ServerState | null,
+  hasAudioFft = false,
+  caps = amberCaps,
+) {
   cockpitProps.value = {
     radioState: state,
-    caps: null,
-    hasCapability: () => true,
+    caps,
+    hasCapability: (name: string) => caps?.capabilities?.includes(name) ?? false,
     hasAudioFft,
     hasDualReceiver: false,
   };
@@ -101,11 +109,15 @@ function mountCockpit(state: ServerState | null, hasAudioFft = false) {
   return target;
 }
 
-function mountScope(state: ServerState | null, hasAudioFft = false) {
+function mountScope(
+  state: ServerState | null,
+  hasAudioFft = false,
+  caps = amberCaps,
+) {
   scopeProps.value = {
     radioState: state,
-    caps: null,
-    hasCapability: () => true,
+    caps,
+    hasCapability: (name: string) => caps?.capabilities?.includes(name) ?? false,
     hasAudioFft,
     hasDualReceiver: false,
   };
@@ -139,6 +151,49 @@ describe('AmberCockpit / AmberScope import migration (MOR-1409 A14)', () => {
     const source = readFileSync('src/components-v2/panels/lcd/AmberScope.svelte', 'utf8');
     expect(source).not.toMatch(/wiring\/state-adapter/);
     expect(source).toContain("from '$lib/runtime/props/panel-props'");
+  });
+});
+
+describe('Amber RIT indicator availability (MOR-1586)', () => {
+  const fresh = {
+    storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
+  } as const;
+  const missing = {
+    storePath: 'fixture', observed: false, freshness: 'unknown', availability: 'missing',
+  } as const;
+
+  function indicatorLabels(target: HTMLElement): string[] {
+    return [...target.querySelectorAll('.lcd-ind')].map((indicator) => indicator.textContent ?? '');
+  }
+
+  it('uses the real capability props to render confirmed RIT in both entry points', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      ritOn: true,
+      ritFreq: 0,
+      ritTx: false,
+      fieldStatus: { ritOn: fresh, ritFreq: fresh, ritTx: fresh },
+    } as unknown as ServerState;
+
+    expect(indicatorLabels(mountCockpit(state))).toContain('RIT');
+    expect(indicatorLabels(mountScope(state))).toContain('RIT');
+  });
+
+  it('suppresses RIT rather than presenting an unobserved false value as confirmed off', () => {
+    const state = {
+      active: 'MAIN',
+      main: baseReceiver(),
+      sub: baseReceiver(),
+      ritOn: false,
+      ritFreq: 0,
+      ritTx: false,
+      fieldStatus: { ritOn: missing, ritFreq: missing, ritTx: missing },
+    } as unknown as ServerState;
+
+    expect(indicatorLabels(mountCockpit(state))).not.toContain('RIT');
+    expect(indicatorLabels(mountScope(state))).not.toContain('RIT');
   });
 });
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -210,104 +210,76 @@ describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
     storePath: 'fixture', observed: true, freshness: 'stale', availability: 'available',
   } as const;
 
-  function indicatorLabels(target: HTMLElement): string[] {
-    return [...target.querySelectorAll('.lcd-ind')].map((indicator) => indicator.textContent ?? '');
-  }
-
   function indicator(target: HTMLElement, label: string): Element | undefined {
     return [...target.querySelectorAll('.lcd-ind')]
       .find((element) => element.textContent === label);
   }
 
-  function fullyObservedState(fieldStatus: Record<string, typeof fresh | typeof missing | typeof stale>) {
-    return {
+  function stateFor(
+    field: string,
+    value: boolean | number,
+    status: typeof fresh | typeof missing | typeof stale,
+  ): ServerState {
+    const state: any = {
       active: 'MAIN',
       main: baseReceiver({ ipplus: true }), sub: baseReceiver(),
       ptt: true, voxOn: true, compressorOn: true, compressorLevel: 7,
       tunerStatus: 1, split: true, dialLock: true,
       ritOn: true, ritFreq: 250, ritTx: true,
-      fieldStatus,
-    } as unknown as ServerState;
+      fieldStatus: { [field]: status },
+    };
+    if (field === 'main.ipplus') state.main.ipplus = value;
+    else state[field] = value;
+    return state as ServerState;
   }
 
-  it('suppresses stale TX rather than rendering a confirmed state in both entry points', () => {
-    const state = {
-      active: 'MAIN', main: baseReceiver(), sub: baseReceiver(), ptt: true,
-      fieldStatus: { ptt: stale },
-    } as unknown as ServerState;
+  const tokenCases = [
+    ['TX', 'ptt', false, true, 'TX', [mountCockpit, mountScope]],
+    ['VOX', 'voxOn', false, true, 'VOX', [mountCockpit, mountScope]],
+    ['PROC', 'compressorOn', false, true, 'PROC 7', [mountCockpit, mountScope]],
+    ['ATU', 'tunerStatus', 0, 1, 'ATU', [mountCockpit]],
+    ['SPLIT', 'split', false, true, 'SPLIT', [mountCockpit, mountScope]],
+    ['LOCK', 'dialLock', false, true, 'LOCK', [mountCockpit, mountScope]],
+    ['IP+', 'main.ipplus', false, true, 'IP+', [mountCockpit]],
+    ['RIT', 'ritOn', false, true, 'RIT', [mountCockpit, mountScope]],
+  ] as const;
 
-    expect(indicatorLabels(mountCockpit(state))).not.toContain('TX');
-    expect(indicatorLabels(mountScope(state))).not.toContain('TX');
-  });
+  it.each(tokenCases)('%s distinguishes fresh off/on from missing/stale', (
+    _name, field, offValue, onValue, label, mounts,
+  ) => {
+    for (const mountPanel of mounts) {
+      const offLabel = _name === 'PROC' ? 'PROC' : label;
+      const off = indicator(mountPanel(stateFor(field, offValue, fresh)), offLabel);
+      expect(off).toBeDefined();
+      expect(off?.classList.contains('active')).toBe(false);
 
-  it('suppresses stale active RIT/XIT inline rows in the cockpit', () => {
-    const state = {
-      active: 'MAIN', main: baseReceiver(), sub: baseReceiver(),
-      ritOn: true, ritFreq: 250, ritTx: true,
-      fieldStatus: { ritOn: stale, ritFreq: stale, ritTx: stale },
-    } as unknown as ServerState;
-
-    expect(mountCockpit(state).querySelector('.lcd-rit-row')).toBeNull();
-  });
-
-  it('renders every changed token only from fresh facts in each applicable entry point', () => {
-    const fieldStatus = Object.fromEntries([
-      'ptt', 'voxOn', 'compressorOn', 'compressorLevel', 'tunerStatus',
-      'split', 'dialLock', 'main.ipplus', 'ritOn', 'ritFreq', 'ritTx',
-    ].map((field) => [field, fresh]));
-    const cockpit = mountCockpit(fullyObservedState(fieldStatus));
-    const scope = mountScope(fullyObservedState(fieldStatus));
-
-    for (const label of ['TX', 'VOX', 'PROC 7', 'ATU', 'SPLIT', 'LOCK', 'IP+', 'RIT']) {
-      expect(indicator(cockpit, label)).toBeDefined();
+      const on = indicator(mountPanel(stateFor(field, onValue, fresh)), label);
+      expect(on).toBeDefined();
+      expect(on?.classList.contains('active')).toBe(true);
+      expect(indicator(mountPanel(stateFor(field, onValue, missing)), label)).toBeUndefined();
+      expect(indicator(mountPanel(stateFor(field, onValue, stale)), label)).toBeUndefined();
     }
-    for (const label of ['TX', 'VOX', 'PROC 7', 'SPLIT', 'LOCK', 'RIT']) {
-      expect(indicator(scope, label)).toBeDefined();
-    }
-    expect(cockpit.querySelector('.rit-label')?.textContent).toBe('RIT');
   });
 
-  it('suppresses every changed token when the corresponding facts are missing or stale', () => {
-    const fieldStatus = Object.fromEntries([
-      'ptt', 'voxOn', 'compressorOn', 'compressorLevel', 'tunerStatus', 'split',
-      'dialLock', 'main.ipplus', 'ritOn', 'ritFreq', 'ritTx',
-    ].map((field, index) => [field, index % 2 === 0 ? missing : stale]));
-    const cockpit = mountCockpit(fullyObservedState(fieldStatus));
-    const scope = mountScope(fullyObservedState(fieldStatus));
-
-    for (const label of ['TX', 'VOX', 'PROC 7', 'ATU', 'SPLIT', 'LOCK', 'IP+', 'RIT']) {
-      expect(indicator(cockpit, label)).toBeUndefined();
+  it('distinguishes ATU from TUNE and never fabricates a PROC level', () => {
+    const tuning = indicator(mountCockpit(stateFor('tunerStatus', 2, fresh)), 'TUNE');
+    expect(tuning?.classList.contains('active')).toBe(true);
+    for (const status of [missing, stale]) {
+      expect(indicator(mountCockpit(stateFor('tunerStatus', 2, status)), 'TUNE')).toBeUndefined();
+      expect(indicator(mountCockpit(stateFor('compressorLevel', 7, status)), 'PROC')).toBeDefined();
+      expect(indicator(mountScope(stateFor('compressorLevel', 7, status)), 'PROC')).toBeDefined();
+      expect(indicator(mountCockpit(stateFor('compressorLevel', 7, status)), 'PROC 7')).toBeUndefined();
+      expect(indicator(mountScope(stateFor('compressorLevel', 7, status)), 'PROC 7')).toBeUndefined();
     }
-    for (const label of ['TX', 'VOX', 'PROC 7', 'SPLIT', 'LOCK', 'RIT']) {
-      expect(indicator(scope, label)).toBeUndefined();
-    }
-    expect(cockpit.querySelector('.lcd-rit-row')).toBeNull();
   });
 
-  it('preserves confirmed-off and confirmed-on distinctions without fabricating levels', () => {
-    const offState = fullyObservedState({ ritOn: fresh, ritFreq: fresh, ritTx: fresh, ptt: fresh });
-    offState.ritOn = false;
-    offState.ritTx = false;
-    offState.ptt = false;
-    const cockpit = mountCockpit(offState);
-    const scope = mountScope(offState);
-    expect(indicator(cockpit, 'RIT')?.classList.contains('active')).toBe(false);
-    expect(indicator(scope, 'RIT')?.classList.contains('active')).toBe(false);
-    expect(indicator(cockpit, 'TX')?.classList.contains('active')).toBe(false);
-    expect(indicator(scope, 'TX')?.classList.contains('active')).toBe(false);
-
-    const levelStale = fullyObservedState({ compressorOn: fresh, compressorLevel: stale });
-    expect(indicator(mountCockpit(levelStale), 'PROC')).toBeDefined();
-    expect(indicator(mountScope(levelStale), 'PROC')).toBeDefined();
-    expect(indicator(mountCockpit(levelStale), 'PROC 7')).toBeUndefined();
-    expect(indicator(mountScope(levelStale), 'PROC 7')).toBeUndefined();
-  });
-
-  it('renders the cockpit inline XIT row only when XIT is confirmed fresh', () => {
-    const state = fullyObservedState({ ritOn: fresh, ritFreq: fresh, ritTx: fresh });
-    state.ritOn = false;
-    state.ritTx = true;
-    expect(mountCockpit(state).querySelector('.rit-label')?.textContent).toBe('XIT');
+  it('shows inline XIT only for fresh XIT-on and hides missing/stale XIT', () => {
+    for (const status of [fresh, missing, stale]) {
+      const state = stateFor('ritTx', true, status) as any;
+      state.ritOn = false;
+      const label = mountCockpit(state).querySelector('.rit-label')?.textContent;
+      expect(label).toBe(status === fresh ? 'XIT' : undefined);
+    }
   });
 });
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -46,7 +46,9 @@ const scopeProps = vi.hoisted(() => ({
 }));
 
 const amberCaps = {
-  capabilities: ['rit', 'xit'],
+  capabilities: [
+    'rit', 'xit', 'vox', 'compressor', 'tuner', 'split', 'dial_lock', 'ip_plus',
+  ],
 } as any;
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
@@ -194,6 +196,118 @@ describe('Amber RIT indicator availability (MOR-1586)', () => {
 
     expect(indicatorLabels(mountCockpit(state))).not.toContain('RIT');
     expect(indicatorLabels(mountScope(state))).not.toContain('RIT');
+  });
+});
+
+describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
+  const fresh = {
+    storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
+  } as const;
+  const missing = {
+    storePath: 'fixture', observed: false, freshness: 'unknown', availability: 'missing',
+  } as const;
+  const stale = {
+    storePath: 'fixture', observed: true, freshness: 'stale', availability: 'available',
+  } as const;
+
+  function indicatorLabels(target: HTMLElement): string[] {
+    return [...target.querySelectorAll('.lcd-ind')].map((indicator) => indicator.textContent ?? '');
+  }
+
+  function indicator(target: HTMLElement, label: string): Element | undefined {
+    return [...target.querySelectorAll('.lcd-ind')]
+      .find((element) => element.textContent === label);
+  }
+
+  function fullyObservedState(fieldStatus: Record<string, typeof fresh | typeof missing | typeof stale>) {
+    return {
+      active: 'MAIN',
+      main: baseReceiver({ ipplus: true }), sub: baseReceiver(),
+      ptt: true, voxOn: true, compressorOn: true, compressorLevel: 7,
+      tunerStatus: 1, split: true, dialLock: true,
+      ritOn: true, ritFreq: 250, ritTx: true,
+      fieldStatus,
+    } as unknown as ServerState;
+  }
+
+  it('suppresses stale TX rather than rendering a confirmed state in both entry points', () => {
+    const state = {
+      active: 'MAIN', main: baseReceiver(), sub: baseReceiver(), ptt: true,
+      fieldStatus: { ptt: stale },
+    } as unknown as ServerState;
+
+    expect(indicatorLabels(mountCockpit(state))).not.toContain('TX');
+    expect(indicatorLabels(mountScope(state))).not.toContain('TX');
+  });
+
+  it('suppresses stale active RIT/XIT inline rows in the cockpit', () => {
+    const state = {
+      active: 'MAIN', main: baseReceiver(), sub: baseReceiver(),
+      ritOn: true, ritFreq: 250, ritTx: true,
+      fieldStatus: { ritOn: stale, ritFreq: stale, ritTx: stale },
+    } as unknown as ServerState;
+
+    expect(mountCockpit(state).querySelector('.lcd-rit-row')).toBeNull();
+  });
+
+  it('renders every changed token only from fresh facts in each applicable entry point', () => {
+    const fieldStatus = Object.fromEntries([
+      'ptt', 'voxOn', 'compressorOn', 'compressorLevel', 'tunerStatus',
+      'split', 'dialLock', 'main.ipplus', 'ritOn', 'ritFreq', 'ritTx',
+    ].map((field) => [field, fresh]));
+    const cockpit = mountCockpit(fullyObservedState(fieldStatus));
+    const scope = mountScope(fullyObservedState(fieldStatus));
+
+    for (const label of ['TX', 'VOX', 'PROC 7', 'ATU', 'SPLIT', 'LOCK', 'IP+', 'RIT']) {
+      expect(indicator(cockpit, label)).toBeDefined();
+    }
+    for (const label of ['TX', 'VOX', 'PROC 7', 'SPLIT', 'LOCK', 'RIT']) {
+      expect(indicator(scope, label)).toBeDefined();
+    }
+    expect(cockpit.querySelector('.rit-label')?.textContent).toBe('RIT');
+  });
+
+  it('suppresses every changed token when the corresponding facts are missing or stale', () => {
+    const fieldStatus = Object.fromEntries([
+      'ptt', 'voxOn', 'compressorOn', 'compressorLevel', 'tunerStatus', 'split',
+      'dialLock', 'main.ipplus', 'ritOn', 'ritFreq', 'ritTx',
+    ].map((field, index) => [field, index % 2 === 0 ? missing : stale]));
+    const cockpit = mountCockpit(fullyObservedState(fieldStatus));
+    const scope = mountScope(fullyObservedState(fieldStatus));
+
+    for (const label of ['TX', 'VOX', 'PROC 7', 'ATU', 'SPLIT', 'LOCK', 'IP+', 'RIT']) {
+      expect(indicator(cockpit, label)).toBeUndefined();
+    }
+    for (const label of ['TX', 'VOX', 'PROC 7', 'SPLIT', 'LOCK', 'RIT']) {
+      expect(indicator(scope, label)).toBeUndefined();
+    }
+    expect(cockpit.querySelector('.lcd-rit-row')).toBeNull();
+  });
+
+  it('preserves confirmed-off and confirmed-on distinctions without fabricating levels', () => {
+    const offState = fullyObservedState({ ritOn: fresh, ritFreq: fresh, ritTx: fresh, ptt: fresh });
+    offState.ritOn = false;
+    offState.ritTx = false;
+    offState.ptt = false;
+    const cockpit = mountCockpit(offState);
+    const scope = mountScope(offState);
+    expect(indicator(cockpit, 'RIT')?.classList.contains('active')).toBe(false);
+    expect(indicator(scope, 'RIT')?.classList.contains('active')).toBe(false);
+    expect(indicator(cockpit, 'TX')?.classList.contains('active')).toBe(false);
+    expect(indicator(scope, 'TX')?.classList.contains('active')).toBe(false);
+
+    const levelStale = fullyObservedState({ compressorOn: fresh, compressorLevel: stale });
+    expect(indicator(mountCockpit(levelStale), 'PROC')).toBeDefined();
+    expect(indicator(mountScope(levelStale), 'PROC')).toBeDefined();
+    expect(indicator(mountCockpit(levelStale), 'PROC 7')).toBeUndefined();
+    expect(indicator(mountScope(levelStale), 'PROC 7')).toBeUndefined();
+  });
+
+  it('renders the cockpit inline XIT row only when XIT is confirmed fresh', () => {
+    const state = fullyObservedState({ ritOn: fresh, ritFreq: fresh, ritTx: fresh });
+    state.ritOn = false;
+    state.ritTx = true;
+    expect(mountCockpit(state).querySelector('.rit-label')?.textContent).toBe('XIT');
   });
 });
 

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -282,6 +282,14 @@ describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
     }
   });
 
+  it('hides the inline row for fresh confirmed-off RIT and XIT', () => {
+    const state = stateFor('ritTx', false, fresh) as any;
+    state.ritOn = false;
+    state.fieldStatus.ritOn = fresh;
+
+    expect(mountCockpit(state).querySelector('.rit-label')).toBeNull();
+  });
+
   it('does not let stale RIT steal inline XIT label priority', () => {
     const state = stateFor('ritTx', true, fresh) as any;
     state.ritOn = true;

--- a/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts
@@ -281,6 +281,14 @@ describe('Amber TX and inline RIT availability (MOR-1586 review)', () => {
       expect(label).toBe(status === fresh ? 'XIT' : undefined);
     }
   });
+
+  it('does not let stale RIT steal inline XIT label priority', () => {
+    const state = stateFor('ritTx', true, fresh) as any;
+    state.ritOn = true;
+    state.fieldStatus.ritOn = stale;
+
+    expect(mountCockpit(state).querySelector('.rit-label')?.textContent).toBe('XIT');
+  });
 });
 
 // ── RIT-offset consumer-boundary guard (AmberCockpit only — AmberScope never


### PR DESCRIPTION
## Summary
- Route both amber LCD entry points through the existing capability-aware props producers.
- Render TX, global amber facts, and cockpit inline RIT/XIT only when their corresponding state fact is fresh and available.
- Add a compact mounted availability matrix for each changed applicable amber token.

Closes #2495
Linear: MOR-1586

## Verification
- Mounted matrix: TX, VOX, PROC, ATU/TUNE, SPLIT, LOCK, IP+, RIT, and inline XIT each distinguish fresh off/on, missing, and stale facts; fresh confirmed-off RIT/XIT renders no inline row, and PROC-level missing/stale never renders a fabricated level.
- Mutation probes: removing AmberScope PROC availability fails PROC missing/stale; forcing TX, VOX, PROC, ATU/TUNE, SPLIT, LOCK, IP+, RIT, and XIT inactive each fails its mapped matrix case. Changing the XIT gate to availability-only fails the fresh-XIT-off witness.
- Mixed-state regression: stale raw RIT plus fresh XIT now renders XIT; reverting the label predicate reproduces RIT.
- `npm run test -- --run src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts` (27 passed)
- `npx vitest run src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts src/lib/runtime/props/__tests__/panel-props.test.ts` (104 passed)
- `npm run check` (0 errors, 0 warnings)
- `npm run lint:boundaries` and exact-file ESLint
- `npm run build`

## Scope and evidence
- Files: 3; LOC: +201/-38 (net +163).
- Profile evidence: `rigs/ic7300.toml` and `rigs/ftx1.toml` declare the relevant capabilities; FTX-1 policies explicitly acquire VOX, compressor, split, RIT/XIT, tuner, and dial-lock facts. No radio-specific branches or constants were added.
- Compatibility: no public API, CLI, config, rigctld wire, or documentation change.
- Hardware: no hardware dependency; display-only state-honesty change.