### PR TITLE
fix(api): scale HTTP watts expectations from profile (MOR-1591)

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -698,7 +698,11 @@ def _af_level_from_param(value: Any) -> int:
     raise ValueError(f"level {value!r} must be an int or a normalized float")
 
 
-def _power_level_expectation_from_param(value: Any) -> int:
+def _power_level_expectation_from_param(
+    value: Any,
+    *,
+    power_max_watts: int | float | None = None,
+) -> int | float:
     """Coerce ``set_rf_power``/``set_power``'s StateStore expectation param.
 
     MOR-1579 round 3: this used to be a plain ``int(raw_level)``, so a
@@ -730,17 +734,24 @@ def _power_level_expectation_from_param(value: Any) -> int:
     ``reconciled``, rather than snapping to a visibly wrong overlay (the
     residual error is bounded at <=0.2% of full scale).
 
-    A bare int is the documented raw/watts wire value (unchanged from
-    before this fix) — dividing it by 255 to form the expectation is only
-    exact for ``raw_255`` radios; for a watts radio this is a known,
-    separate, deferred gap (see the PR body's "Known follow-up"), since
-    the profile needed to convert watts to a fraction isn't reachable
-    from this intent-normalization function.
+    A bare int is the documented raw/watts wire value. When the ingress
+    supplies a positive profile ``power_max_watts`` for a watts-native
+    radio, retain the existing 0-255 expectation representation while
+    scaling that raw watts value to the same normalized fraction as the
+    readback. Callers for raw-255 radios omit the optional profile value.
     """
     if isinstance(value, float) and not isinstance(value, bool):
         if not (0.0 <= value <= 1.0):
             raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
         return max(0, min(255, round(value * 255)))
+    if (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and isinstance(power_max_watts, (int, float))
+        and not isinstance(power_max_watts, bool)
+        and power_max_watts > 0
+    ):
+        return value * 255 / power_max_watts
     return int(value)
 
 
@@ -917,6 +928,7 @@ def command_intent_from_request(
     command_id: str | None = None,
     session_id: str | None = None,
     timeout: float | None = 2.0,
+    power_max_watts: int | float | None = None,
 ) -> CommandIntent:
     """Normalize a production command request into a backend-neutral intent."""
 
@@ -994,7 +1006,10 @@ def command_intent_from_request(
         raw_level = (
             normalized["level"] if "level" in normalized else normalized["value"]
         )
-        normalized["power_level"] = _power_level_expectation_from_param(raw_level)
+        normalized["power_level"] = _power_level_expectation_from_param(
+            raw_level,
+            power_max_watts=power_max_watts,
+        )
     elif command_name == "set_split":
         normalized["split"] = bool(normalized.get("on", False))
     elif command_name == "set_rit":

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1369,12 +1369,18 @@ class ControlHandler:
         intent_params = dict(params)
         if self._server is not None:
             intent_params["_control_server"] = self._server
+        power_max_watts = None
+        if getattr(self._radio, "native_power_unit", "raw_255") == "watts":
+            power_max_watts = getattr(
+                getattr(self._radio, "profile", None), "max_watts", None
+            )
         intent = command_intent_from_request(
             name,
             intent_params,
             source=source,
             command_id=command_id,
             session_id=self._session_id if source == "websocket" else None,
+            power_max_watts=power_max_watts,
         )
         result = await self._command_service.execute(intent)
         return dict(result.executor_result.details or {})

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -1514,3 +1514,53 @@ async def test_http_single_command_missing_required_param_returns_400() -> None:
     assert writer.response_status == 400
     assert writer.response_body["error"] == "invalid_request"
     assert srv.command_queue.drain() == []
+
+
+@pytest.mark.asyncio
+async def test_http_watts_power_expectation_uses_profile_max_watts() -> None:
+    """A documented integer watts command must match the normalized readback."""
+    profile = resolve_radio_profile(model="FTX-1")
+    radio = SimpleNamespace(
+        profile=profile,
+        model=profile.model,
+        capabilities=set(profile.capabilities),
+        native_power_unit="watts",
+        get_powerstat=AsyncMock(return_value=True),
+        set_powerstat=AsyncMock(),
+        get_rf_power=AsyncMock(return_value=0),
+        set_rf_power=AsyncMock(),
+    )
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+
+    writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"id": "watts-50", "name": "set_rf_power", "params": {"level": 50}},
+    )
+
+    assert writer.response_status == 200
+    assert writer.response_body["result"] == {"level": 50}
+    assert srv.command_queue.drain()[0].level == 50
+    [expectation] = srv.command_service.readback_expectations(
+        source="http",
+        session_id=None,
+        command_id="watts-50",
+    )
+    assert profile.max_watts == 100
+    assert expectation.value == pytest.approx(50 / profile.max_watts)
+
+    float_writer = await _post_json(
+        srv,
+        "/api/v1/commands",
+        {"id": "watts-float", "name": "set_rf_power", "params": {"level": 0.4}},
+    )
+
+    assert float_writer.response_status == 200
+    assert float_writer.response_body["result"] == {"level": 40}
+    assert srv.command_queue.drain()[0].level == 40
+    [float_expectation] = srv.command_service.readback_expectations(
+        source="http",
+        session_id=None,
+        command_id="watts-float",
+    )
+    assert float_expectation.value == pytest.approx(102 / 255)


### PR DESCRIPTION
## Summary

- Thread the active watts-native radio profile max watts into the shared HTTP command expectation builder.
- Scale documented integer watts expectations to the normalized readback fraction while preserving the existing normalized float `[0,1]` contract.
- Add an HTTP-level regression witness for FTX-1 profile data: integer 50 W expects 0.5 and normalized float 0.4 still actuates 40 W with its existing expectation behavior.

## Scope

- Linear: MOR-1591 (child A of MOR-1584)
- Tracking parent: #2499
- Closes #2500
- The sync ingress is intentionally untouched; sequential child B (#2501 / MOR-1592) remains blocked on this PR.

## Evidence

- Profile evidence: `rigs/ftx1.toml` declares `power.max_watts = 100`; Yaesu CAT declares watts-native power.
- Red-first on the base: HTTP `set_rf_power(level=50)` recorded a pending expectation of `50 / 255 = 0.196078...`, not the FTX-1 readback fraction `50 / 100 = 0.5`.
- `uv run pytest tests/test_web_command_batch_http.py tests/test_command_service.py -q --tb=short` — 141 passed.
- `uv run ruff check src/rigplane/core/command_service.py src/rigplane/web/handlers/control.py tests/test_web_command_batch_http.py` — passed.
- `uv run ruff format --check src/rigplane/core/command_service.py src/rigplane/web/handlers/control.py tests/test_web_command_batch_http.py` — passed.
- Narrow mypy reports five pre-existing `no-any-return` findings in unchanged `command_service.py` lines 643, 785, 804, 902, and 908; no new finding in changed lines.

## Compatibility and limits

No public API, CLI, config, rigctld-wire, documentation, hardware, or model-specific behavior change. The optional internal argument defaults to existing raw-255 behavior; the HTTP handler supplies it only for a watts-native radio.