### PR TITLE
fix(api): normalize shared power expectations (MOR-1595)

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -43,6 +43,7 @@ _NORMALIZED_LEVEL_EXPECTATION_COMMANDS = {
     "set_rf_gain": "rf_gain",
     "set_squelch": "squelch",
     "set_rf_power": "power_level",
+    "set_power": "power_level",
 }
 
 
@@ -698,7 +699,11 @@ def _af_level_from_param(value: Any) -> int:
     raise ValueError(f"level {value!r} must be an int or a normalized float")
 
 
-def _power_level_expectation_from_param(value: Any) -> int:
+def _power_level_expectation_from_param(
+    value: Any,
+    *,
+    power_max_watts: int | float | None = None,
+) -> int | float:
     """Coerce ``set_rf_power``/``set_power``'s StateStore expectation param.
 
     MOR-1579 round 3: this used to be a plain ``int(raw_level)``, so a
@@ -730,17 +735,24 @@ def _power_level_expectation_from_param(value: Any) -> int:
     ``reconciled``, rather than snapping to a visibly wrong overlay (the
     residual error is bounded at <=0.2% of full scale).
 
-    A bare int is the documented raw/watts wire value (unchanged from
-    before this fix) — dividing it by 255 to form the expectation is only
-    exact for ``raw_255`` radios; for a watts radio this is a known,
-    separate, deferred gap (see the PR body's "Known follow-up"), since
-    the profile needed to convert watts to a fraction isn't reachable
-    from this intent-normalization function.
+    A bare int is the documented raw/watts wire value. When the ingress
+    supplies a positive profile ``power_max_watts`` for a watts-native
+    radio, retain the existing 0-255 expectation representation while
+    scaling that raw watts value to the same normalized fraction as the
+    readback. Callers for raw-255 radios omit the optional profile value.
     """
     if isinstance(value, float) and not isinstance(value, bool):
         if not (0.0 <= value <= 1.0):
             raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
         return max(0, min(255, round(value * 255)))
+    if (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and isinstance(power_max_watts, (int, float))
+        and not isinstance(power_max_watts, bool)
+        and power_max_watts > 0
+    ):
+        return value * 255 / power_max_watts
     return int(value)
 
 
@@ -917,6 +929,7 @@ def command_intent_from_request(
     command_id: str | None = None,
     session_id: str | None = None,
     timeout: float | None = 2.0,
+    power_max_watts: int | float | None = None,
 ) -> CommandIntent:
     """Normalize a production command request into a backend-neutral intent."""
 
@@ -994,7 +1007,10 @@ def command_intent_from_request(
         raw_level = (
             normalized["level"] if "level" in normalized else normalized["value"]
         )
-        normalized["power_level"] = _power_level_expectation_from_param(raw_level)
+        normalized["power_level"] = _power_level_expectation_from_param(
+            raw_level,
+            power_max_watts=power_max_watts,
+        )
     elif command_name == "set_split":
         normalized["split"] = bool(normalized.get("on", False))
     elif command_name == "set_rit":

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1244,7 +1244,12 @@ def test_command_response_observation_carries_session_metadata() -> None:
             "global.operator_controls.power_level",
             88 / 255,
         ),
-        ("set_power", {"level": 77}, "global.operator_controls.power_level", 77),
+        (
+            "set_power",
+            {"level": 77},
+            "global.operator_controls.power_level",
+            77 / 255,
+        ),
         (
             "set_filter_width",
             {"width": 1500},
@@ -1664,6 +1669,56 @@ def test_power_level_float_expectation_matches_readback_scale() -> None:
     assert str(intent.target) == str(path)
     assert observation.value == pytest.approx(102 / 255)
     assert observation.value == pytest.approx(0.4, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    ("name", "level", "expected"),
+    [
+        ("set_rf_power", 50, 0.5),
+        ("set_power", 50, 0.5),
+        ("set_rf_power", 0.4, 102 / 255),
+        ("set_power", 0.4, 102 / 255),
+    ],
+)
+def test_power_expectations_share_canonical_and_alias_contract(
+    name: str,
+    level: int | float,
+    expected: float,
+) -> None:
+    """A watts profile input applies only to integer power commands."""
+    intent = command_intent_from_request(
+        name,
+        {"level": level},
+        source="http",
+        power_max_watts=100,
+    )
+
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=70.0,
+        provider="test",
+    )
+    assert observation.value == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("power_max_watts", [None, 0, -1])
+def test_power_expectation_without_positive_watts_max_preserves_raw_scale(
+    power_max_watts: int | None,
+) -> None:
+    """Absent or invalid watts metadata keeps the raw-255 contract."""
+    intent = command_intent_from_request(
+        "set_rf_power",
+        {"level": 50},
+        source="http",
+        power_max_watts=power_max_watts,
+    )
+
+    observation = command_response_observation(
+        intent,
+        timestamp_monotonic=70.0,
+        provider="test",
+    )
+    assert observation.value == pytest.approx(50 / 255)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Give documented `set_power` the same normalized StateStore expectation contract as `set_rf_power`.
- Add the optional profile-derived max-watts seam to shared power-intent normalization: integer watts use the profile scale; normalized floats preserve the existing 0–255 expectation conversion.
- Cover canonical and alias direct intents, including default, missing, zero, and negative max-watts fallback behavior.

## Scope

- Linear: MOR-1595
- Linear/GitHub tracking parent: MOR-1591 / #2500
- Closes #2503
- Review finding tracked by MOR-1593.
- HTTP threading/batch evidence is deferred to A1 (MOR-1596); sync remains in B (MOR-1592).

## Red-first evidence

On current base, the newly added direct-intent matrix failed seven times: `power_max_watts` was not accepted, and `set_power` retained the stale unnormalized expectation (`77` rather than `77 / 255`).

## Verification

- `uv run pytest tests/test_command_service.py -q --tb=short --timeout=600` — 93 passed.
- `uv run ruff check src/rigplane/core/command_service.py tests/test_command_service.py` — passed.
- `uv run ruff format --check src/rigplane/core/command_service.py tests/test_command_service.py` — passed.
- Direct probes: canonical and alias integer 50 with max 100 both normalize to 0.5; float 0.4 remains 0.4; omitted/zero max retains 50/255.
- Narrow mypy reports the same five pre-existing `no-any-return` errors as `origin/main` (line positions shift only); no new diagnostic.

## Compatibility

The optional internal parameter defaults to existing raw-255 behavior. No API, CLI, config, rigctld-wire, documentation, hardware, model-specific behavior, or HTTP/sync ingress change is included.