### PR TITLE
fix(api): thread HTTP watts expectations (MOR-1596)

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1369,12 +1369,18 @@ class ControlHandler:
         intent_params = dict(params)
         if self._server is not None:
             intent_params["_control_server"] = self._server
+        power_max_watts = None
+        if getattr(self._radio, "native_power_unit", "raw_255") == "watts":
+            power_max_watts = getattr(
+                getattr(self._radio, "profile", None), "max_watts", None
+            )
         intent = command_intent_from_request(
             name,
             intent_params,
             source=source,
             command_id=command_id,
             session_id=self._session_id if source == "websocket" else None,
+            power_max_watts=power_max_watts,
         )
         result = await self._command_service.execute(intent)
         return dict(result.executor_result.details or {})

--- a/tests/test_web_command_batch_http.py
+++ b/tests/test_web_command_batch_http.py
@@ -12,7 +12,14 @@ import pytest
 
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web import server as web_server
-from rigplane.web.radio_poller import CommandQueue, SendCiv, SetFreq, SetMode
+from rigplane.web.radio_poller import (
+    CommandQueue,
+    CommandQueueEntry,
+    SendCiv,
+    SetFreq,
+    SetMode,
+    SetPower,
+)
 from rigplane.web.server import WebConfig, WebServer
 
 
@@ -106,6 +113,19 @@ async def _complete_ordered_commands(
         await queue.wait(timeout=1.0)
         for entry in queue.drain_entries():
             captured.append(entry.command)
+            if entry.future is not None and not entry.future.done():
+                entry.future.set_result(None)
+
+
+async def _complete_ordered_entries(
+    queue: CommandQueue,
+    count: int,
+    captured: list[CommandQueueEntry],
+) -> None:
+    while len(captured) < count:
+        await queue.wait(timeout=1.0)
+        for entry in queue.drain_entries():
+            captured.append(entry)
             if entry.future is not None and not entry.future.done():
                 entry.future.set_result(None)
 
@@ -1514,3 +1534,64 @@ async def test_http_single_command_missing_required_param_returns_400() -> None:
     assert writer.response_status == 400
     assert writer.response_body["error"] == "invalid_request"
     assert srv.command_queue.drain() == []
+
+
+def _watts_radio() -> SimpleNamespace:
+    profile = resolve_radio_profile(model="FTX-1")
+    return SimpleNamespace(
+        profile=profile,
+        model=profile.model,
+        capabilities=set(profile.capabilities),
+        native_power_unit="watts",
+        get_powerstat=AsyncMock(return_value=True),
+        set_powerstat=AsyncMock(),
+        get_rf_power=AsyncMock(return_value=0),
+        set_rf_power=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "level", "expected_level", "expected_expectation"),
+    [
+        ("set_rf_power", 50, 50, 0.5),
+        ("set_power", 50, 50, 0.5),
+        ("set_rf_power", 0.4, 40, 102 / 255),
+        ("set_power", 0.4, 40, 102 / 255),
+    ],
+)
+async def test_http_batch_watts_power_expectation_uses_profile_max_watts(
+    name: str,
+    level: int | float,
+    expected_level: int,
+    expected_expectation: float,
+) -> None:
+    """HTTP batch power commands retain shared watts expectation semantics."""
+    radio = _watts_radio()
+    srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    captured: list[CommandQueueEntry] = []
+    consumer = asyncio.create_task(
+        _complete_ordered_entries(srv.command_queue, 1, captured)
+    )
+
+    try:
+        writer = await _post_json(
+            srv,
+            "/api/v1/commands/batch",
+            {"steps": [{"name": name, "params": {"level": level}}]},
+        )
+    finally:
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+    assert writer.response_status == 200
+    assert writer.response_body["results"][0]["status"] == "executed"
+    [entry] = captured
+    assert entry.command == SetPower(expected_level, unit="watts")
+    assert entry.command_id is not None
+    [expectation] = srv.command_service.readback_expectations(
+        source="http",
+        session_id=None,
+        command_id=entry.command_id,
+    )
+    assert radio.profile.max_watts == 100
+    assert expectation.value == pytest.approx(expected_expectation)


### PR DESCRIPTION
## Summary

- Pass the active profile max watts into the shared RF-power expectation seam only for watts-native radios.
- Add a real `/api/v1/commands/batch` matrix for canonical `set_rf_power` and documented alias `set_power`, covering integer watts and normalized floats.
- Capture the generated queue command ID and assert both `SetPower` actuation and the retained pending expectation.

## Scope

- Linear: MOR-1596
- Tracking parent: MOR-1591 / #2500
- Closes #2504
- A0 shared normalization landed in #2505. The sync ingress remains pending in MOR-1592 / #2501.

## Red-first evidence

On exact base `981466065780402f9159901f81ea90c3a2e06a14`, the four-case batch matrix produced two expected failures: canonical and alias integer `50` both retained `50 / 255 = 0.196078...` instead of the FTX-1 profile fraction `50 / 100 = 0.5`. Both normalized-float `0.4` cases already passed at `102 / 255`. After HTTP threading, all four cases pass with integer actuation `50`, float actuation `40`, and canonical/alias parity.

## Verification

- `uv run pytest tests/test_web_command_batch_http.py tests/test_command_service.py -q --tb=short --timeout=600` — 151 passed.
- `uv run pytest tests/test_sync_coverage.py -q --tb=short --timeout=600` — 12 passed.
- `uv run pytest tests/test_handlers_coverage.py::test_enqueue_set_rf_power_yaesu_tags_watts_unit -q --tb=short --timeout=600` — 1 passed.
- `uv run ruff check src/rigplane/web/handlers/control.py tests/test_web_command_batch_http.py` — passed.
- `uv run ruff format --check src/rigplane/web/handlers/control.py tests/test_web_command_batch_http.py` — passed.
- `uv run mypy src/rigplane/web/handlers/control.py` — passed.
- Unit-gate probe: watts passes profile max `100`; raw-255 passes no max.

## Compatibility

No public API, CLI, config, rigctld-wire, documentation, hardware, model-specific branch, magnitude heuristic, shared-seam redesign, or sync change.