### PR TITLE
fix(api): thread sync watts expectations (MOR-1592)

### DIFF
--- a/src/rigplane/runtime/sync.py
+++ b/src/rigplane/runtime/sync.py
@@ -287,12 +287,17 @@ class IcomRadio:
             raise AttributeError(
                 "set_rf_power requires a radio that implements PowerControlCapable"
             )
+        power_max_watts = None
+        if getattr(self._radio, "native_power_unit", "raw_255") == "watts":
+            profile = getattr(self._radio, "profile", None)
+            power_max_watts = getattr(profile, "max_watts", None)
         self._run(
             self._command_service.execute(
                 command_intent_from_request(
                     "set_rf_power",
                     {"value": level},
                     source="public_api",
+                    power_max_watts=power_max_watts,
                 )
             )
         )

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from rigplane.core.capabilities import CAP_POWER_CONTROL
+from rigplane.profiles import resolve_radio_profile
 from rigplane.runtime._connection_state import RadioConnectionState
 from rigplane.sync import IcomRadio
 
@@ -223,6 +226,72 @@ def test_sync_wrappers_delegate_and_return_values() -> None:
         == 100 / 255
     )
     r._loop.close()
+
+
+def _power_sync_radio(
+    *,
+    native_power_unit: str,
+    max_watts: int | None,
+) -> IcomRadio:
+    r = _radio()
+    profile = resolve_radio_profile(model="FTX-1")
+    r._radio._profile = replace(  # noqa: SLF001
+        profile,
+        max_watts=max_watts,
+        capabilities=frozenset({*profile.capabilities, CAP_POWER_CONTROL}),
+    )
+    r._radio.native_power_unit = native_power_unit
+    r._radio.set_rf_power = AsyncMock()
+    return r
+
+
+@pytest.mark.parametrize("method_name", ["set_rf_power", "set_power"])
+def test_sync_watts_power_expectation_uses_profile_max_watts(
+    method_name: str,
+) -> None:
+    """The sync power command actuates watts and publishes the same fraction."""
+    r = _power_sync_radio(native_power_unit="watts", max_watts=100)
+    try:
+        getattr(r, method_name)(50)
+
+        r._radio.set_rf_power.assert_awaited_once_with(50)
+        field = r._state_store.snapshot().field(  # noqa: SLF001
+            "global.operator_controls.power_level"
+        )
+        assert field.value == pytest.approx(0.5)
+    finally:
+        r._loop.close()
+
+
+@pytest.mark.parametrize(
+    ("native_power_unit", "max_watts", "expected"),
+    [
+        ("watts", 200, 0.25),
+        ("raw_255", 100, 50 / 255),
+        ("watts", None, 50 / 255),
+        ("watts", 0, 50 / 255),
+    ],
+)
+def test_sync_power_expectation_unit_gate_and_safe_fallback(
+    native_power_unit: str,
+    max_watts: int | None,
+    expected: float,
+) -> None:
+    """Only a positive watts-native profile changes the raw expectation scale."""
+    r = _power_sync_radio(
+        native_power_unit=native_power_unit,
+        max_watts=max_watts,
+    )
+    try:
+        r.set_rf_power(50)
+
+        r._radio.set_rf_power.assert_awaited_once_with(50)
+        field = r._state_store.snapshot().field(  # noqa: SLF001
+            "global.operator_controls.power_level"
+        )
+        assert field.value == pytest.approx(expected)
+    finally:
+        r._loop.close()
 
 
 def test_vfo_dispatch_single_rx_uses_ab_methods() -> None:


### PR DESCRIPTION
## Summary

- Thread a watts-native radio profile's `max_watts` through the existing shared command-intent seam for the synchronous RF power API.
- Keep the documented integer sync call as raw watts at actuation while publishing the normalized StateStore expectation.
- Preserve the existing raw-255 and absent/non-positive maximum fallbacks, including the `set_power` compatibility alias.

## Scope and compatibility

- Changes only `src/rigplane/runtime/sync.py` and `tests/test_sync_coverage.py` (74 added lines total).
- A0 shared expectation support and A1 HTTP threading have landed; this PR completes the bounded sync child B.
- The public sync signature remains integer-only. No float behavior, profile data, HTTP behavior, or other command intent is changed.
- No hardware validation is required.

## Red-first evidence

Before the production edit, the six-case targeted matrix produced three expected failures and three passes:

- canonical `set_rf_power(50)`, watts max 100: actuation 50, expectation was `50/255` instead of `0.5`;
- alias `set_power(50)`, watts max 100: actuation 50, expectation was `50/255` instead of `0.5`;
- watts max 200: expectation was `50/255` instead of `0.25`;
- raw-255 with max 100, watts with no maximum, and watts with zero maximum already retained the safe raw expectation.

This exact omission is also the discrimination witness: removing the new keyword restores those three failures while the fallback cases remain green.

## Verification

- `uv run pytest tests/test_sync_coverage.py -q --tb=short --timeout=600` — 18 passed
- `uv run pytest tests/test_command_service.py -q --tb=short --timeout=600` — 93 passed
- `uv run pytest tests/test_web_command_batch_http.py::test_http_batch_watts_power_expectation_uses_profile_max_watts -q --tb=short --timeout=600` — 4 passed
- `uv run ruff format src/rigplane/runtime/sync.py tests/test_sync_coverage.py` — unchanged
- `uv run ruff check src/rigplane/runtime/sync.py tests/test_sync_coverage.py` — passed
- `uv run mypy src/rigplane/runtime/sync.py` — the branch and exact base each report the same 20 pre-existing `no-any-return` diagnostics; no new diagnostic
- `git diff --check` — passed

Profile evidence: the FTX-1 profile declares `max_watts = 100`, and the Yaesu backend exposes watts as its native power unit. The production change reads those existing generic attributes and contains no model-specific value.

Closes #2501
Tracks #2499
Linear: MOR-1592 (child of MOR-1584)
