### PR TITLE
feat(#2518): add speech capability vocabulary

### DIFF
--- a/src/rigplane/core/capabilities.py
+++ b/src/rigplane/core/capabilities.py
@@ -51,6 +51,7 @@ __all__ = [
     "CAP_CSQL",
     "CAP_SQL_TYPE",
     "CAP_VOICE_TX",
+    "CAP_SPEECH",
     "CAP_DATA_MODE",
     "CAP_MOD_INPUT_ROUTING",
     "CAP_AGC",
@@ -152,6 +153,8 @@ CAP_TSQL = "tsql"
 CAP_DTCS = "dtcs"
 CAP_CSQL = "csql"
 CAP_VOICE_TX = "voice_tx"
+# Radio built-in voice-announcement command; distinct from voice TX.
+CAP_SPEECH = "speech"
 # Squelch-type readback (Yaesu FTX-1 CAT ``CT`` "SQL TYPE"). Distinct from the
 # Icom-style ``repeater_tone``/``tsql`` SET-command capabilities: ``sql_type``
 # gates only the observation-pipeline readback that maps the ``CT`` P2 code onto
@@ -247,6 +250,7 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset(
         CAP_CSQL,
         CAP_SQL_TYPE,
         CAP_VOICE_TX,
+        CAP_SPEECH,
         # Data
         CAP_DATA_MODE,
         # Modulation input routing

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from rigplane.command_map import CommandMap
+from rigplane.core.capabilities import CAP_SPEECH, KNOWN_CAPABILITIES
 from rigplane.profiles import BandInfo, FreqRangeInfo, RadioProfile, get_radio_profile
 from rigplane.rig_loader import RigConfig, RigLoadError, discover_rigs, load_rig
 
@@ -161,6 +162,18 @@ provider = 123
         p = _write_toml(tmp_path, toml)
         with pytest.raises(RigLoadError, match="teleportation"):
             load_rig(p)
+
+    def test_speech_capability_loads(self, tmp_path):
+        toml = _MINIMAL_TOML.replace(
+            'features = ["audio", "scope", "meters", "tx"]',
+            'features = ["audio", "speech"]',
+        )
+        rig = load_rig(_write_toml(tmp_path, toml))
+        assert "speech" in rig.capabilities
+
+    def test_speech_capability_is_exported_and_known(self):
+        assert CAP_SPEECH == "speech"
+        assert CAP_SPEECH in KNOWN_CAPABILITIES
 
     def test_invalid_vfo_scheme(self, tmp_path):
         toml = _MINIMAL_TOML.replace('scheme = "ab"', 'scheme = "xyz"')


### PR DESCRIPTION
Closes #2518

## Summary
- export `CAP_SPEECH = "speech"` for the radio built-in voice-announcement capability
- register `speech` in the closed `KNOWN_CAPABILITIES` vocabulary
- prove a minimal `speech` profile loads while an arbitrary unknown tag remains rejected

## Verification
- `uv run pytest tests/test_rig_loader.py -q --tb=short`
- `uv run ruff check src/rigplane/core/capabilities.py tests/test_rig_loader.py`
- `uv run ruff format --check src/rigplane/core/capabilities.py tests/test_rig_loader.py`
- `uv run mypy src/rigplane/core/capabilities.py`
- import and compile checks

No profile declarations, dispatch, frontend, presentation, docs, or generic TTS/accessibility behavior are included.