### PR TITLE
fix(protocol): enforce profile-declared VFO primitives (MOR-1600)

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -19,7 +19,7 @@ from ...core.command_service import (
 )
 from ...core.state_pipeline_contracts import CommandIntent, CommandSource
 from ...core.state_store import StateStore
-from ...profiles import RadioProfile
+from ...profiles import RadioProfile, resolve_radio_profile
 from ..protocol import (  # noqa: TID251
     decode_json,
     encode_json,
@@ -1946,11 +1946,37 @@ class ControlHandler:
                 vfo = str(params.get("vfo", "A"))
                 q.put(SelectVfo(vfo))
                 return {"vfo": vfo}
-            case "vfo_swap":
-                q.put(VfoSwap())
-                return {}
-            case "vfo_equalize":
-                q.put(VfoEqualize())
+            case "vfo_swap" | "vfo_equalize":
+                profile = getattr(radio, "profile", None)
+                if not isinstance(profile, RadioProfile):
+                    model = getattr(radio, "model", None)
+                    try:
+                        profile = (
+                            resolve_radio_profile(model=model)
+                            if isinstance(model, str) and model.strip()
+                            else None
+                        )
+                    except KeyError:
+                        profile = None
+                declared_code = None
+                if isinstance(profile, RadioProfile):
+                    if profile.vfo_scheme == "ab":
+                        declared_code = (
+                            profile.swap_ab_code
+                            if name == "vfo_swap"
+                            else profile.equal_ab_code
+                        )
+                    elif profile.vfo_scheme == "main_sub":
+                        declared_code = (
+                            profile.swap_main_sub_code
+                            if name == "vfo_swap"
+                            else profile.equal_main_sub_code
+                        )
+                if declared_code is None:
+                    raise ValueError(
+                        f"command {name!r} is not supported by active profile"
+                    )
+                q.put(VfoSwap() if name == "vfo_swap" else VfoEqualize())
                 return {}
             case "set_data_mode":
                 dm = int(params["mode"])

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2729,16 +2729,42 @@ class RadioPoller:
                 if self._on_state_event:
                     self._on_state_event("vfo_changed", {"vfo": vfo})
             case VfoSwap():
-                self._last_user_write_ts = time.monotonic()
-                if CAP_DUAL_RX in self._caps:
+                if (
+                    self._profile.vfo_scheme == "ab"
+                    and self._profile.swap_ab_code is not None
+                ):
+                    self._last_user_write_ts = time.monotonic()
+                    await radio.swap_vfo_ab(0)
+                elif (
+                    self._profile.vfo_scheme == "main_sub"
+                    and self._profile.swap_main_sub_code is not None
+                ):
+                    self._last_user_write_ts = time.monotonic()
                     await radio.swap_main_sub()
+                else:
+                    raise CommandError(
+                        f"vfo_swap is unsupported by profile {self._profile.model}"
+                    )
                 # After swap, active VFO stays same but freqs are exchanged
                 if self._on_state_event:
                     self._on_state_event("vfo_swapped", {})
             case VfoEqualize():
-                self._last_user_write_ts = time.monotonic()
-                if CAP_DUAL_RX in self._caps:
+                if (
+                    self._profile.vfo_scheme == "ab"
+                    and self._profile.equal_ab_code is not None
+                ):
+                    self._last_user_write_ts = time.monotonic()
+                    await radio.equalize_vfo_ab(0)
+                elif (
+                    self._profile.vfo_scheme == "main_sub"
+                    and self._profile.equal_main_sub_code is not None
+                ):
+                    self._last_user_write_ts = time.monotonic()
                     await radio.equalize_main_sub()
+                else:
+                    raise CommandError(
+                        f"vfo_equalize is unsupported by profile {self._profile.model}"
+                    )
             case EnableScope(policy=policy, generation=generation):
                 if CAP_SCOPE in self._caps:
                     # Defer scope enable during initial fetch to avoid

--- a/tests/test_vfo_profile_primitives.py
+++ b/tests/test_vfo_profile_primitives.py
@@ -1,0 +1,174 @@
+"""Profile-declared Web VFO primitive admission and routing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.core.exceptions import CommandError
+from rigplane.core.state_store import StateStore
+from rigplane.profiles import resolve_radio_profile
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.radio_poller import (
+    CommandQueue,
+    RadioPoller,
+    VfoEqualize,
+    VfoSwap,
+)
+
+
+_SUPPORTED = (
+    ("IC-705", "ab"),
+    ("IC-7300", "ab"),
+    ("IC-7610", "main_sub"),
+    ("IC-9700", "main_sub"),
+)
+_UNSUPPORTED = (
+    ("FTX-1", "ab_shared"),
+    ("TX-500", "ab"),
+    ("X6100", "ab"),
+    ("X6200", "ab"),
+)
+
+
+def _radio(model: str) -> SimpleNamespace:
+    profile = resolve_radio_profile(model=model)
+    return SimpleNamespace(
+        model=profile.model,
+        profile=profile,
+        capabilities=set(profile.capabilities),
+        swap_vfo_ab=AsyncMock(),
+        equalize_vfo_ab=AsyncMock(),
+        swap_main_sub=AsyncMock(),
+        equalize_main_sub=AsyncMock(),
+    )
+
+
+def _handler(radio: SimpleNamespace, queue: CommandQueue) -> ControlHandler:
+    return ControlHandler(
+        ws=SimpleNamespace(send_text=AsyncMock()),
+        radio=radio,
+        server_version="test",
+        radio_model=radio.model,
+        server=SimpleNamespace(
+            command_queue=queue,
+            command_state_store=StateStore(),
+        ),
+    )
+
+
+@pytest.mark.parametrize(("model", "family"), _SUPPORTED + _UNSUPPORTED)
+def test_shipped_profiles_pin_exact_vfo_primitive_families(
+    model: str,
+    family: str,
+) -> None:
+    profile = resolve_radio_profile(model=model)
+
+    assert profile.vfo_scheme == family
+    if (model, family) in _SUPPORTED:
+        if family == "ab":
+            assert profile.swap_ab_code is not None
+            assert profile.equal_ab_code is not None
+            assert profile.swap_main_sub_code is None
+            assert profile.equal_main_sub_code is None
+        else:
+            assert profile.swap_main_sub_code is not None
+            assert profile.equal_main_sub_code is not None
+            assert profile.swap_ab_code is None
+            assert profile.equal_ab_code is None
+    else:
+        assert profile.swap_ab_code is None
+        assert profile.equal_ab_code is None
+        assert profile.swap_main_sub_code is None
+        assert profile.equal_main_sub_code is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "command", "expected_method", "expected_args"),
+    [
+        (model, command, method, args)
+        for model, family in _SUPPORTED
+        for command, method, args in (
+            (
+                "vfo_swap",
+                "swap_vfo_ab" if family == "ab" else "swap_main_sub",
+                (0,) if family == "ab" else (),
+            ),
+            (
+                "vfo_equalize",
+                "equalize_vfo_ab" if family == "ab" else "equalize_main_sub",
+                (0,) if family == "ab" else (),
+            ),
+        )
+    ],
+)
+async def test_declared_vfo_primitives_admit_and_route_exact_family(
+    model: str,
+    command: str,
+    expected_method: str,
+    expected_args: tuple[int, ...],
+) -> None:
+    radio = _radio(model)
+    queue = CommandQueue()
+    handler = _handler(radio, queue)
+
+    assert await handler._enqueue_command(command, {}) == {}  # noqa: SLF001
+    entries = queue.drain_entries()
+    assert len(entries) == 1
+
+    poller = RadioPoller(radio, queue)
+    await poller._execute(entries[0].command)  # noqa: SLF001
+
+    getattr(radio, expected_method).assert_awaited_once_with(*expected_args)
+    for method_name in (
+        "swap_vfo_ab",
+        "equalize_vfo_ab",
+        "swap_main_sub",
+        "equalize_main_sub",
+    ):
+        if method_name != expected_method:
+            getattr(radio, method_name).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", [model for model, _family in _UNSUPPORTED])
+@pytest.mark.parametrize("command", ("vfo_swap", "vfo_equalize"))
+async def test_absent_vfo_primitive_fails_before_queue_admission(
+    model: str,
+    command: str,
+) -> None:
+    radio = _radio(model)
+    queue = CommandQueue()
+    handler = _handler(radio, queue)
+
+    with pytest.raises(ValueError, match="not supported by active profile"):
+        await handler._enqueue_command(command, {})  # noqa: SLF001
+
+    assert queue.drain_entries() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", [model for model, _family in _UNSUPPORTED])
+@pytest.mark.parametrize(
+    "queued_command",
+    (VfoSwap(), VfoEqualize()),
+    ids=("swap", "equalize"),
+)
+async def test_absent_vfo_primitive_direct_poller_command_fails_closed(
+    model: str,
+    queued_command: VfoSwap | VfoEqualize,
+) -> None:
+    radio = _radio(model)
+    poller = RadioPoller(radio, CommandQueue())
+
+    with pytest.raises(CommandError, match="unsupported by profile"):
+        await poller._execute(queued_command)  # noqa: SLF001
+
+    assert poller._last_user_write_ts == 0.0  # noqa: SLF001
+    radio.swap_vfo_ab.assert_not_awaited()
+    radio.equalize_vfo_ab.assert_not_awaited()
+    radio.swap_main_sub.assert_not_awaited()
+    radio.equalize_main_sub.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Admit `vfo_swap` and `vfo_equalize` only when the loaded profile declares the matching primitive for its VFO family.
- Route A/B profiles to `swap_vfo_ab(0)` / `equalize_vfo_ab(0)` and MAIN/SUB profiles to `swap_main_sub()` / `equalize_main_sub()`.
- Reject absent or mismatched declarations before queue admission; the landed poller prerequisites provide the second fail-closed execution check for generic and Yaesu paths.

## Prerequisites and current head

- #2533 / `9ac781c8` landed Yaesu poller fail-closed behavior.
- #2535 / `7d2c5a94586a7d1ce6252a026e5f60985c2c13c0` landed known/unknown profile-less resolution and generic direct/queued fail-closed behavior.
- This branch merged that exact current main normally. Current head: `fb00d916424d90c063a8fc1a1c2d8eda8837425e`.

The prerequisite `radio_poller.py` implementation subsumes this PR's original poller hunk, so it is intentionally absent from the net diff against current main. The remaining diff is limited to two paths from the original authorized three: Web admission and the focused profile matrix. No prerequisite source or tests are reintroduced by this PR.

## Owner ruling and compatibility

This implements the MOR-1578 owner ruling: these blind commands are allowed only as exact profile-declared radio-side primitives. No observed VFO, active receiver, frequency, mode, split, or slot state is required. There is no frontend direction inference and no primitive-family substitution.

Supported command names and payloads are unchanged. Unsupported direct Web calls now return an explicit error instead of being acknowledged and queued. Tests use mocks and real profile data; no hardware validation is required.

## Profile evidence

- `ic705.toml` and `ic7300.toml`: `vfo.scheme = "ab"` with `swap_ab` and `equal_ab`.
- `ic7610.toml` and `ic9700.toml`: `vfo.scheme = "main_sub"` with `swap_main_sub` and `equal_main_sub`.
- `ftx1.toml`, `tx500.toml`, `x6100.toml`, and `x6200.toml`: no matching swap/equalize declaration.

Generic code reads these loaded profile fields; it contains no radio model branch or wire-value hardcoding.

## Red-first evidence

On original exact base `8290e622afc2e09f3c1f9be30f4e7ff3cad29e33`, the new 32-case focused test produced 20 expected failures and 12 passes:

- four IC-705/IC-7300 A/B routes did not call the declared backend primitive;
- eight unsupported ingress cases were acknowledged instead of raising before queue admission;
- eight unsupported direct-poller cases silently completed instead of failing closed;
- all eight profile-data pins and the four existing MAIN/SUB routes already passed.

## Combined post-prerequisite verification

- Combined targeted pytest matrix — 129 passed. It covers all eight shipped profiles, known and unknown profile-less radios, direct and queued generic execution, Yaesu direct and queued fail-closed behavior, Web admission, exact A/B receiver argument, exact MAIN/SUB zero-argument routes, no observed-VFO fixture, and no mutation side effects.
- `uv run ruff format src/rigplane/web/handlers/control.py src/rigplane/web/radio_poller.py tests/test_vfo_profile_primitives.py` — unchanged
- `uv run ruff check src/rigplane/web/handlers/control.py src/rigplane/web/radio_poller.py tests/test_vfo_profile_primitives.py` — passed
- `uv run mypy src/rigplane/web/handlers/control.py src/rigplane/web/radio_poller.py` — passed
- `uv run lint-imports` — five contracts kept, zero broken
- `git diff --check` — passed

Fresh temporary-copy discrimination remained load-bearing after the merge: bypassing Web profile admission killed all eight unsupported-ingress witnesses; substituting MAIN/SUB calls for A/B killed four focused A/B routes plus both prerequisite known-profile-less A/B routes while all MAIN/SUB cases remained green.

Net diff against current main: 2 authorized files, 205 insertions and 6 deletions, below the 3-file / 400-LOC guardrail.

Closes #2508
Linear: MOR-1600
Parent ruling: MOR-1578
