### PR TITLE
fix: gate scan commands on scan capability (MOR-1607)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1567-remainder-sweeper-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1567-remainder-sweeper-conformance.isolated.test.ts
@@ -38,11 +38,11 @@
  * — `onToggleRxAnt` is the SOLE call site for both names (the
  * `state.txAntenna` value picks which name it would dispatch), so both
  * names refuse identically here, before that branch is ever reached; (3) 6
- * genuinely DISPATCH: all 4 scan intents and `speak` dispatch UNCONDITIONALLY
- * — no capability check (not even `hasCapability('scan')`, though `scan` IS
- * declared on this profile) and no field-observation gate at all, the same
- * ungated shape MOR-1578 already flagged for `vfo_swap`/`vfo_equalize`
- * (leg 1) — cited here as the same class, not re-filed; `set_powerstat`
+ * genuinely DISPATCH: all 4 scan intents require the declared `scan`
+ * capability but no observed scan state; `speak` dispatches unconditionally,
+ * the same ungated shape MOR-1578 already flagged for `vfo_swap`/
+ * `vfo_equalize` (leg 1) — cited here as the same class, not re-filed;
+ * `set_powerstat`
  * DOES check a capability (`power_control`, declared) but has no field
  * gate either (RED-FIRST target, see below). `memory_clear` (via
  * `onClear`) is the one DISPATCH that goes through `currentMemorySnapshot()`'s
@@ -153,16 +153,16 @@ interface IntentCase {
 const CASES: readonly IntentCase[] = [
   { label: 'scan_start', run: () => makeScanHandlers().onScanStart(1),
     frames: [['scan_start', { type: 1 }]],
-    gate: 'no gate at all beyond Number.isSafeInteger(type) — no scan-capability check despite scan being declared (MOR-1578-class, see header)' },
+    gate: 'scan capability declared; type is an integer; no observed scan state required' },
   { label: 'scan_stop', run: () => makeScanHandlers().onScanStop(),
     frames: [['scan_stop', {}]],
-    gate: 'no gate at all — unconditional (MOR-1578-class)' },
+    gate: 'scan capability declared; no observed scan state required' },
   { label: 'scan_set_df_span', run: () => makeScanHandlers().onDfSpanChange(5),
     frames: [['scan_set_df_span', { span: 5 }]],
-    gate: 'no gate at all beyond Number.isSafeInteger(span) (MOR-1578-class)' },
+    gate: 'scan capability declared; span is an integer; no observed scan state required' },
   { label: 'scan_set_resume', run: () => makeScanHandlers().onResumeChange(2),
     frames: [['scan_set_resume', { mode: 2 }]],
-    gate: 'no gate at all beyond Number.isSafeInteger(mode) (MOR-1578-class)' },
+    gate: 'scan capability declared; mode is an integer; no observed scan state required' },
   { label: 'set_dial_lock', run: () => makeSystemHandlers().onDialLock(true),
     frames: [],
     gate: 'currentA03cContext() resolves (state/caps present, receiver count matches vfoScheme) before the top-level dialLock unobserved gate fires (dial_lock capability IS declared) — discrimination evidence in file header' },
@@ -249,6 +249,39 @@ describe('IC-7300 fixture — remainder-sweeper family conformance (MOR-1567)', 
       }
     });
   }
+
+  describe('C13 scan commands', () => {
+    const withoutScan: ReadonlyArray<readonly [string, () => void]> = [
+      ['scan_start', () => makeScanHandlers().onScanStart(1)],
+      ['scan_stop', () => makeScanHandlers().onScanStop()],
+      ['scan_set_df_span', () => makeScanHandlers().onDfSpanChange(5)],
+      ['scan_set_resume', () => makeScanHandlers().onResumeChange(2)],
+    ];
+
+    for (const [name, run] of withoutScan) {
+      it(`${name}: REFUSES without scan capability`, () => {
+        h.caps = { ...fixtureCaps(profile), capabilities: [] };
+        expectRefusal(run);
+      });
+    }
+
+    it('dispatches all four exact frames with scan capability and absent radio state', () => {
+      h.caps = { ...fixtureCaps(profile), capabilities: ['scan'] };
+      h.state = null;
+      const scan = makeScanHandlers();
+      expectFrames(() => {
+        scan.onScanStart(1);
+        scan.onScanStop();
+        scan.onDfSpanChange(5);
+        scan.onResumeChange(2);
+      }, [
+        ['scan_start', { type: 1 }],
+        ['scan_stop', {}],
+        ['scan_set_df_span', { span: 5 }],
+        ['scan_set_resume', { mode: 2 }],
+      ]);
+    });
+  });
 
   describe('EXTENSION — set_rit_frequency: the other 2 call sites for the same wire intent (RIT and XIT share one offset register, per panel-commands.ts:377 comment)', () => {
     it('onXitOffsetChange(100): REFUSES — same ritFreq-unobserved gate as onRitOffsetChange above', () => {

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -392,18 +392,19 @@ export function makeRitXitHandlers() {
 export function makeScanHandlers() {
   return {
     onScanStart: (type: number) => {
-      if (!Number.isSafeInteger(type)) return;
+      if (!hasCapability('scan') || !Number.isSafeInteger(type)) return;
       dispatchRadioIntent({ name: 'scan_start', params: { type } });
     },
     onScanStop: () => {
+      if (!hasCapability('scan')) return;
       dispatchRadioIntent({ name: 'scan_stop', params: {} });
     },
     onDfSpanChange: (span: number) => {
-      if (!Number.isSafeInteger(span)) return;
+      if (!hasCapability('scan') || !Number.isSafeInteger(span)) return;
       dispatchRadioIntent({ name: 'scan_set_df_span', params: { span } });
     },
     onResumeChange: (mode: number) => {
-      if (!Number.isSafeInteger(mode)) return;
+      if (!hasCapability('scan') || !Number.isSafeInteger(mode)) return;
       dispatchRadioIntent({ name: 'scan_set_resume', params: { mode } });
     },
   };


### PR DESCRIPTION
## Summary

- Require the existing `scan` capability before dispatching `scan_start`, `scan_stop`, `scan_set_df_span`, or `scan_set_resume`.
- Keep scan operations explicit: capability presence is sufficient, with no observed scan-state requirement.
- Update the MOR-1567 C13 conformance claims and cover both absent-capability refusal and capability-present dispatch with `state = null`.

Closes #2517
Linear: [MOR-1607](https://linear.app/morozsm/issue/MOR-1607)

## Prerequisite integration

- Merged current `main` at `d03e4aed40b4576873abecfbedacf4e3377c5f6b`, which contains prerequisite PR #2532.
- Updated PR head: `f17ea1837bed490587ca9d2efab670f114eb28ea`.
- The diff against current `main` remains exactly 2 files, +46/-12; prerequisite legacy-test changes do not appear in this PR diff.

## Red-first and falsification evidence

- Before the production edit, the targeted C13 run failed exactly four new tests: each handler dispatched with an empty capability list (`4 failed, 26 passed`).
- Removing each of the four production gates independently made its matching absent-capability test fail by dispatching the exact prohibited frame.
- Changing the positive discriminator to an empty capability list made it fail with zero frames instead of the four expected frames.
- The two owned file blobs are unchanged from the previously mutation-verified head; all mutations remain restored.

## Verification

- Combined C13 plus both prerequisite legacy harness files — 154 passed across 3 files.
- `npm run check` — 0 errors and 0 warnings.
- Exact-file ESLint — clean.
- `npm run lint:boundaries` — clean.
- `npm run build` — passed.
- `git diff --check` — clean.