### PR TITLE
test(#2529): align scan harness capability fixtures

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -138,9 +138,9 @@ const liveCaps = (tags: readonly string[]): Capabilities => ({
   stateContractVersion: 1, providerGeneration: 0,
 } as unknown as Capabilities);
 
-/** `rit`/`xit` capability tags are what makes the ritXit group present;
- *  scan needs no tag at all — its raw fields above are the whole gate. */
-const RIT_XIT_TAGS = ['tx', 'rit', 'xit'] as const;
+/** `rit`/`xit` capability tags make the ritXit group present; the explicit
+ *  scan commands additionally require the declared `scan` capability. */
+const RIT_XIT_TAGS = ['tx', 'rit', 'xit', 'scan'] as const;
 const SILENT_TAGS = ['tx'] as const;
 
 let target: HTMLDivElement;

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -237,7 +237,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
         'tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
         'cw', 'break_in', 'apf', 'twin_peak', 'rx_antenna',
         'split', 'dual_rx', 'dual_watch', 'main_sub_tracking',
-        'bsr', 'preamp', 'attenuator', 'ip_plus',
+        'bsr', 'preamp', 'attenuator', 'ip_plus', 'scan',
       ],
       stateContractVersion: 1,
       providerGeneration: 31,
@@ -590,6 +590,24 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
       ['set_antenna_1', { on: false }],
       ['set_antenna_2', { on: true }],
       ['set_rx_antenna_ant1', { on: true }],
+      ['scan_start', { type: 0x22 }],
+      ['scan_stop', {}],
+      ['scan_set_df_span', { span: 25_000 }],
+      ['scan_set_resume', { mode: 0xd2 }],
+    ]);
+    expectIntentTransport();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+  });
+
+  it('dispatches all explicit scan commands with scan capability and no observed scan state', () => {
+    h.state = null;
+    const scan = makeScanHandlers();
+    scan.onScanStart(0x22);
+    scan.onScanStop();
+    scan.onDfSpanChange(25_000);
+    scan.onResumeChange(0xd2);
+
+    expect(exactCalls()).toEqual([
       ['scan_start', { type: 0x22 }],
       ['scan_stop', {}],
       ['scan_set_df_span', { span: 25_000 }],


### PR DESCRIPTION
Closes #2529

## Summary
- add the declared `scan` capability to both legacy positive fixtures
- preserve exact scan intents while proving all four dispatch without observed scan state

## Verification
- `npm --prefix frontend test -- src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run lint:boundaries`
- `npm --prefix frontend run build`

## Discrimination
A disposable worktree combined this branch with PR #2526 production gate. Removing `scan` from the wiring fixture produced 3 failed scan-dispatch assertions; removing it from the intent fixture produced 2 failed assertions. The combined unmutated pair passed 124/124.