### PR TITLE
fix(#2530): fail closed Yaesu VFO commands

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -524,6 +524,7 @@ class YaesuCatPoller:
             SetTwinPeak,
             SetVox,
             SetTunerStatus,
+            VfoEqualize,
             VfoSwap,
         )
 
@@ -543,7 +544,27 @@ class YaesuCatPoller:
                 code = 0 if vfo.upper() in ("A", "MAIN") else 1
                 await radio.set_vfo_select(code)
             case VfoSwap():
-                await radio.vfo_a_to_b()
+                profile = getattr(radio, "profile", None)
+                if profile is None or profile.swap_ab_code is None:
+                    model = getattr(
+                        profile, "model", getattr(radio, "model", "unknown")
+                    )
+                    raise NotImplementedError(
+                        f"VfoSwap unsupported on {model}: "
+                        "profile declares no swap_ab_code"
+                    )
+                await radio.swap_vfo_ab(0)
+            case VfoEqualize():
+                profile = getattr(radio, "profile", None)
+                if profile is None or profile.equal_ab_code is None:
+                    model = getattr(
+                        profile, "model", getattr(radio, "model", "unknown")
+                    )
+                    raise NotImplementedError(
+                        f"VfoEqualize unsupported on {model}: "
+                        "profile declares no equal_ab_code"
+                    )
+                await radio.equalize_vfo_ab(0)
 
             # ── PTT ──
             case PttOn():

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -24,7 +24,12 @@ from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
 from rigplane.backends.yaesu_cat.transport import CatTimeoutError
 from rigplane.profiles import get_radio_profile
 from rigplane.radio_state import RadioState
-from rigplane.web.radio_poller import CommandQueue, SetFreq
+from rigplane.web.radio_poller import (
+    CommandQueue,
+    SetFreq,
+    VfoEqualize,
+    VfoSwap,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1392,6 +1397,79 @@ async def test_drain_commands_sets_future_exception_on_execution_failure() -> No
     assert future.done()
     assert not future.cancelled()
     assert future.exception() is boom
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("profile_name", ["FTX-1", "TX-500", "X6100", "X6200"])
+@pytest.mark.parametrize(
+    ("command", "profile_primitive", "radio_method"),
+    [
+        (VfoSwap, "swap_ab_code", "swap_vfo_ab"),
+        (VfoEqualize, "equal_ab_code", "equalize_vfo_ab"),
+    ],
+)
+async def test_undeclared_vfo_commands_reject_before_radio_mutation(
+    profile_name: str,
+    command: type[VfoSwap] | type[VfoEqualize],
+    profile_primitive: str,
+    radio_method: str,
+) -> None:
+    """Undeclared direct Yaesu VFO actions must fail closed before mutation."""
+    radio = make_radio()
+    radio.profile = get_radio_profile(profile_name)
+    radio.vfo_a_to_b = AsyncMock()
+    radio.swap_vfo_ab = AsyncMock()
+    radio.equalize_vfo_ab = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda s: None)
+
+    assert getattr(radio.profile, profile_primitive) is None
+    with pytest.raises(
+        NotImplementedError,
+        match=rf"{command.__name__} unsupported on {profile_name}: .*{profile_primitive}",
+    ):
+        await poller._execute_command(command())  # noqa: SLF001
+
+    radio.vfo_a_to_b.assert_not_awaited()
+    getattr(radio, radio_method).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("profile_name", ["FTX-1", "TX-500", "X6100", "X6200"])
+@pytest.mark.parametrize(
+    ("command", "profile_primitive", "radio_method"),
+    [
+        (VfoSwap, "swap_ab_code", "swap_vfo_ab"),
+        (VfoEqualize, "equal_ab_code", "equalize_vfo_ab"),
+    ],
+)
+async def test_undeclared_queued_vfo_commands_set_future_exception_before_mutation(
+    profile_name: str,
+    command: type[VfoSwap] | type[VfoEqualize],
+    profile_primitive: str,
+    radio_method: str,
+) -> None:
+    """Queued undeclared Yaesu VFO actions must never acknowledge success."""
+    radio = make_radio()
+    radio.profile = get_radio_profile(profile_name)
+    radio.vfo_a_to_b = AsyncMock()
+    radio.swap_vfo_ab = AsyncMock()
+    radio.equalize_vfo_ab = AsyncMock()
+    queue = CommandQueue()
+    poller = YaesuCatPoller(radio, callback=lambda s: None, command_queue=queue)
+
+    assert getattr(radio.profile, profile_primitive) is None
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    queue.put_ordered(command(), future=future)
+
+    await poller._drain_commands()  # noqa: SLF001
+
+    error = future.exception()
+    assert isinstance(error, NotImplementedError)
+    assert f"{command.__name__} unsupported on {profile_name}" in str(
+        error
+    ) and profile_primitive in str(error)
+    radio.vfo_a_to_b.assert_not_awaited()
+    getattr(radio, radio_method).assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2530

## Summary
- reject direct Yaesu VFO swap/equalize when the loaded profile lacks the exact A/B primitive declaration
- route a future declared primitive only through swap_vfo_ab(0) or equalize_vfo_ab(0)
- prove direct and queued rejection before radio calls for FTX-1, TX-500, X6100, and X6200

## Verification
- `uv run pytest tests/test_yaesu_cat_poller.py -q --tb=short`
- `uv run ruff check src/rigplane/backends/yaesu_cat/poller.py tests/test_yaesu_cat_poller.py`
- `uv run ruff format --check src/rigplane/backends/yaesu_cat/poller.py tests/test_yaesu_cat_poller.py`
- `uv run mypy src/rigplane/backends/yaesu_cat/poller.py`
- `uv run lint-imports`