### PR TITLE
test: pin IC-7300 speech capability count

### DIFF
--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -191,8 +191,11 @@ class TestCapabilities:
     def test_has_ip_plus(self, profile):
         assert "ip_plus" in profile.capabilities
 
+    def test_has_speech(self, profile):
+        assert "speech" in profile.capabilities
+
     def test_capabilities_count(self, profile):
-        assert len(profile.capabilities) == 41
+        assert len(profile.capabilities) == 42
 
 
 # ── Command overrides ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- pin the IC-7300 exact capability count at 42 for the speech-profile combined candidate
- assert IC-7300 retains explicit `speech` membership

## Validation
- `uv run pytest tests/test_rig_ic7300.py tests/test_rig_multi_vendor.py tests/test_rig_loader.py -q --tb=short`
- `uv run pytest tests/test_rig_ic7300.py::TestCapabilities -q --tb=short`
- `uv run ruff check tests/test_rig_ic7300.py`
- `uv run ruff format --check tests/test_rig_ic7300.py`

## Stack
This is the #2531 prerequisite for #2519 / #2527, intentionally based on and targeted to PR #2527 so the exact count is only evaluated with the profile declaration.

Closes #2531