### PR TITLE
fix(web): fail closed unknown VFO profiles (MOR-1618)

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -981,9 +981,20 @@ class RadioPoller:
                 return resolve_radio_profile(model=raw_model)
         except KeyError:
             pass
-        if "dual_rx" in self._caps:
-            return resolve_radio_profile(model="IC-7610")
-        return resolve_radio_profile(model="IC-7300")
+        return resolve_radio_profile()
+
+    def _vfo_command_profile(self, command: str) -> RadioProfile:
+        """Resolve the exact profile allowed to declare a VFO primitive."""
+        raw_profile = getattr(self._radio, "profile", None)
+        if isinstance(raw_profile, RadioProfile):
+            return raw_profile
+        raw_model = getattr(self._radio, "model", None)
+        try:
+            if isinstance(raw_model, str) and raw_model.strip():
+                return resolve_radio_profile(model=raw_model)
+        except KeyError:
+            pass
+        raise NotImplementedError(f"{command} unsupported: unknown profile-less radio")
 
     def _load_command_map(self) -> dict[str, tuple[int, ...]]:
         """Load command wire bytes from TOML rig profile."""
@@ -2729,15 +2740,45 @@ class RadioPoller:
                 if self._on_state_event:
                     self._on_state_event("vfo_changed", {"vfo": vfo})
             case VfoSwap():
+                profile = self._vfo_command_profile("VfoSwap")
+                if profile.vfo_scheme == "ab" and profile.swap_ab_code is not None:
+                    swap_ab = True
+                elif (
+                    profile.vfo_scheme == "main_sub"
+                    and profile.swap_main_sub_code is not None
+                ):
+                    swap_ab = False
+                else:
+                    raise NotImplementedError(
+                        f"VfoSwap unsupported on {profile.model}: "
+                        "profile declares no matching primitive"
+                    )
                 self._last_user_write_ts = time.monotonic()
-                if CAP_DUAL_RX in self._caps:
+                if swap_ab:
+                    await radio.swap_vfo_ab(0)
+                else:
                     await radio.swap_main_sub()
                 # After swap, active VFO stays same but freqs are exchanged
                 if self._on_state_event:
                     self._on_state_event("vfo_swapped", {})
             case VfoEqualize():
+                profile = self._vfo_command_profile("VfoEqualize")
+                if profile.vfo_scheme == "ab" and profile.equal_ab_code is not None:
+                    equal_ab = True
+                elif (
+                    profile.vfo_scheme == "main_sub"
+                    and profile.equal_main_sub_code is not None
+                ):
+                    equal_ab = False
+                else:
+                    raise NotImplementedError(
+                        f"VfoEqualize unsupported on {profile.model}: "
+                        "profile declares no matching primitive"
+                    )
                 self._last_user_write_ts = time.monotonic()
-                if CAP_DUAL_RX in self._caps:
+                if equal_ab:
+                    await radio.equalize_vfo_ab(0)
+                else:
                     await radio.equalize_main_sub()
             case EnableScope(policy=policy, generation=generation):
                 if CAP_SCOPE in self._caps:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -981,7 +981,9 @@ class RadioPoller:
                 return resolve_radio_profile(model=raw_model)
         except KeyError:
             pass
-        return resolve_radio_profile()
+        if "dual_rx" in self._caps:
+            return resolve_radio_profile(model="IC-7610")
+        return resolve_radio_profile(model="IC-7300")
 
     def _vfo_command_profile(self, command: str) -> RadioProfile:
         """Resolve the exact profile allowed to declare a VFO primitive."""

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1477,6 +1477,22 @@ async def test_unknown_profileless_vfo_commands_fail_before_mutation(
 
 
 @pytest.mark.asyncio
+async def test_unknown_profileless_set_freq_keeps_base_receiver_guard() -> None:
+    """Unknown profile-less non-VFO commands retain the base fallback behavior."""
+    radio = _make_radio()
+    radio.profile = None
+    radio.model = "Unknown Rig"
+    radio.capabilities = set()
+    poller = RadioPoller(radio, CommandQueue())
+
+    with pytest.raises(CommandError, match="receiver=1"):
+        await poller._execute(SetFreq(14_074_000, receiver=1))  # noqa: SLF001
+
+    radio.set_freq.assert_not_awaited()
+    radio.send_civ.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("model", "command", "method"),
     [

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1443,6 +1443,94 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("command", [VfoSwap, VfoEqualize])
+@pytest.mark.parametrize("queued", [False, True], ids=("direct", "queued"))
+async def test_unknown_profileless_vfo_commands_fail_before_mutation(
+    command: type[VfoSwap] | type[VfoEqualize], queued: bool
+) -> None:
+    """Unknown profile-less VFO commands must never inherit a foreign primitive."""
+    radio = _make_radio()
+    radio.profile = None
+    radio.model = "Unknown Rig"
+    radio.capabilities = {"dual_rx"}
+    radio.swap_vfo_ab = AsyncMock()
+    radio.equalize_vfo_ab = AsyncMock()
+    poller = RadioPoller(radio, CommandQueue())
+    timestamp_before = poller._last_user_write_ts  # noqa: SLF001
+
+    if queued:
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        poller._queue.put_ordered(command(), future=future)  # noqa: SLF001
+        poller.start()
+        with pytest.raises(NotImplementedError, match="unknown.*profile"):
+            await asyncio.wait_for(future, timeout=1)
+        poller.stop()
+    else:
+        with pytest.raises(NotImplementedError, match="unknown.*profile"):
+            await poller._execute(command())  # noqa: SLF001
+
+    assert poller._last_user_write_ts == timestamp_before  # noqa: SLF001
+    radio.swap_vfo_ab.assert_not_awaited()
+    radio.equalize_vfo_ab.assert_not_awaited()
+    radio.swap_main_sub.assert_not_awaited()
+    radio.equalize_main_sub.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "command", "method"),
+    [
+        ("IC-7300", VfoSwap, "swap_vfo_ab"),
+        ("IC-7300", VfoEqualize, "equalize_vfo_ab"),
+        ("IC-7610", VfoSwap, "swap_main_sub"),
+        ("IC-7610", VfoEqualize, "equalize_main_sub"),
+    ],
+)
+async def test_profileless_known_model_vfo_commands_resolve_registry_primitive(
+    model: str,
+    command: type[VfoSwap] | type[VfoEqualize],
+    method: str,
+) -> None:
+    """Legacy doubles resolve their exact VFO primitive only from the registry."""
+    radio = _make_radio(model=model)
+    radio.profile = None
+    radio.swap_vfo_ab = AsyncMock()
+    radio.equalize_vfo_ab = AsyncMock()
+    poller = RadioPoller(radio, CommandQueue())
+
+    await poller._execute(command())  # noqa: SLF001
+
+    expected = getattr(radio, method)
+    if method.endswith("_ab"):
+        expected.assert_awaited_once_with(0)
+    else:
+        expected.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["FTX-1", "TX-500", "X6100", "X6200"])
+@pytest.mark.parametrize("command", [VfoSwap, VfoEqualize])
+async def test_undeclared_profile_vfo_commands_fail_before_mutation(
+    model: str, command: type[VfoSwap] | type[VfoEqualize]
+) -> None:
+    """A shipped profile without the primitive cannot acknowledge the command."""
+    radio = _make_radio(model=model)
+    radio.swap_vfo_ab = AsyncMock()
+    radio.equalize_vfo_ab = AsyncMock()
+    poller = RadioPoller(radio, CommandQueue())
+    timestamp_before = poller._last_user_write_ts  # noqa: SLF001
+
+    with pytest.raises(NotImplementedError, match="no matching primitive"):
+        await poller._execute(command())  # noqa: SLF001
+
+    assert poller._last_user_write_ts == timestamp_before  # noqa: SLF001
+    radio.swap_vfo_ab.assert_not_awaited()
+    radio.equalize_vfo_ab.assert_not_awaited()
+    radio.swap_main_sub.assert_not_awaited()
+    radio.equalize_main_sub.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_select_vfo_legacy_backend_falls_back_to_set_vfo() -> None:
     """SelectVfo on backends predating ReceiverBankCapable falls back to set_vfo.
 


### PR DESCRIPTION
## Summary

- Resolve VFO primitives from an attached profile or the generic known-model registry only.
- Reject unknown profile-less and undeclared profiles before the timestamp, radio mutation, or queued success.
- Preserve profile-less IC-7300 A/B and IC-7610 MAIN/SUB legacy-double routing.
- Preserve the pre-existing IC-7300/IC-7610 global fallback for unrelated poller commands.

## Round 2: verifier P1 fixed

The VFO fail-closed resolver remains isolated in `_vfo_command_profile`. `_runtime_profile()` has been restored byte-for-byte to the `origin/main` fallback policy, so unknown/profile-less `SetFreq(receiver=1)` keeps rejecting before `set_freq` or CI-V writes.

## Verification

- `uv run pytest tests/test_radio_poller_coverage.py -q --tb=short --timeout=600` — 228 passed
- `uv run ruff format --check src/rigplane/web/radio_poller.py tests/test_radio_poller_coverage.py`
- `uv run ruff check src/rigplane/web/radio_poller.py tests/test_radio_poller_coverage.py`
- `uv run mypy src/rigplane/web/radio_poller.py`
- `uv run lint-imports`
- `git diff --check`

## Red-first and mutation evidence

- Before the round-2 fix, the new unknown/profile-less `SetFreq(receiver=1)` parity test failed: it acknowledged and wrote instead of raising before radio calls.
- Restoring a generic fallback inside `_vfo_command_profile` makes all four unknown direct/queued VFO cases fail.
- Replacing the original `_runtime_profile()` fallback with generic resolution makes the SetFreq parity test fail.

Closes #2528
Parent blocker: #2525