### PR TITLE
feat(#2509): project VFO primitive capabilities

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -598,6 +598,9 @@ def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     return _runtime_capabilities_impl(radio)
 
 
+_VFO_CAPABILITY_TAGS = frozenset({"vfo_swap", "vfo_equalize"})
+
+
 def _profile_vfo_capability_tags(profile: "RadioProfile") -> set[str]:
     """Project only primitives declared for the profile's VFO scheme."""
     if profile.vfo_scheme == "ab":
@@ -996,6 +999,30 @@ class WebServer:
                 fallback.model,
             )
         return fallback
+
+    def _trusted_vfo_capability_tags(self) -> set[str]:
+        """Resolve VFO tags without the generic profile fallback."""
+        from ..profiles import RadioProfile, resolve_radio_profile
+
+        if self._radio is None:
+            return set()
+        raw_profile = getattr(self._radio, "profile", None)
+        if isinstance(raw_profile, RadioProfile):
+            return _profile_vfo_capability_tags(raw_profile)
+        radio_model = getattr(self._radio, "model", None)
+        candidates = [
+            model
+            for model in (radio_model, self._config.radio_model)
+            if isinstance(model, str) and model != _RADIO_MODEL_UNSPECIFIED
+        ]
+        for candidate in candidates:
+            try:
+                return _profile_vfo_capability_tags(
+                    resolve_radio_profile(model=candidate)
+                )
+            except KeyError:
+                continue
+        return set()
 
     def _bootstrap_state_acquisition(self) -> None:
         """Attach shared StateStore-backed acquisition services when profiled."""
@@ -2867,9 +2894,9 @@ class WebServer:
         )
         model = raw_model if isinstance(raw_model, str) else self._config.radio_model
         profile = self._get_profile()
-        caps = _runtime_capabilities(self._radio) | _profile_vfo_capability_tags(
-            profile
-        )
+        caps = (
+            _runtime_capabilities(self._radio) - _VFO_CAPABILITY_TAGS
+        ) | self._trusted_vfo_capability_tags()
         has_dual_rx = "dual_rx" in caps
         raw_connected = (
             getattr(self._radio, "connected", False) if self._radio else False
@@ -3332,9 +3359,9 @@ class WebServer:
             _raw_model if isinstance(_raw_model, str) else self._config.radio_model
         )
         profile = self._get_profile()
-        caps = _runtime_capabilities(self._radio) | _profile_vfo_capability_tags(
-            profile
-        )
+        caps = (
+            _runtime_capabilities(self._radio) - _VFO_CAPABILITY_TAGS
+        ) | self._trusted_vfo_capability_tags()
 
         freq_ranges = [
             {

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -598,6 +598,29 @@ def _runtime_capabilities(radio: "Radio | None") -> set[str]:
     return _runtime_capabilities_impl(radio)
 
 
+def _profile_vfo_capability_tags(profile: "RadioProfile") -> set[str]:
+    """Project only primitives declared for the profile's VFO scheme."""
+    if profile.vfo_scheme == "ab":
+        return {
+            tag
+            for tag, primitive in (
+                ("vfo_swap", profile.swap_ab_code),
+                ("vfo_equalize", profile.equal_ab_code),
+            )
+            if primitive is not None
+        }
+    if profile.vfo_scheme == "main_sub":
+        return {
+            tag
+            for tag, primitive in (
+                ("vfo_swap", profile.swap_main_sub_code),
+                ("vfo_equalize", profile.equal_main_sub_code),
+            )
+            if primitive is not None
+        }
+    return set()
+
+
 def _supports_scope(radio: "Radio | None") -> bool:
     return "scope" in runtime_capabilities(radio)
 
@@ -2843,9 +2866,11 @@ class WebServer:
             getattr(self._radio, "model", None) if self._radio is not None else None
         )
         model = raw_model if isinstance(raw_model, str) else self._config.radio_model
-        caps = _runtime_capabilities(self._radio)
-        has_dual_rx = "dual_rx" in caps
         profile = self._get_profile()
+        caps = _runtime_capabilities(self._radio) | _profile_vfo_capability_tags(
+            profile
+        )
+        has_dual_rx = "dual_rx" in caps
         raw_connected = (
             getattr(self._radio, "connected", False) if self._radio else False
         )
@@ -3299,7 +3324,6 @@ class WebServer:
                 {"Content-Type": "application/json"},
             )
             return
-        caps = _runtime_capabilities(self._radio)
         tx_audio = browser_tx_audio_facts(self._radio)
         _raw_model = (
             getattr(self._radio, "model", None) if self._radio is not None else None
@@ -3308,6 +3332,9 @@ class WebServer:
             _raw_model if isinstance(_raw_model, str) else self._config.radio_model
         )
         profile = self._get_profile()
+        caps = _runtime_capabilities(self._radio) | _profile_vfo_capability_tags(
+            profile
+        )
 
         freq_ranges = [
             {

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -67,6 +67,23 @@ def _make_radio(model: str = "IC-7610", caps: set[str] | None = None):
     return radio
 
 
+async def _endpoint_vfo_tags(radio) -> tuple[set[str], set[str]]:
+    srv = WebServer(radio)
+    info_writer = _FakeWriter()
+    capabilities_writer = _FakeWriter()
+
+    await srv._serve_info(info_writer)  # noqa: SLF001
+    await srv._serve_capabilities(capabilities_writer)  # noqa: SLF001
+
+    info = _parse_json_body(info_writer)
+    capabilities = _parse_json_body(capabilities_writer)
+    reserved = {"vfo_swap", "vfo_equalize"}
+    return (
+        set(info["capabilities"]["tags"]) & reserved,
+        set(capabilities["capabilities"]) & reserved,
+    )
+
+
 # ── /api/v1/info tests ─────────────────────────────────────────
 
 
@@ -162,17 +179,41 @@ class TestInfoEndpoint:
         assert tags & {"vfo_swap", "vfo_equalize"} == expected
 
     @pytest.mark.asyncio
-    async def test_info_projects_vfo_primitives_independently_for_matching_scheme(self):
+    async def test_vfo_tags_project_primitives_independently_for_matching_scheme(self):
         radio = _make_radio("IC-7300")
         radio.profile = replace(radio.profile, equal_ab_code=None)
-        srv = WebServer(radio)
-        writer = _FakeWriter()
 
-        await srv._serve_info(writer)  # noqa: SLF001
+        expected = {"vfo_swap"}
+        assert await _endpoint_vfo_tags(radio) == (expected, expected)
 
-        tags = set(_parse_json_body(writer)["capabilities"]["tags"])
-        assert "vfo_swap" in tags
-        assert "vfo_equalize" not in tags
+    @pytest.mark.asyncio
+    async def test_vfo_tags_ignore_runtime_injection_on_unsupported_profile(self):
+        radio = _make_radio("X6100", {"vfo_swap", "vfo_equalize"})
+
+        assert await _endpoint_vfo_tags(radio) == (set(), set())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("radio_kind", ["unknown", "missing", "none"])
+    async def test_vfo_tags_fail_closed_without_exact_profile(self, radio_kind):
+        if radio_kind == "none":
+            radio = None
+        else:
+            radio = _make_radio("X6100", set())
+            del radio.profile
+            if radio_kind == "unknown":
+                radio.model = "UNKNOWN-RADIO"
+            else:
+                del radio.model
+
+        assert await _endpoint_vfo_tags(radio) == (set(), set())
+
+    @pytest.mark.asyncio
+    async def test_vfo_tags_resolve_known_profile_when_not_attached(self):
+        radio = _make_radio("IC-7300")
+        del radio.profile
+
+        expected = {"vfo_swap", "vfo_equalize"}
+        assert await _endpoint_vfo_tags(radio) == (expected, expected)
 
 
 # ── /api/v1/capabilities tests ─────────────────────────────────
@@ -366,13 +407,8 @@ class TestCapabilitiesEndpoint:
     async def test_capabilities_rejects_mismatched_vfo_scheme_primitives(self):
         radio = _make_radio("IC-7300")
         radio.profile = replace(radio.profile, vfo_scheme="main_sub")
-        srv = WebServer(radio)
-        writer = _FakeWriter()
 
-        await srv._serve_capabilities(writer)  # noqa: SLF001
-
-        tags = set(_parse_json_body(writer)["capabilities"])
-        assert not tags & {"vfo_swap", "vfo_equalize"}
+        assert await _endpoint_vfo_tags(radio) == (set(), set())
 
 
 def _yaesu(cls=YaesuCatRadio):

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -137,6 +137,43 @@ class TestInfoEndpoint:
         data = _parse_json_body(writer)
         assert "dual_rx" not in data["capabilities"]["tags"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("IC-705", {"vfo_swap", "vfo_equalize"}),
+            ("IC-7300", {"vfo_swap", "vfo_equalize"}),
+            ("IC-7610", {"vfo_swap", "vfo_equalize"}),
+            ("IC-9700", {"vfo_swap", "vfo_equalize"}),
+            ("FTX-1", set()),
+            ("TX-500", set()),
+            ("X6100", set()),
+            ("X6200", set()),
+        ],
+    )
+    async def test_info_projects_exact_profile_vfo_primitives(self, model, expected):
+        radio = _make_radio(model)
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+
+        await srv._serve_info(writer)  # noqa: SLF001
+
+        tags = set(_parse_json_body(writer)["capabilities"]["tags"])
+        assert tags & {"vfo_swap", "vfo_equalize"} == expected
+
+    @pytest.mark.asyncio
+    async def test_info_projects_vfo_primitives_independently_for_matching_scheme(self):
+        radio = _make_radio("IC-7300")
+        radio.profile = replace(radio.profile, equal_ab_code=None)
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+
+        await srv._serve_info(writer)  # noqa: SLF001
+
+        tags = set(_parse_json_body(writer)["capabilities"]["tags"])
+        assert "vfo_swap" in tags
+        assert "vfo_equalize" not in tags
+
 
 # ── /api/v1/capabilities tests ─────────────────────────────────
 
@@ -298,6 +335,44 @@ class TestCapabilitiesEndpoint:
         await srv._serve_capabilities(writer)  # noqa: SLF001
         data = _parse_json_body(writer)
         assert data["antennas"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("IC-705", {"vfo_swap", "vfo_equalize"}),
+            ("IC-7300", {"vfo_swap", "vfo_equalize"}),
+            ("IC-7610", {"vfo_swap", "vfo_equalize"}),
+            ("IC-9700", {"vfo_swap", "vfo_equalize"}),
+            ("FTX-1", set()),
+            ("TX-500", set()),
+            ("X6100", set()),
+            ("X6200", set()),
+        ],
+    )
+    async def test_capabilities_projects_exact_profile_vfo_primitives(
+        self, model, expected
+    ):
+        radio = _make_radio(model)
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+
+        await srv._serve_capabilities(writer)  # noqa: SLF001
+
+        tags = set(_parse_json_body(writer)["capabilities"])
+        assert tags & {"vfo_swap", "vfo_equalize"} == expected
+
+    @pytest.mark.asyncio
+    async def test_capabilities_rejects_mismatched_vfo_scheme_primitives(self):
+        radio = _make_radio("IC-7300")
+        radio.profile = replace(radio.profile, vfo_scheme="main_sub")
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+
+        await srv._serve_capabilities(writer)  # noqa: SLF001
+
+        tags = set(_parse_json_body(writer)["capabilities"])
+        assert not tags & {"vfo_swap", "vfo_equalize"}
 
 
 def _yaesu(cls=YaesuCatRadio):

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -67,20 +67,33 @@ def _make_radio(model: str = "IC-7610", caps: set[str] | None = None):
     return radio
 
 
-async def _endpoint_vfo_tags(radio) -> tuple[set[str], set[str]]:
+async def _endpoint_vfo_tags(radio) -> tuple[set[str], set[str], set[str]]:
+    from rigplane.web.handlers import ControlHandler
+
     srv = WebServer(radio)
     info_writer = _FakeWriter()
     capabilities_writer = _FakeWriter()
+    ws_payloads: list[str] = []
+
+    async def _send_text(payload: str) -> None:
+        ws_payloads.append(payload)
+
+    ws = SimpleNamespace(send_text=_send_text)
+    radio_model = getattr(radio, "model", srv._config.radio_model)  # noqa: SLF001
+    handler = ControlHandler(ws, radio, "0.0.0-test", radio_model, server=srv)
 
     await srv._serve_info(info_writer)  # noqa: SLF001
     await srv._serve_capabilities(capabilities_writer)  # noqa: SLF001
+    await handler._send_hello()  # noqa: SLF001
 
     info = _parse_json_body(info_writer)
     capabilities = _parse_json_body(capabilities_writer)
+    hello = json.loads(ws_payloads.pop())
     reserved = {"vfo_swap", "vfo_equalize"}
     return (
         set(info["capabilities"]["tags"]) & reserved,
         set(capabilities["capabilities"]) & reserved,
+        set(hello["capabilities"]) & reserved,
     )
 
 
@@ -184,13 +197,13 @@ class TestInfoEndpoint:
         radio.profile = replace(radio.profile, equal_ab_code=None)
 
         expected = {"vfo_swap"}
-        assert await _endpoint_vfo_tags(radio) == (expected, expected)
+        assert await _endpoint_vfo_tags(radio) == (expected, expected, expected)
 
     @pytest.mark.asyncio
     async def test_vfo_tags_ignore_runtime_injection_on_unsupported_profile(self):
         radio = _make_radio("X6100", {"vfo_swap", "vfo_equalize"})
 
-        assert await _endpoint_vfo_tags(radio) == (set(), set())
+        assert await _endpoint_vfo_tags(radio) == (set(), set(), set())
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("radio_kind", ["unknown", "missing", "none"])
@@ -205,7 +218,7 @@ class TestInfoEndpoint:
             else:
                 del radio.model
 
-        assert await _endpoint_vfo_tags(radio) == (set(), set())
+        assert await _endpoint_vfo_tags(radio) == (set(), set(), set())
 
     @pytest.mark.asyncio
     async def test_vfo_tags_resolve_known_profile_when_not_attached(self):
@@ -213,7 +226,7 @@ class TestInfoEndpoint:
         del radio.profile
 
         expected = {"vfo_swap", "vfo_equalize"}
-        assert await _endpoint_vfo_tags(radio) == (expected, expected)
+        assert await _endpoint_vfo_tags(radio) == (expected, expected, expected)
 
 
 # ── /api/v1/capabilities tests ─────────────────────────────────
@@ -408,7 +421,7 @@ class TestCapabilitiesEndpoint:
         radio = _make_radio("IC-7300")
         radio.profile = replace(radio.profile, vfo_scheme="main_sub")
 
-        assert await _endpoint_vfo_tags(radio) == (set(), set())
+        assert await _endpoint_vfo_tags(radio) == (set(), set(), set())
 
 
 def _yaesu(cls=YaesuCatRadio):

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -244,7 +244,9 @@ class TestInfoEndpoint:
         assert await _endpoint_vfo_tags(radio) == (set(), set(), set())
 
     @pytest.mark.asyncio
-    async def test_vfo_tags_reject_injection_and_only_fallback_when_runtime_absent(self):
+    async def test_vfo_tags_reject_injection_and_only_fallback_when_runtime_absent(
+        self,
+    ):
         injected = _make_radio("X6100", {"vfo_swap", "vfo_equalize"})
         assert await _endpoint_vfo_tags(injected) == (set(), set(), set())
 


### PR DESCRIPTION
## Summary
- project `vfo_swap` and `vfo_equalize` only from exact primitive declarations matching the trusted active profile’s VFO scheme
- strip reserved VFO tags from raw runtime capability input before projection
- fail closed for missing, unknown, and no-radio profile paths while preserving exact attached and known-resolved profiles
- keep `/api/v1/info`, `/api/v1/capabilities`, and the landed WS hello prerequisite (`f016380af266e956c3410cf349587c5463736b41`) in exact parity
- pin declared Icom, absent FTX-1/TX-500/X6100/X6200, partial, scheme-mismatch, runtime-injection, and fallback-negative cases

Closes #2509

## Verification
- `uv run pytest tests/test_web_capability_guards.py tests/test_web_runtime_helpers.py::test_webserver_and_control_handler_use_same_capabilities_and_ready tests/test_web_runtime_helpers.py::test_websocket_hello_projects_only_trusted_vfo_primitives tests/test_web_server_coverage.py::test_info_endpoint_no_radio -q --tb=short` — 55 passed
- `uv run python scripts/run_consumer_contracts.py` — 2 consumer expectations passed
- mutation checks killed runtime injection, default fallback, primitive conflation, and wrong-scheme selection
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run lint-imports` — 5 contracts kept
- `git diff --check`

`uv run mypy src/` remains blocked by the same 13 pre-existing errors in four unrelated files; neither changed file reports an error.

An unintended broad pytest invocation was interrupted and is not used as a verification gate or product-scope result.