### PR TITLE
fix(#2512): gate CW auto-tune on RX analysis

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -17,8 +17,8 @@ from ...core.command_service import (
     _raw_int_level_from_param,
     command_intent_from_request,
 )
-from ...core.state_pipeline_contracts import CommandIntent, CommandSource
-from ...core.state_store import StateStore
+from ...core.state_pipeline_contracts import CommandIntent, CommandSource, FieldPath
+from ...core.state_store import FreshnessState, StateStore
 from ...profiles import RadioProfile, resolve_radio_profile
 from ..protocol import (  # noqa: TID251
     decode_json,
@@ -1780,6 +1780,26 @@ class ControlHandler:
         ):
             raise RuntimeError("CW auto-tune requires RX audio FFT")
 
+        state_store = getattr(self._server, "command_state_store", None)
+        if not isinstance(state_store, StateStore):
+            raise RuntimeError("CW auto-tune requires observed active RX")
+        try:
+            active_field = state_store.snapshot().field(
+                FieldPath.global_("slow_state", "active")
+            )
+        except KeyError:
+            raise RuntimeError("CW auto-tune requires observed active RX") from None
+        active = active_field.value
+        if active_field.freshness is not FreshnessState.FRESH or active not in (
+            "MAIN",
+            "SUB",
+        ):
+            raise RuntimeError("CW auto-tune requires observed active RX")
+
+        state = self._server._radio_state
+        receiver = 1 if active == "SUB" else 0
+        freq = state.sub.freq if receiver else state.main.freq
+
         broadcaster = self._server._audio_broadcaster
         tuner = CwAutoTuner()
 
@@ -1810,15 +1830,13 @@ class ControlHandler:
             return {"detected": None, "applied": False}
 
         # Read current CW pitch from state, compute VFO shift
-        state = self._server._radio_state
         cw_pitch = state.cw_pitch if state.cw_pitch else 600
         delta = hz - cw_pitch
 
         if abs(delta) > 5:
             # Shift VFO frequency to zero-beat
-            freq = state.main.freq
             q = self._server.command_queue
-            q.put(SetFreq(freq + delta))
+            q.put(SetFreq(freq + delta, receiver=receiver))
 
         return {
             "detected": hz,

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -158,6 +158,7 @@ if TYPE_CHECKING:
 from ...capabilities import (
     CAP_AF_LEVEL,
     CAP_ANTENNA,
+    CAP_AUDIO,
     CAP_BAND_EDGE,
     CAP_BREAK_IN,
     CAP_CW,
@@ -1773,6 +1774,11 @@ class ControlHandler:
 
         if self._server is None:
             raise RuntimeError("server not available")
+        if (
+            not {CAP_CW, CAP_AUDIO}.issubset(runtime_capabilities(self._radio))
+            or getattr(self._server, "_audio_fft_scope", None) is None
+        ):
+            raise RuntimeError("CW auto-tune requires RX audio FFT")
 
         broadcaster = self._server._audio_broadcaster
         tuner = CwAutoTuner()

--- a/tests/test_cw_auto_tune_wiring.py
+++ b/tests/test_cw_auto_tune_wiring.py
@@ -9,6 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
 from rigplane.dsp.tap_registry import TapRegistry
 from rigplane.radio_state import RadioState, ReceiverState
 from rigplane.web.handlers.control import ControlHandler
@@ -21,6 +27,7 @@ def _make_handler(
     radio_state: RadioState | None = None,
     radio: Any = _DEFAULT_RADIO,
     audio_fft_available: bool = True,
+    active_observation: str = "fresh",
 ) -> ControlHandler:
     """Build a ControlHandler with a fake server and WebSocket."""
     ws = MagicMock()
@@ -39,11 +46,26 @@ def _make_handler(
             cw_pitch=600,
         )
 
+    state_store = StateStore()
+    if active_observation != "missing":
+        state_store.apply(
+            Observation(
+                path=FieldPath.global_("slow_state", "active"),
+                value=radio_state.active,
+                source=SourceMetadata(source="state_poller", provider="test"),
+                timestamp_monotonic=1.0,
+                max_age=0.5 if active_observation == "stale" else None,
+            )
+        )
+        if active_observation == "stale":
+            state_store.mark_stale_due(now=2.0)
+
     server = SimpleNamespace(
         _audio_broadcaster=broadcaster,
         _radio_state=radio_state,
         _audio_fft_scope=object() if audio_fft_available else None,
         command_queue=command_queue,
+        command_state_store=state_store,
     )
 
     if radio is _DEFAULT_RADIO:
@@ -117,11 +139,19 @@ class TestCwAutoTuneWiring:
 
         assert result == {"detected": None, "applied": False}
 
-    async def test_successful_detection(self) -> None:
-        """Detected tone returns Hz, delta, and applied flag."""
+    @pytest.mark.parametrize(
+        ("active", "receiver", "expected_freq"),
+        [("MAIN", 0, 14_074_050), ("SUB", 1, 7_030_050)],
+    )
+    async def test_successful_detection_routes_observed_active_receiver(
+        self, active: str, receiver: int, expected_freq: int
+    ) -> None:
+        """Correction source and target are the observed active receiver."""
         handler = _make_handler(
             radio_state=RadioState(
                 main=ReceiverState(freq=14_074_000),
+                sub=ReceiverState(freq=7_030_000),
+                active=active,
                 cw_pitch=600,
             ),
         )
@@ -148,7 +178,42 @@ class TestCwAutoTuneWiring:
         q = handler._server.command_queue
         q.put.assert_called_once()
         cmd = q.put.call_args[0][0]
-        assert cmd.freq == 14_074_000 + 50
+        assert cmd.freq == expected_freq
+        assert cmd.receiver == receiver
+
+    @pytest.mark.parametrize(
+        ("active", "active_observation"),
+        [("MAIN", "missing"), ("MAIN", "stale"), ("UNKNOWN", "fresh")],
+    )
+    async def test_unavailable_active_receiver_rejects_before_side_effects(
+        self, active: str, active_observation: str
+    ) -> None:
+        """Missing, stale, or invalid active-RX evidence fails closed."""
+        handler = _make_handler(
+            radio_state=RadioState(
+                main=ReceiverState(freq=14_074_000),
+                sub=ReceiverState(freq=7_030_000),
+                active=active,
+                cw_pitch=600,
+            ),
+            active_observation=active_observation,
+        )
+        registry = MagicMock()
+        handler._server._audio_broadcaster._tap_registry = registry
+
+        with patch("rigplane.cw_auto_tuner.CwAutoTuner") as tuner:
+            tuner.return_value.start_collection.side_effect = lambda callback: callback(
+                None
+            )
+            with pytest.raises(
+                RuntimeError, match="CW auto-tune requires observed active RX"
+            ):
+                await handler._cw_auto_tune()
+
+        tuner.return_value.start_collection.assert_not_called()
+        registry.register.assert_not_called()
+        handler._server._audio_broadcaster.ensure_relay.assert_not_awaited()
+        handler._server.command_queue.put.assert_not_called()
 
     async def test_detection_none_returns_not_applied(self) -> None:
         """Detected=None (silence) returns applied=False."""

--- a/tests/test_cw_auto_tune_wiring.py
+++ b/tests/test_cw_auto_tune_wiring.py
@@ -13,11 +13,14 @@ from rigplane.dsp.tap_registry import TapRegistry
 from rigplane.radio_state import RadioState, ReceiverState
 from rigplane.web.handlers.control import ControlHandler
 
+_DEFAULT_RADIO = object()
+
 
 def _make_handler(
     *,
     radio_state: RadioState | None = None,
-    radio: Any = None,
+    radio: Any = _DEFAULT_RADIO,
+    audio_fft_available: bool = True,
 ) -> ControlHandler:
     """Build a ControlHandler with a fake server and WebSocket."""
     ws = MagicMock()
@@ -39,12 +42,16 @@ def _make_handler(
     server = SimpleNamespace(
         _audio_broadcaster=broadcaster,
         _radio_state=radio_state,
+        _audio_fft_scope=object() if audio_fft_available else None,
         command_queue=command_queue,
     )
 
+    if radio is _DEFAULT_RADIO:
+        radio = SimpleNamespace(capabilities={"cw", "audio"}, has_usb_audio=True)
+
     handler = ControlHandler(
         ws=ws,
-        radio=radio if radio is not None else MagicMock(),
+        radio=radio,
         server_version="test",
         radio_model="IC-7610",
         server=server,
@@ -56,8 +63,41 @@ class TestCwAutoTuneWiring:
     """Test cw_auto_tune command dispatch in ControlHandler."""
 
     async def test_cw_auto_tune_in_commands_set(self) -> None:
-        """cw_auto_tune is listed in _COMMANDS."""
+        """cw_auto_tune is an RX correction, not a TX-class command."""
         assert "cw_auto_tune" in ControlHandler._COMMANDS
+        assert "cw_auto_tune" not in ControlHandler._TX_COMMANDS
+
+    @pytest.mark.parametrize(
+        ("radio", "audio_fft_available"),
+        [
+            (None, True),
+            (SimpleNamespace(capabilities={"audio"}, has_usb_audio=True), True),
+            (SimpleNamespace(capabilities={"cw"}, has_usb_audio=True), True),
+            (SimpleNamespace(capabilities={"cw", "audio"}, has_usb_audio=True), False),
+        ],
+        ids=("missing-radio", "missing-cw", "missing-audio", "missing-fft"),
+    )
+    async def test_missing_rx_analysis_prerequisite_rejects_before_side_effects(
+        self, radio: Any, audio_fft_available: bool
+    ) -> None:
+        """CW auto-tune needs CW, RX audio, and an active server FFT source."""
+        handler = _make_handler(
+            radio=radio,
+            audio_fft_available=audio_fft_available,
+        )
+        registry = MagicMock()
+        handler._server._audio_broadcaster._tap_registry = registry
+
+        with (
+            patch("rigplane.cw_auto_tuner.CwAutoTuner") as tuner,
+            pytest.raises(RuntimeError, match="CW auto-tune requires RX audio FFT"),
+        ):
+            await handler._cw_auto_tune()
+
+        tuner.return_value.start_collection.assert_not_called()
+        registry.register.assert_not_called()
+        handler._server._audio_broadcaster.ensure_relay.assert_not_awaited()
+        handler._server.command_queue.put.assert_not_called()
 
     async def test_timeout_returns_not_detected(self) -> None:
         """If no audio arrives within 3s, return detected=None."""


### PR DESCRIPTION
## Summary
- fail closed before CW auto-tune side effects unless runtime CW and audio capabilities plus the server FFT source are present
- require a fresh canonical active-receiver observation before collection and route the correction from and to that same MAIN/SUB receiver
- preserve the RX-only frequency correction path and keep the command outside the TX command class
- cover missing radio, CW, audio, FFT, and missing/stale/invalid active-RX evidence plus exact MAIN/SUB frequency and receiver routing

## Red-first evidence
- old head `00b7f64bc5f05e8cf4a829dee009d98b790eff01` queued `SetFreq(14074050, receiver=0)` for active SUB at 7030000 Hz with a +50 Hz correction
- missing, stale, and invalid active-RX evidence did not reject on the old head

## Verification
- targeted CW tests under a foreground 600-second alarm: 25 passed
- Ruff check and format check: passed
- mypy for the changed handler: passed
- import-linter: 5 contracts kept
- git diff check: passed
- mutation checks: forced MAIN, MAIN source frequency, default receiver 0, and TX classification each fail the dedicated regression

Closes #2512