### PR TITLE
fix(#2538): align WS hello VFO capabilities

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -178,6 +178,7 @@ __all__ = ["ControlHandler", "RadioNotReadyError"]
 
 logger = logging.getLogger(__name__)
 _MAX_CW_TEXT_CHARS = 512
+_VFO_CAPABILITY_TAGS = frozenset({"vfo_swap", "vfo_equalize"})
 
 # MOR-624: maps the per-DATA-group MOD-input SET command name (as sent by the
 # frontend auto-restore) to its allowed teardown arm name (MOR-993).
@@ -669,7 +670,38 @@ class ControlHandler:
         await self._ws.send_text(encode_json(msg))
 
     def _capabilities(self) -> set[str]:
-        return set(runtime_capabilities(self._radio))
+        caps = set(runtime_capabilities(self._radio)) - _VFO_CAPABILITY_TAGS
+        if self._radio is None:
+            return caps
+
+        profile = getattr(self._radio, "profile", None)
+        if not isinstance(profile, RadioProfile):
+            radio_model = getattr(self._radio, "model", None)
+            for model in (radio_model, self._radio_model):
+                if not isinstance(model, str) or not model.strip():
+                    continue
+                try:
+                    profile = resolve_radio_profile(model=model)
+                except KeyError:
+                    continue
+                break
+
+        if not isinstance(profile, RadioProfile):
+            return caps
+        primitives: tuple[tuple[str, int | None], ...]
+        if profile.vfo_scheme == "ab":
+            primitives = (
+                ("vfo_swap", profile.swap_ab_code),
+                ("vfo_equalize", profile.equal_ab_code),
+            )
+        elif profile.vfo_scheme == "main_sub":
+            primitives = (
+                ("vfo_swap", profile.swap_main_sub_code),
+                ("vfo_equalize", profile.equal_main_sub_code),
+            )
+        else:
+            primitives = ()
+        return caps | {tag for tag, primitive in primitives if primitive is not None}
 
     def _ensure_receiver_supported(self, receiver: int) -> None:
         if self._radio is None:

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from dataclasses import replace
 from itertools import permutations
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -700,6 +702,60 @@ async def test_webserver_and_control_handler_use_same_capabilities_and_ready() -
     expected_ready = radio_ready(radio)
     assert info["connection"]["radioReady"] is expected_ready
     assert hello["radio_ready"] is expected_ready
+
+
+@pytest.mark.asyncio
+async def test_websocket_hello_projects_only_trusted_vfo_primitives() -> None:
+    """WS hello cannot expose injected VFO primitive capability tags."""
+    from rigplane.profiles import resolve_radio_profile
+    from rigplane.web.handlers import ControlHandler
+    from rigplane.web.websocket import WebSocketConnection
+
+    reserved = {"vfo_swap", "vfo_equalize"}
+    ic7300 = resolve_radio_profile(model="IC-7300")
+    partial_ic7300 = replace(ic7300, equal_ab_code=None)
+    cases = [
+        (SimpleNamespace(model="X6100", capabilities=reserved), "X6100", set()),
+        (SimpleNamespace(model="UNKNOWN", capabilities=reserved), "UNKNOWN", set()),
+        (SimpleNamespace(capabilities=reserved), "UNKNOWN", set()),
+        (None, "IC-7610", set()),
+        (
+            SimpleNamespace(model="IC-7300", capabilities=reserved),
+            "IC-7300",
+            reserved,
+        ),
+        (
+            SimpleNamespace(model="X6100", profile=ic7300, capabilities=reserved),
+            "X6100",
+            reserved,
+        ),
+        (
+            SimpleNamespace(
+                model="X6100", profile=partial_ic7300, capabilities=reserved
+            ),
+            "X6100",
+            {"vfo_swap"},
+        ),
+        (
+            SimpleNamespace(model="IC-7610", capabilities=reserved),
+            "IC-7610",
+            reserved,
+        ),
+    ]
+
+    for radio, radio_model, expected in cases:
+        ws = MagicMock(spec=WebSocketConnection)
+        sent: list[str] = []
+
+        async def _send_text(payload: str) -> None:
+            sent.append(payload)
+
+        ws.send_text = _send_text
+        handler = ControlHandler(ws, radio, "0.0.0-test", radio_model)
+        await handler._send_hello()  # noqa: SLF001
+
+        hello = json.loads(sent.pop())
+        assert hello["capabilities"] == sorted(expected)
 
 
 def test_public_state_projection_uses_snapshot_revisions_and_meter_values() -> None:


### PR DESCRIPTION
## Summary

- remove reserved VFO primitives from raw WebSocket runtime capabilities
- restore only primitives declared by an attached or exact-resolved profile
- cover injected, unknown, missing, no-radio, attached, profileless-known, and partial-profile WS hello frames

## Verification

- `uv run pytest tests/test_web_runtime_helpers.py -q --tb=short`
- `uv run ruff check src/rigplane/web/handlers/control.py tests/test_web_runtime_helpers.py`
- `uv run ruff format --check src/rigplane/web/handlers/control.py tests/test_web_runtime_helpers.py`
- `uv run mypy src/rigplane/web/handlers/control.py`
- `uv run lint-imports`

Closes #2538