### PR TITLE
fix: fail closed unknown runtime VFO tags

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -974,6 +974,44 @@ class WebServer:
             )
         return fallback
 
+    def _projected_runtime_capabilities(self) -> set[str]:
+        """Return runtime tags with VFO primitives trusted only from a profile."""
+        from ..profiles import RadioProfile, resolve_radio_profile
+
+        vfo_tags = {"vfo_swap", "vfo_equalize"}
+        caps = _runtime_capabilities(self._radio) - vfo_tags
+        profile = getattr(self._radio, "profile", None) if self._radio else None
+        if not isinstance(profile, RadioProfile):
+            raw_model = (
+                getattr(self._radio, "model", None) if self._radio is not None else None
+            )
+            candidates = (
+                (raw_model,)
+                if isinstance(raw_model, str) and raw_model.strip()
+                else (self._config.radio_model,)
+            )
+            for model in candidates:
+                try:
+                    profile = resolve_radio_profile(model=model)
+                except KeyError:
+                    continue
+                break
+        if not isinstance(profile, RadioProfile):
+            return caps
+        if profile.vfo_scheme == "ab":
+            primitives = (
+                ("vfo_swap", profile.swap_ab_code),
+                ("vfo_equalize", profile.equal_ab_code),
+            )
+        elif profile.vfo_scheme == "main_sub":
+            primitives = (
+                ("vfo_swap", profile.swap_main_sub_code),
+                ("vfo_equalize", profile.equal_main_sub_code),
+            )
+        else:
+            primitives = ()
+        return caps | {tag for tag, primitive in primitives if primitive is not None}
+
     def _bootstrap_state_acquisition(self) -> None:
         """Attach shared StateStore-backed acquisition services when profiled."""
         radio = self._radio
@@ -2843,7 +2881,7 @@ class WebServer:
             getattr(self._radio, "model", None) if self._radio is not None else None
         )
         model = raw_model if isinstance(raw_model, str) else self._config.radio_model
-        caps = _runtime_capabilities(self._radio)
+        caps = self._projected_runtime_capabilities()
         has_dual_rx = "dual_rx" in caps
         profile = self._get_profile()
         raw_connected = (
@@ -3299,7 +3337,7 @@ class WebServer:
                 {"Content-Type": "application/json"},
             )
             return
-        caps = _runtime_capabilities(self._radio)
+        caps = self._projected_runtime_capabilities()
         tx_audio = browser_tx_audio_facts(self._radio)
         _raw_model = (
             getattr(self._radio, "model", None) if self._radio is not None else None

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -998,6 +998,7 @@ class WebServer:
                 break
         if not isinstance(profile, RadioProfile):
             return caps
+        primitives: tuple[tuple[str, int | None], ...]
         if profile.vfo_scheme == "ab":
             primitives = (
                 ("vfo_swap", profile.swap_ab_code),

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from dataclasses import astuple, replace
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,7 +17,9 @@ from rigplane.radio_protocol import AudioCapable
 from rigplane.runtime.radio import IcomRadio
 from rigplane.types import AudioCodec
 from rigplane.web.handlers.audio import browser_tx_audio_facts
-from rigplane.web.server import WebServer
+from rigplane.web.handlers import ControlHandler
+from rigplane.web.server import WebConfig, WebServer
+from rigplane.web.websocket import WebSocketConnection
 
 
 class _FakeWriter:
@@ -136,6 +139,40 @@ class TestInfoEndpoint:
         await srv._serve_info(writer)  # noqa: SLF001
         data = _parse_json_body(writer)
         assert "dual_rx" not in data["capabilities"]["tags"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_runtime_model_fails_closed_for_reserved_vfo_tags_across_consumers(
+        self,
+    ):
+        """An unknown attached radio cannot inherit configured VFO primitives."""
+        reserved = {"vfo_swap", "vfo_equalize"}
+        radio = _make_radio("IC-7300", caps=reserved)
+        radio.model = "UNKNOWN-RADIO"
+        del radio.profile
+        server = WebServer(radio, WebConfig(radio_model="IC-7300"))
+
+        info_writer = _FakeWriter()
+        await server._serve_info(info_writer)  # noqa: SLF001
+        info = _parse_json_body(info_writer)
+
+        capabilities_writer = _FakeWriter()
+        await server._serve_capabilities(capabilities_writer)  # noqa: SLF001
+        capabilities = _parse_json_body(capabilities_writer)
+
+        ws = MagicMock(spec=WebSocketConnection)
+        sent: list[str] = []
+
+        async def send_text(payload: str) -> None:
+            sent.append(payload)
+
+        ws.send_text = send_text
+        handler = ControlHandler(ws, radio, "0.0.0-test", radio.model)
+        await handler._send_hello()  # noqa: SLF001
+        hello = json.loads(sent.pop())
+
+        assert not (reserved & set(info["capabilities"]["tags"]))
+        assert not (reserved & set(capabilities["capabilities"]))
+        assert not (reserved & set(hello["capabilities"]))
 
 
 # ── /api/v1/capabilities tests ─────────────────────────────────


### PR DESCRIPTION
Closes #2540

## Summary
- project reserved VFO capability tags only from the active trusted profile
- keep configured-model fallback for an absent runtime model
- cover HTTP and WebSocket parity for an unknown runtime model

## Tests
- `uv run pytest tests/test_web_capability_guards.py -q --tb=short`
- `uv run ruff check src/rigplane/web/server.py tests/test_web_capability_guards.py`