### PR TITLE
fix: restore PBT-only spectrum passband overlay (#2569)

### DIFF
--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -118,6 +118,8 @@ const runtimeHarness = vi.hoisted(() => {
   const state = {
     capturedHardwareFrame: null as ((frame: TestScopeFrame) => void) | null,
     capturedDxMessage: null as ((message: unknown) => void) | null,
+    currentState: Object.freeze({ source: 'test-state' }) as unknown,
+    currentCaps: Object.freeze({ source: 'test-capabilities' }) as unknown,
     mockScopeConnected: true,
     tuningStep: 1_000,
     nextLeaseId: 0,
@@ -125,8 +127,8 @@ const runtimeHarness = vi.hoisted(() => {
     dxUnsubscribe: vi.fn(),
   };
   const runtime = {
-    state: Object.freeze({ source: 'test-state' }),
-    caps: Object.freeze({ source: 'test-capabilities' }),
+    get state() { return state.currentState; },
+    get caps() { return state.currentCaps; },
     scope: {
       get hardwareScopeConnected() { return state.mockScopeConnected; },
       subscribeHardware: vi.fn((handler: (frame: TestScopeFrame) => void) => {
@@ -152,10 +154,10 @@ const runtimeHarness = vi.hoisted(() => {
 const mockRuntime = runtimeHarness.runtime;
 
 const authorityHarness = vi.hoisted(() => {
-  const state = { current: null as any };
+  const state = { current: null as any, useProductionSelector: false };
   return {
     state,
-    toSpectrumAuthority: vi.fn(() => state.current),
+    toSpectrumAuthority: vi.fn((_state: unknown, _caps: unknown) => state.current),
     snapSpectrumFilterWidth: vi.fn((raw: number, rule: any) => {
       if (!rule) return null;
       if (rule.kind === 'table') {
@@ -217,7 +219,10 @@ vi.mock('$lib/runtime/adapters/scope-adapter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('$lib/runtime/adapters/scope-adapter')>();
   return {
     ...actual,
-    toSpectrumAuthority: authorityHarness.toSpectrumAuthority,
+    toSpectrumAuthority: (...args: Parameters<typeof actual.toSpectrumAuthority>) =>
+      authorityHarness.state.useProductionSelector
+        ? actual.toSpectrumAuthority(...args)
+        : authorityHarness.toSpectrumAuthority(...args),
     snapSpectrumFilterWidth: authorityHarness.snapSpectrumFilterWidth,
   };
 });
@@ -293,7 +298,8 @@ vi.mock('../../../../components-v2/panels/filter-controls', () => ({
 
 vi.mock('$lib/runtime/props/panel-props', async (importOriginal) => ({
   ...await importOriginal<typeof import('$lib/runtime/props/panel-props')>(),
-  resolveFilterModeConfig: vi.fn(() => null),
+  resolveFilterModeConfig: vi.fn((caps: { filterConfig?: Record<string, unknown> }, mode: string) =>
+    caps.filterConfig?.[mode] ?? null),
 }));
 
 // ---------------------------------------------------------------------------
@@ -315,6 +321,7 @@ import {
   indicatorTone,
 } from '../../../components-v2/layout/StatusBar.svelte';
 import statusBarSource from '../../../components-v2/layout/StatusBar.svelte?raw';
+import { IC7300_CAPABILITIES, IC7300_STATE } from '../../../lib/runtime/adapters/__tests__/fixtures/ic7300-profile';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -368,6 +375,33 @@ function authority(overrides: Partial<Omit<TestAuthority, 'digest'>> = {}): Test
     ...overrides,
   };
   return Object.freeze({ ...core, digest: JSON.stringify(core) });
+}
+
+function freshPbtOnlyIc7300State() {
+  const captured = structuredClone(IC7300_STATE);
+  const { ifShift: _rawIfShift, ...mainWithoutRawIfShift } = captured.main!;
+  const fieldStatus = { ...captured.fieldStatus };
+  delete fieldStatus['main.ifShift'];
+  const fresh = (path: string) => ({
+    observed: true, freshness: 'fresh', availability: 'available', storePath: path,
+  });
+  return {
+    ...captured,
+    main: {
+      ...mainWithoutRawIfShift,
+      mode: 'AM',
+      filterWidth: 10_000,
+      pbtInner: 128,
+      pbtOuter: 128,
+    },
+    fieldStatus: {
+      ...fieldStatus,
+      'main.mode': fresh('main.mode'),
+      'main.filterWidth': fresh('main.filterWidth'),
+      'main.pbtInner': fresh('main.pbtInner'),
+      'main.pbtOuter': fresh('main.pbtOuter'),
+    },
+  };
 }
 
 function emitFrame(overrides: Partial<TestScopeFrame> = {}): TestScopeFrame {
@@ -444,7 +478,10 @@ beforeEach(() => {
   runtimeHarness.state.nextLeaseId = 0;
   runtimeHarness.state.hardwareUnsubscribe = vi.fn();
   runtimeHarness.state.dxUnsubscribe = vi.fn();
+  runtimeHarness.state.currentState = Object.freeze({ source: 'test-state' });
+  runtimeHarness.state.currentCaps = Object.freeze({ source: 'test-capabilities' });
   authorityHarness.state.current = authority();
+  authorityHarness.state.useProductionSelector = false;
   passbandHarness.rawWidth = 2_700;
   passbandHarness.getFilterWidthFromRightEdgePx.mockImplementation(() => passbandHarness.rawWidth);
   spectrumRendererHarness.lastOptions = null;
@@ -810,11 +847,10 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
     expect(handlerHarness.filter.onFilterWidthCommit).toHaveBeenCalledWith(2_700, 0, 17);
   });
 
-  it('renders and resizes a centered PBT-derived passband authority (MOR-1649)', () => {
-    // SpectrumPanel consumes semantic authority only. This is the centered
-    // PBT-only output from scope-adapter: no native IF-shift field is needed.
-    const pbtOnlyAuthority = authority({ ifShiftHz: 0, pbtInnerHz: 0, pbtOuterHz: 0 });
-    authorityHarness.state.current = pbtOnlyAuthority;
+  it('renders and resizes a fresh PBT-only IC-7300 passband via the production selector (MOR-1649)', () => {
+    runtimeHarness.state.currentState = freshPbtOnlyIc7300State();
+    runtimeHarness.state.currentCaps = IC7300_CAPABILITIES;
+    authorityHarness.state.useProductionSelector = true;
     const target = mountPanel();
     emitFrame();
     const { waterfall } = prepareGeometry(target);
@@ -825,7 +861,7 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
     pointer(zone!, 'pointerdown', 41, 100);
     pointer(waterfall, 'pointermove', 41, 130);
     pointer(waterfall, 'pointerup', 41, 130);
-    expect(handlerHarness.filter.onFilterWidthCommit).toHaveBeenCalledWith(2_700, 0, 17);
+    expect(handlerHarness.filter.onFilterWidthCommit).toHaveBeenCalledWith(2_800, 0, 1);
   });
 
   it('normalizes fixed-frame resize X around the captured carrier rather than sample center', () => {

--- a/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
+++ b/frontend/src/components/spectrum/__tests__/SpectrumPanel.component.test.ts
@@ -810,6 +810,24 @@ describe('SpectrumPanel Observation authority and final-gesture intents', () => 
     expect(handlerHarness.filter.onFilterWidthCommit).toHaveBeenCalledWith(2_700, 0, 17);
   });
 
+  it('renders and resizes a centered PBT-derived passband authority (MOR-1649)', () => {
+    // SpectrumPanel consumes semantic authority only. This is the centered
+    // PBT-only output from scope-adapter: no native IF-shift field is needed.
+    const pbtOnlyAuthority = authority({ ifShiftHz: 0, pbtInnerHz: 0, pbtOuterHz: 0 });
+    authorityHarness.state.current = pbtOnlyAuthority;
+    const target = mountPanel();
+    emitFrame();
+    const { waterfall } = prepareGeometry(target);
+    const zone = waterfall.querySelector<HTMLButtonElement>('.passband-resize-zone');
+
+    expect(target.querySelector('.passband-overlay')).not.toBeNull();
+    expect(zone).not.toBeNull();
+    pointer(zone!, 'pointerdown', 41, 100);
+    pointer(waterfall, 'pointermove', 41, 130);
+    pointer(waterfall, 'pointerup', 41, 130);
+    expect(handlerHarness.filter.onFilterWidthCommit).toHaveBeenCalledWith(2_700, 0, 17);
+  });
+
   it('normalizes fixed-frame resize X around the captured carrier rather than sample center', () => {
     authorityHarness.state.current = authority({ frequencyHz: 14_025_000 });
     const target = mountPanel();

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
@@ -332,6 +332,31 @@ describe('MOR-1409 A06a1 canonical spectrum authority selector', () => {
     expect(result?.ifShiftHz).toBe(expectedIfShiftHz);
     expect(result?.ifShiftHz).not.toBeNull();
   });
+
+  it('keeps a fresh centered PBT-only passband without a raw ifShift observation (MOR-1649)', () => {
+    const { ifShift: _rawIfShift, ...pbtOnlyMain } = receiver(14_074_000);
+    const pbtOnlyState = withStatus(state({
+      main: { ...pbtOnlyMain, pbtInner: 128, pbtOuter: 128 } as ServerState['main'],
+    }), 'main.ifShift', undefined);
+    const pbtOnlyCaps = caps({
+      capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'pbt'],
+    });
+
+    expect(toSpectrumAuthority(pbtOnlyState, pbtOnlyCaps)).toMatchObject({
+      ifShiftHz: 0,
+      pbtInnerHz: 0,
+      pbtOuterHz: 0,
+    });
+  });
+
+  it('keeps native IF shift gated by its own raw observation (MOR-1649)', () => {
+    const nativeCaps = caps({
+      capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'if_shift'],
+    });
+
+    expect(toSpectrumAuthority(withStatus(state(), 'main.ifShift', undefined), nativeCaps)?.ifShiftHz)
+      .toBeNull();
+  });
 });
 
 describe('MOR-1409 A06a1 deterministic filter-width snapping', () => {

--- a/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/scope-adapter.authority.isolated.test.ts
@@ -26,6 +26,7 @@ import {
 } from '../scope-adapter';
 import { toRadioViewModel } from '../radio-view-model-adapter';
 import { deriveIfShift, pbtRawToHz } from '$lib/radio/filter-controls';
+import { IC7300_CAPABILITIES, IC7300_STATE } from './fixtures/ic7300-profile';
 
 const fresh: FieldStatus = {
   storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
@@ -110,6 +111,34 @@ function withStatus(base: ServerState, path: string, status: FieldStatus | undef
   if (status) statuses[path] = { ...status, storePath: path };
   else delete statuses[path];
   return { ...base, fieldStatus: statuses } as ServerState;
+}
+
+function freshStatus(path: string): FieldStatus {
+  return { ...fresh, storePath: path };
+}
+
+function freshPbtOnlyIc7300State(): ServerState {
+  const captured = structuredClone(IC7300_STATE);
+  const { ifShift: _rawIfShift, ...mainWithoutRawIfShift } = captured.main!;
+  const fieldStatus = { ...captured.fieldStatus };
+  delete fieldStatus['main.ifShift'];
+  return {
+    ...captured,
+    main: {
+      ...mainWithoutRawIfShift,
+      mode: 'AM',
+      filterWidth: 10_000,
+      pbtInner: 128,
+      pbtOuter: 128,
+    },
+    fieldStatus: {
+      ...fieldStatus,
+      'main.mode': freshStatus('main.mode'),
+      'main.filterWidth': freshStatus('main.filterWidth'),
+      'main.pbtInner': freshStatus('main.pbtInner'),
+      'main.pbtOuter': freshStatus('main.pbtOuter'),
+    },
+  } as ServerState;
 }
 
 afterEach(() => {
@@ -333,28 +362,42 @@ describe('MOR-1409 A06a1 canonical spectrum authority selector', () => {
     expect(result?.ifShiftHz).not.toBeNull();
   });
 
-  it('keeps a fresh centered PBT-only passband without a raw ifShift observation (MOR-1649)', () => {
-    const { ifShift: _rawIfShift, ...pbtOnlyMain } = receiver(14_074_000);
-    const pbtOnlyState = withStatus(state({
-      main: { ...pbtOnlyMain, pbtInner: 128, pbtOuter: 128 } as ServerState['main'],
-    }), 'main.ifShift', undefined);
-    const pbtOnlyCaps = caps({
-      capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'pbt'],
-    });
+  it('keeps a fresh centered PBT-only IC-7300 passband without raw IF-shift authority (MOR-1649)', () => {
+    const pbtOnlyState = freshPbtOnlyIc7300State();
 
-    expect(toSpectrumAuthority(pbtOnlyState, pbtOnlyCaps)).toMatchObject({
+    expect(IC7300_CAPABILITIES).toMatchObject({
+      model: 'IC-7300', receivers: 1, vfoScheme: 'ab', vfoReadback: 'selected_unselected',
+    });
+    expect(IC7300_CAPABILITIES.capabilities).toContain('pbt');
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('dual_rx');
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('if_shift');
+    expect(pbtOnlyState.fieldStatus?.['main.ifShift']).toBeUndefined();
+    expect(toSpectrumAuthority(pbtOnlyState, IC7300_CAPABILITIES)).toMatchObject({
       ifShiftHz: 0,
       pbtInnerHz: 0,
       pbtOuterHz: 0,
     });
   });
 
-  it('keeps native IF shift gated by its own raw observation (MOR-1649)', () => {
+  it.each([
+    ['main.pbtInner', stale], ['main.pbtOuter', stale],
+    ['main.pbtInner', undefined], ['main.pbtOuter', undefined],
+  ] as const)('hides PBT-derived shift when %s is stale or missing (MOR-1649)', (path, status) => {
+    const result = toSpectrumAuthority(
+      withStatus(freshPbtOnlyIc7300State(), path, status), IC7300_CAPABILITIES,
+    );
+
+    expect(result?.ifShiftHz).toBeNull();
+  });
+
+  it('keeps native FTX-1-style IF shift gated by its own raw observation (MOR-1649)', () => {
     const nativeCaps = caps({
       capabilities: ['scope', 'dual_rx', 'filter_width', 'data_mode', 'if_shift'],
     });
+    const nativeState = state({ main: { ...receiver(14_074_000), ifShift: 250 } });
 
-    expect(toSpectrumAuthority(withStatus(state(), 'main.ifShift', undefined), nativeCaps)?.ifShiftHz)
+    expect(toSpectrumAuthority(nativeState, nativeCaps)?.ifShiftHz).toBe(250);
+    expect(toSpectrumAuthority(withStatus(nativeState, 'main.ifShift', undefined), nativeCaps)?.ifShiftHz)
       .toBeNull();
   });
 });

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -132,6 +132,13 @@ function knownReading<T>(
   return strictlySeen(state, path) && field?.reading.status === 'known' ? field.reading.value : null;
 }
 
+function knownSemanticReading<T>(
+  field: { readonly reading: { readonly status: 'known'; readonly value: T } | { readonly status: 'unknown' } }
+    | undefined,
+): T | null {
+  return field?.reading.status === 'known' ? field.reading.value : null;
+}
+
 function activeVfoPath(receiver: 'MAIN' | 'SUB', slot: { readonly kind: string; readonly id?: string }): string {
   const key = receiver === 'SUB' ? 'sub' : 'main';
   return slot.kind === 'slotted' && (slot.id === 'A' || slot.id === 'B')
@@ -175,6 +182,11 @@ export function toSpectrumAuthority(
   const dataFact = knownReading(state, `${key}.dataMode`, passband?.dataMode);
   const filterWidthHz = positiveInteger(widthFact) ? widthFact : null;
   const dataMode = nonnegativeInteger(dataFact) ? dataFact : null;
+  // Native IF shift remains an independently observed raw fact. PBT-only
+  // radios instead expose a semantic shift derived from their two PBT facts.
+  const ifShiftFact = caps.capabilities.includes('if_shift')
+    ? knownReading(state, `${key}.ifShift`, passband?.ifShift)
+    : knownSemanticReading(passband?.ifShift);
   const supportsData = caps.capabilities.includes('data_mode');
   const rule = mode !== null && modeFact === mode && filterWidthHz !== null
     && (!supportsData || dataMode !== null) && caps.capabilities.includes('filter_width')
@@ -188,8 +200,7 @@ export function toSpectrumAuthority(
     filterWidthHz,
     filterShape: finiteNumber(knownReading(state, `${key}.filterShape`, passband?.filterShape))
       ? knownReading(state, `${key}.filterShape`, passband?.filterShape) as number : null,
-    ifShiftHz: finiteNumber(knownReading(state, `${key}.ifShift`, passband?.ifShift))
-      ? knownReading(state, `${key}.ifShift`, passband?.ifShift) as number : null,
+    ifShiftHz: finiteNumber(ifShiftFact) ? ifShiftFact : null,
     pbtInnerHz: finiteNumber(knownReading(state, `${key}.pbtInner`, passband?.pbtInner))
       ? knownReading(state, `${key}.pbtInner`, passband?.pbtInner) as number : null,
     pbtOuterHz: finiteNumber(knownReading(state, `${key}.pbtOuter`, passband?.pbtOuter))

--- a/frontend/src/lib/runtime/adapters/scope-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/scope-adapter.ts
@@ -183,10 +183,13 @@ export function toSpectrumAuthority(
   const filterWidthHz = positiveInteger(widthFact) ? widthFact : null;
   const dataMode = nonnegativeInteger(dataFact) ? dataFact : null;
   // Native IF shift remains an independently observed raw fact. PBT-only
-  // radios instead expose a semantic shift derived from their two PBT facts.
+  // radios instead expose a semantic shift derived from their two fresh PBT
+  // facts; no raw IF-shift observation exists for that radio shape.
   const ifShiftFact = caps.capabilities.includes('if_shift')
     ? knownReading(state, `${key}.ifShift`, passband?.ifShift)
-    : knownSemanticReading(passband?.ifShift);
+    : strictlySeen(state, `${key}.pbtInner`) && strictlySeen(state, `${key}.pbtOuter`)
+      ? knownSemanticReading(passband?.ifShift)
+      : null;
   const supportsData = caps.capabilities.includes('data_mode');
   const rule = mode !== null && modeFact === mode && filterWidthHz !== null
     && (!supportsData || dataMode !== null) && caps.capabilities.includes('filter_width')


### PR DESCRIPTION
## Summary
- preserve the semantic PBT-derived IF-shift fact when no native IF-shift capability exists
- retain the raw field-authority gate for radios with native IF shift
- cover the centered PBT-only overlay and resize path

## Verification
- targeted adapter and SpectrumPanel Vitest coverage
- frontend type and Svelte check
- frontend lint

Refs #2569

Hardware validation remains required: perform RX-only overlay and filter-width resize checks on IC-7300 and FTX-1; do not transmit.