### PR TITLE
fix(#2565): commit Break-in Delay on release

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -51,11 +51,12 @@ const h = vi.hoisted(() => ({
   txRelease: vi.fn(),
 }));
 
-vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
-vi.mock('$lib/runtime/commands/radio-intents', async () => {
-  const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
-});
+vi.mock('$lib/transport/ws-client', () => ({
+  sendCommand: vi.fn(),
+  getControlSession: () => ({ epoch: 1 }),
+  onCommandDelivery: vi.fn(),
+  onControlSessionTransition: vi.fn(),
+}));
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {
     get rxEnabled() { return h.rxEnabled; },
@@ -101,6 +102,7 @@ vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';
+import { getCommandLifecycle, resetCommandLifecycle } from '$lib/stores/commands.svelte';
 import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
 import { setCapabilities } from '$lib/stores/capabilities.svelte';
 import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
@@ -218,6 +220,7 @@ beforeEach(() => {
   h.snapshot = { ...IDLE };
   h.listeners.clear();
   vi.mocked(sendCommand).mockClear();
+  resetCommandLifecycle();
   h.txStart.mockClear();
   h.txRelease.mockClear();
 });
@@ -226,6 +229,7 @@ afterEach(() => {
   if (component) unmount(component);
   component = null;
   document.body.innerHTML = '';
+  resetCommandLifecycle();
 });
 
 /* ── (a) THE NO-KEY-PATH PIN ───────────────────────────────────── */
@@ -274,6 +278,7 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
       if (control instanceof HTMLInputElement) {
         control.value = control.max;
         control.dispatchEvent(new Event('input', { bubbles: true }));
+        control.dispatchEvent(new Event('change', { bubbles: true }));
       } else press(control);
     }
     flushSync();
@@ -286,6 +291,36 @@ describe('the CW surface never becomes a second key path (decomposition R9)', ()
     for (const forbidden of KEY_CLASS_COMMANDS) expect(commands()).not.toContain(forbidden);
     // The App TX authority is never asked for a lease either — the ONE
     // `<RxTxSurface>` above is untouched by everything this surface does.
+    expect(h.txStart).not.toHaveBeenCalled();
+    expect(h.txRelease).not.toHaveBeenCalled();
+  });
+
+  it('commits one IC-7300-shaped Break-in Delay intent only on release', () => {
+    const ic7300Caps = {
+      ...liveCaps(CW_TAGS), model: 'IC-7300', receivers: 1, vfoScheme: 'ab',
+    } as Capabilities;
+    h.caps = ic7300Caps;
+    setCapabilities(ic7300Caps);
+    useState(liveState());
+    render();
+    const input = el('breakInDelay')!.querySelector('input') as HTMLInputElement;
+    for (const value of [80, 96, 111]) {
+      input.value = String(value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith(
+      'set_break_in_delay', { level: 111 }, expect.any(String),
+    );
+    const commandId = vi.mocked(sendCommand).mock.calls[0]![2] as string;
+    expect(getCommandLifecycle(commandId, 1)).toMatchObject({
+      id: commandId, name: 'set_break_in_delay', params: { level: 111 }, status: 'pending',
+    });
+    expect(input.value).toBe('64');
+    expect(el('breakInDelay-value')!.textContent!.trim()).toBe('64');
     expect(h.txStart).not.toHaveBeenCalled();
     expect(h.txRelease).not.toHaveBeenCalled();
   });
@@ -356,7 +391,7 @@ describe('break-in is gated on the ONE txPermit, end to end', () => {
     render();
     press(el('break-in-full')!);
     flushSync();
-    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_break_in', { mode: 2 });
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_break_in', { mode: 2 }, expect.any(String));
   });
 });
 
@@ -372,7 +407,7 @@ describe('APF and TPF are receiver-scoped and follow the active VFO', () => {
     expect(el('apf-value')!.textContent!.trim()).toBe('2');
     press(el('apf-off')!);
     flushSync();
-    expect(sendCommand).toHaveBeenCalledWith('set_apf', { mode: 0, receiver: 1 });
+    expect(sendCommand).toHaveBeenCalledWith('set_apf', { mode: 0, receiver: 1 }, expect.any(String));
   });
 
   it('reads MAIN facts and commands MAIN when MAIN is active', () => {
@@ -380,7 +415,7 @@ describe('APF and TPF are receiver-scoped and follow the active VFO', () => {
     expect(el('apf-value')!.textContent!.trim()).toBe('0');
     press(el('apf-on')!);
     flushSync();
-    expect(sendCommand).toHaveBeenCalledWith('set_apf', { mode: 1, receiver: 0 });
+    expect(sendCommand).toHaveBeenCalledWith('set_apf', { mode: 1, receiver: 0 }, expect.any(String));
   });
 });
 

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -159,6 +159,32 @@
   function setLevel(field: CwLevelField, value: number): void {
     if (cw && usable(cw[field])) onLevelChange?.(field, value);
   }
+  let breakInDelayCancelled = false;
+  function restoreBreakInDelay(target: HTMLInputElement): void {
+    const reading = cw?.breakInDelay.reading;
+    target.value = String(reading?.status === 'known' ? reading.value : Number(target.min));
+  }
+  function noteBreakInDelayInput(): void {
+    breakInDelayCancelled = false;
+  }
+  function commitBreakInDelay(target: HTMLInputElement): void {
+    if (breakInDelayCancelled) {
+      breakInDelayCancelled = false;
+      restoreBreakInDelay(target);
+      return;
+    }
+    const candidate = target.valueAsNumber;
+    const min = Number(target.min);
+    const max = Number(target.max);
+    if (Number.isFinite(candidate) && Number.isFinite(min) && Number.isFinite(max)) {
+      setLevel('breakInDelay', Math.min(max, Math.max(min, Math.round(candidate))));
+    }
+    restoreBreakInDelay(target);
+  }
+  function cancelBreakInDelay(target: HTMLInputElement): void {
+    breakInDelayCancelled = true;
+    restoreBreakInDelay(target);
+  }
   function setApf(on: boolean): void {
     if (cw && usable(cw.apf) && !mutexed('apf')) onApfOn?.(on);
   }
@@ -214,7 +240,15 @@
             type="range" {min} {max} {step}
             value={f.reading.status === 'known' ? f.reading.value : min}
             disabled={!usable(f)}
-            oninput={(event) => setLevel(field, event.currentTarget.valueAsNumber)}
+            oninput={field === 'breakInDelay'
+              ? () => noteBreakInDelayInput()
+              : (event) => setLevel(field, event.currentTarget.valueAsNumber)}
+            onchange={field === 'breakInDelay'
+              ? (event) => commitBreakInDelay(event.currentTarget)
+              : undefined}
+            onpointercancel={field === 'breakInDelay'
+              ? (event) => cancelBreakInDelay(event.currentTarget)
+              : undefined}
           />
           <output data-testid={`cw-keyer-${field}-value`}>{textOf(f)} {unit}</output>
         </label>

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -95,6 +95,7 @@ const press = (el: HTMLElement) => el.dispatchEvent(new MouseEvent('click', { bu
 const slide = (el: HTMLInputElement, value: number) => {
   el.value = String(value);
   el.dispatchEvent(new Event('input', { bubbles: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true }));
 };
 
 /* ── (a) the surface is not a key path ────────────────────────── */
@@ -200,6 +201,59 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
       'reversePaddle', 'apf:false', 'apf:true', 'twinPeak',
     ]);
     r.dispose();
+  });
+});
+
+/* ── MOR-1648 — Break-in Delay commits only on release ─────────── */
+
+describe('Break-in Delay is a canonical-only release gesture (MOR-1648)', () => {
+  it('emits nothing during a drag and one bounded integer on release', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    const input = r.input('breakInDelay')!;
+    for (const value of [80, 96, 111]) {
+      input.value = String(value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(onLevelChange).not.toHaveBeenCalled();
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 111);
+    expect(input.value).toBe('64');
+    expect(r.text('breakInDelay-value')).toBe('64');
+    r.dispose();
+  });
+
+  it('rounds and clamps a programmatic final candidate before dispatch', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    const input = r.input('breakInDelay')!;
+    Object.defineProperty(input, 'valueAsNumber', { configurable: true, value: 300.4 });
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 255);
+    r.dispose();
+  });
+
+  it('cancels a gesture and suppresses its trailing change', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    const input = r.input('breakInDelay')!;
+    input.value = '111';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('pointercancel', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onLevelChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('64');
+    r.dispose();
+  });
+
+  it('emits nothing when unmounted after intermediate drag input', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange });
+    const input = r.input('breakInDelay')!;
+    input.value = '111';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    r.dispose();
+    expect(onLevelChange).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Commit the Break-in Delay range once on native release instead of dispatching intermediate drag input.
- Restore the control from canonical radio observation while confirmation is pending.
- Cover direct cancellation and composed IC-7300-shaped typed intent routing.

## Verification
- Focused frontend gesture and typed-intent witnesses (235 passing tests)
- Frontend type and lint checks
- CI-safe command/radio protocol witnesses (639 passing tests)

Refs #2565

## Hardware follow-up
An owner-present, non-TX IC-7300 rerun remains required before #2565 can be marked Done.