### PR TITLE
fix: schedule Filter Width post-write readback

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -571,6 +571,9 @@ _POST_WRITE_READBACK_FIELDS: dict[type, Callable[[Any], tuple[FieldPath, ...]]] 
     SetDataMode: lambda cmd: (
         FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "data_mode"),
     ),
+    SetFilterWidth: lambda cmd: (
+        FieldPath.active(_post_write_receiver_id(cmd), "freq_mode", "filter_width"),
+    ),
 }
 
 # ``ensure_fresh``'s ``max_age`` asks "how old may the CURRENT StateStore

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1006,6 +1006,14 @@ async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
             SetDataMode(1, receiver=0),
             FieldPath.active("main", "freq_mode", "data_mode"),
         ),
+        (
+            SetFilterWidth(3500, receiver=0),
+            FieldPath.active("main", "freq_mode", "filter_width"),
+        ),
+        (
+            SetFilterWidth(1800, receiver=1),
+            FieldPath.active("sub", "freq_mode", "filter_width"),
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -1119,6 +1127,45 @@ async def test_execute_set_freq_readback_coalesces_with_pending_cadence_request(
     pending = scheduler.pending_requests()
     assert len(pending) == 1  # coalesced, not a second entry
     assert pending[0].priority is AcquisitionPriority.USER
+
+
+@pytest.mark.asyncio
+async def test_execute_set_filter_width_readback_coalesces_and_uses_ic7300_acquisition_path() -> (
+    None
+):
+    path = FieldPath.active("main", "freq_mode", "filter_width")
+    profile = resolve_radio_profile(model="IC-7300")
+    assert profile.state_acquisition is not None
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+    scheduler.ensure_fresh(
+        (path,), max_age=1.5, priority=AcquisitionPriority.BACKGROUND, reason="cadence"
+    )
+    await poller._execute(SetFilterWidth(3500, receiver=0))  # noqa: SLF001
+    pending = scheduler.pending_requests()
+    assert len(pending) == 1
+    assert len(pending) == 1 and pending[0].paths == (path,)
+    assert pending[0].priority is AcquisitionPriority.USER
+    await poller._send_scheduler_requests()  # noqa: SLF001
+    assert any(
+        args == (0x1A,) and kwargs["sub"] == 0x03
+        for args, kwargs in radio.send_civ.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_failed_set_filter_width_does_not_queue_readback() -> None:
+    path = FieldPath.active("main", "freq_mode", "filter_width")
+    radio = _make_radio(active="MAIN")
+    radio.set_filter_width.side_effect = RuntimeError("write failed")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+    with pytest.raises(RuntimeError, match="write failed"):
+        await poller._execute(SetFilterWidth(3500, receiver=0))  # noqa: SLF001
+    assert scheduler.pending_requests() == ()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- schedule a USER-priority active Filter Width readback after a successful write
- cover main/sub routing, request coalescing, the existing IC-7300 acquisition route, and failed-write behavior

## Validation

- `uv run pytest tests/test_radio_poller_coverage.py -q --tb=short -k ...` (13 passed)
- `uv run ruff check src/rigplane/web/radio_poller.py tests/test_radio_poller_coverage.py`
- `uv run ruff format --check src/rigplane/web/radio_poller.py tests/test_radio_poller_coverage.py`
- `git diff --check`

## Acceptance boundary

This implements the software-only portion. The owner-present hardware rerun remains required before issue closure.

Refs #2562