### PR TITLE
test: declare VFO command-bus fixture primitives

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts
@@ -39,7 +39,10 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 vi.mock('$lib/stores/capabilities.svelte', () => ({
   getCapabilities: vi.fn(() => ({
     receivers: 2, vfoScheme: 'main_sub',
-    capabilities: ['dual_rx', 'dual_watch', 'split', 'main_sub_tracking'],
+    capabilities: [
+      'dual_rx', 'dual_watch', 'split', 'main_sub_tracking',
+      'vfo_swap', 'vfo_equalize',
+    ],
   })),
   capabilitiesMatchGeneration: vi.fn(() => true),
   getControlRange: vi.fn(() => null),


### PR DESCRIPTION
## Summary
- declare `vfo_swap` and `vfo_equalize` in the positive command-bus fixture
- keep the fixture limited to its existing exact dispatch expectations

## Verification
- `npm run test -- src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts`
- `npm run check`
- `npm run lint`
- `npm run i18n:check`
- `npm test`

Refs #2578