### PR TITLE
fix(#2510): gate VFO primitives by declared support

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -12,8 +12,8 @@
  * in a DIFFERENT switch (`makeKeyboardHandlers().dispatch`) and are a
  * deliberate scope boundary per `waived.ts`'s header, not covered here.
  *
- * FINDING (fixture-derived split): of the 28, 19 genuinely DISPATCH on this
- * IC-7300 fixture and 9 genuinely REFUSE. Every refusal below is an honest
+ * FINDING (fixture-derived split): of the 28, 17 genuinely DISPATCH on this
+ * IC-7300 fixture and 11 genuinely REFUSE. Every refusal below is an honest
  * fail-closed gate — an unobserved top-level/receiver field, or a
  * single-receiver/no-dual_rx structural gate — never a test artifact. Each
  * case's `gate` string names the exact reason, cross-checked against the
@@ -44,10 +44,10 @@
  * this was a genuinely reachable, user-visible dead control on this
  * profile before the fix — not a theoretical gap.
  *
- * MOR-1578 (filed, cited below where this walk's own rows happen to touch
- * it — not this walk's finding, no production code changed here): (1)
- * `vfo_swap`/`vfo_equalize` dispatch completely unconditionally, no
- * field-observation gate at all (confirmed by the two cases below); (2)
+ * MOR-1604: `vfo_swap`/`vfo_equalize` now dispatch only when the capability
+ * payload declares their exact primitive tag. The byte-faithful IC-7300
+ * capture declares neither, so both correctly refuse without consulting
+ * active receiver, slot, or VFO readback. (2)
  * `switch_active_vfo` reads `context.state.active` RAW, bypassing the
  * observation-gated tautological-MAIN resolution every other action here
  * goes through; (3) `mode-psk`/`mode-pskr` bindings declare `{ mode: 'PSK'
@@ -218,10 +218,10 @@ const CASES: readonly KeyboardCase[] = [
     gate: 'declared rf-level-down binding ({delta:-5}); main.rfGain observed; delta scaled against '
       + 'caps.controls.rf_gain raw domain (MOR-1577, fixed)' },
   { action: 'toggle_monitor', frames: [], gate: 'top-level monitorOn unobserved' },
-  { action: 'vfo_swap', frames: [['vfo_swap', {}]],
-    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all (MOR-1578)' },
-  { action: 'vfo_equalize', frames: [['vfo_equalize', {}]],
-    gate: 'vfoScheme !== "single" — unconditional, no field-observation gate at all (MOR-1578)' },
+  { action: 'vfo_swap', frames: [],
+    gate: 'captured IC-7300 capability payload omits exact vfo_swap primitive tag (MOR-1604)' },
+  { action: 'vfo_equalize', frames: [],
+    gate: 'captured IC-7300 capability payload omits exact vfo_equalize primitive tag (MOR-1604)' },
   { action: 'switch_active_vfo', frames: [],
     gate: 'single receiver / no dual_rx — target computes to SUB, nothing to switch to (reads context.state.active RAW, MOR-1578)' },
   { action: 'set_active_vfo', params: { vfo: 'MAIN' }, frames: [['set_vfo', { vfo: 'MAIN' }]],

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -237,7 +237,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
         'tx', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
         'cw', 'break_in', 'apf', 'twin_peak', 'rx_antenna',
         'split', 'dual_rx', 'dual_watch', 'main_sub_tracking',
-        'bsr', 'preamp', 'attenuator', 'ip_plus', 'scan',
+        'bsr', 'preamp', 'attenuator', 'ip_plus', 'scan', 'vfo_swap', 'vfo_equalize',
       ],
       stateContractVersion: 1,
       providerGeneration: 31,
@@ -1056,6 +1056,47 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.setAudioConfig).toHaveBeenNthCalledWith(3, { focus: 'sub' });
   });
 
+  it('gates blind VFO primitives by their exact declared tags across panel and keyboard paths', () => {
+    h.unavailable.add('active');
+    h.unavailable.add('main.freqHz');
+    h.unavailable.add('main.mode');
+    h.unavailable.add('main.activeSlot');
+    h.unavailable.add('main.vfoA.freqHz');
+    h.unavailable.add('main.vfoB.freqHz');
+
+    for (const [tags, expected] of [
+      [[], []],
+      [['vfo_swap'], [['vfo_swap', {}]]],
+      [['vfo_equalize'], [['vfo_equalize', {}]]],
+      [['vfo_swap', 'vfo_equalize'], [['vfo_swap', {}], ['vfo_equalize', {}]]],
+    ] as const) {
+      h.caps = { ...h.caps!, capabilities: tags };
+      h.sendCommand.mockClear();
+      resetCommandLifecycle();
+      makeVfoHandlers().onSwap();
+      makeVfoHandlers().onEqual();
+      expect(exactCalls()).toEqual(expected);
+
+      h.sendCommand.mockClear();
+      resetCommandLifecycle();
+      expect(dispatchKeyboardRadioAction({ action: 'vfo_swap' })).toBe(true);
+      expect(dispatchKeyboardRadioAction({ action: 'vfo_equalize' })).toBe(true);
+      expect(exactCalls()).toEqual(expected);
+    }
+
+    h.sendCommand.mockClear();
+    resetCommandLifecycle();
+    h.caps = { ...h.caps!, capabilities: ['vfo_swap', 'vfo_equalize'], providerGeneration: 99 };
+    makeVfoHandlers().onSwap();
+    expect(dispatchKeyboardRadioAction({ action: 'vfo_equalize' })).toBe(true);
+    h.caps = { ...h.caps!, providerGeneration: 31, receivers: 1, vfoScheme: 'main_sub' };
+    makeVfoHandlers().onEqual();
+    expect(dispatchKeyboardRadioAction({ action: 'vfo_swap' })).toBe(true);
+    expect(h.sendCommand).not.toHaveBeenCalled();
+    expect(h.patchRadioState).not.toHaveBeenCalled();
+    expect(h.setAudioConfig).not.toHaveBeenCalled();
+  });
+
   it('preserves pending mode focus and local audio focus without patching radio truth', () => {
     const panel = document.createElement('div');
     panel.scrollIntoView = vi.fn();
@@ -1078,7 +1119,7 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
   it('keeps physical MAIN orthogonal to one-RX A/B Selected/Unselected topology', () => {
     h.state = oneReceiverAbState();
     h.caps = {
-      capabilities: ['split', 'tx', 'vox'], receivers: 1, vfoScheme: 'ab',
+      capabilities: ['split', 'tx', 'vox', 'vfo_swap', 'vfo_equalize'], receivers: 1, vfoScheme: 'ab',
       stateContractVersion: 1, providerGeneration: 31,
     };
     const vfo = makeVfoHandlers();

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1132,12 +1132,12 @@ export function makeVfoHandlers() {
   return {
     onSwap: () => {
       const context = currentA03cContext();
-      if (!context || context.caps.vfoScheme === 'single') return;
+      if (!context || !context.caps.capabilities.includes('vfo_swap')) return;
       dispatchRadioIntent({ name: 'vfo_swap', params: {} });
     },
     onEqual: () => {
       const context = currentA03cContext();
-      if (!context || context.caps.vfoScheme === 'single') return;
+      if (!context || !context.caps.capabilities.includes('vfo_equalize')) return;
       dispatchRadioIntent({ name: 'vfo_equalize', params: {} });
     },
     onSplitToggle: () => {
@@ -1461,6 +1461,20 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
   if (!KEYBOARD_RADIO_ACTIONS.has(action)) return false;
   const safeParams = params === undefined ? {} : keyboardParams(params);
   if (safeParams === null) return true;
+
+  // These declared primitives are deliberately blind to receiver and VFO
+  // readback. Their shared panel handlers own the generation/topology/tag
+  // gate; do this after parameter validation, before keyboard active-RX
+  // resolution so an unobserved active field cannot invent a refusal.
+  switch (action) {
+    case 'vfo_swap':
+      makeVfoHandlers().onSwap();
+      return true;
+    case 'vfo_equalize':
+      makeVfoHandlers().onEqual();
+      return true;
+  }
+
   const context = currentKeyboardContext();
   if (!context) return true;
   const receiver = context.receiver;
@@ -1602,12 +1616,6 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
     case 'toggle_split':
       if (has('split') && knownA03cTopLevelField(context, 'split')
         && typeof context.state.split === 'boolean') makeVfoHandlers().onSplitToggle();
-      return true;
-    case 'vfo_swap':
-      makeVfoHandlers().onSwap();
-      return true;
-    case 'vfo_equalize':
-      makeVfoHandlers().onEqual();
       return true;
     case 'switch_active_vfo': {
       const target = context.state.active === 'MAIN' ? 'SUB' : 'MAIN';


### PR DESCRIPTION
## Summary
- gate blind VFO swap/equalize only on their exact declared capability tags
- route keyboard primitives through the same gate after parameter validation
- cover the full tag matrix, blind state, invalid context, and captured missing-tag refusal

## Verification
- `npm test` (347 files, 7470 tests)
- `npm run check`
- `npm run lint`
- `npm run i18n:check`
- `npm run build`

Refs #2584