### PR TITLE
feat(#2520): declare IC-7610 and IC-9700 speech

### DIFF
--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -116,6 +116,7 @@ features = [
     "power_control",
     "dial_lock",
     "scan",
+    "speech",
     "bsr",
     "main_sub_tracking",
     "tuning_step",

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -90,6 +90,7 @@ features = [
     "power_control",
     "dial_lock",
     "scan",
+    "speech",
     "bsr",
     # AGC
     "agc",

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -339,12 +339,14 @@ class TestMultiVendorProfiles:
         [
             ("ic705.toml", ("get_speech", "set_speech")),
             ("ic7300.toml", ("set_speech",)),
+            ("ic7610.toml", ("get_speech",)),
+            ("ic9700.toml", ("set_speech",)),
         ],
     )
     def test_icom_speech_capability_matches_builtin_announcement_routes(
         self, filename, speech_routes, tmp_path
     ):
-        """MOR-1609: profile speech is limited to CI-V 0x13 announcements."""
+        """MOR-1610: profile speech is limited to CI-V 0x13 announcements."""
         rig_path = RIGS_DIR / filename
         rig = load_rig(rig_path)
 


### PR DESCRIPTION
## Summary
- declare `speech` only for IC-7610 and IC-9700 built-in CI-V 0x13 announcement routes
- extend exact route-to-capability coverage while retaining FTX-1 as the route-absent negative control

## Verification
- `uv run pytest tests/test_rig_multi_vendor.py tests/test_rig_ic7610.py tests/test_rig_loader.py -q --tb=short` (318 passed, 1 skipped)
- `uv run ruff check rigs/ic7610.toml rigs/ic9700.toml tests/test_rig_multi_vendor.py tests/test_rig_ic7610.py`
- `uv run ruff format --check tests/test_rig_multi_vendor.py tests/test_rig_ic7610.py`
- `git diff --check`

Refs #2520