### PR TITLE
feat(#2588): declare IC-7610 speech capability

### DIFF
--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -123,6 +123,8 @@ features = [
     "xfc",
     # System
     "system_settings",
+    # Built-in CI-V 0x13 announcement readback (get_speech below).
+    "speech",
 ]
 
 [state_acquisition]

--- a/tests/golden/validation/ic7610.dry-run.json
+++ b/tests/golden/validation/ic7610.dry-run.json
@@ -328,6 +328,11 @@
       "declaration": "supported"
     },
     {
+      "check_id": "speech.presence",
+      "status": "pass",
+      "declaration": "unsupported_pending_evidence"
+    },
+    {
       "check_id": "split.set",
       "status": "skip",
       "declaration": "supported"

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -339,6 +339,7 @@ class TestMultiVendorProfiles:
         [
             ("ic705.toml", ("get_speech", "set_speech")),
             ("ic7300.toml", ("set_speech",)),
+            ("ic7610.toml", ("get_speech",)),
         ],
     )
     def test_icom_speech_capability_matches_builtin_announcement_routes(


### PR DESCRIPTION
## Summary
- declare `speech` in the IC-7610 profile for its existing `get_speech` CI-V `0x13` route
- cover the IC-7610 declaration in the multi-vendor announcement-route contract while preserving the FTX-1 negative control
- regenerate the committed IC-7610 dry-run golden with the prescribed command

## Verification
- red-first: `uv run pytest tests/test_validation_gating.py::test_committed_ic7610_golden_matches_live_dry_run -q --tb=short` (expected stale-golden failure before regeneration)
- `uv run pytest tests/test_rig_ic7610.py tests/test_rig_multi_vendor.py tests/test_validation_gating.py -q --tb=short`
- `uv run rigplane --model IC-7610 validate --provider native --dry-run --gate tests/golden/validation/ic7610.dry-run.json`
- `uv run ruff check rigs/ic7610.toml tests/test_rig_multi_vendor.py tests/golden/validation/ic7610.dry-run.json`
- `uv run ruff format --check tests/test_rig_multi_vendor.py`
- `git diff --check`

No hardware, UI, USB, server, or manual validation actions.

Refs #2588