### PR TITLE
test: isolate lifecycle GC diagnostics

### DIFF
--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -80,12 +81,13 @@ def transport() -> MockTransport:
 
 
 @pytest.fixture  # type: ignore[untyped-decorator]
-def radio(transport: MockTransport) -> IcomRadio:
+def radio(transport: MockTransport) -> Generator[IcomRadio, None, None]:
     r = IcomRadio("192.168.1.100")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True
-    return r
+    yield r
+    r._connected = False
 
 
 def _make_frame(

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -49,6 +49,9 @@ def test_radio_gc_when_disconnected_does_not_log_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """When a Radio is collected after disconnect, no WARN is emitted."""
+    # Collect cyclic garbage from prior tests before caplog starts observing this
+    # test's warning boundary.
+    gc.collect()
     with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
         radio = IcomRadio("192.168.1.1")
         assert radio._conn_state == RadioConnectionState.DISCONNECTED


### PR DESCRIPTION
## Summary
- restore the connected test radio fixture to disconnected state during teardown
- clear prior cyclic garbage before the disconnected-radio warning assertion

## Verification
- `uv run --python 3.11 pytest -q --tb=short tests/test_civ_rx_coverage.py::test_update_radio_state_cmd14_global_dsp_levels_observation_backed[23-108-anti_vox_gain-108] tests/test_civ_rx_coverage.py::test_update_radio_state_cmd1a_vox_delay_observation_backed tests/test_lifecycle_diagnostics.py::test_radio_gc_when_disconnected_does_not_log_warning`
- `uv run --python 3.11 pytest -q --tb=short tests/test_civ_rx_coverage.py tests/test_lifecycle_diagnostics.py`
- `uv run --python 3.11 pytest -q --tb=short -n auto tests/test_civ_rx_coverage.py tests/test_lifecycle_diagnostics.py`
- `uv run --python 3.11 ruff check tests/test_civ_rx_coverage.py tests/test_lifecycle_diagnostics.py`

Refs #2591