### PR TITLE
feat(#2589): declare IC-9700 speech capability

### DIFF
--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -98,6 +98,8 @@ features = [
     "xfc",
     # System
     "system_settings",
+    # Built-in CI-V 0x13 announcement write (set_speech below).
+    "speech",
 ]
 
 # ── Parameterized Capabilities ───────────────────────────────────

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -340,6 +340,7 @@ class TestMultiVendorProfiles:
             ("ic705.toml", ("get_speech", "set_speech")),
             ("ic7300.toml", ("set_speech",)),
             ("ic7610.toml", ("get_speech",)),
+            ("ic9700.toml", ("set_speech",)),
         ],
     )
     def test_icom_speech_capability_matches_builtin_announcement_routes(


### PR DESCRIPTION
## Summary
- declare IC-9700 built-in CI-V 0x13 announcement capability
- extend the shared multi-vendor speech route witness

## Verification
- `uv run pytest tests/test_rig_multi_vendor.py -q --tb=short`
- `uv run pytest -n auto tests/test_rig_multi_vendor.py -q --tb=short`
- `uv run ruff check rigs/ic9700.toml tests/test_rig_multi_vendor.py`
- `uv run ruff format --check rigs/ic9700.toml tests/test_rig_multi_vendor.py`

Refs #2589