### PR TITLE
fix: include missing poller commands in union

### DIFF
--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -836,6 +836,7 @@ Command = (
     | SetMode
     | SendCiv
     | SetFilter
+    | SetFilterShape
     | SetFilterWidth
     | SetPower
     | SetRfGain
@@ -942,6 +943,7 @@ Command = (
     | SetCivTransceive
     | SetCivOutputAnt
     | SetAfMute
+    | SetTunerStatus
     | SetTuningStep
     | SetXfcStatus
     | SetTxFreqMonitor

--- a/tests/test_command_union.py
+++ b/tests/test_command_union.py
@@ -1,0 +1,17 @@
+"""Public ``Command`` union coverage."""
+
+from typing import get_args
+
+from rigplane.runtime._poller_types import (
+    Command,
+    SetFilterShape,
+    SetTunerStatus,
+    Speak,
+)
+
+
+def test_command_union_includes_filter_shape_tuner_status_and_speech() -> None:
+    """The public queue annotation accepts every supported command dataclass."""
+    command_types = set(get_args(Command))
+
+    assert {SetFilterShape, SetTunerStatus, Speak} <= command_types


### PR DESCRIPTION
Refs #2542

## Summary
- include `SetFilterShape` and `SetTunerStatus` in the public `Command` union
- add a regression witness that keeps both commands and `Speak` in the union

## Verification
- `uv run pytest tests/test_command_union.py -q --tb=short`
- `uv run mypy src/rigplane/runtime/_poller_types.py`
- `uv run ruff check src/rigplane/runtime/_poller_types.py tests/test_command_union.py`
- `uv run ruff format --check src/rigplane/runtime/_poller_types.py tests/test_command_union.py`
- `git diff --check`