### PR TITLE
fix: gate active VFO toggle on observed dual RX

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -223,7 +223,7 @@ const CASES: readonly KeyboardCase[] = [
   { action: 'vfo_equalize', frames: [],
     gate: 'captured IC-7300 capability payload omits exact vfo_equalize primitive tag (MOR-1604)' },
   { action: 'switch_active_vfo', frames: [],
-    gate: 'single receiver / no dual_rx — target computes to SUB, nothing to switch to (reads context.state.active RAW, MOR-1578)' },
+    gate: 'single receiver / no dual_rx — no observed dual-RX receiver exists to toggle (MOR-1601)' },
   { action: 'set_active_vfo', params: { vfo: 'MAIN' }, frames: [['set_vfo', { vfo: 'MAIN' }]],
     gate: 'state.main exists — activateReceiver dispatches unconditionally once the receiver resolves' },
   { action: 'toggle_dial_lock', frames: [], gate: 'top-level dialLock unobserved' },

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts
@@ -44,13 +44,13 @@
  * this was a genuinely reachable, user-visible dead control on this
  * profile before the fix — not a theoretical gap.
  *
- * MOR-1604: (1) `vfo_swap`/`vfo_equalize` now dispatch only when the capability
+ * MOR-1604/MOR-1601: (1) `vfo_swap`/`vfo_equalize` now dispatch only when the capability
  * payload declares their exact primitive tag. The byte-faithful IC-7300
  * capture declares neither, so both correctly refuse without consulting
- * active receiver, slot, or VFO readback. (2)
- * `switch_active_vfo` reads `context.state.active` RAW, bypassing the
- * observation-gated tautological-MAIN resolution every other action here
- * goes through; (3) `mode-psk`/`mode-pskr` bindings declare `{ mode: 'PSK'
+ * active receiver, slot, or VFO readback. (2) `switch_active_vfo` dispatches
+ * only with a declared dual-RX MAIN/SUB topology and a fresh observed active
+ * receiver fact; this single-receiver fixture has neither dual-RX support
+ * nor an observed receiver to toggle. (3) `mode-psk`/`mode-pskr` bindings declare `{ mode: 'PSK'
  * }`/`{ mode: 'PSK-R' }`, but this fixture's `caps.modes` is `['USB','LSB',
  * 'CW','CW-R','AM','FM','RTTY','RTTY-R']` — no PSK/PSK-R — so those two
  * refuse here too, adjacent to (not the same case as) `mode_select` below,

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -1497,6 +1497,23 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     h.unavailable.add('active');
     refuse();
     h.unavailable.clear();
+    h.state = { ...state(), fieldStatus: {} } as ServerState;
+    refuse();
+    h.state = {
+      ...state(),
+      fieldStatus: { active: { ...freshStatus, observed: false } },
+    } as ServerState;
+    refuse();
+    h.state = {
+      ...state(),
+      fieldStatus: { active: { ...freshStatus, freshness: 'stale' } },
+    } as ServerState;
+    refuse();
+    h.state = {
+      ...state(),
+      fieldStatus: { active: { storePath: 'active', observed: true, freshness: 'fresh' } },
+    } as unknown as ServerState;
+    refuse();
     h.state = { ...state(), active: 'UNKNOWN' as never };
     refuse();
     h.state = { ...state(), providerGeneration: 32 };

--- a/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts
@@ -1486,6 +1486,46 @@ describe('MOR-1409 A03a/A03b1 canonical receive-control intent handlers', () => 
     expect(h.setAudioConfig).toHaveBeenCalledExactlyOnceWith({ focus: 'main' });
   });
 
+  it('toggles only a fresh observed active receiver on a declared dual-RX MAIN/SUB topology (MOR-1601)', () => {
+    const refuse = () => {
+      expect(dispatchKeyboardRadioAction({ action: 'switch_active_vfo' })).toBe(true);
+      expect(h.sendCommand).not.toHaveBeenCalled();
+      expect(h.setAudioConfig).not.toHaveBeenCalled();
+      expect(getCommandLifecycles()).toHaveLength(0);
+    };
+
+    h.unavailable.add('active');
+    refuse();
+    h.unavailable.clear();
+    h.state = { ...state(), active: 'UNKNOWN' as never };
+    refuse();
+    h.state = { ...state(), providerGeneration: 32 };
+    refuse();
+    h.state = state();
+    h.caps = { ...h.caps!, capabilities: (h.caps!.capabilities as string[]).filter((cap) => cap !== 'dual_rx') };
+    refuse();
+    h.caps = { ...h.caps!, capabilities: [...(h.caps!.capabilities as string[]), 'dual_rx'], receivers: 1, vfoScheme: 'ab' };
+    h.state = oneReceiverAbState();
+    refuse();
+
+    h.caps = {
+      ...h.caps!, receivers: 2, vfoScheme: 'main_sub', providerGeneration: 31,
+      capabilities: [...(h.caps!.capabilities as string[]), 'dual_rx'],
+    };
+    h.state = state('MAIN');
+    expect(dispatchKeyboardRadioAction({ action: 'switch_active_vfo' })).toBe(true);
+    h.state = state('SUB');
+    expect(dispatchKeyboardRadioAction({ action: 'switch_active_vfo' })).toBe(true);
+
+    expect(exactCalls()).toEqual([
+      ['set_vfo', { vfo: 'SUB' }],
+      ['set_vfo', { vfo: 'MAIN' }],
+    ]);
+    expectIntentTransport();
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(1, { focus: 'sub' });
+    expect(h.setAudioConfig).toHaveBeenNthCalledWith(2, { focus: 'main' });
+  });
+
   it('contains hostile params for every newly recognized keyboard action without touching radio or audio state', () => {
     const actions = [
       'toggle_rit', 'toggle_xit', 'clear_rit_xit', 'adjust_af_level', 'adjust_rf_gain',

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1625,7 +1625,7 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
       // active receiver is an observed, fresh fact on a declared dual-RX
       // MAIN/SUB topology. Never infer MAIN from an unobserved raw value.
       if (context.caps.receivers < 2 || !has('dual_rx') || !context.state.sub
-        || !knownA03cTopLevelField(context, 'active')) return true;
+        || !observedAvailableField(context.state, 'active')) return true;
       const active = context.state.active;
       if (active !== 'MAIN' && active !== 'SUB') return true;
       const target = active === 'MAIN' ? 'SUB' : 'MAIN';

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -1621,9 +1621,16 @@ export function dispatchKeyboardRadioAction({ action, params }: KeyboardRadioAct
         && typeof context.state.split === 'boolean') makeVfoHandlers().onSplitToggle();
       return true;
     case 'switch_active_vfo': {
-      const target = context.state.active === 'MAIN' ? 'SUB' : 'MAIN';
+      // MOR-1601: toggling a physical receiver is meaningful only when the
+      // active receiver is an observed, fresh fact on a declared dual-RX
+      // MAIN/SUB topology. Never infer MAIN from an unobserved raw value.
+      if (context.caps.receivers < 2 || !has('dual_rx') || !context.state.sub
+        || !knownA03cTopLevelField(context, 'active')) return true;
+      const active = context.state.active;
+      if (active !== 'MAIN' && active !== 'SUB') return true;
+      const target = active === 'MAIN' ? 'SUB' : 'MAIN';
       if (target === 'MAIN') makeVfoHandlers().onMainVfoClick();
-      else if (context.caps.receivers >= 2 && has('dual_rx') && context.state.sub) makeVfoHandlers().onSubVfoClick();
+      else makeVfoHandlers().onSubVfoClick();
       return true;
     }
     case 'set_active_vfo':


### PR DESCRIPTION
## Summary
- require an observed active receiver before keyboard VFO toggling
- refuse without a declared dual-RX MAIN/SUB topology
- cover stale, malformed, generation-mismatched, capability-absent, and single-RX refusal paths

## Verification
- `npm test -- --run src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts`
- `npm exec eslint -- src/lib/runtime/commands/panel-commands.ts src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts src/lib/runtime/adapters/__tests__/mor1563-keyboard-fanout-conformance.isolated.test.ts`
- `npm run check`

Refs #2511