### PR TITLE
feat(#2543): add TX interlock disposition policy

### DIFF
--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -1,0 +1,173 @@
+"""Pure, shared disposition policy for writes made while RF state matters.
+
+The policy deliberately classifies concrete command dataclasses instead of the
+``Command`` union.  Enforcement seats may therefore use it while that union is
+being corrected, and a missing union member cannot create a privileged path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rigplane.runtime._poller_types import (
+    MemoryToVfo,
+    PttOff,
+    PttOn,
+    QuickDualWatch,
+    QuickDwTrigger,
+    QuickSplit,
+    QuickSplitTrigger,
+    ScanStart,
+    ScanStop,
+    SelectVfo,
+    SendCiv,
+    SetAntenna1,
+    SetAntenna2,
+    SetBand,
+    SetCivOutputAnt,
+    SetDualWatch,
+    SetFreq,
+    SetMainSubTracking,
+    SetMemoryMode,
+    SetMode,
+    SetPowerstat,
+    SetRitFrequency,
+    SetRitTxStatus,
+    SetRxAntenna,
+    SetRxAntennaAnt1,
+    SetRxAntennaAnt2,
+    SetSplit,
+    SetTunerStatus,
+    VfoEqualize,
+    VfoSwap,
+)
+
+__all__ = [
+    "RfState",
+    "TxInterlockDecision",
+    "TxInterlockDisposition",
+    "classify_tx_interlock",
+    "evaluate_tx_interlock",
+]
+
+
+class TxInterlockDisposition(StrEnum):
+    """The fixed safety class assigned to a typed command."""
+
+    ALWAYS_PASS = "always-pass"
+    TX_SAFE = "tx-safe"
+    DEFER = "defer"
+    BLOCK = "block"
+
+
+class RfState(StrEnum):
+    """The observed RF state available to an enforcement seat."""
+
+    RX = "rx"
+    TX = "tx"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class TxInterlockDecision:
+    """A disposition plus whether a seat may attempt the write immediately."""
+
+    disposition: TxInterlockDisposition
+    allowed: bool
+    reason: str
+
+
+# These structural exemptions are intentionally checked before all disruptive
+# tables.  A future incomplete or corrupt disruptive table must not make a
+# de-key/stop operation harder to execute.
+_ALWAYS_PASS_TYPES = (PttOff, ScanStop)
+
+_DEFER_TYPES = (
+    SetFreq,
+    SetMode,
+    SetBand,
+    SelectVfo,
+    VfoSwap,
+    VfoEqualize,
+    SetSplit,
+    SetDualWatch,
+    SetMainSubTracking,
+    QuickSplit,
+    QuickDualWatch,
+    QuickDwTrigger,
+    QuickSplitTrigger,
+    SetMemoryMode,
+    MemoryToVfo,
+    SetRitTxStatus,
+    SetRitFrequency,
+)
+
+_HARD_BLOCK_TYPES = (
+    PttOn,
+    SendCiv,
+    ScanStart,
+    SetAntenna1,
+    SetAntenna2,
+    SetRxAntenna,
+    SetRxAntennaAnt1,
+    SetRxAntennaAnt2,
+    SetCivOutputAnt,
+)
+
+
+def classify_tx_interlock(command: object) -> TxInterlockDisposition:
+    """Return the non-negotiable disposition for one typed command.
+
+    Commands not explicitly disruptive are TX-SAFE by default.  A later
+    profile/provider layer may tighten that default, but this generic policy
+    never loosens structural or hard-block classifications.
+    """
+
+    if isinstance(command, _ALWAYS_PASS_TYPES):
+        return TxInterlockDisposition.ALWAYS_PASS
+    if isinstance(command, SetPowerstat) and not command.on:
+        return TxInterlockDisposition.ALWAYS_PASS
+    if isinstance(command, SetTunerStatus) and command.value == 0:
+        return TxInterlockDisposition.ALWAYS_PASS
+
+    if isinstance(command, SetTunerStatus) and command.value in (1, 2):
+        return TxInterlockDisposition.BLOCK
+    if isinstance(command, _HARD_BLOCK_TYPES):
+        return TxInterlockDisposition.BLOCK
+    if isinstance(command, _DEFER_TYPES):
+        return TxInterlockDisposition.DEFER
+    return TxInterlockDisposition.TX_SAFE
+
+
+def evaluate_tx_interlock(command: object, *, rf_state: RfState) -> TxInterlockDecision:
+    """Evaluate whether a command may be attempted now at an enforcement seat.
+
+    Hard BLOCK and DEFER commands both require *known* RX for an immediate
+    attempt.  The caller owns deferred-lane timing and lifecycle reporting;
+    this pure policy only preserves the fail-closed result and truthful reason.
+    """
+
+    disposition = classify_tx_interlock(command)
+    if disposition in (
+        TxInterlockDisposition.ALWAYS_PASS,
+        TxInterlockDisposition.TX_SAFE,
+    ):
+        return TxInterlockDecision(
+            disposition, True, "TX interlock permits this command."
+        )
+    if rf_state is RfState.RX:
+        return TxInterlockDecision(disposition, True, "RF state is known RX.")
+    if rf_state is RfState.UNKNOWN:
+        return TxInterlockDecision(
+            disposition,
+            False,
+            "RF state is unknown; this command must not be attempted yet.",
+        )
+    if disposition is TxInterlockDisposition.DEFER:
+        return TxInterlockDecision(
+            disposition, False, "RF state is TX; command is deferred."
+        )
+    return TxInterlockDecision(
+        disposition, False, "RF state is TX; command is blocked."
+    )

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -1,0 +1,103 @@
+"""Focused contract tests for the shared TX interlock policy."""
+
+from rigplane.runtime._poller_types import (
+    MemoryToVfo,
+    PttOff,
+    PttOn,
+    ScanStart,
+    ScanStop,
+    SendCiv,
+    SetAcc1ModLevel,
+    SetAntenna1,
+    SetBand,
+    SetCwPitch,
+    SetData1ModInput,
+    SetDualWatch,
+    SetFreq,
+    SetMode,
+    SetPowerstat,
+    SetRitFrequency,
+    SetRitTxStatus,
+    SetSplit,
+    SetTunerStatus,
+    SelectVfo,
+    VfoEqualize,
+    VfoSwap,
+)
+from rigplane.runtime.tx_interlock import (
+    RfState,
+    TxInterlockDisposition,
+    classify_tx_interlock,
+    evaluate_tx_interlock,
+)
+
+
+def test_emergency_stop_commands_take_structural_precedence() -> None:
+    for command in (PttOff(), SetPowerstat(on=False), ScanStop(), SetTunerStatus(0)):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.ALWAYS_PASS
+        decision = evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN)
+        assert decision.allowed is True
+
+
+def test_rf_start_and_disruptive_commands_are_hard_block() -> None:
+    for command in (
+        PttOn(),
+        SendCiv(command=0x00),
+        ScanStart(),
+        SetAntenna1(on=True),
+        SetTunerStatus(1),
+        SetTunerStatus(2),
+    ):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.BLOCK
+
+    assert (
+        classify_tx_interlock(SetPowerstat(on=True)) is TxInterlockDisposition.TX_SAFE
+    )
+
+
+def test_hard_block_fails_closed_for_unknown_rf_state_without_claiming_tx() -> None:
+    decision = evaluate_tx_interlock(PttOn(), rf_state=RfState.UNKNOWN)
+
+    assert decision.allowed is False
+    assert "RF state is unknown" in decision.reason
+    assert "transmitting" not in decision.reason.lower()
+
+
+def test_hard_block_is_allowed_only_when_rx_is_known() -> None:
+    assert evaluate_tx_interlock(PttOn(), rf_state=RfState.RX).allowed is True
+    assert evaluate_tx_interlock(PttOn(), rf_state=RfState.TX).allowed is False
+
+
+def test_disruptive_operations_defer() -> None:
+    for command in (
+        SetFreq(7_100_000),
+        SetMode("USB"),
+        SetBand(4),
+        SelectVfo("MAIN"),
+        VfoSwap(),
+        VfoEqualize(),
+        SetSplit(on=True),
+        SetDualWatch(on=True),
+        MemoryToVfo(channel=1),
+        SetRitTxStatus(on=True),
+        SetRitFrequency(freq=100),
+    ):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.DEFER
+
+
+def test_defer_does_not_loosen_when_rf_state_is_unknown() -> None:
+    decision = evaluate_tx_interlock(SetFreq(7_100_000), rf_state=RfState.UNKNOWN)
+
+    assert decision.disposition is TxInterlockDisposition.DEFER
+    assert decision.allowed is False
+    assert "RF state is unknown" in decision.reason
+
+
+def test_cw_and_modulation_input_controls_are_tx_safe() -> None:
+    for command in (
+        SetCwPitch(600),
+        SetData1ModInput(source=1),
+        SetAcc1ModLevel(level=10),
+    ):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
+        assert evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN).allowed is True


### PR DESCRIPTION
Refs #2543

## Summary
- add a pure runtime classifier for emergency, TX-safe, deferred, and hard-block command dispositions
- fail closed for unknown RF state without claiming TX
- cover the ruled command families with focused tests

## Verification
- `uv run pytest tests/test_tx_interlock_policy.py -q --tb=short`
- `uv run ruff check src/rigplane/runtime/tx_interlock.py tests/test_tx_interlock_policy.py`
- `uv run ruff format --check src/rigplane/runtime/tx_interlock.py tests/test_tx_interlock_policy.py`
- `git diff --check`

No public API, CLI, config, or rigctld wire compatibility change.