### PR TITLE
feat(#2544): add bounded deferred TX command lane

### DIFF
--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -44,7 +44,10 @@ from rigplane.runtime._poller_types import (
 )
 
 __all__ = [
+    "DeferredTxCommandLane",
     "RfState",
+    "TxInterlockDeferredOutcome",
+    "TxInterlockDeferredResult",
     "TxInterlockDecision",
     "TxInterlockDisposition",
     "classify_tx_interlock",
@@ -69,6 +72,15 @@ class RfState(StrEnum):
     UNKNOWN = "unknown"
 
 
+class TxInterlockDeferredOutcome(StrEnum):
+    """A state transition produced by the one-slot deferred command lane."""
+
+    HELD = "held"
+    RELEASED = "released"
+    EXPIRED = "expired"
+    SUPERSEDED = "superseded"
+
+
 @dataclass(frozen=True, slots=True)
 class TxInterlockDecision:
     """A disposition plus whether a seat may attempt the write immediately."""
@@ -76,6 +88,114 @@ class TxInterlockDecision:
     disposition: TxInterlockDisposition
     allowed: bool
     reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class TxInterlockDeferredResult:
+    """A pure lane result for the enforcement seat to act on or report.
+
+    The lane never executes ``command`` and never emits lifecycle events.  For
+    supersession or expiry while accepting a replacement, ``replacement`` is
+    the newly held command; it has its own fresh three-second TTL.
+    """
+
+    outcome: TxInterlockDeferredOutcome
+    command: object
+    expires_at: float
+    replacement: object | None = None
+
+
+@dataclass(slots=True)
+class _DeferredTxCommand:
+    command: object
+    deferred_at: float
+    expires_at: float
+    quiet_since: float | None = None
+
+
+class DeferredTxCommandLane:
+    """Pure, single-slot timing policy for commands classified as ``DEFER``.
+
+    Seats supply their monotonic clock and observed RF state.  This class does
+    not know about radios, tasks, execution, or lifecycle transports: it only
+    decides whether the one held command remains held, may be released, has
+    expired, or was explicitly superseded.
+    """
+
+    _TTL_SECONDS = 3.0
+    _QUIET_SECONDS = 1.0
+
+    def __init__(self) -> None:
+        self._entry: _DeferredTxCommand | None = None
+
+    @property
+    def pending(self) -> object | None:
+        """Return the held command, if any, without exposing lane internals."""
+
+        return self._entry.command if self._entry is not None else None
+
+    def defer(self, command: object, *, now: float) -> TxInterlockDeferredResult:
+        """Hold a ``DEFER`` command, explicitly replacing a prior held command.
+
+        The original command's TTL is never carried forward.  If it was already
+        expired when a new command arrives, expiry is reported truthfully while
+        the new command starts a separate fresh hold.
+        """
+
+        decision = evaluate_tx_interlock(command, rf_state=RfState.TX)
+        if decision.disposition is not TxInterlockDisposition.DEFER:
+            raise ValueError("only commands with DEFER disposition may enter the lane")
+
+        replacement = _DeferredTxCommand(
+            command=command,
+            deferred_at=now,
+            expires_at=now + self._TTL_SECONDS,
+        )
+        previous = self._entry
+        self._entry = replacement
+        if previous is None:
+            return self._result(TxInterlockDeferredOutcome.HELD, replacement)
+        if now >= previous.expires_at:
+            return TxInterlockDeferredResult(
+                TxInterlockDeferredOutcome.EXPIRED,
+                previous.command,
+                previous.expires_at,
+                replacement=command,
+            )
+        return TxInterlockDeferredResult(
+            TxInterlockDeferredOutcome.SUPERSEDED,
+            previous.command,
+            previous.expires_at,
+            replacement=command,
+        )
+
+    def observe(
+        self, *, rf_state: RfState, now: float
+    ) -> TxInterlockDeferredResult | None:
+        """Advance the held command against one RF observation and clock value."""
+
+        entry = self._entry
+        if entry is None:
+            return None
+        if now >= entry.expires_at:
+            self._entry = None
+            return self._result(TxInterlockDeferredOutcome.EXPIRED, entry)
+        if rf_state is not RfState.RX:
+            entry.quiet_since = None
+            return self._result(TxInterlockDeferredOutcome.HELD, entry)
+        if entry.quiet_since is None:
+            entry.quiet_since = now
+            return self._result(TxInterlockDeferredOutcome.HELD, entry)
+        if now - entry.quiet_since < self._QUIET_SECONDS:
+            return self._result(TxInterlockDeferredOutcome.HELD, entry)
+        self._entry = None
+        return self._result(TxInterlockDeferredOutcome.RELEASED, entry)
+
+    @staticmethod
+    def _result(
+        outcome: TxInterlockDeferredOutcome, entry: _DeferredTxCommand
+    ) -> TxInterlockDeferredResult:
+        return TxInterlockDeferredResult(outcome, entry.command, entry.expires_at)
 
 
 # These structural exemptions are intentionally checked before all disruptive

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -25,7 +25,9 @@ from rigplane.runtime._poller_types import (
     VfoSwap,
 )
 from rigplane.runtime.tx_interlock import (
+    DeferredTxCommandLane,
     RfState,
+    TxInterlockDeferredOutcome,
     TxInterlockDisposition,
     classify_tx_interlock,
     evaluate_tx_interlock,
@@ -101,3 +103,105 @@ def test_cw_and_modulation_input_controls_are_tx_safe() -> None:
     ):
         assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
         assert evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN).allowed is True
+
+
+def test_deferred_lane_holds_then_releases_after_continuous_known_rx() -> None:
+    lane = DeferredTxCommandLane()
+    command = SetFreq(7_100_000)
+
+    held = lane.defer(command, now=10.0)
+    assert held.outcome is TxInterlockDeferredOutcome.HELD
+    assert held.command is command
+    assert held.expires_at == 13.0
+
+    assert (
+        lane.observe(rf_state=RfState.RX, now=10.0).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.RX, now=10.999).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+
+    released = lane.observe(rf_state=RfState.RX, now=11.0)
+    assert released.outcome is TxInterlockDeferredOutcome.RELEASED
+    assert released.command is command
+    assert lane.pending is None
+
+
+def test_deferred_lane_resets_only_quiet_progress_for_unknown_or_renewed_tx() -> None:
+    lane = DeferredTxCommandLane()
+    command = SetFreq(7_100_000)
+    lane.defer(command, now=10.0)
+
+    lane.observe(rf_state=RfState.RX, now=10.2)
+    assert (
+        lane.observe(rf_state=RfState.UNKNOWN, now=10.9).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.RX, now=11.0).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.TX, now=11.8).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.RX, now=12.0).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+
+    released = lane.observe(rf_state=RfState.RX, now=13.0)
+    assert released.outcome is TxInterlockDeferredOutcome.EXPIRED
+    assert released.command is command
+    assert lane.pending is None
+
+
+def test_deferred_lane_ttl_never_restarts_on_ptt_qsk_transitions() -> None:
+    lane = DeferredTxCommandLane()
+    command = SetFreq(7_100_000)
+    lane.defer(command, now=0.0)
+
+    lane.observe(rf_state=RfState.TX, now=2.8)
+    lane.observe(rf_state=RfState.RX, now=2.9)
+    expired = lane.observe(rf_state=RfState.RX, now=3.0)
+
+    assert expired.outcome is TxInterlockDeferredOutcome.EXPIRED
+    assert expired.expires_at == 3.0
+    assert lane.pending is None
+    assert lane.observe(rf_state=RfState.RX, now=4.0) is None
+
+
+def test_newer_deferred_command_explicitly_supersedes_the_single_slot() -> None:
+    lane = DeferredTxCommandLane()
+    first = SetFreq(7_100_000)
+    second = SetMode("USB")
+    lane.defer(first, now=10.0)
+
+    superseded = lane.defer(second, now=10.5)
+
+    assert superseded.outcome is TxInterlockDeferredOutcome.SUPERSEDED
+    assert superseded.command is first
+    assert superseded.replacement is second
+    assert superseded.expires_at == 13.0
+    assert lane.pending is second
+    assert (
+        lane.observe(rf_state=RfState.RX, now=10.5).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.RX, now=11.5).outcome
+        is TxInterlockDeferredOutcome.RELEASED
+    )
+
+
+def test_deferred_lane_rejects_non_deferred_commands() -> None:
+    lane = DeferredTxCommandLane()
+
+    try:
+        lane.defer(PttOn(), now=0.0)
+    except ValueError as error:
+        assert "DEFER" in str(error)
+    else:
+        raise AssertionError("only DEFER commands may enter the deferred lane")


### PR DESCRIPTION
Refs #2544

## Summary
- add a pure, single-slot DEFER command lane with exact 3.0s TTL and 1.0s continuously-known-RX release rule
- return explicit held/released/expired/superseded outcomes without execution or lifecycle emission
- cover clock, QSK, unknown, expiry, and supersession edges

## Verification
- `uv run pytest tests/test_tx_interlock_policy.py -q`
- `uv run ruff check src/rigplane/runtime/tx_interlock.py tests/test_tx_interlock_policy.py`
- `uv run ruff format --check src/rigplane/runtime/tx_interlock.py tests/test_tx_interlock_policy.py`
- `uv run mypy src/rigplane/runtime/tx_interlock.py`

No public API, CLI, config, or rigctld wire compatibility change.