### PR TITLE
fix: gate legacy CW auto-tune on RX analysis

### DIFF
--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -30,6 +30,7 @@
   let showBreakIn = $derived(p.hasBreakIn);
   let showApf = $derived(p.hasApf);
   let showTwinPeak = $derived(p.hasTwinPeak);
+  let showAutoTune = $derived(p.autoTuneAvailable);
   let breakInActive = $derived(isBreakInActive(breakIn));
   let apfActive = $derived(isApfActive(apfMode));
   let breakInLabel = $derived(formatBreakIn(breakIn));
@@ -126,11 +127,13 @@
       />
     {/if}
 
-    <div class="toggle-row">
-      <HardwareButton indicator="edge-left" color="green" onclick={() => onAutoTune()}>
-        AUTO TUNE
-      </HardwareButton>
-    </div>
+    {#if showAutoTune}
+      <div class="toggle-row">
+        <HardwareButton indicator="edge-left" color="green" onclick={() => onAutoTune()}>
+          AUTO TUNE
+        </HardwareButton>
+      </div>
+    {/if}
   </div>
 {/if}
 

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -15,6 +15,7 @@ const mockProps = {
   hasBreakIn: true,
   hasApf: true,
   hasTwinPeak: true,
+  autoTuneAvailable: false,
 };
 
 const mockHandlers = {
@@ -54,6 +55,7 @@ beforeEach(() => {
     apfMode: 0, twinPeak: false, currentMode: 'CW',
     apfDisabled: false, tpfDisabled: false,
     hasCw: true, hasBreakIn: true, hasApf: true, hasTwinPeak: true,
+    autoTuneAvailable: false,
   });
   Object.values(mockHandlers).forEach((fn) => fn.mockClear());
 });
@@ -110,10 +112,16 @@ describe('CwPanel component rendering', () => {
     expect(buttons.some((b) => b.textContent?.trim() === 'TPF')).toBe(true);
   });
 
-  it('renders AUTO TUNE button (software CW auto-tune, #675)', () => {
+  it('does not render AUTO TUNE when RX-assisted correction is unavailable', () => {
     const t = mountPanel();
     const buttons = Array.from(t.querySelectorAll('button'));
-    expect(buttons.some((b) => b.textContent?.trim() === 'AUTO TUNE')).toBe(true);
+    expect(buttons.some((b) => b.textContent?.trim() === 'AUTO TUNE')).toBe(false);
+  });
+
+  it('renders AUTO TUNE when RX-assisted correction is available and delegates exactly once', () => {
+    const t = mountPanel({ autoTuneAvailable: true });
+    findButton(t, 'AUTO TUNE').click();
+    expect(mockHandlers.onAutoTune).toHaveBeenCalledTimes(1);
   });
 
   it('unmounts cleanly', () => {

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -735,6 +735,7 @@ export interface CwProps {
   hasBreakIn: boolean;
   hasApf: boolean;
   hasTwinPeak: boolean;
+  autoTuneAvailable: boolean;
 }
 
 export function toCwProps(
@@ -771,6 +772,9 @@ export function toCwProps(
     hasBreakIn: hasCap(caps, 'break_in'),
     hasApf: hasCap(caps, 'apf'),
     hasTwinPeak: hasCap(caps, 'twin_peak'),
+    autoTuneAvailable: hasCap(caps, 'cw')
+      && hasCap(caps, 'audio')
+      && caps?.audioFftAvailable === true,
   };
 }
 


### PR DESCRIPTION
## Summary
- derive legacy CW auto-tune availability from CW, audio, and audio-FFT facts
- hide the unavailable control rather than render a clickable no-op
- preserve the existing shared auto-tune handler contract

## Verification
- `npm test -- --run src/components-v2/panels/__tests__/CwPanel.component.test.ts`
- `npm run check`
- `npm run lint -- --max-warnings=0`

Refs #2514