### PR TITLE
feat(#2602): export TX interlock family metadata

### DIFF
--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -45,10 +45,14 @@ from rigplane.runtime._poller_types import (
 
 __all__ = [
     "RfState",
+    "TX_INTERLOCK_COMMAND_FAMILY_METADATA",
+    "TxInterlockCommandFamily",
+    "TxInterlockCommandFamilyMetadata",
     "TxInterlockDecision",
     "TxInterlockDisposition",
     "classify_tx_interlock",
     "evaluate_tx_interlock",
+    "get_tx_interlock_command_family_metadata",
 ]
 
 
@@ -59,6 +63,95 @@ class TxInterlockDisposition(StrEnum):
     TX_SAFE = "tx-safe"
     DEFER = "defer"
     BLOCK = "block"
+
+
+class TxInterlockCommandFamily(StrEnum):
+    """Stable, generic families with an owner-ruled base disposition."""
+
+    PTT_OFF = "ptt-off"
+    POWER_OFF = "power-off"
+    SCAN_STOP = "scan-stop"
+    TUNER_OFF = "tuner-off"
+    POWER_ON = "power-on"
+    PTT_ON = "ptt-on"
+    RAW_CIV = "raw-civ"
+    SCAN_START = "scan-start"
+    ANTENNA_SWITCH = "antenna-switch"
+    TUNER_ENGAGE = "tuner-engage"
+    FREQUENCY = "frequency"
+    MODE = "mode"
+    BAND = "band"
+    VFO_SELECT = "vfo-select"
+    VFO_TOPOLOGY = "vfo-topology"
+    MEMORY = "memory"
+    RIT_XIT = "rit-xit"
+
+
+@dataclass(frozen=True, slots=True)
+class TxInterlockCommandFamilyMetadata:
+    """One generic family and its non-negotiable typed-policy disposition."""
+
+    family: TxInterlockCommandFamily
+    base_disposition: TxInterlockDisposition
+
+
+TX_INTERLOCK_COMMAND_FAMILY_METADATA = (
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.PTT_OFF, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.POWER_OFF, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.SCAN_STOP, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.TUNER_OFF, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.POWER_ON, TxInterlockDisposition.TX_SAFE
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.PTT_ON, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.RAW_CIV, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.SCAN_START, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.ANTENNA_SWITCH, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.TUNER_ENGAGE, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.FREQUENCY, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.MODE, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.BAND, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.VFO_SELECT, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.VFO_TOPOLOGY, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.MEMORY, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.RIT_XIT, TxInterlockDisposition.DEFER
+    ),
+)
+
+_METADATA_BY_FAMILY = {
+    metadata.family: metadata for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA
+}
 
 
 class RfState(StrEnum):
@@ -78,35 +171,10 @@ class TxInterlockDecision:
     reason: str
 
 
-# These structural exemptions are intentionally checked before all disruptive
-# tables.  A future incomplete or corrupt disruptive table must not make a
-# de-key/stop operation harder to execute.
-_ALWAYS_PASS_TYPES = (PttOff, ScanStop)
-
-_DEFER_TYPES = (
-    SetFreq,
-    SetMode,
-    SetBand,
-    SelectVfo,
-    VfoSwap,
-    VfoEqualize,
-    SetSplit,
-    SetDualWatch,
-    SetMainSubTracking,
-    QuickSplit,
-    QuickDualWatch,
-    QuickDwTrigger,
-    QuickSplitTrigger,
-    SetMemoryMode,
-    MemoryToVfo,
-    SetRitTxStatus,
-    SetRitFrequency,
-)
-
-_HARD_BLOCK_TYPES = (
-    PttOn,
-    SendCiv,
-    ScanStart,
+# These are the antenna-switch variants; all other typed-policy groupings live
+# directly in ``get_tx_interlock_command_family_metadata`` so the exported
+# family metadata remains the one source for classification disposition.
+_ANTENNA_SWITCH_TYPES = (
     SetAntenna1,
     SetAntenna2,
     SetRxAntenna,
@@ -114,6 +182,70 @@ _HARD_BLOCK_TYPES = (
     SetRxAntennaAnt2,
     SetCivOutputAnt,
 )
+
+
+def get_tx_interlock_command_family_metadata(
+    command: object,
+) -> TxInterlockCommandFamilyMetadata | None:
+    """Return stable metadata for an explicitly classified typed command.
+
+    Commands covered only by the generic TX-SAFE default intentionally have no
+    family metadata.  This prevents consumers from mistaking a missing policy
+    classification for a profile-addressable family.
+    """
+
+    if isinstance(command, PttOff):
+        family = TxInterlockCommandFamily.PTT_OFF
+    elif isinstance(command, SetPowerstat):
+        family = (
+            TxInterlockCommandFamily.POWER_OFF
+            if not command.on
+            else TxInterlockCommandFamily.POWER_ON
+        )
+    elif isinstance(command, ScanStop):
+        family = TxInterlockCommandFamily.SCAN_STOP
+    elif isinstance(command, SetTunerStatus) and command.value == 0:
+        family = TxInterlockCommandFamily.TUNER_OFF
+    elif isinstance(command, PttOn):
+        family = TxInterlockCommandFamily.PTT_ON
+    elif isinstance(command, SendCiv):
+        family = TxInterlockCommandFamily.RAW_CIV
+    elif isinstance(command, ScanStart):
+        family = TxInterlockCommandFamily.SCAN_START
+    elif isinstance(command, _ANTENNA_SWITCH_TYPES):
+        family = TxInterlockCommandFamily.ANTENNA_SWITCH
+    elif isinstance(command, SetTunerStatus) and command.value in (1, 2):
+        family = TxInterlockCommandFamily.TUNER_ENGAGE
+    elif isinstance(command, SetFreq):
+        family = TxInterlockCommandFamily.FREQUENCY
+    elif isinstance(command, SetMode):
+        family = TxInterlockCommandFamily.MODE
+    elif isinstance(command, SetBand):
+        family = TxInterlockCommandFamily.BAND
+    elif isinstance(command, SelectVfo):
+        family = TxInterlockCommandFamily.VFO_SELECT
+    elif isinstance(
+        command,
+        (
+            VfoSwap,
+            VfoEqualize,
+            SetSplit,
+            SetDualWatch,
+            SetMainSubTracking,
+            QuickSplit,
+            QuickDualWatch,
+            QuickDwTrigger,
+            QuickSplitTrigger,
+        ),
+    ):
+        family = TxInterlockCommandFamily.VFO_TOPOLOGY
+    elif isinstance(command, (SetMemoryMode, MemoryToVfo)):
+        family = TxInterlockCommandFamily.MEMORY
+    elif isinstance(command, (SetRitTxStatus, SetRitFrequency)):
+        family = TxInterlockCommandFamily.RIT_XIT
+    else:
+        return None
+    return _METADATA_BY_FAMILY[family]
 
 
 def classify_tx_interlock(command: object) -> TxInterlockDisposition:
@@ -124,19 +256,9 @@ def classify_tx_interlock(command: object) -> TxInterlockDisposition:
     never loosens structural or hard-block classifications.
     """
 
-    if isinstance(command, _ALWAYS_PASS_TYPES):
-        return TxInterlockDisposition.ALWAYS_PASS
-    if isinstance(command, SetPowerstat) and not command.on:
-        return TxInterlockDisposition.ALWAYS_PASS
-    if isinstance(command, SetTunerStatus) and command.value == 0:
-        return TxInterlockDisposition.ALWAYS_PASS
-
-    if isinstance(command, SetTunerStatus) and command.value in (1, 2):
-        return TxInterlockDisposition.BLOCK
-    if isinstance(command, _HARD_BLOCK_TYPES):
-        return TxInterlockDisposition.BLOCK
-    if isinstance(command, _DEFER_TYPES):
-        return TxInterlockDisposition.DEFER
+    metadata = get_tx_interlock_command_family_metadata(command)
+    if metadata is not None:
+        return metadata.base_disposition
     return TxInterlockDisposition.TX_SAFE
 
 

--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -1,0 +1,173 @@
+"""Pure, shared disposition policy for writes made while RF state matters.
+
+The policy deliberately classifies concrete command dataclasses instead of the
+``Command`` union.  Enforcement seats may therefore use it while that union is
+being corrected, and a missing union member cannot create a privileged path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rigplane.runtime._poller_types import (
+    MemoryToVfo,
+    PttOff,
+    PttOn,
+    QuickDualWatch,
+    QuickDwTrigger,
+    QuickSplit,
+    QuickSplitTrigger,
+    ScanStart,
+    ScanStop,
+    SelectVfo,
+    SendCiv,
+    SetAntenna1,
+    SetAntenna2,
+    SetBand,
+    SetCivOutputAnt,
+    SetDualWatch,
+    SetFreq,
+    SetMainSubTracking,
+    SetMemoryMode,
+    SetMode,
+    SetPowerstat,
+    SetRitFrequency,
+    SetRitTxStatus,
+    SetRxAntenna,
+    SetRxAntennaAnt1,
+    SetRxAntennaAnt2,
+    SetSplit,
+    SetTunerStatus,
+    VfoEqualize,
+    VfoSwap,
+)
+
+__all__ = [
+    "RfState",
+    "TxInterlockDecision",
+    "TxInterlockDisposition",
+    "classify_tx_interlock",
+    "evaluate_tx_interlock",
+]
+
+
+class TxInterlockDisposition(StrEnum):
+    """The fixed safety class assigned to a typed command."""
+
+    ALWAYS_PASS = "always-pass"
+    TX_SAFE = "tx-safe"
+    DEFER = "defer"
+    BLOCK = "block"
+
+
+class RfState(StrEnum):
+    """The observed RF state available to an enforcement seat."""
+
+    RX = "rx"
+    TX = "tx"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class TxInterlockDecision:
+    """A disposition plus whether a seat may attempt the write immediately."""
+
+    disposition: TxInterlockDisposition
+    allowed: bool
+    reason: str
+
+
+# These structural exemptions are intentionally checked before all disruptive
+# tables.  A future incomplete or corrupt disruptive table must not make a
+# de-key/stop operation harder to execute.
+_ALWAYS_PASS_TYPES = (PttOff, ScanStop)
+
+_DEFER_TYPES = (
+    SetFreq,
+    SetMode,
+    SetBand,
+    SelectVfo,
+    VfoSwap,
+    VfoEqualize,
+    SetSplit,
+    SetDualWatch,
+    SetMainSubTracking,
+    QuickSplit,
+    QuickDualWatch,
+    QuickDwTrigger,
+    QuickSplitTrigger,
+    SetMemoryMode,
+    MemoryToVfo,
+    SetRitTxStatus,
+    SetRitFrequency,
+)
+
+_HARD_BLOCK_TYPES = (
+    PttOn,
+    SendCiv,
+    ScanStart,
+    SetAntenna1,
+    SetAntenna2,
+    SetRxAntenna,
+    SetRxAntennaAnt1,
+    SetRxAntennaAnt2,
+    SetCivOutputAnt,
+)
+
+
+def classify_tx_interlock(command: object) -> TxInterlockDisposition:
+    """Return the non-negotiable disposition for one typed command.
+
+    Commands not explicitly disruptive are TX-SAFE by default.  A later
+    profile/provider layer may tighten that default, but this generic policy
+    never loosens structural or hard-block classifications.
+    """
+
+    if isinstance(command, _ALWAYS_PASS_TYPES):
+        return TxInterlockDisposition.ALWAYS_PASS
+    if isinstance(command, SetPowerstat) and not command.on:
+        return TxInterlockDisposition.ALWAYS_PASS
+    if isinstance(command, SetTunerStatus) and command.value == 0:
+        return TxInterlockDisposition.ALWAYS_PASS
+
+    if isinstance(command, SetTunerStatus) and command.value in (1, 2):
+        return TxInterlockDisposition.BLOCK
+    if isinstance(command, _HARD_BLOCK_TYPES):
+        return TxInterlockDisposition.BLOCK
+    if isinstance(command, _DEFER_TYPES):
+        return TxInterlockDisposition.DEFER
+    return TxInterlockDisposition.TX_SAFE
+
+
+def evaluate_tx_interlock(command: object, *, rf_state: RfState) -> TxInterlockDecision:
+    """Evaluate whether a command may be attempted now at an enforcement seat.
+
+    Hard BLOCK and DEFER commands both require *known* RX for an immediate
+    attempt.  The caller owns deferred-lane timing and lifecycle reporting;
+    this pure policy only preserves the fail-closed result and truthful reason.
+    """
+
+    disposition = classify_tx_interlock(command)
+    if disposition in (
+        TxInterlockDisposition.ALWAYS_PASS,
+        TxInterlockDisposition.TX_SAFE,
+    ):
+        return TxInterlockDecision(
+            disposition, True, "TX interlock permits this command."
+        )
+    if rf_state is RfState.RX:
+        return TxInterlockDecision(disposition, True, "RF state is known RX.")
+    if rf_state is RfState.UNKNOWN:
+        return TxInterlockDecision(
+            disposition,
+            False,
+            "RF state is unknown; this command must not be attempted yet.",
+        )
+    if disposition is TxInterlockDisposition.DEFER:
+        return TxInterlockDecision(
+            disposition, False, "RF state is TX; command is deferred."
+        )
+    return TxInterlockDecision(
+        disposition, False, "RF state is TX; command is blocked."
+    )

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -26,8 +26,10 @@ from rigplane.runtime._poller_types import (
 )
 from rigplane.runtime.tx_interlock import (
     RfState,
+    TxInterlockCommandFamily,
     TxInterlockDisposition,
     classify_tx_interlock,
+    get_tx_interlock_command_family_metadata,
     evaluate_tx_interlock,
 )
 
@@ -101,3 +103,39 @@ def test_cw_and_modulation_input_controls_are_tx_safe() -> None:
     ):
         assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
         assert evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN).allowed is True
+
+
+def test_command_family_metadata_pins_typed_policy_without_classifying_defaults() -> (
+    None
+):
+    cases = (
+        (PttOff(), TxInterlockCommandFamily.PTT_OFF),
+        (SetPowerstat(on=False), TxInterlockCommandFamily.POWER_OFF),
+        (SetPowerstat(on=True), TxInterlockCommandFamily.POWER_ON),
+        (ScanStop(), TxInterlockCommandFamily.SCAN_STOP),
+        (SetTunerStatus(0), TxInterlockCommandFamily.TUNER_OFF),
+        (PttOn(), TxInterlockCommandFamily.PTT_ON),
+        (SendCiv(command=0x00), TxInterlockCommandFamily.RAW_CIV),
+        (ScanStart(), TxInterlockCommandFamily.SCAN_START),
+        (SetAntenna1(on=True), TxInterlockCommandFamily.ANTENNA_SWITCH),
+        (SetTunerStatus(1), TxInterlockCommandFamily.TUNER_ENGAGE),
+        (SetTunerStatus(2), TxInterlockCommandFamily.TUNER_ENGAGE),
+        (SetFreq(7_100_000), TxInterlockCommandFamily.FREQUENCY),
+        (SetMode("USB"), TxInterlockCommandFamily.MODE),
+        (SetBand(4), TxInterlockCommandFamily.BAND),
+        (SelectVfo("MAIN"), TxInterlockCommandFamily.VFO_SELECT),
+        (VfoSwap(), TxInterlockCommandFamily.VFO_TOPOLOGY),
+        (SetSplit(on=True), TxInterlockCommandFamily.VFO_TOPOLOGY),
+        (MemoryToVfo(channel=1), TxInterlockCommandFamily.MEMORY),
+        (SetRitTxStatus(on=True), TxInterlockCommandFamily.RIT_XIT),
+    )
+
+    for command, family in cases:
+        metadata = get_tx_interlock_command_family_metadata(command)
+
+        assert metadata is not None
+        assert metadata.family is family
+        assert metadata.base_disposition is classify_tx_interlock(command)
+
+    assert get_tx_interlock_command_family_metadata(SetTunerStatus(3)) is None
+    assert get_tx_interlock_command_family_metadata(SetCwPitch(600)) is None

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -1,0 +1,103 @@
+"""Focused contract tests for the shared TX interlock policy."""
+
+from rigplane.runtime._poller_types import (
+    MemoryToVfo,
+    PttOff,
+    PttOn,
+    ScanStart,
+    ScanStop,
+    SendCiv,
+    SetAcc1ModLevel,
+    SetAntenna1,
+    SetBand,
+    SetCwPitch,
+    SetData1ModInput,
+    SetDualWatch,
+    SetFreq,
+    SetMode,
+    SetPowerstat,
+    SetRitFrequency,
+    SetRitTxStatus,
+    SetSplit,
+    SetTunerStatus,
+    SelectVfo,
+    VfoEqualize,
+    VfoSwap,
+)
+from rigplane.runtime.tx_interlock import (
+    RfState,
+    TxInterlockDisposition,
+    classify_tx_interlock,
+    evaluate_tx_interlock,
+)
+
+
+def test_emergency_stop_commands_take_structural_precedence() -> None:
+    for command in (PttOff(), SetPowerstat(on=False), ScanStop(), SetTunerStatus(0)):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.ALWAYS_PASS
+        decision = evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN)
+        assert decision.allowed is True
+
+
+def test_rf_start_and_disruptive_commands_are_hard_block() -> None:
+    for command in (
+        PttOn(),
+        SendCiv(command=0x00),
+        ScanStart(),
+        SetAntenna1(on=True),
+        SetTunerStatus(1),
+        SetTunerStatus(2),
+    ):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.BLOCK
+
+    assert (
+        classify_tx_interlock(SetPowerstat(on=True)) is TxInterlockDisposition.TX_SAFE
+    )
+
+
+def test_hard_block_fails_closed_for_unknown_rf_state_without_claiming_tx() -> None:
+    decision = evaluate_tx_interlock(PttOn(), rf_state=RfState.UNKNOWN)
+
+    assert decision.allowed is False
+    assert "RF state is unknown" in decision.reason
+    assert "transmitting" not in decision.reason.lower()
+
+
+def test_hard_block_is_allowed_only_when_rx_is_known() -> None:
+    assert evaluate_tx_interlock(PttOn(), rf_state=RfState.RX).allowed is True
+    assert evaluate_tx_interlock(PttOn(), rf_state=RfState.TX).allowed is False
+
+
+def test_disruptive_operations_defer() -> None:
+    for command in (
+        SetFreq(7_100_000),
+        SetMode("USB"),
+        SetBand(4),
+        SelectVfo("MAIN"),
+        VfoSwap(),
+        VfoEqualize(),
+        SetSplit(on=True),
+        SetDualWatch(on=True),
+        MemoryToVfo(channel=1),
+        SetRitTxStatus(on=True),
+        SetRitFrequency(freq=100),
+    ):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.DEFER
+
+
+def test_defer_does_not_loosen_when_rf_state_is_unknown() -> None:
+    decision = evaluate_tx_interlock(SetFreq(7_100_000), rf_state=RfState.UNKNOWN)
+
+    assert decision.disposition is TxInterlockDisposition.DEFER
+    assert decision.allowed is False
+    assert "RF state is unknown" in decision.reason
+
+
+def test_cw_and_modulation_input_controls_are_tx_safe() -> None:
+    for command in (
+        SetCwPitch(600),
+        SetData1ModInput(source=1),
+        SetAcc1ModLevel(level=10),
+    ):
+        assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
+        assert evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN).allowed is True


### PR DESCRIPTION
## Summary
- export stable generic TX interlock family metadata from the typed policy
- preserve existing classification and evaluation behavior through the metadata resolver
- pin family/disposition contracts, including value-sensitive tuner cases

## Verification
- `uv run pytest tests/test_tx_interlock_policy.py -q --tb=short`
- `uv run ruff check src/rigplane/runtime/tx_interlock.py tests/test_tx_interlock_policy.py`
- `uv run ruff format --check src/rigplane/runtime/tx_interlock.py tests/test_tx_interlock_policy.py`
- `uv run mypy src/rigplane/runtime/tx_interlock.py`
- `git diff --check`

Refs #2602