### PR TITLE
fix(#2554): use raw manual-notch position domain

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -359,7 +359,7 @@ describe('every dsp intent reaches its own command-bus handler', () => {
   it.each([
     ['nrLevel', 5, () => h.nrLevel], ['nbLevel', 30, () => h.nbLevel],
     ['nbDepth', 3, () => h.nbDepth], ['nbWidth', 100, () => h.nbWidth],
-    ['notchFreq', 1200, () => h.notchFreq], ['manualNotchWidth', 2, () => h.manualNotchWidth],
+    ['notchFreq', 128, () => h.notchFreq], ['manualNotchWidth', 2, () => h.manualNotchWidth],
     ['agcTimeConstant', 4, () => h.agcTime],
   ] as const)('routes the "%s" level with its raw value', (field, value, spy) => {
     render();

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -59,7 +59,7 @@
     ['nrLevel', 'NR level', 0, 15, 1],
     ['nbDepth', 'NB depth', 1, 10, 1],
     ['nbWidth', 'NB width', 0, 255, 1],
-    ['notchFreq', 'Notch freq', 0, 3000, 1],
+    ['notchFreq', 'Notch position', 0, 255, 1],
     ['manualNotchWidth', 'Notch width', 0, 2, 1, (v: number) => NOTCH_WIDTH_LABELS[v] ?? String(v)],
     ['agcTimeConstant', 'AGC time', 0, 9, 1, formatAgcTime],
   ] as const;

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -274,6 +274,36 @@ describe('level intents reach the caller with the field and the raw value', () =
   });
 });
 
+// ── 4b. Manual-notch position is the CI-V raw 0..255 domain ───────────────
+
+describe('manual-notch position stays in the documented raw domain', () => {
+  it.each([0, 128, 255])('renders and emits raw notch position %i unchanged', (position) => {
+    const onLevelChange = vi.fn();
+    const view = {
+      ...base(),
+      dsp: {
+        ...base().dsp!,
+        notchFreq: {
+          ...base().dsp!.notchFreq,
+          reading: { status: 'known' as const, value: position },
+        },
+      },
+    } as RadioViewModel;
+
+    withSurface(view, (s) => {
+      const input = s.input('notchFreq')!;
+      expect(s.control('notchFreq')!.textContent).toContain('Notch position');
+      expect(input.min).toBe('0');
+      expect(input.max).toBe('255');
+      expect(input.valueAsNumber).toBe(position);
+      input.value = String(position);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('notchFreq', position);
+    }, { onLevelChange });
+  });
+});
+
 // ── 5. Range-parameterisation: nbLevel takes its ceiling from caps-echo props ─
 
 describe('nbLevel is range-parameterised by the caps-echoed nbLevelMax/nbLevelPercent props', () => {


### PR DESCRIPTION
## Summary
- render semantic manual-notch as a raw 0..255 position
- preserve 0, 128, and 255 unchanged through display and intent
- remove the semantic 0..3000/Hz presentation

## Validation
- `cd frontend && npm test -- --run src/semantic/__tests__/DspSurface.test.ts`
- `cd frontend && npm run check`
- `git diff --check`

Refs #2554