### PR TITLE
fix(#2556): preserve shared keyboard leader prefixes

### DIFF
--- a/frontend/src/components-v2/layout/KeyboardHandler.svelte
+++ b/frontend/src/components-v2/layout/KeyboardHandler.svelte
@@ -4,7 +4,7 @@
     normalizeKeyboardConfig,
     resolveAction,
     resolveSequenceContinuation,
-    resolveSequenceStart,
+    resolveSequenceStarts,
     shouldIgnoreEvent,
     isDigitKey,
     isFrequencyDisplayFocused,
@@ -27,7 +27,7 @@
   }: Props = $props();
 
   let keyboardConfig = $derived(normalizeKeyboardConfig(config));
-  let pendingSequence = $state<KeyboardBindingConfig | null>(null);
+  let pendingSequences = $state<KeyboardBindingConfig[]>([]);
   let leaderLabel = $state<string | null>(null);
   let helpOpen = $state(false);
   let leaderTimer: ReturnType<typeof setTimeout> | null = null;
@@ -46,7 +46,7 @@
   let groupedBindings = $derived(groupBindings(keyboardConfig.bindings));
 
   function clearLeaderState(): void {
-    pendingSequence = null;
+    pendingSequences = [];
     leaderLabel = null;
     if (leaderTimer) {
       clearTimeout(leaderTimer);
@@ -130,7 +130,7 @@
       // leader sequence, or the pill stays armed and a later keystroke
       // (once focus leaves the now-focused, ignored-tag entry input) can
       // complete an unintended leader sequence.
-      if (pendingSequence) clearLeaderState();
+      if (pendingSequences.length) clearLeaderState();
       event.preventDefault();
       return;
     }
@@ -146,7 +146,7 @@
     // second key), but skipping clearLeaderState() would leave the leader
     // pill armed and swallow the NEXT keystroke for up to leaderTimeoutMs.
     if (event.key === 'Tab') {
-      if (pendingSequence) clearLeaderState();
+      if (pendingSequences.length) clearLeaderState();
       return;
     }
 
@@ -155,8 +155,8 @@
       return;
     }
 
-    if (pendingSequence) {
-      const continuation = resolveSequenceContinuation(pendingSequence, event);
+    if (pendingSequences.length) {
+      const continuation = resolveSequenceContinuation(pendingSequences, event);
       clearLeaderState();
       if (continuation) {
         event.preventDefault();
@@ -165,11 +165,11 @@
       return;
     }
 
-    const sequenceStart = resolveSequenceStart(event, keyboardConfig);
-    if (sequenceStart) {
+    const sequenceStarts = resolveSequenceStarts(event, keyboardConfig);
+    if (sequenceStarts.length) {
       event.preventDefault();
-      pendingSequence = sequenceStart;
-      leaderLabel = formatShortcut(sequenceStart);
+      pendingSequences = sequenceStarts;
+      leaderLabel = formatShortcut(sequenceStarts[0]);
       leaderTimer = setTimeout(() => {
         clearLeaderState();
       }, keyboardConfig.leaderTimeoutMs);

--- a/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/KeyboardHandler.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 
 import KeyboardHandler from '../KeyboardHandler.svelte';
-import type { KeyboardConfig, KeyboardActionConfig } from '../keyboard-map';
+import {
+  resolveSequenceContinuation,
+  resolveSequenceStarts,
+  type KeyboardConfig,
+  type KeyboardActionConfig,
+} from '../keyboard-map';
 import VfoSurface from '../../../semantic/VfoSurface.svelte';
 import { topologyFixtures } from '../../../semantic/fixtures/topologies';
 
@@ -71,6 +76,7 @@ describe('KeyboardHandler', () => {
     components.forEach((component) => unmount(component));
     document.body.innerHTML = '';
     document.body.removeAttribute('data-shortcut-hints');
+    vi.useRealTimers();
   });
 
   it('dispatches a configured single-key action', () => {
@@ -94,6 +100,104 @@ describe('KeyboardHandler', () => {
     expect(onAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'focus_target', params: { target: 'vfo' } }),
     );
+  });
+
+  describe('shared-prefix leader sequences (MOR-1636)', () => {
+    const sharedPrefixConfig: KeyboardConfig = {
+      ...config,
+      bindings: [
+        ...config.bindings,
+        {
+          id: 'focus-af',
+          section: 'Focus',
+          label: 'Focus AF',
+          sequence: ['g', 'a'],
+          action: 'focus_target',
+          params: { target: 'af' },
+        },
+        {
+          id: 'focus-rf',
+          section: 'Focus',
+          label: 'Focus RF',
+          sequence: ['g', 'r'],
+          action: 'focus_target',
+          params: { target: 'rf' },
+        },
+        {
+          id: 'focus-filter',
+          section: 'Focus',
+          label: 'Focus Filter',
+          sequence: ['g', 'f'],
+          action: 'focus_target',
+          params: { target: 'filter' },
+        },
+      ],
+    };
+
+    it('keeps every same-prefix candidate available to the continuation resolver', () => {
+      const starts = resolveSequenceStarts({ key: 'g' }, sharedPrefixConfig);
+
+      expect(starts.map((binding) => binding.id)).toEqual([
+        'focus-vfo', 'focus-af', 'focus-rf', 'focus-filter',
+      ]);
+      expect(resolveSequenceContinuation(starts, { key: 'f' })).toEqual(
+        expect.objectContaining({ id: 'focus-filter', params: { target: 'filter' } }),
+      );
+    });
+
+    it.each([
+      ['a', 'af'],
+      ['r', 'rf'],
+      ['f', 'filter'],
+    ])('dispatches g then %s to the declared focus target', (suffix, target) => {
+      const onAction = vi.fn();
+      mountHandler({ config: sharedPrefixConfig, onAction });
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: suffix, bubbles: true, cancelable: true }));
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'focus_target', params: { target } }),
+      );
+    });
+
+    it('clears the pending leader and dispatches nothing for an invalid suffix', () => {
+      const onAction = vi.fn();
+      const target = mountHandler({ config: sharedPrefixConfig, onAction });
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+      flushSync();
+      expect(target.querySelector('.keyboard-leader-pill')).not.toBeNull();
+
+      const invalid = new KeyboardEvent('keydown', { key: 'x', bubbles: true, cancelable: true });
+      window.dispatchEvent(invalid);
+      flushSync();
+
+      expect(invalid.defaultPrevented).toBe(false);
+      expect(onAction).not.toHaveBeenCalled();
+      expect(target.querySelector('.keyboard-leader-pill')).toBeNull();
+    });
+
+    it('clears every pending candidate on leader timeout and dispatches nothing', () => {
+      vi.useFakeTimers();
+      const onAction = vi.fn();
+      const target = mountHandler({ config: sharedPrefixConfig, onAction });
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+      flushSync();
+      expect(target.querySelector('.keyboard-leader-pill')).not.toBeNull();
+
+      vi.advanceTimersByTime(sharedPrefixConfig.leaderTimeoutMs);
+      flushSync();
+      expect(target.querySelector('.keyboard-leader-pill')).toBeNull();
+
+      const continuation = new KeyboardEvent('keydown', { key: 'f', bubbles: true, cancelable: true });
+      window.dispatchEvent(continuation);
+
+      expect(continuation.defaultPrevented).toBe(false);
+      expect(onAction).not.toHaveBeenCalled();
+    });
   });
 
   it('renders the help overlay for the help shortcut', () => {

--- a/frontend/src/components-v2/layout/keyboard-map.ts
+++ b/frontend/src/components-v2/layout/keyboard-map.ts
@@ -253,11 +253,31 @@ export function resolveSequenceStart(
   ) ?? null;
 }
 
+/**
+ * Returns every multi-key binding that can continue from this first key.
+ *
+ * A keyboard leader is a prefix, not a unique binding identifier: profiles
+ * may intentionally declare `g a`, `g r`, and `g f`. Keeping the complete
+ * candidate set lets the handler wait for the second key before choosing one.
+ */
+export function resolveSequenceStarts(
+  event: { key: string; ctrlKey?: boolean; shiftKey?: boolean; altKey?: boolean; metaKey?: boolean },
+  config: KeyboardConfig | null | undefined = DEFAULT_KEYBOARD_CONFIG,
+): KeyboardBindingConfig[] {
+  const normalized = normalizeKeyboardConfig(config);
+  return normalized.bindings.filter(
+    (binding) => binding.sequence.length > 1 && binding.sequence[0] === event.key && modifiersMatch(binding, event),
+  );
+}
+
 export function resolveSequenceContinuation(
-  binding: KeyboardBindingConfig,
+  bindings: KeyboardBindingConfig | KeyboardBindingConfig[],
   event: { key: string },
 ): KeyboardActionConfig | null {
-  if (binding.sequence.length < 2 || binding.sequence[1] !== event.key) {
+  const binding = (Array.isArray(bindings) ? bindings : [bindings]).find(
+    (candidate) => candidate.sequence.length >= 2 && candidate.sequence[1] === event.key,
+  );
+  if (!binding) {
     return null;
   }
   return {


### PR DESCRIPTION
## Summary
- retain all matching multi-key bindings after a shared leader key
- resolve the declared continuation only after the second key arrives
- cover g→a/r/f focus targets plus invalid-suffix and timeout no-dispatch behavior

## Verification
- `cd frontend && npm run test -- --run src/components-v2/layout/__tests__/KeyboardHandler.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run lint`

Refs #2556