### PR TITLE
fix(web-ui): keep manual-notch controls usable in the mobile DSP dialog

### DIFF
--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -89,21 +89,31 @@
 
   /** Local NR mode for modal (supports 2 when server only reports on/off). */
   let nrModalMode = $state(0);
-  let notchModalMode = $state<'off' | 'auto' | 'manual'>('off');
-
   function computeModalStyle(anchor: HTMLElement | undefined): string {
-    if (!anchor) {
-      return 'top: 8px; left: 8px; width: 220px;';
-    }
-    const rect = anchor.getBoundingClientRect();
     const menuWidth = 220;
-    let left = rect.left;
+    let left = anchor?.getBoundingClientRect().left ?? 8;
     if (left + menuWidth > window.innerWidth - 8) {
       left = window.innerWidth - 8 - menuWidth;
     }
     if (left < 8) {
       left = 8;
     }
+
+    // MobileRadioLayout owns the tuning strip's size (including the device
+    // safe-area inset). Read its actual viewport boundary instead of copying
+    // that layout constant here, so this dialog remains above the live strip.
+    const mobileTuningStrip = window.innerWidth < 640
+      ? document.querySelector<HTMLElement>('.m-tuning-strip')
+      : null;
+    if (mobileTuningStrip) {
+      const stripTop = mobileTuningStrip.getBoundingClientRect().top;
+      return `top: 8px; left: ${left}px; width: ${menuWidth}px; bottom: calc(100dvh - ${stripTop}px + 8px); overflow-y: auto;`;
+    }
+
+    if (!anchor) {
+      return 'top: 8px; left: 8px; width: 220px;';
+    }
+    const rect = anchor.getBoundingClientRect();
     const top = rect.bottom + 6;
     return `top: ${top}px; left: ${left}px; width: ${menuWidth}px;`;
   }
@@ -117,7 +127,6 @@
     } else if (kind === 'agc') {
       agcModalStyle = computeModalStyle(agcAnchorEl);
     } else {
-      notchModalMode = notchMode;
       notchModalStyle = computeModalStyle(notchAnchorEl);
     }
     openModal = kind;
@@ -143,7 +152,6 @@
 
   function handleNotchModalMode(v: string | number): void {
     const m = v as 'off' | 'auto' | 'manual';
-    notchModalMode = m;
     onNotchModeChange(m);
   }
 
@@ -395,7 +403,7 @@
     <div class="dsp-modal-block dsp-mode-grid">
       {#each notchOptions as option}
         <HardwareButton
-          active={notchModalMode === option.value}
+          active={notchMode === option.value}
           indicator="edge-left"
           color="cyan"
           onclick={() => handleNotchModalMode(option.value)}
@@ -404,7 +412,7 @@
         </HardwareButton>
       {/each}
     </div>
-    {#if notchModalMode === 'manual'}
+    {#if notchMode === 'manual'}
       <ValueControl
         label="Notch Position"
         value={notchFreq}

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -219,3 +219,76 @@ describe('DspPanel manual-notch position (MOR-1633)', () => {
     expect(mockHandlers.onNotchFreqChange).toHaveBeenNthCalledWith(3, 255);
   });
 });
+
+describe('DspPanel mobile notch dialog (MOR-1631)', () => {
+  function openNotchModal(t: HTMLElement): void {
+    vi.useFakeTimers();
+    try {
+      const notchBtn = Array.from(t.querySelectorAll<HTMLButtonElement>('.dsp-btn-wrap button')).find(
+        (b) => b.textContent?.trim() === 'NOTCH',
+      );
+      notchBtn?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+      vi.advanceTimersByTime(600);
+      flushSync();
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  function modeButton(t: HTMLElement, mode: string): HTMLButtonElement {
+    const button = Array.from(t.querySelectorAll<HTMLButtonElement>('[aria-label="Notch filter settings"] button')).find(
+      (candidate) => candidate.textContent?.trim() === mode,
+    );
+    expect(button).toBeDefined();
+    return button!;
+  }
+
+  it('uses the actual mobile tuning-strip bottom bound without a duplicated fixed height', () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 375 });
+    const tuningStrip = document.createElement('nav');
+    tuningStrip.className = 'm-tuning-strip';
+    tuningStrip.getBoundingClientRect = () => ({ top: 610 } as DOMRect);
+    document.body.appendChild(tuningStrip);
+
+    try {
+      const t = mountPanel({ notchMode: 'manual', notchFreq: 128 });
+      openNotchModal(t);
+      const dialog = t.querySelector<HTMLElement>('[aria-label="Notch filter settings"]');
+      expect(dialog?.style.top).toBe('8px');
+      expect(dialog?.style.bottom).toBe('calc(100dvh + 8px - 610px)');
+      expect(dialog?.textContent).toContain('Notch Position');
+      expect(dialog?.querySelector('[aria-label="Notch Position"]')).not.toBeNull();
+    } finally {
+      tuningStrip.remove();
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
+    }
+  });
+
+  it.each([
+    ['off', 'OFF'],
+    ['auto', 'AUTO'],
+    ['manual', 'MAN'],
+  ] as const)('renders only confirmed %s mode as selected', (notchMode, selectedLabel) => {
+    const t = mountPanel({ notchMode });
+    openNotchModal(t);
+
+    for (const mode of ['OFF', 'AUTO', 'MAN']) {
+      expect(modeButton(t, mode).dataset.active).toBe(String(mode === selectedLabel));
+    }
+    expect(t.querySelector('[aria-label="Notch Position"]') !== null).toBe(notchMode === 'manual');
+  });
+
+  it('does not optimistically select a requested mode before the confirmed radio state changes', () => {
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+
+    modeButton(t, 'MAN').click();
+    flushSync();
+
+    expect(mockHandlers.onNotchModeChange).toHaveBeenCalledExactlyOnceWith('manual');
+    expect(modeButton(t, 'OFF').dataset.active).toBe('true');
+    expect(modeButton(t, 'MAN').dataset.active).toBe('false');
+    expect(t.querySelector('[aria-label="Notch Position"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- bind mobile DSP dialogs to the live tuning-strip boundary, including safe area
- keep notch option selection derived only from confirmed radio state
- cover mobile bounds, confirmed selection, and raw notch position

## Verification
- `npm test -- --run src/components-v2/panels/__tests__/DspPanel.isolated.test.ts src/components-v2/panels/__tests__/DspPanel.component.test.ts`
- `npm run check`
- `npm run lint -- --quiet`

Refs #2551