### PR TITLE
fix(api): reject invalid raw manual-notch positions

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -2185,6 +2185,8 @@ class ControlHandler:
             case "set_notch_filter":
                 level = int(params["value"])
                 rx = int(params.get("receiver", 0))
+                if not 0 <= level <= 255:
+                    raise ValueError("manual-notch position must be between 0 and 255")
                 self._ensure_capability("notch", "set_notch_filter")
                 self._ensure_receiver_supported(rx)
                 q.put(SetNotchFilter(level, receiver=rx))

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -748,6 +748,54 @@ async def test_enqueue_command_variants(
         assert getattr(cmd, key) == value
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [0, 128, 255])
+async def test_enqueue_manual_notch_position_accepts_raw_bounds_unchanged(
+    value: int,
+) -> None:
+    """Manual-notch position is a raw CI-V 0-255 value, not a frequency."""
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        radio=_capable_radio(), server=SimpleNamespace(command_queue=queue)
+    )
+
+    result = await handler._enqueue_command(
+        "set_notch_filter", {"value": value, "receiver": 1}
+    )
+
+    assert result == {"value": value, "receiver": 1}
+    assert queue.items == [SetNotchFilter(value, receiver=1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [-1, 256, 3000])
+async def test_websocket_manual_notch_position_rejects_out_of_range_before_enqueue(
+    value: int,
+) -> None:
+    """Invalid raw manual-notch positions fail on the WebSocket ingress path."""
+    queue = _QueueRecorder()
+    ws = SimpleNamespace(send_text=AsyncMock())
+    handler = _control_handler(
+        ws=ws,
+        radio=_capable_radio(),
+        server=SimpleNamespace(command_queue=queue),
+    )
+
+    await handler._dispatch_command(
+        "notch-position", "set_notch_filter", {"value": value}
+    )
+
+    response = decode_json(ws.send_text.await_args.args[0])
+    assert response == {
+        "type": "response",
+        "id": "notch-position",
+        "ok": False,
+        "error": "command_failed",
+        "message": "manual-notch position must be between 0 and 255",
+    }
+    assert queue.items == []
+
+
 async def test_enqueue_set_rf_power_yaesu_tags_watts_unit() -> None:
     """Yaesu CAT backend → SetPower(unit='watts'); Icom default → 'raw_255'.
 


### PR DESCRIPTION
## Summary

- validate manual-notch position at the WebSocket ingress boundary
- preserve raw `0`, `128`, and `255` unchanged
- return the established structured command failure before invalid input enters the command queue

## Verification

- `uv run pytest tests/test_handlers_coverage.py -q --tb=short`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`

Refs #2555