### PR TITLE
feat(#2617): project filter width command lifecycle

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -1,6 +1,5 @@
 /** MOR-1664 — Filter Width lifecycle projection. */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-
 type FakeCommand = { id: string; name: string; params: Record<string, unknown>;
   originalEpoch: number; eventEpoch?: number; createdAt: number;
   status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
@@ -15,17 +14,25 @@ type FakeState = {
   observationSeq?: number;
   fieldStatus?: Record<string, { observed?: boolean; freshness?: string; availability?: string; lastObservedMonotonic?: number | null }>;
 };
-
 const lifecycle = { commands: [] as FakeCommand[], confirms: [] as [string, number, number][] };
 const runtimeState: { state: FakeState | null } = { state: null };
-const commandRadio = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
-
+const commandRadio = vi.hoisted(() => ({
+  current: null as Record<string, unknown> | null,
+  listeners: new Set<(value: Record<string, unknown> | null) => void>(),
+}));
 vi.mock('$lib/stores/commands.svelte', () => ({
   getCommandLifecycles: () => lifecycle.commands,
   confirmCommand: (id: string, epoch: number, eventEpoch: number) => lifecycle.confirms.push([id, epoch, eventEpoch]),
   isCommandLifecycleSuperseded: () => false,
 }));
-vi.mock('$lib/stores/radio.svelte', () => ({ getRadioState: () => commandRadio.current }));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: () => commandRadio.current,
+  subscribeRadioState: (handler: (value: Record<string, unknown> | null) => void) => {
+    commandRadio.listeners.add(handler);
+    handler(commandRadio.current);
+    return () => commandRadio.listeners.delete(handler);
+  },
+}));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
 }));
@@ -33,7 +40,10 @@ vi.mock('$lib/runtime/tx-controller/app-host', () => ({ getAppTxController: () =
 vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({ toRadioViewModel: () => null }));
 
 import { getFilterWidthCommandLifecycle } from '../panel-adapters';
-
+function emitAcceptedState(value: FakeState | null): void {
+  commandRadio.current = value;
+  for (const handler of commandRadio.listeners) handler(value);
+}
 const command = (over: Partial<FakeCommand> = {}): FakeCommand => ({
   id: 'width-1', name: 'set_filter_width', params: { width: 3000 },
   originalEpoch: 7, eventEpoch: 7, createdAt: 1, status: 'pending', ...over,
@@ -42,15 +52,14 @@ const state = (over: Partial<FakeState> = {}): FakeState => ({
   active: 'MAIN', main: { filterWidth: 2400 }, sub: {}, observationSeq: 4,
   fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 } }, ...over,
 });
-
 describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   afterEach(() => {
     lifecycle.commands = [];
     lifecycle.confirms = [];
     runtimeState.state = null;
     commandRadio.current = null;
+    commandRadio.listeners.clear();
   });
-
   it('stays unavailable rather than fabricating a pending or confirmed value without observed width', () => {
     runtimeState.state = state({ main: {} });
     lifecycle.commands = [command()];
@@ -58,7 +67,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null,
     });
   });
-
   it('keeps canonical observed width separate from a submitted target', () => {
     runtimeState.state = state();
     lifecycle.commands = [command()];
@@ -66,25 +74,14 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       confirmed: 2400, target: 3000, phase: 'pending', busy: true, outcome: null,
     });
   });
-
-  it('does not let a matching snapshot already present at ACK confirm the command', () => {
-    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 4 });
+  it('keeps a fresh matching observation acknowledged when a caller only reads the pure accessor', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toEqual({
       confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([]);
   });
-
-  it('confirms the newest acknowledged target only after a fresh matching observation', () => {
-    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
-    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
-      confirmed: 3000, target: null, phase: 'idle', busy: false, outcome: null,
-    });
-    expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
-  });
-
   it('does not let an unrelated global observation advance confirm a cached matching width', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 99,
       fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 } } });
@@ -92,14 +89,12 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('does not confirm a matching width from a reverse or stale field marker', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 3 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ target: 3000, phase: 'acknowledged', busy: true });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it.each([
     ['missing status', undefined],
     ['unobserved status', { observed: false, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 }],
@@ -115,22 +110,20 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('does not let a legacy record without an ACK field boundary confirm', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged' })];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ target: 3000, phase: 'acknowledged', busy: true });
     expect(lifecycle.confirms).toEqual([]);
   });
-
-  it('uses the first qualified cold marker as a boundary, then confirms only a newer matching marker', () => {
+  it('does not establish a cold boundary from an accessor read', () => {
     runtimeState.state = state({ main: { filterWidth: 2400 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: {} })];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 2400, target: 3000, phase: 'acknowledged', busy: true });
-    expect(lifecycle.commands[0].ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
+    expect(lifecycle.commands[0].ackFieldObservationTimes).toEqual({});
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
-    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: null, phase: 'idle', busy: false });
-    expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.confirms).toEqual([]);
   });
 
   it('does not treat a missing exact field marker in a non-empty ACK map as an empty boundary', () => {
@@ -149,7 +142,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(lifecycle.confirms).toEqual([]);
   });
 
-  it('correlates confirmation with the active SUB receiver rather than MAIN', () => {
+  it('does not let an accessor read confirm SUB independently of MAIN', () => {
     runtimeState.state = state({
       active: 'SUB', main: { filterWidth: 3000 }, sub: { filterWidth: 2800 }, observationSeq: 5,
       fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } },
@@ -159,9 +152,9 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       ackFieldObservationTimes: { 'sub.filterWidth': 4 },
     })];
     expect(getFilterWidthCommandLifecycle()).toEqual({
-      confirmed: 2800, target: null, phase: 'idle', busy: false, outcome: null,
+      confirmed: 2800, target: 2800, phase: 'acknowledged', busy: true, outcome: null,
     });
-    expect(lifecycle.confirms).toEqual([['sub-width', 7, 7]]);
+    expect(lifecycle.confirms).toEqual([]);
   });
 
   it('projects only the newest same-receiver target, so older late events cannot overwrite it', () => {
@@ -220,6 +213,12 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(acknowledged).not.toHaveProperty('radioState');
     expect(acknowledged).not.toHaveProperty('fieldStatus');
     expect(acknowledged).not.toHaveProperty('main');
+    runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 3000 }, fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 73 } } });
+    emitAcceptedState(runtimeState.state);
+    expect(store.getCommandLifecycle('real-ack', 9)?.status).toBe('acknowledged');
+    runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 3000 }, fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 74 } } });
+    emitAcceptedState(runtimeState.state);
+    expect(store.getCommandLifecycle('real-ack', 9)?.status).toBe('confirmed');
 
     commandRadio.current = null;
     store.beginCommand({ id: 'cold-ack', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 9 });
@@ -229,9 +228,11 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
     runtimeState.state = state({ main: { filterWidth: 2400 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    emitAcceptedState(runtimeState.state);
     expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2800, phase: 'acknowledged', busy: true });
     expect(store.getCommandLifecycle('cold-ack', 9)?.ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
     runtimeState.state = state({ main: { filterWidth: 2800 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
+    emitAcceptedState(runtimeState.state);
     expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'idle', busy: false });
     expect(store.getCommandLifecycle('cold-ack', 9)?.status).toBe('confirmed');
     store.resetCommandLifecycle();

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -18,12 +18,14 @@ type FakeCommand = {
   status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
   error?: string;
   ackObservationSeq?: number;
+  ackFieldObservationTimes?: Record<string, number>;
 };
 type FakeState = {
   active: 'MAIN' | 'SUB';
   main: Record<string, unknown>;
   sub: Record<string, unknown>;
   observationSeq?: number;
+  fieldStatus?: Record<string, { observed?: boolean; freshness?: string; availability?: string; lastObservedMonotonic?: number | null }>;
 };
 
 const lifecycle = { commands: [] as FakeCommand[], confirms: [] as [string, number, number][] };
@@ -46,7 +48,8 @@ const command = (over: Partial<FakeCommand> = {}): FakeCommand => ({
   originalEpoch: 7, eventEpoch: 7, createdAt: 1, status: 'pending', ...over,
 });
 const state = (over: Partial<FakeState> = {}): FakeState => ({
-  active: 'MAIN', main: { filterWidth: 2400 }, sub: {}, observationSeq: 4, ...over,
+  active: 'MAIN', main: { filterWidth: 2400 }, sub: {}, observationSeq: 4,
+  fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 } }, ...over,
 });
 
 describe('Filter Width command lifecycle projection (MOR-1664)', () => {
@@ -74,7 +77,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
 
   it('does not let a matching snapshot already present at ACK confirm the command', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 4 });
-    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4 })];
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toEqual({
       confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
     });
@@ -82,17 +85,58 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   });
 
   it('confirms the newest acknowledged target only after a fresh matching observation', () => {
-    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5 });
-    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4 })];
+    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toEqual({
       confirmed: 3000, target: null, phase: 'idle', busy: false, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
   });
 
+  it('does not let an unrelated global observation advance confirm a cached matching width', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 99,
+      fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 } } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it('does not confirm a matching width from a reverse or stale field marker', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 3 } } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it.each([
+    ['missing status', undefined],
+    ['unobserved status', { observed: false, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 }],
+    ['stale status', { observed: true, freshness: 'stale', availability: 'available', lastObservedMonotonic: 5 }],
+    ['unavailable status', { observed: true, freshness: 'fresh', availability: 'stale', lastObservedMonotonic: 5 }],
+  ])('does not confirm from %s evidence', (_case, fieldStatus) => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: fieldStatus === undefined ? {} : { 'main.filterWidth': fieldStatus } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it('does not let a legacy record without an ACK field boundary confirm', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    lifecycle.commands = [command({ status: 'acknowledged' })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it('uses the first finite field marker after an empty new-format ACK boundary', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: {} })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: null, phase: 'idle', busy: false });
+    expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
+  });
+
   it('keeps a fresh non-matching observation canonical while the acknowledged target remains pending', () => {
-    runtimeState.state = state({ main: { filterWidth: 2400 }, observationSeq: 5 });
-    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4 })];
+    runtimeState.state = state({ main: { filterWidth: 2400 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toEqual({
       confirmed: 2400, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
     });
@@ -102,9 +146,11 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   it('correlates confirmation with the active SUB receiver rather than MAIN', () => {
     runtimeState.state = state({
       active: 'SUB', main: { filterWidth: 3000 }, sub: { filterWidth: 2800 }, observationSeq: 5,
+      fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } },
     });
     lifecycle.commands = [command({
       id: 'sub-width', params: { width: 2800, receiver: 1 }, status: 'acknowledged', ackObservationSeq: 4,
+      ackFieldObservationTimes: { 'sub.filterWidth': 4 },
     })];
     expect(getFilterWidthCommandLifecycle()).toEqual({
       confirmed: 2800, target: null, phase: 'idle', busy: false, outcome: null,

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -35,6 +35,7 @@ const commandRadio = vi.hoisted(() => ({ current: null as Record<string, unknown
 vi.mock('$lib/stores/commands.svelte', () => ({
   getCommandLifecycles: () => lifecycle.commands,
   confirmCommand: (id: string, epoch: number, eventEpoch: number) => lifecycle.confirms.push([id, epoch, eventEpoch]),
+  isCommandLifecycleSuperseded: () => false,
 }));
 vi.mock('$lib/stores/radio.svelte', () => ({ getRadioState: () => commandRadio.current }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
@@ -238,6 +239,56 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(store.getCommandLifecycle('cold-ack', 9)).toMatchObject({
       status: 'acknowledged', ackObservationSeq: undefined, ackFieldObservationTimes: {},
     });
+    store.resetCommandLifecycle();
+  });
+
+  it('never resurfaces a superseded receiver lifecycle after its newer outcome retires', async () => {
+    vi.useFakeTimers();
+    vi.doUnmock('$lib/stores/commands.svelte');
+    vi.resetModules();
+    runtimeState.state = state({ main: { filterWidth: 2400 }, sub: { filterWidth: 1800 } });
+    const store = await import('$lib/stores/commands.svelte');
+    const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
+
+    const old = store.beginCommand({
+      id: 'old-main', name: 'set_filter_width', params: { width: 3000, receiver: 0 }, originalEpoch: 7, timeoutMs: 10_000,
+    });
+    expect(store.isCommandLifecycleSuperseded(old)).toBe(false);
+    vi.advanceTimersByTime(1_000);
+    const newer = store.beginCommand({
+      id: 'new-main', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 7, timeoutMs: 10_000,
+    });
+    store.failCommand(newer.id, newer.originalEpoch, 7, 'newer rejected');
+    expect(store.isCommandLifecycleSuperseded(old)).toBe(true);
+
+    vi.advanceTimersByTime(3_000);
+    store.acknowledgeCommand(old.id, old.originalEpoch, 7);
+    vi.advanceTimersByTime(2_000);
+    expect(store.getCommandLifecycle(newer.id, newer.originalEpoch)).toBeUndefined();
+    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: null });
+
+    store.failCommand(old.id, old.originalEpoch, 7, 'late failure');
+    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: null });
+    vi.advanceTimersByTime(5_000);
+    expect(store.getCommandLifecycle(old.id, old.originalEpoch)).toBeUndefined();
+
+    const sub = store.beginCommand({
+      id: 'sub', name: 'set_filter_width', params: { width: 2100, receiver: 1 }, originalEpoch: 7,
+    });
+    runtimeState.state = state({
+      active: 'SUB', main: { filterWidth: 2400 }, sub: { filterWidth: 1800 },
+      fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 } },
+    });
+    expect(store.isCommandLifecycleSuperseded(sub)).toBe(false);
+    expect(getLiveView()).toMatchObject({ confirmed: 1800, target: 2100, phase: 'pending', busy: true });
+
+    store.resetCommandLifecycle();
+    const fresh = store.beginCommand({
+      id: 'fresh-main', name: 'set_filter_width', params: { width: 2600, receiver: 0 }, originalEpoch: 8,
+    });
+    expect(store.isCommandLifecycleSuperseded(fresh)).toBe(false);
+    runtimeState.state = state({ main: { filterWidth: 2400 }, sub: { filterWidth: 1800 } });
+    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2600, phase: 'pending', busy: true });
     store.resetCommandLifecycle();
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -30,11 +30,13 @@ type FakeState = {
 
 const lifecycle = { commands: [] as FakeCommand[], confirms: [] as [string, number, number][] };
 const runtimeState: { state: FakeState | null } = { state: null };
+const commandRadio = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
 
 vi.mock('$lib/stores/commands.svelte', () => ({
   getCommandLifecycles: () => lifecycle.commands,
   confirmCommand: (id: string, epoch: number, eventEpoch: number) => lifecycle.confirms.push([id, epoch, eventEpoch]),
 }));
+vi.mock('$lib/stores/radio.svelte', () => ({ getRadioState: () => commandRadio.current }));
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
 }));
@@ -57,6 +59,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     lifecycle.commands = [];
     lifecycle.confirms = [];
     runtimeState.state = null;
+    commandRadio.current = null;
   });
 
   it('stays unavailable rather than fabricating a pending or confirmed value without observed width', () => {
@@ -113,10 +116,14 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     ['unobserved status', { observed: false, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 }],
     ['stale status', { observed: true, freshness: 'stale', availability: 'available', lastObservedMonotonic: 5 }],
     ['unavailable status', { observed: true, freshness: 'fresh', availability: 'stale', lastObservedMonotonic: 5 }],
-  ])('does not confirm from %s evidence', (_case, fieldStatus) => {
+    ['missing marker', { observed: true, freshness: 'fresh', availability: 'available' }],
+    ['non-finite marker', { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: Number.NaN }],
+  ])('makes the full projection unavailable from %s evidence', (_case, fieldStatus) => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: fieldStatus === undefined ? {} : { 'main.filterWidth': fieldStatus } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
-    expect(getFilterWidthCommandLifecycle()).toMatchObject({ target: 3000, phase: 'acknowledged', busy: true });
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null,
+    });
     expect(lifecycle.confirms).toEqual([]);
   });
 
@@ -132,6 +139,13 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: {} })];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: null, phase: 'idle', busy: false });
     expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
+  });
+
+  it('does not treat a missing exact field marker in a non-empty ACK map as an empty boundary', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'sub.filterWidth': 4 } })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.confirms).toEqual([]);
   });
 
   it('keeps a fresh non-matching observation canonical while the acknowledged target remains pending', () => {
@@ -192,5 +206,38 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(getFilterWidthCommandLifecycle()).toEqual({
       confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: { phase: status, error },
     });
+  });
+
+  it('captures only finite public-field ACK markers through the real command store seam', async () => {
+    vi.doUnmock('$lib/stores/commands.svelte');
+    vi.resetModules();
+    commandRadio.current = {
+      observationSeq: 41,
+      main: { filterWidth: 3000 },
+      fieldStatus: {
+        'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 73 },
+        'main.mode': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: Number.NaN },
+      },
+    };
+    const store = await import('$lib/stores/commands.svelte');
+    store.beginCommand({ id: 'real-ack', name: 'set_filter_width', params: { width: 3000, receiver: 0 }, originalEpoch: 9 });
+    store.acknowledgeCommand('real-ack', 9, 10);
+    const acknowledged = store.getCommandLifecycle('real-ack', 9);
+    expect(acknowledged).toMatchObject({
+      status: 'acknowledged', ackObservationSeq: 41,
+      ackFieldObservationTimes: { 'main.filterWidth': 73 },
+    });
+    expect(acknowledged?.ackFieldObservationTimes).toEqual({ 'main.filterWidth': 73 });
+    expect(acknowledged).not.toHaveProperty('radioState');
+    expect(acknowledged).not.toHaveProperty('fieldStatus');
+    expect(acknowledged).not.toHaveProperty('main');
+
+    commandRadio.current = null;
+    store.beginCommand({ id: 'cold-ack', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 9 });
+    store.acknowledgeCommand('cold-ack', 9, 10);
+    expect(store.getCommandLifecycle('cold-ack', 9)).toMatchObject({
+      status: 'acknowledged', ackObservationSeq: undefined, ackFieldObservationTimes: {},
+    });
+    store.resetCommandLifecycle();
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -54,6 +54,7 @@ const state = (over: Partial<FakeState> = {}): FakeState => ({
 });
 describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   afterEach(() => {
+    vi.useRealTimers();
     lifecycle.commands = [];
     lifecycle.confirms = [];
     runtimeState.state = null;
@@ -125,14 +126,12 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('does not treat a missing exact field marker in a non-empty ACK map as an empty boundary', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'sub.filterWidth': 4 } })];
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('keeps a fresh non-matching observation canonical while the acknowledged target remains pending', () => {
     runtimeState.state = state({ main: { filterWidth: 2400 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
@@ -141,7 +140,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('does not let an accessor read confirm SUB independently of MAIN', () => {
     runtimeState.state = state({
       active: 'SUB', main: { filterWidth: 3000 }, sub: { filterWidth: 2800 }, observationSeq: 5,
@@ -156,7 +154,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('projects only the newest same-receiver target, so older late events cannot overwrite it', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5 });
     lifecycle.commands = [
@@ -168,7 +165,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     expect(lifecycle.confirms).toEqual([]);
   });
-
   it('lets a newer terminal record suppress an older pending target', () => {
     runtimeState.state = state();
     lifecycle.commands = [
@@ -180,7 +176,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       outcome: { phase: 'failed', error: 'rejected' },
     });
   });
-
   it.each([
     ['failed', 'backend rejected'],
     ['timed-out', undefined],
@@ -192,8 +187,8 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: { phase: status, error },
     });
   });
-
   it('captures only finite public-field ACK markers through the real command store seam', async () => {
+    vi.useFakeTimers();
     vi.doUnmock('$lib/stores/commands.svelte');
     vi.resetModules();
     const fields = Object.fromEntries(Array.from({ length: 198 }, (_, index) => [
@@ -213,31 +208,33 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(acknowledged).not.toHaveProperty('radioState');
     expect(acknowledged).not.toHaveProperty('fieldStatus');
     expect(acknowledged).not.toHaveProperty('main');
+    const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
     runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 3000 }, fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 73 } } });
     emitAcceptedState(runtimeState.state);
     expect(store.getCommandLifecycle('real-ack', 9)?.status).toBe('acknowledged');
     runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 3000 }, fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 74 } } });
     emitAcceptedState(runtimeState.state);
     expect(store.getCommandLifecycle('real-ack', 9)?.status).toBe('confirmed');
-
+    expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } });
+    vi.advanceTimersByTime(5_000);
+    expect(store.getCommandLifecycle('real-ack', 9)).toBeUndefined();
+    expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'idle', busy: false, outcome: null });
     commandRadio.current = null;
     store.beginCommand({ id: 'cold-ack', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 9 });
     store.acknowledgeCommand('cold-ack', 9, 10);
     expect(store.getCommandLifecycle('cold-ack', 9)).toMatchObject({
       status: 'acknowledged', ackObservationSeq: undefined, ackFieldObservationTimes: {},
     });
-    const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
     runtimeState.state = state({ main: { filterWidth: 2400 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     emitAcceptedState(runtimeState.state);
     expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2800, phase: 'acknowledged', busy: true });
     expect(store.getCommandLifecycle('cold-ack', 9)?.ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
     runtimeState.state = state({ main: { filterWidth: 2800 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
     emitAcceptedState(runtimeState.state);
-    expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'idle', busy: false });
+    expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } });
     expect(store.getCommandLifecycle('cold-ack', 9)?.status).toBe('confirmed');
     store.resetCommandLifecycle();
   });
-
   it('never resurfaces a superseded receiver lifecycle after its newer outcome retires', async () => {
     vi.useFakeTimers();
     vi.doUnmock('$lib/stores/commands.svelte');

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -47,7 +47,7 @@ vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({ toRadioViewMo
 import { getFilterWidthCommandLifecycle } from '../panel-adapters';
 
 const command = (over: Partial<FakeCommand> = {}): FakeCommand => ({
-  id: 'width-1', name: 'set_filter_width', params: { width: 3000, receiver: 0 },
+  id: 'width-1', name: 'set_filter_width', params: { width: 3000 },
   originalEpoch: 7, eventEpoch: 7, createdAt: 1, status: 'pending', ...over,
 });
 const state = (over: Partial<FakeState> = {}): FakeState => ({
@@ -135,9 +135,12 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(lifecycle.confirms).toEqual([]);
   });
 
-  it('uses the first finite field marker after an empty new-format ACK boundary', () => {
+  it('uses a cold matching marker as a boundary, then confirms only the next one', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: {} })];
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
+    expect(lifecycle.commands[0].ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: null, phase: 'idle', busy: false });
     expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
   });
@@ -212,23 +215,20 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   it('captures only finite public-field ACK markers through the real command store seam', async () => {
     vi.doUnmock('$lib/stores/commands.svelte');
     vi.resetModules();
-    commandRadio.current = {
-      observationSeq: 41,
-      main: { filterWidth: 3000 },
-      fieldStatus: {
-        'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 73 },
-        'main.mode': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: Number.NaN },
-      },
-    };
+    const fields = Object.fromEntries(Array.from({ length: 198 }, (_, index) => [
+      index === 142 ? 'sub.filterWidth' : `other.${index}`,
+      { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: index === 142 ? 73 : Number.NaN },
+    ]));
+    commandRadio.current = { observationSeq: 41, fieldStatus: fields };
     const store = await import('$lib/stores/commands.svelte');
-    store.beginCommand({ id: 'real-ack', name: 'set_filter_width', params: { width: 3000, receiver: 0 }, originalEpoch: 9 });
+    store.beginCommand({ id: 'real-ack', name: 'set_filter_width', params: { width: 3000, receiver: 1 }, originalEpoch: 9 });
     store.acknowledgeCommand('real-ack', 9, 10);
     const acknowledged = store.getCommandLifecycle('real-ack', 9);
     expect(acknowledged).toMatchObject({
       status: 'acknowledged', ackObservationSeq: 41,
-      ackFieldObservationTimes: { 'main.filterWidth': 73 },
+      ackFieldObservationTimes: { 'sub.filterWidth': 73 },
     });
-    expect(acknowledged?.ackFieldObservationTimes).toEqual({ 'main.filterWidth': 73 });
+    expect(acknowledged?.ackFieldObservationTimes).toEqual({ 'sub.filterWidth': 73 });
     expect(acknowledged).not.toHaveProperty('radioState');
     expect(acknowledged).not.toHaveProperty('fieldStatus');
     expect(acknowledged).not.toHaveProperty('main');
@@ -251,7 +251,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
 
     const old = store.beginCommand({
-      id: 'old-main', name: 'set_filter_width', params: { width: 3000, receiver: 0 }, originalEpoch: 7, timeoutMs: 10_000,
+      id: 'old-main', name: 'set_filter_width', params: { width: 3000 }, originalEpoch: 7, timeoutMs: 10_000,
     });
     expect(store.isCommandLifecycleSuperseded(old)).toBe(false);
     vi.advanceTimersByTime(1_000);

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -1,20 +1,8 @@
-/**
- * MOR-1664 — Filter Width lifecycle projection.
- *
- * The adapter is the only place this child may join a command record with
- * radio-observed truth.  It must keep the observed width canonical and make
- * an explicitly unconfirmed target visible only while the newest matching
- * record is live.
- */
+/** MOR-1664 — Filter Width lifecycle projection. */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-type FakeCommand = {
-  id: string;
-  name: string;
-  params: Record<string, unknown>;
-  originalEpoch: number;
-  eventEpoch?: number;
-  createdAt: number;
+type FakeCommand = { id: string; name: string; params: Record<string, unknown>;
+  originalEpoch: number; eventEpoch?: number; createdAt: number;
   status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
   error?: string;
   ackObservationSeq?: number;
@@ -135,10 +123,10 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(lifecycle.confirms).toEqual([]);
   });
 
-  it('uses a cold matching marker as a boundary, then confirms only the next one', () => {
-    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+  it('uses the first qualified cold marker as a boundary, then confirms only a newer matching marker', () => {
+    runtimeState.state = state({ main: { filterWidth: 2400 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: {} })];
-    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true });
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 2400, target: 3000, phase: 'acknowledged', busy: true });
     expect(lifecycle.commands[0].ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
     expect(getFilterWidthCommandLifecycle()).toMatchObject({ confirmed: 3000, target: null, phase: 'idle', busy: false });
@@ -239,6 +227,13 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(store.getCommandLifecycle('cold-ack', 9)).toMatchObject({
       status: 'acknowledged', ackObservationSeq: undefined, ackFieldObservationTimes: {},
     });
+    const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
+    runtimeState.state = state({ main: { filterWidth: 2400 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
+    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2800, phase: 'acknowledged', busy: true });
+    expect(store.getCommandLifecycle('cold-ack', 9)?.ackFieldObservationTimes).toEqual({ 'main.filterWidth': 5 });
+    runtimeState.state = state({ main: { filterWidth: 2800 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 6 } } });
+    expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'idle', busy: false });
+    expect(store.getCommandLifecycle('cold-ack', 9)?.status).toBe('confirmed');
     store.resetCommandLifecycle();
   });
 

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -1,0 +1,150 @@
+/**
+ * MOR-1664 — Filter Width lifecycle projection.
+ *
+ * The adapter is the only place this child may join a command record with
+ * radio-observed truth.  It must keep the observed width canonical and make
+ * an explicitly unconfirmed target visible only while the newest matching
+ * record is live.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type FakeCommand = {
+  id: string;
+  name: string;
+  params: Record<string, unknown>;
+  originalEpoch: number;
+  eventEpoch?: number;
+  createdAt: number;
+  status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
+  error?: string;
+  ackObservationSeq?: number;
+};
+type FakeState = {
+  active: 'MAIN' | 'SUB';
+  main: Record<string, unknown>;
+  sub: Record<string, unknown>;
+  observationSeq?: number;
+};
+
+const lifecycle = { commands: [] as FakeCommand[], confirms: [] as [string, number, number][] };
+const runtimeState: { state: FakeState | null } = { state: null };
+
+vi.mock('$lib/stores/commands.svelte', () => ({
+  getCommandLifecycles: () => lifecycle.commands,
+  confirmCommand: (id: string, epoch: number, eventEpoch: number) => lifecycle.confirms.push([id, epoch, eventEpoch]),
+}));
+vi.mock('$lib/runtime/frontend-runtime', () => ({
+  runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({ getAppTxController: () => null }));
+vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({ toRadioViewModel: () => null }));
+
+import { getFilterWidthCommandLifecycle } from '../panel-adapters';
+
+const command = (over: Partial<FakeCommand> = {}): FakeCommand => ({
+  id: 'width-1', name: 'set_filter_width', params: { width: 3000, receiver: 0 },
+  originalEpoch: 7, eventEpoch: 7, createdAt: 1, status: 'pending', ...over,
+});
+const state = (over: Partial<FakeState> = {}): FakeState => ({
+  active: 'MAIN', main: { filterWidth: 2400 }, sub: {}, observationSeq: 4, ...over,
+});
+
+describe('Filter Width command lifecycle projection (MOR-1664)', () => {
+  afterEach(() => {
+    lifecycle.commands = [];
+    lifecycle.confirms = [];
+    runtimeState.state = null;
+  });
+
+  it('stays unavailable rather than fabricating a pending or confirmed value without observed width', () => {
+    runtimeState.state = state({ main: {} });
+    lifecycle.commands = [command()];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null,
+    });
+  });
+
+  it('keeps canonical observed width separate from a submitted target', () => {
+    runtimeState.state = state();
+    lifecycle.commands = [command()];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 2400, target: 3000, phase: 'pending', busy: true, outcome: null,
+    });
+  });
+
+  it('does not let a matching snapshot already present at ACK confirm the command', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 4 });
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4 })];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
+    });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it('confirms the newest acknowledged target only after a fresh matching observation', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5 });
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4 })];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 3000, target: null, phase: 'idle', busy: false, outcome: null,
+    });
+    expect(lifecycle.confirms).toEqual([['width-1', 7, 7]]);
+  });
+
+  it('keeps a fresh non-matching observation canonical while the acknowledged target remains pending', () => {
+    runtimeState.state = state({ main: { filterWidth: 2400 }, observationSeq: 5 });
+    lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4 })];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 2400, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
+    });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it('correlates confirmation with the active SUB receiver rather than MAIN', () => {
+    runtimeState.state = state({
+      active: 'SUB', main: { filterWidth: 3000 }, sub: { filterWidth: 2800 }, observationSeq: 5,
+    });
+    lifecycle.commands = [command({
+      id: 'sub-width', params: { width: 2800, receiver: 1 }, status: 'acknowledged', ackObservationSeq: 4,
+    })];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 2800, target: null, phase: 'idle', busy: false, outcome: null,
+    });
+    expect(lifecycle.confirms).toEqual([['sub-width', 7, 7]]);
+  });
+
+  it('projects only the newest same-receiver target, so older late events cannot overwrite it', () => {
+    runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5 });
+    lifecycle.commands = [
+      command({ id: 'older', createdAt: 1, status: 'acknowledged', ackObservationSeq: 4 }),
+      command({ id: 'newer', createdAt: 2, params: { width: 2800, receiver: 0 }, status: 'pending' }),
+    ];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 3000, target: 2800, phase: 'pending', busy: true, outcome: null,
+    });
+    expect(lifecycle.confirms).toEqual([]);
+  });
+
+  it('lets a newer terminal record suppress an older pending target', () => {
+    runtimeState.state = state();
+    lifecycle.commands = [
+      command({ id: 'older', createdAt: 1 }),
+      command({ id: 'newer', createdAt: 2, params: { width: 2800, receiver: 0 }, status: 'failed', error: 'rejected' }),
+    ];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 2400, target: null, phase: 'idle', busy: false,
+      outcome: { phase: 'failed', error: 'rejected' },
+    });
+  });
+
+  it.each([
+    ['failed', 'backend rejected'],
+    ['timed-out', undefined],
+    ['cancelled', 'session-disconnected'],
+  ] as const)('clears busy and retains a bounded %s outcome without changing confirmed truth', (status, error) => {
+    runtimeState.state = state({ main: { filterWidth: 2400 } });
+    lifecycle.commands = [command({ status, error })];
+    expect(getFilterWidthCommandLifecycle()).toEqual({
+      confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: { phase: status, error },
+    });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -243,8 +243,8 @@ export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
   return typeof value === 'number' ? value : null;
 }
 
-export type FilterWidthCommandPhase = 'unavailable' | 'idle' | 'pending' | 'acknowledged';
-export type FilterWidthCommandOutcome = 'failed' | 'timed-out' | 'cancelled';
+export type FilterWidthCommandPhase = 'unavailable' | 'idle' | 'pending' | 'acknowledged' | 'confirmed';
+export type FilterWidthCommandOutcome = 'confirmed' | 'failed' | 'timed-out' | 'cancelled';
 export interface FilterWidthCommandLifecycleView {
   confirmed: number | null; target: number | null; phase: FilterWidthCommandPhase; busy: boolean;
   outcome: { phase: FilterWidthCommandOutcome; error?: string } | null;
@@ -280,7 +280,10 @@ export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleVie
   if (!observed) return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null };
 
   const command = latestFilterWidthLifecycle(observed.receiver);
-  if (!command || command.status === 'confirmed') return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
+  if (!command) return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
+  if (command.status === 'confirmed') {
+    return { confirmed: observed.width, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } };
+  }
   if (command.status === 'failed' || command.status === 'timed-out' || command.status === 'cancelled') {
     return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: { phase: command.status, error: command.error } };
   }

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -31,7 +31,7 @@ import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
 import { recordQsy } from './qsy-history-adapter';
-import { confirmCommand, getCommandLifecycles } from '$lib/stores/commands.svelte';
+import { confirmCommand, getCommandLifecycles, isCommandLifecycleSuperseded } from '$lib/stores/commands.svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 
@@ -281,7 +281,8 @@ function latestFilterWidthLifecycle(receiver: 0 | 1) {
   let latest: ReturnType<typeof getCommandLifecycles>[number] | null = null;
   for (const command of getCommandLifecycles()) {
     if (command.name !== 'set_filter_width' || command.params.receiver !== receiver
-      || typeof command.params.width !== 'number' || !Number.isFinite(command.params.width)) continue;
+      || typeof command.params.width !== 'number' || !Number.isFinite(command.params.width)
+      || isCommandLifecycleSuperseded(command)) continue;
     if (!latest || command.createdAt >= latest.createdAt) latest = command;
   }
   return latest;

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -260,13 +260,14 @@ export interface FilterWidthCommandLifecycleView {
   outcome: { phase: FilterWidthCommandOutcome; error?: string } | null;
 }
 
-function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; observationSeq?: number } | null {
+function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; fieldPath: string; fieldStatus: NonNullable<ServerState['fieldStatus']>[string] | undefined } | null {
   const state = runtime.state;
   if (!state) return null;
   const receiver: 0 | 1 = state.active === 'SUB' ? 1 : 0;
   const width = (receiver === 0 ? state.main : state.sub)?.filterWidth;
   if (typeof width !== 'number' || !Number.isFinite(width)) return null;
-  return { receiver, width, observationSeq: state.observationSeq };
+  const fieldPath = receiver === 0 ? 'main.filterWidth' : 'sub.filterWidth';
+  return { receiver, width, fieldPath, fieldStatus: state.fieldStatus?.[fieldPath] };
 }
 
 /** The later array record wins a same-millisecond dispatch tie. */
@@ -297,11 +298,21 @@ export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleVie
 
   const target = command.params.width as number;
   if (command.status === 'acknowledged') {
-    // ACK alone is never confirmation. Require both the command's ack-time
-    // observation boundary and a strictly newer matching observation before
-    // completing this exact id/original-epoch record through the store API.
-    if (command.ackObservationSeq !== undefined && observed.observationSeq !== undefined
-      && observed.observationSeq > command.ackObservationSeq && observed.width === target) {
+    // ACK alone is never confirmation. A qualifying field observation must
+    // be fresh, available and observed, and must carry a finite marker newer
+    // than the marker captured for this exact public field at ACK.  A new
+    // record that had no finite marker for this field at ACK may use its first
+    // finite post-ACK marker; legacy records without the map never confirm.
+    const marker = observed.fieldStatus?.lastObservedMonotonic;
+    const ackMarkers = command.ackFieldObservationTimes;
+    const ackMarker = ackMarkers?.[observed.fieldPath];
+    const isQualifying = observed.fieldStatus?.observed === true
+      && observed.fieldStatus.freshness === 'fresh'
+      && observed.fieldStatus.availability === 'available'
+      && typeof marker === 'number' && Number.isFinite(marker)
+      && ackMarkers !== undefined
+      && (ackMarker === undefined || marker > ackMarker);
+    if (isQualifying && observed.width === target) {
       confirmCommand(command.id, command.originalEpoch, command.eventEpoch ?? command.originalEpoch);
       return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
     }

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -31,7 +31,7 @@ import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
 import { recordQsy } from './qsy-history-adapter';
-import { getCommandLifecycles } from '$lib/stores/commands.svelte';
+import { confirmCommand, getCommandLifecycles } from '$lib/stores/commands.svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 
@@ -241,6 +241,73 @@ export function getActiveFrequencyHz(): number | null {
 export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
   const value = latestPendingParam('set_freq', 'freq', receiver, 'freqHz');
   return typeof value === 'number' ? value : null;
+}
+
+// ── Filter Width command lifecycle (MOR-1664) ──
+/**
+ * A presentation-neutral projection for the Filter Width surface. `confirmed`
+ * always comes from radio-observed state; `target` is only an unconfirmed
+ * command request. The adapter is also the narrow observer that completes an
+ * acknowledged lifecycle record once a later matching observation arrives.
+ */
+export type FilterWidthCommandPhase = 'unavailable' | 'idle' | 'pending' | 'acknowledged';
+export type FilterWidthCommandOutcome = 'failed' | 'timed-out' | 'cancelled';
+export interface FilterWidthCommandLifecycleView {
+  confirmed: number | null;
+  target: number | null;
+  phase: FilterWidthCommandPhase;
+  busy: boolean;
+  outcome: { phase: FilterWidthCommandOutcome; error?: string } | null;
+}
+
+function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; observationSeq?: number } | null {
+  const state = runtime.state;
+  if (!state) return null;
+  const receiver: 0 | 1 = state.active === 'SUB' ? 1 : 0;
+  const width = (receiver === 0 ? state.main : state.sub)?.filterWidth;
+  if (typeof width !== 'number' || !Number.isFinite(width)) return null;
+  return { receiver, width, observationSeq: state.observationSeq };
+}
+
+/** The later array record wins a same-millisecond dispatch tie. */
+function latestFilterWidthLifecycle(receiver: 0 | 1) {
+  let latest: ReturnType<typeof getCommandLifecycles>[number] | null = null;
+  for (const command of getCommandLifecycles()) {
+    if (command.name !== 'set_filter_width' || command.params.receiver !== receiver
+      || typeof command.params.width !== 'number' || !Number.isFinite(command.params.width)) continue;
+    if (!latest || command.createdAt >= latest.createdAt) latest = command;
+  }
+  return latest;
+}
+
+export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleView {
+  const observed = activeFilterWidthReceiver();
+  if (!observed) return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null };
+
+  const command = latestFilterWidthLifecycle(observed.receiver);
+  if (!command || command.status === 'confirmed') {
+    return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
+  }
+  if (command.status === 'failed' || command.status === 'timed-out' || command.status === 'cancelled') {
+    return {
+      confirmed: observed.width, target: null, phase: 'idle', busy: false,
+      outcome: { phase: command.status, error: command.error },
+    };
+  }
+
+  const target = command.params.width as number;
+  if (command.status === 'acknowledged') {
+    // ACK alone is never confirmation. Require both the command's ack-time
+    // observation boundary and a strictly newer matching observation before
+    // completing this exact id/original-epoch record through the store API.
+    if (command.ackObservationSeq !== undefined && observed.observationSeq !== undefined
+      && observed.observationSeq > command.ackObservationSeq && observed.width === target) {
+      confirmCommand(command.id, command.originalEpoch, command.eventEpoch ?? command.originalEpoch);
+      return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
+    }
+    return { confirmed: observed.width, target, phase: 'acknowledged', busy: true, outcome: null };
+  }
+  return { confirmed: observed.width, target, phase: 'pending', busy: true, outcome: null };
 }
 
 // ── Pending discrete-control targets (MOR-1441 leg 2) ──

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -31,7 +31,7 @@ import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
 import { recordQsy } from './qsy-history-adapter';
-import { confirmCommand, getCommandLifecycles, isCommandLifecycleSuperseded } from '$lib/stores/commands.svelte';
+import { getCommandLifecycles, isCommandLifecycleSuperseded } from '$lib/stores/commands.svelte';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 
@@ -243,14 +243,10 @@ export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
   return typeof value === 'number' ? value : null;
 }
 
-// ── Filter Width command lifecycle (MOR-1664) ──
 export type FilterWidthCommandPhase = 'unavailable' | 'idle' | 'pending' | 'acknowledged';
 export type FilterWidthCommandOutcome = 'failed' | 'timed-out' | 'cancelled';
 export interface FilterWidthCommandLifecycleView {
-  confirmed: number | null;
-  target: number | null;
-  phase: FilterWidthCommandPhase;
-  busy: boolean;
+  confirmed: number | null; target: number | null; phase: FilterWidthCommandPhase; busy: boolean;
   outcome: { phase: FilterWidthCommandOutcome; error?: string } | null;
 }
 
@@ -262,19 +258,16 @@ function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; fieldPat
   if (typeof width !== 'number' || !Number.isFinite(width)) return null;
   const fieldPath = receiver === 0 ? 'main.filterWidth' : 'sub.filterWidth';
   const fieldStatus = state.fieldStatus?.[fieldPath];
-  if (fieldStatus?.observed !== true
-    || fieldStatus.freshness !== 'fresh'
-    || fieldStatus.availability !== 'available'
+  if (fieldStatus?.observed !== true || fieldStatus.freshness !== 'fresh' || fieldStatus.availability !== 'available'
     || typeof fieldStatus.lastObservedMonotonic !== 'number'
     || !Number.isFinite(fieldStatus.lastObservedMonotonic)) return null;
   return { receiver, width, fieldPath, fieldStatus };
 }
 
-/** The later array record wins a same-millisecond dispatch tie. */
 function latestFilterWidthLifecycle(receiver: 0 | 1) {
   let latest: ReturnType<typeof getCommandLifecycles>[number] | null = null;
   for (const command of getCommandLifecycles()) {
-    if (command.name !== 'set_filter_width' || (command.params.receiver === 1 ? 1 : 0) !== receiver
+  if (command.name !== 'set_filter_width' || (command.params.receiver === 1 ? 1 : 0) !== receiver
       || typeof command.params.width !== 'number' || !Number.isFinite(command.params.width)
       || isCommandLifecycleSuperseded(command)) continue;
     if (!latest || command.createdAt >= latest.createdAt) latest = command;
@@ -287,32 +280,13 @@ export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleVie
   if (!observed) return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null };
 
   const command = latestFilterWidthLifecycle(observed.receiver);
-  if (!command || command.status === 'confirmed') {
-    return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
-  }
+  if (!command || command.status === 'confirmed') return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
   if (command.status === 'failed' || command.status === 'timed-out' || command.status === 'cancelled') {
-    return {
-      confirmed: observed.width, target: null, phase: 'idle', busy: false,
-      outcome: { phase: command.status, error: command.error },
-    };
+    return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: { phase: command.status, error: command.error } };
   }
 
   const target = command.params.width as number;
-  if (command.status === 'acknowledged') {
-    // ACK alone is never confirmation; legacy records without markers fail closed.
-    const marker = observed.fieldStatus?.lastObservedMonotonic;
-    const ackMarkers = command.ackFieldObservationTimes;
-    const matching = observed.width === target && typeof marker === 'number' && Number.isFinite(marker);
-    const ackMarker = ackMarkers?.[observed.fieldPath];
-    const cold = ackMarkers !== undefined && Object.keys(ackMarkers).length === 0;
-    if (cold && typeof marker === 'number' && Number.isFinite(marker)) {
-      command.ackFieldObservationTimes = { [observed.fieldPath]: marker };
-    } else if (matching && typeof ackMarker === 'number' && Number.isFinite(ackMarker) && marker > ackMarker) {
-      confirmCommand(command.id, command.originalEpoch, command.eventEpoch ?? command.originalEpoch);
-      return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
-    }
-    return { confirmed: observed.width, target, phase: 'acknowledged', busy: true, outcome: null };
-  }
+  if (command.status === 'acknowledged') return { confirmed: observed.width, target, phase: 'acknowledged', busy: true, outcome: null };
   return { confirmed: observed.width, target, phase: 'pending', busy: true, outcome: null };
 }
 

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -244,12 +244,6 @@ export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
 }
 
 // ── Filter Width command lifecycle (MOR-1664) ──
-/**
- * A presentation-neutral projection for the Filter Width surface. `confirmed`
- * always comes from radio-observed state; `target` is only an unconfirmed
- * command request. The adapter is also the narrow observer that completes an
- * acknowledged lifecycle record once a later matching observation arrives.
- */
 export type FilterWidthCommandPhase = 'unavailable' | 'idle' | 'pending' | 'acknowledged';
 export type FilterWidthCommandOutcome = 'failed' | 'timed-out' | 'cancelled';
 export interface FilterWidthCommandLifecycleView {
@@ -280,7 +274,7 @@ function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; fieldPat
 function latestFilterWidthLifecycle(receiver: 0 | 1) {
   let latest: ReturnType<typeof getCommandLifecycles>[number] | null = null;
   for (const command of getCommandLifecycles()) {
-    if (command.name !== 'set_filter_width' || command.params.receiver !== receiver
+    if (command.name !== 'set_filter_width' || (command.params.receiver === 1 ? 1 : 0) !== receiver
       || typeof command.params.width !== 'number' || !Number.isFinite(command.params.width)
       || isCommandLifecycleSuperseded(command)) continue;
     if (!latest || command.createdAt >= latest.createdAt) latest = command;
@@ -305,20 +299,15 @@ export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleVie
 
   const target = command.params.width as number;
   if (command.status === 'acknowledged') {
-    // ACK alone is never confirmation. A qualifying field observation must
-    // be fresh, available and observed, and must carry a finite marker newer
-    // than the marker captured for this exact public field at ACK.  A new
-    // record that had no finite marker for this field at ACK may use its first
-    // finite post-ACK marker; legacy records without the map never confirm.
+    // ACK alone is never confirmation; legacy records without markers fail closed.
     const marker = observed.fieldStatus?.lastObservedMonotonic;
     const ackMarkers = command.ackFieldObservationTimes;
+    const matching = observed.width === target && typeof marker === 'number' && Number.isFinite(marker);
     const ackMarker = ackMarkers?.[observed.fieldPath];
-    const isEmptyNewFormatBoundary = ackMarkers !== undefined && Object.keys(ackMarkers).length === 0;
-    const isQualifying = typeof marker === 'number' && Number.isFinite(marker)
-      && ackMarkers !== undefined
-      && (isEmptyNewFormatBoundary
-        || (typeof ackMarker === 'number' && Number.isFinite(ackMarker) && marker > ackMarker));
-    if (isQualifying && observed.width === target) {
+    const cold = ackMarkers !== undefined && Object.keys(ackMarkers).length === 0;
+    if (cold && matching) {
+      command.ackFieldObservationTimes = { [observed.fieldPath]: marker };
+    } else if (matching && typeof ackMarker === 'number' && Number.isFinite(ackMarker) && marker > ackMarker) {
       confirmCommand(command.id, command.originalEpoch, command.eventEpoch ?? command.originalEpoch);
       return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
     }

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -305,7 +305,7 @@ export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleVie
     const matching = observed.width === target && typeof marker === 'number' && Number.isFinite(marker);
     const ackMarker = ackMarkers?.[observed.fieldPath];
     const cold = ackMarkers !== undefined && Object.keys(ackMarkers).length === 0;
-    if (cold && matching) {
+    if (cold && typeof marker === 'number' && Number.isFinite(marker)) {
       command.ackFieldObservationTimes = { [observed.fieldPath]: marker };
     } else if (matching && typeof ackMarker === 'number' && Number.isFinite(ackMarker) && marker > ackMarker) {
       confirmCommand(command.id, command.originalEpoch, command.eventEpoch ?? command.originalEpoch);

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -267,7 +267,13 @@ function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; fieldPat
   const width = (receiver === 0 ? state.main : state.sub)?.filterWidth;
   if (typeof width !== 'number' || !Number.isFinite(width)) return null;
   const fieldPath = receiver === 0 ? 'main.filterWidth' : 'sub.filterWidth';
-  return { receiver, width, fieldPath, fieldStatus: state.fieldStatus?.[fieldPath] };
+  const fieldStatus = state.fieldStatus?.[fieldPath];
+  if (fieldStatus?.observed !== true
+    || fieldStatus.freshness !== 'fresh'
+    || fieldStatus.availability !== 'available'
+    || typeof fieldStatus.lastObservedMonotonic !== 'number'
+    || !Number.isFinite(fieldStatus.lastObservedMonotonic)) return null;
+  return { receiver, width, fieldPath, fieldStatus };
 }
 
 /** The later array record wins a same-millisecond dispatch tie. */
@@ -306,12 +312,11 @@ export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleVie
     const marker = observed.fieldStatus?.lastObservedMonotonic;
     const ackMarkers = command.ackFieldObservationTimes;
     const ackMarker = ackMarkers?.[observed.fieldPath];
-    const isQualifying = observed.fieldStatus?.observed === true
-      && observed.fieldStatus.freshness === 'fresh'
-      && observed.fieldStatus.availability === 'available'
-      && typeof marker === 'number' && Number.isFinite(marker)
+    const isEmptyNewFormatBoundary = ackMarkers !== undefined && Object.keys(ackMarkers).length === 0;
+    const isQualifying = typeof marker === 'number' && Number.isFinite(marker)
       && ackMarkers !== undefined
-      && (ackMarker === undefined || marker > ackMarker);
+      && (isEmptyNewFormatBoundary
+        || (typeof ackMarker === 'number' && Number.isFinite(ackMarker) && marker > ackMarker));
     if (isQualifying && observed.width === target) {
       confirmCommand(command.id, command.originalEpoch, command.eventEpoch ?? command.originalEpoch);
       return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -20,6 +20,14 @@ export interface CommandLifecycle {
    * value) and would leave the sequence guard permanently unable to fire.
    */
   ackObservationSeq?: number;
+  /**
+   * Bounded ACK-time field-observation markers.  These are correlation
+   * metadata only: they deliberately retain neither radio values nor field
+   * provenance.  An empty object means the current command-store contract
+   * captured no finite markers; an absent property is a legacy record and
+   * must not be used for confirmation.
+   */
+  ackFieldObservationTimes?: Readonly<Record<string, number>>;
 }
 export interface BeginCommandInput {
   id: string; name: string; params: Readonly<Record<string, unknown>>;
@@ -34,6 +42,7 @@ const DEFAULT_TIMEOUT_MS = 5_000;
  */
 const OUTCOME_RETENTION_MS = 5_000;
 const MAX_RETAINED_COMMANDS = 100;
+const MAX_ACK_FIELD_OBSERVATION_TIMES = 100;
 let commands = $state<CommandLifecycle[]>([]);
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
 const key = (id: string, epoch: number): string => `${epoch}:${id}`;
@@ -87,7 +96,14 @@ function transition(
   command.status = status; command.eventEpoch = eventEpoch; command.updatedAt = Date.now();
   if (error) command.error = error;
   if (status === 'acknowledged') {
-    command.ackObservationSeq = getRadioState()?.observationSeq;
+    const radio = getRadioState();
+    command.ackObservationSeq = radio?.observationSeq;
+    const observations: Record<string, number> = {};
+    for (const [path, field] of Object.entries(radio?.fieldStatus ?? {}).slice(0, MAX_ACK_FIELD_OBSERVATION_TIMES)) {
+      const marker = field.lastObservedMonotonic;
+      if (typeof marker === 'number' && Number.isFinite(marker)) observations[path] = marker;
+    }
+    command.ackFieldObservationTimes = observations;
     startLiveDeadline(command);
   } else {
     retainTerminalOutcome(command);

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -45,7 +45,19 @@ const MAX_RETAINED_COMMANDS = 100;
 const MAX_ACK_FIELD_OBSERVATION_TIMES = 100;
 let commands = $state<CommandLifecycle[]>([]);
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
+const supersededRecordKeys = new Set<string>();
 const key = (id: string, epoch: number): string => `${epoch}:${id}`;
+
+/** Command-bus receiver parameters are normalized to MAIN (0) or SUB (1). */
+const receiverScope = (command: Pick<CommandLifecycle, 'params'>): 0 | 1 =>
+  command.params.receiver === 1 ? 1 : 0;
+
+/**
+ * Factual, bounded record-lifetime supersession marker for projections that
+ * must not revive an older command after a newer matching record has retired.
+ */
+export const isCommandLifecycleSuperseded = (command: CommandLifecycle): boolean =>
+  supersededRecordKeys.has(key(command.id, command.originalEpoch));
 
 function clearRecordTimer(command: CommandLifecycle): void {
   const recordKey = key(command.id, command.originalEpoch);
@@ -56,6 +68,7 @@ function clearRecordTimer(command: CommandLifecycle): void {
 function retireRecord(command: CommandLifecycle): void {
   const index = commands.indexOf(command);
   if (index >= 0) commands.splice(index, 1);
+  supersededRecordKeys.delete(key(command.id, command.originalEpoch));
 }
 function retainTerminalOutcome(command: CommandLifecycle): void {
   clearRecordTimer(command);
@@ -83,7 +96,7 @@ function reserveRecordSlot(): void {
   if (commands.length < MAX_RETAINED_COMMANDS) return;
   const terminal = commands.findIndex((command) => command.status !== 'pending' && command.status !== 'acknowledged');
   if (terminal < 0) throw new Error('Command lifecycle capacity exhausted');
-  clearRecordTimer(commands[terminal]); commands.splice(terminal, 1);
+  clearRecordTimer(commands[terminal]); retireRecord(commands[terminal]);
 }
 function transition(
   id: string, originalEpoch: number,
@@ -116,6 +129,12 @@ export function beginCommand(input: BeginCommandInput): CommandLifecycle {
   const now = Date.now();
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const command: CommandLifecycle = { ...input, timeoutMs, createdAt: now, updatedAt: now, status: 'pending' };
+  const scope = receiverScope(command);
+  for (const existing of commands) {
+    if (existing.name === command.name && receiverScope(existing) === scope) {
+      supersededRecordKeys.add(key(existing.id, existing.originalEpoch));
+    }
+  }
   commands.push(command);
   startLiveDeadline(command);
   return command;
@@ -140,5 +159,5 @@ export function cancelPendingCommands(epoch: number, error = 'session-disconnect
 }
 export function resetCommandLifecycle(): void {
   for (const timer of timers.values()) clearTimeout(timer);
-  timers.clear(); commands = [];
+  timers.clear(); commands = []; supersededRecordKeys.clear();
 }

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -1,4 +1,5 @@
-import { getRadioState } from './radio.svelte';
+import { getRadioState, subscribeRadioState } from './radio.svelte';
+import type { ServerState } from '../types/state';
 
 export type CommandLifecycleStatus = 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
 export interface CommandLifecycle {
@@ -36,20 +37,17 @@ const DEFAULT_TIMEOUT_MS = 5_000;
  */
 const OUTCOME_RETENTION_MS = 5_000;
 const MAX_RETAINED_COMMANDS = 100;
-/** Public fields consumed by the filter-width lifecycle projection. */
 const ACK_CORRELATION_PATHS = ['main.filterWidth', 'sub.filterWidth'] as const;
 let commands = $state<CommandLifecycle[]>([]);
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
 const supersededRecordKeys = new Set<string>();
+let filterWidthReconciliationStarted = false;
 const key = (id: string, epoch: number): string => `${epoch}:${id}`;
 
-/** Command-bus receiver parameters are normalized to MAIN (0) or SUB (1). */
 const receiverScope = (command: Pick<CommandLifecycle, 'params'>): 0 | 1 =>
   command.params.receiver === 1 ? 1 : 0;
 
-/** Keeps a superseded record from resurfacing after newer retirement. */
-export const isCommandLifecycleSuperseded = (command: CommandLifecycle): boolean =>
-  supersededRecordKeys.has(key(command.id, command.originalEpoch));
+export const isCommandLifecycleSuperseded = (command: CommandLifecycle): boolean => supersededRecordKeys.has(key(command.id, command.originalEpoch));
 
 function clearRecordTimer(command: CommandLifecycle): void {
   const recordKey = key(command.id, command.originalEpoch);
@@ -101,8 +99,7 @@ function transition(
   command.status = status; command.eventEpoch = eventEpoch; command.updatedAt = Date.now();
   if (error) command.error = error;
   if (status === 'acknowledged') {
-    const radio = getRadioState();
-    command.ackObservationSeq = radio?.observationSeq;
+    const radio = getRadioState(); command.ackObservationSeq = radio?.observationSeq;
     const observations: Record<string, number> = {};
     for (const path of ACK_CORRELATION_PATHS) {
       const field = radio?.fieldStatus?.[path];
@@ -111,9 +108,43 @@ function transition(
     }
     command.ackFieldObservationTimes = observations;
     startLiveDeadline(command);
+    if (command.name === 'set_filter_width') startFilterWidthReconciliation();
   } else {
     retainTerminalOutcome(command);
   }
+}
+
+/** Accepted state, not a presentation read, reconciles Filter Width. */
+function reconcileFilterWidthCommands(state: ServerState | null): void {
+  if (!state) return;
+  for (const command of commands) {
+    if (command.name !== 'set_filter_width' || command.status !== 'acknowledged' || isCommandLifecycleSuperseded(command)) continue;
+
+    const receiver = receiverScope(command);
+    const path = receiver === 1 ? 'sub.filterWidth' : 'main.filterWidth';
+    const field = state.fieldStatus?.[path];
+    const marker = field?.lastObservedMonotonic;
+    const width = (receiver === 1 ? state.sub : state.main)?.filterWidth;
+    const target = command.params.width;
+    if (field?.observed !== true || field.freshness !== 'fresh' || field.availability !== 'available' || typeof marker !== 'number' || !Number.isFinite(marker)
+      || typeof width !== 'number' || !Number.isFinite(width)
+      || typeof target !== 'number' || !Number.isFinite(target)) continue;
+
+    const boundaries = command.ackFieldObservationTimes;
+    if (boundaries === undefined) continue;
+    const boundary = boundaries[path];
+    if (typeof boundary !== 'number' || !Number.isFinite(boundary)) {
+      command.ackFieldObservationTimes = { ...boundaries, [path]: marker };
+      continue;
+    }
+    if (marker > boundary && width === target) transition(command.id, command.originalEpoch, 'confirmed', command.eventEpoch ?? command.originalEpoch);
+  }
+}
+
+function startFilterWidthReconciliation(): void {
+  if (filterWidthReconciliationStarted) return;
+  filterWidthReconciliationStarted = true;
+  subscribeRadioState(reconcileFilterWidthCommands);
 }
 
 export function beginCommand(input: BeginCommandInput): CommandLifecycle {
@@ -123,10 +154,8 @@ export function beginCommand(input: BeginCommandInput): CommandLifecycle {
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const command: CommandLifecycle = { ...input, timeoutMs, createdAt: now, updatedAt: now, status: 'pending' };
   const scope = receiverScope(command);
-  for (const existing of commands) {
-    if (existing.name === command.name && receiverScope(existing) === scope) {
-      supersededRecordKeys.add(key(existing.id, existing.originalEpoch));
-    }
+  for (const existing of commands) if (existing.name === command.name && receiverScope(existing) === scope) {
+    supersededRecordKeys.add(key(existing.id, existing.originalEpoch));
   }
   commands.push(command);
   startLiveDeadline(command);

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -20,13 +20,7 @@ export interface CommandLifecycle {
    * value) and would leave the sequence guard permanently unable to fire.
    */
   ackObservationSeq?: number;
-  /**
-   * Bounded ACK-time field-observation markers.  These are correlation
-   * metadata only: they deliberately retain neither radio values nor field
-   * provenance.  An empty object means the current command-store contract
-   * captured no finite markers; an absent property is a legacy record and
-   * must not be used for confirmation.
-   */
+  /** Bounded correlation markers; absent legacy records must fail closed. */
   ackFieldObservationTimes?: Readonly<Record<string, number>>;
 }
 export interface BeginCommandInput {
@@ -42,7 +36,8 @@ const DEFAULT_TIMEOUT_MS = 5_000;
  */
 const OUTCOME_RETENTION_MS = 5_000;
 const MAX_RETAINED_COMMANDS = 100;
-const MAX_ACK_FIELD_OBSERVATION_TIMES = 100;
+/** Public fields consumed by the filter-width lifecycle projection. */
+const ACK_CORRELATION_PATHS = ['main.filterWidth', 'sub.filterWidth'] as const;
 let commands = $state<CommandLifecycle[]>([]);
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
 const supersededRecordKeys = new Set<string>();
@@ -52,10 +47,7 @@ const key = (id: string, epoch: number): string => `${epoch}:${id}`;
 const receiverScope = (command: Pick<CommandLifecycle, 'params'>): 0 | 1 =>
   command.params.receiver === 1 ? 1 : 0;
 
-/**
- * Factual, bounded record-lifetime supersession marker for projections that
- * must not revive an older command after a newer matching record has retired.
- */
+/** Keeps a superseded record from resurfacing after newer retirement. */
 export const isCommandLifecycleSuperseded = (command: CommandLifecycle): boolean =>
   supersededRecordKeys.has(key(command.id, command.originalEpoch));
 
@@ -112,8 +104,9 @@ function transition(
     const radio = getRadioState();
     command.ackObservationSeq = radio?.observationSeq;
     const observations: Record<string, number> = {};
-    for (const [path, field] of Object.entries(radio?.fieldStatus ?? {}).slice(0, MAX_ACK_FIELD_OBSERVATION_TIMES)) {
-      const marker = field.lastObservedMonotonic;
+    for (const path of ACK_CORRELATION_PATHS) {
+      const field = radio?.fieldStatus?.[path];
+      const marker = field?.lastObservedMonotonic;
       if (typeof marker === 'number' && Number.isFinite(marker)) observations[path] = marker;
     }
     command.ackFieldObservationTimes = observations;


### PR DESCRIPTION
## Summary
- project active Filter Width lifecycle records without replacing confirmed radio truth
- confirm only a fresh post-ACK matching receiver observation
- retain bounded terminal outcomes and supersession behavior

## Verification
- cd frontend && npm test -- src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts src/lib/stores/__tests__/commands.test.ts
- cd frontend && npx eslint src/lib/runtime/adapters/panel-adapters.ts src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
- cd frontend && npm run check

Refs #2624