### PR TITLE
feat(#2618): show Filter Width lifecycle

### DIFF
--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -226,6 +226,7 @@
         step={1}
         unit="Hz"
         renderer="hbar"
+        optimistic={false}
         accentColor="var(--v2-accent-cyan)"
         displayFn={(idx) => formatWidthDisplay(tableIndexToHz(idx))}
         onChange={(idx) => onFilterWidthChange(tableIndexToHz(idx))}

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -6,7 +6,12 @@
   import { getShortcutHint, joinShortcutHints } from '../layout/shortcut-hints';
   import { t } from '$lib/i18n';
 
-  import { deriveFilterProps, getFilterHandlers, getFilterArmed } from '$lib/runtime/adapters/panel-adapters';
+  import {
+    deriveFilterProps,
+    getFilterHandlers,
+    getFilterArmed,
+    getFilterWidthCommandLifecycle,
+  } from '$lib/runtime/adapters/panel-adapters';
 
   const handlers = getFilterHandlers();
   let p = $derived(deriveFilterProps());
@@ -16,6 +21,10 @@
   // pending command is racing toward, never a substitute for the confirmed
   // reading.
   let filterArmed = $derived(getFilterArmed());
+  // The lifecycle is presentation-only. `filterWidth` remains the sole
+  // canonical/confirmed source for all displayed and selected widths.
+  let filterWidthLifecycle = $derived(getFilterWidthCommandLifecycle());
+  let lastPendingWidthTarget = $state<number | null>(null);
   const filterArmedIdBase = $props.id();
 
   let currentMode = $derived(p.currentMode);
@@ -118,7 +127,7 @@
   const filterSettingsShortcut = getShortcutHint('open_filter_settings');
 
   $effect(() => {
-    if (!modalOpen) {
+    if (!modalOpen || (!filterWidthLifecycle.busy && filterWidthLifecycle.outcome !== null)) {
       draftWidths = [...visibleWidths];
     }
   });
@@ -135,6 +144,30 @@
     const formatted = formatFilterWidth(hz);
     return formatted.includes('k') ? `${formatted}Hz` : `${formatted} Hz`;
   }
+
+  $effect(() => {
+    if (filterWidthLifecycle.busy && filterWidthLifecycle.target !== null) {
+      lastPendingWidthTarget = filterWidthLifecycle.target;
+    } else if (filterWidthLifecycle.outcome === null) {
+      lastPendingWidthTarget = null;
+    }
+  });
+
+  let lifecycleTarget = $derived(filterWidthLifecycle.target ?? lastPendingWidthTarget);
+  let filterWidthLiveStatus = $derived.by(() => {
+    const target = lifecycleTarget === null ? formatWidthDisplay(filterWidth) : formatWidthDisplay(lifecycleTarget);
+    const confirmed = formatWidthDisplay(filterWidth);
+    if (filterWidthLifecycle.busy) {
+      return t('core.filter.width.pendingAnnouncement', { target });
+    }
+    switch (filterWidthLifecycle.outcome?.phase) {
+      case 'confirmed': return t('core.filter.width.confirmedAnnouncement', { confirmed });
+      case 'failed': return t('core.filter.width.failedAnnouncement', { target, confirmed });
+      case 'timed-out': return t('core.filter.width.timedOutAnnouncement', { target, confirmed });
+      case 'cancelled': return t('core.filter.width.cancelledAnnouncement', { target, confirmed });
+      default: return '';
+    }
+  });
 
   function openSettings(): void {
     draftWidths = [...visibleWidths];
@@ -164,19 +197,33 @@
 
 {#if isTableMode}
   <div class="panel-body">
-    <ValueControl
-      label="WIDTH"
-      value={hzToTableIndex(filterWidth)}
-      min={0}
-      max={(filterConfig?.table?.length ?? 1) - 1}
-      step={1}
-      unit="Hz"
-      renderer="hbar"
-      accentColor="var(--v2-accent-cyan)"
-      displayFn={(idx) => formatWidthDisplay(tableIndexToHz(idx))}
-      onChange={(idx) => onFilterWidthChange(tableIndexToHz(idx))}
-      variant="hardware-illuminated"
-    />
+    <div
+      class="filter-width-control"
+      data-filter-width-lifecycle
+      role="group"
+      aria-label="Filter width"
+      aria-busy={filterWidthLifecycle.busy}
+    >
+      <ValueControl
+        label="WIDTH"
+        value={hzToTableIndex(filterWidth)}
+        min={0}
+        max={(filterConfig?.table?.length ?? 1) - 1}
+        step={1}
+        unit="Hz"
+        renderer="hbar"
+        accentColor="var(--v2-accent-cyan)"
+        displayFn={(idx) => formatWidthDisplay(tableIndexToHz(idx))}
+        onChange={(idx) => onFilterWidthChange(tableIndexToHz(idx))}
+        variant="hardware-illuminated"
+      />
+      {#if filterWidthLifecycle.busy && lifecycleTarget !== null}
+        <span class="bw-pending-target" data-pending-width-target>
+          PENDING {formatWidthDisplay(lifecycleTarget)}
+        </span>
+      {/if}
+    </div>
+    <span class="sr-only" aria-live="polite" aria-atomic="true" data-filter-width-live>{filterWidthLiveStatus}</span>
 
     {#if hasIfShift}
       <ValueControl
@@ -244,10 +291,22 @@
       </button>
     </div>
 
-    <div class="bw-row">
+    <div
+      class="bw-row"
+      data-filter-width-lifecycle
+      role="group"
+      aria-label="Filter width"
+      aria-busy={filterWidthLifecycle.busy}
+    >
       <span class="bw-label">BW</span>
-      <span class="bw-value">{formatWidthDisplay(filterWidth)}</span>
+      <span class="bw-value" data-confirmed-width>{formatWidthDisplay(filterWidth)}</span>
+      {#if filterWidthLifecycle.busy && lifecycleTarget !== null}
+        <span class="bw-pending-target" data-pending-width-target>
+          PENDING {formatWidthDisplay(lifecycleTarget)}
+        </span>
+      {/if}
     </div>
+    <span class="sr-only" aria-live="polite" aria-atomic="true" data-filter-width-live>{filterWidthLiveStatus}</span>
 
     {#if hasIfShift}
       <ValueControl
@@ -478,6 +537,21 @@
   .bw-value {
     font-size: 14px;
     font-weight: 700;
+  }
+
+  .bw-pending-target {
+    border: 1px dashed var(--v2-accent-cyan);
+    border-radius: 2px;
+    padding: 1px 4px;
+    color: var(--v2-accent-cyan);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+
+  .filter-width-control {
+    display: grid;
+    gap: 4px;
   }
 
   /* Extra separation for stacked illuminated sliders */

--- a/frontend/src/components-v2/panels/FilterPanel.svelte
+++ b/frontend/src/components-v2/panels/FilterPanel.svelte
@@ -24,7 +24,8 @@
   // The lifecycle is presentation-only. `filterWidth` remains the sole
   // canonical/confirmed source for all displayed and selected widths.
   let filterWidthLifecycle = $derived(getFilterWidthCommandLifecycle());
-  let lastPendingWidthTarget = $state<number | null>(null);
+  let lastFilterWidthTransitionId = $state<string | null>(null);
+  let filterWidthLiveStatus = $state('');
   const filterArmedIdBase = $props.id();
 
   let currentMode = $derived(p.currentMode);
@@ -145,27 +146,40 @@
     return formatted.includes('k') ? `${formatted}Hz` : `${formatted} Hz`;
   }
 
-  $effect(() => {
-    if (filterWidthLifecycle.busy && filterWidthLifecycle.target !== null) {
-      lastPendingWidthTarget = filterWidthLifecycle.target;
-    } else if (filterWidthLifecycle.outcome === null) {
-      lastPendingWidthTarget = null;
-    }
-  });
+  let lifecycleTarget = $derived(
+    filterWidthLifecycle.busy ? (filterWidthLifecycle.presentation?.target ?? filterWidthLifecycle.target) : null
+  );
 
-  let lifecycleTarget = $derived(filterWidthLifecycle.target ?? lastPendingWidthTarget);
-  let filterWidthLiveStatus = $derived.by(() => {
-    const target = lifecycleTarget === null ? formatWidthDisplay(filterWidth) : formatWidthDisplay(lifecycleTarget);
-    const confirmed = formatWidthDisplay(filterWidth);
-    if (filterWidthLifecycle.busy) {
-      return t('core.filter.width.pendingAnnouncement', { target });
-    }
-    switch (filterWidthLifecycle.outcome?.phase) {
-      case 'confirmed': return t('core.filter.width.confirmedAnnouncement', { confirmed });
-      case 'failed': return t('core.filter.width.failedAnnouncement', { target, confirmed });
-      case 'timed-out': return t('core.filter.width.timedOutAnnouncement', { target, confirmed });
-      case 'cancelled': return t('core.filter.width.cancelledAnnouncement', { target, confirmed });
-      default: return '';
+  $effect(() => {
+    const lifecycle = filterWidthLifecycle.presentation;
+    if (lifecycle === null) {
+      lastFilterWidthTransitionId = null;
+      filterWidthLiveStatus = '';
+    } else if (lifecycle.transitionId !== lastFilterWidthTransitionId) {
+      // Capture both radio-confirmed state and the exact DTO target once per
+      // immutable transition identity. Retained reads and later canonical
+      // polls cannot rewrite/reannounce this historical transition.
+      const target = formatWidthDisplay(lifecycle.target);
+      const confirmed = formatWidthDisplay(filterWidth);
+      lastFilterWidthTransitionId = lifecycle.transitionId;
+      switch (lifecycle.status) {
+        case 'pending':
+        case 'acknowledged':
+          filterWidthLiveStatus = t('core.filter.width.pendingAnnouncement', { target });
+          break;
+        case 'confirmed':
+          filterWidthLiveStatus = t('core.filter.width.confirmedAnnouncement', { confirmed });
+          break;
+        case 'failed':
+          filterWidthLiveStatus = t('core.filter.width.failedAnnouncement', { target, confirmed });
+          break;
+        case 'timed-out':
+          filterWidthLiveStatus = t('core.filter.width.timedOutAnnouncement', { target, confirmed });
+          break;
+        case 'cancelled':
+          filterWidthLiveStatus = t('core.filter.width.cancelledAnnouncement', { target, confirmed });
+          break;
+      }
     }
   });
 

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import { formatFilterWidth } from '../filter-utils';
 import { deriveIfShift } from '../filter-controls';
 
@@ -46,13 +47,41 @@ const widthLifecycle = {
   phase: 'idle',
   busy: false,
   outcome: null as { phase: 'confirmed' | 'failed' | 'timed-out' | 'cancelled'; error?: string } | null,
+  presentation: null as {
+    lifecycleId: string; transitionId: string; receiver: 0 | 1; sessionEpoch: number;
+    target: number; status: 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'timed-out' | 'cancelled';
+  } | null,
 };
+const propsVersion = new SvelteMap([['value', 0]]);
+const lifecycleState = new SvelteMap([['value', widthLifecycle]]);
+
+function setMockProps(overrides: Partial<typeof mockProps>): void {
+  Object.assign(mockProps, overrides);
+  propsVersion.set('value', (propsVersion.get('value') ?? 0) + 1);
+}
+
+function setWidthLifecycle(overrides: Partial<typeof widthLifecycle>): void {
+  lifecycleState.set('value', { ...(lifecycleState.get('value') ?? widthLifecycle), ...overrides });
+}
+
+function presentation(
+  lifecycleId: string,
+  status: NonNullable<typeof widthLifecycle.presentation>['status'],
+  target: number,
+  receiver: 0 | 1 = 0,
+  sessionEpoch = 7,
+) {
+  return { lifecycleId, transitionId: `${sessionEpoch}:${lifecycleId}:${status}`, receiver, sessionEpoch, target, status };
+}
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
-  deriveFilterProps: () => mockProps,
+  deriveFilterProps: () => {
+    propsVersion.get('value');
+    return { ...mockProps };
+  },
   getFilterHandlers: () => mockHandlers,
   getFilterArmed: () => unarmed,
-  getFilterWidthCommandLifecycle: () => widthLifecycle,
+  getFilterWidthCommandLifecycle: () => lifecycleState.get('value')!,
 }));
 
 import FilterPanel from '../FilterPanel.svelte';
@@ -111,7 +140,7 @@ it('returns raw number string for values below 1000', () => {
 let components: ReturnType<typeof mount>[] = [];
 
 function mountPanel(overrides?: Partial<typeof mockProps>) {
-  if (overrides) Object.assign(mockProps, overrides);
+  if (overrides) setMockProps(overrides);
   const t = document.createElement('div');
   document.body.appendChild(t);
   const component = mount(FilterPanel, { target: t });
@@ -122,7 +151,7 @@ function mountPanel(overrides?: Partial<typeof mockProps>) {
 
 beforeEach(() => {
   components = [];
-  Object.assign(mockProps, {
+  setMockProps({
     currentMode: 'USB',
     currentFilter: 2,
     filterShape: 0,
@@ -151,12 +180,13 @@ beforeEach(() => {
   mockHandlers.onPbtInnerChange = vi.fn();
   mockHandlers.onPbtOuterChange = vi.fn();
   mockHandlers.onPbtReset = vi.fn();
-  Object.assign(widthLifecycle, {
+  lifecycleState.set('value', {
     confirmed: 2400,
     target: null,
     phase: 'idle',
     busy: false,
     outcome: null,
+    presentation: null,
   });
 });
 
@@ -204,7 +234,10 @@ describe('panel structure', () => {
 
 describe('Filter Width lifecycle presentation (MOR-1665)', () => {
   it('keeps the canonical BW readout distinct from a pending target and marks the group busy', () => {
-    Object.assign(widthLifecycle, { target: 3000, phase: 'acknowledged', busy: true });
+    setWidthLifecycle({
+      target: 3000, phase: 'acknowledged', busy: true,
+      presentation: presentation('main-command', 'acknowledged', 3000),
+    });
     const t = mountPanel();
 
     const group = t.querySelector<HTMLElement>('[data-filter-width-lifecycle]');
@@ -220,11 +253,12 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     ['timed-out', 'timed out'],
     ['cancelled', 'cancelled'],
   ] as const)('announces the terminal %s outcome once without changing canonical BW', (phase, message) => {
-    Object.assign(widthLifecycle, {
+    setWidthLifecycle({
       target: null,
       phase: phase === 'confirmed' ? 'confirmed' : 'idle',
       busy: false,
       outcome: { phase },
+      presentation: presentation('main-command', phase, 3000),
     });
     const t = mountPanel();
 
@@ -235,7 +269,10 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
   });
 
   it('keeps a table-mode slider on canonical state while separately marking its pending target', () => {
-    Object.assign(widthLifecycle, { target: 3000, phase: 'pending', busy: true });
+    setWidthLifecycle({
+      target: 3000, phase: 'pending', busy: true,
+      presentation: presentation('table-command', 'pending', 3000),
+    });
     const t = mountPanel({
       filterConfig: {
         defaults: [2400, 2400, 2400], fixed: false, minHz: 1800, maxHz: 3000, stepHz: 1,
@@ -246,6 +283,89 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     expect(t.querySelector<HTMLElement>('[data-filter-width-lifecycle]')?.getAttribute('aria-busy')).toBe('true');
     expect(t.querySelector<HTMLElement>('[role="slider"]')?.getAttribute('aria-valuenow')).toBe('1');
     expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
+  });
+
+  it('uses the exact new lifecycle target instead of a stale prior pending target', () => {
+    const t = mountPanel();
+    setWidthLifecycle({
+      target: 3000, phase: 'pending', busy: true, outcome: null,
+      presentation: presentation('old-main', 'pending', 3000),
+    });
+    flushSync();
+    setMockProps({ filterWidth: 1800 });
+    setWidthLifecycle({
+      confirmed: 1800, target: null, phase: 'idle', busy: false, outcome: { phase: 'failed' },
+      presentation: presentation('new-main', 'failed', 1800),
+    });
+    flushSync();
+
+    const status = t.querySelector('[data-filter-width-live]')?.textContent ?? '';
+    expect(status).toContain('1.8kHz was not applied');
+    expect(status).not.toContain('3kHz');
+    expect(t.querySelector('[data-confirmed-width]')?.textContent).toBe('1.8kHz');
+  });
+
+  it('freezes one terminal message across retained reads and canonical-only changes', async () => {
+    setWidthLifecycle({
+      target: null, phase: 'idle', busy: false, outcome: { phase: 'failed' },
+      presentation: presentation('failed-main', 'failed', 1800),
+    });
+    const t = mountPanel();
+    const live = t.querySelector('[data-filter-width-live]')!;
+    const frozen = live.textContent;
+    const mutations: MutationRecord[] = [];
+    const observer = new MutationObserver((records) => mutations.push(...records));
+    observer.observe(live, { childList: true, characterData: true, subtree: true });
+
+    setMockProps({ filterWidth: 1800 });
+    setWidthLifecycle({ confirmed: 1800 });
+    flushSync();
+    await Promise.resolve();
+
+    expect(live.textContent).toBe(frozen);
+    expect(mutations).toHaveLength(0);
+    observer.disconnect();
+  });
+
+  it('isolates superseding receiver/session identities and clears the live region on GC', () => {
+    const t = mountPanel();
+    setWidthLifecycle({
+      target: 3000, phase: 'pending', busy: true,
+      presentation: presentation('main-old', 'pending', 3000, 0, 7),
+    });
+    flushSync();
+    setWidthLifecycle({
+      target: 2100, phase: 'pending', busy: true,
+      presentation: presentation('sub-new', 'pending', 2100, 1, 8),
+    });
+    flushSync();
+    expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain('2.1kHz');
+    expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('2.1kHz');
+
+    setWidthLifecycle({ target: null, phase: 'idle', busy: false, outcome: null, presentation: null });
+    flushSync();
+    expect(t.querySelector('[data-filter-width-live]')?.textContent).toBe('');
+  });
+
+  it('restores an open modal draft to canonical state on one failed transition', () => {
+    vi.useFakeTimers();
+    const t = mountPanel();
+    (t.querySelector('.settings-button') as HTMLButtonElement).click();
+    flushSync();
+    const activeSlider = document.querySelectorAll<HTMLElement>('.filter-modal [role="slider"]')[1];
+    activeSlider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(60);
+    flushSync();
+    expect(activeSlider.getAttribute('aria-valuenow')).not.toBe('2400');
+
+    setWidthLifecycle({
+      target: null, phase: 'idle', busy: false, outcome: { phase: 'failed' },
+      presentation: presentation('failed-draft', 'failed', 2450),
+    });
+    flushSync();
+    expect(activeSlider.getAttribute('aria-valuenow')).toBe('2400');
+    expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain('2.5kHz was not applied');
+    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -233,6 +233,13 @@ describe('panel structure', () => {
 });
 
 describe('Filter Width lifecycle presentation (MOR-1665)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+  const tableConfig = {
+    defaults: [2400, 2400, 2400], fixed: false, minHz: 1800, maxHz: 3000, stepHz: 1,
+    table: [1800, 2400, 3000],
+  } as typeof mockProps.filterConfig;
+
   it('keeps the canonical BW readout distinct from a pending target and marks the group busy', () => {
     setWidthLifecycle({
       target: 3000, phase: 'acknowledged', busy: true,
@@ -268,22 +275,67 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain(message);
   });
 
-  it('keeps a table-mode slider on canonical state while separately marking its pending target', () => {
-    setWidthLifecycle({
-      target: 3000, phase: 'pending', busy: true,
-      presentation: presentation('table-command', 'pending', 3000),
-    });
-    const t = mountPanel({
-      filterConfig: {
-        defaults: [2400, 2400, 2400], fixed: false, minHz: 1800, maxHz: 3000, stepHz: 1,
-        table: [1800, 2400, 3000],
-      } as typeof mockProps.filterConfig,
-    });
+  it.each(['keyboard', 'pointer'] as const)(
+    'keeps table visuals canonical through raw %s input, pending, and accepted state',
+    (input) => {
+      const t = mountPanel({ filterConfig: tableConfig });
+      const slider = t.querySelector<HTMLElement>('[role="slider"]')!;
+      const hbar = t.querySelector<HTMLElement>('.vc-hbar')!;
+      if (input === 'keyboard') {
+        slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        vi.advanceTimersByTime(60);
+      } else {
+        slider.setPointerCapture = vi.fn();
+        vi.spyOn(hbar, 'getBoundingClientRect').mockReturnValue({ left: 0, width: 100 } as DOMRect);
+        slider.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 100, pointerId: 1 }));
+      }
+      flushSync();
 
-    expect(t.querySelector<HTMLElement>('[data-filter-width-lifecycle]')?.getAttribute('aria-busy')).toBe('true');
-    expect(t.querySelector<HTMLElement>('[role="slider"]')?.getAttribute('aria-valuenow')).toBe('1');
-    expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
-  });
+      expect(mockHandlers.onFilterWidthChange).toHaveBeenCalledWith(3000);
+      expect(t.querySelector('.vc-value')?.textContent).toBe('2.4kHz');
+      expect(hbar.getAttribute('style')).toContain('--vc-fill-percent: 50%');
+      expect(slider.getAttribute('aria-valuenow')).toBe('1');
+      expect(t.querySelector('[data-pending-width-target]')).toBeNull();
+
+      setWidthLifecycle({
+        target: 3000, phase: 'pending', busy: true,
+        presentation: presentation(`table-${input}`, 'pending', 3000),
+      });
+      flushSync();
+      expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
+      expect(t.querySelector('.vc-value')?.textContent).toBe('2.4kHz');
+
+      setMockProps({ filterWidth: 3000 });
+      setWidthLifecycle({
+        confirmed: 3000, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' },
+        presentation: presentation(`table-${input}`, 'confirmed', 3000),
+      });
+      flushSync();
+      expect(t.querySelector('.vc-value')?.textContent).toBe('3kHz');
+      expect(hbar.getAttribute('style')).toContain('--vc-fill-percent: 100%');
+      expect(slider.getAttribute('aria-valuenow')).toBe('2');
+      expect(t.querySelector('[data-pending-width-target]')).toBeNull();
+    },
+  );
+
+  it.each(['failed', 'timed-out', 'cancelled'] as const)(
+    'keeps table visuals canonical when a raw target is %s',
+    (status) => {
+      const t = mountPanel({ filterConfig: tableConfig });
+      const slider = t.querySelector<HTMLElement>('[role="slider"]')!;
+      slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      vi.advanceTimersByTime(60);
+      setWidthLifecycle({
+        target: null, phase: 'idle', busy: false, outcome: { phase: status },
+        presentation: presentation(`table-${status}`, status, 3000),
+      });
+      flushSync();
+      expect(t.querySelector('.vc-value')?.textContent).toBe('2.4kHz');
+      expect(t.querySelector('.vc-hbar')?.getAttribute('style')).toContain('--vc-fill-percent: 50%');
+      expect(slider.getAttribute('aria-valuenow')).toBe('1');
+      expect(t.querySelector('[data-pending-width-target]')).toBeNull();
+    },
+  );
 
   it('uses the exact new lifecycle target instead of a stale prior pending target', () => {
     const t = mountPanel();
@@ -348,7 +400,6 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
   });
 
   it('restores an open modal draft to canonical state on one failed transition', () => {
-    vi.useFakeTimers();
     const t = mountPanel();
     (t.querySelector('.settings-button') as HTMLButtonElement).click();
     flushSync();
@@ -365,7 +416,6 @@ describe('Filter Width lifecycle presentation (MOR-1665)', () => {
     flushSync();
     expect(activeSlider.getAttribute('aria-valuenow')).toBe('2400');
     expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain('2.5kHz was not applied');
-    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts
@@ -40,11 +40,19 @@ const mockHandlers = {
 // default unarmed here, this file's tests are not about that behavior
 // (covered by `mor1536-armed-adoption.test.ts`).
 const unarmed = { armed: false, value: null };
+const widthLifecycle = {
+  confirmed: 2400,
+  target: null as number | null,
+  phase: 'idle',
+  busy: false,
+  outcome: null as { phase: 'confirmed' | 'failed' | 'timed-out' | 'cancelled'; error?: string } | null,
+};
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveFilterProps: () => mockProps,
   getFilterHandlers: () => mockHandlers,
   getFilterArmed: () => unarmed,
+  getFilterWidthCommandLifecycle: () => widthLifecycle,
 }));
 
 import FilterPanel from '../FilterPanel.svelte';
@@ -143,6 +151,13 @@ beforeEach(() => {
   mockHandlers.onPbtInnerChange = vi.fn();
   mockHandlers.onPbtOuterChange = vi.fn();
   mockHandlers.onPbtReset = vi.fn();
+  Object.assign(widthLifecycle, {
+    confirmed: 2400,
+    target: null,
+    phase: 'idle',
+    busy: false,
+    outcome: null,
+  });
 });
 
 afterEach(() => {
@@ -184,6 +199,53 @@ describe('panel structure', () => {
     const ifShiftSlider = sliders[0];
     expect(ifShiftSlider.getAttribute('aria-valuemin')).toBe('-1200');
     expect(ifShiftSlider.getAttribute('aria-valuemax')).toBe('1200');
+  });
+});
+
+describe('Filter Width lifecycle presentation (MOR-1665)', () => {
+  it('keeps the canonical BW readout distinct from a pending target and marks the group busy', () => {
+    Object.assign(widthLifecycle, { target: 3000, phase: 'acknowledged', busy: true });
+    const t = mountPanel();
+
+    const group = t.querySelector<HTMLElement>('[data-filter-width-lifecycle]');
+    expect(group?.getAttribute('aria-busy')).toBe('true');
+    expect(t.querySelector('[data-confirmed-width]')?.textContent).toBe('2.4kHz');
+    expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
+    expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain('not yet confirmed');
+  });
+
+  it.each([
+    ['confirmed', 'confirmed'],
+    ['failed', 'not applied'],
+    ['timed-out', 'timed out'],
+    ['cancelled', 'cancelled'],
+  ] as const)('announces the terminal %s outcome once without changing canonical BW', (phase, message) => {
+    Object.assign(widthLifecycle, {
+      target: null,
+      phase: phase === 'confirmed' ? 'confirmed' : 'idle',
+      busy: false,
+      outcome: { phase },
+    });
+    const t = mountPanel();
+
+    expect(t.querySelector<HTMLElement>('[data-filter-width-lifecycle]')?.getAttribute('aria-busy')).toBe('false');
+    expect(t.querySelector('[data-confirmed-width]')?.textContent).toBe('2.4kHz');
+    expect(t.querySelector('[data-pending-width-target]')).toBeNull();
+    expect(t.querySelector('[data-filter-width-live]')?.textContent).toContain(message);
+  });
+
+  it('keeps a table-mode slider on canonical state while separately marking its pending target', () => {
+    Object.assign(widthLifecycle, { target: 3000, phase: 'pending', busy: true });
+    const t = mountPanel({
+      filterConfig: {
+        defaults: [2400, 2400, 2400], fixed: false, minHz: 1800, maxHz: 3000, stepHz: 1,
+        table: [1800, 2400, 3000],
+      } as typeof mockProps.filterConfig,
+    });
+
+    expect(t.querySelector<HTMLElement>('[data-filter-width-lifecycle]')?.getAttribute('aria-busy')).toBe('true');
+    expect(t.querySelector<HTMLElement>('[role="slider"]')?.getAttribute('aria-valuenow')).toBe('1');
+    expect(t.querySelector('[data-pending-width-target]')?.textContent).toContain('3kHz');
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
@@ -65,6 +65,9 @@ const mockFilterHandlers = {
   onPbtInnerChange: vi.fn(), onPbtOuterChange: vi.fn(), onPbtReset: vi.fn(),
 };
 const mockFilterArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
+const mockFilterWidthLifecycle = {
+  confirmed: 2400, target: null, phase: 'idle' as const, busy: false, outcome: null,
+};
 
 const mockRfProps = {
   rfGain: 1, squelch: 0, att: 0, pre: 0, digiSel: false, ipPlus: false,
@@ -103,6 +106,7 @@ vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveFilterProps: () => mockFilterProps,
   getFilterHandlers: () => mockFilterHandlers,
   getFilterArmed: () => mockFilterArmed,
+  getFilterWidthCommandLifecycle: () => mockFilterWidthLifecycle,
   deriveRfFrontEndProps: () => mockRfProps,
   getRfFrontEndHandlers: () => mockRfHandlers,
   getPreampArmed: () => mockPreArmed,

--- a/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts
@@ -66,7 +66,7 @@ const mockFilterHandlers = {
 };
 const mockFilterArmed: { armed: boolean; value: number | null } = { armed: false, value: null };
 const mockFilterWidthLifecycle = {
-  confirmed: 2400, target: null, phase: 'idle' as const, busy: false, outcome: null,
+  confirmed: 2400, target: null, phase: 'idle' as const, busy: false, outcome: null, presentation: null,
 };
 
 const mockRfProps = {


### PR DESCRIPTION
## Summary
- show Filter Width pending targets separately from canonical radio-confirmed width
- key bounded lifecycle announcements to immutable presentation transition identity
- freeze terminal target and confirmed values per transition so retained reads cannot reannounce stale history
- keep table-mode HBar visuals controlled by accepted RadioState while emitting raw keyboard/pointer targets
- retain existing FilterPanel mocked-adapter coverage

## Verification
- RED on prior heads: stale-target, retained-canonical, and five optimistic table-input witnesses failed
- `npm test -- src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts`
- `npx eslint src/components-v2/panels/FilterPanel.svelte src/components-v2/panels/__tests__/FilterPanel.isolated.test.ts src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts`
- `npm run check`
- `npm run i18n:check`
- `npm test -- --silent`

Refs #2618