### PR TITLE
feat(#2628): expose Filter Width presentation identity

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -64,21 +64,21 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   it('stays unavailable rather than fabricating a pending or confirmed value without observed width', () => {
     runtimeState.state = state({ main: {} });
     lifecycle.commands = [command()];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null,
     });
   });
   it('keeps canonical observed width separate from a submitted target', () => {
     runtimeState.state = state();
     lifecycle.commands = [command()];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 2400, target: 3000, phase: 'pending', busy: true, outcome: null,
     });
   });
   it('keeps a fresh matching observation acknowledged when a caller only reads the pure accessor', () => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 3000, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([]);
@@ -106,7 +106,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   ])('makes the full projection unavailable from %s evidence', (_case, fieldStatus) => {
     runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: fieldStatus === undefined ? {} : { 'main.filterWidth': fieldStatus } });
     lifecycle.commands = [command({ status: 'acknowledged', ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([]);
@@ -135,7 +135,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   it('keeps a fresh non-matching observation canonical while the acknowledged target remains pending', () => {
     runtimeState.state = state({ main: { filterWidth: 2400 }, observationSeq: 5, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } });
     lifecycle.commands = [command({ status: 'acknowledged', ackObservationSeq: 4, ackFieldObservationTimes: { 'main.filterWidth': 4 } })];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 2400, target: 3000, phase: 'acknowledged', busy: true, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([]);
@@ -149,7 +149,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       id: 'sub-width', params: { width: 2800, receiver: 1 }, status: 'acknowledged', ackObservationSeq: 4,
       ackFieldObservationTimes: { 'sub.filterWidth': 4 },
     })];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 2800, target: 2800, phase: 'acknowledged', busy: true, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([]);
@@ -160,7 +160,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       command({ id: 'older', createdAt: 1, status: 'acknowledged', ackObservationSeq: 4 }),
       command({ id: 'newer', createdAt: 2, params: { width: 2800, receiver: 0 }, status: 'pending' }),
     ];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 3000, target: 2800, phase: 'pending', busy: true, outcome: null,
     });
     expect(lifecycle.confirms).toEqual([]);
@@ -171,7 +171,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       command({ id: 'older', createdAt: 1 }),
       command({ id: 'newer', createdAt: 2, params: { width: 2800, receiver: 0 }, status: 'failed', error: 'rejected' }),
     ];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 2400, target: null, phase: 'idle', busy: false,
       outcome: { phase: 'failed', error: 'rejected' },
     });
@@ -183,7 +183,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   ] as const)('clears busy and retains a bounded %s outcome without changing confirmed truth', (status, error) => {
     runtimeState.state = state({ main: { filterWidth: 2400 } });
     lifecycle.commands = [command({ status, error })];
-    expect(getFilterWidthCommandLifecycle()).toEqual({
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({
       confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: { phase: status, error },
     });
   });
@@ -283,5 +283,67 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     runtimeState.state = state({ main: { filterWidth: 2400 }, sub: { filterWidth: 1800 } });
     expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2600, phase: 'pending', busy: true });
     store.resetCommandLifecycle();
+  });
+  it('projects a fresh frozen presentation DTO with stable lifecycle and transition identities', () => {
+    runtimeState.state = state();
+    lifecycle.commands = [command({ id: 'quoted|id', originalEpoch: 7, status: 'pending' })];
+
+    const first = getFilterWidthCommandLifecycle().presentation;
+    const second = getFilterWidthCommandLifecycle().presentation;
+    expect(first).toEqual({
+      lifecycleId: '[7,"quoted|id"]', transitionId: '[7,"quoted|id","pending"]',
+      receiver: 0, sessionEpoch: 7, target: 3000, status: 'pending',
+    });
+    expect(first).not.toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(first?.lifecycleId).toBe(second?.lifecycleId);
+    expect(first?.transitionId).toBe(second?.transitionId);
+    expect(first).not.toHaveProperty('params');
+    expect(first).not.toHaveProperty('fieldStatus');
+  });
+  it('changes only the transition identity across lifecycle statuses and retains terminal targets', () => {
+    runtimeState.state = state();
+    lifecycle.commands = [command({ status: 'pending' })];
+    const pending = getFilterWidthCommandLifecycle().presentation!;
+    lifecycle.commands[0].status = 'acknowledged';
+    const acknowledged = getFilterWidthCommandLifecycle().presentation!;
+    expect(acknowledged).toMatchObject({ lifecycleId: pending.lifecycleId, target: 3000, status: 'acknowledged' });
+    expect(acknowledged.transitionId).not.toBe(pending.transitionId);
+
+    for (const status of ['confirmed', 'failed', 'timed-out', 'cancelled'] as const) {
+      lifecycle.commands[0].status = status;
+      lifecycle.commands[0].error = status === 'failed' ? 'x'.repeat(300) : undefined;
+      expect(getFilterWidthCommandLifecycle().presentation).toMatchObject({
+        lifecycleId: pending.lifecycleId, receiver: 0, sessionEpoch: 7, target: 3000, status,
+      });
+      expect(getFilterWidthCommandLifecycle().presentation?.transitionId).not.toBe(acknowledged.transitionId);
+    }
+    expect(getFilterWidthCommandLifecycle().presentation).not.toHaveProperty('error');
+    lifecycle.commands[0].status = 'failed'; lifecycle.commands[0].error = 'x'.repeat(300);
+    expect(getFilterWidthCommandLifecycle().presentation?.error).toHaveLength(256);
+  });
+  it('isolates receivers and gives reused command ids in a later session a distinct identity', () => {
+    runtimeState.state = state({ active: 'MAIN', sub: { filterWidth: 2100 }, fieldStatus: {
+      'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+      'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+    } });
+    lifecycle.commands = [
+      command({ id: 'same', originalEpoch: 7, params: { width: 3000, receiver: 0 } }),
+      command({ id: 'same', originalEpoch: 8, createdAt: 2, params: { width: 2100, receiver: 1 } }),
+    ];
+    const main = getFilterWidthCommandLifecycle().presentation!;
+    runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 2100 }, fieldStatus: {
+      'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+      'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+    } });
+    const sub = getFilterWidthCommandLifecycle().presentation!;
+    expect(main).toMatchObject({ receiver: 0, target: 3000, sessionEpoch: 7 });
+    expect(sub).toMatchObject({ receiver: 1, target: 2100, sessionEpoch: 8 });
+    expect(sub.lifecycleId).not.toBe(main.lifecycleId);
+    runtimeState.state = state({ active: 'MAIN', sub: { filterWidth: 2100 }, fieldStatus: {
+      'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+      'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
+    } });
+    expect(getFilterWidthCommandLifecycle().presentation?.transitionId).toBe(main.transitionId);
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -215,10 +215,13 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 3000 }, fieldStatus: { 'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 74 } } });
     emitAcceptedState(runtimeState.state);
     expect(store.getCommandLifecycle('real-ack', 9)?.status).toBe('confirmed');
-    expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } });
+    const retained = getLiveView().presentation;
+    expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' }, presentation: {
+      receiver: 1, sessionEpoch: 9, target: 3000, status: 'confirmed',
+    } });
     vi.advanceTimersByTime(5_000);
     expect(store.getCommandLifecycle('real-ack', 9)).toBeUndefined();
-    expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'idle', busy: false, outcome: null });
+    expect(getLiveView()).toMatchObject({ confirmed: 3000, phase: 'idle', busy: false, outcome: null, presentation: null });
     commandRadio.current = null;
     store.beginCommand({ id: 'cold-ack', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 9 });
     store.acknowledgeCommand('cold-ack', 9, 10);
@@ -233,7 +236,9 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     emitAcceptedState(runtimeState.state);
     expect(getLiveView()).toMatchObject({ confirmed: 2800, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } });
     expect(store.getCommandLifecycle('cold-ack', 9)?.status).toBe('confirmed');
+    expect(getLiveView().presentation?.lifecycleId).not.toBe(retained?.lifecycleId);
     store.resetCommandLifecycle();
+    expect(getLiveView().presentation).toBeNull();
   });
   it('never resurfaces a superseded receiver lifecycle after its newer outcome retires', async () => {
     vi.useFakeTimers();
@@ -253,12 +258,13 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     store.failCommand(newer.id, newer.originalEpoch, 7, 'newer rejected');
     expect(store.isCommandLifecycleSuperseded(old)).toBe(true);
+    expect(getLiveView().presentation).toMatchObject({ target: 2800, status: 'failed' });
 
     vi.advanceTimersByTime(3_000);
     store.acknowledgeCommand(old.id, old.originalEpoch, 7);
     vi.advanceTimersByTime(2_000);
     expect(store.getCommandLifecycle(newer.id, newer.originalEpoch)).toBeUndefined();
-    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: null });
+    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: null, presentation: null });
 
     store.failCommand(old.id, old.originalEpoch, 7, 'late failure');
     expect(getLiveView()).toMatchObject({ confirmed: 2400, target: null, phase: 'idle', busy: false, outcome: null });
@@ -274,14 +280,17 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     });
     expect(store.isCommandLifecycleSuperseded(sub)).toBe(false);
     expect(getLiveView()).toMatchObject({ confirmed: 1800, target: 2100, phase: 'pending', busy: true });
+    const subPresentation = getLiveView().presentation;
 
     store.resetCommandLifecycle();
+    expect(getLiveView().presentation).toBeNull();
     const fresh = store.beginCommand({
-      id: 'fresh-main', name: 'set_filter_width', params: { width: 2600, receiver: 0 }, originalEpoch: 8,
+      id: 'sub', name: 'set_filter_width', params: { width: 2600, receiver: 0 }, originalEpoch: 8,
     });
     expect(store.isCommandLifecycleSuperseded(fresh)).toBe(false);
     runtimeState.state = state({ main: { filterWidth: 2400 }, sub: { filterWidth: 1800 } });
     expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2600, phase: 'pending', busy: true });
+    expect(getLiveView().presentation?.lifecycleId).not.toBe(subPresentation?.lifecycleId);
     store.resetCommandLifecycle();
   });
   it('projects a fresh frozen presentation DTO with stable lifecycle and transition identities', () => {
@@ -310,17 +319,48 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(acknowledged).toMatchObject({ lifecycleId: pending.lifecycleId, target: 3000, status: 'acknowledged' });
     expect(acknowledged.transitionId).not.toBe(pending.transitionId);
 
+    const transitionIds = [pending.transitionId, acknowledged.transitionId];
     for (const status of ['confirmed', 'failed', 'timed-out', 'cancelled'] as const) {
       lifecycle.commands[0].status = status;
       lifecycle.commands[0].error = status === 'failed' ? 'x'.repeat(300) : undefined;
       expect(getFilterWidthCommandLifecycle().presentation).toMatchObject({
         lifecycleId: pending.lifecycleId, receiver: 0, sessionEpoch: 7, target: 3000, status,
       });
-      expect(getFilterWidthCommandLifecycle().presentation?.transitionId).not.toBe(acknowledged.transitionId);
+      const transitionId = getFilterWidthCommandLifecycle().presentation?.transitionId;
+      expect(transitionId).not.toBe(acknowledged.transitionId);
+      transitionIds.push(transitionId!);
     }
+    expect(new Set(transitionIds)).toHaveLength(6);
     expect(getFilterWidthCommandLifecycle().presentation).not.toHaveProperty('error');
     lifecycle.commands[0].status = 'failed'; lifecycle.commands[0].error = 'x'.repeat(300);
     expect(getFilterWidthCommandLifecycle().presentation?.error).toHaveLength(256);
+  });
+  it('keeps real-store terminal snapshots until GC and gives every transition a unique identity', async () => {
+    vi.useFakeTimers(); vi.doUnmock('$lib/stores/commands.svelte'); vi.resetModules();
+    const store = await import('$lib/stores/commands.svelte');
+    const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
+    const transitions: string[] = [];
+    const start = (id: string, width: number, timeoutMs?: number) => {
+      runtimeState.state = state(); emitAcceptedState(runtimeState.state); store.resetCommandLifecycle();
+      return store.beginCommand({ id, name: 'set_filter_width', params: { width }, originalEpoch: 12, timeoutMs });
+    };
+    const assertRetainedThenGc = (target: number, status: string) => {
+      const presentation = getLiveView().presentation;
+      expect(presentation).toMatchObject({ target, status, sessionEpoch: 12, receiver: 0 });
+      transitions.push(presentation!.transitionId); vi.advanceTimersByTime(5_000);
+      expect(getLiveView().presentation).toBeNull();
+    };
+
+    const confirmed = start('confirmed', 3000, 50);
+    transitions.push(getLiveView().presentation!.transitionId);
+    store.acknowledgeCommand(confirmed.id, 12, 12); transitions.push(getLiveView().presentation!.transitionId);
+    runtimeState.state = state({ main: { filterWidth: 3000 }, fieldStatus: { 'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 } } }); emitAcceptedState(runtimeState.state);
+    assertRetainedThenGc(3000, 'confirmed');
+    const failed = start('failed', 2800); store.failCommand(failed.id, 12, 12, 'rejected'); assertRetainedThenGc(2800, 'failed');
+    start('cancelled', 2600); store.cancelPendingCommands(12); assertRetainedThenGc(2600, 'cancelled');
+    start('timed-out', 2400, 1); vi.advanceTimersByTime(1); assertRetainedThenGc(2400, 'timed-out');
+    expect(new Set(transitions)).toHaveLength(6);
+    store.resetCommandLifecycle();
   });
   it('isolates receivers and gives reused command ids in a later session a distinct identity', () => {
     runtimeState.state = state({ active: 'MAIN', sub: { filterWidth: 2100 }, fieldStatus: {

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -245,9 +245,21 @@ export function getPendingFrequencyHz(receiver: 0 | 1): number | null {
 
 export type FilterWidthCommandPhase = 'unavailable' | 'idle' | 'pending' | 'acknowledged' | 'confirmed';
 export type FilterWidthCommandOutcome = 'confirmed' | 'failed' | 'timed-out' | 'cancelled';
+export interface FilterWidthLifecyclePresentation {
+  /** Opaque correlation value; consumers must compare it, never parse it. */
+  readonly lifecycleId: string;
+  /** Opaque correlation value for this lifecycle status transition. */
+  readonly transitionId: string;
+  readonly receiver: 0 | 1;
+  readonly sessionEpoch: number;
+  readonly target: number;
+  readonly status: 'pending' | 'acknowledged' | FilterWidthCommandOutcome;
+  readonly error?: string;
+}
 export interface FilterWidthCommandLifecycleView {
   confirmed: number | null; target: number | null; phase: FilterWidthCommandPhase; busy: boolean;
   outcome: { phase: FilterWidthCommandOutcome; error?: string } | null;
+  presentation: Readonly<FilterWidthLifecyclePresentation> | null;
 }
 
 function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; fieldPath: string; fieldStatus: NonNullable<ServerState['fieldStatus']>[string] | undefined } | null {
@@ -275,22 +287,43 @@ function latestFilterWidthLifecycle(receiver: 0 | 1) {
   return latest;
 }
 
+function filterWidthPresentation(
+  command: NonNullable<ReturnType<typeof latestFilterWidthLifecycle>>, receiver: 0 | 1,
+): Readonly<FilterWidthLifecyclePresentation> {
+  const target = command.params.width as number;
+  const lifecycleId = JSON.stringify([command.originalEpoch, command.id]);
+  const terminal = command.status === 'confirmed' || command.status === 'failed'
+    || command.status === 'timed-out' || command.status === 'cancelled';
+  const error = terminal && typeof command.error === 'string' && command.error.length > 0
+    ? command.error.slice(0, 256) : undefined;
+  return Object.freeze({
+    lifecycleId,
+    transitionId: JSON.stringify([command.originalEpoch, command.id, command.status]),
+    receiver,
+    sessionEpoch: command.originalEpoch,
+    target,
+    status: command.status,
+    ...(error === undefined ? {} : { error }),
+  });
+}
+
 export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleView {
   const observed = activeFilterWidthReceiver();
-  if (!observed) return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null };
+  if (!observed) return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null, presentation: null };
 
   const command = latestFilterWidthLifecycle(observed.receiver);
-  if (!command) return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null };
+  if (!command) return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null, presentation: null };
+  const presentation = filterWidthPresentation(command, observed.receiver);
   if (command.status === 'confirmed') {
-    return { confirmed: observed.width, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' } };
+    return { confirmed: observed.width, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' }, presentation };
   }
   if (command.status === 'failed' || command.status === 'timed-out' || command.status === 'cancelled') {
-    return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: { phase: command.status, error: command.error } };
+    return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: { phase: command.status, error: command.error }, presentation };
   }
 
   const target = command.params.width as number;
-  if (command.status === 'acknowledged') return { confirmed: observed.width, target, phase: 'acknowledged', busy: true, outcome: null };
-  return { confirmed: observed.width, target, phase: 'pending', busy: true, outcome: null };
+  if (command.status === 'acknowledged') return { confirmed: observed.width, target, phase: 'acknowledged', busy: true, outcome: null, presentation };
+  return { confirmed: observed.width, target, phase: 'pending', busy: true, outcome: null, presentation };
 }
 
 // ── Pending discrete-control targets (MOR-1441 leg 2) ──


### PR DESCRIPTION
## Summary
- expose a frozen, backend-neutral Filter Width lifecycle presentation snapshot
- retain terminal targets and stable identity through the existing lifecycle window
- cover transition identity, receiver isolation, and control-session reuse

## Verification
- `npm test -- src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.component.test.ts src/lib/stores/__tests__/commands.test.ts`
- `npx eslint src/lib/runtime/adapters/panel-adapters.ts src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts`
- `npm run check`
- `npm test`

Refs #2628