### PR TITLE
feat(value-control): add controlled HBar rendering

### DIFF
--- a/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
@@ -35,6 +35,7 @@
     unit?: string;
     shortcutHint?: string | null;
     title?: string | null;
+    optimistic?: boolean;
   }
 
   let {
@@ -60,6 +61,7 @@
     unit = '',
     shortcutHint = null,
     title = null,
+    optimistic = true,
   }: Props = $props();
 
   let containerEl: HTMLDivElement | null = $state(null);
@@ -92,12 +94,15 @@
   });
 
   // Derived values
-  let fillPercent = $derived(getFillPercent(localValue, min, max));
+  // A controlled HBar may request a target without presenting it as accepted.
+  // The canonical parent prop remains both render source and interaction base.
+  let renderedValue = $derived(optimistic ? localValue : value);
+  let fillPercent = $derived(getFillPercent(renderedValue, min, max));
   let effectiveDefault = $derived(defaultValue ?? min);
   let effectiveFill = $derived(fillGradient
     ? `linear-gradient(90deg, ${fillGradient.join(', ')})`
     : (fillColor ?? accentColor));
-  let displayValue = $derived(displayFn ? displayFn(localValue) : `${localValue}${unit ? '\u00a0' + unit : ''}`);
+  let displayValue = $derived(displayFn ? displayFn(renderedValue) : `${renderedValue}${unit ? '\u00a0' + unit : ''}`);
   
   // Adaptive wheel multiplier based on range (normalize to ~255 baseline)
   let adaptiveWheelMultiplier = $derived(Math.max(1, Math.ceil((max - min) / 255)));
@@ -111,7 +116,7 @@
   });
 
   function emitChange(newValue: number, immediate = false) {
-    if (newValue !== localValue) {
+    if (optimistic && newValue !== localValue) {
       localValue = newValue;
     }
     if (newValue !== value) {
@@ -165,11 +170,11 @@
     const effectiveStep = e.shiftKey ? step / fineStepDivisor : step * wheelMultiplier;
     const direction = e.deltaY > 0 ? -1 : 1;
     const newValue = clamp(
-      snapToStep(localValue + direction * effectiveStep, effectiveStep, min),
+      snapToStep(renderedValue + direction * effectiveStep, effectiveStep, min),
       min,
       max,
     );
-    localValue = newValue;
+    if (optimistic) localValue = newValue;
     markWheelActive();
     onChange(newValue);
   }
@@ -177,7 +182,7 @@
   function handleKeyDown(e: KeyboardEvent) {
     if (disabled) return;
 
-    const newValue = handleKeyboardStep(localValue, e.key, step, fineStepDivisor, min, max, e.shiftKey);
+    const newValue = handleKeyboardStep(renderedValue, e.key, step, fineStepDivisor, min, max, e.shiftKey);
     if (newValue !== null) {
       e.preventDefault();
       emitChange(newValue);

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -31,6 +31,8 @@
     showAllTicks?: boolean;
     /** Discrete renderer: how step marks are drawn (default ruler). */
     tickStyle?: 'ruler' | 'led' | 'notch';
+    /** HBar-only: keep the rendered value parent-controlled until it changes. */
+    optimistic?: boolean;
     // Behavior
     onChange: (value: number) => void;
     debounceMs?: number;
@@ -68,6 +70,7 @@
     tickLabels = [],
     showAllTicks = true,
     tickStyle = 'ruler',
+    optimistic = true,
     onChange,
     debounceMs = 50,
     disabled = false,
@@ -122,6 +125,10 @@
     tickStyle,
   });
 
+  // This is intentionally not part of commonProps: skin and non-HBar renderer
+  // contracts remain unchanged.
+  let hbarProps = $derived({ ...commonProps, optimistic });
+
   // Resolve skin component for the current renderer type (undefined = use built-in)
   let skinComponent = $derived(
     skin
@@ -141,7 +148,7 @@
     <SkinRenderer {...commonProps} />
   {/if}
 {:else if renderer === 'hbar'}
-  <HBarRenderer {...commonProps} />
+  <HBarRenderer {...hbarProps} />
 {:else if renderer === 'bipolar'}
   <BipolarRenderer {...commonProps} />
 {:else if renderer === 'knob'}

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import ValueControl from '../ValueControl.svelte';
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+
+function mountReactive(props: Record<string, unknown>) {
+  const state = $state(props);
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  roots.push(target);
+  // The reactive prop object is the parent canonical source for this mounted witness.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(ValueControl as any, { target, props: state });
+  components.push(component);
+  flushSync();
+  return { state, target };
+}
+
+function slider(target: HTMLElement): HTMLElement {
+  return target.querySelector('[role="slider"]') as HTMLElement;
+}
+
+function visibleValue(target: HTMLElement): string | null {
+  return target.querySelector('.vc-value')?.textContent ?? null;
+}
+
+function fill(target: HTMLElement): string | null {
+  return target.querySelector('.vc-hbar')?.getAttribute('style') ?? null;
+}
+
+function pointer(target: HTMLElement, x: number) {
+  const control = slider(target) as HTMLElement & { setPointerCapture?: (pointerId: number) => void };
+  control.setPointerCapture = vi.fn();
+  const event = new PointerEvent('pointerdown', { bubbles: true, clientX: x, pointerId: 1 });
+  control.dispatchEvent(event);
+}
+
+beforeEach(() => {
+  components = [];
+  roots = [];
+});
+
+afterEach(() => {
+  components.forEach((component) => { void unmount(component); });
+  roots.forEach((root) => root.remove());
+});
+
+const baseProps = {
+  value: 20,
+  min: 0,
+  max: 100,
+  step: 10,
+  label: 'Controlled',
+  renderer: 'hbar' as const,
+  debounceMs: 0,
+};
+
+describe('ValueControl controlled HBar rendering', () => {
+  it('emits a controlled pointer target while display, fill, and ARIA remain canonical', () => {
+    const onChange = vi.fn();
+    const { target } = mountReactive({ ...baseProps, optimistic: false, onChange });
+    vi.spyOn(target.querySelector('.vc-hbar') as HTMLElement, 'getBoundingClientRect')
+      .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+
+    pointer(target, 80);
+    flushSync();
+
+    expect(onChange).toHaveBeenCalledWith(80);
+    expect(visibleValue(target)).toContain('20');
+    expect(fill(target)).toContain('--vc-fill-percent: 20%');
+    expect(slider(target).getAttribute('aria-valuenow')).toBe('20');
+  });
+
+  it('uses canonical value for controlled keyboard arithmetic until the parent accepts', () => {
+    const onChange = vi.fn();
+    const { target } = mountReactive({ ...baseProps, optimistic: false, onChange });
+
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    flushSync();
+
+    expect(onChange).toHaveBeenNthCalledWith(1, 30);
+    expect(onChange).toHaveBeenNthCalledWith(2, 30);
+    expect(visibleValue(target)).toContain('20');
+  });
+
+  it('keeps a same-value parent update authoritative after a rejected controlled request', () => {
+    const onChange = vi.fn();
+    const { state, target } = mountReactive({ ...baseProps, optimistic: false, onChange });
+
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    state.value = 20;
+    flushSync();
+
+    expect(onChange).toHaveBeenCalledWith(30);
+    expect(visibleValue(target)).toContain('20');
+    expect(fill(target)).toContain('--vc-fill-percent: 20%');
+  });
+
+  it('adopts an accepted parent value immediately and uses it for the next keyboard step', () => {
+    const onChange = vi.fn();
+    const { state, target } = mountReactive({ ...baseProps, optimistic: false, onChange });
+
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    state.value = 30;
+    flushSync();
+
+    expect(visibleValue(target)).toContain('30');
+    expect(fill(target)).toContain('--vc-fill-percent: 30%');
+    expect(slider(target).getAttribute('aria-valuenow')).toBe('30');
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(onChange).toHaveBeenLastCalledWith(40);
+  });
+
+  it('preserves immediate optimistic HBar rendering by default', () => {
+    const onChange = vi.fn();
+    const { target } = mountReactive({ ...baseProps, onChange });
+
+    slider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    flushSync();
+
+    expect(onChange).toHaveBeenCalledWith(30);
+    expect(visibleValue(target)).toContain('30');
+    expect(fill(target)).toContain('--vc-fill-percent: 30%');
+  });
+});


### PR DESCRIPTION
Refs #2630

## Summary
- add an opt-in, built-in-HBar-only controlled rendering mode
- retain canonical parent value until an explicit parent update
- preserve default optimistic HBar behavior

## Validation
- `npm test -- src/components-v2/controls/value-control/__tests__/ValueControl.test.ts src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts`
- `npx eslint src/components-v2/controls/value-control/ValueControl.svelte src/components-v2/controls/value-control/HBarRenderer.svelte src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts`
- `npm run check`
- `npm test -- --silent`