### PR TITLE
fix: show pending state for Notch dialog choices

### DIFF
--- a/frontend/src/components-v2/panels/DspPanel.svelte
+++ b/frontend/src/components-v2/panels/DspPanel.svelte
@@ -30,6 +30,22 @@
   let manualNotchArmed = $derived(getManualNotchArmed());
   let autoNotchArmed = $derived(getAutoNotchArmed());
   const notchArmedIdBase = $props.id();
+  // MOR-1672: the dialog uses the same two truthful command strands as the
+  // top-level buttons.  A mode is still selected only from `notchMode`; these
+  // facts merely identify the requested choice while radio confirmation is
+  // delayed.  OFF is a grouped target only when both real false writes are in
+  // flight, never after one partial strand.
+  let autoNotchChoicePending = $derived(autoNotchArmed.armed && autoNotchArmed.value === true);
+  let manualNotchChoicePending = $derived(manualNotchArmed.armed && manualNotchArmed.value === true);
+  let offNotchChoicePending = $derived(
+    autoNotchArmed.armed
+      && autoNotchArmed.value === false
+      && manualNotchArmed.armed
+      && manualNotchArmed.value === false,
+  );
+  let hasNotchChoicePending = $derived(
+    autoNotchChoicePending || manualNotchChoicePending || offNotchChoicePending,
+  );
 
   let nrMode = $derived(p.nrMode);
   let nrLevel = $derived(p.nrLevel);
@@ -402,16 +418,42 @@
     <div class="menu-title">Notch</div>
     <div class="dsp-modal-block dsp-mode-grid">
       {#each notchOptions as option}
-        <HardwareButton
-          active={notchMode === option.value}
-          indicator="edge-left"
-          color="cyan"
-          onclick={() => handleNotchModalMode(option.value)}
+        {@const mode = option.value as 'off' | 'auto' | 'manual'}
+        {@const isPending = mode === 'off'
+          ? offNotchChoicePending
+          : mode === 'auto'
+            ? autoNotchChoicePending
+            : manualNotchChoicePending}
+        {@const pendingId = `${notchArmedIdBase}-dialog-${mode}`}
+        <div
+          class="notch-mode-choice"
+          data-notch-mode-choice={mode}
+          data-notch-pending-target={isPending ? mode : undefined}
+          role="group"
+          aria-label={`Notch mode ${option.label}`}
+          aria-busy={isPending}
         >
-          {option.label}
-        </HardwareButton>
+          <HardwareButton
+            active={notchMode === option.value}
+            indicator="edge-left"
+            color="cyan"
+            armed={isPending}
+            describedBy={isPending ? pendingId : undefined}
+            onclick={() => handleNotchModalMode(option.value)}
+          >
+            {option.label}
+          </HardwareButton>
+          {#if isPending}
+            <span id={pendingId} class="sr-only">{t('core.dsp.notch.pendingAnnouncement')}</span>
+          {/if}
+        </div>
       {/each}
     </div>
+    {#if hasNotchChoicePending}
+      <span class="sr-only" aria-live="polite" aria-atomic="true" data-notch-mode-live>
+        {t('core.dsp.notch.pendingAnnouncement')}
+      </span>
+    {/if}
     {#if notchMode === 'manual'}
       <ValueControl
         label="Notch Position"
@@ -538,6 +580,17 @@
   }
 
   .dsp-mode-grid > :global(button) {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .notch-mode-choice {
+    display: flex;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .notch-mode-choice > :global(button) {
     flex: 1 1 0;
     min-width: 0;
   }

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -36,13 +36,14 @@ const mockHandlers = {
 // MOR-1536: DspPanel now also reads the notch armed signal — default
 // unarmed here, this file's tests are not about that behavior (covered by
 // `mor1536-armed-adoption.test.ts`).
-const unarmed = { armed: false, value: null };
+const autoNotchArmed: { armed: boolean; value: boolean | null } = { armed: false, value: null };
+const manualNotchArmed: { armed: boolean; value: boolean | null } = { armed: false, value: null };
 
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveDspProps: () => mockProps,
   getDspHandlers: () => mockHandlers,
-  getAutoNotchArmed: () => unarmed,
-  getManualNotchArmed: () => unarmed,
+  getAutoNotchArmed: () => autoNotchArmed,
+  getManualNotchArmed: () => manualNotchArmed,
 }));
 
 import DspPanel from '../DspPanel.svelte';
@@ -78,6 +79,10 @@ beforeEach(() => {
   mockHandlers.onNbWidthChange = vi.fn();
   mockHandlers.onManualNotchWidthChange = vi.fn();
   mockHandlers.onAgcTimeChange = vi.fn();
+  autoNotchArmed.armed = false;
+  autoNotchArmed.value = null;
+  manualNotchArmed.armed = false;
+  manualNotchArmed.value = null;
 });
 
 afterEach(() => {
@@ -236,8 +241,9 @@ describe('DspPanel mobile notch dialog (MOR-1631)', () => {
   }
 
   function modeButton(t: HTMLElement, mode: string): HTMLButtonElement {
-    const button = Array.from(t.querySelectorAll<HTMLButtonElement>('[aria-label="Notch filter settings"] button')).find(
-      (candidate) => candidate.textContent?.trim() === mode,
+    const modeValue = mode === 'MAN' ? 'manual' : mode.toLowerCase();
+    const button = t.querySelector<HTMLButtonElement>(
+      `[aria-label="Notch filter settings"] [data-notch-mode-choice="${modeValue}"] button`,
     );
     expect(button).toBeDefined();
     return button!;
@@ -290,5 +296,74 @@ describe('DspPanel mobile notch dialog (MOR-1631)', () => {
     expect(modeButton(t, 'OFF').dataset.active).toBe('true');
     expect(modeButton(t, 'MAN').dataset.active).toBe('false');
     expect(t.querySelector('[aria-label="Notch Position"]')).toBeNull();
+  });
+
+  it.each([
+    ['OFF', 'off'],
+    ['AUTO', 'auto'],
+    ['MAN', 'manual'],
+  ] as const)('uses the dialog-scoped %s choice selector and preserves its exact command target', (label, targetMode) => {
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+
+    modeButton(t, label).click();
+
+    expect(mockHandlers.onNotchModeChange).toHaveBeenCalledExactlyOnceWith(targetMode);
+  });
+
+  it.each([
+    ['AUTO', () => { autoNotchArmed.armed = true; autoNotchArmed.value = true; }],
+    ['MAN', () => { manualNotchArmed.armed = true; manualNotchArmed.value = true; }],
+  ] as const)('marks the delayed %s confirmation on its exact dialog choice without changing confirmed selection', (label, arm) => {
+    arm();
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+
+    const choice = t.querySelector<HTMLElement>(
+      `[aria-label="Notch filter settings"] [data-notch-mode-choice="${label === 'MAN' ? 'manual' : label.toLowerCase()}"]`,
+    );
+    expect(choice?.getAttribute('aria-busy')).toBe('true');
+    expect(modeButton(t, label).dataset.armed).toBe('true');
+    expect(modeButton(t, 'OFF').dataset.active).toBe('true');
+    expect(modeButton(t, label).dataset.active).toBe('false');
+    expect(t.querySelector('[data-notch-mode-live]')?.textContent).toContain('Pending');
+  });
+
+  it('treats OFF as one pending choice only after both false command strands are armed', () => {
+    autoNotchArmed.armed = true;
+    autoNotchArmed.value = false;
+    const partial = mountPanel({ notchMode: 'manual' });
+    openNotchModal(partial);
+    expect(partial.querySelector('[data-notch-mode-choice="off"]')?.getAttribute('aria-busy')).toBe('false');
+    expect(modeButton(partial, 'OFF').dataset.armed).toBeUndefined();
+
+    manualNotchArmed.armed = true;
+    manualNotchArmed.value = false;
+    const grouped = mountPanel({ notchMode: 'manual' });
+    openNotchModal(grouped);
+    expect(grouped.querySelector('[data-notch-mode-choice="off"]')?.getAttribute('aria-busy')).toBe('true');
+    expect(modeButton(grouped, 'OFF').dataset.armed).toBe('true');
+    expect(modeButton(grouped, 'MAN').dataset.active).toBe('true');
+  });
+
+  it.each(['failure', 'timeout'] as const)('clears the dialog pending marker after a %s terminal lifecycle outcome', () => {
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+
+    expect(t.querySelector('[data-notch-mode-choice="auto"]')?.getAttribute('aria-busy')).toBe('false');
+    expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+    expect(t.querySelector('[data-notch-mode-live]')).toBeNull();
+  });
+
+  it('keeps an out-of-band confirmed mode selected while a superseding target is pending', () => {
+    autoNotchArmed.armed = true;
+    autoNotchArmed.value = true;
+    const t = mountPanel({ notchMode: 'manual' });
+    openNotchModal(t);
+
+    expect(modeButton(t, 'MAN').dataset.active).toBe('true');
+    expect(modeButton(t, 'AUTO').dataset.active).toBe('false');
+    expect(modeButton(t, 'AUTO').dataset.armed).toBe('true');
+    expect(t.querySelector('[aria-label="Notch Position"]')).not.toBeNull();
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/DspPanel.component.test.ts
@@ -33,20 +33,53 @@ const mockHandlers = {
   onAgcTimeChange: vi.fn(),
 };
 
-// MOR-1536: DspPanel now also reads the notch armed signal — default
-// unarmed here, this file's tests are not about that behavior (covered by
-// `mor1536-armed-adoption.test.ts`).
-const autoNotchArmed: { armed: boolean; value: boolean | null } = { armed: false, value: null };
-const manualNotchArmed: { armed: boolean; value: boolean | null } = { armed: false, value: null };
-
-vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
-  deriveDspProps: () => mockProps,
-  getDspHandlers: () => mockHandlers,
-  getAutoNotchArmed: () => autoNotchArmed,
-  getManualNotchArmed: () => manualNotchArmed,
+const runtimeState = vi.hoisted(() => ({
+  state: null as {
+    active: 'MAIN' | 'SUB';
+    main: Record<string, unknown>;
+    sub: Record<string, unknown>;
+    observationSeq?: number;
+  } | null,
+  notify: () => {},
 }));
+const mockProjection = vi.hoisted(() => ({ notify: () => {} }));
+
+vi.mock('$lib/runtime/frontend-runtime', async () => {
+  const { createSubscriber } = await import('svelte/reactivity');
+  let update = () => {};
+  const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
+  runtimeState.notify = () => update();
+  return {
+    runtime: {
+      get state() { subscribe(); return runtimeState.state; },
+      get caps() { return null; },
+    },
+  };
+});
+
+vi.mock('$lib/runtime/adapters/panel-adapters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/adapters/panel-adapters')>();
+  const { createSubscriber } = await import('svelte/reactivity');
+  let update = () => {};
+  const subscribe = createSubscriber((notify) => { update = notify; return () => {}; });
+  mockProjection.notify = () => update();
+  return {
+    ...actual,
+    deriveDspProps: () => {
+      subscribe();
+      return { ...mockProps };
+    },
+    getDspHandlers: () => mockHandlers,
+  };
+});
 
 import DspPanel from '../DspPanel.svelte';
+import {
+  acknowledgeCommand,
+  beginCommand,
+  failCommand,
+  resetCommandLifecycle,
+} from '$lib/stores/commands.svelte';
 
 let components: ReturnType<typeof mount>[] = [];
 
@@ -61,6 +94,7 @@ function mountPanel(overrides?: Partial<typeof mockProps>) {
 }
 
 beforeEach(() => {
+  resetCommandLifecycle();
   components = [];
   Object.assign(mockProps, {
     nrMode: 0, nrLevel: 5, nbActive: false, nbLevel: 128,
@@ -79,14 +113,19 @@ beforeEach(() => {
   mockHandlers.onNbWidthChange = vi.fn();
   mockHandlers.onManualNotchWidthChange = vi.fn();
   mockHandlers.onAgcTimeChange = vi.fn();
-  autoNotchArmed.armed = false;
-  autoNotchArmed.value = null;
-  manualNotchArmed.armed = false;
-  manualNotchArmed.value = null;
+  runtimeState.state = {
+    active: 'MAIN',
+    main: { autoNotch: false, manualNotch: false },
+    sub: {},
+    observationSeq: 1,
+  };
 });
 
 afterEach(() => {
   components.forEach((c) => unmount(c));
+  resetCommandLifecycle();
+  runtimeState.state = null;
+  vi.useRealTimers();
   document.body.innerHTML = '';
 });
 
@@ -226,6 +265,22 @@ describe('DspPanel manual-notch position (MOR-1633)', () => {
 });
 
 describe('DspPanel mobile notch dialog (MOR-1631)', () => {
+  let lifecycleSerial = 0;
+
+  function beginNotchCommand(
+    strand: 'auto' | 'manual', on: boolean, timeoutMs = 5_000,
+  ) {
+    const name = strand === 'auto' ? 'set_auto_notch' : 'set_manual_notch';
+    lifecycleSerial += 1;
+    return beginCommand({
+      id: `${name}-${lifecycleSerial}`,
+      name,
+      params: { on, receiver: 0 },
+      originalEpoch: 1,
+      timeoutMs,
+    });
+  }
+
   function openNotchModal(t: HTMLElement): void {
     vi.useFakeTimers();
     try {
@@ -312,12 +367,13 @@ describe('DspPanel mobile notch dialog (MOR-1631)', () => {
   });
 
   it.each([
-    ['AUTO', () => { autoNotchArmed.armed = true; autoNotchArmed.value = true; }],
-    ['MAN', () => { manualNotchArmed.armed = true; manualNotchArmed.value = true; }],
-  ] as const)('marks the delayed %s confirmation on its exact dialog choice without changing confirmed selection', (label, arm) => {
-    arm();
+    ['AUTO', 'auto'],
+    ['MAN', 'manual'],
+  ] as const)('marks the delayed %s confirmation on its exact dialog choice without changing confirmed selection', (label, strand) => {
     const t = mountPanel({ notchMode: 'off' });
     openNotchModal(t);
+    beginNotchCommand(strand, true);
+    flushSync();
 
     const choice = t.querySelector<HTMLElement>(
       `[aria-label="Notch filter settings"] [data-notch-mode-choice="${label === 'MAN' ? 'manual' : label.toLowerCase()}"]`,
@@ -330,36 +386,119 @@ describe('DspPanel mobile notch dialog (MOR-1631)', () => {
   });
 
   it('treats OFF as one pending choice only after both false command strands are armed', () => {
-    autoNotchArmed.armed = true;
-    autoNotchArmed.value = false;
-    const partial = mountPanel({ notchMode: 'manual' });
-    openNotchModal(partial);
-    expect(partial.querySelector('[data-notch-mode-choice="off"]')?.getAttribute('aria-busy')).toBe('false');
-    expect(modeButton(partial, 'OFF').dataset.armed).toBeUndefined();
+    const t = mountPanel({ notchMode: 'manual' });
+    openNotchModal(t);
 
-    manualNotchArmed.armed = true;
-    manualNotchArmed.value = false;
-    const grouped = mountPanel({ notchMode: 'manual' });
-    openNotchModal(grouped);
-    expect(grouped.querySelector('[data-notch-mode-choice="off"]')?.getAttribute('aria-busy')).toBe('true');
-    expect(modeButton(grouped, 'OFF').dataset.armed).toBe('true');
-    expect(modeButton(grouped, 'MAN').dataset.active).toBe('true');
+    beginNotchCommand('auto', false);
+    flushSync();
+    expect(t.querySelector('[data-notch-mode-choice="off"]')?.getAttribute('aria-busy')).toBe('false');
+    expect(modeButton(t, 'OFF').dataset.armed).toBeUndefined();
+
+    beginNotchCommand('manual', false);
+    flushSync();
+    expect(t.querySelector('[data-notch-mode-choice="off"]')?.getAttribute('aria-busy')).toBe('true');
+    expect(modeButton(t, 'OFF').dataset.armed).toBe('true');
+    expect(modeButton(t, 'MAN').dataset.active).toBe('true');
   });
 
-  it.each(['failure', 'timeout'] as const)('clears the dialog pending marker after a %s terminal lifecycle outcome', () => {
+  it('does not resurrect an older AUTO target after its newer same-key command fails and is retained', () => {
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    beginNotchCommand('auto', true, 60_000);
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBe('true');
+
+    vi.setSystemTime(1_001);
+    const newer = beginNotchCommand('auto', false, 60_000);
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+    expect(modeButton(t, 'OFF').dataset.armed).toBeUndefined();
+
+    failCommand(newer.id, newer.originalEpoch, 1, 'expected component-test failure');
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+    expect(t.querySelector('[data-notch-mode-live]')).toBeNull();
+
+    vi.advanceTimersByTime(5_001);
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+  });
+
+  it('does not resurrect an older MAN target after its newer same-key command times out', () => {
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+    vi.useFakeTimers();
+
+    beginNotchCommand('manual', true, 60_000);
+    flushSync();
+    expect(modeButton(t, 'MAN').dataset.armed).toBe('true');
+
+    beginNotchCommand('manual', false, 100);
+    flushSync();
+    expect(modeButton(t, 'MAN').dataset.armed).toBeUndefined();
+
+    vi.advanceTimersByTime(101);
+    flushSync();
+    expect(modeButton(t, 'MAN').dataset.armed).toBeUndefined();
+    expect(t.querySelector('[data-notch-mode-live]')).toBeNull();
+  });
+
+  it('moves pending feedback to the newest same-key target without reviving the superseded target', () => {
     const t = mountPanel({ notchMode: 'off' });
     openNotchModal(t);
 
-    expect(t.querySelector('[data-notch-mode-choice="auto"]')?.getAttribute('aria-busy')).toBe('false');
+    beginNotchCommand('auto', true);
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBe('true');
+
+    beginNotchCommand('auto', false);
+    flushSync();
     expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+    expect(modeButton(t, 'OFF').dataset.armed).toBeUndefined();
+
+    beginNotchCommand('manual', false);
+    flushSync();
+    expect(modeButton(t, 'OFF').dataset.armed).toBe('true');
+    expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+  });
+
+  it('clears pending and selects an out-of-band confirmed AUTO observation', () => {
+    const t = mountPanel({ notchMode: 'off' });
+    openNotchModal(t);
+    const command = beginNotchCommand('auto', true);
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBe('true');
+    expect(modeButton(t, 'OFF').dataset.active).toBe('true');
+
+    acknowledgeCommand(command.id, command.originalEpoch, 1);
+    flushSync();
+    expect(modeButton(t, 'AUTO').dataset.armed).toBe('true');
+
+    runtimeState.state = {
+      active: 'MAIN',
+      main: { autoNotch: true, manualNotch: false },
+      sub: {},
+      observationSeq: 2,
+    };
+    mockProps.notchMode = 'auto';
+    runtimeState.notify();
+    mockProjection.notify();
+    flushSync();
+
+    expect(modeButton(t, 'AUTO').dataset.armed).toBeUndefined();
+    expect(modeButton(t, 'AUTO').dataset.active).toBe('true');
+    expect(modeButton(t, 'OFF').dataset.active).toBe('false');
     expect(t.querySelector('[data-notch-mode-live]')).toBeNull();
   });
 
   it('keeps an out-of-band confirmed mode selected while a superseding target is pending', () => {
-    autoNotchArmed.armed = true;
-    autoNotchArmed.value = true;
     const t = mountPanel({ notchMode: 'manual' });
     openNotchModal(t);
+    beginNotchCommand('auto', true);
+    flushSync();
 
     expect(modeButton(t, 'MAN').dataset.active).toBe('true');
     expect(modeButton(t, 'AUTO').dataset.active).toBe('false');


### PR DESCRIPTION
## Summary
- mark the exact mounted OFF/AUTO/MAN dialog choice as pending without changing confirmed selection
- treat OFF as pending only while both real false command strands are armed
- add exact dialog selectors, accessibility state, and component coverage for delayed confirmation, terminal clearing, supersession, and out-of-band confirmation

## Verification
- `npx vitest run src/components-v2/panels/__tests__/DspPanel.component.test.ts src/components-v2/panels/__tests__/DspPanel.isolated.test.ts src/components-v2/panels/__tests__/mor1536-armed-adoption.test.ts src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts src/lib/runtime/commands/__tests__/panel-commands.intent.isolated.test.ts`
- `npm run check`
- `npm run lint`
- `npm run build`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` (9717 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed)
- `uv run ruff check src/ tests/`

## Notes
- `uv run mypy src/` remains blocked by 13 pre-existing errors in four unrelated Python files.
- Hardware acceptance remains required; no radio/runtime/browser action was performed.

Linear: MOR-1672