### PR TITLE
fix: prevent superseded pending state from resurfacing

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
@@ -156,3 +156,71 @@ for (const fx of fixtures) {
     });
   });
 }
+
+describe.each([
+  {
+    label: 'auto-notch',
+    accessor: getAutoNotchArmed,
+    intentName: 'set_auto_notch',
+    confirmedField: 'autoNotch',
+  },
+  {
+    label: 'manual-notch',
+    accessor: getManualNotchArmed,
+    intentName: 'set_manual_notch',
+    confirmedField: 'manualNotch',
+  },
+] as const)('$label chronological same-key selection (MOR-1672)', ({ accessor, intentName, confirmedField }) => {
+  const command = (status: string, target: boolean, createdAt: number): FakeCommand => ({
+    name: intentName,
+    status,
+    createdAt,
+    updatedAt: createdAt,
+    params: { on: target, receiver: 0 },
+  });
+
+  it.each(['failed', 'cancelled', 'timed-out', 'confirmed'])(
+    'does not resurrect an older pending target after the newer command becomes %s',
+    (terminalStatus) => {
+      runtimeState.state = {
+        active: 'MAIN',
+        main: { [confirmedField]: false },
+        sub: {},
+      };
+      state.commands = [
+        command('pending', true, 10),
+        command(terminalStatus, false, 20),
+      ];
+
+      expect(accessor()).toEqual({ armed: false, value: null });
+    },
+  );
+
+  it('keeps the newest active same-key target armed', () => {
+    runtimeState.state = {
+      active: 'MAIN',
+      main: { [confirmedField]: false },
+      sub: {},
+    };
+    state.commands = [
+      command('pending', false, 10),
+      command('pending', true, 20),
+    ];
+
+    expect(accessor()).toEqual({ armed: true, value: true });
+  });
+
+  it('uses insertion order as the tie-break when same-key commands share a clock tick', () => {
+    runtimeState.state = {
+      active: 'MAIN',
+      main: { [confirmedField]: false },
+      sub: {},
+    };
+    state.commands = [
+      command('pending', true, 20),
+      command('failed', false, 20),
+    ];
+
+    expect(accessor()).toEqual({ armed: false, value: null });
+  });
+});

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts
@@ -42,12 +42,25 @@ type FakeState = {
   observationSeq?: number;
 };
 
-const state: { commands: FakeCommand[] } = { commands: [] };
+const state: { commands: FakeCommand[]; superseded: Set<FakeCommand>; useActual: boolean } = {
+  commands: [],
+  superseded: new Set(),
+  useActual: false,
+};
 const runtimeState: { state: FakeState | null } = { state: null };
 
-vi.mock('$lib/stores/commands.svelte', () => ({
-  getCommandLifecycles: () => state.commands,
-}));
+vi.mock('$lib/stores/commands.svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/stores/commands.svelte')>();
+  return {
+    ...actual,
+    getCommandLifecycles: () => state.useActual ? actual.getCommandLifecycles() : state.commands,
+    isCommandLifecycleSuperseded: (command: Parameters<typeof actual.isCommandLifecycleSuperseded>[0]) => (
+      state.useActual
+        ? actual.isCommandLifecycleSuperseded(command)
+        : state.superseded.has(command as FakeCommand)
+    ),
+  };
+});
 vi.mock('$lib/runtime/frontend-runtime', () => ({
   runtime: { get state() { return runtimeState.state; }, get caps() { return null; } },
 }));
@@ -63,7 +76,18 @@ import {
   getDataModeArmed, getAutoNotchArmed, getManualNotchArmed,
 } from '../panel-adapters';
 
-afterEach(() => { runtimeState.state = null; });
+const actualCommandStore = await vi.importActual<typeof import('$lib/stores/commands.svelte')>(
+  '$lib/stores/commands.svelte',
+);
+
+afterEach(() => {
+  actualCommandStore.resetCommandLifecycle();
+  runtimeState.state = null;
+  state.commands = [];
+  state.superseded.clear();
+  state.useActual = false;
+  vi.useRealTimers();
+});
 
 type Fixture = {
   label: string;
@@ -221,6 +245,40 @@ describe.each([
       command('failed', false, 20),
     ];
 
+    expect(accessor()).toEqual({ armed: false, value: null });
+  });
+
+  it('stays unarmed after the newer terminal record ages out of the actual lifecycle store', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    runtimeState.state = {
+      active: 'MAIN',
+      main: { [confirmedField]: false },
+      sub: {},
+    };
+    state.useActual = true;
+
+    actualCommandStore.beginCommand({
+      id: `${intentName}-older`,
+      name: intentName,
+      params: { on: true, receiver: 0 },
+      originalEpoch: 1,
+      timeoutMs: 60_000,
+    });
+    vi.setSystemTime(1_001);
+    actualCommandStore.beginCommand({
+      id: `${intentName}-newer`,
+      name: intentName,
+      params: { on: false, receiver: 0 },
+      originalEpoch: 1,
+      timeoutMs: 60_000,
+    });
+    actualCommandStore.failCommand(`${intentName}-newer`, 1, 1, 'expected test failure');
+
+    expect(accessor()).toEqual({ armed: false, value: null });
+
+    vi.advanceTimersByTime(5_001);
+    expect(actualCommandStore.getCommandLifecycles()).toHaveLength(1);
     expect(accessor()).toEqual({ armed: false, value: null });
   });
 });

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -450,7 +450,6 @@ function latestPendingParam(
   } | null = null;
   for (const command of getCommandLifecycles()) {
     if (command.name !== intentName) continue;
-    if (command.status !== 'pending' && command.status !== 'acknowledged') continue;
     if (command.params.receiver !== receiver) continue;
     const value = command.params[paramKey];
     if (value === undefined) continue;
@@ -461,7 +460,11 @@ function latestPendingParam(
       };
     }
   }
-  if (!latest) return undefined;
+  // Select chronologically first, then inspect liveness. A newer terminal
+  // same-key record is a barrier: filtering terminal records during the scan
+  // would let an older superseded pending record resurface after the newer
+  // command fails, times out, confirms, or is cancelled (MOR-1672).
+  if (!latest || (latest.status !== 'pending' && latest.status !== 'acknowledged')) return undefined;
   if (latest.status !== 'acknowledged') return latest.value;
 
   // Grace backstop: fires regardless of what the sequence guard below would
@@ -533,11 +536,11 @@ export function getPendingNrOn(receiver: 0 | 1): boolean | null {
  *  - A re-click while armed re-arms at the new target: `latestPendingParam`'s
  *    freshest-`createdAt`-wins tie-break already handles this, no separate
  *    "already armed" state to fight.
- *  - `armed` NEVER survives a terminal failure. A command that reaches
- *    `'failed'`/`'cancelled'`/`'timed-out'` fails `latestPendingParam`'s own
- *    `status !== 'pending' && status !== 'acknowledged'` scan guard and is
- *    excluded from consideration the instant it transitions — `armed` clears
- *    immediately, it must never present a failed command as still in flight.
+ *  - `armed` NEVER survives a terminal outcome. `latestPendingParam` first
+ *    selects the newest same-key record chronologically, then requires that
+ *    exact record to be pending/acknowledged. Thus a newer failed, cancelled,
+ *    timed-out, or confirmed record clears armed immediately and cannot let an
+ *    older superseded command resurface as if it were still in flight.
  *
  * Contract for skins consuming this signal:
  *  - MAY style `armed` however fits: desktop-v2 renders it as a `data-armed`

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -451,6 +451,12 @@ function latestPendingParam(
   for (const command of getCommandLifecycles()) {
     if (command.name !== intentName) continue;
     if (command.params.receiver !== receiver) continue;
+    // Supersession is durable for the older record even after the newer
+    // terminal record's bounded presentation retention expires. Never let a
+    // superseded lifecycle become the newest selectable pending command.
+    // Identity-less legacy/test-double records have no supersession key.
+    if (command.id !== undefined && command.originalEpoch !== undefined
+      && isCommandLifecycleSuperseded(command)) continue;
     const value = command.params[paramKey];
     if (value === undefined) continue;
     if (!latest || command.createdAt >= latest.createdAt) {


### PR DESCRIPTION
## Summary
- select the newest same-key lifecycle chronologically before deciding whether it is still live
- make newer terminal records a barrier so older superseded pending records cannot resurface
- add adversarial AUTO/MAN notch regressions for failure, cancellation, timeout, confirmation, same-tick ordering, and ordinary latest-active behavior

## Verification
- `npx vitest run src/lib/runtime/adapters/__tests__/mor1536-armed-adoption.isolated.test.ts src/lib/runtime/adapters/__tests__/mor1519-mode-armed.isolated.test.ts src/lib/runtime/adapters/__tests__/mor1441-pending-discrete.isolated.test.ts src/lib/runtime/adapters/__tests__/mor1441-pending-frequency.isolated.test.ts src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts` (177 passed)
- `npm test` (350 files, 7570 tests passed)
- `npm run check`
- `npm run lint`
- `npm run build`

## Scope
This is the shared-selector prerequisite for the separate dialog presentation PR #2645. No Notch-specific production branch and no hardware/runtime action.

Linear: MOR-1672