### PR TITLE
fix: filter undeclared mode keyboard bindings

### DIFF
--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -510,6 +510,35 @@ def _merge_keyboard_config(
     )
 
 
+def _filter_undeclared_mode_bindings(
+    keyboard: KeyboardConfig | None,
+    modes: tuple[str, ...],
+) -> KeyboardConfig | None:
+    """Exclude mode shortcuts that do not target a declared profile mode."""
+    if keyboard is None:
+        return None
+
+    bindings = tuple(
+        binding
+        for binding in keyboard.bindings
+        if not (
+            binding.action == "mode_select"
+            and isinstance(binding.params, dict)
+            and isinstance(binding.params.get("mode"), str)
+            and binding.params["mode"] not in modes
+        )
+    )
+    if len(bindings) == len(keyboard.bindings):
+        return keyboard
+    return KeyboardConfig(
+        leader_key=keyboard.leader_key,
+        leader_timeout_ms=keyboard.leader_timeout_ms,
+        alt_hints=keyboard.alt_hints,
+        help_title=keyboard.help_title,
+        bindings=bindings,
+    )
+
+
 def _valid_audio_codec_names() -> set[str]:
     from rigplane.types import AudioCodec
 
@@ -1369,6 +1398,7 @@ def load_rig(path: Path) -> RigConfig:
         override_section,
         filename=filename,
     )
+    keyboard = _filter_undeclared_mode_bindings(keyboard, modes)
 
     # Parse optional [audio] codec and sample-rate policy (#797, #1470).
     codec_preference: tuple[str, ...] | None = None

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -448,6 +448,39 @@ fine = false
                 binding.action == "toggle_help" for binding in rig.keyboard.bindings
             )
 
+    def test_default_mode_bindings_follow_loaded_profile_modes(self):
+        no_psk = load_rig(RIGS_DIR / "ic7300.toml")
+        assert no_psk.keyboard is not None
+        no_psk_ids = {binding.id for binding in no_psk.keyboard.bindings}
+        assert {"mode-lsb", "mode-usb"} <= no_psk_ids
+        assert {"mode-psk", "mode-pskr"}.isdisjoint(no_psk_ids)
+
+        psk_capable = load_rig(RIGS_DIR / "ic7610.toml")
+        assert psk_capable.keyboard is not None
+        psk_capable_ids = {binding.id for binding in psk_capable.keyboard.bindings}
+        assert {"mode-psk", "mode-pskr"} <= psk_capable_ids
+
+    def test_mode_select_with_non_string_mode_preserves_parser_behavior(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[ui.keyboard]
+[[ui.keyboard.bindings]]
+id = "non-string-mode"
+key = "F1"
+action = "mode_select"
+[ui.keyboard.bindings.params]
+mode = 42
+""",
+        )
+
+        rig = load_rig(p)
+
+        assert rig.keyboard is not None
+        assert rig.keyboard.bindings[0].params == {"mode": 42}
+
 
 # ── RadioProfile building ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- exclude merged `mode_select` bindings whose string target is absent from the loaded profile modes
- retain declared LSB/USB and PSK/PSK-R shortcuts where supported
- retain existing parser behavior for non-string mode values

## Verification
- `uv run pytest tests/test_rig_loader.py -q --tb=short` (208 passed, 1 skipped)
- `uv run ruff check src/rigplane/profiles/rig_loader.py tests/test_rig_loader.py`
- public-boundary grep passed

Linear: [MOR-1661](https://linear.app/morozsm/issue/MOR-1661/mor-1578-d-filter-undeclared-mode-select-keyboard-bindings-at-profile)