### PR TITLE
fix: publish narrow IC-7300 PTT poll provenance (MOR-1695)

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
@@ -97,4 +97,15 @@ describe('App TX authority projector', () => {
     expect(project(withPtt(field(12), true), capabilities(), session(2)).ptt)
       .toMatchObject({ value: true, fresh: true, marker: { pttObservationSeq: 4 } });
   });
+  it('accepts a post-baseline PTT poll after reconnect without relaxing any other gate', () => {
+    const project = createAppAuthorityProjector();
+    expect(project(withPtt(field(1, 'poll_response')), capabilities(), session(7)).ptt)
+      .toMatchObject({ value: false, fresh: false, source: 'radio-readback' });
+    expect(project(withPtt(field(2, 'poll_response')), capabilities(), session(7)).ptt)
+      .toMatchObject({ value: false, fresh: true, source: 'radio-readback' });
+    expect(project(withPtt(field(3, 'command_response')), capabilities(), session(7)).ptt)
+      .toMatchObject({ fresh: false, source: 'other' });
+    expect(project(withPtt(field(4, 'poll_response')), capabilities({ tx: false }), session(7)))
+      .toMatchObject({ ptt: { fresh: true }, eligibility: { catPtt: false } });
+  });
 });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
@@ -97,15 +97,4 @@ describe('App TX authority projector', () => {
     expect(project(withPtt(field(12), true), capabilities(), session(2)).ptt)
       .toMatchObject({ value: true, fresh: true, marker: { pttObservationSeq: 4 } });
   });
-  it('accepts a post-baseline PTT poll after reconnect without relaxing any other gate', () => {
-    const project = createAppAuthorityProjector();
-    expect(project(withPtt(field(1, 'poll_response')), capabilities(), session(7)).ptt)
-      .toMatchObject({ value: false, fresh: false, source: 'radio-readback' });
-    expect(project(withPtt(field(2, 'poll_response')), capabilities(), session(7)).ptt)
-      .toMatchObject({ value: false, fresh: true, source: 'radio-readback' });
-    expect(project(withPtt(field(3, 'command_response')), capabilities(), session(7)).ptt)
-      .toMatchObject({ fresh: false, source: 'other' });
-    expect(project(withPtt(field(4, 'poll_response')), capabilities({ tx: false }), session(7)))
-      .toMatchObject({ ptt: { fresh: true }, eligibility: { catPtt: false } });
-  });
 });

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2636,7 +2636,9 @@ class CivRuntime:
         if frame.to_addr == 0x00 or frame.command in (0x00, 0x01):
             source = "civ_unsolicited"
         elif (
-            frame.command == 0x1C
+            frame.to_addr == CONTROLLER_ADDR
+            and frame.from_addr == self._host._radio_addr
+            and frame.command == 0x1C
             and frame.sub == 0x00
             and len(frame.data) == 1
             and frame.data[0] in (0x00, 0x01)

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2632,11 +2632,20 @@ class CivRuntime:
         frame: CivFrame,
         quality: tuple[str, ...] = ("confirmed",),
     ) -> Observation:
-        source: ObservationSource = (
-            "civ_unsolicited"
-            if frame.to_addr == 0x00 or frame.command in (0x00, 0x01)
-            else "command_response"
-        )
+        source: ObservationSource = "command_response"
+        if frame.to_addr == 0x00 or frame.command in (0x00, 0x01):
+            source = "civ_unsolicited"
+        elif (
+            frame.command == 0x1C
+            and frame.sub == 0x00
+            and len(frame.data) == 1
+            and frame.data[0] in (0x00, 0x01)
+        ):
+            # A directed, exact one-byte PTT reply can only be CI-V's 0x1C/0x00
+            # field readback.  It is intentionally narrower than generic command
+            # responses so the Web TX authority gate cannot treat an ACK, setter
+            # success, or unrelated response as radio truth.
+            source = "poll_response"
         return Observation(
             path=path,
             value=value,

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3062,12 +3062,11 @@ def test_observations_from_frame_marks_only_exact_ptt_readback_as_poll_response(
         if observations:
             assert observations[0].source.source == "command_response"
 
-    unsolicited = _make_frame(
-        cmd=0x1C, sub=0x00, data=b"\x01", to_addr=0x00
+    unsolicited = _make_frame(cmd=0x1C, sub=0x00, data=b"\x01", to_addr=0x00)
+    assert (
+        radio._civ_runtime._observations_from_frame(unsolicited)[0].source.source
+        == "civ_unsolicited"
     )
-    assert radio._civ_runtime._observations_from_frame(unsolicited)[
-        0
-    ].source.source == "civ_unsolicited"
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -3036,6 +3036,30 @@ def test_observations_from_frame_normalizes_selected_cmd14_controls(
     assert observation.value == pytest.approx(expected_value)
 
 
+def test_observations_from_frame_marks_only_exact_ptt_readback_as_poll_response(
+    radio: IcomRadio,
+) -> None:
+    """A directed one-byte CI-V PTT readback is radio truth, not a setter ACK.
+
+    The Web TX authority projector may accept ``poll_response`` for PTT, so
+    this deliberately pins the narrow wire shape rather than promoting generic
+    command responses.
+    """
+    readback = _make_frame(cmd=0x1C, sub=0x00, data=b"\x00")
+    assert radio._civ_runtime._observations_from_frame(readback)[0].source.source == (
+        "poll_response"
+    )
+
+    for frame in (
+        _make_frame(cmd=0x1C, sub=0x00, data=b"\x00\x01"),
+        _make_frame(cmd=0x1C, sub=0x01, data=b"\x00"),
+        _make_frame(cmd=0x14, sub=0x03, data=_bcd2(45)),
+    ):
+        observations = radio._civ_runtime._observations_from_frame(frame)
+        if observations:
+            assert observations[0].source.source == "command_response"
+
+
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("sub", "value", "field"),
     [

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1535,7 +1535,7 @@ def test_update_state_cache_exception_suppressed(radio: IcomRadio) -> None:
             _make_frame(cmd=0x1C, sub=0x00, data=b"\x01"),
             "global.tx_state.ptt",
             True,
-            "command_response",
+            "poll_response",
         ),
         (
             _make_frame(cmd=0x07, data=bytes([0xD2, 0x01])),
@@ -3052,12 +3052,22 @@ def test_observations_from_frame_marks_only_exact_ptt_readback_as_poll_response(
 
     for frame in (
         _make_frame(cmd=0x1C, sub=0x00, data=b"\x00\x01"),
+        _make_frame(cmd=0x1C, sub=0x00, data=b"\x02"),
         _make_frame(cmd=0x1C, sub=0x01, data=b"\x00"),
         _make_frame(cmd=0x14, sub=0x03, data=_bcd2(45)),
+        _make_frame(cmd=0x1C, sub=0x00, data=b"\x00", to_addr=0x99),
+        _make_frame(cmd=0x1C, sub=0x00, data=b"\x00", from_addr=0x99),
     ):
         observations = radio._civ_runtime._observations_from_frame(frame)
         if observations:
             assert observations[0].source.source == "command_response"
+
+    unsolicited = _make_frame(
+        cmd=0x1C, sub=0x00, data=b"\x01", to_addr=0x00
+    )
+    assert radio._civ_runtime._observations_from_frame(unsolicited)[
+        0
+    ].source.source == "civ_unsolicited"
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]


### PR DESCRIPTION
## Summary
- classify only exact directed CI-V `0x1C/0x00` responses with one legal PTT byte as `poll_response`
- keep generic, malformed, unrelated, and wrong-address responses non-authoritative
- preserve unsolicited PTT provenance and update all affected runtime coverage expectations

## Verification
- `uv run pytest tests/test_civ_rx_coverage.py -q --tb=short` (368 passed)
- `uv run pytest tests/test_radio.py::TestPtt tests/test_state_pipeline_contracts.py -q --tb=short` (214 passed)
- `uv run ruff check src/rigplane/runtime/_civ_rx.py tests/test_civ_rx_coverage.py`
- `git diff --check`
- public-artifact privacy scan: clean

Implements [MOR-1695](https://linear.app/morozsm/issue/MOR-1695/publish-narrow-ic-7300-ptt-poll-provenance). Parent MOR-1694 remains open pending dependent MOR-1696 and owner-present IC-7300 hardware acceptance; this software merge does not complete either boundary.