### PR TITLE
refactor: publish core TX interlock contract (MOR-1697)

### DIFF
--- a/src/rigplane/core/tx_interlock_contract.py
+++ b/src/rigplane/core/tx_interlock_contract.py
@@ -1,0 +1,105 @@
+"""Stable, dependency-free vocabulary for TX interlock policy metadata."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+__all__ = [
+    "TX_INTERLOCK_COMMAND_FAMILY_METADATA",
+    "TxInterlockCommandFamily",
+    "TxInterlockCommandFamilyMetadata",
+    "TxInterlockDisposition",
+]
+
+
+class TxInterlockDisposition(StrEnum):
+    """The fixed safety class assigned to a typed command."""
+
+    ALWAYS_PASS = "always-pass"
+    TX_SAFE = "tx-safe"
+    DEFER = "defer"
+    BLOCK = "block"
+
+
+class TxInterlockCommandFamily(StrEnum):
+    """Stable, generic families with an owner-ruled base disposition."""
+
+    PTT_OFF = "ptt-off"
+    POWER_OFF = "power-off"
+    SCAN_STOP = "scan-stop"
+    TUNER_OFF = "tuner-off"
+    POWER_ON = "power-on"
+    PTT_ON = "ptt-on"
+    RAW_CIV = "raw-civ"
+    SCAN_START = "scan-start"
+    ANTENNA_SWITCH = "antenna-switch"
+    TUNER_ENGAGE = "tuner-engage"
+    FREQUENCY = "frequency"
+    MODE = "mode"
+    BAND = "band"
+    VFO_SELECT = "vfo-select"
+    VFO_TOPOLOGY = "vfo-topology"
+    MEMORY = "memory"
+    RIT_XIT = "rit-xit"
+
+
+@dataclass(frozen=True, slots=True)
+class TxInterlockCommandFamilyMetadata:
+    """One generic family and its non-negotiable typed-policy disposition."""
+
+    family: TxInterlockCommandFamily
+    base_disposition: TxInterlockDisposition
+
+
+TX_INTERLOCK_COMMAND_FAMILY_METADATA = (
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.PTT_OFF, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.POWER_OFF, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.SCAN_STOP, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.TUNER_OFF, TxInterlockDisposition.ALWAYS_PASS
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.POWER_ON, TxInterlockDisposition.TX_SAFE
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.PTT_ON, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.RAW_CIV, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.SCAN_START, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.ANTENNA_SWITCH, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.TUNER_ENGAGE, TxInterlockDisposition.BLOCK
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.FREQUENCY, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.MODE, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.BAND, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.VFO_SELECT, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.VFO_TOPOLOGY, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.MEMORY, TxInterlockDisposition.DEFER
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.RIT_XIT, TxInterlockDisposition.DEFER
+    ),
+)

--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from rigplane.core.tx_interlock_contract import (
+    TX_INTERLOCK_COMMAND_FAMILY_METADATA,
+    TxInterlockCommandFamily,
+    TxInterlockCommandFamilyMetadata,
+    TxInterlockDisposition,
+)
 from rigplane.runtime._poller_types import (
     MemoryToVfo,
     PttOff,
@@ -58,99 +64,6 @@ __all__ = [
     "get_tx_interlock_command_family_metadata",
 ]
 
-
-class TxInterlockDisposition(StrEnum):
-    """The fixed safety class assigned to a typed command."""
-
-    ALWAYS_PASS = "always-pass"
-    TX_SAFE = "tx-safe"
-    DEFER = "defer"
-    BLOCK = "block"
-
-
-class TxInterlockCommandFamily(StrEnum):
-    """Stable, generic families with an owner-ruled base disposition."""
-
-    PTT_OFF = "ptt-off"
-    POWER_OFF = "power-off"
-    SCAN_STOP = "scan-stop"
-    TUNER_OFF = "tuner-off"
-    POWER_ON = "power-on"
-    PTT_ON = "ptt-on"
-    RAW_CIV = "raw-civ"
-    SCAN_START = "scan-start"
-    ANTENNA_SWITCH = "antenna-switch"
-    TUNER_ENGAGE = "tuner-engage"
-    FREQUENCY = "frequency"
-    MODE = "mode"
-    BAND = "band"
-    VFO_SELECT = "vfo-select"
-    VFO_TOPOLOGY = "vfo-topology"
-    MEMORY = "memory"
-    RIT_XIT = "rit-xit"
-
-
-@dataclass(frozen=True, slots=True)
-class TxInterlockCommandFamilyMetadata:
-    """One generic family and its non-negotiable typed-policy disposition."""
-
-    family: TxInterlockCommandFamily
-    base_disposition: TxInterlockDisposition
-
-
-TX_INTERLOCK_COMMAND_FAMILY_METADATA = (
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.PTT_OFF, TxInterlockDisposition.ALWAYS_PASS
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.POWER_OFF, TxInterlockDisposition.ALWAYS_PASS
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.SCAN_STOP, TxInterlockDisposition.ALWAYS_PASS
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.TUNER_OFF, TxInterlockDisposition.ALWAYS_PASS
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.POWER_ON, TxInterlockDisposition.TX_SAFE
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.PTT_ON, TxInterlockDisposition.BLOCK
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.RAW_CIV, TxInterlockDisposition.BLOCK
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.SCAN_START, TxInterlockDisposition.BLOCK
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.ANTENNA_SWITCH, TxInterlockDisposition.BLOCK
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.TUNER_ENGAGE, TxInterlockDisposition.BLOCK
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.FREQUENCY, TxInterlockDisposition.DEFER
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.MODE, TxInterlockDisposition.DEFER
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.BAND, TxInterlockDisposition.DEFER
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.VFO_SELECT, TxInterlockDisposition.DEFER
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.VFO_TOPOLOGY, TxInterlockDisposition.DEFER
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.MEMORY, TxInterlockDisposition.DEFER
-    ),
-    TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.RIT_XIT, TxInterlockDisposition.DEFER
-    ),
-)
 
 _METADATA_BY_FAMILY = {
     metadata.family: metadata for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -1,5 +1,17 @@
 """Focused contract tests for the shared TX interlock policy."""
 
+from rigplane.core.tx_interlock_contract import (
+    TX_INTERLOCK_COMMAND_FAMILY_METADATA as CORE_TX_INTERLOCK_METADATA,
+)
+from rigplane.core.tx_interlock_contract import (
+    TxInterlockCommandFamily as CoreTxInterlockCommandFamily,
+)
+from rigplane.core.tx_interlock_contract import (
+    TxInterlockCommandFamilyMetadata as CoreTxInterlockCommandFamilyMetadata,
+)
+from rigplane.core.tx_interlock_contract import (
+    TxInterlockDisposition as CoreTxInterlockDisposition,
+)
 from rigplane.runtime._poller_types import (
     MemoryToVfo,
     PttOff,
@@ -25,15 +37,24 @@ from rigplane.runtime._poller_types import (
     VfoSwap,
 )
 from rigplane.runtime.tx_interlock import (
+    TX_INTERLOCK_COMMAND_FAMILY_METADATA,
     DeferredTxCommandLane,
     RfState,
     TxInterlockCommandFamily,
+    TxInterlockCommandFamilyMetadata,
     TxInterlockDeferredOutcome,
     TxInterlockDisposition,
     classify_tx_interlock,
     evaluate_tx_interlock,
     get_tx_interlock_command_family_metadata,
 )
+
+
+def test_runtime_reexports_the_canonical_core_contract_by_identity() -> None:
+    assert TxInterlockDisposition is CoreTxInterlockDisposition
+    assert TxInterlockCommandFamily is CoreTxInterlockCommandFamily
+    assert TxInterlockCommandFamilyMetadata is CoreTxInterlockCommandFamilyMetadata
+    assert TX_INTERLOCK_COMMAND_FAMILY_METADATA is CORE_TX_INTERLOCK_METADATA
 
 
 def test_emergency_stop_commands_take_structural_precedence() -> None:
@@ -57,6 +78,23 @@ def test_rf_start_and_disruptive_commands_are_hard_block() -> None:
     assert (
         classify_tx_interlock(SetPowerstat(on=True)) is TxInterlockDisposition.TX_SAFE
     )
+
+
+def test_tuner_values_keep_mixed_structural_and_default_semantics() -> None:
+    assert (
+        classify_tx_interlock(SetTunerStatus(0)) is TxInterlockDisposition.ALWAYS_PASS
+    )
+    assert classify_tx_interlock(SetTunerStatus(1)) is TxInterlockDisposition.BLOCK
+    assert classify_tx_interlock(SetTunerStatus(2)) is TxInterlockDisposition.BLOCK
+    assert classify_tx_interlock(SetTunerStatus(3)) is TxInterlockDisposition.TX_SAFE
+
+
+def test_unknown_commands_remain_tx_safe_without_family_metadata() -> None:
+    command = object()
+
+    assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
+    assert evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN).allowed is True
+    assert get_tx_interlock_command_family_metadata(command) is None
 
 
 def test_hard_block_fails_closed_for_unknown_rf_state_without_claiming_tx() -> None:


### PR DESCRIPTION
## Summary

- move the stable TX-interlock disposition, command-family, and metadata vocabulary into a stdlib-only Core contract
- statically re-export the identical objects from the existing runtime surface while keeping concrete command classification and metadata lookup runtime-owned
- characterize runtime/Core object identity and preserve tuner, fail-closed, ALWAYS-PASS, BLOCK, TX-SAFE, deferred, and unknown-command semantics

## Context

Linear: MOR-1697

This is the layer-valid prerequisite for MOR-1625. It removes the forbidden Profiles-to-Runtime dependency pressure without adding profile payloads or changing enforcement behavior.

## Validation

- `uv run pytest tests/test_tx_interlock_policy.py -q` — 16 passed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/rigplane/core/tx_interlock_contract.py src/rigplane/runtime/tx_interlock.py`
- `uv run lint-imports` — 5 contracts kept
- `git diff --check`

Full-repository `uv run mypy src/` remains blocked by 13 unrelated diagnostics in four files outside this PR's ownership; both changed source modules pass focused mypy.
