### PR TITLE
fix: apply idle App PTT authority refresh (MOR-1696)

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-host.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TxControllerDependencies } from '../controller';
-import type { PttMarker, TxEvent, TxState } from '../model';
+import { initialTxState, transition, type Eligibility, type PttMarker, type PttObservation, type TxEvent, type TxState } from '../model';
 import type { ControlSessionTransition } from '$lib/transport/ws-client'; type SessionHandler = (projection: any, session: ControlSessionTransition) => void;
 const h = vi.hoisted(() => ({
   contexts: new Map<unknown, unknown>(), factory: vi.fn(), controllers: 0,
@@ -77,6 +77,49 @@ describe('App TxController host', () => {
     h.session!(projection({ state: 'connected', epoch: 5 }, 2), { state: 'connected', epoch: 5 });
     h.lifecycle!(); host.refreshAuthority(); getAppTxController().start('stale', 'lease', 'momentary');
     expect(h.events).toHaveLength(count);
+  });
+  it('applies idle authoritative OFF and reuses that exact marker for an eligible Key start', async () => {
+    const host = provideAppTxControllerHost(bindings()); const facade = getAppTxController();
+    h.session!(projection({ state: 'connected', epoch: 1 }, 1), { state: 'connected', epoch: 1 });
+    expect(facade.snapshot()).toMatchObject({ guard: null, radioTx: 'unknown' });
+    expect(h.effects).toEqual([]);
+
+    host.refreshAuthority();
+    expect(facade.snapshot()).toMatchObject({ guard: null, radioTx: 'off',
+      pttMarker: { authorityEpoch: 1, pttObservationSeq: 2 } });
+    expect(h.effects).toEqual([]);
+
+    facade.start('desktop', 'lease', 'momentary');
+    await Promise.resolve(); await Promise.resolve();
+    expect(facade.snapshot()).toMatchObject({ guard: { authorityEpoch: 1 }, radioTx: 'off' });
+    expect(h.effects).toEqual(['audio', 'on']);
+  });
+  it('rejects equal-marker reuse unless OFF truth and every existing gate still qualify', () => {
+    const marker = { authorityEpoch: 1, pttObservationSeq: 2, pttLastObservedMonotonic: 2 };
+    const ptt: PttObservation = { value: false, observed: true, fresh: true,
+      source: 'radio-readback', marker };
+    const eligibility: Eligibility = { catPtt: true, browserTxAudio: true, controlLive: true,
+      permit: 'allowed', target: { receiver: 'MAIN', slot: 'A', frequencyHz: 100 } };
+    const confirmed = transition(initialTxState(1, { ...marker, pttObservationSeq: 1 }),
+      { type: 'authority', epoch: 1, ptt, eligibility, offCommandId: 'off' }).state;
+    const start = (state: TxState, evidence: PttObservation = ptt, gates: Eligibility = eligibility) =>
+      transition(state, { type: 'start', sourceId: 'desktop', leaseId: 'lease',
+        intent: 'momentary', eligibility: gates, ptt: evidence });
+
+    expect(start(confirmed).effects.map((effect) => effect.type)).toContain('start-audio');
+    const rejected = [
+      start({ ...confirmed, radioTx: 'unknown' }), start({ ...confirmed, radioTx: 'on' }),
+      start(confirmed, { ...ptt, marker: { ...marker, pttObservationSeq: 1 } }),
+      start(confirmed, { ...ptt, marker: { ...marker, authorityEpoch: 0 } }),
+      start(confirmed, { ...ptt, fresh: false }), start(confirmed, { ...ptt, source: 'other' }),
+      start(confirmed, ptt, { ...eligibility, catPtt: false }),
+      start(confirmed, ptt, { ...eligibility, browserTxAudio: false }),
+      start(confirmed, ptt, { ...eligibility, controlLive: false }),
+      start(confirmed, ptt, { ...eligibility, permit: 'denied' }),
+      start(confirmed, ptt, { ...eligibility, target: null }),
+      start({ ...confirmed, phase: 'failed', fault: 'audio-failed' }),
+    ];
+    for (const result of rejected) expect(result.effects).toEqual([]);
   });
   it('dispatches release synchronously, shares its bounded promise, and retains uncertain OFF state', async () => {
     const host = provideAppTxControllerHost(bindings()); const facade = getAppTxController();

--- a/frontend/src/lib/runtime/tx-controller/app-host.ts
+++ b/frontend/src/lib/runtime/tx-controller/app-host.ts
@@ -40,7 +40,7 @@ export function provideAppTxControllerHost(bindings: AppTxControllerHostBindings
   const refreshAuthority = () => {
     if (disposed) return;
     authority = browser.projectAuthority(session);
-    if (controller.snapshot().guard) applyAuthority(authority);
+    applyAuthority(authority);
   };
   const release = (): Promise<void> => {
     if (inFlight) return inFlight;

--- a/frontend/src/lib/runtime/tx-controller/model.ts
+++ b/frontend/src/lib/runtime/tx-controller/model.ts
@@ -43,6 +43,10 @@ const newer = (barrier: PttMarker, observation: PttObservation) => {
   if (barrier.pttObservationSeq !== null || seq !== null) return barrier.pttObservationSeq !== null && seq !== null && seq > barrier.pttObservationSeq;
   return barrier.pttLastObservedMonotonic !== null && at !== null && at > barrier.pttLastObservedMonotonic;
 };
+const sameMarker = (marker: PttMarker, observation: PttObservation) =>
+  marker.authorityEpoch === observation.marker.authorityEpoch
+  && marker.pttObservationSeq === observation.marker.pttObservationSeq
+  && marker.pttLastObservedMonotonic === observation.marker.pttLastObservedMonotonic;
 const authoritative = (observation: PttObservation) => observation.observed && observation.fresh && (observation.source === 'radio-readback' || observation.source === 'backend-observation');
 const ready = (eligibility: Eligibility) => eligibility.catPtt && eligibility.browserTxAudio && eligibility.controlLive && eligibility.permit === 'allowed' && eligibility.target !== null;
 const effect = (type: TxEffectType, state: TxState, commandId?: string, barrier?: PttMarker, guard: TxGuard | null = state.guard): TxEffect => ({ type, ...(guard ? { guard } : {}), ...(commandId !== undefined ? { commandId } : {}), ...(barrier ? { barrier } : {}) });
@@ -90,7 +94,8 @@ export function transition(state: TxState, event: TxEvent): TxTransition {
   if (('offCommandId' in event && typeof event.offCommandId !== 'string') || ((event.type === 'audio-ready' || event.type === 'release' || event.type === 'on-sent') && typeof event.commandId !== 'string')) return { state, effects: [] };
   if (event.type === 'start') {
     if (state.phase !== 'idle') return { state, effects: [] };
-    const ok = ready(event.eligibility) && event.ptt.value === false && authoritative(event.ptt) && newer(state.pttMarker, event.ptt) && event.ptt.marker.authorityEpoch === state.authorityEpoch;
+    const currentConfirmedOff = state.radioTx === 'off' && sameMarker(state.pttMarker, event.ptt);
+    const ok = ready(event.eligibility) && event.ptt.value === false && authoritative(event.ptt) && (newer(state.pttMarker, event.ptt) || currentConfirmedOff) && event.ptt.marker.authorityEpoch === state.authorityEpoch;
     if (!ok) return { state: { ...state, phase: 'failed', fault: 'not-eligible', txRisk: 'none', sourceId: null, leaseId: null, guard: null }, effects: [] };
     const generation = state.generation + 1;
     const guard = { leaseId: event.leaseId, generation, authorityEpoch: state.authorityEpoch };


### PR DESCRIPTION
## Summary
- apply qualifying App PTT authority refreshes while the TX controller is idle
- let Key reuse an equal marker only when the controller already records authoritative PTT OFF from that exact marker
- retain fresh/current authority checks and every existing capability, session, target, permit, audio, RF-state, and fault gate

## Safety
- the real App host/controller regression proves `radioTx` moves from `unknown` to `off` with zero `sendPtt` effects
- equal-marker reuse remains rejected for unknown/on state, stale or non-authoritative evidence, different/prior markers, failed eligibility, and fault state
- no queue, timer, second truth, optimistic state, or model-specific branch was added

## Verification
- `npm --prefix frontend test -- --run src/lib/runtime/tx-controller/__tests__` (11 files, 105 tests passed)
- focused host/model/page/reconnect matrix (7 files, 76 tests passed)
- `npm --prefix frontend run check` (zero errors or warnings)
- focused ESLint, diff check, and privacy scan passed

Implements [MOR-1696](https://linear.app/morozsm/issue/MOR-1696/apply-idle-app-ptt-authority-refresh). Parent MOR-1694 and owner-present IC-7300 hardware acceptance remain open; this software merge does not complete either boundary.