### PR TITLE
[MOR-1625] parse validated profile-driven TX interlock tightening

### DIFF
--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -8,11 +8,15 @@ TOML file with zero Python changes.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Required, TypedDict
 
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
+from rigplane.core.tx_interlock_contract import (
+    TxInterlockCommandFamily,
+    TxInterlockDisposition,
+)
 
 __all__ = [
     "ControlSpec",
@@ -234,6 +238,9 @@ class RadioProfile:
     # data only; future schedulers/adapters consume it instead of Web or
     # rigctld delivery code branching on radio model.
     state_acquisition: RadioAcquisitionProfile | None = None
+    tx_interlock_disposition_overrides: dict[
+        TxInterlockCommandFamily, TxInterlockDisposition
+    ] = field(default_factory=dict)
 
     @property
     def vfo_swap_code(self) -> int | None:

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import tomllib
 import warnings
 from dataclasses import dataclass, field
@@ -1058,6 +1059,32 @@ def _parse_state_acquisition(
 _TX_INTERLOCK_METADATA_BY_FAMILY = {
     metadata.family: metadata for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA
 }
+_TX_INTERLOCK_TABLE_HEADER = re.compile(r"^\[\s*tx_interlock\s*\]\s*(?:#.*)?$")
+_TX_INTERLOCK_NESTED_OVERRIDES_HEADER = re.compile(
+    r"^\[\s*tx_interlock\s*\.\s*disposition_overrides\s*\]\s*(?:#.*)?$"
+)
+_TX_INTERLOCK_DOTTED_OVERRIDES_KEY = re.compile(r"^disposition_overrides\s*\.")
+
+
+def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
+    """Reject TOML encodings that erase the documented inline-table boundary."""
+
+    in_tx_interlock = False
+    for raw_line in source.splitlines():
+        line = raw_line.lstrip()
+        if _TX_INTERLOCK_NESTED_OVERRIDES_HEADER.fullmatch(line):
+            raise RigLoadError(
+                f"{filename}: [tx_interlock].disposition_overrides "
+                "must use inline table syntax"
+            )
+        if line.startswith("["):
+            in_tx_interlock = bool(_TX_INTERLOCK_TABLE_HEADER.fullmatch(line))
+            continue
+        if in_tx_interlock and _TX_INTERLOCK_DOTTED_OVERRIDES_KEY.match(line):
+            raise RigLoadError(
+                f"{filename}: [tx_interlock].disposition_overrides "
+                "must use inline table syntax"
+            )
 
 
 def _parse_tx_interlock_disposition_overrides(
@@ -1134,9 +1161,12 @@ def load_rig(path: Path) -> RigConfig:
 
     try:
         raw = path.read_bytes()
-        data = tomllib.loads(raw.decode())
+        source = raw.decode()
+        data = tomllib.loads(source)
     except Exception as exc:
         raise RigLoadError(f"{filename}: failed to parse TOML: {exc}") from exc
+
+    _validate_tx_interlock_override_syntax(filename, source)
 
     # Validate required sections
     for section in _REQUIRED_SECTIONS:

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1172,7 +1172,9 @@ def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
             and key_path[:1] == ("disposition_overrides",)
             and len(key_path) > 1
         )
-        dotted_at_root = current_table == () and key_path[:2] == forbidden_prefix
+        dotted_at_root = current_table == () and (
+            key_path == ("tx_interlock",) or key_path[:2] == forbidden_prefix
+        )
         if dotted_in_table or dotted_at_root:
             raise RigLoadError(
                 f"{filename}: [tx_interlock].disposition_overrides "

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1178,7 +1178,7 @@ def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
                 outer_inline = (
                     current_table == ()
                     and key_path == ("tx_interlock",)
-                    and any(token[0] == "{" for token in tokens[equals + 1 :])
+                    and tokens[equals + 1][0] == "{"
                 )
                 if dotted_in_table or dotted_at_root or outer_inline:
                     raise RigLoadError(

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1144,8 +1144,9 @@ def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
 
     current_table: tuple[str, ...] = ()
     forbidden_prefix = ("tx_interlock", "disposition_overrides")
+    container_depth = 0
     for tokens in _toml_shape_statements(source):
-        if tokens[0][0] == "[" and tokens[-1][0] == "]":
+        if container_depth == 0 and tokens[0][0] == "[" and tokens[-1][0] == "]":
             inner = tokens[1:-1]
             if inner and inner[0][0] == "[" and inner[-1][0] == "]":
                 inner = inner[1:-1]
@@ -1158,26 +1159,33 @@ def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
                 )
             continue
 
-        equals = next(
-            (position for position, token in enumerate(tokens) if token[0] == "="),
-            None,
-        )
-        if equals is None:
-            continue
-        key_path = _toml_key_path(tokens[:equals])
-        if key_path is None:
-            continue
-        dotted_in_table = (
-            current_table == ("tx_interlock",)
-            and key_path[:1] == ("disposition_overrides",)
-            and len(key_path) > 1
-        )
-        dotted_at_root = current_table == () and key_path[:2] == forbidden_prefix
-        if dotted_in_table or dotted_at_root:
-            raise RigLoadError(
-                f"{filename}: [tx_interlock].disposition_overrides "
-                "must use inline table syntax"
+        if container_depth == 0:
+            equals = next(
+                (position for position, token in enumerate(tokens) if token[0] == "="),
+                None,
             )
+            key_path = _toml_key_path(tokens[:equals]) if equals is not None else None
+            if key_path is not None:
+                dotted_in_table = (
+                    current_table == ("tx_interlock",)
+                    and key_path[:1] == ("disposition_overrides",)
+                    and len(key_path) > 1
+                )
+                dotted_at_root = (
+                    current_table == () and key_path[:2] == forbidden_prefix
+                )
+                outer_inline = (
+                    current_table == ()
+                    and key_path == ("tx_interlock",)
+                    and any(token[0] == "{" for token in tokens[equals + 1 :])
+                )
+                if dotted_in_table or dotted_at_root or outer_inline:
+                    raise RigLoadError(
+                        f"{filename}: [tx_interlock].disposition_overrides "
+                        "must use inline table syntax"
+                    )
+        container_depth += sum(token[0] in "[{" for token in tokens)
+        container_depth -= sum(token[0] in "]}" for token in tokens)
 
 
 def _parse_tx_interlock_disposition_overrides(

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1166,6 +1166,7 @@ def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
             )
             key_path = _toml_key_path(tokens[:equals]) if equals is not None else None
             if key_path is not None:
+                assert equals is not None
                 dotted_in_table = (
                     current_table == ("tx_interlock",)
                     and key_path[:1] == ("disposition_overrides",)

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import tomllib
 import warnings
 from dataclasses import dataclass, field
@@ -1059,28 +1058,122 @@ def _parse_state_acquisition(
 _TX_INTERLOCK_METADATA_BY_FAMILY = {
     metadata.family: metadata for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA
 }
-_TX_INTERLOCK_TABLE_HEADER = re.compile(r"^\[\s*tx_interlock\s*\]\s*(?:#.*)?$")
-_TX_INTERLOCK_NESTED_OVERRIDES_HEADER = re.compile(
-    r"^\[\s*tx_interlock\s*\.\s*disposition_overrides\s*\]\s*(?:#.*)?$"
-)
-_TX_INTERLOCK_DOTTED_OVERRIDES_KEY = re.compile(r"^disposition_overrides\s*\.")
+
+
+def _toml_shape_statements(source: str) -> list[list[tuple[str, str]]]:
+    """Expose only table/key punctuation while shielding strings and comments."""
+
+    statements: list[list[tuple[str, str]]] = []
+    statement: list[tuple[str, str]] = []
+    punctuation = "[]{}.="
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char == "\n":
+            if statement:
+                statements.append(statement)
+                statement = []
+            index += 1
+            continue
+        if char in " \t\r":
+            index += 1
+            continue
+        if char == "#":
+            newline = source.find("\n", index)
+            index = len(source) if newline < 0 else newline
+            continue
+        if source.startswith(('"""', "'''"), index):
+            delimiter = source[index : index + 3]
+            index += 3
+            while index < len(source) and not source.startswith(delimiter, index):
+                if delimiter == '"""' and source[index] == "\\":
+                    index += 2
+                else:
+                    index += 1
+            index += 3
+            for _ in range(2):
+                if index < len(source) and source[index] == delimiter[0]:
+                    index += 1
+            statement.append(("string", ""))
+            continue
+        if char in "\"'":
+            delimiter = char
+            start = index
+            index += 1
+            while index < len(source) and source[index] != delimiter:
+                if delimiter == '"' and source[index] == "\\":
+                    index += 2
+                else:
+                    index += 1
+            index += 1
+            literal = source[start:index]
+            value = tomllib.loads(f"key = {literal}")["key"]
+            statement.append(("key", value))
+            continue
+        if char in punctuation:
+            statement.append((char, char))
+            index += 1
+            continue
+        start = index
+        while index < len(source) and source[index] not in f" \t\r\n#{punctuation}\"'":
+            index += 1
+        statement.append(("key", source[start:index]))
+    if statement:
+        statements.append(statement)
+    return statements
+
+
+def _toml_key_path(tokens: list[tuple[str, str]]) -> tuple[str, ...] | None:
+    """Return a dotted key path, or ``None`` for tokens outside that shape."""
+
+    path: list[str] = []
+    expect_key = True
+    for kind, value in tokens:
+        if expect_key and kind == "key":
+            path.append(value)
+            expect_key = False
+        elif not expect_key and kind == ".":
+            expect_key = True
+        else:
+            return None
+    return tuple(path) if path and not expect_key else None
 
 
 def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
-    """Reject TOML encodings that erase the documented inline-table boundary."""
+    """Require the documented table plus one non-dotted inline mapping key."""
 
-    in_tx_interlock = False
-    for raw_line in source.splitlines():
-        line = raw_line.lstrip()
-        if _TX_INTERLOCK_NESTED_OVERRIDES_HEADER.fullmatch(line):
-            raise RigLoadError(
-                f"{filename}: [tx_interlock].disposition_overrides "
-                "must use inline table syntax"
-            )
-        if line.startswith("["):
-            in_tx_interlock = bool(_TX_INTERLOCK_TABLE_HEADER.fullmatch(line))
+    current_table: tuple[str, ...] = ()
+    forbidden_prefix = ("tx_interlock", "disposition_overrides")
+    for tokens in _toml_shape_statements(source):
+        if tokens[0][0] == "[" and tokens[-1][0] == "]":
+            inner = tokens[1:-1]
+            if inner and inner[0][0] == "[" and inner[-1][0] == "]":
+                inner = inner[1:-1]
+            path = _toml_key_path(inner)
+            current_table = path or ()
+            if current_table[:2] == forbidden_prefix:
+                raise RigLoadError(
+                    f"{filename}: [tx_interlock].disposition_overrides "
+                    "must use inline table syntax"
+                )
             continue
-        if in_tx_interlock and _TX_INTERLOCK_DOTTED_OVERRIDES_KEY.match(line):
+
+        equals = next(
+            (position for position, token in enumerate(tokens) if token[0] == "="),
+            None,
+        )
+        if equals is None:
+            continue
+        key_path = _toml_key_path(tokens[:equals])
+        if key_path is None:
+            continue
+        dotted_in_table = (
+            current_table == ("tx_interlock",)
+            and key_path[:1] == ("disposition_overrides",)
+            and len(key_path) > 1
+        )
+        dotted_at_root = current_table == () and key_path[:2] == forbidden_prefix
+        if dotted_in_table or dotted_at_root:
             raise RigLoadError(
                 f"{filename}: [tx_interlock].disposition_overrides "
                 "must use inline table syntax"

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1172,9 +1172,7 @@ def _validate_tx_interlock_override_syntax(filename: str, source: str) -> None:
             and key_path[:1] == ("disposition_overrides",)
             and len(key_path) > 1
         )
-        dotted_at_root = current_table == () and (
-            key_path == ("tx_interlock",) or key_path[:2] == forbidden_prefix
-        )
+        dotted_at_root = current_table == () and key_path[:2] == forbidden_prefix
         if dotted_in_table or dotted_at_root:
             raise RigLoadError(
                 f"{filename}: [tx_interlock].disposition_overrides "

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import tomllib
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +21,11 @@ from rigplane.core.state_acquisition_policy import (
     ReconciliationPriority,
 )
 from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.tx_interlock_contract import (
+    TX_INTERLOCK_COMMAND_FAMILY_METADATA,
+    TxInterlockCommandFamily,
+    TxInterlockDisposition,
+)
 from rigplane.commands.command_map import CommandMap
 
 __all__ = ["RigConfig", "RigLoadError", "load_rig", "discover_rigs"]
@@ -152,6 +157,9 @@ class RigConfig:
     rx_audio_channel: str = "mix"
     write_only_controls: tuple[str, ...] = ()
     state_acquisition: RadioAcquisitionProfile | None = None
+    tx_interlock_disposition_overrides: dict[
+        TxInterlockCommandFamily, TxInterlockDisposition
+    ] = field(default_factory=dict)
 
     def to_profile(self) -> RadioProfile:
         """Build a ``RadioProfile`` from this config."""
@@ -245,6 +253,7 @@ class RigConfig:
             browser_rx_transcode_to_opus=self.browser_rx_transcode_to_opus,
             write_only_controls=frozenset(self.write_only_controls),
             state_acquisition=self.state_acquisition,
+            tx_interlock_disposition_overrides=self.tx_interlock_disposition_overrides,
         )
 
     def to_command_map(self) -> CommandMap:
@@ -1046,6 +1055,66 @@ def _parse_state_acquisition(
         raise RigLoadError(f"{filename}: [state_acquisition] invalid: {exc}") from exc
 
 
+_TX_INTERLOCK_METADATA_BY_FAMILY = {
+    metadata.family: metadata for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA
+}
+
+
+def _parse_tx_interlock_disposition_overrides(
+    filename: str, raw: object
+) -> dict[TxInterlockCommandFamily, TxInterlockDisposition]:
+    """Validate the profile-only, one-way TX interlock tightening mapping."""
+
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RigLoadError(f"{filename}: [tx_interlock] must be a table")
+
+    unknown_keys = set(raw) - {"disposition_overrides"}
+    if unknown_keys:
+        raise RigLoadError(
+            f"{filename}: [tx_interlock] unknown key(s): {sorted(unknown_keys)}"
+        )
+
+    overrides_raw = raw.get("disposition_overrides", {})
+    if not isinstance(overrides_raw, dict):
+        raise RigLoadError(
+            f"{filename}: [tx_interlock].disposition_overrides must be an inline table"
+        )
+
+    overrides: dict[TxInterlockCommandFamily, TxInterlockDisposition] = {}
+    for family_value, disposition_value in overrides_raw.items():
+        try:
+            family = TxInterlockCommandFamily(family_value)
+        except ValueError as exc:
+            raise RigLoadError(
+                f"{filename}: [tx_interlock].disposition_overrides has unknown "
+                f"command family {family_value!r}"
+            ) from exc
+
+        if not isinstance(disposition_value, str):
+            raise RigLoadError(
+                f"{filename}: [tx_interlock].disposition_overrides[{family_value!r}] "
+                "must be a string"
+            )
+        if disposition_value != TxInterlockDisposition.DEFER.value:
+            raise RigLoadError(
+                f"{filename}: [tx_interlock].disposition_overrides[{family_value!r}] "
+                "must be 'defer'"
+            )
+
+        metadata = _TX_INTERLOCK_METADATA_BY_FAMILY[family]
+        if metadata.base_disposition is not TxInterlockDisposition.TX_SAFE:
+            raise RigLoadError(
+                f"{filename}: [tx_interlock].disposition_overrides family "
+                f"{family_value!r} has base disposition "
+                f"{metadata.base_disposition.value!r}, not tx-safe"
+            )
+        overrides[family] = TxInterlockDisposition.DEFER
+
+    return overrides
+
+
 def load_rig(path: Path) -> RigConfig:
     """Load and validate a rig TOML file.
 
@@ -1520,6 +1589,10 @@ def load_rig(path: Path) -> RigConfig:
         filename,
         data.get("state_acquisition"),
     )
+    tx_interlock_disposition_overrides = _parse_tx_interlock_disposition_overrides(
+        filename,
+        data.get("tx_interlock"),
+    )
 
     return RigConfig(
         id=radio["id"],
@@ -1591,6 +1664,7 @@ def load_rig(path: Path) -> RigConfig:
         rx_audio_channel=rx_audio_channel,
         write_only_controls=write_only_controls,
         state_acquisition=state_acquisition,
+        tx_interlock_disposition_overrides=tx_interlock_disposition_overrides,
     )
 
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -98,14 +98,23 @@ class TestLoadRig:
         assert rig.tx_interlock_disposition_overrides == {}
         assert rig.to_profile().tx_interlock_disposition_overrides == {}
 
-    def test_tx_interlock_parses_tx_safe_to_defer_tightening(self, tmp_path):
+    @pytest.mark.parametrize(
+        ("header", "family_key"),
+        [
+            ("[tx_interlock]", '"power-on"'),
+            ('["tx_interlock"] # quoted top-level key', "'power-on'"),
+        ],
+    )
+    def test_tx_interlock_parses_tx_safe_to_defer_tightening(
+        self, tmp_path, header, family_key
+    ):
         p = _write_toml(
             tmp_path,
             _MINIMAL_TOML
-            + """
+            + f"""
 
-[tx_interlock]
-disposition_overrides = { "power-on" = "defer" }
+{header}
+disposition_overrides = {{ {family_key} = "defer" }} # canonical inline mapping
 """,
         )
 
@@ -176,28 +185,86 @@ disposition_overrides = {{ "{family}" = "defer" }}
             load_rig(p)
 
     @pytest.mark.parametrize(
-        "declaration",
+        ("declaration", "at_root"),
         [
-            """
+            (
+                """
 [tx_interlock.disposition_overrides]
 "power-on" = "defer"
 """,
-            """
+                False,
+            ),
+            (
+                """
+["tx_interlock"."disposition_overrides"]
+"power-on" = "defer"
+""",
+                False,
+            ),
+            (
+                """
+[tx_interlock."disposition_overrides"]
+"power-on" = "defer"
+""",
+                False,
+            ),
+            (
+                """
 [tx_interlock]
 disposition_overrides."power-on" = "defer"
 """,
+                False,
+            ),
+            (
+                """
+[tx_interlock]
+disposition_overrides.power-on = "defer"
+""",
+                False,
+            ),
+            ('tx_interlock.disposition_overrides."power-on" = "defer"\n', True),
+            ('tx_interlock.disposition_overrides.power-on = "defer"\n', True),
         ],
     )
     def test_tx_interlock_rejects_non_inline_override_encodings(
-        self, tmp_path, declaration
+        self, tmp_path, declaration, at_root
     ):
-        p = _write_toml(tmp_path, _MINIMAL_TOML + declaration)
+        content = (
+            declaration + _MINIMAL_TOML if at_root else _MINIMAL_TOML + declaration
+        )
+        p = _write_toml(tmp_path, content)
 
         with pytest.raises(
             RigLoadError,
             match=r"\[tx_interlock\]\.disposition_overrides must use inline table syntax",
         ):
             load_rig(p)
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            '"[tx_interlock.disposition_overrides]"',
+            '\'disposition_overrides."power-on" = "defer"\'',
+            '"""multiline\n[tx_interlock.disposition_overrides]\n"""',
+            "'''multiline\ntx_interlock.disposition_overrides.power-on = 'defer'\n'''",
+        ],
+    )
+    def test_tx_interlock_shape_guard_ignores_string_content(self, tmp_path, label):
+        toml = _MINIMAL_TOML.replace('label = "HF"', f"label = {label}")
+
+        rig = load_rig(_write_toml(tmp_path, toml))
+
+        assert rig.tx_interlock_disposition_overrides == {}
+
+    def test_tx_interlock_shape_guard_ignores_comments(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            "# [tx_interlock.disposition_overrides]\n"
+            '# tx_interlock.disposition_overrides."power-on" = "defer"\n'
+            + _MINIMAL_TOML,
+        )
+
+        assert load_rig(p).tx_interlock_disposition_overrides == {}
 
     def test_load_minimal_power_max_watts(self, tmp_path):
         p = _write_toml(

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -187,41 +187,14 @@ disposition_overrides = {{ "{family}" = "defer" }}
     @pytest.mark.parametrize(
         ("declaration", "at_root"),
         [
+            ('\n[tx_interlock.disposition_overrides]\n"power-on" = "defer"\n', False),
             (
-                """
-[tx_interlock.disposition_overrides]
-"power-on" = "defer"
-""",
+                '\n["tx_interlock"."disposition_overrides"]\n"power-on" = "defer"\n',
                 False,
             ),
-            (
-                """
-["tx_interlock"."disposition_overrides"]
-"power-on" = "defer"
-""",
-                False,
-            ),
-            (
-                """
-[tx_interlock."disposition_overrides"]
-"power-on" = "defer"
-""",
-                False,
-            ),
-            (
-                """
-[tx_interlock]
-disposition_overrides."power-on" = "defer"
-""",
-                False,
-            ),
-            (
-                """
-[tx_interlock]
-disposition_overrides.power-on = "defer"
-""",
-                False,
-            ),
+            ('\n[tx_interlock."disposition_overrides"]\n"power-on" = "defer"\n', False),
+            ('\n[tx_interlock]\ndisposition_overrides."power-on" = "defer"\n', False),
+            ('\n[tx_interlock]\ndisposition_overrides.power-on = "defer"\n', False),
             ('tx_interlock.disposition_overrides."power-on" = "defer"\n', True),
             ('tx_interlock.disposition_overrides.power-on = "defer"\n', True),
         ],
@@ -262,6 +235,33 @@ disposition_overrides.power-on = "defer"
             "# [tx_interlock.disposition_overrides]\n"
             '# tx_interlock.disposition_overrides."power-on" = "defer"\n'
             + _MINIMAL_TOML,
+        )
+
+        assert load_rig(p).tx_interlock_disposition_overrides == {}
+
+    @pytest.mark.parametrize("key", ["tx_interlock", '"tx_interlock"'])
+    def test_tx_interlock_rejects_root_outer_inline_table(self, tmp_path, key):
+        p = _write_toml(
+            tmp_path,
+            f'{key} = {{ disposition_overrides = {{ "power-on" = "defer" }} }}\n'
+            + _MINIMAL_TOML,
+        )
+
+        with pytest.raises(RigLoadError, match="must use inline table syntax"):
+            load_rig(p)
+
+    def test_tx_interlock_shape_guard_tracks_multiline_array_context(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[metadata]
+values = [
+    ["tx_interlock"]
+]
+disposition_overrides.label = "not policy"
+""",
         )
 
         assert load_rig(p).tx_interlock_disposition_overrides == {}

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -224,6 +224,10 @@ disposition_overrides.power-on = "defer"
             ),
             ('tx_interlock.disposition_overrides."power-on" = "defer"\n', True),
             ('tx_interlock.disposition_overrides.power-on = "defer"\n', True),
+            (
+                'tx_interlock = { disposition_overrides = { "power-on" = "defer" } }\n',
+                True,
+            ),
         ],
     )
     def test_tx_interlock_rejects_non_inline_override_encodings(

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -12,6 +12,11 @@ import pytest
 
 from rigplane.command_map import CommandMap
 from rigplane.core.capabilities import CAP_SPEECH, KNOWN_CAPABILITIES
+from rigplane.core.tx_interlock_contract import (
+    TX_INTERLOCK_COMMAND_FAMILY_METADATA,
+    TxInterlockCommandFamily,
+    TxInterlockDisposition,
+)
 from rigplane.profiles import BandInfo, FreqRangeInfo, RadioProfile, get_radio_profile
 from rigplane.rig_loader import RigConfig, RigLoadError, discover_rigs, load_rig
 
@@ -86,6 +91,89 @@ class TestLoadRig:
         p = _write_toml(tmp_path, _MINIMAL_TOML)
         rig = load_rig(p)
         assert rig.model == "IC-7300"
+
+    def test_tx_interlock_tightening_defaults_empty(self, tmp_path):
+        rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
+
+        assert rig.tx_interlock_disposition_overrides == {}
+        assert rig.to_profile().tx_interlock_disposition_overrides == {}
+
+    def test_tx_interlock_parses_tx_safe_to_defer_tightening(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[tx_interlock]
+disposition_overrides = { "power-on" = "defer" }
+""",
+        )
+
+        rig = load_rig(p)
+        expected = {
+            TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
+        }
+
+        assert rig.tx_interlock_disposition_overrides == expected
+        assert rig.to_profile().tx_interlock_disposition_overrides == expected
+
+    @pytest.mark.parametrize(
+        "family",
+        [
+            metadata.family.value
+            for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA
+            if metadata.base_disposition is not TxInterlockDisposition.TX_SAFE
+        ],
+    )
+    def test_tx_interlock_rejects_ineligible_base_family(self, tmp_path, family):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[tx_interlock]
+disposition_overrides = {{ "{family}" = "defer" }}
+""",
+        )
+
+        with pytest.raises(
+            RigLoadError,
+            match=rf"\[tx_interlock\]\.disposition_overrides.*{family}.*not tx-safe",
+        ):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("declaration", "message"),
+        [
+            (
+                'disposition_overrides = { "unknown-family" = "defer" }',
+                "unknown-family",
+            ),
+            ('disposition_overrides = { "power-on" = "block" }', "must be 'defer'"),
+            ('disposition_overrides = { "power-on" = true }', "must be a string"),
+            ('disposition_overrides = ["power-on"]', "must be an inline table"),
+            ("unexpected = true", "unknown key"),
+        ],
+    )
+    def test_tx_interlock_rejects_invalid_schema(self, tmp_path, declaration, message):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + f"""
+
+[tx_interlock]
+{declaration}
+""",
+        )
+
+        with pytest.raises(RigLoadError, match=message):
+            load_rig(p)
+
+    def test_tx_interlock_section_must_be_table(self, tmp_path):
+        p = _write_toml(tmp_path, 'tx_interlock = "invalid"\n' + _MINIMAL_TOML)
+
+        with pytest.raises(RigLoadError, match=r"\[tx_interlock\] must be a table"):
+            load_rig(p)
 
     def test_load_minimal_power_max_watts(self, tmp_path):
         p = _write_toml(

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -175,6 +175,30 @@ disposition_overrides = {{ "{family}" = "defer" }}
         with pytest.raises(RigLoadError, match=r"\[tx_interlock\] must be a table"):
             load_rig(p)
 
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            """
+[tx_interlock.disposition_overrides]
+"power-on" = "defer"
+""",
+            """
+[tx_interlock]
+disposition_overrides."power-on" = "defer"
+""",
+        ],
+    )
+    def test_tx_interlock_rejects_non_inline_override_encodings(
+        self, tmp_path, declaration
+    ):
+        p = _write_toml(tmp_path, _MINIMAL_TOML + declaration)
+
+        with pytest.raises(
+            RigLoadError,
+            match=r"\[tx_interlock\]\.disposition_overrides must use inline table syntax",
+        ):
+            load_rig(p)
+
     def test_load_minimal_power_max_watts(self, tmp_path):
         p = _write_toml(
             tmp_path,

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -178,8 +178,11 @@ disposition_overrides = {{ "{family}" = "defer" }}
         with pytest.raises(RigLoadError, match=message):
             load_rig(p)
 
-    def test_tx_interlock_section_must_be_table(self, tmp_path):
-        p = _write_toml(tmp_path, 'tx_interlock = "invalid"\n' + _MINIMAL_TOML)
+    @pytest.mark.parametrize(
+        "value", ['"invalid"', "[{}]", "[{disposition_overrides={}}]"]
+    )
+    def test_tx_interlock_section_must_be_table(self, tmp_path, value):
+        p = _write_toml(tmp_path, f"tx_interlock = {value}\n" + _MINIMAL_TOML)
 
         with pytest.raises(RigLoadError, match=r"\[tx_interlock\] must be a table"):
             load_rig(p)
@@ -241,11 +244,10 @@ disposition_overrides = {{ "{family}" = "defer" }}
 
     @pytest.mark.parametrize("key", ["tx_interlock", '"tx_interlock"'])
     def test_tx_interlock_rejects_root_outer_inline_table(self, tmp_path, key):
-        p = _write_toml(
-            tmp_path,
-            f'{key} = {{ disposition_overrides = {{ "power-on" = "defer" }} }}\n'
-            + _MINIMAL_TOML,
+        content = (
+            f'{key}={{disposition_overrides={{"power-on"="defer"}}}}\n' + _MINIMAL_TOML
         )
+        p = _write_toml(tmp_path, content)
 
         with pytest.raises(RigLoadError, match="must use inline table syntax"):
             load_rig(p)

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -224,10 +224,6 @@ disposition_overrides.power-on = "defer"
             ),
             ('tx_interlock.disposition_overrides."power-on" = "defer"\n', True),
             ('tx_interlock.disposition_overrides.power-on = "defer"\n', True),
-            (
-                'tx_interlock = { disposition_overrides = { "power-on" = "defer" } }\n',
-                True,
-            ),
         ],
     )
     def test_tx_interlock_rejects_non_inline_override_encodings(


### PR DESCRIPTION
Linear: [MOR-1625](https://linear.app/morozsm/issue/MOR-1625/mor-1500-a3-parse-validated-profile-driven-tx-interlock-tightening)
Closes #2545
Depends on completed MOR-1697 / #2654.

## Summary

- parse the documented `[tx_interlock].disposition_overrides` profile mapping
- validate families and base dispositions against the static Core TX-interlock contract
- allow only the one-way `TX_SAFE -> DEFER` tightening and reject unknown or ineligible declarations
- propagate the typed mapping from `RigConfig` to `RadioProfile`

No rig profile ships an override in this change. No runtime enforcement, unknown-RF exception, model branch, CLI, or hardware behavior is changed.

## Verification

- `uv run pytest tests/test_rig_loader.py -q --tb=short --timeout=600` (232 passed, 1 skipped)
- `uv run ruff check src/rigplane/profiles/__init__.py src/rigplane/profiles/rig_loader.py tests/test_rig_loader.py`
- `uv run mypy src/rigplane/profiles/__init__.py src/rigplane/profiles/rig_loader.py`
- `uv run lint-imports`
- `git diff --check`