### PR TITLE
feat: establish Filter Width feedback foundation (MOR-1699)

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/filter-width-command-lifecycle.isolated.test.ts
@@ -47,9 +47,14 @@ vi.mock('$lib/runtime/frontend-runtime', () => ({
 vi.mock('$lib/runtime/tx-controller/app-host', () => ({ getAppTxController: () => null }));
 vi.mock('$lib/runtime/adapters/radio-view-model-adapter', () => ({ toRadioViewModel: () => null }));
 
-import { getFilterWidthCommandLifecycle } from '../panel-adapters';
-import { beginCommand } from '$lib/stores/commands.svelte';
-import { currentControlSessionEpoch, dispatchRadioIntent } from '$lib/runtime/commands/radio-intents';
+import { FILTER_WIDTH_FEEDBACK_DESCRIPTOR, getFilterWidthCommandLifecycle } from '../panel-adapters';
+import {
+  FILTER_WIDTH_COMMAND_DESCRIPTOR, STATE_BACKED_COMMAND_DESCRIPTORS,
+  beginCommand, getStateBackedCommandDescriptor,
+} from '$lib/stores/commands.svelte';
+import {
+  RADIO_INTENT_NAMES, currentControlSessionEpoch, dispatchRadioIntent,
+} from '$lib/runtime/commands/radio-intents';
 function emitAcceptedState(value: FakeState | null): void {
   commandRadio.current = value;
   for (const handler of commandRadio.listeners) handler(value);
@@ -79,6 +84,19 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     controlSession.epoch = 8;
     expect(currentControlSessionEpoch()).toBe(8);
     expect(command()).toMatchObject({ originalEpoch: 8, eventEpoch: 8 });
+  });
+  it('shares one canonical registered Filter Width descriptor and exact paths', () => {
+    expect(FILTER_WIDTH_FEEDBACK_DESCRIPTOR).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
+    expect(getStateBackedCommandDescriptor('set_filter_width')).toBe(FILTER_WIDTH_COMMAND_DESCRIPTOR);
+    expect(STATE_BACKED_COMMAND_DESCRIPTORS.size).toBe(1);
+    expect(RADIO_INTENT_NAMES).toContain(FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName);
+    const main = FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 0 } }))!;
+    const sub = FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 2100, receiver: 1 } }))!;
+    expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.fieldPath(main)).toBe('main.filterWidth');
+    expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.fieldPath(sub)).toBe('sub.filterWidth');
+    expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.scope(command({ params: { width: 3000, receiver: 2 } }))).toBeNull();
+    expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.target(command({ params: { width: 3000.5 } }))).toBeNull();
+    expect(FILTER_WIDTH_COMMAND_DESCRIPTOR.repeatPolicy).toBe('latest-target-wins');
   });
   it('stays unavailable rather than fabricating a pending or confirmed value without observed width', () => {
     runtimeState.state = state({ main: {} });
@@ -198,6 +216,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   });
   it('captures only finite public-field ACK markers through the real command store seam', async () => {
     vi.useFakeTimers();
+    controlSession.epoch = 9;
     vi.doUnmock('$lib/stores/commands.svelte');
     vi.resetModules();
     const fields = Object.fromEntries(Array.from({ length: 198 }, (_, index) => [
@@ -261,12 +280,16 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       id: 'old-main', name: 'set_filter_width', params: { width: 3000 }, originalEpoch: 7, timeoutMs: 10_000,
     });
     expect(store.isCommandLifecycleSuperseded(old)).toBe(false);
+    const repeated = store.beginCommand({
+      id: 'repeat-main', name: 'set_filter_width', params: { width: 3000 }, originalEpoch: 7, timeoutMs: 10_000,
+    });
+    expect(store.isCommandLifecycleSuperseded(old)).toBe(true);
     vi.advanceTimersByTime(1_000);
     const newer = store.beginCommand({
       id: 'new-main', name: 'set_filter_width', params: { width: 2800, receiver: 0 }, originalEpoch: 7, timeoutMs: 10_000,
     });
     store.failCommand(newer.id, newer.originalEpoch, 7, 'newer rejected');
-    expect(store.isCommandLifecycleSuperseded(old)).toBe(true);
+    expect(store.isCommandLifecycleSuperseded(repeated)).toBe(true);
     expect(getLiveView().presentation).toMatchObject({ target: 2800, status: 'failed' });
 
     vi.advanceTimersByTime(3_000);
@@ -291,15 +314,23 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
     expect(getLiveView()).toMatchObject({ confirmed: 1800, target: 2100, phase: 'pending', busy: true });
     const subPresentation = getLiveView().presentation;
 
-    store.resetCommandLifecycle();
-    expect(getLiveView().presentation).toBeNull();
+    store.cancelPendingCommands(7);
+    expect(store.getCommandLifecycle('sub', 7)?.status).toBe('cancelled');
+    controlSession.epoch = 8;
+    expect(getLiveView()).toMatchObject({ confirmed: 1800, phase: 'idle', outcome: null, presentation: null });
     const fresh = store.beginCommand({
-      id: 'sub', name: 'set_filter_width', params: { width: 2600, receiver: 0 }, originalEpoch: 8,
+      id: 'sub', name: 'set_filter_width', params: { width: 2600, receiver: 1 }, originalEpoch: 8,
     });
     expect(store.isCommandLifecycleSuperseded(fresh)).toBe(false);
-    runtimeState.state = state({ main: { filterWidth: 2400 }, sub: { filterWidth: 1800 } });
-    expect(getLiveView()).toMatchObject({ confirmed: 2400, target: 2600, phase: 'pending', busy: true });
+    expect(getLiveView()).toMatchObject({ confirmed: 1800, target: 2600, phase: 'pending', busy: true });
     expect(getLiveView().presentation?.lifecycleId).not.toBe(subPresentation?.lifecycleId);
+    emitAcceptedState(runtimeState.state); store.acknowledgeCommand('sub', 8, 8);
+    runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 2600 }, fieldStatus: {
+      'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 5 },
+    } }); emitAcceptedState(runtimeState.state);
+    expect(store.getCommandLifecycle('sub', 8)?.status).toBe('confirmed');
+    expect(getLiveView()).toMatchObject({ confirmed: 2600, phase: 'confirmed', outcome: { phase: 'confirmed' } });
+    expect(store.getCommandLifecycle('sub', 7)?.status).toBe('cancelled');
     store.resetCommandLifecycle();
   });
   it('projects a fresh frozen presentation DTO with stable lifecycle and transition identities', () => {
@@ -346,6 +377,7 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
   });
   it('keeps real-store terminal snapshots until GC and gives every transition a unique identity', async () => {
     vi.useFakeTimers(); vi.doUnmock('$lib/stores/commands.svelte'); vi.resetModules();
+    controlSession.epoch = 12;
     const store = await import('$lib/stores/commands.svelte');
     const { getFilterWidthCommandLifecycle: getLiveView } = await import('../panel-adapters');
     const transitions: string[] = [];
@@ -380,7 +412,9 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       command({ id: 'same', originalEpoch: 7, params: { width: 3000, receiver: 0 } }),
       command({ id: 'same', originalEpoch: 8, createdAt: 2, params: { width: 2100, receiver: 1 } }),
     ];
+    controlSession.epoch = 7;
     const main = getFilterWidthCommandLifecycle().presentation!;
+    controlSession.epoch = 8;
     runtimeState.state = state({ active: 'SUB', sub: { filterWidth: 2100 }, fieldStatus: {
       'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
       'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
@@ -393,6 +427,6 @@ describe('Filter Width command lifecycle projection (MOR-1664)', () => {
       'main.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
       'sub.filterWidth': { observed: true, freshness: 'fresh', availability: 'available', lastObservedMonotonic: 4 },
     } });
-    expect(getFilterWidthCommandLifecycle().presentation?.transitionId).toBe(main.transitionId);
+    expect(getFilterWidthCommandLifecycle()).toMatchObject({ phase: 'idle', presentation: null });
   });
 });

--- a/frontend/src/lib/runtime/adapters/panel-adapters.ts
+++ b/frontend/src/lib/runtime/adapters/panel-adapters.ts
@@ -31,7 +31,16 @@ import {
   hasAudioFft, hasDualReceiver, hasCapability,
 } from '$lib/stores/capabilities.svelte';
 import { recordQsy } from './qsy-history-adapter';
-import { getCommandLifecycles, isCommandLifecycleSuperseded } from '$lib/stores/commands.svelte';
+import {
+  FILTER_WIDTH_COMMAND_DESCRIPTOR,
+  getCommandLifecycles,
+  isCommandLifecycleSuperseded,
+  type CommandLifecycle,
+  type ControlFeedbackScope,
+  type StateBackedCommandDescriptor,
+  type StateBackedRepeatPolicy,
+} from '$lib/stores/commands.svelte';
+import { currentControlSessionEpoch } from '../commands/radio-intents';
 import type { ServerState } from '$lib/types/state';
 import type { Capabilities } from '$lib/types/capabilities';
 
@@ -262,68 +271,111 @@ export interface FilterWidthCommandLifecycleView {
   presentation: Readonly<FilterWidthLifecyclePresentation> | null;
 }
 
-function activeFilterWidthReceiver(): { receiver: 0 | 1; width: number; fieldPath: string; fieldStatus: NonNullable<ServerState['fieldStatus']>[string] | undefined } | null {
-  const state = runtime.state;
-  if (!state) return null;
-  const receiver: 0 | 1 = state.active === 'SUB' ? 1 : 0;
-  const width = (receiver === 0 ? state.main : state.sub)?.filterWidth;
-  if (typeof width !== 'number' || !Number.isFinite(width)) return null;
-  const fieldPath = receiver === 0 ? 'main.filterWidth' : 'sub.filterWidth';
-  const fieldStatus = state.fieldStatus?.[fieldPath];
-  if (fieldStatus?.observed !== true || fieldStatus.freshness !== 'fresh' || fieldStatus.availability !== 'available'
-    || typeof fieldStatus.lastObservedMonotonic !== 'number'
-    || !Number.isFinite(fieldStatus.lastObservedMonotonic)) return null;
-  return { receiver, width, fieldPath, fieldStatus };
+export type ControlFeedbackPhase = 'unavailable' | 'idle' | 'submitted' | 'queued' | 'dispatched'
+  | 'awaiting-confirmation' | 'confirmed' | 'failed' | 'timed-out' | 'cancelled' | 'superseded';
+export type ControlFeedbackOutcome = 'confirmed' | 'failed' | 'timed-out' | 'cancelled' | 'superseded';
+export interface ControlFeedback<T> {
+  readonly confirmed: T | null;
+  readonly target: T | null;
+  readonly requestedTarget: T | null;
+  readonly phase: ControlFeedbackPhase;
+  readonly busy: boolean;
+  readonly availability: 'available' | 'unavailable';
+  readonly outcome: Readonly<{ phase: ControlFeedbackOutcome; error?: string }> | null;
+  readonly lifecycleId: string | null;
+  readonly transitionId: string | null;
+  readonly sessionEpoch: number;
+  readonly scope: Readonly<ControlFeedbackScope>;
+  readonly repeatPolicy: StateBackedRepeatPolicy;
 }
 
-function latestFilterWidthLifecycle(receiver: 0 | 1) {
-  let latest: ReturnType<typeof getCommandLifecycles>[number] | null = null;
-  for (const command of getCommandLifecycles()) {
-  if (command.name !== 'set_filter_width' || (command.params.receiver === 1 ? 1 : 0) !== receiver
-      || typeof command.params.width !== 'number' || !Number.isFinite(command.params.width)
-      || isCommandLifecycleSuperseded(command)) continue;
-    if (!latest || command.createdAt >= latest.createdAt) latest = command;
+/** Compatibility name; identity is the sole store-registered descriptor. */
+export { FILTER_WIDTH_COMMAND_DESCRIPTOR as FILTER_WIDTH_FEEDBACK_DESCRIPTOR } from '$lib/stores/commands.svelte';
+
+const sameFeedbackScope = (left: ControlFeedbackScope | null, right: ControlFeedbackScope): boolean =>
+  left !== null && left.control === right.control && left.receiver === right.receiver
+    && (left.slot ?? null) === (right.slot ?? null);
+
+/** Pure projection of explicit lifecycle input plus canonical StateStore truth. */
+export function projectControlFeedback<T>(
+  descriptor: StateBackedCommandDescriptor<T>, state: ServerState | null,
+  commands: readonly CommandLifecycle[], scope: ControlFeedbackScope, currentSessionEpoch: number,
+  superseded: (command: CommandLifecycle) => boolean,
+): Readonly<ControlFeedback<T>> {
+  const empty = (availability: 'available' | 'unavailable', confirmed: T | null): Readonly<ControlFeedback<T>> => Object.freeze({
+    confirmed, target: null, requestedTarget: null,
+    phase: availability === 'available' ? 'idle' : 'unavailable', busy: false, availability,
+    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: currentSessionEpoch,
+    scope: Object.freeze({ ...scope }), repeatPolicy: descriptor.repeatPolicy,
+  });
+  if (state === null) return empty('unavailable', null);
+  const field = state.fieldStatus?.[descriptor.fieldPath(scope)];
+  const confirmed = descriptor.confirmed(state, scope);
+  if (confirmed === null || field?.observed !== true || field.freshness !== 'fresh'
+    || field.availability !== 'available' || typeof field.lastObservedMonotonic !== 'number'
+    || !Number.isFinite(field.lastObservedMonotonic)) return empty('unavailable', null);
+
+  let latest: CommandLifecycle | null = null;
+  for (const command of commands) {
+    if (command.originalEpoch !== currentSessionEpoch || command.name !== descriptor.intentName
+      || !sameFeedbackScope(descriptor.scope(command), scope) || descriptor.target(command) === null
+      || superseded(command)) continue;
+    if (latest === null || command.createdAt >= latest.createdAt) latest = command;
   }
-  return latest;
+  if (latest === null) return empty('available', confirmed);
+  const requestedTarget = descriptor.target(latest)!;
+  const terminal = latest.status === 'confirmed' || latest.status === 'failed'
+    || latest.status === 'timed-out' || latest.status === 'cancelled';
+  const phase: ControlFeedbackPhase = latest.status === 'pending' ? 'submitted'
+    : latest.status === 'acknowledged' ? 'awaiting-confirmation' : latest.status;
+  const error = terminal && typeof latest.error === 'string' && latest.error.length > 0
+    ? latest.error.slice(0, 256) : undefined;
+  return Object.freeze({
+    confirmed, target: terminal ? null : requestedTarget, requestedTarget, phase, busy: !terminal,
+    availability: 'available', outcome: terminal ? Object.freeze({ phase: latest.status as ControlFeedbackOutcome,
+      ...(error === undefined ? {} : { error }) }) : null,
+    lifecycleId: JSON.stringify([latest.originalEpoch, latest.id]),
+    transitionId: JSON.stringify([latest.originalEpoch, latest.id, latest.status]),
+    sessionEpoch: currentSessionEpoch, scope: Object.freeze({ ...scope }), repeatPolicy: descriptor.repeatPolicy,
+  });
 }
 
 function filterWidthPresentation(
-  command: NonNullable<ReturnType<typeof latestFilterWidthLifecycle>>, receiver: 0 | 1,
+  feedback: Readonly<ControlFeedback<number>>,
 ): Readonly<FilterWidthLifecyclePresentation> {
-  const target = command.params.width as number;
-  const lifecycleId = JSON.stringify([command.originalEpoch, command.id]);
-  const terminal = command.status === 'confirmed' || command.status === 'failed'
-    || command.status === 'timed-out' || command.status === 'cancelled';
-  const error = terminal && typeof command.error === 'string' && command.error.length > 0
-    ? command.error.slice(0, 256) : undefined;
+  const status = feedback.phase === 'submitted' ? 'pending'
+    : feedback.phase === 'awaiting-confirmation' ? 'acknowledged' : feedback.phase;
+  const error = feedback.outcome?.error;
   return Object.freeze({
-    lifecycleId,
-    transitionId: JSON.stringify([command.originalEpoch, command.id, command.status]),
-    receiver,
-    sessionEpoch: command.originalEpoch,
-    target,
-    status: command.status,
+    lifecycleId: feedback.lifecycleId!, transitionId: feedback.transitionId!,
+    receiver: feedback.scope.receiver, sessionEpoch: feedback.sessionEpoch,
+    target: feedback.requestedTarget!, status: status as FilterWidthLifecyclePresentation['status'],
     ...(error === undefined ? {} : { error }),
   });
 }
 
 export function getFilterWidthCommandLifecycle(): FilterWidthCommandLifecycleView {
-  const observed = activeFilterWidthReceiver();
-  if (!observed) return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null, presentation: null };
-
-  const command = latestFilterWidthLifecycle(observed.receiver);
-  if (!command) return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: null, presentation: null };
-  const presentation = filterWidthPresentation(command, observed.receiver);
-  if (command.status === 'confirmed') {
-    return { confirmed: observed.width, target: null, phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' }, presentation };
+  const receiver: 0 | 1 = runtime.state?.active === 'SUB' ? 1 : 0;
+  const feedback = projectControlFeedback(
+    FILTER_WIDTH_COMMAND_DESCRIPTOR, runtime.state, getCommandLifecycles(),
+    { control: 'filter-width', receiver }, currentControlSessionEpoch(), isCommandLifecycleSuperseded,
+  );
+  if (feedback.availability === 'unavailable') {
+    return { confirmed: null, target: null, phase: 'unavailable', busy: false, outcome: null, presentation: null };
   }
-  if (command.status === 'failed' || command.status === 'timed-out' || command.status === 'cancelled') {
-    return { confirmed: observed.width, target: null, phase: 'idle', busy: false, outcome: { phase: command.status, error: command.error }, presentation };
+  if (feedback.phase === 'idle') {
+    return { confirmed: feedback.confirmed, target: null, phase: 'idle', busy: false, outcome: null, presentation: null };
   }
-
-  const target = command.params.width as number;
-  if (command.status === 'acknowledged') return { confirmed: observed.width, target, phase: 'acknowledged', busy: true, outcome: null, presentation };
-  return { confirmed: observed.width, target, phase: 'pending', busy: true, outcome: null, presentation };
+  const presentation = filterWidthPresentation(feedback);
+  if (feedback.phase === 'confirmed') return { confirmed: feedback.confirmed, target: null,
+    phase: 'confirmed', busy: false, outcome: { phase: 'confirmed' }, presentation };
+  if (feedback.phase === 'failed' || feedback.phase === 'timed-out' || feedback.phase === 'cancelled') {
+    return { confirmed: feedback.confirmed, target: null, phase: 'idle', busy: false,
+      outcome: { phase: feedback.phase, error: feedback.outcome?.error }, presentation };
+  }
+  return { confirmed: feedback.confirmed, target: feedback.target,
+    phase: feedback.phase === 'awaiting-confirmation' ? 'acknowledged' : 'pending',
+    busy: true, outcome: null, presentation };
 }
 
 // ── Pending discrete-control targets (MOR-1441 leg 2) ──

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -1,5 +1,6 @@
 import { getRadioState, subscribeRadioState } from './radio.svelte';
 import type { ServerState } from '../types/state';
+import type { RadioIntentName } from '../runtime/commands/radio-intents';
 
 export type CommandLifecycleStatus = 'pending' | 'acknowledged' | 'confirmed' | 'failed' | 'cancelled' | 'timed-out';
 export interface CommandLifecycle {
@@ -29,6 +30,49 @@ export interface BeginCommandInput {
   originalEpoch: number; timeoutMs?: number;
 }
 
+export interface ControlFeedbackScope {
+  readonly control: string;
+  readonly receiver: 0 | 1;
+  readonly slot?: string;
+}
+export type StateBackedRepeatPolicy = 'latest-target-wins';
+export interface StateBackedCommandDescriptor<T> {
+  readonly intentName: RadioIntentName;
+  readonly repeatPolicy: StateBackedRepeatPolicy;
+  scope(command: Pick<CommandLifecycle, 'params'>): ControlFeedbackScope | null;
+  fieldPath(scope: ControlFeedbackScope): string;
+  target(command: Pick<CommandLifecycle, 'params'>): T | null;
+  confirmed(state: ServerState, scope: ControlFeedbackScope): T | null;
+  matches(confirmed: T, target: T): boolean;
+}
+
+export type FilterWidthFieldPath = 'main.filterWidth' | 'sub.filterWidth';
+const finiteNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+const safeInteger = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isSafeInteger(value) ? value : null;
+
+export const FILTER_WIDTH_COMMAND_DESCRIPTOR: StateBackedCommandDescriptor<number> = Object.freeze({
+  intentName: 'set_filter_width', repeatPolicy: 'latest-target-wins',
+  scope: (command: Pick<CommandLifecycle, 'params'>) => {
+    const receiver = command.params.receiver;
+    return receiver === undefined || receiver === 0 || receiver === 1
+      ? Object.freeze({ control: 'filter-width', receiver: receiver === 1 ? 1 : 0 }) : null;
+  },
+  fieldPath: (scope: ControlFeedbackScope): FilterWidthFieldPath =>
+    scope.receiver === 1 ? 'sub.filterWidth' : 'main.filterWidth',
+  target: (command: Pick<CommandLifecycle, 'params'>) => safeInteger(command.params.width),
+  confirmed: (state: ServerState, scope: ControlFeedbackScope) => finiteNumber(
+    (scope.receiver === 1 ? state.sub : state.main)?.filterWidth,
+  ),
+  matches: (confirmed: number, target: number) => confirmed === target,
+});
+
+export const STATE_BACKED_COMMAND_DESCRIPTORS: ReadonlyMap<RadioIntentName, StateBackedCommandDescriptor<unknown>> =
+  new Map([[FILTER_WIDTH_COMMAND_DESCRIPTOR.intentName, FILTER_WIDTH_COMMAND_DESCRIPTOR]]);
+export const getStateBackedCommandDescriptor = (intentName: string): StateBackedCommandDescriptor<unknown> | undefined =>
+  (STATE_BACKED_COMMAND_DESCRIPTORS as ReadonlyMap<string, StateBackedCommandDescriptor<unknown>>).get(intentName);
+
 const DEFAULT_TIMEOUT_MS = 5_000;
 /**
  * Terminal outcomes remain available for a five-second bounded presentation
@@ -37,15 +81,21 @@ const DEFAULT_TIMEOUT_MS = 5_000;
  */
 const OUTCOME_RETENTION_MS = 5_000;
 const MAX_RETAINED_COMMANDS = 100;
-const ACK_CORRELATION_PATHS = ['main.filterWidth', 'sub.filterWidth'] as const;
 let commands = $state<CommandLifecycle[]>([]);
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
 const supersededRecordKeys = new Set<string>();
-let filterWidthReconciliationStarted = false;
+let stateBackedReconciliationStarted = false;
 const key = (id: string, epoch: number): string => `${epoch}:${id}`;
 
 const receiverScope = (command: Pick<CommandLifecycle, 'params'>): 0 | 1 =>
   command.params.receiver === 1 ? 1 : 0;
+const scopeKey = (scope: ControlFeedbackScope): string =>
+  JSON.stringify([scope.control, scope.receiver, scope.slot ?? null]);
+const commandScopeKey = (command: Pick<CommandLifecycle, 'name' | 'params'>): string => {
+  const scope = getStateBackedCommandDescriptor(command.name)?.scope(command);
+  return scope === null || scope === undefined
+    ? JSON.stringify(['legacy-receiver', receiverScope(command)]) : scopeKey(scope);
+};
 
 export const isCommandLifecycleSuperseded = (command: CommandLifecycle): boolean => supersededRecordKeys.has(key(command.id, command.originalEpoch));
 
@@ -101,34 +151,37 @@ function transition(
   if (status === 'acknowledged') {
     const radio = getRadioState(); command.ackObservationSeq = radio?.observationSeq;
     const observations: Record<string, number> = {};
-    for (const path of ACK_CORRELATION_PATHS) {
+    const descriptor = getStateBackedCommandDescriptor(command.name);
+    const scope = descriptor?.scope(command);
+    const path = scope === null || scope === undefined ? null : descriptor?.fieldPath(scope);
+    if (path !== null && path !== undefined) {
       const field = radio?.fieldStatus?.[path];
       const marker = field?.lastObservedMonotonic;
       if (typeof marker === 'number' && Number.isFinite(marker)) observations[path] = marker;
     }
     command.ackFieldObservationTimes = observations;
     startLiveDeadline(command);
-    if (command.name === 'set_filter_width') startFilterWidthReconciliation();
+    if (descriptor !== undefined) startStateBackedReconciliation();
   } else {
     retainTerminalOutcome(command);
   }
 }
 
-/** Accepted state, not a presentation read, reconciles Filter Width. */
-function reconcileFilterWidthCommands(state: ServerState | null): void {
+/** Accepted StateStore observations, never presentation reads, reconcile commands. */
+function reconcileStateBackedCommands(state: ServerState | null): void {
   if (!state) return;
   for (const command of commands) {
-    if (command.name !== 'set_filter_width' || command.status !== 'acknowledged' || isCommandLifecycleSuperseded(command)) continue;
-
-    const receiver = receiverScope(command);
-    const path = receiver === 1 ? 'sub.filterWidth' : 'main.filterWidth';
+    if (command.status !== 'acknowledged' || isCommandLifecycleSuperseded(command)) continue;
+    const descriptor = getStateBackedCommandDescriptor(command.name);
+    const scope = descriptor?.scope(command);
+    const target = descriptor?.target(command);
+    if (descriptor === undefined || scope === null || scope === undefined || target === null || target === undefined) continue;
+    const path = descriptor.fieldPath(scope);
     const field = state.fieldStatus?.[path];
     const marker = field?.lastObservedMonotonic;
-    const width = (receiver === 1 ? state.sub : state.main)?.filterWidth;
-    const target = command.params.width;
+    const confirmed = descriptor.confirmed(state, scope);
     if (field?.observed !== true || field.freshness !== 'fresh' || field.availability !== 'available' || typeof marker !== 'number' || !Number.isFinite(marker)
-      || typeof width !== 'number' || !Number.isFinite(width)
-      || typeof target !== 'number' || !Number.isFinite(target)) continue;
+      || confirmed === null) continue;
 
     const boundaries = command.ackFieldObservationTimes;
     if (boundaries === undefined) continue;
@@ -137,14 +190,16 @@ function reconcileFilterWidthCommands(state: ServerState | null): void {
       command.ackFieldObservationTimes = { ...boundaries, [path]: marker };
       continue;
     }
-    if (marker > boundary && width === target) transition(command.id, command.originalEpoch, 'confirmed', command.eventEpoch ?? command.originalEpoch);
+    if (marker > boundary && descriptor.matches(confirmed, target)) {
+      transition(command.id, command.originalEpoch, 'confirmed', command.eventEpoch ?? command.originalEpoch);
+    }
   }
 }
 
-function startFilterWidthReconciliation(): void {
-  if (filterWidthReconciliationStarted) return;
-  filterWidthReconciliationStarted = true;
-  subscribeRadioState(reconcileFilterWidthCommands);
+function startStateBackedReconciliation(): void {
+  if (stateBackedReconciliationStarted) return;
+  stateBackedReconciliationStarted = true;
+  subscribeRadioState(reconcileStateBackedCommands);
 }
 
 export function beginCommand(input: BeginCommandInput): CommandLifecycle {
@@ -153,8 +208,8 @@ export function beginCommand(input: BeginCommandInput): CommandLifecycle {
   const now = Date.now();
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const command: CommandLifecycle = { ...input, timeoutMs, createdAt: now, updatedAt: now, status: 'pending' };
-  const scope = receiverScope(command);
-  for (const existing of commands) if (existing.name === command.name && receiverScope(existing) === scope) {
+  for (const existing of commands) if (existing.originalEpoch === command.originalEpoch
+    && existing.name === command.name && commandScopeKey(existing) === commandScopeKey(command)) {
     supersededRecordKeys.add(key(existing.id, existing.originalEpoch));
   }
   commands.push(command);


### PR DESCRIPTION
## Summary

- register one canonical Filter Width command descriptor in the sole command-lifecycle store
- derive lifecycle correlation, ACK observation barriers, exact StateStore field paths, target extraction, matching, and latest-target-wins semantics from that descriptor
- project typed pure `ControlFeedback<T>` with explicit current-session epoch filtering and preserve the public Filter Width lifecycle accessor
- cover descriptor identity, canonical inventory and paths, shared ACK correlation, retained cancelled prior-session records, reused command IDs, fresh confirmation, and supersession

## Scope

This PR implements MOR-1699, the production foundation unblocked by MOR-1698. MOR-1687 remains the tracking parent for dependent control-feedback adoption.

The change is intentionally bounded to three files and 303 changed LOC. The panel compatibility export is an identity re-export of the store-registered descriptor; no duplicate descriptor or feedback authority is introduced.

## Architecture and safety

- StateStore remains the sole confirmed radio truth
- the existing command-lifecycle store remains the sole lifecycle owner
- ACK and delivery never confirm; confirmation requires a newer, exact, fresh StateStore observation after the captured barrier
- prior-session lifecycle records are excluded before intent, scope, target, supersession, and latest-target selection
- no second store, writer, poller, confirmation timer, model branch, or TX/resource generalization
- no hardware, browser, API, CAT, audio, or TX claim

## Verification

- focused command-store, radio-intent, Filter Width isolated/mounted, and FilterPanel suites: 5 files / 119 tests passed
- full frontend: 350 files / 7,591 tests passed
- `pnpm --dir frontend check` (0 errors, 0 warnings)
- scoped ESLint on all three changed files
- diff/whitespace/privacy checks

Linear: MOR-1699
Parent: MOR-1687
