### PR TITLE
[MOR-1692] retain truthful PBT values across acquisition gaps

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -40,7 +40,10 @@
   import DspSurface, {
     type DspLevelField, type DspToggleField,
   } from '../../semantic/DspSurface.svelte';
-  import FilterSurface from '../../semantic/FilterSurface.svelte';
+  import FilterSurface, {
+    EMPTY_PBT_PRESENTATION, projectPbtPresentation,
+    type PbtObservationOrder, type PbtPresentationEvidence,
+  } from '../../semantic/FilterSurface.svelte';
   import MetersSurface from '../../semantic/MetersSurface.svelte';
   import type { RadioViewModel } from '../../semantic/radio-view-model';
   import RfFrontEndSurface, {
@@ -445,9 +448,49 @@
   // (invariant R9). Without it the adapter emits no `meters` group at all.
   // MOR-1279 slice 3B: the RX-audio snapshot is the FOURTH.
   // MOR-1312 slice 12B: the scope-display snapshot is the FIFTH.
-  let view: RadioViewModel | null = $derived(
-    toRadioViewModel(runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot),
-  );
+  let pbtPresentationState = EMPTY_PBT_PRESENTATION;
+  function pbtEvidence(canonical: RadioViewModel | null): PbtPresentationEvidence {
+    const state = runtime.state;
+    const caps = runtime.caps;
+    const generation = state?.providerGeneration;
+    if (
+      !state || !caps || !Number.isSafeInteger(generation) || generation !== caps.providerGeneration
+      || canonical?.activeReceiver.status !== 'known'
+    ) {
+      return { boundary: null, order: { pbtInner: null, pbtOuter: null } };
+    }
+    const receiver = canonical.activeReceiver.receiver;
+    const base = receiver === 'MAIN' ? 'main.' : 'sub.';
+    const snapshotOrder = (): PbtObservationOrder | null => Number.isSafeInteger(state.observationSeq)
+      ? { source: 'snapshot', value: state.observationSeq }
+      : null;
+    const orderFor = (field: 'pbtInner' | 'pbtOuter'): PbtObservationOrder | null => {
+      const status = state.fieldStatus?.[`${base}${field}`];
+      if (!status) return snapshotOrder();
+      if (
+        status.observed !== true || status.freshness !== 'fresh'
+        || status.availability !== 'available'
+      ) return null;
+      return typeof status.lastObservedMonotonic === 'number'
+        && Number.isFinite(status.lastObservedMonotonic)
+        ? { source: 'field', value: status.lastObservedMonotonic }
+        : snapshotOrder();
+    };
+    return {
+      boundary: `${generation}:${receiver}`,
+      order: { pbtInner: orderFor('pbtInner'), pbtOuter: orderFor('pbtOuter') },
+    };
+  }
+  let view: RadioViewModel | null = $derived.by(() => {
+    const canonical = toRadioViewModel(
+      runtime.state, runtime.caps, txState, rxAudioSnapshot, scopeDisplaySnapshot,
+    );
+    const projection = projectPbtPresentation(
+      pbtPresentationState, canonical, pbtEvidence(canonical),
+    );
+    pbtPresentationState = projection.state;
+    return projection.view;
+  });
 
   /**
    * MOR-1441 leg 2 — active receiver's wire index (0=MAIN, 1=SUB) for the

--- a/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts
@@ -1,0 +1,248 @@
+/**
+ * MOR-1692 — PBT continuity over the real frontend state -> semantic adapter
+ * -> mounted FilterSurface path.  State and capabilities use their real
+ * generation-gated stores; only the network boundary and unrelated TX host
+ * are replaced.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { FieldStatus, ServerState } from '$lib/types/state';
+
+const { sendCommand } = vi.hoisted(() => ({ sendCommand: vi.fn(() => true) }));
+vi.mock('$lib/transport/ws-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/transport/ws-client')>()),
+  sendCommand,
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => ({
+      phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+      mayOwnKey: false, fault: null,
+    }),
+    subscribe: () => () => {}, start: vi.fn(), setIntent: vi.fn(),
+    release: vi.fn(), resetFault: vi.fn(),
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => ({ visible: false, sourceLabel: null }),
+  getModInputTxGuardHandlers: () => ({ onSetLan: vi.fn(), onDismiss: vi.fn() }),
+}));
+
+import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import { resetRadioState, setRadioState } from '$lib/stores/radio.svelte';
+import { resetCommandLifecycle } from '$lib/stores/commands.svelte';
+
+const status = (
+  path: string, at: number, kind: 'fresh' | 'stale' | 'missing' = 'fresh',
+): FieldStatus => ({
+  storePath: path,
+  observed: kind !== 'missing',
+  freshness: kind === 'fresh' ? 'fresh' : kind === 'stale' ? 'stale' : 'unknown',
+  availability: kind === 'fresh' ? 'available' : kind,
+  ...(kind === 'missing' ? {} : { lastObservedMonotonic: at, maxAge: 10 }),
+});
+
+function caps(generation = 0, receivers = 1, pbt = true): Capabilities {
+  return {
+    model: 'fixture', scope: false, audio: false, tx: false,
+    capabilities: pbt ? ['pbt'] : [], receivers, vfoScheme: receivers === 1 ? 'single' : 'main_sub',
+    freqRanges: [], modes: [], filters: [], txBands: null,
+    controls: pbt ? {
+      pbt_inner: {
+        raw_min: 0, raw_max: 255, raw_center: 128,
+        display_min: -1200, display_max: 1200, display_unit: 'Hz',
+      },
+    } : {},
+    stateContractVersion: 1, providerGeneration: generation,
+  } as unknown as Capabilities;
+}
+
+interface StateOptions {
+  generation?: number;
+  revision?: number;
+  observationSeq?: number;
+  active?: 'MAIN' | 'SUB';
+  inner?: number;
+  outer?: number;
+  innerKind?: 'fresh' | 'stale' | 'missing';
+  outerKind?: 'fresh' | 'stale' | 'missing';
+  innerAt?: number;
+  outerAt?: number;
+}
+
+function state(options: StateOptions = {}): ServerState {
+  const {
+    generation = 0, revision = 1, observationSeq = revision, active = 'MAIN',
+    inner = 160, outer = 96, innerKind = 'fresh', outerKind = 'fresh',
+    innerAt = observationSeq, outerAt = observationSeq,
+  } = options;
+  const receiver = (pbtInner: number | undefined, pbtOuter: number | undefined) => ({
+    freqHz: 14_200_000, mode: 'USB', filter: 1, dataMode: 0, sMeter: 20,
+    att: 0, preamp: 0, nb: false, nr: false, afLevel: 100, rfGain: 255, squelch: 0,
+    ...(pbtInner === undefined ? {} : { pbtInner }),
+    ...(pbtOuter === undefined ? {} : { pbtOuter }),
+  });
+  return {
+    stateContractVersion: 1, providerGeneration: generation,
+    revision, stateRevision: revision, freshnessRevision: revision, observationSeq,
+    updatedAt: '2026-08-15T00:00:00Z', active, ptt: false, split: false,
+    dualWatch: false, tunerStatus: 0,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main: receiver(innerKind === 'missing' ? undefined : inner, outerKind === 'missing' ? undefined : outer),
+    sub: receiver(innerKind === 'missing' ? undefined : inner, outerKind === 'missing' ? undefined : outer),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    fieldStatus: {
+      active: status('active', observationSeq),
+      [`${active === 'SUB' ? 'sub' : 'main'}.pbtInner`]: status('pbtInner', innerAt, innerKind),
+      [`${active === 'SUB' ? 'sub' : 'main'}.pbtOuter`]: status('pbtOuter', outerAt, outerKind),
+    },
+  } as unknown as ServerState;
+}
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+
+const row = (field: 'pbtInner' | 'pbtOuter') =>
+  target.querySelector<HTMLElement>(`[data-testid="filter-${field}"]`)!;
+const input = (field: 'pbtInner' | 'pbtOuter') => row(field).querySelector<HTMLInputElement>('input')!;
+const output = (field: 'pbtInner' | 'pbtOuter') => row(field).querySelector('output')!.textContent;
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(SemanticRadioSurfaces, { target });
+  flushSync();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  expect(setCapabilities(caps())).toBe(true);
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+  resetRadioState();
+  clearCapabilities();
+  resetCommandLifecycle();
+  sendCommand.mockClear();
+  vi.useRealTimers();
+});
+
+describe('mounted PBT presentation continuity (MOR-1692)', () => {
+  it('keeps independent last-confirmed values through stale/missing gaps and recovers without an endpoint jump', () => {
+    expect(setRadioState(state())).toBe(true);
+    render();
+    expect([output('pbtInner'), output('pbtOuter')]).toEqual(['300', '-300']);
+
+    expect(setRadioState(state({
+      revision: 2, observationSeq: 2, innerKind: 'stale', outerKind: 'missing',
+    }))).toBe(true);
+    flushSync();
+    expect([output('pbtInner'), output('pbtOuter')]).toEqual(['300', '-300']);
+    expect([row('pbtInner').dataset.presentation, row('pbtOuter').dataset.presentation])
+      .toEqual(['retained', 'retained']);
+    expect(input('pbtInner').disabled).toBe(true);
+    expect(input('pbtOuter').disabled).toBe(true);
+    expect([input('pbtInner').value, input('pbtOuter').value]).toEqual(['300', '-300']);
+
+    expect(setRadioState(state({
+      revision: 3, observationSeq: 3, inner: 176, outer: 80, innerAt: 3, outerAt: 3,
+    }))).toBe(true);
+    flushSync();
+    expect([output('pbtInner'), output('pbtOuter')]).toEqual(['450', '-450']);
+    expect([row('pbtInner').dataset.presentation, row('pbtOuter').dataset.presentation])
+      .toEqual(['confirmed', 'confirmed']);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('shows no false thumb when no confirmed value exists', () => {
+    expect(setRadioState(state({ innerKind: 'missing', outerKind: 'missing' }))).toBe(true);
+    render();
+    expect([output('pbtInner'), output('pbtOuter')]).toEqual(['?', '?']);
+    expect([row('pbtInner').dataset.presentation, row('pbtOuter').dataset.presentation])
+      .toEqual(['unknown', 'unknown']);
+    expect(input('pbtInner').dataset.thumb).toBe('hidden');
+    expect(input('pbtOuter').dataset.thumb).toBe('hidden');
+  });
+
+  it('rejects a delayed older readback, then accepts a newer confirmation', () => {
+    expect(setRadioState(state({ innerAt: 20, outerAt: 20 }))).toBe(true);
+    render();
+
+    expect(setRadioState(state({
+      revision: 2, observationSeq: 2, inner: 64, outer: 192, innerAt: 10, outerAt: 10,
+    }))).toBe(true);
+    flushSync();
+    expect([output('pbtInner'), output('pbtOuter')]).toEqual(['300', '-300']);
+    expect(row('pbtInner').dataset.presentation).toBe('retained');
+
+    expect(setRadioState(state({
+      revision: 3, observationSeq: 3, inner: 176, outer: 80, innerAt: 30, outerAt: 30,
+    }))).toBe(true);
+    flushSync();
+    expect([output('pbtInner'), output('pbtOuter')]).toEqual(['450', '-450']);
+  });
+
+  it('clears continuity on provider generation and receiver identity boundaries', () => {
+    expect(setRadioState(state())).toBe(true);
+    render();
+    expect(output('pbtInner')).toBe('300');
+
+    expect(setCapabilities(caps(1))).toBe(true);
+    expect(setRadioState(state({
+      generation: 1, revision: 1, observationSeq: 1,
+      innerKind: 'missing', outerKind: 'missing',
+    }))).toBe(true);
+    flushSync();
+    expect(row('pbtInner').dataset.presentation).toBe('unknown');
+
+    expect(setCapabilities(caps(2, 2))).toBe(true);
+    expect(setRadioState(state({ generation: 2, revision: 1, observationSeq: 1 }))).toBe(true);
+    flushSync();
+    expect(output('pbtInner')).toBe('300');
+    expect(setRadioState(state({
+      generation: 2, revision: 2, observationSeq: 2, active: 'SUB',
+      innerKind: 'missing', outerKind: 'missing',
+    }))).toBe(true);
+    flushSync();
+    expect(row('pbtInner').dataset.presentation).toBe('unknown');
+  });
+
+  it('does not restore retained values after an explicit unsupported interval', () => {
+    expect(setRadioState(state())).toBe(true);
+    render();
+    expect(output('pbtInner')).toBe('300');
+    expect(setCapabilities(caps(0, 1, false))).toBe(true);
+    flushSync();
+    expect(target.querySelector('[data-testid="filter-pbtInner"]')).toBeNull();
+    expect(setCapabilities(caps())).toBe(true);
+    expect(setRadioState(state({ revision: 2, observationSeq: 2, innerKind: 'missing' }))).toBe(true);
+    flushSync();
+    expect(row('pbtInner').dataset.presentation).toBe('unknown');
+  });
+
+  it('keeps Inner/Outer command gestures independent and recovery emits no extra command', () => {
+    expect(setRadioState(state())).toBe(true);
+    render();
+    input('pbtInner').value = '375';
+    input('pbtInner').dispatchEvent(new Event('input', { bubbles: true }));
+    input('pbtOuter').value = '-375';
+    input('pbtOuter').dispatchEvent(new Event('input', { bubbles: true }));
+    vi.advanceTimersByTime(60);
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+
+    expect(setRadioState(state({
+      revision: 2, observationSeq: 2, innerKind: 'stale', outerKind: 'stale',
+    }))).toBe(true);
+    flushSync();
+    expect(setRadioState(state({
+      revision: 3, observationSeq: 3, inner: 168, outer: 88, innerAt: 3, outerAt: 3,
+    }))).toBe(true);
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -55,7 +55,87 @@
   never something computed off the pending display.
 -->
 <script module lang="ts">
-  import type { TxAuxField } from './radio-view-model';
+  import type { RadioViewModel, TxAuxField } from './radio-view-model';
+
+  export type PbtField = 'pbtInner' | 'pbtOuter';
+  export type PbtObservationOrder =
+    | Readonly<{ source: 'field'; value: number }>
+    | Readonly<{ source: 'snapshot'; value: number }>;
+  type RetainedPbt = Readonly<{ value: number; order: PbtObservationOrder }>;
+  export interface PbtPresentationState {
+    boundary: string | null;
+    pbtInner: RetainedPbt | null;
+    pbtOuter: RetainedPbt | null;
+  }
+  export interface PbtPresentationEvidence {
+    readonly boundary: string | null;
+    readonly order: Readonly<Record<PbtField, PbtObservationOrder | null>>;
+  }
+  export const EMPTY_PBT_PRESENTATION: Readonly<PbtPresentationState> = Object.freeze({
+    boundary: null, pbtInner: null, pbtOuter: null,
+  });
+
+  const PBT_FIELDS = ['pbtInner', 'pbtOuter'] as const;
+  const isNotOlder = (next: PbtObservationOrder, previous: PbtObservationOrder): boolean => {
+    if (next.source === previous.source) return next.value >= previous.value;
+    // A field-local observation marker is stronger than a snapshot fallback.
+    // Never replace it with an incomparable fallback; a real field marker may
+    // establish a new field-local ordering domain.
+    return next.source === 'field';
+  };
+
+  /**
+   * Pure, presentation-only PBT continuity reducer. Canonical radio truth is
+   * never changed: a retained reading remains operational:false, and the
+   * returned state is owned by one mounted composition instance rather than
+   * by a second radio store, poller, writer, or timer.
+   */
+  export function projectPbtPresentation(
+    previous: Readonly<PbtPresentationState>,
+    canonical: RadioViewModel | null,
+    evidence: PbtPresentationEvidence,
+  ): Readonly<{ state: Readonly<PbtPresentationState>; view: RadioViewModel | null }> {
+    const passband = canonical?.filterPassband;
+    if (!canonical || !passband || evidence.boundary === null) {
+      return Object.freeze({ state: EMPTY_PBT_PRESENTATION, view: canonical });
+    }
+    const sameBoundary = previous.boundary === evidence.boundary;
+    const nextState: PbtPresentationState = {
+      boundary: evidence.boundary, pbtInner: null, pbtOuter: null,
+    };
+    const projected = { ...passband };
+    for (const field of PBT_FIELDS) {
+      const current = passband[field];
+      const retained = sameBoundary ? previous[field] : null;
+      const order = evidence.order[field];
+      if (!current.availability.structural) continue;
+      if (
+        current.availability.operational
+        && current.reading.status === 'known'
+        && Number.isFinite(current.reading.value)
+        && order !== null
+      ) {
+        if (retained && !isNotOlder(order, retained.order)) {
+          nextState[field] = retained;
+          projected[field] = {
+            reading: { status: 'known', value: retained.value },
+            availability: { structural: true, operational: false },
+          };
+        } else {
+          nextState[field] = Object.freeze({ value: current.reading.value, order });
+        }
+      } else if (retained) {
+        nextState[field] = retained;
+        projected[field] = {
+          reading: { status: 'known', value: retained.value },
+          availability: { structural: true, operational: false },
+        };
+      }
+    }
+    const state = Object.freeze(nextState);
+    const view = Object.freeze({ ...canonical, filterPassband: Object.freeze(projected) });
+    return Object.freeze({ state, view });
+  }
 
   /** Fixed filter-shape choice set (SHARP/SOFT) — same two options
    *  `FilterPanel`'s shape buttons offer, `[value, label]`. */
@@ -79,6 +159,8 @@
     usable(f) ? undefined : 'field-not-observed';
   const textOf = (f: TxAuxField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : '?';
+  const presentationOf = (f: TxAuxField<unknown>): 'confirmed' | 'retained' | 'unknown' =>
+    usable(f) ? 'confirmed' : f.reading.status === 'known' ? 'retained' : 'unknown';
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
   /** Never fabricates a selection: `usable` alone cannot narrow `reading` for
@@ -89,7 +171,6 @@
 
 <script lang="ts">
   import { t } from '$lib/i18n';
-  import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
     view: RadioViewModel;
@@ -213,11 +294,13 @@
           <label
             class="filter-level" data-testid={`filter-${field}`}
             data-disabled-reason={reasonOf(filterPassband[field])}
+            data-presentation={presentationOf(filterPassband[field])}
           >
             <span class="filter-level-name">{label}</span>
             <input
               type="range" {min} {max} {step}
               value={numberOf(filterPassband[field], min)}
+              data-thumb={filterPassband[field].reading.status === 'known' ? 'visible' : 'hidden'}
               disabled={!usable(filterPassband[field])}
               oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
             />
@@ -245,6 +328,12 @@
   .filter-level-name { min-width: 8ch; }
   .filter-choice[aria-pressed='true'] { font-weight: 700; }
   .filter-choice:disabled { cursor: not-allowed; }
+  /* A range has no native indeterminate state. When no confirmed value has
+     ever existed, hide its thumb instead of rendering the browser's numeric
+     fallback as a plausible zero/endpoint position. The track and '?' remain
+     visible, so structural support and temporary unavailability stay clear. */
+  input[type='range'][data-thumb='hidden']::-webkit-slider-thumb { opacity: 0; }
+  input[type='range'][data-thumb='hidden']::-moz-range-thumb { opacity: 0; }
   /* MOR-1441 leg 2 — a pending (unconfirmed) target never renders identically
      to confirmed truth. Structural (italic + reduced opacity), never a
      color-only tell — same doctrine `.freq[data-freq-status='pending']`


### PR DESCRIPTION
## Summary

- retain each PBT field's last confirmed presentation value only within the same provider-generation and receiver boundary
- keep retained values structurally unavailable/disabled rather than marking them fresh or confirmed
- hide an indeterminate range thumb when no confirmed value exists, and reject delayed older field observations
- keep the continuity reducer local to one mounted composition; no radio store, poller, writer, timer, model branch, or command path is added

## Verification

- `npm test -- --run src/components-v2/wiring/__tests__/semantic-pbt-continuity.component.test.ts src/semantic/__tests__/FilterSurface.test.ts src/lib/runtime/adapters/__tests__/filter-passband-adapter.isolated.test.ts src/lib/runtime/adapters/__tests__/radio-view-model-adapter.test.ts` (149 passed)
- `npm test -- --run` (351 files, 7597 passed; frontend tree unchanged by the subsequent normal merge of current `main`)
- `npm run check`
- `npm run lint`
- diff guard: 3 files, 392 changed LOC; privacy scan clean

## Hardware boundary

Software-only. Owner-present IC-7300 screenshot/browser validation remains required before MOR-1692 can be Done. No runtime, radio, USB, audio, browser, server, CAT, PTT, TUNE, or TX action was performed.

Linear: MOR-1692