### PR TITLE
MOR-1707: validate loader-private scalar control domains

### DIFF
--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -19,7 +19,6 @@ from rigplane.core.tx_interlock_contract import (
 )
 
 __all__ = [
-    "ControlLookupPoint",
     "ControlSpec",
     "FilterWidthSegment",
     "FilterWidthRule",
@@ -35,34 +34,16 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-class ControlLookupPoint(TypedDict):
-    """One raw/display pair for an explicit lookup-table control mapping."""
-
-    raw: int
-    display: int | float
-
-
 class ControlSpec(TypedDict, total=False):
     """Specification for a single radio control (from TOML ``[controls.*]``)."""
 
     style: str
-    range_min: int
-    range_max: int
     raw_min: int
     raw_max: int
-    raw_step: int
-    raw_origin: int
     raw_center: int
-    display_min: int | float
-    display_max: int | float
-    display_step: int | float
-    display_origin: int | float
-    display_center: int | float
+    display_min: int
+    display_max: int
     display_unit: str
-    mapping: str
-    quantization: str
-    restoration: str
-    lookup: list[ControlLookupPoint]
 
 
 class MeterCalibrationPoint(TypedDict):

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -19,6 +19,7 @@ from rigplane.core.tx_interlock_contract import (
 )
 
 __all__ = [
+    "ControlLookupPoint",
     "ControlSpec",
     "FilterWidthSegment",
     "FilterWidthRule",
@@ -34,16 +35,34 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+class ControlLookupPoint(TypedDict):
+    """One raw/display pair for an explicit lookup-table control mapping."""
+
+    raw: int
+    display: int | float
+
+
 class ControlSpec(TypedDict, total=False):
     """Specification for a single radio control (from TOML ``[controls.*]``)."""
 
     style: str
+    range_min: int
+    range_max: int
     raw_min: int
     raw_max: int
+    raw_step: int
+    raw_origin: int
     raw_center: int
-    display_min: int
-    display_max: int
+    display_min: int | float
+    display_max: int | float
+    display_step: int | float
+    display_origin: int | float
+    display_center: int | float
     display_unit: str
+    mapping: str
+    quantization: str
+    restoration: str
+    lookup: list[ControlLookupPoint]
 
 
 class MeterCalibrationPoint(TypedDict):

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -139,6 +139,16 @@ def _control_decimal(value: object, path: str) -> Decimal:
     return decimal
 
 
+def _on_control_lattice(
+    value: int | Decimal, origin: int | Decimal, step: int | Decimal
+) -> bool:
+    (value_num, value_den), (origin_num, origin_den), (step_num, step_den) = (
+        Decimal(item).as_integer_ratio() for item in (value, origin, step)
+    )
+    numerator = (value_num * origin_den - origin_num * value_den) * step_den
+    return numerator % (value_den * origin_den * step_num) == 0
+
+
 def _parse_control_spec(
     filename: str, control_name: str, raw: object
 ) -> tuple[ControlSpec | None, _ScalarControlDomain | None]:
@@ -234,7 +244,7 @@ def _parse_control_spec(
         ("display_min", display_min, display_origin, display_step),
         ("display_max", display_max, display_origin, display_step),
     ):
-        if (value - origin) % step != 0:
+        if not _on_control_lattice(value, origin, step):
             raise RigLoadError(f"{prefix}.{name} must lie on its declared lattice")
     if not raw_min <= raw_origin <= raw_max:
         raise RigLoadError(f"{prefix}.raw_origin must be inside its declared range")
@@ -279,13 +289,13 @@ def _parse_control_spec(
         )
         if not raw_min <= raw_center <= raw_max:
             raise RigLoadError(f"{prefix}.raw_center must be inside its declared range")
-        if (raw_center - raw_origin) % raw_step != 0:
+        if not _on_control_lattice(raw_center, raw_origin, raw_step):
             raise RigLoadError(f"{prefix}.raw_center must lie on its declared lattice")
         if not display_min <= display_center <= display_max:
             raise RigLoadError(
                 f"{prefix}.display_center must be inside its declared range"
             )
-        if (display_center - display_origin) % display_step != 0:
+        if not _on_control_lattice(display_center, display_origin, display_step):
             raise RigLoadError(
                 f"{prefix}.display_center must lie on its declared lattice"
             )

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import math
 import tomllib
 import warnings
 from dataclasses import dataclass, field
+from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from rigplane.core.capabilities import KNOWN_CAPABILITIES
 from rigplane.core.state_acquisition_policy import (
@@ -55,7 +55,7 @@ VALID_CONTROL_STYLES = {
     "toggle_and_level",
     "level_is_toggle",
 }
-VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered", "lookup"}
+VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered"}
 VALID_CONTROL_QUANTIZATION = {
     "nearest_ties_down",
     "nearest_ties_up",
@@ -116,23 +116,32 @@ class RigLoadError(Exception):
     """Raised when a rig TOML file is invalid or malformed."""
 
 
+_ScalarControlDomain = dict[str, str | int | Decimal]
+
+
 def _control_number(value: object, path: str, *, integer: bool = False) -> int | float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         expected = "an integer" if integer else "a finite number"
         raise RigLoadError(f"{path} must be {expected}")
     if integer and not isinstance(value, int):
         raise RigLoadError(f"{path} must be an integer")
-    if not math.isfinite(value):
+    if isinstance(value, float) and not Decimal(str(value)).is_finite():
         raise RigLoadError(f"{path} must be a finite number")
     return value
 
 
-def _on_lattice(value: int | float, origin: int | float, step: int | float) -> bool:
-    offset = (value - origin) / step
-    return math.isclose(offset, round(offset), rel_tol=1e-9, abs_tol=1e-9)
+def _control_decimal(value: object, path: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RigLoadError(f"{path} must be a finite number")
+    decimal = Decimal(str(value))
+    if not decimal.is_finite():
+        raise RigLoadError(f"{path} must be a finite number")
+    return decimal
 
 
-def _parse_control_spec(filename: str, control_name: str, raw: object) -> ControlSpec:
+def _parse_control_spec(
+    filename: str, control_name: str, raw: object
+) -> tuple[ControlSpec | None, _ScalarControlDomain | None]:
     prefix = f"{filename}: [controls.{control_name}]"
     if not isinstance(raw, dict):
         raise RigLoadError(f"{prefix} must be a table")
@@ -171,11 +180,13 @@ def _parse_control_spec(filename: str, control_name: str, raw: object) -> Contro
 
     explicit = bool(set(raw) & _EXPLICIT_CONTROL_DOMAIN_KEYS)
     if not explicit:
-        return dict(raw)  # type: ignore[return-value]
+        return cast(ControlSpec, dict(raw)), None
     if "mapping" not in raw:
         raise RigLoadError(f"{prefix}.mapping is required for an explicit domain")
 
     mapping = raw["mapping"]
+    if mapping == "lookup" or "lookup" in raw:
+        raise RigLoadError(f"{prefix}.lookup mappings are deferred to MOR-1708")
     if not isinstance(mapping, str) or mapping not in VALID_CONTROL_MAPPINGS:
         raise RigLoadError(
             f"{prefix}.mapping must be one of {sorted(VALID_CONTROL_MAPPINGS)!r}"
@@ -189,34 +200,51 @@ def _parse_control_spec(filename: str, control_name: str, raw: object) -> Contro
         "display_max",
         "display_step",
         "display_origin",
+        "display_unit",
         "quantization",
         "restoration",
     }
     missing = sorted(required - set(raw))
     if missing:
+        if "display_unit" in missing:
+            raise RigLoadError(f"{prefix}.display_unit must be a non-empty string")
         if "display_min" in missing and "display_max" in missing:
             raise RigLoadError(f"{prefix}.display_min and display_max are required")
         raise RigLoadError(f"{prefix} missing required key(s): {missing!r}")
 
-    raw_min = _control_number(raw["raw_min"], f"{prefix}.raw_min", integer=True)
-    raw_max = _control_number(raw["raw_max"], f"{prefix}.raw_max", integer=True)
-    raw_step = _control_number(raw["raw_step"], f"{prefix}.raw_step", integer=True)
-    raw_origin = _control_number(
-        raw["raw_origin"], f"{prefix}.raw_origin", integer=True
+    raw_min = int(_control_number(raw["raw_min"], f"{prefix}.raw_min", integer=True))
+    raw_max = int(_control_number(raw["raw_max"], f"{prefix}.raw_max", integer=True))
+    raw_step = int(_control_number(raw["raw_step"], f"{prefix}.raw_step", integer=True))
+    raw_origin = int(
+        _control_number(raw["raw_origin"], f"{prefix}.raw_origin", integer=True)
     )
-    display_min = _control_number(raw["display_min"], f"{prefix}.display_min")
-    display_max = _control_number(raw["display_max"], f"{prefix}.display_max")
-    display_step = _control_number(raw["display_step"], f"{prefix}.display_step")
-    display_origin = _control_number(raw["display_origin"], f"{prefix}.display_origin")
+    display_min = _control_decimal(raw["display_min"], f"{prefix}.display_min")
+    display_max = _control_decimal(raw["display_max"], f"{prefix}.display_max")
+    display_step = _control_decimal(raw["display_step"], f"{prefix}.display_step")
+    display_origin = _control_decimal(raw["display_origin"], f"{prefix}.display_origin")
+    display_unit = raw["display_unit"]
+    if not isinstance(display_unit, str) or not display_unit.strip():
+        raise RigLoadError(f"{prefix}.display_unit must be a non-empty string")
     for name, step in (("raw_step", raw_step), ("display_step", display_step)):
         if step <= 0:
             raise RigLoadError(f"{prefix}.{name} must be > 0")
-    for name, origin, low, high in (
-        ("raw_origin", raw_origin, raw_min, raw_max),
-        ("display_origin", display_origin, display_min, display_max),
+    for name, value, origin, step in (
+        ("raw_min", raw_min, raw_origin, raw_step),
+        ("raw_max", raw_max, raw_origin, raw_step),
+        ("display_min", display_min, display_origin, display_step),
+        ("display_max", display_max, display_origin, display_step),
     ):
-        if not low <= origin <= high:
-            raise RigLoadError(f"{prefix}.{name} must be inside its declared range")
+        if (value - origin) % step != 0:
+            raise RigLoadError(f"{prefix}.{name} must lie on its declared lattice")
+    if not raw_min <= raw_origin <= raw_max:
+        raise RigLoadError(f"{prefix}.raw_origin must be inside its declared range")
+    if not display_min <= display_origin <= display_max:
+        raise RigLoadError(f"{prefix}.display_origin must be inside its declared range")
+
+    if "range_min" in raw and (
+        raw["range_min"] != raw_min or raw["range_max"] != raw_max
+    ):
+        raise RigLoadError(f"{prefix} legacy range must equal explicit raw bounds")
 
     quantization = raw["quantization"]
     if (
@@ -234,75 +262,55 @@ def _parse_control_spec(filename: str, control_name: str, raw: object) -> Contro
         )
 
     if mapping == "identity":
-        raw_domain = (raw_min, raw_max, raw_step, raw_origin)
+        raw_domain = tuple(
+            Decimal(value) for value in (raw_min, raw_max, raw_step, raw_origin)
+        )
         display_domain = (display_min, display_max, display_step, display_origin)
         if raw_domain != display_domain:
             raise RigLoadError(f"{prefix} identity mapping requires identical domains")
     if mapping == "centered":
-        for name, low, high, origin, step in (
-            ("raw_center", raw_min, raw_max, raw_origin, raw_step),
-            (
-                "display_center",
-                display_min,
-                display_max,
-                display_origin,
-                display_step,
-            ),
-        ):
-            if name not in raw:
-                raise RigLoadError(f"{prefix}.{name} is required for centered mapping")
-            center = _control_number(
-                raw[name], f"{prefix}.{name}", integer=name == "raw_center"
+        if "raw_center" not in raw or "display_center" not in raw:
+            raise RigLoadError(f"{prefix} centered mapping requires both center fields")
+        raw_center = int(
+            _control_number(raw["raw_center"], f"{prefix}.raw_center", integer=True)
+        )
+        display_center = _control_decimal(
+            raw["display_center"], f"{prefix}.display_center"
+        )
+        if not raw_min <= raw_center <= raw_max:
+            raise RigLoadError(f"{prefix}.raw_center must be inside its declared range")
+        if (raw_center - raw_origin) % raw_step != 0:
+            raise RigLoadError(f"{prefix}.raw_center must lie on its declared lattice")
+        if not display_min <= display_center <= display_max:
+            raise RigLoadError(
+                f"{prefix}.display_center must be inside its declared range"
             )
-            if not low <= center <= high:
-                raise RigLoadError(f"{prefix}.{name} must be inside its declared range")
-            if not _on_lattice(center, origin, step):
-                raise RigLoadError(f"{prefix}.{name} must lie on its declared lattice")
+        if (display_center - display_origin) % display_step != 0:
+            raise RigLoadError(
+                f"{prefix}.display_center must lie on its declared lattice"
+            )
     elif "raw_center" in raw or "display_center" in raw:
         raise RigLoadError(f"{prefix} center fields require centered mapping")
 
-    lookup = raw.get("lookup")
-    if mapping == "lookup":
-        if not isinstance(lookup, list) or len(lookup) < 2:
-            raise RigLoadError(f"{prefix}.lookup must contain at least two points")
-        points: list[tuple[int, int | float]] = []
-        for index, point in enumerate(lookup):
-            point_path = f"{prefix}.lookup[{index}]"
-            if not isinstance(point, dict) or set(point) != {"raw", "display"}:
-                raise RigLoadError(f"{point_path} must contain only raw and display")
-            point_raw = _control_number(point["raw"], f"{point_path}.raw", integer=True)
-            point_display = _control_number(point["display"], f"{point_path}.display")
-            if not raw_min <= point_raw <= raw_max:
-                raise RigLoadError(f"{point_path}.raw must be inside the raw range")
-            if not display_min <= point_display <= display_max:
-                raise RigLoadError(
-                    f"{point_path}.display must be inside the display range"
-                )
-            if not _on_lattice(point_raw, raw_origin, raw_step):
-                raise RigLoadError(
-                    f"{prefix}.lookup raw value {point_raw} must lie on its declared lattice"
-                )
-            if not _on_lattice(point_display, display_origin, display_step):
-                raise RigLoadError(
-                    f"{prefix}.lookup display value {point_display} must lie on its declared lattice"
-                )
-            points.append((point_raw, point_display))  # type: ignore[arg-type]
-        if any(a[0] >= b[0] for a, b in zip(points, points[1:])):
-            raise RigLoadError(
-                f"{prefix}.lookup raw values must be strictly increasing"
-            )
-        display_deltas = [b[1] - a[1] for a, b in zip(points, points[1:])]
-        if not (
-            all(delta > 0 for delta in display_deltas)
-            or all(delta < 0 for delta in display_deltas)
-        ):
-            raise RigLoadError(
-                f"{prefix}.lookup display values must be strictly monotonic"
-            )
-    elif lookup is not None:
-        raise RigLoadError(f"{prefix}.lookup is only valid for lookup mapping")
-
-    return dict(raw)  # type: ignore[return-value]
+    domain: _ScalarControlDomain = {
+        "mapping": mapping,
+        "raw_min": raw_min,
+        "raw_max": raw_max,
+        "raw_step": raw_step,
+        "raw_origin": raw_origin,
+        "display_min": display_min,
+        "display_max": display_max,
+        "display_step": display_step,
+        "display_origin": display_origin,
+        "display_unit": display_unit,
+        "quantization": quantization,
+        "restoration": restoration,
+    }
+    if mapping == "centered":
+        domain["raw_center"] = raw_center
+        domain["display_center"] = display_center
+    public_spec: ControlSpec | None = {"style": style} if style is not None else None
+    return public_spec, domain
 
 
 @dataclass(frozen=True, slots=True)
@@ -359,6 +367,9 @@ class RigConfig:
     protocol_address: int | None = None
     protocol_baud: int | None = None
     controls: dict[str, ControlSpec] | None = None
+    _control_domains: dict[str, _ScalarControlDomain] | None = field(
+        default=None, repr=False
+    )
     meter_calibrations: dict[str, list[MeterCalibrationPoint]] | None = None
     meter_redlines: dict[str, int] | None = None
     rules: tuple[RuleSpec, ...] = ()
@@ -1771,12 +1782,22 @@ def load_rig(path: Path) -> RigConfig:
     # Parse [controls] (optional)
     controls_raw = data.get("controls")
     controls: dict[str, ControlSpec] | None = None
+    control_domains: dict[str, _ScalarControlDomain] | None = None
     if controls_raw is not None:
         if not isinstance(controls_raw, dict):
             raise RigLoadError(f"{filename}: [controls] must be a table")
         controls = {}
+        control_domains = {}
         for ctrl_name, ctrl_data in controls_raw.items():
-            controls[ctrl_name] = _parse_control_spec(filename, ctrl_name, ctrl_data)
+            public_spec, domain = _parse_control_spec(filename, ctrl_name, ctrl_data)
+            if public_spec is not None:
+                controls[ctrl_name] = public_spec
+            if domain is not None:
+                control_domains[ctrl_name] = domain
+        if not controls and control_domains:
+            controls = None
+        if not control_domains:
+            control_domains = None
 
     # Parse [meters] (optional)
     meters_raw = data.get("meters")
@@ -1805,7 +1826,7 @@ def load_rig(path: Path) -> RigConfig:
             raise RigLoadError(
                 f"{filename}: rule kind must be one of {VALID_RULE_KINDS}, got {kind!r}"
             )
-        rules.append(dict(rule))  # type: ignore[arg-type]
+        rules.append(cast(RuleSpec, dict(rule)))
 
     # Parse [antenna] (optional)
     antenna_section = data.get("antenna", {})
@@ -2002,6 +2023,7 @@ def load_rig(path: Path) -> RigConfig:
         protocol_address=protocol_address,
         protocol_baud=protocol_baud,
         controls=controls,
+        _control_domains=control_domains,
         meter_calibrations=meter_calibrations,
         meter_redlines=meter_redlines,
         rules=tuple(rules),

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import tomllib
 import warnings
 from dataclasses import dataclass, field
@@ -54,6 +55,46 @@ VALID_CONTROL_STYLES = {
     "toggle_and_level",
     "level_is_toggle",
 }
+VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered", "lookup"}
+VALID_CONTROL_QUANTIZATION = {
+    "nearest_ties_down",
+    "nearest_ties_up",
+    "floor",
+    "ceil",
+    "reject",
+}
+VALID_CONTROL_RESTORATION = {"exact", "unavailable"}
+_CONTROL_KEYS = {
+    "style",
+    "range_min",
+    "range_max",
+    "raw_min",
+    "raw_max",
+    "raw_step",
+    "raw_origin",
+    "raw_center",
+    "display_min",
+    "display_max",
+    "display_step",
+    "display_origin",
+    "display_center",
+    "display_unit",
+    "mapping",
+    "quantization",
+    "restoration",
+    "lookup",
+}
+_EXPLICIT_CONTROL_DOMAIN_KEYS = {
+    "raw_step",
+    "raw_origin",
+    "display_step",
+    "display_origin",
+    "display_center",
+    "mapping",
+    "quantization",
+    "restoration",
+    "lookup",
+}
 VALID_RULE_KINDS = {"mutex", "disables", "requires", "value_limit"}
 VALID_KEYBOARD_MODIFIERS = {"SHIFT", "CTRL", "ALT", "META"}
 VALID_AUDIO_SAMPLE_RATES_HZ = {8000, 12000, 16000, 24000, 48000}
@@ -73,6 +114,195 @@ _REQUIRED_RADIO_FIELDS = ("id", "model", "receiver_count", "has_lan", "has_wifi"
 
 class RigLoadError(Exception):
     """Raised when a rig TOML file is invalid or malformed."""
+
+
+def _control_number(value: object, path: str, *, integer: bool = False) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        expected = "an integer" if integer else "a finite number"
+        raise RigLoadError(f"{path} must be {expected}")
+    if integer and not isinstance(value, int):
+        raise RigLoadError(f"{path} must be an integer")
+    if not math.isfinite(value):
+        raise RigLoadError(f"{path} must be a finite number")
+    return value
+
+
+def _on_lattice(value: int | float, origin: int | float, step: int | float) -> bool:
+    offset = (value - origin) / step
+    return math.isclose(offset, round(offset), rel_tol=1e-9, abs_tol=1e-9)
+
+
+def _parse_control_spec(filename: str, control_name: str, raw: object) -> ControlSpec:
+    prefix = f"{filename}: [controls.{control_name}]"
+    if not isinstance(raw, dict):
+        raise RigLoadError(f"{prefix} must be a table")
+
+    unknown = sorted(set(raw) - _CONTROL_KEYS)
+    if unknown:
+        raise RigLoadError(f"{prefix} unknown key(s): {unknown!r}")
+
+    style = raw.get("style")
+    if style is not None and (
+        not isinstance(style, str) or style not in VALID_CONTROL_STYLES
+    ):
+        raise RigLoadError(
+            f"{prefix}.style must be one of {VALID_CONTROL_STYLES}, got {style!r}"
+        )
+
+    for first, last, integer in (
+        ("range_min", "range_max", True),
+        ("raw_min", "raw_max", True),
+        ("display_min", "display_max", False),
+    ):
+        present = [key in raw for key in (first, last)]
+        if any(present) and not all(present):
+            raise RigLoadError(f"{prefix}.{first} and {last} must be declared together")
+        if all(present):
+            low = _control_number(raw[first], f"{prefix}.{first}", integer=integer)
+            high = _control_number(raw[last], f"{prefix}.{last}", integer=integer)
+            if low >= high:
+                raise RigLoadError(f"{prefix}.{first} must be less than {last}")
+    if "raw_center" in raw:
+        _control_number(raw["raw_center"], f"{prefix}.raw_center", integer=True)
+    if "display_center" in raw:
+        _control_number(raw["display_center"], f"{prefix}.display_center")
+    if "display_unit" in raw and not isinstance(raw["display_unit"], str):
+        raise RigLoadError(f"{prefix}.display_unit must be a string")
+
+    explicit = bool(set(raw) & _EXPLICIT_CONTROL_DOMAIN_KEYS)
+    if not explicit:
+        return dict(raw)  # type: ignore[return-value]
+    if "mapping" not in raw:
+        raise RigLoadError(f"{prefix}.mapping is required for an explicit domain")
+
+    mapping = raw["mapping"]
+    if not isinstance(mapping, str) or mapping not in VALID_CONTROL_MAPPINGS:
+        raise RigLoadError(
+            f"{prefix}.mapping must be one of {sorted(VALID_CONTROL_MAPPINGS)!r}"
+        )
+    required = {
+        "raw_min",
+        "raw_max",
+        "raw_step",
+        "raw_origin",
+        "display_min",
+        "display_max",
+        "display_step",
+        "display_origin",
+        "quantization",
+        "restoration",
+    }
+    missing = sorted(required - set(raw))
+    if missing:
+        if "display_min" in missing and "display_max" in missing:
+            raise RigLoadError(f"{prefix}.display_min and display_max are required")
+        raise RigLoadError(f"{prefix} missing required key(s): {missing!r}")
+
+    raw_min = _control_number(raw["raw_min"], f"{prefix}.raw_min", integer=True)
+    raw_max = _control_number(raw["raw_max"], f"{prefix}.raw_max", integer=True)
+    raw_step = _control_number(raw["raw_step"], f"{prefix}.raw_step", integer=True)
+    raw_origin = _control_number(
+        raw["raw_origin"], f"{prefix}.raw_origin", integer=True
+    )
+    display_min = _control_number(raw["display_min"], f"{prefix}.display_min")
+    display_max = _control_number(raw["display_max"], f"{prefix}.display_max")
+    display_step = _control_number(raw["display_step"], f"{prefix}.display_step")
+    display_origin = _control_number(raw["display_origin"], f"{prefix}.display_origin")
+    for name, step in (("raw_step", raw_step), ("display_step", display_step)):
+        if step <= 0:
+            raise RigLoadError(f"{prefix}.{name} must be > 0")
+    for name, origin, low, high in (
+        ("raw_origin", raw_origin, raw_min, raw_max),
+        ("display_origin", display_origin, display_min, display_max),
+    ):
+        if not low <= origin <= high:
+            raise RigLoadError(f"{prefix}.{name} must be inside its declared range")
+
+    quantization = raw["quantization"]
+    if (
+        not isinstance(quantization, str)
+        or quantization not in VALID_CONTROL_QUANTIZATION
+    ):
+        raise RigLoadError(
+            f"{prefix}.quantization must be one of "
+            f"{sorted(VALID_CONTROL_QUANTIZATION)!r}"
+        )
+    restoration = raw["restoration"]
+    if not isinstance(restoration, str) or restoration not in VALID_CONTROL_RESTORATION:
+        raise RigLoadError(
+            f"{prefix}.restoration must be one of {sorted(VALID_CONTROL_RESTORATION)!r}"
+        )
+
+    if mapping == "identity":
+        raw_domain = (raw_min, raw_max, raw_step, raw_origin)
+        display_domain = (display_min, display_max, display_step, display_origin)
+        if raw_domain != display_domain:
+            raise RigLoadError(f"{prefix} identity mapping requires identical domains")
+    if mapping == "centered":
+        for name, low, high, origin, step in (
+            ("raw_center", raw_min, raw_max, raw_origin, raw_step),
+            (
+                "display_center",
+                display_min,
+                display_max,
+                display_origin,
+                display_step,
+            ),
+        ):
+            if name not in raw:
+                raise RigLoadError(f"{prefix}.{name} is required for centered mapping")
+            center = _control_number(
+                raw[name], f"{prefix}.{name}", integer=name == "raw_center"
+            )
+            if not low <= center <= high:
+                raise RigLoadError(f"{prefix}.{name} must be inside its declared range")
+            if not _on_lattice(center, origin, step):
+                raise RigLoadError(f"{prefix}.{name} must lie on its declared lattice")
+    elif "raw_center" in raw or "display_center" in raw:
+        raise RigLoadError(f"{prefix} center fields require centered mapping")
+
+    lookup = raw.get("lookup")
+    if mapping == "lookup":
+        if not isinstance(lookup, list) or len(lookup) < 2:
+            raise RigLoadError(f"{prefix}.lookup must contain at least two points")
+        points: list[tuple[int, int | float]] = []
+        for index, point in enumerate(lookup):
+            point_path = f"{prefix}.lookup[{index}]"
+            if not isinstance(point, dict) or set(point) != {"raw", "display"}:
+                raise RigLoadError(f"{point_path} must contain only raw and display")
+            point_raw = _control_number(point["raw"], f"{point_path}.raw", integer=True)
+            point_display = _control_number(point["display"], f"{point_path}.display")
+            if not raw_min <= point_raw <= raw_max:
+                raise RigLoadError(f"{point_path}.raw must be inside the raw range")
+            if not display_min <= point_display <= display_max:
+                raise RigLoadError(
+                    f"{point_path}.display must be inside the display range"
+                )
+            if not _on_lattice(point_raw, raw_origin, raw_step):
+                raise RigLoadError(
+                    f"{prefix}.lookup raw value {point_raw} must lie on its declared lattice"
+                )
+            if not _on_lattice(point_display, display_origin, display_step):
+                raise RigLoadError(
+                    f"{prefix}.lookup display value {point_display} must lie on its declared lattice"
+                )
+            points.append((point_raw, point_display))  # type: ignore[arg-type]
+        if any(a[0] >= b[0] for a, b in zip(points, points[1:])):
+            raise RigLoadError(
+                f"{prefix}.lookup raw values must be strictly increasing"
+            )
+        display_deltas = [b[1] - a[1] for a, b in zip(points, points[1:])]
+        if not (
+            all(delta > 0 for delta in display_deltas)
+            or all(delta < 0 for delta in display_deltas)
+        ):
+            raise RigLoadError(
+                f"{prefix}.lookup display values must be strictly monotonic"
+            )
+    elif lookup is not None:
+        raise RigLoadError(f"{prefix}.lookup is only valid for lookup mapping")
+
+    return dict(raw)  # type: ignore[return-value]
 
 
 @dataclass(frozen=True, slots=True)
@@ -1542,16 +1772,11 @@ def load_rig(path: Path) -> RigConfig:
     controls_raw = data.get("controls")
     controls: dict[str, ControlSpec] | None = None
     if controls_raw is not None:
+        if not isinstance(controls_raw, dict):
+            raise RigLoadError(f"{filename}: [controls] must be a table")
         controls = {}
         for ctrl_name, ctrl_data in controls_raw.items():
-            if isinstance(ctrl_data, dict):
-                style = ctrl_data.get("style")
-                if style is not None and style not in VALID_CONTROL_STYLES:
-                    raise RigLoadError(
-                        f"{filename}: [controls.{ctrl_name}].style must be one of "
-                        f"{VALID_CONTROL_STYLES}, got {style!r}"
-                    )
-                controls[ctrl_name] = dict(ctrl_data)  # type: ignore[assignment]
+            controls[ctrl_name] = _parse_control_spec(filename, ctrl_name, ctrl_data)
 
     # Parse [meters] (optional)
     meters_raw = data.get("meters")

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -678,14 +678,13 @@ mapping = "linear"
 quantization = "nearest_ties_up"
 restoration = "exact"
 """
+    _LARGE_DECIMAL = _LINEAR.replace(
+        "display_max = 1.0", "display_max = 1000000000000"
+    ).replace("display_step = 0.2", "display_step = 1e-20")
 
     def _load(self, tmp_path, declaration: str):
-        return load_rig(
-            _write_toml(
-                tmp_path,
-                _MINIMAL_TOML + "\n[controls.test_control]\n" + declaration,
-            )
-        )
+        text = _MINIMAL_TOML + "\n[controls.test_control]\n" + declaration
+        return load_rig(_write_toml(tmp_path, text))
 
     @pytest.mark.parametrize(
         ("mapping", "declaration"),
@@ -707,9 +706,7 @@ restoration = "exact"
             ),
         ],
     )
-    def test_scalar_domain_is_private_and_not_serialized(
-        self, tmp_path, mapping, declaration
-    ):
+    def test_scalar_domain_is_private(self, tmp_path, mapping, declaration):
         rig = self._load(tmp_path, declaration)
 
         assert rig._control_domains["test_control"]["mapping"] == mapping
@@ -721,24 +718,23 @@ restoration = "exact"
         [
             ("raw_min = 0", "raw_min = 1", "raw_min must lie"),
             ("raw_max = 10", "raw_max = 9", "raw_max must lie"),
-            (
-                "raw_max = 10",
-                "raw_max = 9007199254740991",
-                "raw_max must lie",
-            ),
+            ("raw_max = 10", "raw_max = 9007199254740991", "raw_max must lie"),
             ("display_min = 0.0", "display_min = 0.05", "display_min must lie"),
-            (
-                "display_max = 1.0",
-                "display_max = 1000000000000.05",
-                "display_max must lie",
-            ),
         ],
     )
-    def test_rejects_off_lattice_endpoints_at_small_and_large_indices(
-        self, tmp_path, old, new, message
-    ):
+    def test_rejects_off_lattice_endpoints(self, tmp_path, old, new, message):
         with pytest.raises(RigLoadError, match=message):
             self._load(tmp_path, self._LINEAR.replace(old, new))
+
+    def test_accepts_large_exact_decimal_lattice_independent_of_context(self, tmp_path):
+        assert self._load(tmp_path, self._LARGE_DECIMAL)._control_domains is not None
+
+    def test_large_off_lattice_raises_rig_load_error(self, tmp_path):
+        declaration = self._LARGE_DECIMAL.replace(
+            "display_min = 0.0", "display_min = 1e-21"
+        ).replace("display_origin = 0.0", "display_origin = 1e-21")
+        with pytest.raises(RigLoadError, match="display_max must lie"):
+            self._load(tmp_path, declaration)
 
     @pytest.mark.parametrize(
         ("centers", "message"),
@@ -769,13 +765,8 @@ restoration = "exact"
 
     @pytest.mark.parametrize("unit", [None, "", "   "])
     def test_explicit_domain_requires_non_empty_display_unit(self, tmp_path, unit):
-        declaration = self._LINEAR
-        if unit is None:
-            declaration = declaration.replace('display_unit = "ratio"\n', "")
-        else:
-            declaration = declaration.replace(
-                'display_unit = "ratio"', f'display_unit = "{unit}"'
-            )
+        replacement = "" if unit is None else f'display_unit = "{unit}"\n'
+        declaration = self._LINEAR.replace('display_unit = "ratio"\n', replacement)
         with pytest.raises(RigLoadError, match="display_unit.*non-empty"):
             self._load(tmp_path, declaration)
 
@@ -785,10 +776,9 @@ restoration = "exact"
             self._load(tmp_path, declaration)
 
     def test_shipped_legacy_profiles_remain_publicly_shape_compatible(self):
-        paths = (
+        for path in sorted(
             path for path in RIGS_DIR.glob("*.toml") if not path.name.startswith("_")
-        )
-        for path in sorted(paths):
+        ):
             rig = load_rig(path)
             assert rig._control_domains is None, path.name
             assert rig.to_profile().controls == rig.controls, path.name

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -664,139 +664,134 @@ mode = 42
 
 
 class TestControlDomainSchema:
-    def _load_control(self, tmp_path, declaration: str):
-        path = _write_toml(
-            tmp_path,
-            _MINIMAL_TOML + "\n[controls.test_control]\n" + declaration,
-        )
-        return load_rig(path).controls["test_control"]
-
-    @pytest.mark.parametrize(
-        ("mapping", "extra"),
-        [
-            ("linear", ""),
-            ("centered", "raw_center = 0\ndisplay_center = 0.0\n"),
-            (
-                "lookup",
-                "lookup = [{ raw = -10, display = -1.0 }, "
-                "{ raw = 0, display = 0.0 }, { raw = 10, display = 1.0 }]\n",
-            ),
-        ],
-    )
-    def test_explicit_domain_mappings_load(self, tmp_path, mapping, extra):
-        control = self._load_control(
-            tmp_path,
-            f"""\
-raw_min = -10
+    _LINEAR = """\
+raw_min = 0
 raw_max = 10
-raw_step = 5
+raw_step = 2
 raw_origin = 0
-display_min = -1.0
+display_min = 0.0
 display_max = 1.0
-display_step = 0.5
+display_step = 0.2
 display_origin = 0.0
 display_unit = "ratio"
-mapping = "{mapping}"
+mapping = "linear"
 quantization = "nearest_ties_up"
 restoration = "exact"
-{extra}""",
+"""
+
+    def _load(self, tmp_path, declaration: str):
+        return load_rig(
+            _write_toml(
+                tmp_path,
+                _MINIMAL_TOML + "\n[controls.test_control]\n" + declaration,
+            )
         )
-
-        assert control["mapping"] == mapping
-        assert control["raw_origin"] == 0
-
-    def test_range_bounds_need_not_be_lattice_points_when_origin_is_explicit(
-        self, tmp_path
-    ):
-        control = self._load_control(
-            tmp_path,
-            """\
-raw_min = -9999
-raw_max = 9999
-raw_step = 50
-raw_origin = 0
-display_min = -9999
-display_max = 9999
-display_step = 50
-display_origin = 0
-mapping = "identity"
-quantization = "reject"
-restoration = "exact"
-""",
-        )
-
-        assert control["raw_origin"] == 0
 
     @pytest.mark.parametrize(
-        ("declaration", "message"),
+        ("mapping", "declaration"),
         [
-            ("raw_min = 0\nraw_max = 10\nraw_step = 1\n", "mapping is required"),
             (
-                "raw_min = 0\nraw_max = 10\nraw_step = 0\nraw_origin = 0\n"
-                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
-                'display_origin = 0\nmapping = "identity"\n'
-                'quantization = "reject"\nrestoration = "exact"\n',
-                "raw_step must be > 0",
+                "identity",
+                _LINEAR.replace("display_max = 1.0", "display_max = 10")
+                .replace("display_step = 0.2", "display_step = 2")
+                .replace('display_unit = "ratio"', 'display_unit = "dimensionless"')
+                .replace('mapping = "linear"', 'mapping = "identity"'),
             ),
+            ("linear", _LINEAR),
             (
-                "raw_min = 0\nraw_max = 10\nraw_step = 2\nraw_origin = 0\nraw_center = 3\n"
-                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
-                'display_origin = 0\nmapping = "centered"\ndisplay_center = 5\n'
-                'quantization = "reject"\nrestoration = "exact"\n',
-                "raw_center must lie on its declared lattice",
+                "centered",
+                _LINEAR.replace("raw_min = 0", "raw_min = -10")
+                .replace("display_min = 0.0", "display_min = -1.0")
+                .replace('mapping = "linear"', 'mapping = "centered"')
+                + "raw_center = 0\ndisplay_center = 0.0\n",
             ),
-            (
-                "raw_min = 0\nraw_max = 10\nraw_step = 1\nraw_origin = 0\n"
-                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
-                'display_origin = 0\nmapping = "lookup"\n'
-                'quantization = "reject"\nrestoration = "exact"\n'
-                "lookup = [{raw = 0, display = 0}, {raw = 5, display = 6}, "
-                "{raw = 10, display = 4}]\n",
-                "lookup display values must be strictly monotonic",
-            ),
-            (
-                "raw_min = 0\nraw_max = 10\nraw_step = 2\nraw_origin = 0\n"
-                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
-                'display_origin = 0\nmapping = "lookup"\n'
-                'quantization = "reject"\nrestoration = "exact"\n'
-                "lookup = [{raw = 0, display = 0}, {raw = 3, display = 3}]\n",
-                "lookup raw value 3 must lie on its declared lattice",
-            ),
-            (
-                "raw_min = 0\nraw_max = 10\nraw_step = 1\nraw_origin = 0\n"
-                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
-                'display_origin = 0\nmapping = "linear"\n'
-                'quantization = "nearest"\nrestoration = "exact"\n',
-                "quantization must be one of",
-            ),
-            (
-                "raw_min = 0\nraw_max = 10\nraw_step = 1\nraw_origin = 0\n"
-                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
-                'display_origin = 0\nmapping = "linear"\n'
-                'quantization = "reject"\nrestoration = "best_effort"\n',
-                "restoration must be one of",
-            ),
-            ("unknown_domain_key = 1\n", "unknown key"),
         ],
     )
-    def test_rejects_malformed_or_ambiguous_domains(
-        self, tmp_path, declaration, message
+    def test_scalar_domain_is_private_and_not_serialized(
+        self, tmp_path, mapping, declaration
+    ):
+        rig = self._load(tmp_path, declaration)
+
+        assert rig._control_domains["test_control"]["mapping"] == mapping
+        assert rig.controls is None
+        assert rig.to_profile().controls is None
+
+    @pytest.mark.parametrize(
+        ("old", "new", "message"),
+        [
+            ("raw_min = 0", "raw_min = 1", "raw_min must lie"),
+            ("raw_max = 10", "raw_max = 9", "raw_max must lie"),
+            (
+                "raw_max = 10",
+                "raw_max = 9007199254740991",
+                "raw_max must lie",
+            ),
+            ("display_min = 0.0", "display_min = 0.05", "display_min must lie"),
+            (
+                "display_max = 1.0",
+                "display_max = 1000000000000.05",
+                "display_max must lie",
+            ),
+        ],
+    )
+    def test_rejects_off_lattice_endpoints_at_small_and_large_indices(
+        self, tmp_path, old, new, message
     ):
         with pytest.raises(RigLoadError, match=message):
-            self._load_control(tmp_path, declaration)
+            self._load(tmp_path, self._LINEAR.replace(old, new))
 
-    def test_legacy_partial_ranges_remain_backward_compatible(self, tmp_path):
-        control = self._load_control(
-            tmp_path,
-            "raw_min = 0\nraw_max = 255\ndisplay_min = 0\ndisplay_max = 15\n",
+    @pytest.mark.parametrize(
+        ("centers", "message"),
+        [
+            ("raw_center = 3\ndisplay_center = 0.0\n", "raw_center must lie"),
+            ("raw_center = 0\ndisplay_center = 0.1\n", "display_center must lie"),
+        ],
+    )
+    def test_rejects_off_lattice_centers(self, tmp_path, centers, message):
+        declaration = self._LINEAR.replace('mapping = "linear"', 'mapping = "centered"')
+        with pytest.raises(RigLoadError, match=message):
+            self._load(tmp_path, declaration + centers)
+
+    @pytest.mark.parametrize(
+        ("extra", "accepted"),
+        [
+            ("range_min = 0\nrange_max = 10\n", True),
+            ("range_min = 0\nrange_max = 11\n", False),
+        ],
+    )
+    def test_legacy_range_must_be_formally_equivalent(self, tmp_path, extra, accepted):
+        declaration = self._LINEAR + extra
+        if accepted:
+            assert self._load(tmp_path, declaration)._control_domains is not None
+        else:
+            with pytest.raises(RigLoadError, match="legacy range.*raw bounds"):
+                self._load(tmp_path, declaration)
+
+    @pytest.mark.parametrize("unit", [None, "", "   "])
+    def test_explicit_domain_requires_non_empty_display_unit(self, tmp_path, unit):
+        declaration = self._LINEAR
+        if unit is None:
+            declaration = declaration.replace('display_unit = "ratio"\n', "")
+        else:
+            declaration = declaration.replace(
+                'display_unit = "ratio"', f'display_unit = "{unit}"'
+            )
+        with pytest.raises(RigLoadError, match="display_unit.*non-empty"):
+            self._load(tmp_path, declaration)
+
+    def test_lookup_is_explicitly_deferred(self, tmp_path):
+        declaration = self._LINEAR.replace('mapping = "linear"', 'mapping = "lookup"')
+        with pytest.raises(RigLoadError, match="lookup.*MOR-1708"):
+            self._load(tmp_path, declaration)
+
+    def test_shipped_legacy_profiles_remain_publicly_shape_compatible(self):
+        paths = (
+            path for path in RIGS_DIR.glob("*.toml") if not path.name.startswith("_")
         )
-
-        assert control == {
-            "raw_min": 0,
-            "raw_max": 255,
-            "display_min": 0,
-            "display_max": 15,
-        }
+        for path in sorted(paths):
+            rig = load_rig(path)
+            assert rig._control_domains is None, path.name
+            assert rig.to_profile().controls == rig.controls, path.name
 
 
 # ── RadioProfile building ───────────────────────────────────────

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -663,6 +663,142 @@ mode = 42
         assert rig.keyboard.bindings[0].params == {"mode": 42}
 
 
+class TestControlDomainSchema:
+    def _load_control(self, tmp_path, declaration: str):
+        path = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML + "\n[controls.test_control]\n" + declaration,
+        )
+        return load_rig(path).controls["test_control"]
+
+    @pytest.mark.parametrize(
+        ("mapping", "extra"),
+        [
+            ("linear", ""),
+            ("centered", "raw_center = 0\ndisplay_center = 0.0\n"),
+            (
+                "lookup",
+                "lookup = [{ raw = -10, display = -1.0 }, "
+                "{ raw = 0, display = 0.0 }, { raw = 10, display = 1.0 }]\n",
+            ),
+        ],
+    )
+    def test_explicit_domain_mappings_load(self, tmp_path, mapping, extra):
+        control = self._load_control(
+            tmp_path,
+            f"""\
+raw_min = -10
+raw_max = 10
+raw_step = 5
+raw_origin = 0
+display_min = -1.0
+display_max = 1.0
+display_step = 0.5
+display_origin = 0.0
+display_unit = "ratio"
+mapping = "{mapping}"
+quantization = "nearest_ties_up"
+restoration = "exact"
+{extra}""",
+        )
+
+        assert control["mapping"] == mapping
+        assert control["raw_origin"] == 0
+
+    def test_range_bounds_need_not_be_lattice_points_when_origin_is_explicit(
+        self, tmp_path
+    ):
+        control = self._load_control(
+            tmp_path,
+            """\
+raw_min = -9999
+raw_max = 9999
+raw_step = 50
+raw_origin = 0
+display_min = -9999
+display_max = 9999
+display_step = 50
+display_origin = 0
+mapping = "identity"
+quantization = "reject"
+restoration = "exact"
+""",
+        )
+
+        assert control["raw_origin"] == 0
+
+    @pytest.mark.parametrize(
+        ("declaration", "message"),
+        [
+            ("raw_min = 0\nraw_max = 10\nraw_step = 1\n", "mapping is required"),
+            (
+                "raw_min = 0\nraw_max = 10\nraw_step = 0\nraw_origin = 0\n"
+                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
+                'display_origin = 0\nmapping = "identity"\n'
+                'quantization = "reject"\nrestoration = "exact"\n',
+                "raw_step must be > 0",
+            ),
+            (
+                "raw_min = 0\nraw_max = 10\nraw_step = 2\nraw_origin = 0\nraw_center = 3\n"
+                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
+                'display_origin = 0\nmapping = "centered"\ndisplay_center = 5\n'
+                'quantization = "reject"\nrestoration = "exact"\n',
+                "raw_center must lie on its declared lattice",
+            ),
+            (
+                "raw_min = 0\nraw_max = 10\nraw_step = 1\nraw_origin = 0\n"
+                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
+                'display_origin = 0\nmapping = "lookup"\n'
+                'quantization = "reject"\nrestoration = "exact"\n'
+                "lookup = [{raw = 0, display = 0}, {raw = 5, display = 6}, "
+                "{raw = 10, display = 4}]\n",
+                "lookup display values must be strictly monotonic",
+            ),
+            (
+                "raw_min = 0\nraw_max = 10\nraw_step = 2\nraw_origin = 0\n"
+                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
+                'display_origin = 0\nmapping = "lookup"\n'
+                'quantization = "reject"\nrestoration = "exact"\n'
+                "lookup = [{raw = 0, display = 0}, {raw = 3, display = 3}]\n",
+                "lookup raw value 3 must lie on its declared lattice",
+            ),
+            (
+                "raw_min = 0\nraw_max = 10\nraw_step = 1\nraw_origin = 0\n"
+                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
+                'display_origin = 0\nmapping = "linear"\n'
+                'quantization = "nearest"\nrestoration = "exact"\n',
+                "quantization must be one of",
+            ),
+            (
+                "raw_min = 0\nraw_max = 10\nraw_step = 1\nraw_origin = 0\n"
+                "display_min = 0\ndisplay_max = 10\ndisplay_step = 1\n"
+                'display_origin = 0\nmapping = "linear"\n'
+                'quantization = "reject"\nrestoration = "best_effort"\n',
+                "restoration must be one of",
+            ),
+            ("unknown_domain_key = 1\n", "unknown key"),
+        ],
+    )
+    def test_rejects_malformed_or_ambiguous_domains(
+        self, tmp_path, declaration, message
+    ):
+        with pytest.raises(RigLoadError, match=message):
+            self._load_control(tmp_path, declaration)
+
+    def test_legacy_partial_ranges_remain_backward_compatible(self, tmp_path):
+        control = self._load_control(
+            tmp_path,
+            "raw_min = 0\nraw_max = 255\ndisplay_min = 0\ndisplay_max = 15\n",
+        )
+
+        assert control == {
+            "raw_min": 0,
+            "raw_max": 255,
+            "display_min": 0,
+            "display_max": 15,
+        }
+
+
 # ── RadioProfile building ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- validate identity, linear, and centered scalar control-domain declarations at profile load time using exact integer modulo and `Decimal(str(value))` display-lattice arithmetic
- retain validated domains only in private `RigConfig._control_domains`; public `ControlSpec`, `RadioProfile.controls`, and capability JSON gain no fields
- reject lookup declarations with an explicit MOR-1708 deferral, contradictory legacy bounds, off-lattice endpoints/centers, and missing or empty display units
- preserve legacy and shipped profile public shapes

## Scope

Exactly 2 files / 398 changed lines relative to current `main`. No runtime, radio, transport, frontend, or hardware changes.

## Verification

- `uv run pytest tests/test_rig_loader.py -q --tb=short` (267 passed, 1 skipped)
- `uv run pytest tests/test_rig_loader.py -q --tb=short -k ControlDomainSchema` (17 passed)
- repository-wide `uv run pytest tests/ -q --tb=short` completed with 10,051 passed; only two unrelated AGC integration timeouts failed
- GitHub required `quick` check: PASS at `6256efb3394c7275b2e22876e8b637b08cc387c5`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/rigplane/profiles/rig_loader.py`
- `uv run lint-imports`
- public-boundary import smoke
- `git diff --check`

Repository-wide `uv run mypy src/` still reports 13 errors outside the two-file PR scope; the changed loader is clean.

## Follow-ups

- MOR-1708: lookup mapping and exact restoration coverage
- MOR-1709: validated capability/wire publication
- MOR-1710: shared conversion and semantic control migrations

Linear: MOR-1707
Parent tracking: MOR-1670