### PR TITLE
MOR-1701: expose feedback on the controlled HBar slider

### DIFF
--- a/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/HBarRenderer.svelte
@@ -36,6 +36,10 @@
     shortcutHint?: string | null;
     title?: string | null;
     optimistic?: boolean;
+    feedbackPhase?: string | null;
+    feedbackBusy?: boolean;
+    feedbackDescription?: string | null;
+    feedbackStatus?: string | null;
   }
 
   let {
@@ -62,7 +66,13 @@
     shortcutHint = null,
     title = null,
     optimistic = true,
+    feedbackPhase = null,
+    feedbackBusy,
+    feedbackDescription = null,
+    feedbackStatus = null,
   }: Props = $props();
+
+  const feedbackDescriptionId = $props.id();
 
   let containerEl: HTMLDivElement | null = $state(null);
   let isDragging = $state(false);
@@ -226,6 +236,9 @@
     aria-valuemax={max}
     aria-valuenow={value}
     aria-disabled={disabled}
+    aria-busy={feedbackBusy}
+    aria-describedby={feedbackDescription ? feedbackDescriptionId : undefined}
+    data-command-phase={feedbackPhase ?? undefined}
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
@@ -258,6 +271,18 @@
       <div class="vc-thumb" aria-hidden="true"></div>
     {/if}
   </div>
+  {#if feedbackDescription}
+    <span id={feedbackDescriptionId} class="sr-only">{feedbackDescription}</span>
+  {/if}
+  {#if feedbackStatus}
+    <span
+      class="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-control-feedback-status
+    >{feedbackStatus}</span>
+  {/if}
 </div>
 
 <style>
@@ -289,6 +314,11 @@
   .vc-value {
     color: var(--vc-text-value, var(--v2-text-bright));
     font-family: 'Roboto Mono', monospace;
+  }
+
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
 
   .disabled {

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -33,6 +33,11 @@
     tickStyle?: 'ruler' | 'led' | 'notch';
     /** HBar-only: keep the rendered value parent-controlled until it changes. */
     optimistic?: boolean;
+    /** HBar-only presentation data; lifecycle ownership remains with the caller. */
+    feedbackPhase?: string | null;
+    feedbackBusy?: boolean;
+    feedbackDescription?: string | null;
+    feedbackStatus?: string | null;
     // Behavior
     onChange: (value: number) => void;
     debounceMs?: number;
@@ -71,6 +76,10 @@
     showAllTicks = true,
     tickStyle = 'ruler',
     optimistic = true,
+    feedbackPhase = null,
+    feedbackBusy,
+    feedbackDescription = null,
+    feedbackStatus = null,
     onChange,
     debounceMs = 50,
     disabled = false,
@@ -127,7 +136,14 @@
 
   // This is intentionally not part of commonProps: skin and non-HBar renderer
   // contracts remain unchanged.
-  let hbarProps = $derived({ ...commonProps, optimistic });
+  let hbarProps = $derived({
+    ...commonProps,
+    optimistic,
+    feedbackPhase,
+    feedbackBusy,
+    feedbackDescription,
+    feedbackStatus,
+  });
 
   // Resolve skin component for the current renderer type (undefined = use built-in)
   let skinComponent = $derived(

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.controlled.svelte.test.ts
@@ -58,6 +58,96 @@ const baseProps = {
 };
 
 describe('ValueControl controlled HBar rendering', () => {
+  it('keeps feedback presentation inert by default on the actual slider', () => {
+    const { target } = mountReactive({ ...baseProps, onChange: vi.fn() });
+    const control = slider(target);
+
+    expect(control.hasAttribute('data-command-phase')).toBe(false);
+    expect(control.hasAttribute('aria-busy')).toBe(false);
+    expect(control.hasAttribute('aria-describedby')).toBe(false);
+    expect(target.querySelector('[data-control-feedback-status]')).toBeNull();
+  });
+
+  it.each([
+    {
+      label: 'Filter Width',
+      description: 'Target 2400 Hz; last confirmed 2300 Hz',
+      status: 'Awaiting confirmation: 2400 Hz',
+    },
+    {
+      label: 'Notch Position',
+      description: 'Цель 160; последнее подтверждённое 128',
+      status: 'Ожидание подтверждения: 160',
+    },
+  ])('projects caller-authored feedback onto the $label HBar without changing truth', ({
+    label, description, status,
+  }) => {
+    const onChange = vi.fn();
+    const { target } = mountReactive({
+      ...baseProps,
+      label,
+      optimistic: false,
+      onChange,
+      feedbackPhase: 'awaiting-confirmation',
+      feedbackBusy: true,
+      feedbackDescription: description,
+      feedbackStatus: status,
+    });
+    const control = slider(target);
+    const descriptionId = control.getAttribute('aria-describedby');
+
+    expect(control.getAttribute('data-command-phase')).toBe('awaiting-confirmation');
+    expect(control.getAttribute('aria-busy')).toBe('true');
+    expect(descriptionId).toBeTruthy();
+    expect(target.querySelector(`#${descriptionId}`)?.textContent).toBe(description);
+    const live = target.querySelector('[data-control-feedback-status]');
+    expect(live?.getAttribute('role')).toBe('status');
+    expect(live?.getAttribute('aria-live')).toBe('polite');
+    expect(live?.getAttribute('aria-atomic')).toBe('true');
+    expect(live?.textContent).toBe(status);
+    expect(visibleValue(target)).toContain('20');
+    expect(fill(target)).toContain('--vc-fill-percent: 20%');
+    expect(control.getAttribute('aria-valuenow')).toBe('20');
+
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    control.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    flushSync();
+    expect(onChange).toHaveBeenNthCalledWith(1, 30);
+    expect(onChange).toHaveBeenNthCalledWith(2, 30);
+    expect(control.getAttribute('aria-valuenow')).toBe('20');
+    expect(fill(target)).toContain('--vc-fill-percent: 20%');
+  });
+
+  it.each(['confirmed', 'failed', 'timed-out', 'cancelled', 'superseded'])(
+    'clears busy for terminal phase %s without changing canonical truth', (phase) => {
+      const { state, target } = mountReactive({
+        ...baseProps,
+        optimistic: false,
+        onChange: vi.fn(),
+        feedbackPhase: 'awaiting-confirmation',
+        feedbackBusy: true,
+        feedbackDescription: 'Target 30; last confirmed 20',
+        feedbackStatus: 'Awaiting confirmation: 30',
+      });
+
+      state.feedbackPhase = phase;
+      state.feedbackBusy = false;
+      state.feedbackDescription = null;
+      state.feedbackStatus = `Terminal: ${phase}`;
+      flushSync();
+
+      const control = slider(target);
+      expect(control.getAttribute('data-command-phase')).toBe(phase);
+      expect(control.getAttribute('aria-busy')).toBe('false');
+      expect(control.hasAttribute('aria-describedby')).toBe(false);
+      expect(target.querySelector('[data-control-feedback-status]')?.textContent)
+        .toBe(`Terminal: ${phase}`);
+      expect(control.getAttribute('aria-valuenow')).toBe('20');
+      expect(visibleValue(target)).toContain('20');
+      expect(fill(target)).toContain('--vc-fill-percent: 20%');
+    },
+  );
+
   it('emits a controlled pointer target while display, fill, and ARIA remain canonical', () => {
     const onChange = vi.fn();
     const { target } = mountReactive({ ...baseProps, optimistic: false, onChange });


### PR DESCRIPTION
## Summary

- add inert-by-default presentation-only feedback props to the built-in ValueControl HBar
- expose caller-authored command phase, busy state, target/last-confirmed description, and polite transition status on the actual `role="slider"` element and its assistive-text nodes
- preserve canonical value, fill/thumb position, `aria-valuenow`, pointer behavior, keyboard arithmetic, and interaction-only debounce while feedback is pending or terminal

The primitive performs no lifecycle inference, translation, deduplication, confirmation timing, state ownership, or command work. English/Russian descriptions and already transition-deduplicated status text are supplied by the caller.

## Verification

- red-first controlled suite: 7 expected failures before implementation
- ValueControl + Filter Width + Notch witnesses: 6 files, 240 tests passed
- full frontend: 350 files, 7,599 tests passed
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`
- diff ownership, whitespace, and privacy checks

Exactly 3 files / 138 changed lines. No runtime, store, transport, radio-model, browser, hardware, audio, CAT, API, or TX changes.

Linear: MOR-1701
Parent: MOR-1687