### PR TITLE
[MOR-1712] enforce normalized ControlFeedback ownership imports

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -23,6 +23,7 @@ import tsPlugin from '@typescript-eslint/eslint-plugin';
 import sveltePlugin from 'eslint-plugin-svelte';
 import svelteParser from 'svelte-eslint-parser';
 import radioAuthorityPlugin from './scripts/radio-authority-eslint-plugin.mjs';
+import controlFeedbackOwnershipPlugin from './scripts/control-feedback-ownership-eslint-plugin.mjs';
 
 /** Modules that only the runtime/wiring layer may import. */
 const FORBIDDEN_RUNTIME_IMPORTS = {
@@ -335,6 +336,16 @@ export default [
     rules: {
       'no-restricted-imports': ['error', FORBIDDEN_PRIMITIVES_IMPORTS],
     },
+  },
+
+  // ── Normalized ownership boundary: pure control-feedback consumers (MOR-1712) ──
+  {
+    files: [
+      'src/primitives/control-feedback/**/*.ts', 'src/primitives/control-feedback/**/*.svelte',
+      'src/semantic/controls/**/*.ts', 'src/semantic/controls/**/*.svelte',
+    ],
+    plugins: { 'control-feedback-ownership': controlFeedbackOwnershipPlugin },
+    rules: { 'control-feedback-ownership/normalized-import-boundary': 'error' },
   },
 
   // ── Import boundary: presentation — layouts, design languages (MOR-1061) ──

--- a/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
+++ b/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
@@ -19,6 +19,10 @@ function literalSource(node) {
 function resolveModule(specifier, filename, cwd) {
   const clean = specifier.split(/[?#]/, 1)[0];
   const root = frontendRoot(filename, cwd);
+  if (clean.startsWith('/@fs/')) {
+    const target = clean.slice('/@fs/'.length);
+    return path.isAbsolute(target) ? path.resolve(target) : null;
+  }
   if (clean === '$lib') return path.resolve(root, 'src/lib');
   if (clean.startsWith('$lib/')) {
     const tail = clean.slice(5).replace(/^\/+/, '');

--- a/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
+++ b/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
@@ -1,0 +1,80 @@
+/** Normalized import boundary for pure ControlFeedback consumers (MOR-1712). */
+import path from 'node:path';
+
+function frontendRoot(filename, cwd) {
+  const absolute = path.resolve(filename);
+  const marker = `${path.sep}src${path.sep}`;
+  const index = absolute.lastIndexOf(marker);
+  return index < 0 ? path.resolve(cwd) : absolute.slice(0, index);
+}
+
+function literalSource(node) {
+  if (node?.type === 'Literal' && typeof node.value === 'string') return node.value;
+  if (node?.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw;
+  }
+  return null;
+}
+
+function resolveModule(specifier, filename, cwd) {
+  const clean = specifier.split(/[?#]/, 1)[0];
+  const root = frontendRoot(filename, cwd);
+  if (clean === '$lib') return path.resolve(root, 'src/lib');
+  if (clean.startsWith('$lib/')) return path.resolve(root, 'src/lib', clean.slice(5));
+  if (clean.startsWith('.')) return path.resolve(path.dirname(filename), clean);
+  if (path.isAbsolute(clean)) return path.resolve(clean);
+  return null;
+}
+
+function isWithin(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`)
+    && relative !== '..' && !path.isAbsolute(relative));
+}
+
+const normalizedImportBoundary = {
+  meta: {
+    type: 'problem', schema: [],
+    messages: {
+      runtime: 'Pure control feedback cannot import runtime ownership: {{source}}.',
+      dynamic: 'Pure control feedback cannot prove a non-literal dynamic import is ownership-safe.',
+    },
+  },
+  create(context) {
+    const filename = context.physicalFilename ?? context.filename;
+    const cwd = context.cwd ?? process.cwd();
+    const runtimeRoot = path.resolve(frontendRoot(filename, cwd), 'src/lib/runtime');
+
+    function checkStatic(node) {
+      const source = literalSource(node.source);
+      if (source === null) return;
+      const resolved = resolveModule(source, filename, cwd);
+      if (resolved !== null && isWithin(resolved, runtimeRoot)) {
+        context.report({ node, messageId: 'runtime', data: { source } });
+      }
+    }
+
+    function checkDynamic(node) {
+      const source = literalSource(node.source);
+      if (source === null) {
+        context.report({ node, messageId: 'dynamic' });
+        return;
+      }
+      const resolved = resolveModule(source, filename, cwd);
+      if (resolved !== null && isWithin(resolved, runtimeRoot)) {
+        context.report({ node, messageId: 'runtime', data: { source } });
+      }
+    }
+
+    return {
+      ImportDeclaration: checkStatic,
+      ExportAllDeclaration: checkStatic,
+      ExportNamedDeclaration(node) { if (node.source) checkStatic(node); },
+      ImportExpression: checkDynamic,
+    };
+  },
+};
+
+export default {
+  rules: { 'normalized-import-boundary': normalizedImportBoundary },
+};

--- a/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
+++ b/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
@@ -1,11 +1,11 @@
 /** Normalized import boundary for pure ControlFeedback consumers (MOR-1712). */
 import path from 'node:path';
 
-function frontendRoot(filename, cwd) {
-  const absolute = path.resolve(filename);
-  const marker = `${path.sep}src${path.sep}`;
+function frontendRoot(filename, cwd, pathApi = path) {
+  const absolute = pathApi.resolve(filename);
+  const marker = `${pathApi.sep}src${pathApi.sep}`;
   const index = absolute.lastIndexOf(marker);
-  return index < 0 ? path.resolve(cwd) : absolute.slice(0, index);
+  return index < 0 ? pathApi.resolve(cwd) : absolute.slice(0, index);
 }
 
 function literalSource(node) {
@@ -16,23 +16,23 @@ function literalSource(node) {
   return null;
 }
 
-function resolveModule(specifier, filename, cwd) {
-  const clean = specifier.split(/[?#]/, 1)[0];
-  const root = frontendRoot(filename, cwd);
+export function resolveModuleForPath(specifier, filename, cwd, pathApi = path) {
+  const clean = specifier.replaceAll('\\', '/').split(/[?#]/, 1)[0];
+  const root = frontendRoot(filename, cwd, pathApi);
   if (clean.startsWith('/@fs/')) {
-    const target = path.normalize(clean.slice('/@fs/'.length));
-    return path.resolve(path.isAbsolute(target) ? target : `${path.sep}${target}`);
+    const target = pathApi.normalize(clean.slice('/@fs/'.length));
+    return pathApi.resolve(pathApi.isAbsolute(target) ? target : `${pathApi.sep}${target}`);
   }
-  if (clean === '$lib') return path.resolve(root, 'src/lib');
+  if (clean === '$lib') return pathApi.resolve(root, 'src/lib');
   if (clean.startsWith('$lib/')) {
     const tail = clean.slice(5).replace(/^\/+/, '');
-    return path.resolve(root, 'src/lib', tail);
+    return pathApi.resolve(root, 'src/lib', tail);
   }
-  if (clean.startsWith('.')) return path.resolve(path.dirname(filename), clean);
+  if (clean.startsWith('.')) return pathApi.resolve(pathApi.dirname(filename), clean);
   if (clean === '/src' || clean.startsWith('/src/')) {
-    return path.resolve(root, clean.replace(/^\/+/, ''));
+    return pathApi.resolve(root, clean.replace(/^\/+/, ''));
   }
-  if (path.isAbsolute(clean)) return path.resolve(clean);
+  if (pathApi.isAbsolute(clean)) return pathApi.resolve(clean);
   return null;
 }
 
@@ -58,7 +58,7 @@ const normalizedImportBoundary = {
     function checkStatic(node) {
       const source = literalSource(node.source);
       if (source === null) return;
-      const resolved = resolveModule(source, filename, cwd);
+      const resolved = resolveModuleForPath(source, filename, cwd);
       if (resolved !== null && isWithin(resolved, runtimeRoot)) {
         context.report({ node, messageId: 'runtime', data: { source } });
       }
@@ -70,7 +70,7 @@ const normalizedImportBoundary = {
         context.report({ node, messageId: 'dynamic' });
         return;
       }
-      const resolved = resolveModule(source, filename, cwd);
+      const resolved = resolveModuleForPath(source, filename, cwd);
       if (resolved !== null && isWithin(resolved, runtimeRoot)) {
         context.report({ node, messageId: 'runtime', data: { source } });
       }

--- a/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
+++ b/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
@@ -20,8 +20,14 @@ function resolveModule(specifier, filename, cwd) {
   const clean = specifier.split(/[?#]/, 1)[0];
   const root = frontendRoot(filename, cwd);
   if (clean === '$lib') return path.resolve(root, 'src/lib');
-  if (clean.startsWith('$lib/')) return path.resolve(root, 'src/lib', clean.slice(5));
+  if (clean.startsWith('$lib/')) {
+    const tail = clean.slice(5).replace(/^\/+/, '');
+    return path.resolve(root, 'src/lib', tail);
+  }
   if (clean.startsWith('.')) return path.resolve(path.dirname(filename), clean);
+  if (clean === '/src' || clean.startsWith('/src/')) {
+    return path.resolve(root, clean.replace(/^\/+/, ''));
+  }
   if (path.isAbsolute(clean)) return path.resolve(clean);
   return null;
 }

--- a/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
+++ b/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
@@ -20,8 +20,8 @@ function resolveModule(specifier, filename, cwd) {
   const clean = specifier.split(/[?#]/, 1)[0];
   const root = frontendRoot(filename, cwd);
   if (clean.startsWith('/@fs/')) {
-    const target = clean.slice('/@fs/'.length);
-    return path.isAbsolute(target) ? path.resolve(target) : null;
+    const target = path.normalize(clean.slice('/@fs/'.length));
+    return path.resolve(path.isAbsolute(target) ? target : `${path.sep}${target}`);
   }
   if (clean === '$lib') return path.resolve(root, 'src/lib');
   if (clean.startsWith('$lib/')) {

--- a/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
+++ b/frontend/scripts/control-feedback-ownership-eslint-plugin.mjs
@@ -1,6 +1,18 @@
 /** Normalized import boundary for pure ControlFeedback consumers (MOR-1712). */
 import path from 'node:path';
 
+/** @typedef {typeof path.win32} PathApi */
+/** @typedef {import('eslint').Rule.RuleContext} RuleContext */
+/** @typedef {import('eslint').Rule.RuleListener} RuleListener */
+/** @typedef {import('eslint').Rule.Node} RuleNode */
+/** @typedef {import('estree').Literal | import('estree').TemplateLiteral} LiteralSource */
+
+/**
+ * @param {string} filename
+ * @param {string} cwd
+ * @param {PathApi} [pathApi]
+ * @returns {string}
+ */
 function frontendRoot(filename, cwd, pathApi = path) {
   const absolute = pathApi.resolve(filename);
   const marker = `${pathApi.sep}src${pathApi.sep}`;
@@ -8,7 +20,21 @@ function frontendRoot(filename, cwd, pathApi = path) {
   return index < 0 ? pathApi.resolve(cwd) : absolute.slice(0, index);
 }
 
+/**
+ * @param {unknown} node
+ * @returns {node is LiteralSource}
+ */
+function isLiteralSource(node) {
+  return typeof node === 'object' && node !== null && 'type' in node
+    && (node.type === 'Literal' || node.type === 'TemplateLiteral');
+}
+
+/**
+ * @param {unknown} node
+ * @returns {string | null}
+ */
 function literalSource(node) {
+  if (!isLiteralSource(node)) return null;
   if (node?.type === 'Literal' && typeof node.value === 'string') return node.value;
   if (node?.type === 'TemplateLiteral' && node.expressions.length === 0) {
     return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw;
@@ -16,6 +42,13 @@ function literalSource(node) {
   return null;
 }
 
+/**
+ * @param {string} specifier
+ * @param {string} filename
+ * @param {string} cwd
+ * @param {PathApi} [pathApi]
+ * @returns {string | null}
+ */
 export function resolveModuleForPath(specifier, filename, cwd, pathApi = path) {
   const clean = specifier.replaceAll('\\', '/').split(/[?#]/, 1)[0];
   const root = frontendRoot(filename, cwd, pathApi);
@@ -36,12 +69,18 @@ export function resolveModuleForPath(specifier, filename, cwd, pathApi = path) {
   return null;
 }
 
+/**
+ * @param {string} candidate
+ * @param {string} root
+ * @returns {boolean}
+ */
 function isWithin(candidate, root) {
   const relative = path.relative(root, candidate);
   return relative === '' || (!relative.startsWith(`..${path.sep}`)
     && relative !== '..' && !path.isAbsolute(relative));
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 const normalizedImportBoundary = {
   meta: {
     type: 'problem', schema: [],
@@ -50,13 +89,18 @@ const normalizedImportBoundary = {
       dynamic: 'Pure control feedback cannot prove a non-literal dynamic import is ownership-safe.',
     },
   },
+  /**
+   * @param {RuleContext} context
+   * @returns {RuleListener}
+   */
   create(context) {
     const filename = context.physicalFilename ?? context.filename;
     const cwd = context.cwd ?? process.cwd();
     const runtimeRoot = path.resolve(frontendRoot(filename, cwd), 'src/lib/runtime');
 
+    /** @param {RuleNode} node */
     function checkStatic(node) {
-      const source = literalSource(node.source);
+      const source = literalSource('source' in node ? node.source : null);
       if (source === null) return;
       const resolved = resolveModuleForPath(source, filename, cwd);
       if (resolved !== null && isWithin(resolved, runtimeRoot)) {
@@ -64,8 +108,9 @@ const normalizedImportBoundary = {
       }
     }
 
+    /** @param {RuleNode} node */
     function checkDynamic(node) {
-      const source = literalSource(node.source);
+      const source = literalSource('source' in node ? node.source : null);
       if (source === null) {
         context.report({ node, messageId: 'dynamic' });
         return;
@@ -76,12 +121,19 @@ const normalizedImportBoundary = {
       }
     }
 
-    return {
+    /** @param {RuleNode} node */
+    function checkNamedExport(node) {
+      if ('source' in node && node.source) checkStatic(node);
+    }
+
+    /** @type {RuleListener} */
+    const listeners = {
       ImportDeclaration: checkStatic,
       ExportAllDeclaration: checkStatic,
-      ExportNamedDeclaration(node) { if (node.source) checkStatic(node); },
+      ExportNamedDeclaration: checkNamedExport,
       ImportExpression: checkDynamic,
     };
+    return listeners;
   },
 };
 

--- a/frontend/src/__tests__/control-feedback-ownership.test.ts
+++ b/frontend/src/__tests__/control-feedback-ownership.test.ts
@@ -1,0 +1,58 @@
+import { ESLint } from 'eslint';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+const RULE = 'control-feedback-ownership/normalized-import-boundary';
+const FILES = [
+  'src/primitives/control-feedback/Probe.ts',
+  'src/semantic/controls/Probe.ts',
+] as const;
+
+async function messages(code: string, filePath: string): Promise<readonly string[]> {
+  const [result] = await new ESLint({ cwd: ROOT }).lintText(code, { filePath });
+  return result.messages.map((message) => message.ruleId ?? '<parser>');
+}
+
+const FORBIDDEN = [
+  [`import value from '$lib/runtime/tx-controller/model';`, 'static import'],
+  [`import type { ControlFeedback } from '$lib/types/../runtime/adapters/panel-adapters';`, 'type import alias traversal'],
+  [`export { runtime } from '$lib/runtime/frontend-runtime';`, 'named export'],
+  [`export * from '$lib/runtime/commands/radio-intents';`, 'export star'],
+  [`void import('$lib/runtime/tx-controller/model');`, 'literal dynamic import'],
+  ['void import(`$lib/runtime/frontend-runtime`);', 'literal template dynamic import'],
+  [`void import(\`$lib/runtime/${'${owner}'}\`);`, 'template dynamic import'],
+  [`void import(owner);`, 'non-literal dynamic import'],
+  [`import value from '../../lib/runtime/tx-controller/model';`, 'relative traversal'],
+] as const;
+
+describe('normalized ControlFeedback ownership boundary (MOR-1712)', () => {
+  it.each(FILES)('rejects every runtime ownership form from %s', async (filePath) => {
+    for (const [code] of FORBIDDEN) expect(await messages(code, filePath)).toContain(RULE);
+  });
+
+  it.each(FILES)('preserves normalized pure/type imports from %s', async (filePath) => {
+    const allowed = [
+      `import type { ServerState } from '$lib/types/state';`,
+      `export type { ServerState } from '$lib/types/../types/state';`,
+      `import type { ServerState } from '$lib/runtime/../types/state';`,
+      `import type { ServerState } from '../../lib/runtime/../types/state';`,
+      `import type { Snippet } from 'svelte';`,
+      `import type { Presentation } from '../../primitives/control-feedback/control-feedback-presentation';`,
+      `void import('$lib/types/state');`,
+      'void import(`$lib/types/state`);',
+    ];
+    for (const code of allowed) expect(await messages(code, filePath)).not.toContain(RULE);
+  });
+
+  it.each([
+    'src/primitives/control-feedback/Probe.svelte',
+    'src/semantic/controls/Probe.svelte',
+  ])('enforces the same boundary in Svelte module scripts from %s', async (filePath) => {
+    expect(await messages(`<script>import x from '$lib/runtime/frontend-runtime';</script>`, filePath))
+      .toContain(RULE);
+    expect(await messages(`<script>import type { ServerState } from '$lib/types/state';</script>`, filePath))
+      .not.toContain(RULE);
+  });
+});

--- a/frontend/src/__tests__/control-feedback-ownership.test.ts
+++ b/frontend/src/__tests__/control-feedback-ownership.test.ts
@@ -17,6 +17,17 @@ async function messages(code: string, filePath: string): Promise<readonly string
 
 const FORBIDDEN = [
   [`import value from '$lib/runtime/tx-controller/model';`, 'static import'],
+  [`import value from '$lib//runtime/frontend-runtime';`, 'repeated-separator import'],
+  [`export { value } from '$lib//runtime/frontend-runtime';`, 'repeated-separator named export'],
+  [`export * from '$lib//runtime/frontend-runtime';`, 'repeated-separator export star'],
+  [`void import('$lib//runtime/frontend-runtime');`, 'repeated-separator dynamic import'],
+  ['void import(`$lib//runtime/frontend-runtime`);', 'repeated-separator template import'],
+  [`import value from '/src/lib/runtime/frontend-runtime';`, 'Vite-root import'],
+  [`export { value } from '/src/lib/runtime/frontend-runtime';`, 'Vite-root named export'],
+  [`export * from '/src/lib/runtime/frontend-runtime';`, 'Vite-root export star'],
+  [`void import('/src/lib/runtime/frontend-runtime');`, 'Vite-root dynamic import'],
+  ['void import(`/src/lib/runtime/frontend-runtime`);', 'Vite-root template dynamic import'],
+  [`import value from '${path.resolve(ROOT, 'src/lib/runtime/frontend-runtime')}';`, 'filesystem absolute import'],
   [`import type { ControlFeedback } from '$lib/types/../runtime/adapters/panel-adapters';`, 'type import alias traversal'],
   [`export { runtime } from '$lib/runtime/frontend-runtime';`, 'named export'],
   [`export * from '$lib/runtime/commands/radio-intents';`, 'export star'],
@@ -29,7 +40,7 @@ const FORBIDDEN = [
 
 describe('normalized ControlFeedback ownership boundary (MOR-1712)', () => {
   it.each(FILES)('rejects every runtime ownership form from %s', async (filePath) => {
-    for (const [code] of FORBIDDEN) expect(await messages(code, filePath)).toContain(RULE);
+    for (const [code, label] of FORBIDDEN) expect(await messages(code, filePath), label).toContain(RULE);
   });
 
   it.each(FILES)('preserves normalized pure/type imports from %s', async (filePath) => {
@@ -37,6 +48,10 @@ describe('normalized ControlFeedback ownership boundary (MOR-1712)', () => {
       `import type { ServerState } from '$lib/types/state';`,
       `export type { ServerState } from '$lib/types/../types/state';`,
       `import type { ServerState } from '$lib/runtime/../types/state';`,
+      `import type { ServerState } from '$lib//runtime/../types/state';`,
+      `import type { ServerState } from '$lib///types/state';`,
+      `import type { ServerState } from '/src/lib/runtime/../types/state';`,
+      `import type { ServerState } from '/src//lib/runtime/../types/state';`,
       `import type { ServerState } from '../../lib/runtime/../types/state';`,
       `import type { Snippet } from 'svelte';`,
       `import type { Presentation } from '../../primitives/control-feedback/control-feedback-presentation';`,

--- a/frontend/src/__tests__/control-feedback-ownership.test.ts
+++ b/frontend/src/__tests__/control-feedback-ownership.test.ts
@@ -10,6 +10,7 @@ const FILES = [
   'src/semantic/controls/Probe.ts',
 ] as const;
 const FS_RUNTIME = `/@fs/${path.resolve(ROOT, 'src/lib/runtime/frontend-runtime')}`;
+const FS_SINGLE_RUNTIME = FS_RUNTIME.replace('/@fs//', '/@fs/');
 
 async function messages(code: string, filePath: string): Promise<readonly string[]> {
   const [result] = await new ESLint({ cwd: ROOT }).lintText(code, { filePath });
@@ -33,6 +34,11 @@ const FORBIDDEN = [
   [`export * from '${FS_RUNTIME}?worker';`, 'Vite FS export star'],
   [`void import('${FS_RUNTIME.replace('/@fs//', '/@fs///')}?raw#module');`, 'Vite FS dynamic import'],
   [`void import(\`${FS_RUNTIME}?url#module\`);`, 'Vite FS template import'],
+  [`import value from '${FS_SINGLE_RUNTIME}';`, 'single-slash Vite FS import'],
+  [`export { value } from '${FS_SINGLE_RUNTIME.replace('/src/lib/', '/src/lib/./')}#module';`, 'single-slash Vite FS named export'],
+  [`export * from '${FS_SINGLE_RUNTIME.replace('/src/lib/', '/src//lib/')}?worker';`, 'single-slash Vite FS export star'],
+  [`void import('${FS_SINGLE_RUNTIME}?raw#module');`, 'single-slash Vite FS dynamic import'],
+  [`void import(\`${FS_SINGLE_RUNTIME.replace('/src/lib/', '/src/./lib/')}?url#module\`);`, 'single-slash Vite FS template import'],
   [`import value from '${path.resolve(ROOT, 'src/lib/runtime/frontend-runtime')}';`, 'filesystem absolute import'],
   [`import type { ControlFeedback } from '$lib/types/../runtime/adapters/panel-adapters';`, 'type import alias traversal'],
   [`export { runtime } from '$lib/runtime/frontend-runtime';`, 'named export'],
@@ -59,6 +65,7 @@ describe('normalized ControlFeedback ownership boundary (MOR-1712)', () => {
       `import type { ServerState } from '/src/lib/runtime/../types/state';`,
       `import type { ServerState } from '/src//lib/runtime/../types/state';`,
       `import type { ServerState } from '/@fs/${path.resolve(ROOT, 'src/lib/types/state')}?raw#module';`,
+      `import type { ServerState } from '/@fs/${path.resolve(ROOT, 'src/lib/./runtime/../types/state').slice(1)}?raw#module';`,
       `import type { ServerState } from '../../lib/runtime/../types/state';`,
       `import type { Snippet } from 'svelte';`,
       `import type { Presentation } from '../../primitives/control-feedback/control-feedback-presentation';`,

--- a/frontend/src/__tests__/control-feedback-ownership.test.ts
+++ b/frontend/src/__tests__/control-feedback-ownership.test.ts
@@ -2,6 +2,7 @@ import { ESLint } from 'eslint';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { resolveModuleForPath } from '../../scripts/control-feedback-ownership-eslint-plugin.mjs';
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 const RULE = 'control-feedback-ownership/normalized-import-boundary';
@@ -51,6 +52,21 @@ const FORBIDDEN = [
 ] as const;
 
 describe('normalized ControlFeedback ownership boundary (MOR-1712)', () => {
+  it('normalizes Vite mixed Windows separators before ownership resolution', () => {
+    const win = path.win32;
+    const filename = 'C:\\workspace\\frontend\\src\\primitives\\control-feedback\\Probe.ts';
+    const root = 'C:\\workspace\\frontend';
+
+    expect(resolveModuleForPath('$lib/\\runtime\\frontend-runtime', filename, root, win))
+      .toBe(win.resolve(root, 'src/lib/runtime/frontend-runtime'));
+    expect(resolveModuleForPath('/src\\lib\\runtime\\frontend-runtime', filename, root, win))
+      .toBe(win.resolve(root, 'src/lib/runtime/frontend-runtime'));
+    expect(resolveModuleForPath('$lib/\\types\\state', filename, root, win))
+      .toBe(win.resolve(root, 'src/lib/types/state'));
+    expect(resolveModuleForPath('/src\\lib\\types\\state', filename, root, win))
+      .toBe(win.resolve(root, 'src/lib/types/state'));
+  });
+
   it.each(FILES)('rejects every runtime ownership form from %s', async (filePath) => {
     for (const [code, label] of FORBIDDEN) expect(await messages(code, filePath), label).toContain(RULE);
   });

--- a/frontend/src/__tests__/control-feedback-ownership.test.ts
+++ b/frontend/src/__tests__/control-feedback-ownership.test.ts
@@ -9,6 +9,7 @@ const FILES = [
   'src/primitives/control-feedback/Probe.ts',
   'src/semantic/controls/Probe.ts',
 ] as const;
+const FS_RUNTIME = `/@fs/${path.resolve(ROOT, 'src/lib/runtime/frontend-runtime')}`;
 
 async function messages(code: string, filePath: string): Promise<readonly string[]> {
   const [result] = await new ESLint({ cwd: ROOT }).lintText(code, { filePath });
@@ -27,6 +28,11 @@ const FORBIDDEN = [
   [`export * from '/src/lib/runtime/frontend-runtime';`, 'Vite-root export star'],
   [`void import('/src/lib/runtime/frontend-runtime');`, 'Vite-root dynamic import'],
   ['void import(`/src/lib/runtime/frontend-runtime`);', 'Vite-root template dynamic import'],
+  [`import value from '${FS_RUNTIME}?raw#module';`, 'Vite FS import'],
+  [`export { value } from '${FS_RUNTIME.replace('/@fs//', '/@fs////')}#module';`, 'Vite FS named export'],
+  [`export * from '${FS_RUNTIME}?worker';`, 'Vite FS export star'],
+  [`void import('${FS_RUNTIME.replace('/@fs//', '/@fs///')}?raw#module');`, 'Vite FS dynamic import'],
+  [`void import(\`${FS_RUNTIME}?url#module\`);`, 'Vite FS template import'],
   [`import value from '${path.resolve(ROOT, 'src/lib/runtime/frontend-runtime')}';`, 'filesystem absolute import'],
   [`import type { ControlFeedback } from '$lib/types/../runtime/adapters/panel-adapters';`, 'type import alias traversal'],
   [`export { runtime } from '$lib/runtime/frontend-runtime';`, 'named export'],
@@ -52,6 +58,7 @@ describe('normalized ControlFeedback ownership boundary (MOR-1712)', () => {
       `import type { ServerState } from '$lib///types/state';`,
       `import type { ServerState } from '/src/lib/runtime/../types/state';`,
       `import type { ServerState } from '/src//lib/runtime/../types/state';`,
+      `import type { ServerState } from '/@fs/${path.resolve(ROOT, 'src/lib/types/state')}?raw#module';`,
       `import type { ServerState } from '../../lib/runtime/../types/state';`,
       `import type { Snippet } from 'svelte';`,
       `import type { Presentation } from '../../primitives/control-feedback/control-feedback-presentation';`,


### PR DESCRIPTION
## Summary

- add a dedicated ESLint rule for pure ControlFeedback consumer ownership boundaries
- normalize $lib aliases, repeated separators, dot segments, query/hash suffixes, Vite project-root /src paths, Vite /@fs ids, real filesystem absolute paths, and relative traversal before runtime containment classification
- cover static imports, type imports, named/export-star forwarding, literal/template dynamic imports, and fail-closed non-literal dynamic imports
- add Vite-compatible Windows mixed-separator resolution tests using path.win32
- type the plugin with precise JSDoc for path APIs, helper values, ESTree literal sources, and ESLint context/nodes/listeners

## Current verification

Head: 8a566d2d992ca56d194f96f2690af75f9a6d40de
Base: 59a8e9323b201fa1c4b9b6a94d4ef84b8a58e63d

- npm run check: 0 errors, 0 warnings
- focused ownership and architecture: 94 passed
- npm test: 352 files, 7,625 passed
- npm run lint
- npm run lint:boundaries
- focused ESLint for the rule and test files
- npm run i18n:check
- npm run build
- diff and privacy guards: clean

## Scope

Exactly 3 PR files and +256 LOC from the base. Architecture-only MOR-1712 child of MOR-1700; no runtime, UI behavior, hardware, API, CAT, audio, or TX changes.
