### PR TITLE
[MOR-1708] validate loader-private lookup domains

### DIFF
--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -55,7 +55,7 @@ VALID_CONTROL_STYLES = {
     "toggle_and_level",
     "level_is_toggle",
 }
-VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered"}
+VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered", "lookup"}
 VALID_CONTROL_QUANTIZATION = {
     "nearest_ties_down",
     "nearest_ties_up",
@@ -116,7 +116,8 @@ class RigLoadError(Exception):
     """Raised when a rig TOML file is invalid or malformed."""
 
 
-_ScalarControlDomain = dict[str, str | int | Decimal]
+_LookupPoint = tuple[int, Decimal]
+_ScalarControlDomain = dict[str, str | int | Decimal | tuple[_LookupPoint, ...]]
 
 
 def _control_number(value: object, path: str, *, integer: bool = False) -> int | float:
@@ -147,6 +148,64 @@ def _on_control_lattice(
     )
     numerator = (value_num * origin_den - origin_num * value_den) * step_den
     return numerator % (value_den * origin_den * step_num) == 0
+
+
+def _parse_control_lookup(
+    raw_lookup: object,
+    prefix: str,
+    raw_range: tuple[int, int, int, int],
+    display_range: tuple[Decimal, Decimal, Decimal, Decimal],
+    restoration: str,
+) -> tuple[_LookupPoint, ...]:
+    if not isinstance(raw_lookup, list) or not raw_lookup:
+        raise RigLoadError(f"{prefix}.lookup must be a non-empty array")
+    raw_min, raw_max, raw_step, raw_origin = raw_range
+    display_min, display_max, display_step, display_origin = display_range
+    points: list[_LookupPoint] = []
+    for index, point in enumerate(raw_lookup):
+        point_prefix = f"{prefix}.lookup[{index}]"
+        if not isinstance(point, dict) or set(point) != {"raw", "display"}:
+            raise RigLoadError(
+                f"{point_prefix} must be a table containing exactly raw and display"
+            )
+        raw_value = int(
+            _control_number(point["raw"], f"{point_prefix}.raw", integer=True)
+        )
+        display_value = _control_decimal(point["display"], f"{point_prefix}.display")
+        if not raw_min <= raw_value <= raw_max:
+            raise RigLoadError(f"{point_prefix}.raw must be inside its declared range")
+        if not _on_control_lattice(raw_value, raw_origin, raw_step):
+            raise RigLoadError(f"{point_prefix}.raw must lie on its declared lattice")
+        if not display_min <= display_value <= display_max:
+            raise RigLoadError(
+                f"{point_prefix}.display must be inside its declared range"
+            )
+        if not _on_control_lattice(display_value, display_origin, display_step):
+            raise RigLoadError(
+                f"{point_prefix}.display must lie on its declared lattice"
+            )
+        points.append((raw_value, display_value))
+
+    axes: tuple[tuple[str, list[int | Decimal]], ...] = (
+        ("raw", [point[0] for point in points]),
+        ("display", [point[1] for point in points]),
+    )
+    for name, values in axes:
+        if len(set(values)) != len(values):
+            raise RigLoadError(f"{prefix}.lookup {name} values must be unique")
+        increasing = all(first < second for first, second in zip(values, values[1:]))
+        decreasing = all(first > second for first, second in zip(values, values[1:]))
+        if len(values) > 1 and not (increasing or decreasing):
+            raise RigLoadError(
+                f"{prefix}.lookup {name} values must be strictly monotonic"
+            )
+
+    expected_raw_points = (raw_max - raw_min) // raw_step + 1
+    if restoration == "exact" and len(points) != expected_raw_points:
+        raise RigLoadError(
+            f"{prefix}.lookup exact restoration requires complete raw lattice coverage"
+        )
+    return tuple(points)
 
 
 def _parse_control_spec(
@@ -195,12 +254,14 @@ def _parse_control_spec(
         raise RigLoadError(f"{prefix}.mapping is required for an explicit domain")
 
     mapping = raw["mapping"]
-    if mapping == "lookup" or "lookup" in raw:
-        raise RigLoadError(f"{prefix}.lookup mappings are deferred to MOR-1708")
     if not isinstance(mapping, str) or mapping not in VALID_CONTROL_MAPPINGS:
         raise RigLoadError(
             f"{prefix}.mapping must be one of {sorted(VALID_CONTROL_MAPPINGS)!r}"
         )
+    if mapping == "lookup" and "lookup" not in raw:
+        raise RigLoadError(f"{prefix}.lookup is required for lookup mapping")
+    if mapping != "lookup" and "lookup" in raw:
+        raise RigLoadError(f"{prefix}.lookup requires lookup mapping")
     required = {
         "raw_min",
         "raw_max",
@@ -271,6 +332,15 @@ def _parse_control_spec(
             f"{prefix}.restoration must be one of {sorted(VALID_CONTROL_RESTORATION)!r}"
         )
 
+    lookup = None
+    if mapping == "lookup":
+        lookup = _parse_control_lookup(
+            raw["lookup"],
+            prefix,
+            (raw_min, raw_max, raw_step, raw_origin),
+            (display_min, display_max, display_step, display_origin),
+            restoration,
+        )
     if mapping == "identity":
         raw_domain = tuple(
             Decimal(value) for value in (raw_min, raw_max, raw_step, raw_origin)
@@ -319,6 +389,9 @@ def _parse_control_spec(
     if mapping == "centered":
         domain["raw_center"] = raw_center
         domain["display_center"] = display_center
+    if mapping == "lookup":
+        assert lookup is not None
+        domain["lookup"] = lookup
     public_spec: ControlSpec | None = {"style": style} if style is not None else None
     return public_spec, domain
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -6,6 +6,7 @@ TDD: these tests were written FIRST, then the implementation.
 from __future__ import annotations
 
 import textwrap
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -681,6 +682,19 @@ restoration = "exact"
     _LARGE_DECIMAL = _LINEAR.replace(
         "display_max = 1.0", "display_max = 1000000000000"
     ).replace("display_step = 0.2", "display_step = 1e-20")
+    _LOOKUP_POINTS = """\
+lookup = [
+  { raw = 0, display = 0.0 },
+  { raw = 2, display = 0.2 },
+  { raw = 4, display = 0.4 },
+  { raw = 6, display = 0.6 },
+  { raw = 8, display = 0.8 },
+  { raw = 10, display = 1.0 },
+]
+"""
+    _LOOKUP = (
+        _LINEAR.replace('mapping = "linear"', 'mapping = "lookup"') + _LOOKUP_POINTS
+    )
 
     def _load(self, tmp_path, declaration: str):
         text = _MINIMAL_TOML + "\n[controls.test_control]\n" + declaration
@@ -770,10 +784,139 @@ restoration = "exact"
         with pytest.raises(RigLoadError, match="display_unit.*non-empty"):
             self._load(tmp_path, declaration)
 
-    def test_lookup_is_explicitly_deferred(self, tmp_path):
+    def test_exact_lookup_is_private_complete_and_non_serialized(self, tmp_path):
+        rig = self._load(tmp_path, 'style = "stepped"\n' + self._LOOKUP)
+
+        assert rig._control_domains["test_control"]["lookup"] == (
+            (0, Decimal("0.0")),
+            (2, Decimal("0.2")),
+            (4, Decimal("0.4")),
+            (6, Decimal("0.6")),
+            (8, Decimal("0.8")),
+            (10, Decimal("1.0")),
+        )
+        public = {"test_control": {"style": "stepped"}}
+        assert rig.controls == public
+        assert rig.to_profile().controls == public
+
+    def test_exact_lookup_requires_every_raw_lattice_point(self, tmp_path):
+        partial = self._LOOKUP.replace("  { raw = 4, display = 0.4 },\n", "")
+        with pytest.raises(RigLoadError, match="exact.*complete raw lattice"):
+            self._load(tmp_path, partial)
+
+    def test_unavailable_lookup_permits_truthful_partial_table(self, tmp_path):
+        partial = self._LOOKUP.replace(
+            'restoration = "exact"', 'restoration = "unavailable"'
+        )
+        partial = partial.replace("  { raw = 4, display = 0.4 },\n", "")
+        assert (
+            len(
+                self._load(tmp_path, partial)._control_domains["test_control"]["lookup"]
+            )
+            == 5
+        )
+
+    def test_lookup_accepts_strictly_decreasing_axes(self, tmp_path):
+        lines = self._LOOKUP_POINTS.splitlines()
+        descending = "\n".join(lines[:1] + list(reversed(lines[1:-1])) + lines[-1:])
         declaration = self._LINEAR.replace('mapping = "linear"', 'mapping = "lookup"')
-        with pytest.raises(RigLoadError, match="lookup.*MOR-1708"):
+        assert (
+            self._load(tmp_path, declaration + descending)._control_domains is not None
+        )
+
+    @pytest.mark.parametrize(
+        ("old", "new", "message"),
+        [
+            ("raw = 4, display = 0.4", "raw = 2, display = 0.4", "raw values.*unique"),
+            (
+                "raw = 4, display = 0.4",
+                "raw = 4, display = 0.2",
+                "display values.*unique",
+            ),
+            (
+                "{ raw = 4, display = 0.4 },\n  { raw = 6, display = 0.6 }",
+                "{ raw = 6, display = 0.4 },\n  { raw = 4, display = 0.6 }",
+                "raw values.*strictly monotonic",
+            ),
+            (
+                "{ raw = 4, display = 0.4 },\n  { raw = 6, display = 0.6 }",
+                "{ raw = 4, display = 0.6 },\n  { raw = 6, display = 0.4 }",
+                "display values.*strictly monotonic",
+            ),
+        ],
+    )
+    def test_lookup_rejects_duplicate_and_non_monotonic_axes(
+        self, tmp_path, old, new, message
+    ):
+        with pytest.raises(RigLoadError, match=message):
+            self._load(tmp_path, self._LOOKUP.replace(old, new))
+
+    @pytest.mark.parametrize(
+        ("old", "new", "message"),
+        [
+            ("raw = 4, display = 0.4", "raw = 3, display = 0.4", "raw.*lattice"),
+            ("raw = 4, display = 0.4", "raw = 12, display = 0.4", "raw.*range"),
+            ("raw = 4, display = 0.4", "raw = 4, display = 0.45", "display.*lattice"),
+            ("raw = 4, display = 0.4", "raw = 4, display = 1.2", "display.*range"),
+        ],
+    )
+    def test_lookup_rejects_out_of_range_and_off_lattice_points(
+        self, tmp_path, old, new, message
+    ):
+        with pytest.raises(RigLoadError, match=message):
+            self._load(tmp_path, self._LOOKUP.replace(old, new))
+
+    def test_lookup_rejects_large_index_tolerance_bypass(self, tmp_path):
+        declaration = self._LOOKUP.replace(
+            "display_max = 1.0", "display_max = 1000000000000.2"
+        )
+        declaration = declaration.replace(
+            "{ raw = 10, display = 1.0 }",
+            "{ raw = 10, display = 1000000000000.05 }",
+        )
+        with pytest.raises(RigLoadError, match="display.*lattice"):
             self._load(tmp_path, declaration)
+
+        declaration = self._LOOKUP.replace("raw_max = 10", "raw_max = 9007199254740992")
+        declaration = declaration.replace(
+            'restoration = "exact"', 'restoration = "unavailable"'
+        )
+        declaration = declaration.replace(
+            "{ raw = 10, display = 1.0 }", "{ raw = 9007199254740991, display = 1.0 }"
+        )
+        with pytest.raises(RigLoadError, match="raw.*lattice"):
+            self._load(tmp_path, declaration)
+
+    def test_unavailable_lookup_still_rejects_ambiguous_display(self, tmp_path):
+        declaration = self._LOOKUP.replace(
+            'restoration = "exact"', 'restoration = "unavailable"'
+        ).replace("raw = 4, display = 0.4", "raw = 4, display = 0.2")
+        with pytest.raises(RigLoadError, match="display values.*unique"):
+            self._load(tmp_path, declaration)
+
+    @pytest.mark.parametrize(
+        "lookup",
+        [
+            "",
+            "lookup = []\n",
+            'lookup = "invalid"\n',
+            "lookup = [0]\n",
+            "lookup = [{ raw = 0 }]\n",
+            "lookup = [{ raw = 0, display = 0.0, extra = 1 }]\n",
+            "lookup = [{ raw = 0.0, display = 0.0 }]\n",
+            "lookup = [{ raw = true, display = 0.0 }]\n",
+            'lookup = [{ raw = 0, display = "zero" }]\n',
+            "lookup = [{ raw = 0, display = nan }]\n",
+        ],
+    )
+    def test_lookup_rejects_empty_and_malformed_tables(self, tmp_path, lookup):
+        declaration = self._LINEAR.replace('mapping = "linear"', 'mapping = "lookup"')
+        with pytest.raises(RigLoadError, match="lookup"):
+            self._load(tmp_path, declaration + lookup)
+
+    def test_lookup_key_requires_lookup_mapping(self, tmp_path):
+        with pytest.raises(RigLoadError, match="lookup.*mapping"):
+            self._load(tmp_path, self._LINEAR + self._LOOKUP_POINTS)
 
     def test_shipped_legacy_profiles_remain_publicly_shape_compatible(self):
         for path in sorted(


### PR DESCRIPTION
## Summary

- validate loader-private lookup tables as immutable raw/Decimal point pairs
- require unique, strictly monotonic, in-range, exact-lattice raw and display axes
- require complete raw-lattice coverage for exact restoration while allowing truthful partial unavailable tables
- keep lookup metadata out of public `ControlSpec`, `RadioProfile.controls`, capabilities, and serialization

## Why

MOR-1708 completes the sequential loader-owned lookup-domain validation child after MOR-1707. Malformed, ambiguous, partial-exact, and large-index tolerance-bypass declarations now fail with bounded `RigLoadError` diagnostics.

Linear: MOR-1708

## Validation

- `uv run pytest tests/test_rig_loader.py -q --tb=short` — 292 passed, 1 skipped
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/rigplane/profiles/rig_loader.py`
- `uv run lint-imports`
- CI-equivalent suite — 9815 passed, 74 skipped, 14 xfailed, 1 xpassed
- diff and privacy review

One unrelated async timeout in the first full run passed in isolation; two subsequent full CI-equivalent runs were green.
