### PR TITLE
[MOR-1705] render unknown PBT without numeric semantics

### DIFF
--- a/frontend/src/semantic/FilterSurface.svelte
+++ b/frontend/src/semantic/FilterSurface.svelte
@@ -79,6 +79,8 @@
     usable(f) ? undefined : 'field-not-observed';
   const textOf = (f: TxAuxField<unknown>): string =>
     f.reading.status === 'known' ? String(f.reading.value) : '?';
+  const presentationOf = (f: TxAuxField<unknown>): 'confirmed' | 'retained' | 'unknown' =>
+    usable(f) ? 'confirmed' : f.reading.status === 'known' ? 'retained' : 'unknown';
   const numberOf = (f: TxAuxField<number>, fallback: number): number =>
     f.reading.status === 'known' ? f.reading.value : fallback;
   /** Never fabricates a selection: `usable` alone cannot narrow `reading` for
@@ -210,19 +212,31 @@
       {/if}
       {#each FILTER_PASSBAND_LEVELS as [field, label, min, max, step] (field)}
         {#if field === 'ifShift' ? filterPassband.ifShiftControlStructural : filterPassband[field].availability.structural}
-          <label
-            class="filter-level" data-testid={`filter-${field}`}
-            data-disabled-reason={reasonOf(filterPassband[field])}
-          >
-            <span class="filter-level-name">{label}</span>
-            <input
-              type="range" {min} {max} {step}
-              value={numberOf(filterPassband[field], min)}
-              disabled={!usable(filterPassband[field])}
-              oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
-            />
-            <output>{textOf(filterPassband[field])}</output>
-          </label>
+          {#if (field === 'pbtInner' || field === 'pbtOuter') && filterPassband[field].reading.status !== 'known'}
+            <div
+              class="filter-level" data-testid={`filter-${field}`} role="status"
+              aria-label={`${label}: unavailable; value not observed`}
+              data-disabled-reason={reasonOf(filterPassband[field])} data-presentation="unknown"
+            >
+              <span class="filter-level-name">{label}</span>
+              <span>Unavailable — value not observed</span>
+            </div>
+          {:else}
+            <label
+              class="filter-level" data-testid={`filter-${field}`}
+              data-disabled-reason={reasonOf(filterPassband[field])}
+              data-presentation={presentationOf(filterPassband[field])}
+            >
+              <span class="filter-level-name">{label}</span>
+              <input
+                type="range" {min} {max} {step}
+                value={numberOf(filterPassband[field], min)}
+                disabled={!usable(filterPassband[field])}
+                oninput={(event) => changePassband(field, event.currentTarget.valueAsNumber)}
+              />
+              <output>{textOf(filterPassband[field])}</output>
+            </label>
+          {/if}
         {/if}
       {/each}
       {#if filterPassband.dataMode.availability.structural}

--- a/frontend/src/semantic/__tests__/FilterSurface.test.ts
+++ b/frontend/src/semantic/__tests__/FilterSurface.test.ts
@@ -525,6 +525,53 @@ describe('level fields emit the raw value, unrescaled', () => {
   });
 });
 
+// ── 5b. Unknown PBT is indeterminate, never an endpoint-shaped range ───────
+
+describe('unknown PBT has no fabricated numeric semantics (MOR-1705)', () => {
+  const PBT_FIELDS = [
+    ['pbtInner', 'PBT inner', 'onPbtInnerChange'],
+    ['pbtOuter', 'PBT outer', 'onPbtOuterChange'],
+  ] as const;
+
+  it.each(PBT_FIELDS)('renders unknown %s as an accessible indeterminate status with no command target', (field, label, handler) => {
+    const spy = vi.fn();
+    const view = withPassbandField(base(), field, { unknown: true });
+    withSurface(view, (s) => {
+      const group = s.group(`filter-${field}`)!;
+      expect(group.getAttribute('role')).toBe('status');
+      expect(group.getAttribute('aria-label')).toBe(`${label}: unavailable; value not observed`);
+      expect(group.textContent).toContain('Unavailable — value not observed');
+      expect(group.querySelector('input')).toBeNull();
+      expect(group.querySelector('[aria-valuenow]')).toBeNull();
+      expect(s.input(`filter-${field}`)).toBeNull();
+      expect(spy).not.toHaveBeenCalled();
+    }, { [handler]: spy });
+  });
+
+  it.each(PBT_FIELDS)('renders known and retained %s as ranges with their own availability', (field, _label, handler) => {
+    const onChange = vi.fn();
+    withSurface(base(), (s) => {
+      const input = s.input(`filter-${field}`)!;
+      expect(input.disabled).toBe(false);
+      expect(s.group(`filter-${field}`)!.dataset.presentation).toBe('confirmed');
+      input.value = '100';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onChange).toHaveBeenCalledExactlyOnceWith(100);
+    }, { [handler]: onChange });
+    const retained = withPassbandField(base(), field, {
+      availability: { structural: true, operational: false },
+    });
+    withSurface(retained, (s) => {
+      const input = s.input(`filter-${field}`)!;
+      expect(input.disabled).toBe(true);
+      expect(s.group(`filter-${field}`)!.dataset.disabledReason).toBe('field-not-observed');
+      expect(s.group(`filter-${field}`)!.dataset.presentation).toBe('retained');
+      expect(s.output(`filter-${field}`)!.textContent).not.toBe('?');
+    });
+  });
+});
+
 // ── 6. filterWidth bounds read their OWN field, independently (F2-style) ────
 
 describe('filterWidth and its bounds carry independent availability', () => {


### PR DESCRIPTION
## Summary

- render structurally supported but unknown PBT Inner/Outer as truthful accessible indeterminate status elements
- omit the numeric range, endpoints, thumb, and input/keyboard/pointer command target until a known value exists
- keep confirmed and presentation-retained known PBT values as ranges, exposing confirmed/retained/unknown presentation state

## Verification

- `npm test -- --run src/semantic/__tests__/FilterSurface.test.ts` (57 passed)
- `npm test -- --run --maxWorkers=2` (354 files, 7,651 passed)
- `npm run check`
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check`
- `npm run build`
- diff guard: 2 files, 74 additions / 13 deletions; privacy scan clean

## Scope

Presentation-only semantic DOM. No store, runtime, poller, writer, timer, model branch, command path, browser, hardware, API, CAT, audio, or TX work.

Linear: MOR-1705