### PR TITLE
feat(MOR-1717): publish validated control domains

### DIFF
--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Required, TypedDict
+from typing import Literal, Never, NotRequired, Required, TypedDict
 
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.tx_interlock_contract import (
@@ -20,6 +20,7 @@ from rigplane.core.tx_interlock_contract import (
 
 __all__ = [
     "ControlLookupPoint",
+    "ControlDomainSpec",
     "ControlSpec",
     "FilterWidthSegment",
     "FilterWidthRule",
@@ -39,28 +40,76 @@ class ControlLookupPoint(TypedDict):
     """One normalized lookup point for a profile control domain."""
 
     raw: int
-    display: float
+    display: str
 
 
 class ControlSpec(TypedDict, total=False):
-    """Specification for a single radio control (from TOML ``[controls.*]``)."""
+    """Legacy control specification (from TOML ``[controls.*]``).
+
+    This remains callable for consumers that construct legacy controls at
+    runtime. Explicit scalar domains use ``ControlDomainSpec`` instead.
+    """
 
     style: str
-    mapping: str
+    raw_min: int
+    raw_max: int
+    raw_center: int
+    display_min: int
+    display_max: int
+    display_unit: str
+
+
+class _ControlDomainBase(TypedDict):
+    """Fields shared by all normalized public control domains."""
+
     raw_min: int
     raw_max: int
     raw_step: int
     raw_origin: int
-    raw_center: int
-    display_min: float
-    display_max: float
-    display_step: float
-    display_origin: float
-    display_center: float
+    display_min: str
+    display_max: str
+    display_step: str
+    display_origin: str
     display_unit: str
     quantization: str
     restoration: str
+    style: NotRequired[str]
+
+
+class IdentityControlDomainSpec(_ControlDomainBase):
+    mapping: Required[Literal["identity"]]
+    raw_center: NotRequired[Never]
+    display_center: NotRequired[Never]
+    lookup: NotRequired[Never]
+
+
+class LinearControlDomainSpec(_ControlDomainBase):
+    mapping: Required[Literal["linear"]]
+    raw_center: NotRequired[Never]
+    display_center: NotRequired[Never]
+    lookup: NotRequired[Never]
+
+
+class CenteredControlDomainSpec(_ControlDomainBase):
+    mapping: Required[Literal["centered"]]
+    raw_center: int
+    display_center: str
+    lookup: NotRequired[Never]
+
+
+class LookupControlDomainSpec(_ControlDomainBase):
+    mapping: Required[Literal["lookup"]]
     lookup: list[ControlLookupPoint]
+    raw_center: NotRequired[Never]
+    display_center: NotRequired[Never]
+
+
+ControlDomainSpec = (
+    IdentityControlDomainSpec
+    | LinearControlDomainSpec
+    | CenteredControlDomainSpec
+    | LookupControlDomainSpec
+)
 
 
 class MeterCalibrationPoint(TypedDict):
@@ -225,7 +274,7 @@ class RadioProfile:
     # Hamlib rig_model integer (from rigs_list.h). Used by the validate
     # ``--provider hamlib`` path to launch stock rigctld with ``-m <id>``.
     hamlib_model_id: int = 2028
-    controls: dict[str, ControlSpec] | None = None
+    controls: dict[str, ControlSpec | ControlDomainSpec] | None = None
     meter_calibrations: dict[str, list[MeterCalibrationPoint]] | None = None
     meter_redlines: dict[str, int] | None = None
     rules: tuple[RuleSpec, ...] = ()

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -19,6 +19,7 @@ from rigplane.core.tx_interlock_contract import (
 )
 
 __all__ = [
+    "ControlLookupPoint",
     "ControlSpec",
     "FilterWidthSegment",
     "FilterWidthRule",
@@ -34,16 +35,32 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+class ControlLookupPoint(TypedDict):
+    """One normalized lookup point for a profile control domain."""
+
+    raw: int
+    display: float
+
+
 class ControlSpec(TypedDict, total=False):
     """Specification for a single radio control (from TOML ``[controls.*]``)."""
 
     style: str
+    mapping: str
     raw_min: int
     raw_max: int
+    raw_step: int
+    raw_origin: int
     raw_center: int
-    display_min: int
-    display_max: int
+    display_min: float
+    display_max: float
+    display_step: float
+    display_origin: float
+    display_center: float
     display_unit: str
+    quantization: str
+    restoration: str
+    lookup: list[ControlLookupPoint]
 
 
 class MeterCalibrationPoint(TypedDict):

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -33,6 +33,7 @@ __all__ = ["RigConfig", "RigLoadError", "load_rig", "discover_rigs"]
 from rigplane.commands.command_spec import CatCommandSpec, CivCommandSpec, CommandSpec
 from rigplane.profiles import (
     BandInfo,
+    ControlDomainSpec,
     ControlLookupPoint,
     ControlSpec,
     FilterWidthRule,
@@ -119,6 +120,14 @@ class RigLoadError(Exception):
 
 _LookupPoint = tuple[int, Decimal]
 _ScalarControlDomain = dict[str, str | int | Decimal | tuple[_LookupPoint, ...]]
+
+
+def _public_decimal(value: Decimal) -> str:
+    """Render an exact Decimal as the frontend's canonical fixed-point string."""
+    rendered = format(value, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return "0" if rendered in {"0", "-0"} else rendered
 
 
 def _control_number(value: object, path: str, *, integer: bool = False) -> int | float:
@@ -513,39 +522,56 @@ class RigConfig:
             )
             for r in self.freq_ranges
         )
-        controls = self.controls
+        controls = cast(
+            dict[str, ControlSpec | ControlDomainSpec] | None, self.controls
+        )
         if self._control_domains:
-            published_controls: dict[str, ControlSpec] = {
-                name: spec.copy() for name, spec in (self.controls or {}).items()
-            }
+            published_controls = cast(
+                dict[str, ControlSpec | ControlDomainSpec],
+                {name: spec.copy() for name, spec in (self.controls or {}).items()},
+            )
             for name, domain in self._control_domains.items():
-                published_domain: ControlSpec = {
+                published_domain: dict[str, object] = {
                     "mapping": cast(str, domain["mapping"]),
                     "raw_min": cast(int, domain["raw_min"]),
                     "raw_max": cast(int, domain["raw_max"]),
                     "raw_step": cast(int, domain["raw_step"]),
                     "raw_origin": cast(int, domain["raw_origin"]),
-                    "display_min": float(cast(Decimal, domain["display_min"])),
-                    "display_max": float(cast(Decimal, domain["display_max"])),
-                    "display_step": float(cast(Decimal, domain["display_step"])),
-                    "display_origin": float(cast(Decimal, domain["display_origin"])),
+                    "display_min": _public_decimal(
+                        cast(Decimal, domain["display_min"])
+                    ),
+                    "display_max": _public_decimal(
+                        cast(Decimal, domain["display_max"])
+                    ),
+                    "display_step": _public_decimal(
+                        cast(Decimal, domain["display_step"])
+                    ),
+                    "display_origin": _public_decimal(
+                        cast(Decimal, domain["display_origin"])
+                    ),
                     "display_unit": cast(str, domain["display_unit"]),
                     "quantization": cast(str, domain["quantization"]),
                     "restoration": cast(str, domain["restoration"]),
                 }
                 if published_domain["mapping"] == "centered":
                     published_domain["raw_center"] = cast(int, domain["raw_center"])
-                    published_domain["display_center"] = float(
+                    published_domain["display_center"] = _public_decimal(
                         cast(Decimal, domain["display_center"])
                     )
                 if published_domain["mapping"] == "lookup":
                     published_domain["lookup"] = [
-                        ControlLookupPoint(raw=raw, display=float(display))
+                        ControlLookupPoint(raw=raw, display=_public_decimal(display))
                         for raw, display in cast(
                             tuple[_LookupPoint, ...], domain["lookup"]
                         )
                     ]
-                published_controls.setdefault(name, {}).update(published_domain)
+                legacy = published_controls.get(name)
+                if legacy is not None and "style" in legacy:
+                    published_domain["style"] = legacy["style"]
+                # The loader has already established the mapping-specific
+                # shape above; this cast keeps the public discriminated union
+                # explicit without weakening its legacy counterpart.
+                published_controls[name] = cast(ControlDomainSpec, published_domain)
             controls = published_controls
 
         return RadioProfile(

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -33,6 +33,7 @@ __all__ = ["RigConfig", "RigLoadError", "load_rig", "discover_rigs"]
 from rigplane.commands.command_spec import CatCommandSpec, CivCommandSpec, CommandSpec
 from rigplane.profiles import (
     BandInfo,
+    ControlLookupPoint,
     ControlSpec,
     FilterWidthRule,
     FilterWidthSegment,
@@ -512,6 +513,40 @@ class RigConfig:
             )
             for r in self.freq_ranges
         )
+        controls = self.controls
+        if self._control_domains:
+            published_controls: dict[str, ControlSpec] = {
+                name: spec.copy() for name, spec in (self.controls or {}).items()
+            }
+            for name, domain in self._control_domains.items():
+                published_domain: ControlSpec = {
+                    "mapping": cast(str, domain["mapping"]),
+                    "raw_min": cast(int, domain["raw_min"]),
+                    "raw_max": cast(int, domain["raw_max"]),
+                    "raw_step": cast(int, domain["raw_step"]),
+                    "raw_origin": cast(int, domain["raw_origin"]),
+                    "display_min": float(cast(Decimal, domain["display_min"])),
+                    "display_max": float(cast(Decimal, domain["display_max"])),
+                    "display_step": float(cast(Decimal, domain["display_step"])),
+                    "display_origin": float(cast(Decimal, domain["display_origin"])),
+                    "display_unit": cast(str, domain["display_unit"]),
+                    "quantization": cast(str, domain["quantization"]),
+                    "restoration": cast(str, domain["restoration"]),
+                }
+                if published_domain["mapping"] == "centered":
+                    published_domain["raw_center"] = cast(int, domain["raw_center"])
+                    published_domain["display_center"] = float(
+                        cast(Decimal, domain["display_center"])
+                    )
+                if published_domain["mapping"] == "lookup":
+                    published_domain["lookup"] = [
+                        ControlLookupPoint(raw=raw, display=float(display))
+                        for raw, display in cast(
+                            tuple[_LookupPoint, ...], domain["lookup"]
+                        )
+                    ]
+                published_controls.setdefault(name, {}).update(published_domain)
+            controls = published_controls
 
         return RadioProfile(
             id=self.id,
@@ -558,7 +593,7 @@ class RigConfig:
             set_mode_via_selected="set_selected_mode" in self.commands,
             protocol_type=self.protocol_type,
             hamlib_model_id=self.hamlib_model_id,
-            controls=self.controls,
+            controls=controls,
             meter_calibrations=self.meter_calibrations,
             meter_redlines=self.meter_redlines,
             rules=self.rules,

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -5,6 +5,7 @@ TDD: these tests were written FIRST, then the implementation.
 
 from __future__ import annotations
 
+import json
 import textwrap
 from decimal import Decimal
 from pathlib import Path
@@ -720,12 +721,39 @@ lookup = [
             ),
         ],
     )
-    def test_scalar_domain_is_private(self, tmp_path, mapping, declaration):
+    def test_scalar_domain_is_published_with_exact_normalized_shape(
+        self, tmp_path, mapping, declaration
+    ):
         rig = self._load(tmp_path, declaration)
 
         assert rig._control_domains["test_control"]["mapping"] == mapping
         assert rig.controls is None
-        assert rig.to_profile().controls is None
+        public = rig.to_profile().controls
+        assert public == {
+            "test_control": {
+                "mapping": mapping,
+                "raw_min": -10 if mapping == "centered" else 0,
+                "raw_max": 10,
+                "raw_step": 2,
+                "raw_origin": 0,
+                "display_min": -1.0 if mapping == "centered" else 0.0,
+                "display_max": 10.0 if mapping == "identity" else 1.0,
+                "display_step": 2.0 if mapping == "identity" else 0.2,
+                "display_origin": 0.0,
+                "display_unit": "dimensionless" if mapping == "identity" else "ratio",
+                "quantization": "nearest_ties_up",
+                "restoration": "exact",
+                **(
+                    {"raw_center": 0, "display_center": 0.0}
+                    if mapping == "centered"
+                    else {}
+                ),
+            }
+        }
+        assert "lookup" not in public["test_control"]
+        assert ("raw_center" in public["test_control"]) is (mapping == "centered")
+        assert ("display_center" in public["test_control"]) is (mapping == "centered")
+        assert json.loads(json.dumps(public)) == public
 
     @pytest.mark.parametrize(
         ("old", "new", "message"),
@@ -784,7 +812,7 @@ lookup = [
         with pytest.raises(RigLoadError, match="display_unit.*non-empty"):
             self._load(tmp_path, declaration)
 
-    def test_exact_lookup_is_private_complete_and_non_serialized(self, tmp_path):
+    def test_exact_lookup_is_published_as_json_safe_objects(self, tmp_path):
         rig = self._load(tmp_path, 'style = "stepped"\n' + self._LOOKUP)
 
         assert rig._control_domains["test_control"]["lookup"] == (
@@ -795,9 +823,36 @@ lookup = [
             (8, Decimal("0.8")),
             (10, Decimal("1.0")),
         )
-        public = {"test_control": {"style": "stepped"}}
-        assert rig.controls == public
+        public = {
+            "test_control": {
+                "style": "stepped",
+                "mapping": "lookup",
+                "raw_min": 0,
+                "raw_max": 10,
+                "raw_step": 2,
+                "raw_origin": 0,
+                "display_min": 0.0,
+                "display_max": 1.0,
+                "display_step": 0.2,
+                "display_origin": 0.0,
+                "display_unit": "ratio",
+                "quantization": "nearest_ties_up",
+                "restoration": "exact",
+                "lookup": [
+                    {"raw": 0, "display": 0.0},
+                    {"raw": 2, "display": 0.2},
+                    {"raw": 4, "display": 0.4},
+                    {"raw": 6, "display": 0.6},
+                    {"raw": 8, "display": 0.8},
+                    {"raw": 10, "display": 1.0},
+                ],
+            }
+        }
+        assert rig.controls == {"test_control": {"style": "stepped"}}
         assert rig.to_profile().controls == public
+        assert json.loads(json.dumps(public)) == public
+        assert "raw_center" not in public["test_control"]
+        assert "display_center" not in public["test_control"]
 
     def test_exact_lookup_requires_every_raw_lattice_point(self, tmp_path):
         partial = self._LOOKUP.replace("  { raw = 4, display = 0.4 },\n", "")
@@ -925,6 +980,12 @@ lookup = [
             rig = load_rig(path)
             assert rig._control_domains is None, path.name
             assert rig.to_profile().controls == rig.controls, path.name
+
+    def test_malformed_domain_rejects_before_profile_production(self, tmp_path):
+        malformed = self._LINEAR.replace("raw_step = 2", "raw_step = 0")
+
+        with pytest.raises(RigLoadError, match="raw_step"):
+            self._load(tmp_path, malformed)
 
 
 # ── RadioProfile building ───────────────────────────────────────

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -19,7 +19,13 @@ from rigplane.core.tx_interlock_contract import (
     TxInterlockCommandFamily,
     TxInterlockDisposition,
 )
-from rigplane.profiles import BandInfo, FreqRangeInfo, RadioProfile, get_radio_profile
+from rigplane.profiles import (
+    BandInfo,
+    ControlSpec,
+    FreqRangeInfo,
+    RadioProfile,
+    get_radio_profile,
+)
 from rigplane.rig_loader import RigConfig, RigLoadError, discover_rigs, load_rig
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
@@ -736,15 +742,15 @@ lookup = [
                 "raw_max": 10,
                 "raw_step": 2,
                 "raw_origin": 0,
-                "display_min": -1.0 if mapping == "centered" else 0.0,
-                "display_max": 10.0 if mapping == "identity" else 1.0,
-                "display_step": 2.0 if mapping == "identity" else 0.2,
-                "display_origin": 0.0,
+                "display_min": "-1" if mapping == "centered" else "0",
+                "display_max": "10" if mapping == "identity" else "1",
+                "display_step": "2" if mapping == "identity" else "0.2",
+                "display_origin": "0",
                 "display_unit": "dimensionless" if mapping == "identity" else "ratio",
                 "quantization": "nearest_ties_up",
                 "restoration": "exact",
                 **(
-                    {"raw_center": 0, "display_center": 0.0}
+                    {"raw_center": 0, "display_center": "0"}
                     if mapping == "centered"
                     else {}
                 ),
@@ -754,6 +760,10 @@ lookup = [
         assert ("raw_center" in public["test_control"]) is (mapping == "centered")
         assert ("display_center" in public["test_control"]) is (mapping == "centered")
         assert json.loads(json.dumps(public)) == public
+        second = rig.to_profile().controls
+        assert second is not public
+        assert second is not None
+        assert second["test_control"] is not public["test_control"]
 
     @pytest.mark.parametrize(
         ("old", "new", "message"),
@@ -831,26 +841,26 @@ lookup = [
                 "raw_max": 10,
                 "raw_step": 2,
                 "raw_origin": 0,
-                "display_min": 0.0,
-                "display_max": 1.0,
-                "display_step": 0.2,
-                "display_origin": 0.0,
+                "display_min": "0",
+                "display_max": "1",
+                "display_step": "0.2",
+                "display_origin": "0",
                 "display_unit": "ratio",
                 "quantization": "nearest_ties_up",
                 "restoration": "exact",
                 "lookup": [
-                    {"raw": 0, "display": 0.0},
-                    {"raw": 2, "display": 0.2},
-                    {"raw": 4, "display": 0.4},
-                    {"raw": 6, "display": 0.6},
-                    {"raw": 8, "display": 0.8},
-                    {"raw": 10, "display": 1.0},
+                    {"raw": 0, "display": "0"},
+                    {"raw": 2, "display": "0.2"},
+                    {"raw": 4, "display": "0.4"},
+                    {"raw": 6, "display": "0.6"},
+                    {"raw": 8, "display": "0.8"},
+                    {"raw": 10, "display": "1"},
                 ],
             }
         }
         assert rig.controls == {"test_control": {"style": "stepped"}}
         assert rig.to_profile().controls == public
-        assert json.loads(json.dumps(public)) == public
+        assert json.loads(json.dumps(public, allow_nan=False)) == public
         assert "raw_center" not in public["test_control"]
         assert "display_center" not in public["test_control"]
 
@@ -981,11 +991,69 @@ lookup = [
             assert rig._control_domains is None, path.name
             assert rig.to_profile().controls == rig.controls, path.name
 
+    def test_legacy_control_spec_remains_runtime_callable_with_its_exact_shape(self):
+        legacy = ControlSpec(
+            style="stepped",
+            raw_min=0,
+            raw_max=10,
+            raw_center=5,
+            display_min=0,
+            display_max=10,
+            display_unit="dimensionless",
+        )
+
+        assert legacy == {
+            "style": "stepped",
+            "raw_min": 0,
+            "raw_max": 10,
+            "raw_center": 5,
+            "display_min": 0,
+            "display_max": 10,
+            "display_unit": "dimensionless",
+        }
+
     def test_malformed_domain_rejects_before_profile_production(self, tmp_path):
         malformed = self._LINEAR.replace("raw_step = 2", "raw_step = 0")
 
         with pytest.raises(RigLoadError, match="raw_step"):
             self._load(tmp_path, malformed)
+
+    @pytest.mark.parametrize(
+        "maximum",
+        [
+            "9" * 400,
+            "9007199254740993",
+            "0.00000000000000000000000000000000000000000000000001",
+            "-0.00000000000000000000000000000000000000000000000001",
+        ],
+    )
+    def test_public_domain_displays_are_lossless_canonical_fixed_point(
+        self, tmp_path, maximum
+    ):
+        if maximum.startswith("-"):
+            magnitude = maximum.removeprefix("-")
+            declaration = self._LINEAR.replace(
+                "display_min = 0.0", f"display_min = {maximum}"
+            )
+            declaration = declaration.replace(
+                "display_step = 0.2", f"display_step = {magnitude}"
+            )
+            declaration = declaration.replace("display_max = 1.0", "display_max = 0")
+            expected_field = "display_min"
+        else:
+            declaration = self._LINEAR.replace(
+                "display_max = 1.0", f"display_max = {maximum}"
+            )
+            declaration = declaration.replace(
+                "display_step = 0.2", f"display_step = {maximum}"
+            )
+            expected_field = "display_max"
+        declaration = declaration.replace("display_origin = 0.0", "display_origin = 0")
+        public = self._load(tmp_path, declaration).to_profile().controls
+        assert public is not None
+        control = public["test_control"]
+        assert json.loads(json.dumps(control, allow_nan=False)) == control
+        assert control[expected_field] == maximum
 
 
 # ── RadioProfile building ───────────────────────────────────────


### PR DESCRIPTION
Summary: publish loader-validated scalar domains through the public RadioProfile controls contract with lossless canonical fixed-point display strings.

Scope: exactly three files; no web, frontend, runtime, or hardware change.

Compatibility: legacy ControlSpec remains runtime-callable and shipped legacy profiles retain their exact public control shape. Explicit domains are Literal-discriminated identity/linear/centered/lookup variants; mapping-only fields are exclusive.

Verification: focused loader 298 passed / 1 skipped; full Python 9882 passed / 13 skipped / 5 deselected / 14 xfailed / 1 xpassed; ruff, changed-source mypy, import-linter, diff/privacy passed.

Linear: MOR-1717