### PR TITLE
feat(MOR-1721): preserve exact control-domain decimals

### DIFF
--- a/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
+++ b/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ExactDecimal } from '../exact-decimal';
 import type { ControlDomain, LookupControlDomain, ScalarControlDomain } from '../capabilities';
 import { validateCapabilities } from '../capabilities';
 
@@ -17,6 +18,17 @@ function controlDomainTypeContract(linear: ScalarControlDomain, lookup: LookupCo
   lookup.lookup[0]!.display = 1;
 }
 void controlDomainTypeContract;
+function exactDecimalTypeContract(value: ExactDecimal): void {
+  const stringValue: string = value;
+  void stringValue;
+  // @ts-expect-error exact display strings are never numeric values
+  const numberValue: number = value;
+  // @ts-expect-error branded strings must not collapse to never
+  const impossible: never = value;
+  void numberValue;
+  void impossible;
+}
+void exactDecimalTypeContract;
 const baseCapabilities = {
   model: 'Test Radio',
   scope: false,
@@ -135,7 +147,15 @@ describe('normalized control capability domains', () => {
     });
     expect(parsed.display_max).toBe(huge);
   });
-  it.each(['+1', '1e3', ' 1', '01', '1.0', '-0', '1.', ''])('rejects noncanonical string display %s', (display) => {
+  it('accepts negative display axes and nonzero origins as canonical strings', () => {
+    const parsed = parse({
+      ...linearDomain,
+      display_min: '-1', display_max: '1', display_step: '0.2', display_origin: '-0.2',
+    });
+    expect(parsed.display_min).toBe('-1');
+    expect(parsed.display_origin).toBe('-0.2');
+  });
+  it.each(['+1', '1e3', ' 1', '01', '1.0', '-0', '-0.0', '1.', ''])('rejects noncanonical string display %s', (display) => {
     expect(() => parse({ ...linearDomain, display_min: display, display_max: '1', display_step: '0.2', display_origin: '0' })).toThrow(TypeError);
   });
   it('rejects mixed number and string display domains, including lookup values', () => {
@@ -182,6 +202,22 @@ describe('normalized control capability domains', () => {
       expect(parsed.lookup[1]!.display).toBe('0.2');
       expect(Object.isFrozen(parsed.lookup[0])).toBe(true);
     }
+  });
+  it('accepts negative fractional lookup values', () => {
+    const parsed = parse({
+      ...linearDomain, raw_max: 2, raw_step: 1, mapping: 'lookup', restoration: 'exact',
+      display_min: '-0.1', display_max: '0.1', display_step: '0.1', display_origin: '-0.1',
+      lookup: [{ raw: 0, display: '-0.1' }, { raw: 1, display: '0' }, { raw: 2, display: '0.1' }],
+    });
+    expect(parsed.mapping).toBe('lookup');
+    if (parsed.mapping === 'lookup') expect(parsed.lookup[0]!.display).toBe('-0.1');
+  });
+  it('accepts tiny negative fixed-point display values', () => {
+    const parsed = parse({
+      ...linearDomain, raw_max: 2, raw_step: 1,
+      display_min: '-0.0001', display_max: '0.0001', display_step: '0.0001', display_origin: '-0.0001',
+    });
+    expect(parsed.display_min).toBe('-0.0001');
   });
   it('rejects large-index lookup values that are only approximately on lattice', () => {
     expect(() => parse({

--- a/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
+++ b/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
@@ -121,6 +121,27 @@ describe('normalized control capability domains', () => {
       display_step: 0.0002,
     })).toThrow(/lattice/);
   });
+  it('normalizes homogeneous legacy display numbers to immutable canonical strings', () => {
+    const parsed = parse({ ...linearDomain, display_min: -0, display_max: 1e-7, display_step: 2e-8, display_origin: -0 });
+    expect(parsed.display_min).toBe('0');
+    expect(parsed.display_step).toBe('0.00000002');
+    expect(Object.isFrozen(parsed)).toBe(true);
+  });
+  it('accepts arbitrary canonical decimal strings without numeric coercion', () => {
+    const huge = `1${'0'.repeat(399)}`;
+    const parsed = parse({
+      ...linearDomain, raw_max: 2, raw_step: 1,
+      display_min: '0', display_max: huge, display_step: `5${'0'.repeat(398)}`, display_origin: '0',
+    });
+    expect(parsed.display_max).toBe(huge);
+  });
+  it.each(['+1', '1e3', ' 1', '01', '1.0', '-0', '1.', ''])('rejects noncanonical string display %s', (display) => {
+    expect(() => parse({ ...linearDomain, display_min: display, display_max: '1', display_step: '0.2', display_origin: '0' })).toThrow(TypeError);
+  });
+  it('rejects mixed number and string display domains, including lookup values', () => {
+    expect(() => parse({ ...linearDomain, display_min: '0' })).toThrow(/homogeneous/);
+    expect(() => parse({ ...linearDomain, mapping: 'lookup', restoration: 'unavailable', lookup: [{ raw: 0, display: '0' }] })).toThrow(/homogeneous/);
+  });
   const lookup = [{ raw: 0, display: 0 }, { raw: 2, display: 0.2 }, { raw: 4, display: 0.4 }];
   it.each([
     ['empty', []],
@@ -149,6 +170,18 @@ describe('normalized control capability domains', () => {
     const parsed = parse({ ...partial, restoration: 'unavailable' });
     expect(parsed.mapping).toBe('lookup');
     if (parsed.mapping === 'lookup') expect(parsed.lookup).toHaveLength(3);
+  });
+  it('normalizes and deeply freezes canonical lookup displays', () => {
+    const parsed = parse({
+      ...linearDomain, mapping: 'lookup', restoration: 'unavailable',
+      display_min: '0', display_max: '1', display_step: '0.2', display_origin: '0',
+      lookup: [{ raw: 0, display: '0' }, { raw: 2, display: '0.2' }],
+    });
+    expect(parsed.mapping).toBe('lookup');
+    if (parsed.mapping === 'lookup') {
+      expect(parsed.lookup[1]!.display).toBe('0.2');
+      expect(Object.isFrozen(parsed.lookup[0])).toBe(true);
+    }
   });
   it('rejects large-index lookup values that are only approximately on lattice', () => {
     expect(() => parse({

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -1,4 +1,8 @@
 // Capabilities — mirrors backend /api/v1/capabilities schema
+import {
+  compareExactDecimals, exactDecimalInteger, exactDecimalNumber, exactDecimalOnLattice,
+  exactDecimalString, type ExactDecimal,
+} from './exact-decimal';
 
 export interface Band {
   name: string;
@@ -88,7 +92,7 @@ export type ControlRestoration = 'exact' | 'unavailable';
 
 export interface ControlLookupPoint {
   readonly raw: number;
-  readonly display: number;
+  readonly display: ExactDecimal;
 }
 
 interface ControlDomainBase {
@@ -98,10 +102,10 @@ interface ControlDomainBase {
   readonly raw_max: number;
   readonly raw_step: number;
   readonly raw_origin: number;
-  readonly display_min: number;
-  readonly display_max: number;
-  readonly display_step: number;
-  readonly display_origin: number;
+  readonly display_min: ExactDecimal;
+  readonly display_max: ExactDecimal;
+  readonly display_step: ExactDecimal;
+  readonly display_origin: ExactDecimal;
   readonly display_unit: string;
   readonly style?: string;
   readonly quantization: ControlQuantization;
@@ -118,7 +122,7 @@ export interface ScalarControlDomain extends ControlDomainBase {
 export interface CenteredControlDomain extends ControlDomainBase {
   readonly mapping: 'centered';
   readonly raw_center: number;
-  readonly display_center: number;
+  readonly display_center: ExactDecimal;
   readonly lookup?: never;
 }
 
@@ -270,23 +274,7 @@ function choice<T extends string>(value: unknown, path: string, values: readonly
   return value as T;
 }
 
-function decimalParts(value: number): readonly [bigint, number] {
-  const match = String(value).match(/^(-?)(\d+)(?:\.(\d+))?(?:e([+-]?\d+))?$/i);
-  if (!match) throw new TypeError('finite number has no decimal representation');
-  const fraction = match[3] ?? '';
-  const coefficient = BigInt(`${match[1]}${match[2]}${fraction}`);
-  return [coefficient, Number(match[4] ?? 0) - fraction.length];
-}
-
-function onLattice(value: number, origin: number, step: number): boolean {
-  const values = [decimalParts(value), decimalParts(origin), decimalParts(step)] as const;
-  const exponent = Math.min(...values.map((item) => item[1]));
-  const scaled = values.map(([coefficient, itemExponent]) =>
-    coefficient * (10n ** BigInt(itemExponent - exponent)));
-  return (scaled[0] - scaled[1]) % scaled[2] === 0n;
-}
-
-function validateAxis(
+function validateRawAxis(
   low: number,
   high: number,
   step: number,
@@ -296,16 +284,27 @@ function validateAxis(
   if (low >= high) invalid(path, 'min < max');
   if (step <= 0) invalid(`${path}_step`, '> 0');
   if (origin < low || origin > high) invalid(`${path}_origin`, 'inside its declared range');
-  if (!onLattice(low, origin, step)) invalid(`${path}_min`, 'a value on its declared lattice');
-  if (!onLattice(high, origin, step)) invalid(`${path}_max`, 'a value on its declared lattice');
+  if (!exactDecimalOnLattice(exactDecimalInteger(low), exactDecimalInteger(origin), exactDecimalInteger(step))) invalid(`${path}_min`, 'a value on its declared lattice');
+  if (!exactDecimalOnLattice(exactDecimalInteger(high), exactDecimalInteger(origin), exactDecimalInteger(step))) invalid(`${path}_max`, 'a value on its declared lattice');
+}
+
+function validateDisplayAxis(
+  low: ExactDecimal, high: ExactDecimal, step: ExactDecimal, origin: ExactDecimal, path: string,
+): void {
+  if (compareExactDecimals(low, high) >= 0) invalid(path, 'min < max');
+  if (compareExactDecimals(step, exactDecimalInteger(0)) <= 0) invalid(`${path}_step`, '> 0');
+  if (compareExactDecimals(origin, low) < 0 || compareExactDecimals(origin, high) > 0) invalid(`${path}_origin`, 'inside its declared range');
+  if (!exactDecimalOnLattice(low, origin, step)) invalid(`${path}_min`, 'a value on its declared lattice');
+  if (!exactDecimalOnLattice(high, origin, step)) invalid(`${path}_max`, 'a value on its declared lattice');
 }
 
 function validateLookup(
   value: unknown,
   path: string,
   rawAxis: readonly [number, number, number, number],
-  displayAxis: readonly [number, number, number, number],
+  displayAxis: readonly [ExactDecimal, ExactDecimal, ExactDecimal, ExactDecimal],
   restoration: ControlRestoration,
+  kind: DisplayKind,
 ): readonly ControlLookupPoint[] {
   if (!Array.isArray(value) || value.length === 0) invalid(path, 'a non-empty array');
   const points = value.map((item, index) => {
@@ -315,22 +314,24 @@ function validateLookup(
       invalid(pointPath, 'an object containing exactly raw and display');
     }
     const raw = safeInteger(point.raw, `${pointPath}.raw`);
-    const display = finiteNumber(point.display, `${pointPath}.display`);
+    const display = readDisplay(point.display, `${pointPath}.display`, kind);
     if (raw < rawAxis[0] || raw > rawAxis[1]) invalid(`${pointPath}.raw`, 'inside its declared range');
-    if (!onLattice(raw, rawAxis[3], rawAxis[2])) invalid(`${pointPath}.raw`, 'a value on its declared lattice');
-    if (display < displayAxis[0] || display > displayAxis[1]) {
+    if (!exactDecimalOnLattice(exactDecimalInteger(raw), exactDecimalInteger(rawAxis[3]), exactDecimalInteger(rawAxis[2]))) invalid(`${pointPath}.raw`, 'a value on its declared lattice');
+    if (compareExactDecimals(display, displayAxis[0]) < 0 || compareExactDecimals(display, displayAxis[1]) > 0) {
       invalid(`${pointPath}.display`, 'inside its declared range');
     }
-    if (!onLattice(display, displayAxis[3], displayAxis[2])) {
+    if (!exactDecimalOnLattice(display, displayAxis[3], displayAxis[2])) {
       invalid(`${pointPath}.display`, 'a value on its declared lattice');
     }
     return Object.freeze({ raw, display });
   });
   for (const field of ['raw', 'display'] as const) {
     const values = points.map((point) => point[field]);
-    if (new Set(values).size !== values.length) invalid(path, `unique ${field} values`);
-    const increasing = values.every((item, index) => index === 0 || values[index - 1] < item);
-    const decreasing = values.every((item, index) => index === 0 || values[index - 1] > item);
+    const order = (left: number | ExactDecimal, right: number | ExactDecimal) => field === 'raw'
+      ? left as number - (right as number) : compareExactDecimals(left as ExactDecimal, right as ExactDecimal);
+    if (values.some((item, index) => index > 0 && order(values[index - 1]!, item) === 0)) invalid(path, `unique ${field} values`);
+    const increasing = values.every((item, index) => index === 0 || order(values[index - 1]!, item) < 0);
+    const decreasing = values.every((item, index) => index === 0 || order(values[index - 1]!, item) > 0);
     if (values.length > 1 && !increasing && !decreasing) invalid(path, `strictly monotonic ${field} values`);
   }
   const expected = (BigInt(rawAxis[1]) - BigInt(rawAxis[0])) / BigInt(rawAxis[2]) + 1n;
@@ -338,6 +339,29 @@ function validateLookup(
     invalid(path, 'complete raw lattice coverage for exact restoration');
   }
   return Object.freeze(points);
+}
+
+type DisplayKind = 'number' | 'string';
+
+function readDisplay(value: unknown, path: string, kind: DisplayKind): ExactDecimal {
+  if (kind === 'number') {
+    if (typeof value !== 'number' || !Number.isFinite(value)) invalid(path, 'a finite number');
+    return exactDecimalNumber(value);
+  }
+  const decimal = exactDecimalString(value);
+  if (!decimal) invalid(path, 'a canonical fixed-point decimal string');
+  return decimal;
+}
+
+function displayKind(raw: Record<string, unknown>, mapping: string, path: string): DisplayKind {
+  const values: unknown[] = [raw.display_min, raw.display_max, raw.display_step, raw.display_origin];
+  if (mapping === 'centered') values.push(raw.display_center);
+  if (mapping === 'lookup' && Array.isArray(raw.lookup)) {
+    raw.lookup.forEach((point) => { if (point && typeof point === 'object' && !Array.isArray(point)) values.push((point as Record<string, unknown>).display); });
+  }
+  const kinds = new Set(values.map((value) => typeof value));
+  if (kinds.size !== 1 || (!kinds.has('number') && !kinds.has('string'))) invalid(path, 'a homogeneous all-number or all-canonical-string display domain');
+  return kinds.has('number') ? 'number' : 'string';
 }
 
 function parseControlDomain(raw: Record<string, unknown>, path: string): ControlDomain {
@@ -349,19 +373,20 @@ function parseControlDomain(raw: Record<string, unknown>, path: string): Control
     'nearest_ties_down', 'nearest_ties_up', 'floor', 'ceil', 'reject',
   ]);
   const restoration = choice(raw.restoration, `${path}.restoration`, ['exact', 'unavailable']);
+  const displays = displayKind(raw, mapping, path);
   const rawAxis = [
     safeInteger(raw.raw_min, `${path}.raw_min`), safeInteger(raw.raw_max, `${path}.raw_max`),
     safeInteger(raw.raw_step, `${path}.raw_step`), safeInteger(raw.raw_origin, `${path}.raw_origin`),
   ] as const;
   const displayAxis = [
-    finiteNumber(raw.display_min, `${path}.display_min`), finiteNumber(raw.display_max, `${path}.display_max`),
-    finiteNumber(raw.display_step, `${path}.display_step`), finiteNumber(raw.display_origin, `${path}.display_origin`),
+    readDisplay(raw.display_min, `${path}.display_min`, displays), readDisplay(raw.display_max, `${path}.display_max`, displays),
+    readDisplay(raw.display_step, `${path}.display_step`, displays), readDisplay(raw.display_origin, `${path}.display_origin`, displays),
   ] as const;
   if (typeof raw.display_unit !== 'string' || !raw.display_unit.trim()) {
     invalid(`${path}.display_unit`, 'a non-empty string');
   }
-  validateAxis(...rawAxis, `${path}.raw`);
-  validateAxis(...displayAxis, `${path}.display`);
+  validateRawAxis(...rawAxis, `${path}.raw`);
+  validateDisplayAxis(...displayAxis, `${path}.display`);
   if ('range_min' in raw || 'range_max' in raw) {
     if (!('range_min' in raw) || !('range_max' in raw)
       || safeInteger(raw.range_min, `${path}.range_min`) !== rawAxis[0]
@@ -373,25 +398,26 @@ function parseControlDomain(raw: Record<string, unknown>, path: string): Control
     choice(raw.style, `${path}.style`, ['toggle', 'stepped', 'selector', 'toggle_and_level', 'level_is_toggle']);
   }
 
-  const domain: Record<string, unknown> = { ...raw, mapping, quantization, restoration };
-  if (mapping === 'identity' && rawAxis.some((item, index) => item !== displayAxis[index])) {
+  const domain: Record<string, unknown> = { ...raw, ...Object.fromEntries(['min', 'max', 'step', 'origin'].map((field, index) => [`display_${field}`, displayAxis[index]!])), mapping, quantization, restoration };
+  if (mapping === 'identity' && rawAxis.some((item, index) => compareExactDecimals(exactDecimalInteger(item), displayAxis[index]!) !== 0)) {
     invalid(path, 'identical raw and display domains for identity mapping');
   }
   if (mapping === 'centered') {
     const rawCenter = safeInteger(raw.raw_center, `${path}.raw_center`);
-    const displayCenter = finiteNumber(raw.display_center, `${path}.display_center`);
-    if (rawCenter < rawAxis[0] || rawCenter > rawAxis[1] || !onLattice(rawCenter, rawAxis[3], rawAxis[2])) {
+    const displayCenter = readDisplay(raw.display_center, `${path}.display_center`, displays);
+    domain.display_center = displayCenter;
+    if (rawCenter < rawAxis[0] || rawCenter > rawAxis[1] || !exactDecimalOnLattice(exactDecimalInteger(rawCenter), exactDecimalInteger(rawAxis[3]), exactDecimalInteger(rawAxis[2]))) {
       invalid(`${path}.raw_center`, 'a value in range on its declared lattice');
     }
-    if (displayCenter < displayAxis[0] || displayCenter > displayAxis[1]
-      || !onLattice(displayCenter, displayAxis[3], displayAxis[2])) {
+    if (compareExactDecimals(displayCenter, displayAxis[0]) < 0 || compareExactDecimals(displayCenter, displayAxis[1]) > 0
+      || !exactDecimalOnLattice(displayCenter, displayAxis[3], displayAxis[2])) {
       invalid(`${path}.display_center`, 'a value in range on its declared lattice');
     }
   } else if ('raw_center' in raw || 'display_center' in raw) {
     invalid(path, 'center fields only for centered mapping');
   }
   if (mapping === 'lookup') {
-    domain.lookup = validateLookup(raw.lookup, `${path}.lookup`, rawAxis, displayAxis, restoration);
+    domain.lookup = validateLookup(raw.lookup, `${path}.lookup`, rawAxis, displayAxis, restoration, displays);
   } else if ('lookup' in raw) {
     invalid(`${path}.lookup`, 'only for lookup mapping');
   }

--- a/frontend/src/lib/types/exact-decimal.ts
+++ b/frontend/src/lib/types/exact-decimal.ts
@@ -1,0 +1,71 @@
+declare const exactDecimal: unique symbol;
+
+/** A canonical, lossless fixed-point decimal string. */
+// The number intersection preserves source compatibility for legacy consumers of
+// ControlRange while runtime values are always strings produced below.
+export type ExactDecimal = string & number & { readonly [exactDecimal]: 'ExactDecimal' };
+
+const CANONICAL = /^(?:0|-[1-9][0-9]*|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/;
+
+type Parts = readonly [coefficient: bigint, scale: number];
+
+function parts(value: ExactDecimal): Parts {
+  const text = value as unknown as string;
+  const negative = text.startsWith('-');
+  const unsigned = negative ? text.slice(1) : text;
+  const [integer, fraction = ''] = unsigned.split('.');
+  return [BigInt(`${negative ? '-' : ''}${integer}${fraction}`), fraction.length];
+}
+
+function canonicalize(sign: string, digits: string, scale: number): ExactDecimal {
+  const stripped = digits.replace(/^0+/, '') || '0';
+  if (stripped === '0') return '0' as ExactDecimal;
+  let integer: string;
+  let fraction = '';
+  if (scale === 0) integer = stripped;
+  else if (stripped.length <= scale) {
+    integer = '0';
+    fraction = `${'0'.repeat(scale - stripped.length)}${stripped}`;
+  } else {
+    integer = stripped.slice(0, -scale);
+    fraction = stripped.slice(-scale);
+  }
+  fraction = fraction.replace(/0+$/, '');
+  return `${sign}${integer}${fraction ? `.${fraction}` : ''}` as ExactDecimal;
+}
+
+export function exactDecimalString(value: unknown): ExactDecimal | null {
+  if (typeof value !== 'string' || !CANONICAL.test(value)) return null;
+  return value as ExactDecimal;
+}
+
+/** Converts a finite legacy JavaScript number without using exponential output. */
+export function exactDecimalNumber(value: number): ExactDecimal {
+  const text = String(value);
+  const match = text.match(/^(-?)(\d+)(?:\.(\d+))?(?:e([+-]?\d+))?$/i);
+  if (!match) throw new TypeError('finite number has no decimal representation');
+  const digits = `${match[2]}${match[3] ?? ''}`;
+  const scale = (match[3] ?? '').length - Number(match[4] ?? 0);
+  if (scale <= 0) return canonicalize(match[1] ?? '', `${digits}${'0'.repeat(-scale)}`, 0);
+  return canonicalize(match[1] ?? '', digits, scale);
+}
+
+export function compareExactDecimals(left: ExactDecimal, right: ExactDecimal): number {
+  const [leftCoefficient, leftScale] = parts(left);
+  const [rightCoefficient, rightScale] = parts(right);
+  const scale = Math.max(leftScale, rightScale);
+  const leftValue = leftCoefficient * (10n ** BigInt(scale - leftScale));
+  const rightValue = rightCoefficient * (10n ** BigInt(scale - rightScale));
+  return leftValue === rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+}
+
+export function exactDecimalInteger(value: number): ExactDecimal {
+  return exactDecimalNumber(value);
+}
+
+export function exactDecimalOnLattice(value: ExactDecimal, origin: ExactDecimal, step: ExactDecimal): boolean {
+  const items = [parts(value), parts(origin), parts(step)] as const;
+  const scale = Math.max(...items.map((item) => item[1]));
+  const scaled = items.map(([coefficient, itemScale]) => coefficient * (10n ** BigInt(scale - itemScale)));
+  return (scaled[0] - scaled[1]) % scaled[2] === 0n;
+}

--- a/frontend/src/lib/types/exact-decimal.ts
+++ b/frontend/src/lib/types/exact-decimal.ts
@@ -1,11 +1,9 @@
 declare const exactDecimal: unique symbol;
 
 /** A canonical, lossless fixed-point decimal string. */
-// The number intersection preserves source compatibility for legacy consumers of
-// ControlRange while runtime values are always strings produced below.
-export type ExactDecimal = string & number & { readonly [exactDecimal]: 'ExactDecimal' };
+export type ExactDecimal = string & { readonly [exactDecimal]: 'ExactDecimal' };
 
-const CANONICAL = /^(?:0|-[1-9][0-9]*|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/;
+const CANONICAL = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/;
 
 type Parts = readonly [coefficient: bigint, scale: number];
 
@@ -35,7 +33,7 @@ function canonicalize(sign: string, digits: string, scale: number): ExactDecimal
 }
 
 export function exactDecimalString(value: unknown): ExactDecimal | null {
-  if (typeof value !== 'string' || !CANONICAL.test(value)) return null;
+  if (typeof value !== 'string' || value === '-0' || !CANONICAL.test(value)) return null;
   return value as ExactDecimal;
 }
 


### PR DESCRIPTION
## Summary
- accept and normalize canonical lossless fixed-point display decimals
- preserve valid negative nonzero decimals while rejecting signed zero and other noncanonical payloads
- retain fail-closed BigInt lattice validation and immutable normalized domains
- fence legacy numeric consumers through merged MOR-1724 compatibility checks

Closes MOR-1721

## Verification
- `npx vitest run src/lib/types/__tests__/capabilities.control-domains.test.ts --maxWorkers=2` (51 passed)
- `npm test -- --maxWorkers=2 --no-file-parallelism`
- `npm run check`
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check`
- `npm run build`
- `git diff --check` and privacy scan