### PR TITLE
fix(MOR-1724): fence legacy control ranges from domains

### DIFF
--- a/frontend/src/lib/radio/filter-controls.control-domain-compatibility.test.ts
+++ b/frontend/src/lib/radio/filter-controls.control-domain-compatibility.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { getControlRange, setCapabilities } from '$lib/stores/capabilities.svelte';
+import type { Capabilities, ControlRange } from '$lib/types/capabilities';
+import { controlRangeFromCaps, pbtRangeFromCaps } from './filter-controls';
+
+const LEGACY_PBT: ControlRange = {
+  raw_min: 0, raw_max: 255, raw_center: 128, display_min: -1200, display_max: 1200,
+};
+const LEGACY_NR: ControlRange = { raw_min: 0, raw_max: 255, display_min: 0, display_max: 15 };
+const LEGACY_NB: ControlRange = { raw_min: 0, raw_max: 9, display_min: 1, display_max: 10 };
+
+function caps(controls: Record<string, unknown>): Capabilities {
+  return {
+    model: 'Test Radio', scope: false, audio: false, tx: false, capabilities: [], receivers: 1,
+    vfoScheme: 'ab', freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm'] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    stateContractVersion: 1, providerGeneration: 0,
+    controls: controls as Capabilities['controls'],
+  };
+}
+
+const domainNumbers = {
+  raw_min: 0, raw_max: 255, raw_step: 1, raw_origin: 0,
+  display_min: -0.125, display_max: 15, display_step: 0.125, display_origin: 0,
+  display_unit: 'dB', mapping: 'linear', quantization: 'nearest_ties_down', restoration: 'exact',
+};
+const domainStrings = {
+  ...domainNumbers,
+  display_min: '-0.0000000000000000000000000000000000000001',
+  display_max: '9'.repeat(400),
+  display_step: '0.0000000000000000000000000000000000000001',
+  display_origin: '-0.125',
+};
+
+describe('legacy numeric control-range compatibility fence (MOR-1724)', () => {
+  it('preserves ordinary legacy PBT, NR, and NB ranges', () => {
+    const capabilitySet = caps({ pbt_inner: LEGACY_PBT, nr_level: LEGACY_NR, nb_depth: LEGACY_NB });
+    expect(pbtRangeFromCaps(capabilitySet)).toEqual({ rawCenter: 128, displayMin: -1200, displayMax: 1200 });
+    expect(controlRangeFromCaps('nr_level', capabilitySet)).toEqual({ rawMin: 0, rawMax: 255, displayMin: 0, displayMax: 15 });
+    expect(controlRangeFromCaps('nb_depth', capabilitySet)).toEqual({ rawMin: 0, rawMax: 9, displayMin: 1, displayMax: 10 });
+  });
+
+  it.each([
+    ['legacy-number explicit domain', domainNumbers],
+    ['normalized string exact domain', domainStrings],
+  ])('fails closed for %s without coercing display values', (_name, domain) => {
+    const capabilitySet = caps({ pbt_inner: domain, nr_level: domain, nb_depth: domain });
+    expect(pbtRangeFromCaps(capabilitySet)).toBeUndefined();
+    expect(controlRangeFromCaps('nr_level', capabilitySet)).toBeUndefined();
+    expect(controlRangeFromCaps('nb_depth', capabilitySet)).toBeUndefined();
+  });
+
+  it('exposes only undiscriminated ranges through the store accessor', () => {
+    expect(setCapabilities(caps({ legacy: LEGACY_NR, exact: domainStrings }))).toBe(true);
+    expect(getControlRange('legacy')).toStrictEqual(LEGACY_NR);
+    expect(getControlRange('exact')).toBeNull();
+  });
+});

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -8,7 +8,9 @@
 // PBT raw <-> display conversion
 // Reads range from capabilities if available, falls back to IC-7610 defaults
 import { getControlRange } from '$lib/stores/capabilities.svelte';
-import type { Capabilities, FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
+import type {
+  Capabilities, ControlRange as CapabilityControlRange, FilterModeConfig, FilterSegmentConfig,
+} from '$lib/types/capabilities';
 
 export const FILTER_BIPOLAR_MIN = -1200;
 export const FILTER_BIPOLAR_MAX = 1200;
@@ -20,6 +22,11 @@ export const FILTER_WIDTH_STEP = 50;
 const PBT_DEFAULTS = { rawCenter: 128, displayMin: -1200, displayMax: 1200 } as const;
 
 export type PbtRange = { rawCenter: number; displayMin: number; displayMax: number };
+
+/** Legacy numeric consumers must not inspect discriminated exact domains. */
+function isLegacyControlRange(control: unknown): control is CapabilityControlRange {
+  return control !== null && typeof control === 'object' && !('mapping' in control);
+}
 
 function pbtRange(): PbtRange {
   try {
@@ -61,7 +68,7 @@ function pbtRange(): PbtRange {
  */
 export function pbtRangeFromCaps(caps: Capabilities | null | undefined): PbtRange | undefined {
   const ctrl = caps?.controls?.pbt_inner;
-  if (!ctrl) return undefined;
+  if (!isLegacyControlRange(ctrl)) return undefined;
   const { raw_center: rawCenter, display_min: displayMin, display_max: displayMax } = ctrl;
   if (
     typeof rawCenter !== 'number' || !Number.isFinite(rawCenter) || rawCenter === 0
@@ -166,8 +173,8 @@ export function controlRangeFromCaps(
   key: string, caps: Capabilities | null | undefined,
 ): ControlDisplayRange | undefined {
   const ctrl = caps?.controls?.[key];
+  if (!isLegacyControlRange(ctrl)) return undefined;
   if (
-    ctrl &&
     ctrl.display_min !== undefined &&
     ctrl.display_max !== undefined &&
     ctrl.display_max > ctrl.display_min

--- a/frontend/src/lib/stores/capabilities.svelte.ts
+++ b/frontend/src/lib/stores/capabilities.svelte.ts
@@ -193,7 +193,8 @@ export function vfoLabel(slot: 'A' | 'B'): string {
 }
 
 export function getControlRange(name: string): ControlRange | null {
-  return capabilities?.controls?.[name] ?? null;
+  const control = capabilities?.controls?.[name];
+  return control && !('mapping' in control) ? control : null;
 }
 
 export function getMeterCalibration(


### PR DESCRIPTION
## Summary

- Make the legacy control-range accessor reject every discriminated domain.
- Make PBT and generic numeric range helpers fail closed before inspecting domain display values.
- Cover numeric and future string exact-domain payloads while preserving legacy PBT, NR, and NB behavior.

## Validation

- Focused MOR-1724 compatibility tests, 4 passed.
- Full frontend suite with two workers, passed.
- Frontend check, lint, boundary lint, i18n check, and production build, passed.

Linear: MOR-1724