### PR TITLE
test(MOR-1718): lock control-domain golden payload

### DIFF
--- a/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
+++ b/frontend/src/lib/types/__tests__/capabilities.control-domains.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ExactDecimal } from '../exact-decimal';
 import type { ControlDomain, LookupControlDomain, ScalarControlDomain } from '../capabilities';
 import { validateCapabilities } from '../capabilities';
+import goldenControls from '../../../../../tests/fixtures/control-domain-controls.json';
 
 function controlDomainTypeContract(linear: ScalarControlDomain, lookup: LookupControlDomain): void {
   // @ts-expect-error normalized bounds are immutable
@@ -64,6 +65,26 @@ function parse(control: Record<string, unknown>): ControlDomain {
   return result.controls?.test as ControlDomain;
 }
 describe('normalized control capability domains', () => {
+  it('consumes the loader-generated golden controls fixture without numeric coercion', () => {
+    const payload = { ...baseCapabilities, controls: goldenControls };
+    const parsed = validateCapabilities(payload);
+    expect(parsed.controls).toEqual(goldenControls);
+    expect(parsed.controls).not.toBe(goldenControls);
+    expect(Object.isFrozen(parsed.controls)).toBe(true);
+    for (const control of Object.values(parsed.controls ?? {})) {
+      expect(Object.isFrozen(control)).toBe(true);
+      expect(typeof (control as ControlDomain).display_min).toBe('string');
+      expect(typeof (control as ControlDomain).display_max).toBe('string');
+      expect(typeof (control as ControlDomain).display_step).toBe('string');
+      expect(typeof (control as ControlDomain).display_origin).toBe('string');
+    }
+    const linear = parsed.controls?.linear as ScalarControlDomain;
+    expect(linear.display_max).toBe(goldenControls.linear.display_max);
+    expect(linear.display_max).toHaveLength(400);
+    const lookup = parsed.controls?.lookup as LookupControlDomain;
+    expect(Object.isFrozen(lookup.lookup)).toBe(true);
+    expect(lookup.lookup.every(Object.isFrozen)).toBe(true);
+  });
   it('leaves legacy capability payloads and legacy controls unchanged', () => {
     expect(validateCapabilities(baseCapabilities)).toBe(baseCapabilities);
     const legacy = { range_min: 0, range_max: 10, style: 'stepped' };

--- a/tests/fixtures/control-domain-controls.json
+++ b/tests/fixtures/control-domain-controls.json
@@ -1,0 +1,66 @@
+{
+  "identity": {
+    "mapping": "identity",
+    "raw_min": -2,
+    "raw_max": 2,
+    "raw_step": 2,
+    "raw_origin": -2,
+    "display_min": "-2",
+    "display_max": "2",
+    "display_step": "2",
+    "display_origin": "-2",
+    "display_unit": "steps",
+    "quantization": "floor",
+    "restoration": "exact",
+    "style": "stepped"
+  },
+  "linear": {
+    "mapping": "linear",
+    "raw_min": 0,
+    "raw_max": 2,
+    "raw_step": 1,
+    "raw_origin": 0,
+    "display_min": "0",
+    "display_max": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "display_step": "500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "display_origin": "0",
+    "display_unit": "huge",
+    "quantization": "nearest_ties_up",
+    "restoration": "exact"
+  },
+  "centered": {
+    "mapping": "centered",
+    "raw_min": -2,
+    "raw_max": 2,
+    "raw_step": 2,
+    "raw_origin": -2,
+    "display_min": "-0.00000000000000000001",
+    "display_max": "0.00000000000000000001",
+    "display_step": "0.00000000000000000001",
+    "display_origin": "-0.00000000000000000001",
+    "display_unit": "tiny",
+    "quantization": "nearest_ties_down",
+    "restoration": "exact",
+    "raw_center": 0,
+    "display_center": "0"
+  },
+  "lookup": {
+    "mapping": "lookup",
+    "raw_min": 0,
+    "raw_max": 4,
+    "raw_step": 2,
+    "raw_origin": 0,
+    "display_min": "-1",
+    "display_max": "1",
+    "display_step": "1",
+    "display_origin": "-1",
+    "display_unit": "label",
+    "quantization": "reject",
+    "restoration": "exact",
+    "lookup": [
+      { "raw": 0, "display": "-1" },
+      { "raw": 2, "display": "0" },
+      { "raw": 4, "display": "1" }
+    ]
+  }
+}

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,6 +16,7 @@ from rigplane.web.api_contract import (
     WEB_API_CONTRACT_VERSION,
 )
 from rigplane.web.server import WebConfig, WebServer
+from rigplane.rig_loader import load_rig
 
 
 class _Writer:
@@ -32,6 +35,157 @@ def _json_response(writer: _Writer) -> tuple[int, dict]:
     status = int(text.split(" ", 2)[1])
     body_start = text.index("\r\n\r\n") + 4
     return status, json.loads(text[body_start:] or "{}")
+
+
+def _golden_controls() -> dict[str, object]:
+    fixture = Path(__file__).parent / "fixtures" / "control-domain-controls.json"
+    return json.loads(fixture.read_text(encoding="utf-8"))
+
+
+def _golden_profile(tmp_path: Path):
+    huge = "1" + "0" * 399
+    half_huge = "5" + "0" * 398
+    toml = f"""\
+[radio]
+id = "golden_controls"
+model = "Golden Controls"
+receiver_count = 1
+has_lan = false
+has_wifi = false
+
+[capabilities]
+features = ["tx"]
+
+[modes]
+list = ["USB"]
+
+[filters]
+list = ["FIL1"]
+
+[vfo]
+scheme = "ab"
+
+[commands]
+
+[commands.overrides]
+
+[controls.identity]
+mapping = "identity"
+raw_min = -2
+raw_max = 2
+raw_step = 2
+raw_origin = -2
+display_min = -2
+display_max = 2
+display_step = 2
+display_origin = -2
+display_unit = "steps"
+quantization = "floor"
+restoration = "exact"
+style = "stepped"
+
+[controls.linear]
+mapping = "linear"
+raw_min = 0
+raw_max = 2
+raw_step = 1
+raw_origin = 0
+display_min = 0
+display_max = {huge}
+display_step = {half_huge}
+display_origin = 0
+display_unit = "huge"
+quantization = "nearest_ties_up"
+restoration = "exact"
+
+[controls.centered]
+mapping = "centered"
+raw_min = -2
+raw_max = 2
+raw_step = 2
+raw_origin = -2
+display_min = -0.00000000000000000001
+display_max = 0.00000000000000000001
+display_step = 0.00000000000000000001
+display_origin = -0.00000000000000000001
+display_unit = "tiny"
+quantization = "nearest_ties_down"
+restoration = "exact"
+raw_center = 0
+display_center = 0
+
+[controls.lookup]
+mapping = "lookup"
+raw_min = 0
+raw_max = 4
+raw_step = 2
+raw_origin = 0
+display_min = -1
+display_max = 1
+display_step = 1
+display_origin = -1
+display_unit = "label"
+quantization = "reject"
+restoration = "exact"
+lookup = [{{ raw = 0, display = -1 }}, {{ raw = 2, display = 0 }}, {{ raw = 4, display = 1 }}]
+"""
+    path = tmp_path / "golden-controls.toml"
+    path.write_text(toml, encoding="utf-8")
+    return load_rig(path).to_profile()
+
+
+@pytest.mark.asyncio
+async def test_control_domains_round_trip_through_both_capability_endpoints(
+    tmp_path: Path,
+) -> None:
+    """The shared JSON is derived only by loading TOML into a RadioProfile."""
+    profile = _golden_profile(tmp_path)
+    assert profile.controls == _golden_controls()
+    radio = SimpleNamespace(
+        model=profile.model,
+        profile=profile,
+        capabilities=set(profile.capabilities),
+        connected=False,
+        control_connected=False,
+        radio_ready=False,
+    )
+    server = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    headers = {"authorization": "Bearer token"}
+    for path in ("/api/v1/info", "/api/v1/capabilities"):
+        writer = _Writer()
+        await server._handle_http(writer, "GET", path, headers=headers)  # noqa: SLF001
+        status, payload = _json_response(writer)
+        assert status == 200
+        controls = (
+            payload["capabilities"]["controls"]
+            if path == "/api/v1/info"
+            else payload["controls"]
+        )
+        assert controls == _golden_controls()
+
+
+@pytest.mark.asyncio
+async def test_capability_endpoints_omit_controls_for_legacy_profiles(
+    tmp_path: Path,
+) -> None:
+    profile = replace(_golden_profile(tmp_path), controls=None)
+    radio = SimpleNamespace(
+        model=profile.model,
+        profile=profile,
+        capabilities=set(profile.capabilities),
+        connected=False,
+        control_connected=False,
+        radio_ready=False,
+    )
+    server = WebServer(radio, WebConfig(host="127.0.0.1", port=0))
+    for path in ("/api/v1/info", "/api/v1/capabilities"):
+        writer = _Writer()
+        await server._handle_http(writer, "GET", path)  # noqa: SLF001
+        _status, payload = _json_response(writer)
+        capability_payload = (
+            payload["capabilities"] if path == "/api/v1/info" else payload
+        )
+        assert "controls" not in capability_payload
 
 
 def test_pro_web_api_contract_lists_stable_surface() -> None:


### PR DESCRIPTION
## Summary
- add a loader-derived shared golden payload for identity, linear, centered, and lookup control domains
- pin both capability endpoints to that payload, with legacy absence preserved
- verify frontend normalization keeps canonical display values as deeply frozen strings

Linear: [MOR-1718](https://linear.app/morozsm/issue/MOR-1718/lock-loader-to-frontend-control-domain-capability-json-round-trip)

## Verification
- `uv run pytest tests/test_web_api_contract.py -q --tb=short`
- `cd frontend && npm test -- --run src/lib/types/__tests__/capabilities.control-domains.test.ts`
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
- `cd frontend && npm test && npm run check && npm run lint && npm run lint:boundaries && npm run i18n:check && npm run build`
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run lint-imports`

`uv run mypy src/` remains blocked by 13 pre-existing errors in four unrelated source files; no source files are changed by this PR.