### PR TITLE
feat(MOR-1722): add exact control-domain math

### DIFF
--- a/frontend/src/lib/radio/__tests__/control-domain.test.ts
+++ b/frontend/src/lib/radio/__tests__/control-domain.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { ControlDomain } from '../../types/capabilities';
+import { decodeControlDomain, encodeControlDomain, quantizeControlDomain } from '../control-domain';
+
+const linear: ControlDomain = Object.freeze({
+  raw_min: -4, raw_max: 4, raw_step: 2, raw_origin: 0,
+  display_min: '-1' as never, display_max: '1' as never, display_step: '0.5' as never, display_origin: '0' as never,
+  display_unit: 'dB', mapping: 'linear', quantization: 'nearest_ties_down', restoration: 'exact',
+});
+
+describe('control-domain exact math', () => {
+  it('maps linear lattice points with negative values and nonzero raw origins', () => {
+    expect(decodeControlDomain(linear, -4)).toBe('-1');
+    expect(decodeControlDomain(linear, 0)).toBe('0');
+    expect(encodeControlDomain(linear, '0.5' as never)).toBe(2);
+    expect(encodeControlDomain(linear, '-0.75' as never)).toBe(-4);
+  });
+  it.each([
+    ['nearest_ties_down', '-0.75', '-1'], ['nearest_ties_up', '-0.75', '-0.5'],
+    ['floor', '-0.75', '-1'], ['ceil', '-0.75', '-0.5'], ['reject', '-0.75', null],
+  ] as const)('uses %s at negative half-step boundaries', (quantization, input, expected) => {
+    expect(quantizeControlDomain({ ...linear, quantization }, input as never)).toBe(expected);
+  });
+  it('keeps tiny steps and huge coefficients exact', () => {
+    const huge = `1${'0'.repeat(300)}`;
+    const domain = { ...linear, raw_min: 0, raw_max: 2, raw_step: 1, raw_origin: 0,
+      display_min: huge as never, display_origin: huge as never, display_step: '0.00000000000000000001' as never,
+      display_max: `${huge}.00000000000000000002` as never };
+    expect(decodeControlDomain(domain, 1)).toBe(`${huge}.00000000000000000001`);
+    expect(encodeControlDomain(domain, `${huge}.00000000000000000002` as never)).toBe(2);
+  });
+  it('uses centered anchors independently of nonzero lattice origins', () => {
+    const domain = { ...linear, mapping: 'centered' as const, raw_center: 0, display_center: '0' as never };
+    expect(decodeControlDomain(domain, -2)).toBe('-0.5');
+    expect(encodeControlDomain(domain, '0.5' as never)).toBe(2);
+  });
+  it('inverts descending lookup values and rejects ambiguous entries', () => {
+    const domain = { ...linear, mapping: 'lookup' as const, lookup: [
+      { raw: -4, display: '1' as never }, { raw: -2, display: '0.5' as never }, { raw: 0, display: '0' as never },
+      { raw: 2, display: '-0.5' as never }, { raw: 4, display: '-1' as never },
+    ] };
+    expect(decodeControlDomain(domain, 2)).toBe('-0.5');
+    expect(encodeControlDomain(domain, '-0.5' as never)).toBe(2);
+    expect(encodeControlDomain({ ...domain, lookup: [...domain.lookup, { raw: 4, display: '-0.5' as never }] }, '-0.5' as never)).toBeNull();
+  });
+  it('never claims reversible encoding for unavailable restoration', () => {
+    expect(encodeControlDomain({ ...linear, restoration: 'unavailable' }, '0' as never)).toBeNull();
+    expect(decodeControlDomain({ ...linear, restoration: 'unavailable' }, 0)).toBe('0');
+  });
+  it('fails closed for off-lattice raw, malformed decimals, bad mapping and overflow', () => {
+    expect(decodeControlDomain(linear, -3)).toBeNull();
+    expect(quantizeControlDomain(linear, '01' as never)).toBeNull();
+    expect(decodeControlDomain({ ...linear, mapping: 'future' as never }, 0)).toBeNull();
+    expect(encodeControlDomain({ ...linear, raw_max: Number.MAX_SAFE_INTEGER + 1 }, '0' as never)).toBeNull();
+  });
+});

--- a/frontend/src/lib/radio/__tests__/control-domain.test.ts
+++ b/frontend/src/lib/radio/__tests__/control-domain.test.ts
@@ -27,6 +27,12 @@ describe('control-domain exact math', () => {
   ] as const)('uses %s at negative half-step boundaries', (quantization, input, expected) => {
     expect(quantizeControlDomain({ ...linear, quantization }, input as never)).toBe(expected);
   });
+  it.each(['nearest_ties_down', 'nearest_ties_up', 'floor', 'ceil', 'reject'] as const)('keeps supported quantization %s valid', (quantization) => {
+    const domain = { ...linear, quantization };
+    expect(decodeControlDomain(domain, 0)).toBe('0');
+    expect(quantizeControlDomain(domain, '0' as never)).toBe('0');
+    expect(encodeControlDomain(domain, '0' as never)).toBe(0);
+  });
   it('keeps tiny steps and huge coefficients exact', () => {
     const huge = `1${'0'.repeat(300)}`;
     const domain = { ...linear, raw_min: 0, raw_max: 2, raw_step: 1, raw_origin: 0,
@@ -76,6 +82,12 @@ describe('control-domain exact math', () => {
     const domain = { ...linear, mapping: 'centered' as const, raw_center: 0, display_center: '0.5' as never };
     expect(decodeControlDomain(domain, -4)).toBeNull();
     expect(decodeControlDomain(domain, 4)).toBeNull();
+    expect(quantizeControlDomain(domain, '0' as never)).toBeNull();
+    expect(encodeControlDomain(domain, '0' as never)).toBeNull();
+  });
+  it.each([undefined, null, 0, {}, [], '', 'nearest'])('fails closed for invalid quantization %p', (quantization) => {
+    const domain = { ...linear, quantization } as ControlDomain;
+    expect(decodeControlDomain(domain, 0)).toBeNull();
     expect(quantizeControlDomain(domain, '0' as never)).toBeNull();
     expect(encodeControlDomain(domain, '0' as never)).toBeNull();
   });

--- a/frontend/src/lib/radio/__tests__/control-domain.test.ts
+++ b/frontend/src/lib/radio/__tests__/control-domain.test.ts
@@ -9,6 +9,12 @@ const linear: ControlDomain = Object.freeze({
 });
 
 describe('control-domain exact math', () => {
+  it('round-trips a valid identity domain', () => {
+    const domain = { ...linear, raw_min: -1, raw_max: 1, raw_step: 1, raw_origin: 0,
+      display_min: '-1' as never, display_max: '1' as never, display_step: '1' as never, display_origin: '0' as never, mapping: 'identity' as const };
+    expect(decodeControlDomain(domain, -1)).toBe('-1');
+    expect(encodeControlDomain(domain, '1' as never)).toBe(1);
+  });
   it('maps linear lattice points with negative values and nonzero raw origins', () => {
     expect(decodeControlDomain(linear, -4)).toBe('-1');
     expect(decodeControlDomain(linear, 0)).toBe('0');
@@ -29,10 +35,18 @@ describe('control-domain exact math', () => {
     expect(decodeControlDomain(domain, 1)).toBe(`${huge}.00000000000000000001`);
     expect(encodeControlDomain(domain, `${huge}.00000000000000000002` as never)).toBe(2);
   });
+  it('canonicalizes mixed-scale arithmetic without signed or fractional zeroes', () => {
+    const domain = { ...linear, raw_min: -2, raw_max: 0, raw_step: 1, raw_origin: 0,
+      display_min: '0' as never, display_max: '0.1' as never, display_step: '0.05' as never, display_origin: '0.1' as never };
+    expect(decodeControlDomain(domain, 0)).toBe('0.1');
+    expect(quantizeControlDomain(domain, '0.1' as never)).toBe('0.1');
+  });
   it('uses centered anchors independently of nonzero lattice origins', () => {
     const domain = { ...linear, mapping: 'centered' as const, raw_center: 0, display_center: '0' as never };
-    expect(decodeControlDomain(domain, -2)).toBe('-0.5');
-    expect(encodeControlDomain(domain, '0.5' as never)).toBe(2);
+    for (const [raw, display] of [[-4, '-1'], [-2, '-0.5'], [0, '0'], [2, '0.5'], [4, '1']] as const) {
+      expect(decodeControlDomain(domain, raw)).toBe(display);
+      expect(encodeControlDomain(domain, display as never)).toBe(raw);
+    }
   });
   it('inverts descending lookup values and rejects ambiguous entries', () => {
     const domain = { ...linear, mapping: 'lookup' as const, lookup: [
@@ -46,6 +60,24 @@ describe('control-domain exact math', () => {
   it('never claims reversible encoding for unavailable restoration', () => {
     expect(encodeControlDomain({ ...linear, restoration: 'unavailable' }, '0' as never)).toBeNull();
     expect(decodeControlDomain({ ...linear, restoration: 'unavailable' }, 0)).toBe('0');
+  });
+  it('rejects values outside the axis before quantization or encoding', () => {
+    expect(quantizeControlDomain(linear, '1.1' as never)).toBeNull();
+    expect(quantizeControlDomain(linear, '-1.1' as never)).toBeNull();
+    expect(encodeControlDomain(linear, '1.1' as never)).toBeNull();
+  });
+  it.each([undefined, null, {}, [{ raw: 0, display: '0', extra: true }], [{ raw: -4, display: '-1' }, { raw: -4, display: '0' }]])('fails closed for malformed lookup %p', (lookup) => {
+    const domain = { ...linear, mapping: 'lookup' as never, lookup } as ControlDomain;
+    expect(decodeControlDomain(domain, 0)).toBeNull();
+    expect(quantizeControlDomain(domain, '0' as never)).toBeNull();
+    expect(encodeControlDomain(domain, '0' as never)).toBeNull();
+  });
+  it('rejects a centered domain whose center offsets do not align', () => {
+    const domain = { ...linear, mapping: 'centered' as const, raw_center: 0, display_center: '0.5' as never };
+    expect(decodeControlDomain(domain, -4)).toBeNull();
+    expect(decodeControlDomain(domain, 4)).toBeNull();
+    expect(quantizeControlDomain(domain, '0' as never)).toBeNull();
+    expect(encodeControlDomain(domain, '0' as never)).toBeNull();
   });
   it('fails closed for off-lattice raw, malformed decimals, bad mapping and overflow', () => {
     expect(decodeControlDomain(linear, -3)).toBeNull();

--- a/frontend/src/lib/radio/control-domain.ts
+++ b/frontend/src/lib/radio/control-domain.ts
@@ -19,8 +19,8 @@ function text([coefficient, scale]: Decimal): ExactDecimal {
   const digits = (coefficient < 0n ? -coefficient : coefficient).toString();
   if (scale === 0) return `${negative}${digits}` as ExactDecimal;
   const padded = digits.padStart(scale + 1, '0');
-  const result = `${negative}${padded.slice(0, -scale)}.${padded.slice(-scale)}`.replace(/\.0+$/, '');
-  return result as ExactDecimal;
+  const fraction = padded.slice(-scale).replace(/0+$/, '');
+  return `${negative}${padded.slice(0, -scale)}${fraction ? `.${fraction}` : ''}` as ExactDecimal;
 }
 
 function align(values: readonly Decimal[]): bigint[] {
@@ -76,6 +76,41 @@ function inAxis(value: Decimal, values: readonly [Decimal, Decimal, Decimal, Dec
   return compare(value, values[0]) >= 0 && compare(value, values[1]) <= 0 && lattice(value, values[3], values[2]) !== null;
 }
 
+function inRange(value: Decimal, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  return compare(value, values[0]) >= 0 && compare(value, values[1]) <= 0;
+}
+
+type LookupPoint = Readonly<{ raw: number; display: ExactDecimal }>;
+
+function lookup(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): readonly LookupPoint[] | null {
+  const candidate = (domain as unknown as { lookup?: unknown }).lookup;
+  if (!Array.isArray(candidate) || candidate.length === 0) return null;
+  const points: LookupPoint[] = [];
+  let rawDirection = 0;
+  let displayDirection = 0;
+  for (const item of candidate) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return null;
+    const record = item as Record<string, unknown>;
+    if (Object.keys(record).length !== 2 || !('raw' in record) || !('display' in record)
+      || typeof record.raw !== 'number' || !Number.isSafeInteger(record.raw) || typeof record.display !== 'string') return null;
+    const raw = record.raw;
+    const displayText = record.display;
+    const display = decimal(displayText);
+    if (!display || rawIndex(domain, raw) === null || !inAxis(display, values)) return null;
+    const previous = points.at(-1);
+    if (previous) {
+      const nextRawDirection = raw > previous.raw ? 1 : raw < previous.raw ? -1 : 0;
+      const nextDisplayDirection = compare(display, decimal(previous.display)!);
+      if (nextRawDirection === 0 || nextDisplayDirection === 0 || (rawDirection && rawDirection !== nextRawDirection)
+        || (displayDirection && displayDirection !== nextDisplayDirection)) return null;
+      rawDirection = nextRawDirection;
+      displayDirection = nextDisplayDirection;
+    }
+    points.push({ raw, display: displayText as ExactDecimal });
+  }
+  return points;
+}
+
 function scalarIndex(domain: ControlDomain): readonly [bigint, bigint] | null {
   const rawMin = rawIndex(domain, domain.raw_min);
   const rawOrigin = rawIndex(domain, domain.raw_origin);
@@ -93,44 +128,60 @@ function sameCardinality(domain: ControlDomain, values: readonly [Decimal, Decim
 }
 
 function isIdentity(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  if (rawIndex(domain, domain.raw_min) === null || rawIndex(domain, domain.raw_max) === null) return false;
   return [domain.raw_min, domain.raw_max, domain.raw_step, domain.raw_origin]
     .every((raw, index) => compare([BigInt(raw), 0], values[index]!) === 0);
 }
 
-function domainIsExact(domain: ControlDomain): boolean {
+function centeredAligned(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  if (domain.mapping !== 'centered') return false;
+  const rawMin = rawIndex(domain, domain.raw_min);
+  const rawCenter = rawIndex(domain, domain.raw_center);
+  const displayCenter = decimal(domain.display_center);
+  const displayOffset = displayCenter ? lattice(displayCenter, values[0], values[2]) : null;
+  return rawMin !== null && rawCenter !== null && displayCenter !== null && inAxis(displayCenter, values)
+    && displayOffset !== null && rawCenter - rawMin === displayOffset && sameCardinality(domain, values);
+}
+
+function validDomain(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  if (domain.mapping === 'identity') return isIdentity(domain, values);
+  if (domain.mapping === 'linear') {
+    const indices = scalarIndex(domain);
+    const originIndex = lattice(values[3], values[0], values[2]);
+    return !!indices && originIndex !== null && indices[1] - indices[0] === originIndex && sameCardinality(domain, values);
+  }
+  if (domain.mapping === 'centered') return centeredAligned(domain, values);
+  return domain.mapping === 'lookup' && lookup(domain, values) !== null;
+}
+
+function domainIsExact(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
   if (domain.restoration !== 'exact') return false;
   if (domain.mapping !== 'lookup') return true;
   const min = rawIndex(domain, domain.raw_min);
   const max = rawIndex(domain, domain.raw_max);
-  if (min === null || max === null || BigInt(domain.lookup.length) !== max - min + 1n) return false;
-  const raws = new Set<number>();
-  const displays = new Set<string>();
-  return domain.lookup.every((point) => Number.isSafeInteger(point.raw) && rawIndex(domain, point.raw) !== null
-    && decimal(point.display) !== null && !raws.has(point.raw) && !displays.has(point.display)
-    && (raws.add(point.raw), displays.add(point.display), true));
+  const points = lookup(domain, values);
+  return min !== null && max !== null && points !== null && BigInt(points.length) === max - min + 1n;
 }
 
 /** Returns a canonical display value, or null when the domain/input is unusable. */
 export function decodeControlDomain(domain: ControlDomain, raw: number): ExactDecimal | null {
   const values = axis(domain);
   const index = rawIndex(domain, raw);
-  if (!values || index === null) return null;
+  if (!values || index === null || !validDomain(domain, values)) return null;
   if (domain.mapping === 'identity') return isIdentity(domain, values) ? text([BigInt(raw), 0]) : null;
   if (domain.mapping === 'lookup') {
-    const matches = domain.lookup.filter((point) => point.raw === raw && decimal(point.display) && inAxis(decimal(point.display)!, values));
-    return matches.length === 1 ? matches[0]!.display : null;
+    const matches = lookup(domain, values);
+    if (!matches) return null;
+    const match = matches.find((point) => point.raw === raw);
+    return match?.display ?? null;
   }
   if (domain.mapping === 'linear') {
-    const indices = scalarIndex(domain);
-    const originIndex = lattice(values[3], values[0], values[2]);
-    if (!indices || originIndex === null || indices[1] - indices[0] !== originIndex || !sameCardinality(domain, values)) return null;
     const result = add(values[3], index, values[2]);
     return inAxis(result, values) ? text(result) : null;
   }
   if (domain.mapping === 'centered') {
-    const center = rawIndex(domain, domain.raw_center);
-    const displayCenter = decimal(domain.display_center);
-    if (center === null || !displayCenter || !inAxis(displayCenter, values) || !sameCardinality(domain, values)) return null;
+    const center = rawIndex(domain, domain.raw_center)!;
+    const displayCenter = decimal(domain.display_center)!;
     const result = add(displayCenter, index - center, values[2]);
     return inAxis(result, values) ? text(result) : null;
   }
@@ -141,7 +192,7 @@ export function decodeControlDomain(domain: ControlDomain, raw: number): ExactDe
 export function quantizeControlDomain(domain: ControlDomain, display: ExactDecimal): ExactDecimal | null {
   const values = axis(domain);
   const value = decimal(display);
-  if (!values || !value) return null;
+  if (!values || !value || !inRange(value, values) || !validDomain(domain, values)) return null;
   const [item, origin, step] = align([value, values[3], values[2]]);
   const difference = item - origin;
   const quotient = floorDivide(difference, step);
@@ -161,10 +212,10 @@ export function quantizeControlDomain(domain: ControlDomain, display: ExactDecim
 
 /** Inverts an exactly restorable domain; unavailable restoration deliberately returns null. */
 export function encodeControlDomain(domain: ControlDomain, display: ExactDecimal): number | null {
-  if (!domainIsExact(domain)) return null;
-  const quantized = quantizeControlDomain(domain, display);
   const values = axis(domain);
-  if (!quantized || !values) return null;
+  if (!values || !validDomain(domain, values) || !domainIsExact(domain, values)) return null;
+  const quantized = quantizeControlDomain(domain, display);
+  if (!quantized) return null;
   if (domain.mapping === 'identity') {
     if (!isIdentity(domain, values)) return null;
     const value = decimal(quantized);
@@ -173,21 +224,21 @@ export function encodeControlDomain(domain: ControlDomain, display: ExactDecimal
     return rawIndex(domain, raw) === null ? null : raw;
   }
   if (domain.mapping === 'lookup') {
-    const matches = domain.lookup.filter((point) => point.display === quantized);
+    const points = lookup(domain, values);
+    if (!points) return null;
+    const matches = points.filter((point) => point.display === quantized);
     return matches.length === 1 ? matches[0]!.raw : null;
   }
   const target = decimal(quantized)!;
   let raw: bigint;
   if (domain.mapping === 'linear') {
-    const indices = scalarIndex(domain);
-    const originIndex = lattice(values[3], values[0], values[2]);
     const displayIndex = lattice(target, values[3], values[2]);
-    if (!indices || originIndex === null || displayIndex === null || indices[1] - indices[0] !== originIndex || !sameCardinality(domain, values)) return null;
+    if (displayIndex === null) return null;
     raw = BigInt(domain.raw_origin) + displayIndex * BigInt(domain.raw_step);
   } else if (domain.mapping === 'centered') {
     const center = rawIndex(domain, domain.raw_center);
     const displayCenter = decimal(domain.display_center);
-    if (center === null || !displayCenter || !sameCardinality(domain, values)) return null;
+    if (center === null || !displayCenter) return null;
     const offset = lattice(target, displayCenter, values[2]);
     if (offset === null) return null;
     raw = BigInt(domain.raw_center) + offset * BigInt(domain.raw_step);

--- a/frontend/src/lib/radio/control-domain.ts
+++ b/frontend/src/lib/radio/control-domain.ts
@@ -4,6 +4,7 @@ import type { ControlDomain, ControlQuantization } from '../types/capabilities';
 type Decimal = readonly [coefficient: bigint, scale: number];
 
 const DECIMAL = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/;
+const QUANTIZATIONS: readonly ControlQuantization[] = ['nearest_ties_down', 'nearest_ties_up', 'floor', 'ceil', 'reject'];
 
 function decimal(value: unknown): Decimal | null {
   if (typeof value !== 'string' || value === '-0' || !DECIMAL.test(value)) return null;
@@ -144,6 +145,8 @@ function centeredAligned(domain: ControlDomain, values: readonly [Decimal, Decim
 }
 
 function validDomain(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  const quantization = (domain as unknown as { quantization?: unknown }).quantization;
+  if (typeof quantization !== 'string' || !QUANTIZATIONS.includes(quantization as ControlQuantization)) return false;
   if (domain.mapping === 'identity') return isIdentity(domain, values);
   if (domain.mapping === 'linear') {
     const indices = scalarIndex(domain);

--- a/frontend/src/lib/radio/control-domain.ts
+++ b/frontend/src/lib/radio/control-domain.ts
@@ -1,0 +1,197 @@
+import type { ExactDecimal } from '../types/exact-decimal';
+import type { ControlDomain, ControlQuantization } from '../types/capabilities';
+
+type Decimal = readonly [coefficient: bigint, scale: number];
+
+const DECIMAL = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?$/;
+
+function decimal(value: unknown): Decimal | null {
+  if (typeof value !== 'string' || value === '-0' || !DECIMAL.test(value)) return null;
+  const negative = value.startsWith('-');
+  const unsigned = negative ? value.slice(1) : value;
+  const [integer, fraction = ''] = unsigned.split('.');
+  return [BigInt(`${negative ? '-' : ''}${integer}${fraction}`), fraction.length];
+}
+
+function text([coefficient, scale]: Decimal): ExactDecimal {
+  if (coefficient === 0n) return '0' as ExactDecimal;
+  const negative = coefficient < 0n ? '-' : '';
+  const digits = (coefficient < 0n ? -coefficient : coefficient).toString();
+  if (scale === 0) return `${negative}${digits}` as ExactDecimal;
+  const padded = digits.padStart(scale + 1, '0');
+  const result = `${negative}${padded.slice(0, -scale)}.${padded.slice(-scale)}`.replace(/\.0+$/, '');
+  return result as ExactDecimal;
+}
+
+function align(values: readonly Decimal[]): bigint[] {
+  const scale = Math.max(...values.map((value) => value[1]));
+  return values.map(([coefficient, valueScale]) => coefficient * 10n ** BigInt(scale - valueScale));
+}
+
+function compare(left: Decimal, right: Decimal): number {
+  const [a, b] = align([left, right]);
+  return a === b ? 0 : a < b ? -1 : 1;
+}
+
+function add(origin: Decimal, steps: bigint, step: Decimal): Decimal {
+  const [base, increment] = align([origin, step]);
+  return [base + steps * increment, Math.max(origin[1], step[1])];
+}
+
+function lattice(value: Decimal, origin: Decimal, step: Decimal): bigint | null {
+  if (compare(step, [0n, 0]) <= 0) return null;
+  const [item, base, unit] = align([value, origin, step]);
+  const difference = item - base;
+  return difference % unit === 0n ? difference / unit : null;
+}
+
+function floorDivide(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  return value < 0n && value % divisor !== 0n ? quotient - 1n : quotient;
+}
+
+function rawIndex(domain: ControlDomain, raw: number): bigint | null {
+  if (!Number.isSafeInteger(raw) || !Number.isSafeInteger(domain.raw_min) || !Number.isSafeInteger(domain.raw_max)
+    || !Number.isSafeInteger(domain.raw_step) || !Number.isSafeInteger(domain.raw_origin)
+    || domain.raw_min >= domain.raw_max || domain.raw_step <= 0 || domain.raw_origin < domain.raw_min
+    || domain.raw_origin > domain.raw_max || raw < domain.raw_min || raw > domain.raw_max) return null;
+  const step = BigInt(domain.raw_step);
+  if ((BigInt(domain.raw_min) - BigInt(domain.raw_origin)) % step !== 0n
+    || (BigInt(domain.raw_max) - BigInt(domain.raw_origin)) % step !== 0n) return null;
+  const index = (BigInt(raw) - BigInt(domain.raw_origin)) / step;
+  return (BigInt(raw) - BigInt(domain.raw_origin)) % step === 0n ? index : null;
+}
+
+function axis(domain: ControlDomain): readonly [Decimal, Decimal, Decimal, Decimal] | null {
+  const values = [domain.display_min, domain.display_max, domain.display_step, domain.display_origin].map(decimal);
+  if (values.some((value) => !value)) return null;
+  const result = values as Decimal[];
+  if (compare(result[0]!, result[1]!) >= 0 || compare(result[2]!, [0n, 0]) <= 0) return null;
+  if (compare(result[3]!, result[0]!) < 0 || compare(result[3]!, result[1]!) > 0) return null;
+  if (lattice(result[0]!, result[3]!, result[2]!) === null || lattice(result[1]!, result[3]!, result[2]!) === null) return null;
+  return result as unknown as readonly [Decimal, Decimal, Decimal, Decimal];
+}
+
+function inAxis(value: Decimal, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  return compare(value, values[0]) >= 0 && compare(value, values[1]) <= 0 && lattice(value, values[3], values[2]) !== null;
+}
+
+function scalarIndex(domain: ControlDomain): readonly [bigint, bigint] | null {
+  const rawMin = rawIndex(domain, domain.raw_min);
+  const rawOrigin = rawIndex(domain, domain.raw_origin);
+  if (rawMin === null || rawOrigin === null) return null;
+  return [rawMin, rawOrigin];
+}
+
+function sameCardinality(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  const rawMin = rawIndex(domain, domain.raw_min);
+  const rawMax = rawIndex(domain, domain.raw_max);
+  const displayMin = lattice(values[0], values[3], values[2]);
+  const displayMax = lattice(values[1], values[3], values[2]);
+  return rawMin !== null && rawMax !== null && displayMin !== null && displayMax !== null
+    && rawMax - rawMin === displayMax - displayMin;
+}
+
+function isIdentity(domain: ControlDomain, values: readonly [Decimal, Decimal, Decimal, Decimal]): boolean {
+  return [domain.raw_min, domain.raw_max, domain.raw_step, domain.raw_origin]
+    .every((raw, index) => compare([BigInt(raw), 0], values[index]!) === 0);
+}
+
+function domainIsExact(domain: ControlDomain): boolean {
+  if (domain.restoration !== 'exact') return false;
+  if (domain.mapping !== 'lookup') return true;
+  const min = rawIndex(domain, domain.raw_min);
+  const max = rawIndex(domain, domain.raw_max);
+  if (min === null || max === null || BigInt(domain.lookup.length) !== max - min + 1n) return false;
+  const raws = new Set<number>();
+  const displays = new Set<string>();
+  return domain.lookup.every((point) => Number.isSafeInteger(point.raw) && rawIndex(domain, point.raw) !== null
+    && decimal(point.display) !== null && !raws.has(point.raw) && !displays.has(point.display)
+    && (raws.add(point.raw), displays.add(point.display), true));
+}
+
+/** Returns a canonical display value, or null when the domain/input is unusable. */
+export function decodeControlDomain(domain: ControlDomain, raw: number): ExactDecimal | null {
+  const values = axis(domain);
+  const index = rawIndex(domain, raw);
+  if (!values || index === null) return null;
+  if (domain.mapping === 'identity') return isIdentity(domain, values) ? text([BigInt(raw), 0]) : null;
+  if (domain.mapping === 'lookup') {
+    const matches = domain.lookup.filter((point) => point.raw === raw && decimal(point.display) && inAxis(decimal(point.display)!, values));
+    return matches.length === 1 ? matches[0]!.display : null;
+  }
+  if (domain.mapping === 'linear') {
+    const indices = scalarIndex(domain);
+    const originIndex = lattice(values[3], values[0], values[2]);
+    if (!indices || originIndex === null || indices[1] - indices[0] !== originIndex || !sameCardinality(domain, values)) return null;
+    const result = add(values[3], index, values[2]);
+    return inAxis(result, values) ? text(result) : null;
+  }
+  if (domain.mapping === 'centered') {
+    const center = rawIndex(domain, domain.raw_center);
+    const displayCenter = decimal(domain.display_center);
+    if (center === null || !displayCenter || !inAxis(displayCenter, values) || !sameCardinality(domain, values)) return null;
+    const result = add(displayCenter, index - center, values[2]);
+    return inAxis(result, values) ? text(result) : null;
+  }
+  return null;
+}
+
+/** Applies the domain's declared display lattice posture without numeric coercion. */
+export function quantizeControlDomain(domain: ControlDomain, display: ExactDecimal): ExactDecimal | null {
+  const values = axis(domain);
+  const value = decimal(display);
+  if (!values || !value) return null;
+  const [item, origin, step] = align([value, values[3], values[2]]);
+  const difference = item - origin;
+  const quotient = floorDivide(difference, step);
+  const remainder = difference - quotient * step;
+  let index: bigint;
+  switch (domain.quantization as ControlQuantization) {
+    case 'floor': index = quotient; break;
+    case 'ceil': index = remainder === 0n ? quotient : quotient + 1n; break;
+    case 'reject': if (remainder !== 0n) return null; index = quotient; break;
+    case 'nearest_ties_down': index = remainder * 2n > step ? quotient + 1n : quotient; break;
+    case 'nearest_ties_up': index = remainder * 2n >= step ? quotient + 1n : quotient; break;
+    default: return null;
+  }
+  const result = add(values[3], index, values[2]);
+  return inAxis(result, values) ? text(result) : null;
+}
+
+/** Inverts an exactly restorable domain; unavailable restoration deliberately returns null. */
+export function encodeControlDomain(domain: ControlDomain, display: ExactDecimal): number | null {
+  if (!domainIsExact(domain)) return null;
+  const quantized = quantizeControlDomain(domain, display);
+  const values = axis(domain);
+  if (!quantized || !values) return null;
+  if (domain.mapping === 'identity') {
+    if (!isIdentity(domain, values)) return null;
+    const value = decimal(quantized);
+    if (!value || value[1] !== 0 || value[0] < BigInt(domain.raw_min) || value[0] > BigInt(domain.raw_max)) return null;
+    const raw = Number(value[0]);
+    return rawIndex(domain, raw) === null ? null : raw;
+  }
+  if (domain.mapping === 'lookup') {
+    const matches = domain.lookup.filter((point) => point.display === quantized);
+    return matches.length === 1 ? matches[0]!.raw : null;
+  }
+  const target = decimal(quantized)!;
+  let raw: bigint;
+  if (domain.mapping === 'linear') {
+    const indices = scalarIndex(domain);
+    const originIndex = lattice(values[3], values[0], values[2]);
+    const displayIndex = lattice(target, values[3], values[2]);
+    if (!indices || originIndex === null || displayIndex === null || indices[1] - indices[0] !== originIndex || !sameCardinality(domain, values)) return null;
+    raw = BigInt(domain.raw_origin) + displayIndex * BigInt(domain.raw_step);
+  } else if (domain.mapping === 'centered') {
+    const center = rawIndex(domain, domain.raw_center);
+    const displayCenter = decimal(domain.display_center);
+    if (center === null || !displayCenter || !sameCardinality(domain, values)) return null;
+    const offset = lattice(target, displayCenter, values[2]);
+    if (offset === null) return null;
+    raw = BigInt(domain.raw_center) + offset * BigInt(domain.raw_step);
+  } else return null;
+  const number = Number(raw);
+  return Number.isSafeInteger(number) && rawIndex(domain, number) !== null && decodeControlDomain(domain, number) === quantized ? number : null;
+}


### PR DESCRIPTION
## Summary

Implements the pure consumer foundation for MOR-1722:

- adds BigInt coefficient/scale math for canonical display strings;
- decodes, quantizes, and encodes identity, linear, centered, and lookup control domains without Number display arithmetic;
- validates malformed, off-lattice, ambiguous, overflowing, unavailable-restoration, and unsupported-quantization inputs fail closed.

### Remediation

- canonicalizes arithmetic outputs, including mixed-scale fractional trailing zeroes;
- rejects display inputs outside the declared axis before quantization;
- validates lookup arrays, point shapes, monotonicity, and uniqueness before access;
- requires centered raw/display center alignment and matching full lattice cardinality;
- validates the complete declared quantization vocabulary before any helper returns a value.

No UI, state/store, command, profile, transport, or hardware behavior changed.

Linear: [MOR-1722](https://linear.app/morozsm/issue/MOR-1722/add-exact-raw-display-control-domain-math-helpers)

## Validation

- focused adversarial/repro and identity/linear/centered/descending-lookup matrix: 32 tests passed
- full frontend: 359 files / 7768 tests passed with at most 2 workers
- frontend type check, lint, boundaries, i18n check, and production build
- diff check and targeted privacy scan
