### PR TITLE
feat(MOR-1725): preserve evaluator root provenance

### DIFF
--- a/frontend/scripts/control-feedback-debt-evaluator.mjs
+++ b/frontend/scripts/control-feedback-debt-evaluator.mjs
@@ -7,9 +7,11 @@ import { expressionChildren, isGenuineUndefined, unwrapExpression } from './cont
  * @param {{ isTracked?: (node: any, scope: any) => boolean }} options
  */
 export function evaluateOrderedEffects(program, { isTracked = () => false } = {}) {
-  const facts = [], active = new Set(), scope = (parent = null) => Object.create(parent);
-  const emit = (kind, node, extra = {}) => facts.push({ kind, node, ...extra });
-  const merge = (values) => { let track = false; for (const value of values) { if (value?.track) track = true; } return { track }; };
+  const facts = [], active = new Map(), scope = (parent = null) => Object.create(parent);
+  const frozen = (values = []) => Object.freeze([...new Set(values)]);
+  const roots = (values) => frozen(values.flatMap((value) => value?.roots || []));
+  const emit = (kind, node, extra = {}) => facts.push(Object.freeze({ kind, node, ...extra }));
+  const merge = (values) => { const provenance = roots(values); return { track: provenance.length > 0 || values.some((value) => value?.track), roots: provenance }; };
   const hasBinding = (env, name) => !!env && name in env;
   const binding = (env, name) => hasBinding(env, name) ? env[name] : undefined;
   const known = (value) => ({ known: true, value, track: false });
@@ -18,9 +20,14 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
   const read = (node, env) => {
     node = unwrapExpression(node);
     if (!node) return { missing: true };
-    if (node.type === 'Identifier') return binding(env, node.name)?.value || { track: isTracked(node, env) };
+    if (node.type === 'Identifier') {
+      const value = binding(env, node.name)?.value;
+      if (value) return value;
+      const track = isTracked(node, env);
+      return { track, roots: track ? frozen([node]) : frozen() };
+    }
     if (node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') return merge([read(node.object, env), node.computed ? read(node.property, env) : null]);
-    return { track: isTracked(node, env) };
+    const track = isTracked(node, env); return { track, roots: track ? frozen([node]) : frozen() };
   };
   const callable = (node, env) => {
     node = unwrapExpression(node);
@@ -38,20 +45,21 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
       for (let index = 0; index < pattern.elements.length; index += 1) {
         const part = pattern.elements[index]; if (!part) continue;
         const rest = (value.items || []).slice(index);
-        const result = bind(part, part.type === 'RestElement' ? { items: rest, track: value.aggregate || (value.items ? merge(rest).track : value.track) } : value.items?.[index] || (value.track ? { track: true } : { missing: true }), env); if (result?.abrupt) return result;
+        const result = bind(part, part.type === 'RestElement' ? { items: rest, roots: value.items ? merge(rest).roots : value.roots, track: value.aggregate || (value.items ? merge(rest).track : value.track) } : value.items?.[index] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result;
       }
     }
     if (pattern.type === 'ObjectPattern') { const used = new Set(); for (const part of pattern.properties || []) {
-      if (part.type === 'RestElement') { const fields = Object.fromEntries(Object.entries(value.fields || {}).filter(([key]) => !used.has(key))); const result = bind(part.argument, { fields, track: value.aggregate || (value.fields ? merge(Object.values(fields)).track : value.track) }, env); if (result?.abrupt) return result; }
-      else { const key = part.key.name || part.key.value; used.add(String(key)); const result = bind(part.value, value.fields?.[key] || (value.track ? { track: true } : { missing: true }), env); if (result?.abrupt) return result; }
+      if (part.type === 'RestElement') { const fields = Object.fromEntries(Object.entries(value.fields || {}).filter(([key]) => !used.has(key))); const result = bind(part.argument, { fields, roots: value.fields ? merge(Object.values(fields)).roots : value.roots, track: value.aggregate || (value.fields ? merge(Object.values(fields)).track : value.track) }, env); if (result?.abrupt) return result; }
+      else { const key = part.key.name || part.key.value; used.add(String(key)); const result = bind(part.value, value.fields?.[key] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result; }
     }
     }
   };
   const invoke = (fn, args) => {
-    if (active.has(fn.node)) { emit('cycle', fn.node, { poison: true }); return { track: true, poison: true }; }
-    active.add(fn.node); const env = scope(fn.env), unknownSpread = args.findIndex((value) => value.spread && !value.items);
+    const invocation = merge(args), previous = active.get(fn.node);
+    if (previous) { const provenance = roots([invocation, previous]); emit('cycle', fn.node, { poison: true, roots: provenance, escapeRoots: provenance }); return { track: true, roots: provenance, poison: true }; }
+    active.set(fn.node, invocation); const env = scope(fn.env), unknownSpread = args.findIndex((value) => value.spread && !value.items);
     if (fn.node.type === 'FunctionExpression' && fn.node.id) env[fn.node.id.name] = { fn, value: { track: false } };
-    for (let index = 0; index < (fn.node.params || []).length; index += 1) { const param = fn.node.params[index], spreadCovers = unknownSpread >= 0 && index >= unknownSpread, result = bind(param, param.type === 'RestElement' ? { items: args.slice(index), track: spreadCovers || merge(args.slice(index)).track } : spreadCovers ? { track: true } : args[index] || { missing: true }, env); if (result?.abrupt) { active.delete(fn.node); return result; } }
+    for (let index = 0; index < (fn.node.params || []).length; index += 1) { const param = fn.node.params[index], spreadCovers = unknownSpread >= 0 && index >= unknownSpread, result = bind(param, param.type === 'RestElement' ? { items: args.slice(index), ...merge(args.slice(index)), track: spreadCovers || merge(args.slice(index)).track } : spreadCovers ? { track: true, roots: invocation.roots } : args[index] || { missing: true }, env); if (result?.abrupt) { active.delete(fn.node); return result; } }
     const result = fn.node.body?.type === 'BlockStatement' ? block(fn.node.body.body, env) : { value: evaluate(fn.node.body, env) };
     active.delete(fn.node); return result.abrupt ? { ...(result.value || known(undefined)), abrupt: true } : result.value || { ...known(undefined), undefined: true };
   };
@@ -60,7 +68,7 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
     if (raw?.type === 'SpreadElement') return { ...argument(raw.argument, env), spread: true };
     if (raw?.type === 'ArrayExpression') {
       const items = []; let aggregate = false; for (const part of raw.elements || []) { const value = part ? argument(part, env) : { missing: true }; if (value.abrupt) return value; aggregate ||= !!value.spread && !value.items && !!value.track; if (value.spread && value.items) items.push(...value.items); else items.push(value); }
-      return { items, track: merge(items).track, aggregate };
+      return { items, ...merge(items), aggregate };
     }
     if (raw?.type === 'ObjectExpression') {
       const fields = {};
@@ -70,7 +78,7 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
         if (part.computed) { const key = evaluate(part.key, env); if (key.abrupt) return key; }
         const value = argument(part.value, env); if (value.abrupt) return value; fields[part.key.name || part.key.value] = value;
       }
-      return { fields, track: track || merge(Object.values(fields)).track, aggregate };
+      return { fields, ...merge(Object.values(fields)), track: track || merge(Object.values(fields)).track, aggregate };
     }
     const value = evaluate(node, env); if (unboundUndefined(raw, env)) return { ...known(undefined), undefined: true }; return value;
   };
@@ -83,6 +91,7 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
     if (node.type === 'ArrayExpression' || node.type === 'ObjectExpression') return argument(node, env);
     if (node.type === 'UnaryExpression') {
       const value = evaluate(node.argument, env); if (value.abrupt) return value;
+      if (node.operator === 'delete' && value.track) emit('mutation', node, { roots: value.roots, targetRoots: frozen(value.roots), escapeRoots: frozen(), poison: true });
       if (node.operator === 'void') return { ...known(undefined), undefined: true, track: value.track };
       if (!isKnown(value)) return value;
       if (node.operator === '!') return { ...known(!value.value), track: value.track };
@@ -97,15 +106,15 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
       if (callee.abrupt || (node.optional && isKnown(callee) && callee.value == null) || inChain && callee.chainShortCircuit) return callee;
       for (const part of node.arguments || []) { const value = argument(part, env); if (value.abrupt) return value; if (value.spread && value.items) args.push(...value.items); else args.push(value); }
       if (fn) return invoke(fn, args);
-      const value = merge([callee, ...args]); if (value.track) emit('escape', node); return value;
+      const value = merge([callee, ...args]); if (value.track) emit('escape', node, { roots: value.roots, escapeRoots: value.roots }); return value;
     }
     if (node.type === 'TaggedTemplateExpression') {
       const values = [evaluate(node.tag, env)]; if (values[0].abrupt) return values[0]; for (const part of node.quasi.expressions || []) { const value = evaluate(part, env); if (value.abrupt) return value; values.push(value); }
-      const value = merge(values); if (value.track) emit('escape', node); return value;
+      const value = merge(values); if (value.track) emit('escape', node, { roots: value.roots, escapeRoots: value.roots }); return value;
     }
     if (node.type === 'AssignmentExpression' || node.type === 'UpdateExpression') {
       const left = evaluate(node.type === 'UpdateExpression' ? node.argument : node.left, env); if (left.abrupt) return left; const right = node.right ? evaluate(node.right, env) : { track: false }; if (right.abrupt) return right; const value = merge([left, right]);
-      if (value.track) emit('mutation', node); return value;
+      if (value.track) emit('mutation', node, { roots: value.roots, targetRoots: frozen(left.roots), escapeRoots: frozen(right.roots), poison: !left.track && right.track }); return value;
     }
     if (node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') {
       const values = [evaluate(node.object, env, inChain)];
@@ -144,7 +153,7 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
       const fn = callable(declaration.init, env), value = declaration.init ? evaluate(declaration.init, env) : { missing: true }; if (value.abrupt) return { complete: true, abrupt: true, value };
       if (declaration.id.type === 'Identifier') env[declaration.id.name] = { fn, value }; else bind(declaration.id, value, env);
     }
-    else if (node.type === 'ReturnStatement') { const value = node.argument ? evaluate(node.argument, env) : { ...known(undefined), undefined: true }; if (value.abrupt) return { complete: true, abrupt: true, value }; if (value.track) emit('return', node); return { complete: true, value }; }
+    else if (node.type === 'ReturnStatement') { const value = node.argument ? evaluate(node.argument, env) : { ...known(undefined), undefined: true }; if (value.abrupt) return { complete: true, abrupt: true, value }; if (value.track) emit('return', node, { roots: value.roots }); return { complete: true, value }; }
     else if (node.type === 'ThrowStatement') return { complete: true, abrupt: true, value: evaluate(node.argument, env) };
     else if (node.type === 'BlockStatement') return block(node.body, scope(env));
     else if (node.type === 'ExpressionStatement') { const value = evaluate(node.expression, env); if (value.abrupt) return { complete: true, abrupt: true, value }; }

--- a/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
@@ -8,6 +8,10 @@ const facts = (source: string) => evaluateOrderedEffects(program(source), {
   isTracked: (node: { type?: string; name?: string }) => node?.type === 'Identifier' && node.name === 'props',
 }).map((fact: { kind: string }) => fact.kind);
 
+const effects = (source: string) => evaluateOrderedEffects(program(source), {
+  isTracked: (node: { type?: string; name?: string }) => node?.type === 'Identifier' && node.name === 'props',
+});
+
 describe('ordered debt evaluator (MOR-1720)', () => {
   it('runs hoisted and const callables only when invoked', () => {
     expect(facts('call(); function call() { mutate(props); return props; } const later = () => mutate(props); later(); function idle() { mutate(props); }'))
@@ -152,5 +156,34 @@ describe('ordered debt evaluator (MOR-1720)', () => {
 
   it('has no facts for unrelated code', () => {
     expect(facts('const add = (a: number, b: number) => a + b; add(1, 2);')).toEqual([]);
+  });
+
+  it('retains immutable roots through bound and returned aliases', () => {
+    const result = effects('function f({ x: [first, ...rest] }) { first.type = 1; delete rest[0]; return first; } const alias = f({ x: [props, props] }); sink(alias);');
+    expect(result.filter((fact) => fact.kind === 'mutation').map((fact) => [fact.targetRoots.length, fact.escapeRoots.length, Object.isFrozen(fact.roots)])).toEqual([[1, 0, true], [1, 0, true]]);
+    expect(result.filter((fact) => fact.kind === 'return').every((fact) => fact.roots.length === 1)).toBe(true);
+    expect(result.filter((fact) => fact.kind === 'escape').at(-1).roots.length).toBe(1);
+  });
+
+  it('preserves plain and defaulted bindings independently of supplied nested values', () => {
+    const result = effects('function f(plain, { nested: [item = props] } = {}) { plain.type = 1; item.type = 1; return plain; } sink(f(props, { nested: [props] })); sink(f(props));');
+    expect(result.filter((fact) => fact.kind === 'mutation').map((fact) => fact.targetRoots.length)).toEqual([1, 1, 1, 1]);
+    expect(result.filter((fact) => fact.kind === 'return').map((fact) => fact.roots.length)).toEqual([1, 1]);
+  });
+
+  it('separates receiver provenance from RHS escapes in runtime order', () => {
+    const writes = effects('const holder = {}; holder.value = props; props.value = holder;').filter((fact) => fact.kind === 'mutation');
+    expect(writes.map((fact) => [fact.targetRoots.length, fact.escapeRoots.length, fact.poison])).toEqual([[0, 1, true], [1, 0, false]]);
+  });
+
+  it('associates cycles with the invoking exposed root only', () => {
+    const result = effects('function rooted(x) { rooted(x); } function unrelated() { unrelated(); } rooted(props); props.type = 1; unrelated();');
+    expect(result.filter((fact) => fact.kind === 'cycle').map((fact) => fact.roots.length)).toEqual([1, 0]);
+    expect(result.filter((fact) => fact.kind === 'mutation')[0].poison).toBe(false);
+  });
+
+  it('keeps repeated default deletes ordered without shared side tables', () => {
+    const writes = effects('function f(x = props) { delete x.value; delete x.value; } f(); f();').filter((fact) => fact.kind === 'mutation');
+    expect(writes.map((fact) => [fact.targetRoots.length, fact.poison])).toEqual([[1, true], [1, true], [1, true], [1, true]]);
   });
 });


### PR DESCRIPTION
## Summary

Preserves immutable exposed-root provenance in ordered evaluator facts across bound aliases, returns, receiver writes, RHS escapes, deletes, defaults, and recursive invocation.

Mutation facts distinguish `targetRoots` from `escapeRoots`; cycle provenance is invocation-specific, so unrelated recursion does not poison an exposed root.

Blocks MOR-1716.

## Validation

- `npm test -- --run src/__tests__/control-feedback-debt-evaluator.test.ts` (29 passed)
- `npm run check`, `npm run lint`, `npm run lint:boundaries`
- `npm run i18n:check`, `npm run build`, `git diff --check`

The full frontend run was started with `--maxWorkers=2`, but the local runner did not retain its terminal summary; it is intentionally not claimed as a passing gate here.