### PR TITLE
feat(MOR-1727): add encoded control domains

### DIFF
--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -20,6 +20,7 @@ from rigplane.core.tx_interlock_contract import (
 
 __all__ = [
     "ControlLookupPoint",
+    "EncodedControlChoice",
     "ControlDomainSpec",
     "ControlSpec",
     "FilterWidthSegment",
@@ -41,6 +42,23 @@ class ControlLookupPoint(TypedDict):
 
     raw: int
     display: str
+
+
+class EncodedControlLabelChoice(TypedDict):
+    """One encoded choice represented by a truthful non-numeric label."""
+
+    raw: int
+    label: str
+
+
+class EncodedControlNumericChoice(TypedDict):
+    """One encoded choice represented by an exact numeric display value."""
+
+    raw: int
+    display: str
+
+
+EncodedControlChoice = EncodedControlLabelChoice | EncodedControlNumericChoice
 
 
 class ControlSpec(TypedDict, total=False):
@@ -104,11 +122,20 @@ class LookupControlDomainSpec(_ControlDomainBase):
     display_center: NotRequired[Never]
 
 
+class EncodedControlDomainSpec(TypedDict):
+    """Discrete raw codes whose choices may be labeled or numeric."""
+
+    mapping: Required[Literal["encoded"]]
+    choices: list[EncodedControlChoice]
+    style: NotRequired[str]
+
+
 ControlDomainSpec = (
     IdentityControlDomainSpec
     | LinearControlDomainSpec
     | CenteredControlDomainSpec
     | LookupControlDomainSpec
+    | EncodedControlDomainSpec
 )
 
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -232,6 +232,7 @@ def _parse_encoded_control_choices(
 
     choices: list[_EncodedChoice] = []
     numeric_values: list[Decimal] = []
+    labeled_choices: list[tuple[int, str, str]] = []
     for index, choice in enumerate(raw_choices):
         choice_prefix = f"{prefix}.choices[{index}]"
         if not isinstance(choice, dict) or set(choice) not in (
@@ -249,6 +250,7 @@ def _parse_encoded_control_choices(
             if not isinstance(label, str) or not label.strip():
                 raise RigLoadError(f"{choice_prefix}.label must be a non-empty string")
             choices.append((raw_value, label))
+            labeled_choices.append((raw_value, label, choice_prefix))
         else:
             display = _control_decimal(choice["display"], f"{choice_prefix}.display")
             choices.append((raw_value, display))
@@ -259,6 +261,15 @@ def _parse_encoded_control_choices(
         raise RigLoadError(f"{prefix}.choices raw values must be unique")
     if len(set(numeric_values)) != len(numeric_values):
         raise RigLoadError(f"{prefix}.choices display values must be unique")
+    if len(labeled_choices) != 1:
+        raise RigLoadError(
+            f"{prefix}.choices must contain exactly one default label choice"
+        )
+    default_raw, default_label, default_prefix = labeled_choices[0]
+    if default_raw != 0:
+        raise RigLoadError(f"{default_prefix}.label default must use raw code 0")
+    if default_label != "Default":
+        raise RigLoadError(f'{default_prefix}.label must be exactly "Default"')
     return tuple(choices)
 
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -323,6 +323,8 @@ def _parse_control_spec(
         raise RigLoadError(
             f"{prefix}.mapping must be one of {sorted(VALID_CONTROL_MAPPINGS)!r}"
         )
+    if mapping != "encoded" and "choices" in raw:
+        raise RigLoadError(f"{prefix}.choices requires encoded mapping")
     if mapping == "encoded":
         if "choices" not in raw:
             raise RigLoadError(f"{prefix}.choices is required for encoded mapping")

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -35,6 +35,7 @@ from rigplane.profiles import (
     BandInfo,
     ControlDomainSpec,
     ControlLookupPoint,
+    EncodedControlChoice,
     ControlSpec,
     FilterWidthRule,
     FilterWidthSegment,
@@ -57,7 +58,7 @@ VALID_CONTROL_STYLES = {
     "toggle_and_level",
     "level_is_toggle",
 }
-VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered", "lookup"}
+VALID_CONTROL_MAPPINGS = {"identity", "linear", "centered", "lookup", "encoded"}
 VALID_CONTROL_QUANTIZATION = {
     "nearest_ties_down",
     "nearest_ties_up",
@@ -85,6 +86,7 @@ _CONTROL_KEYS = {
     "quantization",
     "restoration",
     "lookup",
+    "choices",
 }
 _EXPLICIT_CONTROL_DOMAIN_KEYS = {
     "raw_step",
@@ -96,6 +98,7 @@ _EXPLICIT_CONTROL_DOMAIN_KEYS = {
     "quantization",
     "restoration",
     "lookup",
+    "choices",
 }
 VALID_RULE_KINDS = {"mutex", "disables", "requires", "value_limit"}
 VALID_KEYBOARD_MODIFIERS = {"SHIFT", "CTRL", "ALT", "META"}
@@ -119,7 +122,10 @@ class RigLoadError(Exception):
 
 
 _LookupPoint = tuple[int, Decimal]
-_ScalarControlDomain = dict[str, str | int | Decimal | tuple[_LookupPoint, ...]]
+_EncodedChoice = tuple[int, Decimal | str]
+_ScalarControlDomain = dict[
+    str, str | int | Decimal | tuple[_LookupPoint, ...] | tuple[_EncodedChoice, ...]
+]
 
 
 def _public_decimal(value: Decimal) -> str:
@@ -218,6 +224,44 @@ def _parse_control_lookup(
     return tuple(points)
 
 
+def _parse_encoded_control_choices(
+    raw_choices: object, prefix: str
+) -> tuple[_EncodedChoice, ...]:
+    if not isinstance(raw_choices, list) or not raw_choices:
+        raise RigLoadError(f"{prefix}.choices must be a non-empty array")
+
+    choices: list[_EncodedChoice] = []
+    numeric_values: list[Decimal] = []
+    for index, choice in enumerate(raw_choices):
+        choice_prefix = f"{prefix}.choices[{index}]"
+        if not isinstance(choice, dict) or set(choice) not in (
+            {"raw", "label"},
+            {"raw", "display"},
+        ):
+            raise RigLoadError(
+                f"{choice_prefix} must contain exactly raw and one of label or display"
+            )
+        raw_value = int(
+            _control_number(choice["raw"], f"{choice_prefix}.raw", integer=True)
+        )
+        if "label" in choice:
+            label = choice["label"]
+            if not isinstance(label, str) or not label.strip():
+                raise RigLoadError(f"{choice_prefix}.label must be a non-empty string")
+            choices.append((raw_value, label))
+        else:
+            display = _control_decimal(choice["display"], f"{choice_prefix}.display")
+            choices.append((raw_value, display))
+            numeric_values.append(display)
+
+    raw_values = [choice[0] for choice in choices]
+    if len(set(raw_values)) != len(raw_values):
+        raise RigLoadError(f"{prefix}.choices raw values must be unique")
+    if len(set(numeric_values)) != len(numeric_values):
+        raise RigLoadError(f"{prefix}.choices display values must be unique")
+    return tuple(choices)
+
+
 def _parse_control_spec(
     filename: str, control_name: str, raw: object
 ) -> tuple[ControlSpec | None, _ScalarControlDomain | None]:
@@ -268,6 +312,21 @@ def _parse_control_spec(
         raise RigLoadError(
             f"{prefix}.mapping must be one of {sorted(VALID_CONTROL_MAPPINGS)!r}"
         )
+    if mapping == "encoded":
+        if "choices" not in raw:
+            raise RigLoadError(f"{prefix}.choices is required for encoded mapping")
+        encoded_only = {"mapping", "choices", "style"}
+        unsupported = sorted(set(raw) - encoded_only)
+        if unsupported:
+            raise RigLoadError(
+                f"{prefix}.encoded mapping does not accept key(s): {unsupported!r}"
+            )
+        choices = _parse_encoded_control_choices(raw["choices"], prefix)
+        encoded_domain: _ScalarControlDomain = {"mapping": mapping, "choices": choices}
+        encoded_public_spec: ControlSpec | None = (
+            {"style": style} if style is not None else None
+        )
+        return encoded_public_spec, encoded_domain
     if mapping == "lookup" and "lookup" not in raw:
         raise RigLoadError(f"{prefix}.lookup is required for lookup mapping")
     if mapping != "lookup" and "lookup" in raw:
@@ -531,6 +590,30 @@ class RigConfig:
                 {name: spec.copy() for name, spec in (self.controls or {}).items()},
             )
             for name, domain in self._control_domains.items():
+                if domain["mapping"] == "encoded":
+                    published_encoded_domain: dict[str, object] = {
+                        "mapping": "encoded",
+                        "choices": [
+                            (
+                                cast(EncodedControlChoice, {"raw": raw, "label": value})
+                                if isinstance(value, str)
+                                else cast(
+                                    EncodedControlChoice,
+                                    {"raw": raw, "display": _public_decimal(value)},
+                                )
+                            )
+                            for raw, value in cast(
+                                tuple[_EncodedChoice, ...], domain["choices"]
+                            )
+                        ],
+                    }
+                    legacy = published_controls.get(name)
+                    if legacy is not None and "style" in legacy:
+                        published_encoded_domain["style"] = legacy["style"]
+                    published_controls[name] = cast(
+                        ControlDomainSpec, published_encoded_domain
+                    )
+                    continue
                 published_domain: dict[str, object] = {
                     "mapping": cast(str, domain["mapping"]),
                     "raw_min": cast(int, domain["raw_min"]),

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -944,6 +944,34 @@ choices = [
         with pytest.raises(RigLoadError, match=message):
             self._load(tmp_path, declaration)
 
+    @pytest.mark.parametrize(
+        ("mapping", "declaration"),
+        [
+            (
+                "identity",
+                _LINEAR.replace("display_max = 1.0", "display_max = 10")
+                .replace("display_step = 0.2", "display_step = 2")
+                .replace('display_unit = "ratio"', 'display_unit = "dimensionless"')
+                .replace('mapping = "linear"', 'mapping = "identity"'),
+            ),
+            ("linear", _LINEAR),
+            (
+                "centered",
+                _LINEAR.replace("raw_min = 0", "raw_min = -10")
+                .replace("display_min = 0.0", "display_min = -1.0")
+                .replace('mapping = "linear"', 'mapping = "centered"')
+                + "raw_center = 0\ndisplay_center = 0.0\n",
+            ),
+            ("lookup", _LOOKUP),
+        ],
+    )
+    def test_non_encoded_domains_reject_choices(self, tmp_path, mapping, declaration):
+        with pytest.raises(RigLoadError, match="choices requires encoded mapping"):
+            self._load(
+                tmp_path,
+                declaration + 'choices = [{ raw = 0, label = "Default" }]\n',
+            )
+
     def test_exact_lookup_requires_every_raw_lattice_point(self, tmp_path):
         partial = self._LOOKUP.replace("  { raw = 4, display = 0.4 },\n", "")
         with pytest.raises(RigLoadError, match="exact.*complete raw lattice"):

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -864,6 +864,71 @@ lookup = [
         assert "raw_center" not in public["test_control"]
         assert "display_center" not in public["test_control"]
 
+    def test_encoded_domain_publishes_default_and_exact_numeric_choices(self, tmp_path):
+        declaration = """\
+mapping = "encoded"
+choices = [
+  { raw = 0, label = "Default" },
+  { raw = 1, display = 250 },
+  { raw = 4, display = 1250.5 },
+]
+"""
+
+        rig = self._load(tmp_path, declaration)
+
+        assert rig._control_domains["test_control"]["choices"] == (
+            (0, "Default"),
+            (1, Decimal("250")),
+            (4, Decimal("1250.5")),
+        )
+        public = rig.to_profile().controls
+        assert public == {
+            "test_control": {
+                "mapping": "encoded",
+                "choices": [
+                    {"raw": 0, "label": "Default"},
+                    {"raw": 1, "display": "250"},
+                    {"raw": 4, "display": "1250.5"},
+                ],
+            }
+        }
+        assert json.loads(json.dumps(public, allow_nan=False)) == public
+
+    @pytest.mark.parametrize(
+        ("choices", "message"),
+        [
+            (
+                '[{ raw = 0, label = "Default" }, { raw = 0, display = 250 }]',
+                "raw values.*unique",
+            ),
+            (
+                '[{ raw = 0, label = "Default" }, { raw = 1, display = 250 }, { raw = 2, display = 250 }]',
+                "display values.*unique",
+            ),
+            ('[{ raw = 0, label = "" }]', "label.*non-empty"),
+            ('[{ raw = true, label = "Default" }]', "raw.*integer"),
+            (
+                '[{ raw = 0, label = "Default", display = 250 }]',
+                "exactly raw and one of label or display",
+            ),
+            (
+                '[{ raw = 0, label = "Default", extra = 1 }]',
+                "exactly raw and one of label or display",
+            ),
+            (
+                '[{ raw = 0, label = "Default" }, { raw = 1, display = nan }]',
+                "display.*finite",
+            ),
+        ],
+    )
+    def test_encoded_domain_rejects_ambiguous_or_malformed_choices(
+        self, tmp_path, choices, message
+    ):
+        declaration = 'mapping = "encoded"\nchoices = ' + choices + "\n"
+
+        with pytest.raises(RigLoadError, match=message):
+            self._load(tmp_path, declaration)
+
     def test_exact_lookup_requires_every_raw_lattice_point(self, tmp_path):
         partial = self._LOOKUP.replace("  { raw = 4, display = 0.4 },\n", "")
         with pytest.raises(RigLoadError, match="exact.*complete raw lattice"):

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -907,6 +907,21 @@ choices = [
             ),
             ('[{ raw = 0, label = "" }]', "label.*non-empty"),
             ('[{ raw = true, label = "Default" }]', "raw.*integer"),
+            ("[{ raw = 0, display = 250 }]", "exactly one.*default"),
+            (
+                "[{ raw = 0, display = 250 }, { raw = 1, display = 500 }]",
+                "exactly one.*default",
+            ),
+            (
+                '[{ raw = 0, display = 250 }, { raw = 1, label = "Default" }]',
+                "default.*raw code 0",
+            ),
+            (
+                '[{ raw = 0, label = "Default" }, { raw = 1, label = "Default" }]',
+                "exactly one.*default",
+            ),
+            ('[{ raw = 0, label = "default" }]', 'label must be exactly "Default"'),
+            ('[{ raw = 0, label = "Default " }]', 'label must be exactly "Default"'),
             (
                 '[{ raw = 0, label = "Default", display = 250 }]',
                 "exactly raw and one of label or display",


### PR DESCRIPTION
## Summary
- add a typed, JSON-safe encoded control-domain variant
- require exactly one truthful `Default` label at raw code 0
- preserve exact numeric displays for all other ordered choices
- reject duplicate, ambiguous, malformed, boolean, non-finite, and misplaced choices
- merge current `main` through MOR-1726, retaining its shipped-domain regression coverage

## Verification
- `uv run pytest tests/test_rig_loader.py::TestControlDomainSchema -q --tb=short` (66 passed)
- `uv run pytest tests/test_rig_loader.py -q --tb=short` (316 passed, 1 skipped)
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` (running)
- `uv run ruff check src/rigplane/profiles/__init__.py src/rigplane/profiles/rig_loader.py tests/test_rig_loader.py`
- `uv run ruff format --check src/rigplane/profiles/__init__.py src/rigplane/profiles/rig_loader.py tests/test_rig_loader.py`
- `uv run mypy --follow-imports=normal src/rigplane/profiles/__init__.py src/rigplane/profiles/rig_loader.py`
- `uv run lint-imports`

Tracks MOR-1727.