### PR TITLE
feat(MOR-1728): preserve spread and cycle roots

### DIFF
--- a/frontend/scripts/control-feedback-debt-evaluator.mjs
+++ b/frontend/scripts/control-feedback-debt-evaluator.mjs
@@ -10,7 +10,8 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
   const facts = [], active = new Map(), scope = (parent = null) => Object.create(parent);
   const frozen = (values = []) => Object.freeze([...new Set(values)]);
   const roots = (values) => frozen(values.flatMap((value) => value?.roots || []));
-  const emit = (kind, node, extra = {}) => facts.push(Object.freeze({ kind, node, ...extra }));
+  const noteActive = (provenance) => { if (provenance?.length) for (const state of active.values()) state.roots = frozen([...state.roots, ...provenance]); };
+  const emit = (kind, node, extra = {}) => { facts.push(Object.freeze({ kind, node, ...extra })); noteActive(extra.roots || extra.targetRoots || extra.escapeRoots); };
   const merge = (values) => { const provenance = roots(values); return { track: provenance.length > 0 || values.some((value) => value?.track), roots: provenance }; };
   const hasBinding = (env, name) => !!env && name in env;
   const binding = (env, name) => hasBinding(env, name) ? env[name] : undefined;
@@ -44,12 +45,12 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
     if (pattern.type === 'ArrayPattern') {
       for (let index = 0; index < pattern.elements.length; index += 1) {
         const part = pattern.elements[index]; if (!part) continue;
-        const rest = (value.items || []).slice(index);
-        const result = bind(part, part.type === 'RestElement' ? { items: rest, roots: value.items ? merge(rest).roots : value.roots, track: value.aggregate || (value.items ? merge(rest).track : value.track) } : value.items?.[index] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result;
+        const rest = (value.items || []).slice(index), restValue = merge(rest);
+        const result = bind(part, part.type === 'RestElement' ? { items: rest, roots: frozen([...restValue.roots, ...(value.aggregate ? value.roots : [])]), track: value.aggregate || (value.items ? restValue.track : value.track) } : value.items?.[index] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result;
       }
     }
     if (pattern.type === 'ObjectPattern') { const used = new Set(); for (const part of pattern.properties || []) {
-      if (part.type === 'RestElement') { const fields = Object.fromEntries(Object.entries(value.fields || {}).filter(([key]) => !used.has(key))); const result = bind(part.argument, { fields, roots: value.fields ? merge(Object.values(fields)).roots : value.roots, track: value.aggregate || (value.fields ? merge(Object.values(fields)).track : value.track) }, env); if (result?.abrupt) return result; }
+      if (part.type === 'RestElement') { const fields = Object.fromEntries(Object.entries(value.fields || {}).filter(([key]) => !used.has(key))), rest = merge(Object.values(fields)); const result = bind(part.argument, { fields, roots: frozen([...rest.roots, ...(value.aggregate ? value.roots : [])]), track: value.aggregate || (value.fields ? rest.track : value.track) }, env); if (result?.abrupt) return result; }
       else { const key = part.key.name || part.key.value; used.add(String(key)); const result = bind(part.value, value.fields?.[key] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result; }
     }
     }
@@ -57,7 +58,7 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
   const invoke = (fn, args) => {
     const invocation = merge(args), previous = active.get(fn.node);
     if (previous) { const provenance = roots([invocation, previous]); emit('cycle', fn.node, { poison: true, roots: provenance, escapeRoots: provenance }); return { track: true, roots: provenance, poison: true }; }
-    active.set(fn.node, invocation); const env = scope(fn.env), unknownSpread = args.findIndex((value) => value.spread && !value.items);
+    active.set(fn.node, { roots: invocation.roots }); const env = scope(fn.env), unknownSpread = args.findIndex((value) => value.spread && !value.items);
     if (fn.node.type === 'FunctionExpression' && fn.node.id) env[fn.node.id.name] = { fn, value: { track: false } };
     for (let index = 0; index < (fn.node.params || []).length; index += 1) { const param = fn.node.params[index], spreadCovers = unknownSpread >= 0 && index >= unknownSpread, result = bind(param, param.type === 'RestElement' ? { items: args.slice(index), ...merge(args.slice(index)), track: spreadCovers || merge(args.slice(index)).track } : spreadCovers ? { track: true, roots: invocation.roots } : args[index] || { missing: true }, env); if (result?.abrupt) { active.delete(fn.node); return result; } }
     const result = fn.node.body?.type === 'BlockStatement' ? block(fn.node.body.body, env) : { value: evaluate(fn.node.body, env) };
@@ -72,13 +73,13 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
     }
     if (raw?.type === 'ObjectExpression') {
       const fields = {};
-      let track = false, aggregate = false;
+      let track = false, aggregate = false, spreadRoots = frozen();
       for (const part of raw.properties || []) {
-        if (part.type === 'SpreadElement') { const spread = argument(part.argument, env); if (spread.abrupt) return spread; Object.assign(fields, spread.fields || {}); track ||= !!spread.track; aggregate ||= !spread.fields && !!spread.track; continue; }
+        if (part.type === 'SpreadElement') { const spread = argument(part.argument, env); if (spread.abrupt) return spread; Object.assign(fields, spread.fields || {}); spreadRoots = frozen([...spreadRoots, ...spread.roots]); track ||= !!spread.track; aggregate ||= !spread.fields && !!spread.track; continue; }
         if (part.computed) { const key = evaluate(part.key, env); if (key.abrupt) return key; }
         const value = argument(part.value, env); if (value.abrupt) return value; fields[part.key.name || part.key.value] = value;
       }
-      return { fields, ...merge(Object.values(fields)), track: track || merge(Object.values(fields)).track, aggregate };
+      const value = merge(Object.values(fields)); return { fields, roots: frozen([...value.roots, ...spreadRoots]), track: track || value.track, aggregate };
     }
     const value = evaluate(node, env); if (unboundUndefined(raw, env)) return { ...known(undefined), undefined: true }; return value;
   };

--- a/frontend/scripts/control-feedback-debt-evaluator.mjs
+++ b/frontend/scripts/control-feedback-debt-evaluator.mjs
@@ -46,11 +46,11 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
       for (let index = 0; index < pattern.elements.length; index += 1) {
         const part = pattern.elements[index]; if (!part) continue;
         const rest = (value.items || []).slice(index), restValue = merge(rest);
-        const result = bind(part, part.type === 'RestElement' ? { items: rest, roots: frozen([...restValue.roots, ...(value.aggregate ? value.roots : [])]), track: value.aggregate || (value.items ? restValue.track : value.track) } : value.items?.[index] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result;
+        const result = bind(part, part.type === 'RestElement' ? { items: rest, roots: frozen([...restValue.roots, ...(value.aggregate || !value.items ? value.roots : [])]), track: value.aggregate || (value.items ? restValue.track : value.track) } : value.items?.[index] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result;
       }
     }
     if (pattern.type === 'ObjectPattern') { const used = new Set(); for (const part of pattern.properties || []) {
-      if (part.type === 'RestElement') { const fields = Object.fromEntries(Object.entries(value.fields || {}).filter(([key]) => !used.has(key))), rest = merge(Object.values(fields)); const result = bind(part.argument, { fields, roots: frozen([...rest.roots, ...(value.aggregate ? value.roots : [])]), track: value.aggregate || (value.fields ? rest.track : value.track) }, env); if (result?.abrupt) return result; }
+      if (part.type === 'RestElement') { const fields = Object.fromEntries(Object.entries(value.fields || {}).filter(([key]) => !used.has(key))), rest = merge(Object.values(fields)); const result = bind(part.argument, { fields, roots: frozen([...rest.roots, ...(value.aggregate || !value.fields ? value.roots : [])]), track: value.aggregate || (value.fields ? rest.track : value.track) }, env); if (result?.abrupt) return result; }
       else { const key = part.key.name || part.key.value; used.add(String(key)); const result = bind(part.value, value.fields?.[key] || (value.track ? { track: true, roots: value.roots } : { missing: true }), env); if (result?.abrupt) return result; }
     }
     }

--- a/frontend/scripts/control-feedback-debt-evaluator.mjs
+++ b/frontend/scripts/control-feedback-debt-evaluator.mjs
@@ -75,7 +75,7 @@ export function evaluateOrderedEffects(program, { isTracked = () => false } = {}
       const fields = {};
       let track = false, aggregate = false, spreadRoots = frozen();
       for (const part of raw.properties || []) {
-        if (part.type === 'SpreadElement') { const spread = argument(part.argument, env); if (spread.abrupt) return spread; Object.assign(fields, spread.fields || {}); spreadRoots = frozen([...spreadRoots, ...spread.roots]); track ||= !!spread.track; aggregate ||= !spread.fields && !!spread.track; continue; }
+        if (part.type === 'SpreadElement') { const spread = argument(part.argument, env); if (spread.abrupt) return spread; Object.assign(fields, spread.fields || {}); spreadRoots = frozen([...spreadRoots, ...(spread.roots || [])]); track ||= !!spread.track; aggregate ||= !spread.fields && !!spread.track; continue; }
         if (part.computed) { const key = evaluate(part.key, env); if (key.abrupt) return key; }
         const value = argument(part.value, env); if (value.abrupt) return value; fields[part.key.name || part.key.value] = value;
       }

--- a/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
@@ -12,6 +12,10 @@ const effects = (source: string) => evaluateOrderedEffects(program(source), {
   isTracked: (node: { type?: string; name?: string }) => node?.type === 'Identifier' && node.name === 'props',
 });
 
+const multiRootEffects = (source: string) => evaluateOrderedEffects(program(source), {
+  isTracked: (node: { type?: string; name?: string }) => node?.type === 'Identifier' && ['props', 'other'].includes(node.name || ''),
+});
+
 describe('ordered debt evaluator (MOR-1720)', () => {
   it('runs hoisted and const callables only when invoked', () => {
     expect(facts('call(); function call() { mutate(props); return props; } const later = () => mutate(props); later(); function idle() { mutate(props); }'))
@@ -185,5 +189,26 @@ describe('ordered debt evaluator (MOR-1720)', () => {
   it('keeps repeated default deletes ordered without shared side tables', () => {
     const writes = effects('function f(x = props) { delete x.value; delete x.value; } f(); f();').filter((fact) => fact.kind === 'mutation');
     expect(writes.map((fact) => [fact.targetRoots.length, fact.poison])).toEqual([[1, true], [1, true], [1, true], [1, true]]);
+  });
+
+  it('preserves anonymous spread roots through nested and rest bindings', () => {
+    const object = effects('function f({ ...rest }) { rest.value = 1; sink(rest); delete rest.value; } f({ ...props });');
+    expect(object.map((fact) => [fact.kind, fact.roots.length])).toEqual([['mutation', 1], ['escape', 1], ['mutation', 1]]);
+    const array = effects('function f([value, ...rest]) { value.x = 1; sink(rest); delete value.x; } f([...props]);');
+    expect(array.map((fact) => [fact.kind, fact.roots.length])).toEqual([['mutation', 1], ['escape', 1], ['mutation', 1]]);
+    const nested = effects('function f({ item: { ...rest } }) { delete rest.x; } f({ item: { ...props } });');
+    expect(nested.map((fact) => fact.roots.length)).toEqual([1]);
+  });
+
+  it('attaches only active effect roots to zero-argument recursive cycles', () => {
+    const direct = effects('function direct() { props.x = 1; direct(); } direct();').filter((fact) => fact.kind === 'cycle')[0];
+    const mutual = effects('function a() { b(); } function b() { props.x = 1; a(); } a();').filter((fact) => fact.kind === 'cycle')[0];
+    const unrelated = effects('props.x = 1; function idle() { idle(); } idle(); props.x = 1;').filter((fact) => fact.kind === 'cycle')[0];
+    expect([direct, mutual, unrelated].map((fact) => [fact.roots.length, Object.isFrozen(fact.roots)])).toEqual([[1, true], [1, true], [0, true]]);
+  });
+
+  it('keeps cycle roots invocation-specific, ordered, and non-global', () => {
+    const cycles = multiRootEffects('function f(value) { value.x = 1; f(value); } f(props); f(other);').filter((fact) => fact.kind === 'cycle');
+    expect(cycles.map((fact) => [fact.roots.map((root: { name?: string }) => root.name), Object.isFrozen(fact.roots)])).toEqual([[['props'], true], [['other'], true]]);
   });
 });

--- a/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
@@ -200,6 +200,12 @@ describe('ordered debt evaluator (MOR-1720)', () => {
     expect(nested.map((fact) => fact.roots.length)).toEqual([1]);
   });
 
+  it('treats absent object-spread provenance as immutable empty roots', () => {
+    expect(() => effects('const safe = 0; function empty() {} sink({ ...null }); sink({ ...0 }); sink({ ...safe }); sink({ ...empty() });')).not.toThrow();
+    const mixed = effects('function f(value) { delete value.x; } f({ ...props, ...null }); f({ ...0, ...props }); f({ x: { ...props, ...0 } });');
+    expect(mixed.map((fact) => [fact.kind, fact.roots.length, Object.isFrozen(fact.roots)])).toEqual([['mutation', 1, true], ['mutation', 1, true], ['mutation', 1, true]]);
+  });
+
   it('attaches only active effect roots to zero-argument recursive cycles', () => {
     const direct = effects('function direct() { props.x = 1; direct(); } direct();').filter((fact) => fact.kind === 'cycle')[0];
     const mutual = effects('function a() { b(); } function b() { props.x = 1; a(); } a();').filter((fact) => fact.kind === 'cycle')[0];

--- a/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-evaluator.test.ts
@@ -206,6 +206,16 @@ describe('ordered debt evaluator (MOR-1720)', () => {
     expect(mixed.map((fact) => [fact.kind, fact.roots.length, Object.isFrozen(fact.roots)])).toEqual([['mutation', 1, true], ['mutation', 1, true], ['mutation', 1, true]]);
   });
 
+  it('retains direct and nested rest roots in execution order', () => {
+    const cases = [
+      effects('function f({ ...rest }) { rest.x = 1; sink(rest); delete rest.x; } f(props);'),
+      effects('function f([ ...rest ]) { rest[0] = 1; sink(rest); delete rest[0]; } f(props);'),
+      effects('function f({ nested: { ...rest } }) { rest.x = 1; sink(rest); delete rest.x; } f({ nested: { ...props } });'),
+    ];
+    for (const result of cases) expect(result.map((fact) => [fact.kind, fact.roots.length, fact.targetRoots?.length ?? 0, fact.escapeRoots?.length ?? 0]))
+      .toEqual([['mutation', 1, 1, 0], ['escape', 1, 0, 1], ['mutation', 1, 1, 0]]);
+  });
+
   it('attaches only active effect roots to zero-argument recursive cycles', () => {
     const direct = effects('function direct() { props.x = 1; direct(); } direct();').filter((fact) => fact.kind === 'cycle')[0];
     const mutual = effects('function a() { b(); } function b() { props.x = 1; a(); } a();').filter((fact) => fact.kind === 'cycle')[0];


### PR DESCRIPTION
## Summary
- preserve exposed-root provenance through anonymous object and array spreads, including rest bindings
- retain direct tracked roots for object and array rest bindings without materialized fields or items
- attach roots from active recursive execution paths to direct and mutual zero-argument cycle facts
- treat nullish and nontracked object-spread inputs as empty immutable provenance, while retaining roots for mixed and nested tracked spreads

## Validation
- based on `origin/main` `814cdb8482034c46718816dc9d62e1d3f23c2717`
- `npm --prefix frontend test -- --run src/__tests__/control-feedback-debt-evaluator.test.ts` (34 tests)
- `npm --prefix frontend test -- --maxWorkers=2`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run lint:boundaries`
- `npm --prefix frontend run i18n:check`
- `npm --prefix frontend run build`

Linear: MOR-1728

## Integration note
MOR-1716 remains in open PR #2671. A read-only isolated overlay was attempted, but its branch has diverged in the same evaluator/test files and clean cherry-pick conflicts; no mapper changes or conflict resolution were made.