### PR TITLE
fix(MOR-1729): separate bipolar keyboard step

### DIFF
--- a/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
@@ -188,9 +188,7 @@
   function handleKeyDown(e: KeyboardEvent) {
     if (disabled) return;
 
-    const keyboardIncrement = keyboardStep && keyboardStep > 0
-      ? (e.shiftKey ? keyboardStep / fineStepDivisor : keyboardStep)
-      : null;
+    const keyboardIncrement = getKeyboardIncrement(e.shiftKey);
     const newValue = keyboardIncrement === null
       ? handleKeyboardStep(localValue, e.key, step, fineStepDivisor, min, max, e.shiftKey)
       : handleBipolarKeyboardStep(localValue, e.key, keyboardIncrement);
@@ -198,6 +196,22 @@
       e.preventDefault();
       emitChange(newValue, false, keyboardIncrement !== null);
     }
+  }
+
+  function getKeyboardIncrement(shiftKey: boolean): number | null {
+    if (keyboardStep === undefined) return null;
+    if (!isLatticeCompatible(keyboardStep)) return isLatticeCompatible(step) ? step : null;
+
+    const increment = shiftKey ? keyboardStep / fineStepDivisor : keyboardStep;
+    return isLatticeCompatible(increment) ? increment : step;
+  }
+
+  function isLatticeCompatible(increment: number): boolean {
+    return Number.isFinite(increment)
+      && increment > 0
+      && Number.isFinite(step)
+      && step > 0
+      && Number.isInteger(increment / step);
   }
 
   function handleBipolarKeyboardStep(currentValue: number, key: string, increment: number): number | null {

--- a/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
+++ b/frontend/src/components-v2/controls/value-control/BipolarRenderer.svelte
@@ -19,6 +19,8 @@
     min: number;
     max: number;
     step: number;
+    /** Larger increment for keyboard gestures; step remains the radio value lattice. */
+    keyboardStep?: number;
     defaultValue?: number;
     fineStepDivisor?: number;
     label: string;
@@ -44,6 +46,7 @@
     min,
     max,
     step,
+    keyboardStep,
     defaultValue = 0,
     fineStepDivisor = 10,
     label,
@@ -119,11 +122,12 @@
     return ((v: number) => onChange(v)) as (...args: unknown[]) => void;
   });
 
-  function emitChange(newValue: number, immediate = false) {
-    if (newValue !== localValue) {
+  function emitChange(newValue: number, immediate = false, emitWhenLocalValueChanges = false) {
+    const localValueChanged = newValue !== localValue;
+    if (localValueChanged) {
       localValue = newValue;
     }
-    if (newValue !== value) {
+    if (newValue !== value || (emitWhenLocalValueChanges && localValueChanged)) {
       if (immediate) {
         onChange(newValue);
       } else {
@@ -184,10 +188,32 @@
   function handleKeyDown(e: KeyboardEvent) {
     if (disabled) return;
 
-    const newValue = handleKeyboardStep(localValue, e.key, step, fineStepDivisor, min, max, e.shiftKey);
+    const keyboardIncrement = keyboardStep && keyboardStep > 0
+      ? (e.shiftKey ? keyboardStep / fineStepDivisor : keyboardStep)
+      : null;
+    const newValue = keyboardIncrement === null
+      ? handleKeyboardStep(localValue, e.key, step, fineStepDivisor, min, max, e.shiftKey)
+      : handleBipolarKeyboardStep(localValue, e.key, keyboardIncrement);
     if (newValue !== null) {
       e.preventDefault();
-      emitChange(newValue);
+      emitChange(newValue, false, keyboardIncrement !== null);
+    }
+  }
+
+  function handleBipolarKeyboardStep(currentValue: number, key: string, increment: number): number | null {
+    switch (key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        return clamp(defaultValue + Math.round((currentValue + increment - defaultValue) / increment) * increment, min, max);
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        return clamp(defaultValue + Math.round((currentValue - increment - defaultValue) / increment) * increment, min, max);
+      case 'Home':
+        return min;
+      case 'End':
+        return max;
+      default:
+        return null;
     }
   }
 

--- a/frontend/src/components-v2/controls/value-control/ValueControl.svelte
+++ b/frontend/src/components-v2/controls/value-control/ValueControl.svelte
@@ -10,6 +10,8 @@
     min: number;
     max: number;
     step: number;
+    /** Larger increment for keyboard gestures; step remains the radio value lattice. */
+    keyboardStep?: number;
     defaultValue?: number;
     fineStepDivisor?: number;
     label: string;
@@ -57,6 +59,7 @@
     min,
     max,
     step,
+    keyboardStep,
     defaultValue,
     fineStepDivisor = 10,
     label,
@@ -99,6 +102,7 @@
     min,
     max,
     step,
+    keyboardStep,
     defaultValue,
     fineStepDivisor,
     label,

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
@@ -335,6 +335,47 @@ describe('BipolarRenderer', () => {
     expect(onChange.mock.calls.flat().every((value) => Number.isInteger(value))).toBe(true);
   });
 
+  it.each([0, -50, Number.NaN, 2.5])('falls back to the declared lattice for invalid keyboardStep %s', (keyboardStep) => {
+    const onChange = vi.fn();
+    const target = mountControl({
+      value: 0,
+      min: -9999,
+      max: 9999,
+      step: 5,
+      defaultValue: 0,
+      keyboardStep,
+      label: 'RIT',
+      renderer: 'bipolar',
+      debounceMs: 0,
+      onChange,
+    });
+
+    getSlider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+
+  it('does not emit NaN for a non-finite keyboardStep', () => {
+    const onChange = vi.fn();
+    const target = mountControl({
+      value: 0,
+      min: -9999,
+      max: 9999,
+      step: 5,
+      defaultValue: 0,
+      keyboardStep: Infinity,
+      label: 'RIT',
+      renderer: 'bipolar',
+      debounceMs: 0,
+      onChange,
+    });
+
+    getSlider(target).dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(onChange).toHaveBeenCalledWith(5);
+    expect(onChange.mock.calls.flat().every(Number.isFinite)).toBe(true);
+  });
+
   it('renders polarity markers', () => {
     const target = mountControl({
       value: 0,

--- a/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
+++ b/frontend/src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
@@ -281,6 +281,60 @@ describe('HBarRenderer', () => {
 });
 
 describe('BipolarRenderer', () => {
+  it('uses keyboardStep for origin-anchored bipolar keyboard gestures', () => {
+    const onChange = vi.fn();
+    const target = mountControl({
+      value: 0,
+      min: -9999,
+      max: 9999,
+      step: 1,
+      defaultValue: 0,
+      keyboardStep: 50,
+      label: 'RIT',
+      renderer: 'bipolar',
+      debounceMs: 0,
+      onChange,
+    });
+    const slider = getSlider(target);
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(onChange.mock.calls).toEqual([[50], [0], [-50]]);
+
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(onChange.mock.calls.slice(-3)).toEqual([[-9999], [9999], [9999]]);
+  });
+
+  it('keeps pointer and wheel interaction on the radio lattice', () => {
+    const onChange = vi.fn();
+    const target = mountControl({
+      value: 0,
+      min: -9999,
+      max: 9999,
+      step: 1,
+      defaultValue: 0,
+      keyboardStep: 50,
+      label: 'RIT',
+      renderer: 'bipolar',
+      debounceMs: 0,
+      onChange,
+    });
+    const slider = getSlider(target);
+    const container = target.querySelector('.vc-bipolar') as HTMLDivElement;
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({ left: 0, width: 100 } as DOMRect);
+    Object.assign(slider, { setPointerCapture: vi.fn(), releasePointerCapture: vi.fn() });
+
+    slider.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, clientX: 50.01, bubbles: true }));
+    slider.dispatchEvent(new WheelEvent('wheel', { deltaY: -1, bubbles: true, cancelable: true }));
+
+    expect(onChange.mock.calls.flat().every((value) => Number.isInteger(value))).toBe(true);
+  });
+
   it('renders polarity markers', () => {
     const target = mountControl({
       value: 0,


### PR DESCRIPTION
Linear: MOR-1729

## Summary
- add optional keyboardStep for bipolar keyboard gestures
- preserve step for pointer and wheel radio lattice interaction
- snap keyboard gestures to defaultValue and retain exact endpoints

## Verification
- npm test -- --run src/components-v2/controls/value-control/__tests__/ValueControl.test.ts
- npm run check
- npm run lint
- npm run lint:boundaries
- npm run i18n:check
- npm run build

Full frontend `npm test -- --maxWorkers=2` was run to completion: 358 files / 7774 tests passed; 6 failures are pre-existing in `src/lib/runtime/tx-controller/__tests__/app-host.test.ts` (Svelte lifecycle context behavior), outside this change.