### PR TITLE
fix(MOR-1730): validate exact RIT panel domain

### DIFF
--- a/frontend/src/components-v2/panels/RitXitPanel.svelte
+++ b/frontend/src/components-v2/panels/RitXitPanel.svelte
@@ -3,6 +3,7 @@
   import { HardwareButton, HardwarePlainButton } from '../../lib/Button';
   import { formatOffsetKHz, shouldShowPanel } from './rit-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
+  import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
 
   import { deriveRitXitProps, getRitXitHandlers } from '$lib/runtime/adapters/panel-adapters';
 
@@ -15,6 +16,7 @@
   let xitOffset = $derived(p.xitOffset);
   let hasRit = $derived(p.hasRit);
   let hasXit = $derived(p.hasXit);
+  let ritDomain = $derived(p.ritDomain);
   const onRitToggle = handlers.onRitToggle;
   const onXitToggle = handlers.onXitToggle;
   const onRitOffsetChange = handlers.onRitOffsetChange;
@@ -23,6 +25,8 @@
 
   let visible = $derived(shouldShowPanel(hasRit, hasXit));
   let offsetValue = $derived(xitActive && !ritActive ? xitOffset : ritOffset);
+  let exactOffset = $derived(ritDomain ? decodeControlDomain(ritDomain, offsetValue) : null);
+  let canAdjustOffset = $derived(ritDomain ? exactOffset !== null : Number.isFinite(offsetValue));
   const ritShortcut = getShortcutHint('toggle_rit');
   const xitShortcut = getShortcutHint('toggle_xit');
   const clearShortcut = getShortcutHint('clear_rit_xit');
@@ -40,6 +44,12 @@
   }
 
   function handleOffsetChange(value: number) {
+    if (ritDomain) {
+      const display = decodeControlDomain(ritDomain, value);
+      const encoded = display === null ? null : encodeControlDomain(ritDomain, display);
+      if (encoded === null) return;
+      value = encoded;
+    }
     if (xitActive && !ritActive) {
       onXitOffsetChange(value);
       return;
@@ -62,19 +72,23 @@
           <span class="offset" class:active={xitActive}>{formatOffsetDisplay(xitOffset)}</span>
         </div>
       {/if}
-      <ValueControl
-        label="Offset"
-        value={offsetValue}
-        min={-9999}
-        max={9999}
-        step={50}
-        unit="kHz"
-        displayFn={formatOffsetDisplay}
-        renderer="bipolar"
-        accentColor="var(--v2-accent-cyan)"
-        onChange={handleOffsetChange}
-      variant="hardware-illuminated"
-      />
+      {#if canAdjustOffset}
+        <ValueControl
+          label="Offset"
+          value={offsetValue}
+          min={ritDomain?.raw_min ?? -9999}
+          max={ritDomain?.raw_max ?? 9999}
+          step={ritDomain?.raw_step ?? 50}
+          defaultValue={ritDomain?.raw_origin ?? 0}
+          keyboardStep={ritDomain ? 50 : undefined}
+          unit="kHz"
+          displayFn={formatOffsetDisplay}
+          renderer="bipolar"
+          accentColor="var(--v2-accent-cyan)"
+          onChange={handleOffsetChange}
+          variant="hardware-illuminated"
+        />
+      {/if}
       <div class="clear-row">
         <!-- action-button: momentary command, no sustained state -->
         <HardwarePlainButton onclick={onClear} title={clearShortcut} shortcutHint={clearShortcut}>CLEAR</HardwarePlainButton>

--- a/frontend/src/components-v2/panels/RitXitPanel.svelte
+++ b/frontend/src/components-v2/panels/RitXitPanel.svelte
@@ -4,6 +4,7 @@
   import { formatOffsetKHz, shouldShowPanel } from './rit-utils';
   import { getShortcutHint } from '../layout/shortcut-hints';
   import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
+  import type { ControlDomain } from '$lib/types/capabilities';
 
   import { deriveRitXitProps, getRitXitHandlers } from '$lib/runtime/adapters/panel-adapters';
 
@@ -25,8 +26,9 @@
 
   let visible = $derived(shouldShowPanel(hasRit, hasXit));
   let offsetValue = $derived(xitActive && !ritActive ? xitOffset : ritOffset);
-  let exactOffset = $derived(ritDomain ? decodeControlDomain(ritDomain, offsetValue) : null);
-  let canAdjustOffset = $derived(ritDomain ? exactOffset !== null : Number.isFinite(offsetValue));
+  let canAdjustOffset = $derived(ritDomain === undefined
+    ? Number.isFinite(offsetValue)
+    : ritDomain !== null && canonicalRaw(ritDomain, offsetValue) !== null);
   const ritShortcut = getShortcutHint('toggle_rit');
   const xitShortcut = getShortcutHint('toggle_xit');
   const clearShortcut = getShortcutHint('clear_rit_xit');
@@ -44,9 +46,9 @@
   }
 
   function handleOffsetChange(value: number) {
-    if (ritDomain) {
-      const display = decodeControlDomain(ritDomain, value);
-      const encoded = display === null ? null : encodeControlDomain(ritDomain, display);
+    if (ritDomain !== undefined) {
+      if (ritDomain === null) return;
+      const encoded = canonicalRaw(ritDomain, value);
       if (encoded === null) return;
       value = encoded;
     }
@@ -55,6 +57,16 @@
       return;
     }
     onRitOffsetChange(value);
+  }
+
+  function canonicalRaw(domain: ControlDomain, value: number): number | null {
+    try {
+      const display = decodeControlDomain(domain, value);
+      const encoded = display === null ? null : encodeControlDomain(domain, display);
+      return encoded !== null && Number.isSafeInteger(encoded) ? encoded : null;
+    } catch {
+      return null;
+    }
   }
 </script>
 
@@ -80,7 +92,7 @@
           max={ritDomain?.raw_max ?? 9999}
           step={ritDomain?.raw_step ?? 50}
           defaultValue={ritDomain?.raw_origin ?? 0}
-          keyboardStep={ritDomain ? 50 : undefined}
+          keyboardStep={ritDomain === undefined ? undefined : 50}
           unit="kHz"
           displayFn={formatOffsetDisplay}
           renderer="bipolar"

--- a/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
 import { formatOffset, formatOffsetKHz, shouldShowPanel } from '../rit-utils';
+import type { ControlDomain } from '$lib/types/capabilities';
+import { toRitXitProps } from '$lib/runtime/props/panel-props';
+
+const exactRitDomain: ControlDomain = {
+  mapping: 'identity', raw_min: -9999, raw_max: 9999, raw_step: 1, raw_origin: 0,
+  display_min: '-9999' as never, display_max: '9999' as never,
+  display_step: '1' as never, display_origin: '0' as never,
+  display_unit: 'Hz', quantization: 'reject', restoration: 'exact',
+};
 
 const mockProps = {
   ritActive: false,
@@ -9,6 +18,7 @@ const mockProps = {
   xitOffset: 0,
   hasRit: true,
   hasXit: true,
+  ritDomain: undefined as ControlDomain | null | undefined,
 };
 
 const mockHandlers = {
@@ -43,6 +53,7 @@ beforeEach(() => {
   Object.assign(mockProps, {
     ritActive: false, ritOffset: 0, xitActive: false, xitOffset: 0,
     hasRit: true, hasXit: true,
+    ritDomain: undefined,
   });
   mockHandlers.onRitToggle = vi.fn();
   mockHandlers.onXitToggle = vi.fn();
@@ -233,6 +244,55 @@ describe('RitXitPanel component', () => {
     vi.advanceTimersByTime(60);
 
     expect(mockHandlers.onXitOffsetChange).toHaveBeenCalled();
+  });
+
+  it('keeps the legacy control only when the RIT domain is absent', () => {
+    const target = mountPanel({ ritDomain: undefined });
+    expect(target.querySelector('[role="slider"]')?.getAttribute('aria-valuemin')).toBe('-9999');
+  });
+
+  it('fails closed when an advertised RIT domain is invalid', () => {
+    const target = mountPanel({ ritDomain: null });
+    expect(target.querySelector('[role="slider"]')).toBeNull();
+    expect(mockHandlers.onRitOffsetChange).not.toHaveBeenCalled();
+  });
+
+  it('uses the exact RIT lattice without emitting on initial zero', () => {
+    const target = mountPanel({ ritDomain: exactRitDomain, ritOffset: 0 });
+    const slider = target.querySelector<HTMLElement>('[role="slider"]')!;
+    expect(slider.getAttribute('aria-valuemin')).toBe('-9999');
+    expect(slider.getAttribute('aria-valuemax')).toBe('9999');
+    expect(mockHandlers.onRitOffsetChange).not.toHaveBeenCalled();
+
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    vi.advanceTimersByTime(60);
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    vi.advanceTimersByTime(60);
+    expect(mockHandlers.onRitOffsetChange.mock.calls).toEqual([[50], [0]]);
+  });
+
+  it('fails closed for an exact domain with an invalid current value or unavailable encoding', () => {
+    expect(mountPanel({ ritDomain: exactRitDomain, ritOffset: 10000 }).querySelector('[role="slider"]')).toBeNull();
+    expect(mountPanel({ ritDomain: { ...exactRitDomain, restoration: 'unavailable' }, ritOffset: 0 }).querySelector('[role="slider"]')).toBeNull();
+  });
+
+  it('keeps the XIT-leading intent route while encoding the exact RIT domain', () => {
+    const target = mountPanel({ ritDomain: exactRitDomain, ritActive: false, xitActive: true, xitOffset: 0 });
+    target.querySelector<HTMLElement>('[role="slider"]')!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    vi.advanceTimersByTime(60);
+    expect(mockHandlers.onXitOffsetChange).toHaveBeenCalledWith(50);
+  });
+});
+
+describe('RIT exact-domain mapper', () => {
+  it.each([null, 1, [], {}, { mapping: 'future' }, { mapping: 'identity', raw_origin: 0 }])('rejects advertised malformed domain %p', (rit) => {
+    expect(toRitXitProps(null, { controls: { rit } } as any).ritDomain).toBeNull();
+  });
+
+  it('distinguishes an absent domain from a validated exact domain', () => {
+    expect(toRitXitProps(null, null).ritDomain).toBeUndefined();
+    expect(toRitXitProps(null, { controls: {} } as any).ritDomain).toBeUndefined();
+    expect(toRitXitProps(null, { controls: { rit: exactRitDomain } } as any).ritDomain).toBe(exactRitDomain);
   });
 });
 

--- a/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
@@ -294,6 +294,20 @@ describe('RIT exact-domain mapper', () => {
     expect(toRitXitProps(null, { controls: {} } as any).ritDomain).toBeUndefined();
     expect(toRitXitProps(null, { controls: { rit: exactRitDomain } } as any).ritDomain).toBe(exactRitDomain);
   });
+
+  it.each([
+    { get controls() { throw new Error('controls getter'); } },
+    { controls: new Proxy({}, { getOwnPropertyDescriptor() { throw new Error('own key trap'); } }) },
+    { controls: Object.defineProperty({}, 'rit', { get() { throw new Error('rit getter'); } }) },
+    (() => {
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+      return { controls: proxy };
+    })(),
+  ])('fails closed without throwing for trapped domain acquisition', (caps) => {
+    expect(() => toRitXitProps(null, caps as any).ritDomain).not.toThrow();
+    expect(toRitXitProps(null, caps as any).ritDomain).toBeNull();
+  });
 });
 
 /**

--- a/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/RitXitPanel.isolated.test.ts
@@ -308,6 +308,17 @@ describe('RIT exact-domain mapper', () => {
     expect(() => toRitXitProps(null, caps as any).ritDomain).not.toThrow();
     expect(toRitXitProps(null, caps as any).ritDomain).toBeNull();
   });
+
+  it('fails closed for revoked capabilities before capability-tag lookup', () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+
+    expect(() => toRitXitProps(null, proxy as any)).not.toThrow();
+    const props = toRitXitProps(null, proxy as any);
+    expect(props.hasRit).toBe(false);
+    expect(props.hasXit).toBe(false);
+    expect(props.ritDomain).toBeNull();
+  });
 });
 
 /**

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -19,6 +19,7 @@ import {
   nrRawToDisplay,
   pbtRawToHz,
 } from '$lib/radio/filter-controls';
+import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
 import { isFieldAvailable, getFieldAvailability } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
 
@@ -492,7 +493,30 @@ export interface RitXitProps {
   hasRit: boolean;
   hasXit: boolean;
   /** Exact RIT control contract, when supplied by a normalized capability payload. */
-  ritDomain?: ControlDomain;
+  ritDomain: ControlDomain | null | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validatedRitDomain(caps: Capabilities | null): ControlDomain | null | undefined {
+  const controls = caps?.controls;
+  if (controls === undefined) return undefined;
+  if (!isRecord(controls)) return null;
+  if (!Object.hasOwn(controls, 'rit')) return undefined;
+  const candidate = controls.rit;
+  if (!isRecord(candidate)) return null;
+
+  try {
+    const domain = candidate as ControlDomain;
+    if (!['identity', 'linear', 'centered', 'lookup'].includes(domain.mapping)
+      || !Number.isSafeInteger(domain.raw_origin)) return null;
+    const display = decodeControlDomain(domain, domain.raw_origin);
+    return display !== null && encodeControlDomain(domain, display) === domain.raw_origin ? domain : null;
+  } catch {
+    return null;
+  }
 }
 
 export function toRitXitProps(
@@ -502,16 +526,19 @@ export function toRitXitProps(
   const ritOnAvailable = topFieldAvailable(state, 'ritOn');
   const ritFreqAvailable = topFieldAvailable(state, 'ritFreq');
   const ritTxAvailable = topFieldAvailable(state, 'ritTx');
-  const ritControl = caps?.controls?.rit;
-  return {
+  const props = {
     ritActive: state?.ritOn ?? false,
     ritOffset: ritFreqAvailable ? (state?.ritFreq ?? Number.NaN) : Number.NaN,
     xitActive: state?.ritTx ?? false,
     xitOffset: ritFreqAvailable ? (state?.ritFreq ?? Number.NaN) : Number.NaN,
     hasRit: hasCap(caps, 'rit') && ritOnAvailable,
     hasXit: hasCap(caps, 'xit') && ritTxAvailable,
-    ritDomain: ritControl && 'mapping' in ritControl ? ritControl : undefined,
   };
+  Object.defineProperty(props, 'ritDomain', {
+    value: validatedRitDomain(caps),
+    enumerable: false,
+  });
+  return props as RitXitProps;
 }
 
 /* ── Mode Panel ──────────────────────────────────────────────── */

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -501,14 +501,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function validatedRitDomain(caps: Capabilities | null): ControlDomain | null | undefined {
-  const controls = caps?.controls;
-  if (controls === undefined) return undefined;
-  if (!isRecord(controls)) return null;
-  if (!Object.hasOwn(controls, 'rit')) return undefined;
-  const candidate = controls.rit;
-  if (!isRecord(candidate)) return null;
-
   try {
+    const controls = caps?.controls;
+    if (controls === undefined) return undefined;
+    if (!isRecord(controls)) return null;
+    if (!Object.hasOwn(controls, 'rit')) return undefined;
+    const candidate = controls.rit;
+    if (!isRecord(candidate)) return null;
     const domain = candidate as ControlDomain;
     if (!['identity', 'linear', 'centered', 'lookup'].includes(domain.mapping)
       || !Number.isSafeInteger(domain.raw_origin)) return null;

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ServerState, ReceiverState } from '$lib/types/state';
-import type { Capabilities, FilterModeConfig } from '$lib/types/capabilities';
+import type { Capabilities, ControlDomain, FilterModeConfig } from '$lib/types/capabilities';
 import {
   deriveIfShift,
   nbDepthRawToDisplay,
@@ -491,6 +491,8 @@ export interface RitXitProps {
   xitOffset: number;
   hasRit: boolean;
   hasXit: boolean;
+  /** Exact RIT control contract, when supplied by a normalized capability payload. */
+  ritDomain?: ControlDomain;
 }
 
 export function toRitXitProps(
@@ -500,6 +502,7 @@ export function toRitXitProps(
   const ritOnAvailable = topFieldAvailable(state, 'ritOn');
   const ritFreqAvailable = topFieldAvailable(state, 'ritFreq');
   const ritTxAvailable = topFieldAvailable(state, 'ritTx');
+  const ritControl = caps?.controls?.rit;
   return {
     ritActive: state?.ritOn ?? false,
     ritOffset: ritFreqAvailable ? (state?.ritFreq ?? Number.NaN) : Number.NaN,
@@ -507,6 +510,7 @@ export function toRitXitProps(
     xitOffset: ritFreqAvailable ? (state?.ritFreq ?? Number.NaN) : Number.NaN,
     hasRit: hasCap(caps, 'rit') && ritOnAvailable,
     hasXit: hasCap(caps, 'xit') && ritTxAvailable,
+    ritDomain: ritControl && 'mapping' in ritControl ? ritControl : undefined,
   };
 }
 

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -34,7 +34,11 @@ function activeReceiverKey(state: ServerState): 'main' | 'sub' {
 }
 
 function hasCap(caps: Capabilities | null, name: string): boolean {
-  return caps?.capabilities?.includes(name) ?? false;
+  try {
+    return caps?.capabilities?.includes(name) ?? false;
+  } catch {
+    return false;
+  }
 }
 
 function topFieldAvailable(state: ServerState | null, field: string): boolean {

--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -74,7 +74,17 @@ interface FreqRange {
 }
 
 interface Capabilities {
+  controls?: Record<string, unknown>;
   freqRanges?: FreqRange[];
+}
+
+interface ExactRitDomain {
+  raw_min: number;
+  raw_max: number;
+  raw_step: number;
+  raw_origin: number;
+  mapping: string;
+  restoration: string;
 }
 
 interface WsCommandRecord {
@@ -655,8 +665,20 @@ function bandCode(capabilities: Capabilities, bandName: string): number | undefi
   return undefined;
 }
 
+function exactRitDomain(capabilities: Capabilities): ExactRitDomain | null {
+  const candidate = capabilities.controls?.rit;
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+  const domain = candidate as Partial<ExactRitDomain>;
+  return domain.restoration === 'exact'
+    && typeof domain.mapping === 'string'
+    && [domain.raw_min, domain.raw_max, domain.raw_step, domain.raw_origin].every(Number.isSafeInteger)
+    ? domain as ExactRitDomain
+    : null;
+}
+
 async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]> {
   const expected20mCode = bandCode(capabilities, '20m');
+  const ritDomain = exactRitDomain(capabilities);
   return [
     {
       panel: 'RF FRONT END',
@@ -846,20 +868,44 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
     {
       panel: 'RIT / XIT',
       control: 'Offset',
-      action: 'nudge +1 step',
-      expected: 'set_rit_frequency { freq: <number> }',
+      action: ritDomain ? 'exact 50 Hz keyboard lattice' : 'nudge +1 step',
+      expected: ritDomain ? 'set_rit_frequency { freq: 50, 0, -50, -9999, 9999 }' : 'set_rit_frequency { freq: <number> }',
       locate: (page) => page.getByRole('slider', { name: 'Offset', exact: true }),
       onMissing: async () => ({
         status: 'FAIL',
         actual: 'control missing from DOM',
         details: 'RIT / XIT panel did not render the shared Offset slider.',
       }),
+      prepare: ritDomain ? async (ctx) => {
+        await sendWsCommand(ctx.page, 'set_rit_frequency', { freq: 0 });
+        await waitForState(ctx.request, (state) => state.ritFreq === 0);
+      } : undefined,
       act: async (_page, locator) => {
         await locator.focus();
         await locator.press('ArrowRight');
+        if (ritDomain) {
+          await locator.press('ArrowLeft');
+          await locator.press('ArrowLeft');
+          await locator.press('ArrowRight');
+          await locator.press('ArrowUp');
+          await locator.press('ArrowDown');
+          await locator.press('Home');
+          await locator.press('End');
+        }
       },
-      verify: (_ctx, commands) =>
-        (() => {
+      verify: (_ctx, commands) => {
+        if (ritDomain) {
+          const frequencies = commands
+            .filter((command) => command.name === 'set_rit_frequency')
+            .map((command) => command.params.freq);
+          const expected = [50, 0, -50, 0, 50, 0, -9999, 9999];
+          return frequencies.every(Number.isSafeInteger)
+            && frequencies.every((frequency) => frequency! >= ritDomain.raw_min && frequency! <= ritDomain.raw_max)
+            && JSON.stringify(frequencies) === JSON.stringify(expected)
+            ? { status: 'PASS' as const, actual: formatCommandList(commands) }
+            : { status: 'FAIL' as const, actual: formatCommandList(commands), details: `Expected exact RIT lattice ${expected.join(', ')}` };
+        }
+        return (() => {
           const match = commands.find(
             (command) => command.name === 'set_rit_frequency' && typeof command.params.freq === 'number',
           );
@@ -873,7 +919,8 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
             status: 'FAIL' as const,
             actual: formatCommandList(commands),
           };
-        })(),
+        })();
+      },
       cleanup: async (ctx) => {
         await sendRestoreCommands(ctx.page, ctx.request, [
           { name: 'set_rit_frequency', params: { freq: ctx.originalState.ritFreq } },

--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -74,17 +74,7 @@ interface FreqRange {
 }
 
 interface Capabilities {
-  controls?: Record<string, unknown>;
   freqRanges?: FreqRange[];
-}
-
-interface ExactRitDomain {
-  raw_min: number;
-  raw_max: number;
-  raw_step: number;
-  raw_origin: number;
-  mapping: string;
-  restoration: string;
 }
 
 interface WsCommandRecord {
@@ -665,20 +655,8 @@ function bandCode(capabilities: Capabilities, bandName: string): number | undefi
   return undefined;
 }
 
-function exactRitDomain(capabilities: Capabilities): ExactRitDomain | null {
-  const candidate = capabilities.controls?.rit;
-  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
-  const domain = candidate as Partial<ExactRitDomain>;
-  return domain.restoration === 'exact'
-    && typeof domain.mapping === 'string'
-    && [domain.raw_min, domain.raw_max, domain.raw_step, domain.raw_origin].every(Number.isSafeInteger)
-    ? domain as ExactRitDomain
-    : null;
-}
-
 async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]> {
   const expected20mCode = bandCode(capabilities, '20m');
-  const ritDomain = exactRitDomain(capabilities);
   return [
     {
       panel: 'RF FRONT END',
@@ -868,44 +846,20 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
     {
       panel: 'RIT / XIT',
       control: 'Offset',
-      action: ritDomain ? 'exact 50 Hz keyboard lattice' : 'nudge +1 step',
-      expected: ritDomain ? 'set_rit_frequency { freq: 50, 0, -50, -9999, 9999 }' : 'set_rit_frequency { freq: <number> }',
+      action: 'nudge +1 step',
+      expected: 'set_rit_frequency { freq: <number> }',
       locate: (page) => page.getByRole('slider', { name: 'Offset', exact: true }),
       onMissing: async () => ({
         status: 'FAIL',
         actual: 'control missing from DOM',
         details: 'RIT / XIT panel did not render the shared Offset slider.',
       }),
-      prepare: ritDomain ? async (ctx) => {
-        await sendWsCommand(ctx.page, 'set_rit_frequency', { freq: 0 });
-        await waitForState(ctx.request, (state) => state.ritFreq === 0);
-      } : undefined,
       act: async (_page, locator) => {
         await locator.focus();
         await locator.press('ArrowRight');
-        if (ritDomain) {
-          await locator.press('ArrowLeft');
-          await locator.press('ArrowLeft');
-          await locator.press('ArrowRight');
-          await locator.press('ArrowUp');
-          await locator.press('ArrowDown');
-          await locator.press('Home');
-          await locator.press('End');
-        }
       },
-      verify: (_ctx, commands) => {
-        if (ritDomain) {
-          const frequencies = commands
-            .filter((command) => command.name === 'set_rit_frequency')
-            .map((command) => command.params.freq);
-          const expected = [50, 0, -50, 0, 50, 0, -9999, 9999];
-          return frequencies.every(Number.isSafeInteger)
-            && frequencies.every((frequency) => frequency! >= ritDomain.raw_min && frequency! <= ritDomain.raw_max)
-            && JSON.stringify(frequencies) === JSON.stringify(expected)
-            ? { status: 'PASS' as const, actual: formatCommandList(commands) }
-            : { status: 'FAIL' as const, actual: formatCommandList(commands), details: `Expected exact RIT lattice ${expected.join(', ')}` };
-        }
-        return (() => {
+      verify: (_ctx, commands) =>
+        (() => {
           const match = commands.find(
             (command) => command.name === 'set_rit_frequency' && typeof command.params.freq === 'number',
           );
@@ -919,8 +873,7 @@ async function buildAuditCases(capabilities: Capabilities): Promise<AuditCase[]>
             status: 'FAIL' as const,
             actual: formatCommandList(commands),
           };
-        })();
-      },
+        })(),
       cleanup: async (ctx) => {
         await sendRestoreCommands(ctx.page, ctx.request, [
           { name: 'set_rit_frequency', params: { freq: ctx.originalState.ritFreq } },


### PR DESCRIPTION
Linear: MOR-1730

## Summary
- validate `controls.rit` as a fail-closed tri-state exact-domain contract
- contain hostile getters, proxies, and revoked capabilities during acquisition
- preserve legacy controls only when the entry is genuinely absent

## Verification
- focused panel, props, control-domain, and adapter tests: 186 passed
- full frontend: 360 files / 7,824 tests passed with maxWorkers=2
- check, lint, boundaries, i18n, build, diff, and privacy checks

No Chromium claim: the composed layout mounts the semantic RIT/XIT surface, outside this dependency-owned fallback-panel slice.