### PR TITLE
fix(MOR-1731): consume exact semantic RIT domain

### DIFF
--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -34,6 +34,7 @@
     bindSemanticSurfaceHandlers, getPendingFrequencyHz,
     getPendingFilterSelection, getPendingNbOn, getPendingNrOn, getPendingPreampLevel,
   } from '$lib/runtime/adapters/panel-adapters';
+  import { toRitXitProps } from '$lib/runtime/props/panel-props';
   import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
   import {
     compositionSurfaces, useSurfacePlan, zoneShowsSurface,
@@ -337,6 +338,10 @@
    */
   const ritXitIntents = semanticHandlers.ritXit;
   const scanIntents = semanticHandlers.scan;
+  /** MOR-1731: consume the shared validated tri-state boundary. `undefined`
+   * keeps legacy servers compatible; `null` is the adapter's fail-closed
+   * result for present-but-unusable metadata. */
+  let ritDomain = $derived(toRitXitProps(runtime.state, runtime.caps).ritDomain);
   /**
    * MOR-1310 (slice 9B). The CW intent vocabulary, composed from the SHIPPED
    * `makeCwPanelHandlers` rather than forked. MOR-1606 wires its existing
@@ -1125,7 +1130,7 @@
   {#snippet ritXitScanSurface()}
     {#if view?.ritXit || view?.scan}
       <RitXitScanSurface
-        {view}
+        {view} {ritDomain}
         onRitToggle={ritXitIntents.onRitToggle}
         onXitToggle={ritXitIntents.onXitToggle}
         onRitOffsetChange={ritXitIntents.onRitOffsetChange}

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -24,7 +24,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
-import type { Capabilities } from '$lib/types/capabilities';
+import type { Capabilities, ControlDomain } from '$lib/types/capabilities';
 import type { ServerState } from '$lib/types/state';
 
 type Snapshot = {
@@ -128,7 +128,9 @@ function liveState(over: Partial<ServerState> = {}): ServerState {
   } as unknown as ServerState;
 }
 
-const liveCaps = (tags: readonly string[]): Capabilities => ({
+const liveCaps = (
+  tags: readonly string[], controls?: Capabilities['controls'],
+): Capabilities => ({
   model: 'fixture', scope: false, audio: false, tx: true,
   capabilities: tags, receivers: 2, vfoScheme: 'main_sub', freqRanges: [], modes: [], filters: [],
   audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
@@ -136,7 +138,15 @@ const liveCaps = (tags: readonly string[]): Capabilities => ({
   txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
   scopeSource: null, audioFftAvailable: false,
   stateContractVersion: 1, providerGeneration: 0,
+  ...(controls === undefined ? {} : { controls }),
 } as unknown as Capabilities);
+
+const FTX_RIT_DOMAIN: ControlDomain = {
+  mapping: 'identity', raw_min: -9999, raw_max: 9999, raw_step: 1, raw_origin: 0,
+  display_min: '-9999' as never, display_max: '9999' as never,
+  display_step: '1' as never, display_origin: '0' as never, display_unit: 'Hz',
+  quantization: 'reject', restoration: 'exact',
+};
 
 /** `rit`/`xit` capability tags make the ritXit group present; the explicit
  *  scan commands additionally require the declared `scan` capability. */
@@ -217,6 +227,114 @@ describe('O1: editing via either gate reaches the wire as the identical command'
     for (const name of ['onScanStart', 'onScanStop', 'onResumeChange']) {
       expect(typeof (real.makeScanHandlers() as Record<string, unknown>)[name]).toBe('function');
     }
+  });
+});
+
+describe('MOR-1731 exact RIT domain', () => {
+  function renderExact(state: ServerState = liveState()): HTMLInputElement {
+    const caps = liveCaps(RIT_XIT_TAGS, { rit: FTX_RIT_DOMAIN });
+    h.caps = caps;
+    setCapabilities(caps);
+    useState(state);
+    render();
+    return q<HTMLInputElement>('[data-testid="ritxit-offset"] input')!;
+  }
+
+  function pressAt(raw: number, key: string): void {
+    if (component) unmount(component);
+    component = null;
+    document.body.innerHTML = '';
+    const input = renderExact(liveState({ ritFreq: raw }));
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+    input.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    flushSync();
+  }
+
+  it('renders exact zero on the declared one-Hz native lattice without an intent', () => {
+    const input = renderExact(liveState({ ritFreq: 0 }));
+    expect([input.min, input.max, input.step, input.value]).toEqual(['-9999', '9999', '1', '0']);
+    expect(el('ritxit-offset-value')!.textContent).toBe('0');
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['horizontal', 'ArrowRight', 'ArrowLeft'],
+    ['vertical', 'ArrowUp', 'ArrowDown'],
+  ])('separates %s 50 Hz gestures from the native lattice and preserves endpoints',
+    (_axis, increase, decrease) => {
+      pressAt(0, increase);
+      pressAt(50, decrease);
+      pressAt(0, decrease);
+      pressAt(-50, increase);
+      pressAt(0, 'Home');
+      pressAt(0, 'End');
+      expect(vi.mocked(sendCommand).mock.calls).toEqual([
+        ['set_rit_frequency', { freq: 50 }],
+        ['set_rit_frequency', { freq: 0 }],
+        ['set_rit_frequency', { freq: -50 }],
+        ['set_rit_frequency', { freq: 0 }],
+        ['set_rit_frequency', { freq: -9999 }],
+        ['set_rit_frequency', { freq: 9999 }],
+      ]);
+    });
+
+  it.each([
+    ['RIT-leading', { ritOn: true, ritTx: false }, 50],
+    ['XIT-leading', { ritOn: false, ritTx: true }, -50],
+  ] as const)('%s exact input reaches exactly one existing offset handler', (_name, flags, freq) => {
+    const input = renderExact(liveState(flags));
+    input.value = String(freq);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).toHaveBeenCalledExactlyOnceWith('set_rit_frequency', { freq });
+  });
+
+  it('keeps the legacy constants when capability domains are absent', () => {
+    render();
+    const input = q<HTMLInputElement>('[data-testid="ritxit-offset"] input')!;
+    expect([input.min, input.max, input.step]).toEqual(['-9999', '9999', '50']);
+  });
+
+  it.each([
+    ['malformed domain', liveState(), { rit: { mapping: 'identity' } }],
+    ['invalid current raw value', liveState({ ritFreq: 10000 }), { rit: FTX_RIT_DOMAIN }],
+    ['failed exact encode', liveState({ ritFreq: 0 }), { rit: {
+      ...FTX_RIT_DOMAIN, raw_min: -10000, raw_max: 10000, raw_step: 2,
+      display_min: '-10000' as never, display_max: '10000' as never, display_step: '2' as never,
+    } }],
+  ] as const)('%s refuses adjustment and emits nothing', (_name, state, controls) => {
+    const caps = liveCaps(RIT_XIT_TAGS, controls as never);
+    h.caps = caps;
+    setCapabilities(caps);
+    useState(state);
+    render();
+    const input = q<HTMLInputElement>('[data-testid="ritxit-offset"] input')!;
+    if (_name !== 'failed exact encode') expect(input.disabled).toBe(true);
+    input.value = '1';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unknown receiver', liveState({ active: undefined } as Partial<ServerState>)],
+    ['wrong VFO', liveState({ active: 'OTHER' } as never)],
+    ['unread offset', (() => { const state = liveState({ ritFreq: undefined }); return state; })()],
+    ['stale offset', (() => {
+      const state = liveState();
+      return { ...state, fieldStatus: { ...state.fieldStatus,
+        ritFreq: { ...fresh, freshness: 'stale', availability: 'stale' } } } as ServerState;
+    })()],
+  ] as const)('%s emits no exact-domain offset intent', (_name, state) => {
+    const input = renderExact(state);
+    expect(input.disabled).toBe(true);
+    input.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'ArrowRight', bubbles: true, cancelable: true,
+    }));
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(sendCommand).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/semantic/RitXitScanSurface.svelte
+++ b/frontend/src/semantic/RitXitScanSurface.svelte
@@ -18,10 +18,9 @@
   `set_rit_frequency` command — proven end to end, not merely asserted, in
   `__tests__/semantic-ritxit-scan-wiring.component.test.ts`.
 
-  O2. The -9999..9999 Hz / 50 Hz-step slider bounds are UI convenience
-  (`RitXitPanel`'s own `ValueControl` bounds), not a radio fact — the X6200
-  no-UI-tables lesson kept them out of the 8A contract, so this surface
-  supplies them itself, unchanged from v2.
+  O2. Legacy servers retain the -9999..9999 Hz / 50 Hz-step slider contract.
+  When exact capability metadata is present, the validated domain supplies
+  the native lattice and exact decode/encode path instead (MOR-1731).
 
   WRONG-VFO GUARD (S3b lesson, MOR-1322 verify report). RIT/XIT offsets
   target whichever receiver the radio currently has ACTIVE, and neither
@@ -61,7 +60,7 @@
   import { pressedOf } from './pressed-of';
 
   export const UNKNOWN_TEXT = '—';
-  /** O2 — v2's own `RitXitPanel` bounds, verbatim. */
+  /** O2 — v2's own legacy `RitXitPanel` bounds, verbatim. */
   export const OFFSET_MIN = -9999;
   export const OFFSET_MAX = 9999;
   export const OFFSET_STEP = 50;
@@ -76,6 +75,9 @@
 </script>
 
 <script lang="ts">
+  import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
+  import { exactDecimalNumber } from '$lib/types/exact-decimal';
+  import type { ControlDomain } from '$lib/types/capabilities';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -88,10 +90,11 @@
     onScanStart?: (type: number) => void;
     onScanStop?: () => void;
     onResumeModeChange?: (mode: number) => void;
+    ritDomain?: ControlDomain | null;
   }
   let {
     view, onRitToggle, onXitToggle, onRitOffsetChange, onXitOffsetChange, onClear,
-    onScanStart, onScanStop, onResumeModeChange,
+    onScanStart, onScanStop, onResumeModeChange, ritDomain,
   }: Props = $props();
 
   let rx = $derived(view.ritXit);
@@ -100,8 +103,23 @@
    *  command fires — never what is displayed, since both facts read the
    *  identical register. */
   let xitLeads = $derived(rx !== undefined && isOn(rx.xitActive) && !isOn(rx.ritActive));
+  let offset = $derived(rx && (xitLeads ? rx.xitOffset : rx.ritOffset));
   /** Wrong-VFO guard (S3b) — see file header. */
   let activeKnown = $derived(view.activeReceiver.status === 'known');
+  let decodedOffset = $derived.by(() => {
+    if (!offset || !usable(offset) || offset.reading.status !== 'known') return null;
+    if (ritDomain === undefined) {
+      return Number.isFinite(offset.reading.value)
+        ? { value: offset.reading.value, text: String(offset.reading.value) } : null;
+    }
+    if (ritDomain === null) return null;
+    const text = decodeControlDomain(ritDomain, offset.reading.value);
+    if (text === null) return null;
+    const value = Number(text);
+    return Number.isFinite(value) ? { value, text } : null;
+  });
+  let canAdjustOffset = $derived(activeKnown && offset !== undefined
+    && usable(offset) && decodedOffset !== null && ritDomain !== null);
   let scanningOn = $derived(sc !== undefined && usable(sc.scanning)
     && sc.scanning.reading.status === 'known' && sc.scanning.reading.value === true);
   /** Local UI selection for the NEXT scan START (MOR-1495 review R2 — see
@@ -116,10 +134,30 @@
   // re-loosening the B-wave criterion forbids.
   function toggleRit(): void { if (rx && activeKnown && usable(rx.ritActive)) onRitToggle?.(); }
   function toggleXit(): void { if (rx && activeKnown && usable(rx.xitActive)) onXitToggle?.(); }
-  function changeOffset(hz: number): void {
-    const offset = rx && (xitLeads ? rx.xitOffset : rx.ritOffset);
-    if (!activeKnown || !offset || !usable(offset)) return;
-    if (xitLeads) onXitOffsetChange?.(hz); else onRitOffsetChange?.(hz);
+  function changeOffset(displayHz: number): void {
+    if (!canAdjustOffset || !Number.isFinite(displayHz)) return;
+    let raw = displayHz;
+    if (ritDomain !== undefined) {
+      if (ritDomain === null) return;
+      raw = encodeControlDomain(ritDomain, exactDecimalNumber(displayHz)) ?? Number.NaN;
+      if (!Number.isSafeInteger(raw)) return;
+    }
+    if (xitLeads) onXitOffsetChange?.(raw); else onRitOffsetChange?.(raw);
+  }
+  function offsetKeydown(event: KeyboardEvent): void {
+    if (!canAdjustOffset || decodedOffset === null) return;
+    const min = ritDomain?.raw_min ?? OFFSET_MIN;
+    const max = ritDomain?.raw_max ?? OFFSET_MAX;
+    let next: number;
+    switch (event.key) {
+      case 'ArrowRight': case 'ArrowUp': next = Math.min(decodedOffset.value + 50, max); break;
+      case 'ArrowLeft': case 'ArrowDown': next = Math.max(decodedOffset.value - 50, min); break;
+      case 'Home': next = min; break;
+      case 'End': next = max; break;
+      default: return;
+    }
+    event.preventDefault();
+    changeOffset(next);
   }
   // CLEAR is correctly LEFT UNGATED on field observation (F2 fix round):
   // `onClear` writes `freq: 0` absolutely, not a read-modify-write of the
@@ -147,7 +185,6 @@
 {#if rx || sc}
   <section class="ritxit-scan-surface" data-testid="ritxit-scan-surface" aria-label="RIT, XIT and scan">
     {#if rx}
-      {@const offset = xitLeads ? rx.xitOffset : rx.ritOffset}
       <div class="row" data-testid="ritxit" data-active-vfo-known={activeKnown}>
         {#if rx.ritActive.availability.structural}
           <button
@@ -161,15 +198,20 @@
             disabled={!activeKnown || !usable(rx.xitActive)} onclick={toggleXit}
           >XIT</button>
         {/if}
-        <label class="offset" data-testid="ritxit-offset" data-observed={usable(offset)}>
+        <label class="offset" data-testid="ritxit-offset"
+          data-observed={offset !== undefined && usable(offset)}>
           <span>Offset</span>
           <input
-            type="range" min={OFFSET_MIN} max={OFFSET_MAX} step={OFFSET_STEP}
-            value={offset.reading.status === 'known' ? offset.reading.value : 0}
-            disabled={!activeKnown || !usable(offset)}
+            type="range"
+            min={ritDomain?.raw_min ?? OFFSET_MIN}
+            max={ritDomain?.raw_max ?? OFFSET_MAX}
+            step={ritDomain?.raw_step ?? OFFSET_STEP}
+            value={decodedOffset?.value ?? ritDomain?.raw_origin ?? 0}
+            disabled={!canAdjustOffset}
+            onkeydown={offsetKeydown}
             oninput={(event) => changeOffset(event.currentTarget.valueAsNumber)}
           />
-          <output data-testid="ritxit-offset-value">{textOf(offset)}</output>
+          <output data-testid="ritxit-offset-value">{decodedOffset?.text ?? UNKNOWN_TEXT}</output>
         </label>
         <button type="button" data-testid="ritxit-clear" disabled={!activeKnown} onclick={clear}>CLEAR</button>
       </div>


### PR DESCRIPTION
Linear: MOR-1731

## Summary
- pass the shared validated RIT-domain tri-state into the pure semantic surface
- decode canonical readback and encode every offset intent through the exact domain
- preserve legacy bounds while using the FTX one-Hz lattice with separately prevented 50 Hz keyboard gestures and exact endpoints
- fail closed for malformed domains, invalid/unread/stale state, unknown/wrong VFO, and failed encoding

## Verification
- focused semantic wiring, pure surface, and ValueControl tests: 208 passed
- full frontend: 360 files / 7,837 tests passed with maxWorkers=2
- check/tsc, lint, boundaries, i18n, build, diff, and privacy checks passed

No hardware/browser/TX claim. MOR-1677 still requires owner-present immutable-candidate FTX-1 RIT readback/restoration.