### PR TITLE
test(MOR-1732): add safe FTX-1 RIT Chromium acceptance

### DIFF
--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const PAGE_URL = process.env.RIGPLANE_V2_URL;
+const FTX1_RIT_E2E = process.env.RIGPLANE_FTX1_RIT_E2E === '1';
 const PAGE_ORIGIN = PAGE_URL ? new URL(PAGE_URL).origin : 'http://127.0.0.1:8080';
 const STATE_URL = `${PAGE_ORIGIN}/api/v1/state`;
 const CAPABILITIES_URL = `${PAGE_ORIGIN}/api/v1/capabilities`;
@@ -294,6 +295,36 @@ async function drainCommands(page: Page): Promise<WsCommandRecord[]> {
 
 async function clearCommands(page: Page): Promise<void> {
   await drainCommands(page);
+}
+
+async function sendWebSocketCommand(
+  page: Page,
+  name: string,
+  params: Record<string, unknown>,
+): Promise<void> {
+  await page.evaluate(({ commandName, commandParams }) => {
+    const win = window as Window & { __WS_INSTANCES__?: WebSocket[] };
+    const socket = win.__WS_INSTANCES__?.find((item) => item.readyState === WebSocket.OPEN);
+    if (!socket) throw new Error('control WebSocket is not open');
+    socket.send(JSON.stringify({
+      type: 'cmd',
+      id: `ftx1-rit-${Date.now()}-${Math.random()}`,
+      name: commandName,
+      params: commandParams,
+    }));
+  }, { commandName: name, commandParams: params });
+}
+
+async function setFakeRitState(
+  page: Page,
+  state: { ritOn: boolean; ritTx: boolean; ritFreq: number },
+): Promise<void> {
+  await sendWebSocketCommand(page, 'set_rit_status', { on: state.ritOn });
+  await sendWebSocketCommand(page, 'set_rit_tx_status', { on: state.ritTx });
+  await sendWebSocketCommand(page, 'set_rit_frequency', { freq: state.ritFreq });
+  const expected = { ritOn: state.ritOn, ritTx: state.ritTx, ritFreq: state.ritFreq };
+  await expect.poll(async () => page.request.get(STATE_URL).then((response) => response.json()))
+    .toMatchObject(expected);
 }
 
 async function requestJsonWithRetry<T>(
@@ -1306,9 +1337,56 @@ async function writeReport(
 
 test.describe.configure({ mode: 'serial' });
 
+test('FTX-1 exact RIT lattice in Chromium', async ({ page }) => {
+  test.skip(!FTX1_RIT_E2E, 'Set RIGPLANE_FTX1_RIT_E2E=1 for the dedicated fake target.');
+  expect(PAGE_URL, 'RIGPLANE_V2_URL must point at the isolated fake WebServer').toBeTruthy();
+
+  await installWebSocketInterceptor(page);
+  await page.goto(PAGE_URL ?? '', { waitUntil: 'domcontentloaded' });
+  const slider = page.locator('[data-testid="ritxit-offset"] input');
+  await expect(slider).toBeVisible();
+  await expect(slider).toBeEnabled();
+  await expect(slider).toHaveAttribute('min', '-9999');
+  await expect(slider).toHaveAttribute('max', '9999');
+  await expect(slider).toHaveAttribute('step', '1');
+  await expect(slider).toHaveValue('0');
+  await clearCommands(page);
+  expect((await drainCommands(page)).filter((command) => command.name === 'set_rit_frequency'))
+    .toHaveLength(0);
+
+  const sequence = [50, 0, -50, 0, -9999, 9999];
+  const keys = ['ArrowRight', 'ArrowLeft', 'ArrowLeft', 'ArrowRight', 'Home', 'End'];
+  try {
+    for (const setup of [
+      { label: 'RIT-leading', ritOn: true, ritTx: false, ritFreq: 0 },
+      { label: 'XIT-leading', ritOn: false, ritTx: true, ritFreq: 0 },
+    ]) {
+      await setFakeRitState(page, setup);
+      await expect(slider).toHaveValue('0');
+      await clearCommands(page);
+
+      for (const [index, key] of keys.entries()) {
+        await slider.press(key);
+        await expect(slider, `${setup.label} ${key}`).toHaveValue(String(sequence[index]));
+      }
+
+      const commands = (await drainCommands(page))
+        .filter((command) => command.name === 'set_rit_frequency');
+      const frequencies = commands.map((command) => command.params.freq);
+      expect(frequencies, setup.label).toEqual(sequence);
+      expect(frequencies.every((freq) => Number.isSafeInteger(freq)
+        && Number(freq) >= -9999 && Number(freq) <= 9999)).toBe(true);
+      expect(frequencies).not.toContain(-10000);
+      expect(frequencies).not.toContain(10000);
+    }
+  } finally {
+    await setFakeRitState(page, { ritOn: false, ritTx: false, ritFreq: 0 });
+  }
+});
+
 test('v2 interactive audit against the live backend', async ({ page, request }) => {
   test.skip(
-    !PAGE_URL,
+    FTX1_RIT_E2E || !PAGE_URL,
     'Set RIGPLANE_V2_URL=http://host:port?ui=v2 to run the live backend audit.',
   );
 

--- a/frontend/tests/e2e/v2-ui-interactive.impl.ts
+++ b/frontend/tests/e2e/v2-ui-interactive.impl.ts
@@ -1350,8 +1350,8 @@ test('FTX-1 exact RIT lattice in Chromium', async ({ page }) => {
   await expect(slider).toHaveAttribute('max', '9999');
   await expect(slider).toHaveAttribute('step', '1');
   await expect(slider).toHaveValue('0');
-  await clearCommands(page);
-  expect((await drainCommands(page)).filter((command) => command.name === 'set_rit_frequency'))
+  const startupCommands = await drainCommands(page);
+  expect(startupCommands.filter((command) => command.name === 'set_rit_frequency'))
     .toHaveLength(0);
 
   const sequence = [50, 0, -50, 0, -9999, 9999];

--- a/tests/e2e/ftx1_rit_web_server.py
+++ b/tests/e2e/ftx1_rit_web_server.py
@@ -1,0 +1,168 @@
+"""Local WebServer target for the FTX-1 RIT Chromium acceptance test."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
+from rigplane.profiles import resolve_radio_profile
+from rigplane.runtime._poller_types import (
+    CommandQueue,
+    SetRitFrequency,
+    SetRitStatus,
+    SetRitTxStatus,
+)
+from rigplane.web.server import WebConfig, WebServer
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = SourceMetadata(
+    source="test",
+    provider="ftx1_rit_fake",
+    transport="memory",
+)
+
+
+class Ftx1RitFake:
+    """In-memory RIT/XIT intent and readback only; no physical or TX surfaces."""
+
+    backend_id = "ftx1_rit_fake"
+    model = "FTX-1"
+    connected = True
+    control_connected = True
+    radio_ready = True
+    capabilities = {"rit", "xit"}
+
+    def __init__(self) -> None:
+        self.profile = resolve_radio_profile(model=self.model)
+        self.state_store = StateStore()
+        self._callback: Callable[[Sequence[Observation]], None] | None = None
+        self._seed("slow_state", "active", "MAIN")
+        self._seed("tx_state", "rit_on", False)
+        self._seed("tx_state", "rit_tx", False)
+        self._seed("operator_controls", "rit_freq", 0)
+
+    def _observation(self, family: str, name: str, value: Any) -> Observation:
+        return Observation(
+            path=FieldPath.global_(family, name),
+            value=value,
+            source=SOURCE,
+            timestamp_monotonic=time.monotonic(),
+            provider_generation=self.state_store.provider_generation,
+        )
+
+    def _seed(self, family: str, name: str, value: Any) -> None:
+        self.state_store.apply(self._observation(family, name, value))
+
+    def _readback(self, family: str, name: str, value: Any) -> None:
+        if self._callback is None:
+            raise RuntimeError("observation poller is not attached")
+        self._callback((self._observation(family, name, value),))
+
+    async def set_rit_status(self, on: bool) -> None:
+        self._readback("tx_state", "rit_on", bool(on))
+
+    async def set_rit_tx_status(self, on: bool) -> None:
+        self._readback("tx_state", "rit_tx", bool(on))
+
+    async def set_rit_frequency(self, freq: int) -> None:
+        if (
+            not isinstance(freq, int)
+            or isinstance(freq, bool)
+            or not -9999 <= freq <= 9999
+        ):
+            raise ValueError("RIT frequency must be a safe integer in [-9999, 9999]")
+        self._readback("operator_controls", "rit_freq", freq)
+
+    def create_observation_poller(
+        self,
+        *,
+        callback: Callable[[Sequence[Observation]], None],
+        command_queue: CommandQueue | None = None,
+    ) -> Ftx1RitPoller:
+        self._callback = callback
+        return Ftx1RitPoller(self, command_queue)
+
+
+class Ftx1RitPoller:
+    def __init__(self, radio: Ftx1RitFake, queue: CommandQueue | None) -> None:
+        self._radio = radio
+        self._queue = queue
+        self._stopped = asyncio.Event()
+
+    async def start(self) -> None:
+        while not self._stopped.is_set():
+            if self._queue is None or not self._queue.has_commands:
+                if self._queue is None:
+                    await asyncio.sleep(0.05)
+                else:
+                    await self._queue.wait(timeout=0.05)
+                continue
+            for entry in self._queue.drain_entries():
+                try:
+                    command = entry.command
+                    if isinstance(command, SetRitStatus):
+                        await self._radio.set_rit_status(command.on)
+                    elif isinstance(command, SetRitTxStatus):
+                        await self._radio.set_rit_tx_status(command.on)
+                    elif isinstance(command, SetRitFrequency):
+                        await self._radio.set_rit_frequency(command.freq)
+                    else:
+                        raise ValueError(
+                            f"unsupported fake intent: {type(command).__name__}"
+                        )
+                    if entry.future is not None and not entry.future.done():
+                        entry.future.set_result(None)
+                except Exception as exc:
+                    if (
+                        entry.command_service is not None
+                        and entry.command_id is not None
+                    ):
+                        entry.command_service.fail_command(
+                            entry.command_id, message=str(exc)
+                        )
+                    if entry.future is not None and not entry.future.done():
+                        entry.future.set_exception(exc)
+
+    async def stop(self) -> None:
+        self._stopped.set()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=18765, type=int)
+    parser.add_argument("--static-dir", default=ROOT / "frontend" / "dist", type=Path)
+    return parser.parse_args()
+
+
+async def run() -> None:
+    args = parse_args()
+    if not args.static_dir.is_dir():
+        raise SystemExit(f"frontend build is missing: {args.static_dir}")
+    server = WebServer(
+        Ftx1RitFake(),
+        WebConfig(
+            host=args.host,
+            port=args.port,
+            static_dir=args.static_dir,
+            radio_model="FTX-1",
+            discovery=False,
+            read_only=True,
+        ),
+    )
+    print(f"FTX-1 RIT fake ready at http://{args.host}:{args.port}/?ui=v2", flush=True)
+    await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

- add a WebServer-only FTX-1 RIT/XIT fake with exact profile domain and observed readback
- add a dedicated Chromium acceptance proving the native zero, step, endpoints, and exact RIT/XIT-leading command sequences
- retain intercepted startup frames until the initial no-`set_rit_frequency` assertion, then begin explicit interaction phases
- keep the live-backend audit separate and restore fake frequency/status in `finally`

## Verification

- focused Chromium: 1 passed, 0 skipped
- discriminating injection RED: temporary startup-phase `set_rit_frequency(123)` failed the no-command assertion with received length 1 and `freq: 123`; injection removed before clean GREEN
- prior-base Chromium evidence: `value=1`, `step=50`; current head: `value=0`, `step=1`
- frontend: 360 files / 7837 tests passed with maxWorkers=2
- check, tsc, lint, boundaries, i18n, build passed
- Ruff check/format and Python compile passed
- isolated ports stopped; no listeners remained
- diff/privacy checks passed

Linear: [MOR-1732](https://linear.app/morozsm/issue/MOR-1732/add-safe-chromium-acceptance-for-the-ftx-1-exact-rit-lattice)