### PR TITLE
fix(MOR-1733): consume exact NR level domains

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
@@ -74,6 +74,11 @@ function useCaps(value: Capabilities): void {
 }
 
 const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
+  ['revoked caps proxy', () => {
+    const { proxy, revoke } = Proxy.revocable(caps(), {});
+    revoke();
+    return proxy;
+  }],
   ['caps.controls getter', () => {
     const value = caps();
     Object.defineProperty(value, 'controls', { get: () => { throw new Error('controls getter'); } });
@@ -81,6 +86,9 @@ const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
   }],
   ['controls own-property descriptor', () => caps(new Proxy({}, {
     getOwnPropertyDescriptor: () => { throw new Error('descriptor trap'); },
+  }))],
+  ['controls ownKeys', () => caps(new Proxy({}, {
+    ownKeys: () => { throw new Error('ownKeys trap'); },
   }))],
   ['controls array', () => caps([] as unknown as Record<string, unknown>)],
   ['own nr_level getter', () => {
@@ -94,6 +102,9 @@ const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
   ['nr_level candidate property trap', () => caps({ nr_level: new Proxy({}, {
     has: () => true,
     get: () => { throw new Error('candidate property trap'); },
+  }) })],
+  ['exact-looking candidate descriptor', () => caps({ nr_level: new Proxy(EXACT_NR_DOMAIN, {
+    getOwnPropertyDescriptor: () => { throw new Error('candidate descriptor trap'); },
   }) })],
 ];
 

--- a/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
@@ -74,6 +74,15 @@ function useCaps(value: Capabilities): void {
 }
 
 const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
+  ['exact caps has trap', () => new Proxy(caps({ nr_level: EXACT_NR_DOMAIN }), {
+    has: () => { throw new Error('caps has trap'); },
+  })],
+  ['exact caps ownKeys trap', () => new Proxy(caps({ nr_level: EXACT_NR_DOMAIN }), {
+    ownKeys: () => { throw new Error('caps ownKeys trap'); },
+  })],
+  ['exact caps descriptor trap', () => new Proxy(caps({ nr_level: EXACT_NR_DOMAIN }), {
+    getOwnPropertyDescriptor: () => { throw new Error('caps descriptor trap'); },
+  })],
   ['revoked caps proxy', () => {
     const { proxy, revoke } = Proxy.revocable(caps(), {});
     revoke();
@@ -90,6 +99,9 @@ const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
   ['controls ownKeys', () => caps(new Proxy({}, {
     ownKeys: () => { throw new Error('ownKeys trap'); },
   }))],
+  ['exact controls get trap', () => caps(new Proxy({ nr_level: EXACT_NR_DOMAIN }, {
+    get: () => { throw new Error('controls get trap'); },
+  }))],
   ['controls array', () => caps([] as unknown as Record<string, unknown>)],
   ['own nr_level getter', () => {
     const controls: Record<string, unknown> = {};
@@ -105,6 +117,9 @@ const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
   }) })],
   ['exact-looking candidate descriptor', () => caps({ nr_level: new Proxy(EXACT_NR_DOMAIN, {
     getOwnPropertyDescriptor: () => { throw new Error('candidate descriptor trap'); },
+  }) })],
+  ['exact-looking candidate get trap', () => caps({ nr_level: new Proxy(EXACT_NR_DOMAIN, {
+    get: () => { throw new Error('candidate get trap'); },
   }) })],
 ];
 

--- a/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
@@ -73,6 +73,30 @@ function useCaps(value: Capabilities): void {
   vi.mocked(capabilitiesStore.getCapabilities).mockReturnValue(value);
 }
 
+const METADATA_TRAPS: ReadonlyArray<readonly [string, () => Capabilities]> = [
+  ['caps.controls getter', () => {
+    const value = caps();
+    Object.defineProperty(value, 'controls', { get: () => { throw new Error('controls getter'); } });
+    return value;
+  }],
+  ['controls own-property descriptor', () => caps(new Proxy({}, {
+    getOwnPropertyDescriptor: () => { throw new Error('descriptor trap'); },
+  }))],
+  ['controls array', () => caps([] as unknown as Record<string, unknown>)],
+  ['own nr_level getter', () => {
+    const controls: Record<string, unknown> = {};
+    Object.defineProperty(controls, 'nr_level', { get: () => { throw new Error('nr_level getter'); } });
+    return caps(controls);
+  }],
+  ['nr_level candidate has trap', () => caps({ nr_level: new Proxy({}, {
+    has: () => { throw new Error('candidate has trap'); },
+  }) })],
+  ['nr_level candidate property trap', () => caps({ nr_level: new Proxy({}, {
+    has: () => true,
+    get: () => { throw new Error('candidate property trap'); },
+  }) })],
+];
+
 beforeEach(() => {
   vi.mocked(sendCommand).mockClear();
   useCaps(caps());
@@ -124,6 +148,19 @@ describe('exact NR-level contract (MOR-1733)', () => {
     useCaps(caps({ nr: EXACT_NR_DOMAIN }));
     makeDspHandlers().onNrLevelChange(4);
     expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 68, receiver: 0 });
+  });
+
+  it.each(METADATA_TRAPS)('returns an invalid contract for trapped %s metadata', (_name, makeCaps) => {
+    expect(() => resolveNrLevelContract(makeCaps()).displayToRaw(4)).not.toThrow();
+    expect(resolveNrLevelContract(makeCaps()).displayToRaw(4)).toBeNull();
+    expect(() => nrRawToDisplay(4, controlRangeFromCapsOrDefault('nr_level', makeCaps()))).not.toThrow();
+    expect(nrRawToDisplay(4, controlRangeFromCapsOrDefault('nr_level', makeCaps()))).toBeUndefined();
+  });
+
+  it.each(METADATA_TRAPS)('emits nothing when the command seam encounters trapped %s metadata', (_name, makeCaps) => {
+    useCaps(makeCaps());
+    expect(() => makeDspHandlers().onNrLevelChange(4)).not.toThrow();
+    expect(sendCommand).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/dsp-nr-level.isolated.test.ts
@@ -1,9 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// MOR-490: the NR slider is 0-15 (front-panel scale) but the CI-V wire value
-// is 0-255 BCD.  The DSP handler must convert display -> raw before sending.
-// MOR-1409 A09b removed the store's optimistic patch path entirely — the WS
-// B2/C reducer is the sole writer, so there is no local overlay to flicker.
+import type { Capabilities, ControlDomain } from '$lib/types/capabilities';
 
 vi.mock('$lib/transport/ws-client', () => ({
   sendCommand: vi.fn(),
@@ -21,7 +18,7 @@ vi.mock('$lib/stores/radio.svelte', () => ({
 }));
 
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getCapabilities: vi.fn(() => ({ capabilities: ['nr'], receivers: 2, vfoScheme: 'main_sub' })),
+  getCapabilities: vi.fn(),
   getControlRange: vi.fn(() => null),
 }));
 
@@ -36,34 +33,120 @@ vi.mock('$lib/audio/audio-manager', () => ({
 }));
 
 import { sendCommand } from '$lib/transport/ws-client';
+import * as capabilitiesStore from '$lib/stores/capabilities.svelte';
 import * as radioStore from '$lib/stores/radio.svelte';
-import { makeDspHandlers as makeRuntimeDspHandlers } from '$lib/runtime/commands/panel-commands';
+import {
+  controlRangeFromCapsOrDefault,
+  nrRawToDisplay,
+  resolveNrLevelContract,
+} from '$lib/radio/filter-controls';
+import { makeDspHandlers } from '$lib/runtime/commands/panel-commands';
+
+const EXACT_NR_DOMAIN: ControlDomain = {
+  mapping: 'identity',
+  raw_min: 0,
+  raw_max: 10,
+  raw_step: 1,
+  raw_origin: 0,
+  display_min: '0' as never,
+  display_max: '10' as never,
+  display_step: '1' as never,
+  display_origin: '0' as never,
+  display_unit: 'level',
+  quantization: 'reject',
+  restoration: 'exact',
+};
+
+function caps(controls: Record<string, unknown> = {}): Capabilities {
+  return {
+    model: 'Test Radio', scope: false, audio: false, tx: false,
+    capabilities: ['nr'], receivers: 2, vfoScheme: 'main_sub',
+    freqRanges: [], modes: [], filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm'] },
+    webrtc: { available: false, enabled: false }, txBands: null,
+    stateContractVersion: 1, providerGeneration: 0,
+    controls: controls as Capabilities['controls'],
+  };
+}
+
+function useCaps(value: Capabilities): void {
+  vi.mocked(capabilitiesStore.getCapabilities).mockReturnValue(value);
+}
 
 beforeEach(() => {
   vi.mocked(sendCommand).mockClear();
+  useCaps(caps());
 });
 
-describe.each([
-  ['runtime panel-commands', makeRuntimeDspHandlers],
-])('onNrLevelChange (%s)', (_name, makeHandlers) => {
-  it('converts the 0-15 slider value to the 0-255 wire value before sending', () => {
-    makeHandlers().onNrLevelChange(15);
-    expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 255, receiver: 0 });
+describe('exact NR-level contract (MOR-1733)', () => {
+  it.each([0, 1, 4, 10])('round-trips raw/display %i unchanged through the conversion contract', (value) => {
+    const exactCaps = caps({ nr_level: EXACT_NR_DOMAIN });
+    const conversion = controlRangeFromCapsOrDefault('nr_level', exactCaps);
+    const contract = resolveNrLevelContract(exactCaps);
+
+    expect(nrRawToDisplay(value, conversion)).toBe(value);
+    expect(contract.displayToRaw(value)).toBe(value);
   });
 
-  it('maps the midpoint slider value to the midpoint wire value', () => {
-    makeHandlers().onNrLevelChange(8);
-    // round(8 * 255 / 15) = 136
-    expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 136, receiver: 0 });
+  it('emits the displayed FTX level without rescaling and preserves receiver identity', () => {
+    useCaps(caps({ nr_level: EXACT_NR_DOMAIN }));
+
+    makeDspHandlers().onNrLevelChange(4);
+
+    expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 4, receiver: 0 });
   });
 
-  it('maps zero to zero', () => {
-    makeHandlers().onNrLevelChange(0);
-    expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 0, receiver: 0 });
+  it.each([-1, 11, 0.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    'emits nothing for invalid exact-domain display input %s',
+    (value) => {
+      useCaps(caps({ nr_level: EXACT_NR_DOMAIN }));
+      makeDspHandlers().onNrLevelChange(value);
+      expect(sendCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ['non-restorable', { ...EXACT_NR_DOMAIN, restoration: 'unavailable' }],
+    ['non-round-tripping', {
+      ...EXACT_NR_DOMAIN,
+      mapping: 'lookup',
+      lookup: [0, 1, 4, 10].map((value) => ({ raw: value, display: String(value) })),
+    }],
+    ['malformed exact-present', { ...EXACT_NR_DOMAIN, display_max: '9' }],
+    ['malformed legacy-present', {}],
+  ])('fails closed for a %s nr_level domain', (_name, domain) => {
+    useCaps(caps({ nr_level: domain }));
+    makeDspHandlers().onNrLevelChange(4);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it('never treats controls.nr as the NR-level domain', () => {
+    useCaps(caps({ nr: EXACT_NR_DOMAIN }));
+    makeDspHandlers().onNrLevelChange(4);
+    expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: 68, receiver: 0 });
+  });
+});
+
+describe('legacy NR-level fallback', () => {
+  it.each([
+    [0, 0],
+    [8, 136],
+    [15, 255],
+  ])('maps display %i to raw %i only when an exact nr_level domain is absent', (display, raw) => {
+    makeDspHandlers().onNrLevelChange(display);
+    expect(sendCommand).toHaveBeenCalledWith('set_nr_level', { level: raw, receiver: 0 });
+  });
+
+  it.each([
+    [0, 0],
+    [128, 8],
+    [255, 15],
+  ])('preserves raw %i to display %i', (raw, display) => {
+    expect(nrRawToDisplay(raw, controlRangeFromCapsOrDefault('nr_level', caps()))).toBe(display);
   });
 
   it('has no optimistic store path left to write through (MOR-1409 A09b)', () => {
-    makeHandlers().onNrLevelChange(15);
+    makeDspHandlers().onNrLevelChange(15);
     expect(Object.keys(radioStore)).not.toContain('patchActiveReceiver');
   });
 });

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -166,13 +166,18 @@ export type ControlDisplayRange = ControlRange;
 export type NrLevelContract = Readonly<{
   rawToDisplay: (raw: number) => number | null;
   displayToRaw: (display: number) => number | null;
+  hasNr: boolean;
+  receivers: number | null;
 }>;
 
 const nrLevelContracts = new WeakMap<ControlDisplayRange, NrLevelContract>();
 const INVALID_NR_LEVEL_CONTRACT: NrLevelContract = {
   rawToDisplay: () => null,
   displayToRaw: () => null,
+  hasNr: false,
+  receivers: null,
 };
+const NR_CAPS_KEYS = ['capabilities', 'receivers', 'controls'] as const;
 const EXACT_NR_LEVEL_KEYS = [
   'mapping', 'raw_step', 'raw_origin', 'display_step', 'display_origin',
   'quantization', 'restoration', 'display_center', 'lookup',
@@ -182,23 +187,24 @@ const NR_LEVEL_METADATA_KEYS = [
   'display_unit', 'style', ...EXACT_NR_LEVEL_KEYS,
 ] as const;
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+function snapshotNrRecord(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
   const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
-
-function snapshotNrLevelControl(control: unknown): Record<string, unknown> | null {
-  if (!isPlainRecord(control)) return null;
-  const ownKeys = Reflect.ownKeys(control);
-  const ownsMapping = ownKeys.includes('mapping');
-  if (Reflect.has(control, 'mapping') !== ownsMapping) return null;
+  if (prototype !== Object.prototype && prototype !== null) return null;
+  const ownKeys = Reflect.ownKeys(value);
   const snapshot: Record<string, unknown> = {};
-  for (const key of NR_LEVEL_METADATA_KEYS) {
-    if (!ownKeys.includes(key)) continue;
-    const descriptor = Object.getOwnPropertyDescriptor(control, key);
-    if (!descriptor || !('value' in descriptor)) return null;
-    snapshot[key] = descriptor.value;
+  for (const key of keys) {
+    const owns = ownKeys.includes(key);
+    if (Reflect.has(value, key) !== owns) return null;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!owns) {
+      if (descriptor !== undefined) return null;
+    } else {
+      if (!descriptor || !('value' in descriptor)) return null;
+      const read = Reflect.get(value, key);
+      if (!Object.is(read, descriptor.value)) return null;
+      snapshot[key] = read;
+    }
   }
   return snapshot;
 }
@@ -226,8 +232,11 @@ function legacyNrLevelRange(control: unknown): ControlDisplayRange | null {
   };
 }
 
-function exactNrLevelContract(domain: ControlDomain): NrLevelContract {
+function exactNrLevelContract(
+  domain: ControlDomain, hasNr: boolean, receivers: number,
+): NrLevelContract {
   return {
+    hasNr, receivers,
     rawToDisplay: (raw) => {
       try {
         const exact = decodeControlDomain(domain, raw);
@@ -254,8 +263,11 @@ function exactNrLevelContract(domain: ControlDomain): NrLevelContract {
   };
 }
 
-function legacyNrLevelContract(range: ControlDisplayRange): NrLevelContract {
+function legacyNrLevelContract(
+  range: ControlDisplayRange, hasNr = false, receivers: number | null = null,
+): NrLevelContract {
   return {
+    hasNr, receivers,
     rawToDisplay: (raw) => controlRawToDisplay('nr_level', raw, CONTROL_DEFAULTS.nr_level, range),
     displayToRaw: (display) => controlDisplayToRaw('nr_level', display, CONTROL_DEFAULTS.nr_level, range),
   };
@@ -269,25 +281,30 @@ export function resolveNrLevelContract(
     if (caps === null || caps === undefined) {
       return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
     }
-    if (!isPlainRecord(caps)) return INVALID_NR_LEVEL_CONTRACT;
-    const controls = caps.controls;
-    if (controls === undefined) return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
-    if (!isPlainRecord(controls)) return INVALID_NR_LEVEL_CONTRACT;
-    const ownKeys = Reflect.ownKeys(controls);
-    const ownsNrLevel = ownKeys.includes('nr_level');
-    if (Reflect.has(controls, 'nr_level') !== ownsNrLevel) return INVALID_NR_LEVEL_CONTRACT;
-    const descriptor = Object.getOwnPropertyDescriptor(controls, 'nr_level');
-    if (!ownsNrLevel) {
-      if (descriptor !== undefined) return INVALID_NR_LEVEL_CONTRACT;
-      return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
+    const snapshot = snapshotNrRecord(caps, NR_CAPS_KEYS);
+    if (!snapshot || !Array.isArray(snapshot.capabilities)
+      || Object.getPrototypeOf(snapshot.capabilities) !== Array.prototype
+      || !Number.isSafeInteger(snapshot.receivers) || (snapshot.receivers as number) < 1) {
+      return INVALID_NR_LEVEL_CONTRACT;
     }
-    if (!descriptor || !('value' in descriptor)) return INVALID_NR_LEVEL_CONTRACT;
-    const control = snapshotNrLevelControl(descriptor.value);
+    const capabilities = Array.from(snapshot.capabilities);
+    if (!capabilities.every((name) => typeof name === 'string')) return INVALID_NR_LEVEL_CONTRACT;
+    const hasNr = capabilities.includes('nr');
+    const receivers = snapshot.receivers as number;
+    if (snapshot.controls === undefined) {
+      return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level, hasNr, receivers);
+    }
+    const controls = snapshotNrRecord(snapshot.controls, ['nr_level']);
+    if (!controls) return INVALID_NR_LEVEL_CONTRACT;
+    if (!Object.hasOwn(controls, 'nr_level')) {
+      return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level, hasNr, receivers);
+    }
+    const control = snapshotNrRecord(controls.nr_level, NR_LEVEL_METADATA_KEYS);
     if (!control) return INVALID_NR_LEVEL_CONTRACT;
     const exact = exactNrLevelDomain(control);
-    if (exact) return exactNrLevelContract(exact);
+    if (exact) return exactNrLevelContract(exact, hasNr, receivers);
     const legacy = legacyNrLevelRange(control);
-    return legacy ? legacyNrLevelContract(legacy) : INVALID_NR_LEVEL_CONTRACT;
+    return legacy ? legacyNrLevelContract(legacy, hasNr, receivers) : INVALID_NR_LEVEL_CONTRACT;
   } catch {
     return INVALID_NR_LEVEL_CONTRACT;
   }

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -175,7 +175,7 @@ const INVALID_NR_LEVEL_CONTRACT: NrLevelContract = {
 };
 
 function exactNrLevelDomain(control: unknown): ControlDomain | null {
-  if (control === null || typeof control !== 'object') return null;
+  if (control === null || typeof control !== 'object' || Array.isArray(control)) return null;
   const record = control as Record<string, unknown>;
   const exactKeys = [
     'mapping', 'raw_step', 'raw_origin', 'display_step', 'display_origin',
@@ -205,19 +205,27 @@ function legacyNrLevelRange(control: unknown): ControlDisplayRange | null {
 function exactNrLevelContract(domain: ControlDomain): NrLevelContract {
   return {
     rawToDisplay: (raw) => {
-      const exact = decodeControlDomain(domain, raw);
-      if (exact === null) return null;
-      const display = Number(exact);
-      return Number.isSafeInteger(display)
-        && exactDecimalInteger(display) === exact
-        && encodeControlDomain(domain, exact) === raw
-        ? display : null;
+      try {
+        const exact = decodeControlDomain(domain, raw);
+        if (exact === null) return null;
+        const display = Number(exact);
+        return Number.isSafeInteger(display)
+          && exactDecimalInteger(display) === exact
+          && encodeControlDomain(domain, exact) === raw
+          ? display : null;
+      } catch {
+        return null;
+      }
     },
     displayToRaw: (display) => {
-      if (!Number.isSafeInteger(display)) return null;
-      const exact = exactDecimalInteger(display);
-      const raw = encodeControlDomain(domain, exact);
-      return raw !== null && decodeControlDomain(domain, raw) === exact ? raw : null;
+      try {
+        if (!Number.isSafeInteger(display)) return null;
+        const exact = exactDecimalInteger(display);
+        const raw = encodeControlDomain(domain, exact);
+        return raw !== null && decodeControlDomain(domain, raw) === exact ? raw : null;
+      } catch {
+        return null;
+      }
     },
   };
 }
@@ -233,15 +241,27 @@ function legacyNrLevelContract(range: ControlDisplayRange): NrLevelContract {
 export function resolveNrLevelContract(
   caps: Capabilities | null | undefined,
 ): NrLevelContract {
-  const controls = caps?.controls;
-  if (!controls || !Object.prototype.hasOwnProperty.call(controls, 'nr_level')) {
-    return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
+  try {
+    if (caps === null || caps === undefined) {
+      return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
+    }
+    if (typeof caps !== 'object' || Array.isArray(caps)) return INVALID_NR_LEVEL_CONTRACT;
+    const controls = caps.controls;
+    if (controls === undefined) return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
+    if (controls === null || typeof controls !== 'object' || Array.isArray(controls)) {
+      return INVALID_NR_LEVEL_CONTRACT;
+    }
+    if (!Object.prototype.hasOwnProperty.call(controls, 'nr_level')) {
+      return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
+    }
+    const control = controls.nr_level;
+    const exact = exactNrLevelDomain(control);
+    if (exact) return exactNrLevelContract(exact);
+    const legacy = legacyNrLevelRange(control);
+    return legacy ? legacyNrLevelContract(legacy) : INVALID_NR_LEVEL_CONTRACT;
+  } catch {
+    return INVALID_NR_LEVEL_CONTRACT;
   }
-  const control = controls.nr_level;
-  const exact = exactNrLevelDomain(control);
-  if (exact) return exactNrLevelContract(exact);
-  const legacy = legacyNrLevelRange(control);
-  return legacy ? legacyNrLevelContract(legacy) : INVALID_NR_LEVEL_CONTRACT;
 }
 
 /**
@@ -291,8 +311,19 @@ export function controlRangeFromCapsOrDefault(
 ): ControlDisplayRange {
   const fallback = CONTROL_DEFAULTS[key];
   if (!fallback) throw new Error(`controlRangeFromCapsOrDefault: no CONTROL_DEFAULTS entry for '${key}'`);
+  if (key === 'nr_level') {
+    const contract = resolveNrLevelContract(caps);
+    let selected = fallback;
+    try {
+      selected = controlRangeFromCaps(key, caps) ?? fallback;
+    } catch {
+      // The resolver already classified trapped metadata as invalid.
+    }
+    const range = { ...selected };
+    nrLevelContracts.set(range, contract);
+    return range;
+  }
   const range = { ...(controlRangeFromCaps(key, caps) ?? fallback) };
-  if (key === 'nr_level') nrLevelContracts.set(range, resolveNrLevelContract(caps));
   return range;
 }
 

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -8,8 +8,11 @@
 // PBT raw <-> display conversion
 // Reads range from capabilities if available, falls back to IC-7610 defaults
 import { getControlRange } from '$lib/stores/capabilities.svelte';
+import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
+import { exactDecimalInteger } from '$lib/types/exact-decimal';
 import type {
-  Capabilities, ControlRange as CapabilityControlRange, FilterModeConfig, FilterSegmentConfig,
+  Capabilities, ControlDomain, ControlRange as CapabilityControlRange,
+  FilterModeConfig, FilterSegmentConfig,
 } from '$lib/types/capabilities';
 
 export const FILTER_BIPOLAR_MIN = -1200;
@@ -160,6 +163,87 @@ function controlRange(key: string, fallback: ControlRange): ControlRange {
  *  exported rather than the conversion functions staying un-parameterisable. */
 export type ControlDisplayRange = ControlRange;
 
+export type NrLevelContract = Readonly<{
+  rawToDisplay: (raw: number) => number | null;
+  displayToRaw: (display: number) => number | null;
+}>;
+
+const nrLevelContracts = new WeakMap<ControlDisplayRange, NrLevelContract>();
+const INVALID_NR_LEVEL_CONTRACT: NrLevelContract = {
+  rawToDisplay: () => null,
+  displayToRaw: () => null,
+};
+
+function exactNrLevelDomain(control: unknown): ControlDomain | null {
+  if (control === null || typeof control !== 'object') return null;
+  const record = control as Record<string, unknown>;
+  const exactKeys = [
+    'mapping', 'raw_step', 'raw_origin', 'display_step', 'display_origin',
+    'quantization', 'restoration', 'display_center', 'lookup',
+  ];
+  return exactKeys.some((key) => key in record) ? control as ControlDomain : null;
+}
+
+function legacyNrLevelRange(control: unknown): ControlDisplayRange | null {
+  if (!isLegacyControlRange(control)
+    || !Number.isSafeInteger(control.raw_min) || !Number.isSafeInteger(control.raw_max)
+    || control.raw_min >= control.raw_max) return null;
+  const hasDisplayMin = control.display_min !== undefined;
+  const hasDisplayMax = control.display_max !== undefined;
+  if (hasDisplayMin !== hasDisplayMax) return null;
+  if (!hasDisplayMin) return CONTROL_DEFAULTS.nr_level;
+  if (!Number.isFinite(control.display_min) || !Number.isFinite(control.display_max)
+    || (control.display_max as number) <= (control.display_min as number)) return null;
+  return {
+    rawMin: control.raw_min,
+    rawMax: control.raw_max,
+    displayMin: control.display_min as number,
+    displayMax: control.display_max as number,
+  };
+}
+
+function exactNrLevelContract(domain: ControlDomain): NrLevelContract {
+  return {
+    rawToDisplay: (raw) => {
+      const exact = decodeControlDomain(domain, raw);
+      if (exact === null) return null;
+      const display = Number(exact);
+      return Number.isSafeInteger(display)
+        && exactDecimalInteger(display) === exact
+        && encodeControlDomain(domain, exact) === raw
+        ? display : null;
+    },
+    displayToRaw: (display) => {
+      if (!Number.isSafeInteger(display)) return null;
+      const exact = exactDecimalInteger(display);
+      const raw = encodeControlDomain(domain, exact);
+      return raw !== null && decodeControlDomain(domain, raw) === exact ? raw : null;
+    },
+  };
+}
+
+function legacyNrLevelContract(range: ControlDisplayRange): NrLevelContract {
+  return {
+    rawToDisplay: (raw) => controlRawToDisplay('nr_level', raw, CONTROL_DEFAULTS.nr_level, range),
+    displayToRaw: (display) => controlDisplayToRaw('nr_level', display, CONTROL_DEFAULTS.nr_level, range),
+  };
+}
+
+/** Resolve NR display/readback and command encoding from one model-neutral contract. */
+export function resolveNrLevelContract(
+  caps: Capabilities | null | undefined,
+): NrLevelContract {
+  const controls = caps?.controls;
+  if (!controls || !Object.prototype.hasOwnProperty.call(controls, 'nr_level')) {
+    return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
+  }
+  const control = controls.nr_level;
+  const exact = exactNrLevelDomain(control);
+  if (exact) return exactNrLevelContract(exact);
+  const legacy = legacyNrLevelRange(control);
+  return legacy ? legacyNrLevelContract(legacy) : INVALID_NR_LEVEL_CONTRACT;
+}
+
 /**
  * Derives a `ControlDisplayRange` explicitly from a `Capabilities` object's
  * own `controls[key]` entry (MOR-1290, following the `pbtRangeFromCaps`
@@ -207,7 +291,9 @@ export function controlRangeFromCapsOrDefault(
 ): ControlDisplayRange {
   const fallback = CONTROL_DEFAULTS[key];
   if (!fallback) throw new Error(`controlRangeFromCapsOrDefault: no CONTROL_DEFAULTS entry for '${key}'`);
-  return controlRangeFromCaps(key, caps) ?? fallback;
+  const range = { ...(controlRangeFromCaps(key, caps) ?? fallback) };
+  if (key === 'nr_level') nrLevelContracts.set(range, resolveNrLevelContract(caps));
+  return range;
 }
 
 /**
@@ -229,8 +315,10 @@ export function controlRawToDisplay(
 }
 
 /** Convert a slider display value to the raw CI-V wire value for `key`. */
-export function controlDisplayToRaw(key: string, display: number, fallback: ControlRange): number {
-  const { rawMin, rawMax, displayMin, displayMax } = controlRange(key, fallback);
+export function controlDisplayToRaw(
+  key: string, display: number, fallback: ControlRange, range?: ControlDisplayRange,
+): number {
+  const { rawMin, rawMax, displayMin, displayMax } = range ?? controlRange(key, fallback);
   const span = displayMax - displayMin;
   if (span <= 0) return rawMin;
   const raw = Math.round(((display - displayMin) / span) * (rawMax - rawMin) + rawMin);
@@ -239,7 +327,11 @@ export function controlDisplayToRaw(key: string, display: number, fallback: Cont
 
 /** Convert a raw 0-255 NR wire value to the 0-15 display value. `range`
  *  (MOR-1290) is strictly additive — see `controlRawToDisplay`. */
-export function nrRawToDisplay(raw: number, range?: ControlDisplayRange): number {
+export function nrRawToDisplay(raw: number): number;
+export function nrRawToDisplay(raw: number, range: ControlDisplayRange): number | undefined;
+export function nrRawToDisplay(raw: number, range?: ControlDisplayRange): number | undefined {
+  const contract = range ? nrLevelContracts.get(range) : undefined;
+  if (contract) return contract.rawToDisplay(raw) ?? undefined;
   return controlRawToDisplay('nr_level', raw, CONTROL_DEFAULTS.nr_level, range);
 }
 

--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -173,15 +173,39 @@ const INVALID_NR_LEVEL_CONTRACT: NrLevelContract = {
   rawToDisplay: () => null,
   displayToRaw: () => null,
 };
+const EXACT_NR_LEVEL_KEYS = [
+  'mapping', 'raw_step', 'raw_origin', 'display_step', 'display_origin',
+  'quantization', 'restoration', 'display_center', 'lookup',
+] as const;
+const NR_LEVEL_METADATA_KEYS = [
+  'raw_min', 'raw_max', 'raw_center', 'display_min', 'display_max',
+  'display_unit', 'style', ...EXACT_NR_LEVEL_KEYS,
+] as const;
 
-function exactNrLevelDomain(control: unknown): ControlDomain | null {
-  if (control === null || typeof control !== 'object' || Array.isArray(control)) return null;
-  const record = control as Record<string, unknown>;
-  const exactKeys = [
-    'mapping', 'raw_step', 'raw_origin', 'display_step', 'display_origin',
-    'quantization', 'restoration', 'display_center', 'lookup',
-  ];
-  return exactKeys.some((key) => key in record) ? control as ControlDomain : null;
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function snapshotNrLevelControl(control: unknown): Record<string, unknown> | null {
+  if (!isPlainRecord(control)) return null;
+  const ownKeys = Reflect.ownKeys(control);
+  const ownsMapping = ownKeys.includes('mapping');
+  if (Reflect.has(control, 'mapping') !== ownsMapping) return null;
+  const snapshot: Record<string, unknown> = {};
+  for (const key of NR_LEVEL_METADATA_KEYS) {
+    if (!ownKeys.includes(key)) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(control, key);
+    if (!descriptor || !('value' in descriptor)) return null;
+    snapshot[key] = descriptor.value;
+  }
+  return snapshot;
+}
+
+function exactNrLevelDomain(control: Record<string, unknown>): ControlDomain | null {
+  return EXACT_NR_LEVEL_KEYS.some((key) => Object.hasOwn(control, key))
+    ? control as unknown as ControlDomain : null;
 }
 
 function legacyNrLevelRange(control: unknown): ControlDisplayRange | null {
@@ -245,16 +269,21 @@ export function resolveNrLevelContract(
     if (caps === null || caps === undefined) {
       return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
     }
-    if (typeof caps !== 'object' || Array.isArray(caps)) return INVALID_NR_LEVEL_CONTRACT;
+    if (!isPlainRecord(caps)) return INVALID_NR_LEVEL_CONTRACT;
     const controls = caps.controls;
     if (controls === undefined) return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
-    if (controls === null || typeof controls !== 'object' || Array.isArray(controls)) {
-      return INVALID_NR_LEVEL_CONTRACT;
-    }
-    if (!Object.prototype.hasOwnProperty.call(controls, 'nr_level')) {
+    if (!isPlainRecord(controls)) return INVALID_NR_LEVEL_CONTRACT;
+    const ownKeys = Reflect.ownKeys(controls);
+    const ownsNrLevel = ownKeys.includes('nr_level');
+    if (Reflect.has(controls, 'nr_level') !== ownsNrLevel) return INVALID_NR_LEVEL_CONTRACT;
+    const descriptor = Object.getOwnPropertyDescriptor(controls, 'nr_level');
+    if (!ownsNrLevel) {
+      if (descriptor !== undefined) return INVALID_NR_LEVEL_CONTRACT;
       return legacyNrLevelContract(CONTROL_DEFAULTS.nr_level);
     }
-    const control = controls.nr_level;
+    if (!descriptor || !('value' in descriptor)) return INVALID_NR_LEVEL_CONTRACT;
+    const control = snapshotNrLevelControl(descriptor.value);
+    if (!control) return INVALID_NR_LEVEL_CONTRACT;
     const exact = exactNrLevelDomain(control);
     if (exact) return exactNrLevelContract(exact);
     const legacy = legacyNrLevelRange(control);

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -28,8 +28,9 @@ import { relativeVfoIdentityUnknown, resolveFilterModeConfig } from '../props/pa
 import type { Capabilities, FilterModeConfig, FilterSegmentConfig } from '$lib/types/capabilities';
 import { modInputCommand, modInputStateKey } from '$lib/radio/mod-input';
 import {
-  mapIfShiftToPbt, nbDepthDisplayToRaw, nrDisplayToRaw, pbtHzToRaw, pbtRangeFromCaps,
+  mapIfShiftToPbt, nbDepthDisplayToRaw, pbtHzToRaw, pbtRangeFromCaps,
   quantizeFilterWidthToRule,
+  resolveNrLevelContract,
 } from '$lib/radio/filter-controls';
 import { audioManager } from '$lib/audio/audio-manager';
 import { adjustTuningStep, getTuningStep } from '$lib/stores/tuning.svelte';
@@ -569,8 +570,8 @@ export function makeDspHandlers() {
     onNrLevelChange: (level: number) => {
       const receiver = knownReceiverField('nrLevel');
       if (!hasCapability('nr') || receiver === null || !Number.isFinite(level)) return;
-      // MOR-490: slider is 0-15 (front-panel scale); wire is 0-255 BCD.
-      const raw = nrDisplayToRaw(level);
+      const raw = resolveNrLevelContract(getCapabilities()).displayToRaw(level);
+      if (raw === null) return;
       dispatchRadioIntent({ name: 'set_nr_level', params: { level: raw, receiver } });
     },
     onNbToggle: (on: boolean) => {

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -568,10 +568,18 @@ export function makeDspHandlers() {
       dispatchRadioIntent({ name: 'set_nr', params: { on: mode > 0, receiver } });
     },
     onNrLevelChange: (level: number) => {
-      const receiver = knownReceiverField('nrLevel');
-      if (!hasCapability('nr') || receiver === null || !Number.isFinite(level)) return;
-      const raw = resolveNrLevelContract(getCapabilities()).displayToRaw(level);
-      if (raw === null) return;
+      let receiver: Receiver;
+      let raw: number;
+      try {
+        const resolvedReceiver = knownReceiverField('nrLevel');
+        if (!hasCapability('nr') || resolvedReceiver === null || !Number.isFinite(level)) return;
+        const resolvedRaw = resolveNrLevelContract(getCapabilities()).displayToRaw(level);
+        if (resolvedRaw === null) return;
+        receiver = resolvedReceiver;
+        raw = resolvedRaw;
+      } catch {
+        return;
+      }
       dispatchRadioIntent({ name: 'set_nr_level', params: { level: raw, receiver } });
     },
     onNbToggle: (on: boolean) => {

--- a/frontend/src/lib/runtime/commands/panel-commands.ts
+++ b/frontend/src/lib/runtime/commands/panel-commands.ts
@@ -41,7 +41,9 @@ import { getSharedTuningAccumulator } from './tuning-accumulator';
 
 type Receiver = 0 | 1;
 
-function knownActiveReceiver(field?: string, target?: 'MAIN' | 'SUB'): Receiver | null {
+function knownActiveReceiver(
+  field?: string, target?: 'MAIN' | 'SUB', receiverCount?: number | null,
+): Receiver | null {
   const state = getRadioState();
   if (!state) return null;
   // MOR-1418: on a single-receiver radio, `active` (MAIN/SUB) is
@@ -51,12 +53,12 @@ function knownActiveReceiver(field?: string, target?: 'MAIN' | 'SUB'): Receiver 
   // Dual-RX radios are unaffected: `active` observation is still required
   // whenever it is actually observed (or on any radio with receivers > 1).
   const activeObserved = isFieldAvailable(state, 'active');
-  const singleReceiver = getCapabilities()?.receivers === 1;
+  const receivers = receiverCount === undefined ? getCapabilities()?.receivers : receiverCount;
+  const singleReceiver = receivers === 1;
   const receiverName = target
     ?? (activeObserved ? state.active : singleReceiver ? 'MAIN' : undefined);
   if (receiverName !== 'MAIN' && receiverName !== 'SUB') return null;
   if (receiverName === 'SUB') {
-    const receivers = getCapabilities()?.receivers;
     if (!Number.isSafeInteger(receivers) || (receivers as number) < 2 || !state.sub) return null;
   } else if (!state.main) return null;
   const receiver = receiverName === 'SUB' ? 1 : 0;
@@ -68,8 +70,8 @@ function hasCapability(name: string): boolean {
   return getCapabilities()?.capabilities.includes(name) ?? false;
 }
 
-function knownReceiverField(field: string): Receiver | null {
-  const receiver = knownActiveReceiver(field);
+function knownReceiverField(field: string, receiverCount?: number | null): Receiver | null {
+  const receiver = knownActiveReceiver(field, undefined, receiverCount);
   if (receiver === null) return null;
   const state = getRadioState();
   const target = receiver === 1 ? state?.sub : state?.main;
@@ -571,9 +573,10 @@ export function makeDspHandlers() {
       let receiver: Receiver;
       let raw: number;
       try {
-        const resolvedReceiver = knownReceiverField('nrLevel');
-        if (!hasCapability('nr') || resolvedReceiver === null || !Number.isFinite(level)) return;
-        const resolvedRaw = resolveNrLevelContract(getCapabilities()).displayToRaw(level);
+        const contract = resolveNrLevelContract(getCapabilities());
+        const resolvedReceiver = knownReceiverField('nrLevel', contract.receivers);
+        if (!contract.hasNr || resolvedReceiver === null || !Number.isFinite(level)) return;
+        const resolvedRaw = contract.displayToRaw(level);
         if (resolvedRaw === null) return;
         receiver = resolvedReceiver;
         raw = resolvedRaw;


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-1733](https://linear.app/morozsm/issue/MOR-1733/consume-the-exact-nr-level-domain-in-shared-conversion-and-command)
- Compatibility impact: none; legacy 0..255 to 0..15 NR behavior is preserved when an exact `controls.nr_level` domain is absent

## Summary

- Add one model-neutral NR-level contract resolver shared by display conversion and command encoding.
- Consume only `controls.nr_level` as an exact domain and use the existing exact-domain decode/encode helpers.
- Fail closed for invalid inputs, malformed/non-restorable domains, and trapped capability accessors, descriptors, arrays, or proxies.
- Preserve receiver identity and the existing legacy mapping while preventing `controls.nr` from influencing NR-level scaling.

The root cause was that the Web command path always applied the legacy IC-family 0..15 to 0..255 rescale, even when the active profile declared an exact native NR domain. FTX-1 display level 4 therefore became raw 68 instead of remaining 4.

## Verification

- [x] Red-first focused test demonstrated the legacy rescaling failures
- [x] BLOCKED remediation reproduced all four hostile-metadata paths at the direct resolver and command seam (8 red failures)
- [x] Second BLOCKED remediation reproduced revoked caps, controls `ownKeys`, and candidate descriptor paths (5 red failures)
- [x] Final BLOCKED remediation reproduced caps `has`/`ownKeys`/descriptor, controls `get`, and candidate `get` traps at both seams (10 red failures)
- [x] Focused NR/filter-control suite: 82 tests passed
- [x] Full frontend suite with `--maxWorkers=2`: 360 files / 7,884 tests passed
- [x] `npm run check` and explicit Node `tsc`
- [x] ESLint and frontend boundary lint
- [x] i18n check
- [x] production build
- [x] diff, three-file/400-LOC scope, model-branch, and privacy checks
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented: none

## Agent Review

- [ ] Independent agent review comment posted before merge
- Reviewer:
- Result: `Agent Review: PASS` / `Agent Review: BLOCKED`

## Notes

- Out of scope: UI/store/backend/CAT/audio/hardware changes and owner-present FTX-1 acceptance.
- MOR-1678 remains open through the downstream projection/semantic work and owner-present raw-4 restoration acceptance.
