### PR TITLE
fix(MOR-1734): project exact NR level props

### DIFF
--- a/frontend/src/lib/radio/filter-controls.ts
+++ b/frontend/src/lib/radio/filter-controls.ts
@@ -9,7 +9,7 @@
 // Reads range from capabilities if available, falls back to IC-7610 defaults
 import { getControlRange } from '$lib/stores/capabilities.svelte';
 import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
-import { exactDecimalInteger } from '$lib/types/exact-decimal';
+import { exactDecimalInteger, exactDecimalNumber } from '$lib/types/exact-decimal';
 import type {
   Capabilities, ControlDomain, ControlRange as CapabilityControlRange,
   FilterModeConfig, FilterSegmentConfig,
@@ -166,14 +166,31 @@ export type ControlDisplayRange = ControlRange;
 export type NrLevelContract = Readonly<{
   rawToDisplay: (raw: number) => number | null;
   displayToRaw: (display: number) => number | null;
+  displayDomain: NrLevelDisplayDomain | null;
+  acceptsRaw: (raw: number) => boolean;
   hasNr: boolean;
   receivers: number | null;
+}>;
+
+export type NrLevelDisplayDomain = Readonly<{
+  min: number;
+  max: number;
+  step: number;
+  origin: number;
+}>;
+
+export type NrLevelProjection = Readonly<{
+  value: number | null;
+  domain: NrLevelDisplayDomain | null;
+  adjustable: boolean;
 }>;
 
 const nrLevelContracts = new WeakMap<ControlDisplayRange, NrLevelContract>();
 const INVALID_NR_LEVEL_CONTRACT: NrLevelContract = {
   rawToDisplay: () => null,
   displayToRaw: () => null,
+  displayDomain: null,
+  acceptsRaw: () => false,
   hasNr: false,
   receivers: null,
 };
@@ -235,8 +252,17 @@ function legacyNrLevelRange(control: unknown): ControlDisplayRange | null {
 function exactNrLevelContract(
   domain: ControlDomain, hasNr: boolean, receivers: number,
 ): NrLevelContract {
+  const displayDomain = exactNrLevelDisplayDomain(domain);
   return {
     hasNr, receivers,
+    displayDomain,
+    acceptsRaw: (raw) => {
+      try {
+        return displayDomain !== null && decodeControlDomain(domain, raw) !== null;
+      } catch {
+        return false;
+      }
+    },
     rawToDisplay: (raw) => {
       try {
         const exact = decodeControlDomain(domain, raw);
@@ -263,11 +289,40 @@ function exactNrLevelContract(
   };
 }
 
+function exactNrLevelDisplayDomain(domain: ControlDomain): NrLevelDisplayDomain | null {
+  try {
+    const values = [
+      domain.display_min,
+      domain.display_max,
+      domain.display_step,
+      domain.display_origin,
+    ].map((exact) => {
+      const value = Number(exact);
+      return Number.isFinite(value) && exactDecimalNumber(value) === exact ? value : null;
+    });
+    if (values.some((value) => value === null)) return null;
+    const probe = decodeControlDomain(domain, domain.raw_origin);
+    if (probe === null || encodeControlDomain(domain, probe) !== domain.raw_origin) return null;
+    const [min, max, step, origin] = values as number[];
+    return { min: min!, max: max!, step: step!, origin: origin! };
+  } catch {
+    return null;
+  }
+}
+
 function legacyNrLevelContract(
   range: ControlDisplayRange, hasNr = false, receivers: number | null = null,
 ): NrLevelContract {
   return {
     hasNr, receivers,
+    displayDomain: {
+      min: range.displayMin,
+      max: range.displayMax,
+      step: 1,
+      origin: range.displayMin,
+    },
+    acceptsRaw: (raw) =>
+      Number.isSafeInteger(raw) && raw >= range.rawMin && raw <= range.rawMax,
     rawToDisplay: (raw) => controlRawToDisplay('nr_level', raw, CONTROL_DEFAULTS.nr_level, range),
     displayToRaw: (display) => controlDisplayToRaw('nr_level', display, CONTROL_DEFAULTS.nr_level, range),
   };
@@ -308,6 +363,26 @@ export function resolveNrLevelContract(
   } catch {
     return INVALID_NR_LEVEL_CONTRACT;
   }
+}
+
+/** Project NR-level readback without changing the legacy renderer-facing value. */
+export function projectNrLevel(
+  caps: Capabilities | null | undefined,
+  raw: number | null | undefined,
+  readable: boolean,
+): NrLevelProjection {
+  const contract = resolveNrLevelContract(caps);
+  const domain = contract.displayDomain;
+  if (!readable || raw === null || raw === undefined || !contract.acceptsRaw(raw)) {
+    return { value: null, domain, adjustable: false };
+  }
+  const value = contract.rawToDisplay(raw);
+  const valid = domain !== null && value !== null;
+  return {
+    value: valid ? value : null,
+    domain,
+    adjustable: valid && contract.hasNr,
+  };
 }
 
 /**

--- a/frontend/src/lib/runtime/props/__tests__/nr-level-projection.isolated.test.ts
+++ b/frontend/src/lib/runtime/props/__tests__/nr-level-projection.isolated.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectNrLevel } from '$lib/radio/filter-controls';
+import type { Capabilities, ControlDomain } from '$lib/types/capabilities';
+import type { FieldAvailability, FieldStatus, ReceiverState, ServerState } from '$lib/types/state';
+import { toDspProps } from '../panel-props';
+
+const EXACT_NR_DOMAIN: ControlDomain = {
+  mapping: 'identity',
+  raw_min: 0,
+  raw_max: 10,
+  raw_step: 1,
+  raw_origin: 0,
+  display_min: '0' as never,
+  display_max: '10' as never,
+  display_step: '1' as never,
+  display_origin: '0' as never,
+  display_unit: 'level',
+  quantization: 'reject',
+  restoration: 'exact',
+};
+
+const DISPLAY_DOMAIN = { min: 0, max: 10, step: 1, origin: 0 };
+const LEGACY_DOMAIN = { min: 0, max: 15, step: 1, origin: 0 };
+
+function receiver(overrides: Partial<ReceiverState> = {}): ReceiverState {
+  return {
+    freqHz: 14_074_000,
+    mode: 'USB',
+    filter: 1,
+    dataMode: 0,
+    att: 0,
+    preamp: 0,
+    nb: false,
+    nr: false,
+    afLevel: 128,
+    rfGain: 255,
+    squelch: 0,
+    sMeter: 0,
+    ...overrides,
+  };
+}
+
+function status(availability: FieldAvailability): FieldStatus {
+  return {
+    storePath: 'receiver.nr_level',
+    observed: availability !== 'missing',
+    freshness: availability === 'available'
+      ? 'fresh'
+      : availability === 'stale' ? 'stale' : 'unknown',
+    availability,
+  };
+}
+
+function state(
+  raw: number | undefined,
+  availability: FieldAvailability = 'available',
+  overrides: Partial<ReceiverState> = {},
+): ServerState {
+  const main = receiver({ nrLevel: raw, ...overrides });
+  if (raw === undefined) delete main.nrLevel;
+  return {
+    revision: 1,
+    stateRevision: 1,
+    freshnessRevision: 1,
+    observationSeq: 1,
+    updatedAt: '2026-08-15T00:00:00Z',
+    active: 'MAIN',
+    ptt: false,
+    split: false,
+    dualWatch: false,
+    tunerStatus: 0,
+    txTarget: { status: 'unknown', reason: 'not-observed' },
+    main,
+    sub: receiver(),
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
+    fieldStatus: {
+      'main.nr': status('available'),
+      'main.nrLevel': status(availability),
+      'main.nb': status('available'),
+      'main.manualNotch': status('available'),
+      'main.autoNotch': status('available'),
+    },
+  };
+}
+
+function caps(
+  controls: Record<string, unknown> = {},
+  capabilities: string[] = ['nr'],
+): Capabilities {
+  return {
+    model: 'Test Radio',
+    scope: false,
+    audio: false,
+    tx: false,
+    capabilities,
+    receivers: 1,
+    vfoScheme: 'ab',
+    freqRanges: [],
+    modes: [],
+    filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm'] },
+    webrtc: { available: false, enabled: false },
+    txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+    controls: controls as Capabilities['controls'],
+  };
+}
+
+describe('exact NR-level fallback-props projection (MOR-1734)', () => {
+  it.each([0, 1, 4, 10])('projects exact FTX raw %i unchanged', (raw) => {
+    const capabilities = caps({ nr_level: EXACT_NR_DOMAIN });
+    const expected = { value: raw, domain: DISPLAY_DOMAIN, adjustable: true };
+
+    expect(projectNrLevel(capabilities, raw, true)).toEqual(expected);
+    expect(toDspProps(state(raw), capabilities).nrLevelProjection).toEqual(expected);
+  });
+
+  it.each([
+    ['missing raw state', undefined, 'available'],
+    ['missing field status', 4, 'missing'],
+    ['stale field status', 4, 'stale'],
+    ['raw below the domain', -1, 'available'],
+    ['raw above the domain', 11, 'available'],
+  ] as const)('fails closed for %s', (_name, raw, availability) => {
+    expect(toDspProps(state(raw, availability), caps({ nr_level: EXACT_NR_DOMAIN })).nrLevelProjection)
+      .toEqual({ value: null, domain: DISPLAY_DOMAIN, adjustable: false });
+  });
+
+  it.each([
+    ['malformed', { ...EXACT_NR_DOMAIN, display_max: '9' }],
+    ['trapping', new Proxy({ ...EXACT_NR_DOMAIN }, {
+      get: () => { throw new Error('nr_level metadata trap'); },
+    })],
+  ])('never throws and rejects %s present controls.nr_level metadata', (_name, nrLevel) => {
+    const project = () => toDspProps(state(4), caps({ nr_level: nrLevel })).nrLevelProjection;
+    expect(project).not.toThrow();
+    expect(project()).toEqual({ value: null, domain: null, adjustable: false });
+  });
+
+  it.each([
+    [0, 0],
+    [128, 8],
+    [255, 15],
+  ])('preserves safely absent legacy raw %i as display %i', (raw, display) => {
+    expect(toDspProps(state(raw), caps()).nrLevelProjection).toEqual({
+      value: display,
+      domain: LEGACY_DOMAIN,
+      adjustable: true,
+    });
+  });
+
+  it('requires the NR capability before the projection is adjustable', () => {
+    expect(toDspProps(state(128), caps({}, [])).nrLevelProjection).toEqual({
+      value: 8,
+      domain: LEGACY_DOMAIN,
+      adjustable: false,
+    });
+  });
+
+  it('leaves the existing NR, NB, and notch props unchanged', () => {
+    const props = toDspProps(
+      state(4, 'available', {
+        nr: true,
+        nb: true,
+        nbLevel: 7,
+        manualNotch: true,
+        notchFilter: 77,
+        manualNotchWidth: 2,
+      }),
+      caps({
+        nr_level: EXACT_NR_DOMAIN,
+        nb_depth: { raw_min: 0, raw_max: 9, display_min: 1, display_max: 10 },
+      }, ['nr', 'nb', 'notch']),
+    );
+
+    expect({
+      nrMode: props.nrMode,
+      nrLevel: props.nrLevel,
+      hasNr: props.hasNr,
+      nbActive: props.nbActive,
+      nbLevel: props.nbLevel,
+      notchMode: props.notchMode,
+      notchFreq: props.notchFreq,
+      manualNotchWidth: props.manualNotchWidth,
+      hasNb: props.hasNb,
+      hasNotch: props.hasNotch,
+      hasAutoNotch: props.hasAutoNotch,
+    }).toEqual({
+      nrMode: 1,
+      nrLevel: 0,
+      hasNr: true,
+      nbActive: true,
+      nbLevel: 7,
+      notchMode: 'manual',
+      notchFreq: 77,
+      manualNotchWidth: 2,
+      hasNb: true,
+      hasNotch: true,
+      hasAutoNotch: true,
+    });
+  });
+});

--- a/frontend/src/lib/runtime/props/panel-props.ts
+++ b/frontend/src/lib/runtime/props/panel-props.ts
@@ -18,7 +18,9 @@ import {
   nbDepthRawToDisplay,
   nrRawToDisplay,
   pbtRawToHz,
+  projectNrLevel,
 } from '$lib/radio/filter-controls';
+import type { NrLevelProjection } from '$lib/radio/filter-controls';
 import { decodeControlDomain, encodeControlDomain } from '$lib/radio/control-domain';
 import { isFieldAvailable, getFieldAvailability } from '$lib/state/field-status';
 import { modInputStateKey } from '$lib/radio/mod-input';
@@ -596,6 +598,7 @@ export function toModeProps(
 export interface DspProps {
   nrMode: number;
   nrLevel: number;
+  nrLevelProjection: NrLevelProjection;
   nbActive: boolean;
   nbLevel: number;
   nbDepth: number;
@@ -629,6 +632,7 @@ export function toDspProps(
 
   const nbAvailable = activeFieldAvailable(state, 'nb');
   const nrAvailable = activeFieldAvailable(state, 'nr');
+  const nrLevelAvailable = activeFieldAvailable(state, 'nrLevel');
   const manualNotchAvailable = activeFieldAvailable(state, 'manualNotch');
   const autoNotchAvailable = activeFieldAvailable(state, 'autoNotch');
   // MOR-502: NB depth/width exist only on rigs that expose an nb_depth control
@@ -646,6 +650,7 @@ export function toDspProps(
     nrMode: rx?.nr ? 1 : 0,
     // MOR-490: store holds the raw 0-255 wire value; the slider is 0-15.
     nrLevel: nrRawToDisplay(rx?.nrLevel ?? 0),
+    nrLevelProjection: projectNrLevel(caps, rx?.nrLevel, nrLevelAvailable),
     nbActive: rx?.nb ?? false,
     nbLevel: rx?.nbLevel ?? 0,
     // MOR-498: store holds the 0-9 wire value; the slider is 1-10.


### PR DESCRIPTION
## Summary

- add a pure fail-closed NR-level readback projection built on the MOR-1733 resolver
- emit the additive required nrLevelProjection field from fallback DspProps
- preserve the existing nrLevel, hasNr, NR toggle/mode, NB, notch, and command behavior

Linear: [MOR-1734](https://linear.app/morozsm/issue/MOR-1734/project-exact-nr-level-readback-into-fallback-dsp-props)
Parent: [MOR-1678](https://linear.app/morozsm/issue/MOR-1678)

## Acceptance

- exact FTX raw 0, 1, 4, and 10 project unchanged with domain 0..10, step 1, origin 0
- missing or unread raw state, stale status, and out-of-domain raw values fail closed
- malformed or trapping present metadata returns a null value/domain and never throws
- safely absent metadata keeps the legacy 0..255 to 0..15 projection
- adjustment requires NR capability, fresh readable state, a valid domain, and a valid value

## RED / GREEN evidence

RED commit e65add24: focused Vitest run failed as expected with 15 failed and 1 passed before production implementation.

GREEN commit c86bf29a:
- focused relevant suite: 4 files passed, 148 tests passed
- i18n check: passed
- Svelte/TypeScript check: 0 errors, 0 warnings
- ESLint: passed
- full frontend Vitest: 361 files passed, 7900 tests passed
- production build: passed
- git diff --check: passed

## Compatibility and exclusions

No public HTTP, wire, command, backend, or hardware API changes. This is an additive internal frontend props contract only. No mounted renderer, semantic DSP model, bench/runtime/radio, TX, PTT, TUNE, or keying changes; no hardware validation is required for this child.