### PR TITLE
fix(MOR-1736): carry exact NR projection into semantic DSP

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
@@ -10,18 +10,11 @@ import {
 import { toRadioViewModel } from '../radio-view-model-adapter';
 
 const EXACT_NR_DOMAIN: ControlDomain = {
-  mapping: 'identity',
-  raw_min: 0,
-  raw_max: 10,
-  raw_step: 1,
-  raw_origin: 0,
-  display_min: '0' as never,
-  display_max: '10' as never,
-  display_step: '1' as never,
-  display_origin: '0' as never,
+  mapping: 'identity', raw_min: 0, raw_max: 10, raw_step: 1, raw_origin: 0,
+  display_min: '0' as never, display_max: '10' as never,
+  display_step: '1' as never, display_origin: '0' as never,
   display_unit: 'level',
-  quantization: 'reject',
-  restoration: 'exact',
+  quantization: 'reject', restoration: 'exact',
 };
 
 const EXACT_DISPLAY_DOMAIN = { min: 0, max: 10, step: 1, origin: 0 };
@@ -45,25 +38,11 @@ function fieldStatus(availability: FieldAvailability): FieldStatus {
 
 function receiver(overrides: Partial<ReceiverState> = {}): ReceiverState {
   return {
-    freqHz: 14_074_000,
-    mode: 'USB',
-    filter: 1,
-    dataMode: 0,
-    att: 0,
-    preamp: 0,
-    nb: true,
-    nbLevel: 7,
-    nr: true,
-    afLevel: 128,
-    rfGain: 255,
-    squelch: 0,
-    sMeter: 0,
-    autoNotch: false,
-    manualNotch: true,
-    notchFilter: 77,
-    manualNotchWidth: 2,
-    agc: 2,
-    agcTimeConstant: 9,
+    freqHz: 14_074_000, mode: 'USB', filter: 1, dataMode: 0,
+    att: 0, preamp: 0, nb: true, nbLevel: 7, nr: true,
+    afLevel: 128, rfGain: 255, squelch: 0, sMeter: 0,
+    autoNotch: false, manualNotch: true, notchFilter: 77,
+    manualNotchWidth: 2, agc: 2, agcTimeConstant: 9,
     ...overrides,
   };
 }
@@ -159,6 +138,14 @@ function projectionOf(dsp: DspViewModel): unknown {
   return (dsp as DspViewModel & { nrLevelProjection?: unknown }).nrLevelProjection;
 }
 
+function payloadWithProjection(projection: unknown): unknown {
+  const payload = structuredClone(model(4, caps(EXACT_NR_DOMAIN))) as unknown as {
+    dsp: Record<string, unknown>;
+  };
+  payload.dsp.nrLevelProjection = projection;
+  return payload;
+}
+
 describe('NR-level semantic projection (MOR-1736)', () => {
   it.each([0, 1, 4, 10])('carries exact FTX-1 raw/display %i through adapter and validator', (raw) => {
     const dsp = model(raw, caps(EXACT_NR_DOMAIN)).dsp!;
@@ -213,31 +200,17 @@ describe('NR-level semantic projection (MOR-1736)', () => {
 
   it('leaves NR toggle, NB, notch, and AGC facts unchanged', () => {
     const dsp = model(4, caps(EXACT_NR_DOMAIN)).dsp!;
-    expect({
-      nrActive: dsp.nrActive,
-      nbActive: dsp.nbActive,
-      nbLevel: dsp.nbLevel,
-      nbDepth: dsp.nbDepth,
-      nbWidth: dsp.nbWidth,
-      notchMode: dsp.notchMode,
-      notchFreq: dsp.notchFreq,
-      manualNotchWidth: dsp.manualNotchWidth,
-      agcMode: dsp.agcMode,
-      agcModes: dsp.agcModes,
-      agcTimeConstant: dsp.agcTimeConstant,
-    }).toEqual({
-      nrActive: { reading: { status: 'known', value: true }, availability: { structural: true, operational: true } },
-      nbActive: { reading: { status: 'known', value: true }, availability: { structural: true, operational: true } },
-      nbLevel: { reading: { status: 'known', value: 7 }, availability: { structural: true, operational: true } },
-      nbDepth: { reading: { status: 'known', value: 5 }, availability: { structural: true, operational: true } },
-      nbWidth: { reading: { status: 'known', value: 3 }, availability: { structural: true, operational: true } },
-      notchMode: { reading: { status: 'known', value: 'manual' }, availability: { structural: true, operational: true } },
-      notchFreq: { reading: { status: 'known', value: 77 }, availability: { structural: true, operational: true } },
-      manualNotchWidth: { reading: { status: 'known', value: 2 }, availability: { structural: true, operational: true } },
-      agcMode: { reading: { status: 'known', value: 2 }, availability: { structural: true, operational: true } },
-      agcModes: [1, 2, 3],
-      agcTimeConstant: { reading: { status: 'known', value: 9 }, availability: { structural: true, operational: true } },
-    });
+    const facts = [dsp.nrActive, dsp.nbActive, dsp.nbLevel, dsp.nbDepth, dsp.nbWidth,
+      dsp.notchMode, dsp.notchFreq, dsp.manualNotchWidth, dsp.agcMode, dsp.agcTimeConstant];
+    expect(facts.map((fact) => fact.reading)).toEqual([
+      { status: 'known', value: true }, { status: 'known', value: true },
+      { status: 'known', value: 7 }, { status: 'known', value: 5 },
+      { status: 'known', value: 3 }, { status: 'known', value: 'manual' },
+      { status: 'known', value: 77 }, { status: 'known', value: 2 },
+      { status: 'known', value: 2 }, { status: 'known', value: 9 },
+    ]);
+    expect(facts.every((fact) => fact.availability.structural && fact.availability.operational)).toBe(true);
+    expect(dsp.agcModes).toEqual([1, 2, 3]);
   });
 
   it('keeps the projection optional for old semantic payloads', () => {
@@ -252,10 +225,54 @@ describe('NR-level semantic projection (MOR-1736)', () => {
     ['extra projection member', { value: 4, domain: EXACT_DISPLAY_DOMAIN, adjustable: true, extra: true }],
     ['extra domain member', { value: 4, domain: { ...EXACT_DISPLAY_DOMAIN, extra: true }, adjustable: true }],
   ])('strictly rejects %s whenever the projection is present', (_label, projection) => {
-    const malformed = structuredClone(model(4, caps(EXACT_NR_DOMAIN))) as unknown as {
-      dsp: Record<string, unknown>;
-    };
-    malformed.dsp.nrLevelProjection = projection;
-    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.dsp\.nrLevelProjection/);
+    expect(() => validateRadioViewModel(payloadWithProjection(projection)))
+      .toThrow(/\$\.dsp\.nrLevelProjection/);
+  });
+
+  it.each([
+    ['projection', Object.create({ value: 4, domain: EXACT_DISPLAY_DOMAIN, adjustable: true, extra: true })],
+    ['domain', { value: 4, domain: Object.create(EXACT_DISPLAY_DOMAIN), adjustable: true }],
+  ])('rejects prototype-inherited %s fields', (_label, projection) => {
+    expect(() => validateRadioViewModel(payloadWithProjection(projection)))
+      .toThrow(/\$\.dsp\.nrLevelProjection/);
+  });
+
+  it('rejects accessors without invoking them', () => {
+    let calls = 0;
+    const projection = Object.defineProperty(
+      { domain: EXACT_DISPLAY_DOMAIN, adjustable: true }, 'value',
+      { enumerable: true, get: () => { calls += 1; throw new Error('getter trap'); } },
+    );
+    expect(() => validateRadioViewModel(payloadWithProjection(projection)))
+      .toThrow(/\$\.dsp\.nrLevelProjection/);
+    const setterDomain = Object.defineProperty(
+      { ...EXACT_DISPLAY_DOMAIN }, 'step', { enumerable: true, set: () => { calls += 1; } },
+    );
+    expect(() => validateRadioViewModel(payloadWithProjection(
+      { value: 4, domain: setterDomain, adjustable: true },
+    ))).toThrow(/\$\.dsp\.nrLevelProjection/);
+    expect(calls).toBe(0);
+  });
+
+  it.each([
+    ['symbol extra', () => ({ value: 4, domain: EXACT_DISPLAY_DOMAIN, adjustable: true, [Symbol('extra')]: true })],
+    ['hidden extra', () => Object.defineProperty(
+      { value: 4, domain: EXACT_DISPLAY_DOMAIN, adjustable: true }, 'extra', { value: true },
+    )],
+    ['hidden required field', () => Object.defineProperty(
+      { domain: EXACT_DISPLAY_DOMAIN, adjustable: true }, 'value', { value: 4 },
+    )],
+  ])('rejects %s', (_label, projection) => {
+    expect(() => validateRadioViewModel(payloadWithProjection(projection())))
+      .toThrow(/\$\.dsp\.nrLevelProjection/);
+  });
+
+  it('converts a proxy reflection trap into normal validator rejection', () => {
+    const projection = new Proxy(
+      { value: 4, domain: EXACT_DISPLAY_DOMAIN, adjustable: true },
+      { ownKeys: () => { throw new Error('proxy ownKeys trap'); } },
+    );
+    expect(() => validateRadioViewModel(payloadWithProjection(projection)))
+      .toThrow(/\$\.dsp\.nrLevelProjection/);
   });
 });

--- a/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
@@ -75,15 +75,22 @@ function state(
   const main = receiver({ nrLevel: raw });
   if (raw === undefined) delete main.nrLevel;
   return {
+    revision: 1,
+    stateRevision: 1,
+    freshnessRevision: 1,
+    observationSeq: 1,
+    updatedAt: '2026-08-15T00:00:00Z',
     active: 'MAIN',
     split: false,
     dualWatch: false,
     ptt: false,
+    tunerStatus: 0,
     txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14_074_000 },
     main,
     sub: receiver(),
     nbDepth: 4,
     nbWidth: 3,
+    connection: { rigConnected: true, radioReady: true, controlConnected: true },
     fieldStatus: {
       active: fresh,
       split: fresh,
@@ -105,7 +112,7 @@ function state(
       'main.agc': fresh,
       'main.agcTimeConstant': fresh,
     },
-  } as ServerState;
+  };
 }
 
 function caps(

--- a/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/nr-level-semantic-projection.isolated.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Capabilities, ControlDomain, ControlRange } from '$lib/types/capabilities';
+import type {
+  FieldAvailability, FieldStatus, ReceiverState, ServerState,
+} from '$lib/types/state';
+import {
+  validateRadioViewModel, type DspViewModel, type RadioViewModel,
+} from '../../../../semantic/radio-view-model';
+import { toRadioViewModel } from '../radio-view-model-adapter';
+
+const EXACT_NR_DOMAIN: ControlDomain = {
+  mapping: 'identity',
+  raw_min: 0,
+  raw_max: 10,
+  raw_step: 1,
+  raw_origin: 0,
+  display_min: '0' as never,
+  display_max: '10' as never,
+  display_step: '1' as never,
+  display_origin: '0' as never,
+  display_unit: 'level',
+  quantization: 'reject',
+  restoration: 'exact',
+};
+
+const EXACT_DISPLAY_DOMAIN = { min: 0, max: 10, step: 1, origin: 0 };
+const LEGACY_DISPLAY_DOMAIN = { min: 0, max: 15, step: 1, origin: 0 };
+const OMIT_NR_METADATA = Symbol('omit-nr-metadata');
+
+const fresh: FieldStatus = {
+  storePath: 'fixture', observed: true, freshness: 'fresh', availability: 'available',
+};
+
+function fieldStatus(availability: FieldAvailability): FieldStatus {
+  return {
+    storePath: 'receiver.nr_level',
+    observed: availability !== 'missing',
+    freshness: availability === 'available'
+      ? 'fresh'
+      : availability === 'stale' ? 'stale' : 'unknown',
+    availability,
+  };
+}
+
+function receiver(overrides: Partial<ReceiverState> = {}): ReceiverState {
+  return {
+    freqHz: 14_074_000,
+    mode: 'USB',
+    filter: 1,
+    dataMode: 0,
+    att: 0,
+    preamp: 0,
+    nb: true,
+    nbLevel: 7,
+    nr: true,
+    afLevel: 128,
+    rfGain: 255,
+    squelch: 0,
+    sMeter: 0,
+    autoNotch: false,
+    manualNotch: true,
+    notchFilter: 77,
+    manualNotchWidth: 2,
+    agc: 2,
+    agcTimeConstant: 9,
+    ...overrides,
+  };
+}
+
+function state(
+  raw: number | undefined,
+  availability: FieldAvailability = 'available',
+): ServerState {
+  const main = receiver({ nrLevel: raw });
+  if (raw === undefined) delete main.nrLevel;
+  return {
+    active: 'MAIN',
+    split: false,
+    dualWatch: false,
+    ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14_074_000 },
+    main,
+    sub: receiver(),
+    nbDepth: 4,
+    nbWidth: 3,
+    fieldStatus: {
+      active: fresh,
+      split: fresh,
+      dualWatch: fresh,
+      txTarget: fresh,
+      'main.freqHz': fresh,
+      'main.mode': fresh,
+      'main.filter': fresh,
+      'main.nr': fresh,
+      'main.nrLevel': fieldStatus(availability),
+      'main.nb': fresh,
+      'main.nbLevel': fresh,
+      nbDepth: fresh,
+      nbWidth: fresh,
+      'main.autoNotch': fresh,
+      'main.manualNotch': fresh,
+      'main.notchFilter': fresh,
+      'main.manualNotchWidth': fresh,
+      'main.agc': fresh,
+      'main.agcTimeConstant': fresh,
+    },
+  } as ServerState;
+}
+
+function caps(
+  nrLevel: unknown | typeof OMIT_NR_METADATA = OMIT_NR_METADATA,
+): Capabilities {
+  const nbDepth: ControlRange = {
+    raw_min: 0, raw_max: 9, raw_center: 0, display_min: 1, display_max: 10,
+  };
+  const controls = nrLevel === OMIT_NR_METADATA
+    ? { nb_depth: nbDepth }
+    : { nr_level: nrLevel, nb_depth: nbDepth };
+  return {
+    model: 'FTX-1 fixture',
+    scope: false,
+    audio: false,
+    tx: false,
+    capabilities: ['nr', 'nb', 'notch', 'agc'],
+    receivers: 1,
+    vfoScheme: 'single',
+    freqRanges: [],
+    modes: [],
+    filters: [],
+    audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm'] },
+    webrtc: { available: false, enabled: false },
+    txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+    agcModes: [1, 2, 3],
+    controls: controls as Capabilities['controls'],
+  };
+}
+
+function model(
+  raw: number | undefined,
+  capabilities: Capabilities,
+  availability: FieldAvailability = 'available',
+): RadioViewModel {
+  const view = toRadioViewModel(state(raw, availability), capabilities);
+  expect(view).not.toBeNull();
+  return validateRadioViewModel(view);
+}
+
+function projectionOf(dsp: DspViewModel): unknown {
+  return (dsp as DspViewModel & { nrLevelProjection?: unknown }).nrLevelProjection;
+}
+
+describe('NR-level semantic projection (MOR-1736)', () => {
+  it.each([0, 1, 4, 10])('carries exact FTX-1 raw/display %i through adapter and validator', (raw) => {
+    const dsp = model(raw, caps(EXACT_NR_DOMAIN)).dsp!;
+    expect(projectionOf(dsp)).toEqual({
+      value: raw,
+      domain: EXACT_DISPLAY_DOMAIN,
+      adjustable: true,
+    });
+    expect(dsp.nrLevel.reading).toEqual({ status: 'known', value: raw });
+  });
+
+  it.each([
+    ['stale readback', 4, 'stale'],
+    ['unread value', undefined, 'missing'],
+    ['below-domain value', -1, 'available'],
+    ['above-domain value', 11, 'available'],
+  ] as const)('fails closed for %s', (_label, raw, availability) => {
+    const dsp = model(raw, caps(EXACT_NR_DOMAIN), availability).dsp!;
+    expect(projectionOf(dsp)).toEqual({
+      value: null,
+      domain: EXACT_DISPLAY_DOMAIN,
+      adjustable: false,
+    });
+    expect(dsp.nrLevel.reading).toEqual({ status: 'unknown' });
+  });
+
+  it.each([
+    ['malformed metadata', () => ({ ...EXACT_NR_DOMAIN, display_max: '9' })],
+    ['trapping metadata', () => new Proxy({ ...EXACT_NR_DOMAIN }, {
+      get: () => { throw new Error('nr_level metadata trap'); },
+    })],
+  ] as const)('does not throw and fails closed for %s', (_label, metadata) => {
+    let view: RadioViewModel | undefined;
+    expect(() => { view = model(4, caps(metadata())); }).not.toThrow();
+    expect(projectionOf(view!.dsp!)).toEqual({ value: null, domain: null, adjustable: false });
+    expect(view!.dsp!.nrLevel.reading).toEqual({ status: 'unknown' });
+  });
+
+  it.each([
+    [0, 0],
+    [128, 8],
+    [255, 15],
+  ])('preserves absent-metadata legacy raw %i as display %i', (raw, display) => {
+    const dsp = model(raw, caps()).dsp!;
+    expect(projectionOf(dsp)).toEqual({
+      value: display,
+      domain: LEGACY_DISPLAY_DOMAIN,
+      adjustable: true,
+    });
+    expect(dsp.nrLevel.reading).toEqual({ status: 'known', value: display });
+  });
+
+  it('leaves NR toggle, NB, notch, and AGC facts unchanged', () => {
+    const dsp = model(4, caps(EXACT_NR_DOMAIN)).dsp!;
+    expect({
+      nrActive: dsp.nrActive,
+      nbActive: dsp.nbActive,
+      nbLevel: dsp.nbLevel,
+      nbDepth: dsp.nbDepth,
+      nbWidth: dsp.nbWidth,
+      notchMode: dsp.notchMode,
+      notchFreq: dsp.notchFreq,
+      manualNotchWidth: dsp.manualNotchWidth,
+      agcMode: dsp.agcMode,
+      agcModes: dsp.agcModes,
+      agcTimeConstant: dsp.agcTimeConstant,
+    }).toEqual({
+      nrActive: { reading: { status: 'known', value: true }, availability: { structural: true, operational: true } },
+      nbActive: { reading: { status: 'known', value: true }, availability: { structural: true, operational: true } },
+      nbLevel: { reading: { status: 'known', value: 7 }, availability: { structural: true, operational: true } },
+      nbDepth: { reading: { status: 'known', value: 5 }, availability: { structural: true, operational: true } },
+      nbWidth: { reading: { status: 'known', value: 3 }, availability: { structural: true, operational: true } },
+      notchMode: { reading: { status: 'known', value: 'manual' }, availability: { structural: true, operational: true } },
+      notchFreq: { reading: { status: 'known', value: 77 }, availability: { structural: true, operational: true } },
+      manualNotchWidth: { reading: { status: 'known', value: 2 }, availability: { structural: true, operational: true } },
+      agcMode: { reading: { status: 'known', value: 2 }, availability: { structural: true, operational: true } },
+      agcModes: [1, 2, 3],
+      agcTimeConstant: { reading: { status: 'known', value: 9 }, availability: { structural: true, operational: true } },
+    });
+  });
+
+  it('keeps the projection optional for old semantic payloads', () => {
+    const legacy = structuredClone(model(4, caps(EXACT_NR_DOMAIN))) as RadioViewModel;
+    delete (legacy.dsp as DspViewModel & { nrLevelProjection?: unknown }).nrLevelProjection;
+    const validated = validateRadioViewModel(legacy);
+    expect(projectionOf(validated.dsp!)).toBeUndefined();
+  });
+
+  it.each([
+    ['malformed value', { value: '4', domain: EXACT_DISPLAY_DOMAIN, adjustable: true }],
+    ['extra projection member', { value: 4, domain: EXACT_DISPLAY_DOMAIN, adjustable: true, extra: true }],
+    ['extra domain member', { value: 4, domain: { ...EXACT_DISPLAY_DOMAIN, extra: true }, adjustable: true }],
+  ])('strictly rejects %s whenever the projection is present', (_label, projection) => {
+    const malformed = structuredClone(model(4, caps(EXACT_NR_DOMAIN))) as unknown as {
+      dsp: Record<string, unknown>;
+    };
+    malformed.dsp.nrLevelProjection = projection;
+    expect(() => validateRadioViewModel(malformed)).toThrow(/\$\.dsp\.nrLevelProjection/);
+  });
+});

--- a/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
@@ -45,8 +45,9 @@ import {
 } from '$lib/runtime/props/panel-props';
 import {
   deriveIfShift, pbtRangeFromCaps, pbtRawToHz,
-  controlRangeFromCapsOrDefault, nrRawToDisplay, nbDepthRawToDisplay,
+  controlRangeFromCapsOrDefault, nbDepthRawToDisplay, projectNrLevel,
 } from '$lib/radio/filter-controls';
+import type { NrLevelProjection } from '$lib/radio/filter-controls';
 import {
   derivePresentationCapabilities, type ReceiverId, type VfoSlotId,
 } from './presentation-capabilities';
@@ -573,28 +574,15 @@ function deriveDsp(
   const rx = onSub ? state?.sub : state?.main;
   const base = onSub ? 'sub.' : 'main.';
 
-  // The ONE shipped display-scale conversions (`nrRawToDisplay`/
-  // `nbDepthRawToDisplay`, `$lib/radio/filter-controls`) — called with the
-  // range explicitly derived from THIS function's own `caps` argument
-  // (`controlRangeFromCapsOrDefault`, mirroring `filterPassband`'s
-  // `pbtRangeFromCaps`, MOR-1284 F1), not the capabilities STORE singleton
-  // they otherwise fall back to. MOR-1290 F1 (verify round 1): the plain
-  // `controlRangeFromCaps` alone still returns `undefined` when `caps`
-  // declares no range for the key, and passing `undefined` as `range` makes
-  // `nrRawToDisplay`/`nbDepthRawToDisplay` fall through to THEIR OWN store
-  // lookup — reintroducing the exact module-global dependency this is meant
-  // to close, for the one case (`caps` omitting the key) that matters most
-  // (a server whose capabilities haven't fully landed yet). The `…OrDefault`
-  // wrapper always returns a CONCRETE range — this module's own
-  // `CONTROL_DEFAULTS`, the same ones `nrRawToDisplay`/`nbDepthRawToDisplay`
-  // fall back to today — so the store is NEVER consulted here, in either
-  // branch: the fact is a pure function of `(state, caps)` unconditionally.
-  // See the determinism pin in `__tests__/dsp-adapter.isolated.test.ts`. Computed only
-  // from the field's OWN raw value — never from a `?? 0` stand-in — so an
-  // unobserved nrLevel/nbDepth never silently reports a fabricated reading.
-  const nrLevelRange = controlRangeFromCapsOrDefault('nr_level', caps);
+  // NR readback is projected through the one shared exact/legacy contract;
+  // the semantic reading comes back from that same projection, so the two
+  // cannot disagree. NB depth retains its shipped explicit-range conversion.
+  // Both are computed from the field's own raw value, never a `?? 0` stand-in.
   const nrLevelRaw = numOrUndef(rx?.nrLevel);
-  const nrLevelValue = nrLevelRaw !== undefined ? nrRawToDisplay(nrLevelRaw, nrLevelRange) : undefined;
+  const nrLevelReadable = topFieldAvailable(state, `${base}nrLevel`);
+  const nrLevelProjection: NrLevelProjection = projectNrLevel(
+    caps, nrLevelRaw, nrLevelReadable,
+  );
 
   const nbDepthRange = controlRangeFromCapsOrDefault('nb_depth', caps);
   const nbDepthRaw = numOrUndef(state?.nbDepth);
@@ -614,7 +602,8 @@ function deriveDsp(
 
   return {
     nrActive: txAuxField(hasNrCap, topFieldAvailable(state, `${base}nr`), boolOrUndef(rx?.nr)),
-    nrLevel: txAuxField(hasNrCap, topFieldAvailable(state, `${base}nrLevel`), nrLevelValue),
+    nrLevel: txAuxField(hasNrCap, nrLevelReadable, nrLevelProjection.value ?? undefined),
+    nrLevelProjection,
     nbActive: txAuxField(hasNbCap, topFieldAvailable(state, `${base}nb`), boolOrUndef(rx?.nb)),
     nbLevel: txAuxField(hasNbCap, topFieldAvailable(state, `${base}nbLevel`), numOrUndef(rx?.nbLevel)),
     nbDepth: txAuxField(hasNbDepth, topFieldAvailable(state, 'nbDepth'), nbDepthValue),

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -1447,9 +1447,40 @@ const NOTCH_MODES = ['off', 'auto', 'manual'] as const;
 
 type NrLevelDisplayDomain = NonNullable<NrLevelProjection['domain']>;
 
+function exactOwnDataRecord(
+  value: unknown, keys: readonly string[], path: string,
+): Record<string, unknown> {
+  let snapshot: Record<string, unknown> | null = null;
+  try {
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)
+      && Object.getPrototypeOf(value) === Object.prototype) {
+      const ownKeys = Reflect.ownKeys(value);
+      if (ownKeys.length === keys.length
+        && ownKeys.every((key) => typeof key === 'string' && keys.includes(key))) {
+        const candidate: Record<string, unknown> = {};
+        let valid = true;
+        for (const key of keys) {
+          const descriptor = Object.getOwnPropertyDescriptor(value, key);
+          if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) {
+            valid = false;
+            break;
+          }
+          candidate[key] = descriptor.value;
+        }
+        if (valid) snapshot = candidate;
+      }
+    }
+  } catch {
+    snapshot = null;
+  }
+  if (snapshot === null) invalid(path, `a plain object with exact own data properties [${keys.join(', ')}]`);
+  return snapshot;
+}
+
 function validateNrLevelDisplayDomain(value: unknown, path: string): NrLevelDisplayDomain {
-  const v = record(value, path);
-  exactKeys(v, ['min', 'max', 'step', 'origin'] satisfies readonly (keyof NrLevelDisplayDomain)[], path);
+  const v = exactOwnDataRecord(
+    value, ['min', 'max', 'step', 'origin'] satisfies readonly (keyof NrLevelDisplayDomain)[], path,
+  );
   return {
     min: num(v.min, `${path}.min`),
     max: num(v.max, `${path}.max`),
@@ -1459,8 +1490,9 @@ function validateNrLevelDisplayDomain(value: unknown, path: string): NrLevelDisp
 }
 
 function validateNrLevelProjection(value: unknown, path: string): NrLevelProjection {
-  const v = record(value, path);
-  exactKeys(v, ['value', 'domain', 'adjustable'] satisfies readonly (keyof NrLevelProjection)[], path);
+  const v = exactOwnDataRecord(
+    value, ['value', 'domain', 'adjustable'] satisfies readonly (keyof NrLevelProjection)[], path,
+  );
   return {
     value: nullableNumber(v.value, `${path}.value`),
     domain: v.domain === null ? null : validateNrLevelDisplayDomain(v.domain, `${path}.domain`),

--- a/frontend/src/semantic/radio-view-model.ts
+++ b/frontend/src/semantic/radio-view-model.ts
@@ -16,6 +16,7 @@
  * boolean or a default is the failure mode this contract exists to prevent.
  */
 import type { VfoScheme } from '$lib/types/capabilities';
+import type { NrLevelProjection } from '$lib/radio/filter-controls';
 import type { FrequencyPermit, TxPermit } from '$lib/utils/tx-permit';
 import { invalid, record, exactKeys, str } from './validator-primitives';
 
@@ -398,15 +399,11 @@ export type DspField<T> = TxAuxField<T>;
  * IF-shift, and PBT are family 4 (`filterPassband`, MOR-1284) — this group
  * never duplicates them.
  *
- * `nrLevel`/`nbDepth` are the ONE remaining consumers of `$lib/radio/filter-
- * controls`'s `nrRawToDisplay`/`nbDepthRawToDisplay` — the exact functions
- * `toDspProps` calls — never a re-derived scale (X6200 lesson: control
- * scaling is per-radio-model data, `caps.controls.nr_level`/`.nb_depth`).
- * Like `filterPassband`'s `pbtInner`/`pbtOuter` (MOR-1284 F1), the adapter
- * passes both an explicit `ControlDisplayRange` derived from THIS request's
- * own `caps` argument (`controlRangeFromCaps`) rather than letting them fall
- * back to the capabilities STORE singleton — a fact-layer value must be a
- * pure function of `(state, caps)`, never of module-global state.
+ * `nrLevel` carries the shared `projectNrLevel` result; `nbDepth` uses
+ * `nbDepthRawToDisplay`. Both consume `$lib/radio/filter-controls` rather
+ * than re-deriving a scale (X6200 lesson: scaling is per-radio-model data).
+ * The projection is optional only so semantic payloads and fixtures produced
+ * before MOR-1736 remain valid; the live adapter always emits it.
  *
  * `agcModes` is the capability-derived AGC choice set (`Capabilities.
  * agcModes`, verbatim) — a plain list, not `DspField`-wrapped, for the same
@@ -417,6 +414,8 @@ export type DspField<T> = TxAuxField<T>;
 export interface DspViewModel {
   nrActive: DspField<boolean>;
   nrLevel: DspField<number>;
+  /** Optional only for semantic payloads/fixtures produced before MOR-1736. */
+  nrLevelProjection?: NrLevelProjection;
   nbActive: DspField<boolean>;
   nbLevel: DspField<number>;
   nbDepth: DspField<number>;
@@ -1446,17 +1445,44 @@ function validateFilterPassband(value: unknown, path: string): FilterPassbandVie
 
 const NOTCH_MODES = ['off', 'auto', 'manual'] as const;
 
-/** N4 again: exactly the twelve facts the adapter reads, no speculative keys.
+type NrLevelDisplayDomain = NonNullable<NrLevelProjection['domain']>;
+
+function validateNrLevelDisplayDomain(value: unknown, path: string): NrLevelDisplayDomain {
+  const v = record(value, path);
+  exactKeys(v, ['min', 'max', 'step', 'origin'] satisfies readonly (keyof NrLevelDisplayDomain)[], path);
+  return {
+    min: num(v.min, `${path}.min`),
+    max: num(v.max, `${path}.max`),
+    step: num(v.step, `${path}.step`),
+    origin: num(v.origin, `${path}.origin`),
+  };
+}
+
+function validateNrLevelProjection(value: unknown, path: string): NrLevelProjection {
+  const v = record(value, path);
+  exactKeys(v, ['value', 'domain', 'adjustable'] satisfies readonly (keyof NrLevelProjection)[], path);
+  return {
+    value: nullableNumber(v.value, `${path}.value`),
+    domain: v.domain === null ? null : validateNrLevelDisplayDomain(v.domain, `${path}.domain`),
+    adjustable: bool(v.adjustable, `${path}.adjustable`),
+  };
+}
+
+/** N4 again: exactly the adapter's DSP facts, no speculative keys.
  *  See `radio-view-model-adapter.ts::deriveDsp`. */
 function validateDsp(value: unknown, path: string): DspViewModel {
   const v = record(value, path);
   exactKeys(v, [
-    'nrActive', 'nrLevel', 'nbActive', 'nbLevel', 'nbDepth', 'nbWidth',
+    'nrActive', 'nrLevel', 'nrLevelProjection', 'nbActive', 'nbLevel', 'nbDepth', 'nbWidth',
     'notchMode', 'notchFreq', 'manualNotchWidth', 'agcMode', 'agcModes', 'agcTimeConstant',
   ], path);
+  const nrLevelProjection = optionalGroup(
+    v.nrLevelProjection, `${path}.nrLevelProjection`, validateNrLevelProjection,
+  );
   return {
     nrActive: validateTxAuxField(v.nrActive, `${path}.nrActive`, bool),
     nrLevel: validateTxAuxField(v.nrLevel, `${path}.nrLevel`, num),
+    ...(nrLevelProjection !== undefined ? { nrLevelProjection } : {}),
     nbActive: validateTxAuxField(v.nbActive, `${path}.nbActive`, bool),
     nbLevel: validateTxAuxField(v.nbLevel, `${path}.nbLevel`, num),
     nbDepth: validateTxAuxField(v.nbDepth, `${path}.nbDepth`, num),


### PR DESCRIPTION
## Summary

- add the optional semantic `nrLevelProjection` member for backward-compatible payload validation
- derive semantic NR reading and projection from the shared `projectNrLevel(...)` contract
- validate projection and domain through exact own-data snapshots that reject inherited fields, accessors, symbols, hidden properties, non-plain prototypes, and reflection traps

Linear: [MOR-1736](https://linear.app/morozsm/issue/MOR-1736/carry-the-exact-nr-level-projection-through-the-semantic-dsp-model)
Parent: [MOR-1678](https://linear.app/morozsm/issue/MOR-1678)

## RED / GREEN evidence

- initial RED commit `3b9289bc684e3035bd2df7485e9e9b4c82f5240e`: focused test failed as intended, 16 failed / 2 passed
- initial GREEN commit `8cf624829aa693613ce395abccdc54e62f223368`: focused test 18/18 passed
- verifier remediation RED: 7 adversarial cases failed / 18 passed on the blocked head
- remediation commit `8f628eb0e7232bbecf2e72b2fa2e801a3833bd99`: focused regression set 3 files, 84/84 passed
- full frontend test suite: 362 files, 7925/7925 passed
- `npm run i18n:check`, `npm run check`, `npm run lint`, `npm run lint:boundaries`, and `npm run build` passed
- `git diff --check` passed

## Scope and compatibility

Additive internal frontend semantic contract only. Three owned files and 393 changed LOC. No mounted component, command/backend, bench/runtime/radio, TX/PTT/TUNE/keying, public HTTP, or wire API changes.