### PR TITLE
fix(MOR-1737): consume exact NR projection in semantic DSP

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -189,6 +189,11 @@ const DSP_STATE = {
   autoNotch: false, manualNotch: false, notchFilter: 0, manualNotchWidth: 1,
   agc: 2, agcTimeConstant: 3,
 } as const;
+const EXACT_NR_DOMAIN = {
+  mapping: 'identity', raw_min: 0, raw_max: 10, raw_step: 1, raw_origin: 0,
+  display_min: '0', display_max: '10', display_step: '1', display_origin: '0',
+  display_unit: 'level', quantization: 'reject', restoration: 'exact',
+} as const;
 const DSP_PATHS = [
   'main.nr', 'main.nrLevel', 'main.nb', 'main.nbLevel', 'main.autoNotch',
   'main.manualNotch', 'main.manualNotchWidth', 'main.agc', 'main.agcTimeConstant',
@@ -382,6 +387,57 @@ describe('every dsp intent reaches its own command-bus handler', () => {
     q<HTMLButtonElement>('[data-testid="dsp-agcMode-1"]')!.click();
     flushSync();
     expect(h.agcMode).toHaveBeenCalledExactlyOnceWith(1);
+  });
+});
+
+describe('mounted exact NR projection (MOR-1737)', () => {
+  function exactState(raw: number): ServerState {
+    const state = liveState(true);
+    return { ...state, main: { ...state.main, nrLevel: raw } };
+  }
+
+  function exactCaps(): Capabilities {
+    const caps = liveCaps(true);
+    return {
+      ...caps,
+      controls: { ...caps.controls, nr_level: EXACT_NR_DOMAIN },
+    } as unknown as Capabilities;
+  }
+
+  it.each([0, 1, 4, 10])(
+    'carries FTX-1 runtime raw %i through the real semantic adapter and mounted surface',
+    (raw) => {
+      h.state = exactState(raw);
+      h.caps = exactCaps();
+      render();
+      const input = q<HTMLInputElement>('[data-testid="dsp-nrLevel"] input')!;
+      expect(input.min).toBe('0');
+      expect(input.max).toBe('10');
+      expect(input.step).toBe('1');
+      expect(input.valueAsNumber).toBe(raw);
+      expect(input.disabled).toBe(false);
+    },
+  );
+
+  it('routes display/raw 4 only to the terminal NR-level handler', () => {
+    h.state = exactState(4);
+    h.caps = exactCaps();
+    render();
+    const input = q<HTMLInputElement>('[data-testid="dsp-nrLevel"] input')!;
+    input.value = '4';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    expect(h.nrLevel).toHaveBeenCalledExactlyOnceWith(4);
+  });
+
+  it('preserves the safely absent exact-metadata legacy 0..15 projection', () => {
+    render();
+    const input = q<HTMLInputElement>('[data-testid="dsp-nrLevel"] input')!;
+    expect(input.min).toBe('0');
+    expect(input.max).toBe('15');
+    expect(input.step).toBe('1');
+    expect(input.valueAsNumber).toBe(8);
+    expect(input.disabled).toBe(false);
   });
 });
 

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -88,10 +88,15 @@
     value: number; text: string; usable: boolean;
   }>;
 
+  const safeNrInteger = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value);
+  const onNrLattice = (value: number, origin: number, step: number): boolean =>
+    (BigInt(value) - BigInt(origin)) % BigInt(step) === 0n;
   const acceptsNrValue = (value: unknown, domain: NonNullable<NrDomain>): value is number =>
-    typeof value === 'number' && Number.isSafeInteger(value)
+    safeNrInteger(value) && safeNrInteger(domain.origin)
+    && safeNrInteger(domain.step) && domain.step > 0
     && value >= domain.min && value <= domain.max
-    && (value - domain.origin) % domain.step === 0;
+    && onNrLattice(value, domain.origin, domain.step);
 
   function nrPresentation(dsp: DspViewModel): NrPresentation {
     const unavailable = {
@@ -102,10 +107,12 @@
       const projection = dsp.nrLevelProjection;
       const domain = projection?.domain;
       if (!projection || !domain
-        || !Number.isSafeInteger(domain.min) || !Number.isSafeInteger(domain.max)
-        || !Number.isSafeInteger(domain.step) || domain.step <= 0
-        || !Number.isSafeInteger(domain.origin)
-        || domain.min >= domain.max || domain.origin < domain.min || domain.origin > domain.max) {
+        || !safeNrInteger(domain.min) || !safeNrInteger(domain.max)
+        || !safeNrInteger(domain.step) || domain.step <= 0
+        || !safeNrInteger(domain.origin)
+        || domain.min >= domain.max || domain.origin < domain.min || domain.origin > domain.max
+        || !onNrLattice(domain.min, domain.origin, domain.step)
+        || !onNrLattice(domain.max, domain.origin, domain.step)) {
         return unavailable;
       }
       const projectionUsable = projection.adjustable === true

--- a/frontend/src/semantic/DspSurface.svelte
+++ b/frontend/src/semantic/DspSurface.svelte
@@ -25,7 +25,8 @@
       unobserved present field, honestly disabled.
   (3) Every reading here is rendered exactly as the fact group states it. No
       range-fallback plumbing, no re-derivation of `controlRangeFromCaps` —
-      `nrLevel`/`nbDepth` already arrive display-scaled from the adapter.
+      `nrLevelProjection` carries NR value/domain/usability and `nbDepth`
+      already arrives display-scaled from the adapter.
   (4) `unknown` renders as `?`, never as a v2 fabricated default (0 dB, OFF,
       WIDE) — same fail-closed-presentation doctrine as `TxAuxSurface`.
 
@@ -42,7 +43,7 @@
   digits.
 -->
 <script module lang="ts">
-  import type { DspField } from './radio-view-model';
+  import type { DspField, DspViewModel } from './radio-view-model';
   import { buildAgcOptions } from '../components-v2/panels/agc-utils';
   import { NOTCH_WIDTH_LABELS, formatAgcTime } from '../components-v2/panels/dsp-panel-logic';
   import { rawToPercentDisplay } from '../components-v2/controls/value-control/value-control-core';
@@ -66,6 +67,7 @@
   export type DspToggleField = (typeof DSP_TOGGLES)[number][0];
   export type DspLevelField = (typeof DSP_LEVELS)[number][0] | 'nbLevel';
   const NOTCH_MODES = ['off', 'auto', 'manual'] as const;
+  const [, , NR_FALLBACK_MIN, NR_FALLBACK_MAX, NR_FALLBACK_STEP] = DSP_LEVELS[0];
 
   /** Usable ⇔ the radio HAS it, it is readable NOW, and it has been observed. */
   const usable = (f: DspField<unknown>): boolean =>
@@ -79,6 +81,46 @@
     const v = f.reading.value;
     return typeof v === 'boolean' ? (v ? 'on' : 'off') : format ? format(v as number) : String(v);
   };
+
+  type NrDomain = NonNullable<DspViewModel['nrLevelProjection']>['domain'];
+  type NrPresentation = Readonly<{
+    min: number; max: number; step: number; origin: number;
+    value: number; text: string; usable: boolean;
+  }>;
+
+  const acceptsNrValue = (value: unknown, domain: NonNullable<NrDomain>): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value)
+    && value >= domain.min && value <= domain.max
+    && (value - domain.origin) % domain.step === 0;
+
+  function nrPresentation(dsp: DspViewModel): NrPresentation {
+    const unavailable = {
+      min: NR_FALLBACK_MIN, max: NR_FALLBACK_MAX, step: NR_FALLBACK_STEP,
+      origin: NR_FALLBACK_MIN, value: NR_FALLBACK_MIN, text: '?', usable: false,
+    } as const;
+    try {
+      const projection = dsp.nrLevelProjection;
+      const domain = projection?.domain;
+      if (!projection || !domain
+        || !Number.isSafeInteger(domain.min) || !Number.isSafeInteger(domain.max)
+        || !Number.isSafeInteger(domain.step) || domain.step <= 0
+        || !Number.isSafeInteger(domain.origin)
+        || domain.min >= domain.max || domain.origin < domain.min || domain.origin > domain.max) {
+        return unavailable;
+      }
+      const projectionUsable = projection.adjustable === true
+        && usable(dsp.nrLevel)
+        && acceptsNrValue(projection.value, domain);
+      return {
+        ...domain,
+        value: projectionUsable ? projection.value : domain.origin,
+        text: projectionUsable ? String(projection.value) : '?',
+        usable: projectionUsable,
+      };
+    } catch {
+      return unavailable;
+    }
+  }
 </script>
 
 <script lang="ts">
@@ -125,7 +167,15 @@
     if (f && usable(f) && f.reading.status === 'known') onToggle?.(field, !f.reading.value);
   }
   function level(field: DspLevelField, value: number): void {
-    if (dsp && usable(dsp[field])) onLevelChange?.(field, value);
+    if (!dsp) return;
+    if (field === 'nrLevel') {
+      const presentation = nrPresentation(dsp);
+      if (presentation.usable && acceptsNrValue(value, presentation)) {
+        onLevelChange?.(field, value);
+      }
+      return;
+    }
+    if (usable(dsp[field])) onLevelChange?.(field, value);
   }
   function notch(mode: (typeof NOTCH_MODES)[number]): void {
     if (dsp && usable(dsp.notchMode)) onNotchModeChange?.(mode);
@@ -158,17 +208,19 @@
 
     {#each DSP_LEVELS as [field, label, min, max, step, format] (field)}
       {#if dsp[field].availability.structural}
+        {@const nr = field === 'nrLevel' ? nrPresentation(dsp) : null}
         <label
           class="dsp-level" data-testid={`dsp-${field}`} data-field={field}
-          data-disabled-reason={reasonOf(dsp[field])}
+          data-disabled-reason={nr ? (nr.usable ? undefined : 'field-not-observed') : reasonOf(dsp[field])}
         >
           <span class="dsp-name">{label}</span>
           <input
-            type="range" {min} {max} {step} value={numberOf(dsp[field], min)}
-            disabled={!usable(dsp[field])}
+            type="range" min={nr?.min ?? min} max={nr?.max ?? max} step={nr?.step ?? step}
+            value={nr?.value ?? numberOf(dsp[field], min)}
+            disabled={nr ? !nr.usable : !usable(dsp[field])}
             oninput={(event) => level(field, event.currentTarget.valueAsNumber)}
           />
-          <output>{fmt(dsp[field], format)}</output>
+          <output>{nr?.text ?? fmt(dsp[field], format)}</output>
         </label>
       {/if}
     {/each}

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -364,6 +364,35 @@ describe('exact NR-level projection (MOR-1737)', () => {
       expect(onLevelChange).not.toHaveBeenCalled();
     }, { onLevelChange });
   });
+
+  it.each([
+    ['endpoints off the origin lattice', {
+      value: 5,
+      domain: { min: 0, max: 10, step: 2, origin: 1 },
+      adjustable: true,
+    }],
+    ['overflow-sensitive endpoint delta', {
+      value: Number.MIN_SAFE_INTEGER,
+      domain: {
+        min: Number.MIN_SAFE_INTEGER,
+        max: Number.MAX_SAFE_INTEGER - 1,
+        step: 5,
+        origin: Number.MIN_SAFE_INTEGER,
+      },
+      adjustable: true,
+    }],
+  ] as const)('rejects a projection with %s', (_label, projection) => {
+    const onLevelChange = vi.fn();
+    const view = withNrProjection(projection.value, projection);
+    withSurface(view, (s) => {
+      const input = s.input('nrLevel')!;
+      expect(input.disabled).toBe(true);
+      input.value = String(projection.value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).not.toHaveBeenCalled();
+    }, { onLevelChange });
+  });
 });
 
 // ── 4b. Manual-notch position is the CI-V raw 0..255 domain ───────────────

--- a/frontend/src/semantic/__tests__/DspSurface.test.ts
+++ b/frontend/src/semantic/__tests__/DspSurface.test.ts
@@ -20,7 +20,19 @@ import type { Availability, DspViewModel, RadioViewModel } from '../radio-view-m
 
 /** `1/single` + a fully-observed dsp group (nrActive true, nbActive false —
  *  both toggles exercised at least once by the base fixture). */
-const base = (): RadioViewModel => withDsp(topologyFixtures['1/single']);
+const LEGACY_NR_DOMAIN = { min: 0, max: 15, step: 1, origin: 0 } as const;
+const EXACT_NR_DOMAIN = { min: 0, max: 10, step: 1, origin: 0 } as const;
+
+const base = (): RadioViewModel => {
+  const view = withDsp(topologyFixtures['1/single']);
+  return {
+    ...view,
+    dsp: {
+      ...view.dsp!,
+      nrLevelProjection: { value: 8, domain: LEGACY_NR_DOMAIN, adjustable: true },
+    },
+  };
+};
 
 type AnyField = keyof DspViewModel;
 const NUMERIC_FIELDS: readonly AnyField[] = [
@@ -51,6 +63,21 @@ function withField(
         availability: over.availability ?? current.availability,
       },
     } as DspViewModel,
+  };
+}
+
+function withNrProjection(
+  value: number,
+  projection: DspViewModel['nrLevelProjection'],
+): RadioViewModel {
+  const view = base();
+  return {
+    ...view,
+    dsp: {
+      ...view.dsp!,
+      nrLevel: { ...view.dsp!.nrLevel, reading: { status: 'known', value } },
+      ...(projection === undefined ? {} : { nrLevelProjection: projection }),
+    },
   };
 }
 
@@ -267,6 +294,71 @@ describe('level intents reach the caller with the field and the raw value', () =
       const input = s.input('nrLevel')!;
       expect(input.disabled).toBe(true);
       input.value = '9';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).not.toHaveBeenCalled();
+    }, { onLevelChange });
+  });
+});
+
+describe('exact NR-level projection (MOR-1737)', () => {
+  it.each([0, 1, 4, 10])('renders exact FTX-1 display value %i in its native domain', (value) => {
+    const view = withNrProjection(value, { value, domain: EXACT_NR_DOMAIN, adjustable: true });
+    withSurface(view, (s) => {
+      const input = s.input('nrLevel')!;
+      expect(input.min).toBe('0');
+      expect(input.max).toBe('10');
+      expect(input.step).toBe('1');
+      expect(input.valueAsNumber).toBe(value);
+      expect(s.control('nrLevel')!.textContent).toContain(String(value));
+      expect(input.disabled).toBe(false);
+    });
+  });
+
+  it('emits exact display value 4 without re-projection', () => {
+    const onLevelChange = vi.fn();
+    const view = withNrProjection(4, { value: 4, domain: EXACT_NR_DOMAIN, adjustable: true });
+    withSurface(view, (s) => {
+      const input = s.input('nrLevel')!;
+      input.value = '4';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('nrLevel', 4);
+    }, { onLevelChange });
+  });
+
+  it('uses the projection origin for an unread thumb position', () => {
+    const view = withField(withNrProjection(4, {
+      value: null,
+      domain: { min: 0, max: 10, step: 1, origin: 4 },
+      adjustable: false,
+    }), 'nrLevel', { unknown: true });
+    withSurface(view, (s) => {
+      expect(s.input('nrLevel')!.valueAsNumber).toBe(4);
+      expect(s.input('nrLevel')!.disabled).toBe(true);
+    });
+  });
+
+  it.each([
+    ['malformed projection', withNrProjection(4, {
+      value: 4, domain: { min: 0, max: 10, step: 0, origin: 0 }, adjustable: true,
+    })],
+    ['stale projection', withField(withNrProjection(4, {
+      value: null, domain: EXACT_NR_DOMAIN, adjustable: false,
+    }), 'nrLevel', { availability: { structural: true, operational: false } })],
+    ['unread projection', withField(withNrProjection(4, {
+      value: null, domain: EXACT_NR_DOMAIN, adjustable: false,
+    }), 'nrLevel', { unknown: true })],
+    ['out-of-domain projection', withNrProjection(11, {
+      value: 11, domain: EXACT_NR_DOMAIN, adjustable: true,
+    })],
+    ['absent projection', withDsp(topologyFixtures['1/single'])],
+  ] as const)('fails closed for %s and guards the callback independently of disabled', (_label, view) => {
+    const onLevelChange = vi.fn();
+    withSurface(view, (s) => {
+      const input = s.input('nrLevel')!;
+      expect(input.disabled).toBe(true);
+      input.value = '4';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       flushSync();
       expect(onLevelChange).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- consume `dsp.nrLevelProjection` as the sole NR value/domain/adjustability source in `DspSurface`
- use projection origin for unavailable thumb positioning and fail closed for absent or invalid projections
- preserve `DSP_LEVELS`, legacy 0..15 projection behavior, and every non-NR DSP path
- prove mounted runtime state -> semantic adapter -> surface projection with only the terminal NR-level handler observed

## Tracking

- Linear: [MOR-1737](https://linear.app/morozsm/issue/MOR-1737/consume-the-exact-nr-level-projection-in-mounted-semantic-dsp)
- Parent: [MOR-1678](https://linear.app/morozsm/issue/MOR-1678/honor-the-ftx-1-native-nr-010-domain-in-every-web-projection-and-intent)

## RED / GREEN evidence

RED commit `d29a9640143f305aebbcd0135ade18c4804f658f`:

- focused command failed genuinely with 12 failures and 99 passes
- failures pinned exact FTX-1 0..10 bounds, origin fallback, and fail-closed projection handling

GREEN head `9c1eb159d3d0f8d9b5d941f2831970414f94c314`:

- focused Vitest: 111 passed
- `npm run i18n:check`: pass
- `npm run check`: pass, 0 errors / 0 warnings
- `npm run lint`: pass
- `npm run lint:boundaries`: pass
- `npm test`: 363 files / 7954 tests passed
- `npm run build`: pass
- `git diff --check`: pass

## Scope and exclusions

Exactly three frontend files changed, 208 insertions and 8 deletions. `SemanticRadioSurfaces.svelte` is unchanged. No capability re-projection or copied conversion arithmetic was added. No command/backend, bench/runtime/radio, TX/PTT/TUNE/keying, HTTP, wire, or hardware API change.

Hardware validation is not required for this presentation-only slice. Independent exact-head agent review remains required before merge.