### PR TITLE
fix(MOR-1740): resolve packaged rig profiles

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1635,7 +1635,7 @@ def _resolve_model(
     Returns:
         (radio_addr, model_name, default_baud) — each may be None.
     """
-    from rigplane.rig_loader import discover_rigs
+    from rigplane.rig_loader import discover_available_rigs
 
     model_name: str | None = getattr(args, "model", None)
     radio_addr: int | None = getattr(args, "radio_addr", None)
@@ -1643,7 +1643,7 @@ def _resolve_model(
     if model_name is None:
         return radio_addr, None, None
 
-    rigs = discover_rigs(_rigs_dir())
+    rigs = discover_available_rigs(_rigs_dir())
 
     # Case-insensitive match by model name or by rig id
     matched = None

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import logging
+import tempfile
 import tomllib
 import warnings
 from dataclasses import dataclass, field
 from decimal import Decimal
+from importlib import resources
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any, cast
 
@@ -29,7 +32,13 @@ from rigplane.core.tx_interlock_contract import (
 )
 from rigplane.commands.command_map import CommandMap
 
-__all__ = ["RigConfig", "RigLoadError", "load_rig", "discover_rigs"]
+__all__ = [
+    "RigConfig",
+    "RigLoadError",
+    "load_rig",
+    "discover_rigs",
+    "discover_available_rigs",
+]
 from rigplane.commands.command_spec import CatCommandSpec, CivCommandSpec, CommandSpec
 from rigplane.profiles import (
     BandInfo,
@@ -2309,3 +2318,39 @@ def discover_rigs(directory: Path) -> dict[str, RigConfig]:
         rigs[rig.model] = rig
 
     return rigs
+
+
+def _discover_resource_rigs(directory: Traversable) -> dict[str, RigConfig]:
+    """Load profiles from a package-resource directory.
+
+    Filesystem resources can use the normal loader directly. Non-filesystem
+    resources (for example, a zip import) are materialized together so profile
+    includes such as ``_keyboard-default.toml`` remain available as siblings.
+    """
+    if not directory.is_dir():
+        return {}
+    if isinstance(directory, Path):
+        return discover_rigs(directory)
+
+    with tempfile.TemporaryDirectory(prefix="rigplane-rigs-") as temp_dir:
+        materialized = Path(temp_dir)
+        for resource in directory.iterdir():
+            if resource.is_file() and resource.name.endswith(".toml"):
+                (materialized / resource.name).write_bytes(resource.read_bytes())
+        return discover_rigs(materialized)
+
+
+def discover_available_rigs(
+    fallback_directory: Path | None = None,
+) -> dict[str, RigConfig]:
+    """Discover bundled profiles, with an optional filesystem fallback.
+
+    Package resources are authoritative for installed distributions. The
+    fallback preserves source/editable checkouts whose profiles live at the
+    repository root.
+    """
+    package_rigs = resources.files("rigplane").joinpath("rigs")
+    rigs = _discover_resource_rigs(package_rigs)
+    if rigs or fallback_directory is None:
+        return rigs
+    return discover_rigs(fallback_directory)

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+from importlib import resources
 from pathlib import Path
+from zipfile import ZipFile, Path as ZipPath
 
 import pytest
 
+from rigplane import cli
 from rigplane.cli import _build_backend_config, _build_parser
+from rigplane.rig_loader import discover_available_rigs
 
 
 @pytest.fixture()
@@ -20,6 +24,22 @@ def _parse(parser: argparse.ArgumentParser, args: list[str]) -> argparse.Namespa
 
 
 RIGS_DIR = Path(__file__).resolve().parents[1] / "rigs"
+
+
+def test_packaged_profiles_support_non_filesystem_resources(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    archive_path = tmp_path / "rigplane.zip"
+    with ZipFile(archive_path, "w") as archive:
+        for name in ("ftx1.toml", "_keyboard-default.toml"):
+            archive.writestr(f"rigplane/rigs/{name}", (RIGS_DIR / name).read_bytes())
+
+    with ZipFile(archive_path) as archive:
+        package_root = ZipPath(archive, "rigplane/")
+        monkeypatch.setattr(resources, "files", lambda package: package_root)
+        rigs = discover_available_rigs(tmp_path / "missing-rigs")
+
+    assert rigs["FTX-1"].keyboard is not None
 
 
 class TestModelResolution:
@@ -132,6 +152,37 @@ class TestSerialBackend:
         assert cfg.radio_addr == 0x94
         assert cfg.model == "IC-7300"
         assert cfg.backend == "serial"
+
+    async def test_packaged_model_uses_package_resources(
+        self,
+        parser: argparse.ArgumentParser,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        package_root = tmp_path / "package"
+        package_rigs = package_root / "rigs"
+        package_rigs.mkdir(parents=True)
+        (package_rigs / "ftx1.toml").write_bytes((RIGS_DIR / "ftx1.toml").read_bytes())
+        monkeypatch.setattr(cli, "_rigs_dir", lambda: tmp_path / "missing-rigs")
+        monkeypatch.setattr(resources, "files", lambda package: package_root)
+
+        ns = _parse(
+            parser,
+            [
+                "--backend",
+                "serial",
+                "--serial-port",
+                "/dev/ttyUSB0",
+                "--model",
+                "FTX-1",
+                "status",
+            ],
+        )
+
+        cfg = await _build_backend_config(ns)
+
+        assert cfg.model == "FTX-1"
+        assert cfg.baudrate == 38400
 
     async def test_serial_model_uses_profile_default_baud(
         self, parser: argparse.ArgumentParser


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-1740](https://linear.app/morozsm/issue/MOR-1740)
- Compatibility impact: none; preserves existing CLI matching, errors, and editable/source-tree fallback

This introduces a central package-resource-aware profile discovery seam and switches CLI model resolution to it. Installed filesystem resources and non-filesystem resources such as zip imports are supported, including sibling keyboard profile includes.

## Verification

- [x] Relevant local tests or checks run
- [x] Public/open-core boundary checked
- [x] Release or migration impact documented if applicable

- RED: packaged FTX-1 CLI resolution failed with Unknown model and an empty Available list
- Focused profile/CLI suite: 693 passed, 1 skipped
- Full non-integration Core suite: 9906 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff: passed
- Import-linter: 5 contracts kept
- Wheel smoke: installed wheel resolved FTX-1 at 38400 baud and retained its keyboard profile
- Mypy: unchanged baseline of 13 errors in 4 unrelated files; exact changed-file baseline comparison also remained unchanged
- git diff --check: passed

## Agent Review

- [ ] Independent agent review comment posted before merge
- Reviewer: pending fresh verifier
- Result: pending

## Notes

- Out of scope / follow-ups: Yaesu radio consumer integration is intentionally deferred to the next non-overlapping MOR-1740 slice.
- Stale PR #1903 was not modified, rebased, force-pushed, or closed.