### PR TITLE
MOR-1745: track truthful Yaesu PTT knownness

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable, Sequence
@@ -107,6 +108,8 @@ class YaesuCatPoller:
         self._ema_s_main: float | None = None
         self._ema_s_sub: float | None = None
         self._last_ptt = bool(getattr(radio.radio_state, "ptt", False))
+        self._ptt_observation: Observation | None = None
+        self._ptt_connection_generation: tuple[str | None, int] | None = None
         self._tx_target_generation = self._current_tx_target_generation()
         self._tx_target_invalidation: tuple[str | None, int, int | None] | None = None
         self._tx_target_known_generation: tuple[str | None, int] | None = None
@@ -130,6 +133,33 @@ class YaesuCatPoller:
     def _provider_generation_is_current(self, generation: int | None) -> bool:
         capture = self._capture_provider_generation
         return capture is None or generation == capture()
+
+    def _invalidate_ptt_observation(self) -> None:
+        self._ptt_observation = None
+        self._ptt_connection_generation = None
+        self._last_ptt = False
+
+    def _current_ptt_observation(
+        self, *, now: float | None = None
+    ) -> Observation | None:
+        observation = self._ptt_observation
+        if observation is None or type(observation.value) is not bool:
+            return None
+        provider_generation = self._captured_provider_generation()
+        if provider_generation is not None and (
+            observation.provider_generation != provider_generation
+        ):
+            return None
+        if self._ptt_connection_generation != self._current_tx_target_generation():
+            return None
+        timestamp = time.monotonic() if now is None else now
+        if (
+            observation.max_age is None
+            or timestamp < observation.timestamp_monotonic
+            or timestamp >= observation.timestamp_monotonic + observation.max_age
+        ):
+            return None
+        return observation
 
     def _stamp_provider_generation(
         self,
@@ -237,7 +267,7 @@ class YaesuCatPoller:
             source="yaesu_poll_response",
             transport="serial",
         )
-        observations = (
+        observations: Sequence[Observation] = (
             adapter.observation(
                 _TX_TARGET_PATH,
                 UnknownTxTarget(reason="stale" if known else "not-observed"),
@@ -269,27 +299,40 @@ class YaesuCatPoller:
                 self._radio
             ).poll_medium()
         except (RadioConnectionError, ConnectionError, OSError, CatTransportError):
+            self._invalidate_ptt_observation()
             if not self._provider_generation_is_current(provider_generation):
                 return True
             self._invalidate_tx_target(provider_generation=provider_generation)
             raise
         if not self._provider_generation_is_current(provider_generation):
+            self._invalidate_ptt_observation()
             return True
         if self._current_tx_target_generation() != generation:
             observations = tuple(
-                item for item in observations if item.path != _TX_TARGET_PATH
+                item
+                for item in observations
+                if item.path not in (_TX_TARGET_PATH, YAESU_PTT_PATH)
             )
+            self._invalidate_ptt_observation()
             self._invalidate_tx_target(provider_generation=provider_generation)
         observations = self._stamp_provider_generation(
             observations, provider_generation
         )
+        ptt_observation: Observation | None = None
         for observation in observations:
             if observation.path == YAESU_PTT_PATH:
-                self._last_ptt = bool(observation.value)
+                if type(observation.value) is bool:
+                    ptt_observation = observation
             elif observation.path == _TX_TARGET_PATH:
                 self._tx_target_invalidation = None
                 if isinstance(observation.value, KnownTxTarget):
                     self._tx_target_known_generation = generation
+        if ptt_observation is None:
+            self._invalidate_ptt_observation()
+        else:
+            self._ptt_observation = ptt_observation
+            self._ptt_connection_generation = generation
+            self._last_ptt = ptt_observation.value
         self._observation_callback(observations)
         return True
 
@@ -421,6 +464,7 @@ class YaesuCatPoller:
         provider_generation = None if advance is None else advance()
         try:
             logger.warning("YaesuCatPoller: triggering auto-reconnect")
+            self._invalidate_ptt_observation()
             self._invalidate_tx_target(provider_generation=provider_generation)
             await transport.reconnect()
             logger.info("YaesuCatPoller: reconnected successfully")

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -37,7 +37,7 @@ from ...core.exceptions import TimeoutError as RigplaneTimeoutError
 from ...exceptions import CommandError
 from ...exceptions import ConnectionError as RadioConnectionError
 from ...radio_state import YaesuStateExtension
-from .transport import CatTimeoutError, CatTransportError
+from .transport import CatTimeoutError
 
 if TYPE_CHECKING:
     from ..._poller_types import CommandQueue, CommandQueueEntry
@@ -144,13 +144,16 @@ class YaesuCatPoller:
     ) -> Observation | None:
         observation = self._ptt_observation
         if observation is None or type(observation.value) is not bool:
+            self._invalidate_ptt_observation()
             return None
         provider_generation = self._captured_provider_generation()
         if provider_generation is not None and (
             observation.provider_generation != provider_generation
         ):
+            self._invalidate_ptt_observation()
             return None
         if self._ptt_connection_generation != self._current_tx_target_generation():
+            self._invalidate_ptt_observation()
             return None
         timestamp = time.monotonic() if now is None else now
         if (
@@ -158,6 +161,7 @@ class YaesuCatPoller:
             or timestamp < observation.timestamp_monotonic
             or timestamp >= observation.timestamp_monotonic + observation.max_age
         ):
+            self._invalidate_ptt_observation()
             return None
         return observation
 
@@ -284,6 +288,7 @@ class YaesuCatPoller:
     def _sync_tx_target_generation(self) -> tuple[str | None, int]:
         generation = self._current_tx_target_generation()
         if generation != self._tx_target_generation:
+            self._invalidate_ptt_observation()
             self._invalidate_tx_target()
         return generation
 
@@ -298,7 +303,9 @@ class YaesuCatPoller:
             observations = await YaesuObservationAdapter.from_radio(
                 self._radio
             ).poll_medium()
-        except (RadioConnectionError, ConnectionError, OSError, CatTransportError):
+        except asyncio.CancelledError:
+            raise
+        except Exception:
             self._invalidate_ptt_observation()
             if not self._provider_generation_is_current(provider_generation):
                 return True
@@ -353,7 +360,8 @@ class YaesuCatPoller:
             ema_sub = self._apply_ema(raw, ema_sub)
             return round(ema_sub)
 
-        if self._last_ptt:
+        ptt_observation = self._current_ptt_observation()
+        if ptt_observation is not None and ptt_observation.value:
             observations = await adapter.poll_tx_meters()
         else:
             observations = await adapter.poll_rx_meters(smooth_s_meter=_smooth)

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -481,6 +481,18 @@ def _target_observation(
     )
 
 
+def _ptt_observation(
+    value: bool, *, observed_at: float, max_age: float = 1.0
+) -> Observation:
+    return replace(
+        ProviderObservationAdapter(
+            _profile_state_acquisition(), "yaesu_poll_response", "serial"
+        ).observation(FieldPath.global_("tx_state", "ptt"), value),
+        timestamp_monotonic=observed_at,
+        max_age=max_age,
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("error", (False, True))
 async def test_stale_yaesu_medium_has_no_side_effects(error: bool) -> None:
@@ -513,6 +525,104 @@ async def test_stale_yaesu_medium_has_no_side_effects(error: bool) -> None:
 
     assert not emitted and not poller._last_ptt  # noqa: SLF001
     assert poller._tx_target_known_generation is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("active", (False, True), ids=("rx", "tx"))
+async def test_fresh_yaesu_ptt_observation_is_known(
+    monkeypatch: pytest.MonkeyPatch, active: bool
+) -> None:
+    radio, store = _tx_target_radio(), StateStore()
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "poll_medium",
+        AsyncMock(return_value=(_ptt_observation(active, observed_at=10.0),)),
+    )
+    poller = YaesuCatPoller(radio, observation_callback=lambda _: None)
+    poller.bind_provider_generation(capture=lambda: store.provider_generation)
+
+    await poller._poll_medium()  # noqa: SLF001
+
+    observation = poller._current_ptt_observation(now=10.5)  # noqa: SLF001
+    assert observation is not None
+    assert (observation.value, observation.timestamp_monotonic) == (active, 10.0)
+    assert observation.provider_generation == store.provider_generation
+
+
+@pytest.mark.asyncio
+async def test_stale_yaesu_ptt_observation_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    radio = _tx_target_radio()
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "poll_medium",
+        AsyncMock(return_value=(_ptt_observation(True, observed_at=10.0),)),
+    )
+    poller = YaesuCatPoller(radio, observation_callback=lambda _: None)
+    await poller._poll_medium()  # noqa: SLF001
+
+    assert poller._current_ptt_observation(now=11.0) is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ("unread", "poll-error"))
+async def test_yaesu_ptt_failure_invalidates_known_state(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    radio = _tx_target_radio()
+    next_result: object = () if failure == "unread" else CatTimeoutError("lost")
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "poll_medium",
+        AsyncMock(
+            side_effect=[(_ptt_observation(True, observed_at=10.0),), next_result]
+        ),
+    )
+    poller = YaesuCatPoller(radio, observation_callback=lambda _: None)
+    await poller._poll_medium()  # noqa: SLF001
+
+    if failure == "poll-error":
+        with pytest.raises(CatTimeoutError, match="lost"):
+            await poller._poll_medium()  # noqa: SLF001
+    else:
+        await poller._poll_medium()  # noqa: SLF001
+
+    assert poller._current_ptt_observation(now=10.5) is None  # noqa: SLF001
+    assert not poller._last_ptt  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ("reconnect", "provider-generation"))
+async def test_yaesu_ptt_generation_change_is_unknown_until_newer_poll(
+    monkeypatch: pytest.MonkeyPatch, boundary: str
+) -> None:
+    radio, store = _tx_target_radio(), StateStore()
+    monkeypatch.setattr(
+        YaesuObservationAdapter,
+        "poll_medium",
+        AsyncMock(
+            side_effect=[
+                (_ptt_observation(True, observed_at=10.0),),
+                (_ptt_observation(False, observed_at=11.0),),
+            ]
+        ),
+    )
+    poller = YaesuCatPoller(radio, observation_callback=lambda _: None)
+    poller.bind_provider_generation(capture=lambda: store.provider_generation)
+    await poller._poll_medium()  # noqa: SLF001
+
+    if boundary == "reconnect":
+        radio._transport.stats.reconnects += 1
+        poller._sync_tx_target_generation()  # noqa: SLF001
+    else:
+        store.begin_provider_generation()
+    assert poller._current_ptt_observation(now=10.5) is None  # noqa: SLF001
+
+    await poller._poll_medium()  # noqa: SLF001
+    recovered = poller._current_ptt_observation(now=11.5)  # noqa: SLF001
+    assert recovered is not None and recovered.value is False
+    assert recovered.provider_generation == store.provider_generation
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -566,12 +566,16 @@ async def test_stale_yaesu_ptt_observation_is_unknown(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure", ("unread", "poll-error"))
+@pytest.mark.parametrize("failure", ("unread", "transport-error", "generic-error"))
 async def test_yaesu_ptt_failure_invalidates_known_state(
     monkeypatch: pytest.MonkeyPatch, failure: str
 ) -> None:
     radio = _tx_target_radio()
-    next_result: object = () if failure == "unread" else CatTimeoutError("lost")
+    error_type = {
+        "transport-error": CatTimeoutError,
+        "generic-error": RuntimeError,
+    }.get(failure)
+    next_result: object = () if error_type is None else error_type("lost")
     monkeypatch.setattr(
         YaesuObservationAdapter,
         "poll_medium",
@@ -582,8 +586,8 @@ async def test_yaesu_ptt_failure_invalidates_known_state(
     poller = YaesuCatPoller(radio, observation_callback=lambda _: None)
     await poller._poll_medium()  # noqa: SLF001
 
-    if failure == "poll-error":
-        with pytest.raises(CatTimeoutError, match="lost"):
+    if error_type is not None:
+        with pytest.raises(error_type, match="lost"):
             await poller._poll_medium()  # noqa: SLF001
     else:
         await poller._poll_medium()  # noqa: SLF001
@@ -617,7 +621,17 @@ async def test_yaesu_ptt_generation_change_is_unknown_until_newer_poll(
         poller._sync_tx_target_generation()  # noqa: SLF001
     else:
         store.begin_provider_generation()
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 10.5
+    )
+    with patch.object(YaesuObservationAdapter, "from_radio") as adapter:
+        adapter.return_value.poll_rx_meters = AsyncMock(return_value=())
+        adapter.return_value.poll_tx_meters = AsyncMock(return_value=())
+        await poller._emit_fast_observations()  # noqa: SLF001
+        adapter.return_value.poll_rx_meters.assert_awaited_once()
+        adapter.return_value.poll_tx_meters.assert_not_awaited()
     assert poller._current_ptt_observation(now=10.5) is None  # noqa: SLF001
+    assert not poller._last_ptt  # noqa: SLF001
 
     await poller._poll_medium()  # noqa: SLF001
     recovered = poller._current_ptt_observation(now=11.5)  # noqa: SLF001


### PR DESCRIPTION
## Summary

- retain the latest Yaesu/FTX PTT observation as private dispatcher evidence
- treat missing/unread, poll-error, stale, provider-generation, and reconnect boundaries as unknown
- clear the legacy PTT mirror on invalidation and recover known RX/TX only from a newer successful poll

## Why

MOR-1627 cannot safely apply the shared TX-interlock policy until the Yaesu dispatcher can distinguish fresh known RX/TX from unknown RF state. This is the atomic B2-a prerequisite only; it does not block, defer, or execute commands.

Linear: https://linear.app/morozsm/issue/MOR-1745/mor-1500-b2-a-track-truthful-yaesu-ptt-observation-knownness  
Parent: https://linear.app/morozsm/issue/MOR-1627/mor-1500-b2-enforce-tx-interlock-in-the-yaesu-cat-dispatcher  
GitHub execution parent: #2547

## Scope

Two files, 188 changed LOC versus base `6cf0803369bb4e6e8d655151507fd5d9c8e50293`.

No command disposition, BLOCK/DEFER behavior, deferred lane, lifecycle state, profile/config/public API, runtime/bench, or radio operation is included.

## Red-first evidence

The seven focused knownness cases failed on the exact base with `AttributeError: YaesuCatPoller has no attribute _current_ptt_observation`, then passed after the implementation.

The independent review then found two fail-closed gaps on head `d3b93fa7ec568c6ebb44b7cb99e3b810553d878f`. Focused adversarial tests reproduced three failures: a generic medium-poll exception retained known TX, and reconnect/provider-generation rollover retained the optimistic fast-path TX mirror. Head `8180f05d5e5387c0496aca13cc624a189ab5a8ee` invalidates on every non-cancellation medium-poll failure, neutralizes unknown/stale generation evidence before fast-meter selection, and recovers only from a newer successful poll.

## Validation

- `uv run pytest tests/test_yaesu_cat_poller.py -q --tb=short` — 78 passed
- Yaesu/FTX relevant suite — 542 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9854 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — passed
- `uv run lint-imports` — 5 contracts kept
- focused mypy on the owned source — passed
- full `uv run mypy src/` still reports 12 unrelated pre-existing errors outside the owned paths
- diff check and secret/path scan — passed

## Compatibility

No intentional public API, CLI, config, or rigctld contract change. The retained observation and knownness resolver are private to `YaesuCatPoller`.
