### PR TITLE
test(MOR-1743): gate installed radio profiles

### DIFF
--- a/.github/scripts/installed_profile_smoke.py
+++ b/.github/scripts/installed_profile_smoke.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Hermetic smoke for radio profiles installed from a RigPlane wheel.
+
+Run this copied outside the source checkout with the candidate wheel installed
+into the active virtual environment.  It never opens serial, audio, or radio
+hardware.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tempfile
+import tomllib
+from importlib import metadata, resources
+from pathlib import Path
+from typing import Iterable
+
+
+EXPECTED_PROFILES: dict[str, tuple[str, str]] = {
+    "ftx1.toml": ("yaesu_ftx1", "FTX-1"),
+    "ic705.toml": ("icom_ic705", "IC-705"),
+    "ic7300.toml": ("icom_ic7300", "IC-7300"),
+    "ic7610.toml": ("icom_ic7610", "IC-7610"),
+    "ic9700.toml": ("icom_ic9700", "IC-9700"),
+    "tx500.toml": ("lab599_tx500", "TX-500"),
+    "x6100.toml": ("xiegu_x6100", "X6100"),
+    "x6200.toml": ("xiegu_x6200", "X6200"),
+}
+REQUIRED_RESOURCES = ("_keyboard-default.toml",)
+
+
+class SmokeFailure(RuntimeError):
+    """The installed artifact does not satisfy the packaged-profile contract."""
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def validate_catalog(names: Iterable[str]) -> tuple[str, ...]:
+    """Require an exact, reviewed catalog so missing profiles cannot vanish."""
+    actual = tuple(sorted(names))
+    expected = tuple(EXPECTED_PROFILES)
+    if actual != expected:
+        missing = sorted(set(expected) - set(actual))
+        unexpected = sorted(set(actual) - set(expected))
+        raise SmokeFailure(
+            f"packaged profile catalog mismatch: missing={missing}, "
+            f"unexpected={unexpected}"
+        )
+    return actual
+
+
+def _package_rigs():
+    return resources.files("rigplane").joinpath("rigs")
+
+
+def _profile_resource_names(rig_resources) -> tuple[str, ...]:
+    if not rig_resources.is_dir():
+        raise SmokeFailure("installed package resource rigplane/rigs is missing")
+    names = (
+        entry.name
+        for entry in rig_resources.iterdir()
+        if entry.is_file()
+        and entry.name.endswith(".toml")
+        and not entry.name.startswith("_")
+        and not entry.name.endswith(".draft.toml")
+    )
+    return validate_catalog(names)
+
+
+def _copy_toml_resources(rig_resources, destination: Path) -> None:
+    for entry in rig_resources.iterdir():
+        if entry.is_file() and entry.name.endswith(".toml"):
+            (destination / entry.name).write_bytes(entry.read_bytes())
+
+
+def prove_corrupt_profile_fails_closed(rig_resources=None) -> str:
+    """Corrupt a disposable resource copy and require an actionable failure."""
+    from rigplane.profiles.rig_loader import RigLoadError, discover_rigs
+
+    source = rig_resources if rig_resources is not None else _package_rigs()
+    with tempfile.TemporaryDirectory(prefix="rigplane-corrupt-profile-") as raw_dir:
+        directory = Path(raw_dir)
+        _copy_toml_resources(source, directory)
+        corrupt = directory / "ftx1.toml"
+        if not corrupt.exists():
+            raise SmokeFailure("negative proof cannot find packaged ftx1.toml")
+        corrupt.write_text("[radio\n", encoding="utf-8")
+        try:
+            discover_rigs(directory)
+        except RigLoadError as exc:
+            diagnostic = str(exc)
+            if (
+                "ftx1.toml" not in diagnostic
+                or "failed to parse TOML" not in diagnostic
+            ):
+                raise SmokeFailure(
+                    f"corrupt profile diagnostic is not actionable: {diagnostic}"
+                ) from exc
+            return diagnostic
+    raise SmokeFailure("corrupt packaged profile was accepted")
+
+
+def exercise_ftx1_construction(rigs=None) -> dict[str, object]:
+    """Construct the packaged Yaesu backend without connecting any device."""
+    from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+    from rigplane.profiles.rig_loader import discover_available_rigs
+
+    catalog = rigs if rigs is not None else discover_available_rigs()
+    try:
+        config = catalog["FTX-1"]
+    except KeyError as exc:
+        raise SmokeFailure("public packaged loader did not resolve FTX-1") from exc
+    radio = YaesuCatRadio(
+        "/dev/rigplane-installed-profile-smoke-never-open",
+        profile=config,
+        audio_driver=object(),
+    )
+    result = {
+        "backend": radio.backend_id,
+        "connected": radio.connected,
+        "model": radio.model,
+        "profile_id": radio.profile.id,
+    }
+    if result != {
+        "backend": "yaesu_cat",
+        "connected": False,
+        "model": "FTX-1",
+        "profile_id": "yaesu_ftx1",
+    }:
+        raise SmokeFailure(f"unexpected FTX-1 construction result: {result}")
+    return result
+
+
+def _assert_isolated_install(forbid_root: Path | None) -> Path:
+    import rigplane
+
+    package_root = Path(rigplane.__file__).resolve().parent
+    distribution_root = Path(metadata.distribution("rigplane").locate_file(""))
+    distribution_root = distribution_root.resolve()
+    if not _is_relative_to(package_root, distribution_root):
+        raise SmokeFailure(
+            f"rigplane imported outside installed distribution: {package_root}"
+        )
+    if forbid_root is not None:
+        forbidden = forbid_root.resolve()
+        inspected = [package_root, Path.cwd().resolve()]
+        inspected.extend(
+            Path(entry).resolve()
+            for entry in sys.path
+            if entry and Path(entry).exists()
+        )
+        leaked = [str(path) for path in inspected if _is_relative_to(path, forbidden)]
+        if leaked:
+            raise SmokeFailure(f"source-checkout path leaked into smoke: {leaked}")
+    return package_root
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def run_smoke(
+    *, artifact: Path, candidate_sha: str, forbid_root: Path | None
+) -> dict[str, object]:
+    """Run the installed-artifact proof and return deterministic evidence."""
+    if not re.fullmatch(r"[0-9a-f]{40}", candidate_sha):
+        raise SmokeFailure("candidate SHA must be exactly 40 lowercase hex characters")
+    if not artifact.is_file() or artifact.suffix != ".whl":
+        raise SmokeFailure(f"candidate wheel not found: {artifact}")
+
+    package_root = _assert_isolated_install(forbid_root)
+    rig_resources = _package_rigs()
+    names = _profile_resource_names(rig_resources)
+    resource_names = {
+        entry.name for entry in rig_resources.iterdir() if entry.is_file()
+    }
+    missing_resources = sorted(set(REQUIRED_RESOURCES) - resource_names)
+    if missing_resources:
+        raise SmokeFailure(f"required packaged resources missing: {missing_resources}")
+
+    from rigplane.profiles.rig_loader import discover_available_rigs
+
+    rigs = discover_available_rigs()
+    if len(rigs) != len(names):
+        raise SmokeFailure(
+            f"loader/catalog count mismatch: loaded={len(rigs)}, catalog={len(names)}"
+        )
+    profiles: list[dict[str, str]] = []
+    for filename in names:
+        resource = rig_resources.joinpath(filename)
+        identity = tomllib.loads(resource.read_text(encoding="utf-8"))["radio"]
+        expected_id, expected_model = EXPECTED_PROFILES[filename]
+        if (identity.get("id"), identity.get("model")) != (
+            expected_id,
+            expected_model,
+        ):
+            raise SmokeFailure(
+                f"unexpected identity in packaged {filename}: {identity}"
+            )
+        config = rigs.get(expected_model)
+        if config is None or config.id != expected_id or config.keyboard is None:
+            raise SmokeFailure(
+                f"packaged loader failed identity/include resolution for {filename}"
+            )
+        profiles.append({"filename": filename, "id": config.id, "model": config.model})
+
+    negative_diagnostic = prove_corrupt_profile_fails_closed(rig_resources)
+    ftx1 = exercise_ftx1_construction(rigs)
+    return {
+        "artifact": artifact.name,
+        "artifact_sha256": _sha256(artifact),
+        "candidate_sha": candidate_sha,
+        "ftx1": ftx1,
+        "negative_diagnostic": negative_diagnostic,
+        "package_root": str(package_root),
+        "package_version": metadata.version("rigplane"),
+        "profile_count": len(profiles),
+        "profiles": profiles,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--forbid-root", type=Path)
+    args = parser.parse_args()
+    try:
+        evidence = run_smoke(
+            artifact=args.artifact.resolve(),
+            candidate_sha=args.candidate_sha,
+            forbid_root=args.forbid_root,
+        )
+    except Exception as exc:
+        print(f"installed profile smoke FAILED: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,6 +107,34 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Smoke installed radio profiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_dir="$(mktemp -d)"
+          mapfile -t wheels < <(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -type f -name '*.whl' -print)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "expected exactly one wheel, found ${#wheels[@]}" >&2
+            exit 1
+          fi
+          wheel_name="$(basename "${wheels[0]}")"
+          cp "${wheels[0]}" "$smoke_dir/$wheel_name"
+          cp .github/scripts/installed_profile_smoke.py "$smoke_dir/"
+          uv venv --python 3.13 "$smoke_dir/.venv"
+          uv pip install --python "$smoke_dir/.venv/bin/python" "$smoke_dir/$wheel_name"
+          cd "$smoke_dir"
+          UV_OFFLINE=true .venv/bin/python installed_profile_smoke.py \
+            --artifact "$wheel_name" \
+            --candidate-sha "$GITHUB_SHA" \
+            --forbid-root "$GITHUB_WORKSPACE" \
+            | tee "$GITHUB_WORKSPACE/installed-profile-smoke.json"
+
+      - name: Upload installed-profile smoke evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: installed-profile-smoke
+          path: installed-profile-smoke.json
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/tests/test_installed_profile_smoke.py
+++ b/tests/test_installed_profile_smoke.py
@@ -1,0 +1,64 @@
+"""Focused coverage for the installed-wheel radio-profile smoke gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / ".github/scripts/installed_profile_smoke.py"
+)
+RIGS_DIR = SCRIPT_PATH.parents[2] / "rigs"
+
+
+def _load_smoke_module():
+    spec = importlib.util.spec_from_file_location(
+        "installed_profile_smoke", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_catalog_contract_rejects_silent_profile_loss() -> None:
+    smoke = _load_smoke_module()
+    expected = tuple(smoke.EXPECTED_PROFILES)
+
+    assert smoke.validate_catalog(expected) == expected
+    with pytest.raises(smoke.SmokeFailure, match=r"missing=.*x6200\.toml"):
+        smoke.validate_catalog(expected[:-1])
+
+
+def test_catalog_contract_rejects_unreviewed_profile_addition() -> None:
+    smoke = _load_smoke_module()
+
+    with pytest.raises(smoke.SmokeFailure, match=r"unexpected=.*future\.toml"):
+        smoke.validate_catalog((*smoke.EXPECTED_PROFILES, "future.toml"))
+
+
+def test_corrupt_profile_negative_proof_is_actionable() -> None:
+    smoke = _load_smoke_module()
+
+    diagnostic = smoke.prove_corrupt_profile_fails_closed(RIGS_DIR)
+
+    assert "ftx1.toml" in diagnostic
+    assert "failed" in diagnostic.lower() or "toml" in diagnostic.lower()
+
+
+def test_ftx1_construction_seam_never_connects() -> None:
+    smoke = _load_smoke_module()
+
+    from rigplane.profiles.rig_loader import discover_rigs
+
+    result = smoke.exercise_ftx1_construction(discover_rigs(RIGS_DIR))
+
+    assert result == {
+        "backend": "yaesu_cat",
+        "connected": False,
+        "model": "FTX-1",
+        "profile_id": "yaesu_ftx1",
+    }


### PR DESCRIPTION
Linear: [MOR-1743](https://linear.app/morozsm/issue/MOR-1743/release-gate-installed-package-clean-environment-radio)

## Summary

- add an exact, reviewed packaged-profile catalog smoke for installed wheels
- prove all 8 shipped profiles and the shared keyboard include resolve through package resources
- construct the packaged FTX-1 Yaesu backend without opening serial, audio, or radio hardware
- fail closed on missing/unreviewed catalog entries and corrupt TOML with actionable diagnostics
- run the same hermetic smoke in the PyPI publish workflow and upload deterministic JSON evidence

## Exact-head evidence

- head: `4b2bf280743271a34151d44f8ba319926f960a05`
- wheel: `rigplane-2.11.1-py3-none-any.whl`
- SHA-256: `3a20631f35a1d64fa6e04f2eff25a1e4af0658887245638079c2a6eb83e1ebd5`
- installed outside the checkout into a clean venv; checkout paths rejected
- profile count: 8
- profiles: FTX-1, IC-705, IC-7300, IC-7610, IC-9700, TX-500, X6100, X6200
- corrupt `ftx1.toml` negative proof: fail closed with filename and TOML parse diagnostic
- FTX-1 construction: `backend=yaesu_cat`, `connected=false`, `profile_id=yaesu_ftx1`

## Verification

- red-first focused test: 4 failures before implementation
- focused/relevant: 668 passed
- full non-integration: 9919 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff check/format: pass
- strict web mypy: pass
- import-linter: 5 contracts kept
- actionlint: pass
- exact-head installed-wheel smoke: pass

No runtime, bench, serial, audio, radio, PTT, TUNE, TX, or keying operation was performed.