### PR TITLE
MOR-1747: enforce immediate Yaesu TX interlock policy

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -32,6 +32,11 @@ from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
+from rigplane.runtime.tx_interlock import (
+    RfState,
+    TxInterlockDisposition,
+    evaluate_tx_interlock,
+)
 
 from ...core.exceptions import TimeoutError as RigplaneTimeoutError
 from ...exceptions import CommandError
@@ -164,6 +169,12 @@ class YaesuCatPoller:
             self._invalidate_ptt_observation()
             return None
         return observation
+
+    def _current_rf_state(self) -> RfState:
+        observation = self._current_ptt_observation()
+        if observation is None:
+            return RfState.UNKNOWN
+        return RfState.TX if observation.value else RfState.RX
 
     def _stamp_provider_generation(
         self,
@@ -604,9 +615,15 @@ class YaesuCatPoller:
         """Dispatch a single command to the radio.
 
         Commands come from the web UI CommandQueue.  The dispatcher handles
-        all command types; unsupported commands for this radio are silently
-        dropped.
+        all command types; unsupported commands fail truthfully.
         """
+        decision = evaluate_tx_interlock(cmd, rf_state=self._current_rf_state())
+        if (
+            decision.disposition is TxInterlockDisposition.BLOCK
+            and not decision.allowed
+        ):
+            raise CommandError(decision.reason)
+
         from ..._poller_types import (
             PttOff,
             PttOn,
@@ -646,6 +663,7 @@ class YaesuCatPoller:
             SetPbtInner,
             SetPbtOuter,
             SetPower,
+            SetPowerstat,
             SetPreamp,
             SetRfGain,
             SetRitFrequency,
@@ -717,6 +735,8 @@ class YaesuCatPoller:
                 await radio.set_ptt(True)
             case PttOff():
                 await radio.set_ptt(False)
+            case SetPowerstat(on=on):
+                await radio.set_powerstat(on)
 
             # ── Audio / RF Levels ──
             case SetAfLevel(level=level):
@@ -763,13 +783,17 @@ class YaesuCatPoller:
 
             # ── Filters ──
             case SetFilter(filter_num=_num):
-                pass  # FTX-1 uses filter_width, not discrete filter numbers
+                raise NotImplementedError(
+                    "SetFilter unsupported by Yaesu CAT dispatcher"
+                )
             case SetFilterWidth(width=width):
                 await radio.set_filter_width(width)
             case SetFilterShape(shape=_shape):
-                pass  # Not available on FTX-1
+                raise NotImplementedError(
+                    "SetFilterShape unsupported by Yaesu CAT dispatcher"
+                )
             case SetPbtInner() | SetPbtOuter():
-                pass  # Not available on FTX-1
+                raise NotImplementedError(f"{name} unsupported by Yaesu CAT dispatcher")
 
             # ── IF Shift ──
             case SetIfShift(offset=offset):
@@ -827,11 +851,10 @@ class YaesuCatPoller:
 
             # ── IC-7610-specific (not applicable) ──
             case SetIpPlus() | SetTwinPeak() | SetDigiSel():
-                pass  # Icom-only DSP features
+                raise NotImplementedError(f"{name} unsupported by Yaesu CAT dispatcher")
 
             case _:
-                logger.debug("CMD: unhandled %s — ignoring", name)
-                return
+                raise NotImplementedError(f"{name} unsupported by Yaesu CAT dispatcher")
 
         logger.info("CMD: %s", name)
 

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -20,6 +20,7 @@ from rigplane.core.state_acquisition_policy import (
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation
 from rigplane.core.state_store import StateStore
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
+from rigplane.exceptions import CommandError
 from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
 from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
@@ -491,6 +492,136 @@ def _ptt_observation(
         timestamp_monotonic=observed_at,
         max_age=max_age,
     )
+
+
+def _set_fresh_ptt_observation(poller: YaesuCatPoller, *, active: bool) -> None:
+    poller._ptt_observation = _ptt_observation(  # noqa: SLF001
+        active, observed_at=10.0
+    )
+    poller._ptt_connection_generation = (  # noqa: SLF001
+        poller._current_tx_target_generation()  # noqa: SLF001
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("active", "message"),
+    [(True, "RF state is TX"), (None, "RF state is unknown")],
+    ids=("tx", "unknown"),
+)
+async def test_yaesu_immediate_hard_block_families_fail_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    active: bool | None,
+    message: str,
+) -> None:
+    from rigplane.runtime._poller_types import (
+        PttOn,
+        ScanStart,
+        SendCiv,
+        SetAntenna1,
+        SetAntenna2,
+        SetCivOutputAnt,
+        SetRxAntenna,
+        SetRxAntennaAnt1,
+        SetRxAntennaAnt2,
+        SetTunerStatus,
+    )
+
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 10.5
+    )
+    commands = (
+        PttOn(),
+        SendCiv(command=0x1C),
+        ScanStart(),
+        SetTunerStatus(1),
+        SetTunerStatus(2),
+        SetAntenna1(True),
+        SetAntenna2(True),
+        SetRxAntenna(antenna=1, on=True),
+        SetRxAntennaAnt1(True),
+        SetRxAntennaAnt2(True),
+        SetCivOutputAnt(True),
+    )
+
+    for command in commands:
+        radio = make_radio()
+        radio.set_ptt = AsyncMock()
+        radio.set_tuner = AsyncMock()
+        poller = YaesuCatPoller(radio, callback=lambda _: None)
+        if active is not None:
+            _set_fresh_ptt_observation(poller, active=active)
+
+        with pytest.raises(CommandError, match=message):
+            await poller._execute_command(command)  # noqa: SLF001
+
+        radio.set_ptt.assert_not_awaited()
+        radio.set_tuner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("active", (True, None), ids=("tx", "unknown"))
+async def test_yaesu_emergency_off_commands_bypass_immediate_gate(
+    monkeypatch: pytest.MonkeyPatch, active: bool | None
+) -> None:
+    from rigplane.runtime._poller_types import PttOff, SetPowerstat, SetTunerStatus
+
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 10.5
+    )
+    radio = make_radio()
+    radio.set_ptt = AsyncMock()
+    radio.set_powerstat = AsyncMock()
+    radio.set_tuner = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda _: None)
+    if active is not None:
+        _set_fresh_ptt_observation(poller, active=active)
+
+    await poller._execute_command(PttOff())  # noqa: SLF001
+    await poller._execute_command(SetPowerstat(on=False))  # noqa: SLF001
+    await poller._execute_command(SetTunerStatus(0))  # noqa: SLF001
+
+    radio.set_ptt.assert_awaited_once_with(False)
+    radio.set_powerstat.assert_awaited_once_with(False)
+    radio.set_tuner.assert_awaited_once_with(0)
+
+
+@pytest.mark.asyncio
+async def test_yaesu_known_rx_preserves_immediate_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.runtime._poller_types import PttOn, SendCiv
+
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 10.5
+    )
+    radio = make_radio()
+    radio.set_ptt = AsyncMock()
+    poller = YaesuCatPoller(radio, callback=lambda _: None)
+    _set_fresh_ptt_observation(poller, active=False)
+
+    await poller._execute_command(PttOn())  # noqa: SLF001
+    radio.set_ptt.assert_awaited_once_with(True)
+    with pytest.raises(
+        NotImplementedError, match="SendCiv unsupported by Yaesu CAT dispatcher"
+    ):
+        await poller._execute_command(SendCiv(command=0x1C))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_yaesu_unhandled_always_pass_command_fails_truthfully() -> None:
+    from rigplane.runtime._poller_types import ScanStop
+
+    queue = CommandQueue()
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    queue.put_ordered(ScanStop(), future=future)
+    poller = YaesuCatPoller(make_radio(), command_queue=queue)
+
+    await poller._drain_commands()  # noqa: SLF001
+
+    error = future.exception()
+    assert isinstance(error, NotImplementedError)
+    assert "ScanStop unsupported by Yaesu CAT dispatcher" in str(error)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- enforce the shared TX interlock before the Yaesu/FTX command dispatcher
- hard-block PTT-on, raw CAT, scan-start, tuner engage/start, and antenna command families while TX is known active or RF state is unknown
- keep PTT-off, typed power-off, and tuner-off on the always-attempt path
- fail unsupported Yaesu commands truthfully instead of silently acknowledging them

## Scope

This is the immediate pass/BLOCK B2-b slice only. Deferred commands, TTL, quiet-window, lifecycle, profile overrides, direct Web tuner handling, rigctld, and hardware validation remain out of scope.

Linear: [MOR-1747](https://linear.app/morozsm/issue/MOR-1747)

Parent execution issue: #2547

## Validation

- Red-first witness: 5 focused failures before production changes
- Focused immediate-policy tests: 6 passed
- Full Yaesu poller: 84 passed
- Yaesu/FTX/shared-policy suite: 582 passed
- Full non-integration suite: 9,921 passed, 13 skipped, 14 xfailed, 1 xpassed
- Ruff check and format: passed
- Import-linter: 5 contracts kept
- Changed-file mypy: passed
- Full mypy: 12 pre-existing errors in three untouched files
- Diff guard: 2 files, 170 changed LOC
- No runtime, serial, radio, PTT, TUNE, TX, or keying activity