### PR TITLE
MOR-1748: link module and instance object-flow identities

### DIFF
--- a/frontend/scripts/control-feedback-debt-ast.mjs
+++ b/frontend/scripts/control-feedback-debt-ast.mjs
@@ -3,6 +3,7 @@ import { evaluateOrderedEffects } from './control-feedback-debt-evaluator.mjs';
 
 const WRAPPERS = new Set(['ParenthesizedExpression', 'TSAsExpression', 'TSSatisfiesExpression', 'TSTypeAssertion', 'TSNonNullExpression', 'ChainExpression', 'TSInstantiationExpression']);
 const SKIP = new Set(['parent', 'metadata', 'typeAnnotation', 'typeParameters', 'returnType', 'loc']);
+const FLOW_FUNCTION_SCOPE = Symbol('flowFunctionScope');
 
 /** @param {any} node */
 export function unwrapExpression(node) { let wrapped = false; while (node && WRAPPERS.has(node.type)) { wrapped = true; node = node.expression; } return { node, wrapped }; }
@@ -25,7 +26,7 @@ export function collectObjectFlow(program) {
   const indexFunction = (n, s) => { const child = scope(s, true); if (n.type === 'FunctionExpression' && n.id) declare(child, n.id.name); indexParams(n.params, child); if (n.body?.type === 'BlockStatement') { predeclare(n.body.body, child); hoist(n.body, child); n.body.body.forEach((x) => index(x, child)); } else index(n.body, child); };
   const index = (n, s) => { if (!n || typeof n !== 'object') return; scopes.set(n, s);
     if (n.type === 'Program') { predeclare(n.body, s); hoist(n, s); n.body.forEach((x) => index(x, s)); return; }
-    if (n.type === 'BlockStatement') { const child = scope(s); predeclare(n.body, child); n.body.forEach((x) => index(x, child)); return; }
+    if (n.type === 'BlockStatement') { const child = scope(s, n[FLOW_FUNCTION_SCOPE] === true); predeclare(n.body, child); n.body.forEach((x) => index(x, child)); return; }
     if (n.type === 'FunctionDeclaration') return indexFunction(n, s);
     if (/FunctionExpression$/.test(n.type) || n.type === 'ArrowFunctionExpression') return indexFunction(n, s);
     if (n.type === 'CatchClause') { const child = scope(s); names(child, n.param); index(n.body, child); return; }
@@ -55,19 +56,35 @@ export function collectObjectFlow(program) {
   return exposed;
 }
 
+/** Collect bindings owned by one script, including nested script-scope var declarations. */
+function collectScriptBindings(program) {
+  const bindings = new Set(), varBindings = new Set();
+  const declaration = (n) => /^Export/.test(n?.type) ? n.declaration : n;
+  const noteTopLevel = (n) => {
+    const d = declaration(n);
+    if (d?.type === 'VariableDeclaration') d.declarations.forEach((x) => boundNames(x.id).forEach((name) => bindings.add(name)));
+    if (['FunctionDeclaration', 'ClassDeclaration'].includes(d?.type) && d.id) bindings.add(d.id.name);
+    if (n?.type === 'ImportDeclaration') n.specifiers.forEach((x) => bindings.add(x.local.name));
+  };
+  const noteVars = (n) => {
+    n = declaration(n);
+    if (!n || typeof n !== 'object' || /Function(?:Declaration|Expression)$/.test(n.type) || n.type === 'ArrowFunctionExpression' || /Class(?:Declaration|Expression)$/.test(n.type)) return;
+    if (n.type === 'VariableDeclaration' && n.kind === 'var') n.declarations.forEach((x) => boundNames(x.id).forEach((name) => { bindings.add(name); varBindings.add(name); }));
+    Object.entries(n).forEach(([key, value]) => { if (!SKIP.has(key)) Array.isArray(value) ? value.forEach(noteVars) : noteVars(value); });
+  };
+  (program?.body ?? []).forEach((n) => { noteTopLevel(n); noteVars(n); });
+  return { bindings, varBindings };
+}
+
 /** Analyze Svelte module and instance programs as linked lexical scopes. */
 export function collectSvelteObjectFlows(moduleProgram, instanceProgram) {
   const empty = () => new Map(), instanceOwn = instanceProgram ? collectObjectFlow(instanceProgram) : empty();
   if (!moduleProgram) return { module: empty(), instance: instanceOwn };
-  const shadowed = new Set();
-  const note = (n) => {
-    const d = /^Export/.test(n?.type) ? n.declaration : n;
-    if (d?.type === 'VariableDeclaration') d.declarations.forEach((x) => boundNames(x.id).forEach((name) => shadowed.add(name)));
-    if (['FunctionDeclaration', 'ClassDeclaration'].includes(d?.type) && d.id) shadowed.add(d.id.name);
-    if (n?.type === 'ImportDeclaration') n.specifiers.forEach((x) => shadowed.add(x.local.name));
-  };
-  (instanceProgram?.body ?? []).forEach(note);
-  const instanceBlock = { type: 'BlockStatement', body: instanceProgram?.body ?? [], start: instanceProgram?.start, end: instanceProgram?.end };
+  const { bindings: shadowed, varBindings } = collectScriptBindings(instanceProgram);
+  const declarations = [...varBindings].map((name) => ({ type: 'VariableDeclarator', id: { type: 'Identifier', name }, init: null }));
+  const marker = declarations.length ? [{ type: 'VariableDeclaration', kind: 'let', declarations }] : [];
+  const instanceBlock = { type: 'BlockStatement', body: [...marker, ...(instanceProgram?.body ?? [])], start: instanceProgram?.start, end: instanceProgram?.end };
+  instanceBlock[FLOW_FUNCTION_SCOPE] = true;
   const module = collectObjectFlow({ ...moduleProgram, body: [...(moduleProgram.body ?? []), instanceBlock] });
   const instance = new Map([...module].filter(([name]) => !shadowed.has(name)));
   instanceOwn.forEach((events, name) => instance.set(name, events));

--- a/frontend/scripts/control-feedback-debt-ast.mjs
+++ b/frontend/scripts/control-feedback-debt-ast.mjs
@@ -16,7 +16,7 @@ export function collectObjectFlow(program) {
   const fnScope = (s) => { while (s.parent && !s.fn) s = s.parent; return s; };
   const declare = (s, n) => s.bindings.get(n) ?? (s.bindings.set(n, { root: null, text: null }), s.bindings.get(n));
   const names = (s, p, kind = 'let') => boundNames(p).forEach((n) => declare(kind === 'var' ? fnScope(s) : s, n));
-  const predeclare = (body, s) => (body ?? []).forEach((n) => { if (n.type === 'VariableDeclaration') n.declarations.forEach((d) => names(s, d.id, n.kind)); if (n.type === 'FunctionDeclaration' && n.id) declare(s, n.id.name); });
+  const predeclare = (body, s) => (body ?? []).forEach((n) => { const d = /^Export/.test(n.type) ? n.declaration : n; if (d?.type === 'VariableDeclaration') d.declarations.forEach((x) => names(s, x.id, d.kind)); if (['FunctionDeclaration', 'ClassDeclaration'].includes(d?.type) && d.id) declare(s, d.id.name); if (n.type === 'ImportDeclaration') n.specifiers.forEach((x) => declare(s, x.local.name)); });
   const hoist = (n, s) => { if (!n || typeof n !== 'object' || /Function(?:Declaration|Expression)$/.test(n.type) || n.type === 'ArrowFunctionExpression') return; if (n.type === 'VariableDeclaration' && n.kind === 'var') n.declarations.forEach((d) => names(s, d.id, 'var')); Object.entries(n).forEach(([k, v]) => { if (!SKIP.has(k)) Array.isArray(v) ? v.forEach((x) => hoist(x, s)) : hoist(v, s); }); };
   const direct = (n, s) => { n = unwrapExpression(n).node; return n?.type === 'Identifier' ? get(s, n.name)?.root ?? null : null; };
   const text = (n, s) => { n = unwrapExpression(n).node; return n && Object.hasOwn(n, 'value') && (n.value === null || ['string', 'number', 'boolean', 'bigint'].includes(typeof n.value)) ? String(n.value) : n?.type === 'TemplateLiteral' && !n.expressions.length ? n.quasis[0].value.cooked : n?.type === 'Identifier' ? get(s, n.name)?.text ?? null : null; };
@@ -53,4 +53,23 @@ export function collectObjectFlow(program) {
   });
   for (const events of exposed.values()) events.sort((a, b) => a.order - b.order).forEach((e) => delete e.order);
   return exposed;
+}
+
+/** Analyze Svelte module and instance programs as linked lexical scopes. */
+export function collectSvelteObjectFlows(moduleProgram, instanceProgram) {
+  const empty = () => new Map(), instanceOwn = instanceProgram ? collectObjectFlow(instanceProgram) : empty();
+  if (!moduleProgram) return { module: empty(), instance: instanceOwn };
+  const shadowed = new Set();
+  const note = (n) => {
+    const d = /^Export/.test(n?.type) ? n.declaration : n;
+    if (d?.type === 'VariableDeclaration') d.declarations.forEach((x) => boundNames(x.id).forEach((name) => shadowed.add(name)));
+    if (['FunctionDeclaration', 'ClassDeclaration'].includes(d?.type) && d.id) shadowed.add(d.id.name);
+    if (n?.type === 'ImportDeclaration') n.specifiers.forEach((x) => shadowed.add(x.local.name));
+  };
+  (instanceProgram?.body ?? []).forEach(note);
+  const instanceBlock = { type: 'BlockStatement', body: instanceProgram?.body ?? [], start: instanceProgram?.start, end: instanceProgram?.end };
+  const module = collectObjectFlow({ ...moduleProgram, body: [...(moduleProgram.body ?? []), instanceBlock] });
+  const instance = new Map([...module].filter(([name]) => !shadowed.has(name)));
+  instanceOwn.forEach((events, name) => instance.set(name, events));
+  return { module, instance };
 }

--- a/frontend/scripts/control-feedback-debt-flow.mjs
+++ b/frontend/scripts/control-feedback-debt-flow.mjs
@@ -1,7 +1,7 @@
 /** Compatibility exports for control-feedback inventory object-flow consumers. */
 import { unwrapExpression } from './control-feedback-debt-ast.mjs';
 
-export { collectObjectFlow } from './control-feedback-debt-ast.mjs';
+export { collectObjectFlow, collectSvelteObjectFlows } from './control-feedback-debt-ast.mjs';
 
 /** @param {any} node @returns {any|null} */
 export function unwrapIdentifier(node) {

--- a/frontend/src/__tests__/control-feedback-debt-flow.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-flow.test.ts
@@ -199,5 +199,12 @@ describe('control feedback object flow (MOR-1715)', () => {
       { key: 'type', value: 'instance', poison: false },
     ]);
     expect(functionLocal.instance.get('props')).toBe(functionLocal.module.get('props'));
+
+    const varAlias = linked(moduleSource, `var alias = props; alias.type = 'alias';`);
+    expect(eventSummary(varAlias.module.get('props'))).toEqual([
+      { key: 'type', value: 'module', poison: false },
+      { key: 'type', value: 'alias', poison: false },
+    ]);
+    expect(varAlias.instance.get('props')).toBe(varAlias.module.get('props'));
   });
 });

--- a/frontend/src/__tests__/control-feedback-debt-flow.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-flow.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { parse } from 'svelte/compiler';
 // @ts-ignore -- intentionally plain Node ESM shared by the inventory script.
-import { collectObjectFlow, unwrapIdentifier } from '../../scripts/control-feedback-debt-flow.mjs';
+import { collectObjectFlow, collectSvelteObjectFlows, unwrapIdentifier } from '../../scripts/control-feedback-debt-flow.mjs';
 // @ts-ignore -- compatibility identity must remain delegated to the shared AST helper.
 import { collectObjectFlow as collectSharedObjectFlow } from '../../scripts/control-feedback-debt-ast.mjs';
 
 const program = (source: string) => parse(`<script lang="ts">${source}</script>`, { modern: true }).instance!.content;
 const flow = (source: string, root = 'props') => collectObjectFlow(program(source)).get(root) ?? [];
 const summary = (source: string) => flow(source).map(({ key, value, poison }: any) => ({
+  key, value: value?.value ?? null, poison,
+}));
+const linked = (moduleSource: string, instanceSource: string) => {
+  const parsed: any = parse(`<script module lang="ts">${moduleSource}</script><script lang="ts">${instanceSource}</script>`, { modern: true });
+  return collectSvelteObjectFlows(parsed.module.content, parsed.instance.content);
+};
+const eventSummary = (events: any[] = []) => events.map(({ key, value, poison }: any) => ({
   key, value: value?.value ?? null, poison,
 }));
 
@@ -110,6 +117,60 @@ describe('control feedback object flow (MOR-1715)', () => {
     expect(collectObjectFlow(program(`const a = b; const b = a; a.type = 'range';`)).size).toBe(0);
     expect(summary(`const props = {}; const alias = (0, props); alias.type = 'range';`)).toEqual([
       { key: 'type', value: 'range', poison: false },
+    ]);
+  });
+
+  it('links unshadowed module identities to ordered instance mutations', () => {
+    const scopes = linked(
+      `const props = {}; props.type = 'button';`,
+      `const alias = props; props.type = 'range'; alias.feedbackPolicy = 'radio-backed';`,
+    );
+    expect(eventSummary(scopes.module.get('props'))).toEqual([
+      { key: 'type', value: 'button', poison: false },
+      { key: 'type', value: 'range', poison: false },
+      { key: 'feedback-policy', value: 'radio-backed', poison: false },
+    ]);
+    expect(scopes.instance.get('props')).toBe(scopes.module.get('props'));
+  });
+
+  it('preserves poison and recovery order across wrappers and nested escapes', () => {
+    const scopes = linked(
+      `const props = {};`,
+      `let key = 'type'; (props as Record<string, unknown>)[key] = 'range';
+       mutate(props as Record<string, unknown>); sink({ nested: [props!] });
+       (props as Record<string, unknown>).type = 'number';
+       props.items.push(1);`,
+    );
+    expect(eventSummary(scopes.instance.get('props'))).toEqual([
+      { key: null, value: null, poison: true },
+      { key: null, value: null, poison: true },
+      { key: null, value: null, poison: true },
+      { key: 'type', value: 'number', poison: false },
+      { key: null, value: null, poison: true },
+    ]);
+  });
+
+  it('keeps module and instance shadows isolated in both directions', () => {
+    const instanceRange = linked(
+      `const props = {}; props.type = 'button';`,
+      `const props = {}; props.type = 'range';`,
+    );
+    expect(eventSummary(instanceRange.module.get('props'))).toEqual([
+      { key: 'type', value: 'button', poison: false },
+    ]);
+    expect(eventSummary(instanceRange.instance.get('props'))).toEqual([
+      { key: 'type', value: 'range', poison: false },
+    ]);
+
+    const moduleRange = linked(
+      `const props = {}; props.type = 'range';`,
+      `const props = {}; props.type = 'button';`,
+    );
+    expect(eventSummary(moduleRange.module.get('props'))).toEqual([
+      { key: 'type', value: 'range', poison: false },
+    ]);
+    expect(eventSummary(moduleRange.instance.get('props'))).toEqual([
+      { key: 'type', value: 'button', poison: false },
     ]);
   });
 });

--- a/frontend/src/__tests__/control-feedback-debt-flow.test.ts
+++ b/frontend/src/__tests__/control-feedback-debt-flow.test.ts
@@ -173,4 +173,31 @@ describe('control feedback object flow (MOR-1715)', () => {
       { key: 'type', value: 'button', poison: false },
     ]);
   });
+
+  it('hoists instance script var shadows without crossing function boundaries', () => {
+    const moduleSource = `const props = {}; props.type = 'module';`;
+    const expectShadowed = (instanceSource: string) => {
+      const scopes = linked(moduleSource, instanceSource);
+      expect(eventSummary(scopes.module.get('props'))).toEqual([
+        { key: 'type', value: 'module', poison: false },
+      ]);
+      expect(scopes.instance.get('props')).not.toBe(scopes.module.get('props'));
+    };
+
+    expectShadowed(`var props = props; props.type = 'self';`);
+    expectShadowed(`if (flag) { var props = {}; } props.type = 'block';`);
+    expectShadowed(`for (var props of values) {} props.type = 'loop';`);
+    expectShadowed(`try {} catch (error) { var { props } = error; } props.type = 'catch';`);
+
+    const functionLocal = linked(
+      moduleSource,
+      `function mutateLocal() { var props = {}; props.type = 'local'; }
+       props.type = 'instance';`,
+    );
+    expect(eventSummary(functionLocal.module.get('props'))).toEqual([
+      { key: 'type', value: 'module', poison: false },
+      { key: 'type', value: 'instance', poison: false },
+    ]);
+    expect(functionLocal.instance.get('props')).toBe(functionLocal.module.get('props'));
+  });
 });


### PR DESCRIPTION
## Scope

- Linked issue / task: [MOR-1748](https://linear.app/morozsm/issue/MOR-1748/link-module-and-instance-object-flow-identities-for-debt-ast-analysis)
- Add `collectSvelteObjectFlows(moduleProgram, instanceProgram)` for conservative linked lexical analysis.
- Preserve shared identity for unshadowed module objects while isolating instance shadows.
- Hoist nested script-scope `var` bindings without leaking function-body bindings into the instance script scope.
- Compatibility impact: additive internal analysis API; existing `collectObjectFlow(program)` remains unchanged.

## Verification

- [x] Original base RED: the cross-program API was absent.
- [x] Remediation RED at `e521efee09c0d1cec01390e44dfcf2f41b073fa8`: self-referential and nested script-scope `var` shadows mutated the module root.
- [x] Focused AST/evaluator/baseline/flow suites: 73 passed.
- [x] Full frontend suite: 364 files, 7,973 tests passed.
- [x] `npm run check`, `npm run lint`, `npm run lint:boundaries`, `npm run i18n:check`, and `npm run build` passed.
- [x] `git diff --check`, scope guard, and public secret/path scan passed.
- [x] Scope: 3 files, +135/-4 (139 changed LOC).
- [x] No `control-feedback-debt-inventory.mjs` or PR #2664-owned changes.
- [x] Public/open-core boundary checked.
- [x] No release or migration impact.

## Agent Review

- [ ] Fresh independent exact-head review required for `1cf6d7682e907264eebbf12d1f358396165050b6` before merge.
- The verifier who BLOCKED the old head authored the remediation and cannot PASS the new head.

## Notes

- Out of scope: MOR-1713 inventory integration, baseline changes, runtime/UI/radio behavior, and hardware/TX operations.
- PR #2664 must consume this API only after this prerequisite merges.
