### PR TITLE
fix(MOR-1646): confirm CW control writes from radio readback

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
 
 from ..exceptions import CommandError
 from ..exceptions import ConnectionError as RadioConnectionError
@@ -1369,6 +1369,46 @@ class RadioPoller:
         else:
             self._state_store.apply(observation)
 
+    async def _confirm_global_operator_write(
+        self,
+        name: str,
+        expected: int,
+        getter: Callable[[], Awaitable[int]],
+        *,
+        command_id: str | None,
+        source: CommandSource,
+        session_id: str | None,
+        command_service: CommandService | None,
+        provider_generation: int,
+    ) -> None:
+        """Apply a global operator write only after a matching fresh readback."""
+
+        try:
+            confirmed = await asyncio.wait_for(getter(), timeout=_SEND_TIMEOUT)
+        except Exception:
+            logger.debug(
+                "radio-poller: %s post-write readback failed",
+                name,
+                exc_info=True,
+            )
+            return
+        if provider_generation != self._provider_generation():
+            logger.debug("radio-poller: discarded stale %s readback", name)
+            return
+        if confirmed != expected:
+            logger.warning("radio-poller: %s write readback mismatch", name)
+            return
+        self._apply_global_control_observation(
+            name,
+            confirmed,
+            command_id=command_id,
+            source=source,
+            session_id=session_id,
+            command_service=command_service,
+            provider_generation=provider_generation,
+        )
+        self._apply_compatibility_mirror(lambda state: setattr(state, name, confirmed))
+
     def _apply_global_command_echo_observation(
         self,
         name: str,
@@ -2399,16 +2439,40 @@ class RadioPoller:
                 await _r.set_agc_time_constant(value, receiver=rx)
             case SetCwPitch(value=value):
                 await _r.set_cw_pitch(value)
-                if self._radio_state:
-                    self._radio_state.cw_pitch = value
+                await self._confirm_global_operator_write(
+                    "cw_pitch",
+                    value,
+                    _r.get_cw_pitch,
+                    command_id=command_id,
+                    source=command_source,
+                    session_id=session_id,
+                    command_service=command_service,
+                    provider_generation=provider_generation,
+                )
             case SetKeySpeed(speed=speed):
                 await _r.set_key_speed(speed)
-                if self._radio_state:
-                    self._radio_state.key_speed = speed
+                await self._confirm_global_operator_write(
+                    "key_speed",
+                    speed,
+                    _r.get_key_speed,
+                    command_id=command_id,
+                    source=command_source,
+                    session_id=session_id,
+                    command_service=command_service,
+                    provider_generation=provider_generation,
+                )
             case SetBreakIn(mode=mode):
                 await _r.set_break_in(mode)
-                if self._radio_state:
-                    self._radio_state.break_in = mode
+                await self._confirm_global_operator_write(
+                    "break_in",
+                    mode,
+                    _r.get_break_in,
+                    command_id=command_id,
+                    source=command_source,
+                    session_id=session_id,
+                    command_service=command_service,
+                    provider_generation=provider_generation,
+                )
             case SetApf(mode=mode, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_apf")
                 await _r.set_audio_peak_filter(mode, receiver=rx)

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -63,7 +63,9 @@ from rigplane.web.radio_poller import (
     SetAfLevel,
     SetAgc,
     SetAttenuator,
+    SetBreakIn,
     SetBreakInDelay,
+    SetCwPitch,
     SetData1ModInput,
     SetDataMode,
     SetDigiSel,
@@ -72,6 +74,7 @@ from rigplane.web.radio_poller import (
     SetFilterWidth,
     SetFreq,
     SetIpPlus,
+    SetKeySpeed,
     SetMode,
     SetNB,
     SetNR,
@@ -1216,6 +1219,122 @@ async def test_execute_failed_set_break_in_delay_does_not_queue_readback() -> No
         await poller._execute(SetBreakInDelay(140))  # noqa: SLF001
 
     assert scheduler.pending_requests() == ()
+
+
+@pytest.mark.parametrize(
+    ("cmd", "field", "expected", "previous"),
+    (
+        (SetCwPitch(650), "cw_pitch", 650, 600),
+        (SetKeySpeed(24), "key_speed", 24, 20),
+        (SetBreakIn(1), "break_in", 1, 0),
+        (SetBreakIn(2), "break_in", 2, 0),
+    ),
+    ids=("cw-pitch", "key-speed", "break-in-semi", "break-in-full"),
+)
+@pytest.mark.asyncio
+async def test_cw_operator_write_requires_matching_radio_readback(
+    cmd: Any, field: str, expected: int, previous: int
+) -> None:
+    path = FieldPath.global_("operator_controls", field)
+    store = StateStore()
+    store.begin_provider_generation()
+    state = RadioState()
+    setattr(state, field, previous)
+    radio = _make_radio(model="IC-7300")
+    setter = AsyncMock()
+    getter = AsyncMock(return_value=expected)
+    setattr(radio, f"set_{field}", setter)
+    setattr(radio, f"get_{field}", getter)
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+
+    await poller._execute(cmd, command_id="cw-write-1")  # noqa: SLF001
+
+    setter.assert_awaited_once_with(expected)
+    getter.assert_awaited_once_with()
+    confirmed = store.snapshot().field(path)
+    assert (confirmed.value, confirmed.source.native_id) == (
+        expected,
+        f"{field}_readback",
+    )
+    assert getattr(state, field) == expected
+
+
+@pytest.mark.parametrize(
+    "outcome", ("failure", "timeout", "mismatch", "stale", "new-generation")
+)
+@pytest.mark.asyncio
+async def test_cw_operator_unconfirmed_write_preserves_radio_truth(
+    outcome: str,
+) -> None:
+    cmd, field, expected, previous = SetCwPitch(650), "cw_pitch", 650, 600
+    path = FieldPath.global_("operator_controls", field)
+    store = StateStore()
+    generation = store.begin_provider_generation()
+
+    def seed(value: int, provider_generation: int) -> None:
+        store.apply(
+            Observation(
+                path=path,
+                value=value,
+                source=SourceMetadata(source="poll_response", provider="test"),
+                timestamp_monotonic=time.monotonic(),
+                provider_generation=provider_generation,
+            )
+        )
+
+    seed(previous, generation)
+    before = store.snapshot().field(path)
+    state = RadioState()
+    setattr(state, field, previous)
+    radio = _make_radio(model="IC-7300")
+    setter = AsyncMock()
+
+    async def readback() -> int:
+        if outcome == "failure":
+            raise CommandError("readback failed")
+        if outcome == "timeout":
+            await asyncio.Event().wait()
+        if outcome == "mismatch":
+            return expected + 1
+        if outcome == "new-generation":
+            seed(previous, store.begin_provider_generation())
+        return expected
+
+    getter = AsyncMock(side_effect=readback)
+    setattr(radio, f"set_{field}", setter)
+    setattr(radio, f"get_{field}", getter)
+    poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
+    if outcome == "stale":
+        poller._provider_generation = MagicMock(  # type: ignore[method-assign] # noqa: SLF001
+            side_effect=(generation, generation + 1)
+        )
+
+    with patch("rigplane.web.radio_poller._SEND_TIMEOUT", 0.001):
+        await poller._execute(cmd)  # noqa: SLF001
+
+    setter.assert_awaited_once_with(expected)
+    getter.assert_awaited_once_with()
+    after = store.snapshot().field(path)
+    if outcome != "new-generation":
+        assert after == before
+    else:
+        assert (after.value, after.provider_generation) == (
+            previous,
+            store.provider_generation,
+        )
+    assert getattr(state, field) == previous
+
+
+def test_ic7300_cw_operator_controls_have_paired_readback_routes() -> None:
+    poller = RadioPoller(_make_radio(model="IC-7300"), CommandQueue())
+    for name, route in {
+        "cw_pitch": (0x14, 0x09),
+        "key_speed": (0x14, 0x0C),
+        "break_in": (0x16, 0x47),
+    }.items():
+        assert poller._cmd_map.get(f"set_{name}") == route  # noqa: SLF001
+        assert poller._cmd_map.get(f"get_{name}") == route  # noqa: SLF001
+    assert poller._profile.break_in_modes == (0, 1, 2)  # noqa: SLF001
 
 
 @pytest.mark.parametrize(("receiver", "slot"), ((0, "main"), (1, "sub")))

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3354,6 +3354,7 @@ class TestRadioPoller:
 
         radio = self._make_radio()
         radio.set_key_speed = AsyncMock()
+        radio.get_key_speed = AsyncMock(return_value=24)
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
 
@@ -3372,6 +3373,7 @@ class TestRadioPoller:
 
         radio = self._make_radio()
         radio.set_break_in = AsyncMock()
+        radio.get_break_in = AsyncMock(return_value=1)
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
 
@@ -3830,6 +3832,7 @@ class TestSwitchScopeReceiver:
 
         radio = self._make_radio()
         radio.set_cw_pitch = AsyncMock()
+        radio.get_cw_pitch = AsyncMock(return_value=600)
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
 


### PR DESCRIPTION
Linear: MOR-1646

## Summary
- send CW Pitch, Key Speed, and Break-in writes exactly once
- require one bounded, matching post-write radio readback before updating canonical StateStore or the legacy RadioState mirror
- fail closed on readback failure, timeout, mismatch, stale generation, or provider replacement
- pin IC-7300 paired SET/GET command routes and both SEMI/FULL break-in modes

## Non-goals
- no TX interlock, PTT, TUNE, VOX, keyer, or runtime changes
- no new polling loop or public API changes

## Verification
- red-first: 19 focused poller failures before implementation
- focused MOR-1646 matrix: 10 passed
- relevant CW/IC-7300/commands suite: 748 passed
- full non-integration: 9868 passed, 74 skipped, 14 xfailed, 1 xpassed
- ruff check + format: pass
- import-linter: pass
- diff/privacy: pass
- mypy: baseline-blocked by 12 pre-existing errors on exact base (11 in untouched runtime mixins and the unchanged redundant cast at radio_poller.py:698)

Agent Review: independent exact-head review required; builder has not self-PASSed.