### PR TITLE
fix(MOR-1749): gate direct Web tuner writes by RF state

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -17,9 +17,11 @@ from ...core.command_service import (
     _raw_int_level_from_param,
     command_intent_from_request,
 )
+from ...core.exceptions import CommandError
 from ...core.state_pipeline_contracts import CommandIntent, CommandSource, FieldPath
 from ...core.state_store import FreshnessState, StateStore
 from ...profiles import RadioProfile, resolve_radio_profile
+from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
 from ..protocol import (  # noqa: TID251
     decode_json,
     encode_json,
@@ -98,6 +100,7 @@ from ..radio_poller import (  # noqa: TID251
     SetSystemDate,
     SetSystemTime,
     SetTwinPeak,
+    SetTunerStatus,
     SetDriveGain,
     SetUsbModLevel,
     SetVox,
@@ -1650,22 +1653,39 @@ class ControlHandler:
     ) -> dict[str, Any]:
         if "value" not in params:
             raise ValueError("missing required 'value' parameter")
-        value = int(params["value"])
-        if value not in (0, 1, 2):
-            raise ValueError(f"tuner value must be 0, 1, or 2, got {value}")
+        value = params["value"]
+        if type(value) is not int or value not in (0, 1, 2):
+            raise ValueError(f"tuner value must be 0, 1, or 2; got {value!r}")
         if self._read_only and value == 2:
             raise PermissionError("read-only mode: set_tuner_status TUNING rejected")
+
+        rf_state = RfState.UNKNOWN
+        state_store = getattr(self._server, "command_state_store", None)
+        if isinstance(state_store, StateStore):
+            try:
+                ptt = state_store.snapshot().field(FieldPath.global_("tx_state", "ptt"))
+            except KeyError:
+                pass
+            else:
+                if ptt.freshness is FreshnessState.FRESH and ptt.value is False:
+                    rf_state = RfState.RX
+                elif ptt.freshness is FreshnessState.FRESH and ptt.value is True:
+                    rf_state = RfState.TX
+
+        command = SetTunerStatus(value)
+        decision = evaluate_tx_interlock(command, rf_state=rf_state)
+        if not decision.allowed:
+            raise CommandError(decision.reason)
+
         # Try direct call if the radio has the method
         if radio is not None and CAP_TUNER in radio.capabilities:
             await radio.set_tuner_status(value)
         else:
             # Route through command queue
-            from ..radio_poller import SetTunerStatus  # noqa: TID251
-
             q = self._server.command_queue if self._server is not None else None
             if q is None:
                 raise RuntimeError("no command queue available")
-            q.put(SetTunerStatus(value))
+            q.put(command)
         label = {0: "OFF", 1: "ON", 2: "TUNING"}[value]
         return {"value": value, "label": label}
 

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import struct
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -13,6 +14,12 @@ from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.profiles import resolve_radio_profile
 from rigplane.audio.route import AudioConfigSource, AudioStreamContract
 from rigplane.core.radio_protocol import AudioCapable
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
 from rigplane.runtime.radio import IcomRadio
 from rigplane.scope import ScopeFrame
 from rigplane.types import AudioCodec
@@ -316,9 +323,22 @@ def _control_handler(
     radio: object | None = None,
     server: object | None = None,
     session_id: str | None = None,
+    ptt: bool | None = None,
 ) -> ControlHandler:
     if ws is None:
         ws = SimpleNamespace(send_text=AsyncMock(), recv=AsyncMock())
+    if ptt is not None and server is None:
+        store = StateStore()
+        store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=ptt,
+                source=SourceMetadata("poll_response", "test", "fake", "test"),
+                timestamp_monotonic=time.monotonic(),
+                max_age=1.0,
+            )
+        )
+        server = SimpleNamespace(command_state_store=store, command_queue=None)
     return ControlHandler(
         ws,
         radio,
@@ -2474,7 +2494,7 @@ async def test_set_tuner_status_ws_command() -> None:
     """set_tuner_status fires the radio method and returns label."""
     radio = _capable_radio()
     radio.set_tuner_status = AsyncMock()
-    handler = _control_handler(radio=radio)
+    handler = _control_handler(radio=radio, ptt=False)
     result = await handler._enqueue_command("set_tuner_status", {"value": 2})
     assert result == {"value": 2, "label": "TUNING"}
     radio.set_tuner_status.assert_awaited_once_with(2)
@@ -2483,7 +2503,7 @@ async def test_set_tuner_status_ws_command() -> None:
 @pytest.mark.asyncio
 async def test_set_tuner_status_ws_command_no_radio() -> None:
     """set_tuner_status raises when radio is not connected."""
-    handler = _control_handler(radio=None)
+    handler = _control_handler(radio=None, ptt=False)
     with pytest.raises(RuntimeError, match="no command queue available"):
         await handler._enqueue_command("set_tuner_status", {"value": 1})
 

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -10,19 +10,53 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from rigplane.capabilities import CAP_CW, CAP_TUNER
+from rigplane.core.exceptions import CommandError
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.web.radio_poller import SetTunerStatus
 from rigplane.web.handlers.control import ControlHandler
+
+_UNOBSERVED = object()
 
 
 def _make_handler(
-    *, read_only: bool = False, radio: Any = None
+    *,
+    read_only: bool = False,
+    radio: Any = None,
+    ptt: object = False,
+    stale: bool = False,
 ) -> tuple[ControlHandler, Queue[Any]]:
     """Build a ControlHandler with a fake server and return (handler, command_queue)."""
     ws = MagicMock()
 
     command_queue: Queue[Any] = Queue()
+    clock = FreshnessClock(start=10.0)
+    state_store = StateStore(freshness_clock=clock)
+    if ptt is not _UNOBSERVED:
+        state_store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=ptt,
+                source=SourceMetadata(
+                    source="poll_response",
+                    provider="test",
+                    transport="fake",
+                    native_id="test",
+                ),
+                timestamp_monotonic=clock.now(),
+                max_age=1.0,
+            )
+        )
+        if stale:
+            state_store.mark_stale_due(now=12.0)
 
     server = SimpleNamespace(
         command_queue=command_queue,
+        command_state_store=state_store,
     )
 
     if radio is None:
@@ -196,3 +230,74 @@ class TestWebTunerReadOnly:
 
         assert result == {"value": 2, "label": "TUNING"}
         radio.set_tuner_status.assert_awaited_once_with(2)
+
+    @pytest.mark.parametrize("value", [1, 2])
+    @pytest.mark.parametrize(
+        ("ptt", "stale", "reason"),
+        [
+            (True, False, "RF state is TX"),
+            (_UNOBSERVED, False, "RF state is unknown"),
+            (False, True, "RF state is unknown"),
+            (1, False, "RF state is unknown"),
+        ],
+        ids=["tx", "missing", "stale", "invalid"],
+    )
+    async def test_tuner_engage_fails_closed_before_direct_call(
+        self, value: int, ptt: object, stale: bool, reason: str
+    ) -> None:
+        radio = self._make_tuner_radio()
+        handler, q = _make_handler(radio=radio, ptt=ptt, stale=stale)
+
+        with pytest.raises(CommandError, match=reason):
+            await handler._enqueue_command("set_tuner_status", {"value": value})
+
+        radio.set_tuner_status.assert_not_awaited()
+        assert q.empty()
+
+    @pytest.mark.parametrize("value", [1, 2])
+    @pytest.mark.parametrize("ptt", [True, _UNOBSERVED], ids=["tx", "unknown"])
+    async def test_tuner_engage_fails_closed_before_queue(
+        self, value: int, ptt: object
+    ) -> None:
+        radio = SimpleNamespace(capabilities=frozenset())
+        handler, q = _make_handler(radio=radio, ptt=ptt)
+
+        with pytest.raises(CommandError):
+            await handler._enqueue_command("set_tuner_status", {"value": value})
+
+        assert q.empty()
+
+    @pytest.mark.parametrize(
+        ("ptt", "stale"),
+        [(True, False), (_UNOBSERVED, False), (False, True)],
+        ids=["tx", "missing", "stale"],
+    )
+    async def test_tuner_off_is_always_attempted(
+        self, ptt: object, stale: bool
+    ) -> None:
+        radio = self._make_tuner_radio()
+        handler, _ = _make_handler(radio=radio, ptt=ptt, stale=stale)
+
+        await handler._enqueue_command("set_tuner_status", {"value": 0})
+
+        radio.set_tuner_status.assert_awaited_once_with(0)
+
+    async def test_fresh_rx_queue_preserves_tuner_dispatch(self) -> None:
+        handler, q = _make_handler(
+            radio=SimpleNamespace(capabilities=frozenset()), ptt=False
+        )
+
+        await handler._enqueue_command("set_tuner_status", {"value": 2})
+
+        assert q.get_nowait() == SetTunerStatus(2)
+
+    @pytest.mark.parametrize("value", [True, 1.5, 3, "bogus"])
+    async def test_invalid_tuner_value_fails_without_call(self, value: object) -> None:
+        radio = self._make_tuner_radio()
+        handler, q = _make_handler(radio=radio)
+
+        with pytest.raises(ValueError, match="tuner value"):
+            await handler._enqueue_command("set_tuner_status", {"value": value})
+
+        radio.set_tuner_status.assert_not_awaited()
+        assert q.empty()


### PR DESCRIPTION
## Summary

- derive the direct Web tuner gate from the canonical fresh `global.tx_state.ptt` observation
- enforce the shared `SetTunerStatus` TX-interlock policy before direct backend or queue dispatch
- preserve tuner OFF as always-attempted, fresh RX behavior, and existing read-only semantics
- reject malformed tuner values explicitly

Linear: [MOR-1749](https://linear.app/morozsm/issue/MOR-1749/mor-1500-b3-a-gate-direct-web-tuner-writes-by-rf-state)
Parent: [MOR-1628](https://linear.app/morozsm/issue/MOR-1628/mor-1500-b3-enforce-value-sensitive-tuner-interlock-on-direct-web-path)

## Verification

- RED first: 19 focused failures before implementation
- `uv run pytest -q --tb=short tests/test_web_ptt_readonly.py ...focused handler tuner tests` — 37 passed
- relevant Web/CW/FTX/Yaesu suite — 914 passed, 2 skipped
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9945 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run lint-imports`
- `uv run mypy --strict src/rigplane/web`
- IC-7610, X6200, and FTX-1 validation dry-run golden gates
- frontend i18n/check/Vitest/build — 7969 tests passed

Full `uv run mypy src/` still reports the existing 12 errors in runtime control/audio code and `web/radio_poller.py`; the changed Web boundary passes strict mypy.

## Scope

Exactly 3 files, 163 changed LOC. No lifecycle/readback, deferred lane, CW, profile override, Yaesu poller, Pro/private, runtime, or hardware changes.