### PR TITLE
MOR-1752: classify rigctld setters for shared TX policy

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -37,10 +37,16 @@ from ..core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from ..core.state_store import FreshnessState, StateStore, StateSnapshot
+from ..core.tx_interlock_contract import (
+    TxInterlockCommandFamily,
+    TxInterlockDisposition,
+)
 from ..core.tx_safety import TxOutcome, TxReleaseReason
 from ..exceptions import ConnectionError, TimeoutError as RigplaneTimeoutError
 from ..radio_protocol import StateModelCapable, StateModelService, StateStoreCapable
 from ..radio_state import RadioState, ReceiverState
+from ..runtime import _poller_types as tx_commands  # noqa: TID251
+from ..runtime import tx_interlock
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..types import Mode
 from .contract import (  # noqa: TID251
@@ -230,6 +236,79 @@ def _passband_to_filter(passband_hz: int) -> int | None:
 _TX_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})
 
 
+@dataclass(frozen=True, slots=True)
+class _RigctldTxPolicyClassification:
+    command: object
+    disposition: TxInterlockDisposition
+    family: TxInterlockCommandFamily | None
+
+
+_LEVEL_POLICY_COMMANDS: dict[str, str] = dict(
+    zip(
+        "RFPOWER AF RF SQL NR NB COMP MICGAIN MONITOR_GAIN KEYSPD CWPITCH PREAMP ATT NOTCHF IFSHIFT".split(),
+        "SetPower SetAfLevel SetRfGain SetSquelch SetNRLevel SetNBLevel SetCompressorLevel SetMicGain SetMonitorGain SetKeySpeed SetCwPitch SetPreamp SetAttenuator SetNotchFilter SetIfShift".split(),
+        strict=True,
+    )
+)
+_FUNC_POLICY_COMMANDS: dict[str, str] = dict(
+    zip(
+        "NB NR COMP VOX TONE TSQL ANF LOCK MON APF AGC".split(),
+        "SetNB SetNR SetCompressor SetVox SetRepeaterTone SetRepeaterTsql SetAutoNotch SetDialLock SetMonitor SetAudioPeakFilter SetAgc".split(),
+        strict=True,
+    )
+)
+
+
+def _classify_rigctld_tx_intent(
+    intent: CommandIntent,
+) -> _RigctldTxPolicyClassification:
+    """Map one material rigctld intent into the canonical typed TX policy."""
+    params = intent.params
+    if intent.name == "set_freq":
+        command = tx_commands.SetFreq(int(params["freq_hz"]))
+    elif intent.name == "set_mode":
+        command = tx_commands.SetMode(str(params["mode"]))
+    elif intent.name == "set_ptt":
+        command = tx_commands.PttOn() if bool(params["ptt"]) else tx_commands.PttOff()
+    elif intent.name in ("set_rit", "set_xit"):
+        command = tx_commands.SetRitFrequency(int(params["hz"]))
+    elif intent.name == "set_vfo":
+        command = tx_commands.SelectVfo(str(params["vfo"]))
+    elif intent.name == "set_split_vfo":
+        command = tx_commands.SetSplit(bool(params["on"]))
+    elif intent.name == "send_raw":
+        command = tx_commands.SendCiv(command=0)
+    elif intent.name == "set_level":
+        level = str(params["level"]).upper()
+        command_type = _LEVEL_POLICY_COMMANDS.get(level)
+        if command_type is None:
+            raise ValueError(f"unmapped rigctld TX policy intent: set_level {level!r}")
+        command = getattr(tx_commands, command_type)(params["value"])
+    elif intent.name == "set_func":
+        func = str(params["func"]).upper()
+        on = bool(params["on"])
+        if func == "TUNER":
+            command = tx_commands.SetTunerStatus(1 if on else 0)
+        elif func == "SPLIT":
+            command = tx_commands.SetSplit(on)
+        else:
+            command_type = _FUNC_POLICY_COMMANDS.get(func)
+            if command_type is None:
+                raise ValueError(
+                    f"unmapped rigctld TX policy intent: set_func {func!r}"
+                )
+            command = getattr(tx_commands, command_type)(on)
+    else:
+        raise ValueError(f"unmapped rigctld TX policy intent: {intent.name!r}")
+
+    metadata = tx_interlock.get_tx_interlock_command_family_metadata(command)
+    return _RigctldTxPolicyClassification(
+        command=command,
+        disposition=tx_interlock.classify_tx_interlock(command),
+        family=None if metadata is None else metadata.family,
+    )
+
+
 def _ok() -> RigctldResponse:
     return RigctldResponse(error=HamlibError.OK)
 
@@ -335,6 +414,9 @@ class _RigctldCommandExecutor:
     handler: "RigctldHandler"
 
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        # B4-a establishes the exhaustive policy seam only. B4-b consumes this
+        # result to enforce BLOCK/DEFER; wire behavior remains unchanged here.
+        _classify_rigctld_tx_intent(intent)
         params = intent.params
         if intent.name == "set_freq":
             await self.handler._radio.set_freq(

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -264,6 +264,7 @@ def _classify_rigctld_tx_intent(
 ) -> _RigctldTxPolicyClassification:
     """Map one material rigctld intent into the canonical typed TX policy."""
     params = intent.params
+    command: tx_commands.Command
     if intent.name == "set_freq":
         command = tx_commands.SetFreq(int(params["freq_hz"]))
     elif intent.name == "set_mode":

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -1,0 +1,115 @@
+"""Rigctld write-intent coverage for the shared TX interlock policy."""
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.core.tx_interlock_contract import TxInterlockDisposition
+from rigplane.rigctld.contract import COMMAND_TABLE, ClientSession, RigctldResponse
+from rigplane.rigctld.handler import _classify_rigctld_tx_intent
+from rigplane.rigctld.protocol import format_response, parse_line
+from rigplane.runtime import _poller_types as commands
+
+
+def _intent(name: str, **params: object) -> CommandIntent:
+    return CommandIntent(id="test", name=name, params=params, source="rigctld")
+
+
+def test_material_intents_use_shared_policy() -> None:
+    cases = (
+        (_intent("set_freq", freq_hz=1), commands.SetFreq, "defer", "frequency"),
+        (_intent("set_mode", mode="USB"), commands.SetMode, "defer", "mode"),
+        (_intent("set_ptt", ptt=False), commands.PttOff, "always-pass", "ptt-off"),
+        (_intent("set_ptt", ptt=True), commands.PttOn, "block", "ptt-on"),
+        (_intent("set_rit", hz=50), commands.SetRitFrequency, "defer", "rit-xit"),
+        (_intent("set_xit", hz=-50), commands.SetRitFrequency, "defer", "rit-xit"),
+        (_intent("set_vfo", vfo="VFOA"), commands.SelectVfo, "defer", "vfo-select"),
+        (_intent("set_split_vfo", on=True), commands.SetSplit, "defer", "vfo-topology"),
+        (
+            _intent("send_raw", frame_bytes=b"\xfe\xfd"),
+            commands.SendCiv,
+            "block",
+            "raw-civ",
+        ),
+    )
+    for intent, command_type, disposition, family in cases:
+        classified = _classify_rigctld_tx_intent(intent)
+        assert isinstance(classified.command, command_type)
+        assert classified.disposition.value == disposition
+        assert classified.family is not None
+        assert classified.family.value == family
+
+
+def test_all_current_level_setters_are_typed_tx_safe() -> None:
+    levels = "RFPOWER AF RF SQL NR NB COMP MICGAIN MONITOR_GAIN KEYSPD CWPITCH PREAMP ATT NOTCHF IFSHIFT".split()
+    type_names = "SetPower SetAfLevel SetRfGain SetSquelch SetNRLevel SetNBLevel SetCompressorLevel SetMicGain SetMonitorGain SetKeySpeed SetCwPitch SetPreamp SetAttenuator SetNotchFilter SetIfShift".split()
+    for level, type_name in zip(levels, type_names, strict=True):
+        classified = _classify_rigctld_tx_intent(
+            _intent("set_level", level=level, value=1)
+        )
+        assert isinstance(classified.command, getattr(commands, type_name))
+        assert classified.disposition is TxInterlockDisposition.TX_SAFE
+        assert classified.family is None
+
+
+def test_all_current_function_setters_use_shared_policy() -> None:
+    funcs = "NB NR COMP VOX TONE TSQL ANF LOCK MON APF AGC".split()
+    type_names = "SetNB SetNR SetCompressor SetVox SetRepeaterTone SetRepeaterTsql SetAutoNotch SetDialLock SetMonitor SetAudioPeakFilter SetAgc".split()
+    for func, type_name in zip(funcs, type_names, strict=True):
+        classified = _classify_rigctld_tx_intent(
+            _intent("set_func", func=func, on=True)
+        )
+        assert isinstance(classified.command, getattr(commands, type_name))
+        assert classified.disposition is TxInterlockDisposition.TX_SAFE
+
+    for func, on, disposition in (
+        ("TUNER", False, "always-pass"),
+        ("TUNER", True, "block"),
+        ("SPLIT", True, "defer"),
+    ):
+        assert (
+            _classify_rigctld_tx_intent(
+                _intent("set_func", func=func, on=on)
+            ).disposition.value
+            == disposition
+        )
+
+
+def test_protocol_inventory_aliases_and_wire_output_remain_unchanged() -> None:
+    material_names = "set_freq set_mode set_ptt set_vfo set_level set_func set_split_vfo send_raw".split()
+    material_defs = {
+        definition
+        for definition in COMMAND_TABLE.values()
+        if definition.is_set or definition.long == "send_raw"
+    }
+    assert {definition.long for definition in material_defs} == set(material_names)
+    assert {
+        key for key, definition in COMMAND_TABLE.items() if definition in material_defs
+    } == {
+        alias
+        for definition in material_defs
+        for alias in (definition.short, definition.long)
+    }
+    for wire in (b"F 1", b"\\set_freq 1", b"T 0", b"\\set_ptt 0"):
+        assert (
+            format_response(parse_line(wire), RigctldResponse(), ClientSession())
+            == b"RPRT 0\n"
+        )
+
+
+def test_non_writes_and_future_material_intents_fail_closed() -> None:
+    non_writes = {
+        definition.long
+        for definition in COMMAND_TABLE.values()
+        if not definition.is_set
+        and definition.long != "send_raw"
+        and definition.long == definition.long.lower()
+    }
+    for name in (*non_writes, "future_write"):
+        with pytest.raises(ValueError, match="unmapped rigctld TX policy intent"):
+            _classify_rigctld_tx_intent(_intent(name))
+
+    for name, key in (("set_level", "future"), ("set_func", "future")):
+        with pytest.raises(ValueError, match="unmapped rigctld TX policy intent"):
+            _classify_rigctld_tx_intent(
+                _intent(name, level=key, func=key, value=1, on=True)
+            )


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1752/mor-1500-b4-a-classify-rigctld-setters-for-shared-tx-policy

## Summary

- map every current rigctld material write intent to an existing typed runtime command
- classify through the canonical shared TX interlock policy and retain stable family metadata
- fail explicitly for unknown intents and level/function subfamilies
- type the classifier-local command with the existing exhaustive `tx_commands.Command` union
- preserve current execution and wire behavior; B4-b enforcement is intentionally not included

## Scope

- exactly 2 files
- 198 added LOC
- refreshed base `1e11630ad3bdb58df581fd1cc3ba1eacdeb24590`

## Verification

- RED: focused test initially failed because the classification seam did not exist
- remediation RED: exact blocked head `31d4a2daa61df671ffb3fd2b25b40799c1337d2e` reproduced 20 mypy errors, including the 8 new classifier assignment errors
- focused: 5 passed
- relevant rigctld/interlock suite: 672 passed
- full non-integration on exact head: 9,989 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff and format: pass
- import-linter: 5 contracts kept
- exact base/head mypy parity: both base `1e11630ad3bdb58df581fd1cc3ba1eacdeb24590` and head report the same 12 pre-existing errors in 3 files; no handler classifier errors remain
- diff check and public/private-boundary scans: pass

No runtime, rigctld server, radio, PTT, TUNE, TX, or keying was invoked.