### PR TITLE
fix(MOR-1751): make tuner and CW follow-ups truthful

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1672,6 +1672,8 @@ class ControlHandler:
         else:
             # Await the poller's real completion instead of acknowledging a
             # fire-and-forget enqueue that may subsequently fail.
+            from ..server import _COMMAND_BATCH_STEP_TIMEOUT  # noqa: TID251
+
             q = self._server.command_queue if self._server is not None else None
             if q is None:
                 raise RuntimeError("no command queue available")
@@ -1682,7 +1684,9 @@ class ControlHandler:
                 asyncio.get_running_loop().create_future()
             )
             put_ordered(command, future=completion)
-            outcome = await completion
+            outcome = await asyncio.wait_for(
+                completion, timeout=_COMMAND_BATCH_STEP_TIMEOUT
+            )
         if outcome is False:
             raise CommandError("tuner command was rejected by the backend")
         label = {0: "OFF", 1: "ON", 2: "TUNING"}[value]

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1659,18 +1659,7 @@ class ControlHandler:
         if self._read_only and value == 2:
             raise PermissionError("read-only mode: set_tuner_status TUNING rejected")
 
-        rf_state = RfState.UNKNOWN
-        state_store = getattr(self._server, "command_state_store", None)
-        if isinstance(state_store, StateStore):
-            try:
-                ptt = state_store.snapshot().field(FieldPath.global_("tx_state", "ptt"))
-            except KeyError:
-                pass
-            else:
-                if ptt.freshness is FreshnessState.FRESH and ptt.value is False:
-                    rf_state = RfState.RX
-                elif ptt.freshness is FreshnessState.FRESH and ptt.value is True:
-                    rf_state = RfState.TX
+        rf_state = self._observed_rf_state()
 
         command = SetTunerStatus(value)
         decision = evaluate_tx_interlock(command, rf_state=rf_state)
@@ -1679,15 +1668,40 @@ class ControlHandler:
 
         # Try direct call if the radio has the method
         if radio is not None and CAP_TUNER in radio.capabilities:
-            await radio.set_tuner_status(value)
+            outcome = await radio.set_tuner_status(value)
         else:
-            # Route through command queue
+            # Await the poller's real completion instead of acknowledging a
+            # fire-and-forget enqueue that may subsequently fail.
             q = self._server.command_queue if self._server is not None else None
             if q is None:
                 raise RuntimeError("no command queue available")
-            q.put(command)
+            put_ordered = getattr(q, "put_ordered", None)
+            if not callable(put_ordered):
+                raise RuntimeError("tuner command completion is unavailable")
+            completion: asyncio.Future[object] = (
+                asyncio.get_running_loop().create_future()
+            )
+            put_ordered(command, future=completion)
+            outcome = await completion
+        if outcome is False:
+            raise CommandError("tuner command was rejected by the backend")
         label = {0: "OFF", 1: "ON", 2: "TUNING"}[value]
         return {"value": value, "label": label}
+
+    def _observed_rf_state(self) -> RfState:
+        """Resolve current RF state from fresh, strictly boolean PTT evidence."""
+        state_store = getattr(self._server, "command_state_store", None)
+        if isinstance(state_store, StateStore):
+            try:
+                ptt = state_store.snapshot().field(FieldPath.global_("tx_state", "ptt"))
+            except KeyError:
+                pass
+            else:
+                if ptt.freshness is FreshnessState.FRESH and ptt.value is False:
+                    return RfState.RX
+                elif ptt.freshness is FreshnessState.FRESH and ptt.value is True:
+                    return RfState.TX
+        return RfState.UNKNOWN
 
     async def _ro_get_ref_adjust(
         self, params: dict[str, Any], radio: "Radio | None"
@@ -1893,8 +1907,14 @@ class ControlHandler:
 
         if abs(delta) > 5:
             # Shift VFO frequency to zero-beat
+            command = SetFreq(freq + delta, receiver=receiver)
+            decision = evaluate_tx_interlock(
+                command, rf_state=self._observed_rf_state()
+            )
+            if not decision.allowed:
+                raise CommandError(decision.reason)
             q = self._server.command_queue
-            q.put(SetFreq(freq + delta, receiver=receiver))
+            q.put(command)
 
         return {
             "detected": hz,

--- a/tests/test_cw_auto_tune_wiring.py
+++ b/tests/test_cw_auto_tune_wiring.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rigplane.core.exceptions import CommandError
 from rigplane.core.state_pipeline_contracts import (
     FieldPath,
     Observation,
@@ -20,6 +21,7 @@ from rigplane.radio_state import RadioState, ReceiverState
 from rigplane.web.handlers.control import ControlHandler
 
 _DEFAULT_RADIO = object()
+_UNOBSERVED = object()
 
 
 def _make_handler(
@@ -28,6 +30,8 @@ def _make_handler(
     radio: Any = _DEFAULT_RADIO,
     audio_fft_available: bool = True,
     active_observation: str = "fresh",
+    ptt: object = False,
+    ptt_stale: bool = False,
 ) -> ControlHandler:
     """Build a ControlHandler with a fake server and WebSocket."""
     ws = MagicMock()
@@ -58,6 +62,18 @@ def _make_handler(
             )
         )
         if active_observation == "stale":
+            state_store.mark_stale_due(now=2.0)
+    if ptt is not _UNOBSERVED:
+        state_store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=ptt,
+                source=SourceMetadata(source="state_poller", provider="test"),
+                timestamp_monotonic=1.0,
+                max_age=0.5 if ptt_stale else None,
+            )
+        )
+        if ptt_stale:
             state_store.mark_stale_due(now=2.0)
 
     server = SimpleNamespace(
@@ -180,6 +196,30 @@ class TestCwAutoTuneWiring:
         cmd = q.put.call_args[0][0]
         assert cmd.freq == expected_freq
         assert cmd.receiver == receiver
+
+    @pytest.mark.parametrize(
+        ("ptt", "ptt_stale", "reason"),
+        [
+            (True, False, "RF state is TX"),
+            (_UNOBSERVED, False, "RF state is unknown"),
+            (False, True, "RF state is unknown"),
+            (1, False, "RF state is unknown"),
+        ],
+        ids=("tx", "missing", "stale", "invalid"),
+    )
+    async def test_correction_fails_closed_before_frequency_enqueue(
+        self, ptt: object, ptt_stale: bool, reason: str
+    ) -> None:
+        handler = _make_handler(ptt=ptt, ptt_stale=ptt_stale)
+        with patch("rigplane.cw_auto_tuner.CwAutoTuner") as mock_tuner:
+            mock_tuner.return_value.start_collection.side_effect = lambda callback: (
+                callback(650)
+            )
+
+            with pytest.raises(CommandError, match=reason):
+                await handler._cw_auto_tune()
+
+        handler._server.command_queue.put.assert_not_called()
 
     @pytest.mark.parametrize(
         ("active", "active_observation"),

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from queue import Queue
 from types import SimpleNamespace
 from typing import Any
@@ -283,13 +284,26 @@ class TestWebTunerReadOnly:
         radio.set_tuner_status.assert_awaited_once_with(0)
 
     async def test_fresh_rx_queue_preserves_tuner_dispatch(self) -> None:
-        handler, q = _make_handler(
+        handler, _ = _make_handler(
             radio=SimpleNamespace(capabilities=frozenset()), ptt=False
         )
 
+        class SuccessfulQueue:
+            def __init__(self) -> None:
+                self.commands: list[SetTunerStatus] = []
+
+            def put_ordered(
+                self, command: SetTunerStatus, *, future: asyncio.Future[object]
+            ) -> None:
+                self.commands.append(command)
+                future.set_result(None)
+
+        q = SuccessfulQueue()
+        handler._server.command_queue = q
+
         await handler._enqueue_command("set_tuner_status", {"value": 2})
 
-        assert q.get_nowait() == SetTunerStatus(2)
+        assert q.commands == [SetTunerStatus(2)]
 
     @pytest.mark.parametrize("value", [True, 1.5, 3, "bogus"])
     async def test_invalid_tuner_value_fails_without_call(self, value: object) -> None:
@@ -301,3 +315,53 @@ class TestWebTunerReadOnly:
 
         radio.set_tuner_status.assert_not_awaited()
         assert q.empty()
+
+    @pytest.mark.parametrize("outcome", [False, RuntimeError("backend rejected")])
+    async def test_direct_backend_failure_is_failed_not_acknowledged(
+        self, outcome: object
+    ) -> None:
+        radio = self._make_tuner_radio()
+        if isinstance(outcome, BaseException):
+            radio.set_tuner_status.side_effect = outcome
+        else:
+            radio.set_tuner_status.return_value = outcome
+        handler, _ = _make_handler(radio=radio, ptt=False)
+
+        with pytest.raises((CommandError, RuntimeError), match="rejected"):
+            await handler._enqueue_command("set_tuner_status", {"value": 1})
+
+        radio.set_tuner_status.assert_awaited_once_with(1)
+        states = [event.state for event in handler._command_service.lifecycle_events()]
+        assert states[-1] == "failed"
+        assert "acknowledged" not in states
+
+    @pytest.mark.parametrize("outcome", [False, RuntimeError("backend rejected")])
+    async def test_queued_backend_failure_is_failed_not_acknowledged(
+        self, outcome: object
+    ) -> None:
+        class OutcomeQueue:
+            def __init__(self) -> None:
+                self.commands: list[SetTunerStatus] = []
+
+            def put_ordered(
+                self, command: SetTunerStatus, *, future: asyncio.Future[object]
+            ) -> None:
+                self.commands.append(command)
+                if isinstance(outcome, BaseException):
+                    future.set_exception(outcome)
+                else:
+                    future.set_result(outcome)
+
+        handler, _ = _make_handler(
+            radio=SimpleNamespace(capabilities=frozenset()), ptt=False
+        )
+        queue = OutcomeQueue()
+        handler._server.command_queue = queue
+
+        with pytest.raises((CommandError, RuntimeError)):
+            await handler._enqueue_command("set_tuner_status", {"value": 2})
+
+        assert queue.commands == [SetTunerStatus(2)]
+        states = [event.state for event in handler._command_service.lifecycle_events()]
+        assert states[-1] == "failed"
+        assert "acknowledged" not in states

--- a/tests/test_web_ptt_readonly.py
+++ b/tests/test_web_ptt_readonly.py
@@ -18,6 +18,8 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.web import server as web_server
+from rigplane.web.protocol import decode_json
 from rigplane.web.radio_poller import SetTunerStatus
 from rigplane.web.handlers.control import ControlHandler
 
@@ -365,3 +367,37 @@ class TestWebTunerReadOnly:
         states = [event.state for event in handler._command_service.lifecycle_events()]
         assert states[-1] == "failed"
         assert "acknowledged" not in states
+
+    async def test_queued_backend_timeout_is_terminal_not_acknowledged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class StalledQueue:
+            calls = 0
+            future: asyncio.Future[object] | None = None
+
+            def put_ordered(
+                self, command: SetTunerStatus, *, future: asyncio.Future[object]
+            ) -> None:
+                self.calls += 1
+                self.future = future
+
+        monkeypatch.setattr(web_server, "_COMMAND_BATCH_STEP_TIMEOUT", 0.001)
+        handler, _ = _make_handler(
+            radio=SimpleNamespace(capabilities=frozenset()), ptt=False
+        )
+        handler._ws.send_text = AsyncMock()
+        queue = StalledQueue()
+        handler._server.command_queue = queue
+
+        await asyncio.wait_for(
+            handler._dispatch_command(1, "set_tuner_status", {"value": 2}),
+            timeout=0.1,
+        )
+
+        response = decode_json(handler._ws.send_text.await_args.args[0])
+        states = [event.state for event in handler._command_service.lifecycle_events()]
+        assert response["ok"] is False
+        assert queue.calls == 1
+        assert queue.future is not None and queue.future.cancelled()
+        assert states[-1] == "timed_out"
+        assert not {"acknowledged", "confirmed", "applied"} & set(states)


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1751/mor-1500-b3-b-make-tuner-outcomes-truthful-and-gate-cw-auto-tune

## Summary
- fail tuner commands on backend exceptions or explicit false outcomes and await ordered queue completion before acknowledgement
- bound a stalled ordered-queue completion with the existing Web command-batch completion timeout, yielding a terminal timed-out lifecycle and `ok: false`
- resolve fresh strict-boolean PTT evidence once for both tuner and CW follow-up policy
- gate CW auto-tune SetFreq through the canonical TX interlock immediately before enqueue

## Safety invariants
- tuner OFF remains always-pass
- tuner ON/TUNING remain blocked in TX or unknown RF state
- stalled queue work is enqueued once, its completion future is cancelled on timeout, and it is never acknowledged/confirmed/applied
- CW auto-tune frequency correction writes only in fresh known RX
- intentional CW send/stop paths are unchanged and uninvoked
- no defer, TTL, profile, runtime, serial, or hardware scope
- scope is exactly 3 files and 200 changed LOC

## Verification
- RED on old head `5a62058edfa429738a69b317b6d04c20195a92cc`: never-resolving queue future was cancelled only by the test outer timeout and produced no Web response
- focused timeout/failure dispatch: 4 passed
- focused handler/CW/coverage: 232 passed
- full non-integration: 9,964 passed, 13 skipped, 14 xfailed, 1 xpassed
- Ruff check and changed-file format: pass (global format reports four pre-existing unrelated files)
- import-linter: 5 contracts kept
- strict Web mypy: pass (26 source files)
- frontend i18n/check: pass
- frontend Vitest: 7,973 passed; an initial concurrent load run timed out one unchanged fixture-preflight test, then standalone and serial full reruns passed
- frontend production build: pass
- diff-check/privacy: pass

No hardware, runtime, radio, serial, PTT, TUNE, TX, or keying actions were performed.