### PR TITLE
fix(MOR-1750): gate disruptive Web writes on RF truth

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -717,7 +717,7 @@ class RadioPoller:
             field = snapshot.field(_PTT_PATH)
         except KeyError:
             return RfState.UNKNOWN
-        now = time.monotonic()
+        now = snapshot.generated_at_monotonic
         if (
             field.freshness is not FreshnessState.FRESH
             or type(field.value) is not bool

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -109,6 +109,12 @@ from ..core.tx_target import (
 from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
+from ..runtime.tx_interlock import (
+    RfState,
+    TxInterlockCommandFamily,
+    evaluate_tx_interlock,
+    get_tx_interlock_command_family_metadata,
+)
 from ..types import AudioCodec
 
 if TYPE_CHECKING:
@@ -203,6 +209,13 @@ _DEFAULT_POLL_FIELD_TTL: float = 0.2
 _FAST_INTERVAL: float = 0.025  # meters — wfview queue interval for LAN (25ms)
 _FAST_INTERVAL_SERIAL: float = 0.100  # serial: 10 polls/sec for responsive meters
 _SLOW_INTERVAL: float = 0.25  # levels/settings — rarely change
+_PTT_PATH = FieldPath.global_("tx_state", "ptt")
+_WEB_IMMEDIATE_BLOCK_FAMILIES = (
+    TxInterlockCommandFamily.RAW_CIV,
+    TxInterlockCommandFamily.SCAN_START,
+    TxInterlockCommandFamily.ANTENNA_SWITCH,
+    TxInterlockCommandFamily.TUNER_ENGAGE,
+)
 
 # Fallback for the derived tx_target field's own freshness TTL when a
 # profile has no [state_acquisition] block at all (MOR-1496 review R3, F1
@@ -696,6 +709,33 @@ class RadioPoller:
 
     def _provider_generation(self) -> int:
         return cast(int, self._state_store.provider_generation)
+
+    def _current_rf_state(self) -> RfState:
+        """Return RF truth only from a fresh current-provider PTT observation."""
+        snapshot = self._state_store.snapshot()
+        try:
+            field = snapshot.field(_PTT_PATH)
+        except KeyError:
+            return RfState.UNKNOWN
+        now = time.monotonic()
+        if (
+            field.freshness is not FreshnessState.FRESH
+            or type(field.value) is not bool
+            or field.provider_generation != self._provider_generation()
+            or field.max_age is None
+            or now < field.last_observed_monotonic
+            or now >= field.last_observed_monotonic + field.max_age
+        ):
+            return RfState.UNKNOWN
+        return RfState.TX if field.value else RfState.RX
+
+    def _enforce_tx_interlock(self, cmd: Command) -> None:
+        metadata = get_tx_interlock_command_family_metadata(cmd)
+        if metadata is None or metadata.family not in _WEB_IMMEDIATE_BLOCK_FAMILIES:
+            return
+        decision = evaluate_tx_interlock(cmd, rf_state=self._current_rf_state())
+        if not decision.allowed:
+            raise CommandError(decision.reason)
 
     def _relative_vfo_retention_policy(self) -> tuple[float, float]:
         """Derive a finite tuple window from this provider's expected cadence."""
@@ -1687,6 +1727,7 @@ class RadioPoller:
                             )
                             continue
                         try:
+                            self._enforce_tx_interlock(cmd)
                             await self._execute(
                                 cmd,
                                 command_id=entry.command_id,

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -4,17 +4,13 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from rigplane.capabilities import (
-    CAP_ANTENNA,
-    CAP_POWER_CONTROL,
-    CAP_TUNER,
-)
+from rigplane.capabilities import CAP_ANTENNA, CAP_POWER_CONTROL, CAP_TUNER
 from rigplane.core.state_pipeline_contracts import (
     FieldPath,
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import StateStore
+from rigplane.core.state_store import FreshnessClock, StateStore
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.runtime._poller_types import (
@@ -47,18 +43,22 @@ def _radio() -> SimpleNamespace:
 
 
 def _observe_ptt(
-    store: StateStore, value: bool, *, age: float = 0.0, generation: int | None = None
+    store: StateStore,
+    value: bool,
+    *,
+    observed_at: float | None = None,
+    generation: int | None = None,
 ) -> None:
+    observed_at = time.monotonic() if observed_at is None else observed_at
+    generation = store.provider_generation if generation is None else generation
     store.apply(
         Observation(
             path=_PTT,
             value=value,
             source=SourceMetadata(source="poll_response", provider="test"),
-            timestamp_monotonic=time.monotonic() - age,
+            timestamp_monotonic=observed_at,
             max_age=1.0,
-            provider_generation=store.provider_generation
-            if generation is None
-            else generation,
+            provider_generation=generation,
         )
     )
 
@@ -82,7 +82,6 @@ _BLOCK_CASES = (
 )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(("cmd", "method"), _BLOCK_CASES)
 @pytest.mark.parametrize("ptt", (None, True), ids=("unknown", "tx"))
 async def test_disruptive_write_is_blocked_before_transport(
@@ -98,7 +97,6 @@ async def test_disruptive_write_is_blocked_before_transport(
     getattr(radio, method).assert_not_awaited()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(("cmd", "method"), _BLOCK_CASES)
 async def test_disruptive_write_dispatches_once_in_fresh_rx(
     cmd: object, method: str
@@ -111,7 +109,6 @@ async def test_disruptive_write_dispatches_once_in_fresh_rx(
     getattr(radio, method).assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_fresh_rx_preserves_truthful_unsupported_failure() -> None:
     poller, radio, store = _poller()
     _observe_ptt(store, False)
@@ -120,7 +117,6 @@ async def test_fresh_rx_preserves_truthful_unsupported_failure() -> None:
         await _dispatch(poller, SendCiv(command=0x1A, data=b"\x01"))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("cmd", "method"),
     (
@@ -138,22 +134,26 @@ async def test_safety_stop_or_off_is_always_attempted(cmd: object, method: str) 
     getattr(radio, method).assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_stale_and_generation_rollover_fail_closed_then_fresh_rx_recovers() -> (
-    None
-):
-    poller, radio, store = _poller()
-    command = SendCiv(command=0x1A, data=b"\x01")
-    old_generation = store.provider_generation
-    _observe_ptt(store, False, age=2.0)
-
-    with pytest.raises(CommandError, match="RF state is unknown"):
-        await _dispatch(poller, command)
+def test_manual_clock_ttl_generation_and_recovery() -> None:
+    clock = FreshnessClock(start=10.0)
+    radio, store = _radio(), StateStore(freshness_clock=clock)
     store.begin_provider_generation()
-    _observe_ptt(store, False, generation=old_generation)
-    with pytest.raises(CommandError, match="RF state is unknown"):
-        await _dispatch(poller, command)
-
-    _observe_ptt(store, False)
-    await _dispatch(poller, command)
-    radio.send_civ.assert_awaited_once()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert store.snapshot().generated_at_monotonic == clock.now()
+    assert poller._current_rf_state().value == "rx"  # noqa: SLF001
+    clock.advance(0.999)
+    assert poller._current_rf_state().value == "rx"  # noqa: SLF001
+    clock.advance(0.001)
+    assert poller._current_rf_state().value == "unknown"  # noqa: SLF001
+    clock.advance(0.001)
+    assert poller._current_rf_state().value == "unknown"  # noqa: SLF001
+    old_generation = store.provider_generation
+    store.begin_provider_generation()
+    _observe_ptt(store, True, observed_at=clock.now(), generation=old_generation)
+    assert poller._current_rf_state().value == "unknown"  # noqa: SLF001
+    _observe_ptt(store, True, observed_at=clock.now())
+    assert poller._current_rf_state().value == "tx"  # noqa: SLF001
+    clock.advance(0.1)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._current_rf_state().value == "rx"  # noqa: SLF001

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -1,0 +1,159 @@
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rigplane.capabilities import (
+    CAP_ANTENNA,
+    CAP_POWER_CONTROL,
+    CAP_TUNER,
+)
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
+from rigplane.exceptions import CommandError
+from rigplane.profiles import resolve_radio_profile
+from rigplane.runtime._poller_types import (
+    PttOff,
+    ScanStart,
+    ScanStop,
+    SendCiv,
+    SetAntenna1,
+    SetPowerstat,
+    SetTunerStatus,
+)
+from rigplane.web.radio_poller import CommandQueue, RadioPoller
+
+
+_PTT = FieldPath.global_("tx_state", "ptt")
+
+
+def _radio() -> SimpleNamespace:
+    return SimpleNamespace(
+        profile=resolve_radio_profile(model="IC-7300"),
+        capabilities={CAP_ANTENNA, CAP_POWER_CONTROL, CAP_TUNER},
+        send_civ=AsyncMock(),
+        scan_start=AsyncMock(),
+        scan_stop=AsyncMock(),
+        set_antenna_1=AsyncMock(),
+        set_tuner_status=AsyncMock(),
+        set_powerstat=AsyncMock(),
+        set_ptt=AsyncMock(),
+    )
+
+
+def _observe_ptt(
+    store: StateStore, value: bool, *, age: float = 0.0, generation: int | None = None
+) -> None:
+    store.apply(
+        Observation(
+            path=_PTT,
+            value=value,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=time.monotonic() - age,
+            max_age=1.0,
+            provider_generation=store.provider_generation
+            if generation is None
+            else generation,
+        )
+    )
+
+
+def _poller() -> tuple[RadioPoller, SimpleNamespace, StateStore]:
+    radio, store = _radio(), StateStore()
+    store.begin_provider_generation()
+    return RadioPoller(radio, CommandQueue(), state_store=store), radio, store
+
+
+async def _dispatch(poller: RadioPoller, cmd: object) -> None:
+    poller._enforce_tx_interlock(cmd)  # type: ignore[arg-type] # noqa: SLF001
+    await poller._execute(cmd)  # type: ignore[arg-type] # noqa: SLF001
+
+
+_BLOCK_CASES = (
+    (SendCiv(command=0x1A, data=b"\x01"), "send_civ"),
+    (ScanStart(scan_type=1), "scan_start"),
+    (SetAntenna1(on=True), "set_antenna_1"),
+    (SetTunerStatus(value=1), "set_tuner_status"),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("cmd", "method"), _BLOCK_CASES)
+@pytest.mark.parametrize("ptt", (None, True), ids=("unknown", "tx"))
+async def test_disruptive_write_is_blocked_before_transport(
+    cmd: object, method: str, ptt: bool | None
+) -> None:
+    poller, radio, store = _poller()
+    if ptt is not None:
+        _observe_ptt(store, ptt)
+
+    with pytest.raises(CommandError, match="RF state is (unknown|TX)"):
+        await _dispatch(poller, cmd)
+
+    getattr(radio, method).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("cmd", "method"), _BLOCK_CASES)
+async def test_disruptive_write_dispatches_once_in_fresh_rx(
+    cmd: object, method: str
+) -> None:
+    poller, radio, store = _poller()
+    _observe_ptt(store, False)
+
+    await _dispatch(poller, cmd)
+
+    getattr(radio, method).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fresh_rx_preserves_truthful_unsupported_failure() -> None:
+    poller, radio, store = _poller()
+    _observe_ptt(store, False)
+    del radio.send_civ
+    with pytest.raises(CommandError, match="send_civ is not supported"):
+        await _dispatch(poller, SendCiv(command=0x1A, data=b"\x01"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("cmd", "method"),
+    (
+        (PttOff(), "set_ptt"),
+        (ScanStop(), "scan_stop"),
+        (SetPowerstat(on=False), "set_powerstat"),
+        (SetTunerStatus(value=0), "set_tuner_status"),
+    ),
+)
+async def test_safety_stop_or_off_is_always_attempted(cmd: object, method: str) -> None:
+    poller, radio, _store = _poller()
+    poller._current_rf_state = lambda: pytest.fail("stop/off inspected RF state")  # type: ignore[method-assign] # noqa: SLF001
+    await _dispatch(poller, cmd)
+
+    getattr(radio, method).assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_and_generation_rollover_fail_closed_then_fresh_rx_recovers() -> (
+    None
+):
+    poller, radio, store = _poller()
+    command = SendCiv(command=0x1A, data=b"\x01")
+    old_generation = store.provider_generation
+    _observe_ptt(store, False, age=2.0)
+
+    with pytest.raises(CommandError, match="RF state is unknown"):
+        await _dispatch(poller, command)
+    store.begin_provider_generation()
+    _observe_ptt(store, False, generation=old_generation)
+    with pytest.raises(CommandError, match="RF state is unknown"):
+        await _dispatch(poller, command)
+
+    _observe_ptt(store, False)
+    await _dispatch(poller, command)
+    radio.send_civ.assert_awaited_once()


### PR DESCRIPTION
## Summary

- derive Web RF truth only from a fresh, boolean PTT observation on the current StateStore provider generation
- fail closed before transport for raw CI-V, scan start, antenna switching, and tuner engage/on when RF is TX or unknown
- preserve fresh-RX dispatch, truthful unsupported failures, and structural stop/off attempts without consulting RF state

Linear: [MOR-1750](https://linear.app/morozsm/issue/MOR-1750/mor-1500-b1-a-web-rf-state-adapter-and-immediate-tx-passblock-seat)

## Scope

- 2 files, 200 added LOC
- B1-a only; no deferral/TTL lane, lifecycle fields, or profile/readback work
- base merged non-destructively through `0533df48f6cf283cc885ed0d9aceb23dea8c7315`

## Verification

- RED first: 9 focused failures before the enforcement seat
- `uv run pytest -q tests/test_radio_poller_tx_interlock.py tests/test_radio_poller_coverage.py tests/test_handlers_coverage.py tests/test_web_ptt_readonly.py` — 473 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9912 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- `npx vitest run --exclude src/components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts` — 365 files / 7984 tests passed (the named fixture also passed independently; the command currently still discovers it)
- frontend check, lint, boundaries, i18n, and build — passed
- Ruff and format checks — passed
- focused mypy and import-linter — passed
- full `mypy src/` retains 12 baseline errors outside this diff; focused owned-file mypy is clean
- diff check and secret-safe public scan — passed

No hardware, runtime, serial, radio, PTT, TUNE, TX, or keying operation was performed.