### PR TITLE
MOR-1753: present truthful Break-in Delay feedback

### DIFF
--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -123,6 +123,12 @@
 </script>
 
 <script lang="ts">
+  import {
+    projectControlFeedbackPresentation,
+    type ControlFeedbackPresentation,
+    type ControlFeedbackPresentationInput,
+    type ControlFeedbackPresentationState,
+  } from '../primitives/control-feedback/control-feedback-presentation';
   import type { RadioViewModel } from './radio-view-model';
 
   interface Props {
@@ -132,11 +138,13 @@
     onApfOn?: (on: boolean) => void;
     onTwinPeakToggle?: () => void;
     onReversePaddleToggle?: () => void;
+    breakInDelayFeedback?: Readonly<ControlFeedbackPresentationInput<number>>;
     autoTuneAvailable?: boolean;
     onAutoTune?: () => void;
   }
   let {
     view, onBreakInMode, onLevelChange, onApfOn, onTwinPeakToggle, onReversePaddleToggle,
+    breakInDelayFeedback,
     autoTuneAvailable = false, onAutoTune,
   }: Props = $props();
 
@@ -161,13 +169,85 @@
   function setLevel(field: CwLevelField, value: number): void {
     if (cw && usable(cw[field])) onLevelChange?.(field, value);
   }
+  let effectiveBreakInDelayFeedback = $derived.by<Readonly<ControlFeedbackPresentationInput<number>>>(() => {
+    if (breakInDelayFeedback !== undefined) return breakInDelayFeedback;
+    const field = cw?.breakInDelay;
+    const confirmed = field?.reading.status === 'known' ? field.reading.value : null;
+    const phase = field !== undefined && usable(field) ? 'idle' : 'unavailable';
+    return {
+      confirmed, target: null, requestedTarget: null, phase,
+      transitionId: null, outcome: null,
+    };
+  });
+  let hasBreakInDelayFeedback = $derived(breakInDelayFeedback !== undefined);
+  let breakInDelayPresentationMemory: Readonly<{
+    state: ControlFeedbackPresentationState; announcement: string | null;
+  }> = { state: { announcedTransitionIds: [] }, announcement: null };
+  let breakInDelayPresentation = $derived.by<Readonly<ControlFeedbackPresentation> & {
+    readonly announcement: string | null;
+  }>(() => {
+    const next = projectControlFeedbackPresentation(
+      effectiveBreakInDelayFeedback,
+      breakInDelayPresentationMemory.state,
+      (target) => String(target),
+    );
+    const announcement = next.politeAnnouncement?.message
+      ?? breakInDelayPresentationMemory.announcement;
+    breakInDelayPresentationMemory = { state: next.state, announcement };
+    return Object.freeze({ ...next, announcement });
+  });
+
+  const BUSY_BREAK_IN_DELAY_PHASES = new Set([
+    'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
+  ]);
+  const INTEGRATED_RANGE_POLICY = { 'feedback-policy': 'feedback-integrated' } as const;
+  const RADIO_BACKED_RANGE_POLICY = { 'feedback-policy': 'radio-backed' } as const;
+  let breakInDelayBusy = $derived(BUSY_BREAK_IN_DELAY_PHASES.has(effectiveBreakInDelayFeedback.phase));
+  let breakInDelayEditable = $derived(
+    cw !== undefined && usable(cw.breakInDelay)
+      && effectiveBreakInDelayFeedback.phase !== 'unavailable',
+  );
+  let breakInDelayDraft: number | null = $state(null);
+  let breakInDelayDisplayed = $derived(
+    breakInDelayDraft
+      ?? (breakInDelayBusy
+        ? (effectiveBreakInDelayFeedback.target
+          ?? effectiveBreakInDelayFeedback.requestedTarget
+          ?? effectiveBreakInDelayFeedback.confirmed)
+        : effectiveBreakInDelayFeedback.confirmed)
+      ?? 0,
+  );
+  let breakInDelayPhaseLabel = $derived(
+    breakInDelayDraft !== null
+      ? 'draft'
+      : effectiveBreakInDelayFeedback.phase.replaceAll('-', ' '),
+  );
+  let breakInDelayValueText = $derived.by(() => {
+    const confirmed = effectiveBreakInDelayFeedback.confirmed;
+    if (effectiveBreakInDelayFeedback.phase === 'unavailable' || confirmed === null) {
+      return 'Break-in delay unavailable';
+    }
+    if (breakInDelayDraft !== null) {
+      return `Draft ${breakInDelayDraft}; last confirmed ${confirmed}`;
+    }
+    if (breakInDelayBusy) {
+      return `Requested ${breakInDelayDisplayed}; last confirmed ${confirmed}`;
+    }
+    const requested = effectiveBreakInDelayFeedback.requestedTarget;
+    if (effectiveBreakInDelayFeedback.outcome !== null && requested !== null
+      && effectiveBreakInDelayFeedback.outcome.phase !== 'confirmed') {
+      return `Confirmed ${confirmed}; request ${requested} ${effectiveBreakInDelayFeedback.outcome.phase}`;
+    }
+    return `Confirmed ${confirmed}`;
+  });
   let breakInDelayCancelled = false;
   function restoreBreakInDelay(target: HTMLInputElement): void {
-    const reading = cw?.breakInDelay.reading;
-    target.value = String(reading?.status === 'known' ? reading.value : Number(target.min));
+    target.value = String(effectiveBreakInDelayFeedback.confirmed ?? Number(target.min));
   }
-  function noteBreakInDelayInput(): void {
+  function noteBreakInDelayInput(target: HTMLInputElement): void {
     breakInDelayCancelled = false;
+    const candidate = target.valueAsNumber;
+    if (breakInDelayEditable && Number.isSafeInteger(candidate)) breakInDelayDraft = candidate;
   }
   function commitBreakInDelay(target: HTMLInputElement): void {
     if (breakInDelayCancelled) {
@@ -175,17 +255,25 @@
       restoreBreakInDelay(target);
       return;
     }
-    const candidate = target.valueAsNumber;
+    const candidate = breakInDelayDraft ?? target.valueAsNumber;
     const min = Number(target.min);
     const max = Number(target.max);
     if (Number.isFinite(candidate) && Number.isFinite(min) && Number.isFinite(max)) {
-      setLevel('breakInDelay', Math.min(max, Math.max(min, Math.round(candidate))));
+      if (breakInDelayEditable) {
+        setLevel('breakInDelay', Math.min(max, Math.max(min, Math.round(candidate))));
+      }
     }
-    restoreBreakInDelay(target);
+    breakInDelayDraft = null;
   }
   function cancelBreakInDelay(target: HTMLInputElement): void {
     breakInDelayCancelled = true;
+    breakInDelayDraft = null;
     restoreBreakInDelay(target);
+  }
+  function keyBreakInDelay(event: KeyboardEvent & { currentTarget: HTMLInputElement }): void {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    cancelBreakInDelay(event.currentTarget);
   }
   function setApf(on: boolean): void {
     if (cw && usable(cw.apf) && !mutexed('apf')) onApfOn?.(on);
@@ -241,21 +329,47 @@
       {#if f.availability.structural}
         <label class="cw-keyer-level" data-testid={`cw-keyer-${field}`} data-observed={usable(f)}>
           <span class="cw-keyer-name">{label}</span>
-          <input
-            type="range" {min} {max} {step}
-            value={f.reading.status === 'known' ? f.reading.value : min}
-            disabled={!usable(f)}
-            oninput={field === 'breakInDelay'
-              ? () => noteBreakInDelayInput()
-              : (event) => setLevel(field, event.currentTarget.valueAsNumber)}
-            onchange={field === 'breakInDelay'
-              ? (event) => commitBreakInDelay(event.currentTarget)
-              : undefined}
-            onpointercancel={field === 'breakInDelay'
-              ? (event) => cancelBreakInDelay(event.currentTarget)
-              : undefined}
-          />
-          <output data-testid={`cw-keyer-${field}-value`}>{textOf(f)} {unit}</output>
+          {#if field === 'breakInDelay'}
+            <input
+              {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}
+              value={breakInDelayDisplayed}
+              disabled={hasBreakInDelayFeedback ? !breakInDelayEditable : !usable(f)}
+              data-command-phase={hasBreakInDelayFeedback
+                ? breakInDelayPresentation.attributes['data-command-phase'] : undefined}
+              aria-busy={hasBreakInDelayFeedback
+                ? breakInDelayPresentation.attributes['aria-busy'] : undefined}
+              aria-valuenow={hasBreakInDelayFeedback ? breakInDelayDisplayed : undefined}
+              aria-valuetext={hasBreakInDelayFeedback ? breakInDelayValueText : undefined}
+              oninput={(event) => noteBreakInDelayInput(event.currentTarget)}
+              onchange={(event) => commitBreakInDelay(event.currentTarget)}
+              onpointercancel={(event) => cancelBreakInDelay(event.currentTarget)}
+              onkeydown={keyBreakInDelay}
+            />
+            {#if hasBreakInDelayFeedback}
+            <output
+              data-testid="cw-keyer-breakInDelay-value"
+              data-command-phase={effectiveBreakInDelayFeedback.phase}
+            >{effectiveBreakInDelayFeedback.phase === 'unavailable' ? UNKNOWN_TEXT : breakInDelayDisplayed}
+              <span class:command-pending={breakInDelayBusy}>{breakInDelayPhaseLabel}</span>
+            </output>
+            {#if breakInDelayPresentation.announcement !== null}
+              <span
+                class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+                data-control-feedback-status
+              >{breakInDelayPresentation.announcement}</span>
+            {/if}
+            {:else}
+              <output data-testid="cw-keyer-breakInDelay-value">{textOf(f)} {unit}</output>
+            {/if}
+          {:else}
+            <input
+              {...RADIO_BACKED_RANGE_POLICY} type="range" {min} {max} {step}
+              value={f.reading.status === 'known' ? f.reading.value : min}
+              disabled={!usable(f)}
+              oninput={(event) => setLevel(field, event.currentTarget.valueAsNumber)}
+            />
+            <output data-testid={`cw-keyer-${field}-value`}>{textOf(f)} {unit}</output>
+          {/if}
         </label>
       {/if}
     {/each}
@@ -342,5 +456,10 @@
   .cw-keyer-choice[aria-checked='true'], .cw-keyer-toggle[aria-pressed='true'] { font-weight: 700; }
   /* Second channel beside the unknown TEXT, never the only one. */
   [data-observed='false'] { font-style: italic; }
+  .command-pending { font-style: italic; }
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
   button:disabled, input:disabled { cursor: not-allowed; }
 </style>

--- a/frontend/src/semantic/CwKeyerSurface.svelte
+++ b/frontend/src/semantic/CwKeyerSurface.svelte
@@ -128,6 +128,7 @@
     type ControlFeedbackPresentation,
     type ControlFeedbackPresentationInput,
     type ControlFeedbackPresentationState,
+    type PresentationPhase,
   } from '../primitives/control-feedback/control-feedback-presentation';
   import type { RadioViewModel } from './radio-view-model';
 
@@ -169,15 +170,54 @@
   function setLevel(field: CwLevelField, value: number): void {
     if (cw && usable(cw[field])) onLevelChange?.(field, value);
   }
+  const BUSY_BREAK_IN_DELAY_PHASES: ReadonlySet<PresentationPhase> = new Set([
+    'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
+  ]);
+  const TERMINAL_BREAK_IN_DELAY_PHASES: ReadonlySet<PresentationPhase> = new Set([
+    'confirmed', 'failed', 'timed-out', 'cancelled', 'superseded',
+  ]);
+  const BREAK_IN_DELAY_PHASES: ReadonlySet<PresentationPhase> = new Set([
+    'unavailable', 'idle', ...BUSY_BREAK_IN_DELAY_PHASES, ...TERMINAL_BREAK_IN_DELAY_PHASES,
+  ]);
+  const unavailableFeedback: Readonly<ControlFeedbackPresentationInput<number>> = Object.freeze({
+    confirmed: null, target: null, requestedTarget: null, phase: 'unavailable',
+    transitionId: null, outcome: null,
+  });
+  const breakInDelayDomain = CW_LEVELS.find(([field]) => field === 'breakInDelay')!;
+  const validLevel = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value)
+      && value >= breakInDelayDomain[2] && value <= breakInDelayDomain[3]
+      && (value - breakInDelayDomain[2]) % breakInDelayDomain[4] === 0;
+  function validFeedback(value: Readonly<ControlFeedbackPresentationInput<number>>): boolean {
+    const { confirmed, target, requestedTarget, phase, transitionId, outcome } = value;
+    if (!BREAK_IN_DELAY_PHASES.has(phase)) return false;
+    if (phase === 'unavailable') {
+      return confirmed === null && target === null && requestedTarget === null && outcome === null;
+    }
+    if (!validLevel(confirmed) || (target !== null && !validLevel(target))
+      || (requestedTarget !== null && !validLevel(requestedTarget))) return false;
+    if (phase === 'idle') return target === null && requestedTarget === null && outcome === null;
+    if (BUSY_BREAK_IN_DELAY_PHASES.has(phase)) {
+      return target !== null && requestedTarget !== null && outcome === null
+        && typeof transitionId === 'string' && transitionId.length > 0;
+    }
+    return target === null && requestedTarget !== null && outcome?.phase === phase
+      && typeof transitionId === 'string' && transitionId.length > 0;
+  }
   let effectiveBreakInDelayFeedback = $derived.by<Readonly<ControlFeedbackPresentationInput<number>>>(() => {
-    if (breakInDelayFeedback !== undefined) return breakInDelayFeedback;
-    const field = cw?.breakInDelay;
-    const confirmed = field?.reading.status === 'known' ? field.reading.value : null;
-    const phase = field !== undefined && usable(field) ? 'idle' : 'unavailable';
-    return {
-      confirmed, target: null, requestedTarget: null, phase,
-      transitionId: null, outcome: null,
-    };
+    let candidate: Readonly<ControlFeedbackPresentationInput<number>>;
+    if (breakInDelayFeedback !== undefined) candidate = breakInDelayFeedback;
+    else {
+      const field = cw?.breakInDelay;
+      const confirmed = field?.reading.status === 'known' ? field.reading.value : null;
+      const phase = field !== undefined && usable(field) ? 'idle' : 'unavailable';
+      candidate = {
+        confirmed, target: null, requestedTarget: null, phase,
+        transitionId: null, outcome: null,
+      };
+    }
+    try { return validFeedback(candidate) ? candidate : unavailableFeedback; }
+    catch { return unavailableFeedback; }
   });
   let hasBreakInDelayFeedback = $derived(breakInDelayFeedback !== undefined);
   let breakInDelayPresentationMemory: Readonly<{
@@ -197,9 +237,6 @@
     return Object.freeze({ ...next, announcement });
   });
 
-  const BUSY_BREAK_IN_DELAY_PHASES = new Set([
-    'submitted', 'queued', 'dispatched', 'awaiting-confirmation',
-  ]);
   const INTEGRATED_RANGE_POLICY = { 'feedback-policy': 'feedback-integrated' } as const;
   const RADIO_BACKED_RANGE_POLICY = { 'feedback-policy': 'radio-backed' } as const;
   let breakInDelayBusy = $derived(BUSY_BREAK_IN_DELAY_PHASES.has(effectiveBreakInDelayFeedback.phase));
@@ -207,18 +244,26 @@
     cw !== undefined && usable(cw.breakInDelay)
       && effectiveBreakInDelayFeedback.phase !== 'unavailable',
   );
+  let breakInDelayAuthority = $derived(JSON.stringify([
+    effectiveBreakInDelayFeedback.transitionId, effectiveBreakInDelayFeedback.phase,
+    effectiveBreakInDelayFeedback.confirmed, effectiveBreakInDelayFeedback.target,
+    effectiveBreakInDelayFeedback.requestedTarget, effectiveBreakInDelayFeedback.outcome?.phase ?? null,
+  ]));
   let breakInDelayDraft: number | null = $state(null);
+  let breakInDelayDraftAuthority: string | null = $state(null);
+  let activeBreakInDelayDraft = $derived(
+    breakInDelayDraftAuthority === breakInDelayAuthority ? breakInDelayDraft : null,
+  );
   let breakInDelayDisplayed = $derived(
-    breakInDelayDraft
+    activeBreakInDelayDraft
       ?? (breakInDelayBusy
         ? (effectiveBreakInDelayFeedback.target
           ?? effectiveBreakInDelayFeedback.requestedTarget
           ?? effectiveBreakInDelayFeedback.confirmed)
-        : effectiveBreakInDelayFeedback.confirmed)
-      ?? 0,
+        : effectiveBreakInDelayFeedback.confirmed),
   );
   let breakInDelayPhaseLabel = $derived(
-    breakInDelayDraft !== null
+    activeBreakInDelayDraft !== null
       ? 'draft'
       : effectiveBreakInDelayFeedback.phase.replaceAll('-', ' '),
   );
@@ -227,8 +272,8 @@
     if (effectiveBreakInDelayFeedback.phase === 'unavailable' || confirmed === null) {
       return 'Break-in delay unavailable';
     }
-    if (breakInDelayDraft !== null) {
-      return `Draft ${breakInDelayDraft}; last confirmed ${confirmed}`;
+    if (activeBreakInDelayDraft !== null) {
+      return `Draft ${activeBreakInDelayDraft}; last confirmed ${confirmed}`;
     }
     if (breakInDelayBusy) {
       return `Requested ${breakInDelayDisplayed}; last confirmed ${confirmed}`;
@@ -247,7 +292,10 @@
   function noteBreakInDelayInput(target: HTMLInputElement): void {
     breakInDelayCancelled = false;
     const candidate = target.valueAsNumber;
-    if (breakInDelayEditable && Number.isSafeInteger(candidate)) breakInDelayDraft = candidate;
+    if (breakInDelayEditable && validLevel(candidate)) {
+      breakInDelayDraft = candidate;
+      breakInDelayDraftAuthority = breakInDelayAuthority;
+    }
   }
   function commitBreakInDelay(target: HTMLInputElement): void {
     if (breakInDelayCancelled) {
@@ -255,7 +303,13 @@
       restoreBreakInDelay(target);
       return;
     }
-    const candidate = breakInDelayDraft ?? target.valueAsNumber;
+    if (breakInDelayDraft !== null && breakInDelayDraftAuthority !== breakInDelayAuthority) {
+      breakInDelayDraft = null;
+      breakInDelayDraftAuthority = null;
+      restoreBreakInDelay(target);
+      return;
+    }
+    const candidate = activeBreakInDelayDraft ?? target.valueAsNumber;
     const min = Number(target.min);
     const max = Number(target.max);
     if (Number.isFinite(candidate) && Number.isFinite(min) && Number.isFinite(max)) {
@@ -264,10 +318,12 @@
       }
     }
     breakInDelayDraft = null;
+    breakInDelayDraftAuthority = null;
   }
   function cancelBreakInDelay(target: HTMLInputElement): void {
     breakInDelayCancelled = true;
     breakInDelayDraft = null;
+    breakInDelayDraftAuthority = null;
     restoreBreakInDelay(target);
   }
   function keyBreakInDelay(event: KeyboardEvent & { currentTarget: HTMLInputElement }): void {
@@ -332,13 +388,14 @@
           {#if field === 'breakInDelay'}
             <input
               {...INTEGRATED_RANGE_POLICY} type="range" {min} {max} {step}
-              value={breakInDelayDisplayed}
+              value={breakInDelayDisplayed ?? (hasBreakInDelayFeedback ? undefined : min)}
               disabled={hasBreakInDelayFeedback ? !breakInDelayEditable : !usable(f)}
               data-command-phase={hasBreakInDelayFeedback
                 ? breakInDelayPresentation.attributes['data-command-phase'] : undefined}
               aria-busy={hasBreakInDelayFeedback
                 ? breakInDelayPresentation.attributes['aria-busy'] : undefined}
-              aria-valuenow={hasBreakInDelayFeedback ? breakInDelayDisplayed : undefined}
+              aria-valuenow={hasBreakInDelayFeedback && breakInDelayDisplayed !== null
+                ? breakInDelayDisplayed : undefined}
               aria-valuetext={hasBreakInDelayFeedback ? breakInDelayValueText : undefined}
               oninput={(event) => noteBreakInDelayInput(event.currentTarget)}
               onchange={(event) => commitBreakInDelay(event.currentTarget)}
@@ -349,7 +406,8 @@
             <output
               data-testid="cw-keyer-breakInDelay-value"
               data-command-phase={effectiveBreakInDelayFeedback.phase}
-            >{effectiveBreakInDelayFeedback.phase === 'unavailable' ? UNKNOWN_TEXT : breakInDelayDisplayed}
+            >{effectiveBreakInDelayFeedback.phase === 'unavailable'
+              || breakInDelayDisplayed === null ? UNKNOWN_TEXT : breakInDelayDisplayed}
               <span class:command-pending={breakInDelayBusy}>{breakInDelayPhaseLabel}</span>
             </output>
             {#if breakInDelayPresentation.announcement !== null}

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -37,6 +37,9 @@ import type {
   Availability, BreakInMode, CwKeyerField, CwKeyerViewModel, DisabledReason, RadioViewModel,
 } from '../radio-view-model';
 import { t } from '$lib/i18n';
+import type {
+  ControlFeedbackPresentationInput, PresentationPhase,
+} from '../../primitives/control-feedback/control-feedback-presentation';
 
 const SOURCE = readFileSync('src/semantic/CwKeyerSurface.svelte', 'utf8');
 /** Comments stripped, so the file's own doctrine prose can never be what a
@@ -73,6 +76,7 @@ type Handlers = {
   onApfOn?: (on: boolean) => void;
   onTwinPeakToggle?: () => void;
   onReversePaddleToggle?: () => void;
+  breakInDelayFeedback?: Readonly<ControlFeedbackPresentationInput<number>>;
   onAutoTune?: () => void;
 };
 
@@ -99,6 +103,13 @@ const slide = (el: HTMLInputElement, value: number) => {
   el.dispatchEvent(new Event('input', { bubbles: true }));
   el.dispatchEvent(new Event('change', { bubbles: true }));
 };
+const feedback = (
+  phase: PresentationPhase,
+  over: Partial<ControlFeedbackPresentationInput<number>> = {},
+): Readonly<ControlFeedbackPresentationInput<number>> => ({
+  confirmed: 64, target: null, requestedTarget: null, phase,
+  transitionId: null, outcome: null, ...over,
+});
 
 /* ── (a) the surface is not a key path ────────────────────────── */
 
@@ -122,7 +133,10 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     // BandSurface's identical closure guard. It is a pure string-resolution
     // module (no transport, no controller, no permit utility) and cannot
     // widen this file's reach any more than `./pressed-of` does.
-    expect([...new Set(specifiers)]).toEqual(['$lib/i18n', './radio-view-model', './pressed-of']);
+    expect([...new Set(specifiers)]).toEqual([
+      '$lib/i18n', './radio-view-model', './pressed-of',
+      '../primitives/control-feedback/control-feedback-presentation',
+    ]);
   });
 
   // Kills: `onMount(() => …)` and every relative of it, plus a dynamic import
@@ -151,7 +165,7 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
     const props = CODE.slice(CODE.indexOf('interface Props'), CODE.indexOf('}: Props'));
     expect([...props.matchAll(/^\s{4}(\w+)[?]?:/gm)].map((m) => m[1])).toEqual([
       'view', 'onBreakInMode', 'onLevelChange', 'onApfOn', 'onTwinPeakToggle',
-      'onReversePaddleToggle', 'autoTuneAvailable', 'onAutoTune',
+      'onReversePaddleToggle', 'breakInDelayFeedback', 'autoTuneAvailable', 'onAutoTune',
     ]);
   });
 
@@ -235,23 +249,82 @@ describe('the CW-keyer surface is NOT a key path (decomposition R9)', () => {
   });
 });
 
-/* ── MOR-1648 — Break-in Delay commits only on release ─────────── */
+/* ── MOR-1648/MOR-1753 — truthful draft and feedback ─────────── */
 
-describe('Break-in Delay is a canonical-only release gesture (MOR-1648)', () => {
-  it('emits nothing during a drag and one bounded integer on release', () => {
+describe('Break-in Delay separates draft, submitted target and confirmed truth', () => {
+  it('shows a local draft, then emits one bounded integer and presents the submitted target', () => {
     const onLevelChange = vi.fn();
-    const r = render(base(), { onLevelChange });
+    const r = render(base(), { onLevelChange, breakInDelayFeedback: feedback('idle') });
     const input = r.input('breakInDelay')!;
     for (const value of [80, 96, 111]) {
       input.value = String(value);
       input.dispatchEvent(new Event('input', { bubbles: true }));
     }
     expect(onLevelChange).not.toHaveBeenCalled();
+    flushSync();
+    expect(input.value).toBe('111');
+    expect(r.text('breakInDelay-value')).toContain('111 draft');
     input.dispatchEvent(new Event('change', { bubbles: true }));
     expect(onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 111);
+    flushSync();
     expect(input.value).toBe('64');
-    expect(r.text('breakInDelay-value')).toBe('64');
     r.dispose();
+  });
+
+  it.each([
+    ['submitted', true, 111, null],
+    ['awaiting-confirmation', true, 111, null],
+    ['failed', false, 64, 'failed'],
+    ['timed-out', false, 64, 'timed-out'],
+    ['cancelled', false, 64, 'cancelled'],
+    ['superseded', false, 64, 'superseded'],
+    ['confirmed', false, 111, 'confirmed'],
+  ] as const)('projects %s without presenting an unconfirmed target as canonical', (
+    phase, busy, displayed, outcome,
+  ) => {
+    const terminal = outcome === null ? null : { phase: outcome };
+    const r = render(base(), {
+      breakInDelayFeedback: feedback(phase, {
+        confirmed: phase === 'confirmed' ? 111 : 64,
+        target: busy ? 111 : null,
+        requestedTarget: 111,
+        transitionId: `[1,"command","${phase}"]`,
+        outcome: terminal,
+      }),
+    });
+    const input = r.input('breakInDelay')!;
+    expect(input.value).toBe(String(displayed));
+    expect(input.dataset.commandPhase).toBe(phase);
+    expect(input.getAttribute('aria-busy')).toBe(String(busy));
+    expect(r.text('breakInDelay-value')).toContain(`${displayed} ${phase.replaceAll('-', ' ')}`);
+    const live = target.querySelector('[data-control-feedback-status]');
+    expect(live?.getAttribute('aria-live')).toBe('polite');
+    expect(live?.textContent).toContain('111');
+    r.dispose();
+  });
+
+  it('fails closed when feedback is unavailable and Escape cancels a draft without dispatch', () => {
+    const onLevelChange = vi.fn();
+    const r = render(base(), { onLevelChange, breakInDelayFeedback: feedback('idle') });
+    const input = r.input('breakInDelay')!;
+    input.value = '99';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(onLevelChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('64');
+
+    r.dispose();
+
+    const unavailable = render(base(), {
+      onLevelChange, breakInDelayFeedback: feedback('unavailable', { confirmed: null }),
+    });
+    const unavailableInput = unavailable.input('breakInDelay')!;
+    expect(unavailableInput.disabled).toBe(true);
+    expect(unavailableInput.dataset.commandPhase).toBe('unavailable');
+    expect(unavailableInput.getAttribute('aria-valuetext')).toBe('Break-in delay unavailable');
+    expect(unavailable.text('breakInDelay-value')).toContain('— unavailable');
+    unavailable.dispose();
   });
 
   it('rounds and clamps a programmatic final candidate before dispatch', () => {

--- a/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
+++ b/frontend/src/semantic/__tests__/CwKeyerSurface.test.ts
@@ -28,6 +28,8 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
+// @ts-expect-error -- Svelte does not publish types for its reactive test harness.
+import { proxy } from 'svelte/internal/client';
 import CwKeyerSurface, {
   APF_CHOICES, BREAK_IN_CHOICES, BREAK_IN_REASON_KEY, CW_LEVELS, MUTEX_LABEL, POSTURE_LABEL,
   UNKNOWN_TEXT, breakInBlockedLabel, breakInPosture, type CwLevelField,
@@ -93,6 +95,20 @@ function render(view: RadioViewModel, handlers: Handlers = {}) {
     /** Every focusable control the surface renders, whatever its state. */
     controls: () => [...target.querySelectorAll<HTMLElement>('button, input, select, [tabindex]')],
   };
+}
+
+function renderReactiveFeedback(initial: ControlFeedbackPresentationInput<number>) {
+  const onLevelChange = vi.fn();
+  const props = proxy({ view: base(), onLevelChange, breakInDelayFeedback: initial });
+  const component = mount(CwKeyerSurface, { target, props });
+  flushSync();
+  const input = () => target.querySelector<HTMLInputElement>(
+    '[data-testid="cw-keyer-breakInDelay"] input',
+  )!;
+  const output = () => target.querySelector<HTMLElement>(
+    '[data-testid="cw-keyer-breakInDelay-value"]',
+  )!;
+  return { dispose: () => unmount(component), input, output, onLevelChange, props };
 }
 
 /** A real click, not `.click()`: `.click()` is a no-op on a disabled button, so
@@ -358,6 +374,80 @@ describe('Break-in Delay separates draft, submitted target and confirmed truth',
     input.dispatchEvent(new Event('input', { bubbles: true }));
     r.dispose();
     expect(onLevelChange).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['cancelled', 72, 'provider-replaced'],
+    ['failed', 73, 'failed-transition'],
+    ['timed-out', 74, 'timed-out-transition'],
+    ['superseded', 75, 'superseded-transition'],
+    ['idle', 76, null],
+  ] as const)('invalidates a stale draft when authority advances to %s', (phase, canonical, id) => {
+    const r = renderReactiveFeedback(feedback('idle'));
+    r.input().value = '111';
+    r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    const terminal = phase === 'idle' ? null : { phase };
+    r.props.breakInDelayFeedback = feedback(phase, {
+      confirmed: canonical, requestedTarget: phase === 'idle' ? null : 111,
+      transitionId: id, outcome: terminal,
+    });
+    flushSync();
+    expect(r.input().value).toBe(String(canonical));
+    expect(r.output().textContent).toContain(`${canonical} ${phase.replaceAll('-', ' ')}`);
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+
+    r.input().value = '99';
+    r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 99);
+    r.dispose();
+  });
+
+  it('preserves an active draft while the same feedback authority is re-projected', () => {
+    const current = feedback('awaiting-confirmation', {
+      target: 80, requestedTarget: 80, transitionId: 'authority-a',
+    });
+    const r = renderReactiveFeedback(current);
+    r.input().value = '111';
+    r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    r.props.breakInDelayFeedback = { ...current };
+    flushSync();
+    expect(r.input().value).toBe('111');
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(r.onLevelChange).toHaveBeenCalledExactlyOnceWith('breakInDelay', 111);
+    r.dispose();
+  });
+
+  it.each([
+    ['missing', null], ['not-a-number', Number.NaN], ['infinite', Number.POSITIVE_INFINITY],
+    ['below-domain', -1], ['above-domain', 256], ['off-lattice', 64.5],
+  ] as const)('fails closed for %s canonical truth', (_case, confirmed) => {
+    const r = renderReactiveFeedback(feedback('idle', { confirmed }));
+    expect(r.input().disabled).toBe(true);
+    expect(r.input().hasAttribute('aria-valuenow')).toBe(false);
+    expect(r.input().getAttribute('aria-valuetext')).toBe('Break-in delay unavailable');
+    expect(r.output().textContent).toContain('— unavailable');
+    r.input().value = '99';
+    r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(r.onLevelChange).not.toHaveBeenCalled();
+    r.dispose();
+  });
+
+  it.each([
+    ['non-finite target', feedback('submitted', {
+      target: Number.NaN, requestedTarget: 111, transitionId: 'bad-target',
+    })],
+    ['mismatched terminal outcome', feedback('failed', {
+      requestedTarget: 111, transitionId: 'bad-outcome', outcome: { phase: 'confirmed' },
+    })],
+  ])('fails closed for %s', (_case, malformed) => {
+    const r = renderReactiveFeedback(malformed);
+    expect(r.input().disabled).toBe(true);
+    expect(r.input().hasAttribute('aria-valuenow')).toBe(false);
+    expect(r.output().textContent).toContain('— unavailable');
+    r.dispose();
   });
 });
 


### PR DESCRIPTION
## Summary

- add the pure semantic Break-in Delay feedback consumer contract
- keep canonical, draft, requested target, pending, and terminal outcomes distinct
- expose disabled, phase, busy, value-text, and polite live-region truth without introducing runtime/store access

## Scope

Owned files only:
- frontend/src/semantic/CwKeyerSurface.svelte
- frontend/src/semantic/__tests__/CwKeyerSurface.test.ts

This A1a slice is presentational only. Live SemanticRadioSurfaces wiring and its mounted composition test remain the explicit A1b follow-up. No fallback panel, descriptor, backend, protocol, TX, runtime, radio, or hardware changes.

## Red-first evidence

The exact base 625ca121b89dc761c15efe6c5c9bfe370a501336 rejected the new feedback prop/import contract and retained the canonical-only release expectation. The focused unit contract was then evolved to the authoritative shared feedback DTO.

## Verification

- focused semantic/CW/composition and shared feedback tests: 130 passed
- control-feedback debt inventory: 11 passed
- full frontend serial suite: 365 files, 8010 tests passed
- npm run check: 0 errors, 0 warnings
- npm run lint
- npm run lint:boundaries
- npm run i18n:check
- npm run build
- git diff --check
- exact scope: 2 files, +220/-28 (248 changed LOC)

The default highly parallel full run exposed an unrelated MOR-1409 fixture preflight timeout; that test passed alone in 11 seconds and the complete suite passed with maxWorkers=1.

Linear: https://linear.app/morozsm/issue/MOR-1753

Independent exact-head Agent Review is required before merge.