### PR TITLE
MOR-1754: wire truthful fallback CW feedback

### DIFF
--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -40,7 +40,29 @@
   let showTwinPeak = $derived(p.hasTwinPeak);
   let showAutoTune = $derived(p.autoTuneAvailable);
   let apfActive = $derived(isApfActive(apfMode));
-  let breakInDelayFeedback = $derived(getBreakInDelayControlFeedback());
+  const BUSY_DELAY_PHASES = new Set(['submitted', 'queued', 'dispatched', 'awaiting-confirmation']);
+  const TERMINAL_DELAY_PHASES = new Set(['confirmed', 'failed', 'timed-out', 'cancelled', 'superseded']);
+  const validDelay = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 && value <= 255;
+  function validDelayFeedback(feedback: ReturnType<typeof getBreakInDelayControlFeedback>): boolean {
+    if (feedback.availability === 'unavailable') return feedback.phase === 'unavailable'
+      && feedback.confirmed === null && feedback.target === null && feedback.requestedTarget === null
+      && !feedback.busy && feedback.outcome === null;
+    if (feedback.availability !== 'available' || !validDelay(feedback.confirmed)) return false;
+    const busy = BUSY_DELAY_PHASES.has(feedback.phase);
+    if (feedback.busy !== busy) return false;
+    if (busy) return validDelay(feedback.target) && validDelay(feedback.requestedTarget)
+      && feedback.outcome === null;
+    if (feedback.phase === 'idle') return feedback.target === null
+      && feedback.requestedTarget === null && feedback.outcome === null;
+    return TERMINAL_DELAY_PHASES.has(feedback.phase) && feedback.target === null
+      && validDelay(feedback.requestedTarget) && feedback.outcome?.phase === feedback.phase;
+  }
+  let candidateBreakInDelayFeedback = $derived(getBreakInDelayControlFeedback());
+  let breakInDelayFeedback = $derived(validDelayFeedback(candidateBreakInDelayFeedback)
+    ? candidateBreakInDelayFeedback : { ...candidateBreakInDelayFeedback,
+      confirmed: null, target: null, requestedTarget: null, phase: 'unavailable' as const,
+      busy: false, availability: 'unavailable' as const, outcome: null, transitionId: null });
   let breakInDelayAvailable = $derived(
     breakInDelayFeedback.availability === 'available'
       && breakInDelayFeedback.confirmed !== null,
@@ -53,6 +75,7 @@
   let breakInDelayDraft = $state(0);
   let breakInDelayEditing = $state(false);
   let breakInDelayCancelled = $state(false);
+  let breakInDelayDraftAuthority = $state('');
   let breakInDelayAnnouncement = $state<string | null>(null);
   const announcedBreakInDelayTransitions = new Set<string>();
   const feedbackIntegratedRange = { 'feedback-policy': 'feedback-integrated' } as const;
@@ -61,9 +84,16 @@
     { announcedTransitionIds: [] },
     rawToPercentDisplay,
   ));
-
+  let breakInDelayAuthority = $derived(JSON.stringify([
+    breakInDelayFeedback.sessionEpoch, breakInDelayFeedback.transitionId,
+    breakInDelayFeedback.phase, breakInDelayFeedback.confirmed,
+  ]));
   $effect(() => {
-    const truth = breakInDelayTruth;
+    const truth = breakInDelayTruth, authority = breakInDelayAuthority;
+    if (breakInDelayEditing && breakInDelayDraftAuthority !== authority) {
+      breakInDelayCancelled = true;
+      breakInDelayEditing = false;
+    }
     if (!breakInDelayEditing && truth !== null) breakInDelayDraft = truth;
   });
   $effect(() => {
@@ -77,41 +107,27 @@
       );
     }
   });
-
   const delayText = (value: number | null): string =>
     value === null ? '—' : rawToPercentDisplay(value);
   const delayLabel = (): string =>
     getLocale() === 'ru-RU' ? 'Задержка break-in' : 'Break-in Delay';
-  function breakInDelayMessage(
-    phase: PresentationPhase,
-    target: number | null,
-    confirmed: number | null,
-  ): string {
+  const DELAY_PHASE_COPY: Record<'en' | 'ru', Record<PresentationPhase, string>> = {
+    en: { unavailable: 'Control unavailable', idle: 'Confirmed', submitted: 'Requested',
+      queued: 'Queued', dispatched: 'Dispatched', 'awaiting-confirmation': 'Awaiting',
+      confirmed: 'Radio confirmed', failed: 'Failed', 'timed-out': 'Timed out',
+      cancelled: 'Cancelled', superseded: 'Superseded' },
+    ru: { unavailable: 'Управление недоступно', idle: 'Подтверждено', submitted: 'Запрошено',
+      queued: 'В очереди', dispatched: 'Отправлено', 'awaiting-confirmation': 'Ожидание',
+      confirmed: 'Радио подтвердило', failed: 'Ошибка', 'timed-out': 'Время истекло',
+      cancelled: 'Запрос отменён', superseded: 'Запрос заменён' },
+  };
+  function breakInDelayMessage(phase: PresentationPhase, target: number | null,
+    confirmed: number | null): string {
     const ru = getLocale() === 'ru-RU';
-    const requested = delayText(target);
-    const canonical = delayText(confirmed);
-    const copy: Record<PresentationPhase, string> = ru ? {
-      unavailable: 'Управление недоступно', idle: `Подтверждено: ${canonical}`,
-      submitted: `Запрошено ${requested}; подтверждено ${canonical}`,
-      queued: `В очереди ${requested}; подтверждено ${canonical}`,
-      dispatched: `Отправлено ${requested}; подтверждено ${canonical}`,
-      'awaiting-confirmation': `Ожидание ${requested}; подтверждено ${canonical}`,
-      confirmed: `Радио подтвердило ${canonical}`, failed: `Ошибка ${requested}; осталось ${canonical}`,
-      'timed-out': `Время ожидания ${requested} истекло; осталось ${canonical}`,
-      cancelled: `Запрос ${requested} отменён; осталось ${canonical}`,
-      superseded: `Запрос ${requested} заменён; осталось ${canonical}`,
-    } : {
-      unavailable: 'Control unavailable', idle: `Confirmed: ${canonical}`,
-      submitted: `Requested ${requested}; last confirmed ${canonical}`,
-      queued: `Queued ${requested}; last confirmed ${canonical}`,
-      dispatched: `Dispatched ${requested}; last confirmed ${canonical}`,
-      'awaiting-confirmation': `Awaiting ${requested}; last confirmed ${canonical}`,
-      confirmed: `Radio confirmed ${canonical}`, failed: `Failed ${requested}; confirmed remains ${canonical}`,
-      'timed-out': `Timed out ${requested}; confirmed remains ${canonical}`,
-      cancelled: `Cancelled ${requested}; confirmed remains ${canonical}`,
-      superseded: `Superseded ${requested}; confirmed remains ${canonical}`,
-    };
-    return copy[phase];
+    const label = DELAY_PHASE_COPY[ru ? 'ru' : 'en'][phase], canonical = delayText(confirmed);
+    if (phase === 'unavailable') return label;
+    if (phase === 'idle' || phase === 'confirmed') return `${label}: ${canonical}`;
+    return `${label} ${delayText(target)}; ${ru ? 'подтверждено' : 'confirmed'} ${canonical}`;
   }
   let breakInDelayValueText = $derived(
     !breakInDelayAvailable
@@ -124,13 +140,13 @@
           breakInDelayFeedback.confirmed,
         ),
   );
-
   function restoreBreakInDelay(): void {
     breakInDelayEditing = false;
     breakInDelayDraft = breakInDelayTruth ?? 0;
   }
   function updateBreakInDelayDraft(event: Event): void {
     if (!breakInDelayAvailable) return;
+    if (!breakInDelayEditing) breakInDelayDraftAuthority = breakInDelayAuthority;
     breakInDelayCancelled = false;
     breakInDelayEditing = true;
     breakInDelayDraft = Math.min(255, Math.max(0, Math.round(
@@ -338,8 +354,7 @@
   }
 
   .break-in-delay-control input { width: 100%; accent-color: var(--v2-accent-cyan); }
-  .break-in-delay-phase { font-size: 9px; text-transform: uppercase; }
-  .break-in-delay-phase { opacity: 0.8; }
+  .break-in-delay-phase { font-size: 9px; text-transform: uppercase; opacity: 0.8; }
   .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 
   @media (forced-colors: active) {

--- a/frontend/src/components-v2/panels/CwPanel.svelte
+++ b/frontend/src/components-v2/panels/CwPanel.svelte
@@ -2,9 +2,18 @@
   import '../controls/control-button.css';
   import { HardwareButton } from '$lib/Button';
   import { ValueControl, rawToPercentDisplay } from '../controls/value-control';
+  import { getLocale } from '$lib/i18n';
+  import {
+    projectControlFeedbackPresentation,
+    type PresentationPhase,
+  } from '../../primitives/control-feedback/control-feedback-presentation';
 
-  import { formatBreakIn, isBreakInActive, isApfActive } from './cw-panel-logic';
-  import { deriveCwProps, getCwHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { isApfActive } from './cw-panel-logic';
+  import {
+    deriveCwProps,
+    getBreakInDelayControlFeedback,
+    getCwHandlers,
+  } from '$lib/runtime/adapters/panel-adapters';
 
   const handlers = getCwHandlers();
   let p = $derived(deriveCwProps());
@@ -12,7 +21,6 @@
   let cwPitch = $derived(p.cwPitch ?? 600);
   let keySpeed = $derived(p.keySpeed ?? 12);
   let breakIn = $derived(p.breakIn ?? 0);
-  let breakInDelay = $derived(p.breakInDelay ?? 0);
   let apfMode = $derived(p.apfMode ?? 0);
   let twinPeak = $derived(p.twinPeak ?? false);
   let currentMode = $derived(p.currentMode ?? 'CW');
@@ -31,9 +39,131 @@
   let showApf = $derived(p.hasApf);
   let showTwinPeak = $derived(p.hasTwinPeak);
   let showAutoTune = $derived(p.autoTuneAvailable);
-  let breakInActive = $derived(isBreakInActive(breakIn));
   let apfActive = $derived(isApfActive(apfMode));
-  let breakInLabel = $derived(formatBreakIn(breakIn));
+  let breakInDelayFeedback = $derived(getBreakInDelayControlFeedback());
+  let breakInDelayAvailable = $derived(
+    breakInDelayFeedback.availability === 'available'
+      && breakInDelayFeedback.confirmed !== null,
+  );
+  let breakInDelayTruth = $derived(
+    breakInDelayFeedback.busy && breakInDelayFeedback.target !== null
+      ? breakInDelayFeedback.target
+      : breakInDelayFeedback.confirmed,
+  );
+  let breakInDelayDraft = $state(0);
+  let breakInDelayEditing = $state(false);
+  let breakInDelayCancelled = $state(false);
+  let breakInDelayAnnouncement = $state<string | null>(null);
+  const announcedBreakInDelayTransitions = new Set<string>();
+  const feedbackIntegratedRange = { 'feedback-policy': 'feedback-integrated' } as const;
+  let breakInDelayPresentation = $derived(projectControlFeedbackPresentation(
+    breakInDelayFeedback,
+    { announcedTransitionIds: [] },
+    rawToPercentDisplay,
+  ));
+
+  $effect(() => {
+    const truth = breakInDelayTruth;
+    if (!breakInDelayEditing && truth !== null) breakInDelayDraft = truth;
+  });
+  $effect(() => {
+    const transition = breakInDelayPresentation.politeAnnouncement;
+    if (transition && !announcedBreakInDelayTransitions.has(transition.transitionId)) {
+      announcedBreakInDelayTransitions.add(transition.transitionId);
+      breakInDelayAnnouncement = breakInDelayMessage(
+        transition.phase,
+        breakInDelayFeedback.requestedTarget,
+        breakInDelayFeedback.confirmed,
+      );
+    }
+  });
+
+  const delayText = (value: number | null): string =>
+    value === null ? '—' : rawToPercentDisplay(value);
+  const delayLabel = (): string =>
+    getLocale() === 'ru-RU' ? 'Задержка break-in' : 'Break-in Delay';
+  function breakInDelayMessage(
+    phase: PresentationPhase,
+    target: number | null,
+    confirmed: number | null,
+  ): string {
+    const ru = getLocale() === 'ru-RU';
+    const requested = delayText(target);
+    const canonical = delayText(confirmed);
+    const copy: Record<PresentationPhase, string> = ru ? {
+      unavailable: 'Управление недоступно', idle: `Подтверждено: ${canonical}`,
+      submitted: `Запрошено ${requested}; подтверждено ${canonical}`,
+      queued: `В очереди ${requested}; подтверждено ${canonical}`,
+      dispatched: `Отправлено ${requested}; подтверждено ${canonical}`,
+      'awaiting-confirmation': `Ожидание ${requested}; подтверждено ${canonical}`,
+      confirmed: `Радио подтвердило ${canonical}`, failed: `Ошибка ${requested}; осталось ${canonical}`,
+      'timed-out': `Время ожидания ${requested} истекло; осталось ${canonical}`,
+      cancelled: `Запрос ${requested} отменён; осталось ${canonical}`,
+      superseded: `Запрос ${requested} заменён; осталось ${canonical}`,
+    } : {
+      unavailable: 'Control unavailable', idle: `Confirmed: ${canonical}`,
+      submitted: `Requested ${requested}; last confirmed ${canonical}`,
+      queued: `Queued ${requested}; last confirmed ${canonical}`,
+      dispatched: `Dispatched ${requested}; last confirmed ${canonical}`,
+      'awaiting-confirmation': `Awaiting ${requested}; last confirmed ${canonical}`,
+      confirmed: `Radio confirmed ${canonical}`, failed: `Failed ${requested}; confirmed remains ${canonical}`,
+      'timed-out': `Timed out ${requested}; confirmed remains ${canonical}`,
+      cancelled: `Cancelled ${requested}; confirmed remains ${canonical}`,
+      superseded: `Superseded ${requested}; confirmed remains ${canonical}`,
+    };
+    return copy[phase];
+  }
+  let breakInDelayValueText = $derived(
+    !breakInDelayAvailable
+      ? breakInDelayMessage('unavailable', null, null)
+      : breakInDelayEditing
+        ? `${getLocale() === 'ru-RU' ? 'Черновик' : 'Draft'} ${delayText(breakInDelayDraft)}; ${getLocale() === 'ru-RU' ? 'подтверждено' : 'last confirmed'} ${delayText(breakInDelayFeedback.confirmed)}`
+        : breakInDelayMessage(
+          breakInDelayFeedback.phase,
+          breakInDelayFeedback.target ?? breakInDelayFeedback.requestedTarget,
+          breakInDelayFeedback.confirmed,
+        ),
+  );
+
+  function restoreBreakInDelay(): void {
+    breakInDelayEditing = false;
+    breakInDelayDraft = breakInDelayTruth ?? 0;
+  }
+  function updateBreakInDelayDraft(event: Event): void {
+    if (!breakInDelayAvailable) return;
+    breakInDelayCancelled = false;
+    breakInDelayEditing = true;
+    breakInDelayDraft = Math.min(255, Math.max(0, Math.round(
+      (event.currentTarget as HTMLInputElement).valueAsNumber,
+    )));
+  }
+  function commitBreakInDelay(event: Event): void {
+    if (breakInDelayCancelled) {
+      breakInDelayCancelled = false;
+      restoreBreakInDelay();
+      (event.currentTarget as HTMLInputElement).value = String(breakInDelayDraft);
+      return;
+    }
+    const candidate = (event.currentTarget as HTMLInputElement).valueAsNumber;
+    if (breakInDelayAvailable && Number.isFinite(candidate)) {
+      const bounded = Math.min(255, Math.max(0, Math.round(candidate)));
+      breakInDelayDraft = bounded;
+      onBreakInDelayChange(bounded);
+    }
+    breakInDelayEditing = false;
+  }
+  function cancelBreakInDelay(event?: Event): void {
+    breakInDelayCancelled = true;
+    restoreBreakInDelay();
+    if (event?.currentTarget instanceof HTMLInputElement) {
+      event.currentTarget.value = String(breakInDelayDraft);
+    }
+  }
+  function handleBreakInDelayKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    cancelBreakInDelay(event);
+  }
 
   // MOR-1409 A12 (coordinator adjudication, Core #2317, comment 5246487510):
   // `cwPitch`/`keySpeed` are `?? 600`/`?? 12` guarded above, but `??` does
@@ -113,18 +243,38 @@
     </div>
 
     {#if showBreakIn && breakIn === 1}
-      <ValueControl
-        label="Break-in Delay"
-        value={breakInDelay}
-        min={0}
-        max={255}
-        step={1}
-        renderer="hbar"
-        displayFn={rawToPercentDisplay}
-        accentColor="var(--v2-accent-cyan)"
-        onChange={onBreakInDelayChange}
-        variant="hardware-illuminated"
-      />
+      <label class="break-in-delay-control" data-testid="cw-break-in-delay-control">
+        <span class="break-in-delay-header">
+          <span>{delayLabel()}</span>
+          <output data-testid="cw-break-in-delay-value">
+            {breakInDelayAvailable ? delayText(breakInDelayDraft) : '—'}
+          </output>
+        </span>
+        <input
+          data-testid="cw-break-in-delay"
+          type="range" min="0" max="255" step="1" value={breakInDelayDraft}
+          {...feedbackIntegratedRange}
+          disabled={!breakInDelayAvailable}
+          aria-label={delayLabel()}
+          aria-valuenow={breakInDelayAvailable ? breakInDelayDraft : undefined}
+          aria-valuetext={breakInDelayValueText}
+          aria-busy={breakInDelayPresentation.attributes['aria-busy']}
+          data-command-phase={breakInDelayPresentation.attributes['data-command-phase']}
+          oninput={updateBreakInDelayDraft}
+          onchange={commitBreakInDelay}
+          onpointercancel={cancelBreakInDelay}
+          onkeydown={handleBreakInDelayKeydown}
+        />
+        <span class="break-in-delay-phase" aria-hidden="true">
+          ● {breakInDelayFeedback.phase}
+        </span>
+        {#if breakInDelayAnnouncement}
+          <span
+            class="sr-only" role="status" aria-live="polite" aria-atomic="true"
+            data-testid="cw-break-in-delay-live"
+          >{breakInDelayAnnouncement}</span>
+        {/if}
+      </label>
     {/if}
 
     {#if showAutoTune}
@@ -173,6 +323,32 @@
     display: flex;
     align-items: center;
     gap: 8px;
+  }
+
+  .break-in-delay-control {
+    display: grid;
+    gap: 4px;
+    color: var(--v2-text-label, var(--v2-text-dim));
+    font: 700 10px/1.4 'Roboto Mono', monospace;
+  }
+
+  .break-in-delay-header {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .break-in-delay-control input { width: 100%; accent-color: var(--v2-accent-cyan); }
+  .break-in-delay-phase { font-size: 9px; text-transform: uppercase; }
+  .break-in-delay-phase { opacity: 0.8; }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+
+  @media (forced-colors: active) {
+    .break-in-delay-control input { border: 1px solid CanvasText; }
+    .break-in-delay-phase { forced-color-adjust: none; color: CanvasText; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .break-in-delay-control, .break-in-delay-control * { transition: none !important; }
   }
 
 </style>

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.component.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync } from 'svelte';
+import type { ControlFeedback } from '$lib/runtime/adapters/panel-adapters';
 
 const mockProps = {
   cwPitch: 600,
@@ -29,9 +30,17 @@ const mockHandlers = {
   onAutoTune: vi.fn(),
 };
 
+const mockFeedback = {
+  confirmed: 64, target: null, requestedTarget: null, phase: 'idle', busy: false,
+  availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  sessionEpoch: 1, scope: { control: 'break-in-delay', receiver: 0 },
+  repeatPolicy: 'latest-target-wins',
+} as ControlFeedback<number>;
+
 vi.mock('$lib/runtime/adapters/panel-adapters', () => ({
   deriveCwProps: () => mockProps,
   getCwHandlers: () => mockHandlers,
+  getBreakInDelayControlFeedback: () => mockFeedback,
 }));
 
 import CwPanel from '../CwPanel.svelte';
@@ -58,6 +67,10 @@ beforeEach(() => {
     autoTuneAvailable: false,
   });
   Object.values(mockHandlers).forEach((fn) => fn.mockClear());
+  Object.assign(mockFeedback, {
+    confirmed: 64, target: null, requestedTarget: null, phase: 'idle', busy: false,
+    availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  });
 });
 
 afterEach(() => {
@@ -219,5 +232,57 @@ describe('CwPanel — no "NaN" leak for unobserved pitch/speed (MOR-1409 A12)', 
     const t = mountPanel({ cwPitch: 700, keySpeed: 25 });
     expect(vcValueFor(t, 'CW Pitch')).toBe('700\u00a0Hz');
     expect(vcValueFor(t, 'Key Speed')).toBe('25\u00a0WPM');
+  });
+});
+
+describe('CwPanel Break-in Delay release gesture (MOR-1754)', () => {
+  const delay = (t: HTMLElement) =>
+    t.querySelector<HTMLInputElement>('[data-testid="cw-break-in-delay"]')!;
+
+  it.each(['pointer', 'keyboard'] as const)(
+    'shows draft input immediately and commits one bounded command on %s release',
+    (gesture) => {
+    const t = mountPanel({ breakIn: 1 });
+    const input = delay(t);
+    input.dispatchEvent(gesture === 'pointer'
+      ? new PointerEvent('pointerdown', { bubbles: true })
+      : new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    for (const value of ['80', '96', '111']) {
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    flushSync();
+    expect(mockHandlers.onBreakInDelayChange).not.toHaveBeenCalled();
+    expect(t.querySelector('[data-testid="cw-break-in-delay-value"]')?.textContent).toBe('44%');
+    input.dispatchEvent(gesture === 'pointer'
+      ? new PointerEvent('pointerup', { bubbles: true })
+      : new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(mockHandlers.onBreakInDelayChange).toHaveBeenCalledExactlyOnceWith(111);
+    },
+  );
+
+  it('cancels pointer and keyboard gestures without a trailing commit', () => {
+    for (const event of [
+      new Event('pointercancel', { bubbles: true }),
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    ]) {
+      const t = mountPanel({ breakIn: 1 });
+      const input = delay(t);
+      input.value = '111';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(event);
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      flushSync();
+      expect(input.value).toBe('64');
+    }
+    expect(mockHandlers.onBreakInDelayChange).not.toHaveBeenCalled();
+  });
+
+  it('disables the actual range when canonical feedback is unavailable', () => {
+    Object.assign(mockFeedback, { confirmed: null, phase: 'unavailable', availability: 'unavailable' });
+    const t = mountPanel({ breakIn: 1 });
+    expect(delay(t).disabled).toBe(true);
+    expect(delay(t).getAttribute('aria-valuetext')).toMatch(/unavailable/i);
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
@@ -3,12 +3,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 import { flushSync, mount, unmount } from 'svelte';
 import { setLocale } from '$lib/i18n';
 import type { ControlFeedback } from '$lib/runtime/adapters/panel-adapters';
-
 const props = $state({
   cwPitch: 600, keySpeed: 12, breakIn: 1, breakInDelay: 64, apfMode: 0,
   twinPeak: false, currentMode: 'CW', apfDisabled: false, tpfDisabled: false,
-  hasCw: true, hasBreakIn: true, hasApf: false, hasTwinPeak: false,
-  autoTuneAvailable: false,
+  hasCw: true, hasBreakIn: true, hasApf: false, hasTwinPeak: false, autoTuneAvailable: false,
 });
 const handlers = { onCwPitchChange: vi.fn(), onKeySpeedChange: vi.fn(),
   onBreakInToggle: vi.fn(), onBreakInModeChange: vi.fn(), onBreakInDelayChange: vi.fn(),
@@ -19,11 +17,8 @@ const feedback = $state({
   sessionEpoch: 1, scope: { control: 'break-in-delay', receiver: 0 },
   repeatPolicy: 'latest-target-wins',
 } as ControlFeedback<number>);
-
 let CwPanel: typeof import('../CwPanel.svelte').default;
-let component: ReturnType<typeof mount> | null = null;
-let target: HTMLDivElement;
-
+let component: ReturnType<typeof mount> | null = null, target: HTMLDivElement;
 beforeAll(async () => {
   vi.doMock('$lib/runtime/adapters/panel-adapters', () => ({
     deriveCwProps: () => props, getCwHandlers: () => handlers,
@@ -35,12 +30,9 @@ afterAll(() => vi.doUnmock('$lib/runtime/adapters/panel-adapters'));
 afterEach(() => {
   if (component) unmount(component);
   component = null; target?.remove(); setLocale('en-US');
-  Object.assign(feedback, {
-    confirmed: 64, target: null, requestedTarget: null, phase: 'idle', busy: false,
-    availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
-  });
+  Object.assign(feedback, { confirmed: 64, target: null, requestedTarget: null, phase: 'idle',
+    busy: false, availability: 'available', outcome: null, lifecycleId: null, transitionId: null });
 });
-
 function render() {
   target = document.createElement('div'); document.body.appendChild(target);
   component = mount(CwPanel, { target }); flushSync();
@@ -48,7 +40,6 @@ function render() {
   const live = () => target.querySelector<HTMLElement>('[data-testid="cw-break-in-delay-live"]');
   return { input, live };
 }
-
 describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
   it('projects pending and every terminal phase without replacing canonical truth', () => {
     const r = render();
@@ -57,45 +48,63 @@ describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
       ['awaiting-confirmation', true], ['confirmed', false], ['failed', false],
       ['timed-out', false], ['cancelled', false], ['superseded', false],
     ] as const) {
-      Object.assign(feedback, {
-        phase, busy, target: busy ? 111 : null, requestedTarget: 111,
-        transitionId: `transition-${phase}`, outcome: busy ? null : { phase },
-      });
+      Object.assign(feedback, { phase, busy, target: busy ? 111 : null, requestedTarget: 111,
+        transitionId: `transition-${phase}`, outcome: busy ? null : { phase } });
       flushSync();
-      expect(r.input().dataset.commandPhase).toBe(phase);
-      expect(r.input().getAttribute('aria-busy')).toBe(String(busy));
-      expect(r.input().value).toBe(busy ? '111' : '64');
-      expect(r.live()?.textContent).toBeTruthy();
+      expect([r.input().dataset.commandPhase, r.input().getAttribute('aria-busy'),
+        r.input().value, Boolean(r.live()?.textContent)])
+        .toEqual([phase, String(busy), busy ? '111' : '64', true]);
     }
   });
-
   it('announces one localized message per transition and follows out-of-band truth', () => {
     const r = render();
     Object.assign(feedback, { phase: 'failed', requestedTarget: 111,
-      transitionId: 'one', outcome: { phase: 'failed' } });
-    flushSync();
+      transitionId: 'one', outcome: { phase: 'failed' } }); flushSync();
     const first = r.live()?.textContent;
     Object.assign(feedback, { confirmed: 80 }); flushSync();
-    expect(r.live()?.textContent).toBe(first);
-    expect(r.input().value).toBe('80');
-
-    setLocale('ru-RU');
-    Object.assign(feedback, { phase: 'timed-out', transitionId: 'two',
-      outcome: { phase: 'timed-out' } });
-    flushSync();
+    expect([r.live()?.textContent, r.input().value]).toEqual([first, '80']);
+    setLocale('ru-RU'); Object.assign(feedback, { phase: 'timed-out',
+      transitionId: 'two', outcome: { phase: 'timed-out' } }); flushSync();
     expect(r.live()?.textContent).toMatch(/[А-Яа-я]/);
   });
-
   it('fails closed for stale/unavailable truth and keeps accessibility media seams', () => {
     Object.assign(feedback, { confirmed: null, phase: 'unavailable',
       availability: 'unavailable', transitionId: 'unavailable' });
     const r = render();
-    expect(r.input().disabled).toBe(true);
-    expect(r.input().getAttribute('aria-valuetext')).toMatch(/unavailable/i);
+    expect([r.input().disabled, r.input().getAttribute('aria-valuetext')])
+      .toEqual([true, 'Control unavailable']);
     const source = readFileSync('src/components-v2/panels/CwPanel.svelte', 'utf8');
-    expect(source).toContain('@media (forced-colors: active)');
-    expect(source).toContain('@media (prefers-reduced-motion: reduce)');
-    expect(source).toContain('getBreakInDelayControlFeedback');
+    for (const seam of ['@media (forced-colors: active)', '@media (prefers-reduced-motion: reduce)',
+      'getBreakInDelayControlFeedback']) expect(source).toContain(seam);
     expect(source).not.toMatch(/stores\/(commands|radio)|sendCommand|dispatchRadioIntent/);
+  });
+  it.each([
+    ['provider cancellation', { confirmed: 72, phase: 'cancelled', requestedTarget: 111,
+      transitionId: 'provider-replaced', outcome: { phase: 'cancelled' } }, 72],
+    ['out-of-band truth', { confirmed: 80, transitionId: 'out-of-band' }, 80],
+  ] as const)('%s invalidates a stale draft and suppresses its release', (_case, update, canonical) => {
+    handlers.onBreakInDelayChange.mockClear(); const r = render();
+    r.input().value = '111'; r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    Object.assign(feedback, { ...update, target: null, busy: false }); flushSync();
+    const restored = r.input().value; r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect({ restored, calls: handlers.onBreakInDelayChange.mock.calls })
+      .toEqual({ restored: String(canonical), calls: [] });
+    r.input().value = '90'; r.input().dispatchEvent(new Event('input', { bubbles: true }));
+    r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(handlers.onBreakInDelayChange).toHaveBeenCalledExactlyOnceWith(90);
+  });
+  it.each([
+    ['non-finite', { confirmed: Number.NaN }], ['missing', { confirmed: undefined }],
+    ['out-of-domain', { confirmed: 256 }], ['off-lattice', { confirmed: 1.5 }],
+    ['phase mismatch', { phase: 'failed', busy: true, target: 111,
+      requestedTarget: 111, outcome: { phase: 'failed' } }],
+  ])('fails closed for %s feedback', (_case, malformed) => {
+    handlers.onBreakInDelayChange.mockClear();
+    Object.assign(feedback as unknown as Record<string, unknown>, malformed); const r = render();
+    expect([r.input().disabled, r.input().getAttribute('aria-valuetext'),
+      target.querySelector('[data-testid="cw-break-in-delay-value"]')?.textContent])
+      .toEqual([true, 'Control unavailable', '—']);
+    r.input().value = '111'; r.input().dispatchEvent(new Event('change', { bubbles: true }));
+    expect(handlers.onBreakInDelayChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
+++ b/frontend/src/components-v2/panels/__tests__/CwPanel.feedback-wiring.svelte.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { setLocale } from '$lib/i18n';
+import type { ControlFeedback } from '$lib/runtime/adapters/panel-adapters';
+
+const props = $state({
+  cwPitch: 600, keySpeed: 12, breakIn: 1, breakInDelay: 64, apfMode: 0,
+  twinPeak: false, currentMode: 'CW', apfDisabled: false, tpfDisabled: false,
+  hasCw: true, hasBreakIn: true, hasApf: false, hasTwinPeak: false,
+  autoTuneAvailable: false,
+});
+const handlers = { onCwPitchChange: vi.fn(), onKeySpeedChange: vi.fn(),
+  onBreakInToggle: vi.fn(), onBreakInModeChange: vi.fn(), onBreakInDelayChange: vi.fn(),
+  onApfChange: vi.fn(), onTwinPeakToggle: vi.fn(), onAutoTune: vi.fn() };
+const feedback = $state({
+  confirmed: 64, target: null, requestedTarget: null, phase: 'idle', busy: false,
+  availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  sessionEpoch: 1, scope: { control: 'break-in-delay', receiver: 0 },
+  repeatPolicy: 'latest-target-wins',
+} as ControlFeedback<number>);
+
+let CwPanel: typeof import('../CwPanel.svelte').default;
+let component: ReturnType<typeof mount> | null = null;
+let target: HTMLDivElement;
+
+beforeAll(async () => {
+  vi.doMock('$lib/runtime/adapters/panel-adapters', () => ({
+    deriveCwProps: () => props, getCwHandlers: () => handlers,
+    getBreakInDelayControlFeedback: () => feedback,
+  }));
+  CwPanel = (await import('../CwPanel.svelte')).default;
+});
+afterAll(() => vi.doUnmock('$lib/runtime/adapters/panel-adapters'));
+afterEach(() => {
+  if (component) unmount(component);
+  component = null; target?.remove(); setLocale('en-US');
+  Object.assign(feedback, {
+    confirmed: 64, target: null, requestedTarget: null, phase: 'idle', busy: false,
+    availability: 'available', outcome: null, lifecycleId: null, transitionId: null,
+  });
+});
+
+function render() {
+  target = document.createElement('div'); document.body.appendChild(target);
+  component = mount(CwPanel, { target }); flushSync();
+  const input = () => target.querySelector<HTMLInputElement>('[data-testid="cw-break-in-delay"]')!;
+  const live = () => target.querySelector<HTMLElement>('[data-testid="cw-break-in-delay-live"]');
+  return { input, live };
+}
+
+describe('fallback CwPanel ControlFeedback wiring (MOR-1754)', () => {
+  it('projects pending and every terminal phase without replacing canonical truth', () => {
+    const r = render();
+    for (const [phase, busy] of [
+      ['submitted', true], ['queued', true], ['dispatched', true],
+      ['awaiting-confirmation', true], ['confirmed', false], ['failed', false],
+      ['timed-out', false], ['cancelled', false], ['superseded', false],
+    ] as const) {
+      Object.assign(feedback, {
+        phase, busy, target: busy ? 111 : null, requestedTarget: 111,
+        transitionId: `transition-${phase}`, outcome: busy ? null : { phase },
+      });
+      flushSync();
+      expect(r.input().dataset.commandPhase).toBe(phase);
+      expect(r.input().getAttribute('aria-busy')).toBe(String(busy));
+      expect(r.input().value).toBe(busy ? '111' : '64');
+      expect(r.live()?.textContent).toBeTruthy();
+    }
+  });
+
+  it('announces one localized message per transition and follows out-of-band truth', () => {
+    const r = render();
+    Object.assign(feedback, { phase: 'failed', requestedTarget: 111,
+      transitionId: 'one', outcome: { phase: 'failed' } });
+    flushSync();
+    const first = r.live()?.textContent;
+    Object.assign(feedback, { confirmed: 80 }); flushSync();
+    expect(r.live()?.textContent).toBe(first);
+    expect(r.input().value).toBe('80');
+
+    setLocale('ru-RU');
+    Object.assign(feedback, { phase: 'timed-out', transitionId: 'two',
+      outcome: { phase: 'timed-out' } });
+    flushSync();
+    expect(r.live()?.textContent).toMatch(/[А-Яа-я]/);
+  });
+
+  it('fails closed for stale/unavailable truth and keeps accessibility media seams', () => {
+    Object.assign(feedback, { confirmed: null, phase: 'unavailable',
+      availability: 'unavailable', transitionId: 'unavailable' });
+    const r = render();
+    expect(r.input().disabled).toBe(true);
+    expect(r.input().getAttribute('aria-valuetext')).toMatch(/unavailable/i);
+    const source = readFileSync('src/components-v2/panels/CwPanel.svelte', 'utf8');
+    expect(source).toContain('@media (forced-colors: active)');
+    expect(source).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(source).toContain('getBreakInDelayControlFeedback');
+    expect(source).not.toMatch(/stores\/(commands|radio)|sendCommand|dispatchRadioIntent/);
+  });
+});


### PR DESCRIPTION
## Summary
- consume the canonical Break-in Delay `ControlFeedback<number>` accessor in fallback `CwPanel`
- render canonical, draft, pending, confirmed, failed, timed-out, cancelled, superseded, unavailable/stale, and out-of-band truth with EN/RU accessible announcements
- commit pointer and keyboard release gestures exactly once; cancel restores canonical truth; unavailable controls fail closed
- preserve all other fallback CW controls and keep command/store ownership in the existing adapter path

Linear: [MOR-1754](https://linear.app/morozsm/issue/MOR-1754/mor-1688-a1-fallback-consume-truthful-break-in-delay-feedback-in)
Parent: [MOR-1688](https://linear.app/morozsm/issue/MOR-1688)

## RED-first evidence
- focused tests before implementation: 6 failures for the absent fallback feedback control/wiring; 20 legacy component tests remained green

## Verification
- `npx vitest run ...CwPanel.component.test.ts ...CwPanel.feedback-wiring.svelte.test.ts`: 27 passed
- relevant CW/feedback suite: 200 passed
- `npm test`: 366 files, 8009 tests passed
- `npm run lint`
- `npm run lint:boundaries`
- `npm run check`
- `npm run i18n:check`
- `npm run build`
- debt inventory, diff check, 3-file/376-LOC guardrail, and public-boundary/privacy scan passed

## Non-goals
- no semantic CW surface/composition changes
- no descriptor, adapter/store lifecycle, backend, TX policy, runtime, serial, or hardware changes

Independent exact-head review is required before merge.