### PR TITLE
test(MOR-1756): keep semantic CW verification seams compatible

### DIFF
--- a/frontend/fixtures/stubs/panel-adapters.ts
+++ b/frontend/fixtures/stubs/panel-adapters.ts
@@ -16,6 +16,17 @@ export function bindSemanticSurfaceHandlers() {
   });
 }
 
+/** No Break-in Delay truth or command lifecycle exists in the offline fixture. */
+export function getBreakInDelayControlFeedback() {
+  return Object.freeze({
+    confirmed: null, target: null, requestedTarget: null,
+    phase: 'unavailable' as const, busy: false, availability: 'unavailable' as const,
+    outcome: null, lifecycleId: null, transitionId: null, sessionEpoch: 1,
+    scope: Object.freeze({ control: 'break-in-delay', receiver: 0 as const }),
+    repeatPolicy: 'latest-target-wins' as const,
+  });
+}
+
 /**
  * MOR-1441 — `SemanticRadioSurfaces.svelte` now also imports
  * `getPendingFrequencyHz` from the real `panel-adapters` module. Per this

--- a/frontend/src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts
@@ -48,7 +48,10 @@ const h = vi.hoisted(() => ({
 vi.mock('$lib/transport/ws-client', () => ({ sendCommand: vi.fn() }));
 vi.mock('$lib/runtime/commands/radio-intents', async () => {
   const { sendCommand } = await import('$lib/transport/ws-client');
-  return { dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params) };
+  return {
+    dispatchRadioIntent: ({ name, params }: { name: string; params: Record<string, unknown> }) => sendCommand(name, params),
+    currentControlSessionEpoch: () => 1,
+  };
 });
 vi.mock('$lib/audio/audio-manager', () => ({
   audioManager: {


### PR DESCRIPTION
## Summary

- expose the existing deterministic control-session epoch through the zone-lifecycle test mock
- add an honest unavailable Break-in Delay feedback DTO to the offline fixture adapter stub
- preserve zero-command lifecycle coverage and fixture build compatibility for MOR-1755

## Scope

- Verification-only: 2 files, +15/-1
- No product source, command, transport, backend, runtime, radio, TX, PTT, TUNE, or keying behavior changes

## Verification

- RED evidence from MOR-1755 integration: zone lifecycle failed on missing `currentControlSessionEpoch`; fixture preflight failed on missing `getBreakInDelayControlFeedback`
- `npm test -- --run src/components-v2/wiring/__tests__/cw-keyer-zone-lifecycle.component.test.ts` (3 passed)
- `node frontend/fixtures/capture.mjs --preflight-only` (PASS)
- `npm test -- --run` (365 files, 8024 tests passed)
- `npm run check`
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check`
- `npm run build`
- `git diff --check origin/main...HEAD`

Linear: MOR-1756
Blocks: MOR-1755