### PR TITLE
MOR-1758: retain deferred lane deadline on supersession

### DIFF
--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -102,7 +102,8 @@ class TxInterlockDeferredResult:
 
     The lane never executes ``command`` and never emits lifecycle events.  For
     supersession or expiry while accepting a replacement, ``replacement`` is
-    the newly held command; it has its own fresh three-second TTL.
+    the newly held command.  Active supersession retains the current absolute
+    deadline; a replacement accepted after expiry starts a fresh hold.
     """
 
     outcome: TxInterlockDeferredOutcome
@@ -143,21 +144,29 @@ class DeferredTxCommandLane:
     def defer(self, command: object, *, now: float) -> TxInterlockDeferredResult:
         """Hold a ``DEFER`` command, explicitly replacing a prior held command.
 
-        The original command's TTL is never carried forward.  If it was already
-        expired when a new command arrives, expiry is reported truthfully while
-        the new command starts a separate fresh hold.
+        Active supersession carries forward the original absolute deadline but
+        resets quiet progress for the new payload.  If the prior command was
+        already expired, expiry is reported truthfully while the replacement
+        starts a separate fresh hold.
         """
 
         decision = evaluate_tx_interlock(command, rf_state=RfState.TX)
         if decision.disposition is not TxInterlockDisposition.DEFER:
             raise ValueError("only commands with DEFER disposition may enter the lane")
 
-        replacement = _DeferredTxCommand(
-            command=command,
-            deferred_at=now,
-            expires_at=now + self._TTL_SECONDS,
-        )
         previous = self._entry
+        if previous is not None and now < previous.expires_at:
+            replacement = _DeferredTxCommand(
+                command=command,
+                deferred_at=previous.deferred_at,
+                expires_at=previous.expires_at,
+            )
+        else:
+            replacement = _DeferredTxCommand(
+                command=command,
+                deferred_at=now,
+                expires_at=now + self._TTL_SECONDS,
+            )
         self._entry = replacement
         if previous is None:
             return self._result(TxInterlockDeferredOutcome.HELD, replacement)

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -254,8 +254,12 @@ def test_newer_deferred_command_explicitly_supersedes_the_single_slot() -> None:
     first = SetFreq(7_100_000)
     second = SetMode("USB")
     lane.defer(first, now=10.0)
+    assert (
+        lane.observe(rf_state=RfState.RX, now=10.0).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
 
-    superseded = lane.defer(second, now=10.5)
+    superseded = lane.defer(second, now=11.1)
 
     assert superseded.outcome is TxInterlockDeferredOutcome.SUPERSEDED
     assert superseded.command is first
@@ -263,12 +267,65 @@ def test_newer_deferred_command_explicitly_supersedes_the_single_slot() -> None:
     assert superseded.expires_at == 13.0
     assert lane.pending is second
     assert (
-        lane.observe(rf_state=RfState.RX, now=10.5).outcome
+        lane.observe(rf_state=RfState.RX, now=11.1).outcome
         is TxInterlockDeferredOutcome.HELD
     )
     assert (
-        lane.observe(rf_state=RfState.RX, now=11.5).outcome
+        lane.observe(rf_state=RfState.RX, now=12.099).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.RX, now=12.1).outcome
         is TxInterlockDeferredOutcome.RELEASED
+    )
+
+
+def test_superseding_deferred_command_retains_the_original_deadline() -> None:
+    lane = DeferredTxCommandLane()
+    first = SetFreq(7_100_000)
+    second = SetMode("USB")
+    lane.defer(first, now=10.0)
+
+    superseded = lane.defer(second, now=12.5)
+
+    assert superseded.outcome is TxInterlockDeferredOutcome.SUPERSEDED
+    assert superseded.command is first
+    assert superseded.replacement is second
+    assert superseded.expires_at == 13.0
+    assert lane.pending is second
+    assert (
+        lane.observe(rf_state=RfState.RX, now=12.5).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+
+    expired = lane.observe(rf_state=RfState.RX, now=13.0)
+
+    assert expired.outcome is TxInterlockDeferredOutcome.EXPIRED
+    assert expired.command is second
+    assert expired.expires_at == 13.0
+    assert lane.pending is None
+
+
+def test_command_after_expired_entry_starts_a_new_deadline() -> None:
+    lane = DeferredTxCommandLane()
+    first = SetFreq(7_100_000)
+    second = SetMode("USB")
+    lane.defer(first, now=10.0)
+
+    expired = lane.defer(second, now=13.0)
+
+    assert expired.outcome is TxInterlockDeferredOutcome.EXPIRED
+    assert expired.command is first
+    assert expired.replacement is second
+    assert expired.expires_at == 13.0
+    assert lane.pending is second
+    assert (
+        lane.observe(rf_state=RfState.TX, now=15.999).outcome
+        is TxInterlockDeferredOutcome.HELD
+    )
+    assert (
+        lane.observe(rf_state=RfState.RX, now=16.0).outcome
+        is TxInterlockDeferredOutcome.EXPIRED
     )
 
 


### PR DESCRIPTION
Linear: MOR-1758

## Summary
- retain the original absolute deferred-lane deadline when the active slot is superseded
- reset quiet progress for the replacement payload without refreshing its TTL
- continue granting a fresh TTL when the prior entry is already expired

## Red-first evidence
- exact base `9d8bb6cfa775a24f41d6ccb2ec2f5212c12ad1dc`
- focused suite: 1 failed, 17 passed
- failure proved the replacement incorrectly exposed `expires_at=15.5` and remained HELD at the original `13.0` deadline

## Verification
- `uv run pytest tests/test_tx_interlock_policy.py -q --tb=short` — 18 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9984 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — pass
- `uv run ruff format --check src/ tests/` — 673 files formatted
- `uv run mypy src/rigplane/runtime/tx_interlock.py` — pass
- `uv run lint-imports` — 5 contracts kept
- full `uv run mypy src/` still reports the existing 12 unrelated errors in `_control_phase.py`, `_audio_runtime_mixin.py`, and `web/radio_poller.py`; this PR changes none of those files
- `git diff --check` and privacy scan — pass

## Scope
- 2 files, 90 changed LOC
- no backend, Yaesu, lifecycle, public API, runtime-process, or hardware changes

Fresh independent exact-head Agent Review is required before merge.