### PR TITLE
MOR-1757: release deferred Yaesu commands through TX lane

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -30,10 +30,12 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
-from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
 from rigplane.runtime.tx_interlock import (
+    DeferredTxCommandLane,
     RfState,
+    TxInterlockDeferredOutcome,
     TxInterlockDisposition,
     evaluate_tx_interlock,
 )
@@ -121,6 +123,8 @@ class YaesuCatPoller:
         self._capture_provider_generation: Callable[[], int] | None = None
         self._advance_provider_generation: Callable[[], int] | None = None
         self._pending_receiver_select: CommandQueueEntry | None = None
+        self._deferred_tx_lane = DeferredTxCommandLane()
+        self._deferred_tx_entry: CommandQueueEntry | None = None
 
     def bind_provider_generation(
         self,
@@ -554,10 +558,26 @@ class YaesuCatPoller:
 
     async def _drain_commands(self) -> None:
         """Process all pending commands from the web UI command queue."""
-        if self._command_queue is None or not self._command_queue.has_commands:
+        if self._command_queue is None:
             return
 
-        entries = self._command_queue.drain_entries()
+        now = time.monotonic()
+        transition = self._deferred_tx_lane.observe(
+            rf_state=self._current_rf_state(), now=now
+        )
+        entries: list[CommandQueueEntry] = []
+        if (
+            transition is not None
+            and transition.outcome is not TxInterlockDeferredOutcome.HELD
+        ):
+            entry, self._deferred_tx_entry = self._deferred_tx_entry, None
+            if entry is not None:
+                if transition.outcome is TxInterlockDeferredOutcome.RELEASED:
+                    entries.append(entry)
+                else:
+                    self._finish_deferred_entry(entry, superseded=False)
+        if self._command_queue.has_commands:
+            entries.extend(self._command_queue.drain_entries())
         for entry in entries:
             cmd = entry.command
             if entry.future is not None and entry.future.cancelled():
@@ -566,7 +586,30 @@ class YaesuCatPoller:
                     type(cmd).__name__,
                 )
                 continue
+            now = time.monotonic()
+            rf_state = self._current_rf_state()
+            decision = evaluate_tx_interlock(cmd, rf_state=rf_state)
+            if (
+                decision.disposition is TxInterlockDisposition.DEFER
+                and not decision.allowed
+                and rf_state is RfState.TX
+            ):
+                transition = self._deferred_tx_lane.defer(cmd, now=now)
+                previous, self._deferred_tx_entry = self._deferred_tx_entry, entry
+                if previous is not None:
+                    self._finish_deferred_entry(
+                        previous,
+                        superseded=(
+                            transition.outcome is TxInterlockDeferredOutcome.SUPERSEDED
+                        ),
+                    )
+                continue
             try:
+                if (
+                    decision.disposition is TxInterlockDisposition.DEFER
+                    and not decision.allowed
+                ):
+                    raise CommandError(decision.reason)
                 await self._execute_command(cmd)
                 self._track_receiver_select_readback(entry)
                 if entry.future is not None and not entry.future.done():
@@ -580,6 +623,37 @@ class YaesuCatPoller:
                     type(cmd).__name__,
                     exc_info=True,
                 )
+
+    @classmethod
+    def _finish_deferred_entry(cls, entry: Any, *, superseded: bool) -> None:
+        message = (
+            "deferred command superseded" if superseded else "deferred command expired"
+        )
+        error: BaseException = (
+            CommandError(message) if superseded else TimeoutError(message)
+        )
+        if superseded and entry.command_service is not None and entry.command_id:
+            entry.command_service.expire_command(
+                entry.command_id,
+                source=entry.source,
+                session_id=entry.session_id,
+            )
+            entry.command_service.emit_lifecycle(
+                CommandIntent(
+                    id=entry.command_id,
+                    name="queued_completion",
+                    params={}
+                    if entry.session_id is None
+                    else {"session_id": entry.session_id},
+                    source=entry.source or "internal_policy",
+                ),
+                "superseded",
+                message=message,
+            )
+        elif not superseded:
+            cls._mark_queued_command_failed(entry, error)
+        if entry.future is not None and not entry.future.done():
+            entry.future.set_exception(error)
 
     @staticmethod
     def _mark_queued_command_failed(entry: Any, exc: BaseException) -> None:

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -195,6 +195,7 @@ def _real_ftx1_control_path(
         command_queue=queue,
     )
     poller.bind_provider_generation(capture=lambda: store.provider_generation)
+    _set_fresh_ptt_observation(poller, active=False)
     return radio, handler, poller, store, accept
 
 
@@ -495,12 +496,32 @@ def _ptt_observation(
 
 
 def _set_fresh_ptt_observation(poller: YaesuCatPoller, *, active: bool) -> None:
-    poller._ptt_observation = _ptt_observation(  # noqa: SLF001
-        active, observed_at=10.0
+    poller._ptt_observation = replace(  # noqa: SLF001
+        _ptt_observation(active, observed_at=asyncio.get_running_loop().time()),
+        provider_generation=poller._captured_provider_generation(),  # noqa: SLF001
     )
     poller._ptt_connection_generation = (  # noqa: SLF001
         poller._current_tx_target_generation()  # noqa: SLF001
     )
+
+
+async def _drain_with_ptt(
+    poller: YaesuCatPoller,
+    clock: list[float],
+    now: float,
+    active: bool | None,
+) -> None:
+    clock[0] = now
+    if active is None:
+        poller._invalidate_ptt_observation()  # noqa: SLF001
+    else:
+        poller._ptt_observation = _ptt_observation(  # noqa: SLF001
+            active, observed_at=now
+        )
+        poller._ptt_connection_generation = (  # noqa: SLF001
+            poller._current_tx_target_generation()  # noqa: SLF001
+        )
+    await poller._drain_commands()  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -606,6 +627,98 @@ async def test_yaesu_known_rx_preserves_immediate_dispatch(
         NotImplementedError, match="SendCiv unsupported by Yaesu CAT dispatcher"
     ):
         await poller._execute_command(SendCiv(command=0x1C))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_yaesu_deferred_command_supersedes_without_extending_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [10.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    radio, queue = make_radio(), CommandQueue()
+    radio.set_freq = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    service = MagicMock()
+    first = asyncio.get_running_loop().create_future()
+    second = asyncio.get_running_loop().create_future()
+    queue.put_ordered(
+        SetFreq(7_100_000),
+        future=first,
+        command_id="first",
+        command_service=service,
+    )
+    await _drain_with_ptt(poller, clock, 10.0, True)
+    assert not first.done()
+    queue.put_ordered(SetFreq(7_200_000), future=second)
+    await _drain_with_ptt(poller, clock, 12.5, True)
+    assert isinstance(first.exception(), CommandError)
+    assert "superseded" in str(first.exception())
+    assert not second.done()
+    assert service.emit_lifecycle.call_args.args[1] == "superseded"
+    await _drain_with_ptt(poller, clock, 13.0, False)
+    assert isinstance(second.exception(), TimeoutError)
+    radio.set_freq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_deferred_release_requires_continuous_fresh_rx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [20.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    radio, queue = make_radio(), CommandQueue()
+    radio.set_freq = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    future = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetFreq(7_100_000), future=future)
+    await _drain_with_ptt(poller, clock, 20.0, True)
+    await _drain_with_ptt(poller, clock, 20.5, False)
+    await _drain_with_ptt(poller, clock, 21.0, None)
+    await _drain_with_ptt(poller, clock, 21.1, False)
+    await _drain_with_ptt(poller, clock, 22.099, False)
+    assert not future.done()
+    radio.set_freq.assert_not_awaited()
+    await _drain_with_ptt(poller, clock, 22.1, False)
+    await poller._drain_commands()  # noqa: SLF001
+    assert future.result() is None
+    radio.set_freq.assert_awaited_once_with(7_100_000, receiver=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("knownness", ("missing", "stale", "generation_mismatch"))
+async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
+    monkeypatch: pytest.MonkeyPatch,
+    knownness: str,
+) -> None:
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 30.0
+    )
+    radio, queue = make_radio(), CommandQueue()
+    radio.set_freq = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    if knownness == "stale":
+        _set_fresh_ptt_observation(poller, active=True)
+        poller._ptt_observation = _ptt_observation(True, observed_at=28.0)  # noqa: SLF001
+    elif knownness == "generation_mismatch":
+        poller.bind_provider_generation(capture=lambda: 2)
+        _set_fresh_ptt_observation(poller, active=True)
+        poller._ptt_observation = replace(  # noqa: SLF001
+            poller._ptt_observation,  # noqa: SLF001
+            timestamp_monotonic=30.0,
+            provider_generation=1,
+        )
+    future = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetFreq(7_100_000), future=future)
+    await poller._drain_commands()  # noqa: SLF001
+    error = future.exception()
+    assert isinstance(error, CommandError)
+    assert "unknown" in str(error)
+    radio.set_freq.assert_not_awaited()
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -1839,6 +1952,7 @@ async def test_drain_commands_sets_future_exception_on_execution_failure() -> No
 
     queue = CommandQueue()
     poller = YaesuCatPoller(radio, callback=lambda s: None, command_queue=queue)
+    _set_fresh_ptt_observation(poller, active=False)
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future[None] = loop.create_future()
@@ -1908,6 +2022,7 @@ async def test_undeclared_queued_vfo_commands_set_future_exception_before_mutati
     radio.equalize_vfo_ab = AsyncMock()
     queue = CommandQueue()
     poller = YaesuCatPoller(radio, callback=lambda s: None, command_queue=queue)
+    _set_fresh_ptt_observation(poller, active=False)
 
     assert getattr(radio.profile, profile_primitive) is None
     future: asyncio.Future[None] = asyncio.get_running_loop().create_future()


### PR DESCRIPTION
Linear: MOR-1757

## Summary
- route fresh-known-TX DEFER commands into the shared single-slot `DeferredTxCommandLane`
- keep command futures pending while held, terminally supersede/expire them truthfully, and dispatch once after continuous fresh RX
- fail stale, missing, and provider-generation-mismatched RF evidence closed without entering the lane

## Red-first evidence
- exact merged base `1e11630ad3bdb58df581fd1cc3ba1eacdeb24590`
- selected deferred scenarios: 5 failed / 84 deselected
- failures proved DEFER commands were optimistically dispatched and futures completed successfully under TX/UNKNOWN

## Verification
- `uv run pytest tests/test_yaesu_cat_poller.py -q --tb=short` — 89 passed
- focused Yaesu/FTX/interlock matrix — 578 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9989 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- full Ruff and format check — pass (673 files formatted)
- owned mypy — pass
- import boundaries — 5 contracts kept
- diff check and privacy scan — pass

## Scope
- exactly 2 files, 199 changed LOC
- no shared-policy, public API, Web, protocol, runtime-process, serial, radio, PTT, TUNE, TX, or keying changes

Fresh independent exact-head Agent Review is required before merge.