### PR TITLE
test(MOR-1760): seed explicit RX in deferred Web fixtures

### DIFF
--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -116,6 +116,21 @@ from rigplane.web.web_startup import stop_web_server
 from test_web_managed_tx_owner import _KEY, _TEARDOWN, _poller, _Radio, _Supervisor
 
 
+def _seed_fresh_rx(poller: RadioPoller) -> None:
+    """Give queued DEFER fixtures explicit current-provider RX authority."""
+    store = poller._state_store  # noqa: SLF001
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=False,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=store.snapshot().generated_at_monotonic,
+            max_age=5.0,
+            provider_generation=store.provider_generation,
+        )
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stale", (True, False), ids=("stale", "current"))
 async def test_direct_getter_uses_generation_captured_before_await(stale: bool) -> None:
@@ -1555,6 +1570,7 @@ async def test_scheduler_polling_does_not_starve_user_command_queue() -> None:
     queue = CommandQueue()
     queue.put_ordered(SetFreq(14_074_000))
     poller = RadioPoller(radio, queue, radio_state=RadioState())
+    _seed_fresh_rx(poller)
 
     async def _stop_after_first_wait(*args: object, **kwargs: object) -> None:
         raise asyncio.CancelledError
@@ -1825,6 +1841,7 @@ async def test_unknown_profileless_vfo_commands_fail_before_mutation(
     timestamp_before = poller._last_user_write_ts  # noqa: SLF001
 
     if queued:
+        _seed_fresh_rx(poller)
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         poller._queue.put_ordered(command(), future=future)  # noqa: SLF001
         poller.start()
@@ -3589,6 +3606,7 @@ async def test_queued_core_timeout_emits_timed_out_lifecycle_and_expires_overlay
         radio_state=state,
         state_store=store,
     )
+    _seed_fresh_rx(poller)
 
     await service.execute(
         command_intent_from_request(


### PR DESCRIPTION
## Summary

- seed fresh, current-generation RX authority in exactly the four legacy queued-DEFER fixture cases
- keep scheduler ordering, mutation rejection, and timeout lifecycle assertions unchanged
- preserve UNKNOWN fail-closed production behavior; this PR changes no product source

Linear: [MOR-1760](https://linear.app/rigplane/issue/MOR-1760)

## Red-first evidence

When stacked with MOR-1759 before this fixture prerequisite, the four legacy cases failed because DEFER commands correctly observed UNKNOWN instead of the previously implicit RX assumption. The fixture change supplies explicit RX through the existing StateStore observation seam.

## Verification

- affected base selectors: 6 passed
- same selectors stacked with MOR-1759 product source: 6 passed
- stacked policy/poller/command-service/coverage: 378 passed
- full non-integration on exact head: 10,149 passed, 74 skipped, 112 deselected, 14 xfailed, 1 xpassed
- Ruff check + format on owned file: pass
- import-linter: 5/5 contracts kept
- diff-check, one-file/120-LOC guard, privacy scan: pass
- global Ruff format baseline reports four pre-existing out-of-scope files; no owned-file formatting issue
- direct mypy on the large coverage test file reports pre-existing test-suite typing debt; no new typed production code

## Scope

- 1 file
- 18 changed LOC
- no runtime, radio, transport, or TX behavior changes