### PR TITLE
MOR-1762: retire held Yaesu commands at lifecycle boundaries

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -125,6 +125,9 @@ class YaesuCatPoller:
         self._pending_receiver_select: CommandQueueEntry | None = None
         self._deferred_tx_lane = DeferredTxCommandLane()
         self._deferred_tx_entry: CommandQueueEntry | None = None
+        self._deferred_tx_generation: (
+            tuple[tuple[str | None, int], int | None] | None
+        ) = None
 
     def bind_provider_generation(
         self,
@@ -132,6 +135,8 @@ class YaesuCatPoller:
         capture: Callable[[], int],
         advance: Callable[[], int] | None = None,
     ) -> None:
+        if self._capture_provider_generation is not None:
+            self._cancel_deferred_entry("provider binding replaced")
         self._capture_provider_generation = capture
         self._advance_provider_generation = advance
 
@@ -216,6 +221,7 @@ class YaesuCatPoller:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
+        self._cancel_deferred_entry("poller stopped")
         logger.info("YaesuCatPoller: stopped")
 
     async def pause(self) -> None:
@@ -303,6 +309,7 @@ class YaesuCatPoller:
     def _sync_tx_target_generation(self) -> tuple[str | None, int]:
         generation = self._current_tx_target_generation()
         if generation != self._tx_target_generation:
+            self._cancel_deferred_entry("connection generation changed")
             self._invalidate_ptt_observation()
             self._invalidate_tx_target()
         return generation
@@ -483,6 +490,7 @@ class YaesuCatPoller:
             return  # Another loop is already reconnecting
 
         self._reconnecting = True
+        self._cancel_deferred_entry("serial reconnect")
         advance = self._advance_provider_generation
         provider_generation = None if advance is None else advance()
         try:
@@ -561,6 +569,9 @@ class YaesuCatPoller:
         if self._command_queue is None:
             return
 
+        boundary = self._deferred_generation_change()
+        if boundary is not None:
+            self._cancel_deferred_entry(boundary)
         now = time.monotonic()
         transition = self._deferred_tx_lane.observe(
             rf_state=self._current_rf_state(), now=now
@@ -571,6 +582,7 @@ class YaesuCatPoller:
             and transition.outcome is not TxInterlockDeferredOutcome.HELD
         ):
             entry, self._deferred_tx_entry = self._deferred_tx_entry, None
+            self._deferred_tx_generation = None
             if entry is not None:
                 if transition.outcome is TxInterlockDeferredOutcome.RELEASED:
                     entries.append(entry)
@@ -596,6 +608,14 @@ class YaesuCatPoller:
             ):
                 transition = self._deferred_tx_lane.defer(cmd, now=now)
                 previous, self._deferred_tx_entry = self._deferred_tx_entry, entry
+                if (
+                    previous is None
+                    or transition.outcome is TxInterlockDeferredOutcome.EXPIRED
+                ):
+                    self._deferred_tx_generation = (
+                        self._current_tx_target_generation(),
+                        self._captured_provider_generation(),
+                    )
                 if previous is not None:
                     self._finish_deferred_entry(
                         previous,
@@ -623,6 +643,31 @@ class YaesuCatPoller:
                     type(cmd).__name__,
                     exc_info=True,
                 )
+
+    def _deferred_generation_change(self) -> str | None:
+        generation = self._deferred_tx_generation
+        if generation is None:
+            return None
+        connection, provider = generation
+        if connection != self._current_tx_target_generation():
+            return "connection generation changed"
+        if provider != self._captured_provider_generation():
+            return "provider generation changed"
+        return None
+
+    def _cancel_deferred_entry(self, reason: str) -> None:
+        entry = self._deferred_tx_entry
+        (
+            self._deferred_tx_entry,
+            self._deferred_tx_generation,
+            self._deferred_tx_lane,
+        ) = (None, None, DeferredTxCommandLane())
+        if entry is None:
+            return
+        error = CommandError(f"deferred command cancelled: {reason}")
+        self._mark_queued_command_failed(entry, error)
+        if entry.future is not None and not entry.future.done():
+            entry.future.set_exception(error)
 
     @classmethod
     def _finish_deferred_entry(cls, entry: Any, *, superseded: bool) -> None:

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -722,6 +722,76 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("boundary", "reason"),
+    (
+        ("stop", "stopped"),
+        ("reconnect", "serial reconnect"),
+        ("provider-generation", "provider generation changed"),
+        ("provider-replacement", "provider binding replaced"),
+        ("connection-generation", "connection generation changed"),
+    ),
+)
+async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+    reason: str,
+) -> None:
+    clock = [10.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    radio, queue, store = _tx_target_radio(), CommandQueue(), StateStore()
+    radio.set_freq = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    poller.bind_provider_generation(
+        capture=lambda: store.provider_generation,
+        advance=store.begin_provider_generation,
+    )
+    future = asyncio.get_running_loop().create_future()
+    service = MagicMock()
+    queue.put_ordered(
+        SetFreq(7_100_000),
+        future=future,
+        command_id="held",
+        source="websocket",
+        command_service=service,
+    )
+    _set_fresh_ptt_observation(poller, active=True)
+    await poller._drain_commands()  # noqa: SLF001
+    assert not future.done()
+
+    if boundary == "stop":
+        await poller.stop()
+    elif boundary == "reconnect":
+        radio._transport._maybe_reconnect_needed = lambda: True
+        await poller._try_reconnect()  # noqa: SLF001
+    elif boundary == "provider-generation":
+        store.begin_provider_generation()
+    elif boundary == "provider-replacement":
+        poller.bind_provider_generation(capture=lambda: 1)
+    else:
+        radio._transport.stats.reconnects += 1
+        poller._sync_tx_target_generation()  # noqa: SLF001
+    await poller._drain_commands()  # noqa: SLF001
+
+    error = future.exception()
+    assert isinstance(error, CommandError)
+    assert reason in str(error)
+    assert service.fail_command.call_args.kwargs["timed_out"] is False
+    assert poller._deferred_tx_entry is None  # noqa: SLF001
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+
+    clock[0] = 10.5
+    _set_fresh_ptt_observation(poller, active=False)
+    await poller._drain_commands()  # noqa: SLF001
+    clock[0] = 11.5
+    _set_fresh_ptt_observation(poller, active=False)
+    await poller._drain_commands()  # noqa: SLF001
+    radio.set_freq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_yaesu_unhandled_always_pass_command_fails_truthfully() -> None:
     from rigplane.runtime._poller_types import ScanStop
 


### PR DESCRIPTION
Linear: MOR-1762

## Summary
- atomically retire the Yaesu deferred lane entry on stop, serial reconnect, provider binding replacement, and provider/connection generation changes
- complete the held future exceptionally and terminate pending lifecycle/overlay state with a boundary-specific reason
- prevent fresh RX from a replacement authority from executing a stale held command

## Red-first evidence
- exact base `cdf3da33b879fcac81c9f656602522e9f21eb8e4`
- lifecycle-boundary matrix: 5 failed / 89 deselected
- every boundary left the future pending and the deferred lane live

## Verification
- `uv run pytest tests/test_yaesu_cat_poller.py -q --tb=short` — 94 passed
- focused Yaesu/FTX/interlock matrix — 578 passed
- `uv run pytest tests/ -q --tb=short --ignore=tests/integration` — 9999 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- full Ruff and format check — pass (674 files formatted)
- owned mypy — pass
- import boundaries — 5 contracts kept
- diff check and privacy scan — pass

## Scope
- exactly 2 files, 115 changed LOC
- no shared policy, profile, Web, public API, protocol, hardware, runtime process, serial, radio, PTT, TUNE, TX, or keying operations

Fresh independent exact-head Agent Review is required before merge.