### PR TITLE
MOR-1761: enforce rigctld hard-blocks from canonical RF truth

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -644,14 +644,9 @@ class RigctldHandler:
         self._routing = create_routing(
             radio, self._cache, getattr(config, "max_power_w", 100.0)
         )
-        radio_state_store = (
-            radio.state_store if isinstance(radio, StateStoreCapable) else None
-        )
-        if state_store is None:
-            state_store = radio_state_store
-        self._has_canonical_state_store = (
-            isinstance(state_store, StateStore) and state_store is radio_state_store
-        )
+        if state_store is None and isinstance(radio, StateStoreCapable):
+            state_store = radio.state_store
+        self._has_canonical_state_store = isinstance(state_store, StateStore)
         if not isinstance(state_store, StateStore):
             # Non-canonical, non-decaying fallback (MOR-432): used only when the
             # radio exposes no StateStore. Freshness decay requires a wired,
@@ -705,7 +700,7 @@ class RigctldHandler:
             or field.last_observed_monotonic < 0
             or snapshot.generated_at_monotonic < field.last_observed_monotonic
             or snapshot.generated_at_monotonic - field.last_observed_monotonic
-            > field.max_age
+            >= field.max_age
             or type(snapshot.provider_generation) is not int
             or type(field.provider_generation) is not int
             or snapshot.provider_generation < 0

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections.abc import Callable, Sequence
 from contextvars import ContextVar
@@ -415,9 +416,13 @@ class _RigctldCommandExecutor:
     handler: "RigctldHandler"
 
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
-        # B4-a establishes the exhaustive policy seam only. B4-b consumes this
-        # result to enforce BLOCK/DEFER; wire behavior remains unchanged here.
-        _classify_rigctld_tx_intent(intent)
+        classification = _classify_rigctld_tx_intent(intent)
+        if (
+            classification.disposition is TxInterlockDisposition.BLOCK
+            and self.handler._has_canonical_state_store
+            and self.handler._resolve_rigctld_rf_state() is not tx_interlock.RfState.RX
+        ):
+            raise _RigctldCommandFailure(HamlibError.ERJCTED)
         params = intent.params
         if intent.name == "set_freq":
             await self.handler._radio.set_freq(
@@ -641,6 +646,7 @@ class RigctldHandler:
         )
         if state_store is None and isinstance(radio, StateStoreCapable):
             state_store = radio.state_store
+        self._has_canonical_state_store = isinstance(state_store, StateStore)
         if not isinstance(state_store, StateStore):
             # Non-canonical, non-decaying fallback (MOR-432): used only when the
             # radio exposes no StateStore. Freshness decay requires a wired,
@@ -667,6 +673,41 @@ class RigctldHandler:
     def bind_provider_generation(self, capture: Callable[[], int]) -> None:
         """Bind the server-owned provider token capture for request ingress."""
         self._provider_generation_capture = capture
+
+    def _resolve_rigctld_rf_state(self) -> tx_interlock.RfState:
+        """Resolve strict, generation-bound RF truth for hard-block writes."""
+        snapshot = self._state_store.snapshot()
+        try:
+            field = snapshot.field(FieldPath.global_("tx_state", "ptt"))
+        except KeyError:
+            return tx_interlock.RfState.UNKNOWN
+        values = (
+            snapshot.generated_at_monotonic,
+            field.last_observed_monotonic,
+            field.max_age,
+        )
+        if (
+            field.freshness is not FreshnessState.FRESH
+            or type(field.value) is not bool
+            or any(
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(value)
+                for value in values
+            )
+            or field.max_age is None
+            or field.max_age <= 0
+            or field.last_observed_monotonic < 0
+            or snapshot.generated_at_monotonic < field.last_observed_monotonic
+            or snapshot.generated_at_monotonic - field.last_observed_monotonic
+            > field.max_age
+            or type(snapshot.provider_generation) is not int
+            or type(field.provider_generation) is not int
+            or snapshot.provider_generation < 0
+            or field.provider_generation != snapshot.provider_generation
+        ):
+            return tx_interlock.RfState.UNKNOWN
+        return tx_interlock.RfState.TX if field.value else tx_interlock.RfState.RX
 
     def _packet_data_mode_value(self) -> int | bool:
         value = self._config.wsjtx_data_mode

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -644,9 +644,14 @@ class RigctldHandler:
         self._routing = create_routing(
             radio, self._cache, getattr(config, "max_power_w", 100.0)
         )
-        if state_store is None and isinstance(radio, StateStoreCapable):
-            state_store = radio.state_store
-        self._has_canonical_state_store = isinstance(state_store, StateStore)
+        radio_state_store = (
+            radio.state_store if isinstance(radio, StateStoreCapable) else None
+        )
+        if state_store is None:
+            state_store = radio_state_store
+        self._has_canonical_state_store = (
+            isinstance(state_store, StateStore) and state_store is radio_state_store
+        )
         if not isinstance(state_store, StateStore):
             # Non-canonical, non-decaying fallback (MOR-432): used only when the
             # radio exposes no StateStore. Freshness decay requires a wired,

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -145,8 +145,16 @@ def _store(case: str) -> tuple[StateStore, object | None]:
             path=_PTT,
             value=1 if case == "value" else case == "tx",
             source=SourceMetadata(source="test", provider="tests"),
-            timestamp_monotonic=float("nan") if case == "timestamp" else 9.0,
-            max_age=float("inf") if case == "max-age" else 2.0,
+            timestamp_monotonic=(
+                float("nan")
+                if case == "timestamp"
+                else 11.0
+                if case == "future"
+                else 9.0
+            ),
+            max_age={"before": 1.1, "exact": 1.0, "after": 0.9}.get(
+                case, float("inf") if case == "max-age" else 2.0
+            ),
         )
     )
     if case == "stale":
@@ -159,9 +167,14 @@ def _store(case: str) -> tuple[StateStore, object | None]:
     return store, None
 
 
-def _handler(store: StateStore) -> tuple[RigctldHandler, AsyncMock, Mock]:
+def _handler(
+    store: StateStore, *, public_store: bool = True
+) -> tuple[RigctldHandler, AsyncMock, Mock]:
     radio = AsyncMock()
-    radio.state_store = store
+    if public_store:
+        radio.state_store = store
+    else:
+        del radio.state_store
     routing = Mock()
     routing.set_func = AsyncMock(return_value=RigctldResponse())
     routing.set_level = AsyncMock(return_value=RigctldResponse())
@@ -181,11 +194,14 @@ def _attempt(radio: AsyncMock, routing: Mock, wire: bytes) -> AsyncMock:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("case", ["tx", "absent", "stale", "generation"])
 @pytest.mark.parametrize("wire", _BLOCK_WIRES)
+@pytest.mark.parametrize(
+    "public_store", [True, False], ids=["radio-store", "server-store"]
+)
 async def test_hard_blocks_require_fresh_known_rx(
-    case: str, wire: bytes, monkeypatch: pytest.MonkeyPatch
+    case: str, wire: bytes, public_store: bool, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, forced = _store(case)
-    handler, radio, routing = _handler(store)
+    handler, radio, routing = _handler(store, public_store=public_store)
     if forced is not None:
         monkeypatch.setattr(StateStore, "snapshot", lambda _: forced)
     command = parse_line(wire)
@@ -206,10 +222,22 @@ async def test_hard_blocks_dispatch_once_with_fresh_rx(wire: bytes) -> None:
         radio._send_civ_raw.assert_awaited_once_with(b"\xfe\xfe\x98\xe0\x03\xfd")
 
 
-@pytest.mark.parametrize("case", ["value", "timestamp", "max-age"])
-def test_rf_truth_rejects_malformed_samples(case: str) -> None:
-    handler, _, _ = _handler(_store(case)[0])
-    assert handler._resolve_rigctld_rf_state() is RfState.UNKNOWN  # noqa: SLF001
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [("before", RfState.RX)]
+    + [
+        (case, RfState.UNKNOWN)
+        for case in ("exact", "after", "future", "timestamp", "max-age", "generation")
+    ],
+)
+def test_rf_truth_enforces_strict_age_and_shape(
+    case: str, expected: RfState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, forced = _store(case)
+    handler, _, _ = _handler(store)
+    if forced is not None:
+        monkeypatch.setattr(StateStore, "snapshot", lambda _: forced)
+    assert handler._resolve_rigctld_rf_state() is expected  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -22,8 +22,7 @@ from rigplane.rigctld.contract import (
 )
 from rigplane.rigctld.handler import RigctldHandler, _classify_rigctld_tx_intent
 from rigplane.rigctld.protocol import format_response, parse_line
-from rigplane.runtime import _poller_types as commands
-from rigplane.runtime.tx_interlock import RfState
+from rigplane.runtime import _poller_types as commands, tx_interlock
 
 
 def _intent(name: str, **params: object) -> CommandIntent:
@@ -131,7 +130,6 @@ def test_non_writes_and_future_material_intents_fail_closed() -> None:
             )
 
 
-_PTT = FieldPath.global_("tx_state", "ptt")
 _BLOCK_WIRES = (b"T 1", b"U TUNER 1", b"w FE FE 98 E0 03 FD")
 
 
@@ -142,15 +140,11 @@ def _store(case: str) -> tuple[StateStore, object | None]:
         return store, None
     store.apply(
         Observation(
-            path=_PTT,
+            path=FieldPath.global_("tx_state", "ptt"),
             value=1 if case == "value" else case == "tx",
             source=SourceMetadata(source="test", provider="tests"),
-            timestamp_monotonic=(
-                float("nan")
-                if case == "timestamp"
-                else 11.0
-                if case == "future"
-                else 9.0
+            timestamp_monotonic={"timestamp": float("nan"), "future": 11.0}.get(
+                case, 9.0
             ),
             max_age={"before": 1.1, "exact": 1.0, "after": 0.9}.get(
                 case, float("inf") if case == "max-age" else 2.0
@@ -167,9 +161,7 @@ def _store(case: str) -> tuple[StateStore, object | None]:
     return store, None
 
 
-def _handler(
-    store: StateStore, *, public_store: bool = True
-) -> tuple[RigctldHandler, AsyncMock, Mock]:
+def _handler(store: StateStore, *, public_store: bool = True):
     radio = AsyncMock()
     if public_store:
         radio.state_store = store
@@ -224,14 +216,14 @@ async def test_hard_blocks_dispatch_once_with_fresh_rx(wire: bytes) -> None:
 
 @pytest.mark.parametrize(
     ("case", "expected"),
-    [("before", RfState.RX)]
+    [("before", tx_interlock.RfState.RX)]
     + [
-        (case, RfState.UNKNOWN)
+        (case, tx_interlock.RfState.UNKNOWN)
         for case in ("exact", "after", "future", "timestamp", "max-age", "generation")
     ],
 )
 def test_rf_truth_enforces_strict_age_and_shape(
-    case: str, expected: RfState, monkeypatch: pytest.MonkeyPatch
+    case: str, expected: tx_interlock.RfState, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, forced = _store(case)
     handler, _, _ = _handler(store)

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -161,6 +161,7 @@ def _store(case: str) -> tuple[StateStore, object | None]:
 
 def _handler(store: StateStore) -> tuple[RigctldHandler, AsyncMock, Mock]:
     radio = AsyncMock()
+    radio.state_store = store
     routing = Mock()
     routing.set_func = AsyncMock(return_value=RigctldResponse())
     routing.set_level = AsyncMock(return_value=RigctldResponse())

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -1,13 +1,29 @@
 """Rigctld write-intent coverage for the shared TX interlock policy."""
 
+from dataclasses import replace
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
-from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore
 from rigplane.core.tx_interlock_contract import TxInterlockDisposition
-from rigplane.rigctld.contract import COMMAND_TABLE, ClientSession, RigctldResponse
-from rigplane.rigctld.handler import _classify_rigctld_tx_intent
+from rigplane.rigctld.contract import (
+    COMMAND_TABLE,
+    ClientSession,
+    HamlibError,
+    RigctldConfig,
+    RigctldResponse,
+)
+from rigplane.rigctld.handler import RigctldHandler, _classify_rigctld_tx_intent
 from rigplane.rigctld.protocol import format_response, parse_line
 from rigplane.runtime import _poller_types as commands
+from rigplane.runtime.tx_interlock import RfState
 
 
 def _intent(name: str, **params: object) -> CommandIntent:
@@ -113,3 +129,109 @@ def test_non_writes_and_future_material_intents_fail_closed() -> None:
             _classify_rigctld_tx_intent(
                 _intent(name, level=key, func=key, value=1, on=True)
             )
+
+
+_PTT = FieldPath.global_("tx_state", "ptt")
+_BLOCK_WIRES = (b"T 1", b"U TUNER 1", b"w FE FE 98 E0 03 FD")
+
+
+def _store(case: str) -> tuple[StateStore, object | None]:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    if case == "absent":
+        return store, None
+    store.apply(
+        Observation(
+            path=_PTT,
+            value=1 if case == "value" else case == "tx",
+            source=SourceMetadata(source="test", provider="tests"),
+            timestamp_monotonic=float("nan") if case == "timestamp" else 9.0,
+            max_age=float("inf") if case == "max-age" else 2.0,
+        )
+    )
+    if case == "stale":
+        clock.advance(2.1)
+    snapshot = store.snapshot()
+    if case == "generation":
+        field = replace(snapshot.fields[0], provider_generation=1)
+        snapshot = replace(snapshot, fields=(field,))
+        return store, snapshot
+    return store, None
+
+
+def _handler(store: StateStore) -> tuple[RigctldHandler, AsyncMock, Mock]:
+    radio = AsyncMock()
+    routing = Mock()
+    routing.set_func = AsyncMock(return_value=RigctldResponse())
+    routing.set_level = AsyncMock(return_value=RigctldResponse())
+    radio.rigctld_routing = Mock(return_value=routing)
+    radio._send_civ_raw = AsyncMock(return_value=None)
+    return RigctldHandler(radio, RigctldConfig(), state_store=store), radio, routing
+
+
+def _attempt(radio: AsyncMock, routing: Mock, wire: bytes) -> AsyncMock:
+    if wire.startswith(b"T"):
+        return radio.set_ptt
+    if wire.startswith(b"U"):
+        return routing.set_func
+    return radio._send_civ_raw
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ["tx", "absent", "stale", "generation"])
+@pytest.mark.parametrize("wire", _BLOCK_WIRES)
+async def test_hard_blocks_require_fresh_known_rx(
+    case: str, wire: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, forced = _store(case)
+    handler, radio, routing = _handler(store)
+    if forced is not None:
+        monkeypatch.setattr(StateStore, "snapshot", lambda _: forced)
+    command = parse_line(wire)
+    response = await handler.execute(command)
+    assert response.error is HamlibError.ERJCTED
+    assert format_response(command, response, ClientSession()) == b"RPRT -9\n"
+    _attempt(radio, routing, wire).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wire", _BLOCK_WIRES)
+async def test_hard_blocks_dispatch_once_with_fresh_rx(wire: bytes) -> None:
+    handler, radio, routing = _handler(_store("rx")[0])
+    response = await handler.execute(parse_line(wire))
+    assert response.ok
+    _attempt(radio, routing, wire).assert_awaited_once()
+    if wire.startswith(b"w"):
+        radio._send_civ_raw.assert_awaited_once_with(b"\xfe\xfe\x98\xe0\x03\xfd")
+
+
+@pytest.mark.parametrize("case", ["value", "timestamp", "max-age"])
+def test_rf_truth_rejects_malformed_samples(case: str) -> None:
+    handler, _, _ = _handler(_store(case)[0])
+    assert handler._resolve_rigctld_rf_state() is RfState.UNKNOWN  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ["tx", "rx", "absent", "stale", "generation"])
+async def test_non_block_dispositions_never_resolve_rf_truth(
+    case: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler, radio, routing = _handler(_store(case)[0])
+    resolver = Mock(side_effect=AssertionError("RF truth inspected"))
+    monkeypatch.setattr(handler, "_resolve_rigctld_rf_state", resolver)
+    for wire in (
+        b"T 0",
+        b"U TUNER 0",
+        b"F 1",
+        b"M USB 2400",
+        b"V VFOA",
+        b"S 1 VFOA",
+        b"L AF 0.5",
+    ):
+        assert (await handler.execute(parse_line(wire))).ok
+    for intent in (_intent("set_rit", hz=1), _intent("set_xit", hz=1)):
+        await handler._command_service.execute(intent)  # noqa: SLF001
+    resolver.assert_not_called()
+    radio.set_ptt.assert_awaited_once_with(False)
+    routing.set_func.assert_awaited_once_with("TUNER", False, vfo=None)


### PR DESCRIPTION
Linear: [MOR-1761](https://linear.app/morozsm/issue/MOR-1761/mor-1500-b4-b-enforce-rigctld-hard-blocks-from-canonical-rf-truth)

## Summary

- enforce B4-a BLOCK dispositions before any radio, routing, or raw CI-V dispatch
- resolve RF truth from the canonical StateStore injected at the rigctld execution seat
- treat radio-owned and server-owned stores as authoritative regardless of public radio capability
- fail closed on absent, stale, malformed, expired, future, or provider-generation-mismatched truth
- use an exclusive expiry boundary: age equal to max_age is UNKNOWN
- preserve ALWAYS_PASS, TX_SAFE, and DEFER behavior without RF-state inspection

## Acceptance evidence

- original RED-first witness: 16 failed, 8 passed
- remediation RED witness at commit 77330c32: 13 failed, 31 passed; server-owned-store bypass and exact-expiry acceptance reproduced
- focused exact head: 44 passed
- rigctld, policy, and Yaesu relevant exact head: 812 passed
- serial injected-store smoke: 1 passed
- full non-integration exact head: 10043 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff and format: pass
- import contracts: 5 kept, 0 broken
- mypy exact base/head parity: identical 12 pre-existing errors in 3 unrelated files; no new errors
- git diff --check and public/private-boundary scan: pass

## Scope

Exactly two files, 198 changed LOC:

- src/rigplane/rigctld/handler.py
- tests/test_rigctld_tx_interlock.py

MOR-1765 / PR #2719 supplies the merged explicit-RX legacy serial fixture prerequisite. Its file is absent from this PR diff.

No runtime, bench, serial hardware, radio, PTT, TUNE, keying, or TX operation was performed.
