### PR TITLE
MOR-1764: emit Yaesu deferred hold lifecycle details

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -607,6 +607,9 @@ class YaesuCatPoller:
                 and rf_state is RfState.TX
             ):
                 transition = self._deferred_tx_lane.defer(cmd, now=now)
+                held = self._deferred_tx_lane.observe(rf_state=RfState.TX, now=now)
+                if held is None:
+                    raise RuntimeError("deferred command lane lost its replacement")
                 previous, self._deferred_tx_entry = self._deferred_tx_entry, entry
                 if (
                     previous is None
@@ -623,6 +626,7 @@ class YaesuCatPoller:
                             transition.outcome is TxInterlockDeferredOutcome.SUPERSEDED
                         ),
                     )
+                self._emit_deferred_entry_held(entry, expires_at=held.expires_at)
                 continue
             try:
                 if (
@@ -699,6 +703,25 @@ class YaesuCatPoller:
             cls._mark_queued_command_failed(entry, error)
         if entry.future is not None and not entry.future.done():
             entry.future.set_exception(error)
+
+    @staticmethod
+    def _emit_deferred_entry_held(entry: Any, *, expires_at: float) -> None:
+        if entry.command_service is None or entry.command_id is None:
+            return
+        entry.command_service.emit_lifecycle(
+            CommandIntent(
+                id=entry.command_id,
+                name="queued_completion",
+                params={},
+                source=entry.source or "internal_policy",
+            ),
+            "queued",
+            details={
+                "heldBy": "tx_interlock",
+                "reason": "tx_active",
+                "expiresAt": expires_at,
+            },
+        )
 
     @staticmethod
     def _mark_queued_command_failed(entry: Any, exc: BaseException) -> None:

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -49,7 +49,7 @@ from .transport import CatTimeoutError
 if TYPE_CHECKING:
     from ..._poller_types import CommandQueue, CommandQueueEntry
     from ...radio_state import RadioState
-    from ...core.state_pipeline_contracts import Observation
+    from ...core.state_pipeline_contracts import CommandSource, Observation
     from .radio import YaesuCatRadio
 
 __all__ = ["YaesuCatPoller"]
@@ -705,10 +705,12 @@ class YaesuCatPoller:
             entry.future.set_exception(error)
 
     @staticmethod
-    def _emit_deferred_entry_held(entry: Any, *, expires_at: float) -> None:
+    def _emit_deferred_entry_held(
+        entry: CommandQueueEntry, *, expires_at: float
+    ) -> None:
         if entry.command_service is None or entry.command_id is None:
             return
-        source = entry.source or "internal_policy"
+        source: CommandSource = entry.source or "internal_policy"
         params = {} if entry.session_id is None else {"session_id": entry.session_id}
         target = None
         events = entry.command_service.lifecycle_events()

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -708,12 +708,26 @@ class YaesuCatPoller:
     def _emit_deferred_entry_held(entry: Any, *, expires_at: float) -> None:
         if entry.command_service is None or entry.command_id is None:
             return
+        source = entry.source or "internal_policy"
+        params = {} if entry.session_id is None else {"session_id": entry.session_id}
+        target = None
+        events = entry.command_service.lifecycle_events()
+        if isinstance(events, Sequence):
+            for event in reversed(events):
+                if (
+                    event.command_id == entry.command_id
+                    and event.source == source
+                    and (event.details or {}).get("session_id") == entry.session_id
+                ):
+                    target = event.target
+                    break
         entry.command_service.emit_lifecycle(
             CommandIntent(
                 id=entry.command_id,
                 name="queued_completion",
-                params={},
-                source=entry.source or "internal_policy",
+                params=params,
+                source=source,
+                target=target,
             ),
             "queued",
             details={

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -699,6 +699,53 @@ async def test_yaesu_deferred_command_emits_held_lifecycle_once(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("source", "expected_session"),
+    (("websocket", "ws-ftx1"), ("http", None)),
+)
+async def test_ftx1_web_deferred_hold_preserves_ingress_lifecycle_context(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    expected_session: str | None,
+) -> None:
+    clock = [10.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    monkeypatch.setattr(
+        "rigplane.core.command_service.time.monotonic", lambda: clock[0]
+    )
+    radio, handler, poller, _store, _accept = _real_ftx1_control_path()
+    service = handler._command_service  # noqa: SLF001
+    params = {"freq": 7_100_000, "receiver": 1}
+    original_params = dict(params)
+
+    await handler._enqueue_command(  # noqa: SLF001
+        "set_freq", params, command_id=f"held-{source}", source=source
+    )
+    ingress = service.lifecycle_events()[0]
+    assert params == original_params
+    await _drain_with_ptt(poller, clock, 10.0, True)
+
+    held = service.lifecycle_events()[-1]
+    expected_details = {
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": 13.0,
+    }
+    if expected_session is not None:
+        expected_details["session_id"] = expected_session
+    assert (held.command_id, held.state, held.source, held.target) == (
+        ingress.command_id,
+        "queued",
+        ingress.source,
+        ingress.target,
+    )
+    assert held.details == expected_details
+    radio._transport.write.assert_not_awaited()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("replacement_at", "terminal_state", "replacement_expiry"),
     ((22.5, "superseded", 23.0), (23.0, "timed_out", 26.0)),
 )

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -676,9 +676,7 @@ async def test_yaesu_deferred_command_emits_held_lifecycle_once(
         executor=MagicMock(), state_store=StateStore(), clock=lambda: clock[0]
     )
     poller = YaesuCatPoller(radio, command_queue=queue)
-    queue.put_ordered(
-        SetFreq(7_100_000), command_id="held", command_service=service
-    )
+    queue.put_ordered(SetFreq(7_100_000), command_id="held", command_service=service)
 
     await _drain_with_ptt(poller, clock, 10.0, True)
     event = service.lifecycle_events()[0]
@@ -785,6 +783,7 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
     radio, queue = make_radio(), CommandQueue()
     radio.set_freq = AsyncMock()
     poller = YaesuCatPoller(radio, command_queue=queue)
+    service = MagicMock()
     if knownness == "stale":
         _set_fresh_ptt_observation(poller, active=True)
         poller._ptt_observation = _ptt_observation(True, observed_at=28.0)  # noqa: SLF001
@@ -797,13 +796,19 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
             provider_generation=1,
         )
     future = asyncio.get_running_loop().create_future()
-    queue.put_ordered(SetFreq(7_100_000), future=future)
+    queue.put_ordered(
+        SetFreq(7_100_000),
+        future=future,
+        command_id="unknown",
+        command_service=service,
+    )
     await poller._drain_commands()  # noqa: SLF001
     error = future.exception()
     assert isinstance(error, CommandError)
     assert "unknown" in str(error)
     radio.set_freq.assert_not_awaited()
     assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+    service.emit_lifecycle.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, call as mock_call, patch
 
 import pytest
 
+from rigplane.core.command_service import CommandService
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import (
     FieldCapability,
@@ -660,6 +661,90 @@ async def test_yaesu_deferred_command_supersedes_without_extending_expiry(
     await _drain_with_ptt(poller, clock, 13.0, False)
     assert isinstance(second.exception(), TimeoutError)
     radio.set_freq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_deferred_command_emits_held_lifecycle_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [10.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    radio, queue = make_radio(), CommandQueue()
+    service = CommandService(
+        executor=MagicMock(), state_store=StateStore(), clock=lambda: clock[0]
+    )
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    queue.put_ordered(
+        SetFreq(7_100_000), command_id="held", command_service=service
+    )
+
+    await _drain_with_ptt(poller, clock, 10.0, True)
+    event = service.lifecycle_events()[0]
+    assert (event.command_id, event.state, event.timestamp_monotonic) == (
+        "held",
+        "queued",
+        10.0,
+    )
+    assert event.details == {
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": 13.0,
+    }
+
+    await _drain_with_ptt(poller, clock, 10.5, True)
+    await _drain_with_ptt(poller, clock, 10.75, False)
+    await _drain_with_ptt(poller, clock, 11.0, None)
+    assert service.lifecycle_events() == (event,)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("replacement_at", "terminal_state", "replacement_expiry"),
+    ((22.5, "superseded", 23.0), (23.0, "timed_out", 26.0)),
+)
+async def test_yaesu_deferred_replacement_lifecycle_preserves_deadline_truth(
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_at: float,
+    terminal_state: str,
+    replacement_expiry: float,
+) -> None:
+    clock = [20.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    radio, queue = make_radio(), CommandQueue()
+    service = CommandService(
+        executor=MagicMock(), state_store=StateStore(), clock=lambda: clock[0]
+    )
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    first = asyncio.get_running_loop().create_future()
+    queue.put_ordered(
+        SetFreq(7_100_000),
+        future=first,
+        command_id="first",
+        command_service=service,
+    )
+    await _drain_with_ptt(poller, clock, 20.0, True)
+    queue.put_ordered(
+        SetFreq(7_200_000), command_id="replacement", command_service=service
+    )
+    await _drain_with_ptt(poller, clock, replacement_at, True)
+
+    events = service.lifecycle_events()
+    assert [(event.command_id, event.state) for event in events] == [
+        ("first", "queued"),
+        ("first", terminal_state),
+        ("replacement", "queued"),
+    ]
+    assert events[-1].timestamp_monotonic == replacement_at
+    assert events[-1].details == {
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": replacement_expiry,
+    }
+    assert first.exception() is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- emit one truthful additional `queued` lifecycle event when a Yaesu/FTX-1 command actually enters the shared TX-interlock deferred lane
- report exact held details with the lane's absolute monotonic deadline
- preserve lifecycle ordering and original TTL across supersession, while starting a fresh deadline after expiry
- pin no-reemission and fail-closed UNKNOWN/stale/generation-mismatch behavior with deterministic tests

## Lifecycle contract

```json
{
  "heldBy": "tx_interlock",
  "reason": "tx_active",
  "expiresAt": "<absolute monotonic float>"
}
```

The event timestamp and `expiresAt` use the same injected monotonic clock. No schema, UI, profile-policy, delayed-readback, backend command, or public API changes are included.

## Red-first evidence

On exact base `bd0b9c7c451ed0c8c1bdf7c5c6aa4363b268c985`, the three new focused witnesses failed because no held lifecycle event existed.

## Validation

- `uv run pytest -q tests/test_yaesu_cat_poller.py` — 97 passed
- relevant Yaesu/FTX/interlock matrix — 594 passed
- full non-integration — 10002 passed, 13 skipped, 14 xfailed, 1 xpassed
- Ruff check/format — passed
- import-linter — 5 contracts kept
- owned mypy — passed
- diff-check, two-file/200-LOC scope, privacy scan — passed

Linear: [MOR-1764](https://linear.app/morozsm/issue/MOR-1764/mor-1500-b2-d2-emit-held-lifecycle-details-for-yaesu-deferred-commands)

Fresh independent exact-head review is required before merge.
