### PR TITLE
test(MOR-1763): seed RX in remaining Web fixtures

### DIFF
--- a/tests/test_civ_transaction_ownership.py
+++ b/tests/test_civ_transaction_ownership.py
@@ -11,6 +11,12 @@ import pytest
 from test_radio import MockTransport
 
 from rigplane import IC_7610_ADDR
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
 from rigplane.radio import IcomRadio
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.state_cache import StateCache
@@ -43,6 +49,19 @@ async def _wait_until(predicate: Callable[[], bool], *, timeout: float = 0.5) ->
             return
         await asyncio.sleep(0.005)
     assert predicate()
+
+
+def _seed_fresh_rx(store: StateStore) -> None:
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=False,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=store.snapshot().generated_at_monotonic,
+            max_age=5.0,
+            provider_generation=store.provider_generation,
+        )
+    )
 
 
 async def test_raw_transaction_holding_owner_blocks_competing_external_owner(
@@ -109,7 +128,11 @@ async def test_raw_transaction_quiesces_web_poller_and_defers_queue_until_releas
 ) -> None:
     queue = CommandQueue()
     queue.put_ordered(SetFreq(7_074_000))
-    poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+    store = StateStore()
+    poller = RadioPoller(
+        radio, StateCache(), queue, radio_state=RadioState(), state_store=store
+    )
+    _seed_fresh_rx(store)
     poller._execute = AsyncMock()  # noqa: SLF001
     poller._send_query = AsyncMock()  # noqa: SLF001
     poller._poll_unselected_slot = AsyncMock()  # noqa: SLF001

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -28,6 +28,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from serial_stub import SerialMockRadio
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.state_cache import StateCache
 from rigplane.scope import ScopeFrame
@@ -72,6 +78,19 @@ _requires_static_index = pytest.mark.skipif(
 def _addr(server: WebServer) -> tuple[str, int]:
     assert server._server is not None
     return server._server.sockets[0].getsockname()
+
+
+def _seed_fresh_rx(store: StateStore) -> None:
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=False,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=store.snapshot().generated_at_monotonic,
+            max_age=5.0,
+            provider_generation=store.provider_generation,
+        )
+    )
 
 
 def _ws_accept(key: str) -> str:
@@ -983,6 +1002,7 @@ class TestControlChannel:
     async def test_vfo_swap_command(
         self, server: WebServer, mock_radio: MagicMock
     ) -> None:
+        _seed_fresh_rx(server.command_state_store)
         host, port = _addr(server)
         reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws")
         try:
@@ -3301,6 +3321,7 @@ class TestRadioPoller:
         cache = StateCache()
         queue = CommandQueue()
         poller = RadioPoller(radio, cache, queue)
+        _seed_fresh_rx(poller._state_store)  # noqa: SLF001
 
         poller.start()
         queue.put(SetFreq(7074000))
@@ -3525,6 +3546,7 @@ class TestSwitchScopeReceiver:
         radio = self._make_radio()
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue)
+        _seed_fresh_rx(poller._state_store)  # noqa: SLF001
 
         poller.start()
         queue.put(SelectVfo("SUB"))
@@ -3595,6 +3617,7 @@ class TestSwitchScopeReceiver:
         radio.set_split = AsyncMock()
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+        _seed_fresh_rx(poller._state_store)  # noqa: SLF001
 
         poller.start()
         queue.put(SetSplit(True))
@@ -3631,6 +3654,7 @@ class TestSwitchScopeReceiver:
         radio.set_rit_tx_status = AsyncMock()
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+        _seed_fresh_rx(poller._state_store)  # noqa: SLF001
 
         poller.start()
         queue.put(SetRitTxStatus(True))
@@ -3649,6 +3673,7 @@ class TestSwitchScopeReceiver:
         radio.set_rit_frequency = AsyncMock()
         queue = CommandQueue()
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
+        _seed_fresh_rx(poller._state_store)  # noqa: SLF001
 
         poller.start()
         queue.put(SetRitFrequency(-200))


### PR DESCRIPTION
## Summary

- seed explicit fresh current-generation RX in the seven remaining legacy queued-DEFER fixtures
- preserve raw transaction quiescence and existing VFO/scope/split/RIT wire and state assertions
- change no product source or runtime behavior

Linear: [MOR-1763](https://linear.app/morozsm/issue/MOR-1763)

## Red-first evidence

With MOR-1759 stacked before this fixture prerequisite, exactly seven named tests failed because their implicit RX assumption now correctly resolves to UNKNOWN fail-closed. After the fixture update, all seven pass without weakening production policy.

## Verification

- exact seven selectors on base: 7 passed
- exact seven selectors stacked with MOR-1759: 7 passed
- complete owned modules on base: 203 passed, 2 skipped
- complete owned modules stacked: 203 passed, 2 skipped
- current-main stacked relevant suite: 679 passed, 2 skipped
- current-main stacked sequential full non-integration: 10,158 passed, 74 skipped, 112 deselected, 14 xfailed, 1 xpassed
- owned Ruff check and format: pass
- import-linter: 5/5 contracts kept
- diff-check, two-file/200-LOC guard, and privacy scan: pass

A parallel base/stacked stress run produced only unrelated port/timing interference in per-receiver/proxy tests; the affected modules passed in isolation, and the single sequential current-main stacked full gate above is green. Global Ruff format still reports the four pre-existing out-of-scope baseline files.

## Scope

- 2 test files
- 49 changed LOC
- no product, runtime, radio, transport, or TX changes