### PR TITLE
MOR-1765: seed canonical RX in serial rigctld smoke

### DIFF
--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -13,6 +13,11 @@ import pytest
 from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBackend
 from rigplane.audio_bridge import AudioBridge
 from rigplane.backends.icom7610 import Icom7610SerialRadio
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
 from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
@@ -322,6 +327,18 @@ async def test_rigctld_smoke_with_serial_mock_backend() -> None:
     await server.start()
     try:
         assert server._server is not None
+        assert server._state_store is not None
+        store = server._state_store
+        store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=False,
+                source=SourceMetadata(source="poll_response", provider="test"),
+                timestamp_monotonic=store.snapshot().generated_at_monotonic,
+                max_age=5.0,
+                provider_generation=store.provider_generation,
+            )
+        )
         host, port = _addr_from_asyncio_server(server._server)
         reader, writer = await asyncio.open_connection(host, port)
         try:


### PR DESCRIPTION
Linear: [MOR-1765](https://linear.app/morozsm/issue/MOR-1765/mor-1500-b4-b-prerequisite-seed-canonical-rx-in-serial-rigctld-smoke)

## Summary

- seed a fresh current-generation RX observation in the existing server-injected StateStore
- preserve the legacy serial rigctld smoke's successful PTT wire assertion
- change only test authority setup; no handler or product behavior is modified
- keep absent/UNKNOWN RF truth fail-closed for MOR-1761

## Evidence

- current-main smoke before fixture change: 1 passed
- stacked RED with unpushed MOR-1761 fixes and old fixture: RPRT -9 instead of legacy RPRT 0
- current-main smoke after fixture change: 1 passed
- stacked with MOR-1761 remediation: 1 passed
- relevant serial/rigctld/policy suite: 679 passed
- full non-integration suite: 9999 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff and format: pass
- import contracts: 5 kept, 0 broken
- full mypy: unchanged 12 pre-existing errors in 3 unrelated product files
- diff check and public/private-boundary scan: pass

## Scope

Exactly one test file, 17 changed LOC:

- tests/test_serial_backend_smoke.py

No runtime, bench, serial hardware, radio, PTT, TUNE, keying, or TX operation was performed.
