### PR TITLE
feat(MOR-1759): integrate Web deferred TX lane

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -110,8 +110,11 @@ from .._state_queries import build_state_queries
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..runtime.tx_interlock import (
+    DeferredTxCommandLane,
     RfState,
     TxInterlockCommandFamily,
+    TxInterlockDeferredOutcome,
+    TxInterlockDisposition,
     evaluate_tx_interlock,
     get_tx_interlock_command_family_metadata,
 )
@@ -706,13 +709,15 @@ class RadioPoller:
         # connect starts unarmed; overridable for tests.
         self._max_key_down_seconds: float = _MAX_KEY_DOWN_SECONDS
         self._max_key_down_timer: asyncio.TimerHandle | None = None
+        self._deferred_tx_lane = DeferredTxCommandLane()
+        self._deferred_tx_entry: CommandQueueEntry | None = None
 
     def _provider_generation(self) -> int:
         return cast(int, self._state_store.provider_generation)
 
-    def _current_rf_state(self) -> RfState:
+    def _current_rf_state(self, snapshot: StateSnapshot | None = None) -> RfState:
         """Return RF truth only from a fresh current-provider PTT observation."""
-        snapshot = self._state_store.snapshot()
+        snapshot = snapshot or self._state_store.snapshot()
         try:
             field = snapshot.field(_PTT_PATH)
         except KeyError:
@@ -731,11 +736,85 @@ class RadioPoller:
 
     def _enforce_tx_interlock(self, cmd: Command) -> None:
         metadata = get_tx_interlock_command_family_metadata(cmd)
-        if metadata is None or metadata.family not in _WEB_IMMEDIATE_BLOCK_FAMILIES:
+        if metadata is None or (
+            metadata.family not in _WEB_IMMEDIATE_BLOCK_FAMILIES
+            and metadata.base_disposition is not TxInterlockDisposition.DEFER
+        ):
             return
         decision = evaluate_tx_interlock(cmd, rf_state=self._current_rf_state())
         if not decision.allowed:
             raise CommandError(decision.reason)
+
+    @staticmethod
+    def _terminate_deferred_entry(
+        entry: CommandQueueEntry, outcome: TxInterlockDeferredOutcome
+    ) -> None:
+        if entry.future is not None and not entry.future.done():
+            entry.future.set_exception(
+                CommandError(f"deferred command {outcome.value}")
+            )
+
+    def _stage_tx_interlocked_entries(
+        self, entries: list[CommandQueueEntry]
+    ) -> list[CommandQueueEntry]:
+        """Stage DEFER entries before advancing the existing held slot."""
+        has_defer = self._deferred_tx_lane.pending is not None or any(
+            (metadata := get_tx_interlock_command_family_metadata(entry.command))
+            is not None
+            and metadata.base_disposition is TxInterlockDisposition.DEFER
+            for entry in entries
+        )
+        if not has_defer:
+            return entries
+
+        snapshot = self._state_store.snapshot()
+        now = snapshot.generated_at_monotonic
+        rf_state = self._current_rf_state(snapshot)
+        ready: list[CommandQueueEntry] = []
+        for entry in entries:
+            decision = evaluate_tx_interlock(entry.command, rf_state=rf_state)
+            if decision.disposition is not TxInterlockDisposition.DEFER:
+                ready.append(entry)
+                continue
+            if rf_state is RfState.UNKNOWN:
+                ready.append(entry)
+                continue
+            if decision.allowed and self._deferred_tx_lane.pending is None:
+                ready.append(entry)
+                continue
+            previous = self._deferred_tx_entry
+            result = self._deferred_tx_lane.defer(entry.command, now=now)
+            self._deferred_tx_entry = entry
+            if previous is not None and result.outcome in (
+                TxInterlockDeferredOutcome.EXPIRED,
+                TxInterlockDeferredOutcome.SUPERSEDED,
+            ):
+                self._terminate_deferred_entry(previous, result.outcome)
+
+        result = self._deferred_tx_lane.observe(rf_state=rf_state, now=now)
+        if result is None or result.outcome is TxInterlockDeferredOutcome.HELD:
+            return ready
+        held = self._deferred_tx_entry
+        self._deferred_tx_entry = None
+        if held is None:
+            return ready
+        if result.outcome is TxInterlockDeferredOutcome.RELEASED:
+            ready.append(held)
+        else:
+            self._terminate_deferred_entry(held, result.outcome)
+        return ready
+
+    async def _execute_queued_entry(self, entry: CommandQueueEntry) -> None:
+        self._enforce_tx_interlock(entry.command)
+        await self._execute(
+            entry.command,
+            command_id=entry.command_id,
+            source=entry.source or "websocket",
+            session_id=entry.session_id,
+            command_service=entry.command_service,
+        )
+        if entry.future is not None and not entry.future.done():
+            entry.future.set_result(None)
 
     def _relative_vfo_retention_policy(self) -> tuple[float, float]:
         """Derive a finite tuple window from this provider's expected cadence."""
@@ -1717,8 +1796,10 @@ class RadioPoller:
                     continue
 
                 # 1. Drain command queue (fire-and-forget writes)
-                if self._queue.has_commands:
-                    for entry in self._queue.drain_entries():
+                queued = self._queue.drain_entries() if self._queue.has_commands else []
+                ready = self._stage_tx_interlocked_entries(queued)
+                if ready:
+                    for entry in ready:
                         cmd = entry.command
                         if entry.future is not None and entry.future.cancelled():
                             logger.debug(
@@ -1727,16 +1808,7 @@ class RadioPoller:
                             )
                             continue
                         try:
-                            self._enforce_tx_interlock(cmd)
-                            await self._execute(
-                                cmd,
-                                command_id=entry.command_id,
-                                source=entry.source or "websocket",
-                                session_id=entry.session_id,
-                                command_service=entry.command_service,
-                            )
-                            if entry.future is not None and not entry.future.done():
-                                entry.future.set_result(None)
+                            await self._execute_queued_entry(entry)
                             _backoff = 0.0
                         except (TimeoutError, RigplaneTimeoutError) as exc:
                             self._mark_queued_command_failed(

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -783,25 +783,28 @@ class RadioPoller:
                 ready.append(entry)
                 continue
             previous = self._deferred_tx_entry
-            result = self._deferred_tx_lane.defer(entry.command, now=now)
+            defer_result = self._deferred_tx_lane.defer(entry.command, now=now)
             self._deferred_tx_entry = entry
-            if previous is not None and result.outcome in (
+            if previous is not None and defer_result.outcome in (
                 TxInterlockDeferredOutcome.EXPIRED,
                 TxInterlockDeferredOutcome.SUPERSEDED,
             ):
-                self._terminate_deferred_entry(previous, result.outcome)
+                self._terminate_deferred_entry(previous, defer_result.outcome)
 
-        result = self._deferred_tx_lane.observe(rf_state=rf_state, now=now)
-        if result is None or result.outcome is TxInterlockDeferredOutcome.HELD:
+        observe_result = self._deferred_tx_lane.observe(rf_state=rf_state, now=now)
+        if (
+            observe_result is None
+            or observe_result.outcome is TxInterlockDeferredOutcome.HELD
+        ):
             return ready
         held = self._deferred_tx_entry
         self._deferred_tx_entry = None
         if held is None:
             return ready
-        if result.outcome is TxInterlockDeferredOutcome.RELEASED:
+        if observe_result.outcome is TxInterlockDeferredOutcome.RELEASED:
             ready.append(held)
         else:
-            self._terminate_deferred_entry(held, result.outcome)
+            self._terminate_deferred_entry(held, observe_result.outcome)
         return ready
 
     async def _execute_queued_entry(self, entry: CommandQueueEntry) -> None:

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -19,10 +20,11 @@ from rigplane.runtime._poller_types import (
     ScanStop,
     SendCiv,
     SetAntenna1,
+    SetFreq,
     SetPowerstat,
     SetTunerStatus,
 )
-from rigplane.web.radio_poller import CommandQueue, RadioPoller
+from rigplane.web.radio_poller import CommandQueue, CommandQueueEntry, RadioPoller
 
 
 _PTT = FieldPath.global_("tx_state", "ptt")
@@ -36,6 +38,7 @@ def _radio() -> SimpleNamespace:
         scan_start=AsyncMock(),
         scan_stop=AsyncMock(),
         set_antenna_1=AsyncMock(),
+        set_freq=AsyncMock(),
         set_tuner_status=AsyncMock(),
         set_powerstat=AsyncMock(),
         set_ptt=AsyncMock(),
@@ -157,3 +160,70 @@ def test_manual_clock_ttl_generation_and_recovery() -> None:
     clock.advance(0.1)
     _observe_ptt(store, False, observed_at=clock.now())
     assert poller._current_rf_state().value == "rx"  # noqa: SLF001
+
+
+async def test_deferred_entry_releases_once_with_its_original_future() -> None:
+    clock = FreshnessClock(start=10.0)
+    radio, store, queue = _radio(), StateStore(freshness_clock=clock), CommandQueue()
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, queue, state_store=store)
+    _observe_ptt(store, True, observed_at=clock.now())
+    future = asyncio.get_running_loop().create_future()
+    entry = CommandQueueEntry(SetFreq(14_074_000), future=future)
+
+    assert poller._stage_tx_interlocked_entries([entry]) == []  # noqa: SLF001
+    assert future.done() is False
+    radio.set_freq.assert_not_awaited()
+
+    clock.advance(0.1)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    clock.advance(0.5)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    clock.advance(0.5)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == [entry]  # noqa: SLF001
+
+    await poller._execute_queued_entry(entry)  # noqa: SLF001
+    assert future.result() is None
+    radio.set_freq.assert_awaited_once_with(14_074_000)
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    radio.set_freq.assert_awaited_once()
+
+
+async def test_supersession_keeps_deadline_and_expiry_wins_over_release() -> None:
+    clock = FreshnessClock(start=20.0)
+    radio, store, queue = _radio(), StateStore(freshness_clock=clock), CommandQueue()
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, queue, state_store=store)
+    _observe_ptt(store, True, observed_at=clock.now())
+    old_future = asyncio.get_running_loop().create_future()
+    old = CommandQueueEntry(SetFreq(7_074_000), future=old_future)
+    assert poller._stage_tx_interlocked_entries([old]) == []  # noqa: SLF001
+
+    clock.advance(2.5)
+    _observe_ptt(store, False, observed_at=clock.now())
+    new_future = asyncio.get_running_loop().create_future()
+    new = CommandQueueEntry(SetFreq(14_074_000), future=new_future)
+    assert poller._stage_tx_interlocked_entries([new]) == []  # noqa: SLF001
+    assert "superseded" in str(old_future.exception())
+    radio.set_freq.assert_not_awaited()
+
+    clock.advance(0.5)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    assert "expired" in str(new_future.exception())
+    radio.set_freq.assert_not_awaited()
+
+
+async def test_unknown_deferred_command_fails_closed_without_entering_lane() -> None:
+    poller, radio, _store = _poller()
+    entry = CommandQueueEntry(SetFreq(14_074_000))
+
+    assert poller._stage_tx_interlocked_entries([entry]) == [entry]  # noqa: SLF001
+    with pytest.raises(CommandError, match="RF state is unknown"):
+        await poller._execute_queued_entry(entry)  # noqa: SLF001
+
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    radio.set_freq.assert_not_awaited()

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -227,3 +227,16 @@ async def test_unknown_deferred_command_fails_closed_without_entering_lane() -> 
 
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     radio.set_freq.assert_not_awaited()
+
+
+async def test_fresh_rx_deferred_class_dispatches_immediately_once() -> None:
+    poller, radio, store = _poller()
+    _observe_ptt(store, False)
+    future = asyncio.get_running_loop().create_future()
+    entry = CommandQueueEntry(SetFreq(14_074_000), future=future)
+
+    assert poller._stage_tx_interlocked_entries([entry]) == [entry]  # noqa: SLF001
+    await poller._execute_queued_entry(entry)  # noqa: SLF001
+
+    assert future.result() is None
+    radio.set_freq.assert_awaited_once_with(14_074_000)


### PR DESCRIPTION
## Summary

- integrate the existing shared DeferredTxCommandLane into the queued Web RadioPoller path
- hold DEFER commands during fresh TX without radio dispatch or applied truth, while UNKNOWN fails closed without entering the lane
- release once after continuous fresh RX, preserve original entry/future/deadline across supersession, and terminate expired/superseded futures truthfully
- stage newly queued commands before observing or releasing an older held command

Linear: [MOR-1759](https://linear.app/morozsm/issue/MOR-1759)

## Behavior

- fresh RX keeps the existing immediate path
- fresh TX enters one shared held slot
- UNKNOWN, stale, unavailable, and provider-generation mismatch fail closed and reset RX quiet time
- release requires 1.0 seconds of continuous fresh RX and must occur before the original 3.0-second absolute expiry
- exact expiry wins and performs no dispatch
- hard BLOCK and ALWAYS-PASS behavior remains unchanged
- no B1-c lifecycle projection or B1-d shutdown/readback scope is included

## Red-first evidence

Focused tests were committed first and failed on the pre-implementation branch because the Web poller had no deferred staging/execution seam. The implementation then made the focused matrix green. Two fixture-only prerequisites separately made legacy implicit-RX assumptions explicit without weakening production policy.

## Verification

- final relevant Web/policy/prerequisite suite: 585 passed, 2 skipped
- after final unrelated Yaesu main merge, combined relevant suite: 684 passed, 2 skipped
- full non-integration after both fixture prerequisites: 10,158 passed, 74 skipped, 112 deselected, 14 xfailed, 1 xpassed
- owned Ruff check + format: pass
- mypy on radio_poller.py: pass
- import-linter: 5/5 contracts kept
- diff-check, exact two-file/200-LOC guard, and privacy scan: pass

The full run preceded the final non-overlapping Yaesu-only main merge; the post-merge combined relevant/Yaesu suite is green and exact-head CI is required before merge.

## Scope

- 2 files
- 187 changed LOC
- no runtime launch, hardware, serial, radio, PTT, TUNE, or TX activity