### PR TITLE
MOR-1766: share effective TX interlock decision with deferred lane

### DIFF
--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -100,7 +100,6 @@ class TxInterlockDecision:
     disposition: TxInterlockDisposition
     allowed: bool
     reason: str
-    rf_state: RfState | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,7 +152,8 @@ class DeferredTxCommandLane:
         command: object,
         *,
         now: float,
-        decision: TxInterlockDecision | None = None,
+        rf_state: RfState = RfState.TX,
+        disposition_overrides: TxInterlockDispositionOverrides | None = None,
     ) -> TxInterlockDeferredResult:
         """Hold a ``DEFER`` command, explicitly replacing a prior held command.
 
@@ -163,11 +163,15 @@ class DeferredTxCommandLane:
         starts a separate fresh hold.
         """
 
-        effective = decision or evaluate_tx_interlock(command, rf_state=RfState.TX)
+        effective = evaluate_tx_interlock(
+            command,
+            rf_state=rf_state,
+            disposition_overrides=disposition_overrides,
+        )
         if (
             effective.disposition is not TxInterlockDisposition.DEFER
             or effective.allowed
-            or effective.rf_state is not RfState.TX
+            or rf_state is not RfState.TX
         ):
             raise ValueError("only denied DEFER decisions may be held in the lane")
 
@@ -397,21 +401,20 @@ def evaluate_tx_interlock(
         TxInterlockDisposition.TX_SAFE,
     ):
         return TxInterlockDecision(
-            disposition, True, "TX interlock permits this command.", rf_state
+            disposition, True, "TX interlock permits this command."
         )
     if rf_state is RfState.RX:
-        return TxInterlockDecision(disposition, True, "RF state is known RX.", rf_state)
+        return TxInterlockDecision(disposition, True, "RF state is known RX.")
     if rf_state is RfState.UNKNOWN:
         return TxInterlockDecision(
             disposition,
             False,
             "RF state is unknown; this command must not be attempted yet.",
-            rf_state,
         )
     if disposition is TxInterlockDisposition.DEFER:
         return TxInterlockDecision(
-            disposition, False, "RF state is TX; command is deferred.", rf_state
+            disposition, False, "RF state is TX; command is deferred."
         )
     return TxInterlockDecision(
-        disposition, False, "RF state is TX; command is blocked.", rf_state
+        disposition, False, "RF state is TX; command is blocked."
     )

--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -7,6 +7,7 @@ being corrected, and a missing union member cannot create a privileged path.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -59,6 +60,7 @@ __all__ = [
     "TxInterlockDeferredResult",
     "TxInterlockDecision",
     "TxInterlockDisposition",
+    "TxInterlockDispositionOverrides",
     "classify_tx_interlock",
     "evaluate_tx_interlock",
     "get_tx_interlock_command_family_metadata",
@@ -68,6 +70,10 @@ __all__ = [
 _METADATA_BY_FAMILY = {
     metadata.family: metadata for metadata in TX_INTERLOCK_COMMAND_FAMILY_METADATA
 }
+
+TxInterlockDispositionOverrides = Mapping[
+    TxInterlockCommandFamily, TxInterlockDisposition
+]
 
 
 class RfState(StrEnum):
@@ -94,6 +100,7 @@ class TxInterlockDecision:
     disposition: TxInterlockDisposition
     allowed: bool
     reason: str
+    rf_state: RfState | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,7 +148,13 @@ class DeferredTxCommandLane:
 
         return self._entry.command if self._entry is not None else None
 
-    def defer(self, command: object, *, now: float) -> TxInterlockDeferredResult:
+    def defer(
+        self,
+        command: object,
+        *,
+        now: float,
+        decision: TxInterlockDecision | None = None,
+    ) -> TxInterlockDeferredResult:
         """Hold a ``DEFER`` command, explicitly replacing a prior held command.
 
         Active supersession carries forward the original absolute deadline but
@@ -150,9 +163,13 @@ class DeferredTxCommandLane:
         starts a separate fresh hold.
         """
 
-        decision = evaluate_tx_interlock(command, rf_state=RfState.TX)
-        if decision.disposition is not TxInterlockDisposition.DEFER:
-            raise ValueError("only commands with DEFER disposition may enter the lane")
+        effective = decision or evaluate_tx_interlock(command, rf_state=RfState.TX)
+        if (
+            effective.disposition is not TxInterlockDisposition.DEFER
+            or effective.allowed
+            or effective.rf_state is not RfState.TX
+        ):
+            raise ValueError("only denied DEFER decisions may be held in the lane")
 
         previous = self._entry
         if previous is not None and now < previous.expires_at:
@@ -339,7 +356,34 @@ def classify_tx_interlock(command: object) -> TxInterlockDisposition:
     return TxInterlockDisposition.TX_SAFE
 
 
-def evaluate_tx_interlock(command: object, *, rf_state: RfState) -> TxInterlockDecision:
+def _effective_tx_interlock_disposition(
+    command: object,
+    disposition_overrides: TxInterlockDispositionOverrides | None,
+) -> TxInterlockDisposition:
+    base = classify_tx_interlock(command)
+    if base is TxInterlockDisposition.ALWAYS_PASS or disposition_overrides is None:
+        return base
+    for family, override in disposition_overrides.items():
+        metadata = _METADATA_BY_FAMILY.get(family)
+        if (
+            not isinstance(family, TxInterlockCommandFamily)
+            or metadata is None
+            or metadata.base_disposition is not TxInterlockDisposition.TX_SAFE
+            or override is not TxInterlockDisposition.DEFER
+        ):
+            raise ValueError("invalid or loosening TX interlock override")
+    metadata = get_tx_interlock_command_family_metadata(command)
+    if metadata is None:
+        return base
+    return disposition_overrides.get(metadata.family, base)
+
+
+def evaluate_tx_interlock(
+    command: object,
+    *,
+    rf_state: RfState,
+    disposition_overrides: TxInterlockDispositionOverrides | None = None,
+) -> TxInterlockDecision:
     """Evaluate whether a command may be attempted now at an enforcement seat.
 
     Hard BLOCK and DEFER commands both require *known* RX for an immediate
@@ -347,26 +391,27 @@ def evaluate_tx_interlock(command: object, *, rf_state: RfState) -> TxInterlockD
     this pure policy only preserves the fail-closed result and truthful reason.
     """
 
-    disposition = classify_tx_interlock(command)
+    disposition = _effective_tx_interlock_disposition(command, disposition_overrides)
     if disposition in (
         TxInterlockDisposition.ALWAYS_PASS,
         TxInterlockDisposition.TX_SAFE,
     ):
         return TxInterlockDecision(
-            disposition, True, "TX interlock permits this command."
+            disposition, True, "TX interlock permits this command.", rf_state
         )
     if rf_state is RfState.RX:
-        return TxInterlockDecision(disposition, True, "RF state is known RX.")
+        return TxInterlockDecision(disposition, True, "RF state is known RX.", rf_state)
     if rf_state is RfState.UNKNOWN:
         return TxInterlockDecision(
             disposition,
             False,
             "RF state is unknown; this command must not be attempted yet.",
+            rf_state,
         )
     if disposition is TxInterlockDisposition.DEFER:
         return TxInterlockDecision(
-            disposition, False, "RF state is TX; command is deferred."
+            disposition, False, "RF state is TX; command is deferred.", rf_state
         )
     return TxInterlockDecision(
-        disposition, False, "RF state is TX; command is blocked."
+        disposition, False, "RF state is TX; command is blocked.", rf_state
     )

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -1,5 +1,7 @@
 """Focused contract tests for the shared TX interlock policy."""
 
+import pytest
+
 from rigplane.core.tx_interlock_contract import (
     TX_INTERLOCK_COMMAND_FAMILY_METADATA as CORE_TX_INTERLOCK_METADATA,
 )
@@ -145,6 +147,62 @@ def test_cw_and_modulation_input_controls_are_tx_safe() -> None:
         assert evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN).allowed is True
 
 
+def test_validated_override_produces_one_fail_closed_effective_decision() -> None:
+    command = SetPowerstat(on=True)
+    overrides = {
+        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
+    }
+
+    base = evaluate_tx_interlock(command, rf_state=RfState.UNKNOWN)
+    assert base.disposition is TxInterlockDisposition.TX_SAFE
+    assert base.allowed is True
+
+    unknown = evaluate_tx_interlock(
+        command, rf_state=RfState.UNKNOWN, disposition_overrides=overrides
+    )
+    transmitting = evaluate_tx_interlock(
+        command, rf_state=RfState.TX, disposition_overrides=overrides
+    )
+    receiving = evaluate_tx_interlock(
+        command, rf_state=RfState.RX, disposition_overrides=overrides
+    )
+    assert (unknown.disposition, unknown.allowed) == (
+        TxInterlockDisposition.DEFER,
+        False,
+    )
+    assert (transmitting.disposition, transmitting.allowed) == (
+        TxInterlockDisposition.DEFER,
+        False,
+    )
+    assert (receiving.disposition, receiving.allowed) == (
+        TxInterlockDisposition.DEFER,
+        True,
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.TX_SAFE},
+        {TxInterlockCommandFamily.PTT_ON: TxInterlockDisposition.DEFER},
+        {"power-on": TxInterlockDisposition.DEFER},
+    ),
+)
+def test_invalid_or_loosening_override_cannot_yield_pass(overrides: object) -> None:
+    with pytest.raises(ValueError, match="override"):
+        evaluate_tx_interlock(
+            SetPowerstat(on=True),
+            rf_state=RfState.UNKNOWN,
+            disposition_overrides=overrides,
+        )
+
+    emergency = evaluate_tx_interlock(
+        PttOff(), rf_state=RfState.UNKNOWN, disposition_overrides=overrides
+    )
+    assert emergency.disposition is TxInterlockDisposition.ALWAYS_PASS
+    assert emergency.allowed is True
+
+
 def test_command_family_metadata_pins_typed_policy_without_classifying_defaults() -> (
     None
 ):
@@ -203,6 +261,46 @@ def test_deferred_lane_holds_then_releases_after_continuous_known_rx() -> None:
     assert released.outcome is TxInterlockDeferredOutcome.RELEASED
     assert released.command is command
     assert lane.pending is None
+
+
+def test_deferred_lane_reuses_effective_decision_without_reclassification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    overrides = {
+        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
+    }
+    first = SetPowerstat(on=True)
+    second = SetPowerstat(on=True)
+    first_decision = evaluate_tx_interlock(
+        first, rf_state=RfState.TX, disposition_overrides=overrides
+    )
+    second_decision = evaluate_tx_interlock(
+        second, rf_state=RfState.TX, disposition_overrides=overrides
+    )
+    receiving_decision = evaluate_tx_interlock(
+        second, rf_state=RfState.RX, disposition_overrides=overrides
+    )
+    monkeypatch.setattr(
+        "rigplane.runtime.tx_interlock.evaluate_tx_interlock",
+        lambda *_args, **_kwargs: pytest.fail("effective decision was recomputed"),
+    )
+
+    lane = DeferredTxCommandLane()
+    held = lane.defer(first, now=10.0, decision=first_decision)
+    superseded = lane.defer(second, now=12.5, decision=second_decision)
+    assert held.expires_at == 13.0
+    assert superseded.outcome is TxInterlockDeferredOutcome.SUPERSEDED
+    assert superseded.expires_at == 13.0
+    assert lane.observe(rf_state=RfState.RX, now=13.0).outcome is (
+        TxInterlockDeferredOutcome.EXPIRED
+    )
+
+    with pytest.raises(ValueError, match="held"):
+        lane.defer(
+            SetPowerstat(on=True),
+            now=20.0,
+            decision=receiving_decision,
+        )
 
 
 def test_deferred_lane_resets_only_quiet_progress_for_unknown_or_renewed_tx() -> None:

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -1,5 +1,7 @@
 """Focused contract tests for the shared TX interlock policy."""
 
+from dataclasses import asdict
+
 import pytest
 
 from rigplane.core.tx_interlock_contract import (
@@ -45,6 +47,7 @@ from rigplane.runtime.tx_interlock import (
     TxInterlockCommandFamily,
     TxInterlockCommandFamilyMetadata,
     TxInterlockDeferredOutcome,
+    TxInterlockDecision,
     TxInterlockDisposition,
     classify_tx_interlock,
     evaluate_tx_interlock,
@@ -57,6 +60,22 @@ def test_runtime_reexports_the_canonical_core_contract_by_identity() -> None:
     assert TxInterlockCommandFamily is CoreTxInterlockCommandFamily
     assert TxInterlockCommandFamilyMetadata is CoreTxInterlockCommandFamilyMetadata
     assert TX_INTERLOCK_COMMAND_FAMILY_METADATA is CORE_TX_INTERLOCK_METADATA
+
+
+def test_decision_preserves_legacy_equality_and_serialized_shape() -> None:
+    decision = evaluate_tx_interlock(PttOn(), rf_state=RfState.UNKNOWN)
+    expected = TxInterlockDecision(
+        TxInterlockDisposition.BLOCK,
+        False,
+        "RF state is unknown; this command must not be attempted yet.",
+    )
+
+    assert decision == expected
+    assert asdict(decision) == {
+        "disposition": TxInterlockDisposition.BLOCK,
+        "allowed": False,
+        "reason": "RF state is unknown; this command must not be attempted yet.",
+    }
 
 
 def test_emergency_stop_commands_take_structural_precedence() -> None:
@@ -263,34 +282,29 @@ def test_deferred_lane_holds_then_releases_after_continuous_known_rx() -> None:
     assert lane.pending is None
 
 
-def test_deferred_lane_reuses_effective_decision_without_reclassification(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_deferred_lane_applies_effective_decision_to_the_bound_command() -> None:
     overrides = {
         TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
     }
     first = SetPowerstat(on=True)
     second = SetPowerstat(on=True)
-    first_decision = evaluate_tx_interlock(
-        first, rf_state=RfState.TX, disposition_overrides=overrides
-    )
-    second_decision = evaluate_tx_interlock(
-        second, rf_state=RfState.TX, disposition_overrides=overrides
-    )
-    receiving_decision = evaluate_tx_interlock(
-        second, rf_state=RfState.RX, disposition_overrides=overrides
-    )
-    unknown_decision = evaluate_tx_interlock(
-        second, rf_state=RfState.UNKNOWN, disposition_overrides=overrides
-    )
-    monkeypatch.setattr(
-        "rigplane.runtime.tx_interlock.evaluate_tx_interlock",
-        lambda *_args, **_kwargs: pytest.fail("effective decision was recomputed"),
-    )
 
     lane = DeferredTxCommandLane()
-    held = lane.defer(first, now=10.0, decision=first_decision)
-    superseded = lane.defer(second, now=12.5, decision=second_decision)
+    for refused in (RfState.UNKNOWN, RfState.RX):
+        with pytest.raises(ValueError, match="held"):
+            lane.defer(
+                first,
+                now=10.0,
+                rf_state=refused,
+                disposition_overrides=overrides,
+            )
+
+    held = lane.defer(
+        first, now=10.0, rf_state=RfState.TX, disposition_overrides=overrides
+    )
+    superseded = lane.defer(
+        second, now=12.5, rf_state=RfState.TX, disposition_overrides=overrides
+    )
     assert held.expires_at == 13.0
     assert superseded.outcome is TxInterlockDeferredOutcome.SUPERSEDED
     assert superseded.expires_at == 13.0
@@ -298,9 +312,21 @@ def test_deferred_lane_reuses_effective_decision_without_reclassification(
         TxInterlockDeferredOutcome.EXPIRED
     )
 
-    for refused in (receiving_decision, unknown_decision):
-        with pytest.raises(ValueError, match="held"):
-            lane.defer(SetPowerstat(on=True), now=20.0, decision=refused)
+
+@pytest.mark.parametrize(
+    "command",
+    (PttOn(), PttOff(), SetPowerstat(on=False)),
+)
+def test_deferred_lane_rejects_unbound_forged_decision(command: object) -> None:
+    forged = TxInterlockDecision(
+        TxInterlockDisposition.DEFER,
+        False,
+        "forged TX decision",
+        RfState.TX,
+    )
+
+    with pytest.raises(TypeError, match="decision"):
+        DeferredTxCommandLane().defer(command, now=10.0, decision=forged)
 
 
 def test_deferred_lane_resets_only_quiet_progress_for_unknown_or_renewed_tx() -> None:

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -321,8 +321,7 @@ def test_deferred_lane_rejects_unbound_forged_decision(command: object) -> None:
     forged = TxInterlockDecision(
         TxInterlockDisposition.DEFER,
         False,
-        "forged TX decision",
-        RfState.TX,
+        "forged denied-DEFER/TX claim",
     )
 
     with pytest.raises(TypeError, match="decision"):

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -280,6 +280,9 @@ def test_deferred_lane_reuses_effective_decision_without_reclassification(
     receiving_decision = evaluate_tx_interlock(
         second, rf_state=RfState.RX, disposition_overrides=overrides
     )
+    unknown_decision = evaluate_tx_interlock(
+        second, rf_state=RfState.UNKNOWN, disposition_overrides=overrides
+    )
     monkeypatch.setattr(
         "rigplane.runtime.tx_interlock.evaluate_tx_interlock",
         lambda *_args, **_kwargs: pytest.fail("effective decision was recomputed"),
@@ -295,12 +298,9 @@ def test_deferred_lane_reuses_effective_decision_without_reclassification(
         TxInterlockDeferredOutcome.EXPIRED
     )
 
-    with pytest.raises(ValueError, match="held"):
-        lane.defer(
-            SetPowerstat(on=True),
-            now=20.0,
-            decision=receiving_decision,
-        )
+    for refused in (receiving_decision, unknown_decision):
+        with pytest.raises(ValueError, match="held"):
+            lane.defer(SetPowerstat(on=True), now=20.0, decision=refused)
 
 
 def test_deferred_lane_resets_only_quiet_progress_for_unknown_or_renewed_tx() -> None:


### PR DESCRIPTION
## Summary

- add an optional validated disposition-override mapping to the shared TX-interlock evaluator
- tighten eligible `TX_SAFE` families such as `POWER_ON` to an effective `DEFER` decision without loosening structural or hard-block policy
- carry the evaluated RF state on the additive decision contract
- let the existing deferred lane consume that exact denied-TX decision without reclassifying the command
- preserve all existing lane TTL, quiet-window, supersession, and default-caller behavior

## Safety contract

- absent overrides preserve the base decision
- UNKNOWN remains fail-closed and is not admitted to the held lane
- known TX produces the reusable held decision
- known RX permits the command and is not admitted to the lane
- invalid, raw-string, or loosening mappings raise before they can produce PASS
- structural ALWAYS-PASS commands retain precedence
- no profile parsing, Yaesu wiring, TOML, lifecycle projection, or hardware changes are included

## Red-first evidence

On exact base `1c80d0c24090ce2c49505238b635cd3455781f3d`, all five new focused witnesses failed because the evaluator accepted no override mapping and the lane accepted no precomputed decision.

## Validation

- focused policy: 23 passed
- relevant shared/Web/rigctld/Yaesu seats: 145 passed
- full non-integration: 10009 passed, 13 skipped, 14 xfailed, 1 xpassed
- full mypy exact base/head parity: 12 established errors in the same 3 unrelated files
- Ruff/format/import-linter/diff/privacy: passed
- scope: 2 files, +153/-10 (163 changed LOC)

Linear: [MOR-1766](https://linear.app/morozsm/issue/MOR-1766/mor-1500-b2-d3a-share-effective-tx-interlock-decision-with-deferred)

Fresh independent exact-head review is required before merge.
