### PR TITLE
MOR-1767: consume Yaesu profile TX-interlock overrides

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -607,6 +607,7 @@ class YaesuCatPoller:
                 continue
             now = time.monotonic()
             rf_state = self._current_rf_state()
+            transition = None
             try:
                 overrides = self._tx_interlock_disposition_overrides()
                 decision = evaluate_tx_interlock(
@@ -614,6 +615,17 @@ class YaesuCatPoller:
                     rf_state=rf_state,
                     disposition_overrides=overrides,
                 )
+                if (
+                    decision.disposition is TxInterlockDisposition.DEFER
+                    and not decision.allowed
+                    and rf_state is RfState.TX
+                ):
+                    transition = self._deferred_tx_lane.defer(
+                        cmd,
+                        now=now,
+                        rf_state=rf_state,
+                        disposition_overrides=overrides,
+                    )
             except Exception as exc:
                 self._mark_queued_command_failed(entry, exc)
                 if entry.future is not None and not entry.future.done():
@@ -624,17 +636,7 @@ class YaesuCatPoller:
                     exc_info=True,
                 )
                 continue
-            if (
-                decision.disposition is TxInterlockDisposition.DEFER
-                and not decision.allowed
-                and rf_state is RfState.TX
-            ):
-                transition = self._deferred_tx_lane.defer(
-                    cmd,
-                    now=now,
-                    rf_state=rf_state,
-                    disposition_overrides=overrides,
-                )
+            if transition is not None:
                 held = self._deferred_tx_lane.observe(rf_state=RfState.TX, now=now)
                 if held is None:
                     raise RuntimeError("deferred command lane lost its replacement")

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -607,8 +607,8 @@ class YaesuCatPoller:
                 continue
             now = time.monotonic()
             rf_state = self._current_rf_state()
-            overrides = self._tx_interlock_disposition_overrides()
             try:
+                overrides = self._tx_interlock_disposition_overrides()
                 decision = evaluate_tx_interlock(
                     cmd,
                     rf_state=rf_state,

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -37,6 +37,8 @@ from rigplane.runtime.tx_interlock import (
     RfState,
     TxInterlockDeferredOutcome,
     TxInterlockDisposition,
+    TxInterlockDispositionOverrides,
+    classify_tx_interlock,
     evaluate_tx_interlock,
 )
 
@@ -184,6 +186,11 @@ class YaesuCatPoller:
         if observation is None:
             return RfState.UNKNOWN
         return RfState.TX if observation.value else RfState.RX
+
+    def _tx_interlock_disposition_overrides(
+        self,
+    ) -> TxInterlockDispositionOverrides:
+        return self._radio.profile.tx_interlock_disposition_overrides
 
     def _stamp_provider_generation(
         self,
@@ -600,13 +607,34 @@ class YaesuCatPoller:
                 continue
             now = time.monotonic()
             rf_state = self._current_rf_state()
-            decision = evaluate_tx_interlock(cmd, rf_state=rf_state)
+            overrides = self._tx_interlock_disposition_overrides()
+            try:
+                decision = evaluate_tx_interlock(
+                    cmd,
+                    rf_state=rf_state,
+                    disposition_overrides=overrides,
+                )
+            except Exception as exc:
+                self._mark_queued_command_failed(entry, exc)
+                if entry.future is not None and not entry.future.done():
+                    entry.future.set_exception(exc)
+                logger.warning(
+                    "YaesuCatPoller: command %s failed policy validation",
+                    type(cmd).__name__,
+                    exc_info=True,
+                )
+                continue
             if (
                 decision.disposition is TxInterlockDisposition.DEFER
                 and not decision.allowed
                 and rf_state is RfState.TX
             ):
-                transition = self._deferred_tx_lane.defer(cmd, now=now)
+                transition = self._deferred_tx_lane.defer(
+                    cmd,
+                    now=now,
+                    rf_state=rf_state,
+                    disposition_overrides=overrides,
+                )
                 held = self._deferred_tx_lane.observe(rf_state=RfState.TX, now=now)
                 if held is None:
                     raise RuntimeError("deferred command lane lost its replacement")
@@ -775,10 +803,14 @@ class YaesuCatPoller:
         Commands come from the web UI CommandQueue.  The dispatcher handles
         all command types; unsupported commands fail truthfully.
         """
-        decision = evaluate_tx_interlock(cmd, rf_state=self._current_rf_state())
-        if (
+        decision = evaluate_tx_interlock(
+            cmd,
+            rf_state=self._current_rf_state(),
+            disposition_overrides=self._tx_interlock_disposition_overrides(),
+        )
+        if not decision.allowed and (
             decision.disposition is TxInterlockDisposition.BLOCK
-            and not decision.allowed
+            or classify_tx_interlock(cmd) is TxInterlockDisposition.TX_SAFE
         ):
             raise CommandError(decision.reason)
 

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -21,6 +21,10 @@ from rigplane.core.state_acquisition_policy import (
 from rigplane.core.state_pipeline_contracts import FieldPath, Observation
 from rigplane.core.state_store import StateStore
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
+from rigplane.core.tx_interlock_contract import (
+    TxInterlockCommandFamily,
+    TxInterlockDisposition,
+)
 from rigplane.exceptions import CommandError
 from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
 from rigplane.backends.yaesu_cat.observations import YaesuObservationAdapter
@@ -92,6 +96,7 @@ def make_radio(
         "scan",
         "dial_lock",
     }
+    radio.profile.tx_interlock_disposition_overrides = {}
 
     radio.get_s_meter = AsyncMock(
         side_effect=lambda r=0: s_meter_main if r == 0 else s_meter_sub
@@ -628,6 +633,117 @@ async def test_yaesu_known_rx_preserves_immediate_dispatch(
         NotImplementedError, match="SendCiv unsupported by Yaesu CAT dispatcher"
     ):
         await poller._execute_command(SendCiv(command=0x1C))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_yaesu_profile_power_on_defer_is_command_bound_across_queue_and_execute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.runtime._poller_types import SetPowerstat
+
+    clock = [10.0]
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    radio, queue = make_radio(), CommandQueue()
+    radio.set_powerstat = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    _set_fresh_ptt_observation(poller, active=True)
+    await poller._execute_command(SetPowerstat(on=True))  # noqa: SLF001
+    radio.set_powerstat.assert_awaited_once_with(True)
+    radio.set_powerstat.reset_mock()
+    poller._invalidate_ptt_observation()  # noqa: SLF001
+
+    radio.profile.tx_interlock_disposition_overrides = {
+        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER
+    }
+
+    with pytest.raises(CommandError, match="unknown"):
+        await poller._execute_command(SetPowerstat(on=True))  # noqa: SLF001
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+
+    future = asyncio.get_running_loop().create_future()
+    service = MagicMock()
+    queue.put_ordered(
+        SetPowerstat(on=True),
+        future=future,
+        command_id="profile-power-on",
+        command_service=service,
+    )
+    await _drain_with_ptt(poller, clock, 10.0, True)
+    assert not future.done()
+    assert poller._deferred_tx_lane.pending == SetPowerstat(on=True)  # noqa: SLF001
+    assert service.emit_lifecycle.call_args.args[1] == "queued"
+    assert service.emit_lifecycle.call_args.kwargs["details"] == {
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": 13.0,
+    }
+    radio.set_powerstat.assert_not_awaited()
+
+    await _drain_with_ptt(poller, clock, 10.5, False)
+    await _drain_with_ptt(poller, clock, 11.5, False)
+    await poller._drain_commands()  # noqa: SLF001
+    assert future.result() is None
+    radio.set_powerstat.assert_awaited_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_yaesu_profile_override_unknown_and_invalid_mapping_never_fail_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.runtime._poller_types import SetPowerstat
+
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 30.0
+    )
+    radio, queue = make_radio(), CommandQueue()
+    radio.set_powerstat = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    radio.profile.tx_interlock_disposition_overrides = {
+        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER
+    }
+    unknown = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetPowerstat(on=True), future=unknown)
+    await poller._drain_commands()  # noqa: SLF001
+    assert isinstance(unknown.exception(), CommandError)
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+
+    radio.profile.tx_interlock_disposition_overrides = {
+        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.ALWAYS_PASS
+    }
+    malformed = asyncio.get_running_loop().create_future()
+    queue.put_ordered(SetPowerstat(on=True), future=malformed)
+    await poller._drain_commands()  # noqa: SLF001
+    assert isinstance(malformed.exception(), ValueError)
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+    radio.set_powerstat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_profile_override_cannot_change_structural_floors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.runtime._poller_types import PttOff, PttOn, SetPowerstat
+
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 40.0
+    )
+    radio = make_radio()
+    radio.profile.tx_interlock_disposition_overrides = {
+        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER
+    }
+    radio.set_ptt = AsyncMock()
+    radio.set_powerstat = AsyncMock()
+    poller = YaesuCatPoller(radio)
+    _set_fresh_ptt_observation(poller, active=True)
+
+    with pytest.raises(CommandError, match="RF state is TX"):
+        await poller._execute_command(PttOn())  # noqa: SLF001
+    await poller._execute_command(PttOff())  # noqa: SLF001
+    await poller._execute_command(SetPowerstat(on=False))  # noqa: SLF001
+    radio.set_ptt.assert_awaited_once_with(False)
+    radio.set_powerstat.assert_awaited_once_with(False)
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -641,6 +641,15 @@ async def test_yaesu_profile_power_on_defer_is_command_bound_across_queue_and_ex
 ) -> None:
     from rigplane.runtime._poller_types import SetPowerstat
 
+    class OneShotItemsDict(dict):
+        calls = 0
+
+        def items(self):
+            self.calls += 1
+            if self.calls > 1:
+                raise RuntimeError("second override metadata access")
+            return super().items()
+
     clock = [10.0]
     monkeypatch.setattr(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
@@ -648,19 +657,13 @@ async def test_yaesu_profile_power_on_defer_is_command_bound_across_queue_and_ex
     radio, queue = make_radio(), CommandQueue()
     radio.set_powerstat = AsyncMock()
     poller = YaesuCatPoller(radio, command_queue=queue)
-    _set_fresh_ptt_observation(poller, active=True)
-    await poller._execute_command(SetPowerstat(on=True))  # noqa: SLF001
-    radio.set_powerstat.assert_awaited_once_with(True)
-    radio.set_powerstat.reset_mock()
-    poller._invalidate_ptt_observation()  # noqa: SLF001
-
-    radio.profile.tx_interlock_disposition_overrides = {
-        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER
-    }
+    override = {TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER}
+    radio.profile.tx_interlock_disposition_overrides = override
 
     with pytest.raises(CommandError, match="unknown"):
         await poller._execute_command(SetPowerstat(on=True))  # noqa: SLF001
     assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+    radio.profile.tx_interlock_disposition_overrides = OneShotItemsDict(override)
 
     future = asyncio.get_running_loop().create_future()
     service = MagicMock()
@@ -674,11 +677,6 @@ async def test_yaesu_profile_power_on_defer_is_command_bound_across_queue_and_ex
     assert not future.done()
     assert poller._deferred_tx_lane.pending == SetPowerstat(on=True)  # noqa: SLF001
     assert service.emit_lifecycle.call_args.args[1] == "queued"
-    assert service.emit_lifecycle.call_args.kwargs["details"] == {
-        "heldBy": "tx_interlock",
-        "reason": "tx_active",
-        "expiresAt": 13.0,
-    }
     radio.set_powerstat.assert_not_awaited()
 
     await _drain_with_ptt(poller, clock, 10.5, False)

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -641,15 +641,6 @@ async def test_yaesu_profile_power_on_defer_is_command_bound_across_queue_and_ex
 ) -> None:
     from rigplane.runtime._poller_types import SetPowerstat
 
-    class OneShotItemsDict(dict):
-        calls = 0
-
-        def items(self):
-            self.calls += 1
-            if self.calls > 1:
-                raise RuntimeError("second override metadata access")
-            return super().items()
-
     clock = [10.0]
     monkeypatch.setattr(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
@@ -662,27 +653,29 @@ async def test_yaesu_profile_power_on_defer_is_command_bound_across_queue_and_ex
 
     with pytest.raises(CommandError, match="unknown"):
         await poller._execute_command(SetPowerstat(on=True))  # noqa: SLF001
-    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
-    radio.profile.tx_interlock_disposition_overrides = OneShotItemsDict(override)
 
     future = asyncio.get_running_loop().create_future()
-    service = MagicMock()
-    queue.put_ordered(
-        SetPowerstat(on=True),
-        future=future,
-        command_id="profile-power-on",
-        command_service=service,
-    )
+    queue.put_ordered(SetPowerstat(on=True), future=future)
     await _drain_with_ptt(poller, clock, 10.0, True)
-    assert not future.done()
-    assert poller._deferred_tx_lane.pending == SetPowerstat(on=True)  # noqa: SLF001
-    assert service.emit_lifecycle.call_args.args[1] == "queued"
-    radio.set_powerstat.assert_not_awaited()
-
     await _drain_with_ptt(poller, clock, 10.5, False)
     await _drain_with_ptt(poller, clock, 11.5, False)
     await poller._drain_commands()  # noqa: SLF001
     assert future.result() is None
+
+    trapping = MagicMock(wraps=override)
+    trapping.items.side_effect = (override.items(), RuntimeError("second access"))
+    radio.profile.tx_interlock_disposition_overrides = trapping
+    trapped, service = asyncio.get_running_loop().create_future(), MagicMock()
+    queue.put_ordered(
+        SetPowerstat(on=True),
+        future=trapped,
+        command_id="trap",
+        command_service=service,
+    )
+    await _drain_with_ptt(poller, clock, 12.0, True)
+    assert isinstance(trapped.exception(), RuntimeError)
+    service.fail_command.assert_called_once()
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
     radio.set_powerstat.assert_awaited_once_with(True)
 
 

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -721,6 +721,45 @@ async def test_yaesu_profile_override_unknown_and_invalid_mapping_never_fail_ope
 
 
 @pytest.mark.asyncio
+async def test_yaesu_trapping_profile_override_accessor_terminally_fails_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.runtime._poller_types import SetPowerstat
+
+    class TrappingProfile:
+        state_acquisition = None
+
+        @property
+        def tx_interlock_disposition_overrides(self) -> object:
+            raise RuntimeError("trapping profile override accessor")
+
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 35.0
+    )
+    radio, queue = make_radio(), CommandQueue()
+    radio.profile = TrappingProfile()
+    radio.set_powerstat = AsyncMock()
+    radio._transport.reconnect = AsyncMock()
+    poller = YaesuCatPoller(radio, command_queue=queue)
+    future = asyncio.get_running_loop().create_future()
+    service = MagicMock()
+    queue.put_ordered(
+        SetPowerstat(on=True),
+        future=future,
+        command_id="trapping-profile",
+        command_service=service,
+    )
+
+    await poller._drain_commands()  # noqa: SLF001
+
+    assert isinstance(future.exception(), RuntimeError)
+    service.fail_command.assert_called_once()
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+    radio.set_powerstat.assert_not_awaited()
+    radio._transport.reconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_yaesu_profile_override_cannot_change_structural_floors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- consume the validated radio-profile TX-interlock disposition override mapping in the Yaesu dispatcher
- use the same mapping for queue classification, command-bound deferred-lane admission, and direct execution
- preserve exact absent-override behavior and structural BLOCK/ALWAYS_PASS floors
- fail closed on unknown RF state and malformed defensive inputs without issuing a radio call

## Why

MOR-1625 made profile overrides validated data and MOR-1766 made deferred-lane admission command-bound. The Yaesu/FTX-1 seat still ignored that profile data, so an eligible synthetic `POWER_ON: DEFER` tightening could execute optimistically.

## Validation

- RED on exact base `6ff9c1e21878fc49c6c7abd8838d6c381d542199`: 2 focused failures showing ignored queue/direct profile policy
- focused Yaesu poller: 102 passed
- relevant TX/Yaesu/rigctld: 195 passed
- full non-integration: 10214 passed, 74 skipped, 112 deselected, 14 xfailed, 1 xpassed
- Ruff check and format: PASS
- import boundaries: PASS (5 contracts kept)
- full mypy parity: exact integrated base and head both have the same 12 established errors in 3 unrelated files; no owned-file diagnostic
- diff/privacy guards: PASS
- scope: exactly 2 files, +153/-5 = 158 changed LOC

## Scope

No `rigs/*.toml`, profile parser, model-name branch, UI, readback, runtime, radio, serial, PTT, TUNE, TX, keying, or hardware changes.

Linear: [MOR-1767](https://linear.app/morozsm/issue/MOR-1767/mor-1500-b2-d3b-consume-validated-profile-tx-interlock-overrides-in)
