### PR TITLE
feat(MOR-1768): emit Web deferred lifecycle truth

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -87,6 +87,7 @@ from ..core.acquisition_scheduler import (
     split_ctl_mem_sub,
 )
 from ..core.state_pipeline_contracts import (
+    CommandIntent,
     CommandSource,
     FieldPath,
     Observation,
@@ -746,12 +747,59 @@ class RadioPoller:
             raise CommandError(decision.reason)
 
     @staticmethod
+    def _deferred_intent(entry: CommandQueueEntry) -> CommandIntent | None:
+        if entry.command_service is None or entry.command_id is None:
+            return None
+        source: CommandSource = entry.source or "internal_policy"
+        target = next(
+            (
+                event.target
+                for event in reversed(entry.command_service.lifecycle_events())
+                if event.command_id == entry.command_id
+                and event.source == source
+                and (event.details or {}).get("session_id") == entry.session_id
+            ),
+            None,
+        )
+        params = {} if entry.session_id is None else {"session_id": entry.session_id}
+        return CommandIntent(
+            id=entry.command_id,
+            name="queued_completion",
+            params=params,
+            source=source,
+            target=target,
+        )
+
     def _terminate_deferred_entry(
-        entry: CommandQueueEntry, outcome: TxInterlockDeferredOutcome
+        self, entry: CommandQueueEntry, outcome: TxInterlockDeferredOutcome
     ) -> None:
+        message = f"deferred command {outcome.value}"
+        intent = self._deferred_intent(entry)
+        if outcome is TxInterlockDeferredOutcome.SUPERSEDED and intent is not None:
+            entry.command_service.expire_command(
+                intent.id, source=intent.source, session_id=entry.session_id
+            )
+            entry.command_service.emit_lifecycle(intent, "superseded", message=message)
+        elif outcome is TxInterlockDeferredOutcome.EXPIRED:
+            self._mark_queued_command_failed(
+                entry, CommandError(message), timed_out=True
+            )
         if entry.future is not None and not entry.future.done():
-            entry.future.set_exception(
-                CommandError(f"deferred command {outcome.value}")
+            entry.future.set_exception(CommandError(message))
+
+    def _emit_deferred_entry_held(
+        self, entry: CommandQueueEntry, *, expires_at: float
+    ) -> None:
+        intent = self._deferred_intent(entry)
+        if intent is not None and entry.command_service is not None:
+            entry.command_service.emit_lifecycle(
+                intent,
+                "queued",
+                details={
+                    "heldBy": "tx_interlock",
+                    "reason": "tx_active",
+                    "expiresAt": expires_at,
+                },
             )
 
     def _stage_tx_interlocked_entries(
@@ -790,6 +838,7 @@ class RadioPoller:
                 TxInterlockDeferredOutcome.SUPERSEDED,
             ):
                 self._terminate_deferred_entry(previous, defer_result.outcome)
+            self._emit_deferred_entry_held(entry, expires_at=defer_result.expires_at)
 
         observe_result = self._deferred_tx_lane.observe(rf_state=rf_state, now=now)
         if (

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -776,6 +776,7 @@ class RadioPoller:
         message = f"deferred command {outcome.value}"
         intent = self._deferred_intent(entry)
         if outcome is TxInterlockDeferredOutcome.SUPERSEDED and intent is not None:
+            assert entry.command_service is not None
             entry.command_service.expire_command(
                 intent.id, source=intent.source, session_id=entry.session_id
             )

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from rigplane.capabilities import CAP_ANTENNA, CAP_POWER_CONTROL, CAP_TUNER
+from rigplane.core.command_service import (
+    CommandExecutionResult,
+    CommandService,
+)
 from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -28,6 +33,7 @@ from rigplane.web.radio_poller import CommandQueue, CommandQueueEntry, RadioPoll
 
 
 _PTT = FieldPath.global_("tx_state", "ptt")
+_FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
 
 
 def _radio() -> SimpleNamespace:
@@ -70,6 +76,39 @@ def _poller() -> tuple[RadioPoller, SimpleNamespace, StateStore]:
     radio, store = _radio(), StateStore()
     store.begin_provider_generation()
     return RadioPoller(radio, CommandQueue(), state_store=store), radio, store
+
+
+def _service(clock: FreshnessClock, store: StateStore) -> CommandService:
+    executor = SimpleNamespace(execute=AsyncMock(return_value=CommandExecutionResult()))
+    return CommandService(executor=executor, state_store=store, clock=clock.now)
+
+
+async def _lifecycle_entry(
+    service: CommandService,
+    *,
+    command_id: str,
+    freq: int,
+) -> CommandQueueEntry:
+    await service.execute(
+        CommandIntent(
+            id=command_id,
+            name="set_freq",
+            params={"freq_hz": freq, "session_id": "ws-a"},
+            source="websocket",
+            target=_FREQ,
+            timeout=3.0,
+            pending_policy="scoped",
+            expected_observations=(_FREQ,),
+        )
+    )
+    return CommandQueueEntry(
+        SetFreq(freq),
+        future=asyncio.get_running_loop().create_future(),
+        command_id=command_id,
+        source="websocket",
+        session_id="ws-a",
+        command_service=service,
+    )
 
 
 async def _dispatch(poller: RadioPoller, cmd: object) -> None:
@@ -218,14 +257,20 @@ async def test_supersession_keeps_deadline_and_expiry_wins_over_release() -> Non
 
 
 async def test_unknown_deferred_command_fails_closed_without_entering_lane() -> None:
-    poller, radio, _store = _poller()
-    entry = CommandQueueEntry(SetFreq(14_074_000))
+    clock = FreshnessClock(start=10.0)
+    radio, store = _radio(), StateStore(freshness_clock=clock)
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    service = _service(clock, store)
+    entry = await _lifecycle_entry(service, command_id="unknown", freq=14_074_000)
+    before = service.lifecycle_events()
 
     assert poller._stage_tx_interlocked_entries([entry]) == [entry]  # noqa: SLF001
     with pytest.raises(CommandError, match="RF state is unknown"):
         await poller._execute_queued_entry(entry)  # noqa: SLF001
 
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    assert service.lifecycle_events() == before
     radio.set_freq.assert_not_awaited()
 
 
@@ -240,3 +285,98 @@ async def test_fresh_rx_deferred_class_dispatches_immediately_once() -> None:
 
     assert future.result() is None
     radio.set_freq.assert_awaited_once_with(14_074_000)
+
+
+async def test_deferred_hold_lifecycle_is_single_and_release_stays_unconfirmed() -> (
+    None
+):
+    clock = FreshnessClock(start=10.0)
+    radio, store = _radio(), StateStore(freshness_clock=clock)
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    service = _service(clock, store)
+    entry = await _lifecycle_entry(service, command_id="held", freq=14_074_000)
+    _observe_ptt(store, True, observed_at=clock.now())
+
+    assert poller._stage_tx_interlocked_entries([entry]) == []  # noqa: SLF001
+    held = service.lifecycle_events()[-1]
+    assert (held.command_id, held.state, held.source, held.target) == (
+        "held",
+        "queued",
+        "websocket",
+        _FREQ,
+    )
+    assert held.details == {
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": 13.0,
+        "session_id": "ws-a",
+    }
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    assert service.lifecycle_events()[-1] is held
+
+    clock.advance(0.5)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    clock.advance(0.5)
+    _observe_ptt(store, False, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == [entry]  # noqa: SLF001
+    await poller._execute_queued_entry(entry)  # noqa: SLF001
+
+    assert service.lifecycle_events()[-1] is held
+    assert service.pending_overlays(source="websocket", session_id="ws-a")
+    radio.set_freq.assert_awaited_once_with(14_074_000)
+
+
+async def test_deferred_replacement_and_expiry_emit_ordered_terminal_truth() -> None:
+    clock = FreshnessClock(start=20.0)
+    radio, store = _radio(), StateStore(freshness_clock=clock)
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    service = _service(clock, store)
+    first = await _lifecycle_entry(service, command_id="first", freq=7_074_000)
+    _observe_ptt(store, True, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([first]) == []  # noqa: SLF001
+
+    clock.advance(2.5)
+    replacement = await _lifecycle_entry(
+        service, command_id="replacement", freq=14_074_000
+    )
+    _observe_ptt(store, True, observed_at=clock.now())
+    snapshots: list[tuple[str, str, tuple[str, ...]]] = []
+    service.subscribe_lifecycle(
+        lambda event: snapshots.append(
+            (
+                event.command_id,
+                event.state,
+                tuple(
+                    overlay.command_id
+                    for overlay in service.pending_overlays(
+                        source="websocket", session_id="ws-a"
+                    )
+                ),
+            )
+        )
+    )
+    assert poller._stage_tx_interlocked_entries([replacement]) == []  # noqa: SLF001
+
+    assert [
+        (event.command_id, event.state) for event in service.lifecycle_events()[-2:]
+    ] == [
+        ("first", "superseded"),
+        ("replacement", "queued"),
+    ]
+    assert snapshots == [
+        ("first", "superseded", ("replacement",)),
+        ("replacement", "queued", ("replacement",)),
+    ]
+    assert service.lifecycle_events()[-1].details["expiresAt"] == 23.0
+
+    clock.advance(0.5)
+    _observe_ptt(store, True, observed_at=clock.now())
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    assert service.lifecycle_events()[-1].state == "timed_out"
+    terminal_count = len(service.lifecycle_events())
+    assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
+    assert len(service.lifecycle_events()) == terminal_count
+    radio.set_freq.assert_not_awaited()

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -6,10 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from rigplane.capabilities import CAP_ANTENNA, CAP_POWER_CONTROL, CAP_TUNER
-from rigplane.core.command_service import (
-    CommandExecutionResult,
-    CommandService,
-)
+from rigplane.core.command_service import CommandExecutionResult, CommandService
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
     FieldPath,
@@ -318,7 +315,7 @@ async def test_deferred_hold_lifecycle_is_single_and_release_stays_unconfirmed()
     clock.advance(0.5)
     _observe_ptt(store, False, observed_at=clock.now())
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
-    clock.advance(0.5)
+    clock.advance(1.0)
     _observe_ptt(store, False, observed_at=clock.now())
     assert poller._stage_tx_interlocked_entries([]) == [entry]  # noqa: SLF001
     await poller._execute_queued_entry(entry)  # noqa: SLF001
@@ -370,12 +367,14 @@ async def test_deferred_replacement_and_expiry_emit_ordered_terminal_truth() -> 
         ("first", "superseded", ("replacement",)),
         ("replacement", "queued", ("replacement",)),
     ]
+    assert isinstance(first.future.exception(), CommandError)
     assert service.lifecycle_events()[-1].details["expiresAt"] == 23.0
 
     clock.advance(0.5)
     _observe_ptt(store, True, observed_at=clock.now())
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     assert service.lifecycle_events()[-1].state == "timed_out"
+    assert isinstance(replacement.future.exception(), CommandError)
     terminal_count = len(service.lifecycle_events())
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     assert len(service.lifecycle_events()) == terminal_count


### PR DESCRIPTION
## Summary

- emit additive queued lifecycle truth when the Web RadioPoller holds a command in the existing shared TX-interlock lane
- preserve command identity and target while reporting absolute expiry, supersession, and exact timeout truth
- keep release ingress-acknowledged until the existing downstream/readback path resolves it

Linear: [MOR-1768](https://linear.app/morozsm/issue/MOR-1768)

## Behavior

- first and replacement holds each emit one `queued` event with `heldBy: tx_interlock`, `reason: tx_active`, and the original absolute `expiresAt`
- repeated held observations emit no lifecycle storm
- supersession expires the old overlay before terminal `superseded` and replacement held truth
- exact expiry emits terminal `timed_out` once with no dispatch
- UNKNOWN remains fail-closed and emits no held lifecycle
- normal release emits no synthetic success or confirmation
- B1-b queue, deadline, future, and downstream execution behavior remains unchanged

## Red-first evidence

The focused lifecycle tests were committed first. On the exact base they failed because held commands remained only ingress-acknowledged and replacement/expiry emitted no lifecycle truth. The implementation makes the full focused matrix green.

## Verification

- focused policy/poller/service suite: 393 passed
- relevant Web transaction suite: 203 passed, 2 skipped
- exact-head full non-integration: 9,997 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- owned mypy: clean; full mypy parity: base 12 / head 12 pre-existing errors
- Ruff check and format: pass
- import-linter: 5/5 contracts kept
- frontend check, lint, boundaries, i18n, and build: pass
- diff-check, exact two-file/199-LOC guard, and privacy scan: pass

## Scope

- 2 files
- 199 changed LOC
- no server delivery, frontend behavior, CommandService/Yaesu changes, runtime launch, serial, radio, PTT, TUNE, TX, or keying activity
