### PR TITLE
feat(MOR-1769): deliver deferred lifecycle to WebSocket issuer

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2061,6 +2061,7 @@ class WebServer:
         Recomputing from history has no such failure mode: nothing to leak.
         """
         if event.state not in ("failed", "timed_out"):
+            self._send_command_lifecycle_event(event)
             return
         was_acknowledged = any(
             e.command_id == event.command_id and e.state == "acknowledged"
@@ -2082,6 +2083,65 @@ class WebServer:
             code="commandExecutionFailed",
             params={"reason": reason},
         )
+        self._send_command_lifecycle_event(event)
+
+    def _send_command_lifecycle_event(self, event: CommandLifecycleEvent) -> None:
+        """Deliver validated additive lifecycle truth to its issuer only."""
+        details = event.details
+        timestamp = event.timestamp_monotonic
+        if (
+            event.state not in ("queued", "superseded", "timed_out", "failed")
+            or event.source != "websocket"
+            or not isinstance(event.command_id, str)
+            or not event.command_id.strip()
+            or isinstance(timestamp, bool)
+            or not isinstance(timestamp, (int, float))
+            or not math.isfinite(timestamp)
+            or (event.target is not None and not isinstance(event.target, FieldPath))
+            or (event.message is not None and not isinstance(event.message, str))
+            or not isinstance(details, dict)
+        ):
+            return
+        session_id = details.get("session_id")
+        if not isinstance(session_id, str) or not session_id.strip():
+            return
+        public_details: dict[str, Any] = {}
+        if event.state == "queued":
+            expires_at = details.get("expiresAt")
+            if (
+                set(details) != {"session_id", "heldBy", "reason", "expiresAt"}
+                or details.get("heldBy") != "tx_interlock"
+                or details.get("reason") != "tx_active"
+                or isinstance(expires_at, bool)
+                or not isinstance(expires_at, (int, float))
+                or not math.isfinite(expires_at)
+            ):
+                return
+            public_details = {
+                "heldBy": "tx_interlock",
+                "reason": "tx_active",
+                "expiresAt": expires_at,
+            }
+        elif set(details) != {"session_id"}:
+            return
+        if not any(
+            prior.command_id == event.command_id
+            and prior.source == event.source
+            and prior.state == "acknowledged"
+            and (prior.details or {}).get("session_id") == session_id
+            for prior in self.command_service.lifecycle_events()
+        ):
+            return
+        q = self._session_queues.get(session_id)
+        if q is None:
+            logger.debug("command lifecycle issuer is disconnected: %s", session_id)
+            return
+        payload = {"type": "command_lifecycle", **event.to_dict()}
+        payload["details"] = public_details
+        try:
+            q.put_nowait(payload)
+        except asyncio.QueueFull:
+            logger.debug("command lifecycle issuer queue is full: %s", session_id)
 
     def _broadcast_dx_spot(self, spot: Any) -> None:
         """Add DX spot to buffer and push dx_spot message to all control clients."""

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2060,8 +2060,10 @@ class WebServer:
         would leak a hand-maintained "currently acknowledged" set forever.
         Recomputing from history has no such failure mode: nothing to leak.
         """
+        if not self._send_lifecycle(event, check=True):
+            return
         if event.state not in ("failed", "timed_out"):
-            self._send_command_lifecycle_event(event)
+            self._send_lifecycle(event)
             return
         was_acknowledged = any(
             e.command_id == event.command_id and e.state == "acknowledged"
@@ -2083,10 +2085,12 @@ class WebServer:
             code="commandExecutionFailed",
             params={"reason": reason},
         )
-        self._send_command_lifecycle_event(event)
+        self._send_lifecycle(event)
 
-    def _send_command_lifecycle_event(self, event: CommandLifecycleEvent) -> None:
-        """Deliver validated additive lifecycle truth to its issuer only."""
+    def _send_lifecycle(
+        self, event: CommandLifecycleEvent, check: bool = False
+    ) -> bool:
+        """Validate and optionally deliver additive issuer-only lifecycle truth."""
         details = event.details
         timestamp = event.timestamp_monotonic
         if (
@@ -2101,10 +2105,10 @@ class WebServer:
             or (event.message is not None and not isinstance(event.message, str))
             or not isinstance(details, dict)
         ):
-            return
+            return False
         session_id = details.get("session_id")
         if not isinstance(session_id, str) or not session_id.strip():
-            return
+            return False
         public_details: dict[str, Any] = {}
         if event.state == "queued":
             expires_at = details.get("expiresAt")
@@ -2116,32 +2120,37 @@ class WebServer:
                 or not isinstance(expires_at, (int, float))
                 or not math.isfinite(expires_at)
             ):
-                return
+                return False
             public_details = {
                 "heldBy": "tx_interlock",
                 "reason": "tx_active",
                 "expiresAt": expires_at,
             }
         elif set(details) != {"session_id"}:
-            return
-        if not any(
+            return False
+        acknowledged = any(
             prior.command_id == event.command_id
             and prior.source == event.source
             and prior.state == "acknowledged"
             and (prior.details or {}).get("session_id") == session_id
             for prior in self.command_service.lifecycle_events()
-        ):
-            return
+        )
+        if not acknowledged:
+            return False
+        if check:
+            return True
         q = self._session_queues.get(session_id)
         if q is None:
             logger.debug("command lifecycle issuer is disconnected: %s", session_id)
-            return
+            return False
         payload = {"type": "command_lifecycle", **event.to_dict()}
         payload["details"] = public_details
         try:
             q.put_nowait(payload)
         except asyncio.QueueFull:
             logger.debug("command lifecycle issuer queue is full: %s", session_id)
+            return False
+        return True
 
     def _broadcast_dx_spot(self, spot: Any) -> None:
         """Add DX spot to buffer and push dx_spot message to all control clients."""

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -26,6 +26,7 @@ from rigplane.core.acquisition_scheduler import (
 )
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
+    CommandLifecycleEvent,
     FieldPath,
     Observation,
     SourceMetadata,
@@ -3191,6 +3192,128 @@ def _register_two_sessions(
     return issuer_q, bystander_q
 
 
+def _held_details(**overrides: object) -> dict[str, object]:
+    details: dict[str, object] = {
+        "session_id": "session-issuer",
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": 15.0,
+    }
+    details.update(overrides)
+    return details
+
+
+def _held_lifecycle(**overrides: object) -> CommandLifecycleEvent:
+    values: dict[str, object] = {
+        "command_id": "cmd-held",
+        "state": "queued",
+        "timestamp_monotonic": 12.5,
+        "source": "websocket",
+        "target": FieldPath.active("main", "freq_mode", "freq_hz"),
+        "message": None,
+        "details": _held_details(),
+    }
+    values.update(overrides)
+    return CommandLifecycleEvent(**values)  # type: ignore[arg-type]
+
+
+async def _ack_held(srv: WebServer) -> None:
+    srv.command_service._executor = _StubCommandExecutor()  # noqa: SLF001
+    await srv.command_service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq_hz": 1},
+            source="websocket",
+            command_id="cmd-held",
+            session_id="session-issuer",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    await _ack_held(srv)
+
+    srv._on_command_lifecycle_event(_held_lifecycle())  # noqa: SLF001
+
+    payload = issuer_q.get_nowait()
+    assert tuple(
+        payload[key]
+        for key in (
+            "type",
+            "commandId",
+            "state",
+            "timestampMonotonic",
+            "source",
+        )
+    ) == ("command_lifecycle", "cmd-held", "queued", 12.5, "websocket")
+    assert payload["target"] == "receiver.main.active.freq_mode.freq_hz"
+    assert payload["message"] is None
+    assert payload["details"] == {
+        "heldBy": "tx_interlock",
+        "reason": "tx_active",
+        "expiresAt": 15.0,
+    }
+    assert issuer_q.empty()
+    assert bystander_q.empty()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"command_id": ""},
+        {"source": "public_api"},
+        {"state": "confirmed"},
+        {"timestamp_monotonic": True},
+        {"timestamp_monotonic": float("nan")},
+        {"target": "not-a-field-path"},
+        {"message": 7},
+        {"details": {"session_id": "session-issuer"}},
+        {"details": _held_details(heldBy="wrong")},
+        {"details": _held_details(expiresAt=False)},
+        {"details": _held_details(expiresAt=float("inf"), extra=1)},
+    ],
+)
+@pytest.mark.asyncio
+async def test_malformed_deferred_lifecycle_is_ignored(
+    overrides: dict[str, object],
+) -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    await _ack_held(srv)
+
+    srv._on_command_lifecycle_event(_held_lifecycle(**overrides))  # noqa: SLF001
+
+    assert issuer_q.empty()
+    assert bystander_q.empty()
+
+
+@pytest.mark.asyncio
+async def test_deferred_lifecycle_ack_identity_and_bounded_queue() -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    event = _held_lifecycle()
+    srv._on_command_lifecycle_event(event)  # noqa: SLF001
+    assert issuer_q.empty()
+
+    await _ack_held(srv)
+    cross_session = _held_lifecycle(
+        details={**event.details, "session_id": "session-bystander"}
+    )
+    srv._on_command_lifecycle_event(cross_session)  # noqa: SLF001
+    assert issuer_q.empty() and bystander_q.empty()
+
+    issuer_q.put_nowait({"sentinel": True})
+    srv._on_command_lifecycle_event(event)  # noqa: SLF001
+    assert issuer_q.get_nowait() == {"sentinel": True}
+    srv.unregister_control_event_queue(issuer_q, session_id="session-issuer")
+    _drain_queue(bystander_q)
+    srv._on_command_lifecycle_event(event)  # noqa: SLF001
+    assert bystander_q.empty()
+
+
 @pytest.mark.asyncio
 async def test_post_ack_command_failure_notifies_issuer_only() -> None:
     """A command that fails AFTER being acknowledged reaches the session
@@ -3229,7 +3352,14 @@ async def test_post_ack_command_failure_notifies_issuer_only() -> None:
     assert n["category"] == "command"
     assert n["code"] == "commandExecutionFailed"
     assert "Attenuator level" in n["params"]["reason"]
-    assert issuer_q.empty()  # exactly one notification, not more
+    lifecycle = issuer_q.get_nowait()
+    assert (lifecycle["type"], lifecycle["state"], lifecycle["details"]) == (
+        "command_lifecycle",
+        "failed",
+        {},
+    )
+    assert lifecycle["commandId"] == "cmd-att-1"
+    assert issuer_q.empty()
     assert bystander_q.empty()  # zero — never broadcast
 
 
@@ -3292,6 +3422,9 @@ async def test_command_timed_out_after_ack_notifies_issuer_only() -> None:
     assert n["level"] == "error"
     assert n["code"] == "commandExecutionFailed"
     assert n["params"]["reason"] == "radio did not respond"
+    lifecycle = issuer_q.get_nowait()
+    assert lifecycle["state"] == "timed_out"
+    assert lifecycle["details"] == {}
     assert bystander_q.empty()
 
 

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3239,23 +3239,21 @@ async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
     srv._on_command_lifecycle_event(_held_lifecycle())  # noqa: SLF001
 
     payload = issuer_q.get_nowait()
-    assert tuple(
-        payload[key]
-        for key in (
-            "type",
-            "commandId",
-            "state",
-            "timestampMonotonic",
-            "source",
-        )
-    ) == ("command_lifecycle", "cmd-held", "queued", 12.5, "websocket")
+    assert payload["type"] == "command_lifecycle"
+    assert payload["commandId"] == "cmd-held"
+    assert payload["state"] == "queued"
+    assert payload["timestampMonotonic"] == 12.5
+    assert payload["source"] == "websocket"
     assert payload["target"] == "receiver.main.active.freq_mode.freq_hz"
-    assert payload["message"] is None
     assert payload["details"] == {
         "heldBy": "tx_interlock",
         "reason": "tx_active",
         "expiresAt": 15.0,
     }
+    srv._on_command_lifecycle_event(
+        _held_lifecycle(state="superseded", details={"session_id": "session-issuer"})
+    )  # noqa: SLF001
+    assert issuer_q.get_nowait()["state"] == "superseded"
     assert issuer_q.empty()
     assert bystander_q.empty()
 
@@ -3311,6 +3309,13 @@ async def test_deferred_lifecycle_ack_identity_and_bounded_queue() -> None:
     srv.unregister_control_event_queue(issuer_q, session_id="session-issuer")
     _drain_queue(bystander_q)
     srv._on_command_lifecycle_event(event)  # noqa: SLF001
+    assert bystander_q.empty()
+    srv.command_service._events.append(
+        _held_lifecycle(state="acknowledged", details={"session_id": "unknown"})
+    )  # noqa: SLF001
+    srv._on_command_lifecycle_event(
+        _held_lifecycle(details=_held_details(session_id="unknown"))
+    )  # noqa: SLF001
     assert bystander_q.empty()
 
 

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3192,18 +3192,17 @@ def _register_two_sessions(
     return issuer_q, bystander_q
 
 
-def _held_details(**overrides: object) -> dict[str, object]:
+def _hold(**overrides: object) -> dict[str, object]:
     details: dict[str, object] = {
         "session_id": "session-issuer",
         "heldBy": "tx_interlock",
         "reason": "tx_active",
         "expiresAt": 15.0,
     }
-    details.update(overrides)
-    return details
+    return details | overrides
 
 
-def _held_lifecycle(**overrides: object) -> CommandLifecycleEvent:
+def _life(**overrides: object) -> CommandLifecycleEvent:
     values: dict[str, object] = {
         "command_id": "cmd-held",
         "state": "queued",
@@ -3211,10 +3210,13 @@ def _held_lifecycle(**overrides: object) -> CommandLifecycleEvent:
         "source": "websocket",
         "target": FieldPath.active("main", "freq_mode", "freq_hz"),
         "message": None,
-        "details": _held_details(),
+        "details": _hold(),
     }
-    values.update(overrides)
-    return CommandLifecycleEvent(**values)  # type: ignore[arg-type]
+    return CommandLifecycleEvent(**(values | overrides))  # type: ignore[arg-type]
+
+
+def _terminal(**overrides: object) -> dict[str, object]:
+    return {"state": "failed", "details": {"session_id": "session-issuer"}, **overrides}
 
 
 async def _ack_held(srv: WebServer) -> None:
@@ -3236,13 +3238,11 @@ async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
 
-    srv._on_command_lifecycle_event(_held_lifecycle())  # noqa: SLF001
+    srv._on_command_lifecycle_event(_life())  # noqa: SLF001
 
     payload = issuer_q.get_nowait()
-    assert payload["type"] == "command_lifecycle"
-    assert payload["commandId"] == "cmd-held"
-    assert payload["state"] == "queued"
-    assert payload["timestampMonotonic"] == 12.5
+    assert payload["type"] == "command_lifecycle" and payload["commandId"] == "cmd-held"
+    assert payload["state"] == "queued" and payload["timestampMonotonic"] == 12.5
     assert payload["source"] == "websocket"
     assert payload["target"] == "receiver.main.active.freq_mode.freq_hz"
     assert payload["details"] == {
@@ -3251,10 +3251,9 @@ async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
         "expiresAt": 15.0,
     }
     srv._on_command_lifecycle_event(
-        _held_lifecycle(state="superseded", details={"session_id": "session-issuer"})
+        _life(state="superseded", details={"session_id": "session-issuer"})
     )  # noqa: SLF001
-    assert issuer_q.get_nowait()["state"] == "superseded"
-    assert issuer_q.empty()
+    assert issuer_q.get_nowait()["state"] == "superseded" and issuer_q.empty()
     assert bystander_q.empty()
 
 
@@ -3262,16 +3261,16 @@ async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
     "overrides",
     [
         {"command_id": ""},
-        {"source": "public_api"},
+        _terminal(source="public_api"),
         {"state": "confirmed"},
-        {"timestamp_monotonic": True},
-        {"timestamp_monotonic": float("nan")},
+        _terminal(timestamp_monotonic=True),
+        _terminal(state="timed_out", timestamp_monotonic=float("nan")),
         {"target": "not-a-field-path"},
         {"message": 7},
         {"details": {"session_id": "session-issuer"}},
-        {"details": _held_details(heldBy="wrong")},
-        {"details": _held_details(expiresAt=False)},
-        {"details": _held_details(expiresAt=float("inf"), extra=1)},
+        {"details": _hold(heldBy="wrong")},
+        {"details": _hold(expiresAt=False)},
+        {"details": _hold(expiresAt=float("inf"), extra=1)},
     ],
 )
 @pytest.mark.asyncio
@@ -3282,24 +3281,21 @@ async def test_malformed_deferred_lifecycle_is_ignored(
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
 
-    srv._on_command_lifecycle_event(_held_lifecycle(**overrides))  # noqa: SLF001
+    srv._on_command_lifecycle_event(_life(**overrides))  # noqa: SLF001
 
-    assert issuer_q.empty()
-    assert bystander_q.empty()
+    assert issuer_q.empty() and bystander_q.empty()
 
 
 @pytest.mark.asyncio
 async def test_deferred_lifecycle_ack_identity_and_bounded_queue() -> None:
     srv = WebServer()
     issuer_q, bystander_q = _register_two_sessions(srv)
-    event = _held_lifecycle()
+    event = _life()
     srv._on_command_lifecycle_event(event)  # noqa: SLF001
     assert issuer_q.empty()
 
     await _ack_held(srv)
-    cross_session = _held_lifecycle(
-        details={**event.details, "session_id": "session-bystander"}
-    )
+    cross_session = _life(state="failed", details={"session_id": "session-bystander"})
     srv._on_command_lifecycle_event(cross_session)  # noqa: SLF001
     assert issuer_q.empty() and bystander_q.empty()
 
@@ -3311,11 +3307,9 @@ async def test_deferred_lifecycle_ack_identity_and_bounded_queue() -> None:
     srv._on_command_lifecycle_event(event)  # noqa: SLF001
     assert bystander_q.empty()
     srv.command_service._events.append(
-        _held_lifecycle(state="acknowledged", details={"session_id": "unknown"})
+        _life(state="acknowledged", details={"session_id": "unknown"})
     )  # noqa: SLF001
-    srv._on_command_lifecycle_event(
-        _held_lifecycle(details=_held_details(session_id="unknown"))
-    )  # noqa: SLF001
+    srv._on_command_lifecycle_event(_life(details=_hold(session_id="unknown")))  # noqa: SLF001
     assert bystander_q.empty()
 
 
@@ -3358,13 +3352,10 @@ async def test_post_ack_command_failure_notifies_issuer_only() -> None:
     assert n["code"] == "commandExecutionFailed"
     assert "Attenuator level" in n["params"]["reason"]
     lifecycle = issuer_q.get_nowait()
-    assert (lifecycle["type"], lifecycle["state"], lifecycle["details"]) == (
-        "command_lifecycle",
-        "failed",
-        {},
-    )
-    assert lifecycle["commandId"] == "cmd-att-1"
-    assert issuer_q.empty()
+    assert lifecycle["type"] == "command_lifecycle"
+    assert lifecycle["state"] == "failed"
+    assert lifecycle["details"] == {}
+    assert lifecycle["commandId"] == "cmd-att-1" and issuer_q.empty()
     assert bystander_q.empty()  # zero — never broadcast
 
 


### PR DESCRIPTION
## Summary

- deliver validated deferred command lifecycle messages only to the issuing WebSocket session
- preserve the existing failure notification first, then add the structured lifecycle event
- reject malformed, pre-ack, cross-session, disconnected, and queue-full delivery without broadcast or retry

Linear: [MOR-1769](https://linear.app/morozsm/issue/MOR-1769)

## Wire contract

- base message: `type`, `commandId`, `state`, `timestampMonotonic`, `source`, nullable `target`, nullable `message`, and `details`
- allowed states: `queued`, `superseded`, `timed_out`, and `failed`
- a queued TX-interlock hold exposes only validated `heldBy`, `reason`, and finite `expiresAt` details
- terminal `details` is exactly `{}`; `session_id` remains routing-only and never reaches the wire
- delivery requires an earlier acknowledgement matching command id, WebSocket source, and session id

## Red-first evidence

The delivery and terminal-order tests were committed first. On the exact base, issuer lifecycle and structured failure/timeout messages were absent while malformed and pre-ack cases already remained fail-closed. The implementation makes the full focused matrix green.

## Verification

- focused lifecycle matrix: 15 passed
- adjacent Web/CommandService/Poller suite: 452 passed, 2 skipped
- post-main-merge combined Web/Yaesu suite: 555 passed, 2 skipped
- full non-integration before the final non-overlapping Yaesu-only main merge: 10,010 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- owned server mypy: clean; full mypy base/head parity: 12/12 pre-existing errors
- Ruff check and format: pass
- import-linter: 5/5 contracts kept
- frontend check, lint, boundaries, i18n, and build: pass
- diff-check, exact two-file/200-LOC guard, and privacy scan: pass

## Scope

- 2 files
- 200 changed LOC
- no producer, frontend, CommandService, Yaesu, rigctld, B1-d, runtime launch, serial, radio, PTT, TUNE, TX, or keying changes
