### PR TITLE
MOR-1770: reconcile Yaesu dispatch with canonical readback

### DIFF
--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -28,6 +28,7 @@ from collections.abc import Awaitable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
+from rigplane.core.command_service import _is_yaesu_cat_readback, _yaesu_receiver_alias
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
@@ -66,13 +67,12 @@ _TX_TARGET_PATH = FieldPath.global_("tx_state", "tx_target")
 _ACTIVE_RECEIVER_PATH = FieldPath.global_("slow_state", "active")
 
 
-def _yaesu_observation_path(path: FieldPath) -> FieldPath:
-    if path.scope.value != "receiver" or path.receiver_id not in {"0", "1"}:
-        return path
-    receiver = "main" if path.receiver_id == "0" else "sub"
-    if path.family.value == "freq_mode" and path.slot is None:
-        return FieldPath.active(receiver, path.family.value, path.name)
-    return FieldPath.receiver(receiver, path.family.value, path.name)
+def _exact_readback_value_matches(observed: Any, expected: Any) -> bool:
+    if type(observed) not in (bool, int, float, str) or type(observed) is not type(
+        expected
+    ):
+        return False
+    return bool(observed == expected)
 
 
 class YaesuCatPoller:
@@ -450,7 +450,7 @@ class YaesuCatPoller:
         for expectation in expectations or ():
             if expectation.path == _ACTIVE_RECEIVER_PATH:
                 self._pending_receiver_select = entry
-            self._pending_readbacks[_yaesu_observation_path(expectation.path)] = (
+            self._pending_readbacks[_yaesu_receiver_alias(expectation.path)] = (
                 expectation,
                 entry,
                 generation,
@@ -515,14 +515,12 @@ class YaesuCatPoller:
             )
             matches = (
                 expectation in expectations
-                and observation.value == expectation.value
+                and _exact_readback_value_matches(observation.value, expectation.value)
                 and observation.timestamp_monotonic >= dispatched_at
                 and generation[0] == self._current_tx_target_generation()
                 and generation[1] == self._captured_provider_generation()
                 and observation.provider_generation == generation[1]
-                and observation.source.source == "yaesu_poll_response"
-                and observation.source.provider == "yaesu_cat"
-                and observation.source.transport == "serial"
+                and _is_yaesu_cat_readback(observation.source)
             )
             if matches:
                 result[index] = replace(

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -66,6 +66,15 @@ _TX_TARGET_PATH = FieldPath.global_("tx_state", "tx_target")
 _ACTIVE_RECEIVER_PATH = FieldPath.global_("slow_state", "active")
 
 
+def _yaesu_observation_path(path: FieldPath) -> FieldPath:
+    if path.scope.value != "receiver" or path.receiver_id not in {"0", "1"}:
+        return path
+    receiver = "main" if path.receiver_id == "0" else "sub"
+    if path.family.value == "freq_mode" and path.slot is None:
+        return FieldPath.active(receiver, path.family.value, path.name)
+    return FieldPath.receiver(receiver, path.family.value, path.name)
+
+
 class YaesuCatPoller:
     """Polling scheduler for :class:`~.radio.YaesuCatRadio`.
 
@@ -125,6 +134,7 @@ class YaesuCatPoller:
         self._capture_provider_generation: Callable[[], int] | None = None
         self._advance_provider_generation: Callable[[], int] | None = None
         self._pending_receiver_select: CommandQueueEntry | None = None
+        self._pending_readbacks: dict[FieldPath, tuple[Any, ...]] = {}
         self._deferred_tx_lane = DeferredTxCommandLane()
         self._deferred_tx_entry: CommandQueueEntry | None = None
         self._deferred_tx_generation: (
@@ -369,7 +379,7 @@ class YaesuCatPoller:
             self._ptt_observation = ptt_observation
             self._ptt_connection_generation = generation
             self._last_ptt = ptt_observation.value
-        self._observation_callback(observations)
+        self._observation_callback(self._annotate_yaesu_readbacks(observations))
         return True
 
     async def _emit_fast_observations(self) -> bool:
@@ -415,7 +425,7 @@ class YaesuCatPoller:
         if not self._provider_generation_is_current(provider_generation):
             return True
         self._observation_callback(
-            self._annotate_receiver_select_readback(
+            self._annotate_yaesu_readbacks(
                 self._stamp_provider_generation(observations, provider_generation)
             )
         )
@@ -428,13 +438,24 @@ class YaesuCatPoller:
             or entry.source is None
         ):
             return
-        expectations = entry.command_service.readback_expectations(
+        expectations = entry.command_service.retain_readback_expectations_for_dispatch(
             source=entry.source,
             session_id=entry.session_id,
             command_id=entry.command_id,
         )
-        if any(item.path == _ACTIVE_RECEIVER_PATH for item in expectations):
-            self._pending_receiver_select = entry
+        generation = (
+            self._current_tx_target_generation(),
+            self._captured_provider_generation(),
+        )
+        for expectation in expectations or ():
+            if expectation.path == _ACTIVE_RECEIVER_PATH:
+                self._pending_receiver_select = entry
+            self._pending_readbacks[_yaesu_observation_path(expectation.path)] = (
+                expectation,
+                entry,
+                generation,
+                time.monotonic(),
+            )
 
     def _annotate_receiver_select_readback(
         self, observations: Sequence[Observation]
@@ -476,6 +497,46 @@ class YaesuCatPoller:
                 )
                 self._pending_receiver_select = None
             result.append(observation)
+        return tuple(result)
+
+    def _annotate_yaesu_readbacks(
+        self, observations: Sequence[Observation]
+    ) -> tuple[Observation, ...]:
+        result = list(observations)
+        for index, observation in enumerate(result):
+            pending = self._pending_readbacks.get(observation.path)
+            if pending is None or observation.correlation_id is not None:
+                continue
+            expectation, entry, generation, dispatched_at = pending
+            expectations = entry.command_service.readback_expectations(
+                source=entry.source,
+                session_id=entry.session_id,
+                command_id=entry.command_id,
+            )
+            matches = (
+                expectation in expectations
+                and observation.value == expectation.value
+                and observation.timestamp_monotonic >= dispatched_at
+                and generation[0] == self._current_tx_target_generation()
+                and generation[1] == self._captured_provider_generation()
+                and observation.provider_generation == generation[1]
+                and observation.source.source == "yaesu_poll_response"
+                and observation.source.provider == "yaesu_cat"
+                and observation.source.transport == "serial"
+            )
+            if matches:
+                result[index] = replace(
+                    observation,
+                    source=replace(
+                        observation.source,
+                        command_source=entry.source,
+                        session_id=entry.session_id,
+                    ),
+                    correlation_id=entry.command_id,
+                )
+                self._pending_readbacks.pop(observation.path, None)
+            elif expectation not in expectations:
+                self._pending_readbacks.pop(observation.path, None)
         return tuple(result)
 
     # ------------------------------------------------------------------
@@ -592,7 +653,8 @@ class YaesuCatPoller:
             self._deferred_tx_generation = None
             if entry is not None:
                 if transition.outcome is TxInterlockDeferredOutcome.RELEASED:
-                    entries.append(entry)
+                    if self._deferred_release_is_live(entry):
+                        entries.append(entry)
                 else:
                     self._finish_deferred_entry(entry, superseded=False)
         if self._command_queue.has_commands:
@@ -677,6 +739,36 @@ class YaesuCatPoller:
                     type(cmd).__name__,
                     exc_info=True,
                 )
+
+    def _deferred_release_is_live(self, entry: CommandQueueEntry) -> bool:
+        reason = None
+        if (
+            entry.source == "websocket"
+            and entry.session_id is not None
+            and self._command_queue is not None
+            and not self._command_queue.session_is_live(entry.session_id)
+        ):
+            reason = f"control session {entry.session_id} is gone"
+        elif (
+            entry.command_service is not None
+            and entry.command_id is not None
+            and entry.source is not None
+            and entry.command_service.retain_readback_expectations_for_dispatch(
+                source=entry.source,
+                session_id=entry.session_id,
+                command_id=entry.command_id,
+            )
+            is None
+        ):
+            reason = "deferred command no longer active"
+        if reason is None:
+            return True
+        error = CommandError(reason)
+        if "no longer active" not in reason:
+            self._mark_queued_command_failed(entry, error)
+        if entry.future is not None and not entry.future.done():
+            entry.future.set_exception(error)
+        return False
 
     def _deferred_generation_change(self) -> str | None:
         generation = self._deferred_tx_generation

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -68,11 +68,11 @@ _ACTIVE_RECEIVER_PATH = FieldPath.global_("slow_state", "active")
 
 
 def _exact_readback_value_matches(observed: Any, expected: Any) -> bool:
-    if type(observed) not in (bool, int, float, str) or type(observed) is not type(
-        expected
-    ):
+    kind = type(observed)
+    if kind not in (bool, int, float, str) or kind is not type(expected):
         return False
-    return bool(observed == expected)
+    finite = kind is not float or observed - observed == expected - expected == 0
+    return finite and bool(observed == expected)
 
 
 class YaesuCatPoller:

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -38,6 +38,7 @@ __all__ = [
 _UNSET = object()
 _MAX_READBACK_EXPECTATIONS = 128
 _READBACK_EXPECTATION_GRACE_SECONDS = 2.0
+_DISPATCHABLE_LIFECYCLE_STATES = ("accepted", "queued", "sent", "acknowledged")
 _NORMALIZED_LEVEL_EXPECTATION_COMMANDS = {
     "set_af_level": "af_level",
     "set_rf_gain": "rf_gain",
@@ -359,12 +360,7 @@ class CommandService:
     ) -> tuple[PendingOverlay, ...] | None:
         """Refresh existing expectations at dispatch, or reject a terminal command."""
         event = self._last_event(command_id, source=source, session_id=session_id)
-        if event is None or event.state not in {
-            "accepted",
-            "queued",
-            "sent",
-            "acknowledged",
-        }:
+        if event is None or event.state not in _DISPATCHABLE_LIFECYCLE_STATES:
             return None
         matches = self.readback_expectations(
             source=source, session_id=session_id, command_id=command_id
@@ -949,10 +945,10 @@ def _is_external_rigctld_readback(source: SourceMetadata) -> bool:
 
 
 def _is_yaesu_cat_readback(source: SourceMetadata) -> bool:
-    return (
-        source.source == "yaesu_poll_response"
-        and source.provider == "yaesu_cat"
-        and source.transport == "serial"
+    return (source.source, source.provider, source.transport) == (
+        "yaesu_poll_response",
+        "yaesu_cat",
+        "serial",
     )
 
 

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -350,6 +350,34 @@ class CommandService:
             and item.command_id == command_id
         )
 
+    def retain_readback_expectations_for_dispatch(
+        self,
+        *,
+        source: CommandSource,
+        session_id: str | None,
+        command_id: str,
+    ) -> tuple[PendingOverlay, ...] | None:
+        """Refresh existing expectations at dispatch, or reject a terminal command."""
+        event = self._last_event(command_id, source=source, session_id=session_id)
+        if event is None or event.state not in {
+            "accepted",
+            "queued",
+            "sent",
+            "acknowledged",
+        }:
+            return None
+        matches = self.readback_expectations(
+            source=source, session_id=session_id, command_id=command_id
+        )
+        expires_at = self._clock() + _READBACK_EXPECTATION_GRACE_SECONDS
+        retained = tuple(
+            replace(item, expires_at_monotonic=expires_at) for item in matches
+        )
+        self._readback_expectations = [
+            item for item in self._readback_expectations if item not in matches
+        ] + list(retained)
+        return retained
+
     def discard_readback_expectations(
         self,
         *,
@@ -521,7 +549,10 @@ class CommandService:
     ) -> None:
         if (
             observation.correlation_id is None
-            or not _is_external_rigctld_readback(observation.source)
+            or not (
+                _is_external_rigctld_readback(observation.source)
+                or _is_yaesu_cat_readback(observation.source)
+            )
             or observation.source.command_source is None
         ):
             return
@@ -898,6 +929,10 @@ def _paths_reconcile(observation: Observation, overlay_path: FieldPath) -> bool:
     observation_path = observation.path
     if observation_path == overlay_path:
         return True
+    if _is_yaesu_cat_readback(observation.source):
+        return _yaesu_receiver_alias(observation_path) == _yaesu_receiver_alias(
+            overlay_path
+        )
     if not _is_external_rigctld_readback(observation.source):
         return False
     return _external_rigctld_main_alias(observation_path) == (
@@ -911,6 +946,23 @@ def _is_external_rigctld_readback(source: SourceMetadata) -> bool:
         and source.provider == "external_rigctld"
         and source.transport == "rigctld"
     )
+
+
+def _is_yaesu_cat_readback(source: SourceMetadata) -> bool:
+    return (
+        source.source == "yaesu_poll_response"
+        and source.provider == "yaesu_cat"
+        and source.transport == "serial"
+    )
+
+
+def _yaesu_receiver_alias(path: FieldPath) -> FieldPath:
+    if path.scope.value != "receiver" or path.receiver_id not in {"0", "1"}:
+        return path
+    receiver = "main" if path.receiver_id == "0" else "sub"
+    if path.family.value == "freq_mode" and path.slot is None:
+        return FieldPath.active(receiver, path.family.value, path.name)
+    return FieldPath.receiver(receiver, path.family.value, path.name)
 
 
 def _external_rigctld_main_alias(path: FieldPath) -> FieldPath:

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -2260,8 +2260,8 @@ async def test_ftx1_web_receiver_selection_writes_once_and_waits_for_vs_readback
     truth_trap = MagicMock(**{"__bool__.side_effect": RuntimeError("truthiness trap")})
     untrusted = MagicMock()
     untrusted.__eq__.side_effect = (RuntimeError("equality trap"), object(), truth_trap)
-    for _ in range(3):
-        candidate = replace(observed, value=untrusted)
+    for value in [untrusted] * 3 + [float("nan"), float("inf"), float("-inf")]:
+        candidate = replace(observed, value=value)
         guarded = poller._annotate_yaesu_readbacks((candidate,))[0]  # noqa: SLF001
         accept((guarded,))
     matched = poller._annotate_yaesu_readbacks(  # noqa: SLF001

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1035,8 +1035,7 @@ async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
     )
     future = asyncio.get_running_loop().create_future()
     service = MagicMock()
-    if boundary == "session":
-        queue.register_session("ws")
+    queue.register_session("ws")
     queue.put_ordered(
         SetFreq(7_100_000),
         future=future,
@@ -2258,6 +2257,13 @@ async def test_ftx1_web_receiver_selection_writes_once_and_waits_for_vs_readback
     ).observation(observed_path, 7_100_000)
     observed = replace(observed, provider_generation=store.provider_generation)
     assert poller._annotate_yaesu_readbacks((observed,))[0].correlation_id is None  # noqa: SLF001
+    truth_trap = MagicMock(**{"__bool__.side_effect": RuntimeError("truthiness trap")})
+    untrusted = MagicMock()
+    untrusted.__eq__.side_effect = (RuntimeError("equality trap"), object(), truth_trap)
+    for _ in range(3):
+        candidate = replace(observed, value=untrusted)
+        guarded = poller._annotate_yaesu_readbacks((candidate,))[0]  # noqa: SLF001
+        accept((guarded,))
     matched = poller._annotate_yaesu_readbacks(  # noqa: SLF001
         (replace(observed, value=7_200_000),)
     )[0]

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1013,6 +1013,8 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
         ("provider-generation", "provider generation changed"),
         ("provider-replacement", "provider binding replaced"),
         ("connection-generation", "connection generation changed"),
+        ("command-terminal", "no longer active"),
+        ("session", "gone"),
     ),
 )
 async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
@@ -1033,11 +1035,14 @@ async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
     )
     future = asyncio.get_running_loop().create_future()
     service = MagicMock()
+    if boundary == "session":
+        queue.register_session("ws")
     queue.put_ordered(
         SetFreq(7_100_000),
         future=future,
         command_id="held",
         source="websocket",
+        session_id="ws",
         command_service=service,
     )
     _set_fresh_ptt_observation(poller, active=True)
@@ -1053,15 +1058,23 @@ async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
         store.begin_provider_generation()
     elif boundary == "provider-replacement":
         poller.bind_provider_generation(capture=lambda: 1)
+    elif boundary == "command-terminal":
+        service.retain_readback_expectations_for_dispatch.return_value = None
+    elif boundary == "session":
+        queue.unregister_session("ws")
     else:
         radio._transport.stats.reconnects += 1
         poller._sync_tx_target_generation()  # noqa: SLF001
+    if boundary in {"command-terminal", "session"}:
+        poller._deferred_tx_lane._entry.quiet_since = 9.0  # type: ignore[union-attr]  # noqa: SLF001
+        poller._ptt_observation = _ptt_observation(False, observed_at=10.0)  # noqa: SLF001
     await poller._drain_commands()  # noqa: SLF001
 
     error = future.exception()
     assert isinstance(error, CommandError)
     assert reason in str(error)
-    assert service.fail_command.call_args.kwargs["timed_out"] is False
+    if boundary != "command-terminal":
+        assert service.fail_command.call_args.kwargs["timed_out"] is False
     assert poller._deferred_tx_entry is None  # noqa: SLF001
     assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
 
@@ -2227,6 +2240,33 @@ async def test_ftx1_web_receiver_selection_writes_once_and_waits_for_vs_readback
         mock_call("VS0;"),
     ]
     assert store.snapshot().field(active_path).value == "SUB"
+    observed_path = FieldPath.active("sub", "freq_mode", "freq_hz")
+    for command_id, freq in (("old", 7_100_000), ("latest", 7_200_000)):
+        await handler._enqueue_command(  # noqa: SLF001
+            "set_freq", {"freq": freq, "receiver": 1}, command_id=command_id
+        )
+        dispatched_at = asyncio.get_running_loop().time()
+        await poller._drain_commands()  # noqa: SLF001
+    [latest] = service.readback_expectations(
+        source="websocket", session_id="ws-ftx1", command_id="latest"
+    )
+    assert 1.9 < latest.expires_at_monotonic - dispatched_at <= 2.01
+    observed = ProviderObservationAdapter(
+        radio.profile.state_acquisition,
+        source="yaesu_poll_response",
+        transport="serial",
+    ).observation(observed_path, 7_100_000)
+    observed = replace(observed, provider_generation=store.provider_generation)
+    assert poller._annotate_yaesu_readbacks((observed,))[0].correlation_id is None  # noqa: SLF001
+    matched = poller._annotate_yaesu_readbacks(  # noqa: SLF001
+        (replace(observed, value=7_200_000),)
+    )[0]
+    assert matched.correlation_id == "latest"
+    assert matched.source == replace(
+        observed.source, command_source="websocket", session_id="ws-ftx1"
+    )
+    accept((matched,))
+    assert service.lifecycle_events()[-1].state == "reconciled"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1770/mor-1500-b2-d4-reconcile-yaesu-dispatch-with-canonical-readback

## Summary
- retain existing live CommandService readback expectations for a bounded two-second post-dispatch grace without reviving terminal commands
- correlate exact Yaesu medium/slow poll observations through the existing `reconciled` lifecycle path, including numeric receiver to main/sub canonical aliases
- revalidate deferred command/session liveness immediately before release so stale held work cannot actuate

## Safety and scope
- source is restricted to `yaesu_poll_response` / `yaesu_cat` / `serial` and current provider/CAT generations
- mismatched value, stale timestamp, expired expectation, old generation, wrong provider, or uncommanded observations do not reconcile
- no request-name target mappings, UI, profile, protocol, hardware, or TX actuation changes
- exactly 3 files and 200 changed LOC

## Verification
- RED reproduced on base for dispatch grace, Yaesu correlation, and held terminal/session revocation
- `uv run pytest -q tests/test_yaesu_cat_poller.py` (105 passed)
- relevant Yaesu/FTX/CommandService/Web/interlock suite (829 passed)
- full non-integration suite (10003 passed, 74 skipped, 14 xfailed, 1 xpassed)
- adversarial stale timestamp/provider generation/provider/expiry matrix PASS
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run lint-imports`
- full `uv run mypy src/` exact base/head parity: 12 known errors, 0 owned
- `git diff --check` and public/secret scan clean

Hardware/runtime/radio/serial/PTT/TUNE/TX/keying were not used.