### PR TITLE
fix(MOR-1771): require getter readback for external rigctld state

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -543,7 +543,6 @@ class RigctldClientRadio:
         if freq <= 0:
             raise ValueError("freq must be > 0 Hz")
         await self._transport.command(f"F {int(freq)}")
-        self._state.main.freq = int(freq)
 
     async def get_mode(self, receiver: int = 0) -> tuple[str, int | None]:
         self._require_main_receiver(receiver, "get_mode")
@@ -577,8 +576,6 @@ class RigctldClientRadio:
                 raise ValueError("filter_width must be >= 0")
             command = f"{command} {int(filter_width)}"
         await self._transport.command(command)
-        self._state.main.mode = normalized
-        self._state.main.filter_width = filter_width
 
     async def get_data_mode(self) -> bool:
         # Flat unavailable value — external rigctld has no data-mode read.
@@ -604,7 +601,6 @@ class RigctldClientRadio:
 
     async def set_ptt(self, on: bool) -> None:
         await self._transport.command(f"T {1 if on else 0}")
-        self._state.ptt = bool(on)
 
     async def get_vfo_slot(self, receiver: int = 0) -> str:
         self._require_main_receiver(receiver, "get_vfo_slot")
@@ -617,7 +613,6 @@ class RigctldClientRadio:
         self._require_main_receiver(receiver, "set_vfo_slot")
         normalized = _normalize_vfo_slot(slot)
         await self._transport.command(f"V VFO{normalized}")
-        self._state.main.active_slot = normalized
 
     async def get_rf_gain(self, receiver: int = 0) -> int:
         self._require_main_receiver(receiver, "get_rf_gain")

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -133,22 +133,87 @@ async def test_radio_core_frequency_mode_ptt_and_vfo() -> None:
 
             assert await radio.get_freq() == 14_074_000
             await radio.set_freq(7_050_000)
+            assert radio.radio_state.main.freq == 14_074_000
+            assert await radio.get_freq() == 7_050_000
             assert radio.radio_state.main.freq == 7_050_000
 
             assert await radio.get_mode() == ("USB", 2400)
             await radio.set_mode("LSB", 1800)
+            assert radio.radio_state.main.mode == "USB"
+            assert radio.radio_state.main.filter_width == 2400
+            assert await radio.get_mode() == ("LSB", 1800)
             assert radio.radio_state.main.mode == "LSB"
             assert radio.radio_state.main.filter_width == 1800
 
             assert await radio.get_ptt() is False
             await radio.set_ptt(True)
+            assert radio.radio_state.ptt is False
+            assert await radio.get_ptt() is True
             assert radio.radio_state.ptt is True
 
             assert await radio.get_vfo_slot() == "A"
             await radio.set_vfo_slot("B")
+            assert radio.radio_state.main.active_slot == "A"
+            assert await radio.get_vfo_slot() == "B"
             assert radio.radio_state.main.active_slot == "B"
         finally:
             await radio.disconnect()
+
+    assert server.commands_seen == [
+        "v",
+        "f",
+        "F 7050000",
+        "f",
+        "m",
+        "M LSB 1800",
+        "m",
+        "t",
+        "T 1",
+        "t",
+        "v",
+        "V VFOB",
+        "v",
+    ]
+
+
+async def test_failed_core_setters_leave_radio_state_unchanged() -> None:
+    behavior = FakeRigctldBehavior(unsupported_commands={"F", "M", "T", "V"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            assert await radio.get_freq() == 14_074_000
+            assert await radio.get_mode() == ("USB", 2400)
+            assert await radio.get_ptt() is False
+            assert await radio.get_vfo_slot() == "A"
+
+            for setter in (
+                radio.set_freq(7_050_000),
+                radio.set_mode("LSB", 1800),
+                radio.set_ptt(True),
+                radio.set_vfo_slot("B"),
+            ):
+                with pytest.raises(CommandError, match="unsupported"):
+                    await setter
+                assert radio.radio_state.main.freq == 14_074_000
+                assert radio.radio_state.main.mode == "USB"
+                assert radio.radio_state.main.filter_width == 2400
+                assert radio.radio_state.ptt is False
+                assert radio.radio_state.main.active_slot == "A"
+        finally:
+            await radio.disconnect()
+
+    assert server.commands_seen == [
+        "v",
+        "f",
+        "m",
+        "t",
+        "v",
+        "F 7050000",
+        "M LSB 1800",
+        "T 1",
+        "V VFOB",
+    ]
 
 
 async def test_radio_reports_actionable_connection_failure() -> None:


### PR DESCRIPTION
## Linear

- [MOR-1771](https://linear.app/morozsm/issue/MOR-1771/mor-1500-b4-d0-stop-external-rigctld-setters-from-optimistically)
- Parent: MOR-1629

## Summary

- treat external `rigctld` setter `RPRT 0` as transport acceptance only
- preserve the previous legacy `RadioState` mirror after successful frequency, mode, PTT, and VFO-slot setters
- update observed state only through the existing getter/readback path
- preserve exact Hamlib wire commands and existing failure behavior

## Red-first evidence

- Before implementation: `tests/test_rigctld_client_backend.py` failed at the post-`F 7050000` assertion because the setter changed local state before readback (`1 failed, 20 passed`).

## Verification

- `uv run pytest tests/test_rigctld_client_backend.py -q --tb=short` — 21 passed
- focused external-rigctld/backend/adapter suite — 96 passed
- full non-integration suite — 10063 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — 674 files formatted
- `uv run lint-imports` — 5 contracts kept
- `uv run mypy src/` — exact base parity: 12 pre-existing errors in 3 unchanged files on both base and head
- `git diff --check` and diff secret scan — clean

## Compatibility and safety

- Public API: unchanged
- Rigctld wire bytes: unchanged and asserted exactly
- No runtime, serial, radio, PTT, TUNE, TX, or keying operation was performed
- No B4-c deferred-lane, correlation/generation, handler/server, lifecycle, or protocol-capability scope
