### PR TITLE
MOR-1772: decode epoch-safe Web command lifecycle delivery

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WsCommand, WsMessage } from '../../types/protocol';
 import type { ReceiverState, ServerState } from '../../types/state';
-import type { CommandDeliveryEvent, ControlSessionTransition } from '../ws-client';
+import type { CommandDeliveryEvent, CommandLifecycleDeliveryEvent, ControlSessionTransition } from '../ws-client';
 import { MockWebSocket, instances } from './support/fake-ws-backend';
 
 type ServerStateWithObservation = ServerState & {
@@ -348,6 +348,114 @@ describe('WsChannel', () => {
       { commandId: 'freq', kind: 'ack', originalEpoch: 1, eventEpoch: 1 },
       { commandId: 'freq', kind: 'response-ok', originalEpoch: 1, eventEpoch: 1 },
     ]);
+  });
+
+  it('strictly decodes correlated private command lifecycle frames', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const lifecycle: CommandLifecycleDeliveryEvent[] = [];
+    const ordinary: CommandDeliveryEvent[] = [];
+    const messages: WsMessage[] = [];
+    ch.onCommandLifecycleDelivery((event) => lifecycle.push(event));
+    ch.onCommandDelivery((event) => ordinary.push(event));
+    ch.onMessage((message) => messages.push(message));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+
+    for (const id of ['held', 'timeout', 'failed']) {
+      expect(ch.send({ type: 'cmd', name: 'set_freq', id, params: { freq: 1 } })).toBe(true);
+    }
+    const held = {
+      type: 'command_lifecycle', commandId: 'held', state: 'queued',
+      details: { heldBy: 'tx_interlock', reason: 'tx_active', expiresAt: 12.5, secret: 'drop' },
+      source: 'websocket', session: 'private', target: 'main', timestampMonotonic: 10,
+      originalEpoch: 999, eventEpoch: 999,
+    };
+    instances[0].simulateMessage(JSON.stringify(held));
+    instances[0].simulateMessage(JSON.stringify(held));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'held', ok: true }));
+    instances[0].simulateMessage(JSON.stringify({ ...held, state: 'superseded', message: null, details: {} }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'timeout', state: 'timed_out', message: 'expired', details: {} }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'timeout', ok: true }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'failed', ok: true }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'failed', state: 'failed', message: 'blocked', details: {} }));
+
+    expect(lifecycle).toEqual([
+      { commandId: 'held', kind: 'held', originalEpoch: 1, eventEpoch: 1, reason: 'tx_active', expiresAt: 12.5 },
+      { commandId: 'held', kind: 'superseded', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'timeout', kind: 'timed-out', originalEpoch: 1, eventEpoch: 1, error: 'expired' },
+      { commandId: 'failed', kind: 'failed', originalEpoch: 1, eventEpoch: 1, error: 'blocked' },
+    ]);
+    expect(ordinary.filter((event) => event.kind === 'response-ok')).toHaveLength(3);
+    expect(messages).not.toContainEqual(expect.objectContaining({ type: 'command_lifecycle' }));
+  });
+
+  it('rejects malformed, stale, cancelled, and evicted lifecycle delivery', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandLifecycleDeliveryEvent[] = [];
+    ch.onCommandLifecycleDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'valid', params: {} });
+    const invalid: unknown[] = [null, [], 'text',
+      { type: 'command_lifecycle', commandId: '', state: 'failed' },
+      { type: 'command_lifecycle', commandId: 'unknown', state: 'failed' },
+      { type: 'command_lifecycle', commandId: 'valid', state: 'other' },
+      { type: 'command_lifecycle', commandId: 'valid', state: 'queued', details: null },
+      { type: 'command_lifecycle', commandId: 'valid', state: 'queued', details: { heldBy: 'other', reason: 'tx_active', expiresAt: 1 } },
+      { type: 'command_lifecycle', commandId: 'valid', state: 'queued', details: { heldBy: 'tx_interlock', reason: 'tx_active', expiresAt: true } },
+      { type: 'command_lifecycle', commandId: 'valid', state: 'queued', details: { heldBy: 'tx_interlock', reason: 'tx_active', expiresAt: -1 } },
+      { type: 'command_lifecycle', commandId: 'valid', state: 'failed', message: 3 },
+    ];
+    for (const frame of invalid) instances[0].simulateMessage(JSON.stringify(frame));
+    expect(events).toEqual([]);
+
+    ch.cancelNonPtt('provider changed');
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'valid', state: 'failed', message: null }));
+    for (let i = 0; i <= 100; i += 1) {
+      ch.send({ type: 'cmd', name: 'set_freq', id: `evict-${i}`, params: {} });
+      instances[0].simulateMessage(JSON.stringify({ type: 'response', id: `evict-${i}`, ok: true }));
+    }
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'evict-0', state: 'failed' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'evict-100', state: 'failed' }));
+    expect(events).toEqual([{ commandId: 'evict-100', kind: 'failed', originalEpoch: 1, eventEpoch: 1 }]);
+    expect(instances[0].sent).toHaveLength(102);
+  });
+
+  it('fences lifecycle correlation to its sending socket without consuming responses', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const lifecycle: CommandLifecycleDeliveryEvent[] = [];
+    const ordinary: CommandDeliveryEvent[] = [];
+    ch.onCommandLifecycleDelivery((event) => lifecycle.push(event));
+    ch.onCommandDelivery((event) => ordinary.push(event));
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'offline', params: {} });
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'offline', state: 'failed' }));
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'before-response', params: {} });
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'before-response', state: 'failed' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'before-response', ok: true }));
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'sync-error', params: {} });
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'sync-error', ok: false }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'command_lifecycle', commandId: 'sync-error', state: 'failed' }));
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reused', params: {} });
+    instances[0].simulateClose();
+    vi.advanceTimersByTime(1_300);
+    instances[1].simulateOpen();
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reused', params: {} });
+    const terminal = JSON.stringify({ type: 'command_lifecycle', commandId: 'reused', state: 'failed' });
+    instances[0].simulateMessage(terminal);
+    instances[1].simulateMessage(terminal);
+
+    expect(lifecycle).toEqual([
+      { commandId: 'offline', kind: 'failed', originalEpoch: 0, eventEpoch: 1 },
+      { commandId: 'before-response', kind: 'failed', originalEpoch: 1, eventEpoch: 1 },
+      { commandId: 'reused', kind: 'failed', originalEpoch: 2, eventEpoch: 2 },
+    ]);
+    expect(ordinary).toContainEqual(expect.objectContaining({ commandId: 'before-response', kind: 'response-ok' }));
+    expect(ordinary).toContainEqual(expect.objectContaining({ commandId: 'sync-error', kind: 'response-error' }));
   });
 
   it('rejects the 101st direct generic send before the wire without evicting correlation', async () => {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -19,17 +19,33 @@ export interface CommandDeliveryEvent {
   error?: string;
   cancelled?: boolean;
 }
+export type CommandLifecycleDeliveryKind = 'held' | 'superseded' | 'timed-out' | 'failed';
+export interface CommandLifecycleDeliveryEvent {
+  commandId: string;
+  kind: CommandLifecycleDeliveryKind;
+  originalEpoch: number;
+  eventEpoch: number;
+  reason?: string;
+  expiresAt?: number;
+  error?: string;
+}
 type MessageHandler = (msg: WsIncoming) => void;
 type BinaryHandler = (data: ArrayBuffer) => void;
 type StateHandler = (state: ConnectionState) => void;
 export type ControlSessionTransitionHandler = (transition: ControlSessionTransition) => void;
 type CommandDeliveryHandler = (event: CommandDeliveryEvent) => void;
+type CommandLifecycleDeliveryHandler = (event: CommandLifecycleDeliveryEvent) => void;
 type PendingPttRelease = { command: WsCommand; originalEpoch: number };
 type TrackedPttCommand = PendingPttRelease & {
   seen: Set<CommandDeliveryKind>;
 };
 type PendingNonPttCommand = { command: WsCommand; originalEpoch: number };
 type TrackedNonPttCommand = TrackedPttCommand & { eventEpoch: number };
+type TrackedLifecycleCommand = {
+  originalEpoch: number;
+  eventEpoch: number;
+  seen: Set<CommandLifecycleDeliveryKind>;
+};
 
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
@@ -38,6 +54,7 @@ const KEEPALIVE_INTERVAL_MS = 15_000; // send ping to prevent idle timeout
 const MAX_QUEUE_SIZE = 20;
 const MAX_TRACKED_PTT_COMMANDS = 100;
 const MAX_TRACKED_NON_PTT_COMMANDS = 100;
+const MAX_TRACKED_LIFECYCLE_COMMANDS = 100;
 
 // Command types where only the latest value matters (last write wins)
 const IDEMPOTENT_TYPES = new Set(['set_freq', 'set_mode', 'set_filter']);
@@ -57,6 +74,11 @@ function calcBackoff(attempt: number): number {
 
 function isTabHidden(): boolean {
   return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
 }
 
 // ─── Close observability (MOR-1424) ─────────────────────────────────────────
@@ -91,7 +113,9 @@ export class WsChannel {
   private transportEpoch = 0;
   private trackedPttCommands = new Map<string, TrackedPttCommand>();
   private trackedNonPttCommands = new Map<string, TrackedNonPttCommand>();
+  private trackedLifecycleCommands = new Map<string, TrackedLifecycleCommand>();
   private commandDeliveryHandlers = new Set<CommandDeliveryHandler>();
+  private commandLifecycleDeliveryHandlers = new Set<CommandLifecycleDeliveryHandler>();
   private messageHandlers = new Set<MessageHandler>();
   private binaryHandlers = new Set<BinaryHandler>();
   private stateHandlers = new Set<StateHandler>();
@@ -210,6 +234,10 @@ export class WsChannel {
       } else {
         try {
           const raw = JSON.parse(event.data as string) as Record<string, unknown>;
+          if (raw['type'] === 'command_lifecycle') {
+            this._emitCommandLifecycle(raw, socketEpoch);
+            return;
+          }
           this._emitCommandResult(raw, socketEpoch);
           // Handle status-based error responses ({"status":"error", ...})
           if (raw['status'] === 'error') {
@@ -251,6 +279,7 @@ export class WsChannel {
       console.info('[ws] closed', _lastCloseInfo);
       this._clearHeartbeat();
       this.trackedNonPttCommands.clear();
+      this.trackedLifecycleCommands.clear();
       this.ws = null;
       this.setState('disconnected');
       if (!this.intentionalClose) {
@@ -285,6 +314,7 @@ export class WsChannel {
     const { ws } = this;
     this.ws = null;
     this.trackedNonPttCommands.clear();
+    this.trackedLifecycleCommands.clear();
     if (ws) {
       if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CLOSING) {
         ws.close();
@@ -383,6 +413,11 @@ export class WsChannel {
     return () => this.commandDeliveryHandlers.delete(handler);
   }
 
+  onCommandLifecycleDelivery(handler: CommandLifecycleDeliveryHandler): () => void {
+    this.commandLifecycleDeliveryHandlers.add(handler);
+    return () => this.commandLifecycleDeliveryHandlers.delete(handler);
+  }
+
   get sessionEpoch(): number {
     return this.transportEpoch;
   }
@@ -396,6 +431,7 @@ export class WsChannel {
       this._rejectNonPtt(tracked.command.id, tracked.originalEpoch, error, this.transportEpoch, true);
     }
     this.trackedNonPttCommands.clear();
+    this.trackedLifecycleCommands.clear();
   }
 
   private _sendPtt(ws: WebSocket, pending: PendingPttRelease, eventEpoch: number): boolean {
@@ -438,6 +474,16 @@ export class WsChannel {
     }
     const tracked: TrackedNonPttCommand = { ...pending, eventEpoch, seen: new Set() };
     this.trackedNonPttCommands.set(pending.command.id, tracked);
+    const lifecycleId = pending.command.id;
+    if (typeof lifecycleId === 'string' && lifecycleId.trim().length > 0) {
+      this.trackedLifecycleCommands.delete(lifecycleId);
+      if (this.trackedLifecycleCommands.size >= MAX_TRACKED_LIFECYCLE_COMMANDS) {
+        this.trackedLifecycleCommands.delete(this.trackedLifecycleCommands.keys().next().value!);
+      }
+      this.trackedLifecycleCommands.set(lifecycleId, {
+        originalEpoch: pending.originalEpoch, eventEpoch, seen: new Set(),
+      });
+    }
     this._emitTracked(tracked, 'transport-sent', tracked.eventEpoch);
     return true;
   }
@@ -467,6 +513,45 @@ export class WsChannel {
       this._emitTracked(generic, 'error', generic.eventEpoch, String(raw.message ?? raw.error ?? 'Command failed'));
       this.trackedNonPttCommands.delete(id);
     }
+    const lifecycle = this.trackedLifecycleCommands.get(id);
+    if (lifecycle?.eventEpoch === eventEpoch && (
+      (raw.type === 'response' && raw.ok === false) || raw.type === 'error' || raw.status === 'error'
+    )) this.trackedLifecycleCommands.delete(id);
+  }
+
+  private _emitCommandLifecycle(raw: Record<string, unknown>, eventEpoch: number): void {
+    if (!isPlainRecord(raw)) return;
+    const id = raw.commandId;
+    const state = raw.state;
+    if (typeof id !== 'string' || id.trim().length === 0) return;
+    if (state !== 'queued' && state !== 'superseded' && state !== 'timed_out' && state !== 'failed') return;
+    const tracked = this.trackedLifecycleCommands.get(id);
+    if (!tracked || tracked.eventEpoch !== eventEpoch) return;
+
+    let kind: CommandLifecycleDeliveryKind;
+    let reason: string | undefined;
+    let expiresAt: number | undefined;
+    let error: string | undefined;
+    if (state === 'queued') {
+      const details = raw.details;
+      if (!isPlainRecord(details) || details.heldBy !== 'tx_interlock' || details.reason !== 'tx_active') return;
+      if (typeof details.expiresAt !== 'number' || !Number.isFinite(details.expiresAt) || details.expiresAt < 0) return;
+      kind = 'held';
+      reason = 'tx_active';
+      expiresAt = details.expiresAt;
+    } else {
+      if (raw.message !== undefined && raw.message !== null && typeof raw.message !== 'string') return;
+      kind = state === 'timed_out' ? 'timed-out' : state;
+      if (typeof raw.message === 'string') error = raw.message;
+    }
+    if (tracked.seen.has(kind)) return;
+    tracked.seen.add(kind);
+    this.commandLifecycleDeliveryHandlers.forEach((handler) => handler({
+      commandId: id, kind, originalEpoch: tracked.originalEpoch, eventEpoch,
+      ...(reason ? { reason } : {}), ...(expiresAt !== undefined ? { expiresAt } : {}),
+      ...(error !== undefined ? { error } : {}),
+    }));
+    if (kind !== 'held') this.trackedLifecycleCommands.delete(id);
   }
 
   private _rejectNonPtt(
@@ -860,6 +945,10 @@ export function disconnect() {
 
 export function onCommandDelivery(handler: CommandDeliveryHandler): () => void {
   return _ctrl.onCommandDelivery(handler);
+}
+
+export function onCommandLifecycleDelivery(handler: CommandLifecycleDeliveryHandler): () => void {
+  return _ctrl.onCommandLifecycleDelivery(handler);
 }
 
 export function onControlSessionTransition(handler: ControlSessionTransitionHandler): () => void {


### PR DESCRIPTION
## Linear

[MOR-1772](https://linear.app/morozsm/issue/MOR-1772/mor-1500-b1-c3-decode-epoch-safe-web-command-lifecycle-delivery)

## Summary

- add a separate transport-only lifecycle delivery bus for private `command_lifecycle` frames
- strictly validate and normalize held/superseded/timed-out/failed lifecycle truth
- correlate delivery to the exact successful non-PTT send and WebSocket epoch with bounded retention
- preserve ordinary ACK/response delivery and keep private server fields out of frontend consumers

## Red-first evidence

Before implementation, the focused isolated suite failed 2/69 tests because `WsChannel.onCommandLifecycleDelivery` did not exist.

## Verification

- `npm test -- --run src/lib/transport/__tests__/ws-client.isolated.test.ts` — 70 passed
- `npm test -- --reporter=dot` — 366 files, 8049 passed
- `npm run check` — 0 errors, 0 warnings
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check` — OK (informational fallback notes only)
- `npm run build`
- `git diff --check`

## Scope

- 2 files
- 198 insertions, 1 deletion (199 changed LOC)
- no store projection, backend/runtime/radio/TX, public API, CLI, or config changes

Independent exact-head review is required before merge.
