### PR TITLE
fix(MOR-1773): publish exact-once rigctld transport generations

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -441,24 +441,17 @@ class RigctldClientRadio:
         self._model = model or "External rigctld"
         self._state = RadioState()
         self._vfo_supported = False
-        self._provider_generation_advance: Callable[[], int] | None = None
-        self._has_connected = False
 
     def bind_provider_generation(
         self, *, advance: Callable[[], int] | None = None
     ) -> None:
-        """Let the Web fallback Store fence an explicit replacement connection."""
+        """Let the Web fallback Store fence transport lifecycle edges."""
 
-        self._provider_generation_advance = advance
+        self._transport.bind_provider_generation(advance=advance)
 
     async def connect(self) -> None:
-        if self._has_connected and not self.connected:
-            advance = self._provider_generation_advance
-            if advance is not None:
-                advance()
         await self._transport.connect()
         await self._probe_vfo_support()
-        self._has_connected = True
 
     async def disconnect(self) -> None:
         await self._transport.close()

--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 
 from ...exceptions import CommandError
 from ...exceptions import ConnectionError as RadioConnectionError
@@ -30,6 +31,15 @@ class RigctldTransport:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._lock = asyncio.Lock()
+        self._provider_generation_advance: Callable[[], int] | None = None
+        self._connection_retired = True
+
+    def bind_provider_generation(
+        self, *, advance: Callable[[], int] | None = None
+    ) -> None:
+        """Bind the existing provider-generation lifecycle callback."""
+
+        self._provider_generation_advance = advance
 
     @property
     def connected(self) -> bool:
@@ -40,7 +50,7 @@ class RigctldTransport:
         if self.connected:
             return
         try:
-            self._reader, self._writer = await asyncio.wait_for(
+            reader, writer = await asyncio.wait_for(
                 asyncio.open_connection(self.host, self.port),
                 timeout=self.timeout,
             )
@@ -54,11 +64,24 @@ class RigctldTransport:
                 f"Failed to connect to external rigctld at "
                 f"{self.host}:{self.port}: {exc}"
             ) from exc
+        self._reader, self._writer = reader, writer
+        self._connection_retired = False
 
     async def close(self) -> None:
         writer = self._writer
+        had_connection = self._reader is not None or writer is not None
         self._reader = None
         self._writer = None
+        if had_connection and not self._connection_retired:
+            self._connection_retired = True
+            advance = self._provider_generation_advance
+            if advance is not None:
+                try:
+                    advance()
+                except Exception:
+                    _LOGGER.exception(
+                        "external rigctld provider generation callback failed"
+                    )
         if writer is None:
             return
         writer.close()

--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -49,6 +49,8 @@ class RigctldTransport:
     async def connect(self) -> None:
         if self.connected:
             return
+        if self._reader is not None or self._writer is not None:
+            await self.close()
         try:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_connection(self.host, self.port),

--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -90,7 +90,7 @@ class RigctldTransport:
         except OSError:
             pass
 
-    async def _drain_stale(self) -> None:
+    async def _drain_stale(self, command: str) -> None:
         """Discard any unread bytes left in the socket buffer from a prior
         transaction (e.g. a late/out-of-band frame the bridge injected) so the
         next command reads only its own reply."""
@@ -102,8 +102,18 @@ class RigctldTransport:
                 chunk = await asyncio.wait_for(reader.read(4096), timeout=0.001)
             except (asyncio.TimeoutError, TimeoutError):
                 return
+            except OSError as exc:
+                await self.close()
+                raise RadioConnectionError(
+                    f"Connection to external rigctld at {self.host}:{self.port} "
+                    f"failed while reading response to {command!r}: {exc}"
+                ) from exc
             if not chunk:
-                return  # EOF
+                await self.close()
+                raise RadioConnectionError(
+                    f"External rigctld at {self.host}:{self.port} closed the "
+                    f"connection while handling {command!r}."
+                )
             _LOGGER.debug("rigctld transport: drained %d stale bytes", len(chunk))
 
     async def query(self, command: str, *, response_lines: int) -> list[str]:
@@ -112,7 +122,7 @@ class RigctldTransport:
             raise ValueError("response_lines must be > 0")
 
         async with self._lock:
-            await self._drain_stale()
+            await self._drain_stale(command)
             await self._write_line(command)
             lines: list[str] = []
             for _ in range(response_lines):
@@ -131,7 +141,7 @@ class RigctldTransport:
     async def command(self, command: str) -> None:
         """Send a write command and require ``RPRT 0`` success."""
         async with self._lock:
-            await self._drain_stale()
+            await self._drain_stale(command)
             await self._write_line(command)
             # Re-sync: do ONE blocking read for the server's response.
             # If it is not RPRT-shaped (stray value line that arrived in the

--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -31,6 +31,7 @@ class RigctldTransport:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
         self._provider_generation_advance: Callable[[], int] | None = None
         self._connection_retired = True
 
@@ -47,10 +48,14 @@ class RigctldTransport:
         return writer is not None and not writer.is_closing()
 
     async def connect(self) -> None:
+        async with self._lifecycle_lock:
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
         if self.connected:
             return
         if self._reader is not None or self._writer is not None:
-            await self.close()
+            await self._close_locked()
         try:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_connection(self.host, self.port),
@@ -70,6 +75,10 @@ class RigctldTransport:
         self._connection_retired = False
 
     async def close(self) -> None:
+        async with self._lifecycle_lock:
+            await self._close_locked()
+
+    async def _close_locked(self) -> None:
         writer = self._writer
         had_connection = self._reader is not None or writer is not None
         self._reader = None

--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -161,8 +161,18 @@ class RigctldTransport:
                 except (asyncio.TimeoutError, TimeoutError):
                     # Nothing else buffered — `line` is the actual response.
                     break
+                except OSError as exc:
+                    await self.close()
+                    raise RadioConnectionError(
+                        f"Connection to external rigctld at {self.host}:{self.port} "
+                        f"failed while reading response to {command!r}: {exc}"
+                    ) from exc
                 if not raw:
-                    break  # EOF
+                    await self.close()
+                    raise RadioConnectionError(
+                        f"External rigctld at {self.host}:{self.port} closed the "
+                        f"connection while handling {command!r}."
+                    )
                 _LOGGER.debug(
                     "rigctld transport: skipping non-RPRT line for %r: %r",
                     command,

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -109,27 +109,6 @@ async def test_transport_timeout_eof_malformed_and_negative_rprt() -> None:
             await transport.close()
 
 
-async def test_radio_transport_loss_advances_provider_generation_once() -> None:
-    behavior = FakeRigctldBehavior(disconnect_commands={"f"})
-    async with FakeRigctldServer(behavior=behavior) as server:
-        radio = RigctldClientRadio(host=server.host, port=server.port)
-        await radio.connect()
-        transitions: list[bool] = []
-        radio.bind_provider_generation(
-            advance=lambda: transitions.append(radio.connected) or len(transitions)
-        )
-
-        with pytest.raises(RadioConnectionError, match="closed"):
-            await radio.get_freq()
-
-        assert transitions == [False]
-        with pytest.raises(RadioConnectionError, match="not connected"):
-            await radio.get_freq()
-        assert transitions == [False]
-        await radio.disconnect()
-        assert transitions == [False]
-
-
 @pytest.mark.parametrize(
     ("stage", "read_result", "message"),
     (
@@ -217,7 +196,9 @@ async def test_radio_transport_failures_advance_provider_generation_once(
         assert transitions == [False]
 
 
-async def test_radio_reconnect_does_not_double_advance_transport_generation() -> None:
+async def test_radio_reconnect_does_not_double_advance_transport_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     behavior = FakeRigctldBehavior(disconnect_commands={"f"})
     async with FakeRigctldServer(behavior=behavior) as server:
         radio = RigctldClientRadio(host=server.host, port=server.port)
@@ -230,15 +211,33 @@ async def test_radio_reconnect_does_not_double_advance_transport_generation() ->
         with pytest.raises(RadioConnectionError):
             await radio.get_freq()
         assert generations == [1]
+        with pytest.raises(RadioConnectionError, match="not connected"):
+            await radio.get_freq()
+        await radio.disconnect()
+        assert generations == [1]
 
         await radio.connect()
         assert radio.connected
         assert generations == [1]
 
-        await radio.disconnect()
+        old_writer = radio._transport._writer  # noqa: SLF001
+        assert old_writer is not None
+        close = MagicMock(side_effect=old_writer.close)
+        monkeypatch.setattr(old_writer, "is_closing", lambda: True)
+        monkeypatch.setattr(old_writer, "close", close)
+        monkeypatch.setattr(asyncio, "open_connection", AsyncMock(side_effect=OSError))
+        with pytest.raises(RadioConnectionError):
+            await radio.connect()
+        assert not radio.connected
+        monkeypatch.undo()
+        await radio.connect()
+        assert close.call_count == 1
         assert generations == [1, 2]
+
         await radio.disconnect()
-        assert generations == [1, 2]
+        assert generations == [1, 2, 3]
+        await radio.disconnect()
+        assert generations == [1, 2, 3]
 
 
 async def test_radio_core_frequency_mode_ptt_and_vfo() -> None:

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -131,10 +131,16 @@ async def test_radio_transport_loss_advances_provider_generation_once() -> None:
 
 
 @pytest.mark.parametrize(
-    ("read_result", "message"),
-    ((b"", "closed"), (OSError("stale read lost"), "failed while reading")),
+    ("stage", "read_result", "message"),
+    (
+        ("stale", b"", "closed"),
+        ("stale", OSError("stale read lost"), "failed while reading"),
+        ("resync", b"", "closed"),
+        ("resync", OSError("resync read lost"), "failed while reading"),
+    ),
 )
-async def test_radio_stale_drain_loss_retires_before_command_write(
+async def test_radio_buffered_read_loss_retires_without_subsequent_write(
+    stage: str,
     read_result: bytes | OSError,
     message: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -151,17 +157,23 @@ async def test_radio_stale_drain_loss_retires_before_command_write(
         assert reader is not None and writer is not None
         writes: list[bytes] = []
         monkeypatch.setattr(writer, "write", writes.append)
-        read = (
+        failing_read = (
             AsyncMock(side_effect=read_result)
             if isinstance(read_result, OSError)
             else AsyncMock(return_value=read_result)
         )
-        monkeypatch.setattr(reader, "read", read)
+        if stage == "stale":
+            monkeypatch.setattr(reader, "read", failing_read)
+        else:
+            monkeypatch.setattr(reader, "read", AsyncMock(side_effect=TimeoutError))
+            monkeypatch.setattr(
+                reader, "readline", AsyncMock(side_effect=[b"stray\n", read_result])
+            )
 
         with pytest.raises(RadioConnectionError, match=message):
-            await radio.get_freq()
+            await (radio.get_freq() if stage == "stale" else radio.set_freq(7_050_000))
 
-        assert writes == []
+        assert writes == ([] if stage == "stale" else [b"F 7050000\n"])
         assert transitions == [False]
         await radio.disconnect()
         assert transitions == [False]

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -110,22 +110,16 @@ async def test_transport_timeout_eof_malformed_and_negative_rprt() -> None:
 
 
 @pytest.mark.parametrize(
-    ("stage", "read_result", "message"),
-    (
-        ("stale", b"", "closed"),
-        ("stale", OSError("stale read lost"), "failed while reading"),
-        ("resync", b"", "closed"),
-        ("resync", OSError("resync read lost"), "failed while reading"),
-    ),
+    "failure",
+    "stale_eof stale_oserror resync_eof resync_oserror read_timeout "
+    "write_timeout write_oserror".split(),
 )
-async def test_radio_buffered_read_loss_retires_without_subsequent_write(
-    stage: str,
-    read_result: bytes | OSError,
-    message: str,
-    monkeypatch: pytest.MonkeyPatch,
+async def test_radio_transport_loss_retires_exactly_once(
+    failure: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     async with FakeRigctldServer() as server:
-        radio = RigctldClientRadio(host=server.host, port=server.port)
+        timeout = 0.01 if failure == "read_timeout" else 5.0
+        radio = RigctldClientRadio(host=server.host, port=server.port, timeout=timeout)
         await radio.connect()
         transitions: list[bool] = []
         radio.bind_provider_generation(
@@ -136,62 +130,31 @@ async def test_radio_buffered_read_loss_retires_without_subsequent_write(
         assert reader is not None and writer is not None
         writes: list[bytes] = []
         monkeypatch.setattr(writer, "write", writes.append)
-        failing_read = (
-            AsyncMock(side_effect=read_result)
-            if isinstance(read_result, OSError)
-            else AsyncMock(return_value=read_result)
-        )
-        if stage == "stale":
+        read_result = OSError("read lost") if failure.endswith("oserror") else b""
+        failing_read = AsyncMock(side_effect=[read_result])
+        if failure.startswith("stale"):
             monkeypatch.setattr(reader, "read", failing_read)
-        else:
+        elif failure.startswith("resync"):
             monkeypatch.setattr(reader, "read", AsyncMock(side_effect=TimeoutError))
             monkeypatch.setattr(
                 reader, "readline", AsyncMock(side_effect=[b"stray\n", read_result])
             )
-
-        with pytest.raises(RadioConnectionError, match=message):
-            await (radio.get_freq() if stage == "stale" else radio.set_freq(7_050_000))
-
-        assert writes == ([] if stage == "stale" else [b"F 7050000\n"])
-        assert transitions == [False]
-        await radio.disconnect()
-        assert transitions == [False]
-
-
-@pytest.mark.parametrize("failure", ("read_timeout", "write_timeout", "oserror"))
-async def test_radio_transport_failures_advance_provider_generation_once(
-    failure: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    behavior = FakeRigctldBehavior(
-        command_delays={"f": 0.2} if failure == "read_timeout" else {}
-    )
-    async with FakeRigctldServer(behavior=behavior) as server:
-        radio = RigctldClientRadio(
-            host=server.host,
-            port=server.port,
-            timeout=0.01 if failure == "read_timeout" else 5.0,
+        elif failure.startswith("write"):
+            error = TimeoutError if failure.endswith("timeout") else OSError("lost")
+            monkeypatch.setattr(writer, "drain", AsyncMock(side_effect=error))
+        error_type = (
+            RadioTimeoutError if failure.endswith("timeout") else RadioConnectionError
         )
-        await radio.connect()
-        transitions: list[bool] = []
-        radio.bind_provider_generation(
-            advance=lambda: transitions.append(radio.connected) or len(transitions)
-        )
-        writer = radio._transport._writer  # noqa: SLF001
-        assert writer is not None
-        if failure == "write_timeout":
-            monkeypatch.setattr(writer, "drain", AsyncMock(side_effect=TimeoutError))
-        elif failure == "oserror":
-            monkeypatch.setattr(writer, "drain", AsyncMock(side_effect=OSError("lost")))
-
-        error = RadioConnectionError if failure == "oserror" else RadioTimeoutError
         operation = (
-            radio.set_freq(7_050_000) if failure != "read_timeout" else radio.get_freq()
+            radio.get_freq()
+            if failure.startswith("stale") or failure == "read_timeout"
+            else radio.set_freq(7_050_000)
         )
-        with pytest.raises(error):
+        with pytest.raises(error_type):
             await operation
-
-        assert transitions == [False]
+        expected_write = b"f\n" if failure == "read_timeout" else b"F 7050000\n"
+        expected = [] if failure.startswith("stale") else [expected_write]
+        assert writes == expected and transitions == [False]
         await radio.disconnect()
         assert transitions == [False]
 
@@ -203,23 +166,17 @@ async def test_radio_reconnect_does_not_double_advance_transport_generation(
     async with FakeRigctldServer(behavior=behavior) as server:
         radio = RigctldClientRadio(host=server.host, port=server.port)
         await radio.connect()
-        generations: list[int] = []
-        radio.bind_provider_generation(
-            advance=lambda: generations.append(len(generations) + 1) or generations[-1]
-        )
-
+        advance = MagicMock(return_value=1)
+        radio.bind_provider_generation(advance=advance)
         with pytest.raises(RadioConnectionError):
             await radio.get_freq()
-        assert generations == [1]
+        assert advance.call_count == 1
         with pytest.raises(RadioConnectionError, match="not connected"):
             await radio.get_freq()
         await radio.disconnect()
-        assert generations == [1]
-
+        assert advance.call_count == 1
         await radio.connect()
-        assert radio.connected
-        assert generations == [1]
-
+        assert radio.connected and advance.call_count == 1
         old_writer = radio._transport._writer  # noqa: SLF001
         assert old_writer is not None
         close = MagicMock(side_effect=old_writer.close)
@@ -232,12 +189,45 @@ async def test_radio_reconnect_does_not_double_advance_transport_generation(
         monkeypatch.undo()
         await radio.connect()
         assert close.call_count == 1
-        assert generations == [1, 2]
+        assert advance.call_count == 2
+        await radio.disconnect()
+        assert advance.call_count == 3
+        await radio.disconnect()
+        assert advance.call_count == 3
 
-        await radio.disconnect()
-        assert generations == [1, 2, 3]
-        await radio.disconnect()
-        assert generations == [1, 2, 3]
+
+async def test_transport_concurrent_connect_owns_one_cycle(monkeypatch) -> None:
+    transport = RigctldTransport(host="127.0.0.1")
+    entered, release = asyncio.Event(), asyncio.Event()
+    writers: list[MagicMock] = []
+
+    async def open_connection(*args: object) -> tuple[MagicMock, MagicMock]:
+        if not writers:
+            entered.set()
+            await release.wait()
+        writer = MagicMock()
+        writer.is_closing.return_value = False
+        writer.wait_closed = AsyncMock()
+        writers.append(writer)
+        return MagicMock(), writer
+
+    monkeypatch.setattr(asyncio, "open_connection", open_connection)
+    advance = MagicMock(return_value=1)
+    transport.bind_provider_generation(advance=advance)
+    tasks = [asyncio.create_task(transport.connect())]
+    await entered.wait()
+    tasks.append(asyncio.create_task(transport.connect()))
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.gather(*tasks)
+    assert len(writers) == 1 and advance.call_count == 0
+    await transport.connect()
+    assert len(writers) == 1
+    await transport.close()
+    await transport.connect()
+    await transport.close()
+    assert advance.call_count == 2
+    assert [writer.close.call_count for writer in writers] == [1, 1]
 
 
 async def test_radio_core_frequency_mode_ptt_and_vfo() -> None:

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -130,6 +130,43 @@ async def test_radio_transport_loss_advances_provider_generation_once() -> None:
         assert transitions == [False]
 
 
+@pytest.mark.parametrize(
+    ("read_result", "message"),
+    ((b"", "closed"), (OSError("stale read lost"), "failed while reading")),
+)
+async def test_radio_stale_drain_loss_retires_before_command_write(
+    read_result: bytes | OSError,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        transitions: list[bool] = []
+        radio.bind_provider_generation(
+            advance=lambda: transitions.append(radio.connected) or len(transitions)
+        )
+        reader = radio._transport._reader  # noqa: SLF001
+        writer = radio._transport._writer  # noqa: SLF001
+        assert reader is not None and writer is not None
+        writes: list[bytes] = []
+        monkeypatch.setattr(writer, "write", writes.append)
+        read = (
+            AsyncMock(side_effect=read_result)
+            if isinstance(read_result, OSError)
+            else AsyncMock(return_value=read_result)
+        )
+        monkeypatch.setattr(reader, "read", read)
+
+        with pytest.raises(RadioConnectionError, match=message):
+            await radio.get_freq()
+
+        assert writes == []
+        assert transitions == [False]
+        await radio.disconnect()
+        assert transitions == [False]
+
+
 @pytest.mark.parametrize("failure", ("read_timeout", "write_timeout", "oserror"))
 async def test_radio_transport_failures_advance_provider_generation_once(
     failure: str,

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -106,6 +107,89 @@ async def test_transport_timeout_eof_malformed_and_negative_rprt() -> None:
                 await transport.query("m", response_lines=2)
         finally:
             await transport.close()
+
+
+async def test_radio_transport_loss_advances_provider_generation_once() -> None:
+    behavior = FakeRigctldBehavior(disconnect_commands={"f"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        transitions: list[bool] = []
+        radio.bind_provider_generation(
+            advance=lambda: transitions.append(radio.connected) or len(transitions)
+        )
+
+        with pytest.raises(RadioConnectionError, match="closed"):
+            await radio.get_freq()
+
+        assert transitions == [False]
+        with pytest.raises(RadioConnectionError, match="not connected"):
+            await radio.get_freq()
+        assert transitions == [False]
+        await radio.disconnect()
+        assert transitions == [False]
+
+
+@pytest.mark.parametrize("failure", ("read_timeout", "write_timeout", "oserror"))
+async def test_radio_transport_failures_advance_provider_generation_once(
+    failure: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    behavior = FakeRigctldBehavior(
+        command_delays={"f": 0.2} if failure == "read_timeout" else {}
+    )
+    async with FakeRigctldServer(behavior=behavior) as server:
+        radio = RigctldClientRadio(
+            host=server.host,
+            port=server.port,
+            timeout=0.01 if failure == "read_timeout" else 5.0,
+        )
+        await radio.connect()
+        transitions: list[bool] = []
+        radio.bind_provider_generation(
+            advance=lambda: transitions.append(radio.connected) or len(transitions)
+        )
+        writer = radio._transport._writer  # noqa: SLF001
+        assert writer is not None
+        if failure == "write_timeout":
+            monkeypatch.setattr(writer, "drain", AsyncMock(side_effect=TimeoutError))
+        elif failure == "oserror":
+            monkeypatch.setattr(writer, "drain", AsyncMock(side_effect=OSError("lost")))
+
+        error = RadioConnectionError if failure == "oserror" else RadioTimeoutError
+        operation = (
+            radio.set_freq(7_050_000) if failure != "read_timeout" else radio.get_freq()
+        )
+        with pytest.raises(error):
+            await operation
+
+        assert transitions == [False]
+        await radio.disconnect()
+        assert transitions == [False]
+
+
+async def test_radio_reconnect_does_not_double_advance_transport_generation() -> None:
+    behavior = FakeRigctldBehavior(disconnect_commands={"f"})
+    async with FakeRigctldServer(behavior=behavior) as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        generations: list[int] = []
+        radio.bind_provider_generation(
+            advance=lambda: generations.append(len(generations) + 1) or generations[-1]
+        )
+
+        with pytest.raises(RadioConnectionError):
+            await radio.get_freq()
+        assert generations == [1]
+
+        await radio.connect()
+        assert radio.connected
+        assert generations == [1]
+
+        await radio.disconnect()
+        assert generations == [1, 2]
+        await radio.disconnect()
+        assert generations == [1, 2]
 
 
 async def test_radio_core_frequency_mode_ptt_and_vfo() -> None:


### PR DESCRIPTION
## Summary

- retire each successful external rigctld transport cycle exactly once
- advance the existing provider-generation callback immediately on close, EOF, timeout, or OSError
- keep reconnect on the already-established next generation without a duplicate transition

## Compatibility

- Hamlib wire framing and RPRT parsing are unchanged
- exception types/messages and getter/setter behavior are unchanged
- B4-d0 readback-only state semantics are preserved
- no public API, CLI, config, handler/server, CommandService, or hardware behavior changes

## Red-first evidence

The five focused lifecycle cases failed on the unmodified base because no provider-generation callback ran at transport loss.

## Verification

- focused backend plus adapter: 51 passed
- full non-integration: 10081 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- full Ruff check and format check: passed
- import-linter: 5 contracts kept
- full mypy: exact base parity, 12 existing errors in the same 3 unrelated files on base and head

Linear: MOR-1773