### PR TITLE
MOR-1774: project deferred command lifecycle into the store

### DIFF
--- a/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
+++ b/frontend/src/lib/runtime/commands/__tests__/radio-intents.isolated.test.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { CommandDeliveryEvent, ControlSessionTransition } from '$lib/transport/ws-client';
+import type { CommandDeliveryEvent, CommandLifecycleDeliveryEvent, ControlSessionTransition } from '$lib/transport/ws-client';
 import type { RadioIntent } from '../radio-intents';
 
 const harness = vi.hoisted(() => ({
   delivery: undefined as ((event: CommandDeliveryEvent) => void) | undefined,
+  lifecycle: undefined as ((event: CommandLifecycleDeliveryEvent) => void) | undefined,
   transition: undefined as ((event: ControlSessionTransition) => void) | undefined,
   session: { state: 'connected' as const, epoch: 7 },
   sendCommand: vi.fn((..._args: unknown[]) => true),
@@ -18,6 +19,10 @@ vi.mock('$lib/transport/ws-client', () => ({
     return () => {
       if (harness.delivery === handler) harness.delivery = undefined;
     };
+  }),
+  onCommandLifecycleDelivery: vi.fn((handler: (event: CommandLifecycleDeliveryEvent) => void) => {
+    harness.lifecycle = handler;
+    return () => { if (harness.lifecycle === handler) harness.lifecycle = undefined; };
   }),
   onControlSessionTransition: vi.fn((handler: (event: ControlSessionTransition) => void) => {
     harness.transition = handler;
@@ -36,6 +41,7 @@ describe('typed non-PTT radio intents', () => {
     vi.useFakeTimers();
     vi.resetModules();
     harness.delivery = undefined;
+    harness.lifecycle = undefined;
     harness.transition = undefined;
     harness.session = { state: 'connected', epoch: 7 };
     harness.sendCommand.mockReset().mockReturnValue(true);
@@ -81,6 +87,89 @@ describe('typed non-PTT radio intents', () => {
       eventEpoch: 7,
     });
     expect(lifecycle.getCommandLifecycle('mode-1', 7)).not.toHaveProperty('confirmedValue');
+  });
+
+  it('projects held truth without changing pending or acknowledged authority', () => {
+    const beforeAck = intents.dispatchRadioIntent({ id: 'held-first', name: 'set_freq', params: { freq: 1 } });
+    const held = { commandId: 'held-first', kind: 'held', originalEpoch: 7, eventEpoch: 7,
+      reason: 'tx_active', expiresAt: 12.5 } as const;
+    harness.lifecycle?.(held);
+    const annotation = lifecycle.getCommandLifecycleHold(beforeAck);
+    expect(annotation).toEqual({ ...held });
+    expect(Object.isFrozen(annotation)).toBe(true);
+    expect(lifecycle.getCommandLifecycle(beforeAck.id, 7)?.status).toBe('pending');
+    harness.lifecycle?.(held);
+    expect(lifecycle.getCommandLifecycleHold(beforeAck)).toBe(annotation);
+    harness.delivery?.({ commandId: beforeAck.id, kind: 'ack', originalEpoch: 7, eventEpoch: 7 });
+    expect(lifecycle.getCommandLifecycle(beforeAck.id, 7)?.status).toBe('acknowledged');
+    expect(lifecycle.getCommandLifecycleHold(beforeAck)).toBe(annotation);
+
+    const afterAck = intents.dispatchRadioIntent({ id: 'ack-first', name: 'set_mode', params: { mode: 'CW' } });
+    harness.delivery?.({ commandId: afterAck.id, kind: 'ack', originalEpoch: 7, eventEpoch: 7 });
+    harness.lifecycle?.({ ...held, commandId: afterAck.id });
+    expect(lifecycle.getCommandLifecycle(afterAck.id, 7)?.status).toBe('acknowledged');
+    expect(lifecycle.getCommandLifecycleHold(afterAck)?.commandId).toBe(afterAck.id);
+
+    const ignored = intents.dispatchRadioIntent({ id: 'ignored', name: 'set_freq', params: { freq: 2 } });
+    for (const event of [
+      { ...held, commandId: 'missing' }, { ...held, commandId: ignored.id, originalEpoch: 6 },
+      { ...held, commandId: ignored.id, eventEpoch: 8 },
+    ]) harness.lifecycle?.(event);
+    expect(lifecycle.getCommandLifecycleHold(ignored)).toBeUndefined();
+  });
+
+  it('makes lifecycle terminals authoritative for one resettable five-second window', () => {
+    const record = intents.dispatchRadioIntent({ id: 'terminal', name: 'set_freq', params: { freq: 3 } });
+    harness.lifecycle?.({ commandId: record.id, kind: 'held', originalEpoch: 7, eventEpoch: 7,
+      reason: 'tx_active', expiresAt: 12.5 });
+    harness.delivery?.({ commandId: record.id, kind: 'ack', originalEpoch: 7, eventEpoch: 7 });
+    harness.lifecycle?.({ commandId: record.id, kind: 'failed', originalEpoch: 7, eventEpoch: 7, error: 'blocked' });
+    expect(lifecycle.getCommandLifecycle(record.id, 7)).toMatchObject({ status: 'failed', error: 'blocked' });
+    expect(lifecycle.getCommandLifecycleHold(record)).toBeUndefined();
+    vi.advanceTimersByTime(4_999);
+    expect(lifecycle.getCommandLifecycle(record.id, 7)).toBeDefined();
+    harness.lifecycle?.({ commandId: record.id, kind: 'timed-out', originalEpoch: 7, eventEpoch: 7, error: 'expired' });
+    vi.advanceTimersByTime(1);
+    expect(lifecycle.getCommandLifecycle(record.id, 7)?.status).toBe('timed-out');
+    harness.delivery?.({ commandId: record.id, kind: 'ack', originalEpoch: 7, eventEpoch: 7 });
+    lifecycle.cancelPendingCommands(7); lifecycle.confirmCommand(record.id, 7, 7);
+    expect(lifecycle.getCommandLifecycle(record.id, 7)?.status).toBe('timed-out');
+    vi.advanceTimersByTime(4_998);
+    expect(lifecycle.getCommandLifecycle(record.id, 7)).toBeDefined();
+    vi.advanceTimersByTime(1);
+    expect(lifecycle.getCommandLifecycle(record.id, 7)).toBeUndefined();
+
+    const superseded = intents.dispatchRadioIntent({ id: 'server-superseded', name: 'set_filter', params: { filter: 2 } });
+    harness.lifecycle?.({ commandId: superseded.id, kind: 'superseded', originalEpoch: 7, eventEpoch: 7 });
+    expect(lifecycle.getCommandLifecycle(superseded.id, 7)?.status).toBe('cancelled');
+    expect(lifecycle.isCommandLifecycleSuperseded(superseded)).toBe(true);
+    vi.advanceTimersByTime(5_000);
+    expect(lifecycle.getCommandLifecycle(superseded.id, 7)).toBeUndefined();
+  });
+
+  it('clears held annotations on cancellation, confirmation, timeout, retirement, and reset', () => {
+    const cancel = intents.dispatchRadioIntent({ id: 'held-cancel', name: 'set_filter', params: { filter: 1 } });
+    const emitHeld = (commandId: string) => harness.lifecycle?.({ commandId, kind: 'held',
+      originalEpoch: 7, eventEpoch: 7, reason: 'tx_active', expiresAt: 12.5 });
+    emitHeld(cancel.id); harness.transition?.({ state: 'disconnected', epoch: 7 });
+    expect(lifecycle.getCommandLifecycleHold(cancel)).toBeUndefined();
+
+    const confirmed = intents.dispatchRadioIntent({ id: 'held-confirm', name: 'set_filter', params: { filter: 2 } });
+    harness.delivery?.({ commandId: confirmed.id, kind: 'ack', originalEpoch: 7, eventEpoch: 7 });
+    emitHeld(confirmed.id); lifecycle.confirmCommand(confirmed.id, 7, 7);
+    expect(lifecycle.getCommandLifecycle(confirmed.id, 7)?.status).toBe('confirmed');
+    expect(lifecycle.getCommandLifecycleHold(confirmed)).toBeUndefined();
+
+    const retired = intents.dispatchRadioIntent({ id: 'held-retire', name: 'set_freq', params: { freq: 4 } });
+    emitHeld(retired.id); vi.advanceTimersByTime(5_000);
+    expect(lifecycle.getCommandLifecycle(retired.id, 7)?.status).toBe('timed-out');
+    expect(lifecycle.getCommandLifecycleHold(retired)).toBeUndefined();
+    vi.advanceTimersByTime(5_000);
+    expect(lifecycle.getCommandLifecycle(retired.id, 7)).toBeUndefined();
+    expect(lifecycle.getCommandLifecycleHold(intents.dispatchRadioIntent({ id: retired.id,
+      name: 'set_freq', params: { freq: 5 } }))).toBeUndefined();
+    emitHeld(retired.id); lifecycle.resetCommandLifecycle();
+    expect(lifecycle.getCommandLifecycleHold(retired)).toBeUndefined();
   });
 
   it('isolates error, timeout, cancellation, and stale-session results', () => {
@@ -146,6 +235,7 @@ describe('typed non-PTT radio intents', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/lib/runtime/commands/radio-intents.ts'), 'utf8');
     expect(source).not.toMatch(/from ['"]\$lib\/stores\/radio/);
     expect(source).not.toMatch(/\b(?:patchActiveReceiver|patchRadioState|patchReceiver)\s*\(/);
+    expect(source).not.toMatch(/\bconfirmCommand\s*\(/);
     expect(source).not.toContain('set_keyer_type');
     expect(source).not.toMatch(/['"]ptt(?:_on|_off)?['"]/);
   });

--- a/frontend/src/lib/runtime/commands/radio-intents.ts
+++ b/frontend/src/lib/runtime/commands/radio-intents.ts
@@ -1,5 +1,6 @@
-import { acknowledgeCommand, beginCommand, cancelPendingCommands, failCommand, type CommandLifecycle } from '$lib/stores/commands.svelte';
+import { acknowledgeCommand, applyCommandLifecycleProjection, beginCommand, cancelPendingCommands, failCommand, type CommandLifecycle } from '$lib/stores/commands.svelte';
 import { makeCommandId } from '$lib/types/protocol';
+import * as controlTransport from '$lib/transport/ws-client';
 import { getControlSession, onCommandDelivery, onControlSessionTransition, sendCommand } from '$lib/transport/ws-client';
 
 type FieldKind = 'boolean' | 'integer' | 'normalized' | 'number' | 'receiver' | 'string' | 'vfo';
@@ -99,6 +100,9 @@ onCommandDelivery((event) => {
   else if (event.kind === 'ack' || event.kind === 'response-ok') acknowledgeCommand(event.commandId, event.originalEpoch, event.eventEpoch);
   else failCommand(event.commandId, event.originalEpoch, event.eventEpoch, event.error);
 });
+if (Object.prototype.hasOwnProperty.call(controlTransport, 'onCommandLifecycleDelivery')) {
+  controlTransport.onCommandLifecycleDelivery((event) => applyCommandLifecycleProjection(event, getControlSession().epoch));
+}
 onControlSessionTransition((transition) => {
   if (transition.state === 'disconnected') cancelPendingCommands(transition.epoch);
 });

--- a/frontend/src/lib/stores/commands.svelte.ts
+++ b/frontend/src/lib/stores/commands.svelte.ts
@@ -29,6 +29,15 @@ export interface BeginCommandInput {
   id: string; name: string; params: Readonly<Record<string, unknown>>;
   originalEpoch: number; timeoutMs?: number;
 }
+export interface CommandLifecycleHold {
+  readonly commandId: string; readonly originalEpoch: number; readonly eventEpoch: number;
+  readonly kind: 'held'; readonly reason: 'tx_active'; readonly expiresAt: number;
+}
+export interface CommandLifecycleProjection {
+  readonly commandId: string; readonly originalEpoch: number; readonly eventEpoch: number;
+  readonly kind: 'held' | 'superseded' | 'timed-out' | 'failed';
+  readonly reason?: string; readonly expiresAt?: number; readonly error?: string;
+}
 
 export interface ControlFeedbackScope {
   readonly control: string;
@@ -102,6 +111,7 @@ const MAX_RETAINED_COMMANDS = 100;
 let commands = $state<CommandLifecycle[]>([]);
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
 const supersededRecordKeys = new Set<string>();
+const heldAnnotations = new Map<string, Readonly<CommandLifecycleHold>>();
 let stateBackedReconciliationStarted = false;
 const key = (id: string, epoch: number): string => `${epoch}:${id}`;
 
@@ -116,6 +126,11 @@ const commandScopeKey = (command: Pick<CommandLifecycle, 'name' | 'params'>): st
 };
 
 export const isCommandLifecycleSuperseded = (command: CommandLifecycle): boolean => supersededRecordKeys.has(key(command.id, command.originalEpoch));
+export const getCommandLifecycleHold = (command: Pick<CommandLifecycle, 'id' | 'originalEpoch'>): Readonly<CommandLifecycleHold> | undefined =>
+  heldAnnotations.get(key(command.id, command.originalEpoch));
+const clearCommandHold = (command: Pick<CommandLifecycle, 'id' | 'originalEpoch'>): void => {
+  heldAnnotations.delete(key(command.id, command.originalEpoch));
+};
 
 function clearRecordTimer(command: CommandLifecycle): void {
   const recordKey = key(command.id, command.originalEpoch);
@@ -127,6 +142,7 @@ function retireRecord(command: CommandLifecycle): void {
   const index = commands.indexOf(command);
   if (index >= 0) commands.splice(index, 1);
   supersededRecordKeys.delete(key(command.id, command.originalEpoch));
+  clearCommandHold(command);
 }
 function retainTerminalOutcome(command: CommandLifecycle): void {
   clearRecordTimer(command);
@@ -146,6 +162,7 @@ function startLiveDeadline(command: CommandLifecycle): void {
   timers.set(key(command.id, command.originalEpoch), setTimeout(() => {
     const current = getCommandLifecycle(command.id, command.originalEpoch);
     if (!current || (current.status !== 'pending' && current.status !== 'acknowledged')) return;
+    clearCommandHold(current);
     current.status = 'timed-out'; current.updatedAt = Date.now();
     retainTerminalOutcome(current);
   }, command.timeoutMs));
@@ -181,6 +198,7 @@ function transition(
     startLiveDeadline(command);
     if (descriptor !== undefined) startStateBackedReconciliation();
   } else {
+    clearCommandHold(command);
     retainTerminalOutcome(command);
   }
 }
@@ -245,14 +263,40 @@ export const failCommand = (id: string, epoch: number, eventEpoch: number, error
 /** Downstream observation adapters may call this only after qualifying radio truth. */
 export const confirmCommand = (id: string, epoch: number, eventEpoch: number): void =>
   transition(id, epoch, 'confirmed', eventEpoch);
+export function applyCommandLifecycleProjection(event: CommandLifecycleProjection, currentEpoch: number): void {
+  if (event.eventEpoch !== currentEpoch) return;
+  const command = getCommandLifecycle(event.commandId, event.originalEpoch);
+  if (!command || command.status === 'confirmed'
+    || (command.eventEpoch !== undefined && command.eventEpoch !== event.eventEpoch)) return;
+  const recordKey = key(command.id, command.originalEpoch);
+  if (event.kind === 'held') {
+    if ((command.status !== 'pending' && command.status !== 'acknowledged')
+      || event.reason !== 'tx_active' || typeof event.expiresAt !== 'number') return;
+    const held = Object.freeze({ commandId: event.commandId, kind: 'held' as const,
+      originalEpoch: event.originalEpoch, eventEpoch: event.eventEpoch,
+      reason: 'tx_active' as const, expiresAt: event.expiresAt });
+    const existing = heldAnnotations.get(recordKey);
+    if (existing && existing.expiresAt === held.expiresAt && existing.eventEpoch === held.eventEpoch) return;
+    heldAnnotations.set(recordKey, held);
+    return;
+  }
+  clearCommandHold(command); clearRecordTimer(command);
+  command.eventEpoch = event.eventEpoch; command.updatedAt = Date.now();
+  if (event.error === undefined) delete command.error; else command.error = event.error;
+  if (event.kind === 'superseded') {
+    supersededRecordKeys.add(recordKey); command.status = 'cancelled';
+  } else command.status = event.kind;
+  retainTerminalOutcome(command);
+}
 export function cancelPendingCommands(epoch: number, error = 'session-disconnected'): void {
   for (const command of commands) {
     if (command.originalEpoch !== epoch || (command.status !== 'pending' && command.status !== 'acknowledged')) continue;
     command.status = 'cancelled'; command.updatedAt = Date.now(); command.error = error;
+    clearCommandHold(command);
     retainTerminalOutcome(command);
   }
 }
 export function resetCommandLifecycle(): void {
   for (const timer of timers.values()) clearTimeout(timer);
-  timers.clear(); commands = []; supersededRecordKeys.clear();
+  timers.clear(); commands = []; supersededRecordKeys.clear(); heldAnnotations.clear();
 }


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1774/mor-1500-b1-c4-project-deferred-lifecycle-into-the-command-store

## Summary
- consume the strict epoch-safe `command_lifecycle` delivery bus in the radio-intent layer
- retain an immutable exact-ID/epoch held annotation without changing pending/acknowledged command authority
- project failed, timed-out, and superseded terminal truth into the existing bounded five-second lifecycle presentation window

## Safety and behavior
- wrong command IDs, original epochs, and socket event epochs are ignored
- held-before-ACK and held-after-ACK preserve normal ACK behavior; duplicate holds are true no-ops
- terminal lifecycle clears held state, invalidates prior deadlines, and cannot be revived by late ACK, cancellation, or confirmation
- superseded reuses the existing superseded marker and bounded terminal retirement
- cancellation, real confirmation, timeout, retirement, and reset clear held state
- no radio-state mutation, fabricated confirmation, PTT/TX behavior, backend, or transport decoder changes
- capability-safe subscription preserves isolated consumers whose strict transport mocks intentionally omit the new private bus

## Scope
- exactly 3 owned frontend files
- 141 additions / 3 deletions = 144 changed LOC
- base `350dfd947c2d54aa3d28a88e6029db9562d685b9`
- head `95d254b5a0db3180a51eea747699960c012a9baf`

## Verification
- RED: 3 focused failures before implementation
- focused radio-intents: 15 passed
- adjacent lifecycle/transport/store: 148 passed
- full frontend: 366 files / 8052 tests passed
- `npm run check`
- `npm run lint`
- `npm run lint:boundaries`
- `npm run i18n:check`
- `npm run build`
- diff check and privacy scan clean

No runtime, radio, serial device, PTT, TUNE, TX, or keying action was performed.
