### PR TITLE
MOR-1775: terminate active command lifecycles by scope

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -36,6 +36,7 @@ __all__ = [
 ]
 
 _UNSET = object()
+_MAX_ACTIVE_COMMANDS = 128
 _MAX_READBACK_EXPECTATIONS = 128
 _READBACK_EXPECTATION_GRACE_SECONDS = 2.0
 _DISPATCHABLE_LIFECYCLE_STATES = ("accepted", "queued", "sent", "acknowledged")
@@ -107,6 +108,7 @@ class CommandService:
     """Coordinate backend-neutral command execution and pending overlays."""
 
     __slots__ = (
+        "_active_commands",
         "_clock",
         "_default_pending_ttl",
         "_events",
@@ -131,6 +133,9 @@ class CommandService:
         self._state_store = state_store
         self._clock = clock or time.monotonic
         self._default_pending_ttl = default_pending_ttl
+        self._active_commands: dict[
+            tuple[CommandSource, str | None, str], CommandLifecycleEvent
+        ] = {}
         self._events: list[CommandLifecycleEvent] = []
         self._subscribers: list[LifecycleSubscriber] = []
         self._overlays: list[PendingOverlay] = []
@@ -248,6 +253,49 @@ class CommandService:
         )
         return True
 
+    def terminate_active_commands(
+        self,
+        reason: str,
+        *,
+        source: CommandSource | None = None,
+        session_id: str | None | object = _UNSET,
+    ) -> int:
+        """Fail active commands in an exact source/session lifecycle scope."""
+
+        matches = [
+            (key, event)
+            for key, event in self._active_commands.items()
+            if (source is None or key[0] == source)
+            and (session_id is _UNSET or key[1] == session_id)
+        ]
+        terminated = 0
+        for key, event in matches:
+            if key not in self._active_commands:
+                continue
+            scoped_source, scoped_session, command_id = key
+            self.expire_command(
+                command_id,
+                source=scoped_source,
+                session_id=scoped_session,
+            )
+            self.emit_lifecycle(
+                CommandIntent(
+                    id=command_id,
+                    name="scope_termination",
+                    params={"session_id": scoped_session},
+                    source=scoped_source,
+                    target=event.target,
+                    priority="user",
+                    timeout=None,
+                    pending_policy="none",
+                    expected_observations=(),
+                ),
+                "failed",
+                message=reason,
+            )
+            terminated += 1
+        return terminated
+
     def emit_lifecycle(
         self,
         intent: CommandIntent,
@@ -270,6 +318,22 @@ class CommandService:
             message=message,
             details=payload_details,
         )
+        key = (event.source, _event_session_id(event), event.command_id)
+        if state in _DISPATCHABLE_LIFECYCLE_STATES:
+            if key not in self._active_commands and (
+                len(self._active_commands) >= _MAX_ACTIVE_COMMANDS
+            ):
+                oldest = next(iter(self._active_commands))
+                self.fail_command(
+                    oldest[2],
+                    source=oldest[0],
+                    session_id=oldest[1],
+                    message="active command capacity exceeded",
+                )
+            self._active_commands.pop(key, None)
+            self._active_commands[key] = event
+        else:
+            self._active_commands.pop(key, None)
         self._events.append(event)
         for subscriber in tuple(self._subscribers):
             subscriber(event)

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -311,7 +311,7 @@ class CommandService:
         )
         key = (intent.source, _session_id(intent), intent.id)
         if state in _DISPATCHABLE_LIFECYCLE_STATES:
-            if key not in self._active_commands and (
+            while key not in self._active_commands and (
                 len(self._active_commands) >= _MAX_ACTIVE_COMMANDS
             ):
                 oldest = next(iter(self._active_commands))

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -262,39 +262,30 @@ class CommandService:
     ) -> int:
         """Fail active commands in an exact source/session lifecycle scope."""
 
+        if source is not None and type(source) is not str:
+            return 0
+        if (
+            session_id is not _UNSET
+            and session_id is not None
+            and type(session_id) is not str
+        ):
+            return 0
         matches = [
-            (key, event)
-            for key, event in self._active_commands.items()
+            key
+            for key in self._active_commands
             if (source is None or key[0] == source)
             and (session_id is _UNSET or key[1] == session_id)
         ]
-        terminated = 0
-        for key, event in matches:
-            if key not in self._active_commands:
-                continue
-            scoped_source, scoped_session, command_id = key
-            self.expire_command(
+        for key in matches:
+            self._active_commands.pop(key)
+        for scoped_source, scoped_session, command_id in matches:
+            self.fail_command(
                 command_id,
                 source=scoped_source,
                 session_id=scoped_session,
-            )
-            self.emit_lifecycle(
-                CommandIntent(
-                    id=command_id,
-                    name="scope_termination",
-                    params={"session_id": scoped_session},
-                    source=scoped_source,
-                    target=event.target,
-                    priority="user",
-                    timeout=None,
-                    pending_policy="none",
-                    expected_observations=(),
-                ),
-                "failed",
                 message=reason,
             )
-            terminated += 1
-        return terminated
+        return len(matches)
 
     def emit_lifecycle(
         self,
@@ -308,7 +299,7 @@ class CommandService:
 
         payload_details = dict(details or {})
         if "session_id" in intent.params:
-            payload_details.setdefault("session_id", intent.params["session_id"])
+            payload_details["session_id"] = _session_id(intent)
         event = CommandLifecycleEvent(
             command_id=intent.id,
             state=state,
@@ -330,7 +321,6 @@ class CommandService:
                     session_id=oldest[1],
                     message="active command capacity exceeded",
                 )
-            self._active_commands.pop(key, None)
             self._active_commands[key] = event
         else:
             self._active_commands.pop(key, None)

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -309,7 +309,7 @@ class CommandService:
             message=message,
             details=payload_details,
         )
-        key = (event.source, _event_session_id(event), event.command_id)
+        key = (intent.source, _session_id(intent), intent.id)
         if state in _DISPATCHABLE_LIFECYCLE_STATES:
             if key not in self._active_commands and (
                 len(self._active_commands) >= _MAX_ACTIVE_COMMANDS

--- a/tests/test_command_service_lifecycle_invalidation.py
+++ b/tests/test_command_service_lifecycle_invalidation.py
@@ -21,21 +21,18 @@ class _Trap:
         self.result = result
 
     def __eq__(self, other: object) -> bool:
-        if self.result is None:
-            raise AssertionError("scope equality must not run")
+        assert self.result is not None, "scope equality must not run"
         return self.result
 
 
 def _service() -> tuple[CommandService, StateStore]:
     store = StateStore()
-    service = CommandService(executor=_Executor(), state_store=store)
-    return service, store
+    return CommandService(executor=_Executor(), state_store=store), store
 
 
 def _intent(
     command_id: str, source: str, session_id: str | None = None
 ) -> CommandIntent:
-    path = FieldPath.active("main", "freq_mode", "freq_hz")
     params: dict[str, object] = {"freq_hz": 14_074_000}
     if session_id is not None:
         params["session_id"] = session_id
@@ -44,7 +41,7 @@ def _intent(
         name="set_freq",
         params=params,
         source=cast(CommandSource, source),
-        target=path,
+        target=FieldPath.active("main", "freq_mode", "freq_hz"),
         pending_policy="scoped",
     )
 
@@ -90,11 +87,9 @@ def test_terminate_active_commands_is_exact_scoped_and_idempotent() -> None:
     assert terminate("alias", session_id="alias") == 0
     unsubscribe()
     emit(_intent("z", "websocket", "ws-a"), "accepted")
-    before = service.lifecycle_events()
     for malformed in (_Trap(None), _Trap(True), object()):
         assert terminate("bad", source=malformed) == 0  # type: ignore[arg-type]
         assert terminate("bad", session_id=malformed) == 0
-    assert service.lifecycle_events() == before
 
 
 def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
@@ -104,7 +99,6 @@ def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
         service.emit_lifecycle(intent, "acknowledged")
         service.emit_lifecycle(intent, terminal, message="original")
         assert service.terminate_active_commands("invalidate") == 0
-        assert len(service.lifecycle_events()) == 2
 
 
 async def test_termination_clears_pending_and_late_readback_cannot_revive() -> None:
@@ -136,9 +130,15 @@ def test_active_command_registry_is_bounded_and_terminal_entries_do_not_leak() -
     for index in range(128):
         service.emit_lifecycle(_intent(str(index), "websocket", "ws-a"), "accepted")
     service.emit_lifecycle(_intent("0", "websocket", "ws-a"), "acknowledged")
+
+    def refill(event: object) -> None:
+        if getattr(event, "message", None) == "active command capacity exceeded":
+            service.emit_lifecycle(_intent("cb", "websocket", "ws-a"), "accepted")
+
+    service.subscribe_lifecycle(refill)  # type: ignore[arg-type]
     service.emit_lifecycle(_intent("128", "websocket", "ws-a"), "accepted")
     assert len(service._active_commands) == 128  # noqa: SLF001
-    assert service.lifecycle_events()[-2].command_id == "0"
-    assert service.lifecycle_events()[-2].state == "failed"
+    evicted = [event for event in service.lifecycle_events() if event.message]
+    assert [event.command_id for event in evicted] == ["0", "1"]
     service.terminate_active_commands("shutdown")
     assert service._active_commands == {}  # noqa: SLF001

--- a/tests/test_command_service_lifecycle_invalidation.py
+++ b/tests/test_command_service_lifecycle_invalidation.py
@@ -1,0 +1,131 @@
+from typing import cast
+
+import pytest
+
+from rigplane.core.command_service import CommandExecutionResult, CommandService
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    CommandSource,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FreshnessClock, StateStore
+
+
+class _Executor:
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        return CommandExecutionResult()
+
+
+def _service() -> tuple[CommandService, StateStore, FreshnessClock]:
+    clock = FreshnessClock(start=10.0)
+    store = StateStore(freshness_clock=clock)
+    service = CommandService(executor=_Executor(), state_store=store, clock=clock.now)
+    return service, store, clock
+
+
+def _intent(command_id: str, source: str, session_id: str | None) -> CommandIntent:
+    path = FieldPath.active("main", "freq_mode", "freq_hz")
+    return CommandIntent(
+        id=command_id,
+        name="set_freq",
+        params={"freq_hz": 14_074_000, "session_id": session_id},
+        source=cast(CommandSource, source),
+        target=path,
+        pending_policy="scoped",
+        expected_observations=(path,),
+    )
+
+
+def test_terminate_active_commands_is_exact_scoped_and_idempotent() -> None:
+    service, _, _ = _service()
+    for state, command_id in zip(
+        ("accepted", "queued", "sent", "acknowledged"),
+        ("a", "q", "s", "k"),
+        strict=True,
+    ):
+        service.emit_lifecycle(_intent(command_id, "websocket", "ws-a"), state)
+    service.emit_lifecycle(_intent("a", "websocket", "ws-b"), "acknowledged")
+    service.emit_lifecycle(_intent("a", "http", None), "acknowledged")
+
+    assert (
+        service.terminate_active_commands(
+            "control scope invalidated", source="websocket", session_id="ws-a"
+        )
+        == 4
+    )
+    assert (
+        service.terminate_active_commands(
+            "different reason", source="websocket", session_id="ws-a"
+        )
+        == 0
+    )
+    failed = [event for event in service.lifecycle_events() if event.state == "failed"]
+    assert [(event.command_id, event.message) for event in failed] == [
+        (command_id, "control scope invalidated") for command_id in ("a", "q", "s", "k")
+    ]
+    assert service.terminate_active_commands("http gone", session_id=None) == 1
+    assert service.terminate_active_commands("socket gone", source="websocket") == 1
+
+
+def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
+    for terminal in ("failed", "timed_out", "reconciled", "superseded"):
+        service, _, _ = _service()
+        intent = _intent(terminal, "websocket", "ws-a")
+        service.emit_lifecycle(intent, "acknowledged")
+        service.emit_lifecycle(intent, terminal, message="original")
+        assert service.terminate_active_commands("invalidate") == 0
+        assert len(service.lifecycle_events()) == 2
+
+
+@pytest.mark.asyncio
+async def test_termination_clears_pending_and_late_readback_cannot_revive() -> None:
+    service, store, clock = _service()
+    intent = _intent("late", "websocket", "ws-a")
+    await service.execute(intent)
+    assert service.pending_overlays(source="websocket", session_id="ws-a")
+    assert service.readback_expectations(
+        source="websocket", session_id="ws-a", command_id="late"
+    )
+
+    assert service.terminate_active_commands("provider replaced") == 1
+    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
+    assert (
+        service.readback_expectations(
+            source="websocket", session_id="ws-a", command_id="late"
+        )
+        == ()
+    )
+    before = tuple(service.lifecycle_events())
+    clock.advance(0.1)
+    service.apply_observation(
+        Observation(
+            path=intent.target,
+            value=14_074_000,
+            source=SourceMetadata(
+                source="yaesu_poll_response",
+                provider="yaesu_cat",
+                transport="serial",
+                command_source="websocket",
+                session_id="ws-a",
+            ),
+            timestamp_monotonic=clock.now(),
+            correlation_id="late",
+        )
+    )
+    assert store.snapshot().field(intent.target).value == 14_074_000
+    assert service.lifecycle_events() == before
+
+
+def test_active_command_registry_is_bounded_and_terminal_entries_do_not_leak() -> None:
+    service, _, _ = _service()
+    for index in range(129):
+        intent = _intent(str(index), "websocket", "ws-a")
+        service.emit_lifecycle(intent, "accepted")
+
+    assert len(service._active_commands) == 128  # noqa: SLF001
+    assert service.lifecycle_events()[-2].command_id == "0"
+    assert service.lifecycle_events()[-2].state == "failed"
+    service.terminate_active_commands("shutdown")
+    assert service._active_commands == {}  # noqa: SLF001

--- a/tests/test_command_service_lifecycle_invalidation.py
+++ b/tests/test_command_service_lifecycle_invalidation.py
@@ -8,7 +8,7 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.core.state_store import StateStore
 
 
 class _Executor:
@@ -26,74 +26,80 @@ class _Trap:
         return self.result
 
 
-def _service() -> tuple[CommandService, StateStore, FreshnessClock]:
-    clock = FreshnessClock(start=10.0)
-    store = StateStore(freshness_clock=clock)
-    service = CommandService(executor=_Executor(), state_store=store, clock=clock.now)
-    return service, store, clock
+def _service() -> tuple[CommandService, StateStore]:
+    store = StateStore()
+    service = CommandService(executor=_Executor(), state_store=store)
+    return service, store
 
 
-def _intent(command_id: str, source: str, session_id: str | None) -> CommandIntent:
+def _intent(
+    command_id: str, source: str, session_id: str | None = None
+) -> CommandIntent:
     path = FieldPath.active("main", "freq_mode", "freq_hz")
+    params: dict[str, object] = {"freq_hz": 14_074_000}
+    if session_id is not None:
+        params["session_id"] = session_id
     return CommandIntent(
         id=command_id,
         name="set_freq",
-        params={"freq_hz": 14_074_000, "session_id": session_id},
+        params=params,
         source=cast(CommandSource, source),
         target=path,
         pending_policy="scoped",
-        expected_observations=(path,),
     )
 
 
 def test_terminate_active_commands_is_exact_scoped_and_idempotent() -> None:
-    service, _, _ = _service()
-    for state, command_id in zip(
-        ("accepted", "queued", "sent", "acknowledged"),
-        ("a", "q", "s", "k"),
-        strict=True,
-    ):
-        service.emit_lifecycle(_intent(command_id, "websocket", "ws-a"), state)
-    service.emit_lifecycle(_intent("a", "websocket", "ws-b"), "acknowledged")
-    service.emit_lifecycle(_intent("a", "http", None), "acknowledged")
-
+    service, _ = _service()
+    emit = service.emit_lifecycle
+    terminate = service.terminate_active_commands
+    states = ("accepted", "queued", "sent", "acknowledged")
+    for command_id, state in zip("aqsk", states, strict=True):
+        emit(_intent(command_id, "websocket", "ws-a"), state)
+    emit(_intent("a", "websocket", "ws-b"), "acknowledged")
+    emit(_intent("a", "http"), "acknowledged")
     scope = {"source": "websocket", "session_id": "ws-a"}
-    assert service.terminate_active_commands("control scope invalidated", **scope) == 4
-    assert service.terminate_active_commands("different reason", **scope) == 0
+    assert terminate("control scope invalidated", **scope) == 4
+    assert terminate("different reason", **scope) == 0
     failed = [event for event in service.lifecycle_events() if event.state == "failed"]
-    assert [(event.command_id, event.message) for event in failed] == [
-        (command_id, "control scope invalidated") for command_id in ("a", "q", "s", "k")
-    ]
-    assert service.terminate_active_commands("http gone", session_id=None) == 1
-    assert service.terminate_active_commands("socket gone", source="websocket") == 1
+    expected = [(command_id, "control scope invalidated") for command_id in "aqsk"]
+    assert [(event.command_id, event.message) for event in failed] == expected
+    assert terminate("http gone", session_id=None) == 1
+    assert terminate("socket gone", source="websocket") == 1
+    conflict = {"session_id": "other"}
+    public = _intent("p", "public_api")
+    emit(public, "accepted")
+    emit(public, "acknowledged", details=conflict)
+    assert terminate("public gone", source="public_api") == 1
+    other = emit(_intent("p", "public_api", "other"), "accepted")
+    emit(public, "acknowledged", details=conflict)
+    assert service._active_commands[("public_api", "other", "p")] is other  # noqa: SLF001
     for command_id in ("x", "y"):
-        service.emit_lifecycle(_intent(command_id, "websocket", "ws-a"), "accepted")
+        emit(_intent(command_id, "websocket", "ws-a"), "accepted")
     x_intent = _intent("x", "websocket", "ws-a")
-    service.emit_lifecycle(x_intent, "acknowledged", details={"session_id": "alias"})
-    nested: list[int] = []
+    emit(x_intent, "acknowledged", details={"session_id": "alias"})
 
     def reenter(event: object) -> None:
-        nested.append(service.terminate_active_commands("nested", source="websocket"))
+        assert terminate("nested", source="websocket") == 0
 
     unsubscribe = service.subscribe_lifecycle(reenter)  # type: ignore[arg-type]
-    assert service.terminate_active_commands("outer", source="websocket") == 2
-    assert nested == [0, 0]
+    assert terminate("outer", source="websocket") == 2
     failed = [event for event in service.lifecycle_events() if event.state == "failed"]
     assert [event.command_id for event in failed[-2:]] == ["x", "y"]
     assert {event.message for event in failed[-2:]} == {"outer"}
-    assert service.terminate_active_commands("alias", session_id="alias") == 0
+    assert terminate("alias", session_id="alias") == 0
     unsubscribe()
-    service.emit_lifecycle(_intent("z", "websocket", "ws-a"), "accepted")
+    emit(_intent("z", "websocket", "ws-a"), "accepted")
     before = service.lifecycle_events()
     for malformed in (_Trap(None), _Trap(True), object()):
-        assert service.terminate_active_commands("bad", source=malformed) == 0  # type: ignore[arg-type]
-        assert service.terminate_active_commands("bad", session_id=malformed) == 0
+        assert terminate("bad", source=malformed) == 0  # type: ignore[arg-type]
+        assert terminate("bad", session_id=malformed) == 0
     assert service.lifecycle_events() == before
 
 
 def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
     for terminal in ("failed", "timed_out", "reconciled", "superseded"):
-        service, _, _ = _service()
+        service, _ = _service()
         intent = _intent(terminal, "websocket", "ws-a")
         service.emit_lifecycle(intent, "acknowledged")
         service.emit_lifecycle(intent, terminal, message="original")
@@ -102,7 +108,7 @@ def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
 
 
 async def test_termination_clears_pending_and_late_readback_cannot_revive() -> None:
-    service, store, clock = _service()
+    service, store = _service()
     intent = _intent("late", "websocket", "ws-a")
     await service.execute(intent)
     scope = {"source": "websocket", "session_id": "ws-a"}
@@ -110,33 +116,27 @@ async def test_termination_clears_pending_and_late_readback_cannot_revive() -> N
     assert service.pending_overlays(**scope) == ()
     assert service.readback_expectations(**scope, command_id="late") == ()
     before = tuple(service.lifecycle_events())
-    service.apply_observation(
-        Observation(
-            path=intent.target,
-            value=14_074_000,
-            source=SourceMetadata(
-                source="yaesu_poll_response",
-                provider="yaesu_cat",
-                transport="serial",
-                command_source="websocket",
-                session_id="ws-a",
-            ),
-            timestamp_monotonic=clock.now(),
-            correlation_id="late",
-        )
+    source = SourceMetadata(
+        "yaesu_poll_response",
+        "yaesu_cat",
+        "serial",
+        command_source="websocket",
+        session_id="ws-a",
     )
+    observation = Observation(
+        intent.target, 14_074_000, source, 10.0, correlation_id="late"
+    )
+    service.apply_observation(observation)
     assert store.snapshot().field(intent.target).value == 14_074_000
     assert service.lifecycle_events() == before
 
 
 def test_active_command_registry_is_bounded_and_terminal_entries_do_not_leak() -> None:
-    service, _, _ = _service()
+    service, _ = _service()
     for index in range(128):
-        intent = _intent(str(index), "websocket", "ws-a")
-        service.emit_lifecycle(intent, "accepted")
+        service.emit_lifecycle(_intent(str(index), "websocket", "ws-a"), "accepted")
     service.emit_lifecycle(_intent("0", "websocket", "ws-a"), "acknowledged")
     service.emit_lifecycle(_intent("128", "websocket", "ws-a"), "accepted")
-
     assert len(service._active_commands) == 128  # noqa: SLF001
     assert service.lifecycle_events()[-2].command_id == "0"
     assert service.lifecycle_events()[-2].state == "failed"

--- a/tests/test_command_service_lifecycle_invalidation.py
+++ b/tests/test_command_service_lifecycle_invalidation.py
@@ -1,7 +1,5 @@
 from typing import cast
 
-import pytest
-
 from rigplane.core.command_service import CommandExecutionResult, CommandService
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
@@ -16,6 +14,16 @@ from rigplane.core.state_store import FreshnessClock, StateStore
 class _Executor:
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
         return CommandExecutionResult()
+
+
+class _Trap:
+    def __init__(self, result: bool | None) -> None:
+        self.result = result
+
+    def __eq__(self, other: object) -> bool:
+        if self.result is None:
+            raise AssertionError("scope equality must not run")
+        return self.result
 
 
 def _service() -> tuple[CommandService, StateStore, FreshnessClock]:
@@ -49,24 +57,38 @@ def test_terminate_active_commands_is_exact_scoped_and_idempotent() -> None:
     service.emit_lifecycle(_intent("a", "websocket", "ws-b"), "acknowledged")
     service.emit_lifecycle(_intent("a", "http", None), "acknowledged")
 
-    assert (
-        service.terminate_active_commands(
-            "control scope invalidated", source="websocket", session_id="ws-a"
-        )
-        == 4
-    )
-    assert (
-        service.terminate_active_commands(
-            "different reason", source="websocket", session_id="ws-a"
-        )
-        == 0
-    )
+    scope = {"source": "websocket", "session_id": "ws-a"}
+    assert service.terminate_active_commands("control scope invalidated", **scope) == 4
+    assert service.terminate_active_commands("different reason", **scope) == 0
     failed = [event for event in service.lifecycle_events() if event.state == "failed"]
     assert [(event.command_id, event.message) for event in failed] == [
         (command_id, "control scope invalidated") for command_id in ("a", "q", "s", "k")
     ]
     assert service.terminate_active_commands("http gone", session_id=None) == 1
     assert service.terminate_active_commands("socket gone", source="websocket") == 1
+    for command_id in ("x", "y"):
+        service.emit_lifecycle(_intent(command_id, "websocket", "ws-a"), "accepted")
+    x_intent = _intent("x", "websocket", "ws-a")
+    service.emit_lifecycle(x_intent, "acknowledged", details={"session_id": "alias"})
+    nested: list[int] = []
+
+    def reenter(event: object) -> None:
+        nested.append(service.terminate_active_commands("nested", source="websocket"))
+
+    unsubscribe = service.subscribe_lifecycle(reenter)  # type: ignore[arg-type]
+    assert service.terminate_active_commands("outer", source="websocket") == 2
+    assert nested == [0, 0]
+    failed = [event for event in service.lifecycle_events() if event.state == "failed"]
+    assert [event.command_id for event in failed[-2:]] == ["x", "y"]
+    assert {event.message for event in failed[-2:]} == {"outer"}
+    assert service.terminate_active_commands("alias", session_id="alias") == 0
+    unsubscribe()
+    service.emit_lifecycle(_intent("z", "websocket", "ws-a"), "accepted")
+    before = service.lifecycle_events()
+    for malformed in (_Trap(None), _Trap(True), object()):
+        assert service.terminate_active_commands("bad", source=malformed) == 0  # type: ignore[arg-type]
+        assert service.terminate_active_commands("bad", session_id=malformed) == 0
+    assert service.lifecycle_events() == before
 
 
 def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
@@ -79,26 +101,15 @@ def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
         assert len(service.lifecycle_events()) == 2
 
 
-@pytest.mark.asyncio
 async def test_termination_clears_pending_and_late_readback_cannot_revive() -> None:
     service, store, clock = _service()
     intent = _intent("late", "websocket", "ws-a")
     await service.execute(intent)
-    assert service.pending_overlays(source="websocket", session_id="ws-a")
-    assert service.readback_expectations(
-        source="websocket", session_id="ws-a", command_id="late"
-    )
-
+    scope = {"source": "websocket", "session_id": "ws-a"}
     assert service.terminate_active_commands("provider replaced") == 1
-    assert service.pending_overlays(source="websocket", session_id="ws-a") == ()
-    assert (
-        service.readback_expectations(
-            source="websocket", session_id="ws-a", command_id="late"
-        )
-        == ()
-    )
+    assert service.pending_overlays(**scope) == ()
+    assert service.readback_expectations(**scope, command_id="late") == ()
     before = tuple(service.lifecycle_events())
-    clock.advance(0.1)
     service.apply_observation(
         Observation(
             path=intent.target,
@@ -120,9 +131,11 @@ async def test_termination_clears_pending_and_late_readback_cannot_revive() -> N
 
 def test_active_command_registry_is_bounded_and_terminal_entries_do_not_leak() -> None:
     service, _, _ = _service()
-    for index in range(129):
+    for index in range(128):
         intent = _intent(str(index), "websocket", "ws-a")
         service.emit_lifecycle(intent, "accepted")
+    service.emit_lifecycle(_intent("0", "websocket", "ws-a"), "acknowledged")
+    service.emit_lifecycle(_intent("128", "websocket", "ws-a"), "accepted")
 
     assert len(service._active_commands) == 128  # noqa: SLF001
     assert service.lifecycle_events()[-2].command_id == "0"


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-1775/mor-1500-b1-d-terminate-active-command-lifecycles-on-scope

## Summary
- track accepted, queued, sent, and acknowledged commands in a bounded exact source/session/id registry
- add idempotent `terminate_active_commands(...)` failure invalidation that clears scoped overlays and delayed readback expectations
- fail closed on registry capacity instead of silently losing active lifecycle ownership
- keep late canonical observations applicable to StateStore without reconciling or reviving a terminated command

## Scope and compatibility
- exactly 2 files and 195 changed LOC
- public lifecycle, execute/ACK, readback, and MOR-1770 dispatch-expectation behavior remain compatible
- no Web, Yaesu, frontend, rigctld handler, runtime, profile, protocol, or hardware changes

## Verification
- RED: focused slice initially failed 7 tests on the missing API and registry
- focused final: 4 passed
- relevant CommandService/Web/Yaesu/interlock suite: 361 passed
- full non-integration: 10021 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff check and format: pass
- import-linter: pass
- full mypy exact base/head parity: the same 12 pre-existing errors, zero owned delta
- diff check and privacy/secret scan: pass

No runtime, radio, serial device, PTT, TUNE, TX, or keying action was performed. Builder self-review is not an independent merge gate.
