### PR TITLE
fix(MOR-1776): bind rigctld readback to exact intent

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Sequence
@@ -59,6 +60,9 @@ class _ReadbackCorrelation:
     path: FieldPath
     value: Any
     command_service: "CommandService"
+    provider_generation: int | None
+    dispatched_at_monotonic: float
+    expires_at_monotonic: float
 
 
 class RigctldClientObservationPoller:
@@ -72,6 +76,7 @@ class RigctldClientObservationPoller:
         medium_interval: float = 2.0,
         slow_interval: float = 30.0,
         command_queue: "CommandQueue | None" = None,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._radio = radio
         self._callback = callback
@@ -81,6 +86,7 @@ class RigctldClientObservationPoller:
         self._tasks: list[asyncio.Task[None]] = []
         self._pending_readback_entries: list[_ReadbackCorrelation] = []
         self._capture_provider_generation: Callable[[], int] | None = None
+        self._clock = clock
 
     def bind_provider_generation(
         self,
@@ -120,6 +126,7 @@ class RigctldClientObservationPoller:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
+        self._discard_pending_readbacks()
 
     async def _run_loop(
         self,
@@ -141,7 +148,7 @@ class RigctldClientObservationPoller:
         capture = self._capture_provider_generation
         provider_generation = None if capture is None else capture()
         drained_entries = await self._drain_commands()
-        adapter = RigctldClientObservationAdapter(self._radio)
+        adapter = RigctldClientObservationAdapter(self._radio, clock=self._clock)
         observations: list["Observation"] = list(
             await adapter.read_freq_mode_controls()
         )
@@ -153,11 +160,11 @@ class RigctldClientObservationPoller:
             await _read_drained_slow_control_readbacks(adapter, drained_entries)
         )
         if not self._provider_generation_is_current(provider_generation):
+            self._discard_pending_readbacks()
             return
         self._callback(
-            self._stamp_provider_generation(
-                self._annotate_readback_observations(observations),
-                provider_generation,
+            self._annotate_readback_observations(
+                self._stamp_provider_generation(observations, provider_generation)
             )
         )
 
@@ -166,13 +173,14 @@ class RigctldClientObservationPoller:
 
         capture = self._capture_provider_generation
         provider_generation = None if capture is None else capture()
-        adapter = RigctldClientObservationAdapter(self._radio)
+        adapter = RigctldClientObservationAdapter(self._radio, clock=self._clock)
         observations = await adapter.read_slow_controls()
         if not self._provider_generation_is_current(provider_generation):
+            self._discard_pending_readbacks()
             return
         self._callback(
-            self._stamp_provider_generation(
-                self._annotate_readback_observations(observations), provider_generation
+            self._annotate_readback_observations(
+                self._stamp_provider_generation(observations, provider_generation)
             )
         )
 
@@ -190,10 +198,16 @@ class RigctldClientObservationPoller:
                     type(cmd).__name__,
                 )
                 continue
+            capture = self._capture_provider_generation
+            correlation = _readback_correlation_for_entry(
+                entry,
+                dispatched_at=self._clock(),
+                provider_generation=None if capture is None else capture(),
+            )
             try:
                 await self._execute_command(cmd)
                 successful.append(entry)
-                self._track_readback_entry(entry)
+                self._track_readback_entry(correlation)
                 if entry.future is not None and not entry.future.done():
                     entry.future.set_result(None)
             except Exception as exc:
@@ -207,11 +221,23 @@ class RigctldClientObservationPoller:
                 )
         return tuple(successful)
 
-    def _track_readback_entry(self, entry: "CommandQueueEntry") -> None:
-        correlation = _readback_correlation_for_entry(entry)
+    def _track_readback_entry(self, correlation: _ReadbackCorrelation | None) -> None:
         if correlation is None:
             return
+        replaced = [
+            entry
+            for entry in self._pending_readback_entries
+            if _readback_paths_match(entry.path, correlation.path)
+        ]
+        self._pending_readback_entries = [
+            entry for entry in self._pending_readback_entries if entry not in replaced
+        ]
+        _discard_readback_correlations(replaced)
         self._pending_readback_entries.append(correlation)
+
+    def _discard_pending_readbacks(self) -> None:
+        _discard_readback_correlations(self._pending_readback_entries)
+        self._pending_readback_entries = []
 
     def _annotate_readback_observations(
         self,
@@ -223,7 +249,9 @@ class RigctldClientObservationPoller:
         unmatched = list(self._pending_readback_entries)
         annotated: list[Observation] = []
         for observation in observations:
-            match_index = _matching_readback_entry_index(observation, unmatched)
+            match_index = _matching_readback_entry_index(
+                observation, unmatched, now=self._clock()
+            )
             if match_index is None:
                 annotated.append(observation)
                 continue
@@ -317,6 +345,9 @@ async def _read_drained_slow_control_readbacks(
 
 def _readback_correlation_for_entry(
     entry: "CommandQueueEntry",
+    *,
+    dispatched_at: float,
+    provider_generation: int | None,
 ) -> _ReadbackCorrelation | None:
     if (
         entry.command_service is None
@@ -324,7 +355,7 @@ def _readback_correlation_for_entry(
         or entry.source is None
     ):
         return None
-    expectations = entry.command_service.readback_expectations(
+    expectations = entry.command_service.retain_readback_expectations_for_dispatch(
         source=entry.source,
         session_id=entry.session_id,
         command_id=entry.command_id,
@@ -339,6 +370,9 @@ def _readback_correlation_for_entry(
         path=expectation.path,
         value=expectation.value,
         command_service=entry.command_service,
+        provider_generation=provider_generation,
+        dispatched_at_monotonic=dispatched_at,
+        expires_at_monotonic=expectation.expires_at_monotonic,
     )
 
 
@@ -355,9 +389,11 @@ def _discard_readback_correlations(entries: Sequence[_ReadbackCorrelation]) -> N
 def _matching_readback_entry_index(
     observation: Observation,
     entries: Sequence[_ReadbackCorrelation],
+    *,
+    now: float,
 ) -> int | None:
     for index, entry in enumerate(entries):
-        if _entry_matches_observation(entry, observation):
+        if _entry_matches_observation(entry, observation, now=now):
             return index
     return None
 
@@ -365,11 +401,42 @@ def _matching_readback_entry_index(
 def _entry_matches_observation(
     entry: _ReadbackCorrelation,
     observation: Observation,
+    *,
+    now: float,
 ) -> bool:
-    if not _is_external_rigctld_readback(observation.source):
+    if not _is_external_rigctld_readback(
+        observation.source
+    ) or not _correlation_is_live(entry, now, observation.provider_generation):
         return False
-    return entry.value == observation.value and _readback_paths_match(
-        observation.path, entry.path
+    return (
+        entry.dispatched_at_monotonic
+        < observation.timestamp_monotonic
+        < entry.expires_at_monotonic
+        and type(entry.value) is type(observation.value)
+        and entry.value == observation.value
+        and _readback_paths_match(observation.path, entry.path)
+    )
+
+
+def _correlation_is_live(
+    entry: _ReadbackCorrelation, now: float, provider_generation: int | None
+) -> bool:
+    if (
+        now >= entry.expires_at_monotonic
+        or entry.provider_generation is not None
+        and provider_generation != entry.provider_generation
+    ):
+        return False
+    return any(
+        item.path == entry.path
+        and item.expires_at_monotonic == entry.expires_at_monotonic
+        and type(item.value) is type(entry.value)
+        and item.value == entry.value
+        for item in entry.command_service.readback_expectations(
+            source=entry.source,
+            session_id=entry.session_id,
+            command_id=entry.command_id,
+        )
     )
 
 
@@ -394,6 +461,8 @@ def _with_command_metadata(
         quality=observation.quality,
         correlation_id=entry.command_id,
         max_age=observation.max_age,
+        provider_generation=observation.provider_generation,
+        clock_domain=observation.clock_domain,
     )
 
 

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -95,7 +95,15 @@ class RigctldClientObservationPoller:
         advance: Callable[[], int] | None = None,
     ) -> None:
         self._capture_provider_generation = capture
-        self._radio.bind_provider_generation(advance=advance)
+        if advance is None:
+            self._radio.bind_provider_generation()
+            return
+
+        def retire_and_advance() -> int:
+            self._discard_pending_readbacks()
+            return advance()
+
+        self._radio.bind_provider_generation(advance=retire_and_advance)
 
     def _stamp_provider_generation(
         self, observations: Sequence[Observation], generation: int | None
@@ -207,7 +215,7 @@ class RigctldClientObservationPoller:
             try:
                 await self._execute_command(cmd)
                 successful.append(entry)
-                self._track_readback_entry(correlation)
+                self._track_readback_entry(cmd, correlation)
                 if entry.future is not None and not entry.future.done():
                     entry.future.set_result(None)
             except Exception as exc:
@@ -221,19 +229,20 @@ class RigctldClientObservationPoller:
                 )
         return tuple(successful)
 
-    def _track_readback_entry(self, correlation: _ReadbackCorrelation | None) -> None:
-        if correlation is None:
-            return
+    def _track_readback_entry(
+        self, command: Any, correlation: _ReadbackCorrelation | None
+    ) -> None:
         replaced = [
             entry
             for entry in self._pending_readback_entries
-            if _readback_paths_match(entry.path, correlation.path)
+            if _physical_command_targets_path(command, entry.path)
         ]
+        _discard_readback_correlations(replaced)
         self._pending_readback_entries = [
             entry for entry in self._pending_readback_entries if entry not in replaced
         ]
-        _discard_readback_correlations(replaced)
-        self._pending_readback_entries.append(correlation)
+        if correlation is not None:
+            self._pending_readback_entries.append(correlation)
 
     def _discard_pending_readbacks(self) -> None:
         _discard_readback_correlations(self._pending_readback_entries)
@@ -471,6 +480,15 @@ def _readback_paths_match(readback_path: FieldPath, overlay_path: FieldPath) -> 
         return True
     return _external_rigctld_main_alias(readback_path) == (
         _external_rigctld_main_alias(overlay_path)
+    )
+
+
+def _physical_command_targets_path(command: Any, path: FieldPath) -> bool:
+    command_name = type(command).__name__.lower()
+    target_name = path.name.replace("_", "")
+    return target_name in command_name or (target_name, command_name) in (
+        ("freqhz", "setfreq"),
+        ("activeslot", "selectvfo"),
     )
 
 

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import replace
 
 import pytest
 
@@ -13,7 +12,6 @@ from rigplane._poller_types import (
     CommandQueue,
     EnableScope,
     PttOn,
-    SelectVfo,
     SetAfLevel,
     SetAttenuator,
     SetFreq,
@@ -24,10 +22,7 @@ from rigplane._poller_types import (
     SetRfGain,
 )
 from rigplane.backends.rigctld_client import RigctldClientRadio
-from rigplane.backends.rigctld_client.radio import (
-    RigctldClientObservationPoller,
-    _entry_matches_observation,
-)
+from rigplane.backends.rigctld_client.radio import RigctldClientObservationPoller
 from rigplane.backends.rigctld_client.observations import (
     RigctldClientObservationAdapter,
     build_external_rigctld_acquisition_profile,
@@ -175,18 +170,19 @@ async def test_observation_poller_drains_web_commands_before_readback() -> None:
 
 
 @pytest.mark.asyncio
-async def test_observation_poller_set_success_waits_for_rigctld_readback() -> None:
+@pytest.mark.parametrize("terminal", (False, True))
+async def test_newer_physical_dispatch_supersedes_older_readback(
+    terminal: bool,
+) -> None:
     async with FakeRigctldServer() as server:
         radio = RigctldClientRadio(host=server.host, port=server.port)
         await radio.connect()
         try:
             queue = CommandQueue()
-            clock = FreshnessClock(start=50.0)
-            store = StateStore(freshness_clock=clock)
+            store = StateStore()
             service = CommandService(
                 executor=_NoopCommandExecutor(),
                 state_store=store,
-                clock=clock.now,
             )
             intent = command_intent_from_request(
                 "set_freq",
@@ -210,94 +206,51 @@ async def test_observation_poller_set_success_waits_for_rigctld_readback() -> No
                 command_service=service,
             )
             observations = []
-            poller = RigctldClientObservationPoller(
-                radio,
+            poller = radio.create_observation_poller(
                 callback=observations.extend,
                 command_queue=queue,
-                clock=clock.now,
-            )
-            poller.bind_provider_generation(
-                capture=lambda: store.provider_generation,
-                advance=store.begin_provider_generation,
             )
 
             await poller._drain_commands()  # noqa: SLF001
-            await service.execute(
-                command_intent_from_request(
-                    "set_freq",
-                    {"freq": 7_060_000},
-                    source="websocket",
-                    command_id="latest",
-                )
-            )
-            queue.put_ordered(
-                SetFreq(7_060_000),
-                command_id="latest",
-                source="websocket",
-                command_service=service,
-            )
-            await poller._drain_commands()  # noqa: SLF001
-            pending = poller._pending_readback_entries  # noqa: SLF001
-            assert [item.command_id for item in pending] == ["latest"]
-            entry = pending[0]
-            clock.advance(0.1)
 
             assert future.done()
             assert future.result() is None
             with pytest.raises(KeyError):
                 store.snapshot().field("receiver.0.freq_mode.freq_hz")
 
+            if terminal:
+                service.fail_command(
+                    "ws-rigctld-set-freq", source="websocket", session_id=None
+                )
+            queue.put_ordered(
+                SetFreq(7_050_000),
+                command_id="ws-rigctld-set-freq" if terminal else None,
+                source="websocket",
+                command_service=service,
+            )
+            await poller._drain_commands()  # noqa: SLF001
+            assert poller._pending_readback_entries == []  # noqa: SLF001
+
             await poller._poll_medium()  # noqa: SLF001
+            for observation in observations:
+                service.apply_observation(observation)
+
             freq_observation = next(
                 item
                 for item in observations
                 if str(item.path) == "receiver.main.active.freq_mode.freq_hz"
             )
-            assert _entry_matches_observation(entry, freq_observation, now=clock.now())
-            assert all(
-                not _entry_matches_observation(entry, sample, now=now)
-                for sample, now in (
-                    (replace(freq_observation, value=True), clock.now()),
-                    (
-                        replace(
-                            freq_observation,
-                            timestamp_monotonic=entry.dispatched_at_monotonic,
-                        ),
-                        clock.now(),
-                    ),
-                    (freq_observation, entry.expires_at_monotonic),
-                )
+            assert not any(
+                event.state == "reconciled" for event in service.lifecycle_events()
             )
-            for observation in observations:
-                service.apply_observation(observation)
-
-            assert (
-                service.pending_overlays(
-                    source="websocket",
-                    session_id=None,
-                    command_id="latest",
-                )
-                == ()
-            )
-            assert [
-                event.state
-                for event in service.lifecycle_events()
-                if event.command_id == "latest"
-            ] == ["accepted", "queued", "sent", "acknowledged", "reconciled"]
             assert (
                 store.snapshot().field("receiver.main.active.freq_mode.freq_hz").value
-                == 7_060_000
+                == 7_050_000
             )
             assert freq_observation.source.source == "hamlib_response"
-            assert freq_observation.source.command_source == "websocket"
+            assert freq_observation.source.command_source is None
             assert freq_observation.source.session_id is None
-            assert freq_observation.correlation_id == "latest"
-            assert not _entry_matches_observation(
-                entry, freq_observation, now=clock.now()
-            )
-            poller._track_readback_entry(entry)  # noqa: SLF001
-            await poller.stop()
-            assert poller._pending_readback_entries == []  # noqa: SLF001
+            assert freq_observation.correlation_id is None
         finally:
             await radio.disconnect()
 
@@ -543,11 +496,11 @@ async def test_observation_poller_discards_expectation_when_readback_unavailable
             True,
         ),
         (
-            "select_vfo",
-            {"vfo": "B"},
-            SelectVfo("B"),
-            "receiver.main.vfo.active_slot",
-            "B",
+            "set_mode",
+            {"mode": "USB"},
+            SetMode("USB"),
+            "receiver.main.active.freq_mode.mode",
+            "USB",
         ),
     ),
 )
@@ -860,7 +813,12 @@ async def test_stale_external_rigctld_poll_clears_correlation_at_generation_boun
                 task = asyncio.create_task(poll())
                 await started.wait()
                 assert len(poller._pending_readback_entries) == 1  # noqa: SLF001
-                store.begin_provider_generation()
+                await radio.disconnect()
+                assert poller._pending_readback_entries == []  # noqa: SLF001
+                assert not service.readback_expectations(
+                    command_id="g2", source="websocket", session_id=None
+                )
+                await radio.connect()
                 release.set()
                 await task
 

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 
 import pytest
 
@@ -12,6 +13,7 @@ from rigplane._poller_types import (
     CommandQueue,
     EnableScope,
     PttOn,
+    SelectVfo,
     SetAfLevel,
     SetAttenuator,
     SetFreq,
@@ -22,6 +24,10 @@ from rigplane._poller_types import (
     SetRfGain,
 )
 from rigplane.backends.rigctld_client import RigctldClientRadio
+from rigplane.backends.rigctld_client.radio import (
+    RigctldClientObservationPoller,
+    _entry_matches_observation,
+)
 from rigplane.backends.rigctld_client.observations import (
     RigctldClientObservationAdapter,
     build_external_rigctld_acquisition_profile,
@@ -175,10 +181,12 @@ async def test_observation_poller_set_success_waits_for_rigctld_readback() -> No
         await radio.connect()
         try:
             queue = CommandQueue()
-            store = StateStore()
+            clock = FreshnessClock(start=50.0)
+            store = StateStore(freshness_clock=clock)
             service = CommandService(
                 executor=_NoopCommandExecutor(),
                 state_store=store,
+                clock=clock.now,
             )
             intent = command_intent_from_request(
                 "set_freq",
@@ -202,12 +210,37 @@ async def test_observation_poller_set_success_waits_for_rigctld_readback() -> No
                 command_service=service,
             )
             observations = []
-            poller = radio.create_observation_poller(
+            poller = RigctldClientObservationPoller(
+                radio,
                 callback=observations.extend,
                 command_queue=queue,
+                clock=clock.now,
+            )
+            poller.bind_provider_generation(
+                capture=lambda: store.provider_generation,
+                advance=store.begin_provider_generation,
             )
 
             await poller._drain_commands()  # noqa: SLF001
+            await service.execute(
+                command_intent_from_request(
+                    "set_freq",
+                    {"freq": 7_060_000},
+                    source="websocket",
+                    command_id="latest",
+                )
+            )
+            queue.put_ordered(
+                SetFreq(7_060_000),
+                command_id="latest",
+                source="websocket",
+                command_service=service,
+            )
+            await poller._drain_commands()  # noqa: SLF001
+            pending = poller._pending_readback_entries  # noqa: SLF001
+            assert [item.command_id for item in pending] == ["latest"]
+            entry = pending[0]
+            clock.advance(0.1)
 
             assert future.done()
             assert future.result() is None
@@ -215,6 +248,26 @@ async def test_observation_poller_set_success_waits_for_rigctld_readback() -> No
                 store.snapshot().field("receiver.0.freq_mode.freq_hz")
 
             await poller._poll_medium()  # noqa: SLF001
+            freq_observation = next(
+                item
+                for item in observations
+                if str(item.path) == "receiver.main.active.freq_mode.freq_hz"
+            )
+            assert _entry_matches_observation(entry, freq_observation, now=clock.now())
+            assert all(
+                not _entry_matches_observation(entry, sample, now=now)
+                for sample, now in (
+                    (replace(freq_observation, value=True), clock.now()),
+                    (
+                        replace(
+                            freq_observation,
+                            timestamp_monotonic=entry.dispatched_at_monotonic,
+                        ),
+                        clock.now(),
+                    ),
+                    (freq_observation, entry.expires_at_monotonic),
+                )
+            )
             for observation in observations:
                 service.apply_observation(observation)
 
@@ -222,28 +275,29 @@ async def test_observation_poller_set_success_waits_for_rigctld_readback() -> No
                 service.pending_overlays(
                     source="websocket",
                     session_id=None,
-                    command_id="ws-rigctld-set-freq",
+                    command_id="latest",
                 )
                 == ()
             )
             assert [
                 event.state
                 for event in service.lifecycle_events()
-                if event.command_id == "ws-rigctld-set-freq"
+                if event.command_id == "latest"
             ] == ["accepted", "queued", "sent", "acknowledged", "reconciled"]
             assert (
                 store.snapshot().field("receiver.main.active.freq_mode.freq_hz").value
-                == 7_050_000
-            )
-            freq_observation = next(
-                item
-                for item in observations
-                if str(item.path) == "receiver.main.active.freq_mode.freq_hz"
+                == 7_060_000
             )
             assert freq_observation.source.source == "hamlib_response"
             assert freq_observation.source.command_source == "websocket"
             assert freq_observation.source.session_id is None
-            assert freq_observation.correlation_id == "ws-rigctld-set-freq"
+            assert freq_observation.correlation_id == "latest"
+            assert not _entry_matches_observation(
+                entry, freq_observation, now=clock.now()
+            )
+            poller._track_readback_entry(entry)  # noqa: SLF001
+            await poller.stop()
+            assert poller._pending_readback_entries == []  # noqa: SLF001
         finally:
             await radio.disconnect()
 
@@ -488,6 +542,13 @@ async def test_observation_poller_discards_expectation_when_readback_unavailable
             "receiver.main.operator_toggles.nr",
             True,
         ),
+        (
+            "select_vfo",
+            {"vfo": "B"},
+            SelectVfo("B"),
+            "receiver.main.vfo.active_slot",
+            "B",
+        ),
     ),
 )
 async def test_observation_poller_reconciles_slow_control_set_without_waiting_for_slow_poll(
@@ -599,9 +660,11 @@ async def test_observation_poller_correlates_slow_control_after_overlay_ttl_edge
                 command_service=service,
             )
             observations = []
-            poller = radio.create_observation_poller(
+            poller = RigctldClientObservationPoller(
+                radio,
                 callback=observations.extend,
                 command_queue=queue,
+                clock=lambda: clock.advance(0.01),
             )
 
             await poller._poll_medium()  # noqa: SLF001
@@ -747,7 +810,7 @@ async def test_radio_observation_poller_emits_adapter_covered_reads() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("slow", (False, True))
-async def test_stale_external_rigctld_poll_preserves_correlation_for_next_cycle(
+async def test_stale_external_rigctld_poll_clears_correlation_at_generation_boundary(
     slow: bool,
 ) -> None:
     async with FakeRigctldServer() as server:
@@ -801,8 +864,8 @@ async def test_stale_external_rigctld_poll_preserves_correlation_for_next_cycle(
                 release.set()
                 await task
 
-            assert len(poller._pending_readback_entries) == 1  # noqa: SLF001
-            assert service.readback_expectations(
+            assert poller._pending_readback_entries == []  # noqa: SLF001
+            assert not service.readback_expectations(
                 command_id="g2", source="websocket", session_id=None
             )
             assert service.pending_overlays(
@@ -810,7 +873,7 @@ async def test_stale_external_rigctld_poll_preserves_correlation_for_next_cycle(
             )
             await poll()
             assert poller._pending_readback_entries == []  # noqa: SLF001
-            assert any(
+            assert not any(
                 event.state == "reconciled" for event in service.lifecycle_events()
             )
             await radio.disconnect()


### PR DESCRIPTION
## Summary

- bind external rigctld readback metadata to the exact active command identity, expectation value, dispatch window, and provider generation
- require a strictly post-dispatch external observation before reconciling, with fail-closed exact-type/value/path matching
- retire older same-target ownership after every newer successful physical setter dispatch, including uncommanded and terminal dispatches
- synchronously clear correlations and retained expectations on the existing exact-once provider-generation callback edge

## Compatibility

- external rigctld command wire, RPRT parsing, getters, setters, and exceptions are unchanged
- MOR-1771 no-optimistic-setter state semantics and MOR-1773 transport lifecycle generations are preserved
- no public API, CLI, config, handler/server, CommandService, runtime, or hardware behavior changes
- public/open-core boundary remains generic external rigctld provider behavior

## Red-first evidence

Initial exact-base RED: 4 failures / 7 passes for bounded dispatch/generation behavior.

Remediation RED on blocked head `92517e79a596288a6d8bcd1f4eff9f5f45aacddd`: 3/3 focused failures reproduced older ownership surviving a newer uncommanded dispatch and correlations/expectations surviving disconnect.

## Verification

- remediation focused: 4 passed
- full owned observation-adapter suite: 27 passed
- relevant rigctld client + CommandService + StateStore: 188 passed
- full non-integration: 10089 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- full Ruff check and format check: passed
- import-linter: 5 contracts kept
- full mypy: exact base/head parity, 12 existing errors in the same 3 unrelated files
- diff/privacy: clean
- cumulative scope: exactly 2 files, 200 changed LOC

## Agent Review

- [ ] Fresh independent exact-head Agent Review PASS required before merge
- Blocked review on prior head was addressed; builder did not self-PASS

## Notes

- Linear: MOR-1776
- Exact head: `71d83f7fb2824d7e4aede8cf8ec304d3db68e450`
- Out of scope: B4-e2 lifecycle cleanup, runtime/radio/hardware operations
