### PR TITLE
feat(MOR-1777): invalidate Web commands on provider scope

### DIFF
--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import logging
 import time
+from collections import deque
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from enum import StrEnum
@@ -260,6 +261,8 @@ class StateStore:
         "_history_floor_state_revision",
         "_max_history_count",
         "_observation_seq",
+        "_provider_generation_notifications",
+        "_provider_generation_notifying",
         "_provider_generation_subscribers",
         "_provider_generation",
         "_relative_vfo_retention",
@@ -281,6 +284,10 @@ class StateStore:
         self._observation_seq = 0
         self._provider_generation = 0
         self._provider_generation_subscribers: list[Callable[[int], None]] = []
+        self._provider_generation_notifications: deque[
+            tuple[int, tuple[Callable[[int], None], ...]]
+        ] = deque()
+        self._provider_generation_notifying = False
         self._relative_vfo_retention: _RelativeVfoRetention | None = None
         self._entries: dict[FieldPath, _FieldEntry] = {}
         self._history: list[SnapshotDelta] = []
@@ -315,11 +322,26 @@ class StateStore:
                 freshness=(),
                 reconciliation_requests=(),
             )
-        for subscriber in tuple(self._provider_generation_subscribers):
-            try:
-                subscriber(self._provider_generation)
-            except Exception:
-                logger.warning("provider generation subscriber failed", exc_info=True)
+        self._provider_generation_notifications.append(
+            (self._provider_generation, tuple(self._provider_generation_subscribers))
+        )
+        if self._provider_generation_notifying:
+            return self._provider_generation
+        self._provider_generation_notifying = True
+        try:
+            while self._provider_generation_notifications:
+                generation, subscribers = (
+                    self._provider_generation_notifications.popleft()
+                )
+                for subscriber in subscribers:
+                    try:
+                        subscriber(generation)
+                    except Exception:
+                        logger.warning(
+                            "provider generation subscriber failed", exc_info=True
+                        )
+        finally:
+            self._provider_generation_notifying = False
         return self._provider_generation
 
     def subscribe_provider_generation(

--- a/src/rigplane/core/state_store.py
+++ b/src/rigplane/core/state_store.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import copy
+import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
@@ -19,6 +20,7 @@ from rigplane.core.state_pipeline_contracts import (
 )
 
 _DEFAULT_MAX_HISTORY_COUNT = 4096
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "FieldSnapshot",
@@ -258,6 +260,7 @@ class StateStore:
         "_history_floor_state_revision",
         "_max_history_count",
         "_observation_seq",
+        "_provider_generation_subscribers",
         "_provider_generation",
         "_relative_vfo_retention",
         "_state_revision",
@@ -277,6 +280,7 @@ class StateStore:
         self._freshness_revision = 0
         self._observation_seq = 0
         self._provider_generation = 0
+        self._provider_generation_subscribers: list[Callable[[int], None]] = []
         self._relative_vfo_retention: _RelativeVfoRetention | None = None
         self._entries: dict[FieldPath, _FieldEntry] = {}
         self._history: list[SnapshotDelta] = []
@@ -311,7 +315,28 @@ class StateStore:
                 freshness=(),
                 reconciliation_requests=(),
             )
+        for subscriber in tuple(self._provider_generation_subscribers):
+            try:
+                subscriber(self._provider_generation)
+            except Exception:
+                logger.warning("provider generation subscriber failed", exc_info=True)
         return self._provider_generation
+
+    def subscribe_provider_generation(
+        self, subscriber: Callable[[int], None]
+    ) -> Callable[[], None]:
+        """Subscribe to synchronous generation invalidation notifications."""
+
+        self._provider_generation_subscribers.append(subscriber)
+
+        def unsubscribe() -> None:
+            self._provider_generation_subscribers[:] = [
+                item
+                for item in self._provider_generation_subscribers
+                if item is not subscriber
+            ]
+
+        return unsubscribe
 
     def apply(self, observation: Observation) -> ChangeSet:
         """Apply an explicitly generation-bound observation, or reject it."""

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -758,6 +758,11 @@ class WebServer:
             executor=_SharedControlCommandExecutor(self),
             state_store=self.command_state_store,
         )
+        self._unsubscribe_provider_generation = (
+            self.command_state_store.subscribe_provider_generation(
+                self._on_provider_generation
+            )
+        )
         # MOR-1445: a websocket-queued command can be acknowledged at enqueue
         # and only fail later, once RadioPoller actually executes it against
         # the radio (e.g. a validation error the poller surfaces post-ack).
@@ -1924,6 +1929,12 @@ class WebServer:
         """React to StateStore freshness changes produced by the shared service."""
         self._broadcast_state_update()
 
+    def _on_provider_generation(self, _generation: int) -> None:
+        """Fail active Web work at the canonical provider invalidation edge."""
+        self.command_service.terminate_active_commands(
+            "provider generation invalidated", source="websocket"
+        )
+
     def _build_radio_health(self) -> dict[str, Any]:
         """Build radio health and advance the health revision on transitions."""
         now = time.monotonic()
@@ -2094,7 +2105,8 @@ class WebServer:
         details = event.details
         timestamp = event.timestamp_monotonic
         if (
-            event.state not in ("queued", "superseded", "timed_out", "failed")
+            event.state
+            not in ("queued", "superseded", "timed_out", "failed", "reconciled")
             or event.source != "websocket"
             or not isinstance(event.command_id, str)
             or not event.command_id.strip()
@@ -2126,6 +2138,22 @@ class WebServer:
                 "reason": "tx_active",
                 "expiresAt": expires_at,
             }
+        elif event.state == "reconciled":
+            revision = details.get("revision")
+            observation_seq = details.get("observationSeq")
+            if (
+                set(details) != {"session_id", "revision", "observationSeq"}
+                or type(revision) is not int
+                or revision < 0
+                or type(observation_seq) is not int
+                or observation_seq < 0
+                or event.target is None
+                or event.message != "confirmed by matching observation"
+                or not any(
+                    prior is event for prior in self.command_service.lifecycle_events()
+                )
+            ):
+                return False
         elif set(details) != {"session_id"}:
             return False
         acknowledged = any(
@@ -2758,6 +2786,7 @@ class WebServer:
         from .web_startup import stop_web_server  # noqa: TID251
 
         self._stopping = True
+        self._unsubscribe_provider_generation()
         self._detach_audio_session_listener()
         self._detach_reconnect_status_listener()
         await stop_web_server(self)

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3290,7 +3290,6 @@ async def test_provider_generation_invalidates_only_active_web_commands() -> Non
     assert srv.command_state_store.begin_provider_generation() == 1
     unsubscribe()
     srv._broadcast_state_update(force=True)  # noqa: SLF001
-
     issuer = []
     while not issuer_q.empty():
         issuer.append(issuer_q.get_nowait())
@@ -3321,6 +3320,25 @@ async def test_provider_generation_invalidates_only_active_web_commands() -> Non
     assert issuer_q.empty() and bystander_q.empty()
 
 
+def test_provider_generation_subscribers_serialize_reentrant_advances() -> None:
+    store = StateStore()
+    trace: list[tuple[str, int]] = []
+
+    def first(generation: int) -> None:
+        trace.append(("first", generation))
+        if generation == 1:
+            store.begin_provider_generation()
+
+    store.subscribe_provider_generation(first)
+    unsubscribe = store.subscribe_provider_generation(
+        lambda value: trace.append(("second", value))
+    )
+    assert store.begin_provider_generation() == 2
+    assert trace == [("first", 1), ("second", 1), ("first", 2), ("second", 2)]
+    unsubscribe()
+    unsubscribe()
+
+
 @pytest.mark.asyncio
 async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None:
     srv = WebServer()
@@ -3337,7 +3355,6 @@ async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None
     )
     srv._on_command_lifecycle_event(malformed)  # noqa: SLF001
     assert issuer_q.empty() and bystander_q.empty()
-
     srv.command_service.apply_observation(
         Observation(
             path=FieldPath.receiver("0", "freq_mode", "freq_hz"),
@@ -3353,7 +3370,6 @@ async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None
             provider_generation=srv.command_state_store.provider_generation,
         )
     )
-
     payload = issuer_q.get_nowait()
     assert payload["state"] == "reconciled"
     assert payload["details"] == {}

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3257,6 +3257,110 @@ async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
     assert bystander_q.empty()
 
 
+@pytest.mark.asyncio
+async def test_provider_generation_invalidates_only_active_web_commands() -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    service = srv.command_service
+    service._executor = _StubCommandExecutor()  # noqa: SLF001
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq_hz": 1},
+            source="websocket",
+            command_id="same-id",
+            session_id="session-issuer",
+        )
+    )
+    await service.execute(
+        command_intent_from_request(
+            "set_freq",
+            {"freq_hz": 2},
+            source="public_api",
+            command_id="same-id",
+        )
+    )
+
+    def broken_subscriber(_generation: int) -> None:
+        raise RuntimeError("subscriber broke")
+
+    unsubscribe = srv.command_state_store.subscribe_provider_generation(
+        broken_subscriber
+    )
+    assert srv.command_state_store.begin_provider_generation() == 1
+    unsubscribe()
+    srv._broadcast_state_update(force=True)  # noqa: SLF001
+
+    issuer = []
+    while not issuer_q.empty():
+        issuer.append(issuer_q.get_nowait())
+    bystander = []
+    while not bystander_q.empty():
+        bystander.append(bystander_q.get_nowait())
+    assert [
+        item["state"] for item in issuer if item["type"] == "command_lifecycle"
+    ] == ["failed"]
+    assert not any(item["type"] == "command_lifecycle" for item in bystander)
+    assert service.terminate_active_commands("probe", source="websocket") == 0
+    assert service.terminate_active_commands("probe", source="public_api") == 1
+    service.apply_observation(
+        Observation(
+            path=FieldPath.receiver("0", "freq_mode", "freq_hz"),
+            value=1,
+            source=SourceMetadata(
+                source="poll_response",
+                provider="stale",
+                command_source="websocket",
+                session_id="session-issuer",
+            ),
+            timestamp_monotonic=time.monotonic(),
+            correlation_id="same-id",
+            provider_generation=0,
+        )
+    )
+    assert issuer_q.empty() and bystander_q.empty()
+
+
+@pytest.mark.asyncio
+async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    await _ack_held(srv)
+    malformed = _life(
+        state="reconciled",
+        message="confirmed by matching observation",
+        details={
+            "session_id": "session-issuer",
+            "revision": 1,
+            "observationSeq": 1,
+        },
+    )
+    srv._on_command_lifecycle_event(malformed)  # noqa: SLF001
+    assert issuer_q.empty() and bystander_q.empty()
+
+    srv.command_service.apply_observation(
+        Observation(
+            path=FieldPath.receiver("0", "freq_mode", "freq_hz"),
+            value=1,
+            source=SourceMetadata(
+                source="poll_response",
+                provider="physical",
+                command_source="websocket",
+                session_id="session-issuer",
+            ),
+            timestamp_monotonic=time.monotonic(),
+            correlation_id="cmd-held",
+            provider_generation=srv.command_state_store.provider_generation,
+        )
+    )
+
+    payload = issuer_q.get_nowait()
+    assert payload["state"] == "reconciled"
+    assert payload["details"] == {}
+    assert payload["commandId"] == "cmd-held" and issuer_q.empty()
+    assert bystander_q.empty()
+
+
 @pytest.mark.parametrize(
     "overrides",
     [


### PR DESCRIPTION
## Summary

- add a synchronous, exception-contained StateStore provider-generation subscription seam
- fail active WebSocket command lifecycles at the canonical generation invalidation edge while preserving other sources
- deliver physically reconciled command lifecycle only to the exact issuing WebSocket session

## Scope

- Linear: MOR-1777
- Base: `c204e3332dd388ecb2680d820c26ccc745548799`
- 3 files, 160 insertions / 2 deletions (162 changed LOC)
- no frontend, transport, CommandService implementation, runtime, radio, serial, PTT, TUNE, TX, or keying changes

## Verification

- RED reproduced: provider generation advance left active Web commands alive; exact physical correlated readback produced no issuer lifecycle
- focused: 2 passed
- adjacent: 479 passed / 2 skipped; one HTTP timeout flake passed exact rerun and full file (200 passed / 2 skipped)
- full non-integration: 10093 passed / 13 skipped / 5 deselected / 14 xfailed / 1 xpassed
- frontend: check PASS; 366 files / 8052 tests PASS; build PASS
- Ruff lint/format and import-linter PASS
- mypy exact base/head parity: identical 12 pre-existing errors in 3 files
- diff check and privacy scan PASS

Independent fresh exact-head Agent Review is required before merge. Builder does not self-PASS.
