### PR TITLE
fix(MOR-1778): fence late command completion after invalidation

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -26,6 +26,7 @@ from rigplane.core.state_pipeline_contracts import (
 from rigplane.core.state_store import StateStore
 
 __all__ = [
+    "CommandExecutionInvalidatedError",
     "CommandExecutionResult",
     "CommandExecutor",
     "CommandService",
@@ -51,6 +52,10 @@ _NORMALIZED_LEVEL_EXPECTATION_COMMANDS = {
 
 Clock = Callable[[], float]
 LifecycleSubscriber = Callable[[CommandLifecycleEvent], None]
+
+
+class CommandExecutionInvalidatedError(RuntimeError):
+    """Raised when an executor finishes after its command was invalidated."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,27 +153,38 @@ class CommandService:
         self.emit_lifecycle(intent, "accepted")
         self._record_intent_overlay(intent)
         self.emit_lifecycle(intent, "queued")
-        self.emit_lifecycle(intent, "sent")
+        sent_event = self.emit_lifecycle(intent, "sent")
+        key = (intent.source, _session_id(intent), intent.id)
         provider_generation = self._state_store.provider_generation
 
         try:
             executor_result = await self._executor.execute(intent)
         except (TimeoutError, RigplaneTimeoutError) as exc:
-            self.expire_command(
-                intent.id,
-                source=intent.source,
-                session_id=_session_id(intent),
-            )
-            self.emit_lifecycle(intent, "timed_out", message=str(exc) or None)
+            if self._active_commands.get(key) is sent_event:
+                self.expire_command(
+                    intent.id,
+                    source=intent.source,
+                    session_id=_session_id(intent),
+                )
+                self.emit_lifecycle(intent, "timed_out", message=str(exc) or None)
             raise
         except Exception as exc:
-            self.expire_command(
-                intent.id,
-                source=intent.source,
-                session_id=_session_id(intent),
-            )
-            self.emit_lifecycle(intent, "failed", message=str(exc) or None)
+            if self._active_commands.get(key) is sent_event:
+                self.expire_command(
+                    intent.id,
+                    source=intent.source,
+                    session_id=_session_id(intent),
+                )
+                self.emit_lifecycle(intent, "failed", message=str(exc) or None)
             raise
+
+        if self._active_commands.get(key) is not sent_event:
+            message = (
+                "command invalidated during provider generation change"
+                if self._state_store.provider_generation != provider_generation
+                else "command invalidated during execution"
+            )
+            raise CommandExecutionInvalidatedError(message)
 
         self.emit_lifecycle(intent, "acknowledged", details=executor_result.details)
         changes: list[ChangeSet] = []

--- a/tests/test_command_service_lifecycle_invalidation.py
+++ b/tests/test_command_service_lifecycle_invalidation.py
@@ -1,6 +1,13 @@
+import asyncio
 from typing import cast
 
-from rigplane.core.command_service import CommandExecutionResult, CommandService
+import pytest
+
+from rigplane.core.command_service import (
+    CommandExecutionInvalidatedError,
+    CommandExecutionResult,
+    CommandService,
+)
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
     CommandSource,
@@ -14,6 +21,30 @@ from rigplane.core.state_store import StateStore
 class _Executor:
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
         return CommandExecutionResult()
+
+
+class _GatedExecutor:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.fail = fail
+
+    async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
+        self.started.set()
+        await self.release.wait()
+        if self.fail:
+            raise RuntimeError("executor failed")
+        return CommandExecutionResult(
+            observations=(
+                Observation(
+                    intent.target,
+                    14_074_000,
+                    SourceMetadata("command_response", "test", "memory"),
+                    10.0,
+                    correlation_id=intent.id,
+                ),
+            )
+        )
 
 
 class _Trap:
@@ -99,6 +130,47 @@ def test_terminate_active_commands_preserves_existing_terminal_states() -> None:
         service.emit_lifecycle(intent, "acknowledged")
         service.emit_lifecycle(intent, terminal, message="original")
         assert service.terminate_active_commands("invalidate") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("executor_fails", [False, True])
+async def test_termination_fences_in_flight_executor_completion(
+    executor_fails: bool,
+) -> None:
+    executor = _GatedExecutor(fail=executor_fails)
+    store = StateStore()
+    service = CommandService(executor=executor, state_store=store)
+    intent = _intent("in-flight", "websocket", "ws-a")
+    execution = asyncio.create_task(service.execute(intent))
+    await executor.started.wait()
+    assert [event.state for event in service.lifecycle_events()] == [
+        "accepted",
+        "queued",
+        "sent",
+    ]
+
+    store.begin_provider_generation()
+    assert (
+        service.terminate_active_commands(
+            "provider replaced", source="websocket", session_id="ws-a"
+        )
+        == 1
+    )
+    executor.release.set()
+    error = RuntimeError if executor_fails else CommandExecutionInvalidatedError
+    message = "executor failed" if executor_fails else "provider generation change"
+    with pytest.raises(error, match=message):
+        await execution
+
+    assert [event.state for event in service.lifecycle_events()] == [
+        "accepted",
+        "queued",
+        "sent",
+        "failed",
+    ]
+    with pytest.raises(KeyError):
+        store.snapshot().field(intent.target)
+    assert service.terminate_active_commands("probe") == 0
 
 
 async def test_termination_clears_pending_and_late_readback_cannot_revive() -> None:


### PR DESCRIPTION
## Summary

- fence executor completion against the exact immutable sent lifecycle event before ACK
- preserve the first terminal lifecycle when scope invalidation wins the race
- suppress late observations, reconciliation, reactivation, and duplicate failure/timeout terminals
- surface an explicit `CommandExecutionInvalidatedError` while preserving ordinary generation-only behavior

Linear: [MOR-1778](https://linear.app/morozsm/issue/MOR-1778/mor-1500-b1-d2a-fence-late-command-completion-after-scope-invalidation)
Blocks: MOR-1777 / PR #2732

## Scope

- exact 2 files
- 116 changed LOC (+102/-14)
- base `c204e3332dd388ecb2680d820c26ccc745548799`

## Red / green

- RED: gated executor test failed at collection before the explicit invalidation outcome existed
- GREEN: exact scope termination during gated success/failure produces only `accepted -> queued -> sent -> failed`; resuming produces no ACK, observation, reconciliation, reactivation, or duplicate terminal

## Verification

- focused + adjacent Python 3.11: 99 passed
- full non-integration Python 3.11: 10032 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff lint: pass
- Ruff format check: pass (675 files)
- import-linter: 5 contracts kept
- mypy base/head parity: identical 12 pre-existing errors in 3 files
- diff check: pass
- privacy scan: clean

## Safety

No Web, frontend, Yaesu, rigctld, runtime, hardware, radio, serial, PTT, TUNE, TX, or keying changes. Builder does not self-PASS.