### PR TITLE
feat(MOR-1779): publish rigctld physical write results

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -223,9 +223,8 @@ class RigctldClientObservationPoller:
                 if entry.future is not None and not entry.future.done():
                     entry.future.set_result(None)
             except Exception as exc:
-                self._finish_readbacks(
-                    () if correlation is None else (correlation,), "rejected"
-                )
+                if correlation is not None:
+                    self._finish_readbacks((correlation,), "rejected")
                 self._mark_queued_command_failed(entry, exc)
                 if entry.future is not None and not entry.future.done():
                     entry.future.set_exception(exc)
@@ -245,9 +244,6 @@ class RigctldClientObservationPoller:
             if _physical_command_targets_path(command, entry.path)
         ]
         self._finish_readbacks(replaced, "superseded")
-        self._pending_readback_entries = [
-            entry for entry in self._pending_readback_entries if entry not in replaced
-        ]
         if correlation is not None:
             self._pending_readback_entries.append(correlation)
 
@@ -257,6 +253,11 @@ class RigctldClientObservationPoller:
         status: PhysicalWriteReadbackStatus,
         observation: Observation | None = None,
     ) -> None:
+        self._pending_readback_entries = [
+            entry for entry in self._pending_readback_entries if entry not in entries
+        ]
+        if status != "reconciled":
+            _discard_readback_correlations(entries)
         for entry in entries:
             self._radio._publish_physical_write_result(  # noqa: SLF001
                 PhysicalWriteReadbackResult(
@@ -270,11 +271,6 @@ class RigctldClientObservationPoller:
                     provider_generation=entry.provider_generation,
                 )
             )
-        if status != "reconciled":
-            _discard_readback_correlations(entries)
-        self._pending_readback_entries = [
-            entry for entry in self._pending_readback_entries if entry not in entries
-        ]
 
     def _annotate_readback_observations(
         self,
@@ -297,6 +293,12 @@ class RigctldClientObservationPoller:
             annotated.append(_with_command_metadata(observation, entry))
         now = self._clock()
         for entry in unmatched:
+            if not _correlation_is_live(entry, now, entry.provider_generation):
+                self._finish_readbacks(
+                    (entry,),
+                    "timed_out" if now >= entry.expires_at_monotonic else "cancelled",
+                )
+                continue
             mismatch = next(
                 (
                     item
@@ -310,14 +312,8 @@ class RigctldClientObservationPoller:
                 ),
                 None,
             )
-            status: PhysicalWriteReadbackStatus = (
-                "timed_out" if mismatch is None else "mismatched"
-            )
-            if not _correlation_is_live(entry, now, entry.provider_generation):
-                status = (
-                    "timed_out" if now >= entry.expires_at_monotonic else "cancelled"
-                )
-            self._finish_readbacks((entry,), status, mismatch)
+            if mismatch is not None:
+                self._finish_readbacks((entry,), "mismatched", mismatch)
         return tuple(annotated)
 
     async def _execute_command(self, cmd: Any) -> None:

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -10,6 +10,10 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Sequence
 
 from ...exceptions import CommandError
+from ...core.radio_protocol import (
+    PhysicalWriteReadbackResult,
+    PhysicalWriteReadbackStatus,
+)
 from ...core.state_pipeline_contracts import (
     CommandSource,
     FieldPath,
@@ -100,7 +104,7 @@ class RigctldClientObservationPoller:
             return
 
         def retire_and_advance() -> int:
-            self._discard_pending_readbacks()
+            self._finish_readbacks(self._pending_readback_entries, "provider_lost")
             return advance()
 
         self._radio.bind_provider_generation(advance=retire_and_advance)
@@ -134,7 +138,7 @@ class RigctldClientObservationPoller:
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
-        self._discard_pending_readbacks()
+        self._finish_readbacks(self._pending_readback_entries, "cancelled")
 
     async def _run_loop(
         self,
@@ -168,7 +172,7 @@ class RigctldClientObservationPoller:
             await _read_drained_slow_control_readbacks(adapter, drained_entries)
         )
         if not self._provider_generation_is_current(provider_generation):
-            self._discard_pending_readbacks()
+            self._finish_readbacks(self._pending_readback_entries, "provider_lost")
             return
         self._callback(
             self._annotate_readback_observations(
@@ -184,7 +188,7 @@ class RigctldClientObservationPoller:
         adapter = RigctldClientObservationAdapter(self._radio, clock=self._clock)
         observations = await adapter.read_slow_controls()
         if not self._provider_generation_is_current(provider_generation):
-            self._discard_pending_readbacks()
+            self._finish_readbacks(self._pending_readback_entries, "provider_lost")
             return
         self._callback(
             self._annotate_readback_observations(
@@ -219,6 +223,9 @@ class RigctldClientObservationPoller:
                 if entry.future is not None and not entry.future.done():
                     entry.future.set_result(None)
             except Exception as exc:
+                self._finish_readbacks(
+                    () if correlation is None else (correlation,), "rejected"
+                )
                 self._mark_queued_command_failed(entry, exc)
                 if entry.future is not None and not entry.future.done():
                     entry.future.set_exception(exc)
@@ -237,16 +244,37 @@ class RigctldClientObservationPoller:
             for entry in self._pending_readback_entries
             if _physical_command_targets_path(command, entry.path)
         ]
-        _discard_readback_correlations(replaced)
+        self._finish_readbacks(replaced, "superseded")
         self._pending_readback_entries = [
             entry for entry in self._pending_readback_entries if entry not in replaced
         ]
         if correlation is not None:
             self._pending_readback_entries.append(correlation)
 
-    def _discard_pending_readbacks(self) -> None:
-        _discard_readback_correlations(self._pending_readback_entries)
-        self._pending_readback_entries = []
+    def _finish_readbacks(
+        self,
+        entries: Sequence[_ReadbackCorrelation],
+        status: PhysicalWriteReadbackStatus,
+        observation: Observation | None = None,
+    ) -> None:
+        for entry in entries:
+            self._radio._publish_physical_write_result(  # noqa: SLF001
+                PhysicalWriteReadbackResult(
+                    status=status,
+                    command_id=entry.command_id,
+                    source=entry.source,
+                    session_id=entry.session_id,
+                    path=entry.path,
+                    expected_value=entry.value,
+                    observed_value=None if observation is None else observation.value,
+                    provider_generation=entry.provider_generation,
+                )
+            )
+        if status != "reconciled":
+            _discard_readback_correlations(entries)
+        self._pending_readback_entries = [
+            entry for entry in self._pending_readback_entries if entry not in entries
+        ]
 
     def _annotate_readback_observations(
         self,
@@ -265,9 +293,31 @@ class RigctldClientObservationPoller:
                 annotated.append(observation)
                 continue
             entry = unmatched.pop(match_index)
+            self._finish_readbacks((entry,), "reconciled", observation)
             annotated.append(_with_command_metadata(observation, entry))
-        self._pending_readback_entries = []
-        _discard_readback_correlations(unmatched)
+        now = self._clock()
+        for entry in unmatched:
+            mismatch = next(
+                (
+                    item
+                    for item in observations
+                    if _is_external_rigctld_readback(item.source)
+                    and _correlation_is_live(entry, now, item.provider_generation)
+                    and entry.dispatched_at_monotonic
+                    < item.timestamp_monotonic
+                    < entry.expires_at_monotonic
+                    and _readback_paths_match(item.path, entry.path)
+                ),
+                None,
+            )
+            status: PhysicalWriteReadbackStatus = (
+                "timed_out" if mismatch is None else "mismatched"
+            )
+            if not _correlation_is_live(entry, now, entry.provider_generation):
+                status = (
+                    "timed_out" if now >= entry.expires_at_monotonic else "cancelled"
+                )
+            self._finish_readbacks((entry,), status, mismatch)
         return tuple(annotated)
 
     async def _execute_command(self, cmd: Any) -> None:
@@ -528,6 +578,23 @@ class RigctldClientRadio:
         self._model = model or "External rigctld"
         self._state = RadioState()
         self._vfo_supported = False
+        self._physical_write_result_callback: (
+            Callable[[PhysicalWriteReadbackResult], None] | None
+        ) = None
+
+    def set_physical_write_result_callback(
+        self, callback: Callable[[PhysicalWriteReadbackResult], None] | None
+    ) -> None:
+        self._physical_write_result_callback = callback
+
+    def _publish_physical_write_result(
+        self, result: PhysicalWriteReadbackResult
+    ) -> None:
+        try:
+            if self._physical_write_result_callback is not None:
+                self._physical_write_result_callback(result)
+        except Exception:
+            logger.warning("rigctld-client write-result callback failed", exc_info=True)
 
     def bind_provider_generation(
         self, *, advance: Callable[[], int] | None = None

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -64,7 +64,7 @@ from .types import AudioCodec, BreakInMode, Mode
 if TYPE_CHECKING:
     from ._state_cache import StateCache
     from .acquisition_scheduler import AcquisitionPriority, EnsureFreshResult
-    from .state_pipeline_contracts import FieldPath, Observation
+    from .state_pipeline_contracts import CommandSource, FieldPath, Observation
     from .state_store import StateStore
     from rigplane.audio_bus import AudioBus
     from rigplane.runtime._poller_types import CommandQueue
@@ -110,6 +110,9 @@ __all__ = [
     "RigctldRoutingStrategy",
     "SplitCapable",
     "StateNotifyCapable",
+    "PhysicalWriteReadbackCapable",
+    "PhysicalWriteReadbackResult",
+    "PhysicalWriteReadbackStatus",
     "ObservationPollable",
     "ObservationPoller",
     "StatePollable",
@@ -802,6 +805,40 @@ class ObservationPoller(Protocol):
 
     async def stop(self) -> None:
         """Stop the polling loops and wait for them to finish."""
+        ...
+
+
+PhysicalWriteReadbackStatus = Literal[
+    "reconciled",
+    "mismatched",
+    "rejected",
+    "timed_out",
+    "provider_lost",
+    "cancelled",
+    "superseded",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PhysicalWriteReadbackResult:
+    """Terminal provider evidence for one physically dispatched write."""
+
+    status: PhysicalWriteReadbackStatus
+    command_id: str
+    source: "CommandSource"
+    session_id: str | None
+    path: "FieldPath"
+    expected_value: Any
+    observed_value: Any | None = None
+    provider_generation: int | None = None
+
+
+@runtime_checkable
+class PhysicalWriteReadbackCapable(Protocol):
+    def set_physical_write_result_callback(
+        self, callback: Callable[[PhysicalWriteReadbackResult], None] | None
+    ) -> None:
+        """Register a result callback, or clear it with ``None``."""
         ...
 
 

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -453,6 +453,8 @@ async def test_observation_poller_discards_expectation_when_readback_unavailable
             )
 
             await poller._drain_commands()  # noqa: SLF001
+            poller._annotate_readback_observations(())  # noqa: SLF001
+            assert not results and poller._pending_readback_entries  # noqa: SLF001
             if cancel:
                 await poller.stop()
             else:
@@ -565,11 +567,20 @@ async def test_observation_poller_reconciles_slow_control_set_without_waiting_fo
             )
             observations = []
             results = []
-            radio.set_physical_write_result_callback(results.append)
             poller = radio.create_observation_poller(
                 callback=observations.extend,
                 command_queue=queue,
             )
+
+            def collect_reentrantly(result) -> None:  # type: ignore[no-untyped-def]
+                results.append(result)
+                if len(results) == 1:
+                    poller._finish_readbacks(  # noqa: SLF001
+                        poller._pending_readback_entries,
+                        result.status,  # noqa: SLF001
+                    )
+
+            radio.set_physical_write_result_callback(collect_reentrantly)
 
             await poller._poll_medium()  # noqa: SLF001
             for observation in observations:
@@ -594,7 +605,7 @@ async def test_observation_poller_reconciles_slow_control_set_without_waiting_fo
             assert readback.value == expected_value
             assert readback.source.source == "hamlib_response"
             assert readback.correlation_id == command_id
-            assert results.pop().status == "reconciled"
+            assert [result.status for result in results] == ["reconciled"]
         finally:
             await radio.disconnect()
 
@@ -753,20 +764,12 @@ async def test_observation_poller_unsupported_command_fails_future() -> None:
             service = CommandService(
                 executor=_NoopCommandExecutor(), state_store=StateStore()
             )
+            make_intent = command_intent_from_request
             await service.execute(
-                command_intent_from_request(
-                    "set_freq",
-                    {"freq": 7_050_000},
-                    source="rigctld",
-                    command_id="rejected",
-                )
+                make_intent("set_freq", {"freq": 1}, source="http", command_id="r")
             )
-            queue.put_ordered(
-                SetFreq(7_050_000),
-                command_id="rejected",
-                source="rigctld",
-                command_service=service,
-            )
+            put = queue.put_ordered
+            put(SetFreq(1), command_id="r", source="http", command_service=service)
             results = []
             radio.set_physical_write_result_callback(
                 lambda result: (results.append(result), 1 / 0)

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,7 +30,10 @@ from rigplane.backends.rigctld_client.observations import (
 )
 from rigplane.core.acquisition_scheduler import AcquisitionScheduler, AcquisitionStatus
 from rigplane.core.capabilities import CAP_POWER_CONTROL, CAP_TX
-from rigplane.core.radio_protocol import PowerControlCapable
+from rigplane.core.radio_protocol import (
+    PhysicalWriteReadbackCapable,
+    PowerControlCapable,
+)
 from rigplane.core.state_acquisition_policy import FieldAvailability
 from rigplane.core.command_service import (
     CommandExecutionResult,
@@ -210,6 +214,8 @@ async def test_newer_physical_dispatch_supersedes_older_readback(
                 callback=observations.extend,
                 command_queue=queue,
             )
+            results = []
+            radio.set_physical_write_result_callback(results.append)
 
             await poller._drain_commands()  # noqa: SLF001
 
@@ -230,6 +236,7 @@ async def test_newer_physical_dispatch_supersedes_older_readback(
             )
             await poller._drain_commands()  # noqa: SLF001
             assert poller._pending_readback_entries == []  # noqa: SLF001
+            assert results[-1].status == "superseded"
 
             await poller._poll_medium()  # noqa: SLF001
             for observation in observations:
@@ -283,6 +290,8 @@ async def test_observation_poller_does_not_reconcile_nonmatching_readback() -> N
                 command_service=service,
             )
             observations = []
+            results = []
+            radio.set_physical_write_result_callback(results.append)
             poller = radio.create_observation_poller(
                 callback=observations.extend,
                 command_queue=queue,
@@ -309,6 +318,8 @@ async def test_observation_poller_does_not_reconcile_nonmatching_readback() -> N
             )
             assert freq_observation.value == 7_050_000
             assert freq_observation.correlation_id is None
+            result = results.pop()
+            assert result.status == "mismatched"
             assert (
                 store.snapshot().field("receiver.main.active.freq_mode.freq_hz").value
                 == 7_050_000
@@ -403,17 +414,20 @@ async def test_observation_poller_discards_nonmatching_readback_expectation() ->
 
 
 @pytest.mark.asyncio
-async def test_observation_poller_discards_expectation_when_readback_unavailable() -> (
-    None
-):
+@pytest.mark.parametrize("cancel", (False, True))
+async def test_observation_poller_discards_expectation_when_readback_unavailable(
+    cancel: bool,
+) -> None:
     async with FakeRigctldServer() as server:
         radio = RigctldClientRadio(host=server.host, port=server.port)
         await radio.connect()
         try:
             queue = CommandQueue()
+            clock = FreshnessClock(start=70.0)
             service = CommandService(
                 executor=_NoopCommandExecutor(),
-                state_store=StateStore(),
+                state_store=StateStore(freshness_clock=clock),
+                clock=clock.now,
             )
             command_id = "ws-rigctld-no-readback"
             intent = command_intent_from_request(
@@ -429,13 +443,21 @@ async def test_observation_poller_discards_expectation_when_readback_unavailable
                 source="websocket",
                 command_service=service,
             )
-            poller = radio.create_observation_poller(
+            results = []
+            radio.set_physical_write_result_callback(results.append)
+            poller = RigctldClientObservationPoller(
+                radio,
                 callback=lambda _observations: None,
                 command_queue=queue,
+                clock=clock.now,
             )
 
             await poller._drain_commands()  # noqa: SLF001
-            poller._annotate_readback_observations(())  # noqa: SLF001
+            if cancel:
+                await poller.stop()
+            else:
+                clock.advance(20.0)
+                poller._annotate_readback_observations(())  # noqa: SLF001
 
             assert (
                 service.readback_expectations(
@@ -445,6 +467,7 @@ async def test_observation_poller_discards_expectation_when_readback_unavailable
                 )
                 == ()
             )
+            assert results.pop().status == ("cancelled" if cancel else "timed_out")
         finally:
             await radio.disconnect()
 
@@ -541,6 +564,8 @@ async def test_observation_poller_reconciles_slow_control_set_without_waiting_fo
                 command_service=service,
             )
             observations = []
+            results = []
+            radio.set_physical_write_result_callback(results.append)
             poller = radio.create_observation_poller(
                 callback=observations.extend,
                 command_queue=queue,
@@ -569,6 +594,7 @@ async def test_observation_poller_reconciles_slow_control_set_without_waiting_fo
             assert readback.value == expected_value
             assert readback.source.source == "hamlib_response"
             assert readback.correlation_id == command_id
+            assert results.pop().status == "reconciled"
         finally:
             await radio.disconnect()
 
@@ -723,6 +749,33 @@ async def test_observation_poller_unsupported_command_fails_future() -> None:
             assert future.done()
             with pytest.raises(CommandError, match="not supported"):
                 future.result()
+
+            service = CommandService(
+                executor=_NoopCommandExecutor(), state_store=StateStore()
+            )
+            await service.execute(
+                command_intent_from_request(
+                    "set_freq",
+                    {"freq": 7_050_000},
+                    source="rigctld",
+                    command_id="rejected",
+                )
+            )
+            queue.put_ordered(
+                SetFreq(7_050_000),
+                command_id="rejected",
+                source="rigctld",
+                command_service=service,
+            )
+            results = []
+            radio.set_physical_write_result_callback(
+                lambda result: (results.append(result), 1 / 0)
+            )
+            poller._execute_command = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+                side_effect=CommandError("RPRT -1")
+            )
+            await poller._drain_commands()  # noqa: SLF001
+            assert results.pop().status == "rejected"
         finally:
             await radio.disconnect()
 
@@ -789,6 +842,8 @@ async def test_stale_external_rigctld_poll_clears_correlation_at_generation_boun
                 callback=lambda batch: list(map(service.apply_observation, batch)),
                 command_queue=queue,
             )
+            results = []
+            radio.set_physical_write_result_callback(results.append)
             poller.bind_provider_generation(
                 capture=lambda: store.provider_generation,
                 advance=store.begin_provider_generation,
@@ -815,6 +870,7 @@ async def test_stale_external_rigctld_poll_clears_correlation_at_generation_boun
                 assert len(poller._pending_readback_entries) == 1  # noqa: SLF001
                 await radio.disconnect()
                 assert poller._pending_readback_entries == []  # noqa: SLF001
+                assert results.pop().status == "provider_lost"
                 assert not service.readback_expectations(
                     command_id="g2", source="websocket", session_id=None
                 )
@@ -921,6 +977,7 @@ async def test_tx_capability_excludes_power_control_with_unsupported_power() -> 
         try:
             # Capability set advertises PTT TX but never power control.
             assert CAP_TX in radio.capabilities
+            assert isinstance(radio, PhysicalWriteReadbackCapable)
             assert CAP_POWER_CONTROL not in radio.capabilities
             assert "power" not in radio.capabilities
             # The backend cannot honor power-set/get, so it must not


### PR DESCRIPTION
## Summary
- add an optional backend-neutral `PhysicalWriteReadbackCapable` result contract
- publish exact external rigctld terminal results from the existing bounded MOR-1776 correlation authority
- distinguish reconciled, mismatched, rejected, timed-out, provider-lost, cancelled, and superseded outcomes without optimistic state or handler return mapping

## Scope
- 3 files, 197 changed LOC
- no handler, CommandService, StateStore, Yaesu, Web, frontend, runtime, wire, or hardware changes

## Verification
- RED: focused collection failed because `PhysicalWriteReadbackCapable` was absent
- exact-head focused/relevant: 164 passed
- exact-head full non-integration: 10,096 passed, 13 skipped, 5 deselected, 14 xfailed, 1 xpassed
- Ruff check/format and import-linter: pass
- full mypy: exact base/head parity (12 pre-existing errors; zero new)

Linear: [MOR-1779](https://linear.app/morozsm/issue/MOR-1779/mor-1500-b4-d2-expose-provider-owned-physical-write-readback-results)