### PR TITLE
fix(MOR-1780): expose sanitized reconciliation evidence

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2154,6 +2154,10 @@ class WebServer:
                 )
             ):
                 return False
+            public_details = {
+                "revision": revision,
+                "observationSeq": observation_seq,
+            }
         elif set(details) != {"session_id"}:
             return False
         acknowledged = any(

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3371,10 +3371,49 @@ async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None
         )
     )
     payload = issuer_q.get_nowait()
+    reconciled = srv.command_service.lifecycle_events()[-1]
     assert payload["state"] == "reconciled"
-    assert payload["details"] == {}
+    assert payload["details"] == {
+        "revision": reconciled.details["revision"],
+        "observationSeq": reconciled.details["observationSeq"],
+    }
     assert payload["commandId"] == "cmd-held" and issuer_q.empty()
     assert bystander_q.empty()
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        {"session_id": "session-issuer", "observationSeq": 1},
+        {"session_id": "session-issuer", "revision": 1},
+        {"session_id": "session-issuer", "revision": True, "observationSeq": 1},
+        {"session_id": "session-issuer", "revision": -1, "observationSeq": 1},
+        {"session_id": "session-issuer", "revision": 1.0, "observationSeq": 1},
+        {"session_id": "session-issuer", "revision": 1, "observationSeq": False},
+        {"session_id": "session-issuer", "revision": 1, "observationSeq": -1},
+        {
+            "session_id": "session-issuer",
+            "revision": 1,
+            "observationSeq": 1,
+            "private": "drop",
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_malformed_reconciled_evidence_is_not_delivered(
+    details: dict[str, object],
+) -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    await _ack_held(srv)
+    event = _life(
+        state="reconciled",
+        message="confirmed by matching observation",
+        details=details,
+    )
+    srv.command_service._events.append(event)  # noqa: SLF001
+    srv._on_command_lifecycle_event(event)  # noqa: SLF001
+    assert issuer_q.empty() and bystander_q.empty()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- retain the existing strict issuer/session/ACK/recorded-event authorization for `reconciled` lifecycle
- expose only exact `revision` and `observationSeq` evidence to the issuing WebSocket
- continue stripping `session_id` and all internal/private extensions
- fail closed on missing, boolean, negative, float, or extra evidence

Linear: [MOR-1780](https://linear.app/morozsm/issue/MOR-1780/mor-1500-b1-d3a-expose-sanitized-reconciliation-evidence-to-issuer)
Prerequisite for the planned frontend transport decoder slice.

## Scope

- exact 2 files
- 45 changed LOC (+44/-1)
- base `ae0131bb775b221385ed18fea53865c4fea7557e`

## Red / green

- RED: real correlated reconciliation delivered public `details: {}`
- GREEN: public details exactly match the recorded event revision/observation sequence; malformed evidence yields zero delivery

## Verification

- focused: 10 passed
- adjacent Web: 346 passed, 2 skipped
- full non-integration Python 3.11: 10045 passed, 74 skipped, 5 deselected, 14 xfailed, 1 xpassed
- frontend: check 0/0, 366 files / 8052 tests passed, build passed
- Ruff lint/format: passed
- import-linter: 5 contracts kept
- mypy base/head parity: identical 12 pre-existing errors in 3 files
- diff/privacy: clean

## Safety

No frontend, StateStore, CommandService, Yaesu, rigctld, runtime, hardware, radio, serial, PTT, TUNE, TX, or keying changes. Builder does not self-PASS.