### PR TITLE
feat(MOR-1781): decode reconciled transport evidence

### DIFF
--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WsCommand, WsMessage } from '../../types/protocol';
 import type { ReceiverState, ServerState } from '../../types/state';
-import type { CommandDeliveryEvent, CommandLifecycleDeliveryEvent, ControlSessionTransition } from '../ws-client';
+import type { CommandDeliveryEvent, CommandLifecycleDeliveryEvent, CommandReconciliationDeliveryEvent, ControlSessionTransition } from '../ws-client';
 import { MockWebSocket, instances } from './support/fake-ws-backend';
 
 type ServerStateWithObservation = ServerState & {
@@ -388,6 +388,113 @@ describe('WsChannel', () => {
     ]);
     expect(ordinary.filter((event) => event.kind === 'response-ok')).toHaveLength(3);
     expect(messages).not.toContainEqual(expect.objectContaining({ type: 'command_lifecycle' }));
+  });
+
+  it('emits only sanitized reconciliation evidence after physical lifecycle truth', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const lifecycle: CommandReconciliationDeliveryEvent[] = [];
+    const ordinary: CommandDeliveryEvent[] = [];
+    ch.onCommandReconciliationDelivery((event) => lifecycle.push(event));
+    ch.onCommandDelivery((event) => ordinary.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    sendStateUpdate(instances[0], fullEnvelope(makeState({ revision: 4, observationSeq: 8 })));
+    const stateBefore = radioStoreMock.current;
+    const writesBefore = vi.mocked(setRadioState).mock.calls.length;
+
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reconciled', params: { freq: 1 } });
+    instances[0].simulateMessage(JSON.stringify({ type: 'ack', id: 'reconciled' }));
+    instances[0].simulateMessage(JSON.stringify({ type: 'response', id: 'reconciled', ok: true }));
+    expect(lifecycle).toEqual([]);
+    expect(ordinary.map((event) => event.kind)).toEqual(['transport-sent', 'ack', 'response-ok']);
+
+    instances[0].simulateMessage(JSON.stringify({
+      type: 'command_lifecycle', commandId: 'reconciled', state: 'reconciled',
+      source: 'websocket', target: 'receiver.0.freq_mode.freq_hz',
+      timestampMonotonic: 12.5, message: 'confirmed by matching observation',
+      details: { revision: 5, observationSeq: 9 },
+    }));
+
+    expect(lifecycle).toEqual([{
+      commandId: 'reconciled', kind: 'reconciled', originalEpoch: 1, eventEpoch: 1,
+      revision: 5, observationSeq: 9,
+    }]);
+    expect(radioStoreMock.current).toBe(stateBefore);
+    expect(setRadioState).toHaveBeenCalledTimes(writesBefore);
+  });
+
+  it('rejects malformed, cancelled, and stale-socket reconciliation evidence', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    const events: CommandReconciliationDeliveryEvent[] = [];
+    ch.onCommandReconciliationDelivery((event) => events.push(event));
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'strict', params: {} });
+    const valid = {
+      type: 'command_lifecycle', commandId: 'strict', state: 'reconciled',
+      source: 'websocket', target: 'receiver.0.freq_mode.freq_hz',
+      timestampMonotonic: 12.5, message: 'confirmed by matching observation',
+      details: { revision: 5, observationSeq: 9 },
+    };
+    const invalid = [
+      { ...valid, source: 'public_api' },
+      { ...valid, source: undefined },
+      { ...valid, commandId: ' ' },
+      { ...valid, commandId: undefined },
+      { ...valid, target: null },
+      { ...valid, target: 'not-a-field-path' },
+      { ...valid, target: 'receiver.0.private.secret' },
+      { ...valid, timestampMonotonic: true },
+      { ...valid, timestampMonotonic: Number.NaN },
+      { ...valid, timestampMonotonic: Number.POSITIVE_INFINITY },
+      { ...valid, message: null },
+      { ...valid, message: 'confirmed' },
+      { ...valid, details: null },
+      { ...valid, details: { observationSeq: 9 } },
+      { ...valid, details: { revision: 5 } },
+      { ...valid, details: { revision: true, observationSeq: 9 } },
+      { ...valid, details: { revision: -1, observationSeq: 9 } },
+      { ...valid, details: { revision: 5.5, observationSeq: 9 } },
+      { ...valid, details: { revision: '5', observationSeq: 9 } },
+      { ...valid, details: { revision: Number.MAX_SAFE_INTEGER + 1, observationSeq: 9 } },
+      { ...valid, details: { revision: 5, observationSeq: true } },
+      { ...valid, details: { revision: 5, observationSeq: -1 } },
+      { ...valid, details: { revision: 5, observationSeq: 9.5 } },
+      { ...valid, details: { revision: 5, observationSeq: '9' } },
+      { ...valid, details: { revision: 5, observationSeq: Number.MAX_SAFE_INTEGER + 1 } },
+      { ...valid, details: { revision: 5, observationSeq: Number.POSITIVE_INFINITY } },
+      { ...valid, details: { revision: 5, observationSeq: 9, private: 'drop' } },
+    ];
+    for (const frame of invalid) instances[0].simulateMessage(JSON.stringify(frame));
+    instances[0].simulateMessage('{"type":"command_lifecycle","commandId":"strict","state":"reconciled","source":"websocket","target":"receiver.0.freq_mode.freq_hz","timestampMonotonic":12.5,"message":"confirmed by matching observation","details":{"revision":5,"observationSeq":9,"__proto__":{"private":true}}}');
+    const accessorDetails = {};
+    Object.defineProperties(accessorDetails, {
+      revision: { enumerable: true, get: () => { throw new Error('trap'); } },
+      observationSeq: { enumerable: true, value: 9 },
+    });
+    const parse = vi.spyOn(JSON, 'parse').mockReturnValueOnce({ ...valid, details: accessorDetails });
+    expect(() => instances[0].simulateMessage('{}')).not.toThrow();
+    parse.mockRestore();
+    expect(events).toEqual([]);
+
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'cancelled', params: {} });
+    ch.cancelNonPtt('provider session replaced');
+    instances[0].simulateMessage(JSON.stringify({ ...valid, commandId: 'cancelled' }));
+    expect(events).toEqual([]);
+
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reused', params: {} });
+    instances[0].simulateClose();
+    vi.advanceTimersByTime(1_300);
+    instances[1].simulateOpen();
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reused', params: {} });
+    instances[0].simulateMessage(JSON.stringify({ ...valid, commandId: 'reused' }));
+    instances[1].simulateMessage(JSON.stringify({ ...valid, commandId: 'reused' }));
+    expect(events).toEqual([{
+      commandId: 'reused', kind: 'reconciled', originalEpoch: 2, eventEpoch: 2,
+      revision: 5, observationSeq: 9,
+    }]);
   });
 
   it('rejects malformed, stale, cancelled, and evicted lifecycle delivery', async () => {

--- a/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
+++ b/frontend/src/lib/transport/__tests__/ws-client.isolated.test.ts
@@ -497,6 +497,79 @@ describe('WsChannel', () => {
     }]);
   });
 
+  it('isolates throwing reconciliation subscribers and consumes the correlation first', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    const frame = JSON.stringify({
+      type: 'command_lifecycle', commandId: 'robust', state: 'reconciled',
+      source: 'websocket', target: 'receiver.0.freq_mode.freq_hz',
+      timestampMonotonic: 12.5, message: 'confirmed by matching observation',
+      details: { revision: 5, observationSeq: 9 },
+    });
+    const received: CommandReconciliationDeliveryEvent[] = [];
+    const throwing = vi.fn(() => { throw new Error('faulty consumer'); });
+    ch.onCommandReconciliationDelivery(throwing);
+    ch.onCommandReconciliationDelivery((event) => received.push(event));
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'robust', params: {} });
+    expect(() => instances[0].simulateMessage(frame)).not.toThrow();
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(received).toEqual([{
+      commandId: 'robust', kind: 'reconciled', originalEpoch: 1, eventEpoch: 1,
+      revision: 5, observationSeq: 9,
+    }]);
+
+    instances[0].simulateMessage(frame);
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(received).toHaveLength(1);
+  });
+
+  it('deduplicates reentrant reconciliation delivery over a stable subscriber snapshot', async () => {
+    const { WsChannel } = await import('../ws-client');
+    const ch = new WsChannel();
+    ch.connect('ws://test');
+    instances[0].simulateOpen();
+    const frame = JSON.stringify({
+      type: 'command_lifecycle', commandId: 'reentrant', state: 'reconciled',
+      source: 'websocket', target: 'receiver.0.freq_mode.freq_hz',
+      timestampMonotonic: 12.5, message: 'confirmed by matching observation',
+      details: { revision: 5, observationSeq: 9 },
+    });
+    const first: CommandReconciliationDeliveryEvent[] = [];
+    const second: CommandReconciliationDeliveryEvent[] = [];
+    const added: CommandReconciliationDeliveryEvent[] = [];
+    let armed = true;
+    ch.onCommandReconciliationDelivery((event) => {
+      first.push(event);
+      if (armed) {
+        armed = false;
+        instances[0].simulateMessage(frame);
+        unsubscribeSecond();
+        ch.onCommandReconciliationDelivery((e) => added.push(e));
+      }
+    });
+    const unsubscribeSecond = ch.onCommandReconciliationDelivery((event) => second.push(event));
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reentrant', params: {} });
+    instances[0].simulateMessage(frame);
+
+    const delivered = {
+      commandId: 'reentrant', kind: 'reconciled', originalEpoch: 1, eventEpoch: 1,
+      revision: 5, observationSeq: 9,
+    };
+    expect(first).toEqual([delivered]);
+    expect(second).toEqual([delivered]);
+    expect(added).toEqual([]);
+
+    expect(() => { unsubscribeSecond(); unsubscribeSecond(); }).not.toThrow();
+
+    ch.send({ type: 'cmd', name: 'set_freq', id: 'reentrant', params: {} });
+    instances[0].simulateMessage(frame);
+    expect(first).toHaveLength(2);
+    expect(second).toHaveLength(1);
+    expect(added).toEqual([delivered]);
+  });
+
   it('rejects malformed, stale, cancelled, and evicted lifecycle delivery', async () => {
     const { WsChannel } = await import('../ws-client');
     const ch = new WsChannel();

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -29,12 +29,21 @@ export interface CommandLifecycleDeliveryEvent {
   expiresAt?: number;
   error?: string;
 }
+export interface CommandReconciliationDeliveryEvent {
+  commandId: string;
+  kind: 'reconciled';
+  originalEpoch: number;
+  eventEpoch: number;
+  revision: number;
+  observationSeq: number;
+}
 type MessageHandler = (msg: WsIncoming) => void;
 type BinaryHandler = (data: ArrayBuffer) => void;
 type StateHandler = (state: ConnectionState) => void;
 export type ControlSessionTransitionHandler = (transition: ControlSessionTransition) => void;
 type CommandDeliveryHandler = (event: CommandDeliveryEvent) => void;
 type CommandLifecycleDeliveryHandler = (event: CommandLifecycleDeliveryEvent) => void;
+type CommandReconciliationDeliveryHandler = (event: CommandReconciliationDeliveryEvent) => void;
 type PendingPttRelease = { command: WsCommand; originalEpoch: number };
 type TrackedPttCommand = PendingPttRelease & {
   seen: Set<CommandDeliveryKind>;
@@ -81,6 +90,24 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
     && Object.getPrototypeOf(value) === Object.prototype;
 }
 
+const FIELD_TOKEN = '[a-z0-9_]+';
+const FIELD_FAMILY = '(?:freq_mode|vfo|operator_toggles|operator_controls|meters|tx_state|slow_state|display|connection|health)';
+const LIFECYCLE_TARGET = new RegExp(
+  `^(?:receiver\\.${FIELD_TOKEN}\\.(?:(?:slot\\.[AB]|active|unselected)\\.freq_mode\\.${FIELD_TOKEN}|${FIELD_FAMILY}\\.${FIELD_TOKEN})|(?:global|connection|health)\\.${FIELD_FAMILY}\\.${FIELD_TOKEN}|scope_controls\\.(?:receiver\\.${FIELD_TOKEN}|global)\\.display\\.${FIELD_TOKEN})$`,
+);
+
+function reconciliationEvidence(value: unknown): { revision: number; observationSeq: number } | null {
+  if (!isPlainRecord(value)) return null;
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== 2 || !keys.includes('revision') || !keys.includes('observationSeq')) return null;
+  const revision = Object.getOwnPropertyDescriptor(value, 'revision');
+  const observationSeq = Object.getOwnPropertyDescriptor(value, 'observationSeq');
+  if (!revision || !('value' in revision) || !observationSeq || !('value' in observationSeq)) return null;
+  if (!Number.isSafeInteger(revision.value) || revision.value < 0) return null;
+  if (!Number.isSafeInteger(observationSeq.value) || observationSeq.value < 0) return null;
+  return { revision: revision.value as number, observationSeq: observationSeq.value as number };
+}
+
 // ─── Close observability (MOR-1424) ─────────────────────────────────────────
 //
 // The client previously discarded the WS CloseEvent entirely (onerror just
@@ -116,6 +143,7 @@ export class WsChannel {
   private trackedLifecycleCommands = new Map<string, TrackedLifecycleCommand>();
   private commandDeliveryHandlers = new Set<CommandDeliveryHandler>();
   private commandLifecycleDeliveryHandlers = new Set<CommandLifecycleDeliveryHandler>();
+  private commandReconciliationDeliveryHandlers = new Set<CommandReconciliationDeliveryHandler>();
   private messageHandlers = new Set<MessageHandler>();
   private binaryHandlers = new Set<BinaryHandler>();
   private stateHandlers = new Set<StateHandler>();
@@ -418,6 +446,11 @@ export class WsChannel {
     return () => this.commandLifecycleDeliveryHandlers.delete(handler);
   }
 
+  onCommandReconciliationDelivery(handler: CommandReconciliationDeliveryHandler): () => void {
+    this.commandReconciliationDeliveryHandlers.add(handler);
+    return () => this.commandReconciliationDeliveryHandlers.delete(handler);
+  }
+
   get sessionEpoch(): number {
     return this.transportEpoch;
   }
@@ -524,9 +557,28 @@ export class WsChannel {
     const id = raw.commandId;
     const state = raw.state;
     if (typeof id !== 'string' || id.trim().length === 0) return;
-    if (state !== 'queued' && state !== 'superseded' && state !== 'timed_out' && state !== 'failed') return;
+    if (state !== 'queued' && state !== 'superseded' && state !== 'timed_out' && state !== 'failed' && state !== 'reconciled') return;
     const tracked = this.trackedLifecycleCommands.get(id);
     if (!tracked || tracked.eventEpoch !== eventEpoch) return;
+
+    if (state === 'reconciled') {
+      if (
+        raw.source !== 'websocket'
+        || typeof raw.target !== 'string'
+        || !LIFECYCLE_TARGET.test(raw.target)
+        || typeof raw.timestampMonotonic !== 'number'
+        || !Number.isFinite(raw.timestampMonotonic)
+        || raw.message !== 'confirmed by matching observation'
+      ) return;
+      const evidence = reconciliationEvidence(raw.details);
+      if (!evidence) return;
+      this.commandReconciliationDeliveryHandlers.forEach((handler) => handler({
+        commandId: id, kind: 'reconciled', originalEpoch: tracked.originalEpoch, eventEpoch,
+        ...evidence,
+      }));
+      this.trackedLifecycleCommands.delete(id);
+      return;
+    }
 
     let kind: CommandLifecycleDeliveryKind;
     let reason: string | undefined;
@@ -949,6 +1001,10 @@ export function onCommandDelivery(handler: CommandDeliveryHandler): () => void {
 
 export function onCommandLifecycleDelivery(handler: CommandLifecycleDeliveryHandler): () => void {
   return _ctrl.onCommandLifecycleDelivery(handler);
+}
+
+export function onCommandReconciliationDelivery(handler: CommandReconciliationDeliveryHandler): () => void {
+  return _ctrl.onCommandReconciliationDelivery(handler);
 }
 
 export function onControlSessionTransition(handler: ControlSessionTransitionHandler): () => void {

--- a/frontend/src/lib/transport/ws-client.ts
+++ b/frontend/src/lib/transport/ws-client.ts
@@ -572,11 +572,21 @@ export class WsChannel {
       ) return;
       const evidence = reconciliationEvidence(raw.details);
       if (!evidence) return;
-      this.commandReconciliationDeliveryHandlers.forEach((handler) => handler({
+      // Consume the terminal correlation before dispatch: a reentrant or duplicate
+      // frame must find nothing to correlate, and one throwing subscriber must not
+      // starve the rest or keep the correlation alive.
+      this.trackedLifecycleCommands.delete(id);
+      const delivery: CommandReconciliationDeliveryEvent = {
         commandId: id, kind: 'reconciled', originalEpoch: tracked.originalEpoch, eventEpoch,
         ...evidence,
-      }));
-      this.trackedLifecycleCommands.delete(id);
+      };
+      for (const handler of [...this.commandReconciliationDeliveryHandlers]) {
+        try {
+          handler(delivery);
+        } catch (error) {
+          console.error('[ws] reconciliation subscriber failed', error);
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- add a reconciliation-only transport delivery bus for strictly authorized `command_lifecycle.state == "reconciled"` events
- emit only the command ID, internal socket epochs, revision, and observation sequence
- preserve ordinary response/ACK handling and existing held/terminal lifecycle projection with zero radio-store mutation

Linear: [MOR-1781](https://linear.app/morozsm/issue/MOR-1781/mor-1500-b1-d3b-decode-reconciled-evidence-at-the-frontend-transport)

## Scope
- exact 2 files
- 167 changed LOC (+165/-2)
- base `4deb5ffc7977251fe1df66349348ee5bd77aa122`

## Red / green
- RED: 70 passed, 2 failed because the old decoder emitted no reconciliation delivery
- GREEN: focused 72 passed

## Verification
- frontend check: 0 errors / 0 warnings
- frontend tests: 366 files / 8054 tests passed
- full ESLint, boundary lint, and i18n checks: passed
- production build: passed
- diff/privacy review: clean

## Safety
No store projection, radio-state mutation, backend/runtime/radio/serial/hardware/PTT/TUNE/TX/keying changes. The builder will not self-PASS or merge.