### PR TITLE
fix(MOR-1782): resolve native opus library on Homebrew prefixes

### DIFF
--- a/src/rigplane/audio/_transcoder.py
+++ b/src/rigplane/audio/_transcoder.py
@@ -7,6 +7,10 @@ Opus APIs.
 
 from __future__ import annotations
 
+import contextlib
+import ctypes.util
+import os
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -63,9 +67,57 @@ class _OpuslibBackend:
         return out
 
 
+# Known package-manager prefixes for libopus that the platform library
+# search does not consult (MOR-1782): Homebrew on Apple Silicon
+# (``/opt/homebrew``) and Intel Homebrew / manual installs (``/usr/local``).
+# Kept explicit on purpose -- no filesystem walking.
+_OPUS_LIBRARY_FALLBACK_PATHS: tuple[str, ...] = (
+    "/opt/homebrew/lib/libopus.dylib",
+    "/usr/local/lib/libopus.dylib",
+    "/usr/local/lib/libopus.so",
+)
+
+
+def _find_opus_library_fallback() -> str | None:
+    """Return the first libopus fallback candidate that exists, or ``None``."""
+    for candidate in _OPUS_LIBRARY_FALLBACK_PATHS:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+@contextlib.contextmanager
+def _opus_library_lookup() -> Iterator[None]:
+    """Let ``import opuslib`` find libopus in known package-manager prefixes.
+
+    opuslib locates the native library with ``ctypes.util.find_library("opus")``
+    at import time. On macOS the dyld fallback search does not cover the
+    Homebrew Apple Silicon prefix ``/opt/homebrew/lib``, and CPython's
+    ``find_library`` ignores already-loaded dyld images, so preloading via
+    ``ctypes.CDLL`` cannot make the lookup succeed (MOR-1782). Wrap
+    ``find_library`` for the duration of the import instead: the platform
+    lookup runs first, and only a failed ``opus`` lookup falls back to the
+    explicit prefix list.
+    """
+    real_find_library = ctypes.util.find_library
+
+    def _find_library(name: str) -> str | None:
+        location = real_find_library(name)
+        if location is None and name == "opus":
+            return _find_opus_library_fallback()
+        return location
+
+    ctypes.util.find_library = _find_library
+    try:
+        yield
+    finally:
+        ctypes.util.find_library = real_find_library
+
+
 def _load_default_backend() -> _OpusBackend | None:
     try:
-        import opuslib  # noqa: F401
+        with _opus_library_lookup():
+            import opuslib  # noqa: F401
     except Exception:
         # opuslib raises bare ``Exception`` (not ImportError) when the native
         # libopus cannot be located — catch both cases so the backend falls

--- a/tests/test_audio_transcoder_coverage.py
+++ b/tests/test_audio_transcoder_coverage.py
@@ -13,7 +13,11 @@ Covers:
 
 from __future__ import annotations
 
+import ctypes.util
+import importlib.abc
+import importlib.machinery
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -159,6 +163,126 @@ class TestLoadDefaultBackend:
         with patch.dict(sys.modules, {"opuslib": None}):
             result = _load_default_backend()
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Native Opus library discovery (MOR-1782)
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpuslibFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Meta-path finder that simulates opuslib's import-time native lookup.
+
+    Mirrors the real ``opuslib`` package: at import time it calls
+    ``ctypes.util.find_library('opus')`` and raises a bare ``Exception``
+    when the lookup returns ``None``. This keeps the discovery tests
+    deterministic on any host, with or without a real libopus installed.
+    """
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: object = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname != "opuslib":
+            return None
+        return importlib.machinery.ModuleSpec(fullname, self)
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> None:
+        return None  # default module creation semantics
+
+    def exec_module(self, module: object) -> None:
+        from ctypes.util import find_library
+
+        lib_location = find_library("opus")
+        if lib_location is None:
+            raise Exception("Could not find Opus library. Make sure it is installed.")
+        module.lib_location = lib_location  # type: ignore[attr-defined]
+
+
+def _install_fake_opuslib(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route ``import opuslib`` to the fake finder for the test duration."""
+    monkeypatch.delitem(sys.modules, "opuslib", raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_FakeOpuslibFinder(), *sys.meta_path])
+
+
+class TestOpusLibraryDiscovery:
+    """Pin MOR-1782: libopus living in a package-manager prefix that the
+    platform lookup does not consult must still yield a working backend."""
+
+    def test_uses_platform_lookup_when_library_already_discoverable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Normal path is not regressed: fallback prefixes are not consulted
+        when the platform lookup already finds the library."""
+        _install_fake_opuslib(monkeypatch)
+        monkeypatch.setattr(
+            ctypes.util, "find_library", lambda name: "/usr/lib/libopus.dylib"
+        )
+        fallback = tmp_path / "libopus.dylib"
+        fallback.write_bytes(b"")
+        monkeypatch.setattr(
+            "rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS",
+            (str(fallback),),
+        )
+
+        backend = _load_default_backend()
+
+        assert isinstance(backend, _OpuslibBackend)
+        assert backend._opuslib.lib_location == "/usr/lib/libopus.dylib"
+
+    def test_discovers_library_in_fallback_prefix_when_platform_lookup_fails(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Apple Silicon Homebrew case: find_library('opus') returns None, but
+        libopus exists in a known prefix, so the backend must still load."""
+        _install_fake_opuslib(monkeypatch)
+        monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+        fallback = tmp_path / "libopus.dylib"
+        fallback.write_bytes(b"")
+        monkeypatch.setattr(
+            "rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS",
+            (str(fallback),),
+        )
+
+        backend = _load_default_backend()
+
+        assert isinstance(backend, _OpuslibBackend)
+        assert backend._opuslib.lib_location == str(fallback)
+
+    def test_returns_none_when_library_absent_everywhere(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Fail-closed: no platform hit and no fallback file still yields
+        None, with no exception escaping the factory."""
+        _install_fake_opuslib(monkeypatch)
+        monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+        monkeypatch.setattr(
+            "rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS",
+            (str(tmp_path / "libopus.dylib"),),
+        )
+
+        assert _load_default_backend() is None
+
+    def test_find_library_restored_after_failed_import(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The find_library wrapper is removed again even when the import
+        fails, leaving no global state behind."""
+        _install_fake_opuslib(monkeypatch)
+
+        def patched_find_library(name: str) -> None:
+            return None
+
+        monkeypatch.setattr(ctypes.util, "find_library", patched_find_library)
+        monkeypatch.setattr(
+            "rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS",
+            (str(tmp_path / "libopus.dylib"),),
+        )
+
+        assert _load_default_backend() is None
+        assert ctypes.util.find_library is patched_find_library
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was broken

On macOS on Apple Silicon, browser voice transmit keyed the radio but produced no modulation. Every browser Opus TX frame was silently dropped because the PCM<->Opus transcoder was never constructed.

## Root cause

`opuslib` locates the native library at import time via `ctypes.util.find_library("opus")`. On macOS that lookup consults only the `DYLD_*` environment overrides, `~/lib`, `/usr/local/lib`, `/lib`, `/usr/lib`, and the dyld shared cache. Homebrew on Apple Silicon installs libopus into `/opt/homebrew/lib`, which is not in that list, so `find_library` returns `None`, `import opuslib` raises a bare `Exception`, `_load_default_backend()` degrades to `None`, and the factory raises `AudioCodecBackendError` — the audio layer fails closed, exactly as designed, but for a library that is in fact installed.

Reproduced on macOS on Apple Silicon with libopus installed via Homebrew:

- `find_library("opus")` returns `None`
- `import opuslib` raises `Exception: Could not find Opus library`
- `create_pcm_opus_transcoder(sample_rate=48000)` raises `AudioCodecBackendError`

## Why not preload with ctypes.CDLL

The obvious alternative — `ctypes.CDLL("<prefix>/libopus.dylib")` before importing opuslib, so that its own lookup then succeeds — does not work. CPython's macOS `find_library` (`Lib/ctypes/util.py` delegating to `ctypes/macholib/dyld.py`, `dyld_find`) searches only the env overrides, the fallback directory list above, and the dyld shared cache; it never enumerates already-loaded dyld images. Preloading therefore leaves `find_library("opus")` returning `None` and opuslib still fails to import. Verified against the CPython 3.11 standard library sources.

## What changed

`src/rigplane/audio/_transcoder.py` (+54/-1), exactly at the ticket's seam:

- `_OPUS_LIBRARY_FALLBACK_PATHS`: a closed, explicit list of package-manager prefixes the platform lookup misses — Homebrew Apple Silicon (`/opt/homebrew/lib/libopus.dylib`) and Intel Homebrew / manual installs (`/usr/local/lib/libopus.dylib`, `/usr/local/lib/libopus.so`). No filesystem walking, no environment mutation, no new dependencies.
- `_opus_library_lookup()`: a context manager that wraps `ctypes.util.find_library` for the duration of `import opuslib`. The real lookup runs first; only a failed `opus` query falls back to the prefix list via an `os.path.isfile` check. This works because opuslib binds `from ctypes.util import find_library` at its own import time, i.e. while the wrapper is installed.
- The fail-closed contract is unchanged: if libopus exists nowhere, the import raises, `_load_default_backend()` returns `None`, and frames are dropped rather than reported as delivered.

Thread-safety note, stated honestly: the wrapper temporarily replaces the stdlib-global `ctypes.util.find_library` and restores it in a `finally` block, so restoration is exception-safe in both outcomes. During the microseconds-wide window, a concurrent `find_library` call from another thread would observe the wrapper; that is strictly additive behavior for the single name `"opus"` (every other name delegates verbatim to the real function), and it runs while Python's import machinery is already in flight. No global state survives, on success or on failure.

## Tests

New `TestOpusLibraryDiscovery` in `tests/test_audio_transcoder_coverage.py`. Host-independent by construction: a meta-path finder simulates opuslib's import-time `find_library("opus")` lookup, so the tests pass on machines with or without libopus, including CI containers.

- platform lookup wins when libopus is already discoverable (fallback not consulted) — the normal path is not regressed
- fallback prefix resolves when the platform lookup returns `None` — the Homebrew case
- fail-closed: library absent everywhere still yields `None`, no exception escapes the factory
- `find_library` is restored to its pre-call state even after a failed import

Written failing-first: all four fail on the unfixed code.

Verification on macOS on Apple Silicon with Homebrew libopus 1.6.1 present and no `DYLD_*` set:

- before: `find_library("opus")` returns `None`; the factory raises `AudioCodecBackendError`
- after: `create_pcm_opus_transcoder(sample_rate=48000)` returns a `PcmOpusTranscoder`; a full PCM -> Opus -> PCM roundtrip (960 samples -> 3-byte Opus frame -> 1920-byte PCM frame) succeeds

Gate runs on this branch:

- `pytest tests/test_audio_transcoder.py tests/test_audio_transcoder_coverage.py -q --tb=short` — 59 passed
- `ruff check src/ tests/` — `All checks passed!`
- `ruff format --check src/ tests/` — `675 files already formatted`
- `mypy src/` — 12 errors in 3 files, byte-identical to unmodified main (verified via stash); no new errors
- `lint-imports` — `Contracts: 5 kept, 0 broken`
- `pytest tests/ -q --tb=short` — 3 failed, 10375 passed

## Correction to an earlier interim report

An earlier interim report claimed 5 failing local tests were all pre-existing environment failures. That was wrong in substance for two of them, and this PR body corrects it:

- The two `tests/architecture/test_ui_radio_control_contract.py` failures were caused by the local machine lacking frontend dependencies — those tests shell out to `npx vitest` and `npm run lint`. CI's quick leg does cover them and was green on the base commit. After installing frontend dependencies exactly as CI does (`npm ci` in `frontend/`), all 11 architecture tests pass locally.
- A third failure (`tests/test_state_type_codegen.py`) appeared only while the frontend tree had been provisioned with the wrong package manager (pnpm instead of the CI-blessed `npm ci`); its skip guard keys on the presence of the json2ts binary. Under `npm ci` the codegen gate passes. It never failed on main and is unrelated to this change.

The remaining 3 failures are all in `tests/integration/` — excluded from the quick CI leg (`--ignore=tests/integration`) and identical on unmodified main in this environment (rigctld golden-replay assertion mismatches, e.g. `RPRT -9` vs `RPRT 0`):

- `tests/integration/test_rigctld_audio_pipeline.py::test_rigctld_wsjtx_replay_drives_data2_lan_tx_audio_pipeline`
- `tests/integration/test_rigctld_golden_replay.py::TestGoldenReplayDualRx::test_fldigi_dual_rx_golden_replay`
- `tests/integration/test_rigctld_wsjtx.py::TestWsjtxSplitOnIc7610::test_split_enable_routes_tx_to_sub_receiver`

## Out of scope, deliberately

`src/rigplane/audio/bridge.py` (the local loopback decode path) imports `opuslib` directly and hits the same discovery defect on affected machines. The ticket scoped the fix to the transcoder factory seam, so bridge.py is untouched. It is a follow-up candidate.
