### PR TITLE
fix(MOR-1786): share opus library discovery with the audio bridge

### DIFF
--- a/src/rigplane/audio/bridge.py
+++ b/src/rigplane/audio/bridge.py
@@ -44,6 +44,7 @@ from rigplane.core.types import _AUDIO_CODEC_CHANNELS
 
 from ._bridge_metrics import BridgeMetrics
 from ._bridge_state import BridgeState, BridgeStateChange
+from ._transcoder import _opus_library_lookup
 from .backend import (
     AudioBackend,
     AudioDeviceInfo,
@@ -512,8 +513,12 @@ class AudioBridge:
         )
 
         if self._is_opus:
-            _require_opuslib()
-            import opuslib
+            # Share the MOR-1782 discovery window: the platform
+            # ``find_library("opus")`` does not see Homebrew prefixes on
+            # macOS, so let the same fallback list resolve the import.
+            with _opus_library_lookup():
+                _require_opuslib()
+                import opuslib
 
             self._decoder = opuslib.Decoder(self._sample_rate, self._channels)
         else:

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import ctypes.util
+import importlib.abc
+import importlib.machinery
+import sys
 import types
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -532,6 +537,121 @@ async def test_bridge_rx_via_bus():
     assert bridge._rx_sub._inner._received == 2
 
     await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Opus RX decoder — native library discovery (MOR-1786)
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpuslibFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Meta-path finder that simulates opuslib's import-time native lookup.
+
+    Mirrors the real ``opuslib`` package: at import time it calls
+    ``ctypes.util.find_library("opus")`` and raises a bare ``Exception``
+    when the lookup returns ``None``. Keeps these tests deterministic on any
+    host — with or without libopus installed, including CI containers.
+    """
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: object = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname != "opuslib":
+            return None
+        return importlib.machinery.ModuleSpec(fullname, self)
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> None:
+        return None  # default module creation semantics
+
+    def exec_module(self, module: types.ModuleType) -> None:
+        from ctypes.util import find_library
+
+        lib_location = find_library("opus")
+        if lib_location is None:
+            raise Exception("Could not find Opus library. Make sure it is installed.")
+        module.lib_location = lib_location
+
+        class Decoder:
+            """Minimal stand-in for ``opuslib.Decoder``."""
+
+            def __init__(self, sample_rate: int, channels: int) -> None:
+                self.sample_rate = sample_rate
+                self.channels = channels
+
+        module.Decoder = Decoder
+
+
+def _install_fake_opuslib(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route ``import opuslib`` to the fake finder for the test duration."""
+    monkeypatch.delitem(sys.modules, "opuslib", raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_FakeOpuslibFinder(), *sys.meta_path])
+
+
+async def test_bridge_opus_decoder_found_via_fallback_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """MOR-1786: the platform lookup finds no libopus (``find_library``
+    returns ``None``) but the library exists in a known package-manager
+    prefix — the bridge RX decoder must still be created, exactly like the
+    transcoder-side fix (MOR-1782)."""
+    from rigplane.types import AudioCodec
+
+    _install_fake_opuslib(monkeypatch)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+    fallback = tmp_path / "libopus.dylib"
+    fallback.write_bytes(b"")
+    monkeypatch.setattr(
+        "rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS",
+        (str(fallback),),
+    )
+
+    radio = _make_radio()
+    radio.audio_codec = AudioCodec.OPUS_1CH
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=False, backend=_bridge_backend()
+    )
+
+    await bridge.start()
+    try:
+        assert bridge._decoder is not None
+        assert bridge._decoder.sample_rate == SAMPLE_RATE
+        assert bridge._decoder.channels == CHANNELS
+        assert sys.modules["opuslib"].lib_location == str(fallback)
+    finally:
+        await bridge.stop()
+
+
+async def test_bridge_opus_decoder_absent_everywhere_stays_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """MOR-1786: with libopus absent from the platform lookup AND every
+    fallback prefix, the bridge degrades exactly as it does today — the
+    opuslib error propagates out of ``start()`` after teardown, no decoder
+    is created, and no radio RX demand is left armed."""
+    from rigplane.types import AudioCodec
+
+    _install_fake_opuslib(monkeypatch)
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+    monkeypatch.setattr(
+        "rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS",
+        (str(tmp_path / "libopus.dylib"),),  # deliberately absent
+    )
+
+    radio = _make_radio()
+    radio.audio_codec = AudioCodec.OPUS_1CH
+    bridge = AudioBridge(
+        radio, device_name="BlackHole", tx_enabled=False, backend=_bridge_backend()
+    )
+
+    with pytest.raises(Exception, match="Could not find Opus library"):
+        await bridge.start()
+
+    assert bridge._decoder is None
+    assert bridge.bridge_state == BridgeState.IDLE
+    radio.start_audio_rx_opus.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Defect and user-visible effect

MOR-1782 (PR #2737) fixed native libopus discovery for the Opus transcoder on macOS on Apple Silicon: `opuslib` resolves the native library through `ctypes.util.find_library("opus")`, which never searches the Homebrew ARM prefix `/opt/homebrew/lib`, so the import fails even when the library is installed via `brew install opus`.

`AudioBridge` (`src/rigplane/audio/bridge.py`) imports `opuslib` directly for its RX decoder and bypassed that fixed seam. The result on affected machines was a split failure: browser/loopback TX worked while the bridge RX decode path still failed to start. TX-works-RX-dead is a worse diagnostic state than a uniform failure — it looks like a radio or device problem and sends operators hunting in the wrong place.

## Design choice

The candidate path list must exist in exactly one place. Two shapes were on the table:

- (a) export `_opus_library_lookup()` from `audio/_transcoder.py` and import it in `bridge.py`
- (b) extract the helper into a new `audio/_opus_lookup.py` and have both call sites use it

I chose **(a)**, for one decisive reason plus two supporting ones:

1. The MOR-1782 discovery tests single-source their monkeypatching at `rigplane.audio._transcoder._OPUS_LIBRARY_FALLBACK_PATHS`. Moving the list to a new module (shape b) would silently orphan that monkeypatch — the tests would pass vacuously or fail, and editing them was explicitly out of bounds for this ticket. Keeping the constant where it is keeps the MOR-1782 pins green, byte-for-byte.
2. Minimal diff: no new module, no re-exports, no movement of code the previous review already accepted.
3. Same-layer sibling imports are the established pattern in `bridge.py` (it already imports `.session`, `.backend`, `._bridge_metrics`, `._bridge_state`); `_transcoder` is the module that owns opuslib interop in this layer. `lint-imports` confirms no contract breakage (5 kept, 0 broken).

## What changed

- `src/rigplane/audio/bridge.py` (+7/-2): the RX decoder setup now runs `_require_opuslib()` + `import opuslib` inside the shared `_opus_library_lookup()` window, imported from `._transcoder`. The window wraps `ctypes.util.find_library` for the duration of the import (real lookup first; only a failed `opus` query falls back to the closed explicit prefix list — `/opt/homebrew/lib/libopus.dylib`, `/usr/local/lib/libopus.dylib`, `/usr/local/lib/libopus.so` — checked via `os.path.isfile`), restoring the original in a `finally`. The decoder construction itself stays outside the window, unchanged. No filesystem walking, no environment mutation, no new dependencies.
- `tests/test_audio_bridge.py` (+120/-0): two host-independent tests.

## Fail-closed: unchanged

With libopus absent from both the platform lookup and every fallback prefix, the bridge degrades exactly as before this change: the opuslib error propagates out of `_setup_streams`, `start()` tears down and re-raises, `bridge._decoder` stays `None`, state returns to IDLE, and no radio RX demand is left armed — no frame is ever reported as decoded when it was not. This is pinned by a new test. The MOR-1782 transcoder-side tests are untouched and all pass.

## Test evidence

New tests (written failing-first; the discovery test fails on the unfixed bridge with `Exception: Could not find Opus library. Make sure it is installed.` out of `start()`):

- `test_bridge_opus_decoder_found_via_fallback_prefix` — platform lookup returns `None` (monkeypatched), a fake `libopus.dylib` exists in a tmp prefix (monkeypatched candidate list), import is routed through a meta-path finder that faithfully simulates opuslib's import-time `find_library("opus")` call: `bridge.start()` succeeds, the decoder is built with the bridge's sample rate/channels, and the recorded `lib_location` is the fallback path. Host-independent: passes with or without libopus installed, including CI containers.
- `test_bridge_opus_decoder_absent_everywhere_stays_fail_closed` — no platform hit, no fallback file: `start()` raises the opuslib error, `_decoder` is `None`, state IDLE, `start_audio_rx_opus` never awaited.

Real numbers on this branch:

- `pytest tests/test_audio_bridge.py tests/test_audio_transcoder.py tests/test_audio_transcoder_coverage.py -q --tb=short` — 122 passed
- `pytest tests/ -q --tb=short` — 3 failed, 10377 passed (410s). The 3 failures are in `tests/integration/test_rigctld_audio_pipeline.py`, `tests/integration/test_rigctld_golden_replay.py`, `tests/integration/test_rigctld_wsjtx.py` (rigctld replay assertion mismatches, e.g. expected `RPRT 0` vs actual `RPRT -9`). Pre-existing evidence from an independent source, not `git stash`: a clean `git worktree` checkout of the exact base commit c4da8492 fails identically on the same 3 tests (3 failed in 0.39s). They are also excluded from quick CI (`--ignore=tests/integration`).
- `ruff check src/ tests/` — `All checks passed!`
- `ruff format --check src/ tests/` — `675 files already formatted`
- `mypy src/` — 12 errors in 3 files; identical to the known baseline at the base commit (none in files touched here)
- `lint-imports` — `Contracts: 5 kept, 0 broken`

Real-hardware confirmation on macOS on Apple Silicon with Homebrew libopus present and no `DYLD_*` set: raw `ctypes.util.find_library("opus")` returns `None`, while the same import inside `_opus_library_lookup()` succeeds and `opuslib.Decoder(48000, 1)` constructs.

One environment note for the record: a first full-suite attempt on this branch completed its test summary and then hung once at process exit; the deterministic re-run used for the numbers above exited normally (410s). No tests hung; the summary was identical in both runs.
