### PR TITLE
fix(MOR-1788): rate-limit repeated per-frame TX audio warnings

### DIFF
--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -1314,6 +1314,9 @@ class AudioHandler:
         # path) or when TX is not active.
         self._tx_lease: TxLease | None = None
         self._tx_facts: BrowserTxAudioFacts | None = None
+        # Per-key counters for once-per-frame TX warnings (MOR-1788), applied
+        # by ``_warn_tx_throttled``; cleared at every TX session start.
+        self._tx_warn_counts: dict[str, int] = {}
         self._tx_stop_lock = asyncio.Lock()
         self._seq: int = 0
         # Latest client-reported link-quality snapshot from the periodic
@@ -1482,6 +1485,9 @@ class AudioHandler:
                     raise
                 self._tx_facts = facts
                 self._tx_active = True
+                # New TX session: clear the MOR-1788 warning counters so a
+                # recurrence is never hidden by an earlier session's backlog.
+                self._tx_warn_counts.clear()
                 logger.info("audio: TX active")
         elif msg_type == "audio_stop":
             if direction == "rx":
@@ -1850,6 +1856,33 @@ class AudioHandler:
         await self._broadcaster.unsubscribe(self._frame_queue)
         logger.info("audio: unsubscribed from RX broadcast")
 
+    def _warn_tx_throttled(
+        self, key: str, message: str, *args: Any, exc_info: bool = False
+    ) -> None:
+        """Log a once-per-frame TX warning with repeat throttling (MOR-1788).
+
+        TX warnings fire once per inbound frame (~50/s) and would otherwise
+        bury the single diagnostic line that explains the cause.  Same policy
+        as the UDP error site in ``rigplane.core.transport``: the first three
+        occurrences are logged in full, then every hundredth is logged along
+        with the number of occurrences suppressed since the last emitted
+        line, so no information is lost.  Counters are kept per site key in
+        ``self._tx_warn_counts`` and cleared at TX session start.
+        """
+        n = self._tx_warn_counts.get(key, 0) + 1
+        self._tx_warn_counts[key] = n
+        if n <= 3:
+            logger.warning(message + " (#%d)", *args, n, exc_info=exc_info)
+        elif n % 100 == 0:
+            prev_logged = 3 if n == 100 else n - 100
+            logger.warning(
+                message + " (#%d, suppressed %d)",
+                *args,
+                n,
+                n - prev_logged - 1,
+                exc_info=exc_info,
+            )
+
     async def _handle_tx_audio(self, payload: bytes) -> None:
         """Forward TX audio from browser to radio."""
         if not self._tx_active:
@@ -1859,23 +1892,31 @@ class AudioHandler:
             return
         facts = self._tx_facts
         if facts is None and not self._radio:
-            logger.warning("audio: TX frame ignored (no radio), size=%d", len(payload))
+            self._warn_tx_throttled(
+                "no_radio", "audio: TX frame ignored (no radio), size=%d", len(payload)
+            )
             return
         if facts is None and CAP_AUDIO not in self._radio.capabilities:  # type: ignore[union-attr]
-            logger.warning(
+            self._warn_tx_throttled(
+                "no_capability",
                 "audio: TX frame ignored (radio missing audio capability), size=%d",
                 len(payload),
             )
             return
         if len(payload) < AUDIO_HEADER_SIZE:
-            logger.warning(
+            self._warn_tx_throttled(
+                "frame_too_small",
                 "audio: TX frame too small (%d < %d), ignoring",
                 len(payload),
                 AUDIO_HEADER_SIZE,
             )
             return
         if payload[0] != MSG_TYPE_AUDIO_TX:
-            logger.warning("audio: TX frame wrong type 0x%02x, ignoring", payload[0])
+            self._warn_tx_throttled(
+                "wrong_type",
+                "audio: TX frame wrong type 0x%02x, ignoring",
+                payload[0],
+            )
             return
         browser_codec = payload[1]
         audio_data = payload[AUDIO_HEADER_SIZE:]
@@ -1893,7 +1934,8 @@ class AudioHandler:
                     and tx_codec == AudioCodec.PCM_1CH_16BIT
                 ):
                     if self._transcoder is None:
-                        logger.warning(
+                        self._warn_tx_throttled(
+                            "dropped_no_transcoder",
                             "audio: TX frame dropped incoming_codec=opus "
                             "radio_tx_codec=%s sample_rate=%d "
                             "action=dropped_no_transcoder",
@@ -1907,7 +1949,8 @@ class AudioHandler:
                         await self._push_tx(pcm_data, legacy_method="push_audio_tx_pcm")
                         tx_data_desc = f"{len(pcm_data)} bytes pcm"
                     except Exception as e:
-                        logger.warning(
+                        self._warn_tx_throttled(
+                            "dropped_transcode_failed",
                             "audio: TX frame dropped incoming_codec=opus "
                             "radio_tx_codec=%s sample_rate=%d "
                             "action=dropped_transcode_failed error=%s",
@@ -1921,7 +1964,8 @@ class AudioHandler:
                     await self._push_tx(audio_data, legacy_method="push_audio_tx_opus")
                     tx_data_desc = f"{len(audio_data)} bytes opus"
                 else:
-                    logger.warning(
+                    self._warn_tx_throttled(
+                        "unsupported_codec",
                         "audio: unsupported browser TX codec 0x%02x, dropping frame",
                         browser_codec,
                     )
@@ -1938,7 +1982,9 @@ class AudioHandler:
                         tx_data_desc,
                     )
             except Exception:
-                logger.warning("audio: push TX error", exc_info=True)
+                self._warn_tx_throttled(
+                    "push_tx_error", "audio: push TX error", exc_info=True
+                )
 
     async def _sender_loop(self) -> None:
         """Send queued audio frames to the WebSocket client."""

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1968,6 +1968,83 @@ async def test_audio_handler_pushes_pcm_browser_tx_directly() -> None:
     radio._push_audio_tx_opus.assert_not_awaited()
 
 
+def _tx_frame_warning_messages(
+    caplog: pytest.LogCaptureFixture, action: str
+) -> list[str]:
+    return [
+        record.message
+        for record in caplog.records
+        if record.levelname == "WARNING" and action in record.message
+    ]
+
+
+async def test_tx_frame_warnings_throttled_not_logged_once_per_frame(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-1788: a stuck per-frame failure must not log once per frame.
+
+    Policy (same as the UDP error throttle in ``core.transport``): the first
+    three occurrences log in full, then every hundredth carries the count of
+    suppressed occurrences.  Frames are still dropped — behavior unchanged.
+    """
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _make_web_tx_radio(contract)
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    handler._tx_active = True  # _transcoder stays None → no-transcoder drop path
+
+    with caplog.at_level("WARNING", logger="rigplane.web.handlers.audio"):
+        for _ in range(250):
+            await handler._handle_tx_audio(
+                _make_web_tx_audio_frame(AUDIO_CODEC_OPUS, b"opus-frame")
+            )
+
+    messages = _tx_frame_warning_messages(caplog, "action=dropped_no_transcoder")
+    assert len(messages) == 5  # first 3 in full, then #100 and #200
+    assert "(#1)" in messages[0]
+    assert "(#3)" in messages[2]
+    assert "(#100, suppressed 96)" in messages[3]
+    assert "(#200, suppressed 99)" in messages[4]
+    radio._push_audio_tx_pcm.assert_not_awaited()
+    radio._push_audio_tx_opus.assert_not_awaited()
+
+
+async def test_tx_frame_warning_counters_reset_between_tx_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-1788: counters are per TX session — a recurrence in a later
+    session is never hidden behind a suppressed count from an earlier one."""
+    contract = _make_web_tx_contract(AudioCodec.PCM_1CH_16BIT)
+    radio = _make_web_tx_radio(contract)
+    ws = SimpleNamespace(recv=AsyncMock(), send_binary=AsyncMock())
+    handler = AudioHandler(ws, radio, None)
+    # Host-independent: the transcoder factory fails regardless of whether
+    # libopus exists on the machine, leaving the no-transcoder guard active.
+    monkeypatch.setattr(
+        audio_module,
+        "create_pcm_opus_transcoder",
+        MagicMock(side_effect=RuntimeError("factory failed")),
+    )
+
+    frame = _make_web_tx_audio_frame(AUDIO_CODEC_OPUS, b"opus-frame")
+    with caplog.at_level("WARNING", logger="rigplane.web.handlers.audio"):
+        await handler._handle_control({"type": "audio_start", "direction": "tx"})
+        for _ in range(4):
+            await handler._handle_tx_audio(frame)
+        await handler._handle_control({"type": "audio_stop", "direction": "tx"})
+
+        await handler._handle_control({"type": "audio_start", "direction": "tx"})
+        await handler._handle_tx_audio(frame)
+
+    messages = _tx_frame_warning_messages(caplog, "action=dropped_no_transcoder")
+    # Session 1: #1..#3 in full (4th suppressed); session 2 restarts at #1.
+    assert len(messages) == 4
+    for index, message in enumerate(messages[:3]):
+        assert f"(#{index + 1})" in message
+    assert "(#1)" in messages[-1]
+
+
 class _NeutralWebTxRadio(_WebTxRadio):
     def __init__(self, contract: AudioStreamContract) -> None:
         super().__init__(


### PR DESCRIPTION
## Problem

Several warnings in the browser TX audio path fire once per inbound audio frame, roughly fifty per second. When such a condition holds, the log fills with identical lines and buries the single line that explains the cause.

Real incident (2026-08-16): a missing native Opus decoder logged one explanatory line naming the cause and a working alternative, followed by 151 identical `action=dropped_no_transcoder` warnings in about a second. Reading the log tail showed only the repeated symptom, and the first diagnosis wrongly concluded the explanatory diagnostic had never fired. It had — it was simply out of view.

## Which sites changed

The ticket listed four known candidates and asked for verification against the current code. Verified in `src/rigplane/web/handlers/audio.py`, `_handle_tx_audio()` — every `logger.warning` reachable once per inbound frame is throttled. The verified list is eight sites, not four:

- `audio: TX frame ignored (no radio), size=%d`
- `audio: TX frame ignored (radio missing audio capability), size=%d` (not in the ticket list)
- `audio: TX frame too small (%d < %d), ignoring` (not in the ticket list)
- `audio: TX frame wrong type 0x%02x, ignoring`
- `audio: TX frame dropped ... action=dropped_no_transcoder` (the incident line)
- `audio: TX frame dropped ... action=dropped_transcode_failed` (not in the ticket list)
- `audio: unsupported browser TX codec 0x%02x, dropping frame` (not in the ticket list)
- `audio: push TX error` (keeps `exc_info=True` on emitted lines)

A per-frame debug-level line (`tx_active=False`) is deliberately untouched.

## How: the transport.py policy, implemented once

`src/rigplane/core/transport.py` defines the policy inline at its single UDP error site: first three occurrences in full, then every hundredth carrying a suppressed count. That file is untouched — different layer, correct as-is.

This handler has eight such sites, so the policy is implemented exactly once, as a small private method `_warn_tx_throttled(key, message, *args, exc_info=False)` on `AudioHandler`. Per-site counters live in one dict (`self._tx_warn_counts`, per handler instance) and are cleared at TX session start (`audio_start direction=tx`, right where `_tx_active` becomes `True`), so a later session starts clean and a recurrence is never hidden by an earlier session's backlog. Each call site is now a one-line call. One deliberate refinement over the transport inline version: the suppressed count is computed exactly (occurrences not logged since the last emitted line — 96 at the first hundredth, 99 at subsequent ones) rather than the hardcoded "97", which becomes inaccurate there from the second hundredth on.

## Behavior unchanged

Logging-only change. No control flow moved: every early `return` is byte-identical in position, frames dropped today are still dropped, fail-closed semantics are unchanged, and nothing is ever reported as delivered that was not. Log levels, message wording, and the structured key=value style are preserved; the only addition is the `(#N)` / `(#N, suppressed M)` suffix on emitted lines. No information is lost: the first three occurrences always log in full and the suppressed count surfaces in each later sampled line. Message-suffix compatibility was checked against the existing tests that assert on `action=dropped_no_transcoder` message content — all green.

## Test evidence

New tests in `tests/test_handlers_coverage.py`, written failing-first (both fail on the unfixed handler: 250 emitted warnings instead of 5; no reset), using `caplog`:

- `test_tx_frame_warnings_throttled_not_logged_once_per_frame` — 250 frames through the `dropped_no_transcoder` path emit exactly 5 warnings: `(#1)`, full through `(#3)`, then `(#100, suppressed 96)` and `(#200, suppressed 99)`; frames are still dropped (radio push mocks never awaited).
- `test_tx_frame_warning_counters_reset_between_tx_sessions` — 4 frames in session 1 (3 in full, 4th suppressed), stop, start again, 1 frame: emitted message is `(#1)` again. The transcoder factory is monkeypatched to fail, so the test is identical on machines with and without libopus (CI containers included).

Real numbers for this branch:

- `pytest tests/test_handlers_coverage.py tests/test_web_audio_tx_session.py -q --tb=short` — 182 passed
- `pytest tests/ -q --tb=short` — 3 failed, 10379 passed (412s). The 3 failures are in `tests/integration/test_rigctld_audio_pipeline.py`, `tests/integration/test_rigctld_golden_replay.py`, `tests/integration/test_rigctld_wsjtx.py` — pre-existing, verified against an independent source (not `git stash`): a clean `git worktree` at the exact base commit fdf50996 fails identically (3 failed, 11 passed on those files). They are excluded from quick CI (`--ignore=tests/integration`).
- `ruff check src/ tests/` — `All checks passed!`
- `ruff format --check src/ tests/` — `675 files already formatted`
- `mypy src/` — 12 errors in 3 files; the clean-worktree run at the base commit reports the identical 12/3 (none in the files touched here, including the strict-mypy web layer)
- `lint-imports` — `Contracts: 5 kept, 0 broken`
