### PR TITLE
fix(MOR-1789): report the exact suppressed UDP error count

### DIFF
--- a/src/rigplane/core/transport.py
+++ b/src/rigplane/core/transport.py
@@ -82,8 +82,16 @@ class _UdpProtocol(asyncio.DatagramProtocol):
         if n <= 3:
             logger.warning("UDP error [peer=%s] (#%d): %s", self._peer, n, exc)
         elif n % 100 == 0:
+            # MOR-1789: exact count of occurrences not logged since the
+            # previous emitted line (last full line #3, or the previous
+            # hundredth) — 96 at n=100, 99 at every later hundredth.
+            prev_logged = 3 if n == 100 else n - 100
             logger.warning(
-                "UDP error [peer=%s] (#%d, suppressed 97): %s", self._peer, n, exc
+                "UDP error [peer=%s] (#%d, suppressed %d): %s",
+                self._peer,
+                n,
+                n - prev_logged - 1,
+                exc,
             )
 
     def connection_lost(self, exc: Exception | None) -> None:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -15,6 +15,7 @@ from rigplane.transport import (
     PACKET_QUEUE_MAXSIZE,
     PRESSURE_THRESHOLD,
 )
+from rigplane.core.transport import _UdpProtocol
 from rigplane.types import HEADER_SIZE, PacketType
 
 
@@ -709,3 +710,38 @@ class TestQueuePressure:
 
     def test_pressure_threshold_value(self) -> None:
         assert PRESSURE_THRESHOLD == 0.7
+
+
+# ---------------------------------------------------------------------------
+# UDP error throttling (MOR-1789)
+# ---------------------------------------------------------------------------
+
+
+class TestUdpErrorThrottling:
+    """Throttled UDP error warnings must report the exact number of
+    suppressed occurrences — the count of errors not logged since the
+    previous emitted line — not a hardcoded literal."""
+
+    def test_suppressed_count_is_computed_exactly(
+        self, transport: IcomTransport, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        protocol = _UdpProtocol(transport)
+
+        with caplog.at_level(logging.WARNING, logger="rigplane.core.transport"):
+            for _ in range(250):
+                protocol.error_received(OSError("Broken pipe"))
+
+        records = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING and "UDP error" in rec.message
+        ]
+        # Cadence unchanged: first three in full, then every hundredth.
+        assert len(records) == 5
+        assert "(#1)" in records[0].message
+        assert "(#2)" in records[1].message
+        assert "(#3)" in records[2].message
+        # The n=100 line accounts for 4..99 not logged: 96 suppressed.
+        assert "(#100, suppressed 96)" in records[3].message
+        # The n=200 line accounts for 101..199 not logged: 99 suppressed.
+        assert "(#200, suppressed 99)" in records[4].message


### PR DESCRIPTION
## Problem

`_UdpProtocol.error_received` in `src/rigplane/core/transport.py` throttles repeated UDP error warnings: the first three occurrences log in full, then every hundredth logs with a count of suppressed occurrences. The count was a string literal — `(#%d, suppressed 97)` — not a computed value, and it is wrong at every point:

- at n=100 the occurrences not logged since the previous emitted line (#3) are 4..99 → **96**, not 97 (off by one)
- at n=200 they are 101..199 → **99** (off by two)
- every later hundredth → **99**

The reported number therefore understated the affected span on the first throttled line and understated it even more on every subsequent one — an operator reconstructing "how many errors were there" from the log would get a wrong total.

## Change

Compute the count exactly: occurrences not logged since the previous emitted line. At an emitted hundredth `n`, the previous emitted line is `#3` when `n == 100` and `#(n-100)` otherwise, so the suppressed count is `n - prev_logged - 1`. The same arithmetic already landed for the web audio handler in MOR-1788 (`_warn_tx_throttled`); per the ticket, no code is shared across the core/web layer boundary — `core` cannot import from `web`, and the two four-line implementations staying independent is deliberate. `src/rigplane/web/handlers/audio.py` is untouched.

Logging-only change: the cadence (first three in full, then every hundredth), the message text, the log level, and the bracketed key=value style are all unchanged; only the number is now computed. In `core/transport.py` the counter is initialised once in `__init__` and never reset afterwards. The unrelated `_udp_error_count` attribute in `rigplane/backends/icom7610/drivers/serial_session.py` is a different attribute on a different class — not touched.

## Test evidence

New test in `tests/test_transport.py` (`TestUdpErrorThrottling`), written failing-first: it drives 250 `error_received` calls and records via `caplog`. On the unfixed code it fails on the suppressed values (`97` reported where 96 and 99 are correct); the cadence assertion (5 emitted records: #1, #2, #3, #100, #200) holds before and after, pinning that throttling behavior is unchanged.

Real numbers for this branch:

- `pytest tests/test_transport.py -q --tb=short` — 51 passed
- `pytest tests/ -q --tb=short` — 3 failed, 10380 passed (421s). The 3 failures are in `tests/integration/test_rigctld_audio_pipeline.py`, `tests/integration/test_rigctld_golden_replay.py`, `tests/integration/test_rigctld_wsjtx.py` — pre-existing, verified against an independent source (not `git stash`): a clean `git worktree` at the exact base commit 5a976b6b fails identically (3 failed, 11 passed on those files). They are excluded from quick CI (`--ignore=tests/integration`).
- `ruff check src/ tests/` — `All checks passed!`
- `ruff format --check src/ tests/` — `675 files already formatted`
- `mypy src/` — 12 errors in 3 files; the clean-worktree run at the base commit reports the identical 12/3 (none in the files touched here)
- `lint-imports` — `Contracts: 5 kept, 0 broken`
- Diff: 2 files, +45/-1
