### PR TITLE
chore(MOR-1790): ignore local scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ run-dev.sh
 
 # Logs
 logs/
+
+# Local scratch directories holding third-party documentation artifacts
+# (root-anchored so nested output/ or tmp/ elsewhere in the tree stays
+# tracked; never committed to the public repo — MOR-1790)
+/output/
+/tmp/


### PR DESCRIPTION
## Why

Two local scratch directories holding third-party documentation artifacts — `output/` and `tmp/` — were untracked but not ignored. That combination is a hazard for a public repository: a single `git add -A` by any agent or human would commit material that must not be published, and undoing that means rewriting published history, not reverting a commit. The directories also made tooling report a roughly +14k-line working tree, which produced a false alarm during review of an unrelated small change.

The fix is `.gitignore`-only. No directory contents were deleted or moved; the scratch directories remain in active use.

## What changed

One file: `.gitignore` (+6). Added at the end, immediately after the existing `# Logs` section:

```
/output/
/tmp/
```

with a brief comment. Both patterns are **root-anchored with a leading slash**, so they ignore only the two top-level directories and cannot shadow a legitimate `output/` or `tmp/` nested anywhere else in the tree (e.g. under `src/`, `tests/`, or `frontend/`).

## Verification (real output)

Nothing tracked becomes ignored — `git ls-files output tmp`:

```
(empty; exit 0)
```

Both directories match the new rules — `git check-ignore -v output tmp`:

```
.gitignore:116:/output/	output
.gitignore:117:/tmp/	tmp
```

Nested lookalikes are not ignored — `git check-ignore -v src/tmp tests/tmp frontend/tmp` produces no output (exit 1), proving the anchors hold.

Working tree is clean of the scratch noise — `git status --short`:

```
 M .gitignore
```

Diff is exactly one file — `git diff origin/main --stat`:

```
 .gitignore | 6 ++++++
 1 file changed, 6 insertions(+)
```

## Gates

- `pytest tests/ -q --tb=short` — 3 failed, 10380 passed (430s). The 3 failures are in `tests/integration/test_rigctld_audio_pipeline.py`, `tests/integration/test_rigctld_golden_replay.py`, `tests/integration/test_rigctld_wsjtx.py` — pre-existing, confirmed against an independent source (not `git stash`): a clean `git worktree` at the exact base commit b5ef95e5 fails identically (3 failed, 11 passed on those files). They are excluded from quick CI (`--ignore=tests/integration`). A `.gitignore` change cannot affect them.
- `ruff check src/ tests/` — `All checks passed!`
- `lint-imports` — `Contracts: 5 kept, 0 broken`
