### PR TITLE
feat(MOR-1791): fall back to PCM16 when the server cannot decode Opus

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -69,6 +69,7 @@
     getRadioHealth,
   } from '$lib/stores/connection.svelte';
   import { getActiveFrequencyHz } from '$lib/runtime/adapters/panel-adapters';
+  import { getAudioState } from '$lib/stores/audio.svelte';
   import { hasAnyScope, hasAudio, hasSpectrum } from '$lib/stores/capabilities.svelte';
   import { getLayoutMode, setLayoutMode, type CanonicalLayoutMode, type LayoutMode } from '$lib/stores/layout.svelte';
   import type { SemanticSurfaceName } from '../../presentation/layouts/contract';
@@ -141,6 +142,10 @@
     deriveScopeIndicatorState(runtime.defaultScopeStatus, isPoweredOff),
   );
   let audioState = $derived(isPoweredOff ? 'disconnected' : (isAudioConnected() ? 'connected' : 'disconnected'));
+  // MOR-1791: the server cannot decode Opus, so browser TX runs on the PCM16
+  // capture path. Transmission works — this is a quiet hint next to the audio
+  // indicator, deliberately not a fault chip and not a modal.
+  let txCodecFallback = $derived(!isPoweredOff && getAudioState().txCodecFallback);
   // MOR-1419: derived from the same live WS transport signal as `controlState`
   // (there is no separate HTTP transport anymore, post A10) refined by
   // `radioHealth.serverReachable` when that's been observed — honest, not a
@@ -300,6 +305,11 @@
         <span class="indicator-dot"></span>
         <Volume2 size={12} color="currentColor" strokeWidth={2.5} />
       </span>
+      {#if txCodecFallback}
+        <span class="indicator tx-codec-fallback" role="status" data-testid="tx-codec-fallback" title={t('core.statusbar.txCodecFallback.tooltip')} style="--indicator-color: {stateColor('degraded')}">
+          <span class="codec-fallback-label">{t('core.statusbar.txCodecFallback.label')}</span>
+        </span>
+      {/if}
     {/if}
     <span class="indicator" role="status" title={t('core.statusbar.indicator.http', { state: httpState })} style="--indicator-color: {stateColor(httpState)}">
       <span class="indicator-dot"></span>
@@ -438,6 +448,16 @@
     color: var(--v2-accent-red, #ef4444);
     font-weight: 700;
     margin-left: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* MOR-1791: TX codec fallback — a working state, so it borrows the
+     yellow "degraded" tone rather than the red fault tone. */
+  .codec-fallback-label {
+    font-size: 9px;
+    color: var(--v2-accent-yellow, #facc15);
+    font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.05em;
   }

--- a/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
@@ -1,0 +1,253 @@
+/**
+ * TX codec negotiation on the audio WebSocket (MOR-1791).
+ *
+ * The defect: a server with no native opus codec cannot decode browser Opus
+ * TX frames. It knows this at TX start, but never said so, and the browser
+ * kept sending Opus — the radio keyed while every frame was dropped
+ * fail-closed and nothing reached the air.
+ *
+ * The server now answers `audio_start direction=tx` with an `audio_tx_format`
+ * ack naming the codec it can accept. These tests cover both branches of that
+ * ack plus the operator-visible fallback indication, using the REAL `TxMic`
+ * so the switch is exercised through the actual capture path rather than a
+ * stand-in. Nothing here depends on a native Opus library existing anywhere —
+ * the server's answer is synthesized.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TxMic } from '../tx-mic';
+import { AUDIO_HEADER_SIZE, CODEC_PCM16, SAMPLE_RATE } from '../constants';
+
+const setTxCodecFallbackMock = vi.fn();
+
+vi.mock('../rx-player', () => ({
+  RxPlayer: class {
+    start = vi.fn();
+    stop = vi.fn();
+    flush = vi.fn();
+    setJitterBounds = vi.fn();
+    stats = vi.fn(() => ({ underruns: 0, bufferDepthMs: 0, droppedFrames: 0 }));
+    feed = vi.fn();
+    setFocus = vi.fn();
+    setSplitStereo = vi.fn();
+    setChannelGainDb = vi.fn();
+    get focus() { return 'main'; }
+    get splitStereo() { return false; }
+    get mainGainDb() { return 0; }
+    get subGainDb() { return 0; }
+    set volume(_value: number) {}
+  },
+}));
+
+vi.mock('../../stores/connection.svelte', () => ({
+  setAudioConnected: vi.fn(),
+}));
+
+vi.mock('../../stores/audio.svelte', () => ({
+  setRxEnabled: vi.fn(),
+  setTxEnabled: vi.fn(),
+  setTxCodecFallback: setTxCodecFallbackMock,
+}));
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: vi.fn(() => null),
+}));
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = '';
+  sent: unknown[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(_url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: unknown) { this.sent.push(data); }
+  close() { this.readyState = 3; }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  serverClose(code = 1006, reason = 'rearm') {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+
+  /** Deliver a server→client control frame on the audio WS. */
+  serverText(msg: unknown) {
+    this.onmessage?.({ data: typeof msg === 'string' ? msg : JSON.stringify(msg) });
+  }
+}
+
+async function openManager() {
+  const { audioManager } = await import('../audio-manager');
+  audioManager.startRx();
+  const ws = FakeWebSocket.instances[0];
+  ws.open();
+  return { audioManager, ws };
+}
+
+describe('AudioManager consumes the server TX codec ack', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    setTxCodecFallbackMock.mockClear();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+  });
+
+  it('raises the fallback indication when the server cannot decode Opus', async () => {
+    const { audioManager, ws } = await openManager();
+
+    ws.serverText({
+      type: 'audio_tx_format',
+      codec: 'pcm16',
+      opus_decode: false,
+      sample_rate: 48000,
+    });
+
+    expect(audioManager.txCodecFallback).toBe(true);
+    expect(setTxCodecFallbackMock).toHaveBeenCalledWith(true);
+  });
+
+  it('shows nothing new when the server can decode Opus', async () => {
+    const { audioManager, ws } = await openManager();
+
+    ws.serverText({
+      type: 'audio_tx_format',
+      codec: 'opus',
+      opus_decode: true,
+      sample_rate: 48000,
+    });
+
+    expect(audioManager.txCodecFallback).toBe(false);
+    expect(setTxCodecFallbackMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated and malformed text frames', async () => {
+    const { audioManager, ws } = await openManager();
+
+    ws.serverText({ type: 'audio_format', codec: 'pcm16' });
+    ws.serverText('}{ not json');
+
+    expect(audioManager.txCodecFallback).toBe(false);
+    expect(setTxCodecFallbackMock).not.toHaveBeenCalled();
+  });
+
+  it('drops the indication when the link goes away', async () => {
+    const { audioManager, ws } = await openManager();
+    ws.serverText({ type: 'audio_tx_format', codec: 'pcm16', opus_decode: false });
+    expect(audioManager.txCodecFallback).toBe(true);
+
+    ws.serverClose();
+
+    expect(audioManager.txCodecFallback).toBe(false);
+    expect(setTxCodecFallbackMock).toHaveBeenLastCalledWith(false);
+  });
+});
+
+describe('TxMic adopts the codec the server can accept', () => {
+  let mockTrack: any, mockEncoder: any, mockReader: any, context: any, processor: any;
+
+  beforeEach(() => {
+    mockTrack = { stop: vi.fn(), kind: 'audio' };
+    mockReader = {
+      read: vi.fn(() => Promise.resolve({ done: true })),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    };
+    mockEncoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
+    (globalThis as any).AudioEncoder = function (this: any) {
+      Object.assign(this, mockEncoder);
+      return mockEncoder;
+    };
+    (globalThis as any).MediaStreamTrackProcessor = function () {
+      return { readable: { getReader: () => mockReader } };
+    };
+    processor = null;
+    context = {
+      sampleRate: SAMPLE_RATE,
+      destination: {},
+      createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+      createScriptProcessor: vi.fn(() => {
+        processor = { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
+        return processor;
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    (globalThis as any).AudioContext = vi.fn(function () { return context; });
+    const stream = { getTracks: () => [mockTrack], getAudioTracks: () => [mockTrack] };
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) } },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).AudioEncoder;
+    delete (globalThis as any).MediaStreamTrackProcessor;
+    delete (globalThis as any).AudioContext;
+  });
+
+  it('switches a live Opus capture to PCM16 without reacquiring the microphone', async () => {
+    const sent = vi.fn();
+    const mic = new TxMic(sent);
+    expect(await mic.start()).toBeNull();
+    expect(mic.codec).toBe('opus');
+
+    expect(mic.applyServerCodec('pcm16')).toBe(true);
+
+    expect(mic.codec).toBe('pcm16');
+    expect(mockEncoder.close).toHaveBeenCalled();
+    expect(mockReader.cancel).toHaveBeenCalled();
+    // Same MediaStream — no second permission prompt, no second capture path.
+    expect(mockTrack.stop).not.toHaveBeenCalled();
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+
+    processor.onaudioprocess({
+      inputBuffer: { getChannelData: () => new Float32Array(960).fill(0.25) },
+    });
+    expect(sent).toHaveBeenCalledOnce();
+    const packet = sent.mock.calls[0][0] as ArrayBuffer;
+    expect(new DataView(packet).getUint8(1)).toBe(CODEC_PCM16);
+    expect(packet.byteLength).toBe(AUDIO_HEADER_SIZE + 960 * 2);
+    mic.stop();
+  });
+
+  it('opens later sessions on PCM16 from the first frame', async () => {
+    const sent = vi.fn();
+    const mic = new TxMic(sent);
+    await mic.start();
+    mic.applyServerCodec('pcm16');
+    mic.stop();
+    mockEncoder.configure.mockClear();
+
+    expect(await mic.start()).toBeNull();
+
+    expect(mic.codec).toBe('pcm16');
+    expect(mockEncoder.configure).not.toHaveBeenCalled();
+    mic.stop();
+  });
+
+  it('leaves a working Opus capture alone when the server can decode it', async () => {
+    const mic = new TxMic(vi.fn());
+    await mic.start();
+
+    expect(mic.applyServerCodec('opus')).toBe(false);
+
+    expect(mic.codec).toBe('opus');
+    expect(mockEncoder.close).not.toHaveBeenCalled();
+    expect(context.createScriptProcessor).not.toHaveBeenCalled();
+    mic.stop();
+  });
+});

--- a/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
@@ -18,6 +18,7 @@ import { TxMic } from '../tx-mic';
 import { AUDIO_HEADER_SIZE, CODEC_PCM16, SAMPLE_RATE } from '../constants';
 
 const setTxCodecFallbackMock = vi.fn();
+const setTxEnabledMock = vi.fn();
 
 vi.mock('../rx-player', () => ({
   RxPlayer: class {
@@ -44,7 +45,7 @@ vi.mock('../../stores/connection.svelte', () => ({
 
 vi.mock('../../stores/audio.svelte', () => ({
   setRxEnabled: vi.fn(),
-  setTxEnabled: vi.fn(),
+  setTxEnabled: setTxEnabledMock,
   setTxCodecFallback: setTxCodecFallbackMock,
 }));
 
@@ -96,14 +97,71 @@ async function openManager() {
   return { audioManager, ws };
 }
 
+function sentTypes(ws: FakeWebSocket): string[] {
+  return ws.sent.map((s) => (JSON.parse(s as string) as { type: string }).type);
+}
+
+/**
+ * Install a browser media environment with BOTH capture paths available.
+ *
+ * `contextSampleRate` is what the AudioContext actually gives us: anything
+ * other than `SAMPLE_RATE` makes `startPcmFallback()` refuse, which is the
+ * only way the PCM16 leg can fail on a browser that has WebCodecs.
+ */
+function installMediaGlobals({ contextSampleRate = SAMPLE_RATE } = {}) {
+  const track = { stop: vi.fn(), kind: 'audio' };
+  const reader = {
+    read: vi.fn(() => Promise.resolve({ done: true })),
+    cancel: vi.fn().mockResolvedValue(undefined),
+  };
+  const encoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
+  let processor: any = null;
+  const context = {
+    sampleRate: contextSampleRate,
+    destination: {},
+    createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+    createScriptProcessor: vi.fn(() => {
+      processor = { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
+      return processor;
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  (globalThis as any).AudioEncoder = function (this: any) {
+    Object.assign(this, encoder);
+    return encoder;
+  };
+  (globalThis as any).MediaStreamTrackProcessor = function () {
+    return { readable: { getReader: () => reader } };
+  };
+  (globalThis as any).AudioContext = vi.fn(function () { return context; });
+  const stream = { getTracks: () => [track], getAudioTracks: () => [track] };
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) } },
+    writable: true,
+    configurable: true,
+  });
+  return { track, reader, encoder, context, getProcessor: () => processor };
+}
+
+function clearMediaGlobals(): void {
+  delete (globalThis as any).AudioEncoder;
+  delete (globalThis as any).MediaStreamTrackProcessor;
+  delete (globalThis as any).AudioContext;
+}
+
 describe('AudioManager consumes the server TX codec ack', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllGlobals();
     setTxCodecFallbackMock.mockClear();
+    setTxEnabledMock.mockClear();
     FakeWebSocket.instances = [];
     vi.stubGlobal('WebSocket', FakeWebSocket);
     vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5173' });
+  });
+
+  afterEach(() => {
+    clearMediaGlobals();
   });
 
   it('raises the fallback indication when the server cannot decode Opus', async () => {
@@ -154,49 +212,62 @@ describe('AudioManager consumes the server TX codec ack', () => {
     expect(audioManager.txCodecFallback).toBe(false);
     expect(setTxCodecFallbackMock).toHaveBeenLastCalledWith(false);
   });
+
+  it('never claims a working fallback when the PCM16 path refuses to start', async () => {
+    // The one way the switch can fail on a WebCodecs browser: the
+    // AudioContext will not give us 48 kHz.
+    installMediaGlobals({ contextSampleRate: 44100 });
+    const { audioManager } = await import('../audio-manager');
+    expect(await audioManager.startTx()).toBeNull(); // Opus capture is up
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.sent = [];
+
+    ws.serverText({ type: 'audio_tx_format', codec: 'pcm16', opus_decode: false });
+
+    // The chip must never say "Transmission is working" while the radio is
+    // keyed and the switch did not happen.
+    expect(audioManager.txCodecFallback).toBe(false);
+    expect(setTxCodecFallbackMock).not.toHaveBeenCalledWith(true);
+    // The TX audio session ends through the existing teardown: the server
+    // releases the TX lease, disarming the radio's TX audio leg.
+    expect(sentTypes(ws)).toContain('audio_stop');
+    expect(setTxEnabledMock).toHaveBeenLastCalledWith(false);
+    expect(audioManager.txEnabled).toBe(false);
+    // And the next key reports it as a TX audio START failure — the exact
+    // input the TX controller turns into `audio-failed` and de-keys on.
+    expect(await audioManager.startTx()).toContain('sample rate');
+  });
+
+  it('leaves the pin alone when the ack names a codec it does not know', async () => {
+    installMediaGlobals();
+    const { audioManager } = await import('../audio-manager');
+    await audioManager.startTx();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    ws.serverText({ type: 'audio_tx_format', codec: 'pcm16', opus_decode: false });
+    expect(audioManager.txCodecFallback).toBe(true);
+
+    // Fail-safe, not fail-open: an unrecognized codec must not clear a pin
+    // that a previous ack established.
+    ws.serverText({ type: 'audio_tx_format', codec: 'flac', opus_decode: false });
+
+    expect(audioManager.txCodecFallback).toBe(true);
+    audioManager.stopTx();
+    expect(await audioManager.startTx()).toBeNull();
+    expect(audioManager.txCodec).toBe('pcm16');
+  });
 });
 
 describe('TxMic adopts the codec the server can accept', () => {
-  let mockTrack: any, mockEncoder: any, mockReader: any, context: any, processor: any;
+  let media: ReturnType<typeof installMediaGlobals>;
 
   beforeEach(() => {
-    mockTrack = { stop: vi.fn(), kind: 'audio' };
-    mockReader = {
-      read: vi.fn(() => Promise.resolve({ done: true })),
-      cancel: vi.fn().mockResolvedValue(undefined),
-    };
-    mockEncoder = { configure: vi.fn(), encode: vi.fn(), close: vi.fn(), state: 'configured' };
-    (globalThis as any).AudioEncoder = function (this: any) {
-      Object.assign(this, mockEncoder);
-      return mockEncoder;
-    };
-    (globalThis as any).MediaStreamTrackProcessor = function () {
-      return { readable: { getReader: () => mockReader } };
-    };
-    processor = null;
-    context = {
-      sampleRate: SAMPLE_RATE,
-      destination: {},
-      createMediaStreamSource: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
-      createScriptProcessor: vi.fn(() => {
-        processor = { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
-        return processor;
-      }),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-    (globalThis as any).AudioContext = vi.fn(function () { return context; });
-    const stream = { getTracks: () => [mockTrack], getAudioTracks: () => [mockTrack] };
-    Object.defineProperty(globalThis, 'navigator', {
-      value: { mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) } },
-      writable: true,
-      configurable: true,
-    });
+    media = installMediaGlobals();
   });
 
   afterEach(() => {
-    delete (globalThis as any).AudioEncoder;
-    delete (globalThis as any).MediaStreamTrackProcessor;
-    delete (globalThis as any).AudioContext;
+    clearMediaGlobals();
   });
 
   it('switches a live Opus capture to PCM16 without reacquiring the microphone', async () => {
@@ -205,16 +276,16 @@ describe('TxMic adopts the codec the server can accept', () => {
     expect(await mic.start()).toBeNull();
     expect(mic.codec).toBe('opus');
 
-    expect(mic.applyServerCodec('pcm16')).toBe(true);
+    expect(mic.applyServerCodec('pcm16')).toEqual({ switched: true, error: null });
 
     expect(mic.codec).toBe('pcm16');
-    expect(mockEncoder.close).toHaveBeenCalled();
-    expect(mockReader.cancel).toHaveBeenCalled();
+    expect(media.encoder.close).toHaveBeenCalled();
+    expect(media.reader.cancel).toHaveBeenCalled();
     // Same MediaStream — no second permission prompt, no second capture path.
-    expect(mockTrack.stop).not.toHaveBeenCalled();
+    expect(media.track.stop).not.toHaveBeenCalled();
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
 
-    processor.onaudioprocess({
+    media.getProcessor().onaudioprocess({
       inputBuffer: { getChannelData: () => new Float32Array(960).fill(0.25) },
     });
     expect(sent).toHaveBeenCalledOnce();
@@ -230,12 +301,12 @@ describe('TxMic adopts the codec the server can accept', () => {
     await mic.start();
     mic.applyServerCodec('pcm16');
     mic.stop();
-    mockEncoder.configure.mockClear();
+    media.encoder.configure.mockClear();
 
     expect(await mic.start()).toBeNull();
 
     expect(mic.codec).toBe('pcm16');
-    expect(mockEncoder.configure).not.toHaveBeenCalled();
+    expect(media.encoder.configure).not.toHaveBeenCalled();
     mic.stop();
   });
 
@@ -243,11 +314,33 @@ describe('TxMic adopts the codec the server can accept', () => {
     const mic = new TxMic(vi.fn());
     await mic.start();
 
-    expect(mic.applyServerCodec('opus')).toBe(false);
+    expect(mic.applyServerCodec('opus')).toEqual({ switched: false, error: null });
 
     expect(mic.codec).toBe('opus');
-    expect(mockEncoder.close).not.toHaveBeenCalled();
-    expect(context.createScriptProcessor).not.toHaveBeenCalled();
+    expect(media.encoder.close).not.toHaveBeenCalled();
+    expect(media.context.createScriptProcessor).not.toHaveBeenCalled();
+    mic.stop();
+  });
+
+  it('keeps the live capture whole when the PCM16 leg refuses to start', async () => {
+    // The failure must not kill capture out from under a keyed transmitter:
+    // PCM16 is brought up BEFORE the Opus leg is torn down, so a refusal
+    // leaves the running capture exactly as it was.
+    clearMediaGlobals();
+    media = installMediaGlobals({ contextSampleRate: 44100 });
+    const sent = vi.fn();
+    const mic = new TxMic(sent);
+    await mic.start();
+
+    const result = mic.applyServerCodec('pcm16');
+
+    expect(result.switched).toBe(false);
+    expect(result.error).toContain('sample rate');
+    expect(mic.active).toBe(true);
+    expect(mic.codec).toBe('opus');
+    expect(media.encoder.close).not.toHaveBeenCalled();
+    expect(media.reader.cancel).not.toHaveBeenCalled();
+    expect(media.track.stop).not.toHaveBeenCalled();
     mic.stop();
   });
 });

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -9,7 +9,7 @@
  */
 
 import { RxPlayer, type RxAudioFocus } from './rx-player';
-import { TxMic } from './tx-mic';
+import { TxMic, type TxCodec } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
 import { setRxEnabled, setTxEnabled, setTxCodecFallback } from '../stores/audio.svelte';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
@@ -320,6 +320,9 @@ class AudioManager {
    *  decode Opus. Surfaced to the operator as a quiet status hint. */
   get txCodecFallback(): boolean { return this._txCodecFallback; }
 
+  /** Codec the microphone is currently emitting, or null when not capturing. */
+  get txCodec(): TxCodec | null { return this.txMic.codec; }
+
   private _txCodecFallback = false;
 
   private _handleServerMessage(raw: string): void {
@@ -330,14 +333,39 @@ class AudioManager {
       return;
     }
     if (msg?.type !== 'audio_tx_format') return;
-    // Only an explicit pcm16 answer redirects us; anything else leaves the
-    // client's own codec choice untouched, exactly as before this existed.
-    const codec = msg.codec === 'pcm16' ? 'pcm16' : 'opus';
-    const switched = this.txMic.applyServerCodec(codec);
+    // Fail-safe on an unrecognized codec: ignore the whole ack rather than
+    // guessing. Defaulting to 'opus' would CLEAR a sticky PCM16 pin, i.e.
+    // fail open on exactly the condition this negotiation exists for.
+    const codec = msg.codec === 'pcm16' ? 'pcm16' : msg.codec === 'opus' ? 'opus' : null;
+    if (codec === null) return;
+
+    const { switched, error } = this.txMic.applyServerCodec(codec);
+    if (error !== null) {
+      this._failTxAudio(error);
+      return;
+    }
     if (switched) {
       console.warn('[audio-ws] server cannot decode Opus — TX switched to PCM16');
     }
     this._setTxCodecFallback(msg.opus_decode === false);
+  }
+
+  /**
+   * End browser TX audio after the codec switch could not be completed.
+   *
+   * The server cannot decode Opus and the PCM16 leg refused to start, so no
+   * audio can reach the air on this session. Ending it takes the same
+   * teardown a failed TX audio start takes — `stopTx()` releases the
+   * server-side TX lease, which disarms the radio's TX audio leg — and the
+   * fallback indication is cleared so nothing claims transmission is working
+   * while the transmitter is keyed. The next key re-runs `txMic.start()` on
+   * the pinned PCM16 path and returns this same error from `startTx()`, the
+   * input the TX controller turns into `audio-failed` and de-keys on.
+   */
+  private _failTxAudio(reason: string): void {
+    console.error(`[audio-ws] TX codec switch failed, stopping TX audio: ${reason}`);
+    this._setTxCodecFallback(false);
+    this.stopTx();
   }
 
   private _setTxCodecFallback(active: boolean): void {

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -11,7 +11,7 @@
 import { RxPlayer, type RxAudioFocus } from './rx-player';
 import { TxMic } from './tx-mic';
 import { setAudioConnected } from '../stores/connection.svelte';
-import { setRxEnabled, setTxEnabled } from '../stores/audio.svelte';
+import { setRxEnabled, setTxEnabled, setTxCodecFallback } from '../stores/audio.svelte';
 import { getCapabilities } from '$lib/stores/capabilities.svelte';
 
 export type AudioFocus = RxAudioFocus;
@@ -277,6 +277,10 @@ class AudioManager {
     ws.onmessage = (ev) => {
       if (ev.data instanceof ArrayBuffer) {
         this.rxPlayer.feed(ev.data);
+        return;
+      }
+      if (typeof ev.data === 'string') {
+        this._handleServerMessage(ev.data);
       }
     };
 
@@ -290,6 +294,10 @@ class AudioManager {
       this._clearStatsTimer();
       this.ws = null;
       setAudioConnected(false);
+      // Decoder availability is a fact about the server we are talking to;
+      // once the link is gone we no longer know it. Re-learned at the next
+      // TX start (MOR-1791).
+      this._setTxCodecFallback(false);
       this.notify();
       if (!this._rxEnabled && !this._txEnabled) return;
       // Reconnect with backoff
@@ -297,6 +305,46 @@ class AudioManager {
       this.backoff = Math.min(Math.floor(this.backoff * 1.7), BACKOFF_MAX);
       this.reconnectTimer = setTimeout(() => this.connect(), delay);
     };
+  }
+
+  // ── TX codec negotiation (MOR-1791) ──
+  //
+  // The server answers every ``audio_start direction=tx`` with an
+  // ``audio_tx_format`` ack naming the codec it can actually accept. Without
+  // it, a server with no native opus codec drops every browser Opus frame
+  // fail-closed: the radio keys and nothing reaches the air. Text frames on
+  // this socket were previously discarded, so consuming them is additive on
+  // both sides — an older server simply never sends one and we keep Opus.
+
+  /** True while browser TX is pinned to PCM16 because the server cannot
+   *  decode Opus. Surfaced to the operator as a quiet status hint. */
+  get txCodecFallback(): boolean { return this._txCodecFallback; }
+
+  private _txCodecFallback = false;
+
+  private _handleServerMessage(raw: string): void {
+    let msg: { type?: unknown; codec?: unknown; opus_decode?: unknown };
+    try {
+      msg = JSON.parse(raw) as typeof msg;
+    } catch {
+      return;
+    }
+    if (msg?.type !== 'audio_tx_format') return;
+    // Only an explicit pcm16 answer redirects us; anything else leaves the
+    // client's own codec choice untouched, exactly as before this existed.
+    const codec = msg.codec === 'pcm16' ? 'pcm16' : 'opus';
+    const switched = this.txMic.applyServerCodec(codec);
+    if (switched) {
+      console.warn('[audio-ws] server cannot decode Opus — TX switched to PCM16');
+    }
+    this._setTxCodecFallback(msg.opus_decode === false);
+  }
+
+  private _setTxCodecFallback(active: boolean): void {
+    if (active === this._txCodecFallback) return;
+    this._txCodecFallback = active;
+    setTxCodecFallback(active);
+    this.notify();
   }
 
   // ── Link-quality uplink (MOR-585, ADR §3.6) ──

--- a/frontend/src/lib/audio/tx-mic.ts
+++ b/frontend/src/lib/audio/tx-mic.ts
@@ -21,6 +21,8 @@ type NavigatorWithLegacyMedia = Navigator & {
   mozGetUserMedia?: LegacyGetUserMedia;
 };
 
+export type TxCodec = 'opus' | 'pcm16';
+
 export class TxMic {
   private stream: MediaStream | null = null;
   private encoder: AudioEncoder | null = null;
@@ -32,6 +34,9 @@ export class TxMic {
   private seq = 0;
   private _active = false;
   private sendFn: TxSendFn;
+  // Sticky: the server told us it cannot decode Opus (MOR-1791). Kept across
+  // start/stop so every later PTT opens on PCM16 from the very first frame.
+  private pcm16Pinned = false;
 
   constructor(sendFn: TxSendFn) {
     this.sendFn = sendFn;
@@ -39,6 +44,38 @@ export class TxMic {
 
   get active(): boolean {
     return this._active;
+  }
+
+  /** Codec currently being emitted, or null when not capturing. */
+  get codec(): TxCodec | null {
+    if (!this._active) return null;
+    return this.encoder !== null ? 'opus' : 'pcm16';
+  }
+
+  /**
+   * Adopt the codec the server says it can accept (MOR-1791).
+   *
+   * The server cannot decode Opus on hosts without a native opus codec; it
+   * knows this at TX start and now says so. Rather than key the radio while
+   * every Opus frame is dropped fail-closed, switch to the PCM16 capture
+   * path that already exists below — same path, same MediaStream, no second
+   * permission prompt, no new transport.
+   *
+   * `'opus'` restores the default and never tears down a running capture:
+   * when the decoder is available the client keeps its own codec choice,
+   * exactly as before this negotiation existed.
+   *
+   * Returns true when a live capture was switched to PCM16.
+   */
+  applyServerCodec(codec: TxCodec): boolean {
+    if (codec === 'opus') {
+      this.pcm16Pinned = false;
+      return false;
+    }
+    this.pcm16Pinned = true;
+    if (!this._active || this.encoder === null) return false;
+    this.stopOpusCapture();
+    return this.startPcmFallback() === null;
   }
 
   /** Check if browser supports TX mic */
@@ -110,7 +147,7 @@ export class TxMic {
     this.seq = 0;
     this.pcmPending = [];
 
-    if (!TxMic.supportsWebCodecs()) {
+    if (this.pcm16Pinned || !TxMic.supportsWebCodecs()) {
       return this.startPcmFallback();
     }
 
@@ -166,6 +203,15 @@ export class TxMic {
       this.audioContext = null;
     }
     this.pcmPending = [];
+    this.stopOpusCapture();
+    if (this.stream) {
+      this.stream.getTracks().forEach(t => t.stop());
+      this.stream = null;
+    }
+  }
+
+  /** Tear down the WebCodecs encoder leg, leaving the MediaStream open. */
+  private stopOpusCapture(): void {
     if (this.reader) {
       this.reader.cancel().catch(() => {});
       this.reader = null;
@@ -173,10 +219,6 @@ export class TxMic {
     if (this.encoder) {
       try { this.encoder.close(); } catch { /* ok */ }
       this.encoder = null;
-    }
-    if (this.stream) {
-      this.stream.getTracks().forEach(t => t.stop());
-      this.stream = null;
     }
   }
 

--- a/frontend/src/lib/audio/tx-mic.ts
+++ b/frontend/src/lib/audio/tx-mic.ts
@@ -23,6 +23,19 @@ type NavigatorWithLegacyMedia = Navigator & {
 
 export type TxCodec = 'opus' | 'pcm16';
 
+/** Outcome of adopting a server-advertised TX codec. */
+export interface TxCodecSwitch {
+  /** True when a live capture was actually moved onto PCM16. */
+  switched: boolean;
+  /**
+   * Non-null when the PCM16 leg refused to start. The capture is left
+   * untouched and still running on Opus — which the server cannot decode —
+   * so the caller must end the TX session rather than report a working
+   * fallback.
+   */
+  error: string | null;
+}
+
 export class TxMic {
   private stream: MediaStream | null = null;
   private encoder: AudioEncoder | null = null;
@@ -65,17 +78,23 @@ export class TxMic {
    * when the decoder is available the client keeps its own codec choice,
    * exactly as before this negotiation existed.
    *
-   * Returns true when a live capture was switched to PCM16.
+   * PCM16 is brought up BEFORE the Opus leg is torn down. A refusal must
+   * never kill capture out from under a keyed transmitter, so on failure the
+   * running Opus capture is left whole and the error is returned for the
+   * caller to act on — it is never swallowed.
    */
-  applyServerCodec(codec: TxCodec): boolean {
+  applyServerCodec(codec: TxCodec): TxCodecSwitch {
     if (codec === 'opus') {
       this.pcm16Pinned = false;
-      return false;
+      return { switched: false, error: null };
     }
     this.pcm16Pinned = true;
-    if (!this._active || this.encoder === null) return false;
+    if (!this._active || this.encoder === null) return { switched: false, error: null };
+
+    const error = this.startPcmFallback({ abortCapture: false });
+    if (error !== null) return { switched: false, error };
     this.stopOpusCapture();
-    return this.startPcmFallback() === null;
+    return { switched: true, error: null };
   }
 
   /** Check if browser supports TX mic */
@@ -222,16 +241,33 @@ export class TxMic {
     }
   }
 
-  private startPcmFallback(): string | null {
+  /**
+   * Bring up the PCM16 capture leg.
+   *
+   * `abortCapture` is true when this IS the capture (called from `start()`),
+   * so a refusal must tear the whole attempt down. It is false when swapping
+   * a live Opus capture over (`applyServerCodec`), where the running capture
+   * must survive a refusal rather than die under a keyed transmitter.
+   */
+  private startPcmFallback({ abortCapture = true } = {}): string | null {
     const audioContextCtor = TxMic.audioContextCtor();
     if (!audioContextCtor || !this.stream) {
       return 'TX MIC: PCM capture not supported';
     }
 
     this.audioContext = new audioContextCtor({ sampleRate: SAMPLE_RATE });
-    if (Math.round(this.audioContext.sampleRate) !== SAMPLE_RATE) {
-      this.stop();
-      return `TX MIC: unsupported mic sample rate ${this.audioContext.sampleRate} Hz`;
+    const actualRate = this.audioContext.sampleRate;
+    if (Math.round(actualRate) !== SAMPLE_RATE) {
+      // Read the rate BEFORE tearing down: both teardowns null out
+      // `audioContext`, and reading it afterwards threw a TypeError instead
+      // of returning this error string.
+      if (abortCapture) {
+        this.stop();
+      } else {
+        this.audioContext.close().catch(() => {});
+        this.audioContext = null;
+      }
+      return `TX MIC: unsupported mic sample rate ${actualRate} Hz`;
     }
 
     this.pcmSource = this.audioContext.createMediaStreamSource(this.stream);

--- a/frontend/src/lib/i18n/locales/en-US.json
+++ b/frontend/src/lib/i18n/locales/en-US.json
@@ -26,6 +26,8 @@
   "core.statusbar.indicator.scope": "Scope WebSocket: {state}",
   "core.statusbar.indicator.audio": "Audio WebSocket: {state}",
   "core.statusbar.indicator.http": "State HTTP: {state}",
+  "core.statusbar.txCodecFallback.label": "PCM16",
+  "core.statusbar.txCodecFallback.tooltip": "TX audio: this server cannot decode Opus, so the microphone is sending PCM16 instead. Transmission is working.",
   "core.statusbar.health.radioLinkLost": "radio link lost",
   "core.statusbar.health.radioResponseDelayed": "radio response delayed",
   "core.statusbar.health.radioNotResponding": "radio not responding",

--- a/frontend/src/lib/i18n/locales/ru-RU.json
+++ b/frontend/src/lib/i18n/locales/ru-RU.json
@@ -26,6 +26,8 @@
   "core.statusbar.indicator.scope": "WebSocket панорамы: {state}",
   "core.statusbar.indicator.audio": "Аудио WebSocket: {state}",
   "core.statusbar.indicator.http": "HTTP состояния: {state}",
+  "core.statusbar.txCodecFallback.label": "PCM16",
+  "core.statusbar.txCodecFallback.tooltip": "TX-аудио: сервер не умеет декодировать Opus, поэтому микрофон передаёт PCM16. Передача работает.",
   "core.statusbar.health.radioLinkLost": "связь с трансивером потеряна",
   "core.statusbar.health.radioResponseDelayed": "трансивер отвечает с задержкой",
   "core.statusbar.health.radioNotResponding": "трансивер не отвечает",

--- a/frontend/src/lib/stores/audio.svelte.ts
+++ b/frontend/src/lib/stores/audio.svelte.ts
@@ -6,6 +6,10 @@ let audioState = $state({
   muted: false,
   micEnabled: false,
   bridgeRunning: false,
+  // MOR-1791: the server reported it cannot decode Opus, so browser TX runs
+  // on the PCM16 capture path instead. A working state, not a fault — it is
+  // surfaced as a quiet status hint, never as a modal or a blocking error.
+  txCodecFallback: false,
 });
 
 export function getAudioState(): typeof audioState {
@@ -38,4 +42,8 @@ export function setMicEnabled(v: boolean): void {
 
 export function setBridgeRunning(v: boolean): void {
   audioState.bridgeRunning = v;
+}
+
+export function setTxCodecFallback(v: boolean): void {
+  audioState.txCodecFallback = v;
 }

--- a/src/rigplane/web/handlers/audio.py
+++ b/src/rigplane/web/handlers/audio.py
@@ -1489,6 +1489,7 @@ class AudioHandler:
                 # recurrence is never hidden by an earlier session's backlog.
                 self._tx_warn_counts.clear()
                 logger.info("audio: TX active")
+                await self._send_tx_format(transcoder_ready)
         elif msg_type == "audio_stop":
             if direction == "rx":
                 await self._stop_rx()
@@ -1727,6 +1728,31 @@ class AudioHandler:
     async def _send_error(self, message: str) -> None:
         """Send an error message envelope to the WS client."""
         await self._send_json({"type": "error", "message": message})
+
+    async def _send_tx_format(self, opus_decode: bool) -> None:
+        """Advertise the TX codec this server can accept (MOR-1791).
+
+        The TX mirror of the RX-side ``audio_format`` ack (MOR-584), sent
+        once per armed ``audio_start direction=tx``.  Purely additive: no
+        field is removed and no version is bumped, so a client that ignores
+        audio-WS text frames is affected in no way.
+
+        ``opus_decode`` is the same fact the server already logs — whether a
+        browser Opus TX frame can be decoded at all on the radio's PCM TX
+        leg.  ``codec`` restates it as the codec the client should send, so
+        a browser facing a missing native opus codec can switch to its
+        existing PCM16 capture path instead of keying the radio while every
+        frame is dropped fail-closed.  When Opus IS decodable the ack names
+        Opus and the client keeps its own choice, exactly as before.
+        """
+        await self._send_json(
+            {
+                "type": "audio_tx_format",
+                "codec": "opus" if opus_decode else "pcm16",
+                "opus_decode": opus_decode,
+                "sample_rate": self._tx_sample_rate(),
+            }
+        )
 
     def _ensure_tx_transcoder(self) -> bool:
         """Create (or recreate) the TX Opus→PCM transcoder at the radio's rate.

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import struct
 import time
 from types import SimpleNamespace
@@ -2197,7 +2198,13 @@ async def test_transcoder_failure_arms_tx_and_drops_only_opus_frames(
     assert handler._tx_lease is lease
     # PCM16 reached the radio; the Opus frame stayed fail-closed.
     assert lease.pushed == [b"pcm-frame"]
-    ws.send_text.assert_not_awaited()
+    # The session is never denied — but since MOR-1791 the client IS told
+    # which codec survives, so it can stop feeding Opus into a missing
+    # decoder.  Advisory ack only: no error envelope is sent.
+    sent = [json.loads(call.args[0]) for call in ws.send_text.await_args_list]
+    assert [m["type"] for m in sent] == ["audio_tx_format"]
+    assert sent[0]["codec"] == "pcm16"
+    assert sent[0]["opus_decode"] is False
     messages = [record.message for record in caplog.records]
     assert any("action=dropped_no_transcoder" in message for message in messages)
     assert any("TX Opus decoder unavailable" in message for message in messages)

--- a/tests/test_web_audio_tx_codec_negotiation.py
+++ b/tests/test_web_audio_tx_codec_negotiation.py
@@ -1,0 +1,174 @@
+"""Browser TX codec negotiation on the audio WS (MOR-1791).
+
+The defect: when the server cannot decode Opus (no native opus codec), it
+already knows at ``audio_start direction=tx`` that browser PCM16 TX would
+work — and says so in the log — but nothing tells the client.  The browser
+keeps emitting Opus, every frame is dropped fail-closed, the radio keys, and
+no modulation reaches the air.
+
+The fix is an additive server→client ack on the EXISTING audio control
+channel, mirroring the RX-side ``audio_format`` ack (MOR-584): one
+``audio_tx_format`` message per TX start naming the codec this server can
+actually accept.  Nothing is versioned and nothing is removed — clients that
+ignore audio-WS text frames behave exactly as before.
+
+Host independence: these tests never ask whether a native Opus library
+exists on the machine running them.  Decoder availability is injected by
+stubbing ``AudioHandler._ensure_tx_transcoder``, so both branches are
+exercised on every host.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from _order_sensitive_radios import LanLikeRadio
+
+from rigplane.audio.session import AudioSession
+from rigplane.web.handlers import AudioHandler
+from rigplane.web.protocol import (
+    AUDIO_CODEC_OPUS,
+    AUDIO_CODEC_PCM16,
+    AUDIO_HEADER_SIZE,
+    MSG_TYPE_AUDIO_TX,
+)
+
+
+class _SessionLanRadio(LanLikeRadio):
+    """LAN-like stub + radio-owned session singleton (MOR-579 shape)."""
+
+    capabilities = {"audio", "tx"}
+    backend_id = "rigplane"
+    has_usb_audio = True
+    audio_sample_rate = 48000
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pushed: list[bytes] = []
+        self._audio_session: AudioSession | None = None
+
+    @property
+    def audio_session(self) -> AudioSession:
+        if self._audio_session is None:
+            self._audio_session = AudioSession(self)
+        return self._audio_session
+
+    async def push_tx(self, audio_data: bytes) -> None:
+        await super().push_tx(audio_data)  # raises unless TX is armed
+        self.pushed.append(audio_data)
+
+
+class _CapturingWs:
+    """WS double capturing the JSON text frames the handler sends."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.recv = AsyncMock()
+        self.send_binary = AsyncMock()
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(json.loads(text))
+
+    def messages(self, msg_type: str) -> list[dict[str, Any]]:
+        return [m for m in self.sent if m.get("type") == msg_type]
+
+
+def _make_handler(
+    radio: _SessionLanRadio, *, opus_decode: bool
+) -> tuple[AudioHandler, _CapturingWs]:
+    """Handler whose Opus decoder availability is injected, not discovered."""
+    ws = _CapturingWs()
+    handler = AudioHandler(ws, radio, None)
+
+    def _ensure(*, _ok: bool = opus_decode) -> bool:
+        if _ok:
+            handler._transcoder = SimpleNamespace(
+                opus_to_pcm=lambda data: b"pcm:" + data
+            )
+            handler._transcoder_rate = radio.audio_sample_rate
+            return True
+        handler._transcoder = None
+        handler._transcoder_rate = 0
+        return False
+
+    handler._ensure_tx_transcoder = _ensure  # type: ignore[method-assign]
+    return handler, ws
+
+
+def _tx_frame(codec: int, payload: bytes) -> bytes:
+    return (
+        bytes([MSG_TYPE_AUDIO_TX, codec]) + b"\x00" * (AUDIO_HEADER_SIZE - 2) + payload
+    )
+
+
+async def _start_tx(handler: AudioHandler) -> None:
+    await handler._handle_control({"type": "audio_start", "direction": "tx"})
+
+
+async def test_tx_start_advertises_pcm16_when_opus_decoder_unavailable() -> None:
+    """No decoder → the ack names PCM16, the codec that actually reaches air."""
+    radio = _SessionLanRadio()
+    handler, ws = _make_handler(radio, opus_decode=False)
+
+    await _start_tx(handler)
+
+    acks = ws.messages("audio_tx_format")
+    assert len(acks) == 1, "exactly one TX codec ack per audio_start"
+    assert acks[0]["codec"] == "pcm16"
+    assert acks[0]["opus_decode"] is False
+    assert acks[0]["sample_rate"] == 48000
+    # The session is still armed: a missing decoder never denies TX (MOR-1173).
+    assert handler._tx_active is True
+    assert radio.audio_session.tx_demand == 1
+
+
+async def test_tx_start_advertises_opus_when_decoder_available() -> None:
+    """Decoder present → the ack names Opus; the client keeps today's choice."""
+    radio = _SessionLanRadio()
+    handler, ws = _make_handler(radio, opus_decode=True)
+
+    await _start_tx(handler)
+
+    acks = ws.messages("audio_tx_format")
+    assert len(acks) == 1
+    assert acks[0]["codec"] == "opus"
+    assert acks[0]["opus_decode"] is True
+
+
+async def test_advertised_pcm16_frames_reach_the_radio_with_zero_drops() -> None:
+    """The advertised fallback is the one that works: PCM16 in, PCM16 pushed."""
+    radio = _SessionLanRadio()
+    handler, _ws = _make_handler(radio, opus_decode=False)
+    await _start_tx(handler)
+
+    for i in range(5):
+        await handler._handle_tx_audio(_tx_frame(AUDIO_CODEC_PCM16, b"frame-%d" % i))
+
+    assert radio.pushed == [b"frame-%d" % i for i in range(5)]
+    assert handler._tx_warn_counts == {}, "no drop warnings for the advertised codec"
+
+
+async def test_opus_frames_remain_dropped_fail_closed_without_a_decoder() -> None:
+    """Fail-closed is unchanged: an undecodable frame is never reported applied."""
+    radio = _SessionLanRadio()
+    handler, _ws = _make_handler(radio, opus_decode=False)
+    await _start_tx(handler)
+
+    await handler._handle_tx_audio(_tx_frame(AUDIO_CODEC_OPUS, b"opus-payload"))
+
+    assert radio.pushed == []
+    assert handler._tx_warn_counts.get("dropped_no_transcoder") == 1
+
+
+async def test_no_tx_codec_ack_when_tx_audio_is_unavailable() -> None:
+    """A denied TX start advertises nothing — there is no codec to negotiate."""
+    ws = _CapturingWs()
+    handler = AudioHandler(ws, None, None)
+
+    await _start_tx(handler)
+
+    assert ws.messages("audio_tx_format") == []
+    assert handler._tx_active is False


### PR DESCRIPTION
Closes MOR-1791 (child A of MOR-1783).

## The defect and what it does on the air

When the server host has no native opus codec, the TX Opus→PCM transcoder
cannot be created. The server discovers this at `audio_start direction=tx`
and logs it, naming the working alternative:

```
audio: TX Opus decoder unavailable at 48000 Hz (native opus codec missing?)
       — browser PCM16 TX still works, browser Opus TX frames will be dropped
```

Nothing carried that fact to the browser. The client kept emitting Opus, and
every frame hit the fail-closed guard in `_handle_tx_audio`
(`action=dropped_no_transcoder`). The lease was taken, the radio keyed, and
**no modulation reached the air** — 151 dropped frames in the owner-present
IC-7300 session that produced MOR-1783. The operator's only clue was
`TX FAULT: audio-timeout`, a symptom with no path back to the cause.

`tx-mic.ts` already implemented a complete PCM16 capture path. The capability
existed; it was simply never selected.

## Design: negotiate on the channel that already exists

**Server** (`web/handlers/audio.py`) — one additive ack per armed TX start,
the TX mirror of the RX-side `audio_format` ack from MOR-584:

```json
{"type": "audio_tx_format", "codec": "pcm16", "opus_decode": false, "sample_rate": 48000}
```

`opus_decode` is the exact fact the server already logs: whether a browser
Opus frame can be decoded at all on the radio's PCM TX leg. It is
`facts.codec != PCM16 or _ensure_tx_transcoder()` — so an Opus-native radio,
where the server forwards Opus un-decoded, correctly still advertises `opus`.
The ack is sent only after the arm succeeds; a denied TX start advertises
nothing.

**Client** (`audio-manager.ts`, `tx-mic.ts`) — the audio WS `onmessage`
handler previously discarded everything that was not an `ArrayBuffer`. It now
also parses text frames and acts on `audio_tx_format` only.
`TxMic.applyServerCodec('pcm16')` tears down the WebCodecs encoder leg and
starts the **existing** `startPcmFallback()` on the **same MediaStream** — no
second permission prompt, no second capture path, no new transport. The pin
is sticky across start/stop, so every later PTT opens on PCM16 from frame #1.
`'opus'` restores the default and never disturbs a running capture.

**Operator indication** (`StatusBar.svelte`, `stores/audio.svelte.ts`) — a
small `PCM16` chip beside the audio indicator, in the yellow "degraded" tone
rather than the red fault tone, with a tooltip naming the cause and stating
that transmission is working. No modal, no blocking fault, no toast: this is
a working state. Localized in `en-US` and `ru-RU`; the `TX` glossary token is
preserved in both per `i18n-check`.

### Compatibility

Nothing is versioned and nothing is removed. An older client against a new
server ignores the text frame exactly as it did before. A new client against
an older server never receives one and keeps Opus. Both directions are the
pre-change behavior.

### Invariants held

* **Fail-closed unchanged.** An Opus frame with no decoder is still dropped
  per frame and never reported as delivered — asserted, not assumed.
* **Gates untouched.** The TX eligibility check and the MOR-580 session lease
  path are not modified; a missing decoder still never denies the session
  (MOR-1173).
* **Decoder-available path is byte-identical.** `pcm16Pinned` stays false,
  `applyServerCodec('opus')` is a no-op, and nothing new renders in the UI.

## Test evidence

Tests inject decoder availability by stubbing `_ensure_tx_transcoder` rather
than discovering it, so both branches run identically whether or not libopus
exists on the machine. (It *is* present on the machine that ran these gates,
which is exactly why the injection matters.)

New backend suite `tests/test_web_audio_tx_codec_negotiation.py` (5 tests):
advertises `pcm16`/`opus` on the two branches; PCM16 frames reach the radio
with zero drop warnings; Opus frames stay fail-closed; no ack on an
unavailable TX start. Both negotiation tests were confirmed red before the
server change (`2 failed, 3 passed` — the 3 invariant tests passed on the
unmodified code, as they should).

New frontend suite `tx-codec-negotiation.isolated.test.ts` (7 tests) drives
the **real** `TxMic` rather than a stand-in: fallback indication raised and
cleared; unrelated and malformed text frames ignored; live Opus→PCM16 switch
verified down to the emitted frame header (`getUint8(1) === CODEC_PCM16`,
`byteLength === AUDIO_HEADER_SIZE + 960*2`) with `getUserMedia` called exactly
once and `track.stop()` never called; later sessions open on PCM16 without
reconfiguring the encoder; `'opus'` leaves a working capture alone. Falsified
against the unmodified frontend: **7 failed, 0 passed**.

`tests/test_handlers_coverage.py::test_transcoder_failure_arms_tx_and_drops_only_opus_frames`
asserted `ws.send_text.assert_not_awaited()` — it had codified "the client is
never told", which is the defect. It now asserts exactly one `audio_tx_format`
ack naming `pcm16` and no error envelope.

### Gate output

| Gate | Result |
|---|---|
| `uv run pytest tests/ -q` | `10384 passed, 69 skipped, 5 deselected, 14 xfailed, 1 xpassed`, 4 failed → 1 was the assertion above (fixed, re-run green), 3 are pre-existing integration failures |
| `uv run ruff check src/ tests/` | `All checks passed!` |
| `uv run ruff format --check` | `676 files already formatted` |
| `uv run mypy src/` | `Found 12 errors in 3 files` — byte-identical at the base commit |
| `uv run lint-imports` | `Contracts: 5 kept, 0 broken.` |
| `npm run test` | `Test Files 367 passed (367) · Tests 8059 passed (8059)` |
| `npm run lint` | clean |
| `npm run check` | `4600 FILES 0 ERRORS 0 WARNINGS` |
| `npm run i18n:check` | `OK (3 locale file(s) checked, 256 source keys)` |

The 3 integration failures (`test_rigctld_wsjtx_replay_drives_data2_lan_tx_audio_pipeline`,
`test_fldigi_dual_rx_golden_replay`, `test_split_enable_routes_tx_to_sub_receiver`)
and all 12 mypy errors were reproduced in a **clean detached worktree at the
base commit** `f8f717d6` — not inferred from a stash. They are excluded from
quick CI.

## Scope note for the reviewer

This exceeds the 3-file guardrail: **7 production files, ~155 net production
lines** (582 net including 427 lines of new tests). The owner decision on
MOR-1783 is explicit that the automatic switch and the operator indication
ship together — "silent switching alone was rejected because it hides a
misconfiguration indefinitely" — so the natural backend/frontend or
switch/indicate split would ship the half that was named and rejected. The
indication chain is irreducible under the frontend layering rules: store →
status-bar consumer → two locale catalogs. Flagging it rather than hiding it;
happy to split if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
