### PR TITLE
feat(MOR-1879): gate Web ptt_on at the server TX interlock

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -224,6 +224,7 @@ class CommandService:
         timed_out: bool = False,
         source: CommandSource | None = None,
         session_id: str | None | object = _UNSET,
+        details: Mapping[str, Any] | None = None,
     ) -> bool:
         """Mark a previously acknowledged command as failed and expire overlays."""
 
@@ -266,6 +267,7 @@ class CommandService:
             ),
             "timed_out" if timed_out else "failed",
             message=message,
+            details=details,
         )
         return True
 

--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
+from rigplane.core.exceptions import CommandError
 from rigplane.core.tx_interlock_contract import (
     TX_INTERLOCK_COMMAND_FAMILY_METADATA,
     TxInterlockCommandFamily,
@@ -74,6 +75,20 @@ _METADATA_BY_FAMILY = {
 TxInterlockDispositionOverrides = Mapping[
     TxInterlockCommandFamily, TxInterlockDisposition
 ]
+
+
+class TxInterlockRefusal(CommandError):
+    """Interlock refusal carrying a machine-readable reason for the issuer.
+
+    Lives beside the policy it reports rather than at a seat that raises it:
+    the reason codes are policy vocabulary, and every enforcement seat may
+    need them. ``reason_code`` rides the failed-lifecycle details whitelist so
+    a localized UI never has to parse English prose off the wire (MOR-1879).
+    """
+
+    def __init__(self, message: str, *, reason_code: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
 
 
 class RfState(StrEnum):

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -116,6 +116,7 @@ from ..runtime.tx_interlock import (
     TxInterlockCommandFamily,
     TxInterlockDeferredOutcome,
     TxInterlockDisposition,
+    TxInterlockRefusal,
     evaluate_tx_interlock,
     get_tx_interlock_command_family_metadata,
 )
@@ -219,7 +220,12 @@ _WEB_IMMEDIATE_BLOCK_FAMILIES = (
     TxInterlockCommandFamily.SCAN_START,
     TxInterlockCommandFamily.ANTENNA_SWITCH,
     TxInterlockCommandFamily.TUNER_ENGAGE,
+    # MOR-1879 (MOR-1500 slice 1, owner re-ruling 2026-08-17): Web ptt_on
+    # passes the server interlock on equal terms. On an unmanaged rig the
+    # browser reducer was the only RF gate on this path.
+    TxInterlockCommandFamily.PTT_ON,
 )
+
 
 # Fallback for the derived tx_target field's own freshness TTL when a
 # profile has no [state_acquisition] block at all (MOR-1496 review R3, F1
@@ -746,9 +752,17 @@ class RadioPoller:
             and metadata.base_disposition is not TxInterlockDisposition.DEFER
         ):
             return
-        decision = evaluate_tx_interlock(cmd, rf_state=self._current_rf_state())
+        rf_state = self._current_rf_state()
+        decision = evaluate_tx_interlock(cmd, rf_state=rf_state)
         if not decision.allowed:
-            raise CommandError(decision.reason)
+            raise TxInterlockRefusal(
+                decision.reason,
+                reason_code=(
+                    "radio_transmitting"
+                    if rf_state is RfState.TX
+                    else "rf_state_unknown"
+                ),
+            )
 
     @staticmethod
     def _deferred_intent(entry: CommandQueueEntry) -> CommandIntent | None:
@@ -968,6 +982,11 @@ class RadioPoller:
         }
         if entry.source is not None:
             params["source"] = entry.source
+        if isinstance(exc, TxInterlockRefusal):
+            params["details"] = {
+                "blockedBy": "tx_interlock",
+                "reason": exc.reason_code,
+            }
         entry.command_service.fail_command(
             entry.command_id,
             **params,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2158,6 +2158,33 @@ class WebServer:
                 "revision": revision,
                 "observationSeq": observation_seq,
             }
+        elif event.state == "failed" and set(details) == {
+            "session_id",
+            "blockedBy",
+            "reason",
+        }:
+            # MOR-1879: a TX-interlock refusal reaches its issuer machine-
+            # readably; the reason codes map onto the existing i18n keys
+            # (core.rxTx.blocked.rfStateUnknown / radioTransmitting).
+            # Rebuilt from literals, never passed through: the membership test
+            # is ``__eq__``-based, so an object merely EQUAL to a known code
+            # would otherwise ride onto the wire — the same doctrine as the
+            # ``type(x) is int`` checks in the sibling branches above.
+            reason = details.get("reason")
+            if details.get("blockedBy") != "tx_interlock" or type(reason) is not str:
+                return False
+            if reason == "rf_state_unknown":
+                public_details = {
+                    "blockedBy": "tx_interlock",
+                    "reason": "rf_state_unknown",
+                }
+            elif reason == "radio_transmitting":
+                public_details = {
+                    "blockedBy": "tx_interlock",
+                    "reason": "radio_transmitting",
+                }
+            else:
+                return False
         elif set(details) != {"session_id"}:
             return False
         acknowledged = any(

--- a/tests/test_audio_rx_tx_transition.py
+++ b/tests/test_audio_rx_tx_transition.py
@@ -40,6 +40,11 @@ from rigplane.web.radio_poller import (
     _should_restart_rx,
 )
 
+# MOR-1879: this suite drives PTT dispatch directly; the interlock seat at
+# ``_execute`` now gates ptt_on too, so the RF premise (radio observed in
+# RX before keying) is stated once here — see the conftest fixture.
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 def _make_audio_capable_radio() -> SimpleNamespace:
     """Create stub radio with audio capabilities.

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -5145,6 +5145,9 @@ def _keyed(supervisor: _Supervisor | None) -> tuple[RadioPoller, _Radio, Command
     """A poller on a test-scale bound, its real loop running, PTT ON queued."""
     poller, radio, queue = _tx_poller(supervisor)
     poller._max_key_down_seconds = _BACKSTOP  # noqa: SLF001
+    # MOR-1879: the key itself now passes the server RF gate, so the scenario's
+    # premise — a rig observed in RX that then gets keyed — is stated explicitly.
+    _seed_fresh_rx(poller)
     poller.start()
     queue.put(PttOn(), source="websocket", session_id="ws-1")
     return poller, radio, queue

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from rigplane.capabilities import CAP_ANTENNA, CAP_POWER_CONTROL, CAP_TUNER
+from rigplane.capabilities import CAP_ANTENNA, CAP_AUDIO, CAP_POWER_CONTROL, CAP_TUNER
 from rigplane.core.command_service import CommandExecutionResult, CommandService
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
@@ -18,6 +18,7 @@ from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.runtime._poller_types import (
     PttOff,
+    PttOn,
     ScanStart,
     ScanStop,
     SelectVfo,
@@ -27,7 +28,20 @@ from rigplane.runtime._poller_types import (
     SetPowerstat,
     SetTunerStatus,
 )
-from rigplane.web.radio_poller import CommandQueue, CommandQueueEntry, RadioPoller
+from rigplane.runtime.tx_interlock import (
+    RfState,
+    TxInterlockCommandFamily,
+    TxInterlockDisposition,
+    evaluate_tx_interlock,
+    get_tx_interlock_command_family_metadata,
+)
+from rigplane.web.radio_poller import (
+    _WEB_IMMEDIATE_BLOCK_FAMILIES,
+    CommandQueue,
+    CommandQueueEntry,
+    RadioPoller,
+    TxInterlockRefusal,
+)
 
 
 _PTT = FieldPath.global_("tx_state", "ptt")
@@ -441,3 +455,128 @@ async def test_teardown_drain_unkey_stays_outside_the_execute_seat() -> None:
     await poller.drain_tx_safety_commands(timeout=1.0)
 
     radio.set_ptt.assert_awaited_once_with(False)
+
+
+# ── MOR-1879 (MOR-1500 slice 1): Web ptt_on is server-gated ──────────────────
+
+
+def test_ptt_on_is_a_web_immediate_block_family() -> None:
+    assert TxInterlockCommandFamily.PTT_ON in _WEB_IMMEDIATE_BLOCK_FAMILIES
+
+
+def test_web_and_yaesu_seats_share_the_ptt_on_block_policy() -> None:
+    metadata = get_tx_interlock_command_family_metadata(PttOn())
+    assert metadata is not None
+    assert metadata.family is TxInterlockCommandFamily.PTT_ON
+    assert metadata.base_disposition is TxInterlockDisposition.BLOCK
+    for rf in (RfState.UNKNOWN, RfState.TX):
+        assert evaluate_tx_interlock(PttOn(), rf_state=rf).allowed is False
+    assert evaluate_tx_interlock(PttOn(), rf_state=RfState.RX).allowed is True
+
+
+@pytest.mark.parametrize(
+    ("ptt", "reason", "code"),
+    (
+        (
+            None,
+            "RF state is unknown; this command must not be attempted yet.",
+            "rf_state_unknown",
+        ),
+        (True, "RF state is TX; command is blocked.", "radio_transmitting"),
+    ),
+    ids=("unknown", "tx"),
+)
+async def test_ptt_on_refused_fail_closed_leaves_no_armed_audio_leg(
+    ptt: bool | None, reason: str, code: str
+) -> None:
+    radio, store = _radio(), StateStore()
+    radio.capabilities.add(CAP_AUDIO)
+    radio.start_tx = AsyncMock()
+    radio.stop_tx = AsyncMock()
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    if ptt is not None:
+        _observe_ptt(store, ptt)
+
+    with pytest.raises(TxInterlockRefusal) as excinfo:
+        await _dispatch(poller, PttOn())
+
+    assert str(excinfo.value) == reason
+    assert excinfo.value.reason_code == code
+    radio.set_ptt.assert_not_awaited()
+    # Design-doc R7: the refusal precedes the audio-leg arm entirely — nothing
+    # was armed, so nothing needed disarming.
+    radio.start_tx.assert_not_awaited()
+    radio.stop_tx.assert_not_awaited()
+
+
+async def test_ptt_on_dispatches_in_fresh_rx() -> None:
+    poller, radio, store = _poller()
+    _observe_ptt(store, False)
+
+    await _dispatch(poller, PttOn())
+
+    radio.set_ptt.assert_awaited_once_with(True)
+
+
+@pytest.mark.parametrize("ptt", (None, True), ids=("unknown", "tx"))
+async def test_ptt_off_always_attempts_even_with_corrupted_family_table(
+    monkeypatch: pytest.MonkeyPatch, ptt: bool | None
+) -> None:
+    poller, radio, store = _poller()
+    if ptt is not None:
+        _observe_ptt(store, ptt)
+    corrupt = get_tx_interlock_command_family_metadata(PttOn())
+    assert corrupt is not None
+    monkeypatch.setattr(
+        "rigplane.web.radio_poller.get_tx_interlock_command_family_metadata",
+        lambda _cmd: corrupt,
+    )
+
+    await _dispatch(poller, PttOff())
+
+    radio.set_ptt.assert_awaited_once_with(False)
+
+
+async def test_refused_ptt_on_emits_machine_readable_failed_lifecycle() -> None:
+    clock = FreshnessClock(start=10.0)
+    radio, store = _radio(), StateStore(freshness_clock=clock)
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    service = _service(clock, store)
+    await service.execute(
+        CommandIntent(
+            id="ptt-refused",
+            name="ptt_on",
+            params={"session_id": "ws-a"},
+            source="websocket",
+            target=None,
+            timeout=3.0,
+            pending_policy="none",
+            expected_observations=(),
+        )
+    )
+    entry = CommandQueueEntry(
+        PttOn(),
+        future=asyncio.get_running_loop().create_future(),
+        command_id="ptt-refused",
+        source="websocket",
+        session_id="ws-a",
+        command_service=service,
+    )
+
+    with pytest.raises(TxInterlockRefusal) as excinfo:
+        await poller._execute_queued_entry(entry)  # noqa: SLF001
+    poller._mark_queued_command_failed(entry, excinfo.value)  # noqa: SLF001
+
+    event = service.lifecycle_events()[-1]
+    assert event.state == "failed"
+    assert event.details == {
+        "session_id": "ws-a",
+        "blockedBy": "tx_interlock",
+        "reason": "rf_state_unknown",
+    }
+    assert event.message == (
+        "RF state is unknown; this command must not be attempted yet."
+    )
+    radio.set_ptt.assert_not_awaited()

--- a/tests/test_web_managed_tx_owner.py
+++ b/tests/test_web_managed_tx_owner.py
@@ -71,6 +71,11 @@ from rigplane.web import radio_poller as radio_poller_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
+# MOR-1879: this suite drives PTT dispatch directly; the interlock seat at
+# ``_execute`` now gates ptt_on too, so the RF premise (radio observed in
+# RX before keying) is stated once here — see the conftest fixture.
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 _KEY, _TEARDOWN = ["start_tx", "set_ptt(True)"], ["stop_tx", "restart_rx"]
 _WS1, _WS2 = TxOwner(TxSource.WEBSOCKET, "ws-1"), TxOwner(TxSource.WEBSOCKET, "ws-2")
 

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -25,6 +25,7 @@ from rigplane.profiles import resolve_radio_profile
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
+
 _MOD_COMMANDS = (
     "set_data_off_mod_input",
     "set_data1_mod_input",
@@ -445,6 +446,41 @@ class TestKeyerAttributedTeardown:
         ]
         return handlers, command_queue, poller, radio
 
+    @classmethod
+    async def _key(cls, poller: RadioPoller, session_id: str) -> None:
+        """Key the rig the way an operator does: observed RX, then the write.
+
+        MOR-1879 gates ``ptt_on`` at the interlock seat, so a key request needs
+        a fresh RX observation to pass. The rig is transmitting afterwards, so
+        the TX observation that follows is what the poll loop would report —
+        and it is what keeps the keyer record live for the teardown gate.
+        """
+        cls._observe_ptt(poller, value=False)
+        await poller._execute(PttOn(), source="websocket", session_id=session_id)  # noqa: SLF001
+        cls._observe_ptt(poller, value=True)
+
+    @staticmethod
+    def _observe_ptt(poller: RadioPoller, *, value: bool) -> None:
+        import time as _time
+
+        from rigplane.core.state_pipeline_contracts import (
+            FieldPath,
+            Observation,
+            SourceMetadata,
+        )
+
+        store = poller._state_store  # noqa: SLF001
+        store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=value,
+                source=SourceMetadata(source="poll_response", provider="test"),
+                timestamp_monotonic=_time.monotonic(),
+                max_age=5.0,
+                provider_generation=store.provider_generation,
+            )
+        )
+
     @staticmethod
     def _observe_rx(poller: RadioPoller) -> None:
         import time as _time
@@ -469,7 +505,7 @@ class TestKeyerAttributedTeardown:
 
     async def test_foreign_session_teardown_leaves_the_keyer_on_the_air(self) -> None:
         (a, b), q, poller, radio = self._wired(sessions=("ws-a", "ws-b"))
-        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await self._key(poller, a._session_id)
         radio.set_ptt.assert_awaited_once_with(True)
 
         _teardown(b)
@@ -478,7 +514,7 @@ class TestKeyerAttributedTeardown:
 
     async def test_own_session_teardown_still_unkeys(self) -> None:
         (a, _b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
-        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await self._key(poller, a._session_id)
 
         _teardown(a)
 
@@ -486,7 +522,7 @@ class TestKeyerAttributedTeardown:
 
     async def test_observed_off_voids_the_record_and_restores_the_unkey(self) -> None:
         (a, b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
-        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await self._key(poller, a._session_id)
         self._observe_rx(poller)
 
         _teardown(b)
@@ -502,7 +538,7 @@ class TestKeyerAttributedTeardown:
 
     async def test_ptt_off_write_clears_the_record(self) -> None:
         (a, b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
-        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await self._key(poller, a._session_id)
         await poller._execute(PttOff(), source="websocket", session_id=a._session_id)
 
         _teardown(b)
@@ -511,7 +547,7 @@ class TestKeyerAttributedTeardown:
 
     async def test_operator_unkey_ignores_the_record(self) -> None:
         (a, b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
-        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await self._key(poller, a._session_id)
 
         result = b._enqueue_rc_power("ptt_off", {}, q, b._radio)
 
@@ -529,7 +565,7 @@ class TestKeyerAttributedTeardown:
             )
         )
         poller._managed_tx = lambda source, session: managed  # type: ignore[method-assign]
-        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await self._key(poller, a._session_id)
 
         _teardown(b)
 

--- a/tests/test_web_ptt_arm_failure.py
+++ b/tests/test_web_ptt_arm_failure.py
@@ -36,6 +36,11 @@ from rigplane.core.exceptions import CommandError
 from rigplane.core.tx_safety import TxOutcome
 from rigplane.web.radio_poller import CommandQueue, PttOn, RadioPoller
 
+# MOR-1879: this suite drives PTT dispatch directly; the interlock seat at
+# ``_execute`` now gates ptt_on too, so the RF premise (radio observed in
+# RX before keying) is stated once here — see the conftest fixture.
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 _ARM_FAILED = "TX audio failed to arm"
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -918,6 +918,9 @@ class TestControlChannel:
             await _close_ws(writer)
 
     async def test_command_ptt(self, server: WebServer, mock_radio: MagicMock) -> None:
+        # MOR-1879: keying now passes the server RF gate, so the scenario's
+        # premise — a rig observed in RX — is stated explicitly.
+        _seed_fresh_rx(server.command_state_store)
         host, port = _addr(server)
         reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws")
         try:

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3257,6 +3257,106 @@ async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
     assert bystander_q.empty()
 
 
+class _EqualsReasonCode:
+    """Equal to a known reason code without being one.
+
+    The whitelist's membership test is ``__eq__``-based, so the published
+    payload must be rebuilt from literals rather than passed through — this is
+    the object that rides onto the wire if it ever is not.
+    """
+
+    def __init__(self, code: str) -> None:
+        self._code = code
+
+    def __eq__(self, other: object) -> bool:
+        return other == self._code
+
+    def __hash__(self) -> int:
+        return hash(self._code)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ("rf_state_unknown", "radio_transmitting"))
+async def test_interlock_refusal_reaches_only_its_issuer_machine_readably(
+    reason: str,
+) -> None:
+    """MOR-1879: a failed lifecycle may carry the interlock refusal code."""
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    await _ack_held(srv)
+
+    srv._on_command_lifecycle_event(  # noqa: SLF001
+        _life(
+            state="failed",
+            message="refused by the TX interlock",
+            details={
+                "session_id": "session-issuer",
+                "blockedBy": "tx_interlock",
+                "reason": reason,
+            },
+        )
+    )
+
+    # The pre-existing failure notification still goes out first, unchanged.
+    assert issuer_q.get_nowait()["type"] == "notification"
+    payload = issuer_q.get_nowait()
+    assert payload["type"] == "command_lifecycle"
+    assert payload["state"] == "failed"
+    assert payload["details"] == {"blockedBy": "tx_interlock", "reason": reason}
+    assert issuer_q.empty()
+    assert bystander_q.empty()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "details",
+    (
+        {"session_id": "session-issuer", "blockedBy": "tx_interlock"},
+        {"session_id": "session-issuer", "reason": "rf_state_unknown"},
+        {
+            "session_id": "session-issuer",
+            "blockedBy": "elsewhere",
+            "reason": "rf_state_unknown",
+        },
+        {
+            "session_id": "session-issuer",
+            "blockedBy": "tx_interlock",
+            "reason": "made_up_code",
+        },
+        {
+            "session_id": "session-issuer",
+            "blockedBy": "tx_interlock",
+            "reason": "rf_state_unknown",
+            "extra": 1,
+        },
+        {
+            "session_id": "session-issuer",
+            "blockedBy": "tx_interlock",
+            "reason": _EqualsReasonCode("rf_state_unknown"),
+        },
+    ),
+    ids=(
+        "missing-reason",
+        "missing-blocked-by",
+        "wrong-seat",
+        "unknown-code",
+        "extra-key",
+        "merely-equal-code",
+    ),
+)
+async def test_forged_interlock_refusal_details_are_rejected(
+    details: dict[str, object],
+) -> None:
+    srv = WebServer()
+    issuer_q, bystander_q = _register_two_sessions(srv)
+    await _ack_held(srv)
+
+    srv._on_command_lifecycle_event(_life(state="failed", details=details))  # noqa: SLF001
+
+    assert issuer_q.empty()
+    assert bystander_q.empty()
+
+
 @pytest.mark.asyncio
 async def test_provider_generation_invalidates_only_active_web_commands() -> None:
     srv = WebServer()


### PR DESCRIPTION
# MOR-1879 — MOR-1500 slice 1: server gates Web `ptt_on`

**Slice 1 of the TX beta plan** (Linear design document "TX chain simplification — design pass 2026-08-16", §6, plus the adversarial-review addendum requirements).

**Authority:** the owner re-ruling recorded on MOR-1500 (comment dated 2026-08-17) explicitly supersedes the original "PttOn — already carries its own richer gate stack, no double-judging" exclusion: for unmanaged rigs that "richer gate stack" was the browser-side eligibility reducer reading a delta stream — the mechanism whose freshness defect is MOR-1792. Web `ptt_on` now passes the server-side TX interlock on equal terms with the other immediate-block families.

## What changed

- `src/rigplane/runtime/tx_interlock.py`: new `TxInterlockRefusal(CommandError)` carrying a machine-readable `reason_code` (`rf_state_unknown` / `radio_transmitting`), defined beside the ruleset whose vocabulary its codes are. *(It first landed in `web/radio_poller.py`; review R3 blocked on `quick`'s "Type-check web boundary" step — under `follow_imports = "skip"` plus the `rigplane.web.*` strict override, subclassing an out-of-package symbol trips `disallow_subclassing_any`. Relocating rather than suppressing was the preferred fix.)*
- `src/rigplane/web/radio_poller.py`: `TxInterlockCommandFamily.PTT_ON` added to `_WEB_IMMEDIATE_BLOCK_FAMILIES`; raises the relocated `TxInterlockRefusal`; `_mark_queued_command_failed` forwards it as failed-lifecycle details.
- `src/rigplane/core/command_service.py`: `fail_command` gains an optional `details` pass-through into `emit_lifecycle` (+2 lines).
- `src/rigplane/web/server.py`: `_send_lifecycle` details whitelist gains exactly one new shape — `failed` with `{blockedBy: "tx_interlock", reason: rf_state_unknown|radio_transmitting}` — delivered issuer-only, mapping onto the existing i18n keys `core.rxTx.blocked.rfStateUnknown` / `core.rxTx.blocked.radioTransmitting` (`frontend/src/semantic/rx-tx-surface.ts`). No English prose over the wire into a localized UI; forged/extended shapes are rejected.

## Acceptance evidence (all red-first; collection fails without the src changes)

| Requirement | Test |
| --- | --- |
| Membership assertion | `test_ptt_on_is_a_web_immediate_block_family` |
| PttOn × {RX pass, TX refused, UNKNOWN refused} with exact reasons | `test_ptt_on_refused_fail_closed_leaves_no_armed_audio_leg` (exact reason strings + codes), `test_ptt_on_dispatches_in_fresh_rx` |
| Refusal leaves no armed audio leg (design doc R7) | same test — refusal precedes the arm; `start_tx`/`stop_tx` never awaited |
| PttOff passes under UNKNOWN/TX incl. corrupted table | `test_ptt_off_always_attempts_even_with_corrupted_family_table` (family table corrupted to a BLOCK metadata; structural `_ALWAYS_PASS_TYPES` still passes) |
| Teardown drain unaffected | `test_teardown_drain_delivers_unkey_under_tx` |
| Refusal reaches only the issuer, machine-readably | `test_refused_ptt_on_emits_machine_readable_failed_lifecycle` (poller side); `test_interlock_refusal_reaches_only_its_issuer_machine_readably` + `test_forged_interlock_refusal_details_are_rejected` (server whitelist; bystander session receives nothing) |
| Yaesu seat parity | `test_web_and_yaesu_seats_share_the_ptt_on_block_policy` (shared family metadata + shared `evaluate_tx_interlock`); the Yaesu dispatcher already enforces BLOCK unconditionally (existing `test_yaesu_cat_poller` coverage) |

## File-count disclosure

At head `698df73a`: 4 production files + 8 test files (369 insertions / 10 deletions total), i.e. above the ≤3-file guardrail, disclosed here with the reason. The production surface is small and additive (the refusal type, the family-set entry, a 2-line `details` pass-through, one server whitelist shape); the test breadth is forced, not chosen — widening the blocked family set makes an ungated key impossible, so every suite that keyed without stating an RX premise has to state one now. Several are one-line scenario adaptations seeding a fresh RX observation through each suite's own pre-existing `_seed_fresh_rx` helper. `test_web_mod_input_restore.py` deliberately does **not** take the shared RX premise — it asserts a withhold, so it states its premise per test instead.

## Validation

Numbers below are from the reviewer's run at this exact head (`698df73a`), in a clean worktree with its own `uv sync --all-extras`.

- `uv run pytest tests/ --ignore=tests/integration -n auto`: **10158 passed, 0 failed** (13 skipped, 14 xfailed, 1 xpassed)
- `uv run mypy src/`: 12 errors in 3 files — the known pre-existing baseline, verified identical at base `230fdd04`; zero new
- `uv run mypy --strict src/rigplane/web` (`quick` → "Type-check web boundary"): **Success: no issues found in 26 source files**
- `uv run ruff check` / `ruff format --check`: clean
- `uv run lint-imports`: 5 contracts kept, 0 broken (`web` → `runtime` is a legal downward edge)

## Merge gate — HOLD for bench (design doc R1)

Per the design document, this PR must **not** merge until the owner-present bench measurement on IC-7300: log `_current_rf_state()`-equivalent at ~10 Hz for 5 min idle; ship criterion is zero UNKNOWN outside connect/reconnect windows. The PR is built and ready for independent review; the merge is held for the bench gate.

Slice 2 (the MOR-1792 fix) lands only after this merges and must cite this slice's merge SHA.

