### PR TITLE
fix(MOR-1796): de-key when local TX capture dies mid-transmission

### DIFF
--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -73,6 +73,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({
+    onTxAudioDied: () => () => {},
     startTx: h.start,
     stopLocalAudio: h.stop,
     restoreModAfterConfirmedOff: h.restore,

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../lib/media/media-session', () => ({
 vi.mock('../../../lib/runtime/frontend-runtime', () => ({
   runtime: {
     state: null,
+    onTxAudioDied: () => () => {},
     caps: { scope: true },
     connectionStatus: 'disconnected',
     radioPowerOn: null,

--- a/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
+++ b/frontend/src/lib/audio/__tests__/tx-codec-negotiation.isolated.test.ts
@@ -239,6 +239,29 @@ describe('AudioManager consumes the server TX codec ack', () => {
     expect(await audioManager.startTx()).toContain('sample rate');
   });
 
+  it('notifies onTxAudioDied subscribers exactly on the mid-TX failure path (MOR-1796)', async () => {
+    installMediaGlobals({ contextSampleRate: 44100 });
+    const { audioManager } = await import('../audio-manager');
+    const died: string[] = [];
+    const throwing = () => { died.push('throwing'); throw new Error('faulty subscriber'); };
+    const unsubscribeThrowing = audioManager.onTxAudioDied(throwing);
+    const unsubscribed = audioManager.onTxAudioDied(() => died.push('unsubscribed'));
+    audioManager.onTxAudioDied(() => died.push('kept'));
+    unsubscribed();
+
+    expect(await audioManager.startTx()).toBeNull();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    expect(died).toEqual([]); // a healthy start notifies nobody
+
+    ws.serverText({ type: 'audio_tx_format', codec: 'pcm16', opus_decode: false });
+
+    // The throwing subscriber is isolated; the removed one stays silent.
+    expect(died).toEqual(['throwing', 'kept']);
+    unsubscribeThrowing();
+    unsubscribeThrowing(); // idempotent
+  });
+
   it('leaves the pin alone when the ack names a codec it does not know', async () => {
     installMediaGlobals();
     const { audioManager } = await import('../audio-manager');

--- a/frontend/src/lib/audio/audio-manager.ts
+++ b/frontend/src/lib/audio/audio-manager.ts
@@ -325,6 +325,15 @@ class AudioManager {
 
   private _txCodecFallback = false;
 
+  private txAudioDiedCallbacks = new Set<() => void>();
+
+  /** MOR-1796: notified when mid-transmission TX capture dies and the TX
+   *  audio leg is torn down. The TX controller turns this into a de-key. */
+  onTxAudioDied(callback: () => void): () => void {
+    this.txAudioDiedCallbacks.add(callback);
+    return () => this.txAudioDiedCallbacks.delete(callback);
+  }
+
   private _handleServerMessage(raw: string): void {
     let msg: { type?: unknown; codec?: unknown; opus_decode?: unknown };
     try {
@@ -366,6 +375,14 @@ class AudioManager {
     console.error(`[audio-ws] TX codec switch failed, stopping TX audio: ${reason}`);
     this._setTxCodecFallback(false);
     this.stopTx();
+    // Snapshot + isolate: one throwing subscriber must not starve the rest.
+    for (const callback of [...this.txAudioDiedCallbacks]) {
+      try {
+        callback();
+      } catch (error) {
+        console.error('[audio-ws] TX audio-died subscriber failed', error);
+      }
+    }
   }
 
   private _setTxCodecFallback(active: boolean): void {

--- a/frontend/src/lib/runtime/adapters/tx-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/tx-adapter.ts
@@ -147,5 +147,6 @@ export function getTxAudioControl() {
     startTx,
     stopLocalAudio,
     restoreModAfterConfirmedOff,
+    onTxAudioDied: (callback: () => void) => runtime.onTxAudioDied(callback),
   };
 }

--- a/frontend/src/lib/runtime/frontend-runtime.ts
+++ b/frontend/src/lib/runtime/frontend-runtime.ts
@@ -412,6 +412,11 @@ class FrontendRuntime {
     audioManager.stopTx();
   }
 
+  /** MOR-1796: subscribe to mid-transmission local TX capture death. */
+  onTxAudioDied(callback: () => void): () => void {
+    return audioManager.onTxAudioDied(callback);
+  }
+
   setVolume(v: number): void {
     setVolume(v);
   }

--- a/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies-fault-injection.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies-fault-injection.isolated.test.ts
@@ -11,6 +11,7 @@ vi.mock('$lib/stores/radio.svelte', () => ({ getRadioState: () => h.radio }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({ getCapabilities: () => h.caps }));
 vi.mock('$lib/types/protocol', () => ({ makeCommandId: () => `cmd-${++h.ids}` }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({ getTxAudioControl: () => ({
+  onTxAudioDied: () => () => {},
   startTx: h.start, stopLocalAudio: h.stop, restoreModAfterConfirmedOff: h.restore,
 }) }));
 vi.mock('$lib/transport/ws-client', () => ({

--- a/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies.isolated.test.ts
@@ -10,6 +10,7 @@ vi.mock('$lib/stores/radio.svelte', () => ({ getRadioState: () => h.radio }));
 vi.mock('$lib/stores/capabilities.svelte', () => ({ getCapabilities: () => h.caps }));
 vi.mock('$lib/types/protocol', () => ({ makeCommandId: () => `cmd-${++h.ids}` }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({ getTxAudioControl: () => ({
+  onTxAudioDied: () => () => {},
   startTx: h.start, stopLocalAudio: h.stop, restoreModAfterConfirmedOff: h.restore,
 }) }));
 vi.mock('$lib/transport/ws-client', () => ({

--- a/frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/controller.test.ts
@@ -7,6 +7,7 @@ const eligible: Eligibility = { catPtt: true, browserTxAudio: true, controlLive:
 const start = (): TxEvent => ({ type: 'start', sourceId: 'desktop', leaseId: 'lease', intent: 'momentary', eligibility: eligible, ptt: ptt(false, 1) });
 function harness(audio: Promise<string | null> = Promise.resolve(null), failure: 'off' | 'on' | 'cancel' | 'audio' | 'reentrant' | 'callback-throw' | 10 | 20 | 30 | null = null) {
   const log: string[] = []; const reports: Array<{ command: 'on' | 'off'; report: Parameters<TxControllerDependencies['sendPtt']>[3] }> = [];
+  const audioDied: Array<() => void> = [];
   let id = 0;
   const dependencies: TxControllerDependencies = {
     startAudio: vi.fn(() => { log.push('audio'); if (failure === 'audio') throw new Error('audio'); return audio; }),
@@ -15,12 +16,26 @@ function harness(audio: Promise<string | null> = Promise.resolve(null), failure:
     commandId: vi.fn((command) => `${command}-${++id}`), schedule: vi.fn((callback, delay) => { if (failure === 'callback-throw') { callback(); throw new Error('clock'); } if (delay === failure) throw new Error('clock'); return setTimeout(callback, delay); }),
     cancel: vi.fn((handle) => { clearTimeout(handle as ReturnType<typeof setTimeout>); if (failure === 'cancel') throw new Error('cancel'); }),
     timeoutMs: { 'audio-start': 10, 'on-confirmation': 20, 'off-confirmation': 30 },
+    onAudioDied: vi.fn((callback) => { audioDied.push(callback); return () => {}; }),
   };
-  return { controller: new TxController(1, marker(0), dependencies), dependencies, log, reports };
+  return { controller: new TxController(1, marker(0), dependencies), dependencies, log, reports, audioDied };
 }
 const flush = async () => { await Promise.resolve(); await Promise.resolve(); };
 describe('TxController', () => {
   afterEach(() => vi.useRealTimers());
+  it('routes a mid-lease local audio death to the release path, never without a lease (MOR-1796)', async () => {
+    vi.useFakeTimers(); const h = harness();
+    expect(h.audioDied).toHaveLength(1);
+    h.audioDied[0]();
+    expect(h.controller.snapshot()).toMatchObject({ phase: 'idle', fault: null }); expect(h.log).toEqual([]);
+    h.controller.dispatch(start()); await flush();
+    h.reports[0].report({ outcome: 'sent', eventEpoch: 1, barrier: marker(2) });
+    h.audioDied[0]();
+    expect(h.controller.snapshot()).toMatchObject({ phase: 'releasing', fault: 'audio-failed', pendingOff: { leaseId: 'lease' } });
+    expect(h.log).toEqual(['audio', 'on', 'off', 'stop']);
+    h.audioDied[0]();
+    expect(h.log).toEqual(['audio', 'on', 'off', 'stop']);
+  });
   it('runs audio before one ON and command acknowledgements never create RF truth', async () => {
     vi.useFakeTimers(); const h = harness(); h.controller.dispatch(start()); expect(h.log).toEqual(['audio']);
     await flush(); expect(h.log).toEqual(['audio', 'on']); expect(h.reports.filter((item) => item.command === 'on')).toHaveLength(1);

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-lifecycle-matrix.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-lifecycle-matrix.isolated.test.ts
@@ -55,6 +55,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({
+  onTxAudioDied: () => () => {},
     startTx: h.start,
     stopLocalAudio: h.stop,
     restoreModAfterConfirmedOff: h.restore,

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
@@ -103,6 +103,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({
+  onTxAudioDied: () => () => {},
     startTx: h.start,
     stopLocalAudio: h.stop,
     restoreModAfterConfirmedOff: h.restore,

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-reconnect-dekey-matrix.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-reconnect-dekey-matrix.isolated.test.ts
@@ -65,6 +65,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
   getTxAudioControl: () => ({
+  onTxAudioDied: () => () => {},
     startTx: h.start,
     stopLocalAudio: h.stop,
     restoreModAfterConfirmedOff: h.restore,

--- a/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/model.test.ts
@@ -347,4 +347,40 @@ describe('TX reducer', () => {
     ] as const;
     for (const [state, timer] of timers) for (const patch of [{ leaseId: 'wrong' }, { generation: timer.generation + 1 }, { originalEpoch: 2 }, { eventEpoch: 2 }, { commandId: 'wrong' }]) expect(transition(state, { ...timer, ...patch })).toEqual({ state, effects: [] });
   });
+  it('de-keys through the normal release path when local audio dies mid-lease (MOR-1796)', () => {
+    // Keyed (active): the full release route with the OFF obligation.
+    const keyed = active(); const died = transition(keyed, { type: 'audio-died', guard: keyed.guard!, offCommandId: 'off-died' });
+    expect(types(died)).toEqual(['cancel-timers', 'dispatch-off', 'arm-off-timeout', 'stop-local-audio']);
+    expect(died.state).toMatchObject({ phase: 'releasing', fault: 'audio-failed', txRisk: 'confirmed-on', pendingOff: { commandId: 'off-died', leaseId: 'lease' } });
+    // Keying (key-confirm-pending): same route, risk uncertain.
+    const keying = keyPending(); const diedKeying = transition(keying, { type: 'audio-died', guard: keying.guard!, offCommandId: 'off-died' });
+    expect(types(diedKeying)).toEqual(['cancel-timers', 'dispatch-off', 'arm-off-timeout', 'stop-local-audio']);
+    expect(diedKeying.state).toMatchObject({ phase: 'releasing', fault: 'audio-failed', pendingOff: { commandId: 'off-died' } });
+    // Arming post-audio-ready (ON dispatched, still audio-start-pending): the OFF obligation exists.
+    const pending = start(); const dispatched = transition(pending.state, { type: 'audio-ready', guard: pending.state.guard!, commandId: 'on' });
+    const diedArmed = transition(dispatched.state, { type: 'audio-died', guard: dispatched.state.guard!, offCommandId: 'off-died' });
+    expect(types(diedArmed)).toEqual(['cancel-timers', 'dispatch-off', 'arm-off-timeout', 'stop-local-audio']);
+    expect(diedArmed.state).toMatchObject({ phase: 'releasing', fault: 'audio-failed', pendingOff: { commandId: 'off-died' } });
+    // Arming pre-audio-ready (no key owed): a local failure, no OFF dispatched.
+    const arming = start(); const diedArming = transition(arming.state, { type: 'audio-died', guard: arming.state.guard!, offCommandId: 'off-died' });
+    expect(types(diedArming)).toEqual(['cancel-timers', 'stop-local-audio']);
+    expect(diedArming.state).toMatchObject({ phase: 'failed', fault: 'audio-failed', mayOwnKey: false, pendingOff: null });
+  });
+  it('never de-keys a foreign lease and never disturbs terminal phases on audio-died (MOR-1796)', () => {
+    const keyed = active(); const guard = keyed.guard!;
+    for (const foreign of [{ ...guard, leaseId: 'other' }, { ...guard, generation: guard.generation + 1 }, { ...guard, authorityEpoch: guard.authorityEpoch + 1 }]) {
+      expect(transition(keyed, { type: 'audio-died', guard: foreign, offCommandId: 'off-died' })).toEqual({ state: keyed, effects: [] });
+    }
+    // idle: nothing to release.
+    const idle = initialTxState(1, marker(1));
+    expect(transition(idle, { type: 'audio-died', guard, offCommandId: 'off-died' })).toEqual({ state: idle, effects: [] });
+    // releasing: a late echo must not overwrite the standing obligation or fault.
+    const releasing = transition(keyed, { type: 'release', guard, commandId: 'off' }).state;
+    expect(transition(releasing, { type: 'audio-died', guard: releasing.guard!, offCommandId: 'off-late' })).toEqual({ state: releasing, effects: [] });
+    // failed: the recorded fault survives.
+    const failed = transition(start(initialTxState(1, marker(1)), { eligibility: { ...eligible, catPtt: false } }).state, { type: 'audio-died', guard, offCommandId: 'off-late' });
+    expect(failed.effects).toEqual([]); expect(failed.state.fault).toBe('not-eligible');
+    // malformed offCommandId fails closed.
+    expect(transition(keyed, { type: 'audio-died', guard, offCommandId: 42 as unknown as string })).toEqual({ state: keyed, effects: [] });
+  });
 });

--- a/frontend/src/lib/runtime/tx-controller/browser-dependencies.ts
+++ b/frontend/src/lib/runtime/tx-controller/browser-dependencies.ts
@@ -39,6 +39,7 @@ export function createBrowserTxControllerDependencies() {
       } });
     },
     commandId: () => makeCommandId(),
+    onAudioDied: (callback) => disposed ? noop : track(audio.onTxAudioDied(() => { if (!disposed) callback(); })),
     schedule: (callback, delayMs) => {
       if (disposed) return null;
       let handle: ReturnType<typeof globalThis.setTimeout>;

--- a/frontend/src/lib/runtime/tx-controller/controller.ts
+++ b/frontend/src/lib/runtime/tx-controller/controller.ts
@@ -13,6 +13,9 @@ export interface TxControllerDependencies {
   schedule(callback: () => void, delayMs: number): unknown;
   cancel(handle: unknown): void;
   timeoutMs: Record<Timer, number>;
+  /** MOR-1796: mid-lease local capture death. Optional so pure harnesses need
+   *  no timer plumbing; production wiring subscribes the real audio manager. */
+  onAudioDied?(callback: () => void): () => void;
 }
 const sameGuard = (a: TxGuard, b: TxGuard) =>
   a.leaseId === b.leaseId && a.generation === b.generation && a.authorityEpoch === b.authorityEpoch;
@@ -25,6 +28,14 @@ export class TxController {
   #processing = false;
   constructor(authorityEpoch: number, baseline: PttMarker, private readonly dependencies: TxControllerDependencies) {
     this.#state = initialTxState(authorityEpoch, baseline);
+    // MOR-1796: a death without a lease is not this controller's to act on;
+    // with one, the reducer decides (and its guard check keeps foreign leases
+    // untouchable). Unsubscription rides the dependencies' own disposal.
+    dependencies.onAudioDied?.(() => {
+      const guard = this.#state.guard;
+      if (!guard) return;
+      this.dispatch({ type: 'audio-died', guard, offCommandId: this.dependencies.commandId('off') });
+    });
   }
   snapshot(): TxState { return this.#state; }
   subscribe(listener: (state: TxState) => void): () => void {

--- a/frontend/src/lib/runtime/tx-controller/model.ts
+++ b/frontend/src/lib/runtime/tx-controller/model.ts
@@ -42,6 +42,7 @@ export type TxEvent =
   | ({ type: 'timer-fired'; timer: 'audio-start' | 'on-confirmation' | 'off-confirmation'; commandId: string | null; armRevision: number } & TxCorrelation)
   | ({ type: 'command-result'; command: 'on' | 'off'; outcome: 'sent' | 'ack' | 'response-ok' | 'response-error' | 'transport-error'; commandId: string; barrier: PttMarker | null } & TxCorrelation)
   | { type: 'reset-fault' }
+  | { type: 'audio-died'; guard: TxGuard; offCommandId: string }
   | { type: 'epoch'; epoch: number; baseline: PttMarker; offCommandId: string };
 export type TxTransition = { state: TxState; effects: TxEffect[] };
 export function initialTxState(authorityEpoch: number, baseline: PttMarker): TxState {
@@ -190,6 +191,16 @@ export function transition(state: TxState, event: TxEvent): TxTransition {
   if (event.type === 'fail' && sameGuard(state, event.guard)) {
     if (state.mayOwnKey) return release({ ...state, fault: event.fault }, event.offCommandId);
     return failLocal(state, event.fault);
+  }
+  if (event.type === 'audio-died' && sameGuard(state, event.guard)
+    && (state.phase === 'audio-start-pending' || state.phase === 'key-confirm-pending' || state.phase === 'active')) {
+    // MOR-1796: mid-lease local capture death. With the key owed, de-key
+    // through the normal release path; pre-key it is the same local failure an
+    // arm error is. Releasing/failed are excluded so a late echo can neither
+    // overwrite the standing fault nor disturb an obligation in flight, and
+    // sameGuard means a foreign lease can never be de-keyed from here.
+    if (state.mayOwnKey) return release({ ...state, fault: 'audio-failed' }, event.offCommandId);
+    return failLocal(state, 'audio-failed');
   }
   if (event.type === 'on-sent' && state.onCommandId !== null && state.mayOwnKey && sameGuard(state, event.guard) && state.phase === 'audio-start-pending' && state.onCommandId === event.commandId && event.barrier.authorityEpoch === state.authorityEpoch) {
     return bindOn(state, event.commandId, event.barrier);


### PR DESCRIPTION
# MOR-1796 — de-key when local TX capture dies mid-transmission

**Slice 6 of the TX beta plan** (design document "TX chain simplification — design pass 2026-08-16", §6). Independent of slices 1–2.

## Problem

A mid-transmission local capture death — the concrete instance being the PCM16 fallback start failure after PTT has confirmed (PR #2742) — released the server-side audio leg (`audio_stop` → lease release) but left the radio keyed with a dead modulation source until the operator unkeyed. Found by the independent reviewer of PR #2742.

## What changed (one event, existing seams, no new layer, no new import direction)

- `audio-manager.ts`: `onTxAudioDied(cb)` subscription; `_failTxAudio` notifies subscribers after teardown (snapshot + per-callback exception isolation).
- `frontend-runtime.ts` → `tx-adapter.ts` (`getTxAudioControl`) → `browser-dependencies.ts` (`onAudioDied`, disposed-aware via the existing `track`): the plumbing follows the established runtime-wraps-audio chain.
- `controller.ts`: optional `onAudioDied` dependency; subscribed at construction — death without a lease is ignored; with one, the reducer decides.
- `model.ts`: new `audio-died` event, valid only in `audio-start-pending` / `key-confirm-pending` / `active` (design-doc S1/S2/S3). With the key owed → the normal release path with fault `audio-failed`; pre-key → local failure like an arm error. `releasing`/`failed` excluded so a late echo cannot overwrite a standing fault or disturb an obligation in flight.

## Safety invariants

- A foreign lease can never be de-keyed: the reducer's `sameGuard` check is pinned by tests for mismatched leaseId, generation, and authorityEpoch.
- The existing obligations (pendingOff / modRestore / cleanup) discharge through the unchanged release machinery.
- Zero behavior change while capture stays healthy (healthy-start path notifies nobody, pinned by test).

## Tests (red-first; the reducer suite failed before the model change)

- `model.test.ts`: `audio-died` against every phase — active, key-confirm-pending, audio-start-pending pre/post `audio-ready`, idle, releasing, failed; foreign guard triple; malformed `offCommandId` fails closed.
- `controller.test.ts`: subscription at construction; death while idle → no event, no effects; death while keying → exactly one OFF dispatched then the normal stop; repeat death while releasing → no second OFF.
- `tx-codec-negotiation.isolated.test.ts`: subscribers notified exactly on the mid-TX failure path; unsubscribe idempotent; throwing subscriber isolated; healthy start silent.

## File-count disclosure

6 production files (each 1–11 lines; the seam runs audio-manager → runtime → adapter → dependencies → controller → model) + 3 test files with new coverage + 7 existing test files gained a one-line `onTxAudioDied` stub in their `getTxAudioControl`/runtime mocks. 128 insertions / 1 deletion total.

## Validation

- Full frontend: **8101/8101 tests**, 368 files, all green
- `npm run check`: 0 errors / 0 warnings (4601 files)
- `npm run lint`, `lint:boundaries`, `i18n:check`, production build: clean
