### PR TITLE
fix(MOR-1878): bind keyer identity so teardown releases only its own key

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1315,7 +1315,9 @@ class ControlHandler:
     def _release_ptt_on_teardown(self) -> None:
         """Request best-effort PTT OFF whenever a writable session tears down.
 
-        Unconditional by design (MOR-1013). This release used to be reachable
+        Near-unconditional by design (MOR-1013); MOR-1878 adds exactly one
+        withholding condition — the poller's recorded keyer names a different
+        live session. This release used to be reachable
         only through the MOD-input arm, so a session that keyed the radio but
         never armed a restore disconnected with no unkey enqueued at all and
         stranded the rig in TX. Unkeying is the safe direction, so no session
@@ -1349,6 +1351,27 @@ class ControlHandler:
         queue = getattr(self._server, "command_queue", None)
         if queue is None:
             return
+        # MOR-1878: automated housekeeping releases only its own keyer. The
+        # poller remembers who keyed the unmanaged rig; a different session's
+        # teardown must not drop that transmission mid-over. Every failure of
+        # this consultation (no poller, error) falls through to the unkey —
+        # dropping a transmission is recoverable, a stuck transmitter is not.
+        # Operator-pressed ptt_off never routes through here and stays ungated.
+        poller = getattr(self._server, "_radio_poller", None)
+        if poller is not None:
+            try:
+                permitted = poller.teardown_unkey_permitted(
+                    "websocket", self._session_id
+                )
+            except Exception:
+                permitted = True
+            if not permitted:
+                logger.info(
+                    "control: teardown PTT OFF withheld — another session's "
+                    "key is live (session=%s)",
+                    self._session_id,
+                )
+                return
         try:
             _CommandMetadataQueue(
                 queue,

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -710,6 +710,10 @@ class RadioPoller:
         # connect starts unarmed; overridable for tests.
         self._max_key_down_seconds: float = _MAX_KEY_DOWN_SECONDS
         self._max_key_down_timer: asyncio.TimerHandle | None = None
+        # MOR-1878: identity of the session whose key-ON this poller last wrote
+        # on the unmanaged branch, so automated teardown housekeeping releases
+        # only its own keyer. A single remembered identity, not a lease.
+        self._last_keyer: tuple[CommandSource, str | None] | None = None
         self._deferred_tx_lane = DeferredTxCommandLane()
         self._deferred_tx_entry: CommandQueueEntry | None = None
 
@@ -967,6 +971,27 @@ class RadioPoller:
             entry.command_id,
             **params,
         )
+
+    def teardown_unkey_permitted(
+        self, source: CommandSource, session_id: str | None
+    ) -> bool:
+        """Whether an automated teardown unkey from this session may enqueue.
+
+        MOR-1878: deliberate operator unkeys never consult this — I1 (PTT OFF
+        always attemptable) covers operator action; this gate exists solely so
+        one session's teardown housekeeping cannot drop another session's live
+        transmission on an unmanaged rig. The bias is toward the unkey: no
+        recorded keyer, an observed OFF (nothing left to protect — the stale
+        record is voided), or the keyer itself tearing down all permit it.
+        Only a live record naming a DIFFERENT session withholds it.
+        """
+        keyer = self._last_keyer
+        if keyer is None:
+            return True
+        if self._current_rf_state() is RfState.RX:
+            self._last_keyer = None
+            return True
+        return keyer == (source, session_id)
 
     def _arm_max_key_down(self, source: CommandSource, session_id: str | None) -> None:
         """Bound a key this poller just issued on an unmanaged radio (MOR-1220).
@@ -2430,6 +2455,10 @@ class RadioPoller:
                     # only, so the managed path keeps the supervisor's watchdog
                     # as its single bound and an EXTERNAL key stays untouched.
                     self._arm_max_key_down(command_source, session_id)
+                    # MOR-1878: same placement discipline as the bound above.
+                    # The managed branch records nothing — its lease already
+                    # answers STALE to a non-owner's release.
+                    self._last_keyer = (command_source, session_id)
                 else:
                     transition = await managed.set_ptt(True)
                     if transition.outcome not in _KEY_ACCEPTED:
@@ -2476,6 +2505,10 @@ class RadioPoller:
                     # RAISED left the rig keyed, and must not drop the bound.
                     self._cancel_max_key_down()
                 finally:
+                    # MOR-1878: cleared on the ATTEMPT, not on success — if the
+                    # unkey write raised, the rig may still be keyed and the
+                    # next teardown must be free to send OFF again.
+                    self._last_keyer = None
                     await self._stop_tx_audio_leg()
             case SetPower(level=level, unit=unit):
                 if unit != "raw_255":

--- a/tests/test_web_mod_input_restore.py
+++ b/tests/test_web_mod_input_restore.py
@@ -407,3 +407,130 @@ class TestCommandRouting:
         assert not q.has_commands
         sent: Any = handler._ws.send_text.await_args.args[0]
         assert '"ok":true' in sent and '"armed":false' in sent
+
+
+class TestKeyerAttributedTeardown:
+    """MOR-1878: an automated teardown unkey releases only its own keyer.
+
+    Deliberate operator unkeys never consult the record — I1 (PTT OFF always
+    attemptable) applies to operator action; this gate covers housekeeping only.
+    """
+
+    @staticmethod
+    def _wired(
+        *, sessions: tuple[str, ...]
+    ) -> tuple[list[ControlHandler], CommandQueue, RadioPoller, MagicMock]:
+        from rigplane.core.state_store import StateStore
+
+        command_queue = CommandQueue()
+        radio = MagicMock()
+        radio.profile = resolve_radio_profile(model="IC-7610")
+        radio.capabilities = set(radio.profile.capabilities) - {"audio"}
+        radio.managed_tx = None  # unmanaged: the MOR-1878 path under test
+        radio.set_ptt = AsyncMock()
+        store = StateStore()
+        store.begin_provider_generation()
+        poller = RadioPoller(radio, command_queue, state_store=store)
+        server = SimpleNamespace(command_queue=command_queue, _radio_poller=poller)
+        handlers = [
+            ControlHandler(
+                ws=MagicMock(),
+                radio=radio,
+                server_version="test",
+                radio_model="IC-7610",
+                server=server,
+                session_id=session,
+            )
+            for session in sessions
+        ]
+        return handlers, command_queue, poller, radio
+
+    @staticmethod
+    def _observe_rx(poller: RadioPoller) -> None:
+        import time as _time
+
+        from rigplane.core.state_pipeline_contracts import (
+            FieldPath,
+            Observation,
+            SourceMetadata,
+        )
+
+        store = poller._state_store
+        store.apply(
+            Observation(
+                path=FieldPath.global_("tx_state", "ptt"),
+                value=False,
+                source=SourceMetadata(source="poll_response", provider="test"),
+                timestamp_monotonic=_time.monotonic(),
+                max_age=5.0,
+                provider_generation=store.provider_generation,
+            )
+        )
+
+    async def test_foreign_session_teardown_leaves_the_keyer_on_the_air(self) -> None:
+        (a, b), q, poller, radio = self._wired(sessions=("ws-a", "ws-b"))
+        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        radio.set_ptt.assert_awaited_once_with(True)
+
+        _teardown(b)
+
+        assert q.drain() == []
+
+    async def test_own_session_teardown_still_unkeys(self) -> None:
+        (a, _b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
+        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+
+        _teardown(a)
+
+        assert q.drain() == [PttOff()]
+
+    async def test_observed_off_voids_the_record_and_restores_the_unkey(self) -> None:
+        (a, b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
+        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        self._observe_rx(poller)
+
+        _teardown(b)
+
+        assert q.drain() == [PttOff()]
+
+    async def test_no_recorded_keyer_biases_toward_the_unkey(self) -> None:
+        (_a, b), q, _poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
+
+        _teardown(b)
+
+        assert q.drain() == [PttOff()]
+
+    async def test_ptt_off_write_clears_the_record(self) -> None:
+        (a, b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
+        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+        await poller._execute(PttOff(), source="websocket", session_id=a._session_id)
+
+        _teardown(b)
+
+        assert q.drain() == [PttOff()]
+
+    async def test_operator_unkey_ignores_the_record(self) -> None:
+        (a, b), q, poller, _radio = self._wired(sessions=("ws-a", "ws-b"))
+        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+
+        result = b._enqueue_rc_power("ptt_off", {}, q, b._radio)
+
+        assert result == {}
+        assert q.drain() == [PttOff()]
+
+    async def test_managed_path_records_nothing(self) -> None:
+        (a, b), q, poller, radio = self._wired(sessions=("ws-a", "ws-b"))
+        managed = MagicMock()
+        managed.set_ptt = AsyncMock(
+            return_value=SimpleNamespace(
+                outcome=__import__(
+                    "rigplane.core.tx_safety", fromlist=["TxOutcome"]
+                ).TxOutcome.ACCEPTED
+            )
+        )
+        poller._managed_tx = lambda source, session: managed  # type: ignore[method-assign]
+        await poller._execute(PttOn(), source="websocket", session_id=a._session_id)
+
+        _teardown(b)
+
+        assert q.drain() == [PttOff()]


### PR DESCRIPTION
# MOR-1878 — bind keyer identity: teardown releases only its own key

On unmanaged rigs (every shipped serial/USB Icom backend, incl. the bench IC-7300) a Web control-session teardown enqueued an unconditional `ptt_off`: a phone tab reclaimed by the OS de-keyed the desktop's live transmission mid-over, silently — the MOR-1179 failure shape surviving on the unmanaged path. Identified by the 2026-08-17 adversarial design review as the correct minimal alternative to arming the managed-TX supervisor (MOR-1219, blocked).

## What changed

- `src/rigplane/web/radio_poller.py`: the identity already captured for the MOR-1220 backstop is retained — `_last_keyer = (source, session_id)` recorded when the unmanaged key-ON is written (same placement discipline as the backstop arm: after the write, unmanaged branch only); cleared on any PTT OFF write **attempt** (a failed unkey leaves the rig possibly keyed — the next teardown must be free to fire) and lazily on observed OFF. New query `teardown_unkey_permitted(source, session_id)`.
- `src/rigplane/web/handlers/control.py`: `_release_ptt_on_teardown` consults the poller and withholds its OFF **only** when the record names a different live session. Every failure of the consultation (no poller, exception) falls through to the unkey.

## The heart of the fix (owner-ratified nuance, stated in code comments)

I1 "PTT OFF is always attemptable" applies to **deliberate operator action** — operator-pressed unkeys never route through this gate and stay ungated at every layer. Automated teardown **housekeeping** releases only its own keyer, with the bias toward OFF on any doubt: no recorded keyer, an observed OFF, a stale record, or a failed consultation all still unkey. Dropping a transmission is recoverable; a stuck transmitter is not.

## Acceptance evidence (five rows, red-first — the foreign-session row failed before the fix)

| Row | Test |
| --- | --- |
| A keys; B tears down → no OFF, A stays on the air | `test_foreign_session_teardown_leaves_the_keyer_on_the_air` |
| A keys; A tears down → OFF exactly as today | `test_own_session_teardown_still_unkeys` |
| A keys; record voided by observed OFF → OFF fires (safety bias) | `test_observed_off_voids_the_record_and_restores_the_unkey` |
| Physically keyed / no Web keyer → OFF fires | `test_no_recorded_keyer_biases_toward_the_unkey` |
| Operator-pressed unkey always writes | `test_operator_unkey_ignores_the_record` |

Plus: `test_ptt_off_write_clears_the_record`, `test_managed_path_records_nothing` (managed lease path unchanged — records nothing, teardown unaffected). All 30 pre-existing teardown/mod-restore tests in the file unchanged and green.

## Untouched (guardrails)

MOR-1220 max-key-down backstop; rigctld (per-session release already); managed path; no new state machine, no lease semantics — a single remembered identity with conservative clearing.

## Validation

- `uv run pytest tests/ --ignore=tests/integration`: **10128 passed, 0 failed**
- `uv run mypy src/`: 12 errors in 3 files — the known pre-existing baseline, unchanged
- `uv run ruff check` / `format --check`: clean
- 2 production files + 1 test file; 122 insertions / 21 deletions
