### PR TITLE
fix(MOR-1883): publish exact [controls.rit] domains for Icom/Xiegu profiles

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -826,12 +826,20 @@ display_max = 900
 display_unit = "Hz"
 
 [controls.rit]
+# MOR-1883: exact-form translation of the previously declared range;
+# step 1 from the shared CI-V builder (+/-9999 Hz, 1 Hz BCD).
+mapping = "identity"
 raw_min = -9999
 raw_max = 9999
-raw_center = 0
+raw_step = 1
+raw_origin = 0
 display_min = -9999
 display_max = 9999
+display_step = 1
+display_origin = 0
 display_unit = "Hz"
+quantization = "reject"
+restoration = "exact"
 
 # SWR meter calibration — piecewise-linear lookup from raw 0–255 to SWR ratio.
 # First four points (0=1.0, 48=1.5, 80=2.0, 120=3.0) match the firmware-anchored

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -689,7 +689,11 @@ values = [0, 1, 2]
 labels = { "0" = "OFF", "1" = "SEMI", "2" = "FULL" }
 
 [rit]
-# CI-V 0x21 0x00: wfview RIT Min/Max ±999 (10 Hz BCD steps; same as [controls.rit] raw range)
+# CI-V 0x21 0x00. NOT the operator-facing domain: [controls.rit] is the
+# authority and declares ±9999 Hz in 1 Hz steps (MOR-1883), matching the
+# shared builder commands/system.py::set_rit_frequency and a live 4701 Hz
+# bench write. This wfview-sourced ±999 is kept only as the historical
+# note it always was; nothing in the codebase reads range_hz.
 range_hz = 999
 
 [cw]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1347,12 +1347,23 @@ display_max = 900
 display_unit = "Hz"
 
 [controls.rit]
-raw_min = -999
-raw_max = 999
-raw_center = 0
-display_min = -999
-display_max = 999
+# MOR-1883: exact-form domain (MOR-1730 frontend contract). Range is the
+# shared CI-V builder's +/-9999 Hz in 1 Hz BCD steps (commands/system.py
+# set_rit_frequency), confirmed by a live 4701 Hz write on the bench
+# IC-7300 (2026-08-15) and the Full Manual RIT range of +/-9.999 kHz.
+# The previous legacy +/-999 contradicted all three sources.
+mapping = "identity"
+raw_min = -9999
+raw_max = 9999
+raw_step = 1
+raw_origin = 0
+display_min = -9999
+display_max = 9999
+display_step = 1
+display_origin = 0
 display_unit = "Hz"
+quantization = "reject"
+restoration = "exact"
 
 # SWR meter calibration — piecewise-linear lookup from raw 0–255 to SWR ratio.
 # First four points are firmware-anchored per the IC-7300 CI-V Reference (00=1.0,

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -726,7 +726,9 @@ values = [0, 1, 2]
 labels = { "0" = "OFF", "1" = "SEMI", "2" = "FULL" }
 
 [rit]
-# CI-V 0x21 0x00: ±9.999 kHz in 10 Hz steps
+# CI-V 0x21 0x00: ±9.999 kHz. The operator-facing domain is [controls.rit]
+# (±9999 Hz, 1 Hz steps per the shared CI-V builder, MOR-1883); nothing
+# reads range_hz.
 range_hz = 9999
 
 [cw]

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1381,12 +1381,20 @@ display_max = 900
 display_unit = "Hz"
 
 [controls.rit]
+# MOR-1883: exact-form translation of the previously declared range;
+# step 1 from the shared CI-V builder (+/-9999 Hz, 1 Hz BCD).
+mapping = "identity"
 raw_min = -9999
 raw_max = 9999
-raw_center = 0
+raw_step = 1
+raw_origin = 0
 display_min = -9999
 display_max = 9999
+display_step = 1
+display_origin = 0
 display_unit = "Hz"
+quantization = "reject"
+restoration = "exact"
 
 [meters.s_meter]
 redline_raw = 130

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -156,7 +156,9 @@ values = [0, 1, 2]
 labels = { "0" = "OFF", "1" = "SEMI", "2" = "FULL" }
 
 [rit]
-# CI-V 0x21 0x00: wfview RIT Min/Max ±999 (10 Hz BCD steps; same as [controls.rit] raw range)
+# CI-V 0x21 0x00: wfview RIT Min/Max ±999. [controls.rit] is the operator-
+# facing authority and preserves this same ±999 verbatim (MOR-1883), but
+# in 1 Hz steps per the shared CI-V builder. Nothing reads range_hz.
 range_hz = 999
 
 [cw]

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -857,12 +857,21 @@ display_max = 900
 display_unit = "Hz"
 
 [controls.rit]
+# MOR-1883: exact-form translation of the previously declared range,
+# preserved verbatim (wfview cites RIT Min/Max +/-999; no hardware to
+# verify against, so no new range claim is made here).
+mapping = "identity"
 raw_min = -999
 raw_max = 999
-raw_center = 0
+raw_step = 1
+raw_origin = 0
 display_min = -999
 display_max = 999
+display_step = 1
+display_origin = 0
 display_unit = "Hz"
+quantization = "reject"
+restoration = "exact"
 
 # SWR meter calibration — piecewise-linear lookup from raw 0–255 to SWR ratio.
 # First four points (0=1.0, 48=1.5, 80=2.0, 120=3.0) match the firmware-anchored

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -144,12 +144,20 @@ display_max = 900
 display_unit = "Hz"
 
 [controls.rit]
+# MOR-1883: exact-form translation of the previously declared range;
+# step 1 from the shared CI-V builder (+/-9999 Hz, 1 Hz BCD).
+mapping = "identity"
 raw_min = -9999
 raw_max = 9999
-raw_center = 0
+raw_step = 1
+raw_origin = 0
 display_min = -9999
 display_max = 9999
+display_step = 1
+display_origin = 0
 display_unit = "Hz"
+quantization = "reject"
+restoration = "exact"
 
 [[freq_ranges.ranges]]
 label = "HF"

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -298,12 +298,20 @@ display_max = 1200
 display_unit = "Hz"
 
 [controls.rit]
+# MOR-1883: exact-form translation of the previously declared range;
+# step 1 from the shared CI-V builder (+/-9999 Hz, 1 Hz BCD).
+mapping = "identity"
 raw_min = -9999
 raw_max = 9999
-raw_center = 0
+raw_step = 1
+raw_origin = 0
 display_min = -9999
 display_max = 9999
+display_step = 1
+display_origin = 0
 display_unit = "Hz"
+quantization = "reject"
+restoration = "exact"
 
 # Same HF coverage envelope as X6100 (Xiegu HF/50MHz portables).
 [[freq_ranges.ranges]]

--- a/tests/test_profile_rit_domains.py
+++ b/tests/test_profile_rit_domains.py
@@ -1,0 +1,73 @@
+"""MOR-1883: every declared ``controls.rit`` uses the exact domain form.
+
+Since MOR-1730 the frontend accepts only the exact declaration
+(mapping/raw_step/raw_origin/...); a legacy ``raw_center`` shape validates
+as malformed and fail-closes the RIT/XIT offset control. This register-wide
+guard makes a legacy-shaped declaration a test failure, so no profile can
+silently regress to a disabled slider again.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+RIGS_DIR = Path(__file__).resolve().parents[1] / "rigs"
+_EXACT_KEYS = {
+    "mapping",
+    "raw_min",
+    "raw_max",
+    "raw_step",
+    "raw_origin",
+    "display_min",
+    "display_max",
+    "display_step",
+    "display_origin",
+    "display_unit",
+    "quantization",
+    "restoration",
+}
+
+_RIT_PROFILES = sorted(
+    path.name
+    for path in RIGS_DIR.glob("*.toml")
+    if "rit" in tomllib.loads(path.read_text()).get("controls", {})
+)
+
+
+def test_rit_declarations_exist() -> None:
+    """The guard below must actually be guarding something."""
+    assert _RIT_PROFILES, "no profile declares controls.rit anymore?"
+
+
+@pytest.mark.parametrize("name", _RIT_PROFILES)
+def test_declared_rit_domain_uses_the_exact_form(name: str) -> None:
+    rit = tomllib.loads((RIGS_DIR / name).read_text())["controls"]["rit"]
+    missing = _EXACT_KEYS - set(rit)
+    assert not missing, (
+        f"{name}: controls.rit is missing exact-form keys {sorted(missing)}; "
+        "a legacy raw_center shape fail-closes the RIT/XIT control (MOR-1883)"
+    )
+    assert "raw_center" not in rit, f"{name}: legacy raw_center key present"
+    assert rit["mapping"] in ("identity", "linear", "centered", "lookup")
+    assert isinstance(rit["raw_origin"], int)
+    assert rit["raw_min"] <= rit["raw_origin"] <= rit["raw_max"]
+
+
+def test_ic7300_rit_domain_matches_the_wire_codec() -> None:
+    """The bench radio's range is the CI-V builder's ±9999 Hz, 1 Hz steps.
+
+    Evidence: ``commands/system.py::set_rit_frequency`` validates ±9999 Hz
+    (1 Hz BCD); the owner wrote 4701 Hz to the live IC-7300 on 2026-08-15;
+    the Full Manual gives RIT ±9.999 kHz. The old legacy ±999 contradicted
+    all three.
+    """
+    rit = tomllib.loads((RIGS_DIR / "ic7300.toml").read_text())["controls"]["rit"]
+    assert (rit["raw_min"], rit["raw_max"], rit["raw_step"], rit["raw_origin"]) == (
+        -9999,
+        9999,
+        1,
+        0,
+    )

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1091,24 +1091,32 @@ choices = [
         with pytest.raises(RigLoadError, match="lookup.*mapping"):
             self._load(tmp_path, self._LINEAR + self._LOOKUP_POINTS)
 
-    def test_shipped_legacy_profiles_remain_publicly_shape_compatible(self):
+    # MOR-1883: every profile that declares controls.rit now declares the
+    # exact validated form (the legacy raw_center shape fail-closes the
+    # RIT/XIT control in the MOR-1730 frontend contract).
+    _EXACT_DOMAIN_REGISTER = {
+        "ftx1.toml": {"rit", "nr_level", "manual_notch_freq", "if_shift", "cw_pitch"},
+        "ic705.toml": {"rit"},
+        "ic7300.toml": {"rit"},
+        "ic7610.toml": {"rit"},
+        "ic9700.toml": {"rit"},
+        "x6100.toml": {"rit"},
+        "x6200.toml": {"rit"},
+    }
+
+    def test_shipped_profiles_declare_only_validated_exact_domains(self):
         for path in sorted(
             path for path in RIGS_DIR.glob("*.toml") if not path.name.startswith("_")
         ):
             rig = load_rig(path)
-            if path.name == "ftx1.toml":
-                assert rig._control_domains is not None
-                assert set(rig._control_domains) == {
-                    "rit",
-                    "nr_level",
-                    "manual_notch_freq",
-                    "if_shift",
-                    "cw_pitch",
-                }
-                assert rig.to_profile().controls is not rig.controls
+            expected = self._EXACT_DOMAIN_REGISTER.get(path.name)
+            if expected is None:
+                assert rig._control_domains is None, path.name
+                assert rig.to_profile().controls == rig.controls, path.name
                 continue
-            assert rig._control_domains is None, path.name
-            assert rig.to_profile().controls == rig.controls, path.name
+            assert rig._control_domains is not None, path.name
+            assert set(rig._control_domains) == expected, path.name
+            assert rig.to_profile().controls is not rig.controls, path.name
 
     def test_legacy_control_spec_remains_runtime_callable_with_its_exact_shape(self):
         legacy = ControlSpec(


### PR DESCRIPTION
# MOR-1883 — publish exact `[controls.rit]` domains for Icom/Xiegu profiles

Owner decision 2026-08-17 (MOR-1677 verification finding, fix option "a", before the bench session). Since MOR-1730 the frontend accepts only the exact `[controls.rit]` declaration; every non-FTX-1 profile still published the legacy `raw_center` shape, which `validatedRitDomain` treats as malformed → fail-closed → **the RIT/XIT offset slider is disabled on IC-7300 at main**, where it worked on 2026-08-15.

## What changed (profile data + tests; zero production code)

- Six `[controls.rit]` blocks move from the legacy shape to the exact validated form (mirroring `ftx1.toml`): `ic7300`, `ic705`, `ic7610`, `ic9700`, `x6100`, `x6200`.
- **IC-7300 also corrects its range to ±9999 Hz, step 1.** The legacy ±999 contradicted three sources: the shared CI-V builder (`commands/system.py::set_rit_frequency` validates ±9999 Hz, 1 Hz BCD), the owner's live 4701 Hz write on the bench IC-7300 (2026-08-15, recorded on MOR-1677), and the Full Manual RIT range of ±9.999 kHz.
- **IC-705 / IC-7610 / X6100 / X6200:** verbatim translation of the already-declared ±9999 (step 1 from the shared builder; no new range claims).
- **IC-9700:** verbatim translation of its declared ±999 — wfview-sourced, no hardware to verify against, so deliberately no new range claim (comment in the file says so).
- New register-wide guard `tests/test_profile_rit_domains.py`: any profile declaring `controls.rit` in the legacy shape is a test failure, so no profile can silently regress to a disabled slider; plus the IC-7300 codec-consistency pin.
- `tests/test_rig_loader.py`: the shipped-profiles shape test now expects the exact-domain register (ftx1's five domains + `rit` on the six migrated profiles); the loader validates each block on load.

## File-count disclosure

6 profile data files + 2 test files. Data-driven doctrine: all radio-specific values live in `rigs/*.toml`; the only range CHANGE (IC-7300) is triple-sourced above, everything else is shape translation.

## Structural-audit note (MOR-1865 / audit T3)

This PR deliberately carries its tests in `tests/**` so quick CI runs. The audit's finding stands: a rigs-only PR currently triggers zero CI (quick.yml core filter omits `rigs/**`). The new guard test protects this contract only on PRs that touch `tests/**` — MOR-1865's three-line filter fix is what closes the hole for rigs-only changes.

## Validation

- `uv run pytest tests/ --ignore=tests/integration`: **10137 passed, 0 failed**
- Resolved IC-7300 profile verified: `{'mapping': 'identity', 'raw_min': -9999, 'raw_max': 9999, 'raw_step': 1, 'raw_origin': 0, ...}` — accepted by the frontend's `validatedRitDomain` contract (existing exact-form tests)
- `ruff check` / `format --check`: clean

Bench (consolidated session): IC-7300 RIT slider live again; the FTX-1 `0 → +50 → 0` restore remains MOR-1677's own rerun line.
