### PR TITLE
chore: workflow policy updates from the 2026-08 audit

### DIFF
--- a/.claude/commands/decompose-issue.md
+++ b/.claude/commands/decompose-issue.md
@@ -8,7 +8,7 @@ Break a large issue or epic into atomic, guardrail-compliant tasks.
 
 ## When to use
 
-- Issue exceeds guardrails (>3 files, >200 LOC)
+- Issue exceeds guardrails (>3 files, >400 LOC)
 - Issue is labeled "epic" or contains a task checklist
 - `/scan-issues` identified it as too large for direct execution
 
@@ -30,13 +30,13 @@ Break a large issue or epic into atomic, guardrail-compliant tasks.
 Break into 3–10 tasks. Each task MUST:
 
 - Be independently executable and testable
-- Fit guardrails: ≤3 files, ≤200 LOC, no architecture changes
+- Fit guardrails: ≤3 files, ≤400 LOC, no architecture changes
 - Have a clear expected outcome (not vague)
 - Include estimated files and LOC
 
 Quality checks:
 - No vague tasks ("improve system", "refactor everything")
-- No oversized tasks (>200 LOC)
+- No oversized tasks (>400 LOC)
 - No tightly coupled pairs (task B unusable without task A's uncommitted code)
 - Each task is meaningful on its own (not "rename variable")
 

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -42,7 +42,7 @@ Write `.claude/workflow/refactor-plan.md`:
 - **Risks:** what could break, how to verify it didn't
 - **Rollback:** `git checkout -- <files>` for each step
 
-Guardrails apply: ≤3 files, ≤200 LOC delta, no new abstractions unless explicitly targeted.
+Guardrails apply: ≤3 files, ≤400 LOC delta, no new abstractions unless explicitly targeted.
 
 ### Phase 4: EXECUTE (strict)
 

--- a/.claude/commands/scan-issues.md
+++ b/.claude/commands/scan-issues.md
@@ -29,7 +29,7 @@ Scan open GitHub issues and populate the issue queue with scored candidates.
    - **requires_hardware**: true | false
 
 4. Filter and route:
-   - If issue exceeds guardrails (>3 files, >200 LOC, or labeled "epic") → add to queue with `"status": "needs_decomposition"` and `"reason": "exceeds guardrails — use /decompose-issue N"`
+   - If issue exceeds guardrails (>3 files, >400 LOC, or labeled "epic") → add to queue with `"status": "needs_decomposition"` and `"reason": "exceeds guardrails — use /decompose-issue N"`
    - Otherwise keep if: type is bug OR (type is refactor AND difficulty is low), difficulty is low or medium, requires_hardware is false, score > 0
 
 5. Sort by score descending

--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -49,6 +49,7 @@ Use `.claude/agents/reviewer.md`.
 ### Phase 6: TEST
 Use `.claude/agents/qa.md`.
 - Full test suite, lint, format, type check
+- If HEAD is unchanged since REGCHECK, reuse that full-suite result (do not re-run an identical suite on the same commit) and run only lint, format, and type check
 - If fails → back to EXECUTE (max 2 fix cycles)
 
 ### Phase 7: PR

--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -49,7 +49,7 @@ Use `.claude/agents/reviewer.md`.
 ### Phase 6: TEST
 Use `.claude/agents/qa.md`.
 - Full test suite, lint, format, type check
-- If HEAD is unchanged since REGCHECK, reuse that full-suite result (do not re-run an identical suite on the same commit) and run only lint, format, and type check
+- If the working tree is unchanged since REGCHECK, reuse that full-suite result (do not re-run an identical suite on the same code) and run only lint, format, and type check; any code change after REGCHECK requires a fresh full run
 - If fails → back to EXECUTE (max 2 fix cycles)
 
 ### Phase 7: PR

--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -23,7 +23,7 @@ Use `.claude/agents/planner.md`.
 - Enter Plan Mode first — do NOT start coding
 - Design minimal fix based on research
 - Write plan to `.claude/workflow/plan.md`
-- **STOP if plan violates guardrails** (>3 files, >200 LOC, architecture change)
+- **STOP if plan violates guardrails** (>3 files, >400 LOC, architecture change)
 
 ### Phase 3: EXECUTE
 Use `.claude/agents/executor.md`.
@@ -81,7 +81,7 @@ Use `.claude/agents/qa.md`.
 ## Guardrails (hard limits)
 
 - Max 3 files modified per change
-- Max 200 lines of code added/changed
+- Max 400 lines of code added/changed
 - No architecture changes (no new modules, no protocol changes)
 - No speculative improvements beyond the issue scope
 - Stop immediately if confidence < 0.6 at any phase
@@ -92,4 +92,4 @@ Use `.claude/agents/qa.md`.
 - Missing reproduction steps for a bug
 - Hardware dependency that cannot be mocked
 - Issue requires changes to >3 files
-- Issue requires >200 LOC
+- Issue requires >400 LOC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ When making changes:
 
 - TDD — test first, implement second
 - Batch all fixes, run tests once (not per fix)
-- One full-suite run per HEAD: if the commit is unchanged since the last recorded full run (e.g. REGCHECK), reuse that result — do not re-run an identical suite
+- One full-suite run per tree state: if the code is unchanged since the last recorded full run (e.g. REGCHECK), reuse that result — do not re-run an identical suite
 - Audio tests: `FakeAudioBackend` only — no one-off mocks
 
 ---
@@ -227,7 +227,7 @@ Never skip EXPLORE, REVIEW, or TEST.
 - EXECUTE: implement plan exactly. No extras, no refactors, no scope expansion.
 - REVIEW: independently compare diff against plan. Do not trust EXECUTE assumptions. Reject deviations.
 - TEST: must run after REVIEW, not before. Results must be verified, not assumed.
-- TEST reuses the REGCHECK full-suite result when HEAD is unchanged since REGCHECK; it then runs only ruff + type check + the issue's verification. A new full run is required whenever code changed after REGCHECK.
+- TEST reuses the REGCHECK full-suite result when the working tree is unchanged since REGCHECK; it then runs only ruff (lint + format check) + type check + the issue's verification. A new full run is required whenever code changed after REGCHECK.
 
 Definitions: `.claude/agents/{researcher,planner,executor,reviewer,qa}.md`
 Use subagents for large exploration/review — keep main session lean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ When making changes:
 
 - TDD — test first, implement second
 - Batch all fixes, run tests once (not per fix)
+- One full-suite run per HEAD: if the commit is unchanged since the last recorded full run (e.g. REGCHECK), reuse that result — do not re-run an identical suite
 - Audio tests: `FakeAudioBackend` only — no one-off mocks
 
 ---
@@ -226,6 +227,7 @@ Never skip EXPLORE, REVIEW, or TEST.
 - EXECUTE: implement plan exactly. No extras, no refactors, no scope expansion.
 - REVIEW: independently compare diff against plan. Do not trust EXECUTE assumptions. Reject deviations.
 - TEST: must run after REVIEW, not before. Results must be verified, not assumed.
+- TEST reuses the REGCHECK full-suite result when HEAD is unchanged since REGCHECK; it then runs only ruff + type check + the issue's verification. A new full run is required whenever code changed after REGCHECK.
 
 Definitions: `.claude/agents/{researcher,planner,executor,reviewer,qa}.md`
 Use subagents for large exploration/review — keep main session lean.


### PR DESCRIPTION
## What

Two owner-approved policy updates from the 2026-08 development-workflow audit:

1. **Decomposition guardrail: 200 → 400 LOC.** CLAUDE.md has documented `≤400 LOC` all along, but every enforcing check (`solve-issue`, `scan-issues`, `decompose-issue`, `refactor`) used 200, so the effective threshold disagreed with the documented one and split work into more PRs than intended. All eight enforcement sites across the four command files now say 400 (`grep -rnE '200[ _-]*LOC' .claude/` returns zero hits at head).
2. **Single full-suite run per unchanged tree.** REGCHECK and TEST both demanded a full pytest run although the phase between them (REVIEW) never modifies code. TEST now reuses the REGCHECK result when the working tree is unchanged and re-runs only ruff (lint + format check) and type checks; any code change after REGCHECK still requires a fresh full run.

## Why

Audit measured ~33 merged PRs/day over the last 14 days; a duplicated ~6-minute serial suite per issue and an under-documented 200-LOC split threshold are pure fixed overhead with no quality contribution. Mandatory gates (independent review, REGCHECK, TDD) are unchanged.

## Review history

Independent agent review round 1: BLOCKED — caught the eighth enforcement site (`refactor.md:45`) missed by the audit, plus a reuse-condition loophole ('HEAD unchanged' is trivially true for uncommitted work) and check-list wording drift. All addressed in the follow-up commit.

## Verification

- Docs-only change (`CLAUDE.md` + four `.claude/commands/*.md`); no source touched.
- Full suite at the D1/D2 tree in a clean worktree: 10137 passed, 13 skipped, 14 xfailed, 1 xpassed, 0 failed (118s, `-n auto`); the follow-up commit is md-only on top.
- `ruff check src/ tests/`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
