### PR TITLE
fix(MOR-1884): enforce the TX interlock at _execute with one bootstrap exemption

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -862,7 +862,8 @@ class RadioPoller:
         return ready
 
     async def _execute_queued_entry(self, entry: CommandQueueEntry) -> None:
-        self._enforce_tx_interlock(entry.command)
+        # MOR-1884: the interlock seat lives at the head of ``_execute`` now,
+        # so queued commands and uncommanded internal emits share one seat.
         await self._execute(
             entry.command,
             command_id=entry.command_id,
@@ -2223,7 +2224,18 @@ class RadioPoller:
         source: CommandSource = "websocket",
         session_id: str | None = None,
         command_service: CommandService | None = None,
+        connection_epoch_bootstrap: bool = False,
     ) -> None:
+        # MOR-1884 (MOR-1626 criterion 7): the enforcement seat guards EVERY
+        # write this poller issues — queued commands and uncommanded internal
+        # emits alike. The single exemption is the connection-epoch bootstrap
+        # ``SelectVfo`` in :meth:`establish_vfo_identity`: at connection start
+        # RF is structurally UNKNOWN, and that one ruled write (MOR-1443) is
+        # what makes RF/VFO truth observable at all. Emergency commands need
+        # no exemption — ``_enforce_tx_interlock`` is structurally incapable
+        # of blocking them before any table is consulted.
+        if not connection_epoch_bootstrap:
+            self._enforce_tx_interlock(cmd)
         radio = self._radio
         provider_generation = self._provider_generation()
         _r: Any = radio  # cast for capability methods not on base Radio protocol
@@ -3987,7 +3999,10 @@ class RadioPoller:
             "auto-commanding VFO A once (MOR-1443, receiver=%d)",
             receiver,
         )
-        await self._execute(SelectVfo(vfo="A"))
+        # MOR-1884: the ONE exempted write. RF is structurally UNKNOWN at
+        # connection start, and this ruled bootstrap (MOR-1443) is what makes
+        # identity observable — the seat would otherwise fail it closed forever.
+        await self._execute(SelectVfo(vfo="A"), connection_epoch_bootstrap=True)
 
     def _vfo_identity_paths(self, receiver: int) -> tuple[FieldPath, ...]:
         receiver_id = str(receiver)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,3 +215,29 @@ async def connected_radio(mock_radio: MockIcomRadio) -> AsyncGenerator[IcomRadio
         await radio.connect()
     yield radio
     await radio.disconnect()
+
+
+@pytest.fixture
+def observed_rx_dispatch_premise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """State the RF premise for suites that call ``RadioPoller._execute`` directly.
+
+    MOR-1884 moved the TX-interlock seat to the head of ``_execute`` so that
+    uncommanded internal emits are gated exactly like queued commands. Suites
+    that reach into ``_execute`` to exercise a *dispatch body* therefore have to
+    say what the radio was doing — an un-seeded StateStore reads UNKNOWN, and
+    the seat correctly fails closed on it.
+
+    These suites test dispatch, never the seat: the seat's own matrix (RX pass /
+    TX refuse / UNKNOWN refuse, emergency structural pass, the DEFER lane, the
+    single bootstrap exemption) lives in ``test_radio_poller_tx_interlock.py``.
+    Opt in with ``pytestmark = pytest.mark.usefixtures(...)``; a suite that wants
+    to assert refusal must not use this fixture.
+    """
+    from rigplane.runtime.tx_interlock import RfState
+    from rigplane.web.radio_poller import RadioPoller
+
+    monkeypatch.setattr(
+        RadioPoller,
+        "_current_rf_state",
+        lambda self, snapshot=None: RfState.RX,
+    )

--- a/tests/test_bsr_band_switching.py
+++ b/tests/test_bsr_band_switching.py
@@ -31,6 +31,11 @@ from rigplane.web.radio_poller import (
     SetBand,
 )
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 # ---------------------------------------------------------------------------
 # _civ_expects_response tests

--- a/tests/test_mor1544_digisel_shift_cap.py
+++ b/tests/test_mor1544_digisel_shift_cap.py
@@ -36,6 +36,11 @@ from rigplane.rigctld.state_cache import StateCache
 from rigplane.web.handlers import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetDigiselShift
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -18,6 +18,11 @@ from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetFreq
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 def _make_radio(*, model: str = "IC-7610", active: str = "MAIN") -> MagicMock:
     """A CI-V-capable radio mock: ``send_civ`` is the lane the poller hits.

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -15,6 +15,11 @@ from rigplane.rigctld.state_cache import StateCache
 from rigplane.web.handlers import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetFreq, SetMode
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 def _dual_radio_mock() -> MagicMock:
     profile = resolve_radio_profile(model="IC-7610")

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -44,6 +44,11 @@ from _helpers import freq_response as _freq_response
 from _helpers import mode_response as _mode_response
 from _helpers import wrap_civ_in_udp as _wrap_civ_in_udp
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 # ---------------------------------------------------------------------------
 # Helpers — build fake radio responses as UDP packets wrapping CI-V frames
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -115,6 +115,11 @@ from rigplane.web.web_startup import stop_web_server
 # reuses MOR-1013's harness rather than re-mocking either of them.
 from test_web_managed_tx_owner import _KEY, _TEARDOWN, _poller, _Radio, _Supervisor
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 def _seed_fresh_rx(poller: RadioPoller) -> None:
     """Give queued DEFER fixtures explicit current-provider RX authority."""

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -20,6 +20,7 @@ from rigplane.runtime._poller_types import (
     PttOff,
     ScanStart,
     ScanStop,
+    SelectVfo,
     SendCiv,
     SetAntenna1,
     SetFreq,
@@ -379,3 +380,64 @@ async def test_deferred_replacement_and_expiry_emit_ordered_terminal_truth() -> 
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     assert len(service.lifecycle_events()) == terminal_count
     radio.set_freq.assert_not_awaited()
+
+
+# ── MOR-1884 (MOR-1500 B1-e): the seat guards _execute itself ────────────────
+
+
+@pytest.mark.parametrize("ptt", (None, True), ids=("unknown", "tx"))
+async def test_direct_defer_family_emit_is_refused_at_the_execute_seat(
+    ptt: bool | None,
+) -> None:
+    """An uncommanded internal emit shares the queued commands' seat."""
+    poller, radio, store = _poller()
+    radio.set_vfo_slot = AsyncMock()
+    if ptt is not None:
+        _observe_ptt(store, ptt)
+
+    with pytest.raises(CommandError, match="RF state is (unknown|TX)"):
+        await poller._execute(SelectVfo(vfo="A"))  # noqa: SLF001
+
+    radio.set_vfo_slot.assert_not_awaited()
+
+
+async def test_bootstrap_exemption_passes_the_seat_under_unknown_rf() -> None:
+    """At connection start RF is structurally UNKNOWN; the one exempted write
+    must reach the dispatch body instead of being refused (MOR-1443).
+
+    Discriminated by WHICH failure it hits: the same command without the
+    exemption never leaves the seat ("RF state is unknown"), while the
+    exempted one gets all the way into the SelectVfo dispatch and fails on
+    that command's own readback contract — proof it passed the interlock.
+    """
+    poller, _radio, _store = _poller()
+
+    with pytest.raises(CommandError, match="RF state is unknown"):
+        await poller._execute(SelectVfo(vfo="A"))  # noqa: SLF001
+
+    with pytest.raises(CommandError) as exempted:
+        await poller._execute(  # noqa: SLF001
+            SelectVfo(vfo="A"), connection_epoch_bootstrap=True
+        )
+    assert "RF state" not in str(exempted.value)
+    assert "VFO selection" in str(exempted.value)
+
+
+def test_bootstrap_exemption_has_exactly_one_production_call_site() -> None:
+    from pathlib import Path
+
+    import rigplane.web.radio_poller as radio_poller_module
+
+    source = Path(radio_poller_module.__file__).read_text()
+    assert source.count("connection_epoch_bootstrap=True") == 1
+
+
+async def test_teardown_drain_unkey_stays_outside_the_execute_seat() -> None:
+    """The drain's PttOff is structurally ALWAYS_PASS — no exemption needed."""
+    poller, radio, store = _poller()
+    _observe_ptt(store, True)
+    poller._queue.put(PttOff())  # noqa: SLF001
+
+    await poller.drain_tx_safety_commands(timeout=1.0)
+
+    radio.set_ptt.assert_awaited_once_with(False)

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -21,6 +21,11 @@ from rigplane.types import CivFrame, Mode, bcd_encode
 
 from test_radio import MockTransport, _wrap_civ_in_udp
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_vfo_profile_primitives.py
+++ b/tests/test_vfo_profile_primitives.py
@@ -17,6 +17,11 @@ from rigplane.web.radio_poller import (
     VfoSwap,
 )
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 
 _SUPPORTED = (
     ("IC-705", "ab"),

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -27,6 +27,11 @@ from rigplane.web.radio_poller import (
     SetVoxGain,
 )
 
+# MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
+# dispatch bodies; the interlock seat now lives at its head, so the RF
+# premise is stated once here (see the fixture docstring in conftest.py).
+pytestmark = pytest.mark.usefixtures("observed_rx_dispatch_premise")
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# MOR-1884 — enforce the TX interlock at `_execute`, with one bootstrap exemption

Owner decision 2026-08-17 (option 1 on the MOR-1626 verification finding): close the uncommanded-emit bypass properly rather than record an exemption-by-design.

## The defect

The B1 seat was **queue-only**: `_enforce_tx_interlock` ran inside `_execute_queued_entry`, while `_execute` itself had no interlock at its head. So `establish_vfo_identity`'s `await self._execute(SelectVfo("A"))` — a **DEFER-family** write, issued at poll-loop startup and on soft-reconnect — reached the radio with no interlock at all. Live on the bench IC-7300 (`[vfo] readback = "selected_unselected"`).

This contradicted MOR-1626's own Outcome ("the first action of Web RadioPoller`._execute` so queued Web commands **and uncommanded internal emits** share one enforcement seat"), its red-first witness ("auto-emitted writes bypass any queue-only gate"), and the MOR-1500 owner ruleset §9. The planned B1-d "uncommanded emits" leg shipped only its shutdown/cancellation and confirmation halves.

## The fix

- The seat moves to the head of `_execute`; `_execute_queued_entry` no longer calls it separately. One seat, both doors.
- One keyword-only exemption, `connection_epoch_bootstrap=True`, used at **exactly one production call site**: the `SelectVfo` in `establish_vfo_identity`. Rationale in code: at connection start RF is structurally UNKNOWN, and that one ruled write (MOR-1443) is what makes RF/VFO truth observable at all — the seat would otherwise fail it closed forever and break VFO-identity establishment.
- Emergency commands need no exemption: `_ALWAYS_PASS_TYPES` is consulted before any disruptive table, so `PttOff` (including the teardown drain's) passes structurally on every path.

## Acceptance evidence (red-first; the new tests fail on base)

| Requirement | Test |
| --- | --- |
| Direct (non-queued) DEFER emit refused under TX and under UNKNOWN | `test_direct_defer_family_emit_is_refused_at_the_execute_seat` (both cases, `set_vfo_slot` never awaited) |
| The bootstrap exemption passes the seat under UNKNOWN RF | `test_bootstrap_exemption_passes_the_seat_under_unknown_rf` — discriminated by *which* failure: without the exemption it never leaves the seat ("RF state is unknown"); with it, it reaches the `SelectVfo` dispatch body and fails on that command's own readback contract |
| The exemption has exactly one production call site | `test_bootstrap_exemption_has_exactly_one_production_call_site` (source-level pin) |
| Teardown drain unaffected | `test_teardown_drain_unkey_stays_outside_the_execute_seat` |
| Queued-path behavior unchanged | the full pre-existing B1 battery (block matrix, DEFER lane TTL/quiet-window/supersession, emergency corrupted-table, machine-readable refusal) stays green |

## File-count disclosure (guardrail exceeded, deliberately)

1 production file + 11 test files = 12. The ticket's guardrail is ≤3, so the excess is disclosed rather than silently taken:

- `src/rigplane/web/radio_poller.py` — the seat move + the one exemption (production).
- `tests/test_radio_poller_tx_interlock.py` — the four new acceptance tests.
- `tests/conftest.py` — one new opt-in fixture, `observed_rx_dispatch_premise`.
- **Nine suites × 4 lines each** (`test_radio_poller_coverage`, `test_bsr_band_switching`, `test_vox_tone_state`, `test_vfo_profile_primitives`, `test_mor1544_digisel_shift_cap`, `test_poller_poll_priority`, `test_profiles_routing`, `test_radio`, `test_selected_freq_mode`) — a `pytestmark = pytest.mark.usefixtures(...)` line plus a three-line comment.

**Why a fixture and not per-call seeding:** these suites reach into `_execute` to exercise *dispatch bodies*, and they build pollers inline — 164 constructions in `test_radio_poller_coverage.py` alone. Seeding at each call site would be a ~180-site diff with no added signal. The fixture states the premise once per suite ("the radio is observed in RX") and is documented as opt-in: **a suite that wants to assert refusal must not use it**, and none of these nine assert refusal (verified: zero occurrences of "RF state is" in them). The seat's own matrix — RX pass / TX refuse / UNKNOWN refuse, emergency structural pass, DEFER lane, the single exemption — lives entirely in `test_radio_poller_tx_interlock.py`, which does not use the fixture.

## Note for the reviewer

Textually adjacent to held PR #2745 (MOR-1879, `_WEB_IMMEDIATE_BLOCK_FAMILIES` + `TxInterlockRefusal`): different hunks in the same file, whoever lands second rebases. Semantically they compose — #2745 widens *which* families the seat blocks, this PR widens *which writes* reach the seat.

## Validation

- `uv run pytest tests/ --ignore=tests/integration`: **10133 passed, 0 failed**
- `uv run mypy src/`: 12 errors in 3 files — the known pre-existing baseline, unchanged
- `uv run ruff check` / `format --check` / `lint-imports` (5 contracts kept): clean
