### PR TITLE
test(MOR-1885): pin the teardown unkey gate decisions

### DIFF
--- a/tests/test_web_teardown_unkey_gate.py
+++ b/tests/test_web_teardown_unkey_gate.py
@@ -1,0 +1,188 @@
+"""Direct unit tests for ``RadioPoller.teardown_unkey_permitted`` (MOR-1885).
+
+MOR-1878 added the gate as a safety seat deciding whether an automated
+session teardown may enqueue its own ``ptt_off``. Until now it was covered
+only indirectly, through the end-to-end rows in
+``tests/test_web_mod_input_restore.py::TestKeyerAttributedTeardown`` (which
+drive the gate through ``ControlHandler``/``CommandQueue`` plumbing). This
+file pins the gate's own decision table directly, plus the one caller-side
+default (MOR-1878's ``try/except -> permitted=True``) that consumes it.
+
+Test-only ticket: no production code changes.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
+from rigplane.profiles import resolve_radio_profile
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
+
+
+def _poller(
+    *,
+    ptt_on_error: Exception | None = None,
+    ptt_off_error: Exception | None = None,
+) -> tuple[RadioPoller, MagicMock]:
+    """Build a RadioPoller wired to an unmanaged radio (the MOR-1878 path).
+
+    ``ptt_on_error``/``ptt_off_error``, when given, are raised on the
+    matching ``set_ptt(True)``/``set_ptt(False)`` write only, so a test can
+    key the radio successfully and then observe a single failing write (or
+    vice versa) in isolation.
+    """
+    radio = MagicMock()
+    radio.profile = resolve_radio_profile(model="IC-7610")
+    radio.capabilities = set(radio.profile.capabilities) - {"audio"}
+    # Unmanaged: None reads unmanaged on every interpreter, unlike a bare
+    # Mock (runtime-checkable protocols differ 3.11 vs 3.12+, gh-102433).
+    radio.managed_tx = None
+
+    async def set_ptt(on: bool) -> None:
+        error = ptt_on_error if on else ptt_off_error
+        if error is not None:
+            raise error
+
+    radio.set_ptt = AsyncMock(side_effect=set_ptt)
+    store = StateStore()
+    store.begin_provider_generation()
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    return poller, radio
+
+
+def _observe_rx(poller: RadioPoller) -> None:
+    """Apply a fresh PTT=False observation, matching a real RX readback."""
+    store = poller._state_store
+    store.apply(
+        Observation(
+            path=FieldPath.global_("tx_state", "ptt"),
+            value=False,
+            source=SourceMetadata(source="poll_response", provider="test"),
+            timestamp_monotonic=time.monotonic(),
+            max_age=5.0,
+            provider_generation=store.provider_generation,
+        )
+    )
+
+
+def test_no_recorded_keyer_is_permitted() -> None:
+    poller, _radio = _poller()
+
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is True
+
+
+async def test_recorded_keyer_same_session_is_permitted() -> None:
+    poller, _radio = _poller()
+    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+
+    assert poller.teardown_unkey_permitted("websocket", "ws-a") is True
+
+
+async def test_recorded_keyer_different_session_rf_not_rx_is_not_permitted() -> None:
+    poller, _radio = _poller()
+    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+
+    # No RF observation has landed: _current_rf_state resolves UNKNOWN, not
+    # RX, so the foreign session's teardown must be withheld.
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is False
+
+
+async def test_observed_rx_permits_and_voids_the_record_latch() -> None:
+    poller, _radio = _poller()
+    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    _observe_rx(poller)
+
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is True
+    assert poller._last_keyer is None
+
+    # Latch: once voided the record must never be consulted again, so a
+    # later staleness (RF reverting to UNKNOWN) cannot resurrect the
+    # withhold. Proven by never touching the resolver on the second call —
+    # if the void were missing, the still-live keyer would force a second
+    # `_current_rf_state()` lookup here.
+    poller._current_rf_state = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("resolver must not be consulted after void")
+    )
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is True
+
+
+async def test_failed_unmanaged_ptt_off_write_still_clears_the_record() -> None:
+    poller, _radio = _poller(ptt_off_error=RuntimeError("boom"))
+    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    assert poller._last_keyer == ("websocket", "ws-a")
+
+    raised: Exception | None = None
+    try:
+        await poller._execute(PttOff(), source="websocket", session_id="ws-a")
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None, "the raising unkey write must propagate"
+
+    # finally invariant: cleared on the ATTEMPT, not on success, so the
+    # next teardown (even from a different session) is free to send OFF.
+    assert poller._last_keyer is None
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is True
+
+
+async def test_failed_unmanaged_ptt_on_write_leaves_no_phantom_record() -> None:
+    """Record placement after the write: a key that never reached the rig
+    must not arm the withhold against every other session."""
+    poller, _radio = _poller(ptt_on_error=RuntimeError("key never reached the rig"))
+
+    raised: Exception | None = None
+    try:
+        await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None, "the raising key-on write must propagate"
+
+    assert poller._last_keyer is None
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is True
+
+
+async def test_record_is_per_poller_instance_no_leakage() -> None:
+    poller_a, _radio_a = _poller()
+    poller_b, _radio_b = _poller()
+
+    await poller_a._execute(PttOn(), source="websocket", session_id="ws-a")
+
+    # poller_b never recorded anything: its own gate must not see poller_a's
+    # keyer, even for the identical (source, session_id) pair.
+    assert poller_b.teardown_unkey_permitted("websocket", "ws-a") is True
+    # poller_a, meanwhile, still withholds against a foreign session.
+    assert poller_a.teardown_unkey_permitted("websocket", "ws-b") is False
+
+
+def test_control_handler_defaults_to_permitted_when_gate_raises() -> None:
+    """MOR-1878's try/except -> permitted=True default at the caller seat
+    (``ControlHandler._release_ptt_on_teardown``), the one consumer of this
+    gate. Every failure of the consultation — resolver included — must fall
+    through to the unkey: dropping a transmission is recoverable, a stuck
+    transmitter is not."""
+    poller, radio = _poller()
+    poller.teardown_unkey_permitted = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("resolver exploded")
+    )
+    command_queue = CommandQueue()
+    server = SimpleNamespace(command_queue=command_queue, _radio_poller=poller)
+    handler = ControlHandler(
+        ws=MagicMock(),
+        radio=radio,
+        server_version="test",
+        radio_model="IC-7610",
+        server=server,
+        session_id="ws-a",
+    )
+
+    handler._release_ptt_on_teardown()
+
+    assert command_queue.drain() == [PttOff()]

--- a/tests/test_web_teardown_unkey_gate.py
+++ b/tests/test_web_teardown_unkey_gate.py
@@ -155,9 +155,17 @@ async def test_record_is_per_poller_instance_no_leakage() -> None:
 
     await poller_a._execute(PttOn(), source="websocket", session_id="ws-a")
 
-    # poller_b never recorded anything: its own gate must not see poller_a's
-    # keyer, even for the identical (source, session_id) pair.
-    assert poller_b.teardown_unkey_permitted("websocket", "ws-a") is True
+    # Probe poller_b with a THIRD session id, distinct from "ws-a" (the one
+    # poller_a just keyed with). Reusing "ws-a" here would be vacuous: it
+    # returns True under BOTH per-instance semantics (poller_b recorded
+    # nothing, so the no-recorded-keyer branch fires) AND under a leaked
+    # shared record (poller_b would see keyer == ("websocket", "ws-a"),
+    # matching the very session_id being asked about, so the
+    # `keyer == (source, session_id)` branch also returns True). Only a
+    # session id that differs from the recorded keyer's discriminates: it
+    # stays True on isolation (still no recorded keyer) but flips to False
+    # if state leaked (a live foreign-session record would withhold it).
+    assert poller_b.teardown_unkey_permitted("websocket", "ws-z") is True
     # poller_a, meanwhile, still withholds against a foreign session.
     assert poller_a.teardown_unkey_permitted("websocket", "ws-b") is False
 


### PR DESCRIPTION
## What

Adds direct unit test coverage for `RadioPoller.teardown_unkey_permitted`
(`src/rigplane/web/radio_poller.py`, added by MOR-1878) — a safety gate that
decides whether an automated session-teardown may enqueue its own
`ptt_off`. Until now it was covered only indirectly, through the
end-to-end rows in `tests/test_web_mod_input_restore.py::TestKeyerAttributedTeardown`.

New file: `tests/test_web_teardown_unkey_gate.py` (188 lines, 1 file).

**Test-only ticket. Zero production diff** — confirmed by `git diff --stat`
against `origin/main` showing only the new test file.

## Why

The MOR-1878 simplicity audit found that four of the mechanism's six
decisions hold only by reasoning: ablating any one of them individually
left the existing (end-to-end) battery green. This PR adds tests that
directly discriminate each of those four decisions, plus the two
remaining required cases from the gate's own decision table, plus the
`_current_rf_state` "resolver raises" semantics at the one call site that
consumes this gate.

## Coverage added

1. No recorded keyer → permitted.
2. Recorded keyer, same session → permitted.
3. Recorded keyer, different session, RF not RX → NOT permitted.
4. Recorded keyer, different session, observed RX → permitted, and the
   record is voided (latch: proven by asserting the resolver is never
   consulted again on a follow-up call).
5. A failed unmanaged `set_ptt(False)` (raising write) still clears the
   record — the `finally` invariant.
6. A failed unmanaged `set_ptt(True)` (raising write) leaves no phantom
   record — the record-placement-after-the-write invariant.
7. The record is per-poller-instance — no leakage between two pollers.
8. The `try`/`except -> permitted=True` default at the
   `ControlHandler._release_ptt_on_teardown` call site, when the gate
   itself raises.

## Ablation matrix

Each mutation was applied to the actual production line, run against
`tests/test_web_teardown_unkey_gate.py` + `tests/test_web_mod_input_restore.py`
(45 tests total), confirmed to kill exactly the intended new row while
every other test (including the full pre-existing `TestKeyerAttributedTeardown`
battery) stayed green, then reverted. Final `git diff`/`git status` after
all four mutations confirms a clean revert (zero production diff survives).

| # | Decision | Mutation (file:line) | Row killed | Existing battery |
|---|---|---|---|---|
| 1 | record placement after the write | `radio_poller.py`: move `self._last_keyer = (command_source, session_id)` from after `await radio.set_ptt(True)` to before it | `test_failed_unmanaged_ptt_on_write_leaves_no_phantom_record` | stays green (44/44) |
| 2 | clear-in-`finally` | `radio_poller.py`: move `self._last_keyer = None` out of the `PttOff` case's `finally:` block into the success-only path | `test_failed_unmanaged_ptt_off_write_still_clears_the_record` | stays green (44/44) |
| 3 | the lazy RX void | `radio_poller.py`, `teardown_unkey_permitted`: delete `self._last_keyer = None` in the observed-RX branch | `test_observed_rx_permits_and_voids_the_record_latch` | stays green (44/44), including the pre-existing `test_observed_off_voids_the_record_and_restores_the_unkey` |
| 4 | `try/except -> permitted=True` default | `control.py`, `_release_ptt_on_teardown`: flip `permitted = True` to `permitted = False` in the `except Exception:` branch | `test_control_handler_defaults_to_permitted_when_gate_raises` | stays green (44/44) |

Each mutation was applied, tested, and reverted individually — never combined.

## Gate results

All commands run inside a dedicated worktree with its own `uv sync --all-extras`.

| Gate | Result |
|---|---|
| `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` | 10150 passed, 13 skipped, 14 xfailed, 1 xpassed (0 failed) — one `TestCW::test_send_cw_long_text` timeout on the first run was a pre-existing parallel-load flake, unrelated to this diff (CW/CI-V code, untouched here); passed in isolation and on a clean full re-run |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format --check src/ tests/` | 678 files already formatted |
| `uv run mypy src/` | 12 errors in 3 files — matches the documented pre-existing baseline exactly, zero new errors |
| `uv run lint-imports` | 5 contracts kept, 0 broken |
| `uv run rigplane --model IC-7610/X6200/FTX-1 validate --provider native --dry-run --gate ...` | All three golden gates PASS, 0 regressions (quick.yml `core` path filter trips since this diff touches `tests/**`) |

`quick.yml`'s `frontend` path filter (`frontend/**`, `src/rigplane/web/**`,
or the workflow file itself) does not trip for this diff — only
`tests/**` changed — so `mypy --strict src/rigplane/web` is not a required
gate here; it was not run.

## Not done / deliberately out of scope

- No production code changes — this is a test-only ticket per its own
  spec.
- Did not name MOR-1878 or MOR-1629 anywhere in the commit message (they
  are parent tickets; only MOR-1885 is referenced, to avoid Linear
  auto-closing the wrong ticket on merge).
- Independent review not requested by this PR — per project workflow the
  implementation agent never self-reviews.
