### PR TITLE
feat(MOR-1882): truthful rigctld terminal write results

### DIFF
--- a/docs/api/rigctld.md
+++ b/docs/api/rigctld.md
@@ -333,9 +333,11 @@ Behavior details:
   the handler answers `ETIMEOUT` (`RPRT -5`) with no values: the radio never
   replied, so there is no evidence the raw frame was applied. (Before
   MOR-1882 this answered a successful empty response.)
-- A radio that legitimately sends no reply (fire-and-forget frames) still
-  produces a successful empty response — that is a completed write, not a
-  timeout.
+- A backend that returns no response object at all still produces a
+  successful empty response — that is a completed write, not a timeout.
+  On the shipped Icom backend the rigctld path always waits for a reply or
+  an ACK, so in practice that branch belongs to the handler contract rather
+  than to any current backend.
 - If backend does not implement `_send_civ_raw`, returns `ENIMPL` (`RPRT -4`).
 
 ---

--- a/docs/api/rigctld.md
+++ b/docs/api/rigctld.md
@@ -330,7 +330,12 @@ Behavior details:
 
 - If backend exposes `_send_civ_raw`, command forwards bytes as-is.
 - On transport timeout (`rigplane.exceptions.TimeoutError` or `asyncio.TimeoutError`),
-  handler returns **successful empty response** (not `RPRT -5`).
+  the handler answers `ETIMEOUT` (`RPRT -5`) with no values: the radio never
+  replied, so there is no evidence the raw frame was applied. (Before
+  MOR-1882 this answered a successful empty response.)
+- A radio that legitimately sends no reply (fire-and-forget frames) still
+  produces a successful empty response — that is a completed write, not a
+  timeout.
 - If backend does not implement `_send_civ_raw`, returns `ENIMPL` (`RPRT -4`).
 
 ---

--- a/docs/release-notes/2026-beta-known-limitations.md
+++ b/docs/release-notes/2026-beta-known-limitations.md
@@ -83,6 +83,14 @@ that class of defect is release-blocking by definition and is not on this list.
   split-mode dial restore issued right after unkey can be swallowed this
   way, leaving the rig on the transmit-shifted dial frequency. (MOR-1892)
 
+## rigctld raw CI-V (`w`) timeouts
+
+- **A raw `w` frame the radio never answers is now reported as
+  `RPRT -5` (timeout) instead of an empty success.** Nothing is known about
+  whether such a frame was applied, so reporting success was a lie. Clients
+  that treated the old empty success as "sent OK" will now see an error on
+  frames that time out. WSJT-X and fldigi do not use `w`. (MOR-1882)
+
 ## Dual-receiver topology (permanent limitation)
 
 **Dual-receiver hardware certification is permanently out of scope for this

--- a/docs/release-notes/2026-beta-known-limitations.md
+++ b/docs/release-notes/2026-beta-known-limitations.md
@@ -89,7 +89,9 @@ that class of defect is release-blocking by definition and is not on this list.
   `RPRT -5` (timeout) instead of an empty success.** Nothing is known about
   whether such a frame was applied, so reporting success was a lie. Clients
   that treated the old empty success as "sent OK" will now see an error on
-  frames that time out. WSJT-X and fldigi do not use `w`. (MOR-1882)
+  frames that time out. `w` is a raw CI-V escape hatch for diagnostics and
+  advanced tooling, not part of the frequency/mode/PTT command flow a
+  logging or digital-mode client uses for normal operation. (MOR-1882)
 
 ## Dual-receiver topology (permanent limitation)
 

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -25,8 +25,10 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from ..commands import build_civ_frame
 from ..core.acquisition_scheduler import AcquisitionStatus, EnsureFreshResult
 from ..core.command_service import (
+    CommandExecutionInvalidatedError,
     CommandExecutionResult,
     CommandService,
+    CommandServiceResult,
     PendingOverlay,
     command_intent_from_request,
 )
@@ -319,6 +321,32 @@ def _err(code: HamlibError) -> RigctldResponse:
     return RigctldResponse(error=code)
 
 
+def _terminal_lifecycle_state(
+    result: CommandServiceResult, intent: CommandIntent
+) -> str | None:
+    """Return the last lifecycle state recorded for ``intent`` in ``result``."""
+
+    for event in reversed(result.lifecycle_events):
+        if event.command_id == intent.id:
+            return str(event.state)
+    return None
+
+
+# Terminal lifecycle states that are evidence the write was actually carried
+# out: the executor ran to completion and the command was still the live one
+# when it did (``acknowledged``), or a readback has since confirmed it.
+_APPLIED_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {"acknowledged", "confirmed", "reconciled"}
+)
+
+# Truthful Hamlib answers for the terminal states that mean "not applied".
+# Anything not named here is a write whose fate we cannot vouch for, which is
+# reported as a rejection rather than as success.
+_UNAPPLIED_LIFECYCLE_ERRORS: dict[str, HamlibError] = {
+    "timed_out": HamlibError.ETIMEOUT,
+}
+
+
 def _profile_data_mode_count(radio: Any) -> int:
     profile = getattr(radio, "profile", None)
     count = getattr(profile, "data_mode_count", 1)
@@ -505,11 +533,13 @@ class _RigctldCommandExecutor:
             if send_fn is None:
                 raise _RigctldCommandFailure(HamlibError.ENIMPL)
             frame_bytes = params["frame_bytes"]
-            try:
-                resp = await send_fn(frame_bytes)
-            except (RigplaneTimeoutError, TimeoutError, asyncio.TimeoutError):
-                logger.debug("send_raw: timeout — returning empty response")
-                return CommandExecutionResult(details={"values": []})
+            # A timeout here is deliberately NOT swallowed (MOR-1882): the
+            # radio never answered, so there is no evidence the raw frame was
+            # applied. Letting it propagate gives the command a ``timed_out``
+            # terminal lifecycle and the client an ``RPRT -5``, where the old
+            # empty-but-successful response claimed a write that may never
+            # have landed.
+            resp = await send_fn(frame_bytes)
             if resp is None:
                 return CommandExecutionResult(details={"values": []})
             raw = _civ_frame_to_bytes(resp)
@@ -773,6 +803,69 @@ class RigctldHandler:
             intent.name,
         )
         return _ok()
+
+    async def _execute_write(self, intent: CommandIntent) -> CommandServiceResult:
+        """Run one material write and report only the outcome we actually have.
+
+        This seat answers ``RPRT 0`` for a write the radio never saw in
+        exactly one case: the deliberate pre-send policy drop in
+        :meth:`_defer_write_gate` (known TX, MOR-1881's owner ruling). That
+        exception is bounded — it ends the moment the operator unkeys — and it
+        is taken *before* this method is entered, so nothing here can widen
+        it. Any write that gets this far was sent, and its terminal result is
+        reported truthfully (MOR-1882):
+
+        * **Timeout** — ``ETIMEOUT``, with the ``timed_out`` terminal
+          lifecycle :class:`CommandService` emits on the way past.
+        * **Invalidation / supersession** — the backend call completed but
+          this command was no longer the live one when it did (a newer
+          command took its place, the provider generation changed under it,
+          or another seat failed it), so nothing may be claimed about the
+          radio's state. Reported as ``ERJCTED`` rather than as the
+          ``EINTERNAL`` this used to fall through to: it is a real terminal
+          outcome, not a bug in us.
+        * **Any other non-applied terminal state** — reported rather than
+          discarded. Only the applied states let the caller answer
+          ``RPRT 0``: ``acknowledged`` (the executor completed while this
+          command was still live) and the confirmed/reconciled states a
+          readback can promote it to.
+
+        The truthful codes travel as :class:`_RigctldCommandFailure` so every
+        write path shares the one mapping in :meth:`execute`, rather than each
+        ``_cmd_set_*`` inventing its own.
+
+        Note on evidence: what counts as an ACK is a property of the backend
+        beneath the executor, not of this seat. An Icom ``set_freq`` is
+        dispatched without waiting for a reply, so ``acknowledged`` there means
+        "sent, uncontested" — not "the radio took it". The provider-owned
+        readback seam (:class:`PhysicalWriteReadbackCapable`, MOR-1779) cannot
+        strengthen that here: it only correlates commands dispatched through
+        the observation poller's queue, which rigctld writes deliberately do
+        not use, and waiting on a poll cycle in-band is what MOR-1881 measured
+        as a 2 s delay to a same-connection unkey. Closing that gap means
+        routing rigctld writes through the correlated queue without holding
+        the socket — post-beta work, tracked separately.
+        """
+        try:
+            result = await self._command_service.execute(intent)
+        except CommandExecutionInvalidatedError as exc:
+            logger.warning(
+                "rigctld: %s was invalidated in flight (%s) — reporting failure",
+                intent.name,
+                exc,
+            )
+            raise _RigctldCommandFailure(HamlibError.ERJCTED) from exc
+        state = _terminal_lifecycle_state(result, intent)
+        if state in _APPLIED_LIFECYCLE_STATES:
+            return result
+        logger.warning(
+            "rigctld: %s ended in terminal state %r — not reporting success",
+            intent.name,
+            state,
+        )
+        raise _RigctldCommandFailure(
+            _UNAPPLIED_LIFECYCLE_ERRORS.get(str(state), HamlibError.ERJCTED)
+        )
 
     def _packet_data_mode_value(self) -> int | bool:
         value = self._config.wsjtx_data_mode
@@ -1341,7 +1434,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         return _ok()
 
     # ------------------------------------------------------------------
@@ -1510,7 +1603,7 @@ class RigctldHandler:
             dropped = self._defer_write_gate(intent)
             if dropped is not None:
                 return dropped
-            await self._command_service.execute(intent)
+            await self._execute_write(intent)
             # ``filter_width`` (the local var) is a filter NUMBER, so the
             # readback overlay belongs on ``filter_num`` — that is the key the
             # get_mode projection now reads for the passband. (MOR-895.)
@@ -1542,7 +1635,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         self._cache.update_mode(base_mode_str, filter_width)
         if requested_mode in packet_modes:
             self._cache.update_data_mode(True)
@@ -1711,7 +1804,7 @@ class RigctldHandler:
             self._resolve_target_vfo(cmd.vfo_arg)
         except ValueError:
             return _err(HamlibError.EVFO)
-        await self._command_service.execute(
+        await self._execute_write(
             command_intent_from_request(
                 "set_ptt",
                 {"on": on},
@@ -1881,7 +1974,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         return _ok()
 
     async def _execute_set_vfo(self, vfo: str) -> HamlibError:
@@ -2187,7 +2280,7 @@ class RigctldHandler:
         # Single-RX profiles only have receiver=0; per-VFO state is selected
         # via set_vfo_slot, not receiver= (issue #1354).
         receiver = self._receiver_index_for(target)
-        await self._command_service.execute(
+        await self._execute_write(
             command_intent_from_request(
                 "set_level",
                 {
@@ -2340,7 +2433,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         return _ok()
 
     async def _execute_set_func(
@@ -2428,7 +2521,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         return _ok()
 
     async def _execute_set_split_vfo(self, on: bool, tx_vfo: str) -> HamlibError:
@@ -2575,7 +2668,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         return _ok()
 
     async def _cmd_get_xit(self, cmd: RigctldCommand) -> RigctldResponse:
@@ -2606,7 +2699,7 @@ class RigctldHandler:
         dropped = self._defer_write_gate(intent)
         if dropped is not None:
             return dropped
-        await self._command_service.execute(intent)
+        await self._execute_write(intent)
         return _ok()
 
     # ------------------------------------------------------------------
@@ -2704,7 +2797,9 @@ class RigctldHandler:
 
         Input: space-separated hex tokens or a single backslash-escaped hex string.
         Output: space-separated uppercase hex bytes of the radio's response,
-                or an empty response on timeout.
+                or an empty response when the radio answers nothing at all.
+                A frame that times out is an error (``ETIMEOUT``), not an
+                empty success — see :meth:`_execute_write` (MOR-1882).
         """
         if not cmd.args:
             return _err(HamlibError.EINVAL)
@@ -2714,7 +2809,7 @@ class RigctldHandler:
         except (ValueError, IndexError):
             return _err(HamlibError.EINVAL)
 
-        result = await self._command_service.execute(
+        result = await self._execute_write(
             command_intent_from_request(
                 "send_raw",
                 {"frame_bytes": frame_bytes},

--- a/tests/test_rigctld_handler.py
+++ b/tests/test_rigctld_handler.py
@@ -3224,32 +3224,39 @@ async def test_send_raw_returns_hex_response(
 
 
 @pytest.mark.asyncio
-async def test_send_raw_icom_timeout_returns_empty(
+async def test_send_raw_icom_timeout_answers_etimeout(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
-    """IcomTimeoutError produces empty ok response (not ETIMEOUT)."""
+    """A raw frame the radio never answered is reported as a timeout.
+
+    Until MOR-1882 this answered ``RPRT 0`` with an empty value list: the
+    client was told its raw write had succeeded when the only thing known
+    about it is that no reply ever came.
+    """
     mock_radio._send_civ_raw = AsyncMock(side_effect=IcomTimeoutError("timeout"))
 
     resp = await handler.execute(
         get_cmd("send_raw", "FE", "FE", "98", "E0", "03", "FD")
     )
 
-    assert resp.ok
+    assert resp.error is HamlibError.ETIMEOUT
     assert resp.values == []
+    states = [e.state for e in handler._command_service.lifecycle_events()]  # noqa: SLF001
+    assert states[-1] == "timed_out"
 
 
 @pytest.mark.asyncio
-async def test_send_raw_asyncio_timeout_returns_empty(
+async def test_send_raw_asyncio_timeout_answers_etimeout(
     handler: RigctldHandler, mock_radio: AsyncMock
 ) -> None:
-    """asyncio.TimeoutError also produces empty ok response."""
+    """asyncio.TimeoutError is reported the same way as the backend timeout."""
     mock_radio._send_civ_raw = AsyncMock(side_effect=asyncio.TimeoutError())
 
     resp = await handler.execute(
         get_cmd("send_raw", "FE", "FE", "98", "E0", "03", "FD")
     )
 
-    assert resp.ok
+    assert resp.error is HamlibError.ETIMEOUT
     assert resp.values == []
 
 

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -448,11 +448,17 @@ class _TerminalStateService:
     Models an executor seam that reports a non-applied terminal outcome by
     returning it rather than by raising -- the case the handler used to
     answer ``RPRT 0`` because it discarded the result entirely.
+
+    ``command_id=None`` attributes the extra event to a *different* command,
+    which is what makes the id filter in ``_terminal_lifecycle_state``
+    testable: the returned event slice is a window on a shared log, so a
+    concurrent command's terminal event can be the last one in it.
     """
 
-    def __init__(self, inner: object, state: str) -> None:
+    def __init__(self, inner: object, state: str, command_id: str | None) -> None:
         self._inner = inner
         self._state = state
+        self._command_id = command_id
 
     def __getattr__(self, name: str) -> object:
         return getattr(self._inner, name)
@@ -464,7 +470,9 @@ class _TerminalStateService:
             lifecycle_events=result.lifecycle_events
             + (
                 CommandLifecycleEvent(
-                    command_id=intent.id,
+                    command_id=intent.id
+                    if self._command_id is None
+                    else self._command_id,
                     state=self._state,  # type: ignore[arg-type]
                     timestamp_monotonic=0.0,
                     source="rigctld",
@@ -536,11 +544,35 @@ async def test_unapplied_terminal_state_is_never_answered_with_rprt_0(
     handler._command_service = _TerminalStateService(  # type: ignore[assignment]  # noqa: SLF001
         handler._command_service,  # noqa: SLF001
         state,
+        None,
     )
 
     response = await handler.execute(parse_line(b"F 14074000"))
 
     assert response.error is expected
+
+
+@pytest.mark.asyncio
+async def test_another_commands_terminal_state_does_not_fail_this_write() -> None:
+    """Truthfulness is per command, not per event log.
+
+    ``CommandServiceResult.lifecycle_events`` is a window on a shared log, so
+    a concurrent command's terminal event can be the last entry in it. Reading
+    the log without matching the command id would fail an unrelated healthy
+    write -- and, on the other side of the same bug, let a foreign
+    ``acknowledged`` vouch for a write that never landed.
+    """
+    handler, radio, _routing = _handler(_store("rx")[0])
+    handler._command_service = _TerminalStateService(  # type: ignore[assignment]  # noqa: SLF001
+        handler._command_service,  # noqa: SLF001
+        "failed",
+        "rigctld-set-freq-someone-elses-command",
+    )
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.ok
+    radio.set_freq.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -562,8 +594,14 @@ async def test_success_without_a_lifecycle_record_is_only_the_tx_drop() -> None:
     """The narrow half, stated as a property rather than as a single case.
 
     A write answered ``RPRT 0`` either never entered the command service at
-    all (the known-TX policy drop) or ended in an applied terminal state.
-    There is no third shape.
+    all -- the known-TX policy drop, the one success this seat may report for
+    a write the radio never saw -- or ended in an applied terminal state.
+
+    The property is about *shape*, not about the drop being the only
+    deliberate silence: :meth:`RigctldHandler._route_ptt` also answers
+    ``RPRT 0`` for a policy-declined unkey without writing, and it satisfies
+    this property from the other side, because that decision is taken inside
+    the executor and does leave an ``acknowledged`` record.
     """
     dropped_handler, dropped_radio, _ = _handler(_store("tx")[0])
     dropped = await dropped_handler.execute(parse_line(b"F 14074000"))

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -7,14 +7,17 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from rigplane.capabilities import CAP_RIT
+from rigplane.core.command_service import CommandServiceResult
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
+    CommandLifecycleEvent,
     FieldPath,
     Observation,
     SourceMetadata,
 )
 from rigplane.core.state_store import FreshnessClock, StateStore
 from rigplane.core.tx_interlock_contract import TxInterlockDisposition
+from rigplane.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.rigctld.contract import (
     COMMAND_TABLE,
     ClientSession,
@@ -426,3 +429,154 @@ async def test_rit_xit_are_dropped_silently_during_known_tx(name: str) -> None:
     response = await handler.execute(_rit_xit_cmd(name, 1))
     assert response.ok
     radio.set_rit_frequency.assert_not_awaited()
+
+
+# ── MOR-1882: the two-sided rule for answering a write with ``RPRT 0`` ─────
+# Success may be claimed for a write the radio never saw in exactly one case:
+# the deliberate pre-send policy drop above (known TX, MOR-1881), which is
+# bounded because it ends when the operator unkeys, and which is taken before
+# the command service is ever entered -- so it leaves no lifecycle record at
+# all. Every other way a write can fail to land (timeout, in-flight
+# invalidation, any terminal lifecycle state that is not evidence the write
+# was applied) is reported truthfully. Without both halves pinned the
+# carve-out widens into a loophole that swallows real failures.
+
+
+class _TerminalStateService:
+    """Real command service with one extra terminal lifecycle event appended.
+
+    Models an executor seam that reports a non-applied terminal outcome by
+    returning it rather than by raising -- the case the handler used to
+    answer ``RPRT 0`` because it discarded the result entirely.
+    """
+
+    def __init__(self, inner: object, state: str) -> None:
+        self._inner = inner
+        self._state = state
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._inner, name)
+
+    async def execute(self, intent: CommandIntent) -> CommandServiceResult:
+        result = await self._inner.execute(intent)  # type: ignore[attr-defined]
+        return replace(
+            result,
+            lifecycle_events=result.lifecycle_events
+            + (
+                CommandLifecycleEvent(
+                    command_id=intent.id,
+                    state=self._state,  # type: ignore[arg-type]
+                    timestamp_monotonic=0.0,
+                    source="rigctld",
+                ),
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_applied_write_still_answers_rprt_0() -> None:
+    """Positive control: an ordinary write is unaffected by the new checks."""
+    handler, radio, _routing = _handler(_store("rx")[0])
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.ok
+    radio.set_freq.assert_awaited_once()
+    states = [e.state for e in handler._command_service.lifecycle_events()]  # noqa: SLF001
+    assert states[-1] == "acknowledged"
+
+
+@pytest.mark.asyncio
+async def test_write_timeout_answers_etimeout_not_rprt_0() -> None:
+    handler, radio, _routing = _handler(_store("rx")[0])
+    radio.set_freq = AsyncMock(side_effect=RigplaneTimeoutError("no CI-V reply"))
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.error is HamlibError.ETIMEOUT
+    states = [e.state for e in handler._command_service.lifecycle_events()]  # noqa: SLF001
+    assert states[-1] == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_write_invalidated_in_flight_is_neither_success_nor_einternal() -> None:
+    """Supersession/invalidation is a real terminal outcome, not an internal bug.
+
+    The write completed at the backend but was no longer the live command when
+    it did, so nothing may be claimed about the radio's state.
+    """
+    handler, radio, _routing = _handler(_store("rx")[0])
+
+    async def _invalidate(*_args: object, **_kwargs: object) -> None:
+        service = handler._command_service  # noqa: SLF001
+        sent = [e for e in service.lifecycle_events() if e.state == "sent"]
+        service.fail_command(sent[-1].command_id, source="rigctld", session_id=None)
+
+    radio.set_freq = AsyncMock(side_effect=_invalidate)
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.error is HamlibError.ERJCTED
+    assert response.error is not HamlibError.EINTERNAL
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("failed", HamlibError.ERJCTED),
+        ("timed_out", HamlibError.ETIMEOUT),
+        ("superseded", HamlibError.ERJCTED),
+    ],
+)
+async def test_unapplied_terminal_state_is_never_answered_with_rprt_0(
+    state: str, expected: HamlibError
+) -> None:
+    handler, _radio, _routing = _handler(_store("rx")[0])
+    handler._command_service = _TerminalStateService(  # type: ignore[assignment]  # noqa: SLF001
+        handler._command_service,  # noqa: SLF001
+        state,
+    )
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.error is expected
+
+
+@pytest.mark.asyncio
+async def test_raw_write_timeout_answers_etimeout_not_empty_success() -> None:
+    """``w`` used to swallow its own timeout and answer ``RPRT 0`` with no data."""
+    handler, radio, _routing = _handler(_store("rx")[0])
+    radio._send_civ_raw = AsyncMock(side_effect=RigplaneTimeoutError("no reply"))
+
+    response = await handler.execute(parse_line(b"w FE FE 98 E0 03 FD"))
+
+    assert response.error is HamlibError.ETIMEOUT
+    assert response.values == []
+    states = [e.state for e in handler._command_service.lifecycle_events()]  # noqa: SLF001
+    assert states[-1] == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_success_without_a_lifecycle_record_is_only_the_tx_drop() -> None:
+    """The narrow half, stated as a property rather than as a single case.
+
+    A write answered ``RPRT 0`` either never entered the command service at
+    all (the known-TX policy drop) or ended in an applied terminal state.
+    There is no third shape.
+    """
+    dropped_handler, dropped_radio, _ = _handler(_store("tx")[0])
+    dropped = await dropped_handler.execute(parse_line(b"F 14074000"))
+    assert dropped.ok
+    dropped_radio.set_freq.assert_not_awaited()
+    assert dropped_handler._command_service.lifecycle_events() == ()  # noqa: SLF001
+
+    applied_handler, applied_radio, _ = _handler(_store("rx")[0])
+    applied = await applied_handler.execute(parse_line(b"F 14074000"))
+    assert applied.ok
+    applied_radio.set_freq.assert_awaited_once()
+    states = [
+        e.state
+        for e in applied_handler._command_service.lifecycle_events()  # noqa: SLF001
+    ]
+    assert states[-1] == "acknowledged"


### PR DESCRIPTION
## MOR-1882 — truthful rigctld terminal write results (B4-d3)

Closes the three verified defects in the ticket and pins the MOR-1881 carve-out from both sides.

### What changed

`src/rigplane/rigctld/handler.py`

* New seam `_execute_write(intent)`; all eleven material write call sites (`set_freq`, `set_mode` ×2, `set_ptt`, `set_vfo`, `set_level`, `set_func`, `set_split_vfo`, `set_rit`, `set_xit`, `send_raw`) go through it instead of calling `CommandService.execute` and discarding the result.
* `CommandExecutionInvalidatedError` (supersession / provider-generation change) → `ERJCTED`, not the generic `EINTERNAL` it used to fall through to.
* A terminal lifecycle state that is not evidence of application → truthful error (`timed_out` → `ETIMEOUT`, anything else → `ERJCTED`). Only `acknowledged` / `confirmed` / `reconciled` permit `RPRT 0`.
* `send_raw` no longer swallows its own timeout: the timeout propagates, the command gets a `timed_out` terminal lifecycle, and the client gets `RPRT -5` instead of an empty success.

### The carve-out, both halves

The one place this seat may answer `RPRT 0` for a write the radio never saw is unchanged and untouched: the pre-send policy drop in `_defer_write_gate` during known TX (MOR-1881, owner ruling 2026-08-17). It is taken *before* `_execute_write` is entered, so nothing in the new seam can widen it — the property is asserted directly (`test_success_without_a_lifecycle_record_is_only_the_tx_drop`: a successful write either produced no lifecycle record at all, or ended `acknowledged`; there is no third shape).

The failing half is pinned by: write timeout → `ETIMEOUT`; in-flight invalidation → `ERJCTED` and explicitly not `EINTERNAL`; each non-applied terminal state → its truthful code; raw-write timeout → `ETIMEOUT` with no values. DEFER writes under UNKNOWN/stale RF keep answering `ERJCTED` (existing rows, unchanged).

### AC 1 — the provider readback seam, and why it is not consumed here

`PhysicalWriteReadbackCapable` (MOR-1779) **cannot** be consumed at this seat as written, and the ticket's first criterion is met in the only way the medium allows — the handler reports the terminal outcome it has and invents nothing beyond it. Evidence:

1. Readback correlations are created only for commands dispatched through the observation poller's queue, which carry `command_service` / `command_id` / `source` metadata. rigctld writes call the radio directly from the injected executor, so no correlation entry is ever created for them and no result is ever published for a rigctld command id. A consumer here would be dead code today.
2. Even with correlation, the result arrives a poll cycle later. Waiting for it in-band is exactly what PR #2755's review measured as a +2.003 s delay to a same-connection unkey, on a protocol whose replies are positional and whose clients are synchronous.
3. What counts as an ACK is a backend property, not a handler property: an Icom `set_freq` is dispatched without waiting for a reply at all, so no handler-side check can turn it into readback evidence.

Closing that gap means routing rigctld writes through the correlated queue *without* holding the socket. That is a structural change through the code holding the unkey barrier and belongs with MOR-1888, post-beta. Recorded in the `_execute_write` docstring so the next reader does not re-derive it.

The incidental item (`_has_canonical_state_store` fail-opens when no StateStore is reachable) was **verified, not changed**: production always injects one via the server, and every construction path in the repo that reaches TX-gated writes passes a canonical store. Changing the direct-constructor bypass touches the hard-block gate and is not a one-liner, so it is left as ticketed.

### Verification

* `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` → **10196 passed**, 13 skipped, 14 xfailed, 1 xpassed (94 s).
* `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` → clean.
* `uv run lint-imports` → 5 contracts kept, 0 broken.
* All three validation dry-run golden gates (IC-7610 / X6200 / FTX-1) → PASS, 0 regressions.
* `uv run mypy src/rigplane/rigctld` → the same 2 pre-existing `no-any-return` errors as `main` (verified by running it on `main`); no new ones. `mypy --strict src/rigplane/web` is not tripped — no web/frontend path in the diff.
* **Red-first:** the five new rows and the two rewritten `send_raw` rows all failed against `main`'s behaviour first, for the intended reasons (`EINTERNAL` for invalidation, `RPRT 0` for the unapplied terminal states and the raw timeout).
* **Mutation-checked**, each against the production hunk it covers: ignoring the terminal state → 3 rows fail; swallowing the invalidation → 1 row fails; restoring the `send_raw` timeout swallow → 3 rows fail.

### Behaviour change for clients

A raw `w` frame that times out now answers `RPRT -5` instead of an empty `RPRT 0`; the two tests that encoded the old behaviour are rewritten rather than deleted. Every other wire command name and response framing is unchanged. WSJT-X does not use `w`.

### Guardrails

5 files, +335 / −24 (net ~311 LOC) — LOC within the ticket's ≤400, file count **one over the ≤3 owned files, disclosed**: the two extra files are `docs/api/rigctld.md` and `docs/release-notes/2026-beta-known-limitations.md`, added after independent review found that the public API reference documented the exact `w`-timeout behaviour this change reverses. Leaving that doc false was not an option, and a docs-only follow-up PR would have left `main` self-contradicting between merge and follow-up. No extra production file was touched.

### Follow-ups (not done here, deliberately)

* Routing rigctld writes through the correlated command queue so the provider readback seam can actually vouch for them — post-beta, belongs with MOR-1888 (see AC 1 above).
* Coverage gap found by review: a *foreign* `acknowledged` event vouching for this command's failure is the mirror of the id-filter bug the new row pins, and no row constructs it (the test double appends a single event, so the "own terminal state then foreign applied state" ordering cannot be built with it). The shipped code is correct; this is a missing row, not a defect.
* `_has_canonical_state_store`'s direct-constructor fail-open, verified and left as ticketed.
