### PR TITLE
fix(MOR-1892): re-observe the field a command wrote

### DIFF
--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -37,8 +37,8 @@ logger = logging.getLogger(__name__)
 # it. ``ensure_fresh`` can only express that as an age no prior observation
 # can satisfy, so the request is never short-circuited by a FRESH pre-write
 # value. Same value and same reasoning as the freshness pipeline's own
-# reconciliation path and as the web poller's older per-command table
-# (``_POST_WRITE_READBACK_MAX_AGE``, MOR-1484), which this generalises.
+# reconciliation path and as the web poller's own per-command table
+# (``_POST_WRITE_READBACK_MAX_AGE``, MOR-1484).
 _WRITE_CONFIRMATION_MAX_AGE = 1e-9
 
 __all__ = [
@@ -266,17 +266,26 @@ class CommandService:
         ``StateModelService`` contract: nothing here awaits the radio, so a
         write's reply is never delayed by its own confirmation.
 
-        **Reach, measured rather than assumed** (PR #2758 review): only paths
-        an acquisition profile actually declares can be re-observed, and today
-        that means the global-scope targets — ``global.tx_state.ptt`` among
-        them, which is the one this ticket needs. Receiver-scoped targets do
-        NOT resolve: :func:`_command_target` builds them as
-        ``receiver.<index>.<family>.<name>`` while profiles and the StateStore
-        use ``receiver.<main|sub>.active.<family>.<name>``, so the scheduler
-        answers ``UNAVAILABLE`` and the request is a no-op (logged, not
-        swallowed). That divergence is older than this method and is tracked
-        separately; until it is closed, this does not subsume the web poller's
-        per-command readback table, which builds the canonical paths itself.
+        **Reach, probed rather than assumed** (PR #2758 review). A target is
+        re-observable only where the acquisition profile declares a capability
+        for that exact path; anything else answers ``UNAVAILABLE``. Against the
+        IC-7300 profile:
+
+        * ``global.tx_state.ptt`` — queued. That is the one this ticket needs.
+        * ``global.tx_state.power_on`` — unavailable. Global scope is not by
+          itself enough.
+        * every receiver-scoped target — unavailable, because
+          :func:`_command_target` names the receiver by index
+          (``receiver.0.operator_controls.rf_gain``) while profiles and the
+          StateStore name it (``receiver.main.operator_controls.rf_gain``, and
+          ``receiver.main.active.freq_mode.freq_hz`` for the ``freq_mode``
+          family — the only family where a VFO slot is legal at all).
+
+        Those misses are no-ops, logged rather than swallowed so that a silent
+        miss cannot read as coverage. The divergence is older than this method
+        and is tracked in MOR-1897; until it is closed this does NOT subsume
+        the web poller's per-command readback table, which builds the
+        canonical paths itself.
         """
         service = self._state_model_service
         target = intent.target

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -7,11 +7,14 @@ as confirmed :class:`Observation` values through :class:`StateStore`.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
+from rigplane.core.acquisition_scheduler import AcquisitionPriority
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
@@ -24,6 +27,19 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_store import StateStore
+
+if TYPE_CHECKING:
+    from rigplane.core.radio_protocol import StateModelService
+
+logger = logging.getLogger(__name__)
+
+# A write does not age our knowledge of the field it wrote — it invalidates
+# it. ``ensure_fresh`` can only express that as an age no prior observation
+# can satisfy, so the request is never short-circuited by a FRESH pre-write
+# value. Same value and same reasoning as the freshness pipeline's own
+# reconciliation path and as the web poller's older per-command table
+# (``_POST_WRITE_READBACK_MAX_AGE``, MOR-1484), which this generalises.
+_WRITE_CONFIRMATION_MAX_AGE = 1e-9
 
 __all__ = [
     "CommandExecutionInvalidatedError",
@@ -120,6 +136,7 @@ class CommandService:
         "_executor",
         "_overlays",
         "_readback_expectations",
+        "_state_model_service",
         "_state_store",
         "_subscribers",
     )
@@ -131,11 +148,13 @@ class CommandService:
         state_store: StateStore,
         clock: Clock | None = None,
         default_pending_ttl: float = 2.0,
+        state_model_service: StateModelService | None = None,
     ) -> None:
         if default_pending_ttl < 0:
             raise ValueError("default_pending_ttl must be non-negative")
         self._executor = executor
         self._state_store = state_store
+        self._state_model_service = state_model_service
         self._clock = clock or time.monotonic
         self._default_pending_ttl = default_pending_ttl
         self._active_commands: dict[
@@ -198,11 +217,82 @@ class CommandService:
                 )
             )
 
+        self._request_write_confirmation(intent, executor_result)
+
         return CommandServiceResult(
             lifecycle_events=tuple(self._events[start:]),
             observation_changes=tuple(changes),
             executor_result=executor_result,
         )
+
+    def _request_write_confirmation(
+        self, intent: CommandIntent, executor_result: CommandExecutionResult
+    ) -> None:
+        """Ask for a fresh observation of the field this command just wrote.
+
+        A write does not make our knowledge of that field *stale*, it makes it
+        **wrong**: the field's last observation predates the command, still
+        carries the pre-write value, and is still FRESH. Freshness decay is
+        time-based, so nothing in the pipeline notices, and every consumer
+        that reads observed truth keeps answering from the old value until the
+        next cadence poll happens along. The pending overlay recorded above
+        does not help them: it is deliberately optimistic and deliberately
+        scoped to the ingress that raised the command, because consumers that
+        must not trust our own optimism — the TX interlock first among them —
+        read the raw store instead.
+
+        The concrete casualty (MOR-1892) is RF truth after an unkey. The
+        interlock reads the observed PTT field; for up to a full poll cadence
+        after a client's unkey that field still reads "transmitting", so a
+        write arriving in that window is refused or dropped. WSJT-X in "Fake
+        It" split lands its dial restore exactly there — a fixed 100 ms after
+        its unkey — so the rig is left on the transmit-shifted frequency.
+
+        Closing it by *inferring* RX from our own successful write is what
+        this programme has refused all along, so this does the other thing:
+        it asks the radio, immediately, through the machinery that already
+        exists for it. The written path is queued for re-acquisition at
+        ``AcquisitionPriority.COMMAND`` — the priority class the scheduler
+        reserves for acquisitions caused by a command, and which nothing had
+        wired until now — with an age no earlier observation can satisfy.
+        Whichever drain owns this radio picks it up on its next cycle.
+
+        Three things it deliberately does not do: it does not run when the
+        write failed (nothing was written, so nothing changed), it does not
+        run when the executor already returned an observation of the target
+        (the write came back confirmed — asking again would be pure traffic
+        on a serial budget that is already tight), and it never fails the
+        command. It is also synchronous and fire-and-queue by the
+        ``StateModelService`` contract: nothing here awaits the radio, so a
+        write's reply is never delayed by its own confirmation.
+        """
+        service = self._state_model_service
+        target = intent.target
+        if service is None or target is None:
+            return
+        if any(
+            observation.path == target for observation in executor_result.observations
+        ):
+            return
+        try:
+            ensure_fresh = service.ensure_fresh
+            if asyncio.iscoroutinefunction(ensure_fresh):
+                # A coroutine implementation violates the synchronous
+                # contract; calling it would leave an un-awaited coroutine
+                # behind instead of a queued request.
+                return
+            ensure_fresh(
+                (target,),
+                max_age=_WRITE_CONFIRMATION_MAX_AGE,
+                priority=AcquisitionPriority.COMMAND,
+                reason=f"post_write:{intent.name}",
+            )
+        except Exception:
+            logger.warning(
+                "command service: could not queue write confirmation for %s",
+                target,
+                exc_info=True,
+            )
 
     def apply_observation(self, observation: Observation) -> ChangeSet:
         """Apply a confirmed observation and reconcile matching overlays."""

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -14,7 +14,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Protocol
 
-from rigplane.core.acquisition_scheduler import AcquisitionPriority
+from rigplane.core.acquisition_scheduler import AcquisitionPriority, AcquisitionStatus
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
@@ -265,6 +265,18 @@ class CommandService:
         command. It is also synchronous and fire-and-queue by the
         ``StateModelService`` contract: nothing here awaits the radio, so a
         write's reply is never delayed by its own confirmation.
+
+        **Reach, measured rather than assumed** (PR #2758 review): only paths
+        an acquisition profile actually declares can be re-observed, and today
+        that means the global-scope targets — ``global.tx_state.ptt`` among
+        them, which is the one this ticket needs. Receiver-scoped targets do
+        NOT resolve: :func:`_command_target` builds them as
+        ``receiver.<index>.<family>.<name>`` while profiles and the StateStore
+        use ``receiver.<main|sub>.active.<family>.<name>``, so the scheduler
+        answers ``UNAVAILABLE`` and the request is a no-op (logged, not
+        swallowed). That divergence is older than this method and is tracked
+        separately; until it is closed, this does not subsume the web poller's
+        per-command readback table, which builds the canonical paths itself.
         """
         service = self._state_model_service
         target = intent.target
@@ -281,12 +293,22 @@ class CommandService:
                 # contract; calling it would leave an un-awaited coroutine
                 # behind instead of a queued request.
                 return
-            ensure_fresh(
+            result = ensure_fresh(
                 (target,),
                 max_age=_WRITE_CONFIRMATION_MAX_AGE,
                 priority=AcquisitionPriority.COMMAND,
                 reason=f"post_write:{intent.name}",
             )
+            status = getattr(result, "status", None)
+            if status is not None and str(status) == AcquisitionStatus.UNAVAILABLE:
+                # Not an error, but not a confirmation either: say so rather
+                # than let a silent no-op read as coverage.
+                logger.debug(
+                    "command service: %s cannot be re-observed after %s — "
+                    "no acquisition capability declared for that path",
+                    target,
+                    intent.name,
+                )
         except Exception:
             logger.warning(
                 "command service: could not queue write confirmation for %s",

--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -698,6 +698,12 @@ class RigctldHandler:
         self._command_service = CommandService(
             executor=_RigctldCommandExecutor(self),
             state_store=state_store,
+            # Every write this seat makes asks the radio to re-observe the
+            # field it wrote (MOR-1892). Without it, RF truth trails our own
+            # unkey by up to a poll cadence and the next write is dropped
+            # inside that window — see
+            # ``CommandService._request_write_confirmation``.
+            state_model_service=self._state_model_service,
         )
 
     def bind_provider_generation(self, capture: Callable[[], int]) -> None:

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1908,3 +1908,163 @@ async def test_multi_target_readback_reconciles_only_matching_rit_overlay() -> N
     assert [(str(overlay.path), overlay.value) for overlay in remaining] == [
         ("global.tx_state.rit_on", True)
     ]
+
+
+# ── MOR-1892: a write makes our own knowledge of the field it wrote WRONG, ──
+# not stale. The field's last observation predates the command, still carries
+# the old value, and is still FRESH, so nothing in the time-based freshness
+# pipeline notices. Every consumer reading observed truth — the TX interlock
+# above all — keeps answering from the pre-write value until the next cadence
+# poll happens along. The service closes that in the pipeline's own
+# vocabulary: the written path is queued for re-acquisition at the COMMAND
+# priority the scheduler already reserves for exactly this.
+
+
+class FakeStateModelService:
+    """Records ensure_fresh requests; matches the synchronous service contract."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+
+    def ensure_fresh(
+        self,
+        paths: Any,
+        *,
+        max_age: float,
+        priority: Any,
+        reason: str,
+        timeout: float | None = None,
+    ) -> None:
+        self.requests.append(
+            {
+                "paths": tuple(paths),
+                "max_age": max_age,
+                "priority": str(priority),
+                "reason": reason,
+            }
+        )
+        return None
+
+
+def _service_with_freshness(
+    executor: FakeExecutor,
+) -> tuple[CommandService, FakeStateModelService]:
+    freshness = FakeStateModelService()
+    service = CommandService(
+        executor=executor,
+        state_store=StateStore(),
+        state_model_service=freshness,
+    )
+    return service, freshness
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_acknowledged_write_requests_reobservation_of_its_target() -> None:
+    service, freshness = _service_with_freshness(FakeExecutor())
+
+    await service.execute(_intent())
+
+    assert len(freshness.requests) == 1
+    request = freshness.requests[0]
+    assert request["paths"] == (_freq_path(),)
+    assert request["priority"] == "command"
+    # Effectively zero: the point is "observed AFTER this write", which a
+    # positive age cannot express — an observation taken moments before the
+    # write would satisfy it while carrying the pre-write value.
+    assert request["max_age"] > 0
+    assert request["max_age"] < 1e-6
+    assert "set_freq" in request["reason"]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_ptt_write_requests_reobservation_of_rf_truth() -> None:
+    """The case MOR-1892 is about: RF truth after an unkey.
+
+    WSJT-X in "Fake It" split restores the dial 100 ms after its unkey
+    (a fixed sleep in its own TransceiverBase), well inside the window where
+    the last PTT observation still reads TX. Re-observing the field we just
+    wrote is what closes that window — without inferring RF state from our
+    own command, which the interlock may never do.
+    """
+    service, freshness = _service_with_freshness(FakeExecutor())
+    intent = command_intent_from_request(
+        "set_ptt",
+        {"on": False},
+        source="rigctld",
+        command_id="rigctld-set-ptt-1",
+    )
+
+    await service.execute(intent)
+
+    assert [request["paths"] for request in freshness.requests] == [
+        (FieldPath.global_("tx_state", "ptt"),)
+    ]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_no_reobservation_when_the_write_never_landed() -> None:
+    """Nothing was written, so nothing about our knowledge changed."""
+    service, freshness = _service_with_freshness(
+        FakeExecutor(fail=RigplaneTimeoutError("no reply"))
+    )
+
+    with pytest.raises(RigplaneTimeoutError):
+        await service.execute(_intent())
+
+    assert freshness.requests == []
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_no_reobservation_for_a_command_with_no_observable_target() -> None:
+    service, freshness = _service_with_freshness(FakeExecutor())
+
+    await service.execute(replace(_intent(), target=None, pending_policy="none"))
+
+    assert freshness.requests == []
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_reobservation_failure_never_fails_the_command() -> None:
+    """Confirmation is best effort: a write that reached the radio stands."""
+
+    class Exploding(FakeStateModelService):
+        def ensure_fresh(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("scheduler unavailable")
+
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(),
+        state_model_service=Exploding(),
+    )
+
+    result = await service.execute(_intent())
+
+    assert _states(result.lifecycle_events)[-1] == "acknowledged"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_coroutine_ensure_fresh_is_skipped_not_awaited() -> None:
+    """The service contract is synchronous fire-and-queue.
+
+    An implementation that returns a coroutine would leave it un-awaited (a
+    warning, and no request queued), so it is skipped deliberately instead.
+    """
+
+    class AsyncService:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def ensure_fresh(self, *args: Any, **kwargs: Any) -> None:
+            self.calls += 1
+
+    freshness = AsyncService()
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(),
+        state_model_service=freshness,
+    )
+
+    result = await service.execute(_intent())
+
+    assert freshness.calls == 0
+    assert _states(result.lifecycle_events)[-1] == "acknowledged"

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -2043,28 +2045,56 @@ async def test_reobservation_failure_never_fails_the_command() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_coroutine_ensure_fresh_is_skipped_not_awaited() -> None:
+async def test_coroutine_ensure_fresh_is_skipped_not_called() -> None:
     """The service contract is synchronous fire-and-queue.
 
-    An implementation that returns a coroutine would leave it un-awaited (a
-    warning, and no request queued), so it is skipped deliberately instead.
+    Calling a coroutine implementation would produce an un-awaited coroutine
+    object, never a queued request, so it is skipped instead.
+
+    The probe has to record the call at call time, not inside the coroutine
+    body — a body that never runs cannot witness the bug it is meant to
+    catch. ``AsyncMock`` does exactly that, and ``asyncio.iscoroutinefunction``
+    recognises it, so removing the guard makes this row fail rather than
+    merely emit a warning. (PR #2758 review: the first version of this row
+    counted inside the body and killed no mutation.)
     """
-
-    class AsyncService:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        async def ensure_fresh(self, *args: Any, **kwargs: Any) -> None:
-            self.calls += 1
-
-    freshness = AsyncService()
+    freshness = SimpleNamespace(ensure_fresh=AsyncMock())
     service = CommandService(
         executor=FakeExecutor(),
         state_store=StateStore(),
-        state_model_service=freshness,
+        state_model_service=cast(Any, freshness),
     )
 
     result = await service.execute(_intent())
 
-    assert freshness.calls == 0
+    freshness.ensure_fresh.assert_not_called()
     assert _states(result.lifecycle_events)[-1] == "acknowledged"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_no_reobservation_when_the_executor_already_observed_it() -> None:
+    """A write that came back confirmed needs no confirming read.
+
+    Asking again would be pure traffic on a serial budget that is already
+    tight, and it would arrive after an observation that is already newer
+    than the write.
+    """
+    executor = FakeExecutor(
+        observations=(_observation(_freq_path(), 14_074_000, at=1.0),)
+    )
+    service, freshness = _service_with_freshness(executor)
+
+    await service.execute(_intent())
+
+    assert freshness.requests == []
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_reobservation_still_requested_for_an_unrelated_observation() -> None:
+    """Only an observation OF THE TARGET counts as the write's own confirmation."""
+    executor = FakeExecutor(observations=(_observation(_mode_path(), "USB", at=1.0),))
+    service, freshness = _service_with_freshness(executor)
+
+    await service.execute(_intent())
+
+    assert [request["paths"] for request in freshness.requests] == [(_freq_path(),)]

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Sequence
 from dataclasses import replace
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from rigplane.core.acquisition_scheduler import AcquisitionStatus
 from rigplane.core.command_service import (
     CommandExecutionResult,
     CommandService,
@@ -2068,6 +2070,36 @@ async def test_coroutine_ensure_fresh_is_skipped_not_called() -> None:
     result = await service.execute(_intent())
 
     freshness.ensure_fresh.assert_not_called()
+    assert _states(result.lifecycle_events)[-1] == "acknowledged"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_unavailable_confirmation_is_logged_not_swallowed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A path the profile cannot acquire is a miss, and it has to say so.
+
+    This is the remediation for the review finding that the reach of the
+    confirmation is narrower than it looks: receiver-scoped targets answer
+    ``UNAVAILABLE`` today (MOR-1897). Discarding that answer would let a
+    permanent no-op read as coverage.
+    """
+
+    class UnavailableService:
+        def ensure_fresh(self, *args: Any, **kwargs: Any) -> Any:
+            return SimpleNamespace(status=AcquisitionStatus.UNAVAILABLE)
+
+    service = CommandService(
+        executor=FakeExecutor(),
+        state_store=StateStore(),
+        state_model_service=cast(Any, UnavailableService()),
+    )
+    caplog.set_level(logging.DEBUG, logger="rigplane.core.command_service")
+
+    result = await service.execute(_intent())
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(str(_freq_path()) in message for message in messages)
     assert _states(result.lifecycle_events)[-1] == "acknowledged"
 
 

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -618,3 +618,83 @@ async def test_success_without_a_lifecycle_record_is_only_the_tx_drop() -> None:
         for e in applied_handler._command_service.lifecycle_events()  # noqa: SLF001
     ]
     assert states[-1] == "acknowledged"
+
+
+# ── MOR-1892: the seat's own unkey must not blind its RF truth ─────────────
+# The interlock reads the OBSERVED PTT field, and after a client's unkey that
+# observation still reads "transmitting" until the next poll — up to the
+# field's 0.3 s cadence on an IC-7300. WSJT-X in "Fake It" split restores the
+# dial a fixed 100 ms after its unkey (``QThread::msleep(100)`` in its own
+# ``TransceiverBase::set``), squarely inside that window, so the restore is
+# dropped and the rig is left on the transmit-shifted frequency.
+#
+# The seat closes it by asking the radio, not by inferring RX from its own
+# successful write — see ``CommandService._request_write_confirmation``.
+
+
+class _RecordingStateModelService:
+    def __init__(self) -> None:
+        self.requests: list[tuple[tuple[FieldPath, ...], str, float]] = []
+
+    def ensure_fresh(
+        self,
+        paths: object,
+        *,
+        max_age: float,
+        priority: object,
+        reason: str,
+        timeout: float | None = None,
+    ) -> None:
+        self.requests.append((tuple(paths), str(priority), max_age))  # type: ignore[arg-type]
+        return None
+
+
+def _handler_with_freshness(store: StateStore):
+    radio = AsyncMock()
+    radio.capabilities = {CAP_RIT}
+    radio.state_store = store
+    routing = Mock()
+    routing.set_func = AsyncMock(return_value=RigctldResponse())
+    routing.set_level = AsyncMock(return_value=RigctldResponse())
+    radio.rigctld_routing = Mock(return_value=routing)
+    radio._send_civ_raw = AsyncMock(return_value=None)
+    freshness = _RecordingStateModelService()
+    handler = RigctldHandler(
+        radio,
+        RigctldConfig(),
+        state_store=store,
+        state_model_service=freshness,  # type: ignore[arg-type]
+    )
+    return handler, radio, freshness
+
+
+_PTT_PATH = FieldPath.global_("tx_state", "ptt")
+
+
+@pytest.mark.asyncio
+async def test_unkey_asks_the_radio_to_re_observe_rf_truth() -> None:
+    handler, radio, freshness = _handler_with_freshness(_store("tx")[0])
+
+    response = await handler.execute(parse_line(b"T 0"))
+
+    assert response.ok
+    radio.set_ptt.assert_awaited_once_with(False)
+    ptt_requests = [item for item in freshness.requests if item[0] == (_PTT_PATH,)]
+    assert len(ptt_requests) == 1
+    _paths, priority, max_age = ptt_requests[0]
+    assert priority == "command"
+    # Not "recent enough" — strictly newer than the write. Any positive age
+    # would be satisfied by the pre-unkey observation that reads TX.
+    assert 0 < max_age < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_dropped_write_asks_for_nothing() -> None:
+    """A write that never reached the radio changed no field to re-observe."""
+    handler, radio, freshness = _handler_with_freshness(_store("tx")[0])
+
+    response = await handler.execute(parse_line(b"F 14074000"))
+
+    assert response.ok
+    radio.set_freq.assert_not_awaited()
+    assert freshness.requests == []


### PR DESCRIPTION
## MOR-1892 — re-observe the field a command wrote

Closes the post-unkey drop window at its cause rather than at the seat where it was noticed.

### The corroboration that unblocked this

The ticket held the fix behind evidence that WSJT-X actually retunes inside the window. That evidence is now in the ticket, read from WSJT-X's own sources rather than measured:

* `Transceiver/TransceiverFactory.cpp` wraps any transceiver in `EmulateSplitTransceiver` when "Fake It" is selected — a Hamlib *Net rigctl* rig pointed at us included.
* `Transceiver/TransceiverBase.cpp`, TX→RX branch, in order: `do_ptt(false)` → `do_post_ptt(false)` → `QThread::msleep(100)` → the frequency block, which fires because the TX transition left the shifted dial as the last requested frequency. The 100 ms is an unconditional guard band, not a wait for the rig; nothing confirms PTT state before the restore.
* `widgets/mainwindow.cpp` (`setXIT`): the TX dial offset is `(n/500)*500 - 1500` for TX audio frequency `n`, i.e. zero only for a slot in 1500–1999 Hz. Any other slot shifts the dial for the over and must restore it after.

Against our own numbers (`rigs/ic7300.toml`: `global.tx_state.ptt` cadence 0.3 s, TTL 1.0 s, and no observation recorded on the unkey path), the restore at +100 ms lands inside a window up to ~300 ms wide. It survives only when a poll happens to fall in that first 100 ms — so the failure is intermittent, which is worse for an operator than a deterministic one.

### The fix

`CommandService`, once a command is acknowledged, asks for a fresh observation of the path that command targeted.

The framing that makes this small: **a write does not make our knowledge of a field stale, it makes it wrong.** The last observation predates the command, still carries the old value, and is still `FRESH` — freshness decay is time-based, so nothing in the pipeline notices. The pending overlay does not help the consumers that matter here, because the TX interlock deliberately reads the raw store rather than our own optimism.

Nothing new was invented for it:

* the request goes out at `AcquisitionPriority.COMMAND` — the priority class the scheduler already reserves for acquisitions caused by a command, ranked between `NORMAL` and `USER`, **which nothing had wired until now**;
* the max age is the same effectively-zero value (`1e-9`) the freshness pipeline's reconciliation path and the web poller's post-write readback already use, for the same stated reason;
* the target path comes from `intent.target`, which `command_intent_from_request` already computes.

The web seat has had a per-command-type table (`_POST_WRITE_READBACK_FIELDS`, MOR-1484) doing this for freq/mode/rf_gain/squelch/att/preamp/break-in — but **not for PTT**, and only for that seat.

**Reach, corrected by review — read this before assuming more than it does.** The first version of this PR claimed the intent-driven rule subsumes that table. It does not. A target is re-observable only where the acquisition profile declares a capability for that exact path; `_command_target` names the receiver by index while profiles and the StateStore name it. Probed against the IC-7300 profile (re-run independently of the review):

```
global.tx_state.ptt                       -> queued
global.tx_state.power_on                  -> unavailable
receiver.main.operator_controls.rf_gain   -> queued
receiver.main.active.freq_mode.freq_hz    -> queued
receiver.0.freq_mode.freq_hz              -> unavailable
receiver.0.operator_controls.rf_gain      -> unavailable
```

So the field MOR-1892 needs resolves, and every receiver-scoped confirmation is a no-op — now **logged** rather than discarded, with a test that fails if the log goes, so a permanent miss cannot read as coverage. Note also that global scope alone is not the criterion: `set_powerstat`'s target is unavailable too. (The `active` slot appears only on `freq_mode` paths — it is illegal elsewhere — so the canonical shape differs by family.) The divergence is older than this change and is tracked as **MOR-1897**; the follow-up that would have retired the web table is withdrawn until it is closed.

**It is not RF inference.** The interlock still believes only the radio; this changes *when we ask*, never *what we believe*. It also never delays a reply (the `StateModelService` contract is synchronous fire-and-queue), never runs for a write that failed or was dropped by the TX policy gate, never re-reads a field the executor already returned an observation for, and never fails a command if the scheduler refuses the request.

Wired at the rigctld seat, which had no post-write readback of any kind. The other three `CommandService` owners adopt it by passing one argument — left to a follow-up so each seat's serial budget is measured on its own (the IC-7300 profile already sits at ~19.95 q/s against a 20 q/s ceiling in steady state; these requests are event-driven, not cadence, so they do not move that number).

### Verification

* `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` → **10208 passed**, 13 skipped, 14 xfailed, 1 xpassed (69 s) at the current head.
* Two other runs of the same suite each red-flagged **a different** test (`test_radio.py::TestToneTsqlDualRxCmd29Guard::…`, then `test_icom7610_serial_radio.py::test_serial_link_down_propagates_to_web_radio_health`, the latter alongside an xdist worker crash on a loaded machine at 325 s wall time). Both pass in isolation and neither repeated. That is the MOR-1887 family — eight distinct timing-sensitive tests failing once each across six runs, raised independently on PR #2754 — not this diff.
* `uv run ruff check src/ tests/` + `uv run ruff format --check src/ tests/` → clean.
* `uv run lint-imports` → 5 contracts kept, 0 broken. (`core.command_service` → `core.acquisition_scheduler` is an intra-layer import; no cycle — `acquisition_scheduler` does not reference `command_service`.)
* `uv run mypy src/rigplane/core src/rigplane/rigctld` → 1 error, the same pre-existing `no-any-return` in `rigctld/handler.py` as on `main` (verified by running it on `main`).
* All three validation dry-run golden gates → PASS, 0 regressions.
* **Red-first:** the six new `CommandService` rows and the rigctld unkey row all failed against `main`'s behaviour first; the unkey row was re-checked red by removing only the one-line seat wiring.

### Test coverage, and what kills each row

| Row | Mutation that kills it |
|---|---|
| acknowledged write requests re-observation of its target | drop the `ensure_fresh` call |
| PTT write requests re-observation of RF truth | target the wrong path, or skip `set_ptt` |
| no re-observation when the write never landed | move the call before the executor's exception handling |
| no re-observation for a command with no target | drop the `target is None` guard |
| re-observation failure never fails the command | remove the `except` |
| coroutine `ensure_fresh` is skipped, not called | drop the coroutine guard — verified by mutation after review; the first version of this row counted calls inside the coroutine body, which never runs when the coroutine is not awaited, so it killed nothing. It now probes with `AsyncMock`, which records the call itself |
| no re-observation when the executor already observed the target | drop that skip — verified by mutation; before review no row killed it, and deleting the skip left all 10205 tests green |
| an unrelated observation does not count as the write's confirmation | make the skip match any observation instead of the target |
| an UNAVAILABLE confirmation is logged, not swallowed | delete the log block — verified by mutation after the second review round, which found it uncovered |
| unkey asks the radio to re-observe RF truth (rigctld) | remove the seat wiring |
| a dropped write asks for nothing | — weak row: it guards the TX-drop path against side effects, and no mutation of this diff kills it, because a dropped write never reaches `CommandService` at all. Kept as a regression fence, called out rather than claimed as coverage. |

### Guardrails

4 files — **one file over the ≤3 owned files, disclosed**: the fix belongs in the shared write pipeline (`core/command_service.py` + its tests), and the seat it fixes (`rigctld/handler.py` + its tests) is where the defect was demonstrated. Putting it only at the seat would have been a local poke at a general defect.

### Follow-ups (not done here)

* **MOR-1897** — the receiver-path divergence above. It gates everything below it.
* Adopt the same argument at the three remaining `CommandService` owners (two in `web/server.py`, `web/handlers/control.py`, `runtime/sync.py`). Needs a per-seat serial-budget check, so it is not folded in here. Retiring `_POST_WRITE_READBACK_FIELDS` is **not** on the table until MOR-1897 lands — the table builds canonical paths the intent-driven rule cannot yet reach.
* The bench still owes the end-to-end wire timing on real hardware (our poll phase against WSJT-X's 100 ms). With this merged, that check validates the fix rather than the bug.
