### PR TITLE
fix(MOR-1900): stop fabricating RF truth from the legacy PTT mirror

### DIFF
--- a/src/rigplane/rigctld/handler.py
+++ b/src/rigplane/rigctld/handler.py
@@ -1722,12 +1722,26 @@ class RigctldHandler:
 
         state = self._radio_state()
         if state is not None:
-            self._record_state_sample(
-                ptt_path,
-                bool(state.ptt),
-                source="state_poller",
-                max_age=self._config.cache_ttl,
-            )
+            # MOR-1900: answer the client from the legacy mirror, but never
+            # publish that answer as canonical truth. ``RadioState.ptt``
+            # defaults to ``False`` and the mirror carries no observation
+            # time for it at all, so recording it here stamped a possibly
+            # never-observed "not transmitting" with ``time.monotonic()`` —
+            # i.e. as an observation made now. ``_resolve_rigctld_rf_state``
+            # does not filter by source, so that sample was indistinguishable
+            # from real RF truth and could hand the TX interlock a fabricated
+            # RX, letting a DEFER-classified write through while the PA may
+            # be keyed. A missing or stale canonical field must stay that
+            # way, so the interlock refuses instead of acting on a
+            # manufactured sample. The diagnostic keeps the fallback visible:
+            # a silent miss must not read as coverage.
+            if isinstance(self._state_diagnostics, StateDiagnosticsRecorder):
+                self._state_diagnostics.record(
+                    "rigctld_ptt_mirror_fallback",
+                    "rigctld.handler",
+                    path=str(ptt_path),
+                    value=bool(state.ptt),
+                )
             return RigctldResponse(values=[str(int(state.ptt))])
         return RigctldResponse(values=["0"])
 

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -1,6 +1,7 @@
 """Rigctld write-intent coverage for the shared TX interlock policy."""
 
 import logging
+import time
 from dataclasses import replace
 from unittest.mock import AsyncMock, Mock
 
@@ -15,9 +16,11 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import FreshnessClock, StateStore
+from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
+from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
 from rigplane.core.tx_interlock_contract import TxInterlockDisposition
 from rigplane.exceptions import TimeoutError as RigplaneTimeoutError
+from rigplane.radio_state import RadioState
 from rigplane.rigctld.contract import (
     COMMAND_TABLE,
     ClientSession,
@@ -698,3 +701,121 @@ async def test_dropped_write_asks_for_nothing() -> None:
     assert response.ok
     radio.set_freq.assert_not_awaited()
     assert freshness.requests == []
+
+
+# ---------------------------------------------------------------------------
+# MOR-1900: a ``t`` poll must not manufacture canonical RF truth
+# ---------------------------------------------------------------------------
+
+
+def _mirror_handler(store: StateStore, *, ptt: bool = False):
+    """Handler whose legacy mirror answers ``t`` when the projection misses.
+
+    ``RadioState.ptt`` defaults to ``False`` with no age bound, so this is
+    exactly the never-observed mirror that used to be laundered into the
+    canonical store as a fresh radio observation.
+    """
+    radio = AsyncMock()
+    radio.capabilities = {CAP_RIT}
+    radio.state_store = store
+    radio._state_diagnostics = StateDiagnosticsRecorder(enabled=True)
+    state = RadioState()
+    state.ptt = ptt
+    radio.radio_state = state
+    routing = Mock()
+    routing.set_func = AsyncMock(return_value=RigctldResponse())
+    routing.set_level = AsyncMock(return_value=RigctldResponse())
+    radio.rigctld_routing = Mock(return_value=routing)
+    radio._send_civ_raw = AsyncMock(return_value=None)
+    return RigctldHandler(radio, RigctldConfig(), state_store=store), radio
+
+
+@pytest.mark.asyncio
+async def test_ptt_poll_leaves_an_absent_canonical_field_absent() -> None:
+    store = StateStore()
+    handler, _radio = _mirror_handler(store)
+
+    response = await handler.execute(parse_line(b"t"))
+
+    # The client is still answered from the mirror — unchanged wire behaviour.
+    assert response.ok
+    assert response.values == ["0"]
+    # ... but nothing was published as canonical truth.
+    with pytest.raises(KeyError):
+        store.snapshot().field(_PTT_PATH)
+
+
+def _stale_ptt_store() -> StateStore:
+    """Store whose canonical PTT field has actually decayed to STALE.
+
+    ``mark_stale_due`` is the store's sole freshness-decay entry point, so a
+    field only stops projecting once it has been driven through it.
+    """
+    store = StateStore()
+    store.apply(
+        Observation(
+            path=_PTT_PATH,
+            value=False,
+            source=SourceMetadata(source="test", provider="tests"),
+            timestamp_monotonic=time.monotonic() - 5.0,
+            max_age=1.0,
+        )
+    )
+    store.mark_stale_due()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_ptt_poll_leaves_a_stale_canonical_field_untouched() -> None:
+    store = _stale_ptt_store()
+    handler, _radio = _mirror_handler(store)
+    before = store.snapshot().field(_PTT_PATH)
+    assert before.freshness is not FreshnessState.FRESH
+
+    response = await handler.execute(parse_line(b"t"))
+
+    assert response.ok
+    assert response.values == ["0"]
+    after = store.snapshot().field(_PTT_PATH)
+    assert after.source.source == "test"
+    assert after.freshness is before.freshness
+    assert after.last_observed_monotonic == before.last_observed_monotonic
+    # A stale field is not evidence of RX, and the poll did not make it one.
+    assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_ptt_poll_does_not_unlock_a_deferred_write() -> None:
+    """Refusal replaces fabrication: a poll cannot create RX truth."""
+    store = StateStore()
+    handler, radio = _mirror_handler(store)
+
+    poll = await handler.execute(parse_line(b"t"))
+    assert poll.values == ["0"]
+
+    assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.UNKNOWN
+
+    command = parse_line(b"F 14074000")
+    response = await handler.execute(command)
+
+    assert response.error is HamlibError.ERJCTED
+    assert format_response(command, response, ClientSession()) == b"RPRT -9\n"
+    radio.set_freq.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ptt_poll_records_the_mirror_fallback_as_a_diagnostic() -> None:
+    """A silent miss must not read as coverage."""
+    store = StateStore()
+    handler, radio = _mirror_handler(store, ptt=True)
+
+    await handler.execute(parse_line(b"t"))
+
+    events = [
+        event
+        for event in radio._state_diagnostics.events()
+        if event.kind == "rigctld_ptt_mirror_fallback"
+    ]
+    assert len(events) == 1
+    assert events[0].source == "rigctld.handler"
+    assert events[0].details["value"] is True


### PR DESCRIPTION
## Defect

`RigctldHandler._cmd_get_ptt` (`src/rigplane/rigctld/handler.py:1720-1732`, pre-change) answered a client `t` poll from the canonical projection when it was fresh. On a projection miss it fell back to the legacy `RadioState` mirror **and wrote that mirror value into the canonical StateStore** as a first-class observation:

```python
state = self._radio_state()
if state is not None:
    self._record_state_sample(
        ptt_path, bool(state.ptt),
        source="state_poller", max_age=self._config.cache_ttl,
    )
    return RigctldResponse(values=[str(int(state.ptt))])
```

`_record_state_sample` (`handler.py:1174-1198`) stamps the observation with `time.monotonic()` — *now* — and publishes it through `StateStore.apply`.

Three facts turn that into a false-RX path:

1. `RadioState.ptt` defaults to `False` (`src/rigplane/core/radio_state.py:256`). Before the CI-V pump has ever decoded a `0x1C/00` response, the mirror asserts "not transmitting" with no evidence at all.
2. The mirror carries **no observation time** for `ptt` — `RadioState` has no timestamp fields — so the value was stamped as observed now with nothing to contradict it. (The ticket cited `ptt_ts` at `_state_cache.py:79`; that field belongs to `StateCache`, a *different* class, and is not the mirror `_cmd_get_ptt` reads. The defect is therefore slightly worse than filed, not better: there was no observation time to discard.)
3. `_resolve_rigctld_rf_state` (`handler.py:713-746`) does not filter by `source`. A `source="state_poller"` sample from this path was indistinguishable from a real radio observation and satisfied the FRESH + `max_age` checks for `cache_ttl` seconds.

Consequence: the TX interlock's input could be fabricated. `_defer_write_gate` (`handler.py:748`) then resolved `RfState.RX` and let a DEFER-classified write (frequency, mode, band, VFO select) through **while the PA may be keyed**.

### Why false RX is the forbidden direction

The interlock's two error directions are not symmetric. A false **TX** costs a refused write: the client gets `RPRT -9` or a silently-skipped write, and the operator retries. A false **RX** costs a write applied into a keyed PA — retuning or mode-switching a transmitting radio. One is an inconvenience that announces itself; the other is a hardware-risk event that is silent at the moment it happens. Any tolerance- or confirmation-based design layered on the interlock can be defeated while a path exists that manufactures RX out of a default-`False` field, which is why this is a precondition rather than a cleanup.

## What changed

`src/rigplane/rigctld/handler.py`
- Deleted the `_record_state_sample(...)` call from the `_cmd_get_ptt` fallback branch. The canonical StateStore never receives a PTT observation manufactured by this seat.
- **Unchanged:** the returned `RigctldResponse`. The client is still answered from the mirror. Changing what `t` returns is a separate, client-visible decision and is deliberately out of scope — a non-zero RPRT drives WSJT-X into `TransceiverBase::offline()` -> `shutdown()`.
- Added a `rigctld_ptt_mirror_fallback` state diagnostic on that branch, using the same inline `isinstance(self._state_diagnostics, StateDiagnosticsRecorder)` + `.record(...)` pattern as the neighbouring `acquisition_unavailable` and `rigctld_delivery_trigger` sites in this file. No new mechanism, no new abstraction. (The kind string is not added to the `StateDiagnosticKind` literal, matching the existing `acquisition_unavailable` precedent; `record()` accepts `StateDiagnosticKind | str`.)

`tests/test_rigctld_tx_interlock.py` — four new tests:
- `test_ptt_poll_leaves_an_absent_canonical_field_absent` — the store keeps raising `KeyError` after the poll, and the client still gets `0`.
- `test_ptt_poll_leaves_a_stale_canonical_field_untouched` — source, freshness and `last_observed_monotonic` are all unchanged, and `_resolve_rigctld_rf_state` stays `UNKNOWN`.
- `test_ptt_poll_does_not_unlock_a_deferred_write` — after the poll the gate resolves `UNKNOWN`, `F 14074000` answers `ERJCTED` / `RPRT -9`, and `set_freq` is never awaited. Refusal replaces fabrication.
- `test_ptt_poll_records_the_mirror_fallback_as_a_diagnostic`.

One test-construction note worth recording: `mark_stale_due` is the store's *sole* freshness-decay entry point (`state_store.py:805`, MOR-432 — fields never age on their own). My first stale-case test used the existing `_store("stale")` helper, which only advances the freshness clock; the field stayed `FRESH`, the projection hit, and the fallback was never reached — i.e. the test passed vacuously. `_stale_ptt_store()` drives the field through `mark_stale_due()` so the fallback is genuinely exercised. Any future test asserting "stale field" behaviour in this handler needs the same treatment.

## Mutation result

Restored the `_record_state_sample` call by hand (keeping the new diagnostic, so only the fabrication was mutated) and re-ran with `PYTHONDONTWRITEBYTECODE=1`:

```
3 failed, 1 passed, 92 deselected
FAILED test_ptt_poll_leaves_an_absent_canonical_field_absent
FAILED test_ptt_poll_leaves_a_stale_canonical_field_untouched   (assert 'state_poller' == 'test')
FAILED test_ptt_poll_does_not_unlock_a_deferred_write           (assert RfState.RX is RfState.UNKNOWN)
```

The mutation is killed by three of the four tests. The diagnostic test correctly survives — it pins a different property. The fix was then restored and verified byte-identical to the pre-mutation file by sha256.

## Existing-test decision

No existing test pinned the removed behaviour. I checked every test referencing `get_ptt` (`test_rigctld_handler.py` — including `test_get_ptt_defaults_off`, `test_get_ptt_reads_radio_state`, `test_get_ptt_projects_state_store_snapshot`, `test_get_ptt_keeps_optimistic_state_until_radio_state_catches_up`; plus `test_rigctld_protocol.py`, `test_server_wire.py`, `test_rigctld_client_backend.py`, `test_hamlib_external_rigctld_contract.py`). All of them assert the **response values**, which this change leaves untouched; none asserts that the StateStore is written on a `t` poll. Nothing was deleted, weakened, or updated. The full suite is green unchanged.

## Follow-up findings (reported, not fixed)

### 1. Other `source="state_poller"` launder sites

All six remaining sites are in `src/rigplane/rigctld/handler.py` and all read the same legacy `RadioState` mirror:

| Line | Field | Mirror default | Feeds a decision? |
|---|---|---|---|
| 1390 | per-receiver freq (SUB), `state.sub.freq` | `0` — **not** guarded | No gate reads freq; feeds the client answer and store freshness/readback bookkeeping |
| 1407 | per-receiver freq (MAIN), `main_state.freq` | guarded: `_main_receiver_state()` returns `None` when `freq <= 0` | as above |
| 2143 | `STRENGTH` (SUB s-meter) | `0` | Display only |
| 2166 | `STRENGTH` (MAIN s-meter) | `0`, guarded only by MAIN `freq > 0` | Display only |
| 2192 | `RFPOWER`, `state.power_level` | `0`, guarded by MAIN `freq > 0` | Display only |
| **2511** | **`split`**, `state.split` | **`False`, ungated** | **Closest analogue to this defect** |

The meter/power sites (2143/2166/2192) are display-only, so a laundered value is a cosmetic lie rather than a safety one. The frequency sites are only partly guarded — MAIN filters the never-observed `0` via the `freq > 0` sentinel, but **SUB at line 1390 does not**, so a never-observed SUB frequency of `0` can be published as a fresh canonical observation.

The one I would prioritise is **line 2511 (`split`)**: it has the identical shape to the PTT defect — a `bool` defaulting to `False`, no age bound, no sentinel to filter a never-observed value, laundered as a fresh `state_poller` observation. `set_split_vfo` is a DEFER-classified write in the `vfo-topology` family, so canonical split state sits in the same neighbourhood as the interlock even though `_resolve_rigctld_rf_state` reads only `global.tx_state.ptt` today. Worth its own ticket before anything starts gating on split.

### 2. Does the client-facing `"0"` from a never-observed mirror deserve its own ticket?

**Yes — and it should be filed, but carefully scoped, because the honest fix is not obviously available on this wire.**

The reasoning: after this change the *canonical* store is honest, but the *client* is still told `0` ("not transmitting") on the basis of a `RadioState.ptt` that may never have been observed. For WSJT-X that answer is load-bearing — it polls `t` continuously and uses it to decide whether the rig is already transmitting. So the same false-RX shape that this ticket removed from the interlock's input still exists on the wire, one layer out.

What makes it a separate ticket rather than scope creep here is that the obvious remedy is blocked: hamlib has no "unknown" PTT encoding, and returning a non-zero RPRT drives WSJT-X into `TransceiverBase::offline()` -> `shutdown()`, which itself sends a PTT-off and, on a repeat, opens a modal error dialog. So the ticket is really a design question — options include answering from the mirror only when it has *ever* been observed (requires the mirror to carry an observation time, which today it does not), falling back to a synchronous on-demand read, or accepting the lie and documenting it — and it needs an owner decision, not a builder's judgement. The new `rigctld_ptt_mirror_fallback` diagnostic added here is exactly the instrument that would size the problem first: it counts how often a real deployment answers `t` from the mirror at all.

## Gates

Ran what `.github/workflows/quick.yml` runs for the `core` filter (this diff touches only `src/` and `tests/`, so the `frontend` filter does not match and the frontend block, including `mypy --strict src/rigplane/web`, does not run). Executed with CI's pinned interpreter, `UV_PYTHON=3.11`.

```
pytest tests/ --ignore=tests/integration -n auto --timeout=300 --timeout-method=thread
  10151 passed, 74 skipped, 14 xfailed, 1 xpassed in 71.47s
ruff check src/ tests/            All checks passed!
ruff format --check src/ tests/   678 files already formatted
lint-imports                      Contracts: 5 kept, 0 broken.
node --test .github/scripts/agent-review-gate.test.js   19 pass, 0 fail
validate --dry-run --gate  IC-7610 / X6200 / FTX-1      all exit 0
mypy src/                         12 errors in 3 files — pre-existing
```

`mypy src/` is not a quick.yml gate, but was run per the task brief. Its 12 errors are in `runtime/_audio_runtime_mixin.py` (8), `runtime/_control_phase.py` (3) and `web/radio_poller.py` (1) — none in a file this PR touches, and verified identical at `origin/main` by stashing this diff and re-running.

Guardrails: 2 files, +142/-7.
