### PR TITLE
fix(MOR-1905): fail closed on Yaesu TX2 front-panel-keyed PTT

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1004,18 +1004,27 @@ class YaesuCatRadio:
         ``0`` reads as transmitting, and an unrecognised value fails
         closed (transmitting) with a diagnostic rather than reading as RX.
 
+        PTT is polled at a fast, unthrottled cadence, so a persistently
+        unrecognised state would otherwise flood the log. This reuses the
+        ``_poll_warned_fields`` warn-once-then-DEBUG idiom already used for
+        permanently-unsupported poll fields (MOR-561) rather than adding new
+        rate-limiting machinery.
+
         Returns:
             ``True`` if transmitting, ``False`` if receiving.
         """
         result = await self._query("get_ptt")
         state = result["state"]
         if state not in ("0", "1", "2"):
-            logger.warning(
+            label = "ptt_unrecognised_state"
+            log = logger.debug if label in self._poll_warned_fields else logger.warning
+            self._poll_warned_fields.add(label)
+            log(
                 "read_ptt: unrecognised TX state %r from %s; failing closed (transmitting)",
                 state,
                 self.model,
             )
-        return state != "0"
+        return bool(state != "0")
 
     async def get_ptt(self) -> bool:
         """Query the current PTT state.

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -996,11 +996,26 @@ class YaesuCatRadio:
     async def read_ptt(self) -> bool:
         """Read the current PTT state without mutating legacy state.
 
+        The Yaesu ``TX;`` answer is three-valued, not a plain boolean flag:
+        ``0`` = receiving, ``1`` = transmitting (CAT-keyed), ``2`` =
+        transmitting (the radio itself keyed it -- front panel, mic,
+        footswitch, or VOX). Treating ``2`` as receiving is a fail-open
+        inversion of transmit truth (MOR-1905), so any state other than
+        ``0`` reads as transmitting, and an unrecognised value fails
+        closed (transmitting) with a diagnostic rather than reading as RX.
+
         Returns:
             ``True`` if transmitting, ``False`` if receiving.
         """
         result = await self._query("get_ptt")
-        return bool(result["state"] == "1")
+        state = result["state"]
+        if state not in ("0", "1", "2"):
+            logger.warning(
+                "read_ptt: unrecognised TX state %r from %s; failing closed (transmitting)",
+                state,
+                self.model,
+            )
+        return state != "0"
 
     async def get_ptt(self) -> bool:
         """Query the current PTT state.

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -17,6 +17,7 @@ from rigplane.backends.yaesu_cat.transport import CatTimeoutError
 from rigplane.exceptions import CommandError
 from rigplane.exceptions import ConnectionError as RadioConnectionError
 from rigplane.rig_loader import load_rig
+from rigplane.types import BreakInMode
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -384,6 +385,26 @@ async def test_get_ptt_unexpected_value_reads_as_transmitting(connected_radio, c
 
 
 @pytest.mark.asyncio
+async def test_get_ptt_unexpected_value_warns_once_then_demotes_to_debug(
+    connected_radio, caplog
+):
+    """MOR-1905: repeat unrecognised TX states demote to DEBUG (MOR-561 idiom).
+
+    PTT is polled at a fast, unthrottled cadence; without this, a radio
+    stuck on an unrecognised TX state would flood the log at WARNING every
+    cycle. Reuses the existing warn-once-then-DEBUG mechanism instead of
+    new rate-limiting machinery.
+    """
+    connected_radio._transport.query = AsyncMock(return_value="TX9")
+    with caplog.at_level("DEBUG"):
+        await connected_radio.get_ptt()
+        caplog.clear()
+        await connected_radio.get_ptt()
+    assert not any(record.levelname == "WARNING" for record in caplog.records)
+    assert any(record.levelname == "DEBUG" for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_get_powerstat_unexpected_value_stays_two_valued(connected_radio):
     """MOR-1905 scope pin: PS (power switch) is genuinely two-valued.
 
@@ -393,6 +414,35 @@ async def test_get_powerstat_unexpected_value_stays_two_valued(connected_radio):
     """
     connected_radio._transport.query = AsyncMock(return_value="PS9")
     assert await connected_radio.get_powerstat() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "unexpected_response", "expected"),
+    [
+        ("get_auto_notch", "BC09", False),
+        ("get_narrow", "NA09", False),
+        ("get_split", "ST9", False),
+        ("get_processor", "PR09", False),
+        ("get_cw_spot", "CS9", False),
+        ("get_auto_info", "AI9", False),
+        ("get_vox", "VX9", False),
+        ("get_lock", "LK9", False),
+        ("get_break_in", "BI9", BreakInMode.OFF),
+    ],
+)
+async def test_other_state_readers_stay_two_valued(
+    connected_radio, method_name, unexpected_response, expected
+):
+    """MOR-1905 scope pin: the remaining nine `== "1"` readers are genuinely
+    two-valued fields (unlike PTT's three-valued TX) and must stay a plain
+    equality check. An unrecognised code must fall through to the
+    "off"/False branch, not be swept into PTT's fail-closed treatment by a
+    future blanket edit.
+    """
+    connected_radio._transport.query = AsyncMock(return_value=unexpected_response)
+    result = await getattr(connected_radio, method_name)()
+    assert result == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -335,6 +335,7 @@ async def test_set_ptt_off(connected_radio):
 
 @pytest.mark.asyncio
 async def test_get_ptt_transmitting(connected_radio):
+    """TX1; = RADIO TX off, CAT TX on -> transmitting."""
     connected_radio._transport.query = AsyncMock(return_value="TX1")
     ptt = await connected_radio.get_ptt()
     assert ptt is True
@@ -343,9 +344,55 @@ async def test_get_ptt_transmitting(connected_radio):
 
 @pytest.mark.asyncio
 async def test_get_ptt_receiving(connected_radio):
+    """TX0; = RADIO TX off, CAT TX off -> receiving."""
     connected_radio._transport.query = AsyncMock(return_value="TX0")
     ptt = await connected_radio.get_ptt()
     assert ptt is False
+
+
+@pytest.mark.asyncio
+async def test_get_ptt_transmitting_radio_keyed(connected_radio):
+    """MOR-1905: TX2; = RADIO TX on, CAT TX off -> transmitting.
+
+    P1=2 means the radio itself keyed the transmitter (front-panel PTT,
+    mic, footswitch, VOX) rather than a CAT command. Reading this as
+    "receiving" is a fail-open inversion of transmit truth.
+    """
+    connected_radio._transport.query = AsyncMock(return_value="TX2")
+    ptt = await connected_radio.get_ptt()
+    assert ptt is True
+    assert connected_radio.radio_state.ptt is True
+
+
+@pytest.mark.asyncio
+async def test_read_ptt_transmitting_radio_keyed(connected_radio):
+    """MOR-1905: read_ptt (not just get_ptt) must fail closed on TX2;."""
+    connected_radio._transport.query = AsyncMock(return_value="TX2")
+    assert await connected_radio.read_ptt() is True
+
+
+@pytest.mark.asyncio
+async def test_get_ptt_unexpected_value_reads_as_transmitting(connected_radio, caplog):
+    """MOR-1905: an unrecognised TX state must fail closed, with a diagnostic."""
+    connected_radio._transport.query = AsyncMock(return_value="TX9")
+    with caplog.at_level("WARNING"):
+        ptt = await connected_radio.get_ptt()
+    assert ptt is True
+    assert any(
+        "TX9" in record.message or "9" in record.message for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_powerstat_unexpected_value_stays_two_valued(connected_radio):
+    """MOR-1905 scope pin: PS (power switch) is genuinely two-valued.
+
+    Only the TX answer carries a third "radio keyed it" state; the PTT
+    fail-closed fix must not sweep into other `== "1"` readers like
+    powerstat, which stay a plain equality check.
+    """
+    connected_radio._transport.query = AsyncMock(return_value="PS9")
+    assert await connected_radio.get_powerstat() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was wrong

`YaesuCatRadio.read_ptt` (`src/rigplane/backends/yaesu_cat/radio.py`) mapped the Yaesu `TX;` answer with `bool(result["state"] == "1")`. The Yaesu `TX` answer is three-valued, not a boolean flag:

| P1 | Meaning |
| -- | -- |
| `0` | RX (RADIO TX off, CAT TX off) |
| `1` | TX, CAT-keyed (RADIO TX off, CAT TX on) |
| `2` | TX, radio-keyed (RADIO TX on, CAT TX off — front panel / mic / footswitch / VOX) |

`state == "1"` mapped `"2"` to `False`, i.e. **receiving**. This is a fail-open inversion of transmit truth in exactly the case the interlock exists for: a front-panel or footswitch transmission on a Yaesu reads as RX to every consumer of `read_ptt`, so the TX interlock passes writes it should gate, and the UI shows RX while the PA is keyed. Measured on the bench (FTX-1, front-panel key): `TX;` returned `'2'`.

`get_ptt` (line ~1005) delegates to `read_ptt`, so it inherited both the bug and the fix without a separate code change.

## What changed

`read_ptt` now returns `True` (transmitting) for any state other than `"0"`, and logs a `logger.warning` diagnostic when the state is outside `{"0", "1", "2"}` before still failing closed (transmitting). No other `== "1"` reader in this file was touched — the ticket found eleven occurrences, and only the PTT one is defective; the other ten read genuinely two-valued fields (power switch, RIT/XIT/split flags, break-in mode, etc.).

## Acceptance criteria → tests

All in `tests/test_ftx1_radio.py`:

- `TX2;` reads as transmitting → `test_get_ptt_transmitting_radio_keyed`, `test_read_ptt_transmitting_radio_keyed`
- `TX1;` reads as transmitting → `test_get_ptt_transmitting` (pre-existing, unchanged behavior)
- `TX0;` reads as receiving → `test_get_ptt_receiving` (pre-existing, unchanged behavior)
- Unrecognised value reads as transmitting + diagnostic → `test_get_ptt_unexpected_value_reads_as_transmitting` (asserts `ptt is True` and a `caplog` WARNING record)
- `get_ptt` audited alongside `read_ptt` → covered directly (`get_ptt` delegates to `read_ptt`)
- Other `== "1"` readers stay two-valued (scope pin) → `test_get_powerstat_unexpected_value_stays_two_valued`

## Mutation result (ticket's required check)

Restored `bool(result["state"] == "1")` by hand, ran with `PYTHONDONTWRITEBYTECODE=1`:

```
tests/test_ftx1_radio.py::test_get_ptt_transmitting_radio_keyed FAILED
E   assert False is True
```
RED confirmed. Restored the fix, same test:
```
tests/test_ftx1_radio.py::test_get_ptt_transmitting_radio_keyed PASSED
```
GREEN confirmed.

## Gates run

- `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread`
  → `10244 passed, 13 skipped, 14 xfailed, 1 xpassed`. 6 failures in `tests/test_web_teardown_unkey_gate.py` reproduce identically on `origin/main` with this diff stashed (pre-existing, unrelated to Yaesu PTT — TX interlock RF-state plumbing). One `test_radio.py` parametrized case failed once under `-n auto` and passed on rerun both serially and in a second full parallel run — confirmed xdist flake, not caused by this diff (file untouched by this change).
- `uv run ruff check src/ tests/` → All checks passed. `uv run ruff format src/ tests/` → 1 file reformatted (my new test file, whitespace-only line wrap), re-verified green after.
- `uv run lint-imports` → Contracts: 5 kept, 0 broken.

## Public boundary self-check

```
git log -p origin/main..HEAD | grep -nEi '192\.168|10\.[0-9]+\.|mac-?mini|\.local\b|BWS|rigplane-pro|ssh key|password|token' || echo "public-boundary self-check clean"
```
Output: `public-boundary self-check clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)