### PR TITLE
fix(MOR-1879): unblock red main — state the key premise the gated ptt_on now requires

### DIFF
--- a/tests/test_web_teardown_unkey_gate.py
+++ b/tests/test_web_teardown_unkey_gate.py
@@ -24,6 +24,7 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.core.state_store import StateStore
 from rigplane.profiles import resolve_radio_profile
+from rigplane.runtime.tx_interlock import RfState, TxInterlockRefusal
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, PttOff, PttOn, RadioPoller
 
@@ -59,19 +60,39 @@ def _poller(
     return poller, radio
 
 
-def _observe_rx(poller: RadioPoller) -> None:
-    """Apply a fresh PTT=False observation, matching a real RX readback."""
+def _observe_ptt(poller: RadioPoller, *, value: bool) -> None:
+    """Apply a fresh PTT observation, matching a real poll readback."""
     store = poller._state_store
     store.apply(
         Observation(
             path=FieldPath.global_("tx_state", "ptt"),
-            value=False,
+            value=value,
             source=SourceMetadata(source="poll_response", provider="test"),
             timestamp_monotonic=time.monotonic(),
             max_age=5.0,
             provider_generation=store.provider_generation,
         )
     )
+
+
+def _observe_rx(poller: RadioPoller) -> None:
+    """Apply a fresh PTT=False observation, matching a real RX readback."""
+    _observe_ptt(poller, value=False)
+
+
+async def _key(poller: RadioPoller, session_id: str) -> None:
+    """Key the rig the way an operator does: observed RX, write, observed TX.
+
+    MOR-1879 gates ``ptt_on`` at the interlock seat, so a key request needs a
+    fresh RX observation to pass. The rig transmits afterwards, so the TX
+    observation that follows is what the poll loop would report — and it is
+    what keeps the keyer record live for the teardown gate to weigh. Mirrors
+    the helper the end-to-end twin of these rows uses in
+    ``tests/test_web_mod_input_restore.py::TestKeyerAttributedTeardown``.
+    """
+    _observe_ptt(poller, value=False)
+    await poller._execute(PttOn(), source="websocket", session_id=session_id)
+    _observe_ptt(poller, value=True)
 
 
 def test_no_recorded_keyer_is_permitted() -> None:
@@ -82,23 +103,39 @@ def test_no_recorded_keyer_is_permitted() -> None:
 
 async def test_recorded_keyer_same_session_is_permitted() -> None:
     poller, _radio = _poller()
-    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    await _key(poller, "ws-a")
 
     assert poller.teardown_unkey_permitted("websocket", "ws-a") is True
 
 
 async def test_recorded_keyer_different_session_rf_not_rx_is_not_permitted() -> None:
     poller, _radio = _poller()
-    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    await _key(poller, "ws-a")
 
-    # No RF observation has landed: _current_rf_state resolves UNKNOWN, not
-    # RX, so the foreign session's teardown must be withheld.
+    # RF resolves TX, not RX: the rig is on the air under ws-a, so the
+    # foreign session's teardown must be withheld.
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is False
+
+
+async def test_recorded_keyer_different_session_rf_unknown_is_not_permitted() -> None:
+    """The other not-RX arm: RF truth lapsed rather than reading TX.
+
+    A reconnect opens a new provider generation, which voids the previous
+    generation's PTT observation, so ``_current_rf_state`` resolves UNKNOWN
+    while the keyer record is still live. Not-RX is not-RX: the foreign
+    teardown stays withheld rather than guessing the rig is idle.
+    """
+    poller, _radio = _poller()
+    await _key(poller, "ws-a")
+    poller._state_store.begin_provider_generation()
+
+    assert poller._current_rf_state() is RfState.UNKNOWN
     assert poller.teardown_unkey_permitted("websocket", "ws-b") is False
 
 
 async def test_observed_rx_permits_and_voids_the_record_latch() -> None:
     poller, _radio = _poller()
-    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    await _key(poller, "ws-a")
     _observe_rx(poller)
 
     assert poller.teardown_unkey_permitted("websocket", "ws-b") is True
@@ -117,7 +154,7 @@ async def test_observed_rx_permits_and_voids_the_record_latch() -> None:
 
 async def test_failed_unmanaged_ptt_off_write_still_clears_the_record() -> None:
     poller, _radio = _poller(ptt_off_error=RuntimeError("boom"))
-    await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    await _key(poller, "ws-a")
     assert poller._last_keyer == ("websocket", "ws-a")
 
     raised: Exception | None = None
@@ -137,6 +174,9 @@ async def test_failed_unmanaged_ptt_on_write_leaves_no_phantom_record() -> None:
     """Record placement after the write: a key that never reached the rig
     must not arm the withhold against every other session."""
     poller, _radio = _poller(ptt_on_error=RuntimeError("key never reached the rig"))
+    # Observed RX so the interlock admits the key: the write itself is what
+    # must fail here, not the gate in front of it.
+    _observe_rx(poller)
 
     raised: Exception | None = None
     try:
@@ -153,7 +193,7 @@ async def test_record_is_per_poller_instance_no_leakage() -> None:
     poller_a, _radio_a = _poller()
     poller_b, _radio_b = _poller()
 
-    await poller_a._execute(PttOn(), source="websocket", session_id="ws-a")
+    await _key(poller_a, "ws-a")
 
     # Probe poller_b with a THIRD session id, distinct from "ws-a" (the one
     # poller_a just keyed with). Reusing "ws-a" here would be vacuous: it
@@ -194,3 +234,55 @@ def test_control_handler_defaults_to_permitted_when_gate_raises() -> None:
     handler._release_ptt_on_teardown()
 
     assert command_queue.drain() == [PttOff()]
+
+
+async def test_unkey_is_never_refused_for_want_of_rf_truth() -> None:
+    """The standing invariant: an unkey is never refused for policy reasons.
+
+    MOR-1879 put ``ptt_on`` behind the interlock seat that fails closed on
+    absent RF truth. ``ptt_off`` must stay exempt on the far side of that
+    change, and it is exempt three times over: the seat never consults the
+    policy for it (PTT_OFF is neither an immediate-block family nor DEFER, so
+    ``_enforce_tx_interlock`` returns early); ``classify_tx_interlock`` reads
+    ALWAYS_PASS off ``_ALWAYS_PASS_TYPES`` by type, deliberately ahead of
+    every disruptive table; and ``evaluate_tx_interlock`` answers ALWAYS_PASS
+    before RF state is read at all. This row is the outcome those layers
+    exist for: dropping a transmission is recoverable, a rig left keyed
+    because the server could not prove it was keyed is not.
+    """
+    for rf_setup, expected in (
+        (None, RfState.UNKNOWN),
+        (True, RfState.TX),
+    ):
+        poller, radio = _poller()
+        if rf_setup is not None:
+            _observe_ptt(poller, value=rf_setup)
+        assert poller._current_rf_state() is expected
+
+        await poller._execute(PttOff(), source="websocket", session_id="ws-a")
+
+        radio.set_ptt.assert_awaited_once_with(False)
+
+
+async def test_key_is_refused_when_rf_state_is_unknown() -> None:
+    """The contract MOR-1879 introduced, pinned at the seat these rows use.
+
+    A Web key request with no RF truth behind it is refused fail-closed, the
+    write never reaches the rig, and — the part this file cares about — the
+    refused key leaves no keyer record, so it cannot arm the teardown
+    withhold against every other session.
+    """
+    poller, radio = _poller()
+    assert poller._current_rf_state() is RfState.UNKNOWN
+
+    raised: TxInterlockRefusal | None = None
+    try:
+        await poller._execute(PttOn(), source="websocket", session_id="ws-a")
+    except TxInterlockRefusal as exc:
+        raised = exc
+
+    assert raised is not None, "a key with no RF truth must be refused"
+    assert raised.reason_code == "rf_state_unknown"
+    radio.set_ptt.assert_not_awaited()
+    assert poller._last_keyer is None
+    assert poller.teardown_unkey_permitted("websocket", "ws-b") is True


### PR DESCRIPTION
Unblocks a red `main`. CI run for `main` at 769bfc71 reports `6 failed, 10183 passed`, all six in `tests/test_web_teardown_unkey_gate.py`, all raising `TxInterlockRefusal: RF state is unknown`.

## Which commit introduced it, and how that was determined

Three candidates sat between the last known-green run and the failure:

| commit | quick.yml |
|---|---|
| `fb7a86da` fix(MOR-1892): re-observe the field a command wrote | SUCCESS |
| `b3ab76b1` feat(MOR-1879): gate Web ptt_on at the server TX interlock | **CANCELLED** |
| `6bdb5846` fix(MOR-1900): stop fabricating RF truth from the legacy PTT mirror | **CANCELLED** |
| `769bfc71` feat(MOR-1904): bound key-down for a rigctld-issued key on an unmanaged radio | FAILURE |

Two of the four merged with a cancelled rather than a green run, so the breakage entered unobserved and only surfaced two merges later. That is how this went unnoticed.

Each candidate was checked out in a clean worktree with its own `uv sync --all-extras` (a venv built in another tree imports `rigplane` from *that* tree) and the one file was run:

```
=== fb7a86da fix(MOR-1892): re-observe the field a command wrote ===
8 passed in 3.19s
=== b3ab76b1 feat(MOR-1879): gate Web ptt_on at the server TX interlock ===
6 failed, 2 passed in 1.91s
=== 6bdb5846 fix(MOR-1900): stop fabricating RF truth from the legacy PTT mirror ===
6 failed, 2 passed in 1.82s
```

**First bad commit: `b3ab76b1` (MOR-1879).** `6bdb5846` and `769bfc71` inherited it; neither touches `web/radio_poller.py`.

## Conclusion: (B), the tests were stale — and the unkey invariant is intact

The programme's standing invariant is that **an unkey must never be refused for policy reasons**. The failure text looked like a violation of exactly that. It is not. The evidence:

**1. The refusal lands on `PttOn`, not on the unkey.** The full traceback names the command:

```
async def test_failed_unmanaged_ptt_off_write_still_clears_the_record() -> None:
    poller, _radio = _poller(ptt_off_error=RuntimeError("boom"))
>   await poller._execute(PttOn(), source="websocket", session_id="ws-a")
...
self = <RadioPoller object ...>
cmd = PttOn()
E   rigplane.runtime.tx_interlock.TxInterlockRefusal: RF state is unknown
```

Every one of the six failures is an **arrange** step: each row sets up a recorded keyer with a bare `_execute(PttOn())` against a poller that has never seen an RF observation. The two rows that never key (`test_no_recorded_keyer_is_permitted`, `test_control_handler_defaults_to_permitted_when_gate_raises`) pass at every SHA. MOR-1879 deliberately added `PTT_ON` to `_WEB_IMMEDIATE_BLOCK_FAMILIES`, so that key is now refused fail-closed at RF UNKNOWN — as designed, under an owner re-ruling recorded in the commit message.

**2. The unkey is not refusable — measured, not merely read.** Driving `_execute` directly at each RF state on `769bfc71`:

```
PttOff @ UNKNOWN -> reached radio: [call(False)]
PttOff @ TX      -> reached radio: [call(False)]
PttOn  @ UNKNOWN -> refused: TxInterlockRefusal ... reason_code=rf_state_unknown
PttOn  @ RX      -> reached radio: [call(True)]  keyer=('websocket', 'ws-a')
```

`ptt_off` is exempt three times over, and it takes breaking **all three** to make an unkey refusable:
- `_enforce_tx_interlock` returns early — PTT_OFF is neither an immediate-block family nor DEFER, so RF state is never even read;
- `classify_tx_interlock` reads ALWAYS_PASS off `_ALWAYS_PASS_TYPES` **by type**, deliberately placed ahead of every disruptive table ("a future incomplete or corrupt disruptive table must not make a de-key/stop operation harder to execute");
- `evaluate_tx_interlock` answers ALWAYS_PASS before consulting RF state at all.

**3. The gate's own decision table is unchanged.** After keying with a truthful observed-TX state, a foreign session's teardown is still withheld (`permitted = False`) — the same answer the rows assert.

**4. The introducing commit already applied this exact remediation to the sibling suite.** `b3ab76b1` updated `TestKeyerAttributedTeardown` in `tests/test_web_mod_input_restore.py` — the end-to-end twin of these very rows, named in this file's own module docstring — adding a `_key` helper that observes RX, writes, then observes TX, with the note "MOR-1879 gates `ptt_on` at the interlock seat, so a key request needs a fresh RX observation to pass." It could not reach this file: `tests/test_web_teardown_unkey_gate.py` arrived in parallel via `cdfe45a8` (#2754), so neither branch saw the other, and both merged on cancelled runs.

So: **(B).** The new contract is intended, and it is safe — it tightens the *key*, and leaves the *unkey* structurally unrefusable. No production code needed changing, and none was changed.

## The fix

One file, test-only, `+102 / -10`.

- A local `_key(poller, session_id)` helper stating the premise the gate now requires: observed RX, the write, then observed TX (what the poll loop would report, and what keeps the keyer record live for the gate to weigh). Same shape as the sibling suite's helper. Six arrange sites moved onto it; the row whose `ptt_on` *write* must raise gets a plain `_observe_rx` so the write, not the gate in front of it, is what fails.
- `test_unkey_is_never_refused_for_want_of_rf_truth` — pins the standing invariant directly at this seat: `ptt_off` reaches the rig at RF UNKNOWN and at RF TX.
- `test_key_is_refused_when_rf_state_is_unknown` — pins the contract MOR-1879 introduced, including its `rf_state_unknown` reason code and the part this file cares about: a refused key leaves no keyer record, so it cannot arm the teardown withhold against every other session.
- `test_recorded_keyer_different_session_rf_unknown_is_not_permitted` — the old arrange covered the UNKNOWN arm of the not-RX branch incidentally. Widening the arrange to an observed TX would have narrowed that, so the UNKNOWN arm is now pinned explicitly (a reconnect opens a new provider generation, voiding the prior generation's observation while the keyer record is still live).

## Mutation verification of the new pins

Run with `PYTHONDONTWRITEBYTECODE=1` throughout, so same-second size-preserving edits cannot reuse a stale `.pyc`. Production files restored from git after each mutation.

| mutation | result |
|---|---|
| `PTT_OFF` added to `_WEB_IMMEDIATE_BLOCK_FAMILIES` (layer 1 only) | 11 passed — survives, correctly: layers 2 and 3 still exempt it |
| above + `PTT_OFF` metadata `ALWAYS_PASS -> BLOCK` (layers 1 + 3) | 11 passed — survives, correctly: `_ALWAYS_PASS_TYPES` still answers by type |
| `PttOff` dropped from `_ALWAYS_PASS_TYPES` + layer 1 | 11 passed — survives, correctly: it falls through to TX_SAFE, still permitted |
| `PttOff` reclassified `_ALWAYS_PASS_TYPES -> _HARD_BLOCK_TYPES` **and** `PTT_OFF` added to `_WEB_IMMEDIATE_BLOCK_FAMILIES` — the unkey genuinely becomes refusable | **`test_unkey_is_never_refused_for_want_of_rf_truth` FAILED** with `RF state is unknown` / `RF state is TX; command is blocked` |
| `PTT_ON` removed from `_WEB_IMMEDIATE_BLOCK_FAMILIES` (revert MOR-1879) | **`test_key_is_refused_when_rf_state_is_unknown` FAILED** |

The surviving rows are informative rather than a weakness: they map the defence in depth and show precisely which combination the invariant pin discriminates.

## Gates

Baseline first — the same suite against `origin/main`'s version of the file, in the same worktree and venv:

```
FAILED tests/test_web_teardown_unkey_gate.py::test_failed_unmanaged_ptt_on_write_leaves_no_phantom_record
FAILED tests/test_web_teardown_unkey_gate.py::test_recorded_keyer_same_session_is_permitted
FAILED tests/test_web_teardown_unkey_gate.py::test_recorded_keyer_different_session_rf_not_rx_is_not_permitted
FAILED tests/test_web_teardown_unkey_gate.py::test_record_is_per_poller_instance_no_leakage
FAILED tests/test_web_teardown_unkey_gate.py::test_observed_rx_permits_and_voids_the_record_latch
FAILED tests/test_web_teardown_unkey_gate.py::test_failed_unmanaged_ptt_off_write_still_clears_the_record
= 6 failed, 10240 passed, 13 skipped, 14 xfailed, 1 xpassed, 1 warning in 158.14s =
```

Exactly the six CI reports and nothing else. Then with the fix:

`uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread`
```
= 10249 passed, 13 skipped, 14 xfailed, 1 xpassed, 1 warning in 132.66s (0:02:12) =
```
exit 0. 10240 baseline passes + the 6 restored + 3 new pins = 10249.

`uv run ruff check src/ tests/`
```
All checks passed!
```

`uv run ruff format src/ tests/`
```
679 files left unchanged
```

`uv run lint-imports`
```
rigplane layered architecture KEPT
top siblings must not depend on each other KEPT
mid-tier siblings must not depend on each other KEPT
low-tier siblings must not depend on each other KEPT
validation is a leaf consumer — no lower layer may import it KEPT

Contracts: 5 kept, 0 broken.
```

`uv run mypy --strict src/rigplane/web`
```
Success: no issues found in 26 source files
```

Note on flakes: two earlier full-suite runs came back with 4 and then 2 unrelated failures (`test_rate_limiter`, `test_radio`, `test_icom_receiver_tier` — all CI-V/timing rows), while a concurrent full suite was saturating the machine. All passed in isolation, the sets did not overlap between runs, and the quiet-machine baseline and final runs above are both clean. They are load-induced timing flakes, not this diff — which touches one test file and no production code.

## Guardrails

1 file, +102 / -10. No production code, no new abstractions, no refactoring. Nothing touched in `backends/yaesu_cat/**`, `frontend/**`, `rigctld/server.py`, or `rigs/**`.
