### PR TITLE
fix(MOR-1903): drive a client-gated CI-V PTT re-read in standalone rigctld

### DIFF
--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -22,6 +22,7 @@ import time
 from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any, cast
 
+from ..commands.commander import Priority
 from ..core.acquisition_scheduler import (
     AcquisitionExecutionResult,
     AcquisitionExecutor,
@@ -56,17 +57,21 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["PTT_REREAD_INTERVAL_SECONDS", "RigctldServer", "run_rigctld_server"]
 
-# MOR-1903: standalone rigctld has no cadence poller — ``due_requests()`` is
-# called only by the web radio poller, so in ``rigplane serve`` nothing ever
-# sends a ``0x1C/0x00`` read after connect. Without an observation the strict
-# resolver behind the MOR-1881 DEFER gate (and the BLOCK pre-gate guarding
-# key-down) stays UNKNOWN forever and every frequency / mode / VFO / split /
-# RIT write and every ``T 1`` is refused with ``RPRT -9``.
+# MOR-1903: standalone rigctld had no cadence poller of any kind —
+# ``due_requests()`` is called only by the web radio poller, so nothing ever
+# sent a ``0x1C/0x00`` read after connect, the strict resolver behind the
+# MOR-1881 DEFER gate (and the BLOCK pre-gate guarding key-down) stayed UNKNOWN
+# forever, and every frequency / mode / VFO / split / RIT write and every
+# ``T 1`` was refused with ``RPRT -9``.
 #
-# The TTL is read from ``_civ_rx``'s own table, never copied. A quarter of it
-# puts two reads inside every freshness window, so one lost reply cannot open a
-# gap; a cadence at or above the TTL would instead reproduce the web
-# deployment's known-then-unknown sawtooth, which refuses most writes.
+# The TTL is read from ``_civ_rx``'s own table, never copied; a quarter of it
+# puts two reads in every freshness window, so one lost reply cannot open a gap
+# (a cadence at or above the TTL would reproduce the web deployment's
+# known-then-unknown sawtooth, which refuses most writes). It is a background
+# poller and is sent as one: ``Priority.BACKGROUND`` to yield the shared CI-V
+# lane to user commands, an unkey above all (MOR-497i), and
+# ``wait_dispatch=False`` so parking on the Commander future cannot push the
+# send past the very TTL this cadence exists to stay inside (MOR-497ii).
 PTT_OBSERVATION_TTL_SECONDS: float = _OBSERVATION_MAX_AGE_SECONDS[
     ("global", "tx_state", "ptt")
 ]
@@ -460,8 +465,7 @@ class RigctldServer:
     def _start_ptt_reread_task(self) -> None:
         """Start the client-gated CI-V PTT re-read, if this radio supports it.
 
-        CI-V only: the reply is published canonically by the existing ingress,
-        profile-independently. The Yaesu leg is MOR-1903-B.
+        CI-V only; the Yaesu leg is MOR-1903-B.
         """
         if self._ptt_reread_task is not None:
             return
@@ -485,11 +489,10 @@ class RigctldServer:
             logger.debug("rigctld PTT re-read task failed before stop", exc_info=True)
 
     async def _run_ptt_reread(self) -> None:
-        """Ask the radio for its PTT state while a CAT client is connected.
+        """Drive the *request* only; nothing here writes to the StateStore.
 
-        The *request* only: nothing here writes to the StateStore. If the radio
-        never answers, RF truth stays UNKNOWN and the gate keeps refusing —
-        absence is never filled in (MOR-1900).
+        If the radio never answers, RF truth stays UNKNOWN and the gate keeps
+        refusing — absence is never filled in (MOR-1900).
         """
         while True:
             try:
@@ -498,19 +501,32 @@ class RigctldServer:
             except asyncio.CancelledError:
                 break
             except Exception as exc:
-                # A dead link or a mid-teardown transport must not kill the
-                # driver; the next tick retries and the gate stays honest in
-                # the meantime.
+                # A dead link or mid-teardown transport must not kill the
+                # driver; the next tick retries, honestly UNKNOWN meanwhile.
                 logger.debug("rigctld PTT re-read failed: %s", exc, exc_info=True)
 
     async def _send_ptt_reread_once(self) -> None:
-        """Emit one ``0x1C/0x00`` read, but only with a client attached.
+        """Emit one ``0x1C/0x00`` read on the poller lane, if we may.
 
-        Parity with the lazy poller start: an idle server stays off the wire.
+        Not via ``_send_one_state_query``: that carries bounded on-demand
+        requests on the user-command lane, the wrong lane for a cadence.
         """
-        if self._client_count <= 0:
+        radio = self._radio
+        # Parity with the lazy poller start: an idle server stays off the wire.
+        if self._client_count <= 0 or not isinstance(radio, CivCommandCapable):
             return
-        await self._send_one_state_query(0x1C, 0x00, None)
+        # A Hamlib bridge owns the byte stream; our reads must not pollute it
+        # (MOR-166 slice 2). ``is True``, matching every sibling poller, so a
+        # duck-typed radio never quiesces by accident.
+        if getattr(radio, "external_cat_session_active", False) is True:
+            return
+        await radio.send_civ(
+            0x1C,
+            sub=0x00,
+            wait_response=False,
+            priority=Priority.BACKGROUND,
+            wait_dispatch=False,
+        )
 
     def _start_state_acquisition_drain_task(self) -> None:
         if (
@@ -647,8 +663,9 @@ class RigctldServer:
         """Derive the canonical tx_active fact for the scheduler's dispatch gate.
 
         MOR-1532: standalone rigctld never calls
-        ``AcquisitionScheduler.due_requests()`` (it has no cadence-poll
-        concept of its own), so its scheduler's cached ``_tx_active`` never
+        ``AcquisitionScheduler.due_requests()`` (MOR-1903 gave this seat one
+        cadence of its own -- the PTT re-read -- but it bypasses the scheduler
+        entirely), so its scheduler's cached ``_tx_active`` never
         left the ``__init__`` default of ``True`` -- the MOR-1531
         ``tx_only`` reconciliation gate stayed permanently open in that
         mode. Derived identically to the web poller (MOR-1525 / PR #2438):

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -42,6 +42,7 @@ from ..radio_protocol import (
     StateModelService,
     StateStoreCapable,
 )
+from ..runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
 from ..startup_checks import assert_radio_startup_ready
 from . import audit as _audit  # noqa: TID251
 from .circuit_breaker import CircuitBreaker, CircuitState  # noqa: TID251
@@ -53,7 +54,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["RigctldServer", "run_rigctld_server"]
+__all__ = ["PTT_REREAD_INTERVAL_SECONDS", "RigctldServer", "run_rigctld_server"]
+
+# MOR-1903: standalone rigctld has no cadence poller — ``due_requests()`` is
+# called only by the web radio poller, so in ``rigplane serve`` nothing ever
+# sends a ``0x1C/0x00`` read after connect. Without an observation the strict
+# resolver behind the MOR-1881 DEFER gate (and the BLOCK pre-gate guarding
+# key-down) stays UNKNOWN forever and every frequency / mode / VFO / split /
+# RIT write and every ``T 1`` is refused with ``RPRT -9``.
+#
+# The TTL is read from ``_civ_rx``'s own table, never copied. A quarter of it
+# puts two reads inside every freshness window, so one lost reply cannot open a
+# gap; a cadence at or above the TTL would instead reproduce the web
+# deployment's known-then-unknown sawtooth, which refuses most writes.
+PTT_OBSERVATION_TTL_SECONDS: float = _OBSERVATION_MAX_AGE_SECONDS[
+    ("global", "tx_state", "ptt")
+]
+PTT_REREAD_INTERVAL_SECONDS: float = PTT_OBSERVATION_TTL_SECONDS / 4.0
 
 
 class _AcquisitionExecutorUnavailable(RuntimeError):
@@ -163,6 +180,7 @@ class RigctldServer:
         self._state_store_freshness_task: asyncio.Task[None] | None = None
         self._acquisition_executor: AcquisitionExecutor | None = None
         self._state_acquisition_drain_task: asyncio.Task[None] | None = None
+        self._ptt_reread_task: asyncio.Task[None] | None = None
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
         self._state_diagnostics = getattr(radio, "_state_diagnostics", None)
         # Per-client sliding window for rate limiting: client_id → timestamps
@@ -438,6 +456,61 @@ class RigctldServer:
             self._state_freshness_service.run(),
             name="rigctld-state-freshness",
         )
+
+    def _start_ptt_reread_task(self) -> None:
+        """Start the client-gated CI-V PTT re-read, if this radio supports it.
+
+        CI-V only: the reply is published canonically by the existing ingress,
+        profile-independently. The Yaesu leg is MOR-1903-B.
+        """
+        if self._ptt_reread_task is not None:
+            return
+        if not isinstance(self._radio, CivCommandCapable):
+            return
+        self._ptt_reread_task = asyncio.get_running_loop().create_task(
+            self._run_ptt_reread(),
+            name="rigctld-ptt-reread",
+        )
+
+    async def _stop_ptt_reread_task(self) -> None:
+        task, self._ptt_reread_task = self._ptt_reread_task, None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.debug("rigctld PTT re-read task failed before stop", exc_info=True)
+
+    async def _run_ptt_reread(self) -> None:
+        """Ask the radio for its PTT state while a CAT client is connected.
+
+        The *request* only: nothing here writes to the StateStore. If the radio
+        never answers, RF truth stays UNKNOWN and the gate keeps refusing —
+        absence is never filled in (MOR-1900).
+        """
+        while True:
+            try:
+                await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS)
+                await self._send_ptt_reread_once()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                # A dead link or a mid-teardown transport must not kill the
+                # driver; the next tick retries and the gate stays honest in
+                # the meantime.
+                logger.debug("rigctld PTT re-read failed: %s", exc, exc_info=True)
+
+    async def _send_ptt_reread_once(self) -> None:
+        """Emit one ``0x1C/0x00`` read, but only with a client attached.
+
+        Parity with the lazy poller start: an idle server stays off the wire.
+        """
+        if self._client_count <= 0:
+            return
+        await self._send_one_state_query(0x1C, 0x00, None)
 
     def _start_state_acquisition_drain_task(self) -> None:
         if (
@@ -771,6 +844,7 @@ class RigctldServer:
         logger.info("rigctld listening on %s:%d", addr[0], addr[1])
         self._start_state_freshness_task()
         self._start_state_acquisition_drain_task()
+        self._start_ptt_reread_task()
 
         # Poller starts lazily on first client connection to avoid idle
         # CI-V traffic/noise when no CAT clients are connected.
@@ -792,6 +866,8 @@ class RigctldServer:
         ):
             self._state_store.begin_provider_generation()
             self._fallback_state_store_attached = False
+
+        await self._stop_ptt_reread_task()
 
         if self._state_acquisition_drain_task is not None:
             self._state_acquisition_drain_task.cancel()

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -165,6 +165,10 @@ async def _force_rigctld_gc_ready(server: RigctldServer) -> None:
     for attr in (
         "_state_store_freshness_task",
         "_state_acquisition_drain_task",
+        # MOR-1903: the CI-V PTT re-read task holds a reference to the server
+        # for as long as it runs, so it delays collection exactly like the
+        # two above.
+        "_ptt_reread_task",
     ):
         task = getattr(server, attr, None)
         if task is not None and not task.done():

--- a/tests/test_rigctld_ptt_reread.py
+++ b/tests/test_rigctld_ptt_reread.py
@@ -1,15 +1,13 @@
 # mypy: disable-error-code=untyped-decorator
 """MOR-1903 — standalone rigctld drives its own CI-V PTT re-read.
 
-Standalone ``rigplane serve`` has no cadence poller: ``due_requests()`` is
-called only by the web radio poller, so nothing in that deployment ever sends a
-``0x1C/0x00`` read after connect. With no observation the strict resolver behind
-the MOR-1881 DEFER gate stays UNKNOWN forever and every frequency, mode, VFO and
-key-down command is refused with ``RPRT -9``.
-
-These tests pin the missing *request*, never new data: the value that clears the
-gate may only arrive through the existing CI-V ingress, decoded from a real
-radio reply (MOR-1900 — no mirror-derived truth, no synthesised default).
+Standalone ``rigplane serve`` had no cadence poller at all: ``due_requests()``
+is called only by the web radio poller, so nothing ever sent a ``0x1C/0x00``
+read after connect, the strict resolver behind the MOR-1881 DEFER gate stayed
+UNKNOWN forever, and every frequency, mode, VFO and key-down command was
+refused with ``RPRT -9``. These tests pin the missing *request*, never new
+data: the value that clears the gate may only arrive through the existing CI-V
+ingress, from a real radio reply (MOR-1900).
 """
 
 from __future__ import annotations
@@ -25,6 +23,7 @@ import pytest
 from test_radio import MockTransport
 
 from rigplane.commands import CONTROLLER_ADDR
+from rigplane.commands.commander import Priority
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.radio import IcomRadio
 from rigplane.rigctld import handler as handler_mod
@@ -46,7 +45,6 @@ _UNDECLARED_CIV_MODELS = ("IC-705", "IC-9700", "X6100")
 def _make_radio(model: str) -> IcomRadio:
     radio = IcomRadio("198.51.100.10", model=model)
     transport = MockTransport()
-    # ``assert_radio_startup_ready`` probes this on the control transport.
     transport._udp_transport = object()  # type: ignore[attr-defined]
     radio._civ_transport = transport  # noqa: SLF001
     radio._ctrl_transport = transport  # noqa: SLF001
@@ -93,11 +91,8 @@ def _attach_handler(server: RigctldServer, radio: Any) -> Any:
 
 
 def _ptt_read_calls(send_civ: AsyncMock) -> list[Any]:
-    return [
-        call
-        for call in send_civ.await_args_list
-        if call.args[:1] == (0x1C,) and call.kwargs.get("sub") == 0x00
-    ]
+    hits = (c for c in send_civ.await_args_list if c.args[:1] == (0x1C,))
+    return [c for c in hits if c.kwargs.get("sub") == 0x00]
 
 
 @pytest.fixture  # type: ignore[untyped-decorator]
@@ -107,19 +102,10 @@ def civ_radio() -> Generator[IcomRadio, None, None]:
     radio._connected = False  # noqa: SLF001
 
 
-# --- AC-1: the cadence is sub-TTL, derived from the field's own TTL ---------
-
-
 def test_ptt_reread_interval_is_derived_from_the_observation_ttl() -> None:
-    """Two reads per freshness window, derived from ``_civ_rx``'s own table.
-
-    A cadence at or above the TTL reproduces today's sawtooth (MOR-1903 §2.6).
-    """
+    """Two reads per freshness window, derived from ``_civ_rx``'s own table."""
     assert 0 < PTT_REREAD_INTERVAL_SECONDS < _PTT_TTL_SECONDS
     assert _PTT_TTL_SECONDS / PTT_REREAD_INTERVAL_SECONDS >= 2.0
-
-
-# --- AC-2: RF truth stays resolvable for as long as the radio answers -------
 
 
 async def test_rf_truth_never_decays_while_the_radio_answers(
@@ -155,10 +141,12 @@ async def test_rf_truth_never_decays_while_the_radio_answers(
 
     calls = _ptt_read_calls(send_civ)
     assert len(calls) >= 2, calls
-    assert all(call.kwargs.get("wait_response") is False for call in calls)
-
-
-# --- AC-3: DEFER writes and key-down succeed once a real answer lands -------
+    # A background poller yields the shared CI-V lane and never parks on the
+    # Commander future (MOR-497i / MOR-497ii).
+    for call in calls:
+        assert call.kwargs.get("wait_response") is False
+        assert call.kwargs.get("priority") is Priority.BACKGROUND
+        assert call.kwargs.get("wait_dispatch") is False
 
 
 @pytest.mark.parametrize("model", _UNDECLARED_CIV_MODELS)
@@ -181,21 +169,17 @@ async def test_writes_succeed_after_the_radio_answers_the_reread(model: str) -> 
         await _deliver(radio, _ptt_reply(radio, transmitting=False))
         assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.RX  # noqa: SLF001
 
-        # ``V VFOB`` on a dual-RX rig (IC-9700) takes the ACK-confirmed
-        # receiver-switch path, which a non-answering stub cannot complete.
-        accepted_wires = [b"F 14074000", b"M USB 2400", b"T 1"]
-        if radio.receiver_count == 1:
-            accepted_wires.insert(2, b"V VFOB")
-        for wire in accepted_wires:
-            accepted = await handler.execute(parse_line(wire), session_id="s1")
-            assert accepted.error is None or int(accepted.error) == 0, (wire, accepted)
+        # ``V`` on a dual-RX rig (IC-9700) needs an ACK the stub cannot give:
+        # pin only that the interlock stopped refusing, and run it last — its
+        # ~1s stall would age the observation past its TTL for the next wire.
+        for wire in (b"F 14074000", b"M USB 2400", b"T 1", b"V VFOB"):
+            got = await handler.execute(parse_line(wire), session_id="s1")
+            code = 0 if got.error is None else int(got.error)
+            assert code == 0 or (wire == b"V VFOB" and code != -9), (wire, got)
     finally:
         handler.stop_key_down_backstop()
         await server._stop_ptt_reread_task()  # noqa: SLF001
         radio._connected = False  # noqa: SLF001
-
-
-# --- AC-4: absence is never filled in (the MOR-1900 invariant) --------------
 
 
 async def test_unanswered_reread_never_produces_rf_truth(
@@ -229,22 +213,25 @@ async def test_unanswered_reread_never_produces_rf_truth(
         await server._stop_ptt_reread_task()  # noqa: SLF001
 
 
-# --- AC-5: client gating and clean teardown ---------------------------------
-
-
-async def test_reread_task_is_cancelled_and_awaited_on_stop(
+async def test_no_read_while_an_external_cat_session_owns_the_wire(
     civ_radio: IcomRadio,
 ) -> None:
-    civ_radio.send_civ = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    """A Hamlib bridge owns the byte stream; our reads stay out of it."""
+    send_civ = AsyncMock(return_value=None)
+    civ_radio.send_civ = send_civ  # type: ignore[method-assign]
+    civ_radio.begin_external_cat_session()
     server = RigctldServer(civ_radio, RigctldConfig(port=0))
-    await server.start()
+    server._bootstrap_state_acquisition()  # noqa: SLF001
+    server._client_count = 1  # noqa: SLF001
+    server._start_ptt_reread_task()  # noqa: SLF001
     try:
-        task = server._ptt_reread_task  # noqa: SLF001
-        assert task is not None and not task.done()
+        await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 4.0)
+        assert _ptt_read_calls(send_civ) == []
+        civ_radio.end_external_cat_session()
+        await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 4.0)
+        assert len(_ptt_read_calls(send_civ)) >= 2
     finally:
-        await server.stop()
-    assert server._ptt_reread_task is None  # noqa: SLF001
-    assert task.done()
+        await server._stop_ptt_reread_task()  # noqa: SLF001
 
 
 async def test_started_server_drives_reads_only_while_a_client_is_connected(
@@ -255,6 +242,8 @@ async def test_started_server_drives_reads_only_while_a_client_is_connected(
     civ_radio.send_civ = send_civ  # type: ignore[method-assign]
     server = RigctldServer(civ_radio, RigctldConfig(host="127.0.0.1", port=0))
     await server.start()
+    task = server._ptt_reread_task  # noqa: SLF001
+    assert task is not None and not task.done()
     try:
         await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 4.0)
         assert _ptt_read_calls(send_civ) == []
@@ -280,9 +269,7 @@ async def test_started_server_drives_reads_only_while_a_client_is_connected(
             await writer.wait_closed()
     finally:
         await server.stop()
-
-
-# --- AC-7: non-CI-V radios are untouched by 1903-A (FTX-1 gap: MOR-1903-B) --
+    assert server._ptt_reread_task is None and task.done()  # noqa: SLF001
 
 
 def test_yaesu_radio_gets_no_civ_reread_task() -> None:

--- a/tests/test_rigctld_ptt_reread.py
+++ b/tests/test_rigctld_ptt_reread.py
@@ -1,0 +1,313 @@
+# mypy: disable-error-code=untyped-decorator
+"""MOR-1903 — standalone rigctld drives its own CI-V PTT re-read.
+
+Standalone ``rigplane serve`` has no cadence poller: ``due_requests()`` is
+called only by the web radio poller, so nothing in that deployment ever sends a
+``0x1C/0x00`` read after connect. With no observation the strict resolver behind
+the MOR-1881 DEFER gate stays UNKNOWN forever and every frequency, mode, VFO and
+key-down command is refused with ``RPRT -9``.
+
+These tests pin the missing *request*, never new data: the value that clears the
+gate may only arrive through the existing CI-V ingress, decoded from a real
+radio reply (MOR-1900 — no mirror-derived truth, no synthesised default).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from test_radio import MockTransport
+
+from rigplane.commands import CONTROLLER_ADDR
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.radio import IcomRadio
+from rigplane.rigctld import handler as handler_mod
+from rigplane.rigctld.contract import RigctldConfig
+from rigplane.rigctld.protocol import parse_line
+from rigplane.rigctld.server import PTT_REREAD_INTERVAL_SECONDS, RigctldServer
+from rigplane.runtime import tx_interlock
+from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+from rigplane.types import CivFrame
+
+_PTT_PATH = FieldPath.global_("tx_state", "ptt")
+_PTT_TTL_SECONDS = _OBSERVATION_MAX_AGE_SECONDS[("global", "tx_state", "ptt")]
+
+# Profiles with no ``[state_acquisition]`` block at all — no scheduler is built
+# for them, so the on-demand acquisition path cannot help them either.
+_UNDECLARED_CIV_MODELS = ("IC-705", "IC-9700", "X6100")
+
+
+def _make_radio(model: str) -> IcomRadio:
+    radio = IcomRadio("198.51.100.10", model=model)
+    transport = MockTransport()
+    # ``assert_radio_startup_ready`` probes this on the control transport.
+    transport._udp_transport = object()  # type: ignore[attr-defined]
+    radio._civ_transport = transport  # noqa: SLF001
+    radio._ctrl_transport = transport  # noqa: SLF001
+    radio._connected = True  # noqa: SLF001
+    radio._civ_recovering = False  # noqa: SLF001
+    radio._civ_stream_ready = True  # noqa: SLF001
+    radio._last_civ_data_received = time.monotonic()  # noqa: SLF001
+    return radio
+
+
+def _ptt_reply(radio: IcomRadio, *, transmitting: bool) -> CivFrame:
+    """The radio's own answer to ``0x1C/0x00`` — the only admissible source."""
+    return CivFrame(
+        to_addr=CONTROLLER_ADDR,
+        from_addr=radio._radio_addr,  # noqa: SLF001
+        command=0x1C,
+        sub=0x00,
+        data=bytes([1 if transmitting else 0]),
+        receiver=None,
+    )
+
+
+async def _deliver(radio: IcomRadio, frame: CivFrame) -> None:
+    await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+        frame,
+        generation=radio._civ_epoch,  # noqa: SLF001
+    )
+
+
+def _attach_handler(server: RigctldServer, radio: Any) -> Any:
+    """Build the handler exactly as ``RigctldServer.start()`` does."""
+    server._bootstrap_state_acquisition()  # noqa: SLF001
+    store = server._state_store  # noqa: SLF001
+    assert store is not None
+    handler = handler_mod.RigctldHandler(
+        radio,
+        server._config,  # noqa: SLF001
+        state_store=store,
+        state_model_service=server._state_model_service,  # noqa: SLF001
+    )
+    handler.bind_provider_generation(lambda: store.provider_generation)
+    server._rig_handler = handler  # noqa: SLF001
+    return handler
+
+
+def _ptt_read_calls(send_civ: AsyncMock) -> list[Any]:
+    return [
+        call
+        for call in send_civ.await_args_list
+        if call.args[:1] == (0x1C,) and call.kwargs.get("sub") == 0x00
+    ]
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def civ_radio() -> Generator[IcomRadio, None, None]:
+    radio = _make_radio("IC-705")
+    yield radio
+    radio._connected = False  # noqa: SLF001
+
+
+# --- AC-1: the cadence is sub-TTL, derived from the field's own TTL ---------
+
+
+def test_ptt_reread_interval_is_derived_from_the_observation_ttl() -> None:
+    """Two reads per freshness window, derived from ``_civ_rx``'s own table.
+
+    A cadence at or above the TTL reproduces today's sawtooth (MOR-1903 §2.6).
+    """
+    assert 0 < PTT_REREAD_INTERVAL_SECONDS < _PTT_TTL_SECONDS
+    assert _PTT_TTL_SECONDS / PTT_REREAD_INTERVAL_SECONDS >= 2.0
+
+
+# --- AC-2: RF truth stays resolvable for as long as the radio answers -------
+
+
+async def test_rf_truth_never_decays_while_the_radio_answers(
+    civ_radio: IcomRadio,
+) -> None:
+    """Sampled across more than two freshness windows: never UNKNOWN."""
+    server = RigctldServer(civ_radio, RigctldConfig(port=0))
+    handler = _attach_handler(server, civ_radio)
+    send_civ = AsyncMock(return_value=None)
+
+    async def answering_send_civ(cmd: int, **kwargs: Any) -> None:
+        await send_civ(cmd, **kwargs)
+        if cmd == 0x1C and kwargs.get("sub") == 0x00:
+            await _deliver(civ_radio, _ptt_reply(civ_radio, transmitting=False))
+
+    civ_radio.send_civ = answering_send_civ  # type: ignore[method-assign]
+    server._client_count = 1  # noqa: SLF001
+    server._start_ptt_reread_task()  # noqa: SLF001
+    try:
+        await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 2.0)
+        deadline = time.monotonic() + _PTT_TTL_SECONDS * 2.5
+        samples = 0
+        while time.monotonic() < deadline:
+            assert (
+                handler._resolve_rigctld_rf_state()  # noqa: SLF001
+                is tx_interlock.RfState.RX
+            )
+            samples += 1
+            await asyncio.sleep(0.05)
+        assert samples > 20
+    finally:
+        await server._stop_ptt_reread_task()  # noqa: SLF001
+
+    calls = _ptt_read_calls(send_civ)
+    assert len(calls) >= 2, calls
+    assert all(call.kwargs.get("wait_response") is False for call in calls)
+
+
+# --- AC-3: DEFER writes and key-down succeed once a real answer lands -------
+
+
+@pytest.mark.parametrize("model", _UNDECLARED_CIV_MODELS)
+async def test_writes_succeed_after_the_radio_answers_the_reread(model: str) -> None:
+    radio = _make_radio(model)
+    send_civ = AsyncMock(return_value=None)
+    radio.send_civ = send_civ  # type: ignore[method-assign]
+    server = RigctldServer(radio, RigctldConfig(port=0))
+    handler = _attach_handler(server, radio)
+    server._client_count = 1  # noqa: SLF001
+    server._start_ptt_reread_task()  # noqa: SLF001
+    try:
+        for wire in (b"F 14074000", b"M USB 2400", b"V VFOB", b"T 1"):
+            refused = await handler.execute(parse_line(wire), session_id="s1")
+            assert refused.error is not None and int(refused.error) == -9, wire
+
+        await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 4.0)
+        assert _ptt_read_calls(send_civ), "no 0x1C/0x00 read was ever sent"
+
+        await _deliver(radio, _ptt_reply(radio, transmitting=False))
+        assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.RX  # noqa: SLF001
+
+        # ``V VFOB`` on a dual-RX rig (IC-9700) takes the ACK-confirmed
+        # receiver-switch path, which a non-answering stub cannot complete.
+        accepted_wires = [b"F 14074000", b"M USB 2400", b"T 1"]
+        if radio.receiver_count == 1:
+            accepted_wires.insert(2, b"V VFOB")
+        for wire in accepted_wires:
+            accepted = await handler.execute(parse_line(wire), session_id="s1")
+            assert accepted.error is None or int(accepted.error) == 0, (wire, accepted)
+    finally:
+        handler.stop_key_down_backstop()
+        await server._stop_ptt_reread_task()  # noqa: SLF001
+        radio._connected = False  # noqa: SLF001
+
+
+# --- AC-4: absence is never filled in (the MOR-1900 invariant) --------------
+
+
+async def test_unanswered_reread_never_produces_rf_truth(
+    civ_radio: IcomRadio,
+) -> None:
+    """A radio that does not answer must leave the gate closed.
+
+    Never an observation of the driver's own, never the legacy PTT mirror.
+    """
+    send_civ = AsyncMock(return_value=None)
+    civ_radio.send_civ = send_civ  # type: ignore[method-assign]
+    server = RigctldServer(civ_radio, RigctldConfig(port=0))
+    handler = _attach_handler(server, civ_radio)
+    server._client_count = 1  # noqa: SLF001
+    server._start_ptt_reread_task()  # noqa: SLF001
+    try:
+        await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 6.0)
+        assert len(_ptt_read_calls(send_civ)) >= 2
+
+        store = server._state_store  # noqa: SLF001
+        assert store is not None
+        with pytest.raises(KeyError):
+            store.snapshot().field(_PTT_PATH)
+        assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.UNKNOWN  # noqa: SLF001
+
+        for wire in (b"F 14074000", b"M USB 2400", b"V VFOB", b"T 1"):
+            refused = await handler.execute(parse_line(wire), session_id="s1")
+            assert refused.error is not None and int(refused.error) == -9, wire
+    finally:
+        handler.stop_key_down_backstop()
+        await server._stop_ptt_reread_task()  # noqa: SLF001
+
+
+# --- AC-5: client gating and clean teardown ---------------------------------
+
+
+async def test_reread_task_is_cancelled_and_awaited_on_stop(
+    civ_radio: IcomRadio,
+) -> None:
+    civ_radio.send_civ = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    server = RigctldServer(civ_radio, RigctldConfig(port=0))
+    await server.start()
+    try:
+        task = server._ptt_reread_task  # noqa: SLF001
+        assert task is not None and not task.done()
+    finally:
+        await server.stop()
+    assert server._ptt_reread_task is None  # noqa: SLF001
+    assert task.done()
+
+
+async def test_started_server_drives_reads_only_while_a_client_is_connected(
+    civ_radio: IcomRadio,
+) -> None:
+    """End-to-end over the real listener and the real wire protocol."""
+    send_civ = AsyncMock(return_value=None)
+    civ_radio.send_civ = send_civ  # type: ignore[method-assign]
+    server = RigctldServer(civ_radio, RigctldConfig(host="127.0.0.1", port=0))
+    await server.start()
+    try:
+        await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 4.0)
+        assert _ptt_read_calls(send_civ) == []
+
+        assert server._server is not None  # noqa: SLF001
+        port = server._server.sockets[0].getsockname()[1]  # noqa: SLF001
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 6.0)
+            assert len(_ptt_read_calls(send_civ)) >= 2
+
+            # Unanswered so far: the seat is still fail-closed on the wire.
+            writer.write(b"F 14074000\n")
+            await writer.drain()
+            assert await reader.readline() == b"RPRT -9\n"
+
+            await _deliver(civ_radio, _ptt_reply(civ_radio, transmitting=False))
+            writer.write(b"F 14074000\n")
+            await writer.drain()
+            assert await reader.readline() == b"RPRT 0\n"
+        finally:
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        await server.stop()
+
+
+# --- AC-7: non-CI-V radios are untouched by 1903-A (FTX-1 gap: MOR-1903-B) --
+
+
+def test_yaesu_radio_gets_no_civ_reread_task() -> None:
+    from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+    from rigplane.radio_protocol import CivCommandCapable
+
+    radio = YaesuCatRadio("/dev/null")
+    assert not isinstance(radio, CivCommandCapable)
+
+    server = RigctldServer(radio, RigctldConfig(port=0))
+    server._bootstrap_state_acquisition()  # noqa: SLF001
+    server._client_count = 1  # noqa: SLF001
+    server._start_ptt_reread_task()  # noqa: SLF001
+    assert server._ptt_reread_task is None  # noqa: SLF001
+
+
+@pytest.mark.xfail(
+    reason="MOR-1903-B: no Yaesu acquisition executor exists for the standalone "
+    "rigctld drain, so FTX-1 can never resolve RF truth in that deployment.",
+    strict=True,
+)
+def test_yaesu_standalone_can_resolve_rf_truth() -> None:
+    from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+
+    radio = YaesuCatRadio("/dev/null")
+    server = RigctldServer(radio, RigctldConfig(port=0))
+    handler = _attach_handler(server, radio)
+    assert handler._resolve_rigctld_rf_state() is not tx_interlock.RfState.UNKNOWN  # noqa: SLF001


### PR DESCRIPTION
## MOR-1903 — 1903-A: standalone rigctld drives its own CI-V PTT re-read

### Ticket carried no acceptance criteria

MOR-1903 lists four candidate resolutions marked "owner call" and no acceptance
criteria. It was investigated first, and the investigation corrected several of
the ticket's claims (see *Corrections*). **The owner chose option 2 in its
evidence-corrected form** — work item 1903-A: give standalone `RigctldServer` a
client-gated, sub-TTL `0x1C/0x00` PTT re-read and let the existing CI-V ingress
publish the answer canonically. The acceptance criteria below come from the
investigation's drafted section, not from the ticket.

### The defect

Standalone `rigplane serve` has no cadence poller — `AcquisitionScheduler.due_requests()`
has exactly one caller and it is the web radio poller. So nothing in that
deployment ever sends a `0x1C/0x00` read after connect. With no observation the
strict resolver behind the MOR-1881 DEFER gate stays `UNKNOWN` forever, and the
BLOCK pre-gate guarding key-down uses the same resolver. Result: `F`, `M`, `V`,
`S`, `J`, `U` and `T 1` all answer `RPRT -9`, permanently. Only `T 0`
(ALWAYS_PASS) still works. For a hamlib client that is a dead port, not a
degraded mode.

### The fix

`RigctldServer` drives that one read itself at `PTT_REREAD_INTERVAL_SECONDS` =
a quarter of the field's own freshness TTL, which is **read from the ingress's
own TTL table** rather than copied. The task starts in `start()` and is
cancelled and awaited in `stop()`. It quiesces on two established conditions:
no client attached (parity with the lazy poller start), and an active external
CAT session (MOR-166 slice 2). It is sent as what it is — a background poller:
`Priority.BACKGROUND` so it yields the shared CI-V lane to user commands, an
unkey above all (MOR-497i), and `wait_dispatch=False` so parking on the
Commander future cannot push the send past the very TTL the cadence exists to
stay inside (MOR-497ii).

**No mirror-derived RF truth is introduced.** The driver sends a request and
nothing else — it never applies an `Observation`, never reads `RadioState`,
never synthesises a default `ptt = False`. The value that clears the gate can
only come from a real radio reply decoded by `_civ_rx._observations_from_frame`
and published by `_apply_state_store_observations`, which is already
profile-independent. If the radio does not answer, RF truth stays `UNKNOWN` and
the gate keeps refusing. The emitted frame is byte-identical to one the web
deployment already sends to every affected profile.

### Corrections to the ticket, established during investigation

- The mirror/store split the ticket blames **does not exist for CI-V**:
  `_civ_rx._update_state_cache_from_frame` already publishes canonically and
  profile-independently. The gap is that nothing *sends* the read.
- The ticket's "today those radios are ungated, not refused (fail-open)" is
  **refuted**: the server always injects a `StateStore`, so the gate is active
  on every deployable profile. `not _has_canonical_state_store` is a test-only
  branch.
- Key-down (`T 1`, BLOCK) is refused too, not only DEFER-classified writes.

### Acceptance criteria and how each is tested

Every row below was re-verified against the tree by `pytest --collect-only` on
`tests/test_rigctld_ptt_reread.py`, which collects exactly 10 items from 8 test
functions.

| AC | Test |
| -- | -- |
| 1. Cadence strictly below the field's observation TTL, derived from it | `test_ptt_reread_interval_is_derived_from_the_observation_ttl` |
| 2. RF truth never decays to UNKNOWN while the radio answers, sampled across >2 TTL periods; sent on the background lane | `test_rf_truth_never_decays_while_the_radio_answers` |
| 3. On the three CI-V profiles with no `[state_acquisition]` block: `F`, `M`, `V`, `T 1` all answer `RPRT -9` before a real reply lands. After one lands, `F`, `M` and `T 1` answer `RPRT 0`; `V` is asserted only to be **no longer `ERJCTED` (-9)**, not to be `RPRT 0` — see the note below | `test_writes_succeed_after_the_radio_answers_the_reread[IC-705]`, `[IC-9700]`, `[X6100]` |
| 4. Unanswered read never produces RF truth: no `global.tx_state.ptt` field, resolver UNKNOWN, every DEFER and BLOCK write still `RPRT -9` | `test_unanswered_reread_never_produces_rf_truth` |
| 5. No read while no client is connected; task started by `start()`, cancelled and awaited by `stop()` | `test_started_server_drives_reads_only_while_a_client_is_connected` |
| 6. Declared-ptt profiles unchanged | existing `tests/test_rigctld_tx_interlock.py` + `tests/test_rigctld_key_down_backstop.py` — `114 passed`, matching the pre-change baseline exactly |
| 7. Non-CI-V radios unaffected, FTX-1 gap cannot read as covered | `test_yaesu_radio_gets_no_civ_reread_task` + `strict=True` xfail `test_yaesu_standalone_can_resolve_rf_truth` |
| Review B2. No read while an external CAT master owns the wire, resuming when it ends | `test_no_read_while_an_external_cat_session_owns_the_wire` |

The AC-5 test drives the real TCP listener and the real wire protocol:
`F 14074000` answers `RPRT -9` before an answer lands and `RPRT 0` after.

**A deliberate trade in row 3, stated because it narrowed an assertion.** An
earlier revision asserted `RPRT 0` for `V` but ran it on IC-705 and X6100 only,
skipping IC-9700 whose dual-RX `V` takes an ACK-confirmed receiver-switch path
that a non-answering stub transport cannot complete. The current revision runs
`V` on all three and weakens its assertion to "not `ERJCTED`". That is the right
shape, not merely a cheaper one: the subject under test is the TX interlock, and
what the interlock must stop doing is refusing the write. Whether the stub can
then produce an ACK is a property of the fixture, not of this change — asserting
it was over-specifying, and it cost IC-9700 coverage of `V` entirely. `V` also
runs last in the loop, because its ~1 s stall on IC-9700 would otherwise age the
PTT observation past its 1 s TTL before the next wire is sent.

`tests/test_lifecycle_diagnostics.py` needed one 4-line update: the new task
holds a reference to the server, so its GC-readiness helper must release it
exactly like the two existing tasks.

### Mutation battery

Applied by hand, pinning test confirmed RED, reverted, confirmed GREEN. Every
run with `PYTHONDONTWRITEBYTECODE=1`.

| Mutation | Result |
| -- | -- |
| M1 — cadence raised above the TTL (0.25 → 1.5 s) | RED: `..._interval_is_derived_from_the_observation_ttl`, `..._rf_truth_never_decays_while_the_radio_answers` |
| M2 — drive never started from `start()` | RED: `..._started_server_drives_reads_only_while_a_client_is_connected` |
| M3 — driver applies `Observation(ptt=False)` instead of reading | RED: 7 tests |
| M3b — driver keeps the real send and fabricates **in addition** | RED: `..._unanswered_reread_never_produces_rf_truth` (`Failed: DID NOT RAISE KeyError`) and `..._started_server_drives_reads_only_while_a_client_is_connected` (`assert b'RPRT 0\n' == b'RPRT -9\n'`) |
| M4 — client gate removed | RED: `..._started_server_drives_reads_only_while_a_client_is_connected` |
| M5 — `_defer_write_gate` returns `None` on UNKNOWN (fail-open drift) | RED: 5 tests |

M3b exists because M3 alone could be killed merely by the read going missing.
With the real send left intact, only fabrication-detection can fail — and it
does, so the MOR-1900 prohibition is pinned in its own right. Both M3 variants
logged a marker line proving the mutated branch executed and that the
surrounding `except Exception` did not swallow it.

### Deliberately out of scope — filed separately

- **FTX-1 / Yaesu (1903-B).** FTX-1 is a sixth affected profile: no Yaesu
  acquisition executor exists for the standalone drain, so its request queues
  and is never sent. Not fixed here; pinned by a `strict=True` xfail so it
  cannot silently read as covered.
- **The `x6200` profile declaration (1903-C).** No file under `rigs/` is touched.
- **The frequency and s-meter mirror-laundering** still in `rigctld/handler.py`
  (MOR-1900 removed only the PTT case). Not touched.
- **`core/acquisition_scheduler.py:786-787`** still says rigctld "has no
  cadence-poll concept of its own". That is now stale — this seat has one, which
  bypasses the scheduler. Correcting it would make a fourth file and break the
  3-file guardrail, so it is left for a one-line follow-up. The equivalent
  comments inside `rigctld/server.py` **are** corrected here.

**Known gaps carried out of this PR, so they are not lost:** the stale
`core/acquisition_scheduler.py:786-787` comment above needs a one-line
follow-up; and the "reads stop again on the last client disconnect" property is
**not pinned by a test** — the `_client_count` bookkeeping in `_on_client_done`
was re-verified correct by review, and a follow-up ticket was judged cheaper
than trading comment prose for a test at the 400-line limit.

### Combined mode: `rigplane web --rigctld`

`cli/__init__.py:3840-3842` builds the same `RigctldServer` with no flag
distinguishing the deployments, so combined mode gains this read too. The
behaviour is deliberately **not** gated behind a standalone flag — gating would
re-break x6200, which has a `[state_acquisition]` block but no declared ptt
capability and therefore resolves `UNAVAILABLE` on the on-demand path. Per
radio:

- **Fixes** x6200, ic705, ic9700, x6100 — none of which can resolve RF truth in
  that deployment reliably today.
- **Double-polls** ic7300 and ic7610, which already declare
  `cadence_seconds = 0.3` for ptt. The extra read bypasses that
  profile-declared cadence, so those two radios see roughly 4 Hz from this
  driver on top of their declared 3.3 Hz. It is one extra GET frame, only while
  a CAT client is attached, on the background lane — but it is a real
  divergence from profile-declared cadence and is called out rather than
  buried.
- **ftx1** is unchanged (not CI-V; 1903-B).

### Guardrails

3 files, **+400 / −3**. At the 400-line limit, not over. Reaching it required
compacting test verbosity: two lifecycle tests were merged into one (the same
assertions, one `start()`/`stop()` cycle), and a deployment-shape test the
investigation listed as optional was dropped. No new abstractions or layers;
`_send_one_state_query` is left byte-identical to `main`.

### Gates

| Command | Outcome |
| -- | -- |
| `pytest tests/test_rigctld_ptt_reread.py tests/test_lifecycle_diagnostics.py` | `15 passed, 1 xfailed in 14.77s` |
| `pytest tests/test_rigctld_tx_interlock.py tests/test_rigctld_key_down_backstop.py` | `114 passed in 9.47s` |
| `pytest tests/test_rigctld_server.py tests/test_rigctld_server_coverage.py tests/test_server_wire.py` | `118 passed in 3.16s` |
| `uv run ruff check src/ tests/` | `All checks passed!` |
| `uv run ruff format src/ tests/` | `680 files left unchanged` |
| `uv run lint-imports` | `Contracts: 5 kept, 0 broken.` |
| `uv run mypy src/` | `Found 12 errors in 3 files` — all pre-existing, zero in any file this PR touches |
| `rigplane --model IC-7610 validate --provider native --dry-run --gate …/ic7610.dry-run.json` | `Golden gate: PASS (81 check(s) match, 0 regression(s))`, exit 0 |
| `rigplane --model X6200 validate … x6200.dry-run.json` | `Golden gate: PASS (64 check(s) match, 0 regression(s))`, exit 0 |
| `rigplane --model FTX-1 validate … ftx1.dry-run.json` | `Golden gate: PASS (65 check(s) match, 0 regression(s))`, exit 0 |

The full suite was run on the first revision (`6 failed, 10249 passed`, the 6
being the `tests/test_web_teardown_unkey_gate.py` failures since fixed on `main`
by #2764). It was **not** re-run locally for this revision: the host is
saturated and full-suite runs are killed by the environment rather than
completing. CI is the authority for the full suite on this head.

