### PR TITLE
ci(MOR-1911): run quick checks on rigs and contracts changes

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -44,6 +44,8 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'frontend/**'
+              - 'rigs/**'
+              - 'contracts/**'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.importlinter'

--- a/tests/test_ci_path_filters.py
+++ b/tests/test_ci_path_filters.py
@@ -1,0 +1,81 @@
+"""Pins the `core` change-detection filter in quick.yml.
+
+`.github/workflows/quick.yml` gates every quick-CI check (ruff, mypy,
+import-linter, the validation dry-run golden gates, pytest) behind a
+`dorny/paths-filter` step. Its `core` filter did not list `rigs/**` or the
+repo-root `contracts/**`, so a PR that changed only a radio profile TOML
+(under `rigs/`) or a consumer-contract fixture (under `contracts/`) ran
+zero quick-CI checks and could merge having been tested by nothing
+(MOR-1911).
+
+This test pins the raw glob list with a small regex-based extraction
+rather than a YAML parser: the `filters:` value is itself a nested YAML
+document consumed by the `dorny/paths-filter` action, not a structure the
+outer workflow's own schema exposes, and this repo has no YAML-parsing
+dependency declared for tests to use (PyYAML is present only transitively,
+via a docs tool). A regex anchored on the known block-scalar indentation
+is simpler and does not risk that dependency disappearing.
+
+Honest limit: this only proves the glob string is present in the filter
+config, not that GitHub's `dorny/paths-filter` evaluates a `rigs/`-only or
+`contracts/`-only diff as matching `core`. Per the action's documented glob
+semantics (https://github.com/dorny/paths-filter, which follows
+`micromatch`), a trailing `/**` matches the directory itself, everything
+under it, and any depth of nested files, so `rigs/**` and `contracts/**`
+are the correct globs for "any change anywhere under this directory" —
+but that behavior lives in the action's own engine, outside this repo.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+QUICK_YML = (
+    Path(__file__).resolve().parent.parent / ".github" / "workflows" / "quick.yml"
+)
+
+EXPECTED_CORE_GLOBS = {
+    "src/**",
+    "tests/**",
+    "frontend/**",
+    "pyproject.toml",
+    "uv.lock",
+    ".importlinter",
+    ".github/scripts/**",
+    ".github/workflows/**",
+    "rigs/**",
+    "contracts/**",
+}
+
+# Matches the `core:` list item block inside the `filters: |` block scalar,
+# e.g.:
+#             core:
+#               - 'src/**'
+#               - 'tests/**'
+#             frontend:
+_CORE_BLOCK_RE = re.compile(r"^ {12}core:\n((?:^ {14}- .*\n)+)", re.MULTILINE)
+_GLOB_RE = re.compile(r"- '([^']*)'")
+
+
+def _core_filter_globs() -> set[str]:
+    text = QUICK_YML.read_text()
+    match = _CORE_BLOCK_RE.search(text)
+    assert match, "could not locate the `core:` filter block in quick.yml"
+    return set(_GLOB_RE.findall(match.group(1)))
+
+
+def test_core_filter_covers_rigs_and_contracts() -> None:
+    globs = _core_filter_globs()
+    assert "rigs/**" in globs, (
+        "quick.yml's `core` filter is missing 'rigs/**' — a radio-profile-only "
+        "PR would run zero quick-CI checks (MOR-1911)"
+    )
+    assert "contracts/**" in globs, (
+        "quick.yml's `core` filter is missing 'contracts/**' — a "
+        "consumer-contract-only PR would run zero quick-CI checks (MOR-1911)"
+    )
+
+
+def test_core_filter_matches_expected_set() -> None:
+    assert _core_filter_globs() == EXPECTED_CORE_GLOBS


### PR DESCRIPTION
## Summary

`.github/workflows/quick.yml`'s `core` change-detection filter (a `dorny/paths-filter` step)
did not list `rigs/**` or the repo-root `contracts/**`. Verified: a PR that changes only a
radio profile TOML under `rigs/` or a consumer-contract fixture under `contracts/` runs
**zero** quick-CI checks — no ruff, no import-linter, no validation dry-run golden gates,
no pytest — and can merge having been tested by nothing.

This is ADR row 3b in `docs/plans/2026-08-20-transmit-authority.md` §4. It must land before
the next row in that epic ships measured per-radio profile data, or that data ships untested.

- Adds `'rigs/**'` and `'contracts/**'` to the `core` filter list.
- Adds `tests/test_ci_path_filters.py`, pinning the raw glob list in `core` by direct
  membership (`test_core_filter_covers_rigs_and_contracts`) and by exact set
  (`test_core_filter_matches_expected_set`).

## What else already covers these paths

- `contracts/**` is **partially** covered by `consumer-contracts-gate.yml`, which watches
  only the narrower `contracts/consumer-expectations/**` subtree and runs a different check
  (`scripts/run_consumer_contracts.py`), not the quick-CI suite.
- `rigs/**` had no coverage in any workflow before this change.

## Mutation kill

Deleting `'rigs/**'` from the filter and re-running:

```
tests/test_ci_path_filters.py::test_core_filter_covers_rigs_and_contracts FAILED
E   AssertionError: quick.yml's `core` filter is missing 'rigs/**' — a radio-profile-only PR
    would run zero quick-CI checks (MOR-1911)
tests/test_ci_path_filters.py::test_core_filter_matches_expected_set FAILED
E     Extra items in the right set: 'rigs/**'
2 failed in 0.07s
```

Restored, re-ran clean (`2 passed`), `git status` clean before commit. Run with
`PYTHONDONTWRITEBYTECODE=1`.

Independent review additionally re-proved the mutation for the `contracts/**` half (also
red), and confirmed the pin fails loudly rather than silently when the `filters:` block is
re-indented or re-quoted.

## What this pin does not prove

Three stated limits:

1. It asserts the glob strings are present in the config block handed to
   `dorny/paths-filter`; it does not exercise that action's own micromatch engine.
2. It does not cover the step-level `if:` wiring that consumes `steps.filter.outputs.core`.
3. It does not cover the workflow-level trigger. Adding a `paths:` list under
   `on: pull_request` would re-open the same class of gap with both tests still green.

Limits 2 and 3 belong to the wider false-green problem already tracked separately, not to
this row.

## Correction to an earlier draft of this description

An earlier revision listed `mypy` among the checks a profile-only PR was missing. That was
wrong: the only mypy step (`quick.yml:208-210`) is gated on the `frontend` filter, not
`core`, so a `rigs/`-only PR runs no mypy before or after this change.

## Scope

Two files, +83/-0. Only the `core` filter and the new pinning test. No job definitions,
matrix, or concurrency group changed. No transmit-interlock code touched.