### PR TITLE
feat(MOR-1909): land the transmit-authority vocabulary and engine

### DIFF
--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -50,6 +50,13 @@ RADIO_READBACK_SOURCES: frozenset[str] = frozenset(
     {"poll_response", "civ_unsolicited", "hamlib_response", "yaesu_poll_response"}
 )
 
+#: Every ``TxEvidence.failure`` tag this engine produces itself. A backend's
+#: read primitive may supply its own through ``TxStateReading.failure`` (for
+#: example ``"no-capability"``); those pass through untouched.
+TX_ENGINE_FAILURE_TAGS: frozenset[str] = frozenset(
+    {"timeout", "transport", "read-error", "unverifiable-provenance", "unclassified"}
+)
+
 #: Raw byte writes, excluded by name. Bytes cannot be classified, so the
 #: authority does not classify them; the totality test covers map ∪ this set,
 #: so an unmapped method can never hide as "raw".
@@ -217,6 +224,7 @@ def build_transmit_truth(
     age = snapshot.generated_at_monotonic - field.last_observed_monotonic
     return TransmitTruth(
         value=field.value,
+        # Row 6 routes Yaesu's ``tx_state_map`` attribution into this field.
         attributed=None,
         age_seconds=age if age >= 0.0 else None,
         source=str(field.source.source),
@@ -283,6 +291,11 @@ class TxArgumentContext:
     bands: tuple[tuple[int, int], ...]
 
     def first(self, name: str) -> object | None:
+        """First positional argument, else ``kwargs[name]``.
+
+        A predicate for a method whose interesting argument is *not* the first
+        positional one must read :attr:`args` / :attr:`kwargs` directly.
+        """
         if self.args:
             return self.args[0]
         return self.kwargs.get(name)
@@ -378,10 +391,14 @@ class _Hold:
 
 
 @dataclass
-class _Ticket:
-    """Handed to the caller for the duration of an admitted write."""
+class TxAdmission:
+    """Handed to the caller for the duration of an admitted write.
 
-    family: TxFamily
+    ``family`` is ``None`` only for a ``RAW_EXCLUDED`` method: bytes are not
+    classified, and the admission says so rather than borrowing a family.
+    """
+
+    family: TxFamily | None
     write_class: TxWriteClass
     evidence: TxEvidence | None = None
     holds: list[_Hold] = dataclass_field(default_factory=list)
@@ -472,10 +489,10 @@ class TransmitAuthority:
         method: str,
         args: Sequence[object] = (),
         kwargs: Mapping[str, object] | None = None,
-    ) -> AsyncIterator[_Ticket]:
+    ) -> AsyncIterator[TxAdmission]:
         """Gate one write. The body performs the write; the lock spans both."""
         if method in RAW_EXCLUDED:
-            yield _Ticket(TxFamily.RX_PATH, TxWriteClass.PASS)
+            yield TxAdmission(None, TxWriteClass.PASS)
             return
 
         context = TxArgumentContext(
@@ -503,13 +520,13 @@ class TransmitAuthority:
         write_class = FAMILY_WRITE_CLASS[family]
 
         if write_class is TxWriteClass.PASS:
-            yield _Ticket(family, write_class)
+            yield TxAdmission(family, write_class)
             return
 
         if write_class is TxWriteClass.UNKEY:
             self._deadline = None
             self._holds = []
-            yield _Ticket(family, write_class)
+            yield TxAdmission(family, write_class)
             self._record(method, family, write_class, "sent", None, None)
             return
 
@@ -518,8 +535,12 @@ class TransmitAuthority:
                 ticket = self._admit_keying(family, context)
             else:
                 ticket = await self._admit_hazard(method, family, context)
-            yield ticket
-            self._commit(method, ticket)
+            try:
+                yield ticket
+            finally:
+                # A write that raised may already have reached the radio, so
+                # the hold, the deadline and the record land either way.
+                self._commit(method, ticket)
 
     # -- internals ---------------------------------------------------------
 
@@ -531,7 +552,9 @@ class TransmitAuthority:
             return entry.family
         return TX_ARGUMENT_PREDICATES[entry.predicate](context)
 
-    def _admit_keying(self, family: TxFamily, context: TxArgumentContext) -> _Ticket:
+    def _admit_keying(
+        self, family: TxFamily, context: TxArgumentContext
+    ) -> TxAdmission:
         self._transmit_epoch += 1
         if family is TxFamily.CW_TEXT:
             duration = (
@@ -542,11 +565,11 @@ class TransmitAuthority:
             )
         else:
             hold = _Hold("key")
-        return _Ticket(family, TxWriteClass.KEYING, holds=[hold])
+        return TxAdmission(family, TxWriteClass.KEYING, holds=[hold])
 
     async def _admit_hazard(
         self, method: str, family: TxFamily, context: TxArgumentContext
-    ) -> _Ticket:
+    ) -> TxAdmission:
         def refuse(code: TxRefusalCode, evidence: TxEvidence) -> NoReturn:
             self._refuse(method, family, TxWriteClass.HAZARD, code, evidence)
 
@@ -571,6 +594,10 @@ class TransmitAuthority:
             refuse(unavailable, TxEvidence(solicited=True, failure="timeout"))
         except (OSError, RuntimeError):
             refuse(unavailable, TxEvidence(solicited=True, failure="transport"))
+        except Exception:
+            # TxRefusal is the one exception a consumer of the gate handles, so
+            # a parser fault in the read primitive becomes one too (§3.4).
+            refuse(unavailable, TxEvidence(solicited=True, failure="read-error"))
 
         evidence = TxEvidence(
             value=reading.value,
@@ -595,7 +622,7 @@ class TransmitAuthority:
         holds: list[_Hold] = []
         if family is TxFamily.TUNER and is_tune_start(context):
             holds.append(_Hold("tune"))
-        return _Ticket(family, TxWriteClass.HAZARD, evidence=evidence, holds=holds)
+        return TxAdmission(family, TxWriteClass.HAZARD, evidence=evidence, holds=holds)
 
     def _own_transmit_hold(self, now: float) -> str | None:
         if self._lease_active is not None and self._lease_active():
@@ -611,14 +638,19 @@ class TransmitAuthority:
         ]
         return self._holds
 
-    def _commit(self, method: str, ticket: _Ticket) -> None:
+    def _commit(self, method: str, ticket: TxAdmission) -> None:
         """Called once the caller's write has been handed off."""
         if ticket.holds:
-            self._holds.extend(ticket.holds)
-            self._deadline = self._clock() + self._max_key_down_seconds
-        self._record(
-            method, ticket.family, ticket.write_class, "sent", None, ticket.evidence
-        )
+            # `cw` keeps its computed duration; `key` and `tune` inherit the
+            # key-down bound, so `_active_holds` clears them on the injected
+            # clock even where no driver ever calls `poll()`.
+            deadline = self._clock() + self._max_key_down_seconds
+            for hold in ticket.holds:
+                hold.expires_at = hold.expires_at or deadline
+                self._holds.append(hold)
+            self._deadline = deadline
+        family = str(ticket.family)
+        self._record(method, family, ticket.write_class, "sent", None, ticket.evidence)
 
     def _refuse(
         self,

--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -1,0 +1,666 @@
+"""Transmit-authority vocabulary, classification table and pure engine.
+
+The authority answers one question per write: *would this command throw a
+contact under RF?* — not "are we transmitting". Only the four owner-ruled
+hazard families (band, tuner, antenna, VFO select) and the keying commands
+consult transmit truth; everything the manufacturers permit passes without
+consulting it at all.
+
+The engine performs no I/O of its own: a backend injects the solicited
+transmit-state read and a last-resort unkey, drives :meth:`poll` from a loop it
+already owns, and receives due effects as data. Nothing in the product consumes
+this module yet — it lands ahead of the backend admission rows so the contracts
+exist before any call site cites them.
+
+Design: ``docs/plans/2026-08-20-transmit-authority.md`` §3.3-§3.7.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass, field as dataclass_field, replace
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Literal, NoReturn
+
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.core.state_store import StateSnapshot
+from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Ceiling on the one solicited transmit-state read a hazard admission makes.
+#: Deliberately not the backend's generic 2.0 s GET bound: a relay throw waits
+#: for this, and an order of magnitude under the measured unkey barrier keeps
+#: a same-connection command from queueing behind it.
+TX_READ_DEADLINE_SECONDS: float = 0.3
+
+#: Decision records retained per radio.
+DECISION_LOG_CAPACITY: int = 256
+
+#: The only observation provenance that may feed :class:`TransmitTruth`. Our
+#: own command responses, the state poller, local reconciliation and test
+#: fixtures have no intake — a write outcome is never evidence of receiving.
+RADIO_READBACK_SOURCES: frozenset[str] = frozenset(
+    {"poll_response", "civ_unsolicited", "hamlib_response", "yaesu_poll_response"}
+)
+
+#: Raw byte writes, excluded by name. Bytes cannot be classified, so the
+#: authority does not classify them; the totality test covers map ∪ this set,
+#: so an unmapped method can never hide as "raw".
+RAW_EXCLUDED: frozenset[str] = frozenset(
+    {"send_civ", "send_civ_transaction", "send_civ_raw_fire_and_forget"}
+)
+
+_PTT_FIELD_PATH = FieldPath.global_("tx_state", "ptt")
+
+
+class TxWriteClass(StrEnum):
+    """The closed vocabulary of write classes."""
+
+    PASS = "pass"
+    HAZARD = "hazard"
+    KEYING = "keying"
+    UNKEY = "unkey"
+
+
+class TxFamily(StrEnum):
+    """Neutral, radio-independent command families."""
+
+    FREQUENCY = "frequency"
+    RIT_XIT = "rit-xit"
+    MODE = "mode"
+    VFO_TOPOLOGY = "vfo-topology"
+    LEVELS = "levels"
+    RX_PATH = "rx-path"
+    MEMORY_WRITE = "memory-write"
+    SCAN_START = "scan-start"
+    SCAN_STOP = "scan-stop"
+    POWER_ON = "power-on"
+    POWER_OFF = "power-off"
+    CW_STOP = "cw-stop"
+    BAND = "band"
+    TUNER = "tuner"
+    ANTENNA = "antenna"
+    VFO_SELECT = "vfo-select"
+    PTT_ON = "ptt-on"
+    CW_TEXT = "cw-text"
+    PTT_OFF = "ptt-off"
+
+
+#: The neutral family → class table. Pinned literal, never computed: PASS is
+#: an explicit entry for every permitted family, and hazard membership is a
+#: code-level constant because the four-family rule rests on universal
+#: evidence (relay physics, both vendors, the measured band-change relay
+#: throw under RF) rather than on any one radio.
+FAMILY_WRITE_CLASS: Mapping[TxFamily, TxWriteClass] = MappingProxyType(
+    {
+        TxFamily.FREQUENCY: TxWriteClass.PASS,
+        TxFamily.RIT_XIT: TxWriteClass.PASS,
+        TxFamily.MODE: TxWriteClass.PASS,
+        TxFamily.VFO_TOPOLOGY: TxWriteClass.PASS,
+        TxFamily.LEVELS: TxWriteClass.PASS,
+        TxFamily.RX_PATH: TxWriteClass.PASS,
+        TxFamily.MEMORY_WRITE: TxWriteClass.PASS,
+        TxFamily.SCAN_START: TxWriteClass.PASS,
+        TxFamily.SCAN_STOP: TxWriteClass.PASS,
+        TxFamily.POWER_ON: TxWriteClass.PASS,
+        TxFamily.POWER_OFF: TxWriteClass.PASS,
+        TxFamily.CW_STOP: TxWriteClass.PASS,
+        TxFamily.BAND: TxWriteClass.HAZARD,
+        TxFamily.TUNER: TxWriteClass.HAZARD,
+        TxFamily.ANTENNA: TxWriteClass.HAZARD,
+        TxFamily.VFO_SELECT: TxWriteClass.HAZARD,
+        TxFamily.PTT_ON: TxWriteClass.KEYING,
+        TxFamily.CW_TEXT: TxWriteClass.KEYING,
+        TxFamily.PTT_OFF: TxWriteClass.UNKEY,
+    }
+)
+
+
+class TxRefusalCode(StrEnum):
+    """Every reason the authority declines a write."""
+
+    REFUSED_WHILE_TRANSMITTING = "refused-while-transmitting"
+    TX_TRUTH_UNAVAILABLE = "tx-truth-unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class TxEvidence:
+    """What a decision observed. Required on every refusal, no exceptions."""
+
+    value: bool | None = None
+    attributed: str | None = None
+    age_seconds: float | None = None
+    source: str | None = None
+    solicited: bool = False
+    verified_readback: bool = False
+    failure: str | None = None
+    own_transmit_hold: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TxDecisionRecord:
+    """One record per non-PASS admission."""
+
+    monotonic: float
+    provider_generation: int
+    method: str
+    family: str
+    write_class: TxWriteClass
+    action: Literal["sent", "refused"]
+    code: TxRefusalCode | None
+    evidence: TxEvidence | None
+
+
+class TxRefusal(Exception):
+    """The one exception consumers of the authority handle."""
+
+    def __init__(self, code: TxRefusalCode, evidence: TxEvidence) -> None:
+        super().__init__(str(code))
+        self.code = code
+        self.evidence = evidence
+
+
+@dataclass(frozen=True, slots=True)
+class TxStateReading:
+    """One answer from the injected solicited transmit-state read."""
+
+    value: bool | None
+    attributed: str | None = None
+    source: str | None = None
+    verified_readback: bool = False
+    failure: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TransmitTruth:
+    """Display/UX-grade transmit truth. Never used for a hazard decision."""
+
+    value: bool | None
+    attributed: str | None
+    age_seconds: float | None
+    source: str | None
+    generation_current: bool
+
+
+EMPTY_TRANSMIT_TRUTH = TransmitTruth(
+    value=None,
+    attributed=None,
+    age_seconds=None,
+    source=None,
+    generation_current=False,
+)
+
+
+def build_transmit_truth(
+    snapshot: StateSnapshot, *, provider_generation: int
+) -> TransmitTruth:
+    """Project ``global.tx_state.ptt`` through the provenance pin.
+
+    Freshness is deliberately not pre-collapsed: the age travels out and each
+    consumer applies its own tolerance.
+    """
+    try:
+        field = snapshot.field(_PTT_FIELD_PATH)
+    except KeyError:
+        return EMPTY_TRANSMIT_TRUTH
+    if str(field.source.source) not in RADIO_READBACK_SOURCES:
+        return EMPTY_TRANSMIT_TRUTH
+    if type(field.value) is not bool:
+        return EMPTY_TRANSMIT_TRUTH
+    age = snapshot.generated_at_monotonic - field.last_observed_monotonic
+    return TransmitTruth(
+        value=field.value,
+        attributed=None,
+        age_seconds=age if age >= 0.0 else None,
+        source=str(field.source.source),
+        generation_current=field.provider_generation == provider_generation,
+    )
+
+
+# Band relation — data in, no profile import
+
+
+class BandRelation(StrEnum):
+    """How a target frequency relates to the current one."""
+
+    SAME_BAND = "same-band"
+    CROSS_BAND = "cross-band"
+    UNRESOLVED = "unresolved"
+
+
+def resolve_band(
+    frequency_hz: float | None, bands: Sequence[tuple[int, int]]
+) -> int | None:
+    """Index of the declared band holding ``frequency_hz``, else ``None``.
+
+    ``bands`` arrives as plain ``(low_hz, high_hz)`` tuples built by the
+    backend from its profile — this module imports nothing from ``profiles``.
+    """
+    if frequency_hz is None:
+        return None
+    for index, (low, high) in enumerate(bands):
+        if low <= frequency_hz <= high:
+            return index
+    return None
+
+
+def band_relation(
+    current_hz: float | None,
+    target_hz: float | None,
+    bands: Sequence[tuple[int, int]],
+) -> BandRelation:
+    """Cross-band detection is best-effort extra strictness, never a new gate.
+
+    A gap value, a missing current frequency or a profile with no band data
+    resolves to :attr:`BandRelation.UNRESOLVED` — the manufacturer-permitted
+    floor, because a rule that re-refused whenever the relation is murky would
+    re-enter fail-closed through the back door.
+    """
+    current = resolve_band(current_hz, bands)
+    target = resolve_band(target_hz, bands)
+    if current is None or target is None:
+        return BandRelation.UNRESOLVED
+    return BandRelation.SAME_BAND if current == target else BandRelation.CROSS_BAND
+
+
+# Argument predicates — named and pure
+
+
+@dataclass(frozen=True, slots=True)
+class TxArgumentContext:
+    """Everything a predicate may look at. No I/O, no globals."""
+
+    args: tuple[object, ...]
+    kwargs: Mapping[str, object]
+    current_frequency_hz: float | None
+    bands: tuple[tuple[int, int], ...]
+
+    def first(self, name: str) -> object | None:
+        if self.args:
+            return self.args[0]
+        return self.kwargs.get(name)
+
+
+ArgumentPredicate = Callable[[TxArgumentContext], TxFamily]
+
+
+def ptt_family(context: TxArgumentContext) -> TxFamily:
+    """``set_ptt(True)`` keys; ``set_ptt(False)`` is the one-sided unkey."""
+    return TxFamily.PTT_ON if bool(context.first("value")) else TxFamily.PTT_OFF
+
+
+def powerstat_family(context: TxArgumentContext) -> TxFamily:
+    """``set_powerstat(False)`` joins the short-circuit set, never gated."""
+    return TxFamily.POWER_ON if bool(context.first("value")) else TxFamily.POWER_OFF
+
+
+def frequency_family(context: TxArgumentContext) -> TxFamily:
+    """HAZARD only when both endpoints resolve to declared bands and differ."""
+    target = context.first("frequency")
+    target_hz = float(target) if isinstance(target, (int, float)) else None
+    relation = band_relation(context.current_frequency_hz, target_hz, context.bands)
+    return TxFamily.BAND if relation is BandRelation.CROSS_BAND else TxFamily.FREQUENCY
+
+
+def is_tune_start(context: TxArgumentContext) -> bool:
+    """``set_tuner_status(2)`` starts a tune cycle — a transmission we asked for."""
+    return context.first("value") == 2
+
+
+TX_ARGUMENT_PREDICATES: Mapping[str, ArgumentPredicate] = MappingProxyType(
+    {
+        "ptt": ptt_family,
+        "powerstat": powerstat_family,
+        "frequency": frequency_family,
+    }
+)
+
+
+def short_circuit_family(method: str, context: TxArgumentContext) -> TxFamily | None:
+    """T5: resolve de-key / power-off / stop-CW ahead of every table.
+
+    A corrupt or incomplete classification table must never make an unkey
+    harder, so this consults no map and no profile data.
+    """
+    if method == "stop_cw_text":
+        return TxFamily.CW_STOP
+    if method == "set_ptt" and not bool(context.first("value")):
+        return TxFamily.PTT_OFF
+    if method == "set_powerstat" and not bool(context.first("value")):
+        return TxFamily.POWER_OFF
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class TxMethodEntry:
+    """One row of a per-backend method-name → family map.
+
+    The per-backend maps themselves land beside the methods they pin.
+    """
+
+    family: TxFamily
+    predicate: str | None = None
+
+
+# Effects and view
+
+
+@dataclass(frozen=True, slots=True)
+class TxDeadlineExpiry:
+    """A due key-down deadline, returned as data for a driver to execute."""
+
+    monotonic: float
+    reason: str = "backend_max_key_down"
+
+
+@dataclass(frozen=True, slots=True)
+class TxAuthorityView:
+    """Read-only debuggability surface: why did it decide that."""
+
+    records: tuple[TxDecisionRecord, ...]
+    truth: TransmitTruth | None
+    own_transmit_holds: tuple[str, ...]
+    deadline_monotonic: float | None
+    lease_active: bool
+
+
+@dataclass
+class _Hold:
+    kind: str
+    expires_at: float | None = None
+
+
+@dataclass
+class _Ticket:
+    """Handed to the caller for the duration of an admitted write."""
+
+    family: TxFamily
+    write_class: TxWriteClass
+    evidence: TxEvidence | None = None
+    holds: list[_Hold] = dataclass_field(default_factory=list)
+
+
+class TransmitAuthority:
+    """One instance per radio. Pure: no sockets, no tasks, no module state."""
+
+    def __init__(
+        self,
+        *,
+        read_transmit_state: Callable[[], Awaitable[TxStateReading]],
+        last_resort_unkey: Callable[[], Awaitable[None]],
+        method_map: Mapping[str, TxMethodEntry],
+        clock: Callable[[], float] = time.monotonic,
+        bands: Sequence[tuple[int, int]] = (),
+        current_frequency_hz: Callable[[], float | None] | None = None,
+        lease_active: Callable[[], bool] | None = None,
+        truth_provider: Callable[[], TransmitTruth] | None = None,
+        provider_generation: Callable[[], int] | None = None,
+        cw_hold_duration: Callable[[TxArgumentContext], float] | None = None,
+        read_deadline_seconds: float = TX_READ_DEADLINE_SECONDS,
+        max_key_down_seconds: float = BACKEND_MAX_KEY_DOWN_SECONDS,
+    ) -> None:
+        self._read_transmit_state = read_transmit_state
+        self._last_resort_unkey = last_resort_unkey
+        self._method_map = dict(method_map)
+        self._clock = clock
+        self._bands = tuple(bands)
+        self._current_frequency_hz = current_frequency_hz
+        self._lease_active = lease_active
+        self._truth_provider = truth_provider
+        self._provider_generation = provider_generation
+        self._cw_hold_duration = cw_hold_duration
+        self._read_deadline_seconds = read_deadline_seconds
+        self._max_key_down_seconds = max_key_down_seconds
+
+        self._lock = asyncio.Lock()
+        self._records: deque[TxDecisionRecord] = deque(maxlen=DECISION_LOG_CAPACITY)
+        self._holds: list[_Hold] = []
+        self._deadline: float | None = None
+        self._transmit_epoch = 0
+
+    # -- intake ------------------------------------------------------------
+
+    def note_transmit_observation(self, transmitting: bool) -> None:
+        """Record that the radio was seen transmitting.
+
+        Only the transmitting direction has an effect: it invalidates any read
+        an in-flight hazard admission is holding. A receive report clears
+        nothing — inferring *receive* from anything but a fresh solicited read
+        is what the programme forbids.
+        """
+        if transmitting:
+            self._transmit_epoch += 1
+
+    async def fire_last_resort_unkey(self) -> None:
+        """The last-resort OFF rail, for a driver with no better one."""
+        await self._last_resort_unkey()
+
+    # -- inspection --------------------------------------------------------
+
+    def view(self) -> TxAuthorityView:
+        return TxAuthorityView(
+            records=tuple(self._records),
+            truth=self._truth_provider() if self._truth_provider else None,
+            own_transmit_holds=tuple(
+                hold.kind for hold in self._active_holds(self._clock())
+            ),
+            deadline_monotonic=self._deadline,
+            lease_active=bool(self._lease_active and self._lease_active()),
+        )
+
+    def poll(self, now: float) -> tuple[TxDeadlineExpiry, ...]:
+        """Return due effects and disarm. Drivers execute them on their rails."""
+        deadline = self._deadline
+        if deadline is None or now < deadline:
+            return ()
+        self._deadline = None
+        self._holds = [hold for hold in self._holds if hold.kind == "cw"]
+        return (TxDeadlineExpiry(monotonic=deadline),)
+
+    # -- admission ---------------------------------------------------------
+
+    @asynccontextmanager
+    async def admit(
+        self,
+        method: str,
+        args: Sequence[object] = (),
+        kwargs: Mapping[str, object] | None = None,
+    ) -> AsyncIterator[_Ticket]:
+        """Gate one write. The body performs the write; the lock spans both."""
+        if method in RAW_EXCLUDED:
+            yield _Ticket(TxFamily.RX_PATH, TxWriteClass.PASS)
+            return
+
+        context = TxArgumentContext(
+            args=tuple(args),
+            kwargs=dict(kwargs or {}),
+            current_frequency_hz=(
+                self._current_frequency_hz() if self._current_frequency_hz else None
+            ),
+            bands=self._bands,
+        )
+
+        family = short_circuit_family(method, context)
+        if family is None:
+            family = self._classify(method, context)
+        if family is None:
+            # INV-1's fail direction: nothing defaults to PASS by omission.
+            self._refuse(
+                method,
+                "unclassified",
+                TxWriteClass.HAZARD,
+                TxRefusalCode.TX_TRUTH_UNAVAILABLE,
+                TxEvidence(failure="unclassified"),
+            )
+
+        write_class = FAMILY_WRITE_CLASS[family]
+
+        if write_class is TxWriteClass.PASS:
+            yield _Ticket(family, write_class)
+            return
+
+        if write_class is TxWriteClass.UNKEY:
+            self._deadline = None
+            self._holds = []
+            yield _Ticket(family, write_class)
+            self._record(method, family, write_class, "sent", None, None)
+            return
+
+        async with self._lock:
+            if write_class is TxWriteClass.KEYING:
+                ticket = self._admit_keying(family, context)
+            else:
+                ticket = await self._admit_hazard(method, family, context)
+            yield ticket
+            self._commit(method, ticket)
+
+    # -- internals ---------------------------------------------------------
+
+    def _classify(self, method: str, context: TxArgumentContext) -> TxFamily | None:
+        entry = self._method_map.get(method)
+        if entry is None:
+            return None
+        if entry.predicate is None:
+            return entry.family
+        return TX_ARGUMENT_PREDICATES[entry.predicate](context)
+
+    def _admit_keying(self, family: TxFamily, context: TxArgumentContext) -> _Ticket:
+        self._transmit_epoch += 1
+        if family is TxFamily.CW_TEXT:
+            duration = (
+                self._cw_hold_duration(context) if self._cw_hold_duration else None
+            )
+            hold = _Hold(
+                "cw", None if duration is None else self._clock() + float(duration)
+            )
+        else:
+            hold = _Hold("key")
+        return _Ticket(family, TxWriteClass.KEYING, holds=[hold])
+
+    async def _admit_hazard(
+        self, method: str, family: TxFamily, context: TxArgumentContext
+    ) -> _Ticket:
+        def refuse(code: TxRefusalCode, evidence: TxEvidence) -> NoReturn:
+            self._refuse(method, family, TxWriteClass.HAZARD, code, evidence)
+
+        unavailable = TxRefusalCode.TX_TRUTH_UNAVAILABLE
+
+        # Step 1 — our own transmission, refused with no wire read at all.
+        held = self._own_transmit_hold(self._clock())
+        if held is not None:
+            refuse(
+                TxRefusalCode.REFUSED_WHILE_TRANSMITTING,
+                TxEvidence(own_transmit_hold=held),
+            )
+
+        # Step 2 — one solicited read on this admission's own deadline.
+        epoch = self._transmit_epoch
+        started = self._clock()
+        try:
+            reading = await asyncio.wait_for(
+                self._read_transmit_state(), self._read_deadline_seconds
+            )
+        except asyncio.TimeoutError:
+            refuse(unavailable, TxEvidence(solicited=True, failure="timeout"))
+        except (OSError, RuntimeError):
+            refuse(unavailable, TxEvidence(solicited=True, failure="transport"))
+
+        evidence = TxEvidence(
+            value=reading.value,
+            attributed=reading.attributed,
+            age_seconds=self._clock() - started,
+            source=reading.source,
+            solicited=True,
+            verified_readback=reading.verified_readback,
+            failure=reading.failure,
+        )
+        if reading.value is None:
+            refuse(unavailable, evidence)
+        if not reading.verified_readback:
+            # The rigctld-client answer is an upstream cache, not radio truth.
+            refuse(
+                unavailable,
+                replace(evidence, failure="unverifiable-provenance"),
+            )
+        if reading.value or epoch != self._transmit_epoch:
+            refuse(TxRefusalCode.REFUSED_WHILE_TRANSMITTING, evidence)
+
+        holds: list[_Hold] = []
+        if family is TxFamily.TUNER and is_tune_start(context):
+            holds.append(_Hold("tune"))
+        return _Ticket(family, TxWriteClass.HAZARD, evidence=evidence, holds=holds)
+
+    def _own_transmit_hold(self, now: float) -> str | None:
+        if self._lease_active is not None and self._lease_active():
+            return "lease"
+        active = self._active_holds(now)
+        return active[0].kind if active else None
+
+    def _active_holds(self, now: float) -> list[_Hold]:
+        self._holds = [
+            hold
+            for hold in self._holds
+            if hold.expires_at is None or now < hold.expires_at
+        ]
+        return self._holds
+
+    def _commit(self, method: str, ticket: _Ticket) -> None:
+        """Called once the caller's write has been handed off."""
+        if ticket.holds:
+            self._holds.extend(ticket.holds)
+            self._deadline = self._clock() + self._max_key_down_seconds
+        self._record(
+            method, ticket.family, ticket.write_class, "sent", None, ticket.evidence
+        )
+
+    def _refuse(
+        self,
+        method: str,
+        family: TxFamily | str,
+        write_class: TxWriteClass,
+        code: TxRefusalCode,
+        evidence: TxEvidence,
+    ) -> NoReturn:
+        self._record(method, family, write_class, "refused", code, evidence)
+        _LOGGER.warning(
+            "transmit authority refused write",
+            extra={
+                "method": method,
+                "family": str(family),
+                "writeClass": str(write_class),
+                "code": str(code),
+                "evidence": asdict(evidence),
+            },
+        )
+        raise TxRefusal(code, evidence)
+
+    def _record(
+        self,
+        method: str,
+        family: TxFamily | str,
+        write_class: TxWriteClass,
+        action: Literal["sent", "refused"],
+        code: TxRefusalCode | None,
+        evidence: TxEvidence | None,
+    ) -> None:
+        self._records.append(
+            TxDecisionRecord(
+                monotonic=self._clock(),
+                provider_generation=(
+                    self._provider_generation() if self._provider_generation else 0
+                ),
+                method=method,
+                family=str(family),
+                write_class=write_class,
+                action=action,
+                code=code,
+                evidence=evidence,
+            )
+        )

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -24,6 +24,7 @@ from rigplane.core.tx_authority import (
     RADIO_READBACK_SOURCES,
     RAW_EXCLUDED,
     TX_ARGUMENT_PREDICATES,
+    TX_ENGINE_FAILURE_TAGS,
     TX_READ_DEADLINE_SECONDS,
     BandRelation,
     TransmitAuthority,
@@ -85,6 +86,8 @@ class FakeTransmitStateLink:
         self._clock = clock
         self.reads: list[float] = []
         self.answers: list[TxStateReading | str] = []
+        self.read_started: asyncio.Event | None = None
+        self.release_read: asyncio.Event | None = None
         self.read_latency = 0.01
         self.default = TxStateReading(
             value=False,
@@ -100,6 +103,10 @@ class FakeTransmitStateLink:
 
     async def read(self) -> TxStateReading:
         self.reads.append(self._clock())
+        if self.read_started is not None:
+            self.read_started.set()
+        if self.release_read is not None:
+            await self.release_read.wait()
         for hook in self.on_read:
             hook()  # type: ignore[operator]
         answer = self.answers.pop(0) if self.answers else self.default
@@ -107,6 +114,8 @@ class FakeTransmitStateLink:
             await asyncio.sleep(3600)
         if answer == "boom":
             raise OSError("transport is down")
+        if answer == "garbage":
+            raise ValueError("the row-5 parser could not decode the reply")
         self._clock.advance(self.read_latency)
         assert isinstance(answer, TxStateReading)
         return answer
@@ -434,6 +443,34 @@ async def test_hazard_transport_error_fails_closed() -> None:
     assert excinfo.value.evidence.failure == "transport"
 
 
+async def test_an_unexpected_read_error_is_still_a_typed_refusal() -> None:
+    """§3.4: ``TxRefusal`` is the one exception consumers of the gate handle."""
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script("garbage")
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_antenna_1", ()):
+            pytest.fail("hazard write reached the wire on an undecodable reply")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence.failure == "read-error"
+    assert authority.view().records[-1].action == "refused"
+
+
+def test_engine_failure_tag_set_is_pinned() -> None:
+    """A sixth tag must not appear unnoticed: row 9b widens the web envelope."""
+    assert TX_ENGINE_FAILURE_TAGS == frozenset(
+        {
+            "timeout",
+            "transport",
+            "read-error",
+            "unverifiable-provenance",
+            "unclassified",
+        }
+    )
+
+
 async def test_hazard_without_capability_fails_closed() -> None:
     clock = Clock()
     link = FakeTransmitStateLink(clock)
@@ -580,20 +617,36 @@ async def test_an_admitted_unkey_clears_the_key_hold() -> None:
 # --------------------------------------------------------------------------
 
 
+#: A table that classifies all three T5 methods into HAZARD families. An empty
+#: map is not a poisoned one — it leaves the short-circuit as the only path and
+#: so cannot catch INV-6's mutation ("reorder the short-circuit after the
+#: table"). This map can: with the table consulted first, every de-key path
+#: becomes a hazard write and is refused at a scripted TX.
+POISONED_MAP: Mapping[str, TxMethodEntry] = {
+    "set_ptt": TxMethodEntry(TxFamily.TUNER),
+    "set_powerstat": TxMethodEntry(TxFamily.ANTENNA),
+    "stop_cw_text": TxMethodEntry(TxFamily.BAND),
+}
+
+
 async def test_unkey_is_never_refused_even_with_a_poisoned_table() -> None:
+    """INV-5/INV-6: the T5 short-circuit precedes the table and the wire."""
     clock = Clock()
     link = FakeTransmitStateLink(clock)
-    link.script(TX)
-    authority = build_authority(clock, PoisonedLink(), method_map={})
+    link.script(TX, TX, TX)
+    authority = build_authority(clock, link, method_map=POISONED_MAP)
 
-    async with authority.admit("set_ptt", (False,)):
-        pass
-    async with authority.admit("set_powerstat", (False,)):
-        pass
-    async with authority.admit("stop_cw_text", ()):
-        pass
+    for method, args in (
+        ("set_ptt", (False,)),
+        ("set_powerstat", (False,)),
+        ("stop_cw_text", ()),
+    ):
+        async with authority.admit(method, args):
+            pass
+
+    assert link.reads == []  # not one of the three consulted the radio
     assert authority.view().deadline_monotonic is None
-    assert link.reads == []
+    assert authority.view().records[-1].write_class is TxWriteClass.UNKEY
 
 
 async def test_unkey_clears_the_deadline_and_the_holds() -> None:
@@ -705,6 +758,52 @@ async def test_a_refused_tune_start_neither_holds_nor_arms() -> None:
     assert authority.view().own_transmit_holds == ()
 
 
+@pytest.mark.parametrize(
+    ("method", "args", "hold"),
+    [("set_ptt", (True,), "key"), ("set_tuner_status", (2,), "tune")],
+)
+async def test_own_transmit_holds_do_not_outlive_the_deadline_without_a_driver(
+    method: str, args: tuple[object, ...], hold: str
+) -> None:
+    """The bound the ADR already specifies, evaluated without a ``poll()`` caller.
+
+    Rows 7-11 arm no deadline driver, and a tune start has no natural unkey at
+    all, so a hold that only ``poll()`` could clear would refuse the whole
+    hazard set for the life of the connection. An expired hold does not go
+    blind: it falls through to the solicited read.
+    """
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX, RX)
+    authority = build_authority(clock, link)
+
+    async with authority.admit(method, args):
+        pass
+    assert authority.view().own_transmit_holds == (hold,)
+
+    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS + 1.0)
+    assert authority.view().own_transmit_holds == ()  # poll() was never called
+
+    reads_before = len(link.reads)
+    async with authority.admit("set_antenna_1", ()):
+        pass
+    assert len(link.reads) == reads_before + 1
+
+
+async def test_a_failed_key_write_still_records_its_hold() -> None:
+    """A write that raised may already have reached the radio."""
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(OSError):
+        async with authority.admit("set_ptt", (True,)):
+            raise OSError("the transport died after the frame went out")
+
+    assert authority.view().own_transmit_holds == ("key",)
+    assert authority.view().deadline_monotonic is not None
+
+
 async def test_last_resort_unkey_is_the_only_other_injected_effect() -> None:
     clock = Clock()
     link = FakeTransmitStateLink(clock)
@@ -731,6 +830,41 @@ async def test_a_transmit_observation_between_read_and_write_invalidates_it() ->
         async with authority.admit("set_antenna_1", ()):
             pytest.fail("hazard write used a read a transmit event invalidated")
     assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+
+
+async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
+    """INV-4: the admission lock spans the read and the write it authorised.
+
+    Counts cannot see this — both writes happen either way. Only the *order*
+    of the effects distinguishes a held lock from an open window.
+    """
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX)
+    link.read_started = asyncio.Event()
+    link.release_read = asyncio.Event()
+    authority = build_authority(clock, link)
+    order: list[str] = []
+
+    async def hazard() -> None:
+        async with authority.admit("set_antenna_1", ()):
+            order.append("hazard-write")
+
+    async def key() -> None:
+        async with authority.admit("set_ptt", (True,)):
+            order.append("key-write")
+
+    hazard_task = asyncio.create_task(hazard())
+    await asyncio.wait_for(link.read_started.wait(), 1.0)
+
+    key_task = asyncio.create_task(key())
+    for _ in range(20):
+        await asyncio.sleep(0)  # the key gets every chance to slip in
+    assert order == [], "the key ran while a hazard admission held the lock"
+
+    link.release_read.set()
+    await asyncio.gather(hazard_task, key_task)
+    assert order == ["hazard-write", "key-write"]
 
 
 async def test_a_receive_observation_never_clears_anything() -> None:
@@ -826,8 +960,8 @@ async def test_raw_excluded_methods_are_not_classified() -> None:
     link = FakeTransmitStateLink(clock)
     authority = build_authority(clock, PoisonedLink())
     for method in sorted(RAW_EXCLUDED):
-        async with authority.admit(method, (b"\xfe\xfe",)):
-            pass
+        async with authority.admit(method, (b"\xfe\xfe",)) as admission:
+            assert admission.family is None  # bytes are not classified
     assert authority.view().records == ()
     assert link.reads == []
 

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -1,0 +1,917 @@
+"""Unit tests for the transmit-authority vocabulary and pure engine.
+
+Row 1 of the transmit-authority migration: the engine is consumed by nothing,
+so every test here drives it directly with real fakes and a fake clock. No
+MagicMock anywhere near the authority (repo hard rule).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    SourceMetadata,
+)
+from rigplane.core.state_store import FieldSnapshot, FreshnessState, StateSnapshot
+from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
+from rigplane.core.tx_authority import (
+    DECISION_LOG_CAPACITY,
+    FAMILY_WRITE_CLASS,
+    RADIO_READBACK_SOURCES,
+    RAW_EXCLUDED,
+    TX_ARGUMENT_PREDICATES,
+    TX_READ_DEADLINE_SECONDS,
+    BandRelation,
+    TransmitAuthority,
+    TransmitTruth,
+    TxArgumentContext,
+    TxFamily,
+    TxMethodEntry,
+    TxRefusal,
+    TxRefusalCode,
+    TxStateReading,
+    TxWriteClass,
+    band_relation,
+    build_transmit_truth,
+    resolve_band,
+)
+
+PTT_PATH = FieldPath.global_("tx_state", "ptt")
+
+BANDS: tuple[tuple[int, int], ...] = (
+    (14_000_000, 14_350_000),
+    (21_000_000, 21_450_000),
+    (28_000_000, 29_700_000),
+)
+
+METHOD_MAP: Mapping[str, TxMethodEntry] = {
+    "set_ptt": TxMethodEntry(TxFamily.PTT_ON, predicate="ptt"),
+    "set_powerstat": TxMethodEntry(TxFamily.POWER_ON, predicate="powerstat"),
+    "set_freq": TxMethodEntry(TxFamily.FREQUENCY, predicate="frequency"),
+    "set_mode": TxMethodEntry(TxFamily.MODE),
+    "set_split": TxMethodEntry(TxFamily.VFO_TOPOLOGY),
+    "set_power": TxMethodEntry(TxFamily.LEVELS),
+    "stop_cw_text": TxMethodEntry(TxFamily.CW_STOP),
+    "send_cw_text": TxMethodEntry(TxFamily.CW_TEXT),
+    "set_tuner_status": TxMethodEntry(TxFamily.TUNER),
+    "set_antenna_1": TxMethodEntry(TxFamily.ANTENNA),
+    "set_band": TxMethodEntry(TxFamily.BAND),
+    "set_vfo_slot": TxMethodEntry(TxFamily.VFO_SELECT),
+    "memory_to_vfo": TxMethodEntry(TxFamily.BAND),
+}
+
+
+class Clock:
+    """Deterministic monotonic clock."""
+
+    def __init__(self, start: float = 100.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeTransmitStateLink:
+    """Scripted transmit-state answers plus a wire log."""
+
+    def __init__(self, clock: Clock) -> None:
+        self._clock = clock
+        self.reads: list[float] = []
+        self.answers: list[TxStateReading | str] = []
+        self.read_latency = 0.01
+        self.default = TxStateReading(
+            value=False,
+            attributed="rx",
+            source="poll_response",
+            verified_readback=True,
+            failure=None,
+        )
+        self.on_read: list[object] = []
+
+    def script(self, *answers: TxStateReading | str) -> None:
+        self.answers.extend(answers)
+
+    async def read(self) -> TxStateReading:
+        self.reads.append(self._clock())
+        for hook in self.on_read:
+            hook()  # type: ignore[operator]
+        answer = self.answers.pop(0) if self.answers else self.default
+        if answer == "hang":
+            await asyncio.sleep(3600)
+        if answer == "boom":
+            raise OSError("transport is down")
+        self._clock.advance(self.read_latency)
+        assert isinstance(answer, TxStateReading)
+        return answer
+
+
+class PoisonedLink:
+    """A read callable that must never be invoked."""
+
+    async def read(self) -> TxStateReading:  # pragma: no cover - must not run
+        raise AssertionError("transmit truth was consulted on a PASS write")
+
+
+class FakeUnkey:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self) -> None:
+        self.calls += 1
+
+
+RX = TxStateReading(
+    value=False,
+    attributed="rx",
+    source="poll_response",
+    verified_readback=True,
+    failure=None,
+)
+TX = TxStateReading(
+    value=True,
+    attributed="tx_other",
+    source="poll_response",
+    verified_readback=True,
+    failure=None,
+)
+UNVERIFIED_RX = TxStateReading(
+    value=False,
+    attributed="rx",
+    source="hamlib_response",
+    verified_readback=False,
+    failure=None,
+)
+NO_CAPABILITY = TxStateReading(
+    value=None,
+    attributed=None,
+    source=None,
+    verified_readback=False,
+    failure="no-capability",
+)
+
+
+def build_authority(
+    clock: Clock,
+    link: FakeTransmitStateLink | PoisonedLink,
+    *,
+    unkey: FakeUnkey | None = None,
+    method_map: Mapping[str, TxMethodEntry] | None = None,
+    bands: Sequence[tuple[int, int]] = BANDS,
+    current_frequency_hz: float | None = 14_200_000,
+    lease_active: bool = False,
+    cw_hold_seconds: float | None = 5.0,
+) -> TransmitAuthority:
+    return TransmitAuthority(
+        read_transmit_state=link.read,
+        last_resort_unkey=unkey or FakeUnkey(),
+        method_map=METHOD_MAP if method_map is None else method_map,
+        clock=clock,
+        bands=tuple(bands),
+        current_frequency_hz=lambda: current_frequency_hz,
+        lease_active=lambda: lease_active,
+        cw_hold_duration=(
+            None if cw_hold_seconds is None else (lambda _ctx: cw_hold_seconds)
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# Pinned literals (INV-8 and the raw exclusion)
+# --------------------------------------------------------------------------
+
+
+def test_radio_readback_sources_pin() -> None:
+    """Only radio-readback provenance feeds transmit truth (INV-8).
+
+    Mutation: adding ``"state_poller"`` (or any producer-side tag) to the
+    frozenset must make this test go red.
+    """
+    assert RADIO_READBACK_SOURCES == frozenset(
+        {
+            "poll_response",
+            "civ_unsolicited",
+            "hamlib_response",
+            "yaesu_poll_response",
+        }
+    )
+    for excluded in ("command_response", "state_poller", "local_reconcile", "test"):
+        assert excluded not in RADIO_READBACK_SOURCES
+
+
+def test_raw_excluded_pin() -> None:
+    """Raw byte writes are excluded by name, never classified."""
+    assert RAW_EXCLUDED == frozenset(
+        {
+            "send_civ",
+            "send_civ_transaction",
+            "send_civ_raw_fire_and_forget",
+        }
+    )
+
+
+def test_family_class_table_is_total_and_pinned() -> None:
+    assert set(FAMILY_WRITE_CLASS) == set(TxFamily)
+    hazard = {f for f, c in FAMILY_WRITE_CLASS.items() if c is TxWriteClass.HAZARD}
+    assert hazard == {
+        TxFamily.BAND,
+        TxFamily.TUNER,
+        TxFamily.ANTENNA,
+        TxFamily.VFO_SELECT,
+    }
+    keying = {f for f, c in FAMILY_WRITE_CLASS.items() if c is TxWriteClass.KEYING}
+    assert keying == {TxFamily.PTT_ON, TxFamily.CW_TEXT}
+    unkey = {f for f, c in FAMILY_WRITE_CLASS.items() if c is TxWriteClass.UNKEY}
+    assert unkey == {TxFamily.PTT_OFF}
+    assert FAMILY_WRITE_CLASS[TxFamily.FREQUENCY] is TxWriteClass.PASS
+    assert FAMILY_WRITE_CLASS[TxFamily.MODE] is TxWriteClass.PASS
+    assert FAMILY_WRITE_CLASS[TxFamily.VFO_TOPOLOGY] is TxWriteClass.PASS
+    assert FAMILY_WRITE_CLASS[TxFamily.POWER_OFF] is TxWriteClass.PASS
+    assert FAMILY_WRITE_CLASS[TxFamily.CW_STOP] is TxWriteClass.PASS
+
+
+def test_key_down_bound_is_imported_not_respelled() -> None:
+    from rigplane.core import tx_authority
+
+    assert tx_authority.BACKEND_MAX_KEY_DOWN_SECONDS is BACKEND_MAX_KEY_DOWN_SECONDS
+    source = tx_authority.__file__ or ""
+    assert source.endswith("tx_authority.py")
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "180" not in text
+
+
+def test_read_deadline_is_its_own_named_bound() -> None:
+    assert TX_READ_DEADLINE_SECONDS == 0.3
+
+
+def test_argument_predicate_registry_is_named_and_pure() -> None:
+    assert set(TX_ARGUMENT_PREDICATES) == {"ptt", "powerstat", "frequency"}
+    ctx = TxArgumentContext(
+        args=(True,), kwargs={}, current_frequency_hz=None, bands=()
+    )
+    assert TX_ARGUMENT_PREDICATES["ptt"](ctx) is TxFamily.PTT_ON
+    off = TxArgumentContext(
+        args=(False,), kwargs={}, current_frequency_hz=None, bands=()
+    )
+    assert TX_ARGUMENT_PREDICATES["ptt"](off) is TxFamily.PTT_OFF
+    assert TX_ARGUMENT_PREDICATES["powerstat"](off) is TxFamily.POWER_OFF
+
+
+# --------------------------------------------------------------------------
+# Band relation arithmetic (§3.3)
+# --------------------------------------------------------------------------
+
+
+def test_resolve_band_hits_gap_and_missing_data() -> None:
+    assert resolve_band(14_200_000, BANDS) == 0
+    assert resolve_band(21_100_000, BANDS) == 1
+    assert resolve_band(18_100_000, BANDS) is None  # gap between declared bands
+    assert resolve_band(None, BANDS) is None
+    assert resolve_band(14_200_000, ()) is None
+
+
+@pytest.mark.parametrize(
+    ("current", "target", "bands", "expected"),
+    [
+        (14_200_000, 14_300_000, BANDS, BandRelation.SAME_BAND),
+        (14_200_000, 21_100_000, BANDS, BandRelation.CROSS_BAND),
+        (14_200_000, 18_100_000, BANDS, BandRelation.UNRESOLVED),
+        (18_100_000, 21_100_000, BANDS, BandRelation.UNRESOLVED),
+        (None, 21_100_000, BANDS, BandRelation.UNRESOLVED),
+        (14_200_000, 21_100_000, (), BandRelation.UNRESOLVED),
+    ],
+)
+def test_band_relation(
+    current: float | None,
+    target: float,
+    bands: tuple[tuple[int, int], ...],
+    expected: BandRelation,
+) -> None:
+    assert band_relation(current, target, bands) is expected
+
+
+@pytest.mark.parametrize(
+    ("current", "target", "bands", "family"),
+    [
+        (14_200_000, 14_300_000, BANDS, TxFamily.FREQUENCY),
+        (14_200_000, 21_100_000, BANDS, TxFamily.BAND),
+        (14_200_000, 18_100_000, BANDS, TxFamily.FREQUENCY),
+        (None, 21_100_000, BANDS, TxFamily.FREQUENCY),
+        (14_200_000, 21_100_000, (), TxFamily.FREQUENCY),
+    ],
+)
+def test_frequency_predicate_only_gates_a_resolved_crossing(
+    current: float | None,
+    target: float,
+    bands: tuple[tuple[int, int], ...],
+    family: TxFamily,
+) -> None:
+    ctx = TxArgumentContext(
+        args=(target,), kwargs={}, current_frequency_hz=current, bands=bands
+    )
+    assert TX_ARGUMENT_PREDICATES["frequency"](ctx) is family
+
+
+async def test_cross_band_set_freq_is_gated_and_in_band_is_not() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(TX)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_freq", (14_250_000,)):
+        pass
+    assert link.reads == []  # in-band frequency never consults truth
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_freq", (21_100_000,)):
+            pytest.fail("cross-band write must not reach the wire")
+    assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    assert len(link.reads) == 1
+
+
+# --------------------------------------------------------------------------
+# Fail-direction per class × per truth answer (§3.3)
+# --------------------------------------------------------------------------
+
+
+async def test_pass_class_never_consults_truth() -> None:
+    """INV-3: a poisoned read callable must not be reachable from PASS."""
+    clock = Clock()
+    authority = build_authority(clock, PoisonedLink())
+    sent: list[str] = []
+    for method, args in (
+        ("set_mode", ("USB",)),
+        ("set_split", (True,)),
+        ("set_power", (50,)),
+        ("set_powerstat", (True,)),
+        ("stop_cw_text", ()),
+    ):
+        async with authority.admit(method, args):
+            sent.append(method)
+    assert len(sent) == 5
+    assert authority.view().records == ()
+
+
+async def test_hazard_at_confirmed_rx_reads_before_the_write() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX)
+    authority = build_authority(clock, link)
+    wire: list[str] = []
+    link.on_read.append(lambda: wire.append("read"))
+
+    async with authority.admit("set_antenna_1", ()):
+        wire.append("write")
+
+    assert wire == ["read", "write"]
+    record = authority.view().records[-1]
+    assert record.action == "sent"
+    assert record.family == TxFamily.ANTENNA
+    assert record.write_class is TxWriteClass.HAZARD
+    assert record.code is None
+    assert record.evidence is not None
+    assert record.evidence.solicited is True
+    assert record.evidence.value is False
+    assert record.evidence.age_seconds == pytest.approx(link.read_latency)
+
+
+async def test_hazard_at_transmit_is_refused_with_evidence() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(TX)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_tuner_status", (1,)):
+            pytest.fail("hazard write reached the wire while transmitting")
+
+    refusal = excinfo.value
+    assert refusal.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    assert refusal.evidence.value is True
+    assert refusal.evidence.attributed == "tx_other"
+    assert refusal.evidence.source == "poll_response"
+    assert refusal.evidence.solicited is True
+    assert refusal.evidence.own_transmit_hold is None
+    record = authority.view().records[-1]
+    assert record.action == "refused"
+    assert record.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+
+
+async def test_hazard_read_timeout_fails_closed() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script("hang")
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_band", (20,)):
+            pytest.fail("hazard write reached the wire on an unanswered read")
+
+    refusal = excinfo.value
+    assert refusal.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert refusal.evidence.failure == "timeout"
+    assert refusal.evidence.value is None
+    assert refusal.evidence.solicited is True
+
+
+async def test_hazard_transport_error_fails_closed() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script("boom")
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_vfo_slot", ("B",)):
+            pytest.fail("hazard write reached the wire on a failed read")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence.failure == "transport"
+
+
+async def test_hazard_without_capability_fails_closed() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(NO_CAPABILITY)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("memory_to_vfo", (3,)):
+            pytest.fail("hazard write reached the wire without a read primitive")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence.failure == "no-capability"
+
+
+async def test_unverifiable_readback_fails_closed() -> None:
+    """§3.7: the rigctld-client answer is an upstream cache, not radio truth."""
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(UNVERIFIED_RX)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_antenna_1", ()):
+            pytest.fail("hazard write admitted on an unverifiable readback")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence.failure == "unverifiable-provenance"
+    assert excinfo.value.evidence.verified_readback is False
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [TX, "hang", "boom", NO_CAPABILITY, UNVERIFIED_RX],
+)
+async def test_every_refusal_carries_evidence(answer: TxStateReading | str) -> None:
+    """INV-14: no refusal is exempt from carrying its evidence."""
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(answer)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_tuner_status", (0,)):
+            pytest.fail("refused write reached the wire")
+    evidence = excinfo.value.evidence
+    assert evidence is not None
+    assert (evidence.value is not None) or (evidence.failure is not None)
+    assert authority.view().records[-1].evidence is evidence
+
+
+# --------------------------------------------------------------------------
+# Own-transmit holds — the B6 golden (§3.5 step 1, INV-16)
+# --------------------------------------------------------------------------
+
+
+async def test_b6_golden_own_cw_hold_refuses_without_any_wire_read() -> None:
+    """A scripted RX answer during our own CW message must not admit a hazard.
+
+    B6, on the bench: the radio reported *receiving* while it was audibly
+    still sending a CAT-issued CW message. The hold is the evidence; the wire
+    is not consulted at all.
+    """
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX, RX)  # the radio would answer "receiving" if asked
+    authority = build_authority(clock, link, cw_hold_seconds=5.0)
+
+    async with authority.admit("send_cw_text", ("CQ CQ DE TEST",)):
+        pass
+    assert link.reads == []
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_band", (15,)):
+            pytest.fail("hazard write admitted during our own CW message")
+
+    refusal = excinfo.value
+    assert refusal.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    assert refusal.evidence.own_transmit_hold == "cw"
+    assert refusal.evidence.solicited is False
+    assert refusal.evidence.value is None
+    assert link.reads == []  # no wire read at all
+    assert authority.view().records[-1].evidence.own_transmit_hold == "cw"
+
+    clock.advance(6.0)  # the computed message duration elapses
+    async with authority.admit("set_band", (15,)):
+        pass
+    assert len(link.reads) == 1
+
+
+@pytest.mark.parametrize(
+    ("setup_method", "setup_args", "hold"),
+    [
+        ("set_ptt", (True,), "key"),
+        ("set_tuner_status", (2,), "tune"),
+    ],
+)
+async def test_own_transmit_holds_refuse_hazard_writes(
+    setup_method: str, setup_args: tuple[object, ...], hold: str
+) -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX, RX)
+    authority = build_authority(clock, link)
+
+    async with authority.admit(setup_method, setup_args):
+        pass
+    reads_after_setup = len(link.reads)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_antenna_1", ()):
+            pytest.fail("hazard write admitted while we hold our own transmission")
+    assert excinfo.value.evidence.own_transmit_hold == hold
+    assert len(link.reads) == reads_after_setup  # step 1 makes no wire read
+
+
+async def test_supervisor_lease_is_an_own_transmit_hold() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX)
+    authority = build_authority(clock, link, lease_active=True)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_antenna_1", ()):
+            pytest.fail("hazard write admitted under an active managed lease")
+    assert excinfo.value.evidence.own_transmit_hold == "lease"
+    assert link.reads == []
+
+
+async def test_an_admitted_unkey_clears_the_key_hold() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    async with authority.admit("set_ptt", (False,)):
+        pass
+    async with authority.admit("set_antenna_1", ()):
+        pass
+    assert len(link.reads) == 1
+
+
+# --------------------------------------------------------------------------
+# T5 / INV-5 / INV-6 — the unkey is never made harder
+# --------------------------------------------------------------------------
+
+
+async def test_unkey_is_never_refused_even_with_a_poisoned_table() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(TX)
+    authority = build_authority(clock, PoisonedLink(), method_map={})
+
+    async with authority.admit("set_ptt", (False,)):
+        pass
+    async with authority.admit("set_powerstat", (False,)):
+        pass
+    async with authority.admit("stop_cw_text", ()):
+        pass
+    assert authority.view().deadline_monotonic is None
+    assert link.reads == []
+
+
+async def test_unkey_clears_the_deadline_and_the_holds() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    assert authority.view().deadline_monotonic == pytest.approx(
+        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
+    )
+    assert authority.view().own_transmit_holds == ("key",)
+
+    async with authority.admit("set_ptt", (False,)):
+        pass
+    assert authority.view().deadline_monotonic is None
+    assert authority.view().own_transmit_holds == ()
+
+
+# --------------------------------------------------------------------------
+# KEYING and the one deadline (§3.6, INV-7)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("answer", [RX, TX, "boom"])
+async def test_keying_is_admitted_on_every_truth_answer(
+    answer: TxStateReading | str,
+) -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(answer)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    assert link.reads == []  # a key is explicit operator intent, never truth-gated
+    record = authority.view().records[-1]
+    assert record.action == "sent"
+    assert record.write_class is TxWriteClass.KEYING
+    assert record.evidence is None
+
+
+async def test_deadline_fires_once_and_is_disarmed() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    assert authority.poll(clock.now) == ()
+
+    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS - 0.001)
+    assert authority.poll(clock.now) == ()
+
+    clock.advance(0.002)
+    effects = authority.poll(clock.now)
+    assert len(effects) == 1
+    assert effects[0].reason == "backend_max_key_down"
+    assert authority.poll(clock.now) == ()
+    assert authority.view().deadline_monotonic is None
+    assert authority.view().own_transmit_holds == ()
+
+
+async def test_a_newer_key_rearms_the_deadline() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    clock.advance(60.0)
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    assert authority.view().deadline_monotonic == pytest.approx(
+        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
+    )
+
+
+async def test_admitted_tune_start_holds_and_arms_but_a_bypass_throw_does_not() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX, RX)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_tuner_status", (0,)):
+        pass
+    assert authority.view().deadline_monotonic is None
+    assert authority.view().own_transmit_holds == ()
+
+    async with authority.admit("set_tuner_status", (2,)):
+        pass
+    assert authority.view().own_transmit_holds == ("tune",)
+    assert authority.view().deadline_monotonic == pytest.approx(
+        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
+    )
+
+
+async def test_a_refused_tune_start_neither_holds_nor_arms() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(TX)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal):
+        async with authority.admit("set_tuner_status", (2,)):
+            pytest.fail("tune start admitted while transmitting")
+    assert authority.view().deadline_monotonic is None
+    assert authority.view().own_transmit_holds == ()
+
+
+async def test_last_resort_unkey_is_the_only_other_injected_effect() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    unkey = FakeUnkey()
+    authority = build_authority(clock, link, unkey=unkey)
+
+    await authority.fire_last_resort_unkey()
+    assert unkey.calls == 1
+
+
+# --------------------------------------------------------------------------
+# INV-4 — the read is not shared and is invalidated by a transmit event
+# --------------------------------------------------------------------------
+
+
+async def test_a_transmit_observation_between_read_and_write_invalidates_it() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX)
+    authority = build_authority(clock, link)
+    link.on_read.append(lambda: authority.note_transmit_observation(True))
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_antenna_1", ()):
+            pytest.fail("hazard write used a read a transmit event invalidated")
+    assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+
+
+async def test_a_receive_observation_never_clears_anything() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX)
+    authority = build_authority(clock, link)
+
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    authority.note_transmit_observation(False)
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_antenna_1", ()):
+            pytest.fail("a radio RX report cleared our own key hold")
+    assert excinfo.value.evidence.own_transmit_hold == "key"
+
+
+async def test_concurrent_hazard_admissions_do_not_share_a_read() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    link.script(RX, RX)
+    authority = build_authority(clock, link)
+    order: list[str] = []
+
+    async def hazard(tag: str) -> None:
+        async with authority.admit("set_antenna_1", ()):
+            order.append(f"write:{tag}")
+
+    await asyncio.gather(hazard("a"), hazard("b"))
+    assert len(link.reads) == 2
+    assert len(order) == 2
+
+
+# --------------------------------------------------------------------------
+# Decision ring and view (§3.4)
+# --------------------------------------------------------------------------
+
+
+async def test_decision_ring_is_bounded() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, link)
+    assert DECISION_LOG_CAPACITY == 256
+
+    for _ in range(DECISION_LOG_CAPACITY + 20):
+        async with authority.admit("set_ptt", (True,)):
+            pass
+    assert len(authority.view().records) == DECISION_LOG_CAPACITY
+
+
+async def test_view_reports_truth_holds_and_deadline() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    truth = TransmitTruth(
+        value=False,
+        attributed="rx",
+        age_seconds=0.2,
+        source="poll_response",
+        generation_current=True,
+    )
+    authority = TransmitAuthority(
+        read_transmit_state=link.read,
+        last_resort_unkey=FakeUnkey(),
+        method_map=METHOD_MAP,
+        clock=clock,
+        bands=BANDS,
+        truth_provider=lambda: truth,
+    )
+    async with authority.admit("set_ptt", (True,)):
+        pass
+    view = authority.view()
+    assert view.truth is truth
+    assert view.own_transmit_holds == ("key",)
+    assert view.deadline_monotonic is not None
+    assert view.records[-1].method == "set_ptt"
+
+
+async def test_an_unmapped_method_fails_closed() -> None:
+    """INV-1's fail direction: nothing defaults to PASS by omission."""
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, link)
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit("set_something_new", (1,)):
+            pytest.fail("an unmapped write reached the wire")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence.failure == "unclassified"
+
+
+async def test_raw_excluded_methods_are_not_classified() -> None:
+    clock = Clock()
+    link = FakeTransmitStateLink(clock)
+    authority = build_authority(clock, PoisonedLink())
+    for method in sorted(RAW_EXCLUDED):
+        async with authority.admit(method, (b"\xfe\xfe",)):
+            pass
+    assert authority.view().records == ()
+    assert link.reads == []
+
+
+# --------------------------------------------------------------------------
+# TransmitTruth builder (§3.7)
+# --------------------------------------------------------------------------
+
+
+def _snapshot(
+    *,
+    value: object,
+    source: str,
+    observed: float,
+    generated: float,
+    provider_generation: int = 3,
+) -> StateSnapshot:
+    field = FieldSnapshot(
+        path=PTT_PATH,
+        value=value,
+        freshness=FreshnessState.FRESH,
+        last_observed_monotonic=observed,
+        max_age=1.0,
+        source=SourceMetadata(source=source, provider="fake"),  # type: ignore[arg-type]
+        provider_generation=provider_generation,
+    )
+    return StateSnapshot(
+        state_revision=1,
+        freshness_revision=1,
+        observation_seq=1,
+        generated_at_monotonic=generated,
+        fields=(field,),
+        provider_generation=provider_generation,
+    )
+
+
+def test_transmit_truth_accepts_radio_readback_provenance() -> None:
+    snapshot = _snapshot(
+        value=True, source="poll_response", observed=9.5, generated=10.0
+    )
+    truth = build_transmit_truth(snapshot, provider_generation=3)
+    assert truth.value is True
+    assert truth.source == "poll_response"
+    assert truth.age_seconds == pytest.approx(0.5)
+    assert truth.generation_current is True
+
+
+@pytest.mark.parametrize(
+    "source", ["state_poller", "command_response", "local_reconcile", "test"]
+)
+def test_transmit_truth_rejects_non_readback_provenance(source: str) -> None:
+    snapshot = _snapshot(value=True, source=source, observed=9.5, generated=10.0)
+    truth = build_transmit_truth(snapshot, provider_generation=3)
+    assert truth.value is None
+    assert truth.source is None
+    assert truth.age_seconds is None
+
+
+def test_transmit_truth_requires_a_strict_bool() -> None:
+    snapshot = _snapshot(value=1, source="poll_response", observed=9.5, generated=10.0)
+    assert build_transmit_truth(snapshot, provider_generation=3).value is None
+
+
+def test_transmit_truth_is_empty_without_the_field() -> None:
+    empty = StateSnapshot.empty()
+    truth = build_transmit_truth(empty, provider_generation=0)
+    assert truth == TransmitTruth(
+        value=None,
+        attributed=None,
+        age_seconds=None,
+        source=None,
+        generation_current=False,
+    )
+
+
+def test_transmit_truth_marks_a_stale_generation_without_discarding_it() -> None:
+    snapshot = _snapshot(
+        value=False,
+        source="civ_unsolicited",
+        observed=9.0,
+        generated=10.0,
+        provider_generation=2,
+    )
+    truth = build_transmit_truth(snapshot, provider_generation=3)
+    assert truth.value is False
+    assert truth.generation_current is False
+    assert truth.age_seconds == pytest.approx(1.0)


### PR DESCRIPTION
## What this row lands

ADR row 1 — `src/rigplane/core/tx_authority.py`: the transmit-authority
vocabulary and the pure engine.

- `TxWriteClass` (PASS / HAZARD / KEYING / UNKEY) and the neutral
  `TxFamily` → class table, a pinned literal with PASS as an explicit entry
  for every permitted family.
- Named, pure argument predicates (`ptt`, `powerstat`, `frequency`) in a
  pinned registry, plus `is_tune_start` and the T5 short-circuit resolver
  that runs ahead of the table and all profile data.
- `TxRefusalCode`, `TxEvidence`, `TxDecisionRecord`, `TxRefusal`.
- `TransmitTruth` and `build_transmit_truth()` over a `StateStore` snapshot,
  filtered by `RADIO_READBACK_SOURCES`; freshness is deliberately not
  pre-collapsed.
- `RADIO_READBACK_SOURCES` and `RAW_EXCLUDED` as explicit frozenset literals.
- `TX_READ_DEADLINE_SECONDS = 0.3` (§3.5 step 2), and the one key-down bound
  **imported** from `core/tx_safety.py` — a test asserts the literal `180`
  does not appear in the file.
- The `TransmitAuthority` engine: injected solicited-read and last-resort-unkey
  callables, the per-radio admission lock, own-transmit holds
  (`key` / `cw` / `tune` / `lease`), the deadline state, `poll(now)` returning
  due effects as data, the 256-entry decision ring, and `view()`.

## Nothing consumes it

By design, and a reviewer can check it:

```
$ grep -rn "tx_authority" src/ tests/ frontend/ docs/ \
    | grep -v src/rigplane/core/tx_authority.py \
    | grep -v tests/test_tx_authority.py \
    | grep -v docs/plans/2026-08-20
(no output)
```

The per-backend method-name → family maps are **not** here: they land with
rows 7/8, beside the methods they pin. The engine takes a `method_map` as
constructor data instead.

`core/tx_authority.py` imports nothing from `profiles`; band-edge geometry
arrives as plain `(low_hz, high_hz)` tuples. `uv run lint-imports` is green
(5 contracts kept, 0 broken).

## Declared guardrail deviation

Standing limit is ≤3 files / ≤400 LOC; the ADR declares ~500 LOC of source for
this row and an explicit ceiling of ≤2 source files / ≤2 test files / ≤650
source LOC was approved for it. Measured:

| | files | lines added |
|---|---|---|
| source | 1 (`src/rigplane/core/tx_authority.py`) | 666 |
| tests | 1 (`tests/test_tx_authority.py`) | 917 |
| total | 2 | 1583 |

666 source lines is **16 over the 650 ceiling** — stated rather than hidden.
Of those 666, 470 are code and 196 are blank lines, comments and docstrings;
the remaining overage is evidence rationale in comments, which I chose not to
shave to hit a round number. Test size is not trimmed to fit a number, per the
row's own instruction.

## Behaviour pinned by tests (61 tests)

- `test_radio_readback_sources_pin` — the named mutation below.
- `test_raw_excluded_pin`, `test_family_class_table_is_total_and_pinned`.
- `test_key_down_bound_is_imported_not_respelled`.
- `test_b6_golden_own_cw_hold_refuses_without_any_wire_read` — a scripted RX
  answer during our own CW message must not admit a hazard write; the hold
  refuses with **no wire read at all** and the evidence names it
  (`own_transmit_hold="cw"`).
- Fail direction per class × per truth answer: TX, read timeout, transport
  error, no-capability, unverifiable readback — the last four
  `TX_TRUTH_UNAVAILABLE`, fail-closed.
- `test_every_refusal_carries_evidence` (INV-14), parametrised over all five
  refusing answers.
- Band-relation arithmetic: same-band, cross-band, gap value, missing current
  frequency, no band data — the last three PASS.
- `test_unkey_is_never_refused_even_with_a_poisoned_table` (T5 / INV-5 / INV-6).
- `test_pass_class_never_consults_truth` against a poisoned read callable.
- INV-4: a transmit observation between the read and the write invalidates the
  read; concurrent hazard admissions do not share one.
- Deadline: armed by a key and by an admitted tune start, re-armed by a newer
  key, cleared by an unkey, fires once through `poll()` on a fake clock.
- `TransmitTruth` builder: accepted provenance, rejected provenance, strict
  bool, absent field, stale generation.

No MagicMock anywhere: real fakes, a fake clock, a scripted transmit-state link.

## Mutation evidence

The ADR's named mutation for this row — add `"state_poller"` to the sources
pin. Run with `PYTHONDONTWRITEBYTECODE=1` so a same-second size-preserving
edit cannot reuse a stale `.pyc`:

```
$ PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/test_tx_authority.py -q --tb=short
tests/test_tx_authority.py F............................................ [ 73%]
.........F......                                                         [100%]

=================================== FAILURES ===================================
_______________________ test_radio_readback_sources_pin ________________________
tests/test_tx_authority.py:196: in test_radio_readback_sources_pin
    assert RADIO_READBACK_SOURCES == frozenset(
E   AssertionError: assert frozenset({'c...ll_response'}) == frozenset({'c...ll_response'})
E
E     Extra items in the left set:
E     'state_poller'
E     Use -v to get more diff
______ test_transmit_truth_rejects_non_readback_provenance[state_poller] _______
tests/test_tx_authority.py:884: in test_transmit_truth_rejects_non_readback_provenance
    assert truth.value is None
E   AssertionError: assert True is None
E    +  where True = TransmitTruth(value=True, attributed=None, age_seconds=0.5, source='state_poller', generation_current=True).value
=========================== short test summary info ============================
FAILED tests/test_tx_authority.py::test_radio_readback_sources_pin - Assertio...
FAILED tests/test_tx_authority.py::test_transmit_truth_rejects_non_readback_provenance[state_poller]
========================= 2 failed, 59 passed in 0.73s =========================
```

Two further invariants proven the same way:

- **INV-16** — bypass the own-transmit hold for `cw` in `_admit_hazard`:
  `1 failed, 60 passed`, `test_b6_golden_own_cw_hold_refuses_without_any_wire_read`:
  `Failed: hazard write admitted during our own CW message`.
- **INV-5** — add a refusal branch to the UNKEY dispatch: `1 failed, 60 passed`,
  `test_unkey_is_never_refused_even_with_a_poisoned_table` raises
  `TxRefusal: tx-truth-unavailable`.

## Gates

```
$ uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread
10334 passed, 13 skipped, 15 xfailed, 1 xpassed, 1 warning in 121.44s

$ uv run ruff check src/ tests/            All checks passed!
$ uv run ruff format --check src/ tests/   682 files already formatted
$ uv run lint-imports                      Contracts: 5 kept, 0 broken.
$ uv run mypy src/                         Found 12 errors in 3 files (checked 296 source files)
```

`mypy src/` reports the **same 12 pre-existing errors as the base commit**
(verified by stashing this diff at `9fc90943`: `Found 12 errors in 3 files`).
`uv run mypy src/rigplane/core/tx_authority.py` alone: `Success: no issues found`.

## ADR ambiguities resolved, for the reviewer

1. **When a `key` or `tune` own-transmit hold clears.** §3.5 says the radio's
   own report cannot clear a hold; §3.7 says key/tune holds are "held until the
   radio says otherwise", and step 1 refuses before any read is made, so the
   radio never gets asked. Resolved conservatively, in the tightening
   direction: `key` and `tune` holds clear only on an admitted UNKEY or when
   the key-down deadline fires through `poll()`; `cw` clears on its computed
   duration and on nothing else. A radio RX report clears nothing —
   `note_transmit_observation()` acts only in the transmitting direction, where
   it invalidates an in-flight read (INV-4). Both behaviours are pinned by
   tests. Worst case, stated: a tune start with no following unkey holds until
   the key-down deadline.
2. **The admission shape.** §3.2's diagram shows a bare `await admit(method,
   args)`, but §3.5 requires the admission lock to be held "from the first
   check through the write handoff" and requires the post-write tune hold.
   `admit()` is therefore an async context manager: the caller performs the
   write inside it, the lock spans both, and the "sent" record and the tune
   hold are committed on clean exit.
3. **An unmapped method.** INV-1's totality harness arms per backend with rows
   7/8; until then an unmapped method fails closed here
   (`TX_TRUTH_UNAVAILABLE`, `failure="unclassified"`) rather than defaulting to
   PASS.

## Not touched

The old transmit-interlock mechanism (`runtime/tx_interlock.py`,
`core/tx_interlock_contract.py`, the web/rigctld/Yaesu enforcement seats, the
RF-truth resolvers) is untouched, as the row requires. One observation made in
passing and deliberately **not** acted on is reported to the coordinator rather
than fixed here.


---

# Round 2 — review findings addressed (head `9cc183c09d865dcfd2ea9586097d4ff71f944842`)

Independent review returned BLOCKED with three blocking findings and two further
items. All five are addressed in code, each with a test written first and its
mutation proven red. Measured after: **1 source file, 698 lines** (ceiling 700);
**1 test file, 1051 lines**; 67 tests, all passing.

## B1 — the admission lock is now pinned

**Test:** `test_a_key_cannot_slip_between_a_hazard_read_and_its_write`.

The old concurrency test asserted read *counts*, which are unchanged whether or
not the lock exists. The new test asserts the **order of effects**: a hazard
admission is started and held open inside its solicited read; a key admission is
then launched and given twenty event-loop turns to run. With the lock held it
cannot start at all, and the writes land `["hazard-write", "key-write"]`.

Mutation — replace `async with self._lock:` with `if True:`:

```
tests/test_tx_authority.py:863: in test_a_key_cannot_slip_between_a_hazard_read_and_its_write
    assert order == [], "the key ran while a hazard admission held the lock"
E   AssertionError: the key ran while a hazard admission held the lock
E   assert ['key-write'] == []
E     Left contains one more item: 'key-write'
1 failed, 66 passed
```

## B2 — INV-6's named mutation is now pinned

**Test:** `test_unkey_is_never_refused_even_with_a_poisoned_table`, rebuilt on a
`POISONED_MAP` that classifies `set_ptt` → TUNER, `set_powerstat` → ANTENNA and
`stop_cw_text` → BAND, against a scripted transmitting radio. The review was
right that `method_map={}` is not a poisoned table: it leaves the short-circuit
as the only path. All three de-key paths must be admitted with zero wire reads.

Mutation — swap the two lines so the table is consulted before the short-circuit:

```
src/rigplane/core/tx_authority.py:537: in admit
    ticket = await self._admit_hazard(method, family, context)
src/rigplane/core/tx_authority.py:620: in _admit_hazard
    refuse(TxRefusalCode.REFUSED_WHILE_TRANSMITTING, evidence)
E   rigplane.core.tx_authority.TxRefusal: refused-while-transmitting
1 failed, 66 passed
```

That is exactly the catastrophe T5 exists to prevent: a corrupt table making the
de-key harder.

## B3 — own-transmit holds are bounded, with no driver required

**Fixed in the engine.** `_commit` now stamps `key` and `tune` holds with
`clock() + BACKEND_MAX_KEY_DOWN_SECONDS` — the same bound the design already arms
for them — and `_active_holds` prunes lazily against the injected clock at every
admission. `poll()` keeps its job but stops being load-bearing for correctness.
A `cw` hold keeps its own, shorter, computed duration.

**Test:** `test_own_transmit_holds_do_not_outlive_the_deadline_without_a_driver`,
parametrised over `key` and `tune`, advancing a fake clock past the bound and
never calling `poll()`.

Mutation — restore the previous behaviour (holds clear only via `poll()` or an
admitted unkey):

```
tests/test_tx_authority.py:785: assert authority.view().own_transmit_holds == ()
E   AssertionError: assert ('key',) == ()
E   AssertionError: assert ('tune',) == ()
2 failed, 65 passed
```

This is not a loosening relative to the ADR. The design already specifies that an
admitted tune start arms the deadline, so the hold was always meant to be
bounded; the defect was that the bound was only evaluated by an external driver
that arrives many rows later. An expired hold does not make the gate blind — it
falls through to the solicited read, which is the design's primary instrument,
and at the key-down bound both a CW message and a tune cycle are long finished.
The one case where the read is known to lie is a CAT-issued CW message, and that
hold keeps its own shorter computed duration rather than this bound.

## Item 4 — a failed key write still records its hold

Committing only on clean exit was the fail-open direction for KEYING: a transport
error raised after the frame reached the radio left the authority believing it
was not transmitting, with no hold and no deadline. The `yield` is now wrapped in
`try/finally`, so the hold, the deadline and the decision record land however the
block exits — including on cancellation.

**Decision and reasoning.** Applied to HAZARD as well as KEYING, for the same
reason: a tune-start frame that reached the wire before the exception starts a
transmission just as a key does, and the tightening direction is identical. The
record's `action` stays `"sent"` on a failed write because the field records the
*authority's* decision (it let the write through), not the transport's outcome;
what the transport then did is the caller's to report. Pinned by
`test_a_failed_key_write_still_records_its_hold`; reverting to the bare `yield`
fails it (`assert () == ('key',)`).

## Item 5 — every read failure is a typed refusal

**Decision: broaden the capture.** A `ValueError` from a row-5 parser previously
escaped `admit()` as itself — no `TxRefusal`, no decision record, no log line —
which breaks the rule that `TxRefusal` is the one new exception consumers handle.
The write was still blocked, but a safety gate that hands the caller a raw
traceback has no evidence trail, and the operator's only path to the cause on a
headless box is that log line.

`except Exception` now maps to `TX_TRUTH_UNAVAILABLE` with `failure="read-error"`,
distinct from `"timeout"` and `"transport"` so the cause is not flattened.
`CancelledError` is a `BaseException` and is deliberately not caught. The
alternative — pinning at row 5 that the primitive never raises outside two
types — was rejected: it makes every future backend's parser a latent hole in the
gate's contract, enforced nowhere near the gate.

Also closing the review's follow-up (b): `TX_ENGINE_FAILURE_TAGS` pins the five
tags the engine emits, tested, with backend-supplied tags (`"no-capability"`)
documented as passing through.

Mutation — delete the broad capture: `1 failed, 66 passed`,
`ValueError: the row-5 parser could not decode the reply` escapes the gate.

## Smaller reservations

| Reservation | Action |
|---|---|
| `TxArgumentContext.first(name)` ignores `name` when args are positional | Docstring warning added: a predicate whose interesting argument is not first-positional must read `args`/`kwargs` directly. Behaviour unchanged — it is correct for the three shipped predicates. |
| `build_transmit_truth` hardcodes `attributed=None` | `# Row 6 routes Yaesu's tx_state_map attribution into this field.` — marked pending, not dead. |
| `_Ticket` is a private name yielded by a public API | Renamed to `TxAdmission`. |
| RAW methods labelled `TxFamily.RX_PATH` | `TxAdmission.family` is now `TxFamily | None`, and a raw admission reports `None`. Adding a `RAW` family to the class table was rejected — it would assert that raw bytes *are* classified, which is the opposite of the design's position. Pinned in `test_raw_excluded_methods_are_not_classified`. |

## Gates at this head

```
$ PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/ --ignore=tests/integration -n auto -q \
    --tb=short --timeout=300 --timeout-method=thread
10340 passed, 13 skipped, 15 xfailed, 1 xpassed, 1 warning in 113.52s

$ uv run ruff check src/ tests/                      All checks passed!
$ uv run ruff format --check src/ tests/             682 files already formatted
$ uv run lint-imports                                Contracts: 5 kept, 0 broken.
$ uv run mypy src/                                   Found 12 errors in 3 files (checked 296 source files)
$ uv run mypy src/ --exclude 'tx_authority\.py'      Found 12 errors in 3 files (checked 295 source files)
```

Same 12 pre-existing errors, one fewer file checked — nothing attributable to this
diff, by the review's own method.

Still consumed by nothing: `grep -rn "tx_authority" src/ tests/ frontend/` minus
the module and its test returns no output.

## Guardrails, re-measured

| | files | lines |
|---|---|---|
| source | 1 (`src/rigplane/core/tx_authority.py`) | 698 (ceiling 700) |
| tests | 1 (`tests/test_tx_authority.py`) | 1051 |
| total | 2 | 1749 insertions, 0 deletions |
