### PR TITLE
feat(MOR-1912): carry measured per-radio transmit policy in the profile

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -934,3 +934,15 @@ set_apf_freq   = { cat = { write = "CO03{val:04d};" } }
 
 # ── Clarifier Reset ──
 reset_clarifier = { cat = { write = "RC;" } }
+
+[tx_policy]
+# Measured on the bench (MOR-1912): a controlled write-during-transmit
+# battery sent to the FTX-1 while an operator held a front-panel key. Mode
+# and split were both refused with an explicit `?;` and not applied;
+# frequency and RIT were accepted and applied (silent, confirmed by
+# read-back) — same as the RX baseline — so they are not listed here.
+refused_during_tx = ["mode", "vfo-topology"]
+# The Yaesu `TX;` read-back is three-valued and self-attributing: "0"
+# receiving, "1" transmitting because CAT keyed it, "2" transmitting
+# because the radio keyed itself (front panel/mic/footswitch/VOX).
+tx_state_map = { "0" = "rx", "1" = "tx_cat", "2" = "tx_other" }

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -939,8 +939,10 @@ reset_clarifier = { cat = { write = "RC;" } }
 # Measured on the bench (MOR-1912): a controlled write-during-transmit
 # battery sent to the FTX-1 while an operator held a front-panel key. Mode
 # and split were both refused with an explicit `?;` and not applied;
-# frequency and RIT were accepted and applied (silent, confirmed by
-# read-back) — same as the RX baseline — so they are not listed here.
+# frequency was accepted and applied (silent, confirmed by read-back) —
+# same as the RX baseline — so it is not listed here. RIT-while-keyed was
+# not exercised on this radio (measured accepted on the IC-7300 only —
+# see that profile's [tx_policy] comment).
 refused_during_tx = ["mode", "vfo-topology"]
 # The Yaesu `TX;` read-back is three-valued and self-attributing: "0"
 # receiving, "1" transmitting because CAT keyed it, "2" transmitting

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1597,3 +1597,17 @@ label = "15"
 raw = 241
 actual = 25.0
 label = "25"
+
+[tx_policy]
+# Measured on the bench (MOR-1912): a controlled write-during-transmit
+# battery — frequency, mode, split, RIT — sent to the IC-7300 while an
+# operator held a front-panel key. Every write was accepted and applied
+# (byte-identical to the receiving baseline, confirmed by read-back), so
+# there is no measured refusal to record here.
+refused_during_tx = []
+# The CI-V PTT read-back (cmd 0x1C sub 0x00) is a plain on/off byte with no
+# source attribution — it cannot say whether CAT or the front panel keyed
+# the radio. Positive-RX rule: only the receiving byte is listed, so the
+# transmitting byte (and anything unrecognised) is correctly not-receiving
+# without inventing an attribution the radio never reported.
+tx_state_map = { "0" = "rx" }

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "MeterCalibrationPoint",
     "RadioProfile",
     "RuleSpec",
+    "TxPolicy",
     "get_radio_profile",
     "resolve_radio_profile",
     "KeyboardBinding",
@@ -232,6 +233,39 @@ class KeyboardConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class TxPolicy:
+    """Measured per-radio transmit policy (MOR-1912, ADR row 3a).
+
+    Both fields carry only bench-measured facts — no speculative hooks.
+
+    ``refused_during_tx`` names the command families this radio refuses on
+    its own while transmitting. Entries are opaque, validated strings: the
+    single source of truth for the family vocabulary is
+    ``core/tx_authority.py`` (landing separately), so this type does not
+    check membership, only shape.
+
+    ``tx_state_map`` is the positive transmit-state map for the radio's PTT
+    read-back: it lists the raw values that mean the radio is receiving.
+    Everything else — including a raw value with no entry at all — must be
+    treated as *not receiving* (§3.7 of the transmit-authority ADR). Use
+    :meth:`is_receiving` rather than testing the map directly so that rule
+    cannot be quietly inverted by a later reader.
+    """
+
+    refused_during_tx: frozenset[str] = frozenset()
+    tx_state_map: dict[str, str] = field(default_factory=dict)
+
+    def is_receiving(self, raw_value: str) -> bool:
+        """True only if ``raw_value`` is explicitly mapped to receiving.
+
+        An unmapped value — including one that simply isn't in the map —
+        is never receiving. This is the fail-closed direction the positive
+        transmit-state map exists to guarantee.
+        """
+        return self.tx_state_map.get(raw_value) == "rx"
+
+
+@dataclass(frozen=True, slots=True)
 class RadioProfile:
     """Runtime radio profile used by command routing and capability checks."""
 
@@ -334,6 +368,10 @@ class RadioProfile:
     tx_interlock_disposition_overrides: dict[
         TxInterlockCommandFamily, TxInterlockDisposition
     ] = field(default_factory=dict)
+    # Measured per-radio transmit policy (MOR-1912). Parsed and carried
+    # here; nothing reads it yet — the transmit-authority engine that will
+    # consume it lands in a later row of the same epic.
+    tx_policy: TxPolicy = field(default_factory=TxPolicy)
 
     @property
     def vfo_swap_code(self) -> int | None:

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -54,6 +54,7 @@ from rigplane.profiles import (
     MeterCalibrationPoint,
     RadioProfile,
     RuleSpec,
+    TxPolicy,
 )
 
 logger = logging.getLogger(__name__)
@@ -575,6 +576,7 @@ class RigConfig:
     tx_interlock_disposition_overrides: dict[
         TxInterlockCommandFamily, TxInterlockDisposition
     ] = field(default_factory=dict)
+    tx_policy: TxPolicy = field(default_factory=TxPolicy)
 
     def to_profile(self) -> RadioProfile:
         """Build a ``RadioProfile`` from this config."""
@@ -744,6 +746,7 @@ class RigConfig:
             write_only_controls=frozenset(self.write_only_controls),
             state_acquisition=self.state_acquisition,
             tx_interlock_disposition_overrides=self.tx_interlock_disposition_overrides,
+            tx_policy=self.tx_policy,
         )
 
     def to_command_map(self) -> CommandMap:
@@ -1734,6 +1737,55 @@ def _parse_tx_interlock_disposition_overrides(
     return overrides
 
 
+_TX_POLICY_KEYS = frozenset({"refused_during_tx", "tx_state_map"})
+
+
+def _parse_tx_policy(filename: str, raw: Any) -> TxPolicy:
+    """Parse the measured per-radio ``[tx_policy]`` section (MOR-1912).
+
+    ``refused_during_tx`` entries are validated for shape only — a list of
+    unique, non-empty strings — never against a fixed vocabulary. The
+    command-family vocabulary's single source of truth is
+    ``core/tx_authority.py``, which is not yet on ``main``; duplicating its
+    membership list here would create a second copy with no mechanism
+    keeping it in step with the first.
+    """
+    if raw is None:
+        return TxPolicy()
+    if not isinstance(raw, dict):
+        raise RigLoadError(f"{filename}: [tx_policy] must be a table")
+    _reject_unknown_keys(filename, "[tx_policy]", raw, _TX_POLICY_KEYS)
+
+    refused_raw = raw.get("refused_during_tx", [])
+    if not isinstance(refused_raw, list):
+        raise RigLoadError(f"{filename}: [tx_policy].refused_during_tx must be a list")
+    refused: list[str] = []
+    for entry in refused_raw:
+        if not isinstance(entry, str) or not entry:
+            raise RigLoadError(
+                f"{filename}: [tx_policy].refused_during_tx entries must be "
+                "non-empty strings"
+            )
+        refused.append(entry)
+    if len(refused) != len(set(refused)):
+        raise RigLoadError(
+            f"{filename}: [tx_policy].refused_during_tx must not contain duplicates"
+        )
+
+    state_map_raw = raw.get("tx_state_map", {})
+    if not isinstance(state_map_raw, dict):
+        raise RigLoadError(f"{filename}: [tx_policy].tx_state_map must be a table")
+    tx_state_map: dict[str, str] = {}
+    for key, value in state_map_raw.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise RigLoadError(
+                f"{filename}: [tx_policy].tx_state_map must map strings to strings"
+            )
+        tx_state_map[key] = value
+
+    return TxPolicy(refused_during_tx=frozenset(refused), tx_state_map=tx_state_map)
+
+
 def load_rig(path: Path) -> RigConfig:
     """Load and validate a rig TOML file.
 
@@ -2220,6 +2272,7 @@ def load_rig(path: Path) -> RigConfig:
         filename,
         data.get("tx_interlock"),
     )
+    tx_policy = _parse_tx_policy(filename, data.get("tx_policy"))
 
     return RigConfig(
         id=radio["id"],
@@ -2293,6 +2346,7 @@ def load_rig(path: Path) -> RigConfig:
         write_only_controls=write_only_controls,
         state_acquisition=state_acquisition,
         tx_interlock_disposition_overrides=tx_interlock_disposition_overrides,
+        tx_policy=tx_policy,
     )
 
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -24,6 +24,7 @@ from rigplane.profiles import (
     ControlSpec,
     FreqRangeInfo,
     RadioProfile,
+    TxPolicy,
     get_radio_profile,
 )
 from rigplane.rig_loader import RigConfig, RigLoadError, discover_rigs, load_rig
@@ -669,6 +670,133 @@ mode = 42
 
         assert rig.keyboard is not None
         assert rig.keyboard.bindings[0].params == {"mode": 42}
+
+
+class TestTxPolicy:
+    """[tx_policy] parsing and validation (MOR-1912, ADR row 3a).
+
+    Parsed and carried on the profile; nothing consumes it in this row.
+    """
+
+    def test_absent_section_defaults_to_empty_policy(self, tmp_path):
+        rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
+
+        assert rig.tx_policy == TxPolicy()
+        assert rig.to_profile().tx_policy == TxPolicy()
+
+    def test_parses_families_and_state_map(self, tmp_path):
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[tx_policy]
+refused_during_tx = ["mode", "vfo-topology"]
+tx_state_map = { "0" = "rx", "1" = "tx_cat", "2" = "tx_other" }
+""",
+        )
+
+        rig = load_rig(p)
+        expected = TxPolicy(
+            refused_during_tx=frozenset({"mode", "vfo-topology"}),
+            tx_state_map={"0": "rx", "1": "tx_cat", "2": "tx_other"},
+        )
+
+        assert rig.tx_policy == expected
+        assert rig.to_profile().tx_policy == expected
+
+    def test_refused_during_tx_entries_are_opaque(self, tmp_path):
+        """No membership check against any family vocabulary (deliberate,
+        see the loader's `_parse_tx_policy` docstring): the vocabulary's
+        single source of truth lands separately in `core/tx_authority.py`.
+        """
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[tx_policy]
+refused_during_tx = ["not-a-real-family", "another-nonsense-name"]
+""",
+        )
+
+        rig = load_rig(p)
+
+        assert rig.tx_policy.refused_during_tx == {
+            "not-a-real-family",
+            "another-nonsense-name",
+        }
+
+    def test_non_table_section_is_rejected(self, tmp_path):
+        # Prepended (not appended): _MINIMAL_TOML ends inside
+        # [commands.overrides], so a bare `tx_policy = true` appended after
+        # it would be parsed as a key of that table, not the root section.
+        p = _write_toml(tmp_path, "tx_policy = true\n" + _MINIMAL_TOML)
+
+        with pytest.raises(RigLoadError, match=r"\[tx_policy\] must be a table"):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        ("declaration", "message"),
+        [
+            (
+                "[tx_policy]\nunexpected = true",
+                r"\[tx_policy\] unknown key",
+            ),
+            (
+                '[tx_policy]\nrefused_during_tx = "mode"',
+                r"\[tx_policy\]\.refused_during_tx must be a list",
+            ),
+            (
+                "[tx_policy]\nrefused_during_tx = [1, 2]",
+                r"\[tx_policy\]\.refused_during_tx entries must be non-empty strings",
+            ),
+            (
+                '[tx_policy]\nrefused_during_tx = [""]',
+                r"\[tx_policy\]\.refused_during_tx entries must be non-empty strings",
+            ),
+            (
+                '[tx_policy]\nrefused_during_tx = ["mode", "mode"]',
+                r"\[tx_policy\]\.refused_during_tx must not contain duplicates",
+            ),
+            (
+                '[tx_policy]\ntx_state_map = ["0", "rx"]',
+                r"\[tx_policy\]\.tx_state_map must be a table",
+            ),
+            (
+                '[tx_policy]\ntx_state_map = { "0" = 1 }',
+                r"\[tx_policy\]\.tx_state_map must map strings to strings",
+            ),
+        ],
+    )
+    def test_rejects_invalid_schema(self, tmp_path, declaration, message):
+        p = _write_toml(tmp_path, _MINIMAL_TOML + f"\n{declaration}\n")
+
+        with pytest.raises(RigLoadError, match=message):
+            load_rig(p)
+
+    def test_positive_rx_rule_unmapped_value_is_not_receiving(self, tmp_path):
+        """§3.7 fail-direction pin: only an explicit "rx" entry counts as
+        receiving. An unmapped value — even one that looks plausible, and
+        even the empty map itself — must never be read as receiving.
+        """
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[tx_policy]
+tx_state_map = { "0" = "rx", "1" = "tx_cat" }
+""",
+        )
+
+        policy = load_rig(p).tx_policy
+
+        assert policy.is_receiving("0") is True
+        assert policy.is_receiving("1") is False
+        assert policy.is_receiving("2") is False
+        assert policy.is_receiving("unrecognised") is False
+        assert TxPolicy().is_receiving("0") is False
 
 
 class TestControlDomainSchema:

--- a/tests/test_tx_policy_shipped_profiles.py
+++ b/tests/test_tx_policy_shipped_profiles.py
@@ -1,0 +1,50 @@
+"""Golden values for the measured [tx_policy] data shipped in rigs/*.toml.
+
+MOR-1912, ADR row 3a: this pins the two profiles that carry measured
+transmit-policy facts (ftx1, ic7300) and confirms every other shipped
+profile still loads unchanged with the default (empty) policy — the row
+must not disturb any rig that has not been bench-measured.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rigplane.profiles import TxPolicy
+from rigplane.profiles.rig_loader import discover_rigs
+
+RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+
+
+def test_ftx1_tx_policy_matches_the_bench_measurement():
+    rigs = discover_rigs(RIGS_DIR)
+    profile = rigs["FTX-1"].to_profile()
+
+    assert profile.tx_policy == TxPolicy(
+        refused_during_tx=frozenset({"mode", "vfo-topology"}),
+        tx_state_map={"0": "rx", "1": "tx_cat", "2": "tx_other"},
+    )
+
+
+def test_ic7300_tx_policy_matches_the_bench_measurement():
+    rigs = discover_rigs(RIGS_DIR)
+    profile = rigs["IC-7300"].to_profile()
+
+    assert profile.tx_policy == TxPolicy(
+        refused_during_tx=frozenset(),
+        tx_state_map={"0": "rx"},
+    )
+
+
+def test_every_other_shipped_profile_still_loads_with_default_policy():
+    rigs = discover_rigs(RIGS_DIR)
+    measured = {"FTX-1", "IC-7300"}
+
+    assert len(rigs) > len(measured), "expected more than the two measured rigs"
+
+    for model, rig in rigs.items():
+        if model in measured:
+            continue
+        assert rig.to_profile().tx_policy == TxPolicy(), (
+            f"{model}: unmeasured rig must keep the default empty tx_policy"
+        )


### PR DESCRIPTION
## What

Lands the `[tx_policy]` profile section from the transmit-authority ADR
(`docs/plans/2026-08-20-transmit-authority.md`, §3.3 "Where the data
lives", §3.7, §4 row 3a): loader parsing + validation, a carrier field
`tx_policy: TxPolicy` on `RadioProfile`/`RigConfig`, and the measured data
for the two bench radios (`rigs/ftx1.toml`, `rigs/ic7300.toml`).

Two keys, both measured on the bench (a controlled write-during-transmit
battery of frequency, mode, and split writes sent to both radios, with RIT
additionally sent to the IC-7300 only, while an operator held a
front-panel key, classified by the radio's own answer and confirmed by
read-back):

- `refused_during_tx` — command families the radio refuses **itself**
  while keyed.
- `tx_state_map` — the positive transmit-state map for the PTT read-back.

### FTX-1

```toml
[tx_policy]
refused_during_tx = ["mode", "vfo-topology"]
tx_state_map = { "0" = "rx", "1" = "tx_cat", "2" = "tx_other" }
```

Measured: mode and split were refused with an explicit `?;` and not
applied; frequency was accepted and applied, same as the RX baseline, so
it is not listed. RIT-while-keyed was not exercised on the FTX-1 — that
measurement exists only for the IC-7300 (see below) — so `refused_during_tx`
here reflects only what was actually tested on this radio. The Yaesu `TX;`
read-back (`backends/yaesu_cat/radio.py:996-1027`) is three-valued and
self-attributing — `0` receiving, `1` transmitting because CAT keyed it,
`2` transmitting because the radio keyed itself — so all three values are
honestly recorded, matching the ADR's own illustrative example exactly.

### IC-7300

```toml
[tx_policy]
refused_during_tx = []
tx_state_map = { "0" = "rx" }
```

Measured: every write in that battery — frequency, mode, split, and
RIT — was accepted and applied on the IC-7300 (byte-identical to the
receiving baseline, confirmed by read-back) — no measured refusal, so the
list is empty. The CI-V PTT read-back (cmd
`0x1C` sub `0x00`, `runtime/_civ_rx.py:1566`'s `0x00`/`0x01` allowlist) is
a plain on/off byte with **no source attribution** — it cannot say
whether CAT or the front panel keyed the radio. This is where the ADR's
illustrative example (three-valued map, mirroring Yaesu) does **not**
apply: mapping the transmitting byte to `"tx_cat"` or `"tx_other"` would
fabricate an attribution the radio never reports. Instead the map lists
only the receiving byte — by the positive-RX rule (§3.7), the
transmitting byte (and anything unrecognised) is correctly not-receiving
without inventing who keyed it. This is the smaller-than-Yaesu map the
task anticipated, and the reason is the radio's own reporting capability,
not an oversight.

## Consumed by nothing

No backend, runtime, web, or rigctld code reads `tx_policy` in this row —
confirmed by grep:

```
$ grep -rn '\.tx_policy\b\|TxPolicy(' src/ | grep -v 'src/rigplane/profiles/'
(no output)
```

## Deferred: membership validation

`refused_during_tx` entries are parsed and validated for **shape only** —
a list of non-empty, unique strings — never checked against a fixed
family vocabulary. The command-family vocabulary's single source of truth
is `core/tx_authority.py`, a parallel row not yet on `main`. Adding a
membership check here would create a second copy of that vocabulary in a
different layer, with no mechanism keeping the two in step — exactly the
drift the ADR calls out. A golden test
(`tests/test_tx_policy_shipped_profiles.py`) still pins the exact shipped
values for `ftx1`/`ic7300`, which catches a typo in the two profiles we
actually ship without duplicating the vocabulary.

## §3.7 fail-direction pin

`TxPolicy.is_receiving(raw_value)` returns `True` only for a raw value
explicitly mapped to `"rx"`; every unmapped value — including one that
looks plausible — is not receiving. Pinned at the data layer
(`tests/test_rig_loader.py::TestTxPolicy::test_positive_rx_rule_unmapped_value_is_not_receiving`)
even though nothing consumes the map yet, so a later reader cannot
quietly invert the rule.

## `tx_state_map` mapping type: left as a plain `dict`

`TxPolicy.tx_state_map` is a plain `dict[str, str]` on a frozen (but
shallowly mutable) dataclass, not a `MappingProxyType`. This is a
deliberate choice, not an oversight: `RadioProfile` has roughly a dozen
other `dict`-typed fields (`att_labels`, `pre_labels`, `agc_labels`,
`meter_redlines`, `sample_rate_by_codec`, `controls`, …) and none of them
use `MappingProxyType` — the plain-`dict` convention is the norm for this
whole profile object, not just for the soon-to-be-deleted
`tx_interlock_disposition_overrides`. Switching only `tx_state_map` would
make it the one inconsistent field among many, for a risk (in-place
mutation of profile data that nothing currently reads) this row does not
create. If the row that starts consuming this data wants a stronger
immutability guarantee, that is a decision for that row, made against the
whole `RadioProfile` convention rather than as a one-field special case
here.

## Guardrail deviation (approved ceiling: 4 source / 2 test files)

Measured: 4 source files (`rigs/ftx1.toml` +12, `rigs/ic7300.toml` +14,
`src/rigplane/profiles/__init__.py` +38, `src/rigplane/profiles/rig_loader.py`
+54 = **118 LOC**, well under 400) + 2 test files
(`tests/test_rig_loader.py` +128, `tests/test_tx_policy_shipped_profiles.py`
new, 50 LOC).

## Tests

- `tests/test_rig_loader.py::TestTxPolicy` — absent section defaults to
  an empty policy; exact parse of families + state map; `refused_during_tx`
  entries are opaque (no vocabulary check); malformed-input rejection
  (non-table section, unknown key, non-list `refused_during_tx`,
  non-string/non-empty entries, duplicate entries, non-table
  `tx_state_map`, non-string values); the §3.7 fail-direction pin.
- `tests/test_tx_policy_shipped_profiles.py` — golden exact values for
  `ftx1`/`ic7300`; every other shipped rig (`ic705`, `ic7610`, `ic9700`,
  `tx500`, `x6100`, `x6200`) still loads with the default empty policy.

## Mutation kills (PYTHONDONTWRITEBYTECODE=1, reverted after each, `git status --porcelain` empty both times)

**1. Delete `refused_during_tx` from `ftx1.toml`:**

```
tests/test_tx_policy_shipped_profiles.py:23: in test_ftx1_tx_policy_matches_the_bench_measurement
    assert profile.tx_policy == TxPolicy(
E   AssertionError: assert TxPolicy(refu...: 'tx_other'}) == TxPolicy(refu...: 'tx_other'})
E     Differing attributes:
E     ['refused_during_tx']
E     Drill down into differing attribute refused_during_tx:
E       refused_during_tx: frozenset() != frozenset({'vfo-topology', 'mode'})
FAILED tests/test_tx_policy_shipped_profiles.py::test_ftx1_tx_policy_matches_the_bench_measurement
1 failed, 2 passed
```

**2. Map an unmapped value (`"2"`, currently `tx_other`) to `"rx"` in `ftx1.toml`'s `tx_state_map`:**

```
tests/test_tx_policy_shipped_profiles.py:23: in test_ftx1_tx_policy_matches_the_bench_measurement
    assert profile.tx_policy == TxPolicy(
E   AssertionError: assert TxPolicy(refu...', '2': 'rx'}) == TxPolicy(refu...: 'tx_other'})
E     Differing attributes:
E     ['tx_state_map']
E     Drill down into differing attribute tx_state_map:
E       tx_state_map: {'0': 'rx', '1': 'tx_cat', '2': 'rx'} != {'0': 'rx', '1': 'tx_cat', '2': 'tx_other'}
FAILED tests/test_tx_policy_shipped_profiles.py::test_ftx1_tx_policy_matches_the_bench_measurement
1 failed, 2 passed
```

## Gates

```
uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread
  10326 passed, 13 skipped, 15 xfailed, 1 xpassed, 1 warning in 131.05s

uv run ruff check src/ tests/
  All checks passed!

uv run ruff format --check src/ tests/
  683 files already formatted

uv run lint-imports
  Contracts: 5 kept, 0 broken.

uv run mypy src/
  Found 12 errors in 3 files (_control_phase.py, _audio_runtime_mixin.py, radio_poller.py)
  -- exactly the pre-existing baseline; none of these files are touched by this PR.
```

No flake (`test_managed_ptt_port_token_safety[rebind]`) observed this run.

Additionally ran the existing FTX-1 golden dry-run gate locally against the
changed profile (`rigs/**` entered `quick.yml`'s path filter one PR ago —
MOR-1911, #2767 — so this is close to the first profile-touching PR that
will actually exercise CI):

```
uv run rigplane --model FTX-1 validate --provider native --dry-run --gate tests/golden/validation/ftx1.dry-run.json
  Golden gate: PASS vs tests/golden/validation/ftx1.dry-run.json (65 check(s) match, 0 regression(s))
```

(No golden dry-run fixture exists yet for IC-7300; ran `validate --dry-run`
without `--gate` as a load sanity check — clean, no errors.)

## Explicitly out of scope

Did **not** touch the old `[tx_interlock]` mechanism
(`runtime/tx_interlock.py`, `core/tx_interlock_contract.py`, the
`[tx_interlock]` loader machinery, or any enforcement seat) — none of the
eight shipped rig profiles currently declare `[tx_interlock]`, so there
was nothing to collide with. No defect found in that mechanism during this
row's work.

