### PR TITLE
test(MOR-1913): land the TX-authority conformance matrix and fake transmit-state scripting

### DIFF
--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -1,0 +1,828 @@
+"""Transmit-authority conformance matrix over every shipping backend.
+
+ADR row 4 (``docs/plans/2026-08-20-transmit-authority.md`` §4 row 4, §3.10
+item 3), following the audio precedent
+(``tests/contracts/test_audio_lifecycle_conformance.py``): one scenario matrix,
+run for every shipping backend class against its fake link, with the scripted
+transmit-state answers this row also lands
+(``tests/tx_authority_fakes.py``, §3.10 item 1).
+
+**What this file proves today, and what it merely reserves.**
+
+No backend constructs a :class:`TransmitAuthority` yet — that is rows 7 and 8 —
+so the matrix runs each ADR-named row twice:
+
+*Composed rows (live).* The real engine, the real backend class and the real
+fake wire, with the admission driven from the test. These prove the component
+composes: a hazard write at scripted TX is refused and nothing reaches the
+wire; at scripted RX the solicited read precedes the write; an unmapped value
+is never receiving; an unkey is never refused; a key arms the one deadline and
+the last-resort rail fires the OFF on a fake clock.
+
+*Cutover rows (``xfail(strict=True)``).* The same behaviours driven the way a
+consumer will drive them — a plain method call, or a command through
+``create_observation_poller``'s queue drain — with **no** test-side admission.
+They fail today because the admission is not in the backend. Each names the
+migration row that turns it green. ``strict=True`` is the point: the day a
+cutover lands, the row goes red as an XPASS, which is the signal rows 7/8 need
+that their conformance obligation is met. A row is never weakened to pass
+today: an honest xfail says more than an assertion-free green.
+
+**The queue path is not optional.** §3.2's refutation of the wrapping facade
+turns on item 2: on FTX-1 and hamlib-provider radios the web write path never
+touches the radio object from outside — ``web_startup.py:126-128`` hands the
+``CommandQueue`` into ``create_observation_poller`` and the backend drains it
+against raw ``self``. A matrix that only called backend methods directly would
+prove less than it appears to, so every queue-capable column carries the same
+rows again through the drain, plus a live row proving the drain really does
+reach the backend write method — so the xfails above it rest on working
+plumbing rather than on broken test wiring.
+
+No MagicMock anywhere near the authority (CLAUDE.md hard rule, restated by
+§3.10 item 1); the fakes are plain objects and the clock is injected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+
+import pytest
+from tx_authority_fakes import (
+    CIV_NON_ANSWERS,
+    CONFORMANCE_BACKENDS,
+    NON_RECEIVING_ANSWERS,
+    QUEUE_PATH_BACKENDS,
+    TRANSMITTING_ANSWERS,
+    TX_ANSWER_VOCABULARY,
+    TxConformanceHarness,
+    build_harness,
+    civ_transmit_state_reply,
+)
+
+from rigplane.core.tx_authority import (
+    RADIO_READBACK_SOURCES,
+    TransmitAuthority,
+    TxFamily,
+    TxMethodEntry,
+    TxRefusal,
+    TxRefusalCode,
+    TxStateReading,
+    build_transmit_truth,
+)
+from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
+
+# ---------------------------------------------------------------------------
+# Pinned literals
+# ---------------------------------------------------------------------------
+
+#: The backend columns, as an explicit literal. Never computed from a registry,
+#: a factory table or an enum — the ``test_audio_transport_conformance.py:65-81``
+#: rule, so a backend that quietly stops shipping fails this file instead of
+#: silently shrinking the matrix.
+EXPECTED_BACKENDS: tuple[str, ...] = (
+    "lan-icom",
+    "icom7610-serial",
+    "ic705-serial",
+    "ic7300-serial",
+    "ic9700-serial",
+    "yaesu-ftx1",
+    "rigctld-client",
+)
+
+#: The Icom columns, whose read is a CI-V round trip under the shipped
+#: directed-exact-reply discipline. Explicit literal.
+CIV_BACKENDS: tuple[str, ...] = (
+    "lan-icom",
+    "icom7610-serial",
+    "ic705-serial",
+    "ic7300-serial",
+    "ic9700-serial",
+)
+
+#: The matrix's own method map. The shipped per-backend maps land at rows 7/8
+#: beside the methods they pin (§3.3); this literal covers exactly the methods
+#: the matrix drives, and like every other classification literal it is
+#: written out, never derived.
+CONFORMANCE_METHOD_MAP: Mapping[str, TxMethodEntry] = {
+    "set_tuner_status": TxMethodEntry(TxFamily.TUNER),
+    "set_tuner": TxMethodEntry(TxFamily.TUNER),
+    "set_vfo_slot": TxMethodEntry(TxFamily.VFO_SELECT),
+    "set_ptt": TxMethodEntry(TxFamily.PTT_ON, predicate="ptt"),
+}
+
+
+class FakeClock:
+    """Deterministic monotonic clock — the same shape ``TxSafetySupervisor``'s
+    own tests inject, and the reason no row here sleeps."""
+
+    def __init__(self, start: float = 1_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class RecordingUnkey:
+    """The authority's injected last-resort OFF rail, wired to a real backend."""
+
+    def __init__(self, harness: TxConformanceHarness) -> None:
+        self._harness = harness
+        self.calls = 0
+
+    async def __call__(self) -> None:
+        self.calls += 1
+        await self._harness.unkey()
+
+
+def build_authority(
+    harness: TxConformanceHarness,
+    *,
+    clock: FakeClock | None = None,
+    unkey: RecordingUnkey | None = None,
+) -> TransmitAuthority:
+    """The real engine over a real backend's real fake wire."""
+    return TransmitAuthority(
+        read_transmit_state=harness.read_transmit_state,
+        last_resort_unkey=unkey or RecordingUnkey(harness),
+        method_map=CONFORMANCE_METHOD_MAP,
+        clock=clock or FakeClock(),
+    )
+
+
+@pytest.fixture
+async def harness(
+    request: pytest.FixtureRequest,
+) -> AsyncIterator[TxConformanceHarness]:
+    built = await build_harness(request.param)
+    try:
+        yield built
+    finally:
+        await built.close()
+
+
+def every_backend(*names: str):
+    return pytest.mark.parametrize("harness", names or EXPECTED_BACKENDS, indirect=True)
+
+
+# ---------------------------------------------------------------------------
+# 0. The matrix declares its own shape
+# ---------------------------------------------------------------------------
+
+
+def test_backend_columns_are_an_explicit_literal() -> None:
+    """The fakes module and this file agree, and neither computes the set."""
+    assert CONFORMANCE_BACKENDS == EXPECTED_BACKENDS
+    assert set(CIV_BACKENDS) | {"yaesu-ftx1", "rigctld-client"} == set(
+        EXPECTED_BACKENDS
+    )
+
+
+def test_the_matrix_covers_the_audio_matrix_plus_the_rigctld_client() -> None:
+    """Every class the audio conformance gate ships, plus the one it excludes.
+
+    ``rigctld_client`` carries no audio surface, so it is absent there; it
+    very much ships writes, so it is present here (ADR row 8b).
+    """
+    from contracts.test_audio_transport_conformance import SHIPPING_BACKENDS
+
+    assert len(SHIPPING_BACKENDS) == 6
+    assert len(EXPECTED_BACKENDS) == len(SHIPPING_BACKENDS) + 1
+
+
+def test_queue_path_columns_are_the_observation_pollable_backends() -> None:
+    """``web_startup.py:105-193`` branch 1 — the ingress §3.2 item 2 names."""
+    assert QUEUE_PATH_BACKENDS == ("yaesu-ftx1", "rigctld-client")
+
+
+def test_scripted_answer_vocabulary_pin() -> None:
+    assert TX_ANSWER_VOCABULARY == (
+        "rx",
+        "tx_cat",
+        "tx_other",
+        "silence",
+        "refusal",
+        "unmapped",
+    )
+    assert CIV_NON_ANSWERS == ("ack", "setter_echo", "misaddressed")
+
+
+# ---------------------------------------------------------------------------
+# 1. Fake extensions (§3.10 item 1) — live
+# ---------------------------------------------------------------------------
+
+
+@every_backend()
+@pytest.mark.parametrize("answer", TX_ANSWER_VOCABULARY)
+async def test_every_backend_answers_every_scripted_answer(
+    harness: TxConformanceHarness, answer: str
+) -> None:
+    """The gate's solicited read runs the backend's real read code for each
+    scripted answer, and only a confirmed RX admits a hazard write.
+
+    This is the row that makes every other row in the file meaningful: if a
+    column could not produce the answer, its conformance rows would be
+    vacuous.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_admit_hazard`,
+    # replace `if reading.value or epoch != self._transmit_epoch:` at :619
+    # with `if epoch != self._transmit_epoch:` -> this row goes red for both
+    # transmitting answers on every column: the gate admits a hazard write
+    # while the radio answers "transmitting".
+    """
+    harness.script(answer)
+    authority = build_authority(harness)
+
+    if answer == "rx" and harness.verified_readback:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pass  # admitted: the one answer that may proceed
+        return
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: a hazard write was admitted at {answer!r}")
+
+    if answer in TRANSMITTING_ANSWERS and harness.verified_readback:
+        assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    elif answer == "unmapped":
+        # Either fail-closed direction is correct and the columns differ:
+        # Yaesu's positive map has no entry for `TX9`, so `read_ptt` answers
+        # *transmitting*; the CI-V and hamlib-provider columns produce no
+        # value at all. What must never happen is admission.
+        assert excinfo.value.code in tuple(TxRefusalCode)
+    else:
+        assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence is not None  # INV-14
+
+
+@every_backend()
+async def test_a_confirmed_rx_and_a_keyed_radio_read_their_values(
+    harness: TxConformanceHarness,
+) -> None:
+    """The scripted answers are distinguishable on the wire, not merely named."""
+    harness.script("rx")
+    assert (await harness.read_transmit_state()).value is False
+    harness.script("tx_cat")
+    assert (await harness.read_transmit_state()).value is True
+    harness.script("tx_other")
+    assert (await harness.read_transmit_state()).value is True
+
+
+@pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
+@pytest.mark.parametrize("shape", CIV_NON_ANSWERS)
+async def test_a_civ_read_is_not_satisfied_by_an_ack_echo_or_misaddressed_frame(
+    harness: TxConformanceHarness, shape: str
+) -> None:
+    """INV-13 on the CI-V family: the read is directed and exact.
+
+    An ACK, our own setter echo and a frame from a foreign bus address all go
+    onto the wire; none of them may answer the read. The discrimination is the
+    product's (``_civ_rx.py:1489-1492`` routing guards, ``:2636-2650``
+    provenance narrowing), not the fake's — the fake queues the bytes and asks
+    what the shipped code does with them.
+
+    # MUTATION (two edits, because two shipped checks stand in series): in
+    # `src/rigplane/runtime/_civ_rx.py`, (a) delete both routing guards at
+    # :1489-1492 (`from_addr != radio_addr` and `to_addr not in
+    # (CONTROLLER_ADDR, 0x00)`), and (b) replace the six conjuncts at
+    # :2639-2645 with `frame.command == 0x1C\n and frame.sub == 0x00`
+    # -> the `setter_echo` and `misaddressed` cases go red on all five CI-V
+    # columns (10 rows): both carry a `00` data byte, so a widened
+    # classification makes each of them answer "receiving".
+    # Deleting only guard (a) kills nothing — verified — because the
+    # provenance narrowing at (b) re-checks `from_addr` itself; the `ack`
+    # case is held by a third mechanism again, the decode ladder having no
+    # PTT branch for `0xFB` at all, and survives this mutation.
+    """
+    harness.script(shape)
+    reading = await harness.read_transmit_state()
+    assert reading.value is None, f"{harness.name}: {shape} satisfied the read"
+
+    authority = build_authority(harness)
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: {shape} admitted a hazard write")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+
+
+@pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
+async def test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed(
+    harness: TxConformanceHarness,
+) -> None:
+    """The unmapped CI-V answer is a fail-open canary, not junk.
+
+    ``1C 00`` + ``00 00`` carries a leading ``0x00``: if the exact-shape check
+    were loosened it would decode as *receiving* and admit a relay throw. A
+    junk byte would decode as transmitting and could never catch that.
+
+    # MUTATION: in `src/rigplane/runtime/_civ_rx.py`, delete the
+    # `and len(frame.data) == 1` conjunct at :2643 -> this row goes red: the
+    # two-byte reply earns `poll_response` and reads as receiving.
+    """
+    frame = civ_transmit_state_reply("unmapped", harness.radio._radio_addr)
+    assert frame is not None and frame[-2:-1] == b"\x00"
+
+    harness.script("unmapped")
+    reading = await harness.read_transmit_state()
+    assert reading.value is not False, "an unmapped CI-V shape read as receiving"
+    assert reading.value is None
+    assert reading.failure is not None  # INV-14: the cause travels
+
+
+@every_backend()
+async def test_an_unmapped_transmit_state_value_is_never_receiving(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-9 / §3.7: RX is only ever produced by a positive mapping.
+
+    On Yaesu the unmapped ``TX9`` fails closed to *transmitting*; on the CI-V
+    and hamlib-provider columns it produces no value at all. Both are "not
+    receiving"; neither may admit a hazard write.
+
+    # MUTATION: in `src/rigplane/backends/yaesu_cat/radio.py`, change
+    # `return bool(state != "0")` at :1027 to `return bool(state == "1")`
+    # -> this row goes red on the `yaesu-ftx1` column (MOR-1905's own
+    # mutation): the unmapped `TX9` reads as receiving.
+    """
+    harness.script("unmapped")
+    reading = await harness.read_transmit_state()
+    assert reading.value is not False, f"{harness.name}: unmapped value read as RX"
+
+    authority = build_authority(harness)
+    with pytest.raises(TxRefusal):
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: an unmapped value admitted a hazard write")
+
+
+@every_backend()
+@pytest.mark.parametrize("answer", NON_RECEIVING_ANSWERS)
+async def test_no_failing_answer_ever_resolves_to_receiving(
+    harness: TxConformanceHarness, answer: str
+) -> None:
+    """Silence, a refusal and an unmapped value all fail closed (§3.3 table)."""
+    harness.script(answer)
+    assert (await harness.read_transmit_state()).value is not False
+
+
+# ---------------------------------------------------------------------------
+# 2. Composed conformance — the real engine over the real backend, live
+# ---------------------------------------------------------------------------
+
+
+@every_backend()
+async def test_a_hazard_write_at_scripted_tx_is_refused_and_no_wire_write_occurs(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 1. The refusal is worthless if the bytes went anyway.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
+    # `if write_class is TxWriteClass.PASS:` at :522 to
+    # `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` -> this
+    # row goes red: the hazard write is yielded with no truth consulted and
+    # the tuner frame reaches the wire during transmit.
+    """
+    harness.script("tx_cat")
+    authority = build_authority(harness)
+    writes_before = len(harness.writes())
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            await harness.hazard()
+
+    assert harness.writes()[writes_before:] == [], (
+        f"{harness.name}: a refused hazard write still reached the wire"
+    )
+    if harness.verified_readback:
+        assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    else:
+        # §3.7: the hamlib-provider answer is an upstream cache, never radio
+        # truth, so its hazard families are fail-closed by provenance.
+        assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+        assert excinfo.value.evidence.failure == "unverifiable-provenance"
+
+
+@every_backend(*CIV_BACKENDS, "yaesu-ftx1")
+async def test_a_hazard_write_at_scripted_rx_reads_before_it_writes(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 2: on the wire, the read precedes the write.
+
+    Counts cannot see this — both happen either way. Only the order on the
+    wire distinguishes a solicited read from a cached one (T3/INV-4).
+
+    The ``rigctld-client`` column is absent by design, not by omission: its
+    readback is permanently unverifiable (§3.7), so it never reaches a write
+    to order the read against. ``test_..._refused_and_no_wire_write_occurs``
+    covers it instead.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
+    # `if write_class is TxWriteClass.PASS:` at :522 to
+    # `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` -> this
+    # row goes red: no read frame precedes the write on any column.
+    """
+    harness.script("rx")
+    authority = build_authority(harness)
+    baseline = len(harness.wire())
+
+    async with authority.admit(harness.hazard_method, harness.hazard_args):
+        await harness.hazard()
+
+    wire = list(harness.wire())[baseline:]
+    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
+    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
+    assert reads, f"{harness.name}: the hazard admission performed no read"
+    assert writes, f"{harness.name}: the admitted hazard write never happened"
+    assert reads[-1] < writes[0], (
+        f"{harness.name}: the write preceded the read it was authorised by: {wire}"
+    )
+
+
+@every_backend()
+@pytest.mark.parametrize("answer", ["tx_cat", "silence", "unmapped"])
+async def test_an_unkey_is_never_refused(
+    harness: TxConformanceHarness, answer: str
+) -> None:
+    """§3.10 item 3, row 6 / INV-5: the one-sided unkey, on every column.
+
+    Driven under the most hostile truth each wire can produce — keyed, silent,
+    unmapped — because an unkey that only works when truth is healthy is not
+    the doctrine (``managed_tx_ingress.py:1-21``).
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, insert
+    # `raise TxRefusal(TxRefusalCode.TX_TRUTH_UNAVAILABLE, TxEvidence())` as
+    # the first statement of the `if write_class is TxWriteClass.UNKEY:`
+    # branch at :526 -> this row goes red on every column.
+    """
+    harness.script(answer)
+    authority = build_authority(harness)
+    writes_before = len(harness.writes())
+
+    async with authority.admit("set_ptt", (False,)):
+        await harness.unkey()
+
+    assert harness.writes()[writes_before:], f"{harness.name}: the unkey never landed"
+
+
+@every_backend()
+async def test_our_own_key_makes_the_gate_stricter_never_looser(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-16 / §3.7's own-commands rule, composed over a real backend.
+
+    The wire is scripted to answer *receiving* throughout — the B6 blind spot,
+    where the IC-7300 reported RX while audibly still sending. Our own key
+    must refuse the hazard write anyway, with no wire read at all.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_admit_hazard`,
+    # delete the step-1 `if held is not None:` refusal at :580-584 -> this row
+    # goes red on every column: the scripted RX answer clears our own key.
+    """
+    harness.script("rx")
+    authority = build_authority(harness)
+
+    async with authority.admit("set_ptt", (True,)):
+        await harness.key()
+
+    reads_before = len(harness.reads())
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: a hazard write ran during our own key")
+
+    assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    assert excinfo.value.evidence.own_transmit_hold == "key"
+    assert harness.reads()[reads_before:] == [], (
+        f"{harness.name}: the own-transmit refusal touched the wire"
+    )
+
+
+@every_backend()
+async def test_a_key_arms_the_one_deadline_and_the_off_fires_on_a_fake_clock(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 5, backend half: the arm and the last-resort rail.
+
+    The three *shipped* drivers (web ``call_later``, the observation poller's
+    drain, the rigctld drain) arrive at rows 12a/12b and are reserved below;
+    what is live here is that a key through the authority arms the one
+    deadline and that the OFF, once due, reaches the real backend's real
+    unkey on the real wire.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_commit`, change
+    # `self._deadline = deadline` at :651 to `self._deadline = None` -> this
+    # row goes red on every column: the key arms nothing and no OFF is due.
+    """
+    harness.script("rx")
+    clock = FakeClock()
+    unkey = RecordingUnkey(harness)
+    authority = build_authority(harness, clock=clock, unkey=unkey)
+
+    async with authority.admit("set_ptt", (True,)):
+        await harness.key()
+
+    assert authority.view().deadline_monotonic == pytest.approx(
+        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
+    )
+    assert authority.poll(clock.now) == (), "the deadline fired early"
+
+    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS + 0.001)
+    due = authority.poll(clock.now)
+    assert len(due) == 1
+
+    writes_before = len(harness.writes())
+    await authority.fire_last_resort_unkey()
+    assert unkey.calls == 1
+    assert harness.writes()[writes_before:], (
+        f"{harness.name}: the due OFF never reached the wire"
+    )
+
+
+@every_backend()
+async def test_a_pass_class_write_never_consults_transmit_truth(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-3, composed: a poisoned read must not be reachable from PASS.
+
+    ``set_ptt(False)`` resolves through the T5 short circuit and ``set_freq``
+    is absent from the matrix map, so the row uses the unkey — the one write
+    that is structurally ahead of every table.
+    """
+
+    async def poisoned() -> TxStateReading:  # pragma: no cover - must not run
+        raise AssertionError("transmit truth was consulted on a non-hazard write")
+
+    authority = TransmitAuthority(
+        read_transmit_state=poisoned,
+        last_resort_unkey=RecordingUnkey(harness),
+        method_map=CONFORMANCE_METHOD_MAP,
+        clock=FakeClock(),
+    )
+    async with authority.admit("set_ptt", (False,)):
+        await harness.unkey()
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+async def test_the_queue_drain_reaches_the_backend_write_method(
+    harness: TxConformanceHarness,
+) -> None:
+    """The D1 ingress is real, and this file can drive it.
+
+    Live on purpose: the queue-path cutover rows below are ``xfail``, and an
+    xfail proves nothing if the plumbing under it never worked. ``PttOff`` is
+    the probe because it is ``ALWAYS_PASS`` at the old seat still standing
+    above the authority (row 11 deletes that seat), so this row measures the
+    drain rather than the seat.
+    """
+    harness.script("rx")
+    queue = harness.extras["queue"]
+    assert harness.drain is not None and harness.queue_unkey is not None
+
+    writes_before = len(harness.writes())
+    queue.put_ordered(harness.queue_unkey)
+    await harness.drain()
+
+    assert harness.writes()[writes_before:], (
+        f"{harness.name}: a queued command never reached the backend write method"
+    )
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+async def test_a_set_ptt_write_alone_produces_no_observation(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 7 / INV-8: a write outcome is never evidence of RF.
+
+    The observation callback the web hands ``create_observation_poller`` must
+    stay silent for a bare ``set_ptt`` — only a readback may claim transmit
+    truth.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, add
+    # `"command_response"` to the `RADIO_READBACK_SOURCES` frozenset at
+    # :49-51 -> the sources half of this row goes red.
+    """
+    observations = harness.extras["observations"]
+    observations.clear()
+
+    await harness.key()
+    await harness.unkey()
+
+    laundered = [
+        obs
+        for obs in observations
+        if str(obs.path) == "global.tx_state.ptt"
+        and str(obs.source.source) not in RADIO_READBACK_SOURCES
+    ]
+    assert observations == [] or laundered == [], (
+        f"{harness.name}: a self-write produced a transmit-truth observation"
+    )
+    assert "command_response" not in RADIO_READBACK_SOURCES
+    assert "state_poller" not in RADIO_READBACK_SOURCES
+
+
+@pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
+async def test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth(
+    harness: TxConformanceHarness,
+) -> None:
+    """The same row on the CI-V columns, read off the canonical store."""
+    await harness.key()
+    await harness.unkey()
+    await asyncio.sleep(0)
+
+    store = harness.radio._state_store
+    truth = build_transmit_truth(
+        store.snapshot(), provider_generation=store.provider_generation
+    )
+    assert truth.value is None, f"{harness.name}: our own set_ptt became transmit truth"
+
+
+# ---------------------------------------------------------------------------
+# 3. Cutover rows — reserved, individually reasoned, strict
+# ---------------------------------------------------------------------------
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 7 (Icom) / row 8 (Yaesu, rigctld-client): no backend "
+    "constructs a TransmitAuthority yet, so INV-15 cannot hold. Turns green "
+    "when the admission is constructed in every connect path.",
+)
+async def test_a_backend_constructs_its_own_transmit_authority(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-15: no gated write executes without a constructed authority."""
+    authority = getattr(harness.radio, "_tx_authority", None)
+    assert isinstance(authority, TransmitAuthority)
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 7 (Icom) / row 8 (Yaesu, rigctld-client): the admission call "
+    "is not yet at the top of the gated write methods, so a plain method "
+    "call is ungated. The composed row above already proves the engine "
+    "refuses; this reserves the seat inside the backend.",
+)
+async def test_a_backend_method_call_is_refused_at_scripted_tx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 1, driven the way every consumer drives it."""
+    harness.script("tx_cat")
+    writes_before = len(harness.writes())
+    with pytest.raises(TxRefusal):
+        await harness.hazard()
+    assert harness.writes()[writes_before:] == []
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5 (the read primitive) + row 7/8 (the admission): a plain "
+    "method call performs no solicited read, so nothing precedes the write.",
+)
+async def test_a_backend_method_call_reads_before_it_writes_at_scripted_rx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 2, driven the way every consumer drives it."""
+    harness.script("rx")
+    baseline = len(harness.wire())
+    await harness.hazard()
+    wire = list(harness.wire())[baseline:]
+    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
+    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
+    assert reads and writes and reads[-1] < writes[0]
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 8 (the admission at each backend's real write surface) and, "
+    "on Yaesu, row 11 (deleting the poller's own seat above it): the queue "
+    "drain reaches an ungated backend body. This is the D1 ingress §3.2 "
+    "item 2 names — the one a wrapping facade could never have seen.",
+)
+async def test_a_queued_hazard_write_is_refused_at_scripted_tx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 1 again, through ``create_observation_poller``'s drain."""
+    harness.script("tx_cat")
+    queue = harness.extras["queue"]
+    assert harness.drain is not None
+
+    writes_before = len(harness.writes())
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    queue.put_ordered(harness.queue_command, future=future)
+    await harness.drain()
+
+    assert future.done()
+    assert isinstance(future.exception(), TxRefusal)
+    assert harness.writes()[writes_before:] == []
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5 (the read primitive) + row 8 (the admission) and, on "
+    "Yaesu, row 11: the drain reaches the backend body with no solicited "
+    "read in front of it.",
+)
+async def test_a_queued_hazard_write_reads_before_it_writes_at_scripted_rx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 2 again, through the queue ingress."""
+    harness.script("rx")
+    queue = harness.extras["queue"]
+    assert harness.drain is not None
+
+    baseline = len(harness.wire())
+    queue.put_ordered(harness.queue_command)
+    await harness.drain()
+
+    wire = list(harness.wire())[baseline:]
+    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
+    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
+    assert reads and writes and reads[-1] < writes[0]
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5: `read_transmit_state()` lands on the new capability "
+    "protocol `TransmitStateReadable` (5a Icom, 5b Yaesu + rigctld-client). "
+    "The harness assembles the equivalent from shipped parts meanwhile.",
+)
+async def test_a_backend_exposes_the_row_five_read_primitive(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-13's home: one primitive, per backend, returning typed evidence."""
+    reading = await harness.radio.read_transmit_state()
+    assert isinstance(reading, TxStateReading)
+
+
+@pytest.mark.parametrize("harness", ["rigctld-client"], indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5b: the backend's own primitive must carry "
+    "`verified_readback=False` permanently (§3.7). The harness already marks "
+    "it, and the composed refusal row above proves the gate honours the "
+    "marking; this reserves the marking on the shipped primitive.",
+)
+async def test_the_rigctld_client_primitive_marks_its_readback_unverified(
+    harness: TxConformanceHarness,
+) -> None:
+    harness.script("rx")
+    reading = await harness.radio.read_transmit_state()
+    assert reading.verified_readback is False
+
+
+@pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 6 (Yaesu truth honesty): `tx_state_map` turns the "
+    "three-valued `TX;` answer into an attribution. Today `read_ptt` "
+    "collapses it to a bool, so `tx_other` (the front-panel key) is "
+    "indistinguishable from `tx_cat` in the evidence.",
+)
+async def test_yaesu_attribution_reaches_the_evidence(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.7: attribution is a per-vendor capability, carried not discarded."""
+    harness.script("tx_other")
+    assert (await harness.read_transmit_state()).attributed == "tx_other"
+    harness.script("tx_cat")
+    assert (await harness.read_transmit_state()).attributed == "tx_cat"
+
+
+@pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 6: `set_ptt` self-mutates the legacy mirror "
+    "(`backends/yaesu_cat/radio.py:994`). The row deletes that write; until "
+    "then our own command is still a claim about RF somewhere in the tree.",
+)
+async def test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere(
+    harness: TxConformanceHarness,
+) -> None:
+    """The self-write launder, at its last surviving Yaesu address."""
+    before = harness.radio._state.ptt
+    await harness.key()
+    assert harness.radio._state.ptt == before
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="rows 12a/12b: the shipped deadline drivers. 12a wires the web "
+    "`call_later` (Icom branch) and the observation poller's drain to the "
+    "authority's deadline, both enqueuing `PttOff`; 12b wires the rigctld "
+    "drain and the Icom backend loops. Until then the only rail is the "
+    "authority's own last resort, which the live row above already exercises.",
+)
+async def test_a_shipped_driver_polls_the_authority_deadline(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-7: every delivery carries a driver for the one deadline."""
+    driver = getattr(harness.radio, "_tx_authority_deadline_driver", None)
+    assert driver is not None

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -600,10 +600,11 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
     the legacy ``radio_state`` cache (``yaesu_cat/radio.py:987-994`` and the
     rigctld-client ``set_ptt`` equivalent); neither touches
     ``self._observation_callback`` at all. So ``observations == []`` measured
-    right after the bare write, with no poll cycle ever run, would hold no
-    matter what the write did wrong — the write path and the callback are
-    architecturally disjoint until something drives a poll. That was this
-    row's defect: it measured exactly that, so it never went red.
+    right after the bare write, with no poll cycle ever run, was unreachable
+    under today's code and under every mutation this file declares — the two
+    paths only meet once something drives a poll. It was not unfalsifiable:
+    a write path patched to publish its own observation does redden even the
+    old row. It was unreached, which is enough to make a green meaningless.
 
     What the row needs only shows up once a poll cycle actually runs, so this
     drives one for real — the same method the production polling loop calls
@@ -622,6 +623,14 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
     # row goes red on the `yaesu-ftx1` column: the real PTT readback the
     # driven poll cycle takes now carries a producer-side source, and
     # `laundered` stops being empty.
+    #
+    # MUTATION: in `src/rigplane/backends/yaesu_cat/observations.py`, remove
+    # the `_PTT` branch at :328-333 so the poll cycle stops reading PTT at
+    # all -> the liveness guard below goes red on the `yaesu-ftx1` column.
+    # Without that guard the row would pass on an empty `laundered` list
+    # again, which is the same silent vacuity in a narrower disguise: a
+    # non-empty `observations` proves a cycle ran, not that it read the one
+    # field this row is about.
     """
     observations = harness.extras["observations"]
     observations.clear()
@@ -636,9 +645,9 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
     else:
         await poller._poll_medium()
 
-    assert observations, (
-        f"{harness.name}: the driven poll cycle produced no observations — "
-        "this row proves nothing without a real one to inspect"
+    assert any(str(obs.path) == "global.tx_state.ptt" for obs in observations), (
+        f"{harness.name}: the driven poll cycle read no transmit state — "
+        "this row proves nothing without the field under test to inspect"
     )
     laundered = [
         obs

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -594,31 +594,61 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
 ) -> None:
     """§3.10 item 3, row 7 / INV-8: a write outcome is never evidence of RF.
 
-    The observation callback the web hands ``create_observation_poller`` must
-    stay silent for a bare ``set_ptt`` — only a readback may claim transmit
-    truth.
+    A bare ``set_ptt`` — the harness's direct call on the radio object, not
+    the queue-drained write ``test_the_queue_drain_reaches_the_backend_write_method``
+    already proves reaches the backend — only writes to the wire and updates
+    the legacy ``radio_state`` cache (``yaesu_cat/radio.py:987-994`` and the
+    rigctld-client ``set_ptt`` equivalent); neither touches
+    ``self._observation_callback`` at all. So ``observations == []`` measured
+    right after the bare write, with no poll cycle ever run, would hold no
+    matter what the write did wrong — the write path and the callback are
+    architecturally disjoint until something drives a poll. That was this
+    row's defect: it measured exactly that, so it never went red.
 
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, add
-    # `"command_response"` to the `RADIO_READBACK_SOURCES` frozenset at
-    # :49-51 -> the sources half of this row goes red.
+    What the row needs only shows up once a poll cycle actually runs, so this
+    drives one for real — the same method the production polling loop calls
+    (``YaesuCatPoller._emit_medium_observations`` /
+    ``RigctldClientObservationPoller._poll_medium``), over the same scripted
+    wire the bare write just used, no sleep and no mock. A genuine
+    ``yaesu_poll_response`` / ``hamlib_response`` readback of the current PTT
+    state is expected and correct — §3.7's ``verified_readback`` is what
+    decides whether that readback may be trusted, not this row. What must
+    never appear is a ``global.tx_state.ptt`` observation under any other
+    source: that would be a write outcome wearing a readback's clothes.
+
+    # MUTATION: in `src/rigplane/backends/yaesu_cat/observations.py`, in
+    # `YaesuObservationAdapter._adapter` at :1141, change
+    # `source="yaesu_poll_response"` to `source="command_response"` -> this
+    # row goes red on the `yaesu-ftx1` column: the real PTT readback the
+    # driven poll cycle takes now carries a producer-side source, and
+    # `laundered` stops being empty.
     """
     observations = harness.extras["observations"]
     observations.clear()
+    harness.script("rx")
 
     await harness.key()
     await harness.unkey()
 
+    poller = harness.extras["poller"]
+    if harness.name == "yaesu-ftx1":
+        await poller._emit_medium_observations()
+    else:
+        await poller._poll_medium()
+
+    assert observations, (
+        f"{harness.name}: the driven poll cycle produced no observations — "
+        "this row proves nothing without a real one to inspect"
+    )
     laundered = [
         obs
         for obs in observations
         if str(obs.path) == "global.tx_state.ptt"
         and str(obs.source.source) not in RADIO_READBACK_SOURCES
     ]
-    assert observations == [] or laundered == [], (
+    assert laundered == [], (
         f"{harness.name}: a self-write produced a transmit-truth observation"
     )
-    assert "command_response" not in RADIO_READBACK_SOURCES
-    assert "state_poller" not in RADIO_READBACK_SOURCES
 
 
 @pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -836,7 +836,18 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
     """INV-4: the admission lock spans the read and the write it authorised.
 
     Counts cannot see this — both writes happen either way. Only the *order*
-    of the effects distinguishes a held lock from an open window.
+    of the effects distinguishes a held lock from an open window, and only if
+    the hazard body *awaits*: every real transport write does, and a purely
+    synchronous body reaches its append before the loop can schedule anybody
+    else, so it cannot tell a lock held through the write handoff from one
+    released at the verdict.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, dedent the
+    # `try:/yield ticket/finally:/self._commit(...)` block at :538-543 by one
+    # level so it sits after the `async with self._lock:` body rather than
+    # inside it -> this row goes red with
+    # `["key-write", "hazard-relay-throw"]`: a key completed inside the
+    # relay-throw window.
     """
     clock = Clock()
     link = FakeTransmitStateLink(clock)
@@ -848,7 +859,8 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
 
     async def hazard() -> None:
         async with authority.admit("set_antenna_1", ()):
-            order.append("hazard-write")
+            await asyncio.sleep(0)  # the write handoff every transport makes
+            order.append("hazard-relay-throw")
 
     async def key() -> None:
         async with authority.admit("set_ptt", (True,)):
@@ -864,7 +876,7 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
 
     link.release_read.set()
     await asyncio.gather(hazard_task, key_task)
-    assert order == ["hazard-write", "key-write"]
+    assert order == ["hazard-relay-throw", "key-write"]
 
 
 async def test_a_receive_observation_never_clears_anything() -> None:

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -1,0 +1,558 @@
+"""Scripted transmit-state fakes for the transmit-authority conformance matrix.
+
+ADR row 4, ``docs/plans/2026-08-20-transmit-authority.md`` §3.10 item 1: the
+existing fake harnesses, extended with a **scripted transmit-state answer** so
+the hazard gate's solicited read exercises the real code path rather than a
+hand-written stub of it.
+
+One vocabulary, three wires. Each backend family answers the same six scripted
+answers over its own real read code:
+
+======================  ==========================  ==============  ==============
+answer                  CI-V (Icom)                 Yaesu CAT       rigctld client
+======================  ==========================  ==============  ==============
+``rx``                  directed ``1C 00`` + ``00`` ``TX0``         ``0``
+``tx_cat``              directed ``1C 00`` + ``01`` ``TX1``         ``1``
+``tx_other``            (Icom carries no            ``TX2``         (upstream
+                        attribution — §3.7)                         carries none)
+``silence``             no reply at all             read times out  delayed past
+                                                                    the deadline
+``refusal``             NAK ``FA``                  ``?;``          malformed line
+``unmapped``            ``1C 00`` + ``00 00``       ``TX9``         ``9``
+======================  ==========================  ==============  ==============
+
+The CI-V column additionally scripts three shapes that must **never** satisfy a
+read (INV-13): an ACK, a setter echo, and a mis-addressed frame. They are not
+filtered here — they go onto the wire and are rejected by the shipped
+directed-exact-reply discipline (``runtime/_civ_rx.py:1489-1492`` routing
+guards and ``:2636-2650`` provenance narrowing), which is the whole point: the
+fake proves the *product's* validation discriminates, not its own.
+
+The ``unmapped`` CI-V answer is deliberately ``00 00`` rather than a junk byte.
+Its first byte is ``0x00``, so if the shape check were ever loosened it would
+decode as **receiving** — the fail-open direction. A junk byte like ``0x02``
+would decode as transmitting and could not catch that class of regression.
+
+No MagicMock anywhere (CLAUDE.md hard rule, restated for this row by §3.10
+item 1): every fake here is a plain object with real methods.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer, FakeRigctldState
+from test_radio import MockTransport
+
+from _helpers import wrap_civ_in_udp
+from rigplane.backends.ic705 import Ic705SerialRadio
+from rigplane.backends.ic7300 import Ic7300SerialRadio
+from rigplane.backends.ic9700 import Ic9700SerialRadio
+from rigplane.backends.icom7610 import Icom7610SerialRadio
+from rigplane.backends.rigctld_client.radio import RigctldClientRadio
+from rigplane.backends.yaesu_cat import YaesuCatRadio
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.core.exceptions import CommandError
+from rigplane.core.tx_authority import RADIO_READBACK_SOURCES, TxStateReading
+from rigplane.radio import IcomRadio
+
+# ---------------------------------------------------------------------------
+# The scripted answer vocabulary
+# ---------------------------------------------------------------------------
+
+TxAnswer = Literal["rx", "tx_cat", "tx_other", "silence", "refusal", "unmapped"]
+
+#: Explicit literal, never computed from a type or an enum — the
+#: ``test_audio_transport_conformance.py:65-81`` rule.
+TX_ANSWER_VOCABULARY: tuple[TxAnswer, ...] = (
+    "rx",
+    "tx_cat",
+    "tx_other",
+    "silence",
+    "refusal",
+    "unmapped",
+)
+
+#: The CI-V shapes that must never satisfy a read (INV-13). Also an explicit
+#: literal.
+CIV_NON_ANSWERS: tuple[str, ...] = ("ack", "setter_echo", "misaddressed")
+
+#: Answers that mean "the radio is transmitting". Explicit, never derived.
+TRANSMITTING_ANSWERS: tuple[TxAnswer, ...] = ("tx_cat", "tx_other")
+
+#: Answers that must never resolve to *receiving* on any backend: the read
+#: failed, the radio refused, or the value is outside the positive map (§3.7).
+NON_RECEIVING_ANSWERS: tuple[TxAnswer, ...] = ("silence", "refusal", "unmapped")
+
+_PTT_FIELD = "global.tx_state.ptt"
+
+#: A CI-V address that is not any bench radio's, for the mis-addressed shape.
+FOREIGN_CIV_ADDR = 0x88
+
+
+def civ_transmit_state_reply(answer: str, radio_addr: int) -> bytes | None:
+    """The CI-V frame the fake radio answers a ``1C 00`` read with.
+
+    ``None`` means "answer nothing" — the silence row.
+    """
+    if answer == "rx":
+        return build_civ_frame(
+            CONTROLLER_ADDR, radio_addr, 0x1C, sub=0x00, data=b"\x00"
+        )
+    if answer in ("tx_cat", "tx_other"):
+        # Icom reports no attribution at all, so both keyed answers are the
+        # same byte on this wire; the attribution field stays honestly None.
+        return build_civ_frame(
+            CONTROLLER_ADDR, radio_addr, 0x1C, sub=0x00, data=b"\x01"
+        )
+    if answer == "unmapped":
+        return build_civ_frame(
+            CONTROLLER_ADDR, radio_addr, 0x1C, sub=0x00, data=b"\x00\x00"
+        )
+    if answer == "refusal":
+        return build_civ_frame(CONTROLLER_ADDR, radio_addr, 0xFA)
+    if answer == "ack":
+        return build_civ_frame(CONTROLLER_ADDR, radio_addr, 0xFB)
+    if answer == "setter_echo":
+        # Addressed *to* the radio, exactly as our own ptt_off setter is.
+        return build_civ_frame(
+            radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00, data=b"\x00"
+        )
+    if answer == "misaddressed":
+        return build_civ_frame(
+            CONTROLLER_ADDR, FOREIGN_CIV_ADDR, 0x1C, sub=0x00, data=b"\x00"
+        )
+    if answer == "silence":
+        return None
+    raise AssertionError(f"unscripted transmit-state answer {answer!r}")
+
+
+def _is_civ_transmit_state_read(payload: bytes) -> bool:
+    """``FE FE <to> <from> 1C 00 FD`` — the bare GET, no data byte."""
+    return len(payload) == 7 and payload[4] == 0x1C and payload[5] == 0x00
+
+
+# ---------------------------------------------------------------------------
+# Wires
+# ---------------------------------------------------------------------------
+
+
+class ScriptedCivLink:
+    """A serial CI-V link that answers the transmit-state read by content.
+
+    The shipped serial fake (``tests/test_icom7610_serial_radio.py:125``)
+    scripts replies by *send ordinal*; a solicited read inside a gate has no
+    stable ordinal, so this one matches on ``(command, sub)`` instead. Same
+    duck-typed surface as the production ``SerialCivLink``.
+    """
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+        self.sent_frames: list[bytes] = []
+        self.answer: str = "rx"
+        self.radio_addr: int = 0x94
+        self._replies: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def set_device(self, device: str) -> None:
+        """Reconnection seam the serial base class calls."""
+
+    async def connect(self) -> None:
+        self.connected = self.ready = self.healthy = True
+
+    async def disconnect(self) -> None:
+        self.connected = self.ready = self.healthy = False
+
+    async def send(self, frame: bytes) -> None:
+        if not self.connected:
+            raise ConnectionError("Serial CI-V link is disconnected.")
+        payload = bytes(frame)
+        self.sent_frames.append(payload)
+        if _is_civ_transmit_state_read(payload):
+            reply = civ_transmit_state_reply(self.answer, self.radio_addr)
+            if reply is not None:
+                self._replies.put_nowait(reply)
+
+    async def receive(self, timeout: float | None = None) -> bytes | None:
+        if not self.connected:
+            return None
+        try:
+            return await asyncio.wait_for(
+                self._replies.get(), timeout=0.05 if timeout is None else timeout
+            )
+        except asyncio.TimeoutError:
+            return None
+
+
+class ScriptedLanTransport(MockTransport):
+    """The LAN transport fake, answering the transmit-state read by content."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.answer: str = "rx"
+        self.radio_addr: int = 0x98
+
+    async def send_tracked(self, data: bytes) -> None:
+        await super().send_tracked(data)
+        payload = bytes(data)[0x15:]
+        if _is_civ_transmit_state_read(payload):
+            reply = civ_transmit_state_reply(self.answer, self.radio_addr)
+            if reply is not None:
+                self.queue_response(wrap_civ_in_udp(reply))
+
+    def civ_wire(self) -> list[bytes]:
+        """The CI-V payloads, unwrapped from their UDP envelopes."""
+        return [bytes(pkt)[0x15:] for pkt in self.sent_packets if len(pkt) > 0x15]
+
+
+class ScriptedCatTransport:
+    """Yaesu CAT reads/writes, scripted by answer name.
+
+    Installed over a real ``YaesuCatRadio``'s real transport object by
+    replacing its two async entry points — the established house pattern
+    (``tests/test_ftx1_radio.py:34-46``) minus the mock.
+    """
+
+    _READ_ANSWERS = {
+        "rx": "TX0",
+        "tx_cat": "TX1",
+        "tx_other": "TX2",
+        "unmapped": "TX9",
+        "refusal": "?",
+    }
+
+    def __init__(self, radio: YaesuCatRadio) -> None:
+        self.wire: list[str] = []
+        self.answer: str = "rx"
+        radio._transport._connected = True
+        radio._transport.query = self.query  # type: ignore[method-assign]
+        radio._transport.write = self.write  # type: ignore[method-assign]
+
+    async def query(self, cmd: str, *args: Any, **kwargs: Any) -> str:
+        self.wire.append(f"?{cmd}")
+        if self.answer == "silence":
+            raise asyncio.TimeoutError("no CAT answer")
+        try:
+            return self._READ_ANSWERS[self.answer]
+        except KeyError:  # pragma: no cover - guards a typo in a new row
+            raise AssertionError(
+                f"unscripted transmit-state answer {self.answer!r}"
+            ) from None
+
+    async def write(self, cmd: str, *args: Any, **kwargs: Any) -> None:
+        self.wire.append(f"!{cmd}")
+
+
+# ---------------------------------------------------------------------------
+# One harness row
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TxConformanceHarness:
+    """One backend column of the matrix: a real radio on a scripted wire."""
+
+    name: str
+    radio: Any
+    script: Callable[[str], None]
+    read_transmit_state: Callable[[], Awaitable[TxStateReading]]
+    wire: Callable[[], Sequence[str]]
+    is_read: Callable[[str], bool]
+    hazard_method: str
+    hazard_args: tuple[Any, ...]
+    hazard: Callable[[], Awaitable[None]]
+    key: Callable[[], Awaitable[None]]
+    unkey: Callable[[], Awaitable[None]]
+    close: Callable[[], Awaitable[None]]
+    #: rigctld-client answers from an upstream cache, never the radio (§3.7).
+    verified_readback: bool = True
+    #: Only the ``ObservationPollable`` backends have the queue ingress the
+    #: facade design missed (the D1 lesson, §3.2 item 2).
+    queue_command: Any | None = None
+    queue_unkey: Any | None = None
+    drain: Callable[[], Awaitable[None]] | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def writes(self) -> list[str]:
+        return [entry for entry in self.wire() if not self.is_read(entry)]
+
+    def reads(self) -> list[str]:
+        return [entry for entry in self.wire() if self.is_read(entry)]
+
+
+# ---------------------------------------------------------------------------
+# Per-backend construction
+# ---------------------------------------------------------------------------
+
+_ICOM_SERIAL_CLASSES = {
+    "icom7610-serial": Icom7610SerialRadio,
+    "ic705-serial": Ic705SerialRadio,
+    "ic7300-serial": Ic7300SerialRadio,
+    "ic9700-serial": Ic9700SerialRadio,
+}
+
+#: Every shipping backend class, as an explicit literal. Mirrors
+#: ``tests/contracts/test_audio_transport_conformance.py:83-90`` and adds the
+#: rigctld-client backend, which ships no audio but does ship writes.
+CONFORMANCE_BACKENDS: tuple[str, ...] = (
+    "lan-icom",
+    "icom7610-serial",
+    "ic705-serial",
+    "ic7300-serial",
+    "ic9700-serial",
+    "yaesu-ftx1",
+    "rigctld-client",
+)
+
+#: The backends whose web write path is the ``create_observation_poller``
+#: queue drain (``web_startup.py:105-193`` branch 1) — the ingress a wrapping
+#: facade could never see.
+QUEUE_PATH_BACKENDS: tuple[str, ...] = ("yaesu-ftx1", "rigctld-client")
+
+
+async def _civ_reading(radio: Any, timeout: float) -> TxStateReading:
+    """One solicited CI-V transmit-state read, validated as the product does.
+
+    Row 5 will put this behind ``TransmitStateReadable``; until then the
+    harness assembles it from shipped parts so the conformance rows exercise
+    the real validation rather than a stand-in for it. Note which parts:
+    ``CivRequestTracker`` matches ``(command, sub, receiver)`` with **no**
+    address check (``core/civ.py:410-417``), so the discrimination comes from
+    the RX pump's routing guards plus the provenance narrowing at
+    ``_civ_rx.py:2636-2650`` — exactly the trap §3.4 row 5 names.
+    """
+    frame = build_civ_frame(radio._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)
+    try:
+        reply = await radio._send_civ_expect(frame, label="tx-state", timeout=timeout)
+    except asyncio.TimeoutError:
+        return TxStateReading(value=None, failure="timeout")
+    except CommandError:
+        # No usable answer: nothing came back, or what came back was a NAK.
+        return TxStateReading(value=None, failure="read-error")
+    for observation in radio._civ_runtime._observations_from_frame(reply):
+        if str(observation.path) != _PTT_FIELD:
+            continue
+        source = str(observation.source.source)
+        if source in RADIO_READBACK_SOURCES:
+            return TxStateReading(
+                value=bool(observation.value),
+                attributed=None,  # Icom reports no attribution (§3.7)
+                source=source,
+                verified_readback=True,
+            )
+    return TxStateReading(value=None, failure="unverifiable-provenance")
+
+
+async def _build_lan_icom() -> TxConformanceHarness:
+    transport = ScriptedLanTransport()
+    radio = IcomRadio("192.168.99.1", timeout=0.2)
+    radio._civ_transport = transport
+    radio._ctrl_transport = transport
+    radio._connected = True
+    radio._radio_addr = transport.radio_addr
+    radio._start_civ_rx_pump()
+    await asyncio.sleep(0)
+
+    async def close() -> None:
+        radio._connected = False
+        task = radio._civ_rx_task
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        radio._civ_transport = None
+        radio._ctrl_transport = None
+
+    return TxConformanceHarness(
+        name="lan-icom",
+        radio=radio,
+        script=lambda answer: setattr(transport, "answer", answer),
+        read_transmit_state=lambda: _civ_reading(radio, 0.15),
+        wire=lambda: [payload.hex() for payload in transport.civ_wire()],
+        is_read=_is_hex_civ_read,
+        hazard_method="set_tuner_status",
+        hazard_args=(2,),
+        hazard=lambda: radio.set_tuner_status(2),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=close,
+    )
+
+
+def _is_hex_civ_read(entry: str) -> bool:
+    return _is_civ_transmit_state_read(bytes.fromhex(entry))
+
+
+async def _build_icom_serial(name: str) -> TxConformanceHarness:
+    link = ScriptedCivLink()
+    radio = _ICOM_SERIAL_CLASSES[name](device="/dev/ttyUSB0", civ_link=link)
+    await radio.connect()
+    link.radio_addr = radio._radio_addr
+
+    return TxConformanceHarness(
+        name=name,
+        radio=radio,
+        script=lambda answer: setattr(link, "answer", answer),
+        read_transmit_state=lambda: _civ_reading(radio, 0.15),
+        wire=lambda: [payload.hex() for payload in link.sent_frames],
+        is_read=_is_hex_civ_read,
+        hazard_method="set_tuner_status",
+        hazard_args=(2,),
+        hazard=lambda: radio.set_tuner_status(2),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=radio.disconnect,
+    )
+
+
+async def _build_yaesu() -> TxConformanceHarness:
+    radio = YaesuCatRadio("/dev/null", profile="ftx1")
+    cat = ScriptedCatTransport(radio)
+
+    async def read() -> TxStateReading:
+        try:
+            value = await radio.read_ptt()
+        except asyncio.TimeoutError:
+            return TxStateReading(value=None, failure="timeout")
+        except Exception:
+            # ``?;`` fails the typed parse — the radio refused the read.
+            return TxStateReading(value=None, failure="read-error")
+        return TxStateReading(
+            value=value,
+            # Row 6 routes the three-valued answer through ``tx_state_map``
+            # into this field; today ``read_ptt`` collapses it to a bool.
+            attributed=None,
+            source="yaesu_poll_response",
+            verified_readback=True,
+        )
+
+    from rigplane.runtime._poller_types import CommandQueue, PttOff, SetTunerStatus
+
+    queue = CommandQueue()
+    seen: list[Any] = []
+    poller = radio.create_observation_poller(callback=seen.extend, command_queue=queue)
+
+    async def close() -> None:
+        return None
+
+    return TxConformanceHarness(
+        name="yaesu-ftx1",
+        radio=radio,
+        script=lambda answer: setattr(cat, "answer", answer),
+        read_transmit_state=read,
+        wire=lambda: list(cat.wire),
+        is_read=lambda entry: entry.startswith("?"),
+        # The alias chain's innermost body: ``set_tuner_status`` is a pure
+        # alias onto ``set_tuner`` (§3.2), and the queue drain calls the
+        # latter directly (``yaesu_cat/poller.py:1099-1100``).
+        hazard_method="set_tuner",
+        hazard_args=(1,),
+        hazard=lambda: radio.set_tuner(1),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=close,
+        queue_command=SetTunerStatus(1),
+        queue_unkey=PttOff(),
+        drain=poller._drain_commands,
+        extras={"queue": queue, "poller": poller, "cat": cat, "observations": seen},
+    )
+
+
+async def _build_rigctld_client() -> TxConformanceHarness:
+    server = FakeRigctldServer(state=FakeRigctldState(), behavior=FakeRigctldBehavior())
+    await server.start()
+    radio = RigctldClientRadio(host=server.host, port=server.port)
+    await radio.connect()
+
+    def script(answer: str) -> None:
+        server.behavior.command_delays.pop("t", None)
+        server.behavior.malformed_responses.pop("t", None)
+        server.behavior.disconnect_commands.discard("t")
+        if answer == "rx":
+            server.state.ptt = 0
+        elif answer in ("tx_cat", "tx_other"):
+            server.state.ptt = 1
+        elif answer == "silence":
+            # Realised as the upstream dropping the connection rather than a
+            # bare delay: this socket is shared with every later read, and a
+            # late line arriving after the gate cancelled its ``wait_for``
+            # would answer the *next* read. Same fail direction either way —
+            # no answer, so the hazard gate refuses ``tx-truth-unavailable``.
+            server.behavior.disconnect_commands.add("t")
+        elif answer == "refusal":
+            server.behavior.malformed_responses["t"] = b"RPRT -1\n"
+        elif answer == "unmapped":
+            server.behavior.malformed_responses["t"] = b"9\n"
+        else:  # pragma: no cover - guards a typo in a new row
+            raise AssertionError(f"unscripted transmit-state answer {answer!r}")
+
+    async def read() -> TxStateReading:
+        try:
+            value = await radio.get_ptt()
+        except asyncio.TimeoutError:
+            return TxStateReading(value=None, failure="timeout")
+        except Exception:
+            return TxStateReading(value=None, failure="read-error")
+        # Never radio truth: upstream answers from its own cache (§3.7), so
+        # the gate must refuse every hazard on this backend.
+        return TxStateReading(
+            value=value,
+            attributed=None,
+            source="hamlib_response",
+            verified_readback=False,
+        )
+
+    from rigplane.runtime._poller_types import CommandQueue, PttOff, SelectVfo
+
+    queue = CommandQueue()
+    seen: list[Any] = []
+    poller = radio.create_observation_poller(callback=seen.extend, command_queue=queue)
+
+    async def close() -> None:
+        await radio.disconnect()
+        await server.stop()
+
+    return TxConformanceHarness(
+        name="rigctld-client",
+        radio=radio,
+        script=script,
+        read_transmit_state=read,
+        wire=lambda: list(server.commands_seen),
+        is_read=lambda entry: entry.split(" ")[0] in ("t", r"\get_ptt"),
+        # External rigctld ships no tuner; VFO select is its hazard family.
+        hazard_method="set_vfo_slot",
+        hazard_args=("B",),
+        hazard=lambda: radio.set_vfo_slot("B"),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=close,
+        verified_readback=False,
+        queue_command=SelectVfo("B"),
+        queue_unkey=PttOff(),
+        drain=poller._drain_commands,
+        extras={
+            "queue": queue,
+            "poller": poller,
+            "server": server,
+            "observations": seen,
+        },
+    )
+
+
+async def build_harness(name: str) -> TxConformanceHarness:
+    """Build one backend column. Explicit dispatch, never a registry lookup."""
+    if name == "lan-icom":
+        return await _build_lan_icom()
+    if name in _ICOM_SERIAL_CLASSES:
+        return await _build_icom_serial(name)
+    if name == "yaesu-ftx1":
+        return await _build_yaesu()
+    if name == "rigctld-client":
+        return await _build_rigctld_client()
+    raise AssertionError(f"no harness for backend column {name!r}")


### PR DESCRIPTION
## What this is

ADR row 4 of `docs/plans/2026-08-20-transmit-authority.md` (§3.10 items 1 and 3): the transmit-authority conformance matrix and the scripted transmit-state answers it runs on.

It lands **before** the read primitive (row 5) and the Yaesu honesty row (row 6) so their pins already exist when those rows cite them — the house pattern the audio architecture used (`docs/plans/2026-06-09-target-audio-architecture.md:959-960`: fakes and conformance before every component).

**Tests and fakes only. No production source changed. Nothing in the product calls any of this.**

## Fakes (§3.10 item 1)

One scripted answer vocabulary — confirmed RX, transmitting by CAT, transmitting by the radio itself, silence, an explicit refusal, and an unmapped value — answered by **each backend family's own real read code over its own fake wire**. The CI-V column additionally scripts an ACK, a setter echo and a mis-addressed frame; none may satisfy a read, and the discrimination is the shipped directed-exact-reply discipline rather than the fake's, which is the point (INV-13).

No MagicMock anywhere near the authority (CLAUDE.md hard rule, restated by §3.10 item 1); the fakes are plain objects and the clock is injected.

## Matrix (§3.10 item 3)

Every shipping backend class, listed as an explicit literal — never computed from a registry or an enum, so a backend that quietly stops shipping fails this file instead of silently shrinking the matrix (`tests/contracts/test_audio_transport_conformance.py:65-81` rule). Seven columns: the five Icom classes, `yaesu-ftx1`, and `rigctld-client` — the audio matrix's six plus the one it excludes for having no audio surface.

Each ADR-named row is driven **twice**:

* **Composed rows (live).** The real engine, the real backend class and the real fake wire, with the admission driven from the test. These prove the component composes: a hazard write at scripted TX is refused and nothing reaches the wire; at scripted RX the solicited read precedes the write; an unmapped value is never receiving; an unkey is never refused; a key arms the one deadline and the last-resort rail fires the OFF on a fake clock.
* **Cutover rows (`xfail(strict=True)`).** The same behaviours driven the way a consumer will drive them — a plain method call, or a command through `create_observation_poller`'s queue drain — with **no** test-side admission. They fail today because the admission is not in the backend. Each names the migration row that turns it green. `strict=True` is the point: the day a cutover lands, the row goes red as an XPASS, which is the signal rows 7/8 need that their conformance obligation is met. **A row is never weakened to pass today** — an honest xfail says more than an assertion-free green.

**The queue path is not optional.** §3.2's refutation of the wrapping facade turns on item 2: on FTX-1 and hamlib-provider radios the web write path never touches the radio object from outside — `web_startup.py:126-128` hands the `CommandQueue` into `create_observation_poller` and the backend drains it against raw `self`. A matrix that only called backend methods directly would prove less than it appears to, so every queue-capable column carries the same rows again through the drain, **plus a live row proving the drain really does reach the backend write method** — so the xfails above it rest on working plumbing rather than on broken test wiring.

165 live rows, 42 strict xfails across 10 reserved behaviours.

## What this proves today, and what it does not

**Proves:** the engine landed in row 1 composes correctly against every shipping backend's real read code over its real fake wire; the CI-V read cannot be satisfied by an ACK, a setter echo or a mis-addressed frame; an unmapped transmit-state value is never receiving on any column; the queue drain really does reach the backend write method.

**Does not prove:** that any backend is gated. No backend constructs a `TransmitAuthority` — that is rows 7 and 8. Every such row is present and strictly reserved, not absent.

## Also in this PR

Closes the R1 reservation carried over from row 1: the admission-lock ordering test used a synchronous hazard body, so narrowing the lock to release before the write handoff left the whole suite green. The body now awaits, as every real transport write does, and that mutation is red.

## Guardrail deviation — declared

3 test files, +1401/-3 LOC, no source files. The LOC exceeds the 400-line guardrail; the ADR row's own scope (`tests/contracts/` + fakes, seven backend columns × the full scripted vocabulary × both drive paths) is what sets the size, and trimming it would mean trimming coverage. Measured blast radius above.

## Gates

```
uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread
  10558 passed, 13 skipped, 57 xfailed, 1 xpassed in 87.70s
uv run ruff check src/ tests/          All checks passed!
uv run ruff format --check src/ tests/ 687 files already formatted
uv run lint-imports                    Contracts: 5 kept, 0 broken.
```

The single XPASS is `tests/test_naming_parity.py::test_toml_commands_in_radio[x6100]`, a pre-existing non-strict xfail (epic #295) untouched by this branch.

## Base

Branch was authored on `67fbcbea` and has been merged up to `ad89d10c`, so MOR-1912's `[tx_policy]` work is present, not reverted. `git diff origin/main HEAD` is exactly the three test files above.


## Mutation evidence

Every mutation declared in an inline `# MUTATION:` comment in this branch, applied literally as worded to production source, run against the test the comment names, then restored. `PYTHONDONTWRITEBYTECODE=1` on every run — size-preserving edits otherwise reuse stale bytecode and fake a kill. Twelve declared, twelve killed, no survivors. **Row 10 was re-declared after review** — see the correction directly below the table.

| # | Mutation (file:line — the edit) | Test that must go red | Result |
|---|---|---|---|
| 1 | `src/rigplane/core/tx_authority.py:619` — `_admit_hazard`: `if reading.value or epoch != self._transmit_epoch:` → `if epoch != self._transmit_epoch:` | `tests/contracts/test_tx_authority_conformance.py::test_every_backend_answers_every_scripted_answer` | killed |
| 2 | `src/rigplane/runtime/_civ_rx.py:1489-1492` + `:2639-2645` — delete both routing guards in `_route_civ_frame`, and collapse the six-conjunct `elif` in `_observation` to `frame.command == 0x1C and frame.sub == 0x00` | `tests/contracts/test_tx_authority_conformance.py::test_a_civ_read_is_not_satisfied_by_an_ack_echo_or_misaddressed_frame` | killed |
| 3 | `src/rigplane/runtime/_civ_rx.py:2643` — delete the `and len(frame.data) == 1` conjunct | `tests/contracts/test_tx_authority_conformance.py::test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed` | killed |
| 4 | `src/rigplane/backends/yaesu_cat/radio.py:1027` — `return bool(state != "0")` → `return bool(state == "1")` | `tests/contracts/test_tx_authority_conformance.py::test_an_unmapped_transmit_state_value_is_never_receiving` | killed |
| 5 | `src/rigplane/core/tx_authority.py:522` — `admit()`: `if write_class is TxWriteClass.PASS:` → `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` | `tests/contracts/test_tx_authority_conformance.py::test_a_hazard_write_at_scripted_tx_is_refused_and_no_wire_write_occurs` | killed |
| 6 | same edit as #5, still applied | `tests/contracts/test_tx_authority_conformance.py::test_a_hazard_write_at_scripted_rx_reads_before_it_writes` | killed |
| 7 | `src/rigplane/core/tx_authority.py:526` — `admit()`: insert `raise TxRefusal(TxRefusalCode.TX_TRUTH_UNAVAILABLE, TxEvidence())` as the first statement of the `UNKEY` branch | `tests/contracts/test_tx_authority_conformance.py::test_an_unkey_is_never_refused` | killed |
| 8 | `src/rigplane/core/tx_authority.py:580-584` — `_admit_hazard`: delete the step-1 `if held is not None:` refusal | `tests/contracts/test_tx_authority_conformance.py::test_our_own_key_makes_the_gate_stricter_never_looser` | killed |
| 9 | `src/rigplane/core/tx_authority.py:651` — `_commit`: `self._deadline = deadline` → `self._deadline = None` | `tests/contracts/test_tx_authority_conformance.py::test_a_key_arms_the_one_deadline_and_the_off_fires_on_a_fake_clock` | killed |
| 10 | `src/rigplane/backends/yaesu_cat/observations.py:1141` — `source="yaesu_poll_response"` → `source="command_response"` | `tests/contracts/test_tx_authority_conformance.py::test_a_set_ptt_write_alone_produces_no_observation` | killed |
| 11 | `src/rigplane/core/tx_authority.py:538-543` — `admit()`: dedent the `try:/yield ticket/finally:/self._commit(...)` block one level so it sits after `async with self._lock:` rather than inside it | `tests/test_tx_authority.py::test_a_key_cannot_slip_between_a_hazard_read_and_its_write` | killed |
| 12 | `src/rigplane/core/tx_authority.py:49-51` — add `"state_poller"` to `RADIO_READBACK_SOURCES` (prose-declared at `tests/test_tx_authority.py:202`) | `tests/test_tx_authority.py::test_radio_readback_sources_pin` | killed |

Raw pytest summary lines, in the same order:

```
1.  13 failed, 29 passed in 2.66s
2.  10 failed,  5 passed in 1.85s
3.   5 failed in 0.21s
4.   1 failed,  6 passed in 0.74s
5.   7 failed in 0.16s
6.   6 failed in 0.15s
7.  21 failed in 0.28s
8.   7 failed in 0.95s
9.   7 failed in 0.17s
10.  1 failed, 1 passed in 0.14s
11.  1 failed in 0.04s
12.  1 failed in 0.03s
```

Unmutated baseline over both files, after restoring the tree:

```
uv run pytest tests/contracts/test_tx_authority_conformance.py tests/test_tx_authority.py
  232 passed, 42 xfailed in 12.09s
```

Mutation 2's own comment predicts that the ACK case is held by a *different* mechanism — there is no `0xFB` branch in the decode ladder at all — and therefore survives that edit. That prediction was checked rather than assumed: with the mutation applied, `setter_echo` and `misaddressed` failed on all five CI-V columns (10/10) while `ack` passed on all five, exactly as the comment claims.

### Correction to row 10, and the review finding that produced it

The first version of this branch declared row 10's mutation as adding `"command_response"` to `RADIO_READBACK_SOURCES`. That mutation did turn `test_a_set_ptt_write_alone_produces_no_observation` red — but by failing a trailing `assert "command_response" not in RADIO_READBACK_SOURCES`, a tautology, rather than by exercising the row's stated subject. Independent review found the row's principal clause was **vacuous**, and the measurement backs it:

* `harness.extras["observations"]` is appended to only from inside the pollers' own poll cycle, which the file never drove. `observations == []` was therefore **unreached** under today's code and under every mutation this file declares. It was not *unfalsifiable* — review demonstrated that a write path patched to publish its own observation reddens even the old row — but unreached is already enough to make a green meaningless.
* `assert observations == [] or laundered == []` short-circuited on the first disjunct, which also implies the second, so the interesting half was unreachable twice over.
* The `laundered` comprehension filtered for sources **not** in `RADIO_READBACK_SOURCES`. The hazard INV-8 guards is a self-write reaching the callback wearing a *readback* tag, which that filter excludes. It ran in the safe direction and could not catch the dangerous one.
* Enlarging `RADIO_READBACK_SOURCES` can only shrink what the filter flags, so the old mutation was fail-open by construction and could never redden a passing row.

The row now drives a real poll cycle — the same method the production loop calls — over the same scripted fake wire the write just used, so the callback list is genuinely populated and `laundered == []` is genuinely exercised. Its parametrization over the queue-path columns is unchanged from the original row; no coverage moved. The two trailing frozenset asserts were dropped: `tests/test_tx_authority.py::test_radio_readback_sources_pin` is a strict superset of them, so nothing was lost.

Its mutation is now producer-side and kills for the row's own reason: retag the shipped Yaesu PTT readback as a producer source and the row goes red on that column with `a self-write produced a transmit-truth observation`. The old mutation was re-run against the rewritten row and confirmed **no longer to kill it** — which is exactly why it had to be replaced rather than kept.

Coverage was never missing on the CI-V side: the dangerous direction is live on the five CI-V columns via the sibling row `test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth`. **One honest limit, stated rather than implied:** the Yaesu `xfail(strict=True)` that review named alongside it pins the legacy mirror (`radio._state.ptt`), *not* observation publication — a Yaesu self-write tagged as a readback source would pass the whole suite today. That gap is pre-existing and belongs to ADR row 6, not to this branch, but it should not be papered over by citing an xfail that covers something adjacent.

A second, narrower version of the same defect was then found and closed in a follow-up commit: the liveness guard asserted the driven cycle produced *some* observation, not that it read the field under test, so dropping PTT from the Yaesu poll set left the row green on an empty `laundered` list. The guard now asserts a `global.tx_state.ptt` observation is present, and carries its own mutation — remove the `_PTT` branch from the Yaesu observation adapter and the row goes red on that column (measured: `1 failed, 1 passed in 0.13s`).

What was wrong throughout was a row claiming more than it proved — in the one file whose entire value is that its rows discriminate.

## Note on the full-suite run

One run of the full suite on this branch reported a single failure, `tests/test_radio.py::TestDspLevelParity::test_get_cmd29_dsp_level[get_nr_level-6-91-1]`. It is a load flake under `-n auto`, not a regression: it passes in isolation (49 passed), passes with its whole file under `-n auto` (292 passed) both with and without this branch's change, and the immediately following full-suite run on the identical tree was clean at 10558 passed / 13 skipped / 57 xfailed / 1 xpassed. Recorded rather than quietly re-run.

