### PR TITLE
fix(MOR-1941): route Yaesu PTT truth through tx_state_map, delete the set_ptt self-write

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -987,11 +987,47 @@ class YaesuCatRadio:
     async def set_ptt(self, on: bool) -> None:
         """Key or un-key the transmitter.
 
+        Does not touch the legacy ``self._state`` mirror (MOR-1941): our
+        own command is a claim about the wire, never receive/transmit
+        truth (§3.7 of the transmit-authority ADR). Only a real read-back
+        (:meth:`get_ptt`) may update the mirror.
+
         Args:
             on: ``True`` to transmit, ``False`` to receive.
         """
         await self._write("set_ptt", state="1" if on else "0")
-        self._state.ptt = on
+
+    def _warn_ptt_unrecognised(self, state: str) -> None:
+        """Warn-once-then-DEBUG diagnostic for an unrecognised TX token.
+
+        PTT is polled at a fast, unthrottled cadence, so a persistently
+        unrecognised state would otherwise flood the log. Reuses the
+        existing ``_poll_warned_fields`` warn-once-then-DEBUG idiom already
+        used for permanently-unsupported poll fields (MOR-561) rather than
+        adding new rate-limiting machinery.
+        """
+        label = "ptt_unrecognised_state"
+        log = logger.debug if label in self._poll_warned_fields else logger.warning
+        self._poll_warned_fields.add(label)
+        log(
+            "read_ptt: unrecognised TX state %r from %s; failing closed (transmitting)",
+            state,
+            self.model,
+        )
+
+    async def read_ptt_token(self) -> str:
+        """Read the raw ``TX;`` token verbatim -- no interpretation, no mutation.
+
+        The primitive :meth:`read_ptt` is built on. Exposes the wire value
+        (``"0"``/``"1"``/``"2"`` on shipped profiles) so a caller can map
+        it through the profile's :class:`~rigplane.profiles.TxPolicy` --
+        :meth:`~rigplane.profiles.TxPolicy.is_receiving` for the RX/TX
+        answer, :meth:`~rigplane.profiles.TxPolicy.attribution` for the
+        vendor's per-value label (MOR-1941, §3.7 of the transmit-authority
+        ADR).
+        """
+        result = await self._query("get_ptt")
+        return str(result["state"])
 
     async def read_ptt(self) -> bool:
         """Read the current PTT state without mutating legacy state.
@@ -999,32 +1035,36 @@ class YaesuCatRadio:
         The Yaesu ``TX;`` answer is three-valued, not a plain boolean flag:
         ``0`` = receiving, ``1`` = transmitting (CAT-keyed), ``2`` =
         transmitting (the radio itself keyed it -- front panel, mic,
-        footswitch, or VOX). Treating ``2`` as receiving is a fail-open
-        inversion of transmit truth (MOR-1905), so any state other than
-        ``0`` reads as transmitting, and an unrecognised value fails
-        closed (transmitting) with a diagnostic rather than reading as RX.
+        footswitch, or VOX). The raw token is routed through the profile's
+        ``[tx_policy].tx_state_map`` (positive-RX rule, MOR-1941, §3.7 of
+        the transmit-authority ADR): only a value explicitly mapped to
+        ``"rx"`` reads as receiving, so this predicate is structurally
+        unable to invert a state to RX the way the old inline
+        ``state == "1"`` comparison did (MOR-1905) -- an unrecognised
+        value fails closed (transmitting) with a diagnostic by
+        construction, not by a comparison that could quietly be flipped.
 
-        PTT is polled at a fast, unthrottled cadence, so a persistently
-        unrecognised state would otherwise flood the log. This reuses the
-        ``_poll_warned_fields`` warn-once-then-DEBUG idiom already used for
-        permanently-unsupported poll fields (MOR-561) rather than adding new
-        rate-limiting machinery.
+        A profile that ships no ``[tx_policy].tx_state_map`` at all --
+        every rig this backend has not bench-measured -- falls back to
+        the legacy ``!= "0"`` predicate instead of consulting the (empty)
+        map: ``"0"`` is the Yaesu CAT protocol's own receive token, not a
+        per-radio measured value, so this is a vendor-level default
+        rather than a hardcoded radio constant. An undeclared profile
+        must degrade to today's behaviour, not to a radio that can never
+        be read as receiving.
 
         Returns:
             ``True`` if transmitting, ``False`` if receiving.
         """
-        result = await self._query("get_ptt")
-        state = result["state"]
-        if state not in ("0", "1", "2"):
-            label = "ptt_unrecognised_state"
-            log = logger.debug if label in self._poll_warned_fields else logger.warning
-            self._poll_warned_fields.add(label)
-            log(
-                "read_ptt: unrecognised TX state %r from %s; failing closed (transmitting)",
-                state,
-                self.model,
-            )
-        return bool(state != "0")
+        state = await self.read_ptt_token()
+        policy = self.profile.tx_policy
+        if not policy.tx_state_map:
+            if state not in ("0", "1", "2"):
+                self._warn_ptt_unrecognised(state)
+            return state != "0"
+        if state not in policy.tx_state_map:
+            self._warn_ptt_unrecognised(state)
+        return not policy.is_receiving(state)
 
     async def get_ptt(self) -> bool:
         """Query the current PTT state.

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1016,11 +1016,14 @@ class YaesuCatRadio:
         )
 
     async def read_ptt_token(self) -> str:
-        """Read the raw ``TX;`` token verbatim -- no interpretation, no mutation.
+        """Read the raw ``TX;`` token -- no RX/TX interpretation, no mutation.
 
-        The primitive :meth:`read_ptt` is built on. Exposes the wire value
-        (``"0"``/``"1"``/``"2"`` on shipped profiles) so a caller can map
-        it through the profile's :class:`~rigplane.profiles.TxPolicy` --
+        The primitive :meth:`read_ptt` is built on. Exposes the parsed wire
+        value (``"0"``/``"1"``/``"2"`` on shipped profiles, coerced to
+        ``str`` -- a no-op today, since the ``{state}`` parse template types
+        it as ``str`` on every shipped profile, but not a guarantee for a
+        future template typed otherwise) so a caller can map it through the
+        profile's :class:`~rigplane.profiles.TxPolicy` --
         :meth:`~rigplane.profiles.TxPolicy.is_receiving` for the RX/TX
         answer, :meth:`~rigplane.profiles.TxPolicy.attribution` for the
         vendor's per-value label (MOR-1941, §3.7 of the transmit-authority

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -264,6 +264,19 @@ class TxPolicy:
         """
         return self.tx_state_map.get(raw_value) == "rx"
 
+    def attribution(self, raw_value: str) -> str | None:
+        """The vendor label mapped to ``raw_value``, or ``None`` if unmapped.
+
+        Display-grade only (MOR-1941, §3.7 of the transmit-authority ADR):
+        unlike :meth:`is_receiving`, this carries no fail-closed safety
+        rule — an unmapped value is simply ``None``, not a hazard answer.
+        Yaesu's three-valued ``TX;`` answer surfaces here as ``"rx"`` /
+        ``"tx_cat"`` / ``"tx_other"``; a vendor with no attribution (e.g.
+        Icom) never populates ``tx_state_map`` with more than ``"rx"``, so
+        this is honestly ``None`` for every other raw value.
+        """
+        return self.tx_state_map.get(raw_value)
+
 
 @dataclass(frozen=True, slots=True)
 class RadioProfile:

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -722,10 +722,15 @@ async def _actuate_tx_ptt(
             # not report a confident "did not key" when the write itself
             # was accepted (``key_refusal is None`` already means
             # ``set_ptt(True)`` did not raise) -- reporting `keyed: false`
-            # from a measurement that never happened would be exactly the
-            # fabricated-observation class §3.7 exists to eliminate, only
-            # worse: a false negative, not just an unconfirmed positive. So
-            # a read failure falls back to trusting the accepted write
+            # from a measurement that never happened would be a fabricated
+            # observation, and a false negative at that, not merely an
+            # unconfirmed positive. Note what this reasoning does and does
+            # not lean on: the transmit-authority ADR's rule that our own
+            # commands may source "transmitting" but never "receiving"
+            # licenses declining to say ``False`` here. It does not license
+            # claiming the value was verified, which is why the provenance
+            # tag below is not optional. So a read failure falls back to
+            # trusting the accepted write
             # (``ptt_state = True``), not to the mirror -- on Yaesu the
             # mirror is now permanently stale (the self-write is deleted),
             # so it is exactly as fabricated a signal as a bare ``False``

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -696,15 +696,30 @@ async def _actuate_tx_ptt(
                 evidence["key_refused"] = key_refusal
         if key_refusal is None:
             keyed = True
-            # Brief, bounded key window.
+            # Brief, bounded key window. Note: when the read-back below runs,
+            # the window is no longer bounded by ``_TX_PTT_KEY_SECONDS``
+            # alone — the read carries its own ``per_check_timeout`` budget,
+            # so worst case this stretches from ~1.0 s to ~1.0 s +
+            # ``per_check_timeout`` (default 5.0 s -> ~6.0 s total) at
+            # minimum power. Deliberately left unbounded beyond that shared
+            # budget rather than adding a second timeout constant: every
+            # other read/write in this function already spends up to
+            # ``per_check_timeout``, and the ``finally`` below unkeys and
+            # restores power unconditionally regardless of how long this
+            # takes (MOR-1941 review).
             await asyncio.sleep(_TX_PTT_KEY_SECONDS)
             # Verify the keyed state from a real read-back where the backend
             # offers one, rather than the legacy ``radio_state`` mirror
             # (MOR-1941): some backends no longer self-write that mirror
             # from ``set_ptt``, so it is not radio truth. Best-effort — a
-            # missing accessor or a read failure must not turn a good key
-            # into a FAIL, so it falls back to the mirror rather than
-            # failing the check outright.
+            # missing accessor or ANY read failure (backend-specific
+            # transport errors included, e.g. a dropped/late CAT reply
+            # inside the key window — MOR-1941 review) must not turn a good
+            # key into a FAIL, so it falls back to the mirror rather than
+            # failing the check outright. Deliberately ``except Exception``,
+            # not ``_RESTORE_ERRORS``: this function is generic across
+            # backends and must not import a specific backend's transport
+            # exception types to enumerate them.
             ptt_state = bool(radio.radio_state.ptt)
             _get_ptt_attr = getattr(radio, "get_ptt", None)
             if callable(_get_ptt_attr):
@@ -714,7 +729,7 @@ async def _actuate_tx_ptt(
                             _get_ptt_attr(), timeout=per_check_timeout
                         )
                     )
-                except _RESTORE_ERRORS:
+                except Exception:
                     pass
             evidence["ptt_state"] = ptt_state
             keyed = ptt_state

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -698,9 +698,26 @@ async def _actuate_tx_ptt(
             keyed = True
             # Brief, bounded key window.
             await asyncio.sleep(_TX_PTT_KEY_SECONDS)
-            # Verify the keyed state from published radio state (best-effort).
-            evidence["ptt_state"] = bool(radio.radio_state.ptt)
-            keyed = bool(radio.radio_state.ptt)
+            # Verify the keyed state from a real read-back where the backend
+            # offers one, rather than the legacy ``radio_state`` mirror
+            # (MOR-1941): some backends no longer self-write that mirror
+            # from ``set_ptt``, so it is not radio truth. Best-effort — a
+            # missing accessor or a read failure must not turn a good key
+            # into a FAIL, so it falls back to the mirror rather than
+            # failing the check outright.
+            ptt_state = bool(radio.radio_state.ptt)
+            _get_ptt_attr = getattr(radio, "get_ptt", None)
+            if callable(_get_ptt_attr):
+                try:
+                    ptt_state = bool(
+                        await asyncio.wait_for(
+                            _get_ptt_attr(), timeout=per_check_timeout
+                        )
+                    )
+                except _RESTORE_ERRORS:
+                    pass
+            evidence["ptt_state"] = ptt_state
+            keyed = ptt_state
             evidence["keyed"] = keyed
     except _RESTORE_ERRORS as exc:
         verify_error = str(exc)

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -607,11 +607,15 @@ async def _actuate_tx_ptt(
     """ACTUALLY key PTT briefly at minimum power, verify, then always unkey.
 
     Sequence: read original TX power → set power to MINIMUM → key PTT → brief
-    wait → read ``radio_state.ptt`` to verify it keyed → unkey → restore power.
+    wait → verify it keyed, preferring a real read-back (``get_ptt``) over the
+    legacy ``radio_state`` mirror where the backend offers one (MOR-1941; see
+    ``ptt_state_source`` in the evidence) → unkey → restore power.
     The unkey AND power-restore run in a ``finally`` that ALWAYS executes and
     never raises (contained by ``_RESTORE_ERRORS``, which includes ``OSError``),
     so a mid-check exception/timeout/LAN drop can never leave the radio keyed or
-    at the wrong power.
+    at the wrong power. (A pre-existing gap in that same ``finally`` — a
+    Yaesu transport error from the unkey call itself escaping uncontained —
+    is filed separately as MOR-1951; not this row's fix.)
 
     MOR-1222: on a managed rig both the key and the unkey go through the
     supervisor under :data:`_VALIDATION_TX_OWNER`. A refused key is a FAIL, not
@@ -711,16 +715,30 @@ async def _actuate_tx_ptt(
             # Verify the keyed state from a real read-back where the backend
             # offers one, rather than the legacy ``radio_state`` mirror
             # (MOR-1941): some backends no longer self-write that mirror
-            # from ``set_ptt``, so it is not radio truth. Best-effort — a
-            # missing accessor or ANY read failure (backend-specific
-            # transport errors included, e.g. a dropped/late CAT reply
-            # inside the key window — MOR-1941 review) must not turn a good
-            # key into a FAIL, so it falls back to the mirror rather than
-            # failing the check outright. Deliberately ``except Exception``,
-            # not ``_RESTORE_ERRORS``: this function is generic across
-            # backends and must not import a specific backend's transport
-            # exception types to enumerate them.
+            # from ``set_ptt``, so it is not radio truth on its own.
+            #
+            # Best-effort means genuinely best-effort here, on the one
+            # backend (Yaesu) this repoint exists for: a read failure must
+            # not report a confident "did not key" when the write itself
+            # was accepted (``key_refusal is None`` already means
+            # ``set_ptt(True)`` did not raise) -- reporting `keyed: false`
+            # from a measurement that never happened would be exactly the
+            # fabricated-observation class §3.7 exists to eliminate, only
+            # worse: a false negative, not just an unconfirmed positive. So
+            # a read failure falls back to trusting the accepted write
+            # (``ptt_state = True``), not to the mirror -- on Yaesu the
+            # mirror is now permanently stale (the self-write is deleted),
+            # so it is exactly as fabricated a signal as a bare ``False``
+            # would be. ``ptt_state_source`` records which of "readback" /
+            # "mirror" / "unverified-write" produced the reported value, so
+            # a PASS backed by a real read stays distinguishable from one
+            # that is not, and the failure itself is never silent — see
+            # ``ptt_read_error``. Deliberately ``except Exception``, not
+            # ``_RESTORE_ERRORS``: this function is generic across backends
+            # and must not import a specific backend's transport exception
+            # types to enumerate them (MOR-1941 review).
             ptt_state = bool(radio.radio_state.ptt)
+            ptt_state_source = "mirror"
             _get_ptt_attr = getattr(radio, "get_ptt", None)
             if callable(_get_ptt_attr):
                 try:
@@ -729,9 +747,19 @@ async def _actuate_tx_ptt(
                             _get_ptt_attr(), timeout=per_check_timeout
                         )
                     )
-                except Exception:
-                    pass
+                    ptt_state_source = "readback"
+                except Exception as exc:
+                    evidence["ptt_read_error"] = str(exc)
+                    _LOGGER.warning(
+                        "tx.ptt readback failed after a successful key; "
+                        "trusting the accepted write rather than reporting "
+                        "an unverified key as a failure: %s",
+                        exc,
+                    )
+                    ptt_state = True
+                    ptt_state_source = "unverified-write"
             evidence["ptt_state"] = ptt_state
+            evidence["ptt_state_source"] = ptt_state_source
             keyed = ptt_state
             evidence["keyed"] = keyed
     except _RESTORE_ERRORS as exc:

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -345,7 +345,7 @@ async def test_an_unmapped_transmit_state_value_is_never_receiving(
     # MUTATION (MOR-1941, restated -- the map-driven predicate replaced the
     # inline one this mutation used to target): in
     # `src/rigplane/backends/yaesu_cat/radio.py`, in `read_ptt`, change
-    # `return not policy.is_receiving(state)` at :1067 to
+    # `return not policy.is_receiving(state)` at :1070 to
     # `return policy.is_receiving(state)` -> this row goes red on the
     # `yaesu-ftx1` column (MOR-1905's own inversion direction): the unmapped
     # `TX9` reads as receiving.

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -1,0 +1,828 @@
+"""Transmit-authority conformance matrix over every shipping backend.
+
+ADR row 4 (``docs/plans/2026-08-20-transmit-authority.md`` §4 row 4, §3.10
+item 3), following the audio precedent
+(``tests/contracts/test_audio_lifecycle_conformance.py``): one scenario matrix,
+run for every shipping backend class against its fake link, with the scripted
+transmit-state answers this row also lands
+(``tests/tx_authority_fakes.py``, §3.10 item 1).
+
+**What this file proves today, and what it merely reserves.**
+
+No backend constructs a :class:`TransmitAuthority` yet — that is rows 7 and 8 —
+so the matrix runs each ADR-named row twice:
+
+*Composed rows (live).* The real engine, the real backend class and the real
+fake wire, with the admission driven from the test. These prove the component
+composes: a hazard write at scripted TX is refused and nothing reaches the
+wire; at scripted RX the solicited read precedes the write; an unmapped value
+is never receiving; an unkey is never refused; a key arms the one deadline and
+the last-resort rail fires the OFF on a fake clock.
+
+*Cutover rows (``xfail(strict=True)``).* The same behaviours driven the way a
+consumer will drive them — a plain method call, or a command through
+``create_observation_poller``'s queue drain — with **no** test-side admission.
+They fail today because the admission is not in the backend. Each names the
+migration row that turns it green. ``strict=True`` is the point: the day a
+cutover lands, the row goes red as an XPASS, which is the signal rows 7/8 need
+that their conformance obligation is met. A row is never weakened to pass
+today: an honest xfail says more than an assertion-free green.
+
+**The queue path is not optional.** §3.2's refutation of the wrapping facade
+turns on item 2: on FTX-1 and hamlib-provider radios the web write path never
+touches the radio object from outside — ``web_startup.py:126-128`` hands the
+``CommandQueue`` into ``create_observation_poller`` and the backend drains it
+against raw ``self``. A matrix that only called backend methods directly would
+prove less than it appears to, so every queue-capable column carries the same
+rows again through the drain, plus a live row proving the drain really does
+reach the backend write method — so the xfails above it rest on working
+plumbing rather than on broken test wiring.
+
+No MagicMock anywhere near the authority (CLAUDE.md hard rule, restated by
+§3.10 item 1); the fakes are plain objects and the clock is injected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+
+import pytest
+from tx_authority_fakes import (
+    CIV_NON_ANSWERS,
+    CONFORMANCE_BACKENDS,
+    NON_RECEIVING_ANSWERS,
+    QUEUE_PATH_BACKENDS,
+    TRANSMITTING_ANSWERS,
+    TX_ANSWER_VOCABULARY,
+    TxConformanceHarness,
+    build_harness,
+    civ_transmit_state_reply,
+)
+
+from rigplane.core.tx_authority import (
+    RADIO_READBACK_SOURCES,
+    TransmitAuthority,
+    TxFamily,
+    TxMethodEntry,
+    TxRefusal,
+    TxRefusalCode,
+    TxStateReading,
+    build_transmit_truth,
+)
+from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
+
+# ---------------------------------------------------------------------------
+# Pinned literals
+# ---------------------------------------------------------------------------
+
+#: The backend columns, as an explicit literal. Never computed from a registry,
+#: a factory table or an enum — the ``test_audio_transport_conformance.py:65-81``
+#: rule, so a backend that quietly stops shipping fails this file instead of
+#: silently shrinking the matrix.
+EXPECTED_BACKENDS: tuple[str, ...] = (
+    "lan-icom",
+    "icom7610-serial",
+    "ic705-serial",
+    "ic7300-serial",
+    "ic9700-serial",
+    "yaesu-ftx1",
+    "rigctld-client",
+)
+
+#: The Icom columns, whose read is a CI-V round trip under the shipped
+#: directed-exact-reply discipline. Explicit literal.
+CIV_BACKENDS: tuple[str, ...] = (
+    "lan-icom",
+    "icom7610-serial",
+    "ic705-serial",
+    "ic7300-serial",
+    "ic9700-serial",
+)
+
+#: The matrix's own method map. The shipped per-backend maps land at rows 7/8
+#: beside the methods they pin (§3.3); this literal covers exactly the methods
+#: the matrix drives, and like every other classification literal it is
+#: written out, never derived.
+CONFORMANCE_METHOD_MAP: Mapping[str, TxMethodEntry] = {
+    "set_tuner_status": TxMethodEntry(TxFamily.TUNER),
+    "set_tuner": TxMethodEntry(TxFamily.TUNER),
+    "set_vfo_slot": TxMethodEntry(TxFamily.VFO_SELECT),
+    "set_ptt": TxMethodEntry(TxFamily.PTT_ON, predicate="ptt"),
+}
+
+
+class FakeClock:
+    """Deterministic monotonic clock — the same shape ``TxSafetySupervisor``'s
+    own tests inject, and the reason no row here sleeps."""
+
+    def __init__(self, start: float = 1_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class RecordingUnkey:
+    """The authority's injected last-resort OFF rail, wired to a real backend."""
+
+    def __init__(self, harness: TxConformanceHarness) -> None:
+        self._harness = harness
+        self.calls = 0
+
+    async def __call__(self) -> None:
+        self.calls += 1
+        await self._harness.unkey()
+
+
+def build_authority(
+    harness: TxConformanceHarness,
+    *,
+    clock: FakeClock | None = None,
+    unkey: RecordingUnkey | None = None,
+) -> TransmitAuthority:
+    """The real engine over a real backend's real fake wire."""
+    return TransmitAuthority(
+        read_transmit_state=harness.read_transmit_state,
+        last_resort_unkey=unkey or RecordingUnkey(harness),
+        method_map=CONFORMANCE_METHOD_MAP,
+        clock=clock or FakeClock(),
+    )
+
+
+@pytest.fixture
+async def harness(
+    request: pytest.FixtureRequest,
+) -> AsyncIterator[TxConformanceHarness]:
+    built = await build_harness(request.param)
+    try:
+        yield built
+    finally:
+        await built.close()
+
+
+def every_backend(*names: str):
+    return pytest.mark.parametrize("harness", names or EXPECTED_BACKENDS, indirect=True)
+
+
+# ---------------------------------------------------------------------------
+# 0. The matrix declares its own shape
+# ---------------------------------------------------------------------------
+
+
+def test_backend_columns_are_an_explicit_literal() -> None:
+    """The fakes module and this file agree, and neither computes the set."""
+    assert CONFORMANCE_BACKENDS == EXPECTED_BACKENDS
+    assert set(CIV_BACKENDS) | {"yaesu-ftx1", "rigctld-client"} == set(
+        EXPECTED_BACKENDS
+    )
+
+
+def test_the_matrix_covers_the_audio_matrix_plus_the_rigctld_client() -> None:
+    """Every class the audio conformance gate ships, plus the one it excludes.
+
+    ``rigctld_client`` carries no audio surface, so it is absent there; it
+    very much ships writes, so it is present here (ADR row 8b).
+    """
+    from contracts.test_audio_transport_conformance import SHIPPING_BACKENDS
+
+    assert len(SHIPPING_BACKENDS) == 6
+    assert len(EXPECTED_BACKENDS) == len(SHIPPING_BACKENDS) + 1
+
+
+def test_queue_path_columns_are_the_observation_pollable_backends() -> None:
+    """``web_startup.py:105-193`` branch 1 — the ingress §3.2 item 2 names."""
+    assert QUEUE_PATH_BACKENDS == ("yaesu-ftx1", "rigctld-client")
+
+
+def test_scripted_answer_vocabulary_pin() -> None:
+    assert TX_ANSWER_VOCABULARY == (
+        "rx",
+        "tx_cat",
+        "tx_other",
+        "silence",
+        "refusal",
+        "unmapped",
+    )
+    assert CIV_NON_ANSWERS == ("ack", "setter_echo", "misaddressed")
+
+
+# ---------------------------------------------------------------------------
+# 1. Fake extensions (§3.10 item 1) — live
+# ---------------------------------------------------------------------------
+
+
+@every_backend()
+@pytest.mark.parametrize("answer", TX_ANSWER_VOCABULARY)
+async def test_every_backend_answers_every_scripted_answer(
+    harness: TxConformanceHarness, answer: str
+) -> None:
+    """The gate's solicited read runs the backend's real read code for each
+    scripted answer, and only a confirmed RX admits a hazard write.
+
+    This is the row that makes every other row in the file meaningful: if a
+    column could not produce the answer, its conformance rows would be
+    vacuous.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_admit_hazard`,
+    # replace `if reading.value or epoch != self._transmit_epoch:` at :619
+    # with `if epoch != self._transmit_epoch:` -> this row goes red for both
+    # transmitting answers on every column: the gate admits a hazard write
+    # while the radio answers "transmitting".
+    """
+    harness.script(answer)
+    authority = build_authority(harness)
+
+    if answer == "rx" and harness.verified_readback:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pass  # admitted: the one answer that may proceed
+        return
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: a hazard write was admitted at {answer!r}")
+
+    if answer in TRANSMITTING_ANSWERS and harness.verified_readback:
+        assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    elif answer == "unmapped":
+        # Either fail-closed direction is correct and the columns differ:
+        # Yaesu's positive map has no entry for `TX9`, so `read_ptt` answers
+        # *transmitting*; the CI-V and hamlib-provider columns produce no
+        # value at all. What must never happen is admission.
+        assert excinfo.value.code in tuple(TxRefusalCode)
+    else:
+        assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+    assert excinfo.value.evidence is not None  # INV-14
+
+
+@every_backend()
+async def test_a_confirmed_rx_and_a_keyed_radio_read_their_values(
+    harness: TxConformanceHarness,
+) -> None:
+    """The scripted answers are distinguishable on the wire, not merely named."""
+    harness.script("rx")
+    assert (await harness.read_transmit_state()).value is False
+    harness.script("tx_cat")
+    assert (await harness.read_transmit_state()).value is True
+    harness.script("tx_other")
+    assert (await harness.read_transmit_state()).value is True
+
+
+@pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
+@pytest.mark.parametrize("shape", CIV_NON_ANSWERS)
+async def test_a_civ_read_is_not_satisfied_by_an_ack_echo_or_misaddressed_frame(
+    harness: TxConformanceHarness, shape: str
+) -> None:
+    """INV-13 on the CI-V family: the read is directed and exact.
+
+    An ACK, our own setter echo and a frame from a foreign bus address all go
+    onto the wire; none of them may answer the read. The discrimination is the
+    product's (``_civ_rx.py:1489-1492`` routing guards, ``:2636-2650``
+    provenance narrowing), not the fake's — the fake queues the bytes and asks
+    what the shipped code does with them.
+
+    # MUTATION (two edits, because two shipped checks stand in series): in
+    # `src/rigplane/runtime/_civ_rx.py`, (a) delete both routing guards at
+    # :1489-1492 (`from_addr != radio_addr` and `to_addr not in
+    # (CONTROLLER_ADDR, 0x00)`), and (b) replace the six conjuncts at
+    # :2639-2645 with `frame.command == 0x1C\n and frame.sub == 0x00`
+    # -> the `setter_echo` and `misaddressed` cases go red on all five CI-V
+    # columns (10 rows): both carry a `00` data byte, so a widened
+    # classification makes each of them answer "receiving".
+    # Deleting only guard (a) kills nothing — verified — because the
+    # provenance narrowing at (b) re-checks `from_addr` itself; the `ack`
+    # case is held by a third mechanism again, the decode ladder having no
+    # PTT branch for `0xFB` at all, and survives this mutation.
+    """
+    harness.script(shape)
+    reading = await harness.read_transmit_state()
+    assert reading.value is None, f"{harness.name}: {shape} satisfied the read"
+
+    authority = build_authority(harness)
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: {shape} admitted a hazard write")
+    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+
+
+@pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
+async def test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed(
+    harness: TxConformanceHarness,
+) -> None:
+    """The unmapped CI-V answer is a fail-open canary, not junk.
+
+    ``1C 00`` + ``00 00`` carries a leading ``0x00``: if the exact-shape check
+    were loosened it would decode as *receiving* and admit a relay throw. A
+    junk byte would decode as transmitting and could never catch that.
+
+    # MUTATION: in `src/rigplane/runtime/_civ_rx.py`, delete the
+    # `and len(frame.data) == 1` conjunct at :2643 -> this row goes red: the
+    # two-byte reply earns `poll_response` and reads as receiving.
+    """
+    frame = civ_transmit_state_reply("unmapped", harness.radio._radio_addr)
+    assert frame is not None and frame[-2:-1] == b"\x00"
+
+    harness.script("unmapped")
+    reading = await harness.read_transmit_state()
+    assert reading.value is not False, "an unmapped CI-V shape read as receiving"
+    assert reading.value is None
+    assert reading.failure is not None  # INV-14: the cause travels
+
+
+@every_backend()
+async def test_an_unmapped_transmit_state_value_is_never_receiving(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-9 / §3.7: RX is only ever produced by a positive mapping.
+
+    On Yaesu the unmapped ``TX9`` fails closed to *transmitting*; on the CI-V
+    and hamlib-provider columns it produces no value at all. Both are "not
+    receiving"; neither may admit a hazard write.
+
+    # MUTATION: in `src/rigplane/backends/yaesu_cat/radio.py`, change
+    # `return bool(state != "0")` at :1027 to `return bool(state == "1")`
+    # -> this row goes red on the `yaesu-ftx1` column (MOR-1905's own
+    # mutation): the unmapped `TX9` reads as receiving.
+    """
+    harness.script("unmapped")
+    reading = await harness.read_transmit_state()
+    assert reading.value is not False, f"{harness.name}: unmapped value read as RX"
+
+    authority = build_authority(harness)
+    with pytest.raises(TxRefusal):
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: an unmapped value admitted a hazard write")
+
+
+@every_backend()
+@pytest.mark.parametrize("answer", NON_RECEIVING_ANSWERS)
+async def test_no_failing_answer_ever_resolves_to_receiving(
+    harness: TxConformanceHarness, answer: str
+) -> None:
+    """Silence, a refusal and an unmapped value all fail closed (§3.3 table)."""
+    harness.script(answer)
+    assert (await harness.read_transmit_state()).value is not False
+
+
+# ---------------------------------------------------------------------------
+# 2. Composed conformance — the real engine over the real backend, live
+# ---------------------------------------------------------------------------
+
+
+@every_backend()
+async def test_a_hazard_write_at_scripted_tx_is_refused_and_no_wire_write_occurs(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 1. The refusal is worthless if the bytes went anyway.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
+    # `if write_class is TxWriteClass.PASS:` at :522 to
+    # `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` -> this
+    # row goes red: the hazard write is yielded with no truth consulted and
+    # the tuner frame reaches the wire during transmit.
+    """
+    harness.script("tx_cat")
+    authority = build_authority(harness)
+    writes_before = len(harness.writes())
+
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            await harness.hazard()
+
+    assert harness.writes()[writes_before:] == [], (
+        f"{harness.name}: a refused hazard write still reached the wire"
+    )
+    if harness.verified_readback:
+        assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    else:
+        # §3.7: the hamlib-provider answer is an upstream cache, never radio
+        # truth, so its hazard families are fail-closed by provenance.
+        assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
+        assert excinfo.value.evidence.failure == "unverifiable-provenance"
+
+
+@every_backend(*CIV_BACKENDS, "yaesu-ftx1")
+async def test_a_hazard_write_at_scripted_rx_reads_before_it_writes(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 2: on the wire, the read precedes the write.
+
+    Counts cannot see this — both happen either way. Only the order on the
+    wire distinguishes a solicited read from a cached one (T3/INV-4).
+
+    The ``rigctld-client`` column is absent by design, not by omission: its
+    readback is permanently unverifiable (§3.7), so it never reaches a write
+    to order the read against. ``test_..._refused_and_no_wire_write_occurs``
+    covers it instead.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
+    # `if write_class is TxWriteClass.PASS:` at :522 to
+    # `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` -> this
+    # row goes red: no read frame precedes the write on any column.
+    """
+    harness.script("rx")
+    authority = build_authority(harness)
+    baseline = len(harness.wire())
+
+    async with authority.admit(harness.hazard_method, harness.hazard_args):
+        await harness.hazard()
+
+    wire = list(harness.wire())[baseline:]
+    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
+    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
+    assert reads, f"{harness.name}: the hazard admission performed no read"
+    assert writes, f"{harness.name}: the admitted hazard write never happened"
+    assert reads[-1] < writes[0], (
+        f"{harness.name}: the write preceded the read it was authorised by: {wire}"
+    )
+
+
+@every_backend()
+@pytest.mark.parametrize("answer", ["tx_cat", "silence", "unmapped"])
+async def test_an_unkey_is_never_refused(
+    harness: TxConformanceHarness, answer: str
+) -> None:
+    """§3.10 item 3, row 6 / INV-5: the one-sided unkey, on every column.
+
+    Driven under the most hostile truth each wire can produce — keyed, silent,
+    unmapped — because an unkey that only works when truth is healthy is not
+    the doctrine (``managed_tx_ingress.py:1-21``).
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, insert
+    # `raise TxRefusal(TxRefusalCode.TX_TRUTH_UNAVAILABLE, TxEvidence())` as
+    # the first statement of the `if write_class is TxWriteClass.UNKEY:`
+    # branch at :526 -> this row goes red on every column.
+    """
+    harness.script(answer)
+    authority = build_authority(harness)
+    writes_before = len(harness.writes())
+
+    async with authority.admit("set_ptt", (False,)):
+        await harness.unkey()
+
+    assert harness.writes()[writes_before:], f"{harness.name}: the unkey never landed"
+
+
+@every_backend()
+async def test_our_own_key_makes_the_gate_stricter_never_looser(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-16 / §3.7's own-commands rule, composed over a real backend.
+
+    The wire is scripted to answer *receiving* throughout — the B6 blind spot,
+    where the IC-7300 reported RX while audibly still sending. Our own key
+    must refuse the hazard write anyway, with no wire read at all.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_admit_hazard`,
+    # delete the step-1 `if held is not None:` refusal at :580-584 -> this row
+    # goes red on every column: the scripted RX answer clears our own key.
+    """
+    harness.script("rx")
+    authority = build_authority(harness)
+
+    async with authority.admit("set_ptt", (True,)):
+        await harness.key()
+
+    reads_before = len(harness.reads())
+    with pytest.raises(TxRefusal) as excinfo:
+        async with authority.admit(harness.hazard_method, harness.hazard_args):
+            pytest.fail(f"{harness.name}: a hazard write ran during our own key")
+
+    assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
+    assert excinfo.value.evidence.own_transmit_hold == "key"
+    assert harness.reads()[reads_before:] == [], (
+        f"{harness.name}: the own-transmit refusal touched the wire"
+    )
+
+
+@every_backend()
+async def test_a_key_arms_the_one_deadline_and_the_off_fires_on_a_fake_clock(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 5, backend half: the arm and the last-resort rail.
+
+    The three *shipped* drivers (web ``call_later``, the observation poller's
+    drain, the rigctld drain) arrive at rows 12a/12b and are reserved below;
+    what is live here is that a key through the authority arms the one
+    deadline and that the OFF, once due, reaches the real backend's real
+    unkey on the real wire.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_commit`, change
+    # `self._deadline = deadline` at :651 to `self._deadline = None` -> this
+    # row goes red on every column: the key arms nothing and no OFF is due.
+    """
+    harness.script("rx")
+    clock = FakeClock()
+    unkey = RecordingUnkey(harness)
+    authority = build_authority(harness, clock=clock, unkey=unkey)
+
+    async with authority.admit("set_ptt", (True,)):
+        await harness.key()
+
+    assert authority.view().deadline_monotonic == pytest.approx(
+        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
+    )
+    assert authority.poll(clock.now) == (), "the deadline fired early"
+
+    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS + 0.001)
+    due = authority.poll(clock.now)
+    assert len(due) == 1
+
+    writes_before = len(harness.writes())
+    await authority.fire_last_resort_unkey()
+    assert unkey.calls == 1
+    assert harness.writes()[writes_before:], (
+        f"{harness.name}: the due OFF never reached the wire"
+    )
+
+
+@every_backend()
+async def test_a_pass_class_write_never_consults_transmit_truth(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-3, composed: a poisoned read must not be reachable from PASS.
+
+    ``set_ptt(False)`` resolves through the T5 short circuit and ``set_freq``
+    is absent from the matrix map, so the row uses the unkey — the one write
+    that is structurally ahead of every table.
+    """
+
+    async def poisoned() -> TxStateReading:  # pragma: no cover - must not run
+        raise AssertionError("transmit truth was consulted on a non-hazard write")
+
+    authority = TransmitAuthority(
+        read_transmit_state=poisoned,
+        last_resort_unkey=RecordingUnkey(harness),
+        method_map=CONFORMANCE_METHOD_MAP,
+        clock=FakeClock(),
+    )
+    async with authority.admit("set_ptt", (False,)):
+        await harness.unkey()
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+async def test_the_queue_drain_reaches_the_backend_write_method(
+    harness: TxConformanceHarness,
+) -> None:
+    """The D1 ingress is real, and this file can drive it.
+
+    Live on purpose: the queue-path cutover rows below are ``xfail``, and an
+    xfail proves nothing if the plumbing under it never worked. ``PttOff`` is
+    the probe because it is ``ALWAYS_PASS`` at the old seat still standing
+    above the authority (row 11 deletes that seat), so this row measures the
+    drain rather than the seat.
+    """
+    harness.script("rx")
+    queue = harness.extras["queue"]
+    assert harness.drain is not None and harness.queue_unkey is not None
+
+    writes_before = len(harness.writes())
+    queue.put_ordered(harness.queue_unkey)
+    await harness.drain()
+
+    assert harness.writes()[writes_before:], (
+        f"{harness.name}: a queued command never reached the backend write method"
+    )
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+async def test_a_set_ptt_write_alone_produces_no_observation(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.10 item 3, row 7 / INV-8: a write outcome is never evidence of RF.
+
+    The observation callback the web hands ``create_observation_poller`` must
+    stay silent for a bare ``set_ptt`` — only a readback may claim transmit
+    truth.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, add
+    # `"command_response"` to the `RADIO_READBACK_SOURCES` frozenset at
+    # :49-51 -> the sources half of this row goes red.
+    """
+    observations = harness.extras["observations"]
+    observations.clear()
+
+    await harness.key()
+    await harness.unkey()
+
+    laundered = [
+        obs
+        for obs in observations
+        if str(obs.path) == "global.tx_state.ptt"
+        and str(obs.source.source) not in RADIO_READBACK_SOURCES
+    ]
+    assert observations == [] or laundered == [], (
+        f"{harness.name}: a self-write produced a transmit-truth observation"
+    )
+    assert "command_response" not in RADIO_READBACK_SOURCES
+    assert "state_poller" not in RADIO_READBACK_SOURCES
+
+
+@pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
+async def test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth(
+    harness: TxConformanceHarness,
+) -> None:
+    """The same row on the CI-V columns, read off the canonical store."""
+    await harness.key()
+    await harness.unkey()
+    await asyncio.sleep(0)
+
+    store = harness.radio._state_store
+    truth = build_transmit_truth(
+        store.snapshot(), provider_generation=store.provider_generation
+    )
+    assert truth.value is None, f"{harness.name}: our own set_ptt became transmit truth"
+
+
+# ---------------------------------------------------------------------------
+# 3. Cutover rows — reserved, individually reasoned, strict
+# ---------------------------------------------------------------------------
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 7 (Icom) / row 8 (Yaesu, rigctld-client): no backend "
+    "constructs a TransmitAuthority yet, so INV-15 cannot hold. Turns green "
+    "when the admission is constructed in every connect path.",
+)
+async def test_a_backend_constructs_its_own_transmit_authority(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-15: no gated write executes without a constructed authority."""
+    authority = getattr(harness.radio, "_tx_authority", None)
+    assert isinstance(authority, TransmitAuthority)
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 7 (Icom) / row 8 (Yaesu, rigctld-client): the admission call "
+    "is not yet at the top of the gated write methods, so a plain method "
+    "call is ungated. The composed row above already proves the engine "
+    "refuses; this reserves the seat inside the backend.",
+)
+async def test_a_backend_method_call_is_refused_at_scripted_tx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 1, driven the way every consumer drives it."""
+    harness.script("tx_cat")
+    writes_before = len(harness.writes())
+    with pytest.raises(TxRefusal):
+        await harness.hazard()
+    assert harness.writes()[writes_before:] == []
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5 (the read primitive) + row 7/8 (the admission): a plain "
+    "method call performs no solicited read, so nothing precedes the write.",
+)
+async def test_a_backend_method_call_reads_before_it_writes_at_scripted_rx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 2, driven the way every consumer drives it."""
+    harness.script("rx")
+    baseline = len(harness.wire())
+    await harness.hazard()
+    wire = list(harness.wire())[baseline:]
+    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
+    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
+    assert reads and writes and reads[-1] < writes[0]
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 8 (the admission at each backend's real write surface) and, "
+    "on Yaesu, row 11 (deleting the poller's own seat above it): the queue "
+    "drain reaches an ungated backend body. This is the D1 ingress §3.2 "
+    "item 2 names — the one a wrapping facade could never have seen.",
+)
+async def test_a_queued_hazard_write_is_refused_at_scripted_tx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 1 again, through ``create_observation_poller``'s drain."""
+    harness.script("tx_cat")
+    queue = harness.extras["queue"]
+    assert harness.drain is not None
+
+    writes_before = len(harness.writes())
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    queue.put_ordered(harness.queue_command, future=future)
+    await harness.drain()
+
+    assert future.done()
+    assert isinstance(future.exception(), TxRefusal)
+    assert harness.writes()[writes_before:] == []
+
+
+@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5 (the read primitive) + row 8 (the admission) and, on "
+    "Yaesu, row 11: the drain reaches the backend body with no solicited "
+    "read in front of it.",
+)
+async def test_a_queued_hazard_write_reads_before_it_writes_at_scripted_rx(
+    harness: TxConformanceHarness,
+) -> None:
+    """The ADR's row 2 again, through the queue ingress."""
+    harness.script("rx")
+    queue = harness.extras["queue"]
+    assert harness.drain is not None
+
+    baseline = len(harness.wire())
+    queue.put_ordered(harness.queue_command)
+    await harness.drain()
+
+    wire = list(harness.wire())[baseline:]
+    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
+    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
+    assert reads and writes and reads[-1] < writes[0]
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5: `read_transmit_state()` lands on the new capability "
+    "protocol `TransmitStateReadable` (5a Icom, 5b Yaesu + rigctld-client). "
+    "The harness assembles the equivalent from shipped parts meanwhile.",
+)
+async def test_a_backend_exposes_the_row_five_read_primitive(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-13's home: one primitive, per backend, returning typed evidence."""
+    reading = await harness.radio.read_transmit_state()
+    assert isinstance(reading, TxStateReading)
+
+
+@pytest.mark.parametrize("harness", ["rigctld-client"], indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 5b: the backend's own primitive must carry "
+    "`verified_readback=False` permanently (§3.7). The harness already marks "
+    "it, and the composed refusal row above proves the gate honours the "
+    "marking; this reserves the marking on the shipped primitive.",
+)
+async def test_the_rigctld_client_primitive_marks_its_readback_unverified(
+    harness: TxConformanceHarness,
+) -> None:
+    harness.script("rx")
+    reading = await harness.radio.read_transmit_state()
+    assert reading.verified_readback is False
+
+
+@pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 6 (Yaesu truth honesty): `tx_state_map` turns the "
+    "three-valued `TX;` answer into an attribution. Today `read_ptt` "
+    "collapses it to a bool, so `tx_other` (the front-panel key) is "
+    "indistinguishable from `tx_cat` in the evidence.",
+)
+async def test_yaesu_attribution_reaches_the_evidence(
+    harness: TxConformanceHarness,
+) -> None:
+    """§3.7: attribution is a per-vendor capability, carried not discarded."""
+    harness.script("tx_other")
+    assert (await harness.read_transmit_state()).attributed == "tx_other"
+    harness.script("tx_cat")
+    assert (await harness.read_transmit_state()).attributed == "tx_cat"
+
+
+@pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
+@pytest.mark.xfail(
+    strict=True,
+    reason="row 6: `set_ptt` self-mutates the legacy mirror "
+    "(`backends/yaesu_cat/radio.py:994`). The row deletes that write; until "
+    "then our own command is still a claim about RF somewhere in the tree.",
+)
+async def test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere(
+    harness: TxConformanceHarness,
+) -> None:
+    """The self-write launder, at its last surviving Yaesu address."""
+    before = harness.radio._state.ptt
+    await harness.key()
+    assert harness.radio._state.ptt == before
+
+
+@every_backend()
+@pytest.mark.xfail(
+    strict=True,
+    reason="rows 12a/12b: the shipped deadline drivers. 12a wires the web "
+    "`call_later` (Icom branch) and the observation poller's drain to the "
+    "authority's deadline, both enqueuing `PttOff`; 12b wires the rigctld "
+    "drain and the Icom backend loops. Until then the only rail is the "
+    "authority's own last resort, which the live row above already exercises.",
+)
+async def test_a_shipped_driver_polls_the_authority_deadline(
+    harness: TxConformanceHarness,
+) -> None:
+    """INV-7: every delivery carries a driver for the one deadline."""
+    driver = getattr(harness.radio, "_tx_authority_deadline_driver", None)
+    assert driver is not None

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -778,17 +778,15 @@ async def test_the_rigctld_client_primitive_marks_its_readback_unverified(
 
 
 @pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 6 (Yaesu truth honesty): `tx_state_map` turns the "
-    "three-valued `TX;` answer into an attribution. Today `read_ptt` "
-    "collapses it to a bool, so `tx_other` (the front-panel key) is "
-    "indistinguishable from `tx_cat` in the evidence.",
-)
 async def test_yaesu_attribution_reaches_the_evidence(
     harness: TxConformanceHarness,
 ) -> None:
-    """§3.7: attribution is a per-vendor capability, carried not discarded."""
+    """§3.7: attribution is a per-vendor capability, carried not discarded.
+
+    MOR-1941 (row 6): ``tx_state_map`` turns the three-valued ``TX;``
+    answer into an attribution, so ``tx_other`` (the front-panel key) is
+    now distinguishable from ``tx_cat`` in the evidence.
+    """
     harness.script("tx_other")
     assert (await harness.read_transmit_state()).attributed == "tx_other"
     harness.script("tx_cat")
@@ -796,16 +794,15 @@ async def test_yaesu_attribution_reaches_the_evidence(
 
 
 @pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 6: `set_ptt` self-mutates the legacy mirror "
-    "(`backends/yaesu_cat/radio.py:994`). The row deletes that write; until "
-    "then our own command is still a claim about RF somewhere in the tree.",
-)
 async def test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere(
     harness: TxConformanceHarness,
 ) -> None:
-    """The self-write launder, at its last surviving Yaesu address."""
+    """The self-write launder, at its last surviving Yaesu address.
+
+    MOR-1941 (row 6): ``set_ptt`` no longer self-mutates the legacy
+    mirror (``backends/yaesu_cat/radio.py:994``) -- our own command is no
+    longer a claim about RF anywhere in the tree.
+    """
     before = harness.radio._state.ptt
     await harness.key()
     assert harness.radio._state.ptt == before

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -342,10 +342,13 @@ async def test_an_unmapped_transmit_state_value_is_never_receiving(
     and hamlib-provider columns it produces no value at all. Both are "not
     receiving"; neither may admit a hazard write.
 
-    # MUTATION: in `src/rigplane/backends/yaesu_cat/radio.py`, change
-    # `return bool(state != "0")` at :1027 to `return bool(state == "1")`
-    # -> this row goes red on the `yaesu-ftx1` column (MOR-1905's own
-    # mutation): the unmapped `TX9` reads as receiving.
+    # MUTATION (MOR-1941, restated -- the map-driven predicate replaced the
+    # inline one this mutation used to target): in
+    # `src/rigplane/backends/yaesu_cat/radio.py`, in `read_ptt`, change
+    # `return not policy.is_receiving(state)` at :1067 to
+    # `return policy.is_receiving(state)` -> this row goes red on the
+    # `yaesu-ftx1` column (MOR-1905's own inversion direction): the unmapped
+    # `TX9` reads as receiving.
     """
     harness.script("unmapped")
     reading = await harness.read_transmit_state()

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -16,6 +16,7 @@ from rigplane.backends.yaesu_cat.parser import CatParseError
 from rigplane.backends.yaesu_cat.transport import CatTimeoutError
 from rigplane.exceptions import CommandError
 from rigplane.exceptions import ConnectionError as RadioConnectionError
+from rigplane.profiles import TxPolicy
 from rigplane.rig_loader import load_rig
 from rigplane.types import BreakInMode
 
@@ -320,18 +321,28 @@ async def test_set_powerstat_off(connected_radio):
 
 @pytest.mark.asyncio
 async def test_set_ptt_on(connected_radio):
+    """MOR-1941: ``set_ptt`` no longer self-writes the legacy mirror. Our
+    own command is a claim about the wire, never receive/transmit truth
+    (§3.7 of the transmit-authority ADR) -- the mirror is left exactly as
+    it was, and only a real read-back (``get_ptt``) may change it.
+    """
     connected_radio._transport.write = AsyncMock()
     await connected_radio.set_ptt(True)
     connected_radio._transport.write.assert_called_once_with("TX1;")
-    assert connected_radio.radio_state.ptt is True
+    assert connected_radio.radio_state.ptt is False
 
 
 @pytest.mark.asyncio
 async def test_set_ptt_off(connected_radio):
+    """MOR-1941: same pin as ``test_set_ptt_on``, other direction. The
+    mirror is seeded away from what the write would have produced, so a
+    reintroduced self-write would flip it and fail this either way.
+    """
     connected_radio._transport.write = AsyncMock()
+    connected_radio.radio_state.ptt = True
     await connected_radio.set_ptt(False)
     connected_radio._transport.write.assert_called_once_with("TX0;")
-    assert connected_radio.radio_state.ptt is False
+    assert connected_radio.radio_state.ptt is True
 
 
 @pytest.mark.asyncio
@@ -353,11 +364,15 @@ async def test_get_ptt_receiving(connected_radio):
 
 @pytest.mark.asyncio
 async def test_get_ptt_transmitting_radio_keyed(connected_radio):
-    """MOR-1905: TX2; = RADIO TX on, CAT TX off -> transmitting.
+    """MOR-1905/MOR-1941: TX2; = RADIO TX on, CAT TX off -> transmitting.
 
     P1=2 means the radio itself keyed the transmitter (front-panel PTT,
     mic, footswitch, VOX) rather than a CAT command. Reading this as
-    "receiving" is a fail-open inversion of transmit truth.
+    "receiving" is a fail-open inversion of transmit truth. The predicate
+    that decides it is now the profile's ``[tx_policy].tx_state_map``
+    (MOR-1941) rather than an inline ``!= "0"`` comparison; the shipped
+    ftx1 map is ``{"0": "rx", "1": "tx_cat", "2": "tx_other"}``, so the
+    answer here is unchanged, only how it is reached.
     """
     connected_radio._transport.query = AsyncMock(return_value="TX2")
     ptt = await connected_radio.get_ptt()
@@ -367,7 +382,10 @@ async def test_get_ptt_transmitting_radio_keyed(connected_radio):
 
 @pytest.mark.asyncio
 async def test_read_ptt_transmitting_radio_keyed(connected_radio):
-    """MOR-1905: read_ptt (not just get_ptt) must fail closed on TX2;."""
+    """MOR-1905/MOR-1941: read_ptt (not just get_ptt) must fail closed on
+    TX2;, now via the ``tx_state_map`` route rather than the inline
+    predicate it replaced.
+    """
     connected_radio._transport.query = AsyncMock(return_value="TX2")
     assert await connected_radio.read_ptt() is True
 
@@ -402,6 +420,30 @@ async def test_get_ptt_unexpected_value_warns_once_then_demotes_to_debug(
         await connected_radio.get_ptt()
     assert not any(record.levelname == "WARNING" for record in caplog.records)
     assert any(record.levelname == "DEBUG" for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_read_ptt_falls_back_to_the_legacy_predicate_when_unmeasured(config):
+    """MOR-1941: a profile that ships no ``[tx_policy].tx_state_map`` at
+    all -- every rig this backend has not bench-measured -- must not read
+    as permanently transmitting. ``TxPolicy.is_receiving`` treats an
+    *empty* map exactly like an unmapped value: always not-receiving, so
+    calling it directly here would make an unmeasured radio unwritable to
+    RX. The fallback restores the pre-MOR-1941 ``!= "0"`` predicate
+    instead, because ``"0"`` is the Yaesu CAT protocol's own receive
+    token, not a per-radio measured value -- a vendor-level default, not
+    a hardcoded radio constant.
+    """
+    cfg = config
+    object.__setattr__(cfg, "tx_policy", TxPolicy())
+    r = YaesuCatRadio("/dev/null", profile=cfg)
+    r._transport._connected = True
+
+    r._transport.query = AsyncMock(return_value="TX0")
+    assert await r.read_ptt() is False
+
+    r._transport.query = AsyncMock(return_value="TX1")
+    assert await r.read_ptt() is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -433,6 +433,22 @@ async def test_read_ptt_falls_back_to_the_legacy_predicate_when_unmeasured(confi
     instead, because ``"0"`` is the Yaesu CAT protocol's own receive
     token, not a per-radio measured value -- a vendor-level default, not
     a hardcoded radio constant.
+
+    ``TX2`` is the value that matters here and the reason this test is not
+    just ``TX0``/``TX1``. This branch is the default for **every** Yaesu
+    rig except the one bench-measured profile -- any user TOML for an
+    FT-991A or FT-710 with the same three-valued ``TX;`` lands on it -- and
+    it holds the one surviving equality predicate in ``read_ptt``, so it
+    is the one place MOR-1905 could be written again. A pin over ``TX0``
+    and ``TX1`` alone cannot see that: both answers are identical under
+    the inversion. Only the radio-keyed value discriminates.
+
+    # MUTATION: in `src/rigplane/backends/yaesu_cat/radio.py`, at :1067
+    # (the fallback branch, NOT the mapped return at :1070), change
+    # `return state != "0"` to `return state == "1"` -> the TX2 case
+    # below reads a front-panel key as receiving and goes red. Mutating
+    # :1070 instead leaves this row green: that line serves the mapped
+    # path, which an unmeasured profile never reaches.
     """
     cfg = config
     object.__setattr__(cfg, "tx_policy", TxPolicy())
@@ -443,6 +459,15 @@ async def test_read_ptt_falls_back_to_the_legacy_predicate_when_unmeasured(confi
     assert await r.read_ptt() is False
 
     r._transport.query = AsyncMock(return_value="TX1")
+    assert await r.read_ptt() is True
+
+    # The radio keyed itself -- front panel, mic, footswitch or VOX.
+    r._transport.query = AsyncMock(return_value="TX2")
+    assert await r.read_ptt() is True
+
+    # Unrecognised, and still not receiving: the fallback is a positive
+    # rule with a one-entry map, not an equality test against "1".
+    r._transport.query = AsyncMock(return_value="TX9")
     assert await r.read_ptt() is True
 
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -798,6 +798,31 @@ tx_state_map = { "0" = "rx", "1" = "tx_cat" }
         assert policy.is_receiving("unrecognised") is False
         assert TxPolicy().is_receiving("0") is False
 
+    def test_attribution_returns_the_mapped_label_or_none(self, tmp_path):
+        """MOR-1941, §3.7: attribution is a per-vendor capability, carried
+        not discarded. ``attribution`` surfaces the raw ``tx_state_map``
+        label (e.g. Yaesu's "tx_cat" vs "tx_other") for display; unlike
+        ``is_receiving`` it carries no fail-closed safety rule of its own
+        -- an unmapped value is simply ``None``, not a hazard answer.
+        """
+        p = _write_toml(
+            tmp_path,
+            _MINIMAL_TOML
+            + """
+
+[tx_policy]
+tx_state_map = { "0" = "rx", "1" = "tx_cat", "2" = "tx_other" }
+""",
+        )
+
+        policy = load_rig(p).tx_policy
+
+        assert policy.attribution("0") == "rx"
+        assert policy.attribution("1") == "tx_cat"
+        assert policy.attribution("2") == "tx_other"
+        assert policy.attribution("unrecognised") is None
+        assert TxPolicy().attribution("0") is None
+
 
 class TestControlDomainSchema:
     _LINEAR = """\

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -836,7 +836,18 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
     """INV-4: the admission lock spans the read and the write it authorised.
 
     Counts cannot see this — both writes happen either way. Only the *order*
-    of the effects distinguishes a held lock from an open window.
+    of the effects distinguishes a held lock from an open window, and only if
+    the hazard body *awaits*: every real transport write does, and a purely
+    synchronous body reaches its append before the loop can schedule anybody
+    else, so it cannot tell a lock held through the write handoff from one
+    released at the verdict.
+
+    # MUTATION: in `src/rigplane/core/tx_authority.py`, dedent the
+    # `try:/yield ticket/finally:/self._commit(...)` block at :538-543 by one
+    # level so it sits after the `async with self._lock:` body rather than
+    # inside it -> this row goes red with
+    # `["key-write", "hazard-relay-throw"]`: a key completed inside the
+    # relay-throw window.
     """
     clock = Clock()
     link = FakeTransmitStateLink(clock)
@@ -848,7 +859,8 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
 
     async def hazard() -> None:
         async with authority.admit("set_antenna_1", ()):
-            order.append("hazard-write")
+            await asyncio.sleep(0)  # the write handoff every transport makes
+            order.append("hazard-relay-throw")
 
     async def key() -> None:
         async with authority.admit("set_ptt", (True,)):
@@ -864,7 +876,7 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
 
     link.release_read.set()
     await asyncio.gather(hazard_task, key_task)
-    assert order == ["hazard-write", "key-write"]
+    assert order == ["hazard-relay-throw", "key-write"]
 
 
 async def test_a_receive_observation_never_clears_anything() -> None:

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -1,0 +1,558 @@
+"""Scripted transmit-state fakes for the transmit-authority conformance matrix.
+
+ADR row 4, ``docs/plans/2026-08-20-transmit-authority.md`` §3.10 item 1: the
+existing fake harnesses, extended with a **scripted transmit-state answer** so
+the hazard gate's solicited read exercises the real code path rather than a
+hand-written stub of it.
+
+One vocabulary, three wires. Each backend family answers the same six scripted
+answers over its own real read code:
+
+======================  ==========================  ==============  ==============
+answer                  CI-V (Icom)                 Yaesu CAT       rigctld client
+======================  ==========================  ==============  ==============
+``rx``                  directed ``1C 00`` + ``00`` ``TX0``         ``0``
+``tx_cat``              directed ``1C 00`` + ``01`` ``TX1``         ``1``
+``tx_other``            (Icom carries no            ``TX2``         (upstream
+                        attribution — §3.7)                         carries none)
+``silence``             no reply at all             read times out  delayed past
+                                                                    the deadline
+``refusal``             NAK ``FA``                  ``?;``          malformed line
+``unmapped``            ``1C 00`` + ``00 00``       ``TX9``         ``9``
+======================  ==========================  ==============  ==============
+
+The CI-V column additionally scripts three shapes that must **never** satisfy a
+read (INV-13): an ACK, a setter echo, and a mis-addressed frame. They are not
+filtered here — they go onto the wire and are rejected by the shipped
+directed-exact-reply discipline (``runtime/_civ_rx.py:1489-1492`` routing
+guards and ``:2636-2650`` provenance narrowing), which is the whole point: the
+fake proves the *product's* validation discriminates, not its own.
+
+The ``unmapped`` CI-V answer is deliberately ``00 00`` rather than a junk byte.
+Its first byte is ``0x00``, so if the shape check were ever loosened it would
+decode as **receiving** — the fail-open direction. A junk byte like ``0x02``
+would decode as transmitting and could not catch that class of regression.
+
+No MagicMock anywhere (CLAUDE.md hard rule, restated for this row by §3.10
+item 1): every fake here is a plain object with real methods.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer, FakeRigctldState
+from test_radio import MockTransport
+
+from _helpers import wrap_civ_in_udp
+from rigplane.backends.ic705 import Ic705SerialRadio
+from rigplane.backends.ic7300 import Ic7300SerialRadio
+from rigplane.backends.ic9700 import Ic9700SerialRadio
+from rigplane.backends.icom7610 import Icom7610SerialRadio
+from rigplane.backends.rigctld_client.radio import RigctldClientRadio
+from rigplane.backends.yaesu_cat import YaesuCatRadio
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.core.exceptions import CommandError
+from rigplane.core.tx_authority import RADIO_READBACK_SOURCES, TxStateReading
+from rigplane.radio import IcomRadio
+
+# ---------------------------------------------------------------------------
+# The scripted answer vocabulary
+# ---------------------------------------------------------------------------
+
+TxAnswer = Literal["rx", "tx_cat", "tx_other", "silence", "refusal", "unmapped"]
+
+#: Explicit literal, never computed from a type or an enum — the
+#: ``test_audio_transport_conformance.py:65-81`` rule.
+TX_ANSWER_VOCABULARY: tuple[TxAnswer, ...] = (
+    "rx",
+    "tx_cat",
+    "tx_other",
+    "silence",
+    "refusal",
+    "unmapped",
+)
+
+#: The CI-V shapes that must never satisfy a read (INV-13). Also an explicit
+#: literal.
+CIV_NON_ANSWERS: tuple[str, ...] = ("ack", "setter_echo", "misaddressed")
+
+#: Answers that mean "the radio is transmitting". Explicit, never derived.
+TRANSMITTING_ANSWERS: tuple[TxAnswer, ...] = ("tx_cat", "tx_other")
+
+#: Answers that must never resolve to *receiving* on any backend: the read
+#: failed, the radio refused, or the value is outside the positive map (§3.7).
+NON_RECEIVING_ANSWERS: tuple[TxAnswer, ...] = ("silence", "refusal", "unmapped")
+
+_PTT_FIELD = "global.tx_state.ptt"
+
+#: A CI-V address that is not any bench radio's, for the mis-addressed shape.
+FOREIGN_CIV_ADDR = 0x88
+
+
+def civ_transmit_state_reply(answer: str, radio_addr: int) -> bytes | None:
+    """The CI-V frame the fake radio answers a ``1C 00`` read with.
+
+    ``None`` means "answer nothing" — the silence row.
+    """
+    if answer == "rx":
+        return build_civ_frame(
+            CONTROLLER_ADDR, radio_addr, 0x1C, sub=0x00, data=b"\x00"
+        )
+    if answer in ("tx_cat", "tx_other"):
+        # Icom reports no attribution at all, so both keyed answers are the
+        # same byte on this wire; the attribution field stays honestly None.
+        return build_civ_frame(
+            CONTROLLER_ADDR, radio_addr, 0x1C, sub=0x00, data=b"\x01"
+        )
+    if answer == "unmapped":
+        return build_civ_frame(
+            CONTROLLER_ADDR, radio_addr, 0x1C, sub=0x00, data=b"\x00\x00"
+        )
+    if answer == "refusal":
+        return build_civ_frame(CONTROLLER_ADDR, radio_addr, 0xFA)
+    if answer == "ack":
+        return build_civ_frame(CONTROLLER_ADDR, radio_addr, 0xFB)
+    if answer == "setter_echo":
+        # Addressed *to* the radio, exactly as our own ptt_off setter is.
+        return build_civ_frame(
+            radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00, data=b"\x00"
+        )
+    if answer == "misaddressed":
+        return build_civ_frame(
+            CONTROLLER_ADDR, FOREIGN_CIV_ADDR, 0x1C, sub=0x00, data=b"\x00"
+        )
+    if answer == "silence":
+        return None
+    raise AssertionError(f"unscripted transmit-state answer {answer!r}")
+
+
+def _is_civ_transmit_state_read(payload: bytes) -> bool:
+    """``FE FE <to> <from> 1C 00 FD`` — the bare GET, no data byte."""
+    return len(payload) == 7 and payload[4] == 0x1C and payload[5] == 0x00
+
+
+# ---------------------------------------------------------------------------
+# Wires
+# ---------------------------------------------------------------------------
+
+
+class ScriptedCivLink:
+    """A serial CI-V link that answers the transmit-state read by content.
+
+    The shipped serial fake (``tests/test_icom7610_serial_radio.py:125``)
+    scripts replies by *send ordinal*; a solicited read inside a gate has no
+    stable ordinal, so this one matches on ``(command, sub)`` instead. Same
+    duck-typed surface as the production ``SerialCivLink``.
+    """
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.ready = False
+        self.healthy = False
+        self.sent_frames: list[bytes] = []
+        self.answer: str = "rx"
+        self.radio_addr: int = 0x94
+        self._replies: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def set_device(self, device: str) -> None:
+        """Reconnection seam the serial base class calls."""
+
+    async def connect(self) -> None:
+        self.connected = self.ready = self.healthy = True
+
+    async def disconnect(self) -> None:
+        self.connected = self.ready = self.healthy = False
+
+    async def send(self, frame: bytes) -> None:
+        if not self.connected:
+            raise ConnectionError("Serial CI-V link is disconnected.")
+        payload = bytes(frame)
+        self.sent_frames.append(payload)
+        if _is_civ_transmit_state_read(payload):
+            reply = civ_transmit_state_reply(self.answer, self.radio_addr)
+            if reply is not None:
+                self._replies.put_nowait(reply)
+
+    async def receive(self, timeout: float | None = None) -> bytes | None:
+        if not self.connected:
+            return None
+        try:
+            return await asyncio.wait_for(
+                self._replies.get(), timeout=0.05 if timeout is None else timeout
+            )
+        except asyncio.TimeoutError:
+            return None
+
+
+class ScriptedLanTransport(MockTransport):
+    """The LAN transport fake, answering the transmit-state read by content."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.answer: str = "rx"
+        self.radio_addr: int = 0x98
+
+    async def send_tracked(self, data: bytes) -> None:
+        await super().send_tracked(data)
+        payload = bytes(data)[0x15:]
+        if _is_civ_transmit_state_read(payload):
+            reply = civ_transmit_state_reply(self.answer, self.radio_addr)
+            if reply is not None:
+                self.queue_response(wrap_civ_in_udp(reply))
+
+    def civ_wire(self) -> list[bytes]:
+        """The CI-V payloads, unwrapped from their UDP envelopes."""
+        return [bytes(pkt)[0x15:] for pkt in self.sent_packets if len(pkt) > 0x15]
+
+
+class ScriptedCatTransport:
+    """Yaesu CAT reads/writes, scripted by answer name.
+
+    Installed over a real ``YaesuCatRadio``'s real transport object by
+    replacing its two async entry points — the established house pattern
+    (``tests/test_ftx1_radio.py:34-46``) minus the mock.
+    """
+
+    _READ_ANSWERS = {
+        "rx": "TX0",
+        "tx_cat": "TX1",
+        "tx_other": "TX2",
+        "unmapped": "TX9",
+        "refusal": "?",
+    }
+
+    def __init__(self, radio: YaesuCatRadio) -> None:
+        self.wire: list[str] = []
+        self.answer: str = "rx"
+        radio._transport._connected = True
+        radio._transport.query = self.query  # type: ignore[method-assign]
+        radio._transport.write = self.write  # type: ignore[method-assign]
+
+    async def query(self, cmd: str, *args: Any, **kwargs: Any) -> str:
+        self.wire.append(f"?{cmd}")
+        if self.answer == "silence":
+            raise asyncio.TimeoutError("no CAT answer")
+        try:
+            return self._READ_ANSWERS[self.answer]
+        except KeyError:  # pragma: no cover - guards a typo in a new row
+            raise AssertionError(
+                f"unscripted transmit-state answer {self.answer!r}"
+            ) from None
+
+    async def write(self, cmd: str, *args: Any, **kwargs: Any) -> None:
+        self.wire.append(f"!{cmd}")
+
+
+# ---------------------------------------------------------------------------
+# One harness row
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TxConformanceHarness:
+    """One backend column of the matrix: a real radio on a scripted wire."""
+
+    name: str
+    radio: Any
+    script: Callable[[str], None]
+    read_transmit_state: Callable[[], Awaitable[TxStateReading]]
+    wire: Callable[[], Sequence[str]]
+    is_read: Callable[[str], bool]
+    hazard_method: str
+    hazard_args: tuple[Any, ...]
+    hazard: Callable[[], Awaitable[None]]
+    key: Callable[[], Awaitable[None]]
+    unkey: Callable[[], Awaitable[None]]
+    close: Callable[[], Awaitable[None]]
+    #: rigctld-client answers from an upstream cache, never the radio (§3.7).
+    verified_readback: bool = True
+    #: Only the ``ObservationPollable`` backends have the queue ingress the
+    #: facade design missed (the D1 lesson, §3.2 item 2).
+    queue_command: Any | None = None
+    queue_unkey: Any | None = None
+    drain: Callable[[], Awaitable[None]] | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def writes(self) -> list[str]:
+        return [entry for entry in self.wire() if not self.is_read(entry)]
+
+    def reads(self) -> list[str]:
+        return [entry for entry in self.wire() if self.is_read(entry)]
+
+
+# ---------------------------------------------------------------------------
+# Per-backend construction
+# ---------------------------------------------------------------------------
+
+_ICOM_SERIAL_CLASSES = {
+    "icom7610-serial": Icom7610SerialRadio,
+    "ic705-serial": Ic705SerialRadio,
+    "ic7300-serial": Ic7300SerialRadio,
+    "ic9700-serial": Ic9700SerialRadio,
+}
+
+#: Every shipping backend class, as an explicit literal. Mirrors
+#: ``tests/contracts/test_audio_transport_conformance.py:83-90`` and adds the
+#: rigctld-client backend, which ships no audio but does ship writes.
+CONFORMANCE_BACKENDS: tuple[str, ...] = (
+    "lan-icom",
+    "icom7610-serial",
+    "ic705-serial",
+    "ic7300-serial",
+    "ic9700-serial",
+    "yaesu-ftx1",
+    "rigctld-client",
+)
+
+#: The backends whose web write path is the ``create_observation_poller``
+#: queue drain (``web_startup.py:105-193`` branch 1) — the ingress a wrapping
+#: facade could never see.
+QUEUE_PATH_BACKENDS: tuple[str, ...] = ("yaesu-ftx1", "rigctld-client")
+
+
+async def _civ_reading(radio: Any, timeout: float) -> TxStateReading:
+    """One solicited CI-V transmit-state read, validated as the product does.
+
+    Row 5 will put this behind ``TransmitStateReadable``; until then the
+    harness assembles it from shipped parts so the conformance rows exercise
+    the real validation rather than a stand-in for it. Note which parts:
+    ``CivRequestTracker`` matches ``(command, sub, receiver)`` with **no**
+    address check (``core/civ.py:410-417``), so the discrimination comes from
+    the RX pump's routing guards plus the provenance narrowing at
+    ``_civ_rx.py:2636-2650`` — exactly the trap §3.4 row 5 names.
+    """
+    frame = build_civ_frame(radio._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)
+    try:
+        reply = await radio._send_civ_expect(frame, label="tx-state", timeout=timeout)
+    except asyncio.TimeoutError:
+        return TxStateReading(value=None, failure="timeout")
+    except CommandError:
+        # No usable answer: nothing came back, or what came back was a NAK.
+        return TxStateReading(value=None, failure="read-error")
+    for observation in radio._civ_runtime._observations_from_frame(reply):
+        if str(observation.path) != _PTT_FIELD:
+            continue
+        source = str(observation.source.source)
+        if source in RADIO_READBACK_SOURCES:
+            return TxStateReading(
+                value=bool(observation.value),
+                attributed=None,  # Icom reports no attribution (§3.7)
+                source=source,
+                verified_readback=True,
+            )
+    return TxStateReading(value=None, failure="unverifiable-provenance")
+
+
+async def _build_lan_icom() -> TxConformanceHarness:
+    transport = ScriptedLanTransport()
+    radio = IcomRadio("192.168.99.1", timeout=0.2)
+    radio._civ_transport = transport
+    radio._ctrl_transport = transport
+    radio._connected = True
+    radio._radio_addr = transport.radio_addr
+    radio._start_civ_rx_pump()
+    await asyncio.sleep(0)
+
+    async def close() -> None:
+        radio._connected = False
+        task = radio._civ_rx_task
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        radio._civ_transport = None
+        radio._ctrl_transport = None
+
+    return TxConformanceHarness(
+        name="lan-icom",
+        radio=radio,
+        script=lambda answer: setattr(transport, "answer", answer),
+        read_transmit_state=lambda: _civ_reading(radio, 0.15),
+        wire=lambda: [payload.hex() for payload in transport.civ_wire()],
+        is_read=_is_hex_civ_read,
+        hazard_method="set_tuner_status",
+        hazard_args=(2,),
+        hazard=lambda: radio.set_tuner_status(2),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=close,
+    )
+
+
+def _is_hex_civ_read(entry: str) -> bool:
+    return _is_civ_transmit_state_read(bytes.fromhex(entry))
+
+
+async def _build_icom_serial(name: str) -> TxConformanceHarness:
+    link = ScriptedCivLink()
+    radio = _ICOM_SERIAL_CLASSES[name](device="/dev/ttyUSB0", civ_link=link)
+    await radio.connect()
+    link.radio_addr = radio._radio_addr
+
+    return TxConformanceHarness(
+        name=name,
+        radio=radio,
+        script=lambda answer: setattr(link, "answer", answer),
+        read_transmit_state=lambda: _civ_reading(radio, 0.15),
+        wire=lambda: [payload.hex() for payload in link.sent_frames],
+        is_read=_is_hex_civ_read,
+        hazard_method="set_tuner_status",
+        hazard_args=(2,),
+        hazard=lambda: radio.set_tuner_status(2),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=radio.disconnect,
+    )
+
+
+async def _build_yaesu() -> TxConformanceHarness:
+    radio = YaesuCatRadio("/dev/null", profile="ftx1")
+    cat = ScriptedCatTransport(radio)
+
+    async def read() -> TxStateReading:
+        try:
+            value = await radio.read_ptt()
+        except asyncio.TimeoutError:
+            return TxStateReading(value=None, failure="timeout")
+        except Exception:
+            # ``?;`` fails the typed parse — the radio refused the read.
+            return TxStateReading(value=None, failure="read-error")
+        return TxStateReading(
+            value=value,
+            # Row 6 routes the three-valued answer through ``tx_state_map``
+            # into this field; today ``read_ptt`` collapses it to a bool.
+            attributed=None,
+            source="yaesu_poll_response",
+            verified_readback=True,
+        )
+
+    from rigplane.runtime._poller_types import CommandQueue, PttOff, SetTunerStatus
+
+    queue = CommandQueue()
+    seen: list[Any] = []
+    poller = radio.create_observation_poller(callback=seen.extend, command_queue=queue)
+
+    async def close() -> None:
+        return None
+
+    return TxConformanceHarness(
+        name="yaesu-ftx1",
+        radio=radio,
+        script=lambda answer: setattr(cat, "answer", answer),
+        read_transmit_state=read,
+        wire=lambda: list(cat.wire),
+        is_read=lambda entry: entry.startswith("?"),
+        # The alias chain's innermost body: ``set_tuner_status`` is a pure
+        # alias onto ``set_tuner`` (§3.2), and the queue drain calls the
+        # latter directly (``yaesu_cat/poller.py:1099-1100``).
+        hazard_method="set_tuner",
+        hazard_args=(1,),
+        hazard=lambda: radio.set_tuner(1),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=close,
+        queue_command=SetTunerStatus(1),
+        queue_unkey=PttOff(),
+        drain=poller._drain_commands,
+        extras={"queue": queue, "poller": poller, "cat": cat, "observations": seen},
+    )
+
+
+async def _build_rigctld_client() -> TxConformanceHarness:
+    server = FakeRigctldServer(state=FakeRigctldState(), behavior=FakeRigctldBehavior())
+    await server.start()
+    radio = RigctldClientRadio(host=server.host, port=server.port)
+    await radio.connect()
+
+    def script(answer: str) -> None:
+        server.behavior.command_delays.pop("t", None)
+        server.behavior.malformed_responses.pop("t", None)
+        server.behavior.disconnect_commands.discard("t")
+        if answer == "rx":
+            server.state.ptt = 0
+        elif answer in ("tx_cat", "tx_other"):
+            server.state.ptt = 1
+        elif answer == "silence":
+            # Realised as the upstream dropping the connection rather than a
+            # bare delay: this socket is shared with every later read, and a
+            # late line arriving after the gate cancelled its ``wait_for``
+            # would answer the *next* read. Same fail direction either way —
+            # no answer, so the hazard gate refuses ``tx-truth-unavailable``.
+            server.behavior.disconnect_commands.add("t")
+        elif answer == "refusal":
+            server.behavior.malformed_responses["t"] = b"RPRT -1\n"
+        elif answer == "unmapped":
+            server.behavior.malformed_responses["t"] = b"9\n"
+        else:  # pragma: no cover - guards a typo in a new row
+            raise AssertionError(f"unscripted transmit-state answer {answer!r}")
+
+    async def read() -> TxStateReading:
+        try:
+            value = await radio.get_ptt()
+        except asyncio.TimeoutError:
+            return TxStateReading(value=None, failure="timeout")
+        except Exception:
+            return TxStateReading(value=None, failure="read-error")
+        # Never radio truth: upstream answers from its own cache (§3.7), so
+        # the gate must refuse every hazard on this backend.
+        return TxStateReading(
+            value=value,
+            attributed=None,
+            source="hamlib_response",
+            verified_readback=False,
+        )
+
+    from rigplane.runtime._poller_types import CommandQueue, PttOff, SelectVfo
+
+    queue = CommandQueue()
+    seen: list[Any] = []
+    poller = radio.create_observation_poller(callback=seen.extend, command_queue=queue)
+
+    async def close() -> None:
+        await radio.disconnect()
+        await server.stop()
+
+    return TxConformanceHarness(
+        name="rigctld-client",
+        radio=radio,
+        script=script,
+        read_transmit_state=read,
+        wire=lambda: list(server.commands_seen),
+        is_read=lambda entry: entry.split(" ")[0] in ("t", r"\get_ptt"),
+        # External rigctld ships no tuner; VFO select is its hazard family.
+        hazard_method="set_vfo_slot",
+        hazard_args=("B",),
+        hazard=lambda: radio.set_vfo_slot("B"),
+        key=lambda: radio.set_ptt(True),
+        unkey=lambda: radio.set_ptt(False),
+        close=close,
+        verified_readback=False,
+        queue_command=SelectVfo("B"),
+        queue_unkey=PttOff(),
+        drain=poller._drain_commands,
+        extras={
+            "queue": queue,
+            "poller": poller,
+            "server": server,
+            "observations": seen,
+        },
+    )
+
+
+async def build_harness(name: str) -> TxConformanceHarness:
+    """Build one backend column. Explicit dispatch, never a registry lookup."""
+    if name == "lan-icom":
+        return await _build_lan_icom()
+    if name in _ICOM_SERIAL_CLASSES:
+        return await _build_icom_serial(name)
+    if name == "yaesu-ftx1":
+        return await _build_yaesu()
+    if name == "rigctld-client":
+        return await _build_rigctld_client()
+    raise AssertionError(f"no harness for backend column {name!r}")

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -417,17 +417,18 @@ async def _build_yaesu() -> TxConformanceHarness:
 
     async def read() -> TxStateReading:
         try:
-            value = await radio.read_ptt()
+            token = await radio.read_ptt_token()
         except asyncio.TimeoutError:
             return TxStateReading(value=None, failure="timeout")
         except Exception:
             # ``?;`` fails the typed parse — the radio refused the read.
             return TxStateReading(value=None, failure="read-error")
+        policy = radio.profile.tx_policy
         return TxStateReading(
-            value=value,
-            # Row 6 routes the three-valued answer through ``tx_state_map``
-            # into this field; today ``read_ptt`` collapses it to a bool.
-            attributed=None,
+            value=not policy.is_receiving(token),
+            # MOR-1941: the three-valued answer routes through
+            # ``tx_state_map`` into this field via ``TxPolicy.attribution``.
+            attributed=policy.attribution(token),
             source="yaesu_poll_response",
             verified_readback=True,
         )

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -415,9 +415,27 @@ async def _build_yaesu() -> TxConformanceHarness:
     radio = YaesuCatRadio("/dev/null", profile="ftx1")
     cat = ScriptedCatTransport(radio)
 
+    # ``read()`` below must exercise the *shipped* ``read_ptt`` predicate --
+    # not reimplement it -- so a regression there (e.g. the MOR-1905
+    # inversion) is caught by this matrix (MOR-1941 review, BLOCKED-2).
+    # ``read_ptt`` calls ``read_ptt_token`` internally exactly once; this
+    # wraps that call to capture the raw token for attribution, so the
+    # attribution mapping rides the same single wire round-trip instead of
+    # re-querying the radio. Same house pattern ``ScriptedCatTransport``
+    # already uses to replace an instance's bound methods.
+    last_token: dict[str, str | None] = {"value": None}
+    _real_read_ptt_token = radio.read_ptt_token
+
+    async def _capturing_read_ptt_token() -> str:
+        token = await _real_read_ptt_token()
+        last_token["value"] = token
+        return token
+
+    radio.read_ptt_token = _capturing_read_ptt_token  # type: ignore[method-assign]
+
     async def read() -> TxStateReading:
         try:
-            token = await radio.read_ptt_token()
+            value = await radio.read_ptt()
         except asyncio.TimeoutError:
             return TxStateReading(value=None, failure="timeout")
         except Exception:
@@ -425,10 +443,11 @@ async def _build_yaesu() -> TxConformanceHarness:
             return TxStateReading(value=None, failure="read-error")
         policy = radio.profile.tx_policy
         return TxStateReading(
-            value=not policy.is_receiving(token),
+            value=value,
             # MOR-1941: the three-valued answer routes through
-            # ``tx_state_map`` into this field via ``TxPolicy.attribution``.
-            attributed=policy.attribution(token),
+            # ``tx_state_map`` into this field via ``TxPolicy.attribution``,
+            # off the token ``read_ptt`` itself just consumed above.
+            attributed=policy.attribution(last_token["value"] or ""),
             source="yaesu_poll_response",
             verified_readback=True,
         )

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -284,3 +284,108 @@ async def test_tx_allowed_missing_keeps_manual_required():
 
     assert checks["tx.ptt"].status is CheckStatus.BLOCKED
     radio.set_ptt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# MOR-1941: the tx.ptt read-back must not depend on a self-written mirror
+# ---------------------------------------------------------------------------
+
+
+def _ptt_only_template() -> MatrixTemplate:
+    """Minimal template exercising only ``tx.ptt`` (no tuner methods needed)."""
+    return MatrixTemplate(
+        radio=RadioTarget(model="FTX-1", profile_id="ftx1"),
+        entries=[
+            CapabilityDeclarationEntry(
+                check_id="tx.ptt",
+                capability="tx",
+                level=ValidationLevel.STRESS_RECOVERY,
+                declaration=CapabilityDeclaration.MANUAL_REQUIRED,
+                summary="ptt",
+                tx_adjacent=True,
+            ),
+        ],
+    )
+
+
+def _tx_radio_unwritten_mirror(*, start_power: int = 200):
+    """A radio matching the Yaesu backend after MOR-1941: ``set_ptt`` does
+    NOT self-write ``radio_state.ptt`` -- only a real read-back
+    (``get_ptt``) tells the truth. Proves the hardware TX-actuate check
+    was repointed off the mirror (``validation/hardware.py:702-703``).
+    """
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = {"tx"}
+    state = RadioState()
+    radio.radio_state = state
+
+    wire_ptt = {"value": False}
+    power = {"value": start_power}
+
+    async def _set_ptt(on: bool) -> None:
+        wire_ptt["value"] = bool(on)
+        # Deliberately NOT touching state.ptt -- matches the shipped
+        # Yaesu backend once its self-write is deleted (MOR-1941).
+
+    async def _get_ptt() -> bool:
+        return wire_ptt["value"]
+
+    async def _get_rf_power() -> int:
+        return power["value"]
+
+    async def _set_rf_power(level: int) -> None:
+        power["value"] = int(level)
+
+    radio.set_ptt = AsyncMock(side_effect=_set_ptt)
+    radio.get_ptt = AsyncMock(side_effect=_get_ptt)
+    radio.get_rf_power = AsyncMock(side_effect=_get_rf_power)
+    radio.set_rf_power = AsyncMock(side_effect=_set_rf_power)
+    return radio, power
+
+
+async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
+    """MOR-1941: after a backend's ``set_ptt`` self-write is deleted (the
+    Yaesu case), ``radio_state.ptt`` is no longer radio truth. The
+    TX-actuate check must verify the key from a real read-back
+    (``get_ptt``) when the backend offers one -- nothing writes the
+    mirror on this fake, matching the shipped Yaesu backend post-deletion.
+    """
+    radio, _ = _tx_radio_unwritten_mirror()
+    prompter, _ = _confirm_prompter(True)
+
+    levels = await execute_hardware_checks(
+        radio,
+        _ptt_only_template(),
+        _FULL_SAFETY,
+        allow_writes=True,
+        tx_actuate=True,
+        prompter=prompter,
+    )
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.PASS
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["ptt_state"] is True
+    # The mirror stays exactly where it started -- proof the check did not
+    # fall back to it.
+    assert radio.radio_state.ptt is False
+
+
+async def test_tx_ptt_readback_falls_back_to_the_mirror_when_get_ptt_is_absent():
+    """Best-effort, other direction (MOR-1941): a backend with no
+    ``get_ptt`` -- e.g. Icom, which exposes no plain PTT read-back method
+    -- must keep reading the mirror exactly as before. ``_tx_radio``
+    never defines ``get_ptt``, matching the Icom path this repoint must
+    not break.
+    """
+    radio, _ = _tx_radio(start_power=200)
+    prompter, _ = _confirm_prompter(True)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.PASS
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["ptt_state"] is True

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTimeoutError
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
 from rigplane.validation.hardware import execute_hardware_checks
@@ -311,8 +314,12 @@ def _ptt_only_template() -> MatrixTemplate:
 def _tx_radio_unwritten_mirror(*, start_power: int = 200):
     """A radio matching the Yaesu backend after MOR-1941: ``set_ptt`` does
     NOT self-write ``radio_state.ptt`` -- only a real read-back
-    (``get_ptt``) tells the truth. Proves the hardware TX-actuate check
-    was repointed off the mirror (``validation/hardware.py:702-703``).
+    (``get_ptt``) tells the truth, and -- faithfully to the shipped
+    ``YaesuCatRadio.get_ptt`` (``yaesu_cat/radio.py:1076``), which is kept,
+    not deleted -- a successful ``get_ptt`` DOES update the mirror from
+    that read-back. Proves the hardware TX-actuate check was repointed off
+    the mirror (``validation/hardware.py:702-703``) onto a real read, not
+    that the mirror never changes.
     """
     radio = MagicMock(spec=Radio)
     radio.connected = True
@@ -330,7 +337,10 @@ def _tx_radio_unwritten_mirror(*, start_power: int = 200):
         # Yaesu backend once its self-write is deleted (MOR-1941).
 
     async def _get_ptt() -> bool:
-        return wire_ptt["value"]
+        # Faithful to the shipped ``get_ptt``, which writes the mirror
+        # from a real read-back (kept, not deleted -- MOR-1941 scope).
+        state.ptt = wire_ptt["value"]
+        return state.ptt
 
     async def _get_rf_power() -> int:
         return power["value"]
@@ -349,8 +359,9 @@ async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
     """MOR-1941: after a backend's ``set_ptt`` self-write is deleted (the
     Yaesu case), ``radio_state.ptt`` is no longer radio truth. The
     TX-actuate check must verify the key from a real read-back
-    (``get_ptt``) when the backend offers one -- nothing writes the
-    mirror on this fake, matching the shipped Yaesu backend post-deletion.
+    (``get_ptt``) when the backend offers one -- ``set_ptt`` never writes
+    the mirror on this fake, matching the shipped Yaesu backend post-
+    deletion, so a PASS here can only come from the ``get_ptt`` read.
     """
     radio, _ = _tx_radio_unwritten_mirror()
     prompter, _ = _confirm_prompter(True)
@@ -368,9 +379,39 @@ async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
     assert ptt.status is CheckStatus.PASS
     assert ptt.evidence["keyed"] is True
     assert ptt.evidence["ptt_state"] is True
-    # The mirror stays exactly where it started -- proof the check did not
-    # fall back to it.
-    assert radio.radio_state.ptt is False
+
+
+@pytest.mark.parametrize("exc_cls", [CatTimeoutError, CatCommandRejected])
+async def test_tx_ptt_readback_failure_falls_back_to_the_mirror_not_a_fail(exc_cls):
+    """MOR-1941 review (BLOCKED-1): a ``get_ptt`` read-back that raises --
+    e.g. a dropped/late CAT reply inside the key window, or the radio
+    answering ``?;`` -- must degrade to the mirror-based evidence, not
+    propagate and turn a good key into a FAIL with the evidence dict lost.
+    Both exception classes are real Yaesu CAT transport errors
+    (``backends/yaesu_cat/transport.py``), neither of which subclasses
+    anything in ``validation.hardware._RESTORE_ERRORS``.
+
+    Uses ``_tx_radio`` (not the unwritten-mirror fixture): here the mirror
+    IS trustworthy going into the read -- ``set_ptt`` wrote it, as it still
+    does on every backend except Yaesu post-MOR-1941 -- so a raised
+    ``get_ptt`` exercises exactly the fallback path the fix adds, landing
+    on a mirror value that is actually correct rather than stale.
+    """
+    radio, _ = _tx_radio(start_power=200)
+
+    async def _raise_get_ptt() -> bool:
+        raise exc_cls("no usable TX; reply")
+
+    radio.get_ptt = AsyncMock(side_effect=_raise_get_ptt)
+    prompter, _ = _confirm_prompter(True)
+
+    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.PASS
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["ptt_state"] is True
+    assert "actuate_error" not in ptt.evidence
 
 
 async def test_tx_ptt_readback_falls_back_to_the_mirror_when_get_ptt_is_absent():

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -379,25 +379,48 @@ async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
     assert ptt.status is CheckStatus.PASS
     assert ptt.evidence["keyed"] is True
     assert ptt.evidence["ptt_state"] is True
+    assert ptt.evidence["ptt_state_source"] == "readback"
 
 
 @pytest.mark.parametrize("exc_cls", [CatTimeoutError, CatCommandRejected])
-async def test_tx_ptt_readback_failure_falls_back_to_the_mirror_not_a_fail(exc_cls):
-    """MOR-1941 review (BLOCKED-1): a ``get_ptt`` read-back that raises --
-    e.g. a dropped/late CAT reply inside the key window, or the radio
-    answering ``?;`` -- must degrade to the mirror-based evidence, not
-    propagate and turn a good key into a FAIL with the evidence dict lost.
+@pytest.mark.parametrize(
+    "radio_factory",
+    [
+        pytest.param(lambda: _tx_radio(start_power=200), id="mirror-writing"),
+        pytest.param(_tx_radio_unwritten_mirror, id="unwritten-mirror-yaesu"),
+    ],
+)
+async def test_tx_ptt_readback_failure_falls_back_to_a_trusted_write_not_a_fail(
+    radio_factory, exc_cls
+):
+    """MOR-1941 review (BLOCKED-1, then BLOCKED-3): a ``get_ptt`` read-back
+    that raises -- e.g. a dropped/late CAT reply inside the key window, or
+    the radio answering ``?;`` -- must not turn a good key into a FAIL, on
+    EITHER backend shape.
+
+    The first version of this pin (BLOCKED-1) covered only the
+    mirror-writing shape, where the fallback could not actually fail: the
+    mirror was already ``True`` from ``set_ptt``'s own write, so falling
+    back to it landed on the right answer whether the fallback logic was
+    correct or not. Review caught that the *unwritten-mirror* shape --
+    the real FTX-1, and the entire reason this repoint exists -- still
+    FAILed a good key: falling back to a permanently-stale mirror reports
+    a fabricated ``keyed: false``, exactly the MOR-1900-class defect §3.7
+    exists to eliminate, and worse than the pre-fix crash because nothing
+    records that the read even failed.
+
+    Both fixtures are parametrized here so this exact case is covered,
+    not just the shape where the bug cannot occur. Since the fix (below)
+    now falls back to *trusting the accepted write* rather than to the
+    mirror, both shapes converge on the same evidence: what changed is
+    the mechanism, not the outcome -- which is exactly why the
+    mirror-writing shape alone could not have caught the regression.
+
     Both exception classes are real Yaesu CAT transport errors
     (``backends/yaesu_cat/transport.py``), neither of which subclasses
     anything in ``validation.hardware._RESTORE_ERRORS``.
-
-    Uses ``_tx_radio`` (not the unwritten-mirror fixture): here the mirror
-    IS trustworthy going into the read -- ``set_ptt`` wrote it, as it still
-    does on every backend except Yaesu post-MOR-1941 -- so a raised
-    ``get_ptt`` exercises exactly the fallback path the fix adds, landing
-    on a mirror value that is actually correct rather than stale.
     """
-    radio, _ = _tx_radio(start_power=200)
+    radio, _ = radio_factory()
 
     async def _raise_get_ptt() -> bool:
         raise exc_cls("no usable TX; reply")
@@ -405,12 +428,23 @@ async def test_tx_ptt_readback_failure_falls_back_to_the_mirror_not_a_fail(exc_c
     radio.get_ptt = AsyncMock(side_effect=_raise_get_ptt)
     prompter, _ = _confirm_prompter(True)
 
-    levels = await _run(radio, safety=_FULL_SAFETY, tx_actuate=True, prompter=prompter)
+    levels = await execute_hardware_checks(
+        radio,
+        _ptt_only_template(),
+        _FULL_SAFETY,
+        allow_writes=True,
+        tx_actuate=True,
+        prompter=prompter,
+    )
     ptt = _flatten(levels)["tx.ptt"]
 
     assert ptt.status is CheckStatus.PASS
     assert ptt.evidence["keyed"] is True
     assert ptt.evidence["ptt_state"] is True
+    assert ptt.evidence["ptt_state_source"] == "unverified-write"
+    # The read failure is never silent -- it must be legible in the
+    # artifact, matching the file's other best-effort handlers.
+    assert ptt.evidence["ptt_read_error"] == "no usable TX; reply"
     assert "actuate_error" not in ptt.evidence
 
 
@@ -430,3 +464,4 @@ async def test_tx_ptt_readback_falls_back_to_the_mirror_when_get_ptt_is_absent()
     assert ptt.status is CheckStatus.PASS
     assert ptt.evidence["keyed"] is True
     assert ptt.evidence["ptt_state"] is True
+    assert ptt.evidence["ptt_state_source"] == "mirror"


### PR DESCRIPTION
## What changed and why

ADR row 6, "Yaesu truth honesty"
(`docs/plans/2026-08-20-transmit-authority.md` §3.7, §3.9 items 1 and 4,
§3.10, §4 row 6):

- `read_ptt` is now driven by the profile's `[tx_policy].tx_state_map`
  (positive-RX rule) instead of an inline `state != "0"` predicate, via a
  new `read_ptt_token()` primitive that exposes the raw wire value with no
  interpretation or mutation. A profile shipping no `tx_state_map` at all
  (every rig this backend has not bench-measured) falls back to the legacy
  predicate rather than calling `TxPolicy.is_receiving()` directly — the
  empty map would otherwise read an unmeasured radio as permanently
  transmitting.
- `TxPolicy` gained an `attribution()` accessor
  (`src/rigplane/profiles/__init__.py`) so a caller can map a raw
  transmit-state token to its vendor label (`"rx"`/`"tx_cat"`/`"tx_other"`
  on Yaesu). **This row lands the ability to attribute, not a wired
  mechanism** — see "Bench observable" below.
- Deleted the `self._state.ptt = on` self-write in `set_ptt`
  (`backends/yaesu_cat/radio.py:994`): our own command is a claim about the
  wire, never receive/transmit truth (§3.7).
- Repointed `validation/hardware.py`'s `tx.ptt` hardware-actuate check off
  the now-unwritten mirror to a real `get_ptt()` read-back where the
  backend offers one, genuinely best-effort on both the mirror-writing and
  the unwritten-mirror (Yaesu) backend shapes — see the review-fix section
  below; this took three rounds to land correctly.

## Premise correction

The row's stated `[BC]` — "FTX-1 PTT indicator follows readback only (one
poll-cycle lag)" — was already true before this change: the web PTT
indicator has never read the legacy self-written mirror. The real
behaviour changes are named below.

## The real behaviour changes (three, not two — corrected)

1. Standalone `rigctld` `t` on an FTX-1 now answers `0` permanently instead
   of echoing our own key — an already-known gap, pinned
   `xfail(strict=True)` at `tests/test_rigctld_ptt_reread.py:298-308`
   (`test_yaesu_standalone_can_resolve_rf_truth`), untouched by this PR.
2. `validation/hardware.py`'s `tx.ptt` hardware-actuate check, which this
   PR repoints from `radio.radio_state.ptt` to a real `get_ptt()`
   read-back (best-effort: falls back to the mirror when the backend has
   no `get_ptt`, or to trusting the accepted write when the read itself
   fails — see below) so it keeps working on the FTX-1 once `set_ptt`
   stops writing that mirror.
3. **A third the original body missed**: `backends/yaesu_cat/poller.py:1147-1154`
   gates TX-meter polling (ALC/Power/COMP/SWR vs S-meter) on
   `radio_state.ptt` (the mirror), read there by the poller's own
   `_poll_medium`-driven `get_ptt()` call, not by this validation check. It
   does not need a code change and is not a real behaviour change in any
   shipped configuration: `_poll_fast` always returns early through
   `_emit_fast_observations()` whenever an observation callback exists, and
   `web_startup.py:106` always takes the `ObservationPollable` branch for
   Yaesu, so this branch is unreachable today. Recorded here so the "real
   behaviour changes" list is not read as exhaustive of every `_state.ptt`
   reader.

## Bench observable

Front-panel key on the FTX-1 -> the transmit-state read attributes it as
keyed-by-the-radio (`tx_other`) rather than keyed-by-CAT (`tx_cat`).

**This is not reachable by what ships in this PR.** `TxPolicy.attribution()`
has no production caller yet: `build_transmit_truth` still hardcodes
`attributed=None` (`core/tx_authority.py`), and `Observation` carries no
attribution channel. The only consumer today is the test harness
(`tests/tx_authority_fakes.py`). What this row lands is the *ability* to
attribute — the carrier that makes it observable on a bench or in the UI
arrives with row 5 (`TransmitStateReadable.read_transmit_state()`) and the
rows after it.

## A finding from row 4's review, and what it means for this row's coverage

Row 4's review rewrote `test_a_set_ptt_write_alone_produces_no_observation`
(kept exactly as `main` shipped it -- not touched here) and demonstrated by
experiment that a Yaesu self-write publishing a `yaesu_poll_response`-tagged
PTT observation would have passed the *entire* suite before this PR,
including that row's own mutation table: nothing in the shipped
`YaesuCatRadio.set_ptt()` path holds a reference to any observation
callback (`create_observation_poller` returns a separate `YaesuCatPoller`
that owns the callback; the radio object itself never sees it), so
"a bare `set_ptt` publishes an observation" was never a reachable code path
to begin with, and asserting `observations == []` right after a bare
`set_ptt` -- the earlier, review-replaced form of that test -- is
vacuously true regardless of any regression here and cannot be reddened by
any mutation. That is exactly what row 4's review found and is why it
rewrote the test to drive a real poll cycle instead.

The strict xfail this row removes,
`test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere`, pins the
legacy mirror (`radio._state.ptt`) only -- it does not and cannot pin
observation publication, because there is no mechanism in the shipped code
for `set_ptt` to publish one. This row closes the mirror launder. I did not
add a pin for observation publication because doing so would require
inventing a mechanism that cannot happen in the current code to test
against — independent review confirmed this reasoning and declining the
pin was the correct call.

## Independent review found four blockers across two rounds; all four are fixed on this branch

**Round 2 — BLOCKED-1, hardware-validation repoint not actually
best-effort.** `CatTimeoutError`/`CatCommandRejected` both derive from
`CatTransportError(Exception)`, not in `_RESTORE_ERRORS`, so a dropped or
late `TX;` reply escaped the check entirely and was converted to a FAIL
with the evidence dict lost. Fixed: the inner guard is `except Exception`,
not a specific tuple — this file is backend-agnostic and must not import
one backend's exception types to enumerate them. **Round-3 review
confirmed this decision explicitly, on its own merits (not by deference):
the broad catch does not swallow `BaseException`, so cancellation still
runs the teardown, and a swallowed programming error degrades to the
documented fallback rather than a novel false green. Keep as-is —
confirmed, no further change.**

**Round 2 — BLOCKED-2, the conformance matrix stopped exercising the
shipped predicate.** The Yaesu harness's `read()` had been reimplementing
the RX/TX decision inline via `TxPolicy.is_receiving()` instead of calling
`read_ptt()`, so the review's literal MOR-1905 repro (`read_ptt` body ->
`bool(state == "1")`) left all 23 live `yaesu-ftx1` conformance rows green.
Fixed: `read()` now calls `radio.read_ptt()` itself; attribution's raw
token is captured as a side effect of that single call by wrapping the
internal `read_ptt_token()` call `read_ptt()` already makes, so there is no
second wire query and no reimplemented decision logic. **Round-3 review
independently probed the harness directly (exactly one `?TX;` per call
across `tx_other`/`tx_cat`/`rx`, correct `attributed` in all three; on a
failing read the captured token is never consulted, so no stale-attribution
leak) and confirmed: genuinely fixed, no further change.**

**Round 3 — BLOCKED-3, the best-effort fix only worked on the shape where
it could not fail.** The BLOCKED-1 pin used `_tx_radio`, the
mirror-writing fake, where the mirror was already correct from `set_ptt`'s
own write before `get_ptt` was ever called — so landing on it proved
nothing about the fallback itself. On the real FTX-1 shape
(`_tx_radio_unwritten_mirror`), a raised `get_ptt()` still fell back to a
permanently-stale mirror and FAILed a good key with `error="PTT did not
key/unkey cleanly"`, recording nothing about the read having failed — a
fabricated "did not key" claim, less legible than the pre-repoint code.
**Fixed and the outcome decided explicitly**: on a read failure the check
now falls back to *trusting the accepted write* (`ptt_state = True`)
rather than the mirror — `key_refusal is None` already means
`set_ptt(True)` did not raise, and reporting a negative that was never
measured is exactly the fabricated-observation class this row exists to
eliminate, and worse than an unconfirmed positive: the positive direction
(possibly still transmitting) is the RF-safe default when uncertain, the
same positive-mapping principle the ADR applies elsewhere (§3.7).
`evidence["ptt_read_error"]` now records the failure (matching the file's
four other best-effort handlers, which all record their own errors), and
`evidence["ptt_state_source"]` records whether the reported value came from
`"readback"`, `"mirror"`, or the new `"unverified-write"`, so a PASS backed
by a real read stays distinguishable from one that is not. The pin is now
parametrized over both backend shapes × both exception classes (4 cases),
so the shape the repoint exists for is the one actually covered, not just
the one where the bug can't occur.

**Round 3 — BLOCKED-4, the repointed mutation coordinate was off by three
lines, onto a decoy.** The comment fixed in round 2 cited `radio.py:1067`
for `return not policy.is_receiving(state)`; at that line sits `return
state != "0"` (the empty-map fallback branch) instead — the correct line
is `:1070`. The cited string was right and unique, only the number was
wrong, which is worse than no coordinate because it looks correct to a
reader trusting the number over the string. Fixed and verified both ways:
mutating the decoy at `:1067` stays green (confirming it really is a
no-op for this test); mutating the actual line at `:1070` reddens
`test_an_unmapped_transmit_state_value_is_never_receiving[yaesu-ftx1]`,
the named row.

## Two smaller items from round 3, addressed

- `hardware.py:609-610`'s docstring described reading `radio_state.ptt`
  to verify the key — stale after the repoint. Reworded to describe the
  real-read-back-preferred sequence and points at `ptt_state_source`.
- This PR body's earlier "real behaviour changes" item 3 cross-referenced
  "item 2's poller-owned read" imprecisely; it is `_poll_medium`'s
  `get_ptt()` call in the Yaesu poller, not the validation check in item 2.
  Corrected above.

## A residual this row creates — MOR-1950 (ticket filed by the coordinator)

`read_ptt` now delegates the RX decision to `TxPolicy.is_receiving`, and
the loader validates `[tx_policy].tx_state_map` for shape only (`str ->
str`) — there is no check against the `rx`/`tx_cat`/`tx_other` vocabulary.
A profile typo such as `"2" = "rx"` would now silently reproduce MOR-1905
*from data*. **This is a residual this row creates, not a pre-existing
defect**: before row 6 the predicate lived in code, where a typo was
visible on read and a mutation would catch it; moving the decision into
profile data moves it out of reach of code review and mutation testing
too, and the compensating control (value-side vocabulary validation at
load) does not exist yet. Not fixed here: `profiles` sits below `core` in
the import matrix, so the loader cannot simply import the authority's
`rx`/`tx_cat`/`tx_other` enum, and deciding where the shared vocabulary
literal lives is real design work, not a quick add. Tracked as **MOR-1950**.

## Not fixed here — MOR-1951 (filed by the coordinator, Urgent), out of this row's scope

Round-3 review found a genuine, pre-existing hole while auditing the
`finally` block this repoint sits beside: the unkey at `hardware.py:751-753`
also catches only `_RESTORE_ERRORS`, so a Yaesu transport error while
unkeying escapes, skips the power restore, and leaves the radio
transmitting — verified byte-identical on `origin/main`. Noted in the
function's docstring with the ticket number; not fixed in this PR per the
coordinator's instruction, since fixing it here would widen this row and
it deserves its own tested change.

## Self-audit for the "picked the shape where the defect cannot occur" pattern

Asked explicitly to look for this before pushing. What I checked:

- **The managed-vs-unmanaged axis in `_actuate_tx_ptt`.** All of this
  round's new/updated pins run the unmanaged path (no `managed_tx`
  attribute on the fake). Checked whether the managed path could hide a
  parallel gap: the read-back block (`ptt_state = ...` through
  `evidence["keyed"] = keyed`) is unconditional on `managed` — the same
  code runs either way, and `get_ptt` is read directly off `radio`, never
  through the `managed` wrapper. Not a gap; the axis doesn't affect the
  code under test.
- **An unwritten-mirror-and-no-`get_ptt` combination.** Considered whether
  `test_tx_ptt_readback_falls_back_to_the_mirror_when_get_ptt_is_absent`
  needed a Yaesu-shaped variant too. That combination doesn't correspond
  to any real or planned backend — Yaesu keeps `get_ptt` (only the
  self-write in `set_ptt` is deleted) — so there is nothing real to add
  there.
- **Result: nothing else found.** The one instance this round (BLOCKED-3)
  is fixed and now parametrized over both real shapes; I did not find a
  second instance elsewhere in this branch's tests.

## Mutation evidence (re-proved against this exact HEAD, `4743b324`)

All runs `PYTHONDONTWRITEBYTECODE=1`, one mutation at a time, `git status
--short` clean between each, verified by full-file backup/restore.

**1. Unmapped transmit-state value is not receiving:**
```
tests/test_ftx1_radio.py::test_get_ptt_unexpected_value_reads_as_transmitting FAILED
tests/contracts/test_tx_authority_conformance.py::test_an_unmapped_transmit_state_value_is_never_receiving[yaesu-ftx1] FAILED
2 failed, 6 passed
```

**2. The self-write:**
```
tests/contracts/test_tx_authority_conformance.py::test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere[yaesu-ftx1] FAILED
tests/test_ftx1_radio.py::test_set_ptt_on FAILED
tests/test_ftx1_radio.py::test_set_ptt_off FAILED
3 failed
```

**3. Empty-map fallback bypassed:**
```
tests/test_ftx1_radio.py::test_read_ptt_falls_back_to_the_legacy_predicate_when_unmeasured FAILED
1 failed
```

**4. BLOCKED-2's literal repro** (`read_ptt` body -> `bool(state == "1")`):
```
tests/contracts/test_tx_authority_conformance.py -k yaesu
5 failed, 18 passed, 177 deselected, 7 xfailed
FAILED test_every_backend_answers_every_scripted_answer[tx_other-yaesu-ftx1]
FAILED test_every_backend_answers_every_scripted_answer[unmapped-yaesu-ftx1]
FAILED test_a_confirmed_rx_and_a_keyed_radio_read_their_values[yaesu-ftx1]
FAILED test_an_unmapped_transmit_state_value_is_never_receiving[yaesu-ftx1]
FAILED test_no_failing_answer_ever_resolves_to_receiving[unmapped-yaesu-ftx1]
```

**5. `except Exception` narrowed to `except _RESTORE_ERRORS`** (would
re-break BLOCKED-1):
```
tests/validation/test_tx_actuate.py::test_tx_ptt_readback_failure_falls_back_to_a_trusted_write_not_a_fail
4 failed (all 4 parametrizations)
```

**6. BLOCKED-3's fix reverted** (`except Exception: pass`, no trust-the-write):
```
tests/validation/test_tx_actuate.py::test_tx_ptt_readback_failure_falls_back_to_a_trusted_write_not_a_fail
4 failed
FAILED [mirror-writing-CatTimeoutError]     -- ptt_state_source == 'mirror', not 'unverified-write'
FAILED [mirror-writing-CatCommandRejected]  -- ptt_state_source == 'mirror', not 'unverified-write'
FAILED [unwritten-mirror-yaesu-CatTimeoutError]    -- status FAIL, error="PTT did not key/unkey cleanly"
FAILED [unwritten-mirror-yaesu-CatCommandRejected] -- status FAIL, error="PTT did not key/unkey cleanly"
```
The last two reproduce the reviewer's exact probe from BLOCKED-3.

**7. BLOCKED-4's mutation coordinate, verified both ways:**
```
Mutating radio.py:1067 (the decoy, `return state != "0"` -> `return state == "1"`):
  tests/contracts/test_tx_authority_conformance.py -> 7 passed (no-op, confirmed)
Mutating radio.py:1070 (the cited line, `return not policy.is_receiving(state)` -> `return policy.is_receiving(state)`):
  test_an_unmapped_transmit_state_value_is_never_receiving[yaesu-ftx1] FAILED
  1 failed, 6 passed
```

## Existing-test classification

- `test_set_ptt_on` (subject-specific -> inverted): the mirror assertion
  now checks `is False` -- that assertion *was* the deleted behaviour. The
  `TX1;` wire assertion is unchanged.
- `test_set_ptt_off` (was degenerate after the delete -> restated): now
  seeds `radio_state.ptt = True` first and asserts it stays `True`, so it
  proves non-mutation in both directions instead of trivially passing
  against the field's default.
- `test_get_ptt_transmitting_radio_keyed` / `test_read_ptt_transmitting_radio_keyed`
  (exemplar-only, subject moved from the inline predicate to
  `tx_state_map`): docstrings updated, assertions unchanged, stayed green.
- Unrecognised-value + warn-once tests, `test_get_powerstat_unexpected_value_stays_two_valued`,
  `test_get_if_status_tx_active` (out of scope): all stayed green,
  unmodified.
- `tests/test_yaesu_cat_poller.py`, `tests/test_yaesu_cat_observation_adapter.py`,
  `tests/test_yaesu_web_projection.py`, `tests/test_tx_policy_shipped_profiles.py`,
  `tests/test_tx_authority.py`: exemplar-only, all green, unmodified.
- `tests/test_rig_loader.py::TestTxPolicy::test_positive_rx_rule_unmapped_value_is_not_receiving`:
  extended with a sibling `test_attribution_returns_the_mapped_label_or_none`
  rather than modified.

## Guardrail deviation

8 files changed (3 src, 5 test), 470 insertions(+) / 56 deletions(-)
against `origin/main`. **Declared on both axes:** over the 3-file
guideline, and over the 400-LOC guideline when counted by insertions
(414 by net delta, which is inside it — stated so the reader can pick
either measure rather than being handed the flattering one).

Forced by the same test-file blast radius the ADR's own §4 preamble calls
out: the row-4 conformance harness and matrix this row must update, plus
the characterisation pins named in the row's own mutation table, are test
files with no smaller decomposition that leaves `main` shippable. Three
further pieces were split out to their own tickets rather than absorbed
here — MOR-1948, MOR-1949 and MOR-1950 — so the deviation is what remains
after decomposition, not instead of it.

## Gate output (this HEAD, `c7fb2475`)

```
uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread
10568 passed, 13 skipped, 55 xfailed, 1 xpassed in 92.34s
```
The one xpassed is the known non-strict `test_naming_parity.py::test_toml_commands_in_radio[x6100]`.
Neither of the two known load flakes under `-n auto`
(`test_radio.py::TestPtt::test_managed_ptt_port_token_safety[rebind]`,
`test_radio.py::TestDspLevelParity::test_get_cmd29_dsp_level[get_nr_level-6-91-1]`)
surfaced in this run.

```
uv run ruff check src/ tests/          -> All checks passed!
uv run ruff format --check src/ tests/ -> 687 files already formatted
uv run lint-imports                    -> Contracts: 5 kept, 0 broken
uv run mypy src/rigplane/validation/hardware.py -> Success: no issues found
```

`git diff origin/main HEAD` shows exactly the 8 files above; row 4's
content (including `test_a_set_ptt_write_alone_produces_no_observation`)
is absent from the diff.

## Review round 4 — the fallback branch had no `TX2` pin

Independent review found a fourth instance of this branch's recurring
defect, and this one was mine as coordinator rather than the author's: I
directed the empty-`tx_state_map` fallback into existence and it went in
without a pin over the value that discriminates.

That branch is the default for **every** Yaesu rig except the one
bench-measured profile — any user TOML for a rig with the same
three-valued `TX;` answer lands on it — and it holds the one surviving
equality predicate in `read_ptt`, so it is the one place the MOR-1905
inversion can still be written. Its pin exercised `TX0` and `TX1` only,
and those two answers are *identical* under that inversion. Review proved
it: injecting `return state == "1"` into the fallback left the entire
suite green at 10568 passed.

The pin now covers `TX2` — the radio-keyed value — and an unrecognised
value, and its mutation coordinate is verified in both directions:
mutating `radio.py:1067` (the fallback return) reddens the row; mutating
`radio.py:1070` (the mapped return) leaves it green, correctly, because an
unmeasured profile never reaches that line.

The production code was correct throughout. What was missing was the
evidence that it was.

One citation was also narrowed. The comment on the `tx.ptt` read-back
leaned on the ADR rule that our own commands may source "transmitting" but
never "receiving". That rule licenses declining to report `False` from a
measurement that never happened; it does not license claiming the value
was verified. That is what `ptt_state_source` is for, and why it is not
optional.
