### PR TITLE
data(MOR-1947): declare transmit policy for the six unmeasured rigs

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -872,3 +872,20 @@ label = "3.0"
 raw = 240
 actual = 6.0
 label = "6.0+"
+
+[tx_policy]
+# Not bench-measured — inherited (MOR-1947). The backend factory routes IC-705 onto Ic705SerialRadio.
+# That is the same transmit-state read the measured IC-7300 uses: the
+# solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
+# 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
+# map is the same map, and it is declared here rather than left absent: an
+# absent section parses to "this radio is never receiving", which would
+# refuse band change, the tuner family, antenna switching and VFO select on
+# this radio permanently.
+# No write-during-transmit battery was run on this radio, so no radio-side
+# refusal is claimed. Empty means "nothing measured", not "nothing refuses".
+refused_during_tx = []
+# Positive-RX rule (§3.7): the receiving byte only. This wire carries no
+# keying attribution, so nothing else is mapped and the transmitting byte
+# is not-receiving without an invented source.
+tx_state_map = { "0" = "rx" }

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -878,10 +878,13 @@ label = "6.0+"
 # That is the same transmit-state read the measured IC-7300 uses: the
 # solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
 # 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
-# map is the same map, and it is declared here rather than left absent: an
-# absent section parses to "this radio is never receiving", which would
-# refuse band change, the tuner family, antenna switching and VFO select on
-# this radio permanently.
+# ruling is the same ruling, and it is written here rather than left absent
+# because an absent section and an empty one load identically — only a
+# written section records that this was decided.
+# Nothing on this radio's path reads this map today: the CI-V reply is
+# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
+# the read primitive, not the map. The section is declared so that a later
+# row consumes a stated ruling instead of an absence.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1515,3 +1515,20 @@ kind = "disables"
 when_active = "digisel"
 disables = ["preamp"]
 reason = "DIGI-SEL overrides preamp"
+
+[tx_policy]
+# Not bench-measured — inherited (MOR-1947). The backend factory routes IC-7610 onto Icom7610SerialRadio over serial, and onto IcomRadio itself over LAN.
+# That is the same transmit-state read the measured IC-7300 uses: the
+# solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
+# 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
+# map is the same map, and it is declared here rather than left absent: an
+# absent section parses to "this radio is never receiving", which would
+# refuse band change, the tuner family, antenna switching and VFO select on
+# this radio permanently.
+# No write-during-transmit battery was run on this radio, so no radio-side
+# refusal is claimed. Empty means "nothing measured", not "nothing refuses".
+refused_during_tx = []
+# Positive-RX rule (§3.7): the receiving byte only. This wire carries no
+# keying attribution, so nothing else is mapped and the transmitting byte
+# is not-receiving without an invented source.
+tx_state_map = { "0" = "rx" }

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1521,10 +1521,13 @@ reason = "DIGI-SEL overrides preamp"
 # That is the same transmit-state read the measured IC-7300 uses: the
 # solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
 # 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
-# map is the same map, and it is declared here rather than left absent: an
-# absent section parses to "this radio is never receiving", which would
-# refuse band change, the tuner family, antenna switching and VFO select on
-# this radio permanently.
+# ruling is the same ruling, and it is written here rather than left absent
+# because an absent section and an empty one load identically — only a
+# written section records that this was decided.
+# Nothing on this radio's path reads this map today: the CI-V reply is
+# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
+# the read primitive, not the map. The section is declared so that a later
+# row consumes a stated ruling instead of an absence.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -912,10 +912,13 @@ label = "6.0+"
 # That is the same transmit-state read the measured IC-7300 uses: the
 # solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
 # 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
-# map is the same map, and it is declared here rather than left absent: an
-# absent section parses to "this radio is never receiving", which would
-# refuse band change, the tuner family, antenna switching and VFO select on
-# this radio permanently.
+# ruling is the same ruling, and it is written here rather than left absent
+# because an absent section and an empty one load identically — only a
+# written section records that this was decided.
+# Nothing on this radio's path reads this map today: the CI-V reply is
+# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
+# the read primitive, not the map. The section is declared so that a later
+# row consumes a stated ruling instead of an absence.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -906,3 +906,20 @@ label = "3.0"
 raw = 240
 actual = 6.0
 label = "6.0+"
+
+[tx_policy]
+# Not bench-measured — inherited (MOR-1947). The backend factory routes IC-9700 onto Ic9700SerialRadio.
+# That is the same transmit-state read the measured IC-7300 uses: the
+# solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
+# 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
+# map is the same map, and it is declared here rather than left absent: an
+# absent section parses to "this radio is never receiving", which would
+# refuse band change, the tuner family, antenna switching and VFO select on
+# this radio permanently.
+# No write-during-transmit battery was run on this radio, so no radio-side
+# refusal is claimed. Empty means "nothing measured", not "nothing refuses".
+refused_during_tx = []
+# Positive-RX rule (§3.7): the receiving byte only. This wire carries no
+# keying attribution, so nothing else is mapped and the transmitting byte
+# is not-receiving without an invented source.
+tx_state_map = { "0" = "rx" }

--- a/rigs/tx500.toml
+++ b/rigs/tx500.toml
@@ -255,3 +255,16 @@ get_meter       = { cat = { read = "RM;", parse = "RM{meter}{value:04d};" } }
 get_voltage     = { cat = { read = "VL;", parse = "VL{volts:04d};" } }
 # Transceiver ID (ID) — 019 / 500 / 505.
 get_id          = { cat = { read = "ID;", parse = "ID{id};" } }
+
+[tx_policy]
+# Deliberately empty (MOR-1947) — a declared decision, not an oversight.
+# TX-500 has no serial backend: backends/factory.py refuses the model, so
+# the only path to this radio is the rigctld client, whose transmit-state
+# read is permanently unverified — it answers from upstream Hamlib's cache
+# or another rigplane's retained state, never from a fresh radio read.
+# The `PT;` read declared above is therefore unreachable from here, and its
+# answer has never been measured against a keyed radio besides. The map
+# stays empty, so every hazard family is refused while transmit state is
+# unknown.
+refused_during_tx = []
+tx_state_map = { }

--- a/rigs/tx500.toml
+++ b/rigs/tx500.toml
@@ -263,8 +263,9 @@ get_id          = { cat = { read = "ID;", parse = "ID{id};" } }
 # read is permanently unverified — it answers from upstream Hamlib's cache
 # or another rigplane's retained state, never from a fresh radio read.
 # The `PT;` read declared above is therefore unreachable from here, and its
-# answer has never been measured against a keyed radio besides. The map
-# stays empty, so every hazard family is refused while transmit state is
-# unknown.
+# answer has never been measured against a keyed radio besides. No backend
+# on this radio's path reads this map today, so the empty table records a
+# ruling rather than producing a behaviour: it asserts no receiving value
+# instead of inventing one.
 refused_during_tx = []
 tx_state_map = { }

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -249,3 +249,16 @@ get_squelch  = [0x14, 0x03]
 set_squelch  = [0x14, 0x03]
 
 [commands.overrides]
+
+[tx_policy]
+# Deliberately empty (MOR-1947) — a declared decision, not an oversight.
+# X6100 has no serial backend: backends/factory.py refuses the model, so
+# the only path to this radio is the rigctld client, whose transmit-state
+# read is permanently unverified — it answers from upstream Hamlib's cache
+# or another rigplane's retained state, never from a fresh radio read.
+# The CI-V PTT command declared above is therefore unreachable from here,
+# and mapping a receiving byte would claim a freshness this path cannot
+# deliver. The map stays empty, so every hazard family is refused while
+# transmit state is unknown.
+refused_during_tx = []
+tx_state_map = { }

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -258,7 +258,8 @@ set_squelch  = [0x14, 0x03]
 # or another rigplane's retained state, never from a fresh radio read.
 # The CI-V PTT command declared above is therefore unreachable from here,
 # and mapping a receiving byte would claim a freshness this path cannot
-# deliver. The map stays empty, so every hazard family is refused while
-# transmit state is unknown.
+# deliver. No backend on this radio's path reads this map today, so the
+# empty table records a ruling rather than producing a behaviour: it
+# asserts no receiving value instead of inventing one.
 refused_during_tx = []
 tx_state_map = { }

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -495,3 +495,20 @@ get_command_error_fa = [0xFA]
 get_command_ok_fb    = [0xFB]
 
 [commands.overrides]
+
+[tx_policy]
+# Not bench-measured — inherited (MOR-1947). The backend factory routes X6200 onto Ic705SerialRadio: the Xiegu shares the IC-705 CI-V personality (MOR-170), and this profile declares the same 0x1C/0x00 PTT command.
+# That is the same transmit-state read the measured IC-7300 uses: the
+# solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
+# 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
+# map is the same map, and it is declared here rather than left absent: an
+# absent section parses to "this radio is never receiving", which would
+# refuse band change, the tuner family, antenna switching and VFO select on
+# this radio permanently.
+# No write-during-transmit battery was run on this radio, so no radio-side
+# refusal is claimed. Empty means "nothing measured", not "nothing refuses".
+refused_during_tx = []
+# Positive-RX rule (§3.7): the receiving byte only. This wire carries no
+# keying attribution, so nothing else is mapped and the transmitting byte
+# is not-receiving without an invented source.
+tx_state_map = { "0" = "rx" }

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -501,10 +501,13 @@ get_command_ok_fb    = [0xFB]
 # That is the same transmit-state read the measured IC-7300 uses: the
 # solicited CI-V 0x1C/0x00 request in runtime/radio.py, decoded through the
 # 0x00/0x01 allowlist in runtime/_civ_rx.py. The decode is shared, so the
-# map is the same map, and it is declared here rather than left absent: an
-# absent section parses to "this radio is never receiving", which would
-# refuse band change, the tuner family, antenna switching and VFO select on
-# this radio permanently.
+# ruling is the same ruling, and it is written here rather than left absent
+# because an absent section and an empty one load identically — only a
+# written section records that this was decided.
+# Nothing on this radio's path reads this map today: the CI-V reply is
+# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
+# the read primitive, not the map. The section is declared so that a later
+# row consumes a stated ruling instead of an absence.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/tests/test_tx_policy_shipped_profiles.py
+++ b/tests/test_tx_policy_shipped_profiles.py
@@ -1,8 +1,15 @@
 """Golden values for the [tx_policy] data shipped in rigs/*.toml.
 
 MOR-1912 (ADR row 3a) landed the section for the two bench-measured rigs.
-MOR-1947 settles what the remaining six declare, before the row that wires
-the authority into the backends makes an absent section operative policy.
+MOR-1947 settles what the remaining six declare, so each shipped rig carries
+a written ruling instead of an absence.
+
+What consumes the data is deliberately not asserted here. Only the Yaesu
+backend reads ``tx_state_map`` today (``yaesu_cat/radio.py:1083-1090``, where
+an undeclared profile falls back to the vendor ``!= "0"`` default); the Icom
+read decodes its ``1C 00`` reply natively (``runtime/radio.py``), and
+``core/tx_authority.py`` is handed the read primitive, never the map. Which
+of those paths a later row changes is that row's business, not this one's.
 
 The owner ruling, per radio:
 
@@ -15,14 +22,15 @@ The owner ruling, per radio:
   client, whose read is permanently ``verified_readback=False``, so they
   are fail-closed by provenance regardless of what the map says.
 
-Nothing here may be left implicit: an absent ``[tx_policy]`` section parses
-to the same empty policy as a deliberately empty one, so
-:func:`test_every_shipped_profile_declares_a_tx_policy_section` reads the
-raw TOML text and requires the declaration to be present in the file.
+Nothing here may be left implicit: an absent ``[tx_policy]`` section loads to
+the same empty policy as a deliberately empty one, so
+:func:`test_every_shipped_profile_declares_a_tx_policy_section` parses the raw
+TOML and requires a ``tx_policy`` table to be present in the document.
 """
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 from rigplane.backends.config import SerialBackendConfig
@@ -84,10 +92,12 @@ def test_ic7300_tx_policy_matches_the_bench_measurement():
 def test_every_shipped_profile_declares_a_tx_policy_section():
     """No shipped rig may leave the transmit policy to an absent section.
 
-    An absent section and an empty one parse identically, so this is the
-    only pin that can tell a deliberate declaration from an oversight —
-    and the only thing stopping the next rig TOML from silently shipping
-    "refuse every hazard family forever".
+    An absent section and an empty one load to the same :class:`TxPolicy`,
+    so no assertion on the loaded profile can separate them. This pin parses
+    the raw TOML document instead and requires a ``tx_policy`` *table* to be
+    in it. That, and only that, is what it guarantees: a mention of the
+    section in a comment or a TODO does not satisfy it. Whether the declared
+    contents are right is the business of the per-rig pins below.
     """
     rigs = discover_rigs(RIGS_DIR)
     assert len(rigs) == 8, "shipped rig count changed; re-run the MOR-1947 ruling"
@@ -96,12 +106,15 @@ def test_every_shipped_profile_declares_a_tx_policy_section():
         path.name
         for path in sorted(RIGS_DIR.glob("*.toml"))
         if not path.name.startswith("_")
-        and "[tx_policy]" not in path.read_text(encoding="utf-8")
+        and not isinstance(
+            tomllib.loads(path.read_text(encoding="utf-8")).get("tx_policy"), dict
+        )
     ]
 
     assert undeclared == [], (
-        f"{undeclared}: every shipped rig must declare [tx_policy] explicitly "
-        "(MOR-1947) — an absent section silently means 'never receiving'"
+        f"{undeclared}: every shipped rig must declare a [tx_policy] table "
+        "(MOR-1947) — once loaded, an absent section is indistinguishable "
+        "from a deliberately empty one"
     )
 
 

--- a/tests/test_tx_policy_shipped_profiles.py
+++ b/tests/test_tx_policy_shipped_profiles.py
@@ -1,19 +1,64 @@
-"""Golden values for the measured [tx_policy] data shipped in rigs/*.toml.
+"""Golden values for the [tx_policy] data shipped in rigs/*.toml.
 
-MOR-1912, ADR row 3a: this pins the two profiles that carry measured
-transmit-policy facts (ftx1, ic7300) and confirms every other shipped
-profile still loads unchanged with the default (empty) policy — the row
-must not disturb any rig that has not been bench-measured.
+MOR-1912 (ADR row 3a) landed the section for the two bench-measured rigs.
+MOR-1947 settles what the remaining six declare, before the row that wires
+the authority into the backends makes an absent section operative policy.
+
+The owner ruling, per radio:
+
+* The four Icom siblings that the factory routes onto the *same* Icom
+  transmit-state read primitive as the measured IC-7300 **inherit** its
+  one-entry map. The justification is the shared CI-V decode, not a new
+  bench measurement, and the profiles say so.
+* The two rigs with no serial backend at all (X6100, TX-500) declare an
+  explicitly **empty** map. They are reachable only through the rigctld
+  client, whose read is permanently ``verified_readback=False``, so they
+  are fail-closed by provenance regardless of what the map says.
+
+Nothing here may be left implicit: an absent ``[tx_policy]`` section parses
+to the same empty policy as a deliberately empty one, so
+:func:`test_every_shipped_profile_declares_a_tx_policy_section` reads the
+raw TOML text and requires the declaration to be present in the file.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from rigplane.backends.config import SerialBackendConfig
+from rigplane.backends.factory import create_radio
 from rigplane.profiles import TxPolicy
 from rigplane.profiles.rig_loader import discover_rigs
+from rigplane.runtime.radio import CoreRadio
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+
+# Measured on the live bench (MOR-1912). Everything else is decided here.
+MEASURED = {"FTX-1", "IC-7300"}
+
+# The Icom transmit-state byte: 0x00 means receiving, and nothing else goes
+# in the map, because that wire carries no keying attribution (§3.7).
+ICOM_CIV_MAP = {"0": "rx"}
+
+
+def _routes_onto_the_shared_icom_read(model: str) -> bool:
+    """True if the serial factory hands ``model`` the shared Icom primitive.
+
+    Construction is deliberate rather than a hard-coded model list: the
+    point of the inherit ruling is that these radios decode transmit state
+    through the *same* code as the measured IC-7300, so the test asks the
+    factory instead of restating the answer. ``create_radio`` opens nothing
+    — it assembles the object — so this is safe with no hardware present.
+
+    Method identity, not class kinship: a subclass that overrode
+    ``read_transmit_state`` would no longer share the decode the inherit
+    ruling rests on, and must stop being treated as an inheritor.
+    """
+    try:
+        radio = create_radio(SerialBackendConfig(device="/dev/null", model=model))
+    except ValueError:
+        return False  # no serial backend for this model at all
+    return type(radio).read_transmit_state is CoreRadio.read_transmit_state
 
 
 def test_ftx1_tx_policy_matches_the_bench_measurement():
@@ -32,19 +77,70 @@ def test_ic7300_tx_policy_matches_the_bench_measurement():
 
     assert profile.tx_policy == TxPolicy(
         refused_during_tx=frozenset(),
-        tx_state_map={"0": "rx"},
+        tx_state_map=dict(ICOM_CIV_MAP),
     )
 
 
-def test_every_other_shipped_profile_still_loads_with_default_policy():
+def test_every_shipped_profile_declares_a_tx_policy_section():
+    """No shipped rig may leave the transmit policy to an absent section.
+
+    An absent section and an empty one parse identically, so this is the
+    only pin that can tell a deliberate declaration from an oversight —
+    and the only thing stopping the next rig TOML from silently shipping
+    "refuse every hazard family forever".
+    """
     rigs = discover_rigs(RIGS_DIR)
-    measured = {"FTX-1", "IC-7300"}
+    assert len(rigs) == 8, "shipped rig count changed; re-run the MOR-1947 ruling"
 
-    assert len(rigs) > len(measured), "expected more than the two measured rigs"
+    undeclared = [
+        path.name
+        for path in sorted(RIGS_DIR.glob("*.toml"))
+        if not path.name.startswith("_")
+        and "[tx_policy]" not in path.read_text(encoding="utf-8")
+    ]
 
-    for model, rig in rigs.items():
-        if model in measured:
-            continue
-        assert rig.to_profile().tx_policy == TxPolicy(), (
-            f"{model}: unmeasured rig must keep the default empty tx_policy"
+    assert undeclared == [], (
+        f"{undeclared}: every shipped rig must declare [tx_policy] explicitly "
+        "(MOR-1947) — an absent section silently means 'never receiving'"
+    )
+
+
+def test_icom_siblings_inherit_the_measured_civ_receiving_byte():
+    """The unmeasured Icom siblings carry the IC-7300's one-entry map.
+
+    Derived from factory routing rather than a literal model list: an Icom
+    model added later that decodes transmit state through the same
+    primitive is caught here if it ships without the inherited map.
+    """
+    rigs = discover_rigs(RIGS_DIR)
+
+    inheritors = {
+        model for model in rigs if _routes_onto_the_shared_icom_read(model)
+    } - MEASURED
+
+    assert inheritors == {"IC-705", "IC-7610", "IC-9700", "X6200"}
+
+    for model in sorted(inheritors):
+        assert rigs[model].to_profile().tx_policy == TxPolicy(
+            refused_during_tx=frozenset(),
+            tx_state_map=dict(ICOM_CIV_MAP),
+        ), f"{model}: must inherit the shared-decode receiving byte (MOR-1947)"
+
+
+def test_rigs_without_a_serial_backend_declare_an_empty_map():
+    """X6100 and TX-500 stay fail-closed, and say so in the profile.
+
+    Neither has a serial backend — the factory refuses both — so the only
+    path to them is the rigctld client, whose transmit-state read is
+    permanently unverified. Inheriting a receiving byte would claim a
+    freshness that path can never deliver.
+    """
+    rigs = discover_rigs(RIGS_DIR)
+
+    for model in ("X6100", "TX-500"):
+        assert not _routes_onto_the_shared_icom_read(model), (
+            f"{model} gained a serial backend; its tx_policy ruling must be redone"
+        )
+        assert rigs[model].to_profile().tx_policy == TxPolicy(), (
+            f"{model}: must declare an explicitly empty tx_policy (MOR-1947)"
         )


### PR DESCRIPTION
Settles MOR-1947: every shipped rig now carries a written `[tx_policy]` ruling instead of an absence, ahead of the ADR row that consumes it (`docs/plans/2026-08-20-transmit-authority.md`).

## Why now

Row 3a (#2771) landed `[tx_policy]` with measured data for the two rigs on the live bench. The other six shipped rigs declared no section at all. An absent section and a deliberately empty one load to the same `TxPolicy`, so once the file is loaded nothing can tell an oversight from a decision — and this is the moment to record the decision, while it is still cheap and while the reasoning is in hand.

**No behaviour changes here, and none is predicted.** Only the Yaesu backend reads `tx_state_map` today (`backends/yaesu_cat/radio.py:1083-1090`), and a profile that declares no map falls back there to the vendor-level `!= "0"` predicate — its docstring states outright that an undeclared profile must degrade to today's behaviour. The Icom path decodes its `1C 00` reply natively and consults no policy (`runtime/radio.py`), and `core/tx_authority.py` is handed the read primitive, never the map. What a later row does with this data is that row's business; this PR states the ruling and stops.

## The ruling

**Inherit** — IC-705, IC-7610, IC-9700, X6200. The backend factory routes each onto a class whose `read_transmit_state` is the *same method object* as the measured IC-7300's: the solicited CI-V `0x1C`/`0x00` request in `runtime/radio.py`, decoded through the `0x00`/`0x01` allowlist in `runtime/_civ_rx.py`. Each profile already declares that same PTT command. They get the same one-entry map, justified in the profile by the shared decode — not by a measurement we did not take. `refused_during_tx` stays empty and says why: nothing measured, nothing claimed.

**Fail-closed by provenance** — X6100, TX-500. Neither has a serial backend; the factory refuses both models, so the only path to them is the rigctld client, whose transmit-state read is permanently `verified_readback=False` (it answers from upstream Hamlib's cache, never a fresh radio read), and which the authority engine refuses on that ground regardless of what any map says. Mapping a receiving byte would claim a freshness that path cannot deliver. The map is empty *by declaration*, with the reason in the file.

## Pins and mutations

Five mutations, each killed by a named test:

| Mutation | Test that goes red |
|---|---|
| strip `[tx_policy]` from `rigs/ic705.toml` | `test_every_shipped_profile_declares_a_tx_policy_section` (+ the inheritor pin) |
| empty IC-7610's inherited map | `test_icom_siblings_inherit_the_measured_civ_receiving_byte` |
| give X6100 a receiving byte | `test_rigs_without_a_serial_backend_declare_an_empty_map` |
| set IC-9700's inherited map to a wrong non-empty value | `test_icom_siblings_inherit_the_measured_civ_receiving_byte` |
| delete both sections, leave only a `# TODO(MOR-9999): decide the [tx_policy] ruling for this rig later` comment | `test_every_shipped_profile_declares_a_tx_policy_section` |

`test_every_shipped_profile_declares_a_tx_policy_section` parses the raw TOML and requires a `tx_policy` **table** in the document. That is all it guarantees — a mention of the section in a comment does not satisfy it, and whether the declared contents are right is the business of the per-rig pins. The inheritor set is derived from factory routing and method identity rather than a literal model list, so an Icom model added later without the map — or one that overrides the read — is caught rather than assumed.

## Review round 2

An independent review blocked the first version on two counts; both are fixed in `e9784c4f`, with no change to the declared values.

1. **The stated justification was false against the shipped code.** Four inheritor profiles, the test module and this PR body claimed that an absent section "would refuse band change, the tuner family, antenna switching and VFO select on this radio permanently". The three sites above refute it: the Icom read consults no policy, the authority engine is never handed the map, and the one backend that does read it falls back to the vendor default rather than to a radio that can never be read as receiving. Every affected passage now states only the ruling and facts about code that exists — the consequence claim is removed, not softened into a hedge, and nothing is asserted about what a future row will do.
2. **The declaration pin could not discriminate.** It substring-matched `[tx_policy]` in the file text, so deleting both sections and leaving a comment that merely mentions the name kept the suite green. It now parses the raw TOML; that probe is mutation 5 above, and it goes red.

## Scope

Declared deviation: 7 files (6 rig profiles + 1 test file), all data and pins — **no source change**. The unit of work is one decision applied per shipped radio; splitting six near-identical declarations across PRs would hide the ruling rather than scope it.

## Gates

- `pytest tests/ --ignore=tests/integration -n auto` — 10579 passed, 13 skipped, 47 xfailed, 1 xpassed
- `ruff check` + `ruff format` — clean, 687 files unchanged
- `lint-imports` — 5 kept, 0 broken
- `mypy src/` — 12 errors, all pre-existing (this PR changes no source file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
