### PR TITLE
fix(MOR-1953): correct the vocabulary table and widen the Yaesu read catch

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -20,7 +20,7 @@ from ...types import AudioCodec, BreakInMode
 from ...exceptions import AudioFormatError, CommandError
 from ...exceptions import ConnectionError as RadioConnectionError
 from ...radio_state import RadioState
-from .parser import CatCommandParser, format_command
+from .parser import CatCommandParser, CatParseError, format_command
 from .transport import (
     CatCommandRejected,
     CatTimeoutError,
@@ -1111,16 +1111,21 @@ class YaesuCatRadio:
         The real :class:`~.transport.YaesuCatTransport` raises a typed
         exception per outcome rather than returning a sentinel string, so
         this never trusts a raw ``"?"`` token -- it catches the transport's
-        own vocabulary instead. A rejected or unanswered read is never
-        raised -- it comes back as a :class:`TxStateReading` with a
-        ``failure`` tag -- but a precondition failure ahead of the wire
-        (``read_ptt_token`` -> ``_query`` -> ``_require_connected``, not
-        connected at all) still raises, the same convention every other
-        read on this class follows.
+        own vocabulary instead. A rejected, unanswered, or malformed-but-
+        delivered read is never raised -- it comes back as a
+        :class:`TxStateReading` with a ``failure`` tag -- but a
+        precondition failure ahead of the wire (``read_ptt_token`` ->
+        ``_query`` -> ``_require_connected``, not connected at all) still
+        raises, the same convention every other read on this class
+        follows. A malformed reply that gets past ``query()``'s ``?``-
+        prefix rejection but fails the response template (a noisy serial
+        line) raises :class:`~.parser.CatParseError`, a ``ValueError``
+        subclass outside the ``transport.py`` ``Cat*Error`` family -- also
+        caught here, not a precondition failure.
         """
         try:
             token = await self.read_ptt_token()
-        except CatCommandRejected:
+        except (CatCommandRejected, CatParseError):
             return TxStateReading(value=None, failure="read-error")
         except CatTimeoutError:
             return TxStateReading(value=None, failure="timeout")

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -62,6 +62,7 @@ from tx_authority_fakes import (
 )
 
 from rigplane.backends.rigctld_client.radio import RigctldClientRadio
+from rigplane.backends.yaesu_cat import YaesuCatRadio
 from rigplane.core.tx_authority import (
     RADIO_READBACK_SOURCES,
     TransmitAuthority,
@@ -876,6 +877,110 @@ async def test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout() 
         "'timeout' -- the RadioTimeoutError catch narrowed back to only "
         "asyncio.TimeoutError"
     )
+
+
+@pytest.mark.parametrize("harness", ["rigctld-client"], indirect=True)
+async def test_the_vocabulary_table_does_not_claim_a_delay_it_does_not_deliver(
+    harness: TxConformanceHarness,
+) -> None:
+    """MOR-1953: the vocabulary table's own words must match what its
+    ``script`` function does, not what would be convenient to believe.
+
+    A prior version of the module docstring's table (``tx_authority_fakes.py``
+    top) described the rigctld-client ``silence`` answer as "delayed past
+    the deadline". ``_build_rigctld_client``'s ``script`` does something
+    else: it makes the upstream *drop the connection*
+    (``server.behavior.disconnect_commands``), which the transport reports
+    as ``RadioConnectionError``, not a timeout -- the implementation's own
+    comment already explains why (a genuinely delayed line would arrive in
+    time to answer the *next* read on the shared socket, not this one), and
+    that implementation is correct and unchanged by this row.
+
+    The table was the defect. During MOR-1914 an agent trusted the old
+    wording, wrote a pin scripting ``silence`` and asserting
+    ``failure == "timeout"``, and it failed *with the fix applied* -- red
+    for a reason unrelated to any defect, and it would have gone green for
+    a reason unrelated to any fix. This test pins the table's text against
+    the real behaviour it describes, so the two cannot drift apart again
+    silently.
+
+    The genuine wire-level timeout path is a different scenario entirely,
+    covered separately by
+    ``test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout``
+    above -- deliberately not driven through this harness; see that test's
+    own docstring for why.
+
+    # MUTATION: in `tests/tx_authority_fakes.py`, revert the rigctld-client
+    # `silence` cell in the module docstring's table back to "delayed past
+    # the deadline" -> this row goes red on the docstring assertion below.
+    """
+    import tx_authority_fakes
+
+    doc = tx_authority_fakes.__doc__ or ""
+    assert "delayed past" not in doc and "the deadline" not in doc, (
+        "the vocabulary table still claims the rigctld-client 'silence' "
+        "answer is a delay past the deadline -- it is not; "
+        "_build_rigctld_client's script() drops the connection instead "
+        "(see that function's own comment)"
+    )
+
+    harness.script("silence")
+    reading = await harness.radio.read_transmit_state()
+
+    assert reading.failure == "read-error", (
+        f"scripted 'silence' on rigctld-client reported failure="
+        f"{reading.failure!r}, not 'read-error' -- if this is now "
+        "'timeout' the harness's disconnect-based realisation of "
+        "'silence' has changed and the table needs to change with it"
+    )
+
+
+async def test_the_yaesu_primitive_reports_a_malformed_reply_as_read_error() -> None:
+    """A malformed-but-delivered CAT reply must come back as a
+    :class:`TxStateReading` with ``failure="read-error"``, never escape
+    ``read_transmit_state`` as a raised ``CatParseError``.
+
+    Deliberately not driven through the shared ``yaesu-ftx1`` harness:
+    ``ScriptedCatTransport`` only ever returns the vocabulary's six
+    answers, each of which either parses cleanly against the ``ftx1``
+    profile's ``TX{state};`` template or raises one of the transport's own
+    typed exceptions. A noisy serial line can also deliver a line that gets
+    past ``query()``'s ``?``-prefix rejection but fails the response
+    *template* once ``_query`` (``radio.py:764-781``) hands it to
+    ``CatCommandParser.parse``. That raises ``CatParseError``
+    (``parser.py:157``) -- a ``ValueError`` subclass, not one of the
+    ``transport.py`` ``Cat*Error`` family -- which was not in
+    ``read_transmit_state``'s catch list.
+
+    Three shapes reproduce it against the real ``TX{state};`` template: a
+    ``TX`` answer with no state digit, an answer that isn't a ``TX``
+    answer at all, and an empty line.
+
+    # MUTATION: in `src/rigplane/backends/yaesu_cat/radio.py`, in
+    # `read_transmit_state`, narrow `except (CatCommandRejected,
+    # CatParseError):` back to `except CatCommandRejected:` -> this row
+    # goes red: `CatParseError` escapes the primitive instead of coming
+    # back as `TxStateReading(value=None, failure="read-error")`.
+    """
+    radio = YaesuCatRadio("/dev/null", profile="ftx1")
+    radio._transport._connected = True
+
+    for malformed_reply in ("TX", "FA014074000", ""):
+
+        async def query(
+            cmd: str, *args: object, _reply: str = malformed_reply, **kwargs: object
+        ) -> str:
+            return _reply
+
+        radio._transport.query = query  # type: ignore[method-assign]
+
+        reading = await radio.read_transmit_state()
+
+        assert reading == TxStateReading(value=None, failure="read-error"), (
+            f"a malformed-but-delivered reply {malformed_reply!r} produced "
+            f"{reading!r}, not a clean "
+            "TxStateReading(value=None, failure='read-error')"
+        )
 
 
 @pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -15,11 +15,19 @@ answer                  CI-V (Icom)                 Yaesu CAT       rigctld clie
 ``tx_cat``              directed ``1C 00`` + ``01`` ``TX1``         ``1``
 ``tx_other``            (Icom carries no            ``TX2``         (upstream
                         attribution — §3.7)                         carries none)
-``silence``             no reply at all             read times out  delayed past
-                                                                    the deadline
+``silence``             no reply at all             read times out  upstream drops
+                                                                    the connection
 ``refusal``             NAK ``FA``                  ``?;``          malformed line
 ``unmapped``            ``1C 00`` + ``00 00``       ``TX9``         ``9``
 ======================  ==========================  ==============  ==============
+
+The rigctld-client ``silence`` answer is a dropped connection, not a delayed
+reply -- see ``_build_rigctld_client``'s ``script`` function below for why
+(the socket is shared with every later read). The genuine wire-level-timeout
+path is a different scenario, covered separately by
+``test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout`` in
+``tests/contracts/test_tx_authority_conformance.py``, which is deliberately
+not driven through this harness.
 
 The CI-V column additionally scripts three shapes that must **never** satisfy a
 read (INV-13): an ACK, a setter echo, and a mis-addressed frame. They are not


### PR DESCRIPTION
## Summary

Two defects found and reproduced by independent review of MOR-1914 (ADR row 5, the transmit-state read primitive), deliberately deferred to their own row.

### Defect 1 — the fakes' vocabulary table contradicted its own implementation

`tests/tx_authority_fakes.py`'s module docstring table described the rigctld-client `silence` answer as "delayed past the deadline". The implementation (`_build_rigctld_client`'s `script` function) does something different and correct: it makes the upstream **drop the connection**, which surfaces as `RadioConnectionError`, not a timeout. That socket is shared with every later read, and a genuinely delayed line would arrive in time to answer the *next* read rather than this one — the implementation's own comment already said so.

The table was the defect, and a live trap: during MOR-1914 an agent trusted the table, wrote a pin scripting `silence` and asserting `failure == "timeout"`, and the pin failed *with the fix applied* — red for a reason unrelated to any defect, and it would have gone green for a reason unrelated to any fix.

Fix: corrected the table's wording ("upstream drops the connection") and added a pointer to the test that actually covers the genuine-timeout path, `test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout` (`tests/contracts/test_tx_authority_conformance.py`). The implementation was not touched — it was already correct.

### Defect 2 — `CatParseError` escaped the Yaesu read primitive's catch list

`YaesuCatRadio.read_transmit_state` caught the transport's `Cat*Error` family (`CatCommandRejected`, `CatTimeoutError`, `CatTransportError`) but not `CatParseError`, which a malformed-but-delivered reply raises out of `CatCommandParser.parse` — a `ValueError` subclass defined in `parser.py`, outside the `transport.py` exception hierarchy entirely. Reachable on a noisy serial line: a prefix-matching corrupt line passes `query()`'s `?`-rejection filter and then fails the response template (`TX{state};`) once `_query` hands it to the parser. Reproduced with three malformed-but-delivered replies against the real `ftx1` profile template: `"TX"`, `"FA014074000"`, and `""`.

This was a contract-accuracy defect, not a safety hole — the engine's blanket `except Exception` already made it fail closed — but `read_transmit_state`'s own docstring undersold what it caught, and `TransmitStateReadable`'s protocol docstring (already narrowed during MOR-1914 review) no longer claims the primitive never raises.

Fix: widened the catch to `except (CatCommandRejected, CatParseError): return TxStateReading(value=None, failure="read-error")`, and updated the method's own docstring to name the malformed-reply case explicitly instead of only "rejected or unanswered".

## Mutations

- Restored the table's old "delayed past the deadline" wording → `test_the_vocabulary_table_does_not_claim_a_delay_it_does_not_deliver[rigctld-client]` went red (docstring assertion), confirmed, then restored → green.
- Narrowed the catch back to `except CatCommandRejected:` → `test_the_yaesu_primitive_reports_a_malformed_reply_as_read_error` went red (`CatParseError` escaped uncaught), confirmed, then restored → green.

## Gate results

- `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — **10579 passed, 13 skipped, 47 xfailed, 1 xpassed** (the xpass is a pre-existing, unrelated `test_naming_parity.py::test_toml_commands_in_radio[x6100]` naming-epic case, not touched by this change)
- `uv run ruff check src/ tests/` — all checks passed
- `uv run ruff format src/ tests/` — 687 files unchanged, no diff
- `uv run lint-imports` — 5 contracts kept, 0 broken
- `uv run mypy src/` — **12 pre-existing errors**, all in `src/rigplane/runtime/_control_phase.py`, `src/rigplane/runtime/_audio_runtime_mixin.py`, `src/rigplane/web/radio_poller.py` — none of which this PR touches. No new errors introduced.
- `git diff --stat` — exactly the 3 intended files, 128 insertions / 10 deletions

## Test plan

- [x] Both new pins fail for the predicted reason before the fix
- [x] Both fixes applied, both pins pass
- [x] Full test suite green
- [x] Both named mutations confirmed red, then restored to green
- [x] Lint / import-linter / mypy baseline confirmed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)