### PR TITLE
fix(MOR-1963): repoint dangling refs in solve-issue, add dangling-ref guard

### DIFF
--- a/.claude/commands/solve-issue.md
+++ b/.claude/commands/solve-issue.md
@@ -3,71 +3,67 @@
 You are the orchestrator for the autonomous issue resolution pipeline.
 Process the issue specified in `$ARGUMENTS` (a GitHub issue number).
 
+Roles are dispatched by name. The four that exist are `builder`, `researcher`,
+`scout` and `verifier` (`.claude/agents/`). If a phase below names a role you
+cannot dispatch, **stop and report** — do not substitute another role and do
+not do the phase yourself. Substituting at the REVIEW phase is what the rule
+"the implementation agent never reviews its own work" exists to prevent.
+
 ## Pre-flight
 
-1. Read `.claude/workflow/task.md` — must be idle (no other issue in progress)
-2. Read `.claude/knowledge/patterns.md` and `.claude/knowledge/failures.md`
-3. Fetch issue: `gh issue view $ARGUMENTS --json number,title,body,labels,state`
-4. Write issue context to `.claude/workflow/task.md`
+1. Fetch issue: `gh issue view $ARGUMENTS --json number,title,body,labels,state`
+2. Create an ephemeral worktree on a `codex/<topic>` branch off `origin/main`
+   and do all work there — never on `main`, never in the shared checkout
 
 ## Pipeline: EXPLORE → PLAN → EXECUTE → REGCHECK → REVIEW → TEST → PR
 
 ### Phase 1: EXPLORE
-Use `.claude/agents/researcher.md`.
-- Read the issue, find affected files, check knowledge base
-- Write findings to `.claude/workflow/research.md`
-- **STOP if confidence < 0.6** — mark issue as SKIPPED in queue
+Dispatch the `researcher` role (`.claude/agents/researcher.md`).
+- Read the issue, find affected files
+- Have the researcher report findings back as text
+- **STOP if confidence < 0.6** — mark the issue SKIPPED
 
 ### Phase 2: PLAN
-Use `.claude/agents/planner.md`.
+Plan yourself, as orchestrator. There is no planner role: design decisions
+belong to the coordinator, not to a subagent.
 - Enter Plan Mode first — do NOT start coding
-- Design minimal fix based on research
-- Write plan to `.claude/workflow/plan.md`
-- **STOP if plan violates guardrails** (>3 files, >400 LOC, architecture change)
+- Design the minimal fix from the research findings
+- **STOP if the plan violates guardrails** (>3 files, >400 LOC, architecture change)
 
 ### Phase 3: EXECUTE
-Use `.claude/agents/executor.md`.
-- Implement plan exactly as specified
-- Write tests as specified
-- Update `.claude/workflow/progress.md`
+Dispatch the `builder` role (`.claude/agents/builder.md`) with the plan as its spec.
+- Implement the plan exactly as specified; write tests first
 - Max 2 attempts per change
 
 ### Phase 4: REGCHECK (mandatory)
 Run `/regression-check` (see `.claude/commands/regression-check.md`).
 - Compare test results against baseline
-- Write to `.claude/workflow/regression.md`
 - If regression detected → back to EXECUTE (counts toward retry limit)
 - Do NOT proceed to REVIEW with regressions
 
 ### Phase 5: REVIEW
-Use `.claude/agents/reviewer.md`.
-- Review all changes against plan
-- Check for safety, correctness, layering
-- Write to `.claude/workflow/review.md`
-- If needs_changes → back to EXECUTE (max 2 review loops)
+Dispatch the `verifier` role (`.claude/agents/verifier.md`).
+- The verifier did not write the change and must not be the builder
+- Review all changes against the plan; check safety, correctness, layering
+- Have the verifier report its verdict back as text; you relay it
+- If it reports needed changes → back to EXECUTE (max 2 review loops)
 
 ### Phase 6: TEST
-Use `.claude/agents/qa.md`.
-- Full test suite, lint, format, type check
+Run the gates yourself, from CLAUDE.md § Commands: the standard pytest suite,
+`ruff check`, `ruff format`, and `mypy`.
 - If the working tree is unchanged since REGCHECK, reuse that full-suite result (do not re-run an identical suite on the same code) and run only lint, format, and type check; any code change after REGCHECK requires a fresh full run
-- If fails → back to EXECUTE (max 2 fix cycles)
+- If a gate fails → back to EXECUTE (max 2 fix cycles)
 
 ### Phase 7: PR
-- Create branch: `fix/$ARGUMENTS-<short-slug>` or `feat/$ARGUMENTS-<short-slug>`
-- Commit with conventional message: `fix(#$ARGUMENTS): ...` or `feat(#$ARGUMENTS): ...`
-- Push and create PR via `gh pr create`
+- Commit with a conventional message: `fix(#$ARGUMENTS): ...` or `feat(#$ARGUMENTS): ...`
+- Push and create the PR via `gh pr create`
 - PR body references the issue: `Closes #$ARGUMENTS`
 
 ## Post-pipeline
 
-1. Update `.claude/queue/history.json` with result
-2. Update `.claude/metrics.json`
-3. If success: update `.claude/knowledge/patterns.md` with what worked
-4. If failure: run `/analyze-failure` (mandatory), then update `.claude/knowledge/failures.md`
-5. Reset `.claude/workflow/` files to idle state
-6. Update `.claude/queue/active_issue.json` to idle
-7. **Cleanup workspace** (mandatory — runs on success, failure, and skip):
-   - `git worktree remove <path> --force` (if worktree was used)
+1. If failure: run `/analyze-failure` (mandatory)
+2. **Cleanup workspace** (mandatory — runs on success, failure, and skip):
+   - `git worktree remove <path> --force`
    - `git worktree prune` to clear any orphans
    - Never `rm -rf` worktree directories — always use git commands
    - Workspace may persist ONLY if explicitly marked for manual review
@@ -77,7 +73,7 @@ Use `.claude/agents/qa.md`.
 - Max 2 execution attempts per step
 - Max 2 review loops
 - Max 2 test fix cycles
-- If any limit exceeded → mark FAILED, log reason, update failures.md
+- If any limit exceeded → mark FAILED and log the reason
 
 ## Guardrails (hard limits)
 

--- a/tests/test_claude_instruction_paths.py
+++ b/tests/test_claude_instruction_paths.py
@@ -1,0 +1,128 @@
+"""Cross-reference check for the agent instruction files under `.claude/`.
+
+`.claude/commands/*.md` and `.claude/agents/*.md` are executed by agents, not
+by a compiler, so a reference to a role or command file that is not in the
+tree fails only at run time — and the observed failure modes are recoverable
+ones (a "file does not exist" read error, or an "agent type not found" dispatch
+error that helpfully lists the real roles), which invites an agent to improvise
+a substitute rather than stop. At the review step that is how the rule that an
+implementation agent never reviews its own work stops holding silently.
+
+Scope of this check, and its limits:
+
+* Only `.claude/commands/` and `.claude/agents/` are scanned. `.claude/skills/`
+  is excluded because it contains deliberate negative references — prose that
+  names a path in order to record that the path is gone (see the operator notes
+  in `.claude/skills/release/SKILL.md`), which an existence check cannot tell
+  apart from drift.
+* Only references that must resolve *before* a command runs are checked: role
+  files, command files, and slash-command names. Paths a command writes to are
+  not checked, because they are outputs and are legitimately absent up front.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_DIR = REPO_ROOT / ".claude"
+AGENTS_DIR = CLAUDE_DIR / "agents"
+COMMANDS_DIR = CLAUDE_DIR / "commands"
+SKILLS_DIR = CLAUDE_DIR / "skills"
+
+#: Files this check scans. Skills are deliberately out of scope (see module docstring).
+SCANNED_DIRS = (COMMANDS_DIR, AGENTS_DIR)
+
+_BACKTICKED = re.compile(r"`([^`\n]+)`")
+_AGENT_REF = re.compile(r"^\.claude/agents/([A-Za-z0-9_-]+)\.md$")
+_COMMAND_REF = re.compile(r"^\.claude/commands/([A-Za-z0-9_-]+)\.md$")
+_SLASH_REF = re.compile(r"^/([a-z][a-z0-9-]*)$")
+_FRONTMATTER_NAME = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _scanned_files() -> list[Path]:
+    files = [p for d in SCANNED_DIRS for p in sorted(d.glob("*.md"))]
+    assert files, "no instruction files found to check"
+    return files
+
+
+def _references(path: Path) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        for token in _BACKTICKED.findall(line):
+            out.append((lineno, token.strip()))
+    return out
+
+
+def _frontmatter_name(path: Path) -> str | None:
+    match = _FRONTMATTER_NAME.search(path.read_text())
+    return match.group(1) if match else None
+
+
+@pytest.mark.parametrize(
+    "agent_file", sorted(AGENTS_DIR.glob("*.md")), ids=lambda p: p.name
+)
+def test_agent_frontmatter_name_matches_filename(agent_file: Path) -> None:
+    """A role file must declare the name it is dispatched under.
+
+    Roles are dispatched by name, so a file whose frontmatter `name` differs
+    from its stem is reachable under neither: the path resolves but holds a
+    different role than the reference claims.
+    """
+    assert _frontmatter_name(agent_file) == agent_file.stem
+
+
+def test_referenced_agent_roles_exist() -> None:
+    """Every `.claude/agents/<role>.md` reference names a role that exists."""
+    dangling: list[str] = []
+    for path in _scanned_files():
+        for lineno, token in _references(path):
+            match = _AGENT_REF.match(token)
+            if match is None:
+                continue
+            role = match.group(1)
+            target = AGENTS_DIR / f"{role}.md"
+            if not target.is_file():
+                known = sorted(p.stem for p in AGENTS_DIR.glob("*.md"))
+                dangling.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno} -> {token} "
+                    f"(no such role; roles are {known})"
+                )
+            elif _frontmatter_name(target) != role:
+                dangling.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno} -> {token} "
+                    f"(file exists but declares name {_frontmatter_name(target)!r})"
+                )
+    assert not dangling, "dangling agent-role references:\n" + "\n".join(dangling)
+
+
+def test_referenced_command_files_exist() -> None:
+    """Every `.claude/commands/<name>.md` reference resolves."""
+    dangling = [
+        f"{path.relative_to(REPO_ROOT)}:{lineno} -> {token}"
+        for path in _scanned_files()
+        for lineno, token in _references(path)
+        if (m := _COMMAND_REF.match(token))
+        and not (COMMANDS_DIR / f"{m.group(1)}.md").is_file()
+    ]
+    assert not dangling, "dangling command-file references:\n" + "\n".join(dangling)
+
+
+def test_referenced_slash_commands_exist() -> None:
+    """Every `/name` reference resolves to a command file or a skill."""
+    dangling: list[str] = []
+    for path in _scanned_files():
+        for lineno, token in _references(path):
+            match = _SLASH_REF.match(token)
+            if match is None:
+                continue
+            name = match.group(1)
+            if (COMMANDS_DIR / f"{name}.md").is_file():
+                continue
+            if (SKILLS_DIR / name / "SKILL.md").is_file():
+                continue
+            dangling.append(f"{path.relative_to(REPO_ROOT)}:{lineno} -> {token}")
+    assert not dangling, "dangling slash-command references:\n" + "\n".join(dangling)


### PR DESCRIPTION
## Summary

Finishes an abandoned pass on this branch. Two changes, both scoped to `.claude/commands/solve-issue.md` and `tests/`:

- **`.claude/commands/solve-issue.md`**: it named a `reviewer` role, `qa.md`, a `planner`/`executor` role, and a `.claude/workflow/` directory — none exist. The real roles under `.claude/agents/` are `builder`, `researcher`, `scout`, `verifier`. Repointed each phase to the role that actually matches its job:
  - REVIEW → `verifier` (verified via `.claude/agents/verifier.md` frontmatter: "Independent adversarial review and verification... MUST BE USED for the mandatory pre-merge independent review; the implementation agent never reviews its own work" — matches the phase's job, `reviewer` was not a synonym for something else)
  - EXECUTE → `builder` (frontmatter: "Implementation from a prepared spec")
  - PLAN → orchestrator does it itself (there is no `planner` role)
  - TEST → gates run directly by the orchestrator (there is no `qa` role)
  - Dropped all `.claude/workflow/*.md` / `.claude/queue/*` / `.claude/knowledge/*` bookkeeping — that directory tree doesn't exist in this repo; findings/plans/verdicts are now reported back as text between orchestrator and subagent.

- **`tests/test_claude_instruction_paths.py`** (new): cross-reference check that every `.claude/agents/*.md` / `.claude/commands/*.md` / `/slash-command` reference inside `.claude/commands/` and `.claude/agents/` resolves to a real file, and that a role file's frontmatter `name` matches its filename. `.claude/skills/` is deliberately out of scope (it has intentional negative references).

Confirmed the check discriminates — red on the pre-fix file, green after:

```
=== BEFORE (pre-fix solve-issue.md, restored from git HEAD) ===
tests/test_claude_instruction_paths.py ....F..                           [100%]
FAILED tests/test_claude_instruction_paths.py::test_referenced_agent_roles_exist
AssertionError: dangling agent-role references:
  .claude/commands/solve-issue.md:22 -> .claude/agents/planner.md (no such role; roles are ['builder', 'researcher', 'scout', 'verifier'])
  .claude/commands/solve-issue.md:29 -> .claude/agents/executor.md (no such role; roles are [...])
  .claude/commands/solve-issue.md:43 -> .claude/agents/reviewer.md (no such role; roles are [...])
  .claude/commands/solve-issue.md:50 -> .claude/agents/qa.md (no such role; roles are [...])
1 failed, 6 passed in 0.12s

=== AFTER (fixed solve-issue.md) ===
tests/test_claude_instruction_paths.py .......                           [100%]
7 passed in 0.08s
```

## What was deliberately not touched

The prior agent on this branch also edited a CI workflow path filter and broke two tests pinning that filter set, then stalled diagnosing it. No trace of that edit is present in the tree (`git diff --stat -- .github/` is empty) — nothing to revert.

## Follow-up (not acted on, owner's call)

A parallel audit found the other five of the eight `.claude/commands/*.md` files carry seventeen more dead references between them, and raised the open question of whether this command pipeline was ever actually executed. If it never ran, some of those commands may be candidates for deletion rather than repair — that's a scope and product call this PR doesn't make. Out of scope here by explicit instruction.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — 10599 passed, 13 skipped, 47 xfailed, 1 xpassed, 0 failed. (5 tests failed under `-n auto` parallel load on first run — `test_authority_boundary_and_ten_class_adversarial_corpus_pass`, `TestPtt::test_managed_ptt_port_token_safety[rebind]`, a CI-V dual-RX guard test, `test_pool_saturation_fails_fast_instead_of_queuing`, and a serial-link test — all 5 pass in isolation, confirming parallel-load flakes unrelated to this change.)
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] New test confirmed red before the fix, green after (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)