### PR TITLE
fix(MOR-1967): make whole-tree mypy src/ clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
 `quick.yml` itself; it runs unconditionally in `full.yml` and `publish.yml`
 (the CI workflows table below gives what triggers those). So a PR touching
 only `src/rigplane/runtime/` gets no mypy in CI until `full.yml` next runs.
-Whole-tree `uv run mypy src/` is clean (0 errors) as of MOR-1967. It remains
-advisory and ungated — nothing runs it in `.github/` — and whether to add it
-as a CI gate is a separate, still-open decision.
+Whole-tree `uv run mypy src/` was clean (0 errors) at commit `e2dcbe0f`
+(MOR-1967). It remains advisory and ungated — nothing runs it in `.github/` —
+and whether to add it as a CI gate is a separate, still-open decision.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ Never bare `python` or `pytest`. Worktrees: `uv sync --all-extras` first.
 `quick.yml` itself; it runs unconditionally in `full.yml` and `publish.yml`
 (the CI workflows table below gives what triggers those). So a PR touching
 only `src/rigplane/runtime/` gets no mypy in CI until `full.yml` next runs.
-Whole-tree `uv run mypy src/` is advisory and ungated: at commit `f4ab1e57`
-it reported 12 errors in `runtime/_control_phase.py`,
-`runtime/_audio_runtime_mixin.py` and `web/radio_poller.py`.
+Whole-tree `uv run mypy src/` is clean (0 errors) as of MOR-1967. It remains
+advisory and ungated — nothing runs it in `.github/` — and whether to add it
+as a CI gate is a separate, still-open decision.
 
 ---
 

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -788,14 +788,9 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
             raise ConnectionError("Audio port not available")
 
         self._audio_transport = IcomTransport()
-        # Narrowed alias: self._audio_transport is `IcomTransport | None`, and
-        # mypy cannot carry the "just assigned, not None" fact across the
-        # intervening getattr()/await calls below. `transport` is the same
-        # object, always non-None.
-        transport = self._audio_transport
         audio_sock = getattr(self, "_audio_sock_pending", None)
         try:
-            await transport.connect(
+            await self._audio_transport.connect(
                 self._host,
                 self._audio_port,
                 local_host=getattr(self, "_local_bind_host", None),
@@ -816,14 +811,14 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
             if audio_sock is not None:
                 self._audio_sock_pending = None
 
-        transport.start_ping_loop()
-        transport.start_retransmit_loop()
-        transport.start_idle_loop()
+        self._audio_transport.start_ping_loop()
+        self._audio_transport.start_retransmit_loop()
+        self._audio_transport.start_idle_loop()
 
         # Per wfview, audio stream also uses OpenClose on its own UDP channel.
         await self._send_audio_open_close(open_stream=True)
 
-        self._audio_stream = AudioStream(transport)
+        self._audio_stream = AudioStream(self._audio_transport)
         logger.info("Audio transport connected on port %d", self._audio_port)
 
         # Start EPIPE-storm watchdog for this transport session.

--- a/src/rigplane/runtime/_audio_runtime_mixin.py
+++ b/src/rigplane/runtime/_audio_runtime_mixin.py
@@ -38,6 +38,7 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
     """Audio streaming methods for CoreRadio (mixin)."""
 
     # -- type stubs for attributes defined in CoreRadio.__init__ ---------
+    _audio_transport: IcomTransport | None
     _audio_stream: AudioStream | None
     _pcm_transcoder: PcmOpusTranscoder | None
     _pcm_transcoder_fmt: tuple[int, int, int] | None
@@ -751,7 +752,7 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
                 logger.debug(
                     "audio teardown: transport disconnect failed", exc_info=True
                 )
-            self._audio_transport = None  # type: ignore[assignment]
+            self._audio_transport = None
 
     async def _ensure_audio_transport(self) -> None:
         """Connect the audio transport if not already connected.
@@ -787,9 +788,14 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
             raise ConnectionError("Audio port not available")
 
         self._audio_transport = IcomTransport()
+        # Narrowed alias: self._audio_transport is `IcomTransport | None`, and
+        # mypy cannot carry the "just assigned, not None" fact across the
+        # intervening getattr()/await calls below. `transport` is the same
+        # object, always non-None.
+        transport = self._audio_transport
         audio_sock = getattr(self, "_audio_sock_pending", None)
         try:
-            await self._audio_transport.connect(
+            await transport.connect(
                 self._host,
                 self._audio_port,
                 local_host=getattr(self, "_local_bind_host", None),
@@ -800,7 +806,7 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
             if audio_sock is not None:
                 audio_sock.close()
                 self._audio_sock_pending = None
-            self._audio_transport = None  # type: ignore[assignment]
+            self._audio_transport = None
             if isinstance(exc, OSError):
                 raise ConnectionError(
                     f"Failed to connect audio port {self._audio_port}: {exc}"
@@ -810,14 +816,14 @@ class AudioRuntimeMixin(_MixinBase):  # type: ignore[misc]
             if audio_sock is not None:
                 self._audio_sock_pending = None
 
-        self._audio_transport.start_ping_loop()
-        self._audio_transport.start_retransmit_loop()
-        self._audio_transport.start_idle_loop()
+        transport.start_ping_loop()
+        transport.start_retransmit_loop()
+        transport.start_idle_loop()
 
         # Per wfview, audio stream also uses OpenClose on its own UDP channel.
         await self._send_audio_open_close(open_stream=True)
 
-        self._audio_stream = AudioStream(self._audio_transport)
+        self._audio_stream = AudioStream(transport)
         logger.info("Audio transport connected on port %d", self._audio_port)
 
         # Start EPIPE-storm watchdog for this transport session.

--- a/src/rigplane/runtime/_runtime_protocols.py
+++ b/src/rigplane/runtime/_runtime_protocols.py
@@ -149,6 +149,7 @@ class ControlPhaseHost(Protocol):
     # Status / error tracking
     _last_status_error: int
     _last_status_disconnected: bool
+    _last_auth_error: int
 
     # Background tasks
     _token_task: "asyncio.Task[None] | None"
@@ -220,6 +221,8 @@ class ControlPhaseHost(Protocol):
     ) -> None: ...
 
     async def _receive_civ_port(self) -> int: ...
+
+    async def _force_cleanup_civ(self) -> None: ...
 
     def _status_retry_pause(self) -> float: ...
 

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -724,13 +724,17 @@ class RadioPoller:
         self._deferred_tx_entry: CommandQueueEntry | None = None
 
     def _provider_generation(self) -> int:
-        # int(...), not cast(): under whole-tree `mypy src/` the property is
-        # already `int` (cast would be redundant), but under the isolated
-        # `mypy --strict src/rigplane/web` run `rigplane.web.*`'s
-        # `follow_imports = "skip"` makes the cross-boundary type `Any`, so a
-        # real coercion is needed to keep this function's `-> int` honest
-        # there too.
-        return int(self._state_store.provider_generation)
+        # Annotated local, not cast(): whole-tree `mypy src/` sees
+        # `StateStore.provider_generation` as `int` directly (a cast would be
+        # redundant there), but the isolated `mypy --strict src/rigplane/web`
+        # run resolves it to `Any` — the *global* `follow_imports = "skip"`
+        # in `pyproject.toml` applies to `rigplane.core.state_store` as an
+        # import target of this module, independent of the `rigplane.web.*`
+        # override's own `follow_imports` setting. An annotated local (not a
+        # runtime-coercing `int(...)`) keeps both invocations honest with no
+        # behavioural difference from a plain return.
+        generation: int = self._state_store.provider_generation
+        return generation
 
     def _current_rf_state(self, snapshot: StateSnapshot | None = None) -> RfState:
         """Return RF truth only from a fresh current-provider PTT observation."""

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -724,7 +724,13 @@ class RadioPoller:
         self._deferred_tx_entry: CommandQueueEntry | None = None
 
     def _provider_generation(self) -> int:
-        return cast(int, self._state_store.provider_generation)
+        # int(...), not cast(): under whole-tree `mypy src/` the property is
+        # already `int` (cast would be redundant), but under the isolated
+        # `mypy --strict src/rigplane/web` run `rigplane.web.*`'s
+        # `follow_imports = "skip"` makes the cross-boundary type `Any`, so a
+        # real coercion is needed to keep this function's `-> int` honest
+        # there too.
+        return int(self._state_store.provider_generation)
 
     def _current_rf_state(self, snapshot: StateSnapshot | None = None) -> RfState:
         """Return RF truth only from a fresh current-provider PTT observation."""


### PR DESCRIPTION
## Summary

`uv run mypy src/` reported 12 errors in 3 files at `origin/main` (`902b094f`). All 12 are fixed by stating contracts the code already honored, not by suppressing anything — no new `# type: ignore`, no `Any` widening, no `cast()` used to silence, no `getattr()` used to dodge an attribute check.

**Updated after independent review** (see the review thread below): the first pushed version added two explanatory comments that each stated a false reason. Both were caught, verified, and fixed — see "Review round" below. This description reflects the current state of the branch.

## What each error turned out to be

All twelve are **typing gaps**, not latent defects.

**`src/rigplane/runtime/_control_phase.py` (3× `attr-defined`)** — `ControlPhaseHost` (the `Protocol` describing what `ControlPhaseRuntime` expects from its host, `CoreRadio`) was simply missing two members its sibling `CivRuntimeHost` already declares for the very same host class:
- `_last_auth_error` — set unconditionally at the top of `_connect_once`, on the same lines as the already-declared `_last_status_error`/`_last_status_disconnected`. Traced the two read sites (`getattr(h, "_last_auth_error", 0)`) back to confirm the attribute is always set by the time they run — the `getattr` default is pre-existing defensive style used throughout this file even for attributes that are provably always set, not evidence of a real gap.
- `_force_cleanup_civ` — already implemented on `CoreRadio` (`runtime/radio.py:1763`) and already declared in `CivRuntimeHost`; just never added to `ControlPhaseHost`.

Fix: added both declarations to `ControlPhaseHost` in `_runtime_protocols.py`.

**`src/rigplane/runtime/_audio_runtime_mixin.py` (4× `attr-defined`, 2× `unused-ignore`, 1× `assignment`, 1× `arg-type`)** — `_audio_transport` (`IcomTransport | None`, toggled by connect/disconnect throughout the object's life) was the one attribute of its kind missing from the mixin's own "type stubs for attributes defined in `CoreRadio.__init__`" block, where every sibling attribute (`_audio_stream`, `_pcm_transcoder`, etc.) is already declared. `reveal_type` confirmed mypy was inferring the un-stubbed attribute's type as bare `None`, explaining every error in this file. Declaring the stub alone fixes all seven errors in this file — nothing else about `_ensure_audio_transport` needs to change. The two now-provably-unused `# type: ignore[assignment]` comments were removed.

**`src/rigplane/web/radio_poller.py` (1× `redundant-cast`)** — `_provider_generation()`'s `cast(int, ...)` around `StateStore.provider_generation` (a `-> int` property) is genuinely redundant under whole-tree `mypy src/`, where the property's declared type is fully visible. But `mypy --strict src/rigplane/web` sees the same property as `Any` and a bare return trips `no-any-return`. Deleting the cast outright (as the blunt "redundant-cast → delete it" rule would suggest) passes `mypy src/` but **breaks** the strict-web gate. Fixed with an annotated local (`generation: int = self._state_store.provider_generation; return generation`) — a pure typing construct, not a runtime coercion, that satisfies both gates with zero behavioral change.

Also audited in passing (raised mid-review, not part of the 12, not touched): `_audio_runtime_mixin.py` pre-existing lines 51-52 declare `_audio_stream_request`/`_audio_stream_contract` as non-`Optional`, while `CoreRadio.__init__` types them `X | None`. Confirmed both are unconditionally reassigned to non-`None` values before `__init__` returns (lines 897/904 in `radio.py`, no guard), so no mixin method can ever observe `None` there; plain `mypy src/` reports no override conflict for them. Pre-existing, out of scope for this change, left untouched. Independent review re-checked this and confirmed the audit holds.

## Review round

Independent review (BLOCKED, `bd272257`) reproduced the 12-error baseline and confirmed every mypy fix, but blocked on two explanatory comments that each stated a false reason for code sitting next to it:

1. **`_audio_runtime_mixin.py`** — the first push added a local `transport` alias in `_ensure_audio_transport`, justified by a comment claiming mypy could not narrow `self._audio_transport` across the intervening `getattr()`/`await` calls. Falsified: with the `_audio_transport` stub alone and the alias removed, `rm -rf .mypy_cache && uv run mypy --no-incremental src/` is clean. Worse, the alias was not behavior-neutral — `radio_reconnect.audio_error_watchdog_loop` runs as a separate task and can null `self._audio_transport` during either `await` this method crosses; on `main`, re-reading the attribute after each `await` means a mid-flight null raises a loud, self-healing `AttributeError`, while the alias would have silently finished with `self._audio_stream` wrapping an orphaned transport (leaked UDP socket, live keep-alive loops, no guard can detect it). Reverted to direct `self._audio_transport` access, identical to `main` — only the stub declaration remains.
2. **`radio_poller.py`** — the first push replaced `cast(int, ...)` with `int(...)`, justified by a comment attributing the strict-mode `Any` to the `rigplane.web.*` override's own `follow_imports = "skip"`. Falsified by two experiments: removing that override's setting alone leaves the error in place; removing only the *global* `follow_imports = "skip"` in `pyproject.toml` (applied to the imported `rigplane.core.state_store`) clears it. Fixed as described above with an annotated local and a comment naming the correct config line.

Both fixes were re-verified independently (`rm -rf .mypy_cache && uv run mypy --no-incremental src/` and the equivalent `--strict` invocation) before pushing. Also non-blocking feedback: `CLAUDE.md`'s replacement sentence was present-tense/ungated and could silently rot; re-pinned to the commit where whole-tree mypy went clean (`e2dcbe0f`), matching the SHA-pinned, past-tense form of the sentence it replaced.

## Canon correction

`CLAUDE.md` claimed whole-tree `uv run mypy src/` was advisory/ungated and pinned "12 errors in three files" to a stale commit. Corrected to state it was clean as of commit `e2dcbe0f` (SHA-pinned, past-tense, so it can't silently rot), while explicitly leaving open whether it becomes a CI gate — **that decision is not made by this PR**. `mypy src/` is not added to any workflow here.

## Test plan
- [x] `uv run mypy src/` — 0 errors (296 files, was 12 in 3 files); reverified cold-cache (`rm -rf .mypy_cache && uv run mypy --no-incremental src/`)
- [x] `uv run mypy --strict src/rigplane/web` — 0 errors (26 files, unchanged); reverified cold-cache
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — 688 files already formatted
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — 10604 passed, 13 skipped, 47 xfailed, 1 xpassed, 0 failed, run twice at the final head with consistent results (an earlier run against the first pushed version hit a one-off `pytest-xdist` worker crash — `node down: Not properly terminated` — during an unrelated IC-7610 serial test under elevated host load; not reproduced on any subsequent run, including two independent runs at the final head)

Guardrails: 4 files changed (3 source + CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
