### PR TITLE
fix: resolve a pending CI-V read promptly on NAK instead of timing out

### DIFF
--- a/src/rigplane/core/exceptions.py
+++ b/src/rigplane/core/exceptions.py
@@ -5,6 +5,7 @@ __all__ = [
     "ConnectionError",
     "AuthenticationError",
     "CommandError",
+    "CivNakError",
     "TimeoutError",
     "AudioError",
     "AudioCodecBackendError",
@@ -27,6 +28,15 @@ class AuthenticationError(RigplaneError):
 
 class CommandError(RigplaneError):
     """Raised when a CI-V command fails or returns an error."""
+
+
+class CivNakError(CommandError):
+    """Raised when the radio explicitly declines a CI-V read with NAK.
+
+    Distinct from :class:`TimeoutError`, which means no reply arrived at
+    all: a :class:`CivNakError` means a reply did arrive, and it was a
+    refusal (CI-V command ``0xFA``).
+    """
 
 
 class TimeoutError(RigplaneError):

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -47,7 +47,7 @@ from rigplane.commands import (
     parse_scope_vbw_response,
 )
 from rigplane.commands.levels import _cw_pitch_from_level, _key_speed_from_level
-from rigplane.core.exceptions import ConnectionError, TimeoutError
+from rigplane.core.exceptions import CivNakError, ConnectionError, TimeoutError
 from rigplane.core.tx_safety import ProviderPttObservation, RadioTx
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
@@ -3432,9 +3432,26 @@ class CivRuntime:
             raise TimeoutError("CI-V response timed out")
 
         pending: "asyncio.Future[CivFrame] | None" = None
+        # Only set for a GET (``expects_response``): a NAK frame carries no
+        # reference back to the command it declines, so attributing it to
+        # this specific request is not content-based -- it relies on
+        # ``IcomCommander`` (``commands/commander.py``) serializing dispatch:
+        # the worker awaits one ``_execute_civ_raw`` call to completion
+        # before starting the next, so at most one GET is ever waiting on
+        # this tracker at a time. A NAK to a WRITE is unaffected: it keeps
+        # resolving the plain ACK waiter below, as before.
+        nak_pending: "asyncio.Future[CivFrame] | None" = None
         try:
             if expects_response:
                 pending = self._host._civ_request_tracker.register_response(request_key)
+                nak_or_token = self._host._civ_request_tracker.register_ack(
+                    wait=True,
+                    consume_backlog=False,
+                    nak_only=True,
+                )
+                if isinstance(nak_or_token, int):
+                    raise RuntimeError("ACK waiter registration returned sink token")
+                nak_pending = nak_or_token
             else:
                 pending_or_token = self._host._civ_request_tracker.register_ack(
                     wait=True
@@ -3458,6 +3475,23 @@ class CivRuntime:
             if remaining <= 0:
                 raise TimeoutError("CI-V response timed out")
             try:
+                if nak_pending is not None:
+                    done, _ = await asyncio.wait(
+                        (pending, nak_pending),
+                        timeout=remaining,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if not done:
+                        raise asyncio.TimeoutError("CI-V response timed out")
+                    if nak_pending in done:
+                        # Raises instead if the tracker failed this waiter
+                        # for an unrelated reason (e.g. reconnect); only a
+                        # real NAK frame result becomes ``CivNakError``.
+                        nak_pending.result()
+                        raise CivNakError(
+                            f"CI-V command 0x{request_key.command:02X} declined (NAK)"
+                        )
+                    return pending.result()
                 return await asyncio.wait_for(pending, timeout=remaining)
             except asyncio.TimeoutError:
                 self._host._civ_request_tracker.note_timeout()
@@ -3469,3 +3503,5 @@ class CivRuntime:
         finally:
             if pending is not None:
                 self._host._civ_request_tracker.unregister(pending)
+            if nak_pending is not None:
+                self._host._civ_request_tracker.unregister(nak_pending)

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -300,7 +300,7 @@ from rigplane.commands import set_tone_freq as _set_tone_freq_cmd
 from rigplane.commands import set_tsql_freq as _set_tsql_freq_cmd
 from rigplane.commands import set_vfo as _select_vfo_cmd
 from rigplane.core.env_config import get_managed_tx_enabled
-from rigplane.core.exceptions import CommandError, TimeoutError
+from rigplane.core.exceptions import CivNakError, CommandError, TimeoutError
 from rigplane.core.state_store import StateStore
 from rigplane.core.tx_authority import (
     RADIO_READBACK_SOURCES,
@@ -2530,7 +2530,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_rf_power(self) -> int:
         """Get the RF power level (0-255).
 
-        On timeout falls back to the state cache if populated.
+        Falls back to the state cache if populated when the read times out
+        or the radio declines it with NAK.
         """
         self._check_connected()
         civ = get_rf_power(to_addr=self._radio_addr)
@@ -2542,13 +2543,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             self._last_power = level
             self._state_cache.update_rf_power(level / 255.0)
             return level
-        except TimeoutError:
+        except (TimeoutError, CivNakError):
             if (
                 self._state_cache.is_fresh("rf_power", self._cache_ttl_rf_power)
                 and self._state_cache.rf_power is not None
             ):
                 cached_level = round(self._state_cache.rf_power * 255)
-                logger.debug("get_rf_power: timeout, returning cached %d", cached_level)
+                logger.debug(
+                    "get_rf_power: no fresh read, returning cached %d", cached_level
+                )
                 return cached_level
             raise
 
@@ -4104,7 +4107,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 val = ((raw >> 4) & 0x0F) * 10 + (raw & 0x0F)
                 self._attenuator_state = val != 0
                 return val
-        except TimeoutError:
+        except (TimeoutError, CivNakError):
             pass
 
         if self._attenuator_state is not None:
@@ -4192,7 +4195,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 raw = resp.data[0]
                 self._preamp_level = ((raw >> 4) & 0x0F) * 10 + (raw & 0x0F)
                 return self._preamp_level
-        except TimeoutError:
+        except (TimeoutError, CivNakError):
             pass
 
         if self._preamp_level is not None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,6 +1,7 @@
 """Tests for IcomRadio high-level API."""
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -24,7 +25,7 @@ from rigplane.commands import (
     build_cmd29_frame,
 )
 from rigplane.commander import Priority
-from rigplane.exceptions import CommandError, ConnectionError, TimeoutError
+from rigplane.exceptions import CivNakError, CommandError, ConnectionError, TimeoutError
 from rigplane.core import tx_safety as tx
 from rigplane.radio import IcomRadio
 from rigplane.types import (
@@ -1249,6 +1250,42 @@ class TestAckSinkRobustness:
             assert radio._civ_request_tracker.timeout_count == 0
         finally:
             await radio._civ_runtime.stop_pump()
+
+
+class TestNakOnPendingRead:
+    """A NAK against a pending GET must resolve the waiter promptly.
+
+    Bench measurement on a live IC-7300 found the radio NAKs 9 of 65
+    initial-state GET queries. Before this fix, ``CivRequestTracker``
+    routed NAK events only through ACK waiters, never through the
+    ``_response_waiters`` a GET registers, so a declined GET had nothing on
+    its path to resolve it and could only fail by exhausting the full
+    ``_civ_get_timeout`` deadline.
+    """
+
+    @pytest.mark.asyncio
+    async def test_nak_resolves_pending_read_promptly(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """NAK for a pending read raises ``CivNakError`` well before the deadline.
+
+        The ``radio`` fixture uses ``timeout=0.05`` (``_civ_get_timeout``).
+        Asserting the elapsed time stays far below that deadline is what
+        makes this pin discriminate a genuinely prompt resolution from a
+        "fix" that still waits out the full timeout and only relabels the
+        resulting exception -- a test that checked the exception type alone
+        would pass either way.
+        """
+        mock_transport.queue_response(_nak_response())
+        cmd = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, _CMD_FREQ_GET)
+
+        start = time.monotonic()
+        with pytest.raises(CivNakError):
+            await radio._execute_civ_raw(cmd)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < radio._civ_get_timeout / 2
+        assert radio._civ_request_tracker.pending_count == 0
 
 
 class TestScopeCallbackSafety:


### PR DESCRIPTION
## What

A live IC-7300 bench measurement found the radio NAKs 9 of 65 initial-state
CI-V GET queries. `CivRequestTracker` routed NAK events only through ACK
waiters and RESPONSE events only through response waiters — a GET that gets
explicitly declined had no matching event on its path, so the caller sat
until the full response deadline (~2.0s) expired every time, even though the
radio had already answered.

Measured cost (6 runs, spread under 2%): fire-and-forget sweep 3.34–3.40s vs.
the same sweep awaiting each answer 21.05–21.10s, with each of the 9 declined
calls costing essentially exactly the timeout (2.001–2.055s), ~18s of the
21s total.

## Fix

`_execute_civ_raw` (`src/rigplane/runtime/_civ_rx.py`) now races the existing
response waiter against a NAK-only ACK waiter for any GET
(`expects_response=True`). Whichever resolves first wins; a NAK raises a new
`CivNakError` instead of leaving the response waiter to time out.

**Attribution.** A NAK frame (`FE FE <to> <from> FA FD`) carries no reference
back to the command it declines — no command/sub echo, nothing. Attribution
is therefore positional, not content-based: it relies on `IcomCommander`
(`src/rigplane/commands/commander.py`) serializing dispatch — its worker
loop awaits one `_execute_civ_raw` call to completion before starting the
next, so at most one GET is ever outstanding on this tracker at a time. This
mirrors the existing `_register_civ_data_transaction` /
`execute_civ_transaction` pattern used by the raw CI-V pipe, which already
races a response future against a `nak_only=True` ACK future the same way —
this PR brings the commander-driven GET path (used by `send_civ` /
`_send_civ_expect`, and therefore by every `get_*` method) in line with a
mechanism that already existed for the other path.

**What "declined" surfaces as.** `CivNakError(CommandError)` — a new,
distinct exception, not a reuse of `TimeoutError` or of `_send_civ_expect`'s
existing `resp is None → CommandError("No response for …")` branch. Reusing
the `None`/"No response" idiom was tempting (it's the ​existing convention in
this codebase for "something unexpected happened"), but a NAK is not "no
response" — the radio replied, and the reply was a refusal — so labeling it
"No response for X" would misrepresent what actually happened. `CivNakError`
subclasses `CommandError` only, not `TimeoutError`: `read_transmit_state`
already has separate `except (asyncio.TimeoutError, TimeoutError)` /
`except CommandError` branches that classify a stalled read as
`failure="timeout"` and an explicit refusal as `failure="read-error"`; had
`CivNakError` also inherited `TimeoutError`, it would have been caught by
the first branch and misclassified as a timeout, which is exactly the
distinction this PR exists to preserve.

**Blast radius.** Surveyed every `_send_civ_expect` call site in `radio.py`
plus every `radio.send_civ(..., wait_response=True)` call elsewhere. Three
getters had a real behavioral dependency on the exception being
`TimeoutError` (a graceful cache-fallback that a new, uncaught `CivNakError`
would have bypassed): `get_rf_power`, `get_attenuator_level`, `get_preamp`.
Their `except TimeoutError:` is now `except (TimeoutError, CivNakError):`, so
a declined read degrades exactly like a timed-out one instead of raising
uncaught. `get_split` and `read_transmit_state` already catch `CommandError`
broadly/specifically and needed no change. Two sites (`get_rf_gain`,
`get_af_level`) had `except TimeoutError: raise` — a no-op either way, left
alone. Everywhere else (web poller, rigctld poller) either has no local
catch (an exception still propagates, just faster and better-typed than
before) or already catches broadly (`except Exception:`, `except
CommandError:`).

**Preserved exactly:** the ACK/write path. A NAK against a pending write
still resolves the plain ACK waiter and gets translated to `CommandError` by
the caller (e.g. `parse_ack_nak` in `_set_vfo_wire`), completely unchanged —
covered by the existing `test_set_vfo_wire_nak` / `test_split_nak` /
power-on/off NAK regression tests, which still pass.

## Test

`tests/test_radio.py::TestNakOnPendingRead::test_nak_resolves_pending_read_promptly`
— queues a NAK response for a GET, asserts `CivNakError` is raised **and**
that elapsed wall time stays under half the configured deadline (the `radio`
fixture uses `timeout=0.05`). The elapsed-time assertion is what makes this
pin discriminate a genuinely prompt fix from one that still waits out the
full timeout and only relabels the resulting exception — checking the
exception type alone would pass either way.

Mutation testing (`PYTHONDONTWRITEBYTECODE=1`), both reverted afterward and
confirmed byte-identical to the pre-mutation source:

1. Reverted just the "race" to "wait for the response, then on timeout check
   the NAK" (still ends in `CivNakError`, but only after paying the full
   deadline) → red on the elapsed-time assertion: `0.051s < 0.025s` failed.
2. Reverted the fix entirely (`nak_pending = None`, reproducing the original
   defect) → red with `rigplane.core.exceptions.TimeoutError` instead of
   `CivNakError`.

## Gate results

```
uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread
10605 passed, 13 skipped, 47 xfailed, 1 xpassed in 77.68s

uv run ruff check src/ tests/
All checks passed!

uv run ruff format --check src/ tests/
688 files already formatted

uv run mypy --strict src/rigplane/web
Success: no issues found in 26 source files

uv run lint-imports
Contracts: 5 kept, 0 broken.
```

(`uv run mypy src/` without `--strict` shows 12 pre-existing errors, all in
`runtime/_control_phase.py`, `runtime/_audio_runtime_mixin.py`, and
`web/radio_poller.py` — none of which this PR touches.)

## Files changed

- `src/rigplane/core/exceptions.py` — add `CivNakError(CommandError)`.
- `src/rigplane/runtime/_civ_rx.py` — race NAK vs. response for GETs in
  `_execute_civ_raw`.
- `src/rigplane/runtime/radio.py` — 3 getters now catch `CivNakError`
  alongside `TimeoutError` to preserve their existing cache-fallback
  behavior.
- `tests/test_radio.py` — the pin.

4 files, +94/-8.
