### PR TITLE
fix(MOR-1978): install all extras in every Python test workflow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -46,8 +46,8 @@ git branch --show-current
 Not `main` → warn, ask confirmation.
 
 ```bash
-# 2c. Sync deps (all extras, MOR-1978: mirrors publish.yml's validate job so
-# 2h below exercises the same test surface as release CI)
+# 2c. Sync deps (all extras, MOR-1978: installs the same extras as
+# publish.yml's validate job, so 2h below is not narrower than release CI)
 uv sync --all-extras
 ```
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -46,8 +46,9 @@ git branch --show-current
 Not `main` → warn, ask confirmation.
 
 ```bash
-# 2c. Sync deps
-uv sync --extra dev --extra bridge
+# 2c. Sync deps (all extras, MOR-1978: mirrors publish.yml's validate job so
+# 2h below exercises the same test surface as release CI)
+uv sync --all-extras
 ```
 
 ```bash

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -52,13 +52,15 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        # --all-extras (not --extra dev --extra bridge, MOR-1978): `bridge` is
-        # a no-op alias (pyproject.toml), so the old flags installed no
-        # optional-dependency packages at all. That left every Pillow/scipy/
-        # aiortc/cryptography-gated test in tests/ skipped in CI while still
-        # showing green. `uv sync --all-extras` installs every extra
-        # declared in pyproject.toml's [project.optional-dependencies], so
-        # those tests run instead of skipping.
+        # --all-extras (not --extra dev --extra bridge, MOR-1978): `dev`
+        # already installed its 9 packages (pytest, ruff, mypy, pydantic,
+        # jsonschema, ...) and `bridge` is `[]` (pyproject.toml, a no-op
+        # alias) — but neither flag named `scope` (Pillow), `dsp` (scipy), or
+        # `webrtc` (aiortc), the extras that gate 61 tests in tests/. Those
+        # tests ran skipped in CI while still showing green. `uv sync
+        # --all-extras` installs every extra declared in pyproject.toml's
+        # [project.optional-dependencies], so those tests run instead of
+        # skipping.
         run: uv sync --all-extras
 
       - name: Set up Node.js

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -52,7 +52,14 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra bridge
+        # --all-extras (not --extra dev --extra bridge, MOR-1978): `bridge` is
+        # a no-op alias (pyproject.toml), so the old flags installed no
+        # optional-dependency packages at all. That left every Pillow/scipy/
+        # aiortc/cryptography-gated test in tests/ skipped in CI while still
+        # showing green. `uv sync --all-extras` installs every extra
+        # declared in pyproject.toml's [project.optional-dependencies], so
+        # those tests run instead of skipping.
+        run: uv sync --all-extras
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -53,10 +53,10 @@ jobs:
 
       - name: Install dependencies
         # --all-extras (not --extra dev --extra bridge, MOR-1978): `dev`
-        # already installed its 9 packages (pytest, ruff, mypy, pydantic,
+        # already installed its packages (pytest, ruff, mypy, pydantic,
         # jsonschema, ...) and `bridge` is `[]` (pyproject.toml, a no-op
         # alias) — but neither flag named `scope` (Pillow), `dsp` (scipy), or
-        # `webrtc` (aiortc), the extras that gate 61 tests in tests/. Those
+        # `webrtc` (aiortc), the extras that gate 62 tests in tests/. Those
         # tests ran skipped in CI while still showing green. `uv sync
         # --all-extras` installs every extra declared in pyproject.toml's
         # [project.optional-dependencies], so those tests run instead of

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,15 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra bridge
+        # --all-extras (not --extra dev --extra bridge, MOR-1978): `bridge` is
+        # a no-op alias (pyproject.toml), so the old flags installed no
+        # optional-dependency packages at all. That left every Pillow/scipy/
+        # aiortc/cryptography-gated test in tests/ skipped in this release
+        # validation job while still showing green. `uv sync --all-extras`
+        # installs every extra declared in pyproject.toml's
+        # [project.optional-dependencies], so `validate` exercises the same
+        # test surface as the merged commit it is releasing.
+        run: uv sync --all-extras
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,14 +37,16 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        # --all-extras (not --extra dev --extra bridge, MOR-1978): `bridge` is
-        # a no-op alias (pyproject.toml), so the old flags installed no
-        # optional-dependency packages at all. That left every Pillow/scipy/
-        # aiortc/cryptography-gated test in tests/ skipped in this release
-        # validation job while still showing green. `uv sync --all-extras`
-        # installs every extra declared in pyproject.toml's
-        # [project.optional-dependencies], so `validate` exercises the same
-        # test surface as the merged commit it is releasing.
+        # --all-extras (not --extra dev --extra bridge, MOR-1978): `dev`
+        # already installed its 9 packages (pytest, ruff, mypy, pydantic,
+        # jsonschema, ...) and `bridge` is `[]` (pyproject.toml, a no-op
+        # alias) — but neither flag named `scope` (Pillow), `dsp` (scipy), or
+        # `webrtc` (aiortc), the extras that gate 61 tests in tests/. Those
+        # tests ran skipped in this release validation job while still
+        # showing green. `uv sync --all-extras` installs every extra
+        # declared in pyproject.toml's [project.optional-dependencies], so
+        # `validate` exercises the same test surface as the merged commit it
+        # is releasing.
         run: uv sync --all-extras
 
       - name: Set up Node.js

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Install dependencies
         # --all-extras (not --extra dev --extra bridge, MOR-1978): `dev`
-        # already installed its 9 packages (pytest, ruff, mypy, pydantic,
+        # already installed its packages (pytest, ruff, mypy, pydantic,
         # jsonschema, ...) and `bridge` is `[]` (pyproject.toml, a no-op
         # alias) — but neither flag named `scope` (Pillow), `dsp` (scipy), or
-        # `webrtc` (aiortc), the extras that gate 61 tests in tests/. Those
+        # `webrtc` (aiortc), the extras that gate 62 tests in tests/. Those
         # tests ran skipped in this release validation job while still
         # showing green. `uv sync --all-extras` installs every extra
         # declared in pyproject.toml's [project.optional-dependencies], so

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -71,13 +71,15 @@ jobs:
 
       - name: Install dependencies
         if: steps.filter.outputs.core == 'true' || steps.filter.outputs.frontend == 'true'
-        # --all-extras (not --extra dev --extra bridge, MOR-1978): `bridge` is
-        # a no-op alias (pyproject.toml), so the old flags installed no
-        # optional-dependency packages at all. That left every Pillow/scipy/
-        # aiortc/cryptography-gated test in tests/ skipped in CI while still
-        # showing green. `uv sync --all-extras` installs every extra
-        # declared in pyproject.toml's [project.optional-dependencies], so
-        # those tests run instead of skipping.
+        # --all-extras (not --extra dev --extra bridge, MOR-1978): `dev`
+        # already installed its 9 packages (pytest, ruff, mypy, pydantic,
+        # jsonschema, ...) and `bridge` is `[]` (pyproject.toml, a no-op
+        # alias) — but neither flag named `scope` (Pillow), `dsp` (scipy), or
+        # `webrtc` (aiortc), the extras that gate 61 tests in tests/. Those
+        # tests ran skipped in CI while still showing green. `uv sync
+        # --all-extras` installs every extra declared in pyproject.toml's
+        # [project.optional-dependencies], so those tests run instead of
+        # skipping.
         run: uv sync --all-extras
 
       - name: Agent Review Gate parser tests

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -72,10 +72,10 @@ jobs:
       - name: Install dependencies
         if: steps.filter.outputs.core == 'true' || steps.filter.outputs.frontend == 'true'
         # --all-extras (not --extra dev --extra bridge, MOR-1978): `dev`
-        # already installed its 9 packages (pytest, ruff, mypy, pydantic,
+        # already installed its packages (pytest, ruff, mypy, pydantic,
         # jsonschema, ...) and `bridge` is `[]` (pyproject.toml, a no-op
         # alias) — but neither flag named `scope` (Pillow), `dsp` (scipy), or
-        # `webrtc` (aiortc), the extras that gate 61 tests in tests/. Those
+        # `webrtc` (aiortc), the extras that gate 62 tests in tests/. Those
         # tests ran skipped in CI while still showing green. `uv sync
         # --all-extras` installs every extra declared in pyproject.toml's
         # [project.optional-dependencies], so those tests run instead of

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -71,7 +71,14 @@ jobs:
 
       - name: Install dependencies
         if: steps.filter.outputs.core == 'true' || steps.filter.outputs.frontend == 'true'
-        run: uv sync --extra dev --extra bridge
+        # --all-extras (not --extra dev --extra bridge, MOR-1978): `bridge` is
+        # a no-op alias (pyproject.toml), so the old flags installed no
+        # optional-dependency packages at all. That left every Pillow/scipy/
+        # aiortc/cryptography-gated test in tests/ skipped in CI while still
+        # showing green. `uv sync --all-extras` installs every extra
+        # declared in pyproject.toml's [project.optional-dependencies], so
+        # those tests run instead of skipping.
+        run: uv sync --all-extras
 
       - name: Agent Review Gate parser tests
         if: steps.filter.outputs.core == 'true'

--- a/tests/test_webrtc_sdp_entrypoint.py
+++ b/tests/test_webrtc_sdp_entrypoint.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -82,13 +83,20 @@ async def test_ice_unavailable_when_gate_off() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(webrtc_available(), reason="exercises the no-extra branch")
 async def test_offer_unavailable_when_extra_missing() -> None:
-    """Gate on but aiortc absent → still cleanly unavailable."""
-    server = WebServer(None, WebConfig(webrtc_enabled=True))
-    writer = _FakeWriter()
-    await server._handle_webrtc_offer(writer, {"content-length": "10"}, None)
-    code, body = _parse_response(writer)
+    """Gate on but aiortc absent → still cleanly unavailable.
+
+    Patches ``webrtc_available`` to ``False`` (the pattern
+    ``tests/test_webrtc_signaling.py`` already uses for ``_serve_info`` /
+    ``_serve_capabilities``) rather than skipping when the real extra is
+    installed, so this branch of ``_handle_webrtc_offer`` stays covered in
+    an ``--all-extras`` environment (MOR-1978).
+    """
+    with patch("rigplane.web.server.webrtc_available", return_value=False):
+        server = WebServer(None, WebConfig(webrtc_enabled=True))
+        writer = _FakeWriter()
+        await server._handle_webrtc_offer(writer, {"content-length": "10"}, None)
+        code, body = _parse_response(writer)
     assert code == 503
     assert body["code"] == "webrtc_unavailable"
 


### PR DESCRIPTION
## Summary

Fixes MOR-1978: `quick.yml`, `full.yml`, and `publish.yml` all installed dependencies with `uv sync --extra dev --extra bridge`. `bridge` is declared `bridge = []` in `pyproject.toml` — a no-op alias kept for backwards compatibility (packages moved into core deps, #1090) — so that flag installed nothing, and the extras that do carry packages (`scope`/Pillow, `dsp`/scipy, `webrtc`/aiortc, `tls`/cryptography) were named by no test workflow. 62 tests gated behind those extras have accordingly never executed in CI, while the suite still reported success.

All three workflows now run `uv sync --all-extras` instead, with a comment on each sync step stating why.

## Why `publish.yml` too

`publish.yml`'s `validate` job runs the same `pytest tests/ --ignore=tests/integration` invocation as the other two workflows and gates whether a release is built and published — it should exercise the same test surface as `quick.yml`/`full.yml`, not a narrower one. Its `validate` job runs on GitHub-hosted `ubuntu-latest`, not the `mm-build-core-1` self-hosted runner that `quick.yml`/`full.yml` use, and only triggers on `release: published`, so this leg could not be exercised by this PR's own CI run — noted as an open risk below.

## Measured facts this change relies on (established in MOR-1978, not re-derived here)

* CI today (all three interpreters, byte-identical): `10549 passed, 68 skipped, 47 xfailed, 1 xpassed`.
* A complete environment (`uv sync --all-extras`) on the same commit: `10604 passed, 13 skipped, 47 xfailed, 1 xpassed`.
* Collected item count is 10665 either way (10549+68+47+1 = 10604+13+47+1) — the 55-test difference between those two particular measurements appears in both the passed and skipped columns, and all 55 pass. No hidden failures. (55 is the delta between CI and the build host, which is a cross-host comparison; the count of extras-gated tests is 62 — see the Fix round below.)

## Verification — numbers moved

`Tests (quick)` run at the current head `b2b1a78b` ([run 32546035127](https://github.com/rigplane/rigplane-core/actions/runs/32546035127)), verbatim pytest summary line:

```
===== 10611 passed, 6 skipped, 47 xfailed, 1 xpassed, 6 warnings in 46.52s =====
```

Skipped dropped from 68 to 6 — it did not stay at 68, so the change took effect. A complete environment on the build host gives `10605 passed, 12 skipped` at this head; CI's 6 is a strict subset of that 12. The 6-test gap is measured, not guessed: 4 are libopus — `ctypes.util.find_library("opus")` returns `None` on macOS, so `import opuslib` raises and the gates in `tests/test_pcm_ingress_decode.py`, `tests/test_web_audio_opus_egress_reframing.py` and `tests/test_audio_bridge_stereo.py` fire — and 2 are `frontend build not present (src/rigplane/web/static/index.html missing)` in `tests/test_web_server.py`, which CI satisfies because its frontend step copies the build in before pytest. Both are host conditions, orthogonal to extras. All three measurements land on the same 10665-item total (`passed + skipped + xfailed + xpassed`). The residual 6 CI skips are enumerated and each is a deliberate exclusion: two hardware env opt-ins, the hardware-only `test_audio_path_smoke` row, the PortAudio opt-in, the un-vendored wfview reference (GPLv3 incompatibility), and the `x6100.toml: no agc capability` data conditional. **No extras-related skip remains anywhere.**

## Risk: native-component provisioning on the self-hosted runner — did not materialize

The complete-environment numbers in MOR-1978 were measured on the build host, not on `mm-build-core-1` (the self-hosted runner `quick.yml`/`full.yml` actually use). `aiortc`'s dependency closure and `Pillow` carry native components (aiortc 1.14.0 is itself a `py3-none-any` wheel; the native content is in `av`, `pylibsrtp`, `cryptography`, `google-crc32c`, `cffi`); the concern was that the runner might lack a system library and fail the `uv sync` step itself (a provisioning gap, not a test regression). The `quick.yml` run above shows this did not happen: `uv sync --all-extras` and the full test step both completed on `mm-build-core-1` without incident. `full.yml`'s matrix (3.11/3.12/3.13) has not run against this branch yet — the same install step is unchanged from `quick.yml`, so no different outcome is expected, but it has not been observed directly.

## Out of scope

* Retiring the `audio`/`bridge` no-op extras (MOR-1978 lists it, but it's a separate question about the published package's API surface — left open per the ticket's own scope note).
* `publish.yml`'s `validate` job could not be exercised directly by this PR (release-triggered only, `ubuntu-latest` not the self-hosted runner) — flagged above as an open risk rather than silently assumed fine.

## Fix round (review feedback addressed)

* Rewrote the `Install dependencies` comment in all three workflows: `dev`
  already installed its packages (pytest, ruff, mypy, pydantic, jsonschema,
  ...) and `bridge` is `[]`, but neither flag named `scope`/`dsp`/`webrtc`
  (62 tests: Pillow 45 + aiortc 12 + scipy 5); dropped `cryptography`/`tls`
  from the list since no test in `tests/` skips on it being unimportable.
* This diff created one net-new skip:
  `tests/test_webrtc_sdp_entrypoint.py::test_offer_unavailable_when_extra_missing`
  ran on `main` because aiortc was absent and would otherwise skip once CI
  installs it. It is the only test reaching the `if not webrtc_available()`
  branch of `WebServer._handle_webrtc_offer`. Fixed by patching
  `rigplane.web.server.webrtc_available` to `False` (the pattern
  `tests/test_webrtc_signaling.py` already uses) instead of relying on
  `skipif`, so the branch stays covered in an `--all-extras` environment.
  Quick-run skip count now 6, not 7.
* `.claude/skills/release/SKILL.md` step 2c now runs `uv sync --all-extras`
  to match `publish.yml`'s `validate` job, so the human pre-release gate
  is not narrower than release CI for a missing extra.
* Corrected the count above from 10617 (passed+skipped) to the actual
  collected total, 10665 (passed+skipped+xfailed+xpassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


