### PR TITLE
Contain the managed-TX refusal mis-attribution, delete a dead poll, and point sessions at the Linear handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,12 @@ from GitHub issues with acceptance criteria, add missing issues to the Project,
 and keep fields current while working. See
 `docs/internals/github-project-workflow.md`.
 
+**Session handoff:** the previous session's state lives in the Linear document
+*Session handoff — rigplane-core*
+(https://linear.app/morozsm/document/session-handoff-rigplane-core-9775d5570683).
+Read it first; rewrite it last. Never keep session-handoff state in this
+repository — it is public.
+
 Use subagents — keep the main session lean. The session that takes the work is
 a coordinator: it plans and dispatches, and does not implement. The
 implementation agent never reviews its own work (Language & Git above).

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -161,15 +161,23 @@ class RawCivTransactionResult:
 
 @dataclass(slots=True)
 class _CivDataTransaction:
-    """Exact tracker state owned by one data-returning CI-V request."""
+    """Exact tracker state owned by one data-returning CI-V request.
+
+    ``nak`` is ``None`` when the request was registered with
+    ``nak_terminal=False``: it then owns no ACK/NAK waiter at all, and any
+    refusal routed while it is open falls through to the tracker's orphan
+    backlog instead of settling it.
+    """
 
     response: asyncio.Future[CivFrame]
-    nak: asyncio.Future[CivFrame]
+    nak: asyncio.Future[CivFrame] | None
     owner: object | None = None
     frame: CivFrame | None = None
 
     @property
     def futures(self) -> tuple[asyncio.Future[CivFrame], ...]:
+        if self.nak is None:
+            return (self.response,)
         return (self.response, self.nak)
 
 
@@ -683,7 +691,47 @@ class CivRuntime:
         provider_generation: int,
         observer: Callable[[ProviderPttObservation], None],
     ) -> bool:
-        """Publish one exact PTT response only while its binding stays current."""
+        """Publish one exact PTT response only while its binding stays current.
+
+        Registered with ``nak_terminal=False``, so this read owns no NAK
+        waiter. ``write_managed_ptt`` sends with ``expect="none"`` and owns no
+        waiter either, and ``core/tx_safety.py: TxSafetySupervisor`` issues
+        this read as soon as that write returns — so a refusal of the write
+        reaches the tracker with this read as the only ACK/NAK waiter in
+        registration order, and would settle it. Declining the waiter leaves
+        that refusal an orphan and lets the read wait for its own ``1C 00``
+        answer (``tests/test_raw_civ_transaction.py:
+        test_refused_managed_ptt_write_leaves_the_next_read_authoritative``).
+
+        Two costs, both larger than "a slower failure of the same shape".
+
+        A refusal genuinely aimed at *this* read no longer ends it: the read
+        runs out ``_civ_get_timeout`` and raises ``asyncio.TimeoutError``
+        instead of returning a NAK result. That much is pinned by
+        ``tests/test_raw_civ_transaction.py:
+        test_authoritative_ptt_read_waits_out_its_own_refusal``, which uses a
+        shortened timeout and drives this method directly — no supervisor,
+        no effect service. What follows is read from those modules, not
+        exercised by any test here.
+
+        ``core/tx_safety.py: TxSafetySupervisor`` emits this read with its
+        ``_read_timeout``, and ``runtime/radio.py: CoreRadio.__init__``
+        derives ``_civ_get_timeout`` as ``min(timeout, 2.0)``. Both are 2.0 s
+        under shipped defaults, and the supervisor stamps its deadline first —
+        so on a timeout the effect service's deadline has already expired and
+        ``managed_tx_effect_service.py: _Service._wait`` poisons the attempt
+        instead of settling it, retiring the managed-TX provider generation.
+        On a timeout, ``settle_attempt`` is reached only when the radio was
+        built with a timeout below 2.0 s; a read that answers in time settles
+        normally, which is every ordinary one.
+
+        The orphaned refusal is also not inert. It lands in the tracker's ACK
+        backlog and stays claimable for ``ack_backlog_ttl``, where the next
+        ``register_ack(consume_backlog=True)`` — the form ``_execute_civ_raw``
+        uses — claims it and reports it as that command's failure. So this
+        read stops being charged another command's refusal; the refusal is
+        charged to a different command instead.
+        """
         async with self._ptt_read_lock:
             token = self._managed_tx_ports.get(provider_generation)
             managed = token is not None
@@ -702,7 +750,7 @@ class CivRuntime:
             self._active_ptt_read = read
             try:
                 result = await self.execute_civ_transaction(
-                    civ_frame, expect="data", owner=read
+                    civ_frame, expect="data", owner=read, nak_terminal=False
                 )
                 return (
                     result.status == "response"
@@ -919,12 +967,25 @@ class CivRuntime:
         expect: RawCivExpectation,
         timeout: float | None = None,
         owner: object | None = None,
+        nak_terminal: bool = True,
     ) -> RawCivTransactionResult:
         """Execute one explicitly-scoped raw CI-V transaction.
 
         Unlike the poller/commander path, this does not infer whether a command
         should ACK or return data. The caller must choose ``none``, ``ack``, or
         ``data`` so vendor-specific commands remain deterministic.
+
+        ``nak_terminal`` applies to ``expect="data"`` only. A CI-V refusal
+        names no command, and ``core/civ.py: CivRequestTracker.resolve`` gives
+        an ACK/NAK to the first eligible waiter in registration order, so a
+        request that registers a NAK waiter can be settled by somebody else's
+        refusal. Pass ``nak_terminal=False`` to register no NAK waiter: this
+        request then waits for its exact response, and any refusal routed
+        meanwhile falls through to the tracker's orphan ACK backlog — where it
+        stays claimable for ``ack_backlog_ttl`` by the next
+        ``register_ack(consume_backlog=True)``, rather than being discarded.
+        The cost is that a refusal genuinely aimed at *this* request no longer
+        ends it — it runs out ``timeout`` and fails as a timeout instead.
         """
         assert self._host._civ_transport is not None
         self._ensure_civ_runtime()
@@ -970,7 +1031,9 @@ class CivRuntime:
                     raise RuntimeError("ACK waiter registration returned sink token")
                 pending_waiters.append(pending_or_token)
             else:
-                data_transaction = self._register_civ_data_transaction(request_key)
+                data_transaction = self._register_civ_data_transaction(
+                    request_key, nak_terminal=nak_terminal
+                )
                 data_transaction.owner = owner
                 pending_waiters.extend(data_transaction.futures)
 
@@ -989,7 +1052,12 @@ class CivRuntime:
             if data_transaction is not None:
                 frame = data_transaction.frame
                 if frame is None:
+                    # A future that completed with a *result* has already set
+                    # ``frame`` (``_claim_civ_data_transaction`` runs in the
+                    # same synchronous step as ``resolve``), so every future
+                    # left here carries an exception to re-raise.
                     data_transaction.response.result()
+                    assert data_transaction.nak is not None
                     frame = data_transaction.nak.result()
             else:
                 frame = pending_waiters[0].result()
@@ -1021,23 +1089,26 @@ class CivRuntime:
         )
 
     def _register_civ_data_transaction(
-        self, request_key: CivRequestKey
+        self, request_key: CivRequestKey, *, nak_terminal: bool = True
     ) -> _CivDataTransaction:
         """Register exact response and NAK identities for one data request."""
         if self._civ_data_transaction is not None:
             raise RuntimeError("CI-V data transaction already active")
         tracker = self._host._civ_request_tracker
         response = tracker.register_response(request_key)
-        nak_or_token = tracker.register_ack(
-            wait=True,
-            consume_backlog=False,
-            nak_only=True,
-        )
-        if isinstance(nak_or_token, int):
-            tracker.unregister(response)
-            response.cancel()
-            raise RuntimeError("ACK waiter registration returned sink token")
-        transaction = _CivDataTransaction(response=response, nak=nak_or_token)
+        nak: asyncio.Future[CivFrame] | None = None
+        if nak_terminal:
+            nak_or_token = tracker.register_ack(
+                wait=True,
+                consume_backlog=False,
+                nak_only=True,
+            )
+            if isinstance(nak_or_token, int):
+                tracker.unregister(response)
+                response.cancel()
+                raise RuntimeError("ACK waiter registration returned sink token")
+            nak = nak_or_token
+        transaction = _CivDataTransaction(response=response, nak=nak)
         self._civ_data_transaction = transaction
         return transaction
 
@@ -1062,7 +1133,7 @@ class CivRuntime:
         winner = (
             transaction.nak if event.type == CivEventType.NAK else transaction.response
         )
-        if winner.cancelled() or not winner.done():
+        if winner is None or winner.cancelled() or not winner.done():
             return None
         try:
             frame = winner.result()

--- a/src/rigplane/runtime/_shared_state_runtime.py
+++ b/src/rigplane/runtime/_shared_state_runtime.py
@@ -30,7 +30,6 @@ __all__ = [
     "is_cache_fresh",
     "poll_frequency",
     "poll_mode",
-    "poll_powerstat",
     "poll_standard_fields",
 ]
 
@@ -137,44 +136,6 @@ async def poll_mode(
         return (mode_str, filt)
     except Exception:
         logger.debug("poll_mode: radio call failed", exc_info=True)
-        return None
-
-
-async def poll_powerstat(
-    radio: "Radio",
-    cache: StateCache,
-    ttl: float,
-) -> bool | None:
-    """Return the current power status, using cache when fresh.
-
-    If the ``"powerstat"`` field in *cache* is younger than *ttl* seconds,
-    the cached value is returned immediately without hitting the radio.
-    Otherwise :meth:`Radio.get_powerstat` is called (if supported),
-    the result stored in *cache*, and the fresh value returned.
-
-    On any exception from the radio the cache is left unchanged and
-    ``None`` is returned.
-
-    Args:
-        radio: Connected :class:`Radio` instance (must implement PowerControlCapable).
-        cache: Shared :class:`StateCache` to read from / write to.
-        ttl: Cache TTL in seconds.  Use ``0.0`` to always poll.
-
-    Returns:
-        True if powered on, False if powered off, or ``None`` if the radio call failed.
-    """
-    from rigplane.capabilities import CAP_POWER_CONTROL
-
-    if is_cache_fresh(cache, "powerstat", ttl):
-        return cache.powerstat
-    if CAP_POWER_CONTROL not in radio.capabilities:
-        return None
-    try:
-        power_on = await radio.get_powerstat()  # type: ignore[attr-defined]
-        cache.update_powerstat(power_on)
-        return power_on  # type: ignore[no-any-return]
-    except Exception:
-        logger.debug("poll_powerstat: radio call failed", exc_info=True)
         return None
 
 

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -16,6 +16,7 @@ from rigplane.core.civ import (
     CivRequestTracker,
     request_key_from_frame,
 )
+from rigplane.core import tx_safety as tx
 from rigplane.core.exceptions import ConnectionError as RigplaneConnectionError
 from rigplane.radio import IcomRadio
 from rigplane.runtime._civ_rx import _CivDataTransaction
@@ -424,6 +425,33 @@ async def test_data_transaction_cancel_settles_token_before_late_response(
         parse_civ_frame(_ptt()), generation=radio._civ_epoch
     )
     assert len(observations) == 1
+
+
+async def test_refused_managed_ptt_write_leaves_the_next_read_authoritative(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    """A refused managed TX write must not be charged to the read behind it.
+
+    ``_civ_rx.py: CivRuntime.write_managed_ptt`` sends with ``expect="none"``
+    and so registers no waiter for its own terminal frame, while
+    ``_civ_rx.py: CivRuntime.request_authoritative_ptt_read`` registers its
+    waiters before dispatching. Send #1 is the write and send #2 the read, and
+    both replies are released on send #2 — the write's refusal reaching the
+    tracker after the read was already registered. The read's own ``1C 00``
+    answer, not that refusal, must decide the read.
+    """
+    radio._civ_min_interval = 0.0
+    radio._civ_get_timeout = 1.0
+    observations: list[tx.ProviderPttObservation] = []
+    observer = observations.append
+    assert radio._capture_managed_tx_port(11, observer)
+    transport.queue_response_on_send(2, _wrap(_nak()))
+    transport.queue_response_on_send(2, _wrap(_ptt(0)))
+
+    await radio._write_managed_ptt(11, True)
+    await radio._request_authoritative_ptt_read(11, observer)
+
+    assert [o.value for o in observations] == [tx.RadioTx.OFF]
 
 
 def _wrap(civ_frame: bytes) -> bytes:

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 from test_radio import MockTransport
@@ -64,8 +65,10 @@ def _capture_data_transaction(
     runtime = radio._civ_runtime
     register = runtime._register_civ_data_transaction
 
-    def capture(key: CivRequestKey) -> _CivDataTransaction:
-        transaction = register(key)
+    def capture(
+        key: CivRequestKey, *, nak_terminal: bool = True
+    ) -> _CivDataTransaction:
+        transaction = register(key, nak_terminal=nak_terminal)
         captured.append(transaction)
         return transaction
 
@@ -452,6 +455,31 @@ async def test_refused_managed_ptt_write_leaves_the_next_read_authoritative(
     await radio._request_authoritative_ptt_read(11, observer)
 
     assert [o.value for o in observations] == [tx.RadioTx.OFF]
+
+
+async def test_authoritative_ptt_read_waits_out_its_own_refusal(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    """The price of owning no NAK waiter, stated so it cannot drift silently.
+
+    ``_civ_rx.py: CivRuntime.request_authoritative_ptt_read`` registers no
+    ACK/NAK waiter, so a refusal aimed at the read itself is an orphan too:
+    the read spends its whole ``_civ_get_timeout`` and then fails as a
+    timeout rather than failing fast on the refusal.
+    """
+    radio._civ_min_interval = 0.0
+    radio._civ_get_timeout = 0.05
+    observations: list[tx.ProviderPttObservation] = []
+    observer = observations.append
+    assert radio._capture_managed_tx_port(11, observer)
+    transport.queue_response_on_send(1, _wrap(_nak()))
+
+    started = time.monotonic()
+    with pytest.raises(asyncio.TimeoutError):
+        await radio._request_authoritative_ptt_read(11, observer)
+
+    assert time.monotonic() - started >= radio._civ_get_timeout
+    assert observations == []
 
 
 def _wrap(civ_frame: bytes) -> bytes:


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1980 (commits 2–3). Commits 1 and 4 are unticketed findings from the same session.
- Compatibility impact: **wire behaviour** — one CI-V read stops registering a NAK waiter, see below. No API, CLI or config change.

**Three unrelated units of work in one pull request. Stated plainly rather than dressed up as one.**

| Commit | Unit |
|---|---|
| `799d5ed` | `CLAUDE.md` pointer to the Linear session handoff |
| `ed9d558` + `bbf1f56` | MOR-1980 — containment for the managed-TX refusal mis-attribution |
| `a0cbb8b` | delete `poll_powerstat`, which nothing has ever called |

**Why they are together.** All three were produced in one session on the branch this session was assigned, and pushing to any other branch needed the owner's permission, which was given for keeping them here rather than splitting. Size is not the reason: 4 files / 210 changed lines sits inside the soft threshold (6 / 600) on both counts. Coherence is the cost, and it is real — reviewing this means reviewing three things.

Split on request; the commits are clean and each stands alone.

---

## Unit 1 — the handoff pointer (`799d5ed`)

Six lines in `CLAUDE.md`. The previous handoff lived at `.claude/handoff.md`, which `.gitignore` excludes by construction, so it could not survive a fresh clone and did not. The content moves to Linear, which is private; only the pointer stays here, with the prohibition and its reason attached so the next session does not re-propose the file.

Independently reviewed at four heads now, and re-verified undisturbed at each.

## Unit 2 — MOR-1980 containment (`ed9d558`, `bbf1f56`)

**The defect.** `CivRuntime.write_managed_ptt` sends the managed transmit write with `expect="none"` and registers nothing, so its refusal is an orphan. `CivRequestTracker.resolve` hands an ACK/NAK to the first eligible waiter in registration order — a CI-V refusal names no command, so there is nothing to key on. `core/tx_safety.py: TxSafetySupervisor` issues the `READ_PTT` as soon as that write returns, and `request_authoritative_ptt_read` registers a `nak_only` waiter. **A refusal for the write therefore lands on the read**, and downstream that forces release of the operator's transmit lease, reported as a transport loss.

`ed9d558` pins it — red on the parent commit. `bbf1f56` adds `nak_terminal` to `execute_civ_transaction` and passes `False` from the authoritative PTT read only, so that read owns no NAK waiter and the refusal stays an orphan. Default is `True`, so the raw-transaction endpoint and `CoreRadio.send_civ_transaction` are unchanged — and that default is pinned: flipping it turns 7 tests red.

**This is containment, not a cure, and the containment has two costs. Both are now stated in the code rather than glossed.**

1. **The orphaned refusal is not inert.** It lands in the tracker's ACK backlog and stays claimable for `ack_backlog_ttl`, where the next `register_ack(consume_backlog=True)` claims it and reports it as that command's failure. That is `_execute_civ_raw`'s blocking branch — the only call site in `src/` that reaches the backlog-consuming path, since consumption sits inside `if wait:` and the one other site leaving the default passes `wait=False`. So this read stops being charged another command's refusal; **the refusal is charged to a different command instead.** Severity drops from *forced lease release* to *one spurious command failure*, which is the point, but the mis-charge is displaced, not eliminated. Closing it is MOR-1977 unit A.

2. **A refusal genuinely aimed at the PTT read no longer fails fast**, and what the delay costs is not a slower failure of the same shape. `TxSafetySupervisor._read_timeout` and `CoreRadio.__init__`'s `_civ_get_timeout = min(timeout, 2.0)` are both 2.0 s under shipped defaults, and the supervisor stamps its deadline first — so on a timeout `managed_tx_effect_service.py: _Service._wait` **poisons the attempt rather than settling it**, retiring the managed-TX provider generation. On a timeout, `settle_attempt` is reached only on a radio built with a timeout below 2.0 s; a read that answers in time settles normally, which is every ordinary one. `tests/test_raw_civ_transaction.py::test_authoritative_ptt_read_waits_out_its_own_refusal` pins the timeout on a shortened budget and drives the method directly; the downstream consequence is read from those modules and exercised by no test.

Whether cost 2 is ever paid is not established. The bench inventory of what this radio declines is recorded in MOR-1976, not in this repository, so nothing here pins it either way.

The cause — refusals carry no correlation and the tracker's ACK/NAK lane is keyless — is MOR-1977's and is untouched.

**Two candidates were measured failing** before this one: giving the write its own blocking waiter (the late refusal reaches the read once that waiter is retired) and giving it a fire-and-forget sink (narrows the window to `_civ_ack_sink_grace`, 120 ms, settable from an environment variable). Deliberately excluded: retrying a failed `READ_PTT` before release, which would paper over the mis-attribution and weaken a fail-closed property pinned by `tests/test_tx_safety.py::test_acquisition_read_failure_fails_closed`; and correcting the misleading `TxReleaseReason`, which is separable and reduces no harm here.

## Unit 3 — delete `poll_powerstat` (`a0cbb8b`)

Zero callers in `src/` and zero in `tests/`; the only three references in either tree were its own `__all__` entry, its own definition and its own log line. It polled CI-V `0x18`, which has no read form — Icom defines only `18 00` off, `18 01` on, `18 02` standby. rigctld's own `\get_powerstat` already answers from reachability without polling, pinned by `tests/test_rigctld_handler.py::test_rigctld_get_powerstat_is_wsjtx_compatibility_probe`.

`Radio.get_powerstat` stays: protocol surface on `core/radio_protocol.py: PowerControlCapable`, implemented by the Icom and Yaesu CAT backends. **It has no production caller in `src/` today** — an earlier draft of this message claimed it was reached from the CLI and rigctld, which was false and contradicted its own preceding sentence.

It was the sole reader of `StateCache.powerstat`, which is now written and never read. Left in place rather than widened into this change.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10545 passed, 0 failed**. `uv run ruff check src/ tests/` clean; `ruff format --check` clean (688 files). `uv run lint-imports`: 5 contracts kept, 0 broken.
- [x] Public/open-core boundary checked — no telemetry, no Pro content, no bench detail.
- [x] Release or migration impact documented if applicable — none. The `nak_terminal` default preserves existing behaviour for every caller but the one changed here.

Not run: the Mac mini suite. CI runs the same command, and the local run above agrees with it.

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` agent, relayed by the coordinating session (the reviewing environment has no GitHub access)
- Result so far: **BLOCKED** at `a6875d1`, `2364549` and `0c2e84c`. Re-review requested at this head.
- **Every block has been about prose, never about the code.** An AST comparison at this head — parse `_civ_rx.py`, strip every docstring, dump — is identical to the pre-review `85d9fa4`. Across four rounds not one byte of executable code has changed.
- Round 1: three false claims, two written by the coordinating session. Round 2: the docstrings were genuinely fixed, but the same two sentences survived verbatim in the MOR-1980 commit's own message, so the commit contradicted the docstring it shipped with. Round 3: the rewritten message introduced two new claims that failed the same test — a call-site count that was wrong by enumeration, and a bench inventory that exists only in Linear and so cannot be checked from this repository at all.
- All of it is fixed at this head, and each round's fix was swept for recurrence across all four commit messages and all four changed files.

## Notes

- Out of scope / follow-ups: MOR-1977 unit A (stop the commander path consuming a stale acknowledgement from the backlog) is what would close cost 1 above; the two compose and should land close together. The reviewer's probe for it is a working starting point.
- Also recorded for MOR-1977: `runtime/_civ_rx.py` carries nine bare `assert` statements of the shape that ticket already flags, including one added here that mypy needs for narrowing. Converting one alone would be an unrequested change.