### PR TITLE
test(MOR-1986): pin every command builder against its profile command map

### DIFF
--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -1,0 +1,158 @@
+# Known cmd_map/fallback disagreements, tab separated:
+#   <profile>  <module>:<builder>  <arguments>  <observed frames>
+# tests/test_command_map_parity.py fails on a disagreement missing
+# here, and on a row here that no longer disagrees -- delete that
+# row, never keep it. Regenerating can still add rows, so read any
+# addition as a new divergence someone has to justify.
+IC-705	config.py:get_civ_transceive	(no arguments)	map=fefea4e01a050112fd fallback=fefea4e01a050129fd
+IC-705	config.py:get_data1_mod_input	(no arguments)	map=fefea4e01a050119fd fallback=fefea4e01a050092fd
+IC-705	config.py:get_data_off_mod_input	(no arguments)	map=fefea4e01a050118fd fallback=fefea4e01a050091fd
+IC-705	config.py:get_lan_mod_level	(no arguments)	map=fefea4e01a050117fd fallback=fefea4e01411fd
+IC-705	config.py:get_usb_mod_level	(no arguments)	map=fefea4e01a050116fd fallback=fefea4e01410fd
+IC-705	config.py:set_civ_transceive	enabled=False	map=fefea4e01a050112012900fd fallback=fefea4e01a05012900fd
+IC-705	config.py:set_data1_mod_input	source=0	map=fefea4e01a050119009200fd fallback=fefea4e01a05009200fd
+IC-705	config.py:set_data_off_mod_input	source=0	map=fefea4e01a050118009100fd fallback=fefea4e01a05009100fd
+IC-705	config.py:set_lan_mod_level	level=0	map=fefea4e01a0501170000fd fallback=fefea4e014110000fd
+IC-705	config.py:set_usb_mod_level	level=0	map=fefea4e01a0501160000fd fallback=fefea4e014100000fd
+IC-705	dsp.py:get_attenuator	command29=False	map=fefea4e0290011fd fallback=fefea4e011fd
+IC-705	dsp.py:get_preamp	command29=False	map=fefea4e029001602fd fallback=fefea4e01602fd
+IC-705	dsp.py:set_attenuator	command29=False, on=False	map=fefea4e029001100fd fallback=fefea4e01100fd
+IC-705	dsp.py:set_attenuator_level	command29=False, db=0	map=fefea4e029001100fd fallback=fefea4e01100fd
+IC-705	dsp.py:set_preamp	command29=False	map=fefea4e02900160201fd fallback=fefea4e0160201fd
+IC-705	levels.py:get_dash_ratio	(no arguments)	map=fefea4e01a050252fd fallback=fefea4e01a050228fd
+IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=fefea4e01a050070fd
+IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a050252022830fd fallback=fefea4e01a05022830fd
+IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a05008900700000fd fallback=fefea4e01a0500700000fd
+IC-705	scope.py:get_scope_center_type	receiver=0	map=fefea4e0271cfd fallback=fefea4e0271c00fd
+IC-705	scope.py:get_scope_edge	receiver=0	map=fefea4e02716fd fallback=fefea4e0271600fd
+IC-705	scope.py:get_scope_hold	receiver=0	map=fefea4e02717fd fallback=fefea4e0271700fd
+IC-705	scope.py:get_scope_mode	receiver=0	map=fefea4e02714fd fallback=fefea4e0271400fd
+IC-705	scope.py:get_scope_rbw	receiver=0	map=fefea4e0271ffd fallback=fefea4e0271f00fd
+IC-705	scope.py:get_scope_ref	receiver=0	map=fefea4e02719fd fallback=fefea4e0271900fd
+IC-705	scope.py:get_scope_span	receiver=0	map=fefea4e02715fd fallback=fefea4e0271500fd
+IC-705	scope.py:get_scope_speed	receiver=0	map=fefea4e0271afd fallback=fefea4e0271a00fd
+IC-705	scope.py:get_scope_vbw	receiver=0	map=fefea4e0271dfd fallback=fefea4e0271d00fd
+IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a0500450033fd fallback=fefea4e01a050033fd
+IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a0500450033fd fallback=fefea4e01a050033fd
+IC-7300	config.py:get_acc1_mod_level	(no arguments)	map=fefe94e01a050064fd fallback=fefe94e0140bfd
+IC-7300	config.py:get_civ_output_ant	(no arguments)	map=fefe94e01a050061fd fallback=fefe94e01a050130fd
+IC-7300	config.py:get_civ_transceive	(no arguments)	map=fefe94e01a050071fd fallback=fefe94e01a050129fd
+IC-7300	config.py:get_data1_mod_input	(no arguments)	map=fefe94e01a050067fd fallback=fefe94e01a050092fd
+IC-7300	config.py:get_data_off_mod_input	(no arguments)	map=fefe94e01a050066fd fallback=fefe94e01a050091fd
+IC-7300	config.py:get_usb_mod_level	(no arguments)	map=fefe94e01a050065fd fallback=fefe94e01410fd
+IC-7300	config.py:set_acc1_mod_level	level=0	map=fefe94e01a0500640000fd fallback=fefe94e0140b0000fd
+IC-7300	config.py:set_civ_output_ant	enabled=False	map=fefe94e01a050061013000fd fallback=fefe94e01a05013000fd
+IC-7300	config.py:set_civ_transceive	enabled=False	map=fefe94e01a050071012900fd fallback=fefe94e01a05012900fd
+IC-7300	config.py:set_data1_mod_input	source=0	map=fefe94e01a050067009200fd fallback=fefe94e01a05009200fd
+IC-7300	config.py:set_data_off_mod_input	source=0	map=fefe94e01a050066009100fd fallback=fefe94e01a05009100fd
+IC-7300	config.py:set_usb_mod_level	level=0	map=fefe94e01a0500650000fd fallback=fefe94e014100000fd
+IC-7300	dsp.py:get_attenuator	command29=False	map=fefe94e0290011fd fallback=fefe94e011fd
+IC-7300	dsp.py:get_preamp	command29=False	map=fefe94e029001602fd fallback=fefe94e01602fd
+IC-7300	dsp.py:set_attenuator	command29=False, on=False	map=fefe94e029001100fd fallback=fefe94e01100fd
+IC-7300	dsp.py:set_attenuator_level	command29=False, db=0	map=fefe94e029001100fd fallback=fefe94e01100fd
+IC-7300	dsp.py:set_preamp	command29=False	map=fefe94e02900160201fd fallback=fefe94e0160201fd
+IC-7300	levels.py:get_nb_depth	(no arguments)	map=fefe94e01a050189fd fallback=fefe94e01a050290fd
+IC-7300	levels.py:get_nb_width	(no arguments)	map=fefe94e01a050190fd fallback=fefe94e01a050291fd
+IC-7300	levels.py:get_vox_delay	(no arguments)	map=fefe94e01a050191fd fallback=fefe94e01a050292fd
+IC-7300	levels.py:set_nb_depth	value=0	map=fefe94e01a050189029000fd fallback=fefe94e01a05029000fd
+IC-7300	levels.py:set_nb_width	value=0	map=fefe94e01a05019002910000fd fallback=fefe94e01a0502910000fd
+IC-7300	levels.py:set_ref_adjust	value=0	map=fefe94e01a05007000700000fd fallback=fefe94e01a0500700000fd
+IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a050191029200fd fallback=fefe94e01a05029200fd
+IC-7300	scope.py:get_scope_center_type	receiver=0	map=fefe94e0271cfd fallback=fefe94e0271c00fd
+IC-7300	scope.py:get_scope_edge	receiver=0	map=fefe94e02716fd fallback=fefe94e0271600fd
+IC-7300	scope.py:get_scope_hold	receiver=0	map=fefe94e02717fd fallback=fefe94e0271700fd
+IC-7300	scope.py:get_scope_mode	receiver=0	map=fefe94e02714fd fallback=fefe94e0271400fd
+IC-7300	scope.py:get_scope_rbw	receiver=0	map=fefe94e0271ffd fallback=fefe94e0271f00fd
+IC-7300	scope.py:get_scope_ref	receiver=0	map=fefe94e02719fd fallback=fefe94e0271900fd
+IC-7300	scope.py:get_scope_span	receiver=0	map=fefe94e02715fd fallback=fefe94e0271500fd
+IC-7300	scope.py:get_scope_speed	receiver=0	map=fefe94e0271afd fallback=fefe94e0271a00fd
+IC-7300	scope.py:get_scope_vbw	receiver=0	map=fefe94e0271dfd fallback=fefe94e0271d00fd
+IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a0500300033fd fallback=fefe94e01a050033fd
+IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a0500300033fd fallback=fefe94e01a050033fd
+IC-7610	config.py:get_acc1_mod_level	(no arguments)	map=fefe98e01a050088fd fallback=fefe98e0140bfd
+IC-7610	config.py:get_civ_output_ant	(no arguments)	map=fefe98e01c04fd fallback=fefe98e01a050130fd
+IC-7610	config.py:get_civ_transceive	(no arguments)	map=fefe98e01a050112fd fallback=fefe98e01a050129fd
+IC-7610	config.py:get_lan_mod_level	(no arguments)	map=fefe98e01a050090fd fallback=fefe98e01411fd
+IC-7610	config.py:get_usb_mod_level	(no arguments)	map=fefe98e01a050089fd fallback=fefe98e01410fd
+IC-7610	config.py:set_acc1_mod_level	level=0	map=fefe98e01a0500880000fd fallback=fefe98e0140b0000fd
+IC-7610	config.py:set_civ_output_ant	enabled=False	map=fefe98e01c04013000fd fallback=fefe98e01a05013000fd
+IC-7610	config.py:set_civ_transceive	enabled=False	map=fefe98e01a050112012900fd fallback=fefe98e01a05012900fd
+IC-7610	config.py:set_data1_mod_input	source=0	map=fefe98e01a050092009200fd fallback=fefe98e01a05009200fd
+IC-7610	config.py:set_data2_mod_input	source=0	map=fefe98e01a050093009300fd fallback=fefe98e01a05009300fd
+IC-7610	config.py:set_data3_mod_input	source=0	map=fefe98e01a050094009400fd fallback=fefe98e01a05009400fd
+IC-7610	config.py:set_data_off_mod_input	source=0	map=fefe98e01a050091009100fd fallback=fefe98e01a05009100fd
+IC-7610	config.py:set_lan_mod_level	level=0	map=fefe98e01a0500900000fd fallback=fefe98e014110000fd
+IC-7610	config.py:set_usb_mod_level	level=0	map=fefe98e01a0500890000fd fallback=fefe98e014100000fd
+IC-7610	dsp.py:get_af_mute	command29=False	map=fefe98e029001a09fd fallback=fefe98e01a09fd
+IC-7610	dsp.py:get_attenuator	command29=False	map=fefe98e0290011fd fallback=fefe98e011fd
+IC-7610	dsp.py:get_digisel	command29=False	map=fefe98e02900164efd fallback=fefe98e0164efd
+IC-7610	dsp.py:get_preamp	command29=False	map=fefe98e029001602fd fallback=fefe98e01602fd
+IC-7610	dsp.py:set_af_mute	command29=False, on=False	map=fefe98e029001a0900fd fallback=fefe98e01a0900fd
+IC-7610	dsp.py:set_attenuator	command29=False, on=False	map=fefe98e029001100fd fallback=fefe98e01100fd
+IC-7610	dsp.py:set_attenuator_level	command29=False, db=0	map=fefe98e029001100fd fallback=fefe98e01100fd
+IC-7610	dsp.py:set_digisel	command29=False, on=False	map=fefe98e02900164e00fd fallback=fefe98e0164e00fd
+IC-7610	dsp.py:set_preamp	command29=False	map=fefe98e02900160201fd fallback=fefe98e0160201fd
+IC-7610	levels.py:set_dash_ratio	value=30	map=fefe98e01a050228022830fd fallback=fefe98e01a05022830fd
+IC-7610	levels.py:set_nb_depth	value=0	map=fefe98e01a050290029000fd fallback=fefe98e01a05029000fd
+IC-7610	levels.py:set_nb_width	value=0	map=fefe98e01a05029102910000fd fallback=fefe98e01a0502910000fd
+IC-7610	levels.py:set_ref_adjust	value=0	map=fefe98e01a05007000700000fd fallback=fefe98e01a0500700000fd
+IC-7610	levels.py:set_vox_delay	value=0	map=fefe98e01a050292029200fd fallback=fefe98e01a05029200fd
+IC-7610	scope.py:get_scope_center_type	receiver=0	map=fefe98e0271cfd fallback=fefe98e0271c00fd
+IC-7610	scope.py:get_scope_edge	receiver=0	map=fefe98e02716fd fallback=fefe98e0271600fd
+IC-7610	scope.py:get_scope_hold	receiver=0	map=fefe98e02717fd fallback=fefe98e0271700fd
+IC-7610	scope.py:get_scope_mode	receiver=0	map=fefe98e02714fd fallback=fefe98e0271400fd
+IC-7610	scope.py:get_scope_rbw	receiver=0	map=fefe98e0271ffd fallback=fefe98e0271f00fd
+IC-7610	scope.py:get_scope_ref	receiver=0	map=fefe98e02719fd fallback=fefe98e0271900fd
+IC-7610	scope.py:get_scope_span	receiver=0	map=fefe98e02715fd fallback=fefe98e0271500fd
+IC-7610	scope.py:get_scope_speed	receiver=0	map=fefe98e0271afd fallback=fefe98e0271a00fd
+IC-7610	scope.py:get_scope_vbw	receiver=0	map=fefe98e0271dfd fallback=fefe98e0271d00fd
+IC-7610	vfo.py:get_dual_watch	(no arguments)	map=fefe98e007c2c2fd fallback=fefe98e007c2fd
+IC-7610	vfo.py:get_main_sub_band	(no arguments)	map=fefe98e007d2d2fd fallback=fefe98e007d2fd
+IC-7610	vfo.py:get_quick_dual_watch	(no arguments)	map=fefe98e01a0500320032fd fallback=fefe98e01a050032fd
+IC-7610	vfo.py:get_quick_split	(no arguments)	map=fefe98e01a0500330033fd fallback=fefe98e01a050033fd
+IC-7610	vfo.py:set_quick_dual_watch	(no arguments)	map=fefe98e01a0500320032fd fallback=fefe98e01a050032fd
+IC-7610	vfo.py:set_quick_split	(no arguments)	map=fefe98e01a0500330033fd fallback=fefe98e01a050033fd
+IC-9700	config.py:get_acc1_mod_level	(no arguments)	map=fefea2e01a050064fd fallback=fefea2e0140bfd
+IC-9700	config.py:get_civ_output_ant	(no arguments)	map=fefea2e01a050061fd fallback=fefea2e01a050130fd
+IC-9700	config.py:get_civ_transceive	(no arguments)	map=fefea2e01a050071fd fallback=fefea2e01a050129fd
+IC-9700	config.py:get_data1_mod_input	(no arguments)	map=fefea2e01a050067fd fallback=fefea2e01a050092fd
+IC-9700	config.py:get_data_off_mod_input	(no arguments)	map=fefea2e01a050066fd fallback=fefea2e01a050091fd
+IC-9700	config.py:get_usb_mod_level	(no arguments)	map=fefea2e01a050065fd fallback=fefea2e01410fd
+IC-9700	config.py:set_acc1_mod_level	level=0	map=fefea2e01a0500640000fd fallback=fefea2e0140b0000fd
+IC-9700	config.py:set_civ_output_ant	enabled=False	map=fefea2e01a050061013000fd fallback=fefea2e01a05013000fd
+IC-9700	config.py:set_civ_transceive	enabled=False	map=fefea2e01a050071012900fd fallback=fefea2e01a05012900fd
+IC-9700	config.py:set_data1_mod_input	source=0	map=fefea2e01a050067009200fd fallback=fefea2e01a05009200fd
+IC-9700	config.py:set_data_off_mod_input	source=0	map=fefea2e01a050066009100fd fallback=fefea2e01a05009100fd
+IC-9700	config.py:set_usb_mod_level	level=0	map=fefea2e01a0500650000fd fallback=fefea2e014100000fd
+IC-9700	dsp.py:get_attenuator	command29=False	map=fefea2e0290011fd fallback=fefea2e011fd
+IC-9700	dsp.py:get_preamp	command29=False	map=fefea2e029001602fd fallback=fefea2e01602fd
+IC-9700	dsp.py:set_attenuator	command29=False, on=False	map=fefea2e029001100fd fallback=fefea2e01100fd
+IC-9700	dsp.py:set_attenuator_level	command29=False, db=0	map=fefea2e029001100fd fallback=fefea2e01100fd
+IC-9700	dsp.py:set_preamp	command29=False	map=fefea2e02900160201fd fallback=fefea2e0160201fd
+IC-9700	levels.py:get_nb_depth	(no arguments)	map=fefea2e01a050189fd fallback=fefea2e01a050290fd
+IC-9700	levels.py:get_nb_width	(no arguments)	map=fefea2e01a050190fd fallback=fefea2e01a050291fd
+IC-9700	levels.py:get_vox_delay	(no arguments)	map=fefea2e01a050191fd fallback=fefea2e01a050292fd
+IC-9700	levels.py:set_nb_depth	value=0	map=fefea2e01a050189029000fd fallback=fefea2e01a05029000fd
+IC-9700	levels.py:set_nb_width	value=0	map=fefea2e01a05019002910000fd fallback=fefea2e01a0502910000fd
+IC-9700	levels.py:set_ref_adjust	value=0	map=fefea2e01a05007000700000fd fallback=fefea2e01a0500700000fd
+IC-9700	levels.py:set_vox_delay	value=0	map=fefea2e01a050191029200fd fallback=fefea2e01a05029200fd
+IC-9700	scope.py:get_scope_center_type	receiver=0	map=fefea2e0271cfd fallback=fefea2e0271c00fd
+IC-9700	scope.py:get_scope_edge	receiver=0	map=fefea2e02716fd fallback=fefea2e0271600fd
+IC-9700	scope.py:get_scope_hold	receiver=0	map=fefea2e02717fd fallback=fefea2e0271700fd
+IC-9700	scope.py:get_scope_mode	receiver=0	map=fefea2e02714fd fallback=fefea2e0271400fd
+IC-9700	scope.py:get_scope_rbw	receiver=0	map=fefea2e0271ffd fallback=fefea2e0271f00fd
+IC-9700	scope.py:get_scope_ref	receiver=0	map=fefea2e02719fd fallback=fefea2e0271900fd
+IC-9700	scope.py:get_scope_span	receiver=0	map=fefea2e02715fd fallback=fefea2e0271500fd
+IC-9700	scope.py:get_scope_speed	receiver=0	map=fefea2e0271afd fallback=fefea2e0271a00fd
+IC-9700	scope.py:get_scope_vbw	receiver=0	map=fefea2e0271dfd fallback=fefea2e0271d00fd
+IC-9700	vfo.py:get_dual_watch	(no arguments)	map=fefea2e007c2c2fd fallback=fefea2e007c2fd
+IC-9700	vfo.py:get_main_sub_band	(no arguments)	map=fefea2e007d2d2fd fallback=fefea2e007d2fd
+IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a0500300033fd fallback=fefea2e01a050033fd
+IC-9700	vfo.py:set_quick_split	(no arguments)	map=fefea2e01a0500300033fd fallback=fefea2e01a050033fd
+X6100	ptt.py:ptt_off	(no arguments)	map=fefe70e01c000000fd fallback=fefe70e01c0000fd
+X6100	ptt.py:ptt_on	(no arguments)	map=fefe70e01c000101fd fallback=fefe70e01c0001fd
+X6200	dsp.py:get_attenuator	command29=False	map=fefea4e0290011fd fallback=fefea4e011fd
+X6200	dsp.py:get_preamp	command29=False	map=fefea4e029001602fd fallback=fefea4e01602fd
+X6200	dsp.py:set_attenuator	command29=False, on=False	map=fefea4e029001100fd fallback=fefea4e01100fd
+X6200	dsp.py:set_attenuator_level	command29=False, db=0	map=fefea4e029001100fd fallback=fefea4e01100fd
+X6200	dsp.py:set_preamp	command29=False	map=fefea4e02900160201fd fallback=fefea4e0160201fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -1,0 +1,248 @@
+# What tests/test_command_map_parity.py could NOT compare, and how
+# much it did. Tab separated, five row kinds:
+#   census    <name>              <count>
+#   cat-only  <profile>           <commands, every one of them CAT>
+#   gap       <command name>      <profiles whose map omits it>
+#   noargs    <module>:<builder>  no probe value was accepted
+#   unpinned  <module>:<builder>  no compared builder reaches it
+# A 'gap' row means that profile's CommandMap holds no CI-V entry
+# for the command, so the cmd_map branch raises KeyError and there
+# is no frame to compare. Two causes land a command here: the rig
+# TOML does not define it, or it defines it as a CAT command, which
+# profiles/rig_loader.py: RigConfig.to_command_map drops. A
+# 'cat-only' profile has no CI-V command at all -- every command its
+# TOML defines is CAT, so its CommandMap is empty and every lookup
+# against it raises, whether or not the TOML names that command.
+# Read the gap rows as a follow-up worklist only for the profiles
+# they name that have no 'cat-only' row.
+# 'sites_compared' counts dual-implementation sites statically
+# reachable from a builder that was compared, not sites observed to
+# execute. Every number here is re-measured and asserted by that
+# test. Regenerate, do not edit.
+census	builders_compared	230
+census	cat_only_profiles	2
+census	dual_implementation_sites	139
+census	frames_diverged	152
+census	frames_identical	1273
+census	profile_builder_map_gaps	1006
+census	profiles	8
+census	public_builders	232
+census	sites_compared	126
+cat-only	FTX-1	108
+cat-only	TX-500	50
+gap	get_acc1_mod_level	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_af_level	FTX-1,TX-500
+gap	get_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_agc	FTX-1,TX-500,X6100
+gap	get_agc_time_constant	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_alc	FTX-1,TX-500,X6100,X6200
+gap	get_antenna	FTX-1,TX-500,X6100,X6200
+gap	get_anti_vox_gain	FTX-1,TX-500,X6100,X6200
+gap	get_apf_type_level	FTX-1,IC-7300,TX-500,X6100,X6200
+gap	get_attenuator	FTX-1,TX-500,X6100
+gap	get_audio_peak_filter	FTX-1,TX-500,X6100,X6200
+gap	get_auto_notch	FTX-1,TX-500,X6100,X6200
+gap	get_band_edge_freq	FTX-1,TX-500,X6100
+gap	get_break_in	FTX-1,TX-500,X6100,X6200
+gap	get_break_in_delay	FTX-1,TX-500,X6100,X6200
+gap	get_civ_output_ant	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_civ_transceive	FTX-1,TX-500,X6100,X6200
+gap	get_comp_meter	FTX-1,TX-500,X6100,X6200
+gap	get_compressor	FTX-1,TX-500,X6100,X6200
+gap	get_compressor_level	FTX-1,TX-500,X6100,X6200
+gap	get_cw_pitch	FTX-1,TX-500,X6100
+gap	get_dash_ratio	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_data1_mod_input	FTX-1,TX-500,X6100,X6200
+gap	get_data2_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_data3_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_data_mode	FTX-1,TX-500,X6100,X6200
+gap	get_data_off_mod_input	FTX-1,TX-500,X6100,X6200
+gap	get_dial_lock	FTX-1,TX-500,X6100
+gap	get_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_digisel_shift	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_drive_gain	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_dual_watch	FTX-1,IC-705,IC-7300,TX-500,X6100,X6200
+gap	get_filter_shape	FTX-1,TX-500,X6100,X6200
+gap	get_filter_width	FTX-1,TX-500,X6100
+gap	get_freq	FTX-1,TX-500
+gap	get_id_meter	FTX-1,TX-500,X6100,X6200
+gap	get_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_key_speed	FTX-1,TX-500,X6100
+gap	get_lan_mod_level	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_main_sub_band	FTX-1,IC-705,IC-7300,TX-500,X6100,X6200
+gap	get_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_manual_notch	FTX-1,TX-500,X6100,X6200
+gap	get_manual_notch_width	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_mic_gain	FTX-1,TX-500,X6100
+gap	get_mode	FTX-1,TX-500
+gap	get_monitor	FTX-1,TX-500,X6100,X6200
+gap	get_monitor_gain	FTX-1,TX-500,X6100
+gap	get_nb	FTX-1,TX-500,X6100
+gap	get_nb_depth	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_nb_level	FTX-1,TX-500,X6100
+gap	get_nb_width	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_notch_filter	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_nr	FTX-1,TX-500,X6100,X6200
+gap	get_nr_level	FTX-1,TX-500,X6100
+gap	get_overflow_status	FTX-1,TX-500,X6100,X6200
+gap	get_pbt_inner	FTX-1,TX-500,X6100,X6200
+gap	get_pbt_outer	FTX-1,TX-500,X6100,X6200
+gap	get_power_meter	FTX-1,TX-500,X6100
+gap	get_powerstat	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	get_preamp	FTX-1,TX-500,X6100
+gap	get_quick_dual_watch	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_quick_split	FTX-1,TX-500,X6100,X6200
+gap	get_ref_adjust	FTX-1,TX-500,X6100,X6200
+gap	get_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	get_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	get_rf_gain	FTX-1,TX-500
+gap	get_rf_power	FTX-1,TX-500,X6100
+gap	get_rit_frequency	FTX-1,TX-500,X6100,X6200
+gap	get_rit_status	FTX-1,TX-500,X6100,X6200
+gap	get_rit_tx_status	FTX-1,TX-500,X6100,X6200
+gap	get_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	get_s_meter	FTX-1,TX-500,X6100
+gap	get_s_meter_sql_status	FTX-1,TX-500,X6100,X6200
+gap	get_scope_center_type	FTX-1,TX-500,X6100,X6200
+gap	get_scope_during_tx	FTX-1,TX-500,X6100,X6200
+gap	get_scope_edge	FTX-1,TX-500,X6100,X6200
+gap	get_scope_fixed_edge	FTX-1,TX-500,X6100,X6200
+gap	get_scope_hold	FTX-1,TX-500,X6100,X6200
+gap	get_scope_main_sub	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	get_scope_mode	FTX-1,TX-500,X6100,X6200
+gap	get_scope_rbw	FTX-1,TX-500,X6100,X6200
+gap	get_scope_ref	FTX-1,TX-500,X6100,X6200
+gap	get_scope_single_dual	FTX-1,TX-500,X6100,X6200
+gap	get_scope_span	FTX-1,TX-500,X6100,X6200
+gap	get_scope_speed	FTX-1,TX-500,X6100,X6200
+gap	get_scope_vbw	FTX-1,TX-500,X6100,X6200
+gap	get_speech	FTX-1,TX-500,X6100,X6200
+gap	get_split	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_squelch	FTX-1,TX-500
+gap	get_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
+gap	get_swr	FTX-1,TX-500,X6100
+gap	get_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	get_transceiver_id	FTX-1,TX-500,X6100
+gap	get_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	get_tuner_status	FTX-1,TX-500,X6100
+gap	get_tuning_step	FTX-1,TX-500,X6100,X6200
+gap	get_twin_peak_filter	FTX-1,TX-500,X6100,X6200
+gap	get_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
+gap	get_usb_mod_level	FTX-1,TX-500,X6100,X6200
+gap	get_various_squelch	FTX-1,TX-500,X6100,X6200
+gap	get_vd_meter	FTX-1,TX-500,X6100
+gap	get_vfo	FTX-1,TX-500,X6100
+gap	get_vox	FTX-1,TX-500,X6100,X6200
+gap	get_vox_delay	FTX-1,IC-705,TX-500,X6100,X6200
+gap	get_vox_gain	FTX-1,TX-500,X6100,X6200
+gap	get_xfc_status	FTX-1,TX-500,X6100,X6200
+gap	power_off	FTX-1,TX-500,X6100,X6200
+gap	power_on	FTX-1,TX-500,X6100,X6200
+gap	ptt_off	FTX-1,TX-500
+gap	ptt_on	FTX-1,TX-500
+gap	quick_dual_watch	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	quick_split	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	scan_start	FTX-1,TX-500,X6100,X6200
+gap	scan_start_type	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	scan_stop	FTX-1,TX-500,X6100,X6200
+gap	scope_data_output	FTX-1,TX-500,X6100,X6200
+gap	scope_off	FTX-1,TX-500,X6100,X6200
+gap	scope_on	FTX-1,TX-500,X6100,X6200
+gap	send_cw	FTX-1,TX-500,X6100,X6200
+gap	set_acc1_mod_level	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_af_level	FTX-1,TX-500
+gap	set_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_agc	FTX-1,TX-500,X6100
+gap	set_agc_time_constant	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_antenna	FTX-1,TX-500,X6100,X6200
+gap	set_anti_vox_gain	FTX-1,TX-500,X6100,X6200
+gap	set_apf_type_level	FTX-1,IC-7300,TX-500,X6100,X6200
+gap	set_attenuator	FTX-1,TX-500,X6100
+gap	set_audio_peak_filter	FTX-1,TX-500,X6100,X6200
+gap	set_auto_notch	FTX-1,TX-500,X6100,X6200
+gap	set_break_in	FTX-1,TX-500,X6100,X6200
+gap	set_break_in_delay	FTX-1,TX-500,X6100,X6200
+gap	set_civ_output_ant	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_civ_transceive	FTX-1,TX-500,X6100,X6200
+gap	set_compressor	FTX-1,TX-500,X6100,X6200
+gap	set_compressor_level	FTX-1,TX-500,X6100,X6200
+gap	set_cw_pitch	FTX-1,TX-500,X6100
+gap	set_dash_ratio	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_data1_mod_input	FTX-1,TX-500,X6100,X6200
+gap	set_data2_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_data3_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_data_mode	FTX-1,TX-500,X6100,X6200
+gap	set_data_off_mod_input	FTX-1,TX-500,X6100,X6200
+gap	set_dial_lock	FTX-1,TX-500,X6100
+gap	set_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_digisel_shift	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_drive_gain	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_dual_watch	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	set_filter_shape	FTX-1,TX-500,X6100,X6200
+gap	set_filter_width	FTX-1,TX-500,X6100,X6200
+gap	set_freq	FTX-1,TX-500
+gap	set_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_key_speed	FTX-1,TX-500,X6100
+gap	set_lan_mod_level	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_manual_notch	FTX-1,TX-500,X6100,X6200
+gap	set_manual_notch_width	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_mic_gain	FTX-1,TX-500,X6100
+gap	set_mode	FTX-1,TX-500
+gap	set_monitor	FTX-1,TX-500,X6100,X6200
+gap	set_monitor_gain	FTX-1,TX-500,X6100
+gap	set_nb	FTX-1,TX-500,X6100
+gap	set_nb_depth	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_nb_level	FTX-1,TX-500,X6100
+gap	set_nb_width	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_notch_filter	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_nr	FTX-1,TX-500,X6100,X6200
+gap	set_nr_level	FTX-1,TX-500,X6100
+gap	set_pbt_inner	FTX-1,TX-500,X6100,X6200
+gap	set_pbt_outer	FTX-1,TX-500,X6100,X6200
+gap	set_preamp	FTX-1,TX-500,X6100
+gap	set_quick_dual_watch	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
+gap	set_quick_split	FTX-1,TX-500,X6100,X6200
+gap	set_ref_adjust	FTX-1,TX-500,X6100,X6200
+gap	set_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	set_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	set_rf_gain	FTX-1,TX-500
+gap	set_rf_power	FTX-1,TX-500,X6100
+gap	set_rit_frequency	FTX-1,TX-500,X6100,X6200
+gap	set_rit_status	FTX-1,TX-500,X6100,X6200
+gap	set_rit_tx_status	FTX-1,TX-500,X6100,X6200
+gap	set_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	set_split	FTX-1,TX-500,X6100
+gap	set_squelch	FTX-1,TX-500
+gap	set_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
+gap	set_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	set_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
+gap	set_tuner_status	FTX-1,TX-500,X6100
+gap	set_tuning_step	FTX-1,TX-500,X6100,X6200
+gap	set_twin_peak_filter	FTX-1,TX-500,X6100,X6200
+gap	set_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
+gap	set_usb_mod_level	FTX-1,TX-500,X6100,X6200
+gap	set_vfo	FTX-1,TX-500,X6100
+gap	set_vox	FTX-1,TX-500,X6100,X6200
+gap	set_vox_delay	FTX-1,IC-705,TX-500,X6100,X6200
+gap	set_vox_gain	FTX-1,TX-500,X6100,X6200
+gap	set_xfc_status	FTX-1,TX-500,X6100,X6200
+gap	stop_cw	FTX-1,TX-500,X6100,X6200
+gap	system_date	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	system_time	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+gap	utc_offset	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
+noargs	vfo.py:scan_set_df_span
+noargs	vfo.py:scan_set_resume
+unpinned	antenna.py:get_rx_antenna_ant2
+unpinned	antenna.py:set_rx_antenna_ant2
+unpinned	power.py:get_powerstat
+unpinned	system.py:set_system_date
+unpinned	system.py:set_system_time
+unpinned	system.py:set_utc_offset
+unpinned	vfo.py:quick_dual_watch
+unpinned	vfo.py:quick_split
+unpinned	vfo.py:scan_set_df_span
+unpinned	vfo.py:scan_set_resume
+unpinned	vfo.py:scan_start_type
+unpinned	vfo.py:set_dual_watch_off
+unpinned	vfo.py:set_dual_watch_on

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -1,7 +1,23 @@
-"""CommandMap integration tests — verify cmd_map parity with hardcoded commands.
+"""CommandMap integration tests — IC-7610 parity plus custom-map cases.
 
-For IC-7610, calling any command function with cmd_map from the TOML must
-produce identical output to calling without (hardcoded bytes).
+The parity classes below build one command with the IC-7610 TOML's cmd_map
+and again without it, and require the two frames to match; the override
+class instead feeds a hand-made CommandMap and checks that the frame
+follows its wire bytes.
+
+Parity here is a property of these builders at these arguments, not of the
+package. For IC-7610 alone, tests/command_map_parity_divergences.txt
+records builders whose two frames differ — get_attenuator, get_preamp,
+get_af_mute and get_digisel are asserted equal below and listed there,
+because this file calls them at the default command29=True while the
+divergence needs command29=False.
+
+tests/test_command_map_parity.py generalises the parity cases below: every
+builder it can reach, every profile in rigs/, and one probe per optional
+argument. It does not replace this file — the custom-map cases have no
+counterpart there. What it could not compare is listed in
+tests/command_map_parity_uncovered.txt; check there before assuming a
+builder named below is covered only here.
 """
 
 from __future__ import annotations
@@ -30,7 +46,7 @@ def cmd_map():
 
 
 class TestGetterParity:
-    """Calling getters with IC-7610 cmd_map must match hardcoded output."""
+    """These getters must build the same frame with IC-7610 cmd_map as without."""
 
     def test_get_frequency(self, cmd_map):
         assert commands.get_freq(cmd_map=cmd_map) == commands.get_freq()
@@ -94,7 +110,7 @@ class TestGetterParity:
 
 
 class TestSetterParity:
-    """Calling setters with IC-7610 cmd_map must match hardcoded output."""
+    """These setters must build the same frame with IC-7610 cmd_map as without."""
 
     def test_set_frequency(self, cmd_map):
         assert commands.set_freq(14_200_000, cmd_map=cmd_map) == commands.set_freq(
@@ -144,7 +160,7 @@ class TestSetterParity:
 
 
 class TestHelperCallerParity:
-    """Functions delegating to _build_* helpers must match with cmd_map."""
+    """These _build_*-delegating functions must match with cmd_map."""
 
     def test_get_apf_type_level(self, cmd_map):
         assert (
@@ -199,7 +215,11 @@ class TestHelperCallerParity:
 
 
 class TestCmd29Parity:
-    """Functions using cmd29 framing must match with cmd_map."""
+    """These cmd29-framing functions must match with cmd_map at command29's default.
+
+    Four of them -- ``get_attenuator``, ``get_preamp``, ``get_digisel`` and
+    ``get_af_mute`` -- match only at that default; see the module docstring.
+    """
 
     def test_get_attenuator(self, cmd_map):
         assert commands.get_attenuator(cmd_map=cmd_map) == commands.get_attenuator()
@@ -242,7 +262,7 @@ class TestCmd29Parity:
 
 
 class TestCommandMapOverride:
-    """Custom CommandMap with different wire bytes produces different output."""
+    """A hand-made CommandMap's wire bytes must show up in the frame it builds."""
 
     def test_different_wire_bytes_produce_different_frame(self):
         custom = CommandMap({"get_af_level": (0x16, 0x43)})

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -1,0 +1,540 @@
+"""Pin every dual-implementation command builder against its profile map.
+
+Builders in ``src/rigplane/commands/`` that carry both a ``cmd_map`` branch
+and a hardcoded fallback hold the same CI-V knowledge twice, and only a
+hand-written subset compared the two: ``test_command_map_integration.py``
+calls a fixed list of builders against the IC-7610 map, each at one
+argument set with every optional argument left at its default, and
+``test_commands.py: test_speech_cmd_map_prefers_set_speech_key`` and
+``test_rig_ic7300.py: test_get_speech_cmd_map_uses_set_speech`` each pin
+``get_speech`` alone. Outside that subset the two copies could disagree
+silently, and at least one pair does: the ``cmd_map`` branch of
+``scope.py: get_scope_mode`` and its siblings drops the ``receiver``
+argument that the fallback hands to ``scope.py: _scope_query``.
+
+This test is the general form of that check: it builds every builder it can
+reach both ways, for every profile the library loads out of ``rigs/``, and
+requires the two frames to be byte-identical. It does not replace those
+hand-written checks: they are kept, and whether a builder one of them
+names is also swept here is answerable from
+``command_map_parity_uncovered.txt``, which lists everything this sweep
+could not compare.
+
+Known disagreements live in ``command_map_parity_divergences.txt``, one row
+per (profile, builder, argument case), each recording the two frames it
+produced. A disagreement missing from that file fails, and so does a row
+there that no longer disagrees, which must be deleted rather than kept.
+That does not make the file physically unable to grow — regenerating it
+would add a new row — but growth can only arrive as a committed, reviewable
+edit to this file, never silently.
+
+Nothing here fixes a divergence. Which commands take a receiver prefix byte
+is MOR-1981, and adding one where the radio does not expect it is a write,
+not a no-op — see ``web/radio_poller.py: _SCOPE_RECEIVER_PREFIX_SUBS``.
+
+What could not be compared is not skipped silently:
+``command_map_parity_uncovered.txt`` records the commands a profile's map
+omits, the profiles whose TOML defines every command as CAT so that
+``profiles/rig_loader.py: RigConfig.to_command_map`` drops all of them, the
+builders whose arguments no probe value satisfied, the sites no compared
+builder reaches, and a census of how much was compared. Every number in it
+is re-measured and asserted here, so none of it can go stale unnoticed.
+
+Regenerate both files after an intentional change::
+
+    RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest \
+        tests/test_command_map_parity.py
+"""
+
+from __future__ import annotations
+
+import ast
+import enum
+import functools
+import importlib
+import inspect
+import itertools
+import os
+import pathlib
+import typing
+from collections import defaultdict
+
+import pytest
+
+from rigplane.commands.command_spec import CatCommandSpec
+from rigplane.profiles import resolve_radio_profile
+from rigplane.profiles.rig_loader import discover_rigs
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+COMMANDS_DIR = REPO_ROOT / "src" / "rigplane" / "commands"
+RIGS_DIR = REPO_ROOT / "rigs"
+DIVERGENCES_FILE = pathlib.Path(__file__).with_name(
+    "command_map_parity_divergences.txt"
+)
+UNCOVERED_FILE = pathlib.Path(__file__).with_name("command_map_parity_uncovered.txt")
+REGEN_ENV = "RIGPLANE_REGEN_COMMAND_MAP_PARITY"
+
+# Never probed: the comparison itself varies ``cmd_map`` and supplies the
+# profile's ``to_addr``, and it leaves ``from_addr`` at its default in both
+# frames of every pair, so no value for it is ever synthesised or passed.
+_HARNESS_PARAMS = frozenset({"to_addr", "from_addr", "cmd_map"})
+# Used only while searching for arguments a builder accepts; the
+# comparison below rebuilds every frame with the profile's own
+# ``civ_addr``. A builder that rejected an argument depending on the
+# address would raise there rather than pass quietly.
+_PROBE_ADDR = 0x94
+# Probe values, tried in order. The search that consumes them has no
+# per-builder branch: a builder no value satisfies is reported as a
+# ``noargs`` row, never given a bespoke argument here.
+_INTS = (0, 1, 2, 3, 5, 10, 18, 30, 50, 100, 255, 600, 1000, 2026)
+_FREQS = (14_074_000, 21_074_000)
+_FLOATS = (0.0, 88.5, 1000.0, 14_074_000.0)
+_SEARCH_BUDGET = 8000  # combinations enumerated before a builder is given up on
+
+Key = tuple[str, str]  # (module file name, function name)
+
+
+# ── static analysis: the dual-implementation sites and who reaches them ──
+
+
+def _tests_cmd_map(node: ast.AST) -> bool:
+    """True if *node* contains a literal ``cmd_map is not None`` test."""
+    for child in ast.walk(node):
+        if not (isinstance(child, ast.Compare) and isinstance(child.left, ast.Name)):
+            continue
+        if child.left.id != "cmd_map":
+            continue
+        for op, other in zip(child.ops, child.comparators):
+            if isinstance(op, ast.IsNot) and (
+                isinstance(other, ast.Constant) and other.value is None
+            ):
+                return True
+    return False
+
+
+class _Graph(typing.NamedTuple):
+    sites: frozenset[Key]  # functions branching on ``cmd_map is not None``
+    index: dict[str, frozenset[Key]]  # function name -> where it is defined
+    calls: dict[Key, frozenset[str]]  # caller -> names it forwards cmd_map to
+
+
+@functools.lru_cache(maxsize=1)
+def _graph() -> _Graph:
+    """Read the package's dual-implementation structure out of its source.
+
+    ``calls`` is how a builder that only delegates reaches a shared
+    template in ``commands/_builders.py``: it records the names each
+    function calls while forwarding ``cmd_map``.
+    """
+    sites: set[Key] = set()
+    index: dict[str, set[Key]] = defaultdict(set)
+    calls: dict[Key, set[str]] = defaultdict(set)
+    for path in sorted(COMMANDS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            key = (path.name, node.name)
+            index[node.name].add(key)
+            if _tests_cmd_map(node):
+                sites.add(key)
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Name)
+                    and any(kw.arg == "cmd_map" for kw in child.keywords)
+                ):
+                    calls[key].add(child.func.id)
+    return _Graph(
+        frozenset(sites),
+        {name: frozenset(keys) for name, keys in index.items()},
+        {key: frozenset(names) for key, names in calls.items()},
+    )
+
+
+def _reachable_sites(key: Key) -> frozenset[Key]:
+    """Dual-implementation sites statically reachable from *key*.
+
+    An over-approximation of what a call executes: ``_graph`` records a
+    delegation wherever ``cmd_map`` is forwarded, so a delegation guarded
+    by a condition counts here even on a call that does not take it.
+    """
+    graph = _graph()
+    seen: set[Key] = set()
+    found: set[Key] = set()
+    stack = [key]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        if current in graph.sites:
+            found.add(current)
+        for name in graph.calls.get(current, ()):
+            defined = graph.index.get(name, frozenset())
+            local = [d for d in defined if d[0] == current[0]]
+            if local:
+                stack.append(local[0])
+            elif len(defined) == 1:
+                stack.append(next(iter(defined)))
+    return frozenset(found)
+
+
+# ── the callable surface, and arguments it accepts ──
+
+
+@functools.lru_cache(maxsize=1)
+def _builders() -> dict[Key, typing.Any]:
+    """Every public builder in the package that takes a ``cmd_map``.
+
+    Keyed by the defining function's own name, so a module-level alias
+    collapses onto the function it aliases instead of being compared twice
+    under both names.
+    """
+    found: dict[Key, typing.Any] = {}
+    for path in sorted(COMMANDS_DIR.glob("*.py")):
+        if path.stem == "__init__":
+            continue
+        module = importlib.import_module(f"rigplane.commands.{path.stem}")
+        for value in vars(module).values():
+            if not inspect.isfunction(value) or value.__name__.startswith("_"):
+                continue
+            if value.__module__ != module.__name__:
+                continue
+            if "cmd_map" in inspect.signature(value).parameters:
+                found[(path.name, value.__name__)] = value
+    return found
+
+
+def _values_for(fn: typing.Any, param: inspect.Parameter) -> tuple[typing.Any, ...]:
+    """Probe values for *param*, derived from its annotation alone."""
+    try:
+        annotation = eval(param.annotation, fn.__globals__)  # noqa: S307
+    except Exception:
+        return ()
+    args = typing.get_args(annotation)
+    types = list(args) if args else [annotation]
+    members = [
+        member
+        for candidate in types
+        if isinstance(candidate, type) and issubclass(candidate, enum.Enum)
+        for member in candidate
+    ]
+    if members:
+        return tuple(members) + _INTS
+    if bool in types:
+        return (False, True)
+    if str in types:
+        return ("TEST",)
+    if float in types:
+        return _FLOATS + _FREQS
+    if int in types:
+        return _INTS + _FREQS
+    return ()
+
+
+def _split_params(
+    fn: typing.Any,
+) -> tuple[list[inspect.Parameter], list[inspect.Parameter]]:
+    required: list[inspect.Parameter] = []
+    optional: list[inspect.Parameter] = []
+    for param in inspect.signature(fn).parameters.values():
+        if param.name not in _HARNESS_PARAMS:
+            (optional if param.default is not param.empty else required).append(param)
+    return required, optional
+
+
+def _candidate_kwargs(
+    fn: typing.Any, required: list[inspect.Parameter]
+) -> typing.Iterator[dict[str, typing.Any]]:
+    """Argument dicts to try for *fn*, most likely first."""
+    if not required:
+        yield {}
+        return
+    ladders = [_values_for(fn, param) for param in required]
+    if any(not ladder for ladder in ladders):
+        return
+    names = [param.name for param in required]
+    seen: set[tuple[typing.Any, ...]] = set()
+    for i in range(max(len(ladder) for ladder in ladders)):
+        combo = tuple(ladder[i % len(ladder)] for ladder in ladders)
+        if combo not in seen:
+            seen.add(combo)
+            yield dict(zip(names, combo))
+    for budget, combo in enumerate(itertools.product(*ladders)):
+        if budget >= _SEARCH_BUDGET:
+            return
+        if combo not in seen:
+            seen.add(combo)
+            yield dict(zip(names, combo))
+
+
+def _accepts(fn: typing.Any, kwargs: dict[str, typing.Any]) -> bool:
+    try:
+        fn(to_addr=_PROBE_ADDR, cmd_map=None, **kwargs)
+    except Exception:
+        return False
+    return True
+
+
+def _format_case(kwargs: dict[str, typing.Any]) -> str:
+    if not kwargs:
+        return "(no arguments)"
+    return ", ".join(
+        f"{name}="
+        + (f"{type(v).__name__}.{v.name}" if isinstance(v, enum.Enum) else repr(v))
+        for name, v in sorted(kwargs.items())
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def _cases() -> tuple[dict[Key, list[dict[str, typing.Any]]], frozenset[Key]]:
+    """Argument cases per builder, plus the builders none could be found for.
+
+    The first case passes only required arguments; one further case per
+    optional argument overrides it with a non-default value, because a
+    divergence can hide behind a default — ``scope.py: get_scope_mode``
+    builds identical frames until ``receiver`` is given a value. Argument
+    validation happens before a builder reads ``to_addr``, so this search
+    runs once and its result is reused for every profile.
+    """
+    per_builder: dict[Key, list[dict[str, typing.Any]]] = {}
+    unsynthesisable: set[Key] = set()
+    for key, fn in _builders().items():
+        required, optional = _split_params(fn)
+        base = next(
+            (kw for kw in _candidate_kwargs(fn, required) if _accepts(fn, kw)), None
+        )
+        if base is None:
+            unsynthesisable.add(key)
+            continue
+        cases = [base]
+        for param in optional:
+            for value in _values_for(fn, param):
+                if type(value) is type(param.default) and value == param.default:
+                    continue
+                probe = dict(base, **{param.name: value})
+                if _accepts(fn, probe):
+                    cases.append(probe)
+                    break
+        per_builder[key] = cases
+    return per_builder, frozenset(unsynthesisable)
+
+
+# ── the comparison ──
+
+
+class _Report(typing.NamedTuple):
+    divergences: dict[tuple[str, str, str], str]
+    map_gaps: dict[str, tuple[str, ...]]
+    cat_only_profiles: dict[str, int]
+    unsynthesisable: tuple[str, ...]
+    uncompared_sites: tuple[str, ...]
+    census: dict[str, int]
+
+
+def _cat_only_profiles(rigs: dict[str, typing.Any]) -> dict[str, int]:
+    """Profiles whose every command is CAT, and how many that is.
+
+    ``CommandSpec`` is the union ``CivCommandSpec | CatCommandSpec`` and
+    ``profiles/rig_loader.py: RigConfig.to_command_map`` keeps only the
+    CI-V half, so such a profile ends up with an empty ``CommandMap`` and
+    every lookup against it raises -- it is a gap for every command a
+    builder asks for, whatever its TOML happens to define.
+    """
+    cat_only: dict[str, int] = {}
+    for model, config in rigs.items():
+        specs = list(config.commands.values())
+        if specs and all(isinstance(spec, CatCommandSpec) for spec in specs):
+            cat_only[model] = len(specs)
+    return cat_only
+
+
+@functools.lru_cache(maxsize=1)
+def _report() -> _Report:
+    per_builder, unsynthesisable = _cases()
+    rigs = discover_rigs(RIGS_DIR)
+    divergences: dict[tuple[str, str, str], str] = {}
+    gaps: dict[str, set[str]] = defaultdict(set)
+    gap_pairs: set[tuple[str, Key]] = set()
+    compared: set[Key] = set()
+    identical = 0
+
+    for model, config in sorted(rigs.items()):
+        cmd_map = config.to_command_map()
+        to_addr = resolve_radio_profile(model=model).civ_addr
+        for key, cases in sorted(per_builder.items()):
+            fn = _builders()[key]
+            for kwargs in cases:
+                fallback = fn(to_addr=to_addr, cmd_map=None, **kwargs)
+                try:
+                    mapped = fn(to_addr=to_addr, cmd_map=cmd_map, **kwargs)
+                except KeyError as exc:
+                    # Only CommandMap.get should raise KeyError here;
+                    # anything else is a real failure, so re-raise it.
+                    if "Unknown command " not in str(exc):
+                        raise
+                    name = str(exc).split("Unknown command ")[1].split(".")[0]
+                    gaps[name.strip("'\"")].add(model)
+                    gap_pairs.add((model, key))
+                    continue
+                compared |= _reachable_sites(key)
+                if mapped == fallback:
+                    identical += 1
+                else:
+                    row = (model, f"{key[0]}:{key[1]}", _format_case(kwargs))
+                    divergences[row] = f"map={mapped.hex()} fallback={fallback.hex()}"
+
+    cat_only = _cat_only_profiles(rigs)
+    return _Report(
+        divergences=divergences,
+        map_gaps={name: tuple(sorted(models)) for name, models in gaps.items()},
+        cat_only_profiles=cat_only,
+        unsynthesisable=tuple(sorted(f"{m}:{f}" for m, f in unsynthesisable)),
+        uncompared_sites=tuple(
+            sorted(f"{m}:{f}" for m, f in _graph().sites - compared)
+        ),
+        census={
+            "dual_implementation_sites": len(_graph().sites),
+            "sites_compared": len(compared),
+            "public_builders": len(_builders()),
+            "builders_compared": len(per_builder),
+            "profiles": len(rigs),
+            "cat_only_profiles": len(cat_only),
+            "frames_identical": identical,
+            "frames_diverged": len(divergences),
+            "profile_builder_map_gaps": len(gap_pairs),
+        },
+    )
+
+
+# ── baseline files ──
+
+
+def _read_rows(path: pathlib.Path) -> list[tuple[str, ...]]:
+    return [
+        tuple(line.split("\t"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _render_divergences(report: _Report) -> str:
+    header = [
+        "# Known cmd_map/fallback disagreements, tab separated:",
+        "#   <profile>  <module>:<builder>  <arguments>  <observed frames>",
+        "# tests/test_command_map_parity.py fails on a disagreement missing",
+        "# here, and on a row here that no longer disagrees -- delete that",
+        "# row, never keep it. Regenerating can still add rows, so read any",
+        "# addition as a new divergence someone has to justify.",
+    ]
+    rows = [
+        f"{a}\t{b}\t{c}\t{d}" for (a, b, c), d in sorted(report.divergences.items())
+    ]
+    return "\n".join(header + rows) + "\n"
+
+
+def _render_uncovered(report: _Report) -> str:
+    header = [
+        "# What tests/test_command_map_parity.py could NOT compare, and how",
+        "# much it did. Tab separated, five row kinds:",
+        "#   census    <name>              <count>",
+        "#   cat-only  <profile>           <commands, every one of them CAT>",
+        "#   gap       <command name>      <profiles whose map omits it>",
+        "#   noargs    <module>:<builder>  no probe value was accepted",
+        "#   unpinned  <module>:<builder>  no compared builder reaches it",
+        "# A 'gap' row means that profile's CommandMap holds no CI-V entry",
+        "# for the command, so the cmd_map branch raises KeyError and there",
+        "# is no frame to compare. Two causes land a command here: the rig",
+        "# TOML does not define it, or it defines it as a CAT command, which",
+        "# profiles/rig_loader.py: RigConfig.to_command_map drops. A",
+        "# 'cat-only' profile has no CI-V command at all -- every command its",
+        "# TOML defines is CAT, so its CommandMap is empty and every lookup",
+        "# against it raises, whether or not the TOML names that command.",
+        "# Read the gap rows as a follow-up worklist only for the profiles",
+        "# they name that have no 'cat-only' row.",
+        "# 'sites_compared' counts dual-implementation sites statically",
+        "# reachable from a builder that was compared, not sites observed to",
+        "# execute. Every number here is re-measured and asserted by that",
+        "# test. Regenerate, do not edit.",
+    ]
+    rows = [f"census\t{name}\t{n}" for name, n in sorted(report.census.items())]
+    rows += [
+        f"cat-only\t{model}\t{n}"
+        for model, n in sorted(report.cat_only_profiles.items())
+    ]
+    rows += [
+        f"gap\t{name}\t{','.join(models)}"
+        for name, models in sorted(report.map_gaps.items())
+    ]
+    rows += [f"noargs\t{name}" for name in report.unsynthesisable]
+    rows += [f"unpinned\t{name}" for name in report.uncompared_sites]
+    return "\n".join(header + rows) + "\n"
+
+
+@pytest.fixture(scope="module")
+def report() -> _Report:
+    result = _report()
+    # Not a truthiness test: ``REGEN_ENV=0`` must mean off, not on.
+    if os.environ.get(REGEN_ENV, "") not in {"", "0"}:
+        DIVERGENCES_FILE.write_text(_render_divergences(result), encoding="utf-8")
+        UNCOVERED_FILE.write_text(_render_uncovered(result), encoding="utf-8")
+        pytest.skip(f"{REGEN_ENV} set: baselines rewritten, not checked")
+    return result
+
+
+def test_every_divergence_is_allowlisted(report: _Report) -> None:
+    """No builder may start disagreeing with its profile map unlisted."""
+    allowed = {row[:3] for row in _read_rows(DIVERGENCES_FILE)}
+    unlisted = sorted(set(report.divergences) - allowed)
+    assert not unlisted, "\n".join(
+        f"{p} {b} [{c}] {report.divergences[(p, b, c)]}" for p, b, c in unlisted
+    )
+
+
+def test_allowlist_has_no_stale_entries(report: _Report) -> None:
+    """An entry that no longer diverges must be deleted, never kept."""
+    rows = _read_rows(DIVERGENCES_FILE)
+    stale = sorted(row[:3] for row in rows if row[:3] not in report.divergences)
+    assert not stale, "\n".join(" ".join(row) for row in stale)
+
+
+def test_allowlist_records_the_observed_frames(report: _Report) -> None:
+    """Each row must show the two frames that were actually built."""
+    wrong = [
+        row
+        for row in _read_rows(DIVERGENCES_FILE)
+        if row[:3] in report.divergences and row[3:] != (report.divergences[row[:3]],)
+    ]
+    assert not wrong, "\n".join(
+        f"{' '.join(r[:3])}: recorded {r[3:]}, observed {report.divergences[r[:3]]!r}"
+        for r in wrong
+    )
+
+
+def test_uncovered_inventory_matches(report: _Report) -> None:
+    """Census, CAT-only profiles, map gaps, noargs builders, uncompared sites."""
+    rows = _read_rows(UNCOVERED_FILE)
+    assert {r[1]: int(r[2]) for r in rows if r[0] == "census"} == report.census
+    assert {r[1]: int(r[2]) for r in rows if r[0] == "cat-only"} == (
+        report.cat_only_profiles
+    )
+    assert {r[1]: tuple(r[2].split(",")) for r in rows if r[0] == "gap"} == (
+        report.map_gaps
+    )
+    assert tuple(r[1] for r in rows if r[0] == "noargs") == report.unsynthesisable
+    assert tuple(r[1] for r in rows if r[0] == "unpinned") == report.uncompared_sites
+
+
+def test_every_site_is_reached_by_some_builder() -> None:
+    """No dual-implementation site may sit outside the callable surface.
+
+    A site can still go uncompared because every profile's map omits its
+    command, or because no probe value satisfied its builder; both are
+    listed as ``unpinned`` rows. What must never happen is a site no public
+    builder routes to at all, because then nothing could ever compare it.
+    """
+    reached: set[Key] = set()
+    for key in _builders():
+        reached |= _reachable_sites(key)
+    assert sorted(_graph().sites - reached) == []


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1986 step one.
- Compatibility impact: **none**. Tests only; no production file is touched.

`src/rigplane/commands/` contains **139 command builders that each carry two implementations** of the same knowledge — a branch that reads the profile command map, and a hardcoded fallback below it for when the map has no entry. Only a hand-written IC-7610 subset compared them, at default arguments, so they could disagree unnoticed almost everywhere.

They do. Finding the first divergence — `commands/scope.py`'s `cmd_map` branch silently discarding the `receiver` argument — took most of a day and two research agents.

**This change fixes nothing.** It is a pin, deliberately: deciding *which* commands take a selector byte, and where that knowledge should live, is MOR-1981 and MOR-1983.

**The divergence is latent, not live.** No production code passes a `cmd_map` to any builder — `web/radio_poller.py` is the only `to_command_map()` caller and builds its frames itself. An earlier draft of this body said "live consequences"; that was wrong, and the same overstatement is being corrected on MOR-1981.

## What it does

`tests/test_command_map_parity.py` reads the builder surface out of the source with AST — so no hand-written builder list becomes a fourth source of truth — resolves every `rigs/*.toml` profile through the library's own loader, and calls each builder twice with identical arguments: once with the profile's `CommandMap`, once with `cmd_map=None`. The frames must be byte-identical.

Modelled on the repository's existing shrink-only baseline for documentation citations. Known divergences live in `tests/command_map_parity_divergences.txt`, one row per `(profile, builder, argument case)` with the observed frames recorded. The suite fails on any divergence not listed, **and** on any listed entry that no longer diverges — so the list can only shrink. Regenerate with `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py`.

`tests/command_map_parity_uncovered.txt` is the follow-up worklist: commands no profile's map defines, builders no probe value could satisfy, sites nothing compared, the CAT-only profiles, and a census whose every number is re-measured and asserted.

## What it found

**152 divergences**, across 52 builders and 6 profiles (IC-7610 43, IC-9700 37, IC-7300 35, IC-705 30, X6200 5, X6100 2). Four shapes:

1. **The motivating one** — 36 rows, all `scope.py: get_scope_*` at `receiver=0`: the map branch emits `27 14`, the fallback `27 14 00`. Only visible once `receiver` is given a value, which is why the harness probes optional arguments rather than calling everything at defaults.
2. **`command29` ignored** — 29 rows. `dsp.py: get_attenuator`, `set_preamp` and others still wrap in `0x29` on the map branch at `command29=False`, because that branch hardcodes `command29=True`.
3. **Different sub-command entirely** — e.g. `IC-7300 config.py: get_usb_mod_level` builds `1a 05 00 65` from the map and `14 10` hardcoded; `IC-7610 config.py: get_civ_output_ant` builds `1c 04` versus `1a 05 01 30`. Two genuinely different commands, not a framing byte.
4. **Doubled prefix** — the map's extra wire bytes prepended on top of a prefix the builder already added: `IC-7610 vfo.py: get_quick_split` → `1a 05 00 33 00 33`; `X6100 ptt.py: ptt_on` → `1c 00 01 01` versus `1c 00 01`.

Also **201 distinct command names missing from at least one profile's map** (1006 `(profile, builder)` pairs). Two causes, and the worklist now distinguishes them: the TOML does not define the command, or it defines it as a **CAT** command, which the loader drops by design. FTX-1 (108 commands) and TX-500 (50) are CAT-only — **zero** CI-V commands each — so every gap row naming them is unachievable in principle. That fact is derived at run time from the loaded profiles and asserted, so it cannot go stale.

## Coverage, stated because a test that quietly covers a fraction reads as coverage

- **126 of 139** dual-implementation sites compared for at least one profile. The 13 uncovered split into 2 whose builders no generic probe value satisfies and 11 whose command name no profile's map defines. All are listed, not skipped.
- **230 of 232** public builders exercised. **1273** frame pairs came back identical.
- All **150 of 150** optional parameters across those builders received a non-default probe value; the probe helper has no per-builder branch.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10550 passed, 0 failed**. `uv run ruff check src/ tests/` clean; `ruff format --check` clean (689 files). `uv run lint-imports`: 5 contracts kept, 0 broken. Regeneration confirmed idempotent: after `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1`, `git status` is clean, so both committed baselines are byte-identical to machine output and nothing was hand-edited into them.
- [x] Public/open-core boundary checked — tests and generated inventories only; no telemetry, no Pro content, no bench detail.
- [x] Release or migration impact documented if applicable — none.

Eleven mutation checks confirm the pin bites, on both the baseline files and the source: a stale row, an unlisted divergence, a corrupted frame, a changed census number, a dropped gap row, a renamed CAT-only profile, an orphaned site, and — the one that matters most for the new fact — **giving FTX-1 a single CI-V command turns the inventory test red**, so the CAT-only claim is genuinely re-measured rather than asserted from a name list.

## Guardrails

4 files, 975 insertions, 9 deletions — **984 changed lines**. Inside the hard ceiling (10 files / 1000), by 16 lines; over the soft threshold on lines (600).

Why this is one unit of work: 406 of those lines are the two machine-generated baselines, and the test and the baselines it writes and reads are meaningless apart — splitting them leaves either a test with no allowlist (red) or an allowlist nothing checks. The `tests/test_command_map_integration.py` docstring correction is here because this change is the artifact that falsifies it.

**The 16-line headroom is stated deliberately.** If another review round needs more than that, this gets decomposed rather than the ceiling waived — the ceiling is not author-waivable.

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` agent, relayed by the coordinating session (the reviewing environment has no GitHub access)
- Result: **BLOCKED** at `4f74a49f` — two false prose claims. Re-review requested at this head.
- The review verified the mechanism rather than trusting it: it re-derived every figure independently, confirmed real coverage with a `sys.settrace` line trace instead of the static call graph, ran the mutation checks, confirmed regeneration cannot hide a failure, and ran the suite on 3.11, 3.12 and 3.13. **Nothing about the harness was in question.**
- The two blocked claims: the worklist header stated a cause false for 59 of 871 gap pairs, and the module docstring claimed "nothing compared the two" when three existing tests did. Both fixed, both swept for their class — the integration file carried the same over-claim in five more docstrings, and all six are narrowed.

## Notes

- Out of scope / follow-ups: every one of the 152 divergences. MOR-1981 covers the scope-selector class and names the trap — on a one-byte sub-command an extra `0x00` is a *write*, not a read, so the byte must go to exactly eight commands and not the four that answer bare. MOR-1983 covers the initial sweep as a third source of the same knowledge. Shapes 2, 3 and 4 above are unticketed and at least two of them look like defects rather than framing differences.
- `tests/test_command_map_integration.py` is the hand-written IC-7610-only parity test this generalises and largely subsumes. Kept rather than retired — that is scope expansion — but its docstrings no longer claim universal parity, since this change's own data records 43 IC-7610 divergences including four commands that file asserts equal.