### PR TITLE
fix(MOR-1981): send the scope receiver-selector byte from the connect-time sweep, and drop 0x1E from the set

### DIFF
--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -64,13 +64,33 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 # Scope sub-commands whose READ query carries a one-byte Main/Sub scope
 # selector between the sub-command byte and the frame terminator
 # (0x00 = MAIN, 0x01 = SUB).  Without it the IC-7610 silently ignores the
-# query and the IC-7300 refuses it with a NAK.  Every 0x27 read outside this
-# set must be sent bare.
+# query and the IC-7300 refuses it with a NAK.  Every other 0x27 read carries
+# no selector byte -- except 0x1E, which carries a ``<range><edge>`` selector
+# of its own; see ``get_scope_fixed_edge`` below.
 #
-# Consumed by ``runtime/_state_queries.py: build_state_queries`` and
-# ``web/radio_poller.py: RadioPoller._send_one_state_query`` -- the two
-# senders of 0x27 reads that work from a sub-command list rather than from
-# the per-getter arguments in ``runtime/_scope_runtime.py``.
+# Imported by ``runtime/_state_queries.py: build_state_queries``, whose list
+# ``runtime/radio_initial_state.py: fetch_initial_state`` then sends, and by
+# ``web/radio_poller.py: RadioPoller._send_one_state_query``.  Those are the
+# senders that consult this set.
+#
+# Two further places hold this membership and do NOT import it, so an edit
+# here does not reach them -- change all three together:
+#   ``runtime/_scope_runtime.py`` passes ``receiver=`` per getter, reaching
+#     exactly these eight sub-commands and no others.
+#   ``runtime/_civ_rx.py: CivRuntime._civ_expects_response`` repeats them as
+#     a local tuple to decide whether a 0x27 reply is expected.  That copy is
+#     executable and unpinned: a sub-command added here but not there is sent
+#     with its selector byte and then classified as expecting no response, so
+#     nothing awaits the reply.
+# Nothing asserts that the three agree.  Making the RX path import this
+# constant is the real fix and is deliberately not done here (MOR-1981).
+#
+# ``rigctld/server.py: RigctldServer._send_one_state_query`` has the same
+# shape and does NOT consult this set.  It cannot reach 0x27 today because
+# ``core/acquisition_scheduler.py: IcomCivAcquisitionExecutor.query_for_path``
+# has no ``scope_controls`` branch, so every scope field resolves to None.
+# Nothing pins that.  If that branch is ever added, this set is the third
+# place to wire up, or rigctld will send ``27 14`` bare while web does not.
 #
 # Membership (MOR-1981).  Measured on a live IC-7300, six runs with no
 # variance: each sub-command below is refused with a NAK when sent bare,
@@ -82,7 +102,11 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 # selector for it and the bare form NAKs, so it is the same class.  The
 # IC-7300's own sub-command table could not be reached from the environment
 # this was measured in, so its membership rests on the bench plus the
-# analogy with the IC-705.
+# analogy with the IC-705.  No bench evidence exists for the IC-9700.  The
+# de-risking fact is that ``web/radio_poller.py`` has been putting this exact
+# split on the wire to all four scope-capable profiles since long before this
+# constant existed: the connect sweep is catching up to shipped behaviour,
+# not trying something new.
 #
 # The exclusions are not omissions -- on a sub-command that takes no
 # selector the extra byte is a WRITE, not a no-op:

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -61,14 +61,36 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 )
 
 
-# Scope sub-commands that require a receiver prefix byte in READ queries.
-# Without the prefix, IC-7610 silently ignores the query.
-# 0x12 (receiver select), 0x13 (single/dual), 0x1B (during TX) do NOT need it.
+# Scope sub-commands whose READ query carries a one-byte Main/Sub scope
+# selector between the sub-command byte and the frame terminator
+# (0x00 = MAIN, 0x01 = SUB).  Without it the IC-7610 silently ignores the
+# query and the IC-7300 refuses it with a NAK.  Every 0x27 read outside this
+# set must be sent bare.
 #
 # Consumed by ``runtime/_state_queries.py: build_state_queries`` and
 # ``web/radio_poller.py: RadioPoller._send_one_state_query`` -- the two
 # senders of 0x27 reads that work from a sub-command list rather than from
 # the per-getter arguments in ``runtime/_scope_runtime.py``.
+#
+# Membership (MOR-1981).  Measured on a live IC-7300, six runs with no
+# variance: each sub-command below is refused with a NAK when sent bare,
+# while 0x12, 0x13, 0x1B and 0x1C answer.  Icom's CI-V Reference Guide for
+# the IC-705 -- the same single-scope architecture -- prints a two-byte data
+# field for 0x14, 0x15, 0x16, 0x17, 0x19, 0x1A and 0x1D and a one-byte field
+# for 0x12, 0x13, 0x1B and 0x1C, matching that bench result with no
+# exception.  0x1F (RBW) has no row in that guide, but Hamlib supplies the
+# selector for it and the bare form NAKs, so it is the same class.  The
+# IC-7300's own sub-command table could not be reached from the environment
+# this was measured in, so its membership rests on the bench plus the
+# analogy with the IC-705.
+#
+# The exclusions are not omissions -- on a sub-command that takes no
+# selector the extra byte is a WRITE, not a no-op:
+#   0x1C (center type): ``27 1C 00`` is read as SET center_type=0 (Filter
+#     center).
+#   0x1E (fixed edge): takes ``<frequency range><edge number>`` instead, and
+#     00 is not a legal range -- ranges start at 01.  ``get_scope_fixed_edge``
+#     below builds that pair.
 SCOPE_RECEIVER_SELECTOR_SUBS: frozenset[int] = frozenset(
     {
         _SUB_SCOPE_MODE,  # 0x14 mode (center/fixed/scroll)
@@ -77,10 +99,7 @@ SCOPE_RECEIVER_SELECTOR_SUBS: frozenset[int] = frozenset(
         _SUB_SCOPE_HOLD,  # 0x17 hold
         _SUB_SCOPE_REF,  # 0x19 ref level
         _SUB_SCOPE_SPEED,  # 0x1A sweep speed
-        # 0x1C (center type) does NOT take receiver prefix -- sending 0x00
-        # as prefix is misinterpreted as SET center_type=0 (Filter center).
         _SUB_SCOPE_VBW,  # 0x1D VBW
-        _SUB_SCOPE_FIXED_EDGE,  # 0x1E fixed edge frequencies
         _SUB_SCOPE_RBW,  # 0x1F RBW
     }
 )

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -61,6 +61,36 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 )
 
 
+# Scope sub-commands that require a receiver prefix byte in READ queries.
+# Without the prefix, IC-7610 silently ignores the query.
+# 0x12 (receiver select), 0x13 (single/dual), 0x1B (during TX) do NOT need it.
+#
+# Consumed by ``runtime/_state_queries.py: build_state_queries`` and
+# ``web/radio_poller.py: RadioPoller._send_one_state_query`` -- the two
+# senders of 0x27 reads that work from a sub-command list rather than from
+# the per-getter arguments in ``runtime/_scope_runtime.py``.
+SCOPE_RECEIVER_SELECTOR_SUBS: frozenset[int] = frozenset(
+    {
+        _SUB_SCOPE_MODE,  # 0x14 mode (center/fixed/scroll)
+        _SUB_SCOPE_SPAN,  # 0x15 span
+        _SUB_SCOPE_EDGE,  # 0x16 edge number
+        _SUB_SCOPE_HOLD,  # 0x17 hold
+        _SUB_SCOPE_REF,  # 0x19 ref level
+        _SUB_SCOPE_SPEED,  # 0x1A sweep speed
+        # 0x1C (center type) does NOT take receiver prefix -- sending 0x00
+        # as prefix is misinterpreted as SET center_type=0 (Filter center).
+        _SUB_SCOPE_VBW,  # 0x1D VBW
+        _SUB_SCOPE_FIXED_EDGE,  # 0x1E fixed edge frequencies
+        _SUB_SCOPE_RBW,  # 0x1F RBW
+    }
+)
+
+# The selector value naming the MAIN scope.  It is the only legal value on a
+# single-scope radio, and the value a sender must use when it does not (yet)
+# know which scope the radio has selected.
+SCOPE_SELECTOR_MAIN: int = 0x00
+
+
 def _validate_scope_range(name: str, value: int, minimum: int, maximum: int) -> int:
     if not minimum <= value <= maximum:
         raise ValueError(f"{name} must be {minimum}-{maximum}, got {value}")

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -1,25 +1,36 @@
 """Shared state query list for populating RadioState.
 
-Used by RadioPoller (periodic polling) and will be used by CoreRadio
-(initial state fetch on connection).  Each query is a 3-tuple::
+Used by RadioPoller (periodic polling) and by the one-shot sweep run at
+connect (``runtime/radio_initial_state.py: fetch_initial_state``).  Each
+query is a 3-tuple::
 
     (cmd_byte, sub_byte | None, receiver | None)
 
 ``receiver=None`` means the query is global (not per-receiver).
 ``receiver=0`` or ``receiver=1`` targets a specific receiver and will
 be wrapped in cmd29 when the profile supports it.
+
+``sub_byte`` is ``bytes`` when the read needs payload of its own: the
+first byte is the CI-V sub-command and the rest follow it in the frame.
+Both senders decode that shape with
+``core/acquisition_scheduler.py: split_ctl_mem_sub``.  The scope reads
+below are the only queries built here that use it.
 """
 
 from __future__ import annotations
 
 import logging
 
+from rigplane.commands.scope import (
+    SCOPE_RECEIVER_SELECTOR_SUBS,
+    SCOPE_SELECTOR_MAIN,
+)
 from rigplane.profiles import RadioProfile
 
 logger = logging.getLogger(__name__)
 
 # Type alias for a single state query: (cmd, sub, receiver).
-StateQuery = tuple[int, int | None, int | None]
+StateQuery = tuple[int, int | bytes | None, int | None]
 
 
 def build_state_queries(
@@ -181,21 +192,35 @@ def build_state_queries(
     if "ssb_tx_bw" in capabilities:
         queries.append((0x16, 0x58, None))  # SSB TX bandwidth
     if "scope" in capabilities:
-        queries.extend(
-            [
-                (0x27, 0x12, None),  # Scope receiver selection
-                (0x27, 0x13, None),  # Scope single/dual mode
-                (0x27, 0x14, None),  # Scope mode (center/fixed)
-                (0x27, 0x15, None),  # Scope span
-                (0x27, 0x16, None),  # Scope edge number
-                (0x27, 0x17, None),  # Scope hold
-                (0x27, 0x19, None),  # Scope REF level
-                (0x27, 0x1A, None),  # Scope sweep speed
-                (0x27, 0x1B, None),  # Scope during TX
-                (0x27, 0x1C, None),  # Scope center type
-                (0x27, 0x1D, None),  # Scope VBW
-                (0x27, 0x1F, None),  # Scope RBW
-            ]
-        )
+        # 0x27 reads come in two shapes.  The sub-commands in
+        # SCOPE_RECEIVER_SELECTOR_SUBS carry a one-byte Main/Sub scope
+        # selector; the rest must go out bare, where the same byte would be
+        # read as the first data byte of a WRITE (see commands/scope.py).
+        #
+        # SCOPE_SELECTOR_MAIN is what this list can legitimately name: it is
+        # built at connect, before any 0x27 0x12 response has said which
+        # scope the radio has selected, and MAIN is the value every profile
+        # accepts -- on a single-scope radio it is the only legal one, and
+        # per-model selector ranges are MOR-1988.  A sender that does know
+        # the live selection substitutes it
+        # (web/radio_poller.py: RadioPoller._send_one_state_query).
+        for scope_sub in (
+            0x12,  # Scope receiver selection
+            0x13,  # Scope single/dual mode
+            0x14,  # Scope mode (center/fixed)
+            0x15,  # Scope span
+            0x16,  # Scope edge number
+            0x17,  # Scope hold
+            0x19,  # Scope REF level
+            0x1A,  # Scope sweep speed
+            0x1B,  # Scope during TX
+            0x1C,  # Scope center type
+            0x1D,  # Scope VBW
+            0x1F,  # Scope RBW
+        ):
+            if scope_sub in SCOPE_RECEIVER_SELECTOR_SUBS:
+                queries.append((0x27, bytes([scope_sub, SCOPE_SELECTOR_MAIN]), None))
+            else:
+                queries.append((0x27, scope_sub, None))
 
     return queries

--- a/src/rigplane/runtime/radio_initial_state.py
+++ b/src/rigplane/runtime/radio_initial_state.py
@@ -19,6 +19,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from rigplane.core.acquisition_scheduler import split_ctl_mem_sub
+
 if TYPE_CHECKING:
     # Internal implementation module for IcomRadio — the TID251 ban targets
     # external consumers (web/, rigctld/), not radio.py's own helpers.
@@ -61,11 +63,15 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
         )
         ok = 0
         for cmd_byte, sub_byte, receiver in queries:
+            # A query's sub element carries payload of its own where the read
+            # needs one -- the scope reads that take a Main/Sub selector are
+            # built that way (``_state_queries.py: build_state_queries``).
+            civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
             try:
                 if (
                     receiver is None
                     and cmd_byte in (0x25, 0x26)
-                    and sub_byte == 0x01
+                    and civ_sub == 0x01
                     and radio._profile.vfo_readback == "selected_unselected"
                 ):
                     await radio.send_civ(
@@ -82,16 +88,19 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
                             wait_response=False,
                         )
                     else:
-                        # cmd29-wrapped: 0x29 with [receiver, cmd, sub?]
+                        # cmd29-wrapped: 0x29 with [receiver, cmd, sub?].
+                        # ``civ_sub`` and no ``extra_data``: a sub element
+                        # that carries payload is never paired with a
+                        # receiver, so there is nothing to append here.
                         inner = bytes([receiver, cmd_byte])
-                        if sub_byte is not None:
-                            inner += bytes([sub_byte])
+                        if civ_sub is not None:
+                            inner += bytes([civ_sub])
                         await radio.send_civ(0x29, data=inner, wait_response=False)
                 else:
                     await radio.send_civ(
                         cmd_byte,
-                        sub=sub_byte,
-                        data=b"",
+                        sub=civ_sub,
+                        data=extra_data,
                         wait_response=False,
                     )
                 ok += 1

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1293,8 +1293,8 @@ class RadioPoller:
             f"{self._profile.model} (receivers={self._profile.receiver_count})"
         )
 
-    def _build_state_queries(self) -> list[tuple[int, int | None, int | None]]:
-        result: list[tuple[int, int | None, int | None]] = build_state_queries(
+    def _build_state_queries(self) -> list[tuple[int, int | bytes | None, int | None]]:
+        result: list[tuple[int, int | bytes | None, int | None]] = build_state_queries(
             self._profile,
             self._caps,
             is_serial=self._is_serial,
@@ -1318,15 +1318,17 @@ class RadioPoller:
         does not park the poll loop on the commander future (MOR-497ii); the
         response still arrives via the CI-V RX path.
 
-        ``sub_byte`` is ``bytes`` only for multi-byte ctl-mem sub-addressing
-        (0x1A/0x05 "quick set" reads, e.g. voxDelay, MOR-1483) — always a
-        global (``receiver is None``) read today, so only the final
-        non-receiver, non-scope branch below needs to split it.
+        ``sub_byte`` is ``bytes`` where the read carries payload of its own:
+        multi-byte ctl-mem sub-addressing (0x1A/0x05 "quick set" reads, e.g.
+        voxDelay, MOR-1483) and the 0x27 scope reads that take a Main/Sub
+        selector (MOR-1981). Both are global (``receiver is None``) reads
+        today, which is what the cmd29 branch below asserts.
         """
+        civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
         if (
             receiver is None
             and cmd_byte in (0x25, 0x26)
-            and sub_byte == 0x01
+            and civ_sub == 0x01
             and self._profile.vfo_readback == "selected_unselected"
         ):
             await self._civ(
@@ -1337,7 +1339,7 @@ class RadioPoller:
             )
         elif receiver is not None:
             assert not isinstance(sub_byte, (bytes, bytearray)), (
-                "multi-byte ctl-mem sub-addressing is global-only (receiver=None)"
+                "a sub element carrying payload is global-only (receiver=None)"
             )
             if cmd_byte in (0x25, 0x26):
                 await self._civ(
@@ -1353,21 +1355,23 @@ class RadioPoller:
                 await self._civ(
                     0x29, data=inner, priority=priority, wait_dispatch=False
                 )
-        elif cmd_byte == 0x27 and sub_byte in SCOPE_RECEIVER_SELECTOR_SUBS:
-            # Scope control queries need receiver prefix (00=MAIN, 01=SUB)
+        elif cmd_byte == 0x27 and civ_sub in SCOPE_RECEIVER_SELECTOR_SUBS:
+            # Scope control queries need receiver prefix (00=MAIN, 01=SUB).
+            # ``build_state_queries`` emits MAIN because it runs at connect,
+            # before the radio has said which scope is selected; where the
+            # poller has state to read the live selection from, that
+            # replaces the default.
             scope_rx = 0
             if self._radio_state:
                 scope_rx = self._radio_state.scope_controls.receiver
-            assert isinstance(sub_byte, int)
             await self._civ(
                 cmd_byte,
-                sub=sub_byte,
+                sub=civ_sub,
                 data=bytes([scope_rx]),
                 priority=priority,
                 wait_dispatch=False,
             )
         else:
-            civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
             await self._civ(
                 cmd_byte,
                 sub=civ_sub,
@@ -3621,7 +3625,7 @@ class RadioPoller:
     # State queries interleaved on odd cycles.
     # Tuple: (cmd, sub, receiver) where receiver=None means global query.
     # Populated per instance from runtime profile/capabilities.
-    _STATE_QUERIES: list[tuple[int, int | None, int | None]] = []
+    _STATE_QUERIES: list[tuple[int, int | bytes | None, int | None]] = []
 
     def _pick_high_meter(self, high_idx: int) -> tuple[int, int | None]:
         """Choose HIGH-tier meter based on PTT state."""
@@ -3912,16 +3916,21 @@ class RadioPoller:
                 self._poll_index += 1
                 return
             state_idx = (self._poll_index // 2) % len(self._STATE_QUERIES)
-            cmd_byte, sub_byte, receiver = self._STATE_QUERIES[state_idx]
+            cmd_byte, state_sub, receiver = self._STATE_QUERIES[state_idx]
+            # ``sub`` reports the CI-V sub-command byte; a query that also
+            # carries payload in its sub element (see
+            # ``_send_one_state_query``) has that payload split off here
+            # rather than formatted as part of the byte.
+            diag_sub, _ = split_ctl_mem_sub(state_sub)
             self._record_state_diagnostic(
                 "backend_read",
                 "web.radio_poller",
                 family="state",
                 command=f"0x{cmd_byte:02x}",
-                sub=None if sub_byte is None else f"0x{sub_byte:02x}",
+                sub=None if diag_sub is None else f"0x{diag_sub:02x}",
                 receiver=receiver,
             )
-            await self._send_one_state_query(cmd_byte, sub_byte, receiver)
+            await self._send_one_state_query(cmd_byte, state_sub, receiver)
         self._poll_index += 1
 
     # Issue #2303: passive observation must never select or exchange a VFO.

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1394,12 +1394,18 @@ class RadioPoller:
         Called after scope is enabled — IC-7610 ignores scope control
         queries when scope data output is off.
 
-        Note: commands 0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F
-        require a receiver prefix byte (00=MAIN, 01=SUB) in the READ
-        query — without it the IC-7610 silently ignores the query.
-        The public ``get_scope_*`` methods on ``ScopeRuntimeMixin`` add
-        the prefix from ``radio_state.scope_controls.receiver`` for
-        each affected sub-command.
+        Note: some sub-commands require a receiver prefix byte
+        (00=MAIN, 01=SUB) in the READ query — without it the IC-7610
+        silently ignores the query.  Which ones is
+        ``commands/scope.py: SCOPE_RECEIVER_SELECTOR_SUBS``; do not
+        restate the membership here, it moved there under MOR-1981 and
+        that constant is the one a sender should import.  This method is
+        not one of the senders that consult it: its prefix comes from the per-getter
+        ``receiver=`` arguments in ``runtime/_scope_runtime.py``, which
+        must be changed alongside the set.  The public ``get_scope_*``
+        methods on ``ScopeRuntimeMixin`` add the prefix from
+        ``radio_state.scope_controls.receiver`` for each affected
+        sub-command.
 
         Each getter is bounded by ``_SCOPE_GETTER_TIMEOUT``: a dropped
         scope-control response (common on busy scope streams) only costs

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -74,6 +74,7 @@ from ..capabilities import (
 )
 from .._queue_pressure import PRESSURE_THRESHOLD
 from ..commands.commander import Priority
+from ..commands.scope import SCOPE_RECEIVER_SELECTOR_SUBS
 from ..core.command_service import (
     CommandService,
 )
@@ -1300,25 +1301,6 @@ class RadioPoller:
         )
         return result
 
-    # Scope sub-commands that require a receiver prefix byte in READ queries.
-    # Without the prefix, IC-7610 silently ignores the query.
-    # 0x12 (receiver select), 0x13 (single/dual), 0x1B (during TX) do NOT need it.
-    _SCOPE_RECEIVER_PREFIX_SUBS = frozenset(
-        {
-            0x14,  # mode (center/fixed/scroll)
-            0x15,  # span
-            0x16,  # edge number
-            0x17,  # hold
-            0x19,  # ref level
-            0x1A,  # sweep speed
-            # 0x1C (center type) does NOT take receiver prefix — sending 0x00
-            # as prefix is misinterpreted as SET center_type=0 (Filter center).
-            0x1D,  # VBW
-            0x1E,  # fixed edge frequencies
-            0x1F,  # RBW
-        }
-    )
-
     async def _send_one_state_query(
         self,
         cmd_byte: int,
@@ -1371,7 +1353,7 @@ class RadioPoller:
                 await self._civ(
                     0x29, data=inner, priority=priority, wait_dispatch=False
                 )
-        elif cmd_byte == 0x27 and sub_byte in self._SCOPE_RECEIVER_PREFIX_SUBS:
+        elif cmd_byte == 0x27 and sub_byte in SCOPE_RECEIVER_SELECTOR_SUBS:
             # Scope control queries need receiver prefix (00=MAIN, 01=SUB)
             scope_rx = 0
             if self._radio_state:

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -30,7 +30,7 @@ edit to this file, never silently.
 
 Nothing here fixes a divergence. Which commands take a receiver prefix byte
 is MOR-1981, and adding one where the radio does not expect it is a write,
-not a no-op — see ``web/radio_poller.py: _SCOPE_RECEIVER_PREFIX_SUBS``.
+not a no-op — see ``commands/scope.py: SCOPE_RECEIVER_SELECTOR_SUBS``.
 
 What could not be compared is not skipped silently:
 ``command_map_parity_uncovered.txt`` records the commands a profile's map

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -3830,6 +3830,26 @@ def test_state_queries_include_scope_vbw_rbw_edge_for_ic7610() -> None:
     assert (0x27, 0x1F, None) in queries  # RBW
 
 
+@pytest.mark.asyncio
+async def test_scope_fixed_edge_query_carries_no_selector_byte() -> None:
+    """MOR-1981: 0x27 0x1E must never go out as ``27 1E 00``.
+
+    0x1E takes ``<frequency range><edge number>``, and ``00`` is not a legal
+    frequency range -- they start at ``01``.  While 0x1E was a member of
+    ``commands/scope.py: SCOPE_RECEIVER_SELECTOR_SUBS`` this call put that
+    frame on the wire.  The valid read is built by
+    ``commands/scope.py: get_scope_fixed_edge`` and reaches the radio
+    through ``RadioPoller._fetch_scope_controls``, not through here.
+    """
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._send_one_state_query(0x27, 0x1E, None)  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once()
+    assert radio.send_civ.await_args.kwargs["data"] == b""
+
+
 # ---------------------------------------------------------------------------
 # _adaptive_gap tests
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -3822,12 +3822,36 @@ def test_state_queries_include_scope_vbw_rbw_edge_for_ic7610() -> None:
     poller = RadioPoller(_make_radio(), StateCache(), CommandQueue())
 
     queries = set(poller._STATE_QUERIES)  # noqa: SLF001
-    assert (0x27, 0x16, None) in queries  # edge number
-    assert (0x27, 0x19, None) in queries  # REF level
+    # The eight selector-carrying reads arrive as a two-byte ``sub``
+    # (sub-command + Main/Sub selector); the rest stay bare (MOR-1981).
+    assert (0x27, b"\x16\x00", None) in queries  # edge number
+    assert (0x27, b"\x19\x00", None) in queries  # REF level
     assert (0x27, 0x1B, None) in queries  # during TX
     assert (0x27, 0x1C, None) in queries  # center type
-    assert (0x27, 0x1D, None) in queries  # VBW
-    assert (0x27, 0x1F, None) in queries  # RBW
+    assert (0x27, b"\x1d\x00", None) in queries  # VBW
+    assert (0x27, b"\x1f\x00", None) in queries  # RBW
+
+
+@pytest.mark.asyncio
+async def test_scope_state_query_uses_the_live_scope_receiver() -> None:
+    """The poll rotation overrides the sweep's MAIN default (MOR-1981).
+
+    ``build_state_queries`` runs at connect, before any 0x27 0x12 response
+    has said which scope is selected, so it emits ``SCOPE_SELECTOR_MAIN``.
+    The poller knows the live selection and must substitute it, or a
+    dual-scope radio showing SUB would be polled for MAIN's settings.
+    """
+    radio = _make_radio()
+    state = RadioState()
+    state.scope_controls.receiver = 1
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._send_one_state_query(0x27, b"\x14\x00", None)  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once()
+    assert radio.send_civ.await_args.args[0] == 0x27
+    assert radio.send_civ.await_args.kwargs["sub"] == 0x14
+    assert radio.send_civ.await_args.kwargs["data"] == b"\x01"
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -6,8 +6,19 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
+from rigplane.commands.scope import (
+    SCOPE_RECEIVER_SELECTOR_SUBS,
+    SCOPE_SELECTOR_MAIN,
+)
 from rigplane.runtime._state_queries import build_state_queries
 from rigplane.profiles import resolve_radio_profile
+
+# The 0x27 read sub-commands the sweep sends, split by whether the frame
+# carries the one-byte Main/Sub scope selector.  Spelled out here rather
+# than imported from the production constant, so a change to that set has
+# to be made twice, deliberately (MOR-1981).
+_SELECTOR_SUBS = frozenset({0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F})
+_BARE_SUBS = frozenset({0x12, 0x13, 0x1B, 0x1C})
 
 
 def _ic7610_caps() -> set[str]:
@@ -121,6 +132,34 @@ class TestBuildStateQueries:
         q1 = build_state_queries(profile, caps)
         q2 = build_state_queries(profile, caps)
         assert q1 == q2
+
+
+class TestScopeReceiverSelector:
+    """MOR-1981: which 0x27 reads carry the Main/Sub scope selector byte.
+
+    The separation is the point.  On a sub-command that takes no selector
+    the extra ``0x00`` is not an ignored byte but the first data byte of a
+    WRITE, so a mutation that widens the set has to fail here.
+    """
+
+    def test_constant_holds_exactly_the_eight(self) -> None:
+        assert SCOPE_RECEIVER_SELECTOR_SUBS == _SELECTOR_SUBS
+        assert len(SCOPE_RECEIVER_SELECTOR_SUBS) == 8
+        assert SCOPE_SELECTOR_MAIN == 0x00
+
+    def test_the_bare_four_are_not_in_the_set(self) -> None:
+        """``27 1C 00`` reads as SET center_type=0 (Filter center), not a query."""
+        assert _BARE_SUBS.isdisjoint(SCOPE_RECEIVER_SELECTOR_SUBS)
+        assert len(_BARE_SUBS) == 4
+
+    def test_fixed_edge_is_not_in_the_set(self) -> None:
+        """0x1E takes ``<frequency range><edge number>``, not the selector.
+
+        ``00`` is not a legal frequency range -- they start at ``01`` -- so
+        ``27 1E 00`` is neither a bare read nor a valid one.  The pair is
+        built by ``commands/scope.py: get_scope_fixed_edge``.
+        """
+        assert 0x1E not in SCOPE_RECEIVER_SELECTOR_SUBS
 
 
 # ------------------------------------------------------------------

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -21,6 +21,12 @@ _SELECTOR_SUBS = frozenset({0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F})
 _BARE_SUBS = frozenset({0x12, 0x13, 0x1B, 0x1C})
 
 
+def _scope_queries(
+    queries: list[tuple[int, int | bytes | None, int | None]],
+) -> list[tuple[int, int | bytes | None, int | None]]:
+    return [q for q in queries if q[0] == 0x27]
+
+
 def _ic7610_caps() -> set[str]:
     """Return the full capability set for IC-7610."""
     profile = resolve_radio_profile(model="IC-7610")
@@ -161,6 +167,60 @@ class TestScopeReceiverSelector:
         """
         assert 0x1E not in SCOPE_RECEIVER_SELECTOR_SUBS
 
+    def test_sweep_splits_scope_reads_eight_selector_four_bare(self) -> None:
+        profile = resolve_radio_profile(model="IC-7300")
+        scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
+
+        with_selector = {
+            sub[0] for _, sub, _ in scope if isinstance(sub, (bytes, bytearray))
+        }
+        bare = {sub for _, sub, _ in scope if isinstance(sub, int)}
+
+        assert with_selector == _SELECTOR_SUBS
+        assert bare == _BARE_SUBS
+        assert len(scope) == len(_SELECTOR_SUBS) + len(_BARE_SUBS) == 12
+        # The scope reads are the only queries this builder gives a
+        # payload-carrying sub element to.
+        queries = build_state_queries(profile, _ic7300_caps())
+        assert [
+            cmd for cmd, sub, _ in queries if isinstance(sub, (bytes, bytearray))
+        ] == [0x27] * len(_SELECTOR_SUBS)
+
+    def test_sweep_selector_is_one_byte_and_main(self) -> None:
+        profile = resolve_radio_profile(model="IC-7300")
+        scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
+
+        carried = [sub for _, sub, _ in scope if isinstance(sub, (bytes, bytearray))]
+        assert carried, "no scope read carried a selector"
+        for sub in carried:
+            assert len(sub) == 2
+            assert sub[1] == SCOPE_SELECTOR_MAIN
+
+    @pytest.mark.parametrize("model", ["IC-7300", "IC-7610"])
+    def test_a_payload_carrying_sub_is_never_paired_with_a_receiver(
+        self, model: str
+    ) -> None:
+        """The selector is payload, not the cmd29 receiver slot.
+
+        A non-``None`` third element routes the query through cmd29 in both
+        senders, which is a different frame entirely, and neither carries
+        the payload half of the sub element down that path:
+        ``runtime/radio_initial_state.py: fetch_initial_state`` wraps the
+        sub-command byte alone, and
+        ``web/radio_poller.py: RadioPoller._send_one_state_query`` asserts
+        the combination cannot arise.
+        """
+        profile = resolve_radio_profile(model=model)
+        caps = set(profile.capabilities)
+        queries = build_state_queries(profile, caps)
+
+        assert _scope_queries(queries), "no scope reads to check"
+        assert all(
+            receiver is None
+            for _, sub, receiver in queries
+            if isinstance(sub, (bytes, bytearray))
+        )
+
 
 # ------------------------------------------------------------------
 # CoreRadio._fetch_initial_state tests
@@ -212,6 +272,37 @@ class TestFetchInitialState:
             call(0x26, data=b"\x01", wait_response=False)
             in radio.send_civ.await_args_list
         )
+
+    @pytest.mark.asyncio
+    async def test_scope_reads_carry_the_selector_only_where_it_is_legal(
+        self, radio
+    ) -> None:
+        """MOR-1981: the eight get ``<sub> 00``, the four go out bare.
+
+        Measured on a live IC-7300: the bare form of each of the eight is
+        refused with a NAK, and the four answer.  A mutation that adds the
+        byte to one of the four -- 0x1C above all, where ``27 1C 00`` is a
+        SET -- fails here.
+        """
+        radio._profile = resolve_radio_profile(model="IC-7300")
+
+        await radio._fetch_initial_state()
+
+        sent = radio.send_civ.await_args_list
+        for sub in sorted(_SELECTOR_SUBS):
+            assert (
+                call(
+                    0x27,
+                    sub=sub,
+                    data=bytes([SCOPE_SELECTOR_MAIN]),
+                    wait_response=False,
+                )
+                in sent
+            ), f"0x27/0x{sub:02X} was not sent with a selector byte"
+        for sub in sorted(_BARE_SUBS):
+            assert call(0x27, sub=sub, data=b"", wait_response=False) in sent, (
+                f"0x27/0x{sub:02X} was not sent bare"
+            )
 
     @pytest.mark.asyncio
     async def test_sets_flag_on_success(self, radio) -> None:


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1981.
- Compatibility impact: **wire behaviour, one change.** The connect-time sweep now sends a selector byte on eight `0x27` reads. No API, CLI or config change.

Icom's `0x27` scope reads take a one-byte Main/Sub **scope selector** between the sub-command and the terminator. On a single-scope radio the only legal value is `0x00` — a *"the byte is always zero"* case, not a *"no byte"* case.

**The knowledge already existed in this tree and was correct.** `web/radio_poller.py` held the right set, applied it, and carried the trap in a comment. **The connect-time sweep did not have it** — `runtime/_state_queries.py: build_state_queries` carried its own hardcoded list and the sweep sent bare frames. So this was two senders of scope reads, one right and one wrong, not a missing capability.

Measured on a live IC-7300, six runs, zero variance: the eight sub-commands that need the selector are refused with a NAK; the four that do not are answered. That is 8 of the 9 queries the initial sweep gets declined.

## Four commits

**`bdc0720` — move the set to `commands/scope.py`.** `web/` and `runtime/` are both above `commands/` in the layer matrix, and the import linter forbids `runtime` importing from `web`, so `commands/` is where both senders can reach it. New `SCOPE_RECEIVER_SELECTOR_SUBS` and `SCOPE_SELECTOR_MAIN`; the poller consumes them instead of defining its own. Members are spelled with the `_SUB_SCOPE_*` names already in scope, not raw bytes. The `0x1C` trap comment travelled with the set — it must live beside the thing it guards.

**`fb25e3a` — drop `0x1E`.** Fixed edge frequencies take `<range><edge>` and **no** selector, and `00` is not a legal range — they start at `01`. `commands/scope.py: get_scope_fixed_edge` already built it correctly; the poller's set wrongly included it. **This has no production wire effect** and the earlier draft of this body was wrong to imply one: `build_state_queries` never emitted `(0x27, 0x1E, …)` on base either, and the acquisition executor cannot emit `0x27` at all, so that tuple never reached the poller's sender in production. The fix is to the set's correctness, and the test pins the sender's behaviour directly.

**`77dc83b` — the sweep sends the selector.** The eight leave with a two-byte sub element, the four stay bare. The selector rides the existing multi-byte-`sub` representation that both senders already decode, rather than a new tuple field. `build_state_queries` emits MAIN and the poller still substitutes the live `scope_controls.receiver`, so the IC-7610 SUB-scope rotation is unchanged — verified byte-identical to base at both `scope_rx=0` and `scope_rx=1`.

**`d7c5ce8` — prose corrections from review.** Four false claims in the comment that is now the canonical home of this knowledge, plus a third literal copy of the membership left behind in `RadioPoller._fetch_scope_controls`'s docstring, which now points at the constant instead. Details under Agent Review below. This commit changes no executable byte — the reviewer confirmed it independently by AST comparison, not by reading the diff.

## The separation is the deliverable, not the fix

**On a one-byte sub-command the extra `0x00` is a write, not a no-op.** Sending it to `0x1C` sets centre type to Filter Center. So the eight-versus-four split is pinned at three levels:

- **the constant** — the eight and the four are spelled out in the test as literals rather than imported, so the test cannot be satisfied by comparing the constant against itself;
- **the query list** — the sweep's output is checked for the split, that the selector is one byte and MAIN, and that a payload-carrying sub is never paired with a receiver;
- **the wire** — `tests/test_state_queries.py::TestFetchInitialState::test_scope_reads_carry_the_selector_only_where_it_is_legal` requires the eight to send `data=b"\x00"` and the four `data=b""`.

Mutation proof: adding scope centre type to the set fails **exactly 5 tests**, including the wire-level one. Independently reproduced by the reviewer, who mutated in both directions — adding `0x1E` fails 3, dropping `0x14` fails 4, dropping `0x1F` fails 4, and flipping `SCOPE_SELECTOR_MAIN` to `0x01` fails 2. Every direction bites.

## Evidence, and its limit

Icom's own CI-V Reference Guide for the **IC-705** — same single-scope architecture — prints the width of each sub-command's data field, matching the bench with no exceptions: two bytes for exactly `14, 15, 16, 17, 19, 1A, 1D`, one byte for exactly `12, 13, 1B, 1C`. `0x1F` has no row there, but Hamlib gives it the selector and it NAKs bare.

**Not established: Icom's IC-7300 table itself**, and there is **no bench evidence for the IC-9700** — this constant governs the sweep on four profiles and was measured on one. The code says so where the set is defined.

The fact that actually de-risks this, now stated in the code: **`web/radio_poller.py` has been putting this exact eight-selector/four-bare split on the wire to all four scope-capable profiles since long before the constant existed.** The connect sweep is catching up to shipped behaviour, not trying something new. That is a stronger argument than the IC-705 analogy. The reviewer verified the "exact split" claim rather than accepting it: the base poller set intersected with the base sweep list is exactly the eight.

## Class sweep — senders of `0x27` reads

1. `runtime/radio_initial_state.py: fetch_initial_state`, over the list `build_state_queries` returns — was wrong, fixed here.
2. `web/radio_poller.py: RadioPoller._send_one_state_query` — right except `0x1E`, fixed here.
3. `runtime/_scope_runtime.py` — **already correct**; all fourteen getters re-derived, `receiver=` passed for exactly the eight and omitted for the six that must not take it. *(An earlier draft said "fifteen", which did not even add up against its own 8 + 6; the file defines fourteen `get_scope_*` methods.)*
4. Two `0x27 0x12` **writes** in the poller whose data byte is the receiver — correct by construction.
5. **`rigctld/server.py: RigctldServer._send_one_state_query`** — found by review, not by the original sweep. Same shape, does **not** consult the set, bound as an `AcquisitionQuerySender` at two sites. Safe today only because `core/acquisition_scheduler.py: IcomCivAcquisitionExecutor.query_for_path` has no `scope_controls` branch, so all fifteen scope fields resolve to `None`. Nothing pins that, so the constant's comment now records it as the third site to wire up if that branch is ever added.

**Left unfixed and reported:** three public builders in `commands/scope.py` accept a `receiver` argument for a sub-command that must not take a selector, so a caller passing `receiver=0` would emit a write — `get_scope_center_type`, `scope_set_center_type` (`0x1C`) and `scope_single_dual` (`0x13`). All three verified latent by review: no production caller passes `receiver` to any of them. Fixing them means changing public builder signatures and perturbing the parity baselines, which is outside this change.

## Holders of the membership

Separate from the list of senders, and the thing three review rounds were spent getting right: **three places hold this membership, and two of them do not import the constant.** The comment beside the constant now names all three and says to change them together.

1. `commands/scope.py: SCOPE_RECEIVER_SELECTOR_SUBS` — the canonical one.
2. `runtime/_scope_runtime.py` — holds it as a call-site pattern, `receiver=` passed per getter.
3. `runtime/_civ_rx.py: CivRuntime._civ_expects_response` — holds it as a live tuple `_SCOPE_GET_WITH_RX_PREFIX` in a branch condition. **Executable and unpinned.** A sub-command added to the constant but not to the tuple ships as `27 <sub> 00`, one data byte, and the fall-through classifies it as expecting no response.

Nothing asserts the three agree. **Making the RX path import the constant is the real fix and is deliberately not done here** — it is executable change on the RX path, it needs its own tests, and it would be scope creep. Recorded in the code, and handled the same way the rigctld sender was.

The reviewer tested that enumeration by enumerating rather than by example: an AST sweep of every `.py` under `src/` and `tests/` for any collection literal holding ≥6 of the eight finds exactly three, and the two that are not the constant are `_civ_rx.py`'s tuple and the deliberate literal in `tests/test_state_queries.py` — which imports the constant and asserts equality, so an edit does reach it, loudly.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10622 passed, 0 failed**. `main` at `cb3435c8` gives 10612 with an identical skip set, so the delta is exactly the ten tests added here and nothing became silently skipped. `ruff check` and `ruff format --check` clean (689 files); `lint-imports` 5 kept / 0 broken; doc-citation gate clean; `mypy --strict src/rigplane/web` clean; advisory whole-tree `mypy src/` clean at 296 files.
- [x] Public/open-core boundary checked — no telemetry, no Pro content, no bench detail.
- [x] Release or migration impact documented if applicable — none.

`tests/test_command_map_parity.py` is 5/5 green and no divergence row opened or closed.

## Guardrails — the soft threshold is crossed on file count

**7 files, 422 changed lines** (350 additions + 72 deletions). Lines are under the soft threshold of 600 and nowhere near the hard ceiling; the file count is 7 against a soft 6. *An earlier draft of this body said 408 and was simply wrong; the count above is `git diff --shortstat` against the merge base.*

Why this is one unit of work: every file was forced, none chosen. The four production files are the constant's new home and its senders — a relocation is not a relocation until the old definition is gone. The three test files are the two homes of the functions under test plus a one-line stale citation created by the move itself. `tests/test_radio_poller_coverage.py` is worth naming: it held four assertions that spelled out the **bug** as expected behaviour, so it had to change with the wire format.

The reviewer read the diff rather than this justification and reached the same conclusion: "all seven look forced … this is one unit of work and does not want splitting."

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` agent, relayed by the coordinating session (the reviewing environment has no GitHub access)
- Result: **PASS** at `d7c5ce8`, after **three BLOCKED rounds**.

Every blocking finding across all four rounds was a false or over-wide claim in a comment or docstring. **Not one was a defect in the executable change** — the review verified the wire behaviour rather than trusting it (membership re-derived from `commands/_frame.py`, sweep frames dumped across all four scope-capable profiles, mutation-tested in both directions, poller rotation confirmed byte-identical to base at both receiver values, `rigctld` unreachability derived twice over) and could not break the mechanism.

The rounds, and what they cost:

- **B1** — "Every 0x27 read outside this set must be sent bare" is false for `0x1E`, which the same comment block contradicted a few lines below.
- **B2** — the sender enumeration credited a list-builder as a sender and missed the `rigctld` one entirely.
- **B3** — the B1/B2 fix introduced "so that one edit reaches every sender", false because `runtime/_scope_runtime.py` does not import the constant.
- **B4** — the B3 fix introduced "so the membership has one home", false because `runtime/_civ_rx.py` holds a fourth copy as a live tuple, with a silent-failure mode if the two diverge.

**The pattern is the finding.** B3 and B4 were each introduced by the fix for the round before, because each round corrected the instance the reviewer named without enumerating the class it belonged to — and the reviewer said so explicitly at B4. The fix for B4 swept the class first and the enumeration was then confirmed complete by independent AST sweep. That is why this section is longer than the change deserves: the review history is the useful artefact here, not the four bytes of wire format.

## Notes

- Out of scope / follow-ups: the ninth declined query is `0x18` power status, which has no read form at all — MOR-1983, along with the sweep's failure to read the profile command map. Per-model selector *ranges* are MOR-1988; IC-9700 and IC-7610 are dual-scope and need `01` as well, and `rigs/ic9700.toml` currently mis-declares itself single-receiver. The three latent builder signatures are unticketed.
- **New for MOR-1988, raised by the final review:** on an IC-7610 with the scope on SUB at connect, the sweep hardcodes MAIN for all eight, so the replies carry the `00` prefix and `CivRuntime._handle_27` writes `scope.receiver = 0`, overwriting what the sweep's own `27 12` just read. It self-corrects (`RadioPoller._fetch_scope_controls` reads the receiver first, and `27 12` recurs in the rotation ahead of the eight) and is mostly unreachable, because the IC-7610 ignores scope-control queries while scope data output is off — the state at connect. But before this change those eight got no answer at all on that radio, so it is a **new** bounded transient rather than a pre-existing one. Recorded rather than fixed here.
- **Wording left imprecise on purpose:** the constant's comment says `_scope_runtime.py` "passes `receiver=` per getter". The reviewer notes it is passed at 16 sites — the eight getters and their eight setters. The sub-command coverage claim is unaffected and the sentence is not false, so this is not corrected in code: re-heading the branch for a non-blocking wording nit would discard the PASS and buy another full review round.
- Also unpinned, raised by review: `RadioPoller._send_one_state_query` asserts that a payload-carrying sub is never paired with a receiver, while `fetch_initial_state` silently drops the extra data on that path. Structurally unreachable today — the reviewer checked all eight profiles × serial/LAN × the union of every declared capability — and the comment says so, but the two senders disagree about whether it is worth asserting.
- The `cmd_map` branch of `get_scope_*` still discards `receiver`. Latent — no production code passes a `cmd_map` to any builder — and recorded as a divergence row by the parity pin from #2792.