### PR TITLE
fix(MOR-1977): stop the commander path claiming another command's refusal

### DIFF
--- a/src/rigplane/core/civ.py
+++ b/src/rigplane/core/civ.py
@@ -360,7 +360,12 @@ class CivRequestTracker:
                     # Successfully sunk an ACK for a fire-and-forget request
                     return True
 
-            # Keep short-lived orphan ACKs so strict waiters can consume them.
+            # Park short-lived orphan ACK/NAK frames, bounded and TTL-pruned.
+            # No waiter in ``src/`` claims them: every ``register_ack`` call
+            # site there passes ``consume_backlog=False`` or takes a sink
+            # token (MOR-1977 unit A).  The backlog survives for the
+            # ``ack_orphans`` / ``ack_backlog_drops`` counters, and because
+            # ``consume_backlog=True`` remains this method's default.
             self._ack_orphans += 1
             if self._ack_backlog_size <= 0:
                 self._ack_backlog_drops += 1

--- a/src/rigplane/core/civ.py
+++ b/src/rigplane/core/civ.py
@@ -363,9 +363,11 @@ class CivRequestTracker:
             # Park short-lived orphan ACK/NAK frames, bounded and TTL-pruned.
             # No waiter in ``src/`` claims them: every ``register_ack`` call
             # site there passes ``consume_backlog=False`` or takes a sink
-            # token (MOR-1977 unit A).  The backlog survives for the
-            # ``ack_orphans`` / ``ack_backlog_drops`` counters, and because
-            # ``consume_backlog=True`` remains this method's default.
+            # token (MOR-1977 unit A).  The deque survives because
+            # ``consume_backlog=True`` remains ``register_ack``'s default for
+            # callers that do want it, and for the ``ack_backlog_drops``
+            # accounting below.  ``ack_orphans`` is counted either way -- it
+            # is incremented before the deque is touched at all.
             self._ack_orphans += 1
             if self._ack_backlog_size <= 0:
                 self._ack_backlog_drops += 1

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -725,12 +725,12 @@ class CivRuntime:
         built with a timeout below 2.0 s; a read that answers in time settles
         normally, which is every ordinary one.
 
-        The orphaned refusal is also not inert. It lands in the tracker's ACK
-        backlog and stays claimable for ``ack_backlog_ttl``, where the next
-        ``register_ack(consume_backlog=True)`` — the form ``_execute_civ_raw``
-        uses — claims it and reports it as that command's failure. So this
-        read stops being charged another command's refusal; the refusal is
-        charged to a different command instead.
+        The orphaned refusal lands in the tracker's ACK backlog. Under
+        MOR-1980 that displaced the mis-charge rather than ending it, because
+        ``_execute_civ_raw`` still claimed from the backlog; MOR-1977 unit A
+        closed that, so no blocking waiter in ``src/`` consumes the backlog
+        now and the refusal ages out under ``ack_backlog_ttl`` unclaimed,
+        counted by ``ack_backlog_drops``.
         """
         async with self._ptt_read_lock:
             token = self._managed_tx_ports.get(provider_generation)
@@ -981,11 +981,11 @@ class CivRuntime:
         request that registers a NAK waiter can be settled by somebody else's
         refusal. Pass ``nak_terminal=False`` to register no NAK waiter: this
         request then waits for its exact response, and any refusal routed
-        meanwhile falls through to the tracker's orphan ACK backlog — where it
-        stays claimable for ``ack_backlog_ttl`` by the next
-        ``register_ack(consume_backlog=True)``, rather than being discarded.
-        The cost is that a refusal genuinely aimed at *this* request no longer
-        ends it — it runs out ``timeout`` and fails as a timeout instead.
+        meanwhile falls through to the tracker's orphan ACK backlog, where it
+        ages out under ``ack_backlog_ttl`` without settling anything — no
+        blocking waiter in ``src/`` consumes that backlog. The cost is that a
+        refusal genuinely aimed at *this* request no longer ends it — it runs
+        out ``timeout`` and fails as a timeout instead.
         """
         assert self._host._civ_transport is not None
         self._ensure_civ_runtime()
@@ -3507,8 +3507,13 @@ class CivRuntime:
             if expects_response:
                 pending = self._host._civ_request_tracker.register_response(request_key)
             else:
+                # ``consume_backlog=False``: this waiter is registered before
+                # the frame is sent, so anything already in the orphan ACK/NAK
+                # backlog is necessarily some other command's -- claiming it
+                # would report that command's refusal as this one's.
                 pending_or_token = self._host._civ_request_tracker.register_ack(
-                    wait=True
+                    wait=True,
+                    consume_backlog=False,
                 )
                 if isinstance(pending_or_token, int):
                     raise RuntimeError("ACK waiter registration returned sink token")

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -730,10 +730,13 @@ class CivRuntime:
         ``_execute_civ_raw`` still claimed from the backlog; MOR-1977 unit A
         closed that, so no waiter in ``src/`` claims it. It is retired
         unclaimed by whichever comes first: the TTL prune inside
-        ``register_ack``/``resolve``, the ``drop_ack_backlog`` that opens the
-        next raw transaction, or ``fail_all`` on a generation advance or pump
-        stop. Only the first two increment ``ack_backlog_drops``; arrival is
-        always counted by ``ack_orphans``.
+        ``register_ack``/``resolve``, eviction once the bounded backlog is
+        full, the ``drop_ack_backlog`` that opens the next *response-capable*
+        raw transaction (``expect="ack"``/``"data"`` — an ``expect="none"``
+        send returns before that call), or ``fail_all`` on a generation
+        advance or pump stop. Every one of those except ``fail_all``
+        increments ``ack_backlog_drops``; arrival is always counted by
+        ``ack_orphans``.
         """
         async with self._ptt_read_lock:
             token = self._managed_tx_ports.get(provider_generation)
@@ -986,10 +989,13 @@ class CivRuntime:
         request then waits for its exact response, and any refusal routed
         meanwhile falls through to the tracker's orphan ACK backlog without
         settling anything — no waiter in ``src/`` claims that backlog. It does
-        not linger: this method drops the whole backlog before registering, so
-        on this path the refusal survives only until the next raw transaction.
-        The cost is that a refusal genuinely aimed at *this* request no longer
-        ends it — it runs out ``timeout`` and fails as a timeout instead.
+        not linger indefinitely: this method drops the whole backlog before
+        registering, so the refusal survives only until the next
+        response-capable transaction. An ``expect="none"`` send is not one —
+        it returns before that drop — so a refusal can outlive several managed
+        TX writes. The cost is that a refusal genuinely aimed at *this*
+        request no longer ends it — it runs out ``timeout`` and fails as a
+        timeout instead.
         """
         assert self._host._civ_transport is not None
         self._ensure_civ_runtime()

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -728,9 +728,12 @@ class CivRuntime:
         The orphaned refusal lands in the tracker's ACK backlog. Under
         MOR-1980 that displaced the mis-charge rather than ending it, because
         ``_execute_civ_raw`` still claimed from the backlog; MOR-1977 unit A
-        closed that, so no blocking waiter in ``src/`` consumes the backlog
-        now and the refusal ages out under ``ack_backlog_ttl`` unclaimed,
-        counted by ``ack_backlog_drops``.
+        closed that, so no waiter in ``src/`` claims it. It is retired
+        unclaimed by whichever comes first: the TTL prune inside
+        ``register_ack``/``resolve``, the ``drop_ack_backlog`` that opens the
+        next raw transaction, or ``fail_all`` on a generation advance or pump
+        stop. Only the first two increment ``ack_backlog_drops``; arrival is
+        always counted by ``ack_orphans``.
         """
         async with self._ptt_read_lock:
             token = self._managed_tx_ports.get(provider_generation)
@@ -981,11 +984,12 @@ class CivRuntime:
         request that registers a NAK waiter can be settled by somebody else's
         refusal. Pass ``nak_terminal=False`` to register no NAK waiter: this
         request then waits for its exact response, and any refusal routed
-        meanwhile falls through to the tracker's orphan ACK backlog, where it
-        ages out under ``ack_backlog_ttl`` without settling anything — no
-        blocking waiter in ``src/`` consumes that backlog. The cost is that a
-        refusal genuinely aimed at *this* request no longer ends it — it runs
-        out ``timeout`` and fails as a timeout instead.
+        meanwhile falls through to the tracker's orphan ACK backlog without
+        settling anything — no waiter in ``src/`` claims that backlog. It does
+        not linger: this method drops the whole backlog before registering, so
+        on this path the refusal survives only until the next raw transaction.
+        The cost is that a refusal genuinely aimed at *this* request no longer
+        ends it — it runs out ``timeout`` and fails as a timeout instead.
         """
         assert self._host._civ_transport is not None
         self._ensure_civ_runtime()
@@ -3509,8 +3513,10 @@ class CivRuntime:
             else:
                 # ``consume_backlog=False``: this waiter is registered before
                 # the frame is sent, so anything already in the orphan ACK/NAK
-                # backlog is necessarily some other command's -- claiming it
-                # would report that command's refusal as this one's.
+                # backlog is necessarily some other command's.  The claim pops
+                # the oldest entry whatever it is, so it charges a stranger's
+                # NAK to this command -- or, worse, settles it from a stranger's
+                # ACK, reporting success for a write the radio never answered.
                 pending_or_token = self._host._civ_request_tracker.register_ack(
                     wait=True,
                     consume_backlog=False,

--- a/tests/_order_sensitive_radios.py
+++ b/tests/_order_sensitive_radios.py
@@ -14,7 +14,7 @@ the ``calls`` list.
 Declared transition graphs
 --------------------------
 
-``LanLikeRadio`` — single state field mirroring ``LanAudioStream``::
+``LanLikeRadio`` — single state field mirroring ``AudioStream``::
 
     idle --start_rx--> receiving
     receiving --start_tx--> transmitting
@@ -45,7 +45,7 @@ from rigplane.core.types import AudioCodec
 
 
 class LanLikeRadio:
-    """Radio stub mirroring ``LanAudioStream``'s RX/TX state machine.
+    """Radio stub mirroring ``AudioStream``'s RX/TX state machine.
 
     The real LAN stream supports RX-then-TX only: ``start_rx`` requires
     IDLE state, while ``start_tx`` flips the single state field to

--- a/tests/contracts/test_audio_lifecycle_conformance.py
+++ b/tests/contracts/test_audio_lifecycle_conformance.py
@@ -30,7 +30,7 @@ from the MOR-531 live de-risk), not a real backend row.
 
 Shipping bug surfaced by this suite and fixed in MOR-574 (was a strict
 xfail): ``AudioBridge.stop()`` dropped the RX demand BEFORE stopping
-radio TX, and ``LanAudioStream.stop_rx`` early-returns while
+radio TX, and ``AudioStream.stop_rx`` early-returns while
 TRANSMITTING — so on the LAN backend a bridge stop with TX armed leaked
 the running RX stream (state ended RECEIVING with a live ``_rx_task``
 and zero bus subscribers). Stop-side instance of the MOR-556 ordering
@@ -69,7 +69,7 @@ _TX_DEV = AudioDeviceInfo(id=AudioDeviceId(12), name="Rig CODEC Out", output_cha
 
 
 class _FakeLanAudioTransport:
-    """Minimal IcomTransport stand-in feeding the REAL LanAudioStream."""
+    """Minimal IcomTransport stand-in feeding the REAL AudioStream."""
 
     my_id = 0x0101
     remote_id = 0x0202

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -22,10 +22,12 @@ from rigplane.commands import (
     CONTROLLER_ADDR,
     build_civ_frame,
     build_cmd29_frame,
+    parse_civ_frame,
 )
 from rigplane.commander import Priority
 from rigplane.exceptions import CommandError, ConnectionError, TimeoutError
 from rigplane.core import tx_safety as tx
+from rigplane.core.civ import CivEvent, CivEventType
 from rigplane.radio import IcomRadio
 from rigplane.types import (
     AgcMode,
@@ -1181,6 +1183,48 @@ class TestConnectedProperty:
 
 class TestAckSinkRobustness:
     """Regression tests for fire-and-forget ACK sink behavior."""
+
+    @pytest.mark.asyncio
+    async def test_blocking_write_ignores_an_orphaned_nak(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        """An orphan refusal in the backlog must not settle the next write.
+
+        ``core/civ.py: CivRequestTracker.register_ack`` consumes the orphan
+        ACK/NAK backlog by default, and ``_civ_rx.py:
+        CivRuntime._execute_civ_raw`` registers its ACK waiter *before* it
+        sends — so nothing already in that backlog can be its own. A refusal
+        left there by an earlier command would otherwise complete this write
+        instantly, reporting another command's failure as this one's.
+        """
+        radio._civ_get_timeout = 1.0
+        tracker = radio._civ_request_tracker
+        nak = parse_civ_frame(build_civ_frame(CONTROLLER_ADDR, IC_7610_ADDR, 0xFA))
+        assert tracker.resolve(CivEvent(type=CivEventType.NAK, frame=nak))
+
+        mock_transport.queue_response_on_send(1, _ack_response())
+        write = build_civ_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, _CMD_PTT, sub=_SUB_PTT, data=b"\x01"
+        )
+        try:
+            frame = await radio._execute_civ_raw(write)
+
+            assert frame is not None
+            assert frame.command == _CMD_ACK
+        finally:
+            # Retire the pump through the loop's own exit condition rather
+            # than by cancelling it.  ``CivRuntime._civ_rx_loop`` awaits
+            # ``receive_packet`` under a timeout, and a cancellation delivered
+            # while that await is outstanding surfaces as ``TimeoutError``
+            # instead of ``CancelledError``; the loop catches that and
+            # continues, so the cancellation is consumed and the task keeps
+            # running with ``cancelling() == 1``.  Clearing the transport ends
+            # the loop at its ``while`` on the next pass, within one receive
+            # timeout, with no cancellation involved.
+            radio._civ_transport = None
+            pump = radio._civ_rx_task
+            if pump is not None:
+                await pump
 
     @pytest.mark.asyncio
     async def test_fire_and_forget_missing_ack_does_not_poison_next_ack(

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1213,14 +1213,19 @@ class TestAckSinkRobustness:
             assert frame.command == _CMD_ACK
         finally:
             # Retire the pump through the loop's own exit condition rather
-            # than by cancelling it.  ``CivRuntime._civ_rx_loop`` awaits
-            # ``receive_packet`` under a timeout, and a cancellation delivered
-            # while that await is outstanding surfaces as ``TimeoutError``
-            # instead of ``CancelledError``; the loop catches that and
-            # continues, so the cancellation is consumed and the task keeps
-            # running with ``cancelling() == 1``.  Clearing the transport ends
-            # the loop at its ``while`` on the next pass, within one receive
-            # timeout, with no cancellation involved.
+            # than by cancelling it.  ``core/transport.py:
+            # IcomTransport.receive_packet`` is a bare ``asyncio.wait_for``
+            # over the packet queue, and ``wait_for`` returns the result
+            # instead of propagating when the cancellation arrives after its
+            # inner future has completed -- so the cancel is dropped there,
+            # ``CivRuntime._civ_rx_loop`` never observes it, and the task runs
+            # on with ``cancelling() == 1``.  ``CivRuntime.stop_pump`` cancels
+            # and awaits with no exit condition set first, so it hangs when
+            # that happens; ``audio/lan_stream.py: LanAudioStream.stop_rx``
+            # has the same await shape and is safe only because it clears the
+            # state its loop tests before cancelling.  Clearing the transport
+            # does the same here: the loop ends at its ``while`` on the next
+            # pass, within one receive timeout.
             radio._civ_transport = None
             pump = radio._civ_rx_task
             if pump is not None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1213,19 +1213,29 @@ class TestAckSinkRobustness:
             assert frame.command == _CMD_ACK
         finally:
             # Retire the pump through the loop's own exit condition rather
-            # than by cancelling it.  ``core/transport.py:
-            # IcomTransport.receive_packet`` is a bare ``asyncio.wait_for``
-            # over the packet queue, and ``wait_for`` returns the result
-            # instead of propagating when the cancellation arrives after its
-            # inner future has completed -- so the cancel is dropped there,
-            # ``CivRuntime._civ_rx_loop`` never observes it, and the task runs
-            # on with ``cancelling() == 1``.  ``CivRuntime.stop_pump`` cancels
-            # and awaits with no exit condition set first, so it hangs when
-            # that happens; ``audio/lan_stream.py: LanAudioStream.stop_rx``
-            # has the same await shape and is safe only because it clears the
-            # state its loop tests before cancelling.  Clearing the transport
-            # does the same here: the loop ends at its ``while`` on the next
-            # pass, within one receive timeout.
+            # than by cancelling it, because cancelling it does not behave the
+            # same on every interpreter this project supports.
+            #
+            # ``core/transport.py: IcomTransport.receive_packet`` is a bare
+            # ``asyncio.wait_for`` over the packet queue, and the mock here
+            # mirrors that shape.  On CPython 3.11 -- and only there -- when a
+            # packet is already available at the moment the cancellation
+            # lands, ``wait_for`` returns it and drops the ``CancelledError``,
+            # so ``CivRuntime._civ_rx_loop`` never observes the cancel and
+            # runs on with ``cancelling() == 1``; ``CivRuntime.stop_pump``,
+            # which cancels and then awaits with no exit condition set first,
+            # then never returns.  On 3.12+ ``wait_for`` is built on
+            # ``asyncio.timeouts`` and the cancel propagates, so the loop's
+            # own ``except asyncio.CancelledError`` ends it -- as it also does
+            # on 3.11 when no packet is waiting.  ``runtime/_control_phase.py:
+            # ControlPhaseSessionMechanism._shutdown_supervised_tx`` records
+            # the same 3.11-versus-3.12+ split for the same stdlib reason.
+            #
+            # Clearing the transport is deterministic on all three: the loop
+            # ends at its ``while`` on the next pass, within one receive
+            # timeout, with no cancellation involved.  ``audio/lan_stream.py:
+            # AudioStream.stop_rx`` reaches the same result by clearing the
+            # state its loop tests before cancelling.
             radio._civ_transport = None
             pump = radio._civ_rx_task
             if pump is not None:


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1977, unit A.
- Compatibility impact: **behavioural, one line.** A blocking CI-V write no longer completes from a stale orphan refusal. No API, CLI, config or wire-format change.

A CI-V refusal names no command. `core/civ.py: CivRequestTracker.register_ack` consumes the orphan ACK/NAK backlog by default, and `runtime/_civ_rx.py: CivRuntime._execute_civ_raw`'s blocking branch was the only call site in `src/` that left that default in place.

**It cannot ever be right there.** That branch registers its ACK waiter *before* it sends — registration and `send_tracked` are consecutive statements in one linear function with no branch between them — so anything sitting in the backlog at registration time is necessarily some other command's frame: this one has not reached the wire yet. The claim was never a race the default protected against. It was always a misattribution.

The harm is worse than "reports the wrong failure". `CivRequestTracker._pop_matching_ack_backlog` with `nak_only=False` pops the oldest entry whatever it is, so the claim can settle the write from a stranger's **ACK** — reporting success for a write the radio never answered.

## The fix

`consume_backlog=False`. The other three `register_ack` sites in `src/` already did the equivalent:

| site | form |
|---|---|
| `CivRuntime.execute_civ_transaction`, `expect="ack"` | `consume_backlog=False`, after `drop_ack_backlog()` |
| `CivRuntime._register_civ_data_transaction` | `consume_backlog=False, nak_only=True` |
| `CivRuntime._execute_civ_raw`, fire-and-forget branch | `wait=False` — sink token, never consumes |
| **`CivRuntime._execute_civ_raw`, blocking branch** | **was the default `True` — this change** |

With this one changed, **no waiter in `src/` claims the backlog at all.** Verified by enumeration, not by example: those four are every `register_ack` call site in `src/`, independently re-enumerated across three review rounds.

The backlog survives as a bounded, TTL-pruned parking area for observability. An entry is retired unclaimed by whichever comes first of: the TTL prune inside `register_ack`/`resolve`, eviction once the bounded deque is full, the `drop_ack_backlog` that opens the next *response-capable* raw transaction (`expect="none"` returns before that call), or `fail_all` on a generation advance or pump stop. All of those except `fail_all` increment `ack_backlog_drops`; `ack_orphans` always counts arrival. `ack_backlog_hits` can no longer move from `src/` at all.

## This closes what MOR-1980 displaced, and corrects the prose that described it

#2791 contained the managed-TX mis-attribution by leaving the refusal an orphan, and said plainly in two docstrings that this **displaced** the mis-charge rather than ending it — the orphan stayed "claimable" by the next consuming `register_ack`, which was this exact call site. Its commit message named the follow-up: *"the mis-charge is displaced, not eliminated, and closing it is MOR-1977 unit A."*

Nothing claims it now, so those sentences became false with this change and are corrected here — in `CivRuntime.request_authoritative_ptt_read`, `CivRuntime.execute_civ_transaction`, and (found by review, one level down at the root) the comment in `CivRequestTracker.resolve` that justified the backlog's existence as *"Keep short-lived orphan ACKs so strict waiters can consume them."*

Being claimable by an unrelated command was the defect, not a benefit. That was the open question #2791 left, and this is the answer to it.

## Test

`tests/test_radio.py::TestAckSinkRobustness::test_blocking_write_ignores_an_orphaned_nak` places an orphan NAK in the backlog, queues an ACK for the write, and requires the write to return the ACK. On the parent commit it returns `0xFA` — the failure is the assertion (`assert 250 == 251`) in 0.64 s, not a timeout. Review confirmed it is not circular, and re-derived it from scratch by restoring the pre-fix default through a wrapper with no file edited: the write returns `0xFA` before and `0xFB` after. The test discriminates.

## A second defect, found by this test, reported and NOT fixed here

The pin retires the RX pump by clearing the transport rather than by cancelling it, because **cancelling it does not behave the same on every interpreter this project supports**.

`core/transport.py: IcomTransport.receive_packet` is a bare `asyncio.wait_for` over the packet queue. On **CPython 3.11 only**, and only when a packet is already available at the instant the cancellation lands, `wait_for` returns it and drops the `CancelledError` — 3.11's implementation contains `except CancelledError: if fut.done(): return fut.result()`, while 3.12+ is built on `asyncio.timeouts` and has no such swallow. Measured on each interpreter `full.yml` runs:

| | packet queued at cancel | queue empty at cancel |
|---|---|---|
| 3.11.15 | cancel **dropped**, task runs on, `cancelling() == 1` | cancel observed |
| 3.12.3 | cancel observed | cancel observed |
| 3.13.12 | cancel observed | cancel observed |

Where the cancel is dropped, `CivRuntime._civ_rx_loop` never observes it and **anything awaiting the task hangs — `CivRuntime.stop_pump` included**, since it cancels and then awaits with no exit condition set first. That is the disconnect path. Independently reproduced by review against the real `IcomRadio`: with the queue empty `stop_pump()` returns in 0.000 s; with one packet injected at the cancel instant it hangs.

The tree already recorded this stdlib split correctly, with the qualifier, in `runtime/_control_phase.py: ControlPhaseSessionMechanism._shutdown_supervised_tx`, for an analogous 3.11-only teardown hang. `audio/lan_stream.py: AudioStream.stop_rx` has the same await shape and avoids the hazard by clearing the state its loop tests before cancelling.

> **Two earlier revisions of this PR gave wrong mechanisms for this**, and both were caught by review. The first said the cancellation "surfaces as `TimeoutError`" and is swallowed by the loop's timeout branch — refuted by an instrument that records returns as well as raises; the original probe logged only exceptions and was blind to the returned-packet case. The second gave the right mechanism but stated it unconditionally, when it is 3.11-only and additionally requires a packet to be available. Both corrections matter because they move the defect: it is in product transport code on one interpreter, not in the loop, and not on every version.

Clearing `_civ_transport` ends the loop at its own `while` within one receive timeout, with no cancellation involved, and is deterministic on all three interpreters.

**Deliberately not fixed in this PR.** Different function, different failure mode, and it needs its own tests — the same treatment the `rigctld` sender and the RX-path import got in #2793.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10623 passed, 0 failed**, 12 skipped / 47 xfailed / 1 xpassed. `main` at `d55cbfb2` gives 10622 with an identical skip set, so the delta is exactly the one test added here. `ruff check` and `ruff format --check` clean (689 files); `lint-imports` 5 kept / 0 broken; doc-citation gate clean (847); `mypy --strict src/rigplane/web` clean. Every number independently reproduced by the reviewer at the final head.
- [x] Public/open-core boundary checked — no telemetry, no Pro content.
- [x] Release or migration impact documented if applicable — none.

An intermediate run reported 10561 passed / 74 skipped. That was this container losing its optional extras during an environment rollback, not a code effect: every additional skip named a missing extra (`aiortc`, `libopus`, Pillow, frontend build). After `uv sync --all-extras` the count returned to 10623 / 12.

## Guardrails

**5 files, 117 changed lines.** Inside the soft threshold (6 files / 600 lines) and far from the hard ceiling. Two files beyond the original three are `tests/_order_sensitive_radios.py` and `tests/contracts/test_audio_lifecycle_conformance.py`, touched only to complete a class sweep of a dead symbol name (below) rather than patch the single instance this PR introduced.

## Notes

- `CivRequestTracker.register_ack`'s `consume_backlog=True` default is now unreached from `src/`, and `ack_backlog_hits` is structurally unable to move in production, while `runtime/radio.py: CoreRadio.civ_stats` still lists it as a monitoring key. Whether the backlog should exist at all is a follow-up.
- Two of the three non-consuming sites are inert and unpinned: `execute_civ_transaction` drops the whole backlog before registering, so flipping its `consume_backlog` back to `True` fails no test. Flipping the site this PR changed fails exactly one — the new one.
- `tests/integration/test_reliability_matrix_integration.py` asserts `delta ack_backlog_drops == 0` at two points. Orphans that previously vanished into a consuming `register_ack` will now show as drops — the desired direction, but expect these to start firing on a bench session that produces orphans. Not run by the standard suite.
- **Follow-up raised by review:** `docs/internals/raw-civ-transactions.md` attributes the orphan-backlog drop to `expect="ack"` only, but `execute_civ_transaction` drops before branching, so `expect="data"` drops it too. Pre-existing; the code prose here is now the accurate one and the doc under-describes it.
- Remaining MOR-1977 work is unaffected: this unit is about attribution, not about how long a sweep waits.

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` agent, relayed by the coordinating session (the reviewing environment has no GitHub access)
- **Three rounds. Result: PASS at `6455f256`.** Every blocking finding in all three was prose; **none was a defect in the executable change.** The review accepted the core claim, re-enumerated the call sites, re-derived the pin non-circularly, ran the cross-version probe itself, and ran every gate at the final head.
  - **Round 1, `3434fcaf` — BLOCKED.** The second defect's mechanism was false; `CivRequestTracker.resolve` still carried the comment justifying the backlog as claimable (swept at two consequence sites, missed at its root); and "ages out under `ack_backlog_ttl`, counted by `ack_backlog_drops`" over-claimed three ways.
  - **Round 2, `c131f45d` — BLOCKED.** The replacement mechanism was true but stated unconditionally, and is CPython 3.11-only; it also over-claimed on 3.11 itself, where an empty queue at cancel time — the state this test is actually in — propagates normally. And it cited `LanAudioStream`, a class that does not exist.
  - **Round 3, `6455f256` — PASS.**
- Each finding was re-checked against the code by this session before being accepted, including running the cross-version probe on all three interpreters, rather than taken on trust.
- Both fix commits are prose-only, confirmed by AST comparison with docstrings stripped across every changed file.

**The recurring failure is worth recording, because it is the same one three times.** Each round's fix introduced the next round's finding, because the instance the reviewer named was corrected without sweeping the class it belonged to — and in round 2 the tree already documented the fact correctly elsewhere, unlooked-for. The round-3 fix swept the dead class name across all five occurrences instead of the one under review; four were pre-existing, in two files that were not otherwise part of this change, and one of those files was importing `AudioStream` correctly a few lines below its own docstring saying `LanAudioStream`.