### PR TITLE
fix(MOR-1986): forward command29 from the cmd_map branch instead of hardcoding it

### DIFF
--- a/src/rigplane/commands/dsp.py
+++ b/src/rigplane/commands/dsp.py
@@ -59,7 +59,7 @@ def get_attenuator(
             to_addr=to_addr,
             from_addr=from_addr,
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(to_addr, from_addr, _CMD_ATT, receiver=receiver)
@@ -84,7 +84,7 @@ def set_attenuator_level(
             from_addr=from_addr,
             data=bytes([_bcd_byte(db)]),
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(
@@ -129,7 +129,7 @@ def get_preamp(
             to_addr=to_addr,
             from_addr=from_addr,
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(
@@ -156,7 +156,7 @@ def set_preamp(
             from_addr=from_addr,
             data=bytes([_bcd_byte(level)]),
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(
@@ -192,7 +192,7 @@ def get_digisel(
             to_addr=to_addr,
             from_addr=from_addr,
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(
@@ -223,7 +223,7 @@ def set_digisel(
             from_addr=from_addr,
             data=bytes([_bcd_byte(1 if on else 0)]),
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(
@@ -411,7 +411,7 @@ def get_af_mute(
             to_addr=to_addr,
             from_addr=from_addr,
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(
@@ -438,7 +438,7 @@ def set_af_mute(
             from_addr=from_addr,
             data=b"\x01" if on else b"\x00",
             receiver=receiver,
-            command29=True,
+            command29=command29,
         )
     if command29:
         return build_cmd29_frame(

--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -14,11 +14,6 @@ IC-705	config.py:set_data1_mod_input	source=0	map=fefea4e01a050119009200fd fallb
 IC-705	config.py:set_data_off_mod_input	source=0	map=fefea4e01a050118009100fd fallback=fefea4e01a05009100fd
 IC-705	config.py:set_lan_mod_level	level=0	map=fefea4e01a0501170000fd fallback=fefea4e014110000fd
 IC-705	config.py:set_usb_mod_level	level=0	map=fefea4e01a0501160000fd fallback=fefea4e014100000fd
-IC-705	dsp.py:get_attenuator	command29=False	map=fefea4e0290011fd fallback=fefea4e011fd
-IC-705	dsp.py:get_preamp	command29=False	map=fefea4e029001602fd fallback=fefea4e01602fd
-IC-705	dsp.py:set_attenuator	command29=False, on=False	map=fefea4e029001100fd fallback=fefea4e01100fd
-IC-705	dsp.py:set_attenuator_level	command29=False, db=0	map=fefea4e029001100fd fallback=fefea4e01100fd
-IC-705	dsp.py:set_preamp	command29=False	map=fefea4e02900160201fd fallback=fefea4e0160201fd
 IC-705	levels.py:get_dash_ratio	(no arguments)	map=fefea4e01a050252fd fallback=fefea4e01a050228fd
 IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=fefea4e01a050070fd
 IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a050252022830fd fallback=fefea4e01a05022830fd
@@ -46,11 +41,6 @@ IC-7300	config.py:set_civ_transceive	enabled=False	map=fefe94e01a050071012900fd 
 IC-7300	config.py:set_data1_mod_input	source=0	map=fefe94e01a050067009200fd fallback=fefe94e01a05009200fd
 IC-7300	config.py:set_data_off_mod_input	source=0	map=fefe94e01a050066009100fd fallback=fefe94e01a05009100fd
 IC-7300	config.py:set_usb_mod_level	level=0	map=fefe94e01a0500650000fd fallback=fefe94e014100000fd
-IC-7300	dsp.py:get_attenuator	command29=False	map=fefe94e0290011fd fallback=fefe94e011fd
-IC-7300	dsp.py:get_preamp	command29=False	map=fefe94e029001602fd fallback=fefe94e01602fd
-IC-7300	dsp.py:set_attenuator	command29=False, on=False	map=fefe94e029001100fd fallback=fefe94e01100fd
-IC-7300	dsp.py:set_attenuator_level	command29=False, db=0	map=fefe94e029001100fd fallback=fefe94e01100fd
-IC-7300	dsp.py:set_preamp	command29=False	map=fefe94e02900160201fd fallback=fefe94e0160201fd
 IC-7300	levels.py:get_nb_depth	(no arguments)	map=fefe94e01a050189fd fallback=fefe94e01a050290fd
 IC-7300	levels.py:get_nb_width	(no arguments)	map=fefe94e01a050190fd fallback=fefe94e01a050291fd
 IC-7300	levels.py:get_vox_delay	(no arguments)	map=fefe94e01a050191fd fallback=fefe94e01a050292fd
@@ -83,15 +73,6 @@ IC-7610	config.py:set_data3_mod_input	source=0	map=fefe98e01a050094009400fd fall
 IC-7610	config.py:set_data_off_mod_input	source=0	map=fefe98e01a050091009100fd fallback=fefe98e01a05009100fd
 IC-7610	config.py:set_lan_mod_level	level=0	map=fefe98e01a0500900000fd fallback=fefe98e014110000fd
 IC-7610	config.py:set_usb_mod_level	level=0	map=fefe98e01a0500890000fd fallback=fefe98e014100000fd
-IC-7610	dsp.py:get_af_mute	command29=False	map=fefe98e029001a09fd fallback=fefe98e01a09fd
-IC-7610	dsp.py:get_attenuator	command29=False	map=fefe98e0290011fd fallback=fefe98e011fd
-IC-7610	dsp.py:get_digisel	command29=False	map=fefe98e02900164efd fallback=fefe98e0164efd
-IC-7610	dsp.py:get_preamp	command29=False	map=fefe98e029001602fd fallback=fefe98e01602fd
-IC-7610	dsp.py:set_af_mute	command29=False, on=False	map=fefe98e029001a0900fd fallback=fefe98e01a0900fd
-IC-7610	dsp.py:set_attenuator	command29=False, on=False	map=fefe98e029001100fd fallback=fefe98e01100fd
-IC-7610	dsp.py:set_attenuator_level	command29=False, db=0	map=fefe98e029001100fd fallback=fefe98e01100fd
-IC-7610	dsp.py:set_digisel	command29=False, on=False	map=fefe98e02900164e00fd fallback=fefe98e0164e00fd
-IC-7610	dsp.py:set_preamp	command29=False	map=fefe98e02900160201fd fallback=fefe98e0160201fd
 IC-7610	levels.py:set_dash_ratio	value=30	map=fefe98e01a050228022830fd fallback=fefe98e01a05022830fd
 IC-7610	levels.py:set_nb_depth	value=0	map=fefe98e01a050290029000fd fallback=fefe98e01a05029000fd
 IC-7610	levels.py:set_nb_width	value=0	map=fefe98e01a05029102910000fd fallback=fefe98e01a0502910000fd
@@ -124,11 +105,6 @@ IC-9700	config.py:set_civ_transceive	enabled=False	map=fefea2e01a050071012900fd 
 IC-9700	config.py:set_data1_mod_input	source=0	map=fefea2e01a050067009200fd fallback=fefea2e01a05009200fd
 IC-9700	config.py:set_data_off_mod_input	source=0	map=fefea2e01a050066009100fd fallback=fefea2e01a05009100fd
 IC-9700	config.py:set_usb_mod_level	level=0	map=fefea2e01a0500650000fd fallback=fefea2e014100000fd
-IC-9700	dsp.py:get_attenuator	command29=False	map=fefea2e0290011fd fallback=fefea2e011fd
-IC-9700	dsp.py:get_preamp	command29=False	map=fefea2e029001602fd fallback=fefea2e01602fd
-IC-9700	dsp.py:set_attenuator	command29=False, on=False	map=fefea2e029001100fd fallback=fefea2e01100fd
-IC-9700	dsp.py:set_attenuator_level	command29=False, db=0	map=fefea2e029001100fd fallback=fefea2e01100fd
-IC-9700	dsp.py:set_preamp	command29=False	map=fefea2e02900160201fd fallback=fefea2e0160201fd
 IC-9700	levels.py:get_nb_depth	(no arguments)	map=fefea2e01a050189fd fallback=fefea2e01a050290fd
 IC-9700	levels.py:get_nb_width	(no arguments)	map=fefea2e01a050190fd fallback=fefea2e01a050291fd
 IC-9700	levels.py:get_vox_delay	(no arguments)	map=fefea2e01a050191fd fallback=fefea2e01a050292fd
@@ -151,8 +127,3 @@ IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a0500300033fd fallbac
 IC-9700	vfo.py:set_quick_split	(no arguments)	map=fefea2e01a0500300033fd fallback=fefea2e01a050033fd
 X6100	ptt.py:ptt_off	(no arguments)	map=fefe70e01c000000fd fallback=fefe70e01c0000fd
 X6100	ptt.py:ptt_on	(no arguments)	map=fefe70e01c000101fd fallback=fefe70e01c0001fd
-X6200	dsp.py:get_attenuator	command29=False	map=fefea4e0290011fd fallback=fefea4e011fd
-X6200	dsp.py:get_preamp	command29=False	map=fefea4e029001602fd fallback=fefea4e01602fd
-X6200	dsp.py:set_attenuator	command29=False, on=False	map=fefea4e029001100fd fallback=fefea4e01100fd
-X6200	dsp.py:set_attenuator_level	command29=False, db=0	map=fefea4e029001100fd fallback=fefea4e01100fd
-X6200	dsp.py:set_preamp	command29=False	map=fefea4e02900160201fd fallback=fefea4e0160201fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -22,8 +22,8 @@
 census	builders_compared	230
 census	cat_only_profiles	2
 census	dual_implementation_sites	139
-census	frames_diverged	152
-census	frames_identical	1273
+census	frames_diverged	123
+census	frames_identical	1302
 census	profile_builder_map_gaps	1006
 census	profiles	8
 census	public_builders	232

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -7,10 +7,11 @@ follows its wire bytes.
 
 Parity here is a property of these builders at these arguments, not of the
 package. For IC-7610 alone, tests/command_map_parity_divergences.txt
-records builders whose two frames differ — get_attenuator, get_preamp,
-get_af_mute and get_digisel are asserted equal below and listed there,
-because this file calls them at the default command29=True while the
-divergence needs command29=False.
+records builders whose two frames differ; a builder asserted equal below
+can still be listed there at arguments this file does not use. No dsp.py
+builder is listed as of MOR-1986 — get_attenuator, get_preamp, get_af_mute
+and get_digisel were, at command29=False only, until the cmd_map branch was
+made to forward that argument.
 
 tests/test_command_map_parity.py generalises the parity cases below: every
 builder it can reach, every profile in rigs/, and one probe per optional
@@ -217,8 +218,16 @@ class TestHelperCallerParity:
 class TestCmd29Parity:
     """These cmd29-framing functions must match with cmd_map at command29's default.
 
-    Four of them -- ``get_attenuator``, ``get_preamp``, ``get_digisel`` and
-    ``get_af_mute`` -- match only at that default; see the module docstring.
+    ``get_attenuator``, ``get_preamp``, ``get_digisel`` and ``get_af_mute``
+    used to match only at that default, because the cmd_map branch passed a
+    hardcoded ``command29=True`` while the fallback honoured the argument.
+    MOR-1986 made the branch forward it, so they now match at
+    ``command29=False`` too. The ``_without_cmd29`` tests below name that
+    property at the point of use; they are not its only guard.
+    ``test_command_map_parity.py`` probes every optional argument at a
+    non-default value, so it reaches ``command29=False`` on every profile --
+    regressing this fails those four tests and both of that file's baseline
+    tests, six in all.
     """
 
     def test_get_attenuator(self, cmd_map):
@@ -232,6 +241,26 @@ class TestCmd29Parity:
 
     def test_get_af_mute(self, cmd_map):
         assert commands.get_af_mute(cmd_map=cmd_map) == commands.get_af_mute()
+
+    def test_get_attenuator_without_cmd29(self, cmd_map):
+        assert commands.get_attenuator(
+            cmd_map=cmd_map, command29=False
+        ) == commands.get_attenuator(command29=False)
+
+    def test_get_preamp_without_cmd29(self, cmd_map):
+        assert commands.get_preamp(
+            cmd_map=cmd_map, command29=False
+        ) == commands.get_preamp(command29=False)
+
+    def test_get_digisel_without_cmd29(self, cmd_map):
+        assert commands.get_digisel(
+            cmd_map=cmd_map, command29=False
+        ) == commands.get_digisel(command29=False)
+
+    def test_get_af_mute_without_cmd29(self, cmd_map):
+        assert commands.get_af_mute(
+            cmd_map=cmd_map, command29=False
+        ) == commands.get_af_mute(command29=False)
 
     def test_get_audio_peak_filter(self, cmd_map):
         assert (

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -3,8 +3,10 @@
 Builders in ``src/rigplane/commands/`` that carry both a ``cmd_map`` branch
 and a hardcoded fallback hold the same CI-V knowledge twice, and only a
 hand-written subset compared the two: ``test_command_map_integration.py``
-calls a fixed list of builders against the IC-7610 map, each at one
-argument set with every optional argument left at its default, and
+calls a fixed list of builders against the IC-7610 map, almost all at a
+single argument set with their optional arguments left at the default --
+its ``TestCmd29Parity`` also probes four of them at ``command29=False`` --
+and
 ``test_commands.py: test_speech_cmd_map_prefers_set_speech_key`` and
 ``test_rig_ic7300.py: test_get_speech_cmd_map_uses_set_speech`` each pin
 ``get_speech`` alone. Outside that subset the two copies could disagree


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1986. **Unit 1 of 3** in the mechanical repair of the profile command-map branch (owner decision: single source of truth, no hardcode).
- Compatibility impact: **none on the wire today.** See *Why this is safe* below.

Eight builders in `commands/dsp.py` accept `command29: bool = True` and then pass a **literal** `command29=True` into `_build_from_map`, discarding what the caller asked for. Their fallback branch honours the argument:

```python
def get_attenuator(..., *, command29: bool = True) -> bytes:
    if cmd_map is not None:
        return _build_from_map(..., command29=True)      # ignores the argument
    if command29:
        return build_cmd29_frame(...)
    return build_civ_frame(...)
```

So the two branches disagree for every caller that passes `command29=False`: for example the map branch emits `29 00 11` where `11` was requested.

`commands/_frame.py: _build_from_map` is not at fault — it forwards its own `command29` parameter correctly. The defect is entirely at the call sites, and the fix is eight one-token edits.

## Scope derived, not guessed

By AST over `commands/*.py`: **26 builders both accept `command29` and call `_build_from_map`. Eighteen forward it; eight pass the literal**, and all eight are in `dsp.py`:

| | |
|---|---|
| `get_attenuator` | `set_attenuator_level` |
| `get_preamp` | `set_preamp` |
| `get_digisel` | `set_digisel` |
| `get_af_mute` | `set_af_mute` |

At the head, all 26 forward and none passes a literal.

Note there is **no `get_attenuator_level` builder** — the getter is `get_attenuator`. `get_attenuator_level` is a Radio-protocol method, declared in `core/radio_protocol.py` and implemented in `runtime/radio.py`, `runtime/sync.py` and two backends. An earlier revision of this PR's commit message named it among the builders, which was wrong and is corrected.

`dsp.py: set_attenuator` is a ninth name in the divergence baseline and needs **no edit** — it is a wrapper that already forwards `command29` to `set_attenuator_level`. No other module in `commands/` has this shape.

## Why this is safe

**No caller outside `commands/` passes a `cmd_map` to any builder in production.** Verified exhaustively by review: all 243 `cmd_map`-taking builders enumerated, every call in `src/rigplane/` AST-scanned for a `cmd_map` keyword *or* a positional argument reaching that parameter's index — zero hits. The map branch is unreachable in production; the hardcoded fallback is what ships.

This unit makes the map branch correct so that wiring the profile command map into the send path later is safe. It does not perform that wiring, and it changes no frame any radio currently receives.

The latent hazard it removes is real, though: `tests/test_single_rx_plain_routing.py` (MOR-178) states that single-RX radios answer the plain command and must not see a `0x29` wrapper, so the hardcoded `True` was a write hazard for X6200-class rigs waiting on the switch, not merely cosmetic.

## The baselines are what prove the scope

`tests/test_command_map_parity.py` (from #2792) builds every builder twice with identical arguments — once with the profile's `CommandMap`, once without — and requires byte-identical frames, with known disagreements in a shrink-only allowlist. It failed immediately on this change, naming 29 now-stale rows: the mechanism working, not a regression.

Regenerating with `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1`:

- **29 rows removed, 0 added.** Shrink-only demonstrated, not asserted.
- Census: `frames_diverged` 152 → **123**, `frames_identical` 1273 → **1302**. Same 1425 pairs; 29 now agree.
- Removed rows span exactly `dsp.py`, five profiles (IC-705, IC-7300, IC-7610, IC-9700, X6200), and nine builder names.

Review reproduced this from the other direction: reverting `dsp.py` in a scratch tree and regenerating yields a file **byte-identical to the parent's**, so the baseline delta is exactly and only the consequence of the eight edits.

That closes the whole "map emits the cmd29 wrapper although `command29=False`" divergence class.

## What the reviews forced, and why it mattered

Both blocking rounds were prose, and both were the same failure — the named instance patched, its class not swept:

- **Round 1** — removing the 29 rows falsified two docstrings in `tests/test_command_map_integration.py`, a file this change did not touch: its module docstring claimed the divergence file lists four `dsp.py` getters (it now lists none), and `TestCmd29Parity` claimed those four "match only at that default". The second was a guarantee stated wider than the code with **nothing failing when it stopped being true**. Fixed by adding four `_without_cmd29` tests that pin the newly-won parity at the point of use, rather than by rewording.
- **Round 2** — the round-1 fix then claimed "nothing else fails if that regresses" / "fails exactly those four". False: it is **six**. And the four *added* tests falsified the reciprocal sentence in `test_command_map_parity.py`'s module docstring ("each at one argument set with every optional argument left at its default") — round 1's finding in mirror, the same pair of files swept one way only.

The corrected figure is now established at whole-suite scope by review, which is stronger than this PR measured: reverting the eight edits gives `6 failed, 10621 passed` across the entire standard suite, with no seventh failure anywhere. The six are the four added tests plus `test_every_divergence_is_allowlisted` and `test_uncovered_inventory_matches` — the general sweep probes every optional argument at a non-default value, so it reaches `command29=False` on every profile, which is how the 29 rows arose in the first place.

## Where this sits in the larger job

The parity pin recorded 152 divergences. Classified by wire form they split into two very different groups:

| rows | shape | whose bug |
|---:|---|---|
| 29 | map emits the cmd29 wrapper although `command29=False` | map branch — **this PR** |
| 19 | map doubles the sub-command prefix | map branch — unit 2 |
| 36 | map drops the receiver selector byte | map branch — unit 3 |
| 68 | map and fallback name genuinely **different commands** | needs adjudication per command |

The first three are mechanical, contained, and carry no wire risk while the map branch stays unreachable. The remaining 68 are real disagreements — since the fallback is what ships today, if the profile is right in those cases they are live wrong commands — and each needs evidence (Icom documentation or bench) rather than a code judgement. Deliberately not touched here.

**A second front, raised by review and worth recording:** `web/radio_poller.py: RadioPoller._load_command_map` and `_send_cmd` are an independent second implementation of "profile map to wire", with their own cmd29 decision via `_profile.supports_cmd29` rather than `_build_from_map`. The parity pin does not reach it. That needs its own coverage before the single-source-of-truth switch.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10627 passed, 0 failed**, 12 skipped / 47 xfailed / 1 xpassed. `main` at `0c666d10` gives 10623 with an identical skip set, so the delta is exactly the four tests added here. `ruff check` and `ruff format --check` clean (689 files); `lint-imports` 5 kept / 0 broken; doc-citation gate clean (847); `mypy --strict src/rigplane/web` clean. Regenerating both baselines after the change leaves them byte-identical. Every number independently reproduced by the reviewer at the final head.
- [x] Public/open-core boundary checked — no telemetry, no Pro content.
- [x] Release or migration impact documented if applicable — none.

## Guardrails

**5 files, 96 changed lines.** Inside the soft threshold; two of the five are generated baselines and two are the sibling test files the class sweep required.

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` agent, relayed by the coordinating session (the reviewing environment has no GitHub access)
- **Three rounds. Result: PASS at `8b0c72cf`.** Both blocking rounds were prose; **neither was a defect in the code or the baselines.** The review enumerated the scope by AST at both revisions, proved the baseline edit is a pure shrink and byte-identical when reverted, verified no production path reaches the map branch (keyword *and* positional), and ran every gate.
- One non-blocking imprecision is knowingly left in place: `TestCmd29Parity` says "both of that file's baseline tests" where that file has four baseline-reading tests of which two fail on regression. It understates the guards rather than over-promising, and correcting four characters would discard the PASS for a fourth round. Folded into unit 2, which touches these same two files.