### PR TITLE
fix(MOR-1986): stop the cmd_map branch sending the sub-address twice

### DIFF
--- a/src/rigplane/commands/_builders.py
+++ b/src/rigplane/commands/_builders.py
@@ -124,17 +124,22 @@ def _build_ctl_mem_set(
     cmd_map: CommandMap | None = None,
     cmd_name: str | None = None,
 ) -> bytes:
-    data = prefix + bcd_encode_value(value, byte_count=byte_count)
+    encoded = bcd_encode_value(value, byte_count=byte_count)
     if cmd_map is not None and cmd_name is not None:
+        # When using cmd_map, wire bytes already include the full command
+        # structure including any data prefix, so pass only the encoded value
+        # -- the same rule ``_build_ctl_mem_get`` above applies by passing
+        # ``data=None``. Passing ``prefix`` here too sends the sub-address
+        # twice.
         return _build_from_map(
-            cmd_map, cmd_name, to_addr=to_addr, from_addr=from_addr, data=data
+            cmd_map, cmd_name, to_addr=to_addr, from_addr=from_addr, data=encoded
         )
     return build_civ_frame(
         to_addr,
         from_addr,
         _CMD_CTL_MEM,
         sub=_SUB_CTL_MEM,
-        data=data,
+        data=prefix + encoded,
     )
 
 

--- a/src/rigplane/commands/vfo.py
+++ b/src/rigplane/commands/vfo.py
@@ -361,7 +361,7 @@ def quick_dual_watch(
             "quick_dual_watch",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=_CTL_MEM_QUICK_DUAL_WATCH,
+            data=None,
         )
     return build_civ_frame(
         to_addr,
@@ -384,7 +384,7 @@ def quick_split(
             "quick_split",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=_CTL_MEM_QUICK_SPLIT,
+            data=None,
         )
     return build_civ_frame(
         to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_CTL_MEM, data=_CTL_MEM_QUICK_SPLIT
@@ -404,7 +404,7 @@ def get_quick_split(
             "get_quick_split",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=_CTL_MEM_QUICK_SPLIT,
+            data=None,
         )
     return build_civ_frame(
         to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_CTL_MEM, data=_CTL_MEM_QUICK_SPLIT
@@ -421,7 +421,7 @@ def set_quick_split(
             "set_quick_split",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=_CTL_MEM_QUICK_SPLIT,
+            data=None,
         )
     return build_civ_frame(
         to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_CTL_MEM, data=_CTL_MEM_QUICK_SPLIT
@@ -438,7 +438,7 @@ def get_quick_dual_watch(
             "get_quick_dual_watch",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=_CTL_MEM_QUICK_DUAL_WATCH,
+            data=None,
         )
     return build_civ_frame(
         to_addr,
@@ -459,7 +459,7 @@ def set_quick_dual_watch(
             "set_quick_dual_watch",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=_CTL_MEM_QUICK_DUAL_WATCH,
+            data=None,
         )
     return build_civ_frame(
         to_addr,

--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -9,15 +9,15 @@ IC-705	config.py:get_data1_mod_input	(no arguments)	map=fefea4e01a050119fd fallb
 IC-705	config.py:get_data_off_mod_input	(no arguments)	map=fefea4e01a050118fd fallback=fefea4e01a050091fd
 IC-705	config.py:get_lan_mod_level	(no arguments)	map=fefea4e01a050117fd fallback=fefea4e01411fd
 IC-705	config.py:get_usb_mod_level	(no arguments)	map=fefea4e01a050116fd fallback=fefea4e01410fd
-IC-705	config.py:set_civ_transceive	enabled=False	map=fefea4e01a050112012900fd fallback=fefea4e01a05012900fd
-IC-705	config.py:set_data1_mod_input	source=0	map=fefea4e01a050119009200fd fallback=fefea4e01a05009200fd
-IC-705	config.py:set_data_off_mod_input	source=0	map=fefea4e01a050118009100fd fallback=fefea4e01a05009100fd
+IC-705	config.py:set_civ_transceive	enabled=False	map=fefea4e01a05011200fd fallback=fefea4e01a05012900fd
+IC-705	config.py:set_data1_mod_input	source=0	map=fefea4e01a05011900fd fallback=fefea4e01a05009200fd
+IC-705	config.py:set_data_off_mod_input	source=0	map=fefea4e01a05011800fd fallback=fefea4e01a05009100fd
 IC-705	config.py:set_lan_mod_level	level=0	map=fefea4e01a0501170000fd fallback=fefea4e014110000fd
 IC-705	config.py:set_usb_mod_level	level=0	map=fefea4e01a0501160000fd fallback=fefea4e014100000fd
 IC-705	levels.py:get_dash_ratio	(no arguments)	map=fefea4e01a050252fd fallback=fefea4e01a050228fd
 IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=fefea4e01a050070fd
-IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a050252022830fd fallback=fefea4e01a05022830fd
-IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a05008900700000fd fallback=fefea4e01a0500700000fd
+IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a05025230fd fallback=fefea4e01a05022830fd
+IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a0500890000fd fallback=fefea4e01a0500700000fd
 IC-705	scope.py:get_scope_center_type	receiver=0	map=fefea4e0271cfd fallback=fefea4e0271c00fd
 IC-705	scope.py:get_scope_edge	receiver=0	map=fefea4e02716fd fallback=fefea4e0271600fd
 IC-705	scope.py:get_scope_hold	receiver=0	map=fefea4e02717fd fallback=fefea4e0271700fd
@@ -27,8 +27,8 @@ IC-705	scope.py:get_scope_ref	receiver=0	map=fefea4e02719fd fallback=fefea4e0271
 IC-705	scope.py:get_scope_span	receiver=0	map=fefea4e02715fd fallback=fefea4e0271500fd
 IC-705	scope.py:get_scope_speed	receiver=0	map=fefea4e0271afd fallback=fefea4e0271a00fd
 IC-705	scope.py:get_scope_vbw	receiver=0	map=fefea4e0271dfd fallback=fefea4e0271d00fd
-IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a0500450033fd fallback=fefea4e01a050033fd
-IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a0500450033fd fallback=fefea4e01a050033fd
+IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
+IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-7300	config.py:get_acc1_mod_level	(no arguments)	map=fefe94e01a050064fd fallback=fefe94e0140bfd
 IC-7300	config.py:get_civ_output_ant	(no arguments)	map=fefe94e01a050061fd fallback=fefe94e01a050130fd
 IC-7300	config.py:get_civ_transceive	(no arguments)	map=fefe94e01a050071fd fallback=fefe94e01a050129fd
@@ -36,18 +36,17 @@ IC-7300	config.py:get_data1_mod_input	(no arguments)	map=fefe94e01a050067fd fall
 IC-7300	config.py:get_data_off_mod_input	(no arguments)	map=fefe94e01a050066fd fallback=fefe94e01a050091fd
 IC-7300	config.py:get_usb_mod_level	(no arguments)	map=fefe94e01a050065fd fallback=fefe94e01410fd
 IC-7300	config.py:set_acc1_mod_level	level=0	map=fefe94e01a0500640000fd fallback=fefe94e0140b0000fd
-IC-7300	config.py:set_civ_output_ant	enabled=False	map=fefe94e01a050061013000fd fallback=fefe94e01a05013000fd
-IC-7300	config.py:set_civ_transceive	enabled=False	map=fefe94e01a050071012900fd fallback=fefe94e01a05012900fd
-IC-7300	config.py:set_data1_mod_input	source=0	map=fefe94e01a050067009200fd fallback=fefe94e01a05009200fd
-IC-7300	config.py:set_data_off_mod_input	source=0	map=fefe94e01a050066009100fd fallback=fefe94e01a05009100fd
+IC-7300	config.py:set_civ_output_ant	enabled=False	map=fefe94e01a05006100fd fallback=fefe94e01a05013000fd
+IC-7300	config.py:set_civ_transceive	enabled=False	map=fefe94e01a05007100fd fallback=fefe94e01a05012900fd
+IC-7300	config.py:set_data1_mod_input	source=0	map=fefe94e01a05006700fd fallback=fefe94e01a05009200fd
+IC-7300	config.py:set_data_off_mod_input	source=0	map=fefe94e01a05006600fd fallback=fefe94e01a05009100fd
 IC-7300	config.py:set_usb_mod_level	level=0	map=fefe94e01a0500650000fd fallback=fefe94e014100000fd
 IC-7300	levels.py:get_nb_depth	(no arguments)	map=fefe94e01a050189fd fallback=fefe94e01a050290fd
 IC-7300	levels.py:get_nb_width	(no arguments)	map=fefe94e01a050190fd fallback=fefe94e01a050291fd
 IC-7300	levels.py:get_vox_delay	(no arguments)	map=fefe94e01a050191fd fallback=fefe94e01a050292fd
-IC-7300	levels.py:set_nb_depth	value=0	map=fefe94e01a050189029000fd fallback=fefe94e01a05029000fd
-IC-7300	levels.py:set_nb_width	value=0	map=fefe94e01a05019002910000fd fallback=fefe94e01a0502910000fd
-IC-7300	levels.py:set_ref_adjust	value=0	map=fefe94e01a05007000700000fd fallback=fefe94e01a0500700000fd
-IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a050191029200fd fallback=fefe94e01a05029200fd
+IC-7300	levels.py:set_nb_depth	value=0	map=fefe94e01a05018900fd fallback=fefe94e01a05029000fd
+IC-7300	levels.py:set_nb_width	value=0	map=fefe94e01a0501900000fd fallback=fefe94e01a0502910000fd
+IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a05019100fd fallback=fefe94e01a05029200fd
 IC-7300	scope.py:get_scope_center_type	receiver=0	map=fefe94e0271cfd fallback=fefe94e0271c00fd
 IC-7300	scope.py:get_scope_edge	receiver=0	map=fefe94e02716fd fallback=fefe94e0271600fd
 IC-7300	scope.py:get_scope_hold	receiver=0	map=fefe94e02717fd fallback=fefe94e0271700fd
@@ -57,27 +56,18 @@ IC-7300	scope.py:get_scope_ref	receiver=0	map=fefe94e02719fd fallback=fefe94e027
 IC-7300	scope.py:get_scope_span	receiver=0	map=fefe94e02715fd fallback=fefe94e0271500fd
 IC-7300	scope.py:get_scope_speed	receiver=0	map=fefe94e0271afd fallback=fefe94e0271a00fd
 IC-7300	scope.py:get_scope_vbw	receiver=0	map=fefe94e0271dfd fallback=fefe94e0271d00fd
-IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a0500300033fd fallback=fefe94e01a050033fd
-IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a0500300033fd fallback=fefe94e01a050033fd
+IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
+IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7610	config.py:get_acc1_mod_level	(no arguments)	map=fefe98e01a050088fd fallback=fefe98e0140bfd
 IC-7610	config.py:get_civ_output_ant	(no arguments)	map=fefe98e01c04fd fallback=fefe98e01a050130fd
 IC-7610	config.py:get_civ_transceive	(no arguments)	map=fefe98e01a050112fd fallback=fefe98e01a050129fd
 IC-7610	config.py:get_lan_mod_level	(no arguments)	map=fefe98e01a050090fd fallback=fefe98e01411fd
 IC-7610	config.py:get_usb_mod_level	(no arguments)	map=fefe98e01a050089fd fallback=fefe98e01410fd
 IC-7610	config.py:set_acc1_mod_level	level=0	map=fefe98e01a0500880000fd fallback=fefe98e0140b0000fd
-IC-7610	config.py:set_civ_output_ant	enabled=False	map=fefe98e01c04013000fd fallback=fefe98e01a05013000fd
-IC-7610	config.py:set_civ_transceive	enabled=False	map=fefe98e01a050112012900fd fallback=fefe98e01a05012900fd
-IC-7610	config.py:set_data1_mod_input	source=0	map=fefe98e01a050092009200fd fallback=fefe98e01a05009200fd
-IC-7610	config.py:set_data2_mod_input	source=0	map=fefe98e01a050093009300fd fallback=fefe98e01a05009300fd
-IC-7610	config.py:set_data3_mod_input	source=0	map=fefe98e01a050094009400fd fallback=fefe98e01a05009400fd
-IC-7610	config.py:set_data_off_mod_input	source=0	map=fefe98e01a050091009100fd fallback=fefe98e01a05009100fd
+IC-7610	config.py:set_civ_output_ant	enabled=False	map=fefe98e01c0400fd fallback=fefe98e01a05013000fd
+IC-7610	config.py:set_civ_transceive	enabled=False	map=fefe98e01a05011200fd fallback=fefe98e01a05012900fd
 IC-7610	config.py:set_lan_mod_level	level=0	map=fefe98e01a0500900000fd fallback=fefe98e014110000fd
 IC-7610	config.py:set_usb_mod_level	level=0	map=fefe98e01a0500890000fd fallback=fefe98e014100000fd
-IC-7610	levels.py:set_dash_ratio	value=30	map=fefe98e01a050228022830fd fallback=fefe98e01a05022830fd
-IC-7610	levels.py:set_nb_depth	value=0	map=fefe98e01a050290029000fd fallback=fefe98e01a05029000fd
-IC-7610	levels.py:set_nb_width	value=0	map=fefe98e01a05029102910000fd fallback=fefe98e01a0502910000fd
-IC-7610	levels.py:set_ref_adjust	value=0	map=fefe98e01a05007000700000fd fallback=fefe98e01a0500700000fd
-IC-7610	levels.py:set_vox_delay	value=0	map=fefe98e01a050292029200fd fallback=fefe98e01a05029200fd
 IC-7610	scope.py:get_scope_center_type	receiver=0	map=fefe98e0271cfd fallback=fefe98e0271c00fd
 IC-7610	scope.py:get_scope_edge	receiver=0	map=fefe98e02716fd fallback=fefe98e0271600fd
 IC-7610	scope.py:get_scope_hold	receiver=0	map=fefe98e02717fd fallback=fefe98e0271700fd
@@ -89,10 +79,6 @@ IC-7610	scope.py:get_scope_speed	receiver=0	map=fefe98e0271afd fallback=fefe98e0
 IC-7610	scope.py:get_scope_vbw	receiver=0	map=fefe98e0271dfd fallback=fefe98e0271d00fd
 IC-7610	vfo.py:get_dual_watch	(no arguments)	map=fefe98e007c2c2fd fallback=fefe98e007c2fd
 IC-7610	vfo.py:get_main_sub_band	(no arguments)	map=fefe98e007d2d2fd fallback=fefe98e007d2fd
-IC-7610	vfo.py:get_quick_dual_watch	(no arguments)	map=fefe98e01a0500320032fd fallback=fefe98e01a050032fd
-IC-7610	vfo.py:get_quick_split	(no arguments)	map=fefe98e01a0500330033fd fallback=fefe98e01a050033fd
-IC-7610	vfo.py:set_quick_dual_watch	(no arguments)	map=fefe98e01a0500320032fd fallback=fefe98e01a050032fd
-IC-7610	vfo.py:set_quick_split	(no arguments)	map=fefe98e01a0500330033fd fallback=fefe98e01a050033fd
 IC-9700	config.py:get_acc1_mod_level	(no arguments)	map=fefea2e01a050064fd fallback=fefea2e0140bfd
 IC-9700	config.py:get_civ_output_ant	(no arguments)	map=fefea2e01a050061fd fallback=fefea2e01a050130fd
 IC-9700	config.py:get_civ_transceive	(no arguments)	map=fefea2e01a050071fd fallback=fefea2e01a050129fd
@@ -100,18 +86,17 @@ IC-9700	config.py:get_data1_mod_input	(no arguments)	map=fefea2e01a050067fd fall
 IC-9700	config.py:get_data_off_mod_input	(no arguments)	map=fefea2e01a050066fd fallback=fefea2e01a050091fd
 IC-9700	config.py:get_usb_mod_level	(no arguments)	map=fefea2e01a050065fd fallback=fefea2e01410fd
 IC-9700	config.py:set_acc1_mod_level	level=0	map=fefea2e01a0500640000fd fallback=fefea2e0140b0000fd
-IC-9700	config.py:set_civ_output_ant	enabled=False	map=fefea2e01a050061013000fd fallback=fefea2e01a05013000fd
-IC-9700	config.py:set_civ_transceive	enabled=False	map=fefea2e01a050071012900fd fallback=fefea2e01a05012900fd
-IC-9700	config.py:set_data1_mod_input	source=0	map=fefea2e01a050067009200fd fallback=fefea2e01a05009200fd
-IC-9700	config.py:set_data_off_mod_input	source=0	map=fefea2e01a050066009100fd fallback=fefea2e01a05009100fd
+IC-9700	config.py:set_civ_output_ant	enabled=False	map=fefea2e01a05006100fd fallback=fefea2e01a05013000fd
+IC-9700	config.py:set_civ_transceive	enabled=False	map=fefea2e01a05007100fd fallback=fefea2e01a05012900fd
+IC-9700	config.py:set_data1_mod_input	source=0	map=fefea2e01a05006700fd fallback=fefea2e01a05009200fd
+IC-9700	config.py:set_data_off_mod_input	source=0	map=fefea2e01a05006600fd fallback=fefea2e01a05009100fd
 IC-9700	config.py:set_usb_mod_level	level=0	map=fefea2e01a0500650000fd fallback=fefea2e014100000fd
 IC-9700	levels.py:get_nb_depth	(no arguments)	map=fefea2e01a050189fd fallback=fefea2e01a050290fd
 IC-9700	levels.py:get_nb_width	(no arguments)	map=fefea2e01a050190fd fallback=fefea2e01a050291fd
 IC-9700	levels.py:get_vox_delay	(no arguments)	map=fefea2e01a050191fd fallback=fefea2e01a050292fd
-IC-9700	levels.py:set_nb_depth	value=0	map=fefea2e01a050189029000fd fallback=fefea2e01a05029000fd
-IC-9700	levels.py:set_nb_width	value=0	map=fefea2e01a05019002910000fd fallback=fefea2e01a0502910000fd
-IC-9700	levels.py:set_ref_adjust	value=0	map=fefea2e01a05007000700000fd fallback=fefea2e01a0500700000fd
-IC-9700	levels.py:set_vox_delay	value=0	map=fefea2e01a050191029200fd fallback=fefea2e01a05029200fd
+IC-9700	levels.py:set_nb_depth	value=0	map=fefea2e01a05018900fd fallback=fefea2e01a05029000fd
+IC-9700	levels.py:set_nb_width	value=0	map=fefea2e01a0501900000fd fallback=fefea2e01a0502910000fd
+IC-9700	levels.py:set_vox_delay	value=0	map=fefea2e01a05019100fd fallback=fefea2e01a05029200fd
 IC-9700	scope.py:get_scope_center_type	receiver=0	map=fefea2e0271cfd fallback=fefea2e0271c00fd
 IC-9700	scope.py:get_scope_edge	receiver=0	map=fefea2e02716fd fallback=fefea2e0271600fd
 IC-9700	scope.py:get_scope_hold	receiver=0	map=fefea2e02717fd fallback=fefea2e0271700fd
@@ -123,7 +108,7 @@ IC-9700	scope.py:get_scope_speed	receiver=0	map=fefea2e0271afd fallback=fefea2e0
 IC-9700	scope.py:get_scope_vbw	receiver=0	map=fefea2e0271dfd fallback=fefea2e0271d00fd
 IC-9700	vfo.py:get_dual_watch	(no arguments)	map=fefea2e007c2c2fd fallback=fefea2e007c2fd
 IC-9700	vfo.py:get_main_sub_band	(no arguments)	map=fefea2e007d2d2fd fallback=fefea2e007d2fd
-IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a0500300033fd fallback=fefea2e01a050033fd
-IC-9700	vfo.py:set_quick_split	(no arguments)	map=fefea2e01a0500300033fd fallback=fefea2e01a050033fd
+IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a050030fd fallback=fefea2e01a050033fd
+IC-9700	vfo.py:set_quick_split	(no arguments)	map=fefea2e01a050030fd fallback=fefea2e01a050033fd
 X6100	ptt.py:ptt_off	(no arguments)	map=fefe70e01c000000fd fallback=fefe70e01c0000fd
 X6100	ptt.py:ptt_on	(no arguments)	map=fefe70e01c000101fd fallback=fefe70e01c0001fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -22,8 +22,8 @@
 census	builders_compared	230
 census	cat_only_profiles	2
 census	dual_implementation_sites	139
-census	frames_diverged	123
-census	frames_identical	1302
+census	frames_diverged	108
+census	frames_identical	1317
 census	profile_builder_map_gaps	1006
 census	profiles	8
 census	public_builders	232


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1986. **Unit 2 of 3** in the mechanical repair of the profile command-map branch (owner decision: single source of truth, no hardcode).
- Compatibility impact: **none on the wire today.** No caller outside `commands/` passes a `cmd_map` to any builder, so the map branch is unreachable in production and the hardcoded fallback is what ships.

`commands/_frame.py: _build_from_map` prepends a profile's extra wire bytes to whatever `data` it is given. **Seven call sites also passed a hardcoded sub-address as that `data`**, so the map branch emitted two sub-addresses — usually two *different* ones, not one twice:

```
IC-705 set_civ_transceive
  map      1a 05 0112 0129 00      <- profile's 0112 AND the hardcoded 0129
  fallback 1a 05 0129 00
```

## The rule was already written down correctly, one function away

`_builders.py: _build_ctl_mem_get` passes `data=None` and carries the comment:

> When using cmd_map, wire bytes already include the full command structure including any data prefix, so don't pass prefix as data

Its set-side twin, `_build_ctl_mem_set`, built `prefix + value` and handed that to **both** branches. It now passes only the encoded value to the map branch and keeps `prefix + encoded` for the fallback — the same rule its own getter already stated.

The other six edits are direct `_build_from_map` calls in `vfo.py`: `quick_dual_watch`, `quick_split` and their `get_`/`set_` aliases, each passing `_CTL_MEM_QUICK_*` as data. Their map branches now pass `data=None`. **Every fallback branch is untouched** — the reviewer confirmed this exhaustively rather than by sampling, rebuilding all 3040 (profile, builder, argument-case) pairs at both commits: **0 fallback frames differ, exactly 42 map frames differ.**

**Two caveats the baselines force, and the first is material.** Only the four `get_`/`set_` aliases have divergence rows. Bare `quick_split` and `quick_dual_watch` are declared by **no shipped profile at all** — `command_map_parity_uncovered.txt` lists both as gaps in all eight — so those two edits follow the same rule with no independent evidence behind them. And "the profile already declares those bytes" is exact only for IC-7610, whose `get_quick_split = [0x1A, 0x05, 0x00, 0x33]` happens to equal `_CTL_MEM_QUICK_SPLIT`; IC-705 declares `00 45` and IC-7300/IC-9700 `00 30`. The rule holds regardless — whatever the profile declares is what should go out — but the bytes are not the same bytes.

## Scope taken from the baselines, not from grep

Decoding both frames in all 123 parent rows against the profile each row names: **43 rows are this shape**, where the two frames share command and sub-command *and* the map data is the profile's extra bytes followed by exactly the fallback's data — equivalently, the map frame is the fallback frame with the profile's extra inserted after cmd+sub.

The shared-cmd/sub condition is load-bearing, not decoration: dropping it widens the set to **61 rows across 23 builders**, sweeping in the `acc1`/`lan`/`usb_mod_level` cases where the two branches name genuinely different commands rather than duplicating a prefix.

**Of the 43's seventeen builders, fifteen route through `_build_ctl_mem_set` or those six `vfo.py` calls.** The other two are `ptt.py: ptt_on` and `ptt.py: ptt_off` — a third independent direct call site, left alone deliberately (below).

For the record, the same decode reclassifies the whole remaining baseline:

| rows | shape |
|---:|---|
| 43 | map sends two sub-addresses — **this PR (41 of them)** |
| 36 | map drops the receiver selector byte — unit 3 |
| 40 | profile and hardcode name genuinely different addresses — needs adjudication |
| 4 | a smaller VFO-side shape, not yet characterised |

## The two excluded rows are a data error, not a code error

X6100 `ptt_on` / `ptt_off`. **`rigs/x6100.toml` declares `ptt_on = [0x1C, 0x00, 0x01]`**, writing the payload value into the command bytes. The builder then appends the value itself, giving `1c 00 01 01`.

The builder cannot be the thing at fault: it *must* pass the payload, because five of the seven other profiles that declare these commands — ic705, ic7300, ic7610, ic9700, x6200 — declare `[0x1C, 0x00]`, and dropping the payload for them would turn a key into a read. (FTX-1 does not declare them at all; TX-500 declares them as CAT.)

So this is a data error, and correcting it asserts something about what the X6100 accepts. It wants its own change and its own review rather than a free ride in a code PR. Worth flagging for the programme: harmless today because the fallback ships, and a live wire defect the moment the profile becomes the source of truth.

## The baseline is not a pure line-level shrink — and why that is still correct

**42 rows leave and 27 arrive.** That is a stop-and-look signal, so it was measured rather than explained away:

```
CASES (profile, builder, arguments): 123 -> 108
  cases removed: 15
  cases ADDED  : 0
  rows re-recorded with new frames: 54  (27 old + 27 new)
```

**No case is added.** 27 of the departing rows are the same cases re-recorded with new map frames; 15 are gone because the two branches now agree. Diverging cases fall **123 → 108**, identical frames rise **1302 → 1317** — the same 1425 pairs.

The reviewer verified the "previously masked disagreement" reading for **all 27**, not a sample: in every case the new map frame is the old one with exactly one copy of the fallback's leading sub-address removed at offset `6 + len(extra)`, and the fallback frame is byte-identical. `set_civ_transceive` on IC-705 goes from doubling-on-top-of-a-disagreement to the disagreement alone. That is adjudication work for a later unit, not something this change introduces — but the baseline now states it cleanly.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10627 passed, 0 failed**, 12 skipped / 47 xfailed / 1 xpassed — identical to `main` at `b80220b5`, as expected for a change that alters no reachable behaviour. `ruff check` and `ruff format --check` clean (689 files); `lint-imports` 5 kept / 0 broken; doc-citation gate clean (847); `mypy --strict src/rigplane/web` clean. Every number independently reproduced by the reviewer, who also regenerated both baselines from source at each commit via `git archive` and got byte-for-byte matches.
- [x] Public/open-core boundary checked — no telemetry, no Pro content.
- [x] Release or migration impact documented if applicable — none.

An intermediate run reported 10565 passed / 74 skipped. That was this container losing its optional extras during an environment rollback, not a code effect. After `uv sync --all-extras` the count returned to 10627 / 12. (The rollback also discarded this unit's first implementation; it was redone from the same derivation and reproduced the identical baseline delta.)

## Guardrails

**4 files, 96 changed lines** (43 additions + 53 deletions). Inside the soft threshold; two of the four are generated baselines.

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` agent, relayed by the coordinating session (the reviewing environment has no GitHub access)
- **Round 1 at `b6ca3ef`: BLOCKED.** The code was found correct and complete for its class, all gates green, fallbacks provably untouched. The four blocking findings were all in the commit message, and all one class: universals in the scope justification written from the representative example rather than from the enumeration — the 17/17 routing claim (it is 15/17), the 43-row criterion (as worded it selects 61 across 23 builders), the `quick_*` profile claim (two of six are gaps in every profile), and the ptt profile count (five of seven, not seven).
- Each was re-derived against the tree by this session before being accepted, and **all four quantifiers were re-checked rather than only the one named** — patching the named sentence alone is precisely the failure the finding describes.
- Fixed at `0d8b89e`, a **message-only** amendment: `git diff b6ca3ef 0d8b89e` is empty, so the tree is byte-identical to the reviewed head and every gate result carries over.