### PR TITLE
fix(MOR-1986): make the cmd_map branch send the scope receiver selector

### DIFF
--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -152,6 +152,25 @@ def _scope_payload(value: bytes, receiver: int | None = None) -> bytes:
     return bytes([_validate_scope_receiver(receiver)]) + value
 
 
+def _scope_selector_data(receiver: int | None) -> bytes | None:
+    """Selector byte for a 0x27 read, or ``None`` when no receiver is named.
+
+    Only the sub-commands in ``SCOPE_RECEIVER_SELECTOR_SUBS`` may carry it --
+    on any other 0x27 read the extra byte is a write.  For those eight both
+    branches of the getter agree through this function: the fallback builds
+    its frame with it via ``_scope_query``, and the ``cmd_map`` branch passes
+    it as ``data``.
+
+    ``get_scope_center_type`` is the getter that reaches here and does not
+    agree.  Its 0x1C is outside the set, so its ``cmd_map`` branch correctly
+    sends nothing while its fallback still appends what it is given; the
+    disagreement is pinned in ``tests/command_map_parity_divergences.txt``
+    and closing it means refusing the argument, which changes public builder
+    behaviour (MOR-1981).
+    """
+    return None if receiver is None else bytes([_validate_scope_receiver(receiver)])
+
+
 def _scope_query(
     sub: int,
     *,
@@ -159,8 +178,9 @@ def _scope_query(
     from_addr: int = CONTROLLER_ADDR,
     receiver: int | None = None,
 ) -> bytes:
-    data = None if receiver is None else bytes([_validate_scope_receiver(receiver)])
-    return build_civ_frame(to_addr, from_addr, _CMD_SCOPE, sub=sub, data=data)
+    return build_civ_frame(
+        to_addr, from_addr, _CMD_SCOPE, sub=sub, data=_scope_selector_data(receiver)
+    )
 
 
 def _parse_scope_frame(frame: CivFrame, sub: int) -> bytes:
@@ -429,7 +449,11 @@ def get_scope_mode(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_mode", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_mode",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_MODE, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -471,7 +495,11 @@ def get_scope_span(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_span", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_span",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_SPAN, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -515,7 +543,11 @@ def get_scope_edge(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_edge", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_edge",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_EDGE, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -557,7 +589,11 @@ def get_scope_hold(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_hold", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_hold",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_HOLD, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -598,7 +634,11 @@ def get_scope_ref(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_ref", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_ref",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_REF, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -639,7 +679,11 @@ def get_scope_speed(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_speed", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_speed",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_SPEED, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -756,7 +800,11 @@ def get_scope_vbw(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_vbw", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_vbw",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_VBW, to_addr=to_addr, from_addr=from_addr, receiver=receiver
@@ -867,7 +915,11 @@ def get_scope_rbw(
 ) -> bytes:
     if cmd_map is not None:
         return _build_from_map(
-            cmd_map, "get_scope_rbw", to_addr=to_addr, from_addr=from_addr
+            cmd_map,
+            "get_scope_rbw",
+            to_addr=to_addr,
+            from_addr=from_addr,
+            data=_scope_selector_data(receiver),
         )
     return _scope_query(
         _SUB_SCOPE_RBW, to_addr=to_addr, from_addr=from_addr, receiver=receiver

--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -19,14 +19,6 @@ IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=f
 IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a05025230fd fallback=fefea4e01a05022830fd
 IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a0500890000fd fallback=fefea4e01a0500700000fd
 IC-705	scope.py:get_scope_center_type	receiver=0	map=fefea4e0271cfd fallback=fefea4e0271c00fd
-IC-705	scope.py:get_scope_edge	receiver=0	map=fefea4e02716fd fallback=fefea4e0271600fd
-IC-705	scope.py:get_scope_hold	receiver=0	map=fefea4e02717fd fallback=fefea4e0271700fd
-IC-705	scope.py:get_scope_mode	receiver=0	map=fefea4e02714fd fallback=fefea4e0271400fd
-IC-705	scope.py:get_scope_rbw	receiver=0	map=fefea4e0271ffd fallback=fefea4e0271f00fd
-IC-705	scope.py:get_scope_ref	receiver=0	map=fefea4e02719fd fallback=fefea4e0271900fd
-IC-705	scope.py:get_scope_span	receiver=0	map=fefea4e02715fd fallback=fefea4e0271500fd
-IC-705	scope.py:get_scope_speed	receiver=0	map=fefea4e0271afd fallback=fefea4e0271a00fd
-IC-705	scope.py:get_scope_vbw	receiver=0	map=fefea4e0271dfd fallback=fefea4e0271d00fd
 IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-7300	config.py:get_acc1_mod_level	(no arguments)	map=fefe94e01a050064fd fallback=fefe94e0140bfd
@@ -48,14 +40,6 @@ IC-7300	levels.py:set_nb_depth	value=0	map=fefe94e01a05018900fd fallback=fefe94e
 IC-7300	levels.py:set_nb_width	value=0	map=fefe94e01a0501900000fd fallback=fefe94e01a0502910000fd
 IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a05019100fd fallback=fefe94e01a05029200fd
 IC-7300	scope.py:get_scope_center_type	receiver=0	map=fefe94e0271cfd fallback=fefe94e0271c00fd
-IC-7300	scope.py:get_scope_edge	receiver=0	map=fefe94e02716fd fallback=fefe94e0271600fd
-IC-7300	scope.py:get_scope_hold	receiver=0	map=fefe94e02717fd fallback=fefe94e0271700fd
-IC-7300	scope.py:get_scope_mode	receiver=0	map=fefe94e02714fd fallback=fefe94e0271400fd
-IC-7300	scope.py:get_scope_rbw	receiver=0	map=fefe94e0271ffd fallback=fefe94e0271f00fd
-IC-7300	scope.py:get_scope_ref	receiver=0	map=fefe94e02719fd fallback=fefe94e0271900fd
-IC-7300	scope.py:get_scope_span	receiver=0	map=fefe94e02715fd fallback=fefe94e0271500fd
-IC-7300	scope.py:get_scope_speed	receiver=0	map=fefe94e0271afd fallback=fefe94e0271a00fd
-IC-7300	scope.py:get_scope_vbw	receiver=0	map=fefe94e0271dfd fallback=fefe94e0271d00fd
 IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7610	config.py:get_acc1_mod_level	(no arguments)	map=fefe98e01a050088fd fallback=fefe98e0140bfd
@@ -69,14 +53,6 @@ IC-7610	config.py:set_civ_transceive	enabled=False	map=fefe98e01a05011200fd fall
 IC-7610	config.py:set_lan_mod_level	level=0	map=fefe98e01a0500900000fd fallback=fefe98e014110000fd
 IC-7610	config.py:set_usb_mod_level	level=0	map=fefe98e01a0500890000fd fallback=fefe98e014100000fd
 IC-7610	scope.py:get_scope_center_type	receiver=0	map=fefe98e0271cfd fallback=fefe98e0271c00fd
-IC-7610	scope.py:get_scope_edge	receiver=0	map=fefe98e02716fd fallback=fefe98e0271600fd
-IC-7610	scope.py:get_scope_hold	receiver=0	map=fefe98e02717fd fallback=fefe98e0271700fd
-IC-7610	scope.py:get_scope_mode	receiver=0	map=fefe98e02714fd fallback=fefe98e0271400fd
-IC-7610	scope.py:get_scope_rbw	receiver=0	map=fefe98e0271ffd fallback=fefe98e0271f00fd
-IC-7610	scope.py:get_scope_ref	receiver=0	map=fefe98e02719fd fallback=fefe98e0271900fd
-IC-7610	scope.py:get_scope_span	receiver=0	map=fefe98e02715fd fallback=fefe98e0271500fd
-IC-7610	scope.py:get_scope_speed	receiver=0	map=fefe98e0271afd fallback=fefe98e0271a00fd
-IC-7610	scope.py:get_scope_vbw	receiver=0	map=fefe98e0271dfd fallback=fefe98e0271d00fd
 IC-7610	vfo.py:get_dual_watch	(no arguments)	map=fefe98e007c2c2fd fallback=fefe98e007c2fd
 IC-7610	vfo.py:get_main_sub_band	(no arguments)	map=fefe98e007d2d2fd fallback=fefe98e007d2fd
 IC-9700	config.py:get_acc1_mod_level	(no arguments)	map=fefea2e01a050064fd fallback=fefea2e0140bfd
@@ -98,14 +74,6 @@ IC-9700	levels.py:set_nb_depth	value=0	map=fefea2e01a05018900fd fallback=fefea2e
 IC-9700	levels.py:set_nb_width	value=0	map=fefea2e01a0501900000fd fallback=fefea2e01a0502910000fd
 IC-9700	levels.py:set_vox_delay	value=0	map=fefea2e01a05019100fd fallback=fefea2e01a05029200fd
 IC-9700	scope.py:get_scope_center_type	receiver=0	map=fefea2e0271cfd fallback=fefea2e0271c00fd
-IC-9700	scope.py:get_scope_edge	receiver=0	map=fefea2e02716fd fallback=fefea2e0271600fd
-IC-9700	scope.py:get_scope_hold	receiver=0	map=fefea2e02717fd fallback=fefea2e0271700fd
-IC-9700	scope.py:get_scope_mode	receiver=0	map=fefea2e02714fd fallback=fefea2e0271400fd
-IC-9700	scope.py:get_scope_rbw	receiver=0	map=fefea2e0271ffd fallback=fefea2e0271f00fd
-IC-9700	scope.py:get_scope_ref	receiver=0	map=fefea2e02719fd fallback=fefea2e0271900fd
-IC-9700	scope.py:get_scope_span	receiver=0	map=fefea2e02715fd fallback=fefea2e0271500fd
-IC-9700	scope.py:get_scope_speed	receiver=0	map=fefea2e0271afd fallback=fefea2e0271a00fd
-IC-9700	scope.py:get_scope_vbw	receiver=0	map=fefea2e0271dfd fallback=fefea2e0271d00fd
 IC-9700	vfo.py:get_dual_watch	(no arguments)	map=fefea2e007c2c2fd fallback=fefea2e007c2fd
 IC-9700	vfo.py:get_main_sub_band	(no arguments)	map=fefea2e007d2d2fd fallback=fefea2e007d2fd
 IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a050030fd fallback=fefea2e01a050033fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -22,8 +22,8 @@
 census	builders_compared	230
 census	cat_only_profiles	2
 census	dual_implementation_sites	139
-census	frames_diverged	108
-census	frames_identical	1317
+census	frames_diverged	76
+census	frames_identical	1349
 census	profile_builder_map_gaps	1006
 census	profiles	8
 census	public_builders	232

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -11,8 +11,9 @@ and
 ``test_rig_ic7300.py: test_get_speech_cmd_map_uses_set_speech`` each pin
 ``get_speech`` alone. Outside that subset the two copies could disagree
 silently, and at least one pair does: the ``cmd_map`` branch of
-``scope.py: get_scope_mode`` and its siblings drops the ``receiver``
-argument that the fallback hands to ``scope.py: _scope_query``.
+``scope.py: get_scope_center_type`` sends a bare ``27 1c`` where the
+fallback hands ``scope.py: _scope_query`` a receiver it then appends --
+and on 0x1C that extra byte is a write, not a read.
 
 This test is the general form of that check: it builds every builder it can
 reach both ways, for every profile the library loads out of ``rigs/``, and
@@ -295,7 +296,7 @@ def _cases() -> tuple[dict[Key, list[dict[str, typing.Any]]], frozenset[Key]]:
 
     The first case passes only required arguments; one further case per
     optional argument overrides it with a non-default value, because a
-    divergence can hide behind a default — ``scope.py: get_scope_mode``
+    divergence can hide behind a default — ``scope.py: get_scope_center_type``
     builds identical frames until ``receiver`` is given a value. Argument
     validation happens before a builder reads ``to_addr``, so this search
     runs once and its result is reused for every profile.


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1986. **Unit 3 of 3** in the mechanical repair of the profile command-map branch (owner decision: single source of truth, no hardcode).
- Compatibility impact: **none on the wire today.** No caller outside `commands/` passes a `cmd_map` to any builder, so the map branch is unreachable in production. The fallback — which is what ships — already sent the selector correctly.

Eight scope getters in `commands/scope.py` accept a `receiver` argument, hand it to `_scope_query` on the fallback branch, and **drop it entirely on the `cmd_map` branch**:

```
get_scope_mode(receiver=0)
  map      27 14
  fallback 27 14 00
```

Same getter/setter asymmetry as unit 2 — all eleven scope *setters* already pass the selector through `_scope_payload`.

## The selector byte now has one implementation

`_scope_selector_data` computes it, `_scope_query` builds the fallback frame with it, and the eight map branches pass it as `data`. Previously `_scope_query` held the only copy and the map branches had none.

## Which eight is not a judgement call

They are exactly the members of `SCOPE_RECEIVER_SELECTOR_SUBS` — `0x14` mode, `0x15` span, `0x16` edge, `0x17` hold, `0x19` ref, `0x1A` speed, `0x1D` VBW, `0x1F` RBW — the set MOR-1981 (#2793) established from a live IC-7300 and Icom's IC-705 CI-V guide, and which this repository already pins in three places.

## A ninth getter has the same divergence pointing the other way, and is deliberately not touched

`get_scope_center_type` shows an identical-looking row:

```
get_scope_center_type(receiver=0)
  map      27 1c
  fallback 27 1c 00
```

**But its sub-command is `0x1C`, which is NOT in the set**, and MOR-1981 measured that an extra byte on a `0x1C` read is a *write* setting centre type to Filter Center. So here the map branch's bare `27 1c` is the **correct** frame and the fallback's `27 1c 00` is the defective one.

Making the two agree therefore means stopping the builder from honouring a `receiver` it must not accept — public builder behaviour, and exactly what #2793 deferred when it recorded `get_scope_center_type`, `scope_set_center_type` (`0x1C`) and `scope_single_dual` (`0x13`) as three builders accepting a `receiver` for a sub-command that must not take one. It is latent: no production caller passes `receiver` to any of them.

This is the trap the unit turns on. Nine getters show the same textual divergence; blindly making all nine agree would either break the eight or entrench a write on the ninth.

## Baseline

**32 rows leave, none arrive, and no `(profile, builder, arguments)` case is added** — eight getters across IC-705, IC-7300, IC-7610 and IC-9700.

```
CASES 108 -> 76   removed 32   ADDED 0
```

Diverging cases fall **108 → 76**, identical frames rise **1317 → 1349** — the same 1425 pairs. The only scope rows left in the baseline are the four `get_scope_center_type` ones.

## Where the programme stands after this

The three mechanical repairs of the map branch are done. The baseline went **152 → 123 → 108 → 76** across units 1–3, with zero cases added at any step.

What remains in the 76 is no longer mechanical:

| rows | shape | needs |
|---:|---|---|
| ~40 | profile and hardcode name genuinely different addresses | per-command adjudication against documentation or bench |
| 4 | `get_scope_center_type` | a public-builder behaviour change, deferred by #2793 |
| 2 | X6100 `ptt_on`/`ptt_off` | a profile data fix (`rigs/x6100.toml` writes the payload into the command bytes) |
| rest | smaller shapes, not yet characterised | |

**On the adjudication group**, evidence gathered since unit 2 and worth recording here: comparing our profiles against wfview's rig definitions for IC-705/IC-7300/IC-7610/IC-9700 gives 25 matches out of 31 checked (profile, command) pairs, and **every mismatch is IC-9700**, whose profile carries a block of IC-7300's sub-addresses. The hardcoded fallback — the branch that actually ships — is a single value per command where the real sub-address is model-specific, and these are exposed Radio-protocol methods. That makes the fallback the live defect and the profiles largely right, which inverts the assumption the programme started from.

## Verification

- [x] Relevant local tests or checks run — `uv run pytest tests/ --ignore=tests/integration -n auto`: **10627 passed, 0 failed**, 12 skipped / 47 xfailed / 1 xpassed — identical to `main` at `d1e382f6`, as expected for a change that alters no reachable behaviour. `ruff check` and `ruff format --check` clean (689 files); `lint-imports` 5 kept / 0 broken; doc-citation gate clean (847); `mypy --strict src/rigplane/web` clean.
- [x] Public/open-core boundary checked — no telemetry, no Pro content.
- [x] Release or migration impact documented if applicable — none.

## Guardrails

**3 files, 100 changed lines** (56 additions + 44 deletions). Inside the soft threshold; two of the three are generated baselines.

## Agent Review

- [ ] Independent agent review comment posted before merge — requested; the implementing session never reviews its own work.

---
_Generated by [Claude Code](https://claude.ai/code/session_012TRZb9iohes7vNLdfM15YH)_