### PR TITLE
fix(MOR-1986): take the VFO selector byte from the profile, not a table in the builder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by some other process; under a managed runtime it now escalates to an
   operator-forced unkey (see Changed below) and its exit code is meaningful
   (MOR-1184, MOR-1199).
+- **`rigplane.commands.set_vfo` takes a selector byte, not a VFO name**
+  (MOR-1986). The builder held its own `{"A": 0x00, "B": 0x01, "MAIN": 0xD0,
+  "SUB": 0xD1}` table — rig-specific bytes inside a builder, and a second
+  implementation of a mapping the rig TOMLs declare as `[vfo] main_select` /
+  `sub_select`. It now takes the byte and the profile supplies it:
+  `set_vfo("MAIN", to_addr=...)` becomes
+  `set_vfo(radio.profile.vfo_main_code, to_addr=...)` — but those fields are
+  `int | None`, and four shipped profiles (X6100, X6200, TX-500, FTX-1)
+  declare neither, so a caller must handle `None` rather than pass it
+  through. Callers that passed a name outside those four keys used to select
+  VFO A silently; there is no such fallback now.
+  `IcomRadio`'s signature and accepted alphabet are unchanged —
+  `_set_vfo_wire` still takes "A"/"B"/"MAIN"/"SUB" — but its bytes are not:
+  it now resolves them from the loaded profile, so "A" on a `main_sub`
+  profile sends 0xD0 where it sent 0x00, "MAIN" on an `ab` profile sends
+  0x00 where it sent 0xD0, and a profile declaring no code raises
+  `CommandError` where it used to emit. Every *guarded* caller
+  (`select_receiver`, `swap_vfo_ab`, `equalize_vfo_ab`, the per-receiver
+  VFO fallback) passes "MAIN"/"SUB" on a dual-RX profile. On the dual-RX
+  profiles that declare `main_select`/`sub_select` (IC-7610, IC-9700) the
+  bytes are identical, so a `snapshot_state` → `restore_state` round-trip is
+  unchanged. `restore_state` itself forwards whatever dict it is handed,
+  though: `radio.restore_state({"vfo": "A"})` against a `main_sub` profile
+  now selects the MAIN receiver (0xD0) where it used to select VFO A
+  (0x00), and `restore_state` swallows per-field failures at DEBUG, so
+  nothing surfaces. Hand-built restore dicts should use "MAIN"/"SUB".
 
 ### Changed
 

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -160,7 +160,10 @@ ptt_off(to_addr=0x98) -> bytes
 ### VFO
 
 ```python
-select_vfo(vfo: str = "A", to_addr=0x98) -> bytes
+# ``code`` is the rig's selector byte, from the profile's
+# ``[vfo] main_select`` / ``sub_select`` — this builder holds no
+# name-to-byte table. ``radio.py: CoreRadio._set_vfo_wire`` resolves it.
+select_vfo(code: int, to_addr=0x98) -> bytes
 vfo_a_equals_b(to_addr=0x98) -> bytes
 vfo_swap(to_addr=0x98) -> bytes
 set_split(on: bool, to_addr=0x98) -> bytes

--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -260,7 +260,7 @@
         "rigplane.radio:CoreRadio.set_vfo_slot"
       ],
       "test_patterns": [
-        "tests/test_commands_extended.py::test_vfo_main"
+        "tests/test_commands_extended.py::test_code_reaches_the_wire_unchanged"
       ]
     },
     {
@@ -368,7 +368,7 @@
         "rigplane.radio:CoreRadio.select_receiver"
       ],
       "test_patterns": [
-        "tests/test_commands_extended.py::test_vfo_main"
+        "tests/test_radio_extended.py::test_set_vfo_wire_sends_the_profile_code"
       ]
     },
     {
@@ -386,7 +386,7 @@
         "rigplane.radio:CoreRadio.select_receiver"
       ],
       "test_patterns": [
-        "tests/test_commands_extended.py::test_vfo_sub"
+        "tests/test_radio_extended.py::test_set_vfo_wire_sends_the_profile_code"
       ]
     },
     {

--- a/docs/parity/test_mapping.md
+++ b/docs/parity/test_mapping.md
@@ -30,7 +30,7 @@ This document maps **IC-7610 parity command families** and **reliability integra
 - **system_config:** `test_commands.py::test_get_antenna_1`, `test_commands.py::test_get_system_date`, `test_radio.py::test_get_transceiver_id`
 - **tone_repeater:** `test_commands.py::test_get_repeater_tone`, `test_commands.py::test_get_tone_freq`, `test_commands.py::test_get_tsql_freq`
 - **transceiver_status:** `test_commands.py::test_get_rit_frequency`, `test_civ_rx_coverage.py::test_update_radio_state_rit_frequency`, `test_radio_poller_coverage.py::test_state_queries_include_transceiver_status_reads_for_ic7610`
-- **vfo_dualwatch_scan:** `test_commands_extended.py::test_vfo_main`, `test_civ_rx_coverage.py::dual_watch`, `test_vfo_dual_watch.py::test_start_scan_builds_correct_frame`, `test_main_sub_tracking.py::TestGetMainSubTracking`
+- **vfo_dualwatch_scan:** `test_commands_extended.py::test_code_reaches_the_wire_unchanged`, `test_radio_extended.py::test_set_vfo_wire_sends_the_profile_code`, `test_civ_rx_coverage.py::dual_watch`, `test_vfo_dual_watch.py::test_start_scan_builds_correct_frame`, `test_main_sub_tracking.py::TestGetMainSubTracking`
 
 ---
 

--- a/src/rigplane/commands/vfo.py
+++ b/src/rigplane/commands/vfo.py
@@ -56,19 +56,29 @@ def get_main_sub_band(
 
 
 def set_vfo(
-    vfo: str = "A",
+    code: int,
     *,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Select VFO.
+    """Select a VFO or receiver by its wire code.
 
     Args:
-        vfo: "A", "B", "MAIN", or "SUB".
+        code: The selector byte to send, taken from the caller's profile.
+
+    Which byte names which VFO is a property of the radio, declared per
+    profile as ``[vfo] main_select`` / ``sub_select``.  This builder used
+    to hold its own ``{"A": 0x00, "B": 0x01, "MAIN": 0xD0, "SUB": 0xD1}``
+    table and take a name instead -- the rig-specific hardcoding
+    ``LAYER.md`` forbids, and a second implementation of a mapping the
+    profile already carries: ``web/radio_poller.py`` reached the same
+    selection through ``vfo_main_code`` / ``vfo_sub_code`` while this
+    table ignored the profile entirely.  Any name outside the four keys
+    fell through ``dict.get`` to ``0x00``, so a typo selected VFO A.
+    ``commands`` may not import ``profiles``, so the resolution belongs
+    one layer up -- ``runtime/radio.py: CoreRadio._set_vfo_wire`` does it.
     """
-    codes = {"A": 0x00, "B": 0x01, "MAIN": 0xD0, "SUB": 0xD1}
-    code = codes.get(vfo.upper(), 0x00)
     if cmd_map is not None:
         return _build_from_map(
             cmd_map, "set_vfo", to_addr=to_addr, from_addr=from_addr, data=bytes([code])

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3955,9 +3955,28 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
         Args:
             vfo: "A", "B", "MAIN", or "SUB" (case-insensitive on input).
+
+        The selector byte comes from the profile, not from a table here:
+        ``B``/``SUB`` name the secondary VFO and take ``vfo_sub_code``,
+        anything else the primary and ``vfo_main_code``.  One pair serves
+        both spellings because a profile declares one primary and one
+        secondary selector whatever the rig's front panel calls them
+        (``[vfo] main_select`` / ``sub_select`` in ``rigs/*.toml``).  A
+        profile that declares no code for the VFO asked for raises, rather
+        than falling back to a byte this method invented.
         """
         self._check_connected()
-        civ = _select_vfo_cmd(vfo, to_addr=self._radio_addr)
+        name = vfo.upper()
+        code = (
+            self._profile.vfo_sub_code
+            if name in ("B", "SUB")
+            else self._profile.vfo_main_code
+        )
+        if code is None:
+            raise CommandError(
+                f"profile {self._profile.model} declares no VFO select code for {name}"
+            )
+        civ = _select_vfo_cmd(code, to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="set_vfo")
         ack = parse_ack_nak(resp)
         if ack is False:

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -23,8 +23,8 @@ census	builders_compared	230
 census	cat_only_profiles	2
 census	dual_implementation_sites	139
 census	frames_diverged	76
-census	frames_identical	1349
-census	hardcode_only_builders	49
+census	frames_identical	1344
+census	hardcode_only_builders	16
 census	profile_builder_map_gaps	1006
 census	profiles	8
 census	public_builders	232

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -24,6 +24,7 @@ census	cat_only_profiles	2
 census	dual_implementation_sites	139
 census	frames_diverged	76
 census	frames_identical	1349
+census	hardcode_only_builders	49
 census	profile_builder_map_gaps	1006
 census	profiles	8
 census	public_builders	232

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -44,10 +44,12 @@ builder reaches, and a census of how much was compared. Every number in it
 is re-measured and asserted here, so none of it can go stale unnoticed.
 
 That census also counts what this sweep cannot reach at all:
-``hardcode_only_builders`` is the public builders that take no ``cmd_map``.
-They have no profile branch to disagree with, so no divergence row can ever
-name them however wrong their bytes are — the count is the only thing that
-makes a new one visible.
+``hardcode_only_builders`` is the byte-emitting public builders that take no
+``cmd_map`` — response parsers (``parse_*``) are excluded along with the
+underscore-named kernel modules, since neither emits a command frame for a
+``cmd_map`` to affect. They have no profile branch to disagree with, so no
+divergence row can ever name them however wrong their bytes are — the count
+is the only thing that makes a new one visible.
 
 Regenerate both files after an intentional change::
 
@@ -217,7 +219,7 @@ def _builders() -> dict[Key, typing.Any]:
 
 @functools.lru_cache(maxsize=1)
 def _hardcode_only_builders() -> frozenset[Key]:
-    """Command builders in the public domain modules that take no ``cmd_map``.
+    """Byte-emitting command builders that take no ``cmd_map``.
 
     These are outside everything else this file measures. A builder with
     both branches can disagree with its profile, and a divergence row says
@@ -227,14 +229,23 @@ def _hardcode_only_builders() -> frozenset[Key]:
     the census is asserted for equality, so adding one fails until the
     baseline is regenerated in a reviewable commit.
 
-    Underscore-named modules are skipped, which is where this differs from
-    :func:`_builders`. They hold the framing and codec kernel --
-    ``_frame.py: build_civ_frame``, ``_codec.py: bcd_encode_value`` and
-    their siblings -- which every builder calls and which encode no command
-    of their own, so a ``cmd_map`` would be meaningless to them. Counting
-    them would make this number move whenever the kernel gains a public
-    helper. :func:`_builders` needs no such rule only because nothing in
-    those modules takes a ``cmd_map`` to begin with.
+    Two kinds of function are excluded, for the same reason: underscore-named
+    modules, and any ``parse_*`` function regardless of module. Neither
+    emits a command frame -- the underscore modules hold the framing and
+    codec kernel (``_frame.py: build_civ_frame``, ``_codec.py:
+    bcd_encode_value`` and their siblings) that every builder calls, and a
+    ``parse_*`` function decodes a radio response instead of building one
+    (``freq.py: parse_frequency_response`` and its siblings) -- so a
+    ``cmd_map`` would have nothing to look up for either. Counting either
+    would make this number move for a reason unrelated to what it tracks:
+    the kernel gaining a public helper, or a module gaining a response
+    parser. :func:`_builders` needs no module-level rule because its own
+    ``__name__.startswith("_")`` filter already excludes every underscore
+    module: the eleven kernel helpers that do take a ``cmd_map``
+    (``_builders.py: _build_level_get`` and its nine siblings,
+    ``_frame.py: _build_from_map``) are all underscore-named. A public
+    ``cmd_map``-taking helper added to one of those modules would move
+    ``public_builders`` -- this rule is what keeps it out of this count.
     """
     found: set[Key] = set()
     for path in sorted(COMMANDS_DIR.glob("*.py")):
@@ -245,6 +256,8 @@ def _hardcode_only_builders() -> frozenset[Key]:
             if not inspect.isfunction(value) or value.__name__.startswith("_"):
                 continue
             if value.__module__ != module.__name__:
+                continue
+            if value.__name__.startswith("parse"):
                 continue
             if "cmd_map" not in inspect.signature(value).parameters:
                 found.add((path.name, value.__name__))

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -43,6 +43,12 @@ builders whose arguments no probe value satisfied, the sites no compared
 builder reaches, and a census of how much was compared. Every number in it
 is re-measured and asserted here, so none of it can go stale unnoticed.
 
+That census also counts what this sweep cannot reach at all:
+``hardcode_only_builders`` is the public builders that take no ``cmd_map``.
+They have no profile branch to disagree with, so no divergence row can ever
+name them however wrong their bytes are — the count is the only thing that
+makes a new one visible.
+
 Regenerate both files after an intentional change::
 
     RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest \
@@ -207,6 +213,42 @@ def _builders() -> dict[Key, typing.Any]:
             if "cmd_map" in inspect.signature(value).parameters:
                 found[(path.name, value.__name__)] = value
     return found
+
+
+@functools.lru_cache(maxsize=1)
+def _hardcode_only_builders() -> frozenset[Key]:
+    """Command builders in the public domain modules that take no ``cmd_map``.
+
+    These are outside everything else this file measures. A builder with
+    both branches can disagree with its profile, and a divergence row says
+    so; a builder with no ``cmd_map`` parameter has no profile branch to
+    disagree with, so it can never appear in the divergence baseline however
+    wrong its bytes are. Counting them here is what makes a new one visible:
+    the census is asserted for equality, so adding one fails until the
+    baseline is regenerated in a reviewable commit.
+
+    Underscore-named modules are skipped, which is where this differs from
+    :func:`_builders`. They hold the framing and codec kernel --
+    ``_frame.py: build_civ_frame``, ``_codec.py: bcd_encode_value`` and
+    their siblings -- which every builder calls and which encode no command
+    of their own, so a ``cmd_map`` would be meaningless to them. Counting
+    them would make this number move whenever the kernel gains a public
+    helper. :func:`_builders` needs no such rule only because nothing in
+    those modules takes a ``cmd_map`` to begin with.
+    """
+    found: set[Key] = set()
+    for path in sorted(COMMANDS_DIR.glob("*.py")):
+        if path.stem.startswith("_"):
+            continue
+        module = importlib.import_module(f"rigplane.commands.{path.stem}")
+        for value in vars(module).values():
+            if not inspect.isfunction(value) or value.__name__.startswith("_"):
+                continue
+            if value.__module__ != module.__name__:
+                continue
+            if "cmd_map" not in inspect.signature(value).parameters:
+                found.add((path.name, value.__name__))
+    return frozenset(found)
 
 
 def _values_for(fn: typing.Any, param: inspect.Parameter) -> tuple[typing.Any, ...]:
@@ -401,6 +443,7 @@ def _report() -> _Report:
             "dual_implementation_sites": len(_graph().sites),
             "sites_compared": len(compared),
             "public_builders": len(_builders()),
+            "hardcode_only_builders": len(_hardcode_only_builders()),
             "builders_compared": len(per_builder),
             "profiles": len(rigs),
             "cat_only_profiles": len(cat_only),

--- a/tests/test_commands_extended.py
+++ b/tests/test_commands_extended.py
@@ -1,5 +1,7 @@
 """Extended tests for commands module — VFO, split, att, preamp, CW, power."""
 
+import pytest
+
 import rigplane.commands as raw_commands
 
 from rigplane import IC_7610_ADDR
@@ -26,31 +28,23 @@ bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
 
 
 class TestSelectVfo:
-    def test_vfo_a(self):
-        frame = select_vfo("A")
-        parsed = parse_civ_frame(frame)
+    """The builder sends the selector byte it is handed, and nothing else.
+
+    Which byte names which VFO is declared per rig as ``[vfo] main_select``
+    / ``sub_select`` and resolved by ``runtime/radio.py:
+    CoreRadio._set_vfo_wire``; the builder used to hold its own
+    name-to-byte table instead, which ignored those declarations.
+    """
+
+    @pytest.mark.parametrize("code", [0x00, 0x01, 0xD0, 0xD1])
+    def test_code_reaches_the_wire_unchanged(self, code):
+        parsed = parse_civ_frame(select_vfo(code))
         assert parsed.command == 0x07
-        assert parsed.data == bytes([0x00])
+        assert parsed.data == bytes([code])
 
-    def test_vfo_b(self):
-        frame = select_vfo("B")
-        parsed = parse_civ_frame(frame)
-        assert parsed.data == bytes([0x01])
-
-    def test_vfo_main(self):
-        frame = select_vfo("MAIN")
-        parsed = parse_civ_frame(frame)
-        assert parsed.data == bytes([0xD0])
-
-    def test_vfo_sub(self):
-        frame = select_vfo("SUB")
-        parsed = parse_civ_frame(frame)
-        assert parsed.data == bytes([0xD1])
-
-    def test_vfo_case_insensitive(self):
-        frame = select_vfo("main")
-        parsed = parse_civ_frame(frame)
-        assert parsed.data == bytes([0xD0])
+    def test_a_name_is_not_accepted(self):
+        with pytest.raises(TypeError):
+            select_vfo("MAIN")
 
 
 class TestVfoCommands:

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 import pytest
 
 from rigplane import IC_7610_ADDR
-from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, parse_civ_frame
 from rigplane.commander import Priority
 from rigplane.exceptions import CommandError, ConnectionError, TimeoutError
 from rigplane.radio import IcomRadio
@@ -52,26 +52,82 @@ def radio(mock_transport: MockTransport) -> IcomRadio:
 
 class TestVFO:
     @pytest.mark.asyncio
-    async def test_set_vfo_wire_a(
-        self, radio: IcomRadio, mock_transport: MockTransport
+    @pytest.mark.parametrize(
+        ("model", "vfo", "expected"),
+        [
+            ("IC-7300", "A", 0x00),
+            ("IC-7300", "B", 0x01),
+            ("IC-7300", "MAIN", 0x00),
+            ("IC-7300", "SUB", 0x01),
+            ("IC-7610", "A", 0xD0),
+            ("IC-7610", "B", 0xD1),
+            ("IC-7610", "MAIN", 0xD0),
+            ("IC-7610", "SUB", 0xD1),
+            # The lowercase row must name a *secondary* VFO. "main" would
+            # resolve to vfo_main_code with or without the method's
+            # ``.upper()`` -- it falls to the same else-branch either way --
+            # so it could not fail if that call were dropped. "sub" can.
+            ("IC-7610", "sub", 0xD1),
+        ],
+    )
+    async def test_set_vfo_wire_sends_the_profile_code(
+        self,
+        mock_transport: MockTransport,
+        model: str,
+        vfo: str,
+        expected: int,
     ) -> None:
-        mock_transport.queue_response(_ack_response())
-        await radio._set_vfo_wire("A")
-        assert len(mock_transport.sent_packets) > 0
+        """The selector byte is the profile's, not a table in the method.
+
+        Both spellings of a receiver resolve to the one pair the profile
+        declares, so an ``ab`` profile never emits 0xD0/0xD1 and a
+        ``main_sub`` profile never emits 0x00/0x01.  The table this
+        replaced went the other way — it answered by name alone, so
+        ``"MAIN"`` sent 0xD0 to an IC-7300 that has no MAIN.
+        """
+        r = IcomRadio("192.168.1.100", timeout=0.05, model=model)
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        mock_transport.queue_response(
+            _wrap_civ_in_udp(build_civ_frame(CONTROLLER_ADDR, r._radio_addr, 0xFB))
+        )
+        try:
+            await r._set_vfo_wire(vfo)
+        finally:
+            r._connected = False
+        # Parse the frame out; do not search the datagram for the two bytes.
+        # The UDP control header ends ``... 00 07 00 00 00`` on every packet
+        # this transport sends, so ``b"\x07\x00" in packet`` is true whatever
+        # the payload — it would pass all four IC-7300 rows unchanged.
+        sent = mock_transport.sent_packets[-1]
+        frame = parse_civ_frame(sent[sent.index(b"\xfe\xfe") :])
+        assert frame.command == 0x07
+        assert frame.data == bytes([expected])
 
     @pytest.mark.asyncio
-    async def test_set_vfo_wire_b(
-        self, radio: IcomRadio, mock_transport: MockTransport
+    async def test_set_vfo_wire_without_a_profile_code_raises(
+        self, mock_transport: MockTransport
     ) -> None:
-        mock_transport.queue_response(_ack_response())
-        await radio._set_vfo_wire("B")
+        """No declared code means no frame — never a byte invented here.
 
-    @pytest.mark.asyncio
-    async def test_set_vfo_wire_main(
-        self, radio: IcomRadio, mock_transport: MockTransport
-    ) -> None:
-        mock_transport.queue_response(_ack_response())
-        await radio._set_vfo_wire("MAIN")
+        X6100 is an ``ab`` profile whose ``[vfo]`` section declares neither
+        ``main_select`` nor ``sub_select``.  The deleted table answered
+        ``"MAIN"`` with 0xD0 regardless, so a single-receiver rig got a
+        dual-receiver MAIN-select opcode.  That is the failure this
+        replaces; the table's 0x00 default was for names outside its four
+        keys, which is a different hole.
+        """
+        r = IcomRadio("192.168.1.100", timeout=0.05, model="X6100")
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        try:
+            with pytest.raises(CommandError, match="no VFO select code"):
+                await r._set_vfo_wire("MAIN")
+        finally:
+            r._connected = False
+        assert mock_transport.sent_packets == []
 
     @pytest.mark.asyncio
     async def test_set_vfo_wire_nak(


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-1986 (hardcode removal in `commands/`, continuing #2793 / #2796 / #2798)
- Compatibility impact: **API** (`rigplane.commands.set_vfo` signature) + **wire behavior** (no change on any reachable path — see below) + **docs** (CHANGELOG, API reference, parity matrix)

`commands/vfo.py: set_vfo` held `{"A": 0x00, "B": 0x01, "MAIN": 0xD0, "SUB": 0xD1}` and took a VFO name. That is rig-specific bytes inside a builder — listed under Forbidden Patterns in `commands/LAYER.md` — and a second implementation of a mapping the rig TOMLs declare as `[vfo] main_select` / `sub_select`. `web/radio_poller.py` reaches the same selection through `vfo_main_code` / `vfo_sub_code`; this table ignored the profile entirely. Four of the eight shipped profiles (X6100, X6200, TX-500, FTX-1) declare neither code, which the table papered over.

The builder now takes the byte. `runtime/radio.py: CoreRadio._set_vfo_wire` resolves it from the loaded profile — `"B"`/`"SUB"` take `vfo_sub_code`, anything else `vfo_main_code` — and raises `CommandError` when the profile declares none, instead of answering from a table that had a byte for every rig whether or not the rig had the receiver.

### Two commits, one unit of work — and the numbers

**10 files / 251 changed lines (196+ / 55−).** That is *at* the 10-file hard ceiling with zero headroom, and over the 6-file soft threshold. (An earlier revision of this body said 8 files / 216 lines; that was wrong and is corrected here.)

The two commits:

1. `ec5312e` adds `hardcode_only_builders` to the parity census — the counter for builders that carry no `cmd_map` branch at all, which the existing ratchet could not see.
2. `757d9ab` removes the VFO table and moves `frames_identical`. Its justification is a census delta, which only the ratchet in commit 1 makes assertable.

**Honest caveat:** the reviewer's judgement is that commit 1 is separable — `set_vfo` takes a `cmd_map` and so is not among the 49 that counter counts — and that it would have been a clean standalone PR. That is correct, and dropping it here would bring this to 8 files with real headroom. It is kept because both commits move the same census in service of the same ticket, and because the delta in commit 2 is only checkable against the counter in commit 1. If the owner prefers the split, say so and commit 1 goes to its own PR.

The remaining files are the blast radius of deleting five tests: two test files, the CHANGELOG, the API reference, and two parity docs that cited the deleted tests as evidence.

### What changes on the wire, and what does not

`_set_vfo_wire` is reachable in production only from:

| caller | guard |
|---|---|
| `select_receiver` | `if count <= 1: return` before the call |
| `swap_vfo_ab`, `equalize_vfo_ab` | call sits under `if receiver_count > 1` |
| `_run_with_receiver_vfo_fallback` | each of its **14** call sites guarded by `_require_receiver` (= `0 <= receiver < receiver_count`) or `receiver_count > 1` |
| `radio_state_snapshot.py: restore_state` | passes `_last_vfo`, written only by `_set_vfo_wire` itself and by `_civ_rx.py` under `sub07 == 0xD2` |

All of them pass `"MAIN"` or `"SUB"`, and only on a dual-RX profile. IC-7610 and IC-9700 declare `0xD0`/`0xD1` there, so **those frames are byte-identical**.

The combinations whose bytes change — `"MAIN"`/`"SUB"` against an `ab` profile, `"A"`/`"B"` against a `main_sub` one — are exactly the ones no caller produces. They were also the wrong bytes: the old table answered by name alone, so `"MAIN"` sent `0xD0` to an IC-7300 that has no MAIN receiver.

An FTX-1 profile reaching `CoreRadio` would now raise where it used to emit `0xD0`/`0xD1`. `backends/factory.py: create_radio` routes FTX-1 to `backends/yaesu_cat` only for a serial config; a LAN config builds an `IcomRadio` for any model. Nothing in code stops that pairing — what stops it is that an FTX-1 has no Icom LAN interface.

### Parity census

`frames_identical` 1349 → 1344. The harness probes one extra value for every parameter that has a default, so `vfo: str = "A"` yielded two cases per profile where `code: int` yields one, across the five profiles that declare `set_vfo` as a CI-V command (ic705, ic7300, ic7610, ic9700, x6200). The lost case tested nothing new: the harness passes `"TEST"`, which `dict.get` turned into `0x00` — the same frame as the default `"A"`. `frames_diverged` stays 76 and no allowlist row changed.

## Verification

- [x] Relevant local tests or checks run — `pytest tests/ --ignore=tests/integration -n auto`: **10634 passed**, 12 skipped, 47 xfailed, 1 xpassed, 0 failed. `ruff check` + `ruff format --check` clean. `lint-imports`: 5 contracts kept, 0 broken. `check-doc-citations.sh`: clean (847 grandfathered).
- [x] Public/open-core boundary checked — `commands/` still depends on `core` only; the profile lookup lives in `runtime/`, which may import `profiles`.
- [x] Release or migration impact documented if applicable — CHANGELOG under Unreleased → Breaking changes, with the call-site rewrite and the `int | None` trap spelled out; `docs/api/commands.md` §VFO updated to the new signature.

The new tests **parse** the emitted frame rather than searching the datagram. That is not cosmetic: the UDP control header ends `... 00 07 00 00 00` on every packet this transport sends, so a substring test for `07 00` passes whatever the payload. The first revision of this PR made exactly that mistake and left the two IC-7300 `0x00` cases unable to fail — caught by the reviewer with a mutation, not by inspection. Re-verified with the same mutation (force `_select_vfo_cmd` to always emit `0xD0`, the deleted table's answer for `"MAIN"`): **6 of 9 cases now fail**, including `[IC-7300-A-0]` and `[IC-7300-MAIN-0]`. The three that still pass are the IC-7610 rows whose expected byte *is* `0xD0` — indistinguishable from the mutation by construction, not a gap.

## Agent Review

- [x] Independent agent review comment posted before merge
- Reviewer: independent `verifier` subagent (opus), dispatched by the implementer; the implementer did not review its own work. The reviewer had no GitHub access in its session, so its verdict was relayed unedited by the implementer.
- Result: `Agent Review: BLOCKED 3edfa4b3ae57425cf2fefb8fc894d3bf282126e9` — all three blocking findings fixed at head `757d9abf27103c505eda3a1b85ffebdcdd20afdc`; a fresh review is running against that head.

Fixed since the BLOCKED verdict:

1. **Vacuous byte assertion** — `test_set_vfo_wire_sends_the_profile_code` now parses the CI-V frame and asserts `command` and `data`. Mutation-verified as above.
2. **False statement about the deleted code** — the docstring said the old table answered `0x00` for X6100; `codes.get("MAIN", 0x00)` in fact returned `0xD0`. The `0x00` default applied only to names outside the four keys. Corrected, and the old bug is now stated at its real severity.
3. **`docs/api/commands.md` §VFO** documented the removed `select_vfo(vfo: str = "A", ...)` signature. Updated.

Prose defects the reviewer flagged and this head corrects: "13 call sites" → 14 (the missed one, `_dual_rx_runtime.py: _set_vfo_slot_impl`, is the publicly reachable one); "every rig TOML already declares" → four of eight declare neither; the FTX-1 routing claim now says what actually holds; `docs/CHANGELOG.md` no longer claims "`IcomRadio` is unaffected" while describing a new `CommandError` in the same sentence; the migration snippet names the `int | None` trap.

## Notes

Out of scope / follow-ups:

- **The `in sent_packets[-1]` shape elsewhere.** The reviewer swept the class: `tests/test_radio.py` has five more instances (`b"\x13\x00"`, `b"\x13\x01"`, `b"\x13\x02"`, `b"\x1c\x02\x01"`, `b"\x1c\x02\x00"`). None collide with the header today, so they are sound — but the shape is latent and parsing is the class fix. Not touched here: this PR is at the file ceiling.
- **`docs/api/radio.md`** documents `async def select_vfo(self, vfo: str = "A")`, removed in v0.20 and asserted absent by `tests/test_radio_extended.py::TestVFO::test_select_vfo_alias_removed`. Pre-existing, unrelated to this diff.
- **The poller's 19 hand-assembled `self._civ(...)` sites**, 8 of them VFO selection in `SetFreq` / `SetMode`. They already read the code from the profile, so they are *not* a copy of the table this PR deletes — a separate concern (our own code not using our own abstraction), with its own PR and its own ratchet.
- The `cmd_map` branch is still never taken: no production caller passes a `cmd_map`, so the hardcoded branch is the only executing path in every builder. Wiring the map into the send path is the next step after the poller.
- `rigs/ic9700.toml` carries a block of IC-7300 sub-addresses (`civ_transceive`, `usb_mod_level`, `acc1_mod_level`, `data1_mod_input`, `data_off_mod_input`, `ref_adjust`) — latent today, live the moment the profile becomes the source of truth.
- `rigs/_schema.md` ("adding a new radio = one TOML file, zero Python changes") and `commands/LAYER.md` state opposite designs; neither is in force today.