### PR TITLE
fix: route poller VFO switch dance through CoreRadio/select_receiver

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -2285,32 +2285,41 @@ class RadioPoller:
                 self._last_user_write_ts = time.monotonic()
                 self._ensure_receiver_supported(rx, operation="set_freq")
                 current = self._current_active()
-                if rx != 0 and self._profile.supports_cmd29(0x05):
+                if rx != 0:
+                    # CoreRadio.set_freq already owns the cmd29-vs-VFO-switch
+                    # decision for a non-MAIN receiver (runtime/radio.py,
+                    # runtime/_dual_rx_runtime.py:
+                    # _run_with_receiver_vfo_fallback) — no need to
+                    # reimplement the switch dance here.
                     await radio.set_freq(freq, receiver=rx)
-                elif rx != 0:
-                    if (
-                        self._profile.vfo_sub_code is None
-                        or self._profile.vfo_main_code is None
-                    ):
-                        raise CommandError(
-                            f"set_freq receiver={rx} is unsupported by profile {self._profile.model}: "
-                            "no cmd29 route and no VFO switch codes"
-                        )
-                    if current != "SUB":
-                        await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))
-                        await asyncio.sleep(self._gap)
-                    await radio.set_freq(freq)
-                    if current != "SUB":
-                        await asyncio.sleep(self._gap)
-                        await self._civ(0x07, data=bytes([self._profile.vfo_main_code]))
                 else:
+                    # No lower-layer equivalent for a VFO-aware MAIN write:
+                    # CoreRadio.set_freq(freq, receiver=0) sends a blind,
+                    # VFO-unaware 0x05 regardless of which VFO is selected.
+                    # When SUB is active the poller must still switch to
+                    # MAIN, write, and switch back — routed through the
+                    # public select_receiver API instead of a hand-built
+                    # 0x07 CI-V frame.
+                    select_receiver = getattr(radio, "select_receiver", None)
                     if current != "MAIN" and self._profile.vfo_main_code is not None:
-                        await self._civ(0x07, data=bytes([self._profile.vfo_main_code]))
-                        await asyncio.sleep(self._gap)
+                        if select_receiver is not None:
+                            await select_receiver(0)
+                        else:
+                            logger.warning(
+                                "radio-poller: set_freq receiver=0 — backend "
+                                "lacks select_receiver; skipping "
+                                "restore-to-MAIN switch",
+                            )
                     await radio.set_freq(freq)
                     if current != "MAIN" and self._profile.vfo_sub_code is not None:
-                        await asyncio.sleep(self._gap)
-                        await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))
+                        if select_receiver is not None:
+                            await select_receiver(1)
+                        else:
+                            logger.warning(
+                                "radio-poller: set_freq receiver=0 — backend "
+                                "lacks select_receiver; skipping "
+                                "restore-to-SUB switch",
+                            )
                 # Compatibility mirror until web state delivery reads StateStore.
                 if self._radio_state:
                     target = (
@@ -2329,32 +2338,34 @@ class RadioPoller:
                         (FieldPath.active(str(rx), "freq_mode", "filter_width"),)
                     )
                 current = self._current_active()
-                if rx != 0 and self._profile.supports_cmd29(0x06):
+                if rx != 0:
+                    # See SetFreq above: CoreRadio.set_mode owns the same
+                    # cmd29-vs-VFO-switch decision for a non-MAIN receiver.
                     await radio.set_mode(mode, fw, receiver=rx)
-                elif rx != 0:
-                    if (
-                        self._profile.vfo_sub_code is None
-                        or self._profile.vfo_main_code is None
-                    ):
-                        raise CommandError(
-                            f"set_mode receiver={rx} is unsupported by profile {self._profile.model}: "
-                            "no cmd29 route and no VFO switch codes"
-                        )
-                    if current != "SUB":
-                        await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))
-                        await asyncio.sleep(self._gap)
-                    await radio.set_mode(mode, fw)
-                    if current != "SUB":
-                        await asyncio.sleep(self._gap)
-                        await self._civ(0x07, data=bytes([self._profile.vfo_main_code]))
                 else:
+                    # See SetFreq above: no lower-layer VFO-aware MAIN write
+                    # exists, so the poller still owns the switch-and-restore
+                    # dance here, routed through select_receiver.
+                    select_receiver = getattr(radio, "select_receiver", None)
                     if current != "MAIN" and self._profile.vfo_main_code is not None:
-                        await self._civ(0x07, data=bytes([self._profile.vfo_main_code]))
-                        await asyncio.sleep(self._gap)
+                        if select_receiver is not None:
+                            await select_receiver(0)
+                        else:
+                            logger.warning(
+                                "radio-poller: set_mode receiver=0 — backend "
+                                "lacks select_receiver; skipping "
+                                "restore-to-MAIN switch",
+                            )
                     await radio.set_mode(mode, fw)
                     if current != "MAIN" and self._profile.vfo_sub_code is not None:
-                        await asyncio.sleep(self._gap)
-                        await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))
+                        if select_receiver is not None:
+                            await select_receiver(1)
+                        else:
+                            logger.warning(
+                                "radio-poller: set_mode receiver=0 — backend "
+                                "lacks select_receiver; skipping "
+                                "restore-to-SUB switch",
+                            )
                 # Compatibility mirror until web state delivery reads StateStore.
                 if self._radio_state:
                     target = (

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import call as mock_call
 
 import pytest
 
@@ -39,6 +40,11 @@ def _make_radio(*, model: str = "IC-7610", active: str = "MAIN") -> MagicMock:
     radio.send_civ = AsyncMock()
     radio.set_freq = AsyncMock()
     radio.set_mode = AsyncMock()
+    # The receiver=0-while-SUB-active branch restores MAIN via the public
+    # select_receiver API (not a hand-built 0x07 CI-V frame); a bare
+    # MagicMock attribute is not awaitable, so tests reaching that path
+    # raise TypeError without this.
+    radio.select_receiver = AsyncMock()
     return radio
 
 
@@ -110,25 +116,27 @@ async def test_state_query_sends_fire_and_forget() -> None:
 
 @pytest.mark.asyncio
 async def test_user_command_stays_normal_priority() -> None:
-    """KEY GUARD: a user command's CI-V sends (including the in-command VFO
-    switch) must NOT be de-prioritized to BACKGROUND, and must NEVER be made
-    fire-and-forget (``wait_dispatch`` must stay blocking)."""
-    # active="SUB" so SetFreq(receiver=0) triggers the in-command VFO switch
-    # (_civ(0x07, vfo_main_code)) at radio_poller.py and its restore.
+    """KEY GUARD: a user command's CI-V sends must NOT be de-prioritized to
+    BACKGROUND, and must NEVER be made fire-and-forget (``wait_dispatch``
+    must stay blocking).
+
+    The receiver=0-while-SUB-active in-command VFO switch now goes through
+    ``radio.select_receiver`` (a public API with no priority/wait_dispatch
+    parameters of its own) instead of a hand-built ``_civ(0x07, ...)``
+    frame, so this guard checks the ``select_receiver`` calls the poller
+    makes rather than a raw ``send_civ``. The CI-V frame ``select_receiver``
+    itself emits still defaults to ``Priority.NORMAL`` / blocking dispatch —
+    that guarantee now lives in ``CoreRadio._send_civ_raw`` /
+    ``_send_civ_expect`` (runtime/radio.py), outside what a bare
+    poller-level mock can observe.
+    """
+    # active="SUB" so SetFreq(receiver=0) triggers the in-command
+    # select_receiver(MAIN) switch and its select_receiver(SUB) restore.
     radio = _make_radio(active="SUB")
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
     await poller._execute(SetFreq(14_074_000, receiver=0))  # noqa: SLF001
 
-    # The VFO switch + restore fire via send_civ; none may be BACKGROUND, and
-    # NONE may be fire-and-forget — user commands stay blocking/awaited.
-    assert radio.send_civ.await_count >= 1
-    for call in radio.send_civ.await_args_list:
-        prio = _priority_of(call)
-        assert prio in (None, Priority.NORMAL), (
-            f"user command send_civ used {prio!r}, must not be BACKGROUND"
-        )
-        wd = _wait_dispatch_of(call)
-        assert wd in (None, True), (
-            f"user command send_civ used wait_dispatch={wd!r}, must not be False"
-        )
+    assert radio.select_receiver.await_args_list == [mock_call(0), mock_call(1)]
+    radio.set_freq.assert_awaited_once_with(14_074_000)
+    radio.send_civ.assert_not_awaited()

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -2,8 +2,17 @@
 commands are never de-prioritized on the shared CI-V lane.
 
 Deterministic priority assertions (not timing): every poll send-site must
-pass ``priority=Priority.BACKGROUND`` to ``radio.send_civ``, while user
-commands routed through ``_execute`` must stay at the NORMAL default.
+pass ``priority=Priority.BACKGROUND`` to ``radio.send_civ``. The user-command
+side of the MOR-497(i)/(ii) guarantee (NORMAL priority, blocking dispatch)
+used to be checkable here too, back when the poller built the VFO-switch
+CI-V frame itself. Since that switch now goes through the public
+``radio.select_receiver`` API (no priority/wait_dispatch parameters of its
+own), a poller-level mock can no longer observe what priority the frame
+goes out at — this file only checks that ``_execute`` routes to
+``select_receiver`` instead of a raw ``send_civ`` call. The actual
+NORMAL/blocking pin now lives one layer down, in
+``tests/test_radio_coverage.py::test_select_receiver_vfo_switch_stays_normal_priority_and_blocking``,
+which drives ``CoreRadio.select_receiver`` against a mocked commander.
 """
 
 from __future__ import annotations
@@ -115,20 +124,21 @@ async def test_state_query_sends_fire_and_forget() -> None:
 
 
 @pytest.mark.asyncio
-async def test_user_command_stays_normal_priority() -> None:
-    """KEY GUARD: a user command's CI-V sends must NOT be de-prioritized to
-    BACKGROUND, and must NEVER be made fire-and-forget (``wait_dispatch``
-    must stay blocking).
-
-    The receiver=0-while-SUB-active in-command VFO switch now goes through
+async def test_user_command_vfo_switch_routes_through_select_receiver() -> None:
+    """The receiver=0-while-SUB-active in-command VFO switch goes through
     ``radio.select_receiver`` (a public API with no priority/wait_dispatch
     parameters of its own) instead of a hand-built ``_civ(0x07, ...)``
-    frame, so this guard checks the ``select_receiver`` calls the poller
-    makes rather than a raw ``send_civ``. The CI-V frame ``select_receiver``
-    itself emits still defaults to ``Priority.NORMAL`` / blocking dispatch —
-    that guarantee now lives in ``CoreRadio._send_civ_raw`` /
-    ``_send_civ_expect`` (runtime/radio.py), outside what a bare
-    poller-level mock can observe.
+    frame — this checks the ``select_receiver`` calls the poller makes and
+    that no raw ``send_civ`` is used for this path.
+
+    This does NOT check what priority or dispatch mode the CI-V frame
+    ``select_receiver`` emits under the hood — a bare poller-level mock
+    replaces ``select_receiver`` entirely, so it cannot observe that. The
+    MOR-497(i)/(ii) NORMAL-priority/blocking-dispatch guarantee for that
+    frame is pinned at
+    ``tests/test_radio_coverage.py::test_select_receiver_vfo_switch_stays_normal_priority_and_blocking``
+    instead, against a real ``CoreRadio.select_receiver`` and a mocked
+    commander.
     """
     # active="SUB" so SetFreq(receiver=0) triggers the in-command
     # select_receiver(MAIN) switch and its select_receiver(SUB) restore.

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from rigplane import IcomRadio
-from rigplane.commands.commander import Priority
 from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.rigctld.state_cache import StateCache
+from rigplane.web import radio_poller as radio_poller_module
 from rigplane.web.handlers import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetFreq, SetMode
 
@@ -31,6 +33,11 @@ def _dual_radio_mock() -> MagicMock:
     radio.send_civ = AsyncMock()
     radio.set_freq = AsyncMock()
     radio.set_mode = AsyncMock()
+    # The receiver=0-while-SUB-active branch restores MAIN via the public
+    # select_receiver API (not a hand-built 0x07 CI-V frame); a bare
+    # MagicMock attribute is not awaitable, so tests reaching that path
+    # raise TypeError without this.
+    radio.select_receiver = AsyncMock()
     return radio
 
 
@@ -63,13 +70,20 @@ async def test_single_profile_receiver_guard_is_explicit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dual_profile_poller_routes_sub_freq_via_vfo_switch() -> None:
+async def test_dual_profile_poller_delegates_sub_freq_to_core_radio() -> None:
+    """receiver=1 (SUB) no longer gets a hand-rolled VFO switch in the poller.
+
+    ``CoreRadio.set_freq`` already owns the cmd29-vs-VFO-switch decision for
+    a non-MAIN receiver (runtime/radio.py), so the poller must pass the
+    receiver through unconditionally and never touch ``send_civ`` itself.
+    """
     radio = _dual_radio_mock()
     poller = RadioPoller(radio, StateCache(), CommandQueue())
     await poller._execute(SetFreq(14_074_000, receiver=1))  # noqa: SLF001
 
-    assert radio.send_civ.await_count >= 2
-    radio.set_freq.assert_awaited_once_with(14_074_000)
+    radio.set_freq.assert_awaited_once_with(14_074_000, receiver=1)
+    radio.send_civ.assert_not_awaited()
+    radio.select_receiver.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -105,34 +119,76 @@ async def test_control_handler_checks_capabilities_not_model_name() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dual_profile_poller_routes_main_mode_via_vfo_switch_when_active_sub() -> (
+async def test_dual_profile_poller_routes_main_mode_via_select_receiver_when_active_sub() -> (
     None
 ):
+    """receiver=0 (MAIN) while SUB is active still gets a switch-and-restore.
+
+    There is no lower-layer equivalent for a VFO-aware MAIN write, so the
+    poller keeps this dance — but it must go through the public
+    ``select_receiver`` API instead of building the raw 0x07 CI-V frame
+    itself, and in the right order: MAIN before the write, SUB after.
+    """
     radio = _dual_radio_mock()
     radio._radio_state.active = "SUB"
+    calls: list[str] = []
+    radio.select_receiver = AsyncMock(
+        side_effect=lambda which: calls.append(f"select_receiver({which})")
+    )
+    radio.set_mode = AsyncMock(side_effect=lambda *a, **k: calls.append("set_mode"))
     poller = RadioPoller(radio, StateCache(), CommandQueue())
 
     await poller._execute(SetMode("USB", receiver=0))  # noqa: SLF001
 
-    main_code = bytes([radio.profile.vfo_main_code])
-    sub_code = bytes([radio.profile.vfo_sub_code])
-    # User-command VFO switch stays at NORMAL priority (MOR-497i: only
-    # background polls are demoted to BACKGROUND) and blocking
-    # (MOR-497ii: wait_dispatch=True, never fire-and-forget).
-    radio.send_civ.assert_any_await(
-        0x07,
-        sub=None,
-        data=main_code,
-        wait_response=False,
-        priority=Priority.NORMAL,
-        wait_dispatch=True,
-    )
-    radio.send_civ.assert_any_await(
-        0x07,
-        sub=None,
-        data=sub_code,
-        wait_response=False,
-        priority=Priority.NORMAL,
-        wait_dispatch=True,
-    )
+    assert calls == ["select_receiver(0)", "set_mode", "select_receiver(1)"]
     radio.set_mode.assert_awaited_once_with("USB", None)
+    radio.send_civ.assert_not_awaited()
+
+
+def _count_self_civ_call_sites() -> int:
+    """Count ``self._civ(...)`` call sites in ``radio_poller.py`` via ``ast``.
+
+    Walking the parsed AST for ``Call`` nodes whose function is the
+    attribute ``_civ`` on a ``Name`` node ``self`` means a comment or a
+    string that happens to contain the same text cannot inflate the count
+    the way a regex scan could.
+    """
+    source = inspect.getsource(radio_poller_module)
+    tree = ast.parse(source)
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "_civ"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "self"
+        ):
+            count += 1
+    return count
+
+
+def test_radio_poller_raw_civ_call_count_is_pinned() -> None:
+    """Ratchet: exactly 11 raw ``self._civ(...)`` sites remain.
+
+    The 8 hand-rolled ``self._civ(0x07, ...)`` VFO-switch frames that used
+    to live in ``SetFreq``/``SetMode`` (the ``receiver!=0`` fallback dance
+    and the ``receiver=0``-while-SUB-active restore dance) were removed:
+    the former now delegates to ``CoreRadio.set_freq``/``set_mode``, which
+    already owns that decision; the latter now calls the public
+    ``select_receiver`` API instead of building the raw frame itself. The
+    11 that remain:
+
+    - ``_send_cmd``: 2 — cmd29-wrapped vs. plain generic command dispatch.
+    - ``_send_one_state_query``: 5 — selected/unselected freq/mode state
+      reads plus the scope-receiver default read.
+    - ``_execute``: 3 — the BSR band-switch stored-freq read, ``SelectVfo``'s
+      scope-follow (0x27 0x12), and ``SwitchScopeReceiver`` (0x27 0x12).
+    - ``_send_query``: 1 — the meter poll read.
+
+    Changing this literal deliberately means recounting the real call
+    sites above, not just editing the number.
+    """
+    assert _count_self_civ_call_sites() == 11

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -2300,6 +2300,46 @@ async def test_run_state_transaction_uses_commander_when_available(
 
 
 # ---------------------------------------------------------------------------
+# select_receiver / _set_vfo_wire — priority + dispatch pin (PR #2803 review)
+# ---------------------------------------------------------------------------
+
+
+async def test_select_receiver_vfo_switch_stays_normal_priority_and_blocking(
+    radio: IcomRadio,
+) -> None:
+    """MOR-497(i)/(ii) KEY GUARD, pinned at the layer that now owns it.
+
+    ``RadioPoller``'s user-command paths (``SetFreq``/``SetMode`` with
+    receiver=0 while SUB is active) switch VFOs via the public
+    ``radio.select_receiver`` API rather than a hand-built CI-V frame, so
+    that frame's priority and dispatch mode are no longer observable from a
+    poller-level mock (see
+    ``tests/test_poller_poll_priority.py::test_user_command_vfo_switch_routes_through_select_receiver``).
+    ``select_receiver`` reaches the wire through ``_set_vfo_wire`` →
+    ``_send_civ_expect`` → ``_send_civ_raw`` → ``CivRuntime.send_civ_raw`` →
+    ``commander.send`` (runtime/radio.py, runtime/_civ_rx.py), and none of
+    those hops pass an explicit ``priority`` or ``wait_dispatch`` override,
+    so this asserts the ``Priority.NORMAL`` / ``wait_dispatch=True``
+    defaults actually reach the commander: a user-command VFO switch must
+    never be de-prioritized to BACKGROUND or made fire-and-forget.
+    """
+    from rigplane.commander import IcomCommander, Priority
+    from rigplane.core.types import CivFrame
+
+    ack = CivFrame(to_addr=CONTROLLER_ADDR, from_addr=IC_7610_ADDR, command=0xFB)
+    mock_commander = MagicMock(spec=IcomCommander)
+    mock_commander.send = AsyncMock(return_value=ack)
+    radio._commander = mock_commander
+
+    await radio.select_receiver(1)  # IC-7610 (fixture default) is dual-RX.
+
+    mock_commander.send.assert_awaited_once()
+    _, kwargs = mock_commander.send.await_args
+    assert kwargs["priority"] == Priority.NORMAL
+    assert kwargs["wait_dispatch"] is True
+
+
+# ---------------------------------------------------------------------------
 # scope_stream — task_done (lines 1688-1689)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1738,18 +1738,24 @@ async def test_current_active_defaults_and_setfreq_setmode_branches() -> None:
     assert poller._current_active() == "MAIN"  # noqa: SLF001
 
     radio._radio_state.active = "MAIN"
+    # receiver=1 (SUB) delegates straight to CoreRadio.set_freq, which owns
+    # the cmd29-vs-VFO-switch decision itself — the poller no longer touches
+    # send_civ for this branch.
     await poller._execute(SetFreq(14_074_000, receiver=1))  # noqa: SLF001
-    assert radio.send_civ.await_count >= 2
-    radio.set_freq.assert_awaited_once_with(14_074_000)
+    radio.set_freq.assert_awaited_once_with(14_074_000, receiver=1)
+    radio.send_civ.assert_not_awaited()
 
     radio2 = _make_radio(active="SUB")
     poller2 = RadioPoller(radio2, StateCache(), CommandQueue())
+    # receiver=0 (MAIN) while SUB is active still switches-and-restores in
+    # the poller, via select_receiver (whose fixture side effect below
+    # threads through to send_civ).
     await poller2._execute(SetFreq(7_074_000, receiver=0))  # noqa: SLF001
     assert radio2.send_civ.await_count >= 2
     radio2.set_freq.assert_awaited_once_with(7_074_000)
 
     await poller._execute(SetMode("USB", filter_width=2, receiver=1))  # noqa: SLF001
-    radio.set_mode.assert_awaited_once_with("USB", 2)
+    radio.set_mode.assert_awaited_once_with("USB", 2, receiver=1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1748,10 +1748,21 @@ async def test_current_active_defaults_and_setfreq_setmode_branches() -> None:
     radio2 = _make_radio(active="SUB")
     poller2 = RadioPoller(radio2, StateCache(), CommandQueue())
     # receiver=0 (MAIN) while SUB is active still switches-and-restores in
-    # the poller, via select_receiver (whose fixture side effect below
-    # threads through to send_civ).
+    # the poller, via select_receiver — and in the right order: MAIN before
+    # the write, SUB after. select_receiver/set_freq are re-mocked here (own
+    # side effects, not the fixture's) so the interleaved `order` list below
+    # can pin that sequence, mirroring the SetMode ordering pin in
+    # test_profiles_routing.py::test_dual_profile_poller_routes_main_mode_via_select_receiver_when_active_sub;
+    # that test's freq counterpart was the one direction left unpinned for
+    # this ordering (PR #2803 review).
+    order: list[str] = []
+    radio2.select_receiver = AsyncMock(
+        side_effect=lambda which: order.append(f"select_receiver({which})")
+    )
+    radio2.set_freq = AsyncMock(side_effect=lambda *a, **k: order.append("set_freq"))
     await poller2._execute(SetFreq(7_074_000, receiver=0))  # noqa: SLF001
-    assert radio2.send_civ.await_count >= 2
+    assert order == ["select_receiver(0)", "set_freq", "select_receiver(1)"]
+    radio2.set_freq.assert_awaited_once_with(7_074_000)
     radio2.set_freq.assert_awaited_once_with(7_074_000)
 
     await poller._execute(SetMode("USB", filter_width=2, receiver=1))  # noqa: SLF001


### PR DESCRIPTION
## Summary

`RadioPoller._execute`'s `SetFreq`/`SetMode` arms had 8 raw CI-V `0x07`
VFO-switch call sites (`self._civ(0x07, data=bytes([...vfo_code]))`), split
across four blocks: `SetFreq`'s `rx != 0` fallback and `rx == 0` restore, and
the identical pair in `SetMode`. These were two different defects wearing the
same clothes, and got two different fixes.

### Half A — the `rx != 0` branches (4 sites): deleted, not translated

`CoreRadio.set_freq`/`set_mode` (runtime/radio.py) already own the
cmd29-vs-VFO-switch decision for a non-MAIN receiver — the same decision the
poller was reimplementing by hand. The `if rx != 0 and supports_cmd29(...): ...
elif rx != 0: <hand-rolled switch>` structure collapses to an unconditional
`await radio.set_freq(freq, receiver=rx)` / `await radio.set_mode(mode, fw,
receiver=rx)`.

**Two things verified rather than assumed:**

- **Inter-command gap (investigated, not an open question).** The poller
  inserted `await asyncio.sleep(self._gap)` (12ms LAN / 50ms serial) between
  the switch, the write, and the switch back — all three frames were
  fire-and-forget (`wait_response=False`). `CoreRadio._run_with_receiver_vfo_fallback`
  (runtime/_dual_rx_runtime.py) adds no sleep of its own: its two VFO
  switches go through `_set_vfo_wire` → `_send_civ_expect`, which blocks on
  an ACK response instead, and the write remains fire-and-forget. This is
  safe because pacing was never the poller's alone to provide: every one of
  these frames goes through `commands/commander.py: IcomCommander._loop`,
  which already enforces a `min_interval` floor before each send — 35ms on
  LAN (`ICOM_CIV_MIN_INTERVAL_MS`, `runtime/radio.py`) and 50ms on serial
  (`_SERIAL_DEFAULT_CIV_MIN_INTERVAL_MS`, `backends/_icom_serial_base.py`).
  The removed `self._gap` stacked *on top of* that floor; it was never the
  only pacing in effect. Command-queue pacing is the core's job and is
  already tuned there, so nothing in this PR needed to compensate for
  removing the poller's own copy of it.
- **Error message.** The poller used to raise its own `CommandError` when
  `vfo_sub_code`/`vfo_main_code` were both required and either was `None`,
  regardless of which switch direction actually needed it. Now
  `_run_with_receiver_vfo_fallback` raises (same `CommandError` class —
  `rigplane.exceptions` is a `sys.modules`-aliased re-export of
  `rigplane.core.exceptions`) but only when the code needed for the actual
  switch direction is missing, with text `"{operation} receiver={receiver} is
  unsupported for profile {model}: no {SUB|MAIN} VFO select code"`. No test
  asserted the old exact wording, so nothing needed updating, but this is a
  (narrower, more precise) behavior change worth flagging.

### Half B — the `rx == 0` branches (4 sites): routed through `select_receiver`

No lower-layer equivalent exists for this direction: `CoreRadio.set_freq(freq,
receiver=0)` sends a blind, VFO-unaware `0x05` regardless of which VFO is
selected. So when SUB is active, the poller still owns the
switch-to-MAIN/write/switch-back-to-SUB dance — but now calls the public
`radio.select_receiver(0)` / `select_receiver(1)` API instead of building the
`0x07` frame itself (confirmed `select_receiver(0)` → MAIN, `select_receiver(1)`
→ SUB in runtime/_dual_rx_runtime.py). The existing `vfo_main_code is not
None` / `vfo_sub_code is not None` guards are kept unchanged.

**Correction (review, not the same shape as `SelectVfo`):** an earlier
version of this description said the new sites are guarded "the same
`getattr` + warn-and-skip shape as the existing `SelectVfo` site." That is
only half true — both use `getattr(radio, "select_receiver", None)` to check
for the method, but they diverge on what happens when it's missing.
`SelectVfo` falls back to the legacy `set_vfo` API and, only if that is also
absent, warns and **returns** — the command is abandoned. The new
`SetFreq`/`SetMode` sites have no such fallback: after warning, they **fall
through to the write** on whatever VFO is currently active, with no restore.
This divergence is deliberate rather than a gap to close: this repository
does not add fallback/handling for failures that cannot occur in this
deployment (CLAUDE.md, "Reachable errors only"), and the missing-method
branch cannot occur here. `RadioPoller` is constructed at exactly one call
site (`web/web_startup.py`), on the branch reserved for `CoreRadio`-derived
Icom CI-V backends, and every one of those has `select_receiver`. So the
branch is dead in production today. `tests/serial_stub.py: SerialMockRadio`
is exactly that shape in-tree (`send_civ` + legacy `set_vfo`, no
`select_receiver`), which is how the reviewer could exercise the branch at
all — but nothing constructs a `RadioPoller` around it.

### Net result

8 of the 19 `self._civ(...)` call sites in `radio_poller.py` are gone; the
remaining 11 are pinned by a new AST-based ratchet test
(`test_radio_poller_raw_civ_call_count_is_pinned` in
`tests/test_profiles_routing.py`) that walks the parsed source for `Call`
nodes shaped `self._civ(...)`, so a comment or string containing the same
text can't inflate the count. To change the pinned literal deliberately,
recount the real call sites the test's docstring lists (`_send_cmd`: 2,
`_send_one_state_query`: 5, `_execute`: 3, `_send_query`: 1).

## Test changes

- `tests/test_profiles_routing.py`: `_dual_radio_mock` now wires
  `select_receiver` as an `AsyncMock` (a bare `MagicMock` attribute isn't
  awaitable). Rewrote the two tests whose assertions pinned the old
  `send_civ`-based switch shape to assert on the new call shape instead
  (`test_dual_profile_poller_delegates_sub_freq_to_core_radio`,
  `test_dual_profile_poller_routes_main_mode_via_select_receiver_when_active_sub`).
  Added the ratchet test.
- `tests/test_poller_poll_priority.py`: same `select_receiver`-missing
  fixture gap found and fixed in `_make_radio` (it wasn't the fixture named
  in the original task, but it's the same crash shape reachable by the same
  8 sites this PR touches, and it would have failed the required full-suite
  gate). Renamed `test_user_command_stays_normal_priority` to
  `test_user_command_vfo_switch_routes_through_select_receiver` and trimmed
  its docstring — it checks routing (the poller calls `select_receiver`, not
  raw `send_civ`), not priority; a bare poller-level mock can't observe what
  priority the frame goes out at once the switch moves to `select_receiver`.
  See "Review follow-up" below for where that guarantee is actually pinned
  now.
- `tests/test_radio_poller_coverage.py`: updated two assertions in
  `test_current_active_defaults_and_setfreq_setmode_branches` for the new
  `set_freq(freq, receiver=rx)` / `set_mode(mode, fw, receiver=rx)` call
  signature on the `rx != 0` path (its `_make_radio` already wired
  `select_receiver` correctly, so only the assertions needed updating).

Swept the whole test suite for every `poller._execute(SetFreq|SetMode` call
site (4 files total: the two above plus these two, which needed no changes
because they only exercise `receiver=0` while MAIN is already active, so no
switch code path is reached): `tests/test_selected_freq_mode.py`.

## Review follow-up (independent review, PR #2803)

An independent reviewer BLOCKED this PR on two findings; both are fixed:

- **The MOR-497(i)/(ii) priority/dispatch guarantee lost its pin.** After
  the rewrite, `test_user_command_stays_normal_priority`'s docstring still
  promised "must NOT be de-prioritized … must NEVER be made fire-and-forget"
  while its body only checked `select_receiver` call routing — nothing in
  the tree actually failed if the VFO-switch frame were sent at
  `Priority.BACKGROUND`. Proven by mutation: forcing
  `CoreRadio._set_vfo_wire` to pass `priority=Priority.BACKGROUND` left the
  full suite green. Fixed by adding
  `tests/test_radio_coverage.py::test_select_receiver_vfo_switch_stays_normal_priority_and_blocking`,
  which drives `CoreRadio.select_receiver` (the poller's own call) against a
  mocked `commander` and asserts `priority=Priority.NORMAL` /
  `wait_dispatch=True` reach it — the layer that now actually owns the
  guarantee. Confirmed this test goes red under the same mutation and green
  once reverted. The old poller-level test was renamed and its docstring
  corrected to describe only what it checks (routing), with a pointer to
  the new test for the priority guarantee.
- **The prose describing the missing-`select_receiver` guard was wrong.**
  See the correction inline in "Half B" above — the new sites do not share
  `SelectVfo`'s fallback-then-refuse behavior; they fall through to the
  write with no restore. Judged unreachable in production (single
  `RadioPoller` construction site, always a `CoreRadio` backend), so no
  fallback was added — only the description was corrected.
- **Non-blocking: `SetFreq`'s switch-away/write ordering was unpinned**
  while `SetMode`'s was (an interleaved `calls` list in
  `test_profiles_routing.py`). Closed with the same pattern in
  `tests/test_radio_poller_coverage.py::test_current_active_defaults_and_setfreq_setmode_branches`
  (an `order` list asserting `select_receiver(0)`, `set_freq`,
  `select_receiver(1)` in sequence). Confirmed by mutation (moving the write
  above the switch-away) that the new assertion goes red and passes clean on
  revert.
- **The inter-command-gap "open question" is settled** — see the corrected
  "Half A" paragraph above; `IcomCommander._loop`'s `min_interval` floor
  (35ms LAN / 50ms serial) was already the pacing in effect underneath the
  poller's own `self._gap`, so removing the poller's copy changes nothing
  about command-queue pacing.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — 10636 passed, 1 failed, 12 skipped, 47 xfailed, 1 xpassed. The 1 failure (`tests/test_radio_coverage.py::test_enable_scope_strict_sends_and_acks`) is a pre-existing, host-local environmental failure — the independent reviewer reproduced it identically on a clean extract of base `c7eb43b3` and confirmed CI `quick` is green on both; not caused by this PR.
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — all files already formatted
- [x] `uv run lint-imports` — 5 kept, 0 broken
- [x] `uv run mypy --strict src/rigplane/web` — success, no issues in 26 source files
- [x] Mutation-kill proof for both review-follow-up test fixes (see above): each fails under the corresponding injected defect and passes clean once reverted, confirmed with `PYTHONDONTWRITEBYTECODE=1` to avoid stale-bytecode false kills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
