### PR TITLE
docs: add the auditor role and the mechanism-audit skill to the stale lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,14 +201,19 @@ implementation agent never reviews its own work (Language & Git above).
 Subagent roles with pinned models live in `.claude/agents/`: `scout` (haiku,
 read-only status/fact collection), `builder` (sonnet, implementation from a
 spec), `verifier` (opus, independent review and gate verdicts), `researcher`
-(sonnet, read-only exploration with synthesis). Dispatch through these roles
-by default; a dispatch outside them must pass an explicit model — never let a
-subagent silently inherit the root session's model.
+(sonnet, read-only exploration with synthesis), `auditor` (opus, read-only
+adjudication of audits — mechanism duplication, displacement across layer
+boundaries, dead code — deciding between competing explanations of one observed
+fact rather than collecting facts, which is why it is pinned above `researcher`;
+it reads its method from `.claude/skills/mechanism-audit/SKILL.md` and refuses
+to run when it can neither read that file nor be handed a method inline).
+Dispatch through these roles by default; a dispatch outside them must pass an
+explicit model — never let a subagent silently inherit the root session's model.
 
 Slash commands for scoped workflows live in `.claude/commands/` (`audit-ui`,
 `decompose-issue`, `generate-tests`, `next`, `refactor`, `regression-check`,
-`scan-issues`, `solve-issue`) plus the `release` skill in `.claude/skills/`;
-each file is self-documenting.
+`scan-issues`, `solve-issue`) plus the `release` and `mechanism-audit` skills
+in `.claude/skills/`; each file is self-documenting.
 
 ### The pipeline
 


### PR DESCRIPTION
## What

Commit `3ba1a14a` (#2801) added `.claude/agents/auditor.md` and
`.claude/skills/mechanism-audit/SKILL.md`, but left untouched the paragraph in
`CLAUDE.md` § "Agent working rules" that enumerates the pinned subagent roles
and names what lives in `.claude/skills/`. Both lists have been incomplete since
that merge. This adds the missing entries; it does not restructure the section.

## Verification

Every clause about `auditor` was checked against `.claude/agents/auditor.md` at
`origin/main` rather than paraphrased from the request:

| Claim in the new text | Source in `auditor.md` |
|---|---|
| pinned to opus | frontmatter `model: opus` |
| read-only | `tools: Bash, Read, Grep, Glob` plus the "Read-only, absolutely" section |
| adjudicates duplication, displacement across layer boundaries, dead code | frontmatter `description` |
| decides between competing explanations rather than collecting facts | frontmatter `description`; "Never accept a hypothesis as a premise" |
| reads its method from `.claude/skills/mechanism-audit/SKILL.md` | "Read the method first, or stop" |
| refuses with neither that file nor an inline method | same section: stop unless the dispatch carries a method inline |

`researcher` is `model: sonnet`, so "pinned above `researcher`" holds. The
skills directory contains exactly `mechanism-audit` and `release`.

## Scope

One file, 10 insertions / 5 deletions, Markdown only — no code paths touched, so
the diff itself is the verification. The paragraph's existing wording and the
surrounding section are unchanged apart from reflowing the two edited sentences.

Guardrails: well inside both the soft threshold (6 files · 600 lines) and the
hard ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
