### PR TITLE
docs: cite file:symbol in audit-ui, not file:line

### DIFF
--- a/.claude/commands/audit-ui.md
+++ b/.claude/commands/audit-ui.md
@@ -73,7 +73,7 @@ Write to `.claude/workflow/audit-findings.md`:
 ### Finding F1: <title>
 - **Type:** UI | logic | integration | quality
 - **Severity:** low | medium | high
-- **File:** path:line
+- **File:** path plus symbol name (`AmberFrequency.svelte: formatFreq`); for markup or styling, the component plus the element or selector it concerns
 - **Description:** what's wrong
 - **Reproduction:** how to trigger
 - **Confidence:** high | medium
@@ -115,7 +115,8 @@ gh issue create --title "[LCD] <short description>" --body "$(cat <<'EOF'
 
 ## Location
 
-<file:line references>
+<file plus symbol name (`control.py: ControlHandler._send_hello`); for markup or
+styling, the component plus the element or selector it concerns>
 
 ## Suspected cause
 
@@ -149,5 +150,13 @@ Label mapping:
 - Do NOT fix any issues found
 - Do NOT create issues for things that are clearly intentional design choices
 - Do NOT create duplicate issues — check existing issues first
-- Every issue must reference specific file:line locations
+- Every issue must cite specific locations, as the file and the **symbol name**
+  (`control.py: ControlHandler._send_hello`), matching this repository's
+  convention: line numbers rot silently, so citations use symbols instead.
+  Frontend findings often concern markup or styling with no enclosing symbol —
+  there the unit is the component plus the element, class or selector
+  (`AmberFrequency.svelte: .freq-ghost`), which is what a reader searches for
+  anyway. Fall back to `file:line` only where a finding is about a line with
+  neither — a guard, a constant, one table entry — and then say what stands
+  there, so the citation survives the line moving.
 - Every issue must be actionable (clear what needs to change)


### PR DESCRIPTION
## Problem

`.claude/commands/audit-ui.md` was the last file under `.claude/` still telling
agents to cite code as `file:line`. It carried three such instructions:

- the findings-template `- **File:** path:line` field,
- the `gh issue create` body placeholder `<file:line references>`,
- the closing rule "Every issue must reference specific file:line locations".

`.claude/agents/auditor.md`, `researcher.md`, `scout.md` and
`.claude/skills/mechanism-audit/SKILL.md` are already on the file-plus-symbol
convention; `audit-ui.md` was deliberately left out of #2802 to keep that PR's
scope tight.

## Change

All three converted, reusing the wording already in `auditor.md` rather than a
new phrasing: the same "line numbers rot silently, so citations use symbols
instead" reason, and the same escape hatch — `file:line` only for a finding
about a line with no enclosing symbol, and then say what stands there so the
citation survives the line moving.

One adaptation this file needs and the others do not: UI findings frequently
concern markup or styling, which has no enclosing symbol. Applying the rule
verbatim would send most frontend findings straight down the escape hatch and
leave the convention unenforced exactly where the audit does most of its work.
So the rule names the honest unit for that case — the component plus the
element, class or selector (`AmberFrequency.svelte: .freq-ghost`) — and the
`file:line` fallback is reserved for a line with neither a symbol nor a
selector.

Examples are grounded in the tree rather than invented, so the instruction does
not model a citation a reader would fail to find:
`AmberFrequency.svelte: formatFreq` and `.freq-ghost` exist in
`frontend/src/components-v2/panels/lcd/AmberFrequency.svelte`;
`ControlHandler._send_hello` exists in `src/rigplane/web/handlers/control.py`.

## Verification

Markdown-only change to a single file, so verification is diff scope rather than
the test suite:

- `git diff --stat` → `.claude/commands/audit-ui.md | 15 +++++++++---`, one file
  changed, 12 insertions, 3 deletions.
- `git diff --name-only | grep -cv '\.md$'` → `0`; no source or test file is
  touched, and no `docs/**` file is touched, so the doc-citation gate's scope is
  unaffected.
- `grep -rn 'file:line\|path:line' .claude/` now returns only intentional
  occurrences: the escape hatches in `auditor.md`, `mechanism-audit/SKILL.md`
  and this file, plus `verifier.md`, where the file itself records `file:line`
  as correct for BLOCKED verdicts.

Guardrails: 1 file, 15 changed lines — well inside the soft threshold.

## Review

Not self-reviewed. An independent reviewer posts the `Agent Review:` verdict.