### PR TITLE
test(MOR-1900): repair rigctld integration fixtures for the DEFER gate

### DIFF
--- a/tests/integration/_ptt_reread_fixtures.py
+++ b/tests/integration/_ptt_reread_fixtures.py
@@ -1,0 +1,159 @@
+"""Shared PTT-reread-answering test doubles for rigctld integration fixtures.
+
+MOR-1900 fixture repair. Since ``6bdb5846`` (MOR-1900), ``RigctldHandler``'s
+DEFER write gate (``_defer_write_gate`` in ``rigplane/rigctld/handler.py``)
+only lets a MODE/BAND/VFO_SELECT/VFO_TOPOLOGY/MEMORY write through once
+``_resolve_rigctld_rf_state`` has seen a *fresh*, provider-generation-matched
+``Observation`` at ``global.tx_state.ptt`` in the canonical ``StateStore``.
+That is honest — a real radio supplies this by answering
+``RigctldServer._run_ptt_reread``'s periodic ``0x1C/0x00`` CI-V read
+(MOR-1903). This module gives each fixture shape used under
+``tests/integration/`` the ability to answer that same read, without
+weakening the resolver or the gate it feeds:
+
+* ``PttAnsweringSerialMockRadio`` — for the hand-rolled
+  :class:`serial_stub.SerialMockRadio`, which has no CI-V ingest pipeline at
+  all (``send_civ`` is a documented no-op). It owns a private, real
+  ``StateStore`` (making it ``StateStoreCapable``, so ``RigctldServer`` uses
+  it directly instead of an empty fallback store) and answers a
+  ``(0x1C, 0x00)`` read the same way the real CI-V ingress
+  (``_civ_rx.py: _CivRuntime._observations_from_frame``) would: one
+  ``Observation`` at ``FieldPath.global_("tx_state", "ptt")``, bounded by the
+  same TTL, reflecting the mock's own current ``_ptt`` flag.
+* ``answer_ptt_reread_with_rx`` — for a real :class:`rigplane.radio.IcomRadio`
+  fixture (``RecordingLanRadio`` in ``test_rigctld_audio_pipeline.py``).
+  Reuses the exact technique already proven in
+  ``tests/test_rigctld_ptt_reread.py`` (MOR-1903's own verification of this
+  mechanism): construct the CI-V reply frame a real radio would send, and
+  route it through the real, unmodified
+  ``_CivRuntime._route_civ_frame``/``_observations_from_frame`` ingestion —
+  the same production code path a live CI-V RX stream drives — skipping only
+  the outer transport byte/header decode the fixture never sets up.
+
+Neither helper touches ``_defer_write_gate``, the TX-interlock family
+classification, or any production module; both only make a test double
+capable of answering a read the gate already requires.
+
+Answering the read is not instantaneous, though: ``_run_ptt_reread`` only
+sends its first ``0x1C/0x00`` after one ``PTT_REREAD_INTERVAL_SECONDS`` sleep,
+and only once a client is connected. A real hamlib client that issues a
+DEFER-classified write inside that startup window sees exactly the same
+``RPRT -9`` an unpatched fixture does; that is the resolver working as
+designed, not a bug to route around. ``wait_for_known_rf_state`` below waits
+that same window out — the way a well-behaved client would — instead of
+racing it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+
+from serial_stub import SerialMockRadio
+
+from rigplane.commands import CONTROLLER_ADDR
+from rigplane.core.state_pipeline_contracts import (
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
+from rigplane.runtime import tx_interlock
+from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+from rigplane.types import CivFrame
+
+if TYPE_CHECKING:
+    from rigplane.radio import IcomRadio
+    from rigplane.rigctld.server import RigctldServer
+
+_PTT_PATH = FieldPath.global_("tx_state", "ptt")
+_PTT_TTL_SECONDS = _OBSERVATION_MAX_AGE_SECONDS[("global", "tx_state", "ptt")]
+
+
+class PttAnsweringSerialMockRadio(SerialMockRadio):
+    """SerialMockRadio that answers rigctld's ``0x1C/0x00`` PTT re-read.
+
+    Every other command still goes through the unmodified base class no-op.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._ptt_state_store = StateStore()
+
+    @property
+    def state_store(self) -> StateStore:
+        return self._ptt_state_store
+
+    async def send_civ(
+        self,
+        command: int,
+        sub: int | None = None,
+        data: bytes | None = None,
+        *,
+        wait_response: bool = True,
+        **_ignored_rigctld_send_kwargs: Any,
+    ) -> None:
+        # ``_run_ptt_reread`` calls with ``priority=``/``wait_dispatch=``,
+        # which the base ``SerialMockRadio.send_civ`` does not accept —
+        # absorbed here so the cadence's request no longer raises.
+        if command == 0x1C and sub == 0x00:
+            self._ptt_state_store.apply_current(
+                Observation(
+                    path=_PTT_PATH,
+                    value=self._ptt,
+                    source=SourceMetadata(
+                        source="poll_response",
+                        provider="serial_mock",
+                        native_id="ptt_reread",
+                    ),
+                    timestamp_monotonic=time.monotonic(),
+                    max_age=_PTT_TTL_SECONDS,
+                )
+            )
+            return
+        await super().send_civ(command, sub, data, wait_response=wait_response)
+
+
+def civ_ptt_reply_frame(radio: "IcomRadio", *, transmitting: bool) -> CivFrame:
+    """The CI-V reply a real radio would send to a ``0x1C/0x00`` read."""
+    return CivFrame(
+        to_addr=CONTROLLER_ADDR,
+        from_addr=radio._radio_addr,  # noqa: SLF001
+        command=0x1C,
+        sub=0x00,
+        data=bytes([1 if transmitting else 0]),
+        receiver=None,
+    )
+
+
+async def answer_ptt_reread_with_rx(radio: "IcomRadio") -> None:
+    """Deliver an RX-state ``0x1C/0x00`` reply through real CI-V ingress."""
+    frame = civ_ptt_reply_frame(radio, transmitting=False)
+    await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
+        frame,
+        generation=radio._civ_epoch,  # noqa: SLF001
+    )
+
+
+async def wait_for_known_rf_state(
+    server: "RigctldServer", *, timeout: float = 2.0
+) -> None:
+    """Wait out the startup window before ``_resolve_rigctld_rf_state`` knows RX.
+
+    Requires a client already connected (``server._client_count > 0``) so
+    ``_run_ptt_reread`` actually sends; otherwise this always times out —
+    correctly, since an idle server never converges either.
+    """
+    handler = server._rig_handler  # noqa: SLF001
+    resolve = getattr(handler, "_resolve_rigctld_rf_state", None)
+    assert callable(resolve), "server._rig_handler not initialised — call after start()"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if resolve() is not tx_interlock.RfState.UNKNOWN:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError(
+        "RF state stayed UNKNOWN past the PTT re-read window — "
+        "is a client connected (server._client_count > 0)?"
+    )

--- a/tests/integration/test_rigctld_audio_pipeline.py
+++ b/tests/integration/test_rigctld_audio_pipeline.py
@@ -13,11 +13,12 @@ from rigplane.audio.backend import AudioDeviceId, AudioDeviceInfo, FakeAudioBack
 from rigplane.audio.lan_stream import AudioStream, TX_IDENT
 from rigplane.audio.route import resolve_audio_route, rigctld_wsjtx_policy
 from rigplane.audio_bridge import AudioBridge, FRAME_BYTES, SAMPLES_PER_FRAME
+from rigplane.commands.commander import Priority
 from rigplane.radio import IcomRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
 from rigplane.runtime._connection_state import RadioConnectionState
-from rigplane.types import AudioCodec
+from rigplane.types import AudioCodec, CivFrame
 
 from _audio_pipeline_helpers import (
     assert_contiguous_sequences,
@@ -25,6 +26,7 @@ from _audio_pipeline_helpers import (
     pcm_rms,
     sine_pcm16_mono,
 )
+from _ptt_reread_fixtures import answer_ptt_reread_with_rx, wait_for_known_rf_state
 
 pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
 
@@ -113,6 +115,39 @@ class RecordingLanRadio(IcomRadio):
         self.calls.append(("set_ptt", (bool(on),)))
         self._ptt = bool(on)
         self._state_cache.update_ptt(bool(on))
+
+    async def send_civ(
+        self,
+        command: int,
+        sub: int | None = None,
+        data: bytes | None = None,
+        *,
+        wait_response: bool = True,
+        priority: Priority = Priority.NORMAL,
+        wait_dispatch: bool = True,
+    ) -> CivFrame | None:
+        """Answer ``RigctldServer._run_ptt_reread``'s ``0x1C/0x00`` cadence.
+
+        ``_civ_transport`` is ``_IdleCivTransport`` (always times out), so
+        the real RX loop never sees a reply. Instead of enqueueing over that
+        dead transport, deliver the RX-state reply directly through the same
+        real ingestion (``_CivRuntime._route_civ_frame`` /
+        ``_observations_from_frame``) MOR-1903's own test
+        (``tests/test_rigctld_ptt_reread.py``) uses to verify this exact
+        mechanism — see ``_ptt_reread_fixtures.py``. Every other command
+        still goes through the real ``IcomRadio.send_civ``.
+        """
+        if command == 0x1C and sub == 0x00:
+            await answer_ptt_reread_with_rx(self)
+            return None
+        return await super().send_civ(
+            command,
+            sub,
+            data,
+            wait_response=wait_response,
+            priority=priority,
+            wait_dispatch=wait_dispatch,
+        )
 
 
 class RigctldClient:
@@ -219,6 +254,10 @@ async def test_rigctld_wsjtx_replay_drives_data2_lan_tx_audio_pipeline(
 
     client = await _make_client(server)
     try:
+        # ``M`` (SET MODE) is DEFER-classified; wait out the same startup
+        # window a real hamlib client would (see _ptt_reread_fixtures.py)
+        # before the gate can know the radio is not transmitting.
+        await wait_for_known_rf_state(server)
         assert await client.send("M PKTUSB") == "RPRT 0"
         assert await client.send("T 1") == "RPRT 0"
 

--- a/tests/integration/test_rigctld_golden_replay.py
+++ b/tests/integration/test_rigctld_golden_replay.py
@@ -47,9 +47,10 @@ from pathlib import Path
 
 import pytest
 
-from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
+
+from _ptt_reread_fixtures import PttAnsweringSerialMockRadio, wait_for_known_rf_state
 
 pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
 
@@ -121,8 +122,16 @@ async def rigctld_dual_rx_server() -> AsyncGenerator[RigctldServer, None]:
     chk_vfo branch reads ``radio.profile.receiver_count`` to decide
     whether to advertise vfo_opt — but Variant B currently shorts that
     to ``"0"`` unconditionally, which is why every replay xfails today.
+
+    Uses ``PttAnsweringSerialMockRadio`` (not the bare ``SerialMockRadio``)
+    and keeps one extra connection open for the fixture's lifetime so
+    ``RigctldServer._run_ptt_reread`` (MOR-1903) actually sends and the
+    DEFER write gate can leave UNKNOWN before ``_replay`` opens its own
+    connection and starts sending golden-script lines — see
+    ``_ptt_reread_fixtures.py``. Golden files are untouched; only the
+    fixture's startup sequencing changes.
     """
-    radio = SerialMockRadio(model="IC-7610")
+    radio = PttAnsweringSerialMockRadio(model="IC-7610")
     await radio.connect()
     cfg = RigctldConfig(
         host="127.0.0.1",
@@ -133,9 +142,17 @@ async def rigctld_dual_rx_server() -> AsyncGenerator[RigctldServer, None]:
     )
     srv = RigctldServer(radio, cfg)
     await srv.start()
+    host, port = _addr(srv)
+    _keepalive_reader, keepalive_writer = await asyncio.open_connection(host, port)
+    await wait_for_known_rf_state(srv)
     try:
         yield srv
     finally:
+        keepalive_writer.close()
+        try:
+            await keepalive_writer.wait_closed()
+        except Exception:
+            pass
         await srv.stop()
 
 

--- a/tests/integration/test_rigctld_wsjtx.py
+++ b/tests/integration/test_rigctld_wsjtx.py
@@ -32,9 +32,10 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
-from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
+
+from _ptt_reread_fixtures import PttAnsweringSerialMockRadio, wait_for_known_rf_state
 
 pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
 
@@ -43,7 +44,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
 # ---------------------------------------------------------------------------
 
 
-class RecordingMockRadio(SerialMockRadio):
+class RecordingMockRadio(PttAnsweringSerialMockRadio):
     """SerialMockRadio subclass that records every Radio-level call.
 
     Each recorded entry is ``(method_name, args_tuple)``. The tests assert
@@ -52,6 +53,10 @@ class RecordingMockRadio(SerialMockRadio):
     Adds ``set_split`` which ``SerialMockRadio`` does not implement;
     the rigctld handler calls it via ``getattr(radio, 'set_split', None)``
     so without this override the split-VFO paths would silently no-op.
+
+    Inherits from ``PttAnsweringSerialMockRadio`` (not the bare
+    ``SerialMockRadio``) so it answers rigctld's ``0x1C/0x00`` PTT re-read —
+    see ``_ptt_reread_fixtures.py`` for why that is required since MOR-1900.
     """
 
     def __init__(self, **kwargs: object) -> None:
@@ -174,9 +179,17 @@ async def ic7610_setup() -> AsyncGenerator[
     radio = RecordingMockRadio(model="IC-7610")
     await radio.connect()
     server = await _make_server(radio)
+    # Keep one client connected for the fixture's lifetime so
+    # ``RigctldServer._run_ptt_reread`` (MOR-1903) actually sends and the
+    # DEFER write gate can leave UNKNOWN before any test body issues a
+    # MODE/BAND/VFO write — see ``_ptt_reread_fixtures.py``.
+    keepalive = await _make_client(server)
+    await wait_for_known_rf_state(server)
+    radio.reset_calls()
     try:
         yield radio, server
     finally:
+        await keepalive.close()
         await server.stop()
 
 
@@ -187,9 +200,13 @@ async def ic7300_setup() -> AsyncGenerator[
     radio = RecordingMockRadio(model="IC-7300")
     await radio.connect()
     server = await _make_server(radio)
+    keepalive = await _make_client(server)
+    await wait_for_known_rf_state(server)
+    radio.reset_calls()
     try:
         yield radio, server
     finally:
+        await keepalive.close()
         await server.stop()
 
 


### PR DESCRIPTION
## Summary

Nine tests under `tests/integration/` have been red on `main` since `6bdb5846d11f2385a1c39b7c808cd9afb01896f2` (MOR-1900, #2759). All three CI workflows run `pytest tests/ --ignore=tests/integration`, so nothing in `.github/` ever executed this directory and nobody noticed.

That commit correctly removed a safety bug: `RigctldHandler._cmd_get_ptt` used to answer a client's PTT poll from the legacy `RadioState` mirror and then publish that fabricated value into the canonical `StateStore` as a first-class fresh observation, letting `_defer_write_gate` pass a frequency/mode/band/VFO write while the PA might be keyed — a false RX, the forbidden direction. **The production behaviour is correct.** This PR repairs only the test fixtures — no `src/` file is touched.

Without a genuine observation, `RigctldHandler._resolve_rigctld_rf_state` stays `UNKNOWN` forever for these fixtures, and `_defer_write_gate` correctly refuses every DEFER-classified write (MODE, BAND, VFO_SELECT, VFO_TOPOLOGY, MEMORY) with `RPRT -9`: `SerialMockRadio.send_civ` is a documented no-op, so `RigctldServer._run_ptt_reread`'s cadence (MOR-1903) never produces a reply, and `test_rigctld_audio_pipeline.py`'s `RecordingLanRadio` (a real `IcomRadio` subclass) never gets one either since its `_civ_transport` always times out.

## Mechanism chosen

Two mechanisms were evaluated per the task brief; I did **not** invent a third:

- **`create_observation_poller` wiring** — rejected. `RigctldServer` has no hook to route it into the canonical `StateStore` without changing `src/rigplane/rigctld/server.py` (its only test-injection point, `_poller`, is unrelated to the `StateStore`/`Observation` pipeline). Separately, `SerialMockRadio.baseline_observations()` only ever emits `max_age=None` observations, which `_resolve_rigctld_rf_state` explicitly treats as `UNKNOWN` — a bounded, decaying TTL is required, so this mechanism would have needed further changes beyond just wiring it in.
- **`send_civ` synthesising a reply — chosen**, test-side only:
  - `PttAnsweringSerialMockRadio` (new, `tests/integration/_ptt_reread_fixtures.py`) gives `SerialMockRadio` a private `StateStore` and answers a `(0x1C, 0x00)` read the way real CI-V ingress (`_civ_rx.py: _CivRuntime._observations_from_frame`) would: one `Observation` at `global.tx_state.ptt`, same TTL, reflecting the mock's own `_ptt` flag. `test_rigctld_wsjtx.py` and `test_rigctld_golden_replay.py` now build their mock radios from it instead of the bare `SerialMockRadio`.
  - `answer_ptt_reread_with_rx` (same new module) reuses the exact technique already proven in `tests/test_rigctld_ptt_reread.py` (MOR-1903's own verification test): construct the CI-V reply frame a real radio would send and route it through the real, unmodified `_CivRuntime._route_civ_frame`/`_observations_from_frame` ingestion. `test_rigctld_audio_pipeline.py`'s `RecordingLanRadio` now overrides `send_civ` to use this for the PTT re-read only, delegating every other command to the real `IcomRadio.send_civ`.

Each fixture also now waits for the resolver to leave `UNKNOWN` (`wait_for_known_rf_state`) before issuing a DEFER-classified write — mirroring the startup window any real hamlib client faces, since `_run_ptt_reread` sleeps once before its first send. Racing that window, instead of waiting it out, would have been a fixture bug of its own.

## Goldens

`tests/golden/wsjtx_dual_rx_session.txt`, `fldigi_dual_rx_session.txt`, and `js8call_dual_rx_session.txt` are **untouched** — confirmed via `git diff origin/main -- tests/golden/` (empty) and `git status --short tests/golden/` (empty). Only fixture startup sequencing changed.

## Mutation evidence (safety property still holds)

Mutated `RigctldHandler._defer_write_gate` so `RfState.UNKNOWN` passes (`return None`) instead of refusing (`return _err(HamlibError.ERJCTED)`):
- With the mutation: `tests/test_rigctld_tx_interlock.py` → **13 failed, 82 passed**.
- Reverted: `git diff src/rigplane/rigctld/handler.py` is empty, and the same file → **95 passed**.

No `src/` file is touched by the committed diff — the mutation above was applied and reverted only to demonstrate the gate is genuinely load-bearing.

## Test plan

- [x] `uv run pytest tests/integration/ -q --tb=short --timeout=300 --timeout-method=thread` → **267 passed, 56 skipped** (0 failed; skip count unchanged from the pre-fix baseline of 56)
- [x] `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` → **10634 passed, 1 failed (`test_enable_scope_strict_sends_and_acks`, pre-existing/environmental — reproduces identically before this branch's changes), 12 skipped, 47 xfailed, 1 xpassed**
- [x] `uv run ruff check src/ tests/` → all checks passed
- [x] `uv run ruff format --check src/ tests/` → all formatted
- [x] `uv run lint-imports` → 5 kept, 0 broken

Guardrails: 4 files changed, 237 insertions / 5 deletions — inside the soft threshold (6 files / 600 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)