### PR TITLE
test(MOR-1900): answer the PTT re-read with the double's real key state

### DIFF
--- a/tests/integration/_ptt_reread_fixtures.py
+++ b/tests/integration/_ptt_reread_fixtures.py
@@ -20,7 +20,7 @@ weakening the resolver or the gate it feeds:
   (``_civ_rx.py: _CivRuntime._observations_from_frame``) would: one
   ``Observation`` at ``FieldPath.global_("tx_state", "ptt")``, bounded by the
   same TTL, reflecting the mock's own current ``_ptt`` flag.
-* ``answer_ptt_reread_with_rx`` — for a real :class:`rigplane.radio.IcomRadio`
+* ``answer_ptt_reread`` — for a real :class:`rigplane.radio.IcomRadio`
   fixture (``RecordingLanRadio`` in ``test_rigctld_audio_pipeline.py``).
   Reuses the exact technique already proven in
   ``tests/test_rigctld_ptt_reread.py`` (MOR-1903's own verification of this
@@ -28,7 +28,12 @@ weakening the resolver or the gate it feeds:
   route it through the real, unmodified
   ``_CivRuntime._route_civ_frame``/``_observations_from_frame`` ingestion —
   the same production code path a live CI-V RX stream drives — skipping only
-  the outer transport byte/header decode the fixture never sets up.
+  the outer transport byte/header decode the fixture never sets up. The key
+  state it answers with is the caller's own, never a constant: a helper that
+  replied "not transmitting" unconditionally would re-create the fabricated
+  RX observation ``6bdb5846`` deleted from
+  ``RigctldHandler._cmd_get_ptt`` — the forbidden direction — and no test
+  built on it could ever observe the gate under TX.
 
 Neither helper touches ``_defer_write_gate``, the TX-interlock family
 classification, or any production module; both only make a test double
@@ -64,6 +69,8 @@ from rigplane.runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
 from rigplane.types import CivFrame
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rigplane.radio import IcomRadio
     from rigplane.rigctld.server import RigctldServer
 
@@ -127,12 +134,47 @@ def civ_ptt_reply_frame(radio: "IcomRadio", *, transmitting: bool) -> CivFrame:
     )
 
 
-async def answer_ptt_reread_with_rx(radio: "IcomRadio") -> None:
-    """Deliver an RX-state ``0x1C/0x00`` reply through real CI-V ingress."""
-    frame = civ_ptt_reply_frame(radio, transmitting=False)
+async def answer_ptt_reread(radio: "IcomRadio", *, transmitting: bool) -> None:
+    """Deliver a ``0x1C/0x00`` reply through real CI-V ingress.
+
+    ``transmitting`` is the calling double's own current key state, so the
+    observation this produces tracks what the double is actually doing —
+    the same contract ``PttAnsweringSerialMockRadio.send_civ`` honours by
+    reading its own ``_ptt``. ``test_rigctld_audio_pipeline.py::
+    test_defer_write_is_dropped_while_the_radio_transmits`` is what fails if
+    a caller ever pins this to a constant instead.
+    """
+    frame = civ_ptt_reply_frame(radio, transmitting=transmitting)
     await radio._civ_runtime._route_civ_frame(  # noqa: SLF001
         frame,
         generation=radio._civ_epoch,  # noqa: SLF001
+    )
+
+
+async def _poll_rf_state(
+    server: "RigctldServer",
+    accept: "Callable[[tx_interlock.RfState], bool]",
+    wanted: str,
+    timeout: float,
+) -> None:
+    """Poll ``_resolve_rigctld_rf_state`` until ``accept`` holds, else raise."""
+    handler = server._rig_handler  # noqa: SLF001
+    resolve = getattr(handler, "_resolve_rigctld_rf_state", None)
+    assert callable(resolve), "server._rig_handler not initialised — call after start()"
+    deadline = time.monotonic() + timeout
+    state = resolve()
+    while time.monotonic() < deadline:
+        state = resolve()
+        if accept(state):
+            return
+        await asyncio.sleep(0.02)
+    hint = (
+        " — is a client connected (server._client_count > 0)?"
+        if state is tx_interlock.RfState.UNKNOWN
+        else " — is the double's key state reaching the re-read reply?"
+    )
+    raise AssertionError(
+        f"RF state stayed {state} past the PTT re-read window, wanted {wanted}{hint}"
     )
 
 
@@ -145,15 +187,26 @@ async def wait_for_known_rf_state(
     ``_run_ptt_reread`` actually sends; otherwise this always times out —
     correctly, since an idle server never converges either.
     """
-    handler = server._rig_handler  # noqa: SLF001
-    resolve = getattr(handler, "_resolve_rigctld_rf_state", None)
-    assert callable(resolve), "server._rig_handler not initialised — call after start()"
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if resolve() is not tx_interlock.RfState.UNKNOWN:
-            return
-        await asyncio.sleep(0.02)
-    raise AssertionError(
-        "RF state stayed UNKNOWN past the PTT re-read window — "
-        "is a client connected (server._client_count > 0)?"
+    await _poll_rf_state(
+        server,
+        lambda state: state is not tx_interlock.RfState.UNKNOWN,
+        "anything but UNKNOWN",
+        timeout,
+    )
+
+
+async def wait_for_rf_state(
+    server: "RigctldServer",
+    expected: tx_interlock.RfState,
+    *,
+    timeout: float = 2.0,
+) -> None:
+    """Wait until the gate's resolver reports exactly ``expected``.
+
+    A key state the double changed reaches the resolver only through the
+    next ``_run_ptt_reread`` tick, so this waits for the re-read to carry it
+    rather than assuming the write landed in the canonical store directly.
+    """
+    await _poll_rf_state(
+        server, lambda state: state is expected, str(expected), timeout
     )

--- a/tests/integration/test_rigctld_audio_pipeline.py
+++ b/tests/integration/test_rigctld_audio_pipeline.py
@@ -17,6 +17,7 @@ from rigplane.commands.commander import Priority
 from rigplane.radio import IcomRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
+from rigplane.runtime import tx_interlock
 from rigplane.runtime._connection_state import RadioConnectionState
 from rigplane.types import AudioCodec, CivFrame
 
@@ -26,7 +27,11 @@ from _audio_pipeline_helpers import (
     pcm_rms,
     sine_pcm16_mono,
 )
-from _ptt_reread_fixtures import answer_ptt_reread_with_rx, wait_for_known_rf_state
+from _ptt_reread_fixtures import (
+    answer_ptt_reread,
+    wait_for_known_rf_state,
+    wait_for_rf_state,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.mock_integration]
 
@@ -130,15 +135,19 @@ class RecordingLanRadio(IcomRadio):
 
         ``_civ_transport`` is ``_IdleCivTransport`` (always times out), so
         the real RX loop never sees a reply. Instead of enqueueing over that
-        dead transport, deliver the RX-state reply directly through the same
-        real ingestion (``_CivRuntime._route_civ_frame`` /
+        dead transport, deliver the reply directly through the same real
+        ingestion (``_CivRuntime._route_civ_frame`` /
         ``_observations_from_frame``) MOR-1903's own test
         (``tests/test_rigctld_ptt_reread.py``) uses to verify this exact
-        mechanism — see ``_ptt_reread_fixtures.py``. Every other command
-        still goes through the real ``IcomRadio.send_civ``.
+        mechanism — see ``_ptt_reread_fixtures.py``. What it reports is this
+        radio's own ``_ptt``, the flag ``set_ptt`` maintains, so the DEFER
+        gate sees the double transmit when it transmits; answering a fixed
+        "not transmitting" would be the fabricated RX observation
+        ``6bdb5846`` removed from production. Every other command still goes
+        through the real ``IcomRadio.send_civ``.
         """
         if command == 0x1C and sub == 0x00:
-            await answer_ptt_reread_with_rx(self)
+            await answer_ptt_reread(self, transmitting=self._ptt)
             return None
         return await super().send_civ(
             command,
@@ -236,6 +245,60 @@ async def rigctld_audio_setup() -> AsyncGenerator[
         await bridge.stop()
         await server.stop()
         radio._connected = False
+
+
+async def test_defer_write_is_dropped_while_the_radio_transmits(
+    rigctld_audio_setup: tuple[
+        RecordingLanRadio,
+        RigctldServer,
+        AudioBridge,
+        FakeAudioBackend,
+        _RecordingAudioTransport,
+    ],
+) -> None:
+    """The PTT re-read reports TX, so the DEFER gate drops a MODE write.
+
+    This is the discriminating half of the fixture in
+    ``_ptt_reread_fixtures.py``: it can only reach the ``rf_state is TX``
+    branch of ``RigctldHandler._defer_write_gate`` because
+    ``answer_ptt_reread`` answers with the double's real key state. Pin a
+    constant ``transmitting=False`` back into that helper and
+    ``wait_for_rf_state(..., TX)`` times out here — which is exactly the
+    blindness a fabricated RX observation buys.
+
+    ``RPRT 0`` for a dropped write is the MOR-1881 owner ruling, not a
+    success: hamlib clients take any non-zero RPRT mid-sequence offline, so
+    this seat mirrors the radio's own front panel and ignores the press. The
+    load-bearing assertion is therefore that the radio never saw the write.
+    """
+    radio, server, _bridge, _backend, _transport = rigctld_audio_setup
+
+    client = await _make_client(server)
+    try:
+        await wait_for_known_rf_state(server)
+        assert await client.send("T 1") == "RPRT 0"
+        # The key state reaches the gate only via the next re-read tick.
+        await wait_for_rf_state(server, tx_interlock.RfState.TX)
+
+        def mode_writes() -> list[tuple[str, tuple[Any, ...]]]:
+            return [
+                call for call in radio.calls if call[0] in ("set_mode", "set_data_mode")
+            ]
+
+        dropped_from = mode_writes()
+        assert await client.send("M PKTUSB") == "RPRT 0"
+        assert mode_writes() == dropped_from
+
+        assert await client.send("T 0") == "RPRT 0"
+        await wait_for_rf_state(server, tx_interlock.RfState.RX)
+
+        # Same command, same client, RX now — it reaches the radio, so the
+        # drop above was the TX branch and not a fixture that never writes.
+        assert await client.send("M PKTUSB") == "RPRT 0"
+        assert mode_writes() != dropped_from
+        assert ("set_mode", ("USB", None, 0)) in radio.calls
+    finally:
+        await client.close()
 
 
 async def test_rigctld_wsjtx_replay_drives_data2_lan_tx_audio_pipeline(

--- a/tests/integration/test_rigctld_golden_replay.py
+++ b/tests/integration/test_rigctld_golden_replay.py
@@ -117,19 +117,18 @@ def _addr(server: RigctldServer) -> tuple[str, int]:
 async def rigctld_dual_rx_server() -> AsyncGenerator[RigctldServer, None]:
     """Real RigctldServer bound to localhost:0 with an IC-7610 mock radio.
 
-    Uses SerialMockRadio(model="IC-7610") which exposes the dual-RX
-    profile (receiver_count=2, vfo_scheme="main_sub"). The handler's
-    chk_vfo branch reads ``radio.profile.receiver_count`` to decide
-    whether to advertise vfo_opt — but Variant B currently shorts that
-    to ``"0"`` unconditionally, which is why every replay xfails today.
+    The model is ``"IC-7610"`` for its dual-RX profile
+    (``receiver_count=2``, ``vfo_scheme="main_sub"``): ``_cmd_chk_vfo``
+    answers ``"1"`` — the ``vfo_opt`` handshake every golden trace here was
+    recorded under — only for a profile whose ``receiver_count >= 2``.
 
-    Uses ``PttAnsweringSerialMockRadio`` (not the bare ``SerialMockRadio``)
-    and keeps one extra connection open for the fixture's lifetime so
-    ``RigctldServer._run_ptt_reread`` (MOR-1903) actually sends and the
-    DEFER write gate can leave UNKNOWN before ``_replay`` opens its own
-    connection and starts sending golden-script lines — see
-    ``_ptt_reread_fixtures.py``. Golden files are untouched; only the
-    fixture's startup sequencing changes.
+    The class is ``PttAnsweringSerialMockRadio``, not the bare
+    ``SerialMockRadio``, and one extra connection stays open for the
+    fixture's lifetime so ``RigctldServer._run_ptt_reread`` (MOR-1903)
+    actually sends and the DEFER write gate can leave UNKNOWN before
+    ``_replay`` opens its own connection and starts sending golden-script
+    lines — see ``_ptt_reread_fixtures.py``. Golden files are untouched;
+    only the fixture's startup sequencing changes.
     """
     radio = PttAnsweringSerialMockRadio(model="IC-7610")
     await radio.connect()
@@ -193,8 +192,8 @@ async def _replay(server: RigctldServer, steps: list[_Step]) -> None:
     """Drive one golden script against a live rigctld server.
 
     Raises AssertionError on the first divergence with file-line
-    context. After Variant A 5/5 lands, all assertions hold; until
-    then the wrapping @pytest.mark.xfail catches the failure.
+    context. Since Variant A 5/5 (#1346) removed the xfail markers, that
+    AssertionError is the caller's failure — nothing catches it.
     """
     host, port = _addr(server)
     reader, writer = await asyncio.open_connection(host, port)


### PR DESCRIPTION
Two follow-ups from the independent review of #2808 (merged as `e8fe6e45`). Test-side only.

## 1. An unconditional RX in a test double

`answer_ptt_reread_with_rx` hardcoded `transmitting=False`, so `RecordingLanRadio` answered rigctld's `0x1C/0x00` re-read with "not transmitting" no matter what the double was doing — while its sibling `PttAnsweringSerialMockRadio` correctly reflects its own `_ptt`.

That is the shape commit `6bdb5846` (MOR-1900) removed from production, where `RigctldHandler._cmd_get_ptt` fabricated a confirmed-RX observation and let `_defer_write_gate` pass a mode/band/VFO write while the PA might be keyed. A false RX is the forbidden direction. In a test helper it costs discrimination rather than safety: any test asserting "a DEFER-family write is refused while transmitting" would pass blind, because it could never reach a TX state.

The helper is now `answer_ptt_reread(radio, *, transmitting)`, and `RecordingLanRadio.send_civ` passes its own `_ptt` — the flag `set_ptt` maintains.

### Verified discriminating, not merely green

New `test_defer_write_is_dropped_while_the_radio_transmits`:

1. keys the double (`T 1`), waits for the re-read cadence to carry TX to `_resolve_rigctld_rf_state`;
2. sends `M PKTUSB` and pins that **the radio never saw it** — `RPRT 0` for a dropped write is the MOR-1881 owner ruling (a non-zero RPRT mid-sequence takes hamlib clients offline), so the load-bearing assertion is the absent `set_mode`/`set_data_mode` call, not the return code;
3. unkeys, waits for RX, and pins the same write going through — so step 2's drop is the TX branch and not a fixture that never writes.

Mutation check: re-pinning `transmitting=False` in the helper fails the new test at the TX wait, with the diagnostic `RF state stayed rx past the PTT re-read window, wanted tx`. The old helper could not have failed here at all.

Supporting that wait, `wait_for_rf_state` joins `wait_for_known_rf_state` over one shared polling loop (`_poll_rf_state`), whose timeout message now names the state actually observed.

## 2. Prose that was false with the suite green

In `test_rigctld_golden_replay.py`, the fixture docstring said it uses `SerialMockRadio(model="IC-7610")` three lines above the paragraph explaining it deliberately uses `PttAnsweringSerialMockRadio` instead, and said "which is why every replay xfails today" — the replays pass, and the module docstring in the same file says so. Both rewritten to describe what the fixture does; the `receiver_count=2` / `vfo_scheme="main_sub"` claim was checked against the loaded profile, and the `chk_vfo` claim against `_cmd_chk_vfo`.

**One more instance of the same class, in the same file:** `_replay`'s docstring still claimed "the wrapping `@pytest.mark.xfail` catches the failure" after A5 (#1346) removed every xfail marker. Fixed here too; the other four `xfail` mentions in the file are past-tense History entries and remain true.

## Verification

| Gate | Result |
|---|---|
| `pytest tests/integration/` | **268 passed, 56 skipped** (baseline after #2808: 267 passed, 56 skipped — skips unchanged) |
| `pytest tests/ --ignore=tests/integration -n auto` | 10572 passed, 74 skipped, 47 xfailed, 1 xpassed, **1 failed** |
| `ruff check` / `ruff format --check` | clean |
| `mypy --strict src/rigplane/web` | clean |
| `lint-imports` | 5 kept, 0 broken |

The standard-suite failure is `tests/test_radio_coverage.py::test_enable_scope_strict_sends_and_acks` (`CI-V response timed out`). It is **pre-existing**, not from this diff: verified by reverting all three files to `e8fe6e45` and reproducing the identical failure in isolation. This diff touches nothing that test imports.

## Scope

Test-side only — no change under `src/`, `_defer_write_gate` untouched, `tests/golden/*.txt` byte-identical. 3 files, 152 insertions / 37 deletions: within the soft threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)