### PR TITLE
ci: run tests/integration in all three workflows

### DIFF
--- a/.claude/commands/regression-check.md
+++ b/.claude/commands/regression-check.md
@@ -9,7 +9,7 @@ Detect test regressions after code changes.
 
 ## Steps
 
-1. Run full test suite: `uv run pytest tests/ -q --tb=short --ignore=tests/integration 2>&1`
+1. Run full test suite: `uv run pytest tests/ -q --tb=short 2>&1`
 2. Capture: total passed, failed, errors, warnings, runtime
 3. Read `.claude/workflow/regression.md` for previous baseline (if exists)
 4. Compare against baseline:

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -79,7 +79,7 @@ cd ..
 
 ```bash
 # 2h. Python tests
-uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread
+uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread
 ```
 
 ```bash

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -115,7 +115,7 @@ jobs:
           # Capture pytest's exit code via PIPESTATUS, extract the summary
           # (still needed for the badge, including on failure), then exit
           # with pytest's code so failing tests fail the step.
-          uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
+          uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
           rc=${PIPESTATUS[0]}
           SUMMARY=$(tail -1 pytest-output.txt)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
         run: uv run lint-imports
 
       - name: Run tests
-        run: uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread
+        run: uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread
 
   build:
     needs: validate

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -229,7 +229,7 @@ jobs:
           # Capture pytest's exit code via PIPESTATUS, extract the summary
           # (still needed for the badge, including on failure), then exit
           # with pytest's code so failing tests fail the step.
-          uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
+          uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
           rc=${PIPESTATUS[0]}
           SUMMARY=$(tail -1 pytest-output.txt)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Three workflows, tiered by cost:
 
 | Workflow | Trigger | Scope |
 |---|---|---|
-| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (no integration) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
+| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (incl. `tests/integration`, hardware-gated tests skip automatically) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
 | `full.yml` | cron Mon/Wed/Fri 03:00 UTC + `workflow_dispatch` + push with `[full-ci]` in commit message | Full matrix 3.11/3.12/3.13, everything |
 | `publish.yml` | `release: published` | New `validate` job (full matrix) → `build` → `publish`. No publish if validate fails. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Live bench: **IC-7300, FTX-1**. *(IC-7610 retired 2026-08-04; X6200 destroyed by
 ## Commands (always `uv run`)
 
 ```bash
-uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread  # standard suite (CI parity, ~2 min)
+uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread  # standard suite (CI parity, ~1 min)
 uv run pytest tests/ -q --tb=short                    # serial, incl. integration hooks (profiling/hardware only)
 uv run mypy --strict src/rigplane/web                  # type check (CI gate; see note below)
 uv run ruff check src/ tests/ && uv run ruff format src/ tests/  # lint+format
@@ -172,7 +172,7 @@ cancelled checks — and release branches (named `release/<major.minor>`) are in
 ## Completion criteria
 
 Work is complete ONLY when ALL pass:
-1. `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — zero failures
+1. `uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread` — zero failures
 2. `uv run ruff check src/ tests/` — zero violations
 3. `git diff` — no unintended changes
 

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -50,7 +50,7 @@ The repository has three Actions workflows, tiered to keep billable minutes low:
 
 | Workflow | When it runs | What it does |
 |---|---|---|
-| **Tests (quick)** | push/PR to `main` **only** when one of these paths changes: `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, `.github/workflows/**` | Single Python 3.11 job: `ruff`, `import-linter`, `pytest` (no hardware integration). The frontend block (`npm ci`, type-check, vitest, build, mypy on `src/rigplane/web`) only runs when files under `frontend/**` or `src/rigplane/web/**` actually changed. ~2–5 min. Doc-only edits and CLAUDE.md changes don't trigger CI at all — use `gh workflow run "Tests (quick)"` if you need a manual run. |
+| **Tests (quick)** | push/PR to `main` **only** when one of these paths changes: `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, `.github/workflows/**` | Single Python 3.11 job: `ruff`, `import-linter`, `pytest` (includes `tests/integration`; hardware-gated tests skip automatically without hardware env vars). The frontend block (`npm ci`, type-check, vitest, build, mypy on `src/rigplane/web`) only runs when files under `frontend/**` or `src/rigplane/web/**` actually changed. ~2–5 min. Doc-only edits and CLAUDE.md changes don't trigger CI at all — use `gh workflow run "Tests (quick)"` if you need a manual run. |
 | **Tests (full matrix)** | cron Mon/Wed/Fri 03:00 UTC, manual `workflow_dispatch`, **or** any push whose commit message contains `[full-ci]` | Full 3.11/3.12/3.13 matrix with frontend, mypy, import-linter and the whole pytest suite. |
 | **Publish to PyPI** | on a published GitHub Release | Runs the full validation matrix first; the build/publish jobs only start if validation is green. |
 
@@ -80,12 +80,12 @@ tests/
 ├── test_data_mode.py          # DATA/packet mode semantics
 ├── golden/
 │   └── protocol_golden.json   # 45 golden response fixtures (all commands + errors)
-└── integration/               # Real hardware tests (require a radio)
+└── integration/               # Mostly mocked/fake-radio tests; hardware-gated tests skip automatically
     ├── test_connect.py
     └── test_get_freq.py
 ```
 
-Unit tests use mocked transports — **no radio required**. Integration tests are in `tests/integration/` and require actual hardware.
+Unit tests use mocked transports — **no radio required**. Integration tests in `tests/integration/` mostly run against mocked or fake radios too; only tests gated behind `ICOM_*` / `RIGPLANE_HW_SMOKE` environment variables need actual hardware, and those skip automatically without it.
 
 #### Golden Protocol Tests
 

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -31,11 +31,11 @@ CI runs this automatically; you only need it locally if you're running web-serve
 ## Running Tests
 
 ```bash
-# All unit tests (skip integration tests requiring hardware)
-uv run pytest tests/ -q --tb=short --ignore=tests/integration
+# Full suite (hardware-gated integration tests skip automatically without hardware env vars)
+uv run pytest tests/ -q --tb=short
 
 # With verbose output
-uv run pytest tests/ -v --ignore=tests/integration
+uv run pytest tests/ -v
 
 # Specific test file
 uv run pytest tests/test_commands.py -q --tb=short
@@ -181,6 +181,6 @@ Always include the issue number in the scope (e.g., `#123`) for feature, fix, an
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feat/my-feature`
 3. Make your changes with tests
-4. Ensure all tests pass: `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
+4. Ensure all tests pass: `uv run pytest tests/ -q --tb=short`
 5. Commit with conventional commit message (include issue scope: `feat(#N):`)
 6. Open a PR against `main`

--- a/docs/internals/radio-state-pipeline-validation.md
+++ b/docs/internals/radio-state-pipeline-validation.md
@@ -43,7 +43,7 @@ Run commands from the repository root unless `cwd` says `frontend/`.
 Recommended optional breadth before release:
 
 ```bash
-uv run pytest tests/ -q --tb=short --ignore=tests/integration
+uv run pytest tests/ -q --tb=short
 uv run ruff format --check src tests
 uv run mypy src
 ```

--- a/docs/internals/radio-state-pipeline-validation.md
+++ b/docs/internals/radio-state-pipeline-validation.md
@@ -43,7 +43,6 @@ Run commands from the repository root unless `cwd` says `frontend/`.
 Recommended optional breadth before release:
 
 ```bash
-uv run pytest tests/ -q --tb=short
 uv run ruff format --check src tests
 uv run mypy src
 ```
@@ -158,7 +157,7 @@ Expected outcome: no listener.
 | Encoder-style controls | `tests/test_civ_rx_coverage.py`, `tests/test_radio_poller_coverage.py`, live v2 Playwright | AF/RF gain, PBT, NR/NB, filter/scope controls keep receiver scoping and command correlation. |
 | HTTP/WS consistency | `tests/test_web_server_coverage.py`, `tests/test_delta_encoder.py`, frontend `npx vitest run`, live v2 Playwright | HTTP snapshots and initial WS full state use the same canonical state/freshness revisions; `transportSeq` is ordering metadata only. |
 | Web field availability metadata | `tests/test_web_server_coverage.py` | Legacy `/api/v1/state` fields remain for compatibility, but `fieldStatus` marks each Store-backed public field as observed/fresh, observed/stale, or missing so empty or partial Stores do not present `RadioState` defaults as confirmed state. |
-| rigctld consumer behavior | `tests/test_rigctld_handler.py`, `tests/test_rigctld_server.py`, `tests/integration/test_rigctld_wsjtx.py` when integration is opted in | GET projects from shared state when fresh; stale GET requests acquisition or falls through safely; SET uses scoped pending overlays and preserves Hamlib-style text behavior. |
+| rigctld consumer behavior | `tests/test_rigctld_handler.py`, `tests/test_rigctld_server.py`, `tests/integration/test_rigctld_wsjtx.py` (mock-radio; runs with the standard suite) | GET projects from shared state when fresh; stale GET requests acquisition or falls through safely; SET uses scoped pending overlays and preserves Hamlib-style text behavior. |
 | Command ingress/read-after-write | `tests/test_web_server_coverage.py`, `tests/test_radio_poller_coverage.py`, `tests/test_rigctld_handler.py`, live v2 Playwright | HTTP, WS, and rigctld command IDs are scoped; lifecycle failure/timeout expires overlays; matching observations confirm state. |
 | Reconnect/resync | `tests/test_web_server_coverage.py`, `tests/test_civ_rx_coverage.py`, live v2 Playwright | Web full-state reconnect preserves canonical revisions; CI-V watchdog/backlog recovery does not publish stale scope backlog as control truth. |
 | Cleanup guards | `tests/test_state_pipeline_contracts.py`, `tests/test_civ_rx_coverage.py`, `tests/test_lifecycle_diagnostics.py` | Web poller public revision API is not reintroduced; CIV waiters/watchdog/server lifecycle cleanup paths do not leak tasks or stale waiters. |

--- a/tests/integration/test_audio_routing.py
+++ b/tests/integration/test_audio_routing.py
@@ -8,9 +8,11 @@ cache invalidation. Builds on:
 - #766 — codec/channel change detection triggered by audio_config.
 - #767 / #768 — Option-B ``frame_ms`` + dead-code cleanup.
 
-Marked ``integration`` + ``mock_integration`` — skipped in default CI
-runs; executes via the integration marker and does not require real
-hardware.
+Marked ``integration`` + ``mock_integration``. The ``mock_integration``
+marker is what keeps these off hardware — ``conftest.py``'s
+``pytest_collection_modifyitems`` skips over them without ever adding a
+skip marker — so they run in the standard suite and in all three CI
+workflows, with no real hardware required.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_rigctld_wsjtx.py
+++ b/tests/integration/test_rigctld_wsjtx.py
@@ -20,9 +20,11 @@ What we assert
     * JS8Call heartbeat GETs returning the current state.
     * Backwards-compatible fallback for unknown VFO names.
 
-Tests are marked ``integration`` + ``mock_integration`` so they skip in
-default CI runs but execute via the integration marker and do not require
-real hardware.
+Tests are marked ``integration`` + ``mock_integration``. The
+``mock_integration`` marker is what keeps them off hardware —
+``conftest.py``'s ``pytest_collection_modifyitems`` skips over them
+without ever adding a skip marker — so they run in the standard suite and
+in all three CI workflows, with no real hardware required.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_x6200_audio_scope_smoke.py
+++ b/tests/integration/test_x6200_audio_scope_smoke.py
@@ -5,10 +5,10 @@ X6200 (serial CI-V + USB RX audio) and asserts that at least one FFT
 :class:`ScopeFrame` reaches the audio-scope channel within a few seconds.
 
 OFF BY DEFAULT. This test is double-gated and is skipped in a normal
-``uv run pytest tests/`` run:
+``uv run pytest tests/`` run (CLAUDE.md's standard command collects
+``tests/integration/`` too, but the markers below keep this one from
+executing):
 
-* it lives in ``tests/integration/`` (CLAUDE.md runs with
-  ``--ignore=tests/integration``);
 * it carries the ``serial_integration`` marker, so the integration conftest
   skips it unless ``ICOM_SERIAL_DEVICE`` is configured;
 * it additionally requires ``RIGPLANE_HW_SMOKE=1`` (mirroring the

--- a/tests/test_ci_pytest_invocation.py
+++ b/tests/test_ci_pytest_invocation.py
@@ -15,12 +15,21 @@ script block scalars, not structure a workflow schema exposes as data. A
 regex anchored on the known `uv run pytest tests/` invocation is simpler and
 does not risk that dependency disappearing.
 
-Honest limit: this only proves the flag string is absent from the pytest
-invocation text in the three tracked workflow files. It says nothing about
-a future workflow file this repo might add, or about a flag with equivalent
-effect expressed a different way (e.g. `-k 'not integration'`, a marker
-deselect, or a `pyproject.toml` `addopts` change) — those would need a
-matching assertion added here, or they would drift the same way this one
+`quick.yml` and `full.yml` write this invocation as a shell line
+continuation (`... \\` then `| tee pytest-output.txt` on the next physical
+line) — exactly where a flag would naturally land if someone wrapped the
+command further. Backslash-newline continuations are folded to a single
+space before matching so a flag placed on a continuation line is not
+invisible to the pin.
+
+Honest limit: this proves the flag string is absent from the pytest
+invocation text in the three tracked workflow files, continuation lines
+included. It says nothing about a future workflow file this repo might add,
+a different invocation shape (e.g. `python -m pytest`, a different working
+directory, or an invocation built from a shell variable), or a flag with
+equivalent effect expressed a different way (e.g. `-k 'not integration'`, a
+marker deselect, or a `pyproject.toml` `addopts` change) — those would need
+a matching assertion added here, or they would drift the same way this one
 did.
 """
 
@@ -38,7 +47,11 @@ _PYTEST_INVOCATION_RE = re.compile(r"uv run pytest tests/[^\n]*")
 
 def _pytest_invocations(workflow_name: str) -> list[str]:
     text = (WORKFLOWS_DIR / workflow_name).read_text()
-    invocations = _PYTEST_INVOCATION_RE.findall(text)
+    # Fold shell line continuations first: `... \` + newline is one physical
+    # command, and a flag added on the continuation line would otherwise be
+    # past the `[^\n]*` boundary and invisible to this pin.
+    folded_text = text.replace("\\\n", " ")
+    invocations = _PYTEST_INVOCATION_RE.findall(folded_text)
     assert invocations, (
         f"no `uv run pytest tests/` invocation found in {workflow_name} — "
         "update this pin if the workflow's test step was restructured"

--- a/tests/test_ci_pytest_invocation.py
+++ b/tests/test_ci_pytest_invocation.py
@@ -1,0 +1,57 @@
+"""Pins that no workflow's pytest invocation excludes `tests/integration`.
+
+Nine tests under `tests/integration/` were red for nine days after commit
+`6bdb5846` and nobody was told, because `--ignore=tests/integration` on the
+pytest invocation in all three workflows (`quick.yml`, `full.yml`,
+`publish.yml`) meant nothing in CI ever collected that directory. #2808
+fixed the tests; #2810 removed the flag from all three workflows. That fixes
+the immediate incident but leaves nothing that turns red if the flag is ever
+reintroduced — this test is that guard.
+
+Same regex-extraction approach as `test_ci_path_filters.py`: this repo has
+no YAML-parsing dependency declared for tests to use (PyYAML is present only
+transitively, via a docs tool), and the `run:` step bodies here are shell
+script block scalars, not structure a workflow schema exposes as data. A
+regex anchored on the known `uv run pytest tests/` invocation is simpler and
+does not risk that dependency disappearing.
+
+Honest limit: this only proves the flag string is absent from the pytest
+invocation text in the three tracked workflow files. It says nothing about
+a future workflow file this repo might add, or about a flag with equivalent
+effect expressed a different way (e.g. `-k 'not integration'`, a marker
+deselect, or a `pyproject.toml` `addopts` change) — those would need a
+matching assertion added here, or they would drift the same way this one
+did.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+WORKFLOW_FILES = ("quick.yml", "full.yml", "publish.yml")
+
+_PYTEST_INVOCATION_RE = re.compile(r"uv run pytest tests/[^\n]*")
+
+
+def _pytest_invocations(workflow_name: str) -> list[str]:
+    text = (WORKFLOWS_DIR / workflow_name).read_text()
+    invocations = _PYTEST_INVOCATION_RE.findall(text)
+    assert invocations, (
+        f"no `uv run pytest tests/` invocation found in {workflow_name} — "
+        "update this pin if the workflow's test step was restructured"
+    )
+    return invocations
+
+
+def test_no_workflow_excludes_integration_tests() -> None:
+    for workflow_name in WORKFLOW_FILES:
+        for invocation in _pytest_invocations(workflow_name):
+            assert "--ignore=tests/integration" not in invocation, (
+                f"{workflow_name} excludes tests/integration from its pytest "
+                "invocation again — this is the same shape of incident that "
+                "left tests/integration/ uncollected and red for nine days "
+                "(commit 6bdb5846, fixed by #2808/#2810)"
+            )

--- a/tests/test_ci_pytest_invocation.py
+++ b/tests/test_ci_pytest_invocation.py
@@ -44,6 +44,14 @@ WORKFLOW_FILES = ("quick.yml", "full.yml", "publish.yml")
 
 _PYTEST_INVOCATION_RE = re.compile(r"uv run pytest tests/[^\n]*")
 
+# All three workflows name the pytest step "Run tests" at the same 6-space
+# step indent. Captures everything from that step's `name:` line up to (not
+# including) the next step at the same indent, or end of file.
+_RUN_TESTS_STEP_RE = re.compile(
+    r"^      - name: Run tests\n(.*?)(?=^      - name:|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+
 
 def _pytest_invocations(workflow_name: str) -> list[str]:
     text = (WORKFLOWS_DIR / workflow_name).read_text()
@@ -59,6 +67,16 @@ def _pytest_invocations(workflow_name: str) -> list[str]:
     return invocations
 
 
+def _run_tests_step_body(workflow_name: str) -> str:
+    text = (WORKFLOWS_DIR / workflow_name).read_text()
+    match = _RUN_TESTS_STEP_RE.search(text)
+    assert match, (
+        f"no `Run tests` step found in {workflow_name} — update this pin if "
+        "the step was renamed or restructured"
+    )
+    return match.group(1)
+
+
 def test_no_workflow_excludes_integration_tests() -> None:
     for workflow_name in WORKFLOW_FILES:
         for invocation in _pytest_invocations(workflow_name):
@@ -68,3 +86,15 @@ def test_no_workflow_excludes_integration_tests() -> None:
                 "left tests/integration/ uncollected and red for nine days "
                 "(commit 6bdb5846, fixed by #2808/#2810)"
             )
+        # Checked separately, over the whole `Run tests` step body rather
+        # than only the matched invocation line: a YAML folded block scalar
+        # (`run: >`) puts the flag on its own physical line and folds it
+        # into the shell command only at YAML-parse time, so it would never
+        # appear inside `[^\n]*` above yet would still reach the shell.
+        step_body = _run_tests_step_body(workflow_name)
+        assert "--ignore=tests/integration" not in step_body, (
+            f"{workflow_name}'s `Run tests` step body contains "
+            "--ignore=tests/integration outside the matched invocation "
+            "line — likely a folded (`run: >`) or otherwise reshaped "
+            "block scalar smuggling the flag back in"
+        )


### PR DESCRIPTION
## Summary

- Remove `--ignore=tests/integration` from the pytest invocation in `quick.yml`, `full.yml`, and `publish.yml`. That directory has run in none of the three workflows; this makes it run in all three.
- No Python source changed. No other flags, timeouts, or job structure touched — one flag removed, three files.
- Follow-up commit fixes the doc/prose fallout: every documented "run this before you are done" command still carried `--ignore=tests/integration` after the flag was dropped from CI, including one (CLAUDE.md) that explicitly claimed CI parity. Fixed in `CLAUDE.md`, `.claude/skills/release/SKILL.md`, `.claude/commands/regression-check.md`, `docs/internals/contributing.md`, `docs/internals/radio-state-pipeline-validation.md` (found by a repo-wide sweep, not in the original review), and the docstring in `tests/integration/test_x6200_audio_scope_smoke.py` that cited the old CLAUDE.md behavior. Also adds `tests/test_ci_pytest_invocation.py`, a pin (same regex-extraction style as `tests/test_ci_path_filters.py`, MOR-1911) asserting no workflow's pytest invocation excludes `tests/integration`, so this can't silently drift back.
- That follow-up commit touches 7 files (past the 6-file soft threshold, inside the 10-file hard ceiling). This is one unit of work, not a bundle: every file is falsifying the same sentence for the same reason (documenting a test command that ignores a directory CI no longer ignores), found by exhaustively grepping for the one flag this PR removed — splitting it across PRs would mean shipping some of those false claims and not others with no principled cutoff.

## Why

Nine tests in `tests/integration/` were red for nine days after commit `6bdb5846` and nobody was told, because nothing in CI ran them. They were repaired by #2808. This change is the guard that would have caught that regression in the PR that caused it.

## Measurements (dev Mac mini, `origin/main` = `e8fe6e45`, 14 workers)

| Command | Wall clock | Result |
|---|---|---|
| `tests/ --ignore=tests/integration -n auto` (today's CI command) | 59.90 s | 10635 passed, 12 skipped |
| `tests/ -n auto` (everything) | 60.87 s | 10902 passed, 68 skipped |
| `tests/integration/` alone, serial | ~70 s | 267 passed, 56 skipped |

Marginal cost of including the directory on that machine: about one second, because the parallel run already spreads ten thousand tests across workers. Three consecutive runs of the directory returned identical counts — no flakiness observed.

All 56 skips are hardware-gated by environment variables (`ICOM_HOST`, `ICOM_USER`, `ICOM_PASS`, `ICOM_SERIAL_DEVICE`, `ICOM_ALLOW_*`); on a runner with no radio attached they skip rather than fail. The other 267 run against mock/fake radios (`FakeAudioBackend`, mock CI-V transports) and need no hardware.

## What I checked in `.github/` (step 2 of the spec)

- `tests/**` is already in `quick.yml`'s `core` path filter (the block that decides whether the Python job runs at all), so this change doesn't need a filter update — verified by reading the `filters:` block directly.
- Grepped all of `.github/` for `integration`: the only three hits on the `--ignore=tests/integration` flag are the ones this PR touches. No job-level `continue-on-error`, coverage threshold, or matrix exclusion anywhere assumes the directory doesn't run.
- `pyproject.toml`'s `[tool.pytest.ini_options]` excludes `tests/integration` only via the CLI `--ignore` flag being removed here, not via a marker deselect (`addopts` is `-m 'not slow'`, unrelated) — so nothing else needs to change for the directory to be collected.
- Existing job timeouts (`quick.yml`: 10 min, `full.yml` test job: 25 min, `publish.yml` validate: 25 min) were not touched, per the spec. Given the ~1s-to-tens-of-seconds marginal cost estimate below, they should have headroom, but that's what this PR's own CI run will confirm.

## Runner topology — a correction to the assumed risk

`quick.yml` and `full.yml` run on `[self-hosted, linux, build]` — a self-hosted Mac mini runner, the same class of machine the measurements above were taken on — not GitHub-hosted `ubuntu-latest`. `publish.yml`'s `validate` job is the one job of the three that actually runs on `ubuntu-latest`, and only on `release: published`, not on every push/PR.

This matters for how much the "fewer cores on the real runner" caveat below applies: for `quick.yml`/`full.yml` the self-hosted runner is closer in class to the measurement machine, so the marginal-cost figure is more likely to transfer than it would to a GitHub-hosted box. For `publish.yml`'s `validate` job, the core-count risk applies as originally stated, and that job runs least often (release time), so its exposure is lower-frequency but the risk itself is closer to the pessimistic case.

## The honest risk

The runner-compatibility claim is **inference, not measurement** — it comes from reading skip markers and grepping test bodies, not from running on the actual CI runners. Concretely:

- The marginal-cost measurement was taken on a 14-worker machine. `quick.yml`/`full.yml`'s self-hosted runner and (especially) `publish.yml`'s `ubuntu-latest` runner may have fewer cores, so the real added time could be larger than the one-second figure above — plausibly tens of seconds, especially for `publish.yml`.
- If any of the 267 non-hardware-gated tests bind a fixed port, need an audio device, or assume the working directory is a git checkout, it will fail on the runner rather than skip. I grepped `tests/integration/*.py` for these shapes:
  - Fixed ports bound: none found. The only port-*binding* hit is `RigctldServer` on `localhost:0` (OS-assigned ephemeral port) in `test_rigctld_golden_replay.py`. **Correction:** `test_negative_auth_integration.py` does read a fixed port, `ICOM_NEGATIVE_PORT` (default `59999`), for an outbound *connect* to TEST-NET-1 — it doesn't bind one. That test is gated behind `ICOM_ALLOW_NEGATIVE_TESTS` and skips in CI, so the runner-compatibility argument (nothing binds a fixed port on this runner) still holds, but the original "Fixed ports: none found" overstated it — a fixed port is referenced, just not bound.
  - Audio devices: the only hits are `FakeAudioBackend` / `AudioDeviceInfo` mock objects in `test_rigctld_audio_pipeline.py` — no real device access.
  - `git rev-parse` / other git shell-outs: none found in `tests/integration/`. This shape does exist elsewhere in the suite — `test_known_owner_inventory_is_exact_and_monotonic` is known to fail outside a git checkout because it shells out to `git rev-parse HEAD` — but it is not present in the directory this PR newly runs.
  - No `subprocess.*` or raw `socket.socket(` calls in the integration test files themselves.

**The first CI run on this PR is itself the experiment.** If it goes red, that is information about the real runner environment, not a mistake in this change.

## Full-matrix validation (post-review)

`gh workflow run "Tests (full matrix)" --ref codex/ci-run-integration-tests` (run [33273252011](https://github.com/rigplane/rigplane-core/actions/runs/33273252011)) hit a failure on the 3.12 leg: `tests/test_radio_coverage.py::test_enable_scope_strict_sends_and_acks` — `rigplane.core.exceptions.TimeoutError: CI-V response timed out`. `full.yml`'s matrix has no explicit `fail-fast:`, so the GitHub Actions default (`true`) applied and cancelled the 3.11/3.13 legs before they finished — a matrix in that state can tell you almost nothing about the versions it didn't get to.

To get real data for all three versions, a disposable probe branch (`codex/full-matrix-probe-2810`, `fail-fast: false` added, deleted immediately after use, never merged into this PR) was dispatched (run [33273562499](https://github.com/rigplane/rigplane-core/actions/runs/33273562499)). Results:

| Python | Result |
|---|---|
| 3.11 | 10909 passed, 62 skipped, 47 xfailed, 1 xpassed — **green** |
| 3.12 | 1 failed, 10908 passed, 62 skipped, 47 xfailed, 1 xpassed |
| 3.13 | 1 failed, 10908 passed, 62 skipped, 47 xfailed, 1 xpassed |

Both failures are the same node id and error as above. `tests/integration/` node ids (including the two mock-based files, `test_rigctld_audio_pipeline.py` and `test_audio_routing.py`, whose `isinstance(radio, RigctldRoutable/AudioCapable)` paths were the specific concern) executed and passed on all three legs — confirmed by grepping each job's log for those two files' node ids: 10 PASSED, 0 FAILED, on 3.11, 3.12, and 3.13 alike. So the documented 3.11-vs-3.12+ `isinstance(AsyncMock(), <runtime_checkable Protocol>)` divergence does not manifest here.

**`test_enable_scope_strict_sends_and_acks` is pre-existing and not caused by this PR** — verified on a clean `origin/main` checkout (`06b85853`, zero relation to this branch's changes) where it fails identically and deterministically (fails in well under a second, both standalone and inside the full local suite — not a slow real timeout). No Python source is touched by this PR.

That said, this is new information worth surfacing on its own, separate from this PR's merge decision: this test has so far been treated as a Mac-mini-local environmental flake (it passes in `quick.yml`, which is Python 3.11-only). This run is the first evidence it also fails on the build runner itself, and the pattern across every sample collected today is consistent with a Python-version split rather than pure load-based flakiness: 3.11 passed in both the (cancelled-early but failure-free) first dispatch and the clean probe run; 3.12 failed in both the first dispatch and the probe (2/2); the one clean 3.13 sample (probe only) also failed. Locally, the same test fails deterministically and near-instantly in total isolation on Python 3.13.5 — not something that looks like scheduling noise under load. This is a correlation across a small sample, not a proven cause: it doesn't establish whether adding `tests/integration` (267 more tests, more load) makes the failure *more likely*, only that the failure exists independent of this PR and now has a first data point on the shared build runner. Recommend tracking this separately from #2810 rather than folding a fix into this PR.

## Round 2 — review fixes

Both round-1 BLOCKED findings were fixed at `8908d3df`. Both survived because the round-1 sweep grepped for the literal string `--ignore=tests/integration` instead of the claim it falsified — this round swept for the shape of the claim instead.

### B1 — three more false "CI skips integration" claims

- `CLAUDE.md` CI workflows table, `quick.yml` row: `pytest (no integration)` → `pytest (incl. tests/integration, hardware-gated tests skip automatically)`.
- `docs/internals/contributing.md` CI table row: `pytest (no hardware integration)` → `pytest (includes tests/integration; hardware-gated tests skip automatically without hardware env vars)`.
- `docs/internals/contributing.md` test-structure section: "Integration tests are in `tests/integration/` and require actual hardware" was false (most run against mocks/fakes; only `ICOM_*`/`RIGPLANE_HW_SMOKE`-gated tests need real hardware) — fixed, along with the adjacent tree-diagram comment making the same claim.

Shape sweep (`git grep -n -iE 'no (hardware )?integration|require actual hardware|skips? integration|without integration' -- '*.md' ':!docs/plans'` plus broader variants for "require a radio", "real hardware", "opted in", "explicitly run", and a full-text search for every `tests/integration` mention in `*.md`): found and fixed one more instance in an already-touched file — `docs/internals/radio-state-pipeline-validation.md`'s rigctld-consumer-behavior row said `test_rigctld_wsjtx.py` only runs "when integration is opted in", also false now since it's a mock-radio test collected by the standard suite. Every other hit is a different claim or already true and was left unfixed:
- `.claude/commands/scan-issues.md`, `docs/EXTENDED_PROTOCOL_RESEARCH.md`, `docs/guide/web-ui.md`, `docs/operations/managed-runtime-packaging.md`, `docs/validation/**`, `src/rigplane/validation/LAYER.md` — about live-hardware validation/CAT-audit work, not this suite's CI behavior.
- `docs/parity/test_mapping.md` — "require a real radio" is true for `test_reliability_matrix_integration.py` specifically (verified: hardware-gated via `pytest.skip` on `ICOM_*`/session-contention env vars, no `mock_integration` marker).
- `tests/integration/README.md` — pre-existing, stale local-dev doc (references a `-m integration`/`-m "not integration"` marker workflow and file names that don't match the current suite). Same general topic but not the CI-parity claim this PR is about, and fixing it would be an 11th file against the 10-file hard ceiling. Left unfixed; flagged for separate cleanup.

Non-blocking (owner's call, taken): `docs/internals/radio-state-pipeline-validation.md`'s "Recommended optional breadth" block held a `pytest` line byte-identical to the blocking regression gate in the table directly above it, so it added no breadth — deleted the line rather than leaving a mandatory gate mislabeled optional.

### B2 — the pin didn't fold shell line continuations

`tests/test_ci_pytest_invocation.py` matched `r"uv run pytest tests/[^\n]*"`, which stops at the first physical newline. `quick.yml` and `full.yml` write the invocation as `... \` + `| tee pytest-output.txt` on the next line — exactly where a flag would land if the command grew a wrap. Fixed by folding `\`+newline continuations to a space before matching. Docstring's "Honest limit" paragraph corrected: it claimed the pin covers the whole invocation text and omitted this exact evasion; now says continuation lines are included and lists `python -m pytest` / different-cwd / variable-built invocations as the remaining gaps.

Mutation proof, continuation-line flag on each of the three workflows, pin run before/after:

| Workflow | Mutated (flag on continuation line) | Reverted |
|---|---|---|
| `quick.yml` | RED — `AssertionError: quick.yml excludes tests/integration...` | GREEN — 1 passed |
| `full.yml` | RED — `AssertionError: full.yml excludes tests/integration...` | GREEN — 1 passed |
| `publish.yml` (converted to a `run: \|` block + continuation for the test) | RED — `AssertionError: publish.yml excludes tests/integration...` | GREEN — 1 passed |

All three workflow files verified byte-identical to the committed version after mutation testing (`git diff .github/workflows/` empty).

Checked for other regex-evasion shapes, per the review's ask: no other file under `.github/workflows/` (`agent-review-gate.yml`, `consumer-contracts-gate.yml`, `dispatch-downstream.yml`, `doc-citation-gate.yml`, `docs.yml`, `rebrand-gate.yml`, `state-types-gate.yml`, `visual.yml`) mentions `pytest` at all; no `python -m pytest` form exists anywhere; the pytest steps carry no `working-directory:` override; no composite action, reusable-workflow `uses:` call, Makefile, or tox/nox config hides an invocation outside these three files. Did not add a glob-all-workflows check for a hypothetical fourth workflow, since none exists today — that would be handling an unreachable case.

### Guardrails

10 files / 109 changed lines against merge-base `e8fe6e45` — at the file ceiling, inside the line ceiling. No new file added this round: both blocking fixes landed inside files already touched in round 1.

### Test run (Python 3.13.5, local)

`uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread`: 2 failed, 10901 passed, 68 skipped, 47 xfailed, 1 xpassed.
- `tests/test_radio_coverage.py::test_enable_scope_strict_sends_and_acks` — the pre-existing 3.12+ failure already established and tracked separately in the round-1 review; out of scope here (no Python source touched).
- `tests/test_icom7610_serial_radio.py::<varies per run>` — an `-n auto` xdist worker crash, a different test each of two consecutive full-suite runs; the whole file passes 49/49 serially in under 4s. Consistent with known local parallel-run flakiness on this machine, not a regression from this PR's doc/test-pin-only diff.

`uv run ruff check src/ tests/`: all checks passed. `uv run ruff format --check src/ tests/`: 691 files already formatted.

## Round 3 — review fix (B3)

Round 2's B1 and B2 were confirmed fixed; one B1-shaped instance survived in a place
no earlier sweep looked: Python module docstrings under `tests/integration/` itself,
not just `*.md`.

- `tests/integration/test_audio_routing.py` and `tests/integration/test_rigctld_wsjtx.py`
  both said these tests are "skipped in default CI runs" — true before this PR, false
  now that `--ignore=tests/integration` is gone from all three workflows.
  `tests/integration/conftest.py: pytest_collection_modifyitems` continues past
  `mock_integration` items without ever adding a skip marker, so both files now run in
  the standard suite and in all three CI workflows. Rewritten to say that, checked
  against `conftest.py`'s actual marker logic and against the three workflows' `run:`
  steps (all `uv run pytest tests/ ...`, no `--ignore`).

**12-file count is under an owner-granted ceiling exception**, not a self-waived
ceiling crossing: [comment 5465041532](https://github.com/rigplane/rigplane-core/pull/2810#issuecomment-5465041532)
grants exactly these two files, for the docstring correction only. `git diff --stat
e8fe6e45..HEAD` confirms 12 files, 129 insertions / 26 deletions.

Also applied the review's suggested non-blocking hardening in
`tests/test_ci_pytest_invocation.py` (no new file — same file already in the diff): a
YAML folded block scalar (`run: >` with the flag on its own physical line) evaded the
invocation-line regex, since YAML only folds it to one shell command at parse time,
after the pin's text-based extraction already ran. Added a second assertion checking
the whole `Run tests` step body, not just the matched invocation line. Mutation proof:
rewrote `publish.yml`'s step as `run: >` with `--ignore=tests/integration` on its own
line — pin went RED (`AssertionError: publish.yml's \`Run tests\` step body
contains --ignore=tests/integration...`); reverted via `git checkout` — pin GREEN
again (1 passed). `.github/workflows/` byte-identical to the committed version after.

### Gates at `ef519567`

- `uv run pytest tests/test_ci_pytest_invocation.py -q`: 1 passed.
- `uv run pytest tests/integration/ -q --tb=short --timeout=300 --timeout-method=thread`:
  267 passed, 56 skipped — matches the round-2 measurement exactly.
- `uv run ruff check src/ tests/`: all checks passed.
- `uv run ruff format --check src/ tests/`: 691 files already formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

