### PR TITLE
fix: fire the rigctld PTT re-read immediately on client connect

### DIFF
--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -186,6 +186,10 @@ class RigctldServer:
         self._acquisition_executor: AcquisitionExecutor | None = None
         self._state_acquisition_drain_task: asyncio.Task[None] | None = None
         self._ptt_reread_task: asyncio.Task[None] | None = None
+        # Serializes the scheduled tick against the connect-triggered
+        # immediate re-read below so the two can never put two 0x1C/0x00
+        # requests on the wire back to back.
+        self._ptt_reread_send_lock: asyncio.Lock = asyncio.Lock()
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
         self._state_diagnostics = getattr(radio, "_state_diagnostics", None)
         # Per-client sliding window for rate limiting: client_id → timestamps
@@ -510,23 +514,36 @@ class RigctldServer:
 
         Not via ``_send_one_state_query``: that carries bounded on-demand
         requests on the user-command lane, the wrong lane for a cadence.
+
+        Two independent triggers can reach this method: the scheduled tick
+        in ``_run_ptt_reread`` and the connect-triggered immediate re-read in
+        ``_accept_client``. If one is already in flight when the other
+        fires, the lock makes the second call a no-op instead of a second
+        frame on the wire — the in-flight request already covers the
+        connecting client, since it will resolve within one round trip
+        regardless of which trigger sent it.
         """
-        radio = self._radio
-        # Parity with the lazy poller start: an idle server stays off the wire.
-        if self._client_count <= 0 or not isinstance(radio, CivCommandCapable):
+        if self._ptt_reread_send_lock.locked():
             return
-        # A Hamlib bridge owns the byte stream; our reads must not pollute it
-        # (MOR-166 slice 2). ``is True``, matching every sibling poller, so a
-        # duck-typed radio never quiesces by accident.
-        if getattr(radio, "external_cat_session_active", False) is True:
-            return
-        await radio.send_civ(
-            0x1C,
-            sub=0x00,
-            wait_response=False,
-            priority=Priority.BACKGROUND,
-            wait_dispatch=False,
-        )
+        async with self._ptt_reread_send_lock:
+            radio = self._radio
+            # Parity with the lazy poller start: an idle server stays off
+            # the wire.
+            if self._client_count <= 0 or not isinstance(radio, CivCommandCapable):
+                return
+            # A Hamlib bridge owns the byte stream; our reads must not
+            # pollute it (MOR-166 slice 2). ``is True``, matching every
+            # sibling poller, so a duck-typed radio never quiesces by
+            # accident.
+            if getattr(radio, "external_cat_session_active", False) is True:
+                return
+            await radio.send_civ(
+                0x1C,
+                sub=0x00,
+                wait_response=False,
+                priority=Priority.BACKGROUND,
+                wait_dispatch=False,
+            )
 
     def _start_state_acquisition_drain_task(self) -> None:
         if (
@@ -1008,6 +1025,17 @@ class RigctldServer:
         # Start poller when the first client connects.
         if self._poller is not None and self._client_count == 1:
             self._spawn(self._poller.start())
+
+        # The re-read cadence otherwise ticks on its own clock from server
+        # start: a client connecting just before the next scheduled tick
+        # could find RF truth UNKNOWN and have its first DEFER-family write
+        # refused (RPRT -9). Firing one read on the zero-to-one transition
+        # closes that window instead of waiting out up to a full
+        # PTT_REREAD_INTERVAL_SECONDS; the scheduled cadence continues
+        # unchanged afterward, and the lock in _send_ptt_reread_once keeps
+        # this from ever doubling up with a tick that is already in flight.
+        if self._client_count == 1 and self._ptt_reread_task is not None:
+            self._spawn(self._send_ptt_reread_once())
 
         # Optional WSJT-X compatibility pre-warm for first client:
         # if radio is in USB/LSB/RTTY with DATA off, enable DATA mode upfront

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -186,10 +186,6 @@ class RigctldServer:
         self._acquisition_executor: AcquisitionExecutor | None = None
         self._state_acquisition_drain_task: asyncio.Task[None] | None = None
         self._ptt_reread_task: asyncio.Task[None] | None = None
-        # Serializes the scheduled tick against the connect-triggered
-        # immediate re-read below so the two can never put two 0x1C/0x00
-        # requests on the wire back to back.
-        self._ptt_reread_send_lock: asyncio.Lock = asyncio.Lock()
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
         self._state_diagnostics = getattr(radio, "_state_diagnostics", None)
         # Per-client sliding window for rate limiting: client_id → timestamps
@@ -517,33 +513,42 @@ class RigctldServer:
 
         Two independent triggers can reach this method: the scheduled tick
         in ``_run_ptt_reread`` and the connect-triggered immediate re-read in
-        ``_accept_client``. If one is already in flight when the other
-        fires, the lock makes the second call a no-op instead of a second
-        frame on the wire — the in-flight request already covers the
-        connecting client, since it will resolve within one round trip
-        regardless of which trigger sent it.
+        ``_accept_client``. They are not serialized against each other, so
+        both can put a ``0x1C/0x00`` request on the wire close together.
+        That is harmless: the read carries no side effect and the reply is
+        idempotent, so a duplicate in-flight request changes nothing the
+        gate or the StateStore observes.
         """
-        if self._ptt_reread_send_lock.locked():
+        radio = self._radio
+        # Parity with the lazy poller start: an idle server stays off the wire.
+        if self._client_count <= 0 or not isinstance(radio, CivCommandCapable):
             return
-        async with self._ptt_reread_send_lock:
-            radio = self._radio
-            # Parity with the lazy poller start: an idle server stays off
-            # the wire.
-            if self._client_count <= 0 or not isinstance(radio, CivCommandCapable):
-                return
-            # A Hamlib bridge owns the byte stream; our reads must not
-            # pollute it (MOR-166 slice 2). ``is True``, matching every
-            # sibling poller, so a duck-typed radio never quiesces by
-            # accident.
-            if getattr(radio, "external_cat_session_active", False) is True:
-                return
-            await radio.send_civ(
-                0x1C,
-                sub=0x00,
-                wait_response=False,
-                priority=Priority.BACKGROUND,
-                wait_dispatch=False,
-            )
+        # A Hamlib bridge owns the byte stream; our reads must not pollute it
+        # (MOR-166 slice 2). ``is True``, matching every sibling poller, so a
+        # duck-typed radio never quiesces by accident.
+        if getattr(radio, "external_cat_session_active", False) is True:
+            return
+        await radio.send_civ(
+            0x1C,
+            sub=0x00,
+            wait_response=False,
+            priority=Priority.BACKGROUND,
+            wait_dispatch=False,
+        )
+
+    async def _send_ptt_reread_once_on_connect(self) -> None:
+        """Spawn target for the connect-triggered re-read in ``_accept_client``.
+
+        Same exception discipline as the scheduled-tick caller,
+        ``_run_ptt_reread``: a dead or mid-teardown transport must not
+        surface as an unretrieved task exception on
+        ``RigctldServer._spawn``'s done-callback, which only discards the
+        task and never retrieves its result.
+        """
+        try:
+            await self._send_ptt_reread_once()
+        except Exception as exc:
+            logger.debug("rigctld PTT re-read failed: %s", exc, exc_info=True)
 
     def _start_state_acquisition_drain_task(self) -> None:
         if (
@@ -1032,10 +1037,11 @@ class RigctldServer:
         # refused (RPRT -9). Firing one read on the zero-to-one transition
         # closes that window instead of waiting out up to a full
         # PTT_REREAD_INTERVAL_SECONDS; the scheduled cadence continues
-        # unchanged afterward, and the lock in _send_ptt_reread_once keeps
-        # this from ever doubling up with a tick that is already in flight.
+        # unchanged afterward. This can race a tick already in flight and
+        # put two 0x1C/0x00 requests on the wire close together -- harmless,
+        # since the read is idempotent and carries no side effect.
         if self._client_count == 1 and self._ptt_reread_task is not None:
-            self._spawn(self._send_ptt_reread_once())
+            self._spawn(self._send_ptt_reread_once_on_connect())
 
         # Optional WSJT-X compatibility pre-warm for first client:
         # if radio is in USB/LSB/RTTY with DATA off, enable DATA mode upfront

--- a/tests/integration/_ptt_reread_fixtures.py
+++ b/tests/integration/_ptt_reread_fixtures.py
@@ -34,13 +34,15 @@ Neither helper touches ``_defer_write_gate``, the TX-interlock family
 classification, or any production module; both only make a test double
 capable of answering a read the gate already requires.
 
-Answering the read is not instantaneous, though: ``_run_ptt_reread`` only
-sends its first ``0x1C/0x00`` after one ``PTT_REREAD_INTERVAL_SECONDS`` sleep,
-and only once a client is connected. A real hamlib client that issues a
-DEFER-classified write inside that startup window sees exactly the same
+Answering the read is not instantaneous, though: ``RigctldServer._accept_client``
+fires one ``0x1C/0x00`` immediately on the zero-to-one client transition
+(closing the tick-vs-connect race), but that first send still needs a round
+trip before the reply lands, and ``_run_ptt_reread``'s own scheduled cadence
+only runs once a client is connected at all. A real hamlib client that issues
+a DEFER-classified write inside that round trip sees exactly the same
 ``RPRT -9`` an unpatched fixture does; that is the resolver working as
 designed, not a bug to route around. ``wait_for_known_rf_state`` below waits
-that same window out — the way a well-behaved client would — instead of
+that round trip out — the way a well-behaved client would — instead of
 racing it.
 """
 

--- a/tests/test_rigctld_ptt_reread.py
+++ b/tests/test_rigctld_ptt_reread.py
@@ -13,6 +13,7 @@ ingress, from a real radio reply (MOR-1900).
 from __future__ import annotations
 
 import asyncio
+import gc
 import time
 from collections.abc import Generator
 from typing import Any
@@ -339,6 +340,54 @@ async def test_client_connecting_at_server_start_gets_known_state_before_first_w
             await writer.wait_closed()
     finally:
         await server.stop()
+
+
+async def test_connect_triggered_reread_does_not_leak_loop_exception(
+    civ_radio: IcomRadio,
+) -> None:
+    """A dropped CI-V link at connect must not surface as a loop-level error.
+
+    ``RigctldServer._spawn``'s done-callback only discards the task from
+    ``_bg_tasks``; it never retrieves the task's result. Before this test,
+    a ``ConnectionError`` from ``send_civ`` on the connect-triggered
+    re-read (``_send_ptt_reread_once`` spawned directly, with no exception
+    handling of its own) escaped as an asyncio "Task exception was never
+    retrieved" error, once per connect on a dead link -- plausible whenever
+    a client connects while the CI-V link is down. This pins that the
+    connect path now carries the same swallow-and-log discipline as the
+    scheduled-tick caller, ``_run_ptt_reread``.
+    """
+    civ_radio.send_civ = AsyncMock(  # type: ignore[method-assign]
+        side_effect=ConnectionError("Not connected to radio")
+    )
+    server = RigctldServer(civ_radio, RigctldConfig(host="127.0.0.1", port=0))
+
+    loop = asyncio.get_running_loop()
+    loop_exceptions: list[dict[str, Any]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_exceptions.append(context))
+    try:
+        await server.start()
+        try:
+            assert server._server is not None  # noqa: SLF001
+            port = server._server.sockets[0].getsockname()[1]  # noqa: SLF001
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            try:
+                # Let the connect-triggered task run to completion and be
+                # garbage-collected -- that is when an unretrieved task
+                # exception is reported to the loop's exception handler.
+                await asyncio.sleep(0.05)
+                gc.collect()
+                await asyncio.sleep(0)
+            finally:
+                writer.close()
+                await writer.wait_closed()
+        finally:
+            await server.stop()
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert loop_exceptions == [], loop_exceptions
 
 
 def test_yaesu_radio_gets_no_civ_reread_task() -> None:

--- a/tests/test_rigctld_ptt_reread.py
+++ b/tests/test_rigctld_ptt_reread.py
@@ -281,6 +281,66 @@ async def test_started_server_drives_reads_only_while_a_client_is_connected(
     assert server._ptt_reread_task is None and task.done()  # noqa: SLF001
 
 
+async def test_client_connecting_at_server_start_gets_known_state_before_first_write(
+    civ_radio: IcomRadio,
+) -> None:
+    """Connect-triggered immediate re-read closes the tick-vs-connect race.
+
+    Regression test for the production defect measured on the bench IC-7300:
+    ``_run_ptt_reread`` ticks on its own clock from *server* start, not from
+    when a client connects. Connecting into the cold phase of that cadence
+    -- worst case, right after start, a full ``PTT_REREAD_INTERVAL_SECONDS``
+    from the next scheduled tick -- left RF truth UNKNOWN for that whole
+    window pre-fix, so a client that writes soon after connecting (as
+    WSJT-X's "Test CAT" does) got its first DEFER-classified write refused
+    with ``RPRT -9``. Six connect-and-immediately-write runs on real
+    hardware hit this in 2/6: first refusal ~0.06s after connect, first
+    success only at ~0.26-0.277s -- essentially one whole tick later.
+
+    This test connects immediately after ``server.start()`` (the same
+    worst-case phase) and writes 0.01s later -- 25x tighter than one
+    ``PTT_REREAD_INTERVAL_SECONDS``, comparable to a well-behaved client's
+    own small overhead. Before the fix, this reproduces the RPRT -9 every
+    time (nothing has been sent to the radio yet at that point); after it,
+    the connect-triggered immediate re-read in
+    ``RigctldServer._accept_client`` has already resolved RF truth.
+    """
+    send_civ = AsyncMock(return_value=None)
+
+    async def answering_send_civ(cmd: int, **kwargs: Any) -> None:
+        await send_civ(cmd, **kwargs)
+        if cmd == 0x1C and kwargs.get("sub") == 0x00:
+            await _deliver(civ_radio, _ptt_reply(civ_radio, transmitting=False))
+
+    civ_radio.send_civ = answering_send_civ  # type: ignore[method-assign]
+    server = RigctldServer(civ_radio, RigctldConfig(host="127.0.0.1", port=0))
+    await server.start()
+    try:
+        assert server._server is not None  # noqa: SLF001
+        port = server._server.sockets[0].getsockname()[1]  # noqa: SLF001
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            await asyncio.sleep(0.01)
+            # ``M`` (mode), not ``F``: MOR-1940 reclassified FREQUENCY as
+            # TX-SAFE, so it would already succeed before any answer and
+            # could not demonstrate this race.
+            writer.write(b"M USB 2400\n")
+            await writer.drain()
+            response = await asyncio.wait_for(
+                reader.readline(), timeout=PTT_REREAD_INTERVAL_SECONDS * 0.5
+            )
+            assert response == b"RPRT 0\n", (
+                "first write after connect was refused -- the connect-"
+                f"triggered immediate re-read did not resolve RF truth in "
+                f"time (got {response!r})"
+            )
+        finally:
+            writer.close()
+            await writer.wait_closed()
+    finally:
+        await server.stop()
+
+
 def test_yaesu_radio_gets_no_civ_reread_task() -> None:
     from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
     from rigplane.radio_protocol import CivCommandCapable


### PR DESCRIPTION
## Summary

Standalone rigctld's `0x1C/0x00` PTT re-read (`RigctldServer._run_ptt_reread`) ticks on its own clock from server start, independent of when a client connects. A client that connects into a cold phase of that cadence — worst case, right after start, up to a full `PTT_REREAD_INTERVAL_SECONDS` (0.25s) from the next scheduled tick — found RF truth stuck `UNKNOWN`, so its first DEFER-family write (mode, band, VFO select, VFO topology, memory) was refused with `RPRT -9` by `_defer_write_gate`.

Measured on the bench IC-7300 across six connect-and-immediately-write runs:
- 2/6 hit the window: first `RPRT -9` at ~0.063-0.067s after connect, first success only at ~0.260-0.277s.
- 4/6 happened to connect into a warm phase and succeeded on the first attempt at ~0.17s.
- Idle duration before connect made no difference (1s and 3s gaps behaved identically) — confirms this is phase relative to the tick, not warm-up.

`RPRT -9` is `HamlibError.ERJCTED`, which WSJT-X treats as a fatal CAT error and drops the connection on. So roughly one in three real "Test CAT" attempts failed.

## The fix

`RigctldServer._accept_client` now fires one `_send_ptt_reread_once()` on the client-count zero-to-one transition — the same signal already used to start the poller and the WSJT-X compat pre-warm. The scheduled cadence in `_run_ptt_reread` is untouched; it keeps ticking at the same interval afterward.

The scheduled tick and the connect-triggered send are not serialized against each other, so both can put a `0x1C/0x00` request on the wire close together. That is not a defect: the read carries no side effect and the reply is idempotent, so a duplicate in-flight request changes nothing the gate or the StateStore observes. (An earlier revision of this PR added an `asyncio.Lock` intended to prevent that overlap; Agent Review measured that it could not do so — `send_civ(..., wait_dispatch=False)` has no suspension points, so the lock was released within the same uninterrupted loop step it was acquired in — and that the lock's one reachable branch, hit only when `_wait_for_civ_transport_recovery` holds it for up to 12s, silently dropped the connect-triggered read with no retry. The lock has been removed.)

`_defer_write_gate` and `_resolve_rigctld_rf_state` are unchanged: `UNKNOWN` still refuses. No observation is fabricated — the fix removes the *cause* of spurious `UNKNOWN`, not the response to it.

`RigctldServer._spawn`'s done-callback only discards the task from `_bg_tasks` and never retrieves its result, so a `ConnectionError` from `send_civ` on the connect-triggered path (plausible when a client connects while the CI-V link is down) used to escape as an unretrieved asyncio task exception once per connect. The connect-triggered call now goes through `_send_ptt_reread_once_on_connect`, a thin wrapper matching `_run_ptt_reread`'s own swallow-and-log discipline for the identical failure mode.

## Mutation evidence

1. New regression test on today's code (fix reverted, test kept): **FAILS** — reproduces `RPRT -9` on the first write after connect.
2. Fix restored: test **PASSES**.
3. Separately mutated `_defer_write_gate` so `RfState.UNKNOWN` passes instead of refusing: `tests/test_rigctld_tx_interlock.py` went **13 failed / 82 passed**, then reverted (confirmed clean diff on `handler.py` afterward). This proves the fix was not achieved by weakening the gate.
4. New regression test `test_connect_triggered_reread_does_not_leak_loop_exception` reproduces the reviewer's probe (`send_civ` raising `ConnectionError` on connect, a custom loop exception handler installed): **FAILS** with the exception wrapper reverted (`Task exception was never retrieved`), **PASSES** with `_send_ptt_reread_once_on_connect` in place.

## Test plan

- [x] New test `test_client_connecting_at_server_start_gets_known_state_before_first_write` in `tests/test_rigctld_ptt_reread.py` — fails pre-fix, passes post-fix, verified stable across 5 repeated runs
- [x] New test `test_connect_triggered_reread_does_not_leak_loop_exception` in `tests/test_rigctld_ptt_reread.py` — fails without the exception wrapper, passes with it
- [x] `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — 10636 passed, 1 failed (pre-existing environmental failure, `test_enable_scope_strict_sends_and_acks`), 12 skipped, 47 xfailed, 1 xpassed — matches reference counts at `origin/main` `e8fe6e45` plus the one new test
- [x] `uv run pytest tests/integration/ -q --tb=short --timeout=300 --timeout-method=thread` — 267 passed, 0 failed, 56 skipped — matches reference
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — 690 files already formatted
- [x] `uv run lint-imports` — 5 kept, 0 broken
- [x] `uv run mypy --strict src/rigplane/web` — no issues

Also corrected a docstring in `tests/integration/_ptt_reread_fixtures.py` that this fix directly falsified — it claimed the first `0x1C/0x00` only goes out after one full `PTT_REREAD_INTERVAL_SECONDS` sleep, which is no longer accurate now that connect fires one immediately.

## Open question left for hardware measurement (not addressed here)

Agent Review flagged that in `--wsjtx-compat` mode, the connect-triggered `0x1C/0x00` read is sent at `Priority.BACKGROUND` while `_wsjtx_compat_prewarm` — spawned four lines later in the same `_accept_client` — enqueues `get_mode`/`get_data_mode`/`set_data_mode` at `Priority.NORMAL`, which the commander's priority queue dispatches first. The measured margin on the bench (refusal at ~63ms, round trip ~10-27ms) is thin enough that the window could reopen in that mode specifically. This PR does not change priorities or ordering to pre-empt that; a further bench measurement with `--wsjtx-compat` enabled against this head is expected before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
