### PR TITLE
fix(MOR-1996): make enable_scope STRICT test causally accurate for py3.12+

### DIFF
--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -1107,9 +1107,18 @@ async def test_enable_scope_strict_sends_and_acks(
     """STRICT policy waits for ACK from each command."""
     from rigplane.types import ScopeCompletionPolicy
 
-    # Queue two ACK responses (one for scope-on, one for scope-output)
-    mock_transport.queue_response(_ack_response())
-    mock_transport.queue_response(_ack_response())
+    # Release each ACK only after its own command is actually sent (real
+    # radios can't ACK a command before it goes out over the wire). Queuing
+    # both ACKs up front let the CI-V rx pump race ahead of the second
+    # command's ACK-waiter registration on Python 3.12+ -- asyncio.wait_for()
+    # no longer forces a scheduler yield when its awaitable is already
+    # resolved (gh-97481), so the pump could drain both queued responses back
+    # to back before enable_scope() even sent the second command, filing the
+    # second ACK into the orphan backlog that a freshly-registered waiter is
+    # deliberately barred from consuming (MOR-1977). One ACK per send() call
+    # keeps this test's timing causally accurate on every interpreter.
+    mock_transport.queue_response_on_send(1, _ack_response())
+    mock_transport.queue_response_on_send(2, _ack_response())
     await radio.enable_scope(policy=ScopeCompletionPolicy.STRICT)
 
 


### PR DESCRIPTION
## Root cause

\`tests/test_radio_coverage.py::test_enable_scope_strict_sends_and_acks\` pre-queues **both** mock ACK responses on \`MockTransport\` before calling \`radio.enable_scope(policy=STRICT)\`, which sends two sequential CI-V commands (scope-on, then scope-data-output) and blocks on an ACK for each.

The \`0.014012...\` timeout seen in the traceback is not a constant — it's what's left of the 50ms deadline (\`IcomRadio(timeout=0.05)\` from the test fixture) after the mandatory ~35ms inter-command pacing sleep (\`_civ_min_interval\`, `src/rigplane/runtime/radio.py: CoreRadio.__init__`) is subtracted, computed fresh in \`_execute_civ_raw\` (`src/rigplane/runtime/_civ_rx.py`) for the *second* command.

The real defect is a scheduling race exposed by that tight window:

- \`_civ_rx.py: CivIoMixin._civ_rx_loop\` pumps one CI-V packet per turn via \`MockTransport.receive_packet()\`, which calls \`asyncio.wait_for(self._responses.get(), timeout=0.2)\`.
- On **Python 3.11**, \`asyncio.wait_for()\` always wraps its awaitable via \`ensure_future()\` and forces a scheduler yield/task-hop even when the inner coroutine is already resolvable. That forced yield lets \`enable_scope()\`'s main coroutine interleave and register the *second* command's ACK waiter between the pump processing ACK #1 and ACK #2.
- On **Python 3.12+**, \`wait_for()\` was reimplemented on top of \`asyncio.timeout()\` (gh-97481) and awaits an already-ready coroutine **synchronously, with no forced yield**. The rx pump therefore drains both pre-queued ACKs back-to-back in one shot, *before* \`enable_scope()\` has even sent the second command or registered its waiter.
- The second ACK is then routed with zero waiters registered, so \`CivRequestTracker.resolve()\` (`src/rigplane/core/civ.py`) files it into the orphan \`_ack_backlog\`. When the second command's waiter registers moments later via \`register_ack(wait=True, consume_backlog=False)\`, it deliberately refuses to consume that backlog entry — a MOR-1977 anti-mischarge guard against charging one command's ACK to another. The second command then waits for a frame that will never arrive and genuinely times out.

Verified directly with a minimal repro (\`asyncio.wait_for(already_ready_coro, timeout=1.0)\` racing a concurrently-created task): on 3.11 the concurrent task runs to completion *before* \`wait_for\` returns; on 3.12 \`wait_for\` returns *before* the concurrent task even starts. Also traced \`register_ack\`/\`resolve\` call order directly against this test: on 3.11 they strictly alternate (register→resolve→register→resolve); on 3.12 both \`resolve\` calls fire back-to-back before the second \`register_ack\`.

**This cannot happen against a real radio.** A physical rig's ACK for the second command cannot exist before that command is transmitted over CI-V — there is no causality that would let it arrive early. The race only exists because the test pre-loads both mock responses up front, decoupling "response available" from "command actually sent." The test's own setup was unsound; it was only accidentally timing-safe under 3.11's extra forced yield, not by any real guarantee.

## Fix

Use \`MockTransport.queue_response_on_send()\` (already present in \`tests/test_radio.py\`, built for exactly this) instead of \`queue_response()\`, so each ACK is only released after its own \`send_tracked()\` call — matching real radio causality instead of depending on interpreter-specific scheduling. No production code changed.

## Interpreter evidence (3 runs each, worktree venv)

| Python | Run 1 | Run 2 | Run 3 |
|---|---|---|---|
| 3.11.13 | pass (0.20s) | pass (0.19s) | pass (0.20s) |
| 3.12.11 | pass (0.16s) | pass (0.16s) | pass (0.16s) |
| 3.13.5  | pass (0.22s) | pass (0.21s) | pass (0.22s) |

## Mutation proof (test still discriminates)

The test pins "STRICT waits for and validates an ACK for each of the two commands it sends." To prove it still catches a regression of that behavior, in \`src/rigplane/runtime/_scope_runtime.py: ScopeRuntimeMixin.enable_scope\`, the scope-data-output ACK/NAK check was flipped from \`is False\` to \`is True\`:

```
-                if parse_ack_nak(resp) is False:
+                if parse_ack_nak(resp) is True:
                     raise CommandError("Radio rejected scope data output enable")
```

With that mutation in place, the fixed test goes red on Python 3.12:

```
FAILED tests/test_radio_coverage.py::test_enable_scope_strict_sends_and_acks
rigplane.core.exceptions.CommandError: Radio rejected scope data output enable
```

Mutation reverted via \`git checkout\` before committing (\`git diff --stat\` shows only the test file changed).

## Gates

- \`ruff check src/ tests/\` — all checks passed
- \`ruff format --check src/ tests/\` — 690 files already formatted
- \`lint-imports\` — 5 kept, 0 broken
- \`mypy --strict src/rigplane/web\` — not applicable, no files under \`src/rigplane/web/\` touched

## Wider suite (Python 3.12.11, this worktree)

- Standard suite: **10575 passed, 74 skipped, 47 xfailed, 1 xpassed** (109.76s). Reference at \`origin/main\` was 10635 passed / 12 skipped / 47 xfailed / 1 xpassed. The gap is environment, not regression: this fresh worktree's \`uv sync --all-extras\` doesn't have Pillow, the \`aiortc\` extra, native libopus, or a built frontend bundle (\`src/rigplane/web/static/index.html\`), each of which the affected tests skip on cleanly when absent. No unexpected failures.
- \`tests/integration/\`: **268 passed, 56 skipped** (65.25s), vs. reference 267 passed / 56 skipped — the +1 reflects \`origin/main\` moving since the reference was taken, not a regression.

## Scope note (audit sweep, not fixed here)

Per the "sweep the class" rule, I searched the whole test tree for the same shape (2+ pre-queued mock responses feeding a call that sends multiple sequential blocking CI-V commands). Found 4 candidates total:

- \`tests/test_civ_rx_coverage.py::test_civ_rx_loop_skips_short_packets\` and \`::test_civ_rx_loop_skips_invalid_civ_frames\` — queue 2 packets each, but drive the rx loop directly with a patched counting callback; there's no second caller-side waiter registration to race against, so this isn't the same shape.
- \`tests/test_radio_coverage.py::test_snapshot_state_returns_dict_with_basics\` — queues 3 response frames up front for 3 sequential \`await radio.get_*()\` calls inside \`snapshot_state()\`, which has the identical theoretical race (RESPONSE frames get silently dropped rather than backlogged if no waiter is registered yet). Confirmed it currently passes on Python 3.12 anyway, because its own assertion (\`assert "frequency" in snap or len(snap) >= 0\`) is a tautology that can't go red regardless of which values land in \`snap\`. Left unfixed — it's a separate, pre-existing "test that cannot discriminate" issue, out of scope for this single-node-id release-blocker fix, and repairing its assertion is a design decision beyond this PR's guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)