### PR TITLE
docs: correct tests/integration/README.md against how the directory runs

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,19 +1,20 @@
 # Integration Tests
 
-Most of this directory runs with **no hardware attached**, on every PR.
+Most of this directory runs with **no hardware attached**, on every PR that
+runs the test suite.
 
 The name is historical: it once held only tests that talked to a real Icom
 transceiver. It now holds two populations, distinguished by marker:
 
 | Population | Marker | Needs hardware? |
 |---|---|---|
-| Mock integration | `mock_integration` | No — runs everywhere, including CI |
+| Mock integration | `mock_integration` | No — runs whenever the suite runs (see **CI** below) |
 | Hardware integration | `integration` without `mock_integration` | Yes — skips unless configured |
 
 The hardware population is skipped, not failed, when its environment is not
 configured. The skip is applied in `conftest.py:
-pytest_collection_modifyitems`, which is the authority for what gets gated
-and why.
+pytest_collection_modifyitems`, which is the authority for the
+hardware-configuration skip.
 
 To see the current split on your checkout:
 
@@ -50,12 +51,17 @@ Path-based exclusion (`--ignore=tests/integration`) also works, but see
 
 ## Markers
 
-`integration`, `serial_integration`, `ic7610_parity` and `mock_integration`
-are registered in `conftest.py: pytest_configure`, local to this directory —
-not in the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`,
-which registers a different set (`integration`, `hardware`, `e2e`, `slow`,
-`validation_hardware`). A run that never collects this directory's
-`conftest.py` therefore does not know the three local markers.
+`serial_integration`, `ic7610_parity` and `mock_integration` are registered
+in `conftest.py: pytest_configure`, local to this directory. `integration`
+is registered there too, but it is *not* local — it is also registered in
+the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`, with the
+same description string in both places. `pyproject.toml` additionally
+registers `hardware`, `e2e`, `slow` and `validation_hardware`, which this
+directory does not use.
+
+A run that never collects this directory's `conftest.py` therefore does not
+know the three local markers (`serial_integration`, `ic7610_parity`,
+`mock_integration`) — `integration` stays registered regardless.
 
 ## Hardware configuration
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,59 +1,91 @@
 # Integration Tests
 
-These tests run against a real Icom transceiver on your network.
+Most of this directory runs with **no hardware attached**, on every PR.
 
-## Prerequisites
+The name is historical: it once held only tests that talked to a real Icom
+transceiver. It now holds two populations, distinguished by marker:
 
-1. Icom radio with LAN/WiFi control (IC-7610, IC-705, IC-7300, IC-9700, etc.)
-2. Radio connected to the same network
-3. Username and password configured in the radio
+| Population | Marker | Needs hardware? |
+|---|---|---|
+| Mock integration | `mock_integration` | No — runs everywhere, including CI |
+| Hardware integration | `integration` without `mock_integration` | Yes — skips unless configured |
 
-## Configuration
+The hardware population is skipped, not failed, when its environment is not
+configured. The skip is applied in `conftest.py:
+pytest_collection_modifyitems`, which is the authority for what gets gated
+and why.
 
-Set environment variables:
+To see the current split on your checkout:
+
+```bash
+uv run pytest tests/integration -m mock_integration --co -q      # no hardware needed
+uv run pytest tests/integration -m "integration and not mock_integration" --co -q   # hardware
+```
+
+## Running
+
+Always via `uv run` — never a bare `pytest`.
+
+```bash
+uv run pytest tests/integration -q                  # whole directory
+uv run pytest tests/integration -m mock_integration # only the no-hardware tests
+uv run pytest tests/integration/test_radio_integration.py -v
+uv run pytest tests/integration/test_radio_integration.py::TestFrequency -v
+uv run pytest tests/integration/test_radio_integration.py::TestFrequency::test_get_frequency -v
+```
+
+### Selecting and excluding by marker
+
+`-m "not integration"` does **not** exclude this directory. Six files carry
+only `mock_integration`, so a `not integration` filter still collects their
+tests. Use both markers:
+
+```bash
+uv run pytest tests/ -m "not integration and not mock_integration"   # exclude this directory
+uv run pytest tests/ -m "integration and not mock_integration"       # hardware tests only
+```
+
+Path-based exclusion (`--ignore=tests/integration`) also works, but see
+**CI** below before adding it to anything that runs in CI.
+
+## Markers
+
+`integration`, `serial_integration`, `ic7610_parity` and `mock_integration`
+are registered in `conftest.py: pytest_configure`, local to this directory —
+not in the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`,
+which registers a different set (`integration`, `hardware`, `e2e`, `slow`,
+`validation_hardware`). A run that never collects this directory's
+`conftest.py` therefore does not know the three local markers.
+
+## Hardware configuration
+
+Only needed for the hardware population.
+
+### LAN radio
 
 ```bash
 export ICOM_HOST=192.168.55.40      # Radio IP address
 export ICOM_USER=your_username       # Radio username
 export ICOM_PASS=your_password       # Radio password
-export ICOM_RADIO_ADDR=0x98          # CI-V address (default: IC-7610)
+export ICOM_RADIO_ADDR=0x98          # CI-V address (conftest default: IC-7610)
 ```
 
-## Running Tests
+Prerequisites: an Icom radio with LAN/WiFi control (IC-7610, IC-705, IC-7300,
+IC-9700, …) on the same network, with a username and password configured in
+the radio.
 
-### All tests including integration:
+### Serial radio
+
 ```bash
-pytest
+export ICOM_SERIAL_DEVICE=/dev/ttyUSB0
+export ICOM_SERIAL_BAUDRATE=115200
+export ICOM_SERIAL_RADIO_ADDR=0x98
 ```
 
-### Only integration tests:
-```bash
-pytest -m integration
-```
+### Hardware smoke
 
-### Skip integration tests (unit tests only):
 ```bash
-pytest -m "not integration"
-```
-
-### Verbose output:
-```bash
-pytest -m integration -v -s
-```
-
-### Specific test file:
-```bash
-pytest tests/integration/test_radio_integration.py -v
-```
-
-### Specific test class:
-```bash
-pytest tests/integration/test_radio_integration.py::TestFrequency -v
-```
-
-### Specific test:
-```bash
-pytest tests/integration/test_radio_integration.py::TestFrequency::test_get_frequency -v
+export RIGPLANE_HW_SMOKE=1
 ```
 
 ## Test Categories
@@ -103,12 +135,22 @@ export ICOM_ALLOW_NEGATIVE_TESTS=1       # bad credentials/unreachable host test
 export ICOM_PCM_REQUIRE_FRAMES=1         # set 0 for PCM smoke-only
 ```
 
-## CI/CD
+## CI
 
-Integration tests are **automatically skipped** in CI environments where
-`ICOM_HOST`, `ICOM_USER`, and `ICOM_PASS` are not set.
+This directory is **part of the per-PR gate**. All three workflows
+(`quick.yml`, `full.yml`, `publish.yml`) run `uv run pytest tests/` with no
+path exclusion, so the mock population is collected and must pass like any
+other test. Only the hardware population skips there, because no CI runner
+sets the variables above.
+
+That the flag is absent is pinned by `tests/test_ci_pytest_invocation.py`,
+which turns red if `--ignore=tests/integration` is reintroduced into any of
+the three workflows' pytest invocations. Its module docstring records the
+incident that motivated it and the limits of what it proves.
 
 ## Troubleshooting
+
+Applies to the hardware population.
 
 ### Connection refused
 - Check radio IP: `ping 192.168.55.40`


### PR DESCRIPTION
Stacked on #2810 — base is `codex/ci-run-integration-tests`, not `main`.

## Why stacked rather than based on `main`

`tests/integration/README.md` is the known remainder from #2810: fixing it there would have made that PR an eleventh file against the hard ceiling of 10, which is not author-waivable.

But the corrections it needs include *"this directory is part of the per-PR gate"*, and that is **false on `main` today** — #2810 is still open, and all three workflows on `main` still carry `--ignore=tests/integration`. Basing this on `main` would mean landing prose that is untrue until #2810 merges, which is exactly what the repo's prose rule forbids.

Basing it on #2810's head makes every claim true in the tree the README ships in. GitHub prevents this PR from reaching `main` ahead of #2810 (it retargets to `main` automatically once #2810 merges), but that alone does not fix the merge order for `codex/ci-run-integration-tests` itself — see **Merge order** below for why #2810 must merge to `main` first.

## Merge order

This PR's base is `codex/ci-run-integration-tests` (#2810's branch), not
`main`. Merging this PR first would merge it *into* that branch and inflate
#2810's file count past the owner-granted ceiling exception #2810 is
currently sitting exactly at. The safe order is **#2810 to `main` first** —
this PR then auto-retargets to `main` and merges on its own afterward. Do
not merge this PR ahead of #2810.

## What was wrong

Everything below was measured on this branch, not taken from the ticket.

**1. "These tests run against a real Icom transceiver on your network."** False as a blanket statement. The directory holds 323 tests; **267 run with no hardware at all**, 56 skip. The 56 split as 53 LAN (`ICOM_HOST`/`ICOM_USER`/`ICOM_PASS`), 2 serial (`ICOM_SERIAL_DEVICE`), 1 `RIGPLANE_HW_SMOKE=1`. Gating lives in `conftest.py: pytest_collection_modifyitems`, which exempts anything marked `mock_integration`.

**2. The documented marker workflow did not work.** The README offered:

```
### Skip integration tests (unit tests only):
pytest -m "not integration"
```

Six files (`test_dsp_levels_integration.py`, `test_operator_toggles_integration.py`, `test_rit_tuner_integration.py`, `test_scope_advanced_integration.py`, `test_tone_tsql_integration.py`, `test_vfo_dual_watch_integration.py`) carry only `mock_integration` and not `integration`. So that filter still collects **211 tests from this directory** — verified from repo root:

```
uv run pytest tests/ -m "not integration" -o addopts="" --co -q | grep -c "^tests/integration/"
211
```

Replaced with recipes that were run before being written down:

| Intent | Command | Verified |
|---|---|---|
| Exclude the directory | `-m "not integration and not mock_integration"` | 0 collected from dir |
| Hardware only | `-m "integration and not mock_integration"` | 56 — exactly the set that skips |
| No-hardware only | `-m mock_integration` | 267 |

**3. The "CI/CD" section** claimed integration tests are automatically skipped in CI. Only the hardware population skips; the mock population is collected and must pass. Now says the directory is part of the per-PR gate, and cross-references `tests/test_ci_pytest_invocation.py` so the README and that pin agree rather than drifting apart the way this file did.

**4. Bare `pytest`** replaced with `uv run pytest` per CLAUDE.md.

**5. Marker registration** noted: `mock_integration`, `serial_integration` and `ic7610_parity` are registered in this directory's `conftest.py: pytest_configure`, *not* in the `pyproject.toml` markers list (which registers `integration`, `hardware`, `e2e`, `slow`, `validation_hardware`).

## Rot resistance

No count is written as load-bearing prose — nothing would turn red if `267` drifted. The README gives the commands that report the current split instead. The 16-class category table was verified (all still exist) and is unchanged.

## Verification

Markdown-only, so verified by diff scope rather than by running the suite:

```
git diff --stat        1 file changed, 75 insertions(+), 33 deletions(-)
non-markdown files changed: 0
```

- Doc-citation gate: `clean (847 grandfathered citations)` — citations are file+symbol, no `file:line` introduced.
- `tests/test_ci_pytest_invocation.py`: 1 passed.
- Every command block in the new README was executed and its output matched.

## CI evidence

No CI ran on this PR and none will while it targets a non-`main` base: every
workflow (`quick.yml`, `full.yml`, `publish.yml`) is gated on `pull_request:
branches: [main]`, and this PR's base is a `codex/*` branch. `check-runs`
for the head returns only one entry, "Update Agent Review Gate status". The
empty checks area reflects that gating, not a pass — the verification behind
this change is author-run and reviewer-run, not CI-run. This is inherent to
the stacked base, not a fault of the change, and resolves once #2810 lands
and this PR retargets to `main`.

## Guardrails

1 file, 108 changed lines — inside both the soft threshold and the hard ceiling.

Not self-reviewed; an independent reviewer posts the `Agent Review:` verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
