### PR TITLE
docs: correct tests/integration/README.md against how the directory runs

### DIFF
--- a/.claude/commands/regression-check.md
+++ b/.claude/commands/regression-check.md
@@ -9,7 +9,7 @@ Detect test regressions after code changes.
 
 ## Steps
 
-1. Run full test suite: `uv run pytest tests/ -q --tb=short --ignore=tests/integration 2>&1`
+1. Run full test suite: `uv run pytest tests/ -q --tb=short 2>&1`
 2. Capture: total passed, failed, errors, warnings, runtime
 3. Read `.claude/workflow/regression.md` for previous baseline (if exists)
 4. Compare against baseline:

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -79,7 +79,7 @@ cd ..
 
 ```bash
 # 2h. Python tests
-uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread
+uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread
 ```
 
 ```bash

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -115,7 +115,7 @@ jobs:
           # Capture pytest's exit code via PIPESTATUS, extract the summary
           # (still needed for the badge, including on failure), then exit
           # with pytest's code so failing tests fail the step.
-          uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
+          uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
           rc=${PIPESTATUS[0]}
           SUMMARY=$(tail -1 pytest-output.txt)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
         run: uv run lint-imports
 
       - name: Run tests
-        run: uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread
+        run: uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread
 
   build:
     needs: validate

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -229,7 +229,7 @@ jobs:
           # Capture pytest's exit code via PIPESTATUS, extract the summary
           # (still needed for the badge, including on failure), then exit
           # with pytest's code so failing tests fail the step.
-          uv run pytest tests/ --ignore=tests/integration -n auto --tb=short --timeout=300 --timeout-method=thread \
+          uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread \
             | tee pytest-output.txt
           rc=${PIPESTATUS[0]}
           SUMMARY=$(tail -1 pytest-output.txt)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Three workflows, tiered by cost:
 
 | Workflow | Trigger | Scope |
 |---|---|---|
-| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (no integration) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
+| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (incl. `tests/integration`, hardware-gated tests skip automatically) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
 | `full.yml` | cron Mon/Wed/Fri 03:00 UTC + `workflow_dispatch` + push with `[full-ci]` in commit message | Full matrix 3.11/3.12/3.13, everything |
 | `publish.yml` | `release: published` | New `validate` job (full matrix) → `build` → `publish`. No publish if validate fails. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Live bench: **IC-7300, FTX-1**. *(IC-7610 retired 2026-08-04; X6200 destroyed by
 ## Commands (always `uv run`)
 
 ```bash
-uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread  # standard suite (CI parity, ~2 min)
+uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread  # standard suite (CI parity, ~1 min)
 uv run pytest tests/ -q --tb=short                    # serial, incl. integration hooks (profiling/hardware only)
 uv run mypy --strict src/rigplane/web                  # type check (CI gate; see note below)
 uv run ruff check src/ tests/ && uv run ruff format src/ tests/  # lint+format
@@ -172,7 +172,7 @@ cancelled checks — and release branches (named `release/<major.minor>`) are in
 ## Completion criteria
 
 Work is complete ONLY when ALL pass:
-1. `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` — zero failures
+1. `uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread` — zero failures
 2. `uv run ruff check src/ tests/` — zero violations
 3. `git diff` — no unintended changes
 

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -50,7 +50,7 @@ The repository has three Actions workflows, tiered to keep billable minutes low:
 
 | Workflow | When it runs | What it does |
 |---|---|---|
-| **Tests (quick)** | push/PR to `main` **only** when one of these paths changes: `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, `.github/workflows/**` | Single Python 3.11 job: `ruff`, `import-linter`, `pytest` (no hardware integration). The frontend block (`npm ci`, type-check, vitest, build, mypy on `src/rigplane/web`) only runs when files under `frontend/**` or `src/rigplane/web/**` actually changed. ~2–5 min. Doc-only edits and CLAUDE.md changes don't trigger CI at all — use `gh workflow run "Tests (quick)"` if you need a manual run. |
+| **Tests (quick)** | push/PR to `main` **only** when one of these paths changes: `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, `.github/workflows/**` | Single Python 3.11 job: `ruff`, `import-linter`, `pytest` (includes `tests/integration`; hardware-gated tests skip automatically without hardware env vars). The frontend block (`npm ci`, type-check, vitest, build, mypy on `src/rigplane/web`) only runs when files under `frontend/**` or `src/rigplane/web/**` actually changed. ~2–5 min. Doc-only edits and CLAUDE.md changes don't trigger CI at all — use `gh workflow run "Tests (quick)"` if you need a manual run. |
 | **Tests (full matrix)** | cron Mon/Wed/Fri 03:00 UTC, manual `workflow_dispatch`, **or** any push whose commit message contains `[full-ci]` | Full 3.11/3.12/3.13 matrix with frontend, mypy, import-linter and the whole pytest suite. |
 | **Publish to PyPI** | on a published GitHub Release | Runs the full validation matrix first; the build/publish jobs only start if validation is green. |
 
@@ -80,12 +80,12 @@ tests/
 ├── test_data_mode.py          # DATA/packet mode semantics
 ├── golden/
 │   └── protocol_golden.json   # 45 golden response fixtures (all commands + errors)
-└── integration/               # Real hardware tests (require a radio)
+└── integration/               # Mostly mocked/fake-radio tests; hardware-gated tests skip automatically
     ├── test_connect.py
     └── test_get_freq.py
 ```
 
-Unit tests use mocked transports — **no radio required**. Integration tests are in `tests/integration/` and require actual hardware.
+Unit tests use mocked transports — **no radio required**. Integration tests in `tests/integration/` mostly run against mocked or fake radios too; only tests gated behind `ICOM_*` / `RIGPLANE_HW_SMOKE` environment variables need actual hardware, and those skip automatically without it.
 
 #### Golden Protocol Tests
 

--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -31,11 +31,11 @@ CI runs this automatically; you only need it locally if you're running web-serve
 ## Running Tests
 
 ```bash
-# All unit tests (skip integration tests requiring hardware)
-uv run pytest tests/ -q --tb=short --ignore=tests/integration
+# Full suite (hardware-gated integration tests skip automatically without hardware env vars)
+uv run pytest tests/ -q --tb=short
 
 # With verbose output
-uv run pytest tests/ -v --ignore=tests/integration
+uv run pytest tests/ -v
 
 # Specific test file
 uv run pytest tests/test_commands.py -q --tb=short
@@ -181,6 +181,6 @@ Always include the issue number in the scope (e.g., `#123`) for feature, fix, an
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feat/my-feature`
 3. Make your changes with tests
-4. Ensure all tests pass: `uv run pytest tests/ -q --tb=short --ignore=tests/integration`
+4. Ensure all tests pass: `uv run pytest tests/ -q --tb=short`
 5. Commit with conventional commit message (include issue scope: `feat(#N):`)
 6. Open a PR against `main`

--- a/docs/internals/radio-state-pipeline-validation.md
+++ b/docs/internals/radio-state-pipeline-validation.md
@@ -43,7 +43,7 @@ Run commands from the repository root unless `cwd` says `frontend/`.
 Recommended optional breadth before release:
 
 ```bash
-uv run pytest tests/ -q --tb=short --ignore=tests/integration
+uv run pytest tests/ -q --tb=short
 uv run ruff format --check src tests
 uv run mypy src
 ```

--- a/docs/internals/radio-state-pipeline-validation.md
+++ b/docs/internals/radio-state-pipeline-validation.md
@@ -43,7 +43,6 @@ Run commands from the repository root unless `cwd` says `frontend/`.
 Recommended optional breadth before release:
 
 ```bash
-uv run pytest tests/ -q --tb=short
 uv run ruff format --check src tests
 uv run mypy src
 ```
@@ -158,7 +157,7 @@ Expected outcome: no listener.
 | Encoder-style controls | `tests/test_civ_rx_coverage.py`, `tests/test_radio_poller_coverage.py`, live v2 Playwright | AF/RF gain, PBT, NR/NB, filter/scope controls keep receiver scoping and command correlation. |
 | HTTP/WS consistency | `tests/test_web_server_coverage.py`, `tests/test_delta_encoder.py`, frontend `npx vitest run`, live v2 Playwright | HTTP snapshots and initial WS full state use the same canonical state/freshness revisions; `transportSeq` is ordering metadata only. |
 | Web field availability metadata | `tests/test_web_server_coverage.py` | Legacy `/api/v1/state` fields remain for compatibility, but `fieldStatus` marks each Store-backed public field as observed/fresh, observed/stale, or missing so empty or partial Stores do not present `RadioState` defaults as confirmed state. |
-| rigctld consumer behavior | `tests/test_rigctld_handler.py`, `tests/test_rigctld_server.py`, `tests/integration/test_rigctld_wsjtx.py` when integration is opted in | GET projects from shared state when fresh; stale GET requests acquisition or falls through safely; SET uses scoped pending overlays and preserves Hamlib-style text behavior. |
+| rigctld consumer behavior | `tests/test_rigctld_handler.py`, `tests/test_rigctld_server.py`, `tests/integration/test_rigctld_wsjtx.py` (mock-radio; runs with the standard suite) | GET projects from shared state when fresh; stale GET requests acquisition or falls through safely; SET uses scoped pending overlays and preserves Hamlib-style text behavior. |
 | Command ingress/read-after-write | `tests/test_web_server_coverage.py`, `tests/test_radio_poller_coverage.py`, `tests/test_rigctld_handler.py`, live v2 Playwright | HTTP, WS, and rigctld command IDs are scoped; lifecycle failure/timeout expires overlays; matching observations confirm state. |
 | Reconnect/resync | `tests/test_web_server_coverage.py`, `tests/test_civ_rx_coverage.py`, live v2 Playwright | Web full-state reconnect preserves canonical revisions; CI-V watchdog/backlog recovery does not publish stale scope backlog as control truth. |
 | Cleanup guards | `tests/test_state_pipeline_contracts.py`, `tests/test_civ_rx_coverage.py`, `tests/test_lifecycle_diagnostics.py` | Web poller public revision API is not reintroduced; CIV waiters/watchdog/server lifecycle cleanup paths do not leak tasks or stale waiters. |

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,19 +1,20 @@
 # Integration Tests
 
-Most of this directory runs with **no hardware attached**, on every PR.
+Most of this directory runs with **no hardware attached**, on every PR that
+runs the test suite.
 
 The name is historical: it once held only tests that talked to a real Icom
 transceiver. It now holds two populations, distinguished by marker:
 
 | Population | Marker | Needs hardware? |
 |---|---|---|
-| Mock integration | `mock_integration` | No — runs everywhere, including CI |
+| Mock integration | `mock_integration` | No — runs whenever the suite runs (see **CI** below) |
 | Hardware integration | `integration` without `mock_integration` | Yes — skips unless configured |
 
 The hardware population is skipped, not failed, when its environment is not
 configured. The skip is applied in `conftest.py:
-pytest_collection_modifyitems`, which is the authority for what gets gated
-and why.
+pytest_collection_modifyitems`, which is the authority for the
+hardware-configuration skip.
 
 To see the current split on your checkout:
 
@@ -50,12 +51,17 @@ Path-based exclusion (`--ignore=tests/integration`) also works, but see
 
 ## Markers
 
-`integration`, `serial_integration`, `ic7610_parity` and `mock_integration`
-are registered in `conftest.py: pytest_configure`, local to this directory —
-not in the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`,
-which registers a different set (`integration`, `hardware`, `e2e`, `slow`,
-`validation_hardware`). A run that never collects this directory's
-`conftest.py` therefore does not know the three local markers.
+`serial_integration`, `ic7610_parity` and `mock_integration` are registered
+in `conftest.py: pytest_configure`, local to this directory. `integration`
+is registered there too, but it is *not* local — it is also registered in
+the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`, with the
+same description string in both places. `pyproject.toml` additionally
+registers `hardware`, `e2e`, `slow` and `validation_hardware`, which this
+directory does not use.
+
+A run that never collects this directory's `conftest.py` therefore does not
+know the three local markers (`serial_integration`, `ic7610_parity`,
+`mock_integration`) — `integration` stays registered regardless.
 
 ## Hardware configuration
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,59 +1,91 @@
 # Integration Tests
 
-These tests run against a real Icom transceiver on your network.
+Most of this directory runs with **no hardware attached**, on every PR.
 
-## Prerequisites
+The name is historical: it once held only tests that talked to a real Icom
+transceiver. It now holds two populations, distinguished by marker:
 
-1. Icom radio with LAN/WiFi control (IC-7610, IC-705, IC-7300, IC-9700, etc.)
-2. Radio connected to the same network
-3. Username and password configured in the radio
+| Population | Marker | Needs hardware? |
+|---|---|---|
+| Mock integration | `mock_integration` | No — runs everywhere, including CI |
+| Hardware integration | `integration` without `mock_integration` | Yes — skips unless configured |
 
-## Configuration
+The hardware population is skipped, not failed, when its environment is not
+configured. The skip is applied in `conftest.py:
+pytest_collection_modifyitems`, which is the authority for what gets gated
+and why.
 
-Set environment variables:
+To see the current split on your checkout:
+
+```bash
+uv run pytest tests/integration -m mock_integration --co -q      # no hardware needed
+uv run pytest tests/integration -m "integration and not mock_integration" --co -q   # hardware
+```
+
+## Running
+
+Always via `uv run` — never a bare `pytest`.
+
+```bash
+uv run pytest tests/integration -q                  # whole directory
+uv run pytest tests/integration -m mock_integration # only the no-hardware tests
+uv run pytest tests/integration/test_radio_integration.py -v
+uv run pytest tests/integration/test_radio_integration.py::TestFrequency -v
+uv run pytest tests/integration/test_radio_integration.py::TestFrequency::test_get_frequency -v
+```
+
+### Selecting and excluding by marker
+
+`-m "not integration"` does **not** exclude this directory. Six files carry
+only `mock_integration`, so a `not integration` filter still collects their
+tests. Use both markers:
+
+```bash
+uv run pytest tests/ -m "not integration and not mock_integration"   # exclude this directory
+uv run pytest tests/ -m "integration and not mock_integration"       # hardware tests only
+```
+
+Path-based exclusion (`--ignore=tests/integration`) also works, but see
+**CI** below before adding it to anything that runs in CI.
+
+## Markers
+
+`integration`, `serial_integration`, `ic7610_parity` and `mock_integration`
+are registered in `conftest.py: pytest_configure`, local to this directory —
+not in the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`,
+which registers a different set (`integration`, `hardware`, `e2e`, `slow`,
+`validation_hardware`). A run that never collects this directory's
+`conftest.py` therefore does not know the three local markers.
+
+## Hardware configuration
+
+Only needed for the hardware population.
+
+### LAN radio
 
 ```bash
 export ICOM_HOST=192.168.55.40      # Radio IP address
 export ICOM_USER=your_username       # Radio username
 export ICOM_PASS=your_password       # Radio password
-export ICOM_RADIO_ADDR=0x98          # CI-V address (default: IC-7610)
+export ICOM_RADIO_ADDR=0x98          # CI-V address (conftest default: IC-7610)
 ```
 
-## Running Tests
+Prerequisites: an Icom radio with LAN/WiFi control (IC-7610, IC-705, IC-7300,
+IC-9700, …) on the same network, with a username and password configured in
+the radio.
 
-### All tests including integration:
+### Serial radio
+
 ```bash
-pytest
+export ICOM_SERIAL_DEVICE=/dev/ttyUSB0
+export ICOM_SERIAL_BAUDRATE=115200
+export ICOM_SERIAL_RADIO_ADDR=0x98
 ```
 
-### Only integration tests:
-```bash
-pytest -m integration
-```
+### Hardware smoke
 
-### Skip integration tests (unit tests only):
 ```bash
-pytest -m "not integration"
-```
-
-### Verbose output:
-```bash
-pytest -m integration -v -s
-```
-
-### Specific test file:
-```bash
-pytest tests/integration/test_radio_integration.py -v
-```
-
-### Specific test class:
-```bash
-pytest tests/integration/test_radio_integration.py::TestFrequency -v
-```
-
-### Specific test:
-```bash
-pytest tests/integration/test_radio_integration.py::TestFrequency::test_get_frequency -v
+export RIGPLANE_HW_SMOKE=1
 ```
 
 ## Test Categories
@@ -103,12 +135,22 @@ export ICOM_ALLOW_NEGATIVE_TESTS=1       # bad credentials/unreachable host test
 export ICOM_PCM_REQUIRE_FRAMES=1         # set 0 for PCM smoke-only
 ```
 
-## CI/CD
+## CI
 
-Integration tests are **automatically skipped** in CI environments where
-`ICOM_HOST`, `ICOM_USER`, and `ICOM_PASS` are not set.
+This directory is **part of the per-PR gate**. All three workflows
+(`quick.yml`, `full.yml`, `publish.yml`) run `uv run pytest tests/` with no
+path exclusion, so the mock population is collected and must pass like any
+other test. Only the hardware population skips there, because no CI runner
+sets the variables above.
+
+That the flag is absent is pinned by `tests/test_ci_pytest_invocation.py`,
+which turns red if `--ignore=tests/integration` is reintroduced into any of
+the three workflows' pytest invocations. Its module docstring records the
+incident that motivated it and the limits of what it proves.
 
 ## Troubleshooting
+
+Applies to the hardware population.
 
 ### Connection refused
 - Check radio IP: `ping 192.168.55.40`

--- a/tests/integration/test_x6200_audio_scope_smoke.py
+++ b/tests/integration/test_x6200_audio_scope_smoke.py
@@ -5,10 +5,10 @@ X6200 (serial CI-V + USB RX audio) and asserts that at least one FFT
 :class:`ScopeFrame` reaches the audio-scope channel within a few seconds.
 
 OFF BY DEFAULT. This test is double-gated and is skipped in a normal
-``uv run pytest tests/`` run:
+``uv run pytest tests/`` run (CLAUDE.md's standard command collects
+``tests/integration/`` too, but the markers below keep this one from
+executing):
 
-* it lives in ``tests/integration/`` (CLAUDE.md runs with
-  ``--ignore=tests/integration``);
 * it carries the ``serial_integration`` marker, so the integration conftest
   skips it unless ``ICOM_SERIAL_DEVICE`` is configured;
 * it additionally requires ``RIGPLANE_HW_SMOKE=1`` (mirroring the

--- a/tests/test_ci_pytest_invocation.py
+++ b/tests/test_ci_pytest_invocation.py
@@ -15,12 +15,21 @@ script block scalars, not structure a workflow schema exposes as data. A
 regex anchored on the known `uv run pytest tests/` invocation is simpler and
 does not risk that dependency disappearing.
 
-Honest limit: this only proves the flag string is absent from the pytest
-invocation text in the three tracked workflow files. It says nothing about
-a future workflow file this repo might add, or about a flag with equivalent
-effect expressed a different way (e.g. `-k 'not integration'`, a marker
-deselect, or a `pyproject.toml` `addopts` change) — those would need a
-matching assertion added here, or they would drift the same way this one
+`quick.yml` and `full.yml` write this invocation as a shell line
+continuation (`... \\` then `| tee pytest-output.txt` on the next physical
+line) — exactly where a flag would naturally land if someone wrapped the
+command further. Backslash-newline continuations are folded to a single
+space before matching so a flag placed on a continuation line is not
+invisible to the pin.
+
+Honest limit: this proves the flag string is absent from the pytest
+invocation text in the three tracked workflow files, continuation lines
+included. It says nothing about a future workflow file this repo might add,
+a different invocation shape (e.g. `python -m pytest`, a different working
+directory, or an invocation built from a shell variable), or a flag with
+equivalent effect expressed a different way (e.g. `-k 'not integration'`, a
+marker deselect, or a `pyproject.toml` `addopts` change) — those would need
+a matching assertion added here, or they would drift the same way this one
 did.
 """
 
@@ -38,7 +47,11 @@ _PYTEST_INVOCATION_RE = re.compile(r"uv run pytest tests/[^\n]*")
 
 def _pytest_invocations(workflow_name: str) -> list[str]:
     text = (WORKFLOWS_DIR / workflow_name).read_text()
-    invocations = _PYTEST_INVOCATION_RE.findall(text)
+    # Fold shell line continuations first: `... \` + newline is one physical
+    # command, and a flag added on the continuation line would otherwise be
+    # past the `[^\n]*` boundary and invisible to this pin.
+    folded_text = text.replace("\\\n", " ")
+    invocations = _PYTEST_INVOCATION_RE.findall(folded_text)
     assert invocations, (
         f"no `uv run pytest tests/` invocation found in {workflow_name} — "
         "update this pin if the workflow's test step was restructured"

--- a/tests/test_ci_pytest_invocation.py
+++ b/tests/test_ci_pytest_invocation.py
@@ -1,0 +1,57 @@
+"""Pins that no workflow's pytest invocation excludes `tests/integration`.
+
+Nine tests under `tests/integration/` were red for nine days after commit
+`6bdb5846` and nobody was told, because `--ignore=tests/integration` on the
+pytest invocation in all three workflows (`quick.yml`, `full.yml`,
+`publish.yml`) meant nothing in CI ever collected that directory. #2808
+fixed the tests; #2810 removed the flag from all three workflows. That fixes
+the immediate incident but leaves nothing that turns red if the flag is ever
+reintroduced — this test is that guard.
+
+Same regex-extraction approach as `test_ci_path_filters.py`: this repo has
+no YAML-parsing dependency declared for tests to use (PyYAML is present only
+transitively, via a docs tool), and the `run:` step bodies here are shell
+script block scalars, not structure a workflow schema exposes as data. A
+regex anchored on the known `uv run pytest tests/` invocation is simpler and
+does not risk that dependency disappearing.
+
+Honest limit: this only proves the flag string is absent from the pytest
+invocation text in the three tracked workflow files. It says nothing about
+a future workflow file this repo might add, or about a flag with equivalent
+effect expressed a different way (e.g. `-k 'not integration'`, a marker
+deselect, or a `pyproject.toml` `addopts` change) — those would need a
+matching assertion added here, or they would drift the same way this one
+did.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+WORKFLOW_FILES = ("quick.yml", "full.yml", "publish.yml")
+
+_PYTEST_INVOCATION_RE = re.compile(r"uv run pytest tests/[^\n]*")
+
+
+def _pytest_invocations(workflow_name: str) -> list[str]:
+    text = (WORKFLOWS_DIR / workflow_name).read_text()
+    invocations = _PYTEST_INVOCATION_RE.findall(text)
+    assert invocations, (
+        f"no `uv run pytest tests/` invocation found in {workflow_name} — "
+        "update this pin if the workflow's test step was restructured"
+    )
+    return invocations
+
+
+def test_no_workflow_excludes_integration_tests() -> None:
+    for workflow_name in WORKFLOW_FILES:
+        for invocation in _pytest_invocations(workflow_name):
+            assert "--ignore=tests/integration" not in invocation, (
+                f"{workflow_name} excludes tests/integration from its pytest "
+                "invocation again — this is the same shape of incident that "
+                "left tests/integration/ uncollected and red for nine days "
+                "(commit 6bdb5846, fixed by #2808/#2810)"
+            )


### PR DESCRIPTION
Stacked on #2810 — base is `codex/ci-run-integration-tests`, not `main`.

## Why stacked rather than based on `main`

`tests/integration/README.md` is the known remainder from #2810: fixing it there would have made that PR an eleventh file against the hard ceiling of 10, which is not author-waivable.

But the corrections it needs include *"this directory is part of the per-PR gate"*, and that is **false on `main` today** — #2810 is still open, and all three workflows on `main` still carry `--ignore=tests/integration`. Basing this on `main` would mean landing prose that is untrue until #2810 merges, which is exactly what the repo's prose rule forbids.

Basing it on #2810's head makes every claim true in the tree the README ships in. GitHub prevents this PR from reaching `main` ahead of #2810 (it retargets to `main` automatically once #2810 merges), but that alone does not fix the merge order for `codex/ci-run-integration-tests` itself — see **Merge order** below for why #2810 must merge to `main` first.

## Merge order

This PR's base is `codex/ci-run-integration-tests` (#2810's branch), not
`main`. Merging this PR first would merge it *into* that branch and inflate
#2810's file count past the owner-granted ceiling exception #2810 is
currently sitting exactly at. The safe order is **#2810 to `main` first** —
this PR then auto-retargets to `main` and merges on its own afterward. Do
not merge this PR ahead of #2810.

## What was wrong

Everything below was measured on this branch, not taken from the ticket.

**1. "These tests run against a real Icom transceiver on your network."** False as a blanket statement. The directory holds 323 tests; **267 run with no hardware at all**, 56 skip. The 56 split as 53 LAN (`ICOM_HOST`/`ICOM_USER`/`ICOM_PASS`), 2 serial (`ICOM_SERIAL_DEVICE`), 1 `RIGPLANE_HW_SMOKE=1`. Gating lives in `conftest.py: pytest_collection_modifyitems`, which exempts anything marked `mock_integration`.

**2. The documented marker workflow did not work.** The README offered:

```
### Skip integration tests (unit tests only):
pytest -m "not integration"
```

Six files (`test_dsp_levels_integration.py`, `test_operator_toggles_integration.py`, `test_rit_tuner_integration.py`, `test_scope_advanced_integration.py`, `test_tone_tsql_integration.py`, `test_vfo_dual_watch_integration.py`) carry only `mock_integration` and not `integration`. So that filter still collects **211 tests from this directory** — verified from repo root:

```
uv run pytest tests/ -m "not integration" -o addopts="" --co -q | grep -c "^tests/integration/"
211
```

Replaced with recipes that were run before being written down:

| Intent | Command | Verified |
|---|---|---|
| Exclude the directory | `-m "not integration and not mock_integration"` | 0 collected from dir |
| Hardware only | `-m "integration and not mock_integration"` | 56 — exactly the set that skips |
| No-hardware only | `-m mock_integration` | 267 |

**3. The "CI/CD" section** claimed integration tests are automatically skipped in CI. Only the hardware population skips; the mock population is collected and must pass. Now says the directory is part of the per-PR gate, and cross-references `tests/test_ci_pytest_invocation.py` so the README and that pin agree rather than drifting apart the way this file did.

**4. Bare `pytest`** replaced with `uv run pytest` per CLAUDE.md.

**5. Marker registration** noted: `mock_integration`, `serial_integration` and `ic7610_parity` are registered in this directory's `conftest.py: pytest_configure`, *not* in the `pyproject.toml` markers list (which registers `integration`, `hardware`, `e2e`, `slow`, `validation_hardware`).

## Rot resistance

No count is written as load-bearing prose — nothing would turn red if `267` drifted. The README gives the commands that report the current split instead. The 16-class category table was verified (all still exist) and is unchanged.

## Verification

Markdown-only, so verified by diff scope rather than by running the suite:

```
git diff --stat        1 file changed, 75 insertions(+), 33 deletions(-)
non-markdown files changed: 0
```

- Doc-citation gate: `clean (847 grandfathered citations)` — citations are file+symbol, no `file:line` introduced.
- `tests/test_ci_pytest_invocation.py`: 1 passed.
- Every command block in the new README was executed and its output matched.

## CI evidence

No CI ran on this PR and none will while it targets a non-`main` base: every
workflow (`quick.yml`, `full.yml`, `publish.yml`) is gated on `pull_request:
branches: [main]`, and this PR's base is a `codex/*` branch. `check-runs`
for the head returns only one entry, "Update Agent Review Gate status". The
empty checks area reflects that gating, not a pass — the verification behind
this change is author-run and reviewer-run, not CI-run. This is inherent to
the stacked base, not a fault of the change, and resolves once #2810 lands
and this PR retargets to `main`.

## Guardrails

1 file, 108 changed lines — inside both the soft threshold and the hard ceiling.

Not self-reviewed; an independent reviewer posts the `Agent Review:` verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note on provenance.** This replaces #2814, which GitHub closed automatically when its base branch `codex/ci-run-integration-tests` was deleted on the merge of #2810 (`53b5ec70`). Same branch, same head commit `04ac887b` — no content changed. The review history and the two rounds of findings live on #2814.