### PR TITLE
docs: correct tests/integration/README.md against how the directory runs

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,59 +1,97 @@
 # Integration Tests
 
-These tests run against a real Icom transceiver on your network.
+Most of this directory runs with **no hardware attached**, on every PR that
+runs the test suite.
 
-## Prerequisites
+The name is historical: it once held only tests that talked to a real Icom
+transceiver. It now holds two populations, distinguished by marker:
 
-1. Icom radio with LAN/WiFi control (IC-7610, IC-705, IC-7300, IC-9700, etc.)
-2. Radio connected to the same network
-3. Username and password configured in the radio
+| Population | Marker | Needs hardware? |
+|---|---|---|
+| Mock integration | `mock_integration` | No — runs whenever the suite runs (see **CI** below) |
+| Hardware integration | `integration` without `mock_integration` | Yes — skips unless configured |
 
-## Configuration
+The hardware population is skipped, not failed, when its environment is not
+configured. The skip is applied in `conftest.py:
+pytest_collection_modifyitems`, which is the authority for the
+hardware-configuration skip.
 
-Set environment variables:
+To see the current split on your checkout:
+
+```bash
+uv run pytest tests/integration -m mock_integration --co -q      # no hardware needed
+uv run pytest tests/integration -m "integration and not mock_integration" --co -q   # hardware
+```
+
+## Running
+
+Always via `uv run` — never a bare `pytest`.
+
+```bash
+uv run pytest tests/integration -q                  # whole directory
+uv run pytest tests/integration -m mock_integration # only the no-hardware tests
+uv run pytest tests/integration/test_radio_integration.py -v
+uv run pytest tests/integration/test_radio_integration.py::TestFrequency -v
+uv run pytest tests/integration/test_radio_integration.py::TestFrequency::test_get_frequency -v
+```
+
+### Selecting and excluding by marker
+
+`-m "not integration"` does **not** exclude this directory. Six files carry
+only `mock_integration`, so a `not integration` filter still collects their
+tests. Use both markers:
+
+```bash
+uv run pytest tests/ -m "not integration and not mock_integration"   # exclude this directory
+uv run pytest tests/ -m "integration and not mock_integration"       # hardware tests only
+```
+
+Path-based exclusion (`--ignore=tests/integration`) also works, but see
+**CI** below before adding it to anything that runs in CI.
+
+## Markers
+
+`serial_integration`, `ic7610_parity` and `mock_integration` are registered
+in `conftest.py: pytest_configure`, local to this directory. `integration`
+is registered there too, but it is *not* local — it is also registered in
+the `[tool.pytest.ini_options]` `markers` list in `pyproject.toml`, with the
+same description string in both places. `pyproject.toml` additionally
+registers `hardware`, `e2e`, `slow` and `validation_hardware`, which this
+directory does not use.
+
+A run that never collects this directory's `conftest.py` therefore does not
+know the three local markers (`serial_integration`, `ic7610_parity`,
+`mock_integration`) — `integration` stays registered regardless.
+
+## Hardware configuration
+
+Only needed for the hardware population.
+
+### LAN radio
 
 ```bash
 export ICOM_HOST=192.168.55.40      # Radio IP address
 export ICOM_USER=your_username       # Radio username
 export ICOM_PASS=your_password       # Radio password
-export ICOM_RADIO_ADDR=0x98          # CI-V address (default: IC-7610)
+export ICOM_RADIO_ADDR=0x98          # CI-V address (conftest default: IC-7610)
 ```
 
-## Running Tests
+Prerequisites: an Icom radio with LAN/WiFi control (IC-7610, IC-705, IC-7300,
+IC-9700, …) on the same network, with a username and password configured in
+the radio.
 
-### All tests including integration:
+### Serial radio
+
 ```bash
-pytest
+export ICOM_SERIAL_DEVICE=/dev/ttyUSB0
+export ICOM_SERIAL_BAUDRATE=115200
+export ICOM_SERIAL_RADIO_ADDR=0x98
 ```
 
-### Only integration tests:
-```bash
-pytest -m integration
-```
+### Hardware smoke
 
-### Skip integration tests (unit tests only):
 ```bash
-pytest -m "not integration"
-```
-
-### Verbose output:
-```bash
-pytest -m integration -v -s
-```
-
-### Specific test file:
-```bash
-pytest tests/integration/test_radio_integration.py -v
-```
-
-### Specific test class:
-```bash
-pytest tests/integration/test_radio_integration.py::TestFrequency -v
-```
-
-### Specific test:
-```bash
-pytest tests/integration/test_radio_integration.py::TestFrequency::test_get_frequency -v
+export RIGPLANE_HW_SMOKE=1
 ```
 
 ## Test Categories
@@ -103,12 +141,22 @@ export ICOM_ALLOW_NEGATIVE_TESTS=1       # bad credentials/unreachable host test
 export ICOM_PCM_REQUIRE_FRAMES=1         # set 0 for PCM smoke-only
 ```
 
-## CI/CD
+## CI
 
-Integration tests are **automatically skipped** in CI environments where
-`ICOM_HOST`, `ICOM_USER`, and `ICOM_PASS` are not set.
+This directory is **part of the per-PR gate**. All three workflows
+(`quick.yml`, `full.yml`, `publish.yml`) run `uv run pytest tests/` with no
+path exclusion, so the mock population is collected and must pass like any
+other test. Only the hardware population skips there, because no CI runner
+sets the variables above.
+
+That the flag is absent is pinned by `tests/test_ci_pytest_invocation.py`,
+which turns red if `--ignore=tests/integration` is reintroduced into any of
+the three workflows' pytest invocations. Its module docstring records the
+incident that motivated it and the limits of what it proves.
 
 ## Troubleshooting
+
+Applies to the hardware population.
 
 ### Connection refused
 - Check radio IP: `ping 192.168.55.40`


### PR DESCRIPTION
Corrects `tests/integration/README.md`, which described a marker workflow that no longer matched how the directory runs and carried a pre-existing falsehood: "These tests run against a real Icom transceiver on your network", false for 268 of its 324 tests.

**Measured, not assumed.** 268 tests run with no hardware. The 56 that skip break down as 53 LAN (`ICOM_HOST`/`ICOM_USER`/`ICOM_PASS`) and 2 serial (`ICOM_SERIAL_DEVICE`) via `tests/integration/conftest.py: pytest_collection_modifyitems`, plus 1 via a module-level `RIGPLANE_HW_SMOKE` skipif in `tests/integration/test_x6200_audio_scope_smoke.py`. The `ICOM_ALLOW_*` TX-safety flags gate **none** of these: the modules carrying them set `pytestmark = pytest.mark.integration` without `mock_integration`, so with no hardware configured they are already skipped at collection and their in-body flag checks never run.

Three claims were found by review and narrowed to what the mechanism actually supports:

- The **Markers paragraph** said all four markers are local to this directory's conftest and absent from `pyproject.toml`. `integration` is in both, with a byte-identical description string; only the other three are local. The paragraph also contradicted itself, naming `integration` inside the supposedly different set, and closed with a count of three after listing four.
- **"on every PR"** was unconditional. `quick.yml`'s `Run tests` step is gated on `steps.filter.outputs.core`, so a docs-only PR runs no pytest at all.
- **"the authority for what gets gated and why"** was wider than `pytest_collection_modifyitems`, which owns the hardware-configuration skip only; the TX-safety gates and `RIGPLANE_HW_SMOKE` live in test modules.

## Provenance

This replaces #2814 and #2815, same content, rebuilt cleanly on `main`.

#2814 was based on #2810's branch and GitHub auto-closed it when that branch was deleted on merge (`53b5ec70`). #2815 reopened the same branch against `main`, but because #2810 was **squash**-merged, the branch's own copies of its commits were not ancestors of `main` — the PR showed 11 files and conflicted on `tests/test_ci_pytest_invocation.py`.

That conflict mattered: **`main`'s copy of that file is the newer one**, carrying the `_run_tests_step_body` assertion that catches a `--ignore=tests/integration` smuggled in through a folded (`run: >`) block scalar. Resolving in favour of the branch would have silently deleted that hardening. This branch is built from `main` and takes only the README, so that file is untouched — verified: `git diff origin/main -- tests/test_ci_pytest_invocation.py` is empty.

**Diff: 1 file, +81/−33.** The README content is byte-identical to what was reviewed on #2814 and re-verified against `main` on #2815.

## Review history

Two rounds of findings, all fixed and verified, live on #2814 and #2815. The last review confirmed the prose is correct against `main` and blocked only on the mechanics this PR now resolves:
- #2814 round 1 — three false or overwide claims
- #2814 round 2 — all three verified fixed, clause by clause
- #2815 — prose re-verified against `main`; blocked on the conflict, the 11-file diff, and a body that was false about its own base

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Correction, 2026-08-29.** An earlier revision of this body said all 56 skips were gated "via `pytest_collection_modifyitems`", naming `ICOM_ALLOW_*` and `RIGPLANE_HW_SMOKE` among them. That was false in two ways — those two gates live in test modules, not that hook, and `ICOM_ALLOW_*` gates none of the 56 — and it contradicted this body's own third bullet. It was the same shape of defect the README was blocked for in round 1 of #2814: a claim wider than the mechanism. Introduced while compressing the paragraph during the rebuild; caught in review, corrected above. The README file itself was never affected.



**Second correction, same evening.** The totals in this body said 267 of 323. The tree at this head is **268 of 324** — `main` gained a test in `tests/integration/` via #2809 after the figure was first measured. The `56` and its 53 / 2 / 1 split were and remain exact; only the totals had gone stale.

Worth recording, because it is the more useful half: the paragraph is labelled *"Measured, not assumed"*, which asserts a provenance. The pair was carried unchanged from #2814 through #2815 into #2816 without being re-measured, and two review rounds read it rather than re-derived it. A "measured" label should oblige whoever writes it to re-run the measurement at the head being claimed; otherwise the label outlives the measurement. Caught by a reviewer who re-ran `uv run pytest tests/integration -q --tb=no -rs` instead of inheriting the number.

`tests/integration/README.md` itself carries no counts, so the landing artifact was never affected by this or by the first correction.