### PR TITLE
fix(MOR-2011): resolve Yaesu IF and RM meter commands through the profile

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -907,9 +907,17 @@ set_sql_type   = { cat = { write = "CT0{type:02d};" } }
 get_ctcss_tone = { cat = { read = "CN00;", parse = "CN00{code:03d};" } }
 
 # ── Bulk Status ──
-# IF; returns composite status: freq(9)+sign(1)+rit_offset(4)+rit(1)+xit(1)
-# +bank(1)+chan(2)+tx(1)+mode(1)+vfo(1)+scan(1)+split(1) — parsed in Python
-get_if_status  = { cat = { read = "IF;" } }
+# IF; response layout: P1 chan(5, may be alphanumeric) + P2 freq(9 digits)
+# + P3 clarifier sign(1) + offset(4 digits) + P4 RX CLAR(1) + P5 TX CLAR(1)
+# + P6 mode(1) + P7 VFO/memory select(1) + P8 tone mode(1) + P9 fixed "00"
+# + P10 repeater shift(1). Source: CAT manual FTX-1_CAT_OM_ENG_2508-C (IF
+# command); bench-verified 2026-08-29 against the live FTX-1. The bench
+# radio answered P10="3", a value the manual's IF section does not document
+# (the OS command documents 3=ARS for the same field), so the shift
+# placeholder accepts any single character rather than a restricted set.
+# There is no PTT or split field in this response — those come from the
+# separate TX;/ST; commands.
+get_if_status  = { cat = { read = "IF;", parse = "IF{chan}{freq:09d}{sign}{offset:04d}{rx}{tx}{mode}{vfo}{tone}00{shift};" } }
 
 # ── System ──
 get_powerstat  = { cat = { read = "PS;", parse = "PS{state};" } }

--- a/src/rigplane/backends/yaesu_cat/parser.py
+++ b/src/rigplane/backends/yaesu_cat/parser.py
@@ -31,6 +31,9 @@ Supported placeholders
 {pad:03d}     Padding zeros, 3 digits
 {type:02d}    Type/code value, 2 digits zero-padded
 {mem}         CW message text (write-only)
+{chan}        IF; channel selector, 5 characters (may be alphanumeric)
+{tone}        IF; tone-mode selector, single character
+{shift}       IF; repeater-shift selector, single character
 
 Usage
 -----
@@ -88,6 +91,9 @@ _ALLOWED_PLACEHOLDERS: frozenset[str] = frozenset(
         "val",
         "main",
         "sub",
+        "chan",
+        "tone",
+        "shift",
     }
 )
 
@@ -136,6 +142,14 @@ _PLACEHOLDER_REGEX: dict[str, tuple[str, Any]] = {
     "mem": (r"(?P<mem>.)", str),
     "main:03d": (r"(?P<main>\d{3})", int),
     "sub:03d": (r"(?P<sub>\d{3})", int),
+    # MOR-2011: the FTX-1 IF; bulk-status response carries three fields no
+    # other command uses. P1 "chan" is 5 characters and may be non-numeric
+    # (PMS channels like "P-01L", or the fixed literal "EMGCH"), so it is not
+    # a digit-only field like the other fixed-width groups above. P8 "tone"
+    # and P10 "shift" are each a single character. All three are IF-only.
+    "chan": (r"(?P<chan>.{5})", str),
+    "tone": (r"(?P<tone>.)", str),
+    "shift": (r"(?P<shift>.)", str),
 }
 
 

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1169,8 +1169,10 @@ class YaesuCatRadio:
     # -- RM meters (COMP, ALC, Power, SWR, IDD, VDD) ----------------------
 
     async def _read_meter(self, meter_type: int) -> tuple[int, int]:
-        """Read the meter's profile-defined command. Returns (main, sub) raw
-        values 0–255.
+        """Read the meter's profile-defined command.
+
+        Returns (main, sub) raw 3-digit meter values as parsed by the
+        profile's ``get_meter`` template.
 
         Routes through the ``get_meter`` profile entry (parameterised read
         template, e.g. ``"RM{type};"``) rather than a hardcoded command —

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -761,18 +761,24 @@ class YaesuCatRadio:
         if not self._transport.connected:
             raise RadioConnectionError("Radio not connected — call connect() first")
 
-    async def _query(self, cmd_name: str) -> dict[str, Any]:
+    async def _query(self, cmd_name: str, **params: Any) -> dict[str, Any]:
         """Send a read command and return the parsed response fields.
 
         The transport strips the trailing ``;`` from responses; we add it
         back before passing to the parser (templates include the semicolon).
+
+        *params*, when given, are formatted into the profile's read template
+        via :func:`format_command` (e.g. ``get_meter``'s ``"RM{type};"``).
+        With no params the read template is sent verbatim, as most commands
+        take no parameters in the read direction.
         """
         self._require_connected()
         spec = self._get_spec(cmd_name)
         if spec.read is None:
             raise CommandError(f"Command {cmd_name!r} has no read template")
 
-        raw = await self._transport.query(spec.read)
+        read_cmd = format_command(spec.read, **params) if params else spec.read
+        raw = await self._transport.query(read_cmd)
 
         parser = self._parsers.get(cmd_name)
         if parser is None:
@@ -796,42 +802,35 @@ class YaesuCatRadio:
     async def get_if_status(self) -> dict[str, Any]:
         """Send ``IF;`` and parse the composite response into state fields.
 
-        The Yaesu IF response is a fixed-width string (after the ``IF`` prefix):
-        freq(9) + sign(1) + rit_offset(4) + rit(1) + xit(1)
-        + bank(1) + chan(2) + tx(1) + mode(1) + vfo(1) + scan(1) + split(1)
+        The FTX-1 IF response layout, per the profile's ``get_if_status``
+        parse template (CAT manual FTX-1_CAT_OM_ENG_2508-C, bench-verified
+        2026-08-29): P1 channel(5, may be alphanumeric) + P2 freq(9 digits)
+        + P3 clarifier sign(1) + offset(4 digits) + P4 RX CLAR(1) + P5 TX
+        CLAR(1) + P6 mode(1) + P7 VFO/memory select(1) + P8 tone mode(1) +
+        P9 fixed "00" + P10 repeater shift(1). This response carries no PTT
+        or split field, so this method neither reads nor writes them;
+        :meth:`read_ptt` and ``get_split`` read the ``TX;``/``ST;``
+        commands for that state instead.
 
         Returns a dict with parsed fields and populates :attr:`radio_state`.
         """
-        self._require_connected()
-        raw = await self._transport.query("IF;")
-        # Transport strips trailing ';'; raw starts with "IF" prefix.
-        if not raw.startswith("IF") or len(raw) < 26:
-            raise CommandError(f"Invalid IF response: {raw!r}")
+        result = await self._query("get_if_status")
 
-        body = raw[2:]  # strip "IF" prefix
-        freq = int(body[0:9])
-        sign = body[9]
-        rit_offset = int(body[10:14])
-        rit_on = body[14] == "1"
-        xit_on = body[15] == "1"
-        # body[16] = bank, body[17:19] = channel — skipped
-        tx = body[19] == "1"
-        mode_code = body[20]
-        vfo = int(body[21])
-        # body[22] = scan — skipped
-        split = body[23] == "1"
-
-        rit_hz = rit_offset if sign == "+" else -rit_offset
+        freq = int(result["freq"])
+        offset = int(result["offset"])
+        rit_hz = offset if result["sign"] == "+" else -offset
+        rit_on = result["rx"] == "1"
+        xit_on = result["tx"] == "1"
+        mode_code = result["mode"]
         mode_name = self._code_to_mode.get(mode_code, f"UNKNOWN({mode_code})")
+        vfo = int(result["vfo"])
 
         # Populate state atomically.
         self._state.main.freq = freq
         self._state.main.mode = mode_name
-        self._state.ptt = tx
         self._state.rit_on = rit_on
         self._state.rit_tx = xit_on
         self._state.rit_freq = rit_hz
-        self._state.split = split
 
         return {
             "freq": freq,
@@ -839,9 +838,7 @@ class YaesuCatRadio:
             "rit_offset": rit_hz,
             "rit_on": rit_on,
             "xit_on": xit_on,
-            "tx": tx,
             "vfo": vfo,
-            "split": split,
         }
 
     # -- Frequency ----------------------------------------------------------
@@ -1172,16 +1169,16 @@ class YaesuCatRadio:
     # -- RM meters (COMP, ALC, Power, SWR, IDD, VDD) ----------------------
 
     async def _read_meter(self, meter_type: int) -> tuple[int, int]:
-        """Read RM{type}; meter. Returns (main, sub) raw values 0–255."""
-        self._require_connected()
-        raw = await self._transport.query(f"RM{meter_type};")
-        # Response: "RM{type}{main:03d}{sub:03d}" (transport strips trailing ;)
-        body = raw[2:]  # strip "RM"
-        if len(body) < 7:
-            raise ValueError(f"Malformed RM meter response: {raw!r}")
-        main_val = int(body[1:4])
-        sub_val = int(body[4:7])
-        return main_val, sub_val
+        """Read the meter's profile-defined command. Returns (main, sub) raw
+        values 0–255.
+
+        Routes through the ``get_meter`` profile entry (parameterised read
+        template, e.g. ``"RM{type};"``) rather than a hardcoded command —
+        a malformed or short reply fails the parse template and raises
+        :class:`~.parser.CatParseError` (a ``ValueError`` subclass).
+        """
+        result = await self._query("get_meter", type=meter_type)
+        return result["main"], result["sub"]
 
     async def read_comp_meter(self) -> int:
         """Read COMP (compression) meter without mutating legacy state."""

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -2172,8 +2172,8 @@ class TestIFBulkQuery:
     template — chan(5) + freq(9) + sign(1) + offset(4) + rx(1) + tx(1) +
     mode(1) + vfo(1) + tone(1) + fixed "00" + shift(1) — the layout from the
     CAT manual (FTX-1_CAT_OM_ENG_2508-C), bench-verified 2026-08-29. The
-    baseline frame ``IF00000014228000+000000200003`` is the exact bytes the
-    bench FTX-1 answered.
+    baseline frame ``IF00000014228000+000000200003`` is the bench FTX-1's
+    answer with the transport-stripped trailing ``;`` removed.
     """
 
     MEASURED_FRAME = "IF00000014228000+000000200003"
@@ -2223,6 +2223,30 @@ class TestIFBulkQuery:
         assert connected_radio.radio_state.rit_tx is True
 
     @pytest.mark.asyncio
+    async def test_get_if_status_rit_and_xit_are_not_interchangeable(
+        self, connected_radio
+    ):
+        """P4 (RX CLAR) and P5 (TX CLAR) must map to rit_on/xit_on without
+        being swapped.
+
+        Every other frame in this class has P4 == P5 (both "0" or both
+        "1"), so a swap of the ``{rx}``/``{tx}`` parse fields or of the
+        ``rit_on``/``xit_on`` assignment would stay green against them.
+        This frame is the bench-measured baseline with only body position
+        19 changed from "0" to "1" (P4="1", P5="0": RX CLAR on, TX CLAR
+        off), so it discriminates a swap in either direction.
+        """
+        response = "IF00000014228000+000010200003"
+        connected_radio._transport.query = AsyncMock(return_value=response)
+
+        result = await connected_radio.get_if_status()
+
+        assert result["rit_on"] is True
+        assert result["xit_on"] is False
+        assert connected_radio.radio_state.rit_on is True
+        assert connected_radio.radio_state.rit_tx is False
+
+    @pytest.mark.asyncio
     async def test_get_if_status_does_not_write_ptt_or_split(self, connected_radio):
         """MOR-2011: the IF response has no PTT or split field, so
         get_if_status() must not touch radio_state.ptt / radio_state.split.
@@ -2242,7 +2266,7 @@ class TestIFBulkQuery:
         """A frame that doesn't match the IF template raises CatParseError.
 
         CatParseError is a ValueError subclass (same family the profile's
-        other parameterised reads raise for a mismatched frame).
+        other template-parsed reads raise for a mismatched frame).
         """
         connected_radio._transport.query = AsyncMock(return_value="IF00")
 

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from importlib import resources
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call
@@ -1957,8 +1958,13 @@ async def test_read_meter_power(connected_radio):
 
 @pytest.mark.asyncio
 async def test_read_meter_malformed_response_raises(connected_radio):
+    """A short/malformed RM reply fails the profile's parse template.
+
+    CatParseError is a ValueError subclass, so this stays in the same
+    exception family the old hand-rolled check raised.
+    """
     connected_radio._transport.query = AsyncMock(return_value="RM00")
-    with pytest.raises(ValueError, match="Malformed RM meter response"):
+    with pytest.raises(CatParseError):
         await connected_radio.get_comp_meter()
 
 
@@ -2160,63 +2166,87 @@ async def test_set_squelch_sub_sends_sq1(connected_radio):
 
 
 class TestIFBulkQuery:
-    """Tests for get_if_status() — Yaesu IF; composite response."""
+    """Tests for get_if_status() — Yaesu IF; composite response.
+
+    Frames below are built from the profile's ``get_if_status`` parse
+    template — chan(5) + freq(9) + sign(1) + offset(4) + rx(1) + tx(1) +
+    mode(1) + vfo(1) + tone(1) + fixed "00" + shift(1) — the layout from the
+    CAT manual (FTX-1_CAT_OM_ENG_2508-C), bench-verified 2026-08-29. The
+    baseline frame ``IF00000014228000+000000200003`` is the exact bytes the
+    bench FTX-1 answered.
+    """
+
+    MEASURED_FRAME = "IF00000014228000+000000200003"
 
     @pytest.mark.asyncio
     async def test_get_if_status_parses_all_fields(self, connected_radio):
-        """IF response is parsed into freq, mode, RIT, PTT, split, VFO."""
-        # IF + freq(9) + sign(1) + offset(4) + rit(1) + xit(1)
-        # + bank(1) + chan(2) + tx(1) + mode(1) + vfo(1) + scan(1) + split(1)
-        #      014074000    +    0120    1    0    0    01    0    2    0    0    1
-        response = "IF014074000+01201000102001"
-        connected_radio._transport.query = AsyncMock(return_value=response)
+        """The measured frame parses into freq, mode, RIT/XIT, VFO."""
+        connected_radio._transport.query = AsyncMock(return_value=self.MEASURED_FRAME)
 
         result = await connected_radio.get_if_status()
 
-        assert result["freq"] == 14_074_000
+        assert result["freq"] == 14_228_000
         assert result["mode"] == "USB"  # code "2"
-        assert result["rit_offset"] == 120
-        assert result["rit_on"] is True
+        assert result["rit_offset"] == 0
+        assert result["rit_on"] is False
         assert result["xit_on"] is False
-        assert result["tx"] is False
         assert result["vfo"] == 0
-        assert result["split"] is True
+        assert "tx" not in result
+        assert "split" not in result
 
     @pytest.mark.asyncio
     async def test_get_if_status_populates_state(self, connected_radio):
         """get_if_status() must update radio_state atomically."""
-        # body: freq=007074000, sign=-, offset=0050, rit=1, xit=0,
-        #       bank=0, chan=01, tx=0, mode=1(LSB), vfo=0, scan=0, split=0
-        response = "IF007074000-00501000101000"
-        connected_radio._transport.query = AsyncMock(return_value=response)
+        connected_radio._transport.query = AsyncMock(return_value=self.MEASURED_FRAME)
 
         await connected_radio.get_if_status()
 
         st = connected_radio.radio_state
-        assert st.main.freq == 7_074_000
-        assert st.main.mode == "LSB"  # code "1"
-        assert st.rit_freq == -50
-        assert st.rit_on is True
-        assert st.ptt is False
-        assert st.split is False
+        assert st.main.freq == 14_228_000
+        assert st.main.mode == "USB"
+        assert st.rit_freq == 0
+        assert st.rit_on is False
+        assert st.rit_tx is False
 
     @pytest.mark.asyncio
-    async def test_get_if_status_tx_active(self, connected_radio):
-        """PTT=1 in IF response sets state.ptt = True."""
-        response = "IF014074000+000000001120000"
+    async def test_get_if_status_rit_and_xit_active(self, connected_radio):
+        """RX CLAR (P4) / TX CLAR (P5) digits map to rit_on/xit_on."""
+        # Same frame as MEASURED_FRAME with P4=1, P5=1 (rx/tx clarifier on).
+        response = "IF00000014228000+000011200003"
         connected_radio._transport.query = AsyncMock(return_value=response)
 
         result = await connected_radio.get_if_status()
 
-        assert result["tx"] is True
-        assert connected_radio.radio_state.ptt is True
+        assert result["rit_on"] is True
+        assert result["xit_on"] is True
+        assert connected_radio.radio_state.rit_on is True
+        assert connected_radio.radio_state.rit_tx is True
 
     @pytest.mark.asyncio
-    async def test_get_if_status_invalid_response_raises(self, connected_radio):
-        """Short or malformed IF response raises CommandError."""
+    async def test_get_if_status_does_not_write_ptt_or_split(self, connected_radio):
+        """MOR-2011: the IF response has no PTT or split field, so
+        get_if_status() must not touch radio_state.ptt / radio_state.split.
+        PTT and split truth come from the separate TX;/ST; commands.
+        """
+        connected_radio.radio_state.ptt = True  # sentinel
+        connected_radio.radio_state.split = True  # sentinel
+        connected_radio._transport.query = AsyncMock(return_value=self.MEASURED_FRAME)
+
+        await connected_radio.get_if_status()
+
+        assert connected_radio.radio_state.ptt is True  # unchanged
+        assert connected_radio.radio_state.split is True  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_get_if_status_malformed_response_raises(self, connected_radio):
+        """A frame that doesn't match the IF template raises CatParseError.
+
+        CatParseError is a ValueError subclass (same family the profile's
+        other parameterised reads raise for a mismatched frame).
+        """
         connected_radio._transport.query = AsyncMock(return_value="IF00")
 
-        with pytest.raises(CommandError):
+        with pytest.raises(CatParseError):
             await connected_radio.get_if_status()
 
     @pytest.mark.asyncio
@@ -2224,7 +2254,7 @@ class TestIFBulkQuery:
         """connect() should attempt IF bulk query to seed state."""
         radio._transport.connect = AsyncMock()
         radio._transport._connected = True
-        radio._transport.query = AsyncMock(return_value="IF014074000+000000001020000")
+        radio._transport.query = AsyncMock(return_value="IF00000014074000+000000200003")
 
         await radio.connect()
 
@@ -2241,6 +2271,70 @@ class TestIFBulkQuery:
         await radio.connect()  # should not raise
 
         assert radio.connected
+
+
+# ---------------------------------------------------------------------------
+# MOR-2011: get_meter / get_if_status route the read command through the
+# profile, not a hardcoded literal.
+# ---------------------------------------------------------------------------
+
+
+class TestProfileSourcedCommands:
+    """Pins that go red if either read command regresses to a literal.
+
+    Each pin swaps the profile's ``read`` template for a sentinel before
+    the radio is constructed (parsers compile once in ``__init__``), then
+    asserts the transport received the sentinel-formatted command rather
+    than the real ``RM{type};`` / ``IF;`` wire text. A hardcoded
+    ``f"RM{meter_type};"`` or literal ``"IF;"`` in the implementation would
+    still send the real command and fail these assertions.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_meter_read_command_is_profile_sourced(self, config):
+        config.commands["get_meter"] = replace(
+            config.commands["get_meter"], read="XM{type};"
+        )
+        radio = YaesuCatRadio("/dev/null", profile=config)
+        radio._transport._connected = True
+        radio._transport.query = AsyncMock(return_value="RM6000000")
+
+        await radio.read_swr_meter()
+
+        radio._transport.query.assert_called_once_with("XM6;")
+
+    @pytest.mark.asyncio
+    async def test_get_if_status_read_command_is_profile_sourced(self, config):
+        config.commands["get_if_status"] = replace(
+            config.commands["get_if_status"], read="XF;"
+        )
+        radio = YaesuCatRadio("/dev/null", profile=config)
+        radio._transport._connected = True
+        radio._transport.query = AsyncMock(return_value="IF00000014228000+000000200003")
+
+        await radio.get_if_status()
+
+        radio._transport.query.assert_called_once_with("XF;")
+
+    @pytest.mark.asyncio
+    async def test_get_meter_missing_from_profile_raises_command_error(self, config):
+        del config.commands["get_meter"]
+        radio = YaesuCatRadio("/dev/null", profile=config)
+        radio._transport._connected = True
+
+        with pytest.raises(CommandError):
+            await radio.read_comp_meter()
+
+    @pytest.mark.asyncio
+    async def test_get_if_status_missing_from_profile_raises_command_error(
+        self, config
+    ):
+        del config.commands["get_if_status"]
+        radio = YaesuCatRadio("/dev/null", profile=config)
+        radio._transport._connected = True
+
+        with pytest.raises(CommandError):
+            await radio.get_if_status()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaesu_cat_parser.py
+++ b/tests/test_yaesu_cat_parser.py
@@ -256,6 +256,48 @@ class TestRoundtrip:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# IF{} bulk-status template (MOR-2011) — chan/tone/shift placeholders
+# ---------------------------------------------------------------------------
+
+
+class TestIfStatusTemplate:
+    """The FTX-1 IF; parse template (CAT manual FTX-1_CAT_OM_ENG_2508-C,
+    bench-verified 2026-08-29): chan(5) + freq(9) + sign(1) + offset(4)
+    + rx(1) + tx(1) + mode(1) + vfo(1) + tone(1) + fixed "00" + shift(1).
+    """
+
+    TEMPLATE = "IF{chan}{freq:09d}{sign}{offset:04d}{rx}{tx}{mode}{vfo}{tone}00{shift};"
+
+    def test_parse_measured_frame(self):
+        parser = CatCommandParser(self.TEMPLATE)
+        result = parser.parse("IF00000014228000+000000200003;")
+        assert result == {
+            "chan": "00000",
+            "freq": 14228000,
+            "sign": "+",
+            "offset": 0,
+            "rx": "0",
+            "tx": "0",
+            "mode": "2",
+            "vfo": "0",
+            "tone": "0",
+            "shift": "3",
+        }
+
+    def test_parse_alphanumeric_channel_pms(self):
+        # P1 may be a PMS channel like "P-01L" (manual: non-numeric allowed).
+        parser = CatCommandParser(self.TEMPLATE)
+        result = parser.parse("IFP-01L014228000+000000200003;")
+        assert result["chan"] == "P-01L"
+
+    def test_parse_alphanumeric_channel_emergency(self):
+        # P1 may also be the fixed literal "EMGCH" (manual: emergency channel).
+        parser = CatCommandParser(self.TEMPLATE)
+        result = parser.parse("IFEMGCH014228000+000000200003;")
+        assert result["chan"] == "EMGCH"
+
+
 class TestCompileOnce:
     def test_same_parser_instance_reused(self):
         parser = CatCommandParser("FA{freq:09d};")


### PR DESCRIPTION
Step 0 of the profile-driven command-bytes programme (MOR-2000): make the Yaesu
reference implementation actually exemplary. Two `YaesuCatRadio` methods held
their command text in code instead of resolving it from the profile — the same
defect class the programme removes on the Icom side, living inside its
reference. Ticket: MOR-2011.

## The measured finding that reshaped the ticket

A read-only bench probe of the live FTX-1 (2026-08-29) showed the old
`get_if_status` parsed a frame layout the radio does not emit. Against the
measured answer `IF00000014228000+000000200003;` it produced freq=142 Hz for a
14.228 MHz dial, and the `tx`/`split` fields it extracted (plus the `scan`
offset it skipped) do not exist in the real answer — `tx`'s offset holds RX CLAR,
`scan`'s the VFO/memory select, `split`'s the tone mode. Its writes to `state.ptt` and `state.split` were therefore garbage
writes, masked because the poller overwrites both shortly after via the
dedicated `TX;`/`ST;` reads. The CAT manual FTX-1_CAT_OM_ENG_2508-C confirms
the measured layout field-for-field. The ticket's original "same values before
and after" arrival test was replaced (recorded on MOR-2011) by: the parse
matches the bench frame and the manual, and the phantom fields are gone.

## Changes

- `rigs/ftx1.toml` — `get_if_status` gains a `parse` template matching the
  measured frame, with per-entry provenance (manual 2508-C + bench 2026-08-29;
  the undocumented observed P10=`3` is recorded).
- `parser.py` — three new placeholder names (`chan` 5-char alphanumeric,
  `tone`, `shift`), data rows in the existing per-command extension pattern
  (as `main`/`sub` were added for RM, `delay` for SD).
- `radio.py` — `_query` accepts optional params formatted into the read
  template via the existing `format_command`; `_read_meter` routes through the
  profile's complete `get_meter` entry; `get_if_status` routes through
  `_query` and maps the real P1–P10 fields, no longer touching `state.ptt` /
  `state.split` and no longer returning `tx`/`split` keys. No command literal
  remains in executable code.
- Tests — measured-frame pins for the parser (incl. alphanumeric channel
  forms); profile-sourced-bytes regression pins (sentinel read templates: red
  if either method regresses to a hardcoded literal); refuse-aloud pins
  (CommandError when the profile lacks the entry); IF tests rewritten against
  the real frame incl. a ptt/split-untouched sentinel test.

## Verification

- Targeted suites: 466 passed, 0 failed, 0 skipped (incl. an asymmetric
  rx/tx frame pin whose discrimination was verified by mutation)
  (`test_yaesu_cat_parser`, `test_ftx1_radio`, `test_command_spec`,
  `test_yaesu_cat_poller`); ruff clean.
- Bench, live FTX-1, after the change (measured at `db6d91ef`; the later
  fix commit's `src/` delta is docstring-only, so the result carries over): `get_if_status` freq equals the `FA;`
  read (14228000 Hz); all six RM meters equal the raw probe values
  (VDD raw 212, others 0 at RX); `state.ptt` untouched.
- Full suite: dispatched to the remote test bench for this head.

## Scope

5 files, +255/−74 (329 changed lines) — inside the 6-file/600-line soft
threshold. One unit of work: both methods share the `_query` mechanism change,
and the parse template, parser vocabulary and tests are meaningless apart.

Unblocks the fix round on #2806/#2811, whose Yaesu-reference claim becomes
true without qualification once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
