### PR TITLE
feat(MOR-2001): make every command fallback fall-through observable behind an env flag

### DIFF
--- a/src/rigplane/commands/LAYER.md
+++ b/src/rigplane/commands/LAYER.md
@@ -58,6 +58,22 @@ transport happens in the `runtime` layer that wires it up.
 - **Add a `Priority` level** → extend the `Priority` enum in
   `commander.py`; verify ordering invariants in the queue tests.
 
+## Charter exception: Step 1 measurement hook (temporary)
+
+Approved 2026-08-29 for MOR-2000/MOR-2001 (owner ruling Q4,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1):
+`commands/_fallback_audit.py` wraps each exported `cmd_map`-taking builder
+with a `logging.warning` call fired when the builder is invoked without a
+map, and `commands/__init__.py` installs that wrapper with one call at
+import. Both the wrapping logic and the `logging` I/O it performs are
+confined to `_fallback_audit.py` — no other file in this layer gains a
+charter exception from this ruling. Installation is a no-op — the
+exported names stay the raw functions — unless
+`RIGPLANE_COMMAND_FALLBACK_AUDIT` is set (`core/env_config.py:
+get_command_fallback_audit_enabled`). Step Z of the same plan deletes
+`_fallback_audit.py`, its install call in `commands/__init__.py`, and
+this section.
+
 ## See also
 
 - `docs/plans/2026-04-29-modularization-plan.md` §1.2, §2.2, §3.

--- a/src/rigplane/commands/LAYER.md
+++ b/src/rigplane/commands/LAYER.md
@@ -63,8 +63,9 @@ transport happens in the `runtime` layer that wires it up.
 Approved 2026-08-29 for MOR-2000/MOR-2001 (owner ruling Q4,
 `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1):
 `commands/_fallback_audit.py` wraps each exported `cmd_map`-taking builder
-with a `logging.warning` call fired when the builder is invoked without a
-map, and `commands/__init__.py` installs that wrapper with one call at
+with a call to its own module logger's `.warning()`
+(`logging.getLogger(__name__)`) fired when the builder is invoked without
+a map, and `commands/__init__.py` installs that wrapper with one call at
 import. Both the wrapping logic and the `logging` I/O it performs are
 confined to `_fallback_audit.py` — no other file in this layer gains a
 charter exception from this ruling. Installation is a no-op — the
@@ -72,7 +73,9 @@ exported names stay the raw functions — unless
 `RIGPLANE_COMMAND_FALLBACK_AUDIT` is set (`core/env_config.py:
 get_command_fallback_audit_enabled`). Step Z of the same plan deletes
 `_fallback_audit.py`, its install call in `commands/__init__.py`, and
-this section.
+this section, with a test that goes red if any of the three survives
+past that step; that test is a Step Z deliverable and does not exist
+yet.
 
 ## See also
 

--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -16,6 +16,7 @@ Reference: wfview icomcommander.cpp, IC-7610.rig
 
 # Re-export everything from sub-modules -- no logic in this file.
 
+from . import _fallback_audit
 from ..types import bcd_decode
 
 # --- _frame.py (kernel) ---
@@ -787,3 +788,7 @@ __all__ = [
     "parse_tx_band_count_response",
     "parse_tx_band_edge_response",
 ]
+
+# --- Step 1 measurement hook (temporary; see LAYER.md and
+# docs/plans/2026-08-29-profile-driven-command-bytes.md Step Z) ---
+_fallback_audit.install(globals())

--- a/src/rigplane/commands/_fallback_audit.py
+++ b/src/rigplane/commands/_fallback_audit.py
@@ -1,0 +1,89 @@
+"""Step 1 measurement scaffolding for the profile-driven command-bytes plan.
+
+Temporary. This file, its install call in ``commands/__init__.py``, the env
+var it is gated on (``core/env_config.py:
+get_command_fallback_audit_enabled``), and the charter exception recorded
+for it in ``commands/LAYER.md`` are all deleted in Step Z of
+``docs/plans/2026-08-29-profile-driven-command-bytes.md`` (§4, §8.1 Q4).
+
+It exists to answer one question before that plan touches a single builder:
+which exported command builders are being called without a ``cmd_map`` --
+i.e. which calls are still on the hardcoded fallback path. It changes no
+byte on the wire and no builder's return value; it only wraps each exported
+``cmd_map``-taking builder so a fallback call logs itself.
+
+The wrapping happens only when ``RIGPLANE_COMMAND_FALLBACK_AUDIT`` is set
+(``core/env_config.py: get_command_fallback_audit_enabled``); off, this
+module's ``install`` is a no-op and the names ``commands/__init__.py``
+exports stay the raw functions the sub-modules define.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+from typing import Any
+
+from rigplane.core.env_config import get_command_fallback_audit_enabled
+
+__all__ = ["install"]
+
+logger = logging.getLogger(__name__)
+
+
+def _wrap(fn: Any) -> Any:
+    """Wrap *fn* so a call with ``cmd_map`` left at ``None`` logs once.
+
+    Preserves *fn*'s return value and exception behaviour exactly: it never
+    substitutes its own error for one *fn* would have raised, and it always
+    returns exactly what ``fn(*args, **kwargs)`` returns.
+    """
+    signature = inspect.signature(fn)
+
+    @functools.wraps(fn)
+    def _audited(*args: Any, **kwargs: Any) -> Any:
+        try:
+            bound = signature.bind(*args, **kwargs)
+        except TypeError:
+            # Let fn raise its own error for a call its signature rejects,
+            # unshadowed by a binding failure diagnosed here instead.
+            return fn(*args, **kwargs)
+        bound.apply_defaults()
+        if bound.arguments.get("cmd_map") is None:
+            logger.warning(
+                "command fallback audit: %s called without cmd_map "
+                "(hardcoded fallback engaged)",
+                fn.__qualname__,
+            )
+        return fn(*args, **kwargs)
+
+    return _audited
+
+
+def install(namespace: dict[str, Any]) -> None:
+    """Replace every ``cmd_map``-taking function in *namespace* in place.
+
+    Called once, from the bottom of ``commands/__init__.py``, with its own
+    ``globals()`` after every builder re-export is bound. A no-op unless
+    ``RIGPLANE_COMMAND_FALLBACK_AUDIT`` is set: with the flag off,
+    *namespace* is left untouched.
+
+    A builder reachable under more than one name in *namespace* (a
+    backward-compat alias such as ``speech = get_speech``) is wrapped once;
+    every name bound to it receives the same wrapped object, so the alias
+    relationship -- and therefore "one call, one warning" regardless of
+    which name it came through -- survives wrapping.
+    """
+    if not get_command_fallback_audit_enabled():
+        return
+    wrapped_by_id: dict[int, Any] = {}
+    for name, value in list(namespace.items()):
+        if not inspect.isfunction(value):
+            continue
+        if "cmd_map" not in inspect.signature(value).parameters:
+            continue
+        key = id(value)
+        if key not in wrapped_by_id:
+            wrapped_by_id[key] = _wrap(value)
+        namespace[name] = wrapped_by_id[key]

--- a/src/rigplane/core/env_config.py
+++ b/src/rigplane/core/env_config.py
@@ -244,8 +244,8 @@ def get_command_fallback_audit_enabled() -> bool:
     (``1``/``true``/``on``/``yes``) turns it on. Unrecognised values keep
     the default (off) and warn, like the other knobs in this module.
 
-    This function and its only caller (``commands/_fallback_audit.py``) are
-    Step 1 scaffolding for
+    This function and its only production caller
+    (``commands/_fallback_audit.py``) are Step 1 scaffolding for
     ``docs/plans/2026-08-29-profile-driven-command-bytes.md``; that plan's
     Step Z deletes both, along with this env var. On, ``rigplane.commands``
     wraps every exported ``cmd_map``-taking builder at import so a call

--- a/src/rigplane/core/env_config.py
+++ b/src/rigplane/core/env_config.py
@@ -15,6 +15,7 @@ __all__ = [
     "get_audio_rx_jitter_floor_ms",
     "get_audio_rx_jitter_ceiling_ms",
     "get_managed_tx_enabled",
+    "get_command_fallback_audit_enabled",
 ]
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_SAMPLE_RATES = (8000, 16000, 24000, 48000)
 
 _MANAGED_TX_VAR = "RIGPLANE_MANAGED_TX"
+_COMMAND_FALLBACK_AUDIT_VAR = "RIGPLANE_COMMAND_FALLBACK_AUDIT"
 # The spellings the rest of the codebase already accepts: the truthy set of
 # ``backends._icom_serial_base._env_bool`` and the falsy set the CLI reads
 # ``ICOM_DEBUG`` against. Neither is extended here — a boolean knob that
@@ -231,3 +233,37 @@ def get_managed_tx_enabled() -> bool:
     logger.warning(msg)
     print(f"Warning: {msg}", file=sys.stderr)
     return True
+
+
+def get_command_fallback_audit_enabled() -> bool:
+    """Return whether the command fallback measurement audit is enabled.
+
+    Default: ``False``. Reads ``RIGPLANE_COMMAND_FALLBACK_AUDIT``. Absent,
+    empty, or any falsy spelling (``0``/``false``/``off``/``no``) leaves
+    the audit off; only an explicit truthy spelling
+    (``1``/``true``/``on``/``yes``) turns it on. Unrecognised values keep
+    the default (off) and warn, like the other knobs in this module.
+
+    This function and its only caller (``commands/_fallback_audit.py``) are
+    Step 1 scaffolding for
+    ``docs/plans/2026-08-29-profile-driven-command-bytes.md``; that plan's
+    Step Z deletes both, along with this env var. On, ``rigplane.commands``
+    wraps every exported ``cmd_map``-taking builder at import so a call
+    made without a map logs one WARNING naming the builder; off, the
+    exported names are the raw functions with no wrapper installed.
+    """
+    raw = os.environ.get(_COMMAND_FALLBACK_AUDIT_VAR)
+    if raw is None:
+        return False
+    value = raw.strip().lower()
+    if value in _TRUTHY:
+        return True
+    if not value or value in _FALSY:
+        return False
+    msg = (
+        f"env_config: {_COMMAND_FALLBACK_AUDIT_VAR}={raw!r} is not a recognised "
+        "boolean, keeping the command fallback audit off"
+    )
+    logger.warning(msg)
+    print(f"Warning: {msg}", file=sys.stderr)
+    return False

--- a/tests/test_command_fallback_audit.py
+++ b/tests/test_command_fallback_audit.py
@@ -1,0 +1,202 @@
+"""Tests for the Step 1 command-fallback measurement hook (MOR-2001).
+
+Temporary, like the code under test: this file is deleted in Step Z of
+``docs/plans/2026-08-29-profile-driven-command-bytes.md`` together with
+``src/rigplane/commands/_fallback_audit.py``, its install call in
+``commands/__init__.py``, and the charter exception recorded for it in
+``commands/LAYER.md``.
+
+The flag-on tests need ``rigplane.commands`` reloaded with
+``RIGPLANE_COMMAND_FALLBACK_AUDIT`` set, because the wrapper installs once,
+at import. Several other test files
+(``tests/_command_test_helpers.py: bind_default_addr_module``) mutate the
+same shared ``rigplane.commands`` module object at their own collection
+time to bind a default ``to_addr`` onto every builder, and that mutation
+must still be in place for those files' tests, wherever they run relative
+to this one in the same worker process. ``_reloaded_with_flag`` below
+snapshots ``vars(rigplane.commands)`` before reloading and restores that
+exact snapshot in a ``finally``, so a reload done inside one test here
+never leaks into the next test -- in this file or any other.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import inspect
+import logging
+
+import pytest
+
+import rigplane.commands as commands
+import rigplane.commands._frame as frame_module
+import rigplane.commands.freq as freq_module
+from rigplane.commands import _fallback_audit
+from rigplane.commands.command_map import CommandMap
+from rigplane.commands.speech import get_speech as raw_get_speech
+from rigplane.core.env_config import get_command_fallback_audit_enabled
+
+# ``commands/__init__.py`` does ``from .speech import get_speech, speech``,
+# which rebinds the package attribute ``rigplane.commands.speech`` from the
+# submodule to the *function* alias (``speech = get_speech`` in
+# ``speech.py``). So ``import rigplane.commands.speech as speech_module``
+# resolves to that function, not the submodule -- the import above pins the
+# submodule's own name instead, unaffected by the shadowing.
+
+_FLAG = "RIGPLANE_COMMAND_FALLBACK_AUDIT"
+_AUDIT_LOGGER = _fallback_audit.__name__
+
+
+@contextlib.contextmanager
+def _reloaded_with_flag(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    """Reload ``rigplane.commands`` with ``_FLAG`` set to *value*.
+
+    Restores the module's prior attribute set exactly on exit, so this
+    reload cannot leak into any other test -- including one that mutated
+    the same shared module object before this one ran (see module
+    docstring).
+    """
+    snapshot = dict(vars(commands))
+    if value is None:
+        monkeypatch.delenv(_FLAG, raising=False)
+    else:
+        monkeypatch.setenv(_FLAG, value)
+    try:
+        yield importlib.reload(commands)
+    finally:
+        vars(commands).clear()
+        vars(commands).update(snapshot)
+
+
+class TestGetCommandFallbackAuditEnabled:
+    """The env reader in core/env_config.py, matching get_managed_tx_enabled's style."""
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_FLAG, raising=False)
+        assert get_command_fallback_audit_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "on", "yes", "TRUE", "On"])
+    def test_truthy_values_enable(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv(_FLAG, value)
+        assert get_command_fallback_audit_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", "no", ""])
+    def test_falsy_values_disable(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv(_FLAG, value)
+        assert get_command_fallback_audit_enabled() is False
+
+    def test_unrecognised_value_warns_and_stays_off(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv(_FLAG, "maybe")
+        with caplog.at_level(logging.WARNING, logger="rigplane.core.env_config"):
+            result = get_command_fallback_audit_enabled()
+        assert result is False
+        assert _FLAG in caplog.text
+
+
+class TestFlagOff:
+    """Off means the raw functions -- not a pass-through wrapper."""
+
+    def test_exports_are_the_raw_functions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with _reloaded_with_flag(monkeypatch, None) as reloaded:
+            assert reloaded.get_freq is freq_module.get_freq
+            assert reloaded.set_freq is freq_module.set_freq
+            # Backward-compat alias: same object as its canonical name.
+            assert reloaded.speech is raw_get_speech
+            assert reloaded.get_speech is raw_get_speech
+
+    def test_calling_without_a_map_logs_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with _reloaded_with_flag(monkeypatch, None) as reloaded:
+            with caplog.at_level(logging.WARNING, logger=_AUDIT_LOGGER):
+                reloaded.get_freq(to_addr=0x94, cmd_map=None)
+            assert caplog.records == []
+
+
+class TestFlagOn:
+    """On means every exported cmd_map-taking builder is wrapped."""
+
+    def test_exports_are_wrapped_but_unwrap_to_the_raw_function(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with _reloaded_with_flag(monkeypatch, "1") as reloaded:
+            assert reloaded.get_freq is not freq_module.get_freq
+            assert inspect.unwrap(reloaded.get_freq) is freq_module.get_freq
+            assert reloaded.get_freq.__name__ == "get_freq"
+            assert reloaded.get_freq.__doc__ == freq_module.get_freq.__doc__
+
+    def test_alias_identity_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with _reloaded_with_flag(monkeypatch, "1") as reloaded:
+            # speech = get_speech in speech.py: one wrap, shared by both names.
+            assert reloaded.speech is reloaded.get_speech
+
+    def test_functions_without_cmd_map_are_left_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with _reloaded_with_flag(monkeypatch, "1") as reloaded:
+            assert (
+                "cmd_map" not in inspect.signature(reloaded.build_civ_frame).parameters
+            )
+            assert reloaded.build_civ_frame is frame_module.build_civ_frame
+
+    def test_call_without_a_map_logs_exactly_one_warning_naming_the_builder(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with _reloaded_with_flag(monkeypatch, "1") as reloaded:
+            with caplog.at_level(logging.WARNING, logger=_AUDIT_LOGGER):
+                result = reloaded.get_freq(to_addr=0x94, cmd_map=None)
+            assert result == freq_module.get_freq(to_addr=0x94, cmd_map=None)
+            assert len(caplog.records) == 1
+            assert "get_freq" in caplog.text
+
+    def test_call_with_a_map_logs_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cmd_map = CommandMap({"get_freq": (0x03,)})
+        with _reloaded_with_flag(monkeypatch, "1") as reloaded:
+            with caplog.at_level(logging.WARNING, logger=_AUDIT_LOGGER):
+                reloaded.get_freq(to_addr=0x94, cmd_map=cmd_map)
+            assert caplog.records == []
+
+    def test_return_value_and_exceptions_are_preserved(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with _reloaded_with_flag(monkeypatch, "1") as reloaded:
+            assert reloaded.get_freq(
+                to_addr=0x94, cmd_map=None
+            ) == freq_module.get_freq(to_addr=0x94, cmd_map=None)
+            with pytest.raises(TypeError):
+                reloaded.get_freq()  # missing required to_addr, both wrapped and raw
+
+    def test_reload_does_not_leak_into_the_ambient_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The context manager's restore must actually run.
+
+        Compares against whatever ``commands.get_freq`` was *before* the
+        ``with`` block, not against the raw ``freq_module.get_freq``: another
+        collected test file's ``bind_default_addr_module`` (see module
+        docstring) may already have rebound it to a partial before this test
+        runs, and that is exactly the state the restore must put back.
+        """
+        before = commands.get_freq
+        with _reloaded_with_flag(monkeypatch, "1"):
+            pass
+        assert commands.get_freq is before
+
+
+def test_module_docstring_cites_the_plan_and_step_z() -> None:
+    assert _fallback_audit.__doc__ is not None
+    assert (
+        "docs/plans/2026-08-29-profile-driven-command-bytes.md"
+        in _fallback_audit.__doc__
+    )
+    assert "Step Z" in _fallback_audit.__doc__


### PR DESCRIPTION
Step 1 of the profile-driven command-bytes programme (MOR-2000, plan §4
Step 1). A measurement, not a behaviour change: before any builder migrates,
make the current reality observable — which commands actually reach the
hardcoded fallback branch in a real session.

## Changes

- `core/env_config.py` — `get_command_fallback_audit_enabled()`, reading
  `RIGPLANE_COMMAND_FALLBACK_AUDIT`, in the style of `get_managed_tx_enabled`
  (opt-in, default off).
- `commands/_fallback_audit.py` (new, explicitly temporary — deleted in
  Step Z with its install call, env flag and charter-exception record) —
  wraps each exported `cmd_map`-taking builder; a call with `cmd_map` left
  at `None` logs exactly one WARNING naming the builder. With the flag off,
  `install` is a no-op and the exported names remain the raw functions.
  Aliases are deduplicated by identity so one call yields one warning
  regardless of the name it came through. Return values and exceptions are
  passed through untouched.
- `commands/__init__.py` — one install call at the bottom.
- `commands/LAYER.md` — the Q4 charter exception (plan §8.1), dated,
  ticketed, confined to the one file, with its Step Z deletion named and
  the Step Z red test recorded as a future deliverable (Q4's fourth bound).
- `tests/test_command_fallback_audit.py` (new, 23 tests) — flag off: exports
  are the raw functions and nothing is logged; flag on: one warning without
  a map, none with a map; env-reader parsing. Reload isolation restores the
  exact prior module `__dict__` so collection-order-dependent module state
  (`tests/_command_test_helpers.py`) survives.

## Verification

- Targeted suites: 375 passed (audit + parity + commands) plus 679 passed
  across eleven heavy `rigplane.commands`-importing test files
  (`test_rig_ic7300`, `test_commands_extended`, `test_command_map_integration`,
  `test_scope`, `test_vfo_dual_watch`, `test_dsp_levels_part1`,
  `test_dsp_levels_part2`, `test_main_sub_tracking`, `test_operator_toggles`,
  `test_rf_gain_af_level`, `test_tone_tsql`); ruff clean; lint-imports 5/5
  kept.
- Full suite on the remote bench at `76c08095`: 10672 passed, 12 skipped
  (the standard hardware/profiling-gated set), 0 failed — the prior bench
  baseline (10648 at `db6d91ef`) plus this PR's 23 audit tests plus the one
  rx/tx pin #2817's fix round added after that baseline was taken. The
  result carries over to the current head: the follow-up commit is
  prose-only (LAYER.md and a docstring) and no doctest collection is
  configured, so no executable line differs from `76c08095`.
- Discrimination check: with the `install()` call disabled, exactly the two
  tests that pin the wrapping fail — the pins are not vacuous.

## Scope

5 files, +351/−0 — inside the soft threshold. What the audit output means
and does not mean (it identifies fallback usage; it says nothing about
whether profile bytes are correct) is in plan §4 Step 1.

The bench session that consumes this instrumentation (IC-7300, driving the
mod-level, NB and VOX panels) is the second half of MOR-2001 and follows
separately once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
