### PR TITLE
feat(MOR-2002): pin the wire-tuple contract (Q7, step 2a)

### DIFF
--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -85,6 +85,31 @@ set_freq_a = "FA{freq11};"
 
 CI-V radios don't need this — commands are inferred from CI-V sub-commands.
 
+### CI-V Wire Command Map (`[commands]`)
+
+```toml
+[commands]
+get_freq = [0x03]
+ptt_on   = [0x1C, 0x00, 0x01]
+```
+
+Each entry is a tuple of CI-V wire bytes. `profiles/rig_loader.py:
+RigConfig.to_command_map` builds a `CommandMap` from these entries;
+`commands/_frame.py: _build_from_map` decodes one entry into a frame.
+
+**The tuple contract (Q7,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1):** a tuple
+holds every constant byte of the frame — command, sub-command, and any
+further constant bytes, whether those are extended menu addressing, a
+selector byte, or a constant payload byte. Only a value the caller
+supplies at the call site (e.g. a level to encode) is appended on top of
+the tuple.
+
+`rigs/x6100.toml`'s `ptt_on = [0x1C, 0x00, 0x01]` is valid under this
+contract as written. `rigs/ic7300.toml`'s shorter `ptt_on = [0x1C, 0x00]`
+is the shape rows are being migrated to in Step 2
+(`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Step 2).
+
 ---
 
 ## Layer 1: Capabilities

--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -105,9 +105,10 @@ selector byte, or a constant payload byte. Only a value the caller
 supplies at the call site (e.g. a level to encode) is appended on top of
 the tuple.
 
-`rigs/x6100.toml`'s `ptt_on = [0x1C, 0x00, 0x01]` is valid under this
-contract as written. `rigs/ic7300.toml`'s shorter `ptt_on = [0x1C, 0x00]`
-is the shape rows are being migrated to in Step 2
+`rigs/x6100.toml`'s `ptt_on = [0x1C, 0x00, 0x01]` already carries the
+trailing byte and is valid under this contract as written.
+`rigs/ic7300.toml`'s shorter `ptt_on = [0x1C, 0x00]` is the one that
+needs to grow to match it, in Step 2
 (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Step 2).
 
 ---

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -301,9 +301,14 @@ def _build_from_map(
     """Build a CI-V frame using wire bytes from a CommandMap.
 
     Wire bytes may have 1-N elements.  The first byte is the CI-V command,
-    the second (if present) is the sub-command, and any remaining bytes are
-    prepended to *data* as extended sub-command addressing (e.g. 0x1A 0x05
-    0x00 0x64 for IC-7300 ACC1 mod level).
+    the second (if present) is the sub-command. Any remaining bytes are the
+    frame's further constant bytes, per the tuple contract ruled in Q7
+    (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1): a tuple
+    holds every constant byte of the frame, whether that is extended menu
+    addressing (e.g. 0x1A 0x05 0x00 0x64 for IC-7300 ACC1 mod level), a
+    selector byte, or a constant payload byte (e.g. 0x1C 0x00 0x01 for
+    X6100 ptt_on). They are prepended to *data*; only what the caller
+    passes as *data* is appended after them.
     """
     wire = cmd_map.get(name)
     command = wire[0]

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -884,7 +884,14 @@ def _parse_command_value(
     """Parse a single command value from TOML.
 
     Supports two formats:
-    1. CI-V wire bytes (list): [0x03] or [0x14, 0x01]
+    1. CI-V wire bytes (list): the frame's full constant prefix, per the
+       tuple contract ruled in Q7
+       (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1) —
+       command, sub-command, and any further constant bytes (extended menu
+       addressing, a selector byte, or a constant payload byte). Examples:
+       [0x03] (command only), [0x14, 0x01] (command + sub), or
+       [0x1C, 0x00, 0x01] (command + sub + a constant payload byte, the
+       X6100 ptt_on shape).
     2. CAT command spec (dict): { cat = { read = "FA;", parse = "FA{freq:09d};" } }
 
     Args:

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -334,3 +334,19 @@ class TestCommandMapOverride:
         # The level data should follow the extended sub-command bytes
         idx = result.index(b"\x00\x64")
         assert idx + 2 < len(result) - 1  # there's data after 00 64 before FD
+
+    def test_three_byte_wire_trailing_byte_is_constant_not_addressing(self):
+        """Q7 (docs/plans/2026-08-29-profile-driven-command-bytes.md §8.1):
+        a tuple's trailing byte can be a constant payload or selector byte,
+        not only extended menu addressing — the shape of
+        rigs/x6100.toml's ptt_on = [0x1C, 0x00, 0x01]. It must still land
+        in the frame even though this getter passes no data of its own,
+        so a future change that truncated the tuple at the sub-command
+        would be caught here.
+        """
+        custom = CommandMap({"get_acc1_mod_level": (0x1C, 0x00, 0x01)})
+        result = commands.get_acc1_mod_level(cmd_map=custom)
+        # Frame: FE FE <to> <from> 1C 00 01 FD
+        assert b"\x1c\x00\x01" in result
+        assert result.startswith(b"\xfe\xfe")
+        assert result.endswith(b"\xfd")

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1660,6 +1660,23 @@ class TestToCommandMap:
         cm = load_rig(TEMPLATE_PATH).to_command_map()
         assert len(cm) > 50  # template has ~100 commands
 
+    def test_three_byte_wire_round_trips_intact(self, tmp_path):
+        """Q7 (docs/plans/2026-08-29-profile-driven-command-bytes.md §8.1):
+        a [commands] entry longer than command+sub — here a constant
+        payload byte, the shape of rigs/x6100.toml's
+        ptt_on = [0x1C, 0x00, 0x01] — must arrive in to_command_map()
+        byte-for-byte. Pins against a future "normalization" that cuts a
+        tuple back to (command, sub); nothing in the loader does that
+        today, but nothing would catch it either without this test.
+        """
+        toml = _MINIMAL_TOML.replace(
+            "set_freq = [0x05]",
+            "set_freq = [0x05]\nptt_on = [0x1C, 0x00, 0x01]",
+        )
+        rig = load_rig(_write_toml(tmp_path, toml))
+        cm = rig.to_command_map()
+        assert cm.get("ptt_on") == (0x1C, 0x00, 0x01)
+
     def test_ic7610_drops_dead_tone_commands(self):
         """MOR-682: IC-7610 has no FM-repeater tone capability, so the
         repeater-tone / TSQL command entries must not be in the command map."""


### PR DESCRIPTION
## What Q7 says

Quoting the owner's ruling verbatim (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1, Q7):

> **Q7 — The tuple contract carries the full constant prefix.** A `[commands]` tuple holds every constant byte of the frame, selector bytes included; only a value the caller supplies at the call site is appended on top. `rigs/x6100.toml`'s `ptt_on = [0x1C, 0x00, 0x01]`, which already carries the trailing byte, is valid under the ruling; `rigs/ic7300.toml`'s shorter `ptt_on = [0x1C, 0x00]` is the one that needs to grow. Consequence: `commands/_frame.py: _build_from_map` changes once, to stop assuming a tuple always ends at the sub-command.

This is **Step 2a** of the plan's Step 2 split: "2a = contract + `_build_from_map` + loader validation + `_schema_v2.md`". Step 2b (the TOML row growth, `vfo.py`/`scope.py` fixes, and the divergence-file deletions) is separate, deliberately not touched here.

## What I found before changing anything

Inspecting `commands/_frame.py: _build_from_map`, the mechanics already satisfy Q7: `wire[2:]` is already treated as a data prefix regardless of length, and caller-supplied `data` is appended after it. What contradicted Q7 was only the **prose** — the docstring called the extra bytes "extended sub-command addressing," implying they're only ever menu addressing, never a selector or constant payload byte (the exact case `x6100.toml`'s `ptt_on = [0x1C, 0x00, 0x01]` is). Since the mechanism was already correct, "the one change Q7's ruling requires" (per the plan) is the contract statement, not a code change — I did not touch the composition logic in `_build_from_map`, only its docstring.

The loader (`profiles/rig_loader.py: _parse_command_value` → `CivCommandSpec(bytes=tuple(value))` → `RigConfig.to_command_map`) is a straight pass-through with no length cap anywhere in the chain, so there was likewise no mechanical gap to fix — only the docstring's pre-Q7 examples (`[0x03]` / `[0x14, 0x01]`, both ending at the sub-command) needed updating to a full-prefix example.

## Files changed

- `src/rigplane/commands/_frame.py` — rewrote `_build_from_map`'s docstring to state the Q7 contract (tuple = full constant prefix: command, sub-command, and any further constant bytes — addressing, selector, or payload), citing the plan §8.1. No change to the function body.
- `src/rigplane/profiles/rig_loader.py` — rewrote `_parse_command_value`'s docstring for the same contract, with a full-prefix example (`[0x1C, 0x00, 0x01]`, the X6100 `ptt_on` shape) alongside the existing short examples. No change to parsing logic.
- `rigs/_schema_v2.md` — added a new "CI-V Wire Command Map (`[commands]`)" section under Layer 0 (this tuple format was previously undocumented entirely for CI-V), recording the Q7 contract and the x6100/ic7300 `ptt_on` example: x6100's longer tuple already carries its trailing byte and matches the contract as written; ic7300's shorter tuple is the one that needs to grow to match it, in Step 2.
- `tests/test_command_map_integration.py` — added `TestCommandMapOverride.test_three_byte_wire_trailing_byte_is_constant_not_addressing`, a discriminating pin: a 3-byte `CommandMap` entry `(0x1C, 0x00, 0x01)` (the exact ptt-shaped case Q7 names) fed to `get_acc1_mod_level` (which passes no data of its own) must still emit `1C 00 01` in the frame. This adds a **hand-written-literal** 3-byte case — no existing test builds a `CommandMap` from a literal that long (checked via `grep -rn "CommandMap({" tests/*.py`); the file's existing `test_four_byte_wire_extended_sub`/`test_four_byte_wire_with_set_data` only exercise 4-byte literals. A 3-byte tuple *is* already exercised indirectly: `tests/test_command_map_parity.py` builds a `CommandMap` per profile via the real `to_command_map()`, and X6100's `ptt_on` resolves to exactly `(0x1C, 0x00, 0x01)` there, with the resulting frame pinned in `tests/command_map_parity_divergences.txt` (the `X6100 ptt.py:ptt_on` row, `map=fefe70e01c000101fd`). That coverage is tied to one profile's TOML content and would move if the TOML changed; the new test pins the same mechanism directly, independent of any profile.
- `tests/test_rig_loader.py` — added `TestToCommandMap.test_three_byte_wire_round_trips_intact`, pinning the loader round-trip: a `[commands]` entry `ptt_on = [0x1C, 0x00, 0x01]` loaded via the real `load_rig()` arrives in `RigConfig.to_command_map()` byte-for-byte.

## Loader validation — no new runtime check added

Per the discriminating-pin rule, a new load-time check must fail on a real defect and pass on every legitimate profile row (tuple length is not itself a violation — some are 1 byte, some 4+). I looked for a mechanical gap and found none: `_parse_command_value` already accepts any non-empty list of 0x00–0xFF ints, and nothing downstream (`CivCommandSpec`, `RigConfig.to_command_map`) truncates or reshapes the tuple. The one defect mode Q7 makes checkable — truncation at the sub-command — isn't reachable today, so I did not add a new runtime validator; I added the round-trip **test** instead, which is what would go red if a future "normalization" introduced that truncation. I did not invent a decorative check beyond that.

## Zero-behavior-change evidence

Targeted run (`uv run pytest tests/test_rig_loader.py tests/test_command_map_parity.py tests/test_commands.py tests/test_command_map_integration.py -q --tb=short --timeout=300 --timeout-method=thread`), re-run at this PR's current head:

```
743 items collected → 742 passed, 1 skipped (pre-existing skip, unrelated)
```

Parity test alone, verbose:

```
tests/test_command_map_parity.py::test_every_divergence_is_allowlisted PASSED
tests/test_command_map_parity.py::test_allowlist_has_no_stale_entries PASSED
tests/test_command_map_parity.py::test_allowlist_records_the_observed_frames PASSED
tests/test_command_map_parity.py::test_uncovered_inventory_matches PASSED
tests/test_command_map_parity.py::test_every_site_is_reached_by_some_builder PASSED
5 passed in 0.21s
```

`tests/command_map_parity_divergences.txt` is confirmed byte-for-byte untouched: `git diff --numstat -- tests/command_map_parity_divergences.txt` is empty, and the file's checksum (`8d8aef81e4cda4ddc09e1a98e83f3518`) matches `origin/main` exactly. `uv run ruff check src/ tests/` passes clean.

Both new tests pass against the *unmodified* production code (verified before touching any docstring), confirming this PR changes documentation and test coverage only — no builder, loader, or wire-format behavior changes.

Diff size at current head: 5 files changed, 75 insertions(+), 4 deletions(-) — `rigs/_schema_v2.md` +26/-0, `src/rigplane/commands/_frame.py` +8/-3, `src/rigplane/profiles/rig_loader.py` +8/-1, `tests/test_command_map_integration.py` +16/-0, `tests/test_rig_loader.py` +17/-0. Well inside both the soft (6 files / 600 lines) and hard (10 files / 1000 lines) guardrails.

## Step 2b follows

Deliberately left out of this PR, per the plan's own split:

- `rigs/ic7300.toml`'s `ptt_on`/`ptt_off` rows growing to carry the payload byte they always send (currently `[0x1C, 0x00]`, needs to become `[0x1C, 0x00, 0x01]` / `[0x1C, 0x00, 0x00]`).
- `commands/vfo.py: get_dual_watch`, `get_main_sub_band` — stop double-appending a selector byte the tuple already carries.
- `commands/scope.py: get_scope_center_type` — remove the `receiver` keyword argument (MOR-1981).
- `tests/command_map_parity_divergences.txt` — deleting the 10 class-C rows once the above land.

Refs: MOR-2002, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Step 2 / §8.1 Q7.

## Test plan

- [x] `uv run pytest tests/test_rig_loader.py tests/test_command_map_parity.py tests/test_commands.py tests/test_command_map_integration.py -q --tb=short --timeout=300 --timeout-method=thread` — 742 passed, 1 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `tests/command_map_parity_divergences.txt` confirmed untouched (checksum match)
- [ ] Full suite — runs on the remote test bench per repo policy, not locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
