### PR TITLE
fix(MOR-2002): stop doubling vfo query bytes and refuse the scope receiver argument (step 2b-vfo-scope)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now selects the MAIN receiver (0xD0) where it used to select VFO A
   (0x00), and `restore_state` swallows per-field failures at DEBUG, so
   nothing surfaces. Hand-built restore dicts should use "MAIN"/"SUB".
+- **`rigplane.commands.get_scope_center_type` takes no `receiver` argument**
+  (MOR-1981, MOR-2002). The parameter let a caller name the MAIN or SUB
+  scope for this reading, like the library's other seven scope-selector
+  getters, but 0x1C is not one of them: on the wire, `27 1C 00` is a SET of
+  center_type=0 (Filter center), not a selector prefix on a read — confirmed
+  by a live IC-7300 bench recheck and by all four official Icom CI-V
+  references (IC-705, IC-7300, IC-7610, IC-9700). The `cmd_map` branch never
+  accepted the argument, so passing `receiver=` produced a write the caller
+  believed was a read. No shipped caller passed it — `runtime/_scope_runtime.py`
+  and the `Radio` protocol method never took a receiver for this reading —
+  so this closes a footgun rather than changing observed behaviour; a caller
+  that did pass `receiver=` now gets a `TypeError` instead of a silent SET.
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing surfaces. Hand-built restore dicts should use "MAIN"/"SUB".
 - **`rigplane.commands.get_scope_center_type` takes no `receiver` argument**
   (MOR-1981, MOR-2002). The parameter let a caller name the MAIN or SUB
-  scope for this reading, like the library's other seven scope-selector
+  scope for this reading, like the library's other eight scope-selector
   getters, but 0x1C is not one of them: on the wire, `27 1C 00` is a SET of
   center_type=0 (Filter center), not a selector prefix on a read — confirmed
   by a live IC-7300 bench recheck and by all four official Icom CI-V

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -100,13 +100,16 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 # for 0x12, 0x13, 0x1B and 0x1C, matching that bench result with no
 # exception.  0x1F (RBW) has no row in that guide, but Hamlib supplies the
 # selector for it and the bare form NAKs, so it is the same class.  The
-# IC-7300's own sub-command table could not be reached from the environment
-# this was measured in, so its membership rests on the bench plus the
-# analogy with the IC-705.  No bench evidence exists for the IC-9700.  The
-# de-risking fact is that ``web/radio_poller.py`` has been putting this exact
-# split on the wire to all four scope-capable profiles since long before this
-# constant existed: the connect sweep is catching up to shipped behaviour,
-# not trying something new.
+# IC-7300's own command table (advanced manual, table 19-8) and the
+# IC-7610 and IC-9700 CI-V Reference Guides have since been read directly
+# and print the same split: the IC-7300 leg now has both the bench
+# measurement and its own manual behind it, and the IC-7610 leg is
+# confirmed from its guide.  Documentary evidence exists for the IC-9700
+# (its CI-V Reference Guide); no bench evidence exists for the IC-9700.
+# The de-risking fact is that ``web/radio_poller.py`` has been putting this
+# exact split on the wire to all four scope-capable profiles since long
+# before this constant existed: the connect sweep is catching up to
+# shipped behaviour, not trying something new.
 #
 # The exclusions are not omissions -- on a sub-command that takes no
 # selector the extra byte is a WRITE, not a no-op:
@@ -161,12 +164,21 @@ def _scope_selector_data(receiver: int | None) -> bytes | None:
     its frame with it via ``_scope_query``, and the ``cmd_map`` branch passes
     it as ``data``.
 
-    ``get_scope_center_type`` is the getter that reaches here and does not
-    agree.  Its 0x1C is outside the set, so its ``cmd_map`` branch correctly
-    sends nothing while its fallback still appends what it is given; the
-    disagreement is pinned in ``tests/command_map_parity_divergences.txt``
-    and closing it means refusing the argument, which changes public builder
-    behaviour (MOR-1981).
+    ``get_scope_center_type`` used to accept a ``receiver`` argument and
+    forward it here too, even though its 0x1C sub is outside the set: on
+    0x1C the extra byte is a SET, not a selector -- ``27 1C 00`` sets
+    center_type=0 rather than reading it, confirmed by a live IC-7300
+    bench recheck and by all four official CI-V references (IC-705,
+    IC-7300, IC-7610, IC-9700 guides).  Its ``cmd_map`` branch never took
+    the argument, so the two branches disagreed whenever a caller passed
+    one -- pinned as the ``receiver=0`` rows in
+    ``tests/command_map_parity_divergences.txt`` before this fix.  Closing
+    that (MOR-1981) meant refusing the argument outright rather than
+    special-casing 0x1C: ``get_scope_center_type`` now takes no
+    ``receiver`` parameter at all and always reaches here with
+    ``receiver=None``, so its two branches agree by construction.  The
+    eight selector subs above are the only sub-commands whose getters
+    still pass a real receiver value through this function.
     """
     return None if receiver is None else bytes([_validate_scope_receiver(receiver)])
 
@@ -753,16 +765,18 @@ def get_scope_center_type(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
-    *,
-    receiver: int | None = None,
 ) -> bytes:
+    """Build a bare 'get scope center type' CI-V command (0x27 0x1C).
+
+    Takes no ``receiver`` argument (MOR-1981, MOR-2002 step 2b-vfo-scope):
+    0x1C is outside ``SCOPE_RECEIVER_SELECTOR_SUBS``, so a receiver byte on
+    this read is a SET, not a selector -- see ``_scope_selector_data``.
+    """
     if cmd_map is not None:
         return _build_from_map(
             cmd_map, "get_scope_center_type", to_addr=to_addr, from_addr=from_addr
         )
-    return _scope_query(
-        _SUB_SCOPE_CENTER_TYPE, to_addr=to_addr, from_addr=from_addr, receiver=receiver
-    )
+    return _scope_query(_SUB_SCOPE_CENTER_TYPE, to_addr=to_addr, from_addr=from_addr)
 
 
 def scope_set_center_type(

--- a/src/rigplane/commands/vfo.py
+++ b/src/rigplane/commands/vfo.py
@@ -43,14 +43,19 @@ def get_main_sub_band(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Build a 'get main/sub band' CI-V command (0x07 0xD2)."""
+    """Build a 'get main/sub band' CI-V command (0x07 0xD2).
+
+    The ``[commands]`` tuple (``[0x07, 0xD2]``) already carries the 0xD2
+    query byte as its sub-command, so the ``cmd_map`` branch passes no
+    ``data`` of its own -- passing it again doubled the byte (``07 d2 d2``)
+    until this fix (Q7, step 2b-vfo-scope).
+    """
     if cmd_map is not None:
         return _build_from_map(
             cmd_map,
             "get_main_sub_band",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=b"\xd2",
         )
     return build_civ_frame(to_addr, from_addr, _CMD_VFO_SELECT, data=b"\xd2")
 
@@ -331,14 +336,19 @@ def get_dual_watch(
     from_addr: int = CONTROLLER_ADDR,
     cmd_map: CommandMap | None = None,
 ) -> bytes:
-    """Build CI-V command to query dual watch status (0x07 0xC2)."""
+    """Build CI-V command to query dual watch status (0x07 0xC2).
+
+    The ``[commands]`` tuple (``[0x07, 0xC2]``) already carries the 0xC2
+    query byte as its sub-command, so the ``cmd_map`` branch passes no
+    ``data`` of its own -- passing it again doubled the byte (``07 c2 c2``)
+    until this fix (Q7, step 2b-vfo-scope).
+    """
     if cmd_map is not None:
         return _build_from_map(
             cmd_map,
             "get_dual_watch",
             to_addr=to_addr,
             from_addr=from_addr,
-            data=bytes([_VFO_DUAL_WATCH_QUERY]),
         )
     return build_civ_frame(
         to_addr, from_addr, _CMD_VFO_SELECT, data=bytes([_VFO_DUAL_WATCH_QUERY])

--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -18,7 +18,6 @@ IC-705	levels.py:get_dash_ratio	(no arguments)	map=fefea4e01a050252fd fallback=f
 IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=fefea4e01a050070fd
 IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a05025230fd fallback=fefea4e01a05022830fd
 IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a0500890000fd fallback=fefea4e01a0500700000fd
-IC-705	scope.py:get_scope_center_type	receiver=0	map=fefea4e0271cfd fallback=fefea4e0271c00fd
 IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-7300	config.py:get_acc1_mod_level	(no arguments)	map=fefe94e01a050064fd fallback=fefe94e0140bfd
@@ -39,7 +38,6 @@ IC-7300	levels.py:get_vox_delay	(no arguments)	map=fefe94e01a050191fd fallback=f
 IC-7300	levels.py:set_nb_depth	value=0	map=fefe94e01a05018900fd fallback=fefe94e01a05029000fd
 IC-7300	levels.py:set_nb_width	value=0	map=fefe94e01a0501900000fd fallback=fefe94e01a0502910000fd
 IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a05019100fd fallback=fefe94e01a05029200fd
-IC-7300	scope.py:get_scope_center_type	receiver=0	map=fefe94e0271cfd fallback=fefe94e0271c00fd
 IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7610	config.py:get_acc1_mod_level	(no arguments)	map=fefe98e01a050088fd fallback=fefe98e0140bfd
@@ -52,9 +50,6 @@ IC-7610	config.py:set_civ_output_ant	enabled=False	map=fefe98e01c0400fd fallback
 IC-7610	config.py:set_civ_transceive	enabled=False	map=fefe98e01a05011200fd fallback=fefe98e01a05012900fd
 IC-7610	config.py:set_lan_mod_level	level=0	map=fefe98e01a0500900000fd fallback=fefe98e014110000fd
 IC-7610	config.py:set_usb_mod_level	level=0	map=fefe98e01a0500890000fd fallback=fefe98e014100000fd
-IC-7610	scope.py:get_scope_center_type	receiver=0	map=fefe98e0271cfd fallback=fefe98e0271c00fd
-IC-7610	vfo.py:get_dual_watch	(no arguments)	map=fefe98e007c2c2fd fallback=fefe98e007c2fd
-IC-7610	vfo.py:get_main_sub_band	(no arguments)	map=fefe98e007d2d2fd fallback=fefe98e007d2fd
 IC-9700	config.py:get_acc1_mod_level	(no arguments)	map=fefea2e01a050064fd fallback=fefea2e0140bfd
 IC-9700	config.py:get_civ_output_ant	(no arguments)	map=fefea2e01a050061fd fallback=fefea2e01a050130fd
 IC-9700	config.py:get_civ_transceive	(no arguments)	map=fefea2e01a050071fd fallback=fefea2e01a050129fd
@@ -73,8 +68,5 @@ IC-9700	levels.py:get_vox_delay	(no arguments)	map=fefea2e01a050191fd fallback=f
 IC-9700	levels.py:set_nb_depth	value=0	map=fefea2e01a05018900fd fallback=fefea2e01a05029000fd
 IC-9700	levels.py:set_nb_width	value=0	map=fefea2e01a0501900000fd fallback=fefea2e01a0502910000fd
 IC-9700	levels.py:set_vox_delay	value=0	map=fefea2e01a05019100fd fallback=fefea2e01a05029200fd
-IC-9700	scope.py:get_scope_center_type	receiver=0	map=fefea2e0271cfd fallback=fefea2e0271c00fd
-IC-9700	vfo.py:get_dual_watch	(no arguments)	map=fefea2e007c2c2fd fallback=fefea2e007c2fd
-IC-9700	vfo.py:get_main_sub_band	(no arguments)	map=fefea2e007d2d2fd fallback=fefea2e007d2fd
 IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a050030fd fallback=fefea2e01a050033fd
 IC-9700	vfo.py:set_quick_split	(no arguments)	map=fefea2e01a050030fd fallback=fefea2e01a050033fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -22,8 +22,8 @@
 census	builders_compared	230
 census	cat_only_profiles	2
 census	dual_implementation_sites	139
-census	frames_diverged	74
-census	frames_identical	1346
+census	frames_diverged	66
+census	frames_identical	1350
 census	hardcode_only_builders	16
 census	profile_builder_map_gaps	1006
 census	profiles	8

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -204,6 +204,89 @@ class TestPttWireContractAcrossProfiles:
             assert mapped.endswith(b"\x1c\x00\x00\xfd"), model
 
 
+# ── VFO / scope wire contracts: every declaring profile ─────────
+
+
+class TestVfoScopeMapFallbackParityAcrossProfiles:
+    """MOR-2002 step 2b-vfo-scope (Q7, ``docs/plans/2026-08-29-profile-driven-
+    command-bytes.md`` §4 Step 2). Two divergences closed as one contract
+    application:
+
+    ``vfo.py: get_dual_watch`` / ``get_main_sub_band`` declare a 2-byte
+    ``[command, sub]`` tuple that already carries the query byte as its
+    sub-command; the ``cmd_map`` branch also passed that byte as ``data``,
+    doubling it (``07 c2 c2`` / ``07 d2 d2`` instead of ``07 c2`` / ``07
+    d2``).
+
+    ``scope.py: get_scope_center_type`` took a ``receiver`` keyword whose
+    ``cmd_map`` branch dropped it while the fallback appended it -- on
+    0x1C the extra byte is a SET, not a read (MOR-1981). The fix refuses
+    the argument outright rather than special-casing it, so there is only
+    one call shape left and both branches agree by construction.
+
+    This sweeps every CI-V profile in ``rigs/`` that declares each command
+    and requires the map branch and the fallback branch to build the
+    identical frame.
+    """
+
+    @staticmethod
+    def _maps_declaring(name: str) -> dict[str, CommandMap]:
+        maps: dict[str, CommandMap] = {}
+        for model, config in sorted(discover_rigs(RIG_DIR).items()):
+            cmd_map = config.to_command_map()
+            if cmd_map.has(name):
+                maps[model] = cmd_map
+        return maps
+
+    def test_get_dual_watch_declared_by_ic7610_and_ic9700(self) -> None:
+        assert set(self._maps_declaring("get_dual_watch")) == {"IC-7610", "IC-9700"}
+
+    def test_get_dual_watch_identical_to_fallback_on_every_declaring_profile(
+        self,
+    ) -> None:
+        for model, cmd_map in self._maps_declaring("get_dual_watch").items():
+            mapped = commands.get_dual_watch(cmd_map=cmd_map)
+            fallback = commands.get_dual_watch()
+            assert mapped == fallback, model
+            assert mapped.endswith(b"\x07\xc2\xfd"), model
+
+    def test_get_main_sub_band_declared_by_ic7610_and_ic9700(self) -> None:
+        assert set(self._maps_declaring("get_main_sub_band")) == {
+            "IC-7610",
+            "IC-9700",
+        }
+
+    def test_get_main_sub_band_identical_to_fallback_on_every_declaring_profile(
+        self,
+    ) -> None:
+        for model, cmd_map in self._maps_declaring("get_main_sub_band").items():
+            mapped = commands.get_main_sub_band(cmd_map=cmd_map)
+            fallback = commands.get_main_sub_band()
+            assert mapped == fallback, model
+            assert mapped.endswith(b"\x07\xd2\xfd"), model
+
+    def test_get_scope_center_type_declared_by_all_four_scope_profiles(self) -> None:
+        assert set(self._maps_declaring("get_scope_center_type")) == {
+            "IC-705",
+            "IC-7300",
+            "IC-7610",
+            "IC-9700",
+        }
+
+    def test_get_scope_center_type_identical_to_fallback_on_every_declaring_profile(
+        self,
+    ) -> None:
+        for model, cmd_map in self._maps_declaring("get_scope_center_type").items():
+            mapped = commands.get_scope_center_type(cmd_map=cmd_map)
+            fallback = commands.get_scope_center_type()
+            assert mapped == fallback, model
+            assert mapped.endswith(b"\x27\x1c\xfd"), model
+
+    def test_get_scope_center_type_refuses_receiver_argument(self) -> None:
+        with pytest.raises(TypeError):
+            commands.get_scope_center_type(receiver=0)
+
+
 # ── Helper-delegating functions ─────────────────────────────────
 
 

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -11,9 +11,14 @@ and
 ``test_rig_ic7300.py: test_get_speech_cmd_map_uses_set_speech`` each pin
 ``get_speech`` alone. Outside that subset the two copies could disagree
 silently, and at least one pair does: the ``cmd_map`` branch of
-``scope.py: get_scope_center_type`` sends a bare ``27 1c`` where the
-fallback hands ``scope.py: _scope_query`` a receiver it then appends --
-and on 0x1C that extra byte is a write, not a read.
+``config.py: get_acc1_mod_level`` sends the IC-7300/IC-7610/IC-9700
+extended-menu address ``1A 05 00 64`` where the fallback sends the
+legacy command ``14 0B`` -- two different CI-V commands for the same
+control, not a byte-count mismatch. (``scope.py: get_scope_center_type``
+used to be this module's worked example here: its ``cmd_map`` branch sent
+a bare ``27 1c`` where the fallback appended a receiver byte that turned
+0x1C's read into a SET. MOR-2002 step 2b-vfo-scope closed that by
+refusing the argument outright.)
 
 This test is the general form of that check: it builds every builder it can
 reach both ways, for every profile the library loads out of ``rigs/``, and
@@ -31,9 +36,13 @@ That does not make the file physically unable to grow — regenerating it
 would add a new row — but growth can only arrive as a committed, reviewable
 edit to this file, never silently.
 
-Nothing here fixes a divergence. Which commands take a receiver prefix byte
-is MOR-1981, and adding one where the radio does not expect it is a write,
-not a no-op — see ``commands/scope.py: SCOPE_RECEIVER_SELECTOR_SUBS``.
+Nothing here fixes a divergence: for every command whose ``cmd_map`` branch
+and fallback both still accept a receiver, which ones take that prefix byte
+remains MOR-1981, and adding one where the radio does not expect it is a
+write, not a no-op — see ``commands/scope.py: SCOPE_RECEIVER_SELECTOR_SUBS``.
+``get_scope_center_type`` is the one exception this sweep no longer needs to
+watch: MOR-2002 step 2b-vfo-scope removed its ``receiver`` parameter
+outright, so that builder has no argument left to get wrong.
 
 What could not be compared is not skipped silently:
 ``command_map_parity_uncovered.txt`` records the commands a profile's map
@@ -351,10 +360,14 @@ def _cases() -> tuple[dict[Key, list[dict[str, typing.Any]]], frozenset[Key]]:
 
     The first case passes only required arguments; one further case per
     optional argument overrides it with a non-default value, because a
-    divergence can hide behind a default — ``scope.py: get_scope_center_type``
-    builds identical frames until ``receiver`` is given a value. Argument
-    validation happens before a builder reads ``to_addr``, so this search
-    runs once and its result is reused for every profile.
+    divergence can hide behind a default — until MOR-2002 step
+    2b-vfo-scope, ``scope.py: get_scope_center_type`` built identical
+    frames unless its ``receiver`` argument was given a value, which is
+    why that probe exists rather than stopping at required arguments.
+    Removing the argument closed that one case; this search still probes
+    every remaining optional argument the same way, on the same reasoning.
+    Argument validation happens before a builder reads ``to_addr``, so
+    this search runs once and its result is reused for every profile.
     """
     per_builder: dict[Key, list[dict[str, typing.Any]]] = {}
     unsynthesisable: set[Key] = set()

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -11,10 +11,11 @@ and
 ``test_rig_ic7300.py: test_get_speech_cmd_map_uses_set_speech`` each pin
 ``get_speech`` alone. Outside that subset the two copies could disagree
 silently, and at least one pair does: the ``cmd_map`` branch of
-``config.py: get_acc1_mod_level`` sends the IC-7300/IC-7610/IC-9700
-extended-menu address ``1A 05 00 64`` where the fallback sends the
-legacy command ``14 0B`` -- two different CI-V commands for the same
-control, not a byte-count mismatch. (``scope.py: get_scope_center_type``
+``config.py: get_acc1_mod_level`` sends an extended-menu address --
+``1A 05 00 64`` on IC-7300 and IC-9700, ``1A 05 00 88`` on IC-7610 -- where
+the fallback sends the legacy command ``14 0B`` on all three -- two
+different CI-V commands for the same control, not a byte-count mismatch.
+(``scope.py: get_scope_center_type``
 used to be this module's worked example here: its ``cmd_map`` branch sent
 a bare ``27 1c`` where the fallback appended a receiver byte that turned
 0x1C's read into a SET. MOR-2002 step 2b-vfo-scope closed that by


### PR DESCRIPTION
## Summary

Final piece of Step 2 of `docs/plans/2026-08-29-profile-driven-command-bytes.md` (Steps 2a #2819 and 2b-ptt #2820 already merged). Implements the plan's §4 Step 2 rulings verbatim:

- **`commands/vfo.py: get_dual_watch` / `get_main_sub_band`** — the `cmd_map` branch appended the query byte the tuple already carries in full, doubling it (`07 c2 c2` / `07 d2 d2`). Fixed in the builder: the map branch drops the redundant `data=`. Fallback (`07 c2` / `07 d2`) is unchanged. No rig TOML touched — `rigs/ic7610.toml` and `rigs/ic9700.toml`'s tuples (`[0x07, 0xC2]` / `[0x07, 0xD2]`) were already the complete prefix.
- **`commands/scope.py: get_scope_center_type`** — refuses its `receiver` keyword argument outright (MOR-1981, plan §5 class C). Sub `0x1C` is outside `SCOPE_RECEIVER_SELECTOR_SUBS`, so `27 1C 00` is a SET (center_type=0), not a bare read; the `cmd_map` branch already sent the correct bare frame by omitting the selector. `[0x27, 0x1C]` is unchanged in all four profiles (IC-705, IC-7300, IC-7610, IC-9700) — this is a public builder signature change, not a tuple edit.

**This closes MOR-1981** — the four scope rows (`get_scope_center_type receiver=0` on IC-705/IC-7300/IC-7610/IC-9700) were its subject. Direction is triple/quadruple-sourced per the MOR-2002 comment thread: all four official Icom CI-V documents (IC-7300 advanced manual command table 19-8; IC-7610, IC-9700, IC-705 CI-V Reference Guides) give `27 1C` a one-byte data field `00–02` with **no** selector, and a live IC-7300 bench recheck recorded in MOR-2002 confirmed bare `27 1C` reads (returned 02) while `27 1C 00` is answered with ACK and sets the value (verified by readback, distinct-value control, state restored).

## Documentation upgrade (MOR-2002 comment, 2026-08-29)

Per an owner-requested check, the provenance block above `SCOPE_RECEIVER_SELECTOR_SUBS` and the `_scope_selector_data` docstring in `commands/scope.py` are updated: the IC-7300's own command table (advanced manual, table 19-8) and the IC-7610/IC-9700 CI-V Reference Guides have now been read directly and confirm the split — the IC-7300 leg has both bench and document, the IC-7610 leg is confirmed from its guide, and the IC-9700 leg has documentary evidence (still no bench). The `_scope_selector_data` docstring's second paragraph, which described `get_scope_center_type` as a live divergence, is rewritten to be true at head (the getter no longer reaches that disagreement — it has no `receiver` parameter to disagree with).

`tests/test_command_map_parity.py`'s module-docstring prose (three passages, treating the divergence as live) is updated: the "at least one pair does" example is swapped for `config.py: get_acc1_mod_level` (a currently-live, unrelated divergence — extended-menu address `1A 05 00 64` on IC-7300/IC-9700, `1A 05 00 88` on IC-7610, vs legacy `14 0B` on all three), with the old scope example kept as a past-tense parenthetical; the "nothing here fixes a divergence" paragraph now notes `get_scope_center_type` as the one exception (argument removed, not just pinned); the `_cases()` docstring's "divergence can hide behind a default" example is rewritten past-tense. The harness itself (`_split_params`, `_values_for`, `_cases`) is fully signature-driven via `inspect.signature` — nothing hardcodes a `receiver=0` probe case, so removing the parameter alone removes that case with no harness edit needed.

## TDD

`tests/test_command_map_integration.py` gains `TestVfoScopeMapFallbackParityAcrossProfiles`, written and confirmed **red** before the production fix (doubled bytes on the two vfo builders; `TypeError` not raised for `get_scope_center_type(receiver=0)`), then green after. It sweeps every CI-V profile in `rigs/` that declares each command and asserts map == fallback plus the exact wire ending (`07 c2` / `07 d2` / `27 1c`).

## Parity-file regeneration — exact deltas and arithmetic

Regenerated via `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py`.

**`tests/command_map_parity_divergences.txt`** — loses exactly the 8 class-C rows, gains none:
```
IC-705   scope.py:get_scope_center_type  receiver=0     (removed)
IC-7300  scope.py:get_scope_center_type  receiver=0     (removed)
IC-7610  scope.py:get_scope_center_type  receiver=0     (removed)
IC-7610  vfo.py:get_dual_watch           (no arguments) (removed)
IC-7610  vfo.py:get_main_sub_band        (no arguments) (removed)
IC-9700  scope.py:get_scope_center_type  receiver=0     (removed)
IC-9700  vfo.py:get_dual_watch           (no arguments) (removed)
IC-9700  vfo.py:get_main_sub_band        (no arguments) (removed)
```

**`tests/command_map_parity_uncovered.txt`** — only the two census lines move:
- `frames_diverged`: 74 → 66 (−8, matches all 8 removed rows)
- `frames_identical`: 1346 → 1350 (+4)

Arithmetic: of the 8 removed divergences, the 2 `get_dual_watch` + 2 `get_main_sub_band` rows (4 total, across IC-7610/IC-9700) are cases that **still exist** post-fix — same builder, same argument set (`(no arguments)`) — and now produce byte-identical frames, so they move from diverged to identical (+4 identical). The 4 `get_scope_center_type receiver=0` rows are cases that **no longer exist to compare at all**: `receiver` is gone from the signature, so the harness's `_split_params`/`_cases` machinery (fully driven by `inspect.signature`) never synthesizes that probe case again — it isn't converted to identical, it vanishes from the comparison set outright. Total compared frames: 1346+74=1420 before, 1350+66=1416 after; the difference (4) is exactly those vanished cases. No other census line (`dual_implementation_sites`, `sites_compared`, `public_builders`, `hardcode_only_builders`, `builders_compared`, `profiles`, `cat_only_profiles`, `profile_builder_map_gaps`) changed, and no gap/unsynthesisable/uncompared-site line changed — confirmed by diffing the full file before/after regeneration, not just the two moved numbers.

## Changelog

`docs/CHANGELOG.md` keeps a Breaking-changes convention for public builder signature changes (precedent: the MOR-1986 `set_vfo` entry). Added an entry documenting the removed `receiver` parameter on `rigplane.commands.get_scope_center_type`, noting no shipped caller passed it (verified by grep — `runtime/_scope_runtime.py` and the `Radio` protocol method never took a receiver for this reading), so this closes a footgun rather than changing observed behaviour.

## Guardrails

7 files changed, 167 insertions(+) / 42 deletions(-) at head `9ddd1957f168f867cee7ac4cd811f0dcf8983a9d` — above the 6-file soft threshold (not the 10-file/1000-line hard ceiling). One unit of work: the 8 class-C rows are one contract application (refusing one public argument closes all 8 at once, since they're all instances of the same signature), and the prose/CHANGELOG updates are truth-maintenance for that same fix, not separate scope.

## Test plan

- [x] TDD: new test class written red (confirmed failing pre-fix), green post-fix
- [x] `uv run pytest tests/test_command_map_parity.py tests/test_command_map_integration.py tests/test_scope.py tests/test_state_queries.py tests/test_radio_protocol.py tests/test_radio.py tests/test_vfo_dual_watch.py tests/test_vfo_profile_primitives.py tests/test_rig_ic7610.py tests/test_per_receiver_vfo_roundtrip.py tests/test_mor1545_vfo_fallback_failure_paths.py tests/integration/test_vfo_dual_watch_integration.py tests/integration/test_scope_advanced_integration.py tests/test_web_server.py tests/test_web_server_coverage.py tests/test_radio_poller_coverage.py tests/test_handlers_coverage.py tests/validation/test_hardware_command_families.py -q -n auto` — **1524 passed, 2 skipped** (skip count matches pre-existing baseline)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean (693 files already formatted)
- [x] `uv run mypy --strict src/rigplane/web` — clean (not required by the path filter for this diff, run anyway)
- [x] `.github/scripts/check-doc-citations.sh` — clean, no baseline growth
- [x] Sweep: `grep -rn "get_scope_center_type" src/ tests/` — every caller verified; none pass `receiver=` to the builder
- [x] Full suite left to the remote runner per repo policy (not run locally)

## Review follow-up

Independent review flagged two prose defects, both fixed in a follow-up commit (`docs(MOR-2002): correct the worked-example address and the getter count`, head `9ddd1957f168f867cee7ac4cd811f0dcf8983a9d`):

- The `get_acc1_mod_level` worked example claimed one shared extended-menu address across IC-7300/IC-7610/IC-9700. Checked each divergence row's `map=` hex directly: IC-7300 and IC-9700 share `1A 05 00 64`, but IC-7610 uses `1A 05 00 88`. Both docs above are now corrected to name both addresses.
- The CHANGELOG entry said "other seven scope-selector getters"; `SCOPE_RECEIVER_SELECTOR_SUBS` has eight members (mode, span, edge, hold, ref, speed, vbw, rbw), matching `scope.py`'s own (already-correct) docstring. Corrected to eight.

No behavior changed — both fixes are comment/prose-only. Re-measured: file count unchanged (7); insertions moved 166→167 (updated above), parity-file deltas and test counts are unaffected (confirmed by re-running the targeted battery and diffing the parity files again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
