### PR TITLE
feat(MOR-2003): bind the command map once at radio construction (step 3)

### DIFF
--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -6,12 +6,16 @@ from here, but this module imports nothing from siblings.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from ..types import CivFrame
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..command_map import CommandMap
+
+_BuilderT = TypeVar("_BuilderT", bound="Callable[..., bytes]")
 
 # CI-V addresses
 CONTROLLER_ADDR = 0xE0
@@ -289,6 +293,28 @@ def build_cmd29_frame(
     )
 
 
+def decode_wire_tuple(wire: tuple[int, ...]) -> tuple[int, int | None, bytes]:
+    """Decode one ``[commands]`` wire tuple into ``(command, sub, prefix)``.
+
+    The single decoder named in
+    `docs/plans/2026-08-29-profile-driven-command-bytes.md` §2 ("Exactly one
+    decoder of a `[commands]` wire tuple into `(command, sub, prefix)`") and
+    used by Step 3 (§4) to build `commands/bound.py: BoundCommands.expect`
+    from the same map entry `_build_from_map` builds the request from.
+
+    The first element is the CI-V command, the second (if present) is the
+    sub-command, and any remaining elements are the frame's further constant
+    bytes -- per the tuple contract ruled in Q7 (§8.1): a tuple holds every
+    constant byte of the frame, whether that is extended menu addressing
+    (e.g. 0x1A 0x05 0x00 0x64 for IC-7300 ACC1 mod level), a selector byte,
+    or a constant payload byte (e.g. 0x1C 0x00 0x01 for X6100 ptt_on).
+    """
+    command = wire[0]
+    sub = wire[1] if len(wire) > 1 else None
+    prefix = bytes(wire[2:])
+    return command, sub, prefix
+
+
 def _build_from_map(
     cmd_map: CommandMap,
     name: str,
@@ -300,28 +326,49 @@ def _build_from_map(
 ) -> bytes:
     """Build a CI-V frame using wire bytes from a CommandMap.
 
-    Wire bytes may have 1-N elements.  The first byte is the CI-V command,
-    the second (if present) is the sub-command. Any remaining bytes are the
-    frame's further constant bytes, per the tuple contract ruled in Q7
-    (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1): a tuple
-    holds every constant byte of the frame, whether that is extended menu
-    addressing (e.g. 0x1A 0x05 0x00 0x64 for IC-7300 ACC1 mod level), a
-    selector byte, or a constant payload byte (e.g. 0x1C 0x00 0x01 for
-    X6100 ptt_on). They are prepended to *data*; only what the caller
-    passes as *data* is appended after them.
+    Decodes the wire tuple via :func:`decode_wire_tuple`; any prefix bytes
+    it returns are prepended to *data*, and only what the caller passes as
+    *data* is appended after them.
     """
     wire = cmd_map.get(name)
-    command = wire[0]
-    sub = wire[1] if len(wire) > 1 else None
-    # Extra wire bytes beyond command+sub become a data prefix
-    if len(wire) > 2:
-        extra = bytes(wire[2:])
-        data = extra + data if data else extra
+    command, sub, prefix = decode_wire_tuple(wire)
+    if prefix:
+        data = prefix + data if data else prefix
     if command29:
         return build_cmd29_frame(
             to_addr, from_addr, command, sub=sub, data=data, receiver=receiver
         )
     return build_civ_frame(to_addr, from_addr, command, sub=sub, data=data)
+
+
+def expose_command_key(
+    key: Callable[[CommandMap], str],
+) -> Callable[[_BuilderT], _BuilderT]:
+    """Attach the command-map key a builder resolves through `_build_from_map`.
+
+    Per the owner ruling on MOR-2003 (Step 3,
+    `docs/plans/2026-08-29-profile-driven-command-bytes.md` §3.1/§4): every
+    builder that exposes a key does so uniformly as
+    ``Callable[[CommandMap], str]``, even where the key is a fixed literal
+    the callable ignores its argument to return -- so `commands/speech.py:
+    get_speech`'s per-map probe (``"set_speech" if cmd_map.has("set_speech")
+    else "get_speech"``) fits the same shape rather than needing a split.
+
+    `commands/bound.py: BoundCommands.expect` calls the attached callable
+    with the bound map to learn which entry a builder's reply must be
+    matched against, decoded by the same :func:`decode_wire_tuple` the
+    request used. Attaches the callable as *fn*'s ``cmd_map_key`` attribute
+    and returns *fn* unchanged -- it does not wrap the call, so the
+    Step 1 fallback-audit wrapper (`commands/_fallback_audit.py`), which
+    copies a wrapped function's ``__dict__`` via `functools.wraps`, carries
+    the attribute through unaffected either way.
+    """
+
+    def decorator(fn: _BuilderT) -> _BuilderT:
+        fn.cmd_map_key = key  # type: ignore[attr-defined]
+        return fn
+
+    return decorator
 
 
 def parse_civ_frame(data: bytes) -> CivFrame:

--- a/src/rigplane/commands/bound.py
+++ b/src/rigplane/commands/bound.py
@@ -1,0 +1,138 @@
+"""Bind a radio's `CommandMap` once, at construction.
+
+Implements Candidate A of
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §3.1 ("a bound
+command object"), per Step 3 of the same plan (§4). This step only builds
+the binder and makes it reachable from `runtime/radio.py:
+CoreRadio.__init__`; no production call site moves onto it -- that is
+Steps 5..N.
+
+The owner ruling on MOR-2003 (recorded against §3.1's design fork) settles
+how a builder exposes its command-map key: every builder that exposes one
+does so as ``Callable[[CommandMap], str]``, uniformly -- `speech.py:
+get_speech` is not split into two functions; its per-map probe
+(``"set_speech" if cmd_map.has("set_speech") else "get_speech"``) lives
+inside the callable instead. See `commands/_frame.py: expose_command_key`,
+which attaches that callable to a builder as its ``cmd_map_key``
+attribute.
+
+`BoundCommands` is constructed once per radio, from that radio's
+`CommandMap`. It supplies two things a future call site needs (Steps
+5..N), both derived from one map entry so they cannot drift apart:
+
+- attribute access (`__getattr__`) returns the named builder from
+  `rigplane.commands`'s public namespace with the map already bound as
+  ``cmd_map=``, so a call site reads
+  ``self._commands.set_mic_gain(178, self._radio_addr)``.
+- `expect(builder)` returns the ``(command, sub, prefix)`` triple the
+  matching reply must have, decoded from the SAME map entry by the SAME
+  decoder (`commands/_frame.py: decode_wire_tuple`) the builder itself
+  uses via `_build_from_map` -- see plan §3.1, "Why `expect` takes the
+  builder and not a name".
+
+Per `commands/LAYER.md`, this module imports only `commands` internals and
+`core`; it holds no module-level mutable state and performs no I/O. The
+map is injected by the caller (`runtime/radio.py`), never looked up here.
+
+The import of `rigplane.commands` inside `__getattr__` is deliberately
+deferred to call time rather than done at module level: `bound.py` is
+itself a module of the `commands` package, so an eager, module-level
+``import rigplane.commands`` here would need the package's own
+``__init__.py`` to have finished executing already -- true today because
+nothing in that file imports `bound.py`, but not a fact this module should
+depend on. Resolving lazily means it works either way.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import TYPE_CHECKING, Any
+
+from ._frame import decode_wire_tuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..command_map import CommandMap
+
+__all__ = ["BoundCommands"]
+
+
+def _takes_cmd_map(value: Any) -> bool:
+    """True if *value*'s callable signature has a ``cmd_map`` parameter.
+
+    Deliberately not gated on ``inspect.isfunction``: several test files
+    (`tests/_command_test_helpers.py: bind_default_addr_module`) rebind a
+    builder on the shared ``rigplane.commands`` package namespace into a
+    ``functools.partial`` with a default ``to_addr`` bound, for the
+    remainder of that test worker's session -- a real interaction in the
+    full suite, not a production one, since nothing outside tests ever
+    calls that helper. ``inspect.signature`` still reports the ``cmd_map``
+    parameter correctly on such a partial, so checking the signature
+    directly, the same way `_command_test_helpers.py:
+    CommandModuleProxy.__getattr__` does, is what tolerates it.
+    """
+    try:
+        signature = inspect.signature(value)
+    except (TypeError, ValueError):
+        return False
+    return "cmd_map" in signature.parameters
+
+
+class BoundCommands:
+    """A radio's command builders, pre-bound to its `CommandMap`."""
+
+    __slots__ = ("_map",)
+
+    def __init__(self, cmd_map: CommandMap) -> None:
+        self._map = cmd_map
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        import rigplane.commands as _commands
+
+        try:
+            builder = getattr(_commands, name)
+        except AttributeError:
+            raise AttributeError(
+                f"{type(self).__name__!r} has no builder named {name!r} "
+                "(not exported from rigplane.commands)"
+            ) from None
+        if not callable(builder) or not _takes_cmd_map(builder):
+            raise AttributeError(
+                f"{type(self).__name__!r} has no builder named {name!r} "
+                f"({name!r} in rigplane.commands does not take cmd_map)"
+            )
+        return functools.partial(builder, cmd_map=self._map)
+
+    def expect(self, builder: Callable[..., bytes]) -> tuple[int, int | None, bytes]:
+        """Return the ``(command, sub, prefix)`` triple *builder*'s reply must match.
+
+        Computed from the same map entry, via the same decoder
+        (`_frame.decode_wire_tuple`), that *builder* itself resolves through
+        `_build_from_map` when called with this bound map -- see the module
+        docstring and plan §3.1's "Why `expect` takes the builder and not a
+        name".
+
+        Raises:
+            AttributeError: *builder* has no command-map key exposed yet.
+                Exposure is added module by module in Steps 5..N of
+                `docs/plans/2026-08-29-profile-driven-command-bytes.md`
+                (§4); until a builder's module migrates, `expect` refuses
+                rather than guess.
+        """
+        key_fn = getattr(builder, "cmd_map_key", None)
+        if key_fn is None:
+            name = getattr(builder, "__qualname__", repr(builder))
+            raise AttributeError(
+                f"{name} has no command-map key exposed yet -- expose one "
+                "with @expose_command_key when this builder's module "
+                "migrates in Steps 5..N of "
+                "docs/plans/2026-08-29-profile-driven-command-bytes.md "
+                "(§4); BoundCommands.expect refuses rather than guess."
+            )
+        key = key_fn(self._map)
+        wire = self._map.get(key)
+        return decode_wire_tuple(wire)

--- a/src/rigplane/commands/command_map.py
+++ b/src/rigplane/commands/command_map.py
@@ -46,3 +46,20 @@ class CommandMap:
 
     def __repr__(self) -> str:
         return f"CommandMap({len(self._commands)} commands)"
+
+    def __eq__(self, other: object) -> bool:
+        """Compare by contents, matching this class's ``Immutable mapping`` claim.
+
+        Without this, two ``CommandMap`` instances built from identical
+        dicts (e.g. two calls to ``profiles/rig_loader.py:
+        RigConfig.to_command_map`` for the same TOML) compared unequal by
+        identity -- which broke a pre-existing field-by-field equality
+        sweep once ``profiles/__init__.py: RadioProfile`` gained a
+        ``command_map`` field carrying one (MOR-2003 Step 3).
+        """
+        if not isinstance(other, CommandMap):
+            return NotImplemented
+        return self._commands == other._commands
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self._commands.items()))

--- a/src/rigplane/commands/ptt.py
+++ b/src/rigplane/commands/ptt.py
@@ -10,12 +10,14 @@ from ._frame import (
     _SUB_PTT,
     _build_from_map,
     build_civ_frame,
+    expose_command_key,
 )
 
 if TYPE_CHECKING:
     from ..command_map import CommandMap
 
 
+@expose_command_key(lambda cmd_map: "ptt_on")
 def ptt_on(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
@@ -26,13 +28,16 @@ def ptt_on(
     The payload byte (0x01) is constant, so under the tuple contract
     (Q7, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1)
     every profile's ``ptt_on`` tuple already carries it; the map branch
-    passes no ``data`` of its own.
+    passes no ``data`` of its own. Exposes its command-map key as a plain
+    literal (MOR-2003 Step 3, §3.1) for `commands/bound.py:
+    BoundCommands.expect`.
     """
     if cmd_map is not None:
         return _build_from_map(cmd_map, "ptt_on", to_addr=to_addr, from_addr=from_addr)
     return build_civ_frame(to_addr, from_addr, _CMD_PTT, sub=_SUB_PTT, data=b"\x01")
 
 
+@expose_command_key(lambda cmd_map: "ptt_off")
 def ptt_off(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
@@ -43,7 +48,9 @@ def ptt_off(
     The payload byte (0x00) is constant, so under the tuple contract
     (Q7, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1)
     every profile's ``ptt_off`` tuple already carries it; the map branch
-    passes no ``data`` of its own.
+    passes no ``data`` of its own. Exposes its command-map key as a plain
+    literal (MOR-2003 Step 3, §3.1) for `commands/bound.py:
+    BoundCommands.expect`.
     """
     if cmd_map is not None:
         return _build_from_map(cmd_map, "ptt_off", to_addr=to_addr, from_addr=from_addr)

--- a/src/rigplane/commands/speech.py
+++ b/src/rigplane/commands/speech.py
@@ -9,12 +9,29 @@ from ._frame import (
     _CMD_SPEECH,
     _build_from_map,
     build_civ_frame,
+    expose_command_key,
 )
 
 if TYPE_CHECKING:
     from ..command_map import CommandMap
 
 
+def _speech_key(cmd_map: CommandMap) -> str:
+    """The command-map key `get_speech` resolves for *cmd_map*.
+
+    A profile may expose ``set_speech`` (wfview Set-only) instead of
+    ``get_speech``; this is the one probe among the exposed builders in
+    MOR-2003 Step 3 whose key is a function of the map rather than a fixed
+    literal (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §3.1,
+    "the fourth case"). Shared between `get_speech`'s own body and its
+    `@expose_command_key` decoration so the two cannot drift apart --
+    `tests/test_profile_command_binding.py`'s drift test pins that they
+    agree regardless.
+    """
+    return "set_speech" if cmd_map.has("set_speech") else "get_speech"
+
+
+@expose_command_key(_speech_key)
 def get_speech(
     what: int = 0,
     *,
@@ -32,10 +49,9 @@ def get_speech(
               2 = mode.
     """
     if cmd_map is not None:
-        speech_key = "set_speech" if cmd_map.has("set_speech") else "get_speech"
         return _build_from_map(
             cmd_map,
-            speech_key,
+            _speech_key(cmd_map),
             to_addr=to_addr,
             from_addr=from_addr,
             data=bytes([what]),

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Never, NotRequired, Required, TypedDict
 
+from rigplane.commands.command_map import CommandMap
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.tx_interlock_contract import (
     TxInterlockCommandFamily,
@@ -306,6 +307,18 @@ class RadioProfile:
     modes: tuple[str, ...] = ()
     filters: tuple[str, ...] = ()
     command_names: frozenset[str] = frozenset()
+    # The radio's CI-V wire bytes by command name (MOR-2003 Step 3). ``None``
+    # means this is a hand-built ``RadioProfile`` constructed outside
+    # ``profiles/rig_loader.py`` -- e.g. directly in a test -- with no map
+    # supplied at all. An empty, non-``None`` ``CommandMap`` means the
+    # opposite: a profile that *was* loaded and declares no CI-V commands
+    # (a CAT-only rig, whose TOML entries are all
+    # ``CatCommandSpec`` and get dropped by
+    # ``RigConfig.to_command_map`` -- a known, recorded asymmetry, plan
+    # §8.1 Q8, not resolved here). `runtime/radio.py: CoreRadio.__init__`
+    # treats both the same way: it binds an empty `CommandMap` rather than
+    # raising.
+    command_map: CommandMap | None = None
     filter_width_min: int = 50
     filter_width_max: int = 9999
     filter_width_encoding: str = "segmented_bcd_index"

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -701,6 +701,7 @@ class RigConfig:
             modes=tuple(self.modes),
             filters=tuple(self.filters),
             command_names=frozenset(self.commands),
+            command_map=self.to_command_map(),
             filter_width_min=self.filter_width_min,
             filter_width_max=self.filter_width_max,
             filter_width_encoding=self.filter_width_encoding,

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -309,6 +309,8 @@ from rigplane.core.tx_authority import (
 )
 from rigplane.core.tx_safety import TxOutcome
 from rigplane.runtime.meter_cal import interpolate_swr
+from rigplane.commands.bound import BoundCommands
+from rigplane.commands.command_map import CommandMap
 from rigplane.profiles import RadioProfile, resolve_radio_profile
 from rigplane.core.radio_state import RadioState
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
@@ -880,6 +882,15 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             model=model,
             radio_addr=radio_addr,
         )
+        # Bound once, at construction (MOR-2003 Step 3,
+        # docs/plans/2026-08-29-profile-driven-command-bytes.md §3.1/§4). A
+        # hand-built profile with no ``command_map`` (e.g. a test fixture
+        # constructed outside ``profiles/rig_loader.py``) and a loaded
+        # profile that declares no CI-V commands both bind an empty
+        # ``CommandMap`` here rather than raising -- construction must
+        # never fail on this. No call site reads ``self._commands`` yet;
+        # that migration is Steps 5..N of the same plan.
+        self._commands = BoundCommands(self._profile.command_map or CommandMap({}))
         # Apply per-profile codec preference override (#797) — only if caller
         # accepted the global default. An explicit non-default value always wins.
         # Limitation kept for compatibility with the historical constructor:

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -1,0 +1,272 @@
+"""Tests for MOR-2003 Step 3 of
+``docs/plans/2026-08-29-profile-driven-command-bytes.md``: binding a
+radio's ``CommandMap`` once, at construction, into
+``commands.bound.BoundCommands``.
+
+Four things are pinned here:
+
+- every CI-V profile the library loads out of ``rigs/`` carries its
+  ``CommandMap`` through ``RigConfig.to_profile`` -> ``RadioProfile`` ->
+  ``CoreRadio.__init__`` -> ``BoundCommands`` unchanged (§4 Step 3's own
+  "red if broken" test);
+- ``BoundCommands.__getattr__`` resolves a builder from
+  ``rigplane.commands``'s public namespace with the map already applied,
+  and refuses a name that is not such a builder;
+- ``BoundCommands.expect`` decodes the same map entry, via the same
+  decoder, that the builder itself would use -- for an exposed builder --
+  and refuses with a named-migration message for one that is not exposed
+  yet;
+- the drift guard the owner ruling on MOR-2003 requires: for every builder
+  that exposes a command-map key (``@expose_command_key`` in
+  ``commands/_frame.py``), the exposed callable resolves to exactly the
+  key the builder's own body passes to ``_build_from_map``. This is
+  checked dynamically -- by capturing what each builder actually passes --
+  rather than by re-stating the literal, so the two cannot silently drift
+  apart.
+
+Constructing a full ``CoreRadio`` per profile (rather than binding
+directly off the ``RadioProfile.command_map`` field) was the more thorough
+option and was cheap to run here (six profiles, all in-memory, no I/O) --
+it also doubles as coverage that construction never raises for a real
+profile's map, plain or empty.
+"""
+
+from __future__ import annotations
+
+import functools
+import pathlib
+import sys
+from typing import Any
+
+import pytest
+
+import rigplane.commands as commands
+from rigplane.commands import get_rf_power, get_speech, ptt_on
+from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands.bound import BoundCommands
+from rigplane.commands.command_map import CommandMap
+from rigplane.profiles.rig_loader import discover_rigs
+from rigplane.runtime.radio import CoreRadio
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+RIGS_DIR = REPO_ROOT / "rigs"
+
+
+@functools.lru_cache(maxsize=1)
+def _civ_rig_configs() -> dict[str, Any]:
+    """CI-V rig configs out of ``rigs/`` -- CAT-only profiles excluded.
+
+    A CAT-only profile (FTX-1, TX-500: ``protocol_type`` other than
+    ``"civ"``) has an intentionally empty ``CommandMap`` --
+    ``RigConfig.to_command_map`` drops every ``CatCommandSpec`` entry
+    (plan §7, "FTX-1 and TX-500 are not stranded"). Excluding them here
+    keeps this test's "non-empty" assertion meaningful for the profiles it
+    actually covers.
+    """
+    return {
+        model: config
+        for model, config in discover_rigs(RIGS_DIR).items()
+        if config.protocol_type == "civ"
+    }
+
+
+class TestProfileCarriesCommandMap:
+    """Step 3's own red-if-broken test (plan §4)."""
+
+    @pytest.mark.parametrize("model", sorted(_civ_rig_configs()))
+    def test_bound_command_set_matches_to_command_map(self, model: str) -> None:
+        config = _civ_rig_configs()[model]
+        expected = set(config.to_command_map())
+        assert expected, f"{model}: to_command_map() produced no CI-V commands"
+
+        profile = config.to_profile()
+        assert profile.command_map is not None
+        assert set(profile.command_map) == expected
+
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        assert set(radio._commands._map) == expected
+
+
+class TestCommandMapEquality:
+    """``CommandMap`` is documented as an immutable mapping; make that true for ``==``.
+
+    Motivated directly by this step: ``RadioProfile`` now carries a
+    ``CommandMap`` field, and
+    ``tests/test_ftx1_control_domains.py:
+    test_ftx1_scalar_domains_are_exact_loader_published_capabilities``
+    sweeps every ``RadioProfile`` field for equality between two profiles
+    independently loaded from the same TOML -- which needs two
+    ``CommandMap`` instances with the same contents to compare equal, not
+    only to hold the same names. Before this, ``CommandMap`` had no
+    ``__eq__``, so two instances built from identical dicts compared
+    unequal (identity), and that sweep failed on the new field.
+    """
+
+    def test_equal_contents_compare_equal(self) -> None:
+        assert CommandMap({"ptt_on": (0x1C, 0x00)}) == CommandMap(
+            {"ptt_on": (0x1C, 0x00)}
+        )
+
+    def test_different_contents_compare_unequal(self) -> None:
+        assert CommandMap({"ptt_on": (0x1C, 0x00)}) != CommandMap(
+            {"ptt_on": (0x1C, 0x01)}
+        )
+
+    def test_not_equal_to_a_non_command_map(self) -> None:
+        assert CommandMap({}) != {}
+        assert CommandMap({}) != object()
+
+    def test_hashable_and_consistent_with_equality(self) -> None:
+        a = CommandMap({"ptt_on": (0x1C, 0x00)})
+        b = CommandMap({"ptt_on": (0x1C, 0x00)})
+        assert hash(a) == hash(b)
+
+
+class TestBoundCommandsGetattr:
+    def test_returns_builder_with_map_applied(self) -> None:
+        cmd_map = CommandMap({"ptt_on": (0x1C, 0x00, 0x01)})
+        bound = BoundCommands(cmd_map)
+        assert bound.ptt_on(to_addr=0x94) == ptt_on(to_addr=0x94, cmd_map=cmd_map)
+
+    def test_unknown_name_raises_attribute_error(self) -> None:
+        bound = BoundCommands(CommandMap({}))
+        with pytest.raises(AttributeError):
+            bound.not_a_real_builder_name  # noqa: B018
+
+    def test_non_builder_name_raises_attribute_error(self) -> None:
+        # Exported from rigplane.commands, but not a cmd_map-taking builder.
+        bound = BoundCommands(CommandMap({}))
+        with pytest.raises(AttributeError):
+            bound.CONTROLLER_ADDR  # noqa: B018
+
+    def test_leading_underscore_name_raises_attribute_error(self) -> None:
+        bound = BoundCommands(CommandMap({}))
+        with pytest.raises(AttributeError):
+            bound._build_from_map  # noqa: B018
+
+
+class TestExpect:
+    def test_expect_on_exposed_builder_matches_decoder(self) -> None:
+        wire = (0x1C, 0x00, 0x01)
+        bound = BoundCommands(CommandMap({"ptt_on": wire}))
+        assert bound.expect(ptt_on) == decode_wire_tuple(wire)
+
+    def test_expect_on_speech_resolves_per_map_probe(self) -> None:
+        """The fourth case in plan §3.1: get_speech's key is a function of the map."""
+        with_set = CommandMap({"set_speech": (0x13,)})
+        assert BoundCommands(with_set).expect(get_speech) == decode_wire_tuple((0x13,))
+
+        with_get = CommandMap({"get_speech": (0x13, 0x01)})
+        assert BoundCommands(with_get).expect(get_speech) == decode_wire_tuple(
+            (0x13, 0x01)
+        )
+
+    def test_expect_on_unexposed_builder_names_the_migration(self) -> None:
+        bound = BoundCommands(CommandMap({"get_rf_power": (0x14, 0x0A)}))
+        with pytest.raises(AttributeError, match="Steps 5..N"):
+            bound.expect(get_rf_power)
+
+
+# ── the drift guard ──
+
+_PROBE_MAPS = (
+    CommandMap({}),
+    CommandMap({"set_speech": (0x13,)}),
+)
+
+
+def _exposed_builders() -> list[tuple[str, Any]]:
+    """Every builder in ``rigplane.commands``'s public namespace exposing a key.
+
+    Deduplicated by identity so a backward-compat alias (``speech =
+    get_speech``) is not exercised twice under two names.
+
+    Not gated on ``inspect.isfunction``: several other test files
+    (``tests/_command_test_helpers.py: bind_default_addr_module``) rebind
+    every builder on the shared ``rigplane.commands`` package namespace
+    into a ``functools.partial`` with a default ``to_addr`` bound, for the
+    rest of that test worker's session, once collected -- so by the time a
+    plain (non-parametrized) test function in this module calls this
+    helper, ``getattr(commands, name)`` may already return such a partial
+    rather than the raw function. ``functools.update_wrapper`` (used by
+    that helper) copies the wrapped function's ``__dict__`` onto the
+    partial, so ``cmd_map_key`` and ``__wrapped__`` both survive; checking
+    ``callable`` instead of ``inspect.isfunction``, and deduplicating via
+    ``__wrapped__`` where present, tolerates it the same way
+    `commands/bound.py: _takes_cmd_map` does.
+    """
+    seen: set[int] = set()
+    found: list[tuple[str, Any]] = []
+    for name in commands.__all__:
+        value = getattr(commands, name, None)
+        if not callable(value):
+            continue
+        if getattr(value, "cmd_map_key", None) is None:
+            continue
+        identity = id(getattr(value, "__wrapped__", value))
+        if identity in seen:
+            continue
+        seen.add(identity)
+        found.append((name, value))
+    return found
+
+
+class TestExposedKeyDriftGuard:
+    """The owner ruling's drift test: exposed callable == body's actual key.
+
+    For each exposed builder and each probe map, the builder is called
+    with ``_build_from_map`` monkeypatched to capture the ``name`` it was
+    given, then that capture is compared against calling the builder's own
+    ``cmd_map_key(cmd_map)``. Two probe maps exercise both branches of
+    ``get_speech``'s per-map probe; the other exposed builders (ptt_on,
+    ptt_off) ignore the map and must produce the same literal for both.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd_map", _PROBE_MAPS, ids=["empty_map", "set_speech_map"]
+    )
+    @pytest.mark.parametrize(
+        "case", _exposed_builders(), ids=[c[0] for c in _exposed_builders()]
+    )
+    def test_exposed_key_matches_build_from_map_argument(
+        self,
+        case: tuple[str, Any],
+        cmd_map: CommandMap,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _name, builder = case
+        captured: dict[str, str] = {}
+
+        def _fake_build_from_map(
+            _cmd_map: CommandMap, key: str, *args: Any, **kwargs: Any
+        ) -> bytes:
+            captured["key"] = key
+            return b""
+
+        # Patch the defining module object directly rather than through
+        # monkeypatch's dotted-string resolution: a backward-compat alias
+        # such as ``speech.py``'s ``speech = get_speech`` rebinds the
+        # package-level attribute ``rigplane.commands.speech`` to the
+        # function itself, shadowing the submodule of the same name that
+        # dotted-string lookup would otherwise walk through.
+        defining_module = sys.modules[builder.__module__]
+        monkeypatch.setattr(defining_module, "_build_from_map", _fake_build_from_map)
+        builder(to_addr=0x94, cmd_map=cmd_map)
+        assert "key" in captured, (
+            f"{builder.__qualname__} did not call _build_from_map with cmd_map set"
+        )
+        assert captured["key"] == builder.cmd_map_key(cmd_map)
+
+
+def test_ptt_off_is_also_covered_directly() -> None:
+    """Sanity check the dynamic enumeration actually found both ptt builders.
+
+    Checked by name, not object identity: by the time this runs, another
+    test file collected in the same session may already have rebound
+    ``rigplane.commands.ptt_off`` into a ``functools.partial`` (see
+    ``_exposed_builders``'s docstring), so comparing against the raw
+    ``ptt_off`` imported at the top of this module would be fragile to
+    collection order rather than testing anything real.
+    """
+    names = {name for name, _ in _exposed_builders()}
+    assert {"get_speech", "ptt_on", "ptt_off"} <= names

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -178,22 +178,49 @@ _PROBE_MAPS = (
 def _exposed_builders() -> list[tuple[str, Any]]:
     """Every builder in ``rigplane.commands``'s public namespace exposing a key.
 
-    Deduplicated by identity so a backward-compat alias (``speech =
-    get_speech``) is not exercised twice under two names.
+    Deduplicated by the identity of the attached ``cmd_map_key`` callable --
+    not by ``id(value)`` or a single ``__wrapped__`` hop, and not by
+    ``__qualname__`` -- so a backward-compat alias (``speech = get_speech``)
+    is not exercised twice under two names, and stays that way regardless of
+    how many times the shared ``rigplane.commands`` package namespace has
+    already been rebound by the time this file is collected.
 
-    Not gated on ``inspect.isfunction``: several other test files
-    (``tests/_command_test_helpers.py: bind_default_addr_module``) rebind
-    every builder on the shared ``rigplane.commands`` package namespace
-    into a ``functools.partial`` with a default ``to_addr`` bound, for the
-    rest of that test worker's session, once collected -- so by the time a
-    plain (non-parametrized) test function in this module calls this
-    helper, ``getattr(commands, name)`` may already return such a partial
-    rather than the raw function. ``functools.update_wrapper`` (used by
-    that helper) copies the wrapped function's ``__dict__`` onto the
-    partial, so ``cmd_map_key`` and ``__wrapped__`` both survive; checking
-    ``callable`` instead of ``inspect.isfunction``, and deduplicating via
-    ``__wrapped__`` where present, tolerates it the same way
-    `commands/bound.py: _takes_cmd_map` does.
+    Not gated on ``inspect.isfunction``: five other test files
+    (``tests/_command_test_helpers.py: bind_default_addr_module``, called
+    from ``test_commands.py``, ``test_commands_extended.py``,
+    ``test_main_sub_tracking.py``, ``test_rf_gain_af_level.py`` and
+    ``test_scope.py``) each rebind every builder on the shared
+    ``rigplane.commands`` package namespace into a fresh
+    ``functools.partial`` with a default ``to_addr`` bound, at their own
+    collection time -- and each rebind wraps whatever is *currently* bound
+    to a name, not the original function, so when more than one of those
+    files is collected before this one the same underlying builder ends up
+    wrapped through two or more independent layers (measured: 24 items
+    standalone, 26 in the full suite, before this fix).
+
+    A single ``__wrapped__`` hop only reaches the immediately-inner layer.
+    Two names that alias the same function (``speech`` and ``get_speech``)
+    are wrapped *separately* at every layer -- each rebind iterates
+    ``dir(module)`` and wraps each qualifying name on its own -- so at two
+    or more layers ``speech.__wrapped__`` and ``get_speech.__wrapped__`` are
+    two different partial objects (each wrapping the *previous* layer's own
+    partial for that name), and comparing their identity no longer
+    collapses the alias. ``__qualname__`` would collapse it correctly here
+    (it is copied by value at every layer and is intrinsic to the
+    underlying function, not the name it is reached through), but two
+    *different* builders in two different modules could coincidence-collide
+    on a bare function name as Steps 5..N add more exposed builders here,
+    which ``__qualname__`` alone cannot tell apart.
+
+    ``cmd_map_key`` has neither problem: ``commands/_frame.py:
+    expose_command_key`` attaches it once, directly, to the underlying
+    function's own ``__dict__``, and ``functools.update_wrapper``'s
+    ``__dict__.update()`` step re-copies that exact object -- never a copy
+    of a copy, the same object every time -- onto each new wrapper,
+    however many layers stack, and it is unique per builder (an alias
+    shares the object because it shares the underlying function; two
+    distinct builders never do, even if their keys happen to return the
+    same literal).
     """
     seen: set[int] = set()
     found: list[tuple[str, Any]] = []
@@ -201,9 +228,10 @@ def _exposed_builders() -> list[tuple[str, Any]]:
         value = getattr(commands, name, None)
         if not callable(value):
             continue
-        if getattr(value, "cmd_map_key", None) is None:
+        key_fn = getattr(value, "cmd_map_key", None)
+        if key_fn is None:
             continue
-        identity = id(getattr(value, "__wrapped__", value))
+        identity = id(key_fn)
         if identity in seen:
             continue
         seen.add(identity)


### PR DESCRIPTION
## What landed

Step 3 of `docs/plans/2026-08-29-profile-driven-command-bytes.md` (§3.1
Candidate A, §4). The map binder is built and made reachable; **not one
production call site moves onto it** — that is Steps 5..N.

- **`src/rigplane/commands/bound.py` (new)** — `BoundCommands`, constructed
  once per radio from a `CommandMap`.
  - `__getattr__(name)` resolves the named builder from `rigplane.commands`'s
    public namespace and returns it with `cmd_map=` already bound
    (`functools.partial`). Unknown/non-builder names raise `AttributeError`.
  - `expect(builder)` returns the `(command, sub, prefix)` reply shape,
    derived from the *same* map entry via the *same* decoder the builder
    itself uses through `_build_from_map` — so request and reply can't drift
    apart (plan §3.1, "why `expect` takes the builder and not a name").
  - Imports only `commands` internals + stdlib; the `rigplane.commands`
    import inside `__getattr__` is deferred to call time to avoid a
    module-import-time cycle (`bound.py` lives inside the `commands`
    package).
- **`src/rigplane/commands/_frame.py`** — extracted the one wire-tuple
  decoder (`decode_wire_tuple`) used by both `_build_from_map` and
  `BoundCommands.expect`; added the `expose_command_key` decorator that
  attaches a builder's `Callable[[CommandMap], str]` key.
- **Owner ruling on MOR-2003 (§3.1 design fork):** every exposed key is
  `Callable[[CommandMap], str]`, uniformly — `speech.py: get_speech` is
  **not split**; its existing probe
  (`"set_speech" if cmd_map.has("set_speech") else "get_speech"`) now lives
  inside the exposed callable, factored into a shared `_speech_key` helper so
  the body and the exposure can't drift.
- **Phasing (coordinator decision, recorded here):** exposure applied in
  this PR only to the forcing case (`speech.py: get_speech`) and one small
  already-cleaned module (`ptt.py: ptt_on`/`ptt_off`). Sweeping all ~15
  command modules now would blow the file/LOC ceiling for zero behavior
  gain — that's Steps 5..N, one module at a time. The drift test
  (`tests/test_profile_command_binding.py::TestExposedKeyDriftGuard`)
  dynamically checks every *currently exposed* builder (by capturing what
  its body actually passes to `_build_from_map`, not by re-stating the
  literal), and `expect()` on a builder without an exposure raises a message
  naming Steps 5..N as where it gets one
  (`tests/test_profile_command_binding.py::TestExpect::test_expect_on_unexposed_builder_names_the_migration`
  pins that message).
- **`src/rigplane/profiles/__init__.py` + `rig_loader.py`** — `RadioProfile`
  gains a `command_map: CommandMap | None = None` field (defaulted — the one
  test that constructs `RadioProfile` directly outside `profiles/`,
  `tests/test_radio_connect.py: _lan_profile_without_codec_preference`,
  passes none of the defaulted fields). `RigConfig.to_profile` populates it
  via `self.to_command_map()`, beside `command_names`.
- **`src/rigplane/runtime/radio.py: CoreRadio.__init__`** — constructs
  `self._commands = BoundCommands(self._profile.command_map or
  CommandMap({}))` immediately after resolving the profile. Tolerates
  `None` (hand-built profile) or an empty map (CAT-only profile) — nothing
  may raise at construction; verified against all bare
  `CoreRadio("127.0.0.1")` / `IcomRadio(host="")` test sites in the targeted
  run below.

## No call site changed — evidence

```
$ git diff origin/main -- src/rigplane/runtime/ src/rigplane/web/ src/rigplane/rigctld/
```
Touches exactly one file (`runtime/radio.py`) — 11 added lines, re-measured:
two new import lines, an 8-line comment explaining the construction, and
the one `self._commands = BoundCommands(...)` construction line in
`CoreRadio.__init__`. No other line in `runtime/`, `web/`, or `rigctld/`
changed (`git diff origin/main -- src/rigplane/runtime/ src/rigplane/web/
src/rigplane/rigctld/ | grep -c '^+'` reports 12, which includes the
`+++ b/...` diff header).

## Collateral fix (found while testing, not speculative)

`CommandMap` gained `__eq__`/`__hash__` (compare/hash by contents), matching
its own "Immutable mapping" docstring claim. Without it,
`tests/test_ftx1_control_domains.py`'s pre-existing field-by-field
`RadioProfile` equality sweep broke the moment `command_map` became a real
field: two `CommandMap` instances built from the identical TOML compared
unequal by identity. TDD: red before, green after
(`tests/test_profile_command_binding.py::TestCommandMapEquality`), no other
test in the repo relies on `CommandMap`'s old identity-based (in)equality
(swept via grep).

## One-unit-of-work (9 files, over the 6-file soft threshold)

573 lines (553 insertions + 20 deletions) are the binder + exposure +
profile wiring + its own test file (8 files, re-measured per-file via
`git diff --numstat origin/main..HEAD`); the 9th file and its +17 lines are
the `CommandMap` equality fix, a direct, necessary consequence of file #7
(`profiles/__init__.py`) in the same commit — splitting it into a second PR
would just move a known-red test across a PR boundary. Well under the
1000-line / 10-file hard ceiling (9 files, 590 changed lines — 570
insertions + 20 deletions — measured at this head via `git diff --stat
origin/main..HEAD`; 573 + 17 = 590).

## Testing

Targeted, not full-suite (per dispatch): `tests/test_profile_command_binding.py`
(new — includes the drift guard, `BoundCommands.__getattr__`/`expect` unit
tests, the per-profile binding sweep, and the `CommandMap` equality tests),
`tests/test_commands.py`, `tests/test_rig_ic7300.py`,
`tests/test_command_map_parity.py`, `tests/test_command_map_integration.py`,
`tests/test_radio_connect.py`, `tests/test_managed_radio_runtime.py`,
`tests/test_ftx1_control_domains.py` (the collateral fix's own test) — **610
passed, 0 failed**.

`uv run ruff check src/ tests/` — clean. `uv run ruff format --check src/
tests/` — clean. `uv run lint-imports` — 5 contracts kept, 0 broken. `uv run
mypy --strict src/rigplane/web` — clean (untouched by this change; ran
anyway).

## Design notes / judgment calls

- Constructed a full `CoreRadio` per CI-V profile in the binding-sweep test
  rather than binding directly off `RadioProfile.command_map` — cheap (6
  profiles, in-memory, no I/O) and doubles as proof construction never
  raises for a real profile's map.
- `BoundCommands.__getattr__`/the drift-guard test helper check `callable(...)
  ` + a `cmd_map` parameter in the signature rather than `inspect.isfunction`.
  Reason, found during testing: `tests/_command_test_helpers.py:
  bind_default_addr_module` — re-measured; exactly **five** callers
  (`test_commands.py`, `test_commands_extended.py`,
  `test_main_sub_tracking.py`, `test_rf_gain_af_level.py`,
  `test_scope.py`) — rebinds every builder on the shared
  `rigplane.commands` package namespace into a `functools.partial`
  (default `to_addr` bound) for the rest of a test worker's session, once
  collected. Of this PR's targeted test list, only `test_commands.py` is
  among those five; `test_command_map_integration.py` calls the sibling
  helper `bind_default_addr_globals` instead, which only rebinds names in
  that file's own `globals()`, not the shared package namespace, so it does
  not contribute to this hazard. That's an established, deliberate pattern
  (see `tests/test_command_fallback_audit.py`'s own docstring discussing
  it), and it would otherwise nondeterministically break
  `BoundCommands.__getattr__` depending on pytest collection order / xdist
  worker assignment. Not a production concern — nothing outside tests calls
  that helper.

## Update: fixed a BLOCKED review finding (dedup stability)

Independent review found `_exposed_builders`'s dedup (originally
`id(getattr(value, "__wrapped__", value))`, a single-hop unwrap) collapses
the `speech`/`get_speech` alias correctly at one layer of
`bind_default_addr_module` wrapping, but not at two or more: each of the
five callers above wraps whatever is *currently* bound to a name, so two
callers running before this file in the same worker session leave `speech`
and `get_speech` wrapped through two independent partial chains —
`speech.__wrapped__` and `get_speech.__wrapped__` are then two different
objects, and the alias gets counted twice. Measured: 24 items standalone,
26 collected after two-plus wrapping files (matches the reviewer's report
exactly).

Fixed by deduplicating on `id(value.cmd_map_key)` instead: `commands/_frame.py:
expose_command_key` attaches that callable once, directly, to the
underlying function's own `__dict__`, and `functools.update_wrapper`'s
`__dict__.update()` step re-copies the *same* object forward at every
layer, however many stack — so it never drifts, at any depth. (The
reviewer also offered `__qualname__`; not used, because it would silently
merge two *different* exposed builders in two different modules that
happen to share a bare function name, which `cmd_map_key` identity cannot,
since two distinct builders never share the same key-callable object.)

Verified both directions on this exact scenario
(`tests/test_command_fallback_audit.py tests/test_command_map_integration.py
tests/test_commands_extended.py tests/test_main_sub_tracking.py
tests/test_rf_gain_af_level.py tests/test_scope.py tests/test_commands.py
tests/test_profile_command_binding.py`, collected in that order): the old
dedup reproduces 26 items for `test_profile_command_binding.py` in this
combined run against 24 standalone; the new dedup reports 24 in both.
Commit `test(MOR-2003): make the drift-guard dedup stable under stacked
test wrappers`.

## Owner ruling quoted (for the record)

> The exposed command-map key is a callable over the map, for every
> builder — `get_speech` is NOT split. Every builder exposes its key as
> `Callable[[CommandMap], str]`; for the plain cases the callable ignores
> its argument and returns the literal; `commands/speech.py: get_speech`
> keeps its probe (`"set_speech" if cmd_map.has("set_speech") else
> "get_speech"`) inside the callable. A single drift test asserts every
> builder's exposed callable resolves to exactly the key its body passes to
> `_build_from_map`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


