### PR TITLE
feat(MOR-2005): add the declared-absent command spelling (step 4a)

### DIFF
--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -115,6 +115,34 @@ pins this: it builds `ptt_on`/`ptt_off` against every such profile's map
 and its hardcoded fallback and requires the two frames identical, ending
 in the explicit payload byte.
 
+**Declared-absent (MOR-2005 step 4a, D1/D2 —
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1):**
+
+```toml
+[commands]
+get_dual_watch = { absent = "IC-7300 Full Manual (A7292-4EX), no dual-watch item" }
+```
+
+This spelling records that a named authority — a manual, a wfview rig
+definition, a live-hardware capture — confirms the radio does not have the
+command, and, per D2, records that source in the TOML itself so "verified
+on hardware" and "taken from a manual" stay distinguishable by reading the
+file. It parses to `commands/command_spec.py: AbsentCommandSpec`; the
+`absent` value is the only key allowed in the dict and must be a non-empty
+string.
+
+An entry using this spelling is excluded from `RadioProfile.command_names`
+and from the `CommandMap` `to_command_map` builds, and is recorded instead
+in `RadioProfile.absent_command_names`
+(`tests/test_rig_loader.py: TestAbsentCommandSemantics`,
+`tests/test_command_spec.py: TestAbsentCommandSpec`). This makes "declared
+absent" representable and distinguishable from "neither declared nor
+declared absent" — D1's states (2) and (3). The refusal policy that acts
+on that distinction is a later step (plan §4 Step 4): as of this schema
+addition, `RadioProfile.supports_command` returns `False` for both states
+alike, and no shipped `rigs/*.toml` uses this spelling yet
+(`tests/test_rig_loader.py: TestNoShippedProfileUsesAbsentSpellingYet`).
+
 ---
 
 ## Layer 1: Capabilities

--- a/src/rigplane/commands/command_spec.py
+++ b/src/rigplane/commands/command_spec.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 __all__ = [
     "CivCommandSpec",
     "CatCommandSpec",
+    "AbsentCommandSpec",
     "CommandSpec",
 ]
 
@@ -54,5 +55,41 @@ class CatCommandSpec:
             raise ValueError("CatCommandSpec must have at least one of read/write")
 
 
-# Union type for command specs (CI-V or CAT)
-CommandSpec = CivCommandSpec | CatCommandSpec
+@dataclass(frozen=True, slots=True)
+class AbsentCommandSpec:
+    """Declares that a radio does not have a given command (MOR-2005 step 4a).
+
+    Plan `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1 D1/D2:
+    D1 needs a way to distinguish "this radio does not have the command,
+    confirmed" from "nobody has looked yet"; D2 requires every filled TOML
+    entry to record where its value came from. This spec is both at once —
+    an entry with a source and no bytes.
+
+    Example TOML:
+        get_dual_watch = { absent = "IC-7300 Full Manual (A7292-4EX), no dual-watch item" }
+
+    ``profiles/rig_loader.py: RigConfig.to_profile`` excludes names bound to
+    this spec from ``RadioProfile.command_names`` and records them in
+    ``RadioProfile.absent_command_names`` instead; ``RigConfig.to_command_map``
+    excludes them from the ``CommandMap`` the same way it already excludes
+    ``CatCommandSpec`` entries.
+
+    This spec only makes the state representable. The refusal policy that
+    reads ``absent_command_names`` to distinguish "declared absent" from
+    "declared nowhere" is a later step (plan §4 Step 4, D1 states 2/3) and
+    is not implemented by this dataclass.
+    """
+
+    source: str
+    """The named authority this absence is confirmed against (a manual,
+    a wfview rig definition, a live-hardware capture, ...) — never empty;
+    see D2."""
+
+    def __post_init__(self) -> None:
+        """Validate the D2-required source is present."""
+        if not self.source.strip():
+            raise ValueError("AbsentCommandSpec.source must be a non-empty string")
+
+
+# Union type for command specs (CI-V, CAT, or declared-absent)
+CommandSpec = CivCommandSpec | CatCommandSpec | AbsentCommandSpec

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -307,6 +307,16 @@ class RadioProfile:
     modes: tuple[str, ...] = ()
     filters: tuple[str, ...] = ()
     command_names: frozenset[str] = frozenset()
+    # Command names this radio is confirmed NOT to have, per a named source
+    # recorded in the TOML entry itself (MOR-2005 step 4a: the
+    # `{ absent = "<source>" }` spelling in `[commands]`, parsed into
+    # `commands/command_spec.py: AbsentCommandSpec`). Disjoint from
+    # ``command_names`` by construction (`profiles/rig_loader.py:
+    # RigConfig.to_profile` partitions ``self.commands`` between the two).
+    # A name in neither set is the third, still-unrepresented-by-a-refusal-
+    # policy state: "nobody has looked" — see ``supports_command``'s
+    # docstring for what does and does not yet distinguish it from this set.
+    absent_command_names: frozenset[str] = frozenset()
     # The radio's CI-V wire bytes by command name (MOR-2003 Step 3). ``None``
     # means this is a hand-built ``RadioProfile`` constructed outside
     # ``profiles/rig_loader.py`` -- e.g. directly in a test -- with no map
@@ -430,6 +440,20 @@ class RadioProfile:
         ) in self.cmd29_routes
 
     def supports_command(self, command_name: str) -> bool:
+        """Whether ``command_name`` is declared (with bytes or a CAT
+        template) by this profile.
+
+        Plan `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1
+        D1 names three states for a command name: (1) declared — this
+        returns True; (2) declared absent, via ``absent_command_names``;
+        (3) neither declared nor declared absent. States (2) and (3) are
+        each other's negative space here — this method returns False for
+        both and does not distinguish them; a caller that needs to tell
+        them apart checks ``absent_command_names`` directly. The refusal
+        policy that acts on that distinction (D1's "report unsupported"
+        for (2), "must not exist at release" for (3)) is plan §4 Step 4,
+        a later change — not implemented by this method.
+        """
         return command_name in self.command_names
 
     def resolve_filter_rule(

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -738,7 +738,17 @@ class RigConfig:
             rf_sql_control_model=self.rf_sql_control_model,
             data_mode_count=self.data_mode_count,
             data_mode_labels=self.data_mode_labels,
-            set_mode_via_selected="set_selected_mode" in self.commands,
+            # isinstance, not membership: a declared-absent entry
+            # (AbsentCommandSpec, MOR-2005 step 4a) is a dict key too, but
+            # it means the opposite of "the radio has this command" — see
+            # `tests/test_rig_loader.py:
+            # TestSetModeViaSelectedDiscriminatesAbsent`. CivCommandSpec
+            # specifically (not CatCommandSpec) because this flag gates a
+            # CI-V-only wire path (`runtime/_dual_rx_runtime.py:
+            # DualRxRuntimeMixin._set_mode_main`'s CI-V 0x26 0x00 branch).
+            set_mode_via_selected=isinstance(
+                self.commands.get("set_selected_mode"), CivCommandSpec
+            ),
             protocol_type=self.protocol_type,
             hamlib_model_id=self.hamlib_model_id,
             controls=controls,

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -39,7 +39,12 @@ __all__ = [
     "discover_rigs",
     "discover_available_rigs",
 ]
-from rigplane.commands.command_spec import CatCommandSpec, CivCommandSpec, CommandSpec
+from rigplane.commands.command_spec import (
+    AbsentCommandSpec,
+    CatCommandSpec,
+    CivCommandSpec,
+    CommandSpec,
+)
 from rigplane.profiles import (
     BandInfo,
     ControlDomainSpec,
@@ -700,7 +705,16 @@ class RigConfig:
             freq_ranges=ranges,
             modes=tuple(self.modes),
             filters=tuple(self.filters),
-            command_names=frozenset(self.commands),
+            command_names=frozenset(
+                name
+                for name, spec in self.commands.items()
+                if not isinstance(spec, AbsentCommandSpec)
+            ),
+            absent_command_names=frozenset(
+                name
+                for name, spec in self.commands.items()
+                if isinstance(spec, AbsentCommandSpec)
+            ),
             command_map=self.to_command_map(),
             filter_width_min=self.filter_width_min,
             filter_width_max=self.filter_width_max,
@@ -753,7 +767,10 @@ class RigConfig:
     def to_command_map(self) -> CommandMap:
         """Build a ``CommandMap`` from this config's CI-V commands.
 
-        Only CivCommandSpec entries are included; CatCommandSpec entries are ignored.
+        Only CivCommandSpec entries are included; CatCommandSpec and
+        AbsentCommandSpec entries are excluded (pinned by
+        `tests/test_rig_loader.py: TestAbsentCommandSemantics
+        .test_absent_name_excluded_from_command_map`).
         """
         civ_commands: dict[str, tuple[int, ...]] = {}
         for name, spec in self.commands.items():
@@ -884,7 +901,7 @@ def _parse_command_value(
 ) -> CommandSpec:
     """Parse a single command value from TOML.
 
-    Supports two formats:
+    Supports three formats:
     1. CI-V wire bytes (list): the frame's full constant prefix, per the
        tuple contract ruled in Q7
        (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1) —
@@ -894,6 +911,9 @@ def _parse_command_value(
        [0x1C, 0x00, 0x01] (command + sub + a constant payload byte, the
        X6100 ptt_on shape).
     2. CAT command spec (dict): { cat = { read = "FA;", parse = "FA{freq:09d};" } }
+    3. Declared-absent (dict, MOR-2005 step 4a): { absent = "<source>" } —
+       this radio confirmed does not have the command, per the named
+       authority. See `commands/command_spec.py: AbsentCommandSpec`.
 
     Args:
         filename: Source TOML filename (for error messages).
@@ -901,7 +921,8 @@ def _parse_command_value(
         value: Raw TOML value to parse.
 
     Returns:
-        Parsed CommandSpec (either CivCommandSpec or CatCommandSpec).
+        Parsed CommandSpec (CivCommandSpec, CatCommandSpec, or
+        AbsentCommandSpec).
 
     Raises:
         RigLoadError: If the value format is invalid.
@@ -923,6 +944,23 @@ def _parse_command_value(
                 f"got {value!r}"
             )
         return CivCommandSpec(bytes=tuple(value))
+
+    # Format 3: declared-absent (dict with 'absent' key, MOR-2005 step 4a)
+    if isinstance(value, dict) and "absent" in value:
+        extra_keys = sorted(set(value) - {"absent"})
+        if extra_keys:
+            raise RigLoadError(
+                f"{filename}: [commands].{command_name} = {{ absent = ... }} "
+                f"must not have other keys, got extra: {extra_keys}"
+            )
+        source = value["absent"]
+        if not isinstance(source, str) or not source.strip():
+            raise RigLoadError(
+                f"{filename}: [commands].{command_name}.absent must be a "
+                f"non-empty string naming the authority (a manual, a wfview "
+                f"rig definition, ...), got {source!r}"
+            )
+        return AbsentCommandSpec(source=source)
 
     # Format 2: CAT command spec (dict with 'cat' key)
     if isinstance(value, dict):

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from rigplane.command_spec import CatCommandSpec, CivCommandSpec
+from rigplane.command_spec import AbsentCommandSpec, CatCommandSpec, CivCommandSpec
 from rigplane.rig_loader import RigLoadError, load_rig
 
 
@@ -284,6 +284,71 @@ class TestMixedCommands:
 
         # CAT command is NOT included
         assert not cmd_map.has("get_mode")
+
+
+class TestAbsentCommandSpec:
+    """Tests for the declared-absent command spelling (MOR-2005 step 4a).
+
+    ``{ absent = "<source>" }`` records that a named authority (a manual, a
+    wfview rig definition, ...) confirms this radio does not have the
+    command — a D2-compliant source, not just a gap. Step 4b (a later PR)
+    adds the refusal policy that consumes this; here the shape only needs
+    to parse and round-trip.
+    """
+
+    def test_absent_command_round_trips(self, tmp_path):
+        """The absent spelling loads as AbsentCommandSpec with its source."""
+        toml = (
+            _MINIMAL_CIV_TOML
+            + '\nget_dual_watch = { absent = "IC-7300 Full Manual (A7292-4EX), no dual-watch item" }\n'
+        )
+        p = _write_toml(tmp_path, toml)
+        rig = load_rig(p)
+
+        assert "get_dual_watch" in rig.commands
+        spec = rig.commands["get_dual_watch"]
+        assert isinstance(spec, AbsentCommandSpec)
+        assert spec.source == "IC-7300 Full Manual (A7292-4EX), no dual-watch item"
+
+    def test_absent_source_empty_string_rejected(self, tmp_path):
+        """An empty source defeats D2's provenance requirement."""
+        toml = _MINIMAL_CIV_TOML + '\nget_dual_watch = { absent = "" }\n'
+        p = _write_toml(tmp_path, toml)
+
+        with pytest.raises(RigLoadError, match="non-empty"):
+            load_rig(p)
+
+    def test_absent_and_cat_together_rejected(self, tmp_path):
+        """'absent' and 'cat' are mutually exclusive markers in one entry."""
+        toml = (
+            _MINIMAL_CIV_TOML
+            + '\nget_dual_watch = { absent = "some manual", cat = { read = "DW;" } }\n'
+        )
+        p = _write_toml(tmp_path, toml)
+
+        with pytest.raises(RigLoadError, match="extra"):
+            load_rig(p)
+
+    def test_absent_with_unknown_extra_key_rejected(self, tmp_path):
+        """No other keys are allowed alongside 'absent'."""
+        toml = (
+            _MINIMAL_CIV_TOML
+            + '\nget_dual_watch = { absent = "some manual", note = "x" }\n'
+        )
+        p = _write_toml(tmp_path, toml)
+
+        with pytest.raises(RigLoadError, match="extra"):
+            load_rig(p)
+
+    def test_dict_without_cat_or_absent_key_still_rejected(self, tmp_path):
+        """A dict with neither marker key keeps its original message —
+        this pins that the new 'absent' branch does not swallow the
+        pre-existing 'cat'-key error (unchanged since before MOR-2005)."""
+        toml = _MINIMAL_CIV_TOML + '\nget_invalid = { read = "FA;" }\n'
+        p = _write_toml(tmp_path, toml)
+
+        with pytest.raises(RigLoadError, match="must have 'cat' key"):
+            load_rig(p)
 
 
 class TestBackwardCompatibility:

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from rigplane.command_map import CommandMap
+from rigplane.command_spec import AbsentCommandSpec
 from rigplane.core.capabilities import CAP_SPEECH, KNOWN_CAPABILITIES
 from rigplane.core.tx_interlock_contract import (
     TX_INTERLOCK_COMMAND_FAMILY_METADATA,
@@ -1694,6 +1695,56 @@ class TestToCommandMap:
             assert not cm.has(key), f"dead tone command {key!r} still present"
 
 
+class TestAbsentCommandSemantics:
+    """The declared-absent spelling's effect on ``RadioProfile`` (MOR-2005
+    step 4a, plan `docs/plans/2026-08-29-profile-driven-command-bytes.md`
+    §8.1 D1/D2). This step only makes states (2) declared-absent and (3)
+    unknown *representable* and distinguishable via
+    ``RadioProfile.absent_command_names`` — the refusal policy that acts on
+    that distinction (D1 states 2 vs. 3) is Step 4b, not implemented here.
+    ``supports_command`` returns False for both today, same as before this
+    change.
+    """
+
+    _TOML_WITH_ABSENT = (
+        _MINIMAL_TOML
+        + '\nget_dual_watch = { absent = "IC-7300 Full Manual (A7292-4EX), no dual-watch item" }\n'
+    )
+
+    def test_absent_name_excluded_from_command_names(self, tmp_path):
+        p = _write_toml(tmp_path, self._TOML_WITH_ABSENT)
+        profile = load_rig(p).to_profile()
+        assert "get_dual_watch" not in profile.command_names
+
+    def test_absent_name_present_in_absent_command_names(self, tmp_path):
+        p = _write_toml(tmp_path, self._TOML_WITH_ABSENT)
+        profile = load_rig(p).to_profile()
+        assert "get_dual_watch" in profile.absent_command_names
+
+    def test_supports_command_false_for_absent_name(self, tmp_path):
+        p = _write_toml(tmp_path, self._TOML_WITH_ABSENT)
+        profile = load_rig(p).to_profile()
+        assert profile.supports_command("get_dual_watch") is False
+
+    def test_absent_name_excluded_from_command_map(self, tmp_path):
+        p = _write_toml(tmp_path, self._TOML_WITH_ABSENT)
+        cm = load_rig(p).to_command_map()
+        assert not cm.has("get_dual_watch")
+
+    def test_declared_siblings_unaffected(self, tmp_path):
+        """A declared-absent entry does not push out sibling declared
+        commands from either set."""
+        p = _write_toml(tmp_path, self._TOML_WITH_ABSENT)
+        profile = load_rig(p).to_profile()
+        assert "get_freq" in profile.command_names
+        assert "get_freq" not in profile.absent_command_names
+
+    def test_no_absent_declaration_leaves_absent_command_names_empty(self, tmp_path):
+        p = _write_toml(tmp_path, _MINIMAL_TOML)
+        profile = load_rig(p).to_profile()
+        assert profile.absent_command_names == frozenset()
+
+
 # ── discover_rigs ────────────────────────────────────────────────
 
 
@@ -2570,3 +2621,28 @@ class TestFilterShapeDomainDeclaredOrCapabilityAbsent:
             rig = load_rig(RIGS_DIR / f"{name}.toml")
             assert rig.filter_shape_values == (0, 1), name
             assert rig.filter_shape_labels == {"0": "SHARP", "1": "SOFT"}, name
+
+
+class TestNoShippedProfileUsesAbsentSpellingYet:
+    """MOR-2005 step 4a lands only the ``{ absent = "<source>" }`` spelling
+    itself (plan `docs/plans/2026-08-29-profile-driven-command-bytes.md`
+    §8.1 D1/D2) — it does not fill any profile with it. This is the
+    regression pin for that: today every shipped ``rigs/*.toml`` yields
+    zero ``AbsentCommandSpec`` entries. D2's filling work is separate,
+    ticket-tracked, later work; once a profile starts using the spelling,
+    delete or narrow this test (it is not a promise the spelling stays
+    unused, only a record that it is unused as of this PR).
+    """
+
+    @pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+    def test_no_absent_commands_declared(self, toml_path):
+        rig = load_rig(toml_path)
+        absent = {
+            name
+            for name, spec in rig.commands.items()
+            if isinstance(spec, AbsentCommandSpec)
+        }
+        assert absent == set(), (
+            f"{toml_path.name}: declares absent commands {sorted(absent)} — "
+            f"update/delete this pin now that D2 filling has started"
+        )

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1744,6 +1744,54 @@ class TestAbsentCommandSemantics:
         profile = load_rig(p).to_profile()
         assert profile.absent_command_names == frozenset()
 
+    def test_unknown_name_is_in_neither_set(self, tmp_path):
+        """D1 state (3) — a name the profile never mentions at all, not
+        even as declared-absent — lands in neither set. This is the state
+        this step makes representable but does not yet resolve: it stays
+        indistinguishable from state (2) at ``supports_command``, but is
+        distinguishable here by checking both sets directly."""
+        p = _write_toml(tmp_path, self._TOML_WITH_ABSENT)
+        profile = load_rig(p).to_profile()
+        assert "totally_unknown_command" not in profile.command_names
+        assert "totally_unknown_command" not in profile.absent_command_names
+
+
+class TestSetModeViaSelectedDiscriminatesAbsent:
+    """MOR-2005 step 4a review finding: this step changes what membership
+    in ``RigConfig.commands`` means (a key can now hold an
+    ``AbsentCommandSpec``), so every derivation that read plain membership
+    to mean "the radio has this command" must be swept, not just
+    ``command_names``. ``set_mode_via_selected`` (consumed by
+    `runtime/_dual_rx_runtime.py: DualRxRuntimeMixin._set_mode_main` to
+    gate CI-V 0x26 0x00 selected-mode routing) was the one other such
+    site in `profiles/rig_loader.py: RigConfig.to_profile` — it must be
+    True only when ``set_selected_mode`` is declared with real CI-V bytes,
+    not merely present as *some* dict key.
+    """
+
+    _TOML_WITH_SELECTED_MODE_ABSENT = _MINIMAL_TOML + (
+        '\nset_selected_mode = { absent = "IC-7300 Full Manual '
+        '(A7292-4EX), no selected-mode-set item" }\n'
+    )
+
+    def test_declared_absent_selected_mode_yields_false(self, tmp_path):
+        p = _write_toml(tmp_path, self._TOML_WITH_SELECTED_MODE_ABSENT)
+        profile = load_rig(p).to_profile()
+        assert profile.set_mode_via_selected is False
+
+    def test_declared_with_bytes_still_yields_true(self, tmp_path):
+        """Unchanged behavior for the real declared case (X6200/IC-705
+        shape) — the fix must not flip this the other way."""
+        toml = _MINIMAL_TOML + "\nset_selected_mode = [0x26, 0x00]\n"
+        p = _write_toml(tmp_path, toml)
+        profile = load_rig(p).to_profile()
+        assert profile.set_mode_via_selected is True
+
+    def test_not_declared_at_all_still_yields_false(self, tmp_path):
+        p = _write_toml(tmp_path, _MINIMAL_TOML)
+        profile = load_rig(p).to_profile()
+        assert profile.set_mode_via_selected is False
+
 
 # ── discover_rigs ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Step 4a of `docs/plans/2026-08-29-profile-driven-command-bytes.md` Step 4.
Lands **only** the "declared absent" spelling — schema, loader, and
`RadioProfile` semantics — that decisions D1 and D2 (plan §8.1) need before
the refusal policy in Step 4b can be built.

## The owner rulings this implements (plan §8.1, verbatim)

**D1** (excerpt): "(2) Not declared and the profile knows the radio does not
have the command → report *unsupported by this radio* through
`profiles: RadioProfile.supports_command` ... (3) Not declared and unknown →
this state must not exist at release."

Plan §4 Step 4 (excerpt): "*One thing states 2 and 3 need that does not exist
yet.* Today a profile has no way to say 'this radio does not have this
command' — `profiles/rig_loader.py` builds `command_names` as
`frozenset(self.commands)`, so absence from the TOML is the only
representation... D2 (§8.1) already requires every entry to record where its
value came from, and 'not present on this model, per &lt;named authority&gt;'
is an entry with a source and no bytes. Adding that spelling to
`rigs/_schema_v2.md` and to the loader is part of this step."

**D2** (excerpt): "Every filled entry must record where its value came from,
**in the TOML**, so that 'verified on hardware' and 'taken from a manual' are
distinguishable by reading the file."

## The spelling

```toml
[commands]
get_dual_watch = { absent = "IC-7300 Full Manual (A7292-4EX), no dual-watch item" }
```

One key, `absent`, that is both the marker and the D2-required source in a
single move. `profiles/rig_loader.py: _parse_command_value` already treats a
dict *without* a `cat` key as a `RigLoadError` ("dict must have 'cat' key"),
so `absent` is a new, previously-rejected shape — no collision with the
existing CI-V (list) or CAT (`{ cat = {...} }`) shapes. A dict carrying both
`absent` and `cat` (or any other extra key alongside `absent`) is rejected;
an empty/blank `absent` value is rejected (D2 requires a real source, not a
placeholder).

Parses to a new `commands/command_spec.py: AbsentCommandSpec` (frozen
dataclass, single `source: str` field, validated non-empty), added to the
`CommandSpec` union alongside `CivCommandSpec`/`CatCommandSpec`.

`RigConfig.to_profile` partitions `self.commands` between
`RadioProfile.command_names` (declared entries, behavior-unchanged) and a
new `RadioProfile.absent_command_names` (declared-absent entries).
`to_command_map` already excluded everything but `CivCommandSpec` by
`isinstance` — so absent entries were already dropped from the `CommandMap`
for free; this PR adds a test pinning that instead of leaving it as an
unverified accident.

## Three states representable, not yet enforced — Step 4b follows

This PR makes D1's three states for a command name *distinguishable in data*:

1. Declared (bytes/CAT template) → in `command_names`.
2. Declared absent → in `absent_command_names`.
3. Neither → in neither set.

It does **not** add the refusal policy that acts on that distinction.
`RadioProfile.supports_command` still returns `False` for states (2) and (3)
alike — its docstring says this explicitly, and states so in the same words
as the plan, without claiming behavior this PR doesn't implement. The
guard-test enumerating every builder against every profile
(`tests/test_profile_command_coverage.py`), the runtime refusal path, and
the `_KNOWN_COMMANDS` reconciliation are Step 4b, a separate later PR.

No shipped `rigs/*.toml` uses the new spelling yet —
`tests/test_rig_loader.py: TestNoShippedProfileUsesAbsentSpellingYet` pins
that against every profile in `rigs/` (table-driven off the directory
listing, mirroring the existing AGC/preamp/etc. domain-agreement tests in
the same file). D2's filling work is separate, ticket-tracked work.

## Files (6, at the soft threshold — one unit of work)

- `src/rigplane/commands/command_spec.py` — `AbsentCommandSpec`
- `src/rigplane/profiles/rig_loader.py` — parse the new dict shape;
  partition `command_names`/`absent_command_names` in `to_profile`; pin
  `to_command_map`'s existing exclusion in its docstring; `set_mode_via_selected`
  fix (see review round below)
- `src/rigplane/profiles/__init__.py` — `RadioProfile.absent_command_names`
  field; `supports_command` docstring documents the three states without
  claiming the refusal policy
- `rigs/_schema_v2.md` — documents the spelling in the CI-V `[commands]`
  section, citing file+symbol per the repo's doc-citation convention
- `tests/test_command_spec.py` — round-trip + malformed-shape tests
  (`TestAbsentCommandSpec`)
- `tests/test_rig_loader.py` — `RadioProfile`-level semantics
  (`TestAbsentCommandSemantics`), the shipped-profiles regression pin
  (`TestNoShippedProfileUsesAbsentSpellingYet`), and the review-round fix's
  pin (`TestSetModeViaSelectedDiscriminatesAbsent`)

This is one unit of work: the spelling only means something once the
dataclass, the parser, the profile split, and the documentation all agree,
and splitting further would leave any one piece dead code relative to the
others.

## Review round: `set_mode_via_selected` also read plain membership

Independent review caught that this step changes what a key in
`RigConfig.commands` *means* — a key can now hold an `AbsentCommandSpec`,
which means the opposite of "the radio has this command" — but only one of
the two membership-reading derivations in `to_profile` was updated to
discriminate on that. `set_mode_via_selected="set_selected_mode" in
self.commands` was the second: unchanged, a profile declaring
`set_selected_mode = { absent = "..." }` would still set the flag `True`.

That flag gates a real consumer:
`runtime/_dual_rx_runtime.py: DualRxRuntimeMixin._set_mode_main` uses it to
choose between the bare CI-V 0x06 mode-set and the CI-V 0x26 0x00
selected-mode path. A wrongly-`True` flag would route a MAIN mode change
through a command the profile has explicitly recorded the radio as lacking.

**Predicate chosen:** `isinstance(self.commands.get("set_selected_mode"),
CivCommandSpec)` — not `CommandSpec` in general, `CivCommandSpec`
specifically. The consumer's routing decision (0x06 vs. 0x26 0x00) is
purely CI-V wire-level, so the flag should mean "declared as a CI-V command
with real bytes," not merely "declared, in whatever protocol." This also
naturally makes the not-declared and declared-absent cases collapse to the
same correct answer (`None` and `AbsentCommandSpec` both fail the
isinstance check) without a separate branch for each.

Swept for other instances of the same shape in `profiles/rig_loader.py`:
only these two (`command_names`/`absent_command_names`, already isinstance-based, and
this one) read `self.commands` membership to decide something.
`backends/yaesu_cat/radio.py`'s three `.commands.get(name)` call sites
(`_has_command`, `_has_write_command`, `_get_spec`) already gate on
`isinstance(spec, CatCommandSpec)` and needed no change.

Also added, per review: a name mentioned nowhere in a profile (not declared,
not declared-absent) lands in neither `command_names` nor
`absent_command_names` — D1 state (3), made representable but, as stated
above, not yet distinguished from state (2) by `supports_command`.

## Test evidence (at `e1cb88953633293b5d95eae7410c3b69f4f0eb5c`)

```
uv run pytest tests/test_rig_loader.py tests/test_command_map_parity.py \
  tests/test_profile_command_binding.py tests/test_supports_command.py \
  tests/test_command_spec.py tests/test_state_acquisition_policy.py \
  tests/test_radio.py tests/test_radio_connect.py tests/test_radio_coverage.py \
  -q --tb=short --timeout=300 --timeout-method=thread
...
883 passed, 1 skipped in 28.89s
```

(The 1 skip is pre-existing and unrelated to this change.)
`tests/test_state_acquisition_policy.py` and `tests/test_radio.py` were
added to the run for this round — both assert on `set_mode_via_selected`
directly or via a constructed `CoreRadio`, so they're the regression net
for the review-round fix. `tests/test_radio_connect.py` (the one direct
out-of-`profiles/` `RadioProfile(...)` construction site) and
`tests/test_radio_coverage.py` (the one `dataclasses.replace(profile, ...)`
call site) confirm the new field's default doesn't disturb either
construction path.

```
uv run ruff check src/ tests/          # All checks passed!
uv run ruff format src/ tests/         # clean, 695 unchanged (no reflow this round)
uv run lint-imports                    # Contracts: 5 kept, 0 broken
```

`git diff origin/main` shows only the 6 files above; no `web/`, `runtime/`,
`rigctld/`, or `commands/bound.py` touched.

## Test plan

- [x] `uv run pytest` targeted suite above — 883 passed, 1 skipped
      (pre-existing)
- [x] `uv run ruff check` / `uv run ruff format` — clean
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] Self-check grep for internal identifiers in the diff — empty
- [x] TDD: `set_mode_via_selected` fix confirmed red
      (`assert True is False`) against the pre-fix line before applying
      the isinstance-based fix
