### PR TITLE
fix(MOR-2004): point the poller at the profile-bound command map (step 3b)

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -73,6 +73,8 @@ from ..capabilities import (
     CAP_VOX,
 )
 from .._queue_pressure import PRESSURE_THRESHOLD
+from ..commands._frame import decode_wire_tuple
+from ..commands.command_map import CommandMap
 from ..commands.commander import Priority
 from ..commands.scope import SCOPE_RECEIVER_SELECTOR_SUBS
 from ..core.command_service import (
@@ -661,7 +663,11 @@ class RadioPoller:
         self._last_polled: dict[str, float] = {}
         self._caps: set[str] = self._radio_capabilities()
         self._profile: RadioProfile = self._runtime_profile()
-        self._cmd_map: dict[str, tuple[int, ...]] = self._load_command_map()
+        # Bound once at profile-resolution time (MOR-2003 step 3), not
+        # re-discovered here: ``None`` means a hand-built profile carried no
+        # map at all, which `_send_cmd` treats as a miss on every name rather
+        # than crashing construction (MOR-2004 step 3b).
+        self._cmd_map: CommandMap | None = self._profile.command_map
         # Serial backends need slower polling to avoid flooding the CI-V link
         self._is_serial: bool = not self._profile.has_lan
         self._gap: float = _GAP_SERIAL if self._is_serial else _GAP
@@ -1232,28 +1238,6 @@ class RadioPoller:
             pass
         raise NotImplementedError(f"{command} unsupported: unknown profile-less radio")
 
-    def _load_command_map(self) -> dict[str, tuple[int, ...]]:
-        """Load command wire bytes from TOML rig profile."""
-        try:
-            from pathlib import Path
-
-            from ..rig_loader import discover_rigs
-
-            for rig_dir in [
-                Path(__file__).resolve().parent.parent.parent.parent / "rigs",
-                Path(__file__).resolve().parent.parent / "rigs",
-            ]:
-                if rig_dir.is_dir():
-                    rigs = discover_rigs(rig_dir)
-                    for _model, rig_config in rigs.items():
-                        if rig_config.model == self._profile.model:
-                            # Convert CommandSpec to CI-V wire bytes (filters CAT commands)
-                            cmd_map = rig_config.to_command_map()
-                            return {name: cmd_map.get(name) for name in cmd_map}
-        except Exception:
-            logger.debug("radio-poller: failed to load command map", exc_info=True)
-        return {}
-
     async def _send_cmd(
         self,
         cmd_name: str,
@@ -1261,25 +1245,29 @@ class RadioPoller:
         *,
         receiver: int = 0,
     ) -> bool:
-        """Send a command using wire bytes from TOML profile.
+        """Send a command using the profile-bound CI-V wire bytes.
 
-        Returns True if command was found and sent, False otherwise.
+        Returns True if *cmd_name* was found in the profile's ``command_map``
+        and sent, False if the map is absent (``self._cmd_map is None``) or
+        lacks the name. A miss is logged at WARNING, not DEBUG: pinned by
+        ``tests/test_radio_poller_coverage.py::
+        test_execute_set_agc_undeclared_command_refuses_without_firing_event``
+        -- silence here is the failure mode MOR-2004 closes (a missing
+        command must not read to the caller as a no-op success).
         """
-        wire = self._cmd_map.get(cmd_name)
-        if not wire:
-            logger.debug("radio-poller: command %s not in profile", cmd_name)
+        cmd_map = self._cmd_map
+        if cmd_map is None or not cmd_map.has(cmd_name):
+            logger.warning("radio-poller: command %s not in profile", cmd_name)
             return False
-        cmd = wire[0]
-        sub = wire[1] if len(wire) > 1 else None
-        extra = bytes(wire[2:]) if len(wire) > 2 else b""
-        payload = extra + data
-        if self._profile.supports_cmd29(cmd, sub):
-            inner = bytes([receiver, cmd])
+        command, sub, prefix = decode_wire_tuple(cmd_map.get(cmd_name))
+        payload = prefix + data
+        if self._profile.supports_cmd29(command, sub):
+            inner = bytes([receiver, command])
             if sub is not None:
                 inner += bytes([sub])
             await self._civ(0x29, data=inner + payload)
         else:
-            await self._civ(cmd, sub=sub, data=payload)
+            await self._civ(command, sub=sub, data=payload)
         return True
 
     def _supports_capability(self, capability: str) -> bool:
@@ -2819,11 +2807,18 @@ class RadioPoller:
                 if CAP_AGC in self._caps:
                     self._ensure_receiver_supported(rx, operation="set_agc")
                     await radio.set_agc(mode, receiver=rx)
+                    agc_sent = True
                 else:
-                    # Wire bytes from TOML: set_agc = [0x16, 0x12]
-                    await self._send_cmd("set_agc", bytes([mode]), receiver=rx)
+                    # Wire bytes come from the profile-bound command map
+                    # (self._cmd_map); ``_send_cmd`` returns False, sending
+                    # nothing, when the profile doesn't declare set_agc
+                    # (MOR-2004 step 3b: closes the defect where this branch
+                    # used to fire agc_changed unconditionally either way).
+                    agc_sent = await self._send_cmd(
+                        "set_agc", bytes([mode]), receiver=rx
+                    )
                 # agc read-after-write via overlays + 0x16 0x12 observation.
-                if self._on_state_event:
+                if agc_sent and self._on_state_event:
                     self._on_state_event("agc_changed", {"mode": mode, "receiver": rx})
             case SetRitStatus(on=on):
                 await _r.set_rit_status(on)

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import time
 from collections.abc import Callable
@@ -12,8 +13,10 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands.command_map import CommandMap
 from rigplane.commands.commander import IcomCommander, Priority
-from rigplane.core.capabilities import CAP_SCOPE
+from rigplane.core.capabilities import CAP_AGC, CAP_SCOPE
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
@@ -2423,6 +2426,103 @@ async def test_execute_set_agc_sends_wire_value_without_legacy_mirror() -> None:
     assert state.main.agc == 1
     assert state.sub.agc == 1  # no legacy mirror write
     assert ("agc_changed", {"mode": 2, "receiver": 1}) in events
+
+
+def test_cmd_map_is_the_profile_bound_map_not_a_disk_scan() -> None:
+    """MOR-2004 step 3b: the poller's command map is the exact ``CommandMap``
+    object ``profiles/__init__.py: RadioProfile.command_map`` already
+    carries (bound once at profile-resolution time, MOR-2003 step 3) --
+    identity, not just equality, so a re-parse of ``rigs/`` under
+    ``RadioPoller._load_command_map`` (now deleted) could not silently
+    reappear and still pass.
+    """
+    radio = _make_radio(model="IC-7300")
+    poller = RadioPoller(radio, CommandQueue())
+    assert poller._cmd_map is radio.profile.command_map  # noqa: SLF001
+    assert isinstance(poller._cmd_map, CommandMap)  # noqa: SLF001
+
+
+def test_radio_poller_construction_survives_profile_without_command_map() -> None:
+    """A hand-built profile with no ``command_map`` at all -- ``None``, per
+    ``profiles/__init__.py: RadioProfile.command_map``'s own docstring for a
+    ``RadioProfile`` built outside ``rig_loader.py`` -- must not crash
+    construction. The lookup simply misses at send time (pinned by
+    ``test_execute_set_agc_undeclared_command_refuses_without_firing_event``
+    below for the ``command_map`` case; this test pins the ``None`` case
+    specifically).
+    """
+    radio = _make_radio(model="IC-7300")
+    radio.profile = dataclasses.replace(radio.profile, command_map=None)
+    poller = RadioPoller(radio, CommandQueue())
+    assert poller._cmd_map is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_execute_set_agc_without_cap_agc_emits_profile_wire_bytes() -> None:
+    """No-``CAP_AGC`` path (``RadioPoller._send_cmd``): the frame matches the
+    profile's declared ``set_agc`` wire tuple with the disk scan gone --
+    decoded the same way every other command-map entry is decoded, via
+    ``commands/_frame.py: decode_wire_tuple``. Pinned against IC-7300's own
+    bound map rather than a hardcoded byte pair, so this stays correct if
+    ``rigs/ic7300.toml``'s ``set_agc`` entry ever changes.
+    """
+    events: list[tuple[str, dict]] = []
+    radio = _make_radio(model="IC-7300")
+    radio.capabilities.discard(CAP_AGC)
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        on_state_event=lambda name, data: events.append((name, data)),
+    )
+    command, sub, prefix = decode_wire_tuple(radio.profile.command_map.get("set_agc"))
+    assert not poller._profile.supports_cmd29(command, sub)  # noqa: SLF001
+
+    await poller._execute(SetAgc(2, receiver=0))  # noqa: SLF001
+
+    radio.send_civ.assert_awaited_once_with(
+        command,
+        sub=sub,
+        data=prefix + bytes([2]),
+        wait_response=False,
+        priority=Priority.NORMAL,
+        wait_dispatch=True,
+    )
+    assert ("agc_changed", {"mode": 2, "receiver": 0}) in events
+
+
+@pytest.mark.asyncio
+async def test_execute_set_agc_undeclared_command_refuses_without_firing_event(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MOR-2004 coordinator comment (2026-08-30): before this fix, ``_execute``
+    discarded ``_send_cmd``'s boolean and unconditionally fired
+    ``agc_changed`` even when nothing was sent -- the UI was told AGC
+    changed when no bytes went out. With ``set_agc`` removed from the bound
+    map, the fixed path must send no CI-V frame, fire no event, and log the
+    miss at WARNING (silence is the failure mode this step removes).
+    """
+    events: list[tuple[str, dict]] = []
+    radio = _make_radio(model="IC-7300")
+    radio.capabilities.discard(CAP_AGC)
+    stripped = {
+        name: radio.profile.command_map.get(name)
+        for name in radio.profile.command_map
+        if name != "set_agc"
+    }
+    radio.profile = dataclasses.replace(radio.profile, command_map=CommandMap(stripped))
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        on_state_event=lambda name, data: events.append((name, data)),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="rigplane.web.radio_poller"):
+        await poller._execute(SetAgc(2, receiver=0))  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    radio.set_agc.assert_not_awaited()
+    assert events == []
+    assert "command set_agc not in profile" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Plan quote

From `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Step 3b, verbatim:

> `web/radio_poller.py: RadioPoller._load_command_map` re-discovers `rigs/` by guessing paths relative to `__file__` and returns `{}` on any exception, so a load failure silently becomes "no commands". Point it at the bound map from Step 3 and delete both the scan and `RadioPoller._send_cmd`'s private copy of the wire decomposition.
>
> **Red if broken:** a new case in `tests/test_radio_poller_coverage.py` asserting `set_agc` still emits the profile's bytes with the disk scan gone.

## What changed

`src/rigplane/web/radio_poller.py`:

- Deleted `RadioPoller._load_command_map` entirely — the `__file__`-relative `rigs/` directory guessing, the `discover_rigs` re-parse, and the `except Exception: return {}` swallow. `self._cmd_map` is now `self._profile.command_map` (a `CommandMap | None`), the map already bound once at profile-resolution time in MOR-2003 Step 3 — no re-discovery, no new plumbing.
- `None` handling is explicit and documented at the assignment site: a hand-built profile with no map at all means every lookup misses and takes the refusal path in `_send_cmd`, never a crash at construction.
- `_send_cmd` no longer hand-decomposes `wire[0]/wire[1]/wire[2:]`. It now calls `commands/_frame.py: decode_wire_tuple` — the single wire-tuple decoder the rest of this effort (Steps 1-3) already standardised on — and keeps the cmd29 auto-routing (`self._profile.supports_cmd29`) exactly as it was; that gating is the poller's own behavior, not the decoder's.
- A miss (unmapped command name, or no map at all) now logs at WARNING instead of DEBUG — silence at that level was part of the same failure class this whole plan removes.

## Silent-defect closure (MOR-2004 coordinator comment, 2026-08-30)

Before this PR, `_execute`'s `SetAgc` branch discarded `_send_cmd`'s returned boolean and unconditionally fired `self._on_state_event("agc_changed", ...)` — so on the no-`CAP_AGC` path, a profile that doesn't declare `set_agc` would still tell the UI "AGC changed" even though no CI-V bytes went out. Fixed minimally: `_send_cmd` still returns a bool; the `SetAgc` case now fires `agc_changed` only when a frame was actually sent (`CAP_AGC` native call succeeding, which raises rather than returning falsy on failure — or `_send_cmd` returning `True`). No new exception types or reporting paths were introduced; the three-state undeclared-command policy (declared / known-absent-on-this-radio / neither) is owner decision D1 and Step 4's territory, deliberately not implemented here.

## Why D1 is not implemented here

D1 defines three states for an undeclared command (declared / not declared-and-known-absent / not declared-and-unknown), backed by a new "declared missing, per &lt;authority&gt;" TOML spelling and a coverage-guard test enumerating every builder against every profile. That is Step 4 of the plan, gated on schema/loader changes not touched here. This step only needed to stop the false "success" signal — a miss now visibly refuses (WARNING log, no event) instead of silently no-op-succeeding, without inventing the richer state machine Step 4 owns.

## Sweep for the same defect shape

`_send_cmd` has exactly one call site in `radio_poller.py` (the `SetAgc` branch), confirmed by grep, so there is no second instance of "boolean-returning send helper whose result is discarded before an unconditional state event" to fix in this file. The only other private method returning `bool` that isn't a trivial predicate is `_scope_getter_attempt` (used by `_fetch_scope_controls`); its two call sites already consume the return value for retry logic and never pair it with an unconditional `_on_state_event` call, so it is a different shape (a bounded-retry GET, not a write-success signal) and is left untouched.

## Test evidence (head `6bf3efe0`)

```
uv run pytest tests/test_radio_poller_coverage.py tests/test_mor1537_cmd29_gating.py tests/test_command_map_parity.py -q --tb=short --timeout=300 --timeout-method=thread
286 passed in 10.04s
```

New cases in `tests/test_radio_poller_coverage.py`:
- `test_cmd_map_is_the_profile_bound_map_not_a_disk_scan` — the poller's map is the exact `CommandMap` object `RadioProfile.command_map` already carries (identity, not equality) — pins "disk scan gone".
- `test_radio_poller_construction_survives_profile_without_command_map` — a profile with `command_map=None` does not crash construction.
- `test_execute_set_agc_without_cap_agc_emits_profile_wire_bytes` — the no-`CAP_AGC` path still emits IC-7300's declared `set_agc` bytes, decoded via `decode_wire_tuple`, with the event firing on success.
- `test_execute_set_agc_undeclared_command_refuses_without_firing_event` — with `set_agc` stripped from the bound map: no CI-V frame, no `agc_changed` event, and the miss logged at WARNING. This is the regression pin for the MOR-2004 coordinator-comment defect.

cmd29 routing through `_send_cmd` is already fully pinned by `tests/test_mor1537_cmd29_gating.py::TestSendCmdCmd29Unification` (4 tests: wrap on IC-7610 receiver 0/1, unwrap on IC-7300, and parity with `CoreRadio.set_agc`'s own wrap decision) — referenced here rather than duplicated, per the task's own guidance; all 4 still pass unmodified.

Also ran (clean):
```
uv run mypy --strict src/rigplane/web        # Success: no issues found in 26 source files
uv run ruff check src/ tests/                # All checks passed!
uv run ruff format src/ tests/ --check       # (reformatted once, now clean)
uv run lint-imports                          # Contracts: 5 kept, 0 broken.
```

## Guardrails

2 files changed, 135 insertions(+), 40 deletions(-) — well within the 6-file/600-line soft threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)