### PR TITLE
feat(MOR-2006): migrate config.py onto the bound command map (steps 5..N, module 1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+- **`rigplane.commands.config` builders require `cmd_map`; there is no
+  hardcoded fallback (MOR-2006, Steps 5..N module 1 of
+  `docs/plans/2026-08-29-profile-driven-command-bytes.md`).**
+  `get_acc1_mod_level`/`set_acc1_mod_level`, the USB/LAN mod-level pair,
+  the DATA-OFF/1/2/3 mod-input pairs, and `get_civ_transceive`/
+  `set_civ_transceive`/`get_civ_output_ant`/`set_civ_output_ant` all took
+  an optional `cmd_map` that, unused, fell back to bytes written into the
+  source years ago — on the IC-7300 those bytes collided with `set_mic_gain`
+  (both built `14 0B`), so the ACC1 slider moved MIC gain (MOR-1992). `cmd_map`
+  is now a required keyword-only argument on all eighteen; a call that omits
+  it raises `TypeError` (naming the migration and pointing at
+  `commands/bound.py: BoundCommands` in the message) rather than silently
+  emitting the old, sometimes-wrong bytes. The only production caller in
+  this repository, `runtime/radio.py: CoreRadio`, moved onto
+  `self._commands.<builder>(...)` in the same change, which supplies the
+  map — but an external caller of the free function must do the same:
+  reach these builders through a radio's bound commands rather than
+  calling `rigplane.commands.get_acc1_mod_level(...)` (or any of its
+  seventeen siblings above) directly with no map.
 - **CLI: `rigplane ptt on` no longer returns while the rig is keyed.** The
   command now holds the key for as long as the process runs and unkeys on the
   way out, so the process that keyed the rig is the one that releases it. A

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -6,7 +6,8 @@ from here, but this module imports nothing from siblings.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+import functools
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from ..types import CivFrame
 
@@ -100,12 +101,6 @@ _CTL_MEM_DASH_RATIO = b"\x02\x28"
 _CTL_MEM_NB_DEPTH = b"\x02\x90"
 _CTL_MEM_NB_WIDTH = b"\x02\x91"
 _CTL_MEM_VOX_DELAY = b"\x02\x92"
-_CTL_MEM_DATA_OFF_MOD_INPUT = b"\x00\x91"
-_CTL_MEM_DATA1_MOD_INPUT = b"\x00\x92"
-_CTL_MEM_DATA2_MOD_INPUT = b"\x00\x93"
-_CTL_MEM_DATA3_MOD_INPUT = b"\x00\x94"
-_CTL_MEM_CIV_TRANSCEIVE = b"\x01\x29"
-_CTL_MEM_CIV_OUTPUT_ANT = b"\x01\x30"
 _CTL_MEM_SYSTEM_DATE = b"\x01\x58"
 _CTL_MEM_SYSTEM_TIME = b"\x01\x59"
 _CTL_MEM_UTC_OFFSET = b"\x01\x62"
@@ -118,11 +113,6 @@ _SUB_ANT1 = 0x00
 _SUB_ANT2 = 0x01
 _SUB_RX_ANT_ANT1 = 0x12
 _SUB_RX_ANT_ANT2 = 0x13
-
-# Modulation level sub-commands for 0x14
-_SUB_ACC1_MOD_LEVEL = 0x0B
-_SUB_USB_MOD_LEVEL = 0x10
-_SUB_LAN_MOD_LEVEL = 0x11
 
 # VFO / Scan / Dual Watch
 _CMD_VFO_SELECT = 0x07
@@ -369,6 +359,43 @@ def expose_command_key(
         return fn
 
     return decorator
+
+
+def require_cmd_map(fn: _BuilderT) -> _BuilderT:
+    """Wrap *fn* so a call omitting ``cmd_map`` explains the Q6 API break.
+
+    Per Q6 (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1):
+    ``cmd_map`` is now required, no default, no deprecation cycle -- but
+    Python's own missing-argument ``TypeError`` names only the parameter,
+    not what changed or what to do about it. This appends both to that
+    same message (so a call missing some *other* required argument too
+    still shows it) rather than replacing it. A call that already supplies
+    ``cmd_map`` -- including a literal ``None``, which reaches *fn* and
+    fails there on its own terms -- is unaffected: this only ever fires on
+    Python's missing-argument wording, never an unrelated error from *fn*.
+
+    Applied module by module as Steps 5..N reach each one;
+    `commands/config.py` (module 1) is the first caller.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except TypeError as exc:
+            if "cmd_map" in kwargs or "'cmd_map'" not in str(exc):
+                raise
+            raise TypeError(
+                f"{exc} -- as of MOR-2006 "
+                "(docs/plans/2026-08-29-profile-driven-command-bytes.md), "
+                "every rigplane.commands builder requires the radio's "
+                "CommandMap and no longer has a hardcoded fallback. Call it "
+                "through the radio's bound commands instead of the free "
+                "function directly (commands/bound.py: BoundCommands, e.g. "
+                "self._commands.<builder>(...))."
+            ) from None
+
+    return wrapper  # type: ignore[return-value]
 
 
 def parse_civ_frame(data: bytes) -> CivFrame:

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -361,18 +361,32 @@ def expose_command_key(
     return decorator
 
 
+_CMD_MAP_EXPLANATION = (
+    "as of MOR-2006 (docs/plans/2026-08-29-profile-driven-command-bytes.md), "
+    "every rigplane.commands builder requires the radio's CommandMap and no "
+    "longer has a hardcoded fallback. Call it through the radio's bound "
+    "commands instead of the free function directly (commands/bound.py: "
+    "BoundCommands, e.g. self._commands.<builder>(...))."
+)
+
+
 def require_cmd_map(fn: _BuilderT) -> _BuilderT:
-    """Wrap *fn* so a call omitting ``cmd_map`` explains the Q6 API break.
+    """Wrap *fn* so a missing or ``None`` ``cmd_map`` explains the Q6 API break.
 
     Per Q6 (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1):
-    ``cmd_map`` is now required, no default, no deprecation cycle -- but
-    Python's own missing-argument ``TypeError`` names only the parameter,
-    not what changed or what to do about it. This appends both to that
-    same message (so a call missing some *other* required argument too
-    still shows it) rather than replacing it. A call that already supplies
-    ``cmd_map`` -- including a literal ``None``, which reaches *fn* and
-    fails there on its own terms -- is unaffected: this only ever fires on
-    Python's missing-argument wording, never an unrelated error from *fn*.
+    ``cmd_map`` is required, no default, no deprecation cycle. Two ways a
+    call can still lack a real map, both raising ``TypeError`` with the
+    same ``_CMD_MAP_EXPLANATION`` appended:
+
+    - **Omitted entirely.** Python's own missing-argument ``TypeError``
+      names only the parameter -- caught here and the explanation appended,
+      so a call missing some *other* required argument too still shows it.
+    - **Passed explicitly as ``None``.** Nothing in *fn*'s own signature
+      rejects this at runtime (a type checker would) -- previously it
+      reached *fn*'s body and failed there on its own terms, e.g. an
+      ``AttributeError`` from ``None.get(name)`` inside `_build_from_map`
+      for the de-delegated builders this migration writes. Checked before
+      *fn* is ever called, so this can no longer produce a byte either.
 
     Applied module by module as Steps 5..N reach each one;
     `commands/config.py` (module 1) is the first caller.
@@ -380,20 +394,16 @@ def require_cmd_map(fn: _BuilderT) -> _BuilderT:
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if "cmd_map" in kwargs and kwargs["cmd_map"] is None:
+            raise TypeError(
+                f"{fn.__name__}() cmd_map is None -- {_CMD_MAP_EXPLANATION}"
+            )
         try:
             return fn(*args, **kwargs)
         except TypeError as exc:
             if "cmd_map" in kwargs or "'cmd_map'" not in str(exc):
                 raise
-            raise TypeError(
-                f"{exc} -- as of MOR-2006 "
-                "(docs/plans/2026-08-29-profile-driven-command-bytes.md), "
-                "every rigplane.commands builder requires the radio's "
-                "CommandMap and no longer has a hardcoded fallback. Call it "
-                "through the radio's bound commands instead of the free "
-                "function directly (commands/bound.py: BoundCommands, e.g. "
-                "self._commands.<builder>(...))."
-            ) from None
+            raise TypeError(f"{exc} -- {_CMD_MAP_EXPLANATION}") from None
 
     return wrapper  # type: ignore[return-value]
 

--- a/src/rigplane/commands/config.py
+++ b/src/rigplane/commands/config.py
@@ -1,316 +1,306 @@
-"""Configuration commands: mod levels, mod input routing, CI-V options."""
+"""Configuration commands: mod levels, mod input routing, CI-V options.
+
+Migrated onto the bound command map in MOR-2006 Steps 5..N (module 1,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4): every builder
+here requires ``cmd_map``, with no hardcoded fallback left. This module
+accounted for 44 of the rows `tests/command_map_parity_divergences.txt`
+recorded before this migration -- all now gone, since a divergence needs
+two disagreeing implementations and this module has only one left --
+including the measured ACC1/MIC-gain collision (MOR-1992) and
+``set_data_off_mod_input``, which `runtime/profiles_runtime.py:
+apply_profile` writes with no user action.
+
+Every builder calls `_frame.py: _build_from_map` directly rather than the
+shared `_builders.py: _build_ctl_mem_get` / `_build_ctl_mem_set` templates
+used before migrating: those still carry their own ``cmd_map is None``
+fallback for `levels.py` / `system.py`, unmigrated, so routing through them
+would leave an explicit ``cmd_map=None`` call silently reaching old,
+sometimes-wrong bytes instead of failing loudly.
+"""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ._builders import _build_ctl_mem_get, _build_ctl_mem_set
-from ._codec import _level_bcd_encode
+from ._codec import _level_bcd_encode, bcd_encode_value
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_LEVEL,
-    _CTL_MEM_CIV_OUTPUT_ANT,
-    _CTL_MEM_CIV_TRANSCEIVE,
-    _CTL_MEM_DATA1_MOD_INPUT,
-    _CTL_MEM_DATA2_MOD_INPUT,
-    _CTL_MEM_DATA3_MOD_INPUT,
-    _CTL_MEM_DATA_OFF_MOD_INPUT,
-    _SUB_ACC1_MOD_LEVEL,
-    _SUB_LAN_MOD_LEVEL,
-    _SUB_USB_MOD_LEVEL,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
     from ..command_map import CommandMap
 
 
-# --- Modulation Levels (0x14 0x0B / 0x10 / 0x11) ---
+# --- Modulation Levels (0x14 0x0B / 0x10 / 0x11 on radios without a menu
+# address for them; IC-7300/7610/9700/705 route these through extended
+# menu addresses instead -- see rigs/*.toml) ---
 
 
+@expose_command_key(lambda cmd_map: "get_acc1_mod_level")
+@require_cmd_map
 def get_acc1_mod_level(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_acc1_mod_level", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_ACC1_MOD_LEVEL)
+    return _build_from_map(
+        cmd_map, "get_acc1_mod_level", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_acc1_mod_level")
+@require_cmd_map
 def set_acc1_mod_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_acc1_mod_level",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_LEVEL,
-        sub=_SUB_ACC1_MOD_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "set_acc1_mod_level",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_usb_mod_level")
+@require_cmd_map
 def get_usb_mod_level(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_usb_mod_level", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_USB_MOD_LEVEL)
+    return _build_from_map(
+        cmd_map, "get_usb_mod_level", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_usb_mod_level")
+@require_cmd_map
 def set_usb_mod_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_usb_mod_level",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_LEVEL,
-        sub=_SUB_USB_MOD_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "set_usb_mod_level",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_lan_mod_level")
+@require_cmd_map
 def get_lan_mod_level(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_lan_mod_level", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_LAN_MOD_LEVEL)
+    return _build_from_map(
+        cmd_map, "get_lan_mod_level", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_lan_mod_level")
+@require_cmd_map
 def set_lan_mod_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_lan_mod_level",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_LEVEL,
-        sub=_SUB_LAN_MOD_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "set_lan_mod_level",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=_level_bcd_encode(level),
     )
 
 
-# --- Modulation Input Routing (0x1A 0x05 0x00 0x91-0x94) ---
+# --- Modulation Input Routing (menu addresses vary by radio -- see
+# rigs/*.toml; the values here are names only, no longer bytes) ---
 
 
+@expose_command_key(lambda cmd_map: "get_data_off_mod_input")
+@require_cmd_map
 def get_data_off_mod_input(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    return _build_ctl_mem_get(
-        _CTL_MEM_DATA_OFF_MOD_INPUT,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_data_off_mod_input",
+    return _build_from_map(
+        cmd_map, "get_data_off_mod_input", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_data_off_mod_input")
+@require_cmd_map
 def set_data_off_mod_input(
     source: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 0 <= source <= 5:
         raise ValueError(f"Data Off mod input must be 0-5, got {source}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_DATA_OFF_MOD_INPUT,
-        source,
+    return _build_from_map(
+        cmd_map,
+        "set_data_off_mod_input",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_data_off_mod_input",
+        data=bcd_encode_value(source, byte_count=1),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_data1_mod_input")
+@require_cmd_map
 def get_data1_mod_input(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    return _build_ctl_mem_get(
-        _CTL_MEM_DATA1_MOD_INPUT,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_data1_mod_input",
+    return _build_from_map(
+        cmd_map, "get_data1_mod_input", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_data1_mod_input")
+@require_cmd_map
 def set_data1_mod_input(
     source: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 0 <= source <= 5:
         raise ValueError(f"DATA1 mod input must be 0-5, got {source}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_DATA1_MOD_INPUT,
-        source,
+    return _build_from_map(
+        cmd_map,
+        "set_data1_mod_input",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_data1_mod_input",
+        data=bcd_encode_value(source, byte_count=1),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_data2_mod_input")
+@require_cmd_map
 def get_data2_mod_input(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    return _build_ctl_mem_get(
-        _CTL_MEM_DATA2_MOD_INPUT,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_data2_mod_input",
+    return _build_from_map(
+        cmd_map, "get_data2_mod_input", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_data2_mod_input")
+@require_cmd_map
 def set_data2_mod_input(
     source: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 0 <= source <= 5:
         raise ValueError(f"DATA2 mod input must be 0-5, got {source}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_DATA2_MOD_INPUT,
-        source,
+    return _build_from_map(
+        cmd_map,
+        "set_data2_mod_input",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_data2_mod_input",
+        data=bcd_encode_value(source, byte_count=1),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_data3_mod_input")
+@require_cmd_map
 def get_data3_mod_input(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    return _build_ctl_mem_get(
-        _CTL_MEM_DATA3_MOD_INPUT,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_data3_mod_input",
+    return _build_from_map(
+        cmd_map, "get_data3_mod_input", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_data3_mod_input")
+@require_cmd_map
 def set_data3_mod_input(
     source: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 0 <= source <= 5:
         raise ValueError(f"DATA3 mod input must be 0-5, got {source}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_DATA3_MOD_INPUT,
-        source,
+    return _build_from_map(
+        cmd_map,
+        "set_data3_mod_input",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_data3_mod_input",
+        data=bcd_encode_value(source, byte_count=1),
     )
 
 
-# --- CI-V Options (0x1A 0x05 0x01 0x29 / 0x30) ---
+# --- CI-V Options (menu addresses vary by radio -- see rigs/*.toml) ---
 
 
+@expose_command_key(lambda cmd_map: "get_civ_transceive")
+@require_cmd_map
 def get_civ_transceive(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    return _build_ctl_mem_get(
-        _CTL_MEM_CIV_TRANSCEIVE,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_civ_transceive",
+    return _build_from_map(
+        cmd_map, "get_civ_transceive", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_civ_transceive")
+@require_cmd_map
 def set_civ_transceive(
     enabled: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    return _build_ctl_mem_set(
-        _CTL_MEM_CIV_TRANSCEIVE,
-        1 if enabled else 0,
+    return _build_from_map(
+        cmd_map,
+        "set_civ_transceive",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_civ_transceive",
+        data=bcd_encode_value(1 if enabled else 0, byte_count=1),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_civ_output_ant")
+@require_cmd_map
 def get_civ_output_ant(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    return _build_ctl_mem_get(
-        _CTL_MEM_CIV_OUTPUT_ANT,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_civ_output_ant",
+    return _build_from_map(
+        cmd_map, "get_civ_output_ant", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_civ_output_ant")
+@require_cmd_map
 def set_civ_output_ant(
     enabled: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    return _build_ctl_mem_set(
-        _CTL_MEM_CIV_OUTPUT_ANT,
-        1 if enabled else 0,
+    return _build_from_map(
+        cmd_map,
+        "set_civ_output_ant",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_civ_output_ant",
+        data=bcd_encode_value(1 if enabled else 0, byte_count=1),
     )

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -206,7 +206,6 @@ from rigplane.commands import (
     scan_start_type,
     scan_stop,
     send_cw,
-    set_acc1_mod_level,
     set_af_level,
     set_af_mute,
     set_agc,
@@ -222,16 +221,10 @@ from rigplane.commands import (
     set_break_in,
     set_break_in_delay,
     set_bsr,
-    set_civ_output_ant,
-    set_civ_transceive,
     set_compressor,
     set_compressor_level,
     set_cw_pitch,
     set_dash_ratio,
-    set_data1_mod_input,
-    set_data2_mod_input,
-    set_data3_mod_input,
-    set_data_off_mod_input,
     set_dial_lock,
     set_digisel,
     set_digisel_shift,
@@ -241,7 +234,6 @@ from rigplane.commands import (
     set_freq,
     set_ip_plus,
     set_key_speed,
-    set_lan_mod_level,
     set_manual_notch,
     set_manual_notch_width,
     set_mic_gain,
@@ -274,7 +266,6 @@ from rigplane.commands import (
     set_tuning_step,
     set_twin_peak_filter,
     set_tx_freq_monitor,
-    set_usb_mod_level,
     set_utc_offset,
     set_vox,
     set_vox_delay,
@@ -919,8 +910,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # constructed outside ``profiles/rig_loader.py``) and a loaded
         # profile that declares no CI-V commands both bind an empty
         # ``CommandMap`` here rather than raising -- construction must
-        # never fail on this. No call site reads ``self._commands`` yet;
-        # that migration is Steps 5..N of the same plan.
+        # never fail on this. As of Steps 5..N module 1
+        # (`commands/config.py`, MOR-2006), the mod-level/mod-input/CI-V
+        # option getters and setters below are the first call sites to
+        # read ``self._commands``; the rest still migrate module by
+        # module.
         #
         # ``absent_command_sources``/``on_undeclared`` implement D1's
         # undeclared-command policy (step 4b, plan §4 Step 4 / §8.1): this
@@ -2575,6 +2569,22 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             civ, key=key, dedupe=True, label="get_bool_value"
         )
         return parse_bool_response(resp, command=command, sub=sub, prefix=prefix)
+
+    def _expect_shape(self, builder: Callable[..., bytes]) -> tuple[int, int, bytes]:
+        """The ``(command, sub, prefix)`` a migrated getter's reply must match.
+
+        Thin wrapper over `commands/bound.py: BoundCommands.expect` (MOR-2006
+        §6 population 1): ``expect`` types ``sub`` as ``int | None`` per the
+        wire-tuple contract, but every builder routed through here so far
+        always has one -- the assertion fails loudly instead of reaching
+        ``_get_bcd_level``/``_get_bool_value`` with the wrong type.
+        """
+        command, sub, prefix = self._commands.expect(builder)
+        assert sub is not None, (
+            f"{getattr(builder, '__qualname__', builder)}: map entry has no "
+            "sub-command byte"
+        )
+        return command, sub, prefix
 
     async def _send_fire_and_forget(self, civ: bytes) -> None:
         """Send a fire-and-forget CI-V command after connection checks."""
@@ -4826,149 +4836,167 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             set_rx_antenna_ant2(enabled, to_addr=self._radio_addr)
         )
 
+    # commands/config.py, migrated onto the bound command map (MOR-2006
+    # Steps 5..N module 1, plan §4): requests go through
+    # ``self._commands.<builder>`` and replies through
+    # ``self._expect_shape`` (§6 population 1), rather than the literal
+    # ``command=``/``sub=``/``prefix=`` values every getter below still uses.
+
     async def get_acc1_mod_level(self) -> int:
         """Read ACC1 modulation level (0-255)."""
+        command, sub, prefix = self._expect_shape(get_acc1_mod_level)
         return await self._get_bcd_level(
-            get_acc1_mod_level(to_addr=self._radio_addr),
+            self._commands.get_acc1_mod_level(to_addr=self._radio_addr),
             key="get_acc1_mod_level",
-            command=0x14,
-            sub=0x0B,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_acc1_mod_level(self, level: int) -> None:
         """Set ACC1 modulation level (0-255)."""
         await self._send_fire_and_forget(
-            set_acc1_mod_level(level, to_addr=self._radio_addr)
+            self._commands.set_acc1_mod_level(level, to_addr=self._radio_addr)
         )
 
     async def get_usb_mod_level(self) -> int:
         """Read USB modulation level (0-255)."""
+        command, sub, prefix = self._expect_shape(get_usb_mod_level)
         return await self._get_bcd_level(
-            get_usb_mod_level(to_addr=self._radio_addr),
+            self._commands.get_usb_mod_level(to_addr=self._radio_addr),
             key="get_usb_mod_level",
-            command=0x14,
-            sub=0x10,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_usb_mod_level(self, level: int) -> None:
         """Set USB modulation level (0-255)."""
         await self._send_fire_and_forget(
-            set_usb_mod_level(level, to_addr=self._radio_addr)
+            self._commands.set_usb_mod_level(level, to_addr=self._radio_addr)
         )
 
     async def get_lan_mod_level(self) -> int:
         """Read LAN modulation level (0-255)."""
+        command, sub, prefix = self._expect_shape(get_lan_mod_level)
         return await self._get_bcd_level(
-            get_lan_mod_level(to_addr=self._radio_addr),
+            self._commands.get_lan_mod_level(to_addr=self._radio_addr),
             key="get_lan_mod_level",
-            command=0x14,
-            sub=0x11,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_lan_mod_level(self, level: int) -> None:
         """Set LAN modulation level (0-255)."""
         await self._send_fire_and_forget(
-            set_lan_mod_level(level, to_addr=self._radio_addr)
+            self._commands.set_lan_mod_level(level, to_addr=self._radio_addr)
         )
 
     async def get_data_off_mod_input(self) -> int:
         """Read Data Off modulation input source (0-5)."""
+        command, sub, prefix = self._expect_shape(get_data_off_mod_input)
         return await self._get_bcd_level(
-            get_data_off_mod_input(to_addr=self._radio_addr),
+            self._commands.get_data_off_mod_input(to_addr=self._radio_addr),
             key="get_data_off_mod_input",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x00\x91",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_data_off_mod_input(self, source: int) -> None:
         """Set Data Off modulation input source (0-5)."""
         await self._send_fire_and_forget(
-            set_data_off_mod_input(source, to_addr=self._radio_addr)
+            self._commands.set_data_off_mod_input(source, to_addr=self._radio_addr)
         )
 
     async def get_data1_mod_input(self) -> int:
         """Read DATA1 modulation input source (0-4)."""
+        command, sub, prefix = self._expect_shape(get_data1_mod_input)
         return await self._get_bcd_level(
-            get_data1_mod_input(to_addr=self._radio_addr),
+            self._commands.get_data1_mod_input(to_addr=self._radio_addr),
             key="get_data1_mod_input",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x00\x92",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_data1_mod_input(self, source: int) -> None:
         """Set DATA1 modulation input source (0-4)."""
         await self._send_fire_and_forget(
-            set_data1_mod_input(source, to_addr=self._radio_addr)
+            self._commands.set_data1_mod_input(source, to_addr=self._radio_addr)
         )
 
     async def get_data2_mod_input(self) -> int:
         """Read DATA2 modulation input source (0-4)."""
+        command, sub, prefix = self._expect_shape(get_data2_mod_input)
         return await self._get_bcd_level(
-            get_data2_mod_input(to_addr=self._radio_addr),
+            self._commands.get_data2_mod_input(to_addr=self._radio_addr),
             key="get_data2_mod_input",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x00\x93",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_data2_mod_input(self, source: int) -> None:
         """Set DATA2 modulation input source (0-4)."""
         await self._send_fire_and_forget(
-            set_data2_mod_input(source, to_addr=self._radio_addr)
+            self._commands.set_data2_mod_input(source, to_addr=self._radio_addr)
         )
 
     async def get_data3_mod_input(self) -> int:
         """Read DATA3 modulation input source (0-4)."""
+        command, sub, prefix = self._expect_shape(get_data3_mod_input)
         return await self._get_bcd_level(
-            get_data3_mod_input(to_addr=self._radio_addr),
+            self._commands.get_data3_mod_input(to_addr=self._radio_addr),
             key="get_data3_mod_input",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x00\x94",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_data3_mod_input(self, source: int) -> None:
         """Set DATA3 modulation input source (0-4)."""
         await self._send_fire_and_forget(
-            set_data3_mod_input(source, to_addr=self._radio_addr)
+            self._commands.set_data3_mod_input(source, to_addr=self._radio_addr)
         )
 
     async def get_civ_transceive(self) -> bool:
         """Read CI-V transceive status."""
+        command, sub, prefix = self._expect_shape(get_civ_transceive)
         return await self._get_bool_value(
-            get_civ_transceive(to_addr=self._radio_addr),
+            self._commands.get_civ_transceive(to_addr=self._radio_addr),
             key="get_civ_transceive",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x01\x29",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_civ_transceive(self, enabled: bool) -> None:
         """Set CI-V transceive status."""
         await self._send_fire_and_forget(
-            set_civ_transceive(enabled, to_addr=self._radio_addr)
+            self._commands.set_civ_transceive(enabled, to_addr=self._radio_addr)
         )
 
     async def get_civ_output_ant(self) -> bool:
         """Read CI-V output (ANT) status."""
+        command, sub, prefix = self._expect_shape(get_civ_output_ant)
         return await self._get_bool_value(
-            get_civ_output_ant(to_addr=self._radio_addr),
+            self._commands.get_civ_output_ant(to_addr=self._radio_addr),
             key="get_civ_output_ant",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x01\x30",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_civ_output_ant(self, enabled: bool) -> None:
         """Set CI-V output (ANT) status."""
         await self._send_fire_and_forget(
-            set_civ_output_ant(enabled, to_addr=self._radio_addr)
+            self._commands.set_civ_output_ant(enabled, to_addr=self._radio_addr)
         )
 
     async def get_system_date(self) -> tuple[int, int, int]:

--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -4,34 +4,12 @@
 # here, and on a row here that no longer disagrees -- delete that
 # row, never keep it. Regenerating can still add rows, so read any
 # addition as a new divergence someone has to justify.
-IC-705	config.py:get_civ_transceive	(no arguments)	map=fefea4e01a050112fd fallback=fefea4e01a050129fd
-IC-705	config.py:get_data1_mod_input	(no arguments)	map=fefea4e01a050119fd fallback=fefea4e01a050092fd
-IC-705	config.py:get_data_off_mod_input	(no arguments)	map=fefea4e01a050118fd fallback=fefea4e01a050091fd
-IC-705	config.py:get_lan_mod_level	(no arguments)	map=fefea4e01a050117fd fallback=fefea4e01411fd
-IC-705	config.py:get_usb_mod_level	(no arguments)	map=fefea4e01a050116fd fallback=fefea4e01410fd
-IC-705	config.py:set_civ_transceive	enabled=False	map=fefea4e01a05011200fd fallback=fefea4e01a05012900fd
-IC-705	config.py:set_data1_mod_input	source=0	map=fefea4e01a05011900fd fallback=fefea4e01a05009200fd
-IC-705	config.py:set_data_off_mod_input	source=0	map=fefea4e01a05011800fd fallback=fefea4e01a05009100fd
-IC-705	config.py:set_lan_mod_level	level=0	map=fefea4e01a0501170000fd fallback=fefea4e014110000fd
-IC-705	config.py:set_usb_mod_level	level=0	map=fefea4e01a0501160000fd fallback=fefea4e014100000fd
 IC-705	levels.py:get_dash_ratio	(no arguments)	map=fefea4e01a050252fd fallback=fefea4e01a050228fd
 IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=fefea4e01a050070fd
 IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a05025230fd fallback=fefea4e01a05022830fd
 IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a0500890000fd fallback=fefea4e01a0500700000fd
 IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
-IC-7300	config.py:get_acc1_mod_level	(no arguments)	map=fefe94e01a050064fd fallback=fefe94e0140bfd
-IC-7300	config.py:get_civ_output_ant	(no arguments)	map=fefe94e01a050061fd fallback=fefe94e01a050130fd
-IC-7300	config.py:get_civ_transceive	(no arguments)	map=fefe94e01a050071fd fallback=fefe94e01a050129fd
-IC-7300	config.py:get_data1_mod_input	(no arguments)	map=fefe94e01a050067fd fallback=fefe94e01a050092fd
-IC-7300	config.py:get_data_off_mod_input	(no arguments)	map=fefe94e01a050066fd fallback=fefe94e01a050091fd
-IC-7300	config.py:get_usb_mod_level	(no arguments)	map=fefe94e01a050065fd fallback=fefe94e01410fd
-IC-7300	config.py:set_acc1_mod_level	level=0	map=fefe94e01a0500640000fd fallback=fefe94e0140b0000fd
-IC-7300	config.py:set_civ_output_ant	enabled=False	map=fefe94e01a05006100fd fallback=fefe94e01a05013000fd
-IC-7300	config.py:set_civ_transceive	enabled=False	map=fefe94e01a05007100fd fallback=fefe94e01a05012900fd
-IC-7300	config.py:set_data1_mod_input	source=0	map=fefe94e01a05006700fd fallback=fefe94e01a05009200fd
-IC-7300	config.py:set_data_off_mod_input	source=0	map=fefe94e01a05006600fd fallback=fefe94e01a05009100fd
-IC-7300	config.py:set_usb_mod_level	level=0	map=fefe94e01a0500650000fd fallback=fefe94e014100000fd
 IC-7300	levels.py:get_dash_ratio	(no arguments)	map=fefe94e01a050161fd fallback=fefe94e01a050228fd
 IC-7300	levels.py:get_nb_depth	(no arguments)	map=fefe94e01a050189fd fallback=fefe94e01a050290fd
 IC-7300	levels.py:get_nb_width	(no arguments)	map=fefe94e01a050190fd fallback=fefe94e01a050291fd
@@ -43,28 +21,6 @@ IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a05019100fd fallback=fefe94
 IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7300	vfo.py:quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
-IC-7610	config.py:get_acc1_mod_level	(no arguments)	map=fefe98e01a050088fd fallback=fefe98e0140bfd
-IC-7610	config.py:get_civ_output_ant	(no arguments)	map=fefe98e01c04fd fallback=fefe98e01a050130fd
-IC-7610	config.py:get_civ_transceive	(no arguments)	map=fefe98e01a050112fd fallback=fefe98e01a050129fd
-IC-7610	config.py:get_lan_mod_level	(no arguments)	map=fefe98e01a050090fd fallback=fefe98e01411fd
-IC-7610	config.py:get_usb_mod_level	(no arguments)	map=fefe98e01a050089fd fallback=fefe98e01410fd
-IC-7610	config.py:set_acc1_mod_level	level=0	map=fefe98e01a0500880000fd fallback=fefe98e0140b0000fd
-IC-7610	config.py:set_civ_output_ant	enabled=False	map=fefe98e01c0400fd fallback=fefe98e01a05013000fd
-IC-7610	config.py:set_civ_transceive	enabled=False	map=fefe98e01a05011200fd fallback=fefe98e01a05012900fd
-IC-7610	config.py:set_lan_mod_level	level=0	map=fefe98e01a0500900000fd fallback=fefe98e014110000fd
-IC-7610	config.py:set_usb_mod_level	level=0	map=fefe98e01a0500890000fd fallback=fefe98e014100000fd
-IC-9700	config.py:get_acc1_mod_level	(no arguments)	map=fefea2e01a050112fd fallback=fefea2e0140bfd
-IC-9700	config.py:get_civ_transceive	(no arguments)	map=fefea2e01a050127fd fallback=fefea2e01a050129fd
-IC-9700	config.py:get_data1_mod_input	(no arguments)	map=fefea2e01a050116fd fallback=fefea2e01a050092fd
-IC-9700	config.py:get_data_off_mod_input	(no arguments)	map=fefea2e01a050115fd fallback=fefea2e01a050091fd
-IC-9700	config.py:get_lan_mod_level	(no arguments)	map=fefea2e01a050114fd fallback=fefea2e01411fd
-IC-9700	config.py:get_usb_mod_level	(no arguments)	map=fefea2e01a050113fd fallback=fefea2e01410fd
-IC-9700	config.py:set_acc1_mod_level	level=0	map=fefea2e01a0501120000fd fallback=fefea2e0140b0000fd
-IC-9700	config.py:set_civ_transceive	enabled=False	map=fefea2e01a05012700fd fallback=fefea2e01a05012900fd
-IC-9700	config.py:set_data1_mod_input	source=0	map=fefea2e01a05011600fd fallback=fefea2e01a05009200fd
-IC-9700	config.py:set_data_off_mod_input	source=0	map=fefea2e01a05011500fd fallback=fefea2e01a05009100fd
-IC-9700	config.py:set_lan_mod_level	level=0	map=fefea2e01a0501140000fd fallback=fefea2e014110000fd
-IC-9700	config.py:set_usb_mod_level	level=0	map=fefea2e01a0501130000fd fallback=fefea2e014100000fd
 IC-9700	levels.py:get_dash_ratio	(no arguments)	map=fefea2e01a050224fd fallback=fefea2e01a050228fd
 IC-9700	levels.py:get_ref_adjust	(no arguments)	map=fefea2e01a050072fd fallback=fefea2e01a050070fd
 IC-9700	levels.py:get_vox_delay	(no arguments)	map=fefea2e01a050330fd fallback=fefea2e01a050292fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -1,10 +1,17 @@
 # What tests/test_command_map_parity.py could NOT compare, and how
-# much it did. Tab separated, five row kinds:
-#   census    <name>              <count>
-#   cat-only  <profile>           <commands, every one of them CAT>
-#   gap       <command name>      <profiles whose map omits it>
-#   noargs    <module>:<builder>  no probe value was accepted
-#   unpinned  <module>:<builder>  no compared builder reaches it
+# much it did. Tab separated, six row kinds:
+#   census        <name>              <count>
+#   cat-only      <profile>           <commands, every one of them CAT>
+#   gap           <command name>      <profiles whose map omits it>
+#   noargs        <module>:<builder>  no probe value satisfied its OTHER
+#                                     required arguments (cmd_map still
+#                                     optional there -- a genuinely
+#                                     unsynthesisable case)
+#   requires-map  <module>:<builder>  cmd_map has no default (MOR-2006
+#                                     Steps 5..N migrated it) -- this
+#                                     file's cmd_map=None probe can never
+#                                     be accepted, whatever else is tried
+#   unpinned      <module>:<builder>  no compared builder reaches it
 # A 'gap' row means that profile's CommandMap holds no CI-V entry
 # for the command, so the cmd_map branch raises KeyError and there
 # is no frame to compare. Two causes land a command here: the rig
@@ -19,19 +26,18 @@
 # reachable from a builder that was compared, not sites observed to
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
-census	builders_compared	230
+census	builders_compared	212
 census	cat_only_profiles	2
-census	dual_implementation_sites	139
-census	frames_diverged	71
-census	frames_identical	1353
+census	dual_implementation_sites	133
+census	frames_diverged	27
+census	frames_identical	1345
 census	hardcode_only_builders	16
-census	profile_builder_map_gaps	998
+census	profile_builder_map_gaps	906
 census	profiles	8
 census	public_builders	232
-census	sites_compared	128
+census	sites_compared	122
 cat-only	FTX-1	108
 cat-only	TX-500	50
-gap	get_acc1_mod_level	FTX-1,IC-705,TX-500,X6100,X6200
 gap	get_af_level	FTX-1,TX-500
 gap	get_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_agc	FTX-1,TX-500,X6100
@@ -46,18 +52,12 @@ gap	get_auto_notch	FTX-1,TX-500,X6100,X6200
 gap	get_band_edge_freq	FTX-1,TX-500,X6100
 gap	get_break_in	FTX-1,TX-500,X6100,X6200
 gap	get_break_in_delay	FTX-1,TX-500,X6100,X6200
-gap	get_civ_output_ant	FTX-1,IC-705,IC-9700,TX-500,X6100,X6200
-gap	get_civ_transceive	FTX-1,TX-500,X6100,X6200
 gap	get_comp_meter	FTX-1,TX-500,X6100,X6200
 gap	get_compressor	FTX-1,TX-500,X6100,X6200
 gap	get_compressor_level	FTX-1,TX-500,X6100,X6200
 gap	get_cw_pitch	FTX-1,TX-500,X6100
 gap	get_dash_ratio	FTX-1,TX-500,X6100,X6200
-gap	get_data1_mod_input	FTX-1,TX-500,X6100,X6200
-gap	get_data2_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	get_data3_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_data_mode	FTX-1,TX-500,X6100,X6200
-gap	get_data_off_mod_input	FTX-1,TX-500,X6100,X6200
 gap	get_dial_lock	FTX-1,TX-500,X6100
 gap	get_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_digisel_shift	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
@@ -69,7 +69,6 @@ gap	get_freq	FTX-1,TX-500
 gap	get_id_meter	FTX-1,TX-500,X6100,X6200
 gap	get_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
 gap	get_key_speed	FTX-1,TX-500,X6100
-gap	get_lan_mod_level	FTX-1,IC-7300,TX-500,X6100,X6200
 gap	get_main_sub_band	FTX-1,IC-705,IC-7300,TX-500,X6100,X6200
 gap	get_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_manual_notch	FTX-1,TX-500,X6100,X6200
@@ -129,7 +128,6 @@ gap	get_tuner_status	FTX-1,TX-500,X6100
 gap	get_tuning_step	FTX-1,TX-500,X6100,X6200
 gap	get_twin_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	get_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
-gap	get_usb_mod_level	FTX-1,TX-500,X6100,X6200
 gap	get_various_squelch	FTX-1,TX-500,X6100,X6200
 gap	get_vd_meter	FTX-1,TX-500,X6100
 gap	get_vfo	FTX-1,TX-500,X6100
@@ -150,7 +148,6 @@ gap	scope_data_output	FTX-1,TX-500,X6100,X6200
 gap	scope_off	FTX-1,TX-500,X6100,X6200
 gap	scope_on	FTX-1,TX-500,X6100,X6200
 gap	send_cw	FTX-1,TX-500,X6100,X6200
-gap	set_acc1_mod_level	FTX-1,IC-705,TX-500,X6100,X6200
 gap	set_af_level	FTX-1,TX-500
 gap	set_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_agc	FTX-1,TX-500,X6100
@@ -163,17 +160,11 @@ gap	set_audio_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	set_auto_notch	FTX-1,TX-500,X6100,X6200
 gap	set_break_in	FTX-1,TX-500,X6100,X6200
 gap	set_break_in_delay	FTX-1,TX-500,X6100,X6200
-gap	set_civ_output_ant	FTX-1,IC-705,IC-9700,TX-500,X6100,X6200
-gap	set_civ_transceive	FTX-1,TX-500,X6100,X6200
 gap	set_compressor	FTX-1,TX-500,X6100,X6200
 gap	set_compressor_level	FTX-1,TX-500,X6100,X6200
 gap	set_cw_pitch	FTX-1,TX-500,X6100
 gap	set_dash_ratio	FTX-1,TX-500,X6100,X6200
-gap	set_data1_mod_input	FTX-1,TX-500,X6100,X6200
-gap	set_data2_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	set_data3_mod_input	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_data_mode	FTX-1,TX-500,X6100,X6200
-gap	set_data_off_mod_input	FTX-1,TX-500,X6100,X6200
 gap	set_dial_lock	FTX-1,TX-500,X6100
 gap	set_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_digisel_shift	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
@@ -184,7 +175,6 @@ gap	set_filter_width	FTX-1,TX-500,X6100,X6200
 gap	set_freq	FTX-1,TX-500
 gap	set_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
 gap	set_key_speed	FTX-1,TX-500,X6100
-gap	set_lan_mod_level	FTX-1,IC-7300,TX-500,X6100,X6200
 gap	set_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_manual_notch	FTX-1,TX-500,X6100,X6200
 gap	set_manual_notch_width	FTX-1,IC-705,TX-500,X6100,X6200
@@ -222,7 +212,6 @@ gap	set_tuner_status	FTX-1,TX-500,X6100
 gap	set_tuning_step	FTX-1,TX-500,X6100,X6200
 gap	set_twin_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	set_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
-gap	set_usb_mod_level	FTX-1,TX-500,X6100,X6200
 gap	set_vfo	FTX-1,TX-500,X6100
 gap	set_vox	FTX-1,TX-500,X6100,X6200
 gap	set_vox_delay	FTX-1,IC-705,TX-500,X6100,X6200
@@ -234,6 +223,24 @@ gap	system_time	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
 gap	utc_offset	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
 noargs	vfo.py:scan_set_df_span
 noargs	vfo.py:scan_set_resume
+requires-map	config.py:get_acc1_mod_level
+requires-map	config.py:get_civ_output_ant
+requires-map	config.py:get_civ_transceive
+requires-map	config.py:get_data1_mod_input
+requires-map	config.py:get_data2_mod_input
+requires-map	config.py:get_data3_mod_input
+requires-map	config.py:get_data_off_mod_input
+requires-map	config.py:get_lan_mod_level
+requires-map	config.py:get_usb_mod_level
+requires-map	config.py:set_acc1_mod_level
+requires-map	config.py:set_civ_output_ant
+requires-map	config.py:set_civ_transceive
+requires-map	config.py:set_data1_mod_input
+requires-map	config.py:set_data2_mod_input
+requires-map	config.py:set_data3_mod_input
+requires-map	config.py:set_data_off_mod_input
+requires-map	config.py:set_lan_mod_level
+requires-map	config.py:set_usb_mod_level
 unpinned	antenna.py:get_rx_antenna_ant2
 unpinned	antenna.py:set_rx_antenna_ant2
 unpinned	power.py:get_powerstat

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -106,7 +106,8 @@ _HARNESS_PARAMS = frozenset({"to_addr", "from_addr", "cmd_map"})
 _PROBE_ADDR = 0x94
 # Probe values, tried in order. The search that consumes them has no
 # per-builder branch: a builder no value satisfies is reported as a
-# ``noargs`` row, never given a bespoke argument here.
+# ``noargs`` (or, if its own ``cmd_map`` is required, ``requires-map``)
+# row, never given a bespoke argument here.
 _INTS = (0, 1, 2, 3, 5, 10, 18, 30, 50, 100, 255, 600, 1000, 2026)
 _FREQS = (14_074_000, 21_074_000)
 _FLOATS = (0.0, 88.5, 1000.0, 14_074_000.0)
@@ -301,6 +302,22 @@ def _values_for(fn: typing.Any, param: inspect.Parameter) -> tuple[typing.Any, .
     return ()
 
 
+def _requires_cmd_map(fn: typing.Any) -> bool:
+    """True if *fn*'s ``cmd_map`` parameter has no default.
+
+    A migrated builder (MOR-2006 Steps 5..N) can never accept this file's
+    ``cmd_map=None`` probe (`_accepts`), whatever value its other
+    parameters are given -- a purely structural fact about the signature,
+    independent of why any particular probe call failed. Used in `_cases`
+    to tell that population apart from a builder no probe value happens to
+    satisfy for an unrelated reason (e.g. `vfo.py: scan_set_df_span`,
+    still optional-`cmd_map`, whose own argument has no value in `_INTS`
+    that passes its validation).
+    """
+    param = inspect.signature(fn).parameters.get("cmd_map")
+    return param is not None and param.default is inspect.Parameter.empty
+
+
 def _split_params(
     fn: typing.Any,
 ) -> tuple[list[inspect.Parameter], list[inspect.Parameter]]:
@@ -356,7 +373,9 @@ def _format_case(kwargs: dict[str, typing.Any]) -> str:
 
 
 @functools.lru_cache(maxsize=1)
-def _cases() -> tuple[dict[Key, list[dict[str, typing.Any]]], frozenset[Key]]:
+def _cases() -> tuple[
+    dict[Key, list[dict[str, typing.Any]]], frozenset[Key], frozenset[Key]
+]:
     """Argument cases per builder, plus the builders none could be found for.
 
     The first case passes only required arguments; one further case per
@@ -369,16 +388,25 @@ def _cases() -> tuple[dict[Key, list[dict[str, typing.Any]]], frozenset[Key]]:
     every remaining optional argument the same way, on the same reasoning.
     Argument validation happens before a builder reads ``to_addr``, so
     this search runs once and its result is reused for every profile.
+
+    A builder with no accepted combination splits into two populations,
+    per ``_requires_cmd_map``: one whose ``cmd_map`` is required, so this
+    file's ``cmd_map=None`` probe can never be accepted regardless of any
+    other argument's value (MOR-2006 Steps 5..N — a fact about the
+    signature, not a failed search); and the genuine ``unsynthesisable``
+    case, where ``cmd_map`` is still optional and no value in the probe
+    ladders for its *other* required arguments satisfies its validation.
     """
     per_builder: dict[Key, list[dict[str, typing.Any]]] = {}
     unsynthesisable: set[Key] = set()
+    requires_map: set[Key] = set()
     for key, fn in _builders().items():
         required, optional = _split_params(fn)
         base = next(
             (kw for kw in _candidate_kwargs(fn, required) if _accepts(fn, kw)), None
         )
         if base is None:
-            unsynthesisable.add(key)
+            (requires_map if _requires_cmd_map(fn) else unsynthesisable).add(key)
             continue
         cases = [base]
         for param in optional:
@@ -390,7 +418,7 @@ def _cases() -> tuple[dict[Key, list[dict[str, typing.Any]]], frozenset[Key]]:
                     cases.append(probe)
                     break
         per_builder[key] = cases
-    return per_builder, frozenset(unsynthesisable)
+    return per_builder, frozenset(unsynthesisable), frozenset(requires_map)
 
 
 # ── the comparison ──
@@ -401,6 +429,7 @@ class _Report(typing.NamedTuple):
     map_gaps: dict[str, tuple[str, ...]]
     cat_only_profiles: dict[str, int]
     unsynthesisable: tuple[str, ...]
+    requires_map: tuple[str, ...]
     uncompared_sites: tuple[str, ...]
     census: dict[str, int]
 
@@ -424,7 +453,7 @@ def _cat_only_profiles(rigs: dict[str, typing.Any]) -> dict[str, int]:
 
 @functools.lru_cache(maxsize=1)
 def _report() -> _Report:
-    per_builder, unsynthesisable = _cases()
+    per_builder, unsynthesisable, requires_map = _cases()
     rigs = discover_rigs(RIGS_DIR)
     divergences: dict[tuple[str, str, str], str] = {}
     gaps: dict[str, set[str]] = defaultdict(set)
@@ -463,6 +492,7 @@ def _report() -> _Report:
         map_gaps={name: tuple(sorted(models)) for name, models in gaps.items()},
         cat_only_profiles=cat_only,
         unsynthesisable=tuple(sorted(f"{m}:{f}" for m, f in unsynthesisable)),
+        requires_map=tuple(sorted(f"{m}:{f}" for m, f in requires_map)),
         uncompared_sites=tuple(
             sorted(f"{m}:{f}" for m, f in _graph().sites - compared)
         ),
@@ -510,12 +540,19 @@ def _render_divergences(report: _Report) -> str:
 def _render_uncovered(report: _Report) -> str:
     header = [
         "# What tests/test_command_map_parity.py could NOT compare, and how",
-        "# much it did. Tab separated, five row kinds:",
-        "#   census    <name>              <count>",
-        "#   cat-only  <profile>           <commands, every one of them CAT>",
-        "#   gap       <command name>      <profiles whose map omits it>",
-        "#   noargs    <module>:<builder>  no probe value was accepted",
-        "#   unpinned  <module>:<builder>  no compared builder reaches it",
+        "# much it did. Tab separated, six row kinds:",
+        "#   census        <name>              <count>",
+        "#   cat-only      <profile>           <commands, every one of them CAT>",
+        "#   gap           <command name>      <profiles whose map omits it>",
+        "#   noargs        <module>:<builder>  no probe value satisfied its OTHER",
+        "#                                     required arguments (cmd_map still",
+        "#                                     optional there -- a genuinely",
+        "#                                     unsynthesisable case)",
+        "#   requires-map  <module>:<builder>  cmd_map has no default (MOR-2006",
+        "#                                     Steps 5..N migrated it) -- this",
+        "#                                     file's cmd_map=None probe can never",
+        "#                                     be accepted, whatever else is tried",
+        "#   unpinned      <module>:<builder>  no compared builder reaches it",
         "# A 'gap' row means that profile's CommandMap holds no CI-V entry",
         "# for the command, so the cmd_map branch raises KeyError and there",
         "# is no frame to compare. Two causes land a command here: the rig",
@@ -541,6 +578,7 @@ def _render_uncovered(report: _Report) -> str:
         for name, models in sorted(report.map_gaps.items())
     ]
     rows += [f"noargs\t{name}" for name in report.unsynthesisable]
+    rows += [f"requires-map\t{name}" for name in report.requires_map]
     rows += [f"unpinned\t{name}" for name in report.uncompared_sites]
     return "\n".join(header + rows) + "\n"
 
@@ -586,7 +624,8 @@ def test_allowlist_records_the_observed_frames(report: _Report) -> None:
 
 
 def test_uncovered_inventory_matches(report: _Report) -> None:
-    """Census, CAT-only profiles, map gaps, noargs builders, uncompared sites."""
+    """Census, CAT-only profiles, map gaps, noargs/requires-map builders,
+    uncompared sites."""
     rows = _read_rows(UNCOVERED_FILE)
     assert {r[1]: int(r[2]) for r in rows if r[0] == "census"} == report.census
     assert {r[1]: int(r[2]) for r in rows if r[0] == "cat-only"} == (
@@ -596,6 +635,7 @@ def test_uncovered_inventory_matches(report: _Report) -> None:
         report.map_gaps
     )
     assert tuple(r[1] for r in rows if r[0] == "noargs") == report.unsynthesisable
+    assert tuple(r[1] for r in rows if r[0] == "requires-map") == report.requires_map
     assert tuple(r[1] for r in rows if r[0] == "unpinned") == report.uncompared_sites
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,11 +1,13 @@
 """Tests for CI-V command encoding and decoding."""
 
 import inspect
+from pathlib import Path
 
 import pytest
 import rigplane.commands as raw_commands
 
 from rigplane import IC_7610_ADDR
+from rigplane.rig_loader import load_rig
 from rigplane.commands import (
     CONTROLLER_ADDR,
     build_civ_frame,
@@ -39,6 +41,8 @@ from rigplane.types import (
     SsbTxBandwidth,
 )
 from _command_test_helpers import bind_default_addr_globals, bind_default_addr_module
+
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
 
 _ORIGINAL_COMMANDS = {
     name: getattr(raw_commands, name) for name in raw_commands.__all__
@@ -2118,153 +2122,177 @@ class TestSystemConfigCommands:
         result = parse_bool_response(frame, command=0x12, sub=0x01)
         assert result is False
 
-    # --- Modulation Levels (0x14 0x0B / 0x10 / 0x11) ---
+    # --- Modulation Levels, Modulation Input Routing and CI-V Options ---
+    #
+    # commands/config.py migrated onto the bound command map in MOR-2006
+    # Steps 5..N (module 1): every builder here now requires ``cmd_map``,
+    # and the wire bytes it builds are whatever the profile declares (IC-7610
+    # extended menu addresses, per ``rigs/ic7610.toml``) rather than a
+    # hardcoded fallback -- so the expected frames below are pinned against
+    # the real IC-7610 map, not hand-typed CI-V literals, per MOR-2006's
+    # "prefer load_rig(...) maps over hand literals" convention.
 
-    def test_get_acc1_mod_level_frame(self) -> None:
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_get_acc1_mod_level_frame(self, cmd_map) -> None:
         from rigplane.commands import get_acc1_mod_level
 
-        frame = get_acc1_mod_level()
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x0b\xfd"
+        frame = get_acc1_mod_level(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_acc1_mod_level = [0x1A, 0x05, 0x00, 0x88]
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x88\xfd"
 
-    def test_set_acc1_mod_level_128(self) -> None:
+    def test_set_acc1_mod_level_128(self, cmd_map) -> None:
         from rigplane.commands import set_acc1_mod_level
 
-        frame = set_acc1_mod_level(128)
+        frame = set_acc1_mod_level(128, cmd_map=cmd_map)
         # 128 BCD-encoded: 0x01 0x28
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x0b\x01\x28\xfd"
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x88\x01\x28\xfd"
 
-    def test_set_acc1_mod_level_0(self) -> None:
+    def test_set_acc1_mod_level_0(self, cmd_map) -> None:
         from rigplane.commands import set_acc1_mod_level
 
-        frame = set_acc1_mod_level(0)
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x0b\x00\x00\xfd"
+        frame = set_acc1_mod_level(0, cmd_map=cmd_map)
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x88\x00\x00\xfd"
 
-    def test_set_acc1_mod_level_255(self) -> None:
+    def test_set_acc1_mod_level_255(self, cmd_map) -> None:
         from rigplane.commands import set_acc1_mod_level
 
-        frame = set_acc1_mod_level(255)
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x0b\x02\x55\xfd"
+        frame = set_acc1_mod_level(255, cmd_map=cmd_map)
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x88\x02\x55\xfd"
 
-    def test_set_acc1_mod_level_rejects_out_of_range(self) -> None:
+    def test_set_acc1_mod_level_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_acc1_mod_level
 
         with pytest.raises(ValueError, match="Level must be 0-255"):
-            set_acc1_mod_level(256)
+            set_acc1_mod_level(256, cmd_map=cmd_map)
 
-    def test_get_usb_mod_level_frame(self) -> None:
+    def test_get_acc1_mod_level_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import get_acc1_mod_level
+
+        with pytest.raises(TypeError, match="cmd_map"):
+            get_acc1_mod_level()  # type: ignore[call-arg]
+
+    def test_get_usb_mod_level_frame(self, cmd_map) -> None:
         from rigplane.commands import get_usb_mod_level
 
-        frame = get_usb_mod_level()
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x10\xfd"
+        frame = get_usb_mod_level(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_usb_mod_level = [0x1A, 0x05, 0x00, 0x89]
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x89\xfd"
 
-    def test_set_usb_mod_level_100(self) -> None:
+    def test_set_usb_mod_level_100(self, cmd_map) -> None:
         from rigplane.commands import set_usb_mod_level
 
-        frame = set_usb_mod_level(100)
+        frame = set_usb_mod_level(100, cmd_map=cmd_map)
         # 100 BCD-encoded: 0x01 0x00
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x10\x01\x00\xfd"
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x89\x01\x00\xfd"
 
-    def test_get_lan_mod_level_frame(self) -> None:
+    def test_get_lan_mod_level_frame(self, cmd_map) -> None:
         from rigplane.commands import get_lan_mod_level
 
-        frame = get_lan_mod_level()
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x11\xfd"
+        frame = get_lan_mod_level(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_lan_mod_level = [0x1A, 0x05, 0x00, 0x90]
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x90\xfd"
 
-    def test_set_lan_mod_level_50(self) -> None:
+    def test_set_lan_mod_level_50(self, cmd_map) -> None:
         from rigplane.commands import set_lan_mod_level
 
-        frame = set_lan_mod_level(50)
+        frame = set_lan_mod_level(50, cmd_map=cmd_map)
         # 50 BCD-encoded: 0x00 0x50
-        assert frame == b"\xfe\xfe\x98\xe0\x14\x11\x00\x50\xfd"
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x90\x00\x50\xfd"
 
     def test_parse_mod_level_response(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_level_response
 
-        # ACC1 mod level = 128 (0x01 0x28)
-        civ = b"\xfe\xfe\xe0\x98\x14\x0b\x01\x28\xfd"
+        # ACC1 mod level = 128 (0x01 0x28) at the IC-7610 extended address.
+        civ = b"\xfe\xfe\xe0\x98\x1a\x05\x00\x88\x01\x28\xfd"
         frame = parse_civ_frame(civ)
-        level = parse_level_response(frame, command=0x14, sub=0x0B)
+        level = parse_level_response(frame, command=0x1A, sub=0x05, prefix=b"\x00\x88")
         assert level == 128
 
-    # --- Modulation Input Routing (0x1A 0x05 0x00 0x91-0x94) ---
-
-    def test_get_data_off_mod_input_frame(self) -> None:
+    def test_get_data_off_mod_input_frame(self, cmd_map) -> None:
         from rigplane.commands import get_data_off_mod_input
 
-        frame = get_data_off_mod_input()
-        # FE FE 98 E0 1A 05 00 91 FD
+        frame = get_data_off_mod_input(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_data_off_mod_input = [0x1A, 0x05, 0x00, 0x91]
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x91\xfd"
 
-    def test_set_data_off_mod_input_mic(self) -> None:
+    def test_set_data_off_mod_input_mic(self, cmd_map) -> None:
         from rigplane.commands import set_data_off_mod_input
 
-        frame = set_data_off_mod_input(0)  # MIC
+        frame = set_data_off_mod_input(0, cmd_map=cmd_map)  # MIC
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x91\x00\xfd"
 
-    def test_set_data_off_mod_input_lan(self) -> None:
+    def test_set_data_off_mod_input_lan(self, cmd_map) -> None:
         from rigplane.commands import set_data_off_mod_input
 
-        frame = set_data_off_mod_input(5)  # LAN
+        frame = set_data_off_mod_input(5, cmd_map=cmd_map)  # LAN
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x91\x05\xfd"
 
-    def test_set_data_off_mod_input_rejects_out_of_range(self) -> None:
+    def test_set_data_off_mod_input_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_data_off_mod_input
 
         with pytest.raises(ValueError, match="0-5"):
-            set_data_off_mod_input(6)
+            set_data_off_mod_input(6, cmd_map=cmd_map)
 
-    def test_get_data1_mod_input_frame(self) -> None:
+    def test_get_data1_mod_input_frame(self, cmd_map) -> None:
         from rigplane.commands import get_data1_mod_input
 
-        frame = get_data1_mod_input()
+        frame = get_data1_mod_input(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_data1_mod_input = [0x1A, 0x05, 0x00, 0x92]
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x92\xfd"
 
-    def test_set_data1_mod_input_lan(self) -> None:
+    def test_set_data1_mod_input_lan(self, cmd_map) -> None:
         from rigplane.commands import set_data1_mod_input
 
-        frame = set_data1_mod_input(5)  # LAN
+        frame = set_data1_mod_input(5, cmd_map=cmd_map)  # LAN
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x92\x05\xfd"
 
-    def test_set_data1_mod_input_rejects_out_of_range(self) -> None:
+    def test_set_data1_mod_input_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_data1_mod_input
 
         with pytest.raises(ValueError, match="0-5"):
-            set_data1_mod_input(6)
+            set_data1_mod_input(6, cmd_map=cmd_map)
 
-    def test_get_data2_mod_input_frame(self) -> None:
+    def test_get_data2_mod_input_frame(self, cmd_map) -> None:
         from rigplane.commands import get_data2_mod_input
 
-        frame = get_data2_mod_input()
+        frame = get_data2_mod_input(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_data2_mod_input = [0x1A, 0x05, 0x00, 0x93]
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x93\xfd"
 
-    def test_set_data2_mod_input_lan(self) -> None:
+    def test_set_data2_mod_input_lan(self, cmd_map) -> None:
         from rigplane.commands import set_data2_mod_input
 
-        frame = set_data2_mod_input(5)
+        frame = set_data2_mod_input(5, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x93\x05\xfd"
 
-    def test_get_data3_mod_input_frame(self) -> None:
+    def test_get_data3_mod_input_frame(self, cmd_map) -> None:
         from rigplane.commands import get_data3_mod_input
 
-        frame = get_data3_mod_input()
+        frame = get_data3_mod_input(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_data3_mod_input = [0x1A, 0x05, 0x00, 0x94]
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x94\xfd"
 
-    def test_set_data3_mod_input_lan(self) -> None:
+    def test_set_data3_mod_input_lan(self, cmd_map) -> None:
         from rigplane.commands import set_data3_mod_input
 
-        frame = set_data3_mod_input(5)
+        frame = set_data3_mod_input(5, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x94\x05\xfd"
 
-    def test_set_data3_mod_input_lan_usb(self) -> None:
+    def test_set_data3_mod_input_lan_usb(self, cmd_map) -> None:
         from rigplane.commands import set_data3_mod_input
 
-        frame = set_data3_mod_input(4)  # LAN+USB
+        frame = set_data3_mod_input(4, cmd_map=cmd_map)  # LAN+USB
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x94\x04\xfd"
 
     def test_parse_mod_input_response(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_level_response
 
-        # Data Off mod input = 3 (USB)
+        # Data Off mod input = 3 (USB) at the IC-7610 extended address.
         civ = b"\xfe\xfe\xe0\x98\x1a\x05\x00\x91\x03\xfd"
         frame = parse_civ_frame(civ)
         source = parse_level_response(
@@ -2272,53 +2300,55 @@ class TestSystemConfigCommands:
         )
         assert source == 3
 
-    # --- CI-V Options (0x1A 0x05 0x01 0x29 / 0x30) ---
-
-    def test_get_civ_transceive_frame(self) -> None:
+    def test_get_civ_transceive_frame(self, cmd_map) -> None:
         from rigplane.commands import get_civ_transceive
 
-        frame = get_civ_transceive()
-        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x29\xfd"
+        frame = get_civ_transceive(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_civ_transceive = [0x1A, 0x05, 0x01, 0x12]
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x12\xfd"
 
-    def test_set_civ_transceive_on(self) -> None:
+    def test_set_civ_transceive_on(self, cmd_map) -> None:
         from rigplane.commands import set_civ_transceive
 
-        frame = set_civ_transceive(True)
-        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x29\x01\xfd"
+        frame = set_civ_transceive(True, cmd_map=cmd_map)
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x12\x01\xfd"
 
-    def test_set_civ_transceive_off(self) -> None:
+    def test_set_civ_transceive_off(self, cmd_map) -> None:
         from rigplane.commands import set_civ_transceive
 
-        frame = set_civ_transceive(False)
-        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x29\x00\xfd"
+        frame = set_civ_transceive(False, cmd_map=cmd_map)
+        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x12\x00\xfd"
 
-    def test_get_civ_output_ant_frame(self) -> None:
+    def test_get_civ_output_ant_frame(self, cmd_map) -> None:
         from rigplane.commands import get_civ_output_ant
 
-        frame = get_civ_output_ant()
-        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x30\xfd"
+        frame = get_civ_output_ant(cmd_map=cmd_map)
+        # rigs/ic7610.toml: get_civ_output_ant = [0x1C, 0x04] -- a different
+        # CI-V command family entirely, not another 0x1A 0x05 menu address.
+        assert frame == b"\xfe\xfe\x98\xe0\x1c\x04\xfd"
 
-    def test_set_civ_output_ant_on(self) -> None:
+    def test_set_civ_output_ant_on(self, cmd_map) -> None:
         from rigplane.commands import set_civ_output_ant
 
-        frame = set_civ_output_ant(True)
-        assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x30\x01\xfd"
+        frame = set_civ_output_ant(True, cmd_map=cmd_map)
+        assert frame == b"\xfe\xfe\x98\xe0\x1c\x04\x01\xfd"
 
     def test_parse_civ_bool_response(self) -> None:
         from rigplane.commands import parse_bool_response, parse_civ_frame
 
-        # CI-V transceive = ON
-        civ = b"\xfe\xfe\xe0\x98\x1a\x05\x01\x29\x01\xfd"
+        # CI-V transceive = ON at the IC-7610 extended address.
+        civ = b"\xfe\xfe\xe0\x98\x1a\x05\x01\x12\x01\xfd"
         frame = parse_civ_frame(civ)
-        result = parse_bool_response(frame, command=0x1A, sub=0x05, prefix=b"\x01\x29")
+        result = parse_bool_response(frame, command=0x1A, sub=0x05, prefix=b"\x01\x12")
         assert result is True
 
     def test_parse_civ_output_ant_off_response(self) -> None:
         from rigplane.commands import parse_bool_response, parse_civ_frame
 
-        civ = b"\xfe\xfe\xe0\x98\x1a\x05\x01\x30\x00\xfd"
+        # IC-7610's get_civ_output_ant is plain 0x1C 0x04, no data prefix.
+        civ = b"\xfe\xfe\xe0\x98\x1c\x04\x00\xfd"
         frame = parse_civ_frame(civ)
-        result = parse_bool_response(frame, command=0x1A, sub=0x05, prefix=b"\x01\x30")
+        result = parse_bool_response(frame, command=0x1C, sub=0x04)
         assert result is False
 
     # --- System Date (0x1A 0x05 0x01 0x58) ---

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2173,8 +2173,20 @@ class TestSystemConfigCommands:
         """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
         from rigplane.commands import get_acc1_mod_level
 
-        with pytest.raises(TypeError, match="cmd_map"):
+        with pytest.raises(TypeError, match="MOR-2006"):
             get_acc1_mod_level()  # type: ignore[call-arg]
+
+    def test_get_acc1_mod_level_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely -- not a bare ``AttributeError`` from
+        ``_build_from_map``'s ``None.get(name)``, the exact path
+        de-delegating from the shared ``_build_ctl_mem_get``/
+        ``_build_ctl_mem_set`` templates (this migration's rationale)
+        would otherwise reopen."""
+        from rigplane.commands import get_acc1_mod_level
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_acc1_mod_level(cmd_map=None)
 
     def test_get_usb_mod_level_frame(self, cmd_map) -> None:
         from rigplane.commands import get_usb_mod_level

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -34,6 +34,7 @@ profile's map, plain or empty.
 from __future__ import annotations
 
 import functools
+import inspect
 import pathlib
 import sys
 from typing import Any
@@ -288,9 +289,29 @@ class TestExposedKeyDriftGuard:
         set_data_off_mod_input``'s ``0 <= source <= 5``) is what is being
         satisfied here, never a real map lookup -- the probe *cmd_map*'s
         contents never matter to this search, only its type.
+
+        Synthesises against ``inspect.unwrap(builder)``, not *builder*
+        itself -- a full-suite-only failure (18 deterministic failures,
+        standalone file green) traced to this: when one of the five files
+        that rebind the shared ``rigplane.commands`` namespace into
+        ``functools.partial`` objects (``bind_default_addr_module``, this
+        class's docstring) collects first, ``_exposed_builders`` enumerates
+        a partial, not the raw function. Its ``inspect.signature`` is
+        identical to the raw function's (verified directly), so
+        ``_split_params`` is unaffected -- but ``functools.partial`` has no
+        ``__globals__`` (``update_wrapper`` never copies it), so
+        ``_values_for``'s ``eval(param.annotation, fn.__globals__)`` raises,
+        its bare ``except Exception: return ()`` turns that into an empty
+        probe ladder for every required parameter, and
+        ``_candidate_kwargs`` yields nothing at all -- the loop below never
+        calls *builder* even once. ``inspect.unwrap`` follows the
+        ``__wrapped__`` chain ``update_wrapper`` sets, however many
+        collected files stacked a layer each, back to a function with a
+        real ``__globals__``.
         """
-        required, _optional = _split_params(builder)
-        for kwargs in _candidate_kwargs(builder, required):
+        target = inspect.unwrap(builder)
+        required, _optional = _split_params(target)
+        for kwargs in _candidate_kwargs(target, required):
             try:
                 builder(to_addr=0x94, cmd_map=cmd_map, **kwargs)
             except Exception:

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -48,6 +48,11 @@ from rigplane.commands.command_map import CommandMap
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.runtime.radio import CoreRadio
 
+# Reused rather than re-implemented, per the MOR-2006 drift-guard extension:
+# the same probe-ladder search test_command_map_parity.py uses to find a
+# builder's required arguments (see TestExposedKeyDriftGuard below).
+from test_command_map_parity import _candidate_kwargs, _split_params
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 RIGS_DIR = REPO_ROOT / "rigs"
 
@@ -221,8 +226,20 @@ def _exposed_builders() -> list[tuple[str, Any]]:
     shares the object because it shares the underlying function; two
     distinct builders never do, even if their keys happen to return the
     same literal).
+
+    Deduplicated on ``(id(key_fn), qualname)``, not ``id(key_fn)`` alone
+    (a Step 3/4 review trap recorded against MOR-2006): bare ``id``
+    dedup goes false-green the moment two *distinct* builders ever end up
+    sharing one ``cmd_map_key`` callable object -- e.g. a shared, named key
+    function (unlike each builder's own one-off ``lambda``) passed to
+    ``@expose_command_key`` on two different functions by mistake -- because
+    the second builder found would be silently skipped as "the same
+    alias" and never exercised below. The alias case this function must
+    still collapse (``speech = get_speech``) keeps working: both names
+    resolve to the same underlying function, so they share both ``id``
+    and ``qualname``. Two genuinely different builders share neither.
     """
-    seen: set[int] = set()
+    seen: set[tuple[int, str]] = set()
     found: list[tuple[str, Any]] = []
     for name in commands.__all__:
         value = getattr(commands, name, None)
@@ -231,7 +248,7 @@ def _exposed_builders() -> list[tuple[str, Any]]:
         key_fn = getattr(value, "cmd_map_key", None)
         if key_fn is None:
             continue
-        identity = id(key_fn)
+        identity = (id(key_fn), getattr(value, "__qualname__", name))
         if identity in seen:
             continue
         seen.add(identity)
@@ -248,7 +265,41 @@ class TestExposedKeyDriftGuard:
     ``cmd_map_key(cmd_map)``. Two probe maps exercise both branches of
     ``get_speech``'s per-map probe; the other exposed builders (ptt_on,
     ptt_off) ignore the map and must produce the same literal for both.
+
+    A fixed call shape of ``builder(to_addr=..., cmd_map=...)`` was the
+    original design here, and it broke the moment MOR-2006 exposed
+    ``commands/config.py``'s nine setters, each with a required value
+    argument (``level``, ``source`` or ``enabled``): every one of them
+    raised ``missing 1 required positional argument`` before
+    ``_build_from_map`` was ever reached, so the drift guard never ran the
+    check it exists for. ``_synthesize_case`` below finds a value that
+    argument accepts, reusing ``tests/test_command_map_parity.py``'s own
+    probe-ladder search (``_split_params``/``_candidate_kwargs``) rather
+    than re-implementing it -- ``to_addr``/``from_addr``/``cmd_map`` are
+    supplied by the harness, so those never need synthesising here.
     """
+
+    @staticmethod
+    def _synthesize_case(builder: Any, cmd_map: CommandMap) -> dict[str, Any]:
+        """First argument combination *builder* accepts, beyond the harness.
+
+        Probed with ``_build_from_map`` already faked out (see the caller),
+        so a builder's own validation (e.g. ``config.py:
+        set_data_off_mod_input``'s ``0 <= source <= 5``) is what is being
+        satisfied here, never a real map lookup -- the probe *cmd_map*'s
+        contents never matter to this search, only its type.
+        """
+        required, _optional = _split_params(builder)
+        for kwargs in _candidate_kwargs(builder, required):
+            try:
+                builder(to_addr=0x94, cmd_map=cmd_map, **kwargs)
+            except Exception:
+                continue
+            return kwargs
+        raise AssertionError(
+            f"{builder.__qualname__}: no synthesized argument combination was "
+            "accepted, even with _build_from_map faked out"
+        )
 
     @pytest.mark.parametrize(
         "cmd_map", _PROBE_MAPS, ids=["empty_map", "set_speech_map"]
@@ -279,7 +330,8 @@ class TestExposedKeyDriftGuard:
         # dotted-string lookup would otherwise walk through.
         defining_module = sys.modules[builder.__module__]
         monkeypatch.setattr(defining_module, "_build_from_map", _fake_build_from_map)
-        builder(to_addr=0x94, cmd_map=cmd_map)
+        case_kwargs = self._synthesize_case(builder, cmd_map)
+        builder(to_addr=0x94, cmd_map=cmd_map, **case_kwargs)
         assert "key" in captured, (
             f"{builder.__qualname__} did not call _build_from_map with cmd_map set"
         )

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -1,0 +1,134 @@
+"""The keystone test for MOR-2006 Steps 5..N of
+``docs/plans/2026-08-29-profile-driven-command-bytes.md`` (§4, §6, §7).
+
+Plan §7: "the dangerous half is requests moved, replies not: reads fail on
+the 46 class-A rows and keep working everywhere else, which looks like an
+intermittent radio rather than a bug." A getter whose request now goes
+through the profile's own map but whose reply matcher still expects the
+old, hardcoded command/sub bytes silently mismatches on exactly the
+commands this migration fixes, and nowhere else.
+
+This test makes that state impossible to ship. For every CI-V profile and
+every matcher-backed getter registered in ``MATCHER_BACKED_GETTERS`` below,
+it captures the ``(command, sub, prefix)`` ``runtime/radio.py: CoreRadio``
+actually hands to ``_get_bcd_level``/``_get_bool_value`` when parsing a
+reply, and compares it against the shape independently derived from the
+same profile's ``CommandMap`` entry via
+``commands/_frame.py: decode_wire_tuple`` -- the same decoder
+``commands/bound.py: BoundCommands.expect`` and the request-building
+``_build_from_map`` both resolve through. The two must always agree.
+
+No transport, connection or event I/O is needed for any radio backend:
+``_get_bcd_level``/``_get_bool_value`` are monkeypatched at the class level
+to record their keyword arguments and return a dummy value immediately,
+short-circuiting before either method would touch a socket.
+
+Written to extend, not to be rewritten: add a ``_GetterSpec`` to
+``MATCHER_BACKED_GETTERS`` (§6 population 1) as later modules migrate, and
+this file exercises it against every CI-V profile automatically.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from rigplane.commands._frame import decode_wire_tuple
+from rigplane.runtime.radio import CoreRadio
+
+from test_profile_command_binding import _civ_rig_configs
+
+
+@dataclasses.dataclass(frozen=True)
+class _GetterSpec:
+    """One matcher-backed getter.
+
+    ``method`` is both the ``CoreRadio`` method name and the ``CommandMap``
+    key it resolves -- true for every getter registered so far because
+    each one's builder exposes a literal key equal to its own name (the
+    first case in plan §3.1's four-way classification of how a builder
+    exposes its command-map key; none of config.py's getters is the
+    fourth case, ``commands/speech.py: get_speech``, whose key is a
+    function of the map). ``parser`` is the ``CoreRadio`` method the
+    getter parses its reply through -- ``_get_bcd_level`` for a BCD level
+    or index, ``_get_bool_value`` for a boolean.
+    """
+
+    method: str
+    parser: str
+
+
+# commands/config.py's matcher-backed getters (MOR-2006 Steps 5..N, module
+# 1). Extend this tuple module by module as later steps migrate their own
+# getters -- everything below runs for every entry, against every CI-V
+# profile, with no further change required.
+MATCHER_BACKED_GETTERS: tuple[_GetterSpec, ...] = (
+    _GetterSpec("get_acc1_mod_level", "_get_bcd_level"),
+    _GetterSpec("get_usb_mod_level", "_get_bcd_level"),
+    _GetterSpec("get_lan_mod_level", "_get_bcd_level"),
+    _GetterSpec("get_data_off_mod_input", "_get_bcd_level"),
+    _GetterSpec("get_data1_mod_input", "_get_bcd_level"),
+    _GetterSpec("get_data2_mod_input", "_get_bcd_level"),
+    _GetterSpec("get_data3_mod_input", "_get_bcd_level"),
+    _GetterSpec("get_civ_transceive", "_get_bool_value"),
+    _GetterSpec("get_civ_output_ant", "_get_bool_value"),
+)
+
+
+def _cases() -> list[tuple[str, _GetterSpec]]:
+    return [
+        (model, spec)
+        for model in sorted(_civ_rig_configs())
+        for spec in MATCHER_BACKED_GETTERS
+    ]
+
+
+def _case_id(case: tuple[str, _GetterSpec]) -> str:
+    model, spec = case
+    return f"{model}-{spec.method}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", _cases(), ids=[_case_id(c) for c in _cases()])
+async def test_reply_shape_matches_request_shape(
+    case: tuple[str, _GetterSpec], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model, spec = case
+    config = _civ_rig_configs()[model]
+    profile = config.to_profile()
+    cmd_map = profile.command_map
+    assert cmd_map is not None, f"{model}: to_profile() produced no command_map"
+    if not cmd_map.has(spec.method):
+        pytest.skip(f"{model} does not declare {spec.method}")
+
+    expected_shape = decode_wire_tuple(cmd_map.get(spec.method))
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_parser(
+        self: CoreRadio,
+        civ: bytes,
+        *,
+        key: str,
+        command: int,
+        sub: int | None,
+        prefix: bytes = b"",
+        **kwargs: Any,
+    ) -> Any:
+        captured["shape"] = (command, sub, prefix)
+        return 0
+
+    monkeypatch.setattr(CoreRadio, spec.parser, _fake_parser)
+    radio = CoreRadio("198.51.100.1", profile=profile)
+    await getattr(radio, spec.method)()
+
+    assert "shape" in captured, (
+        f"{model}:{spec.method} never reached CoreRadio.{spec.parser}"
+    )
+    assert captured["shape"] == expected_shape, (
+        f"{model}:{spec.method} parsed its reply against {captured['shape']}, "
+        f"but the request the same call built goes to {expected_shape} -- "
+        "the reply matcher was not migrated with the request."
+    )

--- a/tests/test_undeclared_command_policy.py
+++ b/tests/test_undeclared_command_policy.py
@@ -199,3 +199,33 @@ class TestCoreRadioWiring:
         assert radio._commands.get_freq(to_addr=0x94) == get_freq(  # noqa: SLF001
             to_addr=0x94, cmd_map=profile.command_map
         )
+
+    @pytest.mark.asyncio
+    async def test_migrated_getter_refuses_through_expect_shape(self) -> None:
+        """MOR-2006: a config.py getter's reply-shape lookup refuses too.
+
+        ``runtime/radio.py: CoreRadio.get_lan_mod_level`` calls
+        ``self._expect_shape(get_lan_mod_level)`` (-> ``self._commands.
+        expect``) before it ever builds or sends a frame. When this test
+        was first written, IC-7300 declared no ``get_lan_mod_level`` entry
+        and did not record it absent either -- state 3. MOR-2014 (D2) has
+        since declared it absent (no LAN hardware on this radio; no LAN
+        row anywhere in the Advanced Manual's command table) -- state 2
+        now, same refusal shape, still previously unpinned at the public
+        async-method level (every other case in this file calls
+        ``radio._commands.<builder>`` directly). This one calls the public
+        method itself, which ``tests/test_response_shape_from_profile.py``
+        (the keystone) deliberately never does -- it skips a profile/getter
+        pair the map omits rather than asserting a refusal.
+        """
+        profile = self._ic7300_profile()
+        assert "get_lan_mod_level" not in profile.command_names
+        assert "get_lan_mod_level" in profile.absent_command_names, (
+            "fixture assumption: MOR-2014 (D2) declared IC-7300's "
+            "get_lan_mod_level absent -- if a later D2 pass instead fills "
+            "it with real bytes, this test needs a different undeclared "
+            "config.py getter/profile pair"
+        )
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.get_lan_mod_level()


### PR DESCRIPTION
## Summary

First module migration of Steps 5..N, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4:

> Steps 5..N — Migrate module by module, requests and replies together. One domain module per PR. For each: (a) make `cmd_map` required keyword-only and delete the fallback branch and the constants it alone read; (b) move that module's call sites in `runtime/radio.py`, `runtime/_scope_runtime.py`, `runtime/_dual_rx_runtime.py`, `backends/_icom_serial_base.py` onto the binder; (c) move that module's response matchers **in the same commit**.

> 1. `config.py` — 44 of the 76 divergence rows, and the module that carries the ACC1/MIC collision and `set_data_off_mod_input`, which `runtime/profiles_runtime.py: apply_profile` writes with no user action.

`levels.py` is untouched — that is the next PR.

## Guardrail exception (owner-granted, in-session, before merge)

This PR crosses **both** hard-ceiling dimensions in `CLAUDE.md` §Guardrails: **11 files / 1148 changed lines** against 10 files / 1000 lines (1148, not 1140 — see "Rebase onto origin/main" below for the +8). The owner granted an explicit exception in-session on 2026-08-30, before merge, treating the PR as one unit of work; precedents cited: #2806, #2820. The grant is recorded as a comment on this PR.

The growth is entirely review-required correction, not scope creep: the PR landed its first review at **9 files / 992 changed lines** (under both ceilings), and an independent review returned BLOCKED with four findings, all fixed on this same branch (+169/−57 across 6 files, two of them newly touched, at the review-fix commit before the rebase below added a further +8/−0):

| Finding | Files touched | Δ lines | Why it couldn't be a separate PR |
|---|---|---|---|
| 1. Drift-guard collection-order bug (18 deterministic full-suite failures) | `tests/test_profile_command_binding.py` | +23/−2 | Bug in code this PR introduces (`_synthesize_case`); leaving it broken fails CI on this branch |
| 2. D1 refusal now live but unpinned | `tests/test_undeclared_command_policy.py` (new to this PR) | +22/−0 (+8 more after the rebase below, +30/−0 total) | Missing test for behaviour this PR's migration newly introduces (`CoreRadio.get_lan_mod_level` now reaches `BoundCommands.expect`) |
| 3. `require_cmd_map` explicit `None` bypassed Q6 | `src/rigplane/commands/_frame.py`, `tests/test_commands.py` | +28/−18, +13/−1 | Bug in code this PR introduces (`require_cmd_map`); the exact path the PR's own de-delegation rationale names |
| 4. `noargs` census bucket conflated two causes | `tests/test_command_map_parity.py` (new to this PR), `tests/command_map_parity_uncovered.txt` | +52/−12, +31/−24 | Requested "while touching the regen anyway" for the next module's reviewer; the regen this PR already carries is what made the request cheap here |

The four fixes are additive on top of the same 9 files plus the two new ones. Full mechanism narrative for finding 1 (a `functools.partial`-with-no-`__globals__` bug, not a signature-view difference) is under "Review-fix round" below, kept prominent per the coordinator's request. The +8 lines on top of that (finding 2's file) came from rebasing onto two merged D2 PRs, not from new scope — see the next section.

## Rebase onto origin/main (`a724e7f7`)

While this PR was in review, `#2826` (MOR-2014, IC-7300 D2) and `#2829` (MOR-2015, IC-9700 D2) merged to `main`, both regenerating the same two files this PR regenerates (`tests/command_map_parity_divergences.txt`, `tests/command_map_parity_uncovered.txt`) with corrected/filled IC-7300 and IC-9700 byte data — several of the filled/corrected keys are config.py commands this PR's migration also touches (`get_lan_mod_level`, `data2_mod_input`, `data3_mod_input`, `civ_output_ant`). Rebased onto `origin/main` (`a724e7f7`); the rebase conflicted only in the two generated parity files (everything else — `docs/CHANGELOG.md`, `src/rigplane/commands/_frame.py`, `src/rigplane/commands/config.py`, `src/rigplane/runtime/radio.py`, `tests/test_commands.py`, `tests/test_profile_command_binding.py`, `tests/test_response_shape_from_profile.py` — auto-merged cleanly; `tests/test_undeclared_command_policy.py`'s two independent edits, mine and #2826's, also auto-merged as non-overlapping hunks). Per instruction, the two conflicted files were **not hand-merged**: resolved with a placeholder during the rebase, then `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py` re-ran on the fully rebased tree to produce their real, final content.

**One real (non-generated) conflict surfaced after regeneration, not as a git conflict but as a stale test assumption**: `#2826` declared IC-7300's `get_lan_mod_level` absent (no LAN hardware; no LAN row in the Advanced Manual's command table) — the same key finding 2's new test (`test_migrated_getter_refuses_through_expect_shape`) targeted as a D1 **state-3** case (neither declared nor declared absent). Git's line-level merge didn't (and couldn't) know these two edits touched the same *fact*, only that they touched different lines, so it merged them silently; running the test caught it. Updated the test to assert **state 2** (declared absent) instead, since that is now IC-7300's true state for this key, added a fixture-assumption guard that fails loudly (rather than silently passing on a stale premise) if a future D2 pass fills it with real bytes instead, and confirmed `"not supported by this radio"` still matches — that wording is shared by both D1 states 2 and 3 in `BoundCommands._refusal_for`, so the property finding 2 actually pins (a migrated getter's `_expect_shape` call refuses through the real public async method, previously untested at that level) is unaffected by which state IC-7300 is now in.

**Combined arithmetic — this PR's own delta is identical before and after the rebase; only the baseline it's applied to moved:**

| Census field | Old baseline (`ba8472db`) | This PR's Δ | Old head | New baseline (`a724e7f7`) | This PR's Δ (unchanged) | New head |
|---|---|---|---|---|---|---|
| `dual_implementation_sites` | 139 | −6 | 133 | 139 | −6 | 133 |
| `sites_compared` | 126 | −6 | 120 | 128 (+2 from D2) | −6 | 122 |
| `builders_compared` | 230 | −18 | 212 | 230 (unchanged by D2) | −18 | 212 |
| `frames_diverged` | 66 | −44 | 22 | 71 (+5 from D2) | −44 | 27 |
| `frames_identical` | 1350 | −8 | 1342 | 1353 (+3 from D2) | −8 | 1345 |
| `profile_builder_map_gaps` | 1006 | −92 | 914 | 998 (−8 from D2) | −92 | 906 |
| `public_builders` | 232 | 0 | 232 | 232 | 0 | 232 |
| `hardcode_only_builders` | 16 | 0 | 16 | 16 | 0 | 16 |

Every "This PR's Δ" column is byte-identical before and after — confirmed by regenerating on the rebased tree and diffing, not assumed. The divergence file's row *count* for config.py is also unchanged (44 deleted, both before and after the rebase) even though several IC-9700 rows' actual byte values changed underneath (D2 corrected IC-9700's copied-from-IC-7300 addresses to its own guide's addresses) — a row disappearing because config.py stopped having two implementations to disagree doesn't care what either implementation's bytes were. The 18 `gap`→`requires-map` reclassification (finding 4) is completely unaffected by the rebase for a structural reason: `_requires_cmd_map` is a pure signature check on the builder (`cmd_map` has no default), independent of any profile's TOML content — confirmed the same 18 names, 0 others, both before and after.

## Migration contract, fulfilled per plan §4

**(a) `cmd_map` required, fallback deleted.** All 18 public builders in `commands/config.py` now take `cmd_map: CommandMap` as a required keyword-only argument (no default). The six builders that had their own inline `if cmd_map is not None: ... / return build_civ_frame(...)` branch (the mod-level get/set trio) had it deleted outright. The other twelve (mod-input get/set × 4, CI-V option get/set × 2) previously delegated to the *shared* `_builders.py: _build_ctl_mem_get`/`_build_ctl_mem_set` templates, which still carry their own optional-`cmd_map` fallback for `levels.py` and `system.py` (unmigrated) — deleting that fallback now would break those modules' *only* working path today, since "not one production caller passes cmd_map=" per the plan's own measurement. So config.py's twelve stopped calling the shared templates altogether and call `_frame.py: _build_from_map` directly instead — the same primitive the other six use — which means config.py's own code never has a path back to the old bytes, regardless of what the shared templates still tolerate for other modules.

**Constants:** `_SUB_ACC1_MOD_LEVEL`, `_SUB_USB_MOD_LEVEL`, `_SUB_LAN_MOD_LEVEL` and the six `_CTL_MEM_{DATA_OFF,DATA1,DATA2,DATA3}_MOD_INPUT` / `_CTL_MEM_CIV_{TRANSCEIVE,OUTPUT_ANT}` constants are deleted from `commands/_frame.py` — grepped across `src/` and `tests/` first, confirmed read only by `config.py`'s own (now-deleted) fallback code. `_CMD_LEVEL` and `_CTL_MEM_{REF_ADJUST,DASH_RATIO,NB_DEPTH,NB_WIDTH,VOX_DELAY,SYSTEM_DATE,SYSTEM_TIME,UTC_OFFSET,QUICK_DUAL_WATCH,QUICK_SPLIT}` are still read by `levels.py`/`system.py`/`vfo.py` and are untouched.

**(b) Call sites moved.** `runtime/radio.py` is the *only* file with production call sites for these 18 builders — grepped `runtime/_scope_runtime.py`, `runtime/_dual_rx_runtime.py` and `backends/_icom_serial_base.py`: zero hits for any of the 18 names. All 18 `CoreRadio` methods now call `self._commands.<builder>(...)`; the 9 setter imports (`set_acc1_mod_level` etc.) are removed from the top-of-file import block as dead, the 9 getter imports stay (needed as arguments to `self._commands.expect(...)`, see below). `runtime/profiles_runtime.py: apply_profile`'s `set_data_off_mod_input` call goes through `radio.set_data_off_mod_input(...)` — the method, unaffected by this PR's internals — so the live ACC1/MIC fix and the profile-write fix both land without touching that file.

**(c) Response matchers moved in the same commit.** The 9 matcher-backed getters (7 BCD, 2 bool) now compute their `command=`/`sub=`/`prefix=` via a new `CoreRadio._expect_shape(builder)` helper — a thin wrapper over `commands/bound.py: BoundCommands.expect` that asserts `sub is not None` (every config.py entry has one) before handing the triple to `_get_bcd_level`/`_get_bool_value`. This satisfies §6 population 1 exactly for config.py's slice of the 65 request/response pairs; the other ~56 (levels.py, system.py, etc.) still pass literals, unaffected.

## Deliverable checklist (task spec points 1–8)

1. **config.py rewritten** — 18/18 builders: `cmd_map` required keyword-only, fallback branches deleted, `@expose_command_key` on every one (all resolve a literal key equal to their own name — the first, most common case in plan §3.1's four-way classification).
2. **Call sites found and moved** — see (b) above. No caller lacking `self._commands` was found; nothing to report as a design problem.
3. **Response matchers moved** — see (c) above.
4. **Keystone test** — `tests/test_response_shape_from_profile.py` (new). For every CI-V profile and every entry in `MATCHER_BACKED_GETTERS` (currently config.py's 9), it monkeypatches `CoreRadio._get_bcd_level`/`_get_bool_value` at the class level to capture the `(command, sub, prefix)` the getter actually hands them — no transport, connection or I/O needed for any backend — and asserts it equals `decode_wire_tuple(cmd_map.get(name))` from the same profile. 54 cases (6 CI-V profiles × 9 getters), 26 exercised, 28 skipped where a profile's map omits that command (e.g. IC-705 has no ACC1 jack).

   **Proven red for the half-done state, live during this session:** temporarily reverted `get_acc1_mod_level`'s reply half to the old hardcoded `command=0x14, sub=0x0B` while leaving the request half migrated. Re-ran the keystone test:
   ```
   FAILED [IC-7300-get_acc1_mod_level] parsed its reply against (20, 11, b''), request goes to (26, 5, b'\x00d')
   FAILED [IC-7610-get_acc1_mod_level] parsed its reply against (20, 11, b''), request goes to (26, 5, b'\x00\x88')
   FAILED [IC-9700-get_acc1_mod_level] parsed its reply against (20, 11, b''), request goes to (26, 5, b'\x00d')
   3 failed, 23 passed, 28 skipped
   ```
   (20=0x14, 11=0x0B decimal; 26=0x1A, 5=0x05.) Reverted the revert immediately after; the diff you're reviewing never contained the broken version.

5. **Drift-guard extension** (`tests/test_profile_command_binding.py`):
   - **Argument-case synthesis**, since the guard's fixed `builder(to_addr=..., cmd_map=...)` call shape broke on config.py's 9 setters (each needs `level`/`source`/`enabled`) with `missing 1 required positional argument`, 18 failures (9 setters × 2 probe maps) — this was the **first-round** shape of the bug, fixed by `_synthesize_case`. A **second**, full-suite-only instance of the same class of problem (`inspect.unwrap` needed, not just probe-value synthesis) surfaced in independent review and is fixed on this branch too — see "Review-fix round" below.
   - **Dedup fix**: `_exposed_builders()` deduplicated on bare `id(key_fn)`, which goes false-green the moment two *distinct* builders ever share one `cmd_map_key` callable object (only the alias case, `speech = get_speech`, should collapse). Changed to dedup on `(id(key_fn), qualname)` — the alias still collapses (same object, same qualname), two genuinely different builders no longer could hide one from the other.
6. **Parity files regenerated and inspected** — delta below; regenerated a second time in the review-fix round for the `noargs`/`requires-map` split (finding 4).
7. **Q6 error message** — see below; redesigned in the review-fix round to also cover explicit `cmd_map=None` (finding 3).
8. **MockIcomRadio untouched** — confirmed, no edits to `tests/mock_server.py`.

## Review-fix round (BLOCKED → fixed; superseded by the rebase in "Rebase onto origin/main" above, same content)

### Finding 1 — drift-guard collection-order bug (the mechanism, verified not assumed)

Independent review ran the full suite twice (parallel and serial) and got **18 deterministic failures** in `TestExposedKeyDriftGuard`, all nine config.py setters × two probe maps, with the standalone file green. Reproduced first, exactly: collecting `tests/test_commands.py tests/test_commands_extended.py tests/test_main_sub_tracking.py tests/test_rf_gain_af_level.py tests/test_scope.py tests/test_profile_command_binding.py` together (the five files that rebind the shared `rigplane.commands` namespace, collected before the drift-guard file) → **18 failed, 507 passed**, matching the report.

Traced with a REPL rather than assumed. `tests/_command_test_helpers.py: bind_default_addr_module` rebinds e.g. `rigplane.commands.set_acc1_mod_level` into `functools.partial(raw, to_addr=IC_7610_ADDR)` with `update_wrapper` applied. Confirmed directly:
- `inspect.signature(partial_obj) == inspect.signature(raw)` — **identical** (`(level: 'int', to_addr: 'int', from_addr: 'int' = 224, *, cmd_map: 'CommandMap')` both ways) — this is the signature-view difference the review had already ruled out, confirmed correct.
- `hasattr(partial_obj, "__globals__")` — **False**. `functools.partial` objects never have one; `update_wrapper` copies `__module__`/`__name__`/`__qualname__`/`__annotations__`/`__doc__` and merges `__dict__`, never `__globals__`.

`test_command_map_parity.py: _values_for` does `eval(param.annotation, fn.__globals__)`. Against the partial that raises `AttributeError`, caught by `_values_for`'s own bare `except Exception: return ()` — an **empty probe ladder** for every required parameter. `_candidate_kwargs` then yields nothing at all, so `_synthesize_case`'s loop never calls the builder even once, for every setter with a required value argument, on any collection order that wraps it first.

**Fix**: `_synthesize_case` now computes `required, _optional = _split_params(inspect.unwrap(builder))` and searches `_candidate_kwargs(inspect.unwrap(builder), required)`, while the actually-exercised call still goes through the original (possibly wrapped) `builder`, matching the §3.1 call-site style. `inspect.unwrap` follows the `__wrapped__` chain `update_wrapper` sets, however many rebinding layers stacked, landing on a function with a real `__globals__`.

**Proof, same combined collection order**: `tests/test_commands.py tests/test_commands_extended.py tests/test_main_sub_tracking.py tests/test_rf_gain_af_level.py tests/test_scope.py tests/test_profile_command_binding.py` → **525 passed, 0 failed**. Standalone drift-guard file: 60/60.

### Finding 2 — D1 refusal now live but unpinned

`CoreRadio.get_lan_mod_level` now calls `self._expect_shape(get_lan_mod_level)` → `self._commands.expect(...)` *before* building or sending any frame — newly reachable through this migration and previously exercised in this test file only via `radio._commands.<builder>` directly, never through the public async method. Added `TestCoreRadioWiring.test_migrated_getter_refuses_through_expect_shape` in `tests/test_undeclared_command_policy.py`: constructs a real IC-7300-profiled `CoreRadio` (no transport needed — the refusal fires before any I/O) and asserts `await radio.get_lan_mod_level()` raises `CommandError` matching `"not supported by this radio"`. Written against IC-7300's `get_lan_mod_level` as a D1 state-3 case (neither declared nor declared absent) when this finding was first fixed; the "Rebase onto origin/main" section above explains why it now asserts state 2 (declared absent) instead — the property this test actually pins is unaffected by which state.

### Finding 3 — `require_cmd_map` let an explicit `cmd_map=None` through

The original design only intercepted the *omitted*-`cmd_map` `TypeError`; an explicit `cmd_map=None` reached `fn`'s body and failed as a raw `AttributeError` from `_build_from_map`'s `None.get(name)` — precisely the path this migration's de-delegation rationale (config.py's module docstring) names as the reason to bypass the shared `_build_ctl_mem_get`/`_build_ctl_mem_set` templates. Redesigned `require_cmd_map` to check `kwargs.get("cmd_map") is None` **before** calling `fn` at all, so both omission and explicit `None` raise `TypeError` with the identical shared `_CMD_MAP_EXPLANATION` string appended (extracted as a module-level constant so "the same explanation" is a checkable fact, not a claim about matching prose):
```
>>> rigplane.commands.get_acc1_mod_level(to_addr=0x94)
TypeError: get_acc1_mod_level() missing 1 required keyword-only argument:
'cmd_map' -- as of MOR-2006 (docs/plans/2026-08-29-profile-driven-command-bytes.md),
every rigplane.commands builder requires the radio's CommandMap and no longer
has a hardcoded fallback. ...

>>> rigplane.commands.get_acc1_mod_level(to_addr=0x94, cmd_map=None)
TypeError: get_acc1_mod_level() cmd_map is None -- as of MOR-2006
(docs/plans/2026-08-29-profile-driven-command-bytes.md), every
rigplane.commands builder requires the radio's CommandMap and no longer
has a hardcoded fallback. ...
```
Pinned both in `tests/test_commands.py`: `test_get_acc1_mod_level_requires_cmd_map` now matches `"MOR-2006"` (was the weaker `"cmd_map"`), plus a new `test_get_acc1_mod_level_rejects_explicit_none_the_same_way`.

### Finding 4 — `noargs` census bucket conflated two causes

Before this round, config.py's 18 migrated builders and `vfo.py`'s genuinely-unsynthesisable `scan_set_df_span`/`scan_set_resume` shared one `noargs` label, for two different reasons: the `vfo.py` pair have no probe value that satisfies some *other* required argument (`cmd_map` still optional there); config.py's 18 can never accept the harness's `cmd_map=None` probe at all, *regardless* of any other argument's value, because `cmd_map` has no default. Added `_requires_cmd_map(fn)` — a pure signature check (`cmd_map`'s parameter has no default), not exception-message sniffing — and split `_cases()`'s single `unsynthesisable` set into `unsynthesisable` (genuine, unchanged meaning) and a new `requires_map` population. `_render_uncovered` gained a `requires-map` row kind alongside `noargs`, with the header comment rewritten to describe both.

**This is the one finding where `test_command_map_parity.py`'s own Python changed** — correcting the original PR body's claim that the harness needed no code changes, which was true for the *unlabeled* reclassification but not for giving it an honest label. Regenerated: 18 rows moved from `noargs` to `requires-map` (all `config.py:*`), `vfo.py`'s two stayed `noargs`, **no census-count changes**, no other file's rows touched — confirmed by diffing `tests/command_map_parity_uncovered.txt` line by line.

## Parity-file delta, line-class by line-class (all three regen rounds)

Regenerated with `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py`, three times now (first PR round; finding 4's `requires-map` split; the post-rebase round above), diffed against the then-current `origin/main` after each and inspected every changed line by hand. The census table in "Rebase onto origin/main" above has the exact before/after numbers for the third round; this section is the line-class narrative, current as of the pushed head.

`tests/command_map_parity_divergences.txt`: **44 rows deleted, all `config.py:*`, nothing else touched** — true against both the pre-rebase and post-rebase baseline (the *count* is stable; several IC-9700 rows' specific byte values underneath changed when `#2829` corrected its copied-from-IC-7300 addresses, irrelevant to a row that disappears because config.py stopped having two implementations to disagree at all). Verified by grep that every remaining row belongs to `levels.py`/`vfo.py`.

`tests/command_map_parity_uncovered.txt`:
- **18 `gap` rows deleted** — one per config.py command name. Once `cmd_map` is required, the harness's `cmd_map=None` probe (`_accepts`) no longer succeeds at all for these builders, so `_cases()` moves them entirely out of the comparable set (`per_builder`) and they can no longer produce a gap row either. Stable across the rebase for the same reason as the divergence-row count above.
- **18 `requires-map` rows** (was `noargs` before finding 4's relabel) — same 18 names, now correctly attributed to a required `cmd_map` rather than a generically-unsatisfied probe search. `_requires_cmd_map` is a pure signature check independent of any profile's TOML, so this population is untouched by the rebase.
- **Census deltas** — see the "Rebase onto origin/main" table above for the full before/after/Δ breakdown at both baselines; the Δ column is identical in both.

## Q6 error-message design (as redesigned in the review-fix round; see finding 3)

`commands/_frame.py: require_cmd_map` is a decorator applied to all 18 config.py builders (composed with `@expose_command_key`, applied innermost so `functools.wraps` keeps the wrapped function's real signature visible to `inspect.signature` — confirmed `BoundCommands.__getattr__`'s `_takes_cmd_map` and `test_command_map_parity.py`'s `_builders()` both still see it correctly). It now checks `cmd_map` **before** calling the wrapped builder at all: if the keyword is absent, it lets the call proceed to Python's own missing-argument `TypeError` and re-raises with the shared explanation appended (so a call *also* missing some other required argument still shows that); if `cmd_map` is present but `None`, it raises the same explanation immediately, without ever reaching `_build_from_map`. `docs/CHANGELOG.md` carries a new Breaking-changes entry in the established style (bold one-line summary, then the mechanism, the historical bug it closes, and the concrete migration path for an external caller).

## Known traps, checked

- **`tests/_command_test_helpers.py` partial-rebinding** — accounted for twice: once for `test_commands.py`'s config.py section (adds only `cmd_map=` on top of the existing `to_addr` binding), and a second time for the drift guard's argument-synthesis machinery itself (finding 1 above), which is the deeper instance of the same underlying fact (`bind_default_addr_module`'s partials).
- **Tests pinning old fallback bytes** — `tests/test_commands.py`'s `TestSystemConfigCommands` had ~30 tests calling config.py builders with no `cmd_map`, pinning the literal `14 0B`/`1A 05 00 91` etc. fallback bytes. Converted (not deleted) to a `cmd_map` fixture loading the real IC-7610 map via `load_rig(...)` (preferred over hand literals per the spec), with expected bytes recomputed against IC-7610's actual TOML entries (comment cites the exact `rigs/ic7610.toml` line for each). `tests/test_command_map_integration.py`'s config.py cases already passed `cmd_map=` explicitly and needed no changes.
- **`tests/test_command_fallback_audit.py`** — checked its enumeration: it only exercises `get_freq`/`set_freq` (unmigrated) and the `speech`/`get_speech` alias by name, never a generic sweep of "every cmd_map-taking builder", so config.py's migration doesn't affect it, in either PR round. Ran unchanged: 23/23 pass. Also independently verified the interaction is safe: `_fallback_audit.install()`'s wrapper catches the `TypeError` from `signature.bind()` on a call missing the now-required `cmd_map` and falls through to calling `fn(*args, **kwargs)` directly, which raises the same (`require_cmd_map`-enriched) `TypeError` — no double-wrapping surprise, unaffected by finding 3's redesign since that redesign still raises `TypeError` for the omitted case.

## Test evidence (at the pushed head, `cf0759d1`, post-rebase)

Targeted suite (never the full suite locally, per instructions):
```
uv run pytest tests/test_response_shape_from_profile.py tests/test_command_map_parity.py \
  tests/test_profile_command_binding.py tests/test_undeclared_command_policy.py \
  tests/test_rig_ic7300.py tests/test_command_map_integration.py tests/test_commands.py \
  tests/test_radio.py tests/test_command_fallback_audit.py -q --tb=short --timeout=180
```
→ **948 passed, 28 skipped** (948, not the pre-rebase 943 — the +5 are tests `#2826`/`#2829` added to `tests/test_rig_ic7300.py`/`tests/test_command_map_integration.py`, pulled in by the rebase, nothing this PR added). The keystone's 28-skip *count* is unchanged, but not its composition — checked by running the keystone in a throwaway `git worktree` at the pre-rebase commit and diffing the two 54-case result sets by id rather than trusting the total: exactly two cases flipped, in opposite directions. `IC-9700-get_civ_output_ant` went PASSED→SKIPPED (`#2829` corrected it from a copied-wrong-but-present IC-7300 address to correctly-declared-absent, so `cmd_map.has()` turns false). `IC-9700-get_lan_mod_level` went SKIPPED→PASSED (`#2829` filled a genuine prior gap with its own guide's real address). `get_data2_mod_input`/`get_data3_mod_input` for IC-9700 did **not** change status — they were already skipped pre-`#2829` (a real gap then, same `cmd_map.has()` result now that D2 recorded the gap as `absent` rather than leaving it silently unknown) — an earlier draft of this section named those two as newly-skipping, which this worktree comparison disproves.

Combined-collection proof for finding 1, re-run post-rebase: `tests/test_commands.py tests/test_commands_extended.py tests/test_main_sub_tracking.py tests/test_rf_gain_af_level.py tests/test_scope.py tests/test_profile_command_binding.py` → **526 passed, 0 failed** (526, not 525 — one more test from the rebase, same reason as above).

`uv run ruff check src/ tests/` → all checks passed. `uv run ruff format --check src/ tests/` → all formatted. `uv run lint-imports` → 5/5 contracts kept.

`web/` untouched, so no `mypy --strict` run per CLAUDE.md.

## Figures at head (`cf0759d1`, post-rebase)

11 files changed, 752 insertions(+), 396 deletions(-) = **1148 changed lines** (both hard-ceiling dimensions crossed; owner exception granted, see "Guardrail exception" above; 1148 not 1140 — the rebase's `tests/test_undeclared_command_policy.py` fix added 8 lines net, explained in "Rebase onto origin/main" above). `git diff origin/main...HEAD --stat`:

```
 docs/CHANGELOG.md                         |  19 ++
 src/rigplane/commands/_frame.py           |  61 ++++--   (9 constants deleted, require_cmd_map added + redesigned for finding 3)
 src/rigplane/commands/config.py           | 312 +++++++++++++++---------------  (near-total rewrite)
 src/rigplane/runtime/radio.py             | 134 ++++++++-----
 tests/command_map_parity_divergences.txt  |  44 -----  (regenerated three times; row count stable each time)
 tests/command_map_parity_uncovered.txt    |  67 ++++---   (regenerated three times; requires-map split, then the D2 baseline shift)
 tests/test_command_map_parity.py          |  64 ++++--   (new to the review-fix round: _requires_cmd_map, finding 4)
 tests/test_commands.py                    | 204 +++++++++++--------  (TestSystemConfigCommands rewrite + finding-3 pins)
 tests/test_profile_command_binding.py     |  79 +++++++-   (argument synthesis + finding-1 unwrap fix)
 tests/test_response_shape_from_profile.py | 134 +++++++++++++  (new)
 tests/test_undeclared_command_policy.py   |  30 +++   (new to the review-fix round: finding 2; state-2 rebase fix folded in)
 11 files changed, 752 insertions(+), 396 deletions(-)
```

## Why this is one unit of work (soft-threshold paragraph; still holds after the rebase)

Requests and replies cannot split across PRs (plan explicitly forbids it — "the dangerous half is requests moved, replies not"), and the keystone test that proves that must land in the same commit as the first module it guards, per plan §4/§7 ("must land with the first module, not after it"). The parity-file regen is mechanical fallout of the same change and can't be deferred without leaving stale rows asserting a fact the code no longer has. The drift-guard extension (argument synthesis + dedup fix, then the `inspect.unwrap` fix) is a hard *precondition* for `@expose_command_key`-ing config.py's 9 setters at all — without it the guard can't even call them, in CI or standalone. Test-file updates for the ~30 pinned-fallback-byte tests are the direct, unavoidable consequence of deleting the fallback they pinned. The review-fix round's four findings are each either a bug in code this same PR introduces or a missing pin for behaviour this same PR's migration newly makes reachable — none of it is separable without leaving the tree broken (findings 1 and 3) or a known gap unpinned (findings 2 and 4) at some intermediate commit. The rebase adds nothing to this argument's *shape*, only to its size: two merged D2 PRs regenerating the same generated files this PR regenerates is not something a PR branch can defer or avoid, and the resulting +8 lines (the state-3→state-2 test fix) is the smallest honest fix once regeneration surfaced the stale assumption. The owner's guardrail exception (above) is the mechanism for the resulting size, not a substitute for this argument.

## Anything contradicting the spec / worth flagging

- Nothing found in the original implementation that resisted the pattern. All 18 config.py builders migrated uniformly (all fall into §3.1's "literal key equal to function's own name" case — none needed the per-map-probe shape `get_speech` required).
- The first PR round's body claimed the parity harness reclassifies migrated builders without any change to `test_command_map_parity.py`'s Python. That was true for the *reclassification itself* but incomplete: it left the reclassified builders under a label (`noargs`) that no longer described why they were there. Finding 4 corrected this — `test_command_map_parity.py` **is** modified in the version you're reviewing now, and that correction is exactly what the independent review asked for a future module's reviewer's sake.
- Bypassing the shared `_builders.py: _build_ctl_mem_get`/`_build_ctl_mem_set` templates for config.py's twelve delegated builders (rather than just requiring `cmd_map` and leaving the delegation in place) was a design decision beyond the letter of "make cmd_map required, delete the fallback branch." Made because leaving the delegation in place would mean an explicit `cmd_map=None` call still silently produces the old, sometimes-wrong bytes via the shared template's *own* untouched fallback, and because the parity file's 26 non-direct-branch divergence rows would not have actually disappeared otherwise (verified by inspection before implementing). Finding 3's fix (explicit `None` now raises before reaching any builder body) makes this decision's payoff concrete on the `config.py` side specifically, though the same class of call is still possible against `levels.py`/`system.py` until they migrate.
