### PR TITLE
fix: drop IC-705's dead bare-spelled civ_output keys

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -655,9 +655,6 @@ get_xfc_status = [0x1C, 0x02]
 set_xfc_status = [0x1C, 0x02]
 get_tx_freq_monitor = [0x1C, 0x03]
 set_tx_freq_monitor = [0x1C, 0x03]
-get_civ_output = [0x1C, 0x04]
-set_civ_output = [0x1C, 0x04]
-# NOTE: IC-7610 maps 0x1C 0x04 under antenna context; IC-705.rig labels it "CI-V Output"
 
 # ── RIT / XIT ──
 get_rit_frequency = [0x21, 0x00]

--- a/tests/test_rig_ic705.py
+++ b/tests/test_rig_ic705.py
@@ -1,0 +1,42 @@
+"""IC-705 TOML profile tests — pin what ``rigs/ic705.toml`` must (not) declare."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rigplane.rig_loader import load_rig
+
+RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
+IC705_PATH = RIGS_DIR / "ic705.toml"
+
+
+@pytest.fixture()
+def rig():
+    return load_rig(IC705_PATH)
+
+
+@pytest.fixture()
+def cmdmap(rig):
+    return rig.to_command_map()
+
+
+class TestNoStrayCivOutputKeys:
+    """``get_civ_output``/``set_civ_output`` (bare spelling) are dead keys.
+
+    No builder in ``src/rigplane/commands/`` resolves this spelling; the
+    only reachable builder for 0x1C 0x04 is ``get_civ_output_ant`` /
+    ``set_civ_output_ant`` (``src/rigplane/commands/config.py``). Per the
+    IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.8, IC-705 has no
+    ANT-output CI-V setting at all, so this pins the bare keys' absence
+    rather than asserting anything about the ``_ant`` spelling.
+    """
+
+    def test_bare_civ_output_keys_absent(self, cmdmap) -> None:
+        assert not cmdmap.has("get_civ_output")
+        assert not cmdmap.has("set_civ_output")
+
+    def test_neighboring_key_still_present(self, cmdmap) -> None:
+        """Discrimination guard: the map is loaded and non-empty."""
+        assert cmdmap.has("get_tx_freq_monitor")


### PR DESCRIPTION
## What

Remove the two dead `get_civ_output` / `set_civ_output` keys (and the NOTE
comment explaining them) from `rigs/ic705.toml`, and add
`tests/test_rig_ic705.py` pinning their absence from the loaded IC-705
command map.

## Why

The bare `civ_output` spelling is consumed by no builder: every lookup in
`src/rigplane/commands/*.py` resolves `get_civ_output_ant` /
`set_civ_output_ant` (`src/rigplane/commands/config.py`), and every other
CI-V profile (ic7300/ic7610/ic9700) declares the `_ant` spelling. IC-705 was
the only profile using the bare spelling, so the two lines were unreachable
data that also masked the real state of affairs: per the IC-705 CI-V
Reference Guide (A7560-8EX-1, Jul.2020) p.8 the radio has no ANT-output CI-V
setting at all, which is why #2828 (MOR-2016 D2, in flight) declares the
`_ant` spelling `{ absent = ... }`. Deletion, not rename, is therefore the
fix. #2828 deliberately left these lines alone (documentary byte-sourcing
vs. key-naming bug); the two PRs touch disjoint line ranges of the profile
and do not conflict.

`tests/profile_command_coverage_gaps.txt` and
`tests/command_map_parity_uncovered.txt` are intentionally untouched — the
bare keys appear in neither (no comparison harness ever read them).

## Test

TDD red-first: `TestNoStrayCivOutputKeys::test_bare_civ_output_keys_absent`
fails against the unfixed profile (`CommandMap(234 commands).has('get_civ_output')`
was True) and passes after the deletion. A companion assertion on
`get_tx_freq_monitor` guards against the test passing vacuously on a
misloaded/empty map.

Targeted battery (new file + test_rig_ic705_mor1540 + test_rig_loader +
test_command_map_parity + test_profile_command_coverage +
test_command_map_integration + test_rig_ic7610 + test_rig_ic7300):
598 passed, 1 skipped — baseline at 903c9912 was 596 passed, 1 skipped, so
exactly the 2 new tests were added and nothing regressed. `ruff check` /
`ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
