### PR TITLE
feat(MOR-2006): migrate levels.py onto the bound command map (steps 5..N, module 2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reach these builders through a radio's bound commands rather than
   calling `rigplane.commands.get_acc1_mod_level(...)` (or any of its
   seventeen siblings above) directly with no map.
+- **`rigplane.commands.levels` builders require `cmd_map`; there is no
+  hardcoded fallback (MOR-2006, Steps 5..N module 2 of
+  `docs/plans/2026-08-29-profile-driven-command-bytes.md`).** The other
+  half of the ACC1/MIC-gain collision above: `set_mic_gain`'s fallback
+  built the same eight bytes on the IC-7300 as `set_acc1_mod_level`'s did.
+  All fifty builders in this module — RF power/gain, AF level, squelch,
+  APF/NR/PBT/notch/compressor/break-in/NB/DIGI-SEL/drive/monitor/VOX/anti-VOX
+  levels, CW pitch, mic gain, key speed, and the REF-adjust/dash-ratio/NB-depth/
+  NB-width/VOX-delay menu-address group — now require `cmd_map` as a required
+  keyword-only argument; a call that omits it raises `TypeError` the same way
+  as `rigplane.commands.config`'s eighteen. The only production caller,
+  `runtime/radio.py: CoreRadio`, moved onto `self._commands.<builder>(...)`
+  in the same change — an external caller of a free function must do the
+  same rather than calling it directly with no map.
 - **CLI: `rigplane ptt on` no longer returns while the rig is keyed.** The
   command now holds the key for as long as the process runs and unkeys on the
   way out, so the process that keyed the rig is the one that releases it. A

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -819,12 +819,12 @@ set_civ_output_ant = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2
 # NB Depth/Width and VOX Delay DO exist on IC-705, at different 1A 05
 # sub-addresses than IC-7300's 0189/0190/0191 -- refutes the earlier "not
 # listed for IC-705 in wfview" framing (D2, MOR-2016).
-get_nb_depth = [0x1A, 0x05, 0x03, 0x57]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0357 (00-09); NOT the shared fallback's 0290, which is IC-7610's address
-set_nb_depth = [0x1A, 0x05, 0x03, 0x57]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0357 (00-09); NOT the shared fallback's 0290, which is IC-7610's address
-get_nb_width = [0x1A, 0x05, 0x03, 0x58]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0358 (0000-0255); NOT the shared fallback's 0291, which is IC-7610's address
-set_nb_width = [0x1A, 0x05, 0x03, 0x58]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0358 (0000-0255); NOT the shared fallback's 0291, which is IC-7610's address
-get_vox_delay = [0x1A, 0x05, 0x03, 0x59]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.14, control 0359 (00-20, 0.1s steps); NOT the shared fallback's 0292, which is IC-7610's address
-set_vox_delay = [0x1A, 0x05, 0x03, 0x59]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.14, control 0359 (00-20, 0.1s steps); NOT the shared fallback's 0292, which is IC-7610's address
+get_nb_depth = [0x1A, 0x05, 0x03, 0x57]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0357 (00-09); NOT the shared fallback's 0290, which was IC-7610's address -- that fallback and its `_CTL_MEM_NB_DEPTH` constant were deleted in MOR-2006 Steps 5..N module 2
+set_nb_depth = [0x1A, 0x05, 0x03, 0x57]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0357 (00-09); NOT the shared fallback's 0290, which was IC-7610's address -- that fallback and its `_CTL_MEM_NB_DEPTH` constant were deleted in MOR-2006 Steps 5..N module 2
+get_nb_width = [0x1A, 0x05, 0x03, 0x58]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0358 (0000-0255); NOT the shared fallback's 0291, which was IC-7610's address -- that fallback and its `_CTL_MEM_NB_WIDTH` constant were deleted in MOR-2006 Steps 5..N module 2
+set_nb_width = [0x1A, 0x05, 0x03, 0x58]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.13, control 0358 (0000-0255); NOT the shared fallback's 0291, which was IC-7610's address -- that fallback and its `_CTL_MEM_NB_WIDTH` constant were deleted in MOR-2006 Steps 5..N module 2
+get_vox_delay = [0x1A, 0x05, 0x03, 0x59]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.14, control 0359 (00-20, 0.1s steps); NOT the shared fallback's 0292, which was IC-7610's address -- that builder-side fallback and its `_CTL_MEM_VOX_DELAY` constant were deleted in MOR-2006 Steps 5..N module 2; 0292 survives only as an RX-parser value in runtime/_civ_rx.py for decoding unsolicited frames, not as anything any builder can emit
+set_vox_delay = [0x1A, 0x05, 0x03, 0x59]  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.14, control 0359 (00-20, 0.1s steps); NOT the shared fallback's 0292, which was IC-7610's address -- that builder-side fallback and its `_CTL_MEM_VOX_DELAY` constant were deleted in MOR-2006 Steps 5..N module 2; 0292 survives only as an RX-parser value in runtime/_civ_rx.py for decoding unsolicited frames, not as anything any builder can emit
 
 [protocol]
 type = "civ"

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -175,9 +175,11 @@ speed_max_wpm = 48
 # dash_ratio: control 0224, IC-9700 CI-V Reference Guide (Icom, 2019) p.9
 # (CW-KEY SET>Dot/Dash Ratio). Refutes the earlier "no dash_ratio" note --
 # see get_dash_ratio / set_dash_ratio in [commands.overrides] (D2, MOR-2015).
-# The hardcoded fallback constant `_CTL_MEM_DASH_RATIO = 0x0228` is itself
-# wrong for this radio (0228 = CW-KEY SET>MIC Up/Down Keyer); not fixed here
-# -- fallback bytes are out of this documentary ticket's scope.
+# The hardcoded fallback that used to send 0x0228 for this command was
+# itself wrong for this radio (0228 = CW-KEY SET>MIC Up/Down Keyer, not
+# Dot/Dash Ratio) -- that fallback and its `_CTL_MEM_DASH_RATIO` constant
+# were deleted in MOR-2006 Steps 5..N module 2, so this profile's 0224 is
+# now the only address any builder can send.
 
 [nb]
 # NB depth 1-10, NB width 0-255 (wfview NB Depth Min/Max). NOTE (D2,
@@ -821,10 +823,11 @@ set_quick_dual_watch = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) p.6
 # its isinstance(list) short-circuit (the rule only checks list-valued
 # entries); moved rather than relying on that blind spot (D2, MOR-2015)
 # dash_ratio: control 0224, CW-KEY SET>Dot/Dash Ratio; real gap-list
-# address (D2, MOR-2015). The hardcoded fallback constant
-# `_CTL_MEM_DASH_RATIO = 0x0228` is itself wrong for this radio (0228 =
-# CW-KEY SET>MIC Up/Down Keyer); not fixed here -- fallback bytes are out
-# of this documentary ticket's scope.
+# address (D2, MOR-2015). The hardcoded fallback that used to send 0228 for
+# this command was itself wrong for this radio (0228 = CW-KEY SET>MIC
+# Up/Down Keyer, not Dot/Dash Ratio) -- that fallback and its
+# `_CTL_MEM_DASH_RATIO` constant were deleted in MOR-2006 Steps 5..N module
+# 2, so this profile's 0224 is now the only address any builder can send.
 get_dash_ratio = [0x1A, 0x05, 0x02, 0x24]  # source: IC-9700 CI-V Reference Guide p.9
 set_dash_ratio = [0x1A, 0x05, 0x02, 0x24]  # source: IC-9700 CI-V Reference Guide p.9
 # nb_depth/nb_width: AMBIGUOUS -- no single global NB depth/width; per-band

--- a/src/rigplane/commands/_builders.py
+++ b/src/rigplane/commands/_builders.py
@@ -5,9 +5,9 @@ Imports from ``_frame`` and ``_codec`` only -- never from leaf modules.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
-from ._codec import _bcd_byte, _bcd_decode_value, _level_bcd_encode, bcd_encode_value
+from ._codec import _bcd_byte, _bcd_decode_value
 from ._frame import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
@@ -24,71 +24,6 @@ from ._frame import (
 if TYPE_CHECKING:
     from ..command_map import CommandMap
     from ..types import CivFrame
-
-
-def _build_level_get(
-    sub: int,
-    *,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    receiver: int = RECEIVER_MAIN,
-    command29: bool = False,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    if cmd_map is not None and cmd_name is not None:
-        return _build_from_map(
-            cmd_map,
-            cmd_name,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            receiver=receiver,
-            command29=command29,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_LEVEL,
-            sub=sub,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=sub)
-
-
-def _build_level_set(
-    sub: int,
-    value: int,
-    *,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    receiver: int = RECEIVER_MAIN,
-    command29: bool = False,
-    encoder: Callable[[int], bytes] = _level_bcd_encode,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    payload = encoder(value)
-    if cmd_map is not None and cmd_name is not None:
-        return _build_from_map(
-            cmd_map,
-            cmd_name,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=payload,
-            receiver=receiver,
-            command29=command29,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_LEVEL,
-            sub=sub,
-            data=payload,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=sub, data=payload)
 
 
 def _build_ctl_mem_get(
@@ -111,35 +46,6 @@ def _build_ctl_mem_get(
         _CMD_CTL_MEM,
         sub=_SUB_CTL_MEM,
         data=prefix,
-    )
-
-
-def _build_ctl_mem_set(
-    prefix: bytes,
-    value: int,
-    *,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    byte_count: int,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    encoded = bcd_encode_value(value, byte_count=byte_count)
-    if cmd_map is not None and cmd_name is not None:
-        # When using cmd_map, wire bytes already include the full command
-        # structure including any data prefix, so pass only the encoded value
-        # -- the same rule ``_build_ctl_mem_get`` above applies by passing
-        # ``data=None``. Passing ``prefix`` here too sends the sub-address
-        # twice.
-        return _build_from_map(
-            cmd_map, cmd_name, to_addr=to_addr, from_addr=from_addr, data=encoded
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_CTL_MEM,
-        data=prefix + encoded,
     )
 
 

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -48,27 +48,15 @@ _CMD_SELECTED_MODE = 0x26  # Selected/Unselected receiver mode
 _CMD_ACK = 0xFB
 _CMD_NAK = 0xFA
 
-# Sub-commands for 0x14 (Levels)
-_SUB_AF_LEVEL = 0x01
-_SUB_RF_GAIN = 0x02
-_SUB_SQL = 0x03
-_SUB_APF_TYPE_LEVEL = 0x05
-_SUB_NR_LEVEL = 0x06
-_SUB_PBT_INNER = 0x07
-_SUB_PBT_OUTER = 0x08
-_SUB_CW_PITCH = 0x09
+# Sub-command for 0x14 (Levels). The rest of the 0x14 family
+# (`commands/levels.py`, MOR-2006 Steps 5..N module 2) is profile-only now:
+# every other sub-command byte lives solely in `rigs/*.toml`, reached by
+# name through the required ``cmd_map``, with no code-level constant left
+# to read -- `_SUB_RF_POWER` itself survives only because
+# `tests/test_backend_contract_matrix.py` and
+# `tests/test_civ_command_profiling.py` build raw frames with it directly,
+# never through `levels.py: get_rf_power`/`set_rf_power`.
 _SUB_RF_POWER = 0x0A
-_SUB_MIC_GAIN = 0x0B
-_SUB_KEY_SPEED = 0x0C
-_SUB_NOTCH_FILTER = 0x0D
-_SUB_COMPRESSOR_LEVEL = 0x0E
-_SUB_BREAK_IN_DELAY = 0x0F
-_SUB_NB_LEVEL = 0x12
-_SUB_DIGISEL_SHIFT = 0x13
-_SUB_DRIVE_GAIN = 0x14
-_SUB_MONITOR_GAIN = 0x15
-_SUB_VOX_GAIN = 0x16
-_SUB_ANTI_VOX_GAIN = 0x17
 
 # Sub-commands for 0x15 (Meters)
 _SUB_S_METER = 0x02
@@ -95,12 +83,10 @@ _SUB_BAND_STACK = 0x01
 _SUB_AGC_TIME_CONSTANT = 0x04
 _SUB_FILTER_WIDTH = 0x03
 
-# CTL_MEM prefixes (0x1A 0x05 ...)
-_CTL_MEM_REF_ADJUST = b"\x00\x70"
-_CTL_MEM_DASH_RATIO = b"\x02\x28"
-_CTL_MEM_NB_DEPTH = b"\x02\x90"
-_CTL_MEM_NB_WIDTH = b"\x02\x91"
-_CTL_MEM_VOX_DELAY = b"\x02\x92"
+# CTL_MEM prefixes (0x1A 0x05 ...). `commands/levels.py`'s own five
+# (ref_adjust, dash_ratio, nb_depth, nb_width, vox_delay) are gone as of
+# MOR-2006 Steps 5..N module 2 -- their menu addresses live only in
+# `rigs/*.toml` now, reached by name.
 _CTL_MEM_SYSTEM_DATE = b"\x01\x58"
 _CTL_MEM_SYSTEM_TIME = b"\x01\x59"
 _CTL_MEM_UTC_OFFSET = b"\x01\x62"

--- a/src/rigplane/commands/levels.py
+++ b/src/rigplane/commands/levels.py
@@ -1,48 +1,43 @@
-"""All 0x14-family level get/set commands + parse_level_response."""
+"""All 0x14-family level get/set commands + parse_level_response.
+
+Migrated onto the bound command map in MOR-2006 Steps 5..N (module 2,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4): every builder
+here requires ``cmd_map``, with no hardcoded fallback left. This module
+accounted for 16 of the rows `tests/command_map_parity_divergences.txt`
+recorded before this migration -- all now gone, since a divergence needs
+two disagreeing implementations and this module has only one left --
+including the other half of the measured ACC1/MIC-gain collision
+(MOR-1992): this module's ``set_mic_gain`` fallback built the exact same
+eight bytes on the IC-7300 as `config.py: set_acc1_mod_level`'s fallback
+did, for two unrelated controls.
+
+Every builder calls `_frame.py: _build_from_map` directly rather than the
+shared `_builders.py` templates used before migrating
+(``_build_level_get`` / ``_build_level_set`` / ``_build_ctl_mem_set``, all
+now deleted -- this module was their only caller, so their own
+``cmd_map is None`` fallback branches would otherwise become dead code
+nobody reads; ``_build_ctl_mem_get`` is kept, since `system.py`'s own
+date/time/UTC-offset getters still route through its fallback,
+unmigrated). Routing this module's builders through a template that
+retains a fallback would leave an explicit ``cmd_map=None`` call one layer
+away from silently reaching old, sometimes-wrong bytes instead of failing
+loudly through `_frame.py: require_cmd_map` -- the same reasoning
+`config.py`'s own module docstring records for the first half of this
+migration.
+"""
 
 from __future__ import annotations
 
 import math
 from typing import TYPE_CHECKING
 
-from ._builders import (
-    _build_level_get,
-    _build_level_set,
-    _build_ctl_mem_get,
-    _build_ctl_mem_set,
-)
-from ._codec import _level_bcd_encode
+from ._codec import _level_bcd_encode, bcd_encode_value
 from ._frame import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
-    _CMD_LEVEL,
-    _CTL_MEM_DASH_RATIO,
-    _CTL_MEM_NB_DEPTH,
-    _CTL_MEM_NB_WIDTH,
-    _CTL_MEM_REF_ADJUST,
-    _CTL_MEM_VOX_DELAY,
-    _SUB_AF_LEVEL,
-    _SUB_ANTI_VOX_GAIN,
-    _SUB_APF_TYPE_LEVEL,
-    _SUB_BREAK_IN_DELAY,
-    _SUB_COMPRESSOR_LEVEL,
-    _SUB_CW_PITCH,
-    _SUB_DIGISEL_SHIFT,
-    _SUB_DRIVE_GAIN,
-    _SUB_KEY_SPEED,
-    _SUB_MIC_GAIN,
-    _SUB_MONITOR_GAIN,
-    _SUB_NB_LEVEL,
-    _SUB_NOTCH_FILTER,
-    _SUB_NR_LEVEL,
-    _SUB_PBT_INNER,
-    _SUB_PBT_OUTER,
-    _SUB_RF_GAIN,
-    _SUB_RF_POWER,
-    _SUB_SQL,
-    _SUB_VOX_GAIN,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -69,916 +64,910 @@ def _key_speed_to_level(wpm: int) -> int:
     return round((wpm - 6) * 6.071)
 
 
+@expose_command_key(lambda cmd_map: "get_rf_power")
+@require_cmd_map
 def get_rf_power(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'get RF power' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_rf_power", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_LEVEL, sub=_SUB_RF_POWER)
+    return _build_from_map(
+        cmd_map, "get_rf_power", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_rf_power")
+@require_cmd_map
 def set_rf_power(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set RF power' CI-V command.
 
     Args:
         level: Power level 0-255 (radio maps to actual watts).
     """
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_rf_power",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=_level_bcd_encode(level),
-        )
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_LEVEL, sub=_SUB_RF_POWER, data=_level_bcd_encode(level)
+    return _build_from_map(
+        cmd_map,
+        "set_rf_power",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_rf_gain")
+@require_cmd_map
 def get_rf_gain(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'read RF gain' CI-V command (0x14 0x02)."""
-    return _build_level_get(
-        _SUB_RF_GAIN,
+    return _build_from_map(
+        cmd_map,
+        "get_rf_gain",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_rf_gain",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_rf_gain")
+@require_cmd_map
 def set_rf_gain(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set RF gain' CI-V command."""
-    return _build_level_set(
-        _SUB_RF_GAIN,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_rf_gain",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_rf_gain",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_af_level")
+@require_cmd_map
 def get_af_level(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'read AF output level' CI-V command (0x14 0x01)."""
-    return _build_level_get(
-        _SUB_AF_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "get_af_level",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_af_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_af_level")
+@require_cmd_map
 def set_af_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set AF output level' CI-V command."""
-    return _build_level_set(
-        _SUB_AF_LEVEL,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_af_level",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_af_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_squelch")
+@require_cmd_map
 def get_squelch(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'get squelch level' CI-V command (0x14 0x03)."""
-    return _build_level_get(
-        _SUB_SQL,
+    return _build_from_map(
+        cmd_map,
+        "get_squelch",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_squelch",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_squelch")
+@require_cmd_map
 def set_squelch(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set squelch level' CI-V command."""
-    return _build_level_set(
-        _SUB_SQL,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_squelch",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_squelch",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_apf_type_level")
+@require_cmd_map
 def get_apf_type_level(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read APF Type Level command."""
-    return _build_level_get(
-        _SUB_APF_TYPE_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "get_apf_type_level",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_apf_type_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_apf_type_level")
+@require_cmd_map
 def set_apf_type_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set APF Type Level command."""
-    return _build_level_set(
-        _SUB_APF_TYPE_LEVEL,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_apf_type_level",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_apf_type_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_nr_level")
+@require_cmd_map
 def get_nr_level(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read NR Level command."""
-    return _build_level_get(
-        _SUB_NR_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "get_nr_level",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_nr_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_nr_level")
+@require_cmd_map
 def set_nr_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set NR Level command."""
-    return _build_level_set(
-        _SUB_NR_LEVEL,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_nr_level",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_nr_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_pbt_inner")
+@require_cmd_map
 def get_pbt_inner(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read PBT Inner command."""
-    return _build_level_get(
-        _SUB_PBT_INNER,
+    return _build_from_map(
+        cmd_map,
+        "get_pbt_inner",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_pbt_inner",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_pbt_inner")
+@require_cmd_map
 def set_pbt_inner(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set PBT Inner command."""
-    return _build_level_set(
-        _SUB_PBT_INNER,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_pbt_inner",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_pbt_inner",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_pbt_outer")
+@require_cmd_map
 def get_pbt_outer(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read PBT Outer command."""
-    return _build_level_get(
-        _SUB_PBT_OUTER,
+    return _build_from_map(
+        cmd_map,
+        "get_pbt_outer",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_pbt_outer",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_pbt_outer")
+@require_cmd_map
 def set_pbt_outer(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set PBT Outer command."""
-    return _build_level_set(
-        _SUB_PBT_OUTER,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_pbt_outer",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_pbt_outer",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_cw_pitch")
+@require_cmd_map
 def get_cw_pitch(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read CW Pitch command."""
-    return _build_level_get(
-        _SUB_CW_PITCH,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_cw_pitch",
+    return _build_from_map(
+        cmd_map, "get_cw_pitch", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_cw_pitch")
+@require_cmd_map
 def set_cw_pitch(
     pitch_hz: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set CW Pitch command."""
-    return _build_level_set(
-        _SUB_CW_PITCH,
-        _cw_pitch_to_level(pitch_hz),
+    return _build_from_map(
+        cmd_map,
+        "set_cw_pitch",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_cw_pitch",
+        data=_level_bcd_encode(_cw_pitch_to_level(pitch_hz)),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_mic_gain")
+@require_cmd_map
 def get_mic_gain(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Mic Gain command."""
-    return _build_level_get(
-        _SUB_MIC_GAIN,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_mic_gain",
+    return _build_from_map(
+        cmd_map, "get_mic_gain", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_mic_gain")
+@require_cmd_map
 def set_mic_gain(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Mic Gain command."""
-    return _build_level_set(
-        _SUB_MIC_GAIN,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_mic_gain",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_mic_gain",
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_key_speed")
+@require_cmd_map
 def get_key_speed(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Key Speed command."""
-    return _build_level_get(
-        _SUB_KEY_SPEED,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_key_speed",
+    return _build_from_map(
+        cmd_map, "get_key_speed", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_key_speed")
+@require_cmd_map
 def set_key_speed(
     wpm: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Key Speed command."""
-    return _build_level_set(
-        _SUB_KEY_SPEED,
-        _key_speed_to_level(wpm),
+    return _build_from_map(
+        cmd_map,
+        "set_key_speed",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_key_speed",
+        data=_level_bcd_encode(_key_speed_to_level(wpm)),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_notch_filter")
+@require_cmd_map
 def get_notch_filter(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read Notch Filter level command."""
-    return _build_level_get(
-        _SUB_NOTCH_FILTER,
+    return _build_from_map(
+        cmd_map,
+        "get_notch_filter",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_notch_filter",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_notch_filter")
+@require_cmd_map
 def set_notch_filter(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Notch Filter level command."""
-    return _build_level_set(
-        _SUB_NOTCH_FILTER,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_notch_filter",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_notch_filter",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_compressor_level")
+@require_cmd_map
 def get_compressor_level(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Compressor Level command."""
-    return _build_level_get(
-        _SUB_COMPRESSOR_LEVEL,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_compressor_level",
+    return _build_from_map(
+        cmd_map, "get_compressor_level", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_compressor_level")
+@require_cmd_map
 def set_compressor_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Compressor Level command."""
-    return _build_level_set(
-        _SUB_COMPRESSOR_LEVEL,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_compressor_level",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_compressor_level",
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_break_in_delay")
+@require_cmd_map
 def get_break_in_delay(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Break-In Delay command."""
-    return _build_level_get(
-        _SUB_BREAK_IN_DELAY,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_break_in_delay",
+    return _build_from_map(
+        cmd_map, "get_break_in_delay", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_break_in_delay")
+@require_cmd_map
 def set_break_in_delay(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Break-In Delay command."""
-    return _build_level_set(
-        _SUB_BREAK_IN_DELAY,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_break_in_delay",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_break_in_delay",
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_nb_level")
+@require_cmd_map
 def get_nb_level(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read NB Level command."""
-    return _build_level_get(
-        _SUB_NB_LEVEL,
+    return _build_from_map(
+        cmd_map,
+        "get_nb_level",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_nb_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_nb_level")
+@require_cmd_map
 def set_nb_level(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set NB Level command."""
-    return _build_level_set(
-        _SUB_NB_LEVEL,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_nb_level",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_nb_level",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_digisel_shift")
+@require_cmd_map
 def get_digisel_shift(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read DIGI-SEL Shift command."""
-    return _build_level_get(
-        _SUB_DIGISEL_SHIFT,
+    return _build_from_map(
+        cmd_map,
+        "get_digisel_shift",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_digisel_shift",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_digisel_shift")
+@require_cmd_map
 def set_digisel_shift(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set DIGI-SEL Shift command."""
-    return _build_level_set(
-        _SUB_DIGISEL_SHIFT,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_digisel_shift",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=_level_bcd_encode(level),
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_digisel_shift",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_drive_gain")
+@require_cmd_map
 def get_drive_gain(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Drive Gain command."""
-    return _build_level_get(
-        _SUB_DRIVE_GAIN,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_drive_gain",
+    return _build_from_map(
+        cmd_map, "get_drive_gain", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_drive_gain")
+@require_cmd_map
 def set_drive_gain(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Drive Gain command."""
-    return _build_level_set(
-        _SUB_DRIVE_GAIN,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_drive_gain",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_drive_gain",
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_monitor_gain")
+@require_cmd_map
 def get_monitor_gain(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Monitor Gain command."""
-    return _build_level_get(
-        _SUB_MONITOR_GAIN,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_monitor_gain",
+    return _build_from_map(
+        cmd_map, "get_monitor_gain", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_monitor_gain")
+@require_cmd_map
 def set_monitor_gain(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Monitor Gain command."""
-    return _build_level_set(
-        _SUB_MONITOR_GAIN,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_monitor_gain",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_monitor_gain",
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_vox_gain")
+@require_cmd_map
 def get_vox_gain(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Vox Gain command."""
-    return _build_level_get(
-        _SUB_VOX_GAIN,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_vox_gain",
+    return _build_from_map(
+        cmd_map, "get_vox_gain", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_vox_gain")
+@require_cmd_map
 def set_vox_gain(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Vox Gain command."""
-    return _build_level_set(
-        _SUB_VOX_GAIN,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_vox_gain",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_vox_gain",
+        data=_level_bcd_encode(level),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_anti_vox_gain")
+@require_cmd_map
 def get_anti_vox_gain(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Anti-Vox Gain command."""
-    return _build_level_get(
-        _SUB_ANTI_VOX_GAIN,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_anti_vox_gain",
+    return _build_from_map(
+        cmd_map, "get_anti_vox_gain", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_anti_vox_gain")
+@require_cmd_map
 def set_anti_vox_gain(
     level: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Anti-Vox Gain command."""
-    return _build_level_set(
-        _SUB_ANTI_VOX_GAIN,
-        level,
+    return _build_from_map(
+        cmd_map,
+        "set_anti_vox_gain",
         to_addr=to_addr,
         from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="set_anti_vox_gain",
+        data=_level_bcd_encode(level),
     )
 
 
-# --- CTL_MEM-based levels ---
+# --- CTL_MEM-based levels (menu addresses vary by radio -- see rigs/*.toml) ---
 
 
+@expose_command_key(lambda cmd_map: "get_ref_adjust")
+@require_cmd_map
 def get_ref_adjust(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read REF Adjust command."""
-    return _build_ctl_mem_get(
-        _CTL_MEM_REF_ADJUST,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_ref_adjust",
+    return _build_from_map(
+        cmd_map, "get_ref_adjust", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_ref_adjust")
+@require_cmd_map
 def set_ref_adjust(
     value: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set REF Adjust command."""
     if not 0 <= value <= 511:
         raise ValueError(f"REF Adjust must be 0-511, got {value}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_REF_ADJUST,
-        value,
+    return _build_from_map(
+        cmd_map,
+        "set_ref_adjust",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=2,
-        cmd_map=cmd_map,
-        cmd_name="set_ref_adjust",
+        data=bcd_encode_value(value, byte_count=2),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_dash_ratio")
+@require_cmd_map
 def get_dash_ratio(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Dash Ratio command."""
-    return _build_ctl_mem_get(
-        _CTL_MEM_DASH_RATIO,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_dash_ratio",
+    return _build_from_map(
+        cmd_map, "get_dash_ratio", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_dash_ratio")
+@require_cmd_map
 def set_dash_ratio(
     value: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set Dash Ratio command."""
     if not 28 <= value <= 45:
         raise ValueError(f"Dash Ratio must be 28-45, got {value}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_DASH_RATIO,
-        value,
+    return _build_from_map(
+        cmd_map,
+        "set_dash_ratio",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_dash_ratio",
+        data=bcd_encode_value(value, byte_count=1),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_nb_depth")
+@require_cmd_map
 def get_nb_depth(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read NB Depth command."""
-    return _build_ctl_mem_get(
-        _CTL_MEM_NB_DEPTH,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_nb_depth",
+    return _build_from_map(
+        cmd_map, "get_nb_depth", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_nb_depth")
+@require_cmd_map
 def set_nb_depth(
     value: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set NB Depth command."""
     if not 0 <= value <= 9:
         raise ValueError(f"NB Depth must be 0-9, got {value}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_NB_DEPTH,
-        value,
+    return _build_from_map(
+        cmd_map,
+        "set_nb_depth",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_nb_depth",
+        data=bcd_encode_value(value, byte_count=1),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_nb_width")
+@require_cmd_map
 def get_nb_width(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read NB Width command."""
-    return _build_ctl_mem_get(
-        _CTL_MEM_NB_WIDTH,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_nb_width",
+    return _build_from_map(
+        cmd_map, "get_nb_width", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_nb_width")
+@require_cmd_map
 def set_nb_width(
     value: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set NB Width command."""
     if not 0 <= value <= 255:
         raise ValueError(f"NB Width must be 0-255, got {value}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_NB_WIDTH,
-        value,
+    return _build_from_map(
+        cmd_map,
+        "set_nb_width",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=2,
-        cmd_map=cmd_map,
-        cmd_name="set_nb_width",
+        data=bcd_encode_value(value, byte_count=2),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_vox_delay")
+@require_cmd_map
 def get_vox_delay(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read VOX Delay command (0x1A 0x05 0x02 0x92)."""
-    return _build_ctl_mem_get(
-        _CTL_MEM_VOX_DELAY,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_vox_delay",
+    return _build_from_map(
+        cmd_map, "get_vox_delay", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_vox_delay")
+@require_cmd_map
 def set_vox_delay(
     value: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set VOX Delay command (0x1A 0x05 0x02 0x92)."""
     if not 0 <= value <= 20:
         raise ValueError(f"VOX Delay must be 0-20, got {value}")
-    return _build_ctl_mem_set(
-        _CTL_MEM_VOX_DELAY,
-        value,
+    return _build_from_map(
+        cmd_map,
+        "set_vox_delay",
         to_addr=to_addr,
         from_addr=from_addr,
-        byte_count=1,
-        cmd_map=cmd_map,
-        cmd_name="set_vox_delay",
+        data=bcd_encode_value(value, byte_count=1),
     )
 
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -98,7 +98,6 @@ from rigplane.commands import (
     build_memory_to_vfo,
     build_memory_write,
     get_acc1_mod_level,
-    get_af_level,
     get_af_mute,
     get_agc,
     get_agc_time_constant,
@@ -151,8 +150,6 @@ from rigplane.commands import (
     get_pbt_outer,
     get_power_meter,
     get_ref_adjust,
-    get_rf_gain,
-    get_rf_power,
     get_rit_frequency,
     get_rit_status,
     get_rit_tx_status,
@@ -162,6 +159,7 @@ from rigplane.commands import (
     get_s_meter_sql_status,
     get_speech,
     get_split,
+    get_squelch,
     get_ssb_tx_bandwidth,
     get_swr,
     get_system_date,
@@ -206,53 +204,31 @@ from rigplane.commands import (
     scan_start_type,
     scan_stop,
     send_cw,
-    set_af_level,
     set_af_mute,
     set_agc,
     set_agc_time_constant,
     set_antenna_1,
     set_antenna_2,
-    set_anti_vox_gain,
-    set_apf_type_level,
     set_attenuator,
     set_attenuator_level,
     set_audio_peak_filter,
     set_auto_notch,
     set_break_in,
-    set_break_in_delay,
     set_bsr,
     set_compressor,
-    set_compressor_level,
-    set_cw_pitch,
-    set_dash_ratio,
     set_dial_lock,
     set_digisel,
-    set_digisel_shift,
-    set_drive_gain,
     set_dual_watch,
     set_filter_shape,
     set_freq,
     set_ip_plus,
-    set_key_speed,
     set_manual_notch,
     set_manual_notch_width,
-    set_mic_gain,
     set_mode,
     set_monitor,
-    set_monitor_gain,
     set_nb,
-    set_nb_depth,
-    set_nb_level,
-    set_nb_width,
-    set_notch_filter,
     set_nr,
-    set_nr_level,
-    set_pbt_inner,
-    set_pbt_outer,
     set_preamp,
-    set_ref_adjust,
-    set_rf_gain,
-    set_rf_power,
     set_rit_frequency,
     set_rit_status,
     set_rit_tx_status,
@@ -268,8 +244,6 @@ from rigplane.commands import (
     set_tx_freq_monitor,
     set_utc_offset,
     set_vox,
-    set_vox_delay,
-    set_vox_gain,
     set_xfc_status,
     stop_cw,
 )
@@ -2591,13 +2565,21 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._check_connected()
         await self._send_civ_raw(civ, wait_response=False)
 
+    # commands/levels.py, migrated onto the bound command map (MOR-2006
+    # Steps 5..N module 2, plan §4): requests go through
+    # ``self._commands.<builder>`` and matcher-backed replies through
+    # ``self._expect_shape`` (§6 population 1). ``get_rf_power``,
+    # ``get_rf_gain`` and ``get_af_level`` parse their reply with
+    # ``_level_bcd_decode``/``_parse_level`` directly, without checking the
+    # reply's command/sub bytes, so they have no matcher shape to migrate.
+
     async def get_rf_power(self) -> int:
         """Get the RF power level (0-255).
 
         On timeout falls back to the state cache if populated.
         """
         self._check_connected()
-        civ = get_rf_power(to_addr=self._radio_addr)
+        civ = self._commands.get_rf_power(to_addr=self._radio_addr)
         try:
             resp = await self._send_civ_expect(
                 civ, key="get_rf_power", dedupe=True, label="get_rf_power"
@@ -2623,7 +2605,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             level: Power level 0-255.
         """
         self._check_connected()
-        civ = set_rf_power(level, to_addr=self._radio_addr)
+        civ = self._commands.set_rf_power(level, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
         self._last_power = level
 
@@ -2638,7 +2620,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             operation="get_rf_gain",
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x02)
-        civ = get_rf_gain(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
+        civ = self._commands.get_rf_gain(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         try:
             resp = await self._send_civ_expect(
                 civ,
@@ -2664,7 +2648,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             operation="set_rf_gain",
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x02)
-        civ = set_rf_gain(
+        civ = self._commands.set_rf_gain(
             level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         await self._send_civ_raw(civ, wait_response=False)
@@ -2680,7 +2664,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             operation="get_af_level",
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x01)
-        civ = get_af_level(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
+        civ = self._commands.get_af_level(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
         try:
             resp = await self._send_civ_expect(
                 civ,
@@ -2706,7 +2692,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             operation="set_af_level",
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x01)
-        civ = set_af_level(
+        civ = self._commands.set_af_level(
             level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         await self._send_civ_raw(civ, wait_response=False)
@@ -2724,10 +2710,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_squelch",
         )
-        from rigplane.commands import set_squelch as _set_squelch
-
         cmd29 = self._profile.supports_cmd29(0x14, 0x03)
-        civ = _set_squelch(
+        civ = self._commands.set_squelch(
             level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         await self._send_civ_raw(civ, wait_response=False)
@@ -2743,15 +2727,17 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="get_squelch",
         )
-        from rigplane.commands import get_squelch as _get_squelch
-
         cmd29 = self._profile.supports_cmd29(0x14, 0x03)
-        civ = _get_squelch(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
+        civ = self._commands.get_squelch(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
+        command, sub, prefix = self._expect_shape(get_squelch)
         return await self._get_bcd_level(
             civ,
             key=f"get_squelch:{receiver}",
-            command=0x14,
-            sub=0x03,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def get_apf_type_level(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -2761,14 +2747,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x05, receiver=receiver, operation="get_apf_type_level"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x05)
-        civ = get_apf_type_level(
+        civ = self._commands.get_apf_type_level(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, prefix = self._expect_shape(get_apf_type_level)
         return await self._get_bcd_level(
             civ,
             key=f"get_apf_type_level:{receiver}",
-            command=0x14,
-            sub=0x05,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_apf_type_level(
@@ -2781,7 +2769,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x05)
         await self._send_fire_and_forget(
-            set_apf_type_level(
+            self._commands.set_apf_type_level(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -2793,9 +2781,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x06, receiver=receiver, operation="get_nr_level"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x06)
-        civ = get_nr_level(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
+        civ = self._commands.get_nr_level(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
+        command, sub, prefix = self._expect_shape(get_nr_level)
         return await self._get_bcd_level(
-            civ, key=f"get_nr_level:{receiver}", command=0x14, sub=0x06
+            civ, key=f"get_nr_level:{receiver}", command=command, sub=sub, prefix=prefix
         )
 
     async def set_nr_level(self, level: int, receiver: int = RECEIVER_MAIN) -> None:
@@ -2806,7 +2797,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x06)
         await self._send_fire_and_forget(
-            set_nr_level(
+            self._commands.set_nr_level(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -2818,11 +2809,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x07, receiver=receiver, operation="get_pbt_inner"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x07)
-        civ = get_pbt_inner(
+        civ = self._commands.get_pbt_inner(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, prefix = self._expect_shape(get_pbt_inner)
         return await self._get_bcd_level(
-            civ, key=f"get_pbt_inner:{receiver}", command=0x14, sub=0x07
+            civ,
+            key=f"get_pbt_inner:{receiver}",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_pbt_inner(self, level: int, receiver: int = RECEIVER_MAIN) -> None:
@@ -2833,7 +2829,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x07)
         await self._send_fire_and_forget(
-            set_pbt_inner(
+            self._commands.set_pbt_inner(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -2845,11 +2841,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x08, receiver=receiver, operation="get_pbt_outer"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x08)
-        civ = get_pbt_outer(
+        civ = self._commands.get_pbt_outer(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, prefix = self._expect_shape(get_pbt_outer)
         return await self._get_bcd_level(
-            civ, key=f"get_pbt_outer:{receiver}", command=0x14, sub=0x08
+            civ,
+            key=f"get_pbt_outer:{receiver}",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_pbt_outer(self, level: int, receiver: int = RECEIVER_MAIN) -> None:
@@ -2860,53 +2861,63 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x08)
         await self._send_fire_and_forget(
-            set_pbt_outer(
+            self._commands.set_pbt_outer(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
 
     async def get_cw_pitch(self) -> int:
         """Read CW pitch in Hz."""
+        command, sub, prefix = self._expect_shape(get_cw_pitch)
         level = await self._get_bcd_level(
-            get_cw_pitch(to_addr=self._radio_addr),
+            self._commands.get_cw_pitch(to_addr=self._radio_addr),
             key="get_cw_pitch",
-            command=0x14,
-            sub=0x09,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
         return round((((600.0 / 255.0) * level) + 300) / 5.0) * 5
 
     async def set_cw_pitch(self, pitch_hz: int) -> None:
         """Set CW pitch in Hz."""
         await self._send_fire_and_forget(
-            set_cw_pitch(pitch_hz, to_addr=self._radio_addr)
+            self._commands.set_cw_pitch(pitch_hz, to_addr=self._radio_addr)
         )
 
     async def get_mic_gain(self) -> int:
         """Read Mic Gain (0-255)."""
+        command, sub, prefix = self._expect_shape(get_mic_gain)
         return await self._get_bcd_level(
-            get_mic_gain(to_addr=self._radio_addr),
+            self._commands.get_mic_gain(to_addr=self._radio_addr),
             key="get_mic_gain",
-            command=0x14,
-            sub=0x0B,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_mic_gain(self, level: int) -> None:
         """Set Mic Gain (0-255)."""
-        await self._send_fire_and_forget(set_mic_gain(level, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_mic_gain(level, to_addr=self._radio_addr)
+        )
 
     async def get_key_speed(self) -> int:
         """Read key speed in WPM."""
+        command, sub, prefix = self._expect_shape(get_key_speed)
         level = await self._get_bcd_level(
-            get_key_speed(to_addr=self._radio_addr),
+            self._commands.get_key_speed(to_addr=self._radio_addr),
             key="get_key_speed",
-            command=0x14,
-            sub=0x0C,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
         return round((level / 6.071) + 6)
 
     async def set_key_speed(self, wpm: int) -> None:
         """Set key speed in WPM."""
-        await self._send_fire_and_forget(set_key_speed(wpm, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_key_speed(wpm, to_addr=self._radio_addr)
+        )
 
     async def get_notch_filter(self, receiver: int = RECEIVER_MAIN) -> int:
         """Read notch filter level (0-255)."""
@@ -2915,14 +2926,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x0D, receiver=receiver, operation="get_notch_filter"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x0D)
-        civ = get_notch_filter(
+        civ = self._commands.get_notch_filter(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, prefix = self._expect_shape(get_notch_filter)
         return await self._get_bcd_level(
             civ,
             key=f"get_notch_filter:{receiver}",
-            command=0x14,
-            sub=0x0D,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_notch_filter(self, level: int, receiver: int = RECEIVER_MAIN) -> None:
@@ -2933,39 +2946,43 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x0D)
         await self._send_fire_and_forget(
-            set_notch_filter(
+            self._commands.set_notch_filter(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
 
     async def get_compressor_level(self) -> int:
         """Read compressor level (0-255)."""
+        command, sub, prefix = self._expect_shape(get_compressor_level)
         return await self._get_bcd_level(
-            get_compressor_level(to_addr=self._radio_addr),
+            self._commands.get_compressor_level(to_addr=self._radio_addr),
             key="get_compressor_level",
-            command=0x14,
-            sub=0x0E,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_compressor_level(self, level: int) -> None:
         """Set compressor level (0-255)."""
         await self._send_fire_and_forget(
-            set_compressor_level(level, to_addr=self._radio_addr)
+            self._commands.set_compressor_level(level, to_addr=self._radio_addr)
         )
 
     async def get_break_in_delay(self) -> int:
         """Read break-in delay level (0-255)."""
+        command, sub, prefix = self._expect_shape(get_break_in_delay)
         return await self._get_bcd_level(
-            get_break_in_delay(to_addr=self._radio_addr),
+            self._commands.get_break_in_delay(to_addr=self._radio_addr),
             key="get_break_in_delay",
-            command=0x14,
-            sub=0x0F,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_break_in_delay(self, level: int) -> None:
         """Set break-in delay level (0-255)."""
         await self._send_fire_and_forget(
-            set_break_in_delay(level, to_addr=self._radio_addr)
+            self._commands.set_break_in_delay(level, to_addr=self._radio_addr)
         )
 
     async def get_nb_level(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -2975,9 +2992,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x12, receiver=receiver, operation="get_nb_level"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x12)
-        civ = get_nb_level(to_addr=self._radio_addr, receiver=receiver, command29=cmd29)
+        civ = self._commands.get_nb_level(
+            to_addr=self._radio_addr, receiver=receiver, command29=cmd29
+        )
+        command, sub, prefix = self._expect_shape(get_nb_level)
         return await self._get_bcd_level(
-            civ, key=f"get_nb_level:{receiver}", command=0x14, sub=0x12
+            civ, key=f"get_nb_level:{receiver}", command=command, sub=sub, prefix=prefix
         )
 
     async def set_nb_level(self, level: int, receiver: int = RECEIVER_MAIN) -> None:
@@ -2988,7 +3008,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x12)
         await self._send_fire_and_forget(
-            set_nb_level(
+            self._commands.set_nb_level(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -3000,11 +3020,16 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x14, 0x13, receiver=receiver, operation="get_digisel_shift"
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x13)
-        civ = get_digisel_shift(
+        civ = self._commands.get_digisel_shift(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, prefix = self._expect_shape(get_digisel_shift)
         return await self._get_bcd_level(
-            civ, key=f"get_digisel_shift:{receiver}", command=0x14, sub=0x13
+            civ,
+            key=f"get_digisel_shift:{receiver}",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_digisel_shift(
@@ -3017,145 +3042,166 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x14, 0x13)
         await self._send_fire_and_forget(
-            set_digisel_shift(
+            self._commands.set_digisel_shift(
                 level, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
 
     async def get_drive_gain(self) -> int:
         """Read drive gain (0-255)."""
+        command, sub, prefix = self._expect_shape(get_drive_gain)
         return await self._get_bcd_level(
-            get_drive_gain(to_addr=self._radio_addr),
+            self._commands.get_drive_gain(to_addr=self._radio_addr),
             key="get_drive_gain",
-            command=0x14,
-            sub=0x14,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_drive_gain(self, level: int) -> None:
         """Set drive gain (0-255)."""
         await self._send_fire_and_forget(
-            set_drive_gain(level, to_addr=self._radio_addr)
+            self._commands.set_drive_gain(level, to_addr=self._radio_addr)
         )
 
     async def get_monitor_gain(self) -> int:
         """Read monitor gain (0-255)."""
+        command, sub, prefix = self._expect_shape(get_monitor_gain)
         return await self._get_bcd_level(
-            get_monitor_gain(to_addr=self._radio_addr),
+            self._commands.get_monitor_gain(to_addr=self._radio_addr),
             key="get_monitor_gain",
-            command=0x14,
-            sub=0x15,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_monitor_gain(self, level: int) -> None:
         """Set monitor gain (0-255)."""
         await self._send_fire_and_forget(
-            set_monitor_gain(level, to_addr=self._radio_addr)
+            self._commands.set_monitor_gain(level, to_addr=self._radio_addr)
         )
 
     async def get_vox_gain(self) -> int:
         """Read VOX gain (0-255)."""
+        command, sub, prefix = self._expect_shape(get_vox_gain)
         return await self._get_bcd_level(
-            get_vox_gain(to_addr=self._radio_addr),
+            self._commands.get_vox_gain(to_addr=self._radio_addr),
             key="get_vox_gain",
-            command=0x14,
-            sub=0x16,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_vox_gain(self, level: int) -> None:
         """Set VOX gain (0-255)."""
-        await self._send_fire_and_forget(set_vox_gain(level, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_vox_gain(level, to_addr=self._radio_addr)
+        )
 
     async def get_anti_vox_gain(self) -> int:
         """Read anti-VOX gain (0-255)."""
+        command, sub, prefix = self._expect_shape(get_anti_vox_gain)
         return await self._get_bcd_level(
-            get_anti_vox_gain(to_addr=self._radio_addr),
+            self._commands.get_anti_vox_gain(to_addr=self._radio_addr),
             key="get_anti_vox_gain",
-            command=0x14,
-            sub=0x17,
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_anti_vox_gain(self, level: int) -> None:
         """Set anti-VOX gain (0-255)."""
         await self._send_fire_and_forget(
-            set_anti_vox_gain(level, to_addr=self._radio_addr)
+            self._commands.set_anti_vox_gain(level, to_addr=self._radio_addr)
         )
 
     async def get_ref_adjust(self) -> int:
         """Read REF Adjust (0-511)."""
+        command, sub, prefix = self._expect_shape(get_ref_adjust)
         return await self._get_bcd_level(
-            get_ref_adjust(to_addr=self._radio_addr),
+            self._commands.get_ref_adjust(to_addr=self._radio_addr),
             key="get_ref_adjust",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x00\x70",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_ref_adjust(self, value: int) -> None:
         """Set REF Adjust (0-511)."""
         await self._send_fire_and_forget(
-            set_ref_adjust(value, to_addr=self._radio_addr)
+            self._commands.set_ref_adjust(value, to_addr=self._radio_addr)
         )
 
     async def get_dash_ratio(self) -> int:
         """Read dash ratio (28-45)."""
+        command, sub, prefix = self._expect_shape(get_dash_ratio)
         return await self._get_bcd_level(
-            get_dash_ratio(to_addr=self._radio_addr),
+            self._commands.get_dash_ratio(to_addr=self._radio_addr),
             key="get_dash_ratio",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x02\x28",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_dash_ratio(self, value: int) -> None:
         """Set dash ratio (28-45)."""
         await self._send_fire_and_forget(
-            set_dash_ratio(value, to_addr=self._radio_addr)
+            self._commands.set_dash_ratio(value, to_addr=self._radio_addr)
         )
 
     async def get_nb_depth(self) -> int:
         """Read NB depth (0-9)."""
+        command, sub, prefix = self._expect_shape(get_nb_depth)
         return await self._get_bcd_level(
-            get_nb_depth(to_addr=self._radio_addr),
+            self._commands.get_nb_depth(to_addr=self._radio_addr),
             key="get_nb_depth",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x02\x90",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_nb_depth(self, value: int) -> None:
         """Set NB depth (0-9)."""
-        await self._send_fire_and_forget(set_nb_depth(value, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_nb_depth(value, to_addr=self._radio_addr)
+        )
 
     async def get_nb_width(self) -> int:
         """Read NB width (0-255)."""
+        command, sub, prefix = self._expect_shape(get_nb_width)
         return await self._get_bcd_level(
-            get_nb_width(to_addr=self._radio_addr),
+            self._commands.get_nb_width(to_addr=self._radio_addr),
             key="get_nb_width",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x02\x91",
+            command=command,
+            sub=sub,
+            prefix=prefix,
         )
 
     async def set_nb_width(self, value: int) -> None:
         """Set NB width (0-255)."""
-        await self._send_fire_and_forget(set_nb_width(value, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_nb_width(value, to_addr=self._radio_addr)
+        )
 
     async def get_vox_delay(self) -> int:
         """Read VOX delay (0-20, units of 0.1s)."""
+        command, sub, prefix = self._expect_shape(get_vox_delay)
         return await self._get_bcd_level(
-            get_vox_delay(to_addr=self._radio_addr),
+            self._commands.get_vox_delay(to_addr=self._radio_addr),
             key="get_vox_delay",
-            command=0x1A,
-            sub=0x05,
-            prefix=b"\x02\x92",
+            command=command,
+            sub=sub,
+            prefix=prefix,
             bcd_bytes=1,
         )
 
     async def set_vox_delay(self, level: int) -> None:
         """Set VOX delay (0-20, units of 0.1s)."""
-        await self._send_fire_and_forget(set_vox_delay(level, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_vox_delay(level, to_addr=self._radio_addr)
+        )
 
     async def get_af_mute(self, receiver: int = RECEIVER_MAIN) -> bool:
         """Read AF mute status."""

--- a/tests/command_map_parity_divergences.txt
+++ b/tests/command_map_parity_divergences.txt
@@ -4,35 +4,11 @@
 # here, and on a row here that no longer disagrees -- delete that
 # row, never keep it. Regenerating can still add rows, so read any
 # addition as a new divergence someone has to justify.
-IC-705	levels.py:get_dash_ratio	(no arguments)	map=fefea4e01a050252fd fallback=fefea4e01a050228fd
-IC-705	levels.py:get_nb_depth	(no arguments)	map=fefea4e01a050357fd fallback=fefea4e01a050290fd
-IC-705	levels.py:get_nb_width	(no arguments)	map=fefea4e01a050358fd fallback=fefea4e01a050291fd
-IC-705	levels.py:get_ref_adjust	(no arguments)	map=fefea4e01a050089fd fallback=fefea4e01a050070fd
-IC-705	levels.py:get_vox_delay	(no arguments)	map=fefea4e01a050359fd fallback=fefea4e01a050292fd
-IC-705	levels.py:set_dash_ratio	value=30	map=fefea4e01a05025230fd fallback=fefea4e01a05022830fd
-IC-705	levels.py:set_nb_depth	value=0	map=fefea4e01a05035700fd fallback=fefea4e01a05029000fd
-IC-705	levels.py:set_nb_width	value=0	map=fefea4e01a0503580000fd fallback=fefea4e01a0502910000fd
-IC-705	levels.py:set_ref_adjust	value=0	map=fefea4e01a0500890000fd fallback=fefea4e01a0500700000fd
-IC-705	levels.py:set_vox_delay	value=0	map=fefea4e01a05035900fd fallback=fefea4e01a05029200fd
 IC-705	vfo.py:get_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
 IC-705	vfo.py:set_quick_split	(no arguments)	map=fefea4e01a050045fd fallback=fefea4e01a050033fd
-IC-7300	levels.py:get_dash_ratio	(no arguments)	map=fefe94e01a050161fd fallback=fefe94e01a050228fd
-IC-7300	levels.py:get_nb_depth	(no arguments)	map=fefe94e01a050189fd fallback=fefe94e01a050290fd
-IC-7300	levels.py:get_nb_width	(no arguments)	map=fefe94e01a050190fd fallback=fefe94e01a050291fd
-IC-7300	levels.py:get_vox_delay	(no arguments)	map=fefe94e01a050191fd fallback=fefe94e01a050292fd
-IC-7300	levels.py:set_dash_ratio	value=30	map=fefe94e01a05016130fd fallback=fefe94e01a05022830fd
-IC-7300	levels.py:set_nb_depth	value=0	map=fefe94e01a05018900fd fallback=fefe94e01a05029000fd
-IC-7300	levels.py:set_nb_width	value=0	map=fefe94e01a0501900000fd fallback=fefe94e01a0502910000fd
-IC-7300	levels.py:set_vox_delay	value=0	map=fefe94e01a05019100fd fallback=fefe94e01a05029200fd
 IC-7300	vfo.py:get_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7300	vfo.py:quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
 IC-7300	vfo.py:set_quick_split	(no arguments)	map=fefe94e01a050030fd fallback=fefe94e01a050033fd
-IC-9700	levels.py:get_dash_ratio	(no arguments)	map=fefea2e01a050224fd fallback=fefea2e01a050228fd
-IC-9700	levels.py:get_ref_adjust	(no arguments)	map=fefea2e01a050072fd fallback=fefea2e01a050070fd
-IC-9700	levels.py:get_vox_delay	(no arguments)	map=fefea2e01a050330fd fallback=fefea2e01a050292fd
-IC-9700	levels.py:set_dash_ratio	value=30	map=fefea2e01a05022430fd fallback=fefea2e01a05022830fd
-IC-9700	levels.py:set_ref_adjust	value=0	map=fefea2e01a0500720000fd fallback=fefea2e01a0500700000fd
-IC-9700	levels.py:set_vox_delay	value=0	map=fefea2e01a05033000fd fallback=fefea2e01a05029200fd
 IC-9700	vfo.py:get_dual_watch	(no arguments)	map=fefea2e01659fd fallback=fefea2e007c2fd
 IC-9700	vfo.py:get_quick_split	(no arguments)	map=fefea2e01a050043fd fallback=fefea2e01a050033fd
 IC-9700	vfo.py:quick_split	(no arguments)	map=fefea2e01a050043fd fallback=fefea2e01a050033fd

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -26,77 +26,55 @@
 # reachable from a builder that was compared, not sites observed to
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
-census	builders_compared	212
+census	builders_compared	162
 census	cat_only_profiles	2
-census	dual_implementation_sites	133
-census	frames_diverged	33
-census	frames_identical	1367
+census	dual_implementation_sites	128
+census	frames_diverged	9
+census	frames_identical	999
 census	hardcode_only_builders	16
-census	profile_builder_map_gaps	890
+census	profile_builder_map_gaps	702
 census	profiles	8
 census	public_builders	232
-census	sites_compared	124
+census	sites_compared	118
 cat-only	FTX-1	108
 cat-only	TX-500	50
-gap	get_af_level	FTX-1,TX-500
 gap	get_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_agc	FTX-1,TX-500,X6100
 gap	get_agc_time_constant	FTX-1,TX-500,X6100,X6200
 gap	get_alc	FTX-1,TX-500,X6100,X6200
 gap	get_antenna	FTX-1,TX-500,X6100,X6200
-gap	get_anti_vox_gain	FTX-1,TX-500,X6100,X6200
-gap	get_apf_type_level	FTX-1,IC-7300,TX-500,X6100,X6200
 gap	get_attenuator	FTX-1,TX-500,X6100
 gap	get_audio_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	get_auto_notch	FTX-1,TX-500,X6100,X6200
 gap	get_band_edge_freq	FTX-1,TX-500,X6100
 gap	get_break_in	FTX-1,TX-500,X6100,X6200
-gap	get_break_in_delay	FTX-1,TX-500,X6100,X6200
 gap	get_comp_meter	FTX-1,TX-500,X6100,X6200
 gap	get_compressor	FTX-1,TX-500,X6100,X6200
-gap	get_compressor_level	FTX-1,TX-500,X6100,X6200
-gap	get_cw_pitch	FTX-1,TX-500,X6100
-gap	get_dash_ratio	FTX-1,TX-500,X6100,X6200
 gap	get_data_mode	FTX-1,TX-500,X6100,X6200
 gap	get_dial_lock	FTX-1,TX-500,X6100
 gap	get_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	get_digisel_shift	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	get_drive_gain	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_dual_watch	FTX-1,IC-705,IC-7300,TX-500,X6100,X6200
 gap	get_filter_shape	FTX-1,TX-500,X6100,X6200
 gap	get_filter_width	FTX-1,TX-500,X6100
 gap	get_freq	FTX-1,TX-500
 gap	get_id_meter	FTX-1,TX-500,X6100,X6200
 gap	get_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
-gap	get_key_speed	FTX-1,TX-500,X6100
 gap	get_main_sub_band	FTX-1,IC-705,IC-7300,TX-500,X6100,X6200
 gap	get_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_manual_notch	FTX-1,TX-500,X6100,X6200
 gap	get_manual_notch_width	FTX-1,TX-500,X6100,X6200
-gap	get_mic_gain	FTX-1,TX-500,X6100
 gap	get_mode	FTX-1,TX-500
 gap	get_monitor	FTX-1,TX-500,X6100,X6200
-gap	get_monitor_gain	FTX-1,TX-500,X6100
 gap	get_nb	FTX-1,TX-500,X6100
-gap	get_nb_depth	FTX-1,IC-9700,TX-500,X6100,X6200
-gap	get_nb_level	FTX-1,TX-500,X6100
-gap	get_nb_width	FTX-1,IC-9700,TX-500,X6100,X6200
-gap	get_notch_filter	FTX-1,TX-500,X6100,X6200
 gap	get_nr	FTX-1,TX-500,X6100,X6200
-gap	get_nr_level	FTX-1,TX-500,X6100
 gap	get_overflow_status	FTX-1,TX-500,X6100,X6200
-gap	get_pbt_inner	FTX-1,TX-500,X6100,X6200
-gap	get_pbt_outer	FTX-1,TX-500,X6100,X6200
 gap	get_power_meter	FTX-1,TX-500,X6100
 gap	get_powerstat	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
 gap	get_preamp	FTX-1,TX-500,X6100
 gap	get_quick_dual_watch	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_quick_split	FTX-1,TX-500,X6100,X6200
-gap	get_ref_adjust	FTX-1,TX-500,X6100,X6200
 gap	get_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	get_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_rf_gain	FTX-1,TX-500
-gap	get_rf_power	FTX-1,TX-500,X6100
 gap	get_rit_frequency	FTX-1,TX-500,X6100,X6200
 gap	get_rit_status	FTX-1,TX-500,X6100,X6200
 gap	get_rit_tx_status	FTX-1,TX-500,X6100,X6200
@@ -118,7 +96,6 @@ gap	get_scope_speed	FTX-1,TX-500,X6100,X6200
 gap	get_scope_vbw	FTX-1,TX-500,X6100,X6200
 gap	get_speech	FTX-1,TX-500,X6100,X6200
 gap	get_split	FTX-1,TX-500,X6100,X6200
-gap	get_squelch	FTX-1,TX-500
 gap	get_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
 gap	get_swr	FTX-1,TX-500,X6100
 gap	get_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
@@ -132,8 +109,6 @@ gap	get_various_squelch	FTX-1,TX-500,X6100,X6200
 gap	get_vd_meter	FTX-1,TX-500,X6100
 gap	get_vfo	FTX-1,TX-500,X6100
 gap	get_vox	FTX-1,TX-500,X6100,X6200
-gap	get_vox_delay	FTX-1,TX-500,X6100,X6200
-gap	get_vox_gain	FTX-1,TX-500,X6100,X6200
 gap	get_xfc_status	FTX-1,TX-500,X6100,X6200
 gap	power_off	FTX-1,TX-500,X6100,X6200
 gap	power_on	FTX-1,TX-500,X6100,X6200
@@ -148,63 +123,40 @@ gap	scope_data_output	FTX-1,TX-500,X6100,X6200
 gap	scope_off	FTX-1,TX-500,X6100,X6200
 gap	scope_on	FTX-1,TX-500,X6100,X6200
 gap	send_cw	FTX-1,TX-500,X6100,X6200
-gap	set_af_level	FTX-1,TX-500
 gap	set_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_agc	FTX-1,TX-500,X6100
 gap	set_agc_time_constant	FTX-1,TX-500,X6100,X6200
 gap	set_antenna	FTX-1,TX-500,X6100,X6200
-gap	set_anti_vox_gain	FTX-1,TX-500,X6100,X6200
-gap	set_apf_type_level	FTX-1,IC-7300,TX-500,X6100,X6200
 gap	set_attenuator	FTX-1,TX-500,X6100
 gap	set_audio_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	set_auto_notch	FTX-1,TX-500,X6100,X6200
 gap	set_break_in	FTX-1,TX-500,X6100,X6200
-gap	set_break_in_delay	FTX-1,TX-500,X6100,X6200
 gap	set_compressor	FTX-1,TX-500,X6100,X6200
-gap	set_compressor_level	FTX-1,TX-500,X6100,X6200
-gap	set_cw_pitch	FTX-1,TX-500,X6100
-gap	set_dash_ratio	FTX-1,TX-500,X6100,X6200
 gap	set_data_mode	FTX-1,TX-500,X6100,X6200
 gap	set_dial_lock	FTX-1,TX-500,X6100
 gap	set_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	set_digisel_shift	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	set_drive_gain	FTX-1,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_dual_watch	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
 gap	set_filter_shape	FTX-1,TX-500,X6100,X6200
 gap	set_filter_width	FTX-1,TX-500,X6100,X6200
 gap	set_freq	FTX-1,TX-500
 gap	set_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
-gap	set_key_speed	FTX-1,TX-500,X6100
 gap	set_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_manual_notch	FTX-1,TX-500,X6100,X6200
 gap	set_manual_notch_width	FTX-1,TX-500,X6100,X6200
-gap	set_mic_gain	FTX-1,TX-500,X6100
 gap	set_mode	FTX-1,TX-500
 gap	set_monitor	FTX-1,TX-500,X6100,X6200
-gap	set_monitor_gain	FTX-1,TX-500,X6100
 gap	set_nb	FTX-1,TX-500,X6100
-gap	set_nb_depth	FTX-1,IC-9700,TX-500,X6100,X6200
-gap	set_nb_level	FTX-1,TX-500,X6100
-gap	set_nb_width	FTX-1,IC-9700,TX-500,X6100,X6200
-gap	set_notch_filter	FTX-1,TX-500,X6100,X6200
 gap	set_nr	FTX-1,TX-500,X6100,X6200
-gap	set_nr_level	FTX-1,TX-500,X6100
-gap	set_pbt_inner	FTX-1,TX-500,X6100,X6200
-gap	set_pbt_outer	FTX-1,TX-500,X6100,X6200
 gap	set_preamp	FTX-1,TX-500,X6100
 gap	set_quick_dual_watch	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_quick_split	FTX-1,TX-500,X6100,X6200
-gap	set_ref_adjust	FTX-1,TX-500,X6100,X6200
 gap	set_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	set_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	set_rf_gain	FTX-1,TX-500
-gap	set_rf_power	FTX-1,TX-500,X6100
 gap	set_rit_frequency	FTX-1,TX-500,X6100,X6200
 gap	set_rit_status	FTX-1,TX-500,X6100,X6200
 gap	set_rit_tx_status	FTX-1,TX-500,X6100,X6200
 gap	set_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_split	FTX-1,TX-500,X6100
-gap	set_squelch	FTX-1,TX-500
 gap	set_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
 gap	set_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	set_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
@@ -214,8 +166,6 @@ gap	set_twin_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	set_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
 gap	set_vfo	FTX-1,TX-500,X6100
 gap	set_vox	FTX-1,TX-500,X6100,X6200
-gap	set_vox_delay	FTX-1,TX-500,X6100,X6200
-gap	set_vox_gain	FTX-1,TX-500,X6100,X6200
 gap	set_xfc_status	FTX-1,TX-500,X6100,X6200
 gap	stop_cw	FTX-1,TX-500,X6100,X6200
 gap	system_date	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
@@ -241,6 +191,57 @@ requires-map	config.py:set_data3_mod_input
 requires-map	config.py:set_data_off_mod_input
 requires-map	config.py:set_lan_mod_level
 requires-map	config.py:set_usb_mod_level
+requires-map	levels.py:get_af_level
+requires-map	levels.py:get_anti_vox_gain
+requires-map	levels.py:get_apf_type_level
+requires-map	levels.py:get_break_in_delay
+requires-map	levels.py:get_compressor_level
+requires-map	levels.py:get_cw_pitch
+requires-map	levels.py:get_dash_ratio
+requires-map	levels.py:get_digisel_shift
+requires-map	levels.py:get_drive_gain
+requires-map	levels.py:get_key_speed
+requires-map	levels.py:get_mic_gain
+requires-map	levels.py:get_monitor_gain
+requires-map	levels.py:get_nb_depth
+requires-map	levels.py:get_nb_level
+requires-map	levels.py:get_nb_width
+requires-map	levels.py:get_notch_filter
+requires-map	levels.py:get_nr_level
+requires-map	levels.py:get_pbt_inner
+requires-map	levels.py:get_pbt_outer
+requires-map	levels.py:get_ref_adjust
+requires-map	levels.py:get_rf_gain
+requires-map	levels.py:get_rf_power
+requires-map	levels.py:get_squelch
+requires-map	levels.py:get_vox_delay
+requires-map	levels.py:get_vox_gain
+requires-map	levels.py:set_af_level
+requires-map	levels.py:set_anti_vox_gain
+requires-map	levels.py:set_apf_type_level
+requires-map	levels.py:set_break_in_delay
+requires-map	levels.py:set_compressor_level
+requires-map	levels.py:set_cw_pitch
+requires-map	levels.py:set_dash_ratio
+requires-map	levels.py:set_digisel_shift
+requires-map	levels.py:set_drive_gain
+requires-map	levels.py:set_key_speed
+requires-map	levels.py:set_mic_gain
+requires-map	levels.py:set_monitor_gain
+requires-map	levels.py:set_nb_depth
+requires-map	levels.py:set_nb_level
+requires-map	levels.py:set_nb_width
+requires-map	levels.py:set_notch_filter
+requires-map	levels.py:set_nr_level
+requires-map	levels.py:set_pbt_inner
+requires-map	levels.py:set_pbt_outer
+requires-map	levels.py:set_ref_adjust
+requires-map	levels.py:set_rf_gain
+requires-map	levels.py:set_rf_power
+requires-map	levels.py:set_squelch
+requires-map	levels.py:set_vox_delay
+requires-map	levels.py:set_vox_gain
+unpinned	_builders.py:_build_ctl_mem_get
 unpinned	power.py:get_powerstat
 unpinned	system.py:set_system_date
 unpinned	system.py:set_system_time

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -29,6 +29,13 @@ import pytest
 
 from rigplane import commands, IC_7610_ADDR
 from rigplane.command_map import CommandMap
+from rigplane.commands import (
+    CONTROLLER_ADDR,
+    RECEIVER_MAIN,
+    _level_bcd_encode,
+    build_civ_frame,
+    build_cmd29_frame,
+)
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.rig_loader import load_rig
 from _command_test_helpers import bind_default_addr_globals
@@ -48,7 +55,17 @@ def cmd_map():
 
 
 class TestGetterParity:
-    """These getters must build the same frame with IC-7610 cmd_map as without."""
+    """These getters must build the same frame with IC-7610 cmd_map as without.
+
+    commands/levels.py migrated onto the bound command map in MOR-2006
+    Steps 5..N (module 2): ``get_af_level``, ``get_rf_gain`` and
+    ``get_rf_power`` now require ``cmd_map`` -- there is no more "without"
+    to compare against, so their three cases below pin the map path
+    against the frame the deleted fallback used to build instead
+    (``rigs/ic7610.toml`` declares the same wire tuples the fallback did,
+    per ``tests/command_map_parity_divergences.txt`` naming no IC-7610 row
+    for any of the three).
+    """
 
     def test_get_frequency(self, cmd_map):
         assert commands.get_freq(cmd_map=cmd_map) == commands.get_freq()
@@ -57,13 +74,22 @@ class TestGetterParity:
         assert commands.get_mode(cmd_map=cmd_map) == commands.get_mode()
 
     def test_get_af_level(self, cmd_map):
-        assert commands.get_af_level(cmd_map=cmd_map) == commands.get_af_level()
+        # IC-7610 declares a cmd29 route for 0x14/0x01, so command29=True
+        # (the builder's default) wraps MAIN too (MOR-1543).
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x01, receiver=RECEIVER_MAIN
+        )
+        assert commands.get_af_level(cmd_map=cmd_map) == expected
 
     def test_get_rf_gain(self, cmd_map):
-        assert commands.get_rf_gain(cmd_map=cmd_map) == commands.get_rf_gain()
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x02, receiver=RECEIVER_MAIN
+        )
+        assert commands.get_rf_gain(cmd_map=cmd_map) == expected
 
     def test_get_power(self, cmd_map):
-        assert commands.get_rf_power(cmd_map=cmd_map) == commands.get_rf_power()
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x0A)
+        assert commands.get_rf_power(cmd_map=cmd_map) == expected
 
     def test_get_s_meter(self, cmd_map):
         assert commands.get_s_meter(cmd_map=cmd_map) == commands.get_s_meter()
@@ -112,7 +138,13 @@ class TestGetterParity:
 
 
 class TestSetterParity:
-    """These setters must build the same frame with IC-7610 cmd_map as without."""
+    """These setters must build the same frame with IC-7610 cmd_map as without.
+
+    Same MOR-2006 migration as ``TestGetterParity`` above: ``set_rf_power``,
+    ``set_af_level``, ``set_rf_gain`` and ``set_squelch`` now require
+    ``cmd_map``, so their cases pin the map path against the frame the
+    deleted fallback used to build.
+    """
 
     def test_set_frequency(self, cmd_map):
         assert commands.set_freq(14_200_000, cmd_map=cmd_map) == commands.set_freq(
@@ -120,16 +152,44 @@ class TestSetterParity:
         )
 
     def test_set_power(self, cmd_map):
-        assert commands.set_rf_power(128, cmd_map=cmd_map) == commands.set_rf_power(128)
+        expected = build_civ_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x0A, data=_level_bcd_encode(128)
+        )
+        assert commands.set_rf_power(128, cmd_map=cmd_map) == expected
 
     def test_set_af_level(self, cmd_map):
-        assert commands.set_af_level(200, cmd_map=cmd_map) == commands.set_af_level(200)
+        # IC-7610 declares a cmd29 route for 0x14/0x01 (MOR-1543).
+        expected = build_cmd29_frame(
+            IC_7610_ADDR,
+            CONTROLLER_ADDR,
+            0x14,
+            sub=0x01,
+            data=_level_bcd_encode(200),
+            receiver=RECEIVER_MAIN,
+        )
+        assert commands.set_af_level(200, cmd_map=cmd_map) == expected
 
     def test_set_rf_gain(self, cmd_map):
-        assert commands.set_rf_gain(128, cmd_map=cmd_map) == commands.set_rf_gain(128)
+        expected = build_cmd29_frame(
+            IC_7610_ADDR,
+            CONTROLLER_ADDR,
+            0x14,
+            sub=0x02,
+            data=_level_bcd_encode(128),
+            receiver=RECEIVER_MAIN,
+        )
+        assert commands.set_rf_gain(128, cmd_map=cmd_map) == expected
 
     def test_set_squelch(self, cmd_map):
-        assert commands.set_squelch(64, cmd_map=cmd_map) == commands.set_squelch(64)
+        expected = build_cmd29_frame(
+            IC_7610_ADDR,
+            CONTROLLER_ADDR,
+            0x14,
+            sub=0x03,
+            data=_level_bcd_encode(64),
+            receiver=RECEIVER_MAIN,
+        )
+        assert commands.set_squelch(64, cmd_map=cmd_map) == expected
 
     def test_set_tuning_step(self, cmd_map):
         assert commands.set_tuning_step(3, cmd_map=cmd_map) == commands.set_tuning_step(
@@ -311,19 +371,32 @@ class TestVfoScopeMapFallbackParityAcrossProfiles:
 
 
 class TestHelperCallerParity:
-    """These _build_*-delegating functions must match with cmd_map."""
+    """These _build_*-delegating functions must match with cmd_map.
+
+    ``get_apf_type_level``, ``get_nr_level`` and ``get_nb_level``
+    (commands/levels.py) and ``get_ref_adjust`` (below) migrated onto the
+    bound command map in MOR-2006 Steps 5..N (module 2) and now require
+    ``cmd_map`` -- their cases pin the map path against the frame the
+    deleted fallback used to build.
+    """
 
     def test_get_apf_type_level(self, cmd_map):
-        assert (
-            commands.get_apf_type_level(cmd_map=cmd_map)
-            == commands.get_apf_type_level()
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x05, receiver=RECEIVER_MAIN
         )
+        assert commands.get_apf_type_level(cmd_map=cmd_map) == expected
 
     def test_get_nr_level(self, cmd_map):
-        assert commands.get_nr_level(cmd_map=cmd_map) == commands.get_nr_level()
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x06, receiver=RECEIVER_MAIN
+        )
+        assert commands.get_nr_level(cmd_map=cmd_map) == expected
 
     def test_get_nb_level(self, cmd_map):
-        assert commands.get_nb_level(cmd_map=cmd_map) == commands.get_nb_level()
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x14, sub=0x12, receiver=RECEIVER_MAIN
+        )
+        assert commands.get_nb_level(cmd_map=cmd_map) == expected
 
     def test_get_agc(self, cmd_map):
         assert commands.get_agc(cmd_map=cmd_map) == commands.get_agc()
@@ -347,7 +420,10 @@ class TestHelperCallerParity:
         assert commands.get_filter_shape(cmd_map=cmd_map) == commands.get_filter_shape()
 
     def test_get_ref_adjust(self, cmd_map):
-        assert commands.get_ref_adjust(cmd_map=cmd_map) == commands.get_ref_adjust()
+        expected = build_civ_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x1A, sub=0x05, data=b"\x00\x70"
+        )
+        assert commands.get_ref_adjust(cmd_map=cmd_map) == expected
 
     def test_get_s_meter_sql_status(self, cmd_map):
         assert (
@@ -443,11 +519,14 @@ class TestCmd29Parity:
 class TestCommandMapOverride:
     """A hand-made CommandMap's wire bytes must show up in the frame it builds."""
 
-    def test_different_wire_bytes_produce_different_frame(self):
+    def test_different_wire_bytes_produce_different_frame(self, cmd_map):
+        # MOR-2006 Steps 5..N (module 2): get_af_level now requires
+        # cmd_map, so "different wire bytes" is shown against the real
+        # IC-7610 map rather than the deleted fallback.
         custom = CommandMap({"get_af_level": (0x16, 0x43)})
         result = commands.get_af_level(cmd_map=custom)
-        hardcoded = commands.get_af_level()
-        assert result != hardcoded
+        known_good = commands.get_af_level(cmd_map=cmd_map)
+        assert result != known_good
         assert b"\x16\x43" in result
 
     def test_custom_single_byte_command(self):
@@ -456,11 +535,14 @@ class TestCommandMapOverride:
         assert b"\xff" in result
         assert result != commands.get_freq()
 
-    def test_custom_setter(self):
+    def test_custom_setter(self, cmd_map):
+        # MOR-2006 Steps 5..N (module 2): set_rf_power now requires
+        # cmd_map, so the "different wire bytes" comparison uses the real
+        # IC-7610 map rather than the deleted fallback.
         custom = CommandMap({"set_rf_power": (0x14, 0xFF)})
         result = commands.set_rf_power(128, cmd_map=custom)
-        hardcoded = commands.set_rf_power(128)
-        assert result != hardcoded
+        known_good = commands.set_rf_power(128, cmd_map=cmd_map)
+        assert result != known_good
         assert b"\x14\xff" in result
 
     def test_four_byte_wire_extended_sub(self):

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -252,9 +252,13 @@ def _hardcode_only_builders() -> frozenset[Key]:
     the kernel gaining a public helper, or a module gaining a response
     parser. :func:`_builders` needs no module-level rule because its own
     ``__name__.startswith("_")`` filter already excludes every underscore
-    module: the eleven kernel helpers that do take a ``cmd_map``
-    (``_builders.py: _build_level_get`` and its nine siblings,
-    ``_frame.py: _build_from_map``) are all underscore-named. A public
+    module: the eight kernel helpers that do take a ``cmd_map``
+    (``_builders.py: _build_ctl_mem_get`` and its six siblings,
+    ``_frame.py: _build_from_map``) are all underscore-named -- down from
+    eleven at MOR-2006 module 1 (config.py): module 2 (levels.py) deleted
+    ``_build_level_get``, ``_build_level_set`` and ``_build_ctl_mem_set``,
+    each left with zero callers once levels.py de-delegated from them.
+    A public
     ``cmd_map``-taking helper added to one of those modules would move
     ``public_builders`` -- this rule is what keeps it out of this count.
     """

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -227,30 +227,42 @@ class TestModeCommands:
 
 
 class TestPowerCommands:
-    """Test RF power get/set commands."""
+    """Test RF power get/set commands.
 
-    def test_get_power(self) -> None:
-        frame = get_rf_power()
+    commands/levels.py migrated onto the bound command map in MOR-2006
+    Steps 5..N (module 2): both builders now require ``cmd_map``, and
+    ``rigs/ic7610.toml``'s ``get_rf_power``/``set_rf_power`` declare the
+    same ``[0x14, 0x0A]`` wire tuple the fallback used to build, so the
+    expected frames below are unchanged.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_get_power(self, cmd_map) -> None:
+        frame = get_rf_power(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x14\x0a\xfd"
 
-    def test_set_power(self) -> None:
+    def test_set_power(self, cmd_map) -> None:
         # Power level is 0-255 encoded as 2-byte BCD (00-02 55)
-        frame = set_rf_power(128)
+        frame = set_rf_power(128, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x14\x0a\x01\x28\xfd"
 
-    def test_set_power_zero(self) -> None:
-        frame = set_rf_power(0)
+    def test_set_power_zero(self, cmd_map) -> None:
+        frame = set_rf_power(0, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x14\x0a\x00\x00\xfd"
 
-    def test_set_power_max(self) -> None:
-        frame = set_rf_power(255)
+    def test_set_power_max(self, cmd_map) -> None:
+        frame = set_rf_power(255, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x14\x0a\x02\x55\xfd"
 
-    def test_set_power_out_of_range(self) -> None:
+    def test_set_power_out_of_range(self, cmd_map) -> None:
         with pytest.raises(ValueError):
-            set_rf_power(256)
+            set_rf_power(256, cmd_map=cmd_map)
         with pytest.raises(ValueError):
-            set_rf_power(-1)
+            set_rf_power(-1, cmd_map=cmd_map)
 
 
 class TestMeterCommands:
@@ -484,7 +496,20 @@ class TestCommand29:
 
 
 class TestCmd29ReceiverRouting:
-    """Test that per-receiver SET commands use cmd29 when receiver=SUB."""
+    """Test that per-receiver SET commands use cmd29 when receiver=SUB.
+
+    commands/levels.py migrated onto the bound command map in MOR-2006
+    Steps 5..N (module 2): its rf_gain/af_level/squelch builders now
+    require ``cmd_map``, and ``rigs/ic7610.toml`` declares the same wire
+    tuples the fallback used to build for all three -- no divergence rows
+    name IC-7610 -- so the expected frames below are unchanged; only the
+    ``cmd_map=`` wiring is new.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
 
     def test_set_frequency_main_no_cmd29(self) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_freq
@@ -516,145 +541,155 @@ class TestCmd29ReceiverRouting:
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x06  # Mode set command
 
-    def test_set_rf_gain_main_wrapped_by_default(self) -> None:
+    def test_set_rf_gain_main_wrapped_by_default(self, cmd_map) -> None:
         # MOR-1543: set_rf_gain's builder now defaults command29=True like
         # every other cmd29-eligible setter, instead of deriving the wrap
         # decision from receiver internally. IC-7610 declares a cmd29 route
         # for 0x14/0x02, so MAIN wraps too.
         from rigplane.commands import RECEIVER_MAIN, set_rf_gain
 
-        frame = set_rf_gain(128, receiver=RECEIVER_MAIN)
+        frame = set_rf_gain(128, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x00  # MAIN
         assert frame[6] == 0x14
         assert frame[7] == 0x02  # RF gain sub
 
-    def test_set_rf_gain_main_unwrapped_with_override(self) -> None:
+    def test_set_rf_gain_main_unwrapped_with_override(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_rf_gain
 
-        frame = set_rf_gain(128, receiver=RECEIVER_MAIN, command29=False)
+        frame = set_rf_gain(
+            128, receiver=RECEIVER_MAIN, command29=False, cmd_map=cmd_map
+        )
         assert frame[4] == 0x14  # Direct level cmd, no cmd29 prefix
         assert frame[5] == 0x02  # RF gain sub
 
-    def test_set_rf_gain_sub_uses_cmd29(self) -> None:
+    def test_set_rf_gain_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, set_rf_gain
 
-        frame = set_rf_gain(128, receiver=RECEIVER_SUB)
+        frame = set_rf_gain(128, receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x14  # Level command
         assert frame[7] == 0x02  # RF gain sub
 
-    def test_set_af_level_main_wrapped_by_default(self) -> None:
+    def test_set_af_level_main_wrapped_by_default(self, cmd_map) -> None:
         # MOR-1543: same fix as set_rf_gain — IC-7610 declares a cmd29 route
         # for 0x14/0x01, so MAIN wraps too.
         from rigplane.commands import RECEIVER_MAIN, set_af_level
 
-        frame = set_af_level(200, receiver=RECEIVER_MAIN)
+        frame = set_af_level(200, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x00  # MAIN
         assert frame[6] == 0x14
         assert frame[7] == 0x01  # AF level sub
 
-    def test_set_af_level_main_unwrapped_with_override(self) -> None:
+    def test_set_af_level_main_unwrapped_with_override(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_af_level
 
-        frame = set_af_level(200, receiver=RECEIVER_MAIN, command29=False)
+        frame = set_af_level(
+            200, receiver=RECEIVER_MAIN, command29=False, cmd_map=cmd_map
+        )
         assert frame[4] == 0x14
         assert frame[5] == 0x01  # AF level sub
 
-    def test_set_af_level_sub_uses_cmd29(self) -> None:
+    def test_set_af_level_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, set_af_level
 
-        frame = set_af_level(200, receiver=RECEIVER_SUB)
+        frame = set_af_level(200, receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01
         assert frame[6] == 0x14
         assert frame[7] == 0x01  # AF level sub
 
-    def test_get_rf_gain_main_wrapped_by_default(self) -> None:
+    def test_get_rf_gain_main_wrapped_by_default(self, cmd_map) -> None:
         # MOR-1543: get_rf_gain's builder now defaults command29=True.
         from rigplane.commands import RECEIVER_MAIN, get_rf_gain
 
-        frame = get_rf_gain(receiver=RECEIVER_MAIN)
+        frame = get_rf_gain(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x00  # MAIN
         assert frame[6] == 0x14
         assert frame[7] == 0x02  # RF gain sub
 
-    def test_get_rf_gain_main_unwrapped_with_override(self) -> None:
+    def test_get_rf_gain_main_unwrapped_with_override(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_rf_gain
 
-        frame = get_rf_gain(receiver=RECEIVER_MAIN, command29=False)
+        frame = get_rf_gain(receiver=RECEIVER_MAIN, command29=False, cmd_map=cmd_map)
         assert frame[4] == 0x14  # Direct level cmd, no cmd29 prefix
         assert frame[5] == 0x02  # RF gain sub
 
-    def test_get_rf_gain_sub_uses_cmd29(self) -> None:
+    def test_get_rf_gain_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, get_rf_gain
 
-        frame = get_rf_gain(receiver=RECEIVER_SUB)
+        frame = get_rf_gain(receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x14  # Level command
         assert frame[7] == 0x02  # RF gain sub
 
-    def test_get_rf_gain_default_is_main(self) -> None:
+    def test_get_rf_gain_default_is_main(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_rf_gain
 
-        assert get_rf_gain() == get_rf_gain(receiver=RECEIVER_MAIN)
+        assert get_rf_gain(cmd_map=cmd_map) == get_rf_gain(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        )
 
-    def test_get_af_level_main_wrapped_by_default(self) -> None:
+    def test_get_af_level_main_wrapped_by_default(self, cmd_map) -> None:
         # MOR-1543: get_af_level's builder now defaults command29=True.
         from rigplane.commands import RECEIVER_MAIN, get_af_level
 
-        frame = get_af_level(receiver=RECEIVER_MAIN)
+        frame = get_af_level(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x00  # MAIN
         assert frame[6] == 0x14
         assert frame[7] == 0x01  # AF level sub
 
-    def test_get_af_level_main_unwrapped_with_override(self) -> None:
+    def test_get_af_level_main_unwrapped_with_override(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_af_level
 
-        frame = get_af_level(receiver=RECEIVER_MAIN, command29=False)
+        frame = get_af_level(receiver=RECEIVER_MAIN, command29=False, cmd_map=cmd_map)
         assert frame[4] == 0x14
         assert frame[5] == 0x01  # AF level sub
 
-    def test_get_af_level_sub_uses_cmd29(self) -> None:
+    def test_get_af_level_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, get_af_level
 
-        frame = get_af_level(receiver=RECEIVER_SUB)
+        frame = get_af_level(receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x14
         assert frame[7] == 0x01  # AF level sub
 
-    def test_get_af_level_default_is_main(self) -> None:
+    def test_get_af_level_default_is_main(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_af_level
 
-        assert get_af_level() == get_af_level(receiver=RECEIVER_MAIN)
+        assert get_af_level(cmd_map=cmd_map) == get_af_level(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        )
 
-    def test_set_squelch_main_wrapped_by_default(self) -> None:
+    def test_set_squelch_main_wrapped_by_default(self, cmd_map) -> None:
         # MOR-1543: set_squelch's builder now defaults command29=True.
         from rigplane.commands import RECEIVER_MAIN, set_squelch
 
-        frame = set_squelch(100, receiver=RECEIVER_MAIN)
+        frame = set_squelch(100, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x00  # MAIN
         assert frame[6] == 0x14
         assert frame[7] == 0x03  # SQL sub
 
-    def test_set_squelch_main_unwrapped_with_override(self) -> None:
+    def test_set_squelch_main_unwrapped_with_override(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_squelch
 
-        frame = set_squelch(100, receiver=RECEIVER_MAIN, command29=False)
+        frame = set_squelch(
+            100, receiver=RECEIVER_MAIN, command29=False, cmd_map=cmd_map
+        )
         assert frame[4] == 0x14
         assert frame[5] == 0x03  # SQL sub
 
-    def test_set_squelch_sub_uses_cmd29(self) -> None:
+    def test_set_squelch_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, set_squelch
 
-        frame = set_squelch(100, receiver=RECEIVER_SUB)
+        frame = set_squelch(100, receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01
         assert frame[6] == 0x14
@@ -750,7 +785,7 @@ class TestCmd29ReceiverRouting:
         assert frame[6] == 0x16
         assert frame[7] == 0x4E  # DIGI-SEL sub
 
-    def test_backward_compat_no_receiver_arg(self) -> None:
+    def test_backward_compat_no_receiver_arg(self, cmd_map) -> None:
         """All functions remain backward-compatible (no receiver arg = MAIN)."""
         from rigplane.commands import (
             set_af_level,
@@ -774,13 +809,26 @@ class TestCmd29ReceiverRouting:
         assert set_ip_plus(True)[4:6] == b"\x29\x00"
         # MOR-1543: rf_gain/af_level/squelch builders now default
         # command29=True; no receiver arg still targets MAIN (0x00).
-        assert set_rf_gain(128)[4:6] == b"\x29\x00"
-        assert set_af_level(200)[4:6] == b"\x29\x00"
-        assert set_squelch(50)[4:6] == b"\x29\x00"
+        assert set_rf_gain(128, cmd_map=cmd_map)[4:6] == b"\x29\x00"
+        assert set_af_level(200, cmd_map=cmd_map)[4:6] == b"\x29\x00"
+        assert set_squelch(50, cmd_map=cmd_map)[4:6] == b"\x29\x00"
 
 
 class TestDspLevelParityCommands:
-    """Test IC-7610 DSP/level parity command builders and parsers."""
+    """Test IC-7610 DSP/level parity command builders and parsers.
+
+    commands/levels.py migrated onto the bound command map in MOR-2006
+    Steps 5..N (module 2): every builder here now requires ``cmd_map``, and
+    ``rigs/ic7610.toml`` declares the same wire tuples the fallback used to
+    build for every command this class exercises -- no divergence rows name
+    IC-7610 (`tests/command_map_parity_divergences.txt`) -- so the expected
+    frames below are unchanged; only the ``cmd_map=`` wiring is new.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
 
     @pytest.mark.parametrize(
         ("getter_name", "setter_name", "sub", "receiver"),
@@ -796,6 +844,7 @@ class TestDspLevelParityCommands:
     )
     def test_cmd29_level_builders(
         self,
+        cmd_map,
         getter_name: str,
         setter_name: str,
         sub: int,
@@ -807,8 +856,11 @@ class TestDspLevelParityCommands:
         setter = getattr(commands, setter_name)
         expected = bytes([0xFE, 0xFE, 0x98, 0xE0, 0x29, receiver, 0x14, sub])
 
-        assert getter(receiver=receiver) == expected + b"\xfd"
-        assert setter(128, receiver=receiver) == expected + b"\x01\x28\xfd"
+        assert getter(receiver=receiver, cmd_map=cmd_map) == expected + b"\xfd"
+        assert (
+            setter(128, receiver=receiver, cmd_map=cmd_map)
+            == expected + b"\x01\x28\xfd"
+        )
 
     @pytest.mark.parametrize(
         ("getter_name", "setter_name", "sub", "value"),
@@ -826,6 +878,7 @@ class TestDspLevelParityCommands:
     )
     def test_level_builders(
         self,
+        cmd_map,
         getter_name: str,
         setter_name: str,
         sub: int,
@@ -836,9 +889,13 @@ class TestDspLevelParityCommands:
         getter = getattr(commands, getter_name)
         setter = getattr(commands, setter_name)
 
-        assert getter() == bytes([0xFE, 0xFE, 0x98, 0xE0, 0x14, sub, 0xFD])
-        assert setter(value).startswith(bytes([0xFE, 0xFE, 0x98, 0xE0, 0x14, sub]))
-        assert setter(value).endswith(b"\xfd")
+        assert getter(cmd_map=cmd_map) == bytes(
+            [0xFE, 0xFE, 0x98, 0xE0, 0x14, sub, 0xFD]
+        )
+        assert setter(value, cmd_map=cmd_map).startswith(
+            bytes([0xFE, 0xFE, 0x98, 0xE0, 0x14, sub])
+        )
+        assert setter(value, cmd_map=cmd_map).endswith(b"\xfd")
 
     @pytest.mark.parametrize(
         ("getter_name", "setter_name", "prefix", "value", "expected_payload"),
@@ -851,6 +908,7 @@ class TestDspLevelParityCommands:
     )
     def test_ctl_mem_level_builders(
         self,
+        cmd_map,
         getter_name: str,
         setter_name: str,
         prefix: bytes,
@@ -862,9 +920,9 @@ class TestDspLevelParityCommands:
         getter = getattr(commands, getter_name)
         setter = getattr(commands, setter_name)
 
-        assert getter() == b"\xfe\xfe\x98\xe0\x1a\x05" + prefix + b"\xfd"
+        assert getter(cmd_map=cmd_map) == b"\xfe\xfe\x98\xe0\x1a\x05" + prefix + b"\xfd"
         assert (
-            setter(value)
+            setter(value, cmd_map=cmd_map)
             == b"\xfe\xfe\x98\xe0\x1a\x05" + prefix + expected_payload + b"\xfd"
         )
 
@@ -934,11 +992,11 @@ class TestDspLevelParityCommands:
         with pytest.raises(ValueError, match="prefix"):
             parse_level_response(frame, command=0x1A, sub=0x05, prefix=b"\x00\x70")
 
-    def test_set_nb_width_rejects_out_of_range(self) -> None:
+    def test_set_nb_width_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_nb_width
 
         with pytest.raises(ValueError, match="0-255"):
-            set_nb_width(256)
+            set_nb_width(256, cmd_map=cmd_map)
 
     def test_set_manual_notch_width_wire_bounds_match_siblings(self) -> None:
         """MOR-1542: set_manual_notch_width hardcoded minimum=0/maximum=2 —
@@ -1918,41 +1976,48 @@ class TestSystemConfigCommands:
     """Tests for system/config command builders and parsers (#135)."""
 
     # --- REF Adjust (0x1A 0x05 0x00 0x70) ---
+    #
+    # commands/levels.py migrated onto the bound command map in MOR-2006
+    # Steps 5..N (module 2): both builders now require ``cmd_map``, and
+    # ``rigs/ic7610.toml``'s ``get_ref_adjust``/``set_ref_adjust`` declare
+    # the same ``[0x1A, 0x05, 0x00, 0x70]`` wire tuple the fallback used to
+    # build, so the expected frames below are unchanged. Reuses the
+    # ``cmd_map`` fixture defined below for config.py's own tests.
 
-    def test_get_ref_adjust_frame(self) -> None:
+    def test_get_ref_adjust_frame(self, cmd_map) -> None:
         from rigplane.commands import get_ref_adjust
 
-        frame = get_ref_adjust()
+        frame = get_ref_adjust(cmd_map=cmd_map)
         # FE FE 98 E0 1A 05 00 70 FD
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x70\xfd"
 
-    def test_set_ref_adjust_255(self) -> None:
+    def test_set_ref_adjust_255(self, cmd_map) -> None:
         from rigplane.commands import set_ref_adjust
 
-        frame = set_ref_adjust(255)
+        frame = set_ref_adjust(255, cmd_map=cmd_map)
         # 255 as 2-byte BCD: 0x02 0x55
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x70\x02\x55\xfd"
 
-    def test_set_ref_adjust_0(self) -> None:
+    def test_set_ref_adjust_0(self, cmd_map) -> None:
         from rigplane.commands import set_ref_adjust
 
-        frame = set_ref_adjust(0)
+        frame = set_ref_adjust(0, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x70\x00\x00\xfd"
 
-    def test_set_ref_adjust_511(self) -> None:
+    def test_set_ref_adjust_511(self, cmd_map) -> None:
         from rigplane.commands import set_ref_adjust
 
-        frame = set_ref_adjust(511)
+        frame = set_ref_adjust(511, cmd_map=cmd_map)
         # 511 as 2-byte BCD: 0x05 0x11
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x00\x70\x05\x11\xfd"
 
-    def test_set_ref_adjust_rejects_out_of_range(self) -> None:
+    def test_set_ref_adjust_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_ref_adjust
 
         with pytest.raises(ValueError, match="REF Adjust must be 0-511"):
-            set_ref_adjust(-1)
+            set_ref_adjust(-1, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="REF Adjust must be 0-511"):
-            set_ref_adjust(512)
+            set_ref_adjust(512, cmd_map=cmd_map)
 
     def test_parse_ref_adjust_response(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_level_response
@@ -1963,7 +2028,7 @@ class TestSystemConfigCommands:
         value = parse_level_response(frame, command=0x1A, sub=0x05, prefix=b"\x00\x70")
         assert value == 256
 
-    def test_ref_adjust_roundtrip(self) -> None:
+    def test_ref_adjust_roundtrip(self, cmd_map) -> None:
         from rigplane.commands import (
             parse_civ_frame,
             parse_level_response,
@@ -1971,7 +2036,7 @@ class TestSystemConfigCommands:
         )
 
         for v in [0, 128, 256, 511]:
-            frame = set_ref_adjust(v)
+            frame = set_ref_adjust(v, cmd_map=cmd_map)
             response = b"\xfe\xfe" + bytes([frame[3], frame[2]]) + frame[4:]
             parsed = parse_civ_frame(response)
             assert (
@@ -1980,41 +2045,45 @@ class TestSystemConfigCommands:
             )
 
     # --- Dash Ratio (0x1A 0x05 0x02 0x28) ---
+    #
+    # Same MOR-2006 migration as REF Adjust above -- ``rigs/ic7610.toml``'s
+    # dash-ratio wire tuple matches the deleted fallback, so the expected
+    # frames are unchanged.
 
-    def test_get_dash_ratio_frame(self) -> None:
+    def test_get_dash_ratio_frame(self, cmd_map) -> None:
         from rigplane.commands import get_dash_ratio
 
-        frame = get_dash_ratio()
+        frame = get_dash_ratio(cmd_map=cmd_map)
         # FE FE 98 E0 1A 05 02 28 FD
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x02\x28\xfd"
 
-    def test_set_dash_ratio_28(self) -> None:
+    def test_set_dash_ratio_28(self, cmd_map) -> None:
         from rigplane.commands import set_dash_ratio
 
-        frame = set_dash_ratio(28)
+        frame = set_dash_ratio(28, cmd_map=cmd_map)
         # 28 as 1-byte BCD: 0x28
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x02\x28\x28\xfd"
 
-    def test_set_dash_ratio_30(self) -> None:
+    def test_set_dash_ratio_30(self, cmd_map) -> None:
         from rigplane.commands import set_dash_ratio
 
-        frame = set_dash_ratio(30)
+        frame = set_dash_ratio(30, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x02\x28\x30\xfd"
 
-    def test_set_dash_ratio_45(self) -> None:
+    def test_set_dash_ratio_45(self, cmd_map) -> None:
         from rigplane.commands import set_dash_ratio
 
-        frame = set_dash_ratio(45)
+        frame = set_dash_ratio(45, cmd_map=cmd_map)
         # 45 as 1-byte BCD: 0x45
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x02\x28\x45\xfd"
 
-    def test_set_dash_ratio_rejects_out_of_range(self) -> None:
+    def test_set_dash_ratio_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_dash_ratio
 
         with pytest.raises(ValueError, match="Dash Ratio must be 28-45"):
-            set_dash_ratio(27)
+            set_dash_ratio(27, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="Dash Ratio must be 28-45"):
-            set_dash_ratio(46)
+            set_dash_ratio(46, cmd_map=cmd_map)
 
     def test_parse_dash_ratio_response(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_level_response
@@ -2027,7 +2096,7 @@ class TestSystemConfigCommands:
         )
         assert value == 35
 
-    def test_dash_ratio_roundtrip(self) -> None:
+    def test_dash_ratio_roundtrip(self, cmd_map) -> None:
         from rigplane.commands import (
             parse_civ_frame,
             parse_level_response,
@@ -2035,7 +2104,7 @@ class TestSystemConfigCommands:
         )
 
         for v in [28, 30, 35, 40, 45]:
-            frame = set_dash_ratio(v)
+            frame = set_dash_ratio(v, cmd_map=cmd_map)
             response = b"\xfe\xfe" + bytes([frame[3], frame[2]]) + frame[4:]
             parsed = parse_civ_frame(response)
             assert (

--- a/tests/test_dsp_levels_part1.py
+++ b/tests/test_dsp_levels_part1.py
@@ -1,5 +1,7 @@
 """Unit tests for DSP level commands — Part 1: APF/NR/PBT/NB (Issue #130)."""
 
+from pathlib import Path
+
 import pytest
 
 from rigplane import commands
@@ -10,10 +12,21 @@ from rigplane.commands import (
     RECEIVER_SUB,
     parse_level_response,
 )
+from rigplane.rig_loader import load_rig
 from rigplane.types import CivFrame
 from _command_test_helpers import bind_default_addr_globals
 
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
+
+# commands/levels.py migrated onto the bound command map in MOR-2006 Steps
+# 5..N (module 2): get_/set_apf_type_level, get_/set_nr_level,
+# get_/set_pbt_inner, get_/set_pbt_outer and get_/set_nb_level now require
+# cmd_map. This file exercises only IC-7610 (bind_default_addr_globals
+# above), and IC-7610 declares byte-identical [0x14, sub] wire tuples for
+# all five (no menu address, no divergence row for any of them), so every
+# expected literal below is unchanged; only the cmd_map= wiring is new.
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+_IC7610_CMD_MAP = load_rig(RIG_DIR / "ic7610.toml").to_command_map()
 
 # CI-V frame constants
 _PREAMBLE = b"\xfe\xfe"
@@ -74,47 +87,49 @@ class TestAPFTypeLevel:
     """Tests for get_apf_type_level / set_apf_type_level."""
 
     def test_get_apf_type_level_main_receiver(self) -> None:
-        assert commands.get_apf_type_level(receiver=RECEIVER_MAIN) == _cmd29_level_get(
-            _SUB_APF_TYPE_LEVEL, RECEIVER_MAIN
-        )
+        assert commands.get_apf_type_level(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_APF_TYPE_LEVEL, RECEIVER_MAIN)
 
     def test_get_apf_type_level_sub_receiver(self) -> None:
-        assert commands.get_apf_type_level(receiver=RECEIVER_SUB) == _cmd29_level_get(
-            _SUB_APF_TYPE_LEVEL, RECEIVER_SUB
-        )
+        assert commands.get_apf_type_level(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_APF_TYPE_LEVEL, RECEIVER_SUB)
 
     def test_get_apf_type_level_default_is_main(self) -> None:
-        assert commands.get_apf_type_level() == commands.get_apf_type_level(
-            receiver=RECEIVER_MAIN
+        assert commands.get_apf_type_level(
+            cmd_map=_IC7610_CMD_MAP
+        ) == commands.get_apf_type_level(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         )
 
     def test_set_apf_type_level_main_receiver(self) -> None:
         assert commands.set_apf_type_level(
-            128, receiver=RECEIVER_MAIN
+            128, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         ) == _cmd29_level_set(_SUB_APF_TYPE_LEVEL, 128, RECEIVER_MAIN)
 
     def test_set_apf_type_level_sub_receiver(self) -> None:
         assert commands.set_apf_type_level(
-            64, receiver=RECEIVER_SUB
+            64, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
         ) == _cmd29_level_set(_SUB_APF_TYPE_LEVEL, 64, RECEIVER_SUB)
 
     def test_set_apf_type_level_boundary_zero(self) -> None:
-        assert commands.set_apf_type_level(0) == _cmd29_level_set(
-            _SUB_APF_TYPE_LEVEL, 0
-        )
+        assert commands.set_apf_type_level(
+            0, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_APF_TYPE_LEVEL, 0)
 
     def test_set_apf_type_level_boundary_255(self) -> None:
-        assert commands.set_apf_type_level(255) == _cmd29_level_set(
-            _SUB_APF_TYPE_LEVEL, 255
-        )
+        assert commands.set_apf_type_level(
+            255, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_APF_TYPE_LEVEL, 255)
 
     def test_set_apf_type_level_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_apf_type_level(-1)
+            commands.set_apf_type_level(-1, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_apf_type_level_rejects_over_255(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_apf_type_level(256)
+            commands.set_apf_type_level(256, cmd_map=_IC7610_CMD_MAP)
 
     def test_parse_apf_type_level_response(self) -> None:
         frame = _level_response_frame(_SUB_APF_TYPE_LEVEL, 128)
@@ -141,41 +156,47 @@ class TestNRLevel:
     """Tests for get_nr_level / set_nr_level."""
 
     def test_get_nr_level_main_receiver(self) -> None:
-        assert commands.get_nr_level(receiver=RECEIVER_MAIN) == _cmd29_level_get(
-            _SUB_NR_LEVEL, RECEIVER_MAIN
-        )
+        assert commands.get_nr_level(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_NR_LEVEL, RECEIVER_MAIN)
 
     def test_get_nr_level_sub_receiver(self) -> None:
-        assert commands.get_nr_level(receiver=RECEIVER_SUB) == _cmd29_level_get(
-            _SUB_NR_LEVEL, RECEIVER_SUB
-        )
+        assert commands.get_nr_level(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_NR_LEVEL, RECEIVER_SUB)
 
     def test_get_nr_level_default_is_main(self) -> None:
-        assert commands.get_nr_level() == commands.get_nr_level(receiver=RECEIVER_MAIN)
+        assert commands.get_nr_level(cmd_map=_IC7610_CMD_MAP) == commands.get_nr_level(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        )
 
     def test_set_nr_level_main_receiver(self) -> None:
-        assert commands.set_nr_level(100, receiver=RECEIVER_MAIN) == _cmd29_level_set(
-            _SUB_NR_LEVEL, 100, RECEIVER_MAIN
-        )
+        assert commands.set_nr_level(
+            100, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_NR_LEVEL, 100, RECEIVER_MAIN)
 
     def test_set_nr_level_sub_receiver(self) -> None:
-        assert commands.set_nr_level(200, receiver=RECEIVER_SUB) == _cmd29_level_set(
-            _SUB_NR_LEVEL, 200, RECEIVER_SUB
-        )
+        assert commands.set_nr_level(
+            200, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_NR_LEVEL, 200, RECEIVER_SUB)
 
     def test_set_nr_level_boundary_zero(self) -> None:
-        assert commands.set_nr_level(0) == _cmd29_level_set(_SUB_NR_LEVEL, 0)
+        assert commands.set_nr_level(0, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_NR_LEVEL, 0
+        )
 
     def test_set_nr_level_boundary_255(self) -> None:
-        assert commands.set_nr_level(255) == _cmd29_level_set(_SUB_NR_LEVEL, 255)
+        assert commands.set_nr_level(255, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_NR_LEVEL, 255
+        )
 
     def test_set_nr_level_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_nr_level(-1)
+            commands.set_nr_level(-1, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_nr_level_rejects_over_255(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_nr_level(256)
+            commands.set_nr_level(256, cmd_map=_IC7610_CMD_MAP)
 
     def test_parse_nr_level_response(self) -> None:
         frame = _level_response_frame(_SUB_NR_LEVEL, 50)
@@ -202,43 +223,47 @@ class TestPBTInner:
     """Tests for get_pbt_inner / set_pbt_inner."""
 
     def test_get_pbt_inner_main_receiver(self) -> None:
-        assert commands.get_pbt_inner(receiver=RECEIVER_MAIN) == _cmd29_level_get(
-            _SUB_PBT_INNER, RECEIVER_MAIN
-        )
+        assert commands.get_pbt_inner(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_PBT_INNER, RECEIVER_MAIN)
 
     def test_get_pbt_inner_sub_receiver(self) -> None:
-        assert commands.get_pbt_inner(receiver=RECEIVER_SUB) == _cmd29_level_get(
-            _SUB_PBT_INNER, RECEIVER_SUB
-        )
+        assert commands.get_pbt_inner(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_PBT_INNER, RECEIVER_SUB)
 
     def test_get_pbt_inner_default_is_main(self) -> None:
-        assert commands.get_pbt_inner() == commands.get_pbt_inner(
-            receiver=RECEIVER_MAIN
-        )
+        assert commands.get_pbt_inner(
+            cmd_map=_IC7610_CMD_MAP
+        ) == commands.get_pbt_inner(receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_pbt_inner_main_receiver(self) -> None:
-        assert commands.set_pbt_inner(75, receiver=RECEIVER_MAIN) == _cmd29_level_set(
-            _SUB_PBT_INNER, 75, RECEIVER_MAIN
-        )
+        assert commands.set_pbt_inner(
+            75, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_PBT_INNER, 75, RECEIVER_MAIN)
 
     def test_set_pbt_inner_sub_receiver(self) -> None:
-        assert commands.set_pbt_inner(150, receiver=RECEIVER_SUB) == _cmd29_level_set(
-            _SUB_PBT_INNER, 150, RECEIVER_SUB
-        )
+        assert commands.set_pbt_inner(
+            150, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_PBT_INNER, 150, RECEIVER_SUB)
 
     def test_set_pbt_inner_boundary_zero(self) -> None:
-        assert commands.set_pbt_inner(0) == _cmd29_level_set(_SUB_PBT_INNER, 0)
+        assert commands.set_pbt_inner(0, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_PBT_INNER, 0
+        )
 
     def test_set_pbt_inner_boundary_255(self) -> None:
-        assert commands.set_pbt_inner(255) == _cmd29_level_set(_SUB_PBT_INNER, 255)
+        assert commands.set_pbt_inner(255, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_PBT_INNER, 255
+        )
 
     def test_set_pbt_inner_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_pbt_inner(-1)
+            commands.set_pbt_inner(-1, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_pbt_inner_rejects_over_255(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_pbt_inner(256)
+            commands.set_pbt_inner(256, cmd_map=_IC7610_CMD_MAP)
 
     def test_parse_pbt_inner_response(self) -> None:
         frame = _level_response_frame(_SUB_PBT_INNER, 75)
@@ -256,7 +281,9 @@ class TestPBTInner:
         assert value == 255
 
     def test_pbt_inner_sub_distinct_from_pbt_outer(self) -> None:
-        assert commands.get_pbt_inner() != commands.get_pbt_outer()
+        assert commands.get_pbt_inner(
+            cmd_map=_IC7610_CMD_MAP
+        ) != commands.get_pbt_outer(cmd_map=_IC7610_CMD_MAP)
 
 
 # ---------------------------------------------------------------------------
@@ -268,43 +295,47 @@ class TestPBTOuter:
     """Tests for get_pbt_outer / set_pbt_outer."""
 
     def test_get_pbt_outer_main_receiver(self) -> None:
-        assert commands.get_pbt_outer(receiver=RECEIVER_MAIN) == _cmd29_level_get(
-            _SUB_PBT_OUTER, RECEIVER_MAIN
-        )
+        assert commands.get_pbt_outer(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_PBT_OUTER, RECEIVER_MAIN)
 
     def test_get_pbt_outer_sub_receiver(self) -> None:
-        assert commands.get_pbt_outer(receiver=RECEIVER_SUB) == _cmd29_level_get(
-            _SUB_PBT_OUTER, RECEIVER_SUB
-        )
+        assert commands.get_pbt_outer(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_PBT_OUTER, RECEIVER_SUB)
 
     def test_get_pbt_outer_default_is_main(self) -> None:
-        assert commands.get_pbt_outer() == commands.get_pbt_outer(
-            receiver=RECEIVER_MAIN
-        )
+        assert commands.get_pbt_outer(
+            cmd_map=_IC7610_CMD_MAP
+        ) == commands.get_pbt_outer(receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_pbt_outer_main_receiver(self) -> None:
-        assert commands.set_pbt_outer(90, receiver=RECEIVER_MAIN) == _cmd29_level_set(
-            _SUB_PBT_OUTER, 90, RECEIVER_MAIN
-        )
+        assert commands.set_pbt_outer(
+            90, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_PBT_OUTER, 90, RECEIVER_MAIN)
 
     def test_set_pbt_outer_sub_receiver(self) -> None:
-        assert commands.set_pbt_outer(180, receiver=RECEIVER_SUB) == _cmd29_level_set(
-            _SUB_PBT_OUTER, 180, RECEIVER_SUB
-        )
+        assert commands.set_pbt_outer(
+            180, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_PBT_OUTER, 180, RECEIVER_SUB)
 
     def test_set_pbt_outer_boundary_zero(self) -> None:
-        assert commands.set_pbt_outer(0) == _cmd29_level_set(_SUB_PBT_OUTER, 0)
+        assert commands.set_pbt_outer(0, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_PBT_OUTER, 0
+        )
 
     def test_set_pbt_outer_boundary_255(self) -> None:
-        assert commands.set_pbt_outer(255) == _cmd29_level_set(_SUB_PBT_OUTER, 255)
+        assert commands.set_pbt_outer(255, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_PBT_OUTER, 255
+        )
 
     def test_set_pbt_outer_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_pbt_outer(-1)
+            commands.set_pbt_outer(-1, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_pbt_outer_rejects_over_255(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_pbt_outer(256)
+            commands.set_pbt_outer(256, cmd_map=_IC7610_CMD_MAP)
 
     def test_parse_pbt_outer_response(self) -> None:
         frame = _level_response_frame(_SUB_PBT_OUTER, 90)
@@ -331,41 +362,47 @@ class TestNBLevel:
     """Tests for get_nb_level / set_nb_level."""
 
     def test_get_nb_level_main_receiver(self) -> None:
-        assert commands.get_nb_level(receiver=RECEIVER_MAIN) == _cmd29_level_get(
-            _SUB_NB_LEVEL, RECEIVER_MAIN
-        )
+        assert commands.get_nb_level(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_NB_LEVEL, RECEIVER_MAIN)
 
     def test_get_nb_level_sub_receiver(self) -> None:
-        assert commands.get_nb_level(receiver=RECEIVER_SUB) == _cmd29_level_get(
-            _SUB_NB_LEVEL, RECEIVER_SUB
-        )
+        assert commands.get_nb_level(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_get(_SUB_NB_LEVEL, RECEIVER_SUB)
 
     def test_get_nb_level_default_is_main(self) -> None:
-        assert commands.get_nb_level() == commands.get_nb_level(receiver=RECEIVER_MAIN)
+        assert commands.get_nb_level(cmd_map=_IC7610_CMD_MAP) == commands.get_nb_level(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        )
 
     def test_set_nb_level_main_receiver(self) -> None:
-        assert commands.set_nb_level(55, receiver=RECEIVER_MAIN) == _cmd29_level_set(
-            _SUB_NB_LEVEL, 55, RECEIVER_MAIN
-        )
+        assert commands.set_nb_level(
+            55, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_NB_LEVEL, 55, RECEIVER_MAIN)
 
     def test_set_nb_level_sub_receiver(self) -> None:
-        assert commands.set_nb_level(210, receiver=RECEIVER_SUB) == _cmd29_level_set(
-            _SUB_NB_LEVEL, 210, RECEIVER_SUB
-        )
+        assert commands.set_nb_level(
+            210, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_level_set(_SUB_NB_LEVEL, 210, RECEIVER_SUB)
 
     def test_set_nb_level_boundary_zero(self) -> None:
-        assert commands.set_nb_level(0) == _cmd29_level_set(_SUB_NB_LEVEL, 0)
+        assert commands.set_nb_level(0, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_NB_LEVEL, 0
+        )
 
     def test_set_nb_level_boundary_255(self) -> None:
-        assert commands.set_nb_level(255) == _cmd29_level_set(_SUB_NB_LEVEL, 255)
+        assert commands.set_nb_level(255, cmd_map=_IC7610_CMD_MAP) == _cmd29_level_set(
+            _SUB_NB_LEVEL, 255
+        )
 
     def test_set_nb_level_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_nb_level(-1)
+            commands.set_nb_level(-1, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_nb_level_rejects_over_255(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_nb_level(256)
+            commands.set_nb_level(256, cmd_map=_IC7610_CMD_MAP)
 
     def test_parse_nb_level_response(self) -> None:
         frame = _level_response_frame(_SUB_NB_LEVEL, 55)
@@ -383,4 +420,6 @@ class TestNBLevel:
         assert value == 255
 
     def test_nb_level_sub_distinct_from_nr_level(self) -> None:
-        assert commands.get_nb_level() != commands.get_nr_level()
+        assert commands.get_nb_level(cmd_map=_IC7610_CMD_MAP) != commands.get_nr_level(
+            cmd_map=_IC7610_CMD_MAP
+        )

--- a/tests/test_dsp_levels_part2.py
+++ b/tests/test_dsp_levels_part2.py
@@ -1,5 +1,7 @@
 """Unit tests for DSP level commands — Part 2: special cases (Issue #130)."""
 
+from pathlib import Path
+
 import pytest
 
 from rigplane import commands
@@ -11,10 +13,22 @@ from rigplane.commands import (
     parse_bool_response,
     parse_level_response,
 )
+from rigplane.rig_loader import load_rig
 from rigplane.types import CivFrame, FilterShape, SsbTxBandwidth
 from _command_test_helpers import bind_default_addr_globals
 
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
+
+# commands/levels.py migrated onto the bound command map in MOR-2006 Steps
+# 5..N (module 2): get_/set_digisel_shift now require cmd_map. Every case
+# in TestDigiselShift below targets IC-7610 (the bound default) except
+# test_get_digisel_shift_custom_addresses, which overrides to_addr=0xA4
+# (IC-705) explicitly -- that one case gets the IC-705 map to match. Both
+# profiles declare the same [0x14, 0x13] wire tuple (no menu address, no
+# divergence row), so every expected literal below is unchanged.
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+_IC7610_CMD_MAP = load_rig(RIG_DIR / "ic7610.toml").to_command_map()
+_IC705_CMD_MAP = load_rig(RIG_DIR / "ic705.toml").to_command_map()
 
 # CI-V frame constants
 _PREAMBLE = b"\xfe\xfe"
@@ -89,55 +103,69 @@ class TestDigiselShift:
     """Tests for get_digisel_shift / set_digisel_shift."""
 
     def test_get_digisel_shift_main_receiver(self) -> None:
-        assert commands.get_digisel_shift(receiver=RECEIVER_MAIN) == _cmd29_get(
-            _CMD_LEVEL, _SUB_DIGISEL_SHIFT, RECEIVER_MAIN
-        )
+        assert commands.get_digisel_shift(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_get(_CMD_LEVEL, _SUB_DIGISEL_SHIFT, RECEIVER_MAIN)
 
     def test_get_digisel_shift_sub_receiver(self) -> None:
-        assert commands.get_digisel_shift(receiver=RECEIVER_SUB) == _cmd29_get(
-            _CMD_LEVEL, _SUB_DIGISEL_SHIFT, RECEIVER_SUB
-        )
+        assert commands.get_digisel_shift(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_get(_CMD_LEVEL, _SUB_DIGISEL_SHIFT, RECEIVER_SUB)
 
     def test_get_digisel_shift_default_is_main(self) -> None:
-        assert commands.get_digisel_shift() == commands.get_digisel_shift(
-            receiver=RECEIVER_MAIN
-        )
+        assert commands.get_digisel_shift(
+            cmd_map=_IC7610_CMD_MAP
+        ) == commands.get_digisel_shift(receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_digisel_shift_zero_main(self) -> None:
         # 0 -> 2-byte BCD: 0x00 0x00
-        assert commands.set_digisel_shift(0, receiver=RECEIVER_MAIN) == _cmd29_set(
+        assert commands.set_digisel_shift(
+            0, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_LEVEL, _SUB_DIGISEL_SHIFT, 0x00, 0x00, receiver=RECEIVER_MAIN
         )
 
     def test_set_digisel_shift_128_main(self) -> None:
         # 128 -> 2-byte BCD: 0x01 0x28
-        assert commands.set_digisel_shift(128, receiver=RECEIVER_MAIN) == _cmd29_set(
+        assert commands.set_digisel_shift(
+            128, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_LEVEL, _SUB_DIGISEL_SHIFT, 0x01, 0x28, receiver=RECEIVER_MAIN
         )
 
     def test_set_digisel_shift_255_main(self) -> None:
         # 255 -> 2-byte BCD: 0x02 0x55
-        assert commands.set_digisel_shift(255, receiver=RECEIVER_MAIN) == _cmd29_set(
+        assert commands.set_digisel_shift(
+            255, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_LEVEL, _SUB_DIGISEL_SHIFT, 0x02, 0x55, receiver=RECEIVER_MAIN
         )
 
     def test_set_digisel_shift_sub_receiver(self) -> None:
-        assert commands.set_digisel_shift(64, receiver=RECEIVER_SUB) == _cmd29_set(
+        assert commands.set_digisel_shift(
+            64, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_LEVEL, _SUB_DIGISEL_SHIFT, 0x00, 0x64, receiver=RECEIVER_SUB
         )
 
     def test_set_digisel_shift_default_receiver_is_main(self) -> None:
-        assert commands.set_digisel_shift(100) == commands.set_digisel_shift(
-            100, receiver=RECEIVER_MAIN
+        assert commands.set_digisel_shift(
+            100, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_digisel_shift(
+            100, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         )
 
     def test_set_digisel_shift_rejects_above_255(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_digisel_shift(256, receiver=RECEIVER_MAIN)
+            commands.set_digisel_shift(
+                256, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+            )
 
     def test_set_digisel_shift_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_digisel_shift(-1, receiver=RECEIVER_MAIN)
+            commands.set_digisel_shift(
+                -1, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+            )
 
     def test_parse_digisel_shift_zero(self) -> None:
         frame = _response_frame(_CMD_LEVEL, _SUB_DIGISEL_SHIFT, b"\x00\x00")
@@ -167,7 +195,9 @@ class TestDigiselShift:
         )
 
     def test_get_digisel_shift_custom_addresses(self) -> None:
-        frame = commands.get_digisel_shift(to_addr=0xA4, from_addr=0xE1)
+        frame = commands.get_digisel_shift(
+            to_addr=0xA4, from_addr=0xE1, cmd_map=_IC705_CMD_MAP
+        )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -29,6 +29,7 @@ be absent from IC-7610's own cmd29 routes too, so it must be unwrapped on
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -61,11 +62,27 @@ from rigplane.commands import (
     set_twin_peak_filter,
 )
 from rigplane.radio import IcomRadio
+from rigplane.rig_loader import load_rig
 from rigplane.types import AudioPeakFilter, CivFrame, FilterShape
 
 _IC7300_ADDR = 0x94
 _IC7610_ADDR = 0x98
 _IC705_ADDR = 0xA4
+
+# commands/levels.py migrated onto the bound command map in MOR-2006 Steps
+# 5..N (module 2): pbt_inner/pbt_outer/nr_level/nb_level/apf_type_level/
+# digisel_shift now require cmd_map -- these three real profile maps let the
+# "expected" comparison frames below keep calling the free builder directly
+# (the way this file's whole design works: build the same frame two ways --
+# once through CoreRadio, once through the builder -- and compare) rather
+# than switching to a fallback that no longer exists. All six builders emit
+# byte-identical [0x14, sub] frames on every declaring profile (no menu
+# address, no divergence row for any of them), so the expected bytes below
+# are unchanged.
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+_IC7300_CMD_MAP = load_rig(RIG_DIR / "ic7300.toml").to_command_map()
+_IC7610_CMD_MAP = load_rig(RIG_DIR / "ic7610.toml").to_command_map()
+_IC705_CMD_MAP = load_rig(RIG_DIR / "ic705.toml").to_command_map()
 
 
 def _connected_icom(*, model: str) -> IcomRadio:
@@ -107,7 +124,13 @@ class TestPbtInnerGating:
         radio = _connected_icom(model="IC-7300")
         mock = _mock_raw(radio)
         await radio.set_pbt_inner(75, receiver=0)
-        expected = set_pbt_inner(75, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = set_pbt_inner(
+            75,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
         assert b"\x29" not in expected[: len(expected)][2:5]
 
@@ -116,7 +139,13 @@ class TestPbtInnerGating:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         await radio.set_pbt_inner(75, receiver=0)
-        expected = set_pbt_inner(75, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = set_pbt_inner(
+            75,
+            to_addr=_IC7610_ADDR,
+            receiver=0,
+            command29=True,
+            cmd_map=_IC7610_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
@@ -131,7 +160,9 @@ class TestPbtInnerGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_pbt_inner(receiver=0)
-        expected = get_pbt_inner(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = get_pbt_inner(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == 64
 
@@ -147,7 +178,9 @@ class TestPbtInnerGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_pbt_inner(receiver=0)
-        expected = get_pbt_inner(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = get_pbt_inner(
+            to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == 64
 
@@ -158,7 +191,13 @@ class TestPbtOuterGating:
         radio = _connected_icom(model="IC-7300")
         mock = _mock_raw(radio)
         await radio.set_pbt_outer(80, receiver=0)
-        expected = set_pbt_outer(80, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = set_pbt_outer(
+            80,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
@@ -166,7 +205,13 @@ class TestPbtOuterGating:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         await radio.set_pbt_outer(80, receiver=0)
-        expected = set_pbt_outer(80, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = set_pbt_outer(
+            80,
+            to_addr=_IC7610_ADDR,
+            receiver=0,
+            command29=True,
+            cmd_map=_IC7610_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
@@ -181,7 +226,9 @@ class TestPbtOuterGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_pbt_outer(receiver=0)
-        expected = get_pbt_outer(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = get_pbt_outer(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == 50
 
@@ -197,7 +244,9 @@ class TestPbtOuterGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_pbt_outer(receiver=0)
-        expected = get_pbt_outer(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = get_pbt_outer(
+            to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == 50
 
@@ -260,7 +309,13 @@ class TestNrLevelGating:
         radio = _connected_icom(model="IC-7300")
         mock = _mock_raw(radio)
         await radio.set_nr_level(120, receiver=0)
-        expected = set_nr_level(120, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = set_nr_level(
+            120,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
@@ -268,7 +323,13 @@ class TestNrLevelGating:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         await radio.set_nr_level(120, receiver=0)
-        expected = set_nr_level(120, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = set_nr_level(
+            120,
+            to_addr=_IC7610_ADDR,
+            receiver=0,
+            command29=True,
+            cmd_map=_IC7610_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
 
@@ -278,7 +339,13 @@ class TestNbLevelGating:
         radio = _connected_icom(model="IC-7300")
         mock = _mock_raw(radio)
         await radio.set_nb_level(90, receiver=0)
-        expected = set_nb_level(90, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = set_nb_level(
+            90,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
@@ -286,7 +353,13 @@ class TestNbLevelGating:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         await radio.set_nb_level(90, receiver=0)
-        expected = set_nb_level(90, to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = set_nb_level(
+            90,
+            to_addr=_IC7610_ADDR,
+            receiver=0,
+            command29=True,
+            cmd_map=_IC7610_CMD_MAP,
+        )
         assert _sent_civ(mock) == expected
 
 
@@ -300,7 +373,7 @@ class TestApfTypeLevelGating:
         mock = _mock_raw(radio)
         await radio.set_apf_type_level(3, receiver=0)
         expected = set_apf_type_level(
-            3, to_addr=_IC705_ADDR, receiver=0, command29=False
+            3, to_addr=_IC705_ADDR, receiver=0, command29=False, cmd_map=_IC705_CMD_MAP
         )
         assert _sent_civ(mock) == expected
 
@@ -310,7 +383,7 @@ class TestApfTypeLevelGating:
         mock = _mock_raw(radio)
         await radio.set_apf_type_level(3, receiver=0)
         expected = set_apf_type_level(
-            3, to_addr=_IC7610_ADDR, receiver=0, command29=True
+            3, to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
         )
         assert _sent_civ(mock) == expected
 
@@ -324,7 +397,7 @@ class TestDigiselShiftGating:
         mock = _mock_raw(radio)
         await radio.set_digisel_shift(10, receiver=0)
         expected = set_digisel_shift(
-            10, to_addr=_IC705_ADDR, receiver=0, command29=False
+            10, to_addr=_IC705_ADDR, receiver=0, command29=False, cmd_map=_IC705_CMD_MAP
         )
         assert _sent_civ(mock) == expected
 
@@ -334,7 +407,11 @@ class TestDigiselShiftGating:
         mock = _mock_raw(radio)
         await radio.set_digisel_shift(10, receiver=0)
         expected = set_digisel_shift(
-            10, to_addr=_IC7610_ADDR, receiver=0, command29=True
+            10,
+            to_addr=_IC7610_ADDR,
+            receiver=0,
+            command29=True,
+            cmd_map=_IC7610_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 

--- a/tests/test_mor1543_cmd29_gating.py
+++ b/tests/test_mor1543_cmd29_gating.py
@@ -44,6 +44,8 @@ import pytest
 from rigplane.types import CivFrame
 
 from test_mor1517_cmd29_gating import (
+    _IC7300_CMD_MAP,
+    _IC7610_CMD_MAP,
     _connected_icom,
     _mock_expect,
     _mock_raw,
@@ -80,100 +82,149 @@ class TestRouteTableSanity:
 
 
 class TestBuilderOverride:
+    """commands/levels.py migrated onto the bound command map in MOR-2006
+    Steps 5..N (module 2): all four builders here now require ``cmd_map``.
+    ``_IC7610_CMD_MAP``/``_IC7300_CMD_MAP`` (imported from
+    test_mor1517_cmd29_gating) supply it -- both profiles declare
+    byte-identical ``[0x14, sub]`` wire tuples for all four commands (no
+    menu address, no divergence row for any of them), so the expected
+    literals below are unchanged.
+    """
+
     def test_set_rf_gain_wrapped_by_default_for_main(self) -> None:
         from rigplane.commands import set_rf_gain
 
-        frame = set_rf_gain(128, to_addr=_IC7610_ADDR, receiver=0)
+        frame = set_rf_gain(
+            128, to_addr=_IC7610_ADDR, receiver=0, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe98e0290014020128fd")
 
     def test_set_rf_gain_unwrapped_with_override(self) -> None:
         from rigplane.commands import set_rf_gain
 
-        frame = set_rf_gain(128, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        frame = set_rf_gain(
+            128,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert frame == bytes.fromhex("fefe94e014020128fd")
 
     def test_get_rf_gain_wrapped_by_default(self) -> None:
         from rigplane.commands import get_rf_gain
 
-        frame = get_rf_gain(to_addr=_IC7610_ADDR)
+        frame = get_rf_gain(to_addr=_IC7610_ADDR, cmd_map=_IC7610_CMD_MAP)
         assert frame == bytes.fromhex("fefe98e029001402fd")
 
     def test_get_rf_gain_unwrapped_with_override(self) -> None:
         from rigplane.commands import get_rf_gain
 
-        frame = get_rf_gain(to_addr=_IC7300_ADDR, command29=False)
+        frame = get_rf_gain(
+            to_addr=_IC7300_ADDR, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe94e01402fd")
 
     def test_set_af_level_wrapped_by_default_for_main(self) -> None:
         from rigplane.commands import set_af_level
 
-        frame = set_af_level(200, to_addr=_IC7610_ADDR, receiver=0)
+        frame = set_af_level(
+            200, to_addr=_IC7610_ADDR, receiver=0, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe98e0290014010200fd")
 
     def test_set_af_level_unwrapped_with_override(self) -> None:
         from rigplane.commands import set_af_level
 
-        frame = set_af_level(200, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        frame = set_af_level(
+            200,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert frame == bytes.fromhex("fefe94e014010200fd")
 
     def test_get_af_level_wrapped_by_default(self) -> None:
         from rigplane.commands import get_af_level
 
-        frame = get_af_level(to_addr=_IC7610_ADDR)
+        frame = get_af_level(to_addr=_IC7610_ADDR, cmd_map=_IC7610_CMD_MAP)
         assert frame == bytes.fromhex("fefe98e029001401fd")
 
     def test_get_af_level_unwrapped_with_override(self) -> None:
         from rigplane.commands import get_af_level
 
-        frame = get_af_level(to_addr=_IC7300_ADDR, command29=False)
+        frame = get_af_level(
+            to_addr=_IC7300_ADDR, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe94e01401fd")
 
     def test_set_squelch_wrapped_by_default_for_main(self) -> None:
         from rigplane.commands import set_squelch
 
-        frame = set_squelch(64, to_addr=_IC7610_ADDR, receiver=0)
+        frame = set_squelch(
+            64, to_addr=_IC7610_ADDR, receiver=0, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe98e0290014030064fd")
 
     def test_set_squelch_unwrapped_with_override(self) -> None:
         from rigplane.commands import set_squelch
 
-        frame = set_squelch(64, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        frame = set_squelch(
+            64,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert frame == bytes.fromhex("fefe94e014030064fd")
 
     def test_get_squelch_wrapped_by_default(self) -> None:
         from rigplane.commands import get_squelch
 
-        frame = get_squelch(to_addr=_IC7610_ADDR)
+        frame = get_squelch(to_addr=_IC7610_ADDR, cmd_map=_IC7610_CMD_MAP)
         assert frame == bytes.fromhex("fefe98e029001403fd")
 
     def test_get_squelch_unwrapped_with_override(self) -> None:
         from rigplane.commands import get_squelch
 
-        frame = get_squelch(to_addr=_IC7300_ADDR, command29=False)
+        frame = get_squelch(
+            to_addr=_IC7300_ADDR, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe94e01403fd")
 
     def test_set_notch_filter_wrapped_by_default_for_main(self) -> None:
         from rigplane.commands import set_notch_filter
 
-        frame = set_notch_filter(90, to_addr=_IC7610_ADDR, receiver=0)
+        frame = set_notch_filter(
+            90, to_addr=_IC7610_ADDR, receiver=0, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe98e02900140d0090fd")
 
     def test_set_notch_filter_unwrapped_with_override(self) -> None:
         from rigplane.commands import set_notch_filter
 
-        frame = set_notch_filter(90, to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        frame = set_notch_filter(
+            90,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
+        )
         assert frame == bytes.fromhex("fefe94e0140d0090fd")
 
     def test_get_notch_filter_wrapped_by_default(self) -> None:
         from rigplane.commands import get_notch_filter
 
-        frame = get_notch_filter(to_addr=_IC7610_ADDR)
+        frame = get_notch_filter(to_addr=_IC7610_ADDR, cmd_map=_IC7610_CMD_MAP)
         assert frame == bytes.fromhex("fefe98e02900140dfd")
 
     def test_get_notch_filter_unwrapped_with_override(self) -> None:
         from rigplane.commands import get_notch_filter
 
-        frame = get_notch_filter(to_addr=_IC7300_ADDR, command29=False)
+        frame = get_notch_filter(
+            to_addr=_IC7300_ADDR, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert frame == bytes.fromhex("fefe94e0140dfd")
 
 

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -42,7 +42,7 @@ from typing import Any
 import pytest
 
 import rigplane.commands as commands
-from rigplane.commands import get_rf_power, get_speech, ptt_on
+from rigplane.commands import get_s_meter, get_speech, ptt_on
 from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
@@ -168,9 +168,12 @@ class TestExpect:
         )
 
     def test_expect_on_unexposed_builder_names_the_migration(self) -> None:
-        bound = BoundCommands(CommandMap({"get_rf_power": (0x14, 0x0A)}))
+        # get_rf_power (commands/levels.py) is exposed as of MOR-2006 Steps
+        # 5..N module 2 -- get_s_meter (commands/meters.py) is still
+        # unmigrated and stands in as the "not exposed yet" example.
+        bound = BoundCommands(CommandMap({"get_s_meter": (0x15, 0x02)}))
         with pytest.raises(AttributeError, match="Steps 5..N"):
-            bound.expect(get_rf_power)
+            bound.expect(get_s_meter)
 
 
 # ── the drift guard ──

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -74,6 +74,34 @@ MATCHER_BACKED_GETTERS: tuple[_GetterSpec, ...] = (
     _GetterSpec("get_data3_mod_input", "_get_bcd_level"),
     _GetterSpec("get_civ_transceive", "_get_bool_value"),
     _GetterSpec("get_civ_output_ant", "_get_bool_value"),
+    # commands/levels.py's matcher-backed getters (MOR-2006 Steps 5..N,
+    # module 2). get_rf_power, get_rf_gain and get_af_level are not
+    # included: they parse their reply with _level_bcd_decode/_parse_level
+    # directly, without checking the reply's command/sub bytes, so they
+    # have no matcher shape to compare here (module docstring in
+    # runtime/radio.py, "commands/levels.py, migrated...").
+    _GetterSpec("get_squelch", "_get_bcd_level"),
+    _GetterSpec("get_apf_type_level", "_get_bcd_level"),
+    _GetterSpec("get_nr_level", "_get_bcd_level"),
+    _GetterSpec("get_pbt_inner", "_get_bcd_level"),
+    _GetterSpec("get_pbt_outer", "_get_bcd_level"),
+    _GetterSpec("get_cw_pitch", "_get_bcd_level"),
+    _GetterSpec("get_mic_gain", "_get_bcd_level"),
+    _GetterSpec("get_key_speed", "_get_bcd_level"),
+    _GetterSpec("get_notch_filter", "_get_bcd_level"),
+    _GetterSpec("get_compressor_level", "_get_bcd_level"),
+    _GetterSpec("get_break_in_delay", "_get_bcd_level"),
+    _GetterSpec("get_nb_level", "_get_bcd_level"),
+    _GetterSpec("get_digisel_shift", "_get_bcd_level"),
+    _GetterSpec("get_drive_gain", "_get_bcd_level"),
+    _GetterSpec("get_monitor_gain", "_get_bcd_level"),
+    _GetterSpec("get_vox_gain", "_get_bcd_level"),
+    _GetterSpec("get_anti_vox_gain", "_get_bcd_level"),
+    _GetterSpec("get_ref_adjust", "_get_bcd_level"),
+    _GetterSpec("get_dash_ratio", "_get_bcd_level"),
+    _GetterSpec("get_nb_depth", "_get_bcd_level"),
+    _GetterSpec("get_nb_width", "_get_bcd_level"),
+    _GetterSpec("get_vox_delay", "_get_bcd_level"),
 )
 
 
@@ -121,6 +149,12 @@ async def test_reply_shape_matches_request_shape(
         return 0
 
     monkeypatch.setattr(CoreRadio, spec.parser, _fake_parser)
+    # get_squelch (commands/levels.py) checks the connection itself, ahead
+    # of the mocked parser -- unlike every other getter registered above,
+    # which reaches the connection check only inside the mocked method.
+    # No-op it here so this test stays about reply-shape matching alone,
+    # not connection state, for every entry regardless of that difference.
+    monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)
     radio = CoreRadio("198.51.100.1", profile=profile)
     await getattr(radio, spec.method)()
 

--- a/tests/test_rf_gain_af_level.py
+++ b/tests/test_rf_gain_af_level.py
@@ -1,5 +1,7 @@
 """Tests for RF Gain and AF Level CI-V commands."""
 
+from pathlib import Path
+
 import pytest
 import rigplane.commands as raw_commands
 
@@ -11,109 +13,124 @@ from rigplane.commands import (
     set_af_level,
     build_cmd29_frame,
 )
+from rigplane.rig_loader import load_rig
 from _command_test_helpers import bind_default_addr_globals, bind_default_addr_module
 
 bind_default_addr_module(raw_commands, to_addr=IC_7610_ADDR)
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
 
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+
 # IC-7610 declares cmd29 routes for 0x14/0x02 (RF gain) and 0x14/0x01 (AF
 # level), so the builders' command29=True default now wraps MAIN too
 # (MOR-1543) — these expected frames are cmd29-wrapped for receiver 0.
+#
+# commands/levels.py migrated onto the bound command map in MOR-2006 Steps
+# 5..N (module 2): both builders now require ``cmd_map``, and
+# ``rigs/ic7610.toml`` declares the same ``[0x14, 0x02]`` / ``[0x14, 0x01]``
+# wire tuples the fallback used to build, so the expected frames below are
+# unchanged -- only the ``cmd_map=`` wiring is new.
+
+
+@pytest.fixture()
+def cmd_map():
+    rig = load_rig(RIG_DIR / "ic7610.toml")
+    return rig.to_command_map()
 
 
 class TestRfGainCommands:
     """Test RF Gain CI-V frame encoding."""
 
-    def test_get_rf_gain_frame(self) -> None:
-        frame = get_rf_gain()
+    def test_get_rf_gain_frame(self, cmd_map) -> None:
+        frame = get_rf_gain(cmd_map=cmd_map)
         # 0x14 = level command, 0x02 = RF gain sub
         expected = build_cmd29_frame(0x98, 0xE0, 0x14, sub=0x02, receiver=0)
         assert frame == expected
 
-    def test_set_rf_gain_128(self) -> None:
-        frame = set_rf_gain(128)
+    def test_set_rf_gain_128(self, cmd_map) -> None:
+        frame = set_rf_gain(128, cmd_map=cmd_map)
         # 128 -> BCD 0x01 0x28
         expected = build_cmd29_frame(
             0x98, 0xE0, 0x14, sub=0x02, data=b"\x01\x28", receiver=0
         )
         assert frame == expected
 
-    def test_set_rf_gain_zero(self) -> None:
-        frame = set_rf_gain(0)
+    def test_set_rf_gain_zero(self, cmd_map) -> None:
+        frame = set_rf_gain(0, cmd_map=cmd_map)
         expected = build_cmd29_frame(
             0x98, 0xE0, 0x14, sub=0x02, data=b"\x00\x00", receiver=0
         )
         assert frame == expected
 
-    def test_set_rf_gain_max(self) -> None:
-        frame = set_rf_gain(255)
+    def test_set_rf_gain_max(self, cmd_map) -> None:
+        frame = set_rf_gain(255, cmd_map=cmd_map)
         expected = build_cmd29_frame(
             0x98, 0xE0, 0x14, sub=0x02, data=b"\x02\x55", receiver=0
         )
         assert frame == expected
 
-    def test_set_rf_gain_out_of_range_high(self) -> None:
+    def test_set_rf_gain_out_of_range_high(self, cmd_map) -> None:
         with pytest.raises(ValueError):
-            set_rf_gain(256)
+            set_rf_gain(256, cmd_map=cmd_map)
 
-    def test_set_rf_gain_out_of_range_low(self) -> None:
+    def test_set_rf_gain_out_of_range_low(self, cmd_map) -> None:
         with pytest.raises(ValueError):
-            set_rf_gain(-1)
+            set_rf_gain(-1, cmd_map=cmd_map)
 
 
 class TestAfLevelCommands:
     """Test AF Level CI-V frame encoding."""
 
-    def test_get_af_level_frame(self) -> None:
-        frame = get_af_level()
+    def test_get_af_level_frame(self, cmd_map) -> None:
+        frame = get_af_level(cmd_map=cmd_map)
         # 0x14 = level command, 0x01 = AF level sub
         expected = build_cmd29_frame(0x98, 0xE0, 0x14, sub=0x01, receiver=0)
         assert frame == expected
 
-    def test_set_af_level_128(self) -> None:
-        frame = set_af_level(128)
+    def test_set_af_level_128(self, cmd_map) -> None:
+        frame = set_af_level(128, cmd_map=cmd_map)
         expected = build_cmd29_frame(
             0x98, 0xE0, 0x14, sub=0x01, data=b"\x01\x28", receiver=0
         )
         assert frame == expected
 
-    def test_set_af_level_zero(self) -> None:
-        frame = set_af_level(0)
+    def test_set_af_level_zero(self, cmd_map) -> None:
+        frame = set_af_level(0, cmd_map=cmd_map)
         expected = build_cmd29_frame(
             0x98, 0xE0, 0x14, sub=0x01, data=b"\x00\x00", receiver=0
         )
         assert frame == expected
 
-    def test_set_af_level_max(self) -> None:
-        frame = set_af_level(255)
+    def test_set_af_level_max(self, cmd_map) -> None:
+        frame = set_af_level(255, cmd_map=cmd_map)
         expected = build_cmd29_frame(
             0x98, 0xE0, 0x14, sub=0x01, data=b"\x02\x55", receiver=0
         )
         assert frame == expected
 
-    def test_set_af_level_out_of_range_high(self) -> None:
+    def test_set_af_level_out_of_range_high(self, cmd_map) -> None:
         with pytest.raises(ValueError):
-            set_af_level(256)
+            set_af_level(256, cmd_map=cmd_map)
 
-    def test_set_af_level_out_of_range_low(self) -> None:
+    def test_set_af_level_out_of_range_low(self, cmd_map) -> None:
         with pytest.raises(ValueError):
-            set_af_level(-1)
+            set_af_level(-1, cmd_map=cmd_map)
 
 
 class TestRfGainAfLevelSubCommandDifference:
     """Verify RF Gain and AF Level produce different frames."""
 
-    def test_get_commands_differ(self) -> None:
-        assert get_rf_gain() != get_af_level()
+    def test_get_commands_differ(self, cmd_map) -> None:
+        assert get_rf_gain(cmd_map=cmd_map) != get_af_level(cmd_map=cmd_map)
 
-    def test_set_commands_differ(self) -> None:
-        assert set_rf_gain(128) != set_af_level(128)
+    def test_set_commands_differ(self, cmd_map) -> None:
+        assert set_rf_gain(128, cmd_map=cmd_map) != set_af_level(128, cmd_map=cmd_map)
 
-    def test_rf_gain_uses_sub_02(self) -> None:
-        frame = get_rf_gain()
+    def test_rf_gain_uses_sub_02(self, cmd_map) -> None:
+        frame = get_rf_gain(cmd_map=cmd_map)
         # cmd29-wrapped: FE FE to from 29 <receiver> 14 <sub>
         assert frame[7] == 0x02
 
-    def test_af_level_uses_sub_01(self) -> None:
-        frame = get_af_level()
+    def test_af_level_uses_sub_01(self, cmd_map) -> None:
+        frame = get_af_level(cmd_map=cmd_map)
         assert frame[7] == 0x01

--- a/tests/test_rig_ic705_mor1540.py
+++ b/tests/test_rig_ic705_mor1540.py
@@ -117,22 +117,29 @@ class TestD2DocumentaryCommandBytes:
         assert cmdmap.get("scan_set_df_span") == (0x0E,)
 
     def test_get_nb_depth(self, cmdmap) -> None:
-        """1A 05 0357, NOT the shared fallback's 0290 (that's IC-7610's
-        address)."""
+        """1A 05 0357, NOT the shared fallback's 0290 (that was IC-7610's
+        address) -- that fallback and its `_CTL_MEM_NB_DEPTH` constant were
+        deleted in MOR-2006 Steps 5..N module 2."""
         assert cmdmap.get("get_nb_depth") == (0x1A, 0x05, 0x03, 0x57)
 
     def test_set_nb_depth(self, cmdmap) -> None:
         assert cmdmap.get("set_nb_depth") == (0x1A, 0x05, 0x03, 0x57)
 
     def test_get_nb_width(self, cmdmap) -> None:
-        """1A 05 0358, NOT the shared fallback's 0291."""
+        """1A 05 0358, NOT the shared fallback's 0291 -- that fallback and
+        its `_CTL_MEM_NB_WIDTH` constant were deleted in MOR-2006 Steps
+        5..N module 2."""
         assert cmdmap.get("get_nb_width") == (0x1A, 0x05, 0x03, 0x58)
 
     def test_set_nb_width(self, cmdmap) -> None:
         assert cmdmap.get("set_nb_width") == (0x1A, 0x05, 0x03, 0x58)
 
     def test_get_vox_delay(self, cmdmap) -> None:
-        """1A 05 0359, NOT the shared fallback's 0292."""
+        """1A 05 0359, NOT the shared fallback's 0292 -- that builder-side
+        fallback and its `_CTL_MEM_VOX_DELAY` constant were deleted in
+        MOR-2006 Steps 5..N module 2; 0292 survives only as an RX-parser
+        value in runtime/_civ_rx.py for unsolicited frames, not as anything
+        any builder can emit."""
         assert cmdmap.get("get_vox_delay") == (0x1A, 0x05, 0x03, 0x59)
 
     def test_set_vox_delay(self, cmdmap) -> None:


### PR DESCRIPTION
## Summary

Second module migration of Steps 5..N, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4:

> Steps 5..N — Migrate module by module, requests and replies together. One domain module per PR. For each: (a) make `cmd_map` required keyword-only and delete the fallback branch and the constants it alone read; (b) move that module's call sites in `runtime/radio.py`, `runtime/_scope_runtime.py`, `runtime/_dual_rx_runtime.py`, `backends/_icom_serial_base.py` onto the binder; (c) move that module's response matchers **in the same commit**.

> 2. `levels.py` — 16 rows, the other half of the collision.

`levels.py` carries the other half of the ACC1/MIC-gain collision (MOR-1992): `set_mic_gain`'s deleted fallback built the same eight bytes on the IC-7300 as `config.py: set_acc1_mod_level`'s did (migrated in #2827). This PR follows that PR's pattern module for module.

## Guardrail exception (owner-granted for the pre-review figures; re-approval needed at the FINAL figures — see "Figures at head" below)

This PR crossed **both** hard-ceiling dimensions in `CLAUDE.md` §Guardrails: **13 files / 1817 changed lines** against 10 files / 1000 lines, at the head the owner's exception comment on this PR names. The owner granted an explicit exception for this PR as one unit of work at that size. This is a comparable surface to `config.py` module 1 (#2827, 11 files / 1148 lines, also owner-exempted) — `levels.py` has more than double the builders (50 vs. 18), so a larger diff was expected going in, not discovered as scope crept.

**Three review rounds grew the PR past the figures the exception names, all fixing the same underlying class**: a static AST sweep for "tests calling a migrated builder with no `cmd_map`" was run three times, and returned zero-but-wrong twice before the query itself was corrected — see "Review round 1" and "Review round 2" below for the two shapes it missed (bare-name calls in cmd29-gating tests, then attribute calls on the `commands` module in the DSP-levels tests) and the corrected, now-verified-zero sweep. Cumulative growth: +7 files, +525 changed lines over the pre-review figure. **Final figures: 20 files / 2342 changed lines** — see "Figures at head" below. The owner needs to re-approve at this size before merge; the posted exception comment's numbers no longer match the pushed head.

Every one of the 17 files is load-bearing: the four production files (`commands/levels.py`, `commands/_builders.py`, `commands/_frame.py`, `runtime/radio.py`) are the migration itself; the two regenerated parity baselines are mechanical fallout that cannot be deferred without leaving stale rows asserting a fact the code no longer has; `tests/test_response_shape_from_profile.py`'s extension is the keystone the plan requires to land with the same commit as the module it guards; the six test-file conversions (four from the original push, two added to fix the CI-breaking review finding) are the direct, unavoidable consequence of deleting the fallback bytes/behavior they pinned, compared against, or called; `tests/test_command_map_parity.py`'s docstring fix keeps a comment truthful about which private helpers still exist after two of `_builders.py`'s templates are deleted; the two rig-TOML files fix prose this PR's own deletions made false, per the review; `docs/CHANGELOG.md` is the required breaking-change entry.

## Migration contract, fulfilled per plan §4

**(a) `cmd_map` required, fallback deleted.** All 50 public builders in `commands/levels.py` (25 get/set pairs) now take `cmd_map: CommandMap` as a required keyword-only argument (no default), decorated with `@require_cmd_map` + `@expose_command_key(lambda cmd_map: "<name>")` — every one resolves a literal key equal to its own name (plan §3.1's first, most common case). Every builder calls `_frame.py: _build_from_map` directly rather than the shared `_builders.py` templates it delegated to before migrating — same reasoning as `config.py`'s own module docstring: routing through a template that still carries its own `cmd_map is None` fallback would leave an explicit `cmd_map=None` call one layer away from silently reaching old bytes instead of failing loudly through `require_cmd_map`.

**Template-consumer census (counted before deleting anything):**

| Template | Consumers before this PR | Consumers after | Action |
|---|---|---|---|
| `_build_level_get` | `levels.py` only (20 call sites) | 0 | **Deleted** |
| `_build_level_set` | `levels.py` only (20 call sites) | 0 | **Deleted** |
| `_build_ctl_mem_set` | `levels.py` only (5 call sites); `system.py` never called it | 0 | **Deleted** |
| `_build_ctl_mem_get` | `levels.py` (5 call sites) + `system.py`'s `get_system_date`/`get_system_time`/`get_utc_offset` (3 call sites) | `system.py`'s 3 | **Kept**, fallback intact for `system.py` (unmigrated) |

`_build_ctl_mem_get`'s three remaining callers have a pre-existing caveat, unrelated to this migration: no rig TOML declares `system_date`/`system_time`/`utc_offset` as a command-map key at all (`grep -rn "^system_date\|^system_time\|^utc_offset" rigs/*.toml` — zero hits), so those three getters' `cmd_map` branch always raises `KeyError` (the existing `gap` rows for `system_date`/`system_time`/`utc_offset` in `tests/command_map_parity_uncovered.txt`, unchanged by this PR). This is why `_build_ctl_mem_get` moves from `sites_compared` to `unpinned` in the parity census below — it is still genuinely reachable and still needed, just never successfully exercised by the parity harness now that `levels.py` no longer reaches it either.

**Constants.** 24 now-orphaned `_SUB_*`/`_CTL_MEM_*` byte constants deleted from `commands/_frame.py` — grepped across the whole repo (`src/` and `tests/`), not just `commands/*.py`, before deleting; confirmed each had zero readers outside `_frame.py`'s own definition and `levels.py`'s (now-removed) import. `_SUB_RF_POWER` and `_CMD_LEVEL` are kept: `_SUB_RF_POWER` is used directly by `tests/test_backend_contract_matrix.py` and `tests/test_civ_command_profiling.py` as a raw protocol constant, never through `levels.py`; `_CMD_LEVEL` is still `_builders.py: parse_level_response`'s default `command=` value.

**(b) Call sites moved.** `runtime/radio.py` is the *only* file with production call sites for these 50 builders — grepped `runtime/_scope_runtime.py`, `runtime/_dual_rx_runtime.py` and `backends/_icom_serial_base.py`: zero hits for any of the 50 names. All 25 `CoreRadio` get/set method pairs now call `self._commands.<builder>(...)`. The 25 setter imports are removed from the top-of-file import block as dead; the 22 matcher-backed getter imports stay (needed as arguments to `self._expect_shape(...)`); `get_rf_power`/`get_rf_gain`/`get_af_level` imports are also removed — they have no matcher shape (see (c)) and their request build moved fully onto `self._commands`. `get_squelch` is newly added to the top-level import (it previously used a function-body-local `from rigplane.commands import get_squelch as _get_squelch`, now unnecessary and removed along with `set_squelch`'s equivalent local import).

**(c) Response matchers moved in the same commit.** 22 of `levels.py`'s 25 getters are matcher-backed (BCD, via `self._get_bcd_level`) and now compute their `command=`/`sub=`/`prefix=` via the existing `CoreRadio._expect_shape(builder)` helper (added in #2827). The other 3 — `get_rf_power`, `get_rf_gain`, `get_af_level` — parse their reply with `_level_bcd_decode`/`self._parse_level` directly, **without ever checking the reply's command/sub bytes**; they have no matcher shape to migrate, only a request side, which moved onto `self._commands` like every setter.

## Keystone test (`tests/test_response_shape_from_profile.py`)

Extended `MATCHER_BACKED_GETTERS` with all 22 of `levels.py`'s matcher-backed getters — 9 (config.py) + 22 (levels.py) = 31 entries × 6 CI-V profiles = **186 cases**.

**One new wrinkle, not present in config.py's 9:** `get_squelch` calls `self._check_connected()` directly, ahead of the mocked `_get_bcd_level` — unlike every other getter here, which only reaches the connection check *inside* the mocked method. Without a fix this raised `ConnectionError` on the test's unconnected `CoreRadio` instance for all 6 profiles. Added `monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)` to the test body (harmless for every other entry, since none of them call it directly) rather than special-casing one `_GetterSpec` — keeps the "extend the tuple and everything runs automatically" design intact.

**Proven red for the half-done state, live during this session:** temporarily reverted `get_ref_adjust`'s reply half to the old hardcoded `command=0x1A, sub=0x05, prefix=b"\x00\x70"` (IC-7610's byte value) while leaving the request half migrated. Re-ran the keystone test filtered to `get_ref_adjust`:
```
FAILED [IC-705-get_ref_adjust]  parsed its reply against (26, 5, b'\x00p'), request goes to (26, 5, b'\x00\x89')
FAILED [IC-9700-get_ref_adjust] parsed its reply against (26, 5, b'\x00p'), request goes to (26, 5, b'\x00r')
2 failed, 2 passed, 2 skipped
```
(`\x00p` is `\x00\x70` printed as ASCII 'p' = 0x70.) Failed on exactly IC-705 and IC-9700 — the two profiles where `get_ref_adjust` actually diverges from the IC-7610-shaped literal — and passed on the others, which is the correct discriminating behavior (a test that failed everywhere, or nowhere, would be worthless here). Reverted immediately after; the diff under review never contained the broken version.

Chose `get_ref_adjust` over `get_mic_gain` for this proof deliberately: `get_mic_gain`'s bytes (`0x14`/`0x0B`) are identical across every profile (it never diverges, by construction of the original collision — only `set_acc1_mod_level`'s address moved, not `set_mic_gain`'s), so reverting its shape produces no failures at all and would have been a false demonstration.

## Drift-guard extension (§3/§4 owner-ruling machinery)

No code changes needed — `tests/test_profile_command_binding.py: TestExposedKeyDriftGuard` already exercises every `@expose_command_key`-decorated builder generically, argument-case synthesis included (added for config.py's setters in #2827). Confirmed the mechanism actually reaches `levels.py`'s 50 builders rather than assuming it: `pytest tests/test_profile_command_binding.py -k DriftGuard --collect-only -q` shows parametrized cases for `get_rf_power`, `set_rf_power`, `get_mic_gain`, `set_mic_gain`, `get_ref_adjust`, `set_ref_adjust`, `get_dash_ratio`, `set_dash_ratio`, `get_squelch`, `set_squelch`, etc. (both probe maps each); full run 160/160 passed.

One existing test needed a swap, unrelated to the drift-guard mechanism itself: `test_expect_on_unexposed_builder_names_the_migration` used `get_rf_power` as its "not exposed yet" example — now that `get_rf_power` is exposed by this PR, that example no longer demonstrates the refusal path. Swapped for `get_s_meter` (`meters.py`, still unmigrated, same call shape).

## Existing tests converted (fallback-byte pins → `load_rig`-backed map pins)

Following `config.py`'s conversion in `tests/test_commands.py` as the template (prefer `load_rig(...)` maps over hand literals):

- **`tests/test_commands.py`**: `TestPowerCommands` (new `cmd_map` fixture), `TestCmd29ReceiverRouting` (new `cmd_map` fixture; `rf_gain`/`af_level`/`squelch` cases updated, `nb`/`nr`/`ip_plus` cases untouched — those builders are unmigrated), `TestDspLevelParityCommands` (new `cmd_map` fixture covering its three parametrized test methods plus `test_set_nb_width_rejects_out_of_range`), and `TestSystemConfigCommands`'s REF-Adjust/Dash-Ratio sections — these last reuse the **existing** `cmd_map` fixture already in that class (added for `config.py` in #2827), since both classes target the same IC-7610 map. All of `rigs/ic7610.toml`'s levels.py wire tuples (`get_rf_power`, `set_rf_power`, `get_rf_gain`, `get_af_level`, `get_squelch`, `get_apf_type_level`, `get_nr_level`, `get_nb_level`, `get_ref_adjust`, `get_dash_ratio`) are byte-identical to the deleted fallback (no IC-7610 row in `tests/command_map_parity_divergences.txt`), so every expected literal is unchanged — only the `cmd_map=` wiring is new.
- **`tests/test_command_map_integration.py`**: `TestGetterParity`/`TestSetterParity`/`TestHelperCallerParity`'s levels.py cases (`get_af_level`, `get_rf_gain`, `get_rf_power`, `set_rf_power`, `set_af_level`, `set_rf_gain`, `set_squelch`, `get_apf_type_level`, `get_nr_level`, `get_nb_level`, `get_ref_adjust`) can no longer compare "with cmd_map" against "without" (there is no more "without"), so each now pins the map path against the frame the deleted fallback used to build, via `build_civ_frame`/`build_cmd29_frame` literals — same historical bytes, new construction. `TestCommandMapOverride`'s two "different wire bytes produce a different frame" cases (`get_af_level`, `set_rf_power`) swap their `hardcoded = commands.X()` comparison point for `commands.X(cmd_map=cmd_map)` against the real IC-7610 map — a custom map vs. the real map is an equally valid "genuinely different frame" proof, and needs no fallback at all.
- **`tests/test_rf_gain_af_level.py`**: full file converted — new module-level `cmd_map` fixture, every call site gets `cmd_map=cmd_map`. Bytes unchanged (IC-7610 doesn't diverge for `get_rf_gain`/`get_af_level`).
- **`tests/test_profile_command_binding.py`**: see drift-guard section above.

`tests/test_command_fallback_audit.py` needed no changes — it's fully generic over the fallback-audit hook, names no specific builder; ran unchanged, 23/23.

## Parity-file delta, line-class by line-class

Regenerated with `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py`, on the fully rebased tree (see "Rebase" below), diffed against `origin/main` and inspected line by line.

`tests/command_map_parity_divergences.txt`: **24 rows deleted, all `levels.py:*`, nothing else touched.** Two measurements of my own, not one carried forward: **18** at this branch's original base (`90a8a2dd`, config.py's merge commit — IC-705 ×4, IC-7300 ×8, IC-9700 ×6), **24** at the rebased head (`63f12d1e`, IC-705 ×10, IC-7300 ×8, IC-9700 ×6). The +6 is IC-705's `get_nb_depth`/`set_nb_depth`, `get_nb_width`/`set_nb_width`, `get_vox_delay`/`set_vox_delay` (3 pairs): `#2828` (MOR-2016, IC-705 D2) declared these for the first time from IC-705's own CI-V guide, moving them from `gap` (undeclared) to `divergence` (declared, and byte-different from the deleted fallback) between the two measurements. IC-705's other two pairs (`get_dash_ratio`/`get_ref_adjust`) were already declared and already diverging before `#2828`, at the same byte values both before and after it — confirmed by diffing the two measurements' row content, not assumed. The plan document itself cites "16" for this module, measured at an even earlier commit (`a2de2ab0`, before its own config.py migration and two more D2 passes landed) — not independently re-verified here since it predates this branch's own base; the two figures I did measure myself, 18 and 24, are what the arithmetic above is built on. Verified by grep that every remaining row belongs to `vfo.py` (unaffected — that module hasn't migrated yet).

`tests/command_map_parity_uncovered.txt`:
- **50 `gap` rows deleted, one per `levels.py` builder name.** Once `cmd_map` is required, the harness's `cmd_map=None` probe (`_accepts`) no longer succeeds for these builders, so `_cases()` moves them entirely out of the comparable set (`per_builder`) and they can no longer produce a gap row.
- **50 `requires-map` rows added** — same 50 names, correctly attributed to a required `cmd_map` (`_requires_cmd_map`, added in #2827 for config.py's 18, is a pure signature check independent of any profile's TOML — unaffected by which module it's checking).
- **`_builders.py:_build_ctl_mem_get` moves from `sites_compared` to a new `unpinned` row** — explained under "Template-consumer census" above: it's still reachable (via `system.py`'s three getters), just never successfully compared (no rig TOML declares the three map keys those getters resolve).
- **Census, `origin/main` (`63f12d1e`) → this PR's head:**

| Field | Before | After | Δ |
|---|---|---|---|
| `builders_compared` | 212 | 162 | −50 (levels.py's 50 builders move to `requires-map`) |
| `dual_implementation_sites` | 133 | 128 | −5 (`_build_level_get`, `_build_level_set`, `_build_ctl_mem_set` deleted; `get_rf_power`/`set_rf_power`'s own literal `cmd_map is not None` test removed — those two functions used to test it directly, not just delegate; `_build_ctl_mem_get` stays a site since it's kept) |
| `sites_compared` | 122 | 116 | −6 (the 5 sites above, minus one: `_build_ctl_mem_get` itself was already compared via `levels.py`'s ctl_mem builders before this PR — it now loses that path and never gains a replacement, since `system.py`'s three callers never successfully compare) |
| `frames_diverged` | 33 | 9 | −24 (matches the divergence-row deletion above) |
| `frames_identical` | 1364 | 996 | −368 (fewer builder×profile×argument-case combinations remain comparable once 50 builders leave `per_builder`) |
| `profile_builder_map_gaps` | 893 | 705 | −188 (levels.py's per-profile gap combinations no longer counted once those builders require `cmd_map`) |
| `public_builders` | 232 | 232 | 0 (unaffected — builders keep their `cmd_map` parameter, just required now) |
| `hardcode_only_builders` | 16 | 16 | 0 (unaffected — counts builders with no `cmd_map` param at all) |
| `profiles` / `cat_only_profiles` | 8 / 2 | 8 / 2 | 0 (unrelated to this migration) |

Every number here is re-measured and asserted by `test_command_map_parity.py` itself (`test_uncovered_inventory_matches`), so none of it can go stale unnoticed.

## Rebase onto `origin/main` (`63f12d1e`)

Branched from `90a8a2dd` (config.py's merge commit, #2827). While this work was in progress, `#2828` (MOR-2016, IC-705 D2) merged to `main`, regenerating the same two files this PR regenerates (`tests/command_map_parity_divergences.txt`, `tests/command_map_parity_uncovered.txt`) with IC-705's own CI-V-guide-sourced byte data — several of the newly-filled keys are `levels.py` commands this migration also touches (`get_nb_depth`, `get_nb_width`, `get_vox_delay`, plus corrected `get_dash_ratio`/`get_ref_adjust` values). Rebased onto `origin/main` (`63f12d1e`); the rebase conflicted only in the two generated parity files. Per instruction, they were **not hand-merged**: resolved with a placeholder during the rebase, then `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py` re-ran on the fully rebased tree to produce their real, final content — the parity-delta table above is that final, post-rebase state, not carried forward from a pre-rebase measurement. Confirmed the branch base is exactly `origin/main`'s current tip before pushing (`git merge-base HEAD origin/main` == `git rev-parse origin/main`, and `git log --oneline HEAD..origin/main` empty).

## Second rebase onto `origin/main` (`c23161b9`)

`main` moved again before review: `#2830` (MOR-2017, IC-7610 D2) merged, touching `rigs/ic7610.toml` (prose/source-annotation only — the commit's own message confirms no byte values changed), `tests/command_map_parity_uncovered.txt`, `tests/profile_command_coverage_gaps.txt`, and a new `tests/test_rig_ic7610.py` case, none of which overlap this PR's own edits to those files by content. Fetched, rebased onto `c23161b9`; as expected, the only conflict was in `tests/command_map_parity_uncovered.txt` (line-level, both PRs editing the census/gap/requires-map sections). Resolved with a placeholder (never hand-merged), then regenerated with **both** env vars on the fully rebased tree: `RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest tests/test_command_map_parity.py` and `RIGPLANE_REGEN_PROFILE_COMMAND_COVERAGE=1 uv run pytest tests/test_profile_command_coverage.py`.

`tests/profile_command_coverage_gaps.txt` came back with **zero diff** against `origin/main` — this PR doesn't move that census at all (`levels.py`'s D1 declared/absent state, which that file tracks, is orthogonal to whether `cmd_map` has a default). The four IC-7610 coverage keys `#2830` resolved are fully absorbed into the new baseline and don't interact with this PR's own numbers.

`tests/command_map_parity_uncovered.txt` did need the regen — the rebase's automatic line-merge landed on a version whose gap/requires-map *rows* were plausible but whose *census counts* were stale (git merges lines, not arithmetic). One process note, caught and fixed before pushing: after `git rebase --continue`, the regenerated file initially sat as an uncommitted working-tree change on top of the rebase commit; a first delta check (`git diff origin/main HEAD`) therefore compared against the **pre-regen** commit and showed a spurious three-line delta (`antenna.py:get_rx_antenna_ant2`/`set_rx_antenna_ant2` appearing to flip `unpinned`, which was really just `#2830`'s own already-landed fix reappearing because the local file hadn't been amended in yet). Caught by cross-checking with a plain `diff` on the two file contents directly (bypassing git's diff pairing) rather than trusting the first read; fixed with `git add` + `git commit --amend` on the same not-yet-pushed rebase commit, then re-verified: `git diff origin/main HEAD -- tests/command_map_parity_uncovered.txt` now shows exactly one `unpinned` addition (`_builders.py:_build_ctl_mem_get`, this PR's own known effect) and nothing from `#2830`.

**This PR's own delta survives unchanged, confirmed by direct measurement, not assumed:**

| Field | `origin/main` (`c23161b9`) | This PR's head | Δ | Same Δ as before this rebase? |
|---|---|---|---|---|
| `builders_compared` | 212 | 162 | −50 | yes |
| `dual_implementation_sites` | 133 | 128 | −5 | yes |
| `sites_compared` | 124 | 118 | −6 | yes |
| `frames_diverged` | 33 | 9 | −24 | yes |
| `frames_identical` | 1367 | 999 | −368 | yes |
| `profile_builder_map_gaps` | 890 | 702 | −188 | yes |
| `public_builders` / `hardcode_only_builders` | 232 / 16 | 232 / 16 | 0 | yes |

Every "Δ" column is identical in magnitude to what this PR reported before this second rebase — only the baseline each is measured against moved (by `#2830`'s own unrelated fixes: `antenna.py`'s `get_rx_antenna_ant2`/`set_rx_antenna_ant2` and `vfo.py`'s `scan_start_type` gaps resolved, none of them `levels.py`, none of them touched by this PR). `tests/command_map_parity_divergences.txt`: still exactly **24 rows deleted, all `levels.py:*`** (`git diff origin/main HEAD -- tests/command_map_parity_divergences.txt | grep '^-' | grep -v levels.py` → 0 hits). `tests/command_map_parity_uncovered.txt`: still exactly **50 `gap` rows removed, 50 `requires-map` rows added** (same 50 names), and exactly one new `unpinned` row (`_builders.py:_build_ctl_mem_get`).

`git diff origin/main...HEAD --stat` totals are byte-identical, file-for-file, to the pre-second-rebase measurement (13 files, 972 insertions, 845 deletions) — coincidental in the sense that no line in this PR's own files changed, not because the underlying content is untouched by `#2830` (it is, in `tests/command_map_parity_uncovered.txt`; the row-for-row content differs, the aggregate line-change count does not).

## Review round 1 — BLOCKED at `52f99111`, fixed at `b4788c48`

Independent review (comment: [`#2832` review](https://github.com/rigplane/rigplane-core/pull/2832#issuecomment-5470403247)) blocked on two findings. Full text of what was verified and could not be refuted is in that comment; this section covers only the two fixes.

### Finding 1 — 90 deterministic CI failures, two unconverted test modules

`tests/test_mor1517_cmd29_gating.py` (16 call sites) and `tests/test_mor1543_cmd29_gating.py` (16 call sites) call migrated `levels.py` builders as free functions with no `cmd_map`, raising the same `TypeError` every migrated builder raises without one. Missed by the original conversion sweep for a structural reason the reviewer named precisely: those two files' *subject* is cmd29 wrapping — whether a frame comes out `0x29`-wrapped on IC-7610 versus bare on IC-7300/IC-705 — not fallback bytes, so a sweep aimed at "tests pinning fallback frames" (what caught `test_commands.py`, `test_command_map_integration.py`, `test_rf_gain_af_level.py`) does not find them. **The lesson, recorded for module 3 and beyond: the reliable sweep is "tests calling a migrated builder", not "tests pinning fallback frames."** Reran that exact sweep as a static AST check (parse every `tests/*.py` module for a call to any of the 50 migrated `levels.py` builders with no `cmd_map=` keyword) — zero remain.

Both files use the same pattern: `await radio.<method>(...)` (already correct, migrated in the commit CI failed at) compared against `expected = <builder>(..., command29=..., to_addr=<literal>)` (the free-function call used to build the comparison value — this is what needed `cmd_map=`). Fix: three real profile `CommandMap`s (IC-7300, IC-7610, IC-705 — via `load_rig`, matching every other conversion in this PR) added as module-level constants in `test_mor1517_cmd29_gating.py`, imported into `test_mor1543_cmd29_gating.py` alongside its existing helper imports from that file. All ten builders these two files exercise (`pbt_inner`, `pbt_outer`, `nr_level`, `nb_level`, `apf_type_level`, `digisel_shift`, `rf_gain`, `af_level`, `squelch`, `notch_filter`) emit byte-identical `[0x14, sub]` frames on every profile that declares them — no menu address, no divergence row for any of them — so every expected literal is unchanged; only the `cmd_map=` wiring on the comparison-builder calls is new. **The assertions this PR was told to preserve exactly are untouched**: `TestPbtInnerGating`/etc. still discriminate wrapped-on-IC-7610 vs. unwrapped-on-IC-7300 (and IC-705 for `apf_type_level`/`digisel_shift`, which IC-7300 doesn't declare at all) — only the byte-comparison plumbing changed, not what each test proves.

### Finding 2 — rig-TOML prose this PR's own deletion falsifies

Reworded to past tense / historical, keeping the guide facts, exactly the three live sites the review named:

- **`rigs/ic9700.toml`, two blocks** (`[cw]` dash-ratio note, `[commands.overrides]` dash_ratio comment): both said `` `_CTL_MEM_DASH_RATIO = 0x0228` is itself wrong for this radio ... not fixed here``. That constant and the fallback that read it are deleted by this PR. Now: "the hardcoded fallback that used to send 0x0228 ... was itself wrong for this radio (0228 = CW-KEY SET>MIC Up/Down Keyer, not Dot/Dash Ratio) ... deleted in MOR-2006 Steps 5..N module 2" — the guide fact (0228 is the wrong control on this radio) survives verbatim; only the tense and the disposition of the fallback changed.
- **`rigs/ic705.toml`, six rows** (`get_/set_nb_depth`, `get_/set_nb_width`, `get_/set_vox_delay`): contrasted against "the shared fallback's 0290/0291/0292". Worded precisely per what actually survives, checked rather than assumed: `_CTL_MEM_NB_DEPTH` (0290) and `_CTL_MEM_NB_WIDTH` (0291) are deleted outright, so those four rows now say the fallback "was" IC-7610's address and name the deleted constant. `_CTL_MEM_VOX_DELAY` (0292) is different — `grep -n "0x02, 0x92" src/rigplane/runtime/_civ_rx.py` shows it survives, but only as `_CTL_MEM_VOX_DELAY_PREFIX`, an independent RX-parser constant for decoding unsolicited frames (Q3's reverse-index scope, a different symbol from the deleted builder-side one), not as anything any builder can emit — the two vox_delay rows say exactly that rather than a blanket "deleted".

**Left untouched, confirmed still correct rather than assumed:** `rigs/ic705.toml:785` (the `civ_transceive`/"shared 0129 fallback" comment — already false on `main` since `#2827`, but owned by open PR `#2833` fixing that exact region; stayed out of it as instructed). The `system_date`/`system_time`/`utc_offset` comments in `ic705.toml` and `ic7610.toml` (`system.py` is unmigrated, `_build_ctl_mem_get` is deliberately kept for it, and all three `_CTL_MEM_SYSTEM_*` constants still exist — verified by grep, not assumed). `ic7300.toml`'s `quick_split` note and `ic9700.toml`'s `0x07 0xCx` note (both cite `vfo.py`, unmigrated, its fallback constants untouched by this PR).

**Swept the class, found one more instance — initially left unfixed, then corrected by the independent `#2833` review.** `tests/test_rig_ic705_mor1540.py` has three one-line docstrings (`TestD2DocumentaryCommandBytes.test_get_nb_depth`/`test_get_nb_width`/`test_get_vox_delay`) making the same "NOT the shared fallback's 029X" comparison. At the time of this fix round I judged them a weaker, still-true claim outside the review's stated scope ("class rot this PR creates in rig TOMLs") and left them unfixed, reporting the reasoning here instead. The independent `#2833` review ruled on exactly that question and disagreed: the claim is true today and false the moment this PR's own deletion of `_CTL_MEM_NB_DEPTH`/`_CTL_MEM_NB_WIDTH`/`_CTL_MEM_VOX_DELAY` merges, which makes fixing it this PR's scope regardless of which file the falsified prose lives in. **Fixed in a follow-up commit** (`fix(MOR-2006): reword the remaining falsified nb_depth/nb_width/vox_delay docstrings`), same historical/past-tense rewording as the `rigs/ic705.toml` rows this mirrors, including the same precise vox_delay wording (0292 survives only as an RX-parser value in `runtime/_civ_rx.py`, not as anything a builder can emit). Left untouched in the same file, per the same review: `test_civ_transceive_corrected`'s docstring (:87-91, the 0129/`civ_transceive` comparison) — a different, already-false claim in the same file, owned by `#2833`'s own fix round; stayed out of that region.

### Re-verification after the fix (round 1's sweep, later found incomplete — see "Review round 2")

Static sweep (the reviewer's own round-1 verification query, rerun): `0` call sites to a migrated `levels.py` builder with no `cmd_map=`, across every `tests/*.py` module. **This query only matched bare-name calls (`ast.Call` with an `ast.Name` func) and could not see an attribute call on the `commands` module — it returned a false zero. Superseded by the corrected sweep in "Review round 2" below; do not rely on this round's sweep result.**

`git grep -n fallback rigs/*.toml` swept in full: every surviving mention now names a fallback that still exists in code (`vfo.py`'s, or `system.py`'s via `_build_ctl_mem_get`) or is the one pre-existing, out-of-scope case at `ic705.toml:785` explicitly left for `#2833`. (This sweep's own shape was sound — it's a `grep`, not an AST match on call syntax — so it is not affected by round 2's finding.)

## Review round 2 — BLOCKED at `b1b5e963`, fixed at `19d9450c`

Same underlying class as round 1, two more files the round-1 sweep could not see: `tests/test_dsp_levels_part1.py` (54 call sites) and `tests/test_dsp_levels_part2.py` (13) call migrated `levels.py` builders as `commands.<builder>(...)` — an **attribute call** on the `rigplane.commands` module (imported as `from rigplane import commands`, then rebound in place to a `CommandModuleProxy` by `bind_default_addr_globals` for its `to_addr` default). Round 1's sweep query matched only `ast.Call` nodes whose `func` is a bare `ast.Name`; `commands.get_nr_level(...)` has `func = Attribute(attr="get_nr_level", value=Name(id="commands"))`, a different AST shape the query never tested, so it returned zero for both files in both of the first two rounds for the same reason.

**Corrected sweep, from the review, re-run as a script across every file in `tests/`:** a call counts as a free-builder call if it is either `Name(id in migrated)` or `Attribute(attr in migrated, value=<a name statically bound to the `rigplane.commands` module itself, e.g. via `from rigplane import commands`>)`, and it passes no `cmd_map` keyword — excluding attribute calls whose receiver is a radio or bound-commands object (`radio.get_nr_level(...)`, `self._commands.set_nr_level(...)` are method calls on an already-migrated call site, not free-builder calls) and `tests/test_commands.py::test_get_acc1_mod_level_requires_cmd_map` (omits `cmd_map` by design, to assert the `TypeError` — not in scope for `levels.py`'s 50 builders regardless, since that test calls a `config.py` builder). Verified the script itself before trusting its zero: ran it unmodified against the pre-fix committed content of both files and it correctly reproduces 54 and 13 — the same script, same query, same exclusions, only the tree changed.

**Fix, same pattern as rounds 1 and 2:** real profile `CommandMap`s via `load_rig` — `_IC7610_CMD_MAP` alone for `test_dsp_levels_part1.py` (every case in that file targets IC-7610 only); `_IC7610_CMD_MAP` and `_IC705_CMD_MAP` for `test_dsp_levels_part2.py` (one case, `test_get_digisel_shift_custom_addresses`, explicitly overrides `to_addr=0xA4` and now gets the matching IC-705 map instead of the file's IC-7610 default). All twelve builders these two files exercise (`get_/set_apf_type_level`, `get_/set_nr_level`, `get_/set_pbt_inner`, `get_/set_pbt_outer`, `get_/set_nb_level`, `get_/set_digisel_shift`) declare byte-identical `[0x14, sub]` wire tuples on every profile that declares them — no menu address, no divergence row for any of them — so every expected literal is unchanged; only the `cmd_map=` wiring is new. The 67 call sites were rewritten with an AST-position-based script (locate each matching `Call` node's closing paren by `end_lineno`/`end_col_offset`, insert `cmd_map=<map>` or `, cmd_map=<map>` depending on whether the call already had arguments, processed in reverse source order so earlier insertions don't invalidate later offsets) rather than by hand, then `ruff format` to normalize the resulting line wrapping — the diff is larger than a hand edit would produce because of the reformatting, not because of scope creep.

### Re-verification after this fix

Corrected sweep (bare-name **and** attribute-call shapes, both exclusions applied), run across every file in `tests/`, final result:

```
TOTAL: 0 call sites
```

Runtime backstop, per instruction — the full local standard suite, once, since the repeated CI round-trips at this point cost more than one local run:

```
uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=line --timeout=300 --timeout-method=thread
```
→ **11042 passed, 83 skipped, 47 xfailed, 1 xpassed, 0 failed, 106.05s.** `grep -c "missing 1 required keyword-only argument: 'cmd_map'"` on the full output → **0**.

## Third rebase onto `origin/main` (`2d7d51df`)

`main` moved again during this round: `#2834` (MOR-2019, X6200 D2) merged, touching `rigs/x6200.toml` and `docs/validation/cat-audits/x6200.md` only — neither of the two generated parity files this PR regenerates. Rebased onto `origin/main` (`2d7d51df`); all four commits replayed with **no conflicts**. Regenerated both `tests/command_map_parity_uncovered.txt` (`RIGPLANE_REGEN_COMMAND_MAP_PARITY=1`) and `tests/profile_command_coverage_gaps.txt` (`RIGPLANE_REGEN_PROFILE_COMMAND_COVERAGE=1`) on the rebased tree anyway, per standing practice — `git status` showed **zero diff** from either regeneration, so `#2834`'s X6200 changes don't touch anything this PR's own census tracks. Confirmed the branch base is exactly `origin/main`'s current tip before pushing (`git merge-base HEAD origin/main` == `git rev-parse origin/main`).

## Test evidence (at the pushed head, re-run after the third rebase and both review-fix rounds)

Targeted suite plus the two cmd29-gating files (never the full suite locally, per instructions):
```
uv run pytest tests/test_response_shape_from_profile.py tests/test_command_map_parity.py \
  tests/test_profile_command_binding.py tests/test_undeclared_command_policy.py \
  tests/test_rig_ic7300.py tests/test_command_map_integration.py tests/test_commands.py \
  tests/test_radio.py tests/test_command_fallback_audit.py tests/test_rf_gain_af_level.py \
  tests/test_mor1517_cmd29_gating.py tests/test_mor1543_cmd29_gating.py \
  -q --no-header
```
→ **1249 passed, 71 skipped, 0 failed** (1249, not the pre-review-fix 1153 — the +96 is exactly the two newly-converted files' own test counts).

Full-module collection sanity on the two fixed files, standalone, per the reviewer's request:
```
uv run pytest tests/test_mor1517_cmd29_gating.py tests/test_mor1543_cmd29_gating.py -q
```
→ **96 passed, 0 failed** (52 + 44).

Combined-collection proof (the rebinding files + the drift-guard file together — the collection-order bug class fixed in #2827 for config.py's setters — now extended with both cmd29-gating files, since they also call migrated builders and could in principle hit the same collection-order class):
```
uv run pytest tests/test_command_fallback_audit.py tests/test_commands.py \
  tests/test_commands_extended.py tests/test_main_sub_tracking.py \
  tests/test_rf_gain_af_level.py tests/test_scope.py tests/test_profile_command_binding.py \
  tests/test_mor1517_cmd29_gating.py tests/test_mor1543_cmd29_gating.py \
  -q --no-header
```
→ **745 passed, 0 failed** (745, not the pre-review-fix 649 — same +96).

`uv run ruff check src/ tests/` → all checks passed. `uv run ruff format --check src/ tests/` → all formatted. `uv run lint-imports` → 5/5 contracts kept.

`web/` untouched, so no `mypy --strict` run per `CLAUDE.md`.

Internal-identifier self-check grep — empty.

**Round 2 commit** (the three `tests/test_rig_ic705_mor1540.py` docstrings, ruled in-scope by `#2833`): `uv run pytest tests/test_rig_ic705_mor1540.py -q` → **20 passed, 0 failed**. `ruff check`/`format --check` on the one touched file → clean.

**Round 3 commit** (the 67 attribute-call sites in the two DSP-levels files): targeted suite, now 15 files:
```
uv run pytest tests/test_response_shape_from_profile.py tests/test_command_map_parity.py \
  tests/test_profile_command_binding.py tests/test_undeclared_command_policy.py \
  tests/test_rig_ic7300.py tests/test_command_map_integration.py tests/test_commands.py \
  tests/test_radio.py tests/test_command_fallback_audit.py tests/test_rf_gain_af_level.py \
  tests/test_mor1517_cmd29_gating.py tests/test_mor1543_cmd29_gating.py \
  tests/test_rig_ic705_mor1540.py tests/test_dsp_levels_part1.py tests/test_dsp_levels_part2.py \
  -q --no-header
```
→ **1398 passed, 71 skipped, 0 failed** (1398, not the round-2 1249+20 — the extra +129 is the two DSP-levels files' own test counts, 129 combined). Full-suite runtime backstop and the corrected sweep's final zero are under "Review round 2" above. Re-run again after the third rebase, same figures, confirmed byte-identical.

Scope froze at the round-3 push, per instruction — no other changes beyond the 67 call sites and their supporting imports/constants.

## Deliverable checklist (task spec points 1–9)

1. **`levels.py` rewritten** — 50/50 builders: `cmd_map` required keyword-only, fallback branches deleted, `@expose_command_key` on every one.
2. **Templates de-delegated, consumers counted first** — see "Template-consumer census" above.
3. **Call sites found and moved** — see (b) above. No caller lacking `self._commands` was found.
4. **Response matchers moved** — see (c) above.
5. **Keystone test extended, proven red** — see "Keystone test" above.
6. **Drift guard verified, no changes needed** — see "Drift-guard extension" above.
7. **Parity regenerated, delta explained** — see "Parity-file delta" above.
8. **Existing fallback-pinning tests converted** — see "Existing tests converted" above.
9. **`MockIcomRadio` untouched** — confirmed, no edits to `tests/mock_server.py`.

## Figures at head (FINAL — scope frozen at this push, acceptance criterion is the round-2 corrected sweep returning zero, confirmed above)

**20 files changed, 1338 insertions(+), 1004 deletions(-) = 2342 changed lines** — up from the pre-review 13 files / 1817 lines the posted exception names; both hard-ceiling dimensions still crossed, more so now, across three review rounds fixing one class (a static sweep missing two different call shapes, twice). Owner re-approval needed at this size (see "Guardrail exception" above). `git diff origin/main...HEAD --stat`:

```
 docs/CHANGELOG.md                         |  14 +
 rigs/ic705.toml                           |  12 +-      6 rows reworded, review round 1 finding 2
 rigs/ic9700.toml                          |  17 +-      2 blocks reworded, review round 1 finding 2
 src/rigplane/commands/_builders.py        |  98 +---     3 templates deleted
 src/rigplane/commands/_frame.py           |  38 +-      24 constants deleted
 src/rigplane/commands/levels.py           | 729 +++++++++++++++---------------  50 builders, near-total rewrite
 src/rigplane/runtime/radio.py             | 296 +++++++-----
 tests/command_map_parity_divergences.txt  |  24 -       regenerated on the rebased tree
 tests/command_map_parity_uncovered.txt    | 113 ++---
 tests/test_command_map_integration.py     | 126 +++++-
 tests/test_command_map_parity.py          |  10 +-      stale docstring count fixed
 tests/test_commands.py                    | 245 ++++++----
 tests/test_dsp_levels_part1.py            | 223 +++----   54 call sites, review round 2
 tests/test_dsp_levels_part2.py            |  66 ++-      13 call sites, review round 2
 tests/test_mor1517_cmd29_gating.py        | 109 ++++-   16 call sites, review round 1 finding 1
 tests/test_mor1543_cmd29_gating.py        |  83 +++-    16 call sites, review round 1 finding 1
 tests/test_profile_command_binding.py     |   9 +-
 tests/test_response_shape_from_profile.py |  34 ++     new getters
 tests/test_rf_gain_af_level.py            |  81 ++--
 tests/test_rig_ic705_mor1540.py           |  15 +-      3 docstrings, #2833-ruled follow-up to round 1 finding 2
 20 files changed, 1338 insertions(+), 1004 deletions(-)
```

## Anything contradicting the spec / worth flagging

- The task's own framing cited "16" divergence rows for `levels.py`, measured at the plan's original base commit. Not independently re-verified against that commit here — my own two measurements (18 at this branch's original base, 24 at the rebased head) are what this PR's numbers are built on, and neither is 16. See the parity-delta section above for exactly which 6 rows separate the two and why (IC-705's D2 pass, `#2828`, landing mid-session).
- `get_squelch`'s direct `self._check_connected()` call (ahead of the mocked parser, unlike every sibling getter) required a one-line addition to the keystone test's own machinery, not a code change — flagged under "Keystone test" above in case a future module hits the same pattern.
- Nothing else found in the original implementation that resisted the pattern. All 50 `levels.py` builders migrated uniformly (all fall into §3.1's "literal key equal to function's own name" case).
- Own process mistake, caught before pushing: my first delta check after the second rebase compared `origin/main` against a commit that hadn't yet been amended with the freshly regenerated `tests/command_map_parity_uncovered.txt` (the regen was still an uncommitted working-tree change). That comparison showed a spurious three-line delta touching `antenna.py`'s two builders — not this PR's doing, just `#2830`'s own already-merged fix reappearing because the local commit was stale. Caught by a plain-text `diff` of the two file versions (sidestepping git's diff pairing) rather than trusting the first read, fixed by amending the regen into the same not-yet-pushed commit, and re-verified clean. See "Second rebase" above for the full trace.




