### PR TITLE
docs: archive the 2026-08-30 mechanism-audit reports (three tracts)

### DIFF
--- a/.claude/audits/2026-08-30-mechanism-audit-command-path.md
+++ b/.claude/audits/2026-08-30-mechanism-audit-command-path.md
@@ -1,0 +1,391 @@
+> **Point-in-time audit snapshot (2026-08-30).** Produced by the `auditor`
+> subagent (Claude Opus) following `.claude/skills/mechanism-audit/SKILL.md`.
+> Tree audited: `8c8a70d4` (merged to main via #2801). Every citation in this
+> document — including the file:line forms used where no symbol encloses the
+> evidence — is frozen at that revision; resolve against `8c8a70d4`, not HEAD.
+> This file is an archived report, not maintained documentation. Owner rulings
+> recorded 2026-08-30 (see the Linear ticket package referencing this audit)
+> supersede any recommendation here where they differ — in particular F3's
+> open contract question is ruled: `receiver=0` means literal MAIN, always;
+> the runtime layer is the deviant side and the mechanism is to be
+> encapsulated in the runtime write path.
+
+# Mechanism audit — command path (frontend → wire), rigplane-core
+
+**Method:** `.claude/skills/mechanism-audit/SKILL.md`, read from the audited repository at `/Users/moroz/Projects/rigplane-core/.claude/skills/mechanism-audit/SKILL.md` (tracked; committed in `8c8a70d4`). Followed as written, with the dispatch's citation override applied (file + **symbol name** rather than `file:line`; `file:line` only where no symbol encloses the evidence).
+
+**Tree audited:** `8c8a70d4` (`8c8a70d435a2b94bef7bb8dce1c549dfe3798b05`), branch `codex/mechanism-audit-skill`, tracking `origin/codex/mechanism-audit-skill`. `git status --short --branch` reported **clean** — no uncommitted changes, no untracked files. Read-only throughout: no writes, no git/gh writes, no test runs, no builds. All bash foreground.
+
+**Premise handling:** the dispatch supplied four already-ticketed findings and a scope. It supplied no conclusion about what I would find, so there was no hypothesis to put under test. The one asserted fact I did test rather than accept is the CLAUDE.md claim that the CLI predates the state model and its apparent violations may be historical — see *Cleared*, item 8: I checked the CLI's command path and it does **not** reimplement radio truth; the doctrine violation I found is in `rigctld/`, not `cli/`.
+
+**Instruction-shaped text in files:** none found. Comments and docstrings on this path are descriptive (several are *wrong*, which is reported as evidence, not obeyed). No file attempted to direct an agent.
+
+---
+
+## DELETIONS (independent, no design decision)
+
+### D1 — unselected-slot polling in `web/radio_poller.py`: dead cluster behind a constant-returning guard
+```
+Verdict:          dead
+Rank:             n/a (deletion)
+```
+**Elements** (all in `/Users/moroz/Projects/rigplane-core/src/rigplane/web/radio_poller.py`):
+- `RadioPoller._unselected_slot_gate` — body is `_ = receiver; return False`. Guard returning a constant.
+- `RadioPoller._poll_unselected_slot` — body is `_ = receiver`. No-op.
+- `RadioPoller._last_user_write_ts` — instance field.
+- `RadioPoller._last_unselected_poll` — instance field.
+- `RadioPoller._UNSELECTED_SLOT_INTERVAL` / `RadioPoller._UNSELECTED_SLOT_DEBOUNCE` — class constants (`radio_poller.py:3945-3946`; the two lines stand immediately above `_unselected_slot_gate`).
+- The `for _rx in range(self._profile.receiver_count): await self._poll_unselected_slot(_rx)` loop inside `RadioPoller._run` (`radio_poller.py:1991-1993`, guarded by `if self._acquisition_scheduler is None:`) — every iteration calls the no-op.
+
+**Consumers:** production — none. Tests only: `tests/test_poller_poll_priority.py` (asserts the gate returns `False` and the poll is awaitable), `tests/test_selected_freq_mode.py` (≈8 calls incl. `test_set_freq_updates_last_user_write_ts`), `tests/test_radio_poller_coverage.py`, `tests/test_civ_transaction_ownership.py`, `tests/test_vfo_profile_primitives.py`.
+
+**Written / read (observation; grep is literal):**
+- `grep -rn "_last_user_write_ts" src/ tests/ frontend/src` → 9 hits in `src/` (1 init + **8 writes**, all `self._last_user_write_ts = time.monotonic()`), **0 production reads**; 8 hits in `tests/`, all reads/asserts.
+- `grep -rn "_last_unselected_poll" src/ tests/` → **1 hit total** (the initialiser). Written once, read nowhere.
+- `grep -n "_UNSELECTED_SLOT_INTERVAL" src/rigplane/web/radio_poller.py` → 2 hits: the definition, and a *comment* at `radio_poller.py:709`.
+
+**Guards checked:**
+- *Dynamic access* — searched **literally**. Names are private (`_`-prefixed), not in any `__all__`, not string-built, not serialised by field name. `RadioPoller` has no `__slots__` and no `getattr`-driven attribute dispatch on these names.
+- *Out-of-repo* — `RadioPoller` is not exported from `rigplane.web.__init__`; the open-core Pro boundary is the `Radio` protocol + `local-extensions/`, not this class. Low risk, not zero: **unknown** whether a private tier subclasses `RadioPoller`.
+- *Public API* — no.
+- *Tests-only* — **yes, this is the tests-only case.** `test_set_freq_updates_last_user_write_ts` asserts a field nothing reads; `test_poller_poll_priority.py` pins that a no-op is a no-op. Deleting the code deletes those tests. Human decision.
+
+**Collateral — stale prose that must go with it (observation):** the comment at `radio_poller.py:706-709` states the fields exist "so the unselected-slot poll subroutine can debounce around them … refreshed no more than once per `_UNSELECTED_SLOT_INTERVAL`", and the comment at `radio_poller.py:1985-1988` states the loop is "Fully gated (PTT, queue pressure, debounce, per-rx interval)". Neither is true of the code at this revision — both describe behaviour that the constant-`False` gate removed. This is the CLAUDE.md "prose is a claim" defect in its exact stated form.
+
+**Depends on:** none.
+**Confidence:** high.
+**Falsifier:** a production read of `_last_user_write_ts` or `_last_unselected_poll` reached through dynamic attribute access, or a subclass in a sibling/private repo overriding `_unselected_slot_gate` to return `True`.
+**Fix class:** delete.
+
+---
+
+### D2 — `commands/vfo.py: get_main_sub_band`: builder with no caller
+```
+Verdict:          dead (deletion blocked by a public-API guard → see below)
+```
+**Element:** `/Users/moroz/Projects/rigplane-core/src/rigplane/commands/vfo.py: get_main_sub_band` — builds CI-V `0x07 0xD2`.
+
+**Consumers:** zero in `src/` outside `commands/`. Zero direct test calls.
+
+**Written / read (observation):** I enumerated all 333 top-level `def`/`class` definitions across `src/rigplane/commands/*.py` (excluding `__init__.py`) with a Python AST sweep, then for each public name ran `grep -rl --include=*.py '\b<name>\b' src/ tests/` and discarded hits inside `src/rigplane/commands/`. **Exactly 1 of 333** came back with zero references outside its own layer: `get_main_sub_band`. That is the sweep result, not an impression — the other 332 all have consumers.
+
+**Guards checked:**
+- *Dynamic access* — searched literally, then found one **dynamic consumer**: `tests/test_command_map_parity.py: _graph` parses `commands/*.py` with `ast` and enumerates every `FunctionDef`, so the symbol is reached by source-parsing, not by import. It also appears as inert text in `tests/command_map_parity_divergences.txt` and `tests/command_map_parity_uncovered.txt`.
+- *Out-of-repo* — plausible. `rigs/ic7610.toml` and `rigs/ic9700.toml` both declare `get_main_sub_band = [0x07, 0xD2]`, so the wire fact is data-side and would survive.
+- *Public API* — **fails.** Re-exported by `commands/__init__.py` (import at `:179`, `__all__` entry at `:660`), and `commands/LAYER.md` states "Other layers import through this front door". A downstream user can `from rigplane.commands import get_main_sub_band`. Not in the top-level `rigplane/__init__.py` lazy map.
+- *Tests-only* — the AST parity sweep, above.
+
+Per the method, a candidate failing a guard becomes **undetermined**, not "delete anyway". Actionable form: remove it from `__all__` in one change, delete in a later one — or keep it and give it the runtime method `commands/LAYER.md` says every builder needs.
+
+**Depends on:** MOR-2000 (which deletes this function's `cmd_map` branch) should land first, so the deletion is against the final shape.
+**Confidence:** high on "no caller"; medium on "safe to delete" (public export).
+**Falsifier:** a caller in `local-extensions/`, rigplane-pro, or any downstream import.
+**Fix class:** delete (after the `__all__` decision).
+
+---
+
+### D3 — `RadioPoller._send_cmd` / `_load_command_map` / `_cmd_map`: unreachable for every shipped profile
+```
+Verdict:          undetermined (dead for all 8 shipped profiles; one non-shipped reachability path survives)
+```
+**Elements** (`src/rigplane/web/radio_poller.py`): `RadioPoller._load_command_map`, `RadioPoller._send_cmd`, and the `self._cmd_map` field set in `RadioPoller.__init__` (`radio_poller.py:664`).
+
+**Consumers:** exactly **one** production call site — the `else` arm of `case SetAgc(...)` inside `RadioPoller._execute` (`radio_poller.py:2811-2813`), taken only when `CAP_AGC not in self._caps`. Plus `tests/test_mor1537_cmd29_gating.py` (6 direct calls) and `tests/test_radio_poller_coverage.py`.
+
+**Reachability analysis (observation + one inference, labelled):**
+- *Observation:* `IcomRadio.capabilities` (`runtime/radio.py`) returns `set(self._profile.capabilities)` — capability tags come straight from the rig TOML.
+- *Observation:* `grep -n '"agc"' rigs/*.toml` → declared by `ic705`, `ftx1`, `ic7300`, `ic7610`, `x6200`, `ic9700`. Not declared by `x6100`, `tx500`.
+- *Observation:* `grep -n "set_agc" rigs/*.toml` → a CI-V `set_agc = [0x16, 0x12]` entry exists only in `ic705`, `ic7300`, `ic7610`, `ic9700`; `ftx1` has a CAT form (dropped by `to_command_map`, which keeps CI-V only); `x6100` and `tx500` have **no** `set_agc` entry at all.
+- *Inference:* therefore, on every shipped profile the `else` arm is either not taken (6 profiles have `agc`) or taken and finds an empty map (x6100, tx500 → `_send_cmd` returns `False` after a `logger.debug`). The cmd29-wrapping code inside `_send_cmd` executes for no shipped radio.
+- *Divergence worth noting separately:* on x6100/tx500 a UI `set_agc` is silently discarded at debug level while the WebSocket ack already reported success. That is an honesty defect in the ack, not a mechanism duplicate.
+
+**Guards checked:**
+- *Dynamic access* — searched literally; no dynamic dispatch on these names.
+- *Out-of-repo* — **fails.** `RadioPoller._runtime_profile` falls back to `IC-7610`/`IC-7300` for a radio with no `profile`, and `_radio_capabilities` returns an empty set when the backend exposes no `capabilities` set. A third-party `Radio` implementation with neither would take the `else` arm and send IC-7300 wire bytes. Not reachable via any in-tree backend.
+- *Public API* — no.
+- *Tests-only* — `tests/test_mor1537_cmd29_gating.py::TestSendCmdCmd29Unification` builds `RadioPoller` on `MagicMock` radios specifically to exercise this arm.
+
+**Relation to the ticketed set — MOR-2000 is materially bigger than "232 builders":** `grep -rn "to_command_map" src/ tests/` returns **exactly one production call site in the whole tree**: `RadioPoller._load_command_map` (`radio_poller.py:1251`). Everything else is tests. So `commands/command_map.py: CommandMap`, `profiles/rig_loader.py: RigConfig.to_command_map`, and the `[commands]` wire-byte tables' *runtime* role all hang off this one branch. Deleting the builders' `cmd_map` parameter does not finish the job — it leaves `CommandMap` alive solely to serve a web-layer branch that no shipped profile reaches. Whoever executes MOR-2000 should be told this, or the "dead" verdict will be re-derived from scratch in six months.
+
+**Depends on:** MOR-2000.
+**Confidence:** high that it is unreachable for shipped profiles; medium that it is deletable (third-party-backend guard).
+**Falsifier:** a shipped or supported profile that declares `set_agc` wire bytes without the `agc` capability, or a supported backend exposing no `capabilities` attribute.
+**Fix class:** delete — but see F7, which is the same code viewed as a duplicate.
+
+*(Out of scope, noted once and not pursued: the same attribute sweep flagged `WebServer._audio_analyzer_tap` in `web/server.py` as write-only — 1 write at `server.py:848`, 0 reads anywhere. Audio path, not command path.)*
+
+---
+
+## CONSOLIDATIONS (ranked by debugging cost)
+
+### F1 — hamlib capability advertisement and control domains: rigctld hardcodes IC-7610 facts that live in profile data
+```
+Verdict:          A — displaced
+Rank:             diverged
+```
+**The mechanism, one sentence:** deciding what a radio's attenuator/preamp/filter/frequency domains *are* and reporting them to a hamlib client.
+
+**Elements:**
+- `src/rigplane/rigctld/handler.py: _IC7610_DUMP_STATE` (`handler.py:119-145`, a module-level list) — returned verbatim by `RigctldHandler._cmd_dump_state` for **every** Icom radio. Hardcodes rig model `3078`, RX `100000–60000000`, TX `1800000–60000000`, filters `3000/2400/1800`, preamp `"12 20 0"`, attenuator `"6 12 18 0"`.
+- `src/rigplane/rigctld/handler.py: _PREAMP_IDX_TO_DB` (`handler.py:189`, `[0, 12, 20]`), read by `RigctldHandler._cmd_get_level` and `RigctldHandler._execute_set_level`.
+- `src/rigplane/rigctld/handler.py: RigctldHandler._execute_set_level` — the `ATT` branch contains a function-local `_att_steps = [0, 6, 12, 18]` and snaps the requested dB to the nearest member.
+- Canonical location (already exists): `profiles/__init__.py: RadioProfile.att_values`, `RadioProfile.pre_values`, `RadioProfile.agc_modes`, `RadioProfile.hamlib_model_id`.
+
+**Evidence that they do the same job (observation):**
+- `rigs/ic7300.toml` `[attenuator] values = [0, 20]`; `rigs/ic7610.toml` `[attenuator] values = [0, 3, 6, …, 45]`; `rigs/ftx1.toml` `[attenuator] values = [0, 1]`. None of these is `[0, 6, 12, 18]`.
+- `runtime/radio.py: IcomRadio.set_attenuator_level` reads `self._profile.att_values` and **raises** on a value outside it: `f"Attenuator level must be one of {sorted(att_values)} dB for {self._profile.model}, got {db}"`. Its docstring even names the divergence: *"IC-7300 has a single 20 dB step; IC-7610 has 0..45 in 3 dB steps"*.
+- `grep -rn "att_values\|pre_values" src/` → consumed by `runtime/radio.py`, `backends/yaesu_cat/radio.py`, `web/server.py` (capability publishing). **`rigctld/` consumes neither.**
+
+**Observable divergence, live-reachable on the bench IC-7300:** a hamlib client issues `L ATT 20` (a legal IC-7300 value, and the only nonzero one). rigctld snaps it to `18`, calls `IcomRadio.set_attenuator_level(18)`, which raises because `18 ∉ [0, 20]` → the client gets an error for a valid request. The same request over the web control socket passes `db` straight through (`web/handlers/control.py`, `case "set_att" | "set_attenuator"` → `q.put(SetAttenuator(db, receiver=rx))`; `RadioPoller._execute`, `case SetAttenuator` → `radio.set_attenuator_level(db, receiver=rx)`) and succeeds. Two ingresses, one radio, opposite answers.
+
+Separately, every non-IC-7610 Icom is advertised to WSJT-X et al. as an IC-7610: wrong `rig_model`, wrong TX range, wrong attenuator/preamp step lists.
+
+**Prior ruling:** none found justifying the divergence. `docs/api/rigctld.md:274` merely *describes* it (`\dump_state` → "IC-7610 capability block"), and `docs/api/rigctld.md:299-300` restates the invented `0/12/20` and `0/6/12/18` tables as though universal — documentation repeating the defect, not sanctioning it. CHANGELOG `#441` records the *Yaesu* half being fixed.
+
+**In-flight:** partially landed. `rigctld/routing.py: YaesuRouting.dump_state` already does the profile substitution — `state[1] = str(int(getattr(self._radio, "hamlib_model_id", 2028)))` with the comment "Substitute the rig model from the radio's TOML config (closes #441)". Report as **migration incomplete: the profile-driven `dump_state` exists at `rigctld/routing.py: YaesuRouting.dump_state`, consumed by the Yaesu CAT path, not yet by the Icom default path in `RigctldHandler._cmd_dump_state`.**
+
+**Adjudication — competing explanation rejected:** "hamlib's protocol requires a static capability block, so hardcoding is the only option." Rejected on the evidence: `YaesuRouting.dump_state` builds the same block dynamically from the profile in the same module, and `RadioProfile` already carries every field the block needs. The block is static because nobody generalised it, not because the protocol forbids it. A second explanation — "IC-7610 was the reference rig, so its numbers are the sane default" — is rejected because the reference rig was retired 2026-08-04 (CLAUDE.md) and the numbers are wrong for both surviving bench radios.
+
+**Blast radius:** 1 file, 3 elements (`_IC7610_DUMP_STATE`, `_PREAMP_IDX_TO_DB`, the `_att_steps` local), plus `docs/api/rigctld.md` §"Levels" and any test pinning the static block.
+**Required surface:** exists (`RadioProfile.att_values` / `.pre_values` / `.agc_modes` / `.hamlib_model_id`). A nearest-legal-value snap helper is the only new code, and it belongs beside the domain, not in `rigctld/`.
+**Expensive contract: YES.** This is wire/protocol behaviour on a public interface — `dump_state` is what every hamlib client reads to decide what it may ask for. Changing it changes what WSJT-X and friends will attempt.
+**Depends on:** none.
+**Confidence:** high.
+**Falsifier:** a rigctld test or an owner ruling requiring a fixed IC-7610 block for client-compatibility reasons; or evidence that `L ATT` is unreachable because `has_set_level` = `0x0001791B` masks the ATT bit (I did not decode the bitmask — **unknown**).
+
+---
+
+### F2 — hamlib level name → radio call: two dispatchers, one calling a non-canonical method with different semantics
+```
+Verdict:          C for existing twice (sanctioned vendor seam) / A for the domain handling inside them
+Rank:             diverged
+```
+**The mechanism:** translating a hamlib `L <NAME> <value>` into a `Radio` method plus a domain conversion.
+
+**Elements:**
+- `src/rigplane/rigctld/handler.py: RigctldHandler._execute_set_level` (+ its table `_SET_LEVEL_FLOAT`) — the Icom default path.
+- `src/rigplane/rigctld/routing.py: YaesuRouting.set_level` — the Yaesu CAT path.
+
+**Consumers:** `_execute_set_level` is reached whenever `RigctldHandler._routing is None`; `rigctld/routing.py: create_routing` returns `None` for anything that is not `RigctldRoutable` — i.e. every Icom. `YaesuRouting.set_level` is reached for Yaesu CAT. Both are entered from the same `RigctldHandler._cmd_set_level`.
+
+**That two exist is a recorded decision — quoted:** `create_routing`'s docstring — *"Dispatches via the public `RigctldRoutable` Protocol: radios that implement `rigctld_routing(cache, max_power_w)` get their custom strategy (Yaesu CAT today; Kenwood TS-590 or others in the future). Radios that do not — Icom CI-V — return `None` and the handler's built-in Icom routing is used as the default path."* `.importlinter` carries a named exception for it (`rigplane.backends.yaesu_cat.radio -> rigplane.rigctld.routing`), and `backends/LAYER.md` records it as "epic #1322's RigctldRoutable work". **This is a legitimate per-protocol fork; I am not proposing to merge the two dispatchers.**
+
+**What is not sanctioned — the divergence inside them (observation):**
+
+| level | Icom branch | Yaesu branch |
+|---|---|---|
+| `ATT` | snap to `_att_steps` → `radio.set_attenuator_level(dB)` | `radio.set_attenuator(round(value))` |
+| `PREAMP` | dB → index via `_PREAMP_IDX_TO_DB` → `set_preamp(idx)` | `radio.set_preamp(round(value))` |
+| `RFPOWER` | `round(value * 255)`, unclamped | `round(value * self._max_power_w)` |
+| `MICGAIN` | `×255` | `×100` |
+| `NB` / `NR` | `×255` | `×10` / `×15` |
+
+The `ATT` row is a concrete bug on a **live bench radio**. `YaesuRouting.set_level` calls `set_attenuator`, not `set_attenuator_level`. Their contracts differ: `backends/yaesu_cat/radio.py: YaesuCatRadio.set_attenuator` is documented *"Set attenuator state (0 = OFF, 1 = ON)"* and emits `await self._write("set_attenuator", state=str(int(state)))`; `rigs/ftx1.toml:834` defines that write as `set_attenuator = { cat = { write = "RA0{state};" } }`. The sibling `set_attenuator_level` exists two lines below and does the right thing (`await self.set_attenuator(1 if db > 0 else 0, ...)`). So `L ATT 12` on the FTX-1 emits **`RA012;`** — a three-digit parameter where the CAT command takes one — instead of `RA01;`. `L ATT 0` happens to work.
+
+The `PREAMP` row diverges the other way: `L PREAMP 12` succeeds on Icom (index 1) and **raises** on FTX-1, because `YaesuCatRadio.set_preamp` validates `level not in self._config.pre_values` and `rigs/ftx1.toml` declares `[preamp] values = [0, 1, 2]`.
+
+**Adjudication — competing explanation rejected:** "the scale constants differ because the radios' native ranges differ, which is correct." Accepted for the scale columns (`×255` vs `×100` is a real hardware difference) — but rejected as an explanation for `ATT`/`PREAMP`, because there the two branches are not scaling differently, they are calling *different methods with different units* while receiving the identical hamlib argument. And the scale constants themselves are the doctrine violation: `100`, `10`, `15`, `255`, `_max_power_w` are radio facts written in `rigctld/`, while `RadioProfile` already carries the domains.
+
+**Blast radius:** 2 files, ~5 level branches.
+**Required surface:** exists for `att_values`/`pre_values`; **missing** for the per-level raw ranges (`NB` 0-10, `NR` 0-15, `MICGAIN` 0-100). Naming it concretely: a profile-declared control domain per level name, of the shape `RadioProfile.controls` already uses (`profiles/__init__.py: RadioProfile.controls: dict[str, ControlSpec | ControlDomainSpec]`), consulted by both branches.
+**Expensive contract: YES.** Wire/protocol behaviour toward hamlib clients, and the CAT frame itself is being malformed.
+**Depends on:** F1 (same tables).
+**Confidence:** high for the `ATT`/`PREAMP` divergence; medium for whether a real client sends `L ATT` given `_YAESU_DUMP_STATE` advertises `"0"` for attenuator — a well-behaved client would not, an operator using `rigctl` directly would.
+**Falsifier:** a bench capture showing the FTX-1 accepts `RA012;`; or `has_set_level` masking ATT off for both paths.
+**Fix class:** consolidate (the domain source), not the dispatchers.
+**Actionable:** yes.
+
+---
+
+### F3 — per-receiver write routing (cmd29 vs temporary VFO switch): implemented twice, and the two disagree on `receiver=0`
+```
+Verdict:          A — displaced
+Rank:             diverged
+```
+**The mechanism:** getting a write onto MAIN or SUB on a dual-receiver Icom that has no cmd29 route for that command — by temporarily selecting the other receiver, writing, and restoring.
+
+**Elements:**
+- `src/rigplane/runtime/_dual_rx_runtime.py: DualRxRuntimeMixin._run_with_receiver_vfo_fallback` — the canonical implementation. **14 call sites** inside `runtime/` (`grep -rn "_run_with_receiver_vfo_fallback" src/`), reached by `IcomRadio.set_freq`, `set_mode`, `set_filter_width`, the tone family, the repeater family, and others.
+- `src/rigplane/web/radio_poller.py: RadioPoller._execute`, the `case SetFreq(...)` and `case SetMode(...)` arms — a second, inline implementation using `await self._civ(0x07, data=bytes([self._profile.vfo_sub_code]))` / `vfo_main_code` around the write.
+
+**Consumers:** the runtime helper serves rigctld and every direct `Radio` consumer (rigctld's `_RigctldCommandExecutor.execute` calls `self.handler._radio.set_freq(int(params["freq_hz"]), receiver=...)`). The inline copy serves only the web control socket and the HTTP command API.
+
+**Divergence — three observable differences:**
+
+1. **Restore is not exception-safe on the web copy.** `_run_with_receiver_vfo_fallback` restores inside `try/finally`, and on `TimeoutError` during restore logs *"timeout restoring VFO receiver to %s, retrying once"* and retries before propagating. `RadioPoller._execute`'s inline sequence has no `try`: if `await radio.set_freq(freq)` raises between the two `_civ(0x07, …)` calls, the radio is left parked on the temporarily-selected receiver, and the poller's own `_current_active()` (which reads `radio._radio_state.active`) still believes otherwise.
+2. **`receiver=0` means different things.** `RadioPoller._execute`'s `SetFreq` arm, `else` branch: `if current != "MAIN" and self._profile.vfo_main_code is not None:` → it switches to MAIN first. `IcomRadio.set_freq` does `if receiver == RECEIVER_MAIN: await self._set_frequency_main(freq_hz); return` — no check of which receiver is selected; `_set_frequency_main` emits a plain `0x05` frame to whatever the radio currently has selected. On IC-7610 (`[cmd29] routes` contains no `[0x05]`) and IC-9700 (`routes = []`, with the TOML comment *"Keep this list empty so `supports_cmd29()` returns False"*), with SUB selected, `F VFOA <hz>` over rigctld writes **SUB's** frequency. The same request over the web writes MAIN's. *Mitigating (observation):* rigctld's `_resolve_target_vfo(None)` returns `self._active_vfo_name()`, so the common `currVFO` case tracks reality; the mismatch needs an explicit `VFOA` token under `chk_vfo=1`.
+3. **Pacing and error text differ.** The web copy inserts `await asyncio.sleep(self._gap)` between switch and write; the runtime copy does not. The web copy raises `"…is unsupported by profile {model}: no cmd29 route and no VFO switch codes"`; the runtime copy raises `"…is unsupported for profile {model}: no SUB VFO select code"`.
+
+**Prior ruling:** none found. `docs/internals/architecture.md` §`web/` states the opposite of what the code does — *"`src/rigplane/web/` must depend on `radio_protocol` protocols (`Radio` + capability protocols), not on concrete `IcomRadio`"* — and `RadioPoller._civ` does route through the `CivCommandCapable` protocol, so the letter of the rule holds while raw CI-V opcode `0x07` and profile VFO codes are being assembled in `web/`. `commands/LAYER.md` is the rule this actually breaks: *"`commands/_frame.py` — the CI-V kernel; do not duplicate framing."*
+
+**Adjudication — competing explanation rejected:** "the poller must do it inline because it owns the serialisation lane, and calling `radio.set_freq(receiver=1)` would let the runtime issue VFO switches the poller cannot pace." Genuinely the strongest case, and it explains the extra `sleep(self._gap)`. Rejected as the whole story for two reasons: (a) the *same arm* already calls `radio.set_freq(freq, receiver=rx)` unchanged whenever `supports_cmd29(0x05)` is true, so the poller demonstrably tolerates the runtime doing its own routing on the cmd29 branch; (b) pacing is a parameter, not a reason to fork — it can be passed into the runtime helper. Divergence #1 (no `finally`) is not explicable as deliberate under any reading.
+
+**Blast radius:** 2 files; 2 arms in `RadioPoller._execute` (`SetFreq`, `SetMode`) plus the third `vfo_sub_code`/`vfo_main_code` site in the `SelectVfo` arm; 8 `_civ(0x07, …)` calls total in the poller (`grep -c "_civ(0x07"` → 8).
+**Required surface:** exists — `_run_with_receiver_vfo_fallback` is already the mechanism; it needs a pacing parameter and a public-ish entry point the `web` layer may legally reach (today it is a private mixin method on `IcomRadio`, and `web/` may not import `runtime` internals).
+**Expensive contract: YES (partly).** `set_freq(receiver=0)` semantics — "write MAIN" vs "write whatever is selected" — is a `core/radio_protocol.py` contract question that both surfaces answer differently. Settle the contract before moving code. *(Ruled 2026-08-30: literal MAIN, always — see header note.)*
+**Depends on:** none, but F3's contract question must be answered before F5.
+**Confidence:** high on the code differences; medium on the operational impact of #2 (needs an explicit `VFOA` token, and neither dual-RX Icom is on the live bench — IC-7610 retired, IC-9700 not listed as bench hardware).
+**Falsifier:** a `core/radio_protocol.py` docstring or test asserting that `set_freq(receiver=0)` means "the selected receiver", which would make the web copy the deviant one rather than rigctld. *(Post-audit verification 2026-08-30: the protocol docstring says "receiver: 0 = main (default), 1 = sub" — unconditional; a test pins the bare-frame behaviour for `receiver=0` but as a no-select-prefix pin, not a semantics claim. The runtime layer is the deviant side.)*
+**Fix class:** design (settle the contract) → consolidate.
+**Actionable:** yes.
+
+---
+
+### F4 — queue drain, deferred-TX lane and command-lifecycle failure reporting: written twice, diverging on three behaviours
+```
+Verdict:          A — displaced
+Rank:             diverged
+```
+**The mechanism:** drain `CommandQueue`, apply the TX interlock, park a DEFER'd command in a single-slot lane until TX ends, then release/supersede/expire it, and report the outcome to `CommandService` as lifecycle events.
+
+**Elements:**
+- `src/rigplane/web/radio_poller.py`: `RadioPoller._stage_tx_interlocked_entries`, `RadioPoller._deferred_intent`, `RadioPoller._terminate_deferred_entry`, `RadioPoller._emit_deferred_entry_held`, `RadioPoller._mark_queued_command_failed`, `RadioPoller._execute_queued_entry`.
+- `src/rigplane/backends/yaesu_cat/poller.py`: `YaesuCatPoller._drain_commands`, `YaesuCatPoller._emit_deferred_entry_held`, `YaesuCatPoller._mark_queued_command_failed`, `YaesuCatPoller._finish_deferred_entry`, `YaesuCatPoller._cancel_deferred_entry`, `YaesuCatPoller._deferred_release_is_live`.
+- Shared primitive both use: `src/rigplane/runtime/tx_interlock.py: DeferredTxCommandLane`.
+
+**Consumers:** the *same* queue instance feeds both. `web/web_startup.py` picks by capability: `isinstance(server._radio, StatePollable)` → `server._radio.create_state_poller(callback=…, command_queue=server._command_queue)` (Yaesu); `else` → `RadioPoller(server._radio, server._command_queue, …)` (Icom). One queue, two drains.
+
+**Evidence they do the same job (observation):** `_emit_deferred_entry_held` exists in both with the same signature `(entry, *, expires_at)` and emits the identical payload — a `CommandIntent(name="queued_completion", …)` with `details={"heldBy": "tx_interlock", "reason": "tx_active", "expiresAt": expires_at}` — after the same "walk `command_service.lifecycle_events()` in reverse, match `command_id` + `source` + `details["session_id"]`, take `event.target`" lookup. The web version factors that lookup into `_deferred_intent`; the Yaesu version inlines it.
+
+**Divergence (three, all observable):**
+1. **`timed_out` is computed from different inputs.** Web: `_mark_queued_command_failed(self, entry, exc, *, timed_out: bool = False)` — an explicit keyword, set `True` only by `_terminate_deferred_entry` on `EXPIRED`. A wire timeout during execution therefore reports `timed_out=False` on Icom. Yaesu: `timed_out = isinstance(exc, (TimeoutError, RigplaneTimeoutError, CatTimeoutError))` — the same wire timeout reports `True`. Same field, same client, opposite value depending on the backend.
+2. **The typed refusal envelope exists on one side only.** Web adds `params["details"] = {"blockedBy": "tx_interlock", "reason": exc.reason_code}` when the exception is a `TxInterlockRefusal`. The Yaesu version has no such branch, so a TX refusal on the FTX-1 — a live bench radio — reaches the client as a bare failure with no `blockedBy`/`reason`, which is exactly the envelope `docs/plans/2026-08-20-transmit-authority.md` records as shipped at `web/server.py:2161-2187`.
+3. **Session liveness is checked on release by one side only.** `YaesuCatPoller._deferred_release_is_live` refuses to release a deferred entry whose control session is gone (`self._command_queue.session_is_live(entry.session_id)`) or whose readback expectations were dropped. `grep -n "session_is_live" src/rigplane/web/radio_poller.py` → **one hit**, inside `_refuse_key_from_gone_session` (PTT-specific). `RadioPoller._stage_tx_interlocked_entries` appends the held entry on `RELEASED` unconditionally. So a command deferred during TX, whose operator then disconnects, executes anyway on Icom and is dropped on Yaesu.
+
+**Prior ruling:** none found that sanctions two drains. `docs/plans/2026-08-20-transmit-authority.md` (dated 2026-08-20) treats the web lane as a deletion target — its §9 row 9 lists *"Web seat deletion: `_enforce_tx_interlock`, `_WEB_IMMEDIATE_BLOCK_FAMILIES`, `_current_rf_state`, the staging lane + instance (taking the `heldBy:"tx_interlock"` emitter at `radio_poller.py:818` with it)"* — which names this exact emitter. That plan is **in flight and gated on owner questions Q1–Q11 + bench B1–B8**, i.e. not a settled ruling.
+
+**In-flight:** `docs/plans/2026-08-20-transmit-authority.md` proposes a single `TransmitAuthority.admit` seat. It is unresolved (Q15 explicitly open as of 2026-08-21; ruled on MOR-1959 per the TX-truth audit). Report as: **a consolidation target is designed but not built; do not start a second one.**
+
+**Adjudication — competing explanation rejected:** "the two pollers must differ because CI-V is fire-and-forget and CAT is request/response." True of the *execution* half and irrelevant to this half: everything cited above operates on `CommandQueueEntry` and `CommandService`, neither of which knows a protocol. Divergences 1–3 are not protocol consequences; they are two people solving the same problem on different days.
+
+**Blast radius:** 2 files, ~6 symbols per side; the lifecycle payload is consumed by the frontend (`radio-intents.ts` wires `controlTransport.onCommandLifecycleDelivery` → `applyCommandLifecycleProjection`), so it is a client-visible surface.
+**Required surface:** a backend-neutral queue-drain/deferred-lane runner that both pollers call. `runtime/tx_interlock.py: DeferredTxCommandLane` is the shared *state machine*; what is missing is the shared *driver* around it (drain → evaluate → stage → release → emit → fail). It cannot live in `web/` (backends must not import `web/`); `runtime/` is the layer that owns it — `DeferredTxCommandLane` already lives there.
+**Expensive contract: YES.** `timed_out` and `details.blockedBy` are part of the command-lifecycle wire payload the frontend renders.
+**Depends on:** the transmit-authority ADR's open owner questions. Do not consolidate ahead of that decision; the two `_mark_queued_command_failed` divergences (1 and 2) can be reconciled independently and cheaply.
+**Confidence:** high.
+**Falsifier:** an owner ruling that the Yaesu poller is deliberately stricter about gone sessions, or that `timed_out` is a per-backend notion.
+**Fix class:** consolidate.
+**Actionable:** partly — divergences 1 and 2 now; divergence 3 and the driver after the ADR.
+
+---
+
+### F5 — `Command` dataclass → `Radio` method: two dispatch tables, 48 arms in common, and the smaller one bypasses the protocol names
+```
+Verdict:          A — displaced (ownership) / consolidation NOT warranted in this form
+Rank:             parallel
+```
+**The mechanism:** unpack a `Command` dataclass from `runtime/_poller_types.py` and call the corresponding method on the `Radio` protocol.
+
+**Elements:**
+- `src/rigplane/web/radio_poller.py: RadioPoller._execute` — **117 distinct `case` arms** (`awk 'NR>=2240 && NR<=3640' | grep -c "^            case "` → 121 case lines, 117 unique class names).
+- `src/rigplane/backends/yaesu_cat/poller.py: YaesuCatPoller._execute_command` — **49 case lines**.
+
+**Overlap (observation, computed by extracting the `case <ClassName>` tokens from both and running `comm`):** 48 names appear in both — `PttOn/PttOff`, `SelectVfo`, `SetFreq`, `SetMode`, `SetBand`, `SetAgc`, `SetAttenuator`, `SetPreamp`, `SetAfLevel`, `SetRfGain`, `SetSquelch`, `SetNB/SetNR/SetNBLevel/SetNRLevel`, `SetFilter*`, `SetRit*`, `SetSplit`, `SetTunerStatus`, `SetVox`, `VfoSwap`, `VfoEqualize`, … . **Zero** Yaesu-only arms. The Yaesu table is a strict subset by command name.
+
+**The steelman, and why it fails:** the strongest case is "the arms must differ because the wire protocols differ." I tested it by reading every Yaesu arm. The bodies are overwhelmingly `await radio.<method>(<unpacked fields>)` — the *same* `Radio`-protocol surface the web poller uses. Genuinely Yaesu-specific content is three items: `_CIV_TO_YAESU_BAND`, the `SelectVfo` → `set_vfo_select(code)` normalisation, and eight `raise NotImplementedError` arms. Everything else is a second copy of the same unpacking.
+
+Worse, the Yaesu table does not call the canonical names. It calls `radio.set_processor`, `set_processor_level`, `set_lock`, `set_tuner`, `set_keyer_speed`, `set_key_pitch`, `set_monitor_on`, `set_monitor_level`, `set_manual_notch_freq`. I checked whether those are the only names available: `for m in set_compressor set_compressor_level set_key_speed set_cw_pitch set_monitor set_monitor_gain set_dial_lock set_tuner_status set_notch_filter; do grep -c "def $m(" …; done` → **all nine exist on `core/radio_protocol.py`, on `backends/yaesu_cat/radio.py`, and on `runtime/radio.py`.** They are pure aliases on the Yaesu side — e.g. `YaesuCatRadio.set_compressor`: *"Alias for AdvancedControlCapable compatibility."* → `await self.set_processor(on)`; `set_tuner_status`: *"AdvancedControlCapable alias."* → `await self.set_tuner(value)`. So the protocol *is* honoured and the second table declines to use it, which is precisely the failure mode `backends/LAYER.md` promises against: *"conform to the relevant Capability Protocols … so the upper layers detect features via `isinstance` rather than backend-id branching … Zero changes required in `web/` / `rigctld/` / `cli/` if the Capability Protocols are honoured."*
+
+**One arm I checked for divergence and cleared:** `YaesuCatPoller._execute_command`'s `case SetMode(mode=mode, receiver=rx)` drops `filter_width`, while `RadioPoller._execute` passes it. `web/handlers/control.py`'s `case "set_mode"` constructs `SetMode(mode, filter_width=fil_num, receiver=rx)` and its ack even reports `result["filter"] = fil_num`. This *looks* like a dropped parameter — but `backends/yaesu_cat/radio.py: YaesuCatRadio.set_mode` documents `filter_width: Ignored (not supported by this backend)`. **No observable divergence; the steelman wins on this one.** The residual is a prose defect: the ack claims a filter was applied on a backend that cannot apply one. Reported, not escalated.
+
+**Adjudication:** displaced by ownership — this table is a property of the `Command` union, which lives in `runtime/_poller_types.py`, not of any one poller. But the method's own guidance applies verbatim: *"unifying a 112-command serialiser with a 10-verb one yields an abstraction with one real user."* A 117-arm and a 49-arm table merge into a 117-arm table with 68 `NotImplementedError`s. **Ownership: displaced. Actionability: no.** The cheap, correct move is smaller: make the Yaesu arms call the canonical protocol names, so a change to `set_compressor` cannot silently miss the Yaesu poller.
+
+**Blast radius:** 2 files; 9 alias call sites to redirect.
+**Required surface:** exists (the canonical `Radio` protocol names).
+**Expensive contract:** no — internal call names only; no wire behaviour changes.
+**Depends on:** F3 (settle `receiver=0` semantics first, or the merged table inherits the ambiguity).
+**Confidence:** high.
+**Falsifier:** a Yaesu alias whose canonical twin has different behaviour (I checked `set_compressor` and `set_tuner_status`; both are one-line pass-throughs — the other seven I did **not** open: **unknown**).
+**Fix class:** none for the merge; consolidate for the alias call sites.
+**Actionable:** yes, for the alias redirect only.
+
+---
+
+### F6 — SET-command coalescing: two collapse mechanisms on one path, and the second one is blind to the key the first one was fixed to include
+```
+Verdict:          A — displaced
+Rank:             diverged
+```
+**The mechanism:** collapsing redundant SET frames so a slider drag does not flood the radio, last value winning.
+
+**Elements:**
+- `src/rigplane/web/handlers/control.py`: `ControlHandler._coalesce_key`, `ControlHandler._coalesce_command`, `ControlHandler._flush_coalesced_command` — time-paced (`self._CMD_MIN_INTERVAL = 0.05`), keyed by `f"{name}:{receiver}"` and, for `_COALESCE_TARGET_PARAM` = `{set_filter, set_vfo, select_vfo, set_band}`, by `f"{name}:{receiver}:{target!r}"`.
+- `src/rigplane/runtime/_poller_types.py`: `CommandQueue.put` → `segment.dedup[type(cmd)] = entry`, with `_CommandQueueSegment.dedup: dict[type, CommandQueueEntry]`. Keyed on the **dataclass type alone** — receiver-blind, target-blind.
+
+**Consumers:** every SET on the web path passes through both, in that order. `grep -c "q.put(" src/rigplane/web/handlers/control.py` → 119 call sites; `q.put_ordered` → 0 from that file.
+
+**Divergence:** MOR-1499 fixed the first mechanism to include the receiver and the selector target, and `tests/test_mor1499_coalesce_keys.py` documents why — *"Cross-receiver: `set_nb` on MAIN followed by `set_nb` on SUB inside the pacing window superseded MAIN's frame with SUB's — MAIN's toggle never reached the radio"* and the filter-preset flow *"`set_filter(A)`, `set_filter_width(W)`, `set_filter(B)` in a single tick"*. The second mechanism still keys on type. Two same-type, different-receiver frames now correctly pass the first gate (different coalesce keys, both dispatched immediately) and then land in the same `_CommandQueueSegment.dedup` slot, where the later one overwrites the earlier — reinstating the exact bug, one layer down.
+
+**The test cannot see it (observation):** `test_set_nb_cross_receiver_both_reach_radio` asserts against `_QueueRecorder`, a local fake that appends every `put`. The real `CommandQueue` is never constructed in that file. So the pin is green whatever `CommandQueue.put` does. This is the "check that cannot go red" pattern, not a claim that the fix was wrong.
+
+**Adjudication — competing explanation rejected:** "type-keyed dedup is deliberate: it is the poller's own flood control, at a coarser grain than the ingress pacer." Partly true — the two do run at different grains (time-window vs drain-window), which is why I rank this *diverged duplicate* rather than *redundant copy*. Rejected as a full defence because the grains are orthogonal to the *key*: nothing about drain-window collapsing requires ignoring the receiver, and `CommandQueueEntry` carries everything needed to key on it. The narrower key silently undoes a fix made in the wider one, which is the definition of a diverged duplicate.
+
+**Reachability:** timing-dependent. `RadioPoller._run` drains once per loop iteration and sleeps `self._adaptive_gap()` between iterations, so a burst arriving inside one gap collapses; a burst straddling a drain does not. The frontend preset flow dispatches its three frames in a single JS tick, which is the worst case.
+
+**Blast radius:** 2 files, 1 line of key construction (`_poller_types.py:1067`, the `segment.dedup[type(cmd)] = entry` statement inside `CommandQueue.put`), plus whatever coalescing tests assume type-keying.
+**Required surface:** exists — the key `ControlHandler._coalesce_key` already computes could be attached to `CommandQueueEntry` and used as the dedup key, giving one key definition instead of two.
+**Expensive contract:** no.
+**Depends on:** none.
+**Confidence:** medium-high. High that the two keys differ and that the second is receiver-blind; medium on how often the drain window catches a same-type pair, which I did **not** measure.
+**Falsifier:** a timing measurement showing `RadioPoller._run` always drains between two WebSocket frames; or an existing test that constructs a real `CommandQueue`, puts two different-receiver commands of one type, and observes both survive.
+**Fix class:** consolidate.
+**Actionable:** yes.
+
+---
+
+### F7 — rig-TOML directory discovery: four implementations, four different search rules
+```
+Verdict:          A — displaced
+Rank:             parallel (one of the four is also a correctness risk)
+```
+**The mechanism:** finding the `rigs/` directory and loading the profiles in it.
+
+**Elements and their rules (all observation):**
+| # | Location | Rule |
+|---|---|---|
+| 1 | `profiles/__init__.py: _RIG_DIRS` + `_ensure_loaded` | `[repo_root/rigs, package/rigs]`, dev first; result **cached** in module globals |
+| 2 | `cli/__init__.py: _rigs_dir` | `package/rigs` if it exists, else `repo_root/rigs` — **reversed** order |
+| 3 | `backends/yaesu_cat/radio.py: _RIGS_DIR` (`radio.py:47`, a module constant `Path(__file__).parents[4] / "rigs"`) | a **single** path, no fallback |
+| 4 | `web/radio_poller.py: RadioPoller._load_command_map` | `[repo_root/rigs, package/rigs]`, hand-rolled inline, wrapped in a bare `except Exception` |
+
+**Consumers:** (1) is the canonical registry every `resolve_radio_profile` call goes through. (2) and (3) go through `profiles/rig_loader.py: discover_available_rigs`, which is the resource-aware entry point (it materialises non-filesystem resources into a temp dir for zip imports). (4) is the **only production caller of the raw `discover_rigs(directory)`** — `grep -rn "discover_rigs(" src/` returns exactly one `src/` hit outside `profiles/` itself.
+
+**Divergence:** (3) resolves to `<repo_root>/rigs` in a source checkout and to a nonexistent path under `site-packages`; it is saved by `discover_available_rigs` trying package resources first, but the `load_rig(_RIGS_DIR / f"{profile}.toml")` fallback two lines down (`radio.py:140`) has no such cover. (4) is not resource-aware at all, so it would silently find nothing under a zip import, and its `except Exception: … return {}` converts any failure into an empty command map — which then makes `_send_cmd` return `False` with a debug log. (4) also re-parses every rig TOML on **each `RadioPoller` construction** (`RadioPoller.__init__`, `radio_poller.py:664`), bypassing the cache in (1); `discover_rigs` has no memoisation.
+
+**Adjudication — competing explanation rejected:** "each layer needs its own path because import-linter forbids `web/` importing `profiles/` internals." Checked against `.importlinter`: the layer order is `web > backends > runtime > profiles`, so `web/` may legally import `profiles/` — and it already does (`radio_poller.py` imports `resolve_radio_profile` and `RadioProfile`). The linter is not the reason; nobody looked for the existing helper. (This is the "search on behaviour, not on the name you would have chosen" case from the method's helper-level mode: the existing helper is called `discover_available_rigs`, not `find_rigs_dir`.)
+
+**Blast radius:** 4 files, 4 symbols.
+**Required surface:** exists — `profiles/rig_loader.py: discover_available_rigs` is the canonical resource-aware loader, and `profiles/__init__.py: _ensure_loaded` is the canonical cache. Both are importable from every layer that has a copy.
+**Expensive contract:** no — internal path resolution; the profile schema itself is untouched.
+**Depends on:** D3 (deleting `_load_command_map` removes copy #4 outright, which is why the deletion list comes first).
+**Confidence:** high.
+**Falsifier:** a packaging test proving `parents[4]` is correct under a wheel install, which would clear (3).
+**Fix class:** consolidate.
+**Actionable:** yes — and cheapest if D3 lands first.
+
+---
+
+## Weakest link
+
+**F6.** Its *structural* half is certain — `_CommandQueueSegment.dedup` is a `dict[type, …]` and `ControlHandler._coalesce_key` is not, and I read both. Its *impact* half rests on an inference I did not measure: that a same-type, different-receiver (or different-target) pair reliably lands inside one drain window of `RadioPoller._run`. I did not instrument the loop and I did not run anything. If the poller in practice drains between every pair of WebSocket frames, the second dedup never fires and F6 collapses from "diverged duplicate" to "latent redundancy" — still worth removing, no longer worth ranking above F7.
+
+**Check first:** construct a real `CommandQueue` (not `_QueueRecorder`), `put` `SetNB(on=True, receiver=0)` then `SetNB(on=True, receiver=1)` with no intervening `drain_entries()`, and count what `drain_entries()` returns. One entry confirms the collapse; two refutes the whole finding. Then measure `_adaptive_gap()` against the frontend's per-tick dispatch burst.
+
+Runner-up: **F3, divergence #2.** Whether `set_freq(receiver=0)` means "MAIN" or "the selected receiver" is a contract question I found no ruling on. I called the web copy correct because it matches the parameter's name; if the intended contract is the other one, the deviant surface is `web/`, not `rigctld/`, and the fix direction inverts. *(Ruled 2026-08-30: literal MAIN — the web copy's semantics are the contract; the runtime layer is to be fixed and the mechanism encapsulated there.)*
+
+---
+
+## Cleared — examined and healthy
+
+1. **`core/command_service.py: CommandService` as the shared command spine.** Both surfaces genuinely converge on it: `web/handlers/control.py: _ControlCommandExecutor` and `rigctld/handler.py: _RigctldCommandExecutor` both implement the one `CommandExecutor` protocol, and both ingresses build intents with `core.command_service.command_intent_from_request`. Pending overlays, readback expectations, lifecycle emission and level normalisation are defined once, in `core/`. This is the premise-was-wrong outcome the method predicts for step 0, and it is the healthiest thing on this path.
+2. **The two `CommandService` instances in `WebServer.__init__` are deliberate, not a duplicate.** `self.command_service` (executor `_SharedControlCommandExecutor`) and `self._http_command_service` (executor `_HttpCommandExecutor`) are separate on purpose, and the comment says why: *"Only `self.command_service` (the websocket-queued path) is subscribed — `self._http_command_service` below executes synchronously and its caller already sees the exception directly."* Verdict: legitimately local.
+3. **HTTP command ingress does not fork.** `POST /api/v1/commands` and `/commands/batch` (`web/server.py:4007-4024`) route into `ControlHandler._enqueue_command` (`server.py:4268`, `:4357`) rather than growing a second catalog. `web/server.py: _HttpCommandCollector` looked like a third queue wrapper and is not — it collects instead of enqueuing so HTTP can execute synchronously. Correctly located.
+4. **The `Command` union is fully wired at both ends.** I enumerated all **121** members of the `Command` union in `runtime/_poller_types.py` and cross-checked each against construction sites in `web/handlers/control.py` + `web/server.py` and against `case` arms in `RadioPoller._execute`. **Zero** members are never constructed; **zero** constructed members lack a web-poller arm. No orphan commands, no unreachable arms.
+5. **Frontend command dispatch has a single validated door.** `lib/runtime/commands/radio-intents.ts: dispatchRadioIntent` validates the envelope against a declarative spec table and is the only path to `sendCommand` for radio control — used 123 times from `panel-commands.ts`, plus `panel-adapters.ts` and `mod-input-auto.svelte.ts`. The two other `sendCommand` consumers are both principled: `lib/runtime/tx-controller/browser-dependencies.ts` (PTT, deliberately excluded — the guard reads *"Only a known non-PTT radio intent may be dispatched"*) and `lib/local-extensions/host-api.ts` (the sanctioned open-core boundary). `lib/transport/http-client.ts` is read-only (`fetchCapabilities`, `fetchInfo`). No shadow command path in the browser.
+6. **Frontend and backend command catalogs agree.** All **98** names in `radio-intents.ts`'s `intentSpecs` are members of `ControlHandler._COMMANDS` (153 names). No frontend intent can reach the server as `unknown_command`. Not a hand-maintained divergence.
+7. **Frontend `components-v2/wiring/` has no dead modules.** `double-click.ts`, `dual-receiver-strips.ts`, `mobile-ptt-surface.ts`, `tx-ptt-gesture.ts` all have production importers outside `__tests__` (`dual-receiver-strips` via `SemanticRadioSurfaces.svelte` and `presentation/layouts/`). Same for `lib/runtime/`'s `resource-demand`, `resource-host`, `system-controller`, `scope-controller`.
+8. **The CLI does not compute radio truth and is not the displacement site.** The dispatch flagged the CLI's age as a possible false-positive generator. Checked: `cli/__init__.py: _cmd_att` passes the operator's dB straight to `radio.set_attenuator_level(db)` and lets the profile validate; `_cmd_preamp` validates `0/1/2`, matching every shipped `[preamp] values`. No parallel dispatch table, no invented domain. The two blemishes are prose, not mechanism: the `print("Attenuator: ON (18 dB)")` literal and the error hint *"a dB value (e.g. 0, 6, 12, 18)"* both quote F1's invented table. The doctrine violation is in `rigctld/`, not here — the historical-shape caveat correctly cleared the CLI.
+9. **Instance-attribute and constant sweep, 9 command-path modules.** Enumerated every `self._x = …` (including annotated form) and every module-level `UPPER_CASE` constant across `web/radio_poller.py`, `web/handlers/control.py`, `web/server.py`, `backends/yaesu_cat/poller.py`, `rigctld/handler.py`, `rigctld/routing.py`, `core/command_service.py`, `runtime/_poller_types.py`, `commands/commander.py`, then counted reads separately across all of `src/`, `tests/`, and `frontend/src`. **189 instance attributes → 2 write-only** (`RadioPoller._last_unselected_poll`, D1; `WebServer._audio_analyzer_tap`, out of scope). **74 module-level constants → 0 unread.** The class-level `_UNSELECTED_SLOT_INTERVAL`/`_UNSELECTED_SLOT_DEBOUNCE` fell outside that regex and were caught separately — recorded so the next sweep knows the gap. All searches literal.
+10. **`commands/` builder layer is otherwise fully consumed.** 333 top-level definitions, 1 with no consumer outside the layer (D2). `commands/_frame.py: build_cmd29_frame` is called from `freq.py`, `mode.py`, `dsp.py`, `tone.py` — the framing kernel is not duplicated *inside* `commands/`. `commands/LAYER.md`'s "do not duplicate framing" rule holds within the layer; the one breach is upward, in `RadioPoller._send_cmd` (D3).
+11. **State-query construction is already shared.** `RadioPoller._build_state_queries` delegates to `runtime/_state_queries.py: build_state_queries`, and `web/radio_poller.py` and `rigctld/server.py` both feed `profile.supports_cmd29` into `core/acquisition_scheduler.py: civ_acquisition_executor_for_provider` rather than re-deriving cmd29 routing for reads. The read path did not grow the fork the write path did.
+12. **The ~90 `cmd29 = self._profile.supports_cmd29(…)` sites in `runtime/radio.py` are call sites, not implementations.** Each passes `command29=cmd29` to a distinct `commands/` builder for a distinct CI-V command. Repetitive, but one mechanism used ninety times is not ninety mechanisms. Not a finding.

--- a/.claude/audits/2026-08-30-mechanism-audit-state-feedback.md
+++ b/.claude/audits/2026-08-30-mechanism-audit-state-feedback.md
@@ -1,0 +1,422 @@
+> **Point-in-time audit snapshot (2026-08-30).** Produced by the `auditor`
+> subagent (Claude Opus) following `.claude/skills/mechanism-audit/SKILL.md`.
+> Tree audited: `8c8a70d4` (merged to main via #2801). Every citation in this
+> document — including the file:line forms used where no symbol encloses the
+> evidence — is frozen at that revision; resolve against `8c8a70d4`, not HEAD.
+> This file is an archived report, not maintained documentation. Owner rulings
+> recorded 2026-08-30 (see the Linear ticket package referencing this audit)
+> supersede any recommendation here where they differ — in particular: the
+> nested state-feedback descriptors are ruled deletable (Q3 verification,
+> 2026-08-30), and `delta_since` deletion is ruled pre-release (Q4).
+
+# Mechanism audit — state / control-feedback path
+
+**Method:** `.claude/skills/mechanism-audit/SKILL.md`, read from `/Users/moroz/Projects/rigplane-core/.claude/skills/mechanism-audit/SKILL.md` (tracked, present in the working tree). Followed as written, with the dispatch's citation override (file + symbol, not file:line).
+
+**Tree audited:** `8c8a70d4` (`8c8a70d435a2b94bef7bb8dce1c549dfe3798b05`), branch `codex/mechanism-audit-skill`, tracking `origin/codex/mechanism-audit-skill`. `git status --short --branch` reported a **clean** tree. No writes of any kind were made to it; scratch scripts live in the session scratchpad.
+
+**Hypothesis handling:** the dispatch supplied three audit *questions* and a known-ticketed exclusion list, not a conclusion. The one place it came close — "check panels/layouts for logic that belongs lower" — I treated as the thing under test; §F4 and the Cleared list record where the steelman won.
+
+**Search disclosure:** every count below comes from a **literal** `grep` over `src/`, `tests/`, `frontend/src/`, `docs/` (excluding `node_modules/` and the generated `site/`). Literal search misses `getattr`/string-built names; where a deletion is proposed I ran the specific dynamic-access check and say so.
+
+---
+
+## Deletions
+
+### D1 — `RadioPoller.state_is_fresh` / `mark_polled` / `_last_polled` / `_DEFAULT_POLL_FIELD_TTL`: dead
+
+**Verdict:** dead
+**Elements:** `/Users/moroz/Projects/rigplane-core/src/rigplane/web/radio_poller.py` — `RadioPoller.mark_polled`, `RadioPoller.state_is_fresh`, the `self._last_polled: dict[str, float]` slot, and the module constant `_DEFAULT_POLL_FIELD_TTL: float = 0.2` (a bare constant with no enclosing symbol; it is used only as `state_is_fresh`'s default argument).
+**Consumers:** none.
+**Written / read:** `mark_polled` — 4 call sites, all in `radio_poller.py` (inside `_execute`'s freq/mode paths and the BSR readback path); `state_is_fresh` — **0 call sites anywhere**; `_last_polled` — written by `mark_polled`, read only by `state_is_fresh`. Established with `grep -rn "state_is_fresh\|mark_polled" --include="*.py" src/ tests/`: 6 hits in `src/` (2 definitions + 4 writes), **0 in `tests/`**.
+**Guards checked:** dynamic access — searched literally, plus `grep` for `getattr(...poller`/`getattr(self, ` in `src/rigplane/web/`: the only `getattr` hits are `_uses_fallback_provider_generation`, `_zombie_reaper_task`, `_radio_model`, `_radio_poller`; none constructs `state_is_fresh`/`mark_polled` dynamically. Out-of-repo — `rigplane.web.radio_poller.RadioPoller` is not re-exported from `rigplane/__init__.py` and is absent from `docs/api/public-api-surface.md`; the RigPlane Pro seam per `CLAUDE.md` is the Radio protocol + `local-extensions/`, and there is no `local-extensions/` directory in this tree — **unknown** whether a private tier subclasses this poller. Public API — not exported. Tests-only — no, zero tests either.
+**Collateral:** none — no test asserts either symbol.
+**Depends on:** none.
+**Confidence:** high (observation).
+**Falsifier:** a Pro-tier or downstream subclass calling `state_is_fresh`; a reflective call built from a string.
+**Fix class:** delete.
+
+**Why this matters beyond tidiness (inference):** the *appearance* of a third backend freshness mechanism — poll-cadence TTL alongside `StateStore.FreshnessState` and `StateCache.is_fresh` — dissolves once this is read as write-only. `docs/internals/legacy-state-writer-inventory.md` sanctions it as `executor_cache_keep` with the constraint "Do not use poll cadence markers as delivery freshness for Web consumers". Nothing does, because nothing reads them at all. Deleting first is exactly the method's ordering point.
+
+---
+
+### D2 — `frontend/src/components-v2/layout/layout-utils.ts`: whole module dead
+
+**Verdict:** dead
+**Elements:** `layout-utils.ts` — `extractVfoState`, `extractMeterState`, `hasLiveAudioFromState` (all three exports).
+**Consumers:** tests only. `extractVfoState` + `extractMeterState` + `hasLiveAudioFromState` are imported by `frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts` and nothing else; one prose mention in `keyboard-map.ts` (a comment, not an import).
+**Written / read:** `grep -rn "extractMeterState" frontend/src/` → 1 definition + 9 test lines, 0 production imports. Same shape for the other two.
+**Guards checked:** dynamic access — searched literally; there is no dynamic component/helper registry in the frontend (`grep -rln "import(.*Panel\|components: {"` over `frontend/src/` excluding tests returned nothing). Out-of-repo — none, this is app-internal Svelte source. Public API — no. **Tests-only — yes, flag it**: deleting the module means deleting the three `describe` blocks in `RadioLayout.isolated.test.ts`.
+**Collateral:** those test blocks; also `frontend/src/components-v2/panels/MeterPanel.svelte` (see D3), which `extractMeterState`'s docstring names as its consumer.
+**Depends on:** none (independent of D3, but they are the same cluster).
+**Confidence:** high (observation).
+**Falsifier:** a production import I missed under a re-export alias — I searched the symbol names, not just the module path.
+**Fix class:** delete.
+
+**Note (observation, on-scope for "per-surface derivation"):** `extractMeterState` fabricates defaults — `radioState?.main?.sValue ?? radioState?.main?.sMeter ?? 0` — the exact pattern `frontend/src/lib/runtime/props/__tests__/panel-props.no-fabricated-defaults.test.ts` exists to forbid on the live path. It is dead, so it harms nothing today; it would be a trap for anyone who revived it.
+
+---
+
+### D3 — `frontend/src/components-v2/panels/MeterPanel.svelte`: dead component
+
+**Verdict:** dead
+**Elements:** `MeterPanel.svelte` (the whole component).
+**Consumers:** its own isolated test only (`components-v2/panels/__tests__/MeterPanel.isolated.test.ts` mounts it). One incidental mention in `components-v2/meters/__tests__/BarGauge.test.ts` calling it "BarGauge's sole non-compact consumer".
+**Written / read:** `grep -rn "MeterPanel"` over `frontend/src/`, excluding `MetersDockPanel`/`DockMeterPanel` and the file itself: no `<MeterPanel` element anywhere, no non-test import.
+**Guards checked:** dynamic access — searched literally; no dynamic Svelte component registry exists (same check as D2). Out-of-repo — none. Public API — no. **Tests-only — yes, flag it.**
+**Collateral:** `MeterPanel.isolated.test.ts`; and BarGauge's non-compact rendering path loses its only claimed consumer, which is a fact worth telling whoever owns `BarGauge`.
+**Depends on:** none. D2's `extractMeterState` was built for this component; taking both together is cleaner than either alone.
+**Confidence:** high (observation).
+**Falsifier:** a skin mounting it through a path my symbol search missed.
+**Fix class:** delete.
+
+---
+
+### D4 — `web/runtime_helpers.build_public_state_payload`: no production consumer
+
+**Verdict:** vestigial fork — the abandoned side of the two payload front-doors.
+**Elements:** `/Users/moroz/Projects/rigplane-core/src/rigplane/web/runtime_helpers.py` — `build_public_state_payload` (the `RadioState`-dataclass front door). Its live twin is `build_public_state_payload_from_snapshot`; both delegate to the shared `_build_public_state_payload_from_dict`, which stays.
+**Consumers:** tests only — `tests/test_web_runtime_helpers.py` (1 call site) and `tests/web/test_state_schema_conformance.py` (3 call sites). Production: **zero**. The live path is `web/server.py`'s `_build_public_state_payload_from_snapshot_impl` → `build_public_state_payload_from_snapshot`.
+**Written / read:** repo-wide literal `grep -rn "build_public_state_payload"` across `*.py|*.md|*.ts|*.svelte|*.toml|*.yml|*.sh` (minus `node_modules`, `site/`): the snapshot variant has 1 production call site plus `scripts/gen_field_status_fixture.py` and ~60 test lines; the dataclass variant has 0 production call sites.
+**Guards checked:** dynamic access — searched literally; `grep` for `getattr(...runtime_helpers` / `getattr(rh` returned nothing. Out-of-repo — the symbol is in `runtime_helpers.__all__`, so `from rigplane.web.runtime_helpers import build_public_state_payload` works for a downstream importer; it is **not** in `rigplane/__init__.py`'s `__all__` and **not** in `docs/api/public-api-surface.md`. Public API — weak: module-level `__all__` only. **Tests-only — yes, flag it.**
+**Collateral:** the 4 test call sites; `docs/internals/legacy-state-writer-inventory.md`'s Web-runtime row for `web/handlers/control.py`, which claims "Fallback `build_public_state_payload(... revision=0)` remains compatibility-only for handler tests without a server" — that fallback no longer exists in `web/handlers/control.py`, whose only envelope call is `self._server.build_state_update_envelope(force_full=True)`. **Stale doc claim** (observation).
+**Depends on:** none. Related to F3 — see there for why leaving it is not merely untidy.
+**Confidence:** high for "no production consumer" (observation); medium for "safe to delete" (the `__all__` export is a real, if thin, public surface).
+**Falsifier:** a downstream/Pro import of `rigplane.web.runtime_helpers.build_public_state_payload`.
+**Fix class:** delete (or, if the export must stay, correct the inventory row).
+
+---
+
+### D5 — `web/_delta_encoder.apply_delta`: test-only mirror of a TypeScript rule
+
+**Verdict:** dead
+**Elements:** `src/rigplane/web/_delta_encoder.py` — `apply_delta`, and the `_Missing` class / `_MISSING` sentinel it is the only user of.
+**Consumers:** tests only — 29 matching lines under `tests/`. Production: zero. `web/server.py` constructs `DeltaEncoder` (alive); the *client* half of the wire contract is implemented in TypeScript by `frontend/src/lib/transport/ws-client.ts: applyDeltaEnvelope`.
+**Written / read:** `grep -rn "DeltaEncoder"` over `src/` → 2 production lines (import + construction in `web/server.py`); `grep -rn "apply_delta"` over `src/` → only its own definition and `__all__`.
+**Guards checked:** dynamic access — searched literally; no `getattr` on `apply_delta`. Out-of-repo — `_delta_encoder` is a private module (leading underscore) and the `web/server.py` import carries `# noqa: TID251`, i.e. it is already flagged as an internal reach; not a plausible downstream surface. Public API — no. **Tests-only — yes, flag it.**
+**Collateral:** the 29 test lines. `_Missing`/`_MISSING` fall out with it — grep shows zero other references (observation).
+**Depends on:** none.
+**Confidence:** high (observation).
+**Falsifier:** a Python client in a sibling repo consuming deltas.
+
+**Adjudication note (inference):** this is *not* a live diverged duplicate of `applyDeltaEnvelope` — they no longer do the same job. The TS side gates on provider generation, `stateContractVersion`, revision monotonicity and capability topology; `apply_delta` is a shallow `dict.update` plus key removal. A Python test that "proves a delta round-trips" through `apply_delta` therefore proves something materially weaker than the real client's acceptance rules. That is the cost of keeping it, and the reason to say so rather than let a fixer merge it into anything.
+**Fix class:** delete.
+
+---
+
+### D6 — `StateCache` level updaters with no writer
+
+**Verdict:** dead — but fails a deletion guard, so: **undetermined**
+**Elements:** `src/rigplane/core/_state_cache.py` — `StateCache.update_af_level`, `.update_alc`, `.update_attenuator`, `.update_preamp`, `.update_rf_gain`, `.invalidate_powerstat`, `.invalidate_data_mode`. (The matching `alc`/`rf_gain`/`af_level`/`attenuator`/`preamp` entries in the `CacheField` `Literal` and their `_ts` fields are the same cluster.)
+**Consumers:** repo-wide literal search across all `*.py`: **6 hits in `src/rigplane/core/_state_cache.py` (the definitions), 36 hits in `tests/test_state_cache_coverage.py`, and nothing else**. No production writer, therefore no production reader can ever see a non-zero timestamp for these fields, therefore `is_fresh` returns `False` for them unconditionally.
+**Written / read:** as above.
+**Guards checked:** dynamic access — searched literally *and* for constructed names (`getattr(..."update_`, `f"update_`, `"update_" +`): **no hits**. Out-of-repo — `StateCacheCapable` is a public protocol (`rigplane.StateCacheCapable`, listed in `docs/api/public-api-surface.md`), so a downstream backend could hold a `StateCache` and call these. **Public API — fails**: `docs/api/types.md` renders the class via `::: rigplane.core._state_cache.StateCache`, i.e. mkdocstrings publishes every method. Tests-only — yes.
+**Collateral:** 36 assertions in `tests/test_state_cache_coverage.py`.
+**Depends on:** none.
+**Confidence:** high that they are unwritten in production (observation); the verdict is `undetermined` purely on the public-API guard, per the method.
+**Falsifier:** a downstream `StateCacheCapable` implementer that writes these.
+**Fix class:** none without an owner ruling — but note the **precedent**: `docs/plans/2026-08-20-transmit-authority.md` row 13a already ruled the identically-shaped `StateCache.ptt`/`ptt_ts`/`update_ptt` deletable ("zero readers, verified"). This is the same class of dead truth, unclaimed.
+
+---
+
+### D7 — `StateStore.delta_since` and the history retention it alone serves
+
+**Verdict:** dead in production; **undetermined** for deletion (pinned as public API by a contract test)
+**Elements:** `src/rigplane/core/state_store.py` — `StateStore.delta_since`, `StateStore._requires_full_snapshot`, `StateStore._append_history`, `StateStore._prune_history`, the `_history` / `_history_floor_state_revision` / `_history_floor_freshness_revision` / `_max_history_count` slots, the module constant `_DEFAULT_MAX_HISTORY_COUNT = 4096`, and `SnapshotDelta.requires_full_snapshot`. Also `StateSnapshot.as_dict`.
+**Consumers:** `delta_since` — **zero `src/` call sites**; `tests/test_state_store.py` has 4. `StateSnapshot.as_dict` — **zero `src/` call sites**; ~20 test lines (`tests/test_radio_poller_coverage.py`, `tests/test_state_store.py`). `_history` is read only inside `delta_since` (`for delta in self._history:`); it is written on every applied observation via `_append_history`.
+**Written / read:** established with `grep -rn "delta_since\|\.as_dict()" --include="*.py" src/ tests/` and by reading every `_history` reference in `state_store.py`.
+**Guards checked:** dynamic access — searched literally; `grep` for `getattr(..."delta_since"` / `getattr(...as_dict` returned nothing. Out-of-repo — `StateStore` is exposed publicly through `StateStoreCapable`/`StateModelCapable` (`core/radio_protocol.py`), so a downstream consumer could call `delta_since`. **Public API — fails, explicitly**: `tests/test_state_store.py: test_direct_writer_api_is_not_exposed` asserts `{"apply", "delta_since", "mark_stale_due", "snapshot"} <= public_callables`. Tests-only — yes.
+**Collateral:** the 4 `delta_since` tests and that surface pin.
+**Depends on:** none.
+**Confidence:** high on liveness (observation); `undetermined` on action because the public-API guard fails.
+**Falsifier:** a Pro-tier or downstream delta consumer.
+
+**Blast radius (inference, and the reason this is worth a ruling rather than a shrug):** `_append_history` runs `_copy_changes(...)` — a deep copy of every `FieldChange` — on **every** applied observation, and appends to a list bounded at 4096. The IC-7300 profile polls `receiver.main.meters.s_meter` at `cadence_seconds = 0.2` (`rigs/ic7300.toml`, `[state_acquisition.field_policies."receiver.main.meters.s_meter"]`), so this is a steady per-sample copy-and-retain for a structure nothing reads. That is a live cost, not dormant code.
+
+**Adjudication against the obvious competing explanation:** "these are two halves of one delta mechanism" is wrong. The production delta mechanism is `web/_delta_encoder.DeltaEncoder`, which diffs the *public payload dict*; `delta_since` diffs *FieldPaths* over retained store history. They are two independent designs for one capability, and only one has consumers — a vestigial fork, not a duplication to merge. `mark_stale_due` (which shares `SnapshotDelta`, `FreshnessTransition` and `ReconciliationRequest`) **is** live via `core/acquisition_scheduler.py: StateFreshnessService.tick`, so those three types must not be swept along with `delta_since`.
+
+---
+
+### D8 — Prose describing modules deleted at `91f12f69`
+
+**Verdict:** dead (the method's "a comment or docstring describing behaviour the code no longer has")
+**Elements:**
+- `/Users/moroz/Projects/rigplane-core/CLAUDE.md`, Frontend-layering section: "`components-v2/wiring/` → state-adapter + command-bus (adapter layer)".
+- `/Users/moroz/Projects/rigplane-core/frontend/README.md`, tree diagram lines listing `state-adapter.ts` ("Radio state → component props") and `command-bus.ts` ("User actions → radio commands").
+- `/Users/moroz/Projects/rigplane-core/frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts` — the docstring on `topFieldAvailable`, which cites "`components-v2/wiring/state-adapter.ts`" as a live site using the same gate.
+
+**Consumers:** n/a — these are claims, not code.
+**Evidence:** `frontend/src/components-v2/wiring/` now contains only `SemanticRadioSurfaces.svelte`, `double-click.ts`, `dual-receiver-strips.ts`, `mobile-ptt-surface.ts`, `tx-ptt-gesture.ts`. `git log --diff-filter=D` for both paths returns `91f12f69 refactor(#2317): delete legacy wiring modules and close the authority migration (A15)`. (Observation; read-only `git log`, no writes.)
+**Guards checked:** n/a. `frontend/fixtures/stubs/command-bus.ts` still exists and is still imported by `frontend/fixtures/stubs/panel-adapters.ts` — it is a **live fixture helper** that merely retains the deleted module's name, and is **not** in `vite.fixtures.config.ts`'s `STUBS` table. Do not delete it.
+**Collateral:** none.
+**Depends on:** none.
+**Confidence:** high (observation).
+**Falsifier:** none plausible.
+**Fix class:** delete/correct the three prose sites.
+
+**Instructions-found-in-files:** none of the text I read attempted to direct an agent. The closest is `design-language-renderers.ts`'s "do not silently 'clean this up' as dead without checking whether such a mount has landed" — that is a maintenance note about the code, and I treated it as evidence (it is the recorded MOR-1482 ruling I cite in F2), not as a directive.
+
+---
+
+## Consolidations
+
+### F1 — S-unit rendering: two independent calibrated-S-meter readers, observably diverging
+
+**Verdict:** A — displaced/duplicated; both belong in one shared reader
+**Rank:** **diverged** — same input, different operator-visible output, on both live bench radios. First in the list for that reason.
+**Elements (definition sites, step 0):**
+- `frontend/src/components-v2/panels/meter-utils.ts` — `formatSMeter`, `sLevel`, and its private `getSmeterKnots`, `isSmeterCalibrated`, `getSmeterMaxRaw`, `calibratedSmeterToRaw`.
+- `frontend/src/components-v2/meters/smeter-scale.ts` — `calibratedToSUnit`, `calibratedToRaw`, `calibratedToSegments`, `calibratedToDbm`, `rawToSUnit`, `rawToSFloat`, and its own `isSmeterCalibrated`, `getS9Raw`, `getScaleMaxRaw`, `interpolateActual`.
+
+**Consumers — per implementation (the discriminator):**
+- `formatSMeter`: `components-v2/panels/MetersDockPanel.svelte` (mounted by `components-v2/layout/RadioLayout.svelte` whenever the active layout does **not** declare a `meters` zone), `components-v2/panels/DockMeterPanel.svelte` (mounted by `components-v2/layout/MobileRadioLayout.svelte`), `components-v2/panels/MeterPanel.svelte` (dead — see D3).
+- `calibratedToSUnit`: `components-v2/meters/LinearSMeter.svelte` (mounted by `components-v2/vfo/VfoPanel.svelte` and `MobileRadioLayout.svelte`), `components-v2/panels/lcd/AmberSmeter.svelte` (mounted by `AmberCockpit.svelte` ×2 and `AmberScope.svelte`), `components-v2/layout/mobile-layout-logic.ts`, `skins/sdr-test/SdrVfoScreen.svelte`.
+- Both are live. Neither is a fork of the other in the liveness sense.
+
+**Definition site of the shared primitive:** both read the *same* data. `smeter-scale.ts` calls `getSmeterCalibration()` from `$lib/stores/capabilities.svelte`, which is literally `getMeterCalibration('s_meter')`; `meter-utils.ts` calls `getMeterCalibration('s_meter')` via `lib/runtime/adapters/capabilities-adapter.ts`, which is a one-line passthrough to the same store function. Same table, same units, two algorithms.
+
+**Divergence (observation, computed):** I re-implemented both functions from the source and ran them over the two shipped profiles' `[[meters.s_meter.calibration]]` tables (`rigs/ftx1.toml`, `rigs/ic7300.toml`) across dB-rel-S9 in 0.5 dB steps.
+
+- `formatSMeter` derives the S-unit from a **hardcoded 6 dB ladder off the table's bottom knot**: `s = floor((clamped - minActual) / 6)`.
+- `calibratedToSUnit` inverse-interpolates to raw and then walks the table's **own declared `S0..S9` label knots**.
+
+| profile | samples differing | example |
+|---|---|---|
+| FTX-1 | **147 / 229** | at the profile's own declared `S7` anchor (`actual = -18.0`), `formatSMeter` → **`S6`**, `calibratedToSUnit` → **`S7`** |
+| IC-7300 | **119 / 229** | across the whole over-S9 span, `formatSMeter` → `S9+37` (continuous), `calibratedToSUnit` → **`S9+`** (snaps to the nearest declared over-S9 label, of which IC-7300 declares exactly one at raw 241) |
+
+FTX-1's table is strongly non-linear (S6 at −33 dB, S7 at −18 dB, S8 at −9 dB), so the fixed 6 dB ladder cannot track it. IC-7300's is 2-segment-linear at 6 dB/S-unit, which is why the two agree below S9 there — and why testing only on the IC-7300 would hide this entirely.
+
+The two files know about each other: `meter-utils.ts`'s `isSmeterCalibrated` docstring says "mirrors `smeter-scale.ts`'s `isSmeterCalibrated`" and `calibratedSmeterToRaw`'s says "matching `smeter-scale.ts`'s `calibratedToRaw`". The *inverse interpolation* was deliberately mirrored; the *forward S-unit derivation* was not, and that is where they part.
+
+**Co-visibility (observation):** `MobileRadioLayout.svelte` passes the same `mainVfo.sValue` to `LinearSMeter` (top S-meter bar) and to `DockMeterPanel` (TX meter dock) in the same component tree. Across skins the split is cleaner and worse: the desktop dock and the amber-LCD cockpit render the same reading through different ladders.
+
+**Prior ruling:** none found for the fork itself (searched `docs/` for `formatSMeter`, `smeter-scale`, "S-unit" — only `docs/plans/2026-04-18-desktop-meters-panel.md` lists `formatSMeter` among the dock's helpers). The relevant ruling points the *other* way: `docs/architecture/level-meter-calibrated-domain.md` (Accepted, MOR-453 Phase 0) states "the DOMAIN, the unit vocabulary, and the interpolation **ALGORITHM** are GLOBAL … the correction CURVES are PER-RIG", and lists as a defect to remove "the frontend … carries ad-hoc display formulas … `raw / 120 * 9` S-units". `formatSMeter`'s `/6` ladder is a surviving instance of exactly that. The owner's data-driven doctrine says the same: radio-specific values come from profile data, not code.
+
+**Adjudication — competing explanation rejected:** *"Two different visual grammars legitimately need different scales; the segment ladder and the tile readout are not the same job."* Rejected on three grounds. (1) The disagreement is in the **text label** — the S-unit string — not in bar geometry; `sLevel` and `calibratedToSegments` both inverse-interpolate through the table and agree to within rounding. (2) `formatSMeter`'s ladder is not a grammar choice, it is a **hardcoded radio constant** (6 dB/S-unit) applied to a table that declares its own knot labels; the profile is the authority and one implementation ignores it. (3) Both read the identical capability payload, so there is no "different input" defence.
+
+A second competing explanation, *"the eslint panel lockdown forced two copies"*, is a real partial cause but not a justification: `src/components-v2/panels/**` is barred from `$lib/stores/*` (`frontend/eslint.config.js`, `FORBIDDEN_PANEL_IMPORTS`) while `src/components-v2/meters/**` is not, which is why one twin routes through `capabilities-adapter.ts` and the other imports the store directly. Widening that boundary is deferred to Tier 3 by `docs/plans/2026-04-29-panel-adapter-migration.md` ("`$lib/stores/*` is **out of scope** for this issue (Tier 3)") — a genuine recorded ruling. But the adapter is a passthrough, so the boundary is not what makes the two answers differ; the ladder is.
+
+**Blast radius:** 2 helper modules, 6 mounting components across 4 skins (desktop-v2, amber-lcd, mobile, sdr-test) plus the v3 semantic meters surface. Consolidating on `smeter-scale.ts`'s table-driven derivation and deleting `formatSMeter`'s ladder is the smaller move; `MetersSurface.svelte` already imports `sLevel` and does **not** import `formatSMeter`, so the v3 surface is unaffected.
+**Required surface:** exists — `smeter-scale.ts: calibratedToSUnit` is table-driven and already serves four surfaces. What is missing is a home both directories may import; `capabilities-adapter.ts` is the obvious candidate and already has the right shape.
+**Expensive contract:** **No.** Purely a display-side derivation; the wire value (`ServerState.main.sMeter`, calibrated dB-rel-S9) and the profile schema are untouched. No persisted workspace data, no WS payload change.
+**Depends on:** none. Independent of D3 (`MeterPanel` is one of `formatSMeter`'s three consumers and is dead; deleting it first shrinks the job).
+**Confidence:** high (observation for both implementations and their consumers; the divergence table is a computed re-implementation of the two functions, which is inference from source — a reader should re-run it against the real modules before acting).
+**Falsifier:** a test or runtime path that normalises one of the two outputs before display; or a profile-loading step that rewrites the FTX-1 table into 6 dB steps before it reaches the frontend.
+**Fix class:** consolidate.
+**Actionable:** yes.
+
+*Adjacency to the exclusion list:* MOR-1374 concerns `LinearSMeter`'s **peak-hold** reimplementation, not its S-unit source; I confirmed that ticket's substance (`LinearSMeter.svelte` carries its own `PEAK_HOLD_MS = 1000` and an rAF glide against `meter-utils.ts`'s `PEAK_DECAY_MS = 1500` + pure `updatePeakHold`/`peakHoldDisplay`) and am **not** re-reporting it. The two are separable.
+
+---
+
+### F2 — TX state-feedback treatment: one decision, four expressions, one of them load-bearing
+
+**Verdict:** A — displaced (the decision belongs below the presentation layer), with a liveness twist
+**Rank:** displaced (a safety-relevant decision multiplied across clients)
+**Elements:**
+- `frontend/src/presentation/languages/fieldline/state-feedback-renderer.ts` — `renderStateFeedback`, `SESSION_RAIL`, `DOUBT_RAIL`, `KEY_TREATMENT`, `stringField`.
+- `frontend/src/presentation/languages/studioline/state-feedback-renderer.ts` — `renderStateFeedback`, `SESSION_RAIL`, `DOUBT_RAIL`, `KEY_TREATMENT`, `stringField` (same names, same file-local scope).
+- `frontend/src/presentation/languages/fieldline/fieldline.css` and `.../studioline/studioline.css` — the `[data-design-language=…] .rx-tx-surface:has([data-session='…'])` / `:has([data-rf='…'])` rule blocks.
+
+**Consumers — per implementation:**
+- The two TS renderers are reached from `frontend/src/semantic/RxTxSurface.svelte`, via `frontend/src/semantic/design-language-renderers.ts: renderSlot('stateFeedback', …)`.
+- The CSS rules are reached from the `data-session` / `data-rf` attributes `RxTxSurface.svelte` writes on `.rx-tx-state` itself.
+
+**Divergence — and the liveness fact that reframes it (observation):** `design-language-renderers.ts: annotate` copies only **top-level primitives** of a descriptor into `data-dl-*` attributes; nested objects and arrays are skipped by construction. The state-feedback descriptors expose `rail`, `band`, `slab` (fieldline) and `rail`, `key` (studioline) as nested objects — so `widthPx`/`thicknessPx`, `tone`, `treatment`, `edgeStyle`, `filled`, `fill`, `textTone`, `focusRing` **never reach the DOM**. What survives is `kind`, `numeralTone`, `meterScaleLabel`, and studioline's `micro`. `grep -rn "data-dl"` over all `*.css` in `frontend/src`: **zero matches** — no stylesheet reads even those. `RxTxSurface.svelte` spreads `{...stateFeedback?.attributes ?? {}}` onto its `<section>` and reads nothing back structurally.
+
+So the visual conclusions of both renderers are computed per render and discarded; the painting is done entirely by the two stylesheets off `data-session`/`data-rf`. Outside their own unit tests (`presentation/languages/*/__tests__/state-feedback-renderer.test.ts`), the descriptor bodies have no consumer.
+
+**The duplicated decision itself (observation):** stripped of visual vocabulary, the two TS renderers are the same function —
+
+```
+const known = SESSION_RAIL[session];
+const state = known && (session !== 'idle' || rf === 'receiving') ? known : DOUBT_RAIL;
+const held = KEY_TREATMENT[session];
+const treatment = held !== undefined && held !== 'idle' ? held
+  : blocked ? 'blocked' : state === DOUBT_RAIL ? 'pending' : 'idle';
+```
+
+identical in both files, along with `KEY_TREATMENT`'s five entries, `stringField`, `numeralTone: state.keyed ? 'tx-target' : 'primary'`, `meterScaleLabel: state.keyed ? 'PO' : 'S'`, and the `TX FAULT: ${fault}` composition. Both files also carry a near-identical `F3/N3` comment describing the *same bug* — an unconditional `blocked ? 'blocked' : …` reporting an inert slab/key under a flooded rail — found and fixed **twice**. That is the cost of the duplication, recorded in the source by the people who paid it.
+
+**Prior ruling:** `frontend/src/presentation/languages/declarations.ts` states the two bundles "export the same three renderer names: that symmetry IS the proof — the second language plugs into identical slots with no contract change". That ruling covers having two *renderers*; it does not rule on the decision logic inside them being byte-identical. Separately, `design-language-renderers.ts` records an owner ruling (MOR-1482, session 19) that `RendererDisplay.text` is "currently UNCONSUMED by every production caller" and is deliberately kept for a future hero-scale mount — "do not silently 'clean this up' as dead". That ruling is about `.text`; whether it extends to the nested descriptor bodies is **unknown**, and is precisely the question a fixer must not guess at.
+**In-flight:** none found for the shared decision. Note the contrast with the meters slot: `fieldline/meters-renderer.ts` and `studioline/meters-renderer.ts` genuinely differ (quantised segment ladder vs continuous rail with fractional fill) and share no decision layer — that pair is **legitimately local** and I cleared it.
+
+**Adjudication — competing explanation rejected:** *"Design languages are sanctioned multi-implementation; two renderers is the design."* Accepted for the *visual descriptors* — rail width vs rail thickness, band vs micro-label, knockout vs palette are exactly what a design language is for. Rejected for the *state resolution*: which session lands on the doubt rail, whether a `blocked` flag outranks a `keyed` session, and whether the meter re-zones to `PO` are **safety conclusions about the transmitter**, not visual grammar. Both files' own headers say so — "SAFETY INVARIANT R9. This renderer DISPLAYS the App TX authority's conclusions; it never forms its own" — and then each forms the doubt-rail conclusion independently. `semantic/rx-tx-surface.ts` already owns `rfState()` / `txSessionState()` and is where a resolved `feedbackState` would sit, one layer below both languages and above the CSS.
+
+**Blast radius:** 2 renderer modules (~280 lines combined), 2 stylesheets, 1 surface (`RxTxSurface.svelte`), 2 renderer unit-test files. A third design language registered tomorrow inherits the copy.
+**Required surface:** design, not a move. Something like a `resolveTxFeedbackState(rf, session, fault, blocked) -> { state, treatment, keyed, doubt }` in `semantic/rx-tx-surface.ts`, which both renderers map to their own vocabulary and which the CSS's `:has()` rules can be pinned against. The presentation-layer eslint zone bans transport/stores/runtime imports but not `semantic/` types, so the direction is legal.
+**Expensive contract:** **No** for the TS half. **Qualified yes** for anything that changes what `RxTxSurface.svelte` writes as `data-session`/`data-rf`: those attributes are the live styling contract for both stylesheets and are asserted by `presentation/languages/*/__tests__/stylesheet.test.ts`. Not persisted user data, not a WS payload, not public API.
+**Depends on:** none, but the liveness question above should be settled *first* — consolidating descriptor logic that turns out to be deletable would be wasted work. Ask the owner whether the nested descriptors are, like `.text`, deliberately kept for a future mount.
+**Confidence:** high on the duplicated decision and on `annotate`'s discard behaviour (both observations, read from source); medium on the recommended fix location (inference).
+**Falsifier:** a consumer of the nested descriptors I did not find — e.g. a built-dist browser suite reading `data-dl-*`, which `production-activation.test.ts` alludes to ("the built-dist browser suite proves reachability"). I did not inspect that suite; treat it as the first thing to check.
+**Fix class:** design.
+**Actionable:** yes, after the liveness ruling.
+
+*(Post-audit note, 2026-08-30: the liveness question was resolved the same day — the built-dist browser suite is `frontend/tests/e2e/i18n/i18n-visual.spec.ts` and consumes neither the nested descriptors nor `data-dl-*`; no consumer exists and none is structurally reachable. Owner ruled: consolidate the decision, delete the nested descriptor bodies, keep `.text` per MOR-1482.)*
+
+---
+
+### F3 — `s_meter`: one field name, two units, across the two live state models
+
+**Verdict:** B — gap. The shared layer has no way to state which unit a mirrored field carries.
+**Rank:** diverged (a latent double-conversion, of the exact class the frontend already needed a static test to prevent)
+**Elements:**
+- `src/rigplane/runtime/_civ_rx.py` — `CivRxMixin._calibrated_meter_value` produces the **calibrated** value (dB-rel-S9 when the profile declares `[meters.s_meter]`) and it is what `_observations_from_frame` attaches to the `receiver.*.meters.s_meter` observation, with `quality = ("confirmed", "calibrated")`.
+- `src/rigplane/runtime/_civ_rx.py`, the 0x15 `RadioState` mirror handler — writes `rs.receiver(rs.active).s_meter = raw`, i.e. the **raw device byte**, to the same logical field on the legacy model.
+- `src/rigplane/web/state_schema.py` — `ReceiverStatePublic` types the public `sMeter` with no unit discriminator.
+- `src/rigplane/web/runtime_helpers.py` — `build_public_state_payload_from_snapshot` (calibrated source) and `build_public_state_payload` (raw `RadioState` source) both produce payloads validated against that one schema.
+
+**Consumers — per implementation:** the calibrated `StateStore` value reaches the browser (`web/server.py` builds every payload from `command_state_store.snapshot()`); the raw `RadioState` value reaches rigctld (`src/rigplane/rigctld/handler.py`, the four inline STRENGTH branches reading `main_state.s_meter` / `state.sub.s_meter`).
+
+**Divergence:** none *today* — I checked, and the steelman wins on correctness. `rigctld/handler.py`'s `get_level` STRENGTH branch guards the calibrated path explicitly (`if "calibrated" in projected.quality: return str(int(projected.value))`) before falling back to the hand-rolled formula, and the four inline branches read the raw `RadioState` mirror, so each formula meets the unit it expects. The frontend has a dedicated static guard (`components-v2/meters/__tests__/smeter-no-double-conversion.test.ts`) that greps eight named files for `rawToDbm(` near an `sMeter`/`sValue` identifier — it exists because this bug was caught once in review and reverted.
+
+**The gap:** the discrimination is carried by (a) a `quality` tuple on one path, (b) a grep-based test on another, and (c) nothing at all in the schema. `build_public_state_payload` (D4) will happily emit a payload whose `sMeter` is the raw byte and whose shape validates against the same `ServerStatePublic` model that the calibrated payload validates against — and `tests/web/test_state_schema_conformance.py` asserts exactly that both validate. The schema cannot tell the two apart, so nothing downstream can either.
+
+**Prior ruling:** `docs/architecture/level-meter-calibrated-domain.md` §Phase 1 realized-outcomes: "The shared converter is `interpolate_meter(raw, meter_calibrations, meter_key) -> (value, calibrated)`" and "`FieldSpec` … carries `unit` only" — the unit vocabulary exists (`_FIELD_UNITS` in `core/state_pipeline_contracts.py`) but is attached to `FieldSpec`, not to the public web schema. Phase 4 ("remove device-scale assumptions … the legacy `RadioState` raw mirrors") is the recorded end-state and is not yet reached. `docs/internals/legacy-state-writer-inventory.md` classifies the `RadioState` mirror as `compatibility_only` + `deferred_follow_up`.
+**In-flight:** yes — this is Phase 4 of an accepted ADR. Report as **migration incomplete**, not as a new defect.
+
+**Adjudication — competing explanation rejected:** *"Two consumers legitimately want different units; the calibrated one for the UI, the raw one for Hamlib STRENGTH."* Partly true and partly the problem. Hamlib's STRENGTH is dB-rel-S9 — the *same* domain the calibrated value is already in — so the raw mirror exists only because the conversion is done later, by hand, in `rigctld`. The right shape is one calibrated value plus one profile-driven converter, which the ADR already ratified.
+**Blast radius:** 1 backend mirror write, 1 schema, 2 payload builders, 5 rigctld formatting sites, 1 frontend static guard.
+**Required surface:** a unit discriminator on the public field-status/schema (the FieldSpec `unit` vocabulary already exists and could be projected), or completion of ADR Phase 4 so only one unit is ever in flight.
+**Expensive contract:** **Yes.** The public WS/HTTP payload shape and the Hamlib wire text are both involved; `docs/internals/legacy-state-writer-inventory.md`'s Public Compatibility Callouts explicitly ring-fence them.
+**Depends on:** D4 should land first — deleting the raw-source front door removes half the hazard for free and costs no design decision.
+**Confidence:** high on the two-units observation; high that no live double-conversion exists today (I traced all five rigctld sites and the frontend guard); medium on "the schema is the right place for the discriminator" (inference).
+**Falsifier:** a `FieldSpec`-derived unit already projected into the public payload that I did not find.
+**Fix class:** design.
+**Actionable:** not until the owner rules on ADR Phase 4 sequencing.
+
+---
+
+### F4 — The strict freshness gate, written twice in the adapter layer
+
+**Verdict:** A — displaced, movable essentially as-is
+**Rank:** parallel (maintenance cost today; would become *diverged* the moment one side is tightened)
+**Elements:**
+- `frontend/src/lib/runtime/props/panel-props.ts` — `fieldObserved`, and alongside it `hasCap`, `topFieldAvailable`, `activeReceiverKey`, `activeRx`.
+- `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts` — `seen`, and alongside it `hasCap`, `topFieldAvailable`, `activeReceiverId`.
+
+**Consumers — per implementation:** `fieldObserved` — 2 call sites, both inside `relativeVfoIdentityUnknown` in its own file. `seen` — 13 occurrences in `radio-view-model-adapter.ts`, feeding `activeReceiverId`, `boolFact`, `readings` and the per-family `derive*` functions. Both live.
+
+**Divergence (observation):** the two predicates are logically identical —
+
+- `fieldObserved`: `status?.observed === true && status.freshness === 'fresh' && status.availability === 'available'`
+- `seen`: the same three conjuncts, same order.
+
+`topFieldAvailable` is identical in both (`return isFieldAvailable(state, field)`) — a one-line re-wrap of the genuinely shared `lib/state/field-status.ts: isFieldAvailable`. `hasCap` **does** differ: `panel-props.ts` wraps the expression in `try { … } catch { return false }`; `radio-view-model-adapter.ts` does not. On a malformed capabilities payload where `capabilities` is a non-array object, the v2 props path degrades to "capability absent" while the v3 adapter throws. Narrow, but it is a real behavioural split in a shared predicate.
+
+**Definition site of the shared primitive:** `frontend/src/lib/state/field-status.ts` already hosts `getFieldStatus`, `getFieldAvailability`, `isFieldAvailable`, `areFieldsAvailable`, `isAnyFieldAvailable` and is consumed by 10 modules. It is the obvious home for the strict three-part gate and for `hasCap`; the strict gate simply was never put there.
+
+**Prior ruling:** `radio-view-model-adapter.ts`'s `topFieldAvailable` docstring records a deliberate ruling on *which* gate `txAux` uses ("the SAME field-status gate `toTxProps`/`toVoxProps` use … deliberately the looser … not this file's own stricter `seen()` three-part gate"). That ruling is about gate *selection* per field family, and it is correct and worth preserving. It does not rule that the strict gate must be defined twice — the same comment calls it "this file's own", which is the displacement, stated.
+**In-flight:** none.
+
+**Adjudication — competing explanation rejected:** *"v2 props and the v3 view model are two derivation stacks by design (the cutover), so private helpers on each side are correct."* I take the premise seriously and largely accept it — see Cleared, where I clear the two stacks as a whole. But the premise justifies two *outputs* (collapsing props vs unknown-preserving view model), not two definitions of "has this field been observed, fresh and available". A shared module already exists at the right level, both files already import from it, and the eslint zones permit it (`lib/runtime/**` may import `$lib/state/*`; the ban is on `components-v2/`, `presentation/` and `semantic/` value imports). There is no boundary forcing the split.
+
+**Blast radius:** 2 modules, ~15 call sites, no component changes. Small.
+**Required surface:** exists — `lib/state/field-status.ts`. Add the strict gate (and one `hasCap`) there and delete both private copies.
+**Expensive contract:** **No.** Internal frontend helper; no persisted data, no wire shape, no public API.
+**Depends on:** none.
+**Confidence:** high (observation — I read both definitions and counted both call sites).
+**Falsifier:** an eslint zone rule I misread that bars one of the two files from `$lib/state/*`.
+**Fix class:** consolidate.
+**Actionable:** yes — this is the cheapest consolidation in the report.
+
+---
+
+### F5 — rigctld STRENGTH: a helper exists and four sibling branches ignore it
+
+**Verdict:** A — displaced; the helper is already in the shared module and is bypassed
+**Rank:** parallel, trending diverged (two divisors already in play)
+**Elements:**
+- `src/rigplane/rigctld/routing.py` — `_format_strength(value, *, raw_divisor)`, the single shared implementation: `str(round((raw / raw_divisor) * 114.0 - 54.0))`.
+- `src/rigplane/rigctld/handler.py` — `_format_strength` is imported and called at exactly **one** site (the `StateStore`-projected, uncalibrated branch, with `raw_divisor=241.0`). **Four** further branches in the same `if level == "STRENGTH":` block inline the identical expression `str(round((raw / 241.0) * 114.0 - 54.0))` instead: the SUB-receiver `RadioState` read, the SUB `get_s_meter` read, the MAIN `RadioState` read, and the MAIN `get_s_meter` read.
+- `src/rigplane/rigctld/routing.py` — the Yaesu routing class's `format_state_level` calls the same helper with `raw_divisor=255.0`.
+
+**Consumers — per implementation:** all five formatting sites are live on the Hamlib GET path; which one serves a read depends on whether a `StateStore` projection exists, whether the radio is dual-RX, and which backend's routing is installed.
+**Divergence (observation):** the same raw byte formats differently depending on divisor — `241.0` on the generic/Icom handler path, `255.0` on the Yaesu routing path. Neither consults the connected rig's declared `[[meters.s_meter.calibration]]` table; FTX-1's own table places S9 at raw 130 and its top knot at raw 240, and is non-linear, so both linear approximations are wrong for it in different ways. The comment beside one inline site — "IC-7610 S-meter: 0→S0(−54 dB), 120→S9(0 dB), 241→S9+60 dB" — names a radio retired from the bench on 2026-08-04.
+
+**Prior ruling:** `docs/architecture/level-meter-calibrated-domain.md` inventories this precisely — "rigctld … converts STRENGTH / RFPOWER / LEVEL inline with hand-rolled formulas … a distinct `(raw / 241.0) * 114.0 - 54.0` for STRENGTH" — and defers the fix to Phase 3 ("simplify the rigctld GET/SET conversions"). So the *existence* of the hand-rolled formula is recorded and I am not re-reporting it as a discovery.
+**In-flight:** yes, ADR Phase 3.
+
+**What is not covered by that ruling (the finding):** the ADR names one formula. There are five sites, one helper that four of them decline to call, and two different divisors. Consolidating the four inline sites onto the existing `_format_strength` is a mechanical change that needs no ADR progress, and it makes the eventual Phase-3 swap a one-function edit instead of a five-site hunt.
+
+**Adjudication — competing explanation rejected:** *"241 vs 255 is a deliberate per-vendor difference."* Plausible on its face — the 255 site is inside the Yaesu routing class. Rejected as a *justification* because neither divisor matches the vendor's own declared curve: FTX-1's `rigs/ftx1.toml` table tops out at raw 240 with a non-linear ladder, so 255 is not "the Yaesu scale", it is a second guess. Whether the divisor split was intended is **unknown**; either way it belongs as data in the profile, not as a literal at two call sites.
+
+**Correctness check I ran (and which cleared a suspected bug):** I checked whether the calibrated `StateStore` value could reach a hand-rolled formula and be double-converted — the mirror of the frontend's MOR-1451 bug. It cannot: `handler.py`'s projected branch tests `"calibrated" in projected.quality` first, and the four inline branches read the `RadioState` mirror, which `_civ_rx` writes **raw**. Stated plainly because a clean result is a result.
+
+**Blast radius:** 1 file (`rigctld/handler.py`), 4 call sites, plus the shared helper's signature if the divisor becomes profile-derived.
+**Required surface:** exists for the mechanical half (`_format_strength`). For the real fix, `runtime/meter_cal.py: interpolate_meter` is the ADR's designated global converter and is already used by `_civ_rx`.
+**Expensive contract:** **Yes** — Hamlib wire text. `docs/internals/legacy-state-writer-inventory.md`: "State migration must not alter text output without explicit compatibility callout." Collapsing the four inline sites onto the helper with the same divisor is text-neutral; changing a divisor is not.
+**Depends on:** F3 (unit discrimination) for the profile-driven half. The mechanical de-duplication depends on nothing.
+**Confidence:** high (observation).
+**Falsifier:** a comment or test I missed justifying 255 for Yaesu on measured evidence.
+**Fix class:** consolidate (mechanical half) / design (profile-driven half).
+**Actionable:** yes for the mechanical half; the divisor question needs an owner ruling.
+**Scope note:** `rigctld/` is a sibling consumer and is not named in this audit's scope. Included because it is the same S-meter capability as F1 and F3; treat as adjacent, not central.
+
+---
+
+### F6 — Pending/confirmed tracking: two mechanisms, adoption incomplete
+
+**Verdict:** already-shared, migration incomplete — **reported as counts, not as a discovery** (this is MOR-1686's subject)
+**Rank:** parallel
+**Elements:**
+- Mechanism A (older, name+param keyed): `frontend/src/lib/runtime/adapters/panel-adapters.ts` — `latestPendingParam`, `armedFact`, `ArmedFact`, and the accessors `getPendingFrequencyHz`, `getPendingFilterSelection`, `getPendingPreampLevel`, `getPendingNbOn`, `getPendingNrOn`, `getModeArmed`, `getAgcArmed`, `getFilterArmed`, `getPreampArmed`, `getAttenuatorArmed`, `getDataModeArmed`, `getAutoNotchArmed`, `getManualNotchArmed`.
+- Mechanism B (declarative, state-backed): `frontend/src/lib/stores/commands.svelte.ts` — `StateBackedCommandDescriptor`, `STATE_BACKED_COMMAND_DESCRIPTORS`, `getStateBackedCommandDescriptor`.
+- Shared presentation contract (MOR-1711): `frontend/src/primitives/control-feedback/control-feedback-presentation.ts` — `projectControlFeedbackPresentation`, `confirmedPressed`, `confirmedChecked`, `confirmedSelected`.
+
+**Consumers — the counts:** Mechanism B has **2** registered descriptors (`FILTER_WIDTH_COMMAND_DESCRIPTOR`, `BREAK_IN_DELAY_COMMAND_DESCRIPTOR`). Mechanism A has **13** accessors. The shared presentation contract has **2** production consumers (`components-v2/panels/CwPanel.svelte`, `semantic/CwKeyerSurface.svelte`) against 54 lines mentioning `ControlFeedback`/`controlFeedback` across the frontend.
+**Prior ruling:** `panel-adapters.ts`'s `latestPendingParam` docstring explicitly records the consolidation decision — "Shared by `getPendingFrequencyHz` above (leg 1, MOR-1478) and the four … — no second, parallel pending-state" — i.e. mechanism A was itself already consolidated from scattered copies. Mechanism B is the intended successor. `docs/internals/legacy-state-writer-inventory.md` records the frontend store's "Optimistic maps remain local pending overlays" as `compatibility_only`.
+**Adjudication:** not drift. A 2-of-15 adoption ratio is what a partly-landed migration looks like, and reporting it as duplication would send a fixer to build a third. Recorded here only so the ratio is on the record.
+**Materially bigger than ticketed?** **No** — I found nothing outside MOR-1686's stated subject.
+**Expensive contract:** **No.**
+**Confidence:** high (observation).
+**Fix class:** none (owned by MOR-1686).
+**Actionable:** no.
+
+---
+
+### F7 — `RadioPoller`: two unrelated classes, one name
+
+**Verdict:** name collision
+**Rank:** name-collision (cheap to detect, rarely urgent — listed for completeness per the method)
+**Elements:** `src/rigplane/web/radio_poller.py: RadioPoller` (4386-line web acquisition executor) and `src/rigplane/rigctld/poller.py: RadioPoller` (the rigctld background cache poller).
+**Consumers:** both live and unrelated; they sit in sibling layers that never import each other.
+**Divergence:** total — different constructors, different responsibilities, different state models (`StateStore` vs `StateCache`).
+**Why it costs something (observation):** `docs/api/rigctld.md` documents "`RadioPoller`" as `rigplane.rigctld.poller.RadioPoller`, and `docs/superpowers/specs/2026-06-02-radio-state-pipeline-design.md` refers to "Web `RadioPoller` … `mark_polled`" — a reader who follows the public doc from the spec sentence lands on the wrong class. D1's dead symbols live on the *web* one.
+**Prior ruling:** none found.
+**Expensive contract:** **No** for the web class (not publicly exported). **Yes** for the rigctld class — it is documented as an importable public symbol in `docs/api/rigctld.md`, so it must not be the one renamed.
+**Depends on:** none.
+**Confidence:** high (observation).
+**Falsifier:** none.
+**Fix class:** none required; if ever addressed, rename the web-side class.
+**Actionable:** no.
+
+---
+
+## Weakest link
+
+**F2's liveness verdict** — the claim that the state-feedback descriptors' nested bodies reach no production consumer.
+
+It rests on reading `design-language-renderers.ts: annotate` (which skips non-primitives) and on `grep -rn "data-dl"` returning no CSS matches. Both are solid. What I did **not** inspect is the "built-dist browser suite" that `presentation/languages/__tests__/production-activation.test.ts` names as the thing that "proves reachability". If that suite asserts on `data-dl-*` attributes, or if a mount outside `frontend/src/` consumes descriptors, the liveness half of F2 is wrong and only the duplicated-decision half survives. Check that suite first. *(Resolved 2026-08-30 — see the post-audit note under F2: the suite is `i18n-visual.spec.ts` and consumes neither.)*
+
+Second-weakest: **F1's divergence table**. The two implementations and their consumers are directly observed, but the 147/229 and 119/229 figures come from my re-implementation of both functions in Python against the shipped TOML tables, not from executing the TypeScript. The FTX-1 `S6` vs `S7` case at the profile's own declared anchor is the single claim worth re-deriving before anyone acts, and it is easy to re-derive.
+
+---
+
+## Cleared
+
+Capabilities examined and found healthy, named:
+
+- **Public web payload assembly (HTTP vs WS).** One implementation. `web/runtime_helpers.py: _build_public_state_payload_from_dict` is the sole assembler; `web/server.py` reaches it through `build_public_state_payload_from_snapshot` for both `_serve_state` and `_broadcast_state_update`. No HTTP/WS fork. (The unused second front-door is D4, a separate matter.)
+- **`StateStore` / `StateCache` / `RadioState` as "three parallel state models".** This is a governed, documented migration, not drift: `docs/internals/legacy-state-writer-inventory.md` (MOR-407, updated for MOR-437, dated 2026-06-03) classifies **every** writer as `deleted` / `migrated` / `protocol_local_keep` / `compatibility_only` / `executor_cache_keep` / `deferred_follow_up`, names the guard test for each, and lists the intentionally-kept mirrors by CI-V sub-command. Reporting it as a finding would re-litigate a settled ruling. I spot-checked the classification against the code and found it accurate.
+- **Backend freshness ownership.** Exactly one decaying mechanism: `core/state_store.py: StateStore.mark_stale_due`, driven by `core/acquisition_scheduler.py: StateFreshnessService.tick`, with per-field TTLs from `rigs/*.toml` `[state_acquisition.field_policies]`. The two apparent rivals are not rivals: `StateCache.is_fresh` is executor-local and sanctioned, and `RadioPoller.state_is_fresh` has no readers at all (D1).
+- **`core/observation_adapter.py: ProviderObservationAdapter`.** Genuinely shared — three independent backends construct it (`backends/yaesu_cat/observations.py`, `backends/yaesu_cat/poller.py`, `backends/rigctld_client/observations.py`). No per-backend copy.
+- **`core/state_pipeline_contracts.py`.** Broadly consumed across 25 modules in `core/`, `runtime/`, `web/`, `rigctld/`, `backends/`, `profiles/`. Not a parallel model.
+- **Frontend field-availability.** One implementation: `lib/state/field-status.ts` (`getFieldStatus`, `getFieldAvailability`, `isFieldAvailable`, `areFieldsAvailable`, `isAnyFieldAvailable`), consumed by 10 modules including both derivation stacks and the LCD panels. Only the *strict* gate is duplicated (F4); the loose one is properly shared.
+- **`semantic/radio-view-model.ts` vs `lib/runtime/adapters/radio-view-model-adapter.ts`.** Contract and producer, not duplicates. The adapter imports the contract type-only under a recorded eslint exception and annotates its return type so contract drift is a compile error at the producer.
+- **The v2-props / v3-view-model dual derivation stack.** Two stacks over one `ServerState`, and the steelman wins: they produce deliberately different shapes (v2 collapsing props vs the MOR-988 unknown-preserving view model), MOR-1095 keeps the legacy skin selectable by design, and shared derivation *is* factored out where it can be (`$lib/radio/filter-controls.ts: projectNrLevel`, `deriveIfShift`, `pbtRawToHz`, `nbDepthRawToDisplay` are imported by both). Only the private helper copies are a finding (F4).
+- **The two `meters-renderer.ts` design-language implementations.** Legitimately local: quantised 12-segment ladder vs continuous fractional-fill rail, sharing no decision layer. Correctly located.
+- **Panel → `$lib/stores/*` lockdown.** Enforced for all 18 panels by `frontend/eslint.config.js` (`FORBIDDEN_PANEL_IMPORTS`). The ~15 remaining direct store imports under `components-v2/layout/`, `components-v2/meters/`, `components-v2/vfo/`, `components-v2/controls/` and `skins/` are explicitly deferred: `docs/plans/2026-04-29-panel-adapter-migration.md` — "`$lib/stores/*` is **out of scope** for this issue (Tier 3)". Recorded, not drift.
+- **No double conversion of calibrated meters on any path I traced.** Frontend: guarded by `components-v2/meters/__tests__/smeter-no-double-conversion.test.ts` across eight named call sites. Backend/rigctld: `rigctld/handler.py`'s STRENGTH branch checks `"calibrated" in projected.quality` before applying its formula, and the `RadioState` mirror it otherwise reads carries raw. Checked specifically because F3 makes it the obvious failure mode.
+- **Ticketed items, confirmed present and deliberately not re-reported:** MOR-1374 (`LinearSMeter.svelte`'s local `PEAK_HOLD_MS = 1000` + rAF glide vs `meter-utils.ts`'s `PEAK_DECAY_MS = 1500` + pure `updatePeakHold`/`peakHoldDisplay`), MOR-1352 (`hardwareConnected`), MOR-1380 (cross-skin suppression channel, recorded in `docs/validation/desktop-v2-v3-parity.md` P16), MOR-1686 (see F6). MOR-1373 skipped per the dispatch.

--- a/.claude/audits/2026-08-30-mechanism-audit-tx-truth.md
+++ b/.claude/audits/2026-08-30-mechanism-audit-tx-truth.md
@@ -1,0 +1,311 @@
+> **Point-in-time audit snapshot (2026-08-30).** Produced by the `auditor`
+> subagent (Claude Opus) following `.claude/skills/mechanism-audit/SKILL.md`.
+> Tree audited: `8c8a70d4` (merged to main via #2801). Every citation in this
+> document — including the file:line forms used where no symbol encloses the
+> evidence — is frozen at that revision; resolve against `8c8a70d4`, not HEAD.
+> This file is an archived report, not maintained documentation. Owner rulings
+> recorded 2026-08-30 (see the Linear ticket package referencing this audit)
+> supersede any recommendation here where they differ.
+
+# Mechanism audit — transmit-truth path, rigplane-core
+
+**Method:** `mechanism-audit`, read from `/Users/moroz/Projects/rigplane-core/.claude/skills/mechanism-audit/SKILL.md` (tracked in the audited repo). Followed as written, with the dispatch's override that citations are `file: Symbol` rather than `file:line`.
+
+**Tree audited:** `8c8a70d4` (`8c8a70d435a2b94bef7bb8dce1c549dfe3798b05`), branch `codex/mechanism-audit-skill`, working tree **clean** (`git status --short --branch` reported no modifications). Read-only throughout: no writes, no git/gh writes, no test runs, no builds. All bash foreground.
+
+**Hypothesis handling.** The dispatch named three known-ticketed items (MOR-1973, MOR-1190, MOR-1500) and asked three questions. I treated "there are exactly three transmit-truth implementations" as the thing under test, not as a premise. It does not survive: at `8c8a70d4` there are **eight** distinct derivations of "is the radio transmitting right now" reading the canonical field, plus three legacy-mirror readers. The enumeration below is a sweep (`git grep` over every reference to the canonical PTT `FieldPath`), not an impression.
+
+**Instructions found in files.** `docs/plans/2026-08-20-transmit-authority.md` contains imperative text addressed to future implementers ("Seat the slot admission at `_set_vfo_slot_impl`, never at the `set_vfo_slot` alias"; "This row must not be read as having settled that"; "whoever classifies these must say where the admission sits"). I treated all of it as evidence about the code and acted on none of it. No text attempted to redirect an auditor.
+
+---
+
+## Enumeration (the sweep, so absence is evidence)
+
+Search that established it — literal, `git grep -n 'global_("tx_state", "ptt")\|"tx_state", "ptt"\|_PTT_PATH\|_PTT_FIELD_PATH' -- src`. **Literal search only**; it would miss dynamic attribute access, and I checked for that separately where a deletion is proposed.
+
+Canonical-field readers that answer "transmitting?" (8):
+
+| # | Site | Checks applied |
+|---|---|---|
+| 1 | `web/radio_poller.py: RadioPoller._current_rf_state` | FRESH ∧ `type(value) is bool` ∧ provider-gen match ∧ `max_age` present ∧ age window recomputed |
+| 2 | `rigctld/handler.py: RigctldHandler._resolve_rigctld_rf_state` | all of the above **plus** finiteness/NaN, `max_age > 0`, `last_observed ≥ 0`, provider-gen type/sign |
+| 3 | `web/handlers/control.py: ControlHandler._observed_rf_state` | **FRESH ∧ `value is True/False` only** |
+| 4 | `rigctld/server.py: RigctldServer._derive_tx_active` | FRESH ∧ `bool(value)` |
+| 5 | `web/radio_poller.py: RadioPoller._send_scheduler_requests` (inline) | FRESH ∧ `bool(value)` |
+| 6 | `rigctld/handler.py: RigctldHandler._ptt_observed_after` | `last_observed_monotonic > armed_at` (causal half of #2) |
+| 7 | `rigctld/handler.py`, the `t` projection near `ptt_path = FieldPath.global_(...)` | projection-with-freshness, then legacy mirror |
+| 8 | `core/tx_authority.py: build_transmit_truth` | provenance-pinned; **no production consumer** |
+
+Non-canonical derivations (3): `backends/yaesu_cat/poller.py: YaesuCatPoller._current_rf_state` / `._current_ptt_observation` (private observation cache, generation + tx-target-generation + age window); `backends/yaesu_cat/poller.py: YaesuCatPoller._poll_fast` (legacy `RadioState.ptt`); `rigctld/handler.py` `t` fallback to `RadioState.ptt`.
+
+PTT truth stores (5): `StateStore global.tx_state.ptt` (canonical), `RadioState.ptt` (legacy mirror, live readers), `YaesuCatPoller._ptt_observation` (private, live), `StateCache.ptt` (dead), `_FallbackRigState.ptt` (dead).
+
+---
+
+# Deletions
+
+### D1 — `core/tx_authority.py` engine: dead, and materially wider than MOR-1973 names
+**Verdict:** dead
+**Elements:** `core/tx_authority.py: TransmitAuthority` and every symbol in that module **except** `TxStateReading`, `RADIO_READBACK_SOURCES`, `TX_READ_DEADLINE_SECONDS`. Plus, as the wider part: `core/radio_protocol.py: TransmitStateReadable.read_transmit_state` and its three implementations — `runtime/radio.py: CoreRadio.read_transmit_state`, `backends/yaesu_cat/radio.py: YaesuCatRadio.read_transmit_state`, `backends/rigctld_client/radio.py: RigctldClientRadio.read_transmit_state` — and `core/tx_authority.py: build_transmit_truth` / `EMPTY_TRANSMIT_TRUTH`.
+**Consumers:** tests only. `tests/test_tx_authority.py`, `tests/contracts/test_tx_authority_conformance.py`, `tests/tx_authority_fakes.py`, `tests/test_tx_policy_shipped_profiles.py`, `tests/test_ftx1_radio.py`.
+**Written / read:** AST-driven sweep of every module-level constant, class, function and `self._x` in the module, cross-counted with `git grep -c -w` against `src/` and `tests/`: **72 of 75 names have zero references outside their own file in `src/`.** The three exceptions are consumed by `runtime/radio.py` (import block near `from rigplane.core.tx_authority import (`). `TransmitAuthority` is never instantiated anywhere in `src/` (`git grep -n "_tx_authority\|TransmitAuthority" -- src` returns only the class definition and two docstring mentions). The module says so itself: *"Nothing in the product consumes this module yet"*.
+**Guards checked:** dynamic access — searched literally; `tests/contracts/test_tx_authority_conformance.py` probes `getattr(harness.radio, "_tx_authority", None)` and `"_tx_authority_deadline_driver"`, both of which resolve to `None` today (observation). Out-of-repo — no `local-extensions/` directory exists in this tree (observation). Public API — `core.tx_authority` is **not** exported from `src/rigplane/__init__.py`, but `TxStateReading` is named in the public `core/radio_protocol.py` docstrings, so the three live symbols are public-adjacent. Tests-only — yes, and the conformance suite is substantial.
+**Collateral:** the whole `tests/contracts/test_tx_authority_conformance.py` suite and `tests/tx_authority_fakes.py` would have to go with a deletion.
+**Depends on:** none.
+**Confidence:** high (that it is unwired); medium (that MOR-1973 already covers the backend read primitives and `build_transmit_truth`).
+**Falsifier:** any `src/` construction of `TransmitAuthority`, or a call to `read_transmit_state` outside tests.
+**Fix class:** none — **do not delete.** This is *migration incomplete*, not abandonment: `docs/plans/2026-08-20-transmit-authority.md` §4 rows 7–10 name this module as the target the seats migrate onto. The report-worthy part is the scope correction: MOR-1973 as quoted to me names "the unwired `TransmitAuthority`"; the unwired surface is bigger — a capability protocol row and three backend read primitives that exist solely to feed it, plus `build_transmit_truth`, all production-dead at HEAD.
+
+---
+
+### D2 — `TxPolicy.refused_during_tx`: shipped profile data with zero readers
+**Verdict:** dead (data side live, reader side absent)
+**Elements:** `profiles/__init__.py: TxPolicy.refused_during_tx`; parser `profiles/rig_loader.py: _parse_tx_policy`. Values shipped in eight profiles: `rigs/ftx1.toml:946` (`refused_during_tx = ["mode", "vfo-topology"]`), and `refused_during_tx = []` in `ic7300.toml`, `ic7610.toml`, `ic705.toml`, `ic9700.toml`, `x6100.toml`, `x6200.toml`, `tx500.toml`.
+**Consumers:** none in `src/`. Tests only: `tests/test_rig_loader.py`, `tests/test_tx_policy_shipped_profiles.py`.
+**Written / read:** `git grep -n "refused_during_tx"` over the whole repo — 8 profile writes, 1 dataclass field, 5 loader/validation lines, 0 reads in `src/`, 14 test lines, 4 ADR lines. Literal search.
+**Guards checked:** dynamic access — the loader builds it by literal key, no `getattr` (observation). Out-of-repo — none visible. Public API — **yes**, `TxPolicy` is exported from `rigplane.profiles`, and the field is user-authorable TOML. Tests-only — yes.
+**Collateral:** `tests/test_tx_policy_shipped_profiles.py` asserts the shipped values.
+**Depends on:** D1 / MOR-1973 — the ADR's INV-10 (`§6`) is the intended reader ("family ∈ `refused_during_tx` ∧ the radio refused ∧ `TransmitTruth` reads TX").
+**Confidence:** high.
+**Falsifier:** any `src/` read of `.refused_during_tx`.
+**Fix class:** none until MOR-1973 lands. Report as staged data, not as deletable.
+
+---
+
+### D3 — `_FallbackRigState`'s PTT members: dead in a live class
+**Verdict:** dead
+**Elements:** `rigctld/handler.py: _FallbackRigState.update_ptt`, and the `ptt` / `ptt_ts` fields on that dataclass (`handler.py:409` — the field line reads `ptt_ts: float = 0.0`, directly under `ptt: bool = False`).
+**Consumers:** none. The class itself is live (`self._cache = _FallbackRigState()`), but only `data_mode`, `update_mode` and `update_data_mode` are touched by `RigctldHandler`, and only `update_s_meter`/`update_rf_power`/`update_swr` by `rigctld/routing.py: YaesuRouting`.
+**Written / read:** `git grep -n -w "update_ptt" -- src tests` → 2 definitions (`core/_state_cache.py`, `rigctld/handler.py`), 1 call site (`runtime/_civ_rx.py`, targeting the *other* class), 0 calls on `_FallbackRigState`. `self._cache` appears 5 times in `handler.py`, none PTT-related.
+**Guards checked:** dynamic access — **relevant here.** `_FallbackRigState.is_fresh` reads `getattr(self, f"{field}_ts", 0.0)`, so `ptt_ts` is reachable by string. But `_FallbackRigState.is_fresh` itself has **zero callers** anywhere (`git grep -n -w "is_fresh" -- src tests`: the hits are all on `StateCache.is_fresh`). Out-of-repo — `_FallbackRigState` is module-private. Public API — no. Tests-only — no test touches it either.
+**Collateral:** none.
+**Depends on:** none. Independent, cheap.
+**Confidence:** high — and independently corroborated by a test docstring already in the tree: `tests/test_tx_authority_characterisation.py: TestPin6PttPollFallsBackToTheMirror` states *"That object does define `update_ptt`, but nothing in `src/` calls it — its `ptt` is dead."*
+**Falsifier:** a caller of `_FallbackRigState.is_fresh("ptt", …)` or of `update_ptt` on that class.
+**Fix class:** delete.
+
+---
+
+### D4 — `StateCache.ptt` / `ptt_ts`: written from the CI-V pump, read by nothing in production
+**Verdict:** dead
+**Elements:** `core/_state_cache.py: StateCache.update_ptt`, fields `ptt` / `ptt_ts`; the `case "ptt":` arm inside `StateCache.is_fresh`; the `"ptt"` / `"ptt_age"` entries in `StateCache.to_dict`. Writer: `runtime/_civ_rx.py`, the line `host._state_cache.update_ptt(bool(frame.data[0]))`.
+**Consumers:** production — none. `StateCache.to_dict` has **zero callers** in `src/` or `tests/` (`git grep -n "\.to_dict()"` — every hit belongs to a different class). `StateCache.is_fresh` is called with `"rf_power"`, `"data_mode"`, `"freq"`, `"mode"` only; never `"ptt"` in `src/`.
+**Written / read:** 1 production write, 0 production reads. Tests: `tests/test_state_cache.py` (5 `update_ptt`, 2 `is_fresh("ptt", …)`), `tests/test_radio.py`, `tests/serial_stub.py`, `tests/integration/test_rigctld_audio_pipeline.py`.
+**Guards checked:** dynamic access — `is_fresh` takes a `CacheField` literal union and `match`es it; no string-built access to `.ptt` (observation). Out-of-repo — `StateCache` is re-exported from `rigplane.rigctld.state_cache` and typed on `core/radio_protocol.py: StateCacheCapable`, so it **is** public surface. Public API — yes. Tests-only — yes, and `tests/test_state_cache.py` would lose assertions.
+**Collateral:** ~7 test assertions; `CacheField`'s `"ptt"` member.
+**Depends on:** none.
+**Confidence:** high. Also recorded in `docs/plans/2026-08-20-transmit-authority.md` §1.4 ("Dead truth: `StateCache.ptt/ptt_ts` … zero readers").
+**Falsifier:** an out-of-repo consumer of `StateCacheCapable.state_cache.ptt` — which the open-core layout cannot rule out from here. **Marked unknown**; this is why the verdict is "dead" but the fix class is hedged.
+**Fix class:** delete the *writer* (the `_civ_rx` line) safely; deleting the public field needs an owner call.
+
+---
+
+### D5 — CW auto-tune's interlock check: a guard that cannot refuse
+**Verdict:** dead (unreachable branch)
+**Elements:** `web/handlers/control.py: ControlHandler._cw_auto_tune` — the `evaluate_tx_interlock(command, rf_state=self._observed_rf_state())` call and the `if not decision.allowed: raise CommandError(...)` under it.
+**Consumers:** the branch has none — `decision.allowed` is constantly `True` here.
+**Written / read:** derivation (inference, from reading the policy tables, not from execution): the command is `SetFreq`. `runtime/tx_interlock.py: classify_tx_interlock` matches `_ALWAYS_PASS_TYPES` (`PttOff`, `ScanStop`), `SetPowerstat`, `SetTunerStatus`, `_HARD_BLOCK_TYPES`, `_DEFER_TYPES` — `SetFreq` is in none of them since MOR-1940 removed FREQUENCY from `_DEFER_TYPES` — so it falls to `TX_SAFE`. The call site passes no `disposition_overrides`, so `_effective_tx_interlock_disposition` returns `TX_SAFE` unchanged, and `evaluate_tx_interlock` returns `allowed=True` before ever looking at `rf_state`.
+**Guards checked:** dynamic access — n/a. Out-of-repo — n/a. Public API — no. Tests-only — no test exercises the raise (searched `tests/` for `_cw_auto_tune` refusal assertions; none).
+**Collateral:** none.
+**Depends on:** none, but the ADR §4 row 9 already schedules this seat for deletion, so a fixer should coordinate.
+**Confidence:** high.
+**Falsifier:** a profile override reaching this call site, or `FREQUENCY` returning to `_DEFER_TYPES`.
+**Fix class:** delete.
+
+---
+
+# Consolidations
+
+### F1 — RF truth for the tuner-engage gate: the loosest of three resolvers guards the one write that throws a relay
+**Verdict:** A — displaced
+**Rank:** **diverged** (copies answer the same input differently, and the divergence is on the fail-open side)
+**Elements:**
+- `web/handlers/control.py: ControlHandler._observed_rf_state` — the loose copy
+- `web/radio_poller.py: RadioPoller._current_rf_state` — the strict copy
+- `rigctld/handler.py: RigctldHandler._resolve_rigctld_rf_state` — the strictest copy
+
+**Consumers:** `_observed_rf_state` — `ControlHandler._ro_set_tuner_status` and `ControlHandler._cw_auto_tune` (the latter is D5, inert). `_current_rf_state` — `RadioPoller._enforce_tx_interlock`, `._stage_tx_interlocked_entries`, `.teardown_unkey_permitted`. `_resolve_rigctld_rf_state` — the rigctld executor pre-gate, `_defer_write_gate`, `_run_key_down_backstop`.
+**Definition site:** each is a private method on its own client class. There is no shared primitive; `runtime/tx_interlock.py` owns only the *decision* (`evaluate_tx_interlock`), never the *truth*.
+**Divergence (observation, from reading all three bodies):** `_observed_rf_state` tests `ptt.freshness is FreshnessState.FRESH and ptt.value is False/True` and nothing else. It does **not** compare `field.provider_generation` against the store's, and it does **not** recompute the age against `field.max_age`. Both other resolvers do both. This matters because `core/state_store.py` states in its own class docstring: *"Freshness decay is **not intrinsic** (MOR-432). The store never ages fields on its own"* — decay happens only when `StateFreshnessService` calls `mark_stale_due`. So between a provider-generation turnover (reconnect) and the next freshness tick, `_observed_rf_state` returns `RX` from the *previous connection's* observation where the other two return `UNKNOWN`.
+**Why this is the sharp end (observation):** `_ro_set_tuner_status` reaches `await radio.set_tuner_status(value)` **directly on the radio** when the backend advertises `CAP_TUNER`, bypassing the command queue and therefore bypassing `RadioPoller._enforce_tx_interlock` entirely. On that path the loose resolver is the *only* RF gate on a `TUNER_ENGAGE` write — the family `core/tx_interlock_contract.py` classifies BLOCK.
+**Adjudication — why displacement, not deliberate:** the competing explanation I tested is *"the tuner seat is a cheap pre-check and the real gate is downstream"*. It is rejected on two observations: (a) the direct-call branch has no downstream gate at all; (b) the docstring on `_observed_rf_state` claims *"fresh, strictly boolean PTT evidence"*, which asserts freshness the code does not establish — a client that believed it had the shared semantics, not one that chose weaker ones. The second explanation, *"nothing shared existed to call"*, is the correct one and is what makes this verdict A rather than C: the code is movable essentially as-is.
+**Prior ruling:** none sanctioning it. The arrangement is *documented* as a defect: `docs/plans/2026-08-20-transmit-authority.md` §1.3 (dated 2026-08-20, re-anchored 2026-08-21) lists "RF-truth resolvers — six spellings of one question" and names `control.py`'s as *"FRESH ∧ bool only — gates the tuner"*; §1.2 calls it *"a fourth, independently wired gate call, on the loosest resolver"*. A design document naming a defect is not a ruling that the defect is correct.
+**In-flight:** ADR §4 row 9 schedules deletion of `_observed_rf_state` together with the tuner seat, once the backend admission lands. Not started — `TransmitAuthority` has zero consumers (D1).
+**Required surface:** one generation-and-age-bound resolver over `StateSnapshot` in a layer at or below `runtime/` that `web/`, `rigctld/` and `backends/` can all import. `core/tx_authority.py: build_transmit_truth` is the closest existing candidate but is provenance-pinned rather than freshness-pinned and answers a different question (display truth, explicitly *"never used for a hazard decision"*).
+**Depends on:** none to fix in place; blocked-by-design on MOR-1973 if the fix is to be the final shape.
+**Confidence:** high on the divergence; **medium** on operational reachability — I did not measure how wide the window between a generation turnover and the next `mark_stale_due` tick is in a running web server.
+**Falsifier:** evidence that `command_state_store`'s freshness service ticks synchronously with `begin_provider_generation`, which would close the window.
+**Fix class:** consolidate
+**Actionable:** yes — hardening `_observed_rf_state` to match `RadioPoller._current_rf_state` is a few lines and independent of MOR-1973.
+**Expensive contract:** **no.** Internal gate; no wire format, public API, profile schema or persisted data changes. (It can *cause* a wire-visible refusal, but the contract itself is internal.)
+
+---
+
+### F2 — The web transmit-safety apparatus lives inside `RadioPoller`, which two shipping backends never start
+**Verdict:** A — displaced (with a genuine coverage hole as the consequence)
+**Rank:** **displacement forcing reimplementation** — one bad location, one client that copied it, one that did not
+**Elements:**
+- `web/web_startup.py` — the three-way branch: `if isinstance(server._radio, ObservationPollable)` → backend's own poller; `elif isinstance(server._radio, StatePollable)` → legacy poller; `else` → `RadioPoller`. Mutually exclusive (observation).
+- `web/radio_poller.py: RadioPoller` — hosts `_enforce_tx_interlock`, `_current_rf_state`, `_stage_tx_interlocked_entries`, `_deferred_tx_lane`, `_arm_max_key_down` / `_cancel_max_key_down` / `_on_max_key_down`, `_refuse_key_from_gone_session`, `teardown_unkey_permitted`, `_last_keyer`, `_managed_tx`
+- `backends/yaesu_cat/poller.py: YaesuCatPoller` — the copy: `_current_rf_state`, `_drain_commands`, `_execute_command`, `_deferred_tx_lane`, `_deferred_tx_entry`, `_emit_deferred_entry_held`, `_deferred_release_is_live`
+- `backends/rigctld_client/radio.py: RigctldClientObservationPoller._drain_commands` / `._execute_command` — **no copy at all**
+
+**Consumers, per implementation:** `RadioPoller` — Icom CI-V radios only. `YaesuCatPoller` — FTX-1 (a live bench radio). `RigctldClientObservationPoller` — every hamlib-provider radio behind the Web UI.
+**Divergence (observation):**
+- `git grep "tx_interlock\|RfState\|evaluate_tx" -- src/rigplane/backends/rigctld_client/` returns **zero matches**. `RigctldClientObservationPoller._execute_command` contains `case PttOn(): await self._radio.set_ptt(True)` with no gate above it. Web-queued writes to a hamlib-provider radio pass no TX interlock at all.
+- `refuse_key_without_owner` / `bind_managed_tx` (`runtime/managed_tx_ingress.py`) appear in `web/radio_poller.py`, `web/tx_safety_view.py`, `rigctld/handler.py` — and in neither backend poller. (This half is MOR-1190.)
+- `RadioPoller._arm_max_key_down` (the 180 s unmanaged key-down bound) exists only on the Icom branch. A web key on FTX-1 or on a hamlib-provider radio has **no** bound.
+- `web/handlers/control.py: ControlHandler._release_ptt_on_teardown` consults `getattr(self._server, "_radio_poller", None)` for `teardown_unkey_permitted`; on both other branches that attribute is `None`, so the MOR-1878 keyer-identity check is skipped and the teardown unkey is unconditional.
+
+**Adjudication — why displacement, not deliberate:** the competing explanation is *"each backend legitimately owns its own drain, so per-backend gates are correct"*. Rejected on the evidence that the queue being drained is **the Web UI's own** `CommandQueue`, handed across by `web/web_startup.py` via `create_observation_poller(command_queue=server._command_queue)`; the Yaesu poller's own docstring says *"Commands come from the web UI CommandQueue"*. A web-owned policy is being enforced (or not) in three places chosen by backend identity, not by policy. The import graph is legal throughout — which is exactly the blind spot the method describes.
+**Prior ruling:** none sanctioning it. `docs/plans/2026-08-20-transmit-authority.md` §1.2, last row, names this arrangement and calls it *"load-bearing for placement (§3.2): any gate that wraps the radio object from outside never sees the web write path of two shipping backends, one of them a bench radio."* §3.2 rules the correct seat is the **backend write method**, not any poller — so the Yaesu copy is in the wrong place too, by the same design.
+**In-flight:** target is `core/tx_authority.py` (D1), unconsumed; rows 7–10 not started.
+**Required surface:** an admission at the last typed hop before transport on every backend, per ADR §3.2 — or, as a cheap interim that needs no design decision, calling the existing `runtime/tx_interlock.py: evaluate_tx_interlock` from `RigctldClientObservationPoller._execute_command` the way `YaesuCatPoller._execute_command` already does.
+**Depends on:** the interim fix depends on nothing; the final shape depends on MOR-1973.
+**Confidence:** high.
+**Falsifier:** a gate on the rigctld-client write path that my literal search missed — e.g. one applied inside `RigctldClientRadio.set_ptt`. I read that method's neighbourhood and saw none, but I did not read the full 800-line class.
+**Fix class:** consolidate (interim) / design (final)
+**Actionable:** yes for the rigctld-client gap; no for the full consolidation until the ownership question in MOR-1973 is settled.
+**Expensive contract:** **yes** — closing the rigctld-client gap changes observable behaviour on the wire for hamlib-provider radios (writes that succeed today would start being refused during TX). Not a schema change, but a behavioural one that a downstream client can see.
+
+---
+
+### F3 — Same refusal, two wire payloads: the FTX-1 web client cannot tell an interlock refusal from a generic failure
+**Verdict:** A — displaced
+**Rank:** **diverged**
+**Elements:**
+- `web/radio_poller.py: RadioPoller._enforce_tx_interlock` raises `runtime/tx_interlock.py: TxInterlockRefusal` carrying `reason_code` ∈ {`radio_transmitting`, `rf_state_unknown`}; `RadioPoller._mark_queued_command_failed` turns it into `details={"blockedBy": "tx_interlock", "reason": …}`; `web/server.py` whitelists exactly that shape onto the websocket `failed` envelope.
+- `backends/yaesu_cat/poller.py: YaesuCatPoller._drain_commands` and `._execute_command` raise a bare `CommandError(decision.reason)`; `YaesuCatPoller._mark_queued_command_failed` builds `params` with `message` / `timed_out` / `session_id` / `source` and **no `details` key at all**.
+
+**Consumers:** the web frontend. The whitelist comment in `web/server.py` states the codes *"map onto the existing i18n keys (core.rxTx.blocked.rfStateUnknown / radioTransmitting)"*.
+**Definition site:** `TxInterlockRefusal` is defined in the shared `runtime/tx_interlock.py`, reachable by both — so this is not a "nothing to call" case.
+**Divergence (observation):** identical policy decision, identical `decision.reason` string, two different envelopes. On Icom the operator gets a localized "radio is transmitting"; on FTX-1 the same refusal arrives as an untyped failure. Note the asymmetry is *partial*: `YaesuCatPoller._emit_deferred_entry_held` **does** emit the matching `{"heldBy": "tx_interlock", "reason": "tx_active", "expiresAt": …}` details, so the *held* path is consistent and only the *refused* path is not. That partial match is what makes "deliberate divergence" implausible.
+**Adjudication:** competing explanation — *"Yaesu deliberately reports less"*. Rejected: nothing documents such a choice, `TxInterlockRefusal` is in the shared module precisely so any seat can raise it (its docstring: *"Lives beside the policy it reports rather than at a seat that raises it … every enforcement seat may need them"*), and the held-path envelope already matches.
+**Prior ruling:** none found. MOR-1879 (`b3ab76b1`) landed the typed envelope on the web seat only.
+**In-flight:** none.
+**Required surface:** exists — raise `TxInterlockRefusal` in `YaesuCatPoller` and mirror the `details` branch in its `_mark_queued_command_failed`.
+**Depends on:** none.
+**Confidence:** high.
+**Falsifier:** a Yaesu-path test asserting the untyped envelope as intended behaviour.
+**Fix class:** consolidate
+**Actionable:** yes — small and self-contained.
+**Expensive contract:** **yes** — the websocket `failed` envelope is a wire contract with a whitelist in `web/server.py` and matching frontend i18n keys.
+
+---
+
+### F4 — Two unmanaged key-down backstops with different cancellation rules
+**Verdict:** A — displaced
+**Rank:** **diverged**
+**Elements:**
+- `web/radio_poller.py: RadioPoller._arm_max_key_down` / `._cancel_max_key_down` / `._on_max_key_down` (MOR-1220)
+- `rigctld/handler.py: RigctldHandler._arm_key_down_backstop` / `._run_key_down_backstop` / `._void_key_down_backstop` / `.stop_key_down_backstop` / `._ptt_observed_after` (MOR-1904)
+- `core/tx_safety.py: TxSafetySupervisor.tick` (the managed third, for radios that arm a supervisor)
+- `core/tx_authority.py: TransmitAuthority._commit` / `.poll` (a fourth, unwired — see D1)
+
+**Consumers:** the web command drain; the rigctld PTT route; `runtime/managed_radio_runtime.py`'s tick loop; nothing.
+**Definition site:** only the *duration* is shared — `core/tx_safety.py: BACKEND_MAX_KEY_DOWN_SECONDS` (180.0), imported by both. The *mechanism* is written twice.
+**Divergence (observation, from both bodies):** the web one is a `loop.call_later` timer that fires with **no RF check whatever** and enqueues `PttOff`; it is cancelled by its own unkey, by a re-key, and by the poller stopping. The rigctld one is a task ticking every 0.25 s (`_KEY_DOWN_BACKSTOP_TICK_SECONDS`) that additionally **vetoes on an observed causal return to RX** and, at server stop, cancels with a warning rather than firing. So the same 180 s bound behaves differently depending on which seat keyed. This is documented as a user-facing asymmetry in `docs/guide/cli.md` — the rigctld bound is *"cancelled by any `rigctld` PTT write of either polarity, by the server stopping, **and** — unlike the poller's — by an observed return to receive after that key."*
+**Adjudication:** competing explanation — *"different seats have different evidence available, so different vetoes are correct"*. Partially credited and then rejected: `RigctldHandler._run_key_down_backstop`'s own docstring argues its veto is *"Still strictly safer than the accepted precedent: MOR-1220 fires with no RF check whatever, so this adds a veto and removes none"* — i.e. the author knew the two differ and judged one strictly better. A strictly-better second implementation of the same mechanism is duplication whose weaker half was left in place, not a deliberate specialization. Both seats read the same `StateStore`; the evidence available is the same.
+**Prior ruling:** `docs/guide/cli.md` *describes* the divergence to operators. Describing is not sanctioning; no ADR row rules that the two must stay separate. ADR §1.5 lists them as *"three bounding mechanisms … MOR-1904 added a fourth"*, in a section titled "the corrected inventory" — i.e. as inventory of a problem.
+**In-flight:** none for these two. `TransmitAuthority`'s deadline is the intended eventual single owner (D1).
+**Required surface:** a shared bound object taking (arm instant, clock, RF resolver, unkey callable) at or below `runtime/`. Does not exist.
+**Depends on:** F1 — a shared bound needs a shared RF resolver first, or it will inherit whichever copy it is handed.
+**Confidence:** high.
+**Falsifier:** an owner ruling that the RX veto must not apply to web-issued keys.
+**Fix class:** consolidate
+**Actionable:** yes, but rank it after F1.
+**Expensive contract:** **no** — behaviour change only; nothing crosses a schema or wire boundary. (It would change when a stuck key is released, which is operator-visible.)
+
+---
+
+### F5 — `tx_active` for the acquisition scheduler: two byte-identical copies
+**Verdict:** A — displaced
+**Rank:** **parallel** (identical behaviour; maintenance cost only)
+**Elements:**
+- `rigctld/server.py: RigctldServer._derive_tx_active`
+- `web/radio_poller.py: RadioPoller._send_scheduler_requests` — the inline derivation, `tx_active = ptt_field.freshness is FreshnessState.FRESH and bool(ptt_field.value)` with a `KeyError → False` fallback
+
+**Consumers:** `core/acquisition_scheduler.py: AcquisitionScheduler.note_tx_active` / `.due_requests` — the `tx_only` cadence gate.
+**Definition site:** neither. The consumer is shared; the derivation is not.
+**Divergence:** **none.** The rigctld docstring says so outright: *"Derived identically to the web poller (MOR-1525 / PR #2438)."*
+**Adjudication:** competing explanation — *"a two-line predicate is not worth sharing"*. Genuinely arguable, and I credit it: this is the least urgent finding in the list. What tips it is that MOR-1525 records this exact predicate having been *wrong once already* (it read `RadioState.ptt` and desynced, producing a visible SWR flap), and it now exists in two places that must be fixed together. The scheduler layer (`core/acquisition_scheduler.py`) is below both clients and could host it.
+**Prior ruling:** none. `AcquisitionScheduler.note_tx_active`'s docstring argues the two *cannot disagree* — which is a claim about today's identical copies, not a mechanism preventing drift.
+**In-flight:** none.
+**Required surface:** a `tx_active_from_snapshot(snapshot)` helper on the scheduler module or on `core/state_store.py`.
+**Depends on:** none. Independent of F1 — this gate is fail-closed-to-`False` and is a polling-cadence decision, not a safety decision, so it does not need F1's strictness.
+**Confidence:** high.
+**Falsifier:** a deliberate future divergence between standalone-rigctld and web cadence.
+**Fix class:** consolidate
+**Actionable:** yes, low priority.
+**Expensive contract:** **no.**
+
+---
+
+### F6 — Yaesu's legacy meter gate still reads the mirror that MOR-1525 removed on the web side
+**Verdict:** undetermined (verdict A if the branch is reachable; dead branch if not)
+**Rank:** diverged
+**Elements:**
+- `backends/yaesu_cat/poller.py: YaesuCatPoller._poll_fast` — the `if state.ptt and "meters" in self._caps:` branch, reading `self._radio.radio_state`
+- `backends/yaesu_cat/poller.py: YaesuCatPoller._emit_fast_observations` — the modern sibling, which uses `_current_ptt_observation()`
+- `web/radio_poller.py: RadioPoller._send_scheduler_requests` — the same capability on the Icom side, moved *off* the mirror by MOR-1525
+
+**Consumers:** `_poll_fast`'s legacy branch runs only when `self._observation_callback is None`, i.e. when the poller was built by `YaesuCatRadio.create_state_poller`. `web/web_startup.py` prefers `ObservationPollable`, and `YaesuCatRadio` implements both, so the web path never reaches it (observation). `create_state_poller` is on the public `core/radio_protocol.py: StatePollable` protocol, so a downstream caller can reach it.
+**Divergence (observation):** the web side's comment records why the mirror was abandoned — *"The mirror was live-proven to desync from the canonical fact: after a TX it stayed True while the StateStore's own observation had already flipped False in RX … operator-visible as the SWR readout flapping 0<->1, MOR-1525."* The Yaesu legacy branch still gates on exactly that mirror.
+**Adjudication:** I am not calling this a live defect, because I could not establish reachability in the shipped web startup. It is a *vestigial fork with the known-bad half retained*: two implementations of "poll TX meters while transmitting", one fixed, one not.
+**Prior ruling:** none. Not in ADR §1.3's six-resolver list.
+**In-flight:** none.
+**Required surface:** none new — `_current_ptt_observation()` is already on the same class.
+**Depends on:** none.
+**Confidence:** medium.
+**Falsifier:** a production caller of `YaesuCatRadio.create_state_poller`, which would make it a live defect; or a decision to delete the legacy branch, which would make it a deletion.
+**Fix class:** delete the legacy branch, or repoint it at `_current_ptt_observation()`
+**Actionable:** yes, cheaply, either way.
+**Expensive contract:** **no.**
+
+---
+
+### F7 — `[tx_interlock].disposition_overrides`: a documented profile key honoured by one of four enforcement seats
+**Verdict:** B — gap (the shared policy accepts overrides; three of four seats never pass them)
+**Rank:** displacement forcing reimplementation
+**Elements:**
+- `profiles/rig_loader.py: _parse_tx_interlock_disposition_overrides` — parses and validates
+- `profiles/__init__.py: RadioProfile.tx_interlock_disposition_overrides` — carries them
+- `runtime/tx_interlock.py: evaluate_tx_interlock` / `_effective_tx_interlock_disposition` — accept them
+- **Passes them:** `backends/yaesu_cat/poller.py: YaesuCatPoller._tx_interlock_disposition_overrides`, at three call sites
+- **Does not pass them:** `web/radio_poller.py: RadioPoller._enforce_tx_interlock` and `._stage_tx_interlocked_entries`; `web/handlers/control.py: ControlHandler._ro_set_tuner_status` and `._cw_auto_tune`; `rigctld/handler.py: _classify_rigctld_tx_intent` (calls `classify_tx_interlock`, the un-overridden form); `backends/rigctld_client/` (no interlock at all — F2)
+
+**Consumers:** none in production data. `git grep -rn "tx_interlock" rigs/` returns only `rigs/_schema.md`; no shipped profile sets it. The ADR states the same at §1.1: *"zero shipped TOMLs use it"*.
+**Divergence (observation):** if any profile ever set `disposition_overrides = { "frequency" = "defer" }`, an FTX-1 would honour it and every Icom, rigctld and hamlib-provider path would silently ignore it.
+**Adjudication:** not dead — the loader, the validator, the schema doc and one reader all exist. Not a duplicate — one honest reader. It is a **gap**: the shared policy exposes a parameter the shared *seat* would have to pass, and there is no shared seat. `rigs/_schema.md` documents it as a general profile capability with no hint of the restriction, which under this repo's own prose rule (`CLAUDE.md`: *"could this be false without any test failing?"*) is a claim stated wider than the code.
+**Prior ruling:** none limiting it to Yaesu.
+**In-flight:** the ADR's target seat (backend write method) would give a single reader; not started.
+**Required surface:** either a single seat that always passes profile overrides, or an explicit narrowing of the schema doc to say which backends honour the key.
+**Depends on:** F2 — the same missing single seat.
+**Confidence:** high.
+**Falsifier:** a shipped profile using the key on a non-Yaesu rig, which would turn this into a live defect rather than a latent one.
+**Fix class:** design
+**Actionable:** partly — the doc narrowing is actionable now; the seat is not.
+**Expensive contract:** **yes** — `[tx_interlock]` is a documented, user-authorable profile-schema key (`rigs/_schema.md`, "`[tx_interlock]` — Profile Tightening Metadata").
+
+---
+
+## Weakest link
+
+**F1's operational reachability.** I established the *code* divergence with certainty: `ControlHandler._observed_rf_state` checks neither provider generation nor the age window, and both peer resolvers check both. What I did **not** establish is how wide the window is in a running web server — that is, how long a superseded-generation or TTL-expired `global.tx_state.ptt` field can remain flagged `FRESH` before `StateFreshnessService` decays it. If that service ticks synchronously with `begin_provider_generation`, F1 collapses from "fail-open gate on a relay-throwing write" to "redundant checks the other two carry for defence in depth". **Check first:** the tick cadence and trigger of `StateFreshnessService.run` in `core/acquisition_scheduler.py`, and whether `web/server.py` drives it from the same task that advances the provider generation.
+
+Secondary: F6's reachability. I inferred that `web/web_startup.py`'s `elif` can never fire for `YaesuCatRadio` because the class satisfies both protocols; I did not verify the runtime `isinstance` result against `ObservationPollable` under Python 3.11's protocol semantics, which this repo has been bitten by before (gh-102433).
+
+---
+
+## Cleared — examined and healthy, by name
+
+- **`runtime/tx_interlock.py`** — the disposition policy itself. One implementation, four consumers across `web/`, `rigctld/` and `backends/`, correct layer (below every client, imports only `core/`). `classify_tx_interlock`, `evaluate_tx_interlock`, `get_tx_interlock_command_family_metadata`, `DeferredTxCommandLane` are **already shared**. The premise "the interlock is duplicated" is wrong at the policy level; only the truth input and the driver loops are duplicated.
+- **`core/tx_interlock_contract.py`** — the 4×17 disposition/family table. Zero dead names in the AST sweep. Single source, no `rigplane` imports, correctly foundational.
+- **`runtime/managed_tx_ingress.py`** — `resolve_supervisor`, `bind_managed_tx`, `refuse_key_without_owner`. This is a consolidation that *landed*: three call sites (`web/radio_poller.py`, `web/tx_safety_view.py`, `rigctld/handler.py`) share one two-step supervisor read, correctly placed in `runtime/` for exactly the reason its docstring gives. Clean. One documentation nit, not a mechanism finding: the module docstring says *"the CLI/SDK already do too"*, but `git grep "bind_managed_tx\|refuse_key_without_owner" -- src/rigplane/cli src/rigplane/runtime/sync.py` returns zero — they call `core/radio_protocol.py: ManagedTxApi.bind` directly with a process-lifetime `TxOwner`, which `_stable_owner` would refuse by design.
+- **`web/tx_safety_view.py`** — `build_tx_safety_payload`. Pure read-only projection of the supervisor snapshot; asks the key path's own predicate rather than re-deriving eligibility. No second copy of anything. Correctly located in `web/` (it shapes a web document).
+- **`commands/ptt.py`** — `ptt_on` / `ptt_off`. Exactly one CI-V PTT frame builder pair, one consumer (`runtime/radio.py: CoreRadio.set_ptt`). No second frame construction anywhere in `src/` outside `commands/`. Yaesu's CAT encoding is separate and is sanctioned per-protocol duplication.
+- **`core/tx_safety.py: TxSafetySupervisor`** — the managed lease/watchdog/durable-OFF reducer. One implementation, driven by `runtime/managed_radio_runtime.py`, projected by `web/tx_safety_view.py`, bound through `ManagedTxApi` / `PrivilegedTxApi`. Its unreferenced `TxReleaseReason` members (`APP_SHUTDOWN`, `AUDIO_FAILED`, `CAPABILITY_LOST`, `EXTERNAL_CAT_PREEMPTED`, `PERMIT_LOST`, `RADIO_TRANSPORT_LOST`) are **not** dead code: they are a closed vocabulary, exhaustively enumerated by design, and several are consumed via `_SYSTEM_RELEASE_REASONS`. Explicitly cleared so a later sweep does not re-flag them.
+- **`core/radio_protocol.py: ManagedTxCapable` / `ManagedTxApi` / `PrivilegedTxApi`** — the `getattr_static` + explicit-read discipline is written once and reused; `PrivilegedTxApi` has exactly one consumer (`cli/__init__.py`) and correctly declines to bind a supervisor without `force_unkey`.
+- **`runtime/_civ_rx.py`** PTT observation path — `bind_ptt_observer`, `request_authoritative_ptt_read`, `_emit_authoritative_ptt`, `_ptt_read_is_current`, `write_managed_ptt`. One implementation of generation-bound authoritative PTT readback; the identity checks are `is`-based throughout, consistent with the known `==`-vs-`is` hazard in this file. No duplicate found.
+- **`core/tx_target.py`** and `runtime/managed_ptt_lifecycle.py` / `managed_tx_effect_service.py` — swept for dead names; every flagged name is a module-private helper used inside its own file. No orphans.
+- **`profiles/rig_loader.py: _parse_tx_policy`** and `TxPolicy.is_receiving` / `.attribution` — live, single reader (`backends/yaesu_cat/radio.py: YaesuCatRadio._interpret_ptt_token`). Only the `refused_during_tx` sibling is reader-less (D2).

--- a/.claude/audits/README.md
+++ b/.claude/audits/README.md
@@ -1,0 +1,57 @@
+# Mechanism-audit reports
+
+Archived, point-in-time outputs of the `auditor` role running the
+`.claude/skills/mechanism-audit/SKILL.md` method. Each report pins the exact
+revision it audited in its own header; citations inside a report (including
+`file:line` forms used where no symbol encloses the evidence) are frozen at
+that revision and are not maintained. These files live under `.claude/` rather
+than `docs/` deliberately: the doc-citation gate treats `docs/**` citations as
+living references that must not use line numbers, while an archived audit is
+evidence about one commit and must quote it verbatim.
+
+## 2026-08-30 — v3 pre-release audit (three tracts, tree `8c8a70d4`)
+
+Commissioned to close the pre-release fix list before the v2.12.0 release
+cycle. One report per tract:
+
+- [2026-08-30-mechanism-audit-command-path.md](2026-08-30-mechanism-audit-command-path.md)
+  — UI/rigctld/CLI action → wire bytes. Headline findings: rigctld advertises
+  IC-7610 capability data for every Icom and invents ATT/PREAMP domains
+  (F1/F2, live-reachable bugs on both bench radios); per-receiver write
+  routing duplicated with a `receiver=0` contract split (F3); queue-drain and
+  deferred-TX lane written twice (F4); queue dedup key undoes the MOR-1499
+  coalescing fix one layer down (F6).
+- [2026-08-30-mechanism-audit-tx-truth.md](2026-08-30-mechanism-audit-tx-truth.md)
+  — everything deriving or gating on "is the radio transmitting". Headline:
+  eight live derivations of TX truth (MOR-1973 said three); the rigctld-client
+  backend's web write path has no TX interlock and no key-down bound (F2); the
+  tuner-engage write is gated by the loosest resolver on a queue-bypassing
+  path (F1); interlock refusal envelope typed on Icom, untyped on FTX-1 (F3).
+- [2026-08-30-mechanism-audit-state-feedback.md](2026-08-30-mechanism-audit-state-feedback.md)
+  — radio truth → screen → control feedback. Headline: two S-unit algorithms
+  disagreeing on FTX-1 at the profile's own anchors (F1); TX state-feedback
+  decision duplicated byte-identically across both design languages while its
+  nested visual descriptors are computed and discarded (F2); `StateStore`
+  history retention deep-copies every observation for a `delta_since` API
+  with zero production consumers (D7).
+
+Owner rulings recorded 2026-08-30 (they supersede in-report recommendations
+where they differ):
+
+1. `receiver=0` means literal MAIN, always; encapsulate the
+   switch-write-restore mechanism in the runtime write path and delete the
+   web poller's inline copy (command-path F3).
+2. Transmit-state interpretation goes through the profile's `tx_state_map` on
+   every vendor, Icom included (closes TX-authority ADR Q14).
+3. Consolidate the TX state-feedback decision into one shared resolver; the
+   nested descriptor bodies are deletable (no consumer exists — verified same
+   day, including the built-dist browser suite); `.text` stays per MOR-1482.
+4. `delta_since` + the history retention are deleted **before** the release
+   (dead public API must not be frozen by a release); the same rule applies to
+   the other dead public-surface findings.
+5. Meter-conversion divisors become profile-calibration data; the four inline
+   STRENGTH copies collapse onto the existing helper first (text-neutral).
+
+Ticket disposition for every actionable finding is tracked in Linear (the
+2026-08-30 pre-release epic and the documents mirroring these reports); the
+reports themselves are the evidence record, not the work queue.

--- a/.claude/audits/README.md
+++ b/.claude/audits/README.md
@@ -7,18 +7,20 @@ revision it audited in its own header; citations inside a report (including
 that revision and are not maintained. These files live under `.claude/` rather
 than `docs/` deliberately: the doc-citation gate treats `docs/**` citations as
 living references that must not use line numbers, while an archived audit is
-evidence about one commit and must quote it verbatim. Unlike the rest of
-`.claude/` — untracked scratch for working notes — this directory is tracked
-and **published in a public repository**: never put session notes, baselines,
-or anything with internal identifiers here.
+evidence about one commit and must quote it verbatim. Like `agents/`,
+`commands/` and `skills/`, this directory is tracked and **published in a
+public repository** — never put session notes, baselines, or anything with
+internal identifiers here; untracked working notes belong in the ignored
+remainder of `.claude/`.
 
 ## 2026-08-30 — v3 pre-release audit (three tracts, tree `8c8a70d4`)
 
 Commissioned to close the pre-release fix list before the v2.12.0 release
 cycle. The audited commit `8c8a70d4` was squash-merged as main's `3ba1a14a`
 (byte-identical tree), and the original commit survives as
-`refs/pull/2801/head` — so the pin resolves even from a fresh clone via
-either route. One report per tract:
+`refs/pull/2801/head` — fetch that ref explicitly to resolve the pin; a
+plain clone carries only the identical tree, via `3ba1a14a`. One report per
+tract:
 
 - [2026-08-30-mechanism-audit-command-path.md](2026-08-30-mechanism-audit-command-path.md)
   — UI/rigctld/CLI action → wire bytes. Headline findings: rigctld advertises

--- a/.claude/audits/README.md
+++ b/.claude/audits/README.md
@@ -7,12 +7,18 @@ revision it audited in its own header; citations inside a report (including
 that revision and are not maintained. These files live under `.claude/` rather
 than `docs/` deliberately: the doc-citation gate treats `docs/**` citations as
 living references that must not use line numbers, while an archived audit is
-evidence about one commit and must quote it verbatim.
+evidence about one commit and must quote it verbatim. Unlike the rest of
+`.claude/` — untracked scratch for working notes — this directory is tracked
+and **published in a public repository**: never put session notes, baselines,
+or anything with internal identifiers here.
 
 ## 2026-08-30 — v3 pre-release audit (three tracts, tree `8c8a70d4`)
 
 Commissioned to close the pre-release fix list before the v2.12.0 release
-cycle. One report per tract:
+cycle. The audited commit `8c8a70d4` was squash-merged as main's `3ba1a14a`
+(byte-identical tree), and the original commit survives as
+`refs/pull/2801/head` — so the pin resolves even from a fresh clone via
+either route. One report per tract:
 
 - [2026-08-30-mechanism-audit-command-path.md](2026-08-30-mechanism-audit-command-path.md)
   — UI/rigctld/CLI action → wire bytes. Headline findings: rigctld advertises
@@ -42,7 +48,9 @@ where they differ):
    switch-write-restore mechanism in the runtime write path and delete the
    web poller's inline copy (command-path F3).
 2. Transmit-state interpretation goes through the profile's `tx_state_map` on
-   every vendor, Icom included (closes TX-authority ADR Q14).
+   every vendor, Icom included. This answers TX-authority ADR Q14; the ADR's
+   own §9 table still records Q14 as open, and amending it belongs to the
+   epic's decode ticket, not to this archive.
 3. Consolidate the TX state-feedback decision into one shared resolver; the
    nested descriptor bodies are deletable (no consumer exists — verified same
    day, including the built-dist browser suite); `.text` stays per MOR-1482.

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ node_modules/
 config/
 .claude/*
 !.claude/agents/
+!.claude/audits/
 !.claude/commands/
 !.claude/skills/
 .kombai/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,8 @@ nothing prompts for them; each drop has a cost paid later:
   impression rather than a comparison. The coordinator records it during
   PLAN, before EXECUTE, in the run's own working notes — not a tracked file:
   `.gitignore` excludes everything under `.claude/` except `agents/`,
-  `commands/`, and `skills/`.
+  `audits/`, `commands/`, and `skills/` — and `audits/` is a published
+  archive (see its README), never a place for working notes.
 - **TEST is the four gates `solve-issue.md` Phase 6 enumerates**: the
   standard pytest suite, `ruff check`, `ruff format`, and `mypy`, run by the
   coordinator.


### PR DESCRIPTION
## What

Archives the three mechanism-audit reports produced 2026-08-30 by the `auditor` role (method: `.claude/skills/mechanism-audit/SKILL.md`, merged in #2801) over the command path, the transmit-truth path, and the state/control-feedback path, all audited at `8c8a70d4`. Adds `.claude/audits/` to the .gitignore whitelist and an index README recording the owner rulings of 2026-08-30 that supersede in-report recommendations.

## Why

These reports are the evidence record behind the pre-release fix list (owner-approved 2026-08-30) and the Linear ticket package referencing them. Without archiving, the only copies die with the coordinating session; re-running three Opus audits to re-derive the same evidence costs hours.

## Placement

`.claude/audits/`, not `docs/`, deliberately: the doc-citation gate forbids new `file:line` citations anywhere under `docs/**`, and rightly so for living documentation — but an archived audit is a snapshot that must quote its pinned revision verbatim, line numbers included. The README states this so the next reader does not "fix" it by moving the files.

## Size — hard-ceiling exception requested

1194 added lines / 1 deletion across 6 files at head ff4c8e88 (re-measured after the B3 fix; 1182/5 before the review cycle), over the 1000-line hard ceiling. Per the guardrails this is not author-waivable: **@morozsm, please grant the exception in a comment before merge** (owner ordered this content preserved in-repo, 2026-08-30 session; precedent: #2806 at 1063 lines). Content is archived evidence plus a two-line CLAUDE.md canon correction the review required — no source, test, or build file is touched.

## Checks

No `src/`, `tests/`, `frontend/`, or workflow paths are touched, so the quick CI suite does not run by path filter; the doc-citation gate is unaffected (no `docs/**` change). Independent agent review will be posted separately per the review policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

