### PR TITLE
docs: note where finished mechanism-audit reports are archived

### DIFF
--- a/.claude/skills/mechanism-audit/SKILL.md
+++ b/.claude/skills/mechanism-audit/SKILL.md
@@ -247,6 +247,15 @@ Close every report with two sections:
   without this section cannot be trusted: it offers no evidence the auditor was
   capable of clearing anything.
 
+## Archiving
+
+Finished reports are archived in the audited repository under
+`.claude/audits/`, one file per tract, named
+`YYYY-MM-DD-mechanism-audit-<tract>.md`, with a header pinning the audited
+revision. That directory is tracked and published in the public repository —
+its `README.md` indexes the reports and carries the caution about what must
+never be committed there.
+
 ## Inputs the repository must supply
 
 - **Layer map** — which layer may own mechanism, and the allowed dependency


### PR DESCRIPTION
## What

Adds a short **Archiving** section (9 lines, one file) to `.claude/skills/mechanism-audit/SKILL.md`, between *Report format* and *Inputs the repository must supply*.

## Why

The mechanism-audit method file said nothing about where a finished report is archived, so a future auditor following the method would not learn that `.claude/audits/` exists (created in #2835). The new section records:

- finished reports are archived under `.claude/audits/`, one file per tract;
- the naming convention `YYYY-MM-DD-mechanism-audit-<tract>.md`;
- each report's header pins the audited revision;
- the directory is tracked and published in the public repo — the caution about what must never be committed there lives in `.claude/audits/README.md`.

## Notes

- Docs-only; no code, tests, or CI-gated paths touched. Consistent with the `.claude/` whitelist prose in CLAUDE.md and with `.claude/audits/README.md` (neither file is modified).
- Well under guardrails (1 file, +9/-0).
- Pipeline: EXECUTE by `builder`; independent `verifier` review follows as a relayed comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)