### PR TITLE
test(MOR-2038): generalize skin entrypoint pins over the registry

### DIFF
--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -1,15 +1,18 @@
 /**
- * MOR-2038 — a behavioral entry-point pin for every `SkinId` registered in
- * `skins/registry.ts`, generalized over that registry instead of a
- * hardcoded pair list (the previous version of this file covered only
- * `desktop-v2`/`sdr-test`).
+ * MOR-2038 — every `SkinId` registered in `skins/registry.ts` has a
+ * behavioral entry-point pin: five directly in this file, the sixth
+ * (`dual-receiver-cockpit`) in its own dedicated suite, referenced and
+ * guarded here (point 2 below) rather than duplicated. Generalized over the
+ * registry instead of a hardcoded pair list (the previous version of this
+ * file covered only `desktop-v2`/`sdr-test`).
  *
  * `SKIN_LOADERS` — the registry's `Record<SkinId, () => Promise<...>>` of
- * lazy dynamic imports — is not exported; only `loadSkin(id)` is. So every
- * case below fetches its component through `loadSkin`, the same function
- * `App.svelte` calls, instead of importing a skin's `.svelte` file directly.
- * A loader repointed at the wrong module is visible here exactly as it
- * would be to the app.
+ * lazy dynamic imports — is not exported; only `loadSkin(id)` is. Every case
+ * below that mounts a component fetches it through `loadSkin`, the same
+ * function `App.svelte` calls, instead of importing a skin's `.svelte` file
+ * directly — a loader repointed at the wrong module is visible here exactly
+ * as it would be to the app. The one exception is the `dual-receiver-cockpit`
+ * coverage guard (point 2 below), which mounts nothing itself.
  *
  * Completeness has two layers, because there is no runtime-enumerable list
  * of `SkinId` values to iterate — the union has no runtime representation,
@@ -23,11 +26,17 @@
  *    `vitest run` would NOT catch it: Vite/esbuild transpile this file by
  *    stripping types, so a table that silently fell out of sync would still
  *    run, just without the new id.
- * 2. For the two ids whose coverage lives in another file
- *    (`dual-receiver-cockpit`, `mobile`), the 'skin entrypoint coverage
- *    completeness' suite asserts the named file still exists and still
- *    mentions the skin's own entry component, so a rename or deletion over
- *    there turns this file red instead of the exemption rotting silently.
+ * 2. For the one id whose coverage lives in another file
+ *    (`dual-receiver-cockpit`), a dedicated suite below checks that the
+ *    named file still exists and its source text still contains the skin's
+ *    entry-component filename. That is a substring check, not a behavioral
+ *    one — it cannot confirm a test in that file actually mounts the
+ *    component, only that a prior manual confirmation of that hasn't
+ *    visibly rotted (the file deleted, renamed, or edited to drop the
+ *    reference). `mobile` used to live in this same bucket, on a file that,
+ *    on closer reading, never mounted `MobileSkin` at all — it only
+ *    `?raw`-imported it as a text fixture — so it now gets a real mount pin
+ *    instead (below), the same way `lcd-cockpit`/`lcd-scope` do.
  *
  * `lcd-cockpit`/`lcd-scope` get a real mount pin for the first time here.
  * Both wrappers are zero-prop and hardcode a `variant` literal into
@@ -37,6 +46,12 @@
  * and `...autostep-lifecycle.isolated.test.ts` — nothing here duplicates
  * that. This file pins only the two wrappers' half: that each forwards its
  * own literal down, not LcdLayout's behavior for either value.
+ *
+ * `mobile` gets a real mount pin the same way: `MobileSkin.svelte` is a
+ * zero-prop delegate straight to `MobileRadioLayout`, so its pin mocks
+ * `MobileRadioLayout.svelte` (the same technique as the `RadioLayout`/
+ * `LcdLayout` mocks above) and asserts that loading `mobile` actually
+ * mounts it.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { mount, unmount } from 'svelte';
@@ -45,6 +60,7 @@ import type { SkinId } from '../registry';
 
 const mountedSkinIds = vi.hoisted(() => [] as SkinId[]);
 const mountedLcdVariants = vi.hoisted(() => [] as Array<'cockpit' | 'scope'>);
+const mobileLayoutMounts = vi.hoisted(() => ({ count: 0 }));
 
 vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
   default: (_anchor: unknown, props: { skinId?: SkinId }) => {
@@ -58,6 +74,14 @@ vi.mock('../../components-v2/layout/LcdLayout.svelte', () => ({
   },
 }));
 
+// MobileSkin takes no props at all (`<MobileRadioLayout />`), so there is no
+// value to pin here beyond "loading `mobile` actually mounts this component".
+vi.mock('../../components-v2/layout/MobileRadioLayout.svelte', () => ({
+  default: () => {
+    mobileLayoutMounts.count += 1;
+  },
+}));
+
 import { loadSkin } from '../registry';
 
 const components: Record<string, unknown>[] = [];
@@ -66,11 +90,13 @@ afterEach(() => {
   while (components.length) unmount(components.pop()!);
   mountedSkinIds.length = 0;
   mountedLcdVariants.length = 0;
+  mobileLayoutMounts.count = 0;
 });
 
 type EntrypointCoverage =
   | { readonly kind: 'radio-layout' }
   | { readonly kind: 'lcd-layout'; readonly variant: 'cockpit' | 'scope' }
+  | { readonly kind: 'mobile-layout' }
   | { readonly kind: 'covered-elsewhere'; readonly testFile: string; readonly entryComponentFile: string };
 
 /**
@@ -87,11 +113,7 @@ const SKIN_ENTRYPOINT_COVERAGE: Readonly<Record<SkinId, EntrypointCoverage>> = {
     testFile: 'src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts',
     entryComponentFile: 'DualReceiverCockpit.svelte',
   },
-  mobile: {
-    kind: 'covered-elsewhere',
-    testFile: 'src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts',
-    entryComponentFile: 'MobileSkin.svelte',
-  },
+  mobile: { kind: 'mobile-layout' },
 };
 
 const allSkinIds = Object.keys(SKIN_ENTRYPOINT_COVERAGE) as SkinId[];
@@ -102,6 +124,8 @@ const lcdLayoutCases = allSkinIds.flatMap((id) => {
   const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
   return coverage.kind === 'lcd-layout' ? [[id, coverage.variant] as const] : [];
 });
+
+const mobileLayoutSkinIds = allSkinIds.filter((id) => SKIN_ENTRYPOINT_COVERAGE[id].kind === 'mobile-layout');
 
 const coveredElsewhereCases = allSkinIds.flatMap((id) => {
   const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
@@ -133,10 +157,26 @@ describe('LCD skin entrypoints', () => {
   });
 });
 
-describe('skin entrypoint coverage completeness', () => {
-  // Kills: a `covered-elsewhere` entry surviving after its named test file
-  // is deleted or renamed, or one that never named a file that actually
-  // exercises this skin's entry component to begin with.
+describe('mobile skin entrypoint', () => {
+  // Kills: MobileSkin resolving to anything other than MobileRadioLayout —
+  // a stub, another skin's layout, or nothing mounted at all.
+  it.each(mobileLayoutSkinIds)('mounts MobileRadioLayout (%s)', async (skinId) => {
+    const Component = await loadSkin(skinId);
+    const target = document.createElement('div');
+    components.push(mount(Component, { target }));
+    expect(mobileLayoutMounts.count).toBe(1);
+  });
+});
+
+describe('externally-covered skin entrypoints', () => {
+  // Kills: the named file being deleted or renamed, or edited so its source
+  // no longer mentions the entry component's filename. This is a substring
+  // match on source text, not a proof of behavior: it cannot tell a suite
+  // that genuinely mounts the component apart from one that only imports it
+  // as a `?raw` text fixture, or one whose tests are all `describe.skip`-ed.
+  // Treat a pass here as "the reference hasn't visibly rotted", not as "this
+  // skin is covered" — the latter has to be confirmed by hand when the entry
+  // is written or changed (see the file header for the case that wasn't).
   it.each(coveredElsewhereCases)('%s names a real test file that still mentions its entrypoint', (skinId, coverage) => {
     expect(existsSync(coverage.testFile), `${skinId}: ${coverage.testFile} does not exist`).toBe(true);
     const source = readFileSync(coverage.testFile, 'utf8');

--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -1,8 +1,50 @@
+/**
+ * MOR-2038 — a behavioral entry-point pin for every `SkinId` registered in
+ * `skins/registry.ts`, generalized over that registry instead of a
+ * hardcoded pair list (the previous version of this file covered only
+ * `desktop-v2`/`sdr-test`).
+ *
+ * `SKIN_LOADERS` — the registry's `Record<SkinId, () => Promise<...>>` of
+ * lazy dynamic imports — is not exported; only `loadSkin(id)` is. So every
+ * case below fetches its component through `loadSkin`, the same function
+ * `App.svelte` calls, instead of importing a skin's `.svelte` file directly.
+ * A loader repointed at the wrong module is visible here exactly as it
+ * would be to the app.
+ *
+ * Completeness has two layers, because there is no runtime-enumerable list
+ * of `SkinId` values to iterate — the union has no runtime representation,
+ * and both `SKIN_LOADERS` and the sibling `SKIN_RESOURCE_PLAN` are private:
+ *
+ * 1. `SKIN_ENTRYPOINT_COVERAGE` below is typed `Record<SkinId, ...>`. A
+ *    `SkinId` added to the registry without a matching entry here is a
+ *    missing-property error in this object literal — caught by
+ *    `npm run check` (`svelte-check --tsconfig ./tsconfig.app.json`, whose
+ *    `include` covers every `src/**\/*.ts`, this file included). Plain
+ *    `vitest run` would NOT catch it: Vite/esbuild transpile this file by
+ *    stripping types, so a table that silently fell out of sync would still
+ *    run, just without the new id.
+ * 2. For the two ids whose coverage lives in another file
+ *    (`dual-receiver-cockpit`, `mobile`), the 'skin entrypoint coverage
+ *    completeness' suite asserts the named file still exists and still
+ *    mentions the skin's own entry component, so a rename or deletion over
+ *    there turns this file red instead of the exemption rotting silently.
+ *
+ * `lcd-cockpit`/`lcd-scope` get a real mount pin for the first time here.
+ * Both wrappers are zero-prop and hardcode a `variant` literal into
+ * `LcdLayout`; the `variant` prop's shape
+ * (`variant?: 'cockpit' | 'scope'`) is already pinned on LcdLayout itself by
+ * `components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts`
+ * and `...autostep-lifecycle.isolated.test.ts` — nothing here duplicates
+ * that. This file pins only the two wrappers' half: that each forwards its
+ * own literal down, not LcdLayout's behavior for either value.
+ */
+import { existsSync, readFileSync } from 'node:fs';
 import { mount, unmount } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SkinId } from '../registry';
 
 const mountedSkinIds = vi.hoisted(() => [] as SkinId[]);
+const mountedLcdVariants = vi.hoisted(() => [] as Array<'cockpit' | 'scope'>);
 
 vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
   default: (_anchor: unknown, props: { skinId?: SkinId }) => {
@@ -10,23 +52,97 @@ vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
   },
 }));
 
-import DesktopSkin from '../desktop-v2/DesktopSkin.svelte';
-import SdrTestSkin from '../sdr-test/SdrTestSkin.svelte';
+vi.mock('../../components-v2/layout/LcdLayout.svelte', () => ({
+  default: (_anchor: unknown, props: { variant?: 'cockpit' | 'scope' }) => {
+    if (props.variant) mountedLcdVariants.push(props.variant);
+  },
+}));
+
+import { loadSkin } from '../registry';
 
 const components: Record<string, unknown>[] = [];
 
 afterEach(() => {
   while (components.length) unmount(components.pop()!);
   mountedSkinIds.length = 0;
+  mountedLcdVariants.length = 0;
+});
+
+type EntrypointCoverage =
+  | { readonly kind: 'radio-layout' }
+  | { readonly kind: 'lcd-layout'; readonly variant: 'cockpit' | 'scope' }
+  | { readonly kind: 'covered-elsewhere'; readonly testFile: string; readonly entryComponentFile: string };
+
+/**
+ * One entry per `SkinId` — see the file header for what makes this table
+ * exhaustive and what a `covered-elsewhere` entry is checked against.
+ */
+const SKIN_ENTRYPOINT_COVERAGE: Readonly<Record<SkinId, EntrypointCoverage>> = {
+  'desktop-v2': { kind: 'radio-layout' },
+  'sdr-test': { kind: 'radio-layout' },
+  'lcd-cockpit': { kind: 'lcd-layout', variant: 'cockpit' },
+  'lcd-scope': { kind: 'lcd-layout', variant: 'scope' },
+  'dual-receiver-cockpit': {
+    kind: 'covered-elsewhere',
+    testFile: 'src/skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts',
+    entryComponentFile: 'DualReceiverCockpit.svelte',
+  },
+  mobile: {
+    kind: 'covered-elsewhere',
+    testFile: 'src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts',
+    entryComponentFile: 'MobileSkin.svelte',
+  },
+};
+
+const allSkinIds = Object.keys(SKIN_ENTRYPOINT_COVERAGE) as SkinId[];
+
+const radioLayoutSkinIds = allSkinIds.filter((id) => SKIN_ENTRYPOINT_COVERAGE[id].kind === 'radio-layout');
+
+const lcdLayoutCases = allSkinIds.flatMap((id) => {
+  const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
+  return coverage.kind === 'lcd-layout' ? [[id, coverage.variant] as const] : [];
+});
+
+const coveredElsewhereCases = allSkinIds.flatMap((id) => {
+  const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
+  return coverage.kind === 'covered-elsewhere' ? [[id, coverage] as const] : [];
 });
 
 describe('desktop skin entrypoints', () => {
-  it.each([
-    [DesktopSkin, 'desktop-v2'],
-    [SdrTestSkin, 'sdr-test'],
-  ] as const)('passes its stable skin ID explicitly', (component, skinId) => {
+  // Kills: a RadioLayout-backed skin no longer passing its own SkinId
+  // literal, or passing a different skin's — the assertion pins the exact
+  // value, not merely that some string arrived.
+  it.each(radioLayoutSkinIds)('mounts RadioLayout with its own stable skin ID (%s)', async (skinId) => {
+    const Component = await loadSkin(skinId);
     const target = document.createElement('div');
-    components.push(mount(component, { target }));
+    components.push(mount(Component, { target }));
     expect(mountedSkinIds).toEqual([skinId]);
+  });
+});
+
+describe('LCD skin entrypoints', () => {
+  // Kills: LcdCockpitSkin/LcdScopeSkin forwarding the wrong `variant`
+  // literal to LcdLayout, forwarding the other skin's literal, or dropping
+  // the prop entirely (the guard in the mock above then leaves
+  // mountedLcdVariants empty, which also fails the equality below).
+  it.each(lcdLayoutCases)('forwards variant to LcdLayout (%s -> %s)', async (skinId, variant) => {
+    const Component = await loadSkin(skinId);
+    const target = document.createElement('div');
+    components.push(mount(Component, { target }));
+    expect(mountedLcdVariants).toEqual([variant]);
+  });
+});
+
+describe('skin entrypoint coverage completeness', () => {
+  // Kills: a `covered-elsewhere` entry surviving after its named test file
+  // is deleted or renamed, or one that never named a file that actually
+  // exercises this skin's entry component to begin with.
+  it.each(coveredElsewhereCases)('%s names a real test file that still mentions its entrypoint', (skinId, coverage) => {
+    expect(existsSync(coverage.testFile), `${skinId}: ${coverage.testFile} does not exist`).toBe(true);
+    const source = readFileSync(coverage.testFile, 'utf8');
+    expect(
+      source.includes(coverage.entryComponentFile),
+      `${skinId}: ${coverage.testFile} no longer mentions ${coverage.entryComponentFile}`,
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Generalizes `frontend/src/skins/__tests__/entrypoints.test.ts` from a hardcoded two-pair list into a suite driven by `SkinId`, and adds the behavioral pin that was actually missing.

**Ground-truth correction vs. the ticket text** (confirmed by reading `skins/registry.ts`, `LcdCockpitSkin.svelte`, `LcdScopeSkin.svelte`, `components-v2/layout/LcdLayout.svelte`, and the existing test suite before writing anything):

- The LCD entry points (`LcdCockpitSkin.svelte`, `LcdScopeSkin.svelte`) take **zero props** and hardcode a literal (`variant="cockpit"` / `variant="scope"`) into `LcdLayout`. `LcdLayout`'s own `variant?: 'cockpit' | 'scope'` prop shape is *already* pinned by `LcdLayout.command-bus-migration.isolated.test.ts` and `LcdLayout.autostep-lifecycle.isolated.test.ts`. The real gap was narrower: nothing pinned the two wrappers *forwarding* the right literal.
- Of the four other `SkinId`s without a pin in this file, only `dual-receiver-cockpit` truly had coverage already — its own 1194-line component test (`skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts`) really mounts `DualReceiverCockpit`. `MobileSkin` looked the same at first read (`semantic-mobile-migration.component.test.ts` has a "pure delegator" describe block naming `MobileSkin.svelte`), but the fix round below found that reference to be a `?raw` text-fixture import used only for a source-content assertion — no test there ever mounts `MobileSkin`. So `lcd-cockpit`, `lcd-scope`, and `mobile` all needed a real pin; only `dual-receiver-cockpit`'s test would have been duplicated by writing one here.

**Design, given `skins/registry.ts`'s actual shape:**

- `SKIN_LOADERS` (the `Record<SkinId, () => Promise<...>>` of lazy dynamic imports) is **not exported** — only `loadSkin(id)` is, and there's no other runtime-enumerable list of `SkinId` values anywhere in the codebase (checked before writing). So the suite can't iterate `SKIN_LOADERS` directly; it iterates a table it owns (`SKIN_ENTRYPOINT_COVERAGE`, typed `Readonly<Record<SkinId, EntrypointCoverage>>`) and fetches each component through `loadSkin(id)` — the same call `App.svelte` makes — rather than importing each `.svelte` file directly.
- Completeness is two layers, because there's no runtime way to detect "a `SkinId` this table doesn't know about":
  1. **Type-level:** the `Record<SkinId, ...>` annotation means a `SkinId` added to the registry without a matching table entry is a missing-property error, caught by `npm run check` (`tsconfig.app.json` includes every `src/**/*.ts`, so this test file is checked). Plain `vitest run` would *not* catch this — Vite/esbuild strip types without checking them, so a stale table would just silently run without the new id.
  2. **Runtime, for the one id covered elsewhere** (`dual-receiver-cockpit`): the entry names the covering file, and a test asserts that file still exists and still mentions the skin's own entry-component filename. This is a substring check, not a behavioral one — it goes red if the reference rots (file deleted or renamed), but it cannot prove the referenced file mounts the component; see the fix-round note below for the case where that distinction mattered. `mobile` gets a real mount pin instead (below), the same way `lcd-cockpit`/`lcd-scope` do.
- The two LCD ids get a real mount test here: `LcdLayout.svelte` is mocked (same technique the existing `RadioLayout.svelte` mock already used for `desktop-v2`/`sdr-test`) and the suite asserts the wrapper forwards its own literal.

## Verification

- `cd frontend && npm run check` — 0 errors, 0 warnings (4601 files).
- `cd frontend && npx vitest run src/skins/__tests__/` — 32/32 passed (26 pre-existing in `registry.test.ts`, unchanged; 6 in the rewritten `entrypoints.test.ts`).
- `npx eslint src/skins/__tests__/entrypoints.test.ts` — clean.

**Confirmed every new pin can fail, and fails for the right reason** (each mutation applied only inside this test file, observed red, then reverted — confirmed clean by re-running both commands above afterward and by `git diff` matching the intended final content exactly):
- Radio-layout pin: replaced the expected skin ID with a bogus literal → both `desktop-v2` and `sdr-test` cases failed, showing the *real* mounted value (`"desktop-v2"`/`"sdr-test"`) against the bogus expectation — proves the assertion reads real mount output, not a tautology.
- LCD-layout pin: changed the table's expected `lcd-cockpit` variant to `'scope'` → that case failed showing `Received: ["cockpit"]` (the real, unmutated wrapper's actual output) against `Expected: ["scope"]`; the untouched `lcd-scope` case stayed green in the same run.
- Completeness (covered-elsewhere), existence check: pointed `mobile`'s `testFile` at a nonexistent path → failed with a clear "does not exist" message. (This row was later replaced by a real mount pin — see the fix round below — but the check behaved the same way for `dual-receiver-cockpit`, which keeps this shape.)
- Completeness (covered-elsewhere), content check: pointed `mobile`'s `testFile` at a real but unrelated test file → failed with a clear "no longer mentions MobileSkin.svelte" message.
- Completeness (type-level): added a local-only shadow type (`SkinId | 'seventh-skin-for-verification'`) to the table's annotation, without touching `registry.ts` (out of this PR's file scope) → `npm run check` failed with exactly the expected TS error ("Property '\"seventh-skin-for-verification\"' is missing in type ... required in type 'Readonly<Record<...>>'"), confirming a `SkinId` added without a table entry turns `npm run check` red.

All mutations were reverted before committing; the committed diff was verified against `git diff` to match the intended change with no leftover artifacts.

## Guardrails

1 file changed, 123 insertions(+), 7 deletions(-) — well under both the 6-file/600-line soft threshold and the 10-file/1000-line hard ceiling.

## Scope note

Per the lane assignment, only `frontend/src/skins/__tests__/**` was touched. `skins/registry.ts`, the LCD skin wrappers, `DualReceiverCockpit.svelte`, and `MobileSkin.svelte` were read but not modified.

## Test plan

- [x] `npm run check`
- [x] `npx vitest run src/skins/__tests__/`
- [ ] Full frontend suite on the runner (`fe` target) — pending, to be run separately per the repo's remote-test workflow

## Fix round (review response)

The reviewer found the `covered-elsewhere` mechanism could not discriminate a real behavioral pin from a bare reference, and that `mobile`'s reference (`semantic-mobile-migration.component.test.ts`) was exactly that: it `?raw`-imports `MobileSkin.svelte` as text for a source-content assertion but never mounts it. Fixed:

- `mobile` gets a real mount pin: mocks `MobileRadioLayout.svelte` (the same technique the `RadioLayout`/`LcdLayout` mocks already use) and asserts that loading `mobile` actually mounts it. Same style as the `lcd-cockpit`/`lcd-scope` pins; no more `covered-elsewhere` shortcut for this id.
- The remaining `covered-elsewhere` row (`dual-receiver-cockpit`, whose named file genuinely does `mount(DualReceiverCockpit, ...)`) keeps the same substring check, but its `Kills:` comment and the file header now say plainly what a substring match does and does not prove — it cannot tell a real mount apart from a `?raw` import, or a live suite from one wrapped in `describe.skip`. It only catches the reference rotting (file deleted/renamed) after that has been confirmed by hand.
- Reconciling this PR body with the original commit message's count: "four of six" (commit) counts `SkinId`s that lacked a pin *in this file* before MOR-2038 (`lcd-cockpit`, `lcd-scope`, `dual-receiver-cockpit`, `mobile`) — that count was and stays correct. This PR body's earlier "only `lcd-cockpit`/`lcd-scope` truly lacked coverage" (now corrected above) was wrong about `mobile`: three of those four (`lcd-cockpit`, `lcd-scope`, `mobile`), not two, needed a real pin; only `dual-receiver-cockpit` already had one.
- Non-blocking wording fixes: the header's "every case below fetches through `loadSkin`" claim now excludes the one case that doesn't (the `dual-receiver-cockpit` coverage guard); the former `'skin entrypoint coverage completeness'` describe is renamed `'externally-covered skin entrypoints'` since it doesn't establish completeness (the type-level table does) — it only guards one reference against rotting.

Verification for this round:
- `cd frontend && npm run check` — 0 errors, 0 warnings (4601 files).
- `cd frontend && npx vitest run src/skins/__tests__/entrypoints.test.ts` — 6/6 passed.
- Confirmed the new `mobile` pin goes red for the right reason: temporarily changed `MobileSkin.svelte` to render `RadioLayout` instead of `MobileRadioLayout`, ran the suite → the new test failed (`expected +0 to be 1`, i.e. the mocked `MobileRadioLayout` was never invoked); reverted `MobileSkin.svelte`, suite green again (6/6).
- `npm run lint` and `npm run lint:boundaries` — clean.
