### PR TITLE
fix(MOR-2024): consolidate the two S-unit derivations onto one algorithm

### DIFF
--- a/docs/architecture/level-meter-calibrated-domain.md
+++ b/docs/architecture/level-meter-calibrated-domain.md
@@ -43,7 +43,8 @@ The current state is inconsistent across backends and consumers:
   swr, alc); IC-7300/IC-705/IC-9700 are swr-only; FTX-1 has s_meter + swr (no power,
   no alc); X6100/X6200/TX500 have none. The curves are genuinely per-rig and
   non-linear — e.g. IC-7610 s_meter steps 6/12/12 dB across raw 0/26/52/78 while
-  FTX-1 s_meter steps a uniform 3 dB across raw 0/13/26/39.
+  FTX-1 s_meter is non-uniform: 3 dB per step from raw 0 through 91 (S0-S6),
+  then a 15 dB jump to S7 and 9 dB steps through S9 (`rigs/ftx1.toml`).
 - **Consumers assume raw 0-255.** rigctld (`rigctld/handler.py`, ~L1660-1890)
   converts STRENGTH / RFPOWER / LEVEL inline with hand-rolled formulas — `/255.0` for
   RFPOWER and the float levels, a distinct `(raw / 241.0) * 114.0 - 54.0` for STRENGTH.

--- a/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
@@ -123,8 +123,11 @@ describe('formatSValue (calibrated radio)', () => {
     expect(formatSValue(-24)).toBe('S5');
   });
 
-  it('returns S9+ for values above S9 but below the next anchor', () => {
-    expect(formatSValue(20)).toBe('S9+');
+  it('returns a continuous S9+ reading for values above S9 but below the next anchor, not the bare "S9+" hole (MOR-2024)', () => {
+    // This profile's only declared over-S9 knot is the S9+60 top anchor —
+    // exactly the wide-gap shape that used to fall through rawToSUnit's
+    // backwards knot search and return the literal "S9+" with no number.
+    expect(formatSValue(20)).toBe('S9+20');
   });
 
   // Kills: the old hardcoded +40 clamp — the documented Icom top anchor is

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.test.ts
@@ -150,12 +150,23 @@ describe('rawToSUnit', () => {
     expect(rawToSUnit(130)).toBe('S9');
   });
 
-  it('returns S9+ for raw just above S9 but below S9+10', () => {
-    expect(rawToSUnit(140)).toBe('S9+');
+  it('reads a continuous dB-over-S9 value for raw between S9 and S9+10, not the bare "S9+" hole (MOR-2024)', () => {
+    // Before MOR-2024, any raw strictly between s9Raw and the FIRST
+    // declared over-S9 knot fell through the backwards knot search and
+    // returned the literal string "S9+" with no number attached.
+    expect(rawToSUnit(140)).toBe('S9+3');
   });
 
   it('returns S9+20 for raw 200', () => {
     expect(rawToSUnit(200)).toBe('S9+20');
+  });
+
+  it('reads continuously between two declared over-S9 knots too, not snapped down to the lower one (MOR-2024)', () => {
+    // raw 220 sits between the S9+20 (200) and S9+40 (240) knots. The old
+    // code walked overPoints backwards and returned the highest knot at
+    // or below v, i.e. it silently under-reported "S9+20" for anything up
+    // to (but not including) 240 -- not just the narrower hole above.
+    expect(rawToSUnit(220)).toBe('S9+30');
   });
 
   it('returns S9+40 for raw 240', () => {

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -144,7 +144,6 @@ export function rawToSUnit(raw: number): string {
   const v = Math.max(0, Math.min(MAX_RAW, raw));
   if (!isSmeterCalibrated()) return String(Math.round(v));
 
-  const cal = getCal();
   const s9Raw = getS9Raw();
 
   if (v <= s9Raw) {
@@ -152,16 +151,16 @@ export function rawToSUnit(raw: number): string {
     return `S${Math.min(9, s)}`;
   }
 
-  // Over S9: find matching calibration label
-  const overPoints = cal.filter(p => p.raw > s9Raw);
-  let label = 'S9+';
-  for (let i = overPoints.length - 1; i >= 0; i--) {
-    if (v >= overPoints[i].raw) {
-      label = overPoints[i].label;
-      break;
-    }
-  }
-  return label;
+  // Over S9: an honest, continuous dB-over-S9 reading interpolated from
+  // the profile's own table (MOR-2024) — not a knot-snapped label. The
+  // previous version walked the declared over-S9 knots backwards and
+  // returned the first one at or below `v`, which silently under-reported
+  // any raw strictly between two knots, and fell through to the bare
+  // literal "S9+" with no number at all once `v` was short of every
+  // declared knot (e.g. a profile with a single over-point leaves a wide
+  // gap right above S9 where that used to happen).
+  const over = Math.round(interpolate(v, getCal(), 'actual'));
+  return over > 0 ? `S9+${over}` : 'S9';
 }
 
 /** Map raw 0-255 to dBm value (linear interpolation between calibration

--- a/frontend/src/components-v2/meters/smeter-scale.ts
+++ b/frontend/src/components-v2/meters/smeter-scale.ts
@@ -36,12 +36,15 @@ function getCal(): CalPoint[] {
   return getSmeterCalibration() ?? [];
 }
 
-/** True when the active radio profile declared a real s_meter calibration
- *  table. False means the S-unit/dBm text below must fall back to an honest
- *  raw-scale label instead of fabricating a reading against a borrowed
- *  curve (MOR-1451). */
+/** True when the active radio profile declared an s_meter calibration table
+ *  with at least two knots. Interpolation needs two points to define a
+ *  line; a single knot cannot support a calibrated reading, so it counts
+ *  as uncalibrated the same as zero knots (MOR-2024) rather than resolving
+ *  every input to that one knot's value. False means the S-unit/dBm text
+ *  below must fall back to an honest raw-scale label instead of
+ *  fabricating a reading against a borrowed curve (MOR-1451). */
 export function isSmeterCalibrated(): boolean {
-  return getCal().length > 0;
+  return getCal().length >= 2;
 }
 
 /** Find S9 raw value from calibration; the raw-scale midpoint when

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -118,6 +118,7 @@ import {
   peakHoldDisplay,
   type PeakHoldState,
 } from './meter-utils';
+import { isSmeterCalibrated } from '../meters/smeter-scale';
 
 beforeEach(() => {
   setCapabilities(makeCaps({
@@ -525,6 +526,45 @@ describe('formatSMeter / sLevel — uncalibrated fallback (MOR-1451)', () => {
   });
 
   it('sLevel degrades to a neutral raw-proportional bar position', () => {
+    expect(sLevel(53)).toBeCloseTo(53 / 255);
+  });
+});
+
+describe('formatSMeter / sLevel / isSmeterCalibrated — one-knot table cannot support interpolation (MOR-2024)', () => {
+  // A profile that declares exactly one s_meter knot cannot be
+  // interpolated -- a line needs two points. `isSmeterCalibrated()` must
+  // say "uncalibrated" for one knot, same as zero, instead of letting the
+  // calibrated branch through with a table that can only ever resolve to
+  // that single knot's value. Before this was enforced, `calibratedToRaw()`
+  // (smeter-scale.ts) clamped every input to the lone knot's `actual` and
+  // returned its `raw` unconditionally, so `formatSMeter` printed the same
+  // fabricated S-unit for every reading regardless of the true value --
+  // verified: against a lone `{ raw: 130, actual: 0, label: 'S9' }` knot,
+  // both -20 and 0 produced 'S7' -- while `sLevel`, which already gated on
+  // `getSmeterKnots().length >= 2`, correctly reported the neutral
+  // raw-proportional fallback on the very same tile. No shipped profile
+  // declares a one-knot table today (`rig_loader` enforces no minimum), so
+  // this was latent, not live -- but it must stay caught.
+  const ONE_KNOT_S_METER_CAL = [{ raw: 130, actual: 0, label: 'S9' }];
+
+  beforeEach(() => {
+    setCapabilities(makeCaps({
+      model: 'IC-7300',
+      meterCalibrations: { s_meter: ONE_KNOT_S_METER_CAL },
+    }));
+  });
+
+  it('isSmeterCalibrated is false for a single knot -- interpolation needs two points', () => {
+    expect(isSmeterCalibrated()).toBe(false);
+  });
+
+  it('formatSMeter renders the honest raw-tagged reading, never a fabricated S-unit, and is not constant across inputs', () => {
+    expect(formatSMeter(-20)).toBe('0 raw');
+    expect(formatSMeter(53)).toBe('53 raw');
+    expect(formatSMeter(150)).toBe('150 raw');
+  });
+
+  it('sLevel agrees with formatSMeter that this tile is uncalibrated', () => {
     expect(sLevel(53)).toBeCloseTo(53 / 255);
   });
 });

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -552,6 +552,72 @@ describe('formatSMeter — IC-7300 profile conformance (MOR-1451)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// FTX-1 profile anchors (MOR-2024) — `formatSMeter`'s old ladder assumed
+// every radio's sub-S9 curve is a uniform straight line (`floor((actual -
+// minActual) / 6)`, a hardcoded 6 dB/S-unit step). `IC7610_LIKE_S_METER_CAL`
+// above and `IC7300_S_METER_CAL` above are BOTH uniform 6 dB/unit curves —
+// neither fixture could have caught the ladder disagreeing with a radio's
+// own declared table. This one mirrors `rigs/ftx1.toml`'s real, non-uniform
+// S0..S9 step sequence (6/3/3/3/3/3/15/9/9 dB) so it can.
+// ---------------------------------------------------------------------------
+
+const FTX1_S_METER_CAL = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 13, actual: -51, label: 'S0.5' },
+  { raw: 26, actual: -48, label: 'S1' },
+  { raw: 39, actual: -45, label: 'S2' },
+  { raw: 52, actual: -42, label: 'S3' },
+  { raw: 65, actual: -39, label: 'S4' },
+  { raw: 78, actual: -36, label: 'S5' },
+  { raw: 91, actual: -33, label: 'S6' },
+  { raw: 103, actual: -18, label: 'S7' },
+  { raw: 117, actual: -9, label: 'S8' },
+  { raw: 130, actual: 0, label: 'S9' },
+  { raw: 165, actual: 10, label: 'S9+10' },
+  { raw: 200, actual: 20, label: 'S9+20' },
+  { raw: 240, actual: 40, label: 'S9+40' },
+];
+
+describe('formatSMeter — FTX-1 profile anchors (MOR-2024)', () => {
+  beforeEach(() => {
+    setCapabilities(makeCaps({
+      model: 'FTX-1',
+      meterCalibrations: { s_meter: FTX1_S_METER_CAL },
+    }));
+  });
+
+  it('renders the declared S6/S7/S8 labels at their own anchors, not the uniform-ladder guess', () => {
+    // The old hardcoded floor((actual-minActual)/6) ladder produced S3,
+    // S6, S7 at these three anchors respectively — one or more S-units
+    // short of the profile's own declared label, because FTX-1's real
+    // step past S5 is 3/15/9/9 dB, not a flat 6.
+    expect(formatSMeter(-33)).toBe('S6');
+    expect(formatSMeter(-18)).toBe('S7');
+    expect(formatSMeter(-9)).toBe('S8');
+  });
+
+  it('still renders the low and high ends correctly', () => {
+    expect(formatSMeter(-54)).toBe('S0');
+    expect(formatSMeter(0)).toBe('S9');
+    expect(formatSMeter(40)).toBe('S9+40');
+  });
+});
+
+describe('FTX1_S_METER_CAL sync guard (MOR-2024)', () => {
+  it('every mirrored s_meter knot matches its real rigs/ftx1.toml anchor exactly', () => {
+    const tomlSource = readFileSync('../rigs/ftx1.toml', 'utf8');
+    const realKnots = parseTomlCalibrationTable(tomlSource, 's_meter');
+    expect(realKnots.length).toBeGreaterThanOrEqual(FTX1_S_METER_CAL.length);
+
+    for (const mirrored of FTX1_S_METER_CAL) {
+      const real = realKnots.find((k) => k.raw === mirrored.raw);
+      expect(real, `no real anchor at raw=${mirrored.raw} in rigs/ftx1.toml`).toBeDefined();
+      expect(mirrored).toEqual(real);
+    }
+  });
+});
+
 describe('sLevel (calibrated bar)', () => {
   it('returns ~1.0 at the strongest calibrated reading', () => {
     expect(sLevel(40)).toBeCloseTo(1.0);

--- a/frontend/src/components-v2/panels/meter-utils.test.ts
+++ b/frontend/src/components-v2/panels/meter-utils.test.ts
@@ -540,7 +540,7 @@ describe('formatSMeter / sLevel / isSmeterCalibrated — one-knot table cannot s
   // returned its `raw` unconditionally, so `formatSMeter` printed the same
   // fabricated S-unit for every reading regardless of the true value --
   // verified: against a lone `{ raw: 130, actual: 0, label: 'S9' }` knot,
-  // both -20 and 0 produced 'S7' -- while `sLevel`, which already gated on
+  // both -20 and 0 produced 'S9' -- while `sLevel`, which already gated on
   // `getSmeterKnots().length >= 2`, correctly reported the neutral
   // raw-proportional fallback on the very same tile. No shipped profile
   // declares a one-knot table today (`rig_loader` enforces no minimum), so

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -26,6 +26,12 @@ import {
   getMeterRedline,
 } from '$lib/runtime/adapters/capabilities-adapter';
 import type { MeterCalPoint } from '$lib/runtime/adapters/capabilities-adapter';
+// `formatSMeter`'s calibrated branch defers to the one table-driven S-unit
+// reader (MOR-2024) instead of keeping a second copy of that math here;
+// `isSmeterCalibrated` was a byte-for-byte duplicate of the same import
+// over the same underlying capabilities data, so it is reused too rather
+// than kept as a second "is there a curve" check.
+import { calibratedToSUnit, isSmeterCalibrated } from '../meters/smeter-scale';
 
 export type MeterSource = 'S' | 'SWR' | 'POWER' | 'po';
 
@@ -197,14 +203,6 @@ function getSmeterKnots(): [number, number][] {
   return cal.map((p) => [p.raw, p.actual] as [number, number]);
 }
 
-/** True when the active radio profile declared a real s_meter calibration
- *  table. False means `formatSMeter`/`sLevel` below must fall back to an
- *  honest raw-scale reading instead of fabricating one against a borrowed
- *  curve (MOR-1451) — mirrors `smeter-scale.ts`'s `isSmeterCalibrated`. */
-function isSmeterCalibrated(): boolean {
-  return getSmeterKnots().length > 0;
-}
-
 function getSmeterMaxRaw(): number {
   const knots = getSmeterKnots();
   return knots.length > 0 ? knots[knots.length - 1][0] : RAW_SCALE_MAX;
@@ -237,26 +235,20 @@ function calibratedSmeterToRaw(actual: number): number {
  * Falls back to the honest raw-tagged reading (`formatRaw`, e.g. "53 raw";
  * MOR-1527) when the radio has no s_meter calibration table — never a
  * reading borrowed from a different radio's curve (MOR-1451), and never a
- * naked number indistinguishable from a real S-unit claim (MOR-1535: this
- * was the last of the seven meter formatters still returning the naked
- * pre-MOR-1527 fallback).
+ * naked number indistinguishable from a real S-unit claim (MOR-1535).
+ *
+ * The calibrated branch defers entirely to `smeter-scale.ts`'s
+ * `calibratedToSUnit` (MOR-2024) — this file no longer runs its own S-unit
+ * math. It previously assumed every radio's sub-S9 curve was a uniform
+ * straight line (a hardcoded 6 dB/S-unit ladder), which disagreed with a
+ * profile's own declared table wherever that table was NOT uniform (e.g.
+ * FTX-1's real S0-S9 steps are 6/3/3/3/3/3/15/9/9 dB).
  */
 export function formatSMeter(actual: number): string {
   if (!isSmeterCalibrated()) {
     return formatRaw(actual);
   }
-  const knots = getSmeterKnots();
-  const minActual = knots[0][1];
-  const maxActual = knots[knots.length - 1][1];
-  const clamped = Math.max(minActual, Math.min(maxActual, actual));
-
-  if (clamped >= 0) {
-    const over = Math.round(clamped);
-    return over > 0 ? `S9+${over}` : 'S9';
-  }
-
-  const s = Math.max(0, Math.min(9, Math.floor((clamped - minActual) / 6)));
-  return `S${s}`;
+  return calibratedToSUnit(actual);
 }
 
 /** Bar level for calibrated S-meter values relative to the UI scale full-scale. */

--- a/frontend/src/components-v2/panels/meter-utils.ts
+++ b/frontend/src/components-v2/panels/meter-utils.ts
@@ -27,10 +27,15 @@ import {
 } from '$lib/runtime/adapters/capabilities-adapter';
 import type { MeterCalPoint } from '$lib/runtime/adapters/capabilities-adapter';
 // `formatSMeter`'s calibrated branch defers to the one table-driven S-unit
-// reader (MOR-2024) instead of keeping a second copy of that math here;
-// `isSmeterCalibrated` was a byte-for-byte duplicate of the same import
-// over the same underlying capabilities data, so it is reused too rather
-// than kept as a second "is there a curve" check.
+// reader (MOR-2024) instead of keeping a second copy of that math here.
+// `isSmeterCalibrated` is reused from the same import instead of a second
+// local "is there a curve" check -- the two were never byte-for-byte
+// duplicates (this file's check went through `getSmeterKnots()`, gated at
+// `length >= 2`; the imported one tested `length > 0` directly), so the
+// swap silently loosened the gate to one knot until `smeter-scale.ts`'s
+// `isSmeterCalibrated` was fixed (MOR-2024) to also require `length >= 2`
+// -- interpolation needs two points to define a line, so a single knot
+// cannot support a calibrated reading.
 import { calibratedToSUnit, isSmeterCalibrated } from '../meters/smeter-scale';
 
 export type MeterSource = 'S' | 'SWR' | 'POWER' | 'po';


### PR DESCRIPTION
## Summary

Part 3 of 3 for MOR-2024 (this is the ticket's actual "PR 2" -- see the
first PR in this stack for why the dead-code sweep needed to become two
PRs instead of one). Was stacked on `codex/mor-2024-meters-cleanup` while
that PR (landed as #2852) was pending CI/review; now rebased directly
onto `main` (`git rebase --onto origin/main <old-cleanup-tip> HEAD`, to
replay only this branch's own 3 commits rather than re-attempt the
cleanup PR's already-landed deletions) and retargeted, so this is this
PR's first real CI run -- every gate workflow triggers only on
`pull_request` into `main`, and a codex-branch base never fired them.

The frontend had **two independent S-unit label derivations** that could
disagree:

- `meter-utils.ts`'s `formatSMeter()` used a hardcoded 6 dB/S-unit ladder
  (`floor((actual - minActual) / 6)`).
- `smeter-scale.ts`'s `calibratedToSUnit()` read the profile's own
  calibration table via interpolation.

They agreed only when a radio's curve happened to be uniform (IC-7610,
IC-7300 are both uniform 6 dB/unit lines below S9). FTX-1's real curve is
not: its declared S0-S9 steps are 6/3/3/3/3/3/15/9/9 dB
(`rigs/ftx1.toml`). At FTX-1's own S7 anchor (raw 103, -18 dB-rel-S9) the
ladder said "S6" while the table said "S7" -- the profile's own declared
label.

## What changed

1. **Added a fixture shaped like FTX-1's real curve** to
   `meter-utils.test.ts`. The two existing fixtures
   (`IC7610_LIKE_S_METER_CAL`, `IC7300_S_METER_CAL`) are both uniform
   6 dB/unit lines, so the ladder and the table agree everywhere on
   them -- verified directly: all 8 pre-existing `formatSMeter`
   assertions pass unchanged under the new delegated implementation,
   with no edits to any of them. None of the 8 could have caught this
   disagreement; only a non-uniform fixture can. Confirmed red against
   the old ladder first
   (`formatSMeter(-33)` returned `'S3'`, not `'S6'`) before fixing, per
   TDD. Also added a sync-guard test (reusing the existing
   `parseTomlCalibrationTable` helper already in this file) that checks
   the fixture against the real `rigs/ftx1.toml` table.

2. **Fixed two bugs in `calibratedToSUnit`'s chain** that had to be fixed
   before `formatSMeter` could safely delegate to it:
   - `rawToSUnit`'s over-S9 branch walked the declared over-S9 knots
     backwards and returned the first one at or below the raw value.
     That silently under-reported any value strictly between two knots,
     and fell through to the bare literal `"S9+"` with no number once
     the value was short of every declared knot -- a wide, live-reachable
     gap on any profile with few over-S9 knots (e.g. IC-7300's single
     one covers a 0-60 dB range). Replaced with direct interpolation
     over the table. Updated the two tests that pinned the old hole as
     expected behavior (`LinearSMeter.test.ts`'s `rawToSUnit` suite, and
     `mobile-layout-logic.test.ts`'s `formatSValue` suite -- the same
     bug reached through a different call site, found while running the
     full targeted suite) and added a between-two-knots case neither
     could have caught.
   - `formatSMeter`'s uncalibrated fallback (`"53 raw"`, MOR-1527/
     MOR-1535) had to be preserved without changing `rawToSUnit`'s own
     bare-number convention for its callers. **Correction (fix round 2):**
     this originally named `LinearSMeter`, `AmberSmeter`,
     `mobile-layout-logic` and `SdrVfoScreen` as "direct callers of
     `rawToSUnit`" -- false. `rawToSUnit` has exactly one caller
     repo-wide: `calibratedToSUnit` (same file). Those four call
     `calibratedToSUnit` directly (`mobile-layout-logic`
     via its own `formatSValue` wrapper, which calls `calibratedToSUnit`)
     -- they reach `rawToSUnit`'s bare-number convention only through
     that one level of indirection, and already have their own tested,
     separate "uncalibrated" UI treatment at that layer. `formatSMeter`
     keeps its own calibrated-table gate and raw-tagged fallback; only
     the calibrated branch now defers to `calibratedToSUnit`.

3. **`formatSMeter`'s three live call sites** (`DockMeterPanel.svelte`
   x2, `MetersDockPanel.svelte`) need no changes -- they still call
   `formatSMeter()`, which is now a thin adapter instead of a second
   algorithm.

4. **Consolidated `isSmeterCalibrated()`** onto the one already-exported
   version in `smeter-scale.ts`, removing `meter-utils.ts`'s own private
   copy -- both ultimately read the same store function
   (`getMeterCalibration('s_meter')`), just via two different re-export
   paths.

   **Correction (fix round 2):** this was originally justified as
   swapping in a "byte-for-byte duplicate, verified byte-identical" --
   false. The two copies gated at different knot-count thresholds:
   `smeter-scale.ts`'s required `length > 0`; `meter-utils.ts`'s own
   `getSmeterKnots()` (used elsewhere in the same file, by `sLevel`)
   already required `length >= 2`. A one-knot table exposed the
   gap: `calibratedToRaw()` clamped every input to the lone knot's
   `actual` and returned its `raw` unconditionally (interpolating over a
   single point is undefined, so the code just returned that point), so
   `formatSMeter` printed the *same* fabricated S-unit for every actual
   value passed to it, while `sLevel` -- reading the same profile through
   `getSmeterKnots()` -- correctly fell back to the raw-proportional bar
   on the very same tile. No shipped profile declares a one-knot table
   today (`rig_loader` enforces no minimum), so this was latent, not
   live.

   Per the owner's ruling -- interpolation needs two points to define a
   line, so a single knot cannot support a calibrated reading, and
   printing a constant fabricated S-unit from one is exactly the
   fabrication MOR-1527/MOR-1535 removed -- `isSmeterCalibrated()` now
   requires `length >= 2`, matching `getSmeterKnots()`. Pinned with a new
   one-knot-table suite in `meter-utils.test.ts`: `isSmeterCalibrated` is
   `false`, `formatSMeter` renders the honest `"N raw"` fallback and
   returns different strings for different inputs (not a constant), and
   `sLevel` agrees the tile is uncalibrated.

   **Correction (fix round 3):** the import comment right above this
   consolidation in `meter-utils.ts` still said the two copies were "a
   byte-for-byte duplicate" -- the same false claim, in the same file,
   that motivated the fix round 2 correction above. Verified against the
   pre-consolidation commit: the local copy was
   `getSmeterKnots().length > 0`, and `getSmeterKnots()` itself already
   filtered below 2 knots, so the local check was effectively gated at
   `length >= 2` while the imported one tested `length > 0` directly --
   swapping to the import without also fixing its threshold is exactly
   what loosened the gate to one knot. Rewrote the comment to state that,
   and why the threshold is 2 (interpolation needs two points). Swept the
   rest of this file's comments for the same shape of claim: one other
   (`calibratedSmeterToRaw`'s docstring, "matching smeter-scale.ts's
   `calibratedToRaw`") makes a cross-file matching claim about a pair
   named below, verified true after the fix-round-2 threshold change
   (both now gate on fewer than two knots and compute the identical
   clamp expression) -- left as-is. No other comment in this file
   asserts sameness for the pairs reported below; those remain
   unfixed and out of scope, unchanged.

5. **Corrected a stale doc line** in
   `docs/architecture/level-meter-calibrated-domain.md`: it described
   FTX-1's s_meter curve as "a uniform 3 dB across raw 0/13/26/39" --
   true only for those four cited raws, and misleading as a curve
   description once the profile's own 15/9/9 dB tail past S6 is
   considered (this was the ADR sentence this whole ticket's finding
   falsifies).

## Reported, not fixed (sweep of the class, per the investigation's note)

The investigation that produced this ticket flagged three more possible
duplicate pairs to consider while consolidating. I fixed #1
(`isSmeterCalibrated`, above) with a single call-site swap onto
`smeter-scale.ts`'s exported version. **Correction (fix round 2):** I
did not fix the other two, but the reason given for #1 -- "verified
byte-identical" -- was false, and so were the "identical" claims made
about both of these two. Restated accurately below, including the gate
difference in each, so whoever picks these up is not misled:

- **`calibratedSmeterToRaw()` (meter-utils.ts) vs `calibratedToRaw()`
  (smeter-scale.ts).** Originally described as "verified algorithmically
  identical." Their interpolation math is the same clamp-then-interpolate
  shape, but at the time that claim was made they did not agree at the
  boundary: `calibratedSmeterToRaw` gates on its own `getSmeterKnots()`
  (`length >= 2`), while `calibratedToRaw` gated on `isSmeterCalibrated()`
  (`length > 0`, before this PR's fix above) -- the same shape of gap as
  the `isSmeterCalibrated`/`getSmeterKnots` pair itself. The
  `isSmeterCalibrated` threshold fix above closes this specific gap as a
  direct consequence, not a separate edit: `calibratedToRaw` calls
  `isSmeterCalibrated()` directly, so both functions' passthrough
  branches now trigger under the same "fewer than two knots" condition.
  What's left is two independent implementations of the same math over
  two independently-sourced copies of the same calibration table
  (`$lib/runtime/adapters/capabilities-adapter` vs
  `$lib/stores/capabilities.svelte`) -- a real duplicate, still. Both
  feed `sLevel()` / `calibratedToSegments()` -- the S-meter bar-fill
  fraction, not the label -- which is outside this ticket's acceptance
  criteria ("FTX-1 anchors render their declared labels"), so it is
  reported rather than consolidated here.

- **`getSmeterMaxRaw()` (meter-utils.ts) vs `getScaleMaxRaw()`
  (smeter-scale.ts).** Originally described as duplicating the pair
  above "the same way" -- false, and NOT resolved by the
  `isSmeterCalibrated` fix above, because `getScaleMaxRaw` never calls
  `isSmeterCalibrated` (verified: no reference to it in the function or
  the module-level `getCal()` it reads). For a one-knot table,
  `getSmeterMaxRaw` returns the `RAW_SCALE_MAX` (255) fallback, because
  its `getSmeterKnots()` gate already empties the array below two knots.
  `getScaleMaxRaw` returns that single knot's own `raw` value instead
  (`cal[cal.length - 1]?.raw ?? MAX_RAW` -- the `?? MAX_RAW` only ever
  fires at exactly zero knots, never at one). This discrepancy is real,
  current, and unfixed. Consolidating either pair is likely safe (same
  data source, same math) but changes a different rendering path (the
  bar, not the number) that this PR does not otherwise touch, so both
  are reported rather than folded in here.
- **`RAW_SCALE_MAX` (meter-utils.ts, = 255) vs `MAX_RAW`
  (smeter-scale.ts, = 255).** Two appropriately-scoped local constants
  in two different modules (one used across all six TX/PA meter
  formatters, one used across the S-meter module) that happen to share
  the CI-V raw-byte-range value. Not a behavioral duplicate the way the
  other two are -- consolidating it would mean introducing a new shared
  module for one literal, which doesn't clear this repo's own
  rule-of-three bar yet.

- **`calibratedToRaw()` vs `rawToDbm()` (both smeter-scale.ts) --
  new, unresolved, not from the original investigation.** Found while
  sweeping this file's comments for false sameness claims (fix round 3):
  `calibratedToRaw`'s docstring says its uncalibrated branch is an
  "Identity passthrough ... matching `rawToDbm`." `rawToDbm`'s
  uncalibrated branch rounds (`Math.round(clamp(raw, 0, MAX_RAW))`);
  `calibratedToRaw`'s does not (`clamp(actual, 0, MAX_RAW)`, no
  `Math.round`). For a non-integer input these disagree (e.g. `53.7` ->
  `54` vs `53.7`). **Left as-is rather than edited, because I could not
  establish whether a non-integer input is actually reachable here** --
  every path I traced (`calibratedToSUnit` -> `rawToSUnit`, which rounds
  internally on its own uncalibrated branch) ends up rounded regardless,
  and CI-V meter values are device bytes (integers) in every case I
  checked, which would make the gap inert in practice, but I did not
  verify that exhaustively for every caller. Whoever picks this up
  should start from this evidence (which callers can pass a non-integer
  `actual` while uncalibrated, if any) rather than re-deriving it.

## Why one unit of work

The fixture, the two bug fixes, the delegation, and the one safe
dedup are one change: none of the fixes is independently useful without
the others (the fixture proves the ladder is wrong; the two `rawToSUnit`
bugs must be fixed before delegating to it is safe; the delegation is
the actual consolidation). The doc correction is one line describing the
exact finding this PR is about.

## Test plan

Local and fast, all run in this worktree. **Fix round 2** re-ran every
item below fresh at the current head (none of these figures are carried
forward from the original round):

- [x] `npm run check` -- 0 errors, 0 warnings (4595 files)
- [x] Confirmed red first: new/updated assertions in `meter-utils.test.ts`,
      `LinearSMeter.test.ts` and `mobile-layout-logic.test.ts` failed
      against the pre-fix code with exactly the predicted wrong values
      (`'S3'`, `'S9+'`, `'S9+20'` truncated) before any implementation change
- [x] **Fix round 2, confirmed red first:** the new one-knot-table suite
      in `meter-utils.test.ts` failed against the pre-fix `length > 0`
      gate with exactly the predicted wrong values (`isSmeterCalibrated()`
      `true` instead of `false`; `formatSMeter(-20)` `'S9'` instead of
      `'0 raw'`) before the `length >= 2` fix; green after
- [x] `npx vitest run src/components-v2/panels/meter-utils.test.ts src/components-v2/meters/__tests__/LinearSMeter.test.ts src/components-v2/meters/__tests__/smeter-no-double-conversion.test.ts src/components-v2/panels/__tests__/DockMeterPanel.isolated.test.ts src/components-v2/panels/lcd/__tests__/lcd-components.isolated.test.ts src/components-v2/panels/lcd/__tests__/AmberPanels.honesty-migration.isolated.test.ts src/components-v2/layout/__tests__/mobile-layout-logic.test.ts src/components-v2/layout/__tests__/MobileRadioLayout.honesty.isolated.test.ts src/components-v2/panels/__tests__/MetersDockPanel.isolated.test.ts src/components-v2/panels/__tests__/MetersDockPanel.reduced-motion.svelte.test.ts src/components-v2/panels/__tests__/MetersDockPanel.peakhold.svelte.test.ts` (every test file that imports `formatSMeter`, `calibratedToSUnit`, `rawToSUnit` or `formatSValue`, found by grep -- re-confirmed complete this round by grepping every production importer of `smeter-scale.ts` directly, not just the original list) -- 317 passed (314 + the 3 new one-knot-table assertions)
- [x] `npx vitest run` (full local suite, this machine, re-run fresh this
      round) -- 8046 passed, 1 failed
      (`fixture-capture-root-cwd.test.ts`, a subprocess-timeout test
      unrelated to S-meter calibration -- timed out at 15s under full-suite
      parallel load, then passed in 5.09s run alone; same flake the
      original round observed on this same test, not a regression)
- [x] `npm run lint` -- clean
- [x] `npm run lint:boundaries` -- clean (the new `panels/meter-utils.ts`
      -> `meters/smeter-scale.ts` import is a relative sibling import,
      not one of the banned `$lib/stores` / `$lib/transport` /
      `audio-manager` patterns this boundary enforces)

**Fix round 4 (post-rebase re-verification):** rebased onto `main` after
#2852 (the cleanup PR) merged as `0aedd7a0`, via
`git rebase --onto origin/main 757f38fc009b3d0aaea3471a7a5d427559372731 HEAD`
to replay only this branch's own 3 commits rather than re-attempt
`getNeedleMarks`/`Mark`/`SMeterDemo.svelte`'s already-landed deletions --
clean, no conflicts. Re-verified at the rebased head, all fresh:

- [x] Repo-wide sweep: `getNeedleMarks`, `Mark`, `SMeterDemo.svelte` --
      zero hits for all three, confirming each is gone exactly once
      (not resurrected, not deleted a second time by this branch's own
      commits)
- [x] `npm run check` -- 0 errors, 0 warnings (4598 files)
- [x] `npm run lint` / `npm run lint:boundaries` -- clean
- [x] Targeted 11-file suite (same list as above) -- 317 passed, unchanged
- [x] **FTX-1 fixture re-discriminates post-rebase:** restored the old
      hardcoded ladder in `formatSMeter`, ran the full
      `meter-utils.test.ts` file -- exactly 1 of 77 tests failed
      (`expected 'S3' to be 'S6'`, the same anchor this fixture was built
      to catch), the other 76 stayed green; restored the fix, all 77
      green again; `git diff` clean afterward
- [x] **One-knot-table test re-confirmed post-rebase:**
      `isSmeterCalibrated` still requires `length >= 2`
      (`smeter-scale.ts`); the 3-assertion suite still passes

This PR now targets `main` directly (retargeted from
`codex/mor-2024-meters-cleanup` after that PR merged), so this is its
first real `Tests (quick)` run -- every gate workflow triggers only on
`pull_request` into `main`, and a codex-branch base never fired them.



