### PR TITLE
fix(MOR-2045): wire WS set_quick_split/set_quick_dual_watch to actually write the toggle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -207,6 +207,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   module and it was never a documented public API; external code that imported
   the old path should vendor the double from the repo's test tree instead.
 
+### Fixed
+
+- **WS `set_quick_split`/`set_quick_dual_watch` now write instead of
+  re-reading (MOR-2007 ruling 2 follow-up, MOR-2045).** Both intents parse
+  `on` from `params` and enqueue new `SetQuickSplit`/`SetQuickDualWatch`
+  poller commands, which write through `CoreRadio.set_quick_split`/
+  `set_quick_dual_watch`. Previously they enqueued the same bare read
+  marker as their `get_` twins and silently re-read the current toggle
+  state instead of changing it.
+
 ## [2.11.1] — 2026-06-22
 
 ### Fixed

--- a/docs/api/command-catalog.md
+++ b/docs/api/command-catalog.md
@@ -40,7 +40,7 @@ A command is batch-eligible when all of the following are true:
 2. It is **not** in `ControlHandler._READ_ONLY_HANDLERS` (i.e., it goes through the ordered command queue).
 3. It produces exactly one queued command.
 
-Commands marked `Batch: No` in the table return error `unsupported_in_batch` when used in a batch. Send those via `POST /api/v1/commands` instead. Note: `get_quick_split` and `get_quick_dual_watch` have `Batch: Yes` despite the `get_` prefix — they enqueue write operations and are queue-backed.
+Commands marked `Batch: No` in the table return error `unsupported_in_batch` when used in a batch. Send those via `POST /api/v1/commands` instead. Note: `get_quick_split` and `get_quick_dual_watch` have `Batch: Yes` despite the `get_` prefix — they are queue-backed, dispatched through the command queue rather than answered directly like other `get_*` commands.
 
 Maximum batch size: 128 steps. Per-step timeout: 10 seconds.
 
@@ -244,9 +244,9 @@ the memory protocol reject these commands.
 | `set_xfc_status` | `on: bool` | — | Yes | XFC on/off. `on` is required. |
 | `set_tx_freq_monitor` | `on: bool` | — | Yes | TX frequency monitor. `on` is required. |
 | `get_quick_split` | — | — | Yes | Enqueues `QuickSplit`, which reads the IC-7300 `1A 05 0030`-style persistent Quick Split menu toggle (`CoreRadio.get_quick_split`, MOR-2007). |
-| `set_quick_split` | — | — | Yes | Enqueues the same `QuickSplit` as `get_quick_split` above and only reads — this WS command does not yet parse an `on` value from `params` to write it (`CoreRadio.set_quick_split` exists and works when called directly; the WS handler just doesn't reach it yet). Not an alias in the underlying command layer any more (MOR-2007 gave `get_`/`set_` real, distinct behavior), only in this WS intent's current wiring. |
+| `set_quick_split` | `on: bool` | — | Yes | Enqueues `SetQuickSplit`, which writes the persistent Quick Split menu toggle via `CoreRadio.set_quick_split` (MOR-2007 ruling 2; wired MOR-2045). `on` is required. |
 | `get_quick_dual_watch` | — | — | Yes | Enqueues `QuickDualWatch`, which reads the equivalent persistent Quick Dual Watch menu toggle (`CoreRadio.get_quick_dual_watch`, MOR-2007). |
-| `set_quick_dual_watch` | — | — | Yes | Same gap as `set_quick_split` above: reads via `QuickDualWatch` rather than writing through `CoreRadio.set_quick_dual_watch`. |
+| `set_quick_dual_watch` | `on: bool` | — | Yes | Enqueues `SetQuickDualWatch`, which writes the persistent Quick Dual Watch menu toggle via `CoreRadio.set_quick_dual_watch` (MOR-2007 ruling 2; wired MOR-2045). `on` is required. |
 | `quick_dualwatch` | — | `dual_rx` | Yes | Composite trigger: equalize MAIN→SUB then enable dual watch (emulates front-panel long-press). |
 | `quick_split` | — | `dual_rx` | Yes | Composite trigger: equalize MAIN→SUB then enable split (emulates front-panel long-press). |
 
@@ -355,7 +355,7 @@ Check `GET /api/v1/capabilities` before building model-specific batches. The
 ## Stability notes
 
 - **Stable:** all commands not listed as experimental below.
-- **Experimental:** `cw_auto_tune` (requires audio relay; FFT peak detection; fails if RX audio is inactive). `get_quick_split`, `set_quick_split`, `get_quick_dual_watch`, `set_quick_dual_watch` — the underlying command/runtime layer now reads and writes the real persistent menu toggle (MOR-2007), but this WS intent's `set_` half still only reads (see the table above); prefer `quick_split` / `quick_dualwatch` for the composite front-panel-emulating trigger, which is unaffected.
+- **Experimental:** `cw_auto_tune` (requires audio relay; FFT peak detection; fails if RX audio is inactive). `get_quick_split`, `set_quick_split`, `get_quick_dual_watch`, `set_quick_dual_watch` — the underlying command/runtime layer reads and writes the real persistent menu toggle (MOR-2007; WS wiring MOR-2045); prefer `quick_split` / `quick_dualwatch` for the composite front-panel-emulating trigger, which is unaffected.
 - **Deprecated aliases (kept for backwards compatibility):** `select_vfo`, `set_power`, `set_squelch`, `set_ipplus`, `set_attenuator`, `set_comp`, `set_compressor`. Use the canonical names listed above in new code.
 
 ---

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -95,6 +95,8 @@ __all__ = [
     "SetPower",
     "SetPowerstat",
     "SetPreamp",
+    "SetQuickDualWatch",
+    "SetQuickSplit",
     "SetRefAdjust",
     "SetRepeaterTone",
     "SetRepeaterTsql",
@@ -809,6 +811,16 @@ class QuickDualWatch:
 
 
 @dataclass(frozen=True, slots=True)
+class SetQuickSplit:
+    on: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SetQuickDualWatch:
+    on: bool
+
+
+@dataclass(frozen=True, slots=True)
 class QuickDwTrigger:
     """Emulate the physical [DUAL-W] long-press:
     equalize MAIN→SUB, then enable Dual Watch.
@@ -950,6 +962,8 @@ Command = (
     | SetUtcOffset
     | QuickSplit
     | QuickDualWatch
+    | SetQuickSplit
+    | SetQuickDualWatch
     | QuickDwTrigger
     | QuickSplitTrigger
     | Speak

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -142,6 +142,8 @@ from ..radio_poller import (  # noqa: TID251
     SetXfcStatus,
     SetTxFreqMonitor,
     SetUtcOffset,
+    SetQuickSplit,
+    SetQuickDualWatch,
     QuickSplit,
     QuickDualWatch,
     QuickDwTrigger,
@@ -469,9 +471,9 @@ class ControlHandler:
             "set_quick_dual_watch",
             # Epic #774 — Quick-DW / Quick-Split composite triggers
             # (emulate the IC-7610 front-panel long-press: equalize M→S
-            # then enable DW/Split).  Distinct from the broken
-            # get_/set_quick_* aliases above, which send the config-flag
-            # read frame 0x1A 05 00 32/33.  See follow-up in epic #774.
+            # then enable DW/Split).  Distinct from the get_/set_quick_*
+            # menu-toggle pair above, which reads/writes the persistent
+            # Quick Split / Quick Dual Watch toggles (MOR-2007, MOR-2045).
             "quick_dualwatch",
             "quick_split",
             # Issue #677 — CW auto-tune via FFT peak detection
@@ -2867,12 +2869,20 @@ class ControlHandler:
                 on = bool(params["on"])
                 q.put(SetTxFreqMonitor(on))
                 return {"on": on}
-            case "get_quick_split" | "set_quick_split":
+            case "get_quick_split":
                 q.put(QuickSplit())
                 return {}
-            case "get_quick_dual_watch" | "set_quick_dual_watch":
+            case "set_quick_split":
+                on = bool(params["on"])
+                q.put(SetQuickSplit(on))
+                return {"on": on}
+            case "get_quick_dual_watch":
                 q.put(QuickDualWatch())
                 return {}
+            case "set_quick_dual_watch":
+                on = bool(params["on"])
+                q.put(SetQuickDualWatch(on))
+                return {"on": on}
             case "quick_dualwatch":
                 self._ensure_capability("dual_rx", "quick_dualwatch")
                 q.put(QuickDwTrigger())

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -202,6 +202,8 @@ __all__ = [
     "SetXfcStatus",
     "SetTxFreqMonitor",
     "SetUtcOffset",
+    "SetQuickSplit",
+    "SetQuickDualWatch",
     "QuickSplit",
     "QuickDualWatch",
     "QuickDwTrigger",
@@ -433,6 +435,8 @@ from .._poller_types import (  # noqa: E402
     SetPower,
     SetPowerstat,
     SetPreamp,
+    SetQuickDualWatch,
+    SetQuickSplit,
     SetRefAdjust,
     SetRepeaterTone,
     SetRepeaterTsql,
@@ -3566,13 +3570,15 @@ class RadioPoller:
                 # MOR-2007 ruling 2: quick_split()/quick_dual_watch() were
                 # deleted -- they always sent a bare GET and never read the
                 # reply, so they fired nothing. get_quick_split() is the
-                # real read of the same persistent menu toggle; a write
-                # path for this intent needs a value threaded through the
-                # web command (params["on"]), which no caller does yet --
-                # left as a follow-up, not silently invented here.
+                # real read of the same persistent menu toggle; the write
+                # path is SetQuickSplit/SetQuickDualWatch below (MOR-2045).
                 await _r.get_quick_split()
             case QuickDualWatch():
                 await _r.get_quick_dual_watch()
+            case SetQuickSplit(on=on):
+                await _r.set_quick_split(on)
+            case SetQuickDualWatch(on=on):
+                await _r.set_quick_dual_watch(on)
             case QuickDwTrigger():
                 self._last_user_write_ts = time.monotonic()
                 if CAP_DUAL_RX in self._caps:

--- a/tests/test_handlers_sys_band.py
+++ b/tests/test_handlers_sys_band.py
@@ -22,6 +22,8 @@ from rigplane.web.radio_poller import (
     SetAfMute,
     SetCivOutputAnt,
     SetCivTransceive,
+    SetQuickDualWatch,
+    SetQuickSplit,
     SetRefAdjust,
     SetTuningStep,
     SetTxFreqMonitor,
@@ -496,12 +498,23 @@ async def test_get_quick_split() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_quick_split() -> None:
+async def test_set_quick_split_on() -> None:
     srv, q = _server()
     h = _handler(radio=_capable_radio(), server=srv)
-    result = await h._enqueue_command("set_quick_split", {})
-    assert result == {}
-    assert isinstance(q.items[0], QuickSplit)
+    result = await h._enqueue_command("set_quick_split", {"on": True})
+    assert result == {"on": True}
+    assert isinstance(q.items[0], SetQuickSplit)
+    assert q.items[0].on is True
+
+
+@pytest.mark.asyncio
+async def test_set_quick_split_off() -> None:
+    srv, q = _server()
+    h = _handler(radio=_capable_radio(), server=srv)
+    result = await h._enqueue_command("set_quick_split", {"on": False})
+    assert result == {"on": False}
+    assert isinstance(q.items[0], SetQuickSplit)
+    assert q.items[0].on is False
 
 
 # ---------------------------------------------------------------------------
@@ -520,12 +533,23 @@ async def test_get_quick_dual_watch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_quick_dual_watch() -> None:
+async def test_set_quick_dual_watch_on() -> None:
     srv, q = _server()
     h = _handler(radio=_capable_radio(), server=srv)
-    result = await h._enqueue_command("set_quick_dual_watch", {})
-    assert result == {}
-    assert isinstance(q.items[0], QuickDualWatch)
+    result = await h._enqueue_command("set_quick_dual_watch", {"on": True})
+    assert result == {"on": True}
+    assert isinstance(q.items[0], SetQuickDualWatch)
+    assert q.items[0].on is True
+
+
+@pytest.mark.asyncio
+async def test_set_quick_dual_watch_off() -> None:
+    srv, q = _server()
+    h = _handler(radio=_capable_radio(), server=srv)
+    result = await h._enqueue_command("set_quick_dual_watch", {"on": False})
+    assert result == {"on": False}
+    assert isinstance(q.items[0], SetQuickDualWatch)
+    assert q.items[0].on is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -55,7 +55,9 @@ from rigplane.web.radio_poller import (
     EnableScope,
     PttOff,
     PttOn,
+    QuickDualWatch,
     QuickDwTrigger,
+    QuickSplit,
     QuickSplitTrigger,
     RadioPoller,
     ScanSetResume,
@@ -85,6 +87,8 @@ from rigplane.web.radio_poller import (
     SetPbtOuter,
     SetPower,
     SetPreamp,
+    SetQuickDualWatch,
+    SetQuickSplit,
     SetRfGain,
     SetScopeCenterType,
     SetScopeDual,
@@ -275,6 +279,10 @@ def _make_radio(active: str = "MAIN", *, model: str = "IC-7610") -> MagicMock:
     radio.set_dual_watch = AsyncMock()
     radio.set_split = AsyncMock()
     radio.equalize_main_sub = AsyncMock()
+    radio.get_quick_split = AsyncMock(return_value=False)
+    radio.set_quick_split = AsyncMock()
+    radio.get_quick_dual_watch = AsyncMock(return_value=False)
+    radio.set_quick_dual_watch = AsyncMock()
     radio.scan_start = AsyncMock()
     radio.scan_stop = AsyncMock()
     radio.scan_set_resume = AsyncMock()
@@ -2740,6 +2748,50 @@ async def test_execute_quick_split_trigger_equalizes_then_enables_split() -> Non
     radio.set_split.assert_awaited_once_with(True)
     assert state.split is True
     assert ("split_changed", {"on": True}) in events
+
+
+@pytest.mark.asyncio
+async def test_execute_quick_split_reads_persistent_toggle() -> None:
+    """QuickSplit: real read of CoreRadio.get_quick_split (MOR-2007/MOR-2045)."""
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(QuickSplit())  # noqa: SLF001
+
+    radio.get_quick_split.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_quick_dual_watch_reads_persistent_toggle() -> None:
+    """QuickDualWatch: real read of CoreRadio.get_quick_dual_watch (MOR-2007/MOR-2045)."""
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(QuickDualWatch())  # noqa: SLF001
+
+    radio.get_quick_dual_watch.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_execute_set_quick_split_writes_persistent_toggle() -> None:
+    """SetQuickSplit: writes through CoreRadio.set_quick_split (MOR-2045)."""
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(SetQuickSplit(on=True))  # noqa: SLF001
+
+    radio.set_quick_split.assert_awaited_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_execute_set_quick_dual_watch_writes_persistent_toggle() -> None:
+    """SetQuickDualWatch: writes through CoreRadio.set_quick_dual_watch (MOR-2045)."""
+    radio = _make_radio()
+    poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+    await poller._execute(SetQuickDualWatch(on=False))  # noqa: SLF001
+
+    radio.set_quick_dual_watch.assert_awaited_once_with(False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the gap PR #2846 (MOR-2007) flagged in its ruling-2 section as "explicitly not fixed ... a distinct change": the WS `set_quick_split` / `set_quick_dual_watch` intents enqueued the same bare `QuickSplit()` / `QuickDualWatch()` read marker as their `get_` twins — no value was ever read from `params` — so a frontend "set" silently re-read the current toggle instead of writing it. MOR-2007 made `CoreRadio.set_quick_split(enabled)` / `set_quick_dual_watch(enabled)` real, which turned this from a moot shape into a live defect.

Ticket: MOR-2045 (sub-issue of MOR-2007).

## What changed

- `runtime/_poller_types.py` — new `SetQuickSplit(on: bool)` / `SetQuickDualWatch(on: bool)` poller commands, following the existing convention (bare marker classes for queue-backed reads, separate `Set*` value-carrying classes for writes — no class plays a dual role; an optional field on `QuickSplit` was considered and rejected as a novel pattern). Added to `__all__` and the `Command` union.
- `web/handlers/control.py` — `_enqueue_rc_misc` splits the two combined match arms into four; the `set_` halves parse `on = bool(params["on"])` and return `{"on": on}`, mirroring `set_xfc_status`. Also rewrote the stale `_COMMANDS` comment calling the pair "broken ... aliases" (false since MOR-2007, doubly false now).
- `web/radio_poller.py` — re-exports the two classes; dispatch arms call `CoreRadio.set_quick_split(on)` / `set_quick_dual_watch(on)` (same shape as `SetXfcStatus`: no `_last_user_write_ts`, no `_radio_state` mutation, no readback-table entry — there is no quick_split state field). The ruling-2 comment on the `QuickSplit()` arm no longer claims the write path is unimplemented.
- Tests — handler tests now assert the enqueued type and `.on` for on/off (`test_set_quick_split_on/off`, `test_set_quick_dual_watch_on/off`); four new poller dispatch pins (`tests/test_radio_poller_coverage.py`), including the two read pins that were previously unpinned at the poller layer. One True / one False across the write pins so an `on`-inversion mutant dies.
- Docs — `command-catalog.md`: the two `set_` rows now document `on: bool` and the write path; the batch note's "they enqueue write operations" mislabel corrected; the Experimental note drops the now-false "set_ half still only reads". CHANGELOG entry under Unreleased → Fixed.

## Soft threshold

7 files > the 6-file soft threshold (137 insertions / 21 deletions, well under the line limits). This is one unit of work: one behavior change (the set intents write), and the other six files are its command vocabulary, its dispatch, its tests, and the two docs whose current text asserts the old behavior in present tense — landing the behavior without the doc rows would leave `command-catalog.md` lying at the merge commit.

## Test evidence

- TDD: both updated test files were written first and failed for the expected reason (`ImportError: cannot import name 'SetQuickDualWatch'`), then passed after implementation.
- Mutation kills: (1) re-instating the original combined `case "get_quick_split" | "set_quick_split"` arm fails exactly the four new handler tests; (2) inverting `on` in the dispatch arms fails exactly the two write pins.
- Gates at head: targeted pytest (3 files) 388 passed (baseline at base commit: 382 passed, all still green); `ruff check` clean; `ruff format` no changes; `mypy --strict src/rigplane/web` clean (26 files); `lint-imports` 5 contracts kept.
- Full standard suite: run on the remote runner against this head — result recorded below in a comment before merge.

## Dependency

Developed on top of #2846 (`codex/mor-2007-vfo-migration`), which supplies `CoreRadio.set_quick_split` / `set_quick_dual_watch`. #2846 squash-merged while this change was being built; this branch was then rebased onto `main` at that squash commit, so the diff here is exactly the MOR-2045 change (one commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
