### PR TITLE
refactor(MOR-2039): tighten the skins eslint zone to the panels tier

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -121,7 +121,8 @@ const FORBIDDEN_SEMANTIC_IMPORTS = {
  * Panels must route store reads through `lib/runtime/adapters/*` (state + commands).
  *
  * Note: this is panel-only on purpose. Other presentation layers (layout, display,
- * meters, vfo, controls, skins) have their own Tier-N migrations tracked under #1063.
+ * meters, vfo, controls) have their own Tier-N migrations tracked under #1063;
+ * skins got its own store ban under MOR-2039 (FORBIDDEN_SKINS_IMPORTS below).
  */
 const FORBIDDEN_PANEL_IMPORTS = {
   patterns: [
@@ -154,6 +155,27 @@ const FORBIDDEN_PANEL_IMPORTS = {
         'Use callback props from the adapter/wiring layer instead. ' +
         'See ADR 2026-04-12.',
     },
+  ],
+};
+
+/**
+ * Skins lockdown (MOR-2039 — tightens skins to the panels-tier lockdown
+ * above). Extends the presentation-components ban (transport, audioManager)
+ * with the same `$lib/stores/*` ban FORBIDDEN_PANEL_IMPORTS applies to
+ * panels: skins are the outermost composition layer and, like panels, must
+ * route state through `lib/runtime/adapters/*` instead of reading stores
+ * directly.
+ */
+const FORBIDDEN_SKINS_IMPORTS = {
+  paths: FORBIDDEN_RUNTIME_IMPORTS.paths,
+  patterns: [
+    {
+      group: ['$lib/stores/*', '$lib/stores', '**/lib/stores/*', '**/lib/stores'],
+      message:
+        'Skins must not import from $lib/stores/* — route via lib/runtime/adapters/* instead. ' +
+        'See docs/plans/2026-04-29-panel-adapter-migration.md and ADR 2026-04-12.',
+    },
+    ...FORBIDDEN_RUNTIME_IMPORTS.patterns,
   ],
 };
 
@@ -387,6 +409,27 @@ export default [
     ],
     rules: {
       'no-restricted-imports': ['error', FORBIDDEN_PANEL_IMPORTS],
+    },
+  },
+
+  // ── Import boundary: skins (MOR-2039 — matches the panels-tier lockdown) ──
+  // Adds `$lib/stores/*` to the skins ban and extends coverage to `.ts`
+  // files — the base "presentation components" block above only globs
+  // `src/skins/**/*.svelte`, so a `.ts` file under skins/ (e.g. registry.ts)
+  // matched no skins-specific rule at all before this. Ordered after that
+  // base block so this fully-merged rule wins for the overlapping `.svelte`
+  // file set (flat config replaces, not merges, per rule key — same idiom
+  // as the panels block above). The two direct store imports this ban
+  // exposed (registry.ts's `normalizeLayoutMode`, SdrVfoScreen.svelte's
+  // `getAgcLabels`/`getAttValues`) were migrated to `lib/runtime/adapters/`
+  // in the same change (`layout-mode-adapter.ts`, `capabilities-adapter.ts`).
+  {
+    files: [
+      'src/skins/**/*.svelte',
+      'src/skins/**/*.ts',
+    ],
+    rules: {
+      'no-restricted-imports': ['error', FORBIDDEN_SKINS_IMPORTS],
     },
   },
 

--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -481,15 +481,13 @@ describe('v3 package boundaries (MOR-1061)', () => {
   });
 
   // ── MOR-1093: the sdr-test entrypoint's own import boundary ────────────
-  // `src/skins/**/*.svelte` (and components-v2/layout/**) carry the looser
+  // `src/skins/**/*.svelte` (and components-v2/layout/**) carried the looser
   // FORBIDDEN_RUNTIME_IMPORTS ban (transport + audioManager only — unlike
-  // the presentation/ zone above, capabilities and commands are legal here)
+  // the presentation/ zone above, capabilities and commands were legal here)
   // since MOR-1061, but nothing in this file had ever run that rule through
   // the real config for the sdr-test path. SdrTestSkin.svelte is a pure
   // RadioLayout delegate with no other import; these pin the rule that keeps
-  // it that way, and confirm the capabilities import SdrVfoScreen.svelte
-  // gained under MOR-1093 (replacing a hardcoded manufacturer-specific
-  // fallback table) stays inside the boundary this zone actually enforces.
+  // it that way.
 
   // .svelte fixtures need a <script> block (see the workspace .svelte test
   // above) — svelte-eslint-parser only treats code inside it as a Program
@@ -521,10 +519,46 @@ describe('v3 package boundaries (MOR-1061)', () => {
     expect(hits).toBe(0);
   });
 
-  it('allows the sdr-test diagnostic renderer to import capabilities (unlike the presentation/ zone)', async () => {
+  // ── MOR-2039: skins tightened to the panels tier ───────────────────────
+  // Skins no longer get the "capabilities and commands are legal here"
+  // exception the MOR-1093 comment above used to describe: `$lib/stores/*`
+  // is now banned here too (matching FORBIDDEN_PANEL_IMPORTS), and the zone
+  // now also covers `src/skins/**/*.ts` — before this, a `.ts` file under
+  // skins/ (e.g. registry.ts) matched no skins-specific rule at all, because
+  // the file glob this zone used was `src/skins/**/*.svelte` only.
+  // SdrVfoScreen.svelte and registry.ts migrated their store reads to
+  // `lib/runtime/adapters/` (capabilities-adapter.ts, layout-mode-adapter.ts
+  // respectively); these pin both the new ban and that the migrated call
+  // sites stay inside the boundary.
+
+  it('rejects the sdr-test diagnostic renderer importing capabilities from the store directly (was allowed pre-MOR-2039)', async () => {
     const hits = await restrictedImportHits(
       `<script lang="ts">\n  import { getAgcLabels, getAttValues } from '$lib/stores/capabilities.svelte';\n</script>`,
       'src/skins/sdr-test/SdrVfoScreen.svelte',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('allows the sdr-test diagnostic renderer to import capabilities through the adapter (its actual migrated import)', async () => {
+    const hits = await restrictedImportHits(
+      `<script lang="ts">\n  import { getAgcLabels, getAttValues } from '$lib/runtime/adapters/capabilities-adapter';\n</script>`,
+      'src/skins/sdr-test/SdrVfoScreen.svelte',
+    );
+    expect(hits).toBe(0);
+  });
+
+  it('rejects a skins .ts file importing $lib/stores/* directly (the glob fix — .ts under skins/ had zero coverage before)', async () => {
+    const hits = await restrictedImportHits(
+      `import { normalizeLayoutMode } from '$lib/stores/layout.svelte';`,
+      'src/skins/registry.ts',
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it('allows skins/registry.ts to import layout-mode normalization through the adapter (its actual migrated import)', async () => {
+    const hits = await restrictedImportHits(
+      `import { normalizeLayoutMode } from '$lib/runtime/adapters/layout-mode-adapter';`,
+      'src/skins/registry.ts',
     );
     expect(hits).toBe(0);
   });

--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -483,8 +483,8 @@ describe('v3 package boundaries (MOR-1061)', () => {
   // ── MOR-1093: the sdr-test entrypoint's own import boundary ────────────
   // `src/skins/**/*.svelte` (and components-v2/layout/**) carried the looser
   // FORBIDDEN_RUNTIME_IMPORTS ban (transport + audioManager only — unlike
-  // the presentation/ zone above, capabilities and commands were legal here)
-  // since MOR-1061, but nothing in this file had ever run that rule through
+  // the presentation/ zone above, capabilities were legal here) since
+  // MOR-1061, but nothing in this file had ever run that rule through
   // the real config for the sdr-test path. SdrTestSkin.svelte is a pure
   // RadioLayout delegate with no other import; these pin the rule that keeps
   // it that way.
@@ -520,10 +520,10 @@ describe('v3 package boundaries (MOR-1061)', () => {
   });
 
   // ── MOR-2039: skins tightened to the panels tier ───────────────────────
-  // Skins no longer get the "capabilities and commands are legal here"
-  // exception the MOR-1093 comment above used to describe: `$lib/stores/*`
-  // is now banned here too (matching FORBIDDEN_PANEL_IMPORTS), and the zone
-  // now also covers `src/skins/**/*.ts` — before this, a `.ts` file under
+  // Skins no longer get the "capabilities are legal here" exception the
+  // MOR-1093 comment above used to describe: `$lib/stores/*` is now banned
+  // here too (matching FORBIDDEN_PANEL_IMPORTS), and the zone now also
+  // covers `src/skins/**/*.ts` — before this, a `.ts` file under
   // skins/ (e.g. registry.ts) matched no skins-specific rule at all, because
   // the file glob this zone used was `src/skins/**/*.svelte` only.
   // SdrVfoScreen.svelte and registry.ts migrated their store reads to

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
@@ -117,7 +117,8 @@ afterEach(() => {
   resetCommandLifecycle();
 });
 
-/* ── capabilities-adapter.ts — full 4-export surface, zero prior coverage ── */
+/* ── capabilities-adapter.ts — 4 of its 6 exports, zero prior coverage
+ * (getAgcLabels/getAttValues, added under MOR-2039, aren't covered here) ── */
 
 describe('capabilities-adapter.ts over the live ic7300 caps (MOR-1562)', () => {
   it('getMeterCalibration: exact swr knot points from the live capture', () => {

--- a/frontend/src/lib/runtime/adapters/capabilities-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/capabilities-adapter.ts
@@ -2,14 +2,16 @@
  * Capabilities adapter — exposes capability-derived helpers that don't fit
  * a single panel's typed view-model.
  *
- * Tier 2 batch 2 of the panel→adapter migration (audit doc:
- * `docs/plans/2026-04-29-panel-adapter-migration.md`). The four exports
- * below cover exactly the capability surface that the in-scope helpers
+ * Started as Tier 2 batch 2 of the panel→adapter migration (audit doc:
+ * `docs/plans/2026-04-29-panel-adapter-migration.md`) with four exports
+ * covering the capability surface that the in-scope helpers
  * (`meter-utils.ts`, `filter-controls.ts`) and panels
- * (`AudioRoutingControl.svelte`) currently read from
- * `$lib/stores/capabilities.svelte` directly. Per-panel capability flags
- * already live on `derive*Props()` (see `panel-adapters.ts`); this adapter
- * is intentionally thin, not a parallel hierarchy.
+ * (`AudioRoutingControl.svelte`) read from `$lib/stores/capabilities.svelte`
+ * directly. `getAgcLabels`/`getAttValues` were added under MOR-2039 for the
+ * equivalent skins-tier migration (`skins/sdr-test/SdrVfoScreen.svelte`).
+ * Per-panel capability flags already live on `derive*Props()` (see
+ * `panel-adapters.ts`); this adapter is intentionally thin, not a parallel
+ * hierarchy.
  *
  * Reads delegate directly to the capabilities store (the same pattern
  * other adapters use, e.g. `qsy-history-adapter.ts`, `lcd-chrome-adapter.ts`)
@@ -21,6 +23,8 @@ import {
   getControlRange as _getControlRange,
   getMeterCalibration as _getMeterCalibration,
   getMeterRedline as _getMeterRedline,
+  getAgcLabels as _getAgcLabels,
+  getAttValues as _getAttValues,
 } from '$lib/stores/capabilities.svelte';
 import type { ControlRange } from '$lib/types/capabilities';
 
@@ -68,4 +72,23 @@ export function getControlRange(name: string): ControlRange | null {
  */
 export function getReceiverLabel(id: 'MAIN' | 'SUB'): string {
   return id;
+}
+
+/**
+ * AGC mode → display label map for the active profile (e.g.
+ * `{ '1': 'FAST', '2': 'MID' }`). Routed through capabilities so callers
+ * (e.g. `skins/sdr-test/SdrVfoScreen.svelte`) don't carry their own
+ * per-manufacturer guess (MOR-1093).
+ */
+export function getAgcLabels(): Record<string, string> {
+  return _getAgcLabels();
+}
+
+/**
+ * Attenuator dB steps for the active profile (e.g. `[0, 6, 12, 18]`).
+ * Routed through capabilities for the same reason as `getAgcLabels`
+ * (MOR-1093).
+ */
+export function getAttValues(): number[] {
+  return _getAttValues();
 }

--- a/frontend/src/lib/runtime/adapters/layout-mode-adapter.ts
+++ b/frontend/src/lib/runtime/adapters/layout-mode-adapter.ts
@@ -1,0 +1,14 @@
+/**
+ * Layout-mode adapter — thin façade over `normalizeLayoutMode` for
+ * `skins/registry.ts` (MOR-2039, which banned skins from importing
+ * `$lib/stores/*` directly, matching the panels-tier ban).
+ *
+ * `normalizeLayoutMode` (`lib/stores/layout.svelte.ts`) takes an explicit
+ * value and maps it to its canonical/alias-resolved form; it reads no store
+ * state, so a mechanical re-export is a correct, lossless wrapper — the
+ * same re-export shape `lcd-chrome-adapter.ts` uses to front its (stateful)
+ * store pair, per the precedent in
+ * docs/plans/2026-04-29-panel-adapter-migration.md ("Cluster C", option 1).
+ */
+
+export { normalizeLayoutMode, type LayoutMode } from '$lib/stores/layout.svelte';

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -13,7 +13,7 @@ import type { AppResource } from '$lib/runtime/resource-demand';
 import {
   normalizeLayoutMode,
   type LayoutMode,
-} from '$lib/stores/layout.svelte';
+} from '$lib/runtime/adapters/layout-mode-adapter';
 
 export type SkinId =
   | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';

--- a/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
+++ b/frontend/src/skins/sdr-test/SdrVfoScreen.svelte
@@ -22,7 +22,7 @@
   import { formatFrequency } from '../../components-v2/display/frequency-format';
   import type { VfoStateProps } from '../../components-v2/layout/layout-utils';
   import { calibratedToRaw, calibratedToSUnit, getScaleMaxRaw, getS9Raw } from '../../components-v2/meters/smeter-scale';
-  import { getAgcLabels, getAttValues } from '$lib/stores/capabilities.svelte';
+  import { getAgcLabels, getAttValues } from '$lib/runtime/adapters/capabilities-adapter';
   import { HardwareButton } from '$lib/Button';
 
   /**


### PR DESCRIPTION
**Supersedes #2847** (same branch, `codex/mor-2039-skins-lint-zone`, same reviewed substance — new PR number only because of a GitHub platform restriction, explained below). #2842 (MOR-2041) merged as `6a30cc14`; this branch is rebased onto current `main` and targets it directly — the diff below is the real, final diff, not the PR2-only stack diff #2847 showed.

**Why a new PR number:** #2842's squash-merge deleted its branch, which was #2847's base — GitHub closed #2847 automatically. Rebasing onto `main` and force-pushing (required to get a real head for CI, per the BLOCKED review below) is normal for an open PR, but GitHub does not allow reopening a *closed* PR once its head branch has been force-pushed: `PATCH .../pulls/2847` returns `"state cannot be changed. The codex/mor-2039-skins-lint-zone branch was force-pushed or recreated."`, and this holds even after restoring the base branch that had been deleted. That block is unconditional once triggered, not a permissions issue on this session's end. #2847 stays closed with a pointer to this PR; no work was redone, no history was rewritten.

## Fix round (response to `Agent Review: BLOCKED 398a107b`)

The verifier confirmed the substance (mutation-tested rule, real adapter, no duplication) and blocked on two things:

1. **No CI had ever run at this head** — every gate workflow is `pull_request: branches: [main]`, and this PR targeted `codex/mor-2041-2039-skins`, which no longer exists. Fixed by rebasing onto `main` (`1a50a694` dropped as already-applied-upstream — its diff is byte-identical to `6a30cc14`'s squash-merge content; `398a107b` replayed clean) and opening against `main` directly. `main` gained four more commits between #2842 merging and this push (`010fa05d`, `7ba9369b`, `5a835322`, `2f205546`); none touch a file this PR touches (checked each `--stat` individually), so the rebase landed on the actual current tip with no conflicts.
2. **Two false "commands" claims** in `architecture-boundaries.test.ts` (lines ~486, ~523 pre-fix) said skins lost a "capabilities *and commands* are legal here" exception. Commands were never banned for skins — `FORBIDDEN_SKINS_IMPORTS` has no `FORBIDDEN_COMMANDS_PATTERN`, neither before nor after this PR (a skins fixture importing `$lib/runtime/commands/vfo` scores 0 hits, both pre- and post-MOR-2039). Only `$lib/stores/*` changed. Narrowed both comments to name capabilities only.

Re-ran the mutation check that proves the rule is load-bearing twice — once right after each rebase (the second was a corrective re-rebase onto `main`'s further-advanced tip, see above): removed the `src/skins/**` block from `eslint.config.js` — the same 2 "rejects" fixtures went red both times (`expected 0 to be greater than 0`), nothing else moved (88 passed / 2 failed of 90). Restored both times; back to 90/90. Neither rebase silently dropped the config hunk.

### Non-blocking word fixes, applied

- `mor1562-adapter-seams-conformance.isolated.test.ts`'s section comment said "capabilities-adapter.ts — full 4-export surface" — stale at six exports since this PR adds `getAgcLabels`/`getAttValues`. Narrowed to "4 of its 6 exports" and named the two this file doesn't cover.
- PR body: "five `presentation/layouts/__tests__/*-registration.test.ts` files" (two occurrences) → there are four (`desktop-v2`, `lcd`, `mobile`, `sdr`; confirmed by listing the directory).
- PR body: the "swept every test that mocks either module" bullet named 1 file. Re-swept below.

### Sweep of the same class (per repo doctrine: one wrong instance → check the whole class)

Grepped the whole tree for the "capabilities and commands ... legal" phrase shape: only the two occurrences above exist in tracked source. Also grepped for the same *stale export-count* shape as the mor1562 fix (`capabilities-adapter.ts` claimed to have a fixed small number of exports):

- **Found and fixed** (in this diff): `mor1562-adapter-seams-conformance.isolated.test.ts` (above).
- **Checked and already correct**: `capabilities-adapter.ts`'s own header docstring. It says the adapter *started* with four exports and that `getAgcLabels`/`getAttValues` were added under MOR-2039 — historically framed, doesn't assert a current total, doesn't go stale. No fix needed.
- **Found, NOT fixed (outside this PR's file scope)**: `frontend/src/lib/runtime/adapters/__tests__/conformance/harness.ts:37` — "`capabilities-adapter.ts` imports both alongside the already-mocked `getControlRange`, and omitting them would leave two of that adapter's four exports uncallable." Same stale-count shape, now six. Checked whether it's more than cosmetic: the harness's `$lib/stores/capabilities.svelte` mock (lines 87–103) doesn't stub `getAgcLabels`/`getAttValues` either, so capabilities-adapter.ts's two MOR-2039 exports would throw if called through this harness. Currently dormant — none of the nine `mor15xx-*-conformance.isolated.test.ts` files that consume this shared harness call those two functions (confirmed by grep across `*.isolated.test.ts`). Flagging for whoever next extends that harness or those exports; not fixed here since `harness.ts` is outside this PR's file scope and fixing it would mean adding mock coverage, not just a word.

### Re-derived the "swept every mock" enumeration properly

The original claim ("swept every test that mocks either module") named 1 file; the BLOCKED review's own recount found 3, but *that recount was also incomplete*. A direct grep for `vi.mock('....skins/registry', ...)` at every relative depth turns up **8** real call sites (a 9th hit is a doc-comment example in `qa-cockpit-override.ts`, not a real mock call). Of those 8, 7 use a full factory replacement (`vi.mock(path, () => ({...}))`), so the real `registry.ts` — and its changed import line — is never evaluated:

`src/__tests__/presentation-switch-resources.component.test.ts`, `src/__tests__/presentation-switch-tx.component.test.ts`, `src/__tests__/lazy-presentation.component.test.ts`, `src/__tests__/app-global-host.component.test.ts`, `src/components-v2/layout/__tests__/top-row-visual-regression.isolated.test.ts`, `src/lib/runtime/tx-controller/__tests__/app-lifecycle.component.test.ts`, `src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts`.

The 8th, `src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts`, mocks the same module via `importOriginal` (spreads the real module, overrides `resolveSkinId`) — that one *does* load the real `registry.ts`, including its changed `normalizeLayoutMode` import. Ran it standalone to confirm: 46/46 passed. That's additional live coverage of the migrated import, not a gap.

### CI at the new head

`Tests (quick)` was still queued behind other concurrent PRs on this repo's single self-hosted runner as of this push (run `33346529381`, head `2edede4a`) — this repo has exactly one self-hosted runner, and `quick.yml`/`full.yml`/`visual.yml` all serialize through it. Not waited out in this session; the assigned verifier confirms the run result (including the skipped count and whether the frontend block executed) once the queue drains.

## Summary

Tightens the `skins/**` ESLint zone to match the panels-tier lockdown: `$lib/stores/*` is now banned from skins (previously only transport + audio-manager were), and the zone's glob now covers `src/skins/**/*.ts` in addition to `*.svelte` — before this, a `.ts` file under `skins/` (notably `registry.ts`) matched no skins-specific rule at all.

**Critical constraint driving this PR's shape:** no workflow (`quick.yml`, `full.yml`, `publish.yml`) runs `npm run lint` or `npm run lint:boundaries`. The only CI coverage of any frontend ESLint rule is `frontend/src/__tests__/architecture-boundaries.test.ts`, which lints virtual fixtures programmatically through `vitest`. A rule added to `eslint.config.js` alone would have zero enforcement, so the new rule is pinned there — see "Test changes" below.

## eslint.config.js

Added `FORBIDDEN_SKINS_IMPORTS` (transport + audio-manager, reused from `FORBIDDEN_RUNTIME_IMPORTS`, plus a `$lib/stores/*` ban with skins-specific wording — not a verbatim reuse of `FORBIDDEN_PANEL_IMPORTS`'s message text, which says "Panels must not...") and a new block for `src/skins/**/*.svelte` + `src/skins/**/*.ts`, ordered after the existing base block so it wins for the overlapping `.svelte` set (same "flat config replaces per rule key" idiom the panels-tier block already uses). Updated the panels-block comment that used to list "skins" among the layers still deferred to their own Tier-N migration — it isn't anymore.

## Test changes (`architecture-boundaries.test.ts`)

- Flipped the existing "allows the sdr-test diagnostic renderer to import capabilities (unlike the presentation/ zone)" test — that exception is gone. Renamed and now asserts `hits > 0` for the same fixture.
- Added: a skins `.ts` fixture (`registry.ts`-shaped) importing `$lib/stores/*` now trips the rule — pins the glob fix specifically (before this PR, this exact fixture scored 0 hits because no rule matched `.ts` files under skins at all).
- Added: both real migrated call sites (below) stay legal through their adapter — one fixture per file, importing from `$lib/runtime/adapters/*`, asserting `0` hits.
- Updated the MOR-1093 section comment, which described skins' old "capabilities are legal here" exception — no longer true.

## Migrated the two real direct-store imports the new rule exposed

Verified via `eslint src/skins/**/*.{ts,svelte}` before this change: exactly these two files, zero others.

- **`skins/registry.ts`** — `normalizeLayoutMode` (from `$lib/stores/layout.svelte`) → new `lib/runtime/adapters/layout-mode-adapter.ts`. `normalizeLayoutMode` takes an explicit value and reads no store state, so a mechanical re-export is a lossless wrapper — the same shape `lcd-chrome-adapter.ts` already uses to front its (stateful) store pair (`docs/plans/2026-04-29-panel-adapter-migration.md`, "Cluster C", option 1).
  - *Searched:* grepped `lib/runtime/adapters/` for any existing import of `$lib/stores/layout.svelte` — none. Nearest existing thing is `lcd-chrome-adapter.ts`'s re-export shape; followed it rather than inventing a new pattern.
- **`skins/sdr-test/SdrVfoScreen.svelte`** — `getAgcLabels`/`getAttValues` (from `$lib/stores/capabilities.svelte`) → extended the existing `lib/runtime/adapters/capabilities-adapter.ts` with two more thin passthroughs, matching its four existing exports exactly. Updated its header comment, which claimed "four exports below" — no longer true at six.
  - *Searched:* `panel-adapters.ts`'s `toAgcProps` derives a full per-panel `AgcProps` view-model through the runtime singleton (`ServerState` + `Capabilities` params) — doesn't fit, since `SdrVfoScreen.svelte` is a pure-props component that only needs the raw label/value lookup, not a view-model. `capabilities-adapter.ts` already wraps exactly this "thin passthrough of a capabilities-store getter" pattern four times (`getMeterCalibration`, `getMeterRedline`, `getControlRange`, `getReceiverLabel`); extended it as the fifth/sixth rather than starting a parallel file (close-enough-is-reuse).

`SdrVfoScreen.svelte` is dead code (tracked under MOR-1099 — its own header comment says "not currently mounted"; no production imports). Per the brief, not deleting it (that's a different ticket's call) — migrated its import like every other skins file rather than inventing an adapter nobody else would call, since an adapter whose only caller is a component nobody mounts is still an orphan in spirit even with one caller.

## No behavior change

`normalizeLayoutMode` and `getAgcLabels`/`getAttValues` are unmodified — only re-exported one hop further out. Swept every test that reads `registry.ts` or `SdrVfoScreen.svelte` as raw source text or mocks either module, to make sure none of them assert on the changed import line:
- `sdr-registration.test.ts`'s hardcoded-table check (`not.toMatch(/const AGC_LABELS/)` etc.) matches call sites, not import lines — unaffected.
- 7 suites mock the entire `skins/registry` module via a factory replacement (listed in "Fix round" above) — the real file's internal import is never evaluated in any of them. An 8th, `RadioLayout.isolated.test.ts`, mocks it via `importOriginal` and does load the real (migrated) import — still 46/46 green.
- `skins/__tests__/registry.test.ts` (outside this PR's file scope — entrypoints lane) imports the real `resolveSkinId`/`resolvePersistedSkinId`, exercising the real `normalizeLayoutMode` either way; unaffected and still green.
- Four `presentation/layouts/__tests__/*-registration.test.ts` files and `semantic-mobile-migration.component.test.ts` scan `registry.ts`'s `SKIN_LOADERS`/`SkinId` content, not its import lines — unaffected.

## Out of scope (per the brief, not touched)

The ~15 deferred direct-store imports in `components-v2/layout|meters|vfo|controls` are Tier 3 of `docs/plans/2026-04-29-panel-adapter-migration.md` and explicitly out of scope for this PR.

## Verification

- `npm run check` — 0 errors, 0 warnings (4598 files — re-run at the final rebased head; the file count moved from the originally-reported 4601 because unrelated `main` churn since this PR was opened deleted a few dead files, e.g. #2839's `MeterPanel.svelte`/`NeedleGauge.svelte`)
- `npx vitest run` across `architecture-boundaries.test.ts`, `skins/__tests__/registry.test.ts`, `lib/stores/__tests__/layout.test.ts`, all four `presentation/layouts/__tests__/*-registration.test.ts` + `cockpit-topology-adaptation.test.ts`, `presentation-switch-resources.component.test.ts`, `semantic-mobile-migration.component.test.ts`, and `mor1562-adapter-seams-conformance.isolated.test.ts` — **11 files / 267 tests passed** (re-run and recounted directly at the rebased head — the original body's "10 files" didn't match its own named file list under either the "five" or the corrected "four" registration-file count; the 267 test count was already right)
- `npm run lint` / `npm run lint:boundaries` — clean
- `eslint "src/skins/**/*.{ts,svelte}"` — clean (all six skins)
- Full local frontend suite: run by the independent verifier against `398a107b` pre-rebase (368 files / 8118 tests passed, 0 skipped, 0 failed) and not repeated here (this environment's 10-minute foreground ceiling doesn't fit a full run). The CI run below is the first real gate execution at any head of this PR.

## Size

7 files changed (6 modified + 1 new), 133 insertions / 18 deletions. Over the soft-threshold file count (6), under the line count (600) and both hard-ceiling numbers (10 files / 1000 lines). The 7th file and the extra lines are the fix-round's own prose corrections (`mor1562-...isolated.test.ts` plus a few more comment lines in `architecture-boundaries.test.ts`) responding to the same review cycle as the original 6-file change — not new scope, the same unit of work closing out.
