### PR TITLE
feat(MOR-2007): migrate ptt.py onto the bound command map (steps 5..N, module 4)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `self._commands.<builder>(...)` in the same change — an external caller
   of a free function must do the same rather than calling it directly
   with no map.
+- **`rigplane.commands.ptt` builders require `cmd_map`; there is no
+  hardcoded fallback (MOR-2007, Steps 5..N module 4 of
+  `docs/plans/2026-08-29-profile-driven-command-bytes.md`).** `ptt_on`/
+  `ptt_off` now require `cmd_map` as a required keyword-only argument, the
+  same way as `rigplane.commands.config`/`levels`/`vfo` above. No wire
+  bytes changed: every CI-V profile already declared the identical
+  `[0x1C, 0x00, 0x01]`/`[0x1C, 0x00, 0x00]` tuple the deleted fallback
+  built (the one profile that used to disagree, X6100, was already fixed
+  before this migration). The two production call sites, both in
+  `runtime/radio.py: CoreRadio` — `set_ptt` and the managed-TX
+  `_write_managed_ptt` — moved onto `self._commands.ptt_on`/`.ptt_off` in
+  the same change, touching only the frame-building expression and
+  nothing else in either method (the latter sits in the managed-TX
+  transmit-interlock path).
 - **CLI: `rigplane ptt on` no longer returns while the rig is keyed.** The
   command now holds the key for as long as the process runs and unkeys on the
   way out, so the process that keyed the rig is the one that releases it. A

--- a/src/rigplane/commands/ptt.py
+++ b/src/rigplane/commands/ptt.py
@@ -1,4 +1,30 @@
-"""PTT on/off commands."""
+"""PTT on/off commands.
+
+Migrated onto the bound command map in MOR-2007 Steps 5..N (module 4,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4): both builders
+now require ``cmd_map``, with no hardcoded fallback left. This module
+accounted for 2 of the rows `tests/command_map_parity_divergences.txt`
+recorded before the plan's Step 2 (MOR-2002 step 2b-ptt): ``rigs/x6100.toml``
+already held the 3-byte ``[0x1C, 0x00, <payload>]`` tuple the Q7 tuple
+contract requires, and the ``cmd_map`` branch doubled the payload byte on
+top of it. That divergence was fixed before this migration (commits
+9957ee49/713172a6); the wire bytes below are unchanged by this commit --
+only the ``cmd_map`` requirement is new. Every CI-V profile in `rigs/`
+now declares the identical ``[0x1C, 0x00, 0x01]``/``[0x1C, 0x00, 0x00]``
+tuple, matching the fallback's own bytes exactly (verified by grep across
+`rigs/*.toml` before deleting it), so `tests/command_map_parity_divergences.txt`
+is empty of ptt.py rows and stays that way.
+
+``_CMD_PTT`` (0x1C) survives in `commands/_frame.py`: `commands/system.py`'s
+unmigrated ``get_tuner_status``/``set_tuner_status``/``get_xfc_status``/
+``set_xfc_status``/``get_tx_freq_monitor``/``set_tx_freq_monitor`` still read
+it for their own fallback branches (0x1C is the whole "transceiver status"
+CI-V command family, not just PTT). ``_SUB_PTT`` (0x00) also survives:
+`tests/test_radio.py` imports it directly to build synthetic CivFrames for
+unrelated managed-TX/ACK-tracking tests, unconnected to this module's own
+fallback -- the migration contract deletes a constant only this module's
+fallback alone read, and this one is read elsewhere too.
+"""
 
 from __future__ import annotations
 
@@ -6,11 +32,9 @@ from typing import TYPE_CHECKING
 
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_PTT,
-    _SUB_PTT,
     _build_from_map,
-    build_civ_frame,
     expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -18,40 +42,24 @@ if TYPE_CHECKING:
 
 
 @expose_command_key(lambda cmd_map: "ptt_on")
+@require_cmd_map
 def ptt_on(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a PTT-on CI-V command.
 
     The payload byte (0x01) is constant, so under the tuple contract
     (Q7, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1)
-    every profile's ``ptt_on`` tuple already carries it; the map branch
-    passes no ``data`` of its own. Exposes its command-map key as a plain
-    literal (MOR-2003 Step 3, §3.1) for `commands/bound.py:
-    BoundCommands.expect`.
+    every profile's ``ptt_on`` tuple already carries it; this builder
+    passes no ``data`` of its own.
     """
-    if cmd_map is not None:
-        return _build_from_map(cmd_map, "ptt_on", to_addr=to_addr, from_addr=from_addr)
-    return build_civ_frame(to_addr, from_addr, _CMD_PTT, sub=_SUB_PTT, data=b"\x01")
+    return _build_from_map(cmd_map, "ptt_on", to_addr=to_addr, from_addr=from_addr)
 
 
 @expose_command_key(lambda cmd_map: "ptt_off")
+@require_cmd_map
 def ptt_off(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    """Build a PTT-off CI-V command.
-
-    The payload byte (0x00) is constant, so under the tuple contract
-    (Q7, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1)
-    every profile's ``ptt_off`` tuple already carries it; the map branch
-    passes no ``data`` of its own. Exposes its command-map key as a plain
-    literal (MOR-2003 Step 3, §3.1) for `commands/bound.py:
-    BoundCommands.expect`.
-    """
-    if cmd_map is not None:
-        return _build_from_map(cmd_map, "ptt_off", to_addr=to_addr, from_addr=from_addr)
-    return build_civ_frame(to_addr, from_addr, _CMD_PTT, sub=_SUB_PTT, data=b"\x00")
+    """Build a PTT-off CI-V command. See ``ptt_on``."""
+    return _build_from_map(cmd_map, "ptt_off", to_addr=to_addr, from_addr=from_addr)

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -194,8 +194,6 @@ from rigplane.commands import (
     parse_powerstat,
     power_off,
     power_on,
-    ptt_off,
-    ptt_on,
     send_cw,
     set_af_mute,
     set_agc,
@@ -3763,9 +3761,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         civ = (
-            ptt_on(to_addr=self._radio_addr)
+            self._commands.ptt_on(to_addr=self._radio_addr)
             if on
-            else ptt_off(to_addr=self._radio_addr)
+            else self._commands.ptt_off(to_addr=self._radio_addr)
         )
         await self._send_civ_raw(civ, priority=Priority.IMMEDIATE, wait_response=False)
         logger.debug("set_ptt(%s) sent (fire-and-forget)", on)
@@ -3849,7 +3847,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         return self._civ_runtime.capture_managed_port(provider_generation, observer)
 
     async def _write_managed_ptt(self, provider_generation: int, on: bool) -> None:
-        civ = (ptt_on if on else ptt_off)(to_addr=self._radio_addr)
+        civ = (self._commands.ptt_on if on else self._commands.ptt_off)(
+            to_addr=self._radio_addr
+        )
         await self._civ_runtime.write_managed_ptt(civ, provider_generation)
 
     async def _retire_managed_tx_port(self, provider_generation: int) -> None:

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -26,16 +26,16 @@
 # reachable from a builder that was compared, not sites observed to
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
-census	builders_compared	140
+census	builders_compared	138
 census	cat_only_profiles	2
-census	dual_implementation_sites	105
+census	dual_implementation_sites	103
 census	frames_diverged	0
-census	frames_identical	983
+census	frames_identical	971
 census	hardcode_only_builders	16
-census	profile_builder_map_gaps	570
+census	profile_builder_map_gaps	566
 census	profiles	8
 census	public_builders	230
-census	sites_compared	100
+census	sites_compared	98
 cat-only	FTX-1	108
 cat-only	TX-500	50
 gap	get_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
@@ -105,8 +105,6 @@ gap	get_vox	FTX-1,TX-500,X6100,X6200
 gap	get_xfc_status	FTX-1,TX-500,X6100,X6200
 gap	power_off	FTX-1,TX-500,X6100,X6200
 gap	power_on	FTX-1,TX-500,X6100,X6200
-gap	ptt_off	FTX-1,TX-500
-gap	ptt_on	FTX-1,TX-500
 gap	scope_data_output	FTX-1,TX-500,X6100,X6200
 gap	scope_off	FTX-1,TX-500,X6100,X6200
 gap	scope_on	FTX-1,TX-500,X6100,X6200
@@ -221,6 +219,8 @@ requires-map	levels.py:set_rf_power
 requires-map	levels.py:set_squelch
 requires-map	levels.py:set_vox_delay
 requires-map	levels.py:set_vox_gain
+requires-map	ptt.py:ptt_off
+requires-map	ptt.py:ptt_on
 requires-map	vfo.py:get_dual_watch
 requires-map	vfo.py:get_main_sub_band
 requires-map	vfo.py:get_quick_dual_watch

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -206,10 +206,19 @@ class TestSetterParity:
         assert commands.set_tuning_step(3, cmd_map=cmd_map) == expected
 
     def test_ptt_on(self, cmd_map):
-        assert commands.ptt_on(cmd_map=cmd_map) == commands.ptt_on()
+        # commands/ptt.py migrated onto the bound command map in MOR-2007
+        # Steps 5..N (module 4): ptt_on now requires cmd_map -- pinned
+        # against the frame the deleted fallback used to build.
+        expected = build_civ_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x1C, sub=0x00, data=b"\x01"
+        )
+        assert commands.ptt_on(cmd_map=cmd_map) == expected
 
     def test_ptt_off(self, cmd_map):
-        assert commands.ptt_off(cmd_map=cmd_map) == commands.ptt_off()
+        expected = build_civ_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x1C, sub=0x00, data=b"\x00"
+        )
+        assert commands.ptt_off(cmd_map=cmd_map) == expected
 
     def test_power_on(self, cmd_map):
         assert commands.power_on(cmd_map=cmd_map) == commands.power_on()
@@ -237,18 +246,22 @@ class TestSetterParity:
 
 class TestPttWireContractAcrossProfiles:
     """MOR-2002 step 2b-ptt (Q7, ``docs/plans/2026-08-29-profile-driven-
-    command-bytes.md`` §8.1): a ``[commands]`` tuple carries the full
-    constant prefix, payload byte included. Before this fix,
-    ``rigs/ic705.toml``, ``rigs/ic7300.toml``, ``rigs/ic7610.toml``,
-    ``rigs/ic9700.toml`` and ``rigs/x6200.toml`` held a 2-byte
-    ``ptt_on``/``ptt_off`` tuple and the ``cmd_map`` branch appended the
-    payload byte itself; ``rigs/x6100.toml`` already held the 3-byte tuple,
-    so its map branch doubled the payload
-    (``tests/command_map_parity_divergences.txt``, X6100 rows). This
-    sweeps every CI-V profile in ``rigs/`` that declares
-    ``ptt_on``/``ptt_off`` and requires the map branch and the fallback
-    branch to build the identical frame, ending in the explicit payload
-    byte.
+    command-bytes.md`` §8.1) fixed a doubled-payload divergence while
+    ``ptt.py`` still had a fallback to compare against: ``rigs/ic705.toml``,
+    ``rigs/ic7300.toml``, ``rigs/ic7610.toml``, ``rigs/ic9700.toml`` and
+    ``rigs/x6200.toml`` held a 2-byte ``ptt_on``/``ptt_off`` tuple and the
+    ``cmd_map`` branch appended the payload byte itself; ``rigs/x6100.toml``
+    already held the 3-byte tuple, so its map branch doubled the payload
+    (``tests/command_map_parity_divergences.txt``, X6100 rows, since fixed
+    by commits 9957ee49/713172a6).
+
+    MOR-2007 Steps 5..N (module 4) made ``cmd_map`` required and deleted the
+    fallback, so there is no more "identical to fallback" to assert --
+    converted the same way ``config.py``'s/``levels.py``'s/``vfo.py``'s own
+    migrations converted their equivalent classes (the transitional pin
+    recorded from the #2820 review): every CI-V profile that declares
+    ``ptt_on``/``ptt_off`` is swept and each is pinned directly, ending in
+    the explicit payload byte the Q7 contract requires.
     """
 
     @staticmethod
@@ -263,18 +276,14 @@ class TestPttWireContractAcrossProfiles:
     def test_at_least_one_civ_profile_declares_ptt(self) -> None:
         assert self._civ_ptt_maps()
 
-    def test_ptt_on_identical_to_fallback_on_every_civ_profile(self) -> None:
+    def test_ptt_on_ends_with_the_payload_byte_on_every_civ_profile(self) -> None:
         for model, cmd_map in self._civ_ptt_maps().items():
             mapped = commands.ptt_on(cmd_map=cmd_map)
-            fallback = commands.ptt_on()
-            assert mapped == fallback, model
             assert mapped.endswith(b"\x1c\x00\x01\xfd"), model
 
-    def test_ptt_off_identical_to_fallback_on_every_civ_profile(self) -> None:
+    def test_ptt_off_ends_with_the_payload_byte_on_every_civ_profile(self) -> None:
         for model, cmd_map in self._civ_ptt_maps().items():
             mapped = commands.ptt_off(cmd_map=cmd_map)
-            fallback = commands.ptt_off()
-            assert mapped == fallback, model
             assert mapped.endswith(b"\x1c\x00\x00\xfd"), model
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -345,15 +345,39 @@ class TestFilterWidthCommands:
 
 
 class TestPttCommands:
-    """Test PTT on/off commands."""
+    """Test PTT on/off commands.
 
-    def test_ptt_on(self) -> None:
-        frame = ptt_on()
+    commands/ptt.py migrated onto the bound command map in MOR-2007
+    Steps 5..N (module 4): both builders now require cmd_map. IC-7610's
+    declared ptt_on/ptt_off bytes are unchanged from the deleted
+    fallback's (every CI-V profile already agreed, per the empty
+    tests/command_map_parity_divergences.txt), so the expected literals
+    below are unchanged too -- only the cmd_map= wiring is new.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_ptt_on(self, cmd_map) -> None:
+        frame = ptt_on(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1c\x00\x01\xfd"
 
-    def test_ptt_off(self) -> None:
-        frame = ptt_off()
+    def test_ptt_off(self, cmd_map) -> None:
+        frame = ptt_off(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1c\x00\x00\xfd"
+
+    def test_ptt_on_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            ptt_on()  # type: ignore[call-arg]
+
+    def test_ptt_off_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            ptt_off(cmd_map=None)
 
 
 class TestAckNak:


### PR DESCRIPTION
## Summary

Fourth module migration of Steps 5..N, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4:

> Steps 5..N — Migrate module by module, requests and replies together. One domain module per PR. For each: (a) make `cmd_map` required keyword-only and delete the fallback branch and the constants it alone read; (b) move that module's call sites in `runtime/radio.py`, `runtime/_scope_runtime.py`, `runtime/_dual_rx_runtime.py`, `backends/_icom_serial_base.py` onto the binder; (c) move that module's response matchers **in the same commit**.

`vfo.py` (module 3, #2846) merged first; `ptt.py` is module 4. `scope.py` is held for the next signal.

## Verified against the code, not carried forward — the module's real scope is 2 builders

The dispatch named this module's scope as "`ptt_on`/`ptt_off` + `get_/set_transceiver_status` builders and their fallback branches." **No `get_transceiver_status`/`set_transceiver_status` builder exists anywhere in `commands/`** — grepped the whole package. What does exist: `rigs/ic705.toml`, `x6100.toml` and `x6200.toml` declare a `get_transceiver_status`/`set_transceiver_status` **TOML key** at the identical `[0x1C, 0x00]` tuple `ptt_on`/`ptt_off` use — but nothing in code resolves a name by that key. This is the reverse-index collision the plan's own evidence documents (§C9: *"1C 00 resolves to {get_transceiver_status, ptt_off, ptt_on, set_transceiver_status}"* on IC-705/X6200) and rules out of this programme's scope (Q3, tracked separately as MOR-1993, which blocks MOR-2010). Inventing a builder for it here would be exactly the reverse-index work the owner ruled deferred. Not touched.

So this PR migrates `ptt_on`/`ptt_off` — the module's actual and complete builder surface.

## Divergence file: verified empty, ptt's own rows already closed pre-migration

`tests/command_map_parity_divergences.txt` is empty (confirmed) — the `vfo.py` merge (#2846) removed the last 9 rows. `ptt.py`'s own 2 rows (X6100's doubled payload byte under the pre-Q7 tuple contract) closed earlier, in #2820, before this migration started. Every CI-V profile (`ic705`, `ic7300`, `ic7610`, `ic9700`, `x6100`, `x6200`) now declares the identical `[0x1C, 0x00, 0x01]`/`[0x1C, 0x00, 0x00]` tuple the deleted fallback built (verified by grep across `rigs/*.toml` before deleting it) — **zero wire bytes change** in this PR, only the `cmd_map` requirement.

## Constants: `_CMD_PTT` kept, `_SUB_PTT` kept — both read elsewhere

Per the migration contract ("delete the constants it alone read," grep the whole repo first):

- **`_CMD_PTT` (0x1C) stays** in `commands/_frame.py` — `commands/system.py`'s unmigrated `get_tuner_status`/`set_tuner_status`/`get_xfc_status`/`set_xfc_status`/`get_tx_freq_monitor`/`set_tx_freq_monitor` still read it for their own fallback branches (0x1C is the whole "transceiver status" CI-V family, not just PTT).
- **`_SUB_PTT` (0x00) stays** — `tests/test_radio.py` imports it directly for three synthetic-`CivFrame` tests unconnected to `ptt.py`'s own fallback (managed-TX pacing, ACK/NAK-tracker backlog isolation). Not "alone read" by the deleted fallback, so not deleted.

## Transmit-interlock adjacency: frame-building line only, control flow untouched

Both production call sites are in `runtime/radio.py: CoreRadio`:

- **`set_ptt(on)`** — fire-and-forget (`wait_response=False`, IMMEDIATE priority). Changed `ptt_on(to_addr=...)`/`ptt_off(to_addr=...)` to `self._commands.ptt_on(...)`/`.ptt_off(...)`; nothing else in the method touched.
- **`_write_managed_ptt(provider_generation, on)`** — the managed-TX / transmit-interlock path: hands the frame to `self._civ_runtime.write_managed_ptt(civ, provider_generation)` under a captured provider-generation token. Changed only the frame-building expression `civ = (ptt_on if on else ptt_off)(to_addr=...)` → `civ = (self._commands.ptt_on if on else self._commands.ptt_off)(to_addr=...)`. No restructuring; the token capture, generation check, and `execute_civ_transaction(..., expect="none")` call inside `write_managed_ptt` are byte-for-byte unchanged.

No matcher/keystone extension needed: `ptt.py` has no getter (PTT status reads go through `CoreRadio.read_transmit_state`, which builds its own raw `0x1C 0x00` frame directly, unrelated to this module), and both call sites are fire-and-forget with no reply shape to migrate (`_write_managed_ptt` explicitly passes `expect="none"`).

## Retired `TestPttWireContractAcrossProfiles` into profile-only frame pins

Per the #2820 review's own recorded instruction: the class's `test_ptt_on_identical_to_fallback_on_every_civ_profile`/`test_ptt_off_identical_to_fallback_on_every_civ_profile` compared the map path against `commands.ptt_on()`/`commands.ptt_off()` called bare — that "fallback" call now raises `TypeError` (cmd_map required), so the comparison subject is gone. Converted to pin the map path directly per declaring profile, ending in the explicit payload byte the Q7 contract requires (`...1c 00 01` / `...1c 00 00`) — **no fallback resurrected** to keep it green. Same file's `TestSetterParity::test_ptt_on`/`test_ptt_off` and `tests/test_commands.py::TestPttCommands` converted the same way `config.py`'s/`levels.py`'s/`vfo.py`'s own migrations converted their equivalents (load_rig-backed `cmd_map` fixture, pin the map path directly).

## Sweep + backstop

**Corrected sweep** ("tests calling a migrated builder," both bare-name and `commands.<builder>(...)` attribute-call shapes) as a standalone AST script across every file in `tests/`: **6 hits before this commit** (the 4 just-converted call sites + the 2 `TestPttWireContractAcrossProfiles` sites), **1 after** — the single deliberate negative test (`test_ptt_on_requires_cmd_map`, proving the Q6 `TypeError`), added by this commit.

**Local:** targeted only, per instructions — `tests/test_commands.py`, `test_command_map_integration.py`, `test_profile_command_binding.py`, `test_undeclared_command_policy.py`, `test_naming_parity.py`, `test_radio.py`, every transmit-interlock/managed-TX-adjacent file (`test_web_ptt_arm_failure.py`, `test_web_ptt_audio_teardown.py`, `test_web_ptt_readonly.py`, `test_web_teardown_unkey_gate.py`, `test_web_managed_tx_owner.py`, `test_tx_authority_characterisation.py`, `test_radio_poller_tx_interlock.py`, `test_web_mod_input_restore.py`, `validation/test_tx_actuate.py`, `test_audio_rx_tx_transition.py`, `test_mor1427_rate_limiter_coalesce.py`, `test_command_service.py`), plus `test_cmd29_parsing.py`, `test_rigctld_handler.py`, `test_rigctld_protocol.py`, `test_handlers_coverage.py`, `test_rig_ic7300.py`, `test_rig_ic7610.py`, `test_rig_loader.py` — **all green**, plus `ruff check`/`ruff format` and `lint-imports` clean.

**Remote full-suite backstop** (`the dedicated remote test runner codex/mor-2007-ptt-migration py`), dispatched after pushing: **PASS — 11118 passed, 84 skipped, 48 xfailed, 0 failed, 84s.** `ruff check`: all checks passed.

## Parity/coverage deltas — every line explained

**`tests/command_map_parity_divergences.txt`**: no diff (already empty, stays empty).

**`tests/command_map_parity_uncovered.txt`** (exact deltas): `builders_compared` 140 → 138 (−2), `dual_implementation_sites` 105 → 103 (−2), `frames_identical` 983 → 971 (−12: 6 CI-V profiles × 2 builders leaving the two-sided comparison), `profile_builder_map_gaps` 570 → 566 (−4: FTX-1/TX-500 × 2 builders), `sites_compared` 100 → 98 (−2), `public_builders` unchanged at 230 (no names added or removed — `ptt_on`/`ptt_off` already existed). Both `gap ptt_off`/`gap ptt_on` (FTX-1, TX-500) rows removed — that census only counts a `KeyError` from the now-defunct two-sided comparison. 2 new `requires-map` rows added.

**`tests/profile_command_coverage_gaps.txt`**: **no diff at all.** `ptt_on`/`ptt_off` were already fully declared on every CI-V profile before this migration — requiring `cmd_map` doesn't change builder→key coverage.

## Guardrails

**5 files, 173 changed lines** (initial), **6 files / 187 changed lines** after the CHANGELOG entry — well within the soft threshold (6/600) and hard ceiling (10/1000). Matches the expected size named in the dispatch ("small, one module, 4 builders" — turned out to be 2 real builders once verified against the code, smaller still).

Internal-identifier self-check across the full diff: performed, empty.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

