### PR TITLE
refactor: delete the dead vfo_a_equals_b/vfo_swap builders (mechanism-audit D1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `self._commands.<builder>(...)` in the same change — an external caller
   of a free function must do the same rather than calling it directly
   with no map.
+- **`rigplane.commands.vfo_a_equals_b` and `rigplane.commands.vfo_swap` are
+  removed** (mechanism audit D1; see
+  `.claude/audits/2026-08-30-mechanism-audit-vfo-swap-equalize.md`). The
+  MOR-2007 migration above made `cmd_map` required on both without
+  changing their bytes; this change deletes them outright. Both had zero
+  production call sites and built the identical frame to `set_vfo(0xA0, ...)`
+  and `set_vfo(0xB0, ...)` respectively — both go through the same
+  `_build_from_map(cmd_map, "set_vfo", ...)` call, so a caller wanting the
+  raw bytes gets identical frames from `set_vfo` either way. The
+  profile-driven replacements are
+  `DualReceiverCapable.swap_main_sub`/`equalize_main_sub` and
+  `VfoSlotCapable.swap_vfo_ab`/`equalize_vfo_ab` on the `Radio` protocol.
+  `vfo_a_equals_b`'s hardcoded `0xA0` equalize byte matched no shipped
+  dual-RX profile: IC-7610 and IC-9700, the only two `main_sub`-scheme
+  profiles, both declare `equal_main_sub = [0xB1]`.
 - **CLI: `rigplane ptt on` no longer returns while the rig is keyed.** The
   command now holds the key for as long as the process runs and unkeys on the
   way out, so the process that keyed the rig is the one that releases it. A

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -164,8 +164,6 @@ ptt_off(to_addr=0x98) -> bytes
 # ``[vfo] main_select`` / ``sub_select`` — this builder holds no
 # name-to-byte table. ``radio.py: CoreRadio._set_vfo_wire`` resolves it.
 select_vfo(code: int, to_addr=0x98) -> bytes
-vfo_a_equals_b(to_addr=0x98) -> bytes
-vfo_swap(to_addr=0x98) -> bytes
 set_split(on: bool, to_addr=0x98) -> bytes
 ```
 

--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -274,11 +274,11 @@
       "family": "baseline_core",
       "status": "implemented",
       "runtime_symbols": [
-        "rigplane.commands:vfo_swap",
+        "rigplane.runtime._dual_rx_runtime:DualRxRuntimeMixin.swap_main_sub",
         "rigplane.radio:CoreRadio.swap_main_sub"
       ],
       "test_patterns": [
-        "tests/test_commands_extended.py::test_vfo_swap"
+        "tests/test_vfo_dual_watch.py::test_ic7610_swap_main_sub_sends_0x07_0xb0"
       ]
     },
     {
@@ -292,11 +292,11 @@
       "family": "baseline_core",
       "status": "implemented",
       "runtime_symbols": [
-        "rigplane.commands:vfo_a_equals_b",
+        "rigplane.runtime._dual_rx_runtime:DualRxRuntimeMixin.equalize_main_sub",
         "rigplane.radio:CoreRadio.equalize_main_sub"
       ],
       "test_patterns": [
-        "tests/test_commands_extended.py::test_vfo_a_equals_b"
+        "tests/test_vfo_dual_watch.py::test_ic7610_equalize_main_sub_sends_0x07_0xb1"
       ]
     },
     {

--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -200,8 +200,6 @@ from .vfo import (
     set_vfo,
     start_scan,
     stop_scan,
-    vfo_a_equals_b,
-    vfo_swap,
 )
 
 # --- dsp.py ---
@@ -750,8 +748,6 @@ __all__ = [
     "get_xfc_status",
     "set_xfc_status",
     # VFO extras
-    "vfo_a_equals_b",
-    "vfo_swap",
     "get_split",
     "set_split",
     # Memory

--- a/src/rigplane/commands/vfo.py
+++ b/src/rigplane/commands/vfo.py
@@ -121,37 +121,6 @@ def set_vfo(
     )
 
 
-@expose_command_key(lambda cmd_map: "set_vfo")
-@require_cmd_map
-def vfo_a_equals_b(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
-) -> bytes:
-    """Copy VFO A to VFO B (A=B).
-
-    No production caller reaches this builder (or ``vfo_swap`` below):
-    `runtime/_dual_rx_runtime.py: equalize_vfo_ab`/``swap_vfo_ab`` build
-    the same ``0x07`` frame directly from ``RadioProfile.equal_ab_code``/
-    ``swap_ab_code`` instead, which is the profile-driven byte this
-    builder's ``data=b"\\xa0"`` is not -- out of scope for MOR-2007 (no
-    divergence row and no owner ruling name it); left unchanged, migrated
-    only for ``cmd_map`` per the module-wide contract.
-    """
-    return _build_from_map(
-        cmd_map, "set_vfo", to_addr=to_addr, from_addr=from_addr, data=b"\xa0"
-    )
-
-
-@expose_command_key(lambda cmd_map: "set_vfo")
-@require_cmd_map
-def vfo_swap(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
-) -> bytes:
-    """Swap VFO A and B. See ``vfo_a_equals_b`` -- same caller situation."""
-    return _build_from_map(
-        cmd_map, "set_vfo", to_addr=to_addr, from_addr=from_addr, data=b"\xb0"
-    )
-
-
 @expose_command_key(lambda cmd_map: "set_split")
 @require_cmd_map
 def set_split(

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -34,7 +34,7 @@ census	frames_identical	983
 census	hardcode_only_builders	16
 census	profile_builder_map_gaps	570
 census	profiles	8
-census	public_builders	230
+census	public_builders	228
 census	sites_compared	100
 cat-only	FTX-1	108
 cat-only	TX-500	50
@@ -241,8 +241,6 @@ requires-map	vfo.py:set_quick_split
 requires-map	vfo.py:set_split
 requires-map	vfo.py:set_tuning_step
 requires-map	vfo.py:set_vfo
-requires-map	vfo.py:vfo_a_equals_b
-requires-map	vfo.py:vfo_swap
 unpinned	_builders.py:_build_ctl_mem_get
 unpinned	power.py:get_powerstat
 unpinned	system.py:set_system_date

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -9,7 +9,7 @@
 census	civ_profiles	6
 census	distinct_gap_keys	154
 census	profile_key_gaps	330
-census	public_builders	230
+census	public_builders	228
 gap	get_acc1_mod_level	X6100,X6200
 gap	get_af_mute	X6100,X6200
 gap	get_agc_time_constant	X6100,X6200

--- a/tests/test_commands_extended.py
+++ b/tests/test_commands_extended.py
@@ -12,8 +12,6 @@ from rigplane.commands import (
     build_civ_frame,
     parse_civ_frame,
     select_vfo,
-    vfo_a_equals_b,
-    vfo_swap,
     set_split,
     set_attenuator,
     set_preamp,
@@ -59,20 +57,6 @@ class TestSelectVfo:
         # on cmd_map being omitted (both now raise TypeError post-MOR-2007).
         with pytest.raises(TypeError):
             select_vfo("MAIN", cmd_map=cmd_map)
-
-
-class TestVfoCommands:
-    def test_vfo_a_equals_b(self, cmd_map):
-        frame = vfo_a_equals_b(cmd_map=cmd_map)
-        parsed = parse_civ_frame(frame)
-        assert parsed.command == 0x07
-        assert parsed.data == b"\xa0"
-
-    def test_vfo_swap(self, cmd_map):
-        frame = vfo_swap(cmd_map=cmd_map)
-        parsed = parse_civ_frame(frame)
-        assert parsed.command == 0x07
-        assert parsed.data == b"\xb0"
 
 
 class TestSplit:

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -110,9 +110,14 @@ MATCHER_BACKED_GETTERS: tuple[_GetterSpec, ...] = (
     # .sub -- it cannot route through _get_bcd_level/_get_bool_value at
     # all, and is instead pinned directly by
     # test_get_dual_watch_reply_marker_comes_from_the_map below, this
-    # file's keystone case for that shape. get_vfo, get_main_sub_band,
-    # vfo_a_equals_b and vfo_swap have no production caller in
-    # runtime/radio.py, so there is no CoreRadio getter to register here.
+    # file's keystone case for that shape. get_vfo and get_main_sub_band
+    # have no production caller in runtime/radio.py, so there is no
+    # CoreRadio getter to register here. The 0x07 swap/equalize ops --
+    # `runtime/_dual_rx_runtime.py: DualRxRuntimeMixin.swap_vfo_ab`/
+    # `equalize_vfo_ab`/`swap_main_sub`/`equalize_main_sub` -- are
+    # runtime methods that build the frame from a profile-declared code,
+    # not `rigplane.commands` builders, so there is no commands-layer
+    # getter to register for them either.
     _GetterSpec("get_quick_split", "_get_bool_value"),
     _GetterSpec("get_quick_dual_watch", "_get_bool_value"),
 )


### PR DESCRIPTION
## What

Deletes `rigplane.commands.vfo_a_equals_b` and `rigplane.commands.vfo_swap` and their evidence trail: the re-exports in `commands/__init__.py`, the two direct tests, the ic7610 parity-matrix citations, the two regenerated command-map census snapshots, two lines in `docs/api/commands.md`, a CHANGELOG breaking-change entry, and one test comment that named the deleted builders.

## Why

Mechanism-audit finding **D1** (vestigial fork) — adjudicated by the `auditor` role at main commit `7479ebd5`, archived in PR #2848 as `.claude/audits/2026-08-30-mechanism-audit-vfo-swap-equalize.md`. The short version:

- **Zero production call sites** for either builder, established by an AST call census over `src/` and `tests/` (not a text grep), including the one dynamic-resolution path (`BoundCommands.__getattr__`), TOML command-map keys, rigctld verb routing, and a literal grep of a rigplane-pro checkout.
- Each is **byte-for-byte `set_vfo(0xA0/0xB0, ...)`** — same map key ("set_vfo"), same frame builder. There is no capability `set_vfo` does not already offer; raw-byte callers keep an escape hatch.
- The hardcoded bytes violate `commands/LAYER.md` ("Forbidden patterns: hardcoding rig-specific bytes inside a builder") and the data-driven doctrine. The hardcoded equalize byte `0xA0` matches **no shipped dual-RX profile** (IC-7610/IC-9700 declare `0xB1`).
- The live, correctly-located implementations are `DualRxRuntimeMixin.swap_vfo_ab`/`equalize_vfo_ab`/`swap_main_sub`/`equalize_main_sub` (profile-declared codes, Tier-1 protocols).
- The old parity-matrix citations were **factually wrong**: entry #10 ("VFO Equal MS") records wire `07 B1`, which `vfo_a_equals_b` never emitted. Entries #9/#10 now cite the live mixin methods, whose wire bytes match, plus the `tests/test_vfo_dual_watch.py` tests that assert exactly those bytes.

## Breaking change

Removing exported functions from `rigplane.commands` — declared in the CHANGELOG following the MOR-1986/MOR-2006 precedent. `open-core-policy.md` §5 places `commands/` outside the protected boundary, and the archived owner ruling of 2026-08-30 (`.claude/audits/README.md`, ruling 4) says dead public API must not be frozen by a release.

## Guardrails

9 files — over the 6-file soft threshold, one unit of work: a single deletion plus its mechanically-entailed collateral (2 export lines, 2 tests, 2 regenerated census snapshots whose gate fails otherwise, 2 doc lines, 1 CHANGELOG entry, 1 comment rewrite). 93 changed lines. Splitting any part out would leave a red gate or a false comment.

## Verification

- Targeted suite (`test_commands_extended`, `test_ic7610_parity_matrix`, `test_profile_command_binding`, `test_command_map_parity`, `test_profile_command_coverage`): baseline at base `5a835322` **239 passed / 1 skipped** → **233 passed / 1 skipped**; the delta is exactly the 6 removed test items (2 direct tests + 4 dynamically parametrized cases in `test_profile_command_binding`, which builds its parametrize list from the live builder set).
- `ruff check` clean, `ruff format` no-op, `lint-imports` 5 kept / 0 broken.
- Mutation check on the repointed parity citations (first pass): corrupting either the runtime symbol or the test pattern fails `test_ic7610_parity_matrix` — the citations discriminate.
- Full suite runs in CI on this PR (`quick.yml` path filters match).

## Notes

- Based on post-#2846 main (`5a835322`) — no conflict with the MOR-2007 vfo migration; the builders deleted here are the post-migration (`@require_cmd_map`) versions.
- `docs/plans/discovery-artifacts/` snapshots still name the builders; they are declared point-in-time snapshots and are intentionally untouched.
- Residual caveat from the audit: absence of out-of-tree PyPI consumers cannot be proven; the CHANGELOG entry is the mitigation, per precedent.
- Follow-ups (audit findings D2, D3, F1, F2) are intentionally NOT bundled — D1 must land alone so the fork's abandoned side cannot be consolidated into the live side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)