### PR TITLE
test: delete dead SerialMockRadio VFO stubs and unasserted AsyncMocks (mechanism-audit D3)

### DIFF
--- a/tests/serial_stub.py
+++ b/tests/serial_stub.py
@@ -633,18 +633,6 @@ class SerialMockRadio:
     # Backward-compat alias
     select_vfo = set_vfo
 
-    async def vfo_swap(self) -> None:
-        return None
-
-    async def vfo_exchange(self) -> None:
-        return None
-
-    async def vfo_a_equals_b(self) -> None:
-        return None
-
-    async def vfo_equalize(self) -> None:
-        return None
-
     async def set_powerstat(self, on: bool) -> None:
         self._connected = on
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -474,12 +474,10 @@ def mock_radio() -> MagicMock:
     radio.set_attenuator_level = AsyncMock()
     radio.set_preamp = AsyncMock()
     radio.set_vfo = AsyncMock()
-    radio.vfo_swap = AsyncMock()
     # Canonical dual-RX VFO methods on ``DualReceiverCapable`` (post-#1114);
     # the radio_poller invokes these directly.
     radio.swap_main_sub = AsyncMock()
     radio.equalize_main_sub = AsyncMock()
-    radio.vfo_a_equals_b = AsyncMock()
     radio.set_main_sub_tracking = AsyncMock()
     radio.get_main_sub_tracking = AsyncMock(return_value=False)
     # ScopeCapable protocol attrs (all required for isinstance check in Python 3.12+)


### PR DESCRIPTION
## Summary

Mechanism-audit finding D3 (adjudication archived via #2848): six dead lines in the test tree, deleted.

- `tests/serial_stub.py` — `SerialMockRadio.vfo_swap` / `.vfo_exchange` / `.vfo_a_equals_b` / `.vfo_equalize`: four async no-op bodies, zero call sites.
- `tests/test_web_server.py` — `radio.vfo_swap = AsyncMock()` / `radio.vfo_a_equals_b = AsyncMock()` in the `mock_radio` fixture: never awaited, never asserted.

## Census (verified at 2f205546 = merge base)

- The web `radio_poller` executes `VfoSwap`/`VfoEqualize` only via the canonical `swap_vfo_ab(0)` / `swap_main_sub()` / `equalize_vfo_ab(0)` / `equalize_main_sub()` (`radio_poller.py: RadioPoller` command match, post-#1114); `test_web_server.py: test_vfo_swap_command` asserts `swap_main_sub` directly, and the fixture sets those canonical methods separately.
- `serial_stub.py: _MockObservationPoller` drains the command queue with a structural `match` over `Set*`/`Ptt*` classes only — no `VfoSwap`/`VfoEqualize` arm, no dynamic `getattr` dispatch.
- No capability protocol in `core/radio_protocol.py` names any of the four; `hasattr` probes on these strings are only the negative `assert not hasattr(r, ...)` pins on the async `IcomRadio` (unaffected).
- Same-named live things deliberately untouched: the `vfo_swap`/`vfo_equalize` WS intent strings across web/frontend, the blocking-wrapper aliases `runtime/sync.py: IcomRadio.vfo_equalize` / `.vfo_exchange` (live API, exercised by `tests/test_sync_coverage.py`; the sync wrapper itself is undocumented — `docs/api/radio.md` renders the *async* `runtime.radio.IcomRadio`, whose same-named aliases were removed in v0.19; that doc rot is pre-existing and out of scope here), and the `commands/vfo.py` builders (finding D1, handled by #2853 — no overlap).

Test-tree only; no CHANGELOG entry per the finding's scope.

*(Prose corrections after independent review: an earlier revision of this body called the sync wrapper "SyncRadio" — no such class exists — and misattributed its documentation to `docs/api/radio.md`. The diff was never affected.)*

## Test plan

- Baseline at 2f205546, then post-change: targeted suite (`test_web_server`, `test_backend_contract_matrix`, `test_ic705_backend`, `test_lifecycle_diagnostics`, `test_rigctld_server`, `test_serial_backend_smoke`, `test_serial_stub_framing`, `tests/integration/`) with the standard CI-parity flags: 572 passed / 58 skipped / 0 failed (baseline's 3 fails were the known parallel-run flakes, pass serially).
- Independent verifier additionally ran a mutation check: reinstated all six deletions at the merge base as tripwires (`raise AssertionError` bodies / failing AsyncMocks) and re-ran the full targeted set — 572 passed / 58 skipped / 0 failed, proving zero reachability across 100% of `serial_stub` importers.
- `ruff check src/ tests/` clean; `ruff format --check` unchanged.
- Full suite via CI (quick.yml triggers on `tests/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
