### PR TITLE
refactor: delete RadioProfile.vfo_swap_code/vfo_equal_code dead aliases (mechanism-audit D2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,6 +138,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the `Radio` protocol method never took a receiver for this reading —
   so this closes a footgun rather than changing observed behaviour; a caller
   that did pass `receiver=` now gets a `TypeError` instead of a silent SET.
+- **`RadioProfile.vfo_swap_code` and `RadioProfile.vfo_equal_code` are
+  removed** (mechanism-audit D2; both were self-documented deprecated since
+  issue #710). Read `swap_ab_code`/`swap_main_sub_code` (or
+  `equal_ab_code`/`equal_main_sub_code`) directly; the alias resolution the
+  properties performed was `swap_main_sub_code or swap_ab_code` (and the
+  `equal_` equivalent), so a caller that needs the old ordering inlines that
+  expression. No production code in this repository read either property —
+  consumers were tests only.
 
 ### Changed
 

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -429,24 +429,6 @@ class RadioProfile:
     # consume it lands in a later row of the same epic.
     tx_policy: TxPolicy = field(default_factory=TxPolicy)
 
-    @property
-    def vfo_swap_code(self) -> int | None:
-        """Legacy alias — prefers ``swap_main_sub_code`` for dual-RX rigs.
-
-        Deprecated: use :attr:`swap_ab_code` or :attr:`swap_main_sub_code`
-        directly (issue #710).
-        """
-        return self.swap_main_sub_code or self.swap_ab_code
-
-    @property
-    def vfo_equal_code(self) -> int | None:
-        """Legacy alias — prefers ``equal_main_sub_code`` for dual-RX rigs.
-
-        Deprecated: use :attr:`equal_ab_code` or :attr:`equal_main_sub_code`
-        directly (issue #710).
-        """
-        return self.equal_main_sub_code or self.equal_ab_code
-
     def supports_capability(self, capability: str) -> bool:
         return capability in self.capabilities
 

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -192,9 +192,6 @@ class TestVFOScheme:
         # In ab scheme, "sub" maps to VFO-B
         assert profile.vfo_sub_code == 0x01
 
-    def test_vfo_swap_code(self, profile):
-        assert profile.vfo_swap_code == 0xB0
-
 
 # ── Capabilities ───────────────────────────────────────────────
 

--- a/tests/test_rig_ic7610.py
+++ b/tests/test_rig_ic7610.py
@@ -189,9 +189,6 @@ class TestProfileParity:
     def test_vfo_sub_code(self, profile):
         assert profile.vfo_sub_code == 0xD1
 
-    def test_vfo_swap_code(self, profile):
-        assert profile.vfo_swap_code == 0xB0
-
     def test_freq_ranges_count(self, profile):
         assert len(profile.freq_ranges) == 2
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1377,8 +1377,6 @@ class TestToProfile:
         profile = load_rig(TEMPLATE_PATH).to_profile()
         assert profile.vfo_main_code == 0xD0
         assert profile.vfo_sub_code == 0xD1
-        # Legacy alias still works (issue #710)
-        assert profile.vfo_swap_code == 0xB0
         # IC-7610 template uses legacy [vfo].swap with scheme=main_sub
         assert profile.swap_main_sub_code == 0xB0
         assert profile.swap_ab_code is None
@@ -1502,13 +1500,6 @@ class TestVfoSchemeSplit:
         assert profile.swap_ab_code == 0x07
         assert profile.equal_ab_code == 0x07
 
-    def test_legacy_aliases_prefer_main_sub_when_dual(self, tmp_path):
-        p = _write_toml(tmp_path, self._MAIN_SUB_SPLIT)
-        profile = load_rig(p).to_profile()
-        # Legacy alias returns main_sub value when both are set
-        assert profile.vfo_swap_code == 0xB0
-        assert profile.vfo_equal_code == 0xB1
-
     def test_legacy_swap_maps_to_main_sub_on_dual_scheme(self, tmp_path):
         toml = """\
         [radio]
@@ -1547,8 +1538,6 @@ class TestVfoSchemeSplit:
         assert profile.equal_main_sub_code == 0xB1
         assert profile.swap_ab_code is None
         assert profile.equal_ab_code is None
-        # Legacy alias still resolves
-        assert profile.vfo_swap_code == 0xB0
 
     def test_legacy_swap_maps_to_ab_on_single_rx_scheme(self, tmp_path):
         toml = """\
@@ -1586,9 +1575,6 @@ class TestVfoSchemeSplit:
         assert profile.equal_ab_code == 0xA0
         assert profile.swap_main_sub_code is None
         assert profile.equal_main_sub_code is None
-        # Legacy alias still resolves to the ab code
-        assert profile.vfo_swap_code == 0xB0
-        assert profile.vfo_equal_code == 0xA0
 
     def test_no_deprecation_when_only_new_keys(self, tmp_path, recwarn):
         p = _write_toml(tmp_path, self._MAIN_SUB_SPLIT, name="new_only.toml")

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3788,7 +3788,6 @@ async def test_on_radio_state_change_broadcasts_canonical_state_payload() -> Non
     radio.profile.supports_cmd29 = MagicMock(return_value=False)
     radio.profile.vfo_sub_code = None
     radio.profile.vfo_main_code = None
-    radio.profile.vfo_swap_code = None
 
     srv = WebServer(radio)
     queue = BoundedQueue[dict[str, object]](maxsize=4)


### PR DESCRIPTION
## What

Deletes the two dead legacy alias properties `RadioProfile.vfo_swap_code` and `RadioProfile.vfo_equal_code` (`src/rigplane/profiles/__init__.py`) and their test collateral, with a `### Breaking changes` CHANGELOG entry.

## Why

Mechanism-audit finding **D2** (report archived by #2848: `.claude/audits/2026-08-30-mechanism-audit-vfo-swap-equalize.md`). Both properties were self-documented deprecated (issue #710) and had **zero production readers**: the only `src/` occurrences were the two `def` lines. Owner ruling #4 in `.claude/audits/README.md` — dead public API must not be frozen by a release — applies.

Census re-verified at current main (`2f205546`), matching the audit at `7479ebd5`:
- `src/`: only the two `def` lines
- `tests/`: 8 read assertions + 1 mock write (`test_web_server_coverage.py`), all pinning the aliases themselves
- no `getattr`/string-form access anywhere; zero hits in `frontend/`, `docs/`, `rigs/`

## Changes

- `src/rigplane/profiles/__init__.py` — both `@property` blocks deleted (−18 lines)
- `tests/test_rig_ic7300.py`, `tests/test_rig_ic7610.py` — `test_vfo_swap_code` deleted (each asserted only the alias)
- `tests/test_rig_loader.py` — `test_legacy_aliases_prefer_main_sub_when_dual` deleted (alias-only); alias assertions removed from three surviving tests (the TOML legacy-key mapping and its `DeprecationWarning` pins stay untouched)
- `tests/test_web_server_coverage.py` — one dead mock-write line removed
- `docs/CHANGELOG.md` — breaking-change entry with the replacement expression (`swap_main_sub_code or swap_ab_code`, and the `equal_` equivalent)

## One unit of work (soft threshold: 6 files)

The 6th file is the CHANGELOG entry required for documented `RadioProfile` surface; the other five are one deletion plus its direct collateral — none is separable without leaving the tree red or the census dirty.

## Verification

- Targeted suite (`test_rig_ic7300`, `test_rig_ic7610`, `test_rig_loader`, `test_web_server_coverage`): baseline **674 passed / 1 skipped** at `2f205546` → **671 passed / 1 skipped** after — exactly the 3 deleted test methods, no other delta
- `ruff check` clean · `ruff format --check` clean · `lint-imports` 5 kept / 0 broken
- `git grep -n -w -e vfo_swap_code -e vfo_equal_code` → only the CHANGELOG entry
- Full suite: via CI (per dispatch instruction)

Related: #2853 (finding D1, same audit — no file overlap except `docs/CHANGELOG.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)