### PR TITLE
ci: stop cancelling in-progress runs on main

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: tests-full-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: tests-quick-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   quick:


### PR DESCRIPTION
## Problem

`.github/workflows/quick.yml` keys its `concurrency.group` on `github.ref` and sets `cancel-in-progress: true` unconditionally. That's correct for a `pull_request` ref — a new push should supersede the PR's own previous run — but it's wrong for `main`: every merge starts a `push`-triggered run on `main`, in the same concurrency group as the previous merge's run (`refs/heads/main` never changes), so the new run cancels it.

A cancelled run reports as **success**. So a commit can land on `main` having been tested by nothing, while the badge stays green. Confirmed tonight: at least four `main` runs of `quick.yml` were cancelled this way, and two of the affected commits are on `main` right now with no executed run. This isn't fixable by spacing merges out — with several sessions merging and ~4 minutes per run plus queue time, each merge routinely supersedes the previous one's verification before it finishes. It also matters more than "the PR was already green": a squash commit's tree is generally not the tree the PR run tested (other PRs land in between), so the `main` run is the only thing that ever tests that exact combination.

## Change

One key, two files. Group key unchanged in both; only `cancel-in-progress` changes from an unconditional `true` to a ref comparison:

**`.github/workflows/quick.yml`**, key `concurrency.cancel-in-progress`:
```diff
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

**`.github/workflows/full.yml`**, key `concurrency.cancel-in-progress`:
```diff
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```
`full.yml` has the identical shape — `concurrency.group: tests-full-${{ github.workflow }}-${{ github.ref }}` plus unconditional `cancel-in-progress: true` — and its `on.push.branches` includes `main`, so it is exposed to the same main-cancels-main failure mode (e.g. two `[full-ci]`-tagged merges landing close together, or a scheduled/dispatched run overlapping a push-triggered one). Fixed there with the same one-key change. `full.yml`'s `schedule` and `workflow_dispatch` triggers also resolve `github.ref` to `refs/heads/main` in the common case (schedule runs against the default branch; manual dispatch defaults to it), so the same expression leaves cancellation disabled for those too, consistent with the same rationale.

**`.github/workflows/visual.yml`**: checked, **not changed**. Its `on:` block has only `pull_request: branches: [main]` — no `push` trigger at all (the file's own header comment already documents this as a known PR-only gap, unrelated to this change). Since it never runs against `refs/heads/main`, its `cancel-in-progress: true` only ever cancels a PR's own superseded run, never a `main` run. Nothing to fix.

## Ref-expression reasoning (quick.yml, full.yml identical)

- **`pull_request` event on a PR ref**: GitHub sets `github.ref` for `pull_request` events to the PR merge ref, `refs/pull/<N>/merge` — not `refs/heads/main`. So `github.ref != 'refs/heads/main'` evaluates `true`, and `cancel-in-progress` stays `true`: unchanged from today, a new push to the PR still cancels that PR's own in-progress run.
- **`push` event on `main`**: for a `push` event, `github.ref` is the pushed ref, `refs/heads/main`. So the comparison evaluates `false`, and `cancel-in-progress` becomes `false`: the next merge's run no longer cancels the previous merge's still-running verification. It queues behind it instead.

## Cost, stated plainly

With `cancel-in-progress: false` on `main`, a run that would previously have been cancelled now runs to completion, queued behind whatever is already in progress in that group. That adds load to the self-hosted runner, which is already the bottleneck during busy merge windows — the queue gets longer. Accepted trade: a verified `main` is worth more than a shorter queue, but it's a real cost, not a free fix.

## What this PR's own CI run does and doesn't prove

This PR touches `.github/workflows/**`, which is inside `quick.yml`'s own path filter, so it will trigger a `quick` run on the PR ref. That run evaluates the *old* configuration's semantics for a PR ref either way (`github.ref` is `refs/pull/<N>/merge`, so the new expression also evaluates to `true` there) — it cannot exercise the `main` branch path at all. A green run on this PR is not evidence the fix works on `main`. The `main`-branch behaviour is only verifiable after merge, by observing that two closely-spaced merges each keep their own run to completion instead of one cancelling the other.

## Verification performed

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/quick.yml'))"` and the same for `full.yml` — both OK.
- `git diff --stat`: 2 files changed, 2 insertions(+), 2 deletions(-) — `.github/workflows/quick.yml`, `.github/workflows/full.yml`.
- No other keys touched: triggers, path filters, jobs, and matrix are unchanged in both files.

internal-identifier self-check — empty
