### PR TITLE
fix: converge the two web advertisers of the reserved VFO capability tags (mechanism-audit F1)

### DIFF
--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -681,10 +681,12 @@ class ControlHandler:
         if self._radio is None:
             return caps
         # getattr, not self._radio_model: a few TestCommandGuards fixtures
-        # build ControlHandler via __new__ (bypassing __init__) and set only
-        # ._radio, matching the pre-existing behavior where this attribute
-        # was read lazily and only when self._radio.profile did not already
-        # resolve — which is always true for those fixtures' radios.
+        # build ControlHandler via __new__ (bypassing __init__), setting
+        # only ._radio. Those radios always carry a resolved RadioProfile,
+        # so this argument is never actually read for them (the pre-fix
+        # code read self._radio_model just as eagerly, building its
+        # fallback tuple up front, and would have raised the same
+        # AttributeError had one of these radios ever lacked a profile).
         configured_model = getattr(self, "_radio_model", None)
         return caps | projected_vfo_capability_tags(self._radio, configured_model)
 

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -151,6 +151,8 @@ from ..radio_poller import (  # noqa: TID251
     Speak,
 )
 from ..runtime_helpers import (  # noqa: TID251
+    VFO_CAPABILITY_TAGS,
+    projected_vfo_capability_tags,
     radio_ready,
     runtime_capabilities,
 )
@@ -184,7 +186,6 @@ __all__ = ["ControlHandler", "RadioNotReadyError"]
 
 logger = logging.getLogger(__name__)
 _MAX_CW_TEXT_CHARS = 512
-_VFO_CAPABILITY_TAGS = frozenset({"vfo_swap", "vfo_equalize"})
 
 # MOR-624: maps the per-DATA-group MOD-input SET command name (as sent by the
 # frontend auto-restore) to its allowed teardown arm name (MOR-993).
@@ -676,38 +677,16 @@ class ControlHandler:
         await self._ws.send_text(encode_json(msg))
 
     def _capabilities(self) -> set[str]:
-        caps = set(runtime_capabilities(self._radio)) - _VFO_CAPABILITY_TAGS
+        caps = set(runtime_capabilities(self._radio)) - VFO_CAPABILITY_TAGS
         if self._radio is None:
             return caps
-
-        profile = getattr(self._radio, "profile", None)
-        if not isinstance(profile, RadioProfile):
-            radio_model = getattr(self._radio, "model", None)
-            for model in (radio_model, self._radio_model):
-                if not isinstance(model, str) or not model.strip():
-                    continue
-                try:
-                    profile = resolve_radio_profile(model=model)
-                except KeyError:
-                    continue
-                break
-
-        if not isinstance(profile, RadioProfile):
-            return caps
-        primitives: tuple[tuple[str, int | None], ...]
-        if profile.vfo_scheme == "ab":
-            primitives = (
-                ("vfo_swap", profile.swap_ab_code),
-                ("vfo_equalize", profile.equal_ab_code),
-            )
-        elif profile.vfo_scheme == "main_sub":
-            primitives = (
-                ("vfo_swap", profile.swap_main_sub_code),
-                ("vfo_equalize", profile.equal_main_sub_code),
-            )
-        else:
-            primitives = ()
-        return caps | {tag for tag, primitive in primitives if primitive is not None}
+        # getattr, not self._radio_model: a few TestCommandGuards fixtures
+        # build ControlHandler via __new__ (bypassing __init__) and set only
+        # ._radio, matching the pre-existing behavior where this attribute
+        # was read lazily and only when self._radio.profile did not already
+        # resolve — which is always true for those fixtures' radios.
+        configured_model = getattr(self, "_radio_model", None)
+        return caps | projected_vfo_capability_tags(self._radio, configured_model)
 
     def _ensure_receiver_supported(self, receiver: int) -> None:
         if self._radio is None:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 from ..core.state_pipeline_contracts import FieldFamily, FieldScope, FieldPath, VfoSlot
 from ..core.state_store import FieldSnapshot, FreshnessState, StateSnapshot
 from ..core.tx_target import TxTarget, tx_target_from_dict, validate_tx_target
+from ..profiles import RadioProfile, resolve_radio_profile
 from ..radio_protocol import (
     AudioCapable,
     DualReceiverCapable,
@@ -28,7 +29,14 @@ __all__ = [
     "build_public_state_payload",
     "build_public_state_payload_from_snapshot",
     "primary_receiver_snapshot_ids",
+    "VFO_CAPABILITY_TAGS",
+    "projected_vfo_capability_tags",
 ]
+
+# Reserved runtime capability tags for the VFO-primitive commands
+# (``vfo_swap``, ``vfo_equalize``). These are never trusted from
+# ``radio.capabilities`` directly — see ``projected_vfo_capability_tags``.
+VFO_CAPABILITY_TAGS: frozenset[str] = frozenset({"vfo_swap", "vfo_equalize"})
 
 _RECEIVER_KEY_MAP = {"freq": "freqHz"}
 _SNAPSHOT_RECEIVER_IDS = {
@@ -580,6 +588,64 @@ def runtime_capabilities(radio: "Radio | None") -> set[str]:
     if isinstance(radio, DualReceiverCapable):
         result.add("dual_rx")
     return result
+
+
+def projected_vfo_capability_tags(
+    radio: "Radio | None", configured_model: str | None
+) -> frozenset[str]:
+    """Return the reserved VFO tags (:data:`VFO_CAPABILITY_TAGS`) this radio backs.
+
+    Fail-closed contract, pinned by
+    ``test_ws_hello_and_http_capability_payloads_agree_for_non_resolving_runtime_model``
+    and ``test_unknown_runtime_model_fails_closed_for_reserved_vfo_tags_across_consumers``
+    (``tests/test_web_capability_guards.py``):
+
+    - A resolved :class:`~rigplane.profiles.RadioProfile` on ``radio.profile``
+      is used as-is.
+    - Otherwise exactly one candidate model string is tried: ``radio.model``
+      if it is a non-empty (after ``.strip()``) string, else
+      ``configured_model``. There is no second candidate — a radio-reported
+      model that fails to resolve yields no tags without falling back to
+      ``configured_model``.
+    - A candidate that is not a non-empty string, or that raises ``KeyError``
+      from :func:`~rigplane.profiles.resolve_radio_profile`, yields no tags.
+    - Each tag is included only when its profile field
+      (``swap_ab_code``/``equal_ab_code`` for ``vfo_scheme == "ab"``,
+      ``swap_main_sub_code``/``equal_main_sub_code`` for
+      ``vfo_scheme == "main_sub"``) is not ``None``.
+    """
+    profile = getattr(radio, "profile", None)
+    if not isinstance(profile, RadioProfile):
+        raw_model = getattr(radio, "model", None) if radio is not None else None
+        candidate = (
+            raw_model
+            if isinstance(raw_model, str) and raw_model.strip()
+            else configured_model
+        )
+        if not isinstance(candidate, str) or not candidate.strip():
+            return frozenset()
+        try:
+            profile = resolve_radio_profile(model=candidate)
+        except KeyError:
+            return frozenset()
+
+    if not isinstance(profile, RadioProfile):
+        return frozenset()
+
+    primitives: tuple[tuple[str, int | None], ...]
+    if profile.vfo_scheme == "ab":
+        primitives = (
+            ("vfo_swap", profile.swap_ab_code),
+            ("vfo_equalize", profile.equal_ab_code),
+        )
+    elif profile.vfo_scheme == "main_sub":
+        primitives = (
+            ("vfo_swap", profile.swap_main_sub_code),
+            ("vfo_equalize", profile.equal_main_sub_code),
+        )
+    else:
+        primitives = ()
+    return frozenset(tag for tag, primitive in primitives if primitive is not None)
 
 
 def radio_ready(radio: "Radio | None") -> bool:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -595,24 +595,31 @@ def projected_vfo_capability_tags(
 ) -> frozenset[str]:
     """Return the reserved VFO tags (:data:`VFO_CAPABILITY_TAGS`) this radio backs.
 
-    Fail-closed contract, pinned by
-    ``test_ws_hello_and_http_capability_payloads_agree_for_non_resolving_runtime_model``
-    and ``test_unknown_runtime_model_fails_closed_for_reserved_vfo_tags_across_consumers``
-    (``tests/test_web_capability_guards.py``):
+    Fail-closed contract. Each bullet names the test in
+    ``tests/test_web_capability_guards.py`` that fails if that bullet stops
+    being true:
 
     - A resolved :class:`~rigplane.profiles.RadioProfile` on ``radio.profile``
-      is used as-is.
+      is used as-is, and each tag is included only when its profile field
+      (``swap_ab_code``/``equal_ab_code`` for ``vfo_scheme == "ab"``,
+      ``swap_main_sub_code``/``equal_main_sub_code`` for
+      ``vfo_scheme == "main_sub"``) is not ``None`` — pinned by
+      ``test_vfo_tags_match_across_consumers_for_real_profiles`` and
+      ``test_vfo_tags_keep_partial_and_mismatched_schemes_in_parity``.
     - Otherwise exactly one candidate model string is tried: ``radio.model``
       if it is a non-empty (after ``.strip()``) string, else
       ``configured_model``. There is no second candidate — a radio-reported
-      model that fails to resolve yields no tags without falling back to
-      ``configured_model``.
-    - A candidate that is not a non-empty string, or that raises ``KeyError``
-      from :func:`~rigplane.profiles.resolve_radio_profile`, yields no tags.
-    - Each tag is included only when its profile field
-      (``swap_ab_code``/``equal_ab_code`` for ``vfo_scheme == "ab"``,
-      ``swap_main_sub_code``/``equal_main_sub_code`` for
-      ``vfo_scheme == "main_sub"``) is not ``None``.
+      model that fails to resolve (``KeyError`` from
+      :func:`~rigplane.profiles.resolve_radio_profile`) yields no tags
+      without falling back to ``configured_model`` — pinned by
+      ``test_ws_hello_and_http_capability_payloads_agree_for_non_resolving_runtime_model``
+      and
+      ``test_unknown_runtime_model_fails_closed_for_reserved_vfo_tags_across_consumers``.
+    - A candidate that is not a non-empty string (``radio.model`` absent or
+      blank and ``configured_model`` likewise) never reaches
+      ``resolve_radio_profile`` — whose empty-input path silently returns a
+      default rig profile — and instead yields no tags — pinned by
+      ``test_reserved_vfo_tags_absent_when_no_usable_candidate_model_exists``.
     """
     profile = getattr(radio, "profile", None)
     if not isinstance(profile, RadioProfile):

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -94,9 +94,11 @@ from .radio_poller import (  # noqa: TID251
     RadioPoller,
 )
 from .runtime_helpers import (  # noqa: TID251
+    VFO_CAPABILITY_TAGS,
     build_public_state_payload_from_snapshot,
     classify_radio_health,
     primary_receiver_snapshot_ids,
+    projected_vfo_capability_tags,
     radio_ready,
     runtime_capabilities,
 )
@@ -981,42 +983,10 @@ class WebServer:
 
     def _projected_runtime_capabilities(self) -> set[str]:
         """Return runtime tags with VFO primitives trusted only from a profile."""
-        from ..profiles import RadioProfile, resolve_radio_profile
-
-        vfo_tags = {"vfo_swap", "vfo_equalize"}
-        caps = _runtime_capabilities(self._radio) - vfo_tags
-        profile = getattr(self._radio, "profile", None) if self._radio else None
-        if not isinstance(profile, RadioProfile):
-            raw_model = (
-                getattr(self._radio, "model", None) if self._radio is not None else None
-            )
-            candidates = (
-                (raw_model,)
-                if isinstance(raw_model, str) and raw_model.strip()
-                else (self._config.radio_model,)
-            )
-            for model in candidates:
-                try:
-                    profile = resolve_radio_profile(model=model)
-                except KeyError:
-                    continue
-                break
-        if not isinstance(profile, RadioProfile):
-            return caps
-        primitives: tuple[tuple[str, int | None], ...]
-        if profile.vfo_scheme == "ab":
-            primitives = (
-                ("vfo_swap", profile.swap_ab_code),
-                ("vfo_equalize", profile.equal_ab_code),
-            )
-        elif profile.vfo_scheme == "main_sub":
-            primitives = (
-                ("vfo_swap", profile.swap_main_sub_code),
-                ("vfo_equalize", profile.equal_main_sub_code),
-            )
-        else:
-            primitives = ()
-        return caps | {tag for tag, primitive in primitives if primitive is not None}
+        caps = _runtime_capabilities(self._radio) - VFO_CAPABILITY_TAGS
+        return caps | projected_vfo_capability_tags(
+            self._radio, self._config.radio_model
+        )
 
     def _bootstrap_state_acquisition(self) -> None:
         """Attach shared StateStore-backed acquisition services when profiled."""

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -207,6 +207,51 @@ class TestInfoEndpoint:
         assert not (reserved & set(hello["capabilities"]))
 
     @pytest.mark.asyncio
+    async def test_ws_hello_and_http_capability_payloads_agree_for_non_resolving_runtime_model(
+        self,
+    ):
+        """Production factory: radio.model fails to resolve, configured model does.
+
+        Unlike the sibling test above (which builds ``ControlHandler`` directly
+        with ``radio.model`` as its configured-model argument, so both
+        fallback candidates share the same non-resolving value), this test
+        goes through the production ``WebServer._control_handler_for`` factory,
+        which always passes ``self._config.radio_model`` as that argument
+        regardless of ``radio.model``. That is the one construction where the
+        two candidates differ and can diverge.
+        """
+        reserved = {"vfo_swap", "vfo_equalize"}
+        radio = _make_radio("IC-7300", caps=reserved)
+        radio.model = "UNKNOWN-RADIO"
+        del radio.profile
+        server = WebServer(radio, WebConfig(radio_model="IC-7300"))
+
+        info_writer = _FakeWriter()
+        await server._serve_info(info_writer)  # noqa: SLF001
+        info = _parse_json_body(info_writer)
+
+        capabilities_writer = _FakeWriter()
+        await server._serve_capabilities(capabilities_writer)  # noqa: SLF001
+        capabilities = _parse_json_body(capabilities_writer)
+
+        sent: list[str] = []
+
+        async def send_text(payload: str) -> None:
+            sent.append(payload)
+
+        handler = server._control_handler_for()  # noqa: SLF001
+        handler._ws = SimpleNamespace(send_text=send_text)  # noqa: SLF001
+        await handler._send_hello()  # noqa: SLF001
+        hello = json.loads(sent.pop())
+
+        info_tags = reserved & set(info["capabilities"]["tags"])
+        capabilities_tags = reserved & set(capabilities["capabilities"])
+        hello_tags = reserved & set(hello["capabilities"])
+
+        assert info_tags == capabilities_tags == hello_tags
+        assert not info_tags
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("model", "expected"),
         [

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -215,10 +215,17 @@ class TestInfoEndpoint:
         Unlike the sibling test above (which builds ``ControlHandler`` directly
         with ``radio.model`` as its configured-model argument, so both
         fallback candidates share the same non-resolving value), this test
-        goes through the production ``WebServer._control_handler_for`` factory,
-        which always passes ``self._config.radio_model`` as that argument
-        regardless of ``radio.model``. That is the one construction where the
-        two candidates differ and can diverge.
+        goes through the production ``WebServer._control_handler_for`` factory.
+        That factory is one of three server.py constructions that pass
+        ``self._config.radio_model`` unconditionally (alongside the CW-text
+        and CW-stop HTTP handlers); the two constructions that actually emit
+        ``hello`` over a live control channel — the WS-connect handshake and
+        the WebRTC session manager wiring — pre-collapse the model to
+        ``radio.model`` whenever it is a string, so they cannot diverge this
+        way. This test pins the shared helper's fail-closed semantics at the
+        seam an embedder hits by passing its own ``WebConfig`` with a
+        ``radio_model`` different from the radio's own reported model, not a
+        regression reachable through the shipped WS client.
         """
         reserved = {"vfo_swap", "vfo_equalize"}
         radio = _make_radio("IC-7300", caps=reserved)
@@ -250,6 +257,45 @@ class TestInfoEndpoint:
 
         assert info_tags == capabilities_tags == hello_tags
         assert not info_tags
+
+    @pytest.mark.asyncio
+    async def test_reserved_vfo_tags_absent_when_no_usable_candidate_model_exists(
+        self,
+    ):
+        """Empty-candidate guard: neither side ever reaches resolve_radio_profile.
+
+        ``resolve_radio_profile``'s empty-input path silently returns a
+        default rig profile, so ``projected_vfo_capability_tags`` must
+        short-circuit before calling it when both ``radio.model`` (absent
+        here) and ``configured_model`` (an empty string here) are unusable.
+        """
+        reserved = {"vfo_swap", "vfo_equalize"}
+        radio = _make_radio("IC-7300", caps=reserved)
+        del radio.model
+        del radio.profile
+        server = WebServer(radio, WebConfig(radio_model=""))
+
+        info_writer = _FakeWriter()
+        await server._serve_info(info_writer)  # noqa: SLF001
+        info = _parse_json_body(info_writer)
+
+        capabilities_writer = _FakeWriter()
+        await server._serve_capabilities(capabilities_writer)  # noqa: SLF001
+        capabilities = _parse_json_body(capabilities_writer)
+
+        sent: list[str] = []
+
+        async def send_text(payload: str) -> None:
+            sent.append(payload)
+
+        handler = server._control_handler_for()  # noqa: SLF001
+        handler._ws = SimpleNamespace(send_text=send_text)  # noqa: SLF001
+        await handler._send_hello()  # noqa: SLF001
+        hello = json.loads(sent.pop())
+
+        assert not (reserved & set(info["capabilities"]["tags"]))
+        assert not (reserved & set(capabilities["capabilities"]))
+        assert not (reserved & set(hello["capabilities"]))
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Mechanism-audit finding F1, actionable slice (#1↔#2). The archived report lands as `.claude/audits/2026-08-30-mechanism-audit-vfo-swap-equalize.md` via #2848.

The reserved capability tags `vfo_swap`/`vfo_equalize` were advertised by two independently written filters that disagreed observably: `ControlHandler._capabilities` (WS `hello`) resolved the profile from two candidates — the radio's own `model` string, then the configured model — while `WebServer._projected_runtime_capabilities` (`GET /api/v1/info`, `GET /api/v1/capabilities`) built mutually exclusive candidates (raw model OR config model, never both). For a radio reporting a non-empty model string that does not resolve while the configured model does, the WS hello advertised the tags and the HTTP payloads stripped them. The reachable construction is `WebServer._control_handler_for`, which always passes `config.radio_model` as the handler's `radio_model` argument regardless of `radio.model`.

Both sites now delegate to one shared fail-closed resolver, `runtime_helpers.projected_vfo_capability_tags`: the radio's own `RadioProfile` wins; else the radio's reported model string is the only candidate when usable (unknown model ⇒ no tags, no fallback to the configured model); the configured model is consulted only when the radio reports no usable model string; an empty/non-str candidate never reaches `resolve_radio_profile`, whose empty-input path silently returns a default rig.

## Behavior deltas

1. **Intended (the fix):** WS hello stops advertising the tags for a non-empty, non-resolving `radio.model` even when the configured model resolves — matching the repo's pinned fail-closed intent (`test_unknown_runtime_model_fails_closed_for_reserved_vfo_tags_across_consumers`) and the WS admission path (`_enqueue_rc_frequency`), which never consults the configured model.
2. **Planned tightening:** an empty configured model no longer lets the HTTP sites silently resolve the default rig — pinned by the new `test_reserved_vfo_tags_absent_when_no_usable_candidate_model_exists`.
3. **Adjacent, harmless (surfaced in review):** a non-str `config.radio_model` used to make the HTTP sites resolve the default rig while the WS site returned nothing; both now return nothing.

## Testing

TDD: the divergence test was written first and failed at the parent commit exactly as predicted (hello = `{vfo_swap, vfo_equalize}` vs HTTP = `set()`). Full python suite at this head: 11124 passed / 84 skipped / 48 xfailed vs baseline 11122 / 84 / 48 at the merge base (2f205546) — the delta is exactly the two new tests. Mutation checks by the independent reviewer (tree untouched, PYTHONPATH plugins): the old two-candidate fallback, removal of the empty-candidate guard, a swapped `ab`↔`main_sub` field mapping, and a profile-bypass each kill a named test. `ruff check`, `ruff format --check`, `mypy --strict src/rigplane/web`, `lint-imports` — all clean.

## Out of scope, recorded

- The full seven-site consolidation (radio_poller, the `receiver_count` discriminator in `runtime/sync.py`, the `hasattr` ladder in `runtime/profiles_runtime.py`, the Yaesu poller) needs an owner decision on the resolver surface (audit F1 "Required surface"); this PR deliberately touches only the two web advertising sites.
- `ControlHandler._enqueue_rc_frequency`'s `vfo_swap | vfo_equalize` admission branch is now the last un-converged copy of the scheme→codes mapping (three copies → two) — the natural next slice.
- `WebServer._get_profile` is a third, differently-shaped model filter (sentinel-only check; an empty-string `radio.model` reaches the resolver and silently returns a default profile, bypassing the MOR-174 warning block) — a related but distinct defect, left untouched.
- `RadioProfile.vfo_swap_code` / `.vfo_equal_code` (audit finding D2, dead aliases) were not revived: both sites read `vfo_scheme` plus the four `swap_*`/`equal_*` code fields only.

Review: independent verifier — round 1 BLOCKED on three prose/pinning findings, fixed in the second commit, round 2 PASS; gate directive posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
