### PR TITLE
docs: record tonight's CI/merge-gate operational rules

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -54,5 +54,21 @@ Rules:
   artifact, because the directive pins the exact head SHA the lines refer to;
   everywhere else in your output, cite file plus symbol name. Do not soften a
   BLOCKED into a PASS; do not block on stylistic taste.
+- Post PASS/BLOCKED on the code as soon as review is done. Report CI state as
+  you find it — queued, running, or complete with counts — but do not wait
+  for CI to finish and do not withhold a verdict solely because it hasn't.
+  Confirming checks are green at the exact head before merge is a separate
+  step the coordinator takes, not yours.
 - Bash always runs foreground with an explicit timeout; never use
   run_in_background.
+- That timeout is local only. A test run started on the remote runner
+  through the helper script that drives it keeps running, and keeps holding
+  its queue lock, even after the local process that started it is killed —
+  killing the local side does not stop the remote command. This is easy to
+  trigger by accident: a remote run that exceeds the harness's own
+  10-minute single-command ceiling gets backgrounded, and if the task is
+  then stopped or the agent finishes, the remote side is left running with
+  no parent. The symptom is a stalled queue for everyone on that machine,
+  including the other repository sharing it — not an obviously stuck
+  process. If you kill or abandon a remote run, confirm it actually died on
+  the runner; killing the local process is not enough.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -61,14 +61,17 @@ Rules:
   step the coordinator takes, not yours.
 - Bash always runs foreground with an explicit timeout; never use
   run_in_background.
-- That timeout is local only. A test run started on the remote runner
-  through the helper script that drives it keeps running, and keeps holding
-  its queue lock, even after the local process that started it is killed —
-  killing the local side does not stop the remote command. This is easy to
-  trigger by accident: a remote run that exceeds the harness's own
-  10-minute single-command ceiling gets backgrounded, and if the task is
-  then stopped or the agent finishes, the remote side is left running with
-  no parent. The symptom is a stalled queue for everyone on that machine,
-  including the other repository sharing it — not an obviously stuck
-  process. If you kill or abandon a remote run, confirm it actually died on
-  the runner; killing the local process is not enough.
+- That timeout is local only. A test run started on the remote test host
+  through the helper script that drives it keeps running, and keeps
+  holding whatever lock that script uses, even after the local process
+  that started it is killed — killing the local side does not stop the
+  remote command. (This manual helper is a different mechanism from the
+  GitHub Actions self-hosted runner behind `quick.yml`/`full.yml`/
+  `visual.yml` — do not confuse the two.) This is easy to trigger by
+  accident: a remote run that exceeds the harness's own 10-minute
+  single-command ceiling gets backgrounded, and if the task is then
+  stopped or the agent finishes, the remote side is left running with no
+  parent. The symptom is a stalled queue for other work on that host — not
+  an obviously stuck process. If you kill or abandon a remote run, confirm
+  it actually died on the remote host; killing the local process is not
+  enough.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,10 @@ editing:
 - use `codex/<issue-or-task>` branches for agent work;
 - use `git pull --ff-only --tags` only on clean branches with a normal upstream;
 - do not reset, clean, delete, or rebase uncertain work without explicit user
-  approval.
+  approval;
+- do not share or symlink `node_modules` between worktrees — one worktree's
+  install emptied another's shared directory this way; run a real `npm ci`
+  in each worktree.
 
 Use the global `repo-hygiene` skill for cross-repo inventory and cleanup.
 
@@ -96,8 +99,24 @@ reviews; same-user approval restrictions break automated agent flow.
 Every non-trivial PR requires independent agent review before merge. The
 implementation agent may not be the review agent.
 
-- `Agent Review: PASS` means the PR may merge once required checks are green,
-  the PASS comment is fresh for the current head, and the PR is not draft.
+- `Agent Review: PASS`/`BLOCKED` is the verifier's verdict on the code
+  alone: post it as soon as review is done, reporting CI state as found
+  (queued, running, or complete with counts) without waiting for CI to
+  finish or withholding a verdict because it hasn't. Confirming that
+  required checks are actually green at the exact head is a separate step
+  the coordinator takes immediately before merging — both conditions still
+  gate the merge, just held by two roles instead of one.
+- That split exists because CI is a shared, limited resource: `quick.yml`,
+  `full.yml`, and `visual.yml` all set `runs-on: [self-hosted, linux, build]`,
+  while everything else under `.github/workflows/` runs on `ubuntu-latest`.
+  `gh api repos/rigplane/rigplane-core/actions/runners` currently lists a
+  single registered runner carrying those labels, shared with
+  `rigplane-pro` — a review session that waits on that queue can lose an
+  hour or more for nothing.
+- On that same shared runner, a test that fails once with no repeat on a
+  clean rerun (e.g. `tests/test_mor1499_coalesce_keys.py`, one such case on
+  2026-08-30) is more often runner load than a regression; the same test
+  failing twice is evidence about the code, not the machine.
 - `Agent Review: BLOCKED` must include concrete problems, file/line references
   where applicable, risk, required fixes, and checks to run.
 - The implementation agent must address BLOCKED feedback, push updates, and
@@ -105,8 +124,62 @@ implementation agent may not be the review agent.
 - A failed `Agent Review Gate` without BLOCKED feedback usually means no fresh
   PASS comment exists for the current head; perform or refresh the review
   instead of skipping the PR.
+- A PR based on a branch other than `main` shows a partly-populated check
+  list, which is more misleading than an empty one:
+  `agent-review-gate.yml`'s `pull_request` trigger carries no `branches:`
+  filter and still runs, but the actual test/consistency gates —
+  `quick.yml`, `visual.yml`, `consumer-contracts-gate.yml`,
+  `doc-citation-gate.yml`, `rebrand-gate.yml`, and `state-types-gate.yml` —
+  all scope `pull_request` to `branches: [main]` and do not run at all. It
+  reads as "no problems found" when the tests never ran. Retargeting to
+  `main` afterwards does not by itself start them: that fires an `edited`
+  event, which none of these workflows' triggers list, so only a push (a
+  new commit, or otherwise resynchronizing the PR) starts a run.
+- Never merge with `--delete-branch` while another PR is based on that
+  branch: GitHub auto-closes the child and then refuses to reopen (base
+  gone) or retarget (already closed) it. Retarget every child PR onto
+  `main` and push before merging the parent. If a child is closed this way
+  anyway, rebase its branch onto `main`, open a fresh PR noting which
+  closed PR it supersedes, and budget a re-review — the old review
+  directives died with the old PR.
 - Cancelled checks must be rerun with `gh run rerun <run-id>` or a new push,
   then watched to completion.
+- `quick.yml`'s `concurrency.group` key is the workflow name plus
+  `github.ref`, `cancel-in-progress: true`: every push to `main` cancels
+  whatever `Tests (quick)` run is still queued or running for the merge
+  just before it, and queue time is unbounded — a run can sit queued for
+  minutes and then be cancelled without ever starting. A cancelled run
+  reports success, so a chain of close merges can leave commits on `main`
+  that no completed run ever covered.
+- Before merging to `main`, check
+  `gh run list --workflow=quick.yml --branch=main --limit 3` and wait for
+  the current head's run to have started — ideally finished — instead of
+  waiting a fixed number of minutes: queue time is unbounded, so a
+  wall-clock wait does not work. Do not `gh run rerun` a run cancelled this
+  way; rerunning re-enters the same concurrency group and cancels the
+  current head's run instead — verify the current head's run, which covers
+  every intervening change together. If other work merged while a PR sat
+  open, compare `git rev-parse <squash-sha>^{tree}` to
+  `git rev-parse <pr-head>^{tree}` before trusting the PR's own green run:
+  equal trees mean it already covered that code, unequal means the
+  combination was never tested.
+- Interim protocol until a fix landing separately makes `cancel-in-progress`
+  conditional on the ref: fuse the check and the merge into one shell
+  invocation so the gap between them is seconds, not the minutes between a
+  monitor firing and an operator acting (substitute the PR number):
+
+  ```bash
+  st=$(gh run list --workflow=quick.yml --branch=main --limit 1 --json status --jq '.[0].status')
+  if [ "$st" != "completed" ]; then echo "ABORT: new main run in flight ($st)"; exit 1; fi
+  gh pr merge <N> --squash --delete-branch
+  ```
+
+  This is **not atomic** — roughly one to two seconds remain between the
+  status read and the merge landing, a real window under several concurrent
+  mergers. What it buys: a stale check can no longer be ignored silently,
+  because the merge simply does not run. Treat it as a stopgap: once the
+  conditional `cancel-in-progress` change lands, the race it papers over
+  stops existing and this guard stops being necessary.
 - Draft PRs must not merge. Determine why the PR is draft, finish the missing
   work, run `gh pr ready`, then complete checks and review.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,15 @@ editing:
   approval;
 - do not share or symlink `node_modules` between worktrees — one worktree's
   install emptied another's shared directory this way; run a real `npm ci`
-  in each worktree.
+  in each worktree;
+- a `gh pr merge --delete-branch` run from inside a worktree can exit
+  non-zero even after the merge itself succeeded: the remote merge and
+  branch deletion happen first, over the API, and only then does the CLI
+  try to update the local branch — which fails if that branch is checked
+  out in this or any other worktree. Before retrying a reported failure,
+  check the PR's actual state (`gh pr view <N> --json
+  state,mergedAt,mergeCommit`) rather than assuming the merge did not
+  happen.
 
 Use the global `repo-hygiene` skill for cross-repo inventory and cleanup.
 
@@ -109,10 +117,13 @@ implementation agent may not be the review agent.
 - That split exists because CI is a shared, limited resource: `quick.yml`,
   `full.yml`, and `visual.yml` all set `runs-on: [self-hosted, linux, build]`,
   while everything else under `.github/workflows/` runs on `ubuntu-latest`.
-  `gh api repos/rigplane/rigplane-core/actions/runners` currently lists a
-  single registered runner carrying those labels, shared with
-  `rigplane-pro` — a review session that waits on that queue can lose an
-  hour or more for nothing.
+  `gh api repos/rigplane/rigplane-core/actions/runners` currently lists
+  exactly one registered runner carrying those labels, scoped to this
+  repository alone — `rigplane-pro`'s runners are separate registrations
+  and cannot pick up this repository's jobs. The contention is narrower
+  than a shared queue: this repository's three self-hosted workflows
+  serialize behind a single runner of its own, and a review session that
+  waits on that queue can still lose an hour or more for nothing.
 - On that same shared runner, a test that fails once with no repeat on a
   clean rerun (e.g. `tests/test_mor1499_coalesce_keys.py`, one such case on
   2026-08-30) is more often runner load than a regression; the same test
@@ -133,8 +144,11 @@ implementation agent may not be the review agent.
   all scope `pull_request` to `branches: [main]` and do not run at all. It
   reads as "no problems found" when the tests never ran. Retargeting to
   `main` afterwards does not by itself start them: that fires an `edited`
-  event, which none of these workflows' triggers list, so only a push (a
-  new commit, or otherwise resynchronizing the PR) starts a run.
+  event, which none of these workflows' triggers list. A push (a new
+  commit) starts them, and so does closing and reopening the PR — none of
+  these six workflows lists an explicit `types:` filter on its
+  `pull_request` trigger, so all of them fall back to GitHub's default
+  `[opened, synchronize, reopened]`, and `reopened` fires on reopen.
 - Never merge with `--delete-branch` while another PR is based on that
   branch: GitHub auto-closes the child and then refuses to reopen (base
   gone) or retarget (already closed) it. Retarget every child PR onto
@@ -142,44 +156,80 @@ implementation agent may not be the review agent.
   anyway, rebase its branch onto `main`, open a fresh PR noting which
   closed PR it supersedes, and budget a re-review — the old review
   directives died with the old PR.
-- Cancelled checks must be rerun with `gh run rerun <run-id>` or a new push,
-  then watched to completion.
-- `quick.yml`'s `concurrency.group` key is the workflow name plus
-  `github.ref`, `cancel-in-progress: true`: every push to `main` cancels
-  whatever `Tests (quick)` run is still queued or running for the merge
-  just before it, and queue time is unbounded — a run can sit queued for
-  minutes and then be cancelled without ever starting. A cancelled run
-  reports success, so a chain of close merges can leave commits on `main`
-  that no completed run ever covered.
+- Cancelled checks on a PR branch must be rerun with `gh run rerun
+  <run-id>` or a new push, then watched to completion. On `main` itself,
+  do not rerun this way — see below.
+- A commit can look unverified for two different reasons that report
+  opposite signatures — check which one applies before trusting a green
+  commit or ignoring a red one. A gate whose run is skipped because the
+  change touched none of its watched paths reports `success` (or is simply
+  absent from the check list): green, but unverified, and expected. A
+  cancelled run is different: a check run with conclusion `CANCELLED`
+  makes the commit's overall status-check state `FAILURE` — **red**, not
+  green — and nothing re-queues it automatically. Verified directly
+  against the Actions API: four `main` commits from 2026-08-30 whose
+  `Tests (quick)` run was cancelled each carry an overall `FAILURE` state.
+  A red commit on `main` from a cancelled run needs a person to look at
+  it, because nothing else will.
+- `quick.yml` keys its `concurrency.group` on the workflow name plus
+  `github.ref`, so every push to `main` shares one group with every other
+  push to `main`. Within one group, GitHub keeps at most one *queued*
+  (not-yet-started) run: a push that arrives while the previous push's run
+  is still waiting for a runner cancels that waiting run outright — it
+  never reaches a runner (empty `runner_name`, no steps recorded). This
+  happens regardless of the group's `cancel-in-progress` setting, which
+  only governs whether an *already-started* run is cancelled by a later
+  push, not whether a *queued* one is. All four cancelled `main` runs
+  sampled on 2026-08-30 died this way — queued, not mid-run. Measured and
+  tracked as MOR-2048; see that ticket rather than re-deriving the counts.
 - Before merging to `main`, check
   `gh run list --workflow=quick.yml --branch=main --limit 3` and wait for
-  the current head's run to have started — ideally finished — instead of
-  waiting a fixed number of minutes: queue time is unbounded, so a
-  wall-clock wait does not work. Do not `gh run rerun` a run cancelled this
-  way; rerunning re-enters the same concurrency group and cancels the
-  current head's run instead — verify the current head's run, which covers
-  every intervening change together. If other work merged while a PR sat
-  open, compare `git rev-parse <squash-sha>^{tree}` to
-  `git rev-parse <pr-head>^{tree}` before trusting the PR's own green run:
-  equal trees mean it already covered that code, unequal means the
-  combination was never tested.
-- Interim protocol until a fix landing separately makes `cancel-in-progress`
-  conditional on the ref: fuse the check and the merge into one shell
-  invocation so the gap between them is seconds, not the minutes between a
-  monitor firing and an operator acting (substitute the PR number):
+  the current head's run to have **started** — that is the durable bar,
+  not a fixed wall-clock wait, since queue time is unbounded. `quick.yml`'s
+  `cancel-in-progress` key is now scoped to non-`main` refs, so a push to
+  `main` no longer cancels an already-started run from an earlier push to
+  `main` — once started, that run runs to completion on its own. What a
+  push to `main` can still cancel is a run that has not started yet (see
+  above, MOR-2048); that is exactly why "started", not "completed", is the
+  bar — waiting for full completion adds time on the single shared runner
+  without buying more certainty. Do not `gh run rerun` a run cancelled on
+  `main`'s queue this way; rerunning re-requests a run for the old,
+  superseded commit in the same concurrency group, which can cancel the
+  *current* head's queued run instead of restoring anything — verify the
+  current head's own run, which covers every intervening change together.
+- The remaining race is the queued-run half from above (MOR-2048): a run
+  can still be cancelled in the gap between checking its status and
+  executing the merge, while it waits for a runner. Fuse the check and the
+  merge into one shell invocation so that gap is seconds, not the minutes
+  between a monitor firing and an operator acting (substitute the PR
+  number):
 
   ```bash
   st=$(gh run list --workflow=quick.yml --branch=main --limit 1 --json status --jq '.[0].status')
-  if [ "$st" != "completed" ]; then echo "ABORT: new main run in flight ($st)"; exit 1; fi
-  gh pr merge <N> --squash --delete-branch
+  if [ "$st" = "queued" ]; then echo "ABORT: main run still queued, not started ($st)"; exit 1; fi
+  head_sha=$(gh pr view <N> --json headRefOid --jq .headRefOid)
+  gh pr merge <N> --squash --match-head-commit "$head_sha"
   ```
 
-  This is **not atomic** — roughly one to two seconds remain between the
-  status read and the merge landing, a real window under several concurrent
-  mergers. What it buys: a stale check can no longer be ignored silently,
-  because the merge simply does not run. Treat it as a stopgap: once the
-  conditional `cancel-in-progress` change lands, the race it papers over
-  stops existing and this guard stops being necessary.
+  This is **not atomic** — a run can move from "nothing queued yet" to
+  "queued" in the gap between the read and the merge — but it closes the
+  window every cancelled run sampled so far actually died in (above:
+  queued, not mid-run). Delete the branch afterward only when no child PR
+  is based on it (above); passing `--delete-branch` here unconditionally
+  would break that rule the moment a child PR exists. Treat this as the
+  stopgap for the queued half of the race (MOR-2048), not for the
+  started-run half that the ref-scoped `cancel-in-progress` already fixed
+  — it is retired only when MOR-2048 is, not automatically alongside that
+  fix.
+- After a merge, if a run on `main` looks cancelled or otherwise
+  unverified and you want to know whether an earlier PR run already
+  covered the code that landed, compare
+  `git rev-parse <squash-sha>^{tree}` to `git rev-parse <pr-head>^{tree}`:
+  equal trees mean it already covered that code, unequal means the
+  combination was never tested. Treat this as a strong heuristic, not an
+  identity — a PR's own check runs against `refs/pull/N/merge` (the PR
+  head merged onto the base at test time), not against the PR head commit
+  by itself.
 - Draft PRs must not merge. Determine why the PR is draft, finish the missing
   work, run `gh pr ready`, then complete checks and review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,13 @@ and whether to add it as a CI gate is a separate, still-open decision.
 
 ## CI workflows (Actions billing-aware)
 
-Three workflows, tiered by cost:
+The three workflows below dominate Actions billing and are tiered by cost
+(eleven workflow files exist under `.github/workflows/` in total; the rest
+are narrower path- or event-scoped gates):
 
 | Workflow | Trigger | Scope |
 |---|---|---|
-| `quick.yml` | push/PR to `main` only when `src/**`, `tests/**`, `frontend/**`, `pyproject.toml`, `uv.lock`, `.importlinter`, or `.github/workflows/**` change | Python 3.11 only · ruff · import-linter · pytest (incl. `tests/integration`, hardware-gated tests skip automatically) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
+| `quick.yml` | push/PR to `main`, unconditionally — the workflow always runs, then skips its own steps unless the changed paths match its internal `core`/`frontend` filters (see `quick.yml`) | Python 3.11 only · ruff · import-linter · pytest (incl. `tests/integration`, hardware-gated tests skip automatically) · frontend block runs **only** if `frontend/**` or `src/rigplane/web/**` changed · badges |
 | `full.yml` | cron Mon/Wed/Fri 03:00 UTC + `workflow_dispatch` + push with `[full-ci]` in commit message | Full matrix 3.11/3.12/3.13, everything |
 | `publish.yml` | `release: published` | New `validate` job (full matrix) → `build` → `publish`. No publish if validate fails. |
 

--- a/docs/internals/github-project-workflow.md
+++ b/docs/internals/github-project-workflow.md
@@ -85,8 +85,9 @@ Before merging a non-trivial PR:
 3. Coordinator, immediately before merging: confirm the PR is non-draft,
    all required checks are green, and the exact-head `Agent Review Gate` is
    green. On `main` itself, also confirm the previous merge's `Tests
-   (quick)` run finished rather than getting cancelled by this one
-   (AGENTS.md § Protected main and review gate).
+   (quick)` run has **started**, not merely queued — a queued run would
+   otherwise be displaced by this merge's own push (AGENTS.md § Protected
+   main and review gate; tracked as MOR-2048).
 4. Merge with the expected head SHA guarded by the platform.
 5. Re-read Linear acceptance criteria and reconcile Linear status deliberately;
    a merged PR or closed GitHub issue alone is not acceptance.

--- a/docs/internals/github-project-workflow.md
+++ b/docs/internals/github-project-workflow.md
@@ -76,11 +76,17 @@ Before opening a PR:
 
 Before merging a non-trivial PR:
 
-1. Use a fresh independent reviewer who did not author the change.
-2. Review the exact current 40-hex head SHA and post a normal comment beginning
-   `Agent Review: PASS <full-40-hex-head-SHA>` only after a PASS result.
-3. Confirm the PR is non-draft, all required checks are green, and the exact-head
-   `Agent Review Gate` is green.
+1. Use a fresh independent reviewer (the verifier) who did not author the
+   change.
+2. Verifier: review the exact current 40-hex head SHA and post a normal
+   comment beginning `Agent Review: PASS <full-40-hex-head-SHA>` only after
+   a PASS result. Report CI state as found; do not wait for it to finish
+   (AGENTS.md § Protected main and review gate).
+3. Coordinator, immediately before merging: confirm the PR is non-draft,
+   all required checks are green, and the exact-head `Agent Review Gate` is
+   green. On `main` itself, also confirm the previous merge's `Tests
+   (quick)` run finished rather than getting cancelled by this one
+   (AGENTS.md § Protected main and review gate).
 4. Merge with the expected head SHA guarded by the platform.
 5. Re-read Linear acceptance criteria and reconcile Linear status deliberately;
    a merged PR or closed GitHub issue alone is not acceptance.

--- a/docs/validation/workspace-v1-verification.md
+++ b/docs/validation/workspace-v1-verification.md
@@ -44,7 +44,7 @@ deleted**. That is the rollback window.
 
 ```bash
 cd frontend
-npm ci                       # or symlink an existing node_modules
+npm ci
 npx vitest run src/presentation/workspace/__tests__/workspace-compatibility-verification.test.ts
 ```
 


### PR DESCRIPTION
## Summary

Docs-only PR recording operational CI/merge-gate rules found tonight, placed
into the homes `CLAUDE.md` already points to for this material:

- `AGENTS.md` § Protected main and review gate — the bulk of the content:
  the verifier/coordinator split on the merge gate, the shared self-hosted
  runner and why it makes that split necessary, a lone-flaky-test-under-load
  reading rule, the stacked-PR partly-populated-checklist hazard, the
  `--delete-branch` child-PR hazard, the `quick.yml` concurrency
  cancellation mechanism plus an interim single-shell-invocation merge
  guard (explicitly framed as non-atomic and as a stopgap, not the
  permanent design), and a tree-comparison check for whether a PR's own
  green run already covered the code that actually lands.
- `AGENTS.md` § Multi-agent Git hygiene — one bullet: don't share/symlink
  `node_modules` across worktrees.
- `docs/internals/github-project-workflow.md` § Before merging a
  non-trivial PR — attributed steps 2/3 of the existing numbered list to
  the verifier and coordinator respectively, cross-referencing AGENTS.md
  instead of restating it.
- `.claude/agents/verifier.md` — the verifier's own operational rule (report
  CI state as found, don't wait on it, don't withhold a verdict for it), and
  a bullet next to the existing "Bash always runs foreground" rule about a
  remote test run outliving a killed local process and stranding the
  runner's queue lock.

No code, tests, or workflow YAML touched. No new document created.

## Verification

- `.github/scripts/check-doc-citations.sh` (plain): clean.
- `.github/scripts/check-doc-citations.sh --check-growth origin/main`:
  baseline did not grow. (An earlier growth-check run against a now-stale
  `origin/main` pointer briefly flagged an unrelated pre-existing entry
  removed by someone else's PR that landed while this branch was being
  written; rebasing onto current `origin/main` — no conflicts, none of the
  3 edited files were touched upstream — resolved it. Not something this
  PR's content caused.)
- `gh api repos/rigplane/rigplane-core/actions/runners`: verified myself,
  `total_count: 1` — the "single shared runner" claim in the doc is
  first-hand, not copied from the person who briefed this change.
- Internal-identifier self-check on the diff and this PR body — empty.
- This is docs-only, so `quick.yml`'s path filter does not match anything
  changed here and it legitimately reports no `core`/`frontend` work (the
  job still runs, its filter step just skips the install/test steps). That
  is *not* the same thing as the "stacked PR gets no CI at all" hazard
  this PR documents in `AGENTS.md` — this PR targets `main` directly, so
  `Tests (quick)` and the other gates all trigger normally; they just have
  nothing path-matched to run against a docs change.
- No test suite applies to docs; none run.

## Test plan

- [x] `check-doc-citations.sh` clean (plain + growth-check against current
      `origin/main`)
- [x] Diff and PR body carry no internal hostnames, IPs, usernames, or
      runner/bench identifiers
- [ ] Independent verifier review (required before merge; not performed by
      this PR's author)
