### PR TITLE
fix: reject blank radio.model in WebServer._get_profile candidates

### DIFF
--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -958,7 +958,7 @@ class WebServer:
         candidates = [
             m
             for m in (radio_model, self._config.radio_model)
-            if isinstance(m, str) and m != _RADIO_MODEL_UNSPECIFIED
+            if isinstance(m, str) and m.strip() and m != _RADIO_MODEL_UNSPECIFIED
         ]
         for candidate in candidates:
             try:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -4303,6 +4303,49 @@ class TestGetProfileRouting:
         IC-7610 (MOR-174)."""
         assert WebConfig().radio_model != "IC-7610"
 
+    @pytest.mark.parametrize("blank_model", ["", "   "])
+    def test_blank_radio_model_does_not_short_circuit_configured_model(
+        self, caplog, blank_model
+    ):
+        """A blank radio.model must not win the candidate loop and silently
+        yield the default resolution chain's rig — the configured
+        radio_model is still a usable candidate."""
+        import logging
+
+        from rigplane.profiles import resolve_radio_profile
+
+        radio = SimpleNamespace(model=blank_model, capabilities=set())
+        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
+            srv = self._make_server(radio, radio_model="FTX-1")
+            profile = srv._get_profile()
+
+        assert profile.vfo_scheme == "ab_shared"
+        assert profile != resolve_radio_profile()
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)
+        assert srv._profile_fallback_warned is False  # noqa: SLF001
+
+    def test_blank_radio_and_config_model_still_warns_and_falls_back(self, caplog):
+        """When both radio.model and the configured radio_model are blank,
+        _get_profile() still falls back through the default resolution
+        chain and emits the MOR-174 warning naming the profile actually
+        used — the fix must not turn a warned fallback into a silent one."""
+        import logging
+
+        from rigplane.profiles import RadioProfile, resolve_radio_profile
+
+        radio = SimpleNamespace(model="", capabilities=set())
+        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
+            srv = self._make_server(radio, radio_model="")
+            profile = srv._get_profile()
+
+        assert isinstance(profile, RadioProfile)
+        assert profile == resolve_radio_profile()
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert warnings, "expected a WARNING for the MOR-174 fallback"
+        assert profile.model in warnings[0]
+
 
 class TestGetMeterCalPayload:
     """Unit tests for WebServer._get_meter_cal_payload()."""


### PR DESCRIPTION
## The defect

`WebServer._get_profile` filters its model candidates on the literal sentinel
only:

```python
if isinstance(m, str) and m != _RADIO_MODEL_UNSPECIFIED
```

Blank and whitespace-only strings pass that filter. They then reach
`resolve_radio_profile(model=...)`, which does **not** raise on a blank model —
`profiles/__init__.py` guards with `if isinstance(model, str) and model.strip():`,
so a blank model falls through to the library-wide default resolution chain and
returns the reference LAN rig.

Because a blank `radio.model` is the *first* candidate, it wins the loop, and
two things are skipped:

1. the configured `radio_model` candidate, which may well have resolved
   correctly; and
2. the explicit "never silently impersonate IC-7610 (MOR-174)" warning block,
   which is the documented guard on the intended silent-fallback path.

Reproduced at the base commit (`d7d36a78`):

```python
radio = SimpleNamespace(model="", capabilities=set())
srv = WebServer(radio, WebConfig(host="127.0.0.1", port=0, radio_model="FTX-1"))
srv._get_profile()
# -> IC-7610, vfo_scheme="main_sub", srv._profile_fallback_warned is False
```

The configured FTX-1 (`vfo_scheme="ab_shared"`) is discarded in favour of a
silently-substituted `main_sub` rig — exactly the impersonation MOR-174 exists
to prevent.

## The fix

One predicate, matching the guard already used a few lines below in
`WebServer._projected_runtime_capabilities`:

```python
if isinstance(m, str) and m.strip() and m != _RADIO_MODEL_UNSPECIFIED
```

`_get_profile` keeps its distinct semantics deliberately: unlike the fail-closed
capability resolver, it still falls back through `resolve_radio_profile()` and
logs the MOR-174 warning once when no usable candidate remains. The second new
test pins that, so the fix cannot later be "simplified" into a silent fallback.

No shared helper was extracted. `runtime_helpers.projected_vfo_capability_tags`
(merged as #2858 while this branch was under review, so the sibling guard now
lives there rather than inline in `_projected_runtime_capabilities`) carries the
same `.strip()` predicate, but that resolver is fail-closed — the wrong shape for
a path that must fall back and warn. Two instances of a predicate are not three.

## Tests (written first, confirmed failing)

Both new tests fail against the unmodified source:

```
test_blank_radio_model_does_not_short_circuit_configured_model[]    FAILED
  assert profile.vfo_scheme == "ab_shared"
  AssertionError: assert 'main_sub' == 'ab_shared'
test_blank_radio_model_does_not_short_circuit_configured_model[   ] FAILED
  (same assertion)
test_blank_radio_and_config_model_still_warns_and_falls_back        FAILED
  assert warnings, "expected a WARNING for the MOR-174 fallback"
  AssertionError: assert []
```

## Gates

| Gate | Result |
|---|---|
| `pytest tests/test_web_server.py -n auto` | 203 passed, 2 skipped (baseline 200/2) |
| `pytest tests/test_web_server_coverage.py tests/test_serial_backend_smoke.py -n auto` | 159 passed |
| `ruff check src/ tests/` | clean |
| `ruff format src/ tests/` | 699 files unchanged |
| `mypy --strict src/rigplane/web` | Success, 26 source files |

Size: 2 files, 45 changed lines (44 insertions + 1 deletion) — inside the
soft threshold of 6 files / 600 changed lines.

## Origin

EXPLORE phase of the mechanism-audit F1 slice, confirmed by the independent
reviewer of PR #2858 as a third, differently-shaped radio-model filter distinct
from the two that PR consolidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
