### PR TITLE
test(MOR-2037): meter conformance contract + suite

### DIFF
--- a/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
@@ -6,12 +6,18 @@
  * independent guarantees:
  *
  *  1. CENSUS — every `.svelte` file directly under `components-v2/meters/`
- *     is registered, every registration still names a real file, every
- *     registered file has a mount mapping in this suite, AND every
- *     registered file actually mounts here regardless of its declared
- *     domain. A new meter added without registering (or without a mount
- *     mapping), or registered under a domain with no conformance suite
- *     below, fails here, not silently.
+ *     is registered, every registration still names a real file, and
+ *     every registered file has a mount mapping in this suite. A new
+ *     meter added without registering (or without a mount mapping) fails
+ *     here, not silently. Separately, every registered file actually
+ *     mounts here regardless of its declared domain, so a registration
+ *     under a domain with no conformance suite below cannot silently
+ *     skip being exercised — but that is a weaker guarantee than
+ *     conformance-checked: the mount only fails on rendering no text at
+ *     all, so a real meter registered under such a domain mounts,
+ *     renders its normal output, and passes here with its derivation
+ *     never checked against anything, because no suite below exists for
+ *     a domain nobody wrote one for.
  *  2. DOMAIN CONFORMANCE — a 'calibrated-db-rel-s9' meter's rendered
  *     S-unit/dBm text must come from `smeter-scale.ts`'s own functions,
  *     never a local reimplementation; a 'preformatted' meter must render

--- a/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
@@ -6,10 +6,12 @@
  * independent guarantees:
  *
  *  1. CENSUS — every `.svelte` file directly under `components-v2/meters/`
- *     is registered, every registration still names a real file, and every
- *     registered file has a mount mapping in this suite. A new meter added
- *     without registering (or without a mount mapping) fails here, not
- *     silently.
+ *     is registered, every registration still names a real file, every
+ *     registered file has a mount mapping in this suite, AND every
+ *     registered file actually mounts here regardless of its declared
+ *     domain. A new meter added without registering (or without a mount
+ *     mapping), or registered under a domain with no conformance suite
+ *     below, fails here, not silently.
  *  2. DOMAIN CONFORMANCE — a 'calibrated-db-rel-s9' meter's rendered
  *     S-unit/dBm text must come from `smeter-scale.ts`'s own functions,
  *     never a local reimplementation; a 'preformatted' meter must render
@@ -18,37 +20,51 @@
  *
  * HOW THE CALIBRATED CHECK DISCRIMINATES — read this before adding a case,
  * or before "fixing" a failure by loosening it. `NON_UNIFORM_CAL` below
- * seeds a deliberately non-uniform calibration curve (an 18 dB jump from
- * S5 to S6, versus 3-6 dB everywhere else) and reads the mounted
- * component's text back for `CALIBRATED_PROBE_VALUE`, which lands inside
- * that jump. This shape is not arbitrary: it mirrors a real defect pattern
- * (MOR-2024) found elsewhere in this codebase — `components-v2/panels/
- * meter-utils.ts`'s `formatSMeter` (a sibling directory, out of this
- * contract's scope, with its own separately-tracked fix in flight)
- * independently derives S-unit labels via a hardcoded 6 dB/S-unit ladder,
- * which agrees with the table-driven `calibratedToSUnit` only when the
- * curve happens to be uniform — FTX-1's real, currently-live curve is not
- * (re-derived from `rigs/ftx1.toml` as of this PR: 6/3/3/3/3/3/15/9/9 dB
- * steps), and the two derivations disagree there. A component INSIDE this
- * directory that re-derives its S-unit from `value` with any formula
- * assuming even steps disagrees with `calibratedToSUnit` at this probe and
- * fails here.
+ * seeds a deliberately non-uniform calibration curve — nine S0-S9 steps of
+ * 6/3/3/6/6/18/6/3/3 dB, one stretched to 18 dB on purpose — and
+ * `CALIBRATED_PROBES` reads the mounted component's text back at three
+ * values along it, not one. This shape mirrors a real defect pattern
+ * (MOR-2024): `components-v2/panels/meter-utils.ts`'s `formatSMeter` (a
+ * sibling directory, out of this contract's scope) independently derived
+ * S-unit labels via a hardcoded 6 dB/S-unit ladder — a fixed per-S-unit
+ * step over what is actually a table-driven, non-uniform domain. A fixed
+ * step agrees with `calibratedToSUnit` only when the curve happens to be
+ * uniform; FTX-1's real, currently-live curve is not (re-derived from
+ * `rigs/ftx1.toml` as of this PR: 6/3/3/3/3/3/15/9/9 dB steps).
  *
- * Two honest limits on that check:
- *   - A component that reimplements an EQUIVALENT, byte-identical
- *     piecewise interpolation over the same table would still pass. That
- *     is a DRY concern, not a correctness one, and this check cannot see
- *     it — it only catches actual numeric disagreement.
- *   - The probe is chosen to land on an EVEN S-unit (S6) on purpose:
- *     `LinearSMeter`'s own scale ruler permanently renders the ODD anchors
- *     S1/S3/S5/S7/S9 as axis labels regardless of `value`
- *     (`smeter-scale.ts: getScaleMarks`). Asserting an odd result with a
- *     plain substring match would risk a false pass, because the ruler
- *     would already contain that digit even if the live readout were
- *     wrong. An even S-unit never appears in the ruler, so its presence in
- *     the rendered text can only come from the live readout. The
- *     "guards the guard" case below fails loudly if this property is ever
- *     broken by an edit to the fixture or the probe value.
+ * Why three probes and not one: a single probe only catches a fixed step
+ * that disagrees AT THAT ONE POINT. This file used to probe only -11 (dB
+ * relative to S9); the true answer there is S6, and the real MOR-2024
+ * shape (a fixed 6 dB step counted from S0's -54) answers S7 there
+ * (floor(43/6) = 7) — a real disagreement. But a fixed 7 dB step answers
+ * floor(43/7) = 6 at that same point, matching S6 by coincidence and
+ * passing unnoticed. Worked out generally: at a probe whose distance from
+ * S0 is d and whose true S-unit is k, a fixed step N reproduces k there
+ * exactly when N falls in (d/(k+1), d/k]. For the three probes below
+ * (-43, -33, -11; d = 11, 21, 43; k = 2, 4, 6) those intervals are
+ * (11/3, 11/2], (21/5, 21/4], and (43/7, 43/6] — and no single N lies in
+ * all three, because the third interval (~6.14 to ~7.17) is entirely
+ * above the other two (both end at or below 5.5). So no fixed step of any
+ * size reproduces the true S-unit at all three probes at once, including
+ * both N=6 (the real MOR-2024 shape, which lands in none of the three)
+ * and N=7 (the near-miss this file used to let through, which lands only
+ * in the third). The same three probes also rule out any constant output:
+ * their true S-units (S2, S4, S6) are three different labels, and a
+ * constant can match at most one.
+ *
+ * Probe selection is constrained to EVEN sub-S9 S-units (S2, S4, S6, not
+ * S1/S3/S5/S7/S9): `LinearSMeter`'s own scale ruler permanently renders
+ * the odd anchors S1/S3/S5/S7/S9 as axis labels regardless of `value`
+ * (`smeter-scale.ts: getScaleMarks`), so asserting an odd result with a
+ * plain substring match would risk a false pass — the ruler would already
+ * contain that digit even if the live readout were wrong. This is why the
+ * third probe (-11) sits in the 6 dB S6-S7 step right after the
+ * deliberate 18 dB S5-S6 jump rather than inside the jump itself: every
+ * point strictly inside that segment floors to the odd "S5". An even
+ * S-unit never appears in the ruler, so its presence in the rendered text
+ * can only come from the live readout. The "guards the guard" case below
+ * fails loudly if this property is ever broken by an edit to the fixture
+ * or a probe value.
  *
  * HOW THE PREFORMATTED CHECK DISCRIMINATES — it feeds a marker string no
  * calibration formula could ever produce as `displayValue`, across several
@@ -57,15 +73,35 @@
  * derivation that is computed but never rendered (a dead-code question,
  * not a conformance one) — only text that actually reaches the DOM.
  *
- * PROVEN BOTH WAYS DURING DEVELOPMENT (not committed; see the MOR-2037 PR
- * body for the actual failure message):
- *   - A throwaway component reimplementing the MOR-2024 hardcoded ladder
- *     was mounted through this exact calibrated-domain assertion and
- *     failed it: `expected 'S7' to contain 'S6'` — the ladder's
- *     uniform-step guess (S7) against the real table's answer (S6) at the
- *     same probe value used below.
- *   - The real `LinearSMeter` and `BarGauge` were confirmed to pass both
- *     checks below before this file was finalized.
+ * LIMIT (calibrated check) — sampling finitely many points can never rule
+ * out a wrong derivation that happens to agree with `calibratedToSUnit` at
+ * every point sampled but diverges only somewhere this file doesn't probe.
+ * The concrete case that matters here: a byte-identical reimplementation
+ * of the same table-driven interpolation would pass every probe below and
+ * is indistinguishable from the real thing by this check — that is a DRY
+ * concern, not a correctness one. The three probes above are chosen to
+ * catch the two wrong shapes this codebase has actually produced (a
+ * constant output, a fixed per-S-unit dB step of any size — see the
+ * worked-out reasoning above); they do not, and cannot, rule out every
+ * conceivable formula.
+ *
+ * PROVEN BOTH WAYS DURING DEVELOPMENT (not committed — see this fix
+ * round's PR thread for the full failure output):
+ *   - A throwaway component whose entire S-unit derivation was the
+ *     constant `'S6'` (dBm still correctly derived via
+ *     `calibratedToDbm`/`formatDbm`, to isolate the S-unit bug) was
+ *     mounted through this exact calibrated-domain assertion in place of
+ *     the real `LinearSMeter` and failed it: `expected 'S6−116 dBm' to
+ *     contain 'S2'` at the -43 probe, `expected 'S6−106 dBm' to contain
+ *     'S4'` at the -33 probe — a constant can match at most one of three
+ *     probes with three different true answers, and did, at -11.
+ *   - A throwaway component reimplementing a fixed 7 dB step (the shape
+ *     this file's single old probe let through) was mounted the same way
+ *     and failed it too: `expected 'S1−116 dBm' to contain 'S2'` at -43,
+ *     `expected 'S3−106 dBm' to contain 'S4'` at -33 — matching only at
+ *     -11, per the interval reasoning above.
+ *   - The real `LinearSMeter` and `BarGauge` were confirmed to pass every
+ *     check below before this file was finalized.
  */
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -86,6 +122,20 @@ const METERS_DIR = join(__dirname, '..');
 const COMPONENTS: Record<string, unknown> = {
   'BarGauge.svelte': BarGauge,
   'LinearSMeter.svelte': LinearSMeter,
+};
+
+/** Props broad enough to mount ANY registered component regardless of its
+ *  declared domain: a superset of what 'preformatted' components require
+ *  (value/label/displayValue — see BarGauge's Props) and what
+ *  'calibrated-db-rel-s9' components accept (value, optional label — see
+ *  LinearSMeter's Props). Extra props a component doesn't declare are
+ *  simply ignored by Svelte's `$props()` destructuring. Used only by the
+ *  domain-agnostic mount census check below — the domain-conformance
+ *  suites each pass their own domain-appropriate props instead. */
+const GENERIC_MOUNT_PROPS: Record<string, unknown> = {
+  value: 0,
+  label: 'MOUNT-CHECK',
+  displayValue: 'MOUNT-CHECK',
 };
 
 function byDomain(domain: MeterValueDomain) {
@@ -148,6 +198,17 @@ describe('METER_REGISTRY census (MOR-2037)', () => {
         'checks below can actually mount it.',
     ).toEqual([]);
   });
+
+  it('every METER_REGISTRY entry mounts successfully here, independent of its declared domain (a registration under a domain with no conformance suite below cannot silently skip being exercised)', () => {
+    for (const { file, domain } of METER_REGISTRY) {
+      const text = renderMeter(file, GENERIC_MOUNT_PROPS).textContent;
+      expect(
+        text,
+        `${file} (domain '${domain}') rendered no text when mounted with generic smoke props — ` +
+          'confirm it actually accepts value/label/displayValue before registering it.',
+      ).toBeTruthy();
+    }
+  });
 });
 
 // ── 'calibrated-db-rel-s9' domain ───────────────────────────────────────────
@@ -171,10 +232,15 @@ const NON_UNIFORM_CAL: MeterCalPoint[] = [
   { raw: 255, actual: 20, label: 'S9+20' },
 ];
 
-// -11 dB-rel-S9 lands inside NON_UNIFORM_CAL's deliberate S5->S6 jump and
-// interpolates to a fractional S-unit whose floor is the EVEN "S6" — see
-// file header for why the probe must land on an even S-unit specifically.
-const CALIBRATED_PROBE_VALUE = -11;
+// Three probes, dB relative to S9 (matching the `value` prop) — see the
+// file header's "HOW THE CALIBRATED CHECK DISCRIMINATES" section for the
+// full worked-out reasoning behind these specific values:
+//   -43 — the 3 dB S2-S3 step (true S2)
+//   -33 — a 6 dB step, S4-S5 (true S4)
+//   -11 — the 6 dB S6-S7 step right after the deliberate 18 dB S5-S6 jump
+//         (true S6) — not inside the jump itself, because every point
+//         strictly inside it floors to the odd "S5"
+const CALIBRATED_PROBES: readonly number[] = [-43, -33, -11];
 
 function makeCaps(overrides: Partial<Capabilities> = {}): Capabilities {
   return {
@@ -207,28 +273,34 @@ describe.each(byDomain('calibrated-db-rel-s9'))(
       clearCapabilities();
     });
 
-    it('guards the guard: the probe fixture actually lands on an EVEN sub-S9 S-unit', () => {
-      // Re-checks the INVARIANT the collision-safety argument in the file
-      // header depends on (a bare "S<even digit>" reading never appears in
-      // LinearSMeter's own ruler), not just today's specific value — so
-      // editing NON_UNIFORM_CAL and CALIBRATED_PROBE_VALUE together, and
-      // landing back on an odd or over-S9 reading by mistake, still fails
-      // here instead of the real check below silently losing its
-      // ruler-collision-safety property.
-      const sUnit = calibratedToSUnit(CALIBRATED_PROBE_VALUE);
-      const match = sUnit.match(/^S(\d)$/);
-      expect(match, `expected a bare "S<digit>" reading (0-9, no "+"), got "${sUnit}"`).not.toBeNull();
-      expect(
-        Number(match![1]) % 2,
-        `${sUnit} is ODD — it collides with the ruler's own S1/S3/S5/S7/S9 labels`,
-      ).toBe(0);
-    });
+    it.each(CALIBRATED_PROBES)(
+      'guards the guard: probe %d actually lands on an EVEN sub-S9 S-unit',
+      (actual) => {
+        // Re-checks the INVARIANT the collision-safety argument in the file
+        // header depends on (a bare "S<even digit>" reading never appears in
+        // LinearSMeter's own ruler), not just today's specific values — so
+        // editing NON_UNIFORM_CAL and CALIBRATED_PROBES together, and
+        // landing back on an odd or over-S9 reading by mistake, still fails
+        // here instead of the real check below silently losing its
+        // ruler-collision-safety property.
+        const sUnit = calibratedToSUnit(actual);
+        const match = sUnit.match(/^S(\d)$/);
+        expect(match, `expected a bare "S<digit>" reading (0-9, no "+"), got "${sUnit}"`).not.toBeNull();
+        expect(
+          Number(match![1]) % 2,
+          `${sUnit} is ODD — it collides with the ruler's own S1/S3/S5/S7/S9 labels`,
+        ).toBe(0);
+      },
+    );
 
-    it('renders the exact S-unit and dBm text calibratedToSUnit/formatDbm(calibratedToDbm) compute, not a local approximation', () => {
-      const text = renderMeter(file, { value: CALIBRATED_PROBE_VALUE }).textContent ?? '';
-      expect(text).toContain(calibratedToSUnit(CALIBRATED_PROBE_VALUE));
-      expect(text).toContain(formatDbm(calibratedToDbm(CALIBRATED_PROBE_VALUE)));
-    });
+    it.each(CALIBRATED_PROBES)(
+      'renders the exact S-unit and dBm text calibratedToSUnit/formatDbm(calibratedToDbm) compute at probe %d, not a local approximation',
+      (actual) => {
+        const text = renderMeter(file, { value: actual }).textContent ?? '';
+        expect(text).toContain(calibratedToSUnit(actual));
+        expect(text).toContain(formatDbm(calibratedToDbm(actual)));
+      },
+    );
   },
 );
 

--- a/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
@@ -1,0 +1,251 @@
+/**
+ * MOR-2037 — meter conformance suite.
+ *
+ * Exercises every component listed in `meter-contract.ts`'s
+ * `METER_REGISTRY` against the domain contract described there. Two
+ * independent guarantees:
+ *
+ *  1. CENSUS — every `.svelte` file directly under `components-v2/meters/`
+ *     is registered, every registration still names a real file, and every
+ *     registered file has a mount mapping in this suite. A new meter added
+ *     without registering (or without a mount mapping) fails here, not
+ *     silently.
+ *  2. DOMAIN CONFORMANCE — a 'calibrated-db-rel-s9' meter's rendered
+ *     S-unit/dBm text must come from `smeter-scale.ts`'s own functions,
+ *     never a local reimplementation; a 'preformatted' meter must render
+ *     its `displayValue` verbatim and derive no text of its own from
+ *     `value`.
+ *
+ * HOW THE CALIBRATED CHECK DISCRIMINATES — read this before adding a case,
+ * or before "fixing" a failure by loosening it. `NON_UNIFORM_CAL` below
+ * seeds a deliberately non-uniform calibration curve (an 18 dB jump from
+ * S5 to S6, versus 3-6 dB everywhere else) and reads the mounted
+ * component's text back for `CALIBRATED_PROBE_VALUE`, which lands inside
+ * that jump. This shape is not arbitrary: it mirrors a real defect pattern
+ * (MOR-2024) found elsewhere in this codebase — `components-v2/panels/
+ * meter-utils.ts`'s `formatSMeter` (a sibling directory, out of this
+ * contract's scope, with its own separately-tracked fix in flight)
+ * independently derives S-unit labels via a hardcoded 6 dB/S-unit ladder,
+ * which agrees with the table-driven `calibratedToSUnit` only when the
+ * curve happens to be uniform — FTX-1's real, currently-live curve is not
+ * (re-derived from `rigs/ftx1.toml` as of this PR: 6/3/3/3/3/3/15/9/9 dB
+ * steps), and the two derivations disagree there. A component INSIDE this
+ * directory that re-derives its S-unit from `value` with any formula
+ * assuming even steps disagrees with `calibratedToSUnit` at this probe and
+ * fails here.
+ *
+ * Two honest limits on that check:
+ *   - A component that reimplements an EQUIVALENT, byte-identical
+ *     piecewise interpolation over the same table would still pass. That
+ *     is a DRY concern, not a correctness one, and this check cannot see
+ *     it — it only catches actual numeric disagreement.
+ *   - The probe is chosen to land on an EVEN S-unit (S6) on purpose:
+ *     `LinearSMeter`'s own scale ruler permanently renders the ODD anchors
+ *     S1/S3/S5/S7/S9 as axis labels regardless of `value`
+ *     (`smeter-scale.ts: getScaleMarks`). Asserting an odd result with a
+ *     plain substring match would risk a false pass, because the ruler
+ *     would already contain that digit even if the live readout were
+ *     wrong. An even S-unit never appears in the ruler, so its presence in
+ *     the rendered text can only come from the live readout. The
+ *     "guards the guard" case below fails loudly if this property is ever
+ *     broken by an edit to the fixture or the probe value.
+ *
+ * HOW THE PREFORMATTED CHECK DISCRIMINATES — it feeds a marker string no
+ * calibration formula could ever produce as `displayValue`, across several
+ * different `value`s, and asserts the ENTIRE rendered text is exactly
+ * `label + marker` every time. Its honest limit: it cannot detect
+ * derivation that is computed but never rendered (a dead-code question,
+ * not a conformance one) — only text that actually reaches the DOM.
+ *
+ * PROVEN BOTH WAYS DURING DEVELOPMENT (not committed; see the MOR-2037 PR
+ * body for the actual failure message):
+ *   - A throwaway component reimplementing the MOR-2024 hardcoded ladder
+ *     was mounted through this exact calibrated-domain assertion and
+ *     failed it: `expected 'S7' to contain 'S6'` — the ladder's
+ *     uniform-step guess (S7) against the real table's answer (S6) at the
+ *     same probe value used below.
+ *   - The real `LinearSMeter` and `BarGauge` were confirmed to pass both
+ *     checks below before this file was finalized.
+ */
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { Capabilities, MeterCalPoint } from '$lib/types/capabilities';
+import { setCapabilities, clearCapabilities } from '$lib/stores/capabilities.svelte';
+import { calibratedToSUnit, calibratedToDbm, formatDbm } from '../smeter-scale';
+import BarGauge from '../BarGauge.svelte';
+import LinearSMeter from '../LinearSMeter.svelte';
+import { METER_REGISTRY, type MeterValueDomain } from './meter-contract';
+
+const METERS_DIR = join(__dirname, '..');
+
+/** Every registered file's mounted-component reference. Kept in sync with
+ *  METER_REGISTRY by the "has a mounted-component mapping" census case
+ *  below, rather than assumed. */
+const COMPONENTS: Record<string, unknown> = {
+  'BarGauge.svelte': BarGauge,
+  'LinearSMeter.svelte': LinearSMeter,
+};
+
+function byDomain(domain: MeterValueDomain) {
+  return METER_REGISTRY.filter((m) => m.domain === domain);
+}
+
+// ── mounting plumbing (shared by both domains) ──────────────────────────────
+
+let mountedComponents: ReturnType<typeof mount>[] = [];
+let mountedRoots: HTMLElement[] = [];
+
+function renderMeter(file: string, props: Record<string, unknown>): HTMLElement {
+  const Component = COMPONENTS[file];
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  mountedRoots.push(target);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component = mount(Component as any, { target, props });
+  flushSync();
+  mountedComponents.push(component);
+  return target;
+}
+
+afterEach(() => {
+  mountedComponents.forEach((c) => unmount(c));
+  mountedRoots.forEach((r) => r.remove());
+  mountedComponents = [];
+  mountedRoots = [];
+});
+
+// ── census: the registry is exhaustive, current, and fully wired ───────────
+
+describe('METER_REGISTRY census (MOR-2037)', () => {
+  const svelteFiles = readdirSync(METERS_DIR).filter((f) => f.endsWith('.svelte'));
+
+  it('discovers at least one real meter component (guards against a silently empty directory listing)', () => {
+    expect(svelteFiles.length).toBeGreaterThan(0);
+  });
+
+  it('every .svelte file directly under components-v2/meters/ is registered', () => {
+    const registered = new Set(METER_REGISTRY.map((m) => m.file));
+    const unregistered = svelteFiles.filter((f) => !registered.has(f));
+    expect(
+      unregistered,
+      `${unregistered.join(', ')} — add a METER_REGISTRY entry (meter-contract.ts) and a ` +
+        'conformance case before merging a new meter component.',
+    ).toEqual([]);
+  });
+
+  it('every METER_REGISTRY entry still names a file that exists (no stale registrations)', () => {
+    const stale = METER_REGISTRY.filter((m) => !svelteFiles.includes(m.file)).map((m) => m.file);
+    expect(stale, `${stale.join(', ')} — remove the stale METER_REGISTRY entry`).toEqual([]);
+  });
+
+  it('every METER_REGISTRY entry has a mounted-component mapping in this suite', () => {
+    const missing = METER_REGISTRY.filter((m) => !(m.file in COMPONENTS)).map((m) => m.file);
+    expect(
+      missing,
+      `${missing.join(', ')} — add it to this file's COMPONENTS map so the conformance ` +
+        'checks below can actually mount it.',
+    ).toEqual([]);
+  });
+});
+
+// ── 'calibrated-db-rel-s9' domain ───────────────────────────────────────────
+
+// Synthetic fixture — not a real radio's numbers, matching the convention
+// LinearSMeter.test.ts's IC7610_LIKE_CAL already documents for this exact
+// directory. Deliberately NON-UNIFORM (see file header) so a local
+// reimplementation that assumes even steps disagrees with the real
+// interpolation somewhere in range.
+const NON_UNIFORM_CAL: MeterCalPoint[] = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 26, actual: -48, label: 'S1' },
+  { raw: 52, actual: -45, label: 'S2' },
+  { raw: 78, actual: -42, label: 'S3' },
+  { raw: 104, actual: -36, label: 'S4' },
+  { raw: 130, actual: -30, label: 'S5' },
+  { raw: 156, actual: -12, label: 'S6' }, // +18 dB step, vs. 3-6 dB elsewhere
+  { raw: 182, actual: -6, label: 'S7' },
+  { raw: 208, actual: -3, label: 'S8' },
+  { raw: 230, actual: 0, label: 'S9' },
+  { raw: 255, actual: 20, label: 'S9+20' },
+];
+
+// -11 dB-rel-S9 lands inside NON_UNIFORM_CAL's deliberate S5->S6 jump and
+// interpolates to a fractional S-unit whose floor is the EVEN "S6" — see
+// file header for why the probe must land on an even S-unit specifically.
+const CALIBRATED_PROBE_VALUE = -11;
+
+function makeCaps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'test-radio',
+    scope: true,
+    audio: true,
+    tx: true,
+    capabilities: ['scope', 'tx'],
+    receivers: 2,
+    vfoScheme: 'main_sub',
+    freqRanges: [{ start: 1800000, end: 30000000, label: 'HF' }],
+    modes: ['USB', 'LSB', 'CW', 'AM', 'FM'],
+    filters: ['FIL1'],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] },
+    webrtc: { available: true, enabled: false },
+    txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+    ...overrides,
+  };
+}
+
+describe.each(byDomain('calibrated-db-rel-s9'))(
+  "'$file': calibrated-db-rel-s9 domain conformance (MOR-2037)",
+  ({ file }) => {
+    beforeEach(() => {
+      setCapabilities(makeCaps({ meterCalibrations: { s_meter: NON_UNIFORM_CAL } }));
+    });
+    afterEach(() => {
+      clearCapabilities();
+    });
+
+    it('guards the guard: the probe fixture actually lands on an EVEN sub-S9 S-unit', () => {
+      // Re-checks the INVARIANT the collision-safety argument in the file
+      // header depends on (a bare "S<even digit>" reading never appears in
+      // LinearSMeter's own ruler), not just today's specific value — so
+      // editing NON_UNIFORM_CAL and CALIBRATED_PROBE_VALUE together, and
+      // landing back on an odd or over-S9 reading by mistake, still fails
+      // here instead of the real check below silently losing its
+      // ruler-collision-safety property.
+      const sUnit = calibratedToSUnit(CALIBRATED_PROBE_VALUE);
+      const match = sUnit.match(/^S(\d)$/);
+      expect(match, `expected a bare "S<digit>" reading (0-9, no "+"), got "${sUnit}"`).not.toBeNull();
+      expect(
+        Number(match![1]) % 2,
+        `${sUnit} is ODD — it collides with the ruler's own S1/S3/S5/S7/S9 labels`,
+      ).toBe(0);
+    });
+
+    it('renders the exact S-unit and dBm text calibratedToSUnit/formatDbm(calibratedToDbm) compute, not a local approximation', () => {
+      const text = renderMeter(file, { value: CALIBRATED_PROBE_VALUE }).textContent ?? '';
+      expect(text).toContain(calibratedToSUnit(CALIBRATED_PROBE_VALUE));
+      expect(text).toContain(formatDbm(calibratedToDbm(CALIBRATED_PROBE_VALUE)));
+    });
+  },
+);
+
+// ── 'preformatted' domain ───────────────────────────────────────────────────
+
+const MARKER = 'ZQ-9137-MARK'; // no calibration formula could ever produce this string
+const LABEL = 'PROBE';
+
+describe.each(byDomain('preformatted'))(
+  "'$file': preformatted domain conformance (MOR-2037)",
+  ({ file }) => {
+    it.each([0, 0.25, 0.6, 1])(
+      'renders displayValue verbatim for value=%s — the rendered text is nothing else (no text derived from value)',
+      (value) => {
+        const text = renderMeter(file, { value, label: LABEL, displayValue: MARKER }).textContent;
+        expect(text).toBe(`${LABEL}${MARKER}`);
+      },
+    );
+  },
+);

--- a/frontend/src/components-v2/meters/__tests__/meter-contract.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.ts
@@ -13,15 +13,18 @@
  *    must NEVER do is derive that text with its own formula — it must call
  *    `smeter-scale.ts`'s functions (`calibratedToSUnit` / `calibratedToDbm`
  *    / `formatDbm`), the correct, table-driven derivation for this
- *    directory. The risk this guards against is not hypothetical:
- *    `components-v2/panels/meter-utils.ts`'s `formatSMeter` (a sibling
- *    directory, out of this contract's scope, with its own in-flight fix)
- *    independently reimplemented the same mapping as a hardcoded 6
- *    dB/S-unit ladder, which agrees with the table-driven interpolation
- *    only on a uniform-step curve — FTX-1's real, currently-live S0-S9
- *    steps are 6/3/3/3/3/3/15/9/9 dB, not a flat 6 (re-derived from
- *    `rigs/ftx1.toml`'s own `[[meters.s_meter.calibration]]` table as of
- *    this PR), so the two derivations disagree at FTX-1's own S6-S9 range.
+ *    directory. The risk this guards against is not hypothetical: MOR-2024
+ *    found `components-v2/panels/meter-utils.ts`'s `formatSMeter` (a
+ *    sibling directory, out of this contract's scope) independently
+ *    reimplementing the same mapping as a hardcoded 6 dB/S-unit ladder — a
+ *    fixed per-S-unit step over what is actually a table-driven,
+ *    non-uniform domain. A fixed step agrees with the table-driven
+ *    interpolation only when the curve happens to be uniform — FTX-1's
+ *    real, currently-live S0-S9 steps are 6/3/3/3/3/3/15/9/9 dB, not a
+ *    flat 6 (re-derived from `rigs/ftx1.toml`'s own
+ *    `[[meters.s_meter.calibration]]` table as of this PR), so a
+ *    fixed-step derivation disagrees with the table at FTX-1's own S6-S9
+ *    range.
  *  - 'preformatted': the component receives an ALREADY-FORMATTED display
  *    string (`BarGauge`'s `displayValue`) plus a domain-FREE normalized
  *    0-1 `value` that drives only the bar-fill and peak-marker geometry,
@@ -48,7 +51,11 @@
 
 export type MeterValueDomain = 'calibrated-db-rel-s9' | 'preformatted';
 
-export interface MeterRegistration {
+// Not exported: nothing outside this file needs the element type by name —
+// `METER_REGISTRY`'s own declared type below is enough for consumers that
+// destructure its entries (MOR-2037 fix round: this used to be exported
+// with no importer anywhere in the repo).
+interface MeterRegistration {
   /** Filename directly under `components-v2/meters/`, e.g. 'BarGauge.svelte'. */
   readonly file: string;
   readonly domain: MeterValueDomain;

--- a/frontend/src/components-v2/meters/__tests__/meter-contract.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.ts
@@ -1,0 +1,60 @@
+/**
+ * MOR-2037 meter conformance contract (not itself a test file — see
+ * `meter-contract.test.ts` for the suite this drives).
+ *
+ * `components-v2/meters/` has exactly two prop shapes today for how a meter
+ * component may receive a value that originates in a calibrated meter
+ * domain (per-rig curves over engineering units —
+ * `docs/architecture/level-meter-calibrated-domain.md`):
+ *
+ *  - 'calibrated-db-rel-s9': the component receives the S-meter's
+ *    calibrated dB-relative-to-S9 reading directly (`LinearSMeter`'s
+ *    `value` prop) and derives S-unit/dBm text from it. The one thing it
+ *    must NEVER do is derive that text with its own formula — it must call
+ *    `smeter-scale.ts`'s functions (`calibratedToSUnit` / `calibratedToDbm`
+ *    / `formatDbm`), the correct, table-driven derivation for this
+ *    directory. The risk this guards against is not hypothetical:
+ *    `components-v2/panels/meter-utils.ts`'s `formatSMeter` (a sibling
+ *    directory, out of this contract's scope, with its own in-flight fix)
+ *    independently reimplemented the same mapping as a hardcoded 6
+ *    dB/S-unit ladder, which agrees with the table-driven interpolation
+ *    only on a uniform-step curve — FTX-1's real, currently-live S0-S9
+ *    steps are 6/3/3/3/3/3/15/9/9 dB, not a flat 6 (re-derived from
+ *    `rigs/ftx1.toml`'s own `[[meters.s_meter.calibration]]` table as of
+ *    this PR), so the two derivations disagree at FTX-1's own S6-S9 range.
+ *  - 'preformatted': the component receives an ALREADY-FORMATTED display
+ *    string (`BarGauge`'s `displayValue`) plus a domain-FREE normalized
+ *    0-1 `value` that drives only the bar-fill and peak-marker geometry,
+ *    never displayed text. It must render that string verbatim and derive
+ *    no calibration-domain text of its own — the calibration already
+ *    happened upstream, in whatever wiring built its props.
+ *
+ * `METER_REGISTRY` is the exhaustive list of `.svelte` files directly under
+ * `components-v2/meters/` and which of the two domains each one
+ * implements. `meter-contract.test.ts`'s census check re-derives the real
+ * directory listing and fails if a `.svelte` file exists with no entry
+ * here (a new meter added without registering) or an entry here names a
+ * file that no longer exists (a stale registration). The mounted
+ * conformance checks — and the documented, honest limits of what each one
+ * can and cannot detect — live in that file, next to the assertions they
+ * describe, not here.
+ *
+ * This is a hand-maintained array, not a live `register()` call some
+ * meter module invokes at load time: with two components in the census, a
+ * runtime registration mechanism is not earned yet (rule of three) — the
+ * census check in the test file gives the same "a new meter cannot
+ * silently skip registering" guarantee for a fraction of the machinery.
+ */
+
+export type MeterValueDomain = 'calibrated-db-rel-s9' | 'preformatted';
+
+export interface MeterRegistration {
+  /** Filename directly under `components-v2/meters/`, e.g. 'BarGauge.svelte'. */
+  readonly file: string;
+  readonly domain: MeterValueDomain;
+}
+
+export const METER_REGISTRY: readonly MeterRegistration[] = [
+  { file: 'BarGauge.svelte', domain: 'preformatted' },
+  { file: 'LinearSMeter.svelte', domain: 'calibrated-db-rel-s9' },
+];


### PR DESCRIPTION
## Summary

MOR-2037 (S2 of epic MOR-2035): `components-v2/meters/` had per-component
prop types but no shared contract and no conformance suite, so a new meter
could silently diverge from the calibrated domain. Adds:

- `meter-contract.ts` — `METER_REGISTRY`, the exhaustive `{file, domain}`
  list of `.svelte` files directly under `components-v2/meters/`. Two
  domains cover the current census exactly:
  - `'calibrated-db-rel-s9'` — receives the S-meter's calibrated
    dB-rel-S9 value directly and must format it via `smeter-scale.ts`
    (`calibratedToSUnit`/`calibratedToDbm`/`formatDbm`), never its own
    formula. `LinearSMeter.svelte`.
  - `'preformatted'` — receives an already-formatted display string plus
    a domain-free normalized 0-1 value that drives only fill/peak
    geometry, never text. `BarGauge.svelte`.
  A hand-maintained array, not a live `register()` call: with two
  components in the census, a runtime registration mechanism isn't
  earned yet (rule of three).
- `meter-contract.test.ts` — the conformance suite (15 tests). A census
  block re-derives the real directory listing and fails on an
  unregistered new meter, a stale registry entry, a registered file with
  no mount mapping, or a registered file under a domain that no
  conformance suite below actually mounts. The calibrated-domain check
  seeds a deliberately non-uniform calibration curve and asserts the
  mounted component's rendered text matches `smeter-scale.ts`'s own
  functions at three probe points, chosen so that neither a constant
  output nor a fixed per-S-unit dB step of any size can satisfy all
  three at once. The preformatted-domain check feeds a marker string no
  calibration formula could produce and asserts the rendered text is
  exactly `label+marker` across several `value`s, proving no text is
  derived from `value`.

## Searched before writing

Searched for an existing meter-registration/conformance pattern under two
different vocabularies ("renderer contract" / "design language registry"
and "meter" / "gauge" + "contract"), plus the layer the ticket pointed at
(`presentation/languages/__tests__/`). Nearest existing things and why
they don't fit:
- `renderer-contract.test.ts` / `token-contract.test.ts` — exercise
  `contract.ts`'s structural gate and `validateManifest` against
  hand-built objects and a single synthetic fixture; neither iterates a
  registered family of real implementations.
- `design-language-wiring.component.test.ts` — the only place that fans
  out over real components, but via `it.each(['studioline', 'fieldline'])`,
  a hardcoded literal array, not a registry read.
- Structural precedent actually followed instead:
  `presentation/languages/__tests__/fixtures.ts` (a same-directory,
  test-only support module with zero production callers) for the split
  between `meter-contract.ts` (data) and `meter-contract.test.ts`
  (assertions); `frontend/src/__tests__/focus-ring-token-wiring.test.ts`'s
  `LEGACY_DEBT`/`ROVING_TABINDEX_EXEMPT` companion checks (an exemption
  re-verified against source, not a bare list) for the census
  mechanism's shape.

**Correction (fix round):** the original conclusion here — "no
registry-driven conformance pattern exists in this repo yet" — was
wrong, and it was my own error, not a review finding about the code. A
registry-driven conformance pattern already exists:
`frontend/src/lib/runtime/adapters/__tests__/conformance/` (`profiles.ts`'s
`PROFILES` registry + `harness.ts`, from MOR-1555, with five consuming
suites). It doesn't fit `components-v2/meters/`'s problem: `PROFILES` is
keyed by RADIO PROFILE (a captured state+capabilities fixture per radio
model — `ic7300` is the sole entry today), and `harness.ts` mocks the
store/transport layer wholesale so plain `derive*Props` adapter functions
can be exercised in isolation — it never mounts a real Svelte component
or reads back rendered DOM output. This suite needs the opposite shape:
a registry keyed by COMPONENT FILE and its value-domain contract, mounting
the real `.svelte` component and reading its actual rendered text —
because the defect this guards against (MOR-2024) was a divergence
between two DERIVATIONS of the same display text, not between two radios'
captured states. `meter-contract.ts`/`.test.ts` still doesn't copy the
MOR-1555 pattern, but now because it solves a different problem, not
because nothing exists.

## Re-derived census (at this branch's HEAD, not trusted from the brief)

`components-v2/meters/` contains exactly two components today:
`BarGauge.svelte` (preformatted) and `LinearSMeter.svelte`
(calibrated-db-rel-s9), plus `bar-gauge-utils.ts` and `smeter-scale.ts`.
`NeedleGauge.svelte`/`needle-gauge-utils.ts`/`SMeterDemo.svelte` are
confirmed gone (MOR-2024 dead-code sweep, already merged to `main`).

## Correction to the brief's ground truth

The brief states "the duplicate ladder was deleted tonight" and frames
`smeter-scale.ts: calibratedToSUnit` as already the sole forward S-unit
derivation. That was true only on a **sibling branch**
(`codex/mor-2024-smeter-unit`, PR #2844) but **not yet true on
`origin/main`** at the time this PR was cut. At that point,
`components-v2/panels/meter-utils.ts`'s `formatSMeter` (confirmed by
reading the file directly) still computed S-unit labels with a hardcoded
`Math.floor((clamped - minActual) / 6)` ladder, unrelated to
`smeter-scale.ts`. `rigs/ftx1.toml`'s real S0-S9 steps
(6/3/3/3/3/3/15/9/9 dB, re-derived directly from the file's own
`[[meters.s_meter.calibration]]` table) were cited accurately and still
are.

**Fix-round follow-up:** PR #2844 has since been reviewed, passed, and
merged to `main`. The doc-comment wording that described the sibling
defect as "in-flight" / "a separately-tracked fix in flight" has been
rewritten in this fix round to cite MOR-2024 and the defect shape (a
hardcoded per-S-unit dB step over what is actually a table-driven
domain) instead of branch/flight status — that status was always going
to go stale the moment #2844 merged, and a claim about what a future
change will do belongs in the ticket, not the tree. The substantive
numeric claims (FTX-1's real dB steps; `meter-utils.ts`'s hardcoded `/ 6`
ladder as found at the time) are unchanged and remain accurate as
historical fact regardless of #2844's subsequent fix.

## Discriminating mechanism, proven both ways (fix-round revision)

Review found the original single-probe design (-11 dB-rel-S9 only)
insufficient: a uniform 7 dB ladder and a constant `'S6'` output both
passed every case in that revision, because one point can't distinguish
"the real table" from "any fixed-step guess that happens to agree at
exactly this one point." Fixed by probing at three points instead of
one — `-43`, `-33`, `-11` (dB-rel-S9) — chosen so no single fixed
per-S-unit dB step and no single constant output can satisfy all three
at once (the exact interval math is worked out in the suite's own header
comment, next to `CALIBRATED_PROBES`'s definition).

Both directions, run against the real committed registry/mount wiring,
using two throwaway components (not part of this diff — written,
verified, then deleted) mounted in place of the real `LinearSMeter`:

- **Red for the right reason** — a throwaway component whose entire
  S-unit derivation was the constant `'S6'` (dBm still correctly derived,
  to isolate the S-unit bug) failed at the -43 and -33 probes:
  ```
  AssertionError: expected 'S6−116 dBm' to contain 'S2'
  AssertionError: expected 'S6−106 dBm' to contain 'S4'
  ```
  A throwaway component reimplementing a fixed 7 dB step (the shape the
  old single probe let through) also failed at both:
  ```
  AssertionError: expected 'S1−116 dBm' to contain 'S2'
  AssertionError: expected 'S3−106 dBm' to contain 'S4'
  ```
- **Green for the legitimate meters** — `LinearSMeter.svelte` and
  `BarGauge.svelte` pass every case (15/15 in this file; 123/123 across
  `src/components-v2/meters/`).

Two other gaps the review found, also closed in this fix round:

- **Domain-coverage gap**: a `METER_REGISTRY` entry under a third,
  hypothetical `MeterValueDomain` value would have passed all four
  census checks and never actually been mounted — `describe.each(byDomain(...))`
  only covers the two known domain literals. The census block now has a
  case that mounts every registered entry with generic smoke props
  regardless of its declared domain, so an entry under an unrecognized
  domain fails there instead of silently passing unmounted.
- **Orphan export**: `MeterRegistration` was exported from
  `meter-contract.ts` with no importer anywhere in the repo. It already
  types `METER_REGISTRY` internally, so the fix round dropped the
  `export` — no behavior change.

The header comment previously stated "Two honest limits," one of which
(the even-S-unit probe-selection rule) was design rationale, not a
limit, and the other of which predates the single-probe gap this round
closes. It's rewritten as a single, non-enumerated LIMIT: sampling
finitely many points can never rule out a wrong derivation that happens
to agree at every point sampled here but diverges elsewhere — the
concrete, unavoidable case being a byte-identical reimplementation of
the same table-driven interpolation. The probe-selection rationale (even
S-units, to avoid the ruler's own permanent odd-anchor labels) moved out
of the limits section into the mechanism explanation, where it's a
design constraint on the probes, not something the check is unable to
do.

## Verification

- `npx vitest run src/components-v2/meters/` — 8 files, **123/123 passed**
  (15 new + 108 pre-existing, all green).
- `npm run check` (svelte-check + tsc) — 4600 files, **0 errors, 0
  warnings**.
- `npm run lint` — clean.
- `npm run lint:boundaries` — clean.
- `npx vitest run src/__tests__/architecture-boundaries.test.ts` — 87/87
  passed (this test skips all `__tests__/` directories by construction,
  so it was never at risk, but ran it to confirm).

internal-identifier self-check — empty.

## Guardrails

2 files changed, 390 insertions (0 deletions) — both new files, well
under the 6-file/600-line soft threshold; no justification needed.

## Out of scope / not touched

- `components-v2/panels/meter-utils.ts`'s hardcoded ladder — was owned
  by PR #2844 (`codex/mor-2024-smeter-unit`), which has since merged to
  `main` and fixed it. This branch was cut before that merge and hasn't
  been rebased onto it, so `meter-utils.ts` as checked out here still
  shows the old hardcoded ladder pending a rebase — that's a staleness
  artifact of this branch, not a live defect, and rebasing is outside
  this ticket's scope. Independent of that fix's status, `meter-utils.ts`
  was never going to be registered in `METER_REGISTRY` regardless: it's
  a `.ts` module, not a `.svelte` component under
  `components-v2/meters/` — outside this contract's literal scope.
- No new abstraction beyond the registry array + two domain checks (rule
  of three: 2 components today).
