### PR TITLE
refactor(MOR-2036): export the RxTxSurface/MetersSurface data-* vocabulary

### DIFF
--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -8,7 +8,16 @@
  * Neither imports runtime/capability/transport/command code — enforced at
  * lint time by the presentation/ zone (MOR-1061). See v3 ADR and MOR-977
  * §4 (frozen 2026-08-03).
+ *
+ * The MOR-2036 data-* vocabulary section at the end of this file is a
+ * second, independent contract living in the same module (the ticket's
+ * named home for it) — it shares this header's "type-only from semantic/"
+ * discipline but not its token/renderer subject matter.
  */
+import type {
+  KeyBlockedReason, RfState, TxOrigin, TxSessionState, TxTargetUnknownReason,
+} from '../../semantic/rx-tx-surface';
+import type { DisabledReasonCode } from '../../semantic/radio-view-model';
 
 /**
  * Naming policy (MOR-977 §4.6, MOR-1071): kebab-case, no vendor/model
@@ -206,3 +215,80 @@ export function invokeRenderer(renderer: Renderer, viewModel: unknown, tokens: D
   }
   return renderer(viewModel as RendererViewModel, tokens);
 }
+
+// ── MOR-2036 — the data-* visual-state vocabulary a stylesheet keys off ────
+//
+// `RxTxSurface.svelte` and `MetersSurface.svelte` are the two semantic-
+// vertical files whose `data-*` attributes a SHIPPED design-language
+// stylesheet actually branches on: `fieldline.css` and `studioline.css`
+// each key well over ten rules off `[data-session=...]`/`[data-rf=...]`.
+// This section exists so a THIRD stylesheet author reads these exports
+// instead of reverse-engineering the value sets from those two files, the
+// way the first two families' authors had to.
+//
+// `VfoSurface.svelte` is the third file the MOR-2036 owner ruling scopes
+// this contract to, but neither shipped stylesheet selects on any
+// `data-vfo-*`/`data-active-receiver`/`data-split-*` attribute today — that
+// family carries none of the reverse-engineering burden this section
+// removes, so it is not exported here. Likewise `RxTxSurface.svelte`'s own
+// `data-origin`/`data-intent`/`data-fault-legs`/`data-receiver`/`data-slot`/
+// `data-field` and `MetersSurface.svelte`'s `data-relevant`/`data-observed`/
+// `data-meter` are real vocabularies (documented in each file's own source)
+// that no stylesheet keys off yet either; only the two collisions below
+// (`data-fault`, `data-reason`) are exported without a stylesheet consumer,
+// because they are contract defects in their own right.
+//
+// Value arrays are re-declared rather than imported from `semantic/` —
+// this module reads `semantic/` types only (`import type` above; the v3
+// ADR's one-way dependency, enforced here by inspection rather than by an
+// eslint rule) — the same reason `radio-view-model.ts` re-declares
+// `MeterRfState` instead of importing `RfState`. Agreement with the real
+// unions is pinned in `semantic/__tests__/state-vocabulary.component.test.ts`.
+
+export type { KeyBlockedReason, RfState, TxOrigin, TxSessionState };
+
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-rf` — also `MetersSurface.svelte`'s `data-rf-state` (a separately-declared but member-for-member identical vocabulary, `MeterRfState`). */
+export const RF_STATES: readonly RfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-session`. */
+export const TX_SESSION_STATES: readonly TxSessionState[] = ['idle', 'pending', 'keyed', 'releasing', 'failed'];
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-origin`. */
+export const TX_ORIGINS: readonly TxOrigin[] = ['local', 'external'];
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-target"] data-target`. */
+export const TX_TARGET_STATUSES = ['known', 'unknown'] as const;
+export type TxTargetStatus = (typeof TX_TARGET_STATUSES)[number];
+
+/**
+ * `data-fault` COLLISION (MOR-2036) — the same attribute name renders two
+ * unrelated grammars on two different elements of the semantic vertical:
+ *  - `RxTxSurface.svelte`'s `.rx-tx-fault` paragraph: the App TX authority's
+ *    own fault CODE (`TxAuthoritySnapshot.fault: string | null`), open-ended
+ *    by design — a code this surface has never heard of must still show, so
+ *    this is deliberately not a closed union.
+ *  - `MetersSurface.svelte`'s `.meter-tile`: a plain over-threshold boolean,
+ *    stringified the same way `data-relevant`/`data-observed` are.
+ * Left unrenamed here: both attributes have existing test assertions keyed
+ * to this exact name (e.g. `MetersSurface.test.ts`,
+ * `rx-tx-surface.component.test.ts`) that a rename would break, for no
+ * benefit to this ticket.
+ */
+export type RxTxFaultValue = string;
+export type MetersFaultValue = 'true' | 'false';
+
+/**
+ * `data-reason` COLLISION (MOR-2036) — THREE unrelated unions share this one
+ * attribute name, all in `RxTxSurface.svelte`, depending on which element
+ * renders it:
+ *  - the unknown-TX-target paragraph (`[data-testid="rx-tx-target"]`):
+ *    `TxTargetUnknownReason` — four transient/permanent target facts.
+ *  - a blocked-key-reason list item (`.rx-tx-blocked li`, no sibling
+ *    `data-field`): `KeyBlockedReason` — this surface's own key-gate
+ *    reasons.
+ *  - a disabled-reason list item (same list, WITH a sibling `data-field`):
+ *    `DisabledReasonCode` (`radio-view-model.ts`'s generic disabled-control
+ *    vocabulary) — reused here as-is, not narrowed to TX-only members.
+ * Left unrenamed here: existing test assertions are keyed to this exact
+ * name (e.g. `rx-tx-surface.component.test.ts`'s
+ * `[data-reason="radio-transmitting"]` selector) that a rename would break,
+ * for no benefit to this ticket.
+ */
+export type { DisabledReasonCode, TxTargetUnknownReason };

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -221,10 +221,10 @@ export function invokeRenderer(renderer: Renderer, viewModel: unknown, tokens: D
 // `RxTxSurface.svelte` and `MetersSurface.svelte` are the two semantic-
 // vertical files whose `data-*` attributes a SHIPPED design-language
 // stylesheet actually branches on: `fieldline.css` and `studioline.css`
-// each key well over ten rules off `[data-session=...]`/`[data-rf=...]`.
-// This section exists so a THIRD stylesheet author reads these exports
-// instead of reverse-engineering the value sets from those two files, the
-// way the first two families' authors had to.
+// both key repeated rules off `[data-session=...]`/`[data-rf=...]`. This
+// section exists so a THIRD stylesheet author reads these exports instead
+// of reverse-engineering the value sets from those two files, the way the
+// first two families' authors had to.
 //
 // `VfoSurface.svelte` is the third file the MOR-2036 owner ruling scopes
 // this contract to, but neither shipped stylesheet selects on any

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -9,15 +9,14 @@
  * lint time by the presentation/ zone (MOR-1061). See v3 ADR and MOR-977
  * §4 (frozen 2026-08-03).
  *
- * The MOR-2036 data-* vocabulary section at the end of this file is a
- * second, independent contract living in the same module (the ticket's
- * named home for it) — it shares this header's "type-only from semantic/"
- * discipline but not its token/renderer subject matter.
+ * This file is also a member of the MOR-1077/1078/1079 workspace-purity
+ * closures (`presentation/workspace/__tests__/purity.isolated.test.ts` and
+ * its two siblings), which forbid naming `semantic/` in any import here —
+ * type-only or not. The MOR-2036 data-* vocabulary (`RfState`,
+ * `TxSessionState`, and the `data-fault`/`data-reason` collision types)
+ * needs the real `semantic/` unions, so it lives in the sibling module
+ * `./state-vocabulary.ts` instead of here.
  */
-import type {
-  KeyBlockedReason, RfState, TxOrigin, TxSessionState, TxTargetUnknownReason,
-} from '../../semantic/rx-tx-surface';
-import type { DisabledReasonCode } from '../../semantic/radio-view-model';
 
 /**
  * Naming policy (MOR-977 §4.6, MOR-1071): kebab-case, no vendor/model
@@ -215,80 +214,3 @@ export function invokeRenderer(renderer: Renderer, viewModel: unknown, tokens: D
   }
   return renderer(viewModel as RendererViewModel, tokens);
 }
-
-// ── MOR-2036 — the data-* visual-state vocabulary a stylesheet keys off ────
-//
-// `RxTxSurface.svelte` and `MetersSurface.svelte` are the two semantic-
-// vertical files whose `data-*` attributes a SHIPPED design-language
-// stylesheet actually branches on: `fieldline.css` and `studioline.css`
-// both key repeated rules off `[data-session=...]`/`[data-rf=...]`. This
-// section exists so a THIRD stylesheet author reads these exports instead
-// of reverse-engineering the value sets from those two files, the way the
-// first two families' authors had to.
-//
-// `VfoSurface.svelte` is the third file the MOR-2036 owner ruling scopes
-// this contract to, but neither shipped stylesheet selects on any
-// `data-vfo-*`/`data-active-receiver`/`data-split-*` attribute today — that
-// family carries none of the reverse-engineering burden this section
-// removes, so it is not exported here. Likewise `RxTxSurface.svelte`'s own
-// `data-origin`/`data-intent`/`data-fault-legs`/`data-receiver`/`data-slot`/
-// `data-field` and `MetersSurface.svelte`'s `data-relevant`/`data-observed`/
-// `data-meter` are real vocabularies (documented in each file's own source)
-// that no stylesheet keys off yet either; only the two collisions below
-// (`data-fault`, `data-reason`) are exported without a stylesheet consumer,
-// because they are contract defects in their own right.
-//
-// Value arrays are re-declared rather than imported from `semantic/` —
-// this module reads `semantic/` types only (`import type` above; the v3
-// ADR's one-way dependency, enforced here by inspection rather than by an
-// eslint rule) — the same reason `radio-view-model.ts` re-declares
-// `MeterRfState` instead of importing `RfState`. Agreement with the real
-// unions is pinned in `semantic/__tests__/state-vocabulary.component.test.ts`.
-
-export type { KeyBlockedReason, RfState, TxOrigin, TxSessionState };
-
-/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-rf` — also `MetersSurface.svelte`'s `data-rf-state` (a separately-declared but member-for-member identical vocabulary, `MeterRfState`). */
-export const RF_STATES: readonly RfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
-/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-session`. */
-export const TX_SESSION_STATES: readonly TxSessionState[] = ['idle', 'pending', 'keyed', 'releasing', 'failed'];
-/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-origin`. */
-export const TX_ORIGINS: readonly TxOrigin[] = ['local', 'external'];
-/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-target"] data-target`. */
-export const TX_TARGET_STATUSES = ['known', 'unknown'] as const;
-export type TxTargetStatus = (typeof TX_TARGET_STATUSES)[number];
-
-/**
- * `data-fault` COLLISION (MOR-2036) — the same attribute name renders two
- * unrelated grammars on two different elements of the semantic vertical:
- *  - `RxTxSurface.svelte`'s `.rx-tx-fault` paragraph: the App TX authority's
- *    own fault CODE (`TxAuthoritySnapshot.fault: string | null`), open-ended
- *    by design — a code this surface has never heard of must still show, so
- *    this is deliberately not a closed union.
- *  - `MetersSurface.svelte`'s `.meter-tile`: a plain over-threshold boolean,
- *    stringified the same way `data-relevant`/`data-observed` are.
- * Left unrenamed here: both attributes have existing test assertions keyed
- * to this exact name (e.g. `MetersSurface.test.ts`,
- * `rx-tx-surface.component.test.ts`) that a rename would break, for no
- * benefit to this ticket.
- */
-export type RxTxFaultValue = string;
-export type MetersFaultValue = 'true' | 'false';
-
-/**
- * `data-reason` COLLISION (MOR-2036) — THREE unrelated unions share this one
- * attribute name, all in `RxTxSurface.svelte`, depending on which element
- * renders it:
- *  - the unknown-TX-target paragraph (`[data-testid="rx-tx-target"]`):
- *    `TxTargetUnknownReason` — four transient/permanent target facts.
- *  - a blocked-key-reason list item (`.rx-tx-blocked li`, no sibling
- *    `data-field`): `KeyBlockedReason` — this surface's own key-gate
- *    reasons.
- *  - a disabled-reason list item (same list, WITH a sibling `data-field`):
- *    `DisabledReasonCode` (`radio-view-model.ts`'s generic disabled-control
- *    vocabulary) — reused here as-is, not narrowed to TX-only members.
- * Left unrenamed here: existing test assertions are keyed to this exact
- * name (e.g. `rx-tx-surface.component.test.ts`'s
- * `[data-reason="radio-transmitting"]` selector) that a rename would break,
- * for no benefit to this ticket.
- */
-export type { DisabledReasonCode, TxTargetUnknownReason };

--- a/frontend/src/presentation/languages/fieldline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/stylesheet.test.ts
@@ -20,7 +20,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { FIELDLINE_PALETTE } from '../tokens';
-import type { RfState, TxSessionState } from '../../contract';
+import type { RfState, TxSessionState } from '../../state-vocabulary';
 
 const source = readFileSync('src/presentation/languages/fieldline/fieldline.css', 'utf8');
 // Comments name the very constructs several tests below forbid, so they are

--- a/frontend/src/presentation/languages/fieldline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/fieldline/__tests__/stylesheet.test.ts
@@ -20,6 +20,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { FIELDLINE_PALETTE } from '../tokens';
+import type { RfState, TxSessionState } from '../../contract';
 
 const source = readFileSync('src/presentation/languages/fieldline/fieldline.css', 'utf8');
 // Comments name the very constructs several tests below forbid, so they are
@@ -64,9 +65,15 @@ function parseRules(sheet: string): Rule[] {
 const RULES = parseRules(css);
 const STATE_SCOPED = /:has\(\[data-(?:session|rf)=/;
 
+/**
+ * MOR-2036: `session`/`rf` are the contract's own `TxSessionState`/`RfState`
+ * types, not bare `string` — a fixture below with a typo'd value (e.g.
+ * `'recieving'`) now fails `npm run check` instead of silently making
+ * `matches()` return false for a reason no one asserts on.
+ */
 interface SurfaceState {
-  session: string;
-  rf: string;
+  session: TxSessionState;
+  rf: RfState;
   keyDisabled?: boolean;
 }
 
@@ -95,15 +102,15 @@ function winner(property: string, state: SurfaceState, target: Target = 'surface
   return candidates.at(-1)?.declarations[property];
 }
 
-const RX = { session: 'idle', rf: 'receiving' };
-const PENDING = { session: 'pending', rf: 'uncertain', keyDisabled: true };
-const KEYED = { session: 'keyed', rf: 'transmitting', keyDisabled: true };
-const RELEASING = { session: 'releasing', rf: 'transmitting', keyDisabled: true };
+const RX: SurfaceState = { session: 'idle', rf: 'receiving' };
+const PENDING: SurfaceState = { session: 'pending', rf: 'uncertain', keyDisabled: true };
+const KEYED: SurfaceState = { session: 'keyed', rf: 'transmitting', keyDisabled: true };
+const RELEASING: SurfaceState = { session: 'releasing', rf: 'transmitting', keyDisabled: true };
 // The crux state: a failed session almost always reports RF doubt as well, so
 // the fault rule and the doubt rule both match and one of them has to win.
-const FAULT = { session: 'failed', rf: 'uncertain', keyDisabled: true };
-const RF_UNKNOWN = { session: 'idle', rf: 'unknown' };
-const BLOCKED = { session: 'idle', rf: 'receiving', keyDisabled: true };
+const FAULT: SurfaceState = { session: 'failed', rf: 'uncertain', keyDisabled: true };
+const RF_UNKNOWN: SurfaceState = { session: 'idle', rf: 'unknown' };
+const BLOCKED: SurfaceState = { session: 'idle', rf: 'receiving', keyDisabled: true };
 
 describe('the sheet parses into something worth asserting against', () => {
   it('found the rail, band and slab rules it is about to rank', () => {

--- a/frontend/src/presentation/languages/state-vocabulary.ts
+++ b/frontend/src/presentation/languages/state-vocabulary.ts
@@ -1,0 +1,98 @@
+/**
+ * MOR-2036 — the data-* visual-state vocabulary a stylesheet keys off.
+ *
+ * `RxTxSurface.svelte` and `MetersSurface.svelte` are the two semantic-
+ * vertical files whose `data-*` attributes a SHIPPED design-language
+ * stylesheet actually branches on: `fieldline.css` and `studioline.css`
+ * both key repeated rules off `[data-session=...]`/`[data-rf=...]`. This
+ * module exists so a THIRD stylesheet author reads these exports instead
+ * of reverse-engineering the value sets from those two files, the way the
+ * first two families' authors had to.
+ *
+ * `VfoSurface.svelte` is the third file the MOR-2036 owner ruling scopes
+ * this contract to, but neither shipped stylesheet selects on any
+ * `data-vfo-*`/`data-active-receiver`/`data-split-*` attribute today — that
+ * family carries none of the reverse-engineering burden this module
+ * removes, so it is not exported here. Likewise `RxTxSurface.svelte`'s own
+ * `data-origin`/`data-intent`/`data-fault-legs`/`data-receiver`/`data-slot`/
+ * `data-field` and `MetersSurface.svelte`'s `data-relevant`/`data-observed`/
+ * `data-meter` are real vocabularies (documented in each file's own source)
+ * that no stylesheet keys off yet either; only the two collisions below
+ * (`data-fault`, `data-reason`) are exported without a stylesheet consumer,
+ * because they are contract defects in their own right.
+ *
+ * NOT part of `presentation/languages/contract.ts`: that module is a member
+ * of the MOR-1077/1078/1079 workspace-purity closures
+ * (`presentation/workspace/__tests__/purity.isolated.test.ts` and its two
+ * siblings), which walk the closure's SOURCE TEXT and reject any member
+ * naming `semantic/` in an import specifier — type-only or not, since the
+ * walker does not erase `import type`. This module genuinely needs the real
+ * `semantic/` unions (a second, hand-copied set would drift the moment
+ * either side changed), so it lives here instead, outside that closure —
+ * the same `import type` convention `projection.ts` (this directory)
+ * already uses for the same one-way `presentation` → `semantic` direction:
+ * accepted per the v3 ADR (`docs/plans/2026-07-25-ui-composition-
+ * architecture-v3.md`) and the April ADR's "each layer depends only on the
+ * layer below; never upward" rule (`docs/plans/2026-04-12-target-frontend-
+ * architecture.md`). `contract.ts` itself keeps zero `semantic/`-naming
+ * imports.
+ */
+import type {
+  KeyBlockedReason, RfState, TxOrigin, TxSessionState, TxTargetUnknownReason,
+} from '../../semantic/rx-tx-surface';
+import type { DisabledReasonCode } from '../../semantic/radio-view-model';
+
+export type { KeyBlockedReason, RfState, TxOrigin, TxSessionState };
+
+/**
+ * `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-rf` — also
+ * `MetersSurface.svelte`'s `data-rf-state` (a separately-declared but
+ * member-for-member identical vocabulary, `MeterRfState`). A THIRD,
+ * unrelated `data-rf` lives on `components-v2/panels/TxPanel.svelte`
+ * (`'on' | 'off' | 'unknown'`, disjoint from `RfState` except both include
+ * `'unknown'`) — not exported here; out of scope by owner ruling.
+ */
+export const RF_STATES: readonly RfState[] = ['receiving', 'transmitting', 'uncertain', 'unknown'];
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-session`. */
+export const TX_SESSION_STATES: readonly TxSessionState[] = ['idle', 'pending', 'keyed', 'releasing', 'failed'];
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-state"] data-origin`. */
+export const TX_ORIGINS: readonly TxOrigin[] = ['local', 'external'];
+/** `RxTxSurface.svelte`'s `[data-testid="rx-tx-target"] data-target`. */
+export const TX_TARGET_STATUSES = ['known', 'unknown'] as const;
+export type TxTargetStatus = (typeof TX_TARGET_STATUSES)[number];
+
+/**
+ * `data-fault` COLLISION (MOR-2036) — the same attribute name renders two
+ * unrelated grammars on two different elements of the semantic vertical:
+ *  - `RxTxSurface.svelte`'s `.rx-tx-fault` paragraph: the App TX authority's
+ *    own fault CODE (`TxAuthoritySnapshot.fault: string | null`), open-ended
+ *    by design — a code this surface has never heard of must still show, so
+ *    this is deliberately not a closed union.
+ *  - `MetersSurface.svelte`'s `.meter-tile`: a plain over-threshold boolean,
+ *    stringified the same way `data-relevant`/`data-observed` are.
+ * Left unrenamed here: both attributes have existing test assertions keyed
+ * to this exact name (e.g. `MetersSurface.test.ts`,
+ * `rx-tx-surface.component.test.ts`) that a rename would break, for no
+ * benefit to this ticket.
+ */
+export type RxTxFaultValue = string;
+export type MetersFaultValue = 'true' | 'false';
+
+/**
+ * `data-reason` COLLISION (MOR-2036) — THREE unrelated unions share this one
+ * attribute name, all in `RxTxSurface.svelte`, depending on which element
+ * renders it:
+ *  - the unknown-TX-target paragraph (`[data-testid="rx-tx-target"]`):
+ *    `TxTargetUnknownReason` — four transient/permanent target facts.
+ *  - a blocked-key-reason list item (`.rx-tx-blocked li`, no sibling
+ *    `data-field`): `KeyBlockedReason` — this surface's own key-gate
+ *    reasons.
+ *  - a disabled-reason list item (same list, WITH a sibling `data-field`):
+ *    `DisabledReasonCode` (`radio-view-model.ts`'s generic disabled-control
+ *    vocabulary) — reused here as-is, not narrowed to TX-only members.
+ * Left unrenamed here: existing test assertions are keyed to this exact
+ * name (e.g. `rx-tx-surface.component.test.ts`'s
+ * `[data-reason="radio-transmitting"]` selector) that a rename would break,
+ * for no benefit to this ticket.
+ */
+export type { DisabledReasonCode, TxTargetUnknownReason };

--- a/frontend/src/presentation/languages/studioline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/studioline/__tests__/stylesheet.test.ts
@@ -21,7 +21,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { STUDIOLINE_PALETTE } from '../tokens';
-import type { RfState, TxSessionState } from '../../contract';
+import type { RfState, TxSessionState } from '../../state-vocabulary';
 
 const source = readFileSync('src/presentation/languages/studioline/studioline.css', 'utf8');
 // Comments name the very constructs several tests below forbid, so they are

--- a/frontend/src/presentation/languages/studioline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/studioline/__tests__/stylesheet.test.ts
@@ -21,6 +21,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { STUDIOLINE_PALETTE } from '../tokens';
+import type { RfState, TxSessionState } from '../../contract';
 
 const source = readFileSync('src/presentation/languages/studioline/studioline.css', 'utf8');
 // Comments name the very constructs several tests below forbid, so they are
@@ -65,9 +66,15 @@ function parseRules(sheet: string): Rule[] {
 const RULES = parseRules(css);
 const STATE_SCOPED = /:has\(\[data-(?:session|rf)=/;
 
+/**
+ * MOR-2036: `session`/`rf` are the contract's own `TxSessionState`/`RfState`
+ * types, not bare `string` — a fixture below with a typo'd value (e.g.
+ * `'recieving'`) now fails `npm run check` instead of silently making
+ * `matches()` return false for a reason no one asserts on.
+ */
 interface SurfaceState {
-  session: string;
-  rf: string;
+  session: TxSessionState;
+  rf: RfState;
   keyDisabled?: boolean;
 }
 
@@ -92,15 +99,15 @@ function winner(property: string, state: SurfaceState, target: 'surface' | 'key'
   return candidates.at(-1)?.declarations[property];
 }
 
-const RX = { session: 'idle', rf: 'receiving' };
-const PENDING = { session: 'pending', rf: 'uncertain', keyDisabled: true };
-const KEYED = { session: 'keyed', rf: 'transmitting', keyDisabled: true };
-const RELEASING = { session: 'releasing', rf: 'transmitting', keyDisabled: true };
+const RX: SurfaceState = { session: 'idle', rf: 'receiving' };
+const PENDING: SurfaceState = { session: 'pending', rf: 'uncertain', keyDisabled: true };
+const KEYED: SurfaceState = { session: 'keyed', rf: 'transmitting', keyDisabled: true };
+const RELEASING: SurfaceState = { session: 'releasing', rf: 'transmitting', keyDisabled: true };
 // The crux state: a failed session almost always reports RF doubt as well, so
 // the fault rule and the doubt rule both match and one of them has to win.
-const FAULT = { session: 'failed', rf: 'uncertain', keyDisabled: true };
-const RF_UNKNOWN = { session: 'idle', rf: 'unknown' };
-const BLOCKED = { session: 'idle', rf: 'receiving', keyDisabled: true };
+const FAULT: SurfaceState = { session: 'failed', rf: 'uncertain', keyDisabled: true };
+const RF_UNKNOWN: SurfaceState = { session: 'idle', rf: 'unknown' };
+const BLOCKED: SurfaceState = { session: 'idle', rf: 'receiving', keyDisabled: true };
 
 describe('the sheet parses into something worth asserting against', () => {
   it('found the rail and key rules it is about to rank', () => {

--- a/frontend/src/presentation/languages/tx-feedback-state.ts
+++ b/frontend/src/presentation/languages/tx-feedback-state.ts
@@ -64,12 +64,20 @@ export interface TxFeedbackState {
  * prototype chain instead, so `treatment` escapes as that member rather
  * than falling through. Unreachable in production: `RxTxSurface.svelte`
  * only ever supplies a real `TxSessionState`.
+ *
+ * MOR-2036: `satisfies Record<TxSessionState, TxKeyTreatment>` pins these
+ * keys to EXACTLY `TxSessionState`'s five members. Before this pin the
+ * `Record<string, TxKeyTreatment>` annotation alone let either drift through
+ * silently — a sixth, non-session key (excess property) or a missing one
+ * (required property) both now fail `npm run check`; `isTxSessionState`
+ * below reuses these keys rather than re-enumerating them, so the pin
+ * covers that reuse too.
  */
 const KEY_TREATMENT: Record<string, TxKeyTreatment> = {
   idle: 'idle', pending: 'pending', keyed: 'keyed', releasing: 'keyed', failed: 'fault',
-};
+} satisfies Record<TxSessionState, TxKeyTreatment>;
 
-/** True for exactly `TxSessionState`'s five members — reuses `KEY_TREATMENT`'s keys rather than re-enumerating them. */
+/** True for exactly `TxSessionState`'s five members — reuses `KEY_TREATMENT`'s keys, which the `satisfies` clause above keeps pinned to that exact set (MOR-2036). */
 const isTxSessionState = (value: string): value is TxSessionState =>
   Object.prototype.hasOwnProperty.call(KEY_TREATMENT, value);
 

--- a/frontend/src/semantic/__tests__/state-vocabulary.component.test.ts
+++ b/frontend/src/semantic/__tests__/state-vocabulary.component.test.ts
@@ -1,19 +1,22 @@
 /**
- * MOR-2036 — the data-* visual-state vocabulary contract
- * (`presentation/languages/contract.ts`) pinned against the real semantic
- * vertical.
+ * MOR-2036 — the data-* visual-state vocabulary
+ * (`presentation/languages/state-vocabulary.ts`) pinned against the real
+ * semantic vertical.
  *
- * The contract module cannot value-import from `semantic/` (the v3 ADR's
- * one-way dependency — `presentation/` reads `semantic/` types only, never
- * runtime values), so its `RF_STATES`/`TX_SESSION_STATES`/`TX_ORIGINS` value
- * arrays are member-for-member COPIES of `rx-tx-surface.ts`'s own
- * `RF_LABEL`/`SESSION_LABEL` keys and `TxOrigin`'s members, not imports of
- * them — the same layering reason `radio-view-model.ts` re-declares
- * `MeterRfState` instead of importing `RfState` (see that file's doc
- * comment, and `meters.test.ts`'s "not a fork" pin, which this file mirrors
- * for the contract module).
+ * `state-vocabulary.ts` lives outside `presentation/languages/contract.ts`
+ * because that module is a member of the MOR-1077/1078/1079 workspace-
+ * purity closures and may not name `semantic/` in any import, type-only or
+ * not (see that module's own header). `state-vocabulary.ts` sits outside
+ * those closures, so it reads `semantic/` types (`import type`) the same
+ * one-way way `projection.ts` already does — nothing forbids it a value
+ * import either (no eslint rule bans one, and it is outside the purity
+ * closures), but its `RF_STATES`/`TX_SESSION_STATES`/`TX_ORIGINS` are
+ * written as literal arrays rather than derived from `rx-tx-surface.ts`'s
+ * `RF_LABEL`/`SESSION_LABEL` keys. Agreement with the real unions is pinned
+ * below by set-equality against those keys (and a `TxOrigin` self-map,
+ * which has no label record to diff against).
  *
- * The second half proves the two name collisions the contract documents
+ * The second half proves the two name collisions the vocabulary documents
  * (`data-fault`: an open-ended fault CODE on RxTxSurface vs. a plain
  * boolean on MetersSurface; `data-reason`: three unrelated unions on
  * RxTxSurface alone) are real, by mounting the actual components — a type
@@ -32,7 +35,7 @@ import {
   RF_STATES, TX_ORIGINS, TX_SESSION_STATES, TX_TARGET_STATUSES,
   type DisabledReasonCode, type KeyBlockedReason, type MetersFaultValue, type RxTxFaultValue,
   type TxOrigin, type TxTargetStatus, type TxTargetUnknownReason,
-} from '../../presentation/languages/contract';
+} from '../../presentation/languages/state-vocabulary';
 
 /** Mounts `component`, runs `fn` over its DOM, always unmounts (mirrors `design-language-wiring.component.test.ts`). */
 function withMounted<P extends Record<string, unknown>>(
@@ -46,7 +49,7 @@ function withMounted<P extends Record<string, unknown>>(
   try { fn(target); } finally { unmount(instance); target.remove(); }
 }
 
-describe('contract.ts vocabulary arrays are not a fork of the real unions (MOR-2036)', () => {
+describe('state-vocabulary.ts arrays are not a fork of the real unions (MOR-2036)', () => {
   it('RF_STATES is exactly RfState — RF_LABEL\'s own exhaustive keys', () => {
     expect(new Set(RF_STATES)).toEqual(new Set(Object.keys(RF_LABEL)));
   });

--- a/frontend/src/semantic/__tests__/state-vocabulary.component.test.ts
+++ b/frontend/src/semantic/__tests__/state-vocabulary.component.test.ts
@@ -1,0 +1,147 @@
+/**
+ * MOR-2036 — the data-* visual-state vocabulary contract
+ * (`presentation/languages/contract.ts`) pinned against the real semantic
+ * vertical.
+ *
+ * The contract module cannot value-import from `semantic/` (the v3 ADR's
+ * one-way dependency — `presentation/` reads `semantic/` types only, never
+ * runtime values), so its `RF_STATES`/`TX_SESSION_STATES`/`TX_ORIGINS` value
+ * arrays are member-for-member COPIES of `rx-tx-surface.ts`'s own
+ * `RF_LABEL`/`SESSION_LABEL` keys and `TxOrigin`'s members, not imports of
+ * them — the same layering reason `radio-view-model.ts` re-declares
+ * `MeterRfState` instead of importing `RfState` (see that file's doc
+ * comment, and `meters.test.ts`'s "not a fork" pin, which this file mirrors
+ * for the contract module).
+ *
+ * The second half proves the two name collisions the contract documents
+ * (`data-fault`: an open-ended fault CODE on RxTxSurface vs. a plain
+ * boolean on MetersSurface; `data-reason`: three unrelated unions on
+ * RxTxSurface alone) are real, by mounting the actual components — a type
+ * assertion alone cannot show that the DOM disagrees about one name.
+ *
+ * `*.component.test.ts` mounts real Svelte components and routes to the
+ * isolated vitest project (`vite.config.ts`).
+ */
+import { describe, expect, it } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import MetersSurface from '../MetersSurface.svelte';
+import RxTxSurface from '../RxTxSurface.svelte';
+import { topologyFixtures, withMeters } from '../fixtures/topologies';
+import { BLOCKED_LABEL, RF_LABEL, SESSION_LABEL, type TxAuthoritySnapshot } from '../rx-tx-surface';
+import {
+  RF_STATES, TX_ORIGINS, TX_SESSION_STATES, TX_TARGET_STATUSES,
+  type DisabledReasonCode, type KeyBlockedReason, type MetersFaultValue, type RxTxFaultValue,
+  type TxOrigin, type TxTargetStatus, type TxTargetUnknownReason,
+} from '../../presentation/languages/contract';
+
+/** Mounts `component`, runs `fn` over its DOM, always unmounts (mirrors `design-language-wiring.component.test.ts`). */
+function withMounted<P extends Record<string, unknown>>(
+  component: unknown, props: P, fn: (root: HTMLElement) => void,
+): void {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const instance = mount(component as any, { target, props });
+  flushSync();
+  try { fn(target); } finally { unmount(instance); target.remove(); }
+}
+
+describe('contract.ts vocabulary arrays are not a fork of the real unions (MOR-2036)', () => {
+  it('RF_STATES is exactly RfState — RF_LABEL\'s own exhaustive keys', () => {
+    expect(new Set(RF_STATES)).toEqual(new Set(Object.keys(RF_LABEL)));
+  });
+
+  it('TX_SESSION_STATES is exactly TxSessionState — SESSION_LABEL\'s own exhaustive keys', () => {
+    expect(new Set(TX_SESSION_STATES)).toEqual(new Set(Object.keys(SESSION_LABEL)));
+  });
+
+  it('TX_ORIGINS has exactly TxOrigin\'s two members', () => {
+    // No existing exported Record to diff against (txOrigin() has no label
+    // map), so this is pinned directly against the TYPE via a self-map:
+    // a member added to `TxOrigin` without a matching key here fails
+    // `npm run check` (missing property), and a bogus extra key fails it
+    // too (excess property) — same mechanism as `meters.test.ts`'s
+    // `surfaceToMeter`/`meterToSurface` pair.
+    const originSelf: Record<TxOrigin, true> = { local: true, external: true };
+    expect(new Set(TX_ORIGINS)).toEqual(new Set(Object.keys(originSelf)));
+  });
+});
+
+const IDLE: TxAuthoritySnapshot = {
+  phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null,
+};
+const FAULT: TxAuthoritySnapshot = {
+  phase: 'failed', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: 'audio-failed',
+};
+
+describe('RxTxSurface renders exactly the contract\'s vocabulary (MOR-2036)', () => {
+  it('data-rf/data-session/data-origin/data-target are members of the exported vocabulary, on a known-target idle fixture', () => {
+    withMounted(RxTxSurface, { view: topologyFixtures['1/single'], tx: IDLE }, (root) => {
+      const state = root.querySelector('[data-testid="rx-tx-state"]')!;
+      expect(RF_STATES).toContain(state.getAttribute('data-rf'));
+      expect(TX_SESSION_STATES).toContain(state.getAttribute('data-session'));
+      expect(TX_ORIGINS).toContain(state.getAttribute('data-origin'));
+      const targetEl = root.querySelector('[data-testid="rx-tx-target"]')!;
+      expect(TX_TARGET_STATUSES).toContain(targetEl.getAttribute('data-target'));
+      const expectedTargetStatus: TxTargetStatus = 'known';
+      expect(targetEl.getAttribute('data-target')).toBe(expectedTargetStatus);
+    });
+  });
+
+  it('data-reason\'s THREE collision cases and data-fault\'s fault-code case, on a faulted unknown-target fixture', () => {
+    withMounted(RxTxSurface, { view: topologyFixtures['1/ab'], tx: FAULT }, (root) => {
+      const targetEl = root.querySelector('[data-testid="rx-tx-target"]')!;
+      const expectedTargetStatus: TxTargetStatus = 'unknown';
+      expect(targetEl.getAttribute('data-target')).toBe(expectedTargetStatus);
+
+      // 1. the unknown-target paragraph's own data-reason: TxTargetUnknownReason.
+      // The array is TYPED, not bare — a typo'd member here fails `npm run check`.
+      const TARGET_UNKNOWN_REASONS: readonly TxTargetUnknownReason[] = [
+        'not-observed', 'stale', 'unsupported', 'contradiction',
+      ];
+      const targetReason = targetEl.getAttribute('data-reason');
+      expect(TARGET_UNKNOWN_REASONS).toContain(targetReason);
+      expect(targetReason).toBe('not-observed'); // the '1/ab' fixture's own declared reason
+
+      // 2. a blocked-key list item's data-reason: KeyBlockedReason (no sibling data-field).
+      // `BLOCKED_LABEL: Record<KeyBlockedReason, string>` (rx-tx-surface.ts)
+      // already guarantees its keys are exactly `KeyBlockedReason`'s members;
+      // `Object.keys` itself is only ever typed `string[]`, so recovering
+      // that guarantee needs the cast below.
+      const blockedReasonKeys = Object.keys(BLOCKED_LABEL) as readonly KeyBlockedReason[];
+      const blockedItems = [...root.querySelectorAll('[data-testid="rx-tx-blocked"] li[data-reason]:not([data-field])')];
+      expect(blockedItems.length).toBeGreaterThan(0);
+      for (const li of blockedItems) expect(blockedReasonKeys).toContain(li.getAttribute('data-reason'));
+
+      // 3. a disabled-reason list item's data-reason: DisabledReasonCode, WITH a sibling data-field.
+      const disabledItems = [...root.querySelectorAll('[data-testid="rx-tx-blocked"] li[data-field]')];
+      expect(disabledItems).toHaveLength(1);
+      expect(disabledItems[0].getAttribute('data-field')).toBe('txTarget');
+      const expectedDisabledReason: DisabledReasonCode = 'field-not-observed';
+      expect(disabledItems[0].getAttribute('data-reason')).toBe(expectedDisabledReason);
+
+      // 4. data-fault is the OPEN-ENDED fault CODE here, never a boolean —
+      // the other half of the MOR-2036 collision proof is MetersSurface,
+      // below.
+      const faultEl = root.querySelector('[data-testid="rx-tx-fault"]')!;
+      const faultValue: RxTxFaultValue = faultEl.getAttribute('data-fault') ?? '';
+      expect(faultValue).toBe('audio-failed');
+      expect(faultValue).not.toBe('true');
+      expect(faultValue).not.toBe('false');
+    });
+  });
+});
+
+describe('MetersSurface\'s data-fault is the OTHER collision half: a plain boolean (MOR-2036)', () => {
+  it('every rendered meter tile\'s data-fault is exactly "true" or "false", never a fault code', () => {
+    const view = withMeters(topologyFixtures['1/single'], 'transmitting');
+    withMounted(MetersSurface, { view }, (root) => {
+      const tiles = [...root.querySelectorAll<HTMLElement>('[data-meter-tile][data-fault]')];
+      expect(tiles.length).toBeGreaterThan(0);
+      for (const tile of tiles) {
+        const value = tile.dataset.fault as MetersFaultValue;
+        expect(['true', 'false']).toContain(value);
+      }
+    });
+  });
+});

--- a/frontend/src/semantic/rx-tx-surface.ts
+++ b/frontend/src/semantic/rx-tx-surface.ts
@@ -96,7 +96,7 @@ const BLOCKED_KEY: Record<KeyBlockedReason, string> = {
  *  a live locale switch (MOR-1448 `reasonLabel` precedent). */
 export const blockedLabel = (code: KeyBlockedReason): string => t(BLOCKED_KEY[code]);
 
-type TxTargetUnknownReason = Extract<TxTargetViewModel, { status: 'unknown' }>['reason'];
+export type TxTargetUnknownReason = Extract<TxTargetViewModel, { status: 'unknown' }>['reason'];
 /** MOR-1474: `view.txTarget`'s four `status: 'unknown'` reasons
  *  (`radio-view-model.ts`), each backed by ITS OWN catalog key rather than
  *  interpolating the raw enum word into prose (no `{status}`/`{reason}`


### PR DESCRIPTION
## Fix round (review response)

The Agent Review below (`Agent Review: BLOCKED fd48c10139ac89cddb6dc92c60652490eadd29c3`) found three problems, all fixed in this round. Everywhere below that names `presentation/languages/contract.ts` as the vocabulary's home, read `presentation/languages/state-vocabulary.ts` instead — the rest of each section's reasoning still applies to the relocated code.

**BLOCKING 1 (closure).** `contract.ts` is a member of the MOR-1077/1078/1079 workspace-purity closures (`purity.isolated.test.ts` + its two siblings), which reject any closure member naming `semantic/` in an import — type-only included, since the walker reads source text and does not erase `import type`. The two new `semantic/` imports tripped it, and `Tests (quick)` was genuinely red at the blocked head. Fix: the whole MOR-2036 section moved to a new sibling file, `presentation/languages/state-vocabulary.ts`, which is not reachable from `workspace/contract.ts`'s closure (nothing in that closure imports it), so it may read `semantic/` types the same one-way way `projection.ts` (same directory) already does — the accepted `presentation` → `semantic` direction (v3 ADR; April ADR's "each layer depends only on the layer below, never upward"). Inverting the dependency (defining the unions in `contract.ts` and having `semantic/rx-tx-surface.ts` import them back) was considered and rejected: that is the forbidden upward direction. `contract.ts` itself is now byte-for-byte its pre-PR self plus one doc-comment paragraph pointing at the new file — zero imports, cleanly back inside the closure.

Verified: purity suite (`purity.isolated.test.ts` + 2 siblings) — 3 files, 33 tests, all pass. `npx vitest run src/presentation/ src/semantic/` — 94 files, 2441 tests, all pass. Full `npx vitest run` (whole frontend) — 369 files, 8081 tests, all pass. `npm run check` — 0 errors, 0 warnings, 4601 files. `npm run lint` and `npm run lint:boundaries` — clean.

**BLOCKING 2 (false prose) — three statements corrected:**
1. "enforced here by inspection rather than by an eslint rule" — deleted; the doc comment now names the real enforcement (the three purity closures) directly.
2. "the contract module cannot value-import from `semantic/`" — deleted; nothing forbids it (no eslint rule bans it, and the vocabulary module sits outside the purity closures) — the value arrays are literals by choice, typed against the imported unions and pinned by set-equality in the test, not by any prohibition.
3. "`presentation/` reads `semantic/` types only, never runtime values" (falsified by 6 real value-import edges, all test files) and the "same reason `radio-view-model.ts` re-declares `MeterRfState`" cross-reference — both deleted. The real `MeterRfState` precedent is an intra-`semantic/` cycle-avoidance (`radio-view-model.ts`'s own doc comment: "that module already imports this one, and a contract must not depend on a surface") — unrelated to the presentation/semantic boundary, and no longer analogous once this fix stopped re-declaring anything.

**Non-blocking, also fixed:** the Sweep bullet below had `TxPanel.svelte` in the wrong `data-fault` camp (it renders a fault CODE string — `TX FAULT: {fault}` — not a boolean; moved to the `AppGlobalHost.svelte` camp). The previously-undocumented third `data-rf` collision on `TxPanel.svelte` (`'on' | 'off' | 'unknown'`, overlapping `RfState` only on `'unknown'`) is now noted in `RF_STATES`'s doc comment in `state-vocabulary.ts`. `TxPanel.svelte` itself is untouched — out of scope by owner ruling.

File count is now 7 (was 6): `state-vocabulary.ts` is a required split, not scope creep — `contract.ts`'s purity-closure membership and this vocabulary's genuine need for real `semantic/` types cannot both hold in one file. See "Files / size" below for the updated total.

Internal-identifier self-check (this fix round) — empty.

---

## Summary

Exports the `data-*` visual-state vocabulary for the two semantic-vertical files whose attributes a shipped design-language stylesheet actually keys off — `RxTxSurface.svelte` (`data-rf`/`data-session`/`data-origin`/`data-target`) and the `data-fault`/`data-reason` name collisions between `RxTxSurface.svelte` and `MetersSurface.svelte` — from `presentation/languages/state-vocabulary.ts`, so a third stylesheet author reads these instead of reverse-engineering the value sets from `fieldline.css`/`studioline.css`.

## Search before you write

Searched for an existing vocabulary/contract module before adding one: `rg -l "data-session|data-rf"` across `src/presentation` and `src/semantic`, and read `presentation/languages/contract.ts` (the existing token/renderer/manifest contract) and `presentation/languages/projection.ts` (the `RadioViewModel → RendererViewModel` projection) in full. Neither exports a `data-*` attribute vocabulary today. `contract.ts` was the ticket's originally-named home; the fix round above moved the vocabulary to the sibling module `state-vocabulary.ts` once the MOR-1077/1078/1079 purity closures ruled `contract.ts` out. Either way, the vocabulary reuses the "type-only from `semantic/`" convention `projection.ts` pioneered, not a new one.

## The two collisions

- **`data-fault`**: `RxTxFaultValue = string` (RxTxSurface's open-ended fault CODE — `TxAuthoritySnapshot.fault: string | null` by design, so a closed union would be a false narrowing) vs. `MetersFaultValue = 'true' | 'false'` (MetersSurface's plain boolean). Typed distinctly, collision named in the doc comment, **not renamed** — both attributes have existing test assertions keyed to this exact name (e.g. `MetersSurface.test.ts`, `rx-tx-surface.component.test.ts`) that a rename would break for no benefit to this ticket.
- **`data-reason`**: three distinct unions on `RxTxSurface.svelte` alone, depending on which element renders it — the unknown-target paragraph (`TxTargetUnknownReason`, newly exported from `rx-tx-surface.ts` — it existed but was file-private), a blocked-key list item with no sibling `data-field` (`KeyBlockedReason`), and a disabled-reason list item with a sibling `data-field` (`DisabledReasonCode`, reused as-is, not narrowed to TX-only members). Not renamed — `rx-tx-surface.component.test.ts`'s `[data-reason="radio-transmitting"]` selector (among others) would break.

### Sweep — the collision class is bigger than these two files (left unfixed, reported)

Enumerated every emitter/consumer of `data-fault` and `data-reason` across the tree (both the `data-X` attribute form and the `.dataset.X` JS-property form, which a plain `data-X` grep misses):

- `data-fault` is also emitted by `AppGlobalHost.svelte` and `TxPanel.svelte` (fault-code-string grammar, same camp as RxTxSurface — `TxPanel.svelte`'s `let fault = $derived(txState.fault)` renders `TX FAULT: {fault}`, corrected from an earlier miscategorization as boolean) and by `MetersDockPanel.svelte`/`components-v2/meters/BarGauge.svelte` (boolean grammar, same camp as MetersSurface) — none in the semantic vertical this ticket scopes to. `TxPanel.svelte` also emits an undocumented third `data-rf` (`'on' | 'off' | 'unknown'`), disjoint from `RfState` except both include `'unknown'` — noted in `state-vocabulary.ts`'s `RF_STATES` doc comment.
- `data-reason` is also emitted by `SemanticRadioSurfaces.svelte` (wiring layer), `AntennaSurface.svelte`, `CwKeyerSurface.svelte` (including a bare `data-reason="mutually-exclusive-control"` literal), and `TxAuxSurface.svelte` (the last one legitimately reuses `KeyBlockedReason` via the same `keyBlockedReasons()` call — not a collision, a correct additional consumer).

None of these fall inside the owner-ruled scope (`RxTxSurface`/`MetersSurface`/`VfoSurface`) or this ticket's guardrails, so left unfixed. Reported here for a follow-up MOR-2035 slice to scope from.

## What's exported vs. documented-but-not-exported

Verified via `grep` that `fieldline.css`/`studioline.css` key 16 and 11 rules respectively off `[data-session=...]`/`[data-rf=...]`, and key off **nothing else** in either the semantic vertical's `data-vfo-*`/`data-active-receiver`/`data-split-*` family (`VfoSurface.svelte`) or `RxTxSurface`'s own `data-origin`/`data-intent`/`data-fault-legs`/`data-receiver`/`data-slot`/`data-field` or `MetersSurface`'s `data-relevant`/`data-observed`/`data-meter`. Those vocabularies are real (documented in each file's own source) but carry none of the reverse-engineering burden this ticket exists to remove, so this slice does not export constants for them — doing so with no consumer would violate "no orphans." `data-rf`/`data-session`/`data-origin`/`data-target` (RxTxSurface, CSS-consumed) and the two collisions are exported because they have a real stylesheet consumer or are contract defects in their own right.

## Both-directions proof (data-rf/data-session)

- Typo'd `rf: 'recieving'` in `fieldline/__tests__/stylesheet.test.ts` → `npm run check` fails: `Type '"recieving"' is not assignable to type 'RfState'. Did you mean '"receiving"'?` Reverted.
- Typo'd `session: 'keyd'` in `studioline/__tests__/stylesheet.test.ts` → fails: `Type '"keyd"' is not assignable to type 'TxSessionState'. Did you mean '"keyed"'?` Reverted.
- Restored (legitimate) values → `npm run check`: 0 errors, 0 warnings; both stylesheet test files' full suites pass.

## Both-directions proof (KEY_TREATMENT `satisfies`, the extra fix)

`tx-feedback-state.ts`'s `KEY_TREATMENT` was `Record<string, TxKeyTreatment>` — open-ended, so `isTxSessionState` (which reuses its keys) was true-but-unpinned against `TxSessionState`'s five members.
- Added a bogus 6th key → `npm run check` fails: `Object literal may only specify known properties, and 'bogus' does not exist in type 'Record<TxSessionState, TxKeyTreatment>'.` Reverted.
- Removed the `failed` key → fails: `Property 'failed' is missing in type '...' but required in type 'Record<TxSessionState, TxKeyTreatment>'.` Reverted.
- Restored → 0 errors; `tx-feedback-state.isolated.test.ts`'s 25 tests unchanged (all pass).

## Value-import check (presentation/ → semantic/ layering)

Read every import line (not grepped — a single-line grep misses a multi-line `import type { … } from` block) in every file this PR touches that reaches into `semantic/`: `state-vocabulary.ts`'s two `semantic/` imports are both `import type`, and `tx-feedback-state.ts`'s pre-existing import was already `import type` (untouched). `contract.ts` itself now has no imports at all — it is not one of the files that reaches into `semantic/`. No value import crosses `presentation/` → `semantic/` in either direction this PR introduces. `npm run lint:boundaries` is green but is not evidence of this — it does not check this direction; the workspace-purity closures are the mechanism that would catch a closure member doing so.

## Verification

- `cd frontend && npm run check` — 0 errors, 0 warnings (4601 files).
- `cd frontend && npx vitest run src/presentation/ src/semantic/` — 94 files, 2441 tests, all pass (widened from the original `languages/`-only path after the fix round found that subset had missed the workspace purity-closure regression).
- `cd frontend && npx vitest run` (whole frontend suite) — 369 files, 8081 tests, all pass.
- `cd frontend && npx vitest run --project isolated src/presentation/workspace/__tests__/` (the purity suite specifically) — 3 files, 33 tests, all pass.
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run lint:boundaries` — clean.
- Internal-identifier self-check — empty.

## Files / size

7 files changed, 299 insertions(+), 21 deletions(-) — over the soft-threshold file count (6) by one file, well under the line threshold (600) and the hard ceiling. The 7th file (`state-vocabulary.ts`) is not a second unit of work: it is the same MOR-2036 vocabulary contract as before, relocated out of `contract.ts` because that module's MOR-1077/1078/1079 purity-closure membership forbids naming `semantic/` in any import, which this vocabulary genuinely needs. The contract addition, its two prerequisite exports (`TxTargetUnknownReason`, the `KEY_TREATMENT` pin), and the CSS-test type-tightening it enables all still serve the single acceptance criterion (no bare `data-rf`/`data-session` literals, a wrong value fails the build or a conformance test) and share one new test file as their proof.

## Contradicted the brief

- The ticket's own claim that `MetersSurface.svelte` emits `data-rf` is wrong (it emits `data-rf-state`, a separately-declared but member-for-member identical vocabulary) — already flagged as ground truth in the brief; independently reconfirmed.
- `MetersSurface.test.ts` is not a "getAttribute" file only — it uses both `.dataset.fault` and `.getAttribute('data-fault')` in different describe blocks; `rx-tx-surface.component.test.ts` uses only `.dataset.X` for `data-rf`/`data-session`/`data-origin`/`data-target`/`data-reason`/`data-fault` (dozens of assertions) — a real but self-correcting pattern (compared against live DOM output, not against a second hand-authored literal), so left untouched; not the "silent drift" defect class this ticket targets.
