### PR TITLE
feat(MOR-2008): migrate system.py/cw.py/speech.py/power.py onto the bound command map (batch 1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,6 +138,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runtime/_scope_runtime.py: ScopeRuntimeMixin` and
   `backends/_icom_serial_base.py`, moved onto `self._commands.<builder>`
   in the same change.
+- **`rigplane.commands.system`/`cw`/`speech`/`power` builders require
+  `cmd_map`; there is no hardcoded fallback (MOR-2008, batch 1 of
+  `docs/plans/2026-08-29-profile-driven-command-bytes.md`).** All 26
+  builders across the four modules — transceiver ID, band-edge frequency,
+  tuner/XFC/TX-freq-monitor status, RIT/XIT (system.py); CW keying (cw.py);
+  voice announcement (speech.py); power on/off/status (power.py) — now
+  require `cmd_map` as a required keyword-only argument. 20 of the 26 carry
+  no behaviour change at all: every declaring CI-V profile already held
+  the identical wire tuple the deleted fallback built. **The other
+  six — `get_system_date`/`set_system_date`, `get_system_time`/
+  `set_system_time`, `get_utc_offset`/`set_utc_offset` — carry an intended
+  byte-level behaviour change on IC-7300.** Their pre-migration `cmd_map`
+  branches resolved the bare keys `"system_date"`/`"system_time"`/
+  `"utc_offset"`, which no profile TOML has ever declared (every one
+  spells the direction-prefixed `get_/set_system_date` etc.), so those
+  branches raised `KeyError` for every profile a real `CommandMap` ever
+  reached — dead code, invisible to the divergence sweep, since it never
+  produced a frame to compare. The builders now resolve the
+  direction-prefixed keys the TOML files actually declare. IC-7610's own
+  tuple (`0x01 0x58`/`0x59`/`0x62`) is byte-identical to the deleted
+  fallback's, so nothing changes there; **IC-7300 declares its own family
+  numbers (`0x00 0x94`/`0x95`/`0x96`) and now sends them for the first
+  time**, instead of IC-7610's. `parse_system_date_response`/
+  `parse_system_time_response`/`parse_utc_offset_response` moved with the
+  request: each now takes the map-derived `prefix` the reply must start
+  with (`runtime/radio.py: CoreRadio._expect_shape`), rather than checking
+  a hardcoded constant unconditionally. The only production callers,
+  `runtime/radio.py: CoreRadio`'s own methods, moved onto
+  `self._commands.<builder>(...)` in the same change. Also deleted: the
+  orphaned bare `quick_split`/`quick_dual_watch` rows in `rigs/ic7300.toml`
+  and `rigs/ic9700.toml` — no builder has resolved either since MOR-2007
+  ruling 2 replaced their one-shot triggers with real `get_/set_` pairs;
+  the prefixed rows already carry the recorded D2 sources.
 - **CLI: `rigplane ptt on` no longer returns while the rig is keyed.** The
   command now holds the key for as long as the process runs and unkeys on the
   way out, so the process that keyed the rig is the one that releases it. A

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1042,7 +1042,6 @@ get_tx_freq_monitor = [0x1C, 0x03]
 set_tx_freq_monitor = [0x1C, 0x03]
 get_xfc_status = [0x1C, 0x02]             # XFC = transmit frequency monitor
 set_xfc_status = [0x1C, 0x02]
-quick_split = [0x1A, 0x05, 0x00, 0x30]    # source: IC-7300 Advanced Manual (11a) p.19-4, control 0030 "quick split set" (the hardcoded fallback used to send 0x33, split lock on this radio, not declared -- deleted along with the fallback, MOR-2007 ruling 2). No builder resolves this bare key any more: get_quick_split/set_quick_split below (same 0030 address) replaced the one-shot quick_split()/quick_dual_watch() triggers this key was written for. Left declared rather than removed here -- MOR-2007's scope was the builders, not a TOML sweep for orphaned bare keys.
 
 # ── CW ──
 send_cw = [0x17]
@@ -1319,7 +1318,6 @@ set_quick_split = [0x1A, 0x05, 0x00, 0x30]
 # radio (D2, MOR-2014)
 get_quick_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-7: full 1A 05 submenu has no dual-watch item; 0032 on this radio is FM split offset" }
 set_quick_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-7: full 1A 05 submenu has no dual-watch item; 0032 on this radio is FM split offset" }
-quick_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-7: full 1A 05 submenu has no dual-watch item; 0032 on this radio is FM split offset" }
 get_dash_ratio = [0x1A, 0x05, 0x01, 0x61]  # source: IC-7300 Advanced Manual (11a) command table p.19-6, control 0161 (28..45); live bench 2026-08-30: read of 1A 05 01 61 answered 30
 set_dash_ratio = [0x1A, 0x05, 0x01, 0x61]  # source: IC-7300 Advanced Manual (11a) command table p.19-6, control 0161 (28..45); live bench 2026-08-30: read of 1A 05 01 61 answered 30
 get_nb_depth = [0x1A, 0x05, 0x01, 0x89]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1312,8 +1312,8 @@ get_system_time = [0x1A, 0x05, 0x00, 0x95]
 set_system_time = [0x1A, 0x05, 0x00, 0x95]
 get_utc_offset = [0x1A, 0x05, 0x00, 0x96]
 set_utc_offset = [0x1A, 0x05, 0x00, 0x96]
-get_quick_split = [0x1A, 0x05, 0x00, 0x30]
-set_quick_split = [0x1A, 0x05, 0x00, 0x30]
+get_quick_split = [0x1A, 0x05, 0x00, 0x30]  # source: IC-7300 Advanced Manual (11a) p.19-4, control 0030 "quick split set" (the old hardcoded fallback sent 0x33, split lock, not this address)
+set_quick_split = [0x1A, 0x05, 0x00, 0x30]  # source: IC-7300 Advanced Manual (11a) p.19-4, control 0030 "quick split set" (the old hardcoded fallback sent 0x33, split lock, not this address)
 # Full 1A 05 submenu has no dual-watch item -- 0032 is FM split offset on this
 # radio (D2, MOR-2014)
 get_quick_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-7: full 1A 05 submenu has no dual-watch item; 0032 on this radio is FM split offset" }

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -601,8 +601,6 @@ get_tx_freq_monitor = [0x1C, 0x03]
 set_tx_freq_monitor = [0x1C, 0x03]
 get_xfc_status = [0x1C, 0x02]             # XFC = transmit frequency monitor
 set_xfc_status = [0x1C, 0x02]
-quick_split = [0x1A, 0x05, 0x00, 0x43]    # source: IC-9700 CI-V Reference Guide p.6. No builder resolves this bare key any more -- vfo.py's one-shot quick_split() trigger was deleted (MOR-2007 ruling 2); get_quick_split/set_quick_split below (same 0043 address) replaced it. Left declared rather than removed here -- MOR-2007's scope was the builders, not a TOML sweep for orphaned bare keys. Base [commands], not overrides: bare (non-get_/set_) keys fail test_naming_parity.py::test_overrides_have_prefix there (D2, MOR-2015).
-quick_dual_watch = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) p.6: 0032 = Beep Sound(SUB); doc-wide 'quick' search returns only Quick SPLIT (0043); no Quick Dual Watch concept exists" }
 
 # ── CW ──
 send_cw = [0x17]
@@ -821,18 +819,18 @@ get_utc_offset = [0x1A, 0x05, 0x01, 0x84]   # source: IC-9700 CI-V Reference Gui
 set_utc_offset = [0x1A, 0x05, 0x01, 0x84]   # source: IC-9700 CI-V Reference Guide p.8
 get_quick_split = [0x1A, 0x05, 0x00, 0x43]  # source: IC-9700 CI-V Reference Guide p.6
 set_quick_split = [0x1A, 0x05, 0x00, 0x43]  # source: IC-9700 CI-V Reference Guide p.6
-# bare quick_split: moved to base [commands] (── Split ── section) -- a
-# bare (non-get_/set_) key here fails
-# test_naming_parity.py::test_overrides_have_prefix (D2, MOR-2015)
+# The bare quick_split/quick_dual_watch keys that used to live in base
+# [commands] (── Split ── section) are deleted outright (MOR-2008 batch 1):
+# no builder has resolved either since vfo.py's one-shot quick_split()/
+# quick_dual_watch() triggers were replaced by real get_/set_ pairs
+# (MOR-2007 ruling 2), so they had no reader left, only a dead D2 source
+# to preserve -- carried forward onto these get_/set_ rows instead of a
+# now-pointless bare row (D2, MOR-2015).
 # quick_dual_watch: guide's 0032 = "Beep Sound(SUB)"; a doc-wide "quick"
 # search returns exactly one hit -- "Quick SPLIT" (0043); no "Quick Dual
 # Watch" concept exists in this document at all (D2, MOR-2015)
 get_quick_dual_watch = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) p.6: 0032 = Beep Sound(SUB); doc-wide 'quick' search returns only Quick SPLIT (0043); no Quick Dual Watch concept exists" }
 set_quick_dual_watch = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) p.6: 0032 = Beep Sound(SUB); doc-wide 'quick' search returns only Quick SPLIT (0043); no Quick Dual Watch concept exists" }
-# bare quick_dual_watch: also moved to base [commands] -- a dict-valued
-# { absent = ... } entry here escapes test_overrides_have_prefix only via
-# its isinstance(list) short-circuit (the rule only checks list-valued
-# entries); moved rather than relying on that blind spot (D2, MOR-2015)
 # dash_ratio: control 0224, CW-KEY SET>Dot/Dash Ratio; real gap-list
 # address (D2, MOR-2015). The hardcoded fallback that used to send 0228 for
 # this command was itself wrong for this radio (0228 = CW-KEY SET>MIC

--- a/src/rigplane/commands/_builders.py
+++ b/src/rigplane/commands/_builders.py
@@ -15,7 +15,6 @@ from ._frame import (
     _CMD_LEVEL,
     _CMD_METER,
     _CMD_PREAMP,
-    _SUB_CTL_MEM,
     _build_from_map,
     build_civ_frame,
     build_cmd29_frame,
@@ -24,29 +23,6 @@ from ._frame import (
 if TYPE_CHECKING:
     from ..command_map import CommandMap
     from ..types import CivFrame
-
-
-def _build_ctl_mem_get(
-    prefix: bytes,
-    *,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    if cmd_map is not None and cmd_name is not None:
-        # When using cmd_map, wire bytes already include the full command structure
-        # including any data prefix, so don't pass prefix as data
-        return _build_from_map(
-            cmd_map, cmd_name, to_addr=to_addr, from_addr=from_addr, data=None
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_CTL_MEM,
-        data=prefix,
-    )
 
 
 def _build_meter_bool_get(

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -36,7 +36,6 @@ _CMD_METER = 0x15  # Meter readings
 _CMD_PTT = 0x1C  # Transceiver status / PTT
 _CMD_CTL_MEM = 0x1A  # Memory / configuration command
 _CMD_BAND_EDGE = 0x02  # Band edge frequency
-_CMD_RIT = 0x21  # RIT/XIT
 _CMD_TONE = 0x1B  # Tone/TSQL frequency
 _CMD_MEMORY_MODE = 0x08  # Memory mode (select channel)
 _CMD_MEMORY_WRITE = 0x09  # Memory write
@@ -70,9 +69,6 @@ _SUB_ID_METER = 0x16
 
 # Sub-commands for 0x1C (PTT / Transceiver status)
 _SUB_PTT = 0x00
-_SUB_TUNER_STATUS = 0x01
-_SUB_XFC_STATUS = 0x02
-_SUB_TX_FREQ_MONITOR = 0x03
 
 # Sub-commands for 0x1A (CTL_MEM)
 _SUB_CTL_MEM = 0x05
@@ -129,23 +125,8 @@ _SUB_REPEATER_TSQL = 0x43
 _SUB_TONE_FREQ = 0x00
 _SUB_TSQL_FREQ = 0x01
 
-# RIT sub-commands (0x21)
-_SUB_RIT_FREQ = 0x00
-_SUB_RIT_STATUS = 0x01
-_SUB_RIT_TX_STATUS = 0x02
-
-# CW keying
-_CMD_SEND_CW = 0x17
-
 # Power control
 _CMD_POWER_CTRL = 0x18
-
-# Speech
-_CMD_SPEECH = 0x13
-
-# Transceiver ID
-_CMD_TRANSCEIVER_ID = 0x19
-_SUB_TRANSCEIVER_ID = 0x00
 
 # Scope / Waterfall (0x27)
 _CMD_SCOPE = 0x27
@@ -175,7 +156,8 @@ _COMMANDS_WITH_SUB: set[int] = {
     _CMD_METER,
     _CMD_PTT,
     _CMD_CTL_MEM,
-    _CMD_RIT,
+    0x21,  # RIT/XIT -- named _CMD_RIT until system.py's own reader
+    # (MOR-2008 batch 1) was its last, same as 0x27/0x16/0x19 below
     0x27,
     0x16,
     _CMD_TONE,

--- a/src/rigplane/commands/config.py
+++ b/src/rigplane/commands/config.py
@@ -12,10 +12,13 @@ apply_profile` writes with no user action.
 
 Every builder calls `_frame.py: _build_from_map` directly rather than the
 shared `_builders.py: _build_ctl_mem_get` / `_build_ctl_mem_set` templates
-used before migrating: those still carry their own ``cmd_map is None``
-fallback for `levels.py` / `system.py`, unmigrated, so routing through them
-would leave an explicit ``cmd_map=None`` call silently reaching old,
-sometimes-wrong bytes instead of failing loudly.
+used before migrating: at the time, those still carried their own
+``cmd_map is None`` fallback for `levels.py` / `system.py`, unmigrated, so
+routing through them would have left an explicit ``cmd_map=None`` call
+silently reaching old, sometimes-wrong bytes instead of failing loudly.
+Both templates are gone now -- ``_build_ctl_mem_set`` when `levels.py`
+migrated (MOR-2006 module 2), ``_build_ctl_mem_get`` when `system.py`
+migrated (MOR-2008 batch 1) removed the last caller either one had left.
 """
 
 from __future__ import annotations

--- a/src/rigplane/commands/cw.py
+++ b/src/rigplane/commands/cw.py
@@ -1,4 +1,14 @@
-"""CW keying commands (send_cw, stop_cw)."""
+"""CW keying commands (send_cw, stop_cw).
+
+Migrated onto the bound command map in MOR-2008 (batch 1,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N):
+both builders now require ``cmd_map``, with no hardcoded fallback left.
+Zero divergence rows, zero gap rows -- every profile that declares
+``send_cw``/``stop_cw`` already carries the identical ``[0x17]`` tuple the
+fallback built (verified by grep across ``rigs/*.toml`` before deleting
+it), so ``tests/command_map_parity_divergences.txt`` stays empty of this
+module's rows.
+"""
 
 from __future__ import annotations
 
@@ -6,20 +16,19 @@ from typing import TYPE_CHECKING
 
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_SEND_CW,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
     from ..command_map import CommandMap
 
 
+@expose_command_key(lambda cmd_map: "send_cw")
+@require_cmd_map
 def send_cw(
-    text: str,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    text: str, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> list[bytes]:
     """Build CI-V frames to send CW text.
 
@@ -39,25 +48,20 @@ def send_cw(
     for i in range(0, len(text), 30):
         chunk = text[i : i + 30]
         data = chunk.encode("ascii")
-        if cmd_map is not None:
-            frames.append(
-                _build_from_map(
-                    cmd_map, "send_cw", to_addr=to_addr, from_addr=from_addr, data=data
-                )
+        frames.append(
+            _build_from_map(
+                cmd_map, "send_cw", to_addr=to_addr, from_addr=from_addr, data=data
             )
-        else:
-            frames.append(build_civ_frame(to_addr, from_addr, _CMD_SEND_CW, data=data))
+        )
     return frames
 
 
+@expose_command_key(lambda cmd_map: "stop_cw")
+@require_cmd_map
 def stop_cw(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build CI-V frame to stop CW sending."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "stop_cw", to_addr=to_addr, from_addr=from_addr, data=b"\xff"
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_SEND_CW, data=b"\xff")
+    return _build_from_map(
+        cmd_map, "stop_cw", to_addr=to_addr, from_addr=from_addr, data=b"\xff"
+    )

--- a/src/rigplane/commands/levels.py
+++ b/src/rigplane/commands/levels.py
@@ -14,16 +14,17 @@ did, for two unrelated controls.
 Every builder calls `_frame.py: _build_from_map` directly rather than the
 shared `_builders.py` templates used before migrating
 (``_build_level_get`` / ``_build_level_set`` / ``_build_ctl_mem_set``, all
-now deleted -- this module was their only caller, so their own
+deleted here -- this module was their only caller, so their own
 ``cmd_map is None`` fallback branches would otherwise become dead code
-nobody reads; ``_build_ctl_mem_get`` is kept, since `system.py`'s own
-date/time/UTC-offset getters still route through its fallback,
-unmigrated). Routing this module's builders through a template that
-retains a fallback would leave an explicit ``cmd_map=None`` call one layer
-away from silently reaching old, sometimes-wrong bytes instead of failing
-loudly through `_frame.py: require_cmd_map` -- the same reasoning
-`config.py`'s own module docstring records for the first half of this
-migration.
+nobody reads; ``_build_ctl_mem_get`` was kept at the time, since
+`system.py`'s own date/time/UTC-offset getters still routed through its
+fallback -- it was deleted later, when `system.py` migrated (MOR-2008
+batch 1) removed that last caller too). Routing this module's builders
+through a template that retains a fallback would leave an explicit
+``cmd_map=None`` call one layer away from silently reaching old,
+sometimes-wrong bytes instead of failing loudly through `_frame.py:
+require_cmd_map` -- the same reasoning `config.py`'s own module docstring
+records for the first half of this migration.
 """
 
 from __future__ import annotations

--- a/src/rigplane/commands/power.py
+++ b/src/rigplane/commands/power.py
@@ -1,4 +1,17 @@
-"""Power on/off and powerstat commands."""
+"""Power on/off and powerstat commands.
+
+Migrated onto the bound command map in MOR-2008 (batch 1,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N): all
+three builders now require ``cmd_map``, with no hardcoded fallback left.
+Zero divergence rows, zero gap rows -- every profile that declares
+``get_powerstat``/``power_on``/``power_off`` already carries the identical
+``[0x18]`` tuple the fallback built (verified by grep across
+``rigs/*.toml`` before deleting it; IC-7300/IC-9700 record ``get_powerstat``
+absent instead, per D2 MOR-2014, unaffected by this migration), so
+``tests/command_map_parity_divergences.txt`` stays empty of this module's
+rows. ``parse_powerstat`` is unchanged: its response check reads
+``_CMD_POWER_CTRL`` directly, which does not vary by profile.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +21,8 @@ from ._frame import (
     CONTROLLER_ADDR,
     _CMD_POWER_CTRL,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -16,43 +30,37 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
+@expose_command_key(lambda cmd_map: "get_powerstat")
+@require_cmd_map
 def get_powerstat(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build CI-V frame to query radio power status (0x18 GET)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_powerstat", to_addr=to_addr, from_addr=from_addr, data=b""
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_POWER_CTRL, data=b"")
+    return _build_from_map(
+        cmd_map, "get_powerstat", to_addr=to_addr, from_addr=from_addr, data=b""
+    )
 
 
+@expose_command_key(lambda cmd_map: "power_on")
+@require_cmd_map
 def power_on(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build CI-V frame to power on the radio."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "power_on", to_addr=to_addr, from_addr=from_addr, data=b"\x01"
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_POWER_CTRL, data=b"\x01")
+    return _build_from_map(
+        cmd_map, "power_on", to_addr=to_addr, from_addr=from_addr, data=b"\x01"
+    )
 
 
+@expose_command_key(lambda cmd_map: "power_off")
+@require_cmd_map
 def power_off(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build CI-V frame to power off the radio."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "power_off", to_addr=to_addr, from_addr=from_addr, data=b"\x00"
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_POWER_CTRL, data=b"\x00")
+    return _build_from_map(
+        cmd_map, "power_off", to_addr=to_addr, from_addr=from_addr, data=b"\x00"
+    )
 
 
 def parse_powerstat(frame: CivFrame) -> bool:

--- a/src/rigplane/commands/ptt.py
+++ b/src/rigplane/commands/ptt.py
@@ -15,15 +15,16 @@ tuple, matching the fallback's own bytes exactly (verified by grep across
 `rigs/*.toml` before deleting it), so `tests/command_map_parity_divergences.txt`
 is empty of ptt.py rows and stays that way.
 
-``_CMD_PTT`` (0x1C) survives in `commands/_frame.py`: `commands/system.py`'s
-unmigrated ``get_tuner_status``/``set_tuner_status``/``get_xfc_status``/
-``set_xfc_status``/``get_tx_freq_monitor``/``set_tx_freq_monitor`` still read
-it for their own fallback branches (0x1C is the whole "transceiver status"
-CI-V command family, not just PTT). ``_SUB_PTT`` (0x00) also survives:
-`tests/test_radio.py` imports it directly to build synthetic CivFrames for
-unrelated managed-TX/ACK-tracking tests, unconnected to this module's own
-fallback -- the migration contract deletes a constant only this module's
-fallback alone read, and this one is read elsewhere too.
+``_CMD_PTT`` (0x1C) still survives in `commands/_frame.py`, past
+`commands/system.py`'s own migration (MOR-2008 batch 1), which deleted
+that module's ``get_tuner_status``/``set_tuner_status``/``get_xfc_status``/
+``set_xfc_status``/``get_tx_freq_monitor``/``set_tx_freq_monitor`` fallback
+branches (0x1C is the whole "transceiver status" CI-V command family, not
+just PTT): `tests/test_radio.py` imports ``_CMD_PTT`` directly (alongside
+``_SUB_PTT``, 0x00) to build synthetic CivFrames for unrelated managed-TX/
+ACK-tracking tests, unconnected to either module's fallback -- the
+migration contract deletes a constant only when every reader, module
+fallback or test, is gone, and this one still has one.
 """
 
 from __future__ import annotations

--- a/src/rigplane/commands/speech.py
+++ b/src/rigplane/commands/speech.py
@@ -1,4 +1,21 @@
-"""Speech announcement command (0x13)."""
+"""Speech announcement command (0x13).
+
+Migrated onto the bound command map in MOR-2008 (batch 1,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N):
+``get_speech`` now requires ``cmd_map``, with no hardcoded fallback left.
+Zero divergence rows, zero gap rows -- every profile that declares
+``get_speech``/``set_speech`` already carries the identical ``[0x13]``
+tuple the fallback built (verified by grep across ``rigs/*.toml`` before
+deleting it), so ``tests/command_map_parity_divergences.txt`` stays empty
+of this module's rows.
+
+The pre-migration ``cmd_map`` branch never validated ``what`` -- only the
+fallback branch did, so a caller reaching the map branch with an
+out-of-range value got a frame built anyway, not a ``ValueError``. Folding
+the two branches into one (there is only one left now) applies the
+validation unconditionally, closing that gap rather than carrying it
+forward silently.
+"""
 
 from __future__ import annotations
 
@@ -6,10 +23,9 @@ from typing import TYPE_CHECKING
 
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_SPEECH,
     _build_from_map,
-    build_civ_frame,
     expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -32,12 +48,13 @@ def _speech_key(cmd_map: CommandMap) -> str:
 
 
 @expose_command_key(_speech_key)
+@require_cmd_map
 def get_speech(
     what: int = 0,
     *,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a speech announcement CI-V command (0x13).
 
@@ -48,17 +65,15 @@ def get_speech(
               1 = frequency + S-meter,
               2 = mode.
     """
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            _speech_key(cmd_map),
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([what]),
-        )
     if what not in (0, 1, 2):
         raise ValueError(f"speech 'what' must be 0, 1, or 2, got {what}")
-    return build_civ_frame(to_addr, from_addr, _CMD_SPEECH, data=bytes([what]))
+    return _build_from_map(
+        cmd_map,
+        _speech_key(cmd_map),
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([what]),
+    )
 
 
 # Backward-compat alias

--- a/src/rigplane/commands/system.py
+++ b/src/rigplane/commands/system.py
@@ -1,4 +1,38 @@
-"""System commands: transceiver ID, band edge, tuner, XFC, TX freq monitor, RIT/XIT."""
+"""System commands: transceiver ID, band edge, tuner, XFC, TX freq monitor, RIT/XIT.
+
+Migrated onto the bound command map in MOR-2008 (batch 1,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N): all
+twenty builders now require ``cmd_map``, with no hardcoded fallback left.
+Fourteen of them (transceiver ID, band edge, tuner/XFC/TX-freq-monitor
+status, RIT/XIT) carried zero divergence rows and zero gap rows -- every
+declaring profile's tuple already matched the fallback's own bytes exactly
+(verified by grep across ``rigs/*.toml`` before deleting it), so
+``tests/command_map_parity_divergences.txt`` stays empty of their rows.
+
+The other six -- ``get_system_date``/``set_system_date``,
+``get_system_time``/``set_system_time``, ``get_utc_offset``/
+``set_utc_offset`` -- are the owner-ruled exception: their ``cmd_map``
+branches resolved the bare keys ``"system_date"``/``"system_time"``/
+``"utc_offset"``, which no profile TOML has ever declared (every one of the
+four declaring profiles spells the direction-prefixed
+``get_system_date``/``set_system_date`` etc.), so those branches raised
+``KeyError`` for every profile the moment a real ``CommandMap`` reached
+them -- ``tests/command_map_parity_uncovered.txt`` recorded this as a
+``gap`` row for the bare names on every profile, never a divergence (a gap
+means the ``cmd_map`` branch could not even build a frame to compare). The
+fix is what this migration makes real for the first time: the builders now
+resolve the direction-prefixed keys the TOML files actually declare. On
+IC-7610 that changes nothing observable -- ``rigs/ic7610.toml`` declares
+``0x01 0x58``/``0x01 0x59``/``0x01 0x62``, byte-identical to the shared
+fallback constants below, which is why the fallback path looked correct for
+years. On IC-7300, this is an intended behavior change: ``rigs/ic7300.toml``
+declares its own family numbers ``0x00 0x94``/``0x00 0x95``/``0x00 0x96``,
+and the CommandMap requirement means IC-7300 sends its own correct extended
+addresses for the first time, not IC-7610's. Response parsing moves with
+the request: ``parse_system_date_response``/``parse_system_time_response``/
+``parse_utc_offset_response`` now take the map-derived ``prefix`` the reply
+must start with, rather than checking the module constant unconditionally.
+"""
 
 from __future__ import annotations
 
@@ -7,24 +41,14 @@ from typing import TYPE_CHECKING
 from ._codec import _bcd_decode_value, bcd_encode_value
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_BAND_EDGE,
     _CMD_CTL_MEM,
-    _CMD_PTT,
-    _CMD_RIT,
-    _CMD_TRANSCEIVER_ID,
     _CTL_MEM_SYSTEM_DATE,
     _CTL_MEM_SYSTEM_TIME,
     _CTL_MEM_UTC_OFFSET,
     _SUB_CTL_MEM,
-    _SUB_RIT_FREQ,
-    _SUB_RIT_STATUS,
-    _SUB_RIT_TX_STATUS,
-    _SUB_TRANSCEIVER_ID,
-    _SUB_TUNER_STATUS,
-    _SUB_TX_FREQ_MONITOR,
-    _SUB_XFC_STATUS,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -32,139 +56,104 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
+@expose_command_key(lambda cmd_map: "get_transceiver_id")
+@require_cmd_map
 def get_transceiver_id(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read transceiver ID command (0x19 0x00)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_transceiver_id", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_TRANSCEIVER_ID, sub=_SUB_TRANSCEIVER_ID
+    return _build_from_map(
+        cmd_map, "get_transceiver_id", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "get_band_edge_freq")
+@require_cmd_map
 def get_band_edge_freq(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read band-edge frequency command (0x02)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_band_edge_freq", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_BAND_EDGE)
+    return _build_from_map(
+        cmd_map, "get_band_edge_freq", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_tuner_status")
+@require_cmd_map
 def get_tuner_status(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read tuner/ATU status command (0x1C 0x01)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_tuner_status", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_PTT, sub=_SUB_TUNER_STATUS)
+    return _build_from_map(
+        cmd_map, "get_tuner_status", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_tuner_status")
+@require_cmd_map
 def set_tuner_status(
-    value: int,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    value: int, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a set tuner/ATU status command (0x1C 0x01). 0=off, 1=on, 2=tune."""
     if value not in (0, 1, 2):
         raise ValueError(f"Tuner status must be 0, 1, or 2, got {value}")
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_tuner_status",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([value]),
-        )
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_PTT, sub=_SUB_TUNER_STATUS, data=bytes([value])
+    return _build_from_map(
+        cmd_map,
+        "set_tuner_status",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([value]),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_xfc_status")
+@require_cmd_map
 def get_xfc_status(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read XFC status command (0x1C 0x02)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_xfc_status", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_PTT, sub=_SUB_XFC_STATUS)
+    return _build_from_map(
+        cmd_map, "get_xfc_status", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_xfc_status")
+@require_cmd_map
 def set_xfc_status(
-    on: bool,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    on: bool, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a set XFC status command (0x1C 0x02)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_xfc_status",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=b"\x01" if on else b"\x00",
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_PTT,
-        sub=_SUB_XFC_STATUS,
+    return _build_from_map(
+        cmd_map,
+        "set_xfc_status",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=b"\x01" if on else b"\x00",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_tx_freq_monitor")
+@require_cmd_map
 def get_tx_freq_monitor(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read TX frequency monitor status command (0x1C 0x03)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_tx_freq_monitor", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_PTT, sub=_SUB_TX_FREQ_MONITOR)
+    return _build_from_map(
+        cmd_map, "get_tx_freq_monitor", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_tx_freq_monitor")
+@require_cmd_map
 def set_tx_freq_monitor(
-    on: bool,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    on: bool, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a set TX frequency monitor command (0x1C 0x03)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_tx_freq_monitor",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=b"\x01" if on else b"\x00",
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_PTT,
-        sub=_SUB_TX_FREQ_MONITOR,
+    return _build_from_map(
+        cmd_map,
+        "set_tx_freq_monitor",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=b"\x01" if on else b"\x00",
     )
 
@@ -172,40 +161,39 @@ def set_tx_freq_monitor(
 # --- RIT/XIT ---
 
 
+@expose_command_key(lambda cmd_map: "get_rit_frequency")
+@require_cmd_map
 def get_rit_frequency(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read RIT frequency offset command (0x21 0x00)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_rit_frequency", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_RIT, sub=_SUB_RIT_FREQ)
+    return _build_from_map(
+        cmd_map, "get_rit_frequency", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_rit_frequency")
+@require_cmd_map
 def set_rit_frequency(
     offset_hz: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set RIT frequency offset command (0x21 0x00)."""
     if not -9999 <= offset_hz <= 9999:
-        raise ValueError(f"RIT offset must be \u00b19999 Hz, got {offset_hz}")
+        raise ValueError(f"RIT offset must be ±9999 Hz, got {offset_hz}")
     abs_hz = abs(offset_hz)
     d0 = ((abs_hz % 100 // 10) << 4) | (abs_hz % 10)
     d1 = ((abs_hz % 10000 // 1000) << 4) | (abs_hz % 1000 // 100)
     sign = b"\x01" if offset_hz < 0 else b"\x00"
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_rit_frequency",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([d0, d1]) + sign,
-        )
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_RIT, sub=_SUB_RIT_FREQ, data=bytes([d0, d1]) + sign
+    return _build_from_map(
+        cmd_map,
+        "set_rit_frequency",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([d0, d1]) + sign,
     )
 
 
@@ -218,96 +206,85 @@ def parse_rit_frequency_response(data: bytes) -> int:
     return -hz if sign else hz
 
 
+@expose_command_key(lambda cmd_map: "get_rit_status")
+@require_cmd_map
 def get_rit_status(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_rit_status", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_RIT, sub=_SUB_RIT_STATUS)
+    return _build_from_map(
+        cmd_map, "get_rit_status", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_rit_status")
+@require_cmd_map
 def set_rit_status(
-    on: bool,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    on: bool, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_rit_status",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=b"\x01" if on else b"\x00",
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_RIT,
-        sub=_SUB_RIT_STATUS,
+    return _build_from_map(
+        cmd_map,
+        "set_rit_status",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=b"\x01" if on else b"\x00",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_rit_tx_status")
+@require_cmd_map
 def get_rit_tx_status(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_rit_tx_status", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_RIT, sub=_SUB_RIT_TX_STATUS)
+    return _build_from_map(
+        cmd_map, "get_rit_tx_status", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_rit_tx_status")
+@require_cmd_map
 def set_rit_tx_status(
-    on: bool,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    on: bool, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_rit_tx_status",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=b"\x01" if on else b"\x00",
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_RIT,
-        sub=_SUB_RIT_TX_STATUS,
+    return _build_from_map(
+        cmd_map,
+        "set_rit_tx_status",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=b"\x01" if on else b"\x00",
     )
 
 
 # --- Date / Time / UTC Offset ---
+#
+# The six builders below resolve the direction-prefixed keys
+# (`get_system_date`/`set_system_date` etc.) per the owner ruling in this
+# module's docstring, not the bare `"system_date"`/`"system_time"`/
+# `"utc_offset"` names their pre-migration `cmd_map` branches used to look
+# up -- those bare names are still, and will remain, absent from every
+# profile (`tests/test_undeclared_command_policy.py` pins `"system_date"`
+# as one of the names that stays universally undeclared).
 
 
+@expose_command_key(lambda cmd_map: "get_system_date")
+@require_cmd_map
 def get_system_date(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    from ._builders import _build_ctl_mem_get
-
-    return _build_ctl_mem_get(
-        _CTL_MEM_SYSTEM_DATE,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="system_date",
+    return _build_from_map(
+        cmd_map, "get_system_date", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_system_date")
+@require_cmd_map
 def set_system_date(
     year: int,
     month: int,
     day: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 2000 <= year <= 2099:
         raise ValueError(f"Year must be 2000-2099, got {year}")
@@ -320,26 +297,29 @@ def set_system_date(
         + bcd_encode_value(month, byte_count=1)
         + bcd_encode_value(day, byte_count=1)
     )
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "system_date", to_addr=to_addr, from_addr=from_addr, data=bcd
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_CTL_MEM,
-        data=_CTL_MEM_SYSTEM_DATE + bcd,
+    return _build_from_map(
+        cmd_map, "set_system_date", to_addr=to_addr, from_addr=from_addr, data=bcd
     )
 
 
-def parse_system_date_response(frame: CivFrame) -> tuple[int, int, int]:
+def parse_system_date_response(
+    frame: CivFrame,
+    *,
+    prefix: bytes = _CTL_MEM_SYSTEM_DATE,
+) -> tuple[int, int, int]:
+    """Parse a system-date reply.
+
+    ``prefix`` is the map-derived extended-address bytes the caller's
+    request used (`runtime/radio.py: CoreRadio._expect_shape`); it defaults
+    to the shared IC-7610-shaped constant only so tests built before this
+    migration, which never passed one, keep working unchanged.
+    """
     if frame.command != _CMD_CTL_MEM or frame.sub != _SUB_CTL_MEM:
         raise ValueError(f"Not a system date response: 0x{frame.command:02x}")
     data = frame.data
-    if not data.startswith(_CTL_MEM_SYSTEM_DATE):
+    if not data.startswith(prefix):
         raise ValueError(f"System date prefix mismatch: {data.hex()}")
-    data = data[len(_CTL_MEM_SYSTEM_DATE) :]
+    data = data[len(prefix) :]
     if len(data) < 4:
         raise ValueError(f"System date payload too short: {len(data)} bytes")
     year = _bcd_decode_value(data[0:2])
@@ -348,78 +328,73 @@ def parse_system_date_response(frame: CivFrame) -> tuple[int, int, int]:
     return (year, month, day)
 
 
+@expose_command_key(lambda cmd_map: "get_system_time")
+@require_cmd_map
 def get_system_time(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    from ._builders import _build_ctl_mem_get
-
-    return _build_ctl_mem_get(
-        _CTL_MEM_SYSTEM_TIME,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="system_time",
+    return _build_from_map(
+        cmd_map, "get_system_time", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_system_time")
+@require_cmd_map
 def set_system_time(
     hour: int,
     minute: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 0 <= hour <= 23:
         raise ValueError(f"Hour must be 0-23, got {hour}")
     if not 0 <= minute <= 59:
         raise ValueError(f"Minute must be 0-59, got {minute}")
     bcd = bcd_encode_value(hour, byte_count=1) + bcd_encode_value(minute, byte_count=1)
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "system_time", to_addr=to_addr, from_addr=from_addr, data=bcd
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_CTL_MEM,
-        data=_CTL_MEM_SYSTEM_TIME + bcd,
+    return _build_from_map(
+        cmd_map, "set_system_time", to_addr=to_addr, from_addr=from_addr, data=bcd
     )
 
 
-def parse_system_time_response(frame: CivFrame) -> tuple[int, int]:
+def parse_system_time_response(
+    frame: CivFrame,
+    *,
+    prefix: bytes = _CTL_MEM_SYSTEM_TIME,
+) -> tuple[int, int]:
+    """Parse a system-time reply. See ``parse_system_date_response`` for ``prefix``."""
     if frame.command != _CMD_CTL_MEM or frame.sub != _SUB_CTL_MEM:
         raise ValueError(f"Not a system time response: 0x{frame.command:02x}")
     data = frame.data
-    if not data.startswith(_CTL_MEM_SYSTEM_TIME):
+    if not data.startswith(prefix):
         raise ValueError(f"System time prefix mismatch: {data.hex()}")
-    data = data[len(_CTL_MEM_SYSTEM_TIME) :]
+    data = data[len(prefix) :]
     if len(data) < 2:
         raise ValueError(f"System time payload too short: {len(data)} bytes")
     return (_bcd_decode_value(data[0:1]), _bcd_decode_value(data[1:2]))
 
 
+@expose_command_key(lambda cmd_map: "get_utc_offset")
+@require_cmd_map
 def get_utc_offset(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
-    from ._builders import _build_ctl_mem_get
-
-    return _build_ctl_mem_get(
-        _CTL_MEM_UTC_OFFSET,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="utc_offset",
+    return _build_from_map(
+        cmd_map, "get_utc_offset", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "set_utc_offset")
+@require_cmd_map
 def set_utc_offset(
     hours: int,
     minutes: int,
     is_negative: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     if not 0 <= hours <= 14:
         raise ValueError(f"UTC offset hours must be 0-14, got {hours}")
@@ -430,26 +405,23 @@ def set_utc_offset(
         + bcd_encode_value(minutes, byte_count=1)
         + (b"\x01" if is_negative else b"\x00")
     )
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "utc_offset", to_addr=to_addr, from_addr=from_addr, data=payload
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_CTL_MEM,
-        data=_CTL_MEM_UTC_OFFSET + payload,
+    return _build_from_map(
+        cmd_map, "set_utc_offset", to_addr=to_addr, from_addr=from_addr, data=payload
     )
 
 
-def parse_utc_offset_response(frame: CivFrame) -> tuple[int, int, bool]:
+def parse_utc_offset_response(
+    frame: CivFrame,
+    *,
+    prefix: bytes = _CTL_MEM_UTC_OFFSET,
+) -> tuple[int, int, bool]:
+    """Parse a UTC-offset reply. See ``parse_system_date_response`` for ``prefix``."""
     if frame.command != _CMD_CTL_MEM or frame.sub != _SUB_CTL_MEM:
         raise ValueError(f"Not a UTC offset response: 0x{frame.command:02x}")
     data = frame.data
-    if not data.startswith(_CTL_MEM_UTC_OFFSET):
+    if not data.startswith(prefix):
         raise ValueError(f"UTC offset prefix mismatch: {data.hex()}")
-    data = data[len(_CTL_MEM_UTC_OFFSET) :]
+    data = data[len(prefix) :]
     if len(data) < 3:
         raise ValueError(f"UTC offset payload too short: {len(data)} bytes")
     return (_bcd_decode_value(data[0:1]), _bcd_decode_value(data[1:2]), data[2] != 0x00)

--- a/src/rigplane/commands/vfo.py
+++ b/src/rigplane/commands/vfo.py
@@ -56,9 +56,13 @@ never had a shared per-builder template to de-delegate from (its
 `_CMD_*`/`_SUB_*`/`_CTL_MEM_*`/`_VFO_*` constants were only ever read
 inline, by this module's own fallback branches, now deleted along with the
 branches -- verified by grep against the whole repo before removal from
-`_frame.py`; ``_CMD_CTL_MEM``/``_SUB_CTL_MEM`` survive there, since
-`system.py`'s date/time/UTC-offset getters still route through
-`_builders.py: _build_ctl_mem_get`, unmigrated).
+`_frame.py`; ``_CMD_CTL_MEM``/``_SUB_CTL_MEM`` survive there, read directly
+by several other modules' own builders/parsers (`mode.py`, `memory.py`,
+`dsp.py`, and, since MOR-2008 batch 1, `system.py`'s own
+``parse_system_date_response``/``parse_system_time_response``/
+``parse_utc_offset_response``) -- `_builders.py: _build_ctl_mem_get`,
+the shared template `system.py` used to route through instead, is gone
+now that migration removed its last caller).
 """
 
 from __future__ import annotations

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -108,7 +108,6 @@ from rigplane.commands import (
     get_apf_type_level,
     get_audio_peak_filter,
     get_auto_notch,
-    get_band_edge_freq,
     get_break_in,
     get_break_in_delay,
     get_civ_output_ant,
@@ -152,23 +151,16 @@ from rigplane.commands import (
     get_quick_dual_watch,
     get_quick_split,
     get_ref_adjust,
-    get_rit_frequency,
-    get_rit_status,
-    get_rit_tx_status,
     get_rx_antenna_ant1,
     get_rx_antenna_ant2,
     get_s_meter,
     get_s_meter_sql_status,
-    get_speech,
     get_squelch,
     get_ssb_tx_bandwidth,
     get_swr,
     get_system_date,
     get_system_time,
-    get_transceiver_id,
-    get_tuner_status,
     get_twin_peak_filter,
-    get_tx_freq_monitor,
     get_usb_mod_level,
     get_utc_offset,
     get_various_squelch,
@@ -176,7 +168,6 @@ from rigplane.commands import (
     get_vox,
     get_vox_delay,
     get_vox_gain,
-    get_xfc_status,
     parse_ack_nak,
     parse_band_stack_response,
     parse_bool_response,
@@ -190,11 +181,7 @@ from rigplane.commands import (
     parse_tone_freq_response,
     parse_tsql_freq_response,
     parse_utc_offset_response,
-    get_powerstat,
     parse_powerstat,
-    power_off,
-    power_on,
-    send_cw,
     set_af_mute,
     set_agc,
     set_agc_time_constant,
@@ -219,21 +206,11 @@ from rigplane.commands import (
     set_nb,
     set_nr,
     set_preamp,
-    set_rit_frequency,
-    set_rit_status,
-    set_rit_tx_status,
     set_rx_antenna_ant1,
     set_rx_antenna_ant2,
     set_ssb_tx_bandwidth,
-    set_system_date,
-    set_system_time,
-    set_tuner_status,
     set_twin_peak_filter,
-    set_tx_freq_monitor,
-    set_utc_offset,
     set_vox,
-    set_xfc_status,
-    stop_cw,
 )
 from rigplane.commands import (
     get_attenuator as get_attenuator_cmd,  # Transceiver status family (#136); VFO / Dual Watch / Scanning (#132); Tone/TSQL (#134); System/Config commands (#135); Memory and band-stacking (#133)
@@ -3880,7 +3857,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_band_edge_freq(self) -> int:
         """Read the current band-edge frequency in Hz."""
         self._check_connected()
-        civ = get_band_edge_freq(to_addr=self._radio_addr)
+        civ = self._commands.get_band_edge_freq(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(
             civ, key="get_band_edge_freq", dedupe=True, label="get_band_edge_freq"
         )
@@ -3942,13 +3919,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                   2 = mode.
         """
         self._check_connected()
-        civ = get_speech(what, to_addr=self._radio_addr)
+        civ = self._commands.get_speech(what, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_transceiver_id(self) -> int:
         """Read the transceiver model ID (IC-7610 = 0x98)."""
         self._check_connected()
-        civ = get_transceiver_id(to_addr=self._radio_addr)
+        civ = self._commands.get_transceiver_id(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_transceiver_id")
         if resp.data:
             return resp.data[0]
@@ -3957,7 +3934,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_tuner_status(self) -> int:
         """Read the tuner/ATU status (0=off, 1=on, 2=tuning)."""
         self._check_connected()
-        civ = get_tuner_status(to_addr=self._radio_addr)
+        civ = self._commands.get_tuner_status(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_tuner_status")
         if resp.data:
             return resp.data[0]
@@ -3969,72 +3946,72 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         Fire-and-forget SET command.
         """
         self._check_connected()
-        civ = set_tuner_status(value, to_addr=self._radio_addr)
+        civ = self._commands.set_tuner_status(value, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_xfc_status(self) -> bool:
         """Read XFC (transmit frequency correction) status."""
         self._check_connected()
-        civ = get_xfc_status(to_addr=self._radio_addr)
+        civ = self._commands.get_xfc_status(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_xfc_status")
         return bool(resp.data[0]) if resp.data else False
 
     async def set_xfc_status(self, on: bool) -> None:
         """Set XFC status on/off. Fire-and-forget."""
         self._check_connected()
-        civ = set_xfc_status(on, to_addr=self._radio_addr)
+        civ = self._commands.set_xfc_status(on, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_tx_freq_monitor(self) -> bool:
         """Read TX frequency monitor status."""
         self._check_connected()
-        civ = get_tx_freq_monitor(to_addr=self._radio_addr)
+        civ = self._commands.get_tx_freq_monitor(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_tx_freq_monitor")
         return bool(resp.data[0]) if resp.data else False
 
     async def set_tx_freq_monitor(self, on: bool) -> None:
         """Set TX frequency monitor on/off. Fire-and-forget."""
         self._check_connected()
-        civ = set_tx_freq_monitor(on, to_addr=self._radio_addr)
+        civ = self._commands.set_tx_freq_monitor(on, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_rit_frequency(self) -> int:
         """Read the RIT frequency offset in Hz (±9999)."""
         self._check_connected()
-        civ = get_rit_frequency(to_addr=self._radio_addr)
+        civ = self._commands.get_rit_frequency(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_rit_frequency")
         return parse_rit_frequency_response(resp.data)
 
     async def set_rit_frequency(self, offset_hz: int) -> None:
         """Set the RIT frequency offset in Hz (±9999). Fire-and-forget."""
         self._check_connected()
-        civ = set_rit_frequency(offset_hz, to_addr=self._radio_addr)
+        civ = self._commands.set_rit_frequency(offset_hz, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_rit_status(self) -> bool:
         """Read RIT on/off status."""
         self._check_connected()
-        civ = get_rit_status(to_addr=self._radio_addr)
+        civ = self._commands.get_rit_status(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_rit_status")
         return bool(resp.data[0]) if resp.data else False
 
     async def set_rit_status(self, on: bool) -> None:
         """Set RIT on/off. Fire-and-forget."""
         self._check_connected()
-        civ = set_rit_status(on, to_addr=self._radio_addr)
+        civ = self._commands.set_rit_status(on, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     async def get_rit_tx_status(self) -> bool:
         """Read RIT TX status."""
         self._check_connected()
-        civ = get_rit_tx_status(to_addr=self._radio_addr)
+        civ = self._commands.get_rit_tx_status(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_rit_tx_status")
         return bool(resp.data[0]) if resp.data else False
 
     async def set_rit_tx_status(self, on: bool) -> None:
         """Set RIT TX status on/off. Fire-and-forget."""
         self._check_connected()
-        civ = set_rit_tx_status(on, to_addr=self._radio_addr)
+        civ = self._commands.set_rit_tx_status(on, to_addr=self._radio_addr)
         await self._send_civ_raw(civ, wait_response=False)
 
     # ------------------------------------------------------------------
@@ -5118,11 +5095,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_system_date(self) -> tuple[int, int, int]:
         """Read system date as (year, month, day)."""
         self._check_connected()
-        civ = get_system_date(to_addr=self._radio_addr)
+        civ = self._commands.get_system_date(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(
             civ, key="get_system_date", dedupe=True, label="get_system_date"
         )
-        return parse_system_date_response(resp)
+        _, _, prefix = self._expect_shape(get_system_date)
+        return parse_system_date_response(resp, prefix=prefix)
 
     async def set_system_date(self, year: int, month: int, day: int) -> None:
         """Set system date.
@@ -5133,17 +5111,18 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             day: Day 1-31.
         """
         await self._send_fire_and_forget(
-            set_system_date(year, month, day, to_addr=self._radio_addr)
+            self._commands.set_system_date(year, month, day, to_addr=self._radio_addr)
         )
 
     async def get_system_time(self) -> tuple[int, int]:
         """Read system time as (hour, minute)."""
         self._check_connected()
-        civ = get_system_time(to_addr=self._radio_addr)
+        civ = self._commands.get_system_time(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(
             civ, key="get_system_time", dedupe=True, label="get_system_time"
         )
-        return parse_system_time_response(resp)
+        _, _, prefix = self._expect_shape(get_system_time)
+        return parse_system_time_response(resp, prefix=prefix)
 
     async def set_system_time(self, hour: int, minute: int) -> None:
         """Set system time.
@@ -5153,17 +5132,18 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             minute: Minute 0-59.
         """
         await self._send_fire_and_forget(
-            set_system_time(hour, minute, to_addr=self._radio_addr)
+            self._commands.set_system_time(hour, minute, to_addr=self._radio_addr)
         )
 
     async def get_utc_offset(self) -> tuple[int, int, bool]:
         """Read UTC offset as (hours, minutes, is_negative)."""
         self._check_connected()
-        civ = get_utc_offset(to_addr=self._radio_addr)
+        civ = self._commands.get_utc_offset(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(
             civ, key="get_utc_offset", dedupe=True, label="get_utc_offset"
         )
-        return parse_utc_offset_response(resp)
+        _, _, prefix = self._expect_shape(get_utc_offset)
+        return parse_utc_offset_response(resp, prefix=prefix)
 
     async def set_utc_offset(self, hours: int, minutes: int, is_negative: bool) -> None:
         """Set UTC offset.
@@ -5174,7 +5154,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             is_negative: True for negative (west) offset.
         """
         await self._send_fire_and_forget(
-            set_utc_offset(hours, minutes, is_negative, to_addr=self._radio_addr)
+            self._commands.set_utc_offset(
+                hours, minutes, is_negative, to_addr=self._radio_addr
+            )
         )
 
     async def snapshot_state(self) -> dict[str, object]:
@@ -5229,7 +5211,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             text: CW text (A-Z, 0-9, prosigns).
         """
         self._check_connected()
-        frames = send_cw(text, to_addr=self._radio_addr)
+        frames = self._commands.send_cw(text, to_addr=self._radio_addr)
         for frame in frames:
             resp = await self._send_civ_expect(frame, label="send_cw_text")
             ack = parse_ack_nak(resp)
@@ -5239,7 +5221,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def stop_cw_text(self) -> None:
         """Stop CW sending."""
         self._check_connected()
-        civ = stop_cw(to_addr=self._radio_addr)
+        civ = self._commands.stop_cw(to_addr=self._radio_addr)
         await self._send_civ_raw(civ, priority=Priority.IMMEDIATE)
         # Stop CW may not return ACK, just ignore
 
@@ -5254,7 +5236,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_powerstat(self) -> bool:
         """Get the current radio power state (PowerControlCapable protocol)."""
         self._check_connected()
-        civ = get_powerstat(to_addr=self._radio_addr)
+        civ = self._commands.get_powerstat(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_powerstat")
         return parse_powerstat(resp)
 
@@ -5267,9 +5249,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """
         self._check_connected()
         civ = (
-            power_on(to_addr=self._radio_addr)
+            self._commands.power_on(to_addr=self._radio_addr)
             if on
-            else power_off(to_addr=self._radio_addr)
+            else self._commands.power_off(to_addr=self._radio_addr)
         )
         resp = await self._send_civ_expect(civ, label="set_powerstat")
         ack = parse_ack_nak(resp)

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -26,16 +26,16 @@
 # reachable from a builder that was compared, not sites observed to
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
-census	builders_compared	105
+census	builders_compared	79
 census	cat_only_profiles	2
-census	dual_implementation_sites	70
+census	dual_implementation_sites	46
 census	frames_diverged	0
-census	frames_identical	755
+census	frames_identical	667
 census	hardcode_only_builders	16
-census	profile_builder_map_gaps	434
+census	profile_builder_map_gaps	310
 census	profiles	8
 census	public_builders	228
-census	sites_compared	65
+census	sites_compared	46
 cat-only	FTX-1	108
 cat-only	TX-500	50
 gap	get_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
@@ -46,7 +46,6 @@ gap	get_antenna	FTX-1,TX-500,X6100,X6200
 gap	get_attenuator	FTX-1,TX-500
 gap	get_audio_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	get_auto_notch	FTX-1,TX-500,X6100,X6200
-gap	get_band_edge_freq	FTX-1,TX-500
 gap	get_break_in	FTX-1,TX-500,X6100,X6200
 gap	get_comp_meter	FTX-1,TX-500,X6100,X6200
 gap	get_compressor	FTX-1,TX-500,X6100,X6200
@@ -67,32 +66,20 @@ gap	get_nb	FTX-1,TX-500
 gap	get_nr	FTX-1,TX-500,X6100,X6200
 gap	get_overflow_status	FTX-1,TX-500,X6100,X6200
 gap	get_power_meter	FTX-1,TX-500
-gap	get_powerstat	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
 gap	get_preamp	FTX-1,TX-500
 gap	get_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	get_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_rit_frequency	FTX-1,TX-500,X6100,X6200
-gap	get_rit_status	FTX-1,TX-500,X6100,X6200
-gap	get_rit_tx_status	FTX-1,TX-500,X6100,X6200
 gap	get_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_s_meter	FTX-1,TX-500
 gap	get_s_meter_sql_status	FTX-1,TX-500,X6100,X6200
-gap	get_speech	FTX-1,TX-500,X6100,X6200
 gap	get_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
 gap	get_swr	FTX-1,TX-500
 gap	get_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_transceiver_id	FTX-1,TX-500
 gap	get_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_tuner_status	FTX-1,TX-500
 gap	get_twin_peak_filter	FTX-1,TX-500,X6100,X6200
-gap	get_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
 gap	get_various_squelch	FTX-1,TX-500,X6100,X6200
 gap	get_vd_meter	FTX-1,TX-500
 gap	get_vox	FTX-1,TX-500,X6100,X6200
-gap	get_xfc_status	FTX-1,TX-500,X6100,X6200
-gap	power_off	FTX-1,TX-500,X6100,X6200
-gap	power_on	FTX-1,TX-500,X6100,X6200
-gap	send_cw	FTX-1,TX-500,X6100,X6200
 gap	set_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_agc	FTX-1,TX-500
 gap	set_agc_time_constant	FTX-1,TX-500,X6100,X6200
@@ -119,22 +106,12 @@ gap	set_nr	FTX-1,TX-500,X6100,X6200
 gap	set_preamp	FTX-1,TX-500
 gap	set_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	set_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	set_rit_frequency	FTX-1,TX-500,X6100,X6200
-gap	set_rit_status	FTX-1,TX-500,X6100,X6200
-gap	set_rit_tx_status	FTX-1,TX-500,X6100,X6200
 gap	set_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
 gap	set_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	set_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	set_tuner_status	FTX-1,TX-500
 gap	set_twin_peak_filter	FTX-1,TX-500,X6100,X6200
-gap	set_tx_freq_monitor	FTX-1,TX-500,X6100,X6200
 gap	set_vox	FTX-1,TX-500,X6100,X6200
-gap	set_xfc_status	FTX-1,TX-500,X6100,X6200
-gap	stop_cw	FTX-1,TX-500,X6100,X6200
-gap	system_date	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
-gap	system_time	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
-gap	utc_offset	FTX-1,IC-705,IC-7300,IC-7610,IC-9700,TX-500,X6100,X6200
 requires-map	config.py:get_acc1_mod_level
 requires-map	config.py:get_civ_output_ant
 requires-map	config.py:get_civ_transceive
@@ -153,6 +130,8 @@ requires-map	config.py:set_data3_mod_input
 requires-map	config.py:set_data_off_mod_input
 requires-map	config.py:set_lan_mod_level
 requires-map	config.py:set_usb_mod_level
+requires-map	cw.py:send_cw
+requires-map	cw.py:stop_cw
 requires-map	levels.py:get_af_level
 requires-map	levels.py:get_anti_vox_gain
 requires-map	levels.py:get_apf_type_level
@@ -203,6 +182,9 @@ requires-map	levels.py:set_rf_power
 requires-map	levels.py:set_squelch
 requires-map	levels.py:set_vox_delay
 requires-map	levels.py:set_vox_gain
+requires-map	power.py:get_powerstat
+requires-map	power.py:power_off
+requires-map	power.py:power_on
 requires-map	ptt.py:ptt_off
 requires-map	ptt.py:ptt_on
 requires-map	scope.py:get_scope_center_type
@@ -238,6 +220,27 @@ requires-map	scope.py:scope_set_span
 requires-map	scope.py:scope_set_speed
 requires-map	scope.py:scope_set_vbw
 requires-map	scope.py:scope_single_dual
+requires-map	speech.py:get_speech
+requires-map	system.py:get_band_edge_freq
+requires-map	system.py:get_rit_frequency
+requires-map	system.py:get_rit_status
+requires-map	system.py:get_rit_tx_status
+requires-map	system.py:get_system_date
+requires-map	system.py:get_system_time
+requires-map	system.py:get_transceiver_id
+requires-map	system.py:get_tuner_status
+requires-map	system.py:get_tx_freq_monitor
+requires-map	system.py:get_utc_offset
+requires-map	system.py:get_xfc_status
+requires-map	system.py:set_rit_frequency
+requires-map	system.py:set_rit_status
+requires-map	system.py:set_rit_tx_status
+requires-map	system.py:set_system_date
+requires-map	system.py:set_system_time
+requires-map	system.py:set_tuner_status
+requires-map	system.py:set_tx_freq_monitor
+requires-map	system.py:set_utc_offset
+requires-map	system.py:set_xfc_status
 requires-map	vfo.py:get_dual_watch
 requires-map	vfo.py:get_main_sub_band
 requires-map	vfo.py:get_quick_dual_watch
@@ -258,8 +261,3 @@ requires-map	vfo.py:set_quick_split
 requires-map	vfo.py:set_split
 requires-map	vfo.py:set_tuning_step
 requires-map	vfo.py:set_vfo
-unpinned	_builders.py:_build_ctl_mem_get
-unpinned	power.py:get_powerstat
-unpinned	system.py:set_system_date
-unpinned	system.py:set_system_time
-unpinned	system.py:set_utc_offset

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -7,8 +7,8 @@
 # via { absent = "<source>" } (plan §8.1 D2) or a real command-byte
 # entry in the profile's own TOML. Regenerate, do not hand-edit.
 census	civ_profiles	6
-census	distinct_gap_keys	154
-census	profile_key_gaps	330
+census	distinct_gap_keys	157
+census	profile_key_gaps	324
 census	public_builders	228
 gap	get_acc1_mod_level	X6100,X6200
 gap	get_af_mute	X6100,X6200
@@ -79,12 +79,15 @@ gap	get_scope_vbw	X6100,X6200
 gap	get_speech	X6100,X6200
 gap	get_split	X6100,X6200
 gap	get_ssb_tx_bandwidth	X6100,X6200
+gap	get_system_date	X6100,X6200
+gap	get_system_time	X6100,X6200
 gap	get_tone_freq	IC-7610,X6100,X6200
 gap	get_tsql_freq	IC-7610,X6100,X6200
 gap	get_tuning_step	X6100,X6200
 gap	get_twin_peak_filter	X6100,X6200
 gap	get_tx_freq_monitor	X6100,X6200
 gap	get_usb_mod_level	X6100,X6200
+gap	get_utc_offset	X6100,X6200
 gap	get_various_squelch	X6100,X6200
 gap	get_vox	X6100,X6200
 gap	get_vox_delay	X6100,X6200
@@ -150,17 +153,17 @@ gap	set_rit_status	X6100,X6200
 gap	set_rit_tx_status	X6100,X6200
 gap	set_rx_antenna_ant2	X6100,X6200
 gap	set_ssb_tx_bandwidth	X6100,X6200
+gap	set_system_date	X6100,X6200
+gap	set_system_time	X6100,X6200
 gap	set_tone_freq	IC-7610,X6100,X6200
 gap	set_tsql_freq	IC-7610,X6100,X6200
 gap	set_tuning_step	X6100,X6200
 gap	set_twin_peak_filter	X6100,X6200
 gap	set_tx_freq_monitor	X6100,X6200
 gap	set_usb_mod_level	X6100,X6200
+gap	set_utc_offset	X6100,X6200
 gap	set_vox	X6100,X6200
 gap	set_vox_delay	X6100,X6200
 gap	set_vox_gain	X6100,X6200
 gap	set_xfc_status	X6100,X6200
 gap	stop_cw	X6100,X6200
-gap	system_date	IC-705,IC-7300,IC-7610,IC-9700,X6100,X6200
-gap	system_time	IC-705,IC-7300,IC-7610,IC-9700,X6100,X6200
-gap	utc_offset	IC-705,IC-7300,IC-7610,IC-9700,X6100,X6200

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -121,16 +121,15 @@ class TestGetterParity:
         assert commands.get_power_meter(cmd_map=cmd_map) == commands.get_power_meter()
 
     def test_get_transceiver_id(self, cmd_map):
-        assert (
-            commands.get_transceiver_id(cmd_map=cmd_map)
-            == commands.get_transceiver_id()
-        )
+        # commands/system.py migrated onto the bound command map in
+        # MOR-2008 (batch 1): get_transceiver_id now requires cmd_map --
+        # pinned against the frame the deleted fallback used to build.
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x19, sub=0x00)
+        assert commands.get_transceiver_id(cmd_map=cmd_map) == expected
 
     def test_get_band_edge_freq(self, cmd_map):
-        assert (
-            commands.get_band_edge_freq(cmd_map=cmd_map)
-            == commands.get_band_edge_freq()
-        )
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x02)
+        assert commands.get_band_edge_freq(cmd_map=cmd_map) == expected
 
     def test_scope_on(self, cmd_map):
         # commands/scope.py migrated onto the bound command map in MOR-2007
@@ -230,13 +229,22 @@ class TestSetterParity:
         assert commands.ptt_off(cmd_map=cmd_map) == expected
 
     def test_power_on(self, cmd_map):
-        assert commands.power_on(cmd_map=cmd_map) == commands.power_on()
+        # commands/power.py migrated onto the bound command map in
+        # MOR-2008 (batch 1): power_on/power_off now require cmd_map --
+        # pinned against the frame the deleted fallback used to build.
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x18, data=b"\x01")
+        assert commands.power_on(cmd_map=cmd_map) == expected
 
     def test_power_off(self, cmd_map):
-        assert commands.power_off(cmd_map=cmd_map) == commands.power_off()
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x18, data=b"\x00")
+        assert commands.power_off(cmd_map=cmd_map) == expected
 
     def test_stop_cw(self, cmd_map):
-        assert commands.stop_cw(cmd_map=cmd_map) == commands.stop_cw()
+        # commands/cw.py migrated onto the bound command map in MOR-2008
+        # (batch 1): stop_cw now requires cmd_map -- pinned against the
+        # frame the deleted fallback used to build.
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x17, data=b"\xff")
+        assert commands.stop_cw(cmd_map=cmd_map) == expected
 
     def test_start_scan(self, cmd_map):
         # commands/vfo.py migrated onto the bound command map in MOR-2007

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -252,12 +252,14 @@ def _hardcode_only_builders() -> frozenset[Key]:
     the kernel gaining a public helper, or a module gaining a response
     parser. :func:`_builders` needs no module-level rule because its own
     ``__name__.startswith("_")`` filter already excludes every underscore
-    module: the eight kernel helpers that do take a ``cmd_map``
-    (``_builders.py: _build_ctl_mem_get`` and its six siblings,
+    module: the seven kernel helpers that do take a ``cmd_map``
+    (``_builders.py: _build_meter_bool_get`` and its five siblings,
     ``_frame.py: _build_from_map``) are all underscore-named -- down from
     eleven at MOR-2006 module 1 (config.py): module 2 (levels.py) deleted
     ``_build_level_get``, ``_build_level_set`` and ``_build_ctl_mem_set``,
-    each left with zero callers once levels.py de-delegated from them.
+    each left with zero callers once levels.py de-delegated from them, and
+    MOR-2008 batch 1 (system.py) deleted ``_build_ctl_mem_get`` the same
+    way.
     A public
     ``cmd_map``-taking helper added to one of those modules would move
     ``public_builders`` -- this rule is what keeps it out of this count.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1184,13 +1184,32 @@ class TestOperatorToggleParityCommands:
 
 
 class TestTransceiverStatusBuilders:
-    """Test CI-V builders for transceiver_status commands."""
+    """Test CI-V builders for transceiver_status commands.
 
-    def test_get_band_edge_freq(self) -> None:
+    Migrated onto the bound command map in MOR-2008 (batch 1,
+    `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N):
+    every builder here now requires ``cmd_map`` -- zero divergence rows,
+    so IC-7610's own map declares the identical bytes the fallback used to
+    build, and the expected frames below are unchanged.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_get_band_edge_freq(self, cmd_map) -> None:
         from rigplane.commands import get_band_edge_freq
 
-        frame = get_band_edge_freq()
+        frame = get_band_edge_freq(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x02\xfd" == frame
+
+    def test_get_band_edge_freq_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import get_band_edge_freq
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_band_edge_freq()  # type: ignore[call-arg]
 
     def test_get_various_squelch_main(self) -> None:
         from rigplane.commands import get_various_squelch
@@ -1231,116 +1250,124 @@ class TestTransceiverStatusBuilders:
         frame = get_id_meter()
         assert b"\xfe\xfe\x98\xe0\x15\x16\xfd" == frame
 
-    def test_get_tuner_status(self) -> None:
+    def test_get_tuner_status(self, cmd_map) -> None:
         from rigplane.commands import get_tuner_status
 
-        frame = get_tuner_status()
+        frame = get_tuner_status(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x1c\x01\xfd" == frame
 
-    def test_set_tuner_status_on(self) -> None:
+    def test_set_tuner_status_on(self, cmd_map) -> None:
         from rigplane.commands import set_tuner_status
 
-        frame = set_tuner_status(1)
+        frame = set_tuner_status(1, cmd_map=cmd_map)
         assert b"\x1c\x01\x01" in frame
 
-    def test_set_tuner_status_tune(self) -> None:
+    def test_set_tuner_status_tune(self, cmd_map) -> None:
         from rigplane.commands import set_tuner_status
 
-        frame = set_tuner_status(2)
+        frame = set_tuner_status(2, cmd_map=cmd_map)
         assert b"\x1c\x01\x02" in frame
 
-    def test_set_tuner_status_off(self) -> None:
+    def test_set_tuner_status_off(self, cmd_map) -> None:
         from rigplane.commands import set_tuner_status
 
-        frame = set_tuner_status(0)
+        frame = set_tuner_status(0, cmd_map=cmd_map)
         assert b"\x1c\x01\x00" in frame
 
-    def test_set_tuner_status_invalid(self) -> None:
+    def test_set_tuner_status_invalid(self, cmd_map) -> None:
         from rigplane.commands import set_tuner_status
 
         with pytest.raises(ValueError, match="0, 1, or 2"):
-            set_tuner_status(3)
+            set_tuner_status(3, cmd_map=cmd_map)
 
-    def test_get_tx_freq_monitor(self) -> None:
+    def test_set_tuner_status_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        from rigplane.commands import set_tuner_status
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_tuner_status(1, cmd_map=None)
+
+    def test_get_tx_freq_monitor(self, cmd_map) -> None:
         from rigplane.commands import get_tx_freq_monitor
 
-        frame = get_tx_freq_monitor()
+        frame = get_tx_freq_monitor(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x1c\x03\xfd" == frame
 
-    def test_set_tx_freq_monitor_on(self) -> None:
+    def test_set_tx_freq_monitor_on(self, cmd_map) -> None:
         from rigplane.commands import set_tx_freq_monitor
 
-        frame = set_tx_freq_monitor(True)
+        frame = set_tx_freq_monitor(True, cmd_map=cmd_map)
         assert b"\x1c\x03\x01" in frame
 
-    def test_set_tx_freq_monitor_off(self) -> None:
+    def test_set_tx_freq_monitor_off(self, cmd_map) -> None:
         from rigplane.commands import set_tx_freq_monitor
 
-        frame = set_tx_freq_monitor(False)
+        frame = set_tx_freq_monitor(False, cmd_map=cmd_map)
         assert b"\x1c\x03\x00" in frame
 
-    def test_get_rit_frequency(self) -> None:
+    def test_get_rit_frequency(self, cmd_map) -> None:
         from rigplane.commands import get_rit_frequency
 
-        frame = get_rit_frequency()
+        frame = get_rit_frequency(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x21\x00\xfd" == frame
 
-    def test_set_rit_frequency_positive(self) -> None:
+    def test_set_rit_frequency_positive(self, cmd_map) -> None:
         from rigplane.commands import set_rit_frequency
 
-        frame = set_rit_frequency(150)
+        frame = set_rit_frequency(150, cmd_map=cmd_map)
         # 150 Hz → BCD: d0=0x50 (50), d1=0x01 (01), sign=0x00 (positive)
         assert b"\x21\x00\x50\x01\x00" in frame
 
-    def test_set_rit_frequency_negative(self) -> None:
+    def test_set_rit_frequency_negative(self, cmd_map) -> None:
         from rigplane.commands import set_rit_frequency
 
-        frame = set_rit_frequency(-200)
+        frame = set_rit_frequency(-200, cmd_map=cmd_map)
         # 200 Hz → BCD: d0=0x00, d1=0x02, sign=0x01 (negative)
         assert b"\x21\x00\x00\x02\x01" in frame
 
-    def test_set_rit_frequency_zero(self) -> None:
+    def test_set_rit_frequency_zero(self, cmd_map) -> None:
         from rigplane.commands import set_rit_frequency
 
-        frame = set_rit_frequency(0)
+        frame = set_rit_frequency(0, cmd_map=cmd_map)
         assert b"\x21\x00\x00\x00\x00" in frame
 
-    def test_set_rit_frequency_out_of_range(self) -> None:
+    def test_set_rit_frequency_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_rit_frequency
 
         with pytest.raises(ValueError, match="±9999"):
-            set_rit_frequency(10000)
+            set_rit_frequency(10000, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="±9999"):
-            set_rit_frequency(-10000)
+            set_rit_frequency(-10000, cmd_map=cmd_map)
 
-    def test_get_rit_status(self) -> None:
+    def test_get_rit_status(self, cmd_map) -> None:
         from rigplane.commands import get_rit_status
 
-        frame = get_rit_status()
+        frame = get_rit_status(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x21\x01\xfd" == frame
 
-    def test_set_rit_status_on(self) -> None:
+    def test_set_rit_status_on(self, cmd_map) -> None:
         from rigplane.commands import set_rit_status
 
-        frame = set_rit_status(True)
+        frame = set_rit_status(True, cmd_map=cmd_map)
         assert b"\x21\x01\x01" in frame
 
-    def test_set_rit_status_off(self) -> None:
+    def test_set_rit_status_off(self, cmd_map) -> None:
         from rigplane.commands import set_rit_status
 
-        frame = set_rit_status(False)
+        frame = set_rit_status(False, cmd_map=cmd_map)
         assert b"\x21\x01\x00" in frame
 
-    def test_get_rit_tx_status(self) -> None:
+    def test_get_rit_tx_status(self, cmd_map) -> None:
         from rigplane.commands import get_rit_tx_status
 
-        frame = get_rit_tx_status()
+        frame = get_rit_tx_status(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x21\x02\xfd" == frame
 
-    def test_set_rit_tx_status_on(self) -> None:
+    def test_set_rit_tx_status_on(self, cmd_map) -> None:
         from rigplane.commands import set_rit_tx_status
 
-        frame = set_rit_tx_status(True)
+        frame = set_rit_tx_status(True, cmd_map=cmd_map)
         assert b"\x21\x02\x01" in frame
 
 
@@ -2291,8 +2318,8 @@ class TestSystemConfigCommands:
         omitting it entirely -- not a bare ``AttributeError`` from
         ``_build_from_map``'s ``None.get(name)``, the exact path
         de-delegating from the shared ``_build_ctl_mem_get``/
-        ``_build_ctl_mem_set`` templates (this migration's rationale)
-        would otherwise reopen."""
+        ``_build_ctl_mem_set`` templates (both deleted now, this
+        migration's rationale for deleting them) would otherwise reopen."""
         from rigplane.commands import get_acc1_mod_level
 
         with pytest.raises(TypeError, match="MOR-2006"):
@@ -2474,62 +2501,85 @@ class TestSystemConfigCommands:
         assert result is False
 
     # --- System Date (0x1A 0x05 0x01 0x58) ---
+    #
+    # commands/system.py migrated onto the bound command map in MOR-2008
+    # (batch 1): ``get_system_date``/``set_system_date`` now resolve the
+    # direction-prefixed keys ``rigs/ic7610.toml`` actually declares (the
+    # owner ruling: the bare ``"system_date"`` key the pre-migration
+    # ``cmd_map`` branch resolved was dead on arrival, present on no
+    # profile). IC-7610's own tuple is byte-identical to the deleted
+    # fallback's ``0x01 0x58``, so the expected frames below are unchanged.
 
-    def test_get_system_date_frame(self) -> None:
+    def test_get_system_date_frame(self, cmd_map) -> None:
         from rigplane.commands import get_system_date
 
-        frame = get_system_date()
+        frame = get_system_date(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x58\xfd"
 
-    def test_set_system_date_2026_03_07(self) -> None:
+    def test_get_system_date_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import get_system_date
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_system_date()  # type: ignore[call-arg]
+
+    def test_set_system_date_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
         from rigplane.commands import set_system_date
 
-        frame = set_system_date(2026, 3, 7)
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_system_date(2026, 3, 7, cmd_map=None)
+
+    def test_set_system_date_2026_03_07(self, cmd_map) -> None:
+        from rigplane.commands import set_system_date
+
+        frame = set_system_date(2026, 3, 7, cmd_map=cmd_map)
         # FE FE 98 E0 1A 05 01 58 20 26 03 07 FD
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x58\x20\x26\x03\x07\xfd"
 
-    def test_set_system_date_2000_01_01(self) -> None:
+    def test_set_system_date_2000_01_01(self, cmd_map) -> None:
         from rigplane.commands import set_system_date
 
-        frame = set_system_date(2000, 1, 1)
+        frame = set_system_date(2000, 1, 1, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x58\x20\x00\x01\x01\xfd"
 
-    def test_set_system_date_rejects_invalid_month(self) -> None:
+    def test_set_system_date_rejects_invalid_month(self, cmd_map) -> None:
         from rigplane.commands import set_system_date
 
         with pytest.raises(ValueError, match="Month must be 1-12"):
-            set_system_date(2026, 0, 1)
+            set_system_date(2026, 0, 1, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="Month must be 1-12"):
-            set_system_date(2026, 13, 1)
+            set_system_date(2026, 13, 1, cmd_map=cmd_map)
 
-    def test_set_system_date_rejects_invalid_day(self) -> None:
+    def test_set_system_date_rejects_invalid_day(self, cmd_map) -> None:
         from rigplane.commands import set_system_date
 
         with pytest.raises(ValueError, match="Day must be 1-31"):
-            set_system_date(2026, 3, 0)
+            set_system_date(2026, 3, 0, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="Day must be 1-31"):
-            set_system_date(2026, 3, 32)
+            set_system_date(2026, 3, 32, cmd_map=cmd_map)
 
-    def test_set_system_date_rejects_year_too_low(self) -> None:
+    def test_set_system_date_rejects_year_too_low(self, cmd_map) -> None:
         from rigplane.commands import set_system_date
 
         with pytest.raises(ValueError, match="Year must be 2000-2099"):
-            set_system_date(1999, 1, 1)
+            set_system_date(1999, 1, 1, cmd_map=cmd_map)
 
-    def test_set_system_date_rejects_year_too_high(self) -> None:
+    def test_set_system_date_rejects_year_too_high(self, cmd_map) -> None:
         from rigplane.commands import set_system_date
 
         with pytest.raises(ValueError, match="Year must be 2000-2099"):
-            set_system_date(2100, 1, 1)
+            set_system_date(2100, 1, 1, cmd_map=cmd_map)
 
-    def test_set_system_date_accepts_year_boundaries(self) -> None:
+    def test_set_system_date_accepts_year_boundaries(self, cmd_map) -> None:
         from rigplane.commands import set_system_date
 
         # Should accept 2000 and 2099
-        frame_2000 = set_system_date(2000, 1, 1)
+        frame_2000 = set_system_date(2000, 1, 1, cmd_map=cmd_map)
         assert frame_2000 == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x58\x20\x00\x01\x01\xfd"
 
-        frame_2099 = set_system_date(2099, 12, 31)
+        frame_2099 = set_system_date(2099, 12, 31, cmd_map=cmd_map)
         assert frame_2099 == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x58\x20\x99\x12\x31\xfd"
 
     def test_parse_system_date_response(self) -> None:
@@ -2553,14 +2603,14 @@ class TestSystemConfigCommands:
         assert month == 12
         assert day == 31
 
-    def test_system_date_roundtrip(self) -> None:
+    def test_system_date_roundtrip(self, cmd_map) -> None:
         from rigplane.commands import (
             parse_civ_frame,
             parse_system_date_response,
             set_system_date,
         )
 
-        frame = set_system_date(2025, 6, 15)
+        frame = set_system_date(2025, 6, 15, cmd_map=cmd_map)
         # Simulate radio echoing back the frame (swap addresses)
         response = b"\xfe\xfe" + bytes([frame[3], frame[2]]) + frame[4:]
         parsed = parse_civ_frame(response)
@@ -2569,42 +2619,42 @@ class TestSystemConfigCommands:
 
     # --- System Time (0x1A 0x05 0x01 0x59) ---
 
-    def test_get_system_time_frame(self) -> None:
+    def test_get_system_time_frame(self, cmd_map) -> None:
         from rigplane.commands import get_system_time
 
-        frame = get_system_time()
+        frame = get_system_time(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x59\xfd"
 
-    def test_set_system_time_16_45(self) -> None:
+    def test_set_system_time_16_45(self, cmd_map) -> None:
         from rigplane.commands import set_system_time
 
-        frame = set_system_time(16, 45)
+        frame = set_system_time(16, 45, cmd_map=cmd_map)
         # FE FE 98 E0 1A 05 01 59 16 45 FD
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x59\x16\x45\xfd"
 
-    def test_set_system_time_00_00(self) -> None:
+    def test_set_system_time_00_00(self, cmd_map) -> None:
         from rigplane.commands import set_system_time
 
-        frame = set_system_time(0, 0)
+        frame = set_system_time(0, 0, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x59\x00\x00\xfd"
 
-    def test_set_system_time_23_59(self) -> None:
+    def test_set_system_time_23_59(self, cmd_map) -> None:
         from rigplane.commands import set_system_time
 
-        frame = set_system_time(23, 59)
+        frame = set_system_time(23, 59, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x59\x23\x59\xfd"
 
-    def test_set_system_time_rejects_invalid_hour(self) -> None:
+    def test_set_system_time_rejects_invalid_hour(self, cmd_map) -> None:
         from rigplane.commands import set_system_time
 
         with pytest.raises(ValueError, match="Hour must be 0-23"):
-            set_system_time(24, 0)
+            set_system_time(24, 0, cmd_map=cmd_map)
 
-    def test_set_system_time_rejects_invalid_minute(self) -> None:
+    def test_set_system_time_rejects_invalid_minute(self, cmd_map) -> None:
         from rigplane.commands import set_system_time
 
         with pytest.raises(ValueError, match="Minute must be 0-59"):
-            set_system_time(12, 60)
+            set_system_time(12, 60, cmd_map=cmd_map)
 
     def test_parse_system_time_response(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_system_time_response
@@ -2616,14 +2666,14 @@ class TestSystemConfigCommands:
         assert hour == 16
         assert minute == 45
 
-    def test_system_time_roundtrip(self) -> None:
+    def test_system_time_roundtrip(self, cmd_map) -> None:
         from rigplane.commands import (
             parse_civ_frame,
             parse_system_time_response,
             set_system_time,
         )
 
-        frame = set_system_time(9, 5)
+        frame = set_system_time(9, 5, cmd_map=cmd_map)
         response = b"\xfe\xfe" + bytes([frame[3], frame[2]]) + frame[4:]
         parsed = parse_civ_frame(response)
         hour, minute = parse_system_time_response(parsed)
@@ -2631,51 +2681,51 @@ class TestSystemConfigCommands:
 
     # --- UTC Offset (0x1A 0x05 0x01 0x62) ---
 
-    def test_get_utc_offset_frame(self) -> None:
+    def test_get_utc_offset_frame(self, cmd_map) -> None:
         from rigplane.commands import get_utc_offset
 
-        frame = get_utc_offset()
+        frame = get_utc_offset(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x62\xfd"
 
-    def test_set_utc_offset_plus_05_30(self) -> None:
+    def test_set_utc_offset_plus_05_30(self, cmd_map) -> None:
         from rigplane.commands import set_utc_offset
 
-        frame = set_utc_offset(5, 30, False)
+        frame = set_utc_offset(5, 30, False, cmd_map=cmd_map)
         # FE FE 98 E0 1A 05 01 62 05 30 00 FD
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x62\x05\x30\x00\xfd"
 
-    def test_set_utc_offset_minus_08_00(self) -> None:
+    def test_set_utc_offset_minus_08_00(self, cmd_map) -> None:
         from rigplane.commands import set_utc_offset
 
-        frame = set_utc_offset(8, 0, True)
+        frame = set_utc_offset(8, 0, True, cmd_map=cmd_map)
         # FE FE 98 E0 1A 05 01 62 08 00 01 FD
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x62\x08\x00\x01\xfd"
 
-    def test_set_utc_offset_zero(self) -> None:
+    def test_set_utc_offset_zero(self, cmd_map) -> None:
         from rigplane.commands import set_utc_offset
 
-        frame = set_utc_offset(0, 0, False)
+        frame = set_utc_offset(0, 0, False, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x62\x00\x00\x00\xfd"
 
-    def test_set_utc_offset_max_positive(self) -> None:
+    def test_set_utc_offset_max_positive(self, cmd_map) -> None:
         from rigplane.commands import set_utc_offset
 
-        frame = set_utc_offset(14, 0, False)
+        frame = set_utc_offset(14, 0, False, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x05\x01\x62\x14\x00\x00\xfd"
 
-    def test_set_utc_offset_rejects_invalid_hours(self) -> None:
+    def test_set_utc_offset_rejects_invalid_hours(self, cmd_map) -> None:
         from rigplane.commands import set_utc_offset
 
         with pytest.raises(ValueError, match="hours must be 0-14"):
-            set_utc_offset(15, 0, False)
+            set_utc_offset(15, 0, False, cmd_map=cmd_map)
 
-    def test_set_utc_offset_rejects_invalid_minutes(self) -> None:
+    def test_set_utc_offset_rejects_invalid_minutes(self, cmd_map) -> None:
         from rigplane.commands import set_utc_offset
 
         with pytest.raises(ValueError, match="minutes must be 0/15/30/45"):
-            set_utc_offset(5, 10, False)
+            set_utc_offset(5, 10, False, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="minutes must be 0/15/30/45"):
-            set_utc_offset(5, 60, False)
+            set_utc_offset(5, 60, False, cmd_map=cmd_map)
 
     def test_parse_utc_offset_response_positive(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_utc_offset_response
@@ -2699,44 +2749,65 @@ class TestSystemConfigCommands:
         assert minutes == 0
         assert is_negative is True
 
-    def test_utc_offset_roundtrip(self) -> None:
+    def test_utc_offset_roundtrip(self, cmd_map) -> None:
         from rigplane.commands import (
             parse_civ_frame,
             parse_utc_offset_response,
             set_utc_offset,
         )
 
-        frame = set_utc_offset(9, 45, True)
+        frame = set_utc_offset(9, 45, True, cmd_map=cmd_map)
         response = b"\xfe\xfe" + bytes([frame[3], frame[2]]) + frame[4:]
         parsed = parse_civ_frame(response)
         hours, minutes, is_negative = parse_utc_offset_response(parsed)
         assert (hours, minutes, is_negative) == (9, 45, True)
 
     # --- Speech (0x13) ---
+    #
+    # commands/speech.py migrated onto the bound command map in MOR-2008
+    # (batch 1): ``get_speech`` now requires ``cmd_map``. IC-7610's own
+    # ``get_speech`` tuple is byte-identical to the deleted fallback's
+    # ``0x13``, so the expected frames below are unchanged.
 
-    def test_speech_all(self) -> None:
+    def test_speech_all(self, cmd_map) -> None:
         from rigplane.commands import get_speech
 
-        frame = get_speech(0)
+        frame = get_speech(0, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x13\x00\xfd"
 
-    def test_speech_freq(self) -> None:
+    def test_speech_freq(self, cmd_map) -> None:
         from rigplane.commands import get_speech
 
-        frame = get_speech(1)
+        frame = get_speech(1, cmd_map=cmd_map)
         assert b"\x13\x01" in frame
 
-    def test_speech_mode(self) -> None:
+    def test_speech_mode(self, cmd_map) -> None:
         from rigplane.commands import get_speech
 
-        frame = get_speech(2)
+        frame = get_speech(2, cmd_map=cmd_map)
         assert b"\x13\x02" in frame
 
-    def test_speech_invalid(self) -> None:
+    def test_speech_invalid(self, cmd_map) -> None:
         from rigplane.commands import get_speech
 
         with pytest.raises(ValueError, match="0, 1, or 2"):
-            get_speech(3)
+            get_speech(3, cmd_map=cmd_map)
+
+    def test_speech_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import get_speech
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_speech()  # type: ignore[call-arg]
+
+    def test_speech_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        from rigplane import IC_7610_ADDR
+        from rigplane.commands import get_speech
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_speech(0, to_addr=IC_7610_ADDR, cmd_map=None)
 
     def test_speech_cmd_map_prefers_set_speech_key(self) -> None:
         """Rig profiles may expose set_speech (wfview Set-only) instead of get_speech."""
@@ -2744,35 +2815,36 @@ class TestSystemConfigCommands:
         from rigplane.command_map import CommandMap
         from rigplane.commands import get_speech
 
-        cm = CommandMap({"set_speech": (0x13,)})
-        assert get_speech(0, to_addr=IC_7610_ADDR, cmd_map=cm) == get_speech(
-            0, to_addr=IC_7610_ADDR
+        cm_get = CommandMap({"get_speech": (0x13,)})
+        cm_set = CommandMap({"set_speech": (0x13,)})
+        assert get_speech(0, to_addr=IC_7610_ADDR, cmd_map=cm_set) == get_speech(
+            0, to_addr=IC_7610_ADDR, cmd_map=cm_get
         )
 
     # --- Transceiver ID (0x19 0x00) ---
 
-    def test_get_transceiver_id(self) -> None:
+    def test_get_transceiver_id(self, cmd_map) -> None:
         from rigplane.commands import get_transceiver_id
 
-        frame = get_transceiver_id()
+        frame = get_transceiver_id(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x19\x00\xfd"
 
     # --- XFC Status (0x1C 0x02) ---
 
-    def test_get_xfc_status(self) -> None:
+    def test_get_xfc_status(self, cmd_map) -> None:
         from rigplane.commands import get_xfc_status
 
-        frame = get_xfc_status()
+        frame = get_xfc_status(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1c\x02\xfd"
 
-    def test_set_xfc_status_on(self) -> None:
+    def test_set_xfc_status_on(self, cmd_map) -> None:
         from rigplane.commands import set_xfc_status
 
-        frame = set_xfc_status(True)
+        frame = set_xfc_status(True, cmd_map=cmd_map)
         assert b"\x1c\x02\x01" in frame
 
-    def test_set_xfc_status_off(self) -> None:
+    def test_set_xfc_status_off(self, cmd_map) -> None:
         from rigplane.commands import set_xfc_status
 
-        frame = set_xfc_status(False)
+        frame = set_xfc_status(False, cmd_map=cmd_map)
         assert b"\x1c\x02\x00" in frame

--- a/tests/test_commands_extended.py
+++ b/tests/test_commands_extended.py
@@ -105,46 +105,80 @@ class TestPreamp:
 
 
 class TestCw:
-    def test_send_short(self):
-        frames = send_cw("CQ CQ")
+    """commands/cw.py migrated onto the bound command map in MOR-2008
+    (batch 1): both builders now require ``cmd_map``. IC-7610's own
+    ``send_cw``/``stop_cw`` tuples are byte-identical to the deleted
+    fallback's ``0x17``, so the expected frames below are unchanged.
+    """
+
+    def test_send_short(self, cmd_map):
+        frames = send_cw("CQ CQ", cmd_map=cmd_map)
         assert len(frames) == 1
         parsed = parse_civ_frame(frames[0])
         assert parsed.command == 0x17
         assert parsed.data == b"CQ CQ"
 
-    def test_send_long_splits(self):
+    def test_send_long_splits(self, cmd_map):
         text = "A" * 65
-        frames = send_cw(text)
+        frames = send_cw(text, cmd_map=cmd_map)
         assert len(frames) == 3
         # First chunk 30, second 30, third 5
         assert len(parse_civ_frame(frames[0]).data) == 30
         assert len(parse_civ_frame(frames[1]).data) == 30
         assert len(parse_civ_frame(frames[2]).data) == 5
 
-    def test_send_uppercased(self):
-        frames = send_cw("cq cq")
+    def test_send_uppercased(self, cmd_map):
+        frames = send_cw("cq cq", cmd_map=cmd_map)
         parsed = parse_civ_frame(frames[0])
         assert parsed.data == b"CQ CQ"
 
-    def test_stop_cw(self):
-        frame = stop_cw()
+    def test_stop_cw(self, cmd_map):
+        frame = stop_cw(cmd_map=cmd_map)
         parsed = parse_civ_frame(frame)
         assert parsed.command == 0x17
         assert parsed.data == b"\xff"
 
+    def test_send_cw_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            send_cw("CQ")  # type: ignore[call-arg]
+
+    def test_stop_cw_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            stop_cw(cmd_map=None)
+
 
 class TestPowerOnOff:
-    def test_power_on(self):
-        frame = power_on()
+    """commands/power.py migrated onto the bound command map in MOR-2008
+    (batch 1): all three builders now require ``cmd_map``. IC-7610's own
+    tuples are byte-identical to the deleted fallback's ``0x18``, so the
+    expected frames below are unchanged.
+    """
+
+    def test_power_on(self, cmd_map):
+        frame = power_on(cmd_map=cmd_map)
         parsed = parse_civ_frame(frame)
         assert parsed.command == 0x18
         assert parsed.data == b"\x01"
 
-    def test_power_off(self):
-        frame = power_off()
+    def test_power_off(self, cmd_map):
+        frame = power_off(cmd_map=cmd_map)
         parsed = parse_civ_frame(frame)
         assert parsed.command == 0x18
         assert parsed.data == b"\x00"
+
+    def test_power_on_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            power_on()  # type: ignore[call-arg]
+
+    def test_power_off_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            power_off(cmd_map=None)
 
 
 class TestParseAckNak:

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -270,3 +270,84 @@ async def test_get_dual_watch_reply_marker_comes_from_the_map(
         to_addr=0xE0, from_addr=0xA2, command=command9700, sub=0x12, data=b"\x01"
     )
     assert await _get_dual_watch_answering(radio_9700, wrong_sub_9700) is False
+
+
+# system.py's date/time/UTC-offset getters (MOR-2008 batch 1) are this
+# file's second keystone case: like get_dual_watch above, they cannot
+# register in MATCHER_BACKED_GETTERS, since they parse through their own
+# module-level parse_system_date_response/parse_system_time_response/
+# parse_utc_offset_response rather than _get_bcd_level/_get_bool_value.
+# Each parser takes the map-derived prefix as a keyword (default: the
+# shared IC-7610-shaped constant, kept only so pre-migration tests that
+# never passed one still work) -- CoreRadio.get_system_date/time/utc_offset
+# must pass their own profile's prefix through via _expect_shape, not rely
+# on that default.
+_DATE_TIME_UTC_CASES: tuple[tuple[str, str, bytes], ...] = (
+    ("get_system_date", "get_system_date", b"\x00\x94"),
+    ("get_system_time", "get_system_time", b"\x00\x95"),
+    ("get_utc_offset", "get_utc_offset", b"\x00\x96"),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "radio_method,map_key,ic7300_prefix",
+    _DATE_TIME_UTC_CASES,
+    ids=[case[0] for case in _DATE_TIME_UTC_CASES],
+)
+async def test_date_time_utc_reply_prefix_comes_from_the_map(
+    radio_method: str,
+    map_key: str,
+    ic7300_prefix: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IC-7300's own extended-address prefix must reach the reply parser.
+
+    Manually confirmed red for the half-done shape: pinning the parser's
+    ``prefix`` default (IC-7610-shaped ``0x01 0x58``/``0x01 0x59``/
+    ``0x01 0x62``) instead of ``_expect_shape``'s map-derived one makes the
+    IC-7300 case below raise ``ValueError`` (prefix mismatch) on a reply
+    that correctly echoes IC-7300's real ``0x00 0x94``/``0x95``/``0x96`` --
+    exactly the "requests moved, replies not" failure mode this file
+    exists to make impossible (plan §7): the request would already be
+    right (``self._commands.<method>`` uses the map), only the reply
+    parse would still expect IC-7610's bytes.
+    """
+    ic7300 = _civ_rig_configs()["IC-7300"].to_profile()
+    command, sub, prefix = decode_wire_tuple(ic7300.command_map.get(map_key))
+    assert (command, sub, prefix) == (0x1A, 0x05, ic7300_prefix)
+    radio = CoreRadio("198.51.100.1", profile=ic7300)
+
+    async def _fake_expect(civ: bytes, **kwargs: Any) -> Any:
+        return CivFrame(
+            to_addr=0xE0,
+            from_addr=0x94,
+            command=command,
+            sub=sub,
+            data=prefix + b"\x00" * 4,
+        )
+
+    monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect)
+    monkeypatch.setattr(radio, "_check_connected", lambda: None)
+
+    # A real reply carrying IC-7300's own prefix must parse without error.
+    await getattr(radio, radio_method)()
+
+    # A reply carrying the WRONG (IC-7610-shaped) prefix must not parse as
+    # if it were IC-7300's -- proves the prefix used is this profile's own,
+    # not the parser's hardcoded default.
+    wrong_prefix = b"\x01" + ic7300_prefix[1:]
+    assert wrong_prefix != prefix
+
+    async def _fake_expect_wrong(civ: bytes, **kwargs: Any) -> Any:
+        return CivFrame(
+            to_addr=0xE0,
+            from_addr=0x94,
+            command=command,
+            sub=sub,
+            data=wrong_prefix + b"\x00" * 4,
+        )
+
+    monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect_wrong)
+    with pytest.raises(ValueError, match="prefix mismatch"):
+        await getattr(radio, radio_method)()

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -269,15 +269,12 @@ class TestCommandOverrides:
     def test_get_quick_split(self, cmdmap):
         assert cmdmap.get("get_quick_split") == (0x1A, 0x05, 0x00, 0x30)
 
-    def test_quick_split(self, cmdmap):
-        """Bare ``quick_split`` key (D2, MOR-2014) -- same bytes as the
-        get_/set_ aliases; the deleted fallback used to send 0x33 (split
-        lock, not quick split, on this radio -- a recorded divergence, not
-        a bug). No builder resolves this bare key any more since MOR-2007
-        ruling 2 deleted the one-shot quick_split()/quick_dual_watch()
-        triggers it was written for; left declared regardless (see
-        rigs/ic7300.toml's own comment on this row)."""
-        assert cmdmap.get("quick_split") == (0x1A, 0x05, 0x00, 0x30)
+    # The bare ``quick_split``/``quick_dual_watch`` keys this class used to
+    # pin here are deleted (MOR-2008 batch 1): no builder has resolved
+    # either since MOR-2007 ruling 2 replaced the one-shot
+    # quick_split()/quick_dual_watch() triggers they were written for with
+    # real get_/set_ pairs, so they had no reader left -- see
+    # rigs/ic7300.toml's own comment on this section.
 
     def test_get_dash_ratio(self, cmdmap):
         """D2, MOR-2014: control 0161, IC-7300 Advanced Manual (11a) p.19-6;
@@ -338,12 +335,23 @@ class TestCommandOverrides:
         assert cmdmap.get("get_scope_wave") == (0x27, 0x00)
 
     def test_get_speech_cmd_map_uses_set_speech(self, cmdmap):
-        """Profile exposes set_speech; get_speech() must resolve the same opcode."""
+        """Profile exposes set_speech; get_speech() must resolve the same opcode.
+
+        commands/speech.py migrated onto the bound command map in MOR-2008
+        (batch 1): there is no more bare, cmd_map-less call to compare
+        against, so this pins IC-7300's real map (which declares
+        ``set_speech``, not ``get_speech``) against a hand-built
+        ``get_speech``-only map instead -- both must resolve to the
+        identical ``0x13`` opcode.
+        """
+        from rigplane.command_map import CommandMap
         from rigplane.commands import get_speech
 
-        with_map = get_speech(2, to_addr=0x94, cmd_map=cmdmap)
-        bare = get_speech(2, to_addr=0x94)
-        assert with_map == bare
+        via_set_speech = get_speech(2, to_addr=0x94, cmd_map=cmdmap)
+        via_get_speech = get_speech(
+            2, to_addr=0x94, cmd_map=CommandMap({"get_speech": (0x13,)})
+        )
+        assert via_set_speech == via_get_speech
 
     def test_scope_edge3_6mhz_is_0x20_not_sequential(self, cmdmap):
         """wfview uses 0x18, 0x19, 0x20 for 6 MHz edges (skip 0x1A-0x1F)."""

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2699,13 +2699,16 @@ class TestNoShippedProfileUsesAbsentSpellingYet:
 
 class TestIc7300DeclaresAbsentCommands:
     """MOR-2014 (D2): IC-7300 is the first shipped profile to use the
-    ``{ absent = "<source>" }`` spelling, for 28 commands the IC-7300
+    ``{ absent = "<source>" }`` spelling, for the commands the IC-7300
     Advanced Manual (11a) command table (pp.19-2..19-8) confirms have no
-    row on this radio (27 at D2 time; MOR-2007 ruling 1 later split
-    ``set_dual_watch`` into ``set_dual_watch_off``/``set_dual_watch_on``,
-    +1 net). Pinned by name, not just count, so a future D2 pass on
-    another command can't silently swap one of these for a different one
-    and still pass a bare-count check.
+    row on this radio -- 27 at D2 time; MOR-2007 ruling 1 later split
+    ``set_dual_watch`` into ``set_dual_watch_off``/``set_dual_watch_on``
+    (+1, to 28), then MOR-2008 batch 1 deleted the dead bare
+    ``quick_dual_watch`` entry alongside the bare ``quick_split`` row it
+    was declared next to (-1, back to 27 -- a different 27 than D2's, not
+    the same set reverted). Pinned by name, not just count, so a future D2
+    pass on another command can't silently swap one of these for a
+    different one and still pass a bare-count check.
     """
 
     _EXPECTED_ABSENT = frozenset(
@@ -2738,7 +2741,8 @@ class TestIc7300DeclaresAbsentCommands:
             "get_powerstat",
             "get_quick_dual_watch",
             "set_quick_dual_watch",
-            "quick_dual_watch",
+            # Bare "quick_dual_watch" removed here (MOR-2008 batch 1): no
+            # builder resolved it, only get_/set_quick_dual_watch above do.
             "get_rx_antenna_ant2",
             "set_rx_antenna_ant2",
         }
@@ -2756,15 +2760,18 @@ class TestIc7300DeclaresAbsentCommands:
 
 class TestIc9700DeclaresAbsentCommands:
     """MOR-2015 (D2): IC-9700 is filled with the ``{ absent = "<source>" }``
-    spelling for 26 commands the IC-9700 CI-V Reference Guide (Icom, 2019)
-    confirms have no row on this radio -- 10 unique gap-list base names
-    (af_mute, data2/3_mod_input, digisel, digisel_shift, drive_gain,
-    main_sub_tracking, powerstat, quick_dual_watch, rx_antenna_ant2), plus
-    civ_output_ant (a copied-but-wrong 1A05 address with no real
-    replacement) and the nb_depth/nb_width pair (no single global control,
-    per-band only). Pinned by name, not just count, so a future D2 pass on
-    another command can't silently swap one of these for a different one
-    and still pass a bare-count check.
+    spelling for 25 commands the IC-9700 CI-V Reference Guide (Icom, 2019)
+    confirms have no row on this radio (26 at D2 time; MOR-2008 batch 1
+    later deleted the dead bare ``quick_dual_watch`` entry, -1 net -- see
+    ``rigs/ic9700.toml``'s own comment on that section) -- 10 unique
+    gap-list base names (af_mute, data2/3_mod_input, digisel,
+    digisel_shift, drive_gain, main_sub_tracking, powerstat,
+    quick_dual_watch, rx_antenna_ant2), plus civ_output_ant (a
+    copied-but-wrong 1A05 address with no real replacement) and the
+    nb_depth/nb_width pair (no single global control, per-band only).
+    Pinned by name, not just count, so a future D2 pass on another
+    command can't silently swap one of these for a different one and
+    still pass a bare-count check.
     """
 
     _EXPECTED_ABSENT = frozenset(
@@ -2792,7 +2799,8 @@ class TestIc9700DeclaresAbsentCommands:
             "get_powerstat",
             "get_quick_dual_watch",
             "set_quick_dual_watch",
-            "quick_dual_watch",
+            # Bare "quick_dual_watch" removed here (MOR-2008 batch 1): no
+            # builder resolved it, only get_/set_quick_dual_watch above do.
             "get_rx_antenna_ant2",
             "set_rx_antenna_ant2",
         }

--- a/tests/test_undeclared_command_policy.py
+++ b/tests/test_undeclared_command_policy.py
@@ -36,29 +36,6 @@ from rigplane.runtime.radio import CoreRadio
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 RIGS_DIR = REPO_ROOT / "rigs"
 
-# ``scan_set_df_span`` was this file's original choice, but MOR-2007
-# (ruling 4, D2 residuals) declared it on IC-7300/IC-7610/IC-9700/IC-705,
-# so it is no longer universally undeclared. ``system_date`` (the key
-# ``system.py: get_system_date``/``set_system_date`` resolve via
-# ``_builders.py: _build_ctl_mem_get``'s ``cmd_name=``) takes over: no
-# current rig TOML declares or records it absent -- confirmed by
-# ``tests/test_profile_command_coverage.py`` recording it as a universal
-# gap across every shipped CI-V profile (a plain
-# ``grep -rn system_date rigs/*.toml`` also turns up nothing, since every
-# profile's own menu address lives under ``get_/set_system_date``, not
-# this internal template key). Using a real, un-synthesised name here
-# means this file exercises the same undeclared surface the coverage
-# guard tracks, rather than a name invented only for this test.
-#
-# NOT ``get_powerstat``: MOR-2014 (D2) declared it absent on IC-7300 (no
-# read marker in the manual; live bench answered NAK), so it moved from
-# state 3 (neither declared nor declared absent) to state 2 (declared
-# absent) for this profile -- ``TestDeclaredAbsentRefusal`` and
-# ``tests/test_supports_command.py::
-# TestSupportsCommandReconciliation.test_known_but_declared_absent_command_returns_false``
-# cover that state directly.
-_UNIVERSALLY_UNDECLARED = "system_date"
-
 
 class TestDeclaredAbsentRefusal:
     """State 2: declared absent, via ``absent_command_names``."""
@@ -152,6 +129,11 @@ class TestCoreRadioWiring:
         config = discover_rigs(RIGS_DIR)["IC-7300"]
         return config.to_profile()
 
+    @staticmethod
+    def _x6100_profile():
+        config = discover_rigs(RIGS_DIR)["X6100"]
+        return config.to_profile()
+
     def test_declared_absent_source_reaches_the_refusal(self) -> None:
         profile = self._ic7300_profile()
         assert "set_agc" in profile.command_names, (
@@ -180,14 +162,26 @@ class TestCoreRadioWiring:
             radio._commands.set_agc(0, to_addr=0x94)  # noqa: SLF001
 
     def test_state_three_logs_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        profile = self._ic7300_profile()
-        assert _UNIVERSALLY_UNDECLARED not in profile.command_names
-        assert _UNIVERSALLY_UNDECLARED not in profile.absent_command_names
+        """State 3 through the real ``CoreRadio``/``BoundCommands`` wiring.
+
+        Uses X6100, not IC-7300: MOR-2008 batch 1 moved
+        ``system.py: get_system_date`` onto the direction-prefixed
+        ``get_system_date`` key (the owner ruling -- see that module's
+        docstring), which IC-7300/IC-7610/IC-9700/IC-705 all now declare,
+        so IC-7300 no longer has a state-3 case for this builder.
+        X6100/X6200 do not declare a system-date CI-V address at all,
+        which is exactly state 3 (neither declared nor declared absent) --
+        pinned by ``tests/profile_command_coverage_gaps.txt``'s
+        ``get_system_date`` gap row for both.
+        """
+        profile = self._x6100_profile()
+        assert "get_system_date" not in profile.command_names
+        assert "get_system_date" not in profile.absent_command_names
         radio = CoreRadio("127.0.0.1", profile=profile)
         with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
             with pytest.raises(CommandError, match="not supported by this radio"):
-                radio._commands.get_system_date(to_addr=0x94)  # noqa: SLF001
-        assert _UNIVERSALLY_UNDECLARED in caplog.text
+                radio._commands.get_system_date(to_addr=0x70)  # noqa: SLF001
+        assert "get_system_date" in caplog.text
         assert "not recorded as absent" in caplog.text
 
     def test_declared_command_is_unaffected(self) -> None:


### PR DESCRIPTION
## Summary

MOR-2008 batch 1 of "migrate the 12 zero-divergence modules in batches", `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N. Migrates `system.py`, `cw.py`, `speech.py` and `power.py` (26 builders total) onto the required-`cmd_map` contract established by `config.py` (#2827), `levels.py` (#2832), `vfo.py` (#2846), `ptt.py` (#2851) and `scope.py` (#2860).

## Guardrail exception requested — hard ceiling crossed on BOTH files and lines

**Figures (re-derived at this head via `git diff origin/main...HEAD --numstat`): 24 files, 851 insertions + 666 deletions = 1517 changed lines.** Over both dimensions of the hard ceiling (10 files / 1000 lines) — the first PR in this migration series to cross both at once, not just one. Whitespace-adjusted (`git diff -w`): 24 files, 1359 changed lines — still over both. This is not a formatting artifact like some earlier PRs in this series; it is a genuinely larger change, four modules bundled into one batch as the ticket asked for ("batches allowed, not one-per-commit").

Why it is one unit of work rather than four: the four modules share the same mechanical contract (delete the fallback branch, require `cmd_map`, move call sites onto the binder) and the same generated census files (`tests/command_map_parity_uncovered.txt`, `tests/profile_command_coverage_gaps.txt`) that a split would need to regenerate and reconcile twice instead of once. `system.py` alone accounts for the majority of the size (446 of the 1517 lines, mostly its 20 builders each losing one indentation level plus the six date/time/UTC builders' expanded docstring/parser changes); `cw.py`/`speech.py`/`power.py` together account for far less.

**A concrete split is available if the owner prefers it over the exception:** `system.py` alone in one PR, `cw.py`+`speech.py`+`power.py` together in a second, smaller one. I did not do this preemptively because the work was already complete and fully verified as one unit by the time the combined size became clear; splitting now means re-doing the census regeneration and re-running the full targeted battery twice. Flagging the option rather than deciding it myself.

Per-file breakdown of the largest contributors: `src/rigplane/commands/system.py` (446), `tests/test_commands.py` (300), `src/rigplane/runtime/radio.py` (86), `tests/test_undeclared_command_policy.py` (50), `tests/test_commands_extended.py` (58), `tests/test_rig_loader.py` (42), `tests/test_response_shape_from_profile.py` (81, all additions — a new keystone test), `tests/test_rig_ic7300.py` (34), `tests/command_map_parity_uncovered.txt` (64, regenerated census), `rigs/ic9700.toml` (16), `src/rigplane/commands/power.py` (60), `src/rigplane/commands/speech.py` (41), `src/rigplane/commands/cw.py` (48).

Requesting the owner's exception, the same as `config.py` (#2827, 11/1148), `levels.py` (#2832, 20/2342), `vfo.py` (#2846, 30/2210) and `scope.py` (#2860, 8/1246) before it.

## Contract fulfillment

All 26 public builders — `get_transceiver_id`, `get_band_edge_freq`, `get_/set_tuner_status`, `get_/set_xfc_status`, `get_/set_tx_freq_monitor`, `get_/set_rit_frequency`, `get_/set_rit_status`, `get_/set_rit_tx_status`, `get_/set_system_date`, `get_/set_system_time`, `get_/set_utc_offset` (system.py, 20); `send_cw`/`stop_cw` (cw.py, 2); `get_speech` (speech.py, 1); `get_powerstat`/`power_on`/`power_off` (power.py, 3) — now require `cmd_map` (keyword-only, no default), carry `@expose_command_key` + `@require_cmd_map`, and call `_build_from_map` directly with no fallback branch left.

**Divergence file, verified rather than assumed:** these four modules' combined share was zero rows before this migration (`tests/command_map_parity_divergences.txt` is empty and stays empty) — 20 of the 26 builders never had a divergence to begin with, because every declaring CI-V profile's tuple already matched the deleted fallback's bytes exactly (verified by grep across `rigs/*.toml` before deleting each fallback).

**Constant census:** eleven now-dead constants deleted from `commands/_frame.py` (`_CMD_RIT`, `_CMD_TRANSCEIVER_ID`, `_SUB_TRANSCEIVER_ID`, `_SUB_TUNER_STATUS`, `_SUB_XFC_STATUS`, `_SUB_TX_FREQ_MONITOR`, `_SUB_RIT_FREQ`, `_SUB_RIT_STATUS`, `_SUB_RIT_TX_STATUS`, `_CMD_SEND_CW`, `_CMD_SPEECH`) plus the now-fully-dead `_build_ctl_mem_get` template from `commands/_builders.py` — each verified by a whole-repo grep to have no reader left outside the deleted fallback branches. `_CMD_PTT` was checked and kept: `tests/test_radio.py` imports it directly for unrelated synthetic-frame tests, so it is not this module's to delete. `_CMD_BAND_EDGE`/`_CMD_POWER_CTRL`/`_CMD_CTL_MEM`/`_SUB_CTL_MEM` were checked and kept too: still read directly by `freq.py`'s/`power.py`'s own response parsers or by other not-yet-migrated modules. Three other modules' docstrings (`config.py`, `levels.py`, `vfo.py`) cross-referenced `system.py` as "unmigrated" or `_build_ctl_mem_get` as "kept because of it" — all three updated to reflect the current state, along with `ptt.py`'s docstring (which incorrectly claimed `_CMD_PTT` was one of this module's dead constants during drafting; corrected to describe why it survives).

**Call sites** moved onto `self._commands.<builder>` in `runtime/radio.py` (26 call sites, one per builder; the three date/time/UTC getters additionally route their reply through `self._expect_shape` — see the ruling below).

## The ruling: `system.py`'s date/time/UTC builders move onto the direction-prefixed keys

`get_system_date`/`set_system_date`, `get_system_time`/`set_system_time`, `get_utc_offset`/`set_utc_offset`'s pre-migration `cmd_map` branches resolved the bare keys `"system_date"`/`"system_time"`/`"utc_offset"`. No profile TOML has ever declared a bare entry under those names — all four declaring profiles (IC-705, IC-7300, IC-7610, IC-9700) spell the direction-prefixed `get_/set_system_date` etc. — so those branches raised `KeyError` for every profile a real `CommandMap` ever reached. This was invisible to the divergence sweep (which requires both branches to successfully build a frame before it can compare them): `tests/command_map_parity_uncovered.txt` recorded it as a `gap` on every profile for the bare names, never a divergence.

The fix: the six builders now resolve the direction-prefixed keys the TOML files actually declare (the rejected bare-key alternative stays rejected, per the ruling). **This is an intended byte-level behaviour change on IC-7300, not a regression.** `rigs/ic7610.toml` declares `0x01 0x58`/`0x59`/`0x62` — byte-identical to the deleted fallback's hardcoded constants, which is presumably the radio those constants were originally built against, so nothing changes there. `rigs/ic7300.toml` declares its own family numbers, `0x00 0x94`/`0x95`/`0x96` — genuinely different addresses. Once `cmd_map` becomes required and the bare-key dead end is closed, IC-7300 sends its own correct extended addresses for the first time instead of never successfully sending anything through this path (or, in the one production caller, never being reachable with a real map at all). No divergence row existed for this pre-epic: it was never a divergence, only ever a gap, since the two branches never both produced a frame to compare.

Response parsing moves with the request, per Steps 5..N's own requirement: `parse_system_date_response`/`parse_system_time_response`/`parse_utc_offset_response` now take the map-derived `prefix` as a keyword (default: the shared IC-7610-shaped constant, kept only so tests that predate this migration and never passed one keep working unchanged). `runtime/radio.py: CoreRadio.get_system_date`/`get_system_time`/`get_utc_offset` derive `prefix` via `self._expect_shape(...)` — the same `(command, sub, prefix)` triple `BoundCommands.expect` decodes from the identical map entry the request used — and pass it through. Manually confirmed red for the half-done shape: reverting the `get_system_date` call site to the bare `parse_system_date_response(resp)` (no `prefix=`) makes the new keystone test below fail on IC-7300 with a prefix-mismatch `ValueError`, exactly the "requests moved, replies not" failure mode the plan's keystone test exists to make impossible.

**Data-side ruling, folded into this batch:** the orphaned bare `quick_split`/`quick_dual_watch` rows in `rigs/ic7300.toml` and `rigs/ic9700.toml` are deleted outright. No builder has resolved either since MOR-2007 ruling 2 replaced the one-shot `quick_split()`/`quick_dual_watch()` triggers they were written for with real `get_/set_` pairs; the prefixed rows (declared separately, same addresses) already carry the recorded D2 sources, so nothing is lost. Three tests that pinned the dead bare rows directly (`tests/test_rig_ic7300.py::TestCommandOverrides::test_quick_split`, and the `_EXPECTED_ABSENT` frozensets in `tests/test_rig_loader.py`'s IC-7300 and IC-9700 "declares absent commands" classes) updated accordingly — figures re-derived, not carried forward (IC-7300's absent-count docstring: 27 at D2 time -> 28 after MOR-2007 ruling 1's dual-watch split -> 27 again after this deletion, a different 27, not a reversion; IC-9700's: 26 -> 25).

## Sweep + local/remote verification

**Corrected sweep** ("tests calling a migrated builder," both bare-name and `commands.<builder>(...)`/`raw_commands.<builder>(...)` attribute-call shapes) as a standalone AST script across every file in `tests/` and `src/`: 5 hits in `tests/`, all deliberate (`test_get_band_edge_freq_requires_cmd_map`, `test_get_system_date_requires_cmd_map`, `test_speech_requires_cmd_map`, `test_send_cw_requires_cmd_map`, `test_power_on_requires_cmd_map` — one negative "cmd_map is required" test per module/class, proving the Q6 `TypeError`); 0 hits in `src/`.

**Keystone extension:** the three date/time/UTC getters cannot register in `tests/test_response_shape_from_profile.py`'s `MATCHER_BACKED_GETTERS` table (they parse through their own module-level functions, not `_get_bcd_level`/`_get_bool_value`), so they get a bespoke parametrized test (`test_date_time_utc_reply_prefix_comes_from_the_map`), the same shape `vfo.py`'s `get_dual_watch` keystone case used in module 3 — proves, per builder, that a reply carrying IC-7300's own prefix parses correctly and a reply carrying IC-7610's prefix instead is rejected.

**Local (targeted, per instructions):** `test_commands.py`, `test_commands_extended.py`, `test_command_map_integration.py`, `test_command_map_parity.py`, `test_profile_command_coverage.py`, `test_profile_command_binding.py`, `test_response_shape_from_profile.py`, `test_undeclared_command_policy.py`, `test_rig_ic7300.py`, `test_rig_ic7610.py`, `test_rig_ic705_mor1540.py`, `test_rig_loader.py`, `test_naming_parity.py`, `test_handlers_coverage.py`, `test_radio.py`, `test_supports_command.py`, `tests/integration/test_rit_tuner_integration.py` — all green (1999 passed, 73 skipped, 12 xfailed across the combined run), plus `ruff check`/`ruff format --check` and `lint-imports` clean.

**Remote full-suite backstop**, run once, foreground, to completion on the dedicated remote test runner: **11246 passed, 84 skipped, 48 xfailed, 2 failed, 324s.** `ruff check`: all checks passed. Both failures investigated and confirmed pre-existing/unrelated, not re-run per the "never re-launch a duplicate" instruction:
- `tests/test_icom7610_serial_radio.py::test_serial_link_down_detected_when_healthy_flag_stays_stuck_true` crashed its xdist worker (`node down`). This is the same test *file* crashing a *different* individual test than the earlier `vfo.py` and `scope.py` PRs in this series each hit — three separate crashes in three separate PRs, always a different test in the file, always passing standalone. All 49 tests in the file pass together locally. A follow-up (test-reliability fix, not a production regression) is already tracked outside this PR.
- `tests/test_radio.py::TestToneTsqlDualRxCmd29Guard::test_sub_receiver_get_uses_vfo_select_fallback` failed on a real `asyncio.TimeoutError` inside `_civ_rx.py`'s CI-V response wait — under 14-worker parallel load, not something this diff touches (`get_repeater_tone`, `_dual_rx_runtime.py` and `_civ_rx.py` are all outside this PR's changed files). Passes locally both in isolation and as part of the full 293-test file.

## Parity/coverage deltas — every line explained

**`tests/command_map_parity_divergences.txt`**: no diff (already empty, stays empty).

**`tests/command_map_parity_uncovered.txt`** (re-derived, not carried forward): `builders_compared` 105 -> 79 (-26, the 26 migrated builders drop out of the dual-implementation comparison), `dual_implementation_sites` 70 -> 46 (-24), `sites_compared` 65 -> 46 (-19), `frames_identical` 755 -> 667 (-88, every profile pairing that used to run both branches for a now-migrated builder), `profile_builder_map_gaps` 434 -> 310 (-124, the two-sided comparison this file stops attempting once a builder requires the map), `public_builders` unchanged at 228 (no names added or removed by this PR). 26 new `requires-map` rows (one per migrated builder). 23 `gap` rows removed for 20 of the 26 migrated builder names (`get_band_edge_freq`, `get_powerstat`, `get_rit_frequency`, `get_rit_status`, `get_rit_tx_status`, `get_speech`, `get_transceiver_id`, `get_tuner_status`, `get_tx_freq_monitor`, `get_xfc_status`, `power_off`, `power_on`, `send_cw`, `set_rit_frequency`, `set_rit_status`, `set_rit_tx_status`, `set_tuner_status`, `set_tx_freq_monitor`, `set_xfc_status`, `stop_cw` — FTX-1/TX-500 as cat-only profiles and X6100/X6200 as profiles that never declared these; the "gap" mechanism only fires for a builder still being probed, and a `requires-map` builder stops being probed) plus the bare `system_date`/`system_time`/`utc_offset` names (3 rows, each naming all 8 profiles), since no builder resolves those bare names any more to produce a gap either. Zero new gap rows. 5 `unpinned` rows removed (`_builders.py:_build_ctl_mem_get`, now deleted; `power.py:get_powerstat` and `system.py:set_system_date`/`set_system_time`/`set_utc_offset`, now `requires-map` instead). Gap rows for `quick_split`/`quick_dual_watch` on FTX-1/TX-500/X6100/X6200 unaffected (those never touched the bare IC-7300/IC-9700 rows this PR deletes).

**`tests/profile_command_coverage_gaps.txt`** (re-derived): the direction-prefixed `get_/set_system_date`/`get_/set_system_time`/`get_/set_utc_offset` gap rows for X6100/X6200 (6 new rows, 2 profiles x 3 commands) are genuinely new — the first time this migration's own builders reach these names, and X6100/X6200 do not declare a system-date/time/UTC-offset CI-V address at all (a real, pre-existing documentation gap on those two profiles, not something this PR introduces). Stale allowlist rows for the bare `system_date`/`system_time`/`utc_offset` names removed (18 rows, 6 profiles x 3 names) since no builder resolves those names any more.

Internal-identifier self-check across the full diff and this PR body: performed, empty. The remote backstop ran on the dedicated remote test runner; its host is not named here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
