### PR TITLE
docs: fix ReceiverState/ScopeControlsState import path in public-api-surface

### DIFF
--- a/docs/api/public-api-surface.md
+++ b/docs/api/public-api-surface.md
@@ -16,7 +16,7 @@ This page defines the **officially supported** public API of `rigplane`. Use the
 | `Radio` | Protocol for radio control; use with `create_radio()` for type-safe, backend-agnostic code. |
 | `IcomRadio` | Legacy LAN-specific class; use for direct IC-7610 LAN control or when migrating from older code. |
 | `LanBackendConfig`, `SerialBackendConfig`, `BackendConfig` | Backend configuration for `create_radio()`. |
-| `RadioState`, `ReceiverState`, `ScopeControlsState` | State types exposed by the radio. |
+| `RadioState` | Radio state snapshot. Its component types `ReceiverState` and `ScopeControlsState` are not re-exported from `rigplane`; import them from `rigplane.core.radio_state`. |
 | `RadioProfile`, `get_radio_profile`, `resolve_radio_profile` | Model/profile resolution. |
 | `RADIOS`, `RadioModel`, `get_civ_addr` | Radio model registry and CI-V address lookup. |
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -140,3 +140,22 @@ def test_internal_symbols_still_importable() -> None:
             f"{name} should still be importable from rigplane"
         )
         assert name not in rigplane.__all__, f"{name} should NOT be in __all__"
+
+
+def test_component_state_types_not_top_level() -> None:
+    """Pin the docs/api/public-api-surface.md claim about component state types.
+
+    ReceiverState and ScopeControlsState are components of RadioState and
+    importable from rigplane.core.radio_state. They are not re-exported from
+    the top-level package: the Form F tier-1 sealing (#1200) promoted
+    RadioState/VfoSlotState/YaesuStateExtension from this module and not
+    these two, and no commit has ever exported them.
+    """
+    from rigplane.core.radio_state import ReceiverState, ScopeControlsState
+
+    assert not hasattr(rigplane, "ReceiverState")
+    assert not hasattr(rigplane, "ScopeControlsState")
+    state = rigplane.RadioState()
+    assert isinstance(state.main, ReceiverState)
+    assert isinstance(state.sub, ReceiverState)
+    assert isinstance(state.scope_controls, ScopeControlsState)


### PR DESCRIPTION
## What

`docs/api/public-api-surface.md` claimed `ReceiverState` and `ScopeControlsState` are importable from `rigplane`. They are not: `from rigplane import ReceiverState` raises `AttributeError` (live-verified), and a blob-level sweep over every historical revision of the package `__init__` (both `src/icom_lan/__init__.py` and `src/rigplane/__init__.py`, 65 unique blobs, star-imports included) shows the two names were **never** top-level exports. The doc over-claimed from the day the row was added (#207 era). There is no removed export to restore, so this fixes the doc, not the code.

- The Supported-exports table row now names only `RadioState` and states the real import path for its component types: `rigplane.core.radio_state` (canonical; both names are in its `__all__`, and they are the types of `RadioState.main`/`.sub` and `.scope_controls`).
- The corrected sentence is pinned by a new test, `tests/test_exports.py: test_component_state_types_not_top_level`. Mutation-checked in four directions: it fails if either name is exported eagerly, exported via `_LAZY_MAP`, removed from `rigplane.core.radio_state`, or detached from `RadioState`'s fields. Notably the eager-leak mutation does NOT trip the pre-existing exact-set `__all__` seal, so the pin is not redundant.

**Not an API removal.** The Migration policy's "remove a tier-1 symbol" clause does not apply: the two names were never in the Tier 1 list and never importable, so no deprecation cycle is owed. The table stops promising what the package never provided.

## Sweep of the rest of the document

Per the review instruction that found this defect, every backticked symbol in the document was checked for resolvability (script-assisted, then independently re-verified during review): all 57 Tier-1 names are eager, all 46 Tier-2 names resolve via `_LAZY_MAP`, all fenced import examples execute (including the Tier-3 counter-examples), all 17 frontend `host-api.ts`/`manifest.ts` names exist, enum member lists and dataclass field lists match the code exactly. No other unresolvable name was found. One adjacent pre-existing gap (12 top-level exports assigned to no stability tier) is filed separately as #2869 rather than expanded into this PR.

## Why one unit of work

One doc defect plus the test that pins the corrected sentence, per the "prose is a claim" rule in CLAUDE.md. 2 files, +20/−1.

## Testing

- `pytest tests/test_exports.py tests/test_public_api_surface.py tests/test_radio_state.py` — 99 passed
- `ruff check src/ tests/` clean; `ruff format --check` clean
- `.github/scripts/check-doc-citations.sh` — clean, no new citations, baseline untouched
- Full suite: this diff matches the `core` path filter (`tests/**`), so quick.yml runs the real suite on CI (full local runs are routed to CI per the 2026-08-21 owner ruling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
