### PR TITLE
fix: make SerialCivTransport.receive_packet yield on a disconnected link

### DIFF
--- a/src/rigplane/backends/icom7610/drivers/serial_session.py
+++ b/src/rigplane/backends/icom7610/drivers/serial_session.py
@@ -190,6 +190,15 @@ class SerialCivTransport:
         if not self._packet_queue.empty():
             return self._packet_queue.get_nowait()
 
+        if not self.connected:
+            # ``self._civ_link.receive`` returns ``None`` with no ``await``
+            # at all once the link is disconnected, so calling into it here
+            # would raise below without ever yielding to the event loop.
+            # Honor the ``timeout`` contract explicitly instead, matching
+            # ``SerialControlTransport.receive_packet`` in this module.
+            await asyncio.sleep(timeout)
+            raise asyncio.TimeoutError()
+
         try:
             frame = await self._civ_link.receive(timeout=timeout)
         except Exception as exc:

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +16,7 @@ from rigplane.backends._icom_serial_base import (
 from rigplane.backends.discovery import SerialPortCandidate
 from rigplane.backends.ic705 import Ic705SerialRadio
 from rigplane.backends.icom7610 import Icom7610SerialRadio
+from rigplane.backends.icom7610.drivers.serial_session import SerialCivTransport
 from rigplane import IC_7610_ADDR
 from rigplane.commands import (
     CONTROLLER_ADDR,
@@ -564,6 +566,58 @@ async def test_serial_link_down_while_ptt_active_parks_managed_tx_safely() -> No
     assert managed_tx.ready_calls == [False]
 
     await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_receive_packet_yields_to_event_loop_when_link_drops() -> None:
+    """``SerialCivTransport.receive_packet`` must yield to the event loop
+    while honoring ``timeout``, even once the underlying link is down.
+
+    ``_FakeSerialCivLink.receive`` (like the real ``SerialCivLink.receive``)
+    returns ``None`` with no ``await`` suspension once ``connected`` is
+    False. Before the fix, ``receive_packet`` turned that straight into
+    ``asyncio.TimeoutError`` without any ``await`` of its own, so a caller
+    polling it in a tight ``except TimeoutError: continue`` loop (as
+    ``CivRuntime._civ_rx_loop`` does) never got preempted -- the call
+    returned in the very same event-loop turn it was made in.
+
+    A concurrent task makes this observable directly: it is scheduled
+    before ``receive_packet`` is awaited, so it only gets to run if
+    ``receive_packet`` actually suspends at least once. On the unfixed
+    code the task never runs and ``ticks`` stays at 0.
+    """
+    link = _FakeSerialCivLink()  # connected defaults to False
+    transport = SerialCivTransport(link)
+
+    ticks = 0
+
+    async def _yielder() -> None:
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0)
+
+    yielder = asyncio.create_task(_yielder())
+    try:
+        started = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            await transport.receive_packet(timeout=0.05)
+        elapsed = time.monotonic() - started
+    finally:
+        yielder.cancel()
+        try:
+            await yielder
+        except asyncio.CancelledError:
+            pass
+
+    assert ticks > 0, (
+        "receive_packet() returned without ever yielding to the event "
+        "loop -- a caller polling it in a tight loop would starve every "
+        "other task on a downed link"
+    )
+    # Direction, not magnitude: it must actually wait roughly the
+    # requested timeout rather than yield once and return early.
+    assert elapsed >= 0.04
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`SerialCivTransport.receive_packet` raised `asyncio.TimeoutError` **without ever awaiting** once the CI-V link reported `connected == False`, because both `SerialCivLink.receive` and the test fake open with `if not connected: return None` — a return with no suspension point.

`CivRuntime._civ_rx_loop` consumes that call as `except asyncio.TimeoutError: _cleanup_stale_civ_waiters(); continue`, and `_cleanup_stale_civ_waiters` is a plain `def`. The whole cycle therefore ran inside a single event-loop step with no yield anywhere: the RX pump spun on the CPU and no other task on that loop could run again — including the watchdog whose `asyncio.sleep` is what would otherwise drive recovery.

## Why it looked like a flaky test

The hang exceeded `--timeout=300`, and `--timeout-method=thread` resolves that via `pytest_timeout.timeout_timer` → `os._exit(1)`, which skips interpreter cleanup and reaches the xdist controller as `node down: Not properly terminated`. That signature reads as contention. A missed timing window produces `assert False`, not a dead worker.

## Evidence

**Attribution:** the pty measurements below were produced by a **separate session's harness**, not by this PR's author; ask there to reproduce them. The in-process probe and the mutation figure are this author's own runs.

Measured by that session on a real pty through the unmodified production opener (`SerialCivLink._resolve_opener` → `serial_asyncio.open_serial_connection`), reached via a real `Ic7300SerialRadio.connect()`:

| State | `receive_packet` | Rival `asyncio.sleep(0)` task |
|---|---|---|
| Connected | 5 calls in 1.001s | ran 68,575 times |
| Disconnected | 200,000 calls in 0.058s (3.46M/s) | ran **0 times** |

With the pump alive that pins a core: 0 witness iterations across 8.054s then 10.016s of wall clock, child CPU 98.2% / 95.6% of one core, `SIGUSR1` stack dump naming `_civ_rx.py` in `_civ_rx_loop` → `_cleanup_stale_civ_waiters` inside one `_run_once` callback that never returns.

In-process probe (this author), no xdist and no load: witness ticks 141/3.00s with the link up; with the link down the process makes no progress at all, despite being wrapped in `asyncio.wait_for(..., timeout=20)` — that timer cannot fire either. After this change: 144 ticks/3.00s.

The call also **ignored its `timeout` argument entirely** in that state; the fix restores it.

## Reachability — stated precisely

`_IcomSerialRadioBase._declare_serial_link_down` enters this state **by design**: it calls `_serial_session.disconnect()` and deliberately leaves the RX pump running so the watchdog can drive recovery. Whether the watchdog's repair window closes it first is a race and is **not settled** — it won in one measured run. The two outcomes are coupled: if the pump wedges, the watchdog cannot run at all, since it waits on the queue the pump refuses to release. This change removes the race rather than improving the odds.

**Explicitly not claimed:** that a physically yanked adapter reaches this state. pyserial 3.5 raises `SerialException`, which subclasses `OSError` (verified: MRO is `SerialException → OSError → Exception → BaseException → object`), so `SerialCivLink._read_once` takes its recoverable branch (`await asyncio.sleep(0.5)`, `_connected` stays `True`) and the watchdog repairs the link. An earlier draft asserted the opposite; it was refuted by the peer session's Arm A measurement.

## The fix

Honor the `timeout` contract when the link is down, matching `SerialControlTransport.receive_packet` in the same module. Connected path unchanged — no added latency, and `rx_packet_count` / `ping_seq` / `_udp_error_count` semantics untouched.

The guard sits below the existing `_packet_queue` fast path, which returns synchronously when that queue is non-empty. For this transport that path is currently dead (see the out-of-scope note), but the ordering is deliberate: a queued packet is still delivered ahead of the new branch.

## The test

Drives `receive_packet` directly rather than the pump, so removing the guard makes it fail as a named assertion (`assert 0 > 0`) instead of detecting the hang by hanging. A hang-based test would be killed by `--timeout-method=thread` as a crashed worker rather than a named failure — i.e. it would manufacture the very signature that made this bug invisible. Mutation re-run independently of the authoring agent: named assertion, **0.80s wall clock for the whole `uv run pytest <file>::<test>` invocation** (versus the 300s timeout), no hang, no worker kill.

Both assertions are one-sided bounds, so both are load-independent, and they discriminate different wrong fixes: a `sleep(0)`-style fix passes `ticks > 0` but fails `elapsed >= 0.04`; a blocking `time.sleep` fix passes `elapsed` but fails `ticks`.

## Scope of the defect

This PR fixes one call site. It deliberately makes **no general claim** about which other loops in `src/rigplane` can or cannot starve the event loop — two earlier drafts of this section asserted such a claim and both were false, in the direction that made the analysis look tighter than it was.

What is established and checkable: `except [asyncio.]TimeoutError: … continue` with a non-awaiting handler appears at eight sites in `src/rigplane`. Whether any given one can starve the loop depends on whether its awaited call always suspends, which must be checked per site and per interpreter version — `asyncio.wait_for` stopped force-wrapping in a `Task` at 3.12, so a call that yields on 3.11 (measured: rival ran 3 times) may not on 3.12+ (measured: 0). `quick.yml` runs 3.11 only. Two sites worth a look are recorded below; the rest were not audited to a standard this PR should rest on.

## Verification

- `uv run pytest tests/ --ignore=tests/integration -n auto -q --tb=short --timeout=300 --timeout-method=thread` → 1 failed, 11117 passed, 84 skipped, 48 xfailed. The one failure (`test_managed_ptt_port_token_safety[rebind]`) is present in the pre-change baseline on the same machine and passes serially; the box was heavily loaded.
- `uv run pytest tests/test_icom7610_serial_radio.py tests/test_serial_session.py -q` → 57 passed.
- `uv run ruff check src/ tests/` and `ruff format --check` → clean.
- CI: `quick` passed in 1m20s with the `Run tests` step genuinely executed (skipped steps are the frontend path filter, correct for this diff).

## Out of scope, reported not fixed

- `ControlPhaseRuntime._receive_civ_port` (`runtime/_control_phase.py`) — same `except asyncio.TimeoutError: continue` shape around `receive_packet`, bounded by a 2s deadline. It can see more than one transport type: `ControlPhaseRuntime` is constructed in `CoreRadio.__init__`, which sets `_ctrl_transport = IcomTransport()`, and `_IcomSerialRadioBase` overwrites that afterwards. Not audited further. Note this is **not** the sibling `_wait_for_packet`, whose handler re-raises rather than continuing; both set the same 2s deadline in the same class, so the pair is easy to confuse.
- `audio/lan_stream.py` `AudioStream._rx_loop` — same shape. Its `transport` annotation is not load-bearing (`validation/audio_checks.py` passes a local double via `cast`); the reachability argument is that `_rx_loop` runs only from the task `start_rx` creates. Not audited further.
- `SerialCivTransport._packet_queue` has no producer anywhere in `src/` (the only `packet_queue.put*` is on `IcomTransport`'s own queue). So for **the serial transport specifically**, the `q_size` in `CivRuntime._civ_data_watchdog_loop`'s warning is a structurally-constant zero reported during exactly the incidents it exists to diagnose. That warning also serves `IcomTransport`, where the queue is real. Filed separately as MOR-2050.
- `SerialCivLink._read_once` has an unreachable third `except Exception:` (the preceding bare `except Exception as exc:` catches everything) and a comment asserting `SerialException` "is not a subclass of `OSError`", which is false by measured MRO. Different file; being filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)