### PR TITLE
docs: state the per-zone rule in SdrTestSkin's header, correctly

### DIFF
--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -15,10 +15,11 @@
   key/unkey argument on RadioLayout's `declared` / `semanticRxTx` derivations,
   and is not repeated here.
 
-  Not every suppression keys on a declared zone. Mounting the deck also
+  Not every suppression keys on the surface it hides. Mounting the deck also
   retires the settings modal's `.settings-vfo-ops-row` — split/swap/equalize,
-  which the semantic `VfoSurface` has owned since MOR-1321 — and that one is
-  gated on `semanticDeck` itself, not on any zone.
+  which the semantic `VfoSurface` has owned since MOR-1321 — and that one,
+  like the TX twin above, follows the deck rather than its own zone
+  declaration.
 
   What this manifest does not subtract: it declares no `meters` zone, so the
   legacy meters dock still renders, and the spectrum, the status bar and the

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -10,14 +10,19 @@
   reads THIS entrypoint's manifest and suppresses, per declared zone, the
   legacy twin of every semantic surface the manifest mounts. `sdr-test`
   declares one zone (`main: [vfo, rxTx]`), so the semantic surfaces replace
-  `<VfoHeader>` and the sidebars' `<TxPanel>` does not render (MOR-1065). The
-  per-zone rule itself — and the R9 key/unkey reason the TX twin follows the
-  deck rather than its own zone declaration — is documented on RadioLayout's
-  `declared` / `semanticRxTx` derivations, and is not restated here.
+  `<VfoHeader>` and the sidebars' `<TxPanel>` does not render (MOR-1065). Why
+  the TX twin follows the deck rather than its own zone declaration is the R9
+  key/unkey argument on RadioLayout's `declared` / `semanticRxTx` derivations,
+  and is not repeated here.
 
-  Nothing else is suppressed for this skin: the manifest declares no `meters`
-  zone, so the legacy meters dock still renders, and the sidebars, spectrum
-  and status bar are inherited from the standard desktop layout unchanged.
+  Not every suppression keys on a declared zone. Mounting the deck also
+  retires the settings modal's `.settings-vfo-ops-row` — split/swap/equalize,
+  which the semantic `VfoSurface` has owned since MOR-1321 — and that one is
+  gated on `semanticDeck` itself, not on any zone.
+
+  What this manifest does not subtract: it declares no `meters` zone, so the
+  legacy meters dock still renders, and the spectrum, the status bar and the
+  rest of the sidebars come from the standard desktop layout.
 
   The skin's job is to name the entrypoint id; the manifest says what that id
   composes. Skins may not import transport, audioManager or `$lib/stores/*`

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -15,11 +15,11 @@
   key/unkey argument on RadioLayout's `declared` / `semanticRxTx` derivations,
   and is not repeated here.
 
-  Not every suppression keys on the surface it hides. Mounting the deck also
-  retires the settings modal's `.settings-vfo-ops-row` — split/swap/equalize,
-  which the semantic `VfoSurface` has owned since MOR-1321 — and that one,
-  like the TX twin above, follows the deck rather than its own zone
-  declaration.
+  The deck reaches past the receiver row: the settings modal's
+  `.settings-vfo-ops-row` retires with it too. Split/swap/equalize pair with
+  `vfo`, not a zone of their own — `VfoSurface` owns those controls
+  (MOR-1321) — so the row retires on `declared.has('vfo')`, the same shape as
+  `<AgcPanel>` retiring on `declared.has('dsp')`.
 
   What this manifest does not subtract: it declares no `meters` zone, so the
   legacy meters dock still renders, and the spectrum, the status bar and the

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -1,16 +1,22 @@
 <!--
-  SDR Test Skin — the MOR-1065 migrated reference vertical. Delegates to
-  RadioLayout, which branches on skinId === 'sdr-test' and mounts the
-  semantic VFO/RX-TX surfaces (SemanticRadioSurfaces, MOR-1063/1064) in
-  place of the legacy twin-VFO block and sidebar TX panel. Everything else
-  (sidebars, spectrum, meters dock, status bar) is inherited from the
-  standard desktop layout.
+  SDR Test Skin — the sdr-test presentation entrypoint (MOR-1066). A pure
+  RadioLayout delegate; its import boundary (no transport, no audioManager)
+  is pinned by architecture-boundaries.test.ts, "the sdr-test entrypoint's
+  own import boundary" (MOR-1093).
 
-  Registered as the 'sdr-test' v1 layout manifest under this same id
-  (MOR-1066, presentation/layouts/declarations.ts) — see
-  presentation/layouts/__tests__/sdr-registration.test.ts. The pre-migration
-  SdrVfoScreen prototype is no longer mounted here; RadioLayout stopped
-  swapping it in once the semantic surfaces landed.
+  Which areas of that shell render as semantic surfaces and which keep their
+  legacy twin is decided inside RadioLayout, off the ACTIVE layout manifest's
+  zone declarations — NOT by this file, and no longer by a hardcoded skin-id
+  comparison. The per-zone rule is stated once, in RadioLayout.svelte's own
+  header comment (MOR-1313), and that comment is the authority. It is not
+  restated here on purpose: the description this one replaces kept describing
+  the pre-MOR-1313 `skinId === 'sdr-test'` boolean long after RadioLayout had
+  stopped deciding anything with it.
+
+  This skin's manifest is `sdrTestLayout` (presentation/layouts/declarations.ts);
+  its registration, zones and requiredSemanticSurfaces are pinned by
+  presentation/layouts/__tests__/sdr-registration.test.ts. `SdrVfoScreen.svelte`
+  next door is a diagnostic renderer this entrypoint does not mount.
 -->
 <script lang="ts">
   import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -1,22 +1,31 @@
 <!--
-  SDR Test Skin — the sdr-test presentation entrypoint (MOR-1066). A pure
-  RadioLayout delegate; its import boundary (no transport, no audioManager)
-  is pinned by architecture-boundaries.test.ts, "the sdr-test entrypoint's
-  own import boundary" (MOR-1093).
+  SDR Test Skin — the v3 presentation entrypoint registered under the
+  `sdr-test` layout manifest (MOR-1066, `presentation/layouts/declarations.ts`:
+  `sdrTestLayout`). That manifest's registration, zones and
+  requiredSemanticSurfaces are pinned by
+  `presentation/layouts/__tests__/sdr-registration.test.ts`.
 
-  Which areas of that shell render as semantic surfaces and which keep their
-  legacy twin is decided inside RadioLayout, off the ACTIVE layout manifest's
-  zone declarations — NOT by this file, and no longer by a hardcoded skin-id
-  comparison. The per-zone rule is stated once, in RadioLayout.svelte's own
-  header comment (MOR-1313), and that comment is the authority. It is not
-  restated here on purpose: the description this one replaces kept describing
-  the pre-MOR-1313 `skinId === 'sdr-test'` boolean long after RadioLayout had
-  stopped deciding anything with it.
+  It stays a thin delegate to RadioLayout — the same shape DesktopSkin has —
+  because RadioLayout is where the v3 resolution happens: since MOR-1313 it
+  reads THIS entrypoint's manifest and suppresses, per declared zone, the
+  legacy twin of every semantic surface the manifest mounts. `sdr-test`
+  declares one zone (`main: [vfo, rxTx]`), so the semantic surfaces replace
+  `<VfoHeader>` and the sidebars' `<TxPanel>` does not render (MOR-1065). The
+  per-zone rule itself — and the R9 key/unkey reason the TX twin follows the
+  deck rather than its own zone declaration — is documented on RadioLayout's
+  `declared` / `semanticRxTx` derivations, and is not restated here.
 
-  This skin's manifest is `sdrTestLayout` (presentation/layouts/declarations.ts);
-  its registration, zones and requiredSemanticSurfaces are pinned by
-  presentation/layouts/__tests__/sdr-registration.test.ts. `SdrVfoScreen.svelte`
-  next door is a diagnostic renderer this entrypoint does not mount.
+  Nothing else is suppressed for this skin: the manifest declares no `meters`
+  zone, so the legacy meters dock still renders, and the sidebars, spectrum
+  and status bar are inherited from the standard desktop layout unchanged.
+
+  The skin's job is to name the entrypoint id; the manifest says what that id
+  composes. Skins may not import transport, audioManager or `$lib/stores/*`
+  (eslint `FORBIDDEN_SKINS_IMPORTS`, the last of those added by MOR-2039);
+  `__tests__/architecture-boundaries.test.ts` exercises that rule for this
+  path. `SdrVfoScreen.svelte` next door is not mounted — MOR-1065 replaced
+  this top slot, and it is kept as the pre-migration prototype reference
+  pending MOR-1099.
 -->
 <script lang="ts">
   import RadioLayout from '../../components-v2/layout/RadioLayout.svelte';


### PR DESCRIPTION
## What

`frontend/src/skins/sdr-test/SdrTestSkin.svelte`'s header comment described a
pre-MOR-1313 mechanism: it claimed `RadioLayout` "branches on
`skinId === 'sdr-test'`" and mounts the semantic VFO/RX-TX surfaces on that basis.
Since MOR-1313 the decision is per-zone and manifest-driven.

Getting that right took five rounds and four BLOCKED reviews. Every block was
correct; the history is kept below rather than squashed away, because the defects
are the interesting part.

## Round 1 — `7d0cff25`, BLOCKED

Replaced the description with a **pointer**: "see RadioLayout.svelte's own header
comment, which is the authority", on the theory that a mechanism described twice
will drift twice. Three defects:

1. **The citation named something that does not exist.** `RadioLayout.svelte` has
   no header comment: line 1 is `<script lang="ts">`. The MOR-1313 block lives
   *inside* the script, on the `declared` / `semanticRxTx` derivations. A reader
   following the citation landed on an import list.
2. **"The rule is stated once" was false** — `DesktopSkin.svelte`'s header,
   `contract.ts`'s `declaredSurfaces`, `desktop-declarations.ts`,
   `LeftSidebar.svelte`'s `declared` prop doc and RadioLayout's own MOR-1364 block
   all describe it; the last uses the word "restated".
3. **The import boundary was stated narrower than the lint rule** — "no transport,
   no audioManager" omits the `$lib/stores/*` ban MOR-2039 added to
   `FORBIDDEN_SKINS_IMPORTS`.

It also deleted a still-true sentence: that sidebars, spectrum, meters dock and
status bar are inherited.

## Round 2 — `62db0a99`, BLOCKED

The premise was wrong, not the wording. `DesktopSkin.svelte` — the sibling
entrypoint — solves this same problem by stating the rule compactly for its own
manifest, so the comment was rebuilt on that model. Round 1's three defects were
fixed and verified fixed. Two new ones:

4. **"Nothing else is suppressed for this skin" is false.** Mounting the semantic
   deck also retires the settings modal's `.settings-vfo-ops-row`
   (split/swap/equalize). Enumerating the literal `declared.has(...)` call sites
   and generalising from them missed a gate that consults `declared` indirectly,
   through `semanticDeck`.
5. **"the sidebars … inherited unchanged" contradicted "the sidebars' `<TxPanel>`
   does not render"** two sentences earlier. The "Nothing else" preamble is what
   widened a true sentence into a false one.

## Round 3 — `771e49ef`, BLOCKED

- the sweeping claim is gone; the deck-gated suppression is **named**, because a
  reader who takes "per declared zone" as the whole rule gets that one wrong;
- the sidebars clause now says *the rest of* the sidebars;
- "is not repeated here" is scoped to the R9 rationale alone — attached to a
  compound subject it contradicted the sentence before it, which states the
  per-zone rule in full.


## Round 4 — `78b32aba`, BLOCKED

Round 3's own new sentence was refuted: it said the settings-modal row is "gated on
`semanticDeck` itself, not on any zone". But `semanticDeck` is
`$derived(declared.has('vfo'))` — a zone predicate. The row is gated on a zone
declaration; just not on **its own**. Three things refuted it at once: that
derivation sits one line above the R9 block the same comment cites by symbol, so a
reader following the citation reads the refutation; the named-exception test in
`semantic-desktop-migration.component.test.ts` renders that row for a probe
manifest whose only zone is `rx-tx`; and the comment two paragraphs earlier says
the deck exists *because* the manifest declares a zone.

The clause now reuses the wording the tree already uses six lines earlier for the
structurally identical TX case — "follows the deck rather than its own zone
declaration" — and the framing is "not every suppression keys on **the surface it
hides**", which is what is actually true of both non-obvious sites.

The round-3 review asserted that exactly two suppressions in this shell do not key
on their own surface's zone, and that assertion is what this round's wording was
built on. The round-5 review retracted it: it is **one**. See below.

## Round 5 — `05249123`, current

Round 4's replacement was refuted too, and the review located the error's origin
in itself: round 3 had asserted "exactly two" bypassing suppressions and handed
over the TX twin's wording to reuse. Reusing sourced wording is not a substitute
for checking that it applies.

The ops row is **not** like the TX twin — it is a conforming case:

- the TX twin has a real candidate predicate deliberately rejected —
  `declared.has('rxTx')` exists and is named in three places as the one *not*
  used, for the R9 key/unkey reason;
- the ops row has no such candidate. There is no ops surface (the vocabulary is 14
  names). Its replacement controls live in `VfoSurface`
  (`data-vfo-split`/`-swap`/`-equalize`, MOR-1321) and `VfoSurface` **is** the
  `vfo` surface — so the gate keys on the declaration of the surface that owns the
  replacement. That is the conforming shape, not a bypass.

Round 4's sentence also contradicted itself within one sentence: it named
`VfoSurface` as the owner and then said the row does not follow its own zone
declaration.

The tree already had the idiom for this shape — "AGC pairs with `dsp`, not a zone
of its own: `DspSurface` owns the AGC leaf (5A/MOR-1290), so `<AgcPanel>` retires
on `declared.has('dsp')`" — and the paragraph now mirrors it.

**Corrected enumeration:** exactly **one** suppression in this shell does not key
on its own surface's zone — the TX twin — which the comment already names.

**What the comment says as of this head**, all of it checkable: one zone
`main: [vfo, rxTx]` → semantic surfaces replace `<VfoHeader>`, sidebars'
`<TxPanel>` absent (MOR-1065); the deck also retires `.settings-vfo-ops-row`,
which pairs with `vfo` because `VfoSurface` owns those controls (MOR-1321); no
`meters` zone → legacy meters dock still renders; spectrum, status bar and the
rest of the sidebars inherited; R9 rationale cited by symbol on `declared` /
`semanticRxTx`; import boundary named as the rule set at the width the config
enforces.

No claim that the rule is stated only once. No claim that hardcoded `skinId`
comparisons are gone — RadioLayout still dispatches on `skinId` for the mobile
and LCD shells, and `class:sdr-test` remains an identity hook.

## Not changed

Comment-only across all five commits: the bytes after the comment terminator are
byte-identical to `main`'s.

## Verification (re-run at head `05249123`)

- `npm run check` — 4603 files, 0 errors, 0 warnings
- `npm run lint` (eslint) — clean
- `vitest run` on `sdr-registration.test.ts`, `architecture-boundaries.test.ts`,
  `presentation/layouts/__tests__/registry.test.ts` — 114 passed
- The `/skinId=["']sdr-test["']/` pin in `sdr-registration.test.ts` still
  discriminates: the comment block alone does not satisfy it.

None of these gates can redden on a comment change — they confirm the tree, not
the prose. The prose was checked by review, which is the point of the five rounds.

No Python paths touched.

## Same defect elsewhere — reported, not fixed here

The "RadioLayout.svelte's header comment" citation is not unique to this PR. Open
PR #2872 (`docs/architecture/building-a-skin.md`, MOR-2042) cites the same
non-existent header as authoritative — still present as of this writing. Outside
this change's guardrails, so reported rather than fixed here.

## Size

1 file, well under both the soft (6/600) and hard (10/1000) guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



