### PR TITLE
fix: skip minimized review comments the gate could never actually skip

### DIFF
--- a/.github/scripts/agent-review-gate.js
+++ b/.github/scripts/agent-review-gate.js
@@ -100,12 +100,13 @@ function evaluateReviewGate({comments, headSha, committedAt}) {
     if (
       comment === null ||
       typeof comment !== 'object' ||
-      // Truthiness, deliberately. The REST payload types `minimized` as a
-      // nullable object whose own `reason` is nullable too, so `null`,
-      // `{reason: "outdated"}` and `{reason: null}` are all producible and the
-      // boolean `true` is not. Narrowing this to `comment.minimized?.reason`
-      // would stop skipping a comment hidden without a recorded reason, and
-      // narrowing it to `=== true` (the original) skipped nothing at all.
+      // Truthiness, deliberately. REST types `minimized` as a nullable object
+      // whose own `reason` is nullable, so `{reason: null}` is schema-legal
+      // (no public mutation produces one today -- `minimizeComment` requires a
+      // classifier -- but the schema permits it). Narrowing to
+      // `comment.minimized?.reason` would count such a comment instead of
+      // skipping it; `=== true`, the original, skipped nothing at all, since
+      // the schema admits object-or-null and never a boolean.
       Boolean(comment.minimized) ||
       !TRUSTED_ASSOCIATIONS.has(comment.author_association)
     ) {

--- a/.github/scripts/agent-review-gate.js
+++ b/.github/scripts/agent-review-gate.js
@@ -100,7 +100,7 @@ function evaluateReviewGate({comments, headSha, committedAt}) {
     if (
       comment === null ||
       typeof comment !== 'object' ||
-      comment.minimized === true ||
+      Boolean(comment.minimized) ||
       !TRUSTED_ASSOCIATIONS.has(comment.author_association)
     ) {
       continue;

--- a/.github/scripts/agent-review-gate.js
+++ b/.github/scripts/agent-review-gate.js
@@ -100,6 +100,12 @@ function evaluateReviewGate({comments, headSha, committedAt}) {
     if (
       comment === null ||
       typeof comment !== 'object' ||
+      // Truthiness, deliberately. The REST payload types `minimized` as a
+      // nullable object whose own `reason` is nullable too, so `null`,
+      // `{reason: "outdated"}` and `{reason: null}` are all producible and the
+      // boolean `true` is not. Narrowing this to `comment.minimized?.reason`
+      // would stop skipping a comment hidden without a recorded reason, and
+      // narrowing it to `=== true` (the original) skipped nothing at all.
       Boolean(comment.minimized) ||
       !TRUSTED_ASSOCIATIONS.has(comment.author_association)
     ) {

--- a/.github/scripts/agent-review-gate.test.js
+++ b/.github/scripts/agent-review-gate.test.js
@@ -284,6 +284,14 @@ test('trust, minimization, and PASS freshness are enforced', () => {
     evaluate([comment(directive('PASS'), {minimized: {reason: 'outdated'}})]).state,
     'failure',
   );
+  // `reason` is itself nullable in the schema, so a comment hidden without a
+  // recorded reason arrives as {reason: null}. This is the row that keeps the
+  // predicate at truthiness: narrowing it to `comment.minimized?.reason` counts
+  // this comment instead of skipping it, reinstating the original defect.
+  assert.equal(
+    evaluate([comment(directive('PASS'), {minimized: {reason: null}})]).state,
+    'failure',
+  );
   assert.equal(
     evaluate([
       comment(directive('BLOCKED') + '\n\nsuperseded', {

--- a/.github/scripts/agent-review-gate.test.js
+++ b/.github/scripts/agent-review-gate.test.js
@@ -284,10 +284,11 @@ test('trust, minimization, and PASS freshness are enforced', () => {
     evaluate([comment(directive('PASS'), {minimized: {reason: 'outdated'}})]).state,
     'failure',
   );
-  // `reason` is itself nullable in the schema, so a comment hidden without a
-  // recorded reason arrives as {reason: null}. This is the row that keeps the
-  // predicate at truthiness: narrowing it to `comment.minimized?.reason` counts
-  // this comment instead of skipping it, reinstating the original defect.
+  // `reason` is itself nullable in the schema, so {reason: null} is a legal
+  // hidden-comment payload even though no public mutation produces one today.
+  // This row and the {minimized: true} row above each independently catch a
+  // narrowing to `comment.minimized?.reason`; removing either one still leaves
+  // the narrowing caught, removing both lets it through silently.
   assert.equal(
     evaluate([comment(directive('PASS'), {minimized: {reason: null}})]).state,
     'failure',

--- a/.github/scripts/agent-review-gate.test.js
+++ b/.github/scripts/agent-review-gate.test.js
@@ -275,6 +275,24 @@ test('trust, minimization, and PASS freshness are enforced', () => {
   }
 
   assert.equal(evaluate([comment(directive('PASS'), {minimized: true})]).state, 'failure');
+
+  // The REST payload (issues.listComments) reports a minimized comment as an
+  // OBJECT -- {"reason": "outdated"} -- never as the boolean `true`. A strict
+  // `=== true` check therefore never matches a real hidden comment, so hiding
+  // a superseded directive had no effect on the gate. Both shapes must skip.
+  assert.equal(
+    evaluate([comment(directive('PASS'), {minimized: {reason: 'outdated'}})]).state,
+    'failure',
+  );
+  assert.equal(
+    evaluate([
+      comment(directive('BLOCKED') + '\n\nsuperseded', {
+        minimized: {reason: 'outdated'},
+      }),
+      comment(directive('PASS')),
+    ]).state,
+    'success',
+  );
   assert.equal(
     evaluate([comment(directive('PASS'), {updated_at: '2026-08-08T04:49:59Z'})]).state,
     'failure',


### PR DESCRIPTION
## The defect

`evaluateReviewGate` skips hidden comments with:

```js
comment.minimized === true ||
```

The workflow feeds it the REST payload from `github.rest.issues.listComments` (`.github/workflows/agent-review-gate.yml`). That payload reports a minimized comment as an **object** — `{"reason": "outdated"}` — and `null` when it is not minimized. It never returns the boolean `true`.

So the strict equality never matched a real hidden comment. Minimizing a superseded directive had **no effect on the gate**: a stale `BLOCKED` kept incrementing `blockedCount` forever, and since success requires `blockedCount === 0 && malformedBlockedCount === 0 && passCount > 0`, no number of later `PASS` directives at the same head could clear it.

## Observed

On PR #2871: two superseded `BLOCKED` directives were minimized as `OUTDATED`. The REST payload then reported

```
minimized={"reason":"outdated"}  assoc=MEMBER  Agent Review: BLOCKED c942aa87…
minimized={"reason":"outdated"}  assoc=MEMBER  Agent Review: BLOCKED c942aa87…
minimized=null                   assoc=MEMBER  Agent Review: PASS    c942aa87…
```

and the gate still reported `A trusted exact-head Agent Review BLOCKED directive is active.`

## Why the existing tests stayed green

`agent-review-gate.test.js`'s `comment()` helper defaults to `minimized: false`, and the single hidden-comment case passes `minimized: true`. Both are booleans — a shape this API never produces. The tests and the implementation agreed with each other about a data shape that does not occur, so the suite was green while the mechanism was dead in production.

This is the failure mode where a test cannot discriminate: it exercises the branch, but only with an input the branch never receives.

## The change

Test first, with the real REST shape — it fails before the fix:

```js
assert.equal(
  evaluate([comment(directive('PASS'), {minimized: {reason: 'outdated'}})]).state,
  'failure',
);
```

plus a case pinning the behaviour that motivated this: a minimized `BLOCKED` alongside a live `PASS` must resolve to `success`.

Then `comment.minimized === true` → `Boolean(comment.minimized)`, so both the object form and the boolean form skip, while `false` and `null` continue not to.

## Verification

- `node --test .github/scripts/agent-review-gate.test.js` → **19 pass, 0 fail**.
- Mutation: restoring `=== true` makes the two new assertions fail; restoring `Boolean(...)` makes them pass.
- Behaviour for non-minimized comments is unchanged — `false` and `null` are both falsy, so the pre-existing assertions are untouched (base: 19 `test()` blocks / 73 `assert.` calls; head: 19 / 75).
- Verified against the evaluator that `{"reason": null}` — a comment hidden with no recorded reason, which the OpenAPI schema permits since `reason` is itself nullable — is skipped by truthiness but would be **counted** by `comment.minimized?.reason`, reinstating this bug. A follow-up commit records that constraint as a code comment at the point where someone would change it.

## Scope

Two files, both under `.github/scripts/`. The fix itself is one line; the rest is the comment recording why the predicate is truthiness, and the assertions pinning the shapes it rests on. (No line count here on purpose: this body is amendable, so any exact figure goes stale on the next push — it already did, twice.)

Found while trying to clear a superseded directive on #2871, which remains blocked until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

