### PR TITLE
docs(MOR-2034): record the skins presentation-boundary release gate

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -95,6 +95,11 @@ uv build && rm -rf dist/
 # 2k. Warn-only: prior FAILED issues in .claude/queue/history.json
 ```
 
+```bash
+# 2l. Warn-only, frontend/skins changes: review open gaps in
+# docs/internals/skins-presentation-boundary-gate.md (MOR-2034)
+```
+
 Report: "All pre-flight checks passed ✓" and continue.
 
 ## Step 3 — Generate CHANGELOG content

--- a/docs/internals/skins-presentation-boundary-gate.md
+++ b/docs/internals/skins-presentation-boundary-gate.md
@@ -1,0 +1,121 @@
+# Skins Presentation-Boundary Release Gate
+
+Status: MOR-2034 release gate (epic MOR-2035)
+Date: 2026-08-31
+
+## The criterion
+
+The owner's stated acceptance criterion for the skins architecture, verbatim:
+
+> I can build a theme with its own S-meters and indicators — up to
+> replicating an IC-7610/FTX-1 front panel or drawing my own SDR interface —
+> without touching anything below the presentation layer.
+
+This decomposes into two independent, separately-checkable guarantees:
+
+1. **Presentation-layer boundary** — a skin (and the panels/layouts it is
+   built from) can reach the presentation layer's own exports, and nothing
+   below it: no transport, no store, no audio manager, imported directly.
+2. **Truth derivation stays out of skins** — a skin presents a value; it
+   never computes one. Calibration, unit conversion, and any other "what is
+   actually true" derivation happens once, below the presentation layer, and
+   every presentation-layer consumer reads the same answer.
+
+This document is this repo's `docs/internals/*.md` MOR-XXXX-keyed
+executable-gate entry (the form `radio-state-pipeline-validation.md` uses for
+MOR-348 and `backend-neutral-readiness-gap-register.md` uses for MOR-424) for
+these two guarantees specifically. It does not restate the mechanisms below —
+it names them, so a reviewer can re-run the cited test file and get a real
+pass/fail, not a prose claim.
+
+A note on scope: this entry could not be placed literally next to Linear's
+MOR-1413 (the v3 hardware operator-acceptance gate) or MOR-1102 (the v3
+design-language shipping evidence table) — both are Linear-native process
+gates (an owner-run hardware sign-off, and a ticket description rewritten as
+a finite evidence table) with no file in this repository to extend. This
+entry follows the closest verified in-repo precedent instead (the two
+`docs/internals/` gates named above), and says so rather than asserting an
+adjacency that could not be confirmed.
+
+## Gate 1 — presentation-layer boundary
+
+| Mechanism | File : symbol | What it proves | Honest limit |
+|---|---|---|---|
+| Import-boundary ESLint rules | `frontend/eslint.config.js`: `FORBIDDEN_RUNTIME_IMPORTS`, `FORBIDDEN_PANEL_IMPORTS`, `FORBIDDEN_SKINS_IMPORTS` | `src/skins/**/*.svelte`, `src/skins/**/*.ts`, and `src/components-v2/panels/**` cannot import `$lib/stores/*`, `$lib/transport/*`, or the audio manager | A lint rule, not a test by itself — see the next row for how it is actually exercised |
+| Rules exercised through the real linter | `frontend/src/__tests__/architecture-boundaries.test.ts`: `restrictedImportHits` | Lints synthetic fixture code through `ESLint.lintText` against the real flat config at real skin/panel paths (e.g. `src/skins/sdr-test/SdrTestSkin.svelte`, `src/skins/registry.ts`) — a rule regression here fails the same way `npm run lint` would | Fixture paths need not exist on disk; this proves the *rule*, not that every real file in `skins/` obeys it (no file in the tree currently violates it, but nothing scans the whole tree for a new violation) |
+| Both directions proven | same file, e.g. `'rejects a skins .ts file importing $lib/stores/* directly...'` paired with `'allows skins/registry.ts to import layout-mode normalization through the adapter...'` | For every forbidden import there is a paired case proving the *legitimate* migrated replacement still passes — a custom skin's own instruments are not collateral damage of this rule | — |
+| Skin registry is exhaustive and its entry points really mount | `frontend/src/skins/__tests__/entrypoints.test.ts`: `SKIN_ENTRYPOINT_COVERAGE` | Every `SkinId` in `frontend/src/skins/registry.ts` mounts its declared component through the same `loadSkin()` `App.svelte` calls | The one `'covered-elsewhere'` entry (`dual-receiver-cockpit`) is a substring check on another test file's source text, not a behavioral one — documented as such in the file's own header, not restated here as more than it is |
+
+## Gate 2 — truth derivation stays out of skins
+
+The counterexample that motivated this gate was found and fixed the same
+night as this entry: two independent S-unit derivations disagreed because
+`components-v2/panels/meter-utils.ts`'s old `formatSMeter` reimplemented a
+hardcoded 6 dB/S-unit ladder instead of calling the shared, table-driven
+`smeter-scale.ts`. That ladder happened to match IC-7300's real curve
+(uniform) but disagreed with FTX-1's real, non-uniform curve. Consolidated
+under MOR-2024; `formatSMeter` now delegates entirely to
+`frontend/src/components-v2/meters/smeter-scale.ts`: `calibratedToSUnit`.
+
+| Mechanism | File : symbol | What it proves | Honest limit |
+|---|---|---|---|
+| Meter conformance contract | `frontend/src/components-v2/meters/__tests__/meter-contract.ts`: `METER_REGISTRY` | Census-checks every `.svelte` file directly under `components-v2/meters/` (today: `BarGauge.svelte`, `LinearSMeter.svelte`) is registered and mounts | Explicitly scoped to that one directory by its own file header — not to `skins/` or `components-v2/panels/`, which is where a skin's *own* custom instruments actually live |
+| Domain-conformance suite | `frontend/src/components-v2/meters/__tests__/meter-contract.test.ts` | Mounts `LinearSMeter` against a deliberately non-uniform synthetic calibration table and asserts its rendered S-unit/dBm text equals a fresh `calibratedToSUnit`/`calibratedToDbm` call at three probes chosen so no fixed per-S-unit step can pass all three (full reasoning in the file's own header) | Cannot rule out a byte-identical reimplementation of the same interpolation — a DRY concern, not a correctness one, per the same header |
+| Typed `data-*` vocabulary for stylesheet authors | `frontend/src/presentation/languages/state-vocabulary.ts` | A skin's stylesheet can key off `RxTxSurface`/`MetersSurface` visual state (`RF_STATES`, `TX_SESSION_STATES`, etc.) from a typed export instead of reverse-engineering it from semantic source, and instead of computing it | Scoped to the two files the MOR-2036 owner ruling names; `VfoSurface`'s own vocabulary has no stylesheet consumer yet and is not exported here (see the file's own header) |
+
+### Residual found by this ticket, and closed for two of the three live instances found
+
+`METER_REGISTRY`'s census is scoped to `components-v2/meters/`. Grepping
+every production (non-test) importer of `smeter-scale.ts` finds three call
+sites outside that directory — i.e., in the presentation-layer code a skin
+author actually writes:
+
+1. `frontend/src/components-v2/panels/lcd/AmberSmeter.svelte` — the
+   `amber-lcd` theme's own S-meter, mounted by the `lcd-cockpit`/`lcd-scope`
+   skins. Had a dedicated test
+   (`components-v2/panels/lcd/__tests__/lcd-components.isolated.test.ts`),
+   but its only calibration fixture was uniform (`IC7610_LIKE_S_METER_CAL`,
+   6 dB/S-unit throughout, matching IC-7610's real curve) and its only
+   exact-text assertion was at the S0 anchor — the same shape of gap
+   MOR-2024 fixed in `meter-utils.ts`, just untested here rather than wrong.
+2. `frontend/src/components-v2/layout/mobile-layout-logic.ts`'s
+   `formatSValue`/`formatDbm` — the `mobile` skin's own S-meter formatting.
+   Had a dedicated test
+   (`components-v2/layout/__tests__/mobile-layout-logic.test.ts`), with the
+   same uniform-fixture shape (`IC7300_LIKE_CAL`, deliberately IC-7300-shaped
+   to pin a *different* MOR-2024 fix — the continuous S9+ reading — not this
+   one).
+3. `frontend/src/skins/sdr-test/SdrVfoScreen.svelte` — initially counted as a
+   third live instance; re-derived and struck. `SdrTestSkin.svelte`'s own
+   header states this component has not been mounted since MOR-1065
+   (`RadioLayout` no longer swaps it in), kept only "as the pre-migration
+   prototype reference pending the MOR-1099 legacy-wrapper retirement." It
+   is unreachable dead code, not a live presentation-layer consumer, and
+   that unreachability is already self-documented — not a new finding.
+
+This PR adds a non-uniform-calibration discrimination suite to both real
+test files above (instances 1 and 2), reusing `meter-contract.test.ts`'s own
+fixture and probe reasoning against the real mounted component /
+plain-function call site, proven both ways during development (a throwaway
+hardcoded-6-dB-ladder mutant in each production file, run against the new
+tests, then reverted): the mutant failed all three new probes in both
+files with the same off-by-one-S-unit pattern the meter-contract.test.ts
+header predicts; the real code passes all of them.
+
+What is **not** closed by this PR, and is filed as a follow-up rather than
+attempted here: `METER_REGISTRY`'s census has no structural mechanism that
+would force a *future* skin's new S-meter to get this same discriminating
+regression test — closing instances 1 and 2 required a human (or agent) to
+notice the gap and hand-write the probes, same as it always has. Widening
+the census itself (a directory scope of more than one path, or a third
+`MeterValueDomain` shape for multi-source components like `AmberSmeter`) is
+a structural change to MOR-2037's own contract and is out of this ticket's
+guardrails.
+
+## See also
+
+- `docs/plans/2026-04-12-target-frontend-architecture.md` — the ADR this
+  gate closes the loop on.
+- `docs/architecture/building-a-skin.md` (MOR-2042) — the skin-authoring
+  guide; this document records what is enforced, that one explains how to
+  work within it.

--- a/docs/internals/skins-presentation-boundary-gate.md
+++ b/docs/internals/skins-presentation-boundary-gate.md
@@ -35,7 +35,7 @@ gap and the ticket tracking it (MOR-2054).
 This document is this repo's `docs/internals/*.md` MOR-XXXX-keyed
 executable-gate entry (the form `radio-state-pipeline-validation.md` uses for
 MOR-348 and `backend-neutral-readiness-gap-register.md` uses for MOR-424) for
-these two guarantees specifically. It does not restate the mechanisms below —
+Gates 1 and 2 specifically. It does not restate the mechanisms below —
 it names them, so a reviewer can re-run the cited test file and get a real
 pass/fail, not a prose claim.
 
@@ -54,7 +54,7 @@ adjacency that could not be confirmed.
 |---|---|---|---|
 | Import-boundary ESLint rules | `frontend/eslint.config.js`: `FORBIDDEN_RUNTIME_IMPORTS`, `FORBIDDEN_PANEL_IMPORTS`, `FORBIDDEN_SKINS_IMPORTS` | `src/skins/**/*.svelte`, `src/skins/**/*.ts`, and `src/components-v2/panels/**` cannot import `$lib/stores/*`, `$lib/transport/*`, or the audio manager | A lint rule, not a test by itself — see the next row for how it is actually exercised |
 | Rules exercised through the real linter | `frontend/src/__tests__/architecture-boundaries.test.ts`: `restrictedImportHits` | Lints synthetic fixture code through `ESLint.lintText` against the real flat config at real skin/panel paths (e.g. `src/skins/sdr-test/SdrTestSkin.svelte`, `src/skins/registry.ts`) — a rule regression here fails the same way `npm run lint` would | Fixture paths need not exist on disk; this proves the *rule*, not that every real file in `skins/` obeys it (no file in the tree currently violates it, but nothing scans the whole tree for a new violation) |
-| Both directions proven | same file, e.g. `'rejects a skins .ts file importing $lib/stores/* directly...'` paired with `'allows skins/registry.ts to import layout-mode normalization through the adapter...'` | Within the skins zone, for every forbidden import there is a paired case proving the *legitimate* migrated replacement still passes — a custom skin's own instruments are not collateral damage of this rule | Not file-wide: e.g. the workspace zone's four `rejects …` cases in this same file have no paired `allows …` case |
+| Both directions proven | same file, e.g. `'rejects a skins .ts file importing $lib/stores/* directly...'` paired with `'allows skins/registry.ts to import layout-mode normalization through the adapter...'` | Within the skins zone, for every forbidden import there is a paired case proving the *legitimate* migrated replacement still passes — a custom skin's own instruments are not collateral damage of this rule | Not file-wide: e.g. the workspace zone's four rejection cases in this same file have no paired `allows …` case |
 | Skin registry is exhaustive and its entry points really mount | `frontend/src/skins/__tests__/entrypoints.test.ts`: `SKIN_ENTRYPOINT_COVERAGE` | Every `SkinId` in `frontend/src/skins/registry.ts` mounts its declared component through the same `loadSkin()` `App.svelte` calls | The one `'covered-elsewhere'` entry (`dual-receiver-cockpit`) is a substring check on another test file's source text, not a behavioral one — documented as such in the file's own header, not restated here as more than it is |
 
 ## Gate 2 — truth derivation stays out of skins
@@ -78,10 +78,12 @@ under MOR-2024; `formatSMeter`'s calibrated branch now defers entirely to
 ### Residual found by this ticket, and closed for two of the four call sites found
 
 `METER_REGISTRY`'s census is scoped to `components-v2/meters/`. Grepping
-every production (non-test) importer of `smeter-scale.ts` —
+every production (non-test) mention of `smeter-scale.ts` —
 `grep -rn "smeter-scale" frontend/src | grep -v __tests__ | grep -v '\.test\.'`
-— finds four call sites outside that directory — i.e., in the
-presentation-layer code a skin author actually writes:
+— returns nine lines across six files. Filtering out `LinearSMeter.svelte`
+(already inside that directory) and four comment-only lines in
+`meter-utils.ts`/`AmberCockpit.svelte` leaves four real call sites outside
+it — i.e., in the presentation-layer code a skin author actually writes:
 
 1. `frontend/src/components-v2/panels/lcd/AmberSmeter.svelte` — the
    `amber-lcd` theme's own S-meter, mounted by the `lcd-cockpit`/`lcd-scope`
@@ -131,9 +133,10 @@ test files above (instances 1 and 2), reusing `meter-contract.test.ts`'s own
 fixture and probe reasoning against the real mounted component /
 plain-function call site, proven both ways during development (a throwaway
 hardcoded-6-dB-ladder mutant in each production file, run against the new
-tests, then reverted): the mutant failed all three new probes in both
-files with the same off-by-one-S-unit pattern the meter-contract.test.ts
-header predicts; the real code passes all of them.
+tests, then reverted): the mutant failed all three S-unit probes — of six
+new cases per file, three S-unit and three dBm — in both files with the
+same off-by-one-S-unit pattern the meter-contract.test.ts header predicts;
+the real code passes all six.
 
 What is **not** closed by this PR, and is filed as a follow-up rather than
 attempted here: `METER_REGISTRY`'s census has no structural mechanism that

--- a/docs/internals/skins-presentation-boundary-gate.md
+++ b/docs/internals/skins-presentation-boundary-gate.md
@@ -11,7 +11,8 @@ The owner's stated acceptance criterion for the skins architecture, verbatim:
 > replicating an IC-7610/FTX-1 front panel or drawing my own SDR interface —
 > without touching anything below the presentation layer.
 
-This decomposes into two independent, separately-checkable guarantees:
+Two of the criterion's guarantees are independent, separately-checkable, and
+mechanically enforced today by this document's Gates 1 and 2:
 
 1. **Presentation-layer boundary** — a skin (and the panels/layouts it is
    built from) can reach the presentation layer's own exports, and nothing
@@ -20,6 +21,16 @@ This decomposes into two independent, separately-checkable guarantees:
    never computes one. Calibration, unit conversion, and any other "what is
    actually true" derivation happens once, below the presentation layer, and
    every presentation-layer consumer reads the same answer.
+
+That pair does not cover the criterion's other two clauses. "Up to
+replicating an IC-7610/FTX-1 front panel or drawing my own SDR interface"
+names no mechanism, and none exists — this document does not claim one.
+"Without touching anything below the presentation layer" does have a
+mechanism for one reading of it (Gate 1's ban on a skin *importing* below
+the presentation layer), but making a new skin *selectable* at all requires
+editing a file that sits below the presentation layer — that reading is not
+enforced, and is false today. Gate 3 records it, with the file that owns the
+gap and the ticket tracking it (MOR-2054).
 
 This document is this repo's `docs/internals/*.md` MOR-XXXX-keyed
 executable-gate entry (the form `radio-state-pipeline-validation.md` uses for
@@ -43,7 +54,7 @@ adjacency that could not be confirmed.
 |---|---|---|---|
 | Import-boundary ESLint rules | `frontend/eslint.config.js`: `FORBIDDEN_RUNTIME_IMPORTS`, `FORBIDDEN_PANEL_IMPORTS`, `FORBIDDEN_SKINS_IMPORTS` | `src/skins/**/*.svelte`, `src/skins/**/*.ts`, and `src/components-v2/panels/**` cannot import `$lib/stores/*`, `$lib/transport/*`, or the audio manager | A lint rule, not a test by itself — see the next row for how it is actually exercised |
 | Rules exercised through the real linter | `frontend/src/__tests__/architecture-boundaries.test.ts`: `restrictedImportHits` | Lints synthetic fixture code through `ESLint.lintText` against the real flat config at real skin/panel paths (e.g. `src/skins/sdr-test/SdrTestSkin.svelte`, `src/skins/registry.ts`) — a rule regression here fails the same way `npm run lint` would | Fixture paths need not exist on disk; this proves the *rule*, not that every real file in `skins/` obeys it (no file in the tree currently violates it, but nothing scans the whole tree for a new violation) |
-| Both directions proven | same file, e.g. `'rejects a skins .ts file importing $lib/stores/* directly...'` paired with `'allows skins/registry.ts to import layout-mode normalization through the adapter...'` | For every forbidden import there is a paired case proving the *legitimate* migrated replacement still passes — a custom skin's own instruments are not collateral damage of this rule | — |
+| Both directions proven | same file, e.g. `'rejects a skins .ts file importing $lib/stores/* directly...'` paired with `'allows skins/registry.ts to import layout-mode normalization through the adapter...'` | Within the skins zone, for every forbidden import there is a paired case proving the *legitimate* migrated replacement still passes — a custom skin's own instruments are not collateral damage of this rule | Not file-wide: e.g. the workspace zone's four `rejects …` cases in this same file have no paired `allows …` case |
 | Skin registry is exhaustive and its entry points really mount | `frontend/src/skins/__tests__/entrypoints.test.ts`: `SKIN_ENTRYPOINT_COVERAGE` | Every `SkinId` in `frontend/src/skins/registry.ts` mounts its declared component through the same `loadSkin()` `App.svelte` calls | The one `'covered-elsewhere'` entry (`dual-receiver-cockpit`) is a substring check on another test file's source text, not a behavioral one — documented as such in the file's own header, not restated here as more than it is |
 
 ## Gate 2 — truth derivation stays out of skins
@@ -54,21 +65,23 @@ night as this entry: two independent S-unit derivations disagreed because
 hardcoded 6 dB/S-unit ladder instead of calling the shared, table-driven
 `smeter-scale.ts`. That ladder happened to match IC-7300's real curve
 (uniform) but disagreed with FTX-1's real, non-uniform curve. Consolidated
-under MOR-2024; `formatSMeter` now delegates entirely to
-`frontend/src/components-v2/meters/smeter-scale.ts`: `calibratedToSUnit`.
+under MOR-2024; `formatSMeter`'s calibrated branch now defers entirely to
+`frontend/src/components-v2/meters/smeter-scale.ts`: `calibratedToSUnit`
+(the uncalibrated branch returns `formatRaw`, unchanged).
 
 | Mechanism | File : symbol | What it proves | Honest limit |
 |---|---|---|---|
 | Meter conformance contract | `frontend/src/components-v2/meters/__tests__/meter-contract.ts`: `METER_REGISTRY` | Census-checks every `.svelte` file directly under `components-v2/meters/` (today: `BarGauge.svelte`, `LinearSMeter.svelte`) is registered and mounts | Explicitly scoped to that one directory by its own file header — not to `skins/` or `components-v2/panels/`, which is where a skin's *own* custom instruments actually live |
 | Domain-conformance suite | `frontend/src/components-v2/meters/__tests__/meter-contract.test.ts` | Mounts `LinearSMeter` against a deliberately non-uniform synthetic calibration table and asserts its rendered S-unit/dBm text equals a fresh `calibratedToSUnit`/`calibratedToDbm` call at three probes chosen so no fixed per-S-unit step can pass all three (full reasoning in the file's own header) | Cannot rule out a byte-identical reimplementation of the same interpolation — a DRY concern, not a correctness one, per the same header |
-| Typed `data-*` vocabulary for stylesheet authors | `frontend/src/presentation/languages/state-vocabulary.ts` | A skin's stylesheet can key off `RxTxSurface`/`MetersSurface` visual state (`RF_STATES`, `TX_SESSION_STATES`, etc.) from a typed export instead of reverse-engineering it from semantic source, and instead of computing it | Scoped to the two files the MOR-2036 owner ruling names; `VfoSurface`'s own vocabulary has no stylesheet consumer yet and is not exported here (see the file's own header) |
+| Typed `data-*` vocabulary for stylesheet authors | `frontend/src/presentation/languages/state-vocabulary.ts` | A skin's stylesheet can key off `RxTxSurface`/`MetersSurface` visual state (`RF_STATES`, `TX_SESSION_STATES`, etc.) from a typed export instead of reverse-engineering it from semantic source, and instead of computing it | Scoped to two of the three files the MOR-2036 owner ruling names (`RxTxSurface.svelte`, `MetersSurface.svelte`); `VfoSurface.svelte` — the ruling's third file — has no stylesheet consumer yet and is not exported here (see the file's own header) |
 
-### Residual found by this ticket, and closed for two of the three live instances found
+### Residual found by this ticket, and closed for two of the four call sites found
 
 `METER_REGISTRY`'s census is scoped to `components-v2/meters/`. Grepping
-every production (non-test) importer of `smeter-scale.ts` finds three call
-sites outside that directory — i.e., in the presentation-layer code a skin
-author actually writes:
+every production (non-test) importer of `smeter-scale.ts` —
+`grep -rn "smeter-scale" frontend/src | grep -v __tests__ | grep -v '\.test\.'`
+— finds four call sites outside that directory — i.e., in the
+presentation-layer code a skin author actually writes:
 
 1. `frontend/src/components-v2/panels/lcd/AmberSmeter.svelte` — the
    `amber-lcd` theme's own S-meter, mounted by the `lcd-cockpit`/`lcd-scope`
@@ -85,13 +98,33 @@ author actually writes:
    same uniform-fixture shape (`IC7300_LIKE_CAL`, deliberately IC-7300-shaped
    to pin a *different* MOR-2024 fix — the continuous S9+ reading — not this
    one).
-3. `frontend/src/skins/sdr-test/SdrVfoScreen.svelte` — initially counted as a
-   third live instance; re-derived and struck. `SdrTestSkin.svelte`'s own
-   header states this component has not been mounted since MOR-1065
-   (`RadioLayout` no longer swaps it in), kept only "as the pre-migration
-   prototype reference pending the MOR-1099 legacy-wrapper retirement." It
-   is unreachable dead code, not a live presentation-layer consumer, and
-   that unreachability is already self-documented — not a new finding.
+3. `frontend/src/components-v2/panels/meter-utils.ts` — `formatSMeter`'s
+   calibrated branch imports `calibratedToSUnit`/`isSmeterCalibrated`
+   directly. Missing from the original census by oversight, not a coverage
+   hole: this is the file MOR-2024 fixed in the first place, and its own
+   `meter-utils.test.ts` already carries a non-uniform, FTX-1-anchored
+   discrimination suite (`describe('formatSMeter — FTX-1 profile anchors
+   (MOR-2024)')`) from that fix. No new test is added here.
+4. `frontend/src/skins/sdr-test/SdrVfoScreen.svelte` — initially counted as a
+   live instance; re-derived and struck. `SdrVfoScreen.svelte`'s own header
+   states it has not been mounted since MOR-1065, kept only "as the
+   pre-migration prototype reference pending the MOR-1099 legacy-wrapper
+   retirement" — corroborated by `SdrTestSkin.svelte`'s own header, which
+   confirms "`SdrVfoScreen.svelte` next door is not mounted — MOR-1065
+   replaced this top slot..." It is unreachable dead code, not a live
+   presentation-layer consumer, and that unreachability is already
+   self-documented — not a new finding.
+
+Grepping *importers* is structurally blind to the defect shape this section
+guards against: a file that reimplements the ladder outright imports
+nothing from `smeter-scale.ts`. Swept for that shape across production
+code; no other file derives S-unit or dBm text locally. One related,
+already-reported duplicate exists:
+`frontend/src/components-v2/panels/meter-utils.ts: calibratedSmeterToRaw`
+hand-copies `frontend/src/components-v2/meters/smeter-scale.ts:
+calibratedToRaw`'s knot interpolation instead of calling it — MOR-2024
+residue, feeding `sLevel`'s bar geometry rather than display text, not
+fixed here.
 
 This PR adds a non-uniform-calibration discrimination suite to both real
 test files above (instances 1 and 2), reusing `meter-contract.test.ts`'s own
@@ -112,10 +145,59 @@ the census itself (a directory scope of more than one path, or a third
 a structural change to MOR-2037's own contract and is out of this ticket's
 guardrails.
 
+## Gate 3 — authoring reach below the presentation layer (open gap, not enforced)
+
+The criterion's final clause — "without touching anything below the
+presentation layer" — has two readings. Gates 1 and 2 above enforce the
+*import-direction* reading: a skin's own code may not import transport,
+stores, or the audio manager. Read as an *authoring-reach* claim — which
+files a skin author must edit to ship a new, selectable skin — no mechanism
+enforces it, and it does not hold today:
+
+- `frontend/src/lib/stores/layout.svelte.ts` owns the `LayoutMode` union and
+  `CANONICAL_LAYOUT_MODES`; `normalizeLayoutMode` maps any id outside that
+  set to `'auto'` before it can be selected or persisted.
+- `frontend/src/skins/registry.ts: resolveSkinId` normalizes the user's
+  layout preference through that same function — reached, correctly, via
+  `frontend/src/lib/runtime/adapters/layout-mode-adapter.ts`'s unchanged
+  re-export, so Gate 1's import-boundary rule is not itself violated here —
+  and `frontend/src/App.svelte`'s call to `getLayoutMode()` is what feeds
+  `resolveSkinId` its preference. A new skin id is therefore unreachable and
+  unpersistable through the real selection path until
+  `lib/stores/layout.svelte.ts` itself is edited to add it: a `$lib/stores/*`
+  module `FORBIDDEN_SKINS_IMPORTS` (Gate 1) bans a skin from even importing.
+- Adding the id to the presentation-side
+  `frontend/src/presentation/workspace/contract.ts: WORKSPACE_LAYOUT_IDS`
+  does not avoid this: that array is pinned as a literal specifically
+  because the workspace module cannot reach `layout.svelte.ts` either (its
+  own file header explains why), and `resolveSkinId` still normalizes an id
+  outside `CANONICAL_LAYOUT_MODES` away regardless.
+- The one pre-normalization exception, `dual-receiver-cockpit`, is QA-only:
+  `layout.svelte.ts`'s own comment records that it "can therefore never be
+  persisted via setLayoutMode/the workspace and never appears in the
+  StatusBar skin selector" — not a general path a real skin can use.
+
+| Clause | Mechanism | Verdict |
+|---|---|---|
+| own S-meters | Gate 1 (import boundary) + Gate 2 (`smeter-scale.ts` delegation) | enforced |
+| own indicators | Gate 2's typed `data-*` vocabulary | enforced, scope-limited |
+| replicate an IC-7610/FTX-1 front panel; draw an original SDR interface | — | no mechanism; not claimed elsewhere in this document either |
+| without touching anything below the presentation layer | — (Gate 1 covers only the import-direction reading) | **not enforced; false today** for a genuinely new, selectable skin |
+
+Tracked as MOR-2054, which names this exact link — a `LayoutMode` union
+living in a `$lib/stores/*` zone skins are otherwise forbidden to import —
+as one of several hand-maintained or silently-noncovering sites a new skin
+must currently clear. Closing it is that ticket's scope, not this one's;
+recording the gap honestly is what this document is for.
+
 ## See also
 
 - `docs/plans/2026-04-12-target-frontend-architecture.md` — the ADR this
   gate closes the loop on.
 - `docs/architecture/building-a-skin.md` (MOR-2042) — the skin-authoring
   guide; this document records what is enforced, that one explains how to
-  work within it.
+  work within it. Its "Only if your skin should be reachable from
+  user-facing layout preference" section independently reaches the same
+  conclusion as Gate 3 above: `lib/stores/layout.svelte.ts` must be edited
+  to add a selectable skin, and doing so is not a boundary violation because
+  the eslint ban applies to import statements, not to owning the file.

--- a/docs/plans/2026-04-12-target-frontend-architecture.md
+++ b/docs/plans/2026-04-12-target-frontend-architecture.md
@@ -604,6 +604,12 @@ During Phases 4-5, old and new code coexist:
 | Phase 3 | Semantic component contracts stable for both desktop and LCD |
 | Before Phase 6 | All 4 capability scenarios pass; Scenario B (`scope=false + audio=true`) explicitly verified; manual hardware validation |
 
+These phase gates cover the migration. `docs/internals/skins-presentation-boundary-gate.md`
+(MOR-2034) is the permanent, post-migration release-gate check for this ADR's
+central guarantee — a skin depends only on the presentation layer, and never
+derives radio truth locally — naming the mechanisms that enforce it and
+recording where their reach currently ends.
+
 ---
 
 ## Relationship to existing code

--- a/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/mobile-layout-logic.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, it, expect } from 'vitest';
-import type { Capabilities } from '$lib/types/capabilities';
+import type { Capabilities, MeterCalPoint } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import {
   SSB_STEPS, CW_STEPS, AM_STEPS, FM_STEPS, DEFAULT_STEPS,
   getStepsForMode, formatStep, formatSValue, formatDbm, formatPower,
 } from '../mobile-layout-logic';
+import {
+  calibratedToSUnit, calibratedToDbm, formatDbm as canonicalFormatDbm,
+} from '../../meters/smeter-scale';
 
 // MOR-1451 follow-up: the mobile skin's S-meter readouts must follow the
 // active radio's profile-declared calibration curve (via the shared
@@ -205,4 +208,68 @@ describe('formatPower', () => {
   it('clamps out-of-range normalized input', () => {
     expect(formatPower(1.4)).toBe('100W');
   });
+});
+
+// ── MOR-2034: non-uniform-calibration discrimination ────────────────────────
+// `formatSValue`/`formatDbm` above are one-line delegates to
+// `smeter-scale.ts`'s `calibratedToSUnit`/`calibratedToDbm` (see this file's
+// import). `IC7300_LIKE_CAL` above is deliberately UNIFORM — a straight
+// -54..0 dB line over S0..S9, matching IC-7300's real curve — because its
+// job is pinning the OTHER MOR-2024 fix (the continuous S9+ reading), not
+// this one: a uniform table cannot tell "calls calibratedToSUnit" apart from
+// a hardcoded 6 dB/S-unit reimplementation, because both agree everywhere on
+// it. That is the exact shape MOR-2024 found and fixed in a sibling file
+// (`components-v2/panels/meter-utils.ts`'s old `formatSMeter`). This block
+// reuses `meter-contract.test.ts`'s own non-uniform fixture and probe
+// reasoning (`components-v2/meters/__tests__/meter-contract.test.ts` — see
+// its file header for the full worked-out argument for why these three
+// probes rule out every fixed per-S-unit step) to pin the same guarantee at
+// this call site, which that file's `.svelte`-only census cannot see: this
+// call site is a `.ts` helper behind the `mobile` skin's own layout, not a
+// file directly under `components-v2/meters/`.
+//
+// No ruler-collision caveat applies here (unlike meter-contract.test.ts's
+// DOM-textContent check): `formatSValue`/`formatDbm` are plain
+// string-returning functions with nothing else rendered alongside them, so
+// the exact `.toBe()` comparison below cannot pass by matching an unrelated
+// label.
+const NON_UNIFORM_CAL: MeterCalPoint[] = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 26, actual: -48, label: 'S1' },
+  { raw: 52, actual: -45, label: 'S2' },
+  { raw: 78, actual: -42, label: 'S3' },
+  { raw: 104, actual: -36, label: 'S4' },
+  { raw: 130, actual: -30, label: 'S5' },
+  { raw: 156, actual: -12, label: 'S6' }, // +18 dB step, vs. 3-6 dB elsewhere
+  { raw: 182, actual: -6, label: 'S7' },
+  { raw: 208, actual: -3, label: 'S8' },
+  { raw: 230, actual: 0, label: 'S9' },
+  { raw: 255, actual: 20, label: 'S9+20' },
+];
+
+describe('formatSValue / formatDbm — non-uniform calibration (MOR-2034)', () => {
+  beforeEach(() => {
+    setCapabilities(makeCaps({ meterCalibrations: { s_meter: NON_UNIFORM_CAL } }));
+  });
+
+  // Kills: formatSValue reimplementing its own S-unit math (a fixed step or
+  // any other formula) instead of delegating to calibratedToSUnit — on this
+  // non-uniform table the two would diverge at one of these three probes
+  // (worked out in meter-contract.test.ts's file header) even though they
+  // agree everywhere on the uniform IC7300_LIKE_CAL table above.
+  it.each([-43, -33, -11])(
+    'formatSValue(%d) matches a fresh calibratedToSUnit call, not a local approximation',
+    (actual) => {
+      expect(formatSValue(actual)).toBe(calibratedToSUnit(actual));
+    },
+  );
+
+  // Kills: formatDbm reimplementing its own dBm math instead of delegating
+  // to calibratedToDbm/formatDbm.
+  it.each([-43, -33, -11])(
+    'formatDbm(%d) matches a fresh calibratedToDbm/formatDbm call, not a local approximation',
+    (actual) => {
+      expect(formatDbm(actual)).toBe(canonicalFormatDbm(calibratedToDbm(actual)));
+    },
+  );
 });

--- a/frontend/src/components-v2/panels/lcd/__tests__/lcd-components.isolated.test.ts
+++ b/frontend/src/components-v2/panels/lcd/__tests__/lcd-components.isolated.test.ts
@@ -9,12 +9,13 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, unmount } from 'svelte';
+import type { MeterCalPoint } from '$lib/types/capabilities';
 
 // Fixture calibration table — the numbers `rigs/ic7610.toml` declares, no
 // longer a production default (MOR-1451): a radio profile with no
 // `[meters.s_meter]` table now renders an honest raw-scale label instead of
 // borrowing these.
-const IC7610_LIKE_S_METER_CAL = [
+const IC7610_LIKE_S_METER_CAL: MeterCalPoint[] = [
   { raw: 0, actual: -54, label: 'S0' },
   { raw: 26, actual: -48, label: 'S1' },
   { raw: 52, actual: -36, label: 'S3' },
@@ -26,9 +27,16 @@ const IC7610_LIKE_S_METER_CAL = [
   { raw: 240, actual: 40, label: 'S9+40' },
 ];
 
+// Mutable indirection so the MOR-2034 discrimination suite (bottom of file)
+// can swap in a non-uniform table for its own tests, then hand the default
+// back — `vi.mock` factories are hoisted, but this arrow function re-reads
+// the variable on every call, so a later reassignment is picked up without
+// re-registering the mock.
+let activeSMeterCal: MeterCalPoint[] = IC7610_LIKE_S_METER_CAL;
+
 // Mock capabilities store before any component import
 vi.mock('$lib/stores/capabilities.svelte', () => ({
-  getSmeterCalibration: () => IC7610_LIKE_S_METER_CAL,
+  getSmeterCalibration: () => activeSMeterCal,
   getSmeterRedline: () => null,
   isAudioFftScope: () => false,
   hasAudioFft: () => false,
@@ -39,7 +47,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
   // by MOR-1451, out of its scope). s_meter is the one exception: it has no
   // such fallback, hence the explicit fixture above.
   getMeterCalibration: (meterType: string) =>
-    meterType === 's_meter' ? IC7610_LIKE_S_METER_CAL : null,
+    meterType === 's_meter' ? activeSMeterCal : null,
   getMeterRedline: () => null,
   getControlRange: () => null,
 }));
@@ -78,6 +86,7 @@ import {
   formatAlc,
   formatCompDb,
 } from '../../meter-utils';
+import { calibratedToSUnit, calibratedToDbm, formatDbm } from '../../../meters/smeter-scale';
 
 let target: HTMLDivElement;
 
@@ -275,4 +284,77 @@ describe('AmberSmeter', () => {
     expect(sub.textContent).toBe(formatCompDb(75)); // '15 dB', not '6dB'
     unmount(component);
   });
+});
+
+// ── MOR-2034: non-uniform-calibration discrimination ────────────────────────
+// The S-source tests above ('handles the calibrated floor', 'shows dBm in
+// readout') only assert exact text at S0 and S9 — both calibration ANCHORS,
+// reproduced identically by any reasonable derivation — and `IC7610_LIKE_S_
+// METER_CAL` is itself uniform between them (6 dB/S-unit). Neither can tell
+// AmberSmeter's real `calibratedToSUnit`/`calibratedToDbm` delegation
+// (`AmberSmeter.svelte`'s import) apart from a hardcoded 6 dB/S-unit
+// reimplementation — the exact shape MOR-2024 found and fixed in a sibling
+// file (`components-v2/panels/meter-utils.ts`'s old `formatSMeter`).
+// AmberSmeter is outside `meter-contract.ts`'s `METER_REGISTRY` census (that
+// census is `.svelte` files directly under `components-v2/meters/`; this one
+// lives under `components-v2/panels/lcd/`, mounted by the `lcd-cockpit`/
+// `lcd-scope` skins), so nothing else in the suite would catch a regression
+// here. This block reuses `meter-contract.test.ts`'s own non-uniform
+// fixture and probe reasoning (`components-v2/meters/__tests__/
+// meter-contract.test.ts` — see its file header for the full worked-out
+// argument for why these three probes rule out every fixed per-S-unit step)
+// against the real mounted component, the same technique that file already
+// applies to `LinearSMeter.svelte`.
+describe('AmberSmeter — non-uniform calibration (MOR-2034)', () => {
+  const NON_UNIFORM_CAL: MeterCalPoint[] = [
+    { raw: 0, actual: -54, label: 'S0' },
+    { raw: 26, actual: -48, label: 'S1' },
+    { raw: 52, actual: -45, label: 'S2' },
+    { raw: 78, actual: -42, label: 'S3' },
+    { raw: 104, actual: -36, label: 'S4' },
+    { raw: 130, actual: -30, label: 'S5' },
+    { raw: 156, actual: -12, label: 'S6' }, // +18 dB step, vs. 3-6 dB elsewhere
+    { raw: 182, actual: -6, label: 'S7' },
+    { raw: 208, actual: -3, label: 'S8' },
+    { raw: 230, actual: 0, label: 'S9' },
+    { raw: 255, actual: 20, label: 'S9+20' },
+  ];
+
+  beforeEach(() => {
+    activeSMeterCal = NON_UNIFORM_CAL;
+  });
+
+  afterEach(() => {
+    activeSMeterCal = IC7610_LIKE_S_METER_CAL;
+  });
+
+  // Kills: AmberSmeter reimplementing its own S-unit math (a fixed step or
+  // any other formula) instead of delegating to calibratedToSUnit — on this
+  // non-uniform table the two would diverge at one of these three probes
+  // even though they agree everywhere on the uniform table above. Reads
+  // `.readout-s` specifically, not the whole component's textContent: the
+  // scale ruler renders odd S-unit tick labels (S1/S3/S5/S7/S9) elsewhere in
+  // the same component (see `majorTicks` in `AmberSmeter.svelte`), so a
+  // whole-textContent search would risk a false pass the way
+  // `meter-contract.test.ts`'s file header warns about; scoping to the
+  // readout element side-steps that collision entirely.
+  it.each([-43, -33, -11])(
+    'renders the exact S-unit calibratedToSUnit computes at probe %d, not a local approximation',
+    (actual) => {
+      const component = mount(AmberSmeter, { target, props: { value: actual } });
+      const readout = target.querySelector('.readout-s')!.textContent;
+      expect(readout).toBe(calibratedToSUnit(actual));
+      unmount(component);
+    },
+  );
+
+  it.each([-43, -33, -11])(
+    'renders the exact dBm text calibratedToDbm/formatDbm compute at probe %d, not a local approximation',
+    (actual) => {
+      const component = mount(AmberSmeter, { target, props: { value: actual } });
+      const readout = target.querySelector('.readout-dbm')!.textContent;
+      expect(readout).toBe(formatDbm(calibratedToDbm(actual)));
+      unmount(component);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- Adds `docs/internals/skins-presentation-boundary-gate.md`: the MOR-2034
  release-gate entry for the owner's acceptance criterion ("build a theme
  with its own S-meters and indicators — up to a full IC-7610/FTX-1 replica
  or an original SDR interface — without touching anything below the
  presentation layer"). The mechanical enforcement for both halves of that
  criterion (skins/panels eslint import-boundary zone, entrypoint-coverage
  census, meter conformance contract, typed `data-*` state vocabulary) was
  already built by MOR-2036/2037/2038/2039/2024 — this names those
  mechanisms, states what each proves, and states its honest limit,
  instead of adding a new, redundant check. Follows the form of the two
  closest in-repo precedents, `radio-state-pipeline-validation.md`
  (MOR-348) and `backend-neutral-readiness-gap-register.md` (MOR-424);
  MOR-1413/MOR-1102 are Linear-native gates with no file in this repo to
  sit beside.
- Cross-references the new gate from
  `docs/plans/2026-04-12-target-frontend-architecture.md`'s evidence-gates
  section (6-line addition, no restructuring).
- Closes a real coverage gap the audit surfaced: `METER_REGISTRY`
  (MOR-2037) censuses only `.svelte` files directly under
  `components-v2/meters/`. Two other live production call sites of
  `smeter-scale.ts` — `AmberSmeter.svelte` (the `amber-lcd` theme's own
  S-meter) and the `mobile` skin's `mobile-layout-logic.ts` — had tests,
  but only against a uniform calibration table, which cannot tell a real
  `calibratedToSUnit`/`calibratedToDbm` delegation apart from a hardcoded
  6 dB/S-unit reimplementation (the exact defect shape MOR-2024 fixed in
  `meter-utils.ts`). Adds a non-uniform-calibration discrimination suite
  to both, reusing `meter-contract.test.ts`'s own fixture/probe reasoning.
  A third candidate, `skins/sdr-test/SdrVfoScreen.svelte`, is unreached
  dead code (no import anywhere outside its own file, its test files, and
  one doc comment; `SdrTestSkin.svelte`'s header and `RadioLayout.svelte`
  confirm it), so it is documented as such rather than "fixed".

## Provenance

Recovered from a stranded, uncommitted worktree left by an agent killed
mid-task by a session limit. Rebased onto current `main` (one unrelated
backend commit, MOR-2008 batch 1 — no overlap) and re-verified line by
line against the current tree before landing: every mechanism cited in
the new doc (eslint rule names/scopes, test names, `METER_REGISTRY`
scope, `state-vocabulary.ts` exports, the two precedent docs' form) was
independently re-checked against the actual source, not taken on the
stranded draft's word.

## Test plan

- [x] `npm run check` (svelte-check + tsc) — 4603 files, 0 errors, 0
      warnings
- [x] `npm run lint` (full `eslint src/`) — clean
- [x] `npm run test` (full `vitest run`) — 370 files / 8116 tests passed
- [x] Both-directions proof, reproduced directly (not just re-read from
      the draft):
  - Real violation: a scratch file under `src/skins/` importing
    `$lib/stores/capabilities.svelte` → real `eslint` error: `'$lib/
    stores/capabilities.svelte' import is restricted from being used by
    a pattern. Skins must not import from $lib/stores/* — route via
    lib/runtime/adapters/* instead...` (exit 1). Deleted after.
  - Legitimate skin with its own custom instrument, real files, real
    linter: `eslint src/skins/ src/components-v2/panels/lcd/
    AmberSmeter.svelte src/components-v2/panels/lcd/AmberCockpit.svelte`
    → exit 0, no errors — the criterion's own scenario (a theme with its
    own S-meter) is not collateral damage of the boundary rule.
  - New discrimination tests, red: hand-patched `formatSValue` (mobile)
    and `AmberSmeter`'s `sReadout` with a hardcoded 6 dB/S-unit ladder →
    the new MOR-2034 probes fail (`expected 'S3' to be 'S4'`, `expected
    'S7' to be 'S6'`) in both files; reverted immediately after.
  - New discrimination tests, green: unmutated code, same suites — pass.

Guardrails: 5 files / 374 changed lines (370 additions + 4 deletions, measured at head 5f73cef1), both well under the soft
threshold (6/600).

