### PR TITLE
feat(MOR-2008): migrate mode, tone, antenna, meters and freq onto the bound command map (batch 2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -230,6 +230,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `equal_` equivalent), so a caller that needs the old ordering inlines that
   expression. No production code in this repository read either property —
   consumers were tests only.
+- **`rigplane.commands.mode`/`tone`/`antenna`/`meters` builders require
+  `cmd_map`; there is no hardcoded fallback (MOR-2008, batch 2 of
+  `docs/plans/2026-08-29-profile-driven-command-bytes.md`).** All 40
+  builders across the four modules — operating mode, DATA mode, filter
+  shape/width, SSB TX bandwidth, Main/Sub tracking, AGC time constant
+  (mode.py); repeater tone/TSQL and tone/TSQL frequency (tone.py); ANT1/
+  ANT2 select/read and RX-ANT-state select/read for both antennas
+  (antenna.py); S/SWR/ALC/power/comp/Vd/Id meters, S-meter-squelch/
+  overflow/various-squelch status (meters.py) — plus
+  `rigplane.commands.freq`'s `get_freq`/`set_freq` (2
+  more, 42 in total this batch) now require `cmd_map` as a required
+  keyword-only argument. `freq.py`'s other five builders
+  (`get_selected_freq`/`get_unselected_freq`/`get_selected_mode`/
+  `get_unselected_mode`/`set_selected_mode`) have no `cmd_map` parameter at
+  all and stay out of scope — MOR-2008's Group B (these five plus
+  `memory.py` and `tx_band.py`), ruled by the owner to migrate later, after
+  the missing/inconsistent TOML declarations are filled in from the
+  manuals. Most of these 42 carry no behaviour change: every declaring CI-V
+  profile already held the identical wire tuple the deleted fallback
+  built. **`set_repeater_tone`/`set_repeater_tsql`/`set_tone_freq`/
+  `set_tsql_freq` (and their `get_` twins) are the exception on IC-7610:**
+  `rigs/ic7610.toml` documents that this whole family is intentionally
+  *not* declared, following a live-bench readback (recorded in the TOML,
+  citing MOR-660/661/682) that found the old hardcoded fallback's bytes
+  decoded to garbage (16.5 Hz) on this radio. Before this migration the
+  fallback still built and sent those bytes regardless; now, on IC-7610,
+  the same call raises `CommandError` (undeclared-command refusal) instead
+  — a correction, not a regression: trusting what the profile actually
+  declares over a blind fallback, the same principle behind batch 1's
+  `system.py` IC-7300 date/time fix (there the profile's own bytes replace
+  the fallback's; here the profile's declared *absence* does).
+  `antenna.py`'s `get_antenna`/
+  `set_antenna` ANT1/ANT2 selector is documented in the module's own
+  docstring as deliberately *not* wired through `runtime/radio.py:
+  CoreRadio._expect_shape`: the selector is a CI-V protocol invariant
+  supplied as caller data, not a value the command map declares as a
+  `sub` byte (the TOML's `get_antenna = [0x12]` tuple carries no `sub` at
+  all). The production call sites, in `runtime/radio.py: CoreRadio` and
+  `runtime/_dual_rx_runtime.py: DualRxRuntimeMixin` (the real callers of
+  `get_freq`/`set_freq`/`get_mode`/`set_mode`), moved onto
+  `self._commands.<builder>(...)` in the same change.
 
 ### Changed
 

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1215,11 +1215,14 @@ get_vd_meter = [0x15, 0x15]
 get_id_meter = [0x15, 0x16]
 
 # ── Tone / TSQL ──
-# Intentionally absent: the IC-7610 (HF/6m) has no FM-repeater CTCSS tone
-# feature, so the repeater-tone / TSQL family is NOT declared as a capability
-# (MOR-660/661). With no declared capability and no registry check referencing
-# them, the get/set_repeater_tone, get/set_repeater_tsql, get/set_tone_freq,
-# and get/set_tsql_freq command entries were dead/orphaned and were removed
+# Declared absent (MOR-2008 batch 2 -- promoted from a comment-only D1
+# state 3 (unknown, warn-and-refuse) to a formal state 2 row (declared
+# absent, refuse-silently) below): the IC-7610 (HF/6m) has no
+# FM-repeater CTCSS tone feature, so the repeater-tone / TSQL family is
+# NOT declared as a capability (MOR-660/661). With no declared
+# capability and no registry check referencing them, the
+# get/set_repeater_tone, get/set_repeater_tsql, get/set_tone_freq, and
+# get/set_tsql_freq command entries were dead/orphaned and were removed
 # (MOR-682). Do not re-add them without first declaring the capability.
 #
 # D2 documentary re-check (MOR-2017): the IC-7610 CI-V Reference Guide
@@ -1231,7 +1234,17 @@ get_id_meter = [0x15, 0x16]
 # that finding on IC-7610 (retired from the live bench 2026-08-04). A
 # guide printing a command-table address is not proof the radio's firmware
 # answers it meaningfully. Recorded as a conflict between this pass's
-# verdict and the prior bench finding; not resolved here.
+# verdict and the prior bench finding; not resolved here -- the `absent`
+# source below cites the bench finding as the grounds for the row, not
+# the guide, since the guide is the very thing the row overrides.
+get_repeater_tone = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+set_repeater_tone = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+get_repeater_tsql = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+set_repeater_tsql = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+get_tone_freq = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+set_tone_freq = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+get_tsql_freq = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
+set_tsql_freq = { absent = "live-bench readback (MOR-660/661/682): repeater-tone/TSQL/tone-freq/TSQL-freq replies decoded to garbage (16.5 Hz) on this radio, not the documented values -- D2 re-check MOR-2017 confirms the IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) prints these same addresses regardless" }
 
 # ── Data Mode ──
 get_data_mode = [0x1A, 0x06]

--- a/src/rigplane/commands/_builders.py
+++ b/src/rigplane/commands/_builders.py
@@ -11,9 +11,7 @@ from ._codec import _bcd_byte, _bcd_decode_value
 from ._frame import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
-    _CMD_CTL_MEM,
     _CMD_LEVEL,
-    _CMD_METER,
     _CMD_PREAMP,
     _build_from_map,
     build_civ_frame,
@@ -23,36 +21,6 @@ from ._frame import (
 if TYPE_CHECKING:
     from ..command_map import CommandMap
     from ..types import CivFrame
-
-
-def _build_meter_bool_get(
-    sub: int,
-    *,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    receiver: int = RECEIVER_MAIN,
-    command29: bool = False,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    if cmd_map is not None and cmd_name is not None:
-        return _build_from_map(
-            cmd_map,
-            cmd_name,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            receiver=receiver,
-            command29=command29,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_METER,
-            sub=sub,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=sub)
 
 
 def _build_function_get(
@@ -155,74 +123,6 @@ def _build_function_value_set(
             receiver=receiver,
         )
     return build_civ_frame(to_addr, from_addr, _CMD_PREAMP, sub=sub, data=payload)
-
-
-def _build_ctl_mem_single_bcd_get(
-    sub: int,
-    *,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    receiver: int = RECEIVER_MAIN,
-    command29: bool = False,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    if cmd_map is not None and cmd_name is not None:
-        return _build_from_map(
-            cmd_map,
-            cmd_name,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            receiver=receiver,
-            command29=command29,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_CTL_MEM,
-            sub=sub,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_CTL_MEM, sub=sub)
-
-
-def _build_ctl_mem_single_bcd_set(
-    sub: int,
-    value: int,
-    *,
-    minimum: int,
-    maximum: int,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    receiver: int = RECEIVER_MAIN,
-    command29: bool = False,
-    cmd_map: CommandMap | None = None,
-    cmd_name: str | None = None,
-) -> bytes:
-    if not minimum <= value <= maximum:
-        raise ValueError(f"Value must be {minimum}-{maximum}, got {value}")
-    payload = bytes([_bcd_byte(value)])
-    if cmd_map is not None and cmd_name is not None:
-        return _build_from_map(
-            cmd_map,
-            cmd_name,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=payload,
-            receiver=receiver,
-            command29=command29,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_CTL_MEM,
-            sub=sub,
-            data=payload,
-            receiver=receiver,
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_CTL_MEM, sub=sub, data=payload)
 
 
 def parse_level_response(

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -59,13 +59,9 @@ _SUB_RF_POWER = 0x0A
 
 # Sub-commands for 0x15 (Meters)
 _SUB_S_METER = 0x02
-_SUB_VARIOUS_SQUELCH = 0x05
 _SUB_POWER_METER = 0x11
 _SUB_SWR_METER = 0x12
 _SUB_ALC_METER = 0x13
-_SUB_COMP_METER = 0x14
-_SUB_VD_METER = 0x15
-_SUB_ID_METER = 0x16
 
 # Sub-commands for 0x1C (PTT / Transceiver status)
 _SUB_PTT = 0x00
@@ -77,7 +73,6 @@ _SUB_AF_MUTE = 0x09
 _SUB_MEMORY_CONTENTS = 0x00
 _SUB_BAND_STACK = 0x01
 _SUB_AGC_TIME_CONSTANT = 0x04
-_SUB_FILTER_WIDTH = 0x03
 
 # CTL_MEM prefixes (0x1A 0x05 ...). `commands/levels.py`'s own five
 # (ref_adjust, dash_ratio, nb_depth, nb_width, vox_delay) are gone as of
@@ -88,7 +83,6 @@ _CTL_MEM_SYSTEM_TIME = b"\x01\x59"
 _CTL_MEM_UTC_OFFSET = b"\x01\x62"
 
 # Antenna command (0x12)
-_CMD_ANTENNA = 0x12
 _SUB_ANT1 = 0x00
 _SUB_ANT2 = 0x01
 _SUB_RX_ANT_ANT1 = 0x12
@@ -97,8 +91,6 @@ _SUB_RX_ANT_ANT2 = 0x13
 # ATT / Preamp / DSP function sub-commands (0x11 / 0x16)
 _CMD_ATT = 0x11
 _CMD_PREAMP = 0x16
-_SUB_S_METER_SQL_STATUS = 0x01
-_SUB_OVERFLOW_STATUS = 0x07
 _SUB_PREAMP_STATUS = 0x02
 _SUB_AGC = 0x12
 _SUB_AUDIO_PEAK_FILTER = 0x32
@@ -161,7 +153,8 @@ _COMMANDS_WITH_SUB: set[int] = {
     0x27,
     0x16,
     _CMD_TONE,
-    _CMD_ANTENNA,
+    0x12,  # Antenna -- named _CMD_ANTENNA until antenna.py's own reader
+    # (MOR-2008 batch 2) was its last, same as 0x27/0x16/0x19 below
     0x19,
 }
 

--- a/src/rigplane/commands/antenna.py
+++ b/src/rigplane/commands/antenna.py
@@ -7,10 +7,11 @@ Zero divergence rows -- every declaring profile's tuple already matched the
 fallback's own bytes exactly (verified by grep across ``rigs/*.toml`` before
 deleting each fallback).
 
-Not a matcher-backed-getter candidate for `tests/test_response_shape_from_
-profile.py`'s keystone table, despite all four getters routing through
-``CoreRadio._get_bool_value``: the ANT1/ANT2 selector (0x00/0x01) is not a
-profile-declared sub-command at all -- ``rigs/*.toml``'s own ``get_antenna``
+Not a matcher-backed-getter candidate for
+`tests/test_response_shape_from_profile.py`'s keystone table, despite all
+four getters routing through ``CoreRadio._get_bool_value``: the ANT1/ANT2
+selector (0x00/0x01) is not a profile-declared sub-command at all --
+``rigs/*.toml``'s own ``get_antenna``
 key is a bare ``[0x12]`` tuple with no sub, and the selector is appended by
 the *caller* as data (``_build_from_map(cmd_map, "get_antenna", ...,
 data=bytes([_SUB_ANT1]))``). ``_frame.py: _COMMANDS_WITH_SUB`` still splits

--- a/src/rigplane/commands/antenna.py
+++ b/src/rigplane/commands/antenna.py
@@ -1,4 +1,26 @@
-"""Antenna selection / RX-ANT commands (0x12)."""
+"""Antenna selection / RX-ANT commands (0x12).
+
+Migrated onto the bound command map in MOR-2008 (batch 2,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N): all
+eight builders now require ``cmd_map``, with no hardcoded fallback left.
+Zero divergence rows -- every declaring profile's tuple already matched the
+fallback's own bytes exactly (verified by grep across ``rigs/*.toml`` before
+deleting each fallback).
+
+Not a matcher-backed-getter candidate for `tests/test_response_shape_from_
+profile.py`'s keystone table, despite all four getters routing through
+``CoreRadio._get_bool_value``: the ANT1/ANT2 selector (0x00/0x01) is not a
+profile-declared sub-command at all -- ``rigs/*.toml``'s own ``get_antenna``
+key is a bare ``[0x12]`` tuple with no sub, and the selector is appended by
+the *caller* as data (``_build_from_map(cmd_map, "get_antenna", ...,
+data=bytes([_SUB_ANT1]))``). ``_frame.py: _COMMANDS_WITH_SUB`` still splits
+a 0x12 reply's byte[1] into ``frame.sub``, so the wire-level fact
+``runtime/radio.py``'s hardcoded ``command=0x12, sub=0x00``/``0x01`` checks
+is a CI-V protocol invariant (which physical antenna a value belongs to),
+not something any profile could declare differently -- deriving it via
+``self._expect_shape(...)`` would incorrectly read ``sub=None`` off the
+map's own bare tuple. Left hardcoded, unchanged by this migration.
+"""
 
 from __future__ import annotations
 
@@ -6,170 +28,150 @@ from typing import TYPE_CHECKING
 
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_ANTENNA,
     _SUB_ANT1,
     _SUB_ANT2,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
     from ..command_map import CommandMap
 
 
+@expose_command_key(lambda cmd_map: "get_antenna")
+@require_cmd_map
 def get_antenna_1(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build ANT1 select/read command (0x12 0x00) WITHOUT data byte."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "get_antenna",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT1]),
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_ANTENNA, sub=_SUB_ANT1)
+    return _build_from_map(
+        cmd_map,
+        "get_antenna",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT1]),
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_antenna")
+@require_cmd_map
 def set_antenna_1(
     enabled: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build ANT1 select command (0x12 0x00 <00|01>)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_antenna",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT1]) + (b"\x01" if enabled else b"\x00"),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_ANTENNA,
-        sub=_SUB_ANT1,
-        data=b"\x01" if enabled else b"\x00",
+    return _build_from_map(
+        cmd_map,
+        "set_antenna",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT1]) + (b"\x01" if enabled else b"\x00"),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_antenna")
+@require_cmd_map
 def get_antenna_2(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build ANT2 select/read command (0x12 0x01) WITHOUT data byte."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "get_antenna",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT2]),
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_ANTENNA, sub=_SUB_ANT2)
+    return _build_from_map(
+        cmd_map,
+        "get_antenna",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT2]),
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_antenna")
+@require_cmd_map
 def set_antenna_2(
     enabled: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build ANT2 select command (0x12 0x01 <00|01>)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_antenna",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT2]) + (b"\x01" if enabled else b"\x00"),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_ANTENNA,
-        sub=_SUB_ANT2,
-        data=b"\x01" if enabled else b"\x00",
+    return _build_from_map(
+        cmd_map,
+        "set_antenna",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT2]) + (b"\x01" if enabled else b"\x00"),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_antenna")
+@require_cmd_map
 def get_rx_antenna_ant1(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build read RX ANT state for ANT1 (0x12 0x00). Warning: also selects ANT1."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "get_antenna",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT1]),
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_ANTENNA, sub=_SUB_ANT1)
+    return _build_from_map(
+        cmd_map,
+        "get_antenna",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT1]),
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_antenna")
+@require_cmd_map
 def set_rx_antenna_ant1(
     enabled: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build set RX ANT state for ANT1 (0x12 0x00 <00|01>). Warning: also selects ANT1."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_antenna",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT1]) + (b"\x01" if enabled else b"\x00"),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_ANTENNA,
-        sub=_SUB_ANT1,
-        data=b"\x01" if enabled else b"\x00",
+    return _build_from_map(
+        cmd_map,
+        "set_antenna",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT1]) + (b"\x01" if enabled else b"\x00"),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_rx_antenna_ant2")
+@require_cmd_map
 def get_rx_antenna_ant2(
-    to_addr: int, from_addr: int = CONTROLLER_ADDR, cmd_map: CommandMap | None = None
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build read RX ANT state for ANT2 (0x12 0x01). Warning: also selects ANT2."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "get_rx_antenna_ant2",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT2]),
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_ANTENNA, sub=_SUB_ANT2)
+    return _build_from_map(
+        cmd_map,
+        "get_rx_antenna_ant2",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT2]),
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_rx_antenna_ant2")
+@require_cmd_map
 def set_rx_antenna_ant2(
     enabled: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build set RX ANT state for ANT2 (0x12 0x01 <00|01>). Warning: also selects ANT2."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_rx_antenna_ant2",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([_SUB_ANT2]) + (b"\x01" if enabled else b"\x00"),
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_ANTENNA,
-        sub=_SUB_ANT2,
-        data=b"\x01" if enabled else b"\x00",
+    return _build_from_map(
+        cmd_map,
+        "set_rx_antenna_ant2",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([_SUB_ANT2]) + (b"\x01" if enabled else b"\x00"),
     )
 
 

--- a/src/rigplane/commands/freq.py
+++ b/src/rigplane/commands/freq.py
@@ -7,11 +7,11 @@ divergence rows -- every declaring profile's tuple already matched the
 fallback's own bytes exactly (verified by grep across ``rigs/*.toml``
 before deleting the fallback). ``_CMD_FREQ_GET``/``_CMD_FREQ_SET`` survive
 in `_frame.py`, unaffected: ``parse_frequency_response`` below still reads
-``_CMD_FREQ_GET`` directly, and several tests
-(`tests/test_radio.py`, `tests/test_civ_command_profiling.py`,
-`tests/test_icom7610_serial_radio.py`, `tests/_helpers.py`, others) import
-both constants directly to build synthetic frames, unconnected to this
-module's own fallback.
+``_CMD_FREQ_GET`` directly, and several tests import ``_CMD_FREQ_GET``
+directly to build synthetic frames, unconnected to this module's own
+fallback (`tests/test_radio.py`, `tests/test_icom7610_serial_radio.py`,
+`tests/_helpers.py`, others) -- ``tests/test_civ_command_profiling.py``
+is the only one of these that also imports ``_CMD_FREQ_SET``.
 
 The rest of this module (``get_selected_freq``/``get_unselected_freq``/
 ``get_selected_mode``/``get_unselected_mode``/``set_selected_mode`` and

--- a/src/rigplane/commands/freq.py
+++ b/src/rigplane/commands/freq.py
@@ -1,4 +1,27 @@
-"""Frequency commands (0x03/0x05/0x25/0x26)."""
+"""Frequency commands (0x03/0x05/0x25/0x26).
+
+``get_freq``/``set_freq`` migrated onto the bound command map in MOR-2008
+(batch 2, `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps
+5..N): both now require ``cmd_map``, with no hardcoded fallback left. Zero
+divergence rows -- every declaring profile's tuple already matched the
+fallback's own bytes exactly (verified by grep across ``rigs/*.toml``
+before deleting the fallback). ``_CMD_FREQ_GET``/``_CMD_FREQ_SET`` survive
+in `_frame.py`, unaffected: ``parse_frequency_response`` below still reads
+``_CMD_FREQ_GET`` directly, and several tests
+(`tests/test_radio.py`, `tests/test_civ_command_profiling.py`,
+`tests/test_icom7610_serial_radio.py`, `tests/_helpers.py`, others) import
+both constants directly to build synthetic frames, unconnected to this
+module's own fallback.
+
+The rest of this module (``get_selected_freq``/``get_unselected_freq``/
+``get_selected_mode``/``get_unselected_mode``/``set_selected_mode`` and
+their parsers) is out of this batch's scope: none of the five has a
+``cmd_map`` parameter at all today -- no dual implementation exists to
+delete a fallback from. MOR-2008's Group B (`memory.py`, `tx_band.py`,
+these five) is a separate, later piece of work (owner ruling on the
+ticket): fill the missing/inconsistent TOML declarations from the
+manuals first, then migrate under this same contract.
+"""
 
 from __future__ import annotations
 
@@ -10,12 +33,12 @@ from ._frame import (
     RECEIVER_MAIN,
     _CMD_BAND_EDGE,
     _CMD_FREQ_GET,
-    _CMD_FREQ_SET,
     _CMD_SELECTED_FREQ,
     _CMD_SELECTED_MODE,
     _build_from_map,
     build_civ_frame,
-    build_cmd29_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -23,25 +46,24 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
+@expose_command_key(lambda cmd_map: "get_freq")
+@require_cmd_map
 def get_freq(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'get frequency' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_freq", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_FREQ_GET)
+    return _build_from_map(cmd_map, "get_freq", to_addr=to_addr, from_addr=from_addr)
 
 
+@expose_command_key(lambda cmd_map: "set_freq")
+@require_cmd_map
 def set_freq(
     freq_hz: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set frequency' CI-V command.
 
@@ -59,22 +81,15 @@ def set_freq(
     Returns:
         CI-V frame bytes.
     """
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_freq",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bcd_encode(freq_hz),
-            receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
-        )
-    bcd = bcd_encode(freq_hz)
-    if receiver != RECEIVER_MAIN:
-        return build_cmd29_frame(
-            to_addr, from_addr, _CMD_FREQ_SET, data=bcd, receiver=receiver
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_FREQ_SET, data=bcd)
+    return _build_from_map(
+        cmd_map,
+        "set_freq",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bcd_encode(freq_hz),
+        receiver=receiver,
+        command29=(receiver != RECEIVER_MAIN),
+    )
 
 
 def parse_frequency_response(frame: CivFrame) -> int:

--- a/src/rigplane/commands/meters.py
+++ b/src/rigplane/commands/meters.py
@@ -1,26 +1,32 @@
-"""All 0x15-family meter read commands."""
+"""All 0x15-family meter read commands.
+
+Migrated onto the bound command map in MOR-2008 (batch 2,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N): all
+ten builders now require ``cmd_map``, with no hardcoded fallback left. Zero
+divergence rows -- every declaring profile's tuple already matched the
+fallback's own bytes exactly (verified by grep across ``rigs/*.toml`` before
+deleting each fallback).
+
+``_build_meter_bool_get`` is gone from `_builders.py`: this module was its
+only caller, so its own ``cmd_map is None`` fallback branch would otherwise
+become dead code nobody reads -- ``get_s_meter_sql_status``/
+``get_overflow_status``/``get_various_squelch`` now call `_frame.py:
+_build_from_map` directly instead, the same de-delegation `config.py`'s/
+`levels.py`'s own migrations already did for their single-caller templates.
+"""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ._builders import _build_meter_bool_get
 from ._codec import _level_bcd_decode
 from ._frame import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
     _CMD_METER,
-    _SUB_ALC_METER,
-    _SUB_COMP_METER,
-    _SUB_ID_METER,
-    _SUB_POWER_METER,
-    _SUB_S_METER,
-    _SUB_S_METER_SQL_STATUS,
-    _SUB_SWR_METER,
-    _SUB_VARIOUS_SQUELCH,
-    _SUB_VD_METER,
     _build_from_map,
-    build_civ_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -28,39 +34,31 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
+@expose_command_key(lambda cmd_map: "get_s_meter")
+@require_cmd_map
 def get_s_meter(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'read S-meter' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_s_meter", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_S_METER)
+    return _build_from_map(cmd_map, "get_s_meter", to_addr=to_addr, from_addr=from_addr)
 
 
+@expose_command_key(lambda cmd_map: "get_swr")
+@require_cmd_map
 def get_swr(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'read SWR meter' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(cmd_map, "get_swr", to_addr=to_addr, from_addr=from_addr)
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_SWR_METER)
+    return _build_from_map(cmd_map, "get_swr", to_addr=to_addr, from_addr=from_addr)
 
 
+@expose_command_key(lambda cmd_map: "get_alc")
+@require_cmd_map
 def get_alc(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'read ALC meter' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(cmd_map, "get_alc", to_addr=to_addr, from_addr=from_addr)
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_ALC_METER)
+    return _build_from_map(cmd_map, "get_alc", to_addr=to_addr, from_addr=from_addr)
 
 
 def parse_meter_response(frame: CivFrame) -> int:
@@ -79,110 +77,98 @@ def parse_meter_response(frame: CivFrame) -> int:
     return _level_bcd_decode(frame.data)
 
 
+@expose_command_key(lambda cmd_map: "get_s_meter_sql_status")
+@require_cmd_map
 def get_s_meter_sql_status(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read S-meter squelch status command."""
-    return _build_meter_bool_get(
-        _SUB_S_METER_SQL_STATUS,
+    return _build_from_map(
+        cmd_map,
+        "get_s_meter_sql_status",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_s_meter_sql_status",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_overflow_status")
+@require_cmd_map
 def get_overflow_status(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read overflow status command."""
-    from ._frame import _SUB_OVERFLOW_STATUS
-
-    return _build_meter_bool_get(
-        _SUB_OVERFLOW_STATUS,
-        to_addr=to_addr,
-        from_addr=from_addr,
-        cmd_map=cmd_map,
-        cmd_name="get_overflow_status",
+    return _build_from_map(
+        cmd_map, "get_overflow_status", to_addr=to_addr, from_addr=from_addr
     )
 
 
+@expose_command_key(lambda cmd_map: "get_various_squelch")
+@require_cmd_map
 def get_various_squelch(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read various-squelch status command (0x15 0x05, Command29)."""
-    return _build_meter_bool_get(
-        _SUB_VARIOUS_SQUELCH,
+    return _build_from_map(
+        cmd_map,
+        "get_various_squelch",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_various_squelch",
     )
 
 
+@expose_command_key(lambda cmd_map: "get_power_meter")
+@require_cmd_map
 def get_power_meter(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read RF power meter command (0x15 0x11)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_power_meter", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_POWER_METER)
+    return _build_from_map(
+        cmd_map, "get_power_meter", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_comp_meter")
+@require_cmd_map
 def get_comp_meter(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read compressor meter command (0x15 0x14)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_comp_meter", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_COMP_METER)
+    return _build_from_map(
+        cmd_map, "get_comp_meter", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_vd_meter")
+@require_cmd_map
 def get_vd_meter(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Vd (supply voltage) meter command (0x15 0x15)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_vd_meter", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_VD_METER)
+    return _build_from_map(
+        cmd_map, "get_vd_meter", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_id_meter")
+@require_cmd_map
 def get_id_meter(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Id (drain current) meter command (0x15 0x16)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_id_meter", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_METER, sub=_SUB_ID_METER)
+    return _build_from_map(
+        cmd_map, "get_id_meter", to_addr=to_addr, from_addr=from_addr
+    )

--- a/src/rigplane/commands/mode.py
+++ b/src/rigplane/commands/mode.py
@@ -7,7 +7,7 @@ Zero divergence rows -- every declaring profile's tuple already matched the
 fallback's own bytes exactly (verified by grep across ``rigs/*.toml`` before
 deleting each fallback).
 
-Nine of the fourteen route through `_builders.py` shared templates
+Six of the fourteen route through `_builders.py` shared templates
 (``_build_function_get``/``_build_function_value_set``/
 ``_build_function_bool_set``), which stay -- `dsp.py` (not migrated in this
 batch) still calls them with ``cmd_map=None``, so their fallback branches

--- a/src/rigplane/commands/mode.py
+++ b/src/rigplane/commands/mode.py
@@ -1,4 +1,25 @@
-"""Mode commands (0x04/0x06), data mode, filter shape/width, SSB BW, AGC time constant."""
+"""Mode commands (0x04/0x06), data mode, filter shape/width, SSB BW, AGC time constant.
+
+Migrated onto the bound command map in MOR-2008 (batch 2,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N): all
+fourteen builders now require ``cmd_map``, with no hardcoded fallback left.
+Zero divergence rows -- every declaring profile's tuple already matched the
+fallback's own bytes exactly (verified by grep across ``rigs/*.toml`` before
+deleting each fallback).
+
+Nine of the fourteen route through `_builders.py` shared templates
+(``_build_function_get``/``_build_function_value_set``/
+``_build_function_bool_set``), which stay -- `dsp.py` (not migrated in this
+batch) still calls them with ``cmd_map=None``, so their fallback branches
+are not dead yet. ``_build_ctl_mem_single_bcd_get``/
+``_build_ctl_mem_single_bcd_set`` are gone: this module was their only
+caller, so their own ``cmd_map is None`` fallback branches would otherwise
+become dead code nobody reads -- ``get_filter_width``/
+``get_agc_time_constant``/``set_agc_time_constant`` now call
+`_frame.py: _build_from_map` directly instead, the same de-delegation
+`config.py`'s/`levels.py`'s own migrations already did for their
+single-caller templates.
+"""
 
 from __future__ import annotations
 
@@ -6,27 +27,23 @@ from typing import TYPE_CHECKING
 
 from ..types import FilterShape, Mode, SsbTxBandwidth
 from ._builders import (
-    _build_ctl_mem_single_bcd_get,
-    _build_ctl_mem_single_bcd_set,
+    _build_function_bool_set,
     _build_function_get,
     _build_function_value_set,
 )
-from ._codec import bcd_encode_value
+from ._codec import _bcd_byte, bcd_encode_value
 from ._frame import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
     _CMD_CTL_MEM,
     _CMD_MODE_GET,
-    _CMD_MODE_SET,
-    _SUB_AGC_TIME_CONSTANT,
     _SUB_DATA_MODE,
     _SUB_FILTER_SHAPE,
-    _SUB_FILTER_WIDTH,
     _SUB_MAIN_SUB_TRACKING,
     _SUB_SSB_TX_BANDWIDTH,
     _build_from_map,
-    build_civ_frame,
-    build_cmd29_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -34,19 +51,17 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
+@expose_command_key(lambda cmd_map: "get_mode")
+@require_cmd_map
 def get_mode(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'get mode' CI-V command."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_mode", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_MODE_GET)
+    return _build_from_map(cmd_map, "get_mode", to_addr=to_addr, from_addr=from_addr)
 
 
+@expose_command_key(lambda cmd_map: "set_mode")
+@require_cmd_map
 def set_mode(
     mode: Mode,
     filter_width: int | None = None,
@@ -54,7 +69,7 @@ def set_mode(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set mode' CI-V command.
 
@@ -71,21 +86,15 @@ def set_mode(
     data = bytes([mode])
     if filter_width is not None:
         data += bytes([filter_width])
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_mode",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=data,
-            command29=receiver != RECEIVER_MAIN,
-            receiver=receiver,
-        )
-    if receiver != RECEIVER_MAIN:
-        return build_cmd29_frame(
-            to_addr, from_addr, _CMD_MODE_SET, data=data, receiver=receiver
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_MODE_SET, data=data)
+    return _build_from_map(
+        cmd_map,
+        "set_mode",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=data,
+        command29=receiver != RECEIVER_MAIN,
+        receiver=receiver,
+    )
 
 
 def parse_mode_response(frame: CivFrame) -> tuple[Mode, int | None]:
@@ -109,25 +118,26 @@ def parse_mode_response(frame: CivFrame) -> tuple[Mode, int | None]:
 # --- DATA mode commands (CI-V 0x1A 0x06) ---
 
 
+@expose_command_key(lambda cmd_map: "get_data_mode")
+@require_cmd_map
 def get_data_mode(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a 'get DATA mode' CI-V command (0x1A 0x06)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map, "get_data_mode", to_addr=to_addr, from_addr=from_addr
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_DATA_MODE)
+    return _build_from_map(
+        cmd_map, "get_data_mode", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_data_mode")
+@require_cmd_map
 def set_data_mode(
     on: int | bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set DATA mode' CI-V command (0x1A 0x06 <0x00-0x03>).
 
@@ -137,32 +147,14 @@ def set_data_mode(
     mode_value = int(on) if isinstance(on, bool) else int(on)
     if not 0 <= mode_value <= 3:
         raise ValueError(f"DATA mode must be 0-3, got {mode_value}")
-
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_data_mode",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=bytes([mode_value]),
-            receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
-        )
-    if receiver != RECEIVER_MAIN:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_CTL_MEM,
-            sub=_SUB_DATA_MODE,
-            data=bytes([mode_value]),
-            receiver=receiver,
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_DATA_MODE,
+    return _build_from_map(
+        cmd_map,
+        "set_data_mode",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=bytes([mode_value]),
+        receiver=receiver,
+        command29=(receiver != RECEIVER_MAIN),
     )
 
 
@@ -184,13 +176,15 @@ def parse_data_mode_response(frame: CivFrame) -> bool:
 # --- Filter shape / width ---
 
 
+@expose_command_key(lambda cmd_map: "get_filter_shape")
+@require_cmd_map
 def get_filter_shape(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read DSP IF filter shape command."""
     return _build_function_get(
@@ -204,20 +198,22 @@ def get_filter_shape(
     )
 
 
+@expose_command_key(lambda cmd_map: "set_filter_shape")
+@require_cmd_map
 def set_filter_shape(
     shape: FilterShape | int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set DSP IF filter shape command.
 
     Encodes the raw single-BCD-byte filter-shape value. Which values are
     legal is a per-profile ``[filter_shape] values`` domain, not a universal
-    enum — this builder only enforces the wire-format's single-BCD-byte
+    enum -- this builder only enforces the wire-format's single-BCD-byte
     range and leaves domain validation to the profile-aware caller
     (MOR-1534, mirrors MOR-1522's ``set_agc`` fix).
     """
@@ -235,30 +231,35 @@ def set_filter_shape(
     )
 
 
+@expose_command_key(lambda cmd_map: "get_filter_width")
+@require_cmd_map
 def get_filter_width(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'get DSP IF filter width' CI-V command (0x1A 0x03, cmd29)."""
-    return _build_ctl_mem_single_bcd_get(
-        _SUB_FILTER_WIDTH,
+    return _build_from_map(
+        cmd_map,
+        "get_filter_width",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=True,
-        cmd_map=cmd_map,
-        cmd_name="get_filter_width",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_filter_width")
+@require_cmd_map
 def set_filter_width(
     filter_index: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'set DSP IF filter width' CI-V command (0x1A 0x03, cmd29).
 
@@ -269,33 +270,24 @@ def set_filter_width(
     if filter_index < 0:
         raise ValueError(f"Filter index must be non-negative, got {filter_index}")
     payload = bcd_encode_value(filter_index, byte_count=2)
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_filter_width",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            data=payload,
-            receiver=receiver,
-            command29=True,
-        )
-    return build_cmd29_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_FILTER_WIDTH,
+    return _build_from_map(
+        cmd_map,
+        "set_filter_width",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=payload,
         receiver=receiver,
+        command29=True,
     )
 
 
 # --- SSB TX bandwidth ---
 
 
+@expose_command_key(lambda cmd_map: "get_ssb_tx_bandwidth")
+@require_cmd_map
 def get_ssb_tx_bandwidth(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read SSB TX bandwidth preset command."""
     return _build_function_get(
@@ -307,16 +299,19 @@ def get_ssb_tx_bandwidth(
     )
 
 
+@expose_command_key(lambda cmd_map: "set_ssb_tx_bandwidth")
+@require_cmd_map
 def set_ssb_tx_bandwidth(
     bandwidth: SsbTxBandwidth | int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set SSB TX bandwidth preset command.
 
     Encodes the raw single-BCD-byte bandwidth value. Which values are legal
-    is a per-profile ``[ssb_tx_bw] values`` domain, not a universal enum —
+    is a per-profile ``[ssb_tx_bw] values`` domain, not a universal enum --
     this builder only enforces the wire-format's single-BCD-byte range and
     leaves domain validation to the profile-aware caller (MOR-1534, mirrors
     MOR-1522's ``set_agc`` fix).
@@ -336,10 +331,10 @@ def set_ssb_tx_bandwidth(
 # --- Main/Sub tracking ---
 
 
+@expose_command_key(lambda cmd_map: "get_main_sub_tracking")
+@require_cmd_map
 def get_main_sub_tracking(
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a read Main/Sub Tracking status command (0x16 0x5E)."""
     return _build_function_get(
@@ -351,15 +346,12 @@ def get_main_sub_tracking(
     )
 
 
+@expose_command_key(lambda cmd_map: "set_main_sub_tracking")
+@require_cmd_map
 def set_main_sub_tracking(
-    on: bool,
-    to_addr: int,
-    from_addr: int = CONTROLLER_ADDR,
-    cmd_map: CommandMap | None = None,
+    on: bool, to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
 ) -> bytes:
     """Build a set Main/Sub Tracking status command (0x16 0x5E)."""
-    from ._builders import _build_function_bool_set
-
     return _build_function_bool_set(
         _SUB_MAIN_SUB_TRACKING,
         on,
@@ -373,45 +365,48 @@ def set_main_sub_tracking(
 # --- AGC time constant ---
 
 
+@expose_command_key(lambda cmd_map: "get_agc_time_constant")
+@require_cmd_map
 def get_agc_time_constant(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a read AGC time constant command."""
-    return _build_ctl_mem_single_bcd_get(
-        _SUB_AGC_TIME_CONSTANT,
+    return _build_from_map(
+        cmd_map,
+        "get_agc_time_constant",
         to_addr=to_addr,
         from_addr=from_addr,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="get_agc_time_constant",
     )
 
 
+@expose_command_key(lambda cmd_map: "set_agc_time_constant")
+@require_cmd_map
 def set_agc_time_constant(
     value: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a set AGC time constant command."""
-    return _build_ctl_mem_single_bcd_set(
-        _SUB_AGC_TIME_CONSTANT,
-        value,
-        minimum=0,
-        maximum=13,
+    if not 0 <= value <= 13:
+        raise ValueError(f"Value must be 0-13, got {value}")
+    payload = bytes([_bcd_byte(value)])
+    return _build_from_map(
+        cmd_map,
+        "set_agc_time_constant",
         to_addr=to_addr,
         from_addr=from_addr,
+        data=payload,
         receiver=receiver,
         command29=command29,
-        cmd_map=cmd_map,
-        cmd_name="set_agc_time_constant",
     )

--- a/src/rigplane/commands/tone.py
+++ b/src/rigplane/commands/tone.py
@@ -1,4 +1,18 @@
-"""Repeater tone/TSQL commands (0x1B family, 0x16 0x42/0x43)."""
+"""Repeater tone/TSQL commands (0x1B family, 0x16 0x42/0x43).
+
+Migrated onto the bound command map in MOR-2008 (batch 2,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N): all
+eight builders now require ``cmd_map``, with no hardcoded fallback left.
+Zero divergence rows -- every declaring profile's tuple already matched the
+fallback's own bytes exactly (verified by grep across ``rigs/*.toml`` before
+deleting each fallback).
+
+``get_repeater_tone``/``set_repeater_tone``/``get_repeater_tsql``/
+``set_repeater_tsql`` route through `_builders.py`'s shared
+``_build_function_get``/``_build_function_bool_set`` templates, which stay:
+`dsp.py` (not migrated in this batch) still calls them with ``cmd_map=None``,
+so their fallback branches are not dead yet.
+"""
 
 from __future__ import annotations
 
@@ -15,8 +29,8 @@ from ._frame import (
     _SUB_TONE_FREQ,
     _SUB_TSQL_FREQ,
     _build_from_map,
-    build_civ_frame,
-    build_cmd29_frame,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
@@ -46,13 +60,15 @@ def _decode_tone_freq(data: bytes) -> float:
     return float(hundreds * 100 + tens_units) + tenths_digit / 10.0
 
 
+@expose_command_key(lambda cmd_map: "get_repeater_tone")
+@require_cmd_map
 def get_repeater_tone(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to get repeater tone status (0x16 0x42)."""
     return _build_function_get(
@@ -66,14 +82,16 @@ def get_repeater_tone(
     )
 
 
+@expose_command_key(lambda cmd_map: "set_repeater_tone")
+@require_cmd_map
 def set_repeater_tone(
     on: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to set repeater tone (0x16 0x42)."""
     return _build_function_bool_set(
@@ -88,13 +106,15 @@ def set_repeater_tone(
     )
 
 
+@expose_command_key(lambda cmd_map: "get_repeater_tsql")
+@require_cmd_map
 def get_repeater_tsql(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to get repeater TSQL status (0x16 0x43)."""
     return _build_function_get(
@@ -108,14 +128,16 @@ def get_repeater_tsql(
     )
 
 
+@expose_command_key(lambda cmd_map: "set_repeater_tsql")
+@require_cmd_map
 def set_repeater_tsql(
     on: bool,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to set repeater TSQL (0x16 0x43)."""
     return _build_function_bool_set(
@@ -130,128 +152,90 @@ def set_repeater_tsql(
     )
 
 
+@expose_command_key(lambda cmd_map: "get_tone_freq")
+@require_cmd_map
 def get_tone_freq(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to get tone frequency (0x1B 0x00)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "get_tone_freq",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            command29=command29,
-            receiver=receiver,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr, from_addr, _CMD_TONE, sub=_SUB_TONE_FREQ, receiver=receiver
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_TONE, sub=_SUB_TONE_FREQ)
+    return _build_from_map(
+        cmd_map,
+        "get_tone_freq",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        command29=command29,
+        receiver=receiver,
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_tone_freq")
+@require_cmd_map
 def set_tone_freq(
     freq_hz: float,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to set tone frequency (0x1B 0x00)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_tone_freq",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            command29=command29,
-            receiver=receiver,
-            data=_encode_tone_freq(freq_hz),
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_TONE,
-            sub=_SUB_TONE_FREQ,
-            data=_encode_tone_freq(freq_hz),
-            receiver=receiver,
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_TONE,
-        sub=_SUB_TONE_FREQ,
+    return _build_from_map(
+        cmd_map,
+        "set_tone_freq",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        command29=command29,
+        receiver=receiver,
         data=_encode_tone_freq(freq_hz),
     )
 
 
+@expose_command_key(lambda cmd_map: "get_tsql_freq")
+@require_cmd_map
 def get_tsql_freq(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to get TSQL frequency (0x1B 0x01)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "get_tsql_freq",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            command29=command29,
-            receiver=receiver,
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr, from_addr, _CMD_TONE, sub=_SUB_TSQL_FREQ, receiver=receiver
-        )
-    return build_civ_frame(to_addr, from_addr, _CMD_TONE, sub=_SUB_TSQL_FREQ)
+    return _build_from_map(
+        cmd_map,
+        "get_tsql_freq",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        command29=command29,
+        receiver=receiver,
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_tsql_freq")
+@require_cmd_map
 def set_tsql_freq(
     freq_hz: float,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
     receiver: int = RECEIVER_MAIN,
-    cmd_map: CommandMap | None = None,
     *,
     command29: bool = True,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V command to set TSQL frequency (0x1B 0x01)."""
-    if cmd_map is not None:
-        return _build_from_map(
-            cmd_map,
-            "set_tsql_freq",
-            to_addr=to_addr,
-            from_addr=from_addr,
-            command29=command29,
-            receiver=receiver,
-            data=_encode_tone_freq(freq_hz),
-        )
-    if command29:
-        return build_cmd29_frame(
-            to_addr,
-            from_addr,
-            _CMD_TONE,
-            sub=_SUB_TSQL_FREQ,
-            data=_encode_tone_freq(freq_hz),
-            receiver=receiver,
-        )
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_TONE,
-        sub=_SUB_TSQL_FREQ,
+    return _build_from_map(
+        cmd_map,
+        "set_tsql_freq",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        command29=command29,
+        receiver=receiver,
         data=_encode_tone_freq(freq_hz),
     )
 

--- a/src/rigplane/runtime/_dual_rx_runtime.py
+++ b/src/rigplane/runtime/_dual_rx_runtime.py
@@ -20,13 +20,9 @@ from rigplane.commands import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
     build_civ_frame,
-    get_freq,
-    get_mode,
     parse_frequency_response,
     parse_ack_nak,
     parse_mode_response,
-    set_freq,
-    set_mode,
 )
 from rigplane.commands import get_selected_freq as _get_selected_freq_cmd
 from rigplane.commands import get_selected_mode as _get_selected_mode_cmd
@@ -150,7 +146,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         self, *, bypass_cache: bool = False, update_cache: bool = True
     ) -> int:
         """Read MAIN receiver frequency with optional cache updates."""
-        civ = get_freq(to_addr=self._radio_addr)
+        civ = self._commands.get_freq(to_addr=self._radio_addr)
         try:
             resp = await self._send_civ_expect(
                 civ,
@@ -178,7 +174,9 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         self, freq_hz: int, *, update_cache: bool = True
     ) -> None:
         """Set MAIN receiver frequency with optional cache updates."""
-        civ = set_freq(freq_hz, to_addr=self._radio_addr, receiver=RECEIVER_MAIN)
+        civ = self._commands.set_freq(
+            freq_hz, to_addr=self._radio_addr, receiver=RECEIVER_MAIN
+        )
         await self._send_civ_raw(civ, wait_response=False)
         if update_cache:
             self._last_freq_hz = freq_hz
@@ -188,7 +186,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
         self, *, update_cache: bool = True
     ) -> tuple[Mode, int | None]:
         """Read MAIN receiver mode/filter with optional cache updates."""
-        civ = get_mode(to_addr=self._radio_addr)
+        civ = self._commands.get_mode(to_addr=self._radio_addr)
         try:
             resp = await self._send_civ_expect(civ, label="get_mode_info_main")
             mode, filt = parse_mode_response(resp)
@@ -233,7 +231,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
                 mode, data_mode, resolved_filter, to_addr=self._radio_addr
             )
         else:
-            civ = set_mode(
+            civ = self._commands.set_mode(
                 mode,
                 filter_width=filter_width,
                 to_addr=self._radio_addr,

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -101,9 +101,6 @@ from rigplane.commands import (
     get_af_mute,
     get_agc,
     get_agc_time_constant,
-    get_alc,
-    get_antenna_1,
-    get_antenna_2,
     get_anti_vox_gain,
     get_apf_type_level,
     get_audio_peak_filter,
@@ -112,7 +109,6 @@ from rigplane.commands import (
     get_break_in_delay,
     get_civ_output_ant,
     get_civ_transceive,
-    get_comp_meter,
     get_compressor,
     get_compressor_level,
     get_cw_pitch,
@@ -127,8 +123,6 @@ from rigplane.commands import (
     get_drive_gain,
     get_dual_watch,
     get_filter_shape,
-    get_filter_width,
-    get_id_meter,
     get_ip_plus,
     get_key_speed,
     get_lan_mod_level,
@@ -147,24 +141,18 @@ from rigplane.commands import (
     get_overflow_status,
     get_pbt_inner,
     get_pbt_outer,
-    get_power_meter,
     get_quick_dual_watch,
     get_quick_split,
     get_ref_adjust,
-    get_rx_antenna_ant1,
-    get_rx_antenna_ant2,
-    get_s_meter,
     get_s_meter_sql_status,
     get_squelch,
     get_ssb_tx_bandwidth,
-    get_swr,
     get_system_date,
     get_system_time,
     get_twin_peak_filter,
     get_usb_mod_level,
     get_utc_offset,
     get_various_squelch,
-    get_vd_meter,
     get_vox,
     get_vox_delay,
     get_vox_gain,
@@ -184,9 +172,6 @@ from rigplane.commands import (
     parse_powerstat,
     set_af_mute,
     set_agc,
-    set_agc_time_constant,
-    set_antenna_1,
-    set_antenna_2,
     set_attenuator,
     set_attenuator_level,
     set_audio_peak_filter,
@@ -196,38 +181,23 @@ from rigplane.commands import (
     set_compressor,
     set_dial_lock,
     set_digisel,
-    set_filter_shape,
-    set_freq,
     set_ip_plus,
     set_manual_notch,
     set_manual_notch_width,
-    set_mode,
     set_monitor,
     set_nb,
     set_nr,
     set_preamp,
-    set_rx_antenna_ant1,
-    set_rx_antenna_ant2,
-    set_ssb_tx_bandwidth,
     set_twin_peak_filter,
     set_vox,
 )
 from rigplane.commands import (
     get_attenuator as get_attenuator_cmd,  # Transceiver status family (#136); VFO / Dual Watch / Scanning (#132); Tone/TSQL (#134); System/Config commands (#135); Memory and band-stacking (#133)
 )
-from rigplane.commands import get_data_mode as get_data_mode_cmd
 from rigplane.commands import get_main_sub_tracking as _get_main_sub_tracking_cmd
 from rigplane.commands import get_preamp as get_preamp_cmd
 from rigplane.commands import get_repeater_tone as _get_repeater_tone_cmd
 from rigplane.commands import get_repeater_tsql as _get_repeater_tsql_cmd
-from rigplane.commands import get_tone_freq as _get_tone_freq_cmd
-from rigplane.commands import get_tsql_freq as _get_tsql_freq_cmd
-from rigplane.commands import set_data_mode as set_data_mode_cmd
-from rigplane.commands import set_main_sub_tracking as _set_main_sub_tracking_cmd
-from rigplane.commands import set_repeater_tone as _set_repeater_tone_cmd
-from rigplane.commands import set_repeater_tsql as _set_repeater_tsql_cmd
-from rigplane.commands import set_tone_freq as _set_tone_freq_cmd
-from rigplane.commands import set_tsql_freq as _set_tsql_freq_cmd
 from rigplane.core.env_config import get_managed_tx_enabled
 from rigplane.core.exceptions import CommandError, TimeoutError
 from rigplane.core.state_store import StateStore
@@ -2118,7 +2088,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             return
 
         if self._profile.supports_cmd29(0x05):
-            civ = set_freq(freq_hz, to_addr=self._radio_addr, receiver=receiver)
+            civ = self._commands.set_freq(
+                freq_hz, to_addr=self._radio_addr, receiver=receiver
+            )
             await self._send_civ_raw(civ, wait_response=False)
         else:
             await self._run_with_receiver_vfo_fallback(
@@ -2328,7 +2300,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 operation="get_filter_width",
             )
             if self._profile.supports_cmd29(0x1A, 0x03):
-                civ = get_filter_width(to_addr=self._radio_addr, receiver=receiver)
+                civ = self._commands.get_filter_width(
+                    to_addr=self._radio_addr, receiver=receiver
+                )
             else:
                 civ = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1A, sub=0x03)
 
@@ -2387,7 +2361,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             return
 
         if self._profile.supports_cmd29(0x06):
-            civ = set_mode(
+            civ = self._commands.set_mode(
                 parsed_mode,
                 filter_width=filter_width,
                 to_addr=self._radio_addr,
@@ -2415,7 +2389,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             True if DATA mode is active (DATA1/2/3), False if off.
         """
         self._check_connected()
-        civ = get_data_mode_cmd(to_addr=self._radio_addr)
+        civ = self._commands.get_data_mode(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_data_mode")
         return parse_data_mode_response(resp)
 
@@ -2434,7 +2408,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1A, 0x06):
 
             async def _action() -> None:
-                civ = set_data_mode_cmd(
+                civ = self._commands.set_data_mode(
                     on, to_addr=self._radio_addr, receiver=RECEIVER_MAIN
                 )
                 resp = await self._send_civ_expect(civ, label="action")
@@ -2457,7 +2431,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             receiver=receiver,
             operation="set_data_mode",
         )
-        civ = set_data_mode_cmd(on, to_addr=self._radio_addr, receiver=receiver)
+        civ = self._commands.set_data_mode(
+            on, to_addr=self._radio_addr, receiver=receiver
+        )
         resp = await self._send_civ_expect(civ, label="action")
         ack = parse_ack_nak(resp)
         if ack is False:
@@ -3199,24 +3175,26 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x15, 0x01, receiver=receiver, operation="get_s_meter_sql_status"
         )
         cmd29 = self._profile.supports_cmd29(0x15, 0x01)
-        civ = get_s_meter_sql_status(
+        civ = self._commands.get_s_meter_sql_status(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, _ = self._expect_shape(get_s_meter_sql_status)
         return await self._get_bool_value(
             civ,
             key=f"get_s_meter_sql_status:{receiver}",
-            command=0x15,
-            sub=0x01,
+            command=command,
+            sub=sub,
         )
 
     async def get_overflow_status(self) -> bool:
         """Read OVF indicator status."""
-        civ = get_overflow_status(to_addr=self._radio_addr)
+        civ = self._commands.get_overflow_status(to_addr=self._radio_addr)
+        command, sub, _ = self._expect_shape(get_overflow_status)
         return await self._get_bool_value(
             civ,
             key="get_overflow_status",
-            command=0x15,
-            sub=0x07,
+            command=command,
+            sub=sub,
         )
 
     async def get_agc(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -3549,13 +3527,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x16, 0x56, receiver=receiver, operation="get_filter_shape"
         )
         cmd29 = self._profile.supports_cmd29(0x16, 0x56)
+        command, sub, _ = self._expect_shape(get_filter_shape)
         value = await self._get_bcd_level(
-            get_filter_shape(
+            self._commands.get_filter_shape(
                 to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             ),
             key=f"get_filter_shape:{receiver}",
-            command=0x16,
-            sub=0x56,
+            command=command,
+            sub=sub,
             bcd_bytes=1,
         )
         return FilterShape(value)
@@ -3592,7 +3571,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             )
         cmd29 = self._profile.supports_cmd29(0x16, 0x56)
         await self._send_fire_and_forget(
-            set_filter_shape(
+            self._commands.set_filter_shape(
                 shape_int,
                 to_addr=self._radio_addr,
                 receiver=receiver,
@@ -3602,11 +3581,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
     async def get_ssb_tx_bandwidth(self) -> SsbTxBandwidth:
         """Read SSB transmit bandwidth preset."""
+        command, sub, _ = self._expect_shape(get_ssb_tx_bandwidth)
         value = await self._get_bcd_level(
-            get_ssb_tx_bandwidth(to_addr=self._radio_addr),
+            self._commands.get_ssb_tx_bandwidth(to_addr=self._radio_addr),
             key="get_ssb_tx_bandwidth",
-            command=0x16,
-            sub=0x58,
+            command=command,
+            sub=sub,
             bcd_bytes=1,
         )
         return SsbTxBandwidth(value)
@@ -3634,20 +3614,21 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 f"{self._profile.model}, got {bandwidth_int}"
             )
         await self._send_fire_and_forget(
-            set_ssb_tx_bandwidth(bandwidth_int, to_addr=self._radio_addr)
+            self._commands.set_ssb_tx_bandwidth(bandwidth_int, to_addr=self._radio_addr)
         )
 
     async def get_main_sub_tracking(self) -> bool:
         """Read Main/Sub Tracking status."""
-        civ = _get_main_sub_tracking_cmd(to_addr=self._radio_addr)
+        civ = self._commands.get_main_sub_tracking(to_addr=self._radio_addr)
+        command, sub, _ = self._expect_shape(_get_main_sub_tracking_cmd)
         return await self._get_bool_value(
-            civ, key="get_main_sub_tracking", command=0x16, sub=0x5E
+            civ, key="get_main_sub_tracking", command=command, sub=sub
         )
 
     async def set_main_sub_tracking(self, on: bool) -> None:
         """Set Main/Sub Tracking status."""
         await self._send_fire_and_forget(
-            _set_main_sub_tracking_cmd(on, to_addr=self._radio_addr)
+            self._commands.set_main_sub_tracking(on, to_addr=self._radio_addr)
         )
 
     async def get_agc_time_constant(self, receiver: int = RECEIVER_MAIN) -> int:
@@ -3657,13 +3638,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x1A, 0x04, receiver=receiver, operation="get_agc_time_constant"
         )
         cmd29 = self._profile.supports_cmd29(0x1A, 0x04)
+        command, sub, _ = self._expect_shape(get_agc_time_constant)
         return await self._get_bcd_level(
-            get_agc_time_constant(
+            self._commands.get_agc_time_constant(
                 to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             ),
             key=f"get_agc_time_constant:{receiver}",
-            command=0x1A,
-            sub=0x04,
+            command=command,
+            sub=sub,
             bcd_bytes=1,
         )
 
@@ -3677,7 +3659,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x1A, 0x04)
         await self._send_fire_and_forget(
-            set_agc_time_constant(
+            self._commands.set_agc_time_constant(
                 value,
                 to_addr=self._radio_addr,
                 receiver=receiver,
@@ -3688,7 +3670,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_s_meter(self) -> int:
         """Read the S-meter value (0-255)."""
         self._check_connected()
-        civ = get_s_meter(to_addr=self._radio_addr)
+        civ = self._commands.get_s_meter(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_s_meter")
         return parse_meter_response(resp)
 
@@ -3704,7 +3686,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         unscaled value) use :meth:`get_swr_meter`.
         """
         self._check_connected()
-        civ = get_swr(to_addr=self._radio_addr)
+        civ = self._commands.get_swr(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_swr")
         raw = parse_meter_response(resp)
         return interpolate_swr(raw, self._profile.meter_calibrations)
@@ -3716,14 +3698,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         calibrated SWR ratio (>= 1.0) use :meth:`get_swr`.
         """
         self._check_connected()
-        civ = get_swr(to_addr=self._radio_addr)
+        civ = self._commands.get_swr(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_swr_meter")
         return parse_meter_response(resp)
 
     async def get_alc_meter(self) -> int:
         """Read the ALC meter value (raw 0-255)."""
         self._check_connected()
-        civ = get_alc(to_addr=self._radio_addr)
+        civ = self._commands.get_alc(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_alc_meter")
         return parse_meter_response(resp)
 
@@ -3870,41 +3852,42 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x15, 0x05, receiver=receiver, operation="get_various_squelch"
         )
         cmd29 = self._profile.supports_cmd29(0x15, 0x05)
-        civ = get_various_squelch(
+        civ = self._commands.get_various_squelch(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
+        command, sub, _ = self._expect_shape(get_various_squelch)
         return await self._get_bool_value(
             civ,
             key=f"get_various_squelch:{receiver}",
-            command=0x15,
-            sub=0x05,
+            command=command,
+            sub=sub,
         )
 
     async def get_power_meter(self) -> int:
         """Read the RF power meter (0-255 raw BCD)."""
         self._check_connected()
-        civ = get_power_meter(to_addr=self._radio_addr)
+        civ = self._commands.get_power_meter(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_power_meter")
         return parse_meter_response(resp)
 
     async def get_comp_meter(self) -> int:
         """Read the compressor meter (0-255 raw BCD)."""
         self._check_connected()
-        civ = get_comp_meter(to_addr=self._radio_addr)
+        civ = self._commands.get_comp_meter(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_comp_meter")
         return parse_meter_response(resp)
 
     async def get_vd_meter(self) -> int:
         """Read the Vd supply voltage meter (0-255 raw BCD)."""
         self._check_connected()
-        civ = get_vd_meter(to_addr=self._radio_addr)
+        civ = self._commands.get_vd_meter(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_vd_meter")
         return parse_meter_response(resp)
 
     async def get_id_meter(self) -> int:
         """Read the Id drain current meter (0-255 raw BCD)."""
         self._check_connected()
-        civ = get_id_meter(to_addr=self._radio_addr)
+        civ = self._commands.get_id_meter(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_id_meter")
         return parse_meter_response(resp)
 
@@ -4565,13 +4548,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Read repeater tone status (0x16 0x42)."""
         self._check_connected()
         self._require_receiver(receiver, operation="get_repeater_tone")
+        command, sub, _ = self._expect_shape(_get_repeater_tone_cmd)
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(
             0x16, _SUB_REPEATER_TONE
         ):
 
             async def _action() -> bool:
-                civ = _get_repeater_tone_cmd(
+                civ = self._commands.get_repeater_tone(
                     to_addr=self._radio_addr,
                     receiver=RECEIVER_MAIN,
                     command29=False,
@@ -4579,8 +4563,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 return await self._get_bool_value(
                     civ,
                     key=f"get_repeater_tone:{receiver}",
-                    command=0x16,
-                    sub=_SUB_REPEATER_TONE,
+                    command=command,
+                    sub=sub,
                 )
 
             return await self._run_with_receiver_vfo_fallback(
@@ -4593,14 +4577,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x16, _SUB_REPEATER_TONE, receiver=receiver, operation="get_repeater_tone"
         )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TONE)
-        civ = _get_repeater_tone_cmd(
+        civ = self._commands.get_repeater_tone(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         return await self._get_bool_value(
             civ,
             key=f"get_repeater_tone:{receiver}",
-            command=0x16,
-            sub=_SUB_REPEATER_TONE,
+            command=command,
+            sub=sub,
         )
 
     async def set_repeater_tone(self, on: bool, receiver: int = 0) -> None:
@@ -4614,7 +4598,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
             async def _action() -> None:
                 await self._send_fire_and_forget(
-                    _set_repeater_tone_cmd(
+                    self._commands.set_repeater_tone(
                         on,
                         to_addr=self._radio_addr,
                         receiver=RECEIVER_MAIN,
@@ -4634,7 +4618,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TONE)
         await self._send_fire_and_forget(
-            _set_repeater_tone_cmd(
+            self._commands.set_repeater_tone(
                 on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -4643,13 +4627,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Read repeater TSQL status (0x16 0x43)."""
         self._check_connected()
         self._require_receiver(receiver, operation="get_repeater_tsql")
+        command, sub, _ = self._expect_shape(_get_repeater_tsql_cmd)
 
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(
             0x16, _SUB_REPEATER_TSQL
         ):
 
             async def _action() -> bool:
-                civ = _get_repeater_tsql_cmd(
+                civ = self._commands.get_repeater_tsql(
                     to_addr=self._radio_addr,
                     receiver=RECEIVER_MAIN,
                     command29=False,
@@ -4657,8 +4642,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
                 return await self._get_bool_value(
                     civ,
                     key=f"get_repeater_tsql:{receiver}",
-                    command=0x16,
-                    sub=_SUB_REPEATER_TSQL,
+                    command=command,
+                    sub=sub,
                 )
 
             return await self._run_with_receiver_vfo_fallback(
@@ -4671,14 +4656,14 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x16, _SUB_REPEATER_TSQL, receiver=receiver, operation="get_repeater_tsql"
         )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TSQL)
-        civ = _get_repeater_tsql_cmd(
+        civ = self._commands.get_repeater_tsql(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         return await self._get_bool_value(
             civ,
             key=f"get_repeater_tsql:{receiver}",
-            command=0x16,
-            sub=_SUB_REPEATER_TSQL,
+            command=command,
+            sub=sub,
         )
 
     async def set_repeater_tsql(self, on: bool, receiver: int = 0) -> None:
@@ -4692,7 +4677,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
             async def _action() -> None:
                 await self._send_fire_and_forget(
-                    _set_repeater_tsql_cmd(
+                    self._commands.set_repeater_tsql(
                         on,
                         to_addr=self._radio_addr,
                         receiver=RECEIVER_MAIN,
@@ -4712,7 +4697,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x16, _SUB_REPEATER_TSQL)
         await self._send_fire_and_forget(
-            _set_repeater_tsql_cmd(
+            self._commands.set_repeater_tsql(
                 on, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -4725,7 +4710,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x00):
 
             async def _action() -> float:
-                civ = _get_tone_freq_cmd(
+                civ = self._commands.get_tone_freq(
                     to_addr=self._radio_addr,
                     receiver=RECEIVER_MAIN,
                     command29=False,
@@ -4744,7 +4729,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x1B, 0x00, receiver=receiver, operation="get_tone_freq"
         )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
-        civ = _get_tone_freq_cmd(
+        civ = self._commands.get_tone_freq(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         resp = await self._send_civ_expect(civ, label="get_tone_freq")
@@ -4760,7 +4745,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
             async def _action() -> None:
                 await self._send_fire_and_forget(
-                    _set_tone_freq_cmd(
+                    self._commands.set_tone_freq(
                         freq_hz,
                         to_addr=self._radio_addr,
                         receiver=RECEIVER_MAIN,
@@ -4780,7 +4765,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x00)
         await self._send_fire_and_forget(
-            _set_tone_freq_cmd(
+            self._commands.set_tone_freq(
                 freq_hz, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -4793,7 +4778,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if receiver != RECEIVER_MAIN and not self._profile.supports_cmd29(0x1B, 0x01):
 
             async def _action() -> float:
-                civ = _get_tsql_freq_cmd(
+                civ = self._commands.get_tsql_freq(
                     to_addr=self._radio_addr,
                     receiver=RECEIVER_MAIN,
                     command29=False,
@@ -4812,7 +4797,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             0x1B, 0x01, receiver=receiver, operation="get_tsql_freq"
         )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
-        civ = _get_tsql_freq_cmd(
+        civ = self._commands.get_tsql_freq(
             to_addr=self._radio_addr, receiver=receiver, command29=cmd29
         )
         resp = await self._send_civ_expect(civ, label="get_tsql_freq")
@@ -4828,7 +4813,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
 
             async def _action() -> None:
                 await self._send_fire_and_forget(
-                    _set_tsql_freq_cmd(
+                    self._commands.set_tsql_freq(
                         freq_hz,
                         to_addr=self._radio_addr,
                         receiver=RECEIVER_MAIN,
@@ -4848,7 +4833,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         )
         cmd29 = self._profile.supports_cmd29(0x1B, 0x01)
         await self._send_fire_and_forget(
-            _set_tsql_freq_cmd(
+            self._commands.set_tsql_freq(
                 freq_hz, to_addr=self._radio_addr, receiver=receiver, command29=cmd29
             )
         )
@@ -4860,7 +4845,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def get_antenna_1(self) -> bool:
         """Read ANT1 selection status (0x12 0x00)."""
         return await self._get_bool_value(
-            get_antenna_1(to_addr=self._radio_addr),
+            self._commands.get_antenna_1(to_addr=self._radio_addr),
             key="get_antenna_1",
             command=0x12,
             sub=0x00,
@@ -4872,13 +4857,13 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         IC-7610: data byte encodes RX-ANT OFF/ON.
         """
         await self._send_fire_and_forget(
-            set_antenna_1(enabled, to_addr=self._radio_addr)
+            self._commands.set_antenna_1(enabled, to_addr=self._radio_addr)
         )
 
     async def get_antenna_2(self) -> bool:
         """Read ANT2 selection status (0x12 0x01)."""
         return await self._get_bool_value(
-            get_antenna_2(to_addr=self._radio_addr),
+            self._commands.get_antenna_2(to_addr=self._radio_addr),
             key="get_antenna_2",
             command=0x12,
             sub=0x01,
@@ -4890,7 +4875,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         IC-7610: data byte encodes RX-ANT OFF/ON.
         """
         await self._send_fire_and_forget(
-            set_antenna_2(enabled, to_addr=self._radio_addr)
+            self._commands.set_antenna_2(enabled, to_addr=self._radio_addr)
         )
 
     async def get_rx_antenna_ant1(self) -> bool:
@@ -4899,7 +4884,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         NOTE: On IC-7610 this is implemented via 0x12 0x00 and may select ANT1.
         """
         return await self._get_bool_value(
-            get_rx_antenna_ant1(to_addr=self._radio_addr),
+            self._commands.get_rx_antenna_ant1(to_addr=self._radio_addr),
             key="get_rx_antenna_ant1",
             command=0x12,
             sub=0x00,
@@ -4908,7 +4893,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def set_rx_antenna_ant1(self, enabled: bool) -> None:
         """Set RX ANT state for ANT1 (0x12 0x00 <00|01>)."""
         await self._send_fire_and_forget(
-            set_rx_antenna_ant1(enabled, to_addr=self._radio_addr)
+            self._commands.set_rx_antenna_ant1(enabled, to_addr=self._radio_addr)
         )
 
     async def get_rx_antenna_ant2(self) -> bool:
@@ -4917,7 +4902,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         NOTE: On IC-7610 this is implemented via 0x12 0x01 and may select ANT2.
         """
         return await self._get_bool_value(
-            get_rx_antenna_ant2(to_addr=self._radio_addr),
+            self._commands.get_rx_antenna_ant2(to_addr=self._radio_addr),
             key="get_rx_antenna_ant2",
             command=0x12,
             sub=0x01,
@@ -4926,7 +4911,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
     async def set_rx_antenna_ant2(self, enabled: bool) -> None:
         """Set RX ANT state for ANT2 (0x12 0x01 <00|01>)."""
         await self._send_fire_and_forget(
-            set_rx_antenna_ant2(enabled, to_addr=self._radio_addr)
+            self._commands.set_rx_antenna_ant2(enabled, to_addr=self._radio_addr)
         )
 
     # commands/config.py, migrated onto the bound command map (MOR-2006

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -26,92 +26,62 @@
 # reachable from a builder that was compared, not sites observed to
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
-census	builders_compared	79
+census	builders_compared	37
 census	cat_only_profiles	2
-census	dual_implementation_sites	46
+census	dual_implementation_sites	17
 census	frames_diverged	0
-census	frames_identical	667
+census	frames_identical	373
 census	hardcode_only_builders	16
-census	profile_builder_map_gaps	310
+census	profile_builder_map_gaps	140
 census	profiles	8
 census	public_builders	228
-census	sites_compared	46
+census	sites_compared	17
 cat-only	FTX-1	108
 cat-only	TX-500	50
 gap	get_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_agc	FTX-1,TX-500
-gap	get_agc_time_constant	FTX-1,TX-500,X6100,X6200
-gap	get_alc	FTX-1,TX-500,X6100,X6200
-gap	get_antenna	FTX-1,TX-500,X6100,X6200
 gap	get_attenuator	FTX-1,TX-500
 gap	get_audio_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	get_auto_notch	FTX-1,TX-500,X6100,X6200
 gap	get_break_in	FTX-1,TX-500,X6100,X6200
-gap	get_comp_meter	FTX-1,TX-500,X6100,X6200
 gap	get_compressor	FTX-1,TX-500,X6100,X6200
-gap	get_data_mode	FTX-1,TX-500,X6100,X6200
 gap	get_dial_lock	FTX-1,TX-500
 gap	get_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	get_filter_shape	FTX-1,TX-500,X6100,X6200
-gap	get_filter_width	FTX-1,TX-500
-gap	get_freq	FTX-1,TX-500
-gap	get_id_meter	FTX-1,TX-500,X6100,X6200
 gap	get_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
-gap	get_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	get_manual_notch	FTX-1,TX-500,X6100,X6200
 gap	get_manual_notch_width	FTX-1,TX-500,X6100,X6200
-gap	get_mode	FTX-1,TX-500
 gap	get_monitor	FTX-1,TX-500,X6100,X6200
 gap	get_nb	FTX-1,TX-500
 gap	get_nr	FTX-1,TX-500,X6100,X6200
-gap	get_overflow_status	FTX-1,TX-500,X6100,X6200
-gap	get_power_meter	FTX-1,TX-500
 gap	get_preamp	FTX-1,TX-500
-gap	get_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	get_s_meter	FTX-1,TX-500
-gap	get_s_meter_sql_status	FTX-1,TX-500,X6100,X6200
-gap	get_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
-gap	get_swr	FTX-1,TX-500
-gap	get_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	get_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	get_twin_peak_filter	FTX-1,TX-500,X6100,X6200
-gap	get_various_squelch	FTX-1,TX-500,X6100,X6200
-gap	get_vd_meter	FTX-1,TX-500
 gap	get_vox	FTX-1,TX-500,X6100,X6200
 gap	set_af_mute	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_agc	FTX-1,TX-500
-gap	set_agc_time_constant	FTX-1,TX-500,X6100,X6200
-gap	set_antenna	FTX-1,TX-500,X6100,X6200
 gap	set_attenuator	FTX-1,TX-500
 gap	set_audio_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	set_auto_notch	FTX-1,TX-500,X6100,X6200
 gap	set_break_in	FTX-1,TX-500,X6100,X6200
 gap	set_compressor	FTX-1,TX-500,X6100,X6200
-gap	set_data_mode	FTX-1,TX-500,X6100,X6200
 gap	set_dial_lock	FTX-1,TX-500
 gap	set_digisel	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	set_filter_shape	FTX-1,TX-500,X6100,X6200
-gap	set_filter_width	FTX-1,TX-500,X6100,X6200
-gap	set_freq	FTX-1,TX-500
 gap	set_ip_plus	FTX-1,IC-705,TX-500,X6100,X6200
-gap	set_main_sub_tracking	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
 gap	set_manual_notch	FTX-1,TX-500,X6100,X6200
 gap	set_manual_notch_width	FTX-1,TX-500,X6100,X6200
-gap	set_mode	FTX-1,TX-500
 gap	set_monitor	FTX-1,TX-500,X6100,X6200
 gap	set_nb	FTX-1,TX-500
 gap	set_nr	FTX-1,TX-500,X6100,X6200
 gap	set_preamp	FTX-1,TX-500
-gap	set_repeater_tone	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	set_repeater_tsql	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	set_rx_antenna_ant2	FTX-1,IC-705,IC-7300,IC-9700,TX-500,X6100,X6200
-gap	set_ssb_tx_bandwidth	FTX-1,TX-500,X6100,X6200
-gap	set_tone_freq	FTX-1,IC-7610,TX-500,X6100,X6200
-gap	set_tsql_freq	FTX-1,IC-7610,TX-500,X6100,X6200
 gap	set_twin_peak_filter	FTX-1,TX-500,X6100,X6200
 gap	set_vox	FTX-1,TX-500,X6100,X6200
+requires-map	antenna.py:get_antenna_1
+requires-map	antenna.py:get_antenna_2
+requires-map	antenna.py:get_rx_antenna_ant1
+requires-map	antenna.py:get_rx_antenna_ant2
+requires-map	antenna.py:set_antenna_1
+requires-map	antenna.py:set_antenna_2
+requires-map	antenna.py:set_rx_antenna_ant1
+requires-map	antenna.py:set_rx_antenna_ant2
 requires-map	config.py:get_acc1_mod_level
 requires-map	config.py:get_civ_output_ant
 requires-map	config.py:get_civ_transceive
@@ -132,6 +102,8 @@ requires-map	config.py:set_lan_mod_level
 requires-map	config.py:set_usb_mod_level
 requires-map	cw.py:send_cw
 requires-map	cw.py:stop_cw
+requires-map	freq.py:get_freq
+requires-map	freq.py:set_freq
 requires-map	levels.py:get_af_level
 requires-map	levels.py:get_anti_vox_gain
 requires-map	levels.py:get_apf_type_level
@@ -182,6 +154,30 @@ requires-map	levels.py:set_rf_power
 requires-map	levels.py:set_squelch
 requires-map	levels.py:set_vox_delay
 requires-map	levels.py:set_vox_gain
+requires-map	meters.py:get_alc
+requires-map	meters.py:get_comp_meter
+requires-map	meters.py:get_id_meter
+requires-map	meters.py:get_overflow_status
+requires-map	meters.py:get_power_meter
+requires-map	meters.py:get_s_meter
+requires-map	meters.py:get_s_meter_sql_status
+requires-map	meters.py:get_swr
+requires-map	meters.py:get_various_squelch
+requires-map	meters.py:get_vd_meter
+requires-map	mode.py:get_agc_time_constant
+requires-map	mode.py:get_data_mode
+requires-map	mode.py:get_filter_shape
+requires-map	mode.py:get_filter_width
+requires-map	mode.py:get_main_sub_tracking
+requires-map	mode.py:get_mode
+requires-map	mode.py:get_ssb_tx_bandwidth
+requires-map	mode.py:set_agc_time_constant
+requires-map	mode.py:set_data_mode
+requires-map	mode.py:set_filter_shape
+requires-map	mode.py:set_filter_width
+requires-map	mode.py:set_main_sub_tracking
+requires-map	mode.py:set_mode
+requires-map	mode.py:set_ssb_tx_bandwidth
 requires-map	power.py:get_powerstat
 requires-map	power.py:power_off
 requires-map	power.py:power_on
@@ -241,6 +237,14 @@ requires-map	system.py:set_tuner_status
 requires-map	system.py:set_tx_freq_monitor
 requires-map	system.py:set_utc_offset
 requires-map	system.py:set_xfc_status
+requires-map	tone.py:get_repeater_tone
+requires-map	tone.py:get_repeater_tsql
+requires-map	tone.py:get_tone_freq
+requires-map	tone.py:get_tsql_freq
+requires-map	tone.py:set_repeater_tone
+requires-map	tone.py:set_repeater_tsql
+requires-map	tone.py:set_tone_freq
+requires-map	tone.py:set_tsql_freq
 requires-map	vfo.py:get_dual_watch
 requires-map	vfo.py:get_main_sub_band
 requires-map	vfo.py:get_quick_dual_watch

--- a/tests/integration/test_tone_tsql_integration.py
+++ b/tests/integration/test_tone_tsql_integration.py
@@ -1,4 +1,4 @@
-"""Mock-based integration tests for IC-7610 tone/TSQL commands (issue #134).
+"""Mock-based integration tests for IC-7300 tone/TSQL commands (issue #134).
 
 Tests the full request/response cycle for all 4 tone/TSQL command groups using a
 local mock radio server.  No real hardware required — runs in CI without env vars.
@@ -8,6 +8,18 @@ Commands under test:
   2. Repeater TSQL enable/disable (0x16 sub 0x43)
   3. Tone Frequency set/get (0x1B sub 0x00)
   4. TSQL Frequency set/get (0x1B sub 0x01)
+
+Uses IC-7300, not IC-7610 as originally written: MOR-2008 batch 2
+(`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N)
+migrated this family onto the bound command map, and `rigs/ic7610.toml`
+declares the whole family absent (a live-bench readback found the old
+hardcoded fallback's bytes decoded to garbage on this radio) -- so an
+`IcomRadio` defaulting to IC-7610 now correctly raises `CommandError`
+for every command this file exercises, instead of building a frame.
+IC-7300 declares byte-identical `[0x16/0x1B, sub]` tuples for the family
+and has no cmd29 routes at all (`rigs/ic7300.toml`: "single receiver, no
+cmd29"), so every request here is plain, never cmd29-wrapped -- see
+`ToneMockRadio`'s own docstring below for what that changed in the mock.
 
 Run with::
 
@@ -109,6 +121,25 @@ class ToneMockRadio(MockIcomRadio):
       - 0x1B / sub 0x01: TSQL frequency get/set (3-byte BCD)
 
     All other commands are forwarded to the parent MockIcomRadio.
+
+    Plain dispatch only, never cmd29: this file's radio is IC-7300
+    (module docstring), which has no cmd29 routes at all, so every
+    request the client builds is a bare ``FE FE <to> <from> <cmd> <sub>
+    [data] FD`` frame -- there is no cmd29 envelope, and therefore no
+    receiver-selector byte anywhere in the payload (that byte only
+    exists inside a cmd29 wrapper, which the base class's own
+    ``_dispatch_civ``/``_dispatch_cmd29`` split already strips before a
+    subclass ever sees it -- see ``_dispatch_cmd29``'s ``receiver``
+    parameter, passed in separately, never embedded in ``inner``).
+    Earlier revisions of this mock (written against IC-7610, which does
+    use cmd29 for this whole family) had a ``_strip_receiver_prefix``
+    step in the plain-path handlers below that assumed a receiver byte
+    was there to strip; it was never exercised while every real request
+    on IC-7610 went through ``_dispatch_cmd29`` instead, and would have
+    corrupted the BCD frequency payload the day it was (the hundreds
+    digit of any frequency under 200 Hz is legitimately ``0x00`` or
+    ``0x01``, indistinguishable from a receiver-selector byte). Removed
+    rather than fixed forward, since a plain frame never carries one.
     """
 
     def __init__(self, **kwargs: object) -> None:
@@ -119,105 +150,37 @@ class ToneMockRadio(MockIcomRadio):
         self._tsql_freq_hz: float = _FREQ_DEFAULT
 
     # ------------------------------------------------------------------
-    # Helper: strip receiver prefix (command29)
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _strip_receiver_prefix(data: bytes) -> tuple[int | None, bytes]:
-        """Strip receiver prefix (0x00=MAIN, 0x01=SUB) from command29 data."""
-        if not data:
-            return (None, data)
-        if data[0] in (0x00, 0x01):
-            return (data[0], data[1:])
-        return (None, data)
-
-    # ------------------------------------------------------------------
     # CI-V dispatch override
     # ------------------------------------------------------------------
 
     def _dispatch_civ(self, cmd: int, payload: bytes, from_addr: int) -> bytes | None:
-        """Intercept tone (0x1B) commands (non-command29)."""
+        """Intercept repeater tone/TSQL (0x16) and tone frequency (0x1B)
+        commands -- both always plain here (IC-7300 has no cmd29 route for
+        either), so there is no separate cmd29 dispatch override in this
+        class any more (see the class docstring)."""
+        if cmd == _CMD_FUNC:
+            return self._dispatch_func(payload, from_addr)
         if cmd == _CMD_TONE:
             return self._dispatch_tone(payload, from_addr)
         return super()._dispatch_civ(cmd, payload, from_addr)
 
-    def _dispatch_cmd29(
-        self, real_cmd: int, inner: bytes, from_addr: int, receiver: int
-    ) -> bytes | None:
-        """Handle Command29-wrapped tone/TSQL commands."""
-        to = from_addr
-        frm = self._radio_addr
+    # ------------------------------------------------------------------
+    # Repeater tone/TSQL dispatch (0x16)
+    # ------------------------------------------------------------------
 
-        # Handle 0x16 (PREAMP/functions) with tone/TSQL sub-commands
-        if real_cmd == _CMD_FUNC:
-            if not inner:
-                return self._civ_nak(to, frm)
-            sub = inner[0]
-            rest = inner[1:]
-
-            if sub == _SUB_REPEATER_TONE:
-                if rest:  # SET
-                    self._repeater_tone = rest[0]
-                    return self._civ_ack(to, frm)
-                # GET — wrap in Command29
-                return self._civ_frame(
-                    to,
-                    frm,
-                    0x29,
-                    data=bytes(
-                        [receiver, _CMD_FUNC, _SUB_REPEATER_TONE, self._repeater_tone]
-                    ),
-                )
-
-            if sub == _SUB_REPEATER_TSQL:
-                if rest:  # SET
-                    self._repeater_tsql = rest[0]
-                    return self._civ_ack(to, frm)
-                # GET — wrap in Command29
-                return self._civ_frame(
-                    to,
-                    frm,
-                    0x29,
-                    data=bytes(
-                        [receiver, _CMD_FUNC, _SUB_REPEATER_TSQL, self._repeater_tsql]
-                    ),
-                )
-
-        # Handle 0x1B (tone frequency) sub-commands
-        if real_cmd == _CMD_TONE:
-            if not inner:
-                return self._civ_nak(to, frm)
-            sub = inner[0]
-            rest = inner[1:]
-
-            if sub == _SUB_TONE_FREQ:
-                if len(rest) >= 3:  # SET (3-byte BCD)
-                    self._tone_freq_hz = _decode_tone_freq(rest[:3])
-                    return self._civ_ack(to, frm)
-                # GET — wrap in Command29
-                return self._civ_frame(
-                    to,
-                    frm,
-                    0x29,
-                    data=bytes([receiver, _CMD_TONE, _SUB_TONE_FREQ])
-                    + _encode_tone_freq(self._tone_freq_hz),
-                )
-
-            if sub == _SUB_TSQL_FREQ:
-                if len(rest) >= 3:  # SET (3-byte BCD)
-                    self._tsql_freq_hz = _decode_tone_freq(rest[:3])
-                    return self._civ_ack(to, frm)
-                # GET — wrap in Command29
-                return self._civ_frame(
-                    to,
-                    frm,
-                    0x29,
-                    data=bytes([receiver, _CMD_TONE, _SUB_TSQL_FREQ])
-                    + _encode_tone_freq(self._tsql_freq_hz),
-                )
-
-        # Fall through to parent for other commands (ATT, preamp status, etc.)
-        return super()._dispatch_cmd29(real_cmd, inner, from_addr, receiver)
+    def _dispatch_func(self, payload: bytes, from_addr: int) -> bytes | None:
+        """Dispatch repeater tone/TSQL commands (cmd 0x16)."""
+        if not payload:
+            return self._civ_nak(from_addr, self._radio_addr)
+        sub = payload[0]
+        rest = payload[1:]
+        if sub == _SUB_REPEATER_TONE:
+            return self._handle_repeater_tone(rest, from_addr)
+        if sub == _SUB_REPEATER_TSQL:
+            return self._handle_repeater_tsql(rest, from_addr)
+        # Not a tone/TSQL sub-command: let the parent handle other 0x16
+        # sub-commands (ATT, preamp status, etc.)
+        return super()._dispatch_civ(_CMD_FUNC, payload, from_addr)
 
     # ------------------------------------------------------------------
     # Tone frequency dispatch (0x1B)
@@ -237,90 +200,72 @@ class ToneMockRadio(MockIcomRadio):
 
     # ------------------------------------------------------------------
     # Individual command handlers
+    #
+    # A plain frame (no cmd29 wrapper) never carries a receiver-selector
+    # byte -- that byte lives only in the cmd29 envelope itself, which
+    # this mock never receives for this radio (class docstring). `rest`
+    # below is exactly the on/off byte (repeater tone/TSQL) or the 3-byte
+    # BCD payload (tone/TSQL frequency), with nothing to strip first.
     # ------------------------------------------------------------------
 
     def _handle_repeater_tone(self, rest: bytes, from_addr: int) -> bytes:
         """Handle repeater tone enable/disable (0x16 sub 0x42)."""
         to = from_addr
         frm = self._radio_addr
-        # Strip receiver prefix (command29)
-        receiver, data = self._strip_receiver_prefix(rest)
-        if data:  # SET
-            self._repeater_tone = data[0]
+        if rest:  # SET
+            self._repeater_tone = rest[0]
             return self._civ_ack(to, frm)
-        # GET: include receiver prefix in response if present
-        response_data = (bytes([receiver]) if receiver is not None else b"") + bytes(
-            [self._repeater_tone]
-        )
         return self._civ_frame(
             to,
             frm,
             _CMD_FUNC,
             sub=_SUB_REPEATER_TONE,
-            data=response_data,
+            data=bytes([self._repeater_tone]),
         )
 
     def _handle_repeater_tsql(self, rest: bytes, from_addr: int) -> bytes:
         """Handle repeater TSQL enable/disable (0x16 sub 0x43)."""
         to = from_addr
         frm = self._radio_addr
-        # Strip receiver prefix (command29)
-        receiver, data = self._strip_receiver_prefix(rest)
-        if data:  # SET
-            self._repeater_tsql = data[0]
+        if rest:  # SET
+            self._repeater_tsql = rest[0]
             return self._civ_ack(to, frm)
-        # GET: include receiver prefix in response if present
-        response_data = (bytes([receiver]) if receiver is not None else b"") + bytes(
-            [self._repeater_tsql]
-        )
         return self._civ_frame(
             to,
             frm,
             _CMD_FUNC,
             sub=_SUB_REPEATER_TSQL,
-            data=response_data,
+            data=bytes([self._repeater_tsql]),
         )
 
     def _handle_tone_freq(self, rest: bytes, from_addr: int) -> bytes:
         """Handle tone frequency get/set (0x1B sub 0x00)."""
         to = from_addr
         frm = self._radio_addr
-        # Strip receiver prefix (command29)
-        receiver, data = self._strip_receiver_prefix(rest)
-        if len(data) >= 3:  # SET (3-byte BCD payload)
-            self._tone_freq_hz = _decode_tone_freq(data[:3])
+        if len(rest) >= 3:  # SET (3-byte BCD payload)
+            self._tone_freq_hz = _decode_tone_freq(rest[:3])
             return self._civ_ack(to, frm)
-        # GET: include receiver prefix in response if present
-        response_data = (
-            bytes([receiver]) if receiver is not None else b""
-        ) + _encode_tone_freq(self._tone_freq_hz)
         return self._civ_frame(
             to,
             frm,
             _CMD_TONE,
             sub=_SUB_TONE_FREQ,
-            data=response_data,
+            data=_encode_tone_freq(self._tone_freq_hz),
         )
 
     def _handle_tsql_freq(self, rest: bytes, from_addr: int) -> bytes:
         """Handle TSQL frequency get/set (0x1B sub 0x01)."""
         to = from_addr
         frm = self._radio_addr
-        # Strip receiver prefix (command29)
-        receiver, data = self._strip_receiver_prefix(rest)
-        if len(data) >= 3:  # SET (3-byte BCD payload)
-            self._tsql_freq_hz = _decode_tone_freq(data[:3])
+        if len(rest) >= 3:  # SET (3-byte BCD payload)
+            self._tsql_freq_hz = _decode_tone_freq(rest[:3])
             return self._civ_ack(to, frm)
-        # GET: include receiver prefix in response if present
-        response_data = (
-            bytes([receiver]) if receiver is not None else b""
-        ) + _encode_tone_freq(self._tsql_freq_hz)
         return self._civ_frame(
             to,
             frm,
             _CMD_TONE,
             sub=_SUB_TSQL_FREQ,
-            data=response_data,
+            data=_encode_tone_freq(self._tsql_freq_hz),
         )
 
 
@@ -329,10 +274,16 @@ class ToneMockRadio(MockIcomRadio):
 # ---------------------------------------------------------------------------
 
 
+# IC-7300's CI-V address (RadioModel(name="IC-7300", civ_addr=148)) --
+# module docstring explains why this file uses IC-7300, not the mock's
+# own IC-7610 default (MockIcomRadio's own radio_addr default, 0x98).
+_IC_7300_ADDR = 0x94
+
+
 @pytest.fixture
 async def tone_mock() -> AsyncGenerator[ToneMockRadio, None]:
     """Start a ToneMockRadio server for each test, stop it after."""
-    server = ToneMockRadio()
+    server = ToneMockRadio(radio_addr=_IC_7300_ADDR)
     await server.start()
     yield server
     await server.stop()
@@ -347,6 +298,7 @@ async def tone_radio(tone_mock: ToneMockRadio) -> AsyncGenerator[IcomRadio, None
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7300",
     )
     with fast_connect():
         await radio.connect()

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -8,7 +8,7 @@
 # entry in the profile's own TOML. Regenerate, do not hand-edit.
 census	civ_profiles	6
 census	distinct_gap_keys	157
-census	profile_key_gaps	324
+census	profile_key_gaps	316
 census	public_builders	228
 gap	get_acc1_mod_level	X6100,X6200
 gap	get_af_mute	X6100,X6200
@@ -56,8 +56,8 @@ gap	get_powerstat	IC-705,IC-7610,X6100,X6200
 gap	get_quick_dual_watch	X6100,X6200
 gap	get_quick_split	X6100,X6200
 gap	get_ref_adjust	X6100,X6200
-gap	get_repeater_tone	IC-7610,X6100,X6200
-gap	get_repeater_tsql	IC-7610,X6100,X6200
+gap	get_repeater_tone	X6100,X6200
+gap	get_repeater_tsql	X6100,X6200
 gap	get_rit_frequency	X6100,X6200
 gap	get_rit_status	X6100,X6200
 gap	get_rit_tx_status	X6100,X6200
@@ -81,8 +81,8 @@ gap	get_split	X6100,X6200
 gap	get_ssb_tx_bandwidth	X6100,X6200
 gap	get_system_date	X6100,X6200
 gap	get_system_time	X6100,X6200
-gap	get_tone_freq	IC-7610,X6100,X6200
-gap	get_tsql_freq	IC-7610,X6100,X6200
+gap	get_tone_freq	X6100,X6200
+gap	get_tsql_freq	X6100,X6200
 gap	get_tuning_step	X6100,X6200
 gap	get_twin_peak_filter	X6100,X6200
 gap	get_tx_freq_monitor	X6100,X6200
@@ -146,8 +146,8 @@ gap	set_pbt_outer	X6100,X6200
 gap	set_quick_dual_watch	X6100,X6200
 gap	set_quick_split	X6100,X6200
 gap	set_ref_adjust	X6100,X6200
-gap	set_repeater_tone	IC-7610,X6100,X6200
-gap	set_repeater_tsql	IC-7610,X6100,X6200
+gap	set_repeater_tone	X6100,X6200
+gap	set_repeater_tsql	X6100,X6200
 gap	set_rit_frequency	X6100,X6200
 gap	set_rit_status	X6100,X6200
 gap	set_rit_tx_status	X6100,X6200
@@ -155,8 +155,8 @@ gap	set_rx_antenna_ant2	X6100,X6200
 gap	set_ssb_tx_bandwidth	X6100,X6200
 gap	set_system_date	X6100,X6200
 gap	set_system_time	X6100,X6200
-gap	set_tone_freq	IC-7610,X6100,X6200
-gap	set_tsql_freq	IC-7610,X6100,X6200
+gap	set_tone_freq	X6100,X6200
+gap	set_tsql_freq	X6100,X6200
 gap	set_tuning_step	X6100,X6200
 gap	set_twin_peak_filter	X6100,X6200
 gap	set_tx_freq_monitor	X6100,X6200

--- a/tests/test_command_fallback_audit.py
+++ b/tests/test_command_fallback_audit.py
@@ -17,6 +17,15 @@ to this one in the same worker process. ``_reloaded_with_flag`` below
 snapshots ``vars(rigplane.commands)`` before reloading and restores that
 exact snapshot in a ``finally``, so a reload done inside one test here
 never leaks into the next test -- in this file or any other.
+
+Representative builder: ``dsp.py``'s ``get_attenuator``/``set_attenuator``,
+not ``freq.py``'s ``get_freq``/``set_freq`` as originally written -- MOR-2008
+batch 2 migrated ``get_freq``/``set_freq`` onto the required-``cmd_map``
+contract, so calling either with ``cmd_map=None`` (this file's whole point:
+proving the audit wrapper logs when the old fallback engages) now raises
+``TypeError`` before the wrapper's own logic ever runs. ``dsp.py`` is not
+migrated by any batch so far, so its builders still carry a real
+``cmd_map is None`` fallback branch to audit.
 """
 
 from __future__ import annotations
@@ -30,7 +39,7 @@ import pytest
 
 import rigplane.commands as commands
 import rigplane.commands._frame as frame_module
-import rigplane.commands.freq as freq_module
+import rigplane.commands.dsp as dsp_module
 from rigplane.commands import _fallback_audit
 from rigplane.commands.command_map import CommandMap
 from rigplane.commands.speech import get_speech as raw_get_speech
@@ -106,8 +115,8 @@ class TestFlagOff:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         with _reloaded_with_flag(monkeypatch, None) as reloaded:
-            assert reloaded.get_freq is freq_module.get_freq
-            assert reloaded.set_freq is freq_module.set_freq
+            assert reloaded.get_attenuator is dsp_module.get_attenuator
+            assert reloaded.set_attenuator is dsp_module.set_attenuator
             # Backward-compat alias: same object as its canonical name.
             assert reloaded.speech is raw_get_speech
             assert reloaded.get_speech is raw_get_speech
@@ -117,7 +126,7 @@ class TestFlagOff:
     ) -> None:
         with _reloaded_with_flag(monkeypatch, None) as reloaded:
             with caplog.at_level(logging.WARNING, logger=_AUDIT_LOGGER):
-                reloaded.get_freq(to_addr=0x94, cmd_map=None)
+                reloaded.get_attenuator(to_addr=0x94, cmd_map=None)
             assert caplog.records == []
 
 
@@ -128,10 +137,10 @@ class TestFlagOn:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         with _reloaded_with_flag(monkeypatch, "1") as reloaded:
-            assert reloaded.get_freq is not freq_module.get_freq
-            assert inspect.unwrap(reloaded.get_freq) is freq_module.get_freq
-            assert reloaded.get_freq.__name__ == "get_freq"
-            assert reloaded.get_freq.__doc__ == freq_module.get_freq.__doc__
+            assert reloaded.get_attenuator is not dsp_module.get_attenuator
+            assert inspect.unwrap(reloaded.get_attenuator) is dsp_module.get_attenuator
+            assert reloaded.get_attenuator.__name__ == "get_attenuator"
+            assert reloaded.get_attenuator.__doc__ == dsp_module.get_attenuator.__doc__
 
     def test_alias_identity_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
         with _reloaded_with_flag(monkeypatch, "1") as reloaded:
@@ -152,45 +161,46 @@ class TestFlagOn:
     ) -> None:
         with _reloaded_with_flag(monkeypatch, "1") as reloaded:
             with caplog.at_level(logging.WARNING, logger=_AUDIT_LOGGER):
-                result = reloaded.get_freq(to_addr=0x94, cmd_map=None)
-            assert result == freq_module.get_freq(to_addr=0x94, cmd_map=None)
+                result = reloaded.get_attenuator(to_addr=0x94, cmd_map=None)
+            assert result == dsp_module.get_attenuator(to_addr=0x94, cmd_map=None)
             assert len(caplog.records) == 1
-            assert "get_freq" in caplog.text
+            assert "get_attenuator" in caplog.text
 
     def test_call_with_a_map_logs_nothing(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        cmd_map = CommandMap({"get_freq": (0x03,)})
+        cmd_map = CommandMap({"get_attenuator": (0x11,)})
         with _reloaded_with_flag(monkeypatch, "1") as reloaded:
             with caplog.at_level(logging.WARNING, logger=_AUDIT_LOGGER):
-                reloaded.get_freq(to_addr=0x94, cmd_map=cmd_map)
+                reloaded.get_attenuator(to_addr=0x94, cmd_map=cmd_map)
             assert caplog.records == []
 
     def test_return_value_and_exceptions_are_preserved(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         with _reloaded_with_flag(monkeypatch, "1") as reloaded:
-            assert reloaded.get_freq(
+            assert reloaded.get_attenuator(
                 to_addr=0x94, cmd_map=None
-            ) == freq_module.get_freq(to_addr=0x94, cmd_map=None)
+            ) == dsp_module.get_attenuator(to_addr=0x94, cmd_map=None)
             with pytest.raises(TypeError):
-                reloaded.get_freq()  # missing required to_addr, both wrapped and raw
+                reloaded.get_attenuator()  # missing required to_addr, both wrapped and raw
 
     def test_reload_does_not_leak_into_the_ambient_module(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The context manager's restore must actually run.
 
-        Compares against whatever ``commands.get_freq`` was *before* the
-        ``with`` block, not against the raw ``freq_module.get_freq``: another
-        collected test file's ``bind_default_addr_module`` (see module
-        docstring) may already have rebound it to a partial before this test
-        runs, and that is exactly the state the restore must put back.
+        Compares against whatever ``commands.get_attenuator`` was *before*
+        the ``with`` block, not against the raw ``dsp_module.get_attenuator``:
+        another collected test file's ``bind_default_addr_module`` (see
+        module docstring) may already have rebound it to a partial before
+        this test runs, and that is exactly the state the restore must put
+        back.
         """
-        before = commands.get_freq
+        before = commands.get_attenuator
         with _reloaded_with_flag(monkeypatch, "1"):
             pass
-        assert commands.get_freq is before
+        assert commands.get_attenuator is before
 
 
 def test_module_docstring_cites_the_plan_and_step_z() -> None:

--- a/tests/test_command_map_integration.py
+++ b/tests/test_command_map_integration.py
@@ -38,6 +38,7 @@ from rigplane.commands import (
 )
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.rig_loader import load_rig
+from rigplane.types import bcd_encode
 from _command_test_helpers import bind_default_addr_globals
 
 RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
@@ -68,10 +69,18 @@ class TestGetterParity:
     """
 
     def test_get_frequency(self, cmd_map):
-        assert commands.get_freq(cmd_map=cmd_map) == commands.get_freq()
+        # commands/freq.py migrated onto the bound command map in MOR-2008
+        # (batch 2): get_freq/set_freq now require cmd_map -- pinned
+        # against the frame the deleted fallback used to build.
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x03)
+        assert commands.get_freq(cmd_map=cmd_map) == expected
 
     def test_get_mode(self, cmd_map):
-        assert commands.get_mode(cmd_map=cmd_map) == commands.get_mode()
+        # commands/mode.py migrated onto the bound command map in MOR-2008
+        # (batch 2): get_mode/set_mode now require cmd_map -- pinned
+        # against the frame the deleted fallback used to build.
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x04)
+        assert commands.get_mode(cmd_map=cmd_map) == expected
 
     def test_get_af_level(self, cmd_map):
         # IC-7610 declares a cmd29 route for 0x14/0x01, so command29=True
@@ -92,13 +101,19 @@ class TestGetterParity:
         assert commands.get_rf_power(cmd_map=cmd_map) == expected
 
     def test_get_s_meter(self, cmd_map):
-        assert commands.get_s_meter(cmd_map=cmd_map) == commands.get_s_meter()
+        # commands/meters.py migrated onto the bound command map in
+        # MOR-2008 (batch 2): pinned against the frame the deleted
+        # fallback used to build.
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x15, sub=0x02)
+        assert commands.get_s_meter(cmd_map=cmd_map) == expected
 
     def test_get_swr(self, cmd_map):
-        assert commands.get_swr(cmd_map=cmd_map) == commands.get_swr()
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x15, sub=0x12)
+        assert commands.get_swr(cmd_map=cmd_map) == expected
 
     def test_get_alc(self, cmd_map):
-        assert commands.get_alc(cmd_map=cmd_map) == commands.get_alc()
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x15, sub=0x13)
+        assert commands.get_alc(cmd_map=cmd_map) == expected
 
     def test_get_tuning_step(self, cmd_map):
         # commands/vfo.py migrated onto the bound command map in MOR-2007
@@ -118,7 +133,8 @@ class TestGetterParity:
         assert commands.get_ip_plus(cmd_map=cmd_map) == commands.get_ip_plus()
 
     def test_get_power_meter(self, cmd_map):
-        assert commands.get_power_meter(cmd_map=cmd_map) == commands.get_power_meter()
+        expected = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x15, sub=0x11)
+        assert commands.get_power_meter(cmd_map=cmd_map) == expected
 
     def test_get_transceiver_id(self, cmd_map):
         # commands/system.py migrated onto the bound command map in
@@ -160,9 +176,13 @@ class TestSetterParity:
     """
 
     def test_set_frequency(self, cmd_map):
-        assert commands.set_freq(14_200_000, cmd_map=cmd_map) == commands.set_freq(
-            14_200_000
+        # commands/freq.py migrated onto the bound command map in MOR-2008
+        # (batch 2): pinned against the frame the deleted fallback used to
+        # build.
+        expected = build_civ_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x05, data=bcd_encode(14_200_000)
         )
+        assert commands.set_freq(14_200_000, cmd_map=cmd_map) == expected
 
     def test_set_power(self, cmd_map):
         expected = build_civ_frame(
@@ -442,7 +462,13 @@ class TestHelperCallerParity:
         assert commands.get_dial_lock(cmd_map=cmd_map) == commands.get_dial_lock()
 
     def test_get_filter_shape(self, cmd_map):
-        assert commands.get_filter_shape(cmd_map=cmd_map) == commands.get_filter_shape()
+        # commands/mode.py migrated onto the bound command map in MOR-2008
+        # (batch 2): pinned against the frame the deleted fallback used to
+        # build (command29 defaults True, same as the deleted fallback).
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x16, sub=0x56, receiver=RECEIVER_MAIN
+        )
+        assert commands.get_filter_shape(cmd_map=cmd_map) == expected
 
     def test_get_ref_adjust(self, cmd_map):
         expected = build_civ_frame(
@@ -451,16 +477,22 @@ class TestHelperCallerParity:
         assert commands.get_ref_adjust(cmd_map=cmd_map) == expected
 
     def test_get_s_meter_sql_status(self, cmd_map):
-        assert (
-            commands.get_s_meter_sql_status(cmd_map=cmd_map)
-            == commands.get_s_meter_sql_status()
+        # commands/meters.py migrated onto the bound command map in
+        # MOR-2008 (batch 2): pinned against the frame the deleted
+        # fallback used to build (command29 defaults True).
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x15, sub=0x01, receiver=RECEIVER_MAIN
         )
+        assert commands.get_s_meter_sql_status(cmd_map=cmd_map) == expected
 
     def test_get_agc_time_constant(self, cmd_map):
-        assert (
-            commands.get_agc_time_constant(cmd_map=cmd_map)
-            == commands.get_agc_time_constant()
+        # commands/mode.py migrated onto the bound command map in MOR-2008
+        # (batch 2): pinned against the frame the deleted fallback used to
+        # build (command29 defaults True).
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x1A, sub=0x04, receiver=RECEIVER_MAIN
         )
+        assert commands.get_agc_time_constant(cmd_map=cmd_map) == expected
 
 
 # ── cmd29-aware functions ───────────────────────────────────────
@@ -532,10 +564,13 @@ class TestCmd29Parity:
         )
 
     def test_get_various_squelch(self, cmd_map):
-        assert (
-            commands.get_various_squelch(cmd_map=cmd_map)
-            == commands.get_various_squelch()
+        # commands/meters.py migrated onto the bound command map in
+        # MOR-2008 (batch 2): pinned against the frame the deleted
+        # fallback used to build (command29 defaults True).
+        expected = build_cmd29_frame(
+            IC_7610_ADDR, CONTROLLER_ADDR, 0x15, sub=0x05, receiver=RECEIVER_MAIN
         )
+        assert commands.get_various_squelch(cmd_map=cmd_map) == expected
 
 
 # ── Custom CommandMap (different wire bytes) ────────────────────
@@ -554,11 +589,15 @@ class TestCommandMapOverride:
         assert result != known_good
         assert b"\x16\x43" in result
 
-    def test_custom_single_byte_command(self):
+    def test_custom_single_byte_command(self, cmd_map):
+        # commands/freq.py migrated onto the bound command map in MOR-2008
+        # (batch 2): get_freq now requires cmd_map, so "different wire
+        # bytes" is shown against the real IC-7610 map rather than the
+        # deleted fallback.
         custom = CommandMap({"get_freq": (0xFF,)})
         result = commands.get_freq(cmd_map=custom)
         assert b"\xff" in result
-        assert result != commands.get_freq()
+        assert result != commands.get_freq(cmd_map=cmd_map)
 
     def test_custom_setter(self, cmd_map):
         # MOR-2006 Steps 5..N (module 2): set_rf_power now requires

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -252,14 +252,16 @@ def _hardcode_only_builders() -> frozenset[Key]:
     the kernel gaining a public helper, or a module gaining a response
     parser. :func:`_builders` needs no module-level rule because its own
     ``__name__.startswith("_")`` filter already excludes every underscore
-    module: the seven kernel helpers that do take a ``cmd_map``
-    (``_builders.py: _build_meter_bool_get`` and its five siblings,
+    module: the four kernel helpers that do take a ``cmd_map``
+    (``_builders.py: _build_function_get`` and its two siblings,
     ``_frame.py: _build_from_map``) are all underscore-named -- down from
     eleven at MOR-2006 module 1 (config.py): module 2 (levels.py) deleted
     ``_build_level_get``, ``_build_level_set`` and ``_build_ctl_mem_set``,
-    each left with zero callers once levels.py de-delegated from them, and
+    each left with zero callers once levels.py de-delegated from them,
     MOR-2008 batch 1 (system.py) deleted ``_build_ctl_mem_get`` the same
-    way.
+    way, and MOR-2008 batch 2 (mode.py/meters.py) deleted
+    ``_build_meter_bool_get``/``_build_ctl_mem_single_bcd_get``/
+    ``_build_ctl_mem_single_bcd_set`` the same way.
     A public
     ``cmd_map``-taking helper added to one of those modules would move
     ``public_builders`` -- this rule is what keeps it out of this count.

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -367,8 +367,12 @@ class TestBackwardCompatibility:
 
         The expected-absent set is imported from
         ``test_rig_loader.py: TestIc7610DeclaresAbsentCommands`` rather
-        than duplicated here, so there is exactly one hardcoded pin of
-        "these eight names" in the test suite; this test then checks a
+        than duplicated here, so this file adds no fourth copy of the
+        eight names
+        (``test_rig_loader.py: test_ic7610_drops_dead_tone_commands`` and
+        ``test_rig_ic7610.py: test_no_repeater_tone_family`` enumerate
+        them too, but pin a different property -- absence from the
+        command map, not the parsed spec type); this test then checks a
         different layer against that same external pin (the raw
         ``rig.commands`` dict this file's own ``CommandSpec`` types come
         from, rather than the derived ``RadioProfile.absent_command_names``

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -9,6 +9,7 @@ import pytest
 
 from rigplane.command_spec import AbsentCommandSpec, CatCommandSpec, CivCommandSpec
 from rigplane.rig_loader import RigLoadError, load_rig
+from test_rig_loader import TestIc7610DeclaresAbsentCommands as _Ic7610AbsentPin
 
 
 def _write_toml(tmp_path: Path, content: str, name: str = "test.toml") -> Path:
@@ -354,8 +355,30 @@ class TestAbsentCommandSpec:
 class TestBackwardCompatibility:
     """Ensure existing CI-V rigs load unchanged."""
 
-    def test_ic7610_loads_unchanged(self):
-        """IC-7610 rig loads with CI-V commands as before."""
+    def test_ic7610_loads_civ_except_the_declared_absent_tone_tsql_family(self):
+        """IC-7610 rig loads with CI-V commands as before -- except the
+        eight repeater-tone/TSQL/tone-freq/TSQL-freq keys, which MOR-2008
+        batch 2 promoted from a comment-only exclusion to a formal
+        ``{ absent = "<source>" }`` row (``AbsentCommandSpec``, not
+        ``CivCommandSpec``): see ``rigs/ic7610.toml``'s own rows for the
+        citation. Renamed from ``test_ic7610_loads_unchanged``, which this
+        promotion made false -- that version asserted every single command
+        was ``CivCommandSpec`` with no exception.
+
+        The expected-absent set is imported from
+        ``test_rig_loader.py: TestIc7610DeclaresAbsentCommands`` rather
+        than duplicated here, so there is exactly one hardcoded pin of
+        "these eight names" in the test suite; this test then checks a
+        different layer against that same external pin (the raw
+        ``rig.commands`` dict this file's own ``CommandSpec`` types come
+        from, rather than the derived ``RadioProfile.absent_command_names``
+        property `test_rig_loader.py` checks) -- not merely re-deriving
+        one from the other, which would never catch a break in the
+        conversion between them. Still discriminating either way: a CI-V
+        row silently becoming absent, or an absent row silently reverting
+        to CI-V, fails this test regardless of which of the two names
+        moves.
+        """
         rigs_dir = Path(__file__).resolve().parent.parent / "rigs"
         p = rigs_dir / "ic7610.toml"
 
@@ -364,11 +387,25 @@ class TestBackwardCompatibility:
 
         rig = load_rig(p)
 
-        # All commands should be CivCommandSpec
+        expected_absent = _Ic7610AbsentPin._EXPECTED_ABSENT
         for name, spec in rig.commands.items():
-            assert isinstance(spec, CivCommandSpec), (
-                f"Command {name} is not CivCommandSpec"
-            )
+            if name in expected_absent:
+                assert isinstance(spec, AbsentCommandSpec), (
+                    f"Command {name} is declared absent but not AbsentCommandSpec"
+                )
+            else:
+                assert isinstance(spec, CivCommandSpec), (
+                    f"Command {name} is not CivCommandSpec"
+                )
+        actually_absent = {
+            name
+            for name, spec in rig.commands.items()
+            if isinstance(spec, AbsentCommandSpec)
+        }
+        assert actually_absent == expected_absent, (
+            "rig.commands' AbsentCommandSpec entries drifted from "
+            "TestIc7610DeclaresAbsentCommands._EXPECTED_ABSENT"
+        )
 
         # CommandMap should work as before
         cmd_map = rig.to_command_map()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -142,26 +142,48 @@ class TestParseCivFrame:
 
 
 class TestFrequencyCommands:
-    """Test frequency get/set commands."""
+    """Test frequency get/set commands.
 
-    def test_get_frequency(self) -> None:
-        frame = get_freq()
+    commands/freq.py migrated onto the bound command map in MOR-2008
+    (batch 2): get_freq/set_freq now require cmd_map -- zero divergence,
+    so IC-7610's own map declares the identical bytes the fallback used
+    to build, and the expected frames below are unchanged.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_get_frequency(self, cmd_map) -> None:
+        frame = get_freq(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x03\xfd"
 
-    def test_set_frequency_14mhz(self) -> None:
-        frame = set_freq(14_074_000)
+    def test_get_frequency_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_freq()  # type: ignore[call-arg]
+
+    def test_set_frequency_14mhz(self, cmd_map) -> None:
+        frame = set_freq(14_074_000, cmd_map=cmd_map)
         expected_bcd = b"\x00\x40\x07\x14\x00"
         assert frame == b"\xfe\xfe\x98\xe0\x05" + expected_bcd + b"\xfd"
 
-    def test_set_frequency_7mhz(self) -> None:
-        frame = set_freq(7_074_000)
+    def test_set_frequency_7mhz(self, cmd_map) -> None:
+        frame = set_freq(7_074_000, cmd_map=cmd_map)
         expected_bcd = b"\x00\x40\x07\x07\x00"
         assert frame == b"\xfe\xfe\x98\xe0\x05" + expected_bcd + b"\xfd"
 
-    def test_set_frequency_custom_addr(self) -> None:
-        frame = set_freq(14_074_000, to_addr=0xA4, from_addr=0xE1)
+    def test_set_frequency_custom_addr(self, cmd_map) -> None:
+        frame = set_freq(14_074_000, to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map)
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
+
+    def test_set_frequency_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_freq(14_074_000, cmd_map=None)
 
     def test_parse_frequency_response(self) -> None:
         # Radio responds with cmd 0x03 + 5 bytes BCD
@@ -183,19 +205,35 @@ class TestFrequencyCommands:
 
 
 class TestModeCommands:
-    """Test mode get/set commands."""
+    """Test mode get/set commands.
 
-    def test_get_mode(self) -> None:
-        frame = get_mode()
+    commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): get_mode/set_mode now require cmd_map -- zero divergence,
+    so IC-7610's own map declares the identical bytes the fallback used
+    to build, and the expected frames below are unchanged.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_get_mode(self, cmd_map) -> None:
+        frame = get_mode(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x04\xfd"
 
-    def test_set_mode_usb(self) -> None:
-        frame = set_mode(Mode.USB)
+    def test_set_mode_usb(self, cmd_map) -> None:
+        frame = set_mode(Mode.USB, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x06\x01\xfd"
 
-    def test_set_mode_with_filter(self) -> None:
-        frame = set_mode(Mode.CW, filter_width=2)
+    def test_set_mode_with_filter(self, cmd_map) -> None:
+        frame = set_mode(Mode.CW, filter_width=2, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x06\x03\x02\xfd"
+
+    def test_set_mode_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_mode(Mode.USB)  # type: ignore[call-arg]
 
     def test_parse_mode_response(self) -> None:
         resp = CivFrame(
@@ -266,19 +304,35 @@ class TestPowerCommands:
 
 
 class TestMeterCommands:
-    """Test meter reading commands."""
+    """Test meter reading commands.
 
-    def test_get_s_meter(self) -> None:
-        frame = get_s_meter()
+    commands/meters.py migrated onto the bound command map in MOR-2008
+    (batch 2): all ten builders now require cmd_map -- zero divergence,
+    so IC-7610's own map declares the identical bytes the fallback used
+    to build, and the expected frames below are unchanged.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
+
+    def test_get_s_meter(self, cmd_map) -> None:
+        frame = get_s_meter(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x15\x02\xfd"
 
-    def test_get_swr(self) -> None:
-        frame = get_swr()
+    def test_get_swr(self, cmd_map) -> None:
+        frame = get_swr(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x15\x12\xfd"
 
-    def test_get_alc(self) -> None:
-        frame = get_alc()
+    def test_get_alc(self, cmd_map) -> None:
+        frame = get_alc(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x15\x13\xfd"
+
+    def test_get_s_meter_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_s_meter()  # type: ignore[call-arg]
 
     def test_parse_meter_response(self) -> None:
         # Meter values are 2-byte BCD: 0x01 0x20 = 120
@@ -304,7 +358,18 @@ class TestMeterCommands:
 
 
 class TestFilterWidthCommands:
-    """Test DSP IF filter width command encoding."""
+    """Test DSP IF filter width command encoding.
+
+    commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): set_filter_width now requires cmd_map -- zero divergence,
+    so IC-7610's own map declares the identical bytes the fallback used
+    to build, and the expected frames below are unchanged.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
 
     def test_filter_hz_to_index_uses_segmented_ssb_ranges(self) -> None:
         segments = (
@@ -328,13 +393,18 @@ class TestFilterWidthCommands:
         assert filter_index_to_hz(19, segments=segments) == 1500
         assert filter_index_to_hz(40, segments=segments) == 3600
 
-    def test_set_filter_width_cmd29_frame(self) -> None:
-        frame = set_filter_width(19)
+    def test_set_filter_width_cmd29_frame(self, cmd_map) -> None:
+        frame = set_filter_width(19, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x29\x00\x1a\x03\x00\x19\xfd"
 
-    def test_set_filter_width_sub_receiver_cmd29_frame(self) -> None:
-        frame = set_filter_width(19, receiver=1)
+    def test_set_filter_width_sub_receiver_cmd29_frame(self, cmd_map) -> None:
+        frame = set_filter_width(19, receiver=1, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x29\x01\x1a\x03\x00\x19\xfd"
+
+    def test_set_filter_width_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_filter_width(19)  # type: ignore[call-arg]
 
     def test_parse_meter_response_short_payload_raises(self) -> None:
         resp = CivFrame(
@@ -535,32 +605,32 @@ class TestCmd29ReceiverRouting:
         rig = load_rig(RIG_DIR / "ic7610.toml")
         return rig.to_command_map()
 
-    def test_set_frequency_main_no_cmd29(self) -> None:
+    def test_set_frequency_main_no_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_freq
 
-        frame = set_freq(14_074_000, receiver=RECEIVER_MAIN)
+        frame = set_freq(14_074_000, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x05  # Direct freq set, no cmd29 prefix
 
-    def test_set_frequency_sub_uses_cmd29(self) -> None:
+    def test_set_frequency_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, set_freq
 
-        frame = set_freq(14_074_000, receiver=RECEIVER_SUB)
+        frame = set_freq(14_074_000, receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x05  # Freq set command
 
-    def test_set_mode_main_no_cmd29(self) -> None:
+    def test_set_mode_main_no_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_mode
         from rigplane.types import Mode
 
-        frame = set_mode(Mode.USB, receiver=RECEIVER_MAIN)
+        frame = set_mode(Mode.USB, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x06  # Direct mode set, no cmd29 prefix
 
-    def test_set_mode_sub_uses_cmd29(self) -> None:
+    def test_set_mode_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, set_mode
         from rigplane.types import Mode
 
-        frame = set_mode(Mode.USB, receiver=RECEIVER_SUB)
+        frame = set_mode(Mode.USB, receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01  # SUB receiver
         assert frame[6] == 0x06  # Mode set command
@@ -824,8 +894,8 @@ class TestCmd29ReceiverRouting:
         from rigplane.types import Mode
 
         # freq/mode never use cmd29 (hard exclusion, IC-7610 CI-V quirk).
-        assert set_frequency(14_000_000)[4] == 0x05
-        assert set_mode(Mode.USB)[4] == 0x06
+        assert set_frequency(14_000_000, cmd_map=cmd_map)[4] == 0x05
+        assert set_mode(Mode.USB, cmd_map=cmd_map)[4] == 0x06
         # MOR-1537 follow-up: nb/nr/ip_plus builders now default
         # command29=True; no receiver arg still targets MAIN (0x00).
         assert set_nb(True)[4:6] == b"\x29\x00"
@@ -1037,7 +1107,25 @@ class TestDspLevelParityCommands:
 
 
 class TestOperatorToggleParityCommands:
-    """Test IC-7610 operator toggle/status parity command builders."""
+    """Test IC-7610 operator toggle/status parity command builders.
+
+    MOR-2008 batch 2 migrated three of the getters/setters this class
+    parametrizes over (get_s_meter_sql_status/get_filter_shape/
+    get_agc_time_constant/set_filter_shape/set_agc_time_constant/
+    get_overflow_status/get_ssb_tx_bandwidth/set_ssb_tx_bandwidth) onto
+    the bound command map; the rest are dsp.py/config.py builders still
+    unmigrated at this head. ``cmd_map`` is passed to every parametrized
+    call below rather than splitting the table: IC-7610's own map declares
+    every name in it byte-identically to its fallback (zero divergence,
+    confirmed by ``tests/command_map_parity_divergences.txt`` being empty),
+    so passing it to an unmigrated builder here is a no-op on the frame it
+    builds, not a behaviour change.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        return rig.to_command_map()
 
     @pytest.mark.parametrize(
         ("getter_name", "sub", "receiver"),
@@ -1060,13 +1148,14 @@ class TestOperatorToggleParityCommands:
         getter_name: str,
         sub: int,
         receiver: int,
+        cmd_map,
     ) -> None:
         import rigplane.commands as commands
 
         getter = getattr(commands, getter_name)
         command = 0x15 if sub == 0x01 else 0x1A if sub == 0x04 else 0x16
 
-        assert getter(receiver=receiver) == bytes(
+        assert getter(receiver=receiver, cmd_map=cmd_map) == bytes(
             [0xFE, 0xFE, 0x98, 0xE0, 0x29, receiver, command, sub, 0xFD]
         )
 
@@ -1089,11 +1178,12 @@ class TestOperatorToggleParityCommands:
         setter_name: str,
         value: object,
         expected_tail: bytes,
+        cmd_map,
     ) -> None:
         import rigplane.commands as commands
 
         setter = getattr(commands, setter_name)
-        assert setter(value, receiver=1).endswith(expected_tail)
+        assert setter(value, receiver=1, cmd_map=cmd_map).endswith(expected_tail)
 
     @pytest.mark.parametrize(
         ("getter_name", "sub"),
@@ -1107,12 +1197,14 @@ class TestOperatorToggleParityCommands:
             ("get_ssb_tx_bandwidth", 0x58),
         ],
     )
-    def test_direct_operator_getters(self, getter_name: str, sub: int) -> None:
+    def test_direct_operator_getters(self, getter_name: str, sub: int, cmd_map) -> None:
         import rigplane.commands as commands
 
         getter = getattr(commands, getter_name)
         command = 0x15 if sub == 0x07 else 0x16
-        assert getter() == bytes([0xFE, 0xFE, 0x98, 0xE0, command, sub, 0xFD])
+        assert getter(cmd_map=cmd_map) == bytes(
+            [0xFE, 0xFE, 0x98, 0xE0, command, sub, 0xFD]
+        )
 
     @pytest.mark.parametrize(
         ("setter_name", "value", "expected_tail"),
@@ -1130,11 +1222,12 @@ class TestOperatorToggleParityCommands:
         setter_name: str,
         value: object,
         expected_tail: bytes,
+        cmd_map,
     ) -> None:
         import rigplane.commands as commands
 
         setter = getattr(commands, setter_name)
-        assert setter(value).endswith(expected_tail)
+        assert setter(value, cmd_map=cmd_map).endswith(expected_tail)
 
     @pytest.mark.parametrize(
         ("frame", "kwargs", "expected"),
@@ -1186,11 +1279,14 @@ class TestOperatorToggleParityCommands:
 class TestTransceiverStatusBuilders:
     """Test CI-V builders for transceiver_status commands.
 
-    Migrated onto the bound command map in MOR-2008 (batch 1,
-    `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N):
-    every builder here now requires ``cmd_map`` -- zero divergence rows,
-    so IC-7610's own map declares the identical bytes the fallback used to
-    build, and the expected frames below are unchanged.
+    Migrated onto the bound command map in MOR-2008
+    (`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N):
+    batch 1 for the system.py builders here -- band edge, tuner/XFC/
+    TX-freq-monitor status, RIT/XIT; batch 2 for the meters.py builders --
+    various-squelch and the power/comp/Vd/Id meters. Every builder here now
+    requires ``cmd_map`` -- zero divergence rows, so IC-7610's own map
+    declares the identical bytes the fallback used to build, and the
+    expected frames below are unchanged.
     """
 
     @pytest.fixture()
@@ -1211,43 +1307,43 @@ class TestTransceiverStatusBuilders:
         with pytest.raises(TypeError, match="MOR-2006"):
             get_band_edge_freq()  # type: ignore[call-arg]
 
-    def test_get_various_squelch_main(self) -> None:
+    def test_get_various_squelch_main(self, cmd_map) -> None:
         from rigplane.commands import get_various_squelch
 
-        frame = get_various_squelch(receiver=0x00)
+        frame = get_various_squelch(receiver=0x00, cmd_map=cmd_map)
         # Command29 frame: FE FE to from 29 00 15 05 FD
         assert frame[4] == 0x29  # cmd29 prefix
         assert b"\x15\x05" in frame
 
-    def test_get_various_squelch_sub(self) -> None:
+    def test_get_various_squelch_sub(self, cmd_map) -> None:
         from rigplane.commands import get_various_squelch
 
-        frame = get_various_squelch(receiver=0x01)
+        frame = get_various_squelch(receiver=0x01, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == 0x01  # SUB receiver
 
-    def test_get_power_meter(self) -> None:
+    def test_get_power_meter(self, cmd_map) -> None:
         from rigplane.commands import get_power_meter
 
-        frame = get_power_meter()
+        frame = get_power_meter(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x15\x11\xfd" == frame
 
-    def test_get_comp_meter(self) -> None:
+    def test_get_comp_meter(self, cmd_map) -> None:
         from rigplane.commands import get_comp_meter
 
-        frame = get_comp_meter()
+        frame = get_comp_meter(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x15\x14\xfd" == frame
 
-    def test_get_vd_meter(self) -> None:
+    def test_get_vd_meter(self, cmd_map) -> None:
         from rigplane.commands import get_vd_meter
 
-        frame = get_vd_meter()
+        frame = get_vd_meter(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x15\x15\xfd" == frame
 
-    def test_get_id_meter(self) -> None:
+    def test_get_id_meter(self, cmd_map) -> None:
         from rigplane.commands import get_id_meter
 
-        frame = get_id_meter()
+        frame = get_id_meter(cmd_map=cmd_map)
         assert b"\xfe\xfe\x98\xe0\x15\x16\xfd" == frame
 
     def test_get_tuner_status(self, cmd_map) -> None:
@@ -1673,62 +1769,96 @@ class TestAdvancedScopeValidation:
 
 
 class TestToneTsqlCommands:
-    """Tests for tone/TSQL command builders and parsers (#134)."""
+    """Tests for tone/TSQL command builders and parsers (#134).
+
+    commands/tone.py migrated onto the bound command map in MOR-2008
+    (batch 2): all eight builders now require cmd_map -- zero divergence,
+    so every profile that declares these commands agrees with the
+    fallback's own bytes exactly, and the expected frames below are
+    unchanged. Uses IC-7300, not IC-7610: IC-7610 has no FM-repeater CTCSS
+    tone feature and does not declare this family at all (MOR-660/661/682,
+    re-checked and left that way at D2 MOR-2017 -- see
+    ``rigs/ic7610.toml``'s own comment on the point), so building a
+    cmd_map from it would raise ``KeyError`` for every builder in this
+    class.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        rig = load_rig(RIG_DIR / "ic7300.toml")
+        return rig.to_command_map()
 
     # --- Repeater Tone (0x16 0x42) ---
 
-    def test_get_repeater_tone_main_uses_cmd29(self) -> None:
+    def test_get_repeater_tone_main_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_repeater_tone
 
-        frame = get_repeater_tone(receiver=RECEIVER_MAIN)
+        frame = get_repeater_tone(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_MAIN
         assert frame[6] == 0x16
         assert frame[7] == 0x42
 
-    def test_get_repeater_tone_sub_uses_cmd29(self) -> None:
+    def test_get_repeater_tone_sub_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, get_repeater_tone
 
-        frame = get_repeater_tone(receiver=RECEIVER_SUB)
+        frame = get_repeater_tone(receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_SUB
         assert frame[6] == 0x16
         assert frame[7] == 0x42
 
-    def test_set_repeater_tone_on(self) -> None:
+    def test_set_repeater_tone_on(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_repeater_tone
 
-        frame = set_repeater_tone(True, receiver=RECEIVER_MAIN)
+        frame = set_repeater_tone(True, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[6] == 0x16
         assert frame[7] == 0x42
         assert frame[8] == 0x01
 
-    def test_set_repeater_tone_off(self) -> None:
+    def test_set_repeater_tone_off(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_repeater_tone
 
-        frame = set_repeater_tone(False, receiver=RECEIVER_MAIN)
+        frame = set_repeater_tone(False, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[8] == 0x00
+
+    def test_get_repeater_tone_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import get_repeater_tone
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_repeater_tone()  # type: ignore[call-arg]
 
     # --- Repeater TSQL (0x16 0x43) ---
 
-    def test_get_repeater_tsql_uses_cmd29(self) -> None:
+    def test_get_repeater_tsql_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_repeater_tsql
 
-        frame = get_repeater_tsql(receiver=RECEIVER_MAIN)
+        frame = get_repeater_tsql(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[6] == 0x16
         assert frame[7] == 0x43
 
-    def test_set_repeater_tsql_on_sub(self) -> None:
+    def test_set_repeater_tsql_on_sub(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, set_repeater_tsql
 
-        frame = set_repeater_tsql(True, receiver=RECEIVER_SUB)
+        frame = set_repeater_tsql(True, receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_SUB
         assert frame[6] == 0x16
         assert frame[7] == 0x43
         assert frame[8] == 0x01
+
+    def test_set_repeater_tsql_rejects_explicit_none_the_same_way(
+        self, cmd_map
+    ) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        from rigplane.commands import set_repeater_tsql
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_repeater_tsql(True, cmd_map=None)
 
     # --- Tone frequency encoding/decoding ---
 
@@ -1784,45 +1914,45 @@ class TestToneTsqlCommands:
 
     # --- Tone Frequency command (0x1B 0x00) ---
 
-    def test_get_tone_freq_uses_cmd29(self) -> None:
+    def test_get_tone_freq_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, get_tone_freq
 
-        frame = get_tone_freq(receiver=RECEIVER_MAIN)
+        frame = get_tone_freq(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_MAIN
         assert frame[6] == 0x1B
         assert frame[7] == 0x00
 
-    def test_set_tone_freq_encodes_bcd(self) -> None:
+    def test_set_tone_freq_encodes_bcd(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_tone_freq
 
-        frame = set_tone_freq(88.5, receiver=RECEIVER_MAIN)
+        frame = set_tone_freq(88.5, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[6] == 0x1B
         assert frame[7] == 0x00
         assert frame[8:11] == bytes([0x00, 0x88, 0x05])
 
-    def test_set_tone_freq_rejects_out_of_range(self) -> None:
+    def test_set_tone_freq_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_tone_freq
 
         with pytest.raises(ValueError, match="67.0-254.1"):
-            set_tone_freq(50.0)
+            set_tone_freq(50.0, cmd_map=cmd_map)
 
     # --- TSQL Frequency command (0x1B 0x01) ---
 
-    def test_get_tsql_freq_uses_cmd29(self) -> None:
+    def test_get_tsql_freq_uses_cmd29(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_SUB, get_tsql_freq
 
-        frame = get_tsql_freq(receiver=RECEIVER_SUB)
+        frame = get_tsql_freq(receiver=RECEIVER_SUB, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[5] == RECEIVER_SUB
         assert frame[6] == 0x1B
         assert frame[7] == 0x01
 
-    def test_set_tsql_freq_encodes_bcd(self) -> None:
+    def test_set_tsql_freq_encodes_bcd(self, cmd_map) -> None:
         from rigplane.commands import RECEIVER_MAIN, set_tsql_freq
 
-        frame = set_tsql_freq(110.9, receiver=RECEIVER_MAIN)
+        frame = set_tsql_freq(110.9, receiver=RECEIVER_MAIN, cmd_map=cmd_map)
         assert frame[4] == 0x29
         assert frame[6] == 0x1B
         assert frame[7] == 0x01
@@ -2183,63 +2313,83 @@ class TestSystemConfigCommands:
             )
 
     # --- Antenna Selection (0x12) ---
+    #
+    # commands/antenna.py migrated onto the bound command map in MOR-2008
+    # (batch 2): all eight builders now require cmd_map -- zero
+    # divergence, so IC-7610's own map declares the identical bytes the
+    # fallback used to build, and the expected frames below are unchanged.
 
-    def test_get_antenna_1_frame(self) -> None:
+    def test_get_antenna_1_frame(self, cmd_map) -> None:
         from rigplane.commands import get_antenna_1
 
-        frame = get_antenna_1()
+        frame = get_antenna_1(cmd_map=cmd_map)
         # FE FE 98 E0 12 00 FD
         assert frame == b"\xfe\xfe\x98\xe0\x12\x00\xfd"
 
-    def test_set_antenna_1_on(self) -> None:
+    def test_get_antenna_1_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import get_antenna_1
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_antenna_1()  # type: ignore[call-arg]
+
+    def test_set_antenna_1_on(self, cmd_map) -> None:
         from rigplane.commands import set_antenna_1
 
-        frame = set_antenna_1(True)
+        frame = set_antenna_1(True, cmd_map=cmd_map)
         # FE FE 98 E0 12 00 01 FD
         assert frame == b"\xfe\xfe\x98\xe0\x12\x00\x01\xfd"
 
-    def test_set_antenna_1_off(self) -> None:
+    def test_set_antenna_1_off(self, cmd_map) -> None:
         from rigplane.commands import set_antenna_1
 
-        frame = set_antenna_1(False)
+        frame = set_antenna_1(False, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x00\x00\xfd"
 
-    def test_get_antenna_2_frame(self) -> None:
+    def test_set_antenna_1_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        from rigplane.commands import set_antenna_1
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_antenna_1(True, cmd_map=None)
+
+    def test_get_antenna_2_frame(self, cmd_map) -> None:
         from rigplane.commands import get_antenna_2
 
-        frame = get_antenna_2()
+        frame = get_antenna_2(cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x01\xfd"
 
-    def test_set_antenna_2_on(self) -> None:
+    def test_set_antenna_2_on(self, cmd_map) -> None:
         from rigplane.commands import set_antenna_2
 
-        frame = set_antenna_2(True)
+        frame = set_antenna_2(True, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x01\x01\xfd"
 
-    def test_get_rx_antenna_ant1_frame(self) -> None:
+    def test_get_rx_antenna_ant1_frame(self, cmd_map) -> None:
         from rigplane.commands import get_rx_antenna_ant1
 
-        frame = get_rx_antenna_ant1()
+        frame = get_rx_antenna_ant1(cmd_map=cmd_map)
         # IC-7610 CI-V: RX-ANT is encoded as data byte on 0x12 0x00 (ANT1)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x00\xfd"
 
-    def test_set_rx_antenna_ant1_on(self) -> None:
+    def test_set_rx_antenna_ant1_on(self, cmd_map) -> None:
         from rigplane.commands import set_rx_antenna_ant1
 
-        frame = set_rx_antenna_ant1(True)
+        frame = set_rx_antenna_ant1(True, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x00\x01\xfd"
 
-    def test_get_rx_antenna_ant2_frame(self) -> None:
+    def test_get_rx_antenna_ant2_frame(self, cmd_map) -> None:
         from rigplane.commands import get_rx_antenna_ant2
 
-        frame = get_rx_antenna_ant2()
+        frame = get_rx_antenna_ant2(cmd_map=cmd_map)
         # IC-7610 CI-V: RX-ANT is encoded as data byte on 0x12 0x01 (ANT2)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x01\xfd"
 
-    def test_set_rx_antenna_ant2_off(self) -> None:
+    def test_set_rx_antenna_ant2_off(self, cmd_map) -> None:
         from rigplane.commands import set_rx_antenna_ant2
 
-        frame = set_rx_antenna_ant2(False)
+        frame = set_rx_antenna_ant2(False, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x12\x01\x00\xfd"
 
     def test_parse_antenna_bool_response(self) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1778,9 +1778,11 @@ class TestToneTsqlCommands:
     unchanged. Uses IC-7300, not IC-7610: IC-7610 has no FM-repeater CTCSS
     tone feature and does not declare this family at all (MOR-660/661/682,
     re-checked and left that way at D2 MOR-2017 -- see
-    ``rigs/ic7610.toml``'s own comment on the point), so building a
-    cmd_map from it would raise ``KeyError`` for every builder in this
-    class.
+    ``rigs/ic7610.toml``'s own ``{ absent = ... }`` row for each of the
+    eight commands), so building a cmd_map from it and calling any of
+    these builders directly (bypassing ``BoundCommands``, the layer that
+    turns a declared-absent lookup into ``CommandError``) would still
+    raise ``KeyError`` for every builder in this class.
     """
 
     @pytest.fixture()

--- a/tests/test_data_mode.py
+++ b/tests/test_data_mode.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -20,11 +21,21 @@ from rigplane.commands import (
     parse_data_mode_response,
     set_data_mode,
 )
+from rigplane.rig_loader import load_rig
 from rigplane.rigctld.contract import RigctldCommand, RigctldConfig
 from rigplane.rigctld.handler import RigctldHandler
 from rigplane.rigctld.poller import RadioPoller
 from rigplane.rigctld.state_cache import StateCache
 from rigplane.types import CivFrame, Mode
+
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+
+
+@pytest.fixture()
+def cmd_map():
+    rig = load_rig(RIG_DIR / "ic7610.toml")
+    return rig.to_command_map()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,35 +60,52 @@ def get_cmd(long_cmd: str, *args: str) -> RigctldCommand:
 
 
 class TestGetDataModeCommand:
-    def test_frame_bytes(self) -> None:
-        frame = get_data_mode(to_addr=0x98)
+    """commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): get_data_mode/set_data_mode now require cmd_map -- zero
+    divergence, so IC-7610's own map declares the identical bytes the
+    fallback used to build, and the expected frames below are unchanged.
+    """
+
+    def test_frame_bytes(self, cmd_map) -> None:
+        frame = get_data_mode(to_addr=0x98, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\xfd"
 
-    def test_custom_addresses(self) -> None:
-        frame = get_data_mode(to_addr=0x94, from_addr=0xE1)
+    def test_custom_addresses(self, cmd_map) -> None:
+        frame = get_data_mode(to_addr=0x94, from_addr=0xE1, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x94\xe1\x1a\x06\xfd"
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_data_mode(to_addr=0x98)  # type: ignore[call-arg]
 
 
 class TestSetDataModeCommand:
-    def test_on(self) -> None:
-        frame = set_data_mode(True, to_addr=0x98)
+    def test_on(self, cmd_map) -> None:
+        frame = set_data_mode(True, to_addr=0x98, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x01\xfd"
 
-    def test_off(self) -> None:
-        frame = set_data_mode(False, to_addr=0x98)
+    def test_off(self, cmd_map) -> None:
+        frame = set_data_mode(False, to_addr=0x98, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x00\xfd"
 
-    def test_data2(self) -> None:
-        frame = set_data_mode(2, to_addr=0x98)
+    def test_data2(self, cmd_map) -> None:
+        frame = set_data_mode(2, to_addr=0x98, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x02\xfd"
 
-    def test_data3(self) -> None:
-        frame = set_data_mode(3, to_addr=0x98)
+    def test_data3(self, cmd_map) -> None:
+        frame = set_data_mode(3, to_addr=0x98, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x1a\x06\x03\xfd"
 
-    def test_data3_sub_receiver_uses_cmd29(self) -> None:
-        frame = set_data_mode(3, to_addr=0x98, receiver=1)
+    def test_data3_sub_receiver_uses_cmd29(self, cmd_map) -> None:
+        frame = set_data_mode(3, to_addr=0x98, receiver=1, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x98\xe0\x29\x01\x1a\x06\x03\xfd"
+
+    def test_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_data_mode(True, to_addr=0x98, cmd_map=None)
 
 
 class TestParseDataModeResponse:

--- a/tests/test_dsp_levels_part2.py
+++ b/tests/test_dsp_levels_part2.py
@@ -208,66 +208,101 @@ class TestDigiselShift:
 
 
 class TestAGCTimeConstant:
-    """Tests for get_agc_time_constant / set_agc_time_constant."""
+    """Tests for get_agc_time_constant / set_agc_time_constant.
+
+    commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): both builders now require cmd_map -- zero divergence, so
+    IC-7610's own map declares the identical bytes the fallback used to
+    build, and the expected frames below are unchanged.
+    """
 
     def test_get_agc_time_constant_main_receiver(self) -> None:
-        assert commands.get_agc_time_constant(receiver=RECEIVER_MAIN) == _cmd29_get(
-            _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, RECEIVER_MAIN
-        )
+        assert commands.get_agc_time_constant(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_get(_CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, RECEIVER_MAIN)
 
     def test_get_agc_time_constant_sub_receiver(self) -> None:
-        assert commands.get_agc_time_constant(receiver=RECEIVER_SUB) == _cmd29_get(
-            _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, RECEIVER_SUB
-        )
+        assert commands.get_agc_time_constant(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_get(_CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, RECEIVER_SUB)
 
     def test_get_agc_time_constant_default_is_main(self) -> None:
-        assert commands.get_agc_time_constant() == commands.get_agc_time_constant(
-            receiver=RECEIVER_MAIN
+        assert commands.get_agc_time_constant(
+            cmd_map=_IC7610_CMD_MAP
+        ) == commands.get_agc_time_constant(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         )
+
+    def test_get_agc_time_constant_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.get_agc_time_constant()  # type: ignore[call-arg]
 
     def test_set_agc_time_constant_zero_main(self) -> None:
         # 0 -> BCD byte 0x00
-        assert commands.set_agc_time_constant(0, receiver=RECEIVER_MAIN) == _cmd29_set(
+        assert commands.set_agc_time_constant(
+            0, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, 0x00, receiver=RECEIVER_MAIN
         )
 
     def test_set_agc_time_constant_bcd_encoding_twelve(self) -> None:
         # 12 -> BCD byte 0x12 (NOT 0x0C)
-        frame = commands.set_agc_time_constant(12, receiver=RECEIVER_MAIN)
+        frame = commands.set_agc_time_constant(
+            12, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame == _cmd29_set(
             _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, 0x12, receiver=RECEIVER_MAIN
         )
 
     def test_set_agc_time_constant_bcd_encoding_nine(self) -> None:
         # 9 -> BCD byte 0x09
-        frame = commands.set_agc_time_constant(9, receiver=RECEIVER_MAIN)
+        frame = commands.set_agc_time_constant(
+            9, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame == _cmd29_set(
             _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, 0x09, receiver=RECEIVER_MAIN
         )
 
     def test_set_agc_time_constant_max_value(self) -> None:
         # 13 -> BCD byte 0x13
-        assert commands.set_agc_time_constant(13, receiver=RECEIVER_MAIN) == _cmd29_set(
+        assert commands.set_agc_time_constant(
+            13, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, 0x13, receiver=RECEIVER_MAIN
         )
 
     def test_set_agc_time_constant_sub_receiver(self) -> None:
-        assert commands.set_agc_time_constant(5, receiver=RECEIVER_SUB) == _cmd29_set(
+        assert commands.set_agc_time_constant(
+            5, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(
             _CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, 0x05, receiver=RECEIVER_SUB
         )
 
     def test_set_agc_time_constant_default_receiver_is_main(self) -> None:
-        assert commands.set_agc_time_constant(7) == commands.set_agc_time_constant(
-            7, receiver=RECEIVER_MAIN
+        assert commands.set_agc_time_constant(
+            7, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_agc_time_constant(
+            7, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         )
 
     def test_set_agc_time_constant_rejects_over_13(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_agc_time_constant(14, receiver=RECEIVER_MAIN)
+            commands.set_agc_time_constant(
+                14, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+            )
 
     def test_set_agc_time_constant_rejects_negative(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_agc_time_constant(-1, receiver=RECEIVER_MAIN)
+            commands.set_agc_time_constant(
+                -1, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+            )
+
+    def test_set_agc_time_constant_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.set_agc_time_constant(7, cmd_map=None)
 
     def test_parse_agc_time_constant_zero(self) -> None:
         frame = _response_frame(_CMD_CTL_MEM, _SUB_AGC_TIME_CONSTANT, b"\x00")
@@ -304,61 +339,82 @@ class TestAGCTimeConstant:
 
 
 class TestFilterShape:
-    """Tests for get_filter_shape / set_filter_shape."""
+    """Tests for get_filter_shape / set_filter_shape.
+
+    commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): both builders now require cmd_map -- zero divergence, so
+    IC-7610's own map declares the identical bytes the fallback used to
+    build, and the expected frames below are unchanged.
+    """
 
     def test_get_filter_shape_main_receiver(self) -> None:
-        assert commands.get_filter_shape(receiver=RECEIVER_MAIN) == _cmd29_get(
-            _CMD_PREAMP, _SUB_FILTER_SHAPE, RECEIVER_MAIN
-        )
+        assert commands.get_filter_shape(
+            receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_get(_CMD_PREAMP, _SUB_FILTER_SHAPE, RECEIVER_MAIN)
 
     def test_get_filter_shape_sub_receiver(self) -> None:
-        assert commands.get_filter_shape(receiver=RECEIVER_SUB) == _cmd29_get(
-            _CMD_PREAMP, _SUB_FILTER_SHAPE, RECEIVER_SUB
-        )
+        assert commands.get_filter_shape(
+            receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_get(_CMD_PREAMP, _SUB_FILTER_SHAPE, RECEIVER_SUB)
 
     def test_get_filter_shape_default_is_main(self) -> None:
-        assert commands.get_filter_shape() == commands.get_filter_shape(
-            receiver=RECEIVER_MAIN
-        )
+        assert commands.get_filter_shape(
+            cmd_map=_IC7610_CMD_MAP
+        ) == commands.get_filter_shape(receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP)
+
+    def test_get_filter_shape_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.get_filter_shape()  # type: ignore[call-arg]
 
     def test_set_filter_shape_sharp_main(self) -> None:
         assert commands.set_filter_shape(
-            FilterShape.SHARP, receiver=RECEIVER_MAIN
+            FilterShape.SHARP, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         ) == _cmd29_set(_CMD_PREAMP, _SUB_FILTER_SHAPE, 0x00, receiver=RECEIVER_MAIN)
 
     def test_set_filter_shape_soft_main(self) -> None:
         assert commands.set_filter_shape(
-            FilterShape.SOFT, receiver=RECEIVER_MAIN
+            FilterShape.SOFT, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
         ) == _cmd29_set(_CMD_PREAMP, _SUB_FILTER_SHAPE, 0x01, receiver=RECEIVER_MAIN)
 
     def test_set_filter_shape_sharp_sub_receiver(self) -> None:
         assert commands.set_filter_shape(
-            FilterShape.SHARP, receiver=RECEIVER_SUB
+            FilterShape.SHARP, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
         ) == _cmd29_set(_CMD_PREAMP, _SUB_FILTER_SHAPE, 0x00, receiver=RECEIVER_SUB)
 
     def test_set_filter_shape_soft_sub_receiver(self) -> None:
         assert commands.set_filter_shape(
-            FilterShape.SOFT, receiver=RECEIVER_SUB
+            FilterShape.SOFT, receiver=RECEIVER_SUB, cmd_map=_IC7610_CMD_MAP
         ) == _cmd29_set(_CMD_PREAMP, _SUB_FILTER_SHAPE, 0x01, receiver=RECEIVER_SUB)
 
     def test_set_filter_shape_accepts_int(self) -> None:
-        assert commands.set_filter_shape(0) == commands.set_filter_shape(
-            FilterShape.SHARP
-        )
+        assert commands.set_filter_shape(
+            0, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_filter_shape(FilterShape.SHARP, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_filter_shape_accepts_int_one(self) -> None:
-        assert commands.set_filter_shape(1) == commands.set_filter_shape(
-            FilterShape.SOFT
-        )
+        assert commands.set_filter_shape(
+            1, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_filter_shape(FilterShape.SOFT, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_filter_shape_default_receiver_is_main(self) -> None:
         assert commands.set_filter_shape(
-            FilterShape.SHARP
-        ) == commands.set_filter_shape(FilterShape.SHARP, receiver=RECEIVER_MAIN)
+            FilterShape.SHARP, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_filter_shape(
+            FilterShape.SHARP, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        )
 
     def test_set_filter_shape_rejects_invalid_enum(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_filter_shape(999, receiver=RECEIVER_MAIN)
+            commands.set_filter_shape(
+                999, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+            )
+
+    def test_set_filter_shape_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.set_filter_shape(FilterShape.SHARP, cmd_map=None)
 
     def test_set_filter_shape_builder_accepts_values_outside_the_sharp_soft_enum(
         self,
@@ -370,9 +426,9 @@ class TestFilterShape:
         ``TestFilterShapeDomainValidation`` in ``tests/test_radio.py``).
         This builder only encodes the raw single-BCD-byte value.
         """
-        assert commands.set_filter_shape(2, receiver=RECEIVER_MAIN) == _cmd29_set(
-            _CMD_PREAMP, _SUB_FILTER_SHAPE, 0x02, receiver=RECEIVER_MAIN
-        )
+        assert commands.set_filter_shape(
+            2, receiver=RECEIVER_MAIN, cmd_map=_IC7610_CMD_MAP
+        ) == _cmd29_set(_CMD_PREAMP, _SUB_FILTER_SHAPE, 0x02, receiver=RECEIVER_MAIN)
 
     def test_parse_filter_shape_sharp(self) -> None:
         frame = _response_frame(_CMD_PREAMP, _SUB_FILTER_SHAPE, b"\x00")
@@ -395,46 +451,63 @@ class TestFilterShape:
 
 
 class TestSsbTxBandwidth:
-    """Tests for get_ssb_tx_bandwidth / set_ssb_tx_bandwidth."""
+    """Tests for get_ssb_tx_bandwidth / set_ssb_tx_bandwidth.
+
+    commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): both builders now require cmd_map -- zero divergence, so
+    IC-7610's own map declares the identical bytes the fallback used to
+    build, and the expected frames below are unchanged.
+    """
 
     def test_get_ssb_tx_bandwidth_builds_simple_frame(self) -> None:
-        assert commands.get_ssb_tx_bandwidth() == _simple_get(
+        assert commands.get_ssb_tx_bandwidth(cmd_map=_IC7610_CMD_MAP) == _simple_get(
             _CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH
         )
 
     def test_get_ssb_tx_bandwidth_no_cmd29(self) -> None:
         # Frame must not contain the 0x29 receiver-prefix byte
-        frame = commands.get_ssb_tx_bandwidth()
+        frame = commands.get_ssb_tx_bandwidth(cmd_map=_IC7610_CMD_MAP)
         assert _CMD_CMD29 not in frame[4:]  # after preamble+addresses, no 0x29
 
+    def test_get_ssb_tx_bandwidth_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.get_ssb_tx_bandwidth()  # type: ignore[call-arg]
+
     def test_set_ssb_tx_bandwidth_wide(self) -> None:
-        assert commands.set_ssb_tx_bandwidth(SsbTxBandwidth.WIDE) == _simple_set(
-            _CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x00
-        )
+        assert commands.set_ssb_tx_bandwidth(
+            SsbTxBandwidth.WIDE, cmd_map=_IC7610_CMD_MAP
+        ) == _simple_set(_CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x00)
 
     def test_set_ssb_tx_bandwidth_mid(self) -> None:
-        assert commands.set_ssb_tx_bandwidth(SsbTxBandwidth.MID) == _simple_set(
-            _CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x01
-        )
+        assert commands.set_ssb_tx_bandwidth(
+            SsbTxBandwidth.MID, cmd_map=_IC7610_CMD_MAP
+        ) == _simple_set(_CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x01)
 
     def test_set_ssb_tx_bandwidth_nar(self) -> None:
-        assert commands.set_ssb_tx_bandwidth(SsbTxBandwidth.NAR) == _simple_set(
-            _CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x02
-        )
+        assert commands.set_ssb_tx_bandwidth(
+            SsbTxBandwidth.NAR, cmd_map=_IC7610_CMD_MAP
+        ) == _simple_set(_CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x02)
 
     def test_set_ssb_tx_bandwidth_accepts_int_zero(self) -> None:
-        assert commands.set_ssb_tx_bandwidth(0) == commands.set_ssb_tx_bandwidth(
-            SsbTxBandwidth.WIDE
-        )
+        assert commands.set_ssb_tx_bandwidth(
+            0, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_ssb_tx_bandwidth(SsbTxBandwidth.WIDE, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_ssb_tx_bandwidth_accepts_int_two(self) -> None:
-        assert commands.set_ssb_tx_bandwidth(2) == commands.set_ssb_tx_bandwidth(
-            SsbTxBandwidth.NAR
-        )
+        assert commands.set_ssb_tx_bandwidth(
+            2, cmd_map=_IC7610_CMD_MAP
+        ) == commands.set_ssb_tx_bandwidth(SsbTxBandwidth.NAR, cmd_map=_IC7610_CMD_MAP)
 
     def test_set_ssb_tx_bandwidth_rejects_invalid_enum(self) -> None:
         with pytest.raises(ValueError):
-            commands.set_ssb_tx_bandwidth(999)
+            commands.set_ssb_tx_bandwidth(999, cmd_map=_IC7610_CMD_MAP)
+
+    def test_set_ssb_tx_bandwidth_rejects_explicit_none_the_same_way(self) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.set_ssb_tx_bandwidth(SsbTxBandwidth.WIDE, cmd_map=None)
 
     def test_set_ssb_tx_bandwidth_builder_accepts_values_outside_the_wide_mid_nar_enum(
         self,
@@ -446,7 +519,7 @@ class TestSsbTxBandwidth:
         ``TestSsbTxBandwidthDomainValidation`` in ``tests/test_radio.py``).
         This builder only encodes the raw single-BCD-byte value.
         """
-        assert commands.set_ssb_tx_bandwidth(3) == _simple_set(
+        assert commands.set_ssb_tx_bandwidth(3, cmd_map=_IC7610_CMD_MAP) == _simple_set(
             _CMD_PREAMP, _SUB_SSB_TX_BANDWIDTH, 0x03
         )
 
@@ -465,10 +538,14 @@ class TestSsbTxBandwidth:
         assert SsbTxBandwidth(value) == SsbTxBandwidth.NAR
 
     def test_ssb_tx_bandwidth_distinct_from_filter_shape(self) -> None:
-        assert commands.get_ssb_tx_bandwidth() != commands.get_filter_shape()
+        assert commands.get_ssb_tx_bandwidth(
+            cmd_map=_IC7610_CMD_MAP
+        ) != commands.get_filter_shape(cmd_map=_IC7610_CMD_MAP)
 
     def test_get_ssb_tx_bandwidth_custom_addresses(self) -> None:
-        frame = commands.get_ssb_tx_bandwidth(to_addr=0xA4, from_addr=0xE1)
+        frame = commands.get_ssb_tx_bandwidth(
+            to_addr=0xA4, from_addr=0xE1, cmd_map=_IC7610_CMD_MAP
+        )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 
@@ -537,4 +614,6 @@ class TestAfMute:
         assert frame[3] == 0xE1
 
     def test_af_mute_distinct_from_agc_time_constant(self) -> None:
-        assert commands.get_af_mute() != commands.get_agc_time_constant()
+        assert commands.get_af_mute() != commands.get_agc_time_constant(
+            cmd_map=_IC7610_CMD_MAP
+        )

--- a/tests/test_main_sub_tracking.py
+++ b/tests/test_main_sub_tracking.py
@@ -1,6 +1,10 @@
 """Tests for Main/Sub Tracking command (CI-V 0x16 0x5E)."""
 
+import pytest
+
 import rigplane.commands as raw_commands
+
+from pathlib import Path
 
 from rigplane import IC_7610_ADDR
 from rigplane.commands import (
@@ -8,62 +12,90 @@ from rigplane.commands import (
     set_main_sub_tracking,
     parse_civ_frame,
 )
+from rigplane.rig_loader import load_rig
 from _command_test_helpers import bind_default_addr_globals, bind_default_addr_module
 
 bind_default_addr_module(raw_commands, to_addr=IC_7610_ADDR)
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
 
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+
+
+@pytest.fixture()
+def cmd_map():
+    rig = load_rig(RIG_DIR / "ic7610.toml")
+    return rig.to_command_map()
+
 
 class TestGetMainSubTracking:
-    """Test get_main_sub_tracking frame builder."""
+    """Test get_main_sub_tracking frame builder.
 
-    def test_get_frame_bytes(self) -> None:
-        frame = get_main_sub_tracking()
+    commands/mode.py migrated onto the bound command map in MOR-2008
+    (batch 2): get_main_sub_tracking now requires cmd_map -- zero
+    divergence, so IC-7610's own map declares the identical bytes the
+    fallback used to build, and the expected frames below are unchanged.
+    """
+
+    def test_get_frame_bytes(self, cmd_map) -> None:
+        frame = get_main_sub_tracking(cmd_map=cmd_map)
         # CI-V: FE FE 98 E0 16 5E FD
         assert frame == b"\xfe\xfe\x98\xe0\x16\x5e\xfd"
 
-    def test_get_frame_custom_addr(self) -> None:
-        frame = get_main_sub_tracking(to_addr=0x94, from_addr=0xE1)
+    def test_get_frame_custom_addr(self, cmd_map) -> None:
+        frame = get_main_sub_tracking(to_addr=0x94, from_addr=0xE1, cmd_map=cmd_map)
         assert frame == b"\xfe\xfe\x94\xe1\x16\x5e\xfd"
 
-    def test_get_frame_parsed(self) -> None:
-        frame = get_main_sub_tracking()
+    def test_get_frame_parsed(self, cmd_map) -> None:
+        frame = get_main_sub_tracking(cmd_map=cmd_map)
         parsed = parse_civ_frame(frame)
         assert parsed.command == 0x16
         assert parsed.sub == 0x5E
         assert parsed.data == b""
 
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_main_sub_tracking()  # type: ignore[call-arg]
+
 
 class TestSetMainSubTracking:
     """Test set_main_sub_tracking frame builder."""
 
-    def test_set_on_frame_bytes(self) -> None:
-        frame = set_main_sub_tracking(True)
+    def test_set_on_frame_bytes(self, cmd_map) -> None:
+        frame = set_main_sub_tracking(True, cmd_map=cmd_map)
         # CI-V: FE FE 98 E0 16 5E 01 FD
         assert frame == b"\xfe\xfe\x98\xe0\x16\x5e\x01\xfd"
 
-    def test_set_off_frame_bytes(self) -> None:
-        frame = set_main_sub_tracking(False)
+    def test_set_off_frame_bytes(self, cmd_map) -> None:
+        frame = set_main_sub_tracking(False, cmd_map=cmd_map)
         # CI-V: FE FE 98 E0 16 5E 00 FD
         assert frame == b"\xfe\xfe\x98\xe0\x16\x5e\x00\xfd"
 
-    def test_set_on_parsed(self) -> None:
-        frame = set_main_sub_tracking(True)
+    def test_set_on_parsed(self, cmd_map) -> None:
+        frame = set_main_sub_tracking(True, cmd_map=cmd_map)
         parsed = parse_civ_frame(frame)
         assert parsed.command == 0x16
         assert parsed.sub == 0x5E
         assert parsed.data == b"\x01"
 
-    def test_set_off_parsed(self) -> None:
-        frame = set_main_sub_tracking(False)
+    def test_set_off_parsed(self, cmd_map) -> None:
+        frame = set_main_sub_tracking(False, cmd_map=cmd_map)
         parsed = parse_civ_frame(frame)
         assert parsed.command == 0x16
         assert parsed.sub == 0x5E
         assert parsed.data == b"\x00"
 
-    def test_set_custom_addr(self) -> None:
-        frame = set_main_sub_tracking(True, to_addr=0x94, from_addr=0xE1)
+    def test_set_custom_addr(self, cmd_map) -> None:
+        frame = set_main_sub_tracking(
+            True, to_addr=0x94, from_addr=0xE1, cmd_map=cmd_map
+        )
         assert frame == b"\xfe\xfe\x94\xe1\x16\x5e\x01\xfd"
+
+    def test_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_main_sub_tracking(True, cmd_map=None)
 
 
 class TestMainSubTrackingState:

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -681,13 +681,14 @@ class TestRepeaterToneGating:
     async def test_set_repeater_tone_refused_on_ic7610(self) -> None:
         """IC-7610 has no FM-repeater CTCSS tone feature and does not
         declare ``set_repeater_tone`` (MOR-660/661/682, re-checked and left
-        that way at D2 MOR-2017 -- see ``rigs/ic7610.toml``'s own comment
-        on the point, which records a live-bench readback that the old
-        hardcoded fallback's bytes decoded to garbage on this radio).
-        MOR-2008 batch 2 makes ``cmd_map`` required, so this now correctly
-        refuses (D1 state 3) instead of silently sending those bytes --
-        not a regression, the same shape as system.py's IC-7300 date/time
-        fix in batch 1: the old behaviour was wrong, not merely different.
+        that way at D2 MOR-2017 -- see ``rigs/ic7610.toml``'s own
+        ``{ absent = ... }`` row for this command, which cites a
+        live-bench readback that the old hardcoded fallback's bytes
+        decoded to garbage on this radio). MOR-2008 batch 2 makes
+        ``cmd_map`` required, so this now correctly refuses (D1 state 2,
+        declared absent) instead of silently sending those bytes -- not a
+        regression, the same shape as system.py's IC-7300 date/time fix
+        in batch 1: the old behaviour was wrong, not merely different.
         """
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
@@ -743,10 +744,11 @@ class TestToneFreqGating:
     @pytest.mark.asyncio
     async def test_set_tone_freq_refused_on_ic7610(self) -> None:
         """See ``TestRepeaterToneGating.test_set_repeater_tone_refused_on_
-        ic7610``: same feature family, same TOML comment, same D1 refusal
-        -- ``rigs/ic7610.toml`` cites a live-bench readback showing the old
-        hardcoded fallback's tone-freq bytes decoded to garbage on this
-        radio, so refusing here is the fix, not a regression."""
+        ic7610``: same feature family, same TOML ``{ absent = ... }`` row,
+        same D1 state 2 refusal -- ``rigs/ic7610.toml`` cites a live-bench
+        readback showing the old hardcoded fallback's tone-freq bytes
+        decoded to garbage on this radio, so refusing here is the fix,
+        not a regression."""
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
         with pytest.raises(CommandError, match="not supported by this radio"):

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -61,6 +61,7 @@ from rigplane.commands import (
     set_tsql_freq,
     set_twin_peak_filter,
 )
+from rigplane.core.exceptions import CommandError
 from rigplane.radio import IcomRadio
 from rigplane.rig_loader import load_rig
 from rigplane.types import AudioPeakFilter, CivFrame, FilterShape
@@ -258,7 +259,11 @@ class TestFilterShapeGating:
         mock = _mock_raw(radio)
         await radio.set_filter_shape(FilterShape.SOFT, receiver=0)
         expected = set_filter_shape(
-            FilterShape.SOFT, to_addr=_IC7300_ADDR, receiver=0, command29=False
+            FilterShape.SOFT,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
@@ -268,7 +273,11 @@ class TestFilterShapeGating:
         mock = _mock_raw(radio)
         await radio.set_filter_shape(FilterShape.SOFT, receiver=0)
         expected = set_filter_shape(
-            FilterShape.SOFT, to_addr=_IC7610_ADDR, receiver=0, command29=True
+            FilterShape.SOFT,
+            to_addr=_IC7610_ADDR,
+            receiver=0,
+            command29=True,
+            cmd_map=_IC7610_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
@@ -280,7 +289,9 @@ class TestFilterShapeGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_filter_shape(receiver=0)
-        expected = get_filter_shape(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = get_filter_shape(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == FilterShape.SOFT
 
@@ -292,7 +303,9 @@ class TestFilterShapeGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_filter_shape(receiver=0)
-        expected = get_filter_shape(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = get_filter_shape(
+            to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == FilterShape.SOFT
 
@@ -538,7 +551,11 @@ class TestAgcTimeConstantGating:
         mock = _mock_raw(radio)
         await radio.set_agc_time_constant(5, receiver=0)
         expected = set_agc_time_constant(
-            5, to_addr=_IC7300_ADDR, receiver=0, command29=False
+            5,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
@@ -548,7 +565,7 @@ class TestAgcTimeConstantGating:
         mock = _mock_raw(radio)
         await radio.set_agc_time_constant(5, receiver=0)
         expected = set_agc_time_constant(
-            5, to_addr=_IC7610_ADDR, receiver=0, command29=True
+            5, to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
         )
         assert _sent_civ(mock) == expected
 
@@ -561,7 +578,7 @@ class TestAgcTimeConstantGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_agc_time_constant(receiver=0)
         expected = get_agc_time_constant(
-            to_addr=_IC7300_ADDR, receiver=0, command29=False
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
         )
         assert _sent_civ(mock) == expected
         assert value == 5
@@ -575,7 +592,7 @@ class TestAgcTimeConstantGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_agc_time_constant(receiver=0)
         expected = get_agc_time_constant(
-            to_addr=_IC7610_ADDR, receiver=0, command29=True
+            to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
         )
         assert _sent_civ(mock) == expected
         assert value == 5
@@ -593,7 +610,7 @@ class TestSMeterSqlStatusGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_s_meter_sql_status(receiver=0)
         expected = get_s_meter_sql_status(
-            to_addr=_IC7300_ADDR, receiver=0, command29=False
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
         )
         assert _sent_civ(mock) == expected
         assert value is True
@@ -607,7 +624,7 @@ class TestSMeterSqlStatusGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_s_meter_sql_status(receiver=0)
         expected = get_s_meter_sql_status(
-            to_addr=_IC7610_ADDR, receiver=0, command29=True
+            to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
         )
         assert _sent_civ(mock) == expected
         assert value is True
@@ -625,7 +642,7 @@ class TestVariousSquelchGating:
         mock = _mock_expect(radio, response)
         value = await radio.get_various_squelch(receiver=0)
         expected = get_various_squelch(
-            to_addr=_IC7300_ADDR, receiver=0, command29=False
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
         )
         assert _sent_civ(mock) == expected
         assert value is True
@@ -638,7 +655,9 @@ class TestVariousSquelchGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_various_squelch(receiver=0)
-        expected = get_various_squelch(to_addr=_IC7610_ADDR, receiver=0, command29=True)
+        expected = get_various_squelch(
+            to_addr=_IC7610_ADDR, receiver=0, command29=True, cmd_map=_IC7610_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value is True
 
@@ -650,19 +669,31 @@ class TestRepeaterToneGating:
         mock = _mock_raw(radio)
         await radio.set_repeater_tone(True, receiver=0)
         expected = set_repeater_tone(
-            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+            True,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
-    async def test_set_repeater_tone_wrapped_on_ic7610(self) -> None:
+    async def test_set_repeater_tone_refused_on_ic7610(self) -> None:
+        """IC-7610 has no FM-repeater CTCSS tone feature and does not
+        declare ``set_repeater_tone`` (MOR-660/661/682, re-checked and left
+        that way at D2 MOR-2017 -- see ``rigs/ic7610.toml``'s own comment
+        on the point, which records a live-bench readback that the old
+        hardcoded fallback's bytes decoded to garbage on this radio).
+        MOR-2008 batch 2 makes ``cmd_map`` required, so this now correctly
+        refuses (D1 state 3) instead of silently sending those bytes --
+        not a regression, the same shape as system.py's IC-7300 date/time
+        fix in batch 1: the old behaviour was wrong, not merely different.
+        """
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
-        await radio.set_repeater_tone(True, receiver=0)
-        expected = set_repeater_tone(
-            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
-        )
-        assert _sent_civ(mock) == expected
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.set_repeater_tone(True, receiver=0)
+        mock.assert_not_called()
 
 
 class TestRepeaterTsqlGating:
@@ -672,19 +703,23 @@ class TestRepeaterTsqlGating:
         mock = _mock_raw(radio)
         await radio.set_repeater_tsql(True, receiver=0)
         expected = set_repeater_tsql(
-            True, to_addr=_IC7300_ADDR, receiver=0, command29=False
+            True,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
-    async def test_set_repeater_tsql_wrapped_on_ic7610(self) -> None:
+    async def test_set_repeater_tsql_refused_on_ic7610(self) -> None:
+        """See ``test_set_repeater_tone_refused_on_ic7610``: same feature,
+        same TOML comment, same D1 refusal."""
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
-        await radio.set_repeater_tsql(True, receiver=0)
-        expected = set_repeater_tsql(
-            True, to_addr=_IC7610_ADDR, receiver=0, command29=True
-        )
-        assert _sent_civ(mock) == expected
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.set_repeater_tsql(True, receiver=0)
+        mock.assert_not_called()
 
 
 class TestToneFreqGating:
@@ -697,19 +732,26 @@ class TestToneFreqGating:
         mock = _mock_raw(radio)
         await radio.set_tone_freq(100.0, receiver=0)
         expected = set_tone_freq(
-            100.0, to_addr=_IC7300_ADDR, receiver=0, command29=False
+            100.0,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
-    async def test_set_tone_freq_wrapped_on_ic7610(self) -> None:
+    async def test_set_tone_freq_refused_on_ic7610(self) -> None:
+        """See ``TestRepeaterToneGating.test_set_repeater_tone_refused_on_
+        ic7610``: same feature family, same TOML comment, same D1 refusal
+        -- ``rigs/ic7610.toml`` cites a live-bench readback showing the old
+        hardcoded fallback's tone-freq bytes decoded to garbage on this
+        radio, so refusing here is the fix, not a regression."""
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
-        await radio.set_tone_freq(100.0, receiver=0)
-        expected = set_tone_freq(
-            100.0, to_addr=_IC7610_ADDR, receiver=0, command29=True
-        )
-        assert _sent_civ(mock) == expected
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.set_tone_freq(100.0, receiver=0)
+        mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_tone_freq_unwrapped_on_ic7300(self) -> None:
@@ -723,12 +765,15 @@ class TestToneFreqGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_tone_freq(receiver=0)
-        expected = get_tone_freq(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = get_tone_freq(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == 100.0
 
     @pytest.mark.asyncio
-    async def test_get_tone_freq_wrapped_on_ic7610(self) -> None:
+    async def test_get_tone_freq_refused_on_ic7610(self) -> None:
+        """See ``test_set_tone_freq_refused_on_ic7610``."""
         radio = _connected_icom(model="IC-7610")
         response = CivFrame(
             to_addr=0xE0,
@@ -738,10 +783,9 @@ class TestToneFreqGating:
             data=b"\x01\x00\x00",
         )
         mock = _mock_expect(radio, response)
-        value = await radio.get_tone_freq(receiver=0)
-        expected = get_tone_freq(to_addr=_IC7610_ADDR, receiver=0, command29=True)
-        assert _sent_civ(mock) == expected
-        assert value == 100.0
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.get_tone_freq(receiver=0)
+        mock.assert_not_called()
 
 
 class TestTsqlFreqGating:
@@ -751,19 +795,23 @@ class TestTsqlFreqGating:
         mock = _mock_raw(radio)
         await radio.set_tsql_freq(100.0, receiver=0)
         expected = set_tsql_freq(
-            100.0, to_addr=_IC7300_ADDR, receiver=0, command29=False
+            100.0,
+            to_addr=_IC7300_ADDR,
+            receiver=0,
+            command29=False,
+            cmd_map=_IC7300_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
-    async def test_set_tsql_freq_wrapped_on_ic7610(self) -> None:
+    async def test_set_tsql_freq_refused_on_ic7610(self) -> None:
+        """See ``TestToneFreqGating.test_set_tone_freq_refused_on_ic7610``:
+        same feature family, same TOML comment, same D1 refusal."""
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
-        await radio.set_tsql_freq(100.0, receiver=0)
-        expected = set_tsql_freq(
-            100.0, to_addr=_IC7610_ADDR, receiver=0, command29=True
-        )
-        assert _sent_civ(mock) == expected
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.set_tsql_freq(100.0, receiver=0)
+        mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_tsql_freq_unwrapped_on_ic7300(self) -> None:
@@ -777,12 +825,15 @@ class TestTsqlFreqGating:
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_tsql_freq(receiver=0)
-        expected = get_tsql_freq(to_addr=_IC7300_ADDR, receiver=0, command29=False)
+        expected = get_tsql_freq(
+            to_addr=_IC7300_ADDR, receiver=0, command29=False, cmd_map=_IC7300_CMD_MAP
+        )
         assert _sent_civ(mock) == expected
         assert value == 100.0
 
     @pytest.mark.asyncio
-    async def test_get_tsql_freq_wrapped_on_ic7610(self) -> None:
+    async def test_get_tsql_freq_refused_on_ic7610(self) -> None:
+        """See ``TestToneFreqGating.test_get_tone_freq_refused_on_ic7610``."""
         radio = _connected_icom(model="IC-7610")
         response = CivFrame(
             to_addr=0xE0,
@@ -792,10 +843,9 @@ class TestTsqlFreqGating:
             data=b"\x01\x00\x00",
         )
         mock = _mock_expect(radio, response)
-        value = await radio.get_tsql_freq(receiver=0)
-        expected = get_tsql_freq(to_addr=_IC7610_ADDR, receiver=0, command29=True)
-        assert _sent_civ(mock) == expected
-        assert value == 100.0
+        with pytest.raises(CommandError, match="not supported by this radio"):
+            await radio.get_tsql_freq(receiver=0)
+        mock.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mor1545_vfo_fallback_failure_paths.py
+++ b/tests/test_mor1545_vfo_fallback_failure_paths.py
@@ -180,14 +180,23 @@ class TestSelectBackFailureSemantics:
 class TestVfoFallbackReadDedupeKeyReceiverScoped:
     """MOR-1545 F1: the receiver-scoped dedupe-key fix also covers the
     VFO-fallback read call sites (radio.py ~4341/4419), not just the direct
-    cmd29 path (test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped). On
-    IC-9700 (no cmd29 route) a MAIN direct read and a SUB fallback read
-    build byte-identical request frames -- only the dedupe key can tell
-    them apart. ``_set_vfo_wire`` is stubbed to an instant no-op so the SUB
-    fallback path reaches its own dedupe check before the single-worker
-    commander finishes dispatching MAIN's read, reproducing the coalescing
-    race deterministically (pre-fix: SUB sends zero read frames of its own
-    and returns MAIN's stale answer)."""
+    cmd29 path. On IC-9700 (no cmd29 route) a MAIN direct read and a SUB
+    fallback read build byte-identical request frames -- only the dedupe
+    key can tell them apart. ``_set_vfo_wire`` is stubbed to an instant
+    no-op so the SUB fallback path reaches its own dedupe check before the
+    single-worker commander finishes dispatching MAIN's read, reproducing
+    the coalescing race deterministically (pre-fix: SUB sends zero read
+    frames of its own and returns MAIN's stale answer).
+
+    The direct-cmd29-path comparison this docstring used to point to,
+    ``test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped::
+    test_concurrent_main_and_sub_reads_do_not_coalesce``, is currently
+    ``@pytest.mark.skip``'d (MOR-2008 batch 2: IC-7610, the only dual-RX
+    profile it ran against, does not declare the repeater-tone/TSQL
+    family at all, and redesigning it for IC-9700's own VFO-fallback
+    wire shape is tracked separately). Until that lands, this test here
+    is the one exercising the MAIN-direct-vs-SUB-fallback coalescing
+    scenario end to end, not merely a second example of it."""
 
     @pytest.mark.asyncio
     async def test_concurrent_main_direct_and_sub_fallback_reads_do_not_coalesce(

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -43,7 +43,7 @@ from typing import Any
 import pytest
 
 import rigplane.commands as commands
-from rigplane.commands import get_s_meter, get_speech, ptt_on
+from rigplane.commands import get_selected_freq, get_speech, ptt_on
 from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
@@ -170,11 +170,14 @@ class TestExpect:
 
     def test_expect_on_unexposed_builder_names_the_migration(self) -> None:
         # get_rf_power (commands/levels.py) is exposed as of MOR-2006 Steps
-        # 5..N module 2 -- get_s_meter (commands/meters.py) is still
-        # unmigrated and stands in as the "not exposed yet" example.
-        bound = BoundCommands(CommandMap({"get_s_meter": (0x15, 0x02)}))
+        # 5..N module 2; get_s_meter (commands/meters.py) was the "not
+        # exposed yet" stand-in through batch 1, but MOR-2008 batch 2
+        # migrated meters.py -- get_selected_freq (commands/freq.py) has no
+        # cmd_map parameter at all (Group B, deferred to a later batch per
+        # the owner ruling on the ticket) and stands in instead.
+        bound = BoundCommands(CommandMap({"get_selected_freq": (0x25, 0x00)}))
         with pytest.raises(AttributeError, match="Steps 5..N"):
-            bound.expect(get_s_meter)
+            bound.expect(get_selected_freq)
 
 
 # ── the drift guard ──
@@ -372,6 +375,24 @@ class TestExposedKeyDriftGuard:
         # dotted-string lookup would otherwise walk through.
         defining_module = sys.modules[builder.__module__]
         monkeypatch.setattr(defining_module, "_build_from_map", _fake_build_from_map)
+        # Some builders (mode.py's get_filter_shape/set_filter_shape/
+        # get_ssb_tx_bandwidth/set_ssb_tx_bandwidth/get_main_sub_tracking/
+        # set_main_sub_tracking; tone.py's get_repeater_tone/
+        # set_repeater_tone/get_repeater_tsql/set_repeater_tsql) don't call
+        # ``_build_from_map`` themselves -- they delegate to `_builders.py`'s
+        # shared ``_build_function_get``/``_build_function_bool_set``/
+        # ``_build_function_value_set`` templates, which call *their own*
+        # module-local ``_build_from_map`` binding, not the leaf module's.
+        # Patching only ``defining_module`` leaves that binding live, so the
+        # real lookup runs during probing and raises ``CommandError`` for
+        # every candidate against an empty/unrelated map -- surfacing as
+        # "no synthesized argument combination was accepted" below rather
+        # than as a drift mismatch (MOR-2008 batch 2). ``_builders.py`` is
+        # the one stable shared-template module (its own docstring: "never
+        # from leaf modules"), so patching it too covers every builder that
+        # routes through it, not just this batch's five.
+        builders_module = sys.modules["rigplane.commands._builders"]
+        monkeypatch.setattr(builders_module, "_build_from_map", _fake_build_from_map)
         case_kwargs = self._synthesize_case(builder, cmd_map)
         builder(to_addr=0x94, cmd_map=cmd_map, **case_kwargs)
         assert "key" in captured, (

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -3295,9 +3295,15 @@ class TestToneTsqlDualRxCmd29Guard:
     now reaches SUB via the same VFO-switch fallback already used by
     ``set_freq``/``set_mode``/``set_data_mode`` (select SUB, run the plain
     non-cmd29 command, restore the previously active receiver) instead of
-    raising. ``receiver=0`` (MAIN) and IC-7610 (has cmd29 routes) behavior
-    stay byte-identical — see ``TestToneTsqlParity`` above, which exercises
-    the IC-7610 fixture on both receivers and stays green.
+    raising. ``receiver=0`` (MAIN) behavior is unaffected either way (this
+    class's own ``test_main_receiver_still_sends_direct_frame``/
+    ``test_main_receiver_get_repeater_tone_still_works`` below pin it
+    directly). The comparison this docstring used to make against
+    IC-7610's own cmd29-wrapped path no longer has anything to compare
+    against: MOR-2008 batch 2 found IC-7610 does not declare this family
+    at all (``rigs/ic7610.toml``) and moved ``TestToneTsqlParity`` above
+    onto IC-7300 (single-receiver, no cmd29 routes for this family
+    either) for the ``receiver=0``-only case it can still cover.
     """
 
     @pytest.fixture

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -3129,17 +3129,73 @@ class TestSsbTxBandwidthDomainValidation:
         radio._connected = False
 
 
+# IC-7300's CI-V address (RadioModel(name="IC-7300", civ_addr=148)), used
+# below in place of the module's own IC_7610_ADDR -- see
+# TestToneTsqlParity's docstring for why.
+_IC_7300_ADDR = 0x94
+
+
+def _function_response_ic7300(sub: int, payload: bytes) -> bytes:
+    """``_function_response`` above, but from IC-7300 rather than IC-7610,
+    and always plain (never cmd29-wrapped): ``rigs/ic7300.toml`` declares
+    "single receiver, no cmd29" outright, so a real IC-7300 never sends a
+    cmd29 envelope at all, receiver argument or not.
+
+    A local copy rather than an added parameter on the shared helper:
+    every other caller of ``_function_response`` in this file targets the
+    module's own IC-7610 ``radio`` fixture, so widening it would be an
+    unused knob everywhere except here.
+    """
+    civ = build_civ_frame(CONTROLLER_ADDR, _IC_7300_ADDR, 0x16, sub=sub, data=payload)
+    return _wrap_civ_in_udp(civ)
+
+
 class TestToneTsqlParity:
-    """Test high-level tone/TSQL parity methods (#134)."""
+    """Test high-level tone/TSQL parity methods (#134).
+
+    Uses IC-7300, not the module's default IC-7610 ``radio`` fixture:
+    ``rigs/ic7610.toml`` documents (MOR-660/661/682, re-checked at D2
+    MOR-2017) that IC-7610 does not declare the repeater-tone/TSQL/
+    tone-freq/TSQL-freq family at all -- a live-bench readback found the
+    pre-migration hardcoded fallback's bytes decoded to garbage on this
+    radio. Before MOR-2008 batch 2, the module's default fixture still
+    built and sent those wrong bytes regardless; now it raises
+    ``CommandError`` (D1 refusal) instead, so this class's own premise
+    (these four method pairs succeed and round-trip on the fixture they
+    are handed) needs a profile that actually declares the family.
+    IC-7300 declares byte-identical ``[0x16/0x1B, sub]`` tuples for it
+    (verified against the pre-migration fallback).
+
+    No ``receiver=1`` (SUB) cases here any more, unlike before this
+    migration: IC-7300 is single-receiver (``rigs/ic7300.toml``:
+    "single receiver, no cmd29"), so it cannot stand in for the
+    cmd29-wrapped dual-receiver shape the old parametrize cases pinned.
+    That shape was never actually valid on any *declaring* radio --
+    IC-7610 (dual-RX, cmd29-capable) was the only one, and it turns out
+    not to declare this family at all; the only dual-RX profile that does
+    (IC-9700) has no cmd29 routes for it either, and reaches SUB through
+    the VFO-select fallback instead -- already fully exercised by
+    ``TestToneTsqlDualRxCmd29Guard`` immediately below, which this class
+    does not need to duplicate.
+    """
+
+    @pytest.fixture
+    def radio(self, mock_transport: MockTransport):
+        r = IcomRadio("192.168.1.104", timeout=0.05, model="IC-7300")
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        yield r
+        r._connected = False  # reset _conn_state so __del__ stays quiet
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("method_name", "sub", "payload", "receiver", "expected"),
+        ("method_name", "sub", "payload", "expected"),
         [
-            ("get_repeater_tone", 0x42, b"\x01", 0, True),
-            ("get_repeater_tone", 0x42, b"\x00", 1, False),
-            ("get_repeater_tsql", 0x43, b"\x01", 0, True),
-            ("get_repeater_tsql", 0x43, b"\x00", 1, False),
+            ("get_repeater_tone", 0x42, b"\x01", True),
+            ("get_repeater_tone", 0x42, b"\x00", False),
+            ("get_repeater_tsql", 0x43, b"\x01", True),
+            ("get_repeater_tsql", 0x43, b"\x00", False),
         ],
     )
     async def test_get_repeater_toggle(
@@ -3149,23 +3205,20 @@ class TestToneTsqlParity:
         method_name: str,
         sub: int,
         payload: bytes,
-        receiver: int,
         expected: bool,
     ) -> None:
-        mock_transport.queue_response(
-            _function_response(sub, payload, receiver=receiver)
-        )
-        result = await getattr(radio, method_name)(receiver=receiver)
+        mock_transport.queue_response(_function_response_ic7300(sub, payload))
+        result = await getattr(radio, method_name)()
         assert result is expected
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("method_name", "value", "kwargs", "expected_tail"),
+        ("method_name", "value", "expected_tail"),
         [
-            ("set_repeater_tone", True, {"receiver": 0}, b"\x29\x00\x16\x42\x01\xfd"),
-            ("set_repeater_tone", False, {"receiver": 1}, b"\x29\x01\x16\x42\x00\xfd"),
-            ("set_repeater_tsql", True, {"receiver": 0}, b"\x29\x00\x16\x43\x01\xfd"),
-            ("set_repeater_tsql", False, {"receiver": 1}, b"\x29\x01\x16\x43\x00\xfd"),
+            ("set_repeater_tone", True, b"\x16\x42\x01\xfd"),
+            ("set_repeater_tone", False, b"\x16\x42\x00\xfd"),
+            ("set_repeater_tsql", True, b"\x16\x43\x01\xfd"),
+            ("set_repeater_tsql", False, b"\x16\x43\x00\xfd"),
         ],
     )
     async def test_set_repeater_toggle(
@@ -3174,23 +3227,23 @@ class TestToneTsqlParity:
         mock_transport: MockTransport,
         method_name: str,
         value: bool,
-        kwargs: dict[str, int],
         expected_tail: bytes,
     ) -> None:
-        await getattr(radio, method_name)(value, **kwargs)
+        await getattr(radio, method_name)(value)
         assert mock_transport.sent_packets[-1].endswith(expected_tail)
 
     @pytest.mark.asyncio
     async def test_get_tone_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        civ = build_cmd29_frame(
+        # 3-byte BCD tone frequency: hundreds=0x00, tens_units=0x88,
+        # tenths=0x05 -> 88.5 Hz (_codec.py: _decode_tone_freq).
+        civ = build_civ_frame(
             CONTROLLER_ADDR,
-            IC_7610_ADDR,
+            _IC_7300_ADDR,
             0x1B,
             sub=0x00,
             data=bytes([0x00, 0x88, 0x05]),
-            receiver=0,
         )
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
         assert await radio.get_tone_freq() == pytest.approx(88.5)
@@ -3199,13 +3252,14 @@ class TestToneTsqlParity:
     async def test_get_tsql_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        civ = build_cmd29_frame(
+        # 3-byte BCD TSQL frequency: hundreds=0x01, tens_units=0x10,
+        # tenths=0x09 -> 110.9 Hz.
+        civ = build_civ_frame(
             CONTROLLER_ADDR,
-            IC_7610_ADDR,
+            _IC_7300_ADDR,
             0x1B,
             sub=0x01,
             data=bytes([0x01, 0x10, 0x09]),
-            receiver=0,
         )
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
         assert await radio.get_tsql_freq() == pytest.approx(110.9)
@@ -3215,19 +3269,15 @@ class TestToneTsqlParity:
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         await radio.set_tone_freq(88.5)
-        # cmd29 + receiver=0 + 0x1B + 0x00 + BCD(88.5) + FD
-        assert mock_transport.sent_packets[-1].endswith(
-            b"\x29\x00\x1b\x00\x00\x88\x05\xfd"
-        )
+        # plain (no cmd29 -- IC-7300 has none) + 0x1B + 0x00 + BCD(88.5) + FD
+        assert mock_transport.sent_packets[-1].endswith(b"\x1b\x00\x00\x88\x05\xfd")
 
     @pytest.mark.asyncio
     async def test_set_tsql_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        await radio.set_tsql_freq(110.9, receiver=1)
-        assert mock_transport.sent_packets[-1].endswith(
-            b"\x29\x01\x1b\x01\x01\x10\x09\xfd"
-        )
+        await radio.set_tsql_freq(110.9)
+        assert mock_transport.sent_packets[-1].endswith(b"\x1b\x01\x01\x10\x09\xfd")
 
 
 class TestToneTsqlDualRxCmd29Guard:
@@ -3399,8 +3449,42 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
     in-flight MAIN read could coalesce a SUB caller onto MAIN's answer.
     Fixed to receiver-scope the key (``key=f"get_repeater_tone:{receiver}"``),
     mirroring ``get_filter_width``'s precedent (MOR-1538/#2458).
+
+    Uses IC-7300, not the module's default IC-7610 ``radio`` fixture, for
+    the same reason as ``TestToneTsqlParity`` above: IC-7610 does not
+    declare this family (MOR-2008 batch 2's D1 refusal fix), so a call
+    that used to build and send a wrong-but-successful frame on the
+    default fixture now raises ``CommandError`` instead. IC-7300 is
+    single-receiver, so the MAIN+SUB variant below has no working radio
+    left to run against (below); the same-receiver variant needs no SUB
+    at all and is otherwise unaffected.
     """
 
+    @pytest.fixture
+    def radio(self, mock_transport: MockTransport):
+        r = IcomRadio("192.168.1.104", timeout=0.05, model="IC-7300")
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        yield r
+        r._connected = False  # reset _conn_state so __del__ stays quiet
+
+    @pytest.mark.skip(
+        reason=(
+            "MOR-2008 batch 2: IC-7610, the only dual-RX profile this test "
+            "ever ran against, does not declare the repeater-tone/TSQL "
+            "family at all (rigs/ic7610.toml, live-bench garbage-readback "
+            "finding) -- calling it now raises CommandError instead of "
+            "building a frame. IC-9700, the only other dual-RX profile "
+            "that declares the family, has no cmd29 route for it and "
+            "reaches SUB through a 3-frame VFO-select fallback "
+            "(TestToneTsqlDualRxCmd29Guard above) instead of one cmd29 "
+            "frame -- redesigning this concurrency test's timing "
+            "assumptions (exact sent_packets count, interleaving) around "
+            "that shape is a real piece of work, not a fixture swap, so "
+            "it is left for a dedicated follow-up rather than rushed here."
+        )
+    )
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("method_name", "sub"),
@@ -3418,10 +3502,10 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
         radio._civ_runtime.start_worker()
         try:
             mock_transport.queue_response_on_send(
-                1, _function_response(sub, b"\x01", receiver=0)
+                1, _function_response_ic7300(sub, b"\x01")
             )
             mock_transport.queue_response_on_send(
-                2, _function_response(sub, b"\x00", receiver=1)
+                2, _function_response_ic7300(sub, b"\x00")
             )
             method = getattr(radio, method_name)
             main_result, sub_result = await asyncio.gather(
@@ -3443,7 +3527,7 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
         radio._civ_runtime.start_worker()
         try:
             mock_transport.queue_response_on_send(
-                1, _function_response(0x42, b"\x01", receiver=0)
+                1, _function_response_ic7300(0x42, b"\x01")
             )
             first, second = await asyncio.gather(
                 radio.get_repeater_tone(receiver=0),

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -120,6 +120,33 @@ MATCHER_BACKED_GETTERS: tuple[_GetterSpec, ...] = (
     # getter to register for them either.
     _GetterSpec("get_quick_split", "_get_bool_value"),
     _GetterSpec("get_quick_dual_watch", "_get_bool_value"),
+    # commands/mode.py's, commands/tone.py's and commands/meters.py's
+    # matcher-backed getters (MOR-2008 Steps 5..N, batch 2). get_mode,
+    # get_data_mode and get_filter_width (mode.py) are NOT included: each
+    # parses its reply through its own module-level parse_*_response
+    # function (a hardcoded command/sub check) or, for get_filter_width,
+    # bespoke per-profile BCD/raw-byte handling -- never through
+    # _get_bcd_level/_get_bool_value with a map-derived shape (mirrors
+    # commands/levels.py's get_rf_power/get_rf_gain/get_af_level exclusion
+    # above). meters.py's get_s_meter/get_swr/get_alc/get_power_meter/
+    # get_comp_meter/get_vd_meter/get_id_meter are excluded the same way,
+    # via parse_meter_response; CoreRadio's own getter for get_alc is
+    # additionally named get_alc_meter, not get_alc, which would violate
+    # this dataclass's own method-equals-key invariant besides. antenna.py's
+    # four getters are excluded for the reason documented in antenna.py's
+    # own module docstring: the ANT1/ANT2 selector is a CI-V protocol
+    # invariant supplied as caller data, not a map-declared ``sub`` --
+    # registering them here would derive ``sub=None`` off the map's own
+    # bare ``[0x12]`` tuple and fail every case.
+    _GetterSpec("get_filter_shape", "_get_bcd_level"),
+    _GetterSpec("get_ssb_tx_bandwidth", "_get_bcd_level"),
+    _GetterSpec("get_main_sub_tracking", "_get_bool_value"),
+    _GetterSpec("get_agc_time_constant", "_get_bcd_level"),
+    _GetterSpec("get_repeater_tone", "_get_bool_value"),
+    _GetterSpec("get_repeater_tsql", "_get_bool_value"),
+    _GetterSpec("get_s_meter_sql_status", "_get_bool_value"),
+    _GetterSpec("get_overflow_status", "_get_bool_value"),
+    _GetterSpec("get_various_squelch", "_get_bool_value"),
 )
 
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2672,15 +2672,21 @@ class TestNoShippedProfileUsesAbsentSpellingYet:
     separate, ticket-tracked, later work: MOR-2014 filled ``ic7300.toml``
     (27 commands, D2 documentary + live-bench verdicts), MOR-2015 filled
     ``ic9700.toml`` (26 commands, D2 documentary verdicts against the
-    IC-9700 CI-V Reference Guide), and MOR-2016 filled ``ic705.toml`` (24
+    IC-9700 CI-V Reference Guide), MOR-2016 filled ``ic705.toml`` (24
     commands, D2 documentary verdicts against the IC-705 CI-V Reference
-    Guide). This pin is narrowed rather than deleted so every *other*
-    shipped profile stays proven empty until its own D2 pass fills it too
-    — narrow further (or delete) as each profile gets filled.
+    Guide), and MOR-2008 batch 2 filled ``ic7610.toml`` (8 commands, the
+    repeater-tone/TSQL/tone-freq/TSQL-freq family, promoting a
+    comment-only D1 state 3 to a formal state 2 row grounded in a
+    live-bench readback rather than a documentary source). This pin is
+    narrowed rather than deleted so every *other* shipped profile stays
+    proven empty until its own D2 pass fills it too — narrow further (or
+    delete) as each profile gets filled.
     """
 
     _NOT_YET_FILLED = tuple(
-        p for p in _SHIPPED_RIG_TOMLS if p.stem not in {"ic7300", "ic9700", "ic705"}
+        p
+        for p in _SHIPPED_RIG_TOMLS
+        if p.stem not in {"ic7300", "ic9700", "ic705", "ic7610"}
     )
 
     @pytest.mark.parametrize("toml_path", _NOT_YET_FILLED, ids=lambda p: p.stem)
@@ -2863,5 +2869,44 @@ class TestIc705DeclaresAbsentCommands:
 
     def test_absent_commands_excluded_from_command_map(self):
         cmd_map = load_rig(RIGS_DIR / "ic705.toml").to_command_map()
+        for name in self._EXPECTED_ABSENT:
+            assert not cmd_map.has(name), f"{name} declared absent but still in map"
+
+
+class TestIc7610DeclaresAbsentCommands:
+    """MOR-2008 batch 2 (D1/D2): IC-7610 is filled with the
+    ``{ absent = "<source>" }`` spelling for the repeater-tone/TSQL/
+    tone-freq/TSQL-freq family (8 commands) -- a comment-only exclusion
+    since MOR-661/682 promoted to a formal declared-absent row, grounded
+    in a live-bench readback (tone_freq/tsql_freq replies decoded to
+    garbage, 16.5 Hz) rather than a documentary source, per
+    ``rigs/ic7610.toml``'s own comment on the point. Unlike IC-7300/
+    IC-9700/IC-705 above, this is not a documentary D2 pass over the
+    whole command table -- it is one feature family's absence, already
+    established by MOR-660/661/682 well before this ticket, just not
+    previously spelled with the formal marker. Pinned by name, not just
+    count, so a future D2 pass on another command can't silently swap
+    one of these for a different one and still pass a bare-count check.
+    """
+
+    _EXPECTED_ABSENT = frozenset(
+        {
+            "get_repeater_tone",
+            "set_repeater_tone",
+            "get_repeater_tsql",
+            "set_repeater_tsql",
+            "get_tone_freq",
+            "set_tone_freq",
+            "get_tsql_freq",
+            "set_tsql_freq",
+        }
+    )
+
+    def test_absent_command_names_match(self):
+        profile = load_rig(RIGS_DIR / "ic7610.toml").to_profile()
+        assert profile.absent_command_names == self._EXPECTED_ABSENT
+
+    def test_absent_commands_excluded_from_command_map(self):
+        cmd_map = load_rig(RIGS_DIR / "ic7610.toml").to_command_map()
         for name in self._EXPECTED_ABSENT:
             assert not cmd_map.has(name), f"{name} declared absent but still in map"

--- a/tests/test_tone_tsql.py
+++ b/tests/test_tone_tsql.py
@@ -1,4 +1,4 @@
-"""Unit tests for IC-7610 tone/TSQL commands (#134).
+"""Unit tests for repeater tone/TSQL commands (#134).
 
 Commands tested:
   0x16 0x42 — Repeater Tone enable/disable
@@ -6,7 +6,15 @@ Commands tested:
   0x1B 0x00 — CTCSS Tone frequency (get/set + parse)
   0x1B 0x01 — TSQL frequency (get/set + parse)
 
-All four commands use cmd29 wrapping (dual-receiver).
+Builder-level, not IC-7610-specific despite the file's own historical
+name: the ``cmd_map`` fixture below is IC-7300 (MOR-2008 batch 2 --
+IC-7610 declares this whole family absent). ``command29`` is a
+caller-supplied builder argument (default ``True``), independent of
+which profile's map supplies the inner command/sub bytes, so every
+case in this file still builds a cmd29-wrapped frame regardless of the
+map -- that is a property of calling these builders with no explicit
+``command29=False``, not a claim that IC-7300 (single-receiver, no
+cmd29 routes) would ever really send one.
 """
 
 from __future__ import annotations
@@ -41,14 +49,17 @@ def cmd_map():
     divergence, so every profile that declares this family agrees with
     the fallback's own bytes exactly, and the expected frames throughout
     this file are unchanged. Uses IC-7300, not IC-7610 (despite this
-    file's own docstring/module name): IC-7610 has no FM-repeater CTCSS
-    tone feature and does not declare this family at all
-    (MOR-660/661/682, re-checked and left that way at D2 MOR-2017 -- see
-    ``rigs/ic7610.toml``'s own comment on the point), so building a
-    cmd_map from it would raise ``KeyError`` for every builder this file
-    exercises. ``to_addr`` still defaults to IC_7610_ADDR via
-    ``bind_default_addr_globals`` above -- unaffected, since a builder's
-    address arguments are independent of which profile's map supplies its
+    file's own historical name): IC-7610 has no FM-repeater CTCSS tone
+    feature and does not declare this family at all (MOR-660/661/682,
+    re-checked and left that way at D2 MOR-2017 -- see
+    ``rigs/ic7610.toml``'s own ``{ absent = ... }`` row for each of the
+    eight commands), so calling any of these builders directly with a
+    bare ``CommandMap`` built from it -- as this file does, not through
+    ``BoundCommands``, which is what turns a declared-absent lookup into
+    a ``CommandError`` -- still raises ``KeyError``. ``to_addr``
+    still defaults to IC_7610_ADDR via ``bind_default_addr_globals``
+    above -- unaffected, since a builder's address arguments are
+    independent of which profile's map supplies its
     wire bytes.
     """
     rig = load_rig(RIG_DIR / "ic7300.toml")

--- a/tests/test_tone_tsql.py
+++ b/tests/test_tone_tsql.py
@@ -11,6 +11,8 @@ All four commands use cmd29 wrapping (dual-receiver).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from rigplane import commands
@@ -23,10 +25,35 @@ from rigplane.commands import (
     parse_tone_freq_response,
     parse_tsql_freq_response,
 )
+from rigplane.rig_loader import load_rig
 from rigplane.types import CivFrame
 from _command_test_helpers import bind_default_addr_globals
 
 bind_default_addr_globals(globals(), to_addr=IC_7610_ADDR)
+
+RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
+
+
+@pytest.fixture()
+def cmd_map():
+    """commands/tone.py migrated onto the bound command map in MOR-2008
+    (batch 2): every builder in this file now requires cmd_map -- zero
+    divergence, so every profile that declares this family agrees with
+    the fallback's own bytes exactly, and the expected frames throughout
+    this file are unchanged. Uses IC-7300, not IC-7610 (despite this
+    file's own docstring/module name): IC-7610 has no FM-repeater CTCSS
+    tone feature and does not declare this family at all
+    (MOR-660/661/682, re-checked and left that way at D2 MOR-2017 -- see
+    ``rigs/ic7610.toml``'s own comment on the point), so building a
+    cmd_map from it would raise ``KeyError`` for every builder this file
+    exercises. ``to_addr`` still defaults to IC_7610_ADDR via
+    ``bind_default_addr_globals`` above -- unaffected, since a builder's
+    address arguments are independent of which profile's map supplies its
+    wire bytes.
+    """
+    rig = load_rig(RIG_DIR / "ic7300.toml")
+    return rig.to_command_map()
+
 
 # ---------------------------------------------------------------------------
 # Frame-level constants
@@ -156,40 +183,51 @@ _BCD_TABLE: list[tuple[float, bytes]] = [
 class TestRepeaterTone:
     """Tests for get_repeater_tone / set_repeater_tone."""
 
-    def test_get_main_receiver(self) -> None:
-        assert commands.get_repeater_tone(receiver=RECEIVER_MAIN) == _cmd29_preamp_get(
-            _SUB_REPEATER_TONE, RECEIVER_MAIN
-        )
+    def test_get_main_receiver(self, cmd_map) -> None:
+        assert commands.get_repeater_tone(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) == _cmd29_preamp_get(_SUB_REPEATER_TONE, RECEIVER_MAIN)
 
-    def test_get_sub_receiver(self) -> None:
-        assert commands.get_repeater_tone(receiver=RECEIVER_SUB) == _cmd29_preamp_get(
-            _SUB_REPEATER_TONE, RECEIVER_SUB
-        )
+    def test_get_sub_receiver(self, cmd_map) -> None:
+        assert commands.get_repeater_tone(
+            receiver=RECEIVER_SUB, cmd_map=cmd_map
+        ) == _cmd29_preamp_get(_SUB_REPEATER_TONE, RECEIVER_SUB)
 
-    def test_get_default_is_main(self) -> None:
-        assert commands.get_repeater_tone() == commands.get_repeater_tone(
-            receiver=RECEIVER_MAIN
-        )
+    def test_get_default_is_main(self, cmd_map) -> None:
+        assert commands.get_repeater_tone(
+            cmd_map=cmd_map
+        ) == commands.get_repeater_tone(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
 
-    def test_set_on_main(self) -> None:
-        assert commands.set_repeater_tone(True) == _cmd29_preamp_set(
+    def test_get_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.get_repeater_tone()  # type: ignore[call-arg]
+
+    def test_set_on_main(self, cmd_map) -> None:
+        assert commands.set_repeater_tone(True, cmd_map=cmd_map) == _cmd29_preamp_set(
             _SUB_REPEATER_TONE, 0x01, RECEIVER_MAIN
         )
 
-    def test_set_off_main(self) -> None:
-        assert commands.set_repeater_tone(False) == _cmd29_preamp_set(
+    def test_set_off_main(self, cmd_map) -> None:
+        assert commands.set_repeater_tone(False, cmd_map=cmd_map) == _cmd29_preamp_set(
             _SUB_REPEATER_TONE, 0x00, RECEIVER_MAIN
         )
 
-    def test_set_on_sub(self) -> None:
+    def test_set_on_sub(self, cmd_map) -> None:
         assert commands.set_repeater_tone(
-            True, receiver=RECEIVER_SUB
+            True, receiver=RECEIVER_SUB, cmd_map=cmd_map
         ) == _cmd29_preamp_set(_SUB_REPEATER_TONE, 0x01, RECEIVER_SUB)
 
-    def test_set_off_sub(self) -> None:
+    def test_set_off_sub(self, cmd_map) -> None:
         assert commands.set_repeater_tone(
-            False, receiver=RECEIVER_SUB
+            False, receiver=RECEIVER_SUB, cmd_map=cmd_map
         ) == _cmd29_preamp_set(_SUB_REPEATER_TONE, 0x00, RECEIVER_SUB)
+
+    def test_set_rejects_explicit_none_the_same_way(self, cmd_map) -> None:
+        """An explicit ``cmd_map=None`` must hit the same Q6 explanation as
+        omitting it entirely."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.set_repeater_tone(True, cmd_map=None)
 
     def test_parse_on(self) -> None:
         frame = _preamp_response(_SUB_REPEATER_TONE, b"\x01")
@@ -205,13 +243,15 @@ class TestRepeaterTone:
             is False
         )
 
-    def test_custom_addresses(self) -> None:
-        frame = commands.get_repeater_tone(to_addr=0xA4, from_addr=0xE1)
+    def test_custom_addresses(self, cmd_map) -> None:
+        frame = commands.get_repeater_tone(
+            to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map
+        )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 
-    def test_uses_cmd29_prefix(self) -> None:
-        frame = commands.get_repeater_tone()
+    def test_uses_cmd29_prefix(self, cmd_map) -> None:
+        frame = commands.get_repeater_tone(cmd_map=cmd_map)
         assert frame[4] == _CMD_CMD29
 
 
@@ -223,39 +263,39 @@ class TestRepeaterTone:
 class TestRepeaterTSQL:
     """Tests for get_repeater_tsql / set_repeater_tsql."""
 
-    def test_get_main_receiver(self) -> None:
-        assert commands.get_repeater_tsql(receiver=RECEIVER_MAIN) == _cmd29_preamp_get(
-            _SUB_REPEATER_TSQL, RECEIVER_MAIN
-        )
+    def test_get_main_receiver(self, cmd_map) -> None:
+        assert commands.get_repeater_tsql(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) == _cmd29_preamp_get(_SUB_REPEATER_TSQL, RECEIVER_MAIN)
 
-    def test_get_sub_receiver(self) -> None:
-        assert commands.get_repeater_tsql(receiver=RECEIVER_SUB) == _cmd29_preamp_get(
-            _SUB_REPEATER_TSQL, RECEIVER_SUB
-        )
+    def test_get_sub_receiver(self, cmd_map) -> None:
+        assert commands.get_repeater_tsql(
+            receiver=RECEIVER_SUB, cmd_map=cmd_map
+        ) == _cmd29_preamp_get(_SUB_REPEATER_TSQL, RECEIVER_SUB)
 
-    def test_get_default_is_main(self) -> None:
-        assert commands.get_repeater_tsql() == commands.get_repeater_tsql(
-            receiver=RECEIVER_MAIN
-        )
+    def test_get_default_is_main(self, cmd_map) -> None:
+        assert commands.get_repeater_tsql(
+            cmd_map=cmd_map
+        ) == commands.get_repeater_tsql(receiver=RECEIVER_MAIN, cmd_map=cmd_map)
 
-    def test_set_on_main(self) -> None:
-        assert commands.set_repeater_tsql(True) == _cmd29_preamp_set(
+    def test_set_on_main(self, cmd_map) -> None:
+        assert commands.set_repeater_tsql(True, cmd_map=cmd_map) == _cmd29_preamp_set(
             _SUB_REPEATER_TSQL, 0x01, RECEIVER_MAIN
         )
 
-    def test_set_off_main(self) -> None:
-        assert commands.set_repeater_tsql(False) == _cmd29_preamp_set(
+    def test_set_off_main(self, cmd_map) -> None:
+        assert commands.set_repeater_tsql(False, cmd_map=cmd_map) == _cmd29_preamp_set(
             _SUB_REPEATER_TSQL, 0x00, RECEIVER_MAIN
         )
 
-    def test_set_on_sub(self) -> None:
+    def test_set_on_sub(self, cmd_map) -> None:
         assert commands.set_repeater_tsql(
-            True, receiver=RECEIVER_SUB
+            True, receiver=RECEIVER_SUB, cmd_map=cmd_map
         ) == _cmd29_preamp_set(_SUB_REPEATER_TSQL, 0x01, RECEIVER_SUB)
 
-    def test_set_off_sub(self) -> None:
+    def test_set_off_sub(self, cmd_map) -> None:
         assert commands.set_repeater_tsql(
-            False, receiver=RECEIVER_SUB
+            False, receiver=RECEIVER_SUB, cmd_map=cmd_map
         ) == _cmd29_preamp_set(_SUB_REPEATER_TSQL, 0x00, RECEIVER_SUB)
 
     def test_parse_on(self) -> None:
@@ -272,13 +312,15 @@ class TestRepeaterTSQL:
             is False
         )
 
-    def test_custom_addresses(self) -> None:
-        frame = commands.get_repeater_tsql(to_addr=0xA4, from_addr=0xE1)
+    def test_custom_addresses(self, cmd_map) -> None:
+        frame = commands.get_repeater_tsql(
+            to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map
+        )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 
-    def test_uses_cmd29_prefix(self) -> None:
-        frame = commands.get_repeater_tsql()
+    def test_uses_cmd29_prefix(self, cmd_map) -> None:
+        frame = commands.get_repeater_tsql(cmd_map=cmd_map)
         assert frame[4] == _CMD_CMD29
 
 
@@ -291,55 +333,60 @@ class TestToneFreqBCDEncoding:
     """BCD encoding of CTCSS tone frequencies."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_encode(self, freq: float, bcd: bytes) -> None:
-        frame = commands.set_tone_freq(freq)
+    def test_encode(self, freq: float, bcd: bytes, cmd_map) -> None:
+        frame = commands.set_tone_freq(freq, cmd_map=cmd_map)
         assert bcd in frame
 
-    def test_rejects_below_minimum(self) -> None:
+    def test_rejects_below_minimum(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="67.0"):
-            commands.set_tone_freq(50.0)
+            commands.set_tone_freq(50.0, cmd_map=cmd_map)
 
-    def test_rejects_above_maximum(self) -> None:
+    def test_rejects_above_maximum(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="254.1"):
-            commands.set_tone_freq(300.0)
+            commands.set_tone_freq(300.0, cmd_map=cmd_map)
 
-    def test_accepts_boundary_low(self) -> None:
-        frame = commands.set_tone_freq(67.0)
+    def test_accepts_boundary_low(self, cmd_map) -> None:
+        frame = commands.set_tone_freq(67.0, cmd_map=cmd_map)
         assert b"\x00\x67\x00" in frame
 
-    def test_accepts_boundary_high(self) -> None:
-        frame = commands.set_tone_freq(254.1)
+    def test_accepts_boundary_high(self, cmd_map) -> None:
+        frame = commands.set_tone_freq(254.1, cmd_map=cmd_map)
         assert b"\x02\x54\x01" in frame
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            commands.set_tone_freq(88.5)  # type: ignore[call-arg]
 
 
 class TestGetToneFreq:
     """Frame construction for get_tone_freq (0x1B 0x00)."""
 
-    def test_main_receiver(self) -> None:
-        assert commands.get_tone_freq(receiver=RECEIVER_MAIN) == _cmd29_tone_get(
-            _SUB_TONE_FREQ, RECEIVER_MAIN
+    def test_main_receiver(self, cmd_map) -> None:
+        assert commands.get_tone_freq(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) == _cmd29_tone_get(_SUB_TONE_FREQ, RECEIVER_MAIN)
+
+    def test_sub_receiver(self, cmd_map) -> None:
+        assert commands.get_tone_freq(
+            receiver=RECEIVER_SUB, cmd_map=cmd_map
+        ) == _cmd29_tone_get(_SUB_TONE_FREQ, RECEIVER_SUB)
+
+    def test_default_is_main(self, cmd_map) -> None:
+        assert commands.get_tone_freq(cmd_map=cmd_map) == commands.get_tone_freq(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
         )
 
-    def test_sub_receiver(self) -> None:
-        assert commands.get_tone_freq(receiver=RECEIVER_SUB) == _cmd29_tone_get(
-            _SUB_TONE_FREQ, RECEIVER_SUB
-        )
-
-    def test_default_is_main(self) -> None:
-        assert commands.get_tone_freq() == commands.get_tone_freq(
-            receiver=RECEIVER_MAIN
-        )
-
-    def test_uses_cmd29_prefix(self) -> None:
-        frame = commands.get_tone_freq()
+    def test_uses_cmd29_prefix(self, cmd_map) -> None:
+        frame = commands.get_tone_freq(cmd_map=cmd_map)
         assert frame[4] == _CMD_CMD29
 
-    def test_contains_tone_command_and_sub(self) -> None:
-        frame = commands.get_tone_freq()
+    def test_contains_tone_command_and_sub(self, cmd_map) -> None:
+        frame = commands.get_tone_freq(cmd_map=cmd_map)
         assert bytes([_CMD_TONE, _SUB_TONE_FREQ]) in frame
 
-    def test_custom_addresses(self) -> None:
-        frame = commands.get_tone_freq(to_addr=0xA4, from_addr=0xE1)
+    def test_custom_addresses(self, cmd_map) -> None:
+        frame = commands.get_tone_freq(to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map)
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 
@@ -348,18 +395,20 @@ class TestSetToneFreq:
     """Frame construction for set_tone_freq (0x1B 0x00)."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_set_encodes_bcd(self, freq: float, bcd: bytes) -> None:
-        assert commands.set_tone_freq(freq) == _cmd29_tone_set(
+    def test_set_encodes_bcd(self, freq: float, bcd: bytes, cmd_map) -> None:
+        assert commands.set_tone_freq(freq, cmd_map=cmd_map) == _cmd29_tone_set(
             _SUB_TONE_FREQ, bcd, RECEIVER_MAIN
         )
 
-    def test_set_sub_receiver(self) -> None:
-        assert commands.set_tone_freq(88.5, receiver=RECEIVER_SUB) == _cmd29_tone_set(
-            _SUB_TONE_FREQ, b"\x00\x88\x05", RECEIVER_SUB
-        )
+    def test_set_sub_receiver(self, cmd_map) -> None:
+        assert commands.set_tone_freq(
+            88.5, receiver=RECEIVER_SUB, cmd_map=cmd_map
+        ) == _cmd29_tone_set(_SUB_TONE_FREQ, b"\x00\x88\x05", RECEIVER_SUB)
 
-    def test_set_custom_addresses(self) -> None:
-        frame = commands.set_tone_freq(88.5, to_addr=0xA4, from_addr=0xE1)
+    def test_set_custom_addresses(self, cmd_map) -> None:
+        frame = commands.set_tone_freq(
+            88.5, to_addr=0xA4, from_addr=0xE1, cmd_map=cmd_map
+        )
         assert frame[2] == 0xA4
         assert frame[3] == 0xE1
 
@@ -430,43 +479,43 @@ class TestTSQLFreqBCDEncoding:
     """BCD encoding of TSQL frequencies (shares codec with tone freq)."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_encode(self, freq: float, bcd: bytes) -> None:
-        frame = commands.set_tsql_freq(freq)
+    def test_encode(self, freq: float, bcd: bytes, cmd_map) -> None:
+        frame = commands.set_tsql_freq(freq, cmd_map=cmd_map)
         assert bcd in frame
 
-    def test_rejects_below_minimum(self) -> None:
+    def test_rejects_below_minimum(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="67.0"):
-            commands.set_tsql_freq(50.0)
+            commands.set_tsql_freq(50.0, cmd_map=cmd_map)
 
-    def test_rejects_above_maximum(self) -> None:
+    def test_rejects_above_maximum(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="254.1"):
-            commands.set_tsql_freq(300.0)
+            commands.set_tsql_freq(300.0, cmd_map=cmd_map)
 
 
 class TestGetTSQLFreq:
     """Frame construction for get_tsql_freq (0x1B 0x01)."""
 
-    def test_main_receiver(self) -> None:
-        assert commands.get_tsql_freq(receiver=RECEIVER_MAIN) == _cmd29_tone_get(
-            _SUB_TSQL_FREQ, RECEIVER_MAIN
+    def test_main_receiver(self, cmd_map) -> None:
+        assert commands.get_tsql_freq(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) == _cmd29_tone_get(_SUB_TSQL_FREQ, RECEIVER_MAIN)
+
+    def test_sub_receiver(self, cmd_map) -> None:
+        assert commands.get_tsql_freq(
+            receiver=RECEIVER_SUB, cmd_map=cmd_map
+        ) == _cmd29_tone_get(_SUB_TSQL_FREQ, RECEIVER_SUB)
+
+    def test_default_is_main(self, cmd_map) -> None:
+        assert commands.get_tsql_freq(cmd_map=cmd_map) == commands.get_tsql_freq(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
         )
 
-    def test_sub_receiver(self) -> None:
-        assert commands.get_tsql_freq(receiver=RECEIVER_SUB) == _cmd29_tone_get(
-            _SUB_TSQL_FREQ, RECEIVER_SUB
-        )
-
-    def test_default_is_main(self) -> None:
-        assert commands.get_tsql_freq() == commands.get_tsql_freq(
-            receiver=RECEIVER_MAIN
-        )
-
-    def test_uses_cmd29_prefix(self) -> None:
-        frame = commands.get_tsql_freq()
+    def test_uses_cmd29_prefix(self, cmd_map) -> None:
+        frame = commands.get_tsql_freq(cmd_map=cmd_map)
         assert frame[4] == _CMD_CMD29
 
-    def test_contains_tsql_sub(self) -> None:
-        frame = commands.get_tsql_freq()
+    def test_contains_tsql_sub(self, cmd_map) -> None:
+        frame = commands.get_tsql_freq(cmd_map=cmd_map)
         assert bytes([_CMD_TONE, _SUB_TSQL_FREQ]) in frame
 
 
@@ -474,15 +523,15 @@ class TestSetTSQLFreq:
     """Frame construction for set_tsql_freq (0x1B 0x01)."""
 
     @pytest.mark.parametrize("freq, bcd", _BCD_TABLE)
-    def test_set_encodes_bcd(self, freq: float, bcd: bytes) -> None:
-        assert commands.set_tsql_freq(freq) == _cmd29_tone_set(
+    def test_set_encodes_bcd(self, freq: float, bcd: bytes, cmd_map) -> None:
+        assert commands.set_tsql_freq(freq, cmd_map=cmd_map) == _cmd29_tone_set(
             _SUB_TSQL_FREQ, bcd, RECEIVER_MAIN
         )
 
-    def test_set_sub_receiver(self) -> None:
-        assert commands.set_tsql_freq(88.5, receiver=RECEIVER_SUB) == _cmd29_tone_set(
-            _SUB_TSQL_FREQ, b"\x00\x88\x05", RECEIVER_SUB
-        )
+    def test_set_sub_receiver(self, cmd_map) -> None:
+        assert commands.set_tsql_freq(
+            88.5, receiver=RECEIVER_SUB, cmd_map=cmd_map
+        ) == _cmd29_tone_set(_SUB_TSQL_FREQ, b"\x00\x88\x05", RECEIVER_SUB)
 
 
 class TestParseTSQLFreqResponse:
@@ -532,42 +581,58 @@ class TestParseTSQLFreqResponse:
 class TestCommandDistinctness:
     """Different commands must produce distinct CI-V frames."""
 
-    def test_repeater_tone_vs_tsql_get(self) -> None:
-        assert commands.get_repeater_tone() != commands.get_repeater_tsql()
-
-    def test_repeater_tone_vs_tsql_set_on(self) -> None:
-        assert commands.set_repeater_tone(True) != commands.set_repeater_tsql(True)
-
-    def test_tone_freq_vs_tsql_freq_get(self) -> None:
-        assert commands.get_tone_freq() != commands.get_tsql_freq()
-
-    def test_tone_freq_vs_tsql_freq_set(self) -> None:
-        assert commands.set_tone_freq(88.5) != commands.set_tsql_freq(88.5)
-
-    def test_tone_main_vs_sub_get(self) -> None:
-        assert commands.get_tone_freq(receiver=RECEIVER_MAIN) != commands.get_tone_freq(
-            receiver=RECEIVER_SUB
-        )
-
-    def test_tsql_main_vs_sub_get(self) -> None:
-        assert commands.get_tsql_freq(receiver=RECEIVER_MAIN) != commands.get_tsql_freq(
-            receiver=RECEIVER_SUB
-        )
-
-    def test_repeater_tone_main_vs_sub_get(self) -> None:
+    def test_repeater_tone_vs_tsql_get(self, cmd_map) -> None:
         assert commands.get_repeater_tone(
-            receiver=RECEIVER_MAIN
-        ) != commands.get_repeater_tone(receiver=RECEIVER_SUB)
+            cmd_map=cmd_map
+        ) != commands.get_repeater_tsql(cmd_map=cmd_map)
 
-    def test_tone_on_vs_off(self) -> None:
-        assert commands.set_repeater_tone(True) != commands.set_repeater_tone(False)
+    def test_repeater_tone_vs_tsql_set_on(self, cmd_map) -> None:
+        assert commands.set_repeater_tone(
+            True, cmd_map=cmd_map
+        ) != commands.set_repeater_tsql(True, cmd_map=cmd_map)
 
-    def test_tsql_on_vs_off(self) -> None:
-        assert commands.set_repeater_tsql(True) != commands.set_repeater_tsql(False)
+    def test_tone_freq_vs_tsql_freq_get(self, cmd_map) -> None:
+        assert commands.get_tone_freq(cmd_map=cmd_map) != commands.get_tsql_freq(
+            cmd_map=cmd_map
+        )
 
-    def test_different_tone_freqs(self) -> None:
-        assert commands.set_tone_freq(88.5) != commands.set_tone_freq(110.9)
+    def test_tone_freq_vs_tsql_freq_set(self, cmd_map) -> None:
+        assert commands.set_tone_freq(88.5, cmd_map=cmd_map) != commands.set_tsql_freq(
+            88.5, cmd_map=cmd_map
+        )
 
-    def test_repeater_tone_distinct_from_freq_cmd(self) -> None:
+    def test_tone_main_vs_sub_get(self, cmd_map) -> None:
+        assert commands.get_tone_freq(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) != commands.get_tone_freq(receiver=RECEIVER_SUB, cmd_map=cmd_map)
+
+    def test_tsql_main_vs_sub_get(self, cmd_map) -> None:
+        assert commands.get_tsql_freq(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) != commands.get_tsql_freq(receiver=RECEIVER_SUB, cmd_map=cmd_map)
+
+    def test_repeater_tone_main_vs_sub_get(self, cmd_map) -> None:
+        assert commands.get_repeater_tone(
+            receiver=RECEIVER_MAIN, cmd_map=cmd_map
+        ) != commands.get_repeater_tone(receiver=RECEIVER_SUB, cmd_map=cmd_map)
+
+    def test_tone_on_vs_off(self, cmd_map) -> None:
+        assert commands.set_repeater_tone(
+            True, cmd_map=cmd_map
+        ) != commands.set_repeater_tone(False, cmd_map=cmd_map)
+
+    def test_tsql_on_vs_off(self, cmd_map) -> None:
+        assert commands.set_repeater_tsql(
+            True, cmd_map=cmd_map
+        ) != commands.set_repeater_tsql(False, cmd_map=cmd_map)
+
+    def test_different_tone_freqs(self, cmd_map) -> None:
+        assert commands.set_tone_freq(88.5, cmd_map=cmd_map) != commands.set_tone_freq(
+            110.9, cmd_map=cmd_map
+        )
+
+    def test_repeater_tone_distinct_from_freq_cmd(self, cmd_map) -> None:
         """0x16 and 0x1B commands are fundamentally different."""
-        assert commands.get_repeater_tone() != commands.get_tone_freq()
+        assert commands.get_repeater_tone(cmd_map=cmd_map) != commands.get_tone_freq(
+            cmd_map=cmd_map
+        )


### PR DESCRIPTION
## Summary

MOR-2008 batch 2 of "migrate the 12 zero-divergence modules in batches", `docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N. Migrates `mode.py` (14 builders), `tone.py` (8), `antenna.py` (8), `meters.py` (10), and `freq.py`'s `get_freq`/`set_freq` (2) — 42 builders total — onto the required-`cmd_map` contract established by `config.py`/`levels.py`/`vfo.py`/`ptt.py`/`scope.py` and batch 1 (`system.py`/`cw.py`/`speech.py`/`power.py`, #2868).

## Guardrail exception requested — hard ceiling crossed on both files and lines

**Figures (re-derived at this head via `git diff origin/main...HEAD --numstat`, across both commits): 28 files, 1849 insertions + 1318 deletions = 3167 changed lines.** Over both dimensions of the hard ceiling (10 files / 1000 lines). The owner already granted this PR's size exception before this push, so this round's fixes were not shrunk to fit it — the growth from 23/2804 (first push) to 28/3167 is five more files (`tests/integration/test_tone_tsql_integration.py`, `rigs/ic7610.toml`, `tests/test_rig_loader.py`, `tests/test_mor1545_vfo_fallback_failure_paths.py`, `tests/profile_command_coverage_gaps.txt`) and 363 more lines, all real review-round fixes (a mock rework, a D1 data-file promotion plus its regen, prose corrections, cross-reference repairs) — see "Second review round" below for the full account.

Why it is one unit of work: all five modules share the same mechanical contract (delete the fallback branch, require `cmd_map`, move call sites onto the binder, extend the matcher-backed-getter keystone) and the same generated census file (`tests/command_map_parity_uncovered.txt`) that a split would need to regenerate and reconcile more than once. Two real discoveries mid-batch touched five test files with real behavioural content, not padding; this review round's fixes are the same kind of real content, not size-reduction.

Largest contributors by changed lines: `tests/test_commands.py` (356), `tests/test_tone_tsql.py` (354), `src/rigplane/commands/mode.py` (231), `tests/test_dsp_levels_part2.py` (213), `src/rigplane/commands/antenna.py` (209), `tests/integration/test_tone_tsql_integration.py` (208), `src/rigplane/runtime/radio.py` (185), `tests/test_radio.py` (166), `src/rigplane/commands/tone.py` (158), `tests/test_mor1517_cmd29_gating.py` (156), `src/rigplane/commands/meters.py` (156), `src/rigplane/commands/_builders.py` (100, net deletion), `tests/command_map_parity_uncovered.txt` (90, regenerated census), `tests/test_command_map_integration.py` (79), `src/rigplane/commands/freq.py` (71), `tests/test_main_sub_tracking.py` (66), `tests/test_data_mode.py` (56), `tests/test_command_fallback_audit.py` (56), `tests/test_rig_loader.py` (55), `docs/CHANGELOG.md` (41), `tests/test_profile_command_binding.py` (31), `tests/test_response_shape_from_profile.py` (27), `tests/test_mor1545_vfo_fallback_failure_paths.py` (25), `rigs/ic7610.toml` (25), `tests/profile_command_coverage_gaps.txt` (18), `src/rigplane/runtime/_dual_rx_runtime.py` (14), `src/rigplane/commands/_frame.py` (11), `tests/test_command_map_parity.py` (10).

Requesting the owner's continued exception, already granted for this PR at the first push's size, the same as the four prior modules and batch 1 (#2868, 24/1517) before it.

## Contract fulfillment

All 42 public builders — `get_/set_mode`, `get_/set_data_mode`, `get_/set_filter_shape`, `get_/set_filter_width`, `get_/set_ssb_tx_bandwidth`, `get_/set_main_sub_tracking`, `get_/set_agc_time_constant` (mode.py, 14); `get_/set_repeater_tone`, `get_/set_repeater_tsql`, `get_/set_tone_freq`, `get_/set_tsql_freq` (tone.py, 8); `get_antenna_1`/`set_antenna_1`, `get_antenna_2`/`set_antenna_2`, `get_/set_rx_antenna_ant1`, `get_/set_rx_antenna_ant2` (antenna.py, 8); `get_s_meter`/`get_swr`/`get_alc`/`get_power_meter`/`get_comp_meter`/`get_vd_meter`/`get_id_meter`/`get_s_meter_sql_status`/`get_overflow_status`/`get_various_squelch` (meters.py, 10); `get_freq`/`set_freq` (freq.py, 2) — now require `cmd_map` (keyword-only, no default), carry `@expose_command_key` + `@require_cmd_map`, and call `_build_from_map` directly or through `_builders.py`'s shared `_build_function_get`/`_build_function_bool_set`/`_build_function_value_set` templates with no fallback branch left.

**`freq.py`'s other five builders stay out of scope** (`get_selected_freq`/`get_unselected_freq`/`get_selected_mode`/`get_unselected_mode`/`set_selected_mode`): none has a `cmd_map` parameter at all today, so there is no dual implementation to delete a fallback from. This is MOR-2008's Group B (these five plus `memory.py` and `tx_band.py`), ruled by the owner to migrate later once the missing/inconsistent TOML declarations are filled in from the manuals.

**Divergence file, verified rather than assumed:** these five modules' combined share was zero rows before this migration — every declaring CI-V profile's tuple already matched the deleted fallback's bytes exactly (verified by grep across `rigs/*.toml` before deleting each fallback). `tests/command_map_parity_divergences.txt` shows no diff (already empty, stays empty).

**Constant census:** eight now-dead constants deleted from `commands/_frame.py` (`_SUB_VARIOUS_SQUELCH`, `_SUB_COMP_METER`, `_SUB_VD_METER`, `_SUB_ID_METER`, `_SUB_FILTER_WIDTH`, `_SUB_S_METER_SQL_STATUS`, `_SUB_OVERFLOW_STATUS`, `_CMD_ANTENNA` — the last replaced by a literal `0x12` in `_COMMANDS_WITH_SUB`, mirroring batch 1's `_CMD_RIT` -> `0x21` precedent), plus three now-fully-dead shared templates from `commands/_builders.py` (`_build_meter_bool_get`, `_build_ctl_mem_single_bcd_get`, `_build_ctl_mem_single_bcd_set` — meters.py's/mode.py's only callers). `_CMD_CTL_MEM` also dropped from `_builders.py`'s own import list: with both this batch's two `_build_ctl_mem_single_bcd_*` deletions and batch 1's `_build_ctl_mem_get` deletion applied together (a rebase-only effect — neither batch's deletion alone made it dead), no function left in that file reads it. `_frame.py`'s own `_CMD_CTL_MEM` definition is untouched and still read directly by `mode.py`'s `parse_data_mode_response`. Each deletion verified by a whole-repo grep with zero remaining readers. `_SUB_ALC_METER`/`_SUB_POWER_METER`/`_SUB_S_METER`/`_SUB_SWR_METER`/`_SUB_AGC_TIME_CONSTANT` were checked and kept: still read directly by `tests/mock_server.py`, `tests/test_radio.py`, `backends/yaesu_cat/observations.py`, or `tests/test_dsp_levels_part2.py`/`tests/integration/test_dsp_levels_integration.py`.

**Found, out of scope, reported rather than fixed:** `_SUB_RX_ANT_ANT1`/`_SUB_RX_ANT_ANT2` in `_frame.py` (values `0x12`/`0x13`) have zero readers anywhere in `src/`/`tests/` and are not re-exported from `commands/__init__.py` — but they predate this batch (already dead in the pre-batch2 base commit, not orphaned by anything this PR deletes), so they are left alone rather than swept in under this PR's guardrail budget. `_builders.py`'s kernel-helper docstring in `test_command_map_parity.py` re-derived from eleven (module 1) down to four, not carried forward from either batch's own local count in isolation (batch 1 alone: seven; batch 2 alone against the stale base: five) — the true post-rebase figure only exists once both batches' deletions are combined.

**Call sites** moved onto `self._commands.<builder>` in `runtime/radio.py` (most of the 42, one per builder, plus the SUB-receiver cmd29 branches of `set_freq`/`set_mode`) and in `runtime/_dual_rx_runtime.py: DualRxRuntimeMixin` — the real production callers of `get_freq`/`set_freq`/`get_mode`/`set_mode` for the dual-receiver path live there, not in `radio.py`, which only bare-imported them for that purpose. The plan document's own call-site table (`docs/plans/2026-08-29-profile-driven-command-bytes.md`) names this file explicitly; confirmed by grep before assuming `radio.py` was the sole call-site file. Nine getters gained `_expect_shape` wiring in the same commit and are now registered in `tests/test_response_shape_from_profile.py`'s `MATCHER_BACKED_GETTERS` keystone table (below).

## Two discoveries mid-batch

**antenna.py's ANT1/ANT2 selector stays hardcoded, deliberately.** All four antenna getters route through `CoreRadio._get_bool_value`, which made them look like matcher-backed-getter candidates for the keystone table — but the ANT1/ANT2 selector (`0x00`/`0x01`) is not a profile-declared `sub` at all: `rigs/*.toml`'s own `get_antenna` key is a bare `[0x12]` tuple with no sub, and the selector is appended by the *caller* as `data`. Deriving `(command, sub, prefix)` via `self._expect_shape(...)` here would read `sub=None` off the map's own bare tuple and silently break every case. Documented in `antenna.py`'s own module docstring and left hardcoded, unchanged by this migration; the keystone table's own comment cross-references the same reasoning for why these four are excluded from it.

**IC-7610 does not declare the repeater-tone/TSQL/tone-freq/TSQL-freq family at all.** Discovered via a `KeyError: "Unknown command 'get_repeater_tone'"` while fixing `test_commands.py` against the usual IC-7610 `cmd_map` fixture every other module in this series has used. `rigs/ic7610.toml` carried an extensive comment (citing MOR-660/661/682, "D2 documentary re-check, MOR-2017") stating the whole family is intentionally *not* declared: a live-bench readback found the pre-migration hardcoded fallback's bytes decoded to garbage (16.5 Hz) on this radio, even though the official CI-V guide prints the addresses. Before this migration, `set_repeater_tone`/`set_repeater_tsql`/`set_tone_freq`/`set_tsql_freq` (and their `get_` twins) on IC-7610 still built and sent those wrong bytes regardless, because the fallback ignored the declaration gap; now they raise `CommandError` instead — a correction, not a regression, the same principle as batch 1's `system.py` IC-7300 date/time fix (there the profile's own bytes replace the fallback's; here the profile's declared *absence* does). **This round of review promoted that comment-only exclusion to a formal D1 state 2 declared-absent row** (see "B1-adjacent" below) — the original push left it as a bare comment, which put IC-7610 in D1 state 3 (unknown, warn-and-refuse) rather than state 2 (declared absent, refuse-silently); the refusal message and behavior now both reflect state 2. Two consequences of the underlying discovery, both fixed in the original commit, not deferred:
- `tests/test_commands.py`'s `TestToneTsqlCommands` and the whole of `tests/test_tone_tsql.py` switched their `cmd_map` fixture from IC-7610 to **IC-7300** (verified byte-identical to the old fallback for this family), with a docstring on `test_tone_tsql.py`'s fixture explaining why.
- `tests/test_mor1517_cmd29_gating.py`'s eight "wrapped_on_ic7610" tests (two each across `TestRepeaterToneGating`/`TestRepeaterTsqlGating`/`TestToneFreqGating`/`TestTsqlFreqGating`) asserted a cmd29-wrapped fallback frame on IC-7610 — a premise the real `cmd_map` lookup now makes impossible. Rewritten to `..._refused_on_ic7610`, asserting `pytest.raises(CommandError, match="not supported by this radio")` plus `mock.assert_not_called()`, with docstrings citing the TOML's own garbage-readback finding as evidence this is a correction. Their "unwrapped_on_ic7300" twins are unaffected and just gained `cmd_map=`.

## Test-infrastructure fixes found and fixed in this batch

**`tests/test_profile_command_binding.py`'s exposed-key drift guard didn't reach five of this batch's builders.** `get_filter_shape`/`set_filter_shape`/`get_ssb_tx_bandwidth`/`set_ssb_tx_bandwidth`/`get_main_sub_tracking`/`set_main_sub_tracking`/`get_repeater_tone`/`set_repeater_tone`/`get_repeater_tsql`/`set_repeater_tsql` all failed `TestExposedKeyDriftGuard` with "no synthesized argument combination was accepted, even with `_build_from_map` faked out." Root cause: these ten delegate to `_builders.py`'s shared `_build_function_get`/`_build_function_bool_set`/`_build_function_value_set` templates, which call *their own* module-local `_build_from_map` binding (imported separately into `_builders.py`'s namespace) — not the leaf module's. The guard patched only the leaf module (`mode.py`/`tone.py`), so the real `_build_from_map` ran during probing and raised `CommandError` against the probe maps for every candidate. Fixed by also patching `rigplane.commands._builders`'s `_build_from_map` binding — the one stable shared-template module in the architecture (its own docstring: "never from leaf modules"), so this covers every builder that routes through it, not just this batch's ten. `TestExpect::test_expect_on_unexposed_builder_names_the_migration`'s stand-in for "not exposed yet" (`get_s_meter`) also needed replacing, since meters.py's own migration exposed it in this same PR — switched to `get_selected_freq` (freq.py, Group B, has no `cmd_map` parameter at all).

**The keystone table (`tests/test_response_shape_from_profile.py`) was missing nine matcher-backed getters this batch's own `_expect_shape` wiring created.** `get_filter_shape`, `get_ssb_tx_bandwidth`, `get_main_sub_tracking`, `get_agc_time_constant`, `get_repeater_tone`, `get_repeater_tsql`, `get_s_meter_sql_status`, `get_overflow_status`, `get_various_squelch` all route through `CoreRadio._get_bcd_level`/`_get_bool_value` with a map-derived `(command, sub)` — exactly the shape `MATCHER_BACKED_GETTERS` exists to pin, and exactly the "requests moved, replies not" failure mode the file's own docstring names as the dangerous half of this whole migration series. Added all nine as `_GetterSpec` entries. Manually confirmed red for the half-done shape: reverting `get_filter_shape`'s reply-side `command`/`sub` to a hardcoded, wrong value while its request still went through the map made all four declaring profiles' keystone cases fail with the exact "reply matcher was not migrated with the request" message the test is built to produce; reverted back to the real `self._expect_shape(get_filter_shape)` call afterward. `get_mode`/`get_data_mode`/`get_filter_width` (mode.py) and meters.py's seven getters stay excluded from the table, same as `levels.py`'s `get_rf_power`/`get_rf_gain`/`get_af_level` before them: each parses through its own module-level `parse_*_response` (a hardcoded command/sub check) or, for `get_filter_width`, bespoke per-profile BCD/raw-byte handling, never through the two matcher functions.

**Prior review's forward-looking note, folded in:** PR #2868's review flagged a sweep false-positive class (`getattr`-bound locals in `rigctld/handler.py` shadowing builder names) and asked that the next batch's sweep methodology account for it. Doing so surfaced a second occurrence of the *same* shape one level removed — `rigctld/handler.py`/`rigctld/server.py`'s `get_mode = get_mode_reader(self._radio, _mode_to_hamlib_str)` binds a locally-resolved reader closure via a helper function, not bare `getattr`, but shadows the builder name the same way. Generalized the sweep's exclusion from "any `NAME = getattr(...)` assignment" to "any `NAME = <call>(...)` assignment" (renamed `_is_getattr_shadow_assign` -> `_is_call_shadow_assign`); verified this broader exclusion does not suppress the sweep's own dependency on the `bind_default_addr_globals`/`bind_default_addr_module` test-helper rebinding pattern, since that mechanism mutates via `namespace[name] = ...`/`setattr(...)` — different AST shapes, never a literal `NAME = <call>(...)` statement.

## Two more failures the remote backstop caught

The local targeted battery's file list did not include `tests/test_radio.py` or `tests/test_command_fallback_audit.py` — neither imports the five migrated modules by name, so nothing in the established file-selection heuristic flagged them. The first full-suite run on the dedicated remote test runner found 19 real failures across both; both fixed in this same commit before the second (green) run.

**`tests/test_radio.py`'s `TestToneTsqlParity`/`TestRepeaterToneDedupeKeyReceiverScoped` assumed IC-7610 (the module's default `radio` fixture) answers `get_repeater_tone`/`get_repeater_tsql`/`get_tone_freq`/`get_tsql_freq` — the same broken premise as the `test_mor1517_cmd29_gating.py` "wrapped_on_ic7610" tests already fixed above, just in a different file the sweep-by-import-list missed.** Both classes given their own class-scoped `radio` fixture pointing at IC-7300 instead (single-receiver, `rigs/ic7300.toml`: "single receiver, no cmd29" — declares byte-identical `[0x16/0x1B, sub]` tuples for this family, but never cmd29-wraps anything). This forced two further corrections beyond a fixture swap:
- `TestToneTsqlParity`'s `receiver=1` parametrize cases are gone, not ported: that exact combination (cmd29-wrapped, dual-receiver tone/TSQL) was never valid on any *declaring* radio — IC-7610 was the only dual-RX profile with cmd29 routes for this family, and it does not declare the family at all. IC-9700, the only dual-RX profile that does declare it, has no cmd29 route either and reaches SUB through the VFO-select fallback (`TestToneTsqlDualRxCmd29Guard`, same file, unaffected by this PR) instead — already full coverage for that shape.
- `TestRepeaterToneDedupeKeyReceiverScoped::test_concurrent_main_and_sub_reads_do_not_coalesce` (MOR-1545/#2458 regression coverage for the commander's receiver-scoped dedup key) needs a real SUB receiver in flight concurrently with MAIN; IC-7300 cannot provide one. Redesigning its exact `sent_packets`-count and interleaving assertions around IC-9700's 3-frame VFO-select-fallback SUB path is real work, not a fixture swap, so it is left **explicitly skipped** with a reason citing this discovery, rather than silently deleted or rushed. `test_concurrent_same_receiver_reads_still_dedupe` (same class) needed no such change — it only ever exercised `receiver=0` — and is fixed and green on the IC-7300 fixture.

**`tests/test_command_fallback_audit.py` used `get_freq`/`set_freq` as its stand-in "still has a real `cmd_map is None` fallback branch to audit" builder — exactly the same class of stand-in-retirement `test_expect_on_unexposed_builder_names_the_migration` (above) already hit, in a different file.** This file tests the *generic* `_fallback_audit.py` wrapping mechanism (MOR-2001, itself scheduled for deletion at Step Z of the parent plan) and needs some builder that still has a working `cmd_map=None` fallback to prove the wrapper logs a warning when it engages; `get_freq` no longer does. Switched every functional reference to `dsp.py`'s `get_attenuator`/`set_attenuator` — `dsp.py` is not migrated by any batch in this series so far, so it is a safe stand-in for however many further batches remain (until `dsp.py`'s own turn, at which point whoever migrates it hits this exact swap again, or Step Z has arrived and the file is deleted outright).

## Second review round: BLOCKED findings fixed

PR review at `6b192a94` came back BLOCKED. Every finding below is fixed in this push; the owner's size exception already covers this PR, so nothing here was shrunk to fit — the fixes add real behavior (a mock rework, a data-file promotion, six prose corrections), not padding removed to compensate.

**B1 (blocking): `tests/integration/test_tone_tsql_integration.py` — 22 failures, all `CommandError`.** This file's `IcomRadio` fixture built with no `model=` (default IC-7610), driving exactly the four tone/TSQL method pairs this batch made refuse on IC-7610 — the same class already swept in `tests/`, but `tests/integration/` was never in that sweep's scope (a gap this review round also closes structurally, see B2). Fixed properly, not a one-line model swap, per the review's own note that the mock's `_strip_receiver_prefix` assumes cmd29:
- Switched both fixtures to **IC-7300** (`model="IC-7300"` on the client; `radio_addr=0x94` on `ToneMockRadio`) — the only other option, IC-9700, is dual-RX with no cmd29 route either and would have required the same VFO-fallback complexity already tracked separately for `test_radio.py`'s skipped dedupe test.
- **Real mock rework, not a fixture-only fix.** `ToneMockRadio`'s four `_handle_*` methods (repeater tone/TSQL, tone/TSQL frequency) called a `_strip_receiver_prefix` helper on every plain-path request — a leftover from when this file was IC-7610-only and every real request went through `_dispatch_cmd29` instead, never through these handlers at all. On IC-7300 (no cmd29 support), every request *is* plain, and stripping a "receiver prefix" from a frame that never carries one is a **latent bug**, not a no-op: it silently discarded the leading BCD byte of any tone/TSQL frequency under 200 Hz (67.0–199.9 Hz — the hundreds-digit BCD byte is legitimately `0x00`/`0x01`, indistinguishable from a receiver selector), corrupting the frequency roundtrip for most of this file's own standard test values. Removed the stripping step entirely (a plain frame never carries a receiver byte — that concept exists only inside the cmd29 envelope, which the base `MockIcomRadio`'s own `_dispatch_civ`/`_dispatch_cmd29` split already unwraps before a subclass ever sees `inner`) and wired plain 0x16 dispatch for repeater tone/TSQL into `_dispatch_civ` (previously only 0x1B was intercepted there; 0x16 sub 0x42/0x43 plain requests fell through to the parent, which has no route for them, because on IC-7610 they never needed to — cmd29 caught them first). Removed the now-fully-unreachable `_dispatch_cmd29` override (IC-7300 has no cmd29 routes for this family at all, so nothing in this file will ever build a cmd29-wrapped request again) rather than leave dead code documented as "currently unreachable."
- Verified: **32 passed** locally (targeted, this one file), including every standard test frequency the old bug would have corrupted (67.0, 77.0, 100.0, 110.9, 127.3, 167.9 all have a hundreds-digit BCD byte of `0x00` or `0x01`).

**B1-adjacent: `rigs/ic7610.toml` promoted from D1 state 3 to state 2 for this family.** The comment documenting the tone/TSQL absence carried no `{ absent = "<source>" }` marker, so `BoundCommands._refusal_for` classified IC-7610 as state 3 (unknown — refuse *and* warn via `on_undeclared`) rather than state 2 (declared absent — refuse silently, no warning) for these eight commands, even though the absence was a confirmed, cited fact, not an unknown. Converted the comment into eight formal `get_/set_repeater_tone`, `get_/set_repeater_tsql`, `get_/set_tone_freq`, `get_/set_tsql_freq` rows, each `{ absent = "..." }`, carrying the existing live-bench garbage-readback citation (MOR-660/661/682) as the source and noting the D2 MOR-2017 documentary conflict inline, same as the surrounding comment already did. Verified end to end: `radio._commands.get_repeater_tone(...)` now raises `CommandError: ... (declared absent by this profile, per live-bench readback (MOR-660/661/682): ...)` instead of `... (not declared by this profile, and not recorded as absent)` — no `on_undeclared` warning fires any more for these eight. Added `TestIc7610DeclaresAbsentCommands` to `tests/test_rig_loader.py` (pinning the 8 names, matching the established `TestIc7300/9700/705DeclaresAbsentCommands` pattern) and narrowed `TestNoShippedProfileUsesAbsentSpellingYet`'s `_NOT_YET_FILLED` set to exclude `ic7610` (it now legitimately declares absent commands). Regenerated `tests/profile_command_coverage_gaps.txt`: IC-7610 drops out of the `gap` row for exactly these 8 keys (`census.profile_key_gaps` 324 → 316, a difference of 8; `distinct_gap_keys`/`civ_profiles`/`public_builders` unchanged, since X6100/X6200 still have genuine gaps on the same 8 keys and no key gained or lost a gap-list entry entirely). `tests/command_map_parity_uncovered.txt`/`tests/command_map_parity_divergences.txt` re-regenerated as a no-op check (confirmed byte-identical, no diff) — this class of D1-state change doesn't touch the dual-implementation/requires-map axis those files track.

**Six prose findings, all fixed (class rule — enumerated and read individually, not sampled):**
1. `src/rigplane/commands/mode.py:10` — "Nine of the fourteen route through `_builders.py` shared templates" was wrong; re-counted from the actual call sites (`_build_function_get`/`_build_function_value_set`/`_build_function_bool_set`: 3+2+1 = 6; direct `_build_from_map`: 8; 6+8=14 total) — fixed to "six."
2. `tests/test_radio.py:3299-3300` — `TestToneTsqlDualRxCmd29Guard`'s docstring claimed `TestToneTsqlParity` "exercises the IC-7610 fixture on both receivers and stays green"; that class no longer uses IC-7610 or exercises `receiver=1` at all (see the earlier "Two more failures" section). Rewritten to point at the two still-accurate pinning tests in this same class instead, and to note the IC-7610 comparison this sentence used to make no longer has anything to compare against.
3. `tests/test_mor1545_vfo_fallback_failure_paths.py:181-183` — `TestVfoFallbackReadDedupeKeyReceiverScoped`'s docstring pointed at `test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped::test_concurrent_main_and_sub_reads_do_not_coalesce` as a second example of the same coverage; that test is now `@pytest.mark.skip`'d (documented above). Reworded to state that fact and note this file's own test is currently the one actually exercising the MAIN-direct-vs-SUB-fallback coalescing scenario, not a redundant second copy of it.
4. `src/rigplane/commands/freq.py:10-13` — "several tests ... import both constants" overclaimed: only `tests/test_civ_command_profiling.py` imports both `_CMD_FREQ_GET` and `_CMD_FREQ_SET`; `tests/test_radio.py`, `tests/test_icom7610_serial_radio.py`, and `tests/_helpers.py` import `_CMD_FREQ_GET` only (verified by grep across all four files). Narrowed to say so precisely.
5. `tests/test_tone_tsql.py` module docstring — "Unit tests for IC-7610 tone/TSQL commands" and "All four commands use cmd29 wrapping (dual-receiver)" are both misleading now that the `cmd_map` fixture is IC-7300 (single-receiver, no cmd29 routes for this family). Rewrote to describe this as builder-level testing (`command29` is a caller-supplied argument, independent of which map supplies the wire bytes) rather than a claim about a specific dual-receiver radio's real behavior; also tightened the fixture docstring's own citation from "own comment on the point" to "own `{ absent = ... }` row," and corrected its exception-type claim after checking empirically — calling these builders directly with a bare `CommandMap` (bypassing `BoundCommands`, which is what turns a declared-absent lookup into `CommandError`) still raises `KeyError`, confirmed by running it, not assumed from the D1-state change alone.
6. `src/rigplane/commands/antenna.py:10-11` — the path `tests/test_response_shape_from_profile.py` was split mid-filename across a line break (`test_response_shape_from_` / `profile.py`), making it ungreppable as one string. Rewrapped so the full path sits on one line.

## Sweep + local/remote verification

**Corrected sweep** (bare-name and `commands.<builder>(...)`/`raw_commands.<builder>(...)` attribute-call shapes, with the widened shadow-assignment exclusion above), run as a standalone AST script across every file in `tests/` and `src/`: 0 hits in `src/`; 13 hits in `tests/`, all deliberate `test_..._requires_cmd_map` Q6-negatives (one per builder/class asserting the `TypeError`) — enumerated and read individually, not sampled.

**Local (targeted, per instructions, no full suite), final run across every file this PR (both rounds) touches or that the review named:** `tests/integration/test_tone_tsql_integration.py`, `test_command_map_integration.py`, `test_command_map_parity.py`, `test_commands.py`, `test_command_fallback_audit.py`, `test_data_mode.py`, `test_dsp_levels_part2.py`, `test_main_sub_tracking.py`, `test_mor1517_cmd29_gating.py`, `test_mor1545_vfo_fallback_failure_paths.py`, `test_tone_tsql.py`, `test_response_shape_from_profile.py`, `test_profile_command_coverage.py`, `test_profile_command_binding.py`, `test_undeclared_command_policy.py`, `test_rig_loader.py`, `test_radio.py`, `test_supports_command.py` — **2024 passed, 98 skipped, 1 failed** (`TestPtt::test_managed_ptt_port_token_safety[rebind]`, `src/rigplane/runtime/_civ_rx.py`, `TimeoutError: CI-V response timed out`). That one failure is a pre-existing, timing-sensitive test wholly unrelated to this PR's diff (PTT/managed-TX, not tone/mode/antenna/meters/freq): passed 3/3 in isolation, and flaked non-deterministically across three combined-battery runs (once here, once earlier in a different test, once not at all) purely from CPU contention running 18 files' worth of async tests serially in one process — confirmed by running `tests/test_radio.py` alone (291 passed, 2 skipped, every time). `ruff check`/`ruff format --check`/`lint-imports` all clean (5 contracts kept, 0 broken). Regen no-op check: re-ran both `command_map_parity` regen commands on the final tree — `tests/command_map_parity_uncovered.txt`/`tests/command_map_parity_divergences.txt` came back byte-identical (no diff), confirming this round's fixes didn't touch anything on that axis.

**Checked, does not apply:** main's new `tests/` addition the coordinator flagged as a possible new sweep hit (#2862, "meter conformance contract + suite") turned out to be a frontend TypeScript/Svelte conformance suite for `components-v2/meters/` — no Python file, no reference to `commands/meters.py`. Confirmed by reading the commit's own file list before concluding no action was needed.

**Remote backstop, run twice on the dedicated remote test runner (foreground, to completion) — scope correction from the first round of review:** both runs used the *standard* suite command (`pytest tests/ --ignore=tests/integration ...`, CLAUDE.md's own "standard suite"), which excludes `tests/integration/` by design. That is narrower than `quick.yml`'s own gate, which runs `pytest tests/` with **no ignore** and therefore does collect and run `tests/integration/` — the 22 failures the review found (`tests/integration/test_tone_tsql_integration.py`) were invisible to my backstop precisely because of this scope gap, not because the backstop was green and then something broke afterward. Fixed in this round (see the integration-test section above) and re-verified locally (that one file, targeted, per instructions): **32 passed.**
- First remote run (before the two review-round fixes, standard-suite scope): **19 failed, 11370 passed, 107 skipped, 48 xfailed, 54s.** All 19 failures traced to the two files identified in the "Two more failures the remote backstop caught" section; none pre-existing or unrelated — confirmed by reading every failure's traceback before writing either fix.
- Second remote run (after both fixes, same push, still standard-suite scope): **11387 passed, 109 skipped, 48 xfailed, 0 failed, 82s.** `ruff check`: all checks passed. The +2 skips vs. the first run's skip count are the two deliberately-skipped `test_concurrent_main_and_sub_reads_do_not_coalesce` parametrized cases documented above.
- **Not re-run after this review round's fixes** (`tests/integration/test_tone_tsql_integration.py`, `rigs/ic7610.toml`'s D1 state 2 conversion, the six prose fixes): per instruction, the authoritative check for this push is CI `quick.yml` at the new head, which runs the full, unignored `pytest tests/` — including `tests/integration/` — and is the gate that actually caught B1. Running the remote backstop a third time would duplicate that coverage rather than add to it.

## Parity/coverage deltas — every line explained

**`tests/command_map_parity_divergences.txt`**: no diff (already empty, stays empty).

**`tests/profile_command_coverage_gaps.txt`** (regenerated this review round, B1-adjacent): `census.profile_key_gaps` 324 -> 316 (-8, one per key IC-7610 leaves the `gap` row for: `get_/set_repeater_tone`, `get_/set_repeater_tsql`, `get_/set_tone_freq`, `get_/set_tsql_freq`). `distinct_gap_keys`/`civ_profiles`/`public_builders` unchanged — these 8 keys still have real gaps on X6100/X6200, so no key left the gap list entirely, and no profile or builder count changed. No other rows touched. (No diff before this round.)

**`tests/command_map_parity_uncovered.txt`** (re-derived on the rebased tree, not carried forward): `builders_compared` 79 -> 37 (-42, exactly the 42 migrated builders dropping out of the dual-implementation comparison pool), `dual_implementation_sites`/`sites_compared` 46 -> 17 (-29), `frames_identical` 667 -> 373 (-294), `profile_builder_map_gaps` 310 -> 140 (-170) — all downstream of the same 42-builder move. `frames_diverged` stays 0, `hardcode_only_builders` stays 16 (Group B untouched), `public_builders` stays 228 (no builder added or removed, only re-classified), `profiles`/`cat_only_profiles` unchanged. 42 new `requires-map` rows, one per migrated Python builder name. 38 `gap` rows removed — one per distinct `cmd_map` key those 42 functions resolve to: mode.py (14 keys), tone.py (8), meters.py (10), freq.py (2) each map one-to-one, but antenna.py's 8 functions collapse onto only 4 keys (`get_antenna_1`/`get_antenna_2`/`get_rx_antenna_ant1` all expose `"get_antenna"`; `set_antenna_1`/`set_antenna_2`/`set_rx_antenna_ant1` all expose `"set_antenna"`; `get_rx_antenna_ant2`/`set_rx_antenna_ant2` keep their own distinct keys) — 14+8+4+10+2 = 38, matching exactly. Zero new gap rows.

Internal-identifier self-check across the full diff and this PR body: performed, empty. The remote backstop ran on the dedicated remote test runner; its host is not named here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
