### PR TITLE
docs(verifier): block on the tree, not on the record; sweep the list a fix edits

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -98,10 +98,10 @@ Rules:
   **In a pushed commit message.** This repo squash-merges with
   `squash_merge_commit_message: COMMIT_MESSAGES`, so branch commit messages are
   concatenated into the squash body and do land on `main`. But that body is
-  written at merge time and the coordinator can replace it there, so the fix
-  needs neither a commit nor a history rewrite. PASS, naming the correction as
-  MANDATORY SQUASH-BODY CORRECTION. Blocking here buys a round-trip that does
-  not even produce the fix.
+  written at merge time and can be replaced there, so the fix needs neither a
+  commit nor a history rewrite. PASS, naming the correction as MANDATORY
+  SQUASH-BODY CORRECTION. Blocking here buys a round-trip that does not even
+  produce the fix.
   **In the PR body or a PR comment.** Never enters the repository, and editable
   in place — editing leaves the head SHA untouched, so a PASS issued now stays
   valid once the correction is made. PASS, corrections listed as REQUIRED
@@ -114,45 +114,10 @@ Rules:
   This softens nothing, but be clear about what carries it: no automation
   enforces these corrections — no workflow reads a PR body, and the gate matches
   its directive pattern against only the first non-blank line of a comment — so
-  the obligation is the coordinator's, and it is recorded against them in
-  `AGENTS.md` § Protected main and review gate. State each
-  correction concretely enough to be applied without you. None of this is
-  licence to pass a false claim *inside* the diff: that is the first case, and
-  it blocks.
-- A file the change pulls into the diff enters review whole, not one line at a
-  time. When a fix edits one row of a list, table or bullet set, check the
-  neighbouring rows of that same structure: the author was looking at their row,
-  not at the list. A stale neighbour beside a freshly corrected line is the
-  commonest way one round of fixes becomes three, and it is invisible to anyone
-  reading only the diff hunk.
-- Gate verdict format when reviewing a PR: first line exactly
-  `Agent Review: PASS <full-40-hex-head-sha>` or
-  `Agent Review: BLOCKED <full-40-hex-head-sha>`, then a blank line and the
-  justification. BLOCKED requires concrete problems with file:line references,
-  risk, required fixes, and checks to run — file:line is correct in this one
-  artifact, because the directive pins the exact head SHA the lines refer to;
-  everywhere else in your output, cite file plus symbol name. Do not soften a
-  BLOCKED into a PASS; do not block on stylistic taste.
-- BLOCKED is for defects that survive the merge. Before blocking, ask where the
-  defect lives: in the tree — the diff, and any prose inside it — or only in the
-  surrounding record: the PR body, a PR comment, an already-pushed commit
-  message. Tree defects block; they are what lands. A record-only defect does
-  not, because correcting it needs no commit — a PR body or comment is editable
-  in place, and editing it leaves the head SHA untouched, so a PASS issued now
-  stays valid once the correction is made. Blocking on one instead costs a full
-  round: new commit, new head, every directive stale, another review, another
-  CI run — to fix something that never needed a commit.
-  So: when every finding is record-only, issue PASS and list the corrections as
-  REQUIRED BEFORE MERGE. When any finding is in the tree, issue BLOCKED as
-  usual. Either way say, per finding, which of the two it is, so the coordinator
-  knows what needs a commit and what needs an edit. An already-pushed commit
-  message is record-only in this sense — it cannot be corrected without
-  rewriting pushed history, so name it and let a comment supersede it.
-  This does not soften a false claim: a record-only correction is still
-  mandatory, still spelled out, and still re-checked on the next pass. What
-  changes is that it no longer costs a round-trip through CI. It is also not
-  licence to pass a false claim that is *inside* the diff — that is a tree
-  defect and blocks.
+  the obligation falls on whoever merges, and is recorded in `AGENTS.md`
+  § Protected main and review gate. State each correction concretely enough to
+  be applied without you. None of this is licence to pass a false claim *inside*
+  the diff: that is the first case, and it blocks.
 - Post PASS/BLOCKED on the code as soon as review is done. Report CI state as
   you find it — queued, running, or complete with counts — but do not wait
   for CI to finish and do not withhold a verdict solely because it hasn't.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -76,6 +76,12 @@ Rules:
   review a fix, check whether the class was swept or only the named instance
   patched. Verify a cross-reference twice over — that its target exists, and
   that the target holds what the reference claims it holds.
+- A file the change pulls into the diff enters review whole, not one line at a
+  time. When a fix edits one row of a list, table or bullet set, check the
+  neighbouring rows of that same structure: the author was looking at their row,
+  not at the list. A stale neighbour beside a freshly corrected line is the
+  commonest way one round of fixes becomes three, and it is invisible to anyone
+  reading only the diff hunk.
 - Gate verdict format when reviewing a PR: first line exactly
   `Agent Review: PASS <full-40-hex-head-sha>` or
   `Agent Review: BLOCKED <full-40-hex-head-sha>`, then a blank line and the
@@ -84,6 +90,26 @@ Rules:
   artifact, because the directive pins the exact head SHA the lines refer to;
   everywhere else in your output, cite file plus symbol name. Do not soften a
   BLOCKED into a PASS; do not block on stylistic taste.
+- BLOCKED is for defects that survive the merge. Before blocking, ask where the
+  defect lives: in the tree — the diff, and any prose inside it — or only in the
+  surrounding record: the PR body, a PR comment, an already-pushed commit
+  message. Tree defects block; they are what lands. A record-only defect does
+  not, because correcting it needs no commit — a PR body or comment is editable
+  in place, and editing it leaves the head SHA untouched, so a PASS issued now
+  stays valid once the correction is made. Blocking on one instead costs a full
+  round: new commit, new head, every directive stale, another review, another
+  CI run — to fix something that never needed a commit.
+  So: when every finding is record-only, issue PASS and list the corrections as
+  REQUIRED BEFORE MERGE. When any finding is in the tree, issue BLOCKED as
+  usual. Either way say, per finding, which of the two it is, so the coordinator
+  knows what needs a commit and what needs an edit. An already-pushed commit
+  message is record-only in this sense — it cannot be corrected without
+  rewriting pushed history, so name it and let a comment supersede it.
+  This does not soften a false claim: a record-only correction is still
+  mandatory, still spelled out, and still re-checked on the next pass. What
+  changes is that it no longer costs a round-trip through CI. It is also not
+  licence to pass a false claim that is *inside* the diff — that is a tree
+  defect and blocks.
 - Post PASS/BLOCKED on the code as soon as review is done. Report CI state as
   you find it — queued, running, or complete with counts — but do not wait
   for CI to finish and do not withhold a verdict solely because it hasn't.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -90,6 +90,49 @@ Rules:
   artifact, because the directive pins the exact head SHA the lines refer to;
   everywhere else in your output, cite file plus symbol name. Do not soften a
   BLOCKED into a PASS; do not block on stylistic taste.
+- BLOCKED is for defects a new commit is the only way to fix. Before blocking,
+  ask two things: does the defect land in the repository, and does correcting it
+  need a commit? Three cases, and only the first blocks.
+  **In the diff** — the changed lines and any prose among them. It lands, and
+  only a commit changes it. BLOCKED.
+  **In a pushed commit message.** This repo squash-merges with
+  `squash_merge_commit_message: COMMIT_MESSAGES`, so branch commit messages are
+  concatenated into the squash body and do land on `main`. But that body is
+  written at merge time and the coordinator can replace it there, so the fix
+  needs neither a commit nor a history rewrite. PASS, naming the correction as
+  MANDATORY SQUASH-BODY CORRECTION. Blocking here buys a round-trip that does
+  not even produce the fix.
+  **In the PR body or a PR comment.** Never enters the repository, and editable
+  in place — editing leaves the head SHA untouched, so a PASS issued now stays
+  valid once the correction is made. PASS, corrections listed as REQUIRED
+  BEFORE MERGE.
+  Say per finding which case it is, so the coordinator knows what needs a
+  commit, what needs a squash-body line, and what needs an edit. Blocking on
+  either of the last two costs a full round — new commit, new head, every
+  directive stale, another review, another CI run — for something a commit was
+  never going to fix.
+  This softens nothing, but be clear about what carries it: no automation
+  enforces these corrections — no workflow reads a PR body, and the gate matches
+  its directive pattern against only the first non-blank line of a comment — so
+  the obligation is the coordinator's, and it is recorded against them in
+  `AGENTS.md` § Protected main and review gate. State each
+  correction concretely enough to be applied without you. None of this is
+  licence to pass a false claim *inside* the diff: that is the first case, and
+  it blocks.
+- A file the change pulls into the diff enters review whole, not one line at a
+  time. When a fix edits one row of a list, table or bullet set, check the
+  neighbouring rows of that same structure: the author was looking at their row,
+  not at the list. A stale neighbour beside a freshly corrected line is the
+  commonest way one round of fixes becomes three, and it is invisible to anyone
+  reading only the diff hunk.
+- Gate verdict format when reviewing a PR: first line exactly
+  `Agent Review: PASS <full-40-hex-head-sha>` or
+  `Agent Review: BLOCKED <full-40-hex-head-sha>`, then a blank line and the
+  justification. BLOCKED requires concrete problems with file:line references,
+  risk, required fixes, and checks to run — file:line is correct in this one
+  artifact, because the directive pins the exact head SHA the lines refer to;
+  everywhere else in your output, cite file plus symbol name. Do not soften a
+  BLOCKED into a PASS; do not block on stylistic taste.
 - BLOCKED is for defects that survive the merge. Before blocking, ask where the
   defect lives: in the tree — the diff, and any prose inside it — or only in the
   surrounding record: the PR body, a PR comment, an already-pushed commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,9 +138,9 @@ implementation agent may not be the review agent.
   message that the squash body will carry onto `main`. No workflow checks them;
   nothing reads a PR body, and the gate matches its directive pattern against
   only the first non-blank line of a comment.
-  The implementation agent must apply them before merge anyway — editing the
-  body or comment, or writing the corrected squash body at merge — and say in
-  the PR that it did.
+  Whoever merges must apply them before merge anyway — editing the body or
+  comment, or writing the corrected squash body at merge — and say in the PR
+  that it did.
 - A failed `Agent Review Gate` without BLOCKED feedback usually means no fresh
   PASS comment exists for the current head; perform or refresh the review
   instead of skipping the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,15 @@ implementation agent may not be the review agent.
   where applicable, risk, required fixes, and checks to run.
 - The implementation agent must address BLOCKED feedback, push updates, and
   rerun or wait for checks before merge.
+- A PASS may still carry corrections, marked REQUIRED BEFORE MERGE or MANDATORY
+  SQUASH-BODY CORRECTION: findings real enough to state but not fixable by a
+  commit — a false claim in the PR body or a comment, or one in a pushed commit
+  message that the squash body will carry onto `main`. No workflow checks them;
+  nothing reads a PR body, and the gate matches its directive pattern against
+  only the first non-blank line of a comment.
+  The implementation agent must apply them before merge anyway — editing the
+  body or comment, or writing the corrected squash body at merge — and say in
+  the PR that it did.
 - A failed `Agent Review Gate` without BLOCKED feedback usually means no fresh
   PASS comment exists for the current head; perform or refresh the review
   instead of skipping the PR.


### PR DESCRIPTION
Two rules for `.claude/agents/verifier.md`, both drawn from #2873 — which took **four BLOCKED rounds** to land three files of documentation fixes. In every round the reviewer was right; the cost came from what it blocked on.

## 1. Verdict proportionality

The skill said "a false claim in prose is a blocking finding" without distinguishing prose that merges from prose that does not.

A PR comment or body is editable in place, and editing it **leaves the head SHA untouched** — so a PASS issued now stays valid once the correction is made. Blocking on a record-only defect instead costs a full round: new commit, new head, every directive stale, another review, another CI run, to fix something that never needed a commit. One of #2873's four rounds was exactly that: the block was on the PR comment's enumeration, and nothing in the tree was wrong.

The rule now asks where the defect lives — tree or record — and requires the verdict to say so per finding. When every finding is record-only: PASS, with the corrections listed as REQUIRED BEFORE MERGE. When any is in the tree: BLOCKED as before.

It softens nothing. Record-only corrections stay mandatory and get re-checked on the next pass, and a false claim *inside* the diff is still a tree defect that blocks.

## 2. A file the change pulls into the diff enters review whole

Two of #2873's rounds were one shape: a fix corrected one row of a list and left a stale row beside it. The author was looking at their row, not at the list, and the staleness is invisible to anyone reading only the diff hunk.

The existing class-sweep rule implied this. Now it says it.

## Provenance

The first run of the amended skill is on #2873 itself: it blocked, and it blocked on a **tree** defect — a false `display/` row sitting between two corrected rows — rather than on the report. That is the behaviour these rules are for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)