### PR TITLE
feat: warn when a design-language manifest declares no layout compatibility

### DIFF
--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-guard.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-guard.test.ts
@@ -1,0 +1,126 @@
+/**
+ * MOR-2054 — `layoutCompatibility` is a manifest's own declaration of which
+ * layouts it can activate under (`designLanguageActivation`,
+ * `../../workspace/activation.ts`, MOR-1081). A manifest whose
+ * `layoutCompatibility` holds no `compatible: true` entry can never
+ * activate for any layout, and until this ticket nothing said so.
+ *
+ * Manifest ids below are namespaced `mor-2054-guard-*` and never registered
+ * (these tests call `guardLayoutCompatibility` directly, not through
+ * `registerDesignLanguage`) — deliberately distinct from `fixtures.ts`'s
+ * `validManifest()` default id (`testline`) and from the real families, so
+ * this file's assertions cannot be affected by, or affect, what sibling
+ * files in the shared `fast` pool (`vite.config.ts`, `isolate: false`)
+ * register under those ids.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { declaresNoLayoutCompatibility, guardLayoutCompatibility } from '../layout-compatibility-guard';
+import { validManifest } from './fixtures';
+
+describe('declaresNoLayoutCompatibility', () => {
+  // The literal trap scenario: an author leaves the field empty.
+  it('is true for an empty layoutCompatibility array', () => {
+    const manifest = validManifest({ id: 'mor-2054-guard-empty', layoutCompatibility: [] });
+    expect(declaresNoLayoutCompatibility(manifest)).toBe(true);
+  });
+
+  // The "opt-out" misreading: the author declares only exceptions, expecting
+  // unlisted/excepted layouts to default to compatible. designLanguageActivation
+  // has no such default, so this hits the identical dead end as the empty case.
+  it('is true when every entry is compatible: false', () => {
+    const manifest = validManifest({
+      id: 'mor-2054-guard-all-false',
+      layoutCompatibility: [
+        { layoutId: 'dual-receiver-cockpit', compatible: false },
+        { layoutId: 'desktop-v2', compatible: false, reason: 'not ready yet' },
+      ],
+    });
+    expect(declaresNoLayoutCompatibility(manifest)).toBe(true);
+  });
+
+  // At least one compatible: true entry means designLanguageActivation CAN
+  // return this manifest's id for that layout — not a trap.
+  it('is false when at least one entry is compatible: true', () => {
+    const manifest = validManifest({
+      id: 'mor-2054-guard-has-true',
+      layoutCompatibility: [{ layoutId: 'desktop-v2', compatible: true }],
+    });
+    expect(declaresNoLayoutCompatibility(manifest)).toBe(false);
+  });
+
+  // Mixed case: a real false opt-out alongside a real true entry is a normal,
+  // intentional manifest (this is fieldline's actual shape) — must stay false.
+  it('is false for a mix of compatible: false and compatible: true entries', () => {
+    const manifest = validManifest({
+      id: 'mor-2054-guard-mixed',
+      layoutCompatibility: [
+        { layoutId: 'dual-receiver-cockpit', compatible: false, reason: 'too dense' },
+        { layoutId: 'desktop-v2', compatible: true },
+      ],
+    });
+    expect(declaresNoLayoutCompatibility(manifest)).toBe(false);
+  });
+});
+
+describe('guardLayoutCompatibility', () => {
+  it('passes a manifest through unchanged (same reference), whether or not it warns', () => {
+    const empty = validManifest({ id: 'mor-2054-guard-passthrough-empty', layoutCompatibility: [] });
+    const normal = validManifest({
+      id: 'mor-2054-guard-passthrough-normal',
+      layoutCompatibility: [{ layoutId: 'desktop-v2', compatible: true }],
+    });
+    expect(guardLayoutCompatibility(empty)).toBe(empty);
+    expect(guardLayoutCompatibility(normal)).toBe(normal);
+  });
+
+  it('warns once, naming the manifest id, for a manifest that declares nothing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manifest = validManifest({ id: 'mor-2054-guard-warns', layoutCompatibility: [] });
+
+    guardLayoutCompatibility(manifest);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('mor-2054-guard-warns');
+    expect(warn.mock.calls[0][0]).toContain('will not activate for any layout');
+    warn.mockRestore();
+  });
+
+  it('stays silent for a normal manifest that declares at least one compatible: true entry', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manifest = validManifest({
+      id: 'mor-2054-guard-silent',
+      layoutCompatibility: [{ layoutId: 'desktop-v2', compatible: true }],
+    });
+
+    guardLayoutCompatibility(manifest);
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // "One-time": kills a regression that re-warns on every call for the same
+  // id (e.g. a re-registration during HMR, or a sibling test file
+  // re-registering the same id under the shared `fast`-pool registry).
+  it('warns only once per manifest id across repeated calls', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manifest = validManifest({ id: 'mor-2054-guard-dedup', layoutCompatibility: [] });
+
+    guardLayoutCompatibility(manifest);
+    guardLayoutCompatibility(manifest);
+    guardLayoutCompatibility({ ...manifest }); // same id, different object identity
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  // Proves the guard is actually called from registerDesignLanguage — not
+  // just correct in isolation. Without this, a future edit could drop the
+  // `guardLayoutCompatibility(...)` call from `contract.ts` and every test
+  // above would keep passing while production went back to silent.
+  it('is wired into registerDesignLanguage', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/presentation/languages/contract.ts'), 'utf8');
+    expect(source).toMatch(/registry\.set\(\s*manifest\.id,\s*guardLayoutCompatibility\(\s*manifest\s*\)\s*\)/);
+  });
+});

--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -1,0 +1,85 @@
+/**
+ * MOR-2054 — repo-side twin of `layout-compatibility-guard.test.ts`'s dev
+ * warning: that file protects a THIRD-PARTY author who ships a manifest
+ * declaring no layout compatibility; this file protects THIS repository by
+ * failing the suite outright if any manifest actually shipped here does.
+ *
+ * Mirrors `../../layouts/__tests__/loader-identity-inventory.test.ts`'s
+ * discipline: the manifest list is derived structurally from the barrel's
+ * own export surface, not hand-listed — hand-listing manifest ids here
+ * would be the exact defect MOR-2054 exists to remove (a list that silently
+ * stops matching reality the moment someone adds a manifest and forgets to
+ * update the list).
+ *
+ * Deliberately NOT sourced from `listDesignLanguageIds()`/the live registry:
+ * `contract.ts`'s registry is module-scope, private, mutable state that
+ * sibling test files write throwaway entries into via `registerDesignLanguage`
+ * (e.g. `registry.test.ts`'s "no hardcoded family count" case registers a
+ * `thirdline` id built from `fixtures.ts`'s `validManifest()`, whose default
+ * `layoutCompatibility` is `[]`) — the same class of shared cross-file state
+ * `loader-identity-inventory.test.ts` measured as polluting a registry-sourced
+ * list for the analogous layout registry (22 ids instead of 6, that file's
+ * own comment). Probed directly for this file before writing it (running this
+ * directory, and separately the whole `src/presentation/` tree, under
+ * `--no-file-parallelism` with `listDesignLanguageIds()`): this specific
+ * registry did not currently show `thirdline` leaking across files in either
+ * run, so the risk is not currently observed here — but relying on that would
+ * make correctness depend on vitest's module-sharing behavior under
+ * `isolate: false` never changing and no sibling file ever registering a
+ * colliding id, neither of which this file can pin. The barrel's own export
+ * surface depends on none of that, costs nothing extra to use instead, and
+ * needs no `*.isolated.test.ts` escape hatch (unlike
+ * `loader-identity-inventory.test.ts`, which additionally proves
+ * REGISTRATION identity via `getLayout(id)` — a registry read this file has
+ * no need for, since `declaresNoLayoutCompatibility` is a pure structural
+ * check on the manifest object itself).
+ */
+import { describe, expect, it } from 'vitest';
+import { declaresNoLayoutCompatibility } from '../layout-compatibility-guard';
+import type { DesignLanguageManifest } from '../contract';
+// Namespace import of the declarations barrel, used ONLY to derive the
+// manifest list structurally — never to register anything beyond what
+// importing the barrel already does as a side effect (`registerDesignLanguage`
+// calls at its own module scope).
+import * as languageDeclarationsBarrel from '../declarations';
+
+/** Structural `DesignLanguageManifest` guard for filtering the barrel's
+ *  export surface — every export the barrel currently has IS a manifest,
+ *  but this keeps the derivation honest against a future non-manifest
+ *  export (a helper constant, a re-exported type) landing in the same file
+ *  without silently corrupting the set below. */
+function isDesignLanguageManifest(value: unknown): value is DesignLanguageManifest {
+  return (
+    typeof value === 'object' && value !== null &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    typeof (value as { displayName?: unknown }).displayName === 'string' &&
+    Array.isArray((value as { layoutCompatibility?: unknown }).layoutCompatibility) &&
+    typeof (value as { renderers?: unknown }).renderers === 'object'
+  );
+}
+
+/** Every manifest the barrel exports, derived structurally rather than
+ *  hand-listed (see module doc). */
+const SHIPPED_MANIFESTS: readonly DesignLanguageManifest[] =
+  Object.values(languageDeclarationsBarrel).filter(isDesignLanguageManifest);
+
+describe('every shipped design-language manifest declares at least one compatible layout (MOR-2054)', () => {
+  // Guards the derivation itself: if the barrel filter ever matched nothing
+  // (a broken import, an over-strict guard), every test below would pass
+  // vacuously — this is the check that stays honest about that.
+  it('finds at least one manifest to check', () => {
+    expect(SHIPPED_MANIFESTS.length).toBeGreaterThan(0);
+  });
+
+  it.each(SHIPPED_MANIFESTS.map((manifest) => [manifest.id, manifest] as const))(
+    '"%s" declares at least one layoutCompatibility entry with compatible: true',
+    (_id, manifest) => {
+      // Kills: a shipped manifest whose layoutCompatibility is empty, or
+      // holds only compatible: false entries — either way
+      // designLanguageActivation can never return this manifest's id, for
+      // any layout, silently. See layout-compatibility-guard.ts for the
+      // full empty-vs-no-true reasoning this predicate encodes.
+      expect(declaresNoLayoutCompatibility(manifest)).toBe(false);
+    },
+  );
+});

--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -5,34 +5,40 @@
  * failing the suite outright if any manifest actually shipped here does.
  *
  * Mirrors `../../layouts/__tests__/loader-identity-inventory.test.ts`'s
- * discipline: the manifest list is derived structurally from the barrel's
- * own export surface, not hand-listed — hand-listing manifest ids here
- * would be the exact defect MOR-2054 exists to remove (a list that silently
- * stops matching reality the moment someone adds a manifest and forgets to
- * update the list).
+ * completeness-check discipline specifically: like that file's own
+ * `BARREL_MANIFESTS` derivation, the manifest list here is derived
+ * structurally from the barrel's own export surface, not hand-listed —
+ * hand-listing manifest ids here would be the exact defect MOR-2054 exists
+ * to remove (a list that silently stops matching reality the moment someone
+ * adds a manifest and forgets to update the list). That file's separate
+ * `ALL_MANIFESTS`/`EXPECTED_LOADER_SPECIFIER` tables are, by contrast,
+ * hand-listed literals by design (that file's own comment says so) — used
+ * only for per-id loader-specifier pinning, a check this file has no need
+ * for.
  *
  * Deliberately NOT sourced from `listDesignLanguageIds()`/the live registry:
  * `contract.ts`'s registry is module-scope, private, mutable state that
  * sibling test files write throwaway entries into via `registerDesignLanguage`
  * (e.g. `registry.test.ts`'s "no hardcoded family count" case registers a
  * `thirdline` id built from `fixtures.ts`'s `validManifest()`, whose default
- * `layoutCompatibility` is `[]`) — the same class of shared cross-file state
- * `loader-identity-inventory.test.ts` measured as polluting a registry-sourced
- * list for the analogous layout registry (22 ids instead of 6, that file's
- * own comment). Probed directly for this file before writing it (running this
- * directory, and separately the whole `src/presentation/` tree, under
- * `--no-file-parallelism` with `listDesignLanguageIds()`): this specific
- * registry did not currently show `thirdline` leaking across files in either
- * run, so the risk is not currently observed here — but relying on that would
- * make correctness depend on vitest's module-sharing behavior under
- * `isolate: false` never changing and no sibling file ever registering a
- * colliding id, neither of which this file can pin. The barrel's own export
- * surface depends on none of that, costs nothing extra to use instead, and
- * needs no `*.isolated.test.ts` escape hatch (unlike
- * `loader-identity-inventory.test.ts`, which additionally proves
- * REGISTRATION identity via `getLayout(id)` — a registry read this file has
- * no need for, since `declaresNoLayoutCompatibility` is a pure structural
- * check on the manifest object itself).
+ * `layoutCompatibility` is `[]`). Measured 2026-08-31: the shared layout
+ * registry returns extra ids under `isolate: false` when sibling suites
+ * register probe manifests — the same class of shared cross-file state this
+ * file's own registry is exposed to. Probed directly for THIS file before
+ * writing it (running this directory, and separately the whole
+ * `src/presentation/` tree, under `--no-file-parallelism` with
+ * `listDesignLanguageIds()`): this specific registry did not currently show
+ * `thirdline` leaking across files in either run, so the risk is not
+ * currently observed here — but relying on that would make correctness
+ * depend on vitest's module-sharing behavior under `isolate: false` never
+ * changing and no sibling file ever registering a colliding id, neither of
+ * which this file can pin. The barrel's own export surface depends on none
+ * of that, costs nothing extra to use instead, and needs no
+ * `*.isolated.test.ts` escape hatch (unlike `loader-identity-inventory.test.ts`,
+ * which additionally proves REGISTRATION identity via `getLayout(id)` — a
+ * registry read this file has no need for, since
+ * `declaresNoLayoutCompatibility` is a pure structural check on the manifest
+ * object itself).
  */
 import { describe, expect, it } from 'vitest';
 import { declaresNoLayoutCompatibility } from '../layout-compatibility-guard';

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -17,6 +17,7 @@
  * needs the real `semantic/` unions, so it lives in the sibling module
  * `./state-vocabulary.ts` instead of here.
  */
+import { guardLayoutCompatibility } from './layout-compatibility-guard';
 
 /**
  * Naming policy (MOR-977 §4.6, MOR-1071): kebab-case, no vendor/model
@@ -176,10 +177,18 @@ export function validateManifest(manifest: DesignLanguageManifest): void {
 
 const registry = new Map<string, DesignLanguageManifest>();
 
-/** Validates then registers `manifest`. Re-registering an ID overwrites it. */
+/**
+ * Validates then registers `manifest`. Re-registering an ID overwrites it.
+ *
+ * `guardLayoutCompatibility` (MOR-2054) is a dev-only, pass-through check:
+ * it never throws and never changes `manifest`, so it has no effect on
+ * validation, registration, or on what `designLanguageActivation` later
+ * returns for this manifest — see that module's doc comment for what it
+ * warns about and why this is the one place every manifest passes through.
+ */
 export function registerDesignLanguage(manifest: DesignLanguageManifest): void {
   validateManifest(manifest);
-  registry.set(manifest.id, manifest);
+  registry.set(manifest.id, guardLayoutCompatibility(manifest));
 }
 export function getDesignLanguage(id: string): DesignLanguageManifest | undefined {
   return registry.get(id);

--- a/frontend/src/presentation/languages/layout-compatibility-guard.ts
+++ b/frontend/src/presentation/languages/layout-compatibility-guard.ts
@@ -1,0 +1,94 @@
+/**
+ * Dev-only author-facing warning for MOR-2054.
+ *
+ * `designLanguageActivation` (`../workspace/activation.ts`) activates a
+ * design language for a layout ONLY on an explicit `{compatible: true}`
+ * entry in that language's `layoutCompatibility` for that layout id; any
+ * other shape — no matching entry, or a matching `compatible: false` entry —
+ * resolves to `null`, silently. A manifest whose `layoutCompatibility` has
+ * no `compatible: true` entry AT ALL therefore can never activate for ANY
+ * layout: every lookup `designLanguageActivation` ever performs against it
+ * returns `null`. Nothing before this ticket told the author that.
+ *
+ * Owner ruling, 2026-08-31 (MOR-2054): keep the fail-closed behaviour —
+ * `designLanguageActivation`'s return values are unchanged by this file —
+ * but stop it being silent. Making the field mandatory was considered and
+ * rejected.
+ *
+ * EMPTY VS. "NO TRUE ENTRY": `declaresNoLayoutCompatibility` below fires on
+ * an empty `layoutCompatibility` array AND on a non-empty one containing
+ * only `compatible: false` entries. Both shapes are the identical failure
+ * under `designLanguageActivation`: `[].find(...)` and
+ * `[{compatible:false}, ...].find((e) => e.layoutId === layoutId)` both
+ * either miss or resolve to `compatible !== true`, so the language never
+ * activates for any layout either way — there is no "compatible by default
+ * unless excepted" fallback anywhere in `designLanguageActivation` for an
+ * all-`false` list to fall back on. The ticket's own trap scenario is an
+ * author reading `layoutCompatibility` as opt-out ("declare only your
+ * exceptions") and expecting unlisted or excepted layouts to default to
+ * compatible; a manifest that declares only `false` entries under that same
+ * misreading hits exactly the same silent dead end as one that declares
+ * nothing, so both must warn.
+ *
+ * WHERE THIS IS WIRED: `registerDesignLanguage` (`./contract.ts`) is the
+ * one choke point every manifest passes through — the two built-in
+ * families (`./declarations.ts`) and any third-party skin's manifest
+ * alike — so guarding there, once, covers every manifest that will ever
+ * reach `designLanguageActivation`. Unlike `guardRadioViewModel`
+ * (`components-v2/wiring/radio-view-model-guard.ts`, MOR-2040), no eslint
+ * layering boundary forces this guard into a different directory than the
+ * type and function it checks: `presentation/languages/` carries no import
+ * restriction that `contract.ts` itself doesn't already satisfy, so this
+ * file lives alongside it. The shape is otherwise the same: a thin,
+ * dev-only, pass-through wrapper gated on `import.meta.env.DEV` (Vite's
+ * dev/test-vs-production flag, defaulting to `true` under Vitest) around
+ * the one production seam.
+ *
+ * PRODUCTION STRIPPING: a one-off `vite build` for this change (MOR-2054 PR)
+ * found zero occurrences of this file's warning text or either exported
+ * function name anywhere under `dist/` — the same `import.meta.env.DEV`-
+ * literal + dead-code-elimination treatment MOR-2040 confirmed for
+ * `guardRadioViewModel`. That was a point-in-time check, not a standing CI
+ * gate — that guarantee is a property of the build config, not something a
+ * `vitest` run can observe, so re-run `npm run build && grep -rn
+ * "will not activate for any layout" dist/` after touching this file or the
+ * build config if the guarantee matters again.
+ */
+import type { DesignLanguageManifest } from './contract';
+
+/**
+ * True iff `manifest.layoutCompatibility` contains no entry with
+ * `compatible === true` — the exact condition under which
+ * `designLanguageActivation` can never return this manifest's id, for any
+ * layout. Pure; used both by `guardLayoutCompatibility` below and by the
+ * repo-wide inventory test that checks every manifest actually shipped in
+ * this repository.
+ */
+export function declaresNoLayoutCompatibility(manifest: DesignLanguageManifest): boolean {
+  return !manifest.layoutCompatibility.some((entry) => entry.compatible === true);
+}
+
+/** Manifest ids already warned about, so a re-registration (e.g. HMR, or a
+ *  test file re-registering the same id) does not spam the console. Warning
+ *  state only — never consulted by `declaresNoLayoutCompatibility` or by
+ *  activation, so it cannot change which manifests are flagged, only how
+ *  many times each is reported. */
+const warnedIds = new Set<string>();
+
+/**
+ * Pass-through: always returns `manifest` unchanged, and never throws.
+ * In dev, warns once per manifest id when `declaresNoLayoutCompatibility`
+ * is true. The message states only what `designLanguageActivation` actually
+ * does today — no claim about future behaviour.
+ */
+export function guardLayoutCompatibility(manifest: DesignLanguageManifest): DesignLanguageManifest {
+  if (import.meta.env.DEV && declaresNoLayoutCompatibility(manifest) && !warnedIds.has(manifest.id)) {
+    warnedIds.add(manifest.id);
+    console.warn(
+      `[rigplane] design language "${manifest.id}" declares no layoutCompatibility entry with ` +
+        'compatible: true — it will not activate for any layout. Declare the layouts it supports, ' +
+        `e.g. layoutCompatibility: [{ layoutId: '<id>', compatible: true }].`,
+    );
+  }
+  return manifest;
+}

--- a/frontend/src/presentation/workspace/__tests__/legacy-readers-purity.isolated.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/legacy-readers-purity.isolated.test.ts
@@ -99,6 +99,10 @@ describe('legacy workspace readers are read-only (MOR-1078)', () => {
   it('the closure is exactly the reader plus the two pure presentation contracts', () => {
     expect(closure(ENTRY).sort()).toEqual([
       'src/presentation/languages/contract.ts',
+      // MOR-2054: dev-only, pass-through guard `contract.ts` calls from
+      // `registerDesignLanguage` — imports nothing but `contract.ts` itself
+      // (type-only), so it is pure and belongs in this closure too.
+      'src/presentation/languages/layout-compatibility-guard.ts',
       'src/presentation/layouts/contract.ts',
       'src/presentation/workspace/contract.ts',
       ENTRY,

--- a/frontend/src/presentation/workspace/__tests__/legacy-readers-purity.isolated.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/legacy-readers-purity.isolated.test.ts
@@ -96,7 +96,7 @@ describe('legacy workspace readers are read-only (MOR-1078)', () => {
   });
 
   // ── Pin 3: structural, transitive over the enumerated closure ───────────
-  it('the closure is exactly the reader plus the two pure presentation contracts', () => {
+  it('the closure is exactly the reader plus the two pure presentation contracts and the layout-compatibility guard', () => {
     expect(closure(ENTRY).sort()).toEqual([
       'src/presentation/languages/contract.ts',
       // MOR-2054: dev-only, pass-through guard `contract.ts` calls from

--- a/frontend/src/presentation/workspace/__tests__/purity.isolated.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/purity.isolated.test.ts
@@ -96,7 +96,7 @@ describe('the workspace contract is pure at load (MOR-1077)', () => {
   });
 
   // ── Pin 2: structural, transitive over the enumerated closure ───────────
-  it('the closure is exactly the contract plus the two pure presentation contracts', () => {
+  it('the closure is exactly the contract plus the two pure presentation contracts and the layout-compatibility guard', () => {
     expect(closure(ENTRY).sort()).toEqual([
       'src/presentation/languages/contract.ts',
       // MOR-2054: dev-only, pass-through guard `contract.ts` calls from

--- a/frontend/src/presentation/workspace/__tests__/purity.isolated.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/purity.isolated.test.ts
@@ -99,6 +99,10 @@ describe('the workspace contract is pure at load (MOR-1077)', () => {
   it('the closure is exactly the contract plus the two pure presentation contracts', () => {
     expect(closure(ENTRY).sort()).toEqual([
       'src/presentation/languages/contract.ts',
+      // MOR-2054: dev-only, pass-through guard `contract.ts` calls from
+      // `registerDesignLanguage` — imports nothing but `contract.ts` itself
+      // (type-only), so it is pure and belongs in this closure too.
+      'src/presentation/languages/layout-compatibility-guard.ts',
       'src/presentation/layouts/contract.ts',
       ENTRY,
     ].sort());

--- a/frontend/src/presentation/workspace/__tests__/store-purity.isolated.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/store-purity.isolated.test.ts
@@ -101,7 +101,7 @@ describe('the workspace store is inert until it is initialised (MOR-1079)', () =
     expect([...keys].sort()).toEqual(['rigplane:workspace', 'rigplane:workspace-migrated:v1']);
   });
 
-  it('the closure is the store, the repository and the three pure contracts', () => {
+  it('the closure is the store, the repository, the three pure contracts and the layout-compatibility guard', () => {
     expect(closure(ENTRY).sort()).toEqual([
       'src/presentation/languages/contract.ts',
       // MOR-2054: dev-only, pass-through guard `contract.ts` calls from

--- a/frontend/src/presentation/workspace/__tests__/store-purity.isolated.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/store-purity.isolated.test.ts
@@ -104,6 +104,10 @@ describe('the workspace store is inert until it is initialised (MOR-1079)', () =
   it('the closure is the store, the repository and the three pure contracts', () => {
     expect(closure(ENTRY).sort()).toEqual([
       'src/presentation/languages/contract.ts',
+      // MOR-2054: dev-only, pass-through guard `contract.ts` calls from
+      // `registerDesignLanguage` — imports nothing but `contract.ts` itself
+      // (type-only), so it is pure and belongs in this closure too.
+      'src/presentation/languages/layout-compatibility-guard.ts',
       'src/presentation/layouts/contract.ts',
       'src/presentation/workspace/contract.ts',
       'src/presentation/workspace/legacy-readers.ts',


### PR DESCRIPTION
## ⚠️ Ticket-number discrepancy — read before merging

This work was dispatched to me as **"Ticket: MOR-2054"** with branch name
`codex/mor-2054-empty-compatibility-is-loud`. I verified against Linear before
posting anything and **MOR-2054 is a different, already-Done issue**:
"Adding a skin requires editing 13+ hand-listed sites, and thirteen of them
fail silently," resolved by **deleting** the dead `layoutCompatibility` reader
in `frontend/src/presentation/layouts/compatibility.ts` (PR #2882, branch
`codex/mor-2054-dead-compatibility-reader`, already pushed to origin). That is
unrelated to — and the opposite kind of change from — this PR, which *adds* a
warning to a live, different mechanism
(`presentation/languages/contract.ts`'s `layoutCompatibility` field). I
searched Linear for any issue matching this task's described "owner ruling"
(empty-compatibility warning, fail-closed-but-loud, mandatory-field rejected)
and found none; MOR-2059 and MOR-2060 do not exist either.

Because Linear's GitHub sync appears to auto-attach PRs to the issue named in
their branch/title, I deliberately **did not** use "MOR-2054" in this branch
name or PR title (the local commit message still says `(MOR-2054)` — written
before I'd verified — but per repo convention this branch squash-merges under
this PR's title, so that stray reference should not survive into `main`'s
history). I also **did not** post the "record the ruling" comment my task
asked for, since MOR-2054 is the wrong target and I have no correct issue
number to use instead. **Please file the right ticket (or tell me the
correct number) and link it here** — the code and tests below stand on their
own regardless of ticket number.

---

## What this does

`designLanguageActivation` (`frontend/src/presentation/workspace/activation.ts`)
activates a design language for a layout only on an explicit
`{compatible: true}` `layoutCompatibility` entry; any other shape resolves to
`null`, silently. A manifest that declares no `compatible: true` entry at all
therefore can never activate for any layout — until now, with no warning.

**Owner ruling being implemented** (as given in my task, dated 2026-08-31):
keep the fail-closed behaviour of `designLanguageActivation` unchanged, but
stop the failure being silent — emit a dev-only warning. Making the field
mandatory was considered and rejected.

## Reused vs. written new

- **Reused the MOR-2040 dev-guard pattern** (`components-v2/wiring/radio-view-model-guard.ts`):
  same `import.meta.env.DEV` gate, same thin pass-through-wrapper shape, same
  "point-in-time build+grep" production-stripping verification method. New
  file: `frontend/src/presentation/languages/layout-compatibility-guard.ts`
  (`guardLayoutCompatibility`, `declaresNoLayoutCompatibility`) — wired into
  the one choke point every manifest passes through,
  `contract.ts: registerDesignLanguage`.
- **Reused the loud-enumeration pattern** (`presentation/layouts/__tests__/loader-identity-inventory.test.ts`):
  new repo-side test derives its manifest list structurally from the
  `declarations.ts` barrel rather than hand-listing ids.
- **Checked the `*.isolated.test.ts` registry escape hatch** and did not need
  it: the new inventory test never reads the live registry (it works off the
  barrel + a pure predicate), so it needs no isolation. I probed
  `listDesignLanguageIds()` for cross-file pollution the way the escape-hatch
  note describes (measured for the *layout* registry at 22 ids instead of 6)
  and did **not** reproduce it for the *design-language* registry in this
  repo today — documented as a probed-not-assumed fact in the test's own
  comment, not carried forward as a guaranteed property.
- **Reused `fixtures.ts`'s `validManifest()`** fixture builder in both new
  test files instead of hand-rolling manifest literals.

## Empty vs. "no true entry" — decision and justification

The guard fires when `layoutCompatibility` has **no** `compatible: true`
entry — covering both an empty array and an array containing only
`compatible: false` entries. Justification: `designLanguageActivation`
treats both shapes identically (`.find(...)` either misses or resolves to
`compatible !== true`; there is no "compatible by default unless excepted"
fallback anywhere in that function). The ticket's own trap scenario is an
author reading the field as opt-out ("declare only your exceptions") and
expecting unlisted/excepted layouts to default to compatible — a manifest
declaring only `false` entries under that same misreading hits the exact same
silent dead end as an empty one, so both must warn.

## Negative control (mandatory, per task)

**A — guard unit tests**, neutered the guard's `if` condition
(`if (false && import.meta.env.DEV && ...)`), reran
`layout-compatibility-guard.test.ts`:
```
❯ warns once, naming the manifest id, for a manifest that declares nothing
  AssertionError: expected "warn" to be called 1 times, but got 0 times
❯ warns only once per manifest id across repeated calls
  AssertionError: expected "warn" to be called 1 times, but got 0 times
Test Files  1 failed (1)
     Tests  2 failed | 7 passed (9)
```
Reverted the one-line neuter, reran: `9 passed (9)`. `git diff` on the guard
source after revert: empty.

**B — repo inventory test**, temporarily set `studioline.layoutCompatibility`
to `[]` in `declarations.ts`, reran `layout-compatibility-inventory.test.ts`:
```
stderr: [rigplane] design language "studioline" declares no layoutCompatibility
entry with compatible: true — it will not activate for any layout. ...
❯ "studioline" declares at least one layoutCompatibility entry with compatible: true
  AssertionError: expected true to be false
Test Files  1 failed (1)
     Tests  1 failed | 2 passed (3)
```
(The dev warning from A fired live on this same broken input.) Reverted via
`git checkout -- declarations.ts`; `git diff` on that file: empty. Reran:
`3 passed (3)`.

## Production-bundle evidence

`npm run build` succeeded (4177 modules, `dist/` produced). Grepped every
file under `dist/` for the warning text fragments
(`"will not activate for any layout"`, `"declares no layoutCompatibility"`)
and both exported function names (`guardLayoutCompatibility`,
`declaresNoLayoutCompatibility`): **zero hits** across all 35 asset files —
not a byte-identical diff comparison, just the same grep-based proof MOR-2040
used, showing the dev-only branch and its warning text are absent from the
production bundle.

## Test / lint output

- `npx vitest run src/presentation/`: **56 files / 1029 tests passed**
  (includes 12 new tests: 9 guard unit tests + 3 inventory tests).
- `npx eslint src/presentation/`: clean, zero violations.
- `npm run check` (`svelte-check` + `tsc`): 4606 files, 0 errors, 0 warnings.

## Also touched: 3 stale purity-closure pins

Adding the new (pure) guard file to `contract.ts`'s import graph broke three
MOR-1077/1078/1079 workspace-purity tests that hand-pin the exact transitive
closure (`purity.isolated.test.ts`, `legacy-readers-purity.isolated.test.ts`,
`store-purity.isolated.test.ts`) — each now lists
`src/presentation/languages/layout-compatibility-guard.ts` alongside the
existing `languages/contract.ts` entry. I swept for every copy of this
closure-pinning pattern (`grep -rl "function closure("`) and confirmed these
are the only three; no other instance needed the same fix.

## Guardrail numbers

**7 files changed, 328 insertions(+), 2 deletions(-)** (330 changed lines).
Under the hard ceiling (10 files / 1000 lines). Over the soft file-count
threshold (7 > 6, lines well under 600): justified as one unit of work
because 3 of the 7 files are the purity-pin fixes that *this same change*
mechanically invalidated (not optional, not separable — leaving them stale
would fail the standard test command) and the other 4 are the guard, its
wiring, and its two test files.

## Not done

- Did not run the Python suite (out of scope; not touched).
- Did not post to Linear — see the discrepancy note at the top.
- Did not touch `frontend/src/presentation/layouts/compatibility.ts` or its
  test (the concurrent PR #2882's territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
