### PR TITLE
test(MOR-2060): derive the forward-declaration inventory from the barrel

### DIFF
--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -33,17 +33,39 @@ import type { LayoutManifest } from '../contract';
 // Barrel-only — the M7 lesson, restated on every family in this directory:
 // importing a manifest module directly fires `registerLayout` from this file
 // and, under the fast pool's `isolate: false`, leaks the registration into
-// sibling files.
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+// sibling files. Only `desktopV2Layout`/`sdrTestLayout` are referenced by
+// name below (`sharedShellMounts`, and the last test's spread); every other
+// manifest is reached only through the derived `ALL_MANIFESTS`.
+import { desktopV2Layout, sdrTestLayout } from '../declarations';
+// Namespace import of the SAME barrel, used ONLY to derive ALL_MANIFESTS
+// structurally — never to register anything (a namespace import has no side
+// effect beyond the module evaluation the named import above already
+// triggers). NOT `listLayoutIds()`: the fast pool's `isolate: false` (see
+// vite.config.ts) shares `contract.ts`'s module-scoped registry Map across
+// every test file in the run, and sibling suites (`registry.test.ts`,
+// `mobile-registration.test.ts`) register their own probe manifests into it
+// — `listLayoutIds()` would make this file's inventory depend on cross-file
+// execution order. The barrel's own export surface has no such cross-file
+// state. Same derivation as `loader-identity-inventory.test.ts`'s
+// `BARREL_MANIFESTS` (MOR-2060).
+import * as layoutDeclarationsBarrel from '../declarations';
 
-/** Every manifest currently registered by the barrel (mirrors F8's `REAL_LAYOUTS`). */
-const ALL_MANIFESTS: readonly LayoutManifest[] = [
-  sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  desktopV2Layout,
-];
+/** Structural `LayoutManifest` guard for filtering the barrel's export
+ *  surface — copied from `loader-identity-inventory.test.ts` verbatim. */
+function isLayoutManifest(value: unknown): value is LayoutManifest {
+  return (
+    typeof value === 'object' && value !== null &&
+    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    typeof (value as { loader?: unknown }).loader === 'function'
+  );
+}
+
+/** Every manifest currently registered by the barrel (mirrors F8's
+ *  `REAL_LAYOUTS`), derived from the barrel's own export surface instead of
+ *  hand-listed (MOR-2060) — see the namespace-import comment above. */
+const ALL_MANIFESTS: readonly LayoutManifest[] =
+  Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest);
 
 /** The set this whole file exists to keep honest — see the header comment. */
 const EXPECTED_FORWARD_DECLARED: readonly string[] = [];


### PR DESCRIPTION
## Summary

MOR-2060 (group G2 from the parent forward-declaration audit): `forward-declaration-inventory.test.ts: ALL_MANIFESTS` was a hand-listed copy of the six registered layout manifests. It is now derived from `presentation/layouts/declarations.ts`'s own export surface:

```ts
import * as layoutDeclarationsBarrel from '../declarations';

function isLayoutManifest(value: unknown): value is LayoutManifest {
  return (
    typeof value === 'object' && value !== null &&
    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
    typeof (value as { id?: unknown }).id === 'string' &&
    typeof (value as { loader?: unknown }).loader === 'function'
  );
}

const ALL_MANIFESTS: readonly LayoutManifest[] =
  Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest);
```

Same shape as `loader-identity-inventory.test.ts`'s existing `BARREL_MANIFESTS`, per the ticket's instruction to copy it rather than invent a new one. Deliberately **not** `presentation/layouts/contract.ts: listLayoutIds` — that reads a module-scoped registry Map shared across the suite under `isolate: false`, with test-side `registerLayout` calls from siblings (`registry.test.ts`, `mobile-registration.test.ts`) on top of the 6 production ones, which would make an absolute assertion on it execution-order-dependent.

`DOM_BACKED` and `EXPECTED_FORWARD_DECLARED` are untouched, as instructed — they carry per-skin facts no registry holds. Confirmed by direct reading that `DOM_BACKED`'s completeness guard (the file's first `it`) does exist and does assert `Object.hasOwn(DOM_BACKED, m.id)` for every manifest.

The derived set is exactly the 6 ids the barrel exports, matching the removed hand list one-for-one, and none of the file's three assertions depend on `ALL_MANIFESTS`'s array order (the forward-declared check sorts before comparing; the other two iterate per-item independently) — so neither STOP condition about set-mismatch or order-dependence applies.

## Negative control

Removing a manifest's barrel export does **not** turn this file red — none of its three assertions check `ALL_MANIFESTS` completeness against an independent source; that job belongs to `loader-identity-inventory.test.ts`, which *did* go red correctly. Full account of both mutations tried is in the PR discussion / builder report below. The direction this file's own `DOM_BACKED` guard actually defends — a manifest **added** to the barrel with no probe — goes red cleanly, naming the offender:

```
FAIL forward-declaration-inventory.test.ts > ... > every registered manifest has an asserted DOM-backing proof
AssertionError: no DOM-backing proof registered for "mor-2060-negative-control": expected false to be true
```

All mutations were reverted; `git diff -- frontend/src/presentation/layouts/declarations.ts` is empty and the target test is green again (4/4).

## Test plan

Both required from `frontend/`, FOREGROUND, real output:

- [x] `npx vitest run src/presentation/layouts/` — **26 files / 327 tests passed**
- [x] `npx vitest run src/presentation/layouts/ src/presentation/workspace/` — **36 files / 632 tests passed** (worker-independence: same layouts results whether or not `workspace/` shares the run)
- [x] `npx eslint src/presentation/` — clean, exit 0
- [x] `npm run check` — `4601 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`, exit 0
- [x] Negative control (both directions, see above), reverted, `git diff` clean

**Not run**: the full frontend suite and the full Python suite — out of scope for this change (no Python touched) and the frontend suite exceeds the foreground cap. **The full CI pipeline and an independent agent review are still pending** — this PR should not be treated as verified beyond the scoped runs above until both land.

## Guardrails

1 file changed, 42 changed lines (32 insertions + 10 deletions) — within the 2 files / 80 changed lines budget the ticket set.

## Noticed, not touched

- The other declarability test files (`rf-front-end-declarability.test.ts`, `ritxit-scan-declarability.test.ts`, and siblings) each carry their own hand-listed `ALL`/`REAL_LAYOUTS`-style table with the same shape this ticket removes — that is MOR-2061's twelve-instance sweep, out of scope here.
- `presentation/languages/` has a PR in flight elsewhere; not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
