### PR TITLE
test(MOR-2063): type the presentation-switch width table so a missing skin fails the check

### DIFF
--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -142,8 +142,9 @@ import TxControllerProbe from '../lib/runtime/tx-controller/__tests__/support/Tx
 import type { AppTxController } from '../lib/runtime/tx-controller/app-host';
 
 /** Viewport width → skin id. Reuses App's own resize reactivity as the knob. */
-const WIDTH_FOR: Record<string, number> = {
+const WIDTH_FOR: Record<SkinId, number> = {
   'desktop-v2': 1200,
+  'dual-receiver-cockpit': 1500,
   'lcd-cockpit': 1000,
   'lcd-scope': 900,
   'sdr-test': 1400,


### PR DESCRIPTION
## What

`WIDTH_FOR` in `presentation-switch-tx.component.test.ts` was typed
`Record<string, number>` and covered only five of the six `SkinId` values —
`dual-receiver-cockpit` was silently missing, and nothing noticed. The
sibling file, `presentation-switch-resources.component.test.ts`, already
types its own `WIDTH_FOR` as `Record<SkinId, number>`, which makes an
omitted skin a type error instead of a silent gap.

This PR types the first table the same way and adds the missing entry.
This is a relocation-to-loudness, not a derivation: the widths are
arbitrary human choices for driving `window.innerWidth` in the test harness,
not registry facts, so none of the existing values were touched or computed
from anything.

Before/after:

```ts
// before
const WIDTH_FOR: Record<string, number> = {
  'desktop-v2': 1200,
  'lcd-cockpit': 1000,
  'lcd-scope': 900,
  'sdr-test': 1400,
  'mobile': 390,
};

// after
const WIDTH_FOR: Record<SkinId, number> = {
  'desktop-v2': 1200,
  'dual-receiver-cockpit': 1500,
  'lcd-cockpit': 1000,
  'lcd-scope': 900,
  'sdr-test': 1400,
  'mobile': 390,
};
```

`SkinId` was already imported in this file (`import type { SkinId } from
'../skins/registry';`) for other uses, so no new import or lint-boundary
crossing was needed.

## How the missing width was chosen

Not derived — read the sibling file's own `WIDTH_FOR` and matched it. The
sibling already carries `'dual-receiver-cockpit': 1500`, and every other
entry in the sibling's table is identical value-for-value to this file's
table (`desktop-v2` 1200, `lcd-cockpit` 1000, `lcd-scope` 900, `sdr-test`
1400, `mobile` 390 — all equal across both files). So `1500` isn't just
"consistent with the pattern," it's the exact value the sibling already
assigns to this skin. No human confirmation needed beyond normal review,
since this isn't a guess — it's copied from an existing, already-reviewed
source of truth for the same key.

## The gate that catches this class

Verified directly, not assumed:
- `frontend/tsconfig.app.json`: `"include": ["src/**/*.ts", "src/**/*.d.ts",
  "src/**/*.js", "src/**/*.svelte"]` — no exclude for `__tests__/` or
  `*.test.ts`, so test files are in svelte-check's scope.
- `frontend/package.json`: `"check": "svelte-check --tsconfig
  ./tsconfig.app.json && tsc -p tsconfig.node.json"` — this is what `npm
  run check` runs.
- `.github/workflows/quick.yml`: the `frontend` path filter is `frontend/**`,
  `src/rigplane/web/**`, `.github/workflows/quick.yml`; the `npm run check`
  step is gated on `steps.filter.outputs.frontend == 'true'`.

So `vitest run` does not catch a missing key here (plain object literal,
no exhaustiveness check at the call site), but `npm run check` does, and
since any change adding a skin must touch `frontend/**`, the `frontend`
filter — and therefore this check — always fires for this change class.

## Negative control (verbatim)

`npm run check` on the typed table, unmodified — PASS:

```
> svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json

1788188094799 START ".../frontend"
1788188094956 COMPLETED 4601 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

Deleted the `'dual-receiver-cockpit': 1500,` entry — FAIL, naming the exact
missing skin:

```
> svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json

1788188200070 START ".../frontend"
1788188200197 ERROR "src/__tests__/presentation-switch-tx.component.test.ts" 145:7 "Property '\"dual-receiver-cockpit\"' is missing in type '{ 'desktop-v2': number; 'lcd-cockpit': number; 'lcd-scope': number; 'sdr-test': number; mobile: number; }' but required in type 'Record<SkinId, number>'."
1788188200200 COMPLETED 4601 FILES 1 ERRORS 0 WARNINGS 1 FILES_WITH_PROBLEMS
```

Restored the entry — PASS again:

```
> svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json

1788188294795 START ".../frontend"
1788188294939 COMPLETED 4601 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

`git diff` after restoring — identical to the intended change, no residue
(confirmed byte-for-byte against the diff below).

## Other verification

- `npx vitest run src/__tests__/presentation-switch-tx.component.test.ts` —
  1 file, 4/4 tests pass.
- `npx vitest run src/__tests__/` (the file's directory) — 2 unrelated
  pre-existing timeout flakes (`control-feedback-debt-inventory.test.ts`,
  `control-feedback-ownership.test.ts`, both AST-scanning tests that exceed
  vitest's default 5000ms timeout under this worktree's parallel-worker
  contention). Reproduced identically with this diff fully reverted
  (stashed), so confirmed pre-existing and unrelated to this change; both
  files pass individually. Not touched, per scope.
- `npx eslint src/__tests__/presentation-switch-tx.component.test.ts` —
  exit 0, no output.

## Guardrails

1 file changed, 2 insertions(+), 1 deletion(-) — well under both the soft
threshold (6 files / 600 lines) and the hard ceiling (10 files / 1000
lines).

## Pending

Full suite is pending CI and independent verification — not run locally
per instructions (only this file's own directory was run here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
