### PR TITLE
docs(MOR-2064): correct five statements that are false against the code

### DIFF
--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -612,7 +612,7 @@ delegation wrappers that mount the layout components with a fixed
    - `lcd-scope` -> LCD Scope skin (IC-7300-style scope-dominant)
    - `standard` -> desktop-v2 skin
    - `sdr-test` -> SDR Screen test skin
-   - `auto` -> desktop-v2 when any scope is available, LCD Cockpit when no scope is available.
+   - `auto` -> desktop-v2 unconditionally (MOR-1097 cutover); scope availability does not affect this resolution.
 
 `normalizeLayoutMode()` (`lib/stores/layout.svelte.ts`) normalizes legacy
 persisted values so old localStorage entries keep resolving:
@@ -794,7 +794,7 @@ const sub = state.sub ?? null;
   PTT flow) are always active on a mobile-sized viewport; no query param or stored
   selection is required.
 - **Layout mode expectations:** layout preference (`rigplane-layout`) is capability-aware;
-  `auto` resolves to desktop-v2 only when any scope exists, otherwise LCD Cockpit is selected.
+  `auto` resolves to desktop-v2 unconditionally (MOR-1097 cutover); scope availability plays no part in it.
 - **System action error surfacing:** connect/disconnect/power actions in v2 call
   `runtime.system.*` and surface backend HTTP errors directly in the UI.
 - **Battery API availability:** polling slowdown on low battery is best-effort; browsers without

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -793,8 +793,9 @@ const sub = state.sub ?? null;
   the current (v2) skins-based UI. Mobile interactions (sheet/panel swipe, touch-first
   PTT flow) are always active on a mobile-sized viewport; no query param or stored
   selection is required.
-- **Layout mode expectations:** layout preference (`rigplane-layout`) is capability-aware;
-  `auto` resolves to desktop-v2 unconditionally (MOR-1097 cutover); scope availability plays no part in it.
+- **Layout mode expectations:** layout preference (`rigplane-layout`) resolution is not
+  capability-aware; `auto` resolves to desktop-v2 unconditionally (MOR-1097 cutover), and scope
+  availability plays no part in it.
 - **System action error surfacing:** connect/disconnect/power actions in v2 call
   `runtime.system.*` and surface backend HTTP errors directly in the UI.
 - **Battery API availability:** polling slowdown on low battery is best-effort; browsers without

--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -200,8 +200,9 @@ import { presentationResources, runtime } from '../lib/runtime/frontend-runtime'
 /**
  * The real per-skin resource plan. Mirrored rather than imported because
  * `skins/registry` is mocked here (its `loadSkin` must be controllable);
- * `assertPlanMirrorsProduction()` below fails if production ever diverges,
- * and `skins/__tests__/registry.test.ts` owns the plan's own pin.
+ * the `'mirrors the production per-skin resource plan'` test below fails
+ * if production ever diverges, and `skins/__tests__/registry.test.ts` owns
+ * the plan's own pin.
  */
 const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
   'desktop-v2': ['hardware-scope', 'audio-fft'],

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -121,12 +121,13 @@
   // `LeftSidebar`, `RightSidebar` and `StatusBar` (which each gate their own
   // panels on `!declared.has('<surface>')`), and the settings modal below —
   // this shell's own third copy of six of those panels — gates in place.
-  // Landed INERT: no manifest declares any of `filter`/`rfFrontEnd`/`band`/
-  // `antenna`/`ritXitScan`/`rxAudio`/`dsp`/`cwKeyer` yet, so every predicate
-  // is `false` and the rendered tree is unchanged until S6a/S7/S8/S9 declare
-  // the zones. The ONE exception is the modal's SPLIT/A↔B/A=B row, which
-  // gates on the ALREADY-TRUE `semanticDeck` (S10 §4 — a real, deliberate
-  // change, not inert plumbing).
+  // Landed INERT, then activated by S7/S8/S9 (MOR-1366/1367/1368): the
+  // desktop-v2 manifest now declares all of `filter`/`rfFrontEnd`/`band`/
+  // `antenna`/`ritXitScan`/`rxAudio`/`dsp`/`cwKeyer`, so every predicate
+  // above is live and the branches are reachable on that skin. Separately,
+  // the modal's SPLIT/A↔B/A=B row gates on `semanticDeck`, not on a
+  // `declared` zone (S10 §4 — a real, deliberate change, not inert
+  // plumbing).
   //
   // Same two rules as `semanticRxTx`/`semanticMeters`, restated because this
   // channel now carries them to three more files:

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -123,10 +123,10 @@
   // this shell's own third copy of six of those panels — gates in place.
   // Landed INERT, then activated by S7/S8/S9 (MOR-1366/1367/1368): the
   // desktop-v2 manifest now declares all of `filter`/`rfFrontEnd`/`band`/
-  // `antenna`/`ritXitScan`/`rxAudio`/`dsp`/`cwKeyer`, so every predicate
-  // above is live and the branches are reachable on that skin. Separately,
-  // the modal's SPLIT/A↔B/A=B row gates on `semanticDeck`, not on a
-  // `declared` zone (S10 §4 — a real, deliberate change, not inert
+  // `antenna`/`ritXitScan`/`rxAudio`/`dsp`/`cwKeyer`, so every one of those
+  // predicates is live and the branches are reachable on that skin.
+  // Separately, the modal's SPLIT/A↔B/A=B row gates on `semanticDeck`, not
+  // on a `declared` zone (S10 §4 — a real, deliberate change, not inert
   // plumbing).
   //
   // Same two rules as `semanticRxTx`/`semanticMeters`, restated because this
@@ -333,9 +333,9 @@
                  `hideScopeControls` is the MOR-1369 (S6b-1) suppression
                  channel: reuses the SAME `declared` set as `LeftSidebar`/
                  `RightSidebar`/`StatusBar` above (S6-pre, MOR-1364) rather
-                 than a second derivation. Landed INERT — no manifest
-                 declares a `scopeControls` zone yet, so this is always
-                 `false` today; S6b-2 wires the zone that flips it. -->
+                 than a second derivation. Landed INERT, then activated by
+                 S6b-2 (MOR-1370): the desktop-v2 manifest now declares a
+                 `scopeControls` zone, so this predicate is live too. -->
             <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} />
           </div>
         </div>

--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -12,9 +12,11 @@
  * to remove (a list that silently stops matching reality the moment someone
  * adds a manifest and forgets to update the list). That file's separate
  * `ALL_MANIFESTS`/`EXPECTED_LOADER_SPECIFIER` tables are, by contrast,
- * hand-listed literals by design (that file's own comment says so) — used
- * only for per-id loader-specifier pinning, a check this file has no need
- * for.
+ * hand-listed literals by design (that file's own comment says so) — they
+ * back that file's own completeness assertion, registration-identity pin
+ * and per-id loader-specifier pinning. This file needs none of the three:
+ * its own completeness check is structural (`SHIPPED_MANIFESTS` above), and
+ * it takes no registry read or loader specifier at all.
  *
  * Deliberately NOT sourced from `listDesignLanguageIds()`/the live registry:
  * `contract.ts`'s registry is module-scope, private, mutable state that

--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -15,7 +15,7 @@
  * hand-listed literals by design (that file's own comment says so) — they
  * back that file's own completeness assertion, registration-identity pin
  * and per-id loader-specifier pinning. This file needs none of the three:
- * its own completeness check is structural (`SHIPPED_MANIFESTS` above), and
+ * its own completeness check is structural (`SHIPPED_MANIFESTS` below), and
  * it takes no registry read or loader specifier at all.
  *
  * Deliberately NOT sourced from `listDesignLanguageIds()`/the live registry:

--- a/frontend/src/presentation/workspace/activation.ts
+++ b/frontend/src/presentation/workspace/activation.ts
@@ -14,8 +14,9 @@
  * (MOR-1048/MOR-1263), not this ticket. The gate is the language's OWN frozen
  * manifest data rather than new policy: a family declares, in
  * `layoutCompatibility`, which layouts it can serve. Today `studioline`
- * declares exactly one (`dual-receiver-cockpit`), so the selection activates
- * there and every v2 skin renders byte-identically to before.
+ * declares two (`dual-receiver-cockpit` and `desktop-v2`), so the selection
+ * activates on those and every other v2 skin renders byte-identically to
+ * before.
  *
  * Pure: takes the manifest the caller already resolved, touches no DOM, no
  * storage and no registry — the registry-populating `languages/declarations`

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -94,7 +94,8 @@ describe('skin registry', () => {
 describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
   // Kill-test: removing this branch (or mistyping the literal) leaves the
   // QA-only preference falling through `normalizeLayoutMode` to 'auto',
-  // which resolves to 'desktop-v2' or 'lcd-cockpit' — never the cockpit.
+  // which resolves to 'desktop-v2' unconditionally (MOR-1097 cutover) —
+  // never the cockpit.
   it('resolves the QA-only preference to the cockpit skin', () => {
     expect(resolve({ layoutPreference: 'dual-receiver-cockpit' })).toBe('dual-receiver-cockpit');
     expect(resolve({ layoutPreference: 'dual-receiver-cockpit', hasAnyScope: true })).toBe('dual-receiver-cockpit');


### PR DESCRIPTION
## Summary

MOR-2064: five prose statements (comments/docs) that were false against the code at HEAD, without any test failing to catch it. Text-only fix — no code, no test logic, no restructuring.

Ref: https://linear.app/morozsm/issue/MOR-2064

## The five, before -> after, and the source of every fact in the replacement

**1. `frontend/src/__tests__/presentation-switch-resources.component.test.ts`** (`SKIN_PLAN` doc comment)

- Before: `` `assertPlanMirrorsProduction()` below fails if production ever diverges, ``
- After: `` the `'mirrors the production per-skin resource plan'` test below fails if production ever diverges, ``
- Source: `grep -rn assertPlanMirrorsProduction frontend/src` -> one hit, the comment itself, no such function anywhere. Reading the file found the `it('mirrors the production per-skin resource plan', ...)` test in the same file (reads `skins/registry.ts` source and regex-compares `SKIN_RESOURCE_PLAN` values against `SKIN_PLAN`) — that check already exists, just under a different name. Deviates from the ticket's "write the check or delete the claim": the check exists, so the fix points the comment at the real test instead.

**2. `docs/guide/web-ui.md`** (two occurrences)

- Before (walkthrough): `` `auto` -> desktop-v2 when any scope is available, LCD Cockpit when no scope is available. ``
- After: `` `auto` -> desktop-v2 unconditionally (MOR-1097 cutover); scope availability does not affect this resolution. ``
- Before (expectations list): `` `auto` resolves to desktop-v2 only when any scope exists, otherwise LCD Cockpit is selected. ``
- After: `` `auto` resolves to desktop-v2 unconditionally (MOR-1097 cutover); scope availability plays no part in it. ``
- Source: read `frontend/src/skins/registry.ts: resolveSkinId` directly — the `auto` branch is the final unconditional `return 'desktop-v2'`, and `ctx.hasAnyScope` is never referenced in the function body. Cross-checked against `frontend/src/skins/__tests__/registry.test.ts`, which has a parametrized case titled "resolves auto to the v3 desktop default regardless of scope availability" asserting `desktop-v2` for both `hasAnyScope: true` and `false`.

**3. `frontend/src/components-v2/layout/RadioLayout.svelte`** (MOR-1364 comment block)

- Before: `Landed INERT: no manifest declares any of filter/rfFrontEnd/band/antenna/ritXitScan/rxAudio/dsp/cwKeyer yet, so every predicate is false...`
- After: `Landed INERT, then activated by S7/S8/S9 (MOR-1366/1367/1368): the desktop-v2 manifest now declares all of filter/rfFrontEnd/band/antenna/ritXitScan/rxAudio/dsp/cwKeyer, so every one of those predicates is live and the branches are reachable on that skin.` (plus a reworded, no-longer-"exception"-framed note on the SPLIT/A-B/A=B row)
- Source: grepped all eight zone ids in `frontend/src/presentation/layouts/desktop-declarations.ts` — all eight are declared entries in the live `DESKTOP_V2_ZONES` array feeding `registerLayout`. Traced the read path: `RadioLayout.svelte`'s `declared = $derived(declaredSurfaces(getLayout(skinId)))`, and `declaredSurfaces()` (`presentation/layouts/contract.ts`) flattens `manifest.zones[].surfaces` into the Set — so `declared.has('filter')` etc. is genuinely true for `skinId === 'desktop-v2'`.

**4. `frontend/src/presentation/workspace/activation.ts`** (module header)

- Before: `` Today `studioline` declares exactly one (`dual-receiver-cockpit`), so the selection activates there and every v2 skin renders byte-identically to before. ``
- After: `` Today `studioline` declares two (`dual-receiver-cockpit` and `desktop-v2`), so the selection activates on those and every other v2 skin renders byte-identically to before. ``
- Source: read `frontend/src/presentation/languages/declarations.ts` — `studioline.layoutCompatibility` has two entries, `dual-receiver-cockpit` and `desktop-v2`, both `compatible: true`. `git blame` shows the header was written 2026-08-05 (`1680fb21f`) and `desktop-v2` was added to the manifest 2026-08-07 (`c7e4c1a2`), two days later. Confirmed live via `frontend/src/presentation/workspace/__tests__/selection-adoption.test.ts:272`, which asserts `designLanguageActivation(studioline, 'desktop-v2')` returns `'studioline'`.

**5. `frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts`** (tail clause)

- Before: `` `ALL_MANIFESTS`/`EXPECTED_LOADER_SPECIFIER` tables are... used only for per-id loader-specifier pinning, a check this file has no need for. ``
- After: `` ...they back that file's own completeness assertion, registration-identity pin and per-id loader-specifier pinning. This file needs none of the three: its own completeness check is structural (`SHIPPED_MANIFESTS` below), and it takes no registry read or loader specifier at all. ``
- Source: read the sibling file directly, `frontend/src/presentation/layouts/__tests__/loader-identity-inventory.test.ts`. `ALL_MANIFESTS`'s keys back the completeness test (`it('the manifest table matches every id the barrel exports')`, line ~137-141) and the registration-identity pin (`expect(getLayout(id)).toBe(ALL_MANIFESTS[id])`, line ~149-150); `EXPECTED_LOADER_SPECIFIER` backs that same completeness test plus the actual loader-specifier value pin (line ~160-161). Neither table is used "only" for loader-specifier pinning.

## Swept the class (not fixed, reported)

Per the "when a review hands you one instance, sweep the class" rule, grepped the tree for the same false claim shape as item 2 ("auto" resolution conditioned on scope). Found one additional confirmed instance outside this ticket's five-item, 5-file/80-line budget:

- `frontend/src/presentation/layouts/desktop-declarations.ts` (in a doc comment): "`resolveSkinId`'s default `auto` destination when any scope is available" — same false premise as item 2, verified false the same way. Left unfixed (not one of the ticket's five items, would exceed scope) — flagging for a follow-up.

Two more hits were ambiguous/out of scope and were not entered into the fix set:
- `docs/plans/2026-04-11-presentation-architecture.md` — explicitly `**Status:** Draft for discussion` from 2026-04-11, predates the MOR-1097 cutover; describes the original design proposal, not current behavior. Correctly historical, not a live false claim.
- `docs/plans/2026-08-06-panel-order-workspace-boundary.md` — "the next radio they connect that auto-routes to `lcd-cockpit`" — ambiguous casual phrasing in an incident-narrative plan doc; could mean the literal `auto` layout preference or just "automatically routes" in general. Not clearly the same technical claim, and out of the five-item budget either way.

Fixed in round two (it was left in round one and independent review asked for it): `docs/guide/web-ui.md`'s "layout preference (`rigplane-layout`) is capability-aware" lead-in is now "resolution is not capability-aware". Left alone it directly contradicted the round-one correction in the same sentence. `resolveSkinId` reads only `ctx.isMobile` and `ctx.layoutPreference`; `ctx.capabilities` and `ctx.hasAnyScope` are never dereferenced.

## STOP condition

Not triggered. All five corrections are text-only; none required a code change to become true — in every case the code was already correct and only the prose describing it was stale.

## Verification

`npm run check` (svelte-check + tsc, via symlinked `frontend/node_modules` — no `npm ci`, machine load avg ~190):
```
1788190788942 START ".../mor-2064-correct-false-statements/frontend"
1788190788955 COMPLETED 4604 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

`npx eslint` on the four changed frontend files: exit 0, no output.

`.github/scripts/check-doc-citations.sh --check-growth origin/main`:
```
Doc-citation gate: baseline did not grow relative to 13bab70f64999c9579a3bec1227dccc4870c1151.
```

`.github/scripts/check-doc-citations.sh --check-links --check-growth origin/main`:
```
Doc-link gate: baseline did not grow relative to 13bab70f64999c9579a3bec1227dccc4870c1151.
```

`.github/scripts/check-rebrand-allowlist.sh`:
```
Wave 2 rebrand grep gate: clean.
```

**No test suite was run** — Python suite: out of scope, no Python touched. Frontend test suite: explicitly not run per instructions, since this change alters no behavior (comments/docs only) and running it would only imply coverage that wasn't observed. `npm run check` + targeted `eslint` are what ran.

## Guardrail numbers

**6 files changed, 27 insertions(+), 20 deletions(-) = 47 changed lines**, measured with `gh pr view --json` at head `b42fa172`. Ticket budget: 5 files / 80 changed lines — the sixth file (`frontend/src/skins/__tests__/registry.test.ts`) was added in round two at the reviewer's request, as a further instance of item 2's class.

This is exactly the 6-file soft threshold, so: **why this is one unit of work.** Every change here is the same defect — a sentence that is false against the code — and the repository rule is that a blocked finding naming one instance is a review of its class. Splitting six one-line comment corrections across separate PRs would multiply review cost without improving reviewability, and would leave the file-local class instances knowingly unfixed in between. Round two also swept the class inside a file already in the diff, which is what the rule requires.

## Branch note

Branched from `origin/main` at `13bab70f` (`test(MOR-2063): type the presentation-switch width table so a missing skin fails the check (#2885)`), fetched fresh before starting. `frontend/src/presentation/layouts/compatibility.ts` (deleted earlier today) is not referenced by any of the five items. None of the five files collide with the MOR-2059/MOR-2061 exclusion list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
