### PR TITLE
test(MOR-1545): un-skip the MAIN/SUB dedupe-key guard, on IC-9700's real VFO path

### DIFF
--- a/tests/test_mor1545_vfo_fallback_failure_paths.py
+++ b/tests/test_mor1545_vfo_fallback_failure_paths.py
@@ -1,11 +1,12 @@
 """MOR-1545 (PR #2458 follow-up 2): failure-path coverage for
-``_run_with_receiver_vfo_fallback`` (``_dual_rx_runtime.py:102-147``).
+``runtime/_dual_rx_runtime.py: DualRxRuntimeMixin._run_with_receiver_vfo_fallback``.
 
-13 call sites route through this one helper (VFO-select receiver targeting
-on cmd29-less dual-RX profiles, e.g. IC-9700), yet it had zero direct tests
--- existing tests only exercise the happy path via public tone/TSQL methods.
-These call the private helper directly with a stubbed ``_set_vfo_wire`` to
-pin the failure branches.
+14 call sites route through this one helper (13 in ``runtime/radio.py``, 1
+in ``runtime/_dual_rx_runtime.py`` itself -- counted via
+``grep -rn '_run_with_receiver_vfo_fallback(' src/ | grep -v 'def _run_with_receiver_vfo_fallback'``),
+yet it had zero direct tests -- existing tests only exercise the happy path
+via public tone/TSQL methods. These call the private helper directly with a
+stubbed ``_set_vfo_wire`` to pin the failure branches.
 """
 
 from __future__ import annotations
@@ -179,24 +180,23 @@ class TestSelectBackFailureSemantics:
 
 class TestVfoFallbackReadDedupeKeyReceiverScoped:
     """MOR-1545 F1: the receiver-scoped dedupe-key fix also covers the
-    VFO-fallback read call sites (radio.py ~4341/4419), not just the direct
-    cmd29 path. On IC-9700 (no cmd29 route) a MAIN direct read and a SUB
-    fallback read build byte-identical request frames -- only the dedupe
-    key can tell them apart. ``_set_vfo_wire`` is stubbed to an instant
-    no-op so the SUB fallback path reaches its own dedupe check before the
-    single-worker commander finishes dispatching MAIN's read, reproducing
-    the coalescing race deterministically (pre-fix: SUB sends zero read
-    frames of its own and returns MAIN's stale answer).
+    VFO-fallback read call sites (``IcomRadio.get_repeater_tone`` /
+    ``IcomRadio.get_repeater_tsql``), not just the direct cmd29 path. On
+    IC-9700 (no cmd29 route) a MAIN direct read and a SUB fallback read
+    build byte-identical request frames -- only the dedupe key can tell
+    them apart. ``_set_vfo_wire`` is stubbed to an instant no-op so the SUB
+    fallback path reaches its own dedupe check before the single-worker
+    commander finishes dispatching MAIN's read, reproducing the coalescing
+    race deterministically (pre-fix: SUB sends zero read frames of its own
+    and returns MAIN's stale answer).
 
-    The direct-cmd29-path comparison this docstring used to point to,
-    ``test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped::
-    test_concurrent_main_and_sub_reads_do_not_coalesce``, is currently
-    ``@pytest.mark.skip``'d (MOR-2008 batch 2: IC-7610, the only dual-RX
-    profile it ran against, does not declare the repeater-tone/TSQL
-    family at all, and redesigning it for IC-9700's own VFO-fallback
-    wire shape is tracked separately). Until that lands, this test here
-    is the one exercising the MAIN-direct-vs-SUB-fallback coalescing
-    scenario end to end, not merely a second example of it."""
+    Compare ``test_radio.py::TestRepeaterToneDedupeKeyReceiverScoped::
+    test_concurrent_main_and_sub_reads_do_not_coalesce``: this test here
+    stubs ``_set_vfo_wire`` with a yield-free no-op and asserts a 2-frame
+    path (below), whereas that one drives the real 3-frame VFO
+    select/restore path on the wire (select SUB, GET, restore MAIN). That
+    difference in what each test actually exercises is why neither is
+    redundant with the other."""
 
     @pytest.mark.asyncio
     async def test_concurrent_main_direct_and_sub_fallback_reads_do_not_coalesce(

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -3451,19 +3451,41 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
     """MOR-1545 (PR #2458 follow-up 1): get_repeater_tone/get_repeater_tsql
     deduped GETs on a bare ``key="get_repeater_tone"`` shared across
     MAIN/SUB (``IcomCommander._pending_by_key`` in
-    ``commands/commander.py``, see ``send()`` lines ~151-156). A concurrent
+    ``commands/commander.py``, see ``IcomCommander.send``). A concurrent
     in-flight MAIN read could coalesce a SUB caller onto MAIN's answer.
     Fixed to receiver-scope the key (``key=f"get_repeater_tone:{receiver}"``),
     mirroring ``get_filter_width``'s precedent (MOR-1538/#2458).
 
-    Uses IC-7300, not the module's default IC-7610 ``radio`` fixture, for
-    the same reason as ``TestToneTsqlParity`` above: IC-7610 does not
-    declare this family (MOR-2008 batch 2's D1 refusal fix), so a call
-    that used to build and send a wrong-but-successful frame on the
-    default fixture now raises ``CommandError`` instead. IC-7300 is
-    single-receiver, so the MAIN+SUB variant below has no working radio
-    left to run against (below); the same-receiver variant needs no SUB
-    at all and is otherwise unaffected.
+    ``test_concurrent_same_receiver_reads_still_dedupe`` below still uses
+    IC-7300 (``radio`` fixture), the same reason as ``TestToneTsqlParity``
+    above: IC-7610 does not declare this family (``rigs/ic7610.toml``), so
+    a call that used to build and send a wrong-but-successful frame on the
+    module's default IC-7610 fixture now raises ``CommandError`` instead.
+    ``test_concurrent_main_and_sub_reads_do_not_coalesce`` below instead
+    runs against IC-9700 (``ic9700_radio`` fixture): IC-7300 is
+    single-receiver and so cannot host a MAIN-vs-SUB race, and IC-9700 is
+    the only remaining dual-RX CI-V profile that declares the
+    repeater-tone/TSQL family at all. IC-9700 declares
+    ``[cmd29] routes = []`` for this family, so its SUB path goes through
+    ``DualRxRuntimeMixin._run_with_receiver_vfo_fallback`` (select SUB,
+    plain GET, restore MAIN -- three frames) rather than one cmd29-wrapped
+    frame, which is why this test's response queue and frame-tail
+    assertions below differ from the single-frame same-receiver test
+    underneath it. (The direct, non-fallback ``key=`` site in
+    ``get_repeater_tone``/``get_repeater_tsql`` needs both a declared
+    command and a cmd29 route for ``0x16 0x42``/``0x16 0x43`` to be
+    reachable with ``receiver != MAIN``; checked against every profile
+    under ``rigs/*.toml``, none currently ships both -- IC-7610 has the
+    route but not the declaration, IC-9700 has the declaration but
+    ``routes = []`` -- so only the fallback ``key=`` site below is
+    reachable for SUB today. A future profile could ship both.)
+
+    ``asyncio.gather`` below is called SUB-first (``method(receiver=1)``
+    before ``method(receiver=0)``) by design: verified, a reverted tree
+    (bare ``key="get_repeater_tone"``/``key="get_repeater_tsql"``) fails
+    this test on both parametrizations with SUB dispatched first -- see
+    the method docstring for what each assertion below is checking and
+    why.
     """
 
     @pytest.fixture
@@ -3475,22 +3497,19 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
         yield r
         r._connected = False  # reset _conn_state so __del__ stays quiet
 
-    @pytest.mark.skip(
-        reason=(
-            "MOR-2008 batch 2: IC-7610, the only dual-RX profile this test "
-            "ever ran against, does not declare the repeater-tone/TSQL "
-            "family at all (rigs/ic7610.toml, live-bench garbage-readback "
-            "finding) -- calling it now raises CommandError instead of "
-            "building a frame. IC-9700, the only other dual-RX profile "
-            "that declares the family, has no cmd29 route for it and "
-            "reaches SUB through a 3-frame VFO-select fallback "
-            "(TestToneTsqlDualRxCmd29Guard above) instead of one cmd29 "
-            "frame -- redesigning this concurrency test's timing "
-            "assumptions (exact sent_packets count, interleaving) around "
-            "that shape is a real piece of work, not a fixture swap, so "
-            "it is left for a dedicated follow-up rather than rushed here."
-        )
-    )
+    @pytest.fixture
+    def ic9700_radio(self, mock_transport: MockTransport):
+        # Same shape as TestToneTsqlDualRxCmd29Guard.ic9700_radio above,
+        # including timeout=0.05. Whether a larger timeout would reduce
+        # this test's flake rate under -n auto is unmeasured and deferred
+        # -- not decided here.
+        r = IcomRadio("192.168.1.102", timeout=0.05, model="IC-9700")
+        r._civ_transport = mock_transport
+        r._ctrl_transport = mock_transport
+        r._connected = True
+        yield r
+        r._connected = False  # reset _conn_state so __del__ stays quiet
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("method_name", "sub"),
@@ -3498,30 +3517,52 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
     )
     async def test_concurrent_main_and_sub_reads_do_not_coalesce(
         self,
-        radio: IcomRadio,
+        ic9700_radio: IcomRadio,
         mock_transport: MockTransport,
         method_name: str,
         sub: int,
     ) -> None:
-        """Two receivers in flight at once must each get their own wire
-        read and their own answer -- not one coalesced onto the other."""
-        radio._civ_runtime.start_worker()
+        """MAIN and SUB reads in flight at once must each get their own
+        wire read and their own answer -- not one coalesced onto the
+        other. SUB reaches SUB via the VFO-select fallback (select SUB,
+        GET, restore MAIN); MAIN reaches MAIN directly, so the wire
+        sequence is 4 frames, not 2. The frame-tail assertions below pin
+        that real 3-frame-fallback-plus-1 shape (and are what distinguish
+        this test from the stubbed-``_set_vfo_wire`` sibling in
+        ``test_mor1545_vfo_fallback_failure_paths.
+        TestVfoFallbackReadDedupeKeyReceiverScoped``) -- they are not what
+        catches the coalescing regression itself, which fails the earlier
+        ``assert sub_result is False`` instead. See the class docstring
+        for why ``gather`` is called SUB-first."""
+        ic9700_radio._civ_runtime.start_worker()
         try:
-            mock_transport.queue_response_on_send(
-                1, _function_response_ic7300(sub, b"\x01")
+            ack = _wrap_civ_in_udp(build_civ_frame(CONTROLLER_ADDR, 0xA2, _CMD_ACK))
+            main_civ = build_civ_frame(
+                CONTROLLER_ADDR, 0xA2, 0x16, sub=sub, data=b"\x01"
             )
-            mock_transport.queue_response_on_send(
-                2, _function_response_ic7300(sub, b"\x00")
+            sub_civ = build_civ_frame(
+                CONTROLLER_ADDR, 0xA2, 0x16, sub=sub, data=b"\x00"
             )
-            method = getattr(radio, method_name)
-            main_result, sub_result = await asyncio.gather(
-                method(receiver=0), method(receiver=1)
+            mock_transport.queue_response_on_send(1, ack)  # select SUB ack
+            mock_transport.queue_response_on_send(2, _wrap_civ_in_udp(main_civ))
+            mock_transport.queue_response_on_send(3, _wrap_civ_in_udp(sub_civ))
+            mock_transport.queue_response_on_send(4, ack)  # restore MAIN ack
+
+            method = getattr(ic9700_radio, method_name)
+            sub_result, main_result = await asyncio.gather(
+                method(receiver=1), method(receiver=0)
             )
+
             assert main_result is True
             assert sub_result is False
-            assert len(mock_transport.sent_packets) == 2
+
+            frames = mock_transport.sent_packets
+            assert frames[0].endswith(b"\x07\xd1\xfd")  # select SUB
+            assert frames[1].endswith(bytes([0x16, sub, 0xFD]))  # MAIN GET
+            assert frames[2].endswith(bytes([0x16, sub, 0xFD]))  # SUB GET
+            assert frames[3].endswith(b"\x07\xd0\xfd")  # restore MAIN
         finally:
-            await radio._civ_runtime.stop_worker()
+            await ic9700_radio._civ_runtime.stop_worker()
 
     @pytest.mark.asyncio
     async def test_concurrent_same_receiver_reads_still_dedupe(


### PR DESCRIPTION
## What

Un-skips `TestRepeaterToneDedupeKeyReceiverScoped::test_concurrent_main_and_sub_reads_do_not_coalesce`
and re-targets it at IC-9700's real VFO-select fallback path.

MOR-2008 batch 2 (#2880) skipped this test: it ran against the module's IC-7610
fixture, and IC-7610 does not declare the repeater-tone/TSQL family, so batch 2's
removal of the hardcoded fallback turned the call into a `CommandError` and broke
the test's premise.

The test guards MOR-1545/#2458: `IcomRadio.get_repeater_tone` / `get_repeater_tsql`
pass `key=f"get_repeater_tone:{receiver}"` into `IcomCommander.send`'s single-flight
dedupe, so a concurrent MAIN read and SUB read cannot coalesce onto one wire read.

## Why IC-9700

It is the only remaining dual-receiver CI-V profile that declares the family.
FTX-1 is the other dual-receiver profile, but it is Yaesu CAT — `backends/factory.py`
routes it to `YaesuCatRadio`, which never touches `IcomCommander`'s dedupe at all, and
its `[capabilities] features` lists neither `repeater_tone` nor `tsql`. IC-9700 ships
`[cmd29] routes = []`, so its SUB read goes through
`DualRxRuntimeMixin._run_with_receiver_vfo_fallback` — select SUB, plain GET, restore
MAIN — giving a 4-frame wire sequence against MAIN's single frame.

## Two properties that are load-bearing, and recorded as such

Both were established by measurement, and both are easy to "simplify" away by a future
editor who does not know why they are there, so each is stated in the docstrings:

- **`asyncio.gather` is called SUB-first.** A coherent MAIN-first variant — gather order,
  response queue and frame-tail assertions all flipped together — passes on a
  bare-key tree, i.e. it cannot catch the regression it exists for (measured:
  293 passed on the buggy tree). Flipping only the gather order, leaving the queue
  as-is, does not pass either: it raises `TimeoutError`. So MAIN-first is either blind
  or broken; neither is a usable test.
- **No `len(sent_packets)` assertion.** Under the revert the VFO restore times out and
  retries once, so both trees emit the same frame count. The values discriminate; the
  frame tails pin the real 3-frame shape that distinguishes this test from its stubbed
  sibling.

## Claims corrected because they were false as written

- `tests/test_mor1545_vfo_fallback_failure_paths.py` stated that this test is
  `@pytest.mark.skip`'d and that it was therefore "the one exercising the scenario end
  to end". Both stop being true with this PR. Replaced with an accurate statement of the
  actual difference: that test stubs `_set_vfo_wire` and asserts a 2-frame path; this one
  drives the real 3-frame path.
- That file's header counted 13 call sites through the helper. The measured count is 14
  (13 in `runtime/radio.py`, 1 in `runtime/_dual_rx_runtime.py`). Corrected, with the
  command that reproduces the count.
- The class docstring in `tests/test_radio.py` attributed IC-7610's lack of this family
  to a single event. Two separate events are involved, and the docstring now simply
  states the present-tense fact instead of a provenance chain: `a2646270`
  (MOR-682, #1839, 2026-06-11) removed the `[commands]` entries, and batch 2 `cc632498`
  promoted those eight rows to formal `{ absent = … }` declarations in `rigs/ic7610.toml`.

Also converts the two `file:line` citations both files carried into symbol names
(CLAUDE.md) — both had already rotted: at `cc632498` the cited `radio.py` lines sit in
`get_preamp` and `get_digisel`. And notes that the direct, non-fallback `key=` site is
unreachable for `receiver != MAIN` on every currently shipped profile — reaching it needs
both a declared command and a cmd29 route for `0x16 0x42`/`0x16 0x43`, and IC-7610 has
only the route while IC-9700 has only the declaration.

## Verification — on the Mac mini testbed, not the laptop

| Check | Result |
|---|---|
| `tests/test_radio.py`, this branch | 293 collected, **293 passed, 0 skipped** (was 291 passed / 2 skipped) |
| Same file, the four tone/TSQL keys reverted to bare | **2 failed** — exactly both parametrizations, at `assert sub_result is False` |
| Full python suite (`-n auto`) | 11391 passed, 107 skipped, 48 xfailed, **0 failed** |
| 11 consecutive serial runs of the file | 11/11 green, 293 passed every time |
| 5 consecutive full-suite runs | 5/5 PASS |
| `ruff check` | clean on every run |
| CI `quick` | ran for real (`Core checks selected: true`), 11667 passed / 159 skipped / 48 xfailed |

The red run fails with `assert True is False` on the SUB result — the SUB caller receiving
MAIN's answer — which is precisely the MOR-1545 defect. Only those 2 of 293 tests move, so
the check is targeted rather than merely brittle. An independent review reproduced all of
this on its own branches, and additionally confirmed the test is not over-fitted: renaming
the key format to `f"repeater_tone|rx{receiver}"` (still receiver-scoped) keeps it green.

## Guardrails

2 files, 167 changed lines — under both the soft (6 files / 600 lines) and hard
(10 files / 1000 lines) thresholds. Tests only; `src/` untouched.

## What this does and does not close

`runtime/radio.py` has 27 receiver-scoped `key=f"get_*:{receiver}"` sites. Before this PR,
reverting **all 27** to bare keys reddened exactly **one** test in the 11k+ suite — the
sibling in `test_mor1545_vfo_fallback_failure_paths.py`, which covers `get_repeater_tone`
only. With this PR the same revert reddens **three**: `get_repeater_tsql`'s receiver-scoped
key was pinned by nothing at all before now.

The remaining sites stay unpinned. In particular `get_filter_width` — which these docstrings
cite as the precedent the others were modelled on — is still covered by no test: a
single-family mutation of it kills nothing. That is a separate family and a separate piece
of work, tracked separately rather than widened into this PR.

Whether a larger fixture timeout would reduce this test's flake rate under `-n auto` is
unmeasured and deliberately left open rather than guessed at.
