### PR TITLE
test(MOR-2061): derive the twelve declarability inventories from the barrel

### DIFF
--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -16,10 +16,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('antenna is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -53,11 +51,11 @@ describe('exactly the reviewed manifests declare an antenna zone (MOR-1367)', ()
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_ANTENNA = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S8 gave it, and a family
   // gaining one without review. For the cockpit that is load-bearing rather

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -22,10 +22,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('band is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
@@ -61,11 +59,11 @@ describe('exactly the reviewed manifests declare a band zone (MOR-1367)', () => 
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_BAND = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S8 gave it, and a family
   // gaining one without review. For the cockpit that is load-bearing rather

--- a/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
@@ -18,10 +18,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('cwKeyer is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -61,11 +59,11 @@ describe('exactly the reviewed manifests declare a cwKeyer zone (MOR-1368)', () 
    */
   const DECLARES_CW_KEYER = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: desktop-v2 losing the zone S9 gave it — which would
   // put `CwPanel` back beside `CwKeyerSurface`, i.e. two break-in affordances

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -8,10 +8,8 @@
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('dsp is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition, or reordering the
@@ -45,11 +43,11 @@ describe('exactly the reviewed manifests declare a dsp zone (MOR-1368)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_DSP = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: desktop-v2 losing the zone S9 gave it — which would
   // resurrect FOUR twins at once, `DspPanel` in both sidebars plus the settings

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -15,10 +15,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('filter is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -51,11 +49,11 @@ describe('exactly the reviewed manifests declare a filter zone (MOR-1366)', () =
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_FILTER = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S7 gave it, and a family
   // gaining one without review.

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -30,6 +30,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import type { LayoutManifest } from '../contract';
+import { isLayoutManifest } from './manifest-guard';
 // Barrel-only — the M7 lesson, restated on every family in this directory:
 // importing a manifest module directly fires `registerLayout` from this file
 // and, under the fast pool's `isolate: false`, leaks the registration into
@@ -49,17 +50,6 @@ import { desktopV2Layout, sdrTestLayout } from '../declarations';
 // state. Same derivation as `loader-identity-inventory.test.ts`'s
 // `BARREL_MANIFESTS` (MOR-2060).
 import * as layoutDeclarationsBarrel from '../declarations';
-
-/** Structural `LayoutManifest` guard for filtering the barrel's export
- *  surface — copied from `loader-identity-inventory.test.ts` verbatim. */
-function isLayoutManifest(value: unknown): value is LayoutManifest {
-  return (
-    typeof value === 'object' && value !== null &&
-    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
-    typeof (value as { id?: unknown }).id === 'string' &&
-    typeof (value as { loader?: unknown }).loader === 'function'
-  );
-}
 
 /** Every manifest currently registered by the barrel (mirrors F8's
  *  `REAL_LAYOUTS`), derived from the barrel's own export surface instead of

--- a/frontend/src/presentation/layouts/__tests__/manifest-guard.ts
+++ b/frontend/src/presentation/layouts/__tests__/manifest-guard.ts
@@ -1,0 +1,22 @@
+/**
+ * Structural `LayoutManifest` guard for filtering a namespace import of
+ * `../declarations` down to real manifests. Imported by every
+ * `*-declarability.test.ts` file in this directory and by
+ * `forward-declaration-inventory.test.ts`, each deriving its own inventory
+ * from the barrel instead of hand-listing ids. Not itself a test file.
+ *
+ * Extracted (MOR-2061) from the identical copy `forward-declaration-
+ * inventory.test.ts` carried (MOR-2060); `loader-identity-inventory.test.ts`
+ * still has its own independent copy of the same shape, out of this
+ * ticket's scope.
+ */
+import type { LayoutManifest } from '../contract';
+
+export function isLayoutManifest(value: unknown): value is LayoutManifest {
+  return (
+    typeof value === 'object' && value !== null &&
+    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    typeof (value as { loader?: unknown }).loader === 'function'
+  );
+}

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -18,10 +18,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('meters is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1305 appended
@@ -56,11 +54,11 @@ describe('exactly the reviewed manifests declare a meters zone (MOR-1341)', () =
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_METERS = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S5 gave it, and a family
   // gaining one without review.

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -19,10 +19,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('rfFrontEnd is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1307 appended
@@ -57,11 +55,11 @@ describe('exactly the reviewed manifests declare an rfFrontEnd zone (MOR-1366)',
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_RF_FRONT_END = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S7 gave it, and a family
   // gaining one without review — including the dual-receiver-cockpit, which

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -14,10 +14,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('ritXitScan is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -50,11 +48,11 @@ describe('exactly the reviewed manifests declare a ritXitScan zone (MOR-1367)', 
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_RITXIT_SCAN = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S8 gave it, and a family
   // gaining one without review. For the cockpit that is load-bearing rather

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -16,10 +16,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('rxAudio is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -52,11 +50,11 @@ describe('exactly the reviewed manifests declare an rxAudio zone (MOR-1368)', ()
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_RX_AUDIO = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: desktop-v2 losing the zone S9 gave it (which would
   // resurrect the RX AUDIO twin in both sidebars), and a family gaining one

--- a/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
@@ -28,10 +28,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('scopeControls is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -64,11 +62,11 @@ describe('exactly the reviewed manifests declare a scopeControls zone (MOR-1370)
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_SCOPE_CONTROLS = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S6b-2 gave it (the
   // MOR-1069 dual-receiver-cockpit tab-order assertion is written against

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -23,10 +23,8 @@ import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { RENDERER_SLOT_NAMES } from '../../languages/contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('scopeDisplay is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition.
@@ -59,11 +57,11 @@ describe('exactly the reviewed manifests declare a scopeDisplay zone (MOR-1365)'
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_SCOPE_DISPLAY = ['desktop-v2'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S6a gave it, and a family
   // gaining one without review.

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -18,10 +18,8 @@
 import { describe, it, expect } from 'vitest';
 import { SEMANTIC_SURFACE_NAMES, validateLayoutManifest } from '../contract';
 import { validLayoutManifest } from './fixtures';
-import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
-} from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
+import * as layoutDeclarationsBarrel from '../declarations';
 
 describe('txAux is a declarable semantic surface', () => {
   // Kills: reverting the SEMANTIC_SURFACE_NAMES addition. MOR-1273 appended
@@ -56,11 +54,11 @@ describe('exactly the reviewed manifests declare a txAux zone (MOR-1336)', () =>
   /** The literal — extend by hand, with a layout review, never silently. */
   const DECLARES_TX_AUX = ['desktop-v2', 'dual-receiver-cockpit'];
 
-  const ALL = [
-    ['sdr-test', sdrTestLayout], ['dual-receiver-cockpit', dualReceiverCockpitLayout],
-    ['lcd-cockpit', lcdCockpitLayout], ['lcd-scope', lcdScopeLayout],
-    ['mobile', mobileLayout], ['desktop-v2', desktopV2Layout],
-  ] as const;
+  // [id, manifest] pairs derived from the barrel's export surface
+  // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.
+  const ALL = Object.values(layoutDeclarationsBarrel)
+    .filter(isLayoutManifest)
+    .map((m) => [m.id, m] as const);
 
   // Kills BOTH directions: a family losing the zone S4 gave it, and a family
   // gaining one without review.


### PR DESCRIPTION
## Owner exception to the file-count ceiling — granted 2026-08-31

The repository's hard ceiling is 10 files / 1000 changed lines, and CLAUDE.md marks it
"Not author-waivable — only the owner grants an exception, in the PR, before merge."

**The owner (Sergey Morozik) granted that exception for this change on 2026-08-31, before
merge, in session.** It covers the file count only; the line count is well inside the
ceiling.

Why the count is what it is: the twelve `*-declarability.test.ts` files carry an `ALL`
literal that is byte-identical across all twelve (verified by hash before any edit), so
they are one mechanism, not twelve. Splitting them across PRs would multiply review cost
without improving reviewability, and would leave the repository in a state where some of
the twelve derive and some do not. The thirteenth and fourteenth files are the shared
`manifest-guard.ts` the derivation needs, and `forward-declaration-inventory.test.ts`,
which adopts that shared guard so a fourteenth copy of the predicate is not created.

---

## MOR-2061 — derive the twelve declarability inventories from the barrel

Twelve `presentation/layouts/__tests__/*-declarability.test.ts` files each carried a hand-listed `const ALL = [['sdr-test', sdrTestLayout], ...] as const;` array — verified byte-identical, reached from identical imports, used in three identical ways (`.filter().map().sort()`, `.find()` by id, `it.each(ALL)`). Replaced all twelve with a derivation from a namespace import of `../declarations` filtered by a shared `isLayoutManifest` guard, following the MOR-2060 template (`forward-declaration-inventory.test.ts`). No id literal survives in any of the twelve.

### Byte-identity verification

SHA-256 over each file's `const ALL = [...] as const;` block: all twelve hash to the same digest (`f5713eb6…`), confirmed with a standalone script before any edit. The six-name import block (`desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout, sdrTestLayout` from `../declarations`) is also byte-identical across all twelve. A separate check confirmed those six names are referenced **only** inside the import and the `ALL` block in every file — nothing else in any of the twelve depends on them by name.

`DECLARES_*` literals (11× `['desktop-v2']`, `tx-aux-declarability.test.ts`'s `['desktop-v2', 'dual-receiver-cockpit']`) are untouched — no edit to any of them, per the ticket's explicit STOP condition.

### Shared guard extraction

New file: `frontend/src/presentation/layouts/__tests__/manifest-guard.ts`, exporting `isLayoutManifest`. Extracted from the identical copy `forward-declaration-inventory.test.ts` carried (MOR-2060); that file now imports it instead of defining its own copy (`forward-declaration-inventory.test.ts: isLayoutManifest` local function removed). `loader-identity-inventory.test.ts` keeps its own independent copy — left untouched, out of this ticket's scope per the STOP-conditions list. Per the ticket's own caution, the guard's docstring describes its mechanism only, not a discriminating guarantee — nothing the barrel exports today fails it.

### Removal-mutation control (the constraint that matters most)

Ran against the finished branch: deleted `export { mobileLayout } from './mobile-declarations';` from `declarations.ts`, ran `npx vitest run src/presentation/layouts/`, reverted.

**Result: 3 files outside the twelve go red, 0 of the twelve do.**

- `mobile-registration.test.ts` — 15 failing tests (corrected from 14 on independent review; this line's own total of 17 = 15 + 2 already implied 15) (per-family registration floor for "mobile"; imports `mobileLayout` through the barrel by design, so it breaks the instant the barrel stops re-exporting it)
- `loader-identity-inventory.test.ts` — 2 failing tests: the barrel-completeness check (`BARREL_MANIFESTS` now 5, hand table `ALL_MANIFESTS` still 6 → mismatch) and `"mobile" is registered and its loader resolves to the pinned specifier` (`getLayout('mobile')` now `undefined`)
- `cockpit-topology-adaptation.test.ts` — whole suite crashes at collection: `TypeError: Cannot read properties of undefined (reading 'id')` in `REAL_LAYOUTS.map((m) => [m.id, m] as const)`

`forward-declaration-inventory.test.ts` stays green under this mutation — expected and already documented in the ticket: that file's removal-detection was traded away by MOR-2060, acceptable specifically because the three files above still catch it. Confirms neither STOP condition fires: the twelve don't need a pin (removal reddens plenty outside them), and the sweep didn't go too far (something outside the twelve does redden).

Full per-test breakdown: `Test Files 3 failed | 23 passed (26)`, `Tests 17 failed | 277 passed (294)` (`cockpit-topology-adaptation.test.ts`'s crash removes its tests from the individual count — a suite-level crash, the loudest possible signal).

`git diff` after revert: clean, no residue.

### Addition control

Added an unregistered fake manifest (`fake-unregistered-probe`, structurally valid but never passed to `registerLayout`) as a new barrel export, ran the same suite, reverted.

- All twelve declarability files pick it up live: each grew one new passing test, e.g. `tx-aux-declarability.test.ts > … > fake-unregistered-probe does not require the txAux surface`.
- Bonus confirmation the shared-guard wiring works both ways: `forward-declaration-inventory.test.ts` and `loader-identity-inventory.test.ts` both went red on the addition too (no DOM-backing proof / table-vs-barrel mismatch for the new id) — both derive from the barrel and reacted correctly.

`git diff` after revert: clean, no residue.

### Test runs

`npx vitest run src/presentation/layouts/`: **26 files / 327 tests passed.**
`npx vitest run src/presentation/layouts/ src/presentation/workspace/`: **36 files / 637 tests passed** — same 327 layouts tests pass whether or not workspace/ shares the worker, confirming the derived lists aren't sensitive to cross-file pool state.
`npx eslint src/presentation/`: exit 0, no output.
`npm run check`: `4605 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`, exit 0.

All four re-run at the final (post-revert) head before commit, not just before the negative controls.

Machine load was elevated during this session (`uptime` at time of the runs: `load averages: 5.30 9.82 58.16`, consistent with the noted leaked load generator); no timeouts were hit on any run, so nothing here is being called flaky.

### Owner exception

Ticket text says "12 files plus a helper is 13, past the 10-file hard ceiling" and grants an exception on that basis. The actual count on this branch is **14**: the twelve, `manifest-guard.ts`, and `forward-declaration-inventory.test.ts` — the third file is required by the ticket's own instruction to have the MOR-2060 file use the shared guard too, and is explicitly named alongside the other two in the ticket's STOP-conditions list ("the twelve plus the shared-guard helper plus forward-declaration-inventory.test.ts"). The exception paragraph's "13" appears to predate that instruction. Flagging this plainly rather than silently reporting the ticket's stale number: **14 files, 226 changed lines** (107 insertions, 119 deletions — `git diff --stat` on the head being pushed), both past the 10-file hard ceiling, both under the 400-line budget the ticket sets.

### Pending

Full suite and independent review are pending CI and a separate verifier pass — not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


