### PR TITLE
test(MOR-2062): make the skin resource-plan coverage set fail loudly on a missing skin

### DIFF
--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { AppResource } from '$lib/runtime/resource-demand';
 import type { SkinId } from '../registry';
 
 const entrypoints = vi.hoisted(() => ({
@@ -138,18 +139,34 @@ describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
 // composition root can bridge demand across a swap; it is read off the actual
 // component trees, not invented per skin.
 describe('presentation resource plan', () => {
-  const everySkin = ['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test'] as const;
-
-  it.each([
-    ['desktop-v2', ['audio-fft', 'hardware-scope']],
-    ['sdr-test', ['audio-fft', 'hardware-scope']],
-    ['lcd-cockpit', ['audio-fft']],
-    ['lcd-scope', ['audio-fft']],
+  // MOR-2062: `everySkin` and this it.each table used to be two separately
+  // hand-listed arrays, and both silently dropped `dual-receiver-cockpit` —
+  // five of six skins, no failure anywhere. `Record<SkinId, ...>` is the
+  // same technique the sibling `entrypoints.test.ts` already uses for this
+  // exact constraint (see that file's header: there is no runtime-
+  // enumerable list of `SkinId` values, and both `SKIN_LOADERS` and
+  // `SKIN_RESOURCE_PLAN` in registry.ts are module-private), so a skin
+  // missing from this table is now a `npm run check` compile error instead
+  // of a silent gap. `everySkin` is derived from this table's own keys, so
+  // the two can no longer drift from each other either.
+  const EXPECTED_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
+    'desktop-v2': ['audio-fft', 'hardware-scope'],
+    'dual-receiver-cockpit': [],
+    'sdr-test': ['audio-fft', 'hardware-scope'],
+    'lcd-cockpit': ['audio-fft'],
+    'lcd-scope': ['audio-fft'],
     // The mobile layout mounts SpectrumPanel but no audio-FFT surface.
-    ['mobile', ['hardware-scope']],
-  ] as const)('names the resources the %s tree can demand', (skinId: SkinId, resources) => {
-    expect([...presentationResourcePlan(skinId)].sort()).toEqual([...resources]);
-  });
+    'mobile': ['hardware-scope'],
+  };
+
+  const everySkin = Object.keys(EXPECTED_RESOURCE_PLAN) as SkinId[];
+
+  it.each(Object.entries(EXPECTED_RESOURCE_PLAN) as Array<[SkinId, readonly AppResource[]]>)(
+    'names the resources the %s tree can demand',
+    (skinId, resources) => {
+      expect([...presentationResourcePlan(skinId)].sort()).toEqual([...resources]);
+    },
+  );
 
   // MUTATION KILLED: adding `rx-audio` to any plan. Its lease belongs to the
   // runtime (`setRxLive`), not to a presentation subtree — bridging it would


### PR DESCRIPTION
## Summary

`skins/__tests__/registry.test.ts: everySkin` and the `it.each` table in
the same `describe('presentation resource plan')` each hand-listed five
of six skins, silently omitting `dual-receiver-cockpit`, while
`skins/registry.ts: SKIN_RESOURCE_PLAN` already had all six. Confirmed
this was still live before touching anything: `everySkin` read
`['desktop-v2', 'lcd-cockpit', 'lcd-scope', 'mobile', 'sdr-test']` and the
it.each table had the matching five rows, both missing
`dual-receiver-cockpit`, and no test failed.

## Fork chosen: (b), typing the table as `Record<SkinId, ...>`

**Search performed first** (per ticket): grepped `SkinId`, `SKIN_LOADERS`,
`listSkins`, `skinIds`, `ALL_SKINS`, `SKIN_IDS`, and any `Object.keys`
call near the skins tree. No existing export yields the set of skin ids
at runtime — `SkinId` is a type-only union (no runtime representation),
and both `SKIN_LOADERS` and `SKIN_RESOURCE_PLAN` in `registry.ts` are
module-private.

Between the two STOP-condition forks, I chose **(b)**, not (a), because
the sibling file `skins/__tests__/entrypoints.test.ts` already solves the
*identical* constraint the identical way: its own header states verbatim
"there is no runtime-enumerable list of `SkinId` values to iterate... and
both `SKIN_LOADERS` and the sibling `SKIN_RESOURCE_PLAN` are private,"
and its fix is `SKIN_ENTRYPOINT_COVERAGE: Record<SkinId, ...>` plus
`Object.keys(...) as SkinId[]` for derived iteration. The authoring guide
(`docs/architecture/building-a-skin.md`) documents this `Record<SkinId,
...>` pattern as the prevailing convention across nearly every hand-table
in this area (its wiring checklist calls it out at each of the four
`Record`-typed sites), and the immediately preceding commit on this exact
audit lineage (MOR-2063 / PR #2885) applied the same technique to a
different hand-table one commit before this one. Reusing an established,
documented, working in-repo convention over inventing a new export from
`skins/registry.ts` (the documented skin-authoring surface) is the
"search before you write" / "close enough is reuse" call here — it adds
zero new promise surface to that file, so the owner-ruling disclosure
this ticket asks for is moot: **no new export was added**.

This is a relocation of the hand list into a compiler-checked shape, not
its elimination, exactly as the ticket describes for fork (b) — flagging
that plainly, not presenting it as more than it is. `everySkin` is now
*derived* from the same table's keys (`Object.keys(EXPECTED_RESOURCE_PLAN)
as SkinId[]`), so the two previously-independent hand lists can no longer
drift from each other, on top of no longer being able to drift from
`SkinId`.

## Clerical omission, not a real gap

`SKIN_RESOURCE_PLAN['dual-receiver-cockpit']` is `[]` in `registry.ts`,
with an explicit "Empty by construction" comment (the cockpit mounts no
`SpectrumPanel`/`AudioSpectrumPanel`). Adding `'dual-receiver-cockpit':
[]` to the test's table and running it produces a passing case (`[]`
equals `[]`), and the "never claims rx-audio" test also passes for it
(`[]` cannot contain `'rx-audio'`). No unrelated test broke. This is a
clerical test-coverage gap, not a defect in the resource plan itself.

## Sweep of the class (investigation only, per guardrail policy)

Searched for other hand-authored multi-skin-id tables that could carry
the same silent-drift risk:
- `frontend/src/__tests__/presentation-switch-tx.component.test.ts` —
  already fixed (MOR-2063 / #2885, immediately preceding commit).
- `frontend/src/__tests__/presentation-switch-resources.component.test.ts`
  — checked (`SKIN_PLAN`, `WIDTH_FOR`); both already `Record<SkinId,
  ...>` and both already include `dual-receiver-cockpit`. No drift found.
- `frontend/src/skins/__tests__/entrypoints.test.ts` —
  `SKIN_ENTRYPOINT_COVERAGE` already `Record<SkinId, ...>` and complete
  (used as the precedent above).
- `frontend/src/presentation/workspace/contract.ts` — has a similar
  hand-list shape (`WORKSPACE_LAYOUT_IDS`) but sits under
  `presentation/workspace/**`, called out as an in-flight PR (#2886)
  collision in my task instructions; not touched or further inspected.
- `frontend/src/components-v2/layout/StatusBar.svelte`'s `skinOptions` —
  the authoring guide itself already documents this as a known,
  pre-existing gap with "no check at all" (it's typed against
  `CanonicalLayoutMode`, which deliberately excludes
  `dual-receiver-cockpit` since that skin is QA-only, not
  preference-selectable — not the same "5 of 6" shape as this bug).
  Out of MOR-2062's named scope; left unfixed and reported here.

## Negative control (mandatory)

Chose the typed-`Record` fork, so verified via `npm run check` per the
ticket's instruction. Removed `'dual-receiver-cockpit': []` from
`EXPECTED_RESOURCE_PLAN`, ran `npm run check`:

```
1788192903155 ERROR "src/skins/__tests__/registry.test.ts" 152:9 "Property '\"dual-receiver-cockpit\"' is missing in type '{ 'desktop-v2': (\"hardware-scope\" | \"audio-fft\")[]; 'sdr-test': (\"hardware-scope\" | \"audio-fft\")[]; 'lcd-cockpit': \"audio-fft\"[]; 'lcd-scope': \"audio-fft\"[]; mobile: \"hardware-scope\"[]; }' but required in type 'Record<SkinId, readonly AppResource[]>'."
1788192903156 COMPLETED 4604 FILES 1 ERRORS 0 WARNINGS 1 FILES_WITH_PROBLEMS
```

The error names the missing skin by id, at the exact line. Restored the
entry, re-ran `npm run check` (0 errors) and `npx vitest run src/skins/`
(76/76 passed), and confirmed `git diff` is clean (matches the committed
state, no negative-control leftovers).

## Verification (foreground, this branch)

```
$ npx vitest run src/skins/
 Test Files  3 passed (3)
      Tests  76 passed (76)

$ npx eslint src/skins/__tests__/registry.test.ts
(no output — zero violations)

$ npm run check
1788192963595 COMPLETED 4604 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

`uptime` recorded before each run (machine had elevated but not
pathological load from other sessions' activity; no timeouts hit, no
retries needed):
```
12:13  up 15 days, 16:33  load averages: 24.03 20.91 32.35
12:15  up 15 days, 16:35  load averages: 63.19 34.72 35.71  (restore run, still completed normally)
```

Full suite (`npx vitest run` whole-tree) was **not** run per instructions
(never the whole frontend suite from this agent) — pending CI
(`quick.yml`'s frontend block) and independent review.

## Guardrail numbers

1 file changed, 39 changed lines (28 insertions, 11 deletions) — well
under both the soft threshold (6 files / 600 lines) and the hard ceiling
(10 files / 1000 lines).

## Not done here

- `main` unmerged; this PR is not merged.
- No "Agent Review" directive posted — pending independent verification
  per repo policy (implementation agent does not review its own work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
