### PR TITLE
fix: open the CI-V answer window at the send, not at method entry

### DIFF
--- a/docs/internals/raw-civ-transactions.md
+++ b/docs/internals/raw-civ-transactions.md
@@ -154,14 +154,15 @@ the step returns `civ_owner_conflict`.
 Queued command steps keep the existing 10 second command batch step timeout.
 Transaction steps use `timeout_ms` when present, otherwise `10000`
 milliseconds. Units are always milliseconds in JSON and seconds only inside
-Python internals. Timeout covers ownership acquisition and the wait for the
-radio's answer; it does not include earlier or later batch steps, and it does
-not include this side's outbound work before the frame is sent.
+Python internals. Timeout covers the wait for the radio's answer; it does
+not include earlier or later batch steps, nor this side's outbound work before
+the frame is sent.
 `_civ_rx.py: CivRuntime.execute_civ_transaction` opens the window when the
-frame reaches the transport, so the ACK-sink drain and the `_civ_min_interval`
-pacing gap inside `CivRuntime._send_civ_frame_now` fall outside it. A step's
-wall time can therefore exceed `timeout_ms` by up to the sum of those two, and
-`web/server.py: _HttpCommandExecutor.execute` adds no outer cap of its own.
+frame reaches the transport. Two things run before that and so fall outside it:
+the ACK-sink drain it performs itself, and the `_civ_min_interval` pacing gap
+inside `CivRuntime._send_civ_frame_now`. A step's wall time can therefore exceed
+`timeout_ms` by up to the sum of those two, and `web/server.py:
+_HttpCommandExecutor.execute` adds no outer cap of its own.
 
 On timeout, the transaction primitive must unregister pending CI-V waiters,
 release ownership, and return a per-step timeout result. It must not leave the

--- a/docs/internals/raw-civ-transactions.md
+++ b/docs/internals/raw-civ-transactions.md
@@ -154,8 +154,14 @@ the step returns `civ_owner_conflict`.
 Queued command steps keep the existing 10 second command batch step timeout.
 Transaction steps use `timeout_ms` when present, otherwise `10000`
 milliseconds. Units are always milliseconds in JSON and seconds only inside
-Python internals. Timeout covers ownership acquisition plus the send/wait path
-for the transaction step; it does not include earlier or later batch steps.
+Python internals. Timeout covers ownership acquisition and the wait for the
+radio's answer; it does not include earlier or later batch steps, and it does
+not include this side's outbound work before the frame is sent.
+`_civ_rx.py: CivRuntime.execute_civ_transaction` opens the window when the
+frame reaches the transport, so the ACK-sink drain and the `_civ_min_interval`
+pacing gap inside `CivRuntime._send_civ_frame_now` fall outside it. A step's
+wall time can therefore exceed `timeout_ms` by up to the sum of those two, and
+`web/server.py: _HttpCommandExecutor.execute` adds no outer cap of its own.
 
 On timeout, the transaction primitive must unregister pending CI-V waiters,
 release ownership, and return a per-step timeout result. It must not leave the

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -957,13 +957,11 @@ class CivRuntime:
         self,
         civ_frame: bytes,
         wait_response: bool = True,
-        deadline_monotonic: "float | None" = None,
     ) -> "CivFrame | None":
         """Execute one CI-V command via request tracker (public API)."""
         return await self._execute_civ_raw(
             civ_frame,
             wait_response=wait_response,
-            deadline_monotonic=deadline_monotonic,
         )
 
     async def execute_civ_transaction(
@@ -1007,9 +1005,14 @@ class CivRuntime:
 
         parsed_frame = parse_civ_frame(civ_frame)
         request_key = request_key_from_frame(parsed_frame)
-        deadline_monotonic = time.monotonic() + (
-            timeout if timeout is not None else self._host._civ_get_timeout
-        )
+        # Bounds the *radio's* answer, so it is spent from the send onward
+        # rather than from here: the ``_civ_min_interval`` gap inside
+        # ``_send_civ_frame_now`` and the ACK-sink drain below are this
+        # side's own scheduling.  ``tests/test_raw_civ_transaction.py:
+        # test_pacing_gap_is_not_charged_to_the_answer_window`` fails when
+        # they are charged to this budget; ``_execute_civ_raw`` carried the
+        # same mis-charge.
+        answer_timeout = timeout if timeout is not None else self._host._civ_get_timeout
 
         self._cleanup_stale_civ_waiters()
 
@@ -1025,9 +1028,6 @@ class CivRuntime:
                 "Dropped %d orphan ACK/NAK backlog frame(s) before raw transaction",
                 dropped_backlog,
             )
-        remaining_total = deadline_monotonic - time.monotonic()
-        if remaining_total <= 0:
-            raise asyncio.TimeoutError("CI-V response timed out")
 
         pending_waiters: list[asyncio.Future[CivFrame]] = []
         data_transaction: _CivDataTransaction | None = None
@@ -1049,12 +1049,9 @@ class CivRuntime:
 
             self.start_pump()
             await self._send_civ_frame_now(civ_frame, owner=owner)
-            remaining = deadline_monotonic - time.monotonic()
-            if remaining <= 0:
-                raise asyncio.TimeoutError("CI-V response timed out")
             done, _ = await asyncio.wait(
                 pending_waiters,
-                timeout=remaining,
+                timeout=answer_timeout,
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if not done:
@@ -3464,7 +3461,6 @@ class CivRuntime:
         self,
         civ_frame: bytes,
         wait_response: bool = True,
-        deadline_monotonic: "float | None" = None,
     ) -> "CivFrame | None":
         """Execute one CI-V command via request tracker (serialized by worker)."""
         assert self._host._civ_transport is not None
@@ -3473,8 +3469,6 @@ class CivRuntime:
         parsed_frame = parse_civ_frame(civ_frame)
         request_key = request_key_from_frame(parsed_frame)
         expects_response = self._civ_expects_response(parsed_frame)
-        if deadline_monotonic is None:
-            deadline_monotonic = time.monotonic() + self._host._civ_get_timeout
 
         self._cleanup_stale_civ_waiters()
 
@@ -3508,10 +3502,6 @@ class CivRuntime:
 
         await self._drain_ack_sinks_before_blocking()
 
-        remaining_total = deadline_monotonic - time.monotonic()
-        if remaining_total <= 0:
-            raise TimeoutError("CI-V response timed out")
-
         pending: "asyncio.Future[CivFrame] | None" = None
         try:
             if expects_response:
@@ -3542,11 +3532,19 @@ class CivRuntime:
             await self._host._civ_transport.send_tracked(pkt)
             self._host._last_civ_send_monotonic = time.monotonic()
             assert pending is not None
-            remaining = deadline_monotonic - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError("CI-V response timed out")
+            # The answer window is spent from here, not from method entry:
+            # ``_civ_get_timeout`` bounds how long the *radio* may take,
+            # while the ``_civ_min_interval`` gap above and
+            # ``_drain_ack_sinks_before_blocking`` are this side's own
+            # scheduling.  Charging them to one budget cost a command sent
+            # inside the pacing gap that whole gap of answer window, and all
+            # of it whenever the pacing sleep overshot the remainder --
+            # ``tests/test_radio.py:
+            # TestResponseDeadlineOpensAtSend`` fails on that mis-charge.
             try:
-                return await asyncio.wait_for(pending, timeout=remaining)
+                return await asyncio.wait_for(
+                    pending, timeout=self._host._civ_get_timeout
+                )
             except asyncio.TimeoutError:
                 self._host._civ_request_tracker.note_timeout()
                 logger.debug(

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -1778,13 +1778,11 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self,
         civ_frame: bytes,
         wait_response: bool = True,
-        deadline_monotonic: float | None = None,
     ) -> CivFrame | None:
         """Delegate to CI-V runtime (for tests and internal callers)."""
         return await self._civ_runtime.execute_civ_raw(
             civ_frame,
             wait_response=wait_response,
-            deadline_monotonic=deadline_monotonic,
         )
 
     def _update_state_cache_from_frame(self, frame: CivFrame) -> None:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -744,10 +744,11 @@ class TestPtt:
     # ``func_only``: this bound guards the body, which measured 0.00-0.16 s
     # on a loaded machine.  Charging setup to it as well made whichever
     # parametrisation ran first carry the process's first ``IcomRadio``
-    # construction -- 158 ms against 0.1 ms for the next one when timed
-    # bare, and 1.5-2.0 s of setup on that same loaded run, against 0.00 s
-    # for the other two -- so the marker expired on machine speed rather
-    # than on anything this test drives.
+    # construction, which costs hundreds of milliseconds against a fraction
+    # of one for every later construction in the same process -- 1.5-2.0 s
+    # of setup on a loaded run, against 0.00 s for the other two -- so the
+    # marker expired on machine speed rather than on anything this test
+    # drives.
     @pytest.mark.timeout(2, func_only=True)
     @pytest.mark.parametrize("invalidation", ["rebind", "poison", "reconnect"])
     async def test_managed_ptt_port_token_safety(
@@ -761,8 +762,9 @@ class TestPtt:
         # read's own window, not the behaviour under test, decided the
         # verdict.  The shipped default (``CoreRadio.__init__``:
         # ``min(timeout, 2.0)``) takes it out of the race without hiding a
-        # hang: the body bound above starts before the read is even sent, so
-        # it expires first either way.
+        # read that never answers: the ``asyncio.wait_for(pending_read,
+        # 0.5)`` below is this test's real guard for that, and it is
+        # tighter than both this window and the body bound above.
         radio._civ_get_timeout = 2.0
         sent: list[bytes] = []
         responses: asyncio.Queue[bytes] = asyncio.Queue()
@@ -1349,11 +1351,17 @@ class TestResponseDeadlineOpensAtSend:
     ) -> None:
         # A frame went out just now, so this one is held back a full
         # ``_civ_min_interval``.  Making that gap outlast the whole answer
-        # budget is what lets this fail on the mis-charge alone: the
-        # response is queued before the call, so the only way to time out
-        # is to have spent the window before sending.
-        radio._civ_get_timeout = 0.05
-        radio._civ_min_interval = 0.08
+        # budget is what makes the mis-charge decisive rather than a matter
+        # of scheduling luck: the response is already queued when the frame
+        # goes out, so the window is never spent waiting for the radio.
+        # The two are an order of magnitude above the delivery they wait
+        # for, deliberately.  At 0.05/0.08 this test still passed on the
+        # mis-charge it is meant to catch, but the 50 ms left for the RX
+        # pump to hand over an already-queued response was the same margin
+        # this change exists to stop relying on, and it reddened on correct
+        # code about once in 27 loaded runs.
+        radio._civ_get_timeout = 0.5
+        radio._civ_min_interval = 0.8
         radio._last_civ_send_monotonic = time.monotonic()
 
         mock_transport.queue_response_on_send(1, _freq_response(14_074_000))

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -1,6 +1,7 @@
 """Tests for IcomRadio high-level API."""
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -740,11 +741,29 @@ class TestSquelch:
 class TestPtt:
     """Test PTT toggle."""
 
-    @pytest.mark.timeout(2)
+    # ``func_only``: this bound guards the body, which measured 0.00-0.16 s
+    # on a loaded machine.  Charging setup to it as well made whichever
+    # parametrisation ran first carry the process's first ``IcomRadio``
+    # construction -- 158 ms against 0.1 ms for the next one when timed
+    # bare, and 1.5-2.0 s of setup on that same loaded run, against 0.00 s
+    # for the other two -- so the marker expired on machine speed rather
+    # than on anything this test drives.
+    @pytest.mark.timeout(2, func_only=True)
     @pytest.mark.parametrize("invalidation", ["rebind", "poison", "reconnect"])
     async def test_managed_ptt_port_token_safety(
         self, radio: IcomRadio, invalidation: str
     ) -> None:
+        # The ``rebind``/``poison`` paths hold the authoritative read open
+        # across a whole second command -- including that command's own
+        # ``_civ_min_interval`` pacing gap -- and only then feed the read its
+        # answer.  Against the fixture's 50 ms window that choreography
+        # measured 36-38 ms idle and 134 ms on a loaded machine, so the
+        # read's own window, not the behaviour under test, decided the
+        # verdict.  The shipped default (``CoreRadio.__init__``:
+        # ``min(timeout, 2.0)``) takes it out of the race without hiding a
+        # hang: the body bound above starts before the read is even sent, so
+        # it expires first either way.
+        radio._civ_get_timeout = 2.0
         sent: list[bytes] = []
         responses: asyncio.Queue[bytes] = asyncio.Queue()
         send_release, disconnect_release = asyncio.Event(), asyncio.Event()
@@ -1308,6 +1327,42 @@ class TestAckSinkRobustness:
             assert radio._civ_request_tracker.timeout_count == 0
         finally:
             await radio._civ_runtime.stop_pump()
+
+
+class TestResponseDeadlineOpensAtSend:
+    """The answer window opens when the frame is on the wire, not at entry.
+
+    ``_civ_get_timeout`` bounds how long the *radio* may take to answer.
+    The outbound gap ``_civ_min_interval`` and the ACK-sink drain both run
+    before the send and are this process's own scheduling, not radio
+    latency.  ``_civ_rx.py: CivRuntime._execute_civ_raw`` used to stamp its
+    deadline on entry and charge them to the same budget, so a command sent
+    within ``_civ_min_interval`` of the previous one lost that whole gap
+    from its answer window -- and lost the window entirely whenever the
+    pacing sleep overshot the remainder, raising ``TimeoutError`` without
+    ever waiting for a response.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pacing_gap_is_not_charged_to_the_answer_window(
+        self, radio: IcomRadio, mock_transport: MockTransport
+    ) -> None:
+        # A frame went out just now, so this one is held back a full
+        # ``_civ_min_interval``.  Making that gap outlast the whole answer
+        # budget is what lets this fail on the mis-charge alone: the
+        # response is queued before the call, so the only way to time out
+        # is to have spent the window before sending.
+        radio._civ_get_timeout = 0.05
+        radio._civ_min_interval = 0.08
+        radio._last_civ_send_monotonic = time.monotonic()
+
+        mock_transport.queue_response_on_send(1, _freq_response(14_074_000))
+        cmd = build_civ_frame(IC_7610_ADDR, CONTROLLER_ADDR, 0x03)
+
+        frame = await radio._execute_civ_raw(cmd)
+
+        assert frame is not None
+        assert frame.command == 0x03
 
 
 class TestScopeCallbackSafety:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -744,8 +744,9 @@ class TestPtt:
     # ``func_only``: this bound guards the body, which measured 0.00-0.16 s
     # on a loaded machine.  Charging setup to it as well made whichever
     # parametrisation ran first carry the process's first ``IcomRadio``
-    # construction, which costs hundreds of milliseconds against a fraction
-    # of one for every later construction in the same process -- 1.5-2.0 s
+    # construction, which costs a hundred milliseconds or more against a
+    # fraction of one for every later construction in the same process --
+    # 1.5-2.0 s
     # of setup on a loaded run, against 0.00 s for the other two -- so the
     # marker expired on machine speed rather than on anything this test
     # drives.
@@ -1354,9 +1355,9 @@ class TestResponseDeadlineOpensAtSend:
         # budget is what makes the mis-charge decisive rather than a matter
         # of scheduling luck: the response is already queued when the frame
         # goes out, so the window is never spent waiting for the radio.
-        # The two are an order of magnitude above the delivery they wait
-        # for, deliberately.  At 0.05/0.08 this test still passed on the
-        # mis-charge it is meant to catch, but the 50 ms left for the RX
+        # The window sits an order of magnitude above the handover it does
+        # wait for, and the outbound gap above the window, deliberately.  At 0.05/0.08 this test still caught the
+        # mis-charge it exists for, but the 50 ms left for the RX
         # pump to hand over an already-queued response was the same margin
         # this change exists to stop relying on, and it reddened on correct
         # code about once in 27 loaded runs.

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -489,12 +489,15 @@ async def test_pacing_gap_is_not_charged_to_the_answer_window(
 
     ``execute_civ_transaction`` stamped its deadline on entry, so the
     outbound ``_civ_min_interval`` gap inside ``_send_civ_frame_now`` came
-    out of the same budget as the response.  The response here is queued
-    before the call, so a timeout can only mean the window was spent before
-    the frame was sent.  ``_execute_civ_raw`` carried the same mis-charge --
-    see ``test_radio.py: TestResponseDeadlineOpensAtSend``.
+    out of the same budget as the response.  The response here is already
+    queued when the frame goes out, so the window is never spent waiting
+    for the radio, and the pacing gap outlasting it makes the mis-charge
+    decisive rather than a matter of scheduling luck.  Both values sit an
+    order of magnitude above the delivery they wait for, for the reason
+    ``test_radio.py: TestResponseDeadlineOpensAtSend`` records; that test
+    pins the same mis-charge in ``_execute_civ_raw``.
     """
-    radio._civ_min_interval = 0.08
+    radio._civ_min_interval = 0.8
     radio._last_civ_send_monotonic = time.monotonic()
     response = build_civ_frame(
         CONTROLLER_ADDR,
@@ -504,7 +507,7 @@ async def test_pacing_gap_is_not_charged_to_the_answer_window(
     )
     transport.queue_response_on_send(1, _wrap(response))
 
-    result = await radio.send_civ_transaction(0x03, expect="data", timeout=0.05)
+    result = await radio.send_civ_transaction(0x03, expect="data", timeout=0.5)
 
     assert result.status == "response"
     assert result.frame is not None

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -492,8 +492,9 @@ async def test_pacing_gap_is_not_charged_to_the_answer_window(
     out of the same budget as the response.  The response here is already
     queued when the frame goes out, so the window is never spent waiting
     for the radio, and the pacing gap outlasting it makes the mis-charge
-    decisive rather than a matter of scheduling luck.  Both values sit an
-    order of magnitude above the delivery they wait for, for the reason
+    decisive rather than a matter of scheduling luck.  The window sits an
+    order of magnitude above the handover it does wait for, and the
+    outbound gap above the window, for the reason
     ``test_radio.py: TestResponseDeadlineOpensAtSend`` records; that test
     pins the same mis-charge in ``_execute_civ_raw``.
     """

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -482,6 +482,35 @@ async def test_authoritative_ptt_read_waits_out_its_own_refusal(
     assert observations == []
 
 
+async def test_pacing_gap_is_not_charged_to_the_answer_window(
+    radio: IcomRadio, transport: MockTransport
+) -> None:
+    """``timeout`` bounds the radio's answer, not this side's send pacing.
+
+    ``execute_civ_transaction`` stamped its deadline on entry, so the
+    outbound ``_civ_min_interval`` gap inside ``_send_civ_frame_now`` came
+    out of the same budget as the response.  The response here is queued
+    before the call, so a timeout can only mean the window was spent before
+    the frame was sent.  ``_execute_civ_raw`` carried the same mis-charge --
+    see ``test_radio.py: TestResponseDeadlineOpensAtSend``.
+    """
+    radio._civ_min_interval = 0.08
+    radio._last_civ_send_monotonic = time.monotonic()
+    response = build_civ_frame(
+        CONTROLLER_ADDR,
+        IC_7610_ADDR,
+        0x03,
+        data=bcd_encode(14_074_000),
+    )
+    transport.queue_response_on_send(1, _wrap(response))
+
+    result = await radio.send_civ_transaction(0x03, expect="data", timeout=0.05)
+
+    assert result.status == "response"
+    assert result.frame is not None
+    assert result.frame.command == 0x03
+
+
 def _wrap(civ_frame: bytes) -> bytes:
     pkt = bytearray(0x16 + len(civ_frame))
     pkt[0x10] = 0xC1


### PR DESCRIPTION
## What

`_civ_get_timeout` bounds how long the **radio** may take to answer. Both raw CI-V paths stamped that deadline on method entry and then spent part of it locally before the frame ever left:

- the `_civ_min_interval` outbound gap (35 ms by default), and
- in `_execute_civ_raw`, `_drain_ack_sinks_before_blocking` (up to `_civ_ack_sink_grace`, 120 ms).

Neither is radio latency. This PR spends the window from the send onward in `_execute_civ_raw` and `execute_civ_transaction`.

## Why — measured, not inferred

Instrumented on the tests' 50 ms window, with the frame's response **already queued before the call**, so nothing was actually being waited for:

| condition | window left when `wait_for` was reached |
|---|---|
| idle machine | **14.0 ms** (pacing sleep consumed 35.9 ms of 50) |
| under CPU load | **-8.8 ms** (pacing overshot to 54.5 ms) |
| under CPU load | **-14.6 ms** (send itself descheduled for 27.5 ms) |

At a negative remainder the command raised `TimeoutError` at the pre-wait `remaining <= 0` check **without ever waiting for a response**. That is the intermittent `rigplane.core.exceptions.TimeoutError: CI-V response timed out` reported against `tests/test_radio.py: TestToneTsqlDualRxCmd29Guard::test_sub_receiver_get_uses_vfo_select_fallback`, whose select-SUB / GET / restore-MAIN sequence puts sends 2 and 3 inside the pacing gap.

Reproduction rate on the reported class, under 16-20 CPU hogs on 10 cores:

- before: **1 failure in 15** runs
- after: **0 in 40** runs of the whole reported family

An independent review could not reproduce that class-level rate within its budget (0/10 before, 0/10 after) and marked those two counts UNPROVEN; 0/10 against 1/15 has probability ≈0.50, so it refutes nothing either way. The mechanism itself was reproduced independently by direct instrumentation: **14.2-15.4 ms** left of the 50 ms window idle, **-16.6 / -24.4 / -30.1 ms** loaded, with 2 of 3 loaded pre-change runs failing.

The size of the window is unchanged; only its starting point moves. Production defaults (`min(timeout, 2.0)` = 2.0 s) are unaffected in duration.

## Also in this change

- The two `remaining <= 0` raises are removed. Both were reachable — the observed failure came from the post-send one — so this is a behaviour change, not dead-code removal: a frame that used to be abandoned unsent when the pre-send work overran is now sent. That is the intended direction, and `expect="none"` writes return before the drain and are untouched. A second consequence: those raises bypassed `note_timeout()`, so timeouts are now always counted **within these two methods** — the outer `asyncio.wait_for` in `_send_civ_raw` and `IcomCommander.send` still raises uncounted `asyncio.TimeoutError`.
- `deadline_monotonic` is removed from `execute_civ_raw`/`_execute_civ_raw` and the `CoreRadio` delegate. It existed only to let a caller pre-stamp the entry deadline; no caller in `src/` or `tests/` ever passed it, and keeping it would leave the answer window with two meanings.
- `docs/internals/raw-civ-transactions.md` said the per-step timeout covers the send path. It no longer does — the window opens at the send, so the ACK-sink drain and the pacing gap fall outside it, and `web/server.py: _HttpCommandExecutor.execute` adds no outer cap.

## Second, independent cause in the same family

`TestPtt::test_managed_ptt_port_token_safety` was not fixed by the above and needed two test-side fixes, both backed by measurement rather than by widening a timeout on a hunch:

1. Its `rebind`/`poison` paths hold the authoritative read open across a second command — including that command's own `_civ_min_interval` gap — and only then feed the read its answer. That choreography measured **36-38 ms idle and 134 ms loaded** against the fixture's 50 ms window, so the read's own window decided the verdict. It now uses the shipped default (2.0 s). That hides no hang: the body's own `asyncio.wait_for(pending_read, 0.5)` is the real guard, and review confirmed by mutation — deleting the response feed makes the test fail in ~2.2 s rather than hang.
2. `@pytest.mark.timeout(2)` charged setup to its budget, so whichever parametrisation ran first carried the process's first `IcomRadio` construction — hundreds of milliseconds against a fraction of one for later constructions, and 1.5-2.0 s of setup on a loaded run against 0.00 s for the other two. Scoped to `func_only=True`; verified separately that the marker still fires at 2.0 s on a hanging body.

Result for that test under load: 20/30 failures before scoping the marker, **0/30 after**.

## Changed after independent review

Review BLOCKED the first head. The source fix was confirmed correct and reproduced; the block was entirely on the new tests, and it was right:

- **The new pins were themselves machine-speed flakes.** `TestResponseDeadlineOpensAtSend` reddened **1 in 27** loaded runs against unmodified source, raising from the post-change `asyncio.wait_for` rather than from the defect. At `_civ_get_timeout = 0.05` the pin left 50 ms for the RX pump to hand over an already-queued response — the same margin this PR exists to stop relying on. Both pins are now scaled ten-fold (0.5 / 0.8), preserving the `_civ_min_interval > _civ_get_timeout` relation they discriminate on. Verified in both directions: reverting only the source change still fails both on the exact removed lines, and 35 loaded runs under 14 CPU hogs on 10 cores pass. A repeat of the original 1-in-27 reproduction on this side gave 0/30, which is consistent with the reported rate rather than a refutation of it.
- **Two comment sentences claimed a pre-queued response left "the only way" to time out.** A post-send stall longer than the whole window is a second way, and review has it on tape. Both sentences now state what the pin discriminates on instead of claiming exclusivity.
- **Two further prose corrections** in the PTT test: the guard against a read that never answers is the body's own 0.5 s wait, tighter than either bound the comment named; and the first-construction cost is stated as an order of magnitude rather than a machine-specific figure, after a second party measured 449 ms where this one measured 158 ms.
- **Doc drift** the change introduced is corrected (see above).

A second review of that head returned PASS with five non-blocking prose nits. All five are now fixed in a follow-up commit: "passed on the mis-charge" read backwards in a test file; "the delivery they wait for" was attributed to the outbound pacing gap, which waits for nothing; "hundreds of milliseconds" against measurements of 112, 158 and 449 ms; a stale "ownership acquisition" clause that survived the rewrite of its own doc sentence; and a modifier that read as placing the ACK-sink drain inside `_send_civ_frame_now`.

## Not covered by this change

Two tests from the reported flake list are **not** explained by this root cause, and I never reproduced either failing; review confirmed both exclusions structurally:

- `TestMeters::test_get_power_meter` issues a single first command, so `_last_civ_send_monotonic` is still `0.0`, no pacing gap is taken, and the drain returns immediately.
- `test_rigctld_client_backend.py::test_radio_transport_loss_retires_exactly_once` runs on `RigctldClientRadio` and never reaches `CivRuntime`.

The two remaining ones (`test_ic9700_sub_uses_select_restore_pattern`, `TestPerReceiverMode::test_ic7610_set_mode_sub_uses_fallback`) are the same three-frame select/restore shape with `timeout=0.05`, i.e. the same cause.

Two separate, unrelated flakes surfaced during verification and are **not** addressed here, each tracked on its own:

- `tests/test_web_server.py::TestRadioPoller::test_poller_broadcasts_meter_readings` — failed 1 in 5 full-suite runs with `assert 3 >= 4`. It counts poll ticks inside a fixed `asyncio.sleep(0.2)` against a MagicMock radio, so it never reaches `CivRuntime`.
- `tests/test_civ_command_profiling.py::TestOperationThroughput::test_bcd_encoding_throughput` — failed once with `48935 ops/sec` against a hard 50,000 floor while the host was at load average ~47. Idle it measures 922,000-978,000 ops/sec, ~19x the floor, and `bcd_encode` lives in `core/types.py`, untouched here.

## Verification

- `uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread` — `11665 passed, 163 skipped, 48 xfailed`
- `uv run ruff check src/ tests/`, `uv run ruff format --check src/ tests/` — clean
- `uv run mypy --strict src/rigplane/web` — clean; whole-tree `uv run mypy src/` has 2 pre-existing `[type-var]` errors in `commands/cw.py`, untouched here
- `uv run lint-imports` — 5 contracts kept
- `.github/scripts/check-doc-citations.sh` and `--check-links` — both clean

## Guardrails

5 files, 128 insertions + 28 deletions = 156 changed lines — under the 6 files / 600 lines soft threshold.

## Review

Two independent review rounds so far: the first head was BLOCKED on the new tests being flakes themselves, the second passed with five prose nits. This head carries those nit fixes and needs a fresh directive, since the gate requires the SHA to match the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

