### PR TITLE
test: wait for the meter polls instead of counting a fixed window

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3340,18 +3340,34 @@ class TestRadioPoller:
         queue = CommandQueue()
         poller = RadioPoller(radio, cache, queue)
 
+        def meter_calls() -> list[Any]:
+            return [c for c in radio.send_civ.call_args_list if c[0][0] == 0x15]
+
         poller.start()
         # Initial state fetch is done by CoreRadio._fetch_initial_state() on
         # connect; the poller just runs meter polls every _FAST_INTERVAL=25ms.
-        # 0.2s is plenty for ≥3 meter polls.
-        await asyncio.sleep(0.2)
+        #
+        # Wait for those polls; do not count whatever a fixed sleep happened to
+        # fit. A fixed window counts event-loop wakeups, and a loaded host fits
+        # fewer of them into the same wall-clock time -- so the count measures
+        # machine speed, not poller behaviour (this test failed as
+        # ``assert 3 >= 4`` under `-n auto` on a busy host). At
+        # _FAST_INTERVAL=25ms an idle host reaches both counts below well
+        # inside 0.2s, so only a poller that has stopped polling reaches the
+        # bound.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 10.0
+        while loop.time() < deadline:
+            if radio.send_civ.await_count >= 4 and len(meter_calls()) >= 3:
+                break
+            await asyncio.sleep(0.005)
         poller.stop()
 
+        # Asserted after the wait, not folded into it: when the poller is
+        # healthy the loop breaks the moment these hold, and when the bound
+        # expires they report the counts actually observed.
         assert radio.send_civ.await_count >= 4
-        meter_calls = [
-            c for c in radio.send_civ.call_args_list if c[0][0] == 0x15
-        ]  # cmd=0x15
-        assert len(meter_calls) >= 3
+        assert len(meter_calls()) >= 3  # cmd=0x15
 
     async def test_poller_idempotent_start(self) -> None:
         """Calling start() twice does not create duplicate tasks."""


### PR DESCRIPTION
## The defect

`TestRadioPoller::test_poller_broadcasts_meter_readings` was an intermittent
failure — observed once in five consecutive `-n auto` runs — failing as
`AssertionError: assert 3 >= 4` on `radio.send_civ.await_count`.

The shape was `poller.start()` → `await asyncio.sleep(0.2)` → `poller.stop()` →
count. That counts how many event-loop wakeups fit into a fixed wall-clock
window. A loaded host fits fewer of them into the same 0.2s, so the count
measured machine speed rather than poller behaviour.

It is unrelated to the CI-V answer-window change in `dcd332b6`: this test builds
its radio with `_make_radio()`, a `MagicMock` whose `send_civ` is an `AsyncMock`,
so `rigplane.runtime._civ_rx.CivRuntime` is never reached.

The comment above the assertions also disagreed with them — it claimed "0.2s is
plenty for >=3 meter polls" while the first assertion demanded `>= 4` awaits.
The replacement comment states no counts of its own.

## The change

Wait for the condition the test actually cares about — the meter polls — under a
10s bound, instead of counting whatever a fixed sleep happened to fit.

The assertions stay *after* the wait rather than being folded into it. A wait
helper that raises its own timeout error would leave the assertions unable to
fail at all, and would report a bare timeout instead of the counts. As written,
a healthy poller breaks the loop the moment both hold, and an exhausted bound
falls through to assertions that print what was actually observed.

Test-only; no product file is touched.

## Evidence

Reproduced deterministically without a load generator and without a repeat loop,
using a temporary pytest plugin whose autouse async fixture blocks the test's own
event loop in 20ms slices — the same starvation a busy host causes, but
repeatable:

| shape | under identical starvation |
|---|---|
| before | **5/5 failures**, exact reported signature `assert 3 >= 4` |
| after | **5/5 green**, wait took 0.9–2.3s |

A green test proves nothing on its own, so the reworked test was checked against
two mutations of the product to confirm it can still go red:

| mutation | result |
|---|---|
| `_FAST_INTERVAL` 25ms → 3600s | fails `assert 1 >= 4` at ~10.3s |
| `_HIGH_TIER_RX` emptied | fails `assert 2 >= 4` at ~10.3s |

Both fail after the bound and report the counts observed. The product file was
restored after each mutation (`git diff` clean).

## Gates

Authoritative run is on the dedicated test host, which is not shared with interactive work:

- `pytest` (Python 3.11) — **11391 passed, 107 skipped, 48 xfailed in 81s**, zero failures; `ruff check` clean. Counts differ from the developer-machine run below because that host excludes `tests/integration` and runs 3.11 rather than 3.13.

Developer-machine runs, for comparison only:

- Full suite on an idle developer machine (65% CPU idle at start) — 11663 passed, 163 skipped, 48 xfailed in 112s, zero failures.
- Earlier runs on the same machine while it was loaded are discarded as unreliable: they produced failures with little or no overlap between consecutive runs, which is a property of a contended host rather than of any diff. Every failure seen there was a wall-clock or throughput assertion and passed in isolation.

- `uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread` — **11663 passed, 163 skipped, 48 xfailed in 112s**, zero failures
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format src/ tests/` — 699 files unchanged
- `uv run mypy --strict src/rigplane/web` — no issues in 26 source files, run locally

Note on that last one: it did **not** run in CI for this PR, and an earlier revision of this description wrongly said it did. `quick.yml`'s `frontend` path filter matches `frontend/**`, `src/rigplane/web/**` and `quick.yml` itself; this diff touches only `tests/`, so the "Type-check web boundary" step is reported as `skipped` on this head. It runs unconditionally in `full.yml`. The local run above is the evidence, not the CI badge.

## Guardrails

1 file, 28 changed lines — well inside the 6 files / 600 lines soft threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


