### PR TITLE
test: acceptance probe — build a seventh skin from the authoring guide alone

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -205,6 +205,9 @@ import { presentationResources, runtime } from '../lib/runtime/frontend-runtime'
  * the plan's own pin.
  */
 const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
+  // MOR-2035/MOR-2034 acceptance probe — mounts no SpectrumPanel/
+  // AudioSpectrumPanel, same reasoning as dual-receiver-cockpit below.
+  'accept-probe': [],
   'desktop-v2': ['hardware-scope', 'audio-fft'],
   // MOR-1068: the cockpit mounts the VFO/RX-TX surfaces only — no scope
   // panel of either kind — so it demands nothing and bridges nothing.
@@ -216,6 +219,7 @@ const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
 };
 
 const WIDTH_FOR: Record<SkinId, number> = {
+  'accept-probe': 1100,
   'desktop-v2': 1200,
   'dual-receiver-cockpit': 1500,
   'lcd-cockpit': 1000,

--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -143,6 +143,7 @@ import type { AppTxController } from '../lib/runtime/tx-controller/app-host';
 
 /** Viewport width → skin id. Reuses App's own resize reactivity as the knob. */
 const WIDTH_FOR: Record<SkinId, number> = {
+  'accept-probe': 1100,
   'desktop-v2': 1200,
   'dual-receiver-cockpit': 1500,
   'lcd-cockpit': 1000,

--- a/frontend/src/components-v2/meters/AcceptProbeMeter.svelte
+++ b/frontend/src/components-v2/meters/AcceptProbeMeter.svelte
@@ -1,0 +1,62 @@
+<!--
+  Accept Probe Meter — a bespoke S-meter built for the `accept-probe` skin
+  (MOR-2035 / MOR-2034 acceptance experiment: "build a skin with its own
+  S-meters and indicators without touching anything below the presentation
+  layer"). Domain: 'calibrated-db-rel-s9' (see
+  `components-v2/meters/__tests__/meter-contract.ts`) — `value` is the
+  S-meter's calibrated dB-relative-to-S9 reading, matching `toMeterProps`'s
+  `sValue`/`LinearSMeter`'s own `value` prop. S-unit/dBm text is derived
+  only through `smeter-scale.ts`'s own functions, never a local formula, per
+  that contract's rule for this directory.
+-->
+<script lang="ts">
+  import {
+    calibratedToSegments, calibratedToSUnit, calibratedToDbm, formatDbm,
+  } from './smeter-scale';
+
+  interface Props {
+    value: number;
+    active?: boolean;
+  }
+  let { value, active = false }: Props = $props();
+
+  const segments = $derived(calibratedToSegments(value));
+  const sUnit = $derived(calibratedToSUnit(value));
+  const dbmText = $derived(formatDbm(calibratedToDbm(value)));
+</script>
+
+<div class="accept-probe-meter" data-testid="accept-probe-meter" data-active={active}>
+  <div class="accept-probe-meter-bar">
+    {#each Array.from({ length: 20 }) as _, i (i)}
+      <span class="accept-probe-meter-seg" class:lit={i < segments}></span>
+    {/each}
+  </div>
+  <div class="accept-probe-meter-text">{sUnit} {dbmText}</div>
+</div>
+
+<style>
+  .accept-probe-meter {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-family: monospace;
+  }
+  .accept-probe-meter-bar {
+    display: flex;
+    gap: 1px;
+  }
+  .accept-probe-meter-seg {
+    width: 6px;
+    height: 14px;
+    background: #333;
+  }
+  .accept-probe-meter-seg.lit {
+    background: #4caf50;
+  }
+  .accept-probe-meter[data-active='true'] .accept-probe-meter-seg.lit {
+    background: #ff9800;
+  }
+  .accept-probe-meter-text {
+    font-size: 0.85rem;
+  }
+</style>

--- a/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.test.ts
@@ -118,6 +118,7 @@ import { setCapabilities, clearCapabilities } from '$lib/stores/capabilities.sve
 import { calibratedToSUnit, calibratedToDbm, formatDbm } from '../smeter-scale';
 import BarGauge from '../BarGauge.svelte';
 import LinearSMeter from '../LinearSMeter.svelte';
+import AcceptProbeMeter from '../AcceptProbeMeter.svelte';
 import { METER_REGISTRY, type MeterValueDomain } from './meter-contract';
 
 const METERS_DIR = join(__dirname, '..');
@@ -128,6 +129,7 @@ const METERS_DIR = join(__dirname, '..');
 const COMPONENTS: Record<string, unknown> = {
   'BarGauge.svelte': BarGauge,
   'LinearSMeter.svelte': LinearSMeter,
+  'AcceptProbeMeter.svelte': AcceptProbeMeter,
 };
 
 /** Props broad enough to mount ANY registered component regardless of its

--- a/frontend/src/components-v2/meters/__tests__/meter-contract.ts
+++ b/frontend/src/components-v2/meters/__tests__/meter-contract.ts
@@ -64,4 +64,6 @@ interface MeterRegistration {
 export const METER_REGISTRY: readonly MeterRegistration[] = [
   { file: 'BarGauge.svelte', domain: 'preformatted' },
   { file: 'LinearSMeter.svelte', domain: 'calibrated-db-rel-s9' },
+  // accept-probe skin's own S-meter (MOR-2035/MOR-2034 acceptance probe).
+  { file: 'AcceptProbeMeter.svelte', domain: 'calibrated-db-rel-s9' },
 ];

--- a/frontend/src/presentation/layouts/__tests__/accept-probe-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/accept-probe-registration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * MOR-2035/MOR-2034 — the `accept-probe` acceptance-experiment entrypoint,
+ * registered as a v1 layout manifest (`accept-probe-declarations.ts`) and
+ * resolved through the REAL registry, mirroring the shape
+ * `sdr-registration.test.ts` uses for `sdr-test` (named by
+ * `docs/architecture/building-a-skin.md`'s "Wiring a new skin into the app"
+ * step 3 as the convention to follow).
+ *
+ * Unlike `sdr-test`, `accept-probe` does not delegate into `RadioLayout`
+ * with a `skinId` prop — it is its own dedicated layout component — so the
+ * "shares its id with the skin registry loader" check here confirms the
+ * `registry.ts` loader import path instead of a `skinId=` attribute.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
+  TOPOLOGY_CLASSES,
+} from '../contract';
+// Deliberately through the shared aggregation entry, not
+// `../accept-probe-declarations`' module-scope side effect alone — see
+// `sdr-registration.test.ts`'s identical comment for why (vite.config.ts #771).
+import { acceptProbeLayout } from '../declarations';
+
+describe('the accept-probe entrypoint is registered in the real registry', () => {
+  // Kills: accept-probe-declarations.ts defining the manifest but never
+  // calling registerLayout — the resolution below would then read undefined.
+  it('registers "accept-probe" under its stable entrypoint id', () => {
+    expect(getLayout('accept-probe')).toBe(acceptProbeLayout);
+    expect(acceptProbeLayout.id).toBe('accept-probe');
+  });
+
+  // Kills: a manifest id that drifts from the SkinId AcceptProbeSkin.svelte
+  // actually loads under in skins/registry.ts.
+  it('shares its id with the skin registry loader entry', () => {
+    const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
+    expect(registrySource).toMatch(
+      /'accept-probe':\s*\(\)\s*=>\s*import\(['"]\.\/accept-probe\/AcceptProbeSkin\.svelte['"]\)/,
+    );
+  });
+
+  it('declares a compiled loader', () => {
+    expect(typeof acceptProbeLayout.loader).toBe('function');
+  });
+});
+
+describe('declared semantic zones (own bespoke VFO readout + own bespoke meter)', () => {
+  // meters sits alone in its own `meters`-id zone and is declared but never
+  // required — both required by meters-declarability.test.ts's hand-
+  // reviewed shape checks, neither mentioned by
+  // docs/architecture/building-a-skin.md.
+  it('declares a main vfo zone and a separate meters zone; meters is not required', () => {
+    expect(acceptProbeLayout.zones).toEqual([
+      { id: 'main', surfaces: ['vfo'] },
+      { id: 'meters', surfaces: ['meters'] },
+    ]);
+    expect([...acceptProbeLayout.requiredSemanticSurfaces]).toEqual(['vfo']);
+  });
+});
+
+describe('topology honesty', () => {
+  it('resolves itself on all four canonical topologies', () => {
+    for (const topology of TOPOLOGY_CLASSES) {
+      expect(resolveLayoutForTopology('accept-probe', topology)?.id).toBe('accept-probe');
+    }
+  });
+});
+
+describe('MOR-1160 sizing axis — accept-probe stays fluid', () => {
+  it('declares fluid sizing with no breakpoints', () => {
+    expect(acceptProbeLayout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
+  });
+
+  it('resolves on both a desktop and an iPhone-class portrait viewport — fluid never gates', () => {
+    expect(resolveLayoutForViewport('accept-probe', { width: 1440, height: 900 })?.id).toBe('accept-probe');
+    expect(resolveLayoutForViewport('accept-probe', { width: 390, height: 844 })?.id).toBe('accept-probe');
+  });
+});
+
+describe('no fallback family', () => {
+  it('declares no fallback', () => {
+    expect(acceptProbeLayout.fallbackLayoutId).toBeNull();
+  });
+});

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -64,6 +64,7 @@ const radioLayoutSource = readFileSync('src/components-v2/layout/RadioLayout.sve
 const lcdLayoutSource = readFileSync('src/components-v2/layout/LcdLayout.svelte', 'utf8');
 const mobileLayoutSource = readFileSync('src/components-v2/layout/MobileRadioLayout.svelte', 'utf8');
 const cockpitShellSource = readFileSync('src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte', 'utf8');
+const acceptProbeSkinSource = readFileSync('src/skins/accept-probe/AcceptProbeSkin.svelte', 'utf8');
 
 /**
  * MOR-1313. `sdr-test` and `desktop-v2` share the one shell whose semantic
@@ -97,6 +98,14 @@ const DOM_BACKED: Readonly<Record<string, () => boolean>> = {
   'lcd-scope': () => /<SemanticRadioSurfaces\s*\/>/.test(lcdLayoutSource),
   'mobile': () => /<SemanticRadioSurfaces\s*\/>/.test(mobileLayoutSource),
   'dual-receiver-cockpit': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(cockpitShellSource),
+  // MOR-2035/MOR-2034 acceptance probe — its own dedicated layout (no
+  // SemanticRadioSurfaces mount at all), so the proof reads its own bespoke
+  // markup instead: the vfo-backing frequency readout and the meters-backing
+  // AcceptProbeMeter are both unconditional top-level children, never
+  // wrapped in an `{#if}`.
+  'accept-probe': () =>
+    /data-testid="accept-probe-frequency"/.test(acceptProbeSkinSource)
+    && /<AcceptProbeMeter/.test(acceptProbeSkinSource),
 };
 
 describe('forward-declared vs DOM-backed manifest inventory (verify.md N2)', () => {

--- a/frontend/src/presentation/layouts/__tests__/loader-identity-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/loader-identity-inventory.test.ts
@@ -51,8 +51,8 @@ import { getLayout, type LayoutManifest } from '../contract';
 // directly fires `registerLayout` from THIS file and, under the fast pool's
 // `isolate: false`, would leak the registration into sibling files.
 import {
-  desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
+  acceptProbeLayout, desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout,
+  mobileLayout, sdrTestLayout,
 } from '../declarations';
 // Namespace import of the SAME barrel, used ONLY to derive the completeness
 // set structurally (never to register anything — a namespace import has no
@@ -76,6 +76,7 @@ const ALL_MANIFESTS = {
   'lcd-scope': lcdScopeLayout,
   mobile: mobileLayout,
   'desktop-v2': desktopV2Layout,
+  'accept-probe': acceptProbeLayout,
 } as const;
 
 /**
@@ -94,6 +95,7 @@ const EXPECTED_LOADER_SPECIFIER: Readonly<Record<keyof typeof ALL_MANIFESTS, str
   'lcd-scope': '/src/skins/lcd-scope/LcdScopeSkin.svelte',
   mobile: '/src/skins/mobile/MobileSkin.svelte',
   'desktop-v2': '/src/skins/desktop-v2/DesktopSkin.svelte',
+  'accept-probe': '/src/skins/accept-probe/AcceptProbeSkin.svelte',
 };
 
 /** Pulls the quoted argument out of a stringified `() => import('...')`

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -52,7 +52,7 @@ describe('meters is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a meters zone (MOR-1341)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_METERS = ['desktop-v2'];
+  const DECLARES_METERS = ['desktop-v2', 'accept-probe'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/accept-probe-declarations.ts
+++ b/frontend/src/presentation/layouts/accept-probe-declarations.ts
@@ -1,0 +1,50 @@
+/**
+ * MOR-2035/MOR-2034 — the `accept-probe` skin's layout manifest.
+ *
+ * `accept-probe` is a temporary acceptance-experiment skin: it proves a
+ * skin author can build its own dedicated layout, own S-meter, and own
+ * VFO/RX indicator using only `presentation/` and above, following
+ * `docs/architecture/building-a-skin.md` alone. It does not delegate into
+ * `RadioLayout` or `LcdLayout` — `AcceptProbeSkin.svelte` renders its own
+ * bespoke composition, reading state via `lib/runtime/props/panel-props.ts`
+ * (see that file's `toVfoProps`/`toMeterProps`) rather than mounting the
+ * semantic vertical. `zones`/`requiredSemanticSurfaces` still declare
+ * `vfo`/`meters` as a topology/compatibility fact, the same way
+ * `lcd-cockpit`'s manifest does despite `LcdLayout.svelte` never reading it
+ * back (`lcd-declarations.ts`) — the manifest records what facts this skin
+ * surfaces, independent of which mechanism renders them.
+ *
+ * Kept in its own sibling file, re-exported from `./declarations`, matching
+ * the `lcd-declarations.ts`/`mobile-declarations.ts` convention that file's
+ * own barrel comment describes.
+ *
+ * `meters` sits ALONE in its own zone, id `'meters'`, and is declared but
+ * NEVER required — neither rule is in the guide's own prose. Both are
+ * hand-reviewed shape checks in
+ * `presentation/layouts/__tests__/meters-declarability.test.ts`: "%s
+ * declares it under the stable `meters` id, alone in its zone" (mirroring
+ * `desktop-v2`'s own declaration, the only other manifest that test's
+ * hand-maintained `DECLARES_METERS` literal lists) and "%s does not
+ * require the meters surface" (run against EVERY barrel-derived manifest,
+ * not just meters-declaring ones — a radio reporting no meter fields at
+ * all must still resolve this layout; the surface self-gates on
+ * `view.meters` instead).
+ */
+import { registerLayout, type LayoutManifest } from './contract';
+
+export const acceptProbeLayout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'accept-probe',
+  displayName: 'Accept Probe',
+  loader: () => import('../../skins/accept-probe/AcceptProbeSkin.svelte'),
+  zones: [
+    { id: 'main', surfaces: ['vfo'] },
+    { id: 'meters', surfaces: ['meters'] },
+  ],
+  compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo'],
+  stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
+  fallbackLayoutId: null,
+};
+
+registerLayout(acceptProbeLayout);

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -29,6 +29,7 @@ registerLayout(sdrTestLayout);
 
 export { lcdCockpitLayout, lcdScopeLayout } from './lcd-declarations';
 export { mobileLayout } from './mobile-declarations';
+export { acceptProbeLayout } from './accept-probe-declarations';
 // MOR-1266 registration — see that file. Re-exported for the same reason as
 // dualReceiverCockpitLayout above: this barrel is the ONLY thing that wires
 // desktop-v2's manifest into the app, and a named re-export gives every test

--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -114,6 +114,14 @@ const SKIN_ENTRYPOINT_COVERAGE: Readonly<Record<SkinId, EntrypointCoverage>> = {
     entryComponentFile: 'DualReceiverCockpit.svelte',
   },
   mobile: { kind: 'mobile-layout' },
+  // MOR-2035/MOR-2034 acceptance probe — a dedicated bespoke layout, same
+  // shape as dual-receiver-cockpit above (no RadioLayout/LcdLayout/
+  // MobileRadioLayout delegate to mock against).
+  'accept-probe': {
+    kind: 'covered-elsewhere',
+    testFile: 'src/skins/accept-probe/__tests__/AcceptProbeSkin.component.test.ts',
+    entryComponentFile: 'AcceptProbeSkin.svelte',
+  },
 };
 
 const allSkinIds = Object.keys(SKIN_ENTRYPOINT_COVERAGE) as SkinId[];

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -153,6 +153,9 @@ describe('presentation resource plan', () => {
     'lcd-scope': ['audio-fft'],
     // The mobile layout mounts SpectrumPanel but no audio-FFT surface.
     'mobile': ['hardware-scope'],
+    // MOR-2035/MOR-2034 acceptance probe — mounts no SpectrumPanel/
+    // AudioSpectrumPanel, same reasoning as dual-receiver-cockpit above.
+    'accept-probe': [],
   };
 
   const everySkin = Object.keys(EXPECTED_RESOURCE_PLAN) as SkinId[];

--- a/frontend/src/skins/accept-probe/AcceptProbeSkin.svelte
+++ b/frontend/src/skins/accept-probe/AcceptProbeSkin.svelte
@@ -1,0 +1,93 @@
+<!--
+  Accept Probe Skin — MOR-2035/MOR-2034 acceptance experiment.
+
+  Tests the owner's acceptance criterion: "I can build a theme with its own
+  S-meters and indicators ... without touching anything below the
+  presentation layer." Built from docs/architecture/building-a-skin.md
+  alone (see that doc's "Is a scaffold skin warranted?" section for the
+  two sanctioned shapes — this is the second: a dedicated layout component,
+  not a delegate into RadioLayout/LcdLayout).
+
+  This is its own dedicated layout (registered manifest:
+  presentation/layouts/accept-probe-declarations.ts's acceptProbeLayout) —
+  it does not mount the shared semantic vertical (SemanticRadioSurfaces).
+  It reaches live state through the pure state->props mappers the guide's
+  "Read these first" table names (lib/runtime/props/panel-props.ts's
+  toVfoProps/toMeterProps), supplied with ServerState/Capabilities from the
+  `runtime` singleton ($lib/runtime) — the same calling convention
+  lib/runtime/adapters/panel-adapters.ts's deriveVfoControlProps uses
+  internally. Its own bespoke S-meter is
+  components-v2/meters/AcceptProbeMeter.svelte (registered in
+  components-v2/meters/__tests__/meter-contract.ts's METER_REGISTRY).
+
+  Skins may not import $lib/stores/*, $lib/transport/*, or
+  $lib/audio/audio-manager (eslint FORBIDDEN_SKINS_IMPORTS, MOR-2039) —
+  this file imports neither; state and commands come only through
+  lib/runtime/* and lib/runtime/adapters/*.
+
+  Temporary: this skin exists only to probe the v3 authoring guide
+  (MOR-2035 acceptance criterion for MOR-2034). Whether it stays in the
+  tree is a decision for later, not made by this file.
+-->
+<script lang="ts">
+  import { runtime } from '$lib/runtime';
+  import { toVfoProps, toMeterProps } from '$lib/runtime/props/panel-props';
+  import AcceptProbeMeter from '../../components-v2/meters/AcceptProbeMeter.svelte';
+
+  const vfo = $derived(toVfoProps(runtime.state, 'main'));
+  const meter = $derived(toMeterProps(runtime.state, runtime.caps));
+  const freqDisplay = $derived(
+    Number.isNaN(vfo.freq) ? '---' : (vfo.freq / 1_000_000).toFixed(6),
+  );
+</script>
+
+<div class="accept-probe-skin" data-testid="accept-probe-skin">
+  <div class="accept-probe-freq" data-testid="accept-probe-frequency">
+    <span class="accept-probe-freq-value">{freqDisplay}</span>
+    <span class="accept-probe-freq-unit">MHz</span>
+    <span class="accept-probe-mode">{vfo.mode}</span>
+  </div>
+
+  <div
+    class="accept-probe-indicator"
+    data-testid="accept-probe-rx-tx-indicator"
+    data-active={meter.txActive}
+  >
+    {meter.txActive ? 'TX' : 'RX'}
+  </div>
+
+  <AcceptProbeMeter value={meter.sValue} active={meter.txActive} />
+</div>
+
+<style>
+  .accept-probe-skin {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    font-family: monospace;
+    color: #eee;
+    background: #111;
+  }
+  .accept-probe-freq {
+    font-size: 1.5rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .accept-probe-freq-unit,
+  .accept-probe-mode {
+    font-size: 0.9rem;
+    margin-left: 0.4rem;
+    opacity: 0.8;
+  }
+  .accept-probe-indicator {
+    display: inline-block;
+    width: fit-content;
+    padding: 0.1rem 0.5rem;
+    border-radius: 3px;
+    background: #333;
+  }
+  .accept-probe-indicator[data-active='true'] {
+    background: #c62828;
+    color: #fff;
+  }
+</style>

--- a/frontend/src/skins/accept-probe/__tests__/AcceptProbeSkin.component.test.ts
+++ b/frontend/src/skins/accept-probe/__tests__/AcceptProbeSkin.component.test.ts
@@ -1,0 +1,47 @@
+/**
+ * MOR-2035/MOR-2034 acceptance probe — real mount pin for the `accept-probe`
+ * entrypoint (skins/accept-probe/AcceptProbeSkin.svelte).
+ * `skins/__tests__/entrypoints.test.ts`'s `SKIN_ENTRYPOINT_COVERAGE` points
+ * its `covered-elsewhere` entry for `accept-probe` at this file — its
+ * `entryComponentFile: 'AcceptProbeSkin.svelte'` is checked by a substring
+ * match against this file's own source text, which is why the entrypoint's
+ * filename is named explicitly above, not just through the `loadSkin('accept-probe')`
+ * call below — mirroring `dual-receiver-cockpit`'s entry there. That file's
+ * own header warns a `covered-elsewhere` pin is only a substring-mention
+ * check, not proof of behavior — this suite is the actual behavioral proof:
+ * it mounts the real component through `loadSkin`, the same function
+ * `App.svelte` calls, and asserts its own bespoke markup (frequency
+ * readout, RX/TX indicator, bespoke S-meter) actually renders.
+ */
+import { mount, unmount, flushSync } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadSkin } from '../../registry';
+
+let component: ReturnType<typeof mount> | null = null;
+let target: HTMLElement | null = null;
+
+afterEach(() => {
+  if (component) unmount(component);
+  target?.remove();
+  component = null;
+  target = null;
+});
+
+describe('AcceptProbeSkin entrypoint', () => {
+  it('loads via loadSkin("accept-probe") and mounts its own bespoke markup', async () => {
+    const Component = await loadSkin('accept-probe');
+    target = document.createElement('div');
+    document.body.appendChild(target);
+    component = mount(Component, { target });
+    flushSync();
+
+    expect(target.querySelector('[data-testid="accept-probe-skin"]')).not.toBeNull();
+    expect(target.querySelector('[data-testid="accept-probe-frequency"]')).not.toBeNull();
+    expect(target.querySelector('[data-testid="accept-probe-rx-tx-indicator"]')).not.toBeNull();
+    // The bespoke meter (components-v2/meters/AcceptProbeMeter.svelte,
+    // registered in meter-contract.ts's METER_REGISTRY) actually mounts
+    // as part of this skin's own composition, not just registered in
+    // isolation.
+    expect(target.querySelector('[data-testid="accept-probe-meter"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -16,7 +16,7 @@ import {
 } from '$lib/runtime/adapters/layout-mode-adapter';
 
 export type SkinId =
-  | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';
+  | 'accept-probe' | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';
 
 export interface SkinResolutionContext {
   capabilities: Capabilities | null;
@@ -72,6 +72,11 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
  * `LEGACY_LAYOUT_ALIASES` table.
  */
 const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
+  // MOR-2035/MOR-2034 acceptance probe — see skins/accept-probe/AcceptProbeSkin.svelte.
+  // Not yet reachable from resolveSkinId/layout preference (see
+  // docs/architecture/building-a-skin.md's "Wiring a new skin into the app"
+  // step 5) — this entry is what makes the id addressable at all.
+  'accept-probe': () => import('./accept-probe/AcceptProbeSkin.svelte'),
   'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
   // MOR-1068 (F8): the cockpit's layout manifest registers under this exact
   // id, so it needs the matching loadable SkinId — it was the only registered
@@ -111,6 +116,11 @@ export async function loadSkin(id: SkinId): Promise<Component> {
  * manufacture a live service (v3 ADR invariant 12).
  */
 const SKIN_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
+  // Empty by construction, same reasoning as dual-receiver-cockpit below:
+  // this skin's own VFO readout and AcceptProbeMeter mount no SpectrumPanel,
+  // no AudioSpectrumPanel — naming a resource this tree cannot consume would
+  // be a presentation manufacturing a live service (v3 ADR invariant 12).
+  'accept-probe': [],
   'desktop-v2': ['hardware-scope', 'audio-fft'],
   // Empty by construction: the cockpit mounts the VFO/RX-TX surfaces only —
   // no SpectrumPanel, no AudioSpectrumPanel. Membership only permits


### PR DESCRIPTION
## Verdict

**Criterion MET**, with a guardrail flag. Built `accept-probe`: a skin with
its own dedicated layout, its own registered S-meter
(`components-v2/meters/AcceptProbeMeter.svelte`, domain
`calibrated-db-rel-s9`, passes the real non-uniform-calibration conformance
probes in `meter-contract.test.ts`), and its own RX/TX indicator — touching
only `frontend/src/skins/`, `frontend/src/components-v2/`, and
`frontend/src/presentation/`. Nothing under `frontend/src/lib/`,
`frontend/src/core/`, or any Python was touched.

**Guardrail flag (CLAUDE.md §Guardrails):** this PR is **16 files / 386
changed lines** — crosses the 10-file hard ceiling (not the 1000-line one).
Per CLAUDE.md this is "not author-waivable — only the owner grants an
exception, in the PR, before merge," so flagging here rather than deciding
it myself. I could not find a version under 10 files without either
dropping the bespoke-meter half of the criterion under test, or leaving a
real `npm run check`/`vitest` failure unfixed — 11 of the 16 files are
structurally required even with zero bespoke meter (see breakdown below).

## The four predictions, with real output

**1. Twelve declarability suites cover the skin automatically — TRUE for
11 of 12.** `npx vitest run src/presentation/layouts/` auto-exercised
`accept-probe does not require the X surface` in all twelve, derived from
`declarations.ts`'s barrel (MOR-2061: `Object.values(barrel).filter(isLayoutManifest)`)
— zero edits for antenna/band/cw-keyer/dsp/filter/rf-front-end/rx-audio/
ritxit-scan/scope-controls/scope-display/tx-aux. The 12th,
`meters-declarability.test.ts`, has a *separate* hand-reviewed literal
(`DECLARES_METERS = ['desktop-v2']`) the auto-derived list is checked
against — declaring a `meters` zone (my own choice) correctly demanded a
reviewed addition. First real failure:
```
AssertionError: expected [ 'vfo', 'meters' ] to not include 'meters'
 ❯ meters-declarability.test.ts:87:51 — "%s does not require the meters surface"
```
Actionable without reading the test body.

**2. `skins/__tests__/registry.test.ts` refuses to compile — TRUE.**
```
ERROR "src/skins/__tests__/registry.test.ts" 148:9 "Property '\"accept-probe\"'
is missing in type '{...}' but required in type 'Record<SkinId, readonly AppResource[]>'."
```
Names the skin and the required type; actionable without opening the file.

**3. Viewport-width table in `presentation-switch-tx.component.test.ts`
does the same — TRUE**, and it is a *different file* than the guide names
(`presentation-switch-resources.component.test.ts`). Isolated with a
`git stash` on just that file to get a clean before/after:
```
ERROR "src/__tests__/presentation-switch-tx.component.test.ts" 145:7 "Property
'\"accept-probe\"' is missing in type '{...}' but required in type 'Record<SkinId, number>'."
```
The guide's own step 2 names only the `-resources` file; `-tx` has its own,
undocumented, identically-shaped `WIDTH_FOR` table.

**4. A design-language declaring no layout compatibility warns — TRUE for
its actual scope, FALSE for what a skin author needs.** Read
`presentation/languages/layout-compatibility-guard.ts` (MOR-2054, landed
today as commit `611bc167`): `guardLayoutCompatibility` warns only when a
*design language's own* `layoutCompatibility` array has zero
`compatible: true` entries anywhere — a design-language-author problem.
Neither `studioline` nor `fieldline` has that problem, so neither warns
about `accept-probe` specifically being unlisted. Verified empirically with
a throwaway probe (spied `console.warn`; both
`designLanguageActivation(studioline/fieldline, 'accept-probe')` returned
`null`; zero warnings fired) — probe deleted afterward. `accept-probe` will
never receive studioline/fieldline chrome, and nothing says so.

## Hand-edited sites, with judgement

**Structurally unavoidable** (11 files, present even with zero bespoke
meter): `skins/registry.ts` (guide-documented); both `presentation-switch-*
.component.test.ts` files (`WIDTH_FOR: 1100`, unused elsewhere — a human
width choice); `accept-probe-declarations.ts` + `declarations.ts` re-export
(the manifest itself — zones/topologies/sizing are real design decisions);
`loader-identity-inventory.test.ts` (guide-documented); `forward-
declaration-inventory.test.ts` (guide says optional — it is not, see
below; my own DOM-backing prober reads `AcceptProbeSkin.svelte`'s real
source); `skins/__tests__/registry.test.ts` (not named by the guide at
all); `skins/__tests__/entrypoints.test.ts` (guide-documented); the skin
component and its real mount test.

**Discretionary** (5 files, only because I built a bespoke meter instead of
reusing `LinearSMeter`, to test the criterion's literal words — "its own
S-meters"): `AcceptProbeMeter.svelte`, `meter-contract.ts` registration,
`meter-contract.test.ts`'s `COMPONENTS` map (undocumented — see below),
`meters-declarability.test.ts`'s two hand-reviewed literals,
`accept-probe-registration.test.ts` (guide says "by convention", not
enforced by any completeness check — kept for TDD coverage of my own new
manifest, since nothing else independently checks its topology/sizing/
fallback facts).

## Where the guide was wrong or stale

- **`forward-declaration-inventory.test.ts`**: guide says this family "does
  not fail when a new one is missing — it just stops covering it." The
  file's own header says the opposite ("silently landing an undeclared one
  fails `ALL_MANIFESTS`'s `DOM_BACKED` lookup"), and running it produced 3
  real failures, including a raw `TypeError: DOM_BACKED[m.id] is not a
  function` — not a graceful skip.
- **`meter-contract.test.ts`'s `COMPONENTS` map**: the guide's meter
  section says "a new one must be registered there [`meter-contract.ts`]"
  as if that's the whole story. The test file separately hand-lists every
  mounted component in its own `COMPONENTS` map with its own census check
  and failure message — registering in `meter-contract.ts` alone leaves
  the mount census red.
- **Step 1's "Pinned by `skins/__tests__/registry.test.ts`"** reads as
  passive verification. It is actually a third hand-mirrored
  `Record<SkinId, ...>` table (`EXPECTED_RESOURCE_PLAN`), same shape as
  step 2's tables, requiring the same kind of edit, never described as such.

## Where something stayed silent that should have spoken

- **Prediction 4's real scope** (above): a skin whose layout no design
  language lists gets no chrome and no warning, ever.
- **The `runtime`/`panel-props.ts` calling convention**: the guide's "Read
  these first" table points at `panel-props.ts` and `lib/runtime/
  adapters/*` for "how a skin reaches state," but neither `toVfoProps` nor
  `toMeterProps` takes fewer than a `ServerState`/`Capabilities` argument,
  and nothing in that table names the one import that supplies them
  (`runtime` from `$lib/runtime`). Found only by reading
  `panel-adapters.ts`'s own `deriveVfoControlProps` body and
  `SemanticRadioSurfaces.svelte`'s import list — both permitted reading,
  neither pointed at for this specific purpose.
- **`toMeterProps` has zero production callers** (its own inline comment
  says so) — cited by the guide as a worked example with no live precedent
  to confirm the calling convention against.

## Timing (rough)

Guide + all "read first" files + the two worked examples: about a third of
the time. Writing the skin/meter/manifest: about a fifth. The rest — the
worst part — was iterating against the real compiler and vitest: four
separate undocumented tables/rules (`registry.test.ts`'s resource plan, the
second `WIDTH_FOR`, `forward-declaration-inventory.test.ts`'s `DOM_BACKED`,
`meters-declarability.test.ts`'s two rules) each needed a full run to
surface — the guide never named them.

## Verification (foreground, explicit timeouts, real output in hand)

- `npm run check` (final): `COMPLETED 4611 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`
- `npx vitest run src/presentation/layouts/ src/skins/`: 31 files / 427 tests passed
- `npx vitest run` widened to also cover `src/components-v2/meters/` +
  both `presentation-switch-*.component.test.ts` files: 41 files / 567 tests passed
- `npx eslint src/` (the boundary gate, full tree): exit 0, zero output
- `npx vitest run src/__tests__/architecture-boundaries.test.ts` (sanity,
  file not modified): 90/90 passed

**The full frontend suite was not run** — shared machine, narrow selections
only, per instructions. Pending CI and an independent reviewer.

Do not merge. Probe skin intentionally kept in the tree (not deleted) —
whether it stays is a decision for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
