### PR TITLE
test: mark wall-clock profiling as benchmarks instead of gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,12 +117,13 @@ markers = [
     "e2e: end-to-end tests for PCM API and CLI audio workflows",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "validation_hardware: real-radio validation runs; requires explicit env opt-in",
+    "benchmark: wall-clock measurements, reported rather than gated on; deselected by default (run with -m benchmark)",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short -m 'not slow'"
+addopts = "-v --tb=short -m 'not slow and not benchmark'"
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/test_civ_command_profiling.py
+++ b/tests/test_civ_command_profiling.py
@@ -10,6 +10,17 @@ Operations profiled:
 - Command queue processing
 - Response parsing latency
 - Full roundtrip (send + receive + parse)
+
+Marked ``benchmark`` and so deselected from the default suite: every
+assertion below compares a wall-clock measurement against a fixed
+threshold that idle hardware clears by more than an order of magnitude.
+That makes them measurements rather than gates -- a slowdown small enough
+to matter passes, while a host busy enough to slow the process by that
+same order fails, which is what ``pytest -n auto`` on a loaded machine
+produces. Run them deliberately with ``uv run pytest -m benchmark
+tests/`` and read the printed numbers; tightening a threshold here means
+revisiting that marker, because a threshold tight enough to catch a
+regression is also tight enough to catch a busy neighbour.
 """
 
 from __future__ import annotations
@@ -30,6 +41,8 @@ from rigplane.commands import (
     build_civ_frame,
 )
 from rigplane.types import Mode, bcd_encode
+
+pytestmark = pytest.mark.benchmark
 
 
 class TestCIVCommandProfiling:

--- a/tests/test_civ_command_profiling.py
+++ b/tests/test_civ_command_profiling.py
@@ -11,16 +11,19 @@ Operations profiled:
 - Response parsing latency
 - Full roundtrip (send + receive + parse)
 
-Marked ``benchmark`` and so deselected from the default suite: every
-assertion below compares a wall-clock measurement against a fixed
-threshold that idle hardware clears by more than an order of magnitude.
-That makes them measurements rather than gates -- a slowdown small enough
-to matter passes, while a host busy enough to slow the process by that
-same order fails, which is what ``pytest -n auto`` on a loaded machine
-produces. Run them deliberately with ``uv run pytest -m benchmark
-tests/`` and read the printed numbers; tightening a threshold here means
-revisiting that marker, because a threshold tight enough to catch a
-regression is also tight enough to catch a busy neighbour.
+Marked ``benchmark`` and so deselected from the default suite. These
+assertions compare wall-clock measurements against fixed thresholds that idle
+hardware clears many times over, which makes them measurements rather than
+gates: a slowdown small enough to matter passes, while a host busy enough to
+slow the process by that same factor fails.
+``TestOperationThroughput.test_bcd_encoding_throughput`` failed a full-suite
+run at 48935 ops/sec against its 50000 floor with the host at load average
+~47, having measured over twenty times that floor idle;
+``TestLatencyDistribution`` below records the same effect on p99 from the
+other direction. Run them deliberately with ``uv run pytest -m benchmark
+tests/ -s`` and read the printed numbers. Tightening a threshold here means revisiting the marker, because a threshold
+tight enough to catch a regression is also tight enough to catch a busy
+neighbour.
 """
 
 from __future__ import annotations
@@ -265,10 +268,11 @@ class TestLatencyDistribution:
     def test_frame_creation_latency_distribution(self):
         """Measure frame creation latency percentiles.
 
-        Gates the MOR-416 frame-building performance SLO on p50/p95, which
-        both carry a >20x margin over baseline (~0.17µs / ~0.38µs vs the
-        10µs / 30µs budgets below) and stay stable even on a contended
-        CI runner.
+        Reports the MOR-416 frame-building percentiles. It no longer gates
+        them: this module is marked ``benchmark`` and the default suite does
+        not run it (see the module docstring). p50/p95 carry a >20x margin
+        over baseline (~0.17µs / ~0.38µs vs the 10µs / 30µs budgets below),
+        which is why they held on the contended CI runner where p99 did not.
 
         p99 with only 100 samples is not a statistical percentile -- index
         99 of a 100-sample sort is literally the single worst sample, so a

--- a/tests/test_performance_regressions.py
+++ b/tests/test_performance_regressions.py
@@ -8,16 +8,18 @@ These tests establish performance guarantees for key operations:
 
 All tests use mocked UDP transport to isolate command processing from network latency.
 
-Marked ``benchmark`` and so deselected from the default suite: every
-assertion below compares a wall-clock measurement against a fixed
-threshold that idle hardware clears by more than an order of magnitude.
-That makes them measurements rather than gates -- a slowdown small enough
-to matter passes, while a host busy enough to slow the process by that
-same order fails, which is what ``pytest -n auto`` on a loaded machine
-produces. Run them deliberately with ``uv run pytest -m benchmark
-tests/`` and read the printed numbers; tightening a threshold here means
-revisiting that marker, because a threshold tight enough to catch a
-regression is also tight enough to catch a busy neighbour.
+Marked ``benchmark`` and so deselected from the default suite, module name
+notwithstanding. These assertions compare wall-clock measurements against
+fixed thresholds, and the margins are too wide for any regression worth
+catching to trip one first: the narrowest,
+``TestPerformanceSloValidation.test_frame_overhead_acceptable``, measured
+about seven times its floor across ten runs, and the rest clear theirs by
+far more. A host busy enough to slow the process sevenfold does trip it,
+which is what ``pytest -n auto`` on a loaded machine produces. Run them
+deliberately with ``uv run pytest -m benchmark tests/``; this module prints
+nothing, so a pass is the whole result. Tightening a threshold here means revisiting the marker, because a threshold
+tight enough to catch a regression is also tight enough to catch a busy
+neighbour.
 """
 
 from __future__ import annotations

--- a/tests/test_performance_regressions.py
+++ b/tests/test_performance_regressions.py
@@ -7,12 +7,25 @@ These tests establish performance guarantees for key operations:
 - Radio connection handshake
 
 All tests use mocked UDP transport to isolate command processing from network latency.
+
+Marked ``benchmark`` and so deselected from the default suite: every
+assertion below compares a wall-clock measurement against a fixed
+threshold that idle hardware clears by more than an order of magnitude.
+That makes them measurements rather than gates -- a slowdown small enough
+to matter passes, while a host busy enough to slow the process by that
+same order fails, which is what ``pytest -n auto`` on a loaded machine
+produces. Run them deliberately with ``uv run pytest -m benchmark
+tests/`` and read the printed numbers; tightening a threshold here means
+revisiting that marker, because a threshold tight enough to catch a
+regression is also tight enough to catch a busy neighbour.
 """
 
 from __future__ import annotations
 
 import gc
 import time
+
+import pytest
 
 
 from rigplane import IC_7610_ADDR
@@ -26,6 +39,8 @@ from rigplane.types import Mode, bcd_encode
 from _helpers import freq_response as _freq_response
 from _helpers import mode_response as _mode_response
 from _helpers import wrap_civ_in_udp as _wrap_civ_in_udp
+
+pytestmark = pytest.mark.benchmark
 
 
 # =============================================================================

--- a/tests/test_web_audio_streaming_profile.py
+++ b/tests/test_web_audio_streaming_profile.py
@@ -4,6 +4,17 @@ Measures latency and throughput of:
 - Audio codec operations (ulaw decode, PCM16 encode)
 - Frame building and serialization
 - End-to-end relay loop processing
+
+Marked ``benchmark`` and so deselected from the default suite: every
+assertion below compares a wall-clock measurement against a fixed
+threshold that idle hardware clears by more than an order of magnitude.
+That makes them measurements rather than gates -- a slowdown small enough
+to matter passes, while a host busy enough to slow the process by that
+same order fails, which is what ``pytest -n auto`` on a loaded machine
+produces. Run them deliberately with ``uv run pytest -m benchmark
+tests/`` and read the printed numbers; tightening a threshold here means
+revisiting that marker, because a threshold tight enough to catch a
+regression is also tight enough to catch a busy neighbour.
 """
 
 from __future__ import annotations
@@ -23,6 +34,8 @@ from rigplane.web.protocol import (
     MSG_TYPE_AUDIO_RX,
     AUDIO_CODEC_PCM16,
 )
+
+pytestmark = pytest.mark.benchmark
 
 
 class TestAudioCodecPerformance:

--- a/tests/test_web_audio_streaming_profile.py
+++ b/tests/test_web_audio_streaming_profile.py
@@ -5,16 +5,21 @@ Measures latency and throughput of:
 - Frame building and serialization
 - End-to-end relay loop processing
 
-Marked ``benchmark`` and so deselected from the default suite: every
-assertion below compares a wall-clock measurement against a fixed
-threshold that idle hardware clears by more than an order of magnitude.
-That makes them measurements rather than gates -- a slowdown small enough
-to matter passes, while a host busy enough to slow the process by that
-same order fails, which is what ``pytest -n auto`` on a loaded machine
-produces. Run them deliberately with ``uv run pytest -m benchmark
-tests/`` and read the printed numbers; tightening a threshold here means
-revisiting that marker, because a threshold tight enough to catch a
-regression is also tight enough to catch a busy neighbour.
+The measuring tests here are marked ``benchmark`` and so deselected from the
+default suite: they compare wall-clock measurements against fixed thresholds
+that idle hardware clears many times over -- the narrowest,
+``TestAudioCodecPerformance.test_frame_encode_throughput``, by about eight
+times -- or assert nothing at all and exist to print a number. Either way
+they are measurements rather than gates: a slowdown small enough to matter
+passes, while a busy host fails.
+``TestAudioStreamingEndToEnd.test_client_queue_saturation`` is deliberately
+NOT marked and stays in the default suite: it counts ``QueueFull``
+rejections against a bounded queue, a behaviour that does not depend on how
+fast the host is, so none of the reasoning above reaches it. Run the marked
+ones deliberately with ``uv run pytest -m benchmark tests/ -s`` and read the
+printed numbers. Tightening a threshold here means revisiting the marker, because a threshold
+tight enough to catch a regression is also tight enough to catch a busy
+neighbour.
 """
 
 from __future__ import annotations
@@ -35,9 +40,8 @@ from rigplane.web.protocol import (
     AUDIO_CODEC_PCM16,
 )
 
-pytestmark = pytest.mark.benchmark
 
-
+@pytest.mark.benchmark
 class TestAudioCodecPerformance:
     """Profile audio codec operations."""
 
@@ -65,13 +69,15 @@ class TestAudioCodecPerformance:
         )
         assert p50 < 1000, "ulaw decode should be <1ms"
 
-    @pytest.mark.slow
     def test_ulaw_decode_throughput(self) -> None:
         """Measure ulaw decode throughput (samples/sec).
 
-        Marked ``slow`` so the default test run skips it — GitHub Actions
-        runner allocation is variable enough that the throughput floor
-        flakes on slow nodes. Run ``pytest -m slow`` locally to benchmark.
+        Was marked ``slow`` for a reason that was never about duration —
+        "runner allocation is variable enough that the throughput floor
+        flakes on slow nodes" — which is the ``benchmark`` rationale in the
+        module docstring, reached before that marker existed. It carries
+        ``benchmark`` from the class now, so one marker covers the whole
+        shape and ``slow`` goes back to meaning long-running.
         """
         # 20ms audio @ 16kHz = 320 samples = 320 bytes ulaw
         ulaw_frame = bytes([0x80] * 320)
@@ -148,6 +154,7 @@ class TestAudioCodecPerformance:
         assert throughput > 1e6, "Should encode >1M frames/sec"
 
 
+@pytest.mark.benchmark
 class TestAudioBroadcasterPerformance:
     """Profile AudioBroadcaster relay loop processing."""
 
@@ -245,6 +252,7 @@ class TestAudioBroadcasterPerformance:
 class TestAudioStreamingEndToEnd:
     """End-to-end latency measurements."""
 
+    @pytest.mark.benchmark
     def test_full_pipeline_latency(self) -> None:
         """Measure full pipeline: decode → encode → frame."""
         ulaw_frame = bytes([0x80] * 160)
@@ -273,6 +281,7 @@ class TestAudioStreamingEndToEnd:
         )
         assert p50 < 2000, "Full pipeline should be <2ms"
 
+    @pytest.mark.benchmark
     def test_frame_size_impact(self) -> None:
         """Measure impact of different frame sizes."""
         sizes = [160, 320, 640, 1280]  # 8kHz/16kHz/stereo variations


### PR DESCRIPTION
## Why

`tests/test_civ_command_profiling.py::TestOperationThroughput::test_bcd_encoding_throughput` failed a full-suite run at `48935 ops/sec` against `assert ops_per_sec > 50_000`, while the host sat at load average ~47 on 10 cores. Idle, the same loop measures **922,000-1,054,000 ops/sec** — roughly 20x the floor. It did not catch a slow `bcd_encode`; it caught a busy machine, which is exactly what `pytest -n auto` produces.

## It is a class, not a test

Measured on idle hardware, threshold against measurement:

| Module | asserts | headroom |
|---|---|---|
| `tests/test_civ_command_profiling.py` | 9 | 16x - 400x |
| `tests/test_performance_regressions.py` | 5 | **7x** - 50,000x |
| `tests/test_web_audio_streaming_profile.py` | 5 | 7.8x - 588x |

Sample measurements behind those: BCD latency 1.27 µs against a 20 µs threshold; frame parsing 0.04 µs against 10 µs; frame creation 3,991,778 fps against a 10,000 fps floor; `p50` 0.21 µs against 10 µs; and in the SLO file, 0.002 ms against 100 ms, 7.019 ms against 50 ms, 2.542 ms against 20 ms.

Nothing in that range can gate. `bcd_encode` could grow fifteen times slower and still clear its floor, while a host twenty times busier fails it. Note that the tightest margin is **not** in the file that went red: `test_performance_regressions.py` clears `< 20 ms` at 2.54 ms, so the next failure of this kind was not going to be the same test.

Two of the three modules already say what they are, in their own docstrings — "profiles key radio operations to establish baseline latencies", "Measures latency and throughput". They `print` their numbers, and `-q` hides those, so the default suite runs them for their assertions alone: the half that cannot discriminate.

## What this does

- Declares a `benchmark` marker and deselects it by default, alongside the `slow` marker the repo already had: `addopts = "-v --tb=short -m 'not slow and not benchmark'"`.
- Marks the wall-clock tests: `tests/test_civ_command_profiling.py` and `tests/test_performance_regressions.py` carry a module-level `pytestmark = pytest.mark.benchmark`; `tests/test_web_audio_streaming_profile.py` marks its profiling tests individually, leaving `test_client_queue_saturation` (a correctness assertion) in the default run.
- Records the reason in each module docstring, in terms that stay true: a threshold tight enough to catch a regression is also tight enough to catch a busy neighbour, so tightening one means revisiting the marker.

Verified in both directions: **23 tests** leave the default suite and exactly those 23 collect under `-m benchmark` (8 + 7 + 8 per module, measured 2026-09-15 at the current head with `uv run pytest -m benchmark --collect-only -q`).

## What this gives up

Stated plainly, because it is a real loss: a catastrophic regression — seven times slower or worse — now ships unnoticed by the default suite. These assertions did cover that case, badly.

The alternative that keeps the guard is to measure each operation against a reference workload timed in the same process, so the ratio cancels host speed. That is a rewrite of those 23 tests rather than a marker, and worth doing separately if the coverage is wanted back.

The most contestable part of this change is including `tests/test_performance_regressions.py`, which is named for regression testing and speaks of SLOs. It is here because at 7x-50,000x headroom it does not do that, and its tightest assertion is the most exposed of the three files.

## Verification

- `uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread` — `11878 passed, 182 skipped, 48 xfailed`
- `uv run pytest -m benchmark --collect-only -q` over the three modules — `23/24 tests collected (1 deselected)`
- `uv run ruff check src/ tests/`, `uv run ruff format --check src/ tests/` — clean
- `uv run mypy --strict src/rigplane/web` — clean
- `uv run lint-imports` — 5 contracts kept

## Guardrails

4 files, 66 insertions + 9 deletions = 75 changed lines against current `main` — under the 6 files / 600 lines soft threshold.

**Refreshed 2026-09-15:** this branch was two weeks and 566 commits behind `main`, so `origin/main` was merged into it (merge commit, no rebase). `git diff origin/main...HEAD` is still exactly the four files above. The counts in this body were corrected at the same time after an independent review found them stale.

## Review

Needs an independent agent review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

