### PR TITLE
docs(MOR-2071): correct false claims and fill authoring gaps in building-a-skin.md

### DIFF
--- a/docs/architecture/building-a-skin.md
+++ b/docs/architecture/building-a-skin.md
@@ -43,6 +43,7 @@ restated shape drifts and a pointer does not.
 | `frontend/src/presentation/layouts/contract.ts` | `LayoutManifest`, `SEMANTIC_SURFACE_NAMES`, `registerLayout`, `getLayout`, `declaredSurfaces` | Which semantic surfaces a layout may mount, its topology/sizing declaration, and the registry every layout goes through. A name in `SEMANTIC_SURFACE_NAMES` is *declarable*, not necessarily *mounted* — the file's own header lists which names nothing renders through a manifest yet. |
 | `frontend/src/skins/registry.ts` | `SkinId`, `SKIN_LOADERS` (via `loadSkin`), `SKIN_RESOURCE_PLAN` (via `presentationResourcePlan`), `resolveSkinId` | The single place a skin becomes reachable at runtime. `frontend/src/App.svelte` is the only caller of `loadSkin`/`resolveSkinId`. |
 | `frontend/src/lib/runtime/props/panel-props.ts` and `frontend/src/lib/runtime/adapters/*` | e.g. `toVfoProps`, `toMeterProps`, `panel-adapters.ts`'s handlers | Pure state→props mappers and bound callbacks. A skin (or anything it mounts) reaches state and commands through these, never through stores or transport directly — see "What a skin may not import" below. |
+| `frontend/src/lib/runtime/index.ts` (re-exporting `frontend-runtime.ts`) | `runtime` | The one import that supplies the live `state`/`caps` the mappers above take as arguments. `components-v2/layout/RadioLayout.svelte` and `components-v2/layout/MobileRadioLayout.svelte` both import it from `$lib/runtime`, derive `radioState`/`caps` from `runtime.state`/`runtime.caps`; `MobileRadioLayout.svelte` calls `toMeterProps` the same way. `panel-adapters.ts`'s `deriveAmberCockpitProps` (used by `components-v2/panels/lcd/AmberCockpit.svelte`, which also calls `toMeterProps`) supplies `runtime.state`/`runtime.caps` one layer removed. |
 
 ## Two skins to learn the shape from
 
@@ -131,8 +132,12 @@ preference, and one of its links has no check behind it at all.
    entry to `SKIN_RESOURCE_PLAN` (reached only through
    `presentationResourcePlan`) — `[]` if your skin bridges no App-owned
    resource. Both `SKIN_LOADERS` and `SKIN_RESOURCE_PLAN` are typed
-   `Record<SkinId, ...>`, so a missing key fails to compile. Pinned by
-   `frontend/src/skins/__tests__/registry.test.ts`.
+   `Record<SkinId, ...>`, so a missing key fails to compile.
+   `frontend/src/skins/__tests__/registry.test.ts` pins this file's
+   behaviour, and separately hand-mirrors `SKIN_RESOURCE_PLAN` in its own
+   `EXPECTED_RESOURCE_PLAN` for its own assertions — also typed
+   `Record<SkinId, ...>`, so add your id there too or `npm run check` fails
+   on this file next.
 2. **`frontend/src/__tests__/presentation-switch-resources.component.test.ts`**:
    add your id to `SKIN_PLAN`, a hand-mirrored copy of `SKIN_RESOURCE_PLAN`
    that this file's own "mirrors the production per-skin resource plan"
@@ -162,16 +167,24 @@ preference, and one of its links has no check behind it at all.
    exports" test — so a missing row fails `npx vitest run`, not
    `npm run check`.
 
-   A different family of files also hand-lists every registered manifest,
-   for its own purpose, and does not fail when a new one is missing — it
-   just stops covering it:
+   A related family of files also touches every registered manifest, for
+   narrower purposes of their own, and each one fails loudly when it falls
+   out of sync:
    `frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts`
-   (`ALL_MANIFESTS`, `DOM_BACKED`) and the sibling `*-declarability.test.ts`
-   files in the same directory, one per semantic surface (e.g.
-   `meters-declarability.test.ts`'s `ALL` — its own comment reads "extend
-   by hand, with a layout review, never silently"). Nothing here is
-   required for a minimal skin; know they exist because if your skin
-   should be counted in one of them, nothing will tell you that it isn't.
+   derives its manifest set (`ALL_MANIFESTS`) from the barrel rather than
+   hand-listing it, and fails its own "every registered manifest has an
+   asserted DOM-backing proof" test the moment a new manifest has no entry
+   in the file's hand-listed `DOM_BACKED` table — its own header states
+   this outright. The sibling `*-declarability.test.ts` files (e.g.
+   `meters-declarability.test.ts`) share that shape: the manifest set each
+   one checks (its own `ALL`) is likewise derived from the barrel, and
+   only a narrower, curated table is
+   hand-listed (e.g. that file's `DECLARES_METERS`, "extend by hand, with a
+   layout review, never silently") — a manifest whose actual declarations
+   drift from that table fails the file's own equality assertion. Nothing
+   here is required for a minimal skin that declares none of these
+   surfaces; if yours does, read the relevant file rather than assume a
+   compile error is the only way to find out.
 4. **`frontend/src/skins/__tests__/entrypoints.test.ts`**: add your `SkinId`
    to `SKIN_ENTRYPOINT_COVERAGE`, picking the coverage `kind` that matches
    how you actually mount (`radio-layout` / `lcd-layout` / `mobile-layout`
@@ -238,12 +251,17 @@ preference, and one of its links has no check behind it at all.
 `frontend/src/components-v2/meters/`. A new one must be registered there
 under the correct domain: `'calibrated-db-rel-s9'` (derive S-unit/dBm text
 only through `smeter-scale.ts`'s own functions, never a local formula) or
-`'preformatted'` (render the given `displayValue` verbatim). Reusing one of
-the two existing components (`BarGauge.svelte`, `LinearSMeter.svelte`)
-needs no new registration. `lcd-cockpit`'s own instruments live under
-`components-v2/panels/lcd/` instead and do not touch this contract at all —
-read `meter-contract.ts`'s header before assuming it governs every
-meter-shaped widget in the app.
+`'preformatted'` (render the given `displayValue` verbatim). That
+registration alone is not the whole story: `meter-contract.test.ts` keeps
+its own `COMPONENTS` map — the mounted-component reference for every
+registered file — separately from `METER_REGISTRY`, and its "every
+METER_REGISTRY entry has a mounted-component mapping in this suite" test
+fails until your new component is added there too. Reusing one of the two
+existing components (`BarGauge.svelte`, `LinearSMeter.svelte`) needs no
+new registration.
+`lcd-cockpit`'s own instruments live under `components-v2/panels/lcd/`
+instead and do not touch this contract at all — read `meter-contract.ts`'s
+header before assuming it governs every meter-shaped widget in the app.
 
 ## What a skin may not import
 


### PR DESCRIPTION
## Summary

Implements MOR-2068 and MOR-2071 in one pass over one file:
`docs/architecture/building-a-skin.md`. Both tickets describe findings
from a single audit/build exercise and explicitly warn their text is "a
report of one experiment, not a verified inventory" — every claim below
was re-derived against `origin/main` at `d3a6530e85592212bf4dd2cc678995beb5ce17ff`,
not copied from either ticket or from the PRs that changed the underlying
files.

Documentation only. No production code or test files were touched.

**Revision history on this head:** an independent review of an earlier
version of this PR confirmed every substantive correction below by
mutation, then found two sentences in my own rework that were themselves
unverified universal claims — the exact defect class this PR exists to
fix. A third, pre-existing sentence undercounted a real set. Per owner
ruling, all three are **deleted**, not reworded: this guide is written for
a reader without the source in front of them, so an absent sentence costs
one lookup while a wrong one costs their trust in the whole document. See
"What review caught, and what I deleted" below.

## MOR-2068 — "building-a-skin.md understates coverage"

The guide claimed `forward-declaration-inventory.test.ts` (`ALL_MANIFESTS`,
`DOM_BACKED`) and `meters-declarability.test.ts`'s `ALL` "hand-list every
registered manifest" and "do not fail when a new one is missing."

**Confirmed false, both halves**, against current source:
- `forward-declaration-inventory.test.ts`: `ALL_MANIFESTS` is
  `Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest)` —
  derived from the barrel, not hand-listed (MOR-2060). Its hand-listed
  `DOM_BACKED` table IS checked for completeness by the test
  `'every registered manifest has an asserted DOM-backing proof'`, which
  fails the moment a manifest lacks an entry — the file's own header
  states this outright ("silently landing an undeclared one fails
  `ALL_MANIFESTS`'s `DOM_BACKED` lookup below").
- `meters-declarability.test.ts`: `ALL` is
  `Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest).map(...)`
  — derived, not hand-listed (MOR-2061). **Enumerated, not sampled:** all
  twelve `*-declarability.test.ts` files (`antenna`, `band`, `cw-keyer`,
  `dsp`, `filter`, `meters`, `rf-front-end`, `ritxit-scan`, `rx-audio`,
  `scope-controls`, `scope-display`, `tx-aux`) share this exact shape —
  `const ALL = Object.values(layoutDeclarationsBarrel)...` plus a narrower
  hand-listed `DECLARES_X` literal plus a `'the declaring set is exactly
  the reviewed literal'` equality test that fails on drift.

Also checked per the ticket's instruction to verify the step list's
MOR-2059 repoint rather than assume it: `presentation/layout-mode.ts`
(`LayoutMode`, `CANONICAL_LAYOUT_MODES`), `presentation/workspace/contract.ts`
(`WORKSPACE_LAYOUT_IDS` deriving from `CANONICAL_LAYOUT_MODES`,
`workspaceLayoutManifestId`'s `Record<WorkspaceLayoutId, string | null>`),
and `lib/stores/layout.svelte.ts`/`lib/runtime/adapters/layout-mode-adapter.ts`
(the compatibility-shim chain) — all still accurate. Left untouched.

Also swept every other site the "Wiring a new skin" section names
(`presentation-switch-resources.component.test.ts`'s `SKIN_PLAN`/`WIDTH_FOR`,
`loader-identity-inventory.test.ts`'s `ALL_MANIFESTS`/`EXPECTED_LOADER_SPECIFIER`,
`entrypoints.test.ts`'s `SKIN_ENTRYPOINT_COVERAGE`, `StatusBar.svelte`'s
`skinOptions`, `registry.ts`'s `resolveSkinId`) — all still match current
source; only the passage above was falsified.

## MOR-2071 — "the guide sends an author wrong in three places and silent in two"

1. Same passage as MOR-2068 above — one correction serves both tickets.
2. **Confirmed.** `meter-contract.test.ts`'s `COMPONENTS` map is a second,
   hand-listed table (mounted-component reference per registered file),
   separate from `meter-contract.ts`'s `METER_REGISTRY`. Its own test
   `'every METER_REGISTRY entry has a mounted-component mapping in this
   suite'` fails until a new meter is added there too.
3. **Confirmed.** `skins/__tests__/registry.test.ts` has its own
   `EXPECTED_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]>`,
   hand-mirroring `registry.ts`'s `SKIN_RESOURCE_PLAN`. It needs the same
   edit as `SKIN_RESOURCE_PLAN` itself, and the guide's step 1 named the
   file only as passive verification without saying so.
4. **Confirmed.** The contracts table never named the import that
   supplies `toVfoProps`/`toMeterProps`'s `state`/`caps` arguments —
   `runtime` from `$lib/runtime` (`lib/runtime/index.ts` re-exporting
   `frontend-runtime.ts`).
5. **Corrected per the ticket's own addendum, not as originally filed.**
   The original claim ("`toMeterProps` has zero production callers") is
   itself false: `MobileRadioLayout.svelte` and
   `components-v2/panels/lcd/AmberCockpit.svelte` both call `toMeterProps`
   (the latter via `panel-adapters.ts`'s `deriveAmberCockpitProps`, which
   supplies `runtime.state`/`runtime.caps` one layer removed). Folded into
   the item-4 fix, attributing each caller to the specific mapper it
   actually calls rather than grouping all three files under both
   mappers.

## What review caught, and what I deleted

Independent review confirmed every correction above by mutation. It also
caught two sentences my rework introduced that were themselves confident,
unverified universal claims:

- **"nothing named in this table reads a store or transport module
  directly instead"** — false. Seven of the modules under
  `lib/runtime/adapters/` (`capabilities-adapter.ts`, `panel-adapters.ts`,
  `mod-input-auto.svelte.ts`, `mod-input-tx-guard.svelte.ts`,
  `layout-mode-adapter.ts`, `lcd-chrome-adapter.ts`,
  `qsy-history-adapter.ts`) import `$lib/stores/*` directly — confirmed
  by grep, all seven cited above are real, not a sample. **Deleted**, not
  narrowed: the reviewer's suggested narrowing (to the three `.svelte`
  consumers) is also false — `RadioLayout.svelte` and
  `MobileRadioLayout.svelte` both import `$lib/stores/*` directly too.
- **"used only by that file's mount census"** — false.
  `meter-contract.test.ts`'s `renderMeter` (which reads `COMPONENTS`) is
  called from three sites: the mount census and both
  `describe.each(byDomain(...))` conformance blocks in the same file —
  confirmed the only `mount(...)` call in the file is inside `renderMeter`.
  **Deleted**, not reworded to "the mounting table every conformance case
  goes through" (my first attempt, also rejected per owner ruling: delete
  over rewrite even when the replacement is itself accurate).

One more, pre-existing rather than introduced by me, that review flagged
in the same sweep:

- **"one per semantic surface"** (describing the `*-declarability.test.ts`
  files) — undercounts. `SEMANTIC_SURFACE_NAMES` has fourteen entries;
  twelve declarability files exist; `vfo` and `rxTx` have none. **Deleted**
  the "one per semantic surface" framing entirely — no substitute count,
  per the standing instruction that a repo-derived count in this guide
  will go stale the same way a hand-picked one would.

While re-verifying the surviving text for this response, I independently
caught a fourth issue in my own rework not flagged by either review round:
the `runtime` table row's example sentence grouped
`SemanticRadioSurfaces.svelte`, `RadioLayout.svelte` and
`MobileRadioLayout.svelte` together as calling `toVfoProps`/`toMeterProps`.
`SemanticRadioSurfaces.svelte` calls neither (confirmed: no
`toVfoProps`/`toMeterProps` reference in that file — it uses `runtime` for
other mappers, e.g. `toRadioViewModel`, already documented in a separate
row), and `RadioLayout.svelte` calls `toVfoProps` but never `toMeterProps`.
Fixed by dropping `SemanticRadioSurfaces.svelte` from that sentence and
attributing `toVfoProps`/`toMeterProps` to the specific file that actually
calls each, rather than deleting the whole row — the underlying claim
(that `runtime` supplies live state/caps to these mappers) is real and
was the substance of MOR-2071 items 4–5.

A further review round at head `df30fdb6` caught a fifth issue, in the fix for the fourth: the corrected sentence said `RadioLayout.svelte`/`MobileRadioLayout.svelte` derive `radioState`/`caps` and "pass them to `toVfoProps`" — but `toVfoProps(state: ServerState | null, receiver: 'main' | 'sub')` takes no `caps` parameter; confirmed all four production call sites are `toVfoProps(radioState, 'main'/'sub')`, no `caps` argument. **Deleted** the clause ("and pass them to `toVfoProps`") rather than adding a corrected claim about which mapper takes which argument — per the same ruling, an author can read a function’s signature for themselves, and the argument-routing detail was never the gap MOR-2071 identified; only that `runtime` is the source of the state/caps arguments was.

## Evidence table

Every sentence added or touched in this file on the current head, with
the file opened, the symbol read, and what it actually says:

| new/changed sentence | file opened | symbol read | what it actually says |
|---|---|---|---|
| Table row citation: `frontend/src/lib/runtime/index.ts` (re-exporting `frontend-runtime.ts`) / `runtime` | `frontend/src/lib/runtime/index.ts` | `export { runtime } from './frontend-runtime';` | `runtime` is a real, importable symbol re-exported from this barrel file |
| "The one import that supplies the live `state`/`caps` the mappers above take as arguments." | `frontend/src/lib/runtime/frontend-runtime.ts` | `runtime` object (state/caps getters) | The singleton this table cell names is the thing `toVfoProps`/`toMeterProps` callers read `.state`/`.caps` off of (evidenced by the next two rows) |
| "`RadioLayout.svelte` and `MobileRadioLayout.svelte` both import it from `$lib/runtime`, derive `radioState`/`caps` from `runtime.state`/`runtime.caps`; `MobileRadioLayout.svelte` calls `toMeterProps` the same way." | `components-v2/layout/RadioLayout.svelte`, `components-v2/layout/MobileRadioLayout.svelte` | `import { runtime } from '$lib/runtime'`; `let radioState = $derived(runtime.state)`; `let caps = $derived(runtime.caps)`; `toMeterProps(radioState, caps)` (`MobileRadioLayout.svelte` only) | Both files import `runtime` and derive `radioState`/`caps` from it; only `MobileRadioLayout.svelte` additionally calls `toMeterProps` — confirmed `toVfoProps(state, receiver)` takes no `caps` parameter, so nothing in this row claims it is passed one |
| "`panel-adapters.ts`'s `deriveAmberCockpitProps` (used by `AmberCockpit.svelte`, which also calls `toMeterProps`) supplies `runtime.state`/`runtime.caps` one layer removed." | `lib/runtime/adapters/panel-adapters.ts`, `components-v2/panels/lcd/AmberCockpit.svelte` | `deriveAmberCockpitProps(): AmberCockpitProps { return { radioState: runtime.state, caps: runtime.caps, ... } }`; `let cockpitProps = $derived(deriveAmberCockpitProps())`; `let radioState = $derived(cockpitProps.radioState)`; `toMeterProps(radioState, caps)` | `AmberCockpit.svelte` gets `radioState`/`caps` from `deriveAmberCockpitProps()`, which itself reads `runtime.state`/`runtime.caps` — one indirection layer, then calls `toMeterProps` |
| "`registry.test.ts` pins this file's behaviour, and separately hand-mirrors `SKIN_RESOURCE_PLAN` in its own `EXPECTED_RESOURCE_PLAN` ... so add your id there too or `npm run check` fails on this file next." | `frontend/src/skins/__tests__/registry.test.ts`, `frontend/src/skins/registry.ts` | `const EXPECTED_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {...}`; `const SKIN_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {...}` | Both are identically-shaped `Record<SkinId, ...>` literals; a missing key in either fails `npm run check` |
| "A related family of files also touches every registered manifest ... and each one fails loudly when it falls out of sync: `forward-declaration-inventory.test.ts` derives its manifest set (`ALL_MANIFESTS`) from the barrel ... its own header states this outright." | `presentation/layouts/__tests__/forward-declaration-inventory.test.ts` | `const ALL_MANIFESTS: readonly LayoutManifest[] = Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest);`; `it('every registered manifest has an asserted DOM-backing proof', ...)`; header comment "silently landing an undeclared one fails `ALL_MANIFESTS`'s DOM_BACKED lookup below" | `ALL_MANIFESTS` is derived, not hand-listed; the completeness test fails when a manifest has no `DOM_BACKED` entry; the header says so explicitly |
| "The sibling `*-declarability.test.ts` files (e.g. `meters-declarability.test.ts`) share that shape ... a manifest whose actual declarations drift from that table fails the file's own equality assertion." | all twelve `presentation/layouts/__tests__/*-declarability.test.ts` files | `const ALL = Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest)...` (present verbatim in all 12); `const DECLARES_X = [...]` (hand-listed, one per file); `it('the declaring set is exactly the reviewed literal', ...)` (present verbatim in all 12) | Enumerated all 12 files (not sampled): every one derives its manifest set from the barrel and hand-lists only a narrower per-surface table, with an equality test that fails on drift |
| "Nothing here is required for a minimal skin that declares none of these surfaces; if yours does, read the relevant file rather than assume a compile error is the only way to find out." | `presentation/layouts/__tests__/forward-declaration-inventory.test.ts`, `meters-declarability.test.ts` | `const DOM_BACKED: Readonly<Record<string, () => boolean>>`; `const DECLARES_METERS = ['desktop-v2']` (no `Record` type annotation) | Neither hand-listed table is a compile-checked `Record<SkinId, ...>` — both are caught only by their own vitest assertions, consistent with the section's own framing |
| "That registration alone is not the whole story: `meter-contract.test.ts` keeps its own `COMPONENTS` map ... separately from `METER_REGISTRY`, and its \"every METER_REGISTRY entry has a mounted-component mapping in this suite\" test fails until your new component is added there too." | `components-v2/meters/__tests__/meter-contract.test.ts`, `meter-contract.ts` | `const COMPONENTS: Record<string, unknown> = { 'BarGauge.svelte': BarGauge, 'LinearSMeter.svelte': LinearSMeter };`; `it('every METER_REGISTRY entry has a mounted-component mapping in this suite', () => { const missing = METER_REGISTRY.filter((m) => !(m.file in COMPONENTS))...})` | `COMPONENTS` is a separate hand-listed map in the test file; the named test fails until a new `METER_REGISTRY` entry also gets a `COMPONENTS` entry |
| "Reusing one of the two existing components (`BarGauge.svelte`, `LinearSMeter.svelte`) needs no new registration." (pre-existing text, reflowed only — word-for-word unchanged from `origin/main`) | `components-v2/meters/__tests__/meter-contract.ts` | `export const METER_REGISTRY: readonly MeterRegistration[] = [{ file: 'BarGauge.svelte', ... }, { file: 'LinearSMeter.svelte', ... }]` | Both components are already registered; re-verified accurate, no content change from prior guide text |
| "`lcd-cockpit`'s own instruments live under `components-v2/panels/lcd/` instead and do not touch this contract at all ..." (pre-existing text, reflowed only — word-for-word unchanged from `origin/main`) | `components-v2/panels/lcd/*.svelte` (all files in that directory) | `grep -l "meter-contract" components-v2/panels/lcd/*.svelte` → no matches | No LCD instrument file references `meter-contract.ts`; re-verified accurate, no content change from prior guide text |

## Not reproduced / left alone

Nothing from either ticket was found unreproducible at this head — every
named claim was checked against current source as listed above.

## Deliberately out of scope

- **MOR-2076** — `toMeterProps`'s own source comment is the thing that
  falsely claims no callers exist. Not touched here; source comments are
  out of scope for this docs-only PR.
- **MOR-2065** — pinning this guide's content against the code it
  describes. Not built here per the task's instruction.

**Coordination note:** while implementing this, sessions working MOR-2070
and MOR-2074 (in-flight elsewhere, touching layout-side coverage checks
this guide also describes) flagged that this guide should avoid
closed-list/count framing anywhere it does not derive from something in
the repo that reddens when it changes (umbrella concern MOR-2054). Per a
later owner ruling covering this same PR, the operative rule going
forward is stronger: a wrong sentence gets deleted, not reworded or
hedged, because an absent sentence costs a reader one lookup while a
wrong one costs their trust in the whole document.

## Test plan

- [x] `.github/scripts/check-doc-citations.sh` — clean (846 grandfathered
      citations, no new `path:line` citation added)
- [x] `.github/scripts/check-doc-citations.sh --check-growth origin/main` —
      baseline did not grow
- [x] `.github/scripts/check-doc-citations.sh --check-links` — clean (2
      pre-existing grandfathered dead links, unrelated to this change)
- [x] `.github/scripts/check-doc-citations.sh --check-links --check-growth origin/main` —
      baseline did not grow
- [x] `git diff --stat` — 1 file changed, 35 insertions(+), 17 deletions(-)
- [ ] No Python/frontend suite run — docs-only change, no `src/` or
      `frontend/src/` files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
