### PR TITLE
fix(MOR-2075): widen eslint boundary globs to cover .ts files in display/meters/vfo/controls

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -323,6 +323,10 @@ export default [
 
   // ── Import boundary: presentation components ──
   // Panels, layouts, LCD, skins, and app entry — must NOT import runtime/transport directly.
+  // display/meters/vfo/controls gained `.ts` coverage under MOR-2075 — before that fix,
+  // these globs matched only `*.svelte`, so a `.ts` file in those four directories (e.g.
+  // a utils module) matched no boundary rule at all. panels/ and layout/ already covered
+  // both extensions; this brings the other four presentation-components zones in line.
   {
     files: [
       'src/App.svelte',
@@ -331,9 +335,13 @@ export default [
       'src/components-v2/layout/**/*.svelte',
       'src/components-v2/layout/**/*.ts',
       'src/components-v2/display/**/*.svelte',
+      'src/components-v2/display/**/*.ts',
       'src/components-v2/meters/**/*.svelte',
+      'src/components-v2/meters/**/*.ts',
       'src/components-v2/vfo/**/*.svelte',
+      'src/components-v2/vfo/**/*.ts',
       'src/components-v2/controls/**/*.svelte',
+      'src/components-v2/controls/**/*.ts',
       // semantic and primitives get their own stricter blocks below (MOR-1061):
       'src/skins/**/*.svelte',
     ],

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -323,10 +323,6 @@ export default [
 
   // ── Import boundary: presentation components ──
   // Panels, layouts, LCD, skins, and app entry — must NOT import runtime/transport directly.
-  // display/meters/vfo/controls gained `.ts` coverage under MOR-2075 — before that fix,
-  // these globs matched only `*.svelte`, so a `.ts` file in those four directories (e.g.
-  // a utils module) matched no boundary rule at all. panels/ and layout/ already covered
-  // both extensions; this brings the other four presentation-components zones in line.
   {
     files: [
       'src/App.svelte',

--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -563,13 +563,6 @@ describe('v3 package boundaries (MOR-1061)', () => {
     expect(hits).toBe(0);
   });
 
-  // ── MOR-2075: display/meters/vfo/controls glob fix ──────────────────────
-  // Same shape as the skins .ts pin above (MOR-2039). Probe uses
-  // `$lib/audio/audio-manager`, not transport: `isTransport`
-  // (scripts/radio-authority-eslint-plugin.mjs) matches only
-  // `transport/{ws-client,http-client}`, so a transport probe would also
-  // fail pre-fix via `radio-authority/structural-boundary` for an unrelated
-  // reason.
   it.each([
     ['display', 'src/components-v2/display/frequency-format.ts'],
     ['meters', 'src/components-v2/meters/bar-gauge-utils.ts'],

--- a/frontend/src/__tests__/architecture-boundaries.test.ts
+++ b/frontend/src/__tests__/architecture-boundaries.test.ts
@@ -562,6 +562,26 @@ describe('v3 package boundaries (MOR-1061)', () => {
     );
     expect(hits).toBe(0);
   });
+
+  // ── MOR-2075: display/meters/vfo/controls glob fix ──────────────────────
+  // Same shape as the skins .ts pin above (MOR-2039). Probe uses
+  // `$lib/audio/audio-manager`, not transport: `isTransport`
+  // (scripts/radio-authority-eslint-plugin.mjs) matches only
+  // `transport/{ws-client,http-client}`, so a transport probe would also
+  // fail pre-fix via `radio-authority/structural-boundary` for an unrelated
+  // reason.
+  it.each([
+    ['display', 'src/components-v2/display/frequency-format.ts'],
+    ['meters', 'src/components-v2/meters/bar-gauge-utils.ts'],
+    ['vfo', 'src/components-v2/vfo/vfo-utils.ts'],
+    ['controls', 'src/components-v2/controls/band-utils.ts'],
+  ])('rejects a %s .ts file importing $lib/audio/audio-manager directly (the glob fix — .ts had zero coverage before)', async (_zone, filePath) => {
+    const hits = await restrictedImportHits(
+      `import { audioManager } from '$lib/audio/audio-manager';`,
+      filePath,
+    );
+    expect(hits).toBeGreaterThan(0);
+  });
 });
 
 describe('radio authority boundary (MOR-1406)', () => {


### PR DESCRIPTION
## What changed

`frontend/eslint.config.js`'s "presentation components" `no-restricted-imports`
block (`FORBIDDEN_RUNTIME_IMPORTS`: no `$lib/transport/*`, no
`$lib/audio/audio-manager`) globs `panels/` and `layout/` with both
`**/*.svelte` and `**/*.ts`, but globbed `components-v2/{display,meters,vfo,controls}`
with `**/*.svelte` only. Added the matching `**/*.ts` glob entry for each of
the four directories, in the same two-entry style panels/layout already use
in this block (no new plugin, structure, or shared constant —
`FORBIDDEN_RUNTIME_IMPORTS` is reused as-is).

`src/__tests__/architecture-boundaries.test.ts` gets a new `it.each` block —
same shape as the MOR-2039 skins `.ts` pin already in this file — that fails
when the four glob lines above are absent and passes when they're present.
Red/green output below.

## Re-derived count: 13 `.ts` files newly covered (matches the ticket)

```
src/components-v2/display/frequency-format.ts
src/components-v2/meters/bar-gauge-utils.ts
src/components-v2/meters/smeter-scale.ts
src/components-v2/vfo/vfo-ops-utils.ts
src/components-v2/vfo/vfo-utils.ts
src/components-v2/controls/band-utils.ts
src/components-v2/controls/broadcast-presets.ts
src/components-v2/controls/install-prompt-utils.ts
src/components-v2/controls/status-badge-style.ts
src/components-v2/controls/value-control/index.ts
src/components-v2/controls/value-control/skin.ts
src/components-v2/controls/value-control/skins/index.ts
src/components-v2/controls/value-control/value-control-core.ts
```
(counted with `find ... -name "*.ts" ! -path "*__tests__*" ! -name "*.test.ts"`
under the four directories; test files are excluded here and, separately, are
already exempted by the "tests may import anything" block at the bottom of
the config.)

## No live breach — verified two ways

1. Manually inspected every import line in the 13 files above: none imports
   `$lib/transport/*` or `$lib/audio/audio-manager` (the only two things this
   specific rule set bans — it does not ban `$lib/stores/*`, that's a
   different, stricter rule reserved for panels/skins).
2. `npm run lint` on the full tree, with the widened globs in place, is clean.
   Zero new violations.

## Test pin — red then green

The new `it.each` block in `architecture-boundaries.test.ts` (test titles
`rejects a {display,meters,vfo,controls} .ts file importing
$lib/audio/audio-manager directly ...`) probes one real file per directory
with an injected `$lib/audio/audio-manager` import and asserts a
`no-restricted-imports` hit.

**Red** — with the four `**/*.ts` glob lines removed from `eslint.config.js`:

```
❯ rejects a display .ts file importing $lib/audio/audio-manager directly (the glob fix — .ts had zero coverage before)
❯ rejects a meters .ts file importing $lib/audio/audio-manager directly (the glob fix — .ts had zero coverage before)
❯ rejects a vfo .ts file importing $lib/audio/audio-manager directly (the glob fix — .ts had zero coverage before)
❯ rejects a controls .ts file importing $lib/audio/audio-manager directly (the glob fix — .ts had zero coverage before)

AssertionError: expected 0 to be greater than 0

 Test Files  1 failed (1)
      Tests  4 failed | 1 passed | 89 skipped (94)
```

(The "1 passed" is the pre-existing MOR-2039 skins pin, unaffected by
removing these four lines.)

**Green** — with the glob lines restored:

```
Test Files  1 passed (1)
     Tests  94 passed (94)
```

Why the probe imports `$lib/audio/audio-manager` and not `$lib/transport/*`:
`isTransport` in `scripts/radio-authority-eslint-plugin.mjs` matches only
`transport/{ws-client,http-client}` and has no audio-manager case, so an
audio-manager probe exercises the `no-restricted-imports` rule this PR's
glob change turns on. Confirmed directly: on the pre-fix config, linting a
`.ts` file in `display/` with an audio-manager import reports zero problems.

**Corrected after review.** An earlier version of this paragraph, and a
comment in the test file, added that a transport probe "would also fail
pre-fix via `radio-authority/structural-boundary` for an unrelated reason".
That is true of a hand-run `npx eslint` and **false of the helper this test
uses**: `restrictedImportHits` filters messages to the two restricted-import
rule ids, as its own docblock says, so `structural-boundary` never reaches
the count. Measured: a transport probe through that helper returns 0 pre-fix
and 1 post-fix — an equally clean red-then-green. The comment was deleted
rather than rewritten, per the owner ruling of 2026-08-31.

## Bite demonstration (ad hoc, in addition to the test pin above)

Confirmed the widened glob resolves the rule for a newly-covered file:

```
$ npx eslint --print-config src/components-v2/display/frequency-format.ts \
    | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin)['rules']['no-restricted-imports'], indent=2))"
[
  2,
  {
    "paths": [{ "name": "$lib/audio/audio-manager", ... }],
    "patterns": [
      { "group": ["$lib/transport/*", "**/lib/transport/*"], ... },
      { "group": ["**/lib/audio/audio-manager"], ... }
    ]
  }
]
```

Then temporarily added `import { sendCommand } from '$lib/transport/ws-client';`
to the top of `src/components-v2/display/frequency-format.ts` and ran lint:

```
/…/frontend/src/components-v2/display/frequency-format.ts
  1:1  error  Radio authority module $lib/transport/ws-client is not available across this presentation boundary                                                                                                                                               radio-authority/structural-boundary
  1:1  error  '$lib/transport/ws-client' import is restricted from being used by a pattern. Presentation components must not import transport modules (sendCommand, getChannel). Use callback props from the adapter/wiring layer instead. See ADR 2026-04-12  no-restricted-imports

✖ 2 problems (2 errors, 0 warnings)
```

Reverted the file (confirmed byte-identical to the pre-edit version via
`diff`), then re-ran lint clean (exit 0, no output). No deliberate breakage
remains in the tree.

## `lint:boundaries` script — left unchanged

`frontend/package.json`'s `lint:boundaries` script
(`eslint src/components-v2/panels/ src/components-v2/layout/ src/presentation/`)
already excludes `skins/` despite `skins/` getting its own boundary block in
MOR-2039, and it isn't wired into any CI workflow (grepped
`.github/workflows/*.yml` for `lint:boundaries`, `npm run lint`, and `eslint`
— no matches anywhere); only two docs mention running it manually:
`docs/plans/2026-08-06-settings-modal-boundary.md`,
`docs/validation/workspace-v1-verification.md`. Its directory list already
diverges from what `eslint.config.js`'s zones cover, so that divergence isn't
something this glob fix introduces. Extending the script to include
`display/meters/vfo/controls` (and/or `skins/`) is a separate, deliberate
scope decision — left to whoever wires eslint into CI for MOR-2043 — not
attempted here.

## `architecture-boundaries.test.ts` — otherwise unaffected

This suite lints virtual fixture strings through the real flat config
(`ESLint#lintText`), mostly independent of files on disk. Its only existing
`components-v2/controls/*` fixtures are `.svelte` paths
(`TransportFacadeConsumer.svelte`, `RawCommand.svelte`, `IntentConsumer.svelte`),
already covered before this change; no pre-existing fixture in the file used
a `.ts` path under `display/`, `meters/`, `vfo/`, or `controls/`. The new
`it.each` block added by this PR is the first coverage for those paths.

## Review history on this PR

An earlier revision of this branch added a comment to the "presentation
components" block in `eslint.config.js` claiming these `.ts` files "matched
no boundary rule at all." That was false — `radio-authority/structural-boundary`
already ran on `.ts` files in these directories (it just doesn't cover
`audio-manager`, per the isTransport check above). Independent review caught
it; the comment has been deleted outright rather than re-qualified, per
`git log` on this branch. The first commit's message
(`41209c60`) still contains a version of that same claim — amending it would
require rewriting an already-pushed commit, which this session's tooling
declined to do; the second commit (`25264438`) states and corrects it instead.

## Gate output

```
$ npm run lint            # clean, no output beyond the npm banner
$ npm run check           # svelte-check: 4606 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS; tsc: clean
$ npm run i18n:check      # i18n-check: OK (3 locale file(s) checked, 274 source keys) — pre-existing informational notes only
$ npx vitest run src/__tests__/architecture-boundaries.test.ts
  Test Files  1 passed (1)
       Tests  94 passed (94)
```

Full `npx vitest run` (whole suite) was intentionally **not** run — other
agents are working in this repo concurrently and a full frontend suite run
is this repo's known source of flaky results under contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

