### PR TITLE
test: assert pool-saturation fail-fast by behaviour, not by a stopwatch

### DIFF
--- a/tests/test_usb_audio_capture_open_timeout_mor1438.py
+++ b/tests/test_usb_audio_capture_open_timeout_mor1438.py
@@ -379,18 +379,47 @@ async def test_pool_saturation_fails_fast_instead_of_queuing(
             with pytest.raises(AudioCaptureOpenTimeoutError):
                 await driver.start_rx(lambda _frame: None)
 
-        loop = asyncio.get_event_loop()
-        start = loop.time()
+        wedged = list(backend.rx_streams)
+
         with pytest.raises(AudioCaptureOpenTimeoutError) as exc_info:
             await driver.start_rx(lambda _frame: None)
-        elapsed = loop.time() - start
 
-        assert elapsed < _TEST_TIMEOUT_S / 2, (
-            "saturated pool must fail IMMEDIATELY, not queue for the full "
-            f"capture-open timeout (elapsed={elapsed:.3f}s)"
-        )
         assert "saturated" in str(exc_info.value).lower(), (
             f"expected an honest pool-saturation message, got: {exc_info.value!r}"
+        )
+
+        # "Fails fast" is asserted as behaviour, not as a stopwatch reading.
+        # The fail-fast path never reaches the pool: it closes the open
+        # coroutine instead of submitting it, so the probe's handle is never
+        # started -- whereas an open that QUEUED behind the wedged workers is
+        # started as soon as one of them frees. The whole fail-fast path
+        # through start_rx() has no await points, so a timing bound on it
+        # measures only whether the OS descheduled this process mid-call
+        # (observed: 32ms on an idle host against a 25ms bound), which is
+        # machine speed rather than driver behaviour.
+        #
+        # Release the pool and wait for it to DRAIN -- every wedged open
+        # completes and its abandoned handle is closed -- before reading the
+        # probe. Draining is what gives the read its meaning: a queued probe
+        # sits ahead of those closes in the same FIFO pool, so once all eight
+        # closes have landed, a queued probe would necessarily have started.
+        probe = backend.rx_streams[len(wedged)]
+        gate.set()
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + 10.0
+        while loop.time() < deadline:
+            if all(s.stopped_count for s in wedged):
+                break
+            await asyncio.sleep(0.005)
+
+        assert all(s.stopped_count for s in wedged), (
+            "pool never drained -- the wedged opens' handles were not closed, "
+            "so nothing can be concluded about the probe open"
+        )
+        assert probe.started_count == 0, (
+            "saturated pool must fail WITHOUT handing the open to a worker; "
+            "this handle was started, so the open queued behind the wedged "
+            "workers instead of failing fast"
         )
     finally:
         gate.set()  # release every stuck worker so the pool can drain

--- a/tests/test_usb_audio_capture_open_timeout_mor1438.py
+++ b/tests/test_usb_audio_capture_open_timeout_mor1438.py
@@ -394,15 +394,6 @@ async def test_pool_saturation_fails_fast_instead_of_queuing(
         # started -- whereas an open that QUEUED behind the wedged workers is
         # started as soon as one of them frees.
         #
-        # A wall-clock bound here would not isolate the saturation decision.
-        # That decision is one counter comparison; the rest of what the call
-        # costs is the preamble every start_rx() pays before it -- device
-        # enumeration, which on macOS re-runs an uncached CoreAudio
-        # name->UID lookup (``_get_uid_map``). None of the path's await
-        # points yields to the loop, so that preamble and any descheduling
-        # land in one uninterrupted window. The pre-change bound was 25ms and
-        # went red on an idle host.
-        #
         # Release the pool and wait for it to DRAIN -- every wedged open
         # completes and its abandoned handle is closed -- before reading the
         # probe. Draining is what gives the read its meaning: a queued probe

--- a/tests/test_usb_audio_capture_open_timeout_mor1438.py
+++ b/tests/test_usb_audio_capture_open_timeout_mor1438.py
@@ -392,11 +392,16 @@ async def test_pool_saturation_fails_fast_instead_of_queuing(
         # The fail-fast path never reaches the pool: it closes the open
         # coroutine instead of submitting it, so the probe's handle is never
         # started -- whereas an open that QUEUED behind the wedged workers is
-        # started as soon as one of them frees. The whole fail-fast path
-        # through start_rx() has no await points, so a timing bound on it
-        # measures only whether the OS descheduled this process mid-call
-        # (observed: 32ms on an idle host against a 25ms bound), which is
-        # machine speed rather than driver behaviour.
+        # started as soon as one of them frees.
+        #
+        # A wall-clock bound here would not isolate the saturation decision.
+        # That decision is one counter comparison; the rest of what the call
+        # costs is the preamble every start_rx() pays before it -- device
+        # enumeration, which on macOS re-runs an uncached CoreAudio
+        # name->UID lookup (``_get_uid_map``). None of the path's await
+        # points yields to the loop, so that preamble and any descheduling
+        # land in one uninterrupted window. The pre-change bound was 25ms and
+        # went red on an idle host.
         #
         # Release the pool and wait for it to DRAIN -- every wedged open
         # completes and its abandoned handle is closed -- before reading the


### PR DESCRIPTION
> **Squash-merge body must use this description, not the individual commit bodies.** Commit `cd608214`'s body carries a rationale that review refuted. `e9267dde` rewrote it; `fe1c7617` deleted it instead, per the owner's ruling below. Use the text on this page.

## What

`test_pool_saturation_fails_fast_instead_of_queuing` timed `await driver.start_rx(...)` against the saturated pool and required `elapsed < _TEST_TIMEOUT_S / 2` (25 ms). It now asserts the behaviour that bound was standing in for.

## Why the bound could not hold

A wall-clock bound on this call never isolated the saturation decision. That decision is one counter comparison (`_inflight_opens >= _CAPTURE_OPEN_MAX_WORKERS`); everything else the call costs is the preamble every `start_rx()` runs before it — device enumeration, which on macOS reaches `_get_uid_map` → `rigplane.audio._macos_uid.get_device_uid_map`, a CoreAudio lookup with **no caching** (no decorator on `_get_uid_map`).

Measured with `time.thread_time()` alongside `time.perf_counter()` around the probe open: **wall = 21.12 ms, event-loop-thread CPU = 10.55 ms** — half the window is real work on the loop thread, not descheduling. None of the path's three await points (`_rx_lock` enter/exit, `await self._open_stream`) *yields*: an `asyncio.sleep(0)` ticker advanced **0 times** during the call, so the preamble cost and any descheduling land in one uninterrupted window.

The pre-change assertion went red at `elapsed = 0.032s` on an **idle** host, before any load was injected.

## What replaces it

The fail-fast branch closes the open coroutine rather than submitting it, so the probe's handle is never started; an open that *queued* behind the wedged workers is started as soon as one frees. The test releases the gate, waits for the pool to **drain** (all eight wedged handles closed), then reads the probe. A queued probe sits ahead of those closes in the same FIFO `_work_queue`, so once the closes land it would necessarily have started — that ordering is what makes the read conclusive rather than merely prompt.

## How each claim was established

| Direction | Result |
|---|---|
| Reworked test, healthy product, deterministic 30 ms stall injected into the measured region | **PASS** |
| Pre-change shape, identical stall (control) | **FAIL** — `elapsed=0.161s`; the stall is potent and the difference is the assertion, not the driver |
| Product mutation disabling the saturation check | **FAIL** on the message assertion |
| Same mutation, message assertion neutralised | **FAIL** on the **drain assertion alone** — it discriminates on its own |

Full suite (Mac mini, Python 3.11) at `cd608214`: `11631 passed, 126 skipped, 48 xfailed`, 0 failures. `ruff check`, `ruff format --check`, `mypy --strict src/rigplane/web` clean at both commits. One file, well inside the 6-file/600-line soft threshold; `git diff main...HEAD --shortstat` gives the current figure.

## The other named test

`TestRadioPoller::test_poller_broadcasts_meter_readings` was already converted to a wait-for-the-condition shape in #2897 (commit `36c4b162`), which is merged. No change was needed here.

## Class survey

Other tests do share both shapes — the check the request asked for came back positive.

The enumerated list that stood here has been **deleted rather than corrected**, per the owner's ruling of 2026-08-31. It was wrong in four places, and one of its entries went stale *inside this PR*: deleting nine comment lines shifted a cited line number. A list of `file:line` rows in a document nobody re-runs is precisely the text that makes the next reader stop checking. Re-run the search and you get a correct list; read this one and you would have trusted a wrong one.

Two things from it are worth carrying, and neither is a line number:

- The tightest instance of the sleep-then-count shape is in `tests/test_poller.py`, which demands three poll ticks inside a 50 ms sleep — tighter than the case that actually failed.
- **A separate, inverse defect** lives in this very file: `test_normal_rx_open_timing_unaffected` and `test_normal_tx_open_timing_unaffected` assert `elapsed < 0.5` under the docstring "a well-behaved (non-blocking) open must not pay a meaningful penalty". The penalty named is `_TEST_TIMEOUT_S`, which is `0.05`. An open that paid the **full** timeout still lands ten times inside the bound, so neither test can fail for the reason it exists. Independent review confirmed this. It deserves its own ticket and is not fixed here.

## Review history

Reviewed independently and **BLOCKED** at `cd608214`: the added comment claimed a wall-clock bound on the fail-fast path measured "only" OS descheduling. It does not — `time.thread_time()` against `time.perf_counter()` around the probe open gives wall 21.12 ms with 10.55 ms of event-loop-thread CPU. That review also found four errors in the survey above, all fixed here.

`e9267dde` replaced the refuted sentence with a narrower, verified one. That was the wrong move: under the owner's repo-wide ruling of 2026-08-31, **a wrong or stale comment is deleted, not fixed, narrowed, qualified or rewritten** — a replacement is justified only when removing the text breaks something structural. Nothing here did. `fe1c7617` deletes it.

The measurement is not lost by that deletion; it lives on this page and in git history, which is where a measured number belongs. A number pinned in a comment has nothing that fails when it stops being true.

Two comment paragraphs are kept because neither is wrong and both were established rather than assumed: the one describing what the assertions check, and the FIFO-ordering one explaining why the drain wait is the right condition — review confirmed the latter against `ThreadPoolExecutor._work_queue` and the two submit sites in `usb_driver.py` (`_open_stream`, `_close_late_stream`).

Re-review pending at `fe1c7617`.

