### PR TITLE
fix(MOR-2074): completeness checks for the F8 layout/skin hand-lists

### DIFF
--- a/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
@@ -27,6 +27,17 @@ import {
   desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
   sdrTestLayout,
 } from '../declarations';
+// Namespace import of the SAME barrel, used ONLY to derive the F8
+// completeness set structurally (MOR-2074) — never to register anything (a
+// namespace import has no side effect beyond the module evaluation the named
+// import above already triggers). Same derivation as `loader-identity-
+// inventory.test.ts`'s `BARREL_MANIFESTS` and `forward-declaration-
+// inventory.test.ts`'s `ALL_MANIFESTS` (MOR-2060): NOT `listLayoutIds()`,
+// because the fast pool's `isolate: false` (vite.config.ts) shares
+// `contract.ts`'s module-scoped registry Map across every test file in the
+// run, and sibling suites register their own probe manifests into it.
+import * as layoutDeclarationsBarrel from '../declarations';
+import { isLayoutManifest } from './manifest-guard';
 import { forReceiver, receiversOf } from '../../../components-v2/wiring/dual-receiver-strips';
 import { topologyFixtures, withAudioOnlyScope } from '../../../semantic/fixtures/topologies';
 
@@ -119,12 +130,29 @@ describe('F8 — every registered layout manifest names a loadable skin', () => 
     sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
     desktopV2Layout,
   ];
+
+  // MOR-2074: REAL_LAYOUTS above is a hand-list, so a new manifest exported
+  // from the barrel without a matching entry here used to fall through the
+  // whole F8 rule silently — the it.each below only iterates what this list
+  // names, never what the barrel actually exports. BARREL_MANIFESTS is the
+  // same structural derivation `loader-identity-inventory.test.ts`'s
+  // `BARREL_MANIFESTS` and `forward-declaration-inventory.test.ts`'s
+  // `ALL_MANIFESTS` use (MOR-2060's `isLayoutManifest` guard), so a missing
+  // or stale REAL_LAYOUTS entry now reddens the completeness test below
+  // instead of being skipped.
+  const BARREL_MANIFESTS: readonly LayoutManifest[] =
+    Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest);
+
   const source = readFileSync('src/skins/registry.ts', 'utf8');
   const loadersStart = source.indexOf('const SKIN_LOADERS');
   const loaderIds = [...source.slice(loadersStart, source.indexOf('};', loadersStart))
     .matchAll(/'([a-z0-9-]+)':/g)].map((m) => m[1]);
   const unionStart = source.indexOf('export type SkinId');
   const skinIdUnion = source.slice(unionStart, source.indexOf(';', unionStart));
+
+  it('REAL_LAYOUTS names exactly the manifests the barrel exports', () => {
+    expect(REAL_LAYOUTS.map((m) => m.id).sort()).toEqual(BARREL_MANIFESTS.map((m) => m.id).sort());
+  });
 
   it.each(REAL_LAYOUTS.map((m) => [m.id, m] as const))(
     '"%s" is registered and reachable as a SkinId with a loader', (id, manifest) => {

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -1,31 +1,57 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import type { AppResource } from '$lib/runtime/resource-demand';
 import type { SkinId } from '../registry';
 
-const entrypoints = vi.hoisted(() => ({
-  desktop: { name: 'desktop-v2' },
-  cockpit: { name: 'lcd-cockpit' },
-  scope: { name: 'lcd-scope' },
-  mobile: { name: 'mobile' },
-  sdr: { name: 'sdr-test' },
-  dualReceiverCockpit: { name: 'dual-receiver-cockpit' },
-}));
+// MOR-2074: which SkinId is QA-gated, read off `resolveSkinId`'s actual
+// early-return branch in `../registry.ts` (`if (ctx.layoutPreference ===
+// 'X') return 'X';`, checked on the RAW `ctx.layoutPreference` before
+// `normalizeLayoutMode` runs — the regex requires the `ctx.` prefix
+// specifically so it does not also match the normal forced-preference
+// branches further down, which check the normalized local instead) rather
+// than hand-copied, so this list cannot silently drift from the production
+// branch that actually makes an id reachable only through the QA-only param.
+const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
+const QA_GATED_LAZY_LOAD_IDS = [...registrySource.matchAll(
+  /if \(ctx\.layoutPreference === '([a-z0-9-]+)'\) return '\1';/g,
+)].map((m) => m[1]) as SkinId[];
 
-const lazyImports = vi.hoisted(() => ({
-  desktop: vi.fn(() => ({ default: entrypoints.desktop })),
-  cockpit: vi.fn(() => ({ default: entrypoints.cockpit })),
-  scope: vi.fn(() => ({ default: entrypoints.scope })),
-  mobile: vi.fn(() => ({ default: entrypoints.mobile })),
-  sdr: vi.fn(() => ({ default: entrypoints.sdr })),
-  dualReceiverCockpit: vi.fn(() => ({ default: entrypoints.dualReceiverCockpit })),
-}));
+// MOR-2074: keyed by the literal `SkinId` itself (not an arbitrary local
+// name) and typed `Record<SkinId, ...>`, so a `SkinId` union member added
+// without a matching entry here is a `npm run check` compile error — the
+// same technique `EXPECTED_RESOURCE_PLAN` below already uses (MOR-2062),
+// generalized to the mock entrypoints/loaders every other case in this file
+// reads from.
+const entrypoints = vi.hoisted(() => {
+  const table: Record<SkinId, { name: SkinId }> = {
+    'desktop-v2': { name: 'desktop-v2' },
+    'lcd-cockpit': { name: 'lcd-cockpit' },
+    'lcd-scope': { name: 'lcd-scope' },
+    'mobile': { name: 'mobile' },
+    'sdr-test': { name: 'sdr-test' },
+    'dual-receiver-cockpit': { name: 'dual-receiver-cockpit' },
+  };
+  return table;
+});
 
-vi.mock('../desktop-v2/DesktopSkin.svelte', () => lazyImports.desktop());
-vi.mock('../lcd-cockpit/LcdCockpitSkin.svelte', () => lazyImports.cockpit());
-vi.mock('../lcd-scope/LcdScopeSkin.svelte', () => lazyImports.scope());
-vi.mock('../mobile/MobileSkin.svelte', () => lazyImports.mobile());
-vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports.sdr());
-vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports.dualReceiverCockpit());
+const lazyImports = vi.hoisted(() => {
+  const table: Record<SkinId, () => { default: { name: SkinId } }> = {
+    'desktop-v2': vi.fn(() => ({ default: entrypoints['desktop-v2'] })),
+    'lcd-cockpit': vi.fn(() => ({ default: entrypoints['lcd-cockpit'] })),
+    'lcd-scope': vi.fn(() => ({ default: entrypoints['lcd-scope'] })),
+    'mobile': vi.fn(() => ({ default: entrypoints['mobile'] })),
+    'sdr-test': vi.fn(() => ({ default: entrypoints['sdr-test'] })),
+    'dual-receiver-cockpit': vi.fn(() => ({ default: entrypoints['dual-receiver-cockpit'] })),
+  };
+  return table;
+});
+
+vi.mock('../desktop-v2/DesktopSkin.svelte', () => lazyImports['desktop-v2']());
+vi.mock('../lcd-cockpit/LcdCockpitSkin.svelte', () => lazyImports['lcd-cockpit']());
+vi.mock('../lcd-scope/LcdScopeSkin.svelte', () => lazyImports['lcd-scope']());
+vi.mock('../mobile/MobileSkin.svelte', () => lazyImports['mobile']());
+vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports['sdr-test']());
+vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports['dual-receiver-cockpit']());
 
 import { loadSkin, presentationResourcePlan, resolveSkinId } from '../registry';
 
@@ -62,23 +88,45 @@ describe('skin registry', () => {
     expect(resolve({ hasAnyScope })).toBe(skinId);
   });
 
+  // MOR-2074: derived from `lazyImports` (now `Record<SkinId, ...>`) instead
+  // of a hand-picked five of the six keys — this used to omit
+  // `dual-receiver-cockpit` with no completeness check to catch it, so a
+  // regression that eagerly imported it at module-init time would have
+  // stayed silent here (the only other guard, "does not import ... merely by
+  // resolving other preferences" below, runs later and after several
+  // `resolve()` calls, not at true module-init time).
   it('does not import a skin entrypoint while the registry is initialized', () => {
-    expect(lazyImports.desktop).not.toHaveBeenCalled();
-    expect(lazyImports.cockpit).not.toHaveBeenCalled();
-    expect(lazyImports.scope).not.toHaveBeenCalled();
-    expect(lazyImports.mobile).not.toHaveBeenCalled();
-    expect(lazyImports.sdr).not.toHaveBeenCalled();
+    for (const lazyImport of Object.values(lazyImports)) {
+      expect(lazyImport).not.toHaveBeenCalled();
+    }
   });
 
-  it.each([
-    ['desktop-v2', entrypoints.desktop, lazyImports.desktop],
-    ['lcd-cockpit', entrypoints.cockpit, lazyImports.cockpit],
-    ['lcd-scope', entrypoints.scope, lazyImports.scope],
-    ['mobile', entrypoints.mobile, lazyImports.mobile],
-    ['sdr-test', entrypoints.sdr, lazyImports.sdr],
-  ] as const)('lazily loads the %s entrypoint', async (skinId: SkinId, entrypoint, lazyImport) => {
+  // `dual-receiver-cockpit` is deliberately absent from this table: its own
+  // lazy-load pin lives in the QA-only describe block below and must run
+  // AFTER this table (see that block's call-order comment) — this file has
+  // no per-test mock reset, so merging it here would double-invoke its
+  // loader before that block's "not called merely by resolving" assertion.
+  const LAZY_LOAD_TABLE = [
+    ['desktop-v2', entrypoints['desktop-v2'], lazyImports['desktop-v2']],
+    ['lcd-cockpit', entrypoints['lcd-cockpit'], lazyImports['lcd-cockpit']],
+    ['lcd-scope', entrypoints['lcd-scope'], lazyImports['lcd-scope']],
+    ['mobile', entrypoints['mobile'], lazyImports['mobile']],
+    ['sdr-test', entrypoints['sdr-test'], lazyImports['sdr-test']],
+  ] as const;
+
+  it.each(LAZY_LOAD_TABLE)('lazily loads the %s entrypoint', async (skinId: SkinId, entrypoint, lazyImport) => {
     await expect(loadSkin(skinId)).resolves.toBe(entrypoint);
     expect(lazyImport).toHaveBeenCalledTimes(1);
+  });
+
+  // `QA_GATED_LAZY_LOAD_IDS` is now derived from `../registry.ts` itself
+  // (see its declaration above), not hand-copied, so this only catches a
+  // `SkinId` left off BOTH lists entirely — it does not by itself prove the
+  // QA-gated id's own pin test still exists (see the check next to that
+  // test in the describe block below).
+  it('pins a lazy-load case for every skin, in this table or the QA-gated one', () => {
+    const pinnedIds = [...LAZY_LOAD_TABLE.map(([id]) => id), ...QA_GATED_LAZY_LOAD_IDS];
+    expect(pinnedIds.sort()).toEqual((Object.keys(entrypoints) as SkinId[]).sort());
   });
 });
 
@@ -122,12 +170,30 @@ describe('MOR-1257: QA-only dual-receiver-cockpit reachability', () => {
     for (const layoutPreference of ['auto', 'standard', 'lcd-cockpit', 'lcd-scope', 'sdr-test'] as const) {
       resolve({ layoutPreference });
     }
-    expect(lazyImports.dualReceiverCockpit).not.toHaveBeenCalled();
+    expect(lazyImports['dual-receiver-cockpit']).not.toHaveBeenCalled();
   });
 
-  it('lazily loads the dual-receiver-cockpit entrypoint through the real loader', async () => {
-    await expect(loadSkin('dual-receiver-cockpit')).resolves.toBe(entrypoints.dualReceiverCockpit);
-    expect(lazyImports.dualReceiverCockpit).toHaveBeenCalledTimes(1);
+  // MOR-2074 review: unlike `LAZY_LOAD_TABLE` above, whose "has a pin"
+  // guarantee is structural (`it.each` iterates the array itself, so
+  // deleting a row also removes it from the derived id list the
+  // completeness test compares against), each QA-gated id's pin here is a
+  // freestanding `it.each` case with no array tying its EXISTENCE to
+  // `QA_GATED_LAZY_LOAD_IDS` — deleting this whole block previously left
+  // every other check in this file green. `observedQaGatedLazyLoadPins`
+  // records which ids actually got a pin that ran and passed; the test
+  // below fails if an id in `QA_GATED_LAZY_LOAD_IDS` never reached it.
+  const observedQaGatedLazyLoadPins = new Set<SkinId>();
+
+  it.each(QA_GATED_LAZY_LOAD_IDS)('lazily loads the %s entrypoint through the real loader', async (skinId) => {
+    await expect(loadSkin(skinId)).resolves.toBe(entrypoints[skinId]);
+    expect(lazyImports[skinId]).toHaveBeenCalledTimes(1);
+    observedQaGatedLazyLoadPins.add(skinId);
+  });
+
+  it('every QA-gated id actually reached its own lazy-load pin above', () => {
+    for (const id of QA_GATED_LAZY_LOAD_IDS) {
+      expect(observedQaGatedLazyLoadPins.has(id), `no lazy-load pin ran for QA-gated id "${id}"`).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
## What changed and why

**Instance 1 (the one that matters).** `frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts`'s `describe('F8 — every registered layout manifest names a loadable skin')` iterated a hand-listed `REAL_LAYOUTS` array with no check that it actually names every manifest the `../declarations` barrel exports. A new manifest could be exported from the barrel without a matching `REAL_LAYOUTS` entry and be silently skipped by the whole F8 rule (`it.each` only iterates what the list names). Added a completeness assertion, deriving the barrel's real export surface via the shared `manifest-guard.ts` `isLayoutManifest` structural guard — the same guard `forward-declaration-inventory.test.ts` already imports. `loader-identity-inventory.test.ts`'s own `BARREL_MANIFESTS` uses the identical derivation shape but through its own independent, non-imported copy of that guard, not through `manifest-guard.ts` itself.

**Instance 2 (weaker, already partly mitigated).** `frontend/src/skins/__tests__/registry.test.ts`'s mock `entrypoints`/`lazyImports` objects were hand-listed under arbitrary local names (`desktop`, `cockpit`, `sdr`, ...) with no link to `SkinId`, so a new skin could be added to the registry without any signal that this file's mocks needed a matching entry. Re-keyed both as `Record<SkinId, ...>` — the same technique `EXPECTED_RESOURCE_PLAN` already uses further down in this file — so a `SkinId` union member missing from either object is now a `npm run check` compile error. The "does not import a skin entrypoint while the registry is initialized" case is now derived from that typed record. The "lazily loads the %s entrypoint" table stays a hand-picked five-of-six (`dual-receiver-cockpit`'s own pin must run later, in a separate describe block, for mock-ordering reasons already documented in the file) but now reads its entries from the typed record instead of arbitrary local names.

**Independent review (round 2) found the QA-gated exemption was not self-liquidating.** The completeness test comparing "table ids + one named QA-gated exception" against `entrypoints`' keys could not detect the QA-gated id's *own* pin test being deleted — the reviewer deleted that freestanding `it` and every other check in the file stayed green. Fixed by: (a) deriving `QA_GATED_LAZY_LOAD_IDS` from `resolveSkinId`'s actual QA-gating branch in `registry.ts` (regex-read as text, matching only the branch checked on the raw `ctx.layoutPreference` before normalization, so it cannot also match the normal forced-preference branches) instead of hand-copying it, and (b) adding a runtime-tracked `observedQaGatedLazyLoadPins` set, populated only when the QA-gated pin's own assertions run **and pass** — forcing one of them to fail throws before the id is recorded, so a pin that runs without passing does not count itself present, checked by a new test that fails if an id in `QA_GATED_LAZY_LOAD_IDS` never reached it.

**Three comments deleted, not reworded, per the repo-wide ruling that a wrong comment is deleted rather than fixed/narrowed/rewritten:**
- `registry.test.ts`: "`QA_GATED_LAZY_LOAD_IDS` names that one exception explicitly and the completeness test below checks it against `entrypoints` (now `Record<SkinId, ...>`), so the exclusion stays an asserted, singular exception instead of a silent gap indistinguishable from a skin nobody pinned at all (MOR-2074)." — measured false by the same deletion described above: the exclusion was *not* asserted, and the gap *was* indistinguishable from "nobody pinned it."
- `registry.test.ts`: "Runs first in the file, before any `loadSkin` call, so every entry is still genuinely uncalled at this point." — false; three test groups (eight cases) precede that test in the same `describe`. Deleted with no replacement; the file already carries accurate phrasing elsewhere ("runs before every 'lazily loads' case").
- `cockpit-topology-adaptation.test.ts`: "Kills: a new manifest landing in the barrel without a corresponding entry in REAL_LAYOUTS above — it would otherwise be silently absent from the it.each below instead of failing loudly here (MOR-2074)." — overstated ("landing in the barrel" vs. the accurate "exported from the barrel" already stated a few lines above). Deleted; the accurate statement stands on its own.

## Red-then-green evidence

**Instance 1** — removed `desktopV2Layout` from `REAL_LAYOUTS`, ran the suite:

```
✗ REAL_LAYOUTS names exactly the manifests the barrel exports
AssertionError: expected [ 'dual-receiver-cockpit', …(4) ] to deeply equal [ 'desktop-v2', …(5) ]
- Expected
+ Received
@@ -1,7 +1,6 @@
  [
-   "desktop-v2",
    "dual-receiver-cockpit",
    "lcd-cockpit",
    "lcd-scope",
    "mobile",
    "sdr-test",
Tests  1 failed | 20 passed (21)
```

Restored `desktopV2Layout` → `Tests  22 passed (22)`.

**Instance 2 (Record<SkinId, ...> completeness)** — removed the `'dual-receiver-cockpit'` entry from the `entrypoints` `Record<SkinId, ...>` literal, ran `npm run check`:

```
ERROR "src/skins/__tests__/registry.test.ts" <line:col> "Property '\"dual-receiver-cockpit\"' is missing in type
'{ 'desktop-v2': { name: \"desktop-v2\"; }; 'lcd-cockpit': { name: \"lcd-cockpit\"; }; 'lcd-scope': { name: \"lcd-scope\"; };
mobile: { name: \"mobile\"; }; 'sdr-test': { name: \"sdr-test\"; }; }' but required in type 'Record<SkinId, { name: SkinId; }>'."
COMPLETED 4606 FILES 1 ERRORS 0 WARNINGS 1 FILES_WITH_PROBLEMS
```

Restored the entry → `COMPLETED 4606 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.

**Instance 2 follow-up (self-liquidating QA-gated exemption)** — deleted the `it.each(QA_GATED_LAZY_LOAD_IDS)('lazily loads the %s entrypoint through the real loader', ...)` block (the exact mutation the reviewer applied), ran `registry.test.ts`:

```
✗ every QA-gated id actually reached its own lazy-load pin above
AssertionError: no lazy-load pin ran for QA-gated id "dual-receiver-cockpit": expected false to be true // Object.is equality
- Expected
+ Received
- true
+ false
Tests  1 failed | 26 passed (27)
```

Only this one new test failed; every other test in the file — including the pre-existing "pins a lazy-load case for every skin, in this table or the QA-gated one" completeness test — was among the 26 that stayed green, confirming that check alone could not have caught this mutation. Restored the block → `Tests  28 passed (28)`.

All deliberate breakages were reverted before the final gate run below; none is present in this PR's diff.

## Gate outputs (scoped per the coordinator's instruction — full suite runs on the dedicated test machine + CI, not locally, to avoid concurrent-agent flakiness)

`npm run check`:
```
1788207552124 START ".../mor-2074/frontend"
1788207552140 COMPLETED 4606 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

`npx vitest run` (scoped to the touched suites and their siblings):
```
 Test Files  5 passed (5)
      Tests  67 passed (67)
```

`npm run lint`:
```
> eslint src/
(no output — zero violations)
```

`npm run i18n:check`:
```
i18n-check: 2 note(s) (informational)
  ja-JP / ru-RU missing keys — pre-existing, allowed, unrelated to this change
i18n-check: OK (3 locale file(s) checked, 274 source keys).
```

## Size

Measured against the actual merge-base with `origin/main` (`git diff --stat $(git merge-base origin/main HEAD) HEAD`), since `main` has advanced past this branch's fork point: 2 files changed, 134 insertions(+), 40 deletions(-) — 174 changed lines. Under both the soft threshold (6 files/600 lines) and the hard ceiling (10 files/1000 lines).

## Scope note

Test-only change (no production code touched). Both instances were named explicitly in MOR-2074's own ticket text as the same finding pattern (a hand-list with no completeness check against its real source), so both are fixed here rather than treated as an out-of-scope sweep.

**Explicitly out of scope**, per the coordinator: a manifest brought into the barrel by a bare side-effect `import './x-declarations'` (registering without exporting) is invisible to every completeness check here and in `loader-identity-inventory.test.ts`. That gap predates this PR and is being filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Corrections applied after round-2 review (PR body only, no commit)

Three inaccuracies in this body, all found by the reviewer, all corrected in place above:

* the observed-pins set was described as populated when the pin's assertions *run*; it is populated when they **pass** — measured by forcing one to fail, which throws before the id is recorded;
* "twelve lines above" was a counted position and wrong (the real distance is eighteen to nineteen). Replaced with a form that does not count, since nothing checks a position in prose;
* the pasted compile-error transcript carried a line:column pair that matched neither this head nor the previous one. The coordinates are removed rather than re-measured — they would rot on the next edit to that file, and the error text is what the evidence rests on.

The amended **commit message** was checked separately by the reviewer and is accurate on every point, including both round-1 corrections. This repository squashes using the commit messages rather than the PR body, so the record that reaches `main` is that message.
