### PR TITLE
test(MOR-2070): require every layout to be design-language-listed or exempt

### DIFF
--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -50,6 +50,15 @@ import type { DesignLanguageManifest } from '../contract';
 // importing the barrel already does as a side effect (`registerDesignLanguage`
 // calls at its own module scope).
 import * as languageDeclarationsBarrel from '../declarations';
+// Same namespace-import discipline, LAYOUT side, for the second describe
+// block below (MOR-2070).
+import * as layoutDeclarationsBarrel from '../../layouts/declarations';
+import type { LayoutManifest } from '../../layouts/contract';
+// The shared structural `LayoutManifest` guard every `*-declarability.test.ts`
+// suite in `../../layouts/__tests__/` already derives its own inventory with
+// (e.g. `antenna-declarability.test.ts`'s `ALL`) — reused here rather than
+// reimplemented, per MOR-2070's instruction not to duplicate it.
+import { isLayoutManifest } from '../../layouts/__tests__/manifest-guard';
 
 /** Structural `DesignLanguageManifest` guard for filtering the barrel's
  *  export surface — every export the barrel currently has IS a manifest,
@@ -88,6 +97,139 @@ describe('every shipped design-language manifest declares at least one compatibl
       // any layout, silently. See layout-compatibility-guard.ts for the
       // full empty-vs-no-true reasoning this predicate encodes.
       expect(declaresNoLayoutCompatibility(manifest)).toBe(false);
+    },
+  );
+});
+
+/**
+ * MOR-2070 — layout-side coverage, the counterpart of the describe block
+ * above. That block guards against a shipped LANGUAGE that mentions no
+ * layout at all; this one guards the opposite direction: a shipped LAYOUT
+ * that no language mentions.
+ *
+ * "Unmentioned" conflates two different situations: a new layout nobody has
+ * reviewed for design-language chrome yet (must fail loudly, the way a new
+ * author's mistake should), and a layout this repository has deliberately
+ * decided will never carry design-language chrome (`lcd-cockpit`,
+ * `lcd-scope`, `mobile`, `sdr-test` below). The distinction is recorded here,
+ * on the layout side, as `LAYOUT_EXEMPTIONS` — an explicit list with a reason
+ * per entry — rather than as a full language×layout matrix, which was
+ * considered and deferred under the rule of three (only two design languages
+ * are shipped today; a matrix generalizes over a count that does not exist
+ * yet).
+ *
+ * A layout counts as "mentioned" the moment ANY shipped language's
+ * `layoutCompatibility` names it — a `compatible: true` entry and a
+ * `compatible: false` entry both count equally as evidence a decision was
+ * made, even though only `true` lets `designLanguageActivation` actually
+ * activate for it (`fieldline`'s `dual-receiver-cockpit: false` entry above
+ * is exactly this: a decision, not a silent gap).
+ *
+ * This is enforced as a vitest assertion, not a runtime warning like
+ * `layout-compatibility-guard.ts` (untouched by this ticket): a new layout
+ * manifest only ever enters this repository through a PR, and this suite
+ * runs on every such PR through `quick.yml`'s frontend path filter (any
+ * change under `frontend/**` runs `npx vitest run` in that workflow's
+ * frontend block) — so a layout that reached production without first
+ * passing this file's own assertions below does not happen here, and a
+ * runtime-only check would fire no earlier than a test already does.
+ */
+describe('every layout is design-language-listed or explicitly exempt (MOR-2070)', () => {
+  // [id, manifest] pairs, derived structurally from the layouts barrel's
+  // export surface — never hand-listed, the same discipline `SHIPPED_MANIFESTS`
+  // above follows on the language side, and the same guard (`isLayoutManifest`)
+  // every `*-declarability.test.ts` suite in `../../layouts/__tests__/` already
+  // uses to derive its own layout inventory.
+  const ALL_LAYOUTS: readonly LayoutManifest[] =
+    Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest);
+
+  // Guards the derivation itself, same reason as the language-side check
+  // above: if the barrel filter ever matched nothing, every assertion below
+  // would pass vacuously.
+  it('finds at least one layout to check', () => {
+    expect(ALL_LAYOUTS.length).toBeGreaterThan(0);
+  });
+
+  /** Every layoutId any shipped language's `layoutCompatibility` names —
+   *  `compatible: true` or `false` both count (see header). */
+  const MENTIONED_LAYOUT_IDS = new Set(
+    SHIPPED_MANIFESTS.flatMap((manifest) => manifest.layoutCompatibility.map((entry) => entry.layoutId)),
+  );
+
+  /** Layouts this repository has deliberately decided will carry no
+   *  design-language chrome — extend by hand, with a reason, never silently.
+   *  A layout landing here without a matching entry in `ALL_LAYOUTS` (a
+   *  typo, a renamed/removed layout id) is caught by the third assertion
+   *  below; one that stops being true (a language starts mentioning it) is
+   *  caught by the second. */
+  const LAYOUT_EXEMPTIONS: ReadonlyArray<{ readonly layoutId: string; readonly reason: string }> = [
+    {
+      layoutId: 'lcd-cockpit',
+      reason:
+        'carries its own built-in styling; design-language adoption not planned (owner ruling 2026-08-31, MOR-2070)',
+    },
+    {
+      layoutId: 'lcd-scope',
+      reason:
+        'carries its own built-in styling; design-language adoption not planned (owner ruling 2026-08-31, MOR-2070)',
+    },
+    {
+      layoutId: 'mobile',
+      reason:
+        'carries its own built-in styling; design-language adoption not planned (owner ruling 2026-08-31, MOR-2070)',
+    },
+    {
+      layoutId: 'sdr-test',
+      reason: 'minimal teaching example; no design-language chrome by design (owner ruling 2026-08-31, MOR-2070)',
+    },
+  ];
+  const EXEMPT_LAYOUT_IDS = new Set(LAYOUT_EXEMPTIONS.map((exemption) => exemption.layoutId));
+
+  // Kills: a new layout manifest (a new author's, or a renamed existing one)
+  // landing in the barrel with no layoutCompatibility entry anywhere and no
+  // exemption — the exact silent gap MOR-2070 exists to close.
+  it.each(ALL_LAYOUTS.map((manifest) => [manifest.id] as const))(
+    '"%s" is mentioned by a shipped design language, or carries a justified exemption',
+    (id) => {
+      const decided = MENTIONED_LAYOUT_IDS.has(id) || EXEMPT_LAYOUT_IDS.has(id);
+      expect(
+        decided,
+        `layout "${id}" is mentioned by no shipped design language's layoutCompatibility and has no ` +
+          'exemption entry. Either add a layoutCompatibility entry for it to a shipped language ' +
+          '(frontend/src/presentation/languages/declarations.ts), or add a justified entry to ' +
+          'LAYOUT_EXEMPTIONS in this file.',
+      ).toBe(true);
+    },
+  );
+
+  // Kills: a stale exemption — a layout that WAS unmentioned when exempted,
+  // but a language now names it, so the exemption is dead cover rather than
+  // a live decision. Same self-liquidation shape as
+  // `focus-ring-token-wiring.test.ts`'s "LEGACY_DEBT entries still need
+  // their exemption" case.
+  it.each(LAYOUT_EXEMPTIONS.map((exemption) => [exemption.layoutId] as const))(
+    'exemption "%s" is still needed — no shipped language mentions it',
+    (layoutId) => {
+      expect(
+        MENTIONED_LAYOUT_IDS.has(layoutId),
+        `layout "${layoutId}" is exempt but is now mentioned by a shipped design language — remove its ` +
+          'entry from LAYOUT_EXEMPTIONS instead of leaving it as stale cover.',
+      ).toBe(false);
+    },
+  );
+
+  // Kills: an orphan exemption — a typo'd or since-removed layout id sitting
+  // in LAYOUT_EXEMPTIONS that no longer names anything the barrel exports,
+  // which would otherwise silently exempt nothing while looking like it
+  // covers a real layout.
+  it.each(LAYOUT_EXEMPTIONS.map((exemption) => [exemption.layoutId] as const))(
+    'exemption "%s" refers to a layout id the barrel actually exports',
+    (layoutId) => {
+      expect(
+        ALL_LAYOUTS.some((manifest) => manifest.id === layoutId),
+        `LAYOUT_EXEMPTIONS names "${layoutId}", which is not a layout id the barrel exports — remove ` +
+          'the orphan entry.',
+      ).toBe(true);
     },
   );
 });


### PR DESCRIPTION
## What / why

MOR-2054 already guards the LANGUAGE side: every shipped design language must declare at least one `layoutCompatibility` entry with `compatible: true`, or it can never activate for any layout. What was missing is the LAYOUT side: a layout mentioned by *no* language silently gets no design-language chrome, and "unmentioned" conflated two different situations — a new layout nobody has reviewed yet (should fail loudly) vs. a layout this repo has deliberately decided will never carry design-language chrome (4 of the 6 shipped layouts today).

This PR adds a second `describe` block to `frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts` that closes that gap, per the owner ruling recorded on MOR-2070 (2026-08-31).

## Ruling implemented

- The new-vs-deliberate distinction is recorded on the LAYOUT side as an explicit, typed `LAYOUT_EXEMPTIONS` list (`{layoutId, reason}`) — not a full language×layout matrix (considered and deferred under the rule of three: only two languages are shipped today).
- Enforcement is a vitest assertion, not a runtime warning — the existing runtime guard (`layout-compatibility-guard.ts`) is untouched.
- A layout counts as "mentioned" the moment ANY shipped language's `layoutCompatibility` names it — `compatible: true` and `compatible: false` both count as "a decision exists."
- Each exemption is self-liquidating: the test fails if an exempt layout IS mentioned by any language (same pattern as `focus-ring-token-wiring.test.ts`'s `LEGACY_DEBT` check).
- Initial exemptions: `lcd-cockpit`, `lcd-scope`, `mobile` ("carries its own built-in styling; design-language adoption not planned"), `sdr-test` ("minimal teaching example; no design-language chrome by design").
- Failure messages name the layout id and state the two options: add a `layoutCompatibility` entry to a shipped language, or add a justified exemption.

Layout ids are derived structurally from the layouts barrel (`frontend/src/presentation/layouts/declarations.ts`) via the shared `isLayoutManifest` guard (`frontend/src/presentation/layouts/__tests__/manifest-guard.ts`) that every `*-declarability.test.ts` suite already uses — not reimplemented. Language coverage reuses the file's existing `SHIPPED_MANIFESTS` derivation.

## TDD / discriminating power

Three temporary, uncommitted local mutations proved the new check can fail, each reverted before commit (confirmed via `git status` / `git diff` clean afterward):

- **(a) Removed the `sdr-test` exemption** → failed, naming it:
  `AssertionError: layout "sdr-test" is mentioned by no shipped design language's layoutCompatibility and has no exemption entry. Either add a layoutCompatibility entry for it to a shipped language ... or add a justified entry to LAYOUT_EXEMPTIONS in this file.`
- **(b) Added an exemption for `desktop-v2`** (which IS mentioned by both languages) → failed via the self-liquidation assertion:
  `AssertionError: layout "desktop-v2" is exempt but is now mentioned by a shipped design language — remove its entry from LAYOUT_EXEMPTIONS instead of leaving it as stale cover.`
- **(c) Added a minimal 7th layout manifest to the layouts barrel** (no `layoutCompatibility` entry, no exemption — simulating a new author's layout) → failed, naming the new id:
  `AssertionError: layout "mutation-check-layout" is mentioned by no shipped design language's layoutCompatibility and has no exemption entry.`
  This barrel edit also tripped two OTHER structural-completeness suites, as expected (MOR-2054-style loud sites, not fixed here — reverted along with the mutation): `forward-declaration-inventory.test.ts` (3 failures — missing DOM-backing proof for the new id) and `loader-identity-inventory.test.ts` (1 failure — manifest table mismatch).

## Gate results (worktree `frontend/`)

- `npm run check` — **PASS**: `COMPLETED 4606 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`
- `npm run i18n:check` — **PASS**: `i18n-check: OK (3 locale file(s) checked, 274 source keys)` (only informational notes about missing ja-JP/ru-RU translation keys, which the tool itself documents as allowed)
- `npm run build` — **PASS**: `✓ 4178 modules transformed` / `✓ built in 13.29s`
- `npm run lint` — **PASS**: zero output, zero violations
- `npx vitest run` (full frontend suite) — **flaky locally, not attributable to this change**. Across 4 consecutive full-suite runs on this shared dev machine, between 4 and 12 test files failed each time with `Test timed out in 5000ms`/`15000ms` errors — but the *specific failing files differed every run* (9 distinct, unrelated files touched across all 4 runs combined: `architecture-boundaries`, `control-feedback-debt-inventory`, `control-feedback-ownership`, `fixture-capture-root-cwd`, `semantic-cw-keyer-wiring`, `MobileRadioLayout`, `semantic-desktop-migration`, `semantic-lcd-migration`, `semantic-antenna-wiring`), none of them in the touched file, all in component/wiring suites unrelated to design languages or layouts. `uptime` showed load averages up to 53/51/42 on this 10-core machine, and `ps aux` showed a concurrent, unrelated `svelte-check` process for a different worktree (`mor-2074`) competing for CPU during at least one run. A targeted rerun of the run-1 failing set with this change *stashed* passed cleanly (109/109), and this file's own 18 assertions (2 pre-existing + 16 new) passed with zero failures in **every one** of the 4 full-suite attempts and in 2 additional standalone runs. Last full-suite summary: `Test Files 4 failed | 367 passed (371)`, `Tests 5 failed | 8143 passed (8148)`. CI's `quick.yml` runs `npx vitest run` on an isolated GitHub Actions runner and will give the authoritative signal for this gate.

## Size

1 file changed, +142/−0 lines (well under both the soft threshold of 6 files/600 lines and the hard ceiling of 10 files/1000 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)