### PR TITLE
feat: migrate the remaining Group B builders onto the bound command map (cmd-map batch 4)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -324,6 +324,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remaining to repoint at — its four tests that used to assert "no
   exception, fallback bytes returned" now assert "the wrapper's warning
   still fires, then the builder's own `TypeError` propagates unchanged."
+- **`rigplane.commands.memory`/`tx_band` builders, and `freq.py`'s five
+  remaining selected-receiver builders, require `cmd_map`; none ever had a
+  hardcoded fallback to delete (MOR-2008, batch 4 of
+  `docs/plans/2026-08-29-profile-driven-command-bytes.md`, "Group B" —
+  the last 16 builders in `commands/` with no `cmd_map` parameter at
+  all).** Covers `memory.py`'s nine (`build_memory_mode_get`/`_set`,
+  `build_memory_write`, `build_memory_to_vfo`, `build_memory_clear`,
+  `build_memory_contents_get`/`_set`, `get_bsr`/`set_bsr`), `tx_band.py`'s
+  two (`get_tx_band_count`, `get_tx_band_edge`), and `freq.py`'s five
+  (`get_selected_freq`/`get_unselected_freq`/`get_selected_mode`/
+  `get_unselected_mode`/`set_selected_mode`). Python function names are
+  unchanged — the seven `memory.py` builders with the anomalous
+  `build_X_get`/`build_X_set`/`build_X` shape keep it; only the TOML key
+  spellings were reconciled. Canonical key naming (owner ruling): a
+  genuine get/set value pair keeps its `get_`/`set_` prefix; a
+  single-wire-form action command uses the bare name, matching
+  `power_on`/`ptt_on`/`scan_start` — so `build_memory_write`/
+  `build_memory_to_vfo`/`build_memory_clear` resolve `"memory_write"`/
+  `"memory_to_vfo"`/`"memory_clear"`, not a `get_`/`set_`-prefixed key.
+  IC-705 previously declared redundant `get_X`/`set_X` pairs for these
+  three one-shot actions; the orphan half of each pair is deleted, with a
+  fresh source citation on the single surviving bare-named row (neither
+  half carried one before). The four Icom profiles' 57 DECLARE cells are
+  byte-identical to what these builders sent before migration (verified
+  directly against the deleted hardcoded output, not merely asserted).
+  **Two commands are left deliberately undeclared (D1 state 3) rather
+  than guessed:** `get_memory_mode` on all four Icom profiles (the
+  manuals phrase 0x08 as "Select the Memory mode", imperative, not
+  "Send/read" like the package's other bidirectional rows, and no
+  live-bench probe has settled whether it answers a bare read), and
+  `set_selected_mode` on IC-7300/IC-7610/IC-9700 (the exact
+  (mode, data_mode, filter) SET payload convention was not independently
+  confirmed against those three manuals' own detail pages before this
+  batch — IC-705/X6200/X6100 already declare it and are unaffected).
+  Calling either now raises `CommandError` (undeclared-command refusal)
+  on the affected profiles instead of unconditionally sending the byte
+  the old hardcoded fallback always sent — the honest outcome until a
+  live probe or a manual detail-page read settles the open question.
+  **X6200/X6100 declare all 11 memory.py/tx_band.py keys formally
+  absent:** none of the nine memory-family opcodes nor the two TX-band
+  opcodes appear anywhere in the Radioddity X6200 CI-V V1.0.6 documented
+  opcode table (Table 1, pp.5-9); `get_bsr`/`set_bsr` specifically
+  because the one opcode the table does document at `[0x1A, 0x01]`
+  (already exposed as `get_band_spectrum_display`) is a different,
+  2-byte-payload command, not Icom's own 9-byte band-stacking-register
+  record — same opcode, structurally incompatible wire contract. This
+  migration also **corrects a pre-existing false claim** in
+  `rigs/x6200.toml`'s own "PROVENANCE OPEN" note, which said the
+  band-stacking WRITE side of `[0x1A, 0x01]` was undeclared/undocumented;
+  the same manual page the file already cited documents that SET row too
+  (just not as Icom's `set_bsr`). **`ftx1.toml`/`tx500.toml` (CAT-only,
+  no CI-V command table) declare all 16 canonical keys formally absent**,
+  citing the protocol mismatch rather than leaving them as a silent gap —
+  this removes both profiles from `tests/test_command_map_parity.py`'s
+  `cat_only_profiles` census/`cat-only` rows, since that classification
+  means literally "every `[commands]` entry is `CatCommandSpec`", which a
+  declared-absent row no longer satisfies even though both profiles
+  remain cat-only in every functional sense. The orphan TOML keys
+  `set_selected_freq`/`set_unselected_freq`/`set_unselected_mode` (no
+  Python builder resolves any of the three) are kept, not deleted, on
+  X6200/X6100 — each documents a real, sourced capability the same
+  0x25/0x26 opcodes above confirm — with a one-line comment added noting
+  the absent builder; IC-705's own copies of the same three keys, which
+  carry no source at all, are left untouched. **Hard boundary (MOR-2055,
+  explicitly not touched by this migration):** `build_memory_to_vfo`/
+  `build_memory_clear` still append a 2-byte BCD channel payload that all
+  four Icom manuals show 0x0A/0x0B accepting no data field for at all —
+  this migration re-plumbs the command-map lookup only and does not
+  change those wire bytes; the payload question is MOR-2055's to settle.
+  Three now-dead constants (`_CMD_MEMORY_WRITE`, `_CMD_MEMORY_TO_VFO`,
+  `_CMD_MEMORY_CLEAR`) are deleted from `commands/_frame.py` — an
+  AST-verified census found zero importers anywhere for any of the
+  three once `memory.py`'s own builders stopped reading them directly.
+  The production call sites, in `runtime/radio.py: CoreRadio` and
+  `runtime/_dual_rx_runtime.py: DualRxRuntimeMixin` (the selected/
+  unselected freq/mode readers and the X6200 selected-mode SET path),
+  moved onto `self._commands.<builder>(...)` in the same change.
+  `tests/test_command_fallback_audit.py`'s census is updated: 256 public
+  builders now require `cmd_map` (was 238), and the 33 that lack the
+  parameter entirely are, for the first time, exclusively `parse_*`
+  response decoders — no byte-emitting builder anywhere in `commands/`
+  lacks `cmd_map` any longer.
 
 ### Changed
 

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -943,6 +943,34 @@ set_apf_freq   = { cat = { write = "CO03{val:04d};" } }
 # ── Clarifier Reset ──
 reset_clarifier = { cat = { write = "RC;" } }
 
+# ── Memory / TX band edge / selected-VFO (absent, D2 MOR-2008 batch 4) ──
+# Protocol mismatch, not a documentation gap: [protocol] type is
+# "yaesu_cat" above, every entry in this table is a { cat = ... } spec,
+# and profiles/rig_loader.py: RigConfig.to_command_map keeps only the
+# CI-V half of CommandSpec -- none of these 16 canonical CI-V key names
+# can be declared under the [opcode, sub]-array syntax at all on this
+# profile. The FTX-1 CAT manual documents an analogous memory-channel
+# family under different ASCII commands (MC/MR/MW/MA/MB) and this
+# profile's own get_freq_sub under a different name for the
+# selected/unselected-VFO idea -- both out of Group B's scope, noted only
+# so nobody double-declares them here.
+get_memory_mode      = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio (tests/command_map_parity_uncovered.txt: cat-only FTX-1)" }
+set_memory_mode      = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+memory_write         = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+memory_to_vfo        = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+memory_clear         = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_memory_contents  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+set_memory_contents  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_bsr              = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+set_bsr              = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_tx_band_count    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_tx_band_edge     = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_selected_freq    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_unselected_freq  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_selected_mode    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+get_unselected_mode  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+set_selected_mode    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
+
 [tx_policy]
 # Measured on the bench (MOR-1912): a controlled write-during-transmit
 # battery sent to the FTX-1 while an operator held a front-panel key. Mode

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -485,6 +485,13 @@ bsr_code = 0x0F
 # Every opcode from wfview IC-705.rig Commands\1–124 (excluding TRX placeholders 0x00/0x01).
 # NOTE lines: IC-7300.rig has the feature but IC-705.rig does not (or uses different bytes).
 
+# PROVENANCE OPEN (D2, MOR-2008 batch 4): left deliberately undeclared
+# rather than guessed. House pattern: rigs/ic9700.toml "PROVENANCE OPEN
+# (D2, MOR-2015)".
+# - get_memory_mode [0x08]: this guide's own 0x08 row reads "Select the
+#   Memory mode" (imperative), not "Send/read" like the table's other
+#   bidirectional rows -- no live-bench probe has settled whether it
+#   answers a bare read.
 [commands]
 
 # ── Frequency / Mode ──
@@ -511,15 +518,19 @@ get_main_sub_band = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.20
 quick_dual_watch = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.5: no Main/Sub receiver on this radio; control 0032 on IC-705 is 'Home CH Beep', not quick dual-watch" }
 
 # ── Memory (wfview MemStart=0, Max=99; Memory Contents Max=101) ──
-get_memory_mode = [0x08]
-set_memory_mode = [0x08]
+# get_memory_mode -- PROVENANCE OPEN above, left undeclared (this guide's
+# own 0x08 row reads "Select the Memory mode", imperative, not "Send/read"
+# like the table's other bidirectional rows -- no live-bench probe has
+# settled whether it answers a bare read)
+set_memory_mode = [0x08]                  # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3
 set_memory_group = [0x08, 0xA0]
-get_memory_write = [0x09]
-set_memory_write = [0x09]
-get_memory_to_vfo = [0x0A]
-set_memory_to_vfo = [0x0A]
-get_memory_clear = [0x0B]
-set_memory_clear = [0x0B]
+# memory_write/memory_to_vfo/memory_clear: single wire form, bare
+# canonical key (owner ruling, MOR-2008 batch 4) -- collapses the
+# redundant get_X/set_X pair this file used to declare for each (neither
+# half carried a source; the single surviving row below does).
+memory_write = [0x09]                     # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3
+memory_to_vfo = [0x0A]                     # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3 -- payload MOR-2055, see commands/memory.py: build_memory_to_vfo
+memory_clear = [0x0B]                      # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3 -- payload MOR-2055, see commands/memory.py: build_memory_clear
 
 # ── Offset / Scan / Split ──
 get_freq_offset = [0x0D]
@@ -674,10 +685,10 @@ get_transceiver_id = [0x19, 0x00]
 set_transceiver_id = [0x19, 0x00]
 
 # ── 0x1A ──
-get_memory_contents = [0x1A, 0x00]
-set_memory_contents = [0x1A, 0x00]
-get_bsr = [0x1A, 0x01]
-set_bsr = [0x1A, 0x01]
+get_memory_contents = [0x1A, 0x00]        # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.5 (detail p.17)
+set_memory_contents = [0x1A, 0x00]        # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.5 (detail p.17)
+get_bsr = [0x1A, 0x01]                    # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.5 (detail p.18)
+set_bsr = [0x1A, 0x01]                    # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.5 (detail p.18)
 get_filter_width = [0x1A, 0x03]
 set_filter_width = [0x1A, 0x03]
 # agc_time_constant (0x1A 0x04) exists on IC-705 -- refutes the earlier "NOT
@@ -718,14 +729,22 @@ get_rit_tx_status = [0x21, 0x02]
 set_rit_tx_status = [0x21, 0x02]
 
 # ── Selected / unselected VFO ──
-get_selected_freq = [0x25, 0x00]
+get_selected_freq = [0x25, 0x00]          # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15
+# set_selected_freq: no Python builder exists yet -- orphan key, kept
+# undisturbed by MOR-2008 batch 4 (see that batch's PR body).
 set_selected_freq = [0x25, 0x00]
-get_unselected_freq = [0x25, 0x01]
+get_unselected_freq = [0x25, 0x01]        # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15
 set_unselected_freq = [0x25, 0x01]
-get_selected_mode = [0x26, 0x00]
-set_selected_mode = [0x26, 0x00]
-get_unselected_mode = [0x26, 0x01]
+get_selected_mode = [0x26, 0x00]          # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15 (detail p.26)
+set_selected_mode = [0x26, 0x00]          # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15 (detail p.26)
+get_unselected_mode = [0x26, 0x01]        # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15 (detail p.26)
+# set_unselected_mode: no Python builder exists yet -- orphan key, kept
+# undisturbed by MOR-2008 batch 4 (see that batch's PR body).
 set_unselected_mode = [0x26, 0x01]
+
+# ── TX Band Edge ──
+get_tx_band_count = [0x1E, 0x00]          # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.14
+get_tx_band_edge = [0x1E, 0x01]           # source: IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.14 (detail p.16)
 
 # ── Scope ──
 get_scope_wave = [0x27, 0x00]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -909,6 +909,17 @@ bsr_code = 0x0A
 #
 # IC-7300 has NO Command29 support (single receiver).
 
+# PROVENANCE OPEN (D2, MOR-2008 batch 4): the following are left
+# deliberately undeclared rather than guessed. House pattern:
+# rigs/ic9700.toml "PROVENANCE OPEN (D2, MOR-2015)".
+# - get_memory_mode [0x08]: the IC-7300 Advanced Manual (11a) p.19-3
+#   phrases 0x08 as "Select the Memory mode" (imperative), not "Send/read"
+#   like this table's other bidirectional rows -- no live-bench probe has
+#   settled whether it answers a bare read.
+# - set_selected_mode [0x26, 0x00]: the opcode's GET direction is declared
+#   below (get_selected_mode), but this manual's own p.19-13 detail page
+#   for the SET direction's exact (mode, data_mode, filter) payload
+#   convention was not independently opened before this batch.
 [commands]
 
 # ── Frequency / Mode ──
@@ -917,10 +928,15 @@ set_freq = [0x05]
 get_mode = [0x04]
 set_mode = [0x06]
 get_band_edge_freq = [0x02]
-get_selected_freq = [0x25, 0x00]          # Selected VFO freq
-get_unselected_freq = [0x25, 0x01]        # Unselected VFO freq
-get_selected_mode = [0x26, 0x00]          # Selected VFO mode
-get_unselected_mode = [0x26, 0x01]        # Unselected VFO mode
+get_selected_freq = [0x25, 0x00]          # source: IC-7300 Advanced Manual (11a) p.19-7 (detail p.19-13)
+get_unselected_freq = [0x25, 0x01]        # source: IC-7300 Advanced Manual (11a) p.19-7 (detail p.19-13)
+get_selected_mode = [0x26, 0x00]          # source: IC-7300 Advanced Manual (11a) p.19-7 (detail p.19-13)
+get_unselected_mode = [0x26, 0x01]        # source: IC-7300 Advanced Manual (11a) p.19-7 (detail p.19-13)
+# set_selected_mode -- PROVENANCE OPEN above, left undeclared
+
+# ── TX Band Edge ──
+get_tx_band_count = [0x1E, 0x00]          # source: IC-7300 Advanced Manual (11a) p.19-7
+get_tx_band_edge = [0x1E, 0x01]           # source: IC-7300 Advanced Manual (11a) p.19-7 (detail p.19-9)
 
 # ── VFO ──
 get_vfo = [0x07]
@@ -1135,14 +1151,17 @@ get_dial_lock = [0x16, 0x50]
 set_dial_lock = [0x16, 0x50]
 
 # ── Band Stacking Register ──
-get_bsr = [0x1A, 0x01]
-set_bsr = [0x1A, 0x01]
+get_bsr = [0x1A, 0x01]                    # source: IC-7300 Advanced Manual (11a) p.19-4 (detail p.19-10)
+set_bsr = [0x1A, 0x01]                    # source: IC-7300 Advanced Manual (11a) p.19-4 (detail p.19-10)
 
-# ── Memory ── (NOT_IMPLEMENTED)
-# get_memory_contents = [0x1A, 0x00]
-# set_memory_contents = [0x1A, 0x00]
-# set_memory_mode = [0x08]
-# memory_clear = [0x0B]
+# ── Memory ──
+# get_memory_mode -- PROVENANCE OPEN above, left undeclared
+set_memory_mode = [0x08]                  # source: IC-7300 Advanced Manual (11a) p.19-3
+memory_write = [0x09]                     # source: IC-7300 Advanced Manual (11a) p.19-3
+memory_to_vfo = [0x0A]                    # source: IC-7300 Advanced Manual (11a) p.19-3 -- payload MOR-2055, see commands/memory.py: build_memory_to_vfo
+memory_clear = [0x0B]                     # source: IC-7300 Advanced Manual (11a) p.19-3 -- payload MOR-2055, see commands/memory.py: build_memory_clear
+get_memory_contents = [0x1A, 0x00]        # source: IC-7300 Advanced Manual (11a) p.19-4 (detail p.19-11)
+set_memory_contents = [0x1A, 0x00]        # source: IC-7300 Advanced Manual (11a) p.19-4 (detail p.19-11)
 
 # Menu 0x1A 0x05 sub-addresses: see [commands.overrides] (wfview IC-7300.rig)
 

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1042,6 +1042,17 @@ routes = [
 #   # NOT_IMPLEMENTED — command known from CI-V ref but not yet
 #                       handled by the rigplane backend
 
+# PROVENANCE OPEN (D2, MOR-2008 batch 4): the following are left
+# deliberately undeclared rather than guessed. House pattern:
+# rigs/ic9700.toml "PROVENANCE OPEN (D2, MOR-2015)".
+# - get_memory_mode [0x08]: this guide's own 0x08 row reads "Select the
+#   Memory mode" (imperative), not "Send/read" like the table's other
+#   bidirectional rows -- no live-bench probe has settled whether it
+#   answers a bare read.
+# - set_selected_mode [0x26, 0x00]: the opcode's GET direction is declared
+#   below (get_selected_mode), but this guide's own p.13 detail page for
+#   the SET direction's exact (mode, data_mode, filter) payload
+#   convention was not independently opened before this batch.
 [commands]
 
 # ── Frequency / Mode ──
@@ -1050,6 +1061,10 @@ set_freq = [0x05]
 get_mode = [0x04]
 set_mode = [0x06]
 get_band_edge_freq = [0x02]
+
+# ── TX Band Edge ──
+get_tx_band_count = [0x1E, 0x00]          # source: IC-7610 CI-V Reference Guide (Rev. 4) p.9
+get_tx_band_edge = [0x1E, 0x01]           # source: IC-7610 CI-V Reference Guide (Rev. 4) p.9 (detail p.10)
 
 # ── VFO / Dual Receiver ──
 get_vfo = [0x07]
@@ -1062,10 +1077,11 @@ set_dual_watch_off = [0x07, 0xC0]
 get_main_sub_band = [0x07, 0xD2]          # 0=MAIN, 1=SUB
 get_main_sub_tracking = [0x16, 0x5E]      # 0=OFF, 1=ON
 set_main_sub_tracking = [0x16, 0x5E]
-get_selected_freq = [0x25, 0x00]          # Read selected band freq
-get_unselected_freq = [0x25, 0x01]        # Read unselected band freq
-get_selected_mode = [0x26, 0x00]          # Read selected band mode
-get_unselected_mode = [0x26, 0x01]        # Read unselected band mode
+get_selected_freq = [0x25, 0x00]          # source: IC-7610 CI-V Reference Guide (Rev. 4) p.9 (detail p.13) -- documents 25/26 as "main or sub band" frequency, not "selected/unselected VFO"; same opcode structure
+get_unselected_freq = [0x25, 0x01]        # source: IC-7610 CI-V Reference Guide (Rev. 4) p.9 (detail p.13) -- "main or sub band" wording, see get_selected_freq
+get_selected_mode = [0x26, 0x00]          # source: IC-7610 CI-V Reference Guide (Rev. 4) p.9 (detail p.13) -- "main or sub band" wording, see get_selected_freq
+get_unselected_mode = [0x26, 0x01]        # source: IC-7610 CI-V Reference Guide (Rev. 4) p.9 (detail p.13) -- "main or sub band" wording, see get_selected_freq
+# set_selected_mode -- PROVENANCE OPEN above, left undeclared
 
 # ── Tuning ──
 get_tuning_step = [0x10]
@@ -1297,15 +1313,17 @@ get_ref_adjust = [0x1A, 0x05, 0x00, 0x70]
 set_ref_adjust = [0x1A, 0x05, 0x00, 0x70]
 
 # ── Band Stacking Register ──
-get_bsr = [0x1A, 0x01]                    # Read BSR contents
-set_bsr = [0x1A, 0x01]                    # Write BSR contents
+get_bsr = [0x1A, 0x01]                    # source: IC-7610 CI-V Reference Guide (Rev. 4) p.4 (detail p.10)
+set_bsr = [0x1A, 0x01]                    # source: IC-7610 CI-V Reference Guide (Rev. 4) p.4 (detail p.10)
 
 # ── Memory ──
-set_memory_mode = [0x08]
-memory_write = [0x09]
-memory_to_vfo = [0x0A]
-memory_clear = [0x0B]
-set_memory_contents = [0x1A, 0x00]
+# get_memory_mode -- PROVENANCE OPEN above, left undeclared
+set_memory_mode = [0x08]                  # source: IC-7610 CI-V Reference Guide (Rev. 4) p.3
+memory_write = [0x09]                     # source: IC-7610 CI-V Reference Guide (Rev. 4) p.3
+memory_to_vfo = [0x0A]                    # source: IC-7610 CI-V Reference Guide (Rev. 4) p.3 -- payload MOR-2055, see commands/memory.py: build_memory_to_vfo
+memory_clear = [0x0B]                     # source: IC-7610 CI-V Reference Guide (Rev. 4) p.3 -- payload MOR-2055, see commands/memory.py: build_memory_clear
+get_memory_contents = [0x1A, 0x00]        # source: IC-7610 CI-V Reference Guide (Rev. 4) p.4 (detail p.11)
+set_memory_contents = [0x1A, 0x00]        # source: IC-7610 CI-V Reference Guide (Rev. 4) p.4 (detail p.11)
 
 # ── Menu Settings (0x1A 0x05 ...) ──
 # These are SET menu items with model-specific sub-addresses.

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -448,6 +448,17 @@ routes = []
 #   - get_audio_peak_filter / set_audio_peak_filter [0x16, 0x32]
 #   - get_scope_single_dual                 [0x27, 0x13]
 #   - get_scope_rbw                         [0x27, 0x1F]
+#
+# Added (D2, MOR-2008 batch 4), left deliberately undeclared rather than
+# guessed:
+#   - get_memory_mode [0x08]: this guide's own 0x08 row reads "Select the
+#     Memory mode" (imperative), not "Send/read" like the table's other
+#     bidirectional rows -- no live-bench probe has settled whether it
+#     answers a bare read.
+#   - set_selected_mode [0x26, 0x00]: the opcode's GET direction is
+#     declared below (get_selected_mode), but this guide's own p.23 detail
+#     page for the SET direction's exact (mode, data_mode, filter) payload
+#     convention was not independently opened before this batch.
 
 # ── Frequency / Mode ──
 get_freq = [0x03]
@@ -455,10 +466,15 @@ set_freq = [0x05]
 get_mode = [0x04]
 set_mode = [0x06]
 get_band_edge_freq = [0x02]
-get_selected_freq = [0x25, 0x00]          # Selected VFO freq
-get_unselected_freq = [0x25, 0x01]        # Unselected VFO freq
-get_selected_mode = [0x26, 0x00]          # Selected VFO mode
-get_unselected_mode = [0x26, 0x01]        # Unselected VFO mode
+get_selected_freq = [0x25, 0x00]          # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.11 (detail p.23)
+get_unselected_freq = [0x25, 0x01]        # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.11 (detail p.23)
+get_selected_mode = [0x26, 0x00]          # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.11 (detail p.23)
+get_unselected_mode = [0x26, 0x01]        # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.11 (detail p.23)
+# set_selected_mode -- PROVENANCE OPEN above, left undeclared
+
+# ── TX Band Edge ──
+get_tx_band_count = [0x1E, 0x00]          # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.11
+get_tx_band_edge = [0x1E, 0x01]           # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.11 (detail p.13)
 
 # ── VFO / Dual Receiver ──
 get_vfo = [0x07]
@@ -697,14 +713,17 @@ get_dial_lock = [0x16, 0x50]
 set_dial_lock = [0x16, 0x50]
 
 # ── Band Stacking Register ──
-get_bsr = [0x1A, 0x01]
-set_bsr = [0x1A, 0x01]
+get_bsr = [0x1A, 0x01]                    # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.5 (detail p.15)
+set_bsr = [0x1A, 0x01]                    # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.5 (detail p.15)
 
-# ── Memory ── (NOT_IMPLEMENTED)
-# get_memory_contents = [0x1A, 0x00]
-# set_memory_contents = [0x1A, 0x00]
-# set_memory_mode = [0x08]
-# memory_clear = [0x0B]
+# ── Memory ──
+# get_memory_mode -- PROVENANCE OPEN above, left undeclared
+set_memory_mode = [0x08]                  # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.4
+memory_write = [0x09]                     # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.4
+memory_to_vfo = [0x0A]                    # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.4 -- payload MOR-2055, see commands/memory.py: build_memory_to_vfo
+memory_clear = [0x0B]                     # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.4 -- payload MOR-2055, see commands/memory.py: build_memory_clear
+get_memory_contents = [0x1A, 0x00]        # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.5 (detail pp.14,15)
+set_memory_contents = [0x1A, 0x00]        # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.5 (detail pp.14,15)
 
 # Menu 0x1A 0x05 sub-addresses: see [commands.overrides] (source: IC-9700
 # CI-V Reference Guide (Icom, 2019); corrected/absent per the MOR-2015

--- a/rigs/tx500.toml
+++ b/rigs/tx500.toml
@@ -256,6 +256,33 @@ get_voltage     = { cat = { read = "VL;", parse = "VL{volts:04d};" } }
 # Transceiver ID (ID) — 019 / 500 / 505.
 get_id          = { cat = { read = "ID;", parse = "ID{id};" } }
 
+# ── Memory / TX band edge / selected-VFO (absent, D2 MOR-2008 batch 4) ──
+# Protocol mismatch, not a documentation gap: [protocol] type is
+# "kenwood_cat" above, every entry in this table is a { cat = ... } spec,
+# and profiles/rig_loader.py: RigConfig.to_command_map keeps only the
+# CI-V half of CommandSpec -- none of these 16 canonical CI-V key names
+# can be declared under the [opcode, sub]-array syntax at all on this
+# profile. The Lab599 CAT protocol this radio speaks documents an
+# analogous MC/MR/MW memory-channel family (see the "lab599" variant note
+# above) that this profile does not declare today -- out of Group B's
+# scope, noted only so nobody double-declares it here.
+get_memory_mode      = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio (tests/command_map_parity_uncovered.txt: cat-only TX-500)" }
+set_memory_mode      = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+memory_write         = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+memory_to_vfo        = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+memory_clear         = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_memory_contents  = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+set_memory_contents  = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_bsr              = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+set_bsr              = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_tx_band_count    = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_tx_band_edge     = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_selected_freq    = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_unselected_freq  = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_selected_mode    = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+get_unselected_mode  = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+set_selected_mode    = { absent = "protocol mismatch: [protocol] type = \"kenwood_cat\", no CI-V command table on this radio" }
+
 [tx_policy]
 # Deliberately empty (MOR-1947) — a declared decision, not an oversight.
 # TX-500 has no serial backend: backends/factory.py refuses the model, so

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -471,6 +471,11 @@ set_tuner_status = [0x1C, 0x01]  # source: rigs/x6200.toml (sibling model, D2 MO
 
 # Selected / unselected VFO (0x25 / 0x26)
 get_selected_freq   = [0x25, 0x00]  # source: rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: Radioddity X6200 CI-V V1.0.6 p.9
+# set_selected_freq/set_unselected_freq/set_unselected_mode: no Python
+# builder resolves any of these three keys yet (git grep, zero hits in
+# src/rigplane/ -- MOR-2008 batch 4 D2 audit). Kept, not deleted: each
+# documents a real, sourced capability the same 0x25/0x26 opcodes
+# above confirm, data completeness rather than a code orphan.
 set_selected_freq   = [0x25, 0x00]  # source: rigs/x6200.toml (sibling model, D2 MOR-2018) -- same as get_selected_freq there
 get_unselected_freq = [0x25, 0x01]  # source: rigs/x6200.toml (sibling model, D2 MOR-2018) -- same as get_selected_freq there
 set_unselected_freq = [0x25, 0x01]  # source: rigs/x6200.toml (sibling model, D2 MOR-2018) -- same as get_selected_freq there
@@ -482,6 +487,23 @@ set_unselected_mode  = [0x26, 0x01]  # source: rigs/x6200.toml (sibling model, D
 # Protocol ack/nak echoes (used by transport-level matchers)
 get_command_error_fa = [0xFA]  # source: rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: Icom CI-V protocol convention, copied from the IC-705 profile at MOR-170, no X6200-specific (or X6100-specific) row
 get_command_ok_fb    = [0xFB]  # source: rigs/x6200.toml (sibling model, D2 MOR-2018) -- same as get_command_error_fa there
+
+# Memory / TX band edge (D2, MOR-2008 batch 4): sibling copy of
+# rigs/x6200.toml's own absent declarations -- none of these 11 opcodes
+# appear anywhere in the X6200 V1.0.6 Table 1 (pp.5-9, the complete
+# documented opcode list), and no X6100 CI-V manual exists to check
+# independently (D2 MOR-2018's own sibling-copy ruling).
+get_memory_mode      = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x08/0x09/0x0A/0x0B row anywhere" }
+set_memory_mode      = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x08 row anywhere" }
+memory_write         = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x09 row anywhere" }
+memory_to_vfo        = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x0A row anywhere" }
+memory_clear         = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x0B row anywhere" }
+get_memory_contents  = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x1A 0x00 row anywhere" }
+set_memory_contents  = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x1A 0x00 row anywhere" }
+get_bsr              = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 p.8 -- [0x1A, 0x01] documented, but as a 2-byte get_band_spectrum_display command, not Icom's 9-byte get_bsr record" }
+set_bsr              = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 p.8 -- [0x1A, 0x01] SET row documented, but as a 2-byte band-select command, not Icom's 9-byte set_bsr record" }
+get_tx_band_count    = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x1E row anywhere (table-exhaustiveness inference, not an explicit vendor statement)" }
+get_tx_band_edge     = { absent = "rigs/x6200.toml (sibling model, D2 MOR-2018) -- there: V1.0.6 Table 1 parts 1-5, pp.5-9 -- no 0x1E row anywhere (table-exhaustiveness inference, not an explicit vendor statement)" }
 
 [commands.overrides]
 

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -510,14 +510,27 @@ end_hz = 136000000
 #   Icom model -- MOR-208/179 (commit 5a493d70) and MOR-207 (commit
 #   b1df1e71). See [validation] write_only_controls above.
 #
-# Two more V1.0.6-documented registers (both p.8) have no capability and
-# no [commands] key at all, named here so nobody assumes an existing
-# entry already covers them:
+# One more V1.0.6-documented register (p.8) has no capability and no
+# [commands] key at all, named here so nobody assumes an existing entry
+# already covers it:
 # - front-panel LOCK, [0x1A, 0x05, 0x00, 0x62] -- distinct from
 #   get_dial_lock/set_dial_lock [0x16, 0x50] below.
-# - the band-stacking WRITE side of [0x1A, 0x01] -- get_band_spectrum_display
-#   below is only the read-only GET half; the write/recall direction is
-#   undeclared.
+#
+# Correction (D2, MOR-2008 batch 4): the sentence this note used to carry
+# here -- "the write/recall direction [of [0x1A, 0x01]] is undeclared" --
+# was factually wrong against the source it cited. p.8 documents BOTH
+# directions in the same table cell group: the GET row
+# get_band_spectrum_display declares below, and a SET row right beneath it
+# ("Set Band stacking register D1-Band Number(01-0C), D2 irrelevant").
+# That SET row is real and documented, but it is not the same command as
+# Icom's own set_bsr: its payload is 2 bytes (a filler byte + a 1-byte
+# band number 01-0C), where memory.py: set_bsr builds a 9-byte
+# band+register+frequency+mode+filter record -- same opcode, structurally
+# incompatible wire contract. Canonical set_bsr/get_bsr are therefore
+# declared ABSENT below (not DECLARE), and the X6200-specific 2-byte
+# command stays exposed only as get_band_spectrum_display, with no
+# set_band_spectrum_display key added for the SET row -- that would need
+# its own Python builder, out of this batch's scope.
 
 # Frequency / mode (compatible Icom CI-V subset — see PROVENANCE OPEN above)
 get_freq         = [0x03]  # source: Radioddity X6200 CI-V V1.0.6 p.4, narrative example only (via docs/validation/cat-audits/x6200.md) -- PROVENANCE OPEN above
@@ -608,7 +621,7 @@ get_transceiver_id = [0x19, 0x00]  # source: Radioddity X6200 CI-V V1.0.6 p.8 (v
 
 # 0x1A family (band/spectrum documented by the PDF; filter_width sourced
 # from LIVE evidence instead, per the doctrine live > hamlib > doc)
-get_band_spectrum_display = [0x1A, 0x01]  # source: Radioddity X6200 CI-V V1.0.6 p.8 (via docs/validation/cat-audits/x6200.md; re-checked against the local extract, D2 MOR-2019 -- the whole 0x1A family is on p.8, not p.8-9); read-only GET half only -- see PROVENANCE OPEN above for the undeclared write/band-stacking side
+get_band_spectrum_display = [0x1A, 0x01]  # source: Radioddity X6200 CI-V V1.0.6 p.8 (via docs/validation/cat-audits/x6200.md; re-checked against the local extract, D2 MOR-2019 -- the whole 0x1A family is on p.8, not p.8-9); GET half only -- the SET row on the same page is documented too (D2, MOR-2008 batch 4) but is a different, 2-byte command, not canonical set_bsr -- see PROVENANCE OPEN above
 get_filter_width          = [0x1A, 0x03]  # source: LIVE -- commit 74986b77 (MOR-706, 2026-06-12), raw USB CI-V 0xA4 captures; formula recorded in [filters] above; pinned by tests/test_dsp_filter_family.py::test_x6200_get_filter_width_decodes_raw_byte_index
 
 # PTT / tuner (0x1C family)
@@ -627,6 +640,11 @@ get_xiegu_model_id = [0x1D, 0x19]  # source: Radioddity X6200 CI-V V1.0.6 p.9 (v
 
 # Selected / unselected VFO (0x25 / 0x26)
 get_selected_freq    = [0x25, 0x00]  # source: Radioddity X6200 CI-V V1.0.6 p.9 (via docs/validation/cat-audits/x6200.md)
+# set_selected_freq/set_unselected_freq/set_unselected_mode: no Python
+# builder resolves any of these three keys yet (git grep, zero hits in
+# src/rigplane/ -- MOR-2008 batch 4 D2 audit). Kept, not deleted: each
+# documents a real, sourced capability the same 0x25/0x26 opcodes
+# above confirm, data completeness rather than a code orphan.
 set_selected_freq    = [0x25, 0x00]  # source: same as get_selected_freq
 get_unselected_freq  = [0x25, 0x01]  # source: same as get_selected_freq
 set_unselected_freq  = [0x25, 0x01]  # source: same as get_selected_freq
@@ -638,6 +656,32 @@ set_unselected_mode  = [0x26, 0x01]  # source: same as get_selected_freq
 # Protocol ack/nak echoes (used by transport-level matchers)
 get_command_error_fa = [0xFA]  # source: Icom CI-V protocol convention; copied from the IC-705 profile at MOR-170, no X6200-specific row
 get_command_ok_fb    = [0xFB]  # source: same as get_command_error_fa
+
+# Memory / TX band edge (D2, MOR-2008 batch 4): none of these 11 opcodes
+# appear anywhere in V1.0.6 Table 1 parts 1-5 (pp.5-9, the complete
+# documented opcode list) -- absent, not merely undeclared.
+get_memory_mode      = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 (complete opcode list) -- no 0x08/0x09/0x0A/0x0B row anywhere" }
+set_memory_mode      = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x08 row anywhere" }
+memory_write         = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x09 row anywhere" }
+memory_to_vfo        = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x0A row anywhere" }
+memory_clear         = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x0B row anywhere" }
+get_memory_contents  = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x1A 0x00 row anywhere" }
+set_memory_contents  = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x1A 0x00 row anywhere" }
+# get_bsr/set_bsr: the opcode [0x1A, 0x01] IS documented (see
+# get_band_spectrum_display above and the PROVENANCE OPEN note), but as a
+# different, structurally incompatible command -- 2-byte payload, not
+# Icom's 9-byte band+register+frequency+mode+filter record. Absent for
+# these canonical keys specifically; the opcode is not free for reuse
+# under this name.
+get_bsr              = { absent = "Radioddity X6200 CI-V implementation V1.0.6 p.8 -- [0x1A, 0x01] documented, but as get_band_spectrum_display's 2-byte command, not Icom's 9-byte get_bsr record" }
+set_bsr              = { absent = "Radioddity X6200 CI-V implementation V1.0.6 p.8 -- [0x1A, 0x01] SET row documented, but as a 2-byte band-select command, not Icom's 9-byte set_bsr record" }
+# get_tx_band_count/get_tx_band_edge: no 0x1E row in Table 1 either --
+# slightly softer confidence than the seven above, since the curator's own
+# "KNOWN-ABSENT" preface list (0x18/0x1B/0x21/0x27) does not name 0x1E
+# explicitly; this rests on table exhaustiveness, not an explicit vendor
+# statement.
+get_tx_band_count    = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x1E row anywhere (table-exhaustiveness inference, not an explicit vendor statement)" }
+get_tx_band_edge     = { absent = "Radioddity X6200 CI-V implementation V1.0.6, Table 1 parts 1-5, pp.5-9 -- no 0x1E row anywhere (table-exhaustiveness inference, not an explicit vendor statement)" }
 
 [commands.overrides]
 

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -516,21 +516,17 @@ end_hz = 136000000
 # - front-panel LOCK, [0x1A, 0x05, 0x00, 0x62] -- distinct from
 #   get_dial_lock/set_dial_lock [0x16, 0x50] below.
 #
-# Correction (D2, MOR-2008 batch 4): the sentence this note used to carry
-# here -- "the write/recall direction [of [0x1A, 0x01]] is undeclared" --
-# was factually wrong against the source it cited. p.8 documents BOTH
-# directions in the same table cell group: the GET row
-# get_band_spectrum_display declares below, and a SET row right beneath it
-# ("Set Band stacking register D1-Band Number(01-0C), D2 irrelevant").
-# That SET row is real and documented, but it is not the same command as
-# Icom's own set_bsr: its payload is 2 bytes (a filler byte + a 1-byte
-# band number 01-0C), where memory.py: set_bsr builds a 9-byte
-# band+register+frequency+mode+filter record -- same opcode, structurally
-# incompatible wire contract. Canonical set_bsr/get_bsr are therefore
-# declared ABSENT below (not DECLARE), and the X6200-specific 2-byte
-# command stays exposed only as get_band_spectrum_display, with no
-# set_band_spectrum_display key added for the SET row -- that would need
-# its own Python builder, out of this batch's scope.
+# D2, MOR-2008 batch 4: this note used to also claim the band-stacking
+# WRITE side of [0x1A, 0x01] was undeclared. That was false against the
+# source it cited: p.8 of the same V1.0.6 PDF documents a SET row too
+# ("Set Band stacking register D1-Band Number(01-0C), D2 irrelevant"),
+# three lines under the GET row get_band_spectrum_display already cites
+# below -- established by the MOR-2008 batch 4 D2 audit report (§6.2),
+# which re-derived the page against the local PDF with pdftotext rather
+# than trusting the prior claim. The SET row is real but is not the same
+# command as Icom's own set_bsr (2-byte payload vs. set_bsr's 9-byte
+# band+register+frequency+mode+filter record) -- see get_bsr/set_bsr's
+# own { absent = ... } rows below for the narrower, correct claim.
 
 # Frequency / mode (compatible Icom CI-V subset — see PROVENANCE OPEN above)
 get_freq         = [0x03]  # source: Radioddity X6200 CI-V V1.0.6 p.4, narrative example only (via docs/validation/cat-audits/x6200.md) -- PROVENANCE OPEN above

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -37,10 +37,13 @@ _CMD_PTT = 0x1C  # Transceiver status / PTT
 _CMD_CTL_MEM = 0x1A  # Memory / configuration command
 _CMD_BAND_EDGE = 0x02  # Band edge frequency
 _CMD_TONE = 0x1B  # Tone/TSQL frequency
-_CMD_MEMORY_MODE = 0x08  # Memory mode (select channel)
-_CMD_MEMORY_WRITE = 0x09  # Memory write
-_CMD_MEMORY_TO_VFO = 0x0A  # Memory to VFO
-_CMD_MEMORY_CLEAR = 0x0B  # Memory clear
+_CMD_MEMORY_MODE = 0x08  # Memory mode (select channel). 0x09 (write) / 0x0A
+# (memory-to-VFO) / 0x0B (memory clear) have no surviving constant here as
+# of MOR-2008 batch 4: memory.py's own builders read the wire bytes off
+# the profile's CommandMap now, and no importer anywhere else in
+# src/tests ever read `_CMD_MEMORY_WRITE`/`_CMD_MEMORY_TO_VFO`/
+# `_CMD_MEMORY_CLEAR` directly (AST-verified census, not text grep) --
+# deleted rather than left with zero readers.
 _CMD_TX_BAND_EDGE = 0x1E  # TX band edge frequencies
 _CMD_SELECTED_FREQ = 0x25  # Selected/Unselected receiver frequency
 _CMD_SELECTED_MODE = 0x26  # Selected/Unselected receiver mode

--- a/src/rigplane/commands/freq.py
+++ b/src/rigplane/commands/freq.py
@@ -13,14 +13,21 @@ fallback (`tests/test_radio.py`, `tests/test_icom7610_serial_radio.py`,
 `tests/_helpers.py`, others) -- ``tests/test_civ_command_profiling.py``
 is the only one of these that also imports ``_CMD_FREQ_SET``.
 
-The rest of this module (``get_selected_freq``/``get_unselected_freq``/
-``get_selected_mode``/``get_unselected_mode``/``set_selected_mode`` and
-their parsers) is out of this batch's scope: none of the five has a
-``cmd_map`` parameter at all today -- no dual implementation exists to
-delete a fallback from. MOR-2008's Group B (`memory.py`, `tx_band.py`,
-these five) is a separate, later piece of work (owner ruling on the
-ticket): fill the missing/inconsistent TOML declarations from the
-manuals first, then migrate under this same contract.
+``get_selected_freq``/``get_unselected_freq``/``get_selected_mode``/
+``get_unselected_mode``/``set_selected_mode`` migrated the same way in
+MOR-2008 (batch 4, "Group B"): each now requires ``cmd_map`` too -- no
+dual implementation ever existed for these five either, since none of
+them took a ``cmd_map`` parameter at all before this batch
+(`tests/command_map_parity_uncovered.txt`'s own ``hardcode_only_builders``
+census, pre-migration: 16, this module's share of it: 5).
+``set_selected_mode`` is left deliberately undeclared (D1 state 3) on
+IC-7300/IC-7610/IC-9700: the exact GET/SET wire convention for the full
+``(mode, data_mode, filter)`` tuple this builder sends was not
+independently confirmed against those three manuals' own detail pages
+before this batch, so calling it now raises `core.exceptions.CommandError`
+(undeclared-command refusal) on those three profiles rather than
+declaring bytes nobody has verified -- IC-705, X6200 and X6100 already
+declare it and are unaffected.
 """
 
 from __future__ import annotations
@@ -36,7 +43,6 @@ from ._frame import (
     _CMD_SELECTED_FREQ,
     _CMD_SELECTED_MODE,
     _build_from_map,
-    build_civ_frame,
     expose_command_key,
     require_cmd_map,
 )
@@ -112,20 +118,32 @@ def parse_frequency_response(frame: CivFrame) -> int:
 # --- Selected / Unselected receiver freq & mode (0x25/0x26) ---
 
 
+@expose_command_key(lambda cmd_map: "get_selected_freq")
+@require_cmd_map
 def get_selected_freq(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'get selected receiver frequency' CI-V command (0x25 0x00)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_SELECTED_FREQ, data=bytes([0x00]))
+    return _build_from_map(
+        cmd_map, "get_selected_freq", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_unselected_freq")
+@require_cmd_map
 def get_unselected_freq(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'get unselected receiver frequency' CI-V command (0x25 0x01)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_SELECTED_FREQ, data=bytes([0x01]))
+    return _build_from_map(
+        cmd_map, "get_unselected_freq", to_addr=to_addr, from_addr=from_addr
+    )
 
 
 def parse_selected_freq_response(frame: CivFrame) -> tuple[int, int]:
@@ -145,28 +163,44 @@ def parse_selected_freq_response(frame: CivFrame) -> tuple[int, int]:
     return receiver_byte, freq
 
 
+@expose_command_key(lambda cmd_map: "get_selected_mode")
+@require_cmd_map
 def get_selected_mode(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'get selected receiver mode' CI-V command (0x26 0x00)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_SELECTED_MODE, data=bytes([0x00]))
+    return _build_from_map(
+        cmd_map, "get_selected_mode", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_unselected_mode")
+@require_cmd_map
 def get_unselected_mode(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a 'get unselected receiver mode' CI-V command (0x26 0x01)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_SELECTED_MODE, data=bytes([0x01]))
+    return _build_from_map(
+        cmd_map, "get_unselected_mode", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_selected_mode")
+@require_cmd_map
 def set_selected_mode(
     mode: Mode,
     data_mode: int,
     filter_index: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build a "set selected receiver mode" CI-V command (0x26 0x00).
 
@@ -176,11 +210,12 @@ def set_selected_mode(
     full tuple so a mode-only change preserves the radio's current data-mode
     and filter.
     """
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_SELECTED_MODE,
-        data=bytes([0x00, int(Mode(mode)), int(data_mode), int(filter_index)]),
+    return _build_from_map(
+        cmd_map,
+        "set_selected_mode",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([int(Mode(mode)), int(data_mode), int(filter_index)]),
     )
 
 

--- a/src/rigplane/commands/memory.py
+++ b/src/rigplane/commands/memory.py
@@ -1,4 +1,42 @@
-"""Memory mode/write/clear/contents and band stacking register commands."""
+"""Memory mode/write/clear/contents and band stacking register commands.
+
+All nine builders in this module migrated onto the bound command map in
+MOR-2008 (batch 4, `docs/plans/2026-08-29-profile-driven-command-bytes.md`
+§4 Steps 5..N, "Group B"): each now requires ``cmd_map`` -- no hardcoded
+fallback ever existed to delete here, unlike batches 1-3's modules, since
+none of these nine ever took a ``cmd_map`` parameter at all before this
+batch (`tests/command_map_parity_uncovered.txt`'s own
+``hardcode_only_builders`` census, pre-migration: 16, this module's share
+of it: 9).
+
+Canonical command-map key naming (owner ruling, MOR-2008 batch 4): a
+genuine get/set *value* pair keeps its ``get_``/``set_`` prefix
+(``get_memory_mode``/``set_memory_mode``, ``get_memory_contents``/
+``set_memory_contents``, ``get_bsr``/``set_bsr``); a single-wire-form
+*action* command uses the bare name, the same convention already
+established for ``power_on``/``power_off``/``ptt_on``/``ptt_off``/
+``scan_start`` -- so ``build_memory_write``/``build_memory_to_vfo``/
+``build_memory_clear`` resolve ``"memory_write"``/``"memory_to_vfo"``/
+``"memory_clear"``, not a ``get_``/``set_`` spelling. The Python function
+names keep their anomalous ``build_X_get``/``build_X_set``/``build_X``
+shape (only ``get_bsr``/``set_bsr`` already followed the package-wide
+``get_X``/``set_X`` convention) -- renaming a public function is out of
+this migration's scope; only the TOML key spellings were reconciled.
+
+``get_memory_mode`` is left deliberately undeclared (D1 state 3) on every
+CI-V profile: the four Icom manuals phrase 0x08 as "Select the Memory
+mode" (imperative), not "Send/read" like the package's other bidirectional
+rows, and no live-bench probe has settled whether it answers a bare read
+-- see each profile's own "PROVENANCE OPEN" note. Calling it now raises
+`core.exceptions.CommandError` (undeclared-command refusal) on every
+shipped Icom profile, the honest outcome until that probe happens.
+
+``build_memory_to_vfo``/``build_memory_clear`` still append the 2-byte BCD
+channel payload all four Icom manuals show 0x0A/0x0B accepting no data
+column at all -- MOR-2055, not touched by this migration, which only
+re-plumbs the command-map lookup and leaves the wire bytes exactly as they
+were.
+"""
 
 from __future__ import annotations
 
@@ -9,32 +47,46 @@ from ._codec import _bcd_decode_value, bcd_encode_value
 from ._frame import (
     CONTROLLER_ADDR,
     _CMD_CTL_MEM,
-    _CMD_MEMORY_CLEAR,
     _CMD_MEMORY_MODE,
-    _CMD_MEMORY_TO_VFO,
-    _CMD_MEMORY_WRITE,
     _SUB_BAND_STACK,
     _SUB_MEMORY_CONTENTS,
-    build_civ_frame,
+    _build_from_map,
+    expose_command_key,
+    require_cmd_map,
 )
 
 if TYPE_CHECKING:
+    from ..command_map import CommandMap
     from ..types import BandStackRegister, CivFrame, MemoryChannel
 
 
-def build_memory_mode_get(to_addr: int, from_addr: int = CONTROLLER_ADDR) -> bytes:
+@expose_command_key(lambda cmd_map: "get_memory_mode")
+@require_cmd_map
+def build_memory_mode_get(
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
+) -> bytes:
     """Build CI-V frame to get current memory mode (0x08)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_MEMORY_MODE)
+    return _build_from_map(
+        cmd_map, "get_memory_mode", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "set_memory_mode")
+@require_cmd_map
 def build_memory_mode_set(
-    channel: int, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    channel: int,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to set memory mode (0x08)."""
     if not 1 <= channel <= 101:
         raise ValueError(f"Channel must be 1-101, got {channel}")
     data = bcd_encode_value(channel, byte_count=2)
-    return build_civ_frame(to_addr, from_addr, _CMD_MEMORY_MODE, data=data)
+    return _build_from_map(
+        cmd_map, "set_memory_mode", to_addr=to_addr, from_addr=from_addr, data=data
+    )
 
 
 def parse_memory_mode_response(frame: CivFrame) -> int:
@@ -46,45 +98,99 @@ def parse_memory_mode_response(frame: CivFrame) -> int:
     return _bcd_decode_value(frame.data[:2])
 
 
-def build_memory_write(to_addr: int, from_addr: int = CONTROLLER_ADDR) -> bytes:
+@expose_command_key(lambda cmd_map: "memory_write")
+@require_cmd_map
+def build_memory_write(
+    to_addr: int, from_addr: int = CONTROLLER_ADDR, *, cmd_map: CommandMap
+) -> bytes:
     """Build CI-V frame to write VFO to memory (0x09)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_MEMORY_WRITE)
+    return _build_from_map(
+        cmd_map, "memory_write", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "memory_to_vfo")
+@require_cmd_map
 def build_memory_to_vfo(
-    channel: int, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    channel: int,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    """Build CI-V frame to load memory to VFO (0x0A)."""
+    """Build CI-V frame to load memory to VFO (0x0A).
+
+    Note:
+        The 2-byte BCD channel payload appended here is contradicted by
+        all four Icom manuals, which document 0x0A as a bare command with
+        no data field -- see MOR-2055 for the payload question. This
+        migration re-plumbs the command-map lookup only and does not
+        change these wire bytes.
+    """
     if not 1 <= channel <= 101:
         raise ValueError(f"Channel must be 1-101, got {channel}")
     data = bcd_encode_value(channel, byte_count=2)
-    return build_civ_frame(to_addr, from_addr, _CMD_MEMORY_TO_VFO, data=data)
+    return _build_from_map(
+        cmd_map, "memory_to_vfo", to_addr=to_addr, from_addr=from_addr, data=data
+    )
 
 
+@expose_command_key(lambda cmd_map: "memory_clear")
+@require_cmd_map
 def build_memory_clear(
-    channel: int, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    channel: int,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
-    """Build CI-V frame to clear memory channel (0x0B)."""
+    """Build CI-V frame to clear memory channel (0x0B).
+
+    Note:
+        The 2-byte BCD channel payload appended here is contradicted by
+        all four Icom manuals, which document 0x0B as a bare command with
+        no data field -- see MOR-2055 for the payload question. This
+        migration re-plumbs the command-map lookup only and does not
+        change these wire bytes.
+    """
     if not 1 <= channel <= 101:
         raise ValueError(f"Channel must be 1-101, got {channel}")
     data = bcd_encode_value(channel, byte_count=2)
-    return build_civ_frame(to_addr, from_addr, _CMD_MEMORY_CLEAR, data=data)
+    return _build_from_map(
+        cmd_map, "memory_clear", to_addr=to_addr, from_addr=from_addr, data=data
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_memory_contents")
+@require_cmd_map
 def build_memory_contents_get(
-    channel: int, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    channel: int,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to get memory contents (0x1A 0x00)."""
     if not 1 <= channel <= 101:
         raise ValueError(f"Channel must be 1-101, got {channel}")
     channel_bcd = bcd_encode_value(channel, byte_count=2)
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_MEMORY_CONTENTS, data=channel_bcd
+    return _build_from_map(
+        cmd_map,
+        "get_memory_contents",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=channel_bcd,
     )
 
 
+@expose_command_key(lambda cmd_map: "set_memory_contents")
+@require_cmd_map
 def build_memory_contents_set(
-    mem: MemoryChannel, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    mem: MemoryChannel,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to set memory contents (0x1A 0x00)."""
     from ..types import MemoryChannel as MC
@@ -108,11 +214,11 @@ def build_memory_contents_set(
     payload[15 : 15 + len(name_bytes)] = name_bytes
 
     channel_bcd = bcd_encode_value(mem.channel, byte_count=2)
-    return build_civ_frame(
-        to_addr,
-        from_addr,
-        _CMD_CTL_MEM,
-        sub=_SUB_MEMORY_CONTENTS,
+    return _build_from_map(
+        cmd_map,
+        "set_memory_contents",
+        to_addr=to_addr,
+        from_addr=from_addr,
         data=channel_bcd + bytes(payload),
     )
 
@@ -150,8 +256,15 @@ def parse_memory_contents_response(frame: CivFrame) -> MemoryChannel:
 # --- Band Stacking Register ---
 
 
+@expose_command_key(lambda cmd_map: "get_bsr")
+@require_cmd_map
 def get_bsr(
-    band: int, register: int, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    band: int,
+    register: int,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to get band stacking register (0x1A 0x01)."""
     if not 0 <= band <= 24:
@@ -159,13 +272,19 @@ def get_bsr(
     if not 1 <= register <= 3:
         raise ValueError(f"Register must be 1-3, got {register}")
     data = bytes([band, register])
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_BAND_STACK, data=data
+    return _build_from_map(
+        cmd_map, "get_bsr", to_addr=to_addr, from_addr=from_addr, data=data
     )
 
 
+@expose_command_key(lambda cmd_map: "set_bsr")
+@require_cmd_map
 def set_bsr(
-    bsr: BandStackRegister, to_addr: int, from_addr: int = CONTROLLER_ADDR
+    bsr: BandStackRegister,
+    to_addr: int,
+    from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to set band stacking register (0x1A 0x01)."""
     from ..types import BandStackRegister as BSR
@@ -181,8 +300,8 @@ def set_bsr(
     payload += bcd_encode(bsr.frequency_hz)
     payload += bcd_encode_value(bsr.mode, byte_count=1)
     payload += bcd_encode_value(bsr.filter, byte_count=1)
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_CTL_MEM, sub=_SUB_BAND_STACK, data=payload
+    return _build_from_map(
+        cmd_map, "set_bsr", to_addr=to_addr, from_addr=from_addr, data=payload
     )
 
 

--- a/src/rigplane/commands/tx_band.py
+++ b/src/rigplane/commands/tx_band.py
@@ -3,30 +3,55 @@
 Queries the radio for valid TX frequency ranges:
 - 0x1E 0x00: number of TX bands
 - 0x1E 0x01 [band_bcd]: start/end frequencies for a specific TX band
+
+Both builders migrated onto the bound command map in MOR-2008 (batch 4,
+`docs/plans/2026-08-29-profile-driven-command-bytes.md` §4 Steps 5..N,
+"Group B"): each now requires ``cmd_map`` -- no hardcoded fallback ever
+existed to delete here, since neither took a ``cmd_map`` parameter at all
+before this batch. Neither builder has a production call site
+(`runtime/radio.py`, `runtime/_dual_rx_runtime.py`): only the response
+parsers below are consumed, by `runtime/_civ_rx.py`, decoding unsolicited
+0x1E frames rather than one this module itself requested.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..types import bcd_decode
 from ._frame import (
     CONTROLLER_ADDR,
-    _CMD_TX_BAND_EDGE,
-    build_civ_frame,
+    _build_from_map,
+    expose_command_key,
+    require_cmd_map,
 )
 
+if TYPE_CHECKING:
+    from ..command_map import CommandMap
 
+
+@expose_command_key(lambda cmd_map: "get_tx_band_count")
+@require_cmd_map
 def get_tx_band_count(
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to query number of TX bands (0x1E 0x00)."""
-    return build_civ_frame(to_addr, from_addr, _CMD_TX_BAND_EDGE, sub=0x00)
+    return _build_from_map(
+        cmd_map, "get_tx_band_count", to_addr=to_addr, from_addr=from_addr
+    )
 
 
+@expose_command_key(lambda cmd_map: "get_tx_band_edge")
+@require_cmd_map
 def get_tx_band_edge(
     band: int,
     to_addr: int,
     from_addr: int = CONTROLLER_ADDR,
+    *,
+    cmd_map: CommandMap,
 ) -> bytes:
     """Build CI-V frame to query TX band N edge frequencies (0x1E 0x01).
 
@@ -34,13 +59,18 @@ def get_tx_band_edge(
         band: Band number (0-99, encoded as BCD byte).
         to_addr: Radio CI-V address.
         from_addr: Controller CI-V address.
+        cmd_map: The radio's bound command map.
 
     Returns:
         Complete CI-V frame bytes.
     """
     band_bcd = ((band // 10) << 4) | (band % 10)
-    return build_civ_frame(
-        to_addr, from_addr, _CMD_TX_BAND_EDGE, sub=0x01, data=bytes([band_bcd])
+    return _build_from_map(
+        cmd_map,
+        "get_tx_band_edge",
+        to_addr=to_addr,
+        from_addr=from_addr,
+        data=bytes([band_bcd]),
     )
 
 

--- a/src/rigplane/runtime/_dual_rx_runtime.py
+++ b/src/rigplane/runtime/_dual_rx_runtime.py
@@ -24,11 +24,6 @@ from rigplane.commands import (
     parse_ack_nak,
     parse_mode_response,
 )
-from rigplane.commands import get_selected_freq as _get_selected_freq_cmd
-from rigplane.commands import get_selected_mode as _get_selected_mode_cmd
-from rigplane.commands import set_selected_mode as _set_selected_mode_cmd
-from rigplane.commands import get_unselected_freq as _get_unselected_freq_cmd
-from rigplane.commands import get_unselected_mode as _get_unselected_mode_cmd
 from rigplane.core.radio_protocol import RelativeVfoState
 from rigplane.commands import (
     parse_selected_freq_response as _parse_selected_freq_response,
@@ -227,7 +222,7 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
                 if filter_width is not None
                 else (self._filter_width if self._filter_width is not None else 1)
             )
-            civ = _set_selected_mode_cmd(
+            civ = self._commands.set_selected_mode(
                 mode, data_mode, resolved_filter, to_addr=self._radio_addr
             )
         else:
@@ -253,28 +248,28 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
 
     async def _get_selected_freq(self) -> int:
         """Read the selected (active) receiver frequency via CI-V 0x25 0x00."""
-        civ = _get_selected_freq_cmd(to_addr=self._radio_addr)
+        civ = self._commands.get_selected_freq(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_selected_freq")
         _rcvr, freq = _parse_selected_freq_response(resp)
         return freq
 
     async def _get_unselected_freq(self) -> int:
         """Read the unselected (inactive) receiver frequency via CI-V 0x25 0x01."""
-        civ = _get_unselected_freq_cmd(to_addr=self._radio_addr)
+        civ = self._commands.get_unselected_freq(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_unselected_freq")
         _rcvr, freq = _parse_selected_freq_response(resp)
         return freq
 
     async def _get_selected_mode(self) -> tuple[Mode, int | None]:
         """Read the selected (active) receiver mode via CI-V 0x26 0x00."""
-        civ = _get_selected_mode_cmd(to_addr=self._radio_addr)
+        civ = self._commands.get_selected_mode(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_selected_mode")
         _rcvr, mode, _data_mode, filt = _parse_selected_mode_response(resp)
         return mode, filt
 
     async def _get_unselected_mode(self) -> tuple[Mode, int | None]:
         """Read the unselected (inactive) receiver mode via CI-V 0x26 0x01."""
-        civ = _get_unselected_mode_cmd(to_addr=self._radio_addr)
+        civ = self._commands.get_unselected_mode(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_unselected_mode")
         _rcvr, mode, _data_mode, filt = _parse_selected_mode_response(resp)
         return mode, filt
@@ -282,8 +277,16 @@ class DualRxRuntimeMixin(_MixinBase):  # type: ignore[misc]
     async def read_relative_vfo(self, *, selected: bool) -> RelativeVfoState:
         """Read one Selected/Unselected tuple without changing radio state."""
 
-        freq_cmd = _get_selected_freq_cmd if selected else _get_unselected_freq_cmd
-        mode_cmd = _get_selected_mode_cmd if selected else _get_unselected_mode_cmd
+        freq_cmd = (
+            self._commands.get_selected_freq
+            if selected
+            else self._commands.get_unselected_freq
+        )
+        mode_cmd = (
+            self._commands.get_selected_mode
+            if selected
+            else self._commands.get_unselected_mode
+        )
         role = "selected" if selected else "unselected"
         freq_resp = await self._send_civ_expect(
             freq_cmd(to_addr=self._radio_addr), label=f"get_{role}_freq"

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -91,12 +91,6 @@ from rigplane.commands import (
     build_civ_frame,
     filter_hz_to_index,
     filter_index_to_hz,
-    build_band_stack_get,
-    build_memory_clear,
-    build_memory_contents_set,
-    build_memory_mode_set,
-    build_memory_to_vfo,
-    build_memory_write,
     get_acc1_mod_level,
     get_af_mute,
     get_agc,
@@ -166,7 +160,6 @@ from rigplane.commands import (
     parse_tsql_freq_response,
     parse_utc_offset_response,
     parse_powerstat,
-    set_bsr,
 )
 from rigplane.commands import get_main_sub_tracking as _get_main_sub_tracking_cmd
 from rigplane.commands import get_repeater_tone as _get_repeater_tone_cmd
@@ -5275,19 +5268,21 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if not 1 <= channel <= 101:
             raise ValueError(f"Channel must be 1-101, got {channel}")
         await self._send_fire_and_forget(
-            build_memory_mode_set(channel, to_addr=self._radio_addr)
+            self._commands.build_memory_mode_set(channel, to_addr=self._radio_addr)
         )
 
     async def memory_write(self) -> None:
         """Write current VFO state to selected memory channel."""
-        await self._send_fire_and_forget(build_memory_write(to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.build_memory_write(to_addr=self._radio_addr)
+        )
 
     async def memory_to_vfo(self, channel: int) -> None:
         """Load memory channel to VFO."""
         if not 1 <= channel <= 101:
             raise ValueError(f"Channel must be 1-101, got {channel}")
         await self._send_fire_and_forget(
-            build_memory_to_vfo(channel, to_addr=self._radio_addr)
+            self._commands.build_memory_to_vfo(channel, to_addr=self._radio_addr)
         )
 
     async def memory_clear(self, channel: int) -> None:
@@ -5295,7 +5290,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if not 1 <= channel <= 101:
             raise ValueError(f"Channel must be 1-101, got {channel}")
         await self._send_fire_and_forget(
-            build_memory_clear(channel, to_addr=self._radio_addr)
+            self._commands.build_memory_clear(channel, to_addr=self._radio_addr)
         )
 
     async def get_memory_contents(self, channel: int) -> MemoryChannel:
@@ -5321,7 +5316,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if not 1 <= mem.channel <= 101:
             raise ValueError(f"Channel must be 1-101, got {mem.channel}")
         await self._send_fire_and_forget(
-            build_memory_contents_set(mem, to_addr=self._radio_addr)
+            self._commands.build_memory_contents_set(mem, to_addr=self._radio_addr)
         )
 
     async def get_bsr(self, band: int, register: int) -> BandStackRegister:
@@ -5344,7 +5339,7 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         if not 1 <= register <= 3:
             raise ValueError(f"Register must be 1-3, got {register}")
         self._check_connected()
-        civ = build_band_stack_get(band, register, to_addr=self._radio_addr)
+        civ = self._commands.get_bsr(band, register, to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_bsr")
         return parse_band_stack_response(resp)
 
@@ -5354,7 +5349,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             raise ValueError(f"Band must be 0-24, got {bsr.band}")
         if not 1 <= bsr.register <= 3:
             raise ValueError(f"Register must be 1-3, got {bsr.register}")
-        await self._send_fire_and_forget(set_bsr(bsr, to_addr=self._radio_addr))
+        await self._send_fire_and_forget(
+            self._commands.set_bsr(bsr, to_addr=self._radio_addr)
+        )
 
     # ------------------------------------------------------------------
     # Backward-compat aliases — old names kept for existing callers

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -27,17 +27,15 @@
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
 census	builders_compared	0
-census	cat_only_profiles	2
+census	cat_only_profiles	0
 census	dual_implementation_sites	0
 census	frames_diverged	0
 census	frames_identical	0
-census	hardcode_only_builders	16
+census	hardcode_only_builders	0
 census	profile_builder_map_gaps	0
 census	profiles	8
-census	public_builders	228
+census	public_builders	244
 census	sites_compared	0
-cat-only	FTX-1	108
-cat-only	TX-500	50
 requires-map	antenna.py:get_antenna_1
 requires-map	antenna.py:get_antenna_2
 requires-map	antenna.py:get_rx_antenna_ant1
@@ -104,7 +102,12 @@ requires-map	dsp.py:set_preamp
 requires-map	dsp.py:set_twin_peak_filter
 requires-map	dsp.py:set_vox
 requires-map	freq.py:get_freq
+requires-map	freq.py:get_selected_freq
+requires-map	freq.py:get_selected_mode
+requires-map	freq.py:get_unselected_freq
+requires-map	freq.py:get_unselected_mode
 requires-map	freq.py:set_freq
+requires-map	freq.py:set_selected_mode
 requires-map	levels.py:get_af_level
 requires-map	levels.py:get_anti_vox_gain
 requires-map	levels.py:get_apf_type_level
@@ -155,6 +158,15 @@ requires-map	levels.py:set_rf_power
 requires-map	levels.py:set_squelch
 requires-map	levels.py:set_vox_delay
 requires-map	levels.py:set_vox_gain
+requires-map	memory.py:build_memory_clear
+requires-map	memory.py:build_memory_contents_get
+requires-map	memory.py:build_memory_contents_set
+requires-map	memory.py:build_memory_mode_get
+requires-map	memory.py:build_memory_mode_set
+requires-map	memory.py:build_memory_to_vfo
+requires-map	memory.py:build_memory_write
+requires-map	memory.py:get_bsr
+requires-map	memory.py:set_bsr
 requires-map	meters.py:get_alc
 requires-map	meters.py:get_comp_meter
 requires-map	meters.py:get_id_meter
@@ -246,6 +258,8 @@ requires-map	tone.py:set_repeater_tone
 requires-map	tone.py:set_repeater_tsql
 requires-map	tone.py:set_tone_freq
 requires-map	tone.py:set_tsql_freq
+requires-map	tx_band.py:get_tx_band_count
+requires-map	tx_band.py:get_tx_band_edge
 requires-map	vfo.py:get_dual_watch
 requires-map	vfo.py:get_main_sub_band
 requires-map	vfo.py:get_quick_dual_watch

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -7,9 +7,9 @@
 # via { absent = "<source>" } (plan §8.1 D2) or a real command-byte
 # entry in the profile's own TOML. Regenerate, do not hand-edit.
 census	civ_profiles	6
-census	distinct_gap_keys	145
-census	profile_key_gaps	292
-census	public_builders	228
+census	distinct_gap_keys	147
+census	profile_key_gaps	299
+census	public_builders	244
 gap	get_acc1_mod_level	X6100,X6200
 gap	get_af_mute	X6100,X6200
 gap	get_agc_time_constant	X6100,X6200
@@ -40,6 +40,7 @@ gap	get_lan_mod_level	X6100,X6200
 gap	get_main_sub_band	X6100,X6200
 gap	get_main_sub_tracking	X6100,X6200
 gap	get_manual_notch_width	X6100,X6200
+gap	get_memory_mode	IC-705,IC-7300,IC-7610,IC-9700
 gap	get_monitor	X6100,X6200
 gap	get_nb_depth	X6100,X6200
 gap	get_nb_width	X6100,X6200
@@ -141,6 +142,7 @@ gap	set_rit_frequency	X6100,X6200
 gap	set_rit_status	X6100,X6200
 gap	set_rit_tx_status	X6100,X6200
 gap	set_rx_antenna_ant2	X6100,X6200
+gap	set_selected_mode	IC-7300,IC-7610,IC-9700
 gap	set_ssb_tx_bandwidth	X6100,X6200
 gap	set_system_date	X6100,X6200
 gap	set_system_time	X6100,X6200

--- a/tests/test_command_fallback_audit.py
+++ b/tests/test_command_fallback_audit.py
@@ -27,24 +27,26 @@ repointed to ``dsp.py`` when MOR-2008 batch 2 migrated ``get_freq``/
 MOR-2008 batch 3 migrated ``dsp.py`` too, so ``get_attenuator`` no longer has
 a fallback branch either: calling it with ``cmd_map=None`` now raises
 ``TypeError`` (`_frame.py: require_cmd_map`) instead of returning fallback
-bytes. **No repoint is possible this time** -- a census of every public
-builder across ``commands/*.py`` at this head (``inspect.signature(fn).
+bytes. **No repoint is possible, batch 3 or since** -- a census of every
+public builder across ``commands/*.py`` at this head (``inspect.signature(fn).
 parameters["cmd_map"].default``) found zero builders with an *optional*
-``cmd_map`` left: 238 now require it, and the 51 that lack the parameter
-entirely (``memory.py``, ``tx_band.py``, ``freq.py``'s five selected-
-receiver builders -- Group B, deferred per an owner ruling recorded in
-MOR-2008 batch 2's PR body) never had it in the first place, so
-``_fallback_audit.install`` would not even wrap them (its own gate is
-``"cmd_map" in inspect.signature(value).parameters``). The tests below that
-used to assert "no exception, fallback bytes returned, one warning logged"
-now assert "warning still logged, then the builder's own ``TypeError``
-propagates unchanged" -- the wrapper's log-then-delegate contract holds even
-though delegating no longer has a soft landing. This is exactly the
-precondition ``docs/plans/2026-08-29-profile-driven-command-bytes.md``'s
-Step Z names for deleting this file and ``_fallback_audit.py`` outright;
-Step Z is a separate, larger step (it also touches
-``commands/_frame.py``'s dead-constant census and ``docs/api/commands.md``)
-and is not done here.
+``cmd_map`` left: 238 required it at batch 3 (256 now that MOR-2008 batch 4
+migrated ``memory.py``/``tx_band.py``/``freq.py``'s five selected-receiver
+builders too -- Group B, the last builders anywhere in the package with no
+``cmd_map`` parameter at all), and the 51 that lacked the parameter entirely
+at batch 3 are down to 33 -- every one of them a ``parse_*`` response
+decoder now, never a byte-emitting builder, so none of them ever had a
+fallback to repoint at in the first place; ``_fallback_audit.install``
+would not even wrap them (its own gate is ``"cmd_map" in
+inspect.signature(value).parameters``). The tests below that used to assert
+"no exception, fallback bytes returned, one warning logged" now assert
+"warning still logged, then the builder's own ``TypeError`` propagates
+unchanged" -- the wrapper's log-then-delegate contract holds even though
+delegating no longer has a soft landing. This is exactly the precondition
+``docs/plans/2026-08-29-profile-driven-command-bytes.md``'s Step Z names for
+deleting this file and ``_fallback_audit.py`` outright; Step Z is a
+separate, larger step (it also touches ``commands/_frame.py``'s
+dead-constant census and ``docs/api/commands.md``) and is not done here.
 """
 
 from __future__ import annotations

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -9,7 +9,11 @@ import pytest
 
 from rigplane.command_spec import AbsentCommandSpec, CatCommandSpec, CivCommandSpec
 from rigplane.rig_loader import RigLoadError, load_rig
+from test_rig_loader import TestFtx1DeclaresAbsentCommands as _Ftx1AbsentPin
 from test_rig_loader import TestIc7610DeclaresAbsentCommands as _Ic7610AbsentPin
+from test_rig_loader import TestTx500DeclaresAbsentCommands as _Tx500AbsentPin
+from test_rig_loader import TestX6100DeclaresAbsentCommands as _X6100AbsentPin
+from test_rig_loader import TestX6200DeclaresAbsentCommands as _X6200AbsentPin
 
 
 def _write_toml(tmp_path: Path, content: str, name: str = "test.toml") -> Path:
@@ -415,3 +419,74 @@ class TestBackwardCompatibility:
         cmd_map = rig.to_command_map()
         assert cmd_map.has("get_freq")
         assert cmd_map.has("set_freq")
+
+    def _assert_loads_except_declared_absent(
+        self, toml_name: str, expected_absent: frozenset[str], live_spec_type: type
+    ) -> None:
+        """Shared body for the four MOR-2008 batch 4 checks below: every
+        command in ``rig.commands`` is *live_spec_type* except the pinned
+        absent set, discriminating both directions the same way
+        ``test_ic7610_loads_civ_except_the_declared_absent_tone_tsql_family``
+        above does -- a row silently becoming absent, or an absent row
+        silently reverting to live, fails regardless of which name moves.
+        Generalized to four callers (X6200/X6100: ``CivCommandSpec``;
+        FTX-1/TX-500: ``CatCommandSpec``) rather than duplicated a fourth
+        and fifth time, per the rule of three.
+        """
+        rigs_dir = Path(__file__).resolve().parent.parent / "rigs"
+        p = rigs_dir / toml_name
+
+        if not p.exists():
+            pytest.skip(f"{toml_name} not found")
+
+        rig = load_rig(p)
+
+        for name, spec in rig.commands.items():
+            if name in expected_absent:
+                assert isinstance(spec, AbsentCommandSpec), (
+                    f"Command {name} is declared absent but not AbsentCommandSpec"
+                )
+            else:
+                assert isinstance(spec, live_spec_type), (
+                    f"Command {name} is not {live_spec_type.__name__}"
+                )
+        actually_absent = {
+            name
+            for name, spec in rig.commands.items()
+            if isinstance(spec, AbsentCommandSpec)
+        }
+        assert actually_absent == expected_absent, (
+            f"{toml_name}'s AbsentCommandSpec entries drifted from its own "
+            "TestXDeclaresAbsentCommands._EXPECTED_ABSENT pin"
+        )
+
+    def test_x6200_loads_civ_except_the_declared_absent_group_b_family(self) -> None:
+        """MOR-2008 batch 4: X6200 declares 17 keys absent (6 DSP-family
+        from batch 3, 11 Group B memory/tx_band keys added here) --
+        everything else in its ``[commands]`` table is CivCommandSpec, the
+        5 Group B freq.py keys included (DECLARED-OK, not absent).
+        """
+        self._assert_loads_except_declared_absent(
+            "x6200.toml", _X6200AbsentPin._EXPECTED_ABSENT, CivCommandSpec
+        )
+
+    def test_x6100_loads_civ_except_the_declared_absent_group_b_family(self) -> None:
+        """Sibling of the X6200 check above (D2 MOR-2018 sibling-copy rule)."""
+        self._assert_loads_except_declared_absent(
+            "x6100.toml", _X6100AbsentPin._EXPECTED_ABSENT, CivCommandSpec
+        )
+
+    def test_ftx1_loads_cat_except_the_declared_absent_group_b_family(self) -> None:
+        """MOR-2008 batch 4: FTX-1 declares all 16 Group B canonical keys
+        absent (protocol mismatch -- [protocol] type = "yaesu_cat") --
+        everything else in its ``[commands]`` table is CatCommandSpec.
+        """
+        self._assert_loads_except_declared_absent(
+            "ftx1.toml", _Ftx1AbsentPin._EXPECTED_ABSENT, CatCommandSpec
+        )
+
+    def test_tx500_loads_cat_except_the_declared_absent_group_b_family(self) -> None:
+        """Sibling of the FTX-1 check above ([protocol] type = "kenwood_cat")."""
+        self._assert_loads_except_declared_absent(
+            "tx500.toml", _Tx500AbsentPin._EXPECTED_ABSENT, CatCommandSpec
+        )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2029,26 +2029,39 @@ class TestToneTsqlCommands:
         assert freq == pytest.approx(110.9)
 
     def test_build_memory_mode_get(self) -> None:
+        """get_memory_mode is PROVENANCE OPEN on every shipped Icom profile
+        (MOR-2008 batch 4) -- no profile declares it, so this pins pure
+        byte assembly against a synthetic literal map, the same pattern
+        ``TestExpect: test_expect_on_speech_resolves_per_map_probe`` uses.
+        """
+        from rigplane.command_map import CommandMap
         from rigplane.commands import build_memory_mode_get
 
-        civ = build_memory_mode_get()
+        civ = build_memory_mode_get(cmd_map=CommandMap({"get_memory_mode": (0x08,)}))
         # FE FE 98 E0 08 FD
         assert civ == b"\xfe\xfe\x98\xe0\x08\xfd"
 
-    def test_build_memory_mode_set(self) -> None:
+    def test_build_memory_mode_get_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import build_memory_mode_get
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            build_memory_mode_get()  # type: ignore[call-arg]
+
+    def test_build_memory_mode_set(self, cmd_map) -> None:
         from rigplane.commands import build_memory_mode_set
 
-        civ = build_memory_mode_set(42)
+        civ = build_memory_mode_set(42, cmd_map=cmd_map)
         # FE FE 98 E0 08 00 42 FD (channel 42 in BCD)
         assert civ == b"\xfe\xfe\x98\xe0\x08\x00\x42\xfd"
 
-    def test_build_memory_mode_set_validates_range(self) -> None:
+    def test_build_memory_mode_set_validates_range(self, cmd_map) -> None:
         from rigplane.commands import build_memory_mode_set
 
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_mode_set(0)
+            build_memory_mode_set(0, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_mode_set(102)
+            build_memory_mode_set(102, cmd_map=cmd_map)
 
     def test_parse_memory_mode_response(self) -> None:
         from rigplane.commands import parse_civ_frame, parse_memory_mode_response
@@ -2059,35 +2072,42 @@ class TestToneTsqlCommands:
         channel = parse_memory_mode_response(frame)
         assert channel == 42
 
-    def test_build_memory_write(self) -> None:
+    def test_build_memory_write(self, cmd_map) -> None:
         from rigplane.commands import build_memory_write
 
-        civ = build_memory_write()
+        civ = build_memory_write(cmd_map=cmd_map)
         # FE FE 98 E0 09 FD
         assert civ == b"\xfe\xfe\x98\xe0\x09\xfd"
 
-    def test_build_memory_to_vfo(self) -> None:
+    def test_build_memory_to_vfo(self, cmd_map) -> None:
         from rigplane.commands import build_memory_to_vfo
 
-        civ = build_memory_to_vfo(99)
+        civ = build_memory_to_vfo(99, cmd_map=cmd_map)
         # FE FE 98 E0 0A 00 99 FD (channel 99 in BCD)
         assert civ == b"\xfe\xfe\x98\xe0\x0a\x00\x99\xfd"
 
-    def test_build_memory_clear(self) -> None:
+    def test_build_memory_clear(self, cmd_map) -> None:
         from rigplane.commands import build_memory_clear
 
-        civ = build_memory_clear(1)
+        civ = build_memory_clear(1, cmd_map=cmd_map)
         # FE FE 98 E0 0B 00 01 FD (channel 1 in BCD)
         assert civ == b"\xfe\xfe\x98\xe0\x0b\x00\x01\xfd"
 
-    def test_build_memory_contents_get(self) -> None:
+    def test_build_memory_clear_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import build_memory_clear
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            build_memory_clear(1)  # type: ignore[call-arg]
+
+    def test_build_memory_contents_get(self, cmd_map) -> None:
         from rigplane.commands import build_memory_contents_get
 
-        civ = build_memory_contents_get(50)
+        civ = build_memory_contents_get(50, cmd_map=cmd_map)
         # FE FE 98 E0 1A 00 00 50 FD (0x1A sub=0x00, channel 50 BCD)
         assert civ == b"\xfe\xfe\x98\xe0\x1a\x00\x00\x50\xfd"
 
-    def test_build_memory_contents_set(self) -> None:
+    def test_build_memory_contents_set(self, cmd_map) -> None:
         from rigplane.commands import build_memory_contents_set
         from rigplane.types import MemoryChannel
 
@@ -2103,7 +2123,7 @@ class TestToneTsqlCommands:
             tsql_freq_hz=None,
             name="FT8",
         )
-        civ = build_memory_contents_set(mem)
+        civ = build_memory_contents_set(mem, cmd_map=cmd_map)
         # FE FE 98 E0 1A 00 <channel 2 bytes> <payload 26 bytes> FD
         # Structure: FE FE(2) + to/from(2) + cmd(1) + sub(1) + data(28) + FD(1) = 35 bytes
         assert len(civ) == 35
@@ -2140,24 +2160,31 @@ class TestToneTsqlCommands:
         assert mem.scan == 0
         assert mem.name == "TEST"
 
-    def test_build_band_stack_get(self) -> None:
+    def test_build_band_stack_get(self, cmd_map) -> None:
         from rigplane.commands import build_band_stack_get
 
-        civ = build_band_stack_get(15, 1)  # band 15 (20m), register 1
+        civ = build_band_stack_get(15, 1, cmd_map=cmd_map)  # band 15 (20m), register 1
         # FE FE 98 E0 1A 01 0F 01 FD (0x1A sub=0x01, band=15, reg=1)
         assert civ == b"\xfe\xfe\x98\xe0\x1a\x01\x0f\x01\xfd"
 
-    def test_build_band_stack_get_validates_range(self) -> None:
+    def test_build_band_stack_get_validates_range(self, cmd_map) -> None:
         from rigplane.commands import build_band_stack_get
 
         with pytest.raises(ValueError, match="Band must be 0-24"):
-            build_band_stack_get(25, 1)
+            build_band_stack_get(25, 1, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="Register must be 1-3"):
-            build_band_stack_get(15, 0)
+            build_band_stack_get(15, 0, cmd_map=cmd_map)
         with pytest.raises(ValueError, match="Register must be 1-3"):
-            build_band_stack_get(15, 4)
+            build_band_stack_get(15, 4, cmd_map=cmd_map)
 
-    def test_build_band_stack_set(self) -> None:
+    def test_build_band_stack_get_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        from rigplane.commands import build_band_stack_get
+
+        with pytest.raises(TypeError, match="MOR-2006"):
+            build_band_stack_get(15, 1)  # type: ignore[call-arg]
+
+    def test_build_band_stack_set(self, cmd_map) -> None:
         from rigplane.commands import set_bsr
         from rigplane.types import BandStackRegister
 
@@ -2168,7 +2195,7 @@ class TestToneTsqlCommands:
             mode=1,  # USB
             filter=1,
         )
-        civ = set_bsr(bsr)
+        civ = set_bsr(bsr, cmd_map=cmd_map)
         # FE FE 98 E0 1A 01 0F 01 <freq 5 bytes> <mode 1 byte> <filter 1 byte> FD
         assert civ[:8] == b"\xfe\xfe\x98\xe0\x1a\x01\x0f\x01"
         # freq 14.200 MHz = 00 00 20 14 00 (BCD little-endian)

--- a/tests/test_memory_commands.py
+++ b/tests/test_memory_commands.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import pathlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -25,8 +26,12 @@ from rigplane.commands import (
     build_memory_write,
     parse_memory_contents_response,
 )
+from rigplane.commands.bound import BoundCommands
 from rigplane.radio_protocol import MemoryCapable
+from rigplane.rig_loader import load_rig
 from rigplane.types import BandStackRegister, CivFrame, MemoryChannel
+
+RIG_DIR = pathlib.Path(__file__).resolve().parents[1] / "rigs"
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +39,18 @@ from rigplane.types import BandStackRegister, CivFrame, MemoryChannel
 # ---------------------------------------------------------------------------
 
 RADIO_ADDR = 0x98  # IC-7610 default CI-V address
+
+
+@pytest.fixture()
+def cmd_map():
+    """IC-7610's bound command map -- all nine memory.py builders migrated
+    onto it in MOR-2008 batch 4; every builder this file exercises directly
+    (all but ``build_memory_mode_get``, which is PROVENANCE OPEN
+    everywhere) is declared here with the exact bytes this file's literal
+    frame assertions already expect.
+    """
+    rig = load_rig(RIG_DIR / "ic7610.toml")
+    return rig.to_command_map()
 
 
 # ---------------------------------------------------------------------------
@@ -77,65 +94,75 @@ class TestMemoryCapableProtocol:
 class TestMemoryModeSetBuilder:
     """build_memory_mode_set produces correct CI-V frames."""
 
-    def test_channel_1(self) -> None:
-        frame = build_memory_mode_set(1, to_addr=RADIO_ADDR)
+    def test_channel_1(self, cmd_map) -> None:
+        frame = build_memory_mode_set(1, to_addr=RADIO_ADDR, cmd_map=cmd_map)
         # 0xFE 0xFE <to> <from> 0x08 <BCD channel 2 bytes> 0xFD
         assert frame[:4] == b"\xfe\xfe\x98\xe0"
         assert frame[4] == 0x08  # command
         # Channel 1 in 2-byte BCD
         assert frame[-1:] == b"\xfd"
 
-    def test_channel_101(self) -> None:
-        frame = build_memory_mode_set(101, to_addr=RADIO_ADDR)
+    def test_channel_101(self, cmd_map) -> None:
+        frame = build_memory_mode_set(101, to_addr=RADIO_ADDR, cmd_map=cmd_map)
         assert frame[4] == 0x08
 
-    def test_channel_0_raises(self) -> None:
+    def test_channel_0_raises(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_mode_set(0, to_addr=RADIO_ADDR)
+            build_memory_mode_set(0, to_addr=RADIO_ADDR, cmd_map=cmd_map)
 
-    def test_channel_102_raises(self) -> None:
+    def test_channel_102_raises(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_mode_set(102, to_addr=RADIO_ADDR)
+            build_memory_mode_set(102, to_addr=RADIO_ADDR, cmd_map=cmd_map)
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            build_memory_mode_set(1, to_addr=RADIO_ADDR)  # type: ignore[call-arg]
 
 
 class TestMemoryWriteBuilder:
     """build_memory_write produces correct CI-V frames."""
 
-    def test_basic_frame(self) -> None:
-        frame = build_memory_write(to_addr=RADIO_ADDR)
+    def test_basic_frame(self, cmd_map) -> None:
+        frame = build_memory_write(to_addr=RADIO_ADDR, cmd_map=cmd_map)
         assert frame[:4] == b"\xfe\xfe\x98\xe0"
         assert frame[4] == 0x09  # command
         assert frame[-1:] == b"\xfd"
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            build_memory_write(to_addr=RADIO_ADDR)  # type: ignore[call-arg]
 
 
 class TestMemoryToVfoBuilder:
     """build_memory_to_vfo produces correct CI-V frames."""
 
-    def test_channel_50(self) -> None:
-        frame = build_memory_to_vfo(50, to_addr=RADIO_ADDR)
+    def test_channel_50(self, cmd_map) -> None:
+        frame = build_memory_to_vfo(50, to_addr=RADIO_ADDR, cmd_map=cmd_map)
         assert frame[4] == 0x0A  # command
 
-    def test_channel_0_raises(self) -> None:
+    def test_channel_0_raises(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_to_vfo(0, to_addr=RADIO_ADDR)
+            build_memory_to_vfo(0, to_addr=RADIO_ADDR, cmd_map=cmd_map)
 
 
 class TestMemoryClearBuilder:
     """build_memory_clear produces correct CI-V frames."""
 
-    def test_channel_10(self) -> None:
-        frame = build_memory_clear(10, to_addr=RADIO_ADDR)
+    def test_channel_10(self, cmd_map) -> None:
+        frame = build_memory_clear(10, to_addr=RADIO_ADDR, cmd_map=cmd_map)
         assert frame[4] == 0x0B  # command
 
-    def test_channel_0_raises(self) -> None:
+    def test_channel_0_raises(self, cmd_map) -> None:
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_clear(0, to_addr=RADIO_ADDR)
+            build_memory_clear(0, to_addr=RADIO_ADDR, cmd_map=cmd_map)
 
 
 class TestMemoryContentsSetBuilder:
     """build_memory_contents_set produces correct CI-V frames."""
 
-    def test_basic_channel(self) -> None:
+    def test_basic_channel(self, cmd_map) -> None:
         mem = MemoryChannel(
             channel=1,
             frequency_hz=14_074_000,
@@ -146,17 +173,19 @@ class TestMemoryContentsSetBuilder:
             tonemode=0,
             name="FT8",
         )
-        frame = build_memory_contents_set(mem, to_addr=RADIO_ADDR)
+        frame = build_memory_contents_set(mem, to_addr=RADIO_ADDR, cmd_map=cmd_map)
         assert frame[:4] == b"\xfe\xfe\x98\xe0"
         assert frame[4] == 0x1A  # command
         assert frame[5] == 0x00  # sub-command
         assert frame[-1:] == b"\xfd"
 
-    def test_invalid_type_raises(self) -> None:
+    def test_invalid_type_raises(self, cmd_map) -> None:
         with pytest.raises(TypeError, match="Expected MemoryChannel"):
-            build_memory_contents_set({"channel": 1}, to_addr=RADIO_ADDR)  # type: ignore[arg-type]
+            build_memory_contents_set(
+                {"channel": 1}, to_addr=RADIO_ADDR, cmd_map=cmd_map
+            )  # type: ignore[arg-type]
 
-    def test_invalid_channel_raises(self) -> None:
+    def test_invalid_channel_raises(self, cmd_map) -> None:
         mem = MemoryChannel(
             channel=0,
             frequency_hz=14_074_000,
@@ -167,7 +196,21 @@ class TestMemoryContentsSetBuilder:
             tonemode=0,
         )
         with pytest.raises(ValueError, match="Channel must be 1-101"):
-            build_memory_contents_set(mem, to_addr=RADIO_ADDR)
+            build_memory_contents_set(mem, to_addr=RADIO_ADDR, cmd_map=cmd_map)
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        mem = MemoryChannel(
+            channel=1,
+            frequency_hz=14_074_000,
+            mode=0x01,
+            filter=1,
+            scan=0,
+            datamode=0,
+            tonemode=0,
+        )
+        with pytest.raises(TypeError, match="MOR-2006"):
+            build_memory_contents_set(mem, to_addr=RADIO_ADDR)  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------
@@ -250,12 +293,25 @@ class TestParseMemoryContentsResponse:
 
 
 class TestIcomRadioMemoryMethods:
-    """Verify IcomRadio memory methods call the correct builders."""
+    """Verify IcomRadio memory methods call the correct builders.
+
+    ``radio._commands`` is a real ``BoundCommands`` bound to IC-7610's own
+    map (MOR-2008 batch 4 moved these methods' internals onto
+    ``self._commands.<builder>``) -- a bare ``MagicMock`` here would
+    silently return another ``MagicMock`` in place of real frame bytes
+    (CLAUDE.md: "MagicMock hides signature bugs -- verify against real
+    dataclasses"), and this class's own assertions index into the frame
+    bytes each method sends, so a wrong wiring would surface as a
+    confusing ``TypeError``/comparison failure rather than a clean
+    assertion.
+    """
 
     def _make_radio(self) -> MagicMock:
+        rig = load_rig(RIG_DIR / "ic7610.toml")
         radio = MagicMock()
         radio._radio_addr = RADIO_ADDR
         radio._send_fire_and_forget = AsyncMock()
+        radio._commands = BoundCommands(rig.to_command_map())
         return radio
 
     @pytest.mark.asyncio
@@ -371,10 +427,23 @@ class TestIcomRadioGetBsr:
     IC7610_ADDR = 0x98
 
     def _make_radio(self, radio_addr: int) -> MagicMock:
+        """``radio._commands`` is a real ``BoundCommands`` over a synthetic
+        literal map (MOR-2008 batch 4 moved ``get_bsr`` onto
+        ``self._commands.get_bsr``) -- get_bsr's wire bytes are identical
+        on both radios this class exercises, so a synthetic single-key map
+        pins the shared byte-assembly behaviour without coupling this
+        generic test to either profile's own TOML file. A bare
+        ``MagicMock`` here would silently return another ``MagicMock`` in
+        place of the real request frame this class's own assertions index
+        into.
+        """
+        from rigplane.command_map import CommandMap
+
         radio = MagicMock()
         radio._radio_addr = radio_addr
         radio._check_connected = MagicMock()
         radio._send_civ_expect = AsyncMock()
+        radio._commands = BoundCommands(CommandMap({"get_bsr": (0x1A, 0x01)}))
         return radio
 
     def _band_stack_frame(self, radio_addr: int) -> CivFrame:

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -43,12 +43,14 @@ from typing import Any
 import pytest
 
 import rigplane.commands as commands
-from rigplane.commands import get_selected_freq, get_speech, ptt_on
+from rigplane.commands import get_speech, ptt_on
 from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
+from rigplane.commands.dsp import set_attenuator
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.runtime.radio import CoreRadio
+from rigplane.types import BandStackRegister, MemoryChannel
 
 # Reused rather than re-implemented, per the MOR-2006 drift-guard extension:
 # the same probe-ladder search test_command_map_parity.py uses to find a
@@ -171,13 +173,21 @@ class TestExpect:
     def test_expect_on_unexposed_builder_names_the_migration(self) -> None:
         # get_rf_power (commands/levels.py) is exposed as of MOR-2006 Steps
         # 5..N module 2; get_s_meter (commands/meters.py) was the "not
-        # exposed yet" stand-in through batch 1, but MOR-2008 batch 2
-        # migrated meters.py -- get_selected_freq (commands/freq.py) has no
-        # cmd_map parameter at all (Group B, deferred to a later batch per
-        # the owner ruling on the ticket) and stands in instead.
-        bound = BoundCommands(CommandMap({"get_selected_freq": (0x25, 0x00)}))
+        # exposed yet" stand-in through batch 1, and get_selected_freq
+        # (commands/freq.py) stood in from batch 2 through batch 3 (Group
+        # B, deferred at the time per the owner ruling on the ticket) --
+        # MOR-2008 batch 4 migrated freq.py's Group B builders too, so
+        # every builder in the package now either exposes a key or
+        # resolves one statically (tests/test_profile_command_coverage.py:
+        # test_every_builder_resolves_by_exactly_one_route). dsp.py:
+        # set_attenuator is a stable, permanent stand-in instead: it
+        # deliberately never exposes its own key (it delegates to
+        # set_attenuator_level, whose key is "set_attenuator") rather than
+        # being mid-migration, so this is not a "temporary until the next
+        # batch" choice.
+        bound = BoundCommands(CommandMap({"set_attenuator": (0x11,)}))
         with pytest.raises(AttributeError, match="Steps 5..N"):
-            bound.expect(get_selected_freq)
+            bound.expect(set_attenuator)
 
 
 # ── the drift guard ──
@@ -270,9 +280,32 @@ def _exposed_builders() -> list[tuple[str, Any]]:
 # other exposed builder's probe search; adding a value shifts which combo
 # each of them finds first). vfo.py: scan_set_df_span's 0xA1-0xA7 (MOR-2007)
 # is the one case so far: _INTS's largest members (100, 255) both fall
-# outside that range.
+# outside that range. MOR-2008 batch 4 adds two more, for a different
+# reason: memory.py: build_memory_contents_set/set_bsr each take a
+# required dataclass argument (MemoryChannel/BandStackRegister), which
+# _values_for cannot synthesise at all (not an enum/bool/str/float/int,
+# and each module imports its dataclass only under TYPE_CHECKING, so
+# _values_for's own `eval(annotation, fn.__globals__)` cannot even
+# resolve the name at runtime) -- _candidate_kwargs would yield nothing,
+# so a real instance is supplied directly instead.
 _EXTRA_PROBE_KWARGS: dict[str, dict[str, Any]] = {
     "scan_set_df_span": {"df_span": 0xA1},
+    "build_memory_contents_set": {
+        "mem": MemoryChannel(
+            channel=1,
+            frequency_hz=14_074_000,
+            mode=1,
+            filter=1,
+            scan=0,
+            datamode=0,
+            tonemode=0,
+        )
+    },
+    "set_bsr": {
+        "bsr": BandStackRegister(
+            band=1, register=1, frequency_hz=14_074_000, mode=1, filter=1
+        )
+    },
 }
 
 

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -30,11 +30,15 @@ key comma-separated on the row, the same compact shape
 ``tests/command_map_parity_uncovered.txt``'s own ``gap`` rows use. The
 baseline started large by construction (D2, plan §8.1: at that point no rig
 TOML used the ``{ absent = "<source>" }`` spelling at all). Which profiles
-have since been filled with it is tracked by
-``tests/test_rig_loader.py::TestNoShippedProfileUsesAbsentSpellingYet``
-(narrowed, not deleted, as each profile's own D2 pass lands) rather than
-restated here; this file's baseline is meant to shrink only, never grow
-silently.
+have since been filled with it used to be tracked by
+``tests/test_rig_loader.py::TestNoShippedProfileUsesAbsentSpellingYet``,
+narrowed as each profile's own D2 pass landed; MOR-2008 batch 4's
+``ftx1.toml``/``tx500.toml`` pass was the last shipped profile to be
+filled, narrowing that pin's parametrize set to empty, so it was deleted
+per its own docstring's contingency rather than kept as a vacuous test.
+Each profile's per-model ``TestXDeclaresAbsentCommands`` class in that same
+file is the durable record now, not restated here; this file's baseline is
+meant to shrink only, never grow silently.
 
 Regenerate after an intentional change (a profile gains or loses a
 declaration, or a builder's key changes)::

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import pytest
 
 from rigplane.command_map import CommandMap
-from rigplane.command_spec import AbsentCommandSpec
 from rigplane.core.capabilities import CAP_SPEECH, KNOWN_CAPABILITIES
 from rigplane.core.tx_interlock_contract import (
     TX_INTERLOCK_COMMAND_FAMILY_METADATA,
@@ -2665,47 +2664,33 @@ class TestFilterShapeDomainDeclaredOrCapabilityAbsent:
             assert rig.filter_shape_labels == {"0": "SHARP", "1": "SOFT"}, name
 
 
-class TestNoShippedProfileUsesAbsentSpellingYet:
-    """MOR-2005 step 4a landed only the ``{ absent = "<source>" }`` spelling
-    itself (plan `docs/plans/2026-08-29-profile-driven-command-bytes.md`
-    §8.1 D1/D2) — it did not fill any profile with it. D2's filling work is
-    separate, ticket-tracked, later work: MOR-2014 filled ``ic7300.toml``
-    (27 commands, D2 documentary + live-bench verdicts), MOR-2015 filled
-    ``ic9700.toml`` (26 commands, D2 documentary verdicts against the
-    IC-9700 CI-V Reference Guide), MOR-2016 filled ``ic705.toml`` (24
-    commands, D2 documentary verdicts against the IC-705 CI-V Reference
-    Guide), MOR-2008 batch 2 filled ``ic7610.toml`` (8 commands, the
-    repeater-tone/TSQL/tone-freq/TSQL-freq family, promoting a
-    comment-only D1 state 3 to a formal state 2 row grounded in a
-    live-bench readback rather than a documentary source), and MOR-2008
-    batch 3 filled ``x6100.toml``/``x6200.toml`` (6 commands each, the
-    vox/break-in/manual-notch family, promoting a comment-only D1 state 3
-    to a formal state 2 row grounded in the V1.0.6 documentary table
-    rather than a live capture -- see
-    ``TestX6200DeclaresAbsentCommands``/``TestX6100DeclaresAbsentCommands``
-    below). This pin is narrowed rather than deleted so every *other*
-    shipped profile stays proven empty until its own D2 pass fills it too
-    — narrow further (or delete) as each profile gets filled.
-    """
-
-    _NOT_YET_FILLED = tuple(
-        p
-        for p in _SHIPPED_RIG_TOMLS
-        if p.stem not in {"ic7300", "ic9700", "ic705", "ic7610", "x6100", "x6200"}
-    )
-
-    @pytest.mark.parametrize("toml_path", _NOT_YET_FILLED, ids=lambda p: p.stem)
-    def test_no_absent_commands_declared(self, toml_path):
-        rig = load_rig(toml_path)
-        absent = {
-            name
-            for name, spec in rig.commands.items()
-            if isinstance(spec, AbsentCommandSpec)
-        }
-        assert absent == set(), (
-            f"{toml_path.name}: declares absent commands {sorted(absent)} — "
-            f"update/delete this pin now that D2 filling has started"
-        )
+# MOR-2005 step 4a landed only the ``{ absent = "<source>" }`` spelling
+# itself (plan `docs/plans/2026-08-29-profile-driven-command-bytes.md`
+# §8.1 D1/D2) — it did not fill any profile with it. D2's filling work was
+# separate, ticket-tracked, later work: MOR-2014 filled ``ic7300.toml``
+# (27 commands, D2 documentary + live-bench verdicts), MOR-2015 filled
+# ``ic9700.toml`` (26 commands, D2 documentary verdicts against the
+# IC-9700 CI-V Reference Guide), MOR-2016 filled ``ic705.toml`` (24
+# commands, D2 documentary verdicts against the IC-705 CI-V Reference
+# Guide), MOR-2008 batch 2 filled ``ic7610.toml`` (8 commands, the
+# repeater-tone/TSQL/tone-freq/TSQL-freq family, promoting a comment-only
+# D1 state 3 to a formal state 2 row grounded in a live-bench readback
+# rather than a documentary source), MOR-2008 batch 3 filled
+# ``x6100.toml``/``x6200.toml`` (6 commands each, the vox/break-in/
+# manual-notch family, promoting a comment-only D1 state 3 to a formal
+# state 2 row grounded in the V1.0.6 documentary table rather than a live
+# capture), and MOR-2008 batch 4 added 11 more each to ``x6100.toml``/
+# ``x6200.toml`` (the memory.py/tx_band.py Group B family, same V1.0.6
+# documentary grounding) plus filled ``ftx1.toml``/``tx500.toml`` (16
+# commands each, all 16 Group B canonical keys, grounded in protocol
+# mismatch rather than a documentary or live source). This was the last
+# shipped profile to be filled: a
+# ``TestNoShippedProfileUsesAbsentSpellingYet`` pin used to sit here,
+# narrowed as each profile's own D2 pass landed and deleted, per its own
+# docstring's contingency, once MOR-2008 batch 4's pass narrowed its
+# parametrize set to empty rather than leave a vacuous test collecting
+# zero cases. Each profile's own ``TestXDeclaresAbsentCommands`` class
+# below is the durable per-model record now.
 
 
 class TestIc7300DeclaresAbsentCommands:
@@ -2917,8 +2902,8 @@ class TestIc7610DeclaresAbsentCommands:
             assert not cmd_map.has(name), f"{name} declared absent but still in map"
 
 
-class _X6DeclaresAbsentVoxBreakInManualNotch:
-    """Shared body for the X6100/X6200 absent-DSP-family pin below.
+class _X6DeclaresAbsentCommands:
+    """Shared body for the X6100/X6200 absent-command pin below.
 
     MOR-2008 batch 3: both profiles formally declare
     ``get_/set_vox``, ``get_/set_break_in`` and ``get_/set_manual_notch``
@@ -2932,6 +2917,20 @@ class _X6DeclaresAbsentVoxBreakInManualNotch:
     *present* instead, at opcodes the project's own cat-audit already
     confirmed correct (docs/validation/cat-audits/x6200.md) -- those
     three are not absent commands and must not appear here.
+
+    MOR-2008 batch 4 adds 11 more: the entire memory.py (9 keys) and
+    tx_band.py (2 keys) Group B family is absent on both profiles --
+    none of the nine memory-family opcodes (0x08/0x09/0x0A/0x0B/0x1A 0x00)
+    nor the two TX-band-edge opcodes (0x1E) appear anywhere in the
+    Radioddity X6200 CI-V V1.0.6 Table 1 (pp.5-9, the complete documented
+    opcode list); ``get_bsr``/``set_bsr`` specifically because the
+    opcode [0x1A, 0x01] the table *does* document is a different,
+    2-byte-payload command (exposed instead as
+    ``get_band_spectrum_display``), not Icom's own 9-byte band-stacking
+    record -- see each profile's own ``rigs/*.toml`` comments and the
+    class-name renaming this batch made necessary (was
+    ``_X6DeclaresAbsentVoxBreakInManualNotch``, no longer describes the
+    full set this shared body pins).
     """
 
     _EXPECTED_ABSENT = frozenset(
@@ -2942,6 +2941,17 @@ class _X6DeclaresAbsentVoxBreakInManualNotch:
             "set_break_in",
             "get_manual_notch",
             "set_manual_notch",
+            "get_memory_mode",
+            "set_memory_mode",
+            "memory_write",
+            "memory_to_vfo",
+            "memory_clear",
+            "get_memory_contents",
+            "set_memory_contents",
+            "get_bsr",
+            "set_bsr",
+            "get_tx_band_count",
+            "get_tx_band_edge",
         }
     )
     _TOML_NAME: str
@@ -2969,10 +2979,90 @@ class _X6DeclaresAbsentVoxBreakInManualNotch:
         assert declared_present <= profile.command_names
         assert not (declared_present & profile.absent_command_names)
 
+    def test_selected_freq_mode_family_stays_present_not_absent(self):
+        """The DECLARED-OK sibling fix (MOR-2008 batch 4): the five
+        canonical freq.py Group B keys are sourced and present on both
+        profiles, not absent -- only memory.py/tx_band.py are absent
+        here.
+        """
+        profile = load_rig(RIGS_DIR / self._TOML_NAME).to_profile()
+        declared_present = {
+            "get_selected_freq",
+            "get_unselected_freq",
+            "get_selected_mode",
+            "get_unselected_mode",
+            "set_selected_mode",
+        }
+        assert declared_present <= profile.command_names
+        assert not (declared_present & profile.absent_command_names)
 
-class TestX6200DeclaresAbsentCommands(_X6DeclaresAbsentVoxBreakInManualNotch):
+
+class TestX6200DeclaresAbsentCommands(_X6DeclaresAbsentCommands):
     _TOML_NAME = "x6200.toml"
 
 
-class TestX6100DeclaresAbsentCommands(_X6DeclaresAbsentVoxBreakInManualNotch):
+class TestX6100DeclaresAbsentCommands(_X6DeclaresAbsentCommands):
     _TOML_NAME = "x6100.toml"
+
+
+class _CatOnlyDeclaresAllGroupBAbsent:
+    """Shared body for the FTX-1/TX-500 absent-command pin (MOR-2008
+    batch 4): both cat-only profiles formally declare all 16 Group B
+    canonical keys (memory.py's 9, tx_band.py's 2, freq.py's 5) absent,
+    grounded in protocol mismatch rather than a documentary or live
+    source -- ``[protocol] type`` is not ``"civ"`` on either profile,
+    every ``[commands]`` entry is a ``{ cat = ... }`` spec, and
+    ``profiles/rig_loader.py: RigConfig.to_command_map`` keeps only the
+    CI-V half of ``CommandSpec``, so none of these 16 CI-V-array key names
+    could ever be declared present here regardless of what either radio's
+    own CAT dialect documents.
+
+    Adding these formal rows removes both profiles from
+    ``tests/test_command_map_parity.py``'s own ``cat_only_profiles``
+    census/``cat-only`` rows -- that classification means literally "every
+    ``[commands]`` entry is ``CatCommandSpec``", which a declared-absent
+    row (a third spec type) no longer satisfies, even though both profiles
+    remain cat-only in every functional sense (``[protocol] type``
+    unchanged, ``CommandMap`` still empty). See
+    ``tests/command_map_parity_uncovered.txt``'s regenerated diff in this
+    batch's PR body.
+    """
+
+    _EXPECTED_ABSENT = frozenset(
+        {
+            "get_memory_mode",
+            "set_memory_mode",
+            "memory_write",
+            "memory_to_vfo",
+            "memory_clear",
+            "get_memory_contents",
+            "set_memory_contents",
+            "get_bsr",
+            "set_bsr",
+            "get_tx_band_count",
+            "get_tx_band_edge",
+            "get_selected_freq",
+            "get_unselected_freq",
+            "get_selected_mode",
+            "get_unselected_mode",
+            "set_selected_mode",
+        }
+    )
+    _TOML_NAME: str
+
+    def test_absent_command_names_match(self):
+        profile = load_rig(RIGS_DIR / self._TOML_NAME).to_profile()
+        assert profile.absent_command_names == self._EXPECTED_ABSENT
+
+    def test_absent_commands_excluded_from_command_map(self):
+        cmd_map = load_rig(RIGS_DIR / self._TOML_NAME).to_command_map()
+        for name in self._EXPECTED_ABSENT:
+            assert not cmd_map.has(name), f"{name} declared absent but still in map"
+
+
+class TestFtx1DeclaresAbsentCommands(_CatOnlyDeclaresAllGroupBAbsent):
+    _TOML_NAME = "ftx1.toml"
+
+
+class TestTx500DeclaresAbsentCommands(_CatOnlyDeclaresAllGroupBAbsent):
+    _TOML_NAME = "tx500.toml"

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from rigplane.commands.command_spec import CatCommandSpec
+from rigplane.commands.command_spec import AbsentCommandSpec, CatCommandSpec
 from rigplane.profiles import RadioProfile
 from rigplane.rig_loader import (
     VALID_CONTROL_STYLES,
@@ -22,6 +22,7 @@ from rigplane.rig_loader import (
     discover_rigs,
     load_rig,
 )
+from test_rig_loader import TestTx500DeclaresAbsentCommands as _Tx500AbsentPin
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
 
@@ -441,14 +442,46 @@ class TestMultiVendorProfiles:
     def test_tx500_commands_are_wired(self):
         """MOR-684: kenwood_cat CAT command strings are wired in [commands].
 
-        Previously [commands] was an empty stub; the loaded profile now carries
-        the rev.2 CAT command set as ``CatCommandSpec`` entries.
+        Previously [commands] was an empty stub; the loaded profile now
+        carries the rev.2 CAT command set as ``CatCommandSpec`` entries.
+
+        MOR-2008 batch 4 (D2) added 16 formal ``{ absent = "..." }`` rows
+        for the Group B canonical keys (protocol mismatch -- TX-500 has no
+        CI-V command table at all) -- renamed from a single-branch "every
+        command is CatCommandSpec" assertion, which that batch's own CI
+        run caught failing the moment the first absent row landed, to the
+        exact-split pattern
+        (``test_command_spec.py: test_ic7610_loads_civ_except_the_declared_absent_tone_tsql_family``'s
+        precedent): every command is ``CatCommandSpec`` except the pinned
+        absent set, discriminating both directions so a CAT row silently
+        becoming absent, or an absent row silently reverting to CAT, fails
+        regardless of which name moves. The expected-absent set is
+        imported from ``test_rig_loader.py: TestTx500DeclaresAbsentCommands``
+        rather than duplicated here.
         """
         rig = load_rig(RIGS_DIR / "tx500.toml")
         assert isinstance(rig.commands, dict)
         assert rig.commands  # no longer empty
-        for spec in rig.commands.values():
-            assert isinstance(spec, CatCommandSpec)
+
+        expected_absent = _Tx500AbsentPin._EXPECTED_ABSENT
+        for name, spec in rig.commands.items():
+            if name in expected_absent:
+                assert isinstance(spec, AbsentCommandSpec), (
+                    f"Command {name} is declared absent but not AbsentCommandSpec"
+                )
+            else:
+                assert isinstance(spec, CatCommandSpec), (
+                    f"Command {name} is not CatCommandSpec"
+                )
+        actually_absent = {
+            name
+            for name, spec in rig.commands.items()
+            if isinstance(spec, AbsentCommandSpec)
+        }
+        assert actually_absent == expected_absent, (
+            "tx500.toml's AbsentCommandSpec entries drifted from "
+            "TestTx500DeclaresAbsentCommands._EXPECTED_ABSENT"
+        )
 
     def test_tx500_mode_map_matches_rev2(self):
         """MOR-684: mode list matches Lab599 CAT Protocol rev.2 exactly.

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -1,4 +1,16 @@
-"""Tests for CI-V 0x25/0x26 selected/unselected freq & mode commands."""
+"""Tests for CI-V 0x25/0x26 selected/unselected freq & mode commands.
+
+``get_selected_freq``/``get_unselected_freq``/``get_selected_mode``/
+``get_unselected_mode``/``set_selected_mode`` migrated onto the bound
+command map in MOR-2008 (batch 4, "Group B"): all five now require
+``cmd_map``, no hardcoded fallback ever having existed to delete. IC-7610
+declares the first four with byte-identical wire tuples to the deleted
+hardcoded frames; ``set_selected_mode`` is PROVENANCE OPEN on IC-7610 (and
+IC-7300/IC-9700), so its own builder test below uses X6200's map instead,
+matching the ``to_addr=0xA4`` (X6200's CI-V address) the test already used.
+"""
+
+import pathlib
 
 import pytest
 
@@ -17,9 +29,25 @@ from rigplane.commands import (
     set_selected_mode,
 )
 from rigplane.radio import IcomRadio
+from rigplane.rig_loader import load_rig
 from rigplane.types import CivFrame, Mode, bcd_encode
 
 from test_radio import MockTransport, _wrap_civ_in_udp
+
+RIG_DIR = pathlib.Path(__file__).resolve().parents[1] / "rigs"
+
+
+@pytest.fixture()
+def cmd_map():
+    rig = load_rig(RIG_DIR / "ic7610.toml")
+    return rig.to_command_map()
+
+
+@pytest.fixture()
+def x6200_cmd_map():
+    rig = load_rig(RIG_DIR / "x6200.toml")
+    return rig.to_command_map()
+
 
 # MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
 # dispatch bodies; the interlock seat now lives at its head, so the RF
@@ -62,30 +90,42 @@ def _selected_mode_response(
 
 
 class TestCommandBuilders:
-    def test_get_selected_freq_frame(self) -> None:
-        frame = get_selected_freq(to_addr=0x98)
+    def test_get_selected_freq_frame(self, cmd_map) -> None:
+        frame = get_selected_freq(to_addr=0x98, cmd_map=cmd_map)
         assert b"\x25\x00" in frame
         assert frame.startswith(b"\xfe\xfe")
         assert frame.endswith(b"\xfd")
 
-    def test_get_unselected_freq_frame(self) -> None:
-        frame = get_unselected_freq(to_addr=0x98)
+    def test_get_unselected_freq_frame(self, cmd_map) -> None:
+        frame = get_unselected_freq(to_addr=0x98, cmd_map=cmd_map)
         assert b"\x25\x01" in frame
 
-    def test_get_selected_mode_frame(self) -> None:
-        frame = get_selected_mode(to_addr=0x98)
+    def test_get_selected_mode_frame(self, cmd_map) -> None:
+        frame = get_selected_mode(to_addr=0x98, cmd_map=cmd_map)
         assert b"\x26\x00" in frame
 
-    def test_get_unselected_mode_frame(self) -> None:
-        frame = get_unselected_mode(to_addr=0x98)
+    def test_get_unselected_mode_frame(self, cmd_map) -> None:
+        frame = get_unselected_mode(to_addr=0x98, cmd_map=cmd_map)
         assert b"\x26\x01" in frame
 
-    def test_set_selected_mode_frame(self) -> None:
+    def test_set_selected_mode_frame(self, x6200_cmd_map) -> None:
         # X6200 CI-V address is 0xA4; controller 0xE0; Mode.LSB == 0x00.
         # Frame: FE FE A4 E0 26 00 <receiver=00> <mode=LSB=00> <data_mode=00>
-        #        <filter=01> FD.
-        frame = set_selected_mode(Mode.LSB, 0, 1, to_addr=0xA4)
+        #        <filter=01> FD. set_selected_mode is PROVENANCE OPEN on
+        #        IC-7610 (and IC-7300/IC-9700), so this builder test uses
+        #        X6200's own declared map instead.
+        frame = set_selected_mode(Mode.LSB, 0, 1, to_addr=0xA4, cmd_map=x6200_cmd_map)
         assert frame == b"\xfe\xfe\xa4\xe0\x26\x00\x00\x00\x01\xfd"
+
+    def test_get_selected_freq_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_selected_freq(to_addr=0x98)  # type: ignore[call-arg]
+
+    def test_set_selected_mode_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            set_selected_mode(Mode.LSB, 0, 1, to_addr=0xA4)  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tx_band_edge.py
+++ b/tests/test_tx_band_edge.py
@@ -1,6 +1,16 @@
-"""Tests for TX band edge support (CI-V command 0x1E, issue #541)."""
+"""Tests for TX band edge support (CI-V command 0x1E, issue #541).
+
+``get_tx_band_count``/``get_tx_band_edge`` migrated onto the bound command
+map in MOR-2008 (batch 4, "Group B"): both now require ``cmd_map`` -- no
+hardcoded fallback ever existed to delete, since neither took a
+``cmd_map`` parameter at all before this batch. IC-7610's own declared
+bytes (``[0x1E, 0x00]``/``[0x1E, 0x01]``) are identical to the deleted
+hardcoded frame, so the literal frame assertions below are unchanged.
+"""
 
 from __future__ import annotations
+
+import pathlib
 
 import pytest
 
@@ -15,9 +25,18 @@ from rigplane.commands.tx_band import (
 )
 from rigplane.commands._frame import _CMD_TX_BAND_EDGE
 from rigplane.radio_state import RadioState, TxBandEdge
+from rigplane.rig_loader import load_rig
 from rigplane.types import CivFrame
 
+RIG_DIR = pathlib.Path(__file__).resolve().parents[1] / "rigs"
+
 _RADIO_ADDR = 0x98
+
+
+@pytest.fixture()
+def cmd_map():
+    rig = load_rig(RIG_DIR / "ic7610.toml")
+    return rig.to_command_map()
 
 
 # ---------------------------------------------------------------------------
@@ -36,30 +55,40 @@ class TestCmdConstant:
 
 
 class TestGetTxBandCount:
-    def test_frame_structure(self) -> None:
-        frame = get_tx_band_count(to_addr=_RADIO_ADDR)
+    def test_frame_structure(self, cmd_map) -> None:
+        frame = get_tx_band_count(to_addr=_RADIO_ADDR, cmd_map=cmd_map)
         # FE FE 98 E0 1E 00 FD
         assert frame == bytes([0xFE, 0xFE, 0x98, 0xE0, 0x1E, 0x00, 0xFD])
 
-    def test_custom_from_addr(self) -> None:
-        frame = get_tx_band_count(to_addr=_RADIO_ADDR, from_addr=0xA0)
+    def test_custom_from_addr(self, cmd_map) -> None:
+        frame = get_tx_band_count(to_addr=_RADIO_ADDR, from_addr=0xA0, cmd_map=cmd_map)
         assert frame == bytes([0xFE, 0xFE, 0x98, 0xA0, 0x1E, 0x00, 0xFD])
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_tx_band_count(to_addr=_RADIO_ADDR)  # type: ignore[call-arg]
 
 
 class TestGetTxBandEdge:
-    def test_band_1(self) -> None:
-        frame = get_tx_band_edge(1, to_addr=_RADIO_ADDR)
+    def test_band_1(self, cmd_map) -> None:
+        frame = get_tx_band_edge(1, to_addr=_RADIO_ADDR, cmd_map=cmd_map)
         # FE FE 98 E0 1E 01 01 FD  (band 1 as BCD = 0x01)
         assert frame == bytes([0xFE, 0xFE, 0x98, 0xE0, 0x1E, 0x01, 0x01, 0xFD])
 
-    def test_band_12(self) -> None:
-        frame = get_tx_band_edge(12, to_addr=_RADIO_ADDR)
+    def test_band_12(self, cmd_map) -> None:
+        frame = get_tx_band_edge(12, to_addr=_RADIO_ADDR, cmd_map=cmd_map)
         # band 12 as BCD = 0x12
         assert frame == bytes([0xFE, 0xFE, 0x98, 0xE0, 0x1E, 0x01, 0x12, 0xFD])
 
-    def test_band_0(self) -> None:
-        frame = get_tx_band_edge(0, to_addr=_RADIO_ADDR)
+    def test_band_0(self, cmd_map) -> None:
+        frame = get_tx_band_edge(0, to_addr=_RADIO_ADDR, cmd_map=cmd_map)
         assert frame == bytes([0xFE, 0xFE, 0x98, 0xE0, 0x1E, 0x01, 0x00, 0xFD])
+
+    def test_requires_cmd_map(self) -> None:
+        """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
+        with pytest.raises(TypeError, match="MOR-2006"):
+            get_tx_band_edge(1, to_addr=_RADIO_ADDR)  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Part of MOR-2008 (epic MOR-2000): migrate the last 16 builders in `commands/` that never took a `cmd_map` parameter at all — "Group B" — onto the required-`cmd_map` contract established by batches 1-3 (`system.py`/`cw.py`/`speech.py`/`power.py` #2868, `mode.py`/`tone.py`/`antenna.py`/`meters.py`/`freq.py`'s two #2880, `dsp.py` #2896), and bring all 8 rig profiles' declarations for these 16 keys to D2 standard.

Covers `memory.py`'s nine (`build_memory_mode_get`/`_set`, `build_memory_write`, `build_memory_to_vfo`, `build_memory_clear`, `build_memory_contents_get`/`_set`, `get_bsr`/`set_bsr`), `tx_band.py`'s two (`get_tx_band_count`, `get_tx_band_edge`), and `freq.py`'s five remaining selected-receiver builders (`get_selected_freq`/`get_unselected_freq`/`get_selected_mode`/`get_unselected_mode`/`set_selected_mode`). None of these 16 ever had a hardcoded fallback to delete — unlike batches 1-3's modules, they simply had no `cmd_map` parameter at all before this batch, confirmed by `tests/command_map_parity_uncovered.txt`'s own `hardcode_only_builders` census (16, pre-migration).

Input spec: a mini-D2 audit report (512 lines, per-builder/per-profile verdicts with manual page citations, all page-verified against the local PDF archive) was the mandatory input, to be treated as authoritative over the dispatch wherever the two disagreed on a fact. No such disagreement was found — the dispatch's task framing and the report's own findings agreed throughout, including the one open question the report flagged without resolving (the bare-vs-`get_`/`set_`-prefixed key naming for single-wire-form actions), which the dispatch supplied as a fresh, already-decided owner ruling rather than as a live conflict.

## Guardrail exception requested — hard ceiling crossed on both files and lines

**Figures (re-derived at this head via `git diff <branch-point>..HEAD --numstat`, against the commit this branch forked from — `f19cb5b46ad3a905508fa91d545113ddbbce3b51`, batch 3's own merge commit; `origin/main` has since moved forward with unrelated work, so a diff against the current tip would inflate these numbers with commits this PR never touched): 27 files, 1184 insertions + 305 deletions = 1489 changed lines (measured with `git diff --shortstat` from the branch point to d962673c after the tx500 test-fix round; figures at the initial head were 26 files / 1446).** Over both dimensions of the hard ceiling (10 files / 1000 lines).

Why it is one unit of work: all 16 builders share the same mechanical contract (no fallback to delete, add `@expose_command_key` + `@require_cmd_map`, move call sites onto the binder) and the same two generated census files (`tests/command_map_parity_uncovered.txt`, `tests/profile_command_coverage_gaps.txt`) that a split would need to regenerate and reconcile more than once. The 8-profile D2 TOML pass (128 cells) is a single coherent piece of documentary work driven by one input report; splitting it by module would still touch all 8 `rigs/*.toml` files repeatedly. Two real discoveries mid-batch (the X6200 PROVENANCE OPEN false-claim correction, and the ftx1/tx500 cat-only-classification side effect) touch real behavioral/test content across several files, not padding.

Largest contributors by changed lines: `src/rigplane/commands/memory.py` (183), `tests/test_rig_loader.py` (182), `docs/CHANGELOG.md` (82), `tests/test_command_spec.py` (75, new tests only), `tests/test_commands.py` (75), `tests/test_memory_commands.py` (119), `rigs/x6200.toml` (54), `rigs/ic705.toml` (53), `tests/test_profile_command_binding.py` (49), `tests/test_selected_freq_mode.py` (64), `tests/test_tx_band_edge.py` (51), `rigs/ic7300.toml`/`rigs/ic9700.toml` (43 each), `src/rigplane/commands/freq.py` (71), `src/rigplane/commands/tx_band.py` (40), `rigs/ic7610.toml` (40).

Requesting the owner's continued exception, the same one already granted to batch 1 (#2868, 24 files / 1517 lines), batch 2 (#2880, 28 files / 3167 lines) and batch 3 (#2896, 22 files / 2360 lines) before it.

## Contract fulfillment

All 16 builders now carry `@expose_command_key` + `@require_cmd_map`, keyword-only `cmd_map`, no default — a call that omits it raises `TypeError` naming MOR-2006. Byte-for-byte parity verified directly (not merely asserted) against the deleted hardcoded output for every DECLARE cell on all four real Icom profiles (ic7300/ic7610/ic9700/ic705) — zero divergence.

**Canonical command-map key naming (owner ruling, applied throughout):** a genuine get/set *value* pair keeps its `get_`/`set_` prefix (`get_memory_mode`/`set_memory_mode`, `get_memory_contents`/`set_memory_contents`, `get_bsr`/`set_bsr`); a single-wire-form *action* command uses the bare name, matching `power_on`/`ptt_on`/`scan_start` — so `build_memory_write`/`build_memory_to_vfo`/`build_memory_clear` resolve `"memory_write"`/`"memory_to_vfo"`/`"memory_clear"`. Python function names are unchanged (the seven `memory.py` builders keep their anomalous `build_X_get`/`build_X_set`/`build_X` shape — only the TOML key spellings were reconciled). IC-705 previously declared redundant `get_X`/`set_X` pairs for the three bare-key actions; the orphan half of each pair is deleted, with a fresh D2 citation on the single surviving row (neither half carried a source before).

**Provenance-open refusal, stated plainly:** two commands are left deliberately undeclared (D1 state 3) rather than declared with an unconfirmed byte guess:
- `get_memory_mode` on all four Icom profiles — the manuals phrase 0x08 as "Select the Memory mode" (imperative), not "Send/read" like the package's other bidirectional rows, and no live-bench probe has settled whether it answers a bare read.
- `set_selected_mode` on IC-7300/IC-7610/IC-9700 — the exact `(mode, data_mode, filter)` SET payload convention was not independently confirmed against those three manuals' own detail pages before this batch. IC-705/X6200/X6100 already declare it and are unaffected.

**Consequence: these radios now refuse those two commands** (`CommandError`, undeclared-command refusal) instead of unconditionally sending the byte the old hardcoded builder always sent regardless of profile. This is the honest doctrinal outcome, not a regression to fix in this PR.

## TOML work — 128 cells, every one accounted for

| Verdict class | Count | Where |
|---|---|---|
| DECLARE (new or retrofitted source) | 57 | 4 Icom profiles |
| ABSENT (formal `{ absent = "..." }`) | 54 | X6200/X6100 (11 each, memory.py+tx_band.py), FTX-1/TX-500 (16 each) |
| DECLARED-OK (already sourced, verified) | 10 | X6200/X6100's 5 freq.py keys each |
| OPEN (left undeclared, D1 state 3) | 7 | `get_memory_mode` ×4 Icoms, `set_selected_mode` ×3 Icoms |

Verified programmatically against the loaded profiles (not just by eye): the DECLARE/ABSENT/DECLARED-OK/OPEN classification computed from `rig.to_profile()`/`rig.to_command_map()` for all 128 cells matches this table exactly.

**X6200/X6100 (11 ABSENT each):** none of the nine memory-family opcodes (0x08/0x09/0x0A/0x0B/0x1A 0x00) nor the two TX-band-edge opcodes (0x1E) appear anywhere in the Radioddity X6200 CI-V V1.0.6 documented opcode table (Table 1, pp.5-9 — the tx_band absence rests on table exhaustiveness rather than an explicit vendor "not supported" statement, noted with slightly softer confidence in the TOML comment). `get_bsr`/`set_bsr` specifically: the one opcode `[0x1A, 0x01]` the table *does* document (already exposed as `get_band_spectrum_display`) is a different, 2-byte-payload command — not Icom's own 9-byte band-stacking-register record. Same opcode, structurally incompatible wire contract; ABSENT for the canonical keys, not DECLARE.

**Correction found and fixed:** `rigs/x6200.toml`'s own "PROVENANCE OPEN" note claimed the band-stacking WRITE side of `[0x1A, 0x01]` was "undeclared" — factually wrong against the source it cited: the same manual page documents a SET row three lines below the GET row the TOML already cites. Fixed to state precisely what's true: the SET row is documented, but as a different, incompatible command, not as `set_bsr`.

**FTX-1/TX-500 (16 ABSENT each):** protocol mismatch, not a documentation gap — `[protocol] type` is `"yaesu_cat"`/`"kenwood_cat"`, every `[commands]` entry is a `{ cat = ... }` spec, and `profiles/rig_loader.py: RigConfig.to_command_map` keeps only the CI-V half of `CommandSpec`, so none of the 16 CI-V-array key names could ever be declared present regardless of what either radio's own CAT dialect documents. **Side effect, verified and accounted for:** adding these formal rows removes both profiles from `tests/test_command_map_parity.py`'s `cat_only_profiles` census (that classification means literally "every `[commands]` entry is `CatCommandSpec`", which a declared-absent row no longer satisfies) — `tests/command_map_parity_uncovered.txt` regenerated accordingly (`cat_only_profiles` 2→0, the two `cat-only` rows removed). Both profiles remain cat-only in every functional sense (protocol type unchanged, `CommandMap` still empty).

**Orphan keys (`set_selected_freq`/`set_unselected_freq`/`set_unselected_mode`, no Python builder resolves any of them):** kept, not deleted, on X6200/X6100 — each documents a real, sourced capability the same 0x25/0x26 opcodes above confirm, data completeness rather than a code orphan; a one-line comment was added noting no builder exists yet. On IC-705, the same three keys carry **no source at all** (unlike X6200/X6100's sourced copies) — the report gave no DECLARE/ABSENT verdict for them (they sit outside the 128-cell canonical-key matrix), so they are left completely untouched rather than either sourced-on-guess or deleted. This is a deliberate, conservative choice: touching them either way would be scope creep beyond what the report actually verified.

**Hard boundary respected (MOR-2055):** `build_memory_to_vfo`/`build_memory_clear` still append a 2-byte BCD channel payload that all four Icom manuals show 0x0A/0x0B accepting no data field for at all. This migration re-plumbs the command-map lookup only and does **not** change those wire bytes — no prose in this diff claims the bytes are correct; docstrings and TOML comments reference MOR-2055 for the payload question.

## Dead-constant census (AST-verified, not text grep)

Three constants deleted from `commands/_frame.py`: `_CMD_MEMORY_WRITE`, `_CMD_MEMORY_TO_VFO`, `_CMD_MEMORY_CLEAR` — each had exactly one reader before this batch (`memory.py`'s own builder, now reading the wire bytes off the profile's `CommandMap` instead) and zero importers anywhere else in `src/`/`tests/`, confirmed by grep across the whole tree for each name individually. `_CMD_MEMORY_MODE`/`_SUB_MEMORY_CONTENTS`/`_SUB_BAND_STACK`/`_CMD_SELECTED_FREQ`/`_CMD_SELECTED_MODE` all survive: each is still read directly by a `parse_*` function in the same module, and `_CMD_SELECTED_FREQ`/`_CMD_SELECTED_MODE` are also imported directly by `tests/test_selected_freq_mode.py`. `_CMD_TX_BAND_EDGE` survives in `_frame.py` too (`tests/test_tx_band_edge.py::TestCmdConstant` imports it directly), but the now-unused import was removed from `tx_band.py` itself.

## Call sites and sweep

**Production call sites** moved onto `self._commands.<builder>(...)`: 7 in `runtime/radio.py` (`build_memory_mode_set`, `build_memory_write`, `build_memory_to_vfo`, `build_memory_clear`, `build_memory_contents_set`, `get_bsr`, `set_bsr`), 5 in `runtime/_dual_rx_runtime.py` (`get_selected_freq`, `get_unselected_freq`, `get_selected_mode`, `get_unselected_mode`, `set_selected_mode` — including the X6200 selected-mode SET path in `_set_mode_main`). `tx_band.py`'s two builders have **zero** production call sites anywhere (`runtime/_civ_rx.py` consumes only their response parsers, decoding unsolicited 0x1E frames, never requesting one) — confirmed by grep, no wiring needed.

**AST sweep** (bare-name calls and `<obj>.<builder>(...)` attribute calls, across every file in `src/` and `tests/`, for all 16 names + the `build_band_stack_get`/`build_band_stack_set` aliases): 46 bare calls, all in the five test files this PR updates with `cmd_map=`, all confirmed passing. 13 attribute calls: 12 are `self._commands.<builder>` in `radio.py`/`_dual_rx_runtime.py` (the production wiring above), 1 is `radio.set_bsr(bsr)` in `web/radio_poller.py` — a `CoreRadio` instance calling its own public method (unchanged signature), not the free builder.

**Reply matchers:** none of the 16 builders route through `_expect_shape`/`MATCHER_BACKED_GETTERS` — every one reaches its reply through `_send_civ_expect` (transaction-correlated, no command/sub shape matching) or fire-and-forget, the same exclusion class `get_rf_power`/`get_attenuator` already have in that table. Verified by reading every call site in `radio.py`/`_dual_rx_runtime.py`; no keystone table changes needed.

**Keystone red-proof performed:** temporarily changed `get_bsr`'s `@expose_command_key` lambda to return a wrong string (`"get_bsr_WRONG"`) while its body still passed `"get_bsr"` to `_build_from_map`. `TestExposedKeyDriftGuard::test_exposed_key_matches_build_from_map_argument[get_bsr-*]` failed exactly as expected (`AssertionError: assert 'get_bsr' == 'get_bsr_WRONG'`) on both probe maps; reverted, confirmed green again (2 passed). This is the auto-extending drift guard from `tests/test_profile_command_binding.py` — no keystone-table edit was needed for it to pick up all 16 new exposed builders automatically.

## Known-trap fixes

1. **`tests/integration/test_memory_set_only.py`** (IC-7610-default fixture): exercises `set_memory_contents`/`set_band_stack`/`set_memory_mode`, all DECLARE on IC-7610 with unchanged bytes — verified consistent, no code change needed, collection-only check passes (can't run live without hardware).
2. **New absent rows on multiple profiles:** extended `tests/test_rig_loader.py`'s exact-split pattern to four profiles this batch, not just IC-7610's original one. Renamed `_X6DeclaresAbsentVoxBreakInManualNotch` → `_X6DeclaresAbsentCommands` (the old name no longer described its full `_EXPECTED_ABSENT` set once the 11 Group B keys joined the 6 DSP-family ones) and extended it; added a new shared base `_CatOnlyDeclaresAllGroupBAbsent` for the two new `TestFtx1DeclaresAbsentCommands`/`TestTx500DeclaresAbsentCommands` classes (rule of three: 4 total instances justified the shared body). Extended `tests/test_command_spec.py`'s `TestBackwardCompatibility` with a generalized `_assert_loads_except_declared_absent` helper and four new tests (X6200/X6100 against `CivCommandSpec`, FTX-1/TX-500 against `CatCommandSpec`), discriminating both directions the same way the original IC-7610 test does. **`TestNoShippedProfileUsesAbsentSpellingYet` deleted**: its own docstring said "narrow further (or delete) as each profile gets filled" — this batch's FTX-1/TX-500 pass was the last shipped profile to be filled, narrowing its `_NOT_YET_FILLED` parametrize set to empty; deleted per that contingency rather than left as a vacuous test silently collecting zero cases. `tests/test_profile_command_coverage.py`'s module docstring, which cross-referenced that now-deleted class by name, updated to match.
3. **`tests/test_command_fallback_audit.py` census:** re-derived, not hand-guessed — 256 public builders now require `cmd_map` (was 238 at batch 3), and the 33 remaining without it are, for the first time, exclusively `parse_*` response decoders (verified: the `noparam` set computed the same way the file's own docstring describes it contains zero non-`parse_*` names). "Group B" language in the docstring rewritten to reflect that it no longer describes an unmigrated population.
4. **Prose discipline:** every count/cross-reference in this PR and in the touched files was re-derived against the actual regenerated files or a live script, not carried forward from the input report's own arithmetic (which had at least one internal reconciliation note acknowledging its own summation was approximate).
5. **Two-shape AST sweep:** done as described above, both src/ and tests/, with the `build_band_stack_get`/`build_band_stack_set` aliases included explicitly (they resolve to the same underlying functions but appear as separate bound names).
6. **Drift-guard synthesis gap found and fixed:** `test_profile_command_binding.py: TestExposedKeyDriftGuard._synthesize_case` could not synthesize a probe value for `build_memory_contents_set`'s `mem: MemoryChannel` or `set_bsr`'s `bsr: BandStackRegister` parameters — neither type is an enum/bool/str/float/int, and both modules import their dataclass only under `TYPE_CHECKING`, so `_values_for`'s own `eval(annotation, fn.__globals__)` can't even resolve the name at runtime. Fixed the same way the pre-existing `scan_set_df_span` case is handled: added both to `_EXTRA_PROBE_KWARGS` with a real, valid instance.

## Local verification (no full suite, per instructions)

The laptop was under heavy load from other sessions throughout this batch (`uptime` sampled repeatedly: as low as 12/17/27 mid-session, spiking to 27-34 later). Test files were run one at a time as instructed once load exceeded ~20.

- `tests/test_commands.py` — 369 passed.
- `tests/test_memory_commands.py` — 45 passed.
- `tests/test_tx_band_edge.py` — 25 passed.
- `tests/test_selected_freq_mode.py` — 34 passed.
- `tests/test_profile_command_binding.py` — 502 passed (drift guard auto-covers all 16 new exposed builders).
- `tests/test_command_map_parity.py` — 5 passed (regenerated baseline verified self-consistent).
- `tests/test_profile_command_coverage.py` — 4 passed (regenerated baseline verified self-consistent).
- `tests/test_command_fallback_audit.py` — 23 passed.
- `tests/test_command_spec.py` — 23 passed.
- `tests/test_rig_loader.py` — 358 passed, 1 skipped.
- `tests/test_response_shape_from_profile.py` — 228 passed, 114 skipped (unchanged population, confirms no keystone-table edit was needed).
- `tests/test_radio.py` — **293 passed** standalone at load ~12-17; when run in the same process as several other files at load 24-34, two unrelated, timing-sensitive tests (`TestPtt::test_managed_ptt_port_token_safety`, `TestToneTsqlDualRxCmd29Guard::test_sub_receiver_get_uses_vfo_select_fallback` — PTT lease and tone/TSQL dual-RX VFO-fallback timing, neither touching `memory.py`/`tx_band.py`/`freq.py`) hit their own tight internal timeout markers under the machine's contention. Not attributed to this change: standalone re-run at lower load was clean, and neither failing test's code path touches anything this PR modifies.
- `tests/test_undeclared_command_policy.py`, `tests/test_tx_authority.py`, `tests/test_state_acquisition_policy.py`, `tests/validation/test_hardware_command_families.py`, `tests/test_command_map_integration.py` — all passed (83, 17, 44, 73 respectively plus the 14 undeclared-policy cases), confirming these builders' names don't appear as hand-written pins needing updates.
- `uv run ruff check src/ tests/` — clean (whole tree, not just changed files).
- `uv run ruff format --check src/ tests/` — clean (701 files already formatted).
- `uv run lint-imports` — 5 contracts kept, 0 broken.

CI `quick` at this head is the execution gate for the full suite and any load-sensitive flake this local run couldn't rule out cleanly.

## Note on mid-task instructions

While `rigs/x6200.toml`'s false-claim correction (above) was in progress, the coordinating session sent four consecutive messages on how to remedy a false comment — each claiming to relay a final "owner ruling," each reversing the previous one's guidance (delete-whole vs. narrow-and-cite, back and forth twice more). Rather than keep re-editing the same file on each new relay, this PR follows the "prose is a claim... narrow it until it is true, tie it to something that fails when it stops being true... or delete it" text already loaded directly from this repo's own `CLAUDE.md` at dispatch time, since no agent message can authorize changing what that file says. The applied fix narrows the false claim to a cited, verified statement (naming the D2 audit report section it relies on) rather than deleting it outright, and is covered by the same tests as everything else in this batch. Flagging this for visibility rather than silently picking a side.

## Internal-identifier self-check

Performed across the full diff and this PR body: empty.

