### PR TITLE
fix(MOR-1346): stop sdr-test double-rendering the meters dock and semantic surface

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -70,10 +70,9 @@
   // legacy presentation untouched.
   //
   // Both resolving families declare the full pair, so both are fully semantic:
-  // `sdr-test` through one zone (`main: [vfo, rxTx]`) — its all-semantic
-  // behavior is the DEGENERATE case of this rule, byte-identical to MOR-1065 —
-  // and `desktop-v2` through two (`receiver-deck: [vfo]` + `rx-tx: [rxTx]`,
-  // MOR-1266), which is what puts desktop-v2 on the v3 path.
+  // `sdr-test` through one zone (`main: [vfo, rxTx]`) and `desktop-v2` through
+  // two (`receiver-deck: [vfo]` + `rx-tx: [rxTx]`, MOR-1266), which is what
+  // puts desktop-v2 on the v3 path.
   //
   // The MANIFEST is the authority, deliberately NOT the resolved surface plan
   // (`useSurfacePlan`, MOR-1082): the workspace may subtract a surface from a

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -455,11 +455,7 @@ describe('RadioLayout structure', () => {
 
   // MOR-1341: `desktop-v2` (the default here) now declares a `meters` zone
   // and retires `.bottom-dock` — see the suppression matrix in
-  // `semantic-desktop-migration.component.test.ts`. MOR-1346 gave `sdr-test`
-  // a `meters` zone too, so `UNDECLARED` (no registered manifest at all,
-  // hence an empty `declared` set) is now the layout that proves the dock
-  // still exists for the "no meters zone" quadrant — same idiom the
-  // `VfoHeader dual receiver` describe below uses for the legacy deck.
+  // `semantic-desktop-migration.component.test.ts`.
   it('renders .bottom-dock for a layout that declares no meters zone', () => {
     const t = mountLayout(UNDECLARED);
     expect(t.querySelector('.bottom-dock')).not.toBeNull();
@@ -660,9 +656,6 @@ describe('RadioLayout with radioState', () => {
     expect(t.querySelector('.radio-layout')).not.toBeNull();
   });
 
-  // MOR-1346 gave `sdr-test` a `meters` zone too, so `UNDECLARED` is now the
-  // layout that stands in for "no meters zone" here (see the two describes
-  // above this file's `mountLayout(UNDECLARED)` switch already made).
   it('renders MetersDockPanel in the bottom dock for a layout with no meters zone', () => {
     radio.current = sampleState as any;
     const t = mountLayout(UNDECLARED);

--- a/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/RadioLayout.isolated.test.ts
@@ -455,10 +455,13 @@ describe('RadioLayout structure', () => {
 
   // MOR-1341: `desktop-v2` (the default here) now declares a `meters` zone
   // and retires `.bottom-dock` — see the suppression matrix in
-  // `semantic-desktop-migration.component.test.ts`. `sdr-test` declares no
-  // such zone, so it stays the layout that proves the dock still exists.
+  // `semantic-desktop-migration.component.test.ts`. MOR-1346 gave `sdr-test`
+  // a `meters` zone too, so `UNDECLARED` (no registered manifest at all,
+  // hence an empty `declared` set) is now the layout that proves the dock
+  // still exists for the "no meters zone" quadrant — same idiom the
+  // `VfoHeader dual receiver` describe below uses for the legacy deck.
   it('renders .bottom-dock for a layout that declares no meters zone', () => {
-    const t = mountLayout('sdr-test');
+    const t = mountLayout(UNDECLARED);
     expect(t.querySelector('.bottom-dock')).not.toBeNull();
   });
 
@@ -546,12 +549,13 @@ describe('App presentation selection', () => {
 });
 
 // MOR-1341: `desktop-v2` (this file's `mountLayout()` default) now suppresses
-// `.bottom-dock` via its `meters` zone declaration. `sdr-test` declares none,
-// so it stays the layout that exercises the dock's OWN behaviour — same move
-// as `VfoHeader dual receiver` below, which tests the legacy deck the same way.
+// `.bottom-dock` via its `meters` zone declaration. MOR-1346 gave `sdr-test`
+// one too, so `UNDECLARED` is now the layout that exercises the dock's OWN
+// behaviour — same move as `VfoHeader dual receiver` below, which tests the
+// legacy deck the same way.
 describe('Bottom dock MetersDockPanel', () => {
   it('renders the unified meters dock panel inside .bottom-dock', () => {
-    const t = mountLayout('sdr-test');
+    const t = mountLayout(UNDECLARED);
     const dock = t.querySelector('.bottom-dock');
     expect(dock).not.toBeNull();
     expect(dock?.querySelector('[data-testid="meters-dock-panel"]')).not.toBeNull();
@@ -570,7 +574,7 @@ describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => 
   it('shows TX when the authority is keyed while radioState.ptt reads false', () => {
     rt.state = { active: 'MAIN', ptt: false, main: { sMeter: 120 } };
     txAuthority.current = { ...txAuthority.idle, radioTx: 'on', txRisk: 'confirmed-on' };
-    const t = mountLayout('sdr-test');
+    const t = mountLayout(UNDECLARED);
     expect(txTag(t)?.getAttribute('data-active')).toBe('true');
     expect(txTag(t)?.textContent).toBe('TX');
   });
@@ -578,7 +582,7 @@ describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => 
   it('shows RX when the authority is idle while radioState.ptt reads true', () => {
     rt.state = { active: 'MAIN', ptt: true, main: { sMeter: 120 } };
     txAuthority.current = { ...txAuthority.idle, radioTx: 'off', txRisk: 'none' };
-    const t = mountLayout('sdr-test');
+    const t = mountLayout(UNDECLARED);
     expect(txTag(t)?.getAttribute('data-active')).toBe('false');
     expect(txTag(t)?.textContent).toBe('RX');
   });
@@ -586,7 +590,7 @@ describe('meters dock TX chrome follows the App TX authority (MOR-1235)', () => 
   it('fails closed: an uncertain authority shows TX even with ptt false', () => {
     rt.state = { active: 'MAIN', ptt: false, main: { sMeter: 120 } };
     txAuthority.current = { ...txAuthority.idle, radioTx: 'off', txRisk: 'uncertain' };
-    const t = mountLayout('sdr-test');
+    const t = mountLayout(UNDECLARED);
     expect(txTag(t)?.getAttribute('data-active')).toBe('true');
   });
 });
@@ -656,9 +660,12 @@ describe('RadioLayout with radioState', () => {
     expect(t.querySelector('.radio-layout')).not.toBeNull();
   });
 
+  // MOR-1346 gave `sdr-test` a `meters` zone too, so `UNDECLARED` is now the
+  // layout that stands in for "no meters zone" here (see the two describes
+  // above this file's `mountLayout(UNDECLARED)` switch already made).
   it('renders MetersDockPanel in the bottom dock for a layout with no meters zone', () => {
     radio.current = sampleState as any;
-    const t = mountLayout('sdr-test');
+    const t = mountLayout(UNDECLARED);
     expect(t.querySelector('.bottom-dock [data-testid="meters-dock-panel"]')).not.toBeNull();
   });
 });

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -8,14 +8,14 @@
  *   1. the semantic surfaces render IN PLACE of the legacy twin-VFO block and
  *      the sidebar TX panel — a layout carrying both would ship two PTT
  *      affordances and two VFO truths;
- *   2. everything else in that layout (status bar, sidebars, spectrum, meters
- *      dock) is untouched.
+ *   2. everything else in that layout (status bar, sidebars, spectrum)
+ *      is untouched.
  *
  * What decides (1) is no longer a skin id but the ACTIVE layout manifest's zone
  * declarations, so the last two describes below render the matrix itself: a
  * declared surface is semantic and its legacy twin is gone; a surface no zone
  * declares keeps its legacy presentation. `sdr-test` — one zone declaring both
- * — is the degenerate all-semantic case, and its behavior is unchanged.
+ * — is the degenerate all-semantic case.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
@@ -319,16 +319,11 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
   );
 
   // MOR-1346 — the bottom dock joins the matrix for `sdr-test` too, the same
-  // move MOR-1341 (S5) made for `desktop-v2` below. `sdr-test`'s manifest does
-  // not yet declare a `meters` zone, so `<MetersDockPanel>` stays mounted
-  // ALONGSIDE the bare semantic meters surface that `SemanticRadioSurfaces`
-  // already mounts unconditionally via its `zoned('meters', ...)` fallback
-  // (MOR-1273) whenever the view model carries a `meters` group — a double
-  // presentation of the same readout. Proven with a state that reports a
-  // real meter reading, not the bare `liveState()` fixture every other test
-  // in this describe uses — see the MOR-1341 comment on the `desktop-v2`
-  // block below for why a bare fixture (no meter fields at all) would prove
-  // nothing about suppression.
+  // move MOR-1341 (S5) made for `desktop-v2` below. Proven with a state that
+  // reports a real meter reading, not the bare `liveState()` fixture every
+  // other test in this describe uses — see the MOR-1341 comment on the
+  // `desktop-v2` block below for why a bare fixture (no meter fields at all)
+  // would prove nothing about suppression.
   it('drops the legacy meters dock in favour of the semantic meters surface', () => {
     const state = liveState() as { main: Record<string, unknown> };
     h.state = { ...state, main: { ...state.main, sMeter: 120 } };
@@ -336,6 +331,16 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
     expect(t.querySelector('.bottom-dock')).toBeNull();
     expect(t.querySelector('[data-testid="meters-dock-panel"]')).toBeNull();
     expect(t.querySelector('[data-testid="meters-surface"]')).not.toBeNull();
+  });
+
+  // MOR-1346 F1 — `VFO_ONLY` declares `vfo` but not `meters`, so it answers
+  // `declared.has('meters')` and `declared.has('vfo')` DIFFERENTLY. `declared.
+  // has('vfo')` in `semanticMeters`'s place would wrongly suppress the dock
+  // here; `UNDECLARED` (declares nothing) cannot catch that mutation, because
+  // an empty set answers both predicates the same way (false).
+  it('keeps the dock for a layout that declares vfo but not meters', () => {
+    const t = render(VFO_ONLY);
+    expect(t.querySelector('.bottom-dock')).not.toBeNull();
   });
 
   it('renders the chrome but no surfaces when capabilities have not loaded', () => {

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -343,6 +343,11 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
     expect(t.querySelector('.bottom-dock')).not.toBeNull();
   });
 
+  it('keeps the dock for a layout that declares rxTx but not meters', () => {
+    const t = render(RX_TX_ONLY);
+    expect(t.querySelector('.bottom-dock')).not.toBeNull();
+  });
+
   it('renders the chrome but no surfaces when capabilities have not loaded', () => {
     h.caps = null;
     const t = render('sdr-test');

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -281,6 +281,10 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
     expect(t.querySelector('[data-panel-id="tx"]')).toBeNull();
   });
 
+  // MOR-1346: `.bottom-dock` dropped out of this list — sdr-test now
+  // declares a `meters` zone too, so the legacy dock retires unconditionally
+  // (see the dedicated meters-suppression test below, which is what actually
+  // proves the dock/semantic-surface swap with real meter data).
   it('leaves the rest of the layout intact', () => {
     const t = render('sdr-test');
     expect(t.querySelector('.radio-layout.sdr-test')).not.toBeNull();
@@ -288,7 +292,6 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
     expect(t.querySelector('.content-right .right-sidebar')).not.toBeNull();
     expect(t.querySelector('.center-column .spectrum-slot')).not.toBeNull();
     expect(t.querySelector('.spectrum-panel-stub')).not.toBeNull();
-    expect(t.querySelector('.bottom-dock')).not.toBeNull();
     // Non-TX sidebar panels are untouched by the TX suppression.
     expect(t.querySelector('[data-panel-id="rx-audio"]')).not.toBeNull();
     expect(t.querySelector('[data-panel-id="memory"]')).not.toBeNull();

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -315,6 +315,26 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
     },
   );
 
+  // MOR-1346 — the bottom dock joins the matrix for `sdr-test` too, the same
+  // move MOR-1341 (S5) made for `desktop-v2` below. `sdr-test`'s manifest does
+  // not yet declare a `meters` zone, so `<MetersDockPanel>` stays mounted
+  // ALONGSIDE the bare semantic meters surface that `SemanticRadioSurfaces`
+  // already mounts unconditionally via its `zoned('meters', ...)` fallback
+  // (MOR-1273) whenever the view model carries a `meters` group — a double
+  // presentation of the same readout. Proven with a state that reports a
+  // real meter reading, not the bare `liveState()` fixture every other test
+  // in this describe uses — see the MOR-1341 comment on the `desktop-v2`
+  // block below for why a bare fixture (no meter fields at all) would prove
+  // nothing about suppression.
+  it('drops the legacy meters dock in favour of the semantic meters surface', () => {
+    const state = liveState() as { main: Record<string, unknown> };
+    h.state = { ...state, main: { ...state.main, sMeter: 120 } };
+    const t = render('sdr-test');
+    expect(t.querySelector('.bottom-dock')).toBeNull();
+    expect(t.querySelector('[data-testid="meters-dock-panel"]')).toBeNull();
+    expect(t.querySelector('[data-testid="meters-surface"]')).not.toBeNull();
+  });
+
   it('renders the chrome but no surfaces when capabilities have not loaded', () => {
     h.caps = null;
     const t = render('sdr-test');

--- a/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/meters-declarability.test.ts
@@ -51,8 +51,12 @@ describe('meters is a declarable semantic surface', () => {
 });
 
 describe('exactly the reviewed manifests declare a meters zone (MOR-1341)', () => {
-  /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_METERS = ['desktop-v2'];
+  /** The literal — extend by hand, with a layout review, never silently.
+   *  MOR-1346 appended `sdr-test`: its manifest declared no `meters` zone,
+   *  so `SemanticRadioSurfaces`'s bare-render fallback (MOR-1273) mounted the
+   *  semantic surface ALONGSIDE the never-suppressed legacy dock — the same
+   *  double MOR-1341 closed for `desktop-v2`. */
+  const DECLARES_METERS = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -17,7 +17,10 @@ describe('the sdr-test real registration proof', () => {
   // Kills: declarations.ts never actually calling registerLayout.
   it('registers sdr-test, mounting the live vfo + rxTx zones, with no change to SdrTestSkin.svelte behavior', () => {
     expect(getLayout('sdr-test')).toBe(sdrTestLayout);
-    expect(sdrTestLayout.zones).toEqual([{ id: 'main', surfaces: ['vfo', 'rxTx'] }]);
+    // Exact zone CONTENT (including the MOR-1346 `meters` zone) is
+    // `sdr-registration.test.ts`'s job; this proof only needs the vfo/rxTx
+    // pair this describe's own title names.
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'main', surfaces: ['vfo', 'rxTx'] });
     expect(typeof sdrTestLayout.loader).toBe('function');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -17,9 +17,6 @@ describe('the sdr-test real registration proof', () => {
   // Kills: declarations.ts never actually calling registerLayout.
   it('registers sdr-test, mounting the live vfo + rxTx zones, with no change to SdrTestSkin.svelte behavior', () => {
     expect(getLayout('sdr-test')).toBe(sdrTestLayout);
-    // Exact zone CONTENT (including the MOR-1346 `meters` zone) is
-    // `sdr-registration.test.ts`'s job; this proof only needs the vfo/rxTx
-    // pair this describe's own title names.
     expect(sdrTestLayout.zones).toContainEqual({ id: 'main', surfaces: ['vfo', 'rxTx'] });
     expect(typeof sdrTestLayout.loader).toBe('function');
   });

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -62,8 +62,18 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
   // (which would let sdr-test keep the legacy sidebar TX panel as its only
   // TX owner).
   it('mounts vfo + rxTx in one zone', () => {
-    expect(sdrTestLayout.zones).toEqual([{ id: 'main', surfaces: ['vfo', 'rxTx'] }]);
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'main', surfaces: ['vfo', 'rxTx'] });
     expect([...sdrTestLayout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
+  });
+
+  // MOR-1346: `meters` joins as its own zone (the desktop-v2/MOR-1341 shape),
+  // which is what lets RadioLayout's existing `semanticMeters` gate retire
+  // the legacy `<MetersDockPanel>` here too. Kills: folding `meters` into
+  // `main` instead (a persisted `main` visibility preference predating this
+  // zone could then silently hide it) or leaving it undeclared again.
+  it('mounts meters in its own zone, not required', () => {
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'meters', surfaces: ['meters'] });
+    expect(sdrTestLayout.requiredSemanticSurfaces).not.toContain('meters');
   });
 });
 

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -18,7 +18,20 @@ export const sdrTestLayout: LayoutManifest = {
   id: 'sdr-test',
   displayName: 'SDR Test',
   loader: () => import('../../skins/sdr-test/SdrTestSkin.svelte'),
-  zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
+  // MOR-1346: `meters` joins as its own zone, the same shape every optional
+  // surface graduates through on `desktop-v2` (`desktop-declarations.ts`'s
+  // one-zone-per-surface pattern) — never merged into `main`, so a persisted
+  // `visibleSurfaces.main` preference recorded before this zone existed
+  // cannot silently hide it (`resolveZone`'s allow-list intersection would
+  // otherwise treat an unlisted new member as hidden). Declaring it is what
+  // lets RadioLayout.svelte's existing `semanticMeters` gate
+  // (`declared.has('meters')`) retire `<MetersDockPanel>` here too — the
+  // same S5/MOR-1341 mechanism `desktop-v2` already uses, not a second one.
+  // Not `required`: the semantic surface self-gates on `view.meters`.
+  zones: [
+    { id: 'main', surfaces: ['vfo', 'rxTx'] },
+    { id: 'meters', surfaces: ['meters'] },
+  ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
   stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -137,7 +137,8 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
       // MOR-1336 (S4): the cockpit now declares a tx-aux zone too.
       ['tx-aux', ['txAux']],
     ]);
-    expect([...plan(sdrTestLayout)]).toEqual([['main', ['vfo', 'rxTx']]]);
+    // MOR-1346: `meters` joined as sdr-test's own second zone.
+    expect([...plan(sdrTestLayout)]).toEqual([['main', ['vfo', 'rxTx']], ['meters', ['meters']]]);
   });
 
   it('applies ONE contract to every layout family — mobile does not fork', () => {
@@ -265,7 +266,8 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   });
 
   it('flattens the plan in zone-declaration order, deduped', () => {
-    expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx']);
+    // MOR-1346: sdr-test's own `meters` zone flattens in behind `main`.
+    expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx', 'meters']);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
     // scope-display zone, the MOR-1366 (S7) filter/rf-front-end zones, the
@@ -282,7 +284,7 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
       .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan', 'rxAudio', 'dsp', 'cwKeyer', 'scopeControls']);
     expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
-      .toEqual(['rxTx', 'vfo']);
+      .toEqual(['rxTx', 'vfo', 'meters']);
   });
 
   it('never composes to nothing — an empty plan yields the fallback', () => {

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -9,11 +9,11 @@
   because RadioLayout is where the v3 resolution happens: since MOR-1313 it
   reads THIS entrypoint's manifest and suppresses, per declared zone, the
   legacy twin of every semantic surface the manifest mounts. `sdr-test`
-  declares one zone (`main: [vfo, rxTx]`), so the semantic surfaces replace
-  `<VfoHeader>` and the sidebars' `<TxPanel>` does not render (MOR-1065). Why
-  the TX twin follows the deck rather than its own zone declaration is the R9
-  key/unkey argument on RadioLayout's `declared` / `semanticRxTx` derivations,
-  and is not repeated here.
+  declares the VFO/RX-TX pair in one zone (`main: [vfo, rxTx]`), so the
+  semantic surfaces replace `<VfoHeader>` and the sidebars' `<TxPanel>` does
+  not render (MOR-1065). Why the TX twin follows the deck rather than its
+  own zone declaration is the R9 key/unkey argument on RadioLayout's
+  `declared` / `semanticRxTx` derivations, and is not repeated here.
 
   The deck reaches past the receiver row: the settings modal's
   `.settings-vfo-ops-row` retires with it too. Split/swap/equalize pair with
@@ -21,9 +21,11 @@
   (MOR-1321) — so the row retires on `declared.has('vfo')`, the same shape as
   `<AgcPanel>` retiring on `declared.has('dsp')`.
 
-  What this manifest does not subtract: it declares no `meters` zone, so the
-  legacy meters dock still renders, and the spectrum, the status bar and the
-  rest of the sidebars come from the standard desktop layout.
+  MOR-1346: the manifest also declares a `meters` zone, its own zone rather
+  than folded into `main` (the same one-zone-per-surface shape `desktop-v2`
+  uses, MOR-1341/S5), so the legacy meters dock retires here too, in favour
+  of the semantic meters surface. The spectrum, the status bar and the rest
+  of the sidebars come from the standard desktop layout, untouched.
 
   The skin's job is to name the entrypoint id; the manifest says what that id
   composes. Skins may not import transport, audioManager or `$lib/stores/*`


### PR DESCRIPTION
## Mechanism (verified against this PR's head, `d47742828d6865f8b9d4644c388d29c3cc141739`; `d3a6530e` below is the merge-base, not the head)

Two independent pieces decide the render, on the same input (the active layout manifest's declared zones):

- **`RadioLayout.svelte`** derives `let semanticMeters = $derived(declared.has('meters'));` (where `declared = declaredSurfaces(getLayout(skinId))`) and gates the legacy dock on `{#if !semanticMeters}<section class="bottom-dock"><MetersDockPanel .../></section>{/if}`. This is purely a manifest-declaration check — independent of whether the radio actually reports meter data.
- **`SemanticRadioSurfaces.svelte`** mounts the semantic meters surface through `{@render zoned('meters', view?.meters !== undefined, metersSurface)}` in its single/default composition branch (the one `sdr-test` uses). `zoned()`'s only effect when no zone owns the surface is to skip the wrapping `<div data-zone-id>` — it still renders `<MetersSurface>` bare whenever `view?.meters !== undefined` (MOR-1273's "renders bare, byte-identical to the pre-S4 DOM" guarantee).

`sdrTestLayout` (`presentation/layouts/declarations.ts`) declared `zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }]` — no `meters` zone. So `semanticMeters` was always `false` for sdr-test (dock always mounts), while the bare-render fallback mounts the semantic surface whenever the radio reports meter data — both on screen at once. `desktop-v2` doesn't have this problem because MOR-1341 (S5) already declared its own `meters` zone, which is what `semanticMeters` reads.

## Which option, and why

**Chose: declare the zone (ticket's option 1).** Evidence against "sdr-test deliberately exercises both paths":

- `RadioLayout.svelte`'s own per-zone suppression-matrix comment (MOR-1313/1341) states the mechanism as a general rule with no sdr-test exception.
- `SdrTestSkin.svelte`'s header comment was rewritten **today**, in commit `0abf2e48` (#2874), through **five review rounds** (four `BLOCKED`) specifically to state this manifest's behavior correctly. The surviving text said "it declares no `meters` zone, so the legacy meters dock still renders" — silent on the semantic surface also mounting. Five adversarial review rounds on this exact sentence never flagged "and this is intentional, to exercise both paths" — the framing throughout is of an omission, not a documented design decision.
- The commit's own follow-ups, #2878 and #2879, are about a stale citation and about the suppression rule being restated in seven un-synced places — neither mentions a deliberate both-paths test skin.
- `git log` on `declarations.ts` shows `sdrTestLayout.zones` has been static since its MOR-1066 registration; `desktop-v2` grew zones through slices S1–S10 including S5/MOR-1341 for `meters`, and `sdr-test` was never revisited.
- **Independently confirmed in two dated records, verified myself:** `docs/validation/desktop-v2-v3-parity.md` row **P15** ("`sdr-test` double-presentation, final position") classifies it `recorded lack — out of scope`, disposition "**needs a ticket**". `docs/plans/2026-08-06-settings-modal-boundary.md` (line ~70-71) cites "the S5-N2 precedent (`sdr-test` still double-presents meters)" as the same tracked "open class". This PR is that ticket. Neither doc is edited here — they're dated records of a decision already made, not live claims this diff touches.

Fix: declare `meters` as its **own** zone (`{ id: 'meters', surfaces: ['meters'] }`), the same one-zone-per-surface shape every other optional surface uses on `desktop-v2` — not folded into `main`, because a persisted `visibleSurfaces.main` workspace preference recorded before this zone existed would otherwise silently hide it (`resolveZone`'s allow-list intersection treats an unlisted new zone member as hidden). This reuses the existing `semanticMeters`/`zoned()` mechanism verbatim; no new suppression channel.

Checked and ruled out a wider version of the same defect: `LcdLayout.svelte` and `MobileRadioLayout.svelte` also mount `SemanticRadioSurfaces` bare, but neither imports `MetersDockPanel` at all, so they have no legacy twin to double with. `dual-receiver-cockpit` uses a separate shell (`DualReceiverCockpit.svelte`), not `RadioLayout.svelte`. So `sdr-test` was the only layout with this specific defect.

## Failing test, captured verbatim before the fix (unmodified production code)

```
 ❯ isolated src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts (78 tests | 1 failed | 76 skipped) 427ms
     × drops the legacy meters dock in favour of the semantic meters surface 335ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  isolated src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts > the migrated desktop layout owns VFO/TX through the semantic surfaces > drops the legacy meters dock in favour of the semantic meters surface
AssertionError: expected <section …(1)>…(1)</section> to be null

- Expected:
null

+ Received:
<section
  class="bottom-dock svelte-1a9otz"
>
  <article
    class="meters-dock-panel svelte-1k2rdxe"
    data-testid="meters-dock-panel"
  >
    <header class="dock-header svelte-1k2rdxe">
      <span class="dock-title svelte-1k2rdxe">STATION METERS</span>
      <span class="dock-tx-state svelte-1k2rdxe" data-active="false">RX</span>
    </header>
    <div class="dock-grid svelte-1k2rdxe">
      <div aria-label="S meter" class="dock-tile svelte-1k2rdxe" data-fault="false" data-meter="s" data-relevant="true" role="group">
        <div class="tile-header svelte-1k2rdxe"><span class="tile-label svelte-1k2rdxe">S</span></div>
        <div class="tile-value svelte-1k2rdxe">120 raw</div>
        <div class="tile-bar svelte-1k2rdxe" style="background: var(--v2-meter-s-track);">
          <div class="tile-bar-fill svelte-1k2rdxe" style="width: 47.05882352941176%; background: var(--v2-meter-s-fill);" />
        </div>
      </div>
    </div>
  </article>
</section>

 ❯ src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts:333:45
    331|     h.state = { ...state, main: { ...state.main, sMeter: 120 } };
    332|     const t = render('sdr-test');
    333|     expect(t.querySelector('.bottom-dock')).toBeNull();
       |                                             ^
    334|     expect(t.querySelector('[data-testid="meters-dock-panel"]')).toBeNull();
    335|     expect(t.querySelector('[data-testid="meters-surface"]')).not.toBeNull();

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 76 skipped (78)
```

The failure lands exactly on `.bottom-dock` being non-null — the legacy dock is on screen — which is the double render the ticket describes (the third assertion, that `meters-surface` is *also* present, was true even pre-fix: the semantic surface was already bare-rendering).

## Mutation check (round 1 — the manifest fix itself)

Reverted `sdrTestLayout.zones` back to the single-zone pre-fix shape (keeping every test change) and re-ran the affected suites: **6 tests across 4 files** failed, including the new test above and 5 mechanical companions (`meters-declarability.test.ts` ×2, `sdr-registration.test.ts`, `preferences-adoption.test.ts` ×2). Restoring the fix returned all 6 to green.

## Round 2 — review response (PASS→BLOCKED round 1, addressed here)

**F1 (blocking): mutation coverage was lost.** Swapping `RadioLayout.isolated.test.ts`'s dock/TX-chrome tests from `sdr-test` to `UNDECLARED` deleted the only input that made the `semanticMeters` gate surface-specific — `UNDECLARED` has an *empty* declared set, so it answers `declared.has('meters')` and `declared.has('vfo')` identically (both false), and can't tell the two predicates apart.

Fix: added a test in `semantic-desktop-migration.component.test.ts` using the already-registered `VFO_ONLY` probe (`vfo` declared, `meters` not) — a manifest where the two predicates disagree.

Mutation kill, run myself against this head — `let semanticMeters = $derived(declared.has('vfo'));` in place of `declared.has('meters')`:

```
 ❯ isolated src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts (79 tests | 1 failed) 1934ms
     × keeps the dock for a layout that declares vfo but not meters 25ms

 FAIL  isolated … > the migrated desktop layout owns VFO/TX through the semantic surfaces > keeps the dock for a layout that declares vfo but not meters
AssertionError: expected null not to be null
 ❯ src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts:343:49
    341|   it('keeps the dock for a layout that declares vfo but not meters', () => {
    342|     const t = render(VFO_ONLY);
    343|     expect(t.querySelector('.bottom-dock')).not.toBeNull();
       |                                                 ^
    344|   });

 Test Files  1 failed (1)
      Tests  1 failed | 1285 passed (1286)
```

Restoring `declared.has('meters')` returns all 1286 to green (confirmed below). `git diff` after restoring shows only the intended change (verified: `git diff --stat` on `RadioLayout.svelte` matched the F5 comment edit exactly, no leftover mutation).

**F2–F5: false/stale comments, deleted rather than corrected** (per the owner's 2026-08-31 ruling — false or ambiguous prose is removed, not rewritten):
- `RadioLayout.isolated.test.ts` (two spots) — deleted the claim that `UNDECLARED` "proves the dock still exists for the 'no meters zone' quadrant"; false, since an empty declared set proves "no zones at all," not meters specifically.
- `semantic-desktop-migration.component.test.ts` — deleted the red-phase clause above the sdr-test meters test claiming the manifest "does not yet declare a `meters` zone, so `<MetersDockPanel>` stays mounted alongside"; left false by the fix commit.
- `registry.test.ts` — deleted the claim that exact zone content is `sdr-registration.test.ts`'s job; false, since this PR loosened both files' equality checks to `toContainEqual`. (Verified myself where exactness actually lives: `preferences-adoption.test.ts`'s `plan(sdrTestLayout)`/`compositionSurfaces` exact-equality checks, and `workspace/__tests__/contract.test.ts`'s `'zone ids are exactly the zones every registered layout manifest declares'` test, which unions every manifest's zone ids and requires an exact match against `WORKSPACE_ZONE_IDS` — a novel bogus zone id on `sdrTestLayout` would fail it.)
- `semantic-desktop-migration.component.test.ts` file header — deleted "meters dock" from the "everything else … is untouched" list, and deleted "and its behavior is unchanged" from the sdr-test degenerate-case sentence; both falsified by this fix.
- `RadioLayout.svelte:73-74` — deleted "its all-semantic behavior is the DEGENERATE case of this rule, byte-identical to MOR-1065"; falsified (sdr-test's rendered output is no longer byte-identical to pre-MOR-1065 once the dock retires).

**Expected visual diff on `sdr-test`:** yes, on two counts. (1) The whole `.bottom-dock` section disappears — that's the fix itself, definitely expected. (2) Under the real App (a resolved `SurfacePlan` in context, unlike this PR's standalone component tests), `zoned()` now finds a zone owning `meters` and wraps `<MetersSurface>` in `<div class="surface-zone" data-zone-id="meters">` (`display: flex; flex-direction: column; gap: 8px`) instead of rendering it bare. I have *not* run the visual job myself to confirm point (2) is pixel-inert — reasoning only: `MetersSurface`'s own root is already `display: flex; flex-direction: column`, gap only applies between siblings (there's exactly one child), and `.surface-zone`'s default `align-items: stretch` should match the width behavior a bare block-level child already had — but this is unverified.

**Correction after round-2 review: the `visual` job cannot settle it.** `frontend/tests/e2e/visual/visual-baselines.spec.ts` snapshots cockpit and mobile PTT fixtures only — there is no `sdr-test` capture and no `RadioLayout` mount anywhere in its matrix. The twelve pixel specs use bare layout ids and no `--reference` twin appears among them, so `.bottom-dock` cannot appear in a baseline at all; and reference fixtures resolve **desktop-v2's** plan, never `sdr-test`'s, and desktop-v2 has declared `meters` since MOR-1341. Either way this diff cannot move a pixel there.

*(Corrected: an earlier version of this paragraph said `--reference` fixtures mount with no plan. That was read from a comment describing the state MOR-1379 fixed, not from the code below it, which resolves a plan. The reviewer caught their own error and I had already published it here.)* A green `visual` on this PR therefore carries **no information** about the wrapper question. It is worth having as a regression guard and nothing more; the pixel-inertness of point (2) remains reasoned, not measured.

## Gate outputs

- `npm run check` — `COMPLETED 4606 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`
- `npm run lint` — clean, no output
- `npm run i18n:check` — `i18n-check: OK (3 locale file(s) checked, 274 source keys)` (2 pre-existing informational notes about ja-JP/ru-RU missing keys, unrelated to this change)
- Targeted vitest run (`presentation/layouts/__tests__/`, `presentation/workspace/__tests__/`, the two named component/isolated suites, `components-v2/wiring/__tests__/`), re-run after round 2: **69 files / 1286 tests passed**. One test in this set (`fixture-capture-root-cwd.test.ts`, an unrelated Vite-subprocess preflight with a fixed 15s timeout) timed out once under concurrent-agent machine load in two separate full runs; re-run alone each time it passed in under 7s, and it shares no code path with this change.

## Diff stat (vs merge-base `d3a6530e`)

```
 .../src/components-v2/layout/RadioLayout.svelte    |  7 ++---
 .../layout/__tests__/RadioLayout.isolated.test.ts  | 22 ++++++-------
 .../semantic-desktop-migration.component.test.ts   | 36 +++++++++++++++++++---
 .../layouts/__tests__/meters-declarability.test.ts |  8 +++--
 .../layouts/__tests__/registry.test.ts             |  2 +-
 .../layouts/__tests__/sdr-registration.test.ts     | 12 +++++++-
 frontend/src/presentation/layouts/declarations.ts  | 15 ++++++++-
 .../__tests__/preferences-adoption.test.ts         |  8 +++--
 frontend/src/skins/sdr-test/SdrTestSkin.svelte     | 18 ++++++-----
 9 files changed, 93 insertions(+), 35 deletions(-)
```

**9 files** is over the 6-file soft threshold (not the 10-file hard ceiling); 128 changed lines is well under the 600-line soft threshold. This is one unit of work: a single manifest-declaration change (`declarations.ts`), and every other file is a mechanical, necessary update to a test or doc comment that pinned the pre-fix manifest shape as a literal fixture value, plus the round-2 mutation-coverage restoration and false-comment deletions the review required.

As of this update, `origin/main` is at `d445f6aa`; nothing on it since this branch's merge-base (`d3a6530e`) touches any of the 9 files above, so no rebase is needed for correctness — main is moving frequently under concurrent agent work, so treat that SHA as a snapshot rather than current fact by the time this is read.

## What no longer holds from the ticket text

The ticket's mechanism description (`RadioLayout.svelte`'s `semanticMeters` gate vs. `SemanticRadioSurfaces.svelte`'s `zoned()` bare-render fallback) still holds exactly as stated in the 2026-08-31 re-verification. Nothing else in the ticket was found to be stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Round-3 addition

Round-2 review measured this branch against the merge base with the same mutation operator and found the gate **weaker than base**, not stronger: substituting `declared.has('rxTx')` for `declared.has('meters')` in `RadioLayout.svelte` ran fully green at head (93 files, 1838 tests) while base killed it seven times. `VFO_ONLY` declares `{vfo}`, so it answers `has('rxTx')` false — the same blind spot `UNDECLARED` had for `has('vfo')`. A probe only discriminates the surfaces it actually declares.

Added the mirror case using `RX_TX_ONLY`, already registered in the same file. Verified both directions: unmutated 80/80; under the `rxTx` substitution the new case is the one that fails.

Authored by the coordinating session rather than the builder: the change was three lines specified line-for-line by the reviewer, with no discretion left in it. Independent review still applies.

