### PR TITLE
docs(MOR-2044): reconcile frontend-architecture ADR against the code

### DIFF
--- a/.github/scripts/doc-citation-baseline.txt
+++ b/.github/scripts/doc-citation-baseline.txt
@@ -405,7 +405,6 @@ docs/plans/2026-06-09-target-audio-architecture.md	yaesu_cat/radio.py:394-401
 docs/plans/2026-06-09-target-audio-architecture.md	yaesu_cat/radio.py:403
 docs/plans/2026-07-25-ui-composition-discovery-and-parity.md	docs/plans/2026-04-11-parity-matrix.md:20-120
 docs/plans/2026-07-25-ui-composition-discovery-and-parity.md	docs/plans/2026-04-12-target-frontend-architecture.md:1-52
-docs/plans/2026-07-25-ui-composition-discovery-and-parity.md	docs/plans/2026-04-12-target-frontend-architecture.md:483-515
 docs/plans/2026-07-25-ui-composition-discovery-and-parity.md	docs/plans/2026-07-25-ui-composition-architecture-v3.md:88-139
 docs/plans/2026-07-25-ui-composition-discovery-and-parity.md	frontend/src/App.svelte:22-72
 docs/plans/2026-07-25-ui-composition-discovery-and-parity.md	frontend/src/App.svelte:22-98

--- a/docs/architecture/building-a-skin.md
+++ b/docs/architecture/building-a-skin.md
@@ -4,14 +4,9 @@ A skin is a top-level Svelte component, addressable by a `SkinId`, that
 composes the shared semantic surfaces and/or its own bespoke components into
 a renderable UI. For the conceptual picture of how a skin relates to layout
 and design-language choice, see "Three independent knobs" in
-`docs/plans/2026-04-12-target-frontend-architecture.md` — but that section's
-own "Skin implementation (Svelte 5)" and "Skin resolution and lazy loading"
-code samples further down do not match current code (compare them to
-`SkinId` and `SKIN_LOADERS` in `frontend/src/skins/registry.ts`) and are
-tracked stale under MOR-2044 — do not copy them. Everything below points at
-real, current source instead. Concretely, and independent of that ADR's
-staleness: both worked examples below show that a skin's own code never
-special-cases which design language is active — see the
+`docs/plans/2026-04-12-target-frontend-architecture.md`. Everything below
+points at real, current source. Both worked examples below show that a
+skin's own code never special-cases which design language is active — see the
 `presentation/languages/*` row below for why.
 
 This doc plus the two worked examples it names is meant to be enough:

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -625,15 +625,6 @@ listing all five values above, not a cycle button. `cycleLayoutMode()` — a
 vestigial cycle-through-values helper with no caller — was deleted
 (MOR-2059).
 
-!!! note "Current v2 skins vs. the planned v3 architecture"
-    This is the current (v2 migration-era) skin system — skins are chosen
-    synchronously and rendered from one shared component tree, not
-    lazy-loaded. The target v3 frontend architecture
-    ([`docs/plans/2026-04-12-target-frontend-architecture.md`](../plans/2026-04-12-target-frontend-architecture.md))
-    describes a different, not-yet-implemented design — `import()`-loaded
-    skin components and a workspace/slot layout model. Treat that document
-    as a plan, not as shipped behavior.
-
 ### Bottom sheet gestures
 
 Bottom sheets support swipe-to-dismiss:

--- a/docs/plans/2026-04-12-target-frontend-architecture.md
+++ b/docs/plans/2026-04-12-target-frontend-architecture.md
@@ -19,16 +19,16 @@ This ADR is executable: it contains concrete TypeScript interfaces, Svelte 5 pat
 Four layers, strict one-way dependency:
 
 ```
-┌────────────��─────────────��──────────────────────────┐
+┌────────────────────────────────────────────────────┐
 │  SKIN + LAYOUT + THEME                              │  ← visual shell
 │  (amber-lcd, desktop-v2, mobile, future skins)      │
-├─────────────────��───────────────────────────��───────┤
+├──────────────────────────────────────────────────────┤
 │  SEMANTIC COMPONENTS                                │  ← behavior contracts
-│  (VfoDisplay, MetersSurface, RxAudioControl, ...)   │
-├───────────────���─────────────────────────��───────────┤
+│  (VfoSurface, MetersSurface, RxAudioSurface, ...)   │
+├──────────────────────────────────────────────────────┤
 │  VIEW-MODEL ADAPTERS                                │  ← pure functions
 │  (toVfoProps, toMeterProps, toRxAudioProps, ...)     │
-├───────────────────────────────────────────────���─────┤
+├──────────────────────────────────────────────────────┤
 │  RUNTIME                                            │  ← singleton, no DOM
 │  (transport, audio, scope, state, commands)          │
 └─────────────────────────────────────────────────────┘
@@ -61,79 +61,23 @@ All stateful side effects:
 - Know about skins, themes, or layouts
 - Contain presentation logic
 
-### FrontendRuntime interface
+### FrontendRuntime
 
-```typescript
-interface FrontendRuntime {
-  // Reactive state (Svelte 5 $state internally)
-  readonly state: RadioState;
-  readonly capabilities: Capabilities;
-  readonly connection: ConnectionStatus;
-  readonly layoutPreference: 'auto' | 'lcd' | 'standard';
-  readonly isMobile: boolean;
+See `FrontendRuntime` in `frontend/src/lib/runtime/frontend-runtime.ts`.
 
-  // Controllers
-  readonly audio: AudioController;
-  readonly scope: ScopeController;
-  readonly system: SystemController;
+### Audio
 
-  // Single command dispatch entry point
-  cmd(command: string, params?: Record<string, unknown>): void;
-}
-```
+Owned by `AudioManager` (`frontend/src/lib/audio/audio-manager.ts`),
+`RxPlayer` (`frontend/src/lib/audio/rx-player.ts`), and `TxMic`
+(`frontend/src/lib/audio/tx-mic.ts`).
 
-### AudioController
+### Scope
 
-```typescript
-interface AudioController {
-  readonly rxEnabled: boolean;
-  readonly txEnabled: boolean;
-  readonly monitorMode: 'live' | 'radio' | 'mute';
-  readonly volume: number;          // 0..1
-  readonly wsConnected: boolean;
-  readonly txSupported: boolean;
+See `ScopeController` in `frontend/src/lib/runtime/scope-controller.svelte.ts`.
 
-  setMonitorMode(mode: 'live' | 'radio' | 'mute'): void;
-  setVolume(v: number): void;
-  startTx(): Promise<string | null>;
-  stopTx(): void;
-}
-```
+### System
 
-Owns: `/api/v1/audio` WS, `RxPlayer`, `TxMic`, codec negotiation, `AudioContext` lifecycle.
-
-Does not own: AF level radio command — that goes through `cmd()`.
-
-### ScopeController
-
-```typescript
-interface ScopeController {
-  readonly hardwareScopeAvailable: boolean;
-  readonly audioScopeAvailable: boolean;
-  readonly activeScope: 'hardware' | 'audio-fft' | null;
-
-  readonly scopeFrame: ScopeFrame | null;
-  readonly audioScopeFrame: AudioScopeFrame | null;
-}
-```
-
-Owns: `/api/v1/scope` and `/api/v1/audio-scope` WS connections, binary frame parsing.
-
-Presentation components consume `scopeFrame`/`audioScopeFrame` — they never open channels.
-
-### SystemController
-
-```typescript
-interface SystemController {
-  powerOn(): Promise<void>;
-  powerOff(): Promise<void>;
-  connect(): Promise<void>;
-  disconnect(): Promise<void>;
-  identifyFrequency(freqHz: number): Promise<EibiResult | null>;
-}
-```
-
-Owns: all HTTP calls to backend (`/api/v1/radio/power`, `/api/v1/eibi/identify`, etc.).
+See `SystemController` in `frontend/src/lib/runtime/system-controller.ts`.
 
 ---
 
@@ -143,68 +87,14 @@ Owns: all HTTP calls to backend (`/api/v1/radio/power`, `/api/v1/eibi/identify`,
 
 Adapters are **pure functions**. No side effects, no subscriptions, no imports from transport/audio/WS.
 
-```typescript
-type Adapter<T> = (
-  state: RadioState,
-  caps: Capabilities,
-  audio: AudioController,
-  receiver?: 'main' | 'sub',
-) => T;
-```
+### View-model contract
 
-Each adapter returns a typed view-model with:
-
-- derived display values
-- semantic callbacks (bound from runtime controllers)
-
-### Examples
-
-```typescript
-interface VfoViewModel {
-  freqHz: number;
-  mode: string;
-  filter: number;
-  dataMode: boolean;
-  isActive: boolean;
-  badges: Badge[];
-  onFreqChange: (hz: number) => void;
-  onModeChange: (mode: string) => void;
-  onFilterChange: (filter: number) => void;
-}
-
-interface RxAudioViewModel {
-  monitorMode: 'live' | 'radio' | 'mute';
-  hasLiveAudio: boolean;
-  volume: number;
-  muted: boolean;
-  onMonitorModeChange: (mode: string) => void;
-  onVolumeChange: (v: number) => void;
-}
-
-interface MeterViewModel {
-  sMeter: number;
-  swr: number | null;
-  power: number | null;
-  alc: number | null;
-  comp: number | null;
-  activeTxMeter: 'swr' | 'power' | 'alc' | 'comp';
-}
-
-interface ScopeViewModel {
-  available: boolean;
-  frame: ScopeFrame | null;
-  onTuneToFreq: (hz: number) => void;
-  onSpanChange: (span: number) => void;
-}
-```
+See `frontend/src/semantic/radio-view-model.ts` (the adapter/semantic seam)
+and its producer, `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts`.
 
 ### Adapter location
 
-`frontend/src/adapters/` — one file per domain (vfo, audio, meter, scope, rf, tx, memory, system).
-
-### What adapters replace
-
-The existing `state-adapter.ts` and `command-bus.ts` are the embryonic form of this layer. Migration should refactor them into the adapter pattern, not duplicate alongside.
+`frontend/src/lib/runtime/adapters/`.
 
 ---
 
@@ -224,27 +114,13 @@ Rules:
 
 ### Semantic component list
 
-| Component | Props (key fields) | Callbacks |
-|---|---|---|
-| `VfoDisplay` | freq, mode, filter, dataMode, badges | onFreqChange, onModeChange, onFilterChange |
-| `RxAudioControl` | monitorMode, hasLiveAudio, volume, muted | onMonitorModeChange, onVolumeChange |
-| `TxControl` | pttActive, txEnabled, txSupported | onPttToggle, onStartTx, onStopTx |
-| `MetersSurface` | sMeter, swr, power, alc, comp | — |
-| `ScopeSurface` | available, frame | onTuneToFreq, onSpanChange |
-| `BandSelector` | currentBand, bands | onBandChange |
-| `ModeSelector` | currentMode, modes | onModeChange |
-| `FilterSelector` | currentFilter, filters | onFilterChange |
-| `RfFrontEnd` | att, preamp, nb, nr, rfGain, squelch | onChange per field |
-| `DspControl` | notch, tpf, contour | onChange per field |
-| `MemoryControl` | channels, activeChannel | onRecall, onStore, onClear |
-| `StatusIndicator` | connected, radioReady, wsHealth | onReconnect |
+See `frontend/src/semantic/` for the current set.
 
 ### Svelte 5 pattern
 
 Semantic components use `children: Snippet` or typed props — no `<slot>`. Skins provide concrete rendering.
 
 ```svelte
-<!-- semantic/RxAudioControl.svelte -->
 <script lang="ts">
   interface Props {
     monitorMode: 'live' | 'radio' | 'mute';
@@ -271,118 +147,25 @@ Semantic components use `children: Snippet` or typed props — no `<slot>`. Skin
 | Knob | Changes | Mechanism | Example |
 |---|---|---|---|
 | **Theme** | Colors, fonts, spacing, shadows | CSS custom properties | `dracula.css`, `nord.css`, `crt-green.css` |
-| **Skin** | Visual implementation of semantic components | Concrete Svelte components | `AmberFrequency` vs `IndustrialFrequency` |
-| **Layout** | Spatial arrangement of components on screen | Grid/flex composition in skin top-level | `DesktopGrid` vs `MobileTabs` vs `LcdColumn` |
+| **Skin** | Visual implementation of semantic components | Concrete Svelte components | (skin-specific) |
+| **Layout** | Spatial arrangement of components on screen | Grid/flex composition in skin top-level | (skin-specific) |
 
 **Theme** does not change component identity.
 **Skin** does not change behavior contracts.
 **Layout** does not change transport ownership.
 
-### Skin implementation (Svelte 5)
-
-Each skin is a concrete Svelte component receiving `FrontendRuntime` as its single prop:
-
-```svelte
-<!-- skins/lcd-cockpit/LcdCockpitSkin.svelte -->
-<script lang="ts">
-  import type { FrontendRuntime } from '../../runtime/types';
-  import { toVfoProps, toRxAudioProps, toMeterProps } from '../../adapters';
-
-  import AmberFrequency from './AmberFrequency.svelte';
-  import AmberMeter from './AmberMeter.svelte';
-  import AmberAudioStrip from './AmberAudioStrip.svelte';
-  import LcdFrame from './LcdFrame.svelte';
-
-  interface Props { runtime: FrontendRuntime }
-  let { runtime }: Props = $props();
-
-  const vfo = $derived(toVfoProps(runtime.state, runtime.capabilities, runtime.audio, 'main'));
-  const audio = $derived(toRxAudioProps(runtime.state, runtime.capabilities, runtime.audio));
-  const meter = $derived(toMeterProps(runtime.state, runtime.capabilities));
-</script>
-
-<LcdFrame>
-  <AmberFrequency freq={vfo.freqHz} mode={vfo.mode} />
-  <AmberMeter sMeter={meter.sMeter} />
-  <AmberAudioStrip
-    mode={audio.monitorMode}
-    volume={audio.volume}
-    onModeChange={audio.onMonitorModeChange}
-    onVolumeChange={audio.onVolumeChange}
-  />
-</LcdFrame>
-```
-
 ### Skin resolution and lazy loading
 
-```typescript
-// skins/registry.ts
-type SkinId = 'desktop-v2' | 'amber-lcd' | 'mobile';
+See `SkinId`, `resolveSkinId()`, and `SKIN_LOADERS`/`loadSkin()` in
+`frontend/src/skins/registry.ts`.
 
-function resolveSkinId(ctx: {
-  capabilities: Capabilities;
-  userPreference: 'auto' | 'lcd' | 'standard';
-  isMobile: boolean;
-}): SkinId {
-  if (ctx.isMobile) return 'mobile';
-  if (ctx.userPreference === 'lcd') return 'amber-lcd';
-  if (ctx.userPreference === 'standard') return 'desktop-v2';
-  return ctx.capabilities.scope ? 'desktop-v2' : 'amber-lcd';
-}
+### Layout zones
 
-const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
-  'desktop-v2': () => import('./desktop-v2/DesktopSkin.svelte'),
-  'amber-lcd':  () => import('./lcd-cockpit/LcdCockpitSkin.svelte'),
-  'mobile':     () => import('./mobile/MobileSkin.svelte'),
-};
-```
-
-### App entry point (target)
-
-```svelte
-<!-- App.svelte -->
-<script lang="ts">
-  import { runtime } from './runtime';
-  import { resolveSkinId, loadSkin } from './skins/registry';
-
-  const skinId = $derived(resolveSkinId({
-    capabilities: runtime.capabilities,
-    userPreference: runtime.layoutPreference,
-    isMobile: runtime.isMobile,
-  }));
-
-  let SkinComponent = $state(null);
-  $effect(() => {
-    loadSkin(skinId).then(c => { SkinComponent = c; });
-  });
-</script>
-
-{#if SkinComponent}
-  <SkinComponent {runtime} />
-{:else}
-  <div class="loading">Loading...</div>
-{/if}
-```
-
-### Layout slot model
-
-Each skin's layout arranges semantic components into named zones:
-
-| Slot | Desktop V2 | LCD | Mobile |
-|---|---|---|---|
-| `header` | VfoHeader + StatusBar | StatusBar | Compact VFO + status |
-| `leftRail` | Band, mode, filter, RF groups | LeftSidebar | — (tabbed) |
-| `centerPrimary` | Hardware scope | AmberLcdDisplay | Scope or LCD |
-| `centerSecondary` | Audio FFT / waterfall | Audio FFT (if available) | — |
-| `rightRail` | Audio, DSP, TX, CW groups | RightSidebar | — (tabbed) |
-| `bottomDock` | Meters, DX cluster | — | Bottom bar |
-| `overlay` | Modals, freq entry, settings | Same | Same |
-
-Skins are not required to fill all slots. Empty slots render nothing.
+See `LayoutManifest`/`LayoutZone` in `frontend/src/presentation/layouts/contract.ts`.
 
 ### Theme architecture
 
-Unchanged from current system — 20+ CSS variable themes, applied via `data-theme` attribute:
+Unchanged from current system — CSS variable themes, applied via `data-theme` attribute:
 
 ```css
 [data-theme="dracula"] {
@@ -398,90 +181,16 @@ Themes are orthogonal to skins. Any theme can be applied to any skin (within rea
 
 ---
 
-## Target file structure
+## Top-level layout
 
-```
-frontend/src/
-├── runtime/                          # Layer 1
-│   ├── index.ts                      # createRuntime(), singleton export
-│   ├── types.ts                      # FrontendRuntime, controller interfaces
-│   ├── audio-controller.ts           # AudioController implementation
-│   ├── scope-controller.ts           # ScopeController implementation
-│   ├── system-controller.ts          # SystemController implementation
-│   ├── command-dispatcher.ts         # cmd() + optimistic patches
-│   ├── connection-monitor.ts         # health, reconnect, backoff
-│   └── capability-resolver.ts        # normalize caps into stable flags
-│
-├── adapters/                         # Layer 2
-│   ├── index.ts                      # re-export all adapters
-│   ├── vfo.ts
-│   ├── audio.ts
-│   ├── meter.ts
-│   ├── scope.ts
-│   ├── rf.ts
-│   ├── tx.ts
-│   ├── memory.ts
-│   └── system.ts
-│
-├── semantic/                         # Layer 3
-│   ├── VfoDisplay.svelte
-│   ├── RxAudioControl.svelte
-│   ├── TxControl.svelte
-│   ├── MetersSurface.svelte
-│   ├── ScopeSurface.svelte
-│   ├── BandSelector.svelte
-│   ├── ModeSelector.svelte
-│   ├── FilterSelector.svelte
-│   ├── RfFrontEnd.svelte
-│   ├── DspControl.svelte
-│   ├── MemoryControl.svelte
-│   └── StatusIndicator.svelte
-│
-├── primitives/                       # Shared visual atoms
-│   ├── SegmentedButton.svelte
-│   ├── Knob.svelte
-│   ├── LinearMeter.svelte
-│   ├── SevenSegment.svelte
-│   ├── FrequencyDigits.svelte
-│   ├── CanvasRenderer.svelte
-│   ├── PanelFrame.svelte
-│   └── StatusPill.svelte
-│
-├── skins/                            # Layer 4 — visual implementations
-│   ├── registry.ts                   # resolveSkinId(), loadSkin()
-│   ├── desktop-v2/
-│   │   ├── DesktopSkin.svelte
-│   │   ├── DesktopVfo.svelte
-│   │   ├── DesktopMeter.svelte
-│   │   └── ...
-│   ├── lcd-cockpit/
-│   │   ├── LcdCockpitSkin.svelte
-│   │   ├── AmberFrequency.svelte
-│   │   ├── AmberMeter.svelte
-│   │   └── ...
-│   └── mobile/
-│       ├── MobileSkin.svelte
-│       ├── CompactVfo.svelte
-│       └── ...
-│
-├── themes/                           # CSS tokens
-│   ├── tokens.css                    # base design tokens
-│   ├── dark.css
-│   ├── dracula.css
-│   ├── nord.css
-│   └── ...
-│
-├── stores/                           # Svelte 5 reactive stores (kept)
-│   └── ...                           # migrated into runtime/ over time
-│
-├── lib/                              # Shared utilities (non-runtime)
-│   ├── renderers/                    # Canvas engines (framework-agnostic)
-│   ├── utils/                        # Formatting, smoothing, etc.
-│   ├── data/                         # ARRL band plan, etc.
-│   └── gestures/                     # Touch gesture recognizers
-│
-└── App.svelte                        # Entry point → skin resolver
-```
+- Runtime: `frontend/src/lib/runtime/`
+- Adapters: `frontend/src/lib/runtime/adapters/`
+- Semantic components: `frontend/src/semantic/`
+- Skins: `frontend/src/skins/`
+- Layout manifests: `frontend/src/presentation/layouts/`
+- Themes: `frontend/src/components-v2/theme/`
+- Primitives: `frontend/src/primitives/`
+- Legacy layouts/panels (not yet replaced): `frontend/src/components-v2/`
 
 ---
 
@@ -491,7 +200,7 @@ These must hold at all times after migration. Violation = regression.
 
 ### INV-1: Single RX playback path
 
-All layouts route through the same `AudioController`. Codec negotiation, WS subscription, decoding, volume, and mute are layout-independent.
+All layouts route through the same audio subsystem. Codec negotiation, WS subscription, decoding, volume, and mute are layout-independent.
 
 ### INV-2: Single scope ownership per type
 
@@ -503,7 +212,7 @@ Absence of hardware scope must never alter audio behavior. LCD fallback is a pre
 
 ### INV-4: Capability gating precedes presentation
 
-Panels do not independently decide whether backend capability exists. Runtime/adapters expose stable booleans (`hasLiveAudio`, `hasHardwareScope`, `hasTx`).
+Panels do not independently decide whether backend capability exists. Runtime/adapters expose stable booleans (`hasLiveAudio`, `hardwareScopeAvailable`, `hasTx`).
 
 ### INV-5: Mount/unmount does not change transport
 
@@ -511,7 +220,13 @@ Swapping layouts or mounting/unmounting visual components must not start or stop
 
 ### INV-6: No runtime imports in presentation
 
-Presentation components (semantic, skins, primitives) must not import from `runtime/`, `$lib/transport/`, or `$lib/audio/audio-manager`. Enforced by eslint.
+Presentation components (semantic, skins, primitives) must not import from
+`runtime/`, `$lib/transport/`, or `$lib/audio/audio-manager`. Enforced by
+eslint; see `docs/internals/skins-presentation-boundary-gate.md` (MOR-2034)
+for what is actually checked. Currently violated by
+`frontend/src/components-v2/layout/RadioLayout.svelte`, `LcdLayout.svelte`,
+and `MobileRadioLayout.svelte`, which import `runtime` from `$lib/runtime`
+directly.
 
 ---
 
@@ -535,24 +250,10 @@ Presentation components (semantic, skins, primitives) must not import from `runt
 | Skins | `runtime/` (except `FrontendRuntime` type via props), transport, audio |
 | Primitives | Runtime, adapters, transport, audio, stores |
 
-### eslint enforcement
+### Enforcement
 
-```jsonc
-{
-  "rules": {
-    "no-restricted-imports": ["error", {
-      "patterns": [{
-        "group": ["$lib/transport/*", "$lib/audio/audio-manager"],
-        "message": "Use adapter props. See ADR 2026-04-12."
-      }]
-    }]
-  },
-  "overrides": [{
-    "files": ["src/runtime/**", "src/adapters/**"],
-    "rules": { "no-restricted-imports": "off" }
-  }]
-}
-```
+See `frontend/eslint.config.js` and
+`docs/internals/skins-presentation-boundary-gate.md` (MOR-2034).
 
 ---
 
@@ -560,7 +261,7 @@ Presentation components (semantic, skins, primitives) must not import from `runt
 
 ### 1. Skin imports runtime directly
 
-Turns skins into hidden behavior forks. Skin receives `FrontendRuntime` as a prop from `App.svelte` — it never imports the singleton.
+Turns skins into hidden behavior forks. Skin receives `FrontendRuntime` as a prop from `App.svelte` — it never imports the singleton. Not upheld today by the legacy layout components named in INV-6 above.
 
 ### 2. Theme contains behavior flags
 
@@ -584,27 +285,17 @@ Scope frame parsing, audio header parsing — all binary protocol logic lives in
 
 ---
 
-## Migration coexistence
+## Migration status
 
-During Phases 4-5, old and new code coexist:
-
-1. New skins live in `skins/` — existing `components-v2/` untouched initially
-2. Feature flag `?skin=unified` in `App.svelte` activates new path
-3. Old layouts remain default until parity gate passes
-4. Phase 6 removes old layouts after confirmation
+See `docs/plans/2026-07-25-ui-composition-architecture-v3.md` (extends this
+ADR) and `frontend/src/presentation/layouts/contract.ts` for how skins are
+actually composed today.
 
 ---
 
 ## Evidence gates
 
-| After phase | Gate |
-|---|---|
-| Phase 0 | RX audio failure classified with evidence; eslint guardrails active |
-| Phase 2 | One controller-owned audio/scope path; no presentation-owned WS connections |
-| Phase 3 | Semantic component contracts stable for both desktop and LCD |
-| Before Phase 6 | All 4 capability scenarios pass; Scenario B (`scope=false + audio=true`) explicitly verified; manual hardware validation |
-
-These phase gates cover the migration. `docs/internals/skins-presentation-boundary-gate.md`
+`docs/internals/skins-presentation-boundary-gate.md`
 (MOR-2034) is the permanent, post-migration release-gate check for this ADR's
 central guarantee — a skin depends only on the presentation layer, and never
 derives radio truth locally — naming the mechanisms that enforce it and
@@ -612,28 +303,10 @@ recording where their reach currently ends.
 
 ---
 
-## Relationship to existing code
-
-| Current code | Target equivalent | Migration action |
-|---|---|---|
-| `lib/audio/audio-manager.ts` | `runtime/audio-controller.ts` | Refactor into controller with same internal logic |
-| `components-v2/wiring/state-adapter.ts` | `adapters/*.ts` | Split into per-domain adapters |
-| `components-v2/wiring/command-bus.ts` | `runtime/command-dispatcher.ts` + adapter callbacks | Extract command dispatch to runtime, bind callbacks in adapters |
-| `lib/stores/*.svelte.ts` | `runtime/` internal state | Stores become implementation detail of runtime |
-| `lib/transport/ws-client.ts` | `runtime/` internal | Transport is private to runtime |
-| `components-v2/layout/RadioLayout.svelte` | `skins/desktop-v2/DesktopSkin.svelte` | Rewrite as skin |
-| `components-v2/layout/LcdLayout.svelte` | `skins/lcd-cockpit/LcdCockpitSkin.svelte` + `skins/lcd-scope/LcdScopeSkin.svelte` | Rewrite as skin |
-| `components-v2/panels/*.svelte` | `semantic/*.svelte` + `skins/*/` visual parts | Split semantic contract from visual implementation |
-| `components-v2/theme/` | `themes/` | Move as-is |
-
----
-
 ## Summary
 
 This architecture guarantees:
 
-- **New skin** = new directory in `skins/`, zero changes to runtime/adapters/semantic
 - **New radio capability** = changes in runtime + adapter, zero changes to skins
-- **Audio bug** = fixed in one place (`runtime/audio-controller.ts`), works identically in all skins
-- **Behavioral parity** = enforced architecturally (one runtime, one adapter set) and by eslint
+- **Behavioral parity** = enforced architecturally (one runtime, one adapter set) and by eslint (`docs/internals/skins-presentation-boundary-gate.md`, MOR-2034)
 - **No code duplication** = protocol parsing once in runtime, semantic logic once in adapters, visual variants only in skins

--- a/docs/plans/2026-04-12-target-frontend-architecture.md
+++ b/docs/plans/2026-04-12-target-frontend-architecture.md
@@ -10,8 +10,6 @@
 
 Single authoritative reference for the unified frontend architecture. All implementation issues (`#647`–`#653`) should be judged against this document.
 
-This ADR is executable: it contains concrete TypeScript interfaces, Svelte 5 patterns, file layout, and enforcement rules. It is not a vision doc — it is a build spec.
-
 ---
 
 ## Architecture overview
@@ -21,7 +19,7 @@ Four layers, strict one-way dependency:
 ```
 ┌────────────────────────────────────────────────────┐
 │  SKIN + LAYOUT + THEME                              │  ← visual shell
-│  (amber-lcd, desktop-v2, mobile, future skins)      │
+│  (one Svelte component per SkinId — see Layer 4)   │
 ├──────────────────────────────────────────────────────┤
 │  SEMANTIC COMPONENTS                                │  ← behavior contracts
 │  (VfoSurface, MetersSurface, RxAudioSurface, ...)   │
@@ -94,7 +92,9 @@ and its producer, `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts
 
 ### Adapter location
 
-`frontend/src/lib/runtime/adapters/`.
+`frontend/src/lib/runtime/adapters/`, plus `frontend/src/lib/runtime/props/panel-props.ts`
+— `toVfoProps`, `toMeterProps`, and `toRxAudioProps` (the diagram's own
+examples above) are exported from the latter, not the former.
 
 ---
 
@@ -223,10 +223,7 @@ Swapping layouts or mounting/unmounting visual components must not start or stop
 Presentation components (semantic, skins, primitives) must not import from
 `runtime/`, `$lib/transport/`, or `$lib/audio/audio-manager`. Enforced by
 eslint; see `docs/internals/skins-presentation-boundary-gate.md` (MOR-2034)
-for what is actually checked. Currently violated by
-`frontend/src/components-v2/layout/RadioLayout.svelte`, `LcdLayout.svelte`,
-and `MobileRadioLayout.svelte`, which import `runtime` from `$lib/runtime`
-directly.
+for what is actually checked.
 
 ---
 
@@ -261,7 +258,7 @@ See `frontend/eslint.config.js` and
 
 ### 1. Skin imports runtime directly
 
-Turns skins into hidden behavior forks. Skin receives `FrontendRuntime` as a prop from `App.svelte` — it never imports the singleton. Not upheld today by the legacy layout components named in INV-6 above.
+Turns skins into hidden behavior forks. Skin receives `FrontendRuntime` as a prop from `App.svelte` — it never imports the singleton.
 
 ### 2. Theme contains behavior flags
 

--- a/docs/plans/2026-07-25-ui-composition-discovery-and-parity.md
+++ b/docs/plans/2026-07-25-ui-composition-discovery-and-parity.md
@@ -420,6 +420,5 @@ change these dependencies or reopen accepted architecture.
   `frontend/src/lib/transport/__tests__/ws-client.test.ts:317-469`;
   `frontend/tests/e2e/i18n/i18n-visual.spec.ts:260-318`.
 - Prior intent: `docs/plans/2026-04-12-target-frontend-architecture.md:1-52`;
-  `docs/plans/2026-04-12-target-frontend-architecture.md:483-515`;
   `docs/plans/2026-04-11-parity-matrix.md:20-120`;
   `docs/plans/2026-07-25-ui-composition-architecture-v3.md:88-139`.


### PR DESCRIPTION
## Summary

`docs/plans/2026-04-12-target-frontend-architecture.md` is the ADR
`CLAUDE.md`'s "Frontend layering (enforce)" section cites as live. MOR-2044
reported it still showed a 3-member `SkinId`; a full read against the code
found the staleness was not limited to that one enumeration.

**The 3-member `SkinId` claim was true of the ADR's text, and false of the
code.** The ADR wrote `type SkinId = 'desktop-v2' | 'amber-lcd' | 'mobile'`;
`frontend/src/skins/registry.ts` defines `SkinId` as `'desktop-v2' |
'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' |
'sdr-test'`.

## Scope: 5 files, one unit of work

`docs/plans/2026-04-12-target-frontend-architecture.md` (the ADR itself) is
440 of the changed lines. The other four exist *because* of that change and
would be false the moment it merges without them:

- `docs/architecture/building-a-skin.md` and `docs/guide/web-ui.md` each
  warned readers that specific sections of this ADR were stale and named
  MOR-2044 as the ticket tracking the fix — this PR *is* that fix, so those
  warnings describe a state this PR ends.
- `docs/plans/2026-07-25-ui-composition-discovery-and-parity.md` cited this
  ADR at a line range that only exists at the ADR's pre-PR length (639
  lines); the ADR is 309 lines after this PR.
- `.github/scripts/doc-citation-baseline.txt` shrank by exactly the one
  pair the citation deletion above made obsolete, via
  `check-doc-citations.sh --regenerate` (never hand-edited).

Net: 58 insertions, 404 deletions — under both soft-threshold numbers (6
files / 600 lines), so no owner exception is being requested; noted here
only because the reviewer round anticipated crossing it.

## Approach

Per owner ruling (`CLAUDE.md`, "Delete before you narrow; never weaken"):
a claim that is false, stale, or ambiguous is deleted, not corrected in
place. Interface/table snapshots that had drifted from the code become
pointers to the owning file + symbol (e.g. `SkinId` → point at
`frontend/src/skins/registry.ts`, not a corrected membership list — a
corrected list goes stale the same way the original did). Sections with no
true replacement are cut outright rather than rewritten.

`docs/architecture/building-a-skin.md` is the one file here that is
explicitly named in the ruling as warranting narrowing over deletion, being
"a document written for a reader who does not have the code in front of
them" — the two sentences fixed there (see evidence table) are narrowed
rather than deleted, each checked against the file as it now reads.

## What changed, by file

### `docs/plans/2026-04-12-target-frontend-architecture.md`

Two commits, two review rounds. Sections cut with no replacement (all had
drifted from real code, verified against source — see evidence table for
what remains):

- `FrontendRuntime` / `AudioController` / `ScopeController` /
  `SystemController` hand-copied TypeScript interface blocks.
- The `Adapter<T>` generic type and four example view-model interfaces
  (`VfoViewModel`, `RxAudioViewModel`, `MeterViewModel`, `ScopeViewModel`)
  under Layer 2.
- "What adapters replace" (the state-adapter.ts/command-bus.ts migration
  narrative — both files are gone, deleted outright, not split).
- The 12-row "Semantic component list" table.
- The fictional "Skin implementation (Svelte 5)" code example.
- The "App entry point (target)" section and code example.
- The 7-row "Layout slot model" table.
- The original ASCII "Target file structure" tree (replaced by an 8-line
  bullet list of top-level roots, each independently verified).
- "Migration coexistence" (a `?skin=unified` feature flag and Phase 4-6
  plan that never existed in the code).
- The "Evidence gates" Phase 0/2/3/6 table (the still-accurate pointer to
  the MOR-2034 boundary-gate doc is kept).
- "Relationship to existing code" (8-row table + intro) in full.
- The old "New skin" and "Audio bug" Summary bullets (both named
  files/claims that don't hold).
- The eslint JSON snippet under "eslint enforcement" (rule names didn't
  match the real config).
- (Round 2, post-review) INV-6's "currently violated by" 3-file list. The
  real set is larger and comes in more than one shape: files importing
  `runtime` via the `$lib/runtime` alias (at least `AppGlobalHost.svelte`,
  `LcdLayout.svelte`, `LeftSidebar.svelte`, `MobileRadioLayout.svelte`,
  `RadioLayout.svelte`, `StatusBar.svelte`, `VfoHeader.svelte`,
  `AudioSpectrumPanel.svelte`, `AmberCockpit.svelte`, `AmberScope.svelte`,
  `SemanticRadioSurfaces.svelte`, `ScopeSettingsPopover.svelte`,
  `SpectrumToolbar.svelte`) and files importing it via a relative path
  instead (`components/spectrum/SpectrumPanel.svelte`; `Toast.svelte`
  separately imports transport, not runtime, the same way). Two of the
  alias-import files sit inside the boundary gate's own `panels/**` scope
  while the three originally named do not. No replacement count is written
  into INV-6 — a fixed number here goes stale exactly the way the 3-file
  list it replaces did, and the review round already showed one relative-
  path import that a first count of the alias form alone would miss.
- (Round 2) Anti-pattern #1's clause leaning on that same list, which also
  misdescribed the mechanism (`App.svelte` mounts the resolved skin as
  `<Presentation />` with zero props — "receives FrontendRuntime as a prop"
  is not the operative path).
- (Round 2) The architecture-overview diagram's skin-shell example line,
  which still enumerated `amber-lcd, desktop-v2, mobile` — the same
  three-member set this ticket exists to remove — two paragraphs above the
  `SkinId` fix.
- (Round 2) The Purpose-section sentence claiming the ADR "contains
  concrete TypeScript interfaces" — zero ` ```typescript ` fences remain.

One correction I caught before shipping: I initially drafted "the
`VfoViewModel`/`RxAudioViewModel`/`MeterViewModel`/`ScopeViewModel`
interfaces this ADR proposed do not exist in the code." That's wrong for
two of the four — `VfoViewModel` and `RxAudioViewModel` are real, exported
interfaces in `frontend/src/semantic/radio-view-model.ts` (MOR-1062),
consumed by `frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts`.
Only `MeterViewModel`/`ScopeViewModel` (singular) are absent verbatim — the
codebase evolved them into `MetersViewModel` (plural) and
`ScopeDisplayViewModel`/`ScopeControlsViewModel`/`ScopeAvailabilityViewModel`
(split three ways), in that same file. This PR does not ship a corrected
interface list for that reason either — see the "View-model contract"
pointer instead.

### `docs/architecture/building-a-skin.md` (narrowed, not deleted — see above)

- Deleted the sentence warning that this ADR's "Skin implementation (Svelte
  5)" and "Skin resolution and lazy loading" code samples "do not match
  current code ... tracked stale under MOR-2044 — do not copy them." Both
  headings are now pointers with no code sample left to warn about.
- The deletion left "Everything below points at real, current source
  **instead**" with no antecedent, and a following "**Concretely:**" that
  no longer elaborated anything. Removed both connective words rather than
  inventing a new contrast.

### `docs/guide/web-ui.md`

- Deleted the "Current v2 skins vs. the planned v3 architecture" admonition
  telling readers to "treat that document as a plan, not as shipped
  behavior" and describing a "workspace/slot layout model" the ADR no
  longer describes. Checked the surrounding section afterward: nothing else
  refers back to the admonition or to "the planned v3 architecture."
- `frontend/README.md`'s own ADR reference was checked and carries no such
  warning to begin with (a bare pointer, one line) — left untouched.

### `docs/plans/2026-07-25-ui-composition-discovery-and-parity.md`

- Deleted the `docs/plans/2026-04-12-target-frontend-architecture.md:483-515`
  citation (valid at the ADR's pre-PR 639 lines, past EOF at 309). The
  `:1-52` citation in the same list was checked and remains valid.

### `.github/scripts/doc-citation-baseline.txt`

- Shrunk via `check-doc-citations.sh --regenerate`: removed 1, added 0.
  Never hand-edited.

## What I found stale but deliberately did not fix here

- The real skin-composition mechanism (a layout manifest/zone system in
  `frontend/src/presentation/layouts/`, with `RadioLayout.svelte` /
  `LcdLayout.svelte` / `MobileRadioLayout.svelte` suppressing legacy
  `components-v2/panels/*` per declared zone) is a substantial addition
  beyond this ADR's original design. `docs/plans/2026-07-25-ui-composition-architecture-v3.md`
  already extends this ADR for exactly this territory (its own header says
  `**Extends:** docs/plans/2026-04-12-target-frontend-architecture.md`),
  and a fuller, canonical description belongs to MOR-1101's publication
  effort, not to a second description bolted onto this file.
- `frontend/src/lib/runtime/props/panel-props.ts` also carries real,
  heavily-used adapter functions (`toVfoProps`, `toMeterProps`,
  `toRxAudioProps` — the architecture-overview diagram's own examples,
  confirmed exported from that file, not from `lib/runtime/adapters/`).
  "Adapter location" now names both files rather than asserting
  `lib/runtime/adapters/` is the only one.
- Whether `docs/internals/skins-presentation-boundary-gate.md`'s Gate 1
  scope should also cover `components-v2/layout/**` and
  `components/spectrum/**` (not just `panels/**`, which is where two of
  the alias-import violators sit) is a question for that gate document's
  owner, not this ADR.

## CLAUDE.md pointer

Not touched (owned by another in-flight PR at the time; that PR has since
merged, but a content review of `CLAUDE.md` itself is out of this ticket's
scope). No change needed: the ADR stays at the same path
(`docs/plans/2026-04-12-target-frontend-architecture.md`), so `CLAUDE.md`'s
citation of that path remains correct; only the ADR's content changed.

## Gates

```
$ .github/scripts/check-doc-citations.sh
Doc-citation gate: clean (845 grandfathered citations).

$ .github/scripts/check-doc-citations.sh --check-growth origin/main
Doc-citation gate: baseline did not grow relative to a3b9c7951b283f8e506b71306eba01174b5a22b8.

$ .github/scripts/check-doc-citations.sh --check-links
Doc-link gate: clean (2 grandfathered dead link(s), repo-wide *.md scope).

$ .github/scripts/check-doc-citations.sh --check-links --check-growth origin/main
Doc-link gate: baseline did not grow relative to a3b9c7951b283f8e506b71306eba01174b5a22b8.
```

No test suite was run (documentation-only change; not requested for this
ticket). `main`'s own `Tests (quick)` is independently red at the time of
this PR for an unrelated hang in `tests/test_icom7610_serial_radio.py`
(MOR-2081, owned elsewhere) — not something this PR touches or causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Corrections after round-2 review (PR body only, no commit)

Two measured figures in this body were wrong and are corrected above:

* the ADR's length was given as **640 → 313**; measured, it is **639 on `main` and 309 at this head**;
* a commit message in this branch states "the real count is 13" for files importing the runtime singleton. Re-derived shape-neutrally — counting relative-path imports as well as `$lib/` alias imports — it is **21 non-test files, 15 of them outside `lib/`**. The alias-keyed enumeration missed members. Nothing in the ADR depends on this: it carries no count, verified by exhaustive sweep, so the file is unaffected either way.

The squash commit message is composed explicitly at merge and carries neither wrong figure.
