### PR TITLE
test(MOR-2070): delete overclaiming prose from the layout-coverage check

### DIFF
--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -57,7 +57,7 @@ import type { LayoutManifest } from '../../layouts/contract';
 // The shared structural `LayoutManifest` guard every `*-declarability.test.ts`
 // suite in `../../layouts/__tests__/` already derives its own inventory with
 // (e.g. `antenna-declarability.test.ts`'s `ALL`) — reused here rather than
-// reimplemented, per MOR-2070's instruction not to duplicate it.
+// reimplemented.
 import { isLayoutManifest } from '../../layouts/__tests__/manifest-guard';
 
 /** Structural `DesignLanguageManifest` guard for filtering the barrel's
@@ -122,7 +122,7 @@ describe('every shipped design-language manifest declares at least one compatibl
  * `layoutCompatibility` names it — a `compatible: true` entry and a
  * `compatible: false` entry both count equally as evidence a decision was
  * made, even though only `true` lets `designLanguageActivation` actually
- * activate for it (`fieldline`'s `dual-receiver-cockpit: false` entry above
+ * activate for it (`fieldline`'s `dual-receiver-cockpit: false` entry
  * is exactly this: a decision, not a silent gap).
  *
  * This is enforced as a vitest assertion, not a runtime warning like
@@ -130,11 +130,9 @@ describe('every shipped design-language manifest declares at least one compatibl
  * manifest only ever enters this repository through a PR, and this suite
  * runs on every such PR through `quick.yml`'s frontend path filter (any
  * change under `frontend/**` runs `npx vitest run` in that workflow's
- * frontend block) — so a layout that reached production without first
- * passing this file's own assertions below does not happen here, and a
- * runtime-only check would fire no earlier than a test already does.
+ * frontend block).
  */
-describe('every layout is design-language-listed or explicitly exempt (MOR-2070)', () => {
+describe('every barrel-exported layout is design-language-listed or explicitly exempt (MOR-2070)', () => {
   // [id, manifest] pairs, derived structurally from the layouts barrel's
   // export surface — never hand-listed, the same discipline `SHIPPED_MANIFESTS`
   // above follows on the language side, and the same guard (`isLayoutManifest`)


### PR DESCRIPTION
## Summary

Four prose cuts in `frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts`, per the repo-wide owner ruling (2026-08-31): wrong/stale prose is deleted, not corrected or narrowed. No production or test logic changes — deletions only, except one describe-title rewording (item 4).

- Deleted the false-attribution clause "per MOR-2070's instruction not to duplicate it" — the ticket text contains no such instruction (PR #2904 reviewer finding).
- Deleted the false word "above" from the `fieldline`/`dual-receiver-cockpit: false` parenthetical — that entry lives in `declarations.ts`, not earlier in this file (PR #2904 reviewer finding).
- Deleted the tail claiming a layout that skipped this file's assertions "does not happen here" and that a runtime check "would fire no earlier than a test already does" — both falsified by MOR-2077's measured counterexample: a manifest registered via a bare side-effect import (not re-exported through the barrel) is invisible to this file's barrel-derived `ALL_LAYOUTS`, so its assertions never run on it even though it is live, and for exactly that class a runtime check would fire earlier.
- Renamed the describe title from "every layout is..." to "every barrel-exported layout is..." — `ALL_LAYOUTS` is derived from `Object.values(layoutDeclarationsBarrel).filter(isLayoutManifest)`, i.e. exactly the barrel's exports, not every layout that exists (MOR-2077).

## Gates run (frontend/)

- `npx vitest run src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts` — 1 file, 18 tests passed; renamed describe title confirmed in verbose output.
- `npm run check` — 4606 files, 0 errors, 0 warnings.
- `npm run lint` — clean, no output.
- `npm run i18n:check` — OK (3 locale files, 274 source keys); only pre-existing informational notes about missing ja-JP/ru-RU translation keys, unrelated to this change.
- Full vitest/build skipped: diff touches only comment lines (`//`, ` * `) and one `describe()` string literal used solely as a test-display name — no executable code changed.

## Size

1 file, 4 insertions / 6 deletions — well under both guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)