### PR TITLE
fix(validation): drop the stale SET-only rationale from the T9 bsr family

### DIFF
--- a/src/rigplane/validation/registry/_assembly.py
+++ b/src/rigplane/validation/registry/_assembly.py
@@ -42,7 +42,7 @@ REGISTRY: tuple[CheckSpec, ...] = (
     # stable-sort by level so new checks slot in without reordering 1-21) ---
     + _TONE_CHECKS  # T7: repeater_tone, tone_freq, tsql, tsql_freq
     + _VFO_CHECKS  # T8: split, vfo_slot, dual_watch
-    + _MEMORY_CHECKS  # T9: bsr (manual; CI-V memory surface is SET-only)
+    + _MEMORY_CHECKS  # T9: bsr (manual)
     + _SYSTEM_CHECKS  # T10: system clock, key_speed, vox, dial_lock
     + _SCOPE_CHECKS  # T11 (MOR-646): scope-control SET commands (cmd 0x27)
 )

--- a/src/rigplane/validation/registry/_memory.py
+++ b/src/rigplane/validation/registry/_memory.py
@@ -1,14 +1,13 @@
 """Memory / band-stack checks.
 
 Command-coverage family T9 (MOR-644). This family is read-mostly by charter,
-but the Icom CI-V memory surface is SET-only on the IC-7610: ``get_memory_mode``,
-``get_memory_contents`` and ``get_bsr`` exist on the runtime but raise
-``NotImplementedError`` (commands 0x08 / 0x1A 0x00 / 0x1A 0x01 have no GET
-variant per the CI-V Reference Manual), and the write ops (``set_memory_mode``,
-``memory_to_vfo``, ``set_bsr``) cannot be restored without a readback — i.e.
-they are not RMVR-safe. The only honest automated representation is a MANUAL
-check; the rest of the family is deferred until a radio with memory readback
-lands (see PR body).
+but ``CoreRadio.get_memory_mode`` and ``CoreRadio.get_memory_contents`` raise
+``NotImplementedError`` (pinned by the ``*_still_raises_not_implemented``
+tests in tests/test_memory_commands.py), so ``set_memory_mode`` and
+``memory_to_vfo`` have no readback and memory-channel checks stay deferred.
+``CoreRadio.get_bsr`` works (MOR-681); ``bsr.select`` stays MANUAL because it
+asks the operator to confirm the band display changed, and whether an
+automated BSR check should exist is an open decision — issue #2910.
 """
 
 from __future__ import annotations
@@ -17,7 +16,6 @@ from rigplane.validation.registry._types import CheckKind, CheckSpec, ValueRule
 from rigplane.validation.schema import FailureDomain, ValidationLevel
 
 CHECKS: tuple[CheckSpec, ...] = (
-    # bsr.select — manual: CI-V band-stack write is SET-only (no readback).
     CheckSpec(
         check_id="bsr.select",
         capability="bsr",
@@ -26,8 +24,8 @@ CHECKS: tuple[CheckSpec, ...] = (
         failure_domain=FailureDomain.COMMAND_EXECUTION,
         summary=(
             "Operator verifies band-stack register select/recall on the rig; "
-            "the CI-V command is SET-only (no GET variant) so automated "
-            "readback is impossible."
+            "the prompt confirms the rig's band display changed, which a "
+            "register readback does not confirm."
         ),
         protocol="bsr",
         get_op=None,

--- a/tests/test_memory_commands.py
+++ b/tests/test_memory_commands.py
@@ -352,6 +352,26 @@ class TestIcomRadioMemoryMethods:
         assert frame_arg[4] == 0x1A
         assert frame_arg[5] == 0x01
 
+    @pytest.mark.asyncio
+    async def test_get_memory_mode_still_raises_not_implemented(self) -> None:
+        """Pins the T9 registry rationale (validation/registry/_memory.py) for get_memory_mode."""
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio()
+        bound = IcomRadio.get_memory_mode.__get__(radio, type(radio))
+        with pytest.raises(NotImplementedError):
+            await bound()
+
+    @pytest.mark.asyncio
+    async def test_get_memory_contents_still_raises_not_implemented(self) -> None:
+        """Pins the T9 registry rationale (validation/registry/_memory.py) for get_memory_contents."""
+        from rigplane.radio import IcomRadio
+
+        radio = self._make_radio()
+        bound = IcomRadio.get_memory_contents.__get__(radio, type(radio))
+        with pytest.raises(NotImplementedError):
+            await bound(1)
+
 
 # ---------------------------------------------------------------------------
 # Band-stack READ (get_bsr) — MOR-681


### PR DESCRIPTION
## What

Found while preparing cmd-map batch 4 (#2906), out of scope there. The T9 memory/band-stack family (`validation/registry/_memory.py`) recorded a rationale that has been false since MOR-681 (#1827): its module docstring, the `bsr.select` `CheckSpec.summary`, and two comments claimed `get_bsr` raises `NotImplementedError` and that CI-V `0x1A 0x01` has no GET variant — while `runtime/radio.py: CoreRadio.get_bsr` issues that read and parses the reply, pinned by `tests/test_memory_commands.py::TestIcomRadioGetBsr` (`test_get_bsr_no_longer_raises_not_implemented`, `test_get_bsr_ic7610_still_works`).

Per the CLAUDE.md prose rules (narrow before delete; delete before weaken):

- **Deleted**: the false `get_bsr`/"no GET variant" claims, the false `# ... SET-only (no readback)` comment above the spec, the "only honest automated representation" totality, the dead-end "(see PR body)" reference, and the over-broad "CI-V memory surface is SET-only" parenthetical in `_assembly.py`.
- **Narrowed and tied**: `get_memory_mode` / `get_memory_contents` still raise `NotImplementedError` (verified in `runtime/radio.py`; now pinned by two new tests, `test_get_memory_mode_still_raises_not_implemented` / `test_get_memory_contents_still_raises_not_implemented`, so the registry rationale fails loudly if those reads ever land — the exact silent-rot mechanism that let the `get_bsr` claim survive MOR-681). `bsr.select` stays MANUAL: it is an operator-perception check — the prompt (`validation/hardware.py: _PERCEPTION_PROMPTS`) confirms the band display changed, which no register readback confirms.
- **Not changed**: classification, kinds, ops, runtime behavior. Whether an automated BSR check should now exist (READ_ONLY probe or RMVR via a named handler — the generic runner cannot drive `get_bsr(band, register)`) is an owner design decision, tracked in #2910. The dated cat-audit snapshots (`docs/validation/cat-audits/`) are left untouched; `ic7300.md` already records the correction in its follow-up table.

## Verification

- Baseline at 2898ce46: the 4 affected test files → 128 passed. After: **130 passed** (128 + 2 new pins); `ruff check` and `ruff format --check` clean.
- Mutation check on the new pins: making either getter return a value instead of raising fails its pin test (`DID NOT RAISE`); `radio.py` restored clean afterwards.
- mypy not run locally: quick.yml gates mypy only behind the frontend path filter, which this diff does not match.
- Full suite: via this PR's quick.yml run (core filter matches `src/**` and `tests/**`).

Refs #2910

🤖 Generated with [Claude Code](https://claude.com/claude-code)