### PR TITLE
docs: correct stale "no manifest declares" zone comments

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -566,16 +566,23 @@ describe('the semantic receiver deck carries the VFO ops again (MOR-1321)', () =
  * same `declaredSurfaces(manifest)` set `RadioLayout` already derives down to
  * `LeftSidebar`, `RightSidebar` and `StatusBar`.
  *
- * Nothing renders differently today (no manifest declares any of these zones),
- * which is the whole point: the risky plumbing lands once, independently
- * pinned, and each zone slice after it is a two-file manifest edit. The ONE
+ * Nothing rendered differently WHEN THIS LANDED — no manifest declared any of
+ * these zones yet — which was the whole point: the risky plumbing lands once,
+ * independently pinned, and each zone slice after it is a two-file manifest
+ * edit. Those slices have since landed and `desktop-v2` declares every one of
+ * these zones (S6a/S7/S8/S9), so the channel is LIVE on the flagship
+ * skin rather than inert. The ONE
  * exception is the settings modal's SPLIT/A↔B/A=B row, which gates on the
  * already-true `semanticDeck` — a real, deliberate change, pinned by its own
  * named test below rather than folded into the inertness claim.
  *
- * The probes are `desktop-v2`'s REAL manifest plus exactly ONE zone — the
- * literal shape S6a/S7/S8/S9 will land — so a row that fails here is a
- * statement about the channel and not about a hand-built fixture.
+ * The probe apparatus this paragraph used to describe — `desktop-v2`'s REAL
+ * manifest plus exactly ONE synthetic zone — is GONE. Every surface graduated
+ * to a real declaration, so `ZONES` below is an empty literal and THIS
+ * describe registers no zone probe of its own (that literal's own docstring
+ * records why it was left empty rather than deleted). Each graduate's coverage
+ * moved to a describe asserting the REAL registration, which is the stronger
+ * statement.
  */
 describe('the legacy-twin suppression channel (MOR-1364, S6-pre)', () => {
   /** Every panel id either sidebar can host. Without these the pins would pass

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -942,11 +942,21 @@
     MOR-1265. STRUCTURAL gate: the surface mounts only when the view model
     actually carries the group, so a radio the MOR-1244 evidence gate
     declined renders the pre-1265 element shape exactly (pinned in
-    `__tests__/semantic-tx-aux-wiring.component.test.ts`). Bare in BOTH
-    compositions and with no `data-zone-id`: `'txAux'` is merely declarable
-    by a manifest after this slice; no manifest declares a txAux zone yet,
-    and binding one here would put a zone id in the DOM that no layout
-    asked for (the MOR-1069 lesson). `view?.txAux` (rather than the caller
+    `__tests__/semantic-tx-aux-wiring.component.test.ts`).
+
+    CORRECTION: the sentences that stood here described a bare, unzoned mount
+    in BOTH compositions because `'txAux'` was merely DECLARABLE. That held
+    only until MOR-1336 (S4), which routed this surface through the generic
+    `zoned()` path below AND declared the zone on both sides of the
+    composition split — `desktop-declarations.ts` (single, the flagship skin)
+    and `dual-receiver-cockpit.ts` (dual) each carry
+    `{ id: 'tx-aux', surfaces: ['txAux'] }`. It renders bare wherever
+    `zoneOwning()` finds no zone carrying it: under a layout that declares no
+    `tx-aux` zone, on a standalone mount that resolves no plan, OR when a
+    workspace subtraction has emptied the zone — see `zoneOwning`'s own
+    LIMITATION note above, which records that the plan is POST-subtraction and
+    that this last case is indistinguishable from the first two here.
+    `view?.txAux` (rather than the caller
     nesting this under `{#if view}`) keeps the same "never renders while
     view is null" behavior now that the surrounding structure changed
     around it (MOR-1258).
@@ -996,9 +1006,14 @@
     carries the MOR-1269 `meters` group, so a radio that reports no meters —
     or one for which no App TX authority was supplied, and therefore no honest
     TX relevance could be stated — renders the pre-1273 element shape exactly.
-    Bare and unzoned in BOTH compositions: `'meters'` becomes declarable by a
-    manifest with this slice, but no manifest declares a meters zone, and the
-    zone schema stays config-free (risk R3).
+    CORRECTION: `'meters'` became DECLARABLE with this slice, and MOR-1341
+    (S5) declared it — `desktop-declarations.ts` carries `{ id: 'meters',
+    surfaces: ['meters'] }`, and `RadioLayout.svelte` retires the legacy
+    `<MetersDockPanel>` on that declaration. The "bare and unzoned in BOTH
+    compositions" shape this paragraph described held only until S5. It still
+    renders bare in the DUAL composition, whose only layout
+    (`dual-receiver-cockpit.ts`) declares no `meters` zone. The zone schema
+    stays config-free (risk R3) either way.
 
     It takes NO authority snapshot and no intent callbacks. That is the R9
     boundary made structural: the meters are a readout, their TX truth is
@@ -1018,8 +1033,9 @@
     audio chain renders the pre-1279 element shape exactly.
 
     UNLIKE those two it is rendered in the SINGLE composition ONLY. This is the
-    first semantic surface that carries interactive controls no manifest
-    declares a zone for, and the cockpit has a hard MOR-1069 rule: every
+    first semantic surface carrying interactive controls that the DUAL
+    composition's only layout (`dual-receiver-cockpit.ts`) declares no zone
+    for, and the cockpit has a hard MOR-1069 rule: every
     focusable control lives inside a declared zone, and the rx-tx zone is LAST
     in the tab order. A control-bearing surface mounted bare would break both
     clauses at once, and the two alternatives are worse — binding a zone id no
@@ -1028,6 +1044,10 @@
     unkey button. `'rxAudio'` became DECLARABLE with this slice, so the cockpit
     gains the surface the moment its manifest declares a zone for it — a layout
     decision, separately reviewed, exactly as txAux and meters left it.
+    `desktop-v2` HAS since made that decision (MOR-1368, S9), which is why the
+    single composition mounts this surface zoned UNDER THAT LAYOUT — not under
+    `sdr-test`/`mobile`/`lcd-*`, which declare no such zone. The cockpit has
+    made no such decision either.
 
     It takes NO authority snapshot: nothing here is TX truth. The intents are
     the shipped command bus, wired above.
@@ -1073,8 +1093,11 @@
     if no manifest anywhere had declared the zone yet; it hadn't been updated
     after S7 landed, and that staleness led a later review round to
     misdiagnose which component renders the IF-shift control on desktop-v2.
-    The dual cockpit remains the one composition still undeclared for this
-    zone — the rest of this comment's reasoning about IT stands.
+    The dual cockpit remains the one COMPOSITION still undeclared for this
+    zone (`sdr-test`, `mobile` and the two `lcd-*` layouts declare no `filter`
+    zone either, but they are single-composition, so the dual-mount reasoning
+    never reached them) — the rest of this comment's reasoning about the
+    cockpit stands.
   -->
   {#snippet filterSurface()}
     {#if view?.modeFilter || view?.filterPassband}
@@ -1095,16 +1118,18 @@
   <!--
     MOR-1309 (vocabulary slice 8C, SAFETY-ADJACENT). Same structural gate as
     the surfaces above, and the SAME single-composition-only rule `rxAudio`
-    carries: this surface renders focusable controls and no manifest declares
-    an `antenna` zone, so mounting it in the dual composition would put
-    controls outside every declared zone — the MOR-1069 invariant the cockpit
-    enforces, and `zoned()` does NOT grant that permission on its own
-    (`zoneOwning()` returns null for an undeclared surface and renders bare,
-    which IS the violating shape). Its absence from the dual composition is
-    pinned by name in `__tests__/semantic-antenna-wiring.component.test.ts`.
-    `'antenna'` became DECLARABLE with this slice, so a layout gains the
-    surface the moment its manifest declares a zone — a layout decision,
-    separately reviewed, exactly as txAux/meters/rxAudio left it.
+    carries: this surface renders focusable controls and the DUAL
+    composition's only layout (`dual-receiver-cockpit.ts`) declares no
+    `antenna` zone, so mounting it there would put controls outside every
+    declared zone — the MOR-1069 invariant the cockpit enforces, and `zoned()`
+    does NOT grant that permission on its own (`zoneOwning()` returns null for
+    a surface the ACTIVE layout has not declared, and renders bare, which IS
+    the violating shape). Its absence from the dual composition is pinned by
+    name in `__tests__/semantic-antenna-wiring.component.test.ts`.
+    `'antenna'` became DECLARABLE with this slice, and `desktop-v2` declared
+    it in MOR-1367 (S8) — which is why the SINGLE composition mounts it zoned
+    under THAT layout (not under `sdr-test`/`mobile`/`lcd-*`). The cockpit has
+    made no such decision, so the rule above still binds there.
 
     It DOES take the App-owned TX authority snapshot: unlike `rxAudio`,
     switching a TX antenna under power is a hazard, and the surface gates on
@@ -1131,7 +1156,9 @@
     Like `rxAudioSurface` and UNLIKE `txAuxSurface`/`metersSurface`, it is
     rendered in the SINGLE composition ONLY (MOR-1304/MOR-1305 zone-mount
     ruling). `DspSurface` renders up to 8 range inputs and 7 buttons — it is
-    control-bearing, and the cockpit's MOR-1069 rule forbids mounting any
+    control-bearing, and `desktop-v2` declared a `dsp` zone in MOR-1368 (S9)
+    while the cockpit still declares none; the cockpit's MOR-1069 rule
+    forbids mounting any
     control-bearing surface bare in the dual composition: every focusable
     control must live inside a declared zone, with rx-tx last in the tab
     order. `'dsp'` became DECLARABLE with this slice, so the cockpit gains the
@@ -1164,11 +1191,13 @@
     SINGLE COMPOSITION ONLY — the MOR-1304 mounting canon (`RfFrontEndSurface.
     svelte`'s file header): this surface carries focusable controls (preamp
     and attenuator choice buttons, RF-gain/squelch sliders, DIGI-SEL/IP+
-    toggles) and no shipped manifest declares an `rfFrontEnd` zone yet, so a
-    bare dual mount would put controls outside every declared zone — exactly
-    the defect the MOR-1279 rxAudio precedent avoided. `'rfFrontEnd'` became
-    DECLARABLE with this slice; the cockpit gains the surface the moment a
-    rework slice declares a zone for it, same as `rxAudio` left it.
+    toggles) and the DUAL composition's only layout
+    (`dual-receiver-cockpit.ts`) declares no `rfFrontEnd` zone, so a bare dual
+    mount would put controls outside every declared zone — exactly the defect
+    the MOR-1279 rxAudio precedent avoided. `'rfFrontEnd'` became DECLARABLE
+    with this slice, and `desktop-v2` declared it in MOR-1366 (S7); the
+    cockpit gains the surface the moment a rework slice declares a zone for it
+    there, same as `rxAudio` left it.
   -->
   {#snippet rfFrontEndSurface()}
     {#if view?.rfFrontEnd}
@@ -1188,14 +1217,17 @@
     MOR-1307 (vocabulary slice 7B). Same structural gate as the surfaces above,
     and the SAME single-composition-only mounting as `rxAudioSurface`, for the
     same MOR-1069 reason: this surface is control-bearing (band buttons, a
-    frequency entry field and its Set button) and no manifest declares a `band`
-    zone, so a dual mount would put focusable controls outside every declared
-    zone and break the cockpit's "tab order ends in rx-tx" invariant. `zoned()`
-    does not grant that permission by itself — `zoneOwning()` answers `null` for
-    an undeclared surface and the mount renders BARE, which is the violating
-    shape. `'band'` becomes DECLARABLE with this slice; the cockpit gains the
-    surface the moment a rework slice declares a zone for it, and the dual
-    absence is pinned by name in
+    frequency entry field and its Set button) and the DUAL composition's only
+    layout (`dual-receiver-cockpit.ts`) declares no `band` zone, so a dual
+    mount would put focusable controls outside every declared zone and break
+    the cockpit's "tab order ends in rx-tx" invariant. `zoned()` does not
+    grant that permission by itself — `zoneOwning()` answers `null` for a
+    surface the ACTIVE layout has not declared, and the mount renders BARE,
+    which is the violating shape. `'band'` becomes DECLARABLE with this slice,
+    and `desktop-v2` declared it in MOR-1367 (S8) — retiring `BandSelector`'s
+    HAM half only, through `hamBands={!declared.has('band')}`. The cockpit
+    gains the surface the moment a rework slice declares a zone for it there,
+    and the dual absence is pinned by name in
     `__tests__/semantic-band-wiring.component.test.ts`.
 
     It takes NO authority snapshot: the TX permit it renders is already decided
@@ -1210,14 +1242,15 @@
 
   <!--
     MOR-1308 (vocabulary slice 8B). Same reasoning as `rxAudioSurface` above:
-    the second semantic surface carrying interactive controls no manifest
-    declares a zone for, so — per the MOR-1304 mounting canon — it mounts in
+    the second semantic surface carrying interactive controls the DUAL
+    composition's only layout (`dual-receiver-cockpit.ts`) declares no zone
+    for, so — per the MOR-1304 mounting canon — it mounts in
     the SINGLE composition only, and its dual-composition absence is pinned in
     `__tests__/semantic-ritxit-scan-wiring.component.test.ts` with a view
     model that actually carries the `ritXit`/`scan` groups (a fixture that
     cannot see the surface would repeat the bug that canon exists to catch).
-    `'ritXitScan'` becomes DECLARABLE with this slice; no manifest declares a
-    zone for it yet.
+    `'ritXitScan'` becomes DECLARABLE with this slice, and `desktop-v2`
+    declared it in MOR-1367 (S8); the cockpit still declares none.
   -->
   {#snippet ritXitScanSurface()}
     {#if view?.ritXit || view?.scan}
@@ -1238,14 +1271,18 @@
   <!--
     MOR-1310 (vocabulary slice 9B) — SAFETY-CRITICAL. Same structural gate as
     the surfaces above, and the SAME single-composition-only mounting as
-    `rxAudioSurface`: this surface is control-bearing, no manifest declares a
-    `cwKeyer` zone, and the MOR-1069 cockpit rule is that every focusable
+    `rxAudioSurface`: this surface is control-bearing, the DUAL composition's
+    only layout (`dual-receiver-cockpit.ts`) declares no `cwKeyer` zone, and
+    the MOR-1069 cockpit rule is that every focusable
     control lives inside a declared zone with rx-tx last in the tab order.
     Mounted bare in the dual composition it would break both clauses; folded
     into the rx-tx zone it would put a keyer slider between the operator and
-    the unkey button. `'cwKeyer'` became DECLARABLE with this slice, so the
-    cockpit gains the surface the moment a manifest declares a zone — a layout
-    decision, separately reviewed, exactly as rxAudio left it. Its absence from
+    the unkey button. `'cwKeyer'` became DECLARABLE with this slice, and
+    `desktop-v2` declared it in MOR-1368 (S9) — which, per that manifest's own
+    SAFETY note, makes `CwKeyerSurface` the sole break-in affordance on the
+    flagship skin. The cockpit gains the surface the moment ITS manifest
+    declares a zone — a layout decision, separately reviewed, exactly as
+    rxAudio left it. Its absence from
     the dual composition is pinned by name in
     `__tests__/semantic-cw-keyer-wiring.component.test.ts`.
 
@@ -1274,8 +1311,12 @@
     as `txAuxSurface`/`metersSurface` above: the surface mounts only when the
     view model actually carries the MOR-1301 `scopeDisplay` group, so a radio
     with neither a hardware scope nor an audio-FFT source renders the
-    pre-1312 element shape exactly. Bare and unzoned in BOTH compositions,
-    the `meters`/`txAux` shape, NOT `rxAudio`'s single-only shape:
+    pre-1312 element shape exactly. Mounted in BOTH compositions — the
+    `meters`/`txAux` shape, NOT `rxAudio`'s single-only shape — and zoned
+    wherever `zoneOwning()` finds a zone carrying `scopeDisplay`, which
+    `desktop-v2` has declared as `scope-display` since MOR-1365 (S6a); bare
+    otherwise, including the dual composition, whose only layout
+    (`dual-receiver-cockpit.ts`) declares none:
     `ScopeDisplaySurface` renders zero focusable elements (pinned in
     `__tests__/ScopeDisplaySurface.test.ts` and re-pinned below at the
     composed-tree level), so it carries none of the MOR-1069 tab-order risk a
@@ -1296,10 +1337,14 @@
   <!--
     MOR-1311 (vocabulary slice 11B, the LAST B-slice of the vocabulary
     program). Same mounting canon as `ritXitScanSurface`/`cwKeyerSurface`
-    above: control-bearing, no manifest declares a `scopeControls` zone, so
-    per the MOR-1304 ruling's option (i) it mounts in the SINGLE composition
-    only, bare, and must render NOTHING in the DUAL composition — pinned by
-    name in `__tests__/semantic-scope-controls-wiring.component.test.ts`.
+    above: control-bearing, and the DUAL composition's only layout
+    (`dual-receiver-cockpit.ts`) declares no `scopeControls` zone, so per the
+    MOR-1304 ruling's option (i) it mounts in the SINGLE composition only and
+    must render NOTHING in the DUAL composition — pinned by name in
+    `__tests__/semantic-scope-controls-wiring.component.test.ts`. No longer
+    bare under `desktop-v2`, which declared this zone in MOR-1370 (S6b-2) as
+    the last surface in the vocabulary to graduate; still bare under the
+    single-composition layouts that declare none (`sdr-test`/`mobile`/`lcd-*`).
   -->
   {#snippet scopeControlsSurface()}
     {#if view?.scopeControls}
@@ -1318,8 +1363,10 @@
     <!--
       MOR-1258: the zone now carries RxTxSurface AND the two TX-adjacent
       alerts that used to sit at the bottom of this component, unzoned.
-      TxAuxSurface stays OUTSIDE — it declares no zone (see above) — so it
-      renders after the zone rather than between RxTxSurface and the alerts,
+      TxAuxSurface stays OUTSIDE this zone — it mounts through `zoned()` in
+      its OWN `tx-aux` zone, which the cockpit manifest has declared since
+      MOR-1336 — so it renders after the rx-tx zone rather than between
+      RxTxSurface and the alerts,
       which is the one DOM-order change this ticket makes: the alerts move
       up to sit beside RxTxSurface instead of after TxAuxSurface.
     -->

--- a/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-antenna-wiring.component.test.ts
@@ -7,9 +7,11 @@
  * transport/runtime/authority SEAMS are spied:
  *
  *   (a) MOUNTING CANON (MOR-1304 ruling). The surface is control-bearing and
- *       no manifest declares an `antenna` zone, so it must NOT appear in the
- *       DUAL composition — bare OR through `zoned()`, which renders bare for an
- *       undeclared surface and is therefore not permission. The pin below
+ *       the dual composition's only layout (`dual-receiver-cockpit.ts`)
+ *       declares no `antenna` zone, so it must NOT appear in the
+ *       DUAL composition — bare OR through `zoned()`, which renders bare for a
+ *       surface the ACTIVE layout has not declared and is therefore not
+ *       permission. The pin below
  *       renders `strips="dual"` with a view model that DOES carry the antenna
  *       group; a fixture that cannot see the surface would make it vacuous.
  *   (b) SAFETY, end to end: while the App-owned TX authority reports the
@@ -192,8 +194,9 @@ afterEach(() => {
 describe('the antenna surface never mounts in the dual composition (MOR-1304 canon)', () => {
   /**
    * MUTATION KILLED: mounting this surface in the cockpit, bare or through
-   * `zoned()`. It renders focusable controls and no manifest declares an
-   * `antenna` zone, so `zoneOwning()` returns null and `zoned` renders BARE —
+   * `zoned()`. It renders focusable controls and `dual-receiver-cockpit.ts`
+   * declares no `antenna` zone, so `zoneOwning()` returns null and `zoned`
+   * renders BARE —
    * outside every declared zone, breaking the MOR-1069 invariant that every
    * focusable control sits inside a declared zone with rx-tx last in the tab
    * order. The view model here DOES carry the group (asserted below), so this

--- a/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-band-wiring.component.test.ts
@@ -7,7 +7,8 @@
  * and runtime SEAMS are spied:
  *
  *   (a) THE MOUNTING CANON. The surface is control-bearing (band buttons, a
- *       frequency field, a Set button) and no manifest declares a `band` zone,
+ *       frequency field, a Set button) and the dual composition's only layout
+ *       (`dual-receiver-cockpit.ts`) declares no `band` zone,
  *       so it must NOT appear in the dual composition — and the pin renders the
  *       dual composition with caps that DO emit the group, because a fixture
  *       that cannot see the surface is the bug, not the proof (MOR-1304 §1).
@@ -214,7 +215,8 @@ describe('the band surface obeys the zone-mount canon (MOR-1069 / MOR-1304)', ()
   /**
    * THE DUAL-ABSENCE PIN. MUTATION KILLED: mounting this surface in the dual
    * composition — bare, or through `zoned()`, which renders bare anyway while
-   * no manifest declares a `band` zone (`zoneOwning()` answers `null`). The
+   * the cockpit manifest declares no `band` zone (`zoneOwning()` answers
+   * `null`). The
    * view model here DOES carry the band group (asserted below via the single
    * composition), so this is not the vacuous green MOR-1304 §1 warned about.
    */

--- a/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-cw-keyer-wiring.component.test.ts
@@ -23,8 +23,9 @@
  *       band-plan lookup anywhere in the CW path.
  *   (d) Receiver-scoped intents (APF, TPF) target the ACTIVE VFO — the facts
  *       and the commands must name the same receiver.
- *   (e) MOUNTING: the surface is control-bearing and no manifest declares a
- *       `cwKeyer` zone, so it renders in the SINGLE composition only. The dual
+ *   (e) MOUNTING: the surface is control-bearing and the dual composition's
+ *       only layout (`dual-receiver-cockpit.ts`) declares no `cwKeyer` zone,
+ *       so it renders in the SINGLE composition only. The dual
  *       composition must not grow it — asserted with a view model that DOES
  *       carry the group, because a fixture that cannot see the surface would
  *       reproduce the very hole the MOR-1304 ruling was written about.
@@ -657,8 +658,9 @@ describe('the surface mounts only where a declared zone can hold it', () => {
 
   /**
    * MUTATION KILLED: mounting this surface bare in the cockpit (the MOR-1304
-   * ruling). It is control-bearing and no manifest declares a `cwKeyer` zone,
-   * so MOR-1069's cockpit rule — every focusable control inside a declared
+   * ruling). It is control-bearing and `dual-receiver-cockpit.ts` — the only
+   * layout with a dual composition — declares no `cwKeyer` zone, so
+   * MOR-1069's cockpit rule — every focusable control inside a declared
    * zone, tab order ending in rx-tx — would break on both clauses; folding it
    * into the rx-tx zone would put break-in choices between the operator and
    * the unkey button.

--- a/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-dsp-wiring.component.test.ts
@@ -329,8 +329,9 @@ describe('the dsp surface mounts only when the view model carries the group', ()
    * range inputs and 7 buttons — it is control-bearing, and the cockpit's
    * MOR-1069 rule forbids mounting any control-bearing surface bare in the
    * dual composition: every focusable control must live inside a declared
-   * zone, with rx-tx last in the tab order. No manifest declares a `dsp`
-   * zone, so the dual composition renders NO dsp surface at all — same
+   * zone, with rx-tx last in the tab order. `dual-receiver-cockpit.ts` — the
+   * only layout with a dual composition — declares no `dsp` zone, so the dual
+   * composition renders NO dsp surface at all — same
    * precedent as `rxAudioSurface`
    * (`semantic-rx-audio-wiring.component.test.ts`). The view model here DOES
    * carry the `dsp` group (see `beforeEach`) — a fixture that cannot see the

--- a/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-meters-wiring.component.test.ts
@@ -302,9 +302,14 @@ describe('the meters surface mounts only when the view model carries the group',
     expect(Object.keys(relevance())).toContain('power');
   });
 
-  // MUTATION KILLED: giving the meters surface a `data-zone-id`. `meters` is
-  // declarable after this slice, but no manifest declares a meters zone — and
-  // the zone schema stays config-free (risk R3).
+  // MUTATION KILLED: giving the meters surface a `data-zone-id` of its own.
+  // This mount is bare because a STANDALONE render resolves no surface plan
+  // (`useSurfacePlan()` falls back to `NO_PLAN`), so `zoneOwning()` answers
+  // `null` whatever any manifest declares — not because the zone is
+  // undeclared program-wide. `desktop-v2` has declared a `meters` zone since
+  // MOR-1341 (S5); the dual composition's own layout
+  // (`dual-receiver-cockpit.ts`) declares none. The zone schema stays
+  // config-free (risk R3) either way.
   it('binds no zone id to the meters surface in either composition', () => {
     render({ strips: 'dual' });
     const zones = [...target.querySelectorAll<HTMLElement>('[data-zone-id]')]

--- a/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-ritxit-scan-wiring.component.test.ts
@@ -13,9 +13,11 @@
  *       `set_rit_frequency` command — proving `makeRitXitHandlers()`'s two
  *       offset handlers converge, not merely asserting it about a stub.
  *   (b) MOUNTING CANON (MOR-1304 ruling). This is a control-bearing surface
- *       with no manifest-declared zone, so per the canon's option (i) it
- *       mounts in the SINGLE composition only, bare, and renders NOTHING in
- *       the DUAL composition — pinned here with a view model that actually
+ *       the DUAL composition's only layout (`dual-receiver-cockpit.ts`)
+ *       declares no zone for, so per the canon's option (i) it mounts in the
+ *       SINGLE composition only and renders NOTHING in the DUAL composition.
+ *       No longer bare under `desktop-v2`, which declared `rit-xit-scan` in
+ *       MOR-1367 (S8) — pinned here with a view model that actually
  *       CARRIES the `ritXit`/`scan` groups (a fixture that cannot see the
  *       surface would repeat the exact vacuous-green bug the canon exists to
  *       catch, per the rxAudio precedent).

--- a/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-rx-audio-wiring.component.test.ts
@@ -415,13 +415,15 @@ describe('the surface mounts only when the view model carries the group', () => 
 
   /**
    * MUTATION KILLED: mounting this surface bare in the cockpit. It is the
-   * first semantic surface carrying interactive controls that no manifest
-   * declares a zone for, and MOR-1069's cockpit rule is that every focusable
+   * first semantic surface carrying interactive controls that the DUAL
+   * composition's only layout (`dual-receiver-cockpit.ts`) declares no zone
+   * for, and MOR-1069's cockpit rule is that every focusable
    * control lives inside a declared zone with rx-tx last in the tab order
    * (`skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts`
    * enforces it). Mounted bare it breaks both clauses; folded into the rx-tx
    * zone it would put an AF slider between the operator and the unkey button.
-   * It waits for a declared zone — which this slice made possible.
+   * It waited for a declared zone, which this slice made possible;
+   * `desktop-v2` supplied one in MOR-1368 (S9), and the cockpit still has not.
    */
   it('renders NO rx-audio surface in the dual composition, zoned or unzoned', () => {
     render({ strips: 'dual' });

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-controls-wiring.component.test.ts
@@ -12,9 +12,12 @@
  *   (a) every control category (choice, toggle, stepper) reaches the wire as
  *       the exact command `SpectrumToolbar.svelte`/`ScopeSettingsPopover.svelte`
  *       themselves dispatch — composed, not forked.
- *   (b) MOUNTING CANON (MOR-1304 ruling). Control-bearing, no manifest
- *       declares a `scopeControls` zone, so it mounts in the SINGLE
- *       composition only, bare, and renders NOTHING in the DUAL composition
+ *   (b) MOUNTING CANON (MOR-1304 ruling). Control-bearing, and the DUAL
+ *       composition's only layout (`dual-receiver-cockpit.ts`) declares no
+ *       `scopeControls` zone, so it mounts in the SINGLE composition only and
+ *       renders NOTHING in the DUAL composition. Not bare under `desktop-v2`
+ *       any more: MOR-1370 (S6b-2) declared that zone, the last surface in
+ *       the vocabulary to graduate
  *       — pinned with a view model that actually CARRIES the group (the
  *       rxAudio/ritXitScan/cwKeyer precedent), plus a control test mounting
  *       the same fixture in single to foreclose vacuity.
@@ -323,7 +326,7 @@ describe('the surface mounts only in the single composition, never in dual', () 
 /**
  * `desktopV2Layout` now carries a `scope-controls` zone
  * (`presentation/layouts/desktop-declarations.ts`). Unlike `scopeDisplay`
- * (pure readout, bare in both compositions), `scopeControls` is
+ * (pure readout, mounted in both compositions), `scopeControls` is
  * control-bearing and mounts SINGLE-COMPOSITION-ONLY under the MOR-1304
  * canon — so there is no dual-composition half of this claim to make; (b)
  * above already proves the dual composition mounts nothing regardless of the

--- a/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-scope-display-wiring.component.test.ts
@@ -16,8 +16,12 @@
  *       `defaultScopeStatus` — the composed-tree analogue of the adapter-level
  *       probe in `scope-display-adapter.test.ts`.
  *   (c) Unlike `rxAudio` (control-bearing, single-composition-only), this
- *       surface is PURE READOUT and mounts BARE in BOTH compositions, the
- *       `meters`/`txAux` shape — proved by mounting it in `dual` too.
+ *       surface is PURE READOUT and mounts in BOTH compositions, the
+ *       `meters`/`txAux` shape — proved by mounting it in `dual` too. It is
+ *       zoned wherever `zoneOwning()` finds a zone carrying `scopeDisplay`
+ *       (`desktop-v2` declares one as `scope-display`, MOR-1365/S6a), and
+ *       bare otherwise — the dual composition, a standalone mount with no
+ *       plan, or a workspace subtraction that emptied the zone.
  *   (d) The default path must stay byte-identical: a radio that declares no
  *       scope capability renders exactly the pre-1312 element shape.
  */
@@ -295,9 +299,13 @@ describe('the scope-display surface mounts only when the view model carries the 
     },
   );
 
-  // Same shape as `meters`/`txAux`: declarable, but no manifest declares a
-  // `scopeDisplay` zone in this slice — the surface renders bare in BOTH
-  // compositions, unlike `rxAudio`'s single-only mount.
+  // Mounted in BOTH compositions, unlike `rxAudio`'s single-only mount. This
+  // pin renders bare because a STANDALONE mount resolves no surface plan
+  // (`useSurfacePlan()` falls back to `NO_PLAN`), so `zoneOwning()` answers
+  // `null` for every surface here whatever any manifest declares — not
+  // because the zone is undeclared program-wide. `desktop-v2` has declared a
+  // `scopeDisplay` zone since MOR-1365 (S6a); the dual composition's own
+  // layout (`dual-receiver-cockpit.ts`) still declares none.
   it('binds no zone id to the scope-display surface in either composition', () => {
     h.caps = liveCaps(true);
     h.scopeStatus = { ...LIVE_SCOPE_STATUS };

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -624,7 +624,9 @@ describe('MOR-1082 — the semantic vertical consults the resolved surface plan'
 // `zoneOwning`/`zoned` in `SemanticRadioSurfaces` is written ONCE and applied
 // uniformly to every optional surface (txAux, meters, and — single
 // composition only — rxAudio). Every pin above proves it exclusively against
-// txAux, which is also the one real manifest happens to declare a zone for —
+// txAux, which was the only one OF THOSE THREE a real manifest declared a
+// zone for when these pins were written (`vfo`/`rxTx` had zones from the
+// start; `desktop-v2` declares all fourteen surfaces today) —
 // a wiring change that special-cased `if (surface === 'txAux')` would pass
 // every one of them just as well. These pins exercise the SAME mechanism
 // against `meters`, a structurally unrelated surface, through a SYNTHETIC
@@ -710,8 +712,13 @@ describe('MOR-1336 — a declared zone renders nothing for a radio without the g
  * `filter`, the MOR-1279 rxAudio shape.
  *
  * `FilterSurface` renders up to 14 focusable controls (mode/filter/shape
- * choice buttons, the width slider, three passband-level sliders) and no
- * shipped manifest declares a `filter` zone (`filter-declarability.test.ts`).
+ * choice buttons, the width slider, three passband-level sliders), and the
+ * DUAL composition's only layout (`dual-receiver-cockpit.ts`) declares no
+ * `filter` zone. `desktop-v2` DOES declare one — MOR-1366 (S7) — and
+ * `filter-declarability.test.ts` pins the declaring set as exactly
+ * `['desktop-v2']`. This sentence previously cited that same file as evidence
+ * that NO shipped manifest declared the zone, which that file has contradicted
+ * since S7 landed.
  * The cockpit's MOR-1069 invariant requires every focusable control to sit
  * inside a zone the active layout's manifest actually declares, with `rx-tx`
  * last in the tab order — a control-bearing surface mounted bare in the DUAL

--- a/frontend/src/components/spectrum/SpectrumPanel.svelte
+++ b/frontend/src/components/spectrum/SpectrumPanel.svelte
@@ -50,8 +50,10 @@
   // `hideScopeControls` is forwarded the same way (MOR-1369, v3-rework
   // S6b-1): it hides the toolbar's fact-backed `scopeControls.*` half once a
   // layout's manifest declares a `scopeControls` zone (S6b-2). Landed INERT
-  // — no manifest declares that zone yet, so `RadioLayout` always passes
-  // `false` today and this prop is a pure pass-through, no logic of its own.
+  // with S6b-1 and LIVE since MOR-1370 (S6b-2) declared that zone on
+  // `desktop-v2`: `RadioLayout` forwards
+  // `hideScopeControls={declared.has('scopeControls')}`, which is `true`
+  // there. This prop stays a pure pass-through, no logic of its own.
   //
   // `hideAutoStepToggle` is forwarded the same way (MOR-1486 ruling B,
   // owner session 19): it hides the toolbar's AUTO (mode-follow) toggle on

--- a/frontend/src/components/spectrum/SpectrumToolbar.svelte
+++ b/frontend/src/components/spectrum/SpectrumToolbar.svelte
@@ -58,9 +58,14 @@
      * (`scopeDemandOn`) is client-side scope-streaming demand, not a
      * `scopeControls.*` field either, and also stays unconditional.
      *
-     * Landed INERT (MOR-1369, S6b-1): no manifest declares a `scopeControls`
-     * zone yet, so this defaults `false` and nothing renders differently.
-     * Safe only because an omitting caller keeps the prop `false` — the same
+     * Landed INERT with MOR-1369 (S6b-1) and is LIVE now: MOR-1370 (S6b-2)
+     * declared the `scopeControls` zone on `desktop-v2`, so
+     * `RadioLayout.svelte` forwards
+     * `hideScopeControls={declared.has('scopeControls')}` — `true` on the
+     * flagship skin, pinned by "passes hideScopeControls=true on real
+     * desktop-v2, which declares the scope-controls zone" in
+     * `components-v2/layout/__tests__/RadioLayout.isolated.test.ts`. It still
+     * defaults `false`, which is what keeps an omitting caller safe — the same
      * shape as `hideSourceControls` above and the MOR-1364 `hideTxPanel`/
      * `declared` channel (S5-N3: safe because the surface degrades to a bare
      * render when unzoned, a guarantee that lives in

--- a/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
@@ -1,9 +1,11 @@
 /**
- * MOR-1310 — `cwKeyer` is DECLARABLE, and nothing declares it yet.
+ * MOR-1310 — `cwKeyer` is DECLARABLE. MOR-1368 (S9) declares it for real.
  *
- * Slice 9B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
+ * Slice 9B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately did not touch any manifest, and it added
  * no design-language renderer slot (that set was frozen by MOR-1072).
+ * MOR-1368 flips the second half, on `desktop-v2` ONLY; the inventory below
+ * is a LITERAL of who declares it.
  *
  * Same three pins as `rx-audio-declarability.test.ts` /
  * `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -1,8 +1,10 @@
 /**
- * MOR-1305 — `dsp` is DECLARABLE, and nothing declares it yet.
+ * MOR-1305 — `dsp` is DECLARABLE. MOR-1368 (S9) declares it for real.
  *
- * Slice 5B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest. Mirrors
+ * Slice 5B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately did not touch any manifest. MOR-1368
+ * flips the second half, on `desktop-v2` ONLY; the inventory below is a
+ * LITERAL of who declares it. Mirrors
  * `tx-aux-declarability.test.ts`/`meters-declarability.test.ts`.
  */
 import { describe, it, expect } from 'vitest';

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -1,10 +1,12 @@
 /**
- * MOR-1279 — `rxAudio` is DECLARABLE, and nothing declares it yet.
+ * MOR-1279 — `rxAudio` is DECLARABLE. MOR-1368 (S9) declares it for real.
  *
- * Slice 3B adds the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
- * the surface later; it deliberately does not touch any manifest, and it adds
+ * Slice 3B added the name to `SEMANTIC_SURFACE_NAMES` so a manifest CAN mount
+ * the surface later; it deliberately did not touch any manifest, and it added
  * no design-language renderer slot (that set was frozen by MOR-1072 — adding
- * one would be a language-contract change this slice must not make).
+ * one would be a language-contract change that slice must not make).
+ * MOR-1368 flips the second half, on `desktop-v2` ONLY. The inventory below
+ * is a LITERAL of who declares it, mirroring `filter-declarability.test.ts`.
  *
  * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`:
  *   - drop the name and a future manifest's zone stops validating;

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -19,10 +19,15 @@ import { isValidLanguageId as isValidProductId } from '../languages/contract';
  *  by MOR-1307, `antenna` by MOR-1309, `ritXitScan` by MOR-1308, `cwKeyer` by
  *  MOR-1310, `scopeDisplay` by MOR-1312, `scopeControls` by MOR-1311 — the
  *  LAST B-slice of the vocabulary program). Adding a name makes it
- *  DECLARABLE — it does not mount anything by itself, and no manifest
- *  declares a `meters`, `rxAudio`, `filter`, `dsp`, `rfFrontEnd`, `band`,
- *  `antenna`, `ritXitScan`, `cwKeyer`, `scopeDisplay` or `scopeControls`
- *  zone yet (the cockpit declares only `txAux`, as `tx-aux` — MOR-1336).
+ *  DECLARABLE — it does not mount anything by itself. Which layouts then
+ *  DECLARE a name is recorded in `__tests__/*-declarability.test.ts` for the
+ *  twelve names that have such a file (`vfo` and `rxTx` predate the pattern
+ *  and have none), each pinning its own `DECLARES_*` literal against the real
+ *  barrel: as of the rework tail `desktop-v2`
+ *  declares a zone for EVERY name in this list (`desktop-declarations.ts`'s
+ *  `DESKTOP_V2_ZONES`, with `__tests__/zone-ownership-coverage.test.ts`
+ *  holding the partition), while the dual cockpit declares only `vfo`,
+ *  `rxTx` and `txAux`.
  *  Distinct from the design-language renderer slot of the same name
  *  (`languages/contract.ts`'s `RENDERER_SLOT_NAMES`): that one says how a
  *  language DRAWS a meter, this one says which layout zone may HOST the

--- a/frontend/src/semantic/ScopeDisplaySurface.svelte
+++ b/frontend/src/semantic/ScopeDisplaySurface.svelte
@@ -22,8 +22,9 @@
   `__tests__/ScopeDisplaySurface.test.ts` and re-pinned at the composed-tree
   level in `semantic-scope-display-wiring.component.test.ts`, so a future
   control addition trips both. That property is what lets `SemanticRadioSurfaces`
-  mount this surface bare in BOTH compositions (the `meters`/`txAux` shape,
-  not the control-bearing `rxAudio` single-only shape).
+  mount this surface in BOTH compositions (the `meters`/`txAux` shape, not the
+  control-bearing `rxAudio` single-only shape) — bare included, wherever
+  `zoneOwning()` finds no zone carrying `scopeDisplay`.
 
   `hardwareConnected` (MOR-1312 addition, MOR-1352 finding) is genuinely NOT
   redundant with `health` when `source === 'audio_fft'` — see

--- a/frontend/src/semantic/__tests__/MetersSurface.test.ts
+++ b/frontend/src/semantic/__tests__/MetersSurface.test.ts
@@ -202,10 +202,12 @@ describe('the meters surface is display-only and self-gates on group presence', 
     });
   });
 
-  // MUTATION KILLED: adding a `data-zone-id` here. `meters` is declarable as a
-  // semantic surface after this slice, but no manifest declares a meters zone
-  // — binding one would put a zone id in the DOM no layout asked for
-  // (the MOR-1069 lesson, carried forward from MOR-1265).
+  // MUTATION KILLED: adding a `data-zone-id` here. The PURE surface never
+  // binds a zone id of its own — that belongs to the `zoned()` wrapper in
+  // `components-v2/wiring/SemanticRadioSurfaces.svelte`, which reads the
+  // active layout's plan. Binding one here would put a zone id in the DOM no
+  // layout asked for (the MOR-1069 lesson, carried forward from MOR-1265),
+  // and would duplicate the one `desktop-v2` already declares (MOR-1341, S5).
   it('binds no zone id', () => {
     withSurface(base(), () => {
       expect(target.querySelectorAll('[data-zone-id]')).toHaveLength(0);

--- a/frontend/src/semantic/__tests__/ScopeDisplaySurface.test.ts
+++ b/frontend/src/semantic/__tests__/ScopeDisplaySurface.test.ts
@@ -99,8 +99,9 @@ describe('the scope-display surface is display-only and self-gates on group pres
 
   // MUTATION PROBE (1 of 2 required by the ticket): grows a button/input of
   // any kind. Zero focusable elements is what lets `SemanticRadioSurfaces`
-  // mount this surface bare in BOTH compositions (the `meters` shape, not
-  // `rxAudio`'s single-only shape) — see `ScopeDisplaySurface.svelte`'s doc
+  // mount this surface in BOTH compositions (the `meters` shape, not
+  // `rxAudio`'s single-only shape), bare included wherever `zoneOwning()`
+  // finds no zone carrying `scopeDisplay` — see `ScopeDisplaySurface.svelte`'s doc
   // comment and `semantic-scope-display-wiring.component.test.ts`.
   it('contributes no focusable control of any kind', () => {
     withSurface(base(), () => {

--- a/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
+++ b/frontend/src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte
@@ -7,19 +7,23 @@
   components-v2/wiring/SemanticRadioSurfaces.svelte). No manufacturer
   conditionals, no runtime/store/command import here.
 
-  MOR-1068: the manifest's four declared zones — `primary-vfo`,
-  `secondary-vfo`, `global`, `rx-tx` — are realized by that one `strips="dual"`
-  composition, in declaration order, each tagged with its `data-zone-id`. They
+  MOR-1068: the manifest's five declared zones — `primary-vfo`,
+  `secondary-vfo`, `global`, `rx-tx` and `tx-aux` (added by MOR-1336, S4) —
+  are realized by that one `strips="dual"` composition, in declaration order,
+  each tagged with its `data-zone-id`. They
   cannot be split across separate mounts here: a second SemanticRadioSurfaces
   would be a second TX lease source, and single TX authority is the layout's
   hardest invariant.
 
-  Scope and controls remain inert structural zones. MOR-1062/1065 ship only
-  the vfo/rxTx semantic surfaces — nothing here may claim those regions are
-  live, and they declare no manifest zone for the same reason. Same two-level
-  gating as the surfaces themselves (MOR-977): present so the shell composes
-  every named region, disabled because no real surface backs them yet — never
-  falsely active. `global` left this list when the radio-wide row moved in:
+  Scope and controls remain inert structural placeholders: this manifest
+  declares no zone that would place a semantic surface in either region, so
+  nothing here may claim those regions are live. The reason is the ABSENCE OF
+  A DECLARED ZONE, not the absence of a surface — `scopeDisplay` is in fact
+  mounted by this very composition (`SemanticRadioSurfaces.svelte`'s
+  `strips === 'dual'` branch renders it, bare, since this manifest declares no
+  `scope-display` zone). Same two-level gating as the surfaces themselves
+  (MOR-977): present so the shell composes every named region, disabled
+  because no declared zone backs them — never falsely active. `global` left this list when the radio-wide row moved in:
   a zone holding live switches gates at the widget, not with a container
   marker (MOR-1067 verification F7).
 


### PR DESCRIPTION
## What

A comment-only sweep correcting one class of stale prose: comments asserting that
**"no manifest declares a `<X>` zone"** for a semantic surface, when `desktop-v2`
in fact declares it.

Each claim was true when its B-slice landed and was never revisited as the rework
tail (S4, S5, S6a, S6b-2, S7, S8, S9) progressively declared every zone.
`desktop-v2` now declares a zone for **all 14** members of
`SEMANTIC_SURFACE_NAMES`; `zone-ownership-coverage.test.ts` records that its
ledger is empty.

No code changed. Proven mechanically rather than asserted: every touched file was
compiled before and after and the outputs compared, with a control mutation
confirming the comparator reports inequality on a one-token code change.

## The real invariant

The sentences were not merely stale — they named the wrong subject. What they
protect is the **mounting canon**: a control-bearing surface must not mount in the
DUAL composition, because a bare mount would put focusable controls outside every
declared zone (MOR-1069). The DUAL composition is reached only through
`skins/dual-receiver-cockpit/DualReceiverCockpit.svelte` (`strips="dual"`), so the
load-bearing fact is:

> `dual-receiver-cockpit.ts` — the only layout with a dual composition — declares
> no zone for this surface.

Still true, which is why every pin still passes.

## Notable findings

- **`presentation/layouts/contract.ts`** — the docstring of `SEMANTIC_SURFACE_NAMES`
  itself listed eleven surfaces as undeclared. The definitional site the rest of
  the family defers to.
- **`semantic-tx-aux-wiring.component.test.ts`** claimed no shipped manifest
  declares a `filter` zone and **cited `filter-declarability.test.ts` as evidence**
  — a file whose first line reads "MOR-1366 (S7) declares it for real" and which
  pins `DECLARES_FILTER = ['desktop-v2']`. The citation was refuted by its own source.
- **Three of twelve `*-declarability.test.ts` headers** said "nothing declares it
  yet" while their own `DECLARES_* = ['desktop-v2']` literal said otherwise. The
  other nine had already been corrected; these three were missed.
- **`DualReceiverCockpit.svelte`** listed "four declared zones" beside a manifest
  declaring five — a handwritten list next to a derived one.
- **"bare in BOTH compositions"** existed in six copies for `scopeDisplay`; all
  are now consistent with the zone it has had since MOR-1365.

## Deliberately NOT changed

Ten sites with similar wording were each opened and verified TRUE: past-tense
history of a superseded state; claims about the synthetic id `synthetic-meters-zone`;
the cockpit's inert `scope`/`controls` placeholders; and pins deliberately driven
by an unresolvable layout id.

`skins/sdr-test/SdrTestSkin.svelte` says it declares no `meters` zone. True at this
base, and that file plus `declarations.ts` belong to in-flight PR #2907 (MOR-1346),
which adds that zone. Left for that PR.

## Verification

- `npx vitest run` — **371 files / 8148 tests, all passing.** (Path-filtered runs
  collapse to one of the two vitest projects and silently exclude
  `*.component.test.ts`, i.e. most of the files under review; the whole-suite
  number is the only honest one here.)
- `npx eslint src --max-warnings=0` — exit 0. `max-len` applies to comments, so
  this genuinely discriminates on a comment-only diff.
- `npx svelte-check --tsconfig ./tsconfig.app.json` — 0 errors, 0 warnings, 4606 files.
- Comment-only proven across all 22 files, control-tested in both directions.
- Class re-swept with a newline-insensitive matcher: a literal
  `grep "no manifest declares"` misses instances whose phrase wraps across lines,
  which is how several survived earlier passes.
- No `file:line` citations introduced; new prose cites file + symbol.

## Review

Three rounds, two independent reviewers, both adversarial and read-only. Rounds 1
and 2 returned BLOCKED and found 18 defects between them — including four sites
this sweep had missed, and five in prose written to fix earlier findings. Both
reviewers independently found the `contract.ts` docstring.

From round 3 the remedy for a prose defect is DELETION, not rewriting: on this
change every rewrite proved to be a fresh unverified claim.

## Guardrails

**Hard ceiling exceeded with owner approval.** 22 files vs the 10-file ceiling; the
owner granted the exception explicitly, having been offered a split first. The
sweep's value is the completeness of the class — a partial sweep leaves the reader
unable to tell which surviving instances are stale and which are deliberate, which
is the exact failure being fixed. Changed lines are well under the 1000-line
ceiling. No behaviour change, no new abstraction, no new API.

## Follow-up (not in this PR)

Several test NAMES are misleading in the same way the comments were — e.g.
`renders it bare in the single composition` (dsp, rx-audio, cw-keyer, band). True
only of a standalone mount that resolves no surface plan; under `desktop-v2` those
surfaces mount zoned. Renaming tests is a code change, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
