### PR TITLE
refactor: derive scope reply shapes from the profile command map

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,6 +138,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runtime/_scope_runtime.py: ScopeRuntimeMixin` and
   `backends/_icom_serial_base.py`, moved onto `self._commands.<builder>`
   in the same change.
+- **`rigplane.commands.scope`'s fifteen `parse_scope_*_response` functions
+  take a map-derived `command`/`sub`, closing the response-side gap the
+  builder migration above left open (MOR-2008).** Each now accepts
+  optional `command`/`sub` keywords, defaulting to the same `_CMD_SCOPE`/
+  `_SUB_SCOPE_*` constants checked before this change, so a caller that
+  never passes them — `runtime/_civ_rx.py`'s unsolicited-frame decoding
+  (no command-map entry to derive a shape from) and every pre-migration
+  direct test call — keeps working unchanged. The sixteen production call
+  sites in `runtime/_scope_runtime.py: ScopeRuntimeMixin` (fifteen getters
+  plus `set_scope_fixed_edge`'s self-reparse of the frame it just built,
+  which shares `get_scope_fixed_edge`'s reply shape) now derive both
+  values via `runtime/radio.py: CoreRadio._expect_shape`, the mechanism
+  batch 1's `system.py` date/time/UTC parsers and batch 3's twelve
+  dsp.py getters already use. No observable behaviour change on any of
+  the four CI-V profiles that declare scope commands: every one already
+  declares the identical `[0x27, sub]` tuple these constants held (this
+  module's own divergence-free history, noted in the entry above).
+  Registered in `tests/test_response_shape_from_profile.py` as three
+  dedicated cases (one generic, covering thirteen of the fifteen parsers;
+  one for `get_scope_session_state`'s two-key round trip; one for
+  `set_scope_fixed_edge`'s self-reparse) rather than a `MATCHER_BACKED_GETTERS`
+  row, since none of the fifteen route through `_get_bcd_level`/
+  `_get_bool_value` — the same reason batch 1's date/time/UTC trio and
+  `get_dual_watch` are each a dedicated case there instead of a table row.
 - **`rigplane.commands.system`/`cw`/`speech`/`power` builders require
   `cmd_map`; there is no hardcoded fallback (MOR-2008, batch 1 of
   `docs/plans/2026-08-29-profile-driven-command-bytes.md`).** All 26

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -13,12 +13,18 @@ every remaining builder (verified by grep across ``rigs/*.toml`` before
 deleting it).
 
 ``_CMD_SCOPE`` and every ``_SUB_SCOPE_*`` constant survive in
-`commands/_frame.py`: the ``parse_scope_*_response`` functions below still
-read them directly, unmigrated -- see the note above ``_scope_selector_data``
-for why that response-side machinery is out of this PR's scope. Only this
-module's own private ``_scope_query`` helper is deleted: it built the
-fallback's frame exclusively (14 call sites, all fallback branches now
-gone) and nothing outside this module ever imported it.
+`commands/_frame.py`, now as defaults only: every ``parse_scope_*_response``
+function below (MOR-2008, this module's last residual step) takes the
+map-derived ``command``/``sub`` its caller resolved via
+`commands/bound.py: BoundCommands.expect` /
+`runtime/radio.py: CoreRadio._expect_shape`, falling back to the constant
+only for a caller that never passes one -- `runtime/_civ_rx.py`'s
+unsolicited-frame decoding (population 3, no request/reply round trip, no
+command-map entry to derive a shape from) and every pre-migration direct
+test call. Only this module's own private ``_scope_query`` helper is
+deleted: it built the fallback's frame exclusively (14 call sites, all
+fallback branches now gone) and nothing outside this module ever imported
+it.
 
 **Ruling: ``scope_set_center_type`` loses its ``receiver`` keyword.** The
 latent setter-side twin of MOR-1981 (closed on the getter,
@@ -217,30 +223,17 @@ def _scope_selector_data(receiver: int | None) -> bytes | None:
     are the only sub-commands whose getters still pass a real receiver
     value through this function.
 
-    The response side of this same distinction --
-    ``parse_scope_*_response``, below -- is unmigrated: each still checks
-    the reply's command/sub against the hardcoded ``_CMD_SCOPE``/
-    ``_SUB_SCOPE_*`` constants rather than a shape derived from
-    ``cmd_map``. This is a structurally different, fourth response-matching
-    population from the ones `docs/plans/2026-08-29-profile-driven-command-bytes.md`
-    §6 measures (population 1's 65 ``_get_bcd_level``/``_get_bool_value``/
-    direct ``parse_level_response``/``parse_bool_response`` sites, and
-    population 3's 105 unsolicited-frame comparisons in ``_civ_rx.py``) --
-    it was never counted, and Steps 5..N never named it. No scope.py row
-    has ever appeared in ``tests/command_map_parity_divergences.txt`` for
-    a reason unrelated to this argument (every profile's declared tuple
-    already equals these hardcoded constants), so nothing currently
-    depends on the response side reading the map -- retrofitting all
-    sixteen ``parse_scope_*_response`` functions to accept a map-derived
-    shape is a redesign of this module's response architecture, not this
-    module's fair share of Steps 5..N, and is left for a separate pass if
-    a real divergence is ever found.
+    The response side of this same distinction -- ``parse_scope_*_response``,
+    below -- now takes its ``command``/``sub`` from the same map entry too
+    (MOR-2008, this module's last residual step; see the module docstring).
     """
     return None if receiver is None else bytes([_validate_scope_receiver(receiver)])
 
 
-def _parse_scope_frame(frame: CivFrame, sub: int) -> bytes:
-    if frame.command != _CMD_SCOPE or frame.sub != sub:
+def _parse_scope_frame(
+    frame: CivFrame, sub: int, *, command: int = _CMD_SCOPE
+) -> bytes:
+    if frame.command != command or frame.sub != sub:
         got = 0 if frame.sub is None else frame.sub
         raise ValueError(
             f"Not a scope response: command 0x{frame.command:02x} sub 0x{got:02x}"
@@ -266,17 +259,22 @@ def _split_scope_receiver_prefix(
     return None, data
 
 
-def _decode_scope_bool(frame: CivFrame, sub: int) -> bool:
-    data = _parse_scope_frame(frame, sub)
+def _decode_scope_bool(frame: CivFrame, sub: int, *, command: int = _CMD_SCOPE) -> bool:
+    data = _parse_scope_frame(frame, sub, command=command)
     if len(data) != 1:
         raise ValueError(f"Scope bool response must be 1 byte, got {len(data)}")
     return data[0] != 0x00
 
 
 def _decode_scope_value(
-    frame: CivFrame, sub: int, *, minimum: int, maximum: int
+    frame: CivFrame,
+    sub: int,
+    *,
+    minimum: int,
+    maximum: int,
+    command: int = _CMD_SCOPE,
 ) -> tuple[int | None, int]:
-    data = _parse_scope_frame(frame, sub)
+    data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(1,))
     value = payload[0]
     _validate_scope_range("scope value", value, minimum, maximum)
@@ -284,9 +282,14 @@ def _decode_scope_value(
 
 
 def _decode_scope_bcd_value(
-    frame: CivFrame, sub: int, *, minimum: int, maximum: int
+    frame: CivFrame,
+    sub: int,
+    *,
+    minimum: int,
+    maximum: int,
+    command: int = _CMD_SCOPE,
 ) -> tuple[int | None, int]:
-    data = _parse_scope_frame(frame, sub)
+    data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(1,))
     value = _bcd_decode_value(payload)
     _validate_scope_range("scope value", value, minimum, maximum)
@@ -917,33 +920,55 @@ def scope_set_rbw(
 # --- Parse functions ---
 
 
-def parse_scope_enabled_response(frame: CivFrame) -> bool:
-    """Parse a ``0x27 0x10`` panel-scope state response."""
-    return _decode_scope_bool(frame, _SUB_SCOPE_ON)
+def parse_scope_enabled_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_ON
+) -> bool:
+    """Parse a ``0x27 0x10`` panel-scope state response.
+
+    ``command``/``sub`` are the map-derived shape the caller's request used
+    (`runtime/_scope_runtime.py: ScopeRuntimeMixin.get_scope_session_state`
+    via `runtime/radio.py: CoreRadio._expect_shape`); they default to the
+    shared hardcoded constants only so a caller that never passes one --
+    `runtime/_civ_rx.py`'s unsolicited-frame decoding, and every
+    pre-migration direct test call -- keeps working unchanged. Every other
+    ``parse_scope_*_response`` function below takes the same two keywords
+    for the same reason.
+    """
+    return _decode_scope_bool(frame, sub, command=command)
 
 
-def parse_scope_data_output_enabled_response(frame: CivFrame) -> bool:
+def parse_scope_data_output_enabled_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_DATA_OUTPUT
+) -> bool:
     """Parse a ``0x27 0x11`` waveform-output state response."""
-    return _decode_scope_bool(frame, _SUB_SCOPE_DATA_OUTPUT)
+    return _decode_scope_bool(frame, sub, command=command)
 
 
-def parse_scope_main_sub_response(frame: CivFrame) -> int:
-    data = _parse_scope_frame(frame, _SUB_SCOPE_MAIN_SUB)
+def parse_scope_main_sub_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_MAIN_SUB
+) -> int:
+    data = _parse_scope_frame(frame, sub, command=command)
     if len(data) != 1:
         raise ValueError(f"Scope receiver response must be 1 byte, got {len(data)}")
     return _validate_scope_range("scope receiver", data[0], 0, 1)
 
 
-def parse_scope_single_dual_response(frame: CivFrame) -> bool:
-    return _decode_scope_bool(frame, _SUB_SCOPE_SINGLE_DUAL)
+def parse_scope_single_dual_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_SINGLE_DUAL
+) -> bool:
+    return _decode_scope_bool(frame, sub, command=command)
 
 
-def parse_scope_mode_response(frame: CivFrame) -> tuple[int | None, int]:
-    return _decode_scope_value(frame, _SUB_SCOPE_MODE, minimum=0, maximum=3)
+def parse_scope_mode_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_MODE
+) -> tuple[int | None, int]:
+    return _decode_scope_value(frame, sub, minimum=0, maximum=3, command=command)
 
 
-def parse_scope_span_response(frame: CivFrame) -> tuple[int | None, int]:
-    data = _parse_scope_frame(frame, _SUB_SCOPE_SPAN)
+def parse_scope_span_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_SPAN
+) -> tuple[int | None, int]:
+    data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(1, 5))
     if len(payload) == 1:
         return receiver, _validate_scope_range("scope span", payload[0], 0, 7)
@@ -955,7 +980,9 @@ def parse_scope_span_response(frame: CivFrame) -> tuple[int | None, int]:
     return receiver, span
 
 
-def parse_scope_ref_response(frame: CivFrame) -> tuple[int | None, float]:
+def parse_scope_ref_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_REF
+) -> tuple[int | None, float]:
     """Decode scope REF level from CI-V response.
 
     Wire format (IC-7610 CI-V Reference p.15):
@@ -963,7 +990,7 @@ def parse_scope_ref_response(frame: CivFrame) -> tuple[int | None, float]:
       byte 1: high nibble = 0.1 dB digit, low nibble = 0
       byte 2: sign (0x00 = +, 0x01 = -)
     """
-    data = _parse_scope_frame(frame, _SUB_SCOPE_REF)
+    data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(3,))
     b0, b1 = payload[0], payload[1]
     tens_db = (b0 >> 4) & 0x0F
@@ -975,36 +1002,50 @@ def parse_scope_ref_response(frame: CivFrame) -> tuple[int | None, float]:
     return receiver, ref
 
 
-def parse_scope_speed_response(frame: CivFrame) -> tuple[int | None, int]:
-    return _decode_scope_value(frame, _SUB_SCOPE_SPEED, minimum=0, maximum=2)
+def parse_scope_speed_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_SPEED
+) -> tuple[int | None, int]:
+    return _decode_scope_value(frame, sub, minimum=0, maximum=2, command=command)
 
 
-def parse_scope_edge_response(frame: CivFrame) -> tuple[int | None, int]:
-    return _decode_scope_bcd_value(frame, _SUB_SCOPE_EDGE, minimum=1, maximum=4)
+def parse_scope_edge_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_EDGE
+) -> tuple[int | None, int]:
+    return _decode_scope_bcd_value(frame, sub, minimum=1, maximum=4, command=command)
 
 
-def parse_scope_hold_response(frame: CivFrame) -> tuple[int | None, bool]:
-    data = _parse_scope_frame(frame, _SUB_SCOPE_HOLD)
+def parse_scope_hold_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_HOLD
+) -> tuple[int | None, bool]:
+    data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(1,))
     return receiver, payload[0] != 0x00
 
 
-def parse_scope_during_tx_response(frame: CivFrame) -> bool:
-    return _decode_scope_bool(frame, _SUB_SCOPE_DURING_TX)
+def parse_scope_during_tx_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_DURING_TX
+) -> bool:
+    return _decode_scope_bool(frame, sub, command=command)
 
 
-def parse_scope_center_type_response(frame: CivFrame) -> tuple[int | None, int]:
-    return _decode_scope_value(frame, _SUB_SCOPE_CENTER_TYPE, minimum=0, maximum=2)
+def parse_scope_center_type_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_CENTER_TYPE
+) -> tuple[int | None, int]:
+    return _decode_scope_value(frame, sub, minimum=0, maximum=2, command=command)
 
 
-def parse_scope_vbw_response(frame: CivFrame) -> tuple[int | None, bool]:
-    data = _parse_scope_frame(frame, _SUB_SCOPE_VBW)
+def parse_scope_vbw_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_VBW
+) -> tuple[int | None, bool]:
+    data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(1,))
     return receiver, payload[0] != 0x00
 
 
-def parse_scope_fixed_edge_response(frame: CivFrame) -> ScopeFixedEdge:
-    data = _parse_scope_frame(frame, _SUB_SCOPE_FIXED_EDGE)
+def parse_scope_fixed_edge_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_FIXED_EDGE
+) -> ScopeFixedEdge:
+    data = _parse_scope_frame(frame, sub, command=command)
     _receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(12,))
     return ScopeFixedEdge(
         range_index=_bcd_decode_value(payload[:1]),
@@ -1014,5 +1055,7 @@ def parse_scope_fixed_edge_response(frame: CivFrame) -> ScopeFixedEdge:
     )
 
 
-def parse_scope_rbw_response(frame: CivFrame) -> tuple[int | None, int]:
-    return _decode_scope_value(frame, _SUB_SCOPE_RBW, minimum=0, maximum=2)
+def parse_scope_rbw_response(
+    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_RBW
+) -> tuple[int | None, int]:
+    return _decode_scope_value(frame, sub, minimum=0, maximum=2, command=command)

--- a/src/rigplane/runtime/_scope_runtime.py
+++ b/src/rigplane/runtime/_scope_runtime.py
@@ -18,6 +18,21 @@ else:
     _MixinBase = object
 
 from rigplane.commands import (
+    get_scope_center_type,
+    get_scope_data_output_enabled,
+    get_scope_during_tx,
+    get_scope_edge,
+    get_scope_enabled,
+    get_scope_fixed_edge,
+    get_scope_hold,
+    get_scope_main_sub,
+    get_scope_mode,
+    get_scope_rbw,
+    get_scope_ref,
+    get_scope_single_dual,
+    get_scope_span,
+    get_scope_speed,
+    get_scope_vbw,
     parse_ack_nak,
     parse_civ_frame,
     parse_scope_center_type_response,
@@ -147,9 +162,17 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_data_output_enabled(to_addr=self._radio_addr),
             label="get_scope_data_output_enabled",
         )
+        panel_command, panel_sub, _ = self._expect_shape(get_scope_enabled)
+        output_command, output_sub, _ = self._expect_shape(
+            get_scope_data_output_enabled
+        )
         return (
-            parse_scope_enabled_response(panel_response),
-            parse_scope_data_output_enabled_response(output_response),
+            parse_scope_enabled_response(
+                panel_response, command=panel_command, sub=panel_sub
+            ),
+            parse_scope_data_output_enabled_response(
+                output_response, command=output_command, sub=output_sub
+            ),
         )
 
     async def restore_scope_session_state(self, state: tuple[bool, bool]) -> None:
@@ -197,7 +220,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_main_sub(to_addr=self._radio_addr),
             label="get_scope_receiver",
         )
-        receiver = parse_scope_main_sub_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_main_sub)
+        receiver = parse_scope_main_sub_response(resp, command=command, sub=sub)
         self._scope_controls().receiver = receiver
         return receiver
 
@@ -219,7 +243,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_single_dual(to_addr=self._radio_addr),
             label="get_scope_dual",
         )
-        dual: bool = parse_scope_single_dual_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_single_dual)
+        dual: bool = parse_scope_single_dual_response(resp, command=command, sub=sub)
         self._scope_controls().dual = dual
         return dual
 
@@ -243,7 +268,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_mode(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_mode",
         )
-        rx_hint, mode = parse_scope_mode_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_mode)
+        rx_hint, mode = parse_scope_mode_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().mode = mode
         return mode
@@ -268,7 +294,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_span(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_span",
         )
-        rx_hint, span = parse_scope_span_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_span)
+        rx_hint, span = parse_scope_span_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().span = span
         return span
@@ -293,7 +320,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_edge(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_edge",
         )
-        rx_hint, edge = parse_scope_edge_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_edge)
+        rx_hint, edge = parse_scope_edge_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().edge = edge
         return edge
@@ -318,7 +346,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_hold(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_hold",
         )
-        rx_hint, hold = parse_scope_hold_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_hold)
+        rx_hint, hold = parse_scope_hold_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().hold = hold
         return hold
@@ -343,7 +372,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_ref(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_ref",
         )
-        rx_hint, ref_db = parse_scope_ref_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_ref)
+        rx_hint, ref_db = parse_scope_ref_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().ref_db = ref_db
         return ref_db
@@ -368,7 +398,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_speed(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_speed",
         )
-        rx_hint, speed = parse_scope_speed_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_speed)
+        rx_hint, speed = parse_scope_speed_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().speed = speed
         return speed
@@ -392,7 +423,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_during_tx(to_addr=self._radio_addr),
             label="get_scope_during_tx",
         )
-        during_tx = parse_scope_during_tx_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_during_tx)
+        during_tx = parse_scope_during_tx_response(resp, command=command, sub=sub)
         self._scope_controls().during_tx = during_tx
         return during_tx
 
@@ -412,7 +444,10 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_center_type(to_addr=self._radio_addr),
             label="get_scope_center_type",
         )
-        receiver, center_type = parse_scope_center_type_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_center_type)
+        receiver, center_type = parse_scope_center_type_response(
+            resp, command=command, sub=sub
+        )
         self._apply_scope_receiver_hint(receiver)
         self._scope_controls().center_type = center_type
         return center_type
@@ -434,7 +469,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_vbw(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_vbw",
         )
-        rx_hint, narrow = parse_scope_vbw_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_vbw)
+        rx_hint, narrow = parse_scope_vbw_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().vbw_narrow = narrow
         return narrow
@@ -483,7 +519,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             ),
             label="get_scope_fixed_edge",
         )
-        fixed_edge = parse_scope_fixed_edge_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_fixed_edge)
+        fixed_edge = parse_scope_fixed_edge_response(resp, command=command, sub=sub)
         self._scope_controls().fixed_edge = fixed_edge
         self._scope_controls().edge = fixed_edge.edge
         return fixed_edge
@@ -512,7 +549,10 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
         # Re-parse the frame we just built to recover the resolved range_index
         # (computed inside commands/scope.py: scope_set_fixed_edge) without
         # duplicating logic.
-        fixed_edge = parse_scope_fixed_edge_response(parse_civ_frame(civ))
+        command, sub, _ = self._expect_shape(get_scope_fixed_edge)
+        fixed_edge = parse_scope_fixed_edge_response(
+            parse_civ_frame(civ), command=command, sub=sub
+        )
         self._scope_controls().fixed_edge = fixed_edge
         self._scope_controls().edge = fixed_edge.edge
 
@@ -524,7 +564,8 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             self._commands.get_scope_rbw(to_addr=self._radio_addr, receiver=receiver),
             label="get_scope_rbw",
         )
-        rx_hint, rbw = parse_scope_rbw_response(resp)
+        command, sub, _ = self._expect_shape(get_scope_rbw)
+        rx_hint, rbw = parse_scope_rbw_response(resp, command=command, sub=sub)
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().rbw = rbw
         return rbw

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -35,8 +35,10 @@ from typing import Any
 
 import pytest
 
+from rigplane.commands._codec import bcd_encode_value
 from rigplane.commands._frame import decode_wire_tuple
-from rigplane.core.types import CivFrame
+from rigplane.commands.command_map import CommandMap
+from rigplane.core.types import CivFrame, bcd_encode
 from rigplane.runtime.radio import CoreRadio
 
 from test_profile_command_binding import _civ_rig_configs
@@ -412,3 +414,263 @@ async def test_date_time_utc_reply_prefix_comes_from_the_map(
     monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect_wrong)
     with pytest.raises(ValueError, match="prefix mismatch"):
         await getattr(radio, radio_method)()
+
+
+# commands/scope.py's fifteen parse_scope_*_response functions (MOR-2008,
+# this module's last residual step) are this file's third keystone case:
+# each parses through its own module-level parser, never
+# _get_bcd_level/_get_bool_value, so none can register in
+# MATCHER_BACKED_GETTERS above. Unlike the date/time/utc case, no CI-V
+# profile's declared [0x27, sub] tuple has ever diverged from another's for
+# any scope key (commands/scope.py's module docstring), so there is no real
+# pair of profiles to prove a mismatch with the way IC-7300 vs IC-7610 did
+# for date/time/utc. Each case below instead builds a CommandMap that
+# deliberately DIVERGES one scope key from its real, TOML-declared value --
+# simulating the "a future profile disagrees with the hardcoded default"
+# scenario the retrofit exists to survive -- and checks that
+# ScopeRuntimeMixin's getter follows the mutated map, not the module's
+# constant.
+_SCOPE_DIVERGENT_SUB = 0x7E
+
+
+def _mutate_command_map(
+    cmd_map: CommandMap, key: str, wire: tuple[int, ...]
+) -> CommandMap:
+    return CommandMap({**{k: cmd_map.get(k) for k in cmd_map}, key: wire})
+
+
+@dataclasses.dataclass(frozen=True)
+class _ScopeGetterSpec:
+    """One scope getter parsed by a dedicated ``parse_scope_*_response``.
+
+    ``method`` is the ``ScopeRuntimeMixin`` getter to call (takes no
+    arguments for every entry below). ``map_key`` is the ``CommandMap`` key
+    its request builder resolves -- equal to ``method`` for every entry
+    except ``get_scope_receiver``/``get_scope_dual``, whose builders are
+    named ``get_scope_main_sub``/``get_scope_single_dual``
+    (`commands/scope.py`). ``payload`` is a wire-valid ``CivFrame.data`` for
+    that getter's reply -- sized and ranged to satisfy its parser's own
+    length/value checks, independent of the command/sub shape this test
+    varies.
+    """
+
+    method: str
+    map_key: str
+    payload: bytes
+
+
+_SCOPE_GETTER_SPECS: tuple[_ScopeGetterSpec, ...] = (
+    _ScopeGetterSpec("get_scope_receiver", "get_scope_main_sub", b"\x00"),
+    _ScopeGetterSpec("get_scope_dual", "get_scope_single_dual", b"\x01"),
+    _ScopeGetterSpec("get_scope_mode", "get_scope_mode", b"\x02"),
+    _ScopeGetterSpec("get_scope_span", "get_scope_span", b"\x03"),
+    _ScopeGetterSpec(
+        "get_scope_edge", "get_scope_edge", bcd_encode_value(2, byte_count=1)
+    ),
+    _ScopeGetterSpec("get_scope_hold", "get_scope_hold", b"\x01"),
+    _ScopeGetterSpec("get_scope_ref", "get_scope_ref", b"\x05\x00\x00"),
+    _ScopeGetterSpec("get_scope_speed", "get_scope_speed", b"\x01"),
+    _ScopeGetterSpec("get_scope_during_tx", "get_scope_during_tx", b"\x01"),
+    _ScopeGetterSpec("get_scope_center_type", "get_scope_center_type", b"\x01"),
+    _ScopeGetterSpec("get_scope_vbw", "get_scope_vbw", b"\x01"),
+    _ScopeGetterSpec(
+        "get_scope_fixed_edge",
+        "get_scope_fixed_edge",
+        bcd_encode_value(1, byte_count=1)
+        + bcd_encode_value(1, byte_count=1)
+        + bcd_encode(1_000_000)
+        + bcd_encode(2_000_000),
+    ),
+    _ScopeGetterSpec("get_scope_rbw", "get_scope_rbw", b"\x01"),
+)
+
+
+def _scope_cases() -> list[tuple[str, _ScopeGetterSpec]]:
+    return [
+        (model, spec)
+        for model in sorted(_civ_rig_configs())
+        for spec in _SCOPE_GETTER_SPECS
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    _scope_cases(),
+    ids=[f"{model}-{spec.method}" for model, spec in _scope_cases()],
+)
+async def test_scope_getter_reply_shape_comes_from_the_map(
+    case: tuple[str, _ScopeGetterSpec], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scope getter's reply matcher must follow ITS OWN profile's map entry.
+
+    Manually confirmed red for the half-done shape (evidence in the PR):
+    reverting any one of `runtime/_scope_runtime.py`'s sixteen
+    ``self._expect_shape(get_scope_*)`` call sites to that getter's
+    pre-migration hardcoded ``_CMD_SCOPE``/``_SUB_SCOPE_*`` constants makes
+    this test's second assertion fail for every profile and that one
+    getter -- the divergent-map reply would be rejected (module constant
+    doesn't match the mutated map), while the stale-map reply would be
+    wrongly accepted (module constant happens to equal the pre-mutation
+    value) -- exactly the "requests moved, replies not" failure mode this
+    file exists to make impossible (plan §7).
+    """
+    model, spec = case
+    config = _civ_rig_configs()[model]
+    profile = config.to_profile()
+    cmd_map = profile.command_map
+    assert cmd_map is not None, f"{model}: to_profile() produced no command_map"
+    if not cmd_map.has(spec.map_key):
+        pytest.skip(f"{model} does not declare {spec.map_key}")
+
+    real_command, real_sub, real_prefix = decode_wire_tuple(cmd_map.get(spec.map_key))
+    assert real_prefix == b"", (
+        f"{model}:{spec.map_key} declares a data prefix ({real_prefix!r}) this "
+        "test does not model -- every scope.py wire tuple observed so far is "
+        "a bare [command, sub]."
+    )
+    assert real_sub != _SCOPE_DIVERGENT_SUB
+
+    mutated_map = _mutate_command_map(
+        cmd_map, spec.map_key, (real_command, _SCOPE_DIVERGENT_SUB)
+    )
+    mutated_profile = dataclasses.replace(profile, command_map=mutated_map)
+    monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)
+    radio = CoreRadio("198.51.100.1", profile=mutated_profile)
+
+    def _reply(sub: int) -> CivFrame:
+        return CivFrame(
+            to_addr=0xE0,
+            from_addr=profile.civ_addr,
+            command=real_command,
+            sub=sub,
+            data=spec.payload,
+        )
+
+    # A reply carrying the MUTATED map's own sub-command must parse without
+    # error -- proves the shape checked is THIS profile's (here,
+    # deliberately divergent) map entry, not the module's hardcoded default.
+    async def _fake_expect_divergent(civ: bytes, **kwargs: Any) -> CivFrame:
+        return _reply(_SCOPE_DIVERGENT_SUB)
+
+    monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect_divergent)
+    await getattr(radio, spec.method)()
+
+    # A reply carrying the key's REAL (pre-mutation) sub-command must NOT
+    # parse as if it matched -- it no longer does, once this profile's own
+    # map has been mutated away from it.
+    async def _fake_expect_stale(civ: bytes, **kwargs: Any) -> CivFrame:
+        return _reply(real_sub)
+
+    monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect_stale)
+    with pytest.raises(ValueError, match="Not a scope response"):
+        await getattr(radio, spec.method)()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", sorted(_civ_rig_configs()))
+async def test_get_scope_session_state_reply_shape_comes_from_the_map(
+    model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``get_scope_session_state`` parses TWO replies through TWO different
+    map keys (``scope_on``/``scope_data_output``) in one call, so it cannot
+    register as a single ``_ScopeGetterSpec`` row above. Mutates only the
+    panel key (``scope_on``); the data-output reply stays a real,
+    unmutated match throughout, proving the two replies are checked
+    independently against their own keys rather than one shared shape.
+    """
+    config = _civ_rig_configs()[model]
+    profile = config.to_profile()
+    cmd_map = profile.command_map
+    assert cmd_map is not None
+    if not (cmd_map.has("scope_on") and cmd_map.has("scope_data_output")):
+        pytest.skip(f"{model} does not declare scope_on/scope_data_output")
+
+    panel_command, panel_sub, _ = decode_wire_tuple(cmd_map.get("scope_on"))
+    output_command, output_sub, _ = decode_wire_tuple(cmd_map.get("scope_data_output"))
+    assert panel_sub != _SCOPE_DIVERGENT_SUB
+
+    mutated_map = _mutate_command_map(
+        cmd_map, "scope_on", (panel_command, _SCOPE_DIVERGENT_SUB)
+    )
+    mutated_profile = dataclasses.replace(profile, command_map=mutated_map)
+    monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)
+    radio = CoreRadio("198.51.100.1", profile=mutated_profile)
+
+    call_count = {"n": 0}
+
+    async def _fake_expect_divergent(civ: bytes, **kwargs: Any) -> CivFrame:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return CivFrame(
+                to_addr=0xE0,
+                from_addr=profile.civ_addr,
+                command=panel_command,
+                sub=_SCOPE_DIVERGENT_SUB,
+                data=b"\x01",
+            )
+        return CivFrame(
+            to_addr=0xE0,
+            from_addr=profile.civ_addr,
+            command=output_command,
+            sub=output_sub,
+            data=b"\x01",
+        )
+
+    monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect_divergent)
+    assert await radio.get_scope_session_state() == (True, True)
+
+    async def _fake_expect_stale_panel(civ: bytes, **kwargs: Any) -> CivFrame:
+        return CivFrame(
+            to_addr=0xE0,
+            from_addr=profile.civ_addr,
+            command=panel_command,
+            sub=panel_sub,
+            data=b"\x01",
+        )
+
+    monkeypatch.setattr(radio, "_send_civ_expect", _fake_expect_stale_panel)
+    with pytest.raises(ValueError, match="Not a scope response"):
+        await radio.get_scope_session_state()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", sorted(_civ_rig_configs()))
+async def test_set_scope_fixed_edge_reply_shape_comes_from_the_map(
+    model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``set_scope_fixed_edge`` makes no network round trip: it re-parses the
+    frame it just built (`runtime/_scope_runtime.py`) to recover the
+    resolved ``range_index``, a second call site for
+    ``parse_scope_fixed_edge_response`` sharing ``get_scope_fixed_edge``'s
+    map key. The request builder and this re-parse must read the SAME
+    mutated map for the round trip to still succeed -- checked directly,
+    with no mocked reply to manipulate (there is no network call to mock).
+    """
+    config = _civ_rig_configs()[model]
+    profile = config.to_profile()
+    cmd_map = profile.command_map
+    assert cmd_map is not None
+    if not cmd_map.has("get_scope_fixed_edge"):
+        pytest.skip(f"{model} does not declare get_scope_fixed_edge")
+
+    real_command, real_sub, _ = decode_wire_tuple(cmd_map.get("get_scope_fixed_edge"))
+    assert real_sub != _SCOPE_DIVERGENT_SUB
+    mutated_map = _mutate_command_map(
+        cmd_map, "get_scope_fixed_edge", (real_command, _SCOPE_DIVERGENT_SUB)
+    )
+    mutated_profile = dataclasses.replace(profile, command_map=mutated_map)
+    monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)
+    radio = CoreRadio("198.51.100.1", profile=mutated_profile)
+
+    async def _fake_send_civ_raw(civ: bytes, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(radio, "_send_civ_raw", _fake_send_civ_raw)
+
+    # The request builder reads this SAME mutated map, so the frame it
+    # builds already carries sub=_SCOPE_DIVERGENT_SUB. A parser still
+    # checking the module's hardcoded _SUB_SCOPE_FIXED_EDGE would reject
+    # its own request's echo; deriving the shape from the same map instead
+    # (this call site's retrofit) must not raise here.
+    await radio.set_scope_fixed_edge(edge=1, start_hz=1_000_000, end_hz=2_000_000)


### PR DESCRIPTION
## Summary

Last code residual of the profile-driven command-bytes migration
(epic tracked internally; scope.py's builders already moved onto the
bound command map in an earlier PR, leaving its response parsers on
hardcoded shapes — this closes that gap).

- `commands/scope.py`'s fifteen `parse_scope_*_response` functions
  (enabled, data-output-enabled, main/sub, single/dual, mode, span,
  edge, hold, ref, speed, during-TX, center-type, VBW, fixed-edge,
  RBW) each gain optional `command`/`sub` keywords, defaulting to the
  same `_CMD_SCOPE`/`_SUB_SCOPE_*` constants checked before this
  change — an unmigrated caller (`runtime/_civ_rx.py`'s
  unsolicited-frame decoding, which has no command-map entry to
  derive a shape from; pre-migration direct test calls) keeps
  working unchanged.
- The sixteen production call sites in
  `runtime/_scope_runtime.py: ScopeRuntimeMixin` (fifteen getters,
  plus `set_scope_fixed_edge`'s self-reparse of the frame it just
  built, which shares `get_scope_fixed_edge`'s reply shape) now
  derive both values via `runtime/radio.py: CoreRadio._expect_shape`,
  the same mechanism this migration series already uses elsewhere
  (e.g. `system.py`'s date/time/UTC parsers, `dsp.py`'s twelve
  matcher-backed getters).
- `tests/test_response_shape_from_profile.py` (the keystone) gains
  three dedicated cases — none of these fifteen parsers route
  through `_get_bcd_level`/`_get_bool_value`, so none can register in
  `MATCHER_BACKED_GETTERS` (the same reason the date/time/UTC trio
  and `get_dual_watch` are each a dedicated case there already).

## Site count

The dispatch for this work estimated 16 hardcoded shapes. The actual
count of top-level `parse_scope_*_response` function *definitions* in
`commands/scope.py` is **15** (verified: `grep -c '^def parse_.*_response'
src/rigplane/commands/scope.py`). The number of production *call sites*
needing retrofit in `runtime/_scope_runtime.py` is **16**, because
`parse_scope_fixed_edge_response` is called from two places
(`get_scope_fixed_edge`'s round trip and `set_scope_fixed_edge`'s
self-reparse of the frame it just built) — both now updated.

## Retrofit vs. pin

All 15 parsers / 16 call sites are retrofitted (no pins used). A pin
was considered unnecessary because a direct retrofit was reasonable at
every site — no case needed the "assert profile tuples equal the
hardcoded constants" fallback the dispatch allowed for a genuinely
unreasonable site.

## Sweep results

- **Call-site sweep** (dispatch: "sweep ALL of src/ ... for scope
  parser callers"): `grep -rl "parse_scope_.*_response" src/rigplane/`
  finds exactly two importers — `runtime/_scope_runtime.py` (the
  retrofit target, request/reply round trips) and `runtime/_civ_rx.py`
  (unsolicited-frame decoding, explicitly out of scope per the
  dispatch — no command-map entry exists for an unprompted frame, and
  this file is untouched: `git diff --stat -- src/rigplane/runtime/_civ_rx.py`
  is empty). No callers exist in `rigctld/`, `web/`, or
  `runtime/_dual_rx_runtime.py`.
- **Whole-table/per-profile assertion sweep** (dispatch: "sweep by
  AST" for any spec-type/shape assertion this change falsifies):
  grepped every test file for `inspect.signature` /
  `getfullargspec` / `co_varnames` / `co_argcount` / `__defaults__`
  (13 hits across 8 files) and read each. Every one checks for a
  `cmd_map` parameter on **builders** (`"cmd_map" in
  inspect.signature(value).parameters`) — an axis this change never
  touches, since no `parse_*` function gains `cmd_map`. One
  (`test_command_map_parity.py`'s hardcode-only-builder census)
  explicitly excludes any name starting with `parse` before that
  check. `test_commands.py`'s whole-table `to_addr` check only applies
  to functions that declare a `to_addr` parameter, which none of the
  fifteen retrofitted parsers do. Also read (read-only, per the
  collision-avoidance note below) `test_command_fallback_audit.py` and
  `test_naming_parity.py`, the two files enumerating every
  `rigplane.commands` member — neither asserts anything about parser
  signatures; both are green, unaffected.
- **Collision check**: the dispatch flagged a concurrent builder
  deleting `_fallback_audit.py` / `test_command_fallback_audit.py` /
  `_frame.py` dead constants / `docs/api/commands.md` in a separate
  worktree. None of those files are touched by this PR (confirmed via
  `git diff --stat`); `test_command_fallback_audit.py` was read for
  the sweep above but not modified, and its current census entry
  ("33 [builders lacking cmd_map] are, for the first time, exclusively
  `parse_*` response decoders") stays true after this change, since
  no `parse_*` function gains a `cmd_map` parameter.
- **Integration fixtures** (dispatch trap: "tests/integration/
  fixtures defaulting to IC-7610 that exercise scope getters"):
  `grep -n "parse_scope\|scope.py\|_scope_runtime"
  tests/integration/test_scope_advanced_integration.py
  tests/integration/test_x6200_audio_scope_smoke.py` returns nothing
  — both exercise the public `CoreRadio`/`IcomRadio` getters only,
  transparently unaffected by the new keyword-only parser parameters.

## Keystone red-proof evidence

Three representative call sites, each covering one of the three
distinct test mechanisms added, were manually reverted to their
pre-migration hardcoded check and confirmed red, then restored
(confirmed via `git diff` showing only the intended change before the
final test run):

1. `get_scope_mode` (generic case, shared by 12 other getters):
   reverting to `parse_scope_mode_response(resp)` (no `command`/`sub`)
   made `test_scope_getter_reply_shape_comes_from_the_map[*-get_scope_mode]`
   fail for all 4 declaring profiles (IC-705/7300/7610/9700) with
   `ValueError: Not a scope response: command 0x27 sub 0x7e`.
2. `get_scope_session_state` (two-key case): reverting to the
   pre-migration two bare parser calls made
   `test_get_scope_session_state_reply_shape_comes_from_the_map` fail
   the same way for all 4 profiles.
3. `set_scope_fixed_edge` (self-reparse, no network round trip):
   reverting to `parse_scope_fixed_edge_response(parse_civ_frame(civ))`
   made `test_set_scope_fixed_edge_reply_shape_comes_from_the_map` fail
   the same way for all 4 profiles.

All three mechanisms restored cleanly; `git diff` after restore
matched the final committed diff exactly.

## Regen delta note

`RIGPLANE_REGEN_COMMAND_MAP_PARITY=1 uv run pytest
tests/test_command_map_parity.py` and
`RIGPLANE_REGEN_PROFILE_COMMAND_COVERAGE=1 uv run pytest
tests/test_profile_command_coverage.py` were both run; neither
fixture file (`tests/command_map_parity_uncovered.txt`,
`tests/profile_command_coverage_gaps.txt`) changed
(`git diff --stat` empty for both). Expected: this PR touches
response parsers and their runtime call sites, not any command-map
*builder*, so the builder-parity/coverage census these fixtures
record has nothing new to capture.

## Size

4 files changed, 450 insertions(+), 80 deletions(-) — under both the
soft threshold (6 files / 600 lines) and the hard ceiling
(10 files / 1000 lines); no waiver needed or requested.

## Internal-identifier self-check

empty

## Test plan

- [x] `uv run pytest tests/test_response_shape_from_profile.py
      tests/test_scope.py tests/test_commands.py tests/test_radio.py
      tests/test_command_map_parity.py
      tests/test_profile_command_coverage.py tests/test_naming_parity.py
      tests/test_command_fallback_audit.py -q` — 1045 passed, 144
      skipped, 12 xfailed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run lint-imports` — 5 contracts kept, 0 broken
- [x] `.github/scripts/check-doc-citations.sh` and `--check-links` —
      clean
- [x] Mutation/red-proof cycle for all three keystone test mechanisms
      (see above)
- [ ] CI quick — pending; a red on the known `test_icom7610_serial_radio.py`
      worker-crash flake family, or the frontend Vite budget test, would
      be reported as that known flake rather than chased

🤖 Generated with [Claude Code](https://claude.com/claude-code)
