### PR TITLE
docs: fix the workspace-v1 runbook's CI gate block

### DIFF
--- a/docs/validation/workspace-v1-verification.md
+++ b/docs/validation/workspace-v1-verification.md
@@ -48,14 +48,16 @@ npm ci
 npx vitest run src/presentation/workspace/__tests__/workspace-compatibility-verification.test.ts
 ```
 
-Full gate (what CI runs):
+Full gate — the `Frontend install + check + tests + build` step of
+`.github/workflows/quick.yml`, its checks in that order:
 
 ```bash
 cd frontend
-npx vitest run          # whole frontend suite
-npm run lint
-npm run lint:boundaries
+npm ci
+npm run i18n:check
 npm run check
+npx vitest run          # whole frontend suite
+npm run build
 ```
 
 The suite is **fast-pool** (MOR-1272): storage is injected as a fake, so there


### PR DESCRIPTION
## What

`docs/validation/workspace-v1-verification.md`'s "How to re-run" section had a
`Full gate (what CI runs)` block that no workflow matched.

## Why it was false

- **`npm run lint` and `npm run lint:boundaries` are not run by any workflow.**
  At `bb5123a8`, `git grep -e 'eslint' -e 'npm run lint' -- .github/` exits 1.
  (Scope of that claim: the two npm *scripts* are never invoked. Eslint itself
  does execute in CI — `frontend/src/__tests__/architecture-boundaries.test.ts`
  and `control-feedback-ownership.test.ts` both `import { ESLint } from 'eslint'`
  and lint against the real flat config, so they run inside the `npx vitest run`
  this doc already cites.)
- The block omitted `npm ci`, `npm run i18n:check` and `npm run build`, and put
  `npx vitest run` first — the reverse of the real order.

## What it says now

The commands of the `Frontend install + check + tests + build` step of
`.github/workflows/quick.yml`, read from that file at `bb5123a8`, in its order:
`npm ci` → `npm run i18n:check` → `npm run check` → `npx vitest run` →
`npm run build`.

Cited by file + step name, no line numbers, per CLAUDE.md. Naming the workflow
file is load-bearing rather than decorative: `.github/workflows/publish.yml`
carries a step with the *identical* name and a different command list (no
`i18n:check`), so the step name alone would not identify which one is meant.

The block lists that step's *checks*, not its trailing copy-into-static
plumbing.

## Scope note — MOR-2043

MOR-2043 (branch `codex/mor-2043-eslint-ci-gate`, `deef705f`) adds a
`Frontend lint` step running `npm run lint` and splits this step into three
(`Frontend install` / `Frontend lint` / `Frontend check + tests + build`). It is
**not merged into main**, so this block does not claim it. When MOR-2043 lands,
this block needs `npm run lint` added after `npm ci` and its step citation
updated.

`npm run lint:boundaries` (`eslint src/components-v2/panels/
src/components-v2/layout/ src/presentation/` — `frontend/package.json`) is
invoked by no workflow on main or on the MOR-2043 branch, so it is dropped
rather than reworded.

## Known-loose wording, not fixed here

The retained label `Full gate` is the loosest remaining phrasing: the sentence
pins its scope to one named step, but three further blocking check steps in the
same job also run under the frontend path filter (`Frontend i18n visual smoke`,
`Frontend fixture-harness capture`, `Type-check web boundary`). The independent
reviewer weighed this and did not block, since every claim the sentence actually
makes verifies. Recorded here rather than silently widened or narrowed.

## Gates

Doc-only; no source or CI file changes.

- `.github/scripts/check-doc-citations.sh` → clean (845 grandfathered citations)
- `.github/scripts/check-doc-citations.sh --check-links` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)