### PR TITLE
fix(MOR-1880): client reads the server freshness contract for PTT

### DIFF
--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
@@ -55,25 +55,36 @@ describe('App TX authority projector', () => {
       facts: null, modInputSource: { status: 'unknown' },
     });
   });
-  it('advances only for genuinely newer qualifying field-specific evidence', () => {
+  it('reads the server freshness contract instead of re-deriving delivery cadence (MOR-1792)', () => {
     const project = createAppAuthorityProjector();
+    // The very first qualifying projection is fresh: no baseline suppression.
     expect(project(radio(), capabilities(), session(1)).ptt).toMatchObject({
-      observed: true, fresh: false, source: 'radio-readback',
-      marker: { pttObservationSeq: 1 },
+      observed: true, fresh: true, source: 'radio-readback',
+      marker: { authorityEpoch: 1, pttObservationSeq: null, pttLastObservedMonotonic: 1 },
+    });
+    // Decay regression: a second delivery carrying the SAME fieldStatus stays
+    // fresh with the same server marker — no delta-cadence re-derivation.
+    expect(project(radio(), capabilities(), session(1)).ptt).toMatchObject({
+      fresh: true, marker: { pttObservationSeq: null, pttLastObservedMonotonic: 1 },
     });
     const newer = withPtt(field(2, 'civ_unsolicited'));
     expect(project(newer, capabilities(), session(1)).ptt).toMatchObject({
       value: false, observed: true, fresh: true, source: 'backend-observation',
-      marker: { pttObservationSeq: 2, pttLastObservedMonotonic: 2 },
+      marker: { pttObservationSeq: null, pttLastObservedMonotonic: 2 },
     });
-    const duplicate = project(radio({ ptt: true, revision: 1_000, fieldStatus: { ...radio().fieldStatus, ptt: field(2, 'civ_unsolicited') } }), capabilities(), session(1));
-    expect(duplicate.ptt).toMatchObject({ value: true, fresh: false, marker: { pttObservationSeq: 2 } });
+    // A lower server timestamp is reported verbatim, never re-minted: the
+    // reducer's newer() is what refuses to advance on it.
+    expect(project(withPtt(field(1, 'civ_unsolicited')), capabilities(), session(1)).ptt)
+      .toMatchObject({ fresh: true, marker: { pttLastObservedMonotonic: 1 } });
     for (const malicious of ['toString', 'constructor', '__proto__'])
-      expect(project(withPtt(field(3, malicious)), capabilities(), session(1)).ptt).toMatchObject({ source: 'other', fresh: false, marker: { pttObservationSeq: 2, pttLastObservedMonotonic: 2 } });
+      expect(project(withPtt(field(3, malicious)), capabilities(), session(1)).ptt)
+        .toMatchObject({ source: 'other', fresh: false, marker: { pttObservationSeq: null, pttLastObservedMonotonic: null } });
     expect(project(withPtt(field(3, 'hamlib_response')), capabilities(), session(1)).ptt.source).toBe('radio-readback');
     expect(project(withPtt(field(4, 'yaesu_poll_response')), capabilities(), session(1)).ptt.fresh).toBe(true);
   });
-  it('rejects bad evidence and retains a per-epoch baseline against stale epochs', () => {
+  it('rejects bad evidence with a marker that can never advance, and epochs stay honest', () => {
+    // MOR-1694/1695 counterexample set, preserved verbatim: generic command
+    // responses and non-field authorities never become fresh PTT truth.
     const rejected = [
       field(2, 'command_response'), field(3, 'state_poller'),
       field(4, 'local_reconcile'), field(5, 'test'), field(6, 'unknown'),
@@ -84,17 +95,25 @@ describe('App TX authority projector', () => {
     for (const evidence of rejected) {
       const project = createAppAuthorityProjector();
       const first = project(withPtt(evidence), capabilities(), session(1));
-      expect(first.ptt).toMatchObject({ fresh: false, marker: { pttObservationSeq: 0 } });
+      expect(first.ptt).toMatchObject({
+        fresh: false,
+        marker: { pttObservationSeq: null, pttLastObservedMonotonic: null },
+      });
     }
     const project = createAppAuthorityProjector();
     project(radio(), capabilities(), session(1));
     project(withPtt(field(2)), capabilities(), session(1));
+    // Baseline regression: the FIRST projection after an epoch change is
+    // fresh — the old needsBaseline suppression is gone.
     const baseline = project(withPtt(field(10)), capabilities(), session(2));
-    expect(baseline.ptt).toMatchObject({ fresh: false, marker: { authorityEpoch: 2, pttObservationSeq: 3 } });
+    expect(baseline.ptt).toMatchObject({
+      fresh: true,
+      marker: { authorityEpoch: 2, pttObservationSeq: null, pttLastObservedMonotonic: 10 },
+    });
+    // A stale epoch can never be fresh or advance anything.
     expect(project(withPtt(field(11)), capabilities(), session(1)))
-      .toMatchObject({ epoch: 2, eligibility: { controlLive: false }, ptt: { fresh: false } });
-    expect(project(withPtt(field(10)), capabilities(), session(2)).ptt.fresh).toBe(false);
+      .toMatchObject({ epoch: 2, eligibility: { controlLive: false }, ptt: { fresh: false, marker: { pttLastObservedMonotonic: null } } });
     expect(project(withPtt(field(12), true), capabilities(), session(2)).ptt)
-      .toMatchObject({ value: true, fresh: true, marker: { pttObservationSeq: 4 } });
+      .toMatchObject({ value: true, fresh: true, marker: { pttLastObservedMonotonic: 12 } });
   });
 });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/browser-dependencies.isolated.test.ts
@@ -76,7 +76,7 @@ describe('browser TxController dependencies', () => {
     factory.dependencies.sendPtt('on', 'on-1', correlation, (report) => reports.push(report));
     expect(h.send).toHaveBeenCalledWith('ptt_on', { target, originalEpoch: 4 }, 'on-1');
     expect(reports).toEqual([{ outcome: 'sent', eventEpoch: 7,
-      barrier: { authorityEpoch: 7, pttObservationSeq: 2, pttLastObservedMonotonic: 2 } }]);
+      barrier: { authorityEpoch: 7, pttObservationSeq: null, pttLastObservedMonotonic: 2 } }]);
     emit({ commandId: 'foreign', kind: 'error', originalEpoch: 4, eventEpoch: 7 });
     emit({ commandId: 'on-1', kind: 'ack', originalEpoch: 3, eventEpoch: 7 }); expect(reports).toHaveLength(1);
     for (const [kind, outcome] of [['ack', 'ack'], ['response-ok', 'response-ok']] as const) {

--- a/frontend/src/lib/runtime/tx-controller/app-authority.ts
+++ b/frontend/src/lib/runtime/tx-controller/app-authority.ts
@@ -49,18 +49,11 @@ function controllerTarget(facts: TxCapabilityFacts | null): TxTarget {
     : null;
 }
 export function createAppAuthorityProjector() {
-  let epoch = -1; let ordinal = 0;
-  let lastPttAt: number | null = null;
-  let needsBaseline = true;
+  let epoch = -1;
   return (state: ServerState | null, capabilities: Capabilities | null,
     session: ControlSessionTransition): AppAuthorityProjection => {
     const validEpoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0;
-    const lowerEpoch = !validEpoch || session.epoch < epoch;
-    if (!lowerEpoch && session.epoch > epoch) {
-      epoch = session.epoch;
-      lastPttAt = null;
-      needsBaseline = true;
-    }
+    if (validEpoch && session.epoch > epoch) epoch = session.epoch;
     const currentSession = validEpoch && session.epoch === epoch;
     const controlLive = currentSession && session.state === 'connected';
     const inputs = projectInputs(state);
@@ -73,26 +66,37 @@ export function createAppAuthorityProjector() {
     const status = state?.fieldStatus?.ptt;
     const source = authoritySource(status?.source?.source);
     const at = status?.lastObservedMonotonic;
-    const qualifies = controlLive
+    const validAt = typeof at === 'number' && Number.isFinite(at);
+    // MOR-1792 (slice 2): `fresh` IS the server's freshness contract —
+    // `freshness === 'fresh' && availability === 'available'` — read off the
+    // delivered fieldStatus, plus the structural validity of the reading
+    // itself (live session, boolean value, observed, finite timestamp,
+    // field-specific authority). The old projector additionally required
+    // this DELIVERY to carry a strictly newer timestamp than the previous
+    // delivery consumed (`lastPttAt`) and suppressed the first qualifying
+    // edge per epoch (`needsBaseline`): both re-derived radio freshness from
+    // the delta cadence and produced the intermittent first-press refusal.
+    // Deleted, together with the client-minted `ordinal`.
+    const fresh = controlLive
       && typeof state?.ptt === 'boolean'
       && status?.observed === true
       && status.freshness === 'fresh'
       && status.availability === 'available'
-      && typeof at === 'number'
-      && Number.isFinite(at)
-      && source !== 'other'
-      && (lastPttAt === null || at > lastPttAt);
-    const baseline = qualifies && needsBaseline;
-    if (qualifies) { ordinal += 1; lastPttAt = at; needsBaseline = false; }
+      && validAt
+      && source !== 'other';
     return {
       epoch, facts, modInputSource: inputs.modInputSource, eligibility,
       ptt: {
         value: typeof state?.ptt === 'boolean' ? state.ptt : false,
-        observed: status?.observed === true, fresh: qualifies && !baseline, source,
+        observed: status?.observed === true, fresh, source,
+        // The marker is the server's own observation timestamp, never a
+        // client mint. A non-fresh projection carries a null timestamp, so
+        // `newer()` in the reducer can never advance on it — the property
+        // the deleted `ordinal` used to provide (#2744 review invariant).
         marker: {
           authorityEpoch: epoch,
-          pttObservationSeq: ordinal,
-          pttLastObservedMonotonic: lastPttAt,
+          pttObservationSeq: null,
+          pttLastObservedMonotonic: fresh && validAt ? at : null,
         },
       },
     };


### PR DESCRIPTION
## What this does

MOR-1792 slice 2 (MOR-1880). The app-authority projector (`app-authority.ts`) used to redefine "fresh" client-side, as "this delivery's PTT timestamp is strictly newer than the previous delivery's" (`lastPttAt`), and suppressed the first qualifying edge per epoch (`needsBaseline`). Those are properties of delta-delivery cadence, not of the radio's own state — a quiet band produced no broadcast advance, so a first key press racing a non-advancing delivery was refused not-eligible even with every backend input green.

Before this change, the client re-derived freshness from delivery cadence. After it, the client reads the server's own freshness contract directly (`freshness === 'fresh' && availability === 'available'`, plus structural validity of the reading), and the marker it forwards is the server's `lastObservedMonotonic` — never a client-minted value. `ordinal`, `lastPttAt`, and `needsBaseline` are deleted from the projector.

`model.ts: newer()` already had a fallback branch for a null `pttObservationSeq` (it compares `pttLastObservedMonotonic` instead) before this PR — the surrounding reducer was already built to accept exactly what a non-fresh projection now produces (a null marker timestamp, so `newer()` can never advance on it).

## Rebase

Rebased onto current `origin/main` (`a7de1369`, "docs: fix the workspace-v1 runbook's CI gate block (#2919)"). Confirmed a true no-op: `app-authority.ts` is byte-identical between the branch's original merge-base (`0bd9bc94`) and `origin/main`, and `diff <(git show <original-commit>) <(git show <rebased-commit>)` on this branch's patch is identical except for the commit hash line itself. New head: `cbff57b7a24e0e401a2e2096383ce9ed1a0618ea`.

## Diffstat

3 files, +56/−33:
```
 frontend/.../__tests__/app-authority.test.ts               | 45 +++++++++++++++-------
 frontend/.../__tests__/browser-dependencies.isolated.test.ts |  2 +-
 frontend/src/lib/runtime/tx-controller/app-authority.ts     | 42 +++++++++++---------
```

## Red-then-green (established for this PR, at the rebased head)

**Green — 12 touched suites / 258 tests, at branch tip:**
```
 Test Files  12 passed (12)
      Tests  258 passed (258)
```

**Red — same 12 suites, with `app-authority.ts` alone reverted to its pre-change (parent-commit) content, test files untouched:**
```
 FAIL   fast  .../app-authority.test.ts > App TX authority projector > reads the server freshness contract instead of re-deriving delivery cadence (MOR-1792)
AssertionError: expected { value: false, observed: true, …(3) } to match object { observed: true, fresh: true, …(2) }
- Expected
+ Received
  {
-   "fresh": true,
+   "fresh": false,
    "marker": {
      "authorityEpoch": 1,
      "pttLastObservedMonotonic": 1,
-     "pttObservationSeq": null,
+     "pttObservationSeq": 1,
    },
    ...
  }

 FAIL   fast  .../app-authority.test.ts > App TX authority projector > rejects bad evidence with a marker that can never advance, and epochs stay honest
AssertionError: expected { value: false, observed: true, …(3) } to match object { fresh: false, marker: { …(2) } }
  {
    "fresh": false,
    "marker": {
      "pttLastObservedMonotonic": null,
-     "pttObservationSeq": null,
+     "pttObservationSeq": 0,
    },
  }

 FAIL   isolated  .../browser-dependencies.isolated.test.ts > browser TxController dependencies > registers before send, freezes lease correlation, and maps only delivery evidence
AssertionError: expected [ { outcome: 'sent', …(2) } ] to deeply equal [ { outcome: 'sent', …(2) } ]
  [
    {
      "barrier": {
        "authorityEpoch": 7,
        "pttLastObservedMonotonic": 2,
-       "pttObservationSeq": null,
+       "pttObservationSeq": 2,
      },
      ...
    },
  ]

 Test Files  2 failed | 10 passed (12)
      Tests  3 failed | 255 passed (258)
```

**Restored** `app-authority.ts` to the committed version (`git checkout HEAD -- ...`); `git status` on the worktree showed a clean tree before and after this cycle. Re-ran the same 12 suites: back to 12 passed / 258 passed, matching the first run.

## Gates run

- `npm run check` (svelte-check + tsc): 0 errors, 0 warnings
- `npm run lint` (eslint): clean, exit 0
- `npm run i18n:check`: OK — the two informational notes it prints (missing `ja-JP`/`ru-RU` keys) are pre-existing and unrelated to this change; CI does not require full locale coverage
- The 12 touched vitest suites: see red-then-green above

Per the task scope, the full frontend suite was not run (other sessions active on this host).

## Open item for the owner — not resolved here

`docs/plans/2026-08-20-transmit-authority.md` (§10, "the bench owes exactly one number") records that MOR-1792 still owes a bench first-key-press baseline measurement. That gated the sibling slice-1 PR (#2745, already merged without an on-record discharge of the gate, per the doc's §1.6/Q1). Whether it also gates this slice-2 PR is not decided here — flagging it for the owner's call rather than claiming it is satisfied.
