### PR TITLE
fix: refuse to resolve an unidentified radio profile instead of guessing

### DIFF
--- a/src/rigplane/backends/icom7610/serial.py
+++ b/src/rigplane/backends/icom7610/serial.py
@@ -21,7 +21,7 @@ class Icom7610SerialRadio(_IcomSerialRadioBase):
     guardrail that raises ``CommandError``.
     """
 
-    _DEFAULT_MODEL = ""
+    _DEFAULT_MODEL = "IC-7610"
 
     # ------------------------------------------------------------------
     # IC-7610 specific: stop_audio_rx_pcm delegates to stop_audio_rx_opus

--- a/src/rigplane/profiles/LAYER.md
+++ b/src/rigplane/profiles/LAYER.md
@@ -19,7 +19,8 @@ runtime/backend layers consult for routing, validation, and UI surfacing.
 - `KeyboardBinding`, `KeyboardConfig` — UI-surfaced shortcut config.
 - `get_radio_profile(name_or_id)` — registry lookup by model or id.
 - `resolve_radio_profile(profile=, model=, radio_addr=)` — unified
-  resolution entry; falls back to IC-7610 / first LAN-capable profile.
+  resolution entry; raises `ValueError` when none of the three identifies
+  the radio (plan §8.1 Q5 — no silent default profile).
 - `reload_profiles()` — test/dev helper that resets the lazy registry.
 
 `profiles/rig_loader.py` exposes `discover_rigs()` and the TOML schema

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -558,7 +558,16 @@ def resolve_radio_profile(
     model: str | None = None,
     radio_addr: int | None = None,
 ) -> RadioProfile:
-    """Resolve runtime profile from explicit profile/model or CI-V address."""
+    """Resolve a runtime profile from an explicit override or a CI-V address.
+
+    A ``RadioProfile`` or a non-blank profile/model name is a deliberate
+    caller override and always wins over ``radio_addr``. When none of the
+    three identifies the radio — no profile, a ``None`` or
+    blank/whitespace-only model, and either no ``radio_addr`` or one that
+    matches no loaded profile — this raises :class:`ValueError` instead of
+    guessing a default profile (plan §8.1 Q5): an unidentified radio must
+    refuse rather than be silently driven as some other rig.
+    """
     _ensure_loaded()
     if isinstance(profile, RadioProfile):
         return profile
@@ -568,17 +577,11 @@ def resolve_radio_profile(
         return get_radio_profile(model)
     if radio_addr is not None and radio_addr in _by_civ_addr:
         return _by_civ_addr[radio_addr]
-    # Default fallback — prefer IC-7610 (primary LAN reference rig), then any LAN profile
-    profiles = _ensure_loaded()
-    ic7610 = profiles.get("IC-7610")
-    if ic7610 is not None and ic7610.has_lan:
-        return ic7610
-    for p in profiles.values():
-        if p.has_lan:
-            return p
-    if profiles:
-        return next(iter(profiles.values()))
-    raise KeyError("No rig profiles loaded — check rigs/ directory")
+    raise ValueError(
+        "Cannot resolve a radio profile: no profile, model, or matching "
+        "radio_addr identifies the radio. Pass an explicit profile= or "
+        "model= — rigplane no longer guesses a default rig."
+    )
 
 
 def reload_profiles() -> None:

--- a/src/rigplane/web/runtime_helpers.py
+++ b/src/rigplane/web/runtime_helpers.py
@@ -617,8 +617,7 @@ def projected_vfo_capability_tags(
       ``test_unknown_runtime_model_fails_closed_for_reserved_vfo_tags_across_consumers``.
     - A candidate that is not a non-empty string (``radio.model`` absent or
       blank and ``configured_model`` likewise) never reaches
-      ``resolve_radio_profile`` — whose empty-input path silently returns a
-      default rig profile — and instead yields no tags — pinned by
+      ``resolve_radio_profile`` and instead yields no tags — pinned by
       ``test_reserved_vfo_tags_absent_when_no_usable_candidate_model_exists``.
     """
     profile = getattr(radio, "profile", None)

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -738,7 +738,6 @@ class WebServer:
     ) -> None:
         self._radio = radio
         self._config = config or WebConfig()
-        self._profile_fallback_warned = False
         self._state_diagnostics = StateDiagnosticsRecorder(
             enabled=self._config.state_diagnostics
         )
@@ -967,19 +966,12 @@ class WebServer:
                 return resolve_radio_profile(model=candidate)
             except KeyError:
                 continue
-        # Unknown model: use the library-wide default resolution chain
-        # (reference LAN rig → any LAN rig → first loaded profile) and say
-        # so — never silently impersonate IC-7610 (MOR-174).
-        fallback = resolve_radio_profile()
-        if not self._profile_fallback_warned:
-            self._profile_fallback_warned = True
-            logger.warning(
-                "No rig profile matches radio model %r; falling back to %r — "
-                "capabilities, scope and CI-V behavior may not match the radio",
-                candidates[0] if candidates else self._config.radio_model,
-                fallback.model,
-            )
-        return fallback
+        # No candidate identified the radio (missing/blank model on both the
+        # radio and the config) or every candidate failed to resolve:
+        # resolve_radio_profile() itself now refuses rather than guessing a
+        # default profile (plan §8.1 Q5) — propagate that refusal instead of
+        # impersonating some other rig.
+        return resolve_radio_profile()
 
     def _projected_runtime_capabilities(self) -> set[str]:
         """Return runtime tags with VFO primitives trusted only from a profile."""

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -947,8 +947,16 @@ class WebServer:
     # Helpers for scope callback operations
     # ------------------------------------------------------------------
 
-    def _get_profile(self) -> "RadioProfile":
-        """Resolve the RadioProfile for the connected radio."""
+    def _resolve_profile_if_identified(self) -> "RadioProfile | None":
+        """Return the radio's profile, or None if nothing identifies it.
+
+        "No radio attached and no model configured" is a normal state (the
+        server hasn't connected to a radio yet) rather than a caller error,
+        so it never reaches ``resolve_radio_profile`` at all here -- unlike
+        an identification *attempt* that fails (a named ``radio.model`` or
+        configured ``radio_model`` that resolve_radio_profile can't find),
+        which still goes through the usual resolve-or-refuse path below.
+        """
         from ..profiles import RadioProfile, resolve_radio_profile
 
         raw_profile = getattr(self._radio, "profile", None) if self._radio else None
@@ -961,17 +969,32 @@ class WebServer:
             for m in (radio_model, self._config.radio_model)
             if isinstance(m, str) and m.strip() and m != _RADIO_MODEL_UNSPECIFIED
         ]
+        if not candidates:
+            return None
         for candidate in candidates:
             try:
                 return resolve_radio_profile(model=candidate)
             except KeyError:
                 continue
-        # No candidate identified the radio (missing/blank model on both the
-        # radio and the config) or every candidate failed to resolve:
-        # resolve_radio_profile() itself now refuses rather than guessing a
-        # default profile (plan §8.1 Q5) — propagate that refusal instead of
-        # impersonating some other rig.
+        # Every named candidate failed to resolve: resolve_radio_profile()
+        # itself now refuses rather than guessing a default profile (plan
+        # §8.1 Q5) — propagate that refusal instead of impersonating some
+        # other rig.
         return resolve_radio_profile()
+
+    def _get_profile(self) -> "RadioProfile":
+        """Resolve the RadioProfile for the connected radio.
+
+        Raises if nothing identifies the radio -- callers that must
+        tolerate "no radio attached yet" (e.g. ``_serve_info``) use
+        :meth:`_resolve_profile_if_identified` instead.
+        """
+        profile = self._resolve_profile_if_identified()
+        if profile is None:
+            from ..profiles import resolve_radio_profile
+
+            return resolve_radio_profile()  # raises: nothing identifies the radio
+        return profile
 
     def _projected_runtime_capabilities(self) -> set[str]:
         """Return runtime tags with VFO primitives trusted only from a profile."""
@@ -2975,7 +2998,12 @@ class WebServer:
         model = raw_model if isinstance(raw_model, str) else self._config.radio_model
         caps = self._projected_runtime_capabilities()
         has_dual_rx = "dual_rx" in caps
-        profile = self._get_profile()
+        # No radio attached and no model configured is a normal "not
+        # connected yet" state, not an unidentified radio to refuse (plan
+        # §8.1 Q5 covers resolve_radio_profile and radio construction, not
+        # this): this endpoint must keep serving with neutral defaults for
+        # every profile-derived field instead of calling the resolver.
+        profile = self._resolve_profile_if_identified()
         raw_connected = (
             getattr(self._radio, "connected", False) if self._radio else False
         )
@@ -2986,29 +3014,24 @@ class WebServer:
         control_connected = (
             raw_control_connected if isinstance(raw_control_connected, bool) else False
         )
-        body = json.dumps(
-            {
-                # Backward-compatible legacy fields
-                "server": "rigplane",
-                "version": __version__,
-                "proto": WEB_API_CONTRACT_VERSION,
-                "radio": model,
-                # New structured fields
-                "model": model,
-                "capabilities": {
-                    "hasSpectrum": "scope" in caps,
-                    "hasAudio": "audio" in caps,
-                    "hasTx": "tx" in caps,
-                    "hasDualReceiver": has_dual_rx,
-                    "hasTuner": "tuner" in caps,
-                    "hasCw": "cw" in caps,
-                    "hasWebrtc": webrtc_available() and "audio" in caps,
-                    "maxReceivers": (
-                        profile.receiver_count
-                        if self._radio is not None
-                        else (2 if has_dual_rx else 1)
-                    ),
-                    "tags": sorted(caps),
+        capabilities: dict[str, object] = {
+            "hasSpectrum": "scope" in caps,
+            "hasAudio": "audio" in caps,
+            "hasTx": "tx" in caps,
+            "hasDualReceiver": has_dual_rx,
+            "hasTuner": "tuner" in caps,
+            "hasCw": "cw" in caps,
+            "hasWebrtc": webrtc_available() and "audio" in caps,
+            "maxReceivers": (
+                profile.receiver_count
+                if profile is not None
+                else (2 if has_dual_rx else 1)
+            ),
+            "tags": sorted(caps),
+        }
+        if profile is not None:
+            capabilities.update(
+                {
                     "modes": list(profile.modes),
                     "filters": list(profile.filters),
                     "filterWidthMin": profile.filter_width_min,
@@ -3025,7 +3048,9 @@ class WebServer:
                         list(profile.pre_values) if profile.pre_values else None
                     ),
                     "preLabels": profile.pre_labels,
-                    "agcModes": list(profile.agc_modes) if profile.agc_modes else None,
+                    "agcModes": (
+                        list(profile.agc_modes) if profile.agc_modes else None
+                    ),
                     "agcLabels": profile.agc_labels,
                     "rfSqlControlModel": profile.rf_sql_control_model,
                     "antennas": profile.antenna_tx_count,
@@ -3039,7 +3064,18 @@ class WebServer:
                         for b in fr.bands
                     ]
                     or None,
-                },
+                }
+            )
+        body = json.dumps(
+            {
+                # Backward-compatible legacy fields
+                "server": "rigplane",
+                "version": __version__,
+                "proto": WEB_API_CONTRACT_VERSION,
+                "radio": model,
+                # New structured fields
+                "model": model,
+                "capabilities": capabilities,
                 "connection": {
                     "rigConnected": connected,
                     "radioReady": self._radio_ready(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,6 +210,7 @@ async def connected_radio(mock_radio: MockIcomRadio) -> AsyncGenerator[IcomRadio
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
     with fast_connect():
         await radio.connect()

--- a/tests/contracts/test_audio_lifecycle_conformance.py
+++ b/tests/contracts/test_audio_lifecycle_conformance.py
@@ -104,7 +104,7 @@ class _Harness:
 def _lan_harness() -> _Harness:
     from unittest.mock import MagicMock
 
-    radio = IcomRadio("192.168.99.1")
+    radio = IcomRadio("192.168.99.1", model="IC-7610")
     radio._connected = True
     radio._civ_transport = MagicMock()
     radio._audio_stream = AudioStream(_FakeLanAudioTransport())

--- a/tests/integration/test_dsp_levels_integration.py
+++ b/tests/integration/test_dsp_levels_integration.py
@@ -329,6 +329,7 @@ async def dsp_radio(dsp_mock: DspLevelsMockRadio) -> AsyncGenerator[IcomRadio, N
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
     with fast_connect():
         await radio.connect()

--- a/tests/integration/test_operator_toggles_integration.py
+++ b/tests/integration/test_operator_toggles_integration.py
@@ -377,6 +377,7 @@ async def toggle_radio(toggle_mock: ToggleMockRadio) -> AsyncGenerator[IcomRadio
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
     with fast_connect():
         await radio.connect()
@@ -959,6 +960,7 @@ class TestNakHandling:
                 username="testuser",
                 password="testpass",
                 timeout=1.0,
+                model="IC-7610",
             )
             with fast_connect():
                 await nak_radio.connect()

--- a/tests/integration/test_rit_tuner_integration.py
+++ b/tests/integration/test_rit_tuner_integration.py
@@ -279,6 +279,7 @@ async def rit_tuner_radio(
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
     with fast_connect():
         await radio.connect()

--- a/tests/integration/test_scope_advanced_integration.py
+++ b/tests/integration/test_scope_advanced_integration.py
@@ -190,6 +190,7 @@ async def scope_radio(scope_mock: ScopeMockRadio) -> AsyncGenerator[IcomRadio, N
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
     with fast_connect():
         await radio.connect()

--- a/tests/integration/test_vfo_dual_watch_integration.py
+++ b/tests/integration/test_vfo_dual_watch_integration.py
@@ -224,6 +224,7 @@ async def vfo_radio(vfo_mock: VfoDualWatchMockRadio) -> AsyncGenerator[IcomRadio
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
     with fast_connect():
         await radio.connect()

--- a/tests/serial_stub.py
+++ b/tests/serial_stub.py
@@ -192,7 +192,7 @@ class SerialMockRadio:
         self,
         *,
         profile: RadioProfile | str | None = None,
-        model: str | None = None,
+        model: str | None = "IC-7610",
     ) -> None:
         self._profile = resolve_radio_profile(profile=profile, model=model)
         self._connected = False

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -32,7 +32,7 @@ class TestAudioCodecEnum:
 
 class TestRadioAudioConfig:
     def test_default_codec(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         assert r.audio_codec == AudioCodec.PCM_2CH_16BIT
         assert r.audio_sample_rate == 48000
         assert r.audio_stream_request.rx_codec == AudioCodec.PCM_2CH_16BIT
@@ -56,6 +56,7 @@ class TestRadioAudioConfig:
             "192.168.1.100",
             audio_codec=AudioCodec.OPUS_1CH,
             audio_sample_rate=16000,
+            model="IC-7610",
         )
         assert r.audio_codec == AudioCodec.OPUS_1CH
         assert r.audio_sample_rate == 16000
@@ -76,16 +77,16 @@ class TestRadioAudioConfig:
         monkeypatch.setenv("ICOM_AUDIO_SAMPLE_RATE", "24000")
         monkeypatch.setattr(radio_module, "_DEFAULT_AUDIO_SAMPLE_RATE", 24000)
 
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
 
         assert r.audio_sample_rate == 24000
 
     def test_codec_from_int(self) -> None:
-        r = IcomRadio("192.168.1.100", audio_codec=0x40)
+        r = IcomRadio("192.168.1.100", audio_codec=0x40, model="IC-7610")
         assert r.audio_codec == AudioCodec.OPUS_1CH
 
     def test_codec_ulaw(self) -> None:
-        r = IcomRadio("192.168.1.100", audio_codec=AudioCodec.ULAW_1CH)
+        r = IcomRadio("192.168.1.100", audio_codec=AudioCodec.ULAW_1CH, model="IC-7610")
         assert r.audio_codec == AudioCodec.ULAW_1CH
 
 

--- a/tests/test_audio_fullduplex.py
+++ b/tests/test_audio_fullduplex.py
@@ -18,7 +18,7 @@ def mock_transport() -> MockTransport:
 
 @pytest.fixture
 def radio(mock_transport: MockTransport) -> IcomRadio:
-    r = IcomRadio("192.168.1.100")
+    r = IcomRadio("192.168.1.100", model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
@@ -53,7 +53,7 @@ class TestFullDuplex:
 
     @pytest.mark.asyncio
     async def test_start_audio_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.start_audio_opus(lambda pkt: None)
 

--- a/tests/test_audio_pipeline_harness.py
+++ b/tests/test_audio_pipeline_harness.py
@@ -36,7 +36,9 @@ class _RecordingAudioTransport:
 
 async def test_bridge_tx_pipeline_sends_raw_pcm_when_tx_codec_is_pcm() -> None:
     transport = _RecordingAudioTransport()
-    radio = IcomRadio("192.0.2.10", username="u", password="p", timeout=0.05)
+    radio = IcomRadio(
+        "192.0.2.10", username="u", password="p", timeout=0.05, model="IC-7610"
+    )
     radio._connected = True
     radio._civ_transport = object()
     radio._conn_state = RadioConnectionState.CONNECTED
@@ -102,7 +104,9 @@ async def test_bridge_tx_pipeline_degrades_to_rx_only_when_tx_codec_is_opus() ->
     shipping backend negotiates a non-PCM TX codec for the bridge.
     """
     transport = _RecordingAudioTransport()
-    radio = IcomRadio("192.0.2.10", username="u", password="p", timeout=0.05)
+    radio = IcomRadio(
+        "192.0.2.10", username="u", password="p", timeout=0.05, model="IC-7610"
+    )
     radio._connected = True
     radio._civ_transport = object()
     radio._conn_state = RadioConnectionState.CONNECTED

--- a/tests/test_audio_recovery.py
+++ b/tests/test_audio_recovery.py
@@ -32,6 +32,7 @@ def _make_radio(**kwargs) -> IcomRadio:
         reconnect_max_delay=0.2,
         watchdog_timeout=0.3,
         auto_recover_audio=True,
+        model="IC-7610",
     )
     defaults.update(kwargs)
     radio = IcomRadio("192.168.1.100", **defaults)
@@ -77,20 +78,20 @@ class _DummyTranscoder:
 @pytest.mark.e2e
 class TestAudioRecoveryConfig:
     def test_default_auto_recover_true(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         assert radio._auto_recover_audio is True
 
     def test_disable_auto_recover(self) -> None:
-        radio = IcomRadio("192.168.1.100", auto_recover_audio=False)
+        radio = IcomRadio("192.168.1.100", auto_recover_audio=False, model="IC-7610")
         assert radio._auto_recover_audio is False
 
     def test_on_audio_recovery_callback_stored(self) -> None:
         cb = MagicMock()
-        radio = IcomRadio("192.168.1.100", on_audio_recovery=cb)
+        radio = IcomRadio("192.168.1.100", on_audio_recovery=cb, model="IC-7610")
         assert radio._on_audio_recovery is cb
 
     def test_on_audio_recovery_default_none(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         assert radio._on_audio_recovery is None
 
 

--- a/tests/test_audio_recovery_session.py
+++ b/tests/test_audio_recovery_session.py
@@ -105,6 +105,7 @@ class _StatefulFakeStream(FakeAudioStream):
 
 
 def _make_radio(**kwargs: object) -> IcomRadio:
+    kwargs.setdefault("model", "IC-7610")
     radio = IcomRadio("192.168.1.100", **kwargs)  # type: ignore[arg-type]
     radio._ctrl_transport = MagicMock()
     radio._civ_transport = MagicMock()

--- a/tests/test_audio_session_radio_owned.py
+++ b/tests/test_audio_session_radio_owned.py
@@ -33,7 +33,7 @@ from rigplane.runtime.radio import IcomRadio
 
 def test_icom_audio_session_is_cached_singleton() -> None:
     """Repeated access returns the SAME session object (lazy + cached)."""
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     session = radio.audio_session
     assert isinstance(session, AudioSession)
     assert radio.audio_session is session
@@ -41,7 +41,7 @@ def test_icom_audio_session_is_cached_singleton() -> None:
 
 def test_icom_audio_session_wraps_shared_audio_bus() -> None:
     """The radio-owned session wraps the radio's shared AudioBus."""
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     assert radio.audio_session.bus is radio.audio_bus
 
 

--- a/tests/test_audio_transcoder.py
+++ b/tests/test_audio_transcoder.py
@@ -127,7 +127,7 @@ class TestPcmOpusTranscoder:
 class TestRadioPcmHooks:
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_internal_sends_raw_pcm(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
 
         pcm = b"\x01\x02" * 960
@@ -138,7 +138,7 @@ class TestRadioPcmHooks:
     async def test_push_audio_tx_pcm_internal_encodes_when_tx_codec_is_opus(
         self,
     ) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._audio_tx_codec = AudioCodec.OPUS_1CH
         radio.push_audio_tx_opus = AsyncMock()  # type: ignore[method-assign]
 
@@ -153,7 +153,7 @@ class TestRadioPcmHooks:
         radio.push_audio_tx_opus.assert_awaited_once_with(b"opus:\x01\x02")
 
     def test_decode_audio_packet_to_pcm_and_callback_adapter(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
 
         class _DummyTranscoder:
             def opus_to_pcm(self, opus: bytes) -> bytes:
@@ -177,7 +177,7 @@ class TestRadioPcmHooks:
 class TestRadioPcmRxApi:
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_decodes_and_forwards_gaps(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         fake_stream = FakeAudioStream()
@@ -207,7 +207,7 @@ class TestRadioPcmRxApi:
 
     @pytest.mark.asyncio
     async def test_stop_audio_rx_pcm_delegates(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         fake_stream = FakeAudioStream()
         radio._audio_stream = fake_stream  # type: ignore[assignment]
 
@@ -216,25 +216,25 @@ class TestRadioPcmRxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_invalid_callback(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(TypeError, match="callback must be callable"):
             await radio.start_audio_rx_pcm(None)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_invalid_jitter_depth_type(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(TypeError, match="jitter_depth must be an int"):
             await radio.start_audio_rx_pcm(lambda _: None, jitter_depth=1.5)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_invalid_jitter_depth_value(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ValueError, match="jitter_depth must be >= 0"):
             await radio.start_audio_rx_pcm(lambda _: None, jitter_depth=-1)
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_invalid_format(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         with pytest.raises(AudioFormatError, match="Unsupported sample_rate"):
@@ -242,7 +242,7 @@ class TestRadioPcmRxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_rx_pcm_disconnected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError, match="Not connected to radio"):
             await radio.start_audio_rx_pcm(lambda _: None)
 
@@ -250,7 +250,7 @@ class TestRadioPcmRxApi:
 class TestRadioPcmTxApi:
     @pytest.mark.asyncio
     async def test_start_audio_tx_pcm_starts_stream_and_tracks_format(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         fake_stream = FakeAudioStream()
@@ -265,7 +265,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_sends_raw_pcm(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         radio._pcm_tx_fmt = (48000, 1, 20)
@@ -277,7 +277,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_not_started(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
 
@@ -286,7 +286,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_tx_pcm_invalid_types(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(TypeError, match="sample_rate must be an int"):
             await radio.start_audio_tx_pcm(sample_rate=True)  # type: ignore[arg-type]
         with pytest.raises(TypeError, match="channels must be an int"):
@@ -296,7 +296,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_tx_pcm_invalid_format(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
 
@@ -305,7 +305,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_tx_pcm_does_not_require_opus_backend(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         fake_stream = FakeAudioStream()
@@ -321,7 +321,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_tx_pcm_defaults_to_contract_sample_rate(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         fake_stream = FakeAudioStream()
@@ -349,7 +349,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_push_audio_tx_pcm_frame_size_error(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         radio._civ_transport = MagicMock()
         radio._pcm_tx_fmt = (48000, 1, 20)
@@ -359,7 +359,7 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_stop_audio_tx_pcm_delegates_and_clears_state(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         fake_stream = FakeAudioStream()
         radio._audio_stream = fake_stream  # type: ignore[assignment]
         radio._pcm_tx_fmt = (48000, 1, 20)
@@ -370,6 +370,6 @@ class TestRadioPcmTxApi:
 
     @pytest.mark.asyncio
     async def test_start_audio_tx_pcm_disconnected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError, match="Not connected to radio"):
             await radio.start_audio_tx_pcm()

--- a/tests/test_audio_transport_lan.py
+++ b/tests/test_audio_transport_lan.py
@@ -28,7 +28,7 @@ from rigplane.radio import IcomRadio
 
 def _make_radio() -> tuple[IcomRadio, FakeAudioStream]:
     """Build a 'connected' IcomRadio with a FakeAudioStream installed."""
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     radio._connected = True
     radio._civ_transport = MagicMock()
     stream = FakeAudioStream()
@@ -50,11 +50,11 @@ def _use_opus_tx_contract(radio: IcomRadio) -> None:
 
 class TestAudioTransportConformance:
     def test_icom_radio_satisfies_audio_transport(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         assert isinstance(radio, AudioTransport)
 
     def test_neutral_methods_present(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         for name in ("start_rx", "stop_rx", "start_tx", "push_tx", "stop_tx"):
             assert callable(getattr(radio, name))
 

--- a/tests/test_backend_contract_matrix.py
+++ b/tests/test_backend_contract_matrix.py
@@ -124,7 +124,7 @@ def backend_fixture(request: pytest.FixtureRequest) -> _BackendFixture:
     name = str(request.param)
     if name == "lan":
         transport = _MockLanTransport()
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._civ_transport = transport
         radio._ctrl_transport = transport
         radio._connected = True

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -68,12 +68,13 @@ class TestBackendConfigValidation:
 
 
 class TestCreateRadioFactory:
-    def test_create_radio_builds_lan_backend(self) -> None:
-        radio = create_radio(
-            LanBackendConfig(host="192.168.55.40", username="u", password="p")
-        )
-        assert isinstance(radio, IcomRadio)
-        assert radio.model == "IC-7610"
+    def test_create_radio_lan_backend_refuses_without_a_model(self) -> None:
+        """A LAN backend with no model/profile/radio_addr no longer
+        silently impersonates IC-7610 (plan §8.1 Q5) — it refuses."""
+        with pytest.raises(ValueError, match="Cannot resolve a radio profile"):
+            create_radio(
+                LanBackendConfig(host="192.168.55.40", username="u", password="p")
+            )
 
     def test_create_radio_uses_profile_civ_addr_when_model_provided(self) -> None:
         radio = create_radio(LanBackendConfig(host="192.168.55.40", model="IC-7300"))
@@ -119,7 +120,7 @@ class TestCreateRadioFactory:
         assert radio._serial_ptt_mode == "civ"
 
     def test_lan_backend_has_icom_lan_backend_id(self) -> None:
-        radio = create_radio(LanBackendConfig(host="192.168.55.40"))
+        radio = create_radio(LanBackendConfig(host="192.168.55.40", model="IC-7610"))
         assert radio.backend_id == "rigplane"
 
     def test_serial_icom_backend_has_icom_serial_backend_id(self) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -82,7 +82,7 @@ def transport() -> MockTransport:
 
 @pytest.fixture  # type: ignore[untyped-decorator]
 def radio(transport: MockTransport) -> Generator[IcomRadio, None, None]:
-    r = IcomRadio("192.168.1.100")
+    r = IcomRadio("192.168.1.100", model="IC-7610")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True

--- a/tests/test_civ_rx_dispatch_golden.py
+++ b/tests/test_civ_rx_dispatch_golden.py
@@ -66,7 +66,7 @@ def _build_frame(spec: dict[str, Any]) -> CivFrame:
 @pytest.fixture
 def radio() -> IcomRadio:
     transport = MockTransport()
-    r = IcomRadio("192.168.1.100")
+    r = IcomRadio("192.168.1.100", model="IC-7610")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True

--- a/tests/test_civ_rx_short_frame_robustness.py
+++ b/tests/test_civ_rx_short_frame_robustness.py
@@ -28,7 +28,7 @@ from rigplane.types import CivFrame
 
 def _make_radio() -> IcomRadio:
     transport = MockTransport()
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     radio._civ_transport = transport
     radio._ctrl_transport = transport
     radio._connected = True

--- a/tests/test_civ_transaction_ownership.py
+++ b/tests/test_civ_transaction_ownership.py
@@ -30,7 +30,7 @@ def transport() -> MockTransport:
 
 @pytest.fixture
 def radio(transport: MockTransport):
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -586,7 +586,7 @@ class TestCmdPttManagedIngress:
         # member, so ``isinstance(..., ManagedTxCapable)`` now reads True
         # structurally -- the probe the protocol's own docstring says not to
         # trust. ``bind()`` returning ``None`` is the invariant that matters.)
-        shipped = RuntimeIcomRadio("127.0.0.1")
+        shipped = RuntimeIcomRadio("127.0.0.1", model="IC-7610")
         writes: list[bool] = []
 
         async def _record(on: bool) -> None:

--- a/tests/test_connect_teardown_hygiene.py
+++ b/tests/test_connect_teardown_hygiene.py
@@ -160,7 +160,7 @@ class _TimeoutCivTransport(ConnectMockTransport):
 class TestFailedConnectRetryHygiene:
     async def test_failed_discovery_then_retry_leaves_no_orphans(self) -> None:
         """Stale-LAN-slot: discovery timeout, then a clean successful retry."""
-        radio = IcomRadio("192.168.1.100", username="u", password="p")
+        radio = IcomRadio("192.168.1.100", username="u", password="p", model="IC-7610")
         ctrl = radio._ctrl_transport  # real IcomTransport — real keepalive tasks
         assert isinstance(ctrl, IcomTransport)
 

--- a/tests/test_credential_refresh.py
+++ b/tests/test_credential_refresh.py
@@ -49,14 +49,18 @@ class _FakeCtrlTransport:
 
 
 def test_update_credentials_mutates_stored_values() -> None:
-    r = IcomRadio("192.168.1.100", username="old-user", password="old-pass")
+    r = IcomRadio(
+        "192.168.1.100", username="old-user", password="old-pass", model="IC-7610"
+    )
     r.update_credentials(username="new-user", password="new-pass")
     assert r._username == "new-user"
     assert r._password == "new-pass"
 
 
 def test_update_credentials_partial_update_keeps_other_field() -> None:
-    r = IcomRadio("192.168.1.100", username="old-user", password="old-pass")
+    r = IcomRadio(
+        "192.168.1.100", username="old-user", password="old-pass", model="IC-7610"
+    )
     r.update_credentials(password="new-pass")
     assert r._username == "old-user"
     assert r._password == "new-pass"
@@ -66,7 +70,9 @@ def test_update_credentials_partial_update_keeps_other_field() -> None:
 
 
 def test_update_credentials_noop_when_no_args() -> None:
-    r = IcomRadio("192.168.1.100", username="old-user", password="old-pass")
+    r = IcomRadio(
+        "192.168.1.100", username="old-user", password="old-pass", model="IC-7610"
+    )
     r.update_credentials()
     assert r._username == "old-user"
     assert r._password == "old-pass"
@@ -74,7 +80,9 @@ def test_update_credentials_noop_when_no_args() -> None:
 
 @pytest.mark.asyncio
 async def test_full_reconnect_builds_login_packet_with_new_password() -> None:
-    r = IcomRadio("192.168.1.100", username="user", password="old-pass")
+    r = IcomRadio(
+        "192.168.1.100", username="user", password="old-pass", model="IC-7610"
+    )
     r._ctrl_transport = _FakeCtrlTransport()  # type: ignore[assignment]
     r.update_credentials(password="new-pass")
 
@@ -97,7 +105,9 @@ async def test_full_reconnect_builds_login_packet_with_new_password() -> None:
 
 @pytest.mark.asyncio
 async def test_soft_reconnect_reuses_token_and_does_not_reauth() -> None:
-    r = IcomRadio("192.168.1.100", username="user", password="old-pass")
+    r = IcomRadio(
+        "192.168.1.100", username="user", password="old-pass", model="IC-7610"
+    )
     r._ctrl_transport = _FakeCtrlTransport()  # type: ignore[assignment]
     r._token = 0x1234
     # Healthy CI-V transport with fresh data => soft_reconnect noop path.

--- a/tests/test_docs_runtime_sync.py
+++ b/tests/test_docs_runtime_sync.py
@@ -32,7 +32,7 @@ def _assert_doc_patterns(rel_path: str, patterns: list[str]) -> None:
 
 
 def test_runtime_invariant_radio_ready_tracks_civ_health() -> None:
-    radio = IcomRadio("127.0.0.1")
+    radio = IcomRadio("127.0.0.1", model="IC-7610")
     radio._conn_state = RadioConnectionState.CONNECTED
     radio._civ_transport = SimpleNamespace(_udp_error_count=0)
     radio._civ_stream_ready = True

--- a/tests/test_dsp_filter_family.py
+++ b/tests/test_dsp_filter_family.py
@@ -102,7 +102,7 @@ class TestDspControlCapableSatisfaction:
     """Both IcomRadio and YaesuCatRadio satisfy the extended DspControlCapable."""
 
     def test_icom_radio_is_dsp_control_capable(self) -> None:
-        radio = IcomRadio(host="127.0.0.1", username="x", password="y")
+        radio = IcomRadio(host="127.0.0.1", username="x", password="y", model="IC-7610")
         assert isinstance(radio, DspControlCapable)
 
     def test_yaesu_cat_radio_is_dsp_control_capable(self) -> None:
@@ -131,7 +131,7 @@ class TestDspControlCapableSatisfaction:
 # ---------------------------------------------------------------------------
 
 
-def _connected_icom(*, model: str | None = None) -> IcomRadio:
+def _connected_icom(*, model: str | None = "IC-7610") -> IcomRadio:
     """Build a minimally-connected IcomRadio for unit tests."""
     kwargs: dict[str, str] = {}
     if model is not None:

--- a/tests/test_dx_cluster.py
+++ b/tests/test_dx_cluster.py
@@ -426,7 +426,12 @@ class TestWebServerDXBroadcast:
         """_broadcast_dx_spot() pushes dx_spot message to control event queues."""
         from rigplane.web.server import WebConfig, WebServer
 
-        config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
+        config = WebConfig(
+            host="127.0.0.1",
+            port=0,
+            keepalive_interval=9999.0,
+            radio_model="IC-7610",
+        )
         srv = WebServer(None, config)
 
         q: asyncio.Queue = asyncio.Queue()
@@ -507,7 +512,12 @@ class TestWebServerDXBroadcast:
         from rigplane.web.server import WebConfig, WebServer
         from rigplane.web.websocket import WS_OP_TEXT, WebSocketConnection
 
-        config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
+        config = WebConfig(
+            host="127.0.0.1",
+            port=0,
+            keepalive_interval=9999.0,
+            radio_model="IC-7610",
+        )
         srv = WebServer(None, config)
 
         spot = DXSpot(spotter="K1ABC", freq=14074000, call="JA1XYZ")

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -1502,7 +1502,7 @@ def test_serial_scope_pacing_profile_is_separate_from_lan(
         device="/dev/ttyUSB0",
         civ_link=_FakeSerialCivLink(),
     )
-    lan_radio = IcomRadio("192.168.55.40")
+    lan_radio = IcomRadio("192.168.55.40", model="IC-7610")
     assert serial_radio._civ_min_interval > lan_radio._civ_min_interval
 
 

--- a/tests/test_issue_141_core_refactor.py
+++ b/tests/test_issue_141_core_refactor.py
@@ -10,5 +10,5 @@ def test_icom_radio_is_thin_wrapper_over_core() -> None:
 
 def test_wrapper_constructor_signature_is_compatible() -> None:
     """Wrapper should instantiate with the same constructor as before."""
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     assert radio.model == "IC-7610"

--- a/tests/test_lifecycle_diagnostics.py
+++ b/tests/test_lifecycle_diagnostics.py
@@ -30,7 +30,7 @@ def test_radio_gc_with_active_connection_logs_warning(
 ) -> None:
     """When a Radio is collected while still 'connected', a WARN is emitted."""
     with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
-        radio = IcomRadio("192.168.1.1")
+        radio = IcomRadio("192.168.1.1", model="IC-7610")
         # Simulate still connected (e.g. user forgot disconnect() or async with exit)
         radio._conn_state = RadioConnectionState.CONNECTED
         del radio
@@ -53,7 +53,7 @@ def test_radio_gc_when_disconnected_does_not_log_warning(
     # test's warning boundary.
     gc.collect()
     with caplog.at_level(logging.WARNING, logger="rigplane.runtime.radio"):
-        radio = IcomRadio("192.168.1.1")
+        radio = IcomRadio("192.168.1.1", model="IC-7610")
         assert radio._conn_state == RadioConnectionState.DISCONNECTED
         del radio
         gc.collect()

--- a/tests/test_managed_radio_runtime.py
+++ b/tests/test_managed_radio_runtime.py
@@ -321,7 +321,7 @@ async def test_shutdown_error_is_shared(error: BaseException) -> None:
 
 @pytest.mark.asyncio
 async def test_real_core_radio_keyword_port_binds_effectless_generation() -> None:
-    radio = CoreRadio("127.0.0.1")
+    radio = CoreRadio("127.0.0.1", model="IC-7610")
     rt = runtime(lifecycle=radio)
     changed = await rt.replace_provider(ready=False)
     assert changed.snapshot.provider_generation == 1
@@ -332,7 +332,7 @@ async def test_real_core_radio_keyword_port_binds_effectless_generation() -> Non
 @pytest.mark.asyncio
 async def test_real_core_radio_fresh_read_preserves_healthy_generation() -> None:
     transport = MockTransport()
-    radio = CoreRadio("127.0.0.1", timeout=0.05)
+    radio = CoreRadio("127.0.0.1", timeout=0.05, model="IC-7610")
     radio._civ_transport = transport
     radio._connected = True
     rt = runtime(lifecycle=radio)

--- a/tests/test_managed_tx_api.py
+++ b/tests/test_managed_tx_api.py
@@ -83,7 +83,7 @@ def test_shipped_radio_is_dormant() -> None:
     # must still hold is the invariant that matters: nothing constructs or
     # arms a runtime until PR2, so the facade refuses to bind and the legacy
     # provider path stays untouched.
-    shipped = IcomRadio("127.0.0.1")
+    shipped = IcomRadio("127.0.0.1", model="IC-7610")
 
     assert ManagedTxApi.bind(shipped, _OWNER) is None
     assert ManagedTxApi.bind(object(), _OWNER) is None

--- a/tests/test_managed_tx_assembly.py
+++ b/tests/test_managed_tx_assembly.py
@@ -74,7 +74,7 @@ _OWNER = TxOwner(TxSource.SDK, "session")
 
 def _unconnected_radio() -> IcomRadio:
     """A constructed-but-never-connected radio -- no transport, no runtime."""
-    return IcomRadio("127.0.0.1")
+    return IcomRadio("127.0.0.1", model="IC-7610")
 
 
 # --- (a) real class member, not a conjured attribute -----------------------
@@ -112,7 +112,7 @@ def test_unconnected_radio_managed_tx_is_none() -> None:
 
 def test_bare_core_radio_managed_tx_is_none() -> None:
     # Not just the LAN subclass -- the member is inert on the shared base too.
-    radio = CoreRadio("127.0.0.1")
+    radio = CoreRadio("127.0.0.1", model="IC-7610")
 
     assert radio.managed_tx is None
 
@@ -268,7 +268,7 @@ class _AssembledRadio(CoreRadio):
         answers_probe: bool = True,
         host: str = "127.0.0.1",
     ) -> None:
-        super().__init__(host)
+        super().__init__(host, model="IC-7610")
         self.provider = provider
         self.answers_probe = answers_probe
         self.probes: list[bytes] = []

--- a/tests/test_managed_tx_identity_pins.py
+++ b/tests/test_managed_tx_identity_pins.py
@@ -111,7 +111,7 @@ def transport() -> MockTransport:
 
 @pytest.fixture
 def radio(transport: MockTransport):
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True

--- a/tests/test_mock_integration.py
+++ b/tests/test_mock_integration.py
@@ -31,6 +31,7 @@ class TestConnect:
             port=mock_radio.control_port,
             username="testuser",
             password="testpass",
+            model="IC-7610",
         )
         with fast_connect():
             await radio.connect()
@@ -46,6 +47,7 @@ class TestConnect:
                 port=mock_radio.control_port,
                 username="testuser",
                 password="testpass",
+                model="IC-7610",
             ) as radio:
                 assert radio.connected
         # After __aexit__, should be disconnected
@@ -59,6 +61,7 @@ class TestConnect:
             port=mock_radio.control_port,
             username="wronguser",
             password="wrongpass",
+            model="IC-7610",
         )
         with fast_connect():
             with pytest.raises(AuthenticationError):
@@ -76,6 +79,7 @@ class TestConnect:
                     port=mock_radio.control_port,
                     username="testuser",
                     password="testpass",
+                    model="IC-7610",
                 )
                 await radio.connect()
                 assert radio.connected

--- a/tests/test_mor1408_slow_client_recovery.py
+++ b/tests/test_mor1408_slow_client_recovery.py
@@ -17,7 +17,7 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.web._delta_encoder import apply_delta
 from rigplane.web.handlers.control import ControlHandler
-from rigplane.web.server import WebServer
+from rigplane.web.server import WebConfig, WebServer
 
 
 _SOURCE = SourceMetadata(source="test", provider="mor1408", transport="fake")
@@ -51,7 +51,7 @@ def _state_data(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def test_overflow_replaces_all_queued_state_frames_with_same_encode_full() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
     initial = server.register_control_event_queue(slow)
     assert initial["type"] == "full"
@@ -82,7 +82,7 @@ def test_overflow_replaces_all_queued_state_frames_with_same_encode_full() -> No
 
 
 def test_mixed_queue_overflow_preserves_nonstate_order_after_recovery_full() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=4)
     server.register_control_event_queue(slow)
     slow.put_nowait({"type": "notification", "name": "a", "data": {}})
@@ -100,7 +100,7 @@ def test_mixed_queue_overflow_preserves_nonstate_order_after_recovery_full() -> 
 
 
 def test_registration_and_subscribe_share_one_encoder_sequence_with_peers() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     peer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     first = server.register_control_event_queue(peer)
     assert first["type"] == "full"
@@ -134,7 +134,7 @@ def test_registration_and_subscribe_share_one_encoder_sequence_with_peers() -> N
 
 
 def test_repeated_overflow_keeps_only_the_latest_recovery_full() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
     server.register_control_event_queue(slow)
 
@@ -149,7 +149,7 @@ def test_repeated_overflow_keeps_only_the_latest_recovery_full() -> None:
 
 
 def test_fast_and_two_independently_slow_clients_share_one_encode() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     fast: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     slow_a: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
     slow_b: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
@@ -189,7 +189,7 @@ def test_fast_and_two_independently_slow_clients_share_one_encode() -> None:
 
 
 def test_inflight_delta_precedes_recovery_full_after_overflow() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
     direct_baseline = server.register_control_event_queue(slow)
     _observe(server, 14_070_000)
@@ -210,7 +210,7 @@ def test_inflight_delta_precedes_recovery_full_after_overflow() -> None:
 
 
 def test_provider_generation_full_evicts_all_old_generation_state_frames() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     slow: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
     server.register_control_event_queue(slow)
     old_generation = server.command_state_store.provider_generation
@@ -231,7 +231,7 @@ def test_provider_generation_full_evicts_all_old_generation_state_frames() -> No
 
 
 def test_handshake_b_to_h_to_d_missing_key_counterexample_converges() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     peer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     base = server.register_control_event_queue(peer)
     _observe(server, 14_070_000)  # B -> H changes the key.
@@ -269,7 +269,7 @@ async def test_initial_send_cancellation_unregisters_before_liveness() -> None:
                 "receive loop must not start after initial-send cancellation"
             )
 
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     handler = ControlHandler(
         CancelInitialSend(),
         None,
@@ -285,7 +285,7 @@ async def test_initial_send_cancellation_unregisters_before_liveness() -> None:
 
 
 def test_registration_encode_failure_is_transactional() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=3)
 
     def fail() -> tuple[object, dict[str, Any]]:
@@ -298,7 +298,7 @@ def test_registration_encode_failure_is_transactional() -> None:
 
 
 def test_disconnect_reconnect_has_no_recovery_structure_and_new_full() -> None:
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     old: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=2)
     server.register_control_event_queue(old)
     _observe(server, 14_070_000)
@@ -324,7 +324,7 @@ async def test_subscribe_queues_full_then_dx_and_future_delta_converges() -> Non
                 "subscribe must not direct-send beside the sender loop"
             )
 
-    server = WebServer(None)
+    server = WebServer(None, WebConfig(radio_model="IC-7610"))
     peer: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     peer_base = server.register_control_event_queue(peer)
     handler = ControlHandler(Ws(), None, "test", "IC-TEST", server=server)

--- a/tests/test_mor1409_web_authority.py
+++ b/tests/test_mor1409_web_authority.py
@@ -76,7 +76,7 @@ async def test_success_is_lifecycle_only_until_provider_observation(
     public_value,
 ) -> None:
     radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
-    server = WebServer(radio, WebConfig())
+    server = WebServer(radio, WebConfig(radio_model="IC-7610"))
     server.command_queue.put = lambda *_args, **_kwargs: None  # type: ignore[method-assign]
     generation = server.command_state_store.provider_generation
     server.command_service.apply_observation(_observation(path, confirmed, generation))
@@ -132,7 +132,7 @@ async def test_failed_enqueue_changes_no_radio_truth(
     _public_value,
 ) -> None:
     radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
-    server = WebServer(radio, WebConfig())
+    server = WebServer(radio, WebConfig(radio_model="IC-7610"))
     generation = server.command_state_store.provider_generation
     server.command_service.apply_observation(_observation(path, confirmed, generation))
 

--- a/tests/test_mor1545_dedupe_key_inventory.py
+++ b/tests/test_mor1545_dedupe_key_inventory.py
@@ -390,7 +390,7 @@ async def _reader(row: _Race) -> AsyncIterator[tuple[IcomRadio, MockTransport]]:
     """
     transport = MockTransport()
     if row.profile == "IC-7610":
-        radio = _build_radio(_IC7610_HOST, transport)
+        radio = _build_radio(_IC7610_HOST, transport, model="IC-7610")
     else:
         radio = _build_radio(_IC9700_HOST, transport, model="IC-9700")
 

--- a/tests/test_mor1545_filter_width_dedupe_key.py
+++ b/tests/test_mor1545_filter_width_dedupe_key.py
@@ -83,7 +83,7 @@ def mock_transport() -> MockTransport:
 def ic7610_radio(mock_transport: MockTransport) -> Iterator[IcomRadio]:
     """Dual-RX profile that lists [0x1A, 0x03] in its cmd29 routes, so SUB
     takes the direct branch rather than the VFO-select fallback."""
-    r = IcomRadio("192.168.1.100", timeout=_CIV_TIMEOUT_S)
+    r = IcomRadio("192.168.1.100", timeout=_CIV_TIMEOUT_S, model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True

--- a/tests/test_pcm_e2e.py
+++ b/tests/test_pcm_e2e.py
@@ -35,7 +35,7 @@ class _DummyTranscoder:
 
 def _make_radio() -> IcomRadio:
     """Build an IcomRadio pre-wired with mocks for PCM pipeline tests."""
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     radio._connected = True
     radio._civ_transport = MagicMock()
     radio._audio_stream = MagicMock()

--- a/tests/test_pcm_ingress_decode.py
+++ b/tests/test_pcm_ingress_decode.py
@@ -43,7 +43,7 @@ _MIXIN_MODULE = "rigplane.runtime._audio_runtime_mixin"
 
 def _lan_radio(codec: AudioCodec, stream: FakeAudioStream) -> IcomRadio:
     """Connected LAN radio with a fake audio stream and a forced RX codec."""
-    radio = IcomRadio("192.168.1.100")
+    radio = IcomRadio("192.168.1.100", model="IC-7610")
     radio._connected = True
     radio._civ_transport = MagicMock()
     radio._audio_stream = stream  # type: ignore[assignment]

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -192,3 +192,56 @@ def test_radio_poller_raw_civ_call_count_is_pinned() -> None:
     sites above, not just editing the number.
     """
     assert _count_self_civ_call_sites() == 11
+
+
+# ---------------------------------------------------------------------------
+# resolve_radio_profile fails closed (plan §8.1 Q5, MOR-2012)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRadioProfileFailsClosed:
+    """The silent IC-7610/first-LAN-profile default fallback is removed:
+    an unidentified radio must refuse, never guess."""
+
+    def test_no_identifying_information_raises_a_clear_refusal(self) -> None:
+        """No profile, no model, no radio_addr — resolve_radio_profile()
+        must raise rather than silently return a default profile."""
+        with pytest.raises(ValueError) as excinfo:
+            resolve_radio_profile()
+
+        # Must not be KeyError: get_radio_profile() already raises KeyError
+        # for a *named* model that isn't found, so callers need to be able
+        # to tell "nothing identified the radio" apart from "you named an
+        # unknown one" by exception type alone.
+        assert not isinstance(excinfo.value, KeyError)
+        assert type(excinfo.value) is ValueError
+
+    @pytest.mark.parametrize("blank_model", ["", "   "])
+    def test_blank_model_raises_the_same_refusal(self, blank_model: str) -> None:
+        """A blank or whitespace-only model counts as "nothing identifies
+        the radio" — it must not silently resolve to a default profile."""
+        with pytest.raises(ValueError) as excinfo:
+            resolve_radio_profile(model=blank_model)
+
+        assert not isinstance(excinfo.value, KeyError)
+        assert type(excinfo.value) is ValueError
+
+    def test_unmatched_radio_addr_alone_also_refuses(self) -> None:
+        """A radio_addr that matches no loaded profile is also "nothing
+        identifies the radio" -- 0xFF is not any shipped rig's civ_addr."""
+        with pytest.raises(ValueError) as excinfo:
+            resolve_radio_profile(radio_addr=0xFF)
+
+        assert not isinstance(excinfo.value, KeyError)
+
+    def test_explicit_model_override_still_resolves(self) -> None:
+        """A profile/model passed explicitly by the caller remains the
+        deliberate override it already was -- unchanged by this ruling."""
+        profile = resolve_radio_profile(model="IC-7300")
+        assert profile.model == "IC-7300"
+
+        same_profile_object = resolve_radio_profile(profile=profile)
+        assert same_profile_object is profile
+
+        by_name = resolve_radio_profile(profile="IC-9700")
+        assert by_name.model == "IC-9700"

--- a/tests/test_quickwins_regression.py
+++ b/tests/test_quickwins_regression.py
@@ -21,7 +21,7 @@ from rigplane.diagnostics._logging import (
     SafeRotatingFileHandler,
     configure_diagnostic_logging,
 )
-from rigplane.web.server import WebServer
+from rigplane.web.server import WebConfig, WebServer
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +48,7 @@ def test_stalled_subscriber_no_log_warnings_on_overflow() -> None:
     maxsize and calling _broadcast_state_update many times — zero warnings
     should be emitted, and the server must not raise.
     """
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     stalled: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=4)
     srv.register_control_event_queue(stalled)
 
@@ -185,7 +185,7 @@ def test_no_subscribers_skips_build(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_connecting_client_still_gets_initial_state() -> None:
     """Fix C (#1877 2a): force=True (used on connect) must still build and deliver."""
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     srv.register_control_event_queue(q)
 

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -323,7 +323,7 @@ def radio(mock_transport: MockTransport):
     """Shared radio fixture with explicit teardown to silence the
     ``Radio collected with active connection/tasks`` __del__ warning
     from tests that bypass the real connect/disconnect lifecycle."""
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
@@ -336,7 +336,7 @@ class TestContextManager:
 
     @pytest.mark.asyncio
     async def test_disconnect(self, mock_transport: MockTransport) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -347,7 +347,7 @@ class TestContextManager:
 
     @pytest.mark.asyncio
     async def test_context_manager_exit(self, mock_transport: MockTransport) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -1138,7 +1138,7 @@ class TestTimeout:
 
     @pytest.mark.asyncio
     async def test_timeout_on_no_response(self, mock_transport: MockTransport) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=0.1)
+        radio = IcomRadio("192.168.1.100", timeout=0.1, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -1149,7 +1149,7 @@ class TestTimeout:
     async def test_deadline_timeout_does_not_always_send_three_attempts(
         self, mock_transport: MockTransport
     ) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=0.2)
+        radio = IcomRadio("192.168.1.100", timeout=0.2, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -1166,19 +1166,19 @@ class TestDisconnected:
 
     @pytest.mark.asyncio
     async def test_get_frequency_disconnected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await radio.get_freq()
 
     @pytest.mark.asyncio
     async def test_set_frequency_disconnected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await radio.set_freq(14_074_000)
 
     @pytest.mark.asyncio
     async def test_send_civ_disconnected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await radio.send_civ(0x03)
 
@@ -1199,7 +1199,7 @@ class TestConnectedProperty:
     """Test connected property."""
 
     def test_initially_disconnected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         assert not radio.connected
 
 
@@ -1285,7 +1285,7 @@ class TestAckSinkRobustness:
                 raise OSError("send failed")
 
         t = FailingTransport()
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._ctrl_transport = t
         radio._civ_transport = t
         radio._connected = True
@@ -1736,7 +1736,7 @@ class TestCivTimeoutIsolation:
         self, mock_transport: MockTransport
     ) -> None:
         """After a CI-V timeout, the next command must succeed independently."""
-        radio = IcomRadio("192.168.1.100", timeout=0.1)
+        radio = IcomRadio("192.168.1.100", timeout=0.1, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -1758,7 +1758,7 @@ class TestCivTimeoutIsolation:
         self, mock_transport: MockTransport
     ) -> None:
         """Multiple consecutive timeouts do not corrupt tracker state."""
-        radio = IcomRadio("192.168.1.100", timeout=0.1)
+        radio = IcomRadio("192.168.1.100", timeout=0.1, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -1780,7 +1780,7 @@ class TestCivTimeoutIsolation:
         self, mock_transport: MockTransport
     ) -> None:
         """A timeout on get_frequency does not block a subsequent set_frequency."""
-        radio = IcomRadio("192.168.1.100", timeout=0.1)
+        radio = IcomRadio("192.168.1.100", timeout=0.1, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -1887,7 +1887,7 @@ class TestSpeechTransceiverIdXfc:
 
     @pytest.fixture
     def radio(self, mock_transport: MockTransport) -> IcomRadio:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         r._connected = True
         r._radio_addr = 0x98
         r._civ_transport = mock_transport
@@ -1967,7 +1967,7 @@ class TestStateCacheFromUnsolicitedFrames:
     """_update_state_cache_from_frame populates cache from radio-pushed frames."""
 
     def _make_radio(self) -> IcomRadio:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._connected = True
         return radio
 
@@ -2056,7 +2056,7 @@ class TestGetFallbackToCache:
         self, mock_transport: MockTransport
     ) -> None:
         """get_frequency returns cached freq when radio is silent."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05)
+        radio = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2070,7 +2070,7 @@ class TestGetFallbackToCache:
         self, mock_transport: MockTransport
     ) -> None:
         """get_frequency raises TimeoutError when cache is empty and radio is silent."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05)
+        radio = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2083,7 +2083,7 @@ class TestGetFallbackToCache:
         self, mock_transport: MockTransport
     ) -> None:
         """get_mode_info returns cached mode/filter when radio is silent."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05)
+        radio = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2098,7 +2098,7 @@ class TestGetFallbackToCache:
         self, mock_transport: MockTransport
     ) -> None:
         """get_mode_info raises TimeoutError when cache is empty and radio is silent."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05)
+        radio = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2120,7 +2120,9 @@ class TestGetFallbackCacheTTL:
         self, mock_transport: MockTransport
     ) -> None:
         """get_frequency raises TimeoutError when cached value is older than TTL."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"freq": 10.0})
+        radio = IcomRadio(
+            "192.168.1.100", timeout=0.05, cache_ttl_s={"freq": 10.0}, model="IC-7610"
+        )
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2136,7 +2138,9 @@ class TestGetFallbackCacheTTL:
         self, mock_transport: MockTransport
     ) -> None:
         """get_frequency returns cached value when it is within TTL."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"freq": 10.0})
+        radio = IcomRadio(
+            "192.168.1.100", timeout=0.05, cache_ttl_s={"freq": 10.0}, model="IC-7610"
+        )
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2150,7 +2154,9 @@ class TestGetFallbackCacheTTL:
         self, mock_transport: MockTransport
     ) -> None:
         """get_mode_info raises TimeoutError when cached value is older than TTL."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"mode": 10.0})
+        radio = IcomRadio(
+            "192.168.1.100", timeout=0.05, cache_ttl_s={"mode": 10.0}, model="IC-7610"
+        )
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2165,7 +2171,9 @@ class TestGetFallbackCacheTTL:
         self, mock_transport: MockTransport
     ) -> None:
         """get_mode_info returns cached value when it is within TTL."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"mode": 10.0})
+        radio = IcomRadio(
+            "192.168.1.100", timeout=0.05, cache_ttl_s={"mode": 10.0}, model="IC-7610"
+        )
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2180,7 +2188,12 @@ class TestGetFallbackCacheTTL:
         self, mock_transport: MockTransport
     ) -> None:
         """get_power raises TimeoutError when cached value is older than TTL."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"rf_power": 30.0})
+        radio = IcomRadio(
+            "192.168.1.100",
+            timeout=0.05,
+            cache_ttl_s={"rf_power": 30.0},
+            model="IC-7610",
+        )
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2195,7 +2208,12 @@ class TestGetFallbackCacheTTL:
         self, mock_transport: MockTransport
     ) -> None:
         """get_power returns cached value when it is within TTL."""
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"rf_power": 30.0})
+        radio = IcomRadio(
+            "192.168.1.100",
+            timeout=0.05,
+            cache_ttl_s={"rf_power": 30.0},
+            model="IC-7610",
+        )
         radio._ctrl_transport = mock_transport
         radio._civ_transport = mock_transport
         radio._connected = True
@@ -2210,7 +2228,9 @@ class TestGetFallbackCacheTTL:
     ) -> None:
         """cache_ttl_s merges with defaults, overriding individual fields."""
         # Only override freq TTL; mode/rf_power keep defaults.
-        radio = IcomRadio("192.168.1.100", timeout=0.05, cache_ttl_s={"freq": 1.0})
+        radio = IcomRadio(
+            "192.168.1.100", timeout=0.05, cache_ttl_s={"freq": 1.0}, model="IC-7610"
+        )
         assert radio._cache_ttl_freq == 1.0
         assert radio._cache_ttl_mode == 10.0
         assert radio._cache_ttl_rf_power == 30.0
@@ -2519,7 +2539,7 @@ class TestNbDepthWidthPollerDispatch:
         # must reflect the radio's REAL value, not the sent value. The readback
         # response is released only after the GET send (send #2) so the
         # fire-and-forget SET (send #1) does not consume it.
-        radio = IcomRadio("192.168.1.100", timeout=0.5)
+        radio = IcomRadio("192.168.1.100", timeout=0.5, model="IC-7610")
         radio._civ_transport = mock_transport
         radio._ctrl_transport = mock_transport
         radio._connected = True
@@ -2556,7 +2576,7 @@ class TestNbDepthWidthPollerDispatch:
         # Post-set write-through readback (MOR-491-B): radio reports 200 even
         # though 255 was sent. The web state reflects the radio's real value.
         # Release the readback response only after the GET send (send #2).
-        radio = IcomRadio("192.168.1.100", timeout=0.5)
+        radio = IcomRadio("192.168.1.100", timeout=0.5, model="IC-7610")
         radio._civ_transport = mock_transport
         radio._ctrl_transport = mock_transport
         radio._connected = True

--- a/tests/test_radio_connect.py
+++ b/tests/test_radio_connect.py
@@ -150,7 +150,7 @@ def _build_status(
 class TestSendTokenAck:
     @pytest.mark.asyncio
     async def test_sends_token_ack(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         radio._token = 0x12345678
@@ -167,7 +167,7 @@ class TestSendTokenAck:
 class TestReceiveGuid:
     @pytest.mark.asyncio
     async def test_receives_guid(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         mt.queue_response(_build_conninfo())
@@ -177,7 +177,7 @@ class TestReceiveGuid:
 
     @pytest.mark.asyncio
     async def test_no_conninfo(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=0.5)
+        radio = IcomRadio("192.168.1.100", timeout=0.5, model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         # No response queued → returns None
@@ -188,7 +188,9 @@ class TestReceiveGuid:
 class TestSendConninfo:
     @pytest.mark.asyncio
     async def test_sends_conninfo(self) -> None:
-        radio = IcomRadio("192.168.1.100", username="test", password="pass")
+        radio = IcomRadio(
+            "192.168.1.100", username="test", password="pass", model="IC-7610"
+        )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         radio._token = 0x12345678
@@ -199,7 +201,7 @@ class TestSendConninfo:
 
     @pytest.mark.asyncio
     async def test_sends_conninfo_without_guid(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         radio._token = 0
@@ -253,6 +255,7 @@ class TestSendConninfo:
             password="p",
             audio_codec=AudioCodec.PCM_2CH_16BIT,
             audio_sample_rate=48000,
+            model="IC-7610",
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -271,7 +274,7 @@ class TestSendConninfo:
 class TestReceiveCivPort:
     @pytest.mark.asyncio
     async def test_receives_civ_port(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=1.0)
+        radio = IcomRadio("192.168.1.100", timeout=1.0, model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         mt.queue_response(_build_status(50002, 50003))
@@ -281,7 +284,7 @@ class TestReceiveCivPort:
 
     @pytest.mark.asyncio
     async def test_timeout_returns_zero(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=0.2)
+        radio = IcomRadio("192.168.1.100", timeout=0.2, model="IC-7610")
         mt = ConnectMockTransport()
         # Cap receive_packet timeout so the 2.0s deadline loop iterates fast
         _orig_recv = mt.receive_packet
@@ -296,7 +299,7 @@ class TestReceiveCivPort:
 
     @pytest.mark.asyncio
     async def test_skips_non_status(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=1.0)
+        radio = IcomRadio("192.168.1.100", timeout=1.0, model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         # Queue a non-status packet first, then status
@@ -307,7 +310,7 @@ class TestReceiveCivPort:
 
     @pytest.mark.asyncio
     async def test_two_zero_status_packets_return_quickly(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=5.0)
+        radio = IcomRadio("192.168.1.100", timeout=5.0, model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         mt.queue_response(_build_status(0, 50003))
@@ -323,7 +326,7 @@ class TestReceiveCivPort:
 
     @pytest.mark.asyncio
     async def test_status_rejection_error_is_recorded(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=1.0)
+        radio = IcomRadio("192.168.1.100", timeout=1.0, model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         mt.queue_response(_build_status(0, 50003, error=0xFFFFFFFF))
@@ -332,7 +335,7 @@ class TestReceiveCivPort:
         assert getattr(radio, "_last_status_error", 0) == 0xFFFFFFFF
 
     def test_status_retry_pause_uses_reject_cooldown(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._last_status_error = 0xFFFFFFFF
         assert (
             radio._control_phase._status_retry_pause()
@@ -348,7 +351,7 @@ class TestReceiveCivPort:
 class TestSendOpenClose:
     @pytest.mark.asyncio
     async def test_open(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._civ_transport = mt
         await radio._send_open_close(open_stream=True)
@@ -358,7 +361,7 @@ class TestSendOpenClose:
 
     @pytest.mark.asyncio
     async def test_close(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._civ_transport = mt
         await radio._send_open_close(open_stream=False)
@@ -368,7 +371,7 @@ class TestSendOpenClose:
 
     @pytest.mark.asyncio
     async def test_noop_without_transport(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         radio._civ_transport = None
         await radio._send_open_close(open_stream=True)  # no error
 
@@ -376,7 +379,7 @@ class TestSendOpenClose:
 class TestWaitForPacket:
     @pytest.mark.asyncio
     async def test_returns_correct_size(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=1.0)
+        radio = IcomRadio("192.168.1.100", timeout=1.0, model="IC-7610")
         mt = ConnectMockTransport()
         mt.queue_response(b"\x00" * 0x20)  # wrong size
         mt.queue_response(b"\x00" * 0x60)  # correct
@@ -387,7 +390,7 @@ class TestWaitForPacket:
 
     @pytest.mark.asyncio
     async def test_timeout(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=0.1)
+        radio = IcomRadio("192.168.1.100", timeout=0.1, model="IC-7610")
         mt = ConnectMockTransport()
         # Cap receive_packet timeout so the 2.0s deadline is reached quickly
         _orig_recv = mt.receive_packet
@@ -401,7 +404,7 @@ class TestWaitForPacket:
 
     @pytest.mark.asyncio
     async def test_skips_wrong_sizes(self) -> None:
-        radio = IcomRadio("192.168.1.100", timeout=1.0)
+        radio = IcomRadio("192.168.1.100", timeout=1.0, model="IC-7610")
         mt = ConnectMockTransport()
         for _ in range(5):
             mt.queue_response(b"\x00" * 0x10)
@@ -431,7 +434,7 @@ class TestFlushQueue:
 class TestDisconnect:
     @pytest.mark.asyncio
     async def test_disconnect_cleans_up(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         radio._civ_transport = mt
@@ -442,14 +445,14 @@ class TestDisconnect:
 
     @pytest.mark.asyncio
     async def test_disconnect_when_not_connected(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         await radio.disconnect()  # should not raise
 
     @pytest.mark.asyncio
     async def test_aexit(self) -> None:
-        radio = IcomRadio("192.168.1.100")
+        radio = IcomRadio("192.168.1.100", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
         radio._civ_transport = mt
@@ -461,7 +464,9 @@ class TestDisconnect:
 class TestConnectReadiness:
     @pytest.mark.asyncio
     async def test_connect_raises_when_radio_never_becomes_ready(self) -> None:
-        radio = IcomRadio("192.168.1.100", username="u", password="p", timeout=0.2)
+        radio = IcomRadio(
+            "192.168.1.100", username="u", password="p", timeout=0.2, model="IC-7610"
+        )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
 
@@ -506,7 +511,7 @@ class TestConnectReadiness:
 class TestConnectSessionRejection:
     @pytest.mark.asyncio
     async def test_connect_raises_on_status_rejection_after_retries(self) -> None:
-        radio = IcomRadio("192.168.1.100", username="u", password="p")
+        radio = IcomRadio("192.168.1.100", username="u", password="p", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
 
@@ -543,7 +548,7 @@ class TestConnectSessionRejection:
     async def test_data_port_discovery_timeout_retries_and_closes_pending_sockets(
         self,
     ) -> None:
-        radio = IcomRadio("192.168.1.100", username="u", password="p")
+        radio = IcomRadio("192.168.1.100", username="u", password="p", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
 
@@ -746,6 +751,7 @@ class TestConnectSessionRejection:
             password="p",
             audio_codec=AudioCodec.PCM_2CH_16BIT,
             audio_codec_explicit=True,
+            model="IC-7610",
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -797,6 +803,7 @@ class TestConnectSessionRejection:
             password="p",
             # Default profile is IC-7610, whose stereo codec is profile-selected.
             audio_codec=AudioCodec.PCM_2CH_16BIT,
+            model="IC-7610",
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -1006,6 +1013,7 @@ class TestConnectSessionRejection:
             username="u",
             password="p",
             audio_codec=AudioCodec.PCM_1CH_16BIT,
+            model="IC-7610",
         )
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
@@ -1068,7 +1076,7 @@ class TestWifiBindBehavior:
     async def test_connect_uses_routed_local_bind_host_for_control_and_civ(
         self,
     ) -> None:
-        radio = IcomRadio("192.168.2.1", username="u", password="p")
+        radio = IcomRadio("192.168.2.1", username="u", password="p", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
 
@@ -1139,7 +1147,7 @@ class TestWifiBindBehavior:
         self,
     ) -> None:
         """civ_port=0 after all retries (no 0xFFFFFFFF flag) also raises ConnectionError."""
-        radio = IcomRadio("192.168.1.100", username="u", password="p")
+        radio = IcomRadio("192.168.1.100", username="u", password="p", model="IC-7610")
         mt = ConnectMockTransport()
         radio._ctrl_transport = mt
 

--- a/tests/test_radio_coverage.py
+++ b/tests/test_radio_coverage.py
@@ -130,7 +130,7 @@ def mock_transport() -> MockTransport:
 
 @pytest.fixture
 def radio(mock_transport: MockTransport):
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True

--- a/tests/test_radio_extended.py
+++ b/tests/test_radio_extended.py
@@ -38,7 +38,7 @@ def mock_transport() -> MockTransport:
 
 @pytest.fixture
 def radio(mock_transport: MockTransport) -> IcomRadio:
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
@@ -139,7 +139,7 @@ class TestVFO:
 
     @pytest.mark.asyncio
     async def test_set_vfo_wire_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r._set_vfo_wire("A")
 
@@ -157,22 +157,22 @@ class TestVFO:
 
     def test_set_vfo_attribute_removed(self) -> None:
         """Deprecated ``set_vfo`` overload is removed in v0.20 (#1206)."""
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         assert not hasattr(r, "set_vfo")
 
     def test_select_vfo_alias_removed(self) -> None:
         """Deprecated ``select_vfo`` alias is removed in v0.20 (#1206)."""
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         assert not hasattr(r, "select_vfo")
 
     def test_vfo_exchange_attribute_removed(self) -> None:
         """Deprecated ``vfo_exchange`` alias is removed in v0.19."""
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         assert not hasattr(r, "vfo_exchange")
 
     def test_vfo_equalize_attribute_removed(self) -> None:
         """Deprecated ``vfo_equalize`` alias is removed in v0.19."""
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         assert not hasattr(r, "vfo_equalize")
 
 
@@ -206,7 +206,7 @@ class TestSplitMode:
 
     @pytest.mark.asyncio
     async def test_split_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.set_split(True)
 
@@ -316,7 +316,7 @@ class TestAttenuator:
 
     @pytest.mark.asyncio
     async def test_att_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.set_attenuator(True)
 
@@ -369,7 +369,7 @@ class TestPreamp:
 
     @pytest.mark.asyncio
     async def test_preamp_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.set_preamp(1)
 
@@ -418,7 +418,7 @@ class TestCW:
 
     @pytest.mark.asyncio
     async def test_cw_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.send_cw_text("CQ")
 
@@ -494,7 +494,7 @@ class TestReceiverAwareContract:
 
     @pytest.mark.asyncio
     async def test_stop_cw_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.stop_cw_text()
 
@@ -539,7 +539,7 @@ class TestPowerControl:
 
     @pytest.mark.asyncio
     async def test_power_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.power_control(True)
 
@@ -552,19 +552,19 @@ class TestPowerControl:
 class TestAudio:
     @pytest.mark.asyncio
     async def test_start_rx_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.start_audio_rx_opus(lambda pkt: None)
 
     @pytest.mark.asyncio
     async def test_start_tx_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.start_audio_tx_opus()
 
     @pytest.mark.asyncio
     async def test_push_tx_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.push_audio_tx_opus(b"\x00" * 100)
 
@@ -575,7 +575,7 @@ class TestAudio:
 
     @pytest.mark.asyncio
     async def test_start_tx_pcm_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.start_audio_tx_pcm()
 
@@ -624,7 +624,7 @@ class TestAudio:
 class TestPttDisconnected:
     @pytest.mark.asyncio
     async def test_set_ptt_disconnected(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             await r.set_ptt(True)
 
@@ -651,7 +651,7 @@ class TestPttDisconnected:
 
 class TestInternals:
     def test_check_connected_raises(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         with pytest.raises(ConnectionError):
             r._check_connected()
 
@@ -685,7 +685,7 @@ class TestInternals:
 
 class TestConstructor:
     def test_defaults(self) -> None:
-        r = IcomRadio("10.0.0.1")
+        r = IcomRadio("10.0.0.1", model="IC-7610")
         assert r._host == "10.0.0.1"
         assert r._port == 50001
         assert r._radio_addr == IC_7610_ADDR

--- a/tests/test_radio_protocol.py
+++ b/tests/test_radio_protocol.py
@@ -333,7 +333,7 @@ def test_icom_radio_satisfies_scope_capable_with_extended_surface() -> None:
     from rigplane.radio import IcomRadio
     from rigplane.radio_protocol import ScopeCapable
 
-    radio = IcomRadio(host="")
+    radio = IcomRadio(host="", model="IC-7610")
     assert isinstance(radio, ScopeCapable)
 
     expected_methods = (

--- a/tests/test_raw_civ_pipe.py
+++ b/tests/test_raw_civ_pipe.py
@@ -28,7 +28,7 @@ def transport() -> MockTransport:
 
 @pytest.fixture
 def radio(transport: MockTransport):
-    r = IcomRadio("192.168.1.100")
+    r = IcomRadio("192.168.1.100", model="IC-7610")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True

--- a/tests/test_raw_civ_transaction.py
+++ b/tests/test_raw_civ_transaction.py
@@ -31,7 +31,7 @@ def transport() -> MockTransport:
 
 @pytest.fixture
 def radio(transport: MockTransport):
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = transport
     r._ctrl_transport = transport
     r._connected = True

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -25,6 +25,7 @@ def radio() -> IcomRadio:
         reconnect_delay=0.1,
         reconnect_max_delay=0.5,
         watchdog_timeout=0.3,
+        model="IC-7610",
     )
     mt = MockTransport()
     r._ctrl_transport = mt
@@ -44,7 +45,7 @@ class TestWatchdog:
 
     @pytest.mark.asyncio
     async def test_stop_when_not_started(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         r._control_phase._stop_watchdog()  # should not raise
 
     @pytest.mark.asyncio
@@ -81,7 +82,7 @@ class TestWatchdog:
 class TestReconnect:
     @pytest.mark.asyncio
     async def test_stop_reconnect_when_not_started(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         r._control_phase._stop_reconnect()  # should not raise
 
     @pytest.mark.asyncio
@@ -111,11 +112,11 @@ class TestReconnect:
 
 class TestAutoReconnectConfig:
     def test_default_off(self) -> None:
-        r = IcomRadio("192.168.1.100")
+        r = IcomRadio("192.168.1.100", model="IC-7610")
         assert r._auto_reconnect is False
 
     def test_enabled(self) -> None:
-        r = IcomRadio("192.168.1.100", auto_reconnect=True)
+        r = IcomRadio("192.168.1.100", auto_reconnect=True, model="IC-7610")
         assert r._auto_reconnect is True
         assert r._reconnect_delay == 2.0
         assert r._reconnect_max_delay == 60.0
@@ -128,6 +129,7 @@ class TestAutoReconnectConfig:
             reconnect_delay=5.0,
             reconnect_max_delay=120.0,
             watchdog_timeout=15.0,
+            model="IC-7610",
         )
         assert r._reconnect_delay == 5.0
         assert r._reconnect_max_delay == 120.0

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -989,7 +989,7 @@ def _ack_udp() -> bytes:
 @pytest.fixture
 def radio_with_mock() -> tuple[IcomRadio, MockTransport]:
     t = MockTransport()
-    r = IcomRadio("192.168.1.1")
+    r = IcomRadio("192.168.1.1", model="IC-7610")
     r._civ_transport = t  # type: ignore[assignment]
     r._ctrl_transport = t  # type: ignore[assignment]
     r._connected = True

--- a/tests/test_scope_stress.py
+++ b/tests/test_scope_stress.py
@@ -114,7 +114,7 @@ def _make_scope_udp_packets(count: int) -> list[bytes]:
 def radio_with_mock() -> tuple[IcomRadio, MockTransport]:
     """Radio with mock CIV/ctrl transport, connected state, radio_addr set for scope."""
     t = MockTransport()
-    r = IcomRadio("192.168.1.1")
+    r = IcomRadio("192.168.1.1", model="IC-7610")
     r._civ_transport = t  # type: ignore[assignment]
     r._ctrl_transport = t  # type: ignore[assignment]
     r._connected = True

--- a/tests/test_selected_freq_mode.py
+++ b/tests/test_selected_freq_mode.py
@@ -245,7 +245,7 @@ def mock_transport() -> MockTransport:
 
 @pytest.fixture
 def radio(mock_transport: MockTransport):
-    r = IcomRadio("192.168.1.100", timeout=0.05)
+    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True

--- a/tests/test_session_lifecycle_e2e.py
+++ b/tests/test_session_lifecycle_e2e.py
@@ -89,6 +89,7 @@ def _make_radio(sim: MockIcomRadio) -> IcomRadio:
         username="testuser",
         password="testpass",
         timeout=5.0,
+        model="IC-7610",
     )
 
 

--- a/tests/test_state_pipeline_contracts.py
+++ b/tests/test_state_pipeline_contracts.py
@@ -131,7 +131,7 @@ def _server_with_conflicting_legacy_state() -> tuple[WebServer, StateSnapshot]:
     legacy_state.ptt = True
     server = WebServer(
         _StateStoreRadio(store, legacy_state),
-        WebConfig(state_diagnostics=True),
+        WebConfig(state_diagnostics=True, radio_model="IC-7610"),
     )
     server._radio_state = legacy_state  # noqa: SLF001
     server._radio_poller = _LegacyRevisionPoller()  # noqa: SLF001

--- a/tests/test_state_pipeline_diagnostics.py
+++ b/tests/test_state_pipeline_diagnostics.py
@@ -96,7 +96,7 @@ def test_civ_meter_write_records_diagnostic_without_notify_or_revision() -> None
 def test_web_meter_write_delivers_state_store_revision_without_unrelated_trigger() -> (
     None
 ):
-    server = WebServer(config=WebConfig(state_diagnostics=True))
+    server = WebServer(config=WebConfig(state_diagnostics=True, radio_model="IC-7610"))
     queue: BoundedQueue[dict[str, Any]] = BoundedQueue(maxsize=8)
     registration_full = server.register_control_event_queue(queue)
     assert registration_full["type"] == "full"

--- a/tests/test_tap_surface.py
+++ b/tests/test_tap_surface.py
@@ -324,9 +324,12 @@ def test_fft_scope_receives_frames_via_named_post_dsp_stage() -> None:
 async def test_scope_service_lifecycle_and_serializer_matrix(
     hardware: bool, audio: bool, scope_source: str | None
 ) -> None:
-    from rigplane.web.server import WebServer
+    from rigplane.web.server import WebConfig, WebServer
 
-    server = WebServer(_MatrixRadio(hardware=hardware, audio=audio))
+    server = WebServer(
+        _MatrixRadio(hardware=hardware, audio=audio),
+        WebConfig(radio_model="IC-7610"),
+    )
     scope = server._audio_fft_scope
     assert (scope is not None) is audio
     if scope is not None:
@@ -381,11 +384,11 @@ async def test_runtime_hardware_scope_is_cached_for_dispatch_and_teardown() -> N
 async def test_audio_tag_without_proven_route_does_not_advertise_fft(
     hardware: bool,
 ) -> None:
-    from rigplane.web.server import WebServer
+    from rigplane.web.server import WebConfig, WebServer
 
     radio = _MatrixRadio(hardware=hardware, audio=True)
     radio.audio_bus = None
-    server = WebServer(radio)
+    server = WebServer(radio, WebConfig(radio_model="IC-7610"))
     writer = _Writer()
     await server._serve_capabilities(writer)
     capabilities = _json_body(writer)

--- a/tests/test_token_renewal.py
+++ b/tests/test_token_renewal.py
@@ -12,7 +12,7 @@ from test_radio import MockTransport
 
 @pytest.fixture
 def radio() -> IcomRadio:
-    r = IcomRadio("192.168.1.100")
+    r = IcomRadio("192.168.1.100", model="IC-7610")
     mt = MockTransport()
     r._ctrl_transport = mt
     r._connected = True

--- a/tests/test_tx_safety_diagnostics.py
+++ b/tests/test_tx_safety_diagnostics.py
@@ -511,7 +511,7 @@ def test_an_unmanaged_radio_says_so_and_publishes_no_safety_fields() -> None:
     rest — idle phase, no obligation, no conflict — which is the one reading
     this block must never support.
     """
-    payload = build_tx_safety_payload(IcomRadio("127.0.0.1"))
+    payload = build_tx_safety_payload(IcomRadio("127.0.0.1", model="IC-7610"))
 
     assert payload["status"] == "unmanaged"
     for field in ("phase", "lease", "watchdog", "durableOff", "uncertainShutdown"):

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -57,7 +57,7 @@ def _make_radio_with_state() -> IcomRadio:
     """IcomRadio with RadioState wired up for _update_radio_state_from_frame tests."""
     from test_civ_rx_coverage import MockTransport  # type: ignore[import]
 
-    r = IcomRadio("192.168.1.100")
+    r = IcomRadio("192.168.1.100", model="IC-7610")
     r._civ_transport = MockTransport()
     r._ctrl_transport = r._civ_transport
     r._connected = True

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -250,7 +250,10 @@ def test_command_batch_docs_use_numeric_data_mode_contract() -> None:
 
 @pytest.mark.asyncio
 async def test_stable_http_payloads_satisfy_required_field_contract() -> None:
-    srv = WebServer(None, WebConfig(host="127.0.0.1", port=0, auth_token="token"))
+    srv = WebServer(
+        None,
+        WebConfig(host="127.0.0.1", port=0, auth_token="token", radio_model="IC-7610"),
+    )
     srv._server = type(  # noqa: SLF001
         "_Server",
         (),

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -264,10 +264,18 @@ class TestInfoEndpoint:
     ):
         """Empty-candidate guard: neither side ever reaches resolve_radio_profile.
 
-        ``resolve_radio_profile``'s empty-input path silently returns a
-        default rig profile, so ``projected_vfo_capability_tags`` must
-        short-circuit before calling it when both ``radio.model`` (absent
-        here) and ``configured_model`` (an empty string here) are unusable.
+        ``projected_vfo_capability_tags`` must short-circuit before calling
+        ``resolve_radio_profile`` when both ``radio.model`` (absent here)
+        and ``configured_model`` (an empty string here) are unusable. The
+        capabilities leg is checked against
+        ``_projected_runtime_capabilities()`` directly rather than through
+        ``_serve_capabilities()``: unlike ``_serve_info()``, that endpoint
+        has no fielded no-radio-attached case (MOR-2012 follow-up) and
+        still requires an identified radio for its other, unrelated
+        fields -- there is no candidate that identifies the radio for
+        ``_get_profile()`` without also making it a usable candidate for
+        ``projected_vfo_capability_tags``, since both check the same two
+        attributes in the same order.
         """
         reserved = {"vfo_swap", "vfo_equalize"}
         radio = _make_radio("IC-7300", caps=reserved)
@@ -279,9 +287,7 @@ class TestInfoEndpoint:
         await server._serve_info(info_writer)  # noqa: SLF001
         info = _parse_json_body(info_writer)
 
-        capabilities_writer = _FakeWriter()
-        await server._serve_capabilities(capabilities_writer)  # noqa: SLF001
-        capabilities = _parse_json_body(capabilities_writer)
+        capabilities_tags = sorted(server._projected_runtime_capabilities())  # noqa: SLF001
 
         sent: list[str] = []
 
@@ -294,7 +300,7 @@ class TestInfoEndpoint:
         hello = json.loads(sent.pop())
 
         assert not (reserved & set(info["capabilities"]["tags"]))
-        assert not (reserved & set(capabilities["capabilities"]))
+        assert not (reserved & set(capabilities_tags))
         assert not (reserved & set(hello["capabilities"]))
 
     @pytest.mark.asyncio

--- a/tests/test_web_recovery_durable_off.py
+++ b/tests/test_web_recovery_durable_off.py
@@ -509,7 +509,7 @@ class _ManagedRadio(CoreRadio):
     """
 
     def __init__(self, provider: _Provider) -> None:
-        super().__init__("127.0.0.1")
+        super().__init__("127.0.0.1", model="IC-7610")
         self.provider = provider
         self._civ_transport = _CivPort()  # type: ignore[assignment]
         self._ports: dict[int, tuple[int, object]] = {}

--- a/tests/test_web_runtime_helpers.py
+++ b/tests/test_web_runtime_helpers.py
@@ -74,7 +74,10 @@ class _FakeRadio:
         self.connected = connected
         self.radio_ready = radio_ready_flag
         self.control_connected = False
-        self.model = "IC-TEST"
+        # X6100: resolves (must not raise) but contributes zero VFO tags
+        # (swap/equal codes all None), so it doesn't perturb capability
+        # comparisons keyed off the fake's own declared .capabilities.
+        self.model = "X6100"
         self.conn_state = None
         self._last_civ_data_received = None
         self._civ_ready_idle_timeout = None

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -536,7 +536,9 @@ async def server(mock_radio: MagicMock) -> WebServer:
 
 @pytest.fixture
 async def server_no_radio() -> WebServer:
-    config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
+    config = WebConfig(
+        host="127.0.0.1", port=0, keepalive_interval=9999.0, radio_model="IC-7610"
+    )
     srv = WebServer(None, config)
     await srv.start()
     yield srv
@@ -2822,7 +2824,12 @@ class TestConfigurableKeepalive:
 
     async def test_large_interval_no_pings_during_short_test(self) -> None:
         """With keepalive_interval=9999, no ping frames arrive in a short test."""
-        config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
+        config = WebConfig(
+            host="127.0.0.1",
+            port=0,
+            keepalive_interval=9999.0,
+            radio_model="IC-7610",
+        )
         async with WebServer(None, config) as srv:
             host, port = _addr(srv)
             reader, writer, _ = await _ws_connect(host, port, "/api/v1/ws")
@@ -2897,7 +2904,12 @@ class TestScopeEnableAtomic:
 
     async def test_server_responsive_after_connect_disconnect_cycles(self) -> None:
         """HTTP endpoint must return 200 after several WS connect/disconnect cycles."""
-        config = WebConfig(host="127.0.0.1", port=0, keepalive_interval=9999.0)
+        config = WebConfig(
+            host="127.0.0.1",
+            port=0,
+            keepalive_interval=9999.0,
+            radio_model="IC-7610",
+        )
         radio = MagicMock()
         _add_scope_capable_attrs(radio)
         _del_poller_factory_attrs(radio)
@@ -4271,48 +4283,22 @@ class TestGetProfileRouting:
         assert isinstance(profile, RadioProfile)
         assert "IC-7610" in profile.model
 
-    def test_unresolved_radio_model_warns_and_names_model(self, caplog):
-        """Unknown radio model logs a WARNING naming it instead of silently
-        impersonating IC-7610 (MOR-174)."""
-        import logging
-
-        from rigplane.profiles import RadioProfile, resolve_radio_profile
-
+    def test_unresolved_radio_model_refuses_instead_of_guessing(self):
+        """An unknown radio model refuses instead of silently impersonating
+        a default profile (plan §8.1 Q5)."""
         radio = SimpleNamespace(model="ACME-9000", capabilities=set())
-        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
-            srv = self._make_server(radio, radio_model="ACME-9000")
-            profile = srv._get_profile()
+        srv = self._make_server(radio, radio_model="ACME-9000")
 
-        assert isinstance(profile, RadioProfile)
-        warnings = [
-            r.getMessage()
-            for r in caplog.records
-            if r.levelno == logging.WARNING and "ACME-9000" in r.getMessage()
-        ]
-        assert warnings, "expected a WARNING naming the unresolved radio model"
-        # Fallback must be the library-wide default resolution chain, and the
-        # warning must name the profile actually used — never a silent
-        # hard-coded IC-7610.
-        assert profile == resolve_radio_profile()
-        assert profile.model in warnings[0]
+        with pytest.raises(ValueError, match="Cannot resolve a radio profile"):
+            srv._get_profile()
 
-    def test_unresolved_config_model_warns_when_no_radio(self, caplog):
-        """Unresolvable config radio_model (no radio) warns and still yields a
-        profile via the default resolution chain (MOR-174)."""
-        import logging
+    def test_unresolved_config_model_refuses_when_no_radio(self):
+        """Unresolvable config radio_model (no radio) refuses instead of
+        silently falling back to a guessed profile (plan §8.1 Q5)."""
+        srv = self._make_server(radio=None, radio_model="NOT-A-RADIO")
 
-        from rigplane.profiles import RadioProfile
-
-        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
-            srv = self._make_server(radio=None, radio_model="NOT-A-RADIO")
-            profile = srv._get_profile()
-
-        assert isinstance(profile, RadioProfile)
-        assert any(
-            "NOT-A-RADIO" in r.getMessage()
-            for r in caplog.records
-            if r.levelno == logging.WARNING
-        )
+        with pytest.raises(ValueError, match="Cannot resolve a radio profile"):
+            srv._get_profile()
 
     def test_default_config_radio_model_is_not_ic7610(self):
         """WebConfig.radio_model defaults to a neutral sentinel, not a silent
@@ -4321,46 +4307,26 @@ class TestGetProfileRouting:
 
     @pytest.mark.parametrize("blank_model", ["", "   "])
     def test_blank_radio_model_does_not_short_circuit_configured_model(
-        self, caplog, blank_model
+        self, blank_model
     ):
-        """A blank radio.model must not win the candidate loop and silently
-        yield the default resolution chain's rig — the configured
-        radio_model is still a usable candidate."""
-        import logging
-
-        from rigplane.profiles import resolve_radio_profile
-
+        """A blank radio.model must not win the candidate loop — the
+        configured radio_model is still a usable candidate."""
         radio = SimpleNamespace(model=blank_model, capabilities=set())
-        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
-            srv = self._make_server(radio, radio_model="FTX-1")
-            profile = srv._get_profile()
+        srv = self._make_server(radio, radio_model="FTX-1")
+        profile = srv._get_profile()
 
         assert profile.vfo_scheme == "ab_shared"
-        assert profile != resolve_radio_profile()
-        assert not any(r.levelno == logging.WARNING for r in caplog.records)
-        assert srv._profile_fallback_warned is False  # noqa: SLF001
+        assert profile.model == "FTX-1"
 
-    def test_blank_radio_and_config_model_still_warns_and_falls_back(self, caplog):
+    def test_blank_radio_and_config_model_refuses_instead_of_falling_back(self):
         """When both radio.model and the configured radio_model are blank,
-        _get_profile() still falls back through the default resolution
-        chain and emits the MOR-174 warning naming the profile actually
-        used — the fix must not turn a warned fallback into a silent one."""
-        import logging
-
-        from rigplane.profiles import RadioProfile, resolve_radio_profile
-
+        _get_profile() now refuses (plan §8.1 Q5) instead of silently
+        falling back to a guessed default profile."""
         radio = SimpleNamespace(model="", capabilities=set())
-        with caplog.at_level(logging.WARNING, logger="rigplane.web.server"):
-            srv = self._make_server(radio, radio_model="")
-            profile = srv._get_profile()
+        srv = self._make_server(radio, radio_model="")
 
-        assert isinstance(profile, RadioProfile)
-        assert profile == resolve_radio_profile()
-        warnings = [
-            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
-        ]
-        assert warnings, "expected a WARNING for the MOR-174 fallback"
-        assert profile.model in warnings[0]
+        with pytest.raises(ValueError, match="Cannot resolve a radio profile"):
+            srv._get_profile()
 
 
 class TestGetMeterCalPayload:

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -517,7 +517,7 @@ def test_state_store_s_meter_change_broadcasts_without_legacy_revision_event() -
 
 @pytest.mark.asyncio
 async def test_control_run_initial_full_state_counts_registered_client() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     ws = _RunOnceControlWs()
     handler = ControlHandler(ws, None, "0.0.0-test", "IC-TEST", server=srv)
 
@@ -531,7 +531,7 @@ async def test_control_run_initial_full_state_counts_registered_client() -> None
 
 
 def test_control_queue_lifecycle_broadcasts_ws_client_count_changes() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     observer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     peer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     srv.register_control_event_queue(observer)
@@ -550,7 +550,7 @@ def test_control_queue_lifecycle_broadcasts_ws_client_count_changes() -> None:
 
 
 def test_ws_client_lifecycle_delta_includes_public_state_sequence() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     observer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     peer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     first_envelope = srv.register_control_event_queue(observer)
@@ -576,7 +576,7 @@ def test_ws_client_lifecycle_delta_includes_public_state_sequence() -> None:
 
 @pytest.mark.asyncio
 async def test_scope_lifecycle_broadcasts_ws_client_count_changes() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     observer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     scope_handler = object()
     srv.register_control_event_queue(observer)
@@ -596,7 +596,7 @@ async def test_scope_lifecycle_broadcasts_ws_client_count_changes() -> None:
 
 @pytest.mark.asyncio
 async def test_audio_rx_lifecycle_broadcasts_ws_client_count_changes() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     observer: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=8)
     srv.register_control_event_queue(observer)
     _drain_queue(observer)
@@ -919,7 +919,7 @@ async def test_http_power_is_lifecycle_only_until_provider_observation() -> None
         capabilities={"power_control"},
         set_powerstat=AsyncMock(),
     )
-    srv = WebServer(radio, WebConfig())
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     srv._radio_state.power_on = True  # noqa: SLF001
     state_change = MagicMock()
     srv._on_radio_state_change = state_change  # type: ignore[method-assign]
@@ -1160,7 +1160,7 @@ async def test_set_freq_optimistic_overlay_suppressed_during_external_cat() -> N
         capabilities=set(),
         external_cat_session_active=True,
     )
-    srv = WebServer(radio, WebConfig())
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
 
     freq_path = FieldPath.active("0", "freq_mode", "freq_hz")
@@ -1365,7 +1365,7 @@ async def test_set_mod_input_overlay_yields_to_newer_external_readback() -> None
     # with a DIFFERENT source must win (last-writer-wins); the optimistic value
     # must not pin the source.
     radio = SimpleNamespace(connected=True, capabilities={"data_mode"})
-    srv = WebServer(radio, WebConfig())
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     srv.command_queue.put = lambda *a, **k: None  # type: ignore[method-assign]
 
     intent = command_intent_from_request(
@@ -1895,7 +1895,7 @@ async def test_scope_health_and_radio_state_event_paths() -> None:
 async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revision() -> (
     None
 ):
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store.apply(
         _store_observation(
             FieldPath.active("0", "freq_mode", "freq_hz"),
@@ -1940,7 +1940,7 @@ async def test_http_snapshot_matches_initial_ws_full_state_for_same_store_revisi
 async def test_same_value_observation_metadata_updates_http_and_initial_ws_full_state() -> (
     None
 ):
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     path = FieldPath.active("0", "freq_mode", "freq_hz")
     srv.command_state_store.apply(
         Observation(
@@ -2008,7 +2008,7 @@ async def test_same_value_observation_metadata_updates_http_and_initial_ws_full_
 
 
 def test_empty_state_store_marks_legacy_defaults_as_missing() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
 
     public_state = srv.build_public_state()
 
@@ -2036,7 +2036,7 @@ def test_empty_state_store_marks_legacy_defaults_as_missing() -> None:
 
 
 def test_partial_state_store_marks_observed_and_missing_fields_separately() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store.apply(
         _store_observation(
             FieldPath.active("0", "freq_mode", "freq_hz"),
@@ -2075,7 +2075,7 @@ def test_partial_state_store_marks_observed_and_missing_fields_separately() -> N
 def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision() -> (
     None
 ):
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     srv.command_state_store.apply(
@@ -2116,7 +2116,7 @@ def test_meter_only_state_store_change_emits_web_delta_without_legacy_revision()
 def test_freshness_only_state_store_change_emits_web_delta() -> None:
     clock = FreshnessClock(start=5.0)
     store = StateStore(freshness_clock=clock)
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store = store
     srv.command_service._state_store = store  # noqa: SLF001
     srv._http_command_service._state_store = store  # noqa: SLF001
@@ -2156,7 +2156,7 @@ def test_freshness_only_state_store_change_emits_web_delta() -> None:
 
 
 def test_same_value_observation_metadata_change_emits_web_delta() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     path = FieldPath.active("0", "freq_mode", "freq_hz")
@@ -2213,7 +2213,7 @@ def test_same_value_observation_metadata_change_emits_web_delta() -> None:
 
 
 def test_initial_full_state_envelope_does_not_consume_broadcast_delta() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     srv.command_state_store.apply(
@@ -2267,7 +2267,7 @@ def test_state_delivery_contract_is_bound_to_store_generation() -> None:
         _civ_epoch=99,
         managed_tx_generation=123,
     )
-    srv = WebServer(radio)
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     generation = srv.command_state_store.begin_provider_generation()
 
     envelope = srv.build_state_update_envelope()
@@ -2280,7 +2280,7 @@ def test_state_delivery_contract_is_bound_to_store_generation() -> None:
 
 
 def test_generation_transition_forces_existing_encoder_to_emit_full() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     first = srv.build_state_update_envelope()
     first_seq = first["data"]["publicStateSeq"]
 
@@ -2307,7 +2307,7 @@ def test_lifecycle_observations_are_current_generation_and_idempotent() -> None:
         radio_ready=True,
         capabilities=set(),
     )
-    srv = WebServer(radio)
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     generation = srv.command_state_store.begin_provider_generation()
 
     srv.build_public_state()
@@ -2342,7 +2342,7 @@ def test_lifecycle_observations_are_current_generation_and_idempotent() -> None:
 def test_lifecycle_retry_after_generation_advance_has_one_complete_current_tuple(
     advance_on_apply: int,
 ) -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     store = _GenerationAdvanceOnApplyStore(advance_on_apply=advance_on_apply)
     srv.command_state_store = store
 
@@ -2379,7 +2379,7 @@ def test_lifecycle_retry_after_generation_advance_has_one_complete_current_tuple
 def test_public_and_ws_retry_when_profile_projection_retires_generation(
     wire: str,
 ) -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     store = srv.command_state_store
     get_profile = srv._get_profile  # noqa: SLF001
     fired = False
@@ -2404,7 +2404,7 @@ def test_public_and_ws_retry_when_profile_projection_retires_generation(
 
 @pytest.mark.asyncio
 async def test_capabilities_retry_when_profile_build_retires_generation() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     store = srv.command_state_store
     get_profile = srv._get_profile  # noqa: SLF001
     fired = False
@@ -2450,7 +2450,7 @@ async def test_continuous_lifecycle_generation_churn_fails_closed_without_state_
 
 @pytest.mark.asyncio
 async def test_http_and_capabilities_share_the_current_store_generation() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     generation = srv.command_state_store.begin_provider_generation()
 
     state_writer = _FakeWriter()
@@ -2500,7 +2500,7 @@ async def test_capabilities_defaults_to_separate_rf_sql_control_model() -> None:
 
 @pytest.mark.asyncio
 async def test_generation_transition_changes_state_etag() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     first_writer = _FakeWriter()
     await srv._serve_state(first_writer)  # noqa: SLF001
     first_header = first_writer.buffer.decode("ascii", errors="replace").split(
@@ -2527,7 +2527,7 @@ async def test_generation_transition_changes_state_etag() -> None:
 async def test_initial_full_state_envelope_revisions_match_ingested_legacy_state() -> (
     None
 ):
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     legacy = RadioState()
     legacy.main.freq = 14_250_000
     legacy.main.mode = "USB"
@@ -2565,7 +2565,7 @@ async def test_state_response_refreshes_live_connection_payload_without_revision
         capabilities: set[str] = set()
 
     radio = _LiveConnectionRadio()
-    srv = WebServer(radio)
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
 
     writer = _FakeWriter()
     await srv._serve_state(writer)  # noqa: SLF001
@@ -2614,7 +2614,7 @@ def test_broadcast_state_update_refreshes_live_connection_payload_without_revisi
         capabilities: set[str] = set()
 
     radio = _LiveConnectionRadio()
-    srv = WebServer(radio)
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     first = srv.register_control_event_queue(q)
     initial = first["data"]
@@ -2633,7 +2633,7 @@ def test_broadcast_state_update_refreshes_live_connection_payload_without_revisi
 
 
 def test_legacy_state_store_sync_can_clear_default_boolean_values() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     transmitting = RadioState()
     transmitting.ptt = True
     srv.sync_state_store_from_radio_state(transmitting)
@@ -2647,7 +2647,7 @@ def test_legacy_state_store_sync_can_clear_default_boolean_values() -> None:
 
 
 def test_legacy_state_store_sync_preserves_receiver_fields() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     legacy = RadioState()
     legacy.main.data_mode = 2
     legacy.main.filter_width = 1_800
@@ -2671,7 +2671,7 @@ def test_legacy_sync_does_not_override_present_store_value_on_contended_path() -
     unlike the existing legacy-sync tests that only fill UNtouched paths.
     """
 
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     path = FieldPath.global_("tx_state", "ptt")
     store_source = SourceMetadata(
         source="civ_unsolicited",
@@ -2700,7 +2700,7 @@ def test_legacy_sync_does_not_override_present_store_value_on_contended_path() -
 
 
 def test_legacy_state_store_sync_can_clear_default_receiver_values() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     legacy = RadioState()
     legacy.main.data_mode = 2
     srv.sync_state_store_from_radio_state(legacy)
@@ -2714,7 +2714,7 @@ def test_legacy_state_store_sync_can_clear_default_receiver_values() -> None:
 
 
 def test_legacy_state_store_sync_preserves_global_rit_on() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     legacy = RadioState()
     legacy.rit_on = True
 
@@ -2726,7 +2726,7 @@ def test_legacy_state_store_sync_preserves_global_rit_on() -> None:
 def test_public_state_uses_ingested_legacy_active_after_state_store_observations() -> (
     None
 ):
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store.apply(
         _store_observation(
             FieldPath.active("0", "freq_mode", "freq_hz"),
@@ -2745,7 +2745,7 @@ def test_public_state_uses_ingested_legacy_active_after_state_store_observations
 
 
 def test_public_state_uses_ingested_legacy_global_toggle_after_observations() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store.apply(
         _store_observation(
             FieldPath.active("0", "freq_mode", "freq_hz"),
@@ -2763,7 +2763,7 @@ def test_public_state_uses_ingested_legacy_global_toggle_after_observations() ->
 
 
 def test_public_state_sync_can_clear_legacy_global_toggle_default() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store.apply(
         _store_observation(
             FieldPath.active("0", "freq_mode", "freq_hz"),
@@ -2785,7 +2785,7 @@ def test_public_state_sync_can_clear_legacy_global_toggle_default() -> None:
 
 @pytest.mark.asyncio
 async def test_http_and_ws_full_state_share_post_sync_legacy_snapshot() -> None:
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     srv.command_state_store.apply(
         _store_observation(
             FieldPath.active("0", "freq_mode", "freq_hz"),
@@ -3014,7 +3014,7 @@ async def test_send_response_and_run_web_server() -> None:
 @pytest.mark.asyncio
 async def test_broadcast_notification_puts_to_all_queues() -> None:
     """broadcast_notification pushes notification dict to all registered queues."""
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q1: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     q2: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q1)
@@ -3038,7 +3038,7 @@ async def test_broadcast_notification_puts_to_all_queues() -> None:
 @pytest.mark.asyncio
 async def test_broadcast_notification_default_category() -> None:
     """broadcast_notification uses 'system' as default category."""
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
@@ -3051,7 +3051,7 @@ async def test_broadcast_notification_default_category() -> None:
 @pytest.mark.asyncio
 async def test_broadcast_notification_full_queue_no_crash() -> None:
     """broadcast_notification silently skips full queues (dead clients)."""
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=1)
     q.put_nowait({"type": "other"})  # fill the queue
     srv.register_control_event_queue(q)
@@ -3071,7 +3071,7 @@ async def test_broadcast_notification_includes_reason_code_when_set() -> None:
     `params` are present only when the caller supplies them, so legacy
     consumers that only read `message` keep working.
     """
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
@@ -3094,7 +3094,7 @@ async def test_broadcast_notification_includes_reason_code_when_set() -> None:
 @pytest.mark.asyncio
 async def test_broadcast_notification_threads_params_through() -> None:
     """broadcast_notification copies `params` into the payload when provided."""
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
@@ -3114,7 +3114,7 @@ async def test_broadcast_notification_threads_params_through() -> None:
 @pytest.mark.asyncio
 async def test_broadcast_notification_omits_code_for_legacy_path() -> None:
     """Calls without an explicit `code` keep the legacy English-only shape."""
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
 
@@ -3234,7 +3234,7 @@ async def _ack_held(srv: WebServer) -> None:
 
 @pytest.mark.asyncio
 async def test_deferred_lifecycle_is_delivered_only_to_its_issuer() -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
 
@@ -3281,7 +3281,7 @@ async def test_interlock_refusal_reaches_only_its_issuer_machine_readably(
     reason: str,
 ) -> None:
     """MOR-1879: a failed lifecycle may carry the interlock refusal code."""
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
 
@@ -3347,7 +3347,7 @@ async def test_interlock_refusal_reaches_only_its_issuer_machine_readably(
 async def test_forged_interlock_refusal_details_are_rejected(
     details: dict[str, object],
 ) -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
 
@@ -3359,7 +3359,7 @@ async def test_forged_interlock_refusal_details_are_rejected(
 
 @pytest.mark.asyncio
 async def test_provider_generation_invalidates_only_active_web_commands() -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     service = srv.command_service
     service._executor = _StubCommandExecutor()  # noqa: SLF001
@@ -3441,7 +3441,7 @@ def test_provider_generation_subscribers_serialize_reentrant_advances() -> None:
 
 @pytest.mark.asyncio
 async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
     malformed = _life(
@@ -3503,7 +3503,7 @@ async def test_physical_reconciled_lifecycle_is_issuer_only_and_strict() -> None
 async def test_malformed_reconciled_evidence_is_not_delivered(
     details: dict[str, object],
 ) -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
     event = _life(
@@ -3536,7 +3536,7 @@ async def test_malformed_reconciled_evidence_is_not_delivered(
 async def test_malformed_deferred_lifecycle_is_ignored(
     overrides: dict[str, object],
 ) -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     await _ack_held(srv)
 
@@ -3547,7 +3547,7 @@ async def test_malformed_deferred_lifecycle_is_ignored(
 
 @pytest.mark.asyncio
 async def test_deferred_lifecycle_ack_identity_and_bounded_queue() -> None:
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     event = _life()
     srv._on_command_lifecycle_event(event)  # noqa: SLF001
@@ -3584,7 +3584,7 @@ async def test_post_ack_command_failure_notifies_issuer_only() -> None:
     production ``subscribe_lifecycle`` call in ``WebServer.__init__`` must
     turn this test red; a test-side redundant subscribe would mask that.
     """
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     srv.command_service._executor = _StubCommandExecutor()  # noqa: SLF001
     service = srv.command_service
@@ -3626,7 +3626,7 @@ async def test_command_failure_before_ack_notifies_no_one() -> None:
     as a WS response (and, client-side, as a refusal toast per MOR-1422) —
     a second notification from this seam would be a duplicate.
     """
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     service = _wire_stub_command_service(
         srv, _StubCommandExecutor(raises=ValueError("bad db value"))
@@ -3657,7 +3657,7 @@ async def test_command_timed_out_after_ack_notifies_issuer_only() -> None:
     handlers/control.py's register_control_event_queue(session_id=...)
     call sites runs against production wiring in more than one test.
     """
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     issuer_q, bystander_q = _register_two_sessions(srv)
     srv.command_service._executor = _StubCommandExecutor()  # noqa: SLF001
     service = srv.command_service
@@ -3703,7 +3703,7 @@ async def test_target_none_and_scoped_commands_do_not_leak_state_on_success() ->
     acknowledged" from CommandService's own history on demand, so there is
     no WebServer-owned per-command state to leak in the first place.
     """
-    srv = WebServer()
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     q: BoundedQueue[dict[str, object]] = BoundedQueue(maxsize=16)
     srv.register_control_event_queue(q)
     service = _wire_stub_command_service(srv, _StubCommandExecutor())
@@ -3743,7 +3743,7 @@ async def test_state_response_includes_revision_and_updated_at() -> None:
     import datetime as _dt
     import json as _json
 
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     writer = _FakeWriter()
     await srv._serve_state(writer)  # noqa: SLF001
 
@@ -3765,7 +3765,7 @@ async def test_state_response_includes_lifecycle_observations_without_poller() -
     """A first delivery synchronously seeds the Store-owned lifecycle tuple."""
     import json as _json
 
-    srv = WebServer(None)
+    srv = WebServer(None, WebConfig(radio_model="IC-7610"))
     assert srv._radio_poller is None  # noqa: SLF001
     writer = _FakeWriter()
     await srv._serve_state(writer)  # noqa: SLF001
@@ -3789,7 +3789,7 @@ async def test_on_radio_state_change_broadcasts_canonical_state_payload() -> Non
     radio.profile.vfo_sub_code = None
     radio.profile.vfo_main_code = None
 
-    srv = WebServer(radio)
+    srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
     queue = BoundedQueue[dict[str, object]](maxsize=4)
     srv.register_control_event_queue(queue)
     srv.command_state_store.apply(
@@ -3865,26 +3865,14 @@ async def test_info_endpoint_returns_structured_capabilities() -> None:
 
 
 @pytest.mark.asyncio
-async def test_info_endpoint_no_radio() -> None:
-    """/api/v1/info works without a radio (all capabilities false)."""
-    import json as _json
-
+async def test_info_endpoint_no_radio_refuses_instead_of_guessing() -> None:
+    """/api/v1/info raises when nothing identifies the radio (plan §8.1
+    Q5) rather than reporting a guessed default profile's capabilities."""
     srv = WebServer(None)
     writer = _FakeWriter()
-    await srv._serve_info(writer)  # noqa: SLF001
 
-    text = writer.buffer.decode("ascii", errors="replace")
-    body_start = text.index("\r\n\r\n") + 4
-    data = _json.loads(text[body_start:])
-    caps = data["capabilities"]
-    assert caps["hasSpectrum"] is False
-    assert caps["hasAudio"] is False
-    assert caps["hasDualReceiver"] is False
-    assert caps["maxReceivers"] == 1
-    assert caps["tags"] == []
-    conn = data["connection"]
-    assert conn["rigConnected"] is False
-    assert conn["radioReady"] is False
+    with pytest.raises(ValueError, match="Cannot resolve a radio profile"):
+        await srv._serve_info(writer)  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------
@@ -3980,7 +3968,7 @@ class TestCamelCaseState:
         """Integration: _serve_state HTTP response body is camelCase."""
         import json as _json
 
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
         writer = _FakeWriter()
         await srv._serve_state(writer)  # noqa: SLF001
         text = writer.buffer.decode("ascii", errors="replace")
@@ -4004,7 +3992,7 @@ class TestStateEtag:
     @pytest.mark.asyncio
     async def test_state_response_includes_etag(self) -> None:
         """GET /api/v1/state returns an ETag header."""
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
         writer = _FakeWriter()
         await srv._serve_state(writer)
         text = writer.buffer.decode("ascii", errors="replace")
@@ -4016,7 +4004,7 @@ class TestStateEtag:
         """GET /api/v1/state with matching If-None-Match returns 304 and empty body."""
 
         # First request — get the ETag
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
         writer = _FakeWriter()
         await srv._serve_state(writer)
         text = writer.buffer.decode("ascii", errors="replace")
@@ -4049,7 +4037,7 @@ class TestStateEtag:
             capabilities: set[str] = set()
 
         radio = _ConnectionRadio()
-        srv = WebServer(radio)
+        srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
 
         writer = _FakeWriter()
         await srv._serve_state(writer)  # noqa: SLF001
@@ -4073,7 +4061,7 @@ class TestStateEtag:
     @pytest.mark.asyncio
     async def test_state_etag_changes_when_ws_client_counts_change(self) -> None:
         """WS client counts are part of the public state payload and ETag."""
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
 
         writer = _FakeWriter()
         await srv._serve_state(writer)  # noqa: SLF001
@@ -4099,7 +4087,7 @@ class TestStateEtag:
         self,
     ) -> None:
         """publicStateSeq distinguishes repeated live metadata values."""
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
 
         writer = _FakeWriter()
         await srv._serve_state(writer)  # noqa: SLF001
@@ -4153,7 +4141,7 @@ class TestStateEtag:
             capabilities: set[str] = set()
 
         radio = _HealthRadio()
-        srv = WebServer(radio)
+        srv = WebServer(radio, WebConfig(radio_model="IC-7610"))
         writer = _FakeWriter()
         await srv._serve_state(writer)
         text = writer.buffer.decode("ascii", errors="replace")
@@ -4182,7 +4170,7 @@ class TestStateEtag:
         self,
     ) -> None:
         """Same-value observations update fieldStatus and must invalidate ETag."""
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
         path = FieldPath.active("0", "freq_mode", "freq_hz")
         srv.command_state_store.apply(
             Observation(
@@ -4240,7 +4228,7 @@ class TestStateEtag:
     @pytest.mark.asyncio
     async def test_state_200_when_etag_differs(self) -> None:
         """GET /api/v1/state with stale If-None-Match returns 200 with full body."""
-        srv = WebServer(None)
+        srv = WebServer(None, WebConfig(radio_model="IC-7610"))
         writer = _FakeWriter()
         fake_headers = {"if-none-match": '"stale-etag-999"'}
         await srv._serve_state(writer, fake_headers)

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -3865,14 +3865,30 @@ async def test_info_endpoint_returns_structured_capabilities() -> None:
 
 
 @pytest.mark.asyncio
-async def test_info_endpoint_no_radio_refuses_instead_of_guessing() -> None:
-    """/api/v1/info raises when nothing identifies the radio (plan §8.1
-    Q5) rather than reporting a guessed default profile's capabilities."""
+async def test_info_endpoint_no_radio_serves_with_rig_connected_false() -> None:
+    """/api/v1/info works with no radio attached and no model configured
+    (all capabilities false) -- "no radio attached" is not "an
+    unidentified radio": WebServer must not call the profile resolver at
+    all in that state, and must not raise (MOR-2012 follow-up)."""
+    import json as _json
+
     srv = WebServer(None)
     writer = _FakeWriter()
+    await srv._serve_info(writer)  # noqa: SLF001
 
-    with pytest.raises(ValueError, match="Cannot resolve a radio profile"):
-        await srv._serve_info(writer)  # noqa: SLF001
+    text = writer.buffer.decode("ascii", errors="replace")
+    body_start = text.index("\r\n\r\n") + 4
+    data = _json.loads(text[body_start:])
+    assert data["proto"] == 1
+    caps = data["capabilities"]
+    assert caps["hasSpectrum"] is False
+    assert caps["hasAudio"] is False
+    assert caps["hasDualReceiver"] is False
+    assert caps["maxReceivers"] == 1
+    assert caps["tags"] == []
+    conn = data["connection"]
+    assert conn["rigConnected"] is False
+    assert conn["radioReady"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_webrtc_signaling.py
+++ b/tests/test_webrtc_signaling.py
@@ -133,7 +133,7 @@ class TestCapabilitiesWebrtcBlock:
 
     @pytest.mark.asyncio
     async def test_present_and_unavailable_by_default(self):
-        srv = WebServer(radio=None)
+        srv = WebServer(radio=None, config=WebConfig(radio_model="IC-7610"))
         writer = _FakeWriter()
 
         with patch("rigplane.web.server.webrtc_available", return_value=False):
@@ -147,7 +147,10 @@ class TestCapabilitiesWebrtcBlock:
 
     @pytest.mark.asyncio
     async def test_reflects_available_and_enabled_gate(self):
-        srv = WebServer(radio=None, config=WebConfig(webrtc_enabled=True))
+        srv = WebServer(
+            radio=None,
+            config=WebConfig(webrtc_enabled=True, radio_model="IC-7610"),
+        )
         writer = _FakeWriter()
 
         with patch("rigplane.web.server.webrtc_available", return_value=True):

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -333,7 +333,7 @@ QUEUE_PATH_BACKENDS: tuple[str, ...] = ("yaesu-ftx1", "rigctld-client")
 
 async def _build_lan_icom() -> TxConformanceHarness:
     transport = ScriptedLanTransport()
-    radio = IcomRadio("192.168.99.1", timeout=0.2)
+    radio = IcomRadio("192.168.99.1", timeout=0.2, model="IC-7610")
     radio._civ_transport = transport
     radio._ctrl_transport = transport
     radio._connected = True


### PR DESCRIPTION
## Summary

Implements the owner's Q5 ruling (plan `docs/plans/2026-08-29-profile-driven-command-bytes.md` §8.1): `resolve_radio_profile`'s silent fallback (IC-7610 → first LAN profile → first loaded profile) is removed. When nothing identifies the radio — no profile, a `None`/blank/whitespace-only model, and no `radio_addr` matching a loaded profile — it now raises `ValueError` with a message naming what's missing. An explicit `profile=`/`model=` override, or a `radio_addr` that matches a loaded profile, resolves exactly as before.

A blank/whitespace-only `model` now counts as "nothing identifies the radio" and refuses. This also closes **#2863**: `RigctldServer._resolved_radio_profile` calls `resolve_radio_profile(model=model)` inside a bare `except Exception: return None`, so the new `ValueError` on blank input is caught there and correctly yields `None` instead of the wrong rig's `state_acquisition`/`supports_cmd29`.

Closes #2863

## Exception type chosen

`ValueError`, not a new class. Search: grepped `core/exceptions.py` (only `RigplaneError`/`ConnectionError`/`AuthenticationError`/`CommandError`/`TimeoutError`/audio errors — none fit "insufficient identifying input") and `profiles/rig_loader.py`'s `RigLoadError` (scoped to TOML parsing, not resolution). The repo's own precedent for this *exact* class of bug — an unidentified/unsupported radio that must fail loud instead of guessing — is `backends/factory.py`'s MOR-174 fix (`f70...`/PR #1798): `raise ValueError(f"Unsupported serial model {model!r}; ...")`. `ValueError` is also the dominant idiom for bad/insufficient constructor input throughout `runtime/radio.py` and `backends/factory.py`. Required test 4(a) asserts `type(exc) is ValueError` and `not isinstance(exc, KeyError)` — `KeyError` stays reserved for "a *named* profile/model wasn't found" (`get_radio_profile`), so a caller can tell "you gave me nothing" apart from "you named something unknown" by exception type alone.

## Production call sites affected

The refusal is the ruling's intent, but three production paths change observable behavior:

1. **`backends/factory.py: create_radio` for a LAN backend with no `model`/`profile`/`radio_addr`.** Confirmed empirically: the CLI's own `_build_backend_config` returns `LanBackendConfig(model=None, radio_addr=None, profile=None)` whenever `--model` and `--radio-addr` are both omitted (`_resolve_model` returns `(None, None, None)` when `args.model is None`). **This means the bare `rigplane --host <ip>` invocation over LAN — the tool's most basic usage pattern — now raises instead of silently connecting as IC-7610.** The user must now pass `--model` (or `--radio-addr`). This is exactly the ruling's intent, but it is a real, common-path behavior change, not a corner case.
   - Worse, this exception is **uncaught** by the CLI: `radio = create_radio(config)` (`cli/__init__.py`) has no `try/except`, unlike the adjacent `_build_backend_config` call, so the user sees a raw Python traceback instead of a clean `Error: ...` line. This is a pre-existing gap in the CLI's error handling that my change now exercises; fixing `cli/__init__.py`'s error handling is outside this PR's scope (a different file, its own review surface), so I've flagged it as a separate follow-up task rather than folding it in here.
2. **`backends/factory.py: create_radio` for a serial backend with no `--model`.** This one does *not* regress: `create_radio`'s own serial-class-selection logic already treats an omitted model as "use the IC-7610 driver" (`model = (config.model or "IC-7610").upper()`), a decision independent of and predating this ruling. It was only *masked* by `resolve_radio_profile`'s fallback that `Icom7610SerialRadio._DEFAULT_MODEL` was `""` (its three siblings — IC-705, IC-7300, IC-9700 — each default to their own model name; IC-7610's was the only empty one, apparently an oversight, not a documented decision — no comment or ticket explains it, and `git log -S` traces it to the original 2026-07 rebrand commit with no rationale). I set it to `"IC-7610"` (`src/rigplane/backends/icom7610/serial.py`, 1 line) so the pre-existing "no serial --model ⇒ IC-7610" decision keeps working now that the resolver no longer rescues it by accident.
3. **`web/server.py: WebServer._get_profile()`** — the MOR-174 warn-and-guess branch is deleted; when neither the radio nor the configured `radio_model` identifies the radio, the state/capability paths (`/api/v1/state`, the WS hello handshake, capability reporting) now raise. Confirmed unreachable from the CLI's `web`/`station` command: `config_kwargs["radio_model"] = getattr(radio, "model", "IC-7610")` runs unconditionally there, and by that point `radio` was already constructed via `create_radio` (point 1), which by now guarantees a resolved `.model`.
   - **One deliberate exception, added after the consumer-contracts gate caught a fielded regression:** `GET /api/v1/info` is probed by the Pro companion *with no rig attached* (pinned by `contracts/consumer-expectations/pro/info_proto.json`, whose producer artifact is built from `WebServer(radio=None)`). A new `_resolve_profile_if_identified()` returns `None` — without calling the resolver at all — when there is nothing to identify ("no radio" is not "an unidentified radio"), and `_serve_info` is its **only** caller: `/info` serves `proto: 1`, `rigConnected: false` and neutral capability defaults. A *named*-but-unresolvable model still refuses through both methods, and no default-rig guess is reintroduced anywhere (both facts verified independently in review).

## Dependent-site count vs. the ticket's estimate

Re-derived at this PR's head (`baf9c0f8`, branched from `bce3be1e`), not carried forward from the ticket's `9957ee49` measurement:

- **3 bare `CoreRadio(...)` sites** (`tests/test_managed_radio_runtime.py` ×2, `tests/test_managed_tx_assembly.py` ×1) — matches the ticket's named list exactly.
- **177 bare `IcomRadio(`/`CoreRadio(` constructions across 52 files** (AST census: `Call` nodes named `IcomRadio`/`CoreRadio` with no `model=`/`profile=`/`radio_addr=` keyword, no `**kwargs` spread, and no 5th+ positional arg) — vs. the ticket's "~252 across 63 files" measured at a different, older commit. All 177 pinned with an explicit `model="IC-7610"` (the value every one of them was already receiving via the removed fallback — LAN/no-`radio_addr` always resolved to IC-7610 first), reformatted with `ruff format`; no test assertion changed.
- **Beyond the ticket's named list**, found empirically by running the affected files and reading each failure:
  - `tests/serial_stub.py: SerialMockRadio.__init__` calls `resolve_radio_profile` directly at construction; its `model` parameter's default was `None`. Changed the default to `"IC-7610"` (1 line), fixing all 10 bare `SerialMockRadio()` call sites across 6 files transitively.
  - **2 subclass `super().__init__()` calls** reaching `CoreRadio.__init__` with no model: `tests/test_managed_tx_assembly.py: _AssembledRadio.__init__` and `tests/test_web_recovery_durable_off.py: _ManagedRadio.__init__` (the latter's only subclass, `_NoOpRetireBackend` in `tests/test_managed_tx_identity_pins.py`, inherits the fix). Found by an AST sweep for classes subclassing `CoreRadio`/`IcomRadio` (transitively) whose own `__init__` calls `super().__init__(...)` without an identifying kwarg.
  - **4 `**kwargs`-spread helper functions** whose *default* (no caller-supplied `model`) needed a value: `tests/test_audio_recovery.py: _make_radio`, `tests/test_dsp_filter_family.py: _connected_icom`, `tests/test_audio_recovery_session.py: _make_radio`, `tests/test_mor1545_dedupe_key_inventory.py`'s IC-7610 branch of `_build_radio`. (`tests/integration/`'s spread-based radio fixtures were *not* touched — `radio_config`'s `radio_addr` defaults to `0x98`, IC-7610's CI-V address, so they already self-identify.)
  - **1 aliased-import site**: `tests/test_cli_async.py` imports the real `runtime.radio.IcomRadio` as `RuntimeIcomRadio`; the by-literal-name AST census missed it until a second, import-aware pass matched local names back to their originating module.
  - **`tests/test_web_server.py`**: 4 tests in `TestGetProfileRouting` whose entire point was the removed MOR-174 warn-and-fallback contract are rewritten to assert the refusal (not pinned — pinning would defeat what they test); the `server_no_radio` fixture and 2 further tests (`TestConfigurableKeepalive`, `TestScopeEnableAtomic`) pinned an explicit `radio_model`.
  - **`tests/test_web_server_coverage.py`**: 67 unique test functions construct `WebServer()`/`WebServer(None)`/`WebServer(radio)` with an unresolvable config; all pinned via an explicit `WebConfig(radio_model="IC-7610")`. `test_info_endpoint_no_radio` was first rewritten as a refusal test, then — after the consumer-contracts gate proved `/info` has a fielded no-radio consumer — replaced by `test_info_endpoint_no_radio_serves_with_rig_connected_false`, which asserts `WebServer(None)._serve_info()` succeeds with `proto == 1`, `rigConnected is False`, and the same capability defaults the original pre-PR test asserted (red-proof: fails on the pre-fix head with the exact CI error).
  - **`tests/test_backend_factory.py`**: 2 tests — `test_create_radio_builds_lan_backend` rewritten (renamed `test_create_radio_lan_backend_refuses_without_a_model`) to assert the refusal (production call site #1 above); `test_lan_backend_has_icom_lan_backend_id` pinned.
  - `src/rigplane/web/runtime_helpers.py`: one docstring parenthetical describing the now-removed "resolve_radio_profile's empty-input path silently returns a default rig profile" is deleted (it would be false).
  - `src/rigplane/profiles/LAYER.md`: the one-line public-API summary of `resolve_radio_profile`'s fallback behavior is corrected.

## Discriminating test evidence (mutation kill)

Two mutations, both re-run at the final head (`6b097cb8`) during the independent review:

1. Reinstating the exact removed fallback body in `resolve_radio_profile` (the IC-7610 → any-LAN-profile → first-loaded-profile chain, ending in the old `raise KeyError(...)`) → **8 tests fail with `DID NOT RAISE <class 'ValueError'>`** (7 test functions, one parametrized ×2, independently re-measured in review): `tests/test_profiles_routing.py::TestResolveRadioProfileFailsClosed` (4/4 refusal cases — `test_explicit_model_override_still_resolves` correctly stayed green, since it doesn't touch the fallback path), `tests/test_web_server.py::TestGetProfileRouting` (3 rewritten refusal tests), `tests/test_backend_factory.py::test_create_radio_lan_backend_refuses_without_a_model`. (An earlier round reported 9: the ninth was the since-replaced `/info` refusal test, superseded by the consumer-contract ruling below.)
2. Re-pointing `_serve_info` back at `_get_profile()` → the no-radio info test fails **and** `scripts/run_consumer_contracts.py` reproduces the CI gate failure verbatim (`FAIL contracts/consumer-expectations/pro/info_proto.json: failed to build producer artifact: Cannot resolve a radio profile...`).

Both mutations restored; `git diff` confirms no trace remains.

## Test evidence

- New/rewritten tests: `uv run pytest tests/test_profiles_routing.py -v` — 12 passed (4 new in `TestResolveRadioProfileFailsClosed`).
- `uv run python scripts/run_consumer_contracts.py`: both consumer contracts PASS.
- Sweep of every test file constructing `WebServer(` (36 files, `-n auto`): **1241 passed, 4 skipped, 0 failed**. Conftest files construct none; no import aliasing; no `WebServer` subclasses (all four sweep claims re-run independently in review).
- Combined targeted set across all rounds + `tests/integration/` (90 files, `-n auto`): **3668 passed, 61 skipped, 1 failed** — the one failure is `tests/test_radio.py::TestMeters::test_get_swr_meter`, an untouched CI-V mock-timing test that timed out under parallel load and passes in isolation (pre-existing flakiness, not a regression).
- `quick` at the final head: executed green (Core and Frontend blocks both ran; 12009 passed), run 33459488362. `consumer-contracts-gate`: green.
- `uv run ruff check src/ tests/`: All checks passed.
- `uv run ruff format --check src/ tests/`: 700 files already formatted.
- `uv run lint-imports`: Contracts: 5 kept, 0 broken.
- Regen check on the command-map/profile-coverage census files (`tests/command_map_parity_uncovered.txt`, `tests/profile_command_coverage_gaps.txt`): confirmed no-op — `git status` shows no changes to either tracked file, and their owning test files (`tests/test_command_map_parity.py`, `tests/test_profile_command_coverage.py`) pass unchanged. Expected: this PR touches profile *resolution*, not command builders or rig TOMLs.
- `tests/mock_server.py: MockIcomRadio` was not touched (data-driven doctrine; it doesn't call `resolve_radio_profile` or subclass `CoreRadio`).

## Size — guardrail crossing, not self-waived

**75 files changed, 543 insertions / 401 deletions (944 changed lines)** at the final head (`6b097cb8`; figures re-derived from `git diff` against `main` and independently re-measured in review). This crosses the **hard ceiling on file count** (75 > 10) — it does not cross the line-count ceiling (944 < 1000). Per `CLAUDE.md`, this is not author-waivable; the owner's exception is recorded in this PR's comments. I did not decompose the change because the two obvious splits both break something in between commits: (a) landing the resolver change before the test-fixture sweep leaves the tree red until the sweep lands, and there is no way to land a subset of the sweep without also being red (every touched test file was independently broken by the resolver change, empirically, by running it — not a static guess); (b) landing the sweep before the resolver change is landing dead test edits with nothing to test. The size is almost entirely mechanical, same-shaped edits (an explicit `model=`/`radio_model=` at a construction that previously leaned on the removed fallback) across many files — 5 files are the actual behavior change (`profiles/__init__.py`, `profiles/LAYER.md`, `backends/icom7610/serial.py`, `web/server.py`, `web/runtime_helpers.py`); the other 70 are its test-suite consequence, across three rounds: the original radio-construction sweep (59 files), the `/info` consumer fix (1 test file), and the `WebServer`-with-a-model-less-fake sweep the first census could not see (11 files, caught by `quick` at the second head).

## Internal-identifier self-check

empty

