### PR TITLE
docs: name the counting method behind the C9 collision column

### DIFF
--- a/docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md
+++ b/docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md
@@ -598,6 +598,13 @@ granularity `_civ_rx.py` actually matches on:
 | X6200 | 62 | 38 | 22 | 4 | 38 | 22 |
 | X6100 | 12 | 9 | 3 | 2 | 8 | 4 |
 
+**Counting method for the `(cmd, sub)` columns:** "sub" is taken
+*positionally* — the declared tuple's second byte whenever the tuple has two or
+more bytes — not by whether `commands/_frame.py: parse_civ_frame` would assign
+that command a sub at all (`_COMMANDS_WITH_SUB`). The numbers above stand under
+that definition; the parser-grounded definition, which differs and is the one
+used from here on, is in `docs/plans/2026-09-01-reverse-command-index.md` §1.
+
 The worst cases are not exotic. On IC-705 and X6200, `1C 00` resolves to
 `{get_transceiver_status, ptt_off, ptt_on, set_transceiver_status}` — four
 names on one tuple. On IC-705, `0E` resolves to


### PR DESCRIPTION
## What

Section C9 of `docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md`
publishes a per-profile `(cmd, sub)` collision-count column without saying how
"sub" was determined. Two definitions are in play in this repository and they
give different counts, so the column could not be compared against the
reverse-index plan's figures.

This adds one two-sentence annotation naming the method. It changes no number.

## Why the numbers are not touched

The column is correct under its own method. The defect is the missing method
name, not the arithmetic.

Re-derived at `a2de2ab0` in a clean detached worktree (each profile loaded via
`profiles/rig_loader.py: discover_rigs`, its command map inverted twice —
once keying on the declared tuple's second byte, once on what
`commands/_frame.py: parse_civ_frame` assigns to `frame.command`/`frame.sub`
for a frame synthesized from that tuple):

| Profile | positional | parser-grounded | published column |
|---|---|---|---|
| IC-705  | 109 / 101 | 106 / 99 | 109 / 101 |
| IC-7300 | 95 / 60   | 93 / 62  | 95 / 60   |
| IC-7610 | 109 / 65  | 103 / 67 | 109 / 65  |
| IC-9700 | 100 / 61  | 94 / 63  | 100 / 61  |
| X6200   | 38 / 22   | 36 / 20  | 38 / 22   |
| X6100   | 8 / 4     | 8 / 4    | 8 / 4     |

(keys / colliding keys). The positional method reproduces all six published
rows exactly; the parser-grounded method reproduces neither of the five rows
where the two definitions diverge. That is the evidence for calling the
column's method positional.

The annotation deliberately makes no directional claim about the difference,
because there is no single direction to state. The colliding-key count is
higher under the parser-grounded method on IC-7300, IC-7610 and IC-9700 and
lower on IC-705 and X6200; the key count is lower on all five diverging
profiles and higher on none. X6100 declares none of the divergent tuples and
is method-independent.

## Verification

- `.github/scripts/check-doc-citations.sh` — clean (844 grandfathered
  citations); no `file:line` citation added, the two new code references use
  file-plus-symbol and bare-symbol form.
- `.github/scripts/check-doc-citations.sh --check-links` — clean. The sibling
  document is referenced as a backticked path, matching this file's existing
  style, so no new markdown link enters the link gate.
- `uv run ruff check src/ tests/` — clean.
- The pytest suite was **not** run: the diff is one markdown file and cannot
  affect it. Flagging this rather than implying a suite result that was never
  produced.

## Scope

One file, 7 added lines. Well inside the soft threshold.
