### PR TITLE
fix(MOR-1880): read the server's freshness contract instead of the delivery cadence

### DIFF
--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -271,7 +271,7 @@ async function mountConnectedApp(): Promise<{
   const socket = instances[0];
   socket.simulateOpen();
 
-  await observePtt(false, 2); // first fresh (non-baseline) PTT reading
+  await observePtt(false, 2);
 
   const controller = capturedController();
   if (!controller) throw new Error('TxControllerProbe never captured a controller');

--- a/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/app-authority.test.ts
@@ -58,7 +58,7 @@ describe('App TX authority projector', () => {
   it('advances only for genuinely newer qualifying field-specific evidence', () => {
     const project = createAppAuthorityProjector();
     expect(project(radio(), capabilities(), session(1)).ptt).toMatchObject({
-      observed: true, fresh: false, source: 'radio-readback',
+      observed: true, fresh: true, source: 'radio-readback',
       marker: { pttObservationSeq: 1 },
     });
     const newer = withPtt(field(2, 'civ_unsolicited'));
@@ -66,14 +66,18 @@ describe('App TX authority projector', () => {
       value: false, observed: true, fresh: true, source: 'backend-observation',
       marker: { pttObservationSeq: 2, pttLastObservedMonotonic: 2 },
     });
+    // MOR-1880: a repeated lastObservedMonotonic (the radio reporting the same
+    // thing again, e.g. because a delta omitted this field) does not advance
+    // the ordinal — but it is still `fresh`, since freshness now reads the
+    // field's own status rather than delivery cadence.
     const duplicate = project(radio({ ptt: true, revision: 1_000, fieldStatus: { ...radio().fieldStatus, ptt: field(2, 'civ_unsolicited') } }), capabilities(), session(1));
-    expect(duplicate.ptt).toMatchObject({ value: true, fresh: false, marker: { pttObservationSeq: 2 } });
+    expect(duplicate.ptt).toMatchObject({ value: true, fresh: true, marker: { pttObservationSeq: 2 } });
     for (const malicious of ['toString', 'constructor', '__proto__'])
       expect(project(withPtt(field(3, malicious)), capabilities(), session(1)).ptt).toMatchObject({ source: 'other', fresh: false, marker: { pttObservationSeq: 2, pttLastObservedMonotonic: 2 } });
     expect(project(withPtt(field(3, 'hamlib_response')), capabilities(), session(1)).ptt.source).toBe('radio-readback');
     expect(project(withPtt(field(4, 'yaesu_poll_response')), capabilities(), session(1)).ptt.fresh).toBe(true);
   });
-  it('rejects bad evidence and retains a per-epoch baseline against stale epochs', () => {
+  it('rejects bad evidence outright; a new epoch or a repeated timestamp does not by itself make a reading non-fresh', () => {
     const rejected = [
       field(2, 'command_response'), field(3, 'state_poller'),
       field(4, 'local_reconcile'), field(5, 'test'), field(6, 'unknown'),
@@ -89,12 +93,41 @@ describe('App TX authority projector', () => {
     const project = createAppAuthorityProjector();
     project(radio(), capabilities(), session(1));
     project(withPtt(field(2)), capabilities(), session(1));
-    const baseline = project(withPtt(field(10)), capabilities(), session(2));
-    expect(baseline.ptt).toMatchObject({ fresh: false, marker: { authorityEpoch: 2, pttObservationSeq: 3 } });
+    // MOR-1880: the first qualifying projection of a new epoch (session(2), a
+    // reconnect) is fresh — there is no more per-epoch baseline suppression.
+    const afterEpochBump = project(withPtt(field(10)), capabilities(), session(2));
+    expect(afterEpochBump.ptt).toMatchObject({ fresh: true, marker: { authorityEpoch: 2, pttObservationSeq: 3 } });
+    // A stale session (epoch behind the projector's current epoch) still
+    // reports controlLive: false and therefore non-fresh — unrelated to
+    // decay or baseline, and unaffected by MOR-1880.
     expect(project(withPtt(field(11)), capabilities(), session(1)))
       .toMatchObject({ epoch: 2, eligibility: { controlLive: false }, ptt: { fresh: false } });
-    expect(project(withPtt(field(10)), capabilities(), session(2)).ptt.fresh).toBe(false);
+    // MOR-1880: repeating the SAME lastObservedMonotonic (field(10) again,
+    // identical to afterEpochBump's) does not advance the ordinal, but it is
+    // still fresh — this is the operator's actual bug: the radio reporting
+    // the same thing because nothing changed must not read as stale.
+    expect(project(withPtt(field(10)), capabilities(), session(2)).ptt)
+      .toMatchObject({ fresh: true, marker: { pttObservationSeq: 3 } });
     expect(project(withPtt(field(12), true), capabilities(), session(2)).ptt)
       .toMatchObject({ value: true, fresh: true, marker: { pttObservationSeq: 4 } });
+  });
+  it('reports fresh: true on a repeated fieldStatus.ptt timestamp, not just the first (MOR-1880 decay regression)', () => {
+    const project = createAppAuthorityProjector();
+    project(withPtt(field(1)), capabilities(), session(1)); // epoch baseline
+    project(withPtt(field(2)), capabilities(), session(1)); // genuinely newer, past the baseline
+    const first = project(withPtt(field(5)), capabilities(), session(1));
+    // Identical lastObservedMonotonic: the radio reporting the same thing
+    // again because nothing changed, exactly as it does on every delta that
+    // omits fieldStatus.ptt.
+    const second = project(withPtt(field(5)), capabilities(), session(1));
+    expect(first.ptt.fresh).toBe(true);
+    expect(second.ptt.fresh).toBe(true);
+  });
+  it('reports fresh: true on the first qualifying projection after an epoch change (MOR-1880 baseline regression)', () => {
+    const project = createAppAuthorityProjector();
+    project(withPtt(field(1)), capabilities(), session(1));
+    project(withPtt(field(2)), capabilities(), session(1));
+    const afterReconnect = project(withPtt(field(3)), capabilities(), session(2)); // epoch bump 1 -> 2
+    expect(afterReconnect.ptt.fresh).toBe(true);
   });
 });

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-freshness-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-freshness-authority.isolated.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ControlSessionTransition } from '$lib/transport/ws-client';
+import { MockWebSocket, instances } from '$lib/transport/__tests__/support/fake-ws-backend';
+
+// ─── Freshness-contract integration pin (MOR-1880) — the REAL
+// `createAppAuthorityProjector` joined to the REAL `TxController` through the
+// REAL stack ─────────────────────────────────────────────────────────────────
+//
+// Every other app-authority test (`app-authority.test.ts`) drives the
+// projector alone. The sibling integration files
+// (`integration-lifecycle-matrix.isolated.test.ts`,
+// `integration-reconnect-dekey-matrix.isolated.test.ts`) already join the
+// real projector to the real reducer the same way this file does — but every
+// PTT observation either of them dispatches uses a strictly advancing
+// `lastObservedMonotonic` (checked directly: every `dispatchStart`/
+// `confirmAuthority` call in both files passes a timestamp higher than the
+// one before it). Neither ever dispatches `start` against a REPEATED,
+// non-advancing timestamp — the exact shape MOR-1880 fixes and closed PR
+// #2921 broke (it set `pttObservationSeq: null` unconditionally, and 8163
+// other tests in this suite stayed green while keying was impossible end to
+// end). This file is the one that exercises that shape: `setup()` below is a
+// deliberately small, direct reproduction of `app-host.ts`'s
+// `applyAuthority` — `provideAppTxControllerHost` itself can't run here
+// because it needs a live Svelte component for `getContext`/`setContext`,
+// the same reason the sibling integration files give.
+//
+// Real: the REAL `WsChannel` singleton in `$lib/transport/ws-client` (driven
+// only at the socket boundary by the shared `MockWebSocket` fake), the REAL
+// `createBrowserTxControllerDependencies()` factory (so the REAL
+// `createAppAuthorityProjector`), and a REAL `TxController`
+// (`controller.ts`/`model.ts`, untouched by MOR-1880). Mocked: only the facts
+// seam `browser-dependencies.ts` reads from (`radio.svelte`,
+// `capabilities.svelte`, `tx-adapter`) — the same seam every sibling file
+// mocks.
+//
+// Like the sibling isolated files, `vi.resetModules()` runs every `it()`
+// because `ws-client` holds module-level singletons that would otherwise leak
+// session/epoch state across tests sharing a module cache.
+//
+// The scenario: a normal page-load session sequence (`connecting`/epoch 0 —
+// emitted by `wsClient.connect()` itself — then `connected`/epoch 1 once the
+// socket opens), one genuinely newer PTT observation to move `radioTx` off
+// `'unknown'`, then a SECOND observation repeating the same
+// `lastObservedMonotonic` — the shape a delta that omits `fieldStatus.ptt`
+// produces in production (MOR-1880's actual bug). The key control is then
+// pressed (`start`) against that repeated-timestamp reading. Before MOR-1880,
+// `app-authority.ts` reported that reading `fresh: false` (decayed), so
+// `authoritative()` failed and `start` refused with `fault: 'not-eligible'` /
+// `'ptt-not-authoritative'` — the operator's bench symptom. After MOR-1880 the
+// reading is `fresh: true`, and `model.ts`'s existing `currentConfirmedOff`
+// leg (untouched by this fix) recognizes the repeated reading as "unchanged
+// because nothing changed" and lets `start` proceed.
+
+const h = vi.hoisted(() => ({
+  radio: null as any,
+  caps: null as any,
+  start: vi.fn(async (): Promise<string | null> => null),
+  stop: vi.fn(),
+  restore: vi.fn(),
+}));
+vi.mock('$lib/stores/radio.svelte', () => ({
+  getRadioState: () => h.radio,
+  setRadioState: () => {},
+  patchActiveReceiver: () => {},
+  patchRadioState: () => {},
+  resetRadioState: () => {},
+}));
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  getCapabilities: () => h.caps,
+  capabilitiesMatchGeneration: () => true,
+  clearCapabilities: () => {},
+  setCapabilities: () => true,
+}));
+vi.mock('$lib/runtime/adapters/tx-adapter', () => ({
+  getTxAudioControl: () => ({
+  onTxAudioDied: () => () => {},
+    startTx: h.start,
+    stopLocalAudio: h.stop,
+    restoreModAfterConfirmedOff: h.restore,
+  }),
+}));
+
+type WsClientModule = typeof import('$lib/transport/ws-client');
+type ConnectionModule = typeof import('$lib/stores/connection.svelte');
+type BrowserDepsModule = typeof import('../browser-dependencies');
+type ControllerModule = typeof import('../controller');
+type Factory = ReturnType<BrowserDepsModule['createBrowserTxControllerDependencies']>;
+type Controller = InstanceType<ControllerModule['TxController']>;
+
+const field = (at: number) => ({
+  observed: true, freshness: 'fresh' as const, availability: 'available' as const,
+  lastObservedMonotonic: at, source: { source: 'poll_response' },
+});
+const target = { receiver: 'SUB' as const, slot: 'B' as const, frequencyHz: 150 };
+
+function resetFacts(): void {
+  h.radio = {
+    revision: 1, ptt: false, active: 'SUB', txTarget: { status: 'known', ...target },
+    main: { dataMode: 0 }, sub: { dataMode: 1 }, data1ModInput: 5,
+    fieldStatus: { ptt: field(1), txTarget: field(1), data1ModInput: field(1) },
+  };
+  h.caps = {
+    tx: true, audioTx: true, capabilities: ['tx', 'mod_input_routing'],
+    vfoScheme: 'main_sub', audioTxRequiredModInputSource: 5, txBands: [{ start: 100, end: 200 }],
+  } as Capabilities;
+}
+
+const flush = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+async function loadStack() {
+  const wsClient = (await import('$lib/transport/ws-client')) as WsClientModule;
+  const connection = (await import('$lib/stores/connection.svelte')) as ConnectionModule;
+  const browserDeps = (await import('../browser-dependencies')) as BrowserDepsModule;
+  const controllerModule = (await import('../controller')) as ControllerModule;
+  return { wsClient, connection, browserDeps, controllerModule };
+}
+
+/** Boot the real control channel, factory, and controller — wired the same
+ * way `app-host.ts`'s `provideAppTxControllerHost` wires them (`applyAuthority`
+ * below mirrors its `epoch`-then-`authority` dispatch exactly), minus the
+ * Svelte context. `wsClient.connect()` fires the real `'connecting'`/epoch 0
+ * session transition synchronously (already observed by `subscribeSession`
+ * below); `socket.simulateOpen()` fires the real `'connected'`/epoch 1 one. */
+async function setup(): Promise<{
+  factory: Factory; controller: Controller; socket: MockWebSocket;
+  getSession: () => ControlSessionTransition;
+}> {
+  const { wsClient, connection, browserDeps, controllerModule } = await loadStack();
+  const factory = browserDeps.createBrowserTxControllerDependencies();
+  const baseline = factory.projectAuthority({ state: 'disconnected', epoch: 0 });
+  const controller = new controllerModule.TxController(baseline.epoch, baseline.ptt.marker, factory.dependencies);
+  let session: ControlSessionTransition = { state: 'disconnected', epoch: 0 };
+  factory.subscribeSession((authority, transition) => {
+    session = transition;
+    const offCommandId = factory.dependencies.commandId('off');
+    if (authority.epoch > controller.snapshot().authorityEpoch) {
+      controller.dispatch({ type: 'epoch', epoch: authority.epoch, baseline: authority.ptt.marker, offCommandId });
+    }
+    controller.dispatch({
+      type: 'authority', epoch: authority.epoch, ptt: authority.ptt,
+      eligibility: authority.eligibility, offCommandId,
+    });
+  });
+  connection.setRadioReady(true);
+  wsClient.connect('ws://test/api/v1/ws');
+  const socket = instances[0];
+  socket.simulateOpen();
+  return { factory, controller, socket, getSession: () => session };
+}
+
+/** Push a new `fieldStatus.ptt` reading and replay it through the real
+ * projector as a real `authority` event — the same shape `refreshAuthority()`
+ * produces in production on every backend push. */
+function observeAuthority(
+  controller: Controller, factory: Factory, session: ControlSessionTransition, at: number,
+) {
+  h.radio = { ...h.radio, ptt: false, fieldStatus: { ...h.radio.fieldStatus, ptt: field(at) } };
+  const authority = factory.projectAuthority(session);
+  controller.dispatch({
+    type: 'authority', epoch: authority.epoch, ptt: authority.ptt,
+    eligibility: authority.eligibility, offCommandId: factory.dependencies.commandId('off'),
+  });
+  return authority;
+}
+
+/** Re-project the CURRENT `fieldStatus.ptt` (no new reading pushed) and
+ * dispatch `start` against it — the operator pressing the key control against
+ * whatever the projector reports right now. */
+function dispatchStart(
+  controller: Controller, factory: Factory, session: ControlSessionTransition, leaseId: string,
+) {
+  const authority = factory.projectAuthority(session);
+  controller.dispatch({
+    type: 'start', sourceId: 'panel-a', leaseId, intent: 'momentary',
+    eligibility: authority.eligibility, ptt: authority.ptt,
+  });
+  return authority;
+}
+
+function sentFrames(socket: MockWebSocket): Array<{ name: string }> {
+  return socket.sent.map((raw) => JSON.parse(raw));
+}
+function countFrames(name: string, socket: MockWebSocket): number {
+  return sentFrames(socket).filter((f) => f.name === name).length;
+}
+
+describe('tx-controller freshness-authority integration pin — real projector + real reducer (MOR-1880)', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    instances.length = 0;
+    originalWebSocket = globalThis.WebSocket;
+    // @ts-expect-error install the mock as the global WebSocket constructor
+    globalThis.WebSocket = MockWebSocket;
+    vi.resetModules();
+    resetFacts();
+    h.start.mockReset().mockResolvedValue(null);
+    h.stop.mockClear();
+    h.restore.mockClear();
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.resetModules();
+  });
+
+  it('keys through a repeated-timestamp reading — the delta-omits-fieldStatus.ptt shape — instead of refusing not-eligible', async () => {
+    const { factory, controller, socket, getSession } = await setup();
+
+    // One genuinely newer reading moves radioTx off 'unknown' to 'off'.
+    observeAuthority(controller, factory, getSession(), 2);
+    expect(controller.snapshot()).toMatchObject({ phase: 'idle', radioTx: 'off' });
+
+    // A SECOND reading repeating the exact same lastObservedMonotonic — the
+    // shape a delta that omits fieldStatus.ptt produces (a bench measurement
+    // on an IC-7300 over USB serial found fieldStatus.ptt present in 3 of 149
+    // captured state_update messages, all three of type "full" — MOR-1880).
+    observeAuthority(controller, factory, getSession(), 2);
+    expect(controller.snapshot().phase).toBe('idle');
+
+    // The operator presses the key control against that repeated-timestamp
+    // reading.
+    dispatchStart(controller, factory, getSession(), 'lease-freshness-pin');
+    await flush();
+
+    expect(controller.snapshot()).toMatchObject({ phase: 'key-confirm-pending', fault: null });
+    expect(countFrames('ptt_on', socket)).toBe(1);
+  });
+});

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-freshness-authority.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-freshness-authority.isolated.test.ts
@@ -11,11 +11,8 @@ import { MockWebSocket, instances } from '$lib/transport/__tests__/support/fake-
 // projector alone. The sibling integration files
 // (`integration-lifecycle-matrix.isolated.test.ts`,
 // `integration-reconnect-dekey-matrix.isolated.test.ts`) already join the
-// real projector to the real reducer the same way this file does — but every
-// PTT observation either of them dispatches uses a strictly advancing
-// `lastObservedMonotonic` (checked directly: every `dispatchStart`/
-// `confirmAuthority` call in both files passes a timestamp higher than the
-// one before it). Neither ever dispatches `start` against a REPEATED,
+// real projector to the real reducer the same way this file does. Neither
+// ever dispatches `start` against a REPEATED,
 // non-advancing timestamp — the exact shape MOR-1880 fixes and closed PR
 // #2921 broke (it set `pttObservationSeq: null` unconditionally, and 8163
 // other tests in this suite stayed green while keying was impossible end to

--- a/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
+++ b/frontend/src/lib/runtime/tx-controller/__tests__/integration-page-lifecycle.isolated.test.ts
@@ -195,13 +195,7 @@ const settle = async () => { await Promise.resolve(); await Promise.resolve(); }
 /** Bump the PTT fieldStatus to a fresh, newer monotonic reading and force
  * `App.svelte`'s own `$effect` (which depends on the mocked `runtime.state`/
  * `runtime.caps`) to re-run, which calls the REAL `txHost.refreshAuthority()`
- * — the same reactivity glue a real backend push does in production. The
- * very first authority projection computed once the control session goes
- * 'connected' is deliberately swallowed as a non-fresh baseline (this is
- * `app-authority.ts`'s own anti-replay guard, not a test artifact — see
- * `integration-lifecycle-matrix.isolated.test.ts`'s `dispatchStart` for the identical
- * two-step shape), so every caller needs at least one of these before a PTT
- * observation is treated as authoritative. */
+ * — the same reactivity glue a real backend push does in production. */
 async function observePtt(value: boolean, at: number): Promise<void> {
   h.radio = { ...h.radio, ptt: value, fieldStatus: { ...h.radio.fieldStatus, ptt: field(at) } };
   h.notifyRuntime();
@@ -250,7 +244,7 @@ async function mountConnectedApp(): Promise<{
   const socket = instances[0];
   socket.simulateOpen(); // fires the real subscribeSession callback in app-host
 
-  await observePtt(false, 2); // first fresh (non-baseline) PTT reading
+  await observePtt(false, 2);
 
   const controller = capturedController();
   if (!controller) throw new Error('TxControllerProbe never captured a controller');

--- a/frontend/src/lib/runtime/tx-controller/app-authority.ts
+++ b/frontend/src/lib/runtime/tx-controller/app-authority.ts
@@ -51,7 +51,6 @@ function controllerTarget(facts: TxCapabilityFacts | null): TxTarget {
 export function createAppAuthorityProjector() {
   let epoch = -1; let ordinal = 0;
   let lastPttAt: number | null = null;
-  let needsBaseline = true;
   return (state: ServerState | null, capabilities: Capabilities | null,
     session: ControlSessionTransition): AppAuthorityProjection => {
     const validEpoch = Number.isSafeInteger(session.epoch) && session.epoch >= 0;
@@ -59,7 +58,6 @@ export function createAppAuthorityProjector() {
     if (!lowerEpoch && session.epoch > epoch) {
       epoch = session.epoch;
       lastPttAt = null;
-      needsBaseline = true;
     }
     const currentSession = validEpoch && session.epoch === epoch;
     const controlLive = currentSession && session.state === 'connected';
@@ -73,22 +71,27 @@ export function createAppAuthorityProjector() {
     const status = state?.fieldStatus?.ptt;
     const source = authoritySource(status?.source?.source);
     const at = status?.lastObservedMonotonic;
-    const qualifies = controlLive
+    const fresh = controlLive
       && typeof state?.ptt === 'boolean'
       && status?.observed === true
       && status.freshness === 'fresh'
       && status.availability === 'available'
       && typeof at === 'number'
       && Number.isFinite(at)
-      && source !== 'other'
-      && (lastPttAt === null || at > lastPttAt);
-    const baseline = qualifies && needsBaseline;
-    if (qualifies) { ordinal += 1; lastPttAt = at; needsBaseline = false; }
+      && source !== 'other';
+    // `ordinal`/`lastPttAt` only track WHEN the server's own timestamp moved
+    // forward, so a marker comparison (model.ts: newer()) can still tell two
+    // observations apart. They no longer gate `fresh` itself: the field's own
+    // status (observed/freshness/availability) is the server's contract, and
+    // delivery cadence — whether this projection happens to repeat a
+    // timestamp already seen, e.g. because a delta omitted this field — is a
+    // property of the network, not of the reading.
+    if (fresh && typeof at === 'number' && (lastPttAt === null || at > lastPttAt)) { ordinal += 1; lastPttAt = at; }
     return {
       epoch, facts, modInputSource: inputs.modInputSource, eligibility,
       ptt: {
         value: typeof state?.ptt === 'boolean' ? state.ptt : false,
-        observed: status?.observed === true, fresh: qualifies && !baseline, source,
+        observed: status?.observed === true, fresh, source,
         marker: {
           authorityEpoch: epoch,
           pttObservationSeq: ordinal,


### PR DESCRIPTION
## What this does

MOR-1880. `app-authority.ts`'s freshness predicate re-derived "fresh" from delivery cadence — the field's `lastObservedMonotonic` had to be strictly newer than the previous accepted reading, and a `needsBaseline` flag additionally forced the first qualifying reading of each session epoch to read as stale. A bench measurement on an IC-7300 over USB serial captured 149 `state_update` messages over 20 seconds: 3 of type "full", 146 of type "delta"; `fieldStatus.ptt` appeared in all 3 fulls and none of the 146 deltas. `ws-client.ts`'s `applyDeltaEnvelope` merges a delta as `{ ...currentState, ...changed }`, so a delta that omits `fieldStatus.ptt` leaves the retained field's timestamp exactly where the last full left it — meaning the decay term collapsed `fresh` on nearly every projection.

Both the decay term and `needsBaseline` are removed from `fresh`, which now reads only the field's own reported status (`observed`/`freshness`/`availability`/`source`) — the server's actual contract, not delivery cadence. `ordinal` and `lastPttAt` are deliberately retained: they still advance only when a projection is fresh AND the server's timestamp has moved forward, so `model.ts`'s `newer()` marker comparison is unaffected. **`model.ts` is untouched by this PR.** With `fresh` no longer collapsing on a repeated reading, `model.ts`'s existing `currentConfirmedOff` leg — already written to treat an unchanged authoritative reading as confirmed-off — becomes reachable, which is what lets a `start` dispatch against a repeated timestamp succeed.

This corrects closed PR #2921, which set `pttObservationSeq: null` unconditionally and broke keying end to end while 8163 other tests stayed green (see the integration-pin test added here for why).

## Diffstat

3 files, +280/−14:
```
 frontend/.../tx-controller/__tests__/app-authority.test.ts                          |  45 +++-
 frontend/.../tx-controller/__tests__/integration-freshness-authority.isolated.test.ts | 230 +++++++++
 frontend/src/lib/runtime/tx-controller/app-authority.ts                              |  19 +-
```

## Tests added/changed, with mutation-failure output

Three tests per the spec, each shown to fail when `app-authority.ts` alone is reverted to its pre-change content (test files left as-is):

**1. Decay regression** (`app-authority.test.ts`, "reports fresh: true on a repeated fieldStatus.ptt timestamp, not just the first (MOR-1880 decay regression)"):
```
AssertionError: expected false to be true // Object.is equality
❯ src/lib/runtime/tx-controller/__tests__/app-authority.test.ts:124:30
    expect(second.ptt.fresh).toBe(true);
```

**2. Baseline regression** (`app-authority.test.ts`, "reports fresh: true on the first qualifying projection after an epoch change (MOR-1880 baseline regression)"):
```
AssertionError: expected false to be true // Object.is equality
❯ src/lib/runtime/tx-controller/__tests__/app-authority.test.ts:131:38
    expect(afterReconnect.ptt.fresh).toBe(true);
```

**3. Integration pin** (new file `integration-freshness-authority.isolated.test.ts`, real `createAppAuthorityProjector` joined to a real `TxController` via the same `epoch`/`authority` dispatch shape as `app-host.ts`; neither the projector nor the reducer is mocked):
```
AssertionError: expected { Object (phase, intent, ...) } to match object { phase: 'key-confirm-pending', ...(1) }
- Expected
+ Received
  {
-   "fault": null,
-   "phase": "key-confirm-pending",
+   "fault": "not-eligible",
+   "phase": "failed",
  }
```
Confirmed via an added probe that `faultDetail` on the reverted code is exactly `["ptt-not-authoritative"]` — the operator's bench symptom, reproduced end to end.

Two other, pre-existing tests in `app-authority.test.ts` also had to be updated (their prior expectations encoded the old, incorrect contract — a duplicate-timestamp reading expected `fresh: false`, and the first reading of a session expected `fresh: false`); both also fail against the reverted code for the same reason.

After each revert, `git checkout HEAD -- frontend/src/lib/runtime/tx-controller/app-authority.ts` restored the fix; `git status`/`git diff` showed a clean tree (no mutation residue) before the final suite run below.

## Before/after suite counts

- **Baseline** (recorded at `1c32d02c`, an ancestor of this branch's base — confirmed no `frontend/` diff between the two): `npm run test` in `frontend/` → **372 test files passed, 8163 tests passed, 0 failed**.
- **This branch**: `npm run test` in `frontend/` → **373 test files passed, 8166 tests passed, 0 failed** (372+1 new file, 8163+3 new tests — no other file or test count changed).
- `npm run check` (svelte-check + tsc): **4607 files, 0 errors, 0 warnings**.
- `npm run lint`: clean.

## Scope

2 files modified + 1 file added, 294 changed lines — within guardrails (soft threshold 6 files/600 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up commit: deleted false prose (independent review)

Independent review confirmed the fix but found four now-false comments — three describing the removed `needsBaseline` mechanism, one an overclaim in the file this PR adds. Per the merged rule (delete a false statement, do not rewrite it), each is deleted outright with no replacement text:

1. `integration-freshness-authority.isolated.test.ts` — the header sentence claiming both neighboring integration files pass only strictly advancing PTT timestamps.
2. `integration-page-lifecycle.isolated.test.ts` — the doc-comment sentence attributing a swallowed first observation to `app-authority.ts`'s "anti-replay guard".
3. `integration-page-lifecycle.isolated.test.ts` — the inline `// first fresh (non-baseline) PTT reading` comment.
4. `presentation-switch-tx.component.test.ts` — the same inline comment.

No executable test code was changed; `model.ts` remains untouched. `npm run test` stayed at 373 files / 8166 tests / 0 failed.

**Note on verification:** `git diff origin/main...HEAD` on the two files this PR does not otherwise touch shows 3 added lines, not 0. Each is mechanically unavoidable while satisfying "don't touch executable code" / valid comment syntax, and none adds new prose: two are the untouched code statement (`await observePtt(false, 2);`) with only the trailing false comment truncated off (the `+` line is an exact prefix of the `-` line, zero new characters); the third moves the pre-existing `*/` doc-comment terminator onto the now-last (true) sentence after the false sentence that used to carry it is deleted (2 relocated characters, no new words). None restates or corrects any deleted claim.

