### PR TITLE
fix: report create_radio's ValueError as an error, not a traceback

### DIFF
--- a/src/rigplane/cli/__init__.py
+++ b/src/rigplane/cli/__init__.py
@@ -1888,7 +1888,11 @@ async def _run(args: argparse.Namespace) -> int:
         return 1
     if args.command == "audio" and args.audio_command == "probe":
         return await _cmd_audio_probe(config, args)
-    radio = create_radio(config)
+    try:
+        radio = create_radio(config)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
     if args.command in ("web", "station"):
         # Declared listeners are checked before the radio connects (MOR-1437):

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -1484,7 +1484,6 @@ class TestRunErrorHandling:
             command="status",
             json=False,
         )
-        # Mock create_radio to raise immediately instead of attempting real network connect
         mock_radio = MagicMock()
         mock_radio.__aenter__ = AsyncMock(
             side_effect=ConnectionError("test connection failed")

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -1497,6 +1497,66 @@ class TestRunErrorHandling:
         assert "Error" in err
 
     @pytest.mark.asyncio
+    async def test_run_reports_unsupported_serial_model_cleanly(self, capsys) -> None:
+        """create_radio's own ValueError reaches the user as `Error: ...`, not a traceback.
+
+        X6100 has a rig profile (so _resolve_model accepts --model X6100 and
+        _build_backend_config returns), but backends.factory.create_radio has no
+        serial route for it and raises; that raise used to escape _run uncaught.
+        """
+        args = Namespace(
+            backend="serial",
+            serial_port="/dev/ttyUSB0",
+            serial_baud=None,
+            serial_ptt_mode="civ",
+            host="",
+            control_port=50001,
+            user="",
+            password="",
+            timeout=0.1,
+            model="X6100",
+            radio_addr=None,
+            rx_device=None,
+            tx_device=None,
+            command="status",
+            json=False,
+        )
+        rc = await _run(args)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert err.startswith("Error: Unsupported serial model 'X6100'")
+        assert "Traceback" not in err
+
+    @pytest.mark.asyncio
+    async def test_run_reports_unresolvable_profile_cleanly(self, capsys) -> None:
+        """A profile that cannot be resolved is a user-input error, not a crash.
+
+        `rigplane --host <ip>` with no --model leaves the config with neither a
+        model nor a radio_addr. create_radio is patched to raise, so this pins
+        _run's handling independently of what makes it raise.
+        """
+        args = Namespace(
+            host="192.168.1.100",
+            control_port=50001,
+            user="",
+            password="",
+            timeout=0.1,
+            model=None,
+            radio_addr=None,
+            command="status",
+            json=False,
+        )
+        with patch(
+            "rigplane.cli.create_radio",
+            side_effect=ValueError("Cannot resolve a radio profile: pass --model."),
+        ):
+            rc = await _run(args)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert err.startswith("Error: Cannot resolve a radio profile")
+        assert "Traceback" not in err
+
+    @pytest.mark.asyncio
     async def test_run_audio_rx_routes_to_handler(self) -> None:
         args = Namespace(
             host="192.168.1.100",

--- a/tests/test_cli_async.py
+++ b/tests/test_cli_async.py
@@ -1528,11 +1528,12 @@ class TestRunErrorHandling:
 
     @pytest.mark.asyncio
     async def test_run_reports_unresolvable_profile_cleanly(self, capsys) -> None:
-        """A profile that cannot be resolved is a user-input error, not a crash.
+        """A radio nothing identifies is a user-input error, not a crash.
 
         `rigplane --host <ip>` with no --model leaves the config with neither a
-        model nor a radio_addr. create_radio is patched to raise, so this pins
-        _run's handling independently of what makes it raise.
+        model nor a radio_addr, so profiles.resolve_radio_profile refuses rather
+        than guessing a default rig, and that ValueError leaves create_radio by
+        way of IcomRadio's constructor. No mock: this is the real path.
         """
         args = Namespace(
             host="192.168.1.100",
@@ -1545,11 +1546,7 @@ class TestRunErrorHandling:
             command="status",
             json=False,
         )
-        with patch(
-            "rigplane.cli.create_radio",
-            side_effect=ValueError("Cannot resolve a radio profile: pass --model."),
-        ):
-            rc = await _run(args)
+        rc = await _run(args)
         assert rc == 1
         err = capsys.readouterr().err
         assert err.startswith("Error: Cannot resolve a radio profile")


### PR DESCRIPTION
## What

`_run` in `src/rigplane/cli/__init__.py` guarded `_build_backend_config` with `except ValueError -> print("Error: ...") / return 1`, but left the very next line — `radio = create_radio(config)` — unguarded. A `ValueError` from the backend factory reached the user as a raw Python traceback.

This wraps that call in the same handler, and adds two tests.

## Why it is reachable

Two ways, both verified by running them:

- **A model that ships a rig profile but has no serial route.** `--backend serial --model X6100` printed a traceback ending in `ValueError: Unsupported serial model 'X6100'`. `TX-500` is the second such model. `_resolve_model` accepts both (they have rig TOMLs), then `create_radio` refuses them — a shipped rig profile is data, not a backend route.
- **A radio nothing identifies.** Since `eb78e3b8` (#2922) landed on main, `rigplane --host <ip>` with no `--model` no longer resolves silently to IC-7610 — `resolve_radio_profile` refuses, and that `ValueError` leaves `create_radio` through `IcomRadio.__init__`. That is the plainest possible invocation, and before this change it ended in a traceback.

## Why `except ValueError` and not something wider

`profiles.get_radio_profile` can raise `KeyError`, and `IcomRadio` resolves its profile eagerly in `__init__`, so the narrow type is a real question rather than an assumption. It is unreachable from `_run`: `cli._resolve_model` validates `--model` against the shipped rig profiles first and returns the canonical name.

Established by enumerating all four backends against every loaded rig model — 36 combinations. Exactly three raise, all `ValueError`: `lan/None`, `serial/TX-500`, `serial/X6100`. Zero `KeyError`.

## What is deliberately not here

- **The other `create_radio` sites.** `cli/_validate.py` has four more, and `validate` / `radio-validate` dispatch straight from `main()` without passing through `_run`, so this guard does not cover them. Tracked as MOR-2096 — deliberately not referenced in a closing form, since this PR does not fix it. Scoping note there: only two of those four are reachable, and a third genuinely unguarded construction sits nearby.
- **The audio-probe call site**, inside `_attempt_stock_radio_lan_audio_probe`. It needs no guard: every attempt runs through `audio.probe_runner._attempt_once`, which catches `Exception` and normalizes it into a failed `AudioProbeResult`. Verified by running it — no traceback escapes. A guard there would be unreachable code.
- **Any change to the refusal itself.** `backends/factory.py` must keep raising for unknown serial models (MOR-174); `tests/test_backend_factory.py::test_create_radio_serial_unknown_model_raises` pins it and passes unmodified.

## Evidence

- Full suite on the merged tree: **11943 passed**, 274 skipped, 48 xfailed, 72s.
- `ruff check` + `ruff format --check` clean; `mypy --strict src/rigplane/web` clean; `lint-imports` 5 contracts kept, 0 broken.
- Both new tests confirmed to discriminate: with the guard deleted on a scratch copy of this tree, both fail. Neither uses a mock — both exercise the real path.

## Size

2 files, 64 changed lines. Well under the 6/600 soft threshold.

## Note for whoever merges

This branch has multiple commits plus a merge commit, and squash bodies here come from the commit messages rather than this description — pass explicit `--subject` / `--body` rather than accepting the concatenation.

Independent review has not yet run against this head. An earlier verifier pass returned PASS, but on a pre-merge tree and before the second test was rewritten to drop its mock, so it does not cover this SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)