### PR TITLE
fix(MOR-2091): correct the CTCSS tone/TSQL BCD byte layout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -546,6 +546,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set_quick_dual_watch`. Previously they enqueued the same bare read
   marker as their `get_` twins and silently re-read the current toggle
   state instead of changing it.
+- **`get_tone_freq`/`set_tone_freq`/`get_tsql_freq`/`set_tsql_freq` used
+  the wrong CI-V byte layout, on every profile that declares the family
+  (IC-705, IC-7300, IC-9700; IC-7610 declares it `absent`) (MOR-2091).**
+  `commands/tone.py`'s codec packed/read the 3-byte BCD payload as
+  `[hundreds][tens+units][tenths]`; the documented layout (identical in
+  the IC-705, IC-7300, IC-9700 and IC-7610 CI-V references) is six packed
+  BCD digits read as tenths of a Hz: `[0][0][100Hz][10Hz][1Hz][0.1Hz]`.
+  `get_tone_freq`/`get_tsql_freq` returned wrong values -- a live IC-7300
+  capture of an 88.5 Hz tone decoded as 16.5 Hz. `set_tone_freq`/
+  `set_tsql_freq` encoded a 100 Hz BCD digit outside its documented 0-2
+  range for most tones (88.5 Hz encoded as `00 88 05`, digit 8). The
+  released 2.11.1 carries this bug.
 
 ## [2.11.1] — 2026-06-22
 

--- a/src/rigplane/commands/tone.py
+++ b/src/rigplane/commands/tone.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ._builders import _build_function_bool_set, _build_function_get
-from ._codec import _bcd_byte, _bcd_decode_value
+from ._codec import _bcd_decode_value, bcd_encode_value
 from ._frame import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
@@ -39,25 +39,28 @@ if TYPE_CHECKING:
 
 
 def _encode_tone_freq(freq_hz: float) -> bytes:
-    """Encode tone frequency (Hz) to 3-byte BCD."""
+    """Encode tone frequency (Hz) to 3-byte BCD.
+
+    Three bytes hold six packed BCD digits, read as a decimal integer of
+    tenths of a Hz: ``[0][0][100Hz digit][10Hz digit][1Hz digit]
+    [0.1Hz digit]`` (IC-705 CI-V Reference Guide 2020 p.21, "Repeater
+    tone/tone squelch frequency settings", command 1B 00/1B 01 -- the same
+    layout as the IC-7300 Advanced Manual, IC-9700 and IC-7610 CI-V
+    references). MOR-2091 fixed a prior layout mismatch here; see
+    ``tests/test_tone_tsql.py``'s ``_BCD_TABLE`` for the full manual and
+    hardware-capture sourcing.
+    """
     if not 67.0 <= freq_hz <= 254.1:
         raise ValueError(f"Tone frequency must be 67.0-254.1 Hz, got {freq_hz}")
     total_tenths = round(freq_hz * 10)
-    integer_hz = total_tenths // 10
-    hundreds = integer_hz // 100
-    tens_units = integer_hz % 100
-    tenths_digit = total_tenths % 10
-    return bytes([_bcd_byte(hundreds), _bcd_byte(tens_units), _bcd_byte(tenths_digit)])
+    return bcd_encode_value(total_tenths, byte_count=3)
 
 
 def _decode_tone_freq(data: bytes) -> float:
-    """Decode 3-byte BCD to tone frequency (Hz)."""
+    """Decode 3-byte BCD to tone frequency (Hz). Inverse of `_encode_tone_freq`."""
     if len(data) < 3:
         raise ValueError(f"Expected 3 bytes for tone freq, got {len(data)}")
-    hundreds = _bcd_decode_value(data[0:1])
-    tens_units = _bcd_decode_value(data[1:2])
-    tenths_digit = _bcd_decode_value(data[2:3])
-    return float(hundreds * 100 + tens_units) + tenths_digit / 10.0
+    return _bcd_decode_value(data[:3]) / 10.0
 
 
 @expose_command_key(lambda cmd_map: "get_repeater_tone")

--- a/tests/integration/test_tone_tsql_integration.py
+++ b/tests/integration/test_tone_tsql_integration.py
@@ -86,24 +86,23 @@ def _bcd_byte_decode(b: int) -> int:
 def _encode_tone_freq(freq_hz: float) -> bytes:
     """Encode a CTCSS tone frequency to 3-byte BCD.
 
-    The radio stores frequency in three BCD bytes:
-      byte[0] = hundreds of Hz  (e.g. 110.9 Hz → _bcd_byte(1)  = 0x01)
-      byte[1] = tens+units of Hz (e.g. 110.9 Hz → _bcd_byte(10) = 0x10)
-      byte[2] = tenths of Hz    (e.g. 110.9 Hz → _bcd_byte(9)  = 0x09)
+    MOR-2091: the radio packs six BCD digits as
+    [0][0][100Hz digit][10Hz digit][1Hz digit][0.1Hz digit] -- not
+    [hundreds][tens+units][tenths] (one byte per component) as this mock
+    originally, incorrectly, assumed. See tests/test_tone_tsql.py's
+    ``_BCD_TABLE`` header comment for the manual sourcing. E.g. 110.9 Hz:
+    tenths=1109 -> byte[0]=0x00, byte[1]=_bcd_byte(11)=0x11,
+    byte[2]=_bcd_byte(9)=0x09.
     """
-    int_part = int(freq_hz)
-    hundreds = int_part // 100
-    tens_units = int_part % 100
-    tenths_digit = int(round(freq_hz * 10)) % 10
-    return bytes([_bcd_byte(hundreds), _bcd_byte(tens_units), _bcd_byte(tenths_digit)])
+    total_tenths = int(round(freq_hz * 10))
+    return bytes([0x00, _bcd_byte(total_tenths // 100), _bcd_byte(total_tenths % 100)])
 
 
 def _decode_tone_freq(data: bytes) -> float:
-    """Decode 3-byte BCD to a CTCSS tone frequency in Hz."""
-    hundreds = _bcd_byte_decode(data[0])
-    tens_units = _bcd_byte_decode(data[1])
-    tenths = _bcd_byte_decode(data[2])
-    return round(hundreds * 100 + tens_units + tenths / 10.0, 1)
+    """Decode 3-byte BCD to a CTCSS tone frequency in Hz. Inverse of
+    `_encode_tone_freq` above."""
+    total_tenths = _bcd_byte_decode(data[1]) * 100 + _bcd_byte_decode(data[2])
+    return round(total_tenths / 10.0, 1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1883,31 +1883,39 @@ class TestToneTsqlCommands:
             set_repeater_tsql(True, cmd_map=None)
 
     # --- Tone frequency encoding/decoding ---
+    #
+    # MOR-2091: this class duplicated test_tone_tsql.py's _BCD_TABLE bug --
+    # byte values pinned from the buggy encoder's own output, not from the
+    # radio or the manuals (both landed in the same commit as the codec
+    # itself, d21d2d66, #134). Corrected here the same way; see
+    # tests/test_tone_tsql.py's _BCD_TABLE header comment for the
+    # documented layout, the four manuals checked against it, and the live
+    # IC-7300 capture for 88.5 Hz (00 08 85).
 
     def test_encode_tone_freq_88_5(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(88.5) == bytes([0x00, 0x88, 0x05])
+        assert _encode_tone_freq(88.5) == bytes([0x00, 0x08, 0x85])
 
     def test_encode_tone_freq_110_9(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(110.9) == bytes([0x01, 0x10, 0x09])
+        assert _encode_tone_freq(110.9) == bytes([0x00, 0x11, 0x09])
 
     def test_encode_tone_freq_100_0(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(100.0) == bytes([0x01, 0x00, 0x00])
+        assert _encode_tone_freq(100.0) == bytes([0x00, 0x10, 0x00])
 
     def test_encode_tone_freq_67_0(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(67.0) == bytes([0x00, 0x67, 0x00])
+        assert _encode_tone_freq(67.0) == bytes([0x00, 0x06, 0x70])
 
     def test_encode_tone_freq_254_1(self) -> None:
         from rigplane.commands import _encode_tone_freq
 
-        assert _encode_tone_freq(254.1) == bytes([0x02, 0x54, 0x01])
+        assert _encode_tone_freq(254.1) == bytes([0x00, 0x25, 0x41])
 
     def test_encode_tone_freq_rejects_out_of_range(self) -> None:
         from rigplane.commands import _encode_tone_freq
@@ -1920,12 +1928,12 @@ class TestToneTsqlCommands:
     def test_decode_tone_freq_88_5(self) -> None:
         from rigplane.commands import _decode_tone_freq
 
-        assert _decode_tone_freq(bytes([0x00, 0x88, 0x05])) == pytest.approx(88.5)
+        assert _decode_tone_freq(bytes([0x00, 0x08, 0x85])) == pytest.approx(88.5)
 
     def test_decode_tone_freq_110_9(self) -> None:
         from rigplane.commands import _decode_tone_freq
 
-        assert _decode_tone_freq(bytes([0x01, 0x10, 0x09])) == pytest.approx(110.9)
+        assert _decode_tone_freq(bytes([0x00, 0x11, 0x09])) == pytest.approx(110.9)
 
     def test_decode_tone_freq_roundtrip(self) -> None:
         from rigplane.commands import _decode_tone_freq, _encode_tone_freq
@@ -1952,7 +1960,7 @@ class TestToneTsqlCommands:
         assert frame[4] == 0x29
         assert frame[6] == 0x1B
         assert frame[7] == 0x00
-        assert frame[8:11] == bytes([0x00, 0x88, 0x05])
+        assert frame[8:11] == bytes([0x00, 0x08, 0x85])
 
     def test_set_tone_freq_rejects_out_of_range(self, cmd_map) -> None:
         from rigplane.commands import set_tone_freq
@@ -1978,7 +1986,7 @@ class TestToneTsqlCommands:
         assert frame[4] == 0x29
         assert frame[6] == 0x1B
         assert frame[7] == 0x01
-        assert frame[8:11] == bytes([0x01, 0x10, 0x09])
+        assert frame[8:11] == bytes([0x00, 0x11, 0x09])
 
     # --- Response parsers ---
 
@@ -1997,7 +2005,7 @@ class TestToneTsqlCommands:
             IC_7610_ADDR,
             0x1B,
             sub=0x00,
-            data=bytes([0x00, 0x88, 0x05]),
+            data=bytes([0x00, 0x08, 0x85]),
             receiver=RECEIVER_MAIN,
         )
         frame = parse_civ_frame(civ)
@@ -2020,7 +2028,7 @@ class TestToneTsqlCommands:
             IC_7610_ADDR,
             0x1B,
             sub=0x01,
-            data=bytes([0x01, 0x10, 0x09]),
+            data=bytes([0x00, 0x11, 0x09]),
             receiver=RECEIVER_SUB,
         )
         frame = parse_civ_frame(civ)

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -803,7 +803,7 @@ class TestToneFreqGating:
             from_addr=_IC7300_ADDR,
             command=0x1B,
             sub=0x00,
-            data=b"\x01\x00\x00",
+            data=b"\x00\x10\x00",  # 100.0 Hz -- MOR-2091, see _BCD_TABLE
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_tone_freq(receiver=0)
@@ -863,7 +863,7 @@ class TestTsqlFreqGating:
             from_addr=_IC7300_ADDR,
             command=0x1B,
             sub=0x01,
-            data=b"\x01\x00\x00",
+            data=b"\x00\x10\x00",  # 100.0 Hz -- MOR-2091, see _BCD_TABLE
         )
         mock = _mock_expect(radio, response)
         value = await radio.get_tsql_freq(receiver=0)

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -3318,14 +3318,13 @@ class TestToneTsqlParity:
     async def test_get_tone_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        # 3-byte BCD tone frequency: hundreds=0x00, tens_units=0x88,
-        # tenths=0x05 -> 88.5 Hz (_codec.py: _decode_tone_freq).
+        # 88.5 Hz -- MOR-2091, see tests/test_tone_tsql.py's _BCD_TABLE.
         civ = build_civ_frame(
             CONTROLLER_ADDR,
             _IC_7300_ADDR,
             0x1B,
             sub=0x00,
-            data=bytes([0x00, 0x88, 0x05]),
+            data=bytes([0x00, 0x08, 0x85]),
         )
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
         assert await radio.get_tone_freq() == pytest.approx(88.5)
@@ -3334,14 +3333,13 @@ class TestToneTsqlParity:
     async def test_get_tsql_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
-        # 3-byte BCD TSQL frequency: hundreds=0x01, tens_units=0x10,
-        # tenths=0x09 -> 110.9 Hz.
+        # 110.9 Hz -- MOR-2091, see tests/test_tone_tsql.py's _BCD_TABLE.
         civ = build_civ_frame(
             CONTROLLER_ADDR,
             _IC_7300_ADDR,
             0x1B,
             sub=0x01,
-            data=bytes([0x01, 0x10, 0x09]),
+            data=bytes([0x00, 0x11, 0x09]),
         )
         mock_transport.queue_response(_wrap_civ_in_udp(civ))
         assert await radio.get_tsql_freq() == pytest.approx(110.9)
@@ -3352,14 +3350,14 @@ class TestToneTsqlParity:
     ) -> None:
         await radio.set_tone_freq(88.5)
         # plain (no cmd29 -- IC-7300 has none) + 0x1B + 0x00 + BCD(88.5) + FD
-        assert mock_transport.sent_packets[-1].endswith(b"\x1b\x00\x00\x88\x05\xfd")
+        assert mock_transport.sent_packets[-1].endswith(b"\x1b\x00\x00\x08\x85\xfd")
 
     @pytest.mark.asyncio
     async def test_set_tsql_freq(
         self, radio: IcomRadio, mock_transport: MockTransport
     ) -> None:
         await radio.set_tsql_freq(110.9)
-        assert mock_transport.sent_packets[-1].endswith(b"\x1b\x01\x01\x10\x09\xfd")
+        assert mock_transport.sent_packets[-1].endswith(b"\x1b\x01\x00\x11\x09\xfd")
 
 
 class TestToneTsqlDualRxCmd29Guard:
@@ -3417,7 +3415,7 @@ class TestToneTsqlDualRxCmd29Guard:
                 "get_tone_freq",
                 b"\x1b\x00\xfd",
                 build_civ_frame(
-                    CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x00, data=b"\x00\x88\x05"
+                    CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x00, data=b"\x00\x08\x85"
                 ),
                 88.5,
             ),
@@ -3425,7 +3423,7 @@ class TestToneTsqlDualRxCmd29Guard:
                 "get_tsql_freq",
                 b"\x1b\x01\xfd",
                 build_civ_frame(
-                    CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x01, data=b"\x01\x10\x09"
+                    CONTROLLER_ADDR, 0xA2, 0x1B, sub=0x01, data=b"\x00\x11\x09"
                 ),
                 110.9,
             ),
@@ -3465,8 +3463,8 @@ class TestToneTsqlDualRxCmd29Guard:
         [
             ("set_repeater_tone", (True,), b"\x16\x42\x01\xfd"),
             ("set_repeater_tsql", (True,), b"\x16\x43\x01\xfd"),
-            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x88\x05\xfd"),
-            ("set_tsql_freq", (110.9,), b"\x1b\x01\x01\x10\x09\xfd"),
+            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x08\x85\xfd"),
+            ("set_tsql_freq", (110.9,), b"\x1b\x01\x00\x11\x09\xfd"),
         ],
     )
     async def test_sub_receiver_set_uses_vfo_select_fallback(
@@ -3503,8 +3501,8 @@ class TestToneTsqlDualRxCmd29Guard:
         [
             ("set_repeater_tone", (True,), b"\x16\x42\x01\xfd"),
             ("set_repeater_tsql", (True,), b"\x16\x43\x01\xfd"),
-            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x88\x05\xfd"),
-            ("set_tsql_freq", (110.9,), b"\x1b\x01\x01\x10\x09\xfd"),
+            ("set_tone_freq", (88.5,), b"\x1b\x00\x00\x08\x85\xfd"),
+            ("set_tsql_freq", (110.9,), b"\x1b\x01\x00\x11\x09\xfd"),
         ],
     )
     async def test_main_receiver_still_sends_direct_frame(

--- a/tests/test_tone_tsql.py
+++ b/tests/test_tone_tsql.py
@@ -29,6 +29,7 @@ from rigplane.commands import (
     CONTROLLER_ADDR,
     RECEIVER_MAIN,
     RECEIVER_SUB,
+    _decode_tone_freq,
     parse_bool_response,
     parse_tone_freq_response,
     parse_tsql_freq_response,
@@ -175,15 +176,46 @@ def _tsql_freq_response(bcd: bytes, receiver: int | None = None) -> CivFrame:
 # BCD encoding reference values
 # ---------------------------------------------------------------------------
 
-# freq_hz → expected 3-byte BCD encoding
+# freq_hz → expected 3-byte BCD encoding.
+#
+# Layout: 3 bytes hold six packed BCD digits, read as a decimal integer of
+# tenths of a Hz -- [0][0][100Hz digit 0-2][10Hz digit][1Hz digit]
+# [0.1Hz digit]. Confirmed identical, 2026-08-31, in all four local CI-V
+# references (command 1B 00/1B 01, "Repeater tone/tone squelch frequency
+# settings"): IC-705 CI-V Reference Guide 2020 p.21, IC-7300 Advanced
+# Manual (rev. 11a) p.19-13, IC-9700 CI-V Reference Guide p.19, IC-7610
+# CI-V Reference Guide 2021 p.13.
+#
+# 88.5 Hz (00 08 85) is a live capture, not computed: bench IC-7300,
+# 2026-09-01, 115200 CI-V (owner-reported), bypassing RigPlane --
+#   request fe fe 94 e0 1b 00 fd -> reply fe fe e0 94 1b 00 00 08 85 fd
+# (see test_decode_matches_bench_ic7300_capture below). The other five are
+# computed from the layout above for standard CTCSS chart frequencies.
+#
+# MOR-2091: this table previously held the output of the buggy encoder
+# itself (e.g. 88.5 Hz paired with 00 88 05), so it round-tripped against
+# the bug instead of catching it.
 _BCD_TABLE: list[tuple[float, bytes]] = [
-    (67.0, b"\x00\x67\x00"),
-    (88.5, b"\x00\x88\x05"),
-    (110.9, b"\x01\x10\x09"),
-    (136.5, b"\x01\x36\x05"),
-    (167.9, b"\x01\x67\x09"),
-    (254.1, b"\x02\x54\x01"),
+    (67.0, b"\x00\x06\x70"),
+    (88.5, b"\x00\x08\x85"),  # live capture -- see comment above
+    (110.9, b"\x00\x11\x09"),
+    (136.5, b"\x00\x13\x65"),
+    (167.9, b"\x00\x16\x79"),
+    (254.1, b"\x00\x25\x41"),
 ]
+
+
+def test_decode_matches_bench_ic7300_capture() -> None:
+    """Anchor for _BCD_TABLE's 88.5 Hz row: a captured value, not a value
+    derived from (and therefore blind to bugs in) the codec under test.
+
+    Bench IC-7300, 2026-09-01, 115200 CI-V (owner-reported), bypassing
+    RigPlane. The radio's tone was 88.5 Hz (confirmed in its own menu by
+    the owner):
+      request fe fe 94 e0 1b 00 fd
+      reply   fe fe e0 94 1b 00 00 08 85 fd   (data = 00 08 85)
+    """
+    assert _decode_tone_freq(bytes([0x00, 0x08, 0x85])) == 88.5
 
 
 # ===========================================================================
@@ -358,11 +390,14 @@ class TestToneFreqBCDEncoding:
 
     def test_accepts_boundary_low(self, cmd_map) -> None:
         frame = commands.set_tone_freq(67.0, cmd_map=cmd_map)
-        assert b"\x00\x67\x00" in frame
+        # 67.0 Hz -> 000670; see _BCD_TABLE's header comment for the layout
+        # and manual sourcing.
+        assert b"\x00\x06\x70" in frame
 
     def test_accepts_boundary_high(self, cmd_map) -> None:
         frame = commands.set_tone_freq(254.1, cmd_map=cmd_map)
-        assert b"\x02\x54\x01" in frame
+        # 254.1 Hz -> 002541; see _BCD_TABLE's header comment.
+        assert b"\x00\x25\x41" in frame
 
     def test_requires_cmd_map(self) -> None:
         """cmd_map is required keyword-only -- MOR-2006 Q6's API break."""
@@ -414,7 +449,9 @@ class TestSetToneFreq:
     def test_set_sub_receiver(self, cmd_map) -> None:
         assert commands.set_tone_freq(
             88.5, receiver=RECEIVER_SUB, cmd_map=cmd_map
-        ) == _cmd29_tone_set(_SUB_TONE_FREQ, b"\x00\x88\x05", RECEIVER_SUB)
+        ) == _cmd29_tone_set(
+            _SUB_TONE_FREQ, b"\x00\x08\x85", RECEIVER_SUB
+        )  # 88.5 Hz, see _BCD_TABLE
 
     def test_set_custom_addresses(self, cmd_map) -> None:
         frame = commands.set_tone_freq(
@@ -442,7 +479,8 @@ class TestParseToneFreqResponse:
         assert decoded == pytest.approx(freq, abs=0.05)
 
     def test_decode_no_receiver(self) -> None:
-        frame = _tone_freq_response(b"\x00\x88\x05", receiver=None)
+        # 88.5 Hz, see _BCD_TABLE.
+        frame = _tone_freq_response(b"\x00\x08\x85", receiver=None)
         rx, freq = parse_tone_freq_response(frame)
         assert rx is None
         assert freq == pytest.approx(88.5)
@@ -542,7 +580,9 @@ class TestSetTSQLFreq:
     def test_set_sub_receiver(self, cmd_map) -> None:
         assert commands.set_tsql_freq(
             88.5, receiver=RECEIVER_SUB, cmd_map=cmd_map
-        ) == _cmd29_tone_set(_SUB_TSQL_FREQ, b"\x00\x88\x05", RECEIVER_SUB)
+        ) == _cmd29_tone_set(
+            _SUB_TSQL_FREQ, b"\x00\x08\x85", RECEIVER_SUB
+        )  # 88.5 Hz, see _BCD_TABLE
 
 
 class TestParseTSQLFreqResponse:
@@ -556,7 +596,8 @@ class TestParseTSQLFreqResponse:
         assert decoded == pytest.approx(freq, abs=0.05)
 
     def test_decode_no_receiver(self) -> None:
-        frame = _tsql_freq_response(b"\x00\x88\x05", receiver=None)
+        # 88.5 Hz, see _BCD_TABLE.
+        frame = _tsql_freq_response(b"\x00\x08\x85", receiver=None)
         rx, freq = parse_tsql_freq_response(frame)
         assert rx is None
         assert freq == pytest.approx(88.5)

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -201,11 +201,17 @@ def test_civ_rx_0x16_0x43_notify_event(tmp_path: object) -> None:
 
 
 def _bcd_tone_freq(hundreds: int, tens_units: int, tenths: int) -> bytes:
-    """3-byte BCD encoding: [hundreds, tens+units, tenths digit]."""
-    h = ((hundreds // 10) << 4) | (hundreds % 10)
-    tu = ((tens_units // 10) << 4) | (tens_units % 10)
-    t = ((tenths // 10) << 4) | (tenths % 10)
-    return bytes([h, tu, t])
+    """3-byte BCD encoding for a tone frequency split into its
+    hundreds-of-Hz / tens-and-units-of-Hz / tenths-of-Hz components.
+
+    MOR-2091: the wire layout packs six BCD digits as
+    [0][0][100Hz digit][10Hz digit][1Hz digit][0.1Hz digit] (see
+    tests/test_tone_tsql.py's ``_BCD_TABLE`` header comment for the
+    manual sourcing) -- one byte per *component* (as this helper
+    originally, incorrectly, assumed) is not the same split.
+    """
+    tens_digit, units_digit = divmod(tens_units, 10)
+    return bytes([0x00, (hundreds << 4) | tens_digit, (units_digit << 4) | tenths])
 
 
 def test_civ_rx_0x1b_0x00_sets_tone_freq_main(tmp_path: object) -> None:
@@ -216,7 +222,7 @@ def test_civ_rx_0x1b_0x00_sets_tone_freq_main(tmp_path: object) -> None:
     """
     r = _make_radio_with_state()
     rs = r._radio_state
-    # 88.5 Hz → [0x00, 0x88, 0x05]
+    # 88.5 Hz → [0x00, 0x08, 0x85]
     data = _bcd_tone_freq(0, 88, 5)
     frame = _make_frame(cmd=0x1B, sub=0x00, data=data, receiver=0x00)
     r._civ_runtime._update_state_cache_from_frame(frame)
@@ -229,7 +235,7 @@ def test_civ_rx_0x1b_0x01_sets_tsql_freq_sub(tmp_path: object) -> None:
     """0x1B 0x01 with receiver=1 observes sub tsql_freq in centihz (MOR-451)."""
     r = _make_radio_with_state()
     rs = r._radio_state
-    # 100.0 Hz → [0x01, 0x00, 0x00]
+    # 100.0 Hz → [0x00, 0x10, 0x00]
     data = _bcd_tone_freq(1, 0, 0)
     frame = _make_frame(cmd=0x1B, sub=0x01, data=data, receiver=0x01)
     r._civ_runtime._update_state_cache_from_frame(frame)


### PR DESCRIPTION
The CTCSS tone codec packed three bytes as `[hundreds][tens+units][tenths]`.
Icom's layout is six packed BCD digits reading as tenths of a Hz. On the
IC-7300 bench the radio answered `fe fe e0 94 1b 00 00 08 85 fd` for 88.5 Hz
and the decoder returned **16.5**.

The wrong value then tripped a range guard, so `rigplane validate` reported
`skip: current value outside settable range` rather than writing garbage to the
radio. That skip was a working safeguard, and it is why the defect survived:
the summary line read as missing information rather than as a finding.

Live on the IC-7300, 2026-08-31.

## Size

**8 files / 213 changed lines**, past the 6-file soft threshold, which forbids
nothing but asks the body to say why this is one unit of work.

One codec is wrong; five test files pinned the wrong layout and one integration
file exercised it. The pins cannot stay while the codec changes — they encode
the same wrong claim from the other side. `docs/CHANGELOG.md` is the eighth.

## Provenance of the old layout

Traced during review, because "who checked this and against what" decided
whether the fix was safe. All five pins descend from a single wrong docstring:
`d21d2d66` (#134, 2026-03-07) introduced the codec together with four of them
in one commit by one author, and `7d5bc3e3` copied that docstring's wording
into a test helper a month later. Nothing checked the layout against a radio or
a manual until the bench run. That is why a plausible-looking wrong layout held
a green suite since March — there was never an independent observation for it
to disagree with.

## Review

Independently reviewed across two rounds; `Agent Review: PASS` at the head
being merged. The second round established mechanically that the round-2
changes touched no executable line — comments and docstrings stripped by
`tokenize`/`ast` and the remainder hashed, with a control proving the
comparison can report inequality — which is what licensed carrying the first
round's codec verification forward rather than re-running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
