### PR TITLE
fix(MOR-2089): resolve tx.ptt readback capability via TransmitStateReadable

### DIFF
--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -48,6 +48,7 @@ from rigplane.core.radio_protocol import (
     RitXitCapable,
     ScopeCapable,
     SystemControlCapable,
+    TransmitStateReadable,
     UsbAudioCapable,
 )
 from rigplane.core.tx_safety import TxOutcome, TxOwner, TxSource, TxTransition
@@ -607,9 +608,14 @@ async def _actuate_tx_ptt(
     """ACTUALLY key PTT briefly at minimum power, verify, then always unkey.
 
     Sequence: read original TX power → set power to MINIMUM → key PTT → brief
-    wait → verify it keyed, preferring a real read-back (``get_ptt``) over the
-    legacy ``radio_state`` mirror where the backend offers one (MOR-1941; see
-    ``ptt_state_source`` in the evidence) → unkey → restore power.
+    wait → verify it keyed, preferring a real read-back
+    (:meth:`~rigplane.core.radio_protocol.TransmitStateReadable.read_transmit_state`)
+    over the legacy ``radio_state`` mirror on a backend that implements the
+    protocol (MOR-1941 introduced the preference; MOR-2089 moved the
+    capability check off a hardcoded ``get_ptt`` probe onto the protocol
+    itself, so an Icom radio -- which never had ``get_ptt`` -- gets a real
+    read too; see ``ptt_state_source`` in the evidence) → unkey → restore
+    power.
     The unkey AND power-restore run in a ``finally`` that ALWAYS executes and
     never raises (contained by ``_RESTORE_ERRORS``, which includes ``OSError``),
     so a mid-check exception/timeout/LAN drop can never leave the radio keyed or
@@ -713,46 +719,63 @@ async def _actuate_tx_ptt(
             # takes (MOR-1941 review).
             await asyncio.sleep(_TX_PTT_KEY_SECONDS)
             # Verify the keyed state from a real read-back where the backend
-            # offers one, rather than the legacy ``radio_state`` mirror
-            # (MOR-1941): some backends no longer self-write that mirror
-            # from ``set_ptt``, so it is not radio truth on its own.
+            # implements ``TransmitStateReadable`` (MOR-1914), rather than
+            # the legacy ``radio_state`` mirror (MOR-1941): some backends no
+            # longer self-write that mirror from ``set_ptt``, so it is not
+            # radio truth on its own. MOR-2089: this used to probe for a
+            # ``get_ptt`` attribute, which no Icom backend defines, so on an
+            # Icom the check fell back to the ``radio_state`` mirror instead
+            # of any solicited read; on the IC-7300 bench that mirror read
+            # ``False`` and a good key reported ``keyed: False``. The
+            # capability check is now ``isinstance(radio,
+            # TransmitStateReadable)``, which ``runtime.radio.CoreRadio``
+            # satisfies too.
             #
-            # Best-effort means genuinely best-effort here, on the one
-            # backend (Yaesu) this repoint exists for: a read failure must
-            # not report a confident "did not key" when the write itself
-            # was accepted (``key_refusal is None`` already means
-            # ``set_ptt(True)`` did not raise) -- reporting `keyed: false`
-            # from a measurement that never happened would be a fabricated
-            # observation, and a false negative at that, not merely an
-            # unconfirmed positive. Note what this reasoning does and does
-            # not lean on: the transmit-authority ADR's rule that our own
-            # commands may source "transmitting" but never "receiving"
-            # licenses declining to say ``False`` here. It does not license
-            # claiming the value was verified, which is why the provenance
-            # tag below is not optional. So a read failure falls back to
-            # trusting the accepted write
-            # (``ptt_state = True``), not to the mirror -- on Yaesu the
-            # mirror is now permanently stale (the self-write is deleted),
-            # so it is exactly as fabricated a signal as a bare ``False``
-            # would be. ``ptt_state_source`` records which of "readback" /
-            # "mirror" / "unverified-write" produced the reported value, so
-            # a PASS backed by a real read stays distinguishable from one
-            # that is not, and the failure itself is never silent — see
-            # ``ptt_read_error``. Deliberately ``except Exception``, not
-            # ``_RESTORE_ERRORS``: this function is generic across backends
-            # and must not import a specific backend's transport exception
-            # types to enumerate them (MOR-1941 review).
+            # Best-effort means genuinely best-effort: neither an exception
+            # from ``read_transmit_state()`` nor a normal return with no
+            # usable value (``TxStateReading.value is None`` -- a timed-out
+            # or malformed reply) may report a confident "did not key" when
+            # the write itself was accepted (``key_refusal is None`` already
+            # means ``set_ptt(True)`` did not raise) -- reporting
+            # ``keyed: false`` from a measurement that never happened would
+            # be a fabricated observation, and a false negative at that, not
+            # merely an unconfirmed positive. Note what this reasoning does
+            # and does not lean on: the transmit-authority ADR's rule that
+            # our own commands may source "transmitting" but never
+            # "receiving" licenses declining to say ``False`` here. It does
+            # not license claiming the value was verified, which is why the
+            # provenance tag below is not optional. So either failure falls
+            # back to trusting the accepted write (``ptt_state = True``),
+            # not to the mirror -- as fabricated a signal as a bare
+            # ``False`` would be.
+            #
+            # A radio that does not implement ``TransmitStateReadable`` at
+            # all is a distinct case: the mirror is reported (unchanged from
+            # before this ticket), but ``ptt_read_unavailable`` says so in
+            # the evidence -- a consumer must not have to already know that
+            # ``ptt_state_source == "mirror"`` can mean "no read capability"
+            # (MOR-2089).
+            #
+            # ``ptt_state_source`` records which of "readback" / "mirror" /
+            # "unverified-write" produced the value, so neither failure mode
+            # is silent -- see ``ptt_read_error`` / ``ptt_read_unavailable``.
+            # Deliberately ``except Exception``, not ``_RESTORE_ERRORS``:
+            # generic across backends, must not import a specific backend's
+            # transport exception types (MOR-1941 review). Its own protocol
+            # docstring is explicit that ``read_transmit_state()`` is not a
+            # blanket "never raises" guarantee: besides the ahead-of-wire
+            # ``_check_connected()`` precondition, ``CoreRadio`` can also
+            # raise from a transport-recovery failure reached mid-send
+            # (``runtime/_civ_rx.py: _send_civ_raw`` ->
+            # ``_wait_for_civ_transport_recovery``) -- this catch is not
+            # narrowed to either.
             ptt_state = bool(radio.radio_state.ptt)
             ptt_state_source = "mirror"
-            _get_ptt_attr = getattr(radio, "get_ptt", None)
-            if callable(_get_ptt_attr):
+            if isinstance(radio, TransmitStateReadable):
                 try:
-                    ptt_state = bool(
-                        await asyncio.wait_for(
-                            _get_ptt_attr(), timeout=per_check_timeout
-                        )
+                    reading = await asyncio.wait_for(
+                        radio.read_transmit_state(), timeout=per_check_timeout
                     )
-                    ptt_state_source = "readback"
                 except Exception as exc:
                     evidence["ptt_read_error"] = str(exc)
                     _LOGGER.warning(
@@ -763,6 +786,31 @@ async def _actuate_tx_ptt(
                     )
                     ptt_state = True
                     ptt_state_source = "unverified-write"
+                else:
+                    if reading.value is None:
+                        evidence["ptt_read_error"] = reading.failure or "unverifiable"
+                        _LOGGER.warning(
+                            "tx.ptt readback returned no value after a "
+                            "successful key (failure=%s); trusting the "
+                            "accepted write rather than reporting an "
+                            "unverified key as a failure",
+                            reading.failure,
+                        )
+                        ptt_state = True
+                        ptt_state_source = "unverified-write"
+                    else:
+                        ptt_state = reading.value
+                        ptt_state_source = "readback"
+            else:
+                evidence["ptt_read_unavailable"] = (
+                    "radio does not implement TransmitStateReadable"
+                )
+                _LOGGER.warning(
+                    "tx.ptt has no TransmitStateReadable capability; "
+                    "falling back to the radio_state mirror (%s), which is "
+                    "not a solicited read of radio truth",
+                    ptt_state,
+                )
             evidence["ptt_state"] = ptt_state
             evidence["ptt_state_source"] = ptt_state_source
             keyed = ptt_state

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -17,6 +17,7 @@ import pytest
 from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTimeoutError
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
+from rigplane.core.tx_authority import TxStateReading
 from rigplane.validation.hardware import execute_hardware_checks
 from rigplane.validation.interactive import InteractivePrompter
 from rigplane.validation.schema import (
@@ -290,7 +291,12 @@ async def test_tx_allowed_missing_keeps_manual_required():
 
 
 # ---------------------------------------------------------------------------
-# MOR-1941: the tx.ptt read-back must not depend on a self-written mirror
+# MOR-1941 / MOR-2089: the tx.ptt read-back must not depend on a self-written
+# mirror, and the capability check gating it must not depend on a
+# hardcoded, per-backend method name (``get_ptt``) either -- it must go
+# through the ``TransmitStateReadable`` protocol, checked with
+# ``isinstance``, so a backend that implements the protocol under a
+# different underlying method gets the real read too.
 # ---------------------------------------------------------------------------
 
 
@@ -314,13 +320,9 @@ def _ptt_only_template() -> MatrixTemplate:
 def _tx_radio_unwritten_mirror(*, start_power: int = 200):
     """A radio matching the Yaesu backend after MOR-1941: ``set_ptt`` does
     NOT self-write ``radio_state.ptt`` -- only a real read-back
-    (``get_ptt``) tells the truth, and -- faithfully to the shipped
-    ``YaesuCatRadio.get_ptt`` (``yaesu_cat/radio.py:1096`` -- moved +20 by
-    MOR-1914's imports and its new ``_interpret_ptt_token`` helper), which
-    is kept, not deleted -- a successful ``get_ptt`` DOES update the mirror from
-    that read-back. Proves the hardware TX-actuate check was repointed off
-    the mirror (``validation/hardware.py:702-703``) onto a real read, not
-    that the mirror never changes.
+    (``read_transmit_state``, the ``TransmitStateReadable`` protocol member,
+    MOR-1914) tells the truth. Proves the hardware TX-actuate check
+    (``_actuate_tx_ptt``) is driven off a real read, not the mirror.
     """
     radio = MagicMock(spec=Radio)
     radio.connected = True
@@ -337,11 +339,15 @@ def _tx_radio_unwritten_mirror(*, start_power: int = 200):
         # Deliberately NOT touching state.ptt -- matches the shipped
         # Yaesu backend once its self-write is deleted (MOR-1941).
 
-    async def _get_ptt() -> bool:
-        # Faithful to the shipped ``get_ptt``, which writes the mirror
-        # from a real read-back (kept, not deleted -- MOR-1941 scope).
-        state.ptt = wire_ptt["value"]
-        return state.ptt
+    async def _read_transmit_state() -> TxStateReading:
+        # Deliberately does NOT touch ``state.ptt`` either, matching the
+        # shipped ``YaesuCatRadio.read_transmit_state``: the mirror stays
+        # stale, so a PASS here can only come from this read.
+        return TxStateReading(
+            value=wire_ptt["value"],
+            source="yaesu_poll_response",
+            verified_readback=True,
+        )
 
     async def _get_rf_power() -> int:
         return power["value"]
@@ -350,19 +356,21 @@ def _tx_radio_unwritten_mirror(*, start_power: int = 200):
         power["value"] = int(level)
 
     radio.set_ptt = AsyncMock(side_effect=_set_ptt)
-    radio.get_ptt = AsyncMock(side_effect=_get_ptt)
+    radio.read_transmit_state = AsyncMock(side_effect=_read_transmit_state)
     radio.get_rf_power = AsyncMock(side_effect=_get_rf_power)
     radio.set_rf_power = AsyncMock(side_effect=_set_rf_power)
     return radio, power
 
 
-async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
-    """MOR-1941: after a backend's ``set_ptt`` self-write is deleted (the
-    Yaesu case), ``radio_state.ptt`` is no longer radio truth. The
-    TX-actuate check must verify the key from a real read-back
-    (``get_ptt``) when the backend offers one -- ``set_ptt`` never writes
-    the mirror on this fake, matching the shipped Yaesu backend post-
-    deletion, so a PASS here can only come from the ``get_ptt`` read.
+async def test_tx_ptt_readback_uses_read_transmit_state_not_the_unwritten_mirror():
+    """MOR-1941 + MOR-2089: after a backend's ``set_ptt`` self-write is
+    deleted (the Yaesu case), ``radio_state.ptt`` is no longer radio truth.
+    The TX-actuate check must verify the key from a real read-back
+    (``read_transmit_state``, gated on ``isinstance(radio,
+    TransmitStateReadable)``) when the backend implements the protocol --
+    ``set_ptt`` never writes the mirror on this fake, matching the shipped
+    Yaesu backend post-deletion, so a PASS here can only come from the
+    ``read_transmit_state`` read.
     """
     radio, _ = _tx_radio_unwritten_mirror()
     prompter, _ = _confirm_prompter(True)
@@ -381,6 +389,7 @@ async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
     assert ptt.evidence["keyed"] is True
     assert ptt.evidence["ptt_state"] is True
     assert ptt.evidence["ptt_state_source"] == "readback"
+    assert "ptt_read_unavailable" not in ptt.evidence
 
 
 @pytest.mark.parametrize("exc_cls", [CatTimeoutError, CatCommandRejected])
@@ -394,10 +403,9 @@ async def test_tx_ptt_readback_uses_get_ptt_not_the_unwritten_mirror():
 async def test_tx_ptt_readback_failure_falls_back_to_a_trusted_write_not_a_fail(
     radio_factory, exc_cls
 ):
-    """MOR-1941 review (BLOCKED-1, then BLOCKED-3): a ``get_ptt`` read-back
-    that raises -- e.g. a dropped/late CAT reply inside the key window, or
-    the radio answering ``?;`` -- must not turn a good key into a FAIL, on
-    EITHER backend shape.
+    """MOR-1941 review (BLOCKED-1, then BLOCKED-3), mechanism updated by
+    MOR-2089: a ``read_transmit_state`` read-back that raises must not turn
+    a good key into a FAIL, on EITHER backend shape.
 
     The first version of this pin (BLOCKED-1) covered only the
     mirror-writing shape, where the fallback could not actually fail: the
@@ -411,22 +419,28 @@ async def test_tx_ptt_readback_failure_falls_back_to_a_trusted_write_not_a_fail(
     records that the read even failed.
 
     Both fixtures are parametrized here so this exact case is covered,
-    not just the shape where the bug cannot occur. Since the fix (below)
-    now falls back to *trusting the accepted write* rather than to the
-    mirror, both shapes converge on the same evidence: what changed is
-    the mechanism, not the outcome -- which is exactly why the
-    mirror-writing shape alone could not have caught the regression.
+    not just the shape where the bug cannot occur. Since the fix falls
+    back to *trusting the accepted write* rather than to the mirror, both
+    shapes converge on the same evidence: what changed is the mechanism,
+    not the outcome -- which is exactly why the mirror-writing shape
+    alone could not have caught the regression.
 
-    Both exception classes are real Yaesu CAT transport errors
-    (``backends/yaesu_cat/transport.py``), neither of which subclasses
-    anything in ``validation.hardware._RESTORE_ERRORS``.
+    ``exc_cls`` is not a claim that Yaesu's ``read_transmit_state`` would
+    raise it -- it doesn't. ``CatTimeoutError`` and
+    ``CatCommandRejected`` are used here only as two real exception types
+    that do not subclass ``validation.hardware._RESTORE_ERRORS``, standing
+    in for whatever ``read_transmit_state`` raises, so this pins that
+    ``_actuate_tx_ptt``'s generic ``except Exception`` treats it the same
+    way regardless of type or backend. ``_tx_radio`` (the mirror-writing
+    shape) does not define ``read_transmit_state`` by default -- this test
+    adds it, the same way it used to add ``get_ptt``.
     """
     radio, _ = radio_factory()
 
-    async def _raise_get_ptt() -> bool:
+    async def _raise_read_transmit_state() -> TxStateReading:
         raise exc_cls("no usable TX; reply")
 
-    radio.get_ptt = AsyncMock(side_effect=_raise_get_ptt)
+    radio.read_transmit_state = AsyncMock(side_effect=_raise_read_transmit_state)
     prompter, _ = _confirm_prompter(True)
 
     levels = await execute_hardware_checks(
@@ -449,12 +463,70 @@ async def test_tx_ptt_readback_failure_falls_back_to_a_trusted_write_not_a_fail(
     assert "actuate_error" not in ptt.evidence
 
 
-async def test_tx_ptt_readback_falls_back_to_the_mirror_when_get_ptt_is_absent():
-    """Best-effort, other direction (MOR-1941): a backend with no
-    ``get_ptt`` -- e.g. Icom, which exposes no plain PTT read-back method
-    -- must keep reading the mirror exactly as before. ``_tx_radio``
-    never defines ``get_ptt``, matching the Icom path this repoint must
-    not break.
+@pytest.mark.parametrize(
+    "radio_factory",
+    [
+        pytest.param(lambda: _tx_radio(start_power=200), id="mirror-writing"),
+        pytest.param(_tx_radio_unwritten_mirror, id="unwritten-mirror-yaesu"),
+    ],
+)
+async def test_tx_ptt_readback_with_no_value_falls_back_to_a_trusted_write_not_a_fail(
+    radio_factory,
+):
+    """MOR-2089: ``TransmitStateReadable.read_transmit_state`` is documented
+    (``core/radio_protocol.py``) to answer a failed or unverifiable read by
+    returning normally with ``TxStateReading(value=None, failure=...)``
+    rather than raising -- all three shipped backends do exactly this for
+    an ordinary wire-level failure. That path must fall back to trusting the
+    accepted write exactly
+    like the raising path above -- otherwise ``bool(None)`` would silently
+    become a fabricated ``keyed: False`` mislabeled
+    ``ptt_state_source: "readback"``, the same MOR-1900-class defect this
+    file already guards against for a raised exception.
+    """
+    radio, _ = radio_factory()
+
+    async def _no_value_read_transmit_state() -> TxStateReading:
+        return TxStateReading(value=None, failure="timeout")
+
+    radio.read_transmit_state = AsyncMock(side_effect=_no_value_read_transmit_state)
+    prompter, _ = _confirm_prompter(True)
+
+    levels = await execute_hardware_checks(
+        radio,
+        _ptt_only_template(),
+        _FULL_SAFETY,
+        allow_writes=True,
+        tx_actuate=True,
+        prompter=prompter,
+    )
+    ptt = _flatten(levels)["tx.ptt"]
+
+    assert ptt.status is CheckStatus.PASS
+    assert ptt.evidence["keyed"] is True
+    assert ptt.evidence["ptt_state"] is True
+    assert ptt.evidence["ptt_state_source"] == "unverified-write"
+    assert ptt.evidence["ptt_read_error"] == "timeout"
+
+
+async def test_tx_ptt_readback_falls_back_to_the_mirror_when_transmit_state_readable_is_absent():
+    """Best-effort, other direction (MOR-1941), legibility fixed by
+    MOR-2089: a backend that does not implement ``TransmitStateReadable``
+    must keep reading the mirror exactly as before -- ``_tx_radio`` defines
+    neither ``get_ptt`` nor ``read_transmit_state``. This is no longer a
+    stand-in for a real Icom radio specifically: ``runtime.radio.CoreRadio``
+    has implemented ``TransmitStateReadable`` since MOR-1914, and MOR-2089
+    is what makes ``_actuate_tx_ptt`` actually consult it, so an actual
+    Icom now takes the ``readback`` path exercised above, not this one --
+    this fixture instead stands for whatever future backend genuinely
+    lacks the capability.
+
+    What MOR-2089 changes here is legibility: before, this fallback was
+    silent (no evidence field said why the source was ``"mirror"``); now
+    ``ptt_read_unavailable`` says so explicitly, so a consumer does not
+    have to already know that ``ptt_state_source == "mirror"`` can mean
+    "no read capability" instead of "read the mirror and it happened to be
+    right".
     """
     radio, _ = _tx_radio(start_power=200)
     prompter, _ = _confirm_prompter(True)
@@ -466,3 +538,7 @@ async def test_tx_ptt_readback_falls_back_to_the_mirror_when_get_ptt_is_absent()
     assert ptt.evidence["keyed"] is True
     assert ptt.evidence["ptt_state"] is True
     assert ptt.evidence["ptt_state_source"] == "mirror"
+    assert (
+        ptt.evidence["ptt_read_unavailable"]
+        == "radio does not implement TransmitStateReadable"
+    )


### PR DESCRIPTION
`_actuate_tx_ptt` decided whether to trust a real PTT readback by probing for a
hardcoded `get_ptt` attribute. **No Icom backend defines `get_ptt`** — and `git
log -S` over both the current and the pre-rebrand `src/icom_lan/**` paths shows
none ever did. So on an Icom the check fell back to the `radio_state` mirror
instead of any solicited read; on the IC-7300 bench a good key reported
`keyed: False`.

The radio was fine. The tool was lying about it.

Replaces the `getattr` probe with `isinstance(radio, TransmitStateReadable)` and
a real `read_transmit_state()` call. A read returning `TxStateReading(value=None,
…)` now falls back to trusting the accepted write, tagged
`ptt_state_source: "unverified-write"`, rather than letting `bool(None)`
fabricate `keyed: False` under a `"readback"` label. A backend without the
capability records `ptt_read_unavailable`, so `"mirror"` is no longer silently
ambiguous between "no read capability" and "read the mirror for real".

## Size

2 files / 284 changed lines — inside both soft numbers.

## Review

Three rounds, independently reviewed each time. Rounds 1 and 2 were BLOCKED on
**prose, never on code** — a docstring claimed the wrong set of backends could
raise past a successful key, twice, in opposite directions, while the file it
cited (`core/radio_protocol.py: TransmitStateReadable.read_transmit_state`) had
the right answer all along.

Round 3 applied the repository's standing rule — delete a false claim rather
than rewrite it, since a rewrite is a fresh unverified claim — and the reviewer
established the round was purely deletions: the only insertion anywhere in the
tree diff is the token `doesn't.` replacing `doesn't (see above).` A period.
Zero new words, so nothing could be smuggled in.

`Agent Review: PASS` at the head being merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
