### PR TITLE
fix(MOR-2104): narrow the FTX-1 sql_type write to the single digit the radio accepts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -578,6 +578,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set_tsql_freq` encoded a 100 Hz BCD digit outside its documented 0-2
   range for most tones (88.5 Hz encoded as `00 88 05`, digit 8). The
   released 2.11.1 carries this bug.
+- **FTX-1 `set_sql_type` write template used two digits where the
+  manual documents one (MOR-2104).** `rigs/ftx1.toml`'s write template
+  rendered `CT002;` for squelch-type value 2; the FTX-1 CAT OM ENG
+  2508-C's `CT SQL TYPE` table documents P2 as a single digit (0-5).
+  Narrowed the template to `CT0{type};`, matching the read side's
+  parse, which already used the correct width.
 
 ## [2.11.1] — 2026-06-22
 

--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -897,10 +897,10 @@ set_clarifier_freq = { cat = { write = "CF001{sign}{offset:04d};" } }
 
 # ── Tone / CTCSS ──
 # MOR-473: the live FTX-1 answers ``CT0;`` with a SINGLE-digit P2 ("CT00;"),
-# so the READ parse takes one digit. The write width is left as ``{type:02d}``
-# (an unconfirmed residual) until a live write capture confirms otherwise.
+# so the READ parse takes one digit.
 get_sql_type   = { cat = { read = "CT0;", parse = "CT0{type};" } }
-set_sql_type   = { cat = { write = "CT0{type:02d};" } }
+# FTX-1_CAT_OM_ENG_2508-C, CT SQL TYPE: P2 is a single digit.
+set_sql_type   = { cat = { write = "CT0{type};" } }
 # CTCSS TONE FREQUENCY (MOR-458). CN P1=0 MAIN, P2=0 CTCSS; the answer's P3
 # (000-049) is the standard 50-tone EIA tone-chart index. Read-only here (the
 # observation pipeline maps the index → centiHz onto tone_freq/tsql_freq).

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1450,8 +1450,8 @@ async def test_get_sql_type_tone(connected_radio):
 @pytest.mark.asyncio
 async def test_set_sql_type(connected_radio):
     connected_radio._transport.write = AsyncMock()
-    await connected_radio.set_sql_type(3)
-    connected_radio._transport.write.assert_called_once_with("CT003;")
+    await connected_radio.set_sql_type(2)
+    connected_radio._transport.write.assert_called_once_with("CT02;")
 
 
 # -- CTCSS tone frequency (CN command, MOR-458) -----------------------------


### PR DESCRIPTION
`rigs/ftx1.toml` built the `sql_type` write with a two-digit parameter where the
radio takes one, so every `sql_type` write ever sent to an FTX-1 was malformed.

The read half was already correct (`parse = "CT0{type};"`), which is why the
asymmetry survived: reads kept working and nothing failed loudly.

## What the manual says

`FTX-1_CAT_OM_ENG_2508-C`, `CT SQL TYPE` (physical PDF page 10, printed page 9):

```
Set:     C T P1 P2 ;      P1  0: MAIN-side  1: SUB-side
Read:    C T P1 ;         P2  0: CTCSS OFF  1: ENC ON/DEC OFF  2: ENC ON/DEC ON
Answer:  C T P1 P2 ;          3: DCS ON     4: PR FREQ         5: REV TONE
```

P2 is a single digit. `CT0{type:02d};` rendered `CT002;` for value 2 — one
character longer than the frame the radio accepts.

## Bench evidence

Captured on a live FTX-1 at 38400 baud, then reproduced independently on a
second occasion through a different code path:

| frame | radio's answer |
| --- | --- |
| `CT002;` (what we sent) | `?;` — command not understood; readback unchanged |
| `CT02;` (the manual's format) | accepted; readback became `CT02;` |

Taken on 14.228 MHz in USB, so no mode or band precondition is involved — the
frame format is the whole story. The original value was restored afterwards.

The `?;` answer was discarded by our own tooling, which reported "control did
not react" instead. That is tracked separately as MOR-2103; it is why this took
a manual reading to find rather than being reported by the validation harness.

## The test was green while pinning the wrong contract

`tests/test_ftx1_radio.py::test_set_sql_type` already asserted the emitted byte
string — it asserted `"CT003;"`. A test that pins the wrong frame is worse than
no test, because it stops the next reader looking. Corrected to pin `"CT02;"`.

Independent review re-derived the whole documented domain rather than the single
value: with the old template all six legal values 0-5 emitted a malformed frame;
with the new one all six match the manual and round-trip through the read parser.
Mutation checks confirm the test also reddens on `CT{type};` (drops P1) and
`CT1{type};` (wrong side), so it pins the parameter position as well as the width,
and stays green under a benign nearby edit.

## Sweep — the acceptance criterion asked for the class, not the instance

All 29 zero-padded write templates in `rigs/ftx1.toml` were checked against the
manual, not just the six `:02d` ones. `sql_type` is the only case of a template
being wider than its documented parameter. Digit count is per-command and does
not generalise: `FR{mode:02d};` is two digits and correct, `CT0{type:02d};` was
two digits and wrong.

One instance of a different shape was found and filed separately rather than
folded in: `set_break_in_delay` renders four raw milliseconds where the manual
documents a two-digit table index (MOR-2110). It has no live confirmation yet,
so it does not belong in this change.

## Guardrails

3 files, 16 changed lines — well inside the soft threshold.