### PR TITLE
fix(MOR-2106): resolve the scope MAIN/SUB setter from its own declaration

### DIFF
--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1273,6 +1273,7 @@ scope_on = [0x27, 0x10]
 scope_off = [0x27, 0x10]
 scope_data_output = [0x27, 0x11]
 get_scope_main_sub = [0x27, 0x12]         # 0=MAIN, 1=SUB
+set_scope_main_sub = [0x27, 0x12]         # source: IC-7610 CI-V Reference Guide (A7380-7EX-2, May.2021) p.9, Cmd 27 Sub 12 "Main or Sub scope setting (00=Main, 01=Sub)" -- same [cmd, sub] as get_scope_main_sub above; command 27 itself carries the guide's own "*" (Send/read data) marker, and the IC-7610 is a genuine dual-receiver (MAIN/SUB) transceiver (MOR-2106)
 get_scope_single_dual = [0x27, 0x13]
 get_scope_mode = [0x27, 0x14]
 get_scope_span = [0x27, 0x15]

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -681,6 +681,7 @@ scope_data_output = [0x27, 0x11]
 # is a dual-receiver (MAIN/SUB) radio; that reasoning was evidently ported
 # unchanged from IC-7300 (genuinely single-receiver) (D2, MOR-2015).
 get_scope_main_sub = [0x27, 0x12]         # source: IC-9700 CI-V Reference Guide p.12
+set_scope_main_sub = [0x27, 0x12]         # source: IC-9700 CI-V Reference Guide p.12 (Cmd 27 Sub 12* "Send/read the Main or Sub scope setting (00=Main, 01=Sub)" -- MOR-2106)
 get_scope_single_dual = [0x27, 0x13]
 get_scope_mode = [0x27, 0x14]
 get_scope_span = [0x27, 0x15]

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -430,7 +430,7 @@ def get_scope_main_sub(
     )
 
 
-@expose_command_key(lambda cmd_map: "get_scope_main_sub")
+@expose_command_key(lambda cmd_map: "set_scope_main_sub")
 @require_cmd_map
 def scope_main_sub(
     receiver: int,
@@ -441,7 +441,7 @@ def scope_main_sub(
 ) -> bytes:
     return _build_from_map(
         cmd_map,
-        "get_scope_main_sub",
+        "set_scope_main_sub",
         to_addr=to_addr,
         from_addr=from_addr,
         data=bytes([_validate_scope_receiver(receiver)]),

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3133,22 +3133,30 @@ class RadioPoller:
                     await self.restore_scope_session()
                     logger.info("radio-poller: scope session state restored")
             case SwitchScopeReceiver(receiver=receiver):
-                # Fire-and-forget scope receiver select (0x27 0x12)
+                # Fire-and-forget scope receiver select (0x27 0x12), routed
+                # through the profile-bound command map (self._cmd_map) via
+                # ``_send_cmd`` instead of a hardcoded literal -- a profile
+                # that doesn't declare set_scope_main_sub can now refuse
+                # this write (MOR-2106). ``_send_cmd`` returns False, sending
+                # nothing, on a miss; the mirror/reconfirm/log below are
+                # gated on that return the same way the MOR-2004 SetAgc
+                # branch above gates its state event on ``agc_sent``.
                 self._ensure_receiver_supported(
                     receiver,
                     operation="switch_scope_receiver",
                 )
-                await self._civ(0x27, sub=0x12, data=bytes([receiver]))
-                if self._radio_state:
-                    self._radio_state.scope_controls.receiver = receiver
-                if CAP_SCOPE in self._caps:
-                    await self._reconfirm_scope_field(
-                        "get_scope_receiver", radio.get_scope_receiver
+                sent = await self._send_cmd("set_scope_main_sub", bytes([receiver]))
+                if sent:
+                    if self._radio_state:
+                        self._radio_state.scope_controls.receiver = receiver
+                    if CAP_SCOPE in self._caps:
+                        await self._reconfirm_scope_field(
+                            "get_scope_receiver", radio.get_scope_receiver
+                        )
+                    logger.info(
+                        "radio-poller: scope receiver → %s",
+                        "SUB" if receiver else "MAIN",
                     )
-                logger.info(
-                    "radio-poller: scope receiver → %s",
-                    "SUB" if receiver else "MAIN",
-                )
             case SetScopeDuringTx(on=on):
                 if CAP_SCOPE in self._caps:
                     await radio.set_scope_during_tx(on)

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -7,8 +7,8 @@
 # via { absent = "<source>" } (plan §8.1 D2) or a real command-byte
 # entry in the profile's own TOML. Regenerate, do not hand-edit.
 census	civ_profiles	6
-census	distinct_gap_keys	147
-census	profile_key_gaps	299
+census	distinct_gap_keys	148
+census	profile_key_gaps	302
 census	public_builders	243
 gap	get_acc1_mod_level	X6100,X6200
 gap	get_af_mute	X6100,X6200
@@ -142,6 +142,7 @@ gap	set_rit_frequency	X6100,X6200
 gap	set_rit_status	X6100,X6200
 gap	set_rit_tx_status	X6100,X6200
 gap	set_rx_antenna_ant2	X6100,X6200
+gap	set_scope_main_sub	IC-7300,X6100,X6200
 gap	set_selected_mode	IC-7300,IC-7610,IC-9700
 gap	set_ssb_tx_bandwidth	X6100,X6200
 gap	set_system_date	X6100,X6200

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -171,27 +171,31 @@ def _count_self_civ_call_sites() -> int:
 
 
 def test_radio_poller_raw_civ_call_count_is_pinned() -> None:
-    """Ratchet: exactly 11 raw ``self._civ(...)`` sites remain.
+    """Ratchet: exactly 10 raw ``self._civ(...)`` sites remain.
 
     The 8 hand-rolled ``self._civ(0x07, ...)`` VFO-switch frames that used
     to live in ``SetFreq``/``SetMode`` (the ``receiver!=0`` fallback dance
     and the ``receiver=0``-while-SUB-active restore dance) were removed:
     the former now delegates to ``CoreRadio.set_freq``/``set_mode``, which
     already owns that decision; the latter now calls the public
-    ``select_receiver`` API instead of building the raw frame itself. The
-    11 that remain:
+    ``select_receiver`` API instead of building the raw frame itself.
+    ``SwitchScopeReceiver`` was the 11th (MOR-2106): it now resolves
+    ``set_scope_main_sub`` through ``_send_cmd`` instead of building
+    ``0x27 0x12`` as a literal in ``_execute`` -- reusing ``_send_cmd``'s
+    existing two call sites below rather than adding a new one. The 10
+    that remain:
 
     - ``_send_cmd``: 2 — cmd29-wrapped vs. plain generic command dispatch.
     - ``_send_one_state_query``: 5 — selected/unselected freq/mode state
       reads plus the scope-receiver default read.
-    - ``_execute``: 3 — the BSR band-switch stored-freq read, ``SelectVfo``'s
-      scope-follow (0x27 0x12), and ``SwitchScopeReceiver`` (0x27 0x12).
+    - ``_execute``: 2 — the BSR band-switch stored-freq read and
+      ``SelectVfo``'s scope-follow (0x27 0x12).
     - ``_send_query``: 1 — the meter poll read.
 
     Changing this literal deliberately means recounting the real call
     sites above, not just editing the number.
     """
-    assert _count_self_civ_call_sites() == 11
+    assert _count_self_civ_call_sites() == 10
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -3125,6 +3125,36 @@ async def test_execute_switch_scope_receiver_mirrors_state_and_reconfirms() -> N
 
 
 @pytest.mark.asyncio
+async def test_execute_switch_scope_receiver_undeclared_command_sends_no_frame() -> (
+    None
+):
+    """MOR-2106: before the fix, ``SwitchScopeReceiver`` built its CI-V frame
+    from hardcoded literals (``self._civ(0x27, sub=0x12, ...)``), bypassing
+    the command map entirely -- a profile could not refuse the write. Routed
+    through ``_send_cmd("set_scope_main_sub", ...)`` instead, the same
+    fail-closed path ``test_execute_set_agc_undeclared_command_refuses_
+    without_firing_event`` above pins for MOR-2004's ``set_agc``: with
+    ``set_scope_main_sub`` removed from the bound map, no CI-V frame goes
+    out and neither the state mirror nor the reconfirm read-back fire.
+    """
+    radio = _make_radio(model="IC-7610")
+    stripped = {
+        name: radio.profile.command_map.get(name)
+        for name in radio.profile.command_map
+        if name != "set_scope_main_sub"
+    }
+    radio.profile = dataclasses.replace(radio.profile, command_map=CommandMap(stripped))
+    state = RadioState()
+    poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
+
+    await poller._execute(SwitchScopeReceiver(1))  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    radio.get_scope_receiver.assert_not_awaited()
+    assert state.scope_controls.receiver == 0  # untouched default, not mirrored to 1
+
+
+@pytest.mark.asyncio
 async def test_execute_set_scope_span_reconfirm_timeout_does_not_raise_for_other_leaves() -> (
     None
 ):

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -38,6 +38,7 @@ import pytest
 from rigplane.commands._codec import bcd_encode_value
 from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.command_map import CommandMap
+from rigplane.core.exceptions import CommandError
 from rigplane.core.types import CivFrame, bcd_encode
 from rigplane.runtime.radio import CoreRadio
 
@@ -674,3 +675,100 @@ async def test_set_scope_fixed_edge_reply_shape_comes_from_the_map(
     # its own request's echo; deriving the shape from the same map instead
     # (this call site's retrofit) must not raise here.
     await radio.set_scope_fixed_edge(edge=1, start_hz=1_000_000, end_hz=2_000_000)
+
+
+# MOR-2106: `commands/scope.py: scope_main_sub` (the WRITE builder) used to
+# resolve "get_scope_main_sub" -- the READ key -- through `_build_from_map`,
+# so a profile that declared only the getter (or declared the setter
+# explicitly absent) could not refuse the write: the getter's declared bytes
+# went out regardless. The two tests below build a profile explicitly missing
+# `set_scope_main_sub` (never relying on any shipped `rigs/*.toml` staying
+# that way -- sibling ticket MOR-2105 is editing `rigs/ic7300.toml`) and
+# assert both that `CoreRadio.set_scope_receiver` raises `CommandError`
+# naming the setter key AND that no frame reaches the transport.
+def _drop_command_map_key(cmd_map: CommandMap, key: str) -> CommandMap:
+    return CommandMap({k: cmd_map.get(k) for k in cmd_map if k != key})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", sorted(_civ_rig_configs()))
+async def test_scope_main_sub_setter_refuses_when_only_getter_declared(
+    model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A profile declaring `get_scope_main_sub` but NOT `set_scope_main_sub`
+    must refuse `set_scope_receiver` before any CI-V bytes are sent.
+
+    Pre-fix, this was false: `scope_main_sub` (the write builder) resolved
+    "get_scope_main_sub" through `_build_from_map`, so the getter's declared
+    wire bytes went out on write too, unconditionally.
+    """
+    config = _civ_rig_configs()[model]
+    profile = config.to_profile()
+    cmd_map = profile.command_map
+    assert cmd_map is not None
+    if not cmd_map.has("get_scope_main_sub"):
+        pytest.skip(f"{model} does not declare get_scope_main_sub")
+
+    mutated_map = _drop_command_map_key(cmd_map, "set_scope_main_sub")
+    mutated_profile = dataclasses.replace(profile, command_map=mutated_map)
+    monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)
+    radio = CoreRadio("198.51.100.1", profile=mutated_profile)
+
+    frames: list[bytes] = []
+
+    async def _record_send_civ_raw(civ: bytes, **kwargs: Any) -> None:
+        frames.append(civ)
+        return None
+
+    monkeypatch.setattr(radio, "_send_civ_raw", _record_send_civ_raw)
+
+    with pytest.raises(CommandError, match="set_scope_main_sub"):
+        await radio.set_scope_receiver(1)
+
+    assert frames == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", sorted(_civ_rig_configs()))
+async def test_scope_main_sub_setter_refuses_when_declared_absent(
+    model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stronger form of the test above: `set_scope_main_sub` is declared
+    ABSENT (D1 state 2, `commands/bound.py: BoundCommands._refusal_for`)
+    rather than merely missing (state 3) -- this cannot pass by accident
+    off a KeyError from an unrelated typo, because the refusal message must
+    quote the declared source.
+    """
+    config = _civ_rig_configs()[model]
+    profile = config.to_profile()
+    cmd_map = profile.command_map
+    assert cmd_map is not None
+    if not cmd_map.has("get_scope_main_sub"):
+        pytest.skip(f"{model} does not declare get_scope_main_sub")
+
+    mutated_map = _drop_command_map_key(cmd_map, "set_scope_main_sub")
+    source = "test fixture (MOR-2106): scope MAIN/SUB write declared absent"
+    mutated_profile = dataclasses.replace(
+        profile,
+        command_map=mutated_map,
+        absent_command_sources={
+            **profile.absent_command_sources,
+            "set_scope_main_sub": source,
+        },
+    )
+    monkeypatch.setattr(CoreRadio, "_check_connected", lambda self: None)
+    radio = CoreRadio("198.51.100.1", profile=mutated_profile)
+
+    frames: list[bytes] = []
+
+    async def _record_send_civ_raw(civ: bytes, **kwargs: Any) -> None:
+        frames.append(civ)
+        return None
+
+    monkeypatch.setattr(radio, "_send_civ_raw", _record_send_civ_raw)
+
+    with pytest.raises(CommandError, match="set_scope_main_sub") as excinfo:
+        await radio.set_scope_receiver(1)
+
+    assert source in str(excinfo.value)
+    assert frames == []


### PR DESCRIPTION
A write builder resolved the **read** key, so a profile could not refuse the write
even when it declared the setter absent.

`src/rigplane/commands/scope.py: scope_main_sub` writes, but both its
`@expose_command_key` lambda and its `_build_from_map` call asked for
`get_scope_main_sub`. Because that key is present, `commands/bound.py:
BoundCommands` had nothing to refuse on.

## Reproduced in-process, not inferred

With a recording transport in place of `_send_civ_raw`, run against the IC-7300
profile (the frame addresses below are its `0x94`), with `set_scope_main_sub`
**explicitly absent**:

| profile state | before | after |
| --- | --- | --- |
| getter declared, setter absent | frame `fe fe 94 e0 27 12 01 fd` emitted | `CommandError` naming the missing declaration, **zero frames** |
| getter key removed | already refused, zero frames | unchanged on IC-7300; on IC-705, IC-7610 and IC-9700, which declare the setter, the write now succeeds |
| setter key removed | frame emitted anyway | now refused |

The middle row matters: MOR-2006's fail-closed machinery was never broken. The
setter simply asked it about a key that was present, so it had nothing to object
to. This change routes the setter to the key that machinery already guards.

## Three parts

1. `commands/scope.py: scope_main_sub` resolves `set_scope_main_sub`.
2. `web/radio_poller.py`'s `SwitchScopeReceiver` case stops writing `0x27 0x12`
   as hardcoded literals and goes through the existing map-resolving
   `RadioPoller._send_cmd`, following the `SetAgc` precedent in the same method.
   On refusal it now skips the state mirror, the reconfirm read and the success
   log, rather than reporting success for a frame that was never sent.
3. `rigs/ic7610.toml` and `rigs/ic9700.toml` declare `set_scope_main_sub`. Both
   radios have a genuine SUB receiver and the byte is documented for both.

The IC-7610 citation is stated as read, not as quoted: that guide's row carries
no per-row marker and no "Send/read" verb, and writability rests on the parent
`27*` marker plus the legend. An independent review enumerated every bare
per-row marker in the whole guide — three, all under unstarred parents — so its
absence under `27*` is the guide's normal state rather than a signal. The
IC-9700 row says "Send/read" explicitly.

`rigs/ic7300.toml` is deliberately untouched. It declares no
`set_scope_main_sub`, so after this change the write is refused there — which is
correct: the manual and a recorded bench reply both say the value is fixed.

## Only one of thirteen

Twelve other builders in `commands/scope.py` resolve a `get_*` key the same way.
They are the remaining instances of this defect, not a different shape, and they
are filed as MOR-2113. They stay untouched because each needs per-radio `set_*`
declarations that do not exist: of the six CI-V profiles, only `rigs/ic705.toml`
declares them, while IC-7300, IC-7610 and IC-9700 declare the getters and none
of the setters. Flipping the builders without the data would break twelve scope
controls on three radios.

## Tests

Three. The poller test's discriminating assertion is that the transport saw
nothing; the two refusal tests discriminate on the raised `CommandError` and
additionally assert an empty frame list.

Each derives its profile from a shipped one and drops the key, so none depends on
any shipped file's *setter* state — including `rigs/ic7300.toml`, which MOR-2105 is
editing.

Both source fixes were reverted in isolation: each reddens only its own tests, so
the two are independent and each test pins the fix it covers.

## Two invariant pins moved, and why

- `tests/profile_command_coverage_gaps.txt` — regenerated, not hand-edited.
  `set_scope_main_sub` becomes a builder-resolved key for the first time, so it
  becomes a coverage gap for the three profiles that do not declare it.
- `tests/test_profiles_routing.py` — the raw-`self._civ` ratchet drops 11 to 10.
  The sites were recounted by AST and the docstring's enumeration corrected, not
  the number decremented; that docstring asks for exactly this.

## Guardrails

8 files / 185 changed lines: over the 6-file soft threshold, well under 600 lines
and under both hard-ceiling axes. It is one unit of work — the profile
declarations cannot be split out, because an intermediate commit would have the
builder resolving a key neither IC-7610 nor IC-9700 declares and scope MAIN/SUB
switching broken on both; the two invariant-pin files are mechanically derived
from the source change; the two test files are its pins.
