### PR TITLE
fix(MOR-2107): match USB audio by longest shared topology prefix, not a fixed hub mask

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -173,19 +173,20 @@ When multiple Icom radios are connected via USB simultaneously (e.g. IC-7300 + I
 **`usb_audio_resolve.py`** solves this by correlating USB hub topology:
 
 ```
-Serial port path  →  TTY suffix  →  IORegistry locationID  →  hub prefix (upper 16 bits)
+Serial port path  →  TTY suffix  →  IORegistry locationID
                                                                        │
-USB Audio CODEC entries in IORegistry  →  filter by same hub prefix   │
+USB Audio CODEC entries in IORegistry  →  longest shared locationID   │
+                                          nibble prefix wins           │
                                                                        ▼
-                                          sounddevice index lookup  (by sorted position)
+                                          sounddevice index lookup  (by product-name identity)
                                                                        │
                                                                        ▼
                                           AudioDeviceMapping(rx_device_index, tx_device_index)
 ```
 
 - **macOS**: Full support via `/usr/sbin/ioreg -l`. Zero external deps.
-- **Linux**: Not yet implemented — falls back to name-based selection.
-- **Windows**: Not planned.
+- **Linux**: Implemented via sysfs USB-topology traversal (`_resolve_linux`): the serial port and each ALSA card are resolved to their USB device node, and the card sharing the longest common USB-device path prefix (`_common_usb_path_score`) wins, with `idVendor`/`idProduct` as a tie-break. Exercised by unit tests against a fixture sysfs tree.
+- **Windows**: Implemented via USB PnP topology (`_resolve_windows`): the serial COM port and audio endpoint are matched by their shared parent composite-device instance path, with VID:PID as a fallback. Unit-tested via an injected PnP query; the real PowerShell/WMI enumeration (`_query_windows_pnp_devices`) is, per its own docstring, unvalidated against real Windows hardware.
 
 `UsbAudioDriver` calls `resolve_audio_for_serial_port(serial_port)` when a `serial_port` is provided. If resolution succeeds, the returned device indices take precedence over any name-based or default selection. If resolution fails (platform not supported, `ioreg` missing, or no matching devices), name-based fallback applies.
 

--- a/src/rigplane/audio/_usb_resolve.py
+++ b/src/rigplane/audio/_usb_resolve.py
@@ -13,11 +13,18 @@ rather than fragile, collision-prone device-name strings.
 1. Parse the serial port's TTY suffix → find its ``locationID`` in IORegistry.
    Both ``usbserial-XXXX`` (FTDI/CP210x) and ``usbmodemXXXX`` (CDC-ACM, e.g.
    the X6200's WCH CH342 bridge) suffixes are recognised.
-2. Extract the upper 16 bits of ``locationID`` as the USB hub prefix.
-3. Find all USB audio devices (``USB Audio CODEC``, ``USB Audio Device``) in
+2. Find all USB audio devices (``USB Audio CODEC``, ``USB Audio Device``) in
    IORegistry with their ``locationID``.
-4. Match audio devices sharing the same hub prefix as the serial port.
-5. Map the matched audio device to ``sounddevice`` indices by **identity**:
+3. Score each candidate audio device by its longest shared ``locationID``
+   component prefix with the serial port — the controller byte, then each
+   remaining hex digit, from the most-significant end (see
+   :func:`_common_location_prefix_score`); the candidate with the longest
+   match wins, ties kept at the lowest ``locationID``. The upper 16 bits
+   alone do not work here: the FTX-1's CAT (``0x00110000``) and audio
+   (``0x00120000``) match the controller byte and the next digit, then
+   diverge, while the IC-7300, X6200 and existing Yaesu fixture pairs each
+   match one digit further, and the IC-7610 pair two (MOR-2107).
+4. Map the matched audio device to ``sounddevice`` indices by **identity**:
    group the enumerated USB-audio entries into per-device clusters (a duplex
    entry stands alone; an output-only entry adjacent to a same-named
    input-only entry forms one split-pair cluster), then select the cluster
@@ -45,8 +52,9 @@ Platform support:
 - **Windows**: Topology resolution via USB PnP (MOR-229). The serial ``COMx``
   function and the USB Audio Class function of one physical radio share a
   parent USB composite-device instance path, which is the topology anchor
-  (the analogue of the macOS hub prefix). When the parent link is unavailable,
-  a VID:PID robust-identity fallback links serial↔audio. The OS enumeration is
+  (the Windows counterpart of the macOS anchor described above). When the
+  parent link is unavailable, a VID:PID robust-identity fallback links
+  serial↔audio. The OS enumeration is
   isolated behind an injectable ``pnp_query`` callable so the resolver is
   testable off-Windows. Audio→``sounddevice`` mapping reuses the MOR-230
   identity primitive (product name + same-name rank).
@@ -80,7 +88,7 @@ import platform
 import re
 import subprocess
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Sequence
 
 from rigplane.audio.backend import _ALSA_HW_RE
 
@@ -101,8 +109,11 @@ class AudioDeviceMapping:
         rx_device_index: ``sounddevice`` index for the RX (input/capture) device.
         tx_device_index: ``sounddevice`` index for the TX (output/playback) device.
         serial_port: The serial port path that was resolved.
-        location_prefix: The USB hub prefix (upper 16 bits of locationID) used
-            for matching, or ``None`` if resolution used a fallback method.
+        location_prefix: A platform-specific USB-topology diagnostic value,
+            not used to select the match: the serial port's ``locationID``
+            upper 16 bits on macOS, a synthesized bus/port identity on
+            Linux (see :func:`_usb_path_location_prefix`), or always
+            ``None`` on Windows.
     """
 
     rx_device_index: int
@@ -119,7 +130,7 @@ class WindowsPnpDevice:
     serial (CDC/COM) function or the USB Audio Class function. The
     ``parent_pnp_id`` is the shared composite-device instance path that links
     the two functions of one physical radio (the Windows analogue of the macOS
-    USB hub prefix).
+    topology anchor).
 
     Attributes:
         pnp_device_id: The function's own PnP instance path
@@ -209,7 +220,7 @@ def _resolve_macos(
         )
         return None
 
-    serial_prefix = serial_location >> 16
+    serial_prefix = serial_location >> 16  # diagnostic only — not the match key
 
     # 4. Find all USB Audio CODEC (name, locationID) pairs
     audio_entries = _find_audio_codec_entries(ioreg_text)
@@ -217,13 +228,21 @@ def _resolve_macos(
         logger.warning("usb-audio-resolve: no USB Audio CODEC devices found in ioreg")
         return None
 
-    # 5. Check if any audio device shares our hub prefix
-    matching = [loc for _name, loc in audio_entries if (loc >> 16) == serial_prefix]
-    if not matching:
+    # 5. Check that some audio device shares USB topology with the serial
+    # port at all (longest-shared-component score > 0) before attempting to
+    # pair one. A >>16 mask misses the FTX-1: its CAT (0x00110000) and
+    # audio (0x00120000) match only the controller byte and the next digit
+    # before diverging, one digit short of what >>16 requires (MOR-2107).
+    best_score = max(
+        _common_location_prefix_score(serial_location, loc)
+        for _name, loc in audio_entries
+    )
+    if best_score <= 0:
         logger.warning(
-            "usb-audio-resolve: no audio devices match prefix %#06x for %s",
-            serial_prefix,
+            "usb-audio-resolve: no audio devices share USB topology with %s "
+            "(serial loc %#010x)",
             serial_port,
+            serial_location,
         )
         return None
 
@@ -741,6 +760,25 @@ def _sysfs_usb_audio_cards(sysfs_root: str) -> list[tuple[str, str]]:
     return sorted(cards, key=lambda c: c[0])
 
 
+def _common_prefix_score(a: Sequence[Any], b: Sequence[Any]) -> int:
+    """Count the shared leading elements of two sequences.
+
+    Compares ``a`` and ``b`` element-by-element from the start and counts
+    matching leading elements before the first divergence (or before either
+    sequence ends). The shared primitive behind :func:`_common_usb_path_score`
+    (Linux) and :func:`_common_location_prefix_score` (macOS); each supplies
+    its own platform adapter, and the two scores are not comparable to one
+    another — see :func:`_resolve_linux`'s identity-bonus addition, which
+    this primitive has no equivalent for.
+    """
+    score = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        score += 1
+    return score
+
+
 def _common_usb_path_score(serial_dev: str, card_dev: str) -> int:
     """Score the shared USB-device path prefix length of two device nodes.
 
@@ -749,14 +787,46 @@ def _common_usb_path_score(serial_dev: str, card_dev: str) -> int:
     devices sit deeper on the same physical hub branch; an equal full path
     means they are the *same* USB device (composite radio).
     """
-    a = _usb_path_components(serial_dev)
-    b = _usb_path_components(card_dev)
-    score = 0
-    for x, y in zip(a, b):
-        if x != y:
-            break
-        score += 1
-    return score
+    return _common_prefix_score(
+        _usb_path_components(serial_dev), _usb_path_components(card_dev)
+    )
+
+
+def _common_location_prefix_score(serial_location: int, audio_location: int) -> int:
+    """Score the shared ``locationID`` component prefix of a serial port and
+    an audio device candidate — the macOS analogue of
+    :func:`_common_usb_path_score`.
+
+    Compares both ``locationID`` values as the component lists
+    :func:`_location_id_components` produces (controller byte, then each
+    remaining hex digit, from the most-significant end) and counts matching
+    leading components before the first divergence. Used by
+    :func:`_resolve_macos` and :func:`_pair_audio_device_for_location` to
+    pick the best-matching audio device instead of requiring a fixed-width
+    prefix match (MOR-2107): the FTX-1's CAT (``0x00110000``) and audio
+    (``0x00120000``) match the controller byte and the next digit, then
+    diverge, while the IC-7300, X6200 and existing Yaesu fixture pairs each
+    match one digit further before diverging, and the IC-7610 pair two.
+    """
+    return _common_prefix_score(
+        _location_id_components(serial_location),
+        _location_id_components(audio_location),
+    )
+
+
+def _location_id_components(loc: int) -> list[int]:
+    """Split a macOS ``locationID`` into a controller byte and per-digit nibbles.
+
+    ``locationID`` is a 32-bit value; this returns 7 components: the top
+    byte (bits 31-24) as one integer, then each of the remaining 6 hex
+    digits (bits 23-0), most-significant first. The components are nibbles
+    (and one leading byte) because that is how ``locationID`` is packed;
+    whether one nibble corresponds to one USB hub hop is not established in
+    this repository.
+    """
+    controller = (loc >> 24) & 0xFF
+    nibbles = [(loc >> shift) & 0xF for shift in range(20, -1, -4)]
+    return [controller, *nibbles]
 
 
 def _usb_path_components(usb_dev: str) -> list[str]:
@@ -970,13 +1040,14 @@ def _pair_audio_device_for_location(
     """Select the ``(rx_index, tx_index)`` for the matched audio device.
 
     Pairing is by **identity**, not positional order across flattened
-    input/output lists. The serial port's hub prefix selects the matched
-    audio device (an IORegistry ``(product_name, locationID)`` entry); that
-    device's identity is its product name plus its **rank among same-named
-    audio devices** (sorted by ``locationID``). The corresponding
-    ``sounddevice`` cluster (see :func:`_cluster_usb_audio_devices`) is the
-    rank-th cluster carrying the same product name, and it yields the device
-    indices.
+    input/output lists. The audio device with the longest shared
+    ``locationID`` component prefix (see :func:`_common_location_prefix_score`)
+    is the matched device (an IORegistry ``(product_name, locationID)``
+    entry); that device's identity is its product name plus its **rank
+    among same-named audio devices** (sorted by ``locationID``). The
+    corresponding ``sounddevice`` cluster (see
+    :func:`_cluster_usb_audio_devices`) is the rank-th cluster carrying the
+    same product name, and it yields the device indices.
 
     This is the reusable, platform-neutral pairing primitive the future
     Linux/Windows resolvers (MOR-228/229) can call once they enumerate audio
@@ -992,23 +1063,24 @@ def _pair_audio_device_for_location(
     order, which for same-model devices tracks ``locationID`` order — this
     preserves the validated homogeneous-multi-radio behaviour.
 
-    Returns ``None`` when the serial port shares no audio hub prefix or when
-    no same-named cluster occupies the matched device's rank.
+    Returns ``None`` when no audio device shares even the leading
+    ``locationID`` component (the controller byte) with the serial port, or
+    when no same-named cluster occupies the matched device's rank.
     """
-    serial_prefix = serial_location >> 16
     sorted_entries = sorted(audio_entries, key=lambda e: e[1])
 
-    # The matched audio device shares the serial port's hub prefix.
-    matched_idx = next(
-        (
-            i
-            for i, (_n, loc) in enumerate(sorted_entries)
-            if (loc >> 16) == serial_prefix
-        ),
-        None,
-    )
-    if matched_idx is None:
+    # The matched audio device has the longest shared locationID component
+    # prefix with the serial port (MOR-2107). ``list.index`` on the max
+    # picks the first (lowest-locationID) tie, mirroring the previous
+    # exact-match lookup's tie-break.
+    scores = [
+        _common_location_prefix_score(serial_location, loc)
+        for _n, loc in sorted_entries
+    ]
+    best_score = max(scores, default=0)
+    if best_score <= 0:
         return None
+    matched_idx = scores.index(best_score)
     matched_name, _matched_loc = sorted_entries[matched_idx]
     # Rank of the matched device among same-named audio devices.
     same_name_rank = sum(

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -90,8 +90,11 @@ IOREG_THREE_RADIOS = textwrap.dedent("""\
 """)
 
 
-# Yaesu FTX-1 ("USB Audio Device") alongside Icom IC-7610 ("USB Audio CODEC")
-# FTX-1: audio @ 0x20132200, serial HRI @ 0x20131000 (same hub prefix 0x2013)
+# Synthetic Yaesu-style shape (audio and serial share hub prefix 0x2013 by
+# construction). This is NOT the FTX-1's real IORegistry layout — the real
+# layout is IOREG_FTX1_REAL_TOPOLOGY below, where the CAT bridge and audio
+# device do NOT share a hub prefix. A same-prefix fixture like this one
+# cannot exercise the MOR-2107 defect (see TestResolveFtx1RealTopology).
 IOREG_YAESU_AND_ICOM = textwrap.dedent("""\
     | +-o USB Audio Device@20132200  <class IOUSBHostDevice, id 0x1000d4711>
     | |   "locationID" = 538124800
@@ -112,8 +115,8 @@ IOREG_YAESU_AND_ICOM = textwrap.dedent("""\
     | |   | "IOCalloutDevice" = "/dev/cu.usbserial-111120"
 """)
 
-# Yaesu FTX-1 only (no Icom)
-# audio @ 0x20132200, serial HRI @ 0x20131000 (same hub prefix 0x2013)
+# Synthetic Yaesu-style shape, no Icom (see IOREG_YAESU_AND_ICOM above for
+# why this does not model real FTX-1 hardware).
 IOREG_YAESU_ONLY = textwrap.dedent("""\
     | +-o USB Audio Device@20132200  <class IOUSBHostDevice, id 0x1000d4711>
     | |   "locationID" = 538124800
@@ -123,6 +126,77 @@ IOREG_YAESU_ONLY = textwrap.dedent("""\
     | | +-o AppleUSBSLCOM
     | |   | "IOTTYSuffix" = "01AE340D0"
     | |   | "IOCalloutDevice" = "/dev/cu.usbserial-01AE340D0"
+""")
+
+# FTX-1 REAL IORegistry topology (MOR-2107): the CAT bridge and the audio
+# device are siblings under an internal hub, at DIFFERENT hub prefixes
+# (0x0011 vs 0x0012) — this is the shape that reproduces the defect, unlike
+# the synthetic same-prefix fixtures above. "YAESU HRI USB I/F" is a third
+# sibling present on real hardware; it is neither the CAT port nor an audio
+# device, so it is inert for resolution and included only for topology
+# fidelity.
+IOREG_FTX1_REAL_TOPOLOGY = textwrap.dedent("""\
+    | +-o CP2105 Dual USB to UART Bridge Controller@00110000
+    | |   "locationID" = 1114112
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "FTX1CAT01"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-FTX1CAT01"
+    | +-o USB Audio Device@00120000  <class IOUSBHostDevice, id 0x1000f7101>
+    | |   "locationID" = 1179648
+    | |   "USB Product Name" = "USB Audio Device"
+    | +-o YAESU HRI USB I/F@00130000  <class IOUSBHostDevice, id 0x1000f7102>
+    | |   "locationID" = 1245184
+""")
+
+# FTX-1 real topology (as above) alongside an IC-7300 on a separate hub —
+# proves the longest-prefix match still picks each radio's own audio device
+# when a second, unrelated radio is present.
+IOREG_FTX1_REAL_AND_ICOM = textwrap.dedent("""\
+    | +-o CP2105 Dual USB to UART Bridge Controller@00110000
+    | |   "locationID" = 1114112
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "FTX1CAT01"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-FTX1CAT01"
+    | +-o USB Audio Device@00120000  <class IOUSBHostDevice, id 0x1000f7101>
+    | |   "locationID" = 1179648
+    | |   "USB Product Name" = "USB Audio Device"
+    | +-o YAESU HRI USB I/F@00130000  <class IOUSBHostDevice, id 0x1000f7102>
+    | |   "locationID" = 1245184
+    | +-o USB Audio CODEC@20144000  <class IOUSBHostDevice, id 0x1000045f6>
+    | |   "locationID" = 538198016
+    | |   "USB Product Name" = "USB Audio CODEC"
+    | +-o CP2102 USB to UART Bridge Controller@20141000
+    | |   "locationID" = 538185728
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "201410"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-201410"
+""")
+
+# Two DIFFERENT radios (A, B) on sibling ports of one EXTERNAL USB hub
+# (0x14100000) — unlike the FTX-1's internal-hub siblings above, A and B
+# are separate physical radios. Pins why an adaptive longest-shared-nibble
+# match is needed instead of any fixed-width shift: resolving radio B's
+# CAT port (0x14121000), a >>20 mask also matches radio A's audio device
+# (0x14114000) — a silent mis-route — while >>16 and the longest-prefix
+# scorer both correctly match radio B's own audio (0x14124000). Verified
+# in TestResolveExternalHubDisambiguation below (MOR-2107 review, B5).
+IOREG_EXTERNAL_HUB_TWO_RADIOS = textwrap.dedent("""\
+    | +-o USB Audio CODEC@14114000  <class IOUSBHostDevice, id 0x1000e1a01>
+    | |   "locationID" = 336674816
+    | |   "USB Product Name" = "USB Audio CODEC"
+    | +-o CP2102 USB to UART Bridge Controller@14111000
+    | |   "locationID" = 336662528
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "RADIOA01"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-RADIOA01"
+    | +-o USB Audio Device@14124000  <class IOUSBHostDevice, id 0x1000e1a02>
+    | |   "locationID" = 336740352
+    | |   "USB Product Name" = "USB Audio Device"
+    | +-o CP2102 USB to UART Bridge Controller@14121000
+    | |   "locationID" = 336728064
+    | | +-o AppleUSBSLCOM
+    | |   | "IOTTYSuffix" = "RADIOB01"
+    | |   | "IOCalloutDevice" = "/dev/cu.usbserial-RADIOB01"
 """)
 
 
@@ -447,6 +521,86 @@ class TestResolveYaesu:
 
         # Different devices
         assert result_yaesu.rx_device_index != result_icom.rx_device_index
+
+
+class TestResolveFtx1RealTopology:
+    """MOR-2107: the FTX-1's real IORegistry shape does not share an upper-16-bit
+    hub prefix between its CAT bridge (0x0011) and its audio device (0x0012) —
+    see IOREG_FTX1_REAL_TOPOLOGY. A fixed hub-prefix mask fails to resolve this;
+    the longest-shared-nibble-prefix match must still find the CAT port's own
+    audio device.
+    """
+
+    def test_ftx1_alone_resolves_to_its_own_audio(self) -> None:
+        sd = _make_mock_sd_mixed(usb_codec_count=0, usb_device_count=1)
+        result = _resolve_macos(
+            "/dev/cu.usbserial-FTX1CAT01",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_FTX1_REAL_TOPOLOGY,
+        )
+        assert result is not None
+        assert result.serial_port == "/dev/cu.usbserial-FTX1CAT01"
+        assert result.location_prefix == 0x0011
+        assert result.rx_device_index == 2
+        assert result.tx_device_index == 1
+
+    def test_ftx1_alongside_another_radio_resolves_to_its_own_audio(self) -> None:
+        sd = _make_mock_sd_mixed(usb_codec_count=1, usb_device_count=1)
+        result_ftx1 = _resolve_macos(
+            "/dev/cu.usbserial-FTX1CAT01",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_FTX1_REAL_AND_ICOM,
+        )
+        assert result_ftx1 is not None
+        assert result_ftx1.location_prefix == 0x0011
+
+        result_ic7300 = _resolve_macos(
+            "/dev/cu.usbserial-201410",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_FTX1_REAL_AND_ICOM,
+        )
+        assert result_ic7300 is not None
+        assert result_ic7300.location_prefix == 0x2014
+
+        # Each radio must resolve to its own audio device, never the other's.
+        assert result_ftx1.rx_device_index != result_ic7300.rx_device_index
+        assert result_ftx1.tx_device_index != result_ic7300.tx_device_index
+
+
+class TestResolveExternalHubDisambiguation:
+    """MOR-2107 review (B5): two DIFFERENT radios (A, B) on sibling ports of
+    one EXTERNAL hub — the scenario a fixed-width prefix mask exists to
+    avoid mis-routing, as opposed to the FTX-1's own internal-hub CAT/audio
+    pair. Resolving radio B's CAT port under a >>20 fixed mask also matches
+    radio A's audio device (see IOREG_EXTERNAL_HUB_TWO_RADIOS); the
+    longest-shared-nibble-prefix scorer must not.
+    """
+
+    def test_radio_b_resolves_to_its_own_audio_not_radio_as(self) -> None:
+        sd = _make_mock_sd_mixed(usb_codec_count=1, usb_device_count=1)
+        result = _resolve_macos(
+            "/dev/cu.usbserial-RADIOB01",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_EXTERNAL_HUB_TWO_RADIOS,
+        )
+        assert result is not None
+        assert result.location_prefix == 0x1412
+        # Radio B's own audio is "USB Audio Device" (rx=2, tx=1), not
+        # radio A's "USB Audio CODEC" (rx=4, tx=3).
+        assert result.rx_device_index == 2
+        assert result.tx_device_index == 1
+
+    def test_radio_a_resolves_to_its_own_audio(self) -> None:
+        sd = _make_mock_sd_mixed(usb_codec_count=1, usb_device_count=1)
+        result = _resolve_macos(
+            "/dev/cu.usbserial-RADIOA01",
+            sounddevice_module=sd,
+            ioreg_output=IOREG_EXTERNAL_HUB_TWO_RADIOS,
+        )
+        assert result is not None
+        assert result.location_prefix == 0x1411
+        assert result.rx_device_index == 4
+        assert result.tx_device_index == 3
 
 
 class TestResolvePlatformDispatch:
@@ -851,7 +1005,7 @@ class TestNameFallbackXiegu:
 # parent device (instance path like USB\VID_xxxx&PID_yyyy\serial) whose
 # children are the CDC/serial function (exposing a COMx name) and the USB
 # Audio Class function (exposing an audio endpoint name). The shared *parent*
-# instance path is the topology anchor, mirroring the macOS hub-prefix anchor.
+# instance path is the topology anchor, mirroring the macOS topology anchor.
 #
 # Modelled set:
 #   - Xiegu X6200: C-Media composite parent, COM3 serial + "USB Audio Device"


### PR DESCRIPTION
The macOS resolver anchored on a fixed slice of `locationID` — the upper 16 bits —
and treated that as "the hub this port sits on". A composite device whose CAT
bridge and audio function diverge *inside* that slice cannot be resolved at all.

The FTX-1 is such a device: it contains its own USB hub, and its two functions sit
on different downstream ports of it. Resolution fell through to matching on the
device **name**, which is what the module exists to avoid — `"USB Audio Device"` is
a generic USB Audio Class string also used by another supported radio's codec.

## What replaces it

Longest shared topology prefix, best-of-N — the strategy the Linux path in this
same file already uses (`_common_usb_path_score`), ported to the packed integer
macOS reports. The shared loop is now one primitive, `_common_prefix_score`, with a
per-platform adapter on each side: `_usb_path_components` for sysfs paths,
`_location_id_components` for `locationID`.

Both scoring **policies** stay separate. Linux keeps its `idVendor:idProduct`
identity bonus; Windows is untouched, because its exact-equality match on an
OS-supplied parent instance path is a different shape, not a third instance of this
one.

## Why not simply widen the mask — the honest reason

A wider fixed shift (`>>20`, `>>24`, `>>28`) also resolves every radio the
repository has fixture data for, the FTX-1 included. So the argument is **not**
that nothing else works.

The argument is that a fixed width silently mis-routes two different radios on
sibling ports of one external hub. `TestResolveExternalHubDisambiguation` now pins
exactly that: under a `>>20` mask, radio B receives radio A's device indices.

Its companion `test_radio_a_…` survives that mutation, because A's audio happens to
sort lower — an accident of ordering, not a property of the mask. Stated so the
pair is not mistaken for two independent pins.

## A latent defect this closed, found by re-deriving rather than trusting

The controller byte is now compared as one atomic component instead of as two
independent hex digits. Under the old scoring, the FTX-1's CAT port scored **1**
against an unrelated radio's audio device — a false-positive signal on a
cross-radio pair no fixture tests. The FTX-1's own device still won, so nothing
surfaced. Those two controller bytes are `0x00` and `0x01`; they now score 0.

## Prose corrections

Several sentences described the old mechanism and became false. They were deleted
or narrowed to what is measurable, including the causal explanation for the FTX-1's
failure — which turned out not to be "different tree depths on different models",
since the two fixtures that have that property resolve fine and the one that fails
has its functions at the same depth. The real distinguishing fact is the depth of
the two functions' nearest common ancestor, which depends on the host port, not the
model.

`docs/internals/architecture.md`'s resolver section is corrected in the same pass:
its macOS bullet described the old mask, and its Linux and Windows bullets said
"Not yet implemented" and "Not planned" for two resolvers that exist and are
tested.

Whether one `locationID` nibble corresponds to one USB hub tier is **not
established in this repository**, and the code says exactly that rather than citing
an outside source. This change alters what the score counts, not the threshold it
is compared against.

## Verification

89 tests pass. Live-hardware verification on the FTX-1 is outstanding — this was
built and checked against fixtures only.