### PR TITLE
fix(MOR-2105): stop the RMVR harness flipping IC-7300 controls that have one legal value

### DIFF
--- a/docs/validation/cat-audits/ic7300.md
+++ b/docs/validation/cat-audits/ic7300.md
@@ -101,7 +101,7 @@ Legend — Backend: method name or `—`. Profile: `[commands]` key or cap. Vali
 | `27 1C` | center type | `get_/set_scope_center_type` | scope cmds | `scope_center_type.set` **RMVR** |
 | `27 1D` | VBW | `get_/set_scope_vbw` | scope cmds | `scope_vbw.set` **RMVR** |
 | `27 1E` | fixed-edge freqs | `get_/set_scope_fixed_edge` | scope cmds | `scope_fixed_edge.read` **READ** |
-| `27 1F` | RBW | `get_/set_scope_rbw` | scope cmds | `scope_rbw.set` **RMVR** |
+| `27 1F` | RBW | `get_/set_scope_rbw` **absent** (MOR-2105: no row in the manual's 0x27 sub-command table) | scope cmds | `scope_rbw.set` **UNSUPPORTED** |
 | `27 12`/`13` | main/sub, single/dual | `get_scope_single_dual` | scope cmds | `scope_dual.set`/`scope_receiver.set` (no-op on 7300, single-RX) |
 | `0E` | scan start/stop | `scan_start`/`scan_stop` | `scan` | `scan.presence` **—** |
 | `13` | speech synthesizer | `get_speech` | `set_speech` | — (device front-panel) |

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -107,6 +107,24 @@ features = [
 # guess rather than a data-driven fact.
 rf_sql_control_model = "combined"
 
+# Per-check_id validation classification (MOR-2105 part 2), a check_id-grained
+# sibling to a future [validation].write_only_controls list (IC-7300 does not
+# need one today). scope_dual.set (27 13, p.19-7) is documented and the radio
+# answers it, but IC-7300 has only one scope, so 00 (Single only) is the only
+# legal value it can ever hold -- the RMVR read-modify-verify-restore harness
+# would flip to a value the radio can never report back, not because
+# anything is broken. The source is the manual page and data-column fact
+# establishing that.
+#
+# scope_receiver.set (27 12, same page, live bench 2026-08-30: 27 12 00, see
+# get_scope_main_sub below) is fixed-value for the SAME reason -- one
+# receiver -- but is deliberately NOT declared here: receiver_count above
+# already states that fact, and validation/hardware.py derives
+# scope_receiver.set's fixed-value status from it instead of restating it as
+# a second, independently-editable source of truth (MOR-2105 part 2, F1).
+[validation.fixed_value]
+"scope_dual.set" = "IC-7300 Advanced Manual (11a) command table p.19-7: 27 13 data column = 00 (Single only)"
+
 [state_acquisition]
 provider = "icom_civ"
 default_cadence_seconds = 1.5

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1132,7 +1132,11 @@ get_scope_during_tx = [0x27, 0x1B]
 get_scope_center_type = [0x27, 0x1C]
 get_scope_vbw = [0x27, 0x1D]
 get_scope_fixed_edge = [0x27, 0x1E]
-get_scope_rbw = [0x27, 0x1F]
+# MOR-2105: the 0x27 sub-command table (IC-7300 Advanced Manual (11a)
+# pp.19-7..19-8) runs 1E then 20 -- no 1F row. Live bench: scope_rbw.set
+# timed out with no answer, consistent with an unimplemented command.
+get_scope_rbw = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-7..19-8: 0x27 sub-command table runs 1E then 20, no 1F row" }
+set_scope_rbw = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-7..19-8: 0x27 sub-command table runs 1E then 20, no 1F row" }
 
 # ── Scan ──
 scan_start = [0x0E]

--- a/src/rigplane/cli/_validate.py
+++ b/src/rigplane/cli/_validate.py
@@ -881,8 +881,10 @@ async def _run_hardware(
         return 3, artifact
 
     # Resolve the radio profile for per-radio validation classification
-    # (write-only controls, MOR-208). Best-effort: unknown model → no profile.
+    # (write-only controls, MOR-208; fixed-value checks, MOR-2105 part 2).
+    # Best-effort: unknown model → no profile.
     write_only_capabilities: frozenset[str] = frozenset()
+    fixed_value_checks: dict[str, str] = {}
     if config.model:
         from rigplane.profiles import get_radio_profile
 
@@ -892,6 +894,7 @@ async def _run_hardware(
             profile = None
         if profile is not None:
             write_only_capabilities = profile.write_only_controls
+            fixed_value_checks = profile.fixed_value_checks
 
     transport = _transport_info_from_config(config)
     radio = create_radio(config)
@@ -910,6 +913,7 @@ async def _run_hardware(
                 allow_writes=not bool(getattr(args, "read_only", False)),
                 per_check_timeout=getattr(args, "timeout", 5.0) or 5.0,
                 write_only_capabilities=write_only_capabilities,
+                fixed_value_checks=fixed_value_checks,
                 prompter=_build_prompter(args),
                 tx_actuate=_tx_actuate_enabled(args),
                 audio_probe_frames=audio_probe_frames,
@@ -1101,6 +1105,9 @@ async def _run_hardware_hamlib(
                         per_check_timeout=timeout,
                         write_only_capabilities=(
                             profile.write_only_controls if profile else frozenset()
+                        ),
+                        fixed_value_checks=(
+                            profile.fixed_value_checks if profile else {}
                         ),
                         prompter=_build_prompter(args),
                         tx_actuate=_tx_actuate_enabled(args),

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -417,6 +417,24 @@ class RadioProfile:
     # driven from ``[validation].write_only_controls`` in the rig TOML (MOR-208).
     # Empty by default: every control uses the standard RMVR path.
     write_only_controls: frozenset[str] = frozenset()
+    # Validation check_id -> source establishing that this radio has only one
+    # legal value for that control (MOR-2105 part 2): a check_id-grained
+    # sibling to ``write_only_controls`` above, needed because a capability
+    # like "scope" mixes fixed-value checks with genuinely multi-valued ones
+    # on the same radio (scope_span.set). A check_id named here makes the
+    # RMVR read-modify-verify-restore harness (`validation/hardware.py:
+    # _run_one_check`) report SKIP, quoting the source, instead of flipping
+    # to a value the radio can never report back and reporting a false FAIL.
+    # Data-driven from ``[validation.fixed_value]`` in the rig TOML -- but
+    # only for a fact with no other home. IC-7300's scope_dual.set (single
+    # scope) lives here because nothing else in this dataclass says so;
+    # scope_receiver.set (single receiver) does NOT, even though it is
+    # fixed-value for the same reason, because ``receiver_count``/
+    # ``supports_receiver`` above already say so and the harness derives it
+    # from that instead of restating it as a second, independently-editable
+    # source of truth (F1, MOR-2105 part 2 owner ruling). Empty by default:
+    # every control uses the standard RMVR path.
+    fixed_value_checks: dict[str, str] = field(default_factory=dict)
     # Provider-specific state acquisition metadata (MOR-344). This is profile
     # data only; future schedulers/adapters consume it instead of Web or
     # rigctld delivery code branching on radio model.

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -581,6 +581,11 @@ class RigConfig:
     # average with a silent R loses 6 dB).
     rx_audio_channel: str = "mix"
     write_only_controls: tuple[str, ...] = ()
+    # Per-check_id fixed-value declarations (MOR-2105 part 2): check_id ->
+    # source establishing that this radio has only one legal value for that
+    # control. See ``RadioProfile.fixed_value_checks`` (profiles/__init__.py)
+    # for the full rationale.
+    fixed_value_checks: dict[str, str] = field(default_factory=dict)
     state_acquisition: RadioAcquisitionProfile | None = None
     tx_interlock_disposition_overrides: dict[
         TxInterlockCommandFamily, TxInterlockDisposition
@@ -782,6 +787,7 @@ class RigConfig:
             browser_rx_transport=self.browser_rx_transport,
             browser_rx_transcode_to_opus=self.browser_rx_transcode_to_opus,
             write_only_controls=frozenset(self.write_only_controls),
+            fixed_value_checks=dict(self.fixed_value_checks),
             state_acquisition=self.state_acquisition,
             tx_interlock_disposition_overrides=self.tx_interlock_disposition_overrides,
             tx_policy=self.tx_policy,
@@ -1934,6 +1940,34 @@ def load_rig(path: Path) -> RigConfig:
             )
     write_only_controls = tuple(write_only_raw)
 
+    # Validate [validation.fixed_value] — a check_id-grained sibling to
+    # write_only_controls above (MOR-2105 part 2), for a fact with no other
+    # home in RadioProfile: some controls genuinely have only one legal
+    # value on this radio (e.g. IC-7300's single scope), so the RMVR harness
+    # must SKIP the flip instead of reporting a false FAIL for a value
+    # nothing on the radio can ever report back. Keyed by check_id, finer
+    # than write_only_controls' per-capability grain -- a capability like
+    # "scope" mixes fixed-value checks with genuinely multi-valued ones
+    # (e.g. scope_span.set). Each source is required non-empty, in the
+    # spirit of the `{ absent = "<source>" }` convention in [commands].
+    # check_id existence cannot be cross-checked here against the live
+    # registry (`validation/registry/_assembly.py: REGISTRY_BY_ID`) --
+    # `rigplane.profiles` may not import `rigplane.validation`, per
+    # `.importlinter`'s validation-leaf contract -- so that cross-check is
+    # a test (`tests/test_rig_loader.py::TestFixedValueChecks::
+    # test_ic7300_fixed_value_check_ids_are_real_registry_check_ids`), not a
+    # parameter here (F4, MOR-2105 part 2 owner ruling: an unused
+    # ``known_check_ids`` parameter with no production caller was an
+    # orphan).
+    fixed_value_raw = data.get("validation", {}).get("fixed_value", {})
+    for check_id, source in fixed_value_raw.items():
+        if not isinstance(source, str) or not source.strip():
+            raise RigLoadError(
+                f"{filename}: [validation.fixed_value].{check_id!r} must be "
+                f"a non-empty string naming the source, got {source!r}"
+            )
+    fixed_value_checks = dict(fixed_value_raw)
+
     # Validate [vfo]
     vfo = data["vfo"]
     scheme = vfo.get("scheme", "")
@@ -2426,6 +2460,7 @@ def load_rig(path: Path) -> RigConfig:
         browser_rx_transcode_to_opus=browser_rx_transcode_to_opus,
         rx_audio_channel=rx_audio_channel,
         write_only_controls=write_only_controls,
+        fixed_value_checks=fixed_value_checks,
         state_acquisition=state_acquisition,
         tx_interlock_disposition_overrides=tx_interlock_disposition_overrides,
         tx_policy=tx_policy,

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -209,6 +209,7 @@ async def execute_hardware_checks(
     allow_writes: bool,
     per_check_timeout: float = DEFAULT_PER_CHECK_TIMEOUT,
     write_only_capabilities: frozenset[str] = frozenset(),
+    fixed_value_checks: dict[str, str] = {},  # noqa: B006 -- read-only
     prompter: InteractivePrompter | None = None,
     tx_actuate: bool = False,
     audio_probe_frames: Sequence[bytes | None] | None = None,
@@ -238,6 +239,13 @@ async def execute_hardware_checks(
     it (dry-run/CI, or a non-AudioCapable radio) those probes keep their
     MANUAL_REQUIRED behaviour. ``audio.tx.byte_perfect`` is out of scope here
     and is never run against live hardware (it needs TX loopback).
+
+    *fixed_value_checks* (MOR-2105 part 2) names, by check_id, RMVR_SAFE_WRITE
+    checks this radio has only one legal value for (e.g. IC-7300's
+    scope_receiver.set/scope_dual.set — single receiver, single scope). Such
+    a check reports SKIP, quoting the source, instead of flipping to a value
+    the radio can never report back and reporting a false FAIL. Empty by
+    default: every check uses the standard RMVR path.
     """
     # MOR-666: resolve the single pre-TX confirmation up front so it is asked at
     # most once per run (not per check). ``confirm()`` ignores ``--assume-yes``,
@@ -257,6 +265,7 @@ async def execute_hardware_checks(
                 allow_writes=allow_writes,
                 per_check_timeout=per_check_timeout,
                 write_only_capabilities=write_only_capabilities,
+                fixed_value_checks=fixed_value_checks,
                 prompter=prompter,
                 tx_actuate_confirmed=tx_actuate_confirmed,
                 audio_probe_frames=audio_probe_frames,
@@ -335,6 +344,7 @@ async def _run_one_check(
     allow_writes: bool,
     per_check_timeout: float,
     write_only_capabilities: frozenset[str] = frozenset(),
+    fixed_value_checks: dict[str, str] = {},  # noqa: B006 -- read-only
     prompter: InteractivePrompter | None = None,
     tx_actuate_confirmed: bool = False,
     audio_probe_frames: Sequence[bytes | None] | None = None,
@@ -413,6 +423,56 @@ async def _run_one_check(
             return await _set_and_observe(
                 radio, entry, spec, per_check_timeout=per_check_timeout
             )
+
+    # Per-radio fixed-value classification (MOR-2105 part 2): a control this
+    # radio has only one legal value for reports SKIP, naming the source,
+    # instead of the RMVR cycle flipping to a value the radio can never
+    # report back and reporting a false FAIL. Two sources, both checked
+    # before any radio I/O and independent of --read-only:
+    # - scope_receiver.set is DERIVED from RadioProfile.receiver_count (F1,
+    #   owner ruling): a single-receiver radio already says so via
+    #   receiver_count/supports_receiver, so this is not restated as TOML
+    #   data that could silently disagree with it.
+    # - every other entry is TOML-DECLARED, via [validation.fixed_value] in
+    #   the rig TOML (fixed_value_checks, keyed by check_id -- finer than
+    #   write_only_capabilities' per-capability grain above, since a
+    #   capability like "scope" mixes fixed-value checks with genuinely
+    #   multi-valued ones, e.g. scope_span.set), for a fact with no other
+    #   home in RadioProfile (IC-7300's scope_dual.set: single scope).
+    # Checked ahead of Pre-gate 4 (not inside a per-check_id handler) so it
+    # applies uniformly whether or not entry.check_id has a named handler in
+    # _SUPPORTED_HANDLERS -- a fixed-value declaration for one of those 15
+    # would otherwise be silently ignored.
+    if entry.check_id == "scope_receiver.set":
+        receiver_count = getattr(
+            getattr(radio, "profile", None), "receiver_count", None
+        )
+        if isinstance(receiver_count, int) and receiver_count <= 1:
+            return _base_result(
+                entry,
+                CheckStatus.SKIP,
+                evidence={
+                    "reason": (
+                        "scope_receiver.set is fixed-value: this radio's "
+                        f"profile declares receiver_count={receiver_count}, "
+                        "so there is no second receiver to select; not "
+                        "attempting the flip"
+                    )
+                },
+            )
+    fixed_source = fixed_value_checks.get(entry.check_id)
+    if fixed_source is not None:
+        return _base_result(
+            entry,
+            CheckStatus.SKIP,
+            evidence={
+                "reason": (
+                    f"{entry.check_id} is declared fixed-value (single "
+                    f"legal value) by the profile, per {fixed_source}; "
+                    "not attempting the flip"
+                )
+            },
+        )
 
     # Pre-gate 4: SUPPORTED -> check-specific logic.
     handler = _SUPPORTED_HANDLERS.get(entry.check_id)

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -404,6 +404,12 @@ class TestRemovedCommands:
         assert not cmdmap.has("get_drive_gain")
         assert not cmdmap.has("set_drive_gain")
 
+    def test_no_scope_rbw(self, cmdmap):
+        """MOR-2105: IC-7300 Advanced Manual (11a) 0x27 sub-command table
+        (pp.19-7..19-8) runs 1E then 20 -- no 1F row."""
+        assert not cmdmap.has("get_scope_rbw")
+        assert not cmdmap.has("set_scope_rbw")
+
 
 # ── Spectrum params ────────────────────────────────────────────
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2114,6 +2114,61 @@ class TestWriteOnlyControls:
         assert {"rit", "xit", "notch", "nr", "nb", "compressor"} <= caps
 
 
+class TestFixedValueChecks:
+    """[validation.fixed_value] parsing and propagation (MOR-2105 part 2).
+
+    Only for a fact with no other home in ``RadioProfile`` (F1/F2, owner
+    ruling): ``scope_receiver.set`` (IC-7300's single-receiver fact) is NOT
+    declared here -- ``receiver_count``/``supports_receiver`` already say
+    so, and ``validation/hardware.py: _run_one_check`` derives it from that
+    directly instead of restating it. Only ``scope_dual.set`` (single-scope;
+    no ``receiver_count``-like field exists for "scope count") uses this
+    table.
+    """
+
+    def test_fixed_value_checks_parsed(self, tmp_path):
+        toml = (
+            _MINIMAL_TOML
+            + '\n[validation.fixed_value]\n"scope_dual.set" = "some source"\n'
+        )
+        rig = load_rig(_write_toml(tmp_path, toml))
+        assert rig.fixed_value_checks == {"scope_dual.set": "some source"}
+        assert rig.to_profile().fixed_value_checks == {"scope_dual.set": "some source"}
+
+    def test_fixed_value_checks_defaults_empty(self, tmp_path):
+        rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
+        assert rig.fixed_value_checks == {}
+        assert rig.to_profile().fixed_value_checks == {}
+
+    def test_fixed_value_checks_source_must_be_nonempty_string(self, tmp_path):
+        toml = _MINIMAL_TOML + '\n[validation.fixed_value]\n"scope_dual.set" = ""\n'
+        with pytest.raises(RigLoadError, match="non-empty string"):
+            load_rig(_write_toml(tmp_path, toml))
+
+    def test_ic7300_fixed_value_checks_is_exactly_scope_dual(self):
+        """MOR-2105 part 2, F1: after deriving scope_receiver.set from
+        receiver_count, rigs/ic7300.toml's [validation.fixed_value] table
+        must hold exactly one entry -- a second entry reappearing here
+        (e.g. a future edit re-adding scope_receiver.set) would silently
+        reinstate the two-sources-of-truth defect F1 removed.
+        """
+        profile = load_rig(RIGS_DIR / "ic7300.toml").to_profile()
+        assert profile.fixed_value_checks == {
+            "scope_dual.set": (
+                "IC-7300 Advanced Manual (11a) command table p.19-7: "
+                "27 13 data column = 00 (Single only)"
+            )
+        }
+
+    # The cross-check against the live validation registry
+    # (test_every_shipped_profiles_fixed_value_check_ids_are_real_registry_
+    # check_ids) lives below, parametrized over _SHIPPED_RIG_TOMLS rather
+    # than hardcoded to ic7300.toml here, per the directory-driven idiom
+    # TestAgcDomainDeclaredOrCapabilityAbsent's docstring states just below
+    # this class -- _SHIPPED_RIG_TOMLS is defined after this class, so the
+    # parametrize can't reference it from inside this class body.
+
+
 # ── AGC domain declaration, table-driven over every shipped profile ──────
 # (MOR-1522). "Shipped profile" = every rigs/*.toml except the UI-only
 # _keyboard-default.toml, taken from the directory listing itself rather
@@ -2123,6 +2178,29 @@ class TestWriteOnlyControls:
 _SHIPPED_RIG_TOMLS = sorted(
     p for p in RIGS_DIR.glob("*.toml") if p.name != "_keyboard-default.toml"
 )
+
+
+@pytest.mark.parametrize("toml_path", _SHIPPED_RIG_TOMLS, ids=lambda p: p.stem)
+def test_every_shipped_profiles_fixed_value_check_ids_are_real_registry_check_ids(
+    toml_path,
+):
+    """[validation.fixed_value] check_id existence, cross-checked against the
+    live validation registry, over every shipped profile (MOR-2105 part 2) --
+    directory-driven like TestAgcDomainDeclaredOrCapabilityAbsent just below,
+    so a future profile adding this table lands under the same cross-check
+    without a hand-written addition here. Most profiles declare no
+    [validation.fixed_value] table at all (empty dict, trivially a subset);
+    today only rigs/ic7300.toml (scope_dual.set) is non-empty.
+    `rigplane.profiles` may not import `rigplane.validation`
+    (`.importlinter`'s validation-leaf contract), so `load_rig` itself
+    cannot raise on an unknown check_id at parse time -- this test is where
+    that guarantee is exercised instead, by a caller (this test file) that
+    may legally import both.
+    """
+    from rigplane.validation.registry import REGISTRY_BY_ID
+
+    profile = load_rig(toml_path).to_profile()
+    assert set(profile.fixed_value_checks) <= set(REGISTRY_BY_ID)
 
 
 class TestAgcDomainDeclaredOrCapabilityAbsent:
@@ -2702,9 +2780,11 @@ class TestIc7300DeclaresAbsentCommands:
     (+1, to 28), then MOR-2008 batch 1 deleted the dead bare
     ``quick_dual_watch`` entry alongside the bare ``quick_split`` row it
     was declared next to (-1, back to 27 -- a different 27 than D2's, not
-    the same set reverted). Pinned by name, not just count, so a future D2
-    pass on another command can't silently swap one of these for a
-    different one and still pass a bare-count check.
+    the same set reverted), then MOR-2105 part 1 (2026-09-01) added
+    ``get_scope_rbw``/``set_scope_rbw`` (+2, to 29 -- the current count,
+    per ``len(_EXPECTED_ABSENT)``). Pinned by name, not just count, so a
+    future D2 pass on another command can't silently swap one of these for
+    a different one and still pass a bare-count check.
     """
 
     _EXPECTED_ABSENT = frozenset(

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2741,6 +2741,10 @@ class TestIc7300DeclaresAbsentCommands:
             # builder resolved it, only get_/set_quick_dual_watch above do.
             "get_rx_antenna_ant2",
             "set_rx_antenna_ant2",
+            # MOR-2105: IC-7300 Advanced Manual (11a) 0x27 sub-command table
+            # (pp.19-7..19-8) runs 1E then 20 -- no 1F row.
+            "get_scope_rbw",
+            "set_scope_rbw",
         }
     )
 

--- a/tests/test_validate_hamlib_provider.py
+++ b/tests/test_validate_hamlib_provider.py
@@ -398,6 +398,47 @@ async def test_run_hardware_forwards_write_only_capabilities(
     assert captured["write_only_capabilities"] == frozenset({"rit", "xit", "notch"})
 
 
+async def test_run_hardware_forwards_fixed_value_checks(monkeypatch: Any) -> None:
+    """_run_hardware (native) forwards profile.fixed_value_checks to the
+    hardware runner (MOR-2105 part 2). Uses IC-7300, not X6200: X6200's
+    fixed_value_checks is {} (no [validation.fixed_value] declared), so
+    asserting {} there would pass even if the CLI never read the profile at
+    all -- a hollow pin (independent review finding). IC-7300's is
+    non-empty, so only a correctly-threaded value satisfies this assertion.
+    """
+    template = _identify_template(profile_id="icom_ic7300")
+    safety = OperatorSafetyBlock()
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="IC-7300")
+    captured: dict[str, Any] = {}
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute(*args: Any, **kwargs: Any) -> Any:
+        captured["fixed_value_checks"] = kwargs.get("fixed_value_checks")
+        return []
+
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks", fake_execute
+    )
+    monkeypatch.setattr(_validate, "_emit_artifact", lambda artifact, args: None)
+
+    await _validate._run_hardware(
+        _base_args(model="IC-7300", read_only=False), template, safety
+    )
+
+    assert (
+        captured["fixed_value_checks"]
+        == get_radio_profile("IC-7300").fixed_value_checks
+    )
+    assert captured["fixed_value_checks"]  # non-empty: a hollow-pin guard
+
+
 async def test_run_hardware_hamlib_forwards_write_only_capabilities(
     monkeypatch: Any,
 ) -> None:
@@ -435,6 +476,52 @@ async def test_run_hardware_hamlib_forwards_write_only_capabilities(
     await _validate._run_hardware_hamlib(_base_args(), template, safety)
 
     assert captured["write_only_capabilities"] == frozenset({"rit", "xit", "notch"})
+
+
+async def test_run_hardware_hamlib_forwards_fixed_value_checks(
+    monkeypatch: Any,
+) -> None:
+    """_run_hardware_hamlib forwards profile.fixed_value_checks too
+    (MOR-2105 part 2). IC-7300, not X6200, for the same hollow-pin reason as
+    test_run_hardware_forwards_fixed_value_checks above.
+    """
+    _FakeBridge.instances.clear()
+    template = _identify_template(profile_id="icom_ic7300")
+    safety = OperatorSafetyBlock()
+    native_config = RigctldBackendConfig(host="127.0.0.1", port=4532, model="IC-7300")
+    captured: dict[str, Any] = {}
+
+    async def fake_build_backend_config(_args: Any) -> Any:
+        return native_config
+
+    def fake_create_radio(config: Any) -> Any:
+        return _FakeNativeRadio()
+
+    async def fake_execute(*args: Any, **kwargs: Any) -> Any:
+        captured["fixed_value_checks"] = kwargs.get("fixed_value_checks")
+        return []
+
+    async def fake_await_tcp_ready(
+        host: str, port: int, *, timeout: float = 10.0
+    ) -> bool:
+        return True
+
+    monkeypatch.setattr("rigplane.cli._build_backend_config", fake_build_backend_config)
+    monkeypatch.setattr("rigplane.backends.factory.create_radio", fake_create_radio)
+    monkeypatch.setattr("rigplane.hamlib_bridge.HamlibBridge", _FakeBridge)
+    monkeypatch.setattr(
+        "rigplane.validation.hardware.execute_hardware_checks", fake_execute
+    )
+    monkeypatch.setattr(_validate, "_await_tcp_ready", fake_await_tcp_ready)
+    monkeypatch.setattr(_validate, "_emit_artifact", lambda artifact, args: None)
+
+    await _validate._run_hardware_hamlib(_base_args(model="IC-7300"), template, safety)
+
+    assert (
+        captured["fixed_value_checks"]
+        == get_radio_profile("IC-7300").fixed_value_checks
+    )
+    assert captured["fixed_value_checks"]  # non-empty: a hollow-pin guard
 
 
 # ---------------------------------------------------------------------------

--- a/tests/validation/test_hardware_command_families.py
+++ b/tests/validation/test_hardware_command_families.py
@@ -96,12 +96,19 @@ def _stateful_value_radio(
     return radio, store
 
 
-async def _run(radio, check_id: str, *, safety: OperatorSafetyBlock | None = None):
+async def _run(
+    radio,
+    check_id: str,
+    *,
+    safety: OperatorSafetyBlock | None = None,
+    fixed_value_checks: dict[str, str] | None = None,
+):
     levels = await execute_hardware_checks(
         radio,
         _template_for(check_id),
         safety or OperatorSafetyBlock(),
         allow_writes=True,
+        fixed_value_checks=fixed_value_checks or {},
     )
     return _flatten(levels)[check_id]
 
@@ -514,6 +521,141 @@ async def test_scope_receiver_set_flips_main_sub():
     assert result.status is CheckStatus.PASS
     assert store["value"] == 0  # restored to MAIN
     assert 1 in store["writes"]  # flipped to SUB during the check
+
+
+async def test_scope_receiver_set_skips_via_derived_receiver_count():
+    """MOR-2105 part 2, F1 (owner ruling): scope_receiver.set's fixed-value
+    status is DERIVED from RadioProfile.receiver_count, not declared a
+    second time in TOML -- IC-7300's real profile (receiver_count=1) is
+    used directly, so this proves the derivation reads that field rather
+    than any independently-editable [validation.fixed_value] entry (none
+    exists for scope_receiver.set -- see TestFixedValueChecks in
+    tests/test_rig_loader.py). No frame may reach the transport (the fake
+    radio's get/set ops must never be awaited), unlike
+    test_scope_receiver_set_flips_main_sub just above, which drives the
+    SAME check_id on a radio with no ``.profile`` at all and must keep
+    actually flipping.
+    """
+    from rigplane.profiles import get_radio_profile
+
+    profile = get_radio_profile("IC-7300")
+    assert profile.receiver_count == 1
+    assert "scope_receiver.set" not in profile.fixed_value_checks
+
+    radio, _store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_receiver",
+        set_op="set_scope_receiver",
+        start=0,
+        receiver_kw=False,
+    )
+    radio.profile = profile
+    result = await _run(radio, "scope_receiver.set")
+    assert result.status is CheckStatus.SKIP
+    assert "scope_receiver.set" in result.evidence["reason"]
+    assert "receiver_count=1" in result.evidence["reason"]
+    radio.get_scope_receiver.assert_not_awaited()
+    radio.set_scope_receiver.assert_not_awaited()
+
+
+async def test_scope_receiver_set_still_flips_when_receiver_count_is_two():
+    """Negative control for the derivation above: IC-7610's real profile
+    declares receiver_count=2, so scope_receiver.set must NOT be treated as
+    fixed-value on it -- proving the derivation is conditional on the
+    profile's own data, not a blanket skip for the check_id.
+    """
+    from rigplane.profiles import get_radio_profile
+
+    profile = get_radio_profile("IC-7610")
+    assert profile.receiver_count == 2
+
+    radio, store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_receiver",
+        set_op="set_scope_receiver",
+        start=0,
+        receiver_kw=False,
+    )
+    radio.profile = profile
+    result = await _run(radio, "scope_receiver.set")
+    assert result.status is CheckStatus.PASS
+    assert store["value"] == 0  # restored to MAIN
+    assert 1 in store["writes"]  # flipped to SUB during the check
+
+
+async def test_scope_dual_set_skips_on_ic7300_fixed_value_declaration():
+    """MOR-2105 part 2: IC-7300 declares scope_dual.set fixed-value in
+    [validation.fixed_value] (single scope -- 00 is the only legal value the
+    command can ever hold, and there is no RadioProfile field like
+    receiver_count to derive it from -- F2, owner ruling), so the RMVR
+    harness must report SKIP naming that declaration instead of attempting
+    the flip -- and no frame may reach the transport (the fake radio's
+    get/set ops must never be awaited), unlike
+    test_scope_dual_set_rmvr_roundtrip just above, which drives the SAME
+    check_id on a radio with no such declaration and must keep actually
+    flipping.
+    """
+    from rigplane.profiles import get_radio_profile
+
+    profile = get_radio_profile("IC-7300")
+    assert profile.fixed_value_checks.keys() == {"scope_dual.set"}
+
+    radio, _store = _stateful_value_radio(
+        capability="scope",
+        get_op="get_scope_dual",
+        set_op="set_scope_dual",
+        start=False,
+        receiver_kw=False,
+    )
+    result = await _run(
+        radio, "scope_dual.set", fixed_value_checks=profile.fixed_value_checks
+    )
+    assert result.status is CheckStatus.SKIP
+    assert "scope_dual.set" in result.evidence["reason"]
+    assert profile.fixed_value_checks["scope_dual.set"] in result.evidence["reason"]
+    radio.get_scope_dual.assert_not_awaited()
+    radio.set_scope_dual.assert_not_awaited()
+
+
+async def test_fixed_value_declaration_is_honoured_for_a_named_handler_check_id():
+    """Review finding (independent of the coordinator's F3): before the gate
+    moved to _run_one_check, it lived inside _check_from_spec, which is only
+    reached when entry.check_id has no entry in _SUPPORTED_HANDLERS (15
+    check_ids, 13 of them RMVR_SAFE_WRITE -- af_level.set, agc.set,
+    attenuator.set, filter_width.set, freq.write, mode.set, nb.set,
+    notch.set, nr.set, preamp.set, rf_gain.set, rit.set, xit.set). A
+    [validation.fixed_value] entry for any of those 13 was silently ignored
+    -- the named handler ran the real RMVR cycle regardless. nb.set is one
+    of them; no shipped profile declares it fixed-value (this is a synthetic
+    declaration proving the mechanism, not a real IC-7300 fact). Same input,
+    with and without the declaration:
+    """
+    radio, store = _stateful_value_radio(
+        capability="nb",
+        get_op="get_nb",
+        set_op="set_nb",
+        start=False,
+        receiver_kw=False,
+    )
+    result_without = await _run(radio, "nb.set")
+    assert result_without.status is CheckStatus.PASS
+    assert True in store["writes"]  # the real handler actually flipped it
+
+    radio2, store2 = _stateful_value_radio(
+        capability="nb",
+        get_op="get_nb",
+        set_op="set_nb",
+        start=False,
+        receiver_kw=False,
+    )
+    result_with = await _run(
+        radio2, "nb.set", fixed_value_checks={"nb.set": "synthetic test declaration"}
+    )
+    assert result_with.status is CheckStatus.SKIP
+    assert "nb.set" in result_with.evidence["reason"]
+    assert store2["writes"] == []  # the named handler never ran
+    radio2.get_nb.assert_not_awaited()
+    radio2.set_nb.assert_not_awaited()
 
 
 async def test_scope_edge_set_cycles_within_valid_edges():


### PR DESCRIPTION
Two IC-7300 scope checks reported `fail` for a reason that is not a defect, and a
third declared a command the manual does not document.

**This ticket was filed with a false premise and rewritten.** It originally claimed
`27 12`, `27 13` and `27 1F` were all absent from the IC-7300 Advanced Manual 11a.
Two of the three are documented — as fixed-value commands, `00=Main only` and
`00=Single only` — and the profile already carried a live bench capture of the
radio answering `27 12 00`. Only `27 1F` is genuinely undocumented. The manual page
has now been read independently by five agents.

## The actual defect

On a single-receiver, single-scope radio, `00` is the **only legal value** for those
two commands. The read-modify-verify-restore check flips to the other value and
reports a failure when the radio does not follow. There is no other value.

## Two halves, and only one needed new machinery

**`27 1F`** — genuinely undocumented; the `0x27` table runs `1E` then `20`.
Declared absent with the manual citation, in the form the `dual_watch` family in the
same file already uses.

**`27 12` / `27 13`** — the harness must stop flipping them, from profile data
rather than a special case:

- `scope_receiver.set` needs **no declaration**. `rigs/ic7300.toml` already says
  `receiver_count = 1`, and `RadioProfile.supports_receiver` already implements the
  predicate. The gate derives it. Declaring it a second time in another notation
  would have been two sources of truth for one fact.
- `scope_dual.set` does need one: no `RadioProfile` field represents a scope count,
  verified against all 73 fields. So `[validation.fixed_value]` carries it — a table
  of check id to manual citation, mirroring the plumbing `[validation].write_only_controls`
  already uses for the same kind of per-radio classification.

## Where the gate sits, and why it matters

Beside the existing per-radio write-only branch in `_run_one_check`, above handler
dispatch — not inside `_check_from_spec`.

Placed lower, it would have been reached only when no named handler exists, and
**silently ignored for 13 of the 45 RMVR checks**. The loader would still have
accepted such a declaration as valid, so the only guardrail would have told an author
the entry was fine while the harness discarded it.

## Testing

The two existing tests that drive a fake dual-receiver radio and assert the flip
**succeeds** are unmodified and still pass — they are the control proving the gate is
per-radio rather than a global disable. Forcing the derivation unconditional reddens
both them and the negative control, so the control discriminates on `receiver_count`
itself, not merely on a check id.

The registry cross-check is directory-driven over all shipped profiles rather than
hardcoded to one file, so a second profile adding the table cannot land unchecked.

Both CLI passthroughs are pinned on an IC-7300 config, not X6200 — X6200's table is
empty, so asserting it there would pass whether or not the value is threaded at all.

Worth stating because it is not obvious: **the golden dry-run gates give this change
no coverage in either direction.** `--dry-run` invokes the hardware-check path zero
times, so their passing is not evidence here and the unit tests carry the whole load.

## Guardrails

10 files / 475 changed lines. Ten reaches the hard-ceiling file count without
crossing it, and changed lines are far under. The five hops each live in a different
file by the codebase's own layering — TOML, loader, profile field, CLI passthrough,
harness gate — plus their tests, a doc row and the audit file the change falsifies.
There is no smaller functional slice: the first half alone is 3 files and 16 lines,
which is not worth its own review and CI run.