### PR TITLE
fix(MOR-2103): surface the Yaesu ?; rejection instead of guessing at no reaction

### DIFF
--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -17,7 +17,7 @@ from ...command_spec import CatCommandSpec
 from ...commands import hz_to_table_index, table_index_to_hz
 from ...core.tx_authority import TxStateReading
 from ...types import AudioCodec, BreakInMode
-from ...exceptions import AudioFormatError, CommandError
+from ...exceptions import AudioFormatError, CommandError, CommandRejectedError
 from ...exceptions import ConnectionError as RadioConnectionError
 from ...radio_state import RadioState
 from .parser import CatCommandParser, CatParseError, format_command
@@ -788,14 +788,32 @@ class YaesuCatRadio:
         return parser.parse(raw + ";")
 
     async def _write(self, cmd_name: str, **kwargs: Any) -> None:
-        """Format and send a write command (no response expected)."""
+        """Format and send a write command (no response expected).
+
+        Raises:
+            CommandRejectedError: If the radio rejects the command with
+                ``?;`` (MOR-2103), translated from the transport's
+                :class:`~.transport.CatCommandRejected` — a plain
+                ``Exception`` subclass, not :class:`~...exceptions.RigplaneError`,
+                so it would otherwise escape ``validation/hardware.py``'s
+                ``_guard`` uncaught. A dedicated subclass of
+                :class:`~...exceptions.CommandError` (not a plain
+                ``CommandError``) so a caller that needs to know the radio
+                positively refused the command — as opposed to, say, a local
+                encoder rejecting an out-of-range value before anything was
+                sent — can identify it structurally, by type, instead of
+                re-deriving it from the exception's message text.
+        """
         self._require_connected()
         spec = self._get_spec(cmd_name)
         if spec.write is None:
             raise CommandError(f"Command {cmd_name!r} has no write template")
 
         cmd = format_command(spec.write, **kwargs)
-        await self._transport.write(cmd)
+        try:
+            await self._transport.write(cmd)
+        except CatCommandRejected as exc:
+            raise CommandRejectedError(str(exc)) from exc
 
     # -- IF Bulk Query ------------------------------------------------------
 

--- a/src/rigplane/backends/yaesu_cat/transport.py
+++ b/src/rigplane/backends/yaesu_cat/transport.py
@@ -14,7 +14,12 @@ Design principles (learned from production):
    lines that don't match the expected command prefix.
 
 3. **``?;`` = hard error.**  Radio returns ``?;`` for unrecognized commands.
-   Detected immediately in both ``write()`` and ``query()``.
+   Detected in ``query()``. In ``write()`` (MOR-2103), detected only for a
+   ``?;`` that arrives among the first ``_DRAIN_MAX_LINES`` post-write
+   lines and within ``_DRAIN_TIMEOUT`` of the read that would see it — one
+   that arrives after the drain has already gone quiet, or as the line
+   behind ``_DRAIN_MAX_LINES`` or more auto-info lines, drains unread and
+   is not detected.
 
 4. **Health tracking.**  Consecutive errors trigger automatic reconnect.
    Stats (queries, writes, errors, reconnects) available for diagnostics.
@@ -301,25 +306,37 @@ class YaesuCatTransport:
 
     async def _drain_responses(
         self,
+        command: str,
         drain_timeout: float = _DRAIN_TIMEOUT,
         max_lines: int = _DRAIN_MAX_LINES,
     ) -> int:
         """Read and discard echo / auto-info lines until silence.
 
         Returns the number of lines drained.
+
+        Raises:
+            CatCommandRejected: If a drained line is ``?;`` (MOR-2103) — the
+                radio rejected *command*. Silence within *drain_timeout* is
+                the normal, healthy case (the ``CatTimeoutError`` branch
+                below) and must never raise.
         """
         drained = 0
         for _ in range(max_lines):
             try:
                 line = await self.readline(timeout=drain_timeout)
-                drained += 1
-                self._stats.stale_lines_skipped += 1
-                if self._debug_logging:
-                    logger.debug("CAT: drained post-write line: %r", line)
             except CatTimeoutError:
                 break  # Silence — buffer is clean
             except CatTransportError:
                 break  # Port error — bail out
+            drained += 1
+            if line == "?":
+                self._stats.record_error(f"rejected: {command}")
+                raise CatCommandRejected(
+                    f"Radio rejected command {command!r} (returned '?;')"
+                )
+            self._stats.stale_lines_skipped += 1
+            if self._debug_logging:
+                logger.debug("CAT: drained post-write line: %r", line)
         # Flush any partial bytes that didn't form a complete line
         await self.flush_rx()
         return drained
@@ -341,13 +358,14 @@ class YaesuCatTransport:
             command: CAT command string (e.g. ``"MD0E;"``).
 
         Raises:
+            CatCommandRejected: If the radio returns ``?;`` (MOR-2103).
             CatTransportError: On serial I/O failure.
         """
         async with self._lock:
             await self.flush_rx()
             await self._raw_write(command)
             self._stats.writes += 1
-            drained = await self._drain_responses()
+            drained = await self._drain_responses(command)
             self._stats.record_success()
             if drained and self._debug_logging:
                 logger.debug("CAT: drained %d line(s) after write %r", drained, command)

--- a/src/rigplane/core/exceptions.py
+++ b/src/rigplane/core/exceptions.py
@@ -5,6 +5,7 @@ __all__ = [
     "ConnectionError",
     "AuthenticationError",
     "CommandError",
+    "CommandRejectedError",
     "TimeoutError",
     "AudioError",
     "AudioCodecBackendError",
@@ -27,6 +28,13 @@ class AuthenticationError(RigplaneError):
 
 class CommandError(RigplaneError):
     """Raised when a CI-V command fails or returns an error."""
+
+
+class CommandRejectedError(CommandError):
+    """Raised when the radio positively refused a command (e.g. a Yaesu
+    ``?;`` response), as opposed to a locally-detected encoding error, a
+    missing command template, or any other :class:`CommandError` that never
+    reached the radio at all."""
 
 
 class TimeoutError(RigplaneError):

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -34,6 +34,7 @@ from typing import Any, TypeVar, cast
 from rigplane.core.exceptions import (
     AuthenticationError,
     CommandError,
+    CommandRejectedError,
     ConnectionError as RigConnectionError,
     RigplaneError,
     TimeoutError as RigTimeoutError,
@@ -65,6 +66,7 @@ from rigplane.validation.schema import (
     LevelResult,
     MatrixTemplate,
     OperatorSafetyBlock,
+    RmvrOutcome,
     ValidationLevel,
 )
 
@@ -321,8 +323,14 @@ def _base_result(
     failure_domain: FailureDomain | None = None,
     evidence: dict[str, object] | None = None,
     error: str | None = None,
+    outcome: RmvrOutcome | None = None,
 ) -> CheckResult:
-    """Build a :class:`CheckResult` carrying ``entry``'s static fields."""
+    """Build a :class:`CheckResult` carrying ``entry``'s static fields.
+
+    ``outcome`` is the internal-only ``CheckResult.outcome`` carrier
+    (MOR-2103) -- every existing caller omits it and gets ``None``, exactly
+    as before this parameter existed.
+    """
     return CheckResult(
         check_id=entry.check_id,
         capability=entry.capability,
@@ -333,6 +341,7 @@ def _base_result(
         failure_domain=failure_domain,
         evidence=evidence or {},
         error=error,
+        outcome=outcome,
     )
 
 
@@ -1015,6 +1024,14 @@ async def _guard(
 
     Returns ``(value, None)`` on success or ``(None, failure_result)`` on any
     handled error. Never swallows ``KeyboardInterrupt``/``SystemExit``.
+
+    The returned ``CheckResult.outcome`` (MOR-2103) is set structurally, at
+    the point each exception is caught, for the two cases an RMVR write or
+    verify-read leg can positively identify: a per-check timeout, or a
+    :class:`CommandRejectedError`. Every other except clause below leaves it
+    at its default ``None`` -- ``_guard`` does not guess; a caller that
+    wants a label for those must not invent one either (see
+    ``_rmvr_failure_outcome`` in this module).
     """
     try:
         value = await asyncio.wait_for(coro, timeout=per_check_timeout)
@@ -1025,6 +1042,7 @@ async def _guard(
             CheckStatus.FAIL,
             failure_domain=FailureDomain.COMMAND_EXECUTION,
             error=f"timeout after {per_check_timeout}s",
+            outcome=RmvrOutcome.TIMED_OUT,
         )
     except (RigConnectionError, AuthenticationError) as exc:
         return None, _base_result(
@@ -1032,6 +1050,19 @@ async def _guard(
             CheckStatus.FAIL,
             failure_domain=FailureDomain.TRANSPORT,
             error=str(exc),
+        )
+    except CommandRejectedError as exc:
+        # MOR-2103: a positively-identified command rejection (a Yaesu "?;",
+        # translated by YaesuCatRadio._write) is structurally distinct from
+        # every other CommandError below it in this except chain — those
+        # never reached the radio at all (no write template, a local
+        # encoder ValueError, any other RigplaneError).
+        return None, _base_result(
+            entry,
+            CheckStatus.FAIL,
+            failure_domain=FailureDomain.COMMAND_EXECUTION,
+            error=str(exc),
+            outcome=RmvrOutcome.REJECTED,
         )
     except CommandError as exc:
         return None, _base_result(
@@ -1070,6 +1101,28 @@ async def _guard(
             failure_domain=FailureDomain.COMMAND_EXECUTION,
             error=str(exc),
         )
+
+
+def _rmvr_failure_outcome(fail: CheckResult, *, leg: str) -> RmvrOutcome | None:
+    """Read ``_guard``'s own RMVR classification for the write or
+    verify-read leg, applying the one constraint ``_guard`` itself cannot
+    know (MOR-2103).
+
+    ``leg`` is ``"write"`` for the changed-value write, or ``"read"`` for
+    the post-write verify read (the write already succeeded by the time
+    this leg runs). ``fail.outcome`` was set structurally by ``_guard`` --
+    at the point it caught the underlying exception, from the exception's
+    type -- not re-derived here from ``failure_domain``, ``error`` text, or
+    ``evidence``.
+
+    The read leg can never report REJECTED: a read-leg failure happens
+    after the write already succeeded, so a rejection there could never
+    mean the write was refused -- a category error regardless of what
+    ``_guard``'s classification says. TIMED_OUT is valid on either leg.
+    """
+    if leg == "read" and fail.outcome is RmvrOutcome.REJECTED:
+        return None
+    return fail.outcome
 
 
 def _default_equal(a: T, b: T) -> bool:
@@ -1315,6 +1368,9 @@ async def _read_modify_verify_restore(
         if w_fail is not None:
             evidence["write_error"] = w_fail.error
             outcome = w_fail
+            write_outcome = _rmvr_failure_outcome(w_fail, leg="write")
+            if write_outcome is not None:
+                evidence["outcome"] = write_outcome.value
         else:
             readback, r_fail = await _guard(
                 read(), entry, per_check_timeout=per_check_timeout
@@ -1322,6 +1378,9 @@ async def _read_modify_verify_restore(
             if r_fail is not None:
                 evidence["readback_error"] = r_fail.error
                 outcome = r_fail
+                read_outcome = _rmvr_failure_outcome(r_fail, leg="read")
+                if read_outcome is not None:
+                    evidence["outcome"] = read_outcome.value
             else:
                 evidence["readback"] = readback
                 reacted = equal(cast(T, readback), changed)
@@ -1357,6 +1416,7 @@ async def _read_modify_verify_restore(
     if reacted and restored:
         return _base_result(entry, CheckStatus.PASS, evidence=evidence)
     if not reacted:
+        evidence["outcome"] = RmvrOutcome.IGNORED.value
         return _base_result(
             entry,
             CheckStatus.FAIL,
@@ -1557,6 +1617,9 @@ async def _check_mode_set(
         if w_fail is not None:
             evidence["write_error"] = w_fail.error
             outcome = w_fail
+            write_outcome = _rmvr_failure_outcome(w_fail, leg="write")
+            if write_outcome is not None:
+                evidence["outcome"] = write_outcome.value
         else:
             readback, r_fail = await _guard(
                 radio.get_mode(0), entry, per_check_timeout=per_check_timeout
@@ -1564,6 +1627,9 @@ async def _check_mode_set(
             if r_fail is not None:
                 evidence["readback_error"] = r_fail.error
                 outcome = r_fail
+                read_outcome = _rmvr_failure_outcome(r_fail, leg="read")
+                if read_outcome is not None:
+                    evidence["outcome"] = read_outcome.value
             else:
                 assert readback is not None
                 evidence["readback_mode"] = readback[0]
@@ -1601,6 +1667,7 @@ async def _check_mode_set(
     if reacted and restored:
         return _base_result(entry, CheckStatus.PASS, evidence=evidence)
     if not reacted:
+        evidence["outcome"] = RmvrOutcome.IGNORED.value
         return _base_result(
             entry,
             CheckStatus.FAIL,

--- a/src/rigplane/validation/schema.py
+++ b/src/rigplane/validation/schema.py
@@ -103,6 +103,22 @@ class FailureDomain(StrEnum):
     SCOPE_WATERFALL = "scope_waterfall"
 
 
+class RmvrOutcome(StrEnum):
+    """Closed vocabulary for how an RMVR write or verify-read leg failed
+    (MOR-2103). NOT a member of :class:`FailureDomain` -- that enum is
+    frozen under ``SCHEMA_VERSION`` and
+    ``docs/contracts/validation-matrix-v1.md`` enumerates its members
+    verbatim. This is a sibling vocabulary for a narrower, hardware.py-local
+    question ("how did this write attempt fail"), populated into the
+    free-form ``evidence["outcome"]`` key the contract already declares
+    open, not into a new top-level schema field.
+    """
+
+    REJECTED = "rejected"
+    IGNORED = "ignored"
+    TIMED_OUT = "timed_out"
+
+
 @dataclass(frozen=True, slots=True)
 class CheckResult:
     """Observed result for a single validation check."""
@@ -118,6 +134,15 @@ class CheckResult:
     error: str | None = None
     started_at: str | None = None
     finished_at: str | None = None
+    # Internal-only carrier for _guard's own RMVR classification (MOR-2103):
+    # set exclusively by validation/hardware.py: _guard on the intermediate
+    # CheckResult it returns to _read_modify_verify_restore/_check_mode_set,
+    # so those callers read a structural value instead of re-deriving one
+    # from evidence or error text. Deliberately excluded from to_dict() --
+    # not part of the published artifact schema; the RMVR callers copy it
+    # into their own evidence["outcome"] (already free-form per the
+    # contract) when they build the check's real, published result.
+    outcome: RmvrOutcome | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -637,6 +662,7 @@ __all__ = [
     "CapabilityDeclaration",
     "ValidationLevel",
     "FailureDomain",
+    "RmvrOutcome",
     "CheckResult",
     "LevelResult",
     "OperatorSafetyBlock",

--- a/tests/test_yaesu_cat_transport.py
+++ b/tests/test_yaesu_cat_transport.py
@@ -14,6 +14,7 @@ from rigplane.backends.yaesu_cat import (
     CatTransportError,
     YaesuCatTransport,
 )
+from rigplane.backends.yaesu_cat.transport import CatCommandRejected
 
 
 class FakeStreamReader:
@@ -155,6 +156,26 @@ class TestYaesuCatTransport:
 
         with pytest.raises(CatTransportError, match="not connected"):
             await transport.write("FA;")
+
+    async def test_write_rejected_raises_and_names_frame(
+        self, mock_serial_connection: Any
+    ) -> None:
+        """write() raises CatCommandRejected when the radio answers '?;'
+        instead of silently discarding it as a drained stale line
+        (MOR-2103)."""
+        reader = FakeStreamReader([b"?;"])
+        writer = FakeStreamWriter()
+        mock_serial_connection.open_serial_connection = AsyncMock(
+            return_value=(reader, writer)
+        )
+
+        transport = YaesuCatTransport(device="/dev/test")
+        await transport.connect()
+
+        with pytest.raises(CatCommandRejected, match=r"CT002;"):
+            await transport.write("CT002;")
+
+        assert writer.written == [b"CT002;"]
 
     async def test_readline_returns_response_without_terminator(
         self, mock_serial_connection: Any

--- a/tests/validation/test_hardware.py
+++ b/tests/validation/test_hardware.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from rigplane.core.exceptions import CommandRejectedError
 from rigplane.core.exceptions import TimeoutError as RigTimeoutError
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
@@ -1658,3 +1659,123 @@ async def test_unknown_check_id_still_skips():
     check = _flatten(levels)["bogus.thing"]
     assert check.status is CheckStatus.SKIP
     assert "no hardware handler" in str(check.evidence.get("reason", ""))
+
+
+# ---------------------------------------------------------------------------
+# MOR-2103 — the generic RMVR outcome wiring in _read_modify_verify_restore.
+#
+# _check_mode_set's own tests (tests/validation/test_hardware_ftx1.py) only
+# exercise mode.set, the ONE RMVR_SAFE_WRITE check with its own hand-copied
+# handler. The other 44 route through _read_modify_verify_restore, whose
+# outcome wiring had no test at all before this section: three mutations,
+# each deleting one of the three added blocks, left 298 tests in
+# tests/validation/ plus tests/test_yaesu_cat_transport.py green.
+# ---------------------------------------------------------------------------
+
+
+def _rf_gain_radio(scenario: str, *, original: int = 100):
+    """A MagicMock(spec=Radio) driving one of five _read_modify_verify_restore
+    outcomes through rf_gain.set (a generic-path RMVR_SAFE_WRITE check)."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "X6200"
+    radio.capabilities = {"rf_gain"}
+
+    get_calls = {"n": 0}
+    set_calls = {"n": 0}
+
+    async def _get(receiver: int = 0) -> int:
+        get_calls["n"] += 1
+        if get_calls["n"] == 2:  # the post-write verify read
+            if scenario == "timed_out_read":
+                await asyncio.sleep(30)  # cut off by _guard's per-check timeout
+            if scenario == "value_error_read":
+                raise ValueError("Parse error for 'RG{level:03d};' against 'RG;'")
+            if scenario == "rejected_read":
+                raise CommandRejectedError(
+                    "Radio rejected command 'RG100;' (returned '?;')"
+                )
+        return original
+
+    async def _set(value: int, receiver: int = 0) -> None:
+        set_calls["n"] += 1
+        if scenario == "rejected_write" and set_calls["n"] == 1:  # the changed write
+            raise CommandRejectedError(
+                "Radio rejected command 'RG100;' (returned '?;')"
+            )
+
+    radio.get_rf_gain = AsyncMock(side_effect=_get)
+    radio.set_rf_gain = AsyncMock(side_effect=_set)
+    return radio
+
+
+async def test_rf_gain_rejected_write_reports_outcome():
+    """A CommandRejectedError on the write leg is outcome=rejected at the
+    generic RMVR site, not only at _check_mode_set's hand-copy (MOR-2103)."""
+    radio = _rf_gain_radio("rejected_write")
+    template = _single_entry_template(check_id="rf_gain.set", capability="rf_gain")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["rf_gain.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["outcome"] == "rejected"
+
+
+async def test_rf_gain_ignored_reports_outcome():
+    """A write that returns cleanly but never moves the readback is
+    outcome=ignored at the generic RMVR site (MOR-2103)."""
+    radio = _rf_gain_radio("ignored")
+    template = _single_entry_template(check_id="rf_gain.set", capability="rf_gain")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["rf_gain.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["outcome"] == "ignored"
+
+
+async def test_rf_gain_value_error_on_read_is_not_rejected():
+    """A local/parse ValueError on the verify-read never reached the radio
+    -- must not be labelled outcome=rejected at the generic site either
+    (MOR-2103)."""
+    radio = _rf_gain_radio("value_error_read")
+    template = _single_entry_template(check_id="rf_gain.set", capability="rf_gain")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["rf_gain.set"]
+    assert check.status is CheckStatus.FAIL
+    assert "outcome" not in check.evidence
+
+
+async def test_rf_gain_timed_out_on_read_reports_outcome():
+    """A per-check _guard timeout on the verify-read leg is outcome=timed_out
+    -- proves the read-leg wiring itself is present at the generic site, not
+    only the write-leg one (MOR-2103)."""
+    radio = _rf_gain_radio("timed_out_read")
+    template = _single_entry_template(check_id="rf_gain.set", capability="rf_gain")
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=True,
+        per_check_timeout=0.05,
+    )
+    check = _flatten(levels)["rf_gain.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["outcome"] == "timed_out"
+
+
+async def test_rf_gain_rejected_read_is_not_reported_as_rejected():
+    """A read-leg CommandRejectedError can never mean the write was refused
+    -- the write already succeeded by the time this leg runs. Pins the leg
+    guard's sense at the generic site (MOR-2103)."""
+    radio = _rf_gain_radio("rejected_read")
+    template = _single_entry_template(check_id="rf_gain.set", capability="rf_gain")
+    levels = await execute_hardware_checks(
+        radio, template, OperatorSafetyBlock(), allow_writes=True
+    )
+    check = _flatten(levels)["rf_gain.set"]
+    assert check.status is CheckStatus.FAIL
+    assert "outcome" not in check.evidence

--- a/tests/validation/test_hardware_ftx1.py
+++ b/tests/validation/test_hardware_ftx1.py
@@ -21,9 +21,11 @@ regress the Icom radios that share the same checks.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.types import AgcMode
 from rigplane.validation.hardware import execute_hardware_checks
@@ -34,6 +36,7 @@ from rigplane.validation.schema import (
     MatrixTemplate,
     OperatorSafetyBlock,
     RadioTarget,
+    RmvrOutcome,
     ValidationLevel,
 )
 
@@ -634,3 +637,178 @@ async def test_ctcss_tone_read_unsupported_without_getter():
     del radio.get_ctcss_tone
     check = await _run(radio, check_id="ctcss_tone.read", capability="sql_type")
     assert check.status is CheckStatus.UNSUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# MOR-2103 — write-path ``?;`` rejection: the three-way RMVR outcome
+# ---------------------------------------------------------------------------
+
+
+def test_rmvr_outcome_is_pinned() -> None:
+    """A fourth outcome must not appear unnoticed (mirrors
+    tests/test_tx_authority.py: test_engine_failure_tag_set_is_pinned)."""
+    assert {member.value for member in RmvrOutcome} == {
+        "rejected",
+        "ignored",
+        "timed_out",
+    }
+
+
+#
+# Drives a REAL YaesuCatTransport + YaesuCatRadio (not a MagicMock(spec=Radio),
+# unlike the fixtures above) against a scripted serial wire, so the fix under
+# test -- YaesuCatTransport._drain_responses inspecting the drained line for
+# "?;" -- runs for real. tests/tx_authority_fakes.py: ScriptedCatTransport is
+# a pattern to copy, not an object to reuse here: it fakes the whole
+# transport and its write() never raises. The rejection below comes from
+# this fake's own scripting, independent of any shipped rigs/ftx1.toml entry
+# (sibling ticket MOR-2104 fixed sql_type's CAT write-template width there,
+# merged as 4efe071a).
+
+
+class _ScriptedModeWire:
+    """Fake serial wire understanding only the FTX-1 ``MD0`` mode command.
+
+    Assigned as both ``_reader`` and ``_writer`` on a real
+    ``YaesuCatTransport`` instance. ``behavior`` selects one of the three
+    RMVR outcomes under test:
+
+    * ``"reject"`` -- every ``MD0{code};`` SET gets ``?;`` back, regardless
+      of the value, so the initial write AND the RMVR restore-write both
+      hit the same rejection.
+    * ``"ignore"`` -- a SET gets silence (the real accepted-write response,
+      bench-measured for MOR-2103) but the stored mode code never changes.
+    * ``"hang"`` -- any SET's ``drain()`` blocks until cancelled, so the
+      write leg itself times out at ``_guard``'s per-check timeout.
+      ``YaesuCatTransport._raw_write`` awaits the writer's ``drain()``
+      before ``_drain_responses`` ever runs and with no timeout of its own
+      -- unlike the post-write response read, which the transport bounds
+      with its own 30 ms drain window -- so a stalled writer genuinely
+      reaches ``_guard``'s per-check timeout on the write coroutine, not
+      only on a read.
+    """
+
+    def __init__(self, *, behavior: str, initial_code: str) -> None:
+        self.behavior = behavior
+        self.code = initial_code
+        self._last_write = b""
+        self.closed = False
+
+    # -- StreamWriter side ---------------------------------------------
+    def write(self, data: bytes) -> None:
+        self._last_write = data
+
+    async def drain(self) -> None:
+        if self.behavior == "hang" and self._last_write != b"MD0;":
+            await asyncio.sleep(30)  # cut off by _guard's per-check timeout
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+    # -- StreamReader side ---------------------------------------------
+    async def readuntil(self, separator: bytes) -> bytes:
+        cmd = self._last_write.decode("ascii")
+        if cmd == "MD0;":  # GET
+            return f"MD0{self.code};".encode("ascii")
+        if cmd.startswith("MD0") and cmd.endswith(";") and cmd != "MD0;":  # SET
+            if self.behavior == "reject":
+                return b"?;"
+            if self.behavior != "ignore":
+                self.code = cmd[3:-1]
+            raise asyncio.TimeoutError("accepted write: silence")
+        raise asyncio.TimeoutError(f"unscripted CAT frame: {cmd!r}")
+
+
+def _scripted_mode_radio(wire: _ScriptedModeWire) -> YaesuCatRadio:
+    radio = YaesuCatRadio("/dev/null", profile="ftx1")
+    radio._transport._connected = True
+    radio._transport._reader = wire
+    radio._transport._writer = wire
+    return radio
+
+
+async def test_mode_set_rejected_reports_outcome_and_frame():
+    """A Yaesu ``?;`` on the write surfaces as outcome=rejected, naming the
+    rejected frame in ``check.error`` -- not the old 'control did not react'
+    guess (MOR-2103)."""
+    wire = _ScriptedModeWire(behavior="reject", initial_code="1")  # LSB
+    radio = _scripted_mode_radio(wire)
+    check = await _run(radio, check_id="mode.set", capability="")
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["outcome"] == "rejected"
+    assert "MD02;" in check.error  # the rejected SET frame (LSB -> USB)
+
+
+async def test_mode_set_ignored_reports_outcome():
+    """A write that returns cleanly but never moves the readback is a
+    genuinely different diagnosis from a rejection (MOR-2103)."""
+    wire = _ScriptedModeWire(behavior="ignore", initial_code="1")  # LSB
+    radio = _scripted_mode_radio(wire)
+    check = await _run(radio, check_id="mode.set", capability="")
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["outcome"] == "ignored"
+    assert check.error == "control did not react: readback equals original"
+
+
+async def test_mode_set_timed_out_reports_outcome():
+    """A per-check ``_guard`` timeout on the write coroutine itself (a
+    stalled writer, MOR-2103) is the third, distinct outcome -- not the
+    transport's own 30 ms post-write drain silence, which is the healthy
+    accepted-write path."""
+    wire = _ScriptedModeWire(behavior="hang", initial_code="1")  # LSB
+    radio = _scripted_mode_radio(wire)
+    template = _single_entry_template(check_id="mode.set", capability="")
+    levels = await execute_hardware_checks(
+        radio,
+        template,
+        OperatorSafetyBlock(),
+        allow_writes=True,
+        per_check_timeout=0.05,
+    )
+    check = _flatten(levels)["mode.set"]
+    assert check.status is CheckStatus.FAIL
+    assert check.evidence["outcome"] == "timed_out"
+
+
+async def test_mode_set_local_value_error_is_not_rejected():
+    """A local encoder ``ValueError`` never reached the radio at all -- it
+    must not be labelled outcome=rejected (MOR-2103). Uses a
+    ``MagicMock(spec=Radio)`` directly, not the scripted wire: the failure
+    originates in the radio call itself, before any frame would be sent."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = set()
+    radio.get_mode = AsyncMock(return_value=("LSB", None))
+    radio.set_mode = AsyncMock(side_effect=ValueError("mode 'XYZ' out of range"))
+    check = await _run(radio, check_id="mode.set", capability="")
+    assert check.status is CheckStatus.FAIL
+    assert "outcome" not in check.evidence
+
+
+async def test_mode_set_readback_parse_error_is_not_rejected():
+    """The worst case: the SET was accepted and the radio answered
+    correctly -- a parse-template mismatch on the verify read is our own
+    bug, not a radio rejection (MOR-2103). A width mismatch like this is
+    the same class of defect MOR-2104 fixed for sql_type's write
+    template -- this scenario is its parse-template analogue, not the
+    same bug."""
+    radio = MagicMock(spec=Radio)
+    radio.connected = True
+    radio.model = "FTX-1"
+    radio.capabilities = set()
+    radio.get_mode = AsyncMock(
+        side_effect=[
+            ("LSB", None),  # original read
+            ValueError("Parse error for 'MD0{mode};' against 'MD;'"),  # verify read
+            ("LSB", None),  # restore read
+        ]
+    )
+    radio.set_mode = AsyncMock()  # both the changed-write and the restore succeed
+    check = await _run(radio, check_id="mode.set", capability="")
+    assert check.status is CheckStatus.FAIL
+    assert "outcome" not in check.evidence
+    assert check.evidence["restored"] is True


### PR DESCRIPTION
Closes MOR-2103.

A Yaesu radio answers `?;` to a CAT command it does not recognize. On the write
path that line was drained and discarded as ordinary post-write auto-info, so
the rejection never surfaced: the RMVR harness saw a clean write and an
unchanged readback, and reported "control did not react: readback equals
original" — sending an investigator to the radio, the mode and the band when the
radio had already named the problem over the wire.

The rejection is now surfaced structurally end to end — transport detects,
`YaesuCatRadio._write` translates to a new `CommandRejectedError(CommandError)`,
`_guard` classifies once into a new `RmvrOutcome`, and the RMVR functions read
that field rather than re-deriving a label from a message string or a boolean.

**The read path is deliberately not changed.** Translating `CatCommandRejected`
in `_query` looks like a one-line symmetry fix and is a transmit-safety
regression: `read_transmit_state` and `observations.py: _safe_read` both
pattern-match the raw transport type, and applying that change reddens
`test_no_failing_answer_ever_resolves_to_receiving[refusal-yaesu-ftx1]`
("silence, a refusal and an unmapped value all fail closed"). Verified by the
reviewer applying it, not by reading.

### Size: 8 files / 477 changed lines — past the 6-file soft threshold

One vertical slice, not several units of work: detect (transport) → translate
(radio) → the type (`core/exceptions`) → the vocabulary and its carrier
(`validation/schema`) → classify and publish (`validation/hardware`), plus the
three test files that pin each layer. The file count grew 5 → 7 → 8 entirely
through review-driven correction: `core/exceptions.py` and `schema.py` exist
because the first review round rejected a message-prefix match in favour of a
structural signal, and `tests/validation/test_hardware.py` exists because the
third round found the generic RMVR path — 44 of the 45 `RMVR_SAFE_WRITE` checks
— had no test of its own. Hard ceiling (10 / 1000) not approached.

### Known gap, out of scope

The read side still lets a `?;` escape `_guard` unclassified, and three
(site, leg, outcome) combinations are unpinned — a write-leg timeout at the
generic site, and two at the hand-copied `_check_mode_set`. None can produce a
*wrong* outcome; they lose a `timed_out` label on a check already reported FAIL
with error text. Follow-up ticket to be filed.
