### PR TITLE
refactor: one splitting rule for CI-V wire tuples

### DIFF
--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -266,6 +266,19 @@ _COMMANDS_WITH_SUB: set[int] = {
 }
 
 
+def command_carries_sub(command: int) -> bool:
+    """Whether *command*'s wire bytes include a CI-V sub-command byte.
+
+    The one place this question is answered: :func:`decode_wire_tuple`
+    (splitting a declared ``[commands]`` tuple) and :func:`parse_civ_frame`
+    (splitting a received frame's payload) both call this instead of each
+    keeping its own copy of :data:`_COMMANDS_WITH_SUB`, so a tuple split
+    for a request and a frame split for its reply agree on where the
+    sub-command byte is.
+    """
+    return command in _COMMANDS_WITH_SUB
+
+
 def build_civ_frame(
     to_addr: int,
     from_addr: int,
@@ -342,22 +355,29 @@ def build_cmd29_frame(
 def decode_wire_tuple(wire: tuple[int, ...]) -> tuple[int, int | None, bytes]:
     """Decode one ``[commands]`` wire tuple into ``(command, sub, prefix)``.
 
-    The single decoder named in
-    `docs/plans/2026-08-29-profile-driven-command-bytes.md` §2 ("Exactly one
-    decoder of a `[commands]` wire tuple into `(command, sub, prefix)`") and
-    used by Step 3 (§4) to build `commands/bound.py: BoundCommands.expect`
-    from the same map entry `_build_from_map` builds the request from.
+    The first element is the CI-V command. Whether the next element is a
+    sub-command byte is decided by :func:`command_carries_sub` -- the same
+    predicate :func:`parse_civ_frame` uses to split a received frame's
+    payload, so a reply parsed off the wire agrees with a tuple decoded
+    here on where the sub-command byte is. When the command does not carry
+    one, ``sub`` is ``None`` and that byte stays in ``prefix`` instead.
 
-    The first element is the CI-V command, the second (if present) is the
-    sub-command, and any remaining elements are the frame's further constant
-    bytes -- per the tuple contract ruled in Q7 (§8.1): a tuple holds every
-    constant byte of the frame, whether that is extended menu addressing
-    (e.g. 0x1A 0x05 0x00 0x64 for IC-7300 ACC1 mod level), a selector byte,
-    or a constant payload byte (e.g. 0x1C 0x00 0x01 for X6100 ptt_on).
+    Any remaining elements are the frame's further constant bytes -- per
+    the tuple contract ruled in Q7 (§8.1 of
+    `docs/plans/2026-08-29-profile-driven-command-bytes.md`): a tuple holds
+    every constant byte of the frame, whether that is extended menu
+    addressing (e.g. 0x1A 0x05 0x00 0x64 for IC-7300 ACC1 mod level), a
+    selector byte, or a constant payload byte (e.g. 0x1C 0x00 0x01 for
+    X6100 ptt_on).
     """
     command = wire[0]
-    sub = wire[1] if len(wire) > 1 else None
-    prefix = bytes(wire[2:])
+    rest = wire[1:]
+    if rest and command_carries_sub(command):
+        sub: int | None = rest[0]
+        prefix = bytes(rest[1:])
+    else:
+        sub = None
+        prefix = bytes(rest)
     return command, sub, prefix
 
 
@@ -491,7 +511,7 @@ def parse_civ_frame(data: bytes) -> CivFrame:
         real_command = payload[1]
         inner_payload = payload[2:]
         # Check if real command uses sub-commands
-        if real_command in _COMMANDS_WITH_SUB and len(inner_payload) >= 1:
+        if command_carries_sub(real_command) and len(inner_payload) >= 1:
             return CivFrame(
                 to_addr=to_addr,
                 from_addr=from_addr,
@@ -520,7 +540,7 @@ def parse_civ_frame(data: bytes) -> CivFrame:
         )
 
     # Determine if first payload byte is a sub-command
-    if command in _COMMANDS_WITH_SUB and len(payload) >= 1:
+    if command_carries_sub(command) and len(payload) >= 1:
         return CivFrame(
             to_addr=to_addr,
             from_addr=from_addr,

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -271,10 +271,9 @@ def command_carries_sub(command: int) -> bool:
 
     The one place this question is answered: :func:`decode_wire_tuple`
     (splitting a declared ``[commands]`` tuple) and :func:`parse_civ_frame`
-    (splitting a received frame's payload) both call this instead of each
-    keeping its own copy of :data:`_COMMANDS_WITH_SUB`, so a tuple split
-    for a request and a frame split for its reply agree on where the
-    sub-command byte is.
+    (splitting a received frame's payload) both call this, so a tuple
+    split for a request and a frame split for its reply agree on where
+    the sub-command byte is.
     """
     return command in _COMMANDS_WITH_SUB
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -4148,31 +4148,37 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         ``_get_bool_value``-style getter it cannot assume the value lands
         in ``frame.sub``: IC-7610's ``[0x07, 0xC2]`` is a VFO-select-family
         command, and ``0x07`` carries no CI-V sub-command per
-        `commands/_frame.py: _COMMANDS_WITH_SUB` (so
+        `commands/_frame.py: command_carries_sub` (so
         `runtime/_civ_rx.py`'s unsolicited-frame decoding, which shares
         that same parser, is unaffected) -- the query's marker byte is
-        echoed as ``data[0]`` instead. IC-9700's ``[0x16, 0x59]`` is a real
-        CI-V sub-command family (``0x16`` IS in that set), so its marker
-        lands in ``frame.sub`` normally. Handling both keeps this getter
-        correct across profiles rather than pinned to whichever shape the
-        request happened to use.
+        echoed as ``data[0]`` instead, and ``BoundCommands.expect`` puts
+        that same byte at the front of ``prefix`` (``sub=None``) rather
+        than in ``sub``. IC-9700's ``[0x16, 0x59]`` is a real CI-V
+        sub-command family (``0x16`` IS in that set), so its marker lands
+        in ``frame.sub`` normally and ``prefix`` is empty. Handling both
+        keeps this getter correct across profiles rather than pinned to
+        whichever shape the request happened to use. Resolves its shape
+        via ``BoundCommands.expect`` directly rather than
+        ``self._expect_shape``: that helper asserts a non-``None`` ``sub``,
+        which IC-7610's row legitimately does not have.
         """
         self._check_connected()
-        command, sub, prefix = self._expect_shape(get_dual_watch)
+        command, sub, prefix = self._commands.expect(get_dual_watch)
         civ = self._commands.get_dual_watch(to_addr=self._radio_addr)
         resp = await self._send_civ_expect(civ, label="get_dual_watch")
         if resp.command != command:
             return False
         if resp.sub is not None:
-            # e.g. IC-9700's [0x16, 0x59]: 0x16 IS in _COMMANDS_WITH_SUB, so
-            # parse_civ_frame already split the marker into .sub.
+            # e.g. IC-9700's [0x16, 0x59]: 0x16 IS in command_carries_sub,
+            # so parse_civ_frame already split the marker into .sub.
             if resp.sub != sub:
                 return False
             data = resp.data[len(prefix) :]
             return bool(data) and data[0] != 0x00
         # e.g. IC-7610's [0x07, 0xC2]: 0x07 carries no CI-V sub-command, so
-        # the marker is echoed as data[0] instead of landing in .sub.
-        if not resp.data or resp.data[0] != sub:
+        # the marker is echoed as data[0] instead of landing in .sub, and
+        # BoundCommands.expect put it at prefix[0] instead of sub.
+        if not prefix or not resp.data or resp.data[0] != prefix[0]:
             return False
         data = resp.data[1:]
         return bool(data) and data[0] != 0x00

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -256,28 +256,24 @@ async def test_get_dual_watch_reply_marker_comes_from_the_map(
 ) -> None:
     """Keystone case for ``get_dual_watch``, which cannot register in
     ``MATCHER_BACKED_GETTERS`` above: 0x07 carries no CI-V sub-command
-    (``_frame.py: _COMMANDS_WITH_SUB`` excludes it, unlike 0x1A/0x16 for
+    (``_frame.py: command_carries_sub`` excludes it, unlike 0x1A/0x16 for
     the getters above), so its reply marker is echoed in ``data[0]``
     rather than landing in ``.sub`` -- it cannot route through
     ``_get_bcd_level``/``_get_bool_value`` at all, and
     ``runtime/radio.py: CoreRadio.get_dual_watch`` handles both wire
-    shapes itself instead.
+    shapes itself instead, resolving its shape via
+    ``BoundCommands.expect`` directly rather than ``self._expect_shape``
+    (which asserts a non-``None`` ``sub``, wrong for IC-7610's row).
 
     Proven against two profiles whose ``get_dual_watch`` commands are
-    wire-incompatible -- IC-7610's ``[0x07, 0xC2]`` (marker in data[0])
-    and IC-9700's ``[0x16, 0x59]`` (marker in .sub, since 0x16 IS in
-    ``_COMMANDS_WITH_SUB``) -- so a marker hardcoded to either family's
-    byte answers the OTHER family's reply wrongly regardless of the
-    actual on/off value: exactly the "requests moved, replies not"
-    failure mode this file exists to make impossible (plan §7).
-
-    Manually confirmed red for the half-done shape: reverting
-    ``get_dual_watch`` to its pre-migration check (literal
-    ``resp.data[0] == 0xC2``, ignoring ``resp.sub``/the map) makes
-    ``test_ic9700`` below fail -- IC-9700's real reply is
-    ``command=0x16, sub=0x59, data=[value]``, which never contains
-    ``0xC2`` anywhere, so the reverted check would always return
-    ``False`` regardless of the actual toggle state.
+    wire-incompatible -- IC-7610's ``[0x07, 0xC2]`` (marker in data[0],
+    ``sub=None``, so ``BoundCommands.expect`` puts the marker byte at
+    ``prefix[0]`` instead) and IC-9700's ``[0x16, 0x59]`` (marker in
+    .sub, since 0x16 IS in ``command_carries_sub``) -- so a marker
+    hardcoded to either family's byte answers the OTHER family's reply
+    wrongly regardless of the actual on/off value: exactly the "requests
+    moved, replies not" failure mode this file exists to make impossible
+    (plan §7).
     """
 
     async def _get_dual_watch_answering(radio: CoreRadio, frame) -> bool:
@@ -291,7 +287,7 @@ async def test_get_dual_watch_reply_marker_comes_from_the_map(
     # IC-7610: [0x07, 0xC2] -- 0x07 has no CI-V sub-command, marker in data[0].
     ic7610 = _civ_rig_configs()["IC-7610"].to_profile()
     command, sub, prefix = decode_wire_tuple(ic7610.command_map.get("get_dual_watch"))
-    assert (command, sub, prefix) == (0x07, 0xC2, b"")
+    assert (command, sub, prefix) == (0x07, None, b"\xc2")
     radio_7610 = CoreRadio("198.51.100.1", profile=ic7610)
 
     on_reply = CivFrame(
@@ -311,7 +307,7 @@ async def test_get_dual_watch_reply_marker_comes_from_the_map(
     )
     assert await _get_dual_watch_answering(radio_7610, wrong_marker) is False
 
-    # IC-9700: [0x16, 0x59] -- 0x16 IS in _COMMANDS_WITH_SUB, marker in .sub.
+    # IC-9700: [0x16, 0x59] -- 0x16 IS in command_carries_sub, marker in .sub.
     ic9700 = _civ_rig_configs()["IC-9700"].to_profile()
     command9700, sub9700, prefix9700 = decode_wire_tuple(
         ic9700.command_map.get("get_dual_watch")

--- a/tests/test_response_shape_from_profile.py
+++ b/tests/test_response_shape_from_profile.py
@@ -108,7 +108,7 @@ MATCHER_BACKED_GETTERS: tuple[_GetterSpec, ...] = (
     _GetterSpec("get_vox_delay", "_get_bcd_level"),
     # commands/vfo.py's matcher-backed getters (MOR-2007 Steps 5..N,
     # module 3). get_dual_watch is NOT included: 0x07 carries no CI-V
-    # sub-command (_frame.py: _COMMANDS_WITH_SUB excludes it, unlike
+    # sub-command (_frame.py: command_carries_sub excludes it, unlike
     # 0x1A here), so its reply marker lands in data[0] rather than
     # .sub -- it cannot route through _get_bcd_level/_get_bool_value at
     # all, and is instead pinned directly by

--- a/tests/test_wire_tuple_splitting.py
+++ b/tests/test_wire_tuple_splitting.py
@@ -9,9 +9,7 @@ in ``.data`` otherwise. The two disagreed for every declared row with two
 or more elements whose first byte is outside that set -- measured here
 (at ``df7b1788``) as 51 of 1161 declared rows across the six CI-V
 profiles (16 distinct names). This count moves as ``rigs/*.toml`` gains
-or loses rows; what stays fixed is which 16 names disagree, since that
-depends only on each name's first wire byte, not on how many other rows
-exist.
+or loses rows.
 
 Both functions now go through the single predicate
 ``command_carries_sub``, this file pins two properties of that fix:
@@ -64,9 +62,11 @@ def _build_frame_via(
     decoder: Callable[[tuple[int, ...]], tuple[int, int | None, bytes]],
     wire: tuple[int, ...],
 ) -> bytes:
-    """Mirror ``_build_from_map``'s use of a decoder: prepend ``prefix`` to
-    (absent) caller data, then build the frame -- with no additional
-    caller-supplied data, matching every declared row's own GET/bare shape.
+    """Mirror ``_build_from_map``'s use of a decoder, with no caller-supplied
+    ``data``: builds a frame from just the decoded ``command``, ``sub`` and
+    ``prefix``. Many declared rows are SET commands never sent bare, so
+    this exercises each row's own constant bytes but not a caller-supplied
+    payload (e.g. a SET command's value).
     """
     command, sub, prefix = decoder(wire)
     data = prefix if prefix else None

--- a/tests/test_wire_tuple_splitting.py
+++ b/tests/test_wire_tuple_splitting.py
@@ -1,0 +1,131 @@
+"""One splitting rule for CI-V wire tuples.
+
+``commands/_frame.py`` used to have two independent rules for where a
+sub-command byte lives: ``decode_wire_tuple`` (splitting a declared
+``[commands]`` tuple) always treated ``wire[1]`` as ``sub`` positionally,
+while ``parse_civ_frame`` (splitting a received frame's payload) put the
+byte in ``.sub`` only for a command in ``_COMMANDS_WITH_SUB`` and left it
+in ``.data`` otherwise. The two disagreed for every declared row with two
+or more elements whose first byte is outside that set -- measured here
+(at ``df7b1788``) as 51 of 1161 declared rows across the six CI-V
+profiles (16 distinct names). This count moves as ``rigs/*.toml`` gains
+or loses rows; what stays fixed is which 16 names disagree, since that
+depends only on each name's first wire byte, not on how many other rows
+exist.
+
+Both functions now go through the single predicate
+``command_carries_sub``, this file pins two properties of that fix:
+
+- ``decode_wire_tuple(wire)`` agrees with what ``parse_civ_frame`` assigns
+  to a frame built from that same wire, for every declared row on every
+  shipped CI-V profile (``test_decode_wire_tuple_matches_parse_civ_frame``
+  below -- this is also this change's red-proof: reverting
+  ``decode_wire_tuple`` to its pre-fix positional rule makes this test
+  fail on exactly the 51 rows enumerated above, and pass everywhere else).
+- moving a byte from ``sub`` to the front of ``prefix`` (or back) changes
+  nothing about the bytes ``_build_from_map`` puts on the wire, for every
+  declared row (``test_wire_tuple_split_is_byte_neutral`` below).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from collections.abc import Callable
+
+import pytest
+
+from rigplane.commands._frame import (
+    build_civ_frame,
+    decode_wire_tuple,
+    parse_civ_frame,
+)
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from test_profile_command_binding import _civ_rig_configs  # noqa: E402
+
+_TO_ADDR = 0xE0
+_FROM_ADDR = 0x94
+
+
+def _old_decode_wire_tuple(wire: tuple[int, ...]) -> tuple[int, int | None, bytes]:
+    """The pre-fix rule: ``wire[1]`` is ``sub`` positionally, regardless of
+    ``command_carries_sub``. Kept only to compute the "before" bytes for
+    ``test_wire_tuple_split_is_byte_neutral`` -- ``decode_wire_tuple``
+    itself no longer behaves this way.
+    """
+    command = wire[0]
+    sub = wire[1] if len(wire) > 1 else None
+    prefix = bytes(wire[2:])
+    return command, sub, prefix
+
+
+def _build_frame_via(
+    decoder: Callable[[tuple[int, ...]], tuple[int, int | None, bytes]],
+    wire: tuple[int, ...],
+) -> bytes:
+    """Mirror ``_build_from_map``'s use of a decoder: prepend ``prefix`` to
+    (absent) caller data, then build the frame -- with no additional
+    caller-supplied data, matching every declared row's own GET/bare shape.
+    """
+    command, sub, prefix = decoder(wire)
+    data = prefix if prefix else None
+    return build_civ_frame(_TO_ADDR, _FROM_ADDR, command, sub=sub, data=data)
+
+
+def _all_declared_rows() -> list[tuple[str, str, tuple[int, ...]]]:
+    rows: list[tuple[str, str, tuple[int, ...]]] = []
+    for model in sorted(_civ_rig_configs()):
+        cmd_map = _civ_rig_configs()[model].to_profile().command_map
+        assert cmd_map is not None, f"{model}: to_profile() produced no command_map"
+        for name in cmd_map:
+            rows.append((model, name, cmd_map.get(name)))
+    return rows
+
+
+_ROWS = _all_declared_rows()
+
+
+def _row_id(row: tuple[str, str, tuple[int, ...]]) -> str:
+    model, name, _wire = row
+    return f"{model}-{name}"
+
+
+@pytest.mark.parametrize("row", _ROWS, ids=[_row_id(r) for r in _ROWS])
+def test_decode_wire_tuple_matches_parse_civ_frame(
+    row: tuple[str, str, tuple[int, ...]],
+) -> None:
+    """``decode_wire_tuple(wire)`` and ``parse_civ_frame`` of a frame built
+    from that wire assign the same ``(command, sub)`` -- for every
+    declared row on every shipped CI-V profile, not just the 51 rows
+    known to have disagreed before this fix.
+    """
+    _model, _name, wire = row
+    command, sub, prefix = decode_wire_tuple(wire)
+
+    frame_bytes = build_civ_frame(
+        _TO_ADDR, _FROM_ADDR, command, sub=sub, data=prefix if prefix else None
+    )
+    parsed = parse_civ_frame(frame_bytes)
+
+    assert (parsed.command, parsed.sub) == (command, sub)
+    assert parsed.data == prefix
+
+
+@pytest.mark.parametrize("row", _ROWS, ids=[_row_id(r) for r in _ROWS])
+def test_wire_tuple_split_is_byte_neutral(
+    row: tuple[str, str, tuple[int, ...]],
+) -> None:
+    """Moving a byte between ``sub`` and the front of ``prefix`` must not
+    change the bytes ``_build_from_map`` puts on the wire, for every
+    declared row -- not just the 51 whose split actually changed.
+
+    The "before" bytes are computed here from ``_old_decode_wire_tuple``
+    (the pre-fix positional rule), not read from a recorded fixture, so
+    this test measures the fix's effect directly rather than trusting a
+    stored expectation.
+    """
+    _model, _name, wire = row
+    before = _build_frame_via(_old_decode_wire_tuple, wire)
+    after = _build_frame_via(decode_wire_tuple, wire)
+    assert before == after


### PR DESCRIPTION
## Problem

`commands/_frame.py` held **two** functions that split CI-V bytes and disagreed with each other:

- `decode_wire_tuple(wire)` split a **declared** `[commands]` tuple positionally — `sub = wire[1] if len(wire) > 1 else None`.
- `parse_civ_frame(data)` split a **received** frame by membership in the module-private `_COMMANDS_WITH_SUB`.

For any command outside that set they gave different answers about the same bytes: one called the second element `sub`, the other left it in `data[0]`. **51 of 1161 declared rows disagreed** at `df7b1788` (1160 rows at `c2f8ddab`; the count moves with the profiles, the 51/16 split does not), across 16 distinct names in the **six** CI-V profiles — `ftx1.toml` and `tx500.toml` contribute zero rows because `RigConfig.to_command_map` drops CAT specs.

`decode_wire_tuple`'s own docstring called itself "the single decoder", citing a merged plan that says so.

The cost was already being paid: `CoreRadio.get_dual_watch` branches on both shapes at runtime and documents why. One local workaround for a rule that should exist once.

## Change

`command_carries_sub(command)` in `commands/_frame.py` is now the one place that question is answered; both functions call it. `decode_wire_tuple` returns `sub=None` and moves the byte to the front of `prefix` when the command carries no sub-command, matching what `parse_civ_frame` will present for the reply.

`get_dual_watch` — the only caller in the tree whose declared row is in the disagreeing class — resolves its shape through `BoundCommands.expect` directly and compares the marker against `prefix[0]`. Its existing dual-shape workaround is left in place; removing it is a separate behaviour question.

`_expect_shape`, its assertion, `_get_bcd_level`, `_get_bool_value` and the parse helpers are **untouched**. An earlier, wider version widened all of them and was reverted: it reached `_scope_runtime.py` and `commands/scope.py` — owned by other sessions — and 60 more call sites, for no behavioural gain.

## Why it is safe

**Byte-neutral on the wire.** `_build_from_map` prepends `prefix` to `data`, so moving a byte from `sub` to the head of `prefix` emits identical frames. Verified over three independently enumerated spaces:

- `_build_from_map`: 1161 rows × 5 `data` values × `command29` ∈ {F,T} × `receiver` ∈ {0,1} = **23,220 points, identical**
- every public `commands` builder through `BoundCommands`, all six CI-V profiles — **1,494 points, identical**
- `web/radio_poller.py: RadioPoller._send_cmd` (a third consumer the change does not touch): call *shape* moves for 306 of 6,966 points, **flattened wire identical at all of them**; `supports_cmd29` gives the same answer for every row

**`get_dual_watch` behaviour.** 275-point diff of the reply space, executed at both commits. 9 points differ, and all 9 are unreachable through `parse_civ_frame` — the only producer of `CivFrame` in `src/`: a `0x07` frame can never carry a non-`None` `.sub`, and a `0x16` frame with a payload can never carry `.sub is None`. Identical on every reply the parser can produce.

**Exactly one call site needed to change.** AST enumeration of all 74 `_expect_shape` sites (58 `runtime/radio.py`, 16 `runtime/_scope_runtime.py`), each argument resolved against all six profiles: one row outside `command_carries_sub`. The class was swept too — zero call sites with a length-1 row, so no latent sibling remains.

## Red-proof

`tests/test_wire_tuple_splitting.py::test_decode_wire_tuple_matches_parse_civ_frame`, with `decode_wire_tuple` mutated back to the positional rule:

```
51 failed, 2271 passed in 0.82s
E   assert (7, None) == (7, 194)
```

The failing node ids were extracted and diffed against the 51 rows derived independently from `_COMMANDS_WITH_SUB` — **identical sets**. The byte-neutrality test reddens on a different mutation (1310 rows) and stays green under a semantics-preserving rewrite, so neither test is hollow.

## Verification

Independent adversarial review, `Agent Review: PASS`, findings carried from `b8bad424` and re-confirmed for the prose delta at `b0e0e758`. The delta was verified prose-only by stripping docstrings and comparing ASTs, with a control proving the comparison can see an executable change.

Remote testbed, `tests/integration` excluded: **14069 passed, 0 failed, 160 skipped, 48 xfailed** against baseline 11747 / 0 / 160 / 48 — the +2322 is exactly this branch's new test file, skips and xfails identical to the unit. `ruff`, `lint-imports`, `mypy --strict src/rigplane/web` clean; `mypy src/rigplane/commands/ src/rigplane/runtime/` byte-identical to base at 23 errors.

## Scope

4 files, 4 → 5 with the prose commit. Nothing in `runtime/_scope_runtime.py`, `commands/scope.py`, `profiles/`, `rigs/`, or `validation/`. Inside the 6-file / 600-line soft threshold.

This is a prerequisite for the reverse command index (Step Z2): an index that groups declared tuples by the wrong splitter misgroups those 51 rows silently, and the splitting rule was unreachable outside `_frame.py` until now.

## Follow-up, not in this change

`_COMMANDS_WITH_SUB` remains module-private and now has one public question in front of it. Whether the set itself should move is a separate decision.
