### PR TITLE
fix: cite or correct five IC-7300 profile rows

### DIFF
--- a/docs/validation/cat-audits/ic7300.md
+++ b/docs/validation/cat-audits/ic7300.md
@@ -9,7 +9,7 @@ Protocol: Icom CI-V, `FE FE 94 E0 … FD`, transceiver address **0x94**. Default
 
 ### IC-7300 vs IC-7610 divergence (7300-specific)
 - **Single receiver** — no dual-watch, no MAIN/SUB band select, no `0x29` (cmd29). Scope is `27 12`=Main-only, `27 13`=Single-only.
-- **Single antenna + ATU** — `0x12` is a 1-of-1 selector; **no RX antenna**, no ANT1/ANT2 (profile `has_rx_ant=false`, `tx_count=1`).
+- **Single antenna + ATU, no antenna-select command** — no `0x12` row in the IC-7300 Advanced Manual (11a) command table pp.19-3..19-8, no ANT1/ANT2 selection documented; bench 2026-09-01 NAK'd `12 00`/`12`/`12 01`, with `03` answering DATA before and after (`get_antenna`/`set_antenna` declared absent). **No RX antenna**, no ANT1/ANT2 (profile `has_rx_ant=false`, `tx_count=1`).
 - **APF is a plain ON/OFF toggle** (`16 32`, 0/1) — *not* the IC-7610 WIDE/MID/NAR 3-level. Profile maps `audio_peak_filter`→`16 32`; the 3-level `apf_type_level`→`14 05` is flagged `NOT_IMPLEMENTED` in-profile.
 - **2 preamp levels** (`16 02`: 0/1/2), no DIGI-SEL, no drive_gain, single DATA sub-mode.
 

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -967,6 +967,10 @@ get_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3:
 # pre-migration fallback resolved -- MOR-2007 ruling 1 split the setter key)
 set_dual_watch_off = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only" }
 set_dual_watch_on = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only" }
+# MOR-2117: the bare name dispatches to set_dual_watch_on/set_dual_watch_off
+# above, both already absent for the same reason -- without this row,
+# supports_command answered True for a name the profile otherwise denies.
+set_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only; dispatches to set_dual_watch_on/set_dual_watch_off, both declared absent above" }
 get_main_sub_band = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table has no 0xD2" }
 get_main_sub_tracking = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x16 family has no 0x5E" }
 set_main_sub_tracking = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x16 family has no 0x5E" }
@@ -988,8 +992,15 @@ get_digisel_shift = { absent = "IC-7300 Advanced Manual (11a) command table pp.1
 set_digisel_shift = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family has no 0x13" }
 
 # ── Antenna ──
-get_antenna = [0x12]                      # Single antenna
-set_antenna = [0x12]
+# MOR-2118: no 0x12 antenna-select command on this radio.
+# - Manual: IC-7300 Advanced Manual (11a) CI-V command table pp.19-3..19-8 --
+#   no 0x12 row (table runs 11* attenuator then 13 speech); no ANT1/ANT2/
+#   "antenna select" anywhere in the document; one physical [ANT] connector.
+# - Bench, 2026-09-01, remote testbed, /dev/cu.usbserial-143310 @115200, addr
+#   0x94: 12 00, 12, and 12 01 each NAK'd (fe fe e0 94 fa fd); 03 answered
+#   fe fe e0 94 03 00 80 23 07 00 fd (DATA) before and after.
+get_antenna = { absent = "IC-7300 Advanced Manual (11a) CI-V command table pp.19-3..19-8: no 0x12 row, no ANT1/ANT2 selection documented, one physical [ANT] connector; bench 2026-09-01 addr 0x94: 12 00/12/12 01 each NAK'd, 03 answered DATA before and after" }
+set_antenna = { absent = "IC-7300 Advanced Manual (11a) CI-V command table pp.19-3..19-8: no 0x12 row, no ANT1/ANT2 selection documented, one physical [ANT] connector; bench 2026-09-01 addr 0x94: 12 00/12/12 01 each NAK'd, 03 answered DATA before and after" }
 get_rx_antenna_ant2 = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no 0x16 0x53 row; single antenna jack" }
 set_rx_antenna_ant2 = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no 0x16 0x53 row; single antenna jack" }
 
@@ -1139,7 +1150,7 @@ scope_data_output = [0x27, 0x11]
 # (11a) command table p.19-7; live bench 2026-08-30 replied 27 12 00 (D2,
 # MOR-2014). Refutes the earlier "no scope_main_sub" note.
 get_scope_main_sub = [0x27, 0x12]         # source: IC-7300 Advanced Manual (11a) p.19-7 (fixed value 00 = Main only); live bench 2026-08-30 reply 27 12 00
-get_scope_single_dual = [0x27, 0x13]
+get_scope_single_dual = [0x27, 0x13]      # source: IC-7300 Advanced Manual (11a) p.19-7 (data column 00 = Single only); bench 2026-09-01: 27 13 -> fe fe e0 94 27 13 00 fd (27 12 -> fe fe e0 94 27 12 00 fd alongside it, 03 answering either side, 0x27 0x00 scope frames filtered out)
 get_scope_mode = [0x27, 0x14]
 get_scope_span = [0x27, 0x15]
 get_scope_edge = [0x27, 0x16]
@@ -1345,8 +1356,17 @@ get_data3_mod_input = { absent = "IC-7300 Advanced Manual (11a) command table p.
 set_data3_mod_input = { absent = "IC-7300 Advanced Manual (11a) command table p.19-5: DATA-input family has only 0066/0067, no DATA1/2/3 split" }
 get_civ_transceive = [0x1A, 0x05, 0x00, 0x71]
 set_civ_transceive = [0x1A, 0x05, 0x00, 0x71]
-get_civ_output_ant = [0x1A, 0x05, 0x00, 0x61]
-set_civ_output_ant = [0x1A, 0x05, 0x00, 0x61]
+# MOR-2118: measured 2026-09-01 14:39-14:41 UTC, remote testbed. Owner
+# toggled the front-panel "CI-V Output (for ANT)" setting OFF->ON between
+# two passes, changing nothing else:
+#   1A 05 00 61 -> 00     / 00        did NOT move
+#   1A 05 01 57 -> 00 14  / 00 14     unchanged (level-shaped, not a toggle)
+#   1A 05 00 73 -> 00     / 01        moved with the setting
+# Established: 0061 did not move with the setting; 0073 did. Not
+# established: that 0073 moves with *only* this setting -- one reported
+# operator change, not an isolation test.
+get_civ_output_ant = [0x1A, 0x05, 0x00, 0x73]
+set_civ_output_ant = [0x1A, 0x05, 0x00, 0x73]
 get_system_date = [0x1A, 0x05, 0x00, 0x94]
 set_system_date = [0x1A, 0x05, 0x00, 0x94]
 get_system_time = [0x1A, 0x05, 0x00, 0x95]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -685,7 +685,6 @@ values = [0x01, 0x02, 0x03, 0x12, 0x13, 0x22, 0x23]
 values = [0xD0, 0xD3]
 
 [antenna]
-# CI-V 0x12: single antenna, no RX antenna
 tx_count = 1
 has_rx_ant = false
 
@@ -1362,10 +1361,14 @@ set_civ_transceive = [0x1A, 0x05, 0x00, 0x71]
 #   1A 05 00 61 -> 00     / 00        did NOT move
 #   1A 05 01 57 -> 00 14  / 00 14     unchanged (level-shaped, not a toggle)
 #   1A 05 00 73 -> 00     / 01        moved with the setting
-# Established: 0061 did not move with the setting; 0073 did. Not
-# established: that 0073 moves with *only* this setting -- one reported
-# operator change, not an isolation test.
-get_civ_output_ant = [0x1A, 0x05, 0x00, 0x73]
+# The manual disagrees with itself on the address: p.19-5 assigns 1A 05
+# 0073 to "CI-V Output (for ANT) capability"; three notes on p.19-7 (under
+# 1C 00 and 1C 03) instead name 1A 05 0157 for the same setting, but p.19-6
+# assigns 0157 to "present number" (0001 to 9999), an unrelated counter --
+# the bench measurement above resolves the contradiction in favor of 0073.
+# Independent corroboration: docs/validation/cat-audits/ic7300.md (a
+# different manual extraction) also lists 1A 05 0073 for this setting.
+get_civ_output_ant = [0x1A, 0x05, 0x00, 0x73]  # source: IC-7300 Advanced Manual (11a) p.19-5
 set_civ_output_ant = [0x1A, 0x05, 0x00, 0x73]
 get_system_date = [0x1A, 0x05, 0x00, 0x94]
 set_system_date = [0x1A, 0x05, 0x00, 0x94]

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -442,9 +442,7 @@ class RadioProfile:
     tx_interlock_disposition_overrides: dict[
         TxInterlockCommandFamily, TxInterlockDisposition
     ] = field(default_factory=dict)
-    # Measured per-radio transmit policy (MOR-1912). Parsed and carried
-    # here; nothing reads it yet — the transmit-authority engine that will
-    # consume it lands in a later row of the same epic.
+    # Measured per-radio transmit policy (MOR-1912).
     tx_policy: TxPolicy = field(default_factory=TxPolicy)
 
     def supports_capability(self, capability: str) -> bool:

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -358,7 +358,10 @@ class TestCommandOverrides:
         assert cmdmap.get("get_scope_edge3_6mhz") == (0x1A, 0x05, 0x01, 0x20)
 
     def test_get_civ_output_ant(self, cmdmap):
-        assert cmdmap.get("get_civ_output_ant") == (0x1A, 0x05, 0x00, 0x61)
+        """MOR-2118: bench 2026-09-01 toggled front-panel "CI-V Output (for
+        ANT)" OFF->ON between two passes; 0073 moved with it, 0061 did not
+        (see rigs/ic7300.toml's own citation on this row)."""
+        assert cmdmap.get("get_civ_output_ant") == (0x1A, 0x05, 0x00, 0x73)
 
     def test_agc_time_constant(self, cmdmap):
         assert cmdmap.get("get_agc_time_constant") == (0x1A, 0x04)

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -359,8 +359,11 @@ class TestCommandOverrides:
 
     def test_get_civ_output_ant(self, cmdmap):
         """MOR-2118: bench 2026-09-01 toggled front-panel "CI-V Output (for
-        ANT)" OFF->ON between two passes; 0073 moved with it, 0061 did not
-        (see rigs/ic7300.toml's own citation on this row)."""
+        ANT)" OFF->ON between two passes; 0073 moved with it, 0061 did not.
+        The manual is internally inconsistent about the address (IC-7300
+        Advanced Manual (11a) p.19-5 names 0073; three notes on p.19-7 name
+        0157, which p.19-6 identifies as an unrelated counter) -- see
+        rigs/ic7300.toml's own citation on this row for the resolution."""
         assert cmdmap.get("get_civ_output_ant") == (0x1A, 0x05, 0x00, 0x73)
 
     def test_agc_time_constant(self, cmdmap):

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2781,16 +2781,23 @@ class TestIc7300DeclaresAbsentCommands:
     ``quick_dual_watch`` entry alongside the bare ``quick_split`` row it
     was declared next to (-1, back to 27 -- a different 27 than D2's, not
     the same set reverted), then MOR-2105 part 1 (2026-09-01) added
-    ``get_scope_rbw``/``set_scope_rbw`` (+2, to 29 -- the current count,
-    per ``len(_EXPECTED_ABSENT)``). Pinned by name, not just count, so a
-    future D2 pass on another command can't silently swap one of these for
-    a different one and still pass a bare-count check.
+    ``get_scope_rbw``/``set_scope_rbw`` (+2, to 29), then the same day
+    MOR-2118 added ``get_antenna``/``set_antenna`` (no 0x12 row on this
+    radio) and MOR-2117 added the bare ``set_dual_watch`` (dispatches to
+    the two split names above, already absent, but was itself in neither
+    list) (+3, to 32 -- the current count, per ``len(_EXPECTED_ABSENT)``).
+    Pinned by name, not just count, so a future D2 pass on another command
+    can't silently swap one of these for a different one and still pass a
+    bare-count check.
     """
 
     _EXPECTED_ABSENT = frozenset(
         {
             "get_af_mute",
             "set_af_mute",
+            # MOR-2118: no 0x12 antenna-select command on this radio.
+            "get_antenna",
+            "set_antenna",
             "get_apf_type_level",
             "set_apf_type_level",
             "get_data2_mod_input",
@@ -2804,11 +2811,13 @@ class TestIc7300DeclaresAbsentCommands:
             "get_drive_gain",
             "set_drive_gain",
             "get_dual_watch",
-            # set_dual_watch_off/set_dual_watch_on, not the bare
-            # set_dual_watch the pre-migration fallback used to resolve
-            # (MOR-2007 ruling 1 split the setter key).
             "set_dual_watch_off",
             "set_dual_watch_on",
+            # MOR-2117: bare "set_dual_watch" dispatches to the two split
+            # names above (MOR-2007 ruling 1 split the setter key), which
+            # were already absent -- the bare name itself was in neither
+            # list, so supports_command answered True for it.
+            "set_dual_watch",
             "get_lan_mod_level",
             "set_lan_mod_level",
             "get_main_sub_band",


### PR DESCRIPTION
## What this is

Five rows in `rigs/ic7300.toml` that made claims about the radio nobody had checked. Three were wrong, one was right but unevidenced, and one comment in `profiles/__init__.py` said the opposite of the code.

Each row carries how it was established. Where the evidence supports less than an identification, the row says what was measured rather than what it means.

## The rows

**`get_antenna` / `set_antenna` → declared absent.** Three independent directions agree: the IC-7300 Advanced Manual (11a) CI-V table pp.19-3..19-8 has no `0x12` row (it runs `11*` attenuator, then `13` speech), the document has zero occurrences of ANT1/ANT2/antenna-selection, and one physical `[ANT]` connector. On the bench, `12 00`, `12` and `12 01` each returned `fe fe e0 94 fa fd` — an active refusal, with `03` answering either side.

`git log -S` shows the row was written once in `70683b13` (#256, original profile creation) and never revisited, while its immediate neighbours got manual citations later in the MOR-2014 pass. The trailing `# Single antenna` comment is deleted, not reworded: it explained why the radio has one antenna, which made a wrong declaration look considered.

**`civ_output_ant` `[0x1A,0x05,0x00,0x61]` → `[0x1A,0x05,0x00,0x73]`.** The manual names the register on p.19-5: `1A 05 0073 | 00/01 | Send/read the CI-V Output (for ANT) capability`. It also contradicts itself — p.19-7's three notes under `1C 00`/`1C 03` name `1A 05 0157` for the same setting, while p.19-6 assigns `0157` to "present number (0001 to 9999)". The bench resolved it: across an owner front-panel toggle OFF→ON, `0073` moved `00`→`01`, `0157` read `00 14` unchanged, `0061` did not move. `docs/validation/cat-audits/ic7300.md` already listed `0073`, from a different extraction.

Not propagated to `ic705.toml` or `ic9700.toml`, which carry the same `0061`. Neither radio is on the bench and only the IC-7300 manual was read — copying one radio's evidence to another is how `0061` reached three profiles.

**bare `set_dual_watch` → declared absent.** `set_dual_watch_on`/`_off` were already absent citing the `0x07` table (`00`/`01`/`A0`/`B0` only); the bare name the dispatcher resolves was in neither list, so `supports_command` answered True for something the profile explicitly denies. Measured before and after: `True` → `False`.

**`get_scope_single_dual` — citation added, declaration unchanged.** It was a bare tuple beside a neighbour carrying a full citation. The bench confirms it: `27 13` → `fe fe e0 94 27 13 00 fd`. Correct all along, just unevidenced.

**`profiles/__init__.py` — "nothing reads it yet" deleted** above `tx_policy`. False: `backends/yaesu_cat/radio.py` reads it in `_interpret_ptt_token` and `read_transmit_state`. Deleted rather than narrowed — a narrowed version would be a fresh unverified claim about a set that moves.

Two stale claims asserting the opposite of the above are also removed: the `# CI-V 0x12:` comment in the `[antenna]` block, and `0x12` is a 1-of-1 selector in `docs/validation/cat-audits/ic7300.md` — the document a future implementer reads before touching antenna handling, and how `[0x12]` would get re-added.

## Verification

Independent adversarial review: `Agent Review: PASS`. First round returned BLOCKED on three prose findings, all cleared here. The reviewer read the manual pages itself rather than taking the citations, enumerated the complete `0x16` and `0x12` sub-command columns, and confirmed the corroborating document is byte-identical at the merge base rather than circular.

`_EXPECTED_ABSENT` 29 → 32, hand-maintained (no regen path), verified by loading the profile rather than counting the literal. The two regenerable baselines did not move, and that was proven able to say otherwise — corrupting them and re-running restored them, and deleting an unrelated command made the coverage baseline differ.

Mutation-tested per row: `0x73`→`0x61` fails `test_get_civ_output_ant`; `get_antenna`/`set_antenna` back to `[0x12]` fails both absent-list tests; dropping the bare `set_dual_watch` fails the absent-list test. Control: a legitimate reword of an `absent` reason string changes nothing.

Remote testbed, `tests/integration` excluded: **11765 passed, 0 failed, 161 skipped, 48 xfailed**. Both doc gates clean.

## Follow-ups, not in this change

- **`get_audio_peak_filter = [0x16, 0x32]` is wrong on the IC-7300.** Same shape as the antenna row — uncited, and the manual's `0x16` sub-command column has no `32`. Bench, this session: `16 32` → NAK, while `16 4F` (twin peak, documented) and `16 02` (preamp) both answer in the same family and `03` answers either side. The refusal is specific to the sub-command, not the family.
- `rigs/ic705.toml` has the same bare `set_dual_watch` gap this change closes for IC-7300. The IC-705 CI-V Reference Guide's `0x07` table is likewise `00`/`01`/`A0`/`B0` and the document never mentions dual watch, so the same fix applies — but on that radio's own evidence.
- The doc-citation baseline grandfathers `(document, citation)` **string** pairs and never opens the cited file, so a baselined `file:line` citation cannot go red when its target moves. At least two `rigs/ic7300.toml:N` citations in `docs/plans/2026-08-20-transmit-authority.md` already pointed at the wrong content before this branch.
