### PR TITLE
docs: correct three claims falsified by today's merges

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -136,7 +136,7 @@ rigplane now uses a **shared-core backend-neutral architecture**. Consumers (CLI
 3. **Backend Adapters** — thin adapters for LAN (UDP) and serial (USB CI-V + audio)
 4. **Shared Core** — `CoreRadio` with commander, state, CI-V routing, scope assembly
 5. **Transports** — LAN uses UDP sockets, serial uses `SerialCivLink` + `UsbAudioDriver`
-6. **USB Audio Resolver** — `usb_audio_resolve.py` maps a serial port to the correct `sounddevice` indices via macOS IORegistry topology (used by `UsbAudioDriver` when `serial_port` is provided)
+6. **USB Audio Resolver** — `src/rigplane/audio/_usb_resolve.py` maps a serial port to the correct `sounddevice` indices via macOS IORegistry topology (used by `UsbAudioDriver` when `serial_port` is provided)
 
 ### Backend-Neutral Boundary
 
@@ -170,13 +170,13 @@ See [IC-7610 USB Serial Backend Setup Guide](../guide/ic7610-usb-setup.md) for d
 
 When multiple Icom radios are connected via USB simultaneously (e.g. IC-7300 + IC-7610), each exposes an identically named "USB Audio CODEC" device. The library cannot determine which audio device belongs to which radio by name alone.
 
-**`usb_audio_resolve.py`** solves this by correlating USB hub topology:
+**`src/rigplane/audio/_usb_resolve.py`** solves this by correlating USB hub topology:
 
 ```
 Serial port path  →  TTY suffix  →  IORegistry locationID
                                                                        │
 USB Audio CODEC entries in IORegistry  →  longest shared locationID   │
-                                          nibble prefix wins           │
+                                          component prefix wins        │
                                                                        ▼
                                           sounddevice index lookup  (by product-name identity)
                                                                        │
@@ -184,7 +184,7 @@ USB Audio CODEC entries in IORegistry  →  longest shared locationID   │
                                           AudioDeviceMapping(rx_device_index, tx_device_index)
 ```
 
-- **macOS**: Full support via `/usr/sbin/ioreg -l`. Zero external deps.
+- **macOS**: Full support via `/usr/sbin/ioreg -l`. Zero external deps. The candidate audio device sharing the longest common `locationID` component prefix with the serial port wins (`_common_location_prefix_score`): the top byte (bits 31-24, the USB controller) is compared as one whole unit, then each remaining hex digit individually, most-significant first (`_location_id_components`) — not a uniform nibble-by-nibble scan of the full 32 bits.
 - **Linux**: Implemented via sysfs USB-topology traversal (`_resolve_linux`): the serial port and each ALSA card are resolved to their USB device node, and the card sharing the longest common USB-device path prefix (`_common_usb_path_score`) wins, with `idVendor`/`idProduct` as a tie-break. Exercised by unit tests against a fixture sysfs tree.
 - **Windows**: Implemented via USB PnP topology (`_resolve_windows`): the serial COM port and audio endpoint are matched by their shared parent composite-device instance path, with VID:PID as a fallback. Unit-tested via an injected PnP query; the real PowerShell/WMI enumeration (`_query_windows_pnp_devices`) is, per its own docstring, unvalidated against real Windows hardware.
 

--- a/docs/validation/cat-audits/ftx1.md
+++ b/docs/validation/cat-audits/ftx1.md
@@ -74,7 +74,7 @@ material:
 | B — validation coverage | BI break-in and PR/PL compressor on/off still lack the requested RMVR rows. The `sql_type.set` RMVR now exists, so its remaining failure is routed separately rather than counted as a missing row. | MOR-673 — Backlog; MOR-696 — Backlog |
 | C — operator commands | `MX` MOX, `OS` repeater shift, and `TS` TX watch remain absent from the backend/profile surface. Documentation of `MX` or `TS` is not TX-test authorization. | MOR-675 — Backlog |
 | C — memory/keyer feature | The memory bank plus CW/voice message-keyer surface remains unimplemented. For `MC`, implementation must use the 2508-C receiver-qualified read `MCP1;` (`MC0;`/`MC1;`), not the 2507-B `MC;`. | MOR-676 — Backlog epic; decompose before implementation |
-| D — CAT mismatch | `sql_type.set` exists, but the profile retains an unconfirmed two-digit CT write while 2508-C documents one receiver digit plus one SQL-type digit. The recorded non-round-trip evidence is historical; current hardware acceptance is still required. | MOR-696 — Backlog |
+| D — CAT mismatch | `sql_type.set` exists, and `rigs/ftx1.toml`'s `set_sql_type` now writes the single SQL-type digit 2508-C documents (`CT0{type};`), corrected from a two-digit write by MOR-2104. The recorded non-round-trip evidence is historical; current hardware acceptance is still required. | MOR-696 — Backlog |
 | A — unsupported power | CAT power control must not imply a uniformly supported browser power control. | MOR-1673 |
 | A — capability-derived bands | Exposed bands must follow actual profile capability rather than a static front-end list. | MOR-1674 |
 | A — AF presentation | CAT AF-scale values require the agreed percent formatting. | MOR-1675 |

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -430,6 +430,20 @@ def get_scope_main_sub(
     )
 
 
+# scope_main_sub resolves "set_scope_main_sub", its own write key
+# (MOR-2106): the corrected shape. 12 other write builders in this file
+# (scope_single_dual, scope_set_mode, scope_set_span, scope_set_edge,
+# scope_set_hold, scope_set_ref, scope_set_speed, scope_set_during_tx,
+# scope_set_center_type, scope_set_vbw, scope_set_fixed_edge,
+# scope_set_rbw) still resolve their paired get_* key -- the known,
+# tracked defect (MOR-2113). The remaining 5 (scope_on, scope_off,
+# scope_data_output, scope_data_output_on, scope_data_output_off) are
+# NOT instances of that defect: no scope-capable profile (ic705,
+# ic7300, ic7610, ic9700) declares a get_*/set_*-prefixed variant of
+# scope_on/scope_off/scope_data_output at all, so each of the five
+# already resolves the only key its profile declares -- the same
+# "resolves its own declaration" shape MOR-2106 established as
+# correct.
 @expose_command_key(lambda cmd_map: "set_scope_main_sub")
 @require_cmd_map
 def scope_main_sub(

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1954,11 +1954,11 @@ def load_rig(path: Path) -> RigConfig:
     # registry (`validation/registry/_assembly.py: REGISTRY_BY_ID`) --
     # `rigplane.profiles` may not import `rigplane.validation`, per
     # `.importlinter`'s validation-leaf contract -- so that cross-check is
-    # a test (`tests/test_rig_loader.py::TestFixedValueChecks::
-    # test_ic7300_fixed_value_check_ids_are_real_registry_check_ids`), not a
-    # parameter here (F4, MOR-2105 part 2 owner ruling: an unused
-    # ``known_check_ids`` parameter with no production caller was an
-    # orphan).
+    # a test (`tests/test_rig_loader.py:
+    # test_every_shipped_profiles_fixed_value_check_ids_are_real_registry_
+    # check_ids`), not a parameter here (F4, MOR-2105 part 2 owner ruling:
+    # an unused ``known_check_ids`` parameter with no production caller was
+    # an orphan).
     fixed_value_raw = data.get("validation", {}).get("fixed_value", {})
     for check_id, source in fixed_value_raw.items():
         if not isinstance(source, str) or not source.strip():

--- a/tests/test_usb_audio_resolve.py
+++ b/tests/test_usb_audio_resolve.py
@@ -174,7 +174,7 @@ IOREG_FTX1_REAL_AND_ICOM = textwrap.dedent("""\
 
 # Two DIFFERENT radios (A, B) on sibling ports of one EXTERNAL USB hub
 # (0x14100000) — unlike the FTX-1's internal-hub siblings above, A and B
-# are separate physical radios. Pins why an adaptive longest-shared-nibble
+# are separate physical radios. Pins why an adaptive longest-shared-component
 # match is needed instead of any fixed-width shift: resolving radio B's
 # CAT port (0x14121000), a >>20 mask also matches radio A's audio device
 # (0x14114000) — a silent mis-route — while >>16 and the longest-prefix
@@ -527,8 +527,8 @@ class TestResolveFtx1RealTopology:
     """MOR-2107: the FTX-1's real IORegistry shape does not share an upper-16-bit
     hub prefix between its CAT bridge (0x0011) and its audio device (0x0012) —
     see IOREG_FTX1_REAL_TOPOLOGY. A fixed hub-prefix mask fails to resolve this;
-    the longest-shared-nibble-prefix match must still find the CAT port's own
-    audio device.
+    the longest-shared-component-prefix match must still find the CAT port's
+    own audio device.
     """
 
     def test_ftx1_alone_resolves_to_its_own_audio(self) -> None:
@@ -573,7 +573,7 @@ class TestResolveExternalHubDisambiguation:
     avoid mis-routing, as opposed to the FTX-1's own internal-hub CAT/audio
     pair. Resolving radio B's CAT port under a >>20 fixed mask also matches
     radio A's audio device (see IOREG_EXTERNAL_HUB_TWO_RADIOS); the
-    longest-shared-nibble-prefix scorer must not.
+    longest-shared-component-prefix scorer must not.
     """
 
     def test_radio_b_resolves_to_its_own_audio_not_radio_as(self) -> None:


### PR DESCRIPTION
A post-merge audit over today's five merged tickets found that three of them left behind, or introduced, a statement that is false against the code now on `main`. This corrects them. **Prose only — no behaviour change.**

| what was false | introduced by |
| -- | -- |
| `docs/internals/architecture.md` said the macOS audio matcher wins on the longest shared locationID **nibble** prefix. `_location_id_components` returns the top byte as one indivisible unit plus six nibbles — and that distinction is precisely what the same change made load-bearing (`0x00` vs `0x01` score 0 as bytes, 1 as nibbles). Three descriptions in `tests/test_usb_audio_resolve.py` said the same thing. | MOR-2107 |
| `docs/validation/cat-audits/ftx1.md` still described the profile as retaining an unconfirmed two-digit `CT` write — the thing that change removed. | MOR-2104 (left stale) |
| `src/rigplane/profiles/rig_loader.py` cited `TestFixedValueChecks::test_ic7300_fixed_value_check_ids_are_real_registry_check_ids`. The class exists; that method never did. | MOR-2105 |

Also: two citations in `architecture.md` named `usb_audio_resolve.py`, which is a re-export shim rather than where the implementation lives — retargeted to `src/rigplane/audio/_usb_resolve.py`. And `src/rigplane/commands/scope.py` gained a comment explaining why one builder of thirteen differs from its neighbours; before this, `MOR-2113` appeared nowhere in the tree, so the file could not explain its own asymmetry.

### One sentence deliberately left alone

The same cat-audit row says **"current hardware acceptance is still required"**, and that is **true**. What exists is a pre-fix, hand-driven capture of the frame; no post-fix run of the `sql_type.set` check through the harness exists anywhere. An earlier version of this task told the builder that acceptance was complete — that was wrong and was retracted before it was written. The sentence is byte-identical to `main`.

### Why this needed two review rounds

The first round found a **false claim inside the fix** — the comment said five builders share a command key with their getter, and `scope_off` shares with nothing. It also refuted the commit message's own evidence: `usb_audio_resolve.py` was said never to have existed at that path, established with `ls` plus `git log --all --diff-filter=A`. That pair is blind to renames, and the file arrived by one (`R056 src/icom_lan/usb_audio_resolve.py → …`). Both are fixed; the rationale now concedes the name is importable and justifies the retarget on implementation-vs-alias.

The second round did not accept the remaining claim on reading. It reproduced the refusal semantics through the real loader, mutating a scratch profile into a genuine `{ absent = … }` declaration: all five bare-key writes are refused when the profile refuses them, so they are not instances of the MOR-2113 defect. Control: the unmutated profile emits a frame.

### Behavioural inertness, measured

Base-vs-head ASTs with docstrings stripped are **identical** for all three `.py` files, each with a mutation control showing the comparison can report inequality.

### Follow-up, not in scope

4 of the 5 bare-key writers share a key with a *read* builder, so a profile can refuse those writes but cannot refuse them while keeping the read. That is a profile-schema expressiveness gap — fixed by adding keys to four profiles, not by changing a builder — and is not the defect MOR-2113 names.
