### PR TITLE
fix(MOR-2121): widen the CI-V GET timeout used by flaky test fixtures

### DIFF
--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -322,8 +322,21 @@ def mock_transport() -> MockTransport:
 def radio(mock_transport: MockTransport):
     """Shared radio fixture with explicit teardown to silence the
     ``Radio collected with active connection/tasks`` __del__ warning
-    from tests that bypass the real connect/disconnect lifecycle."""
-    r = IcomRadio("192.168.1.100", timeout=0.05, model="IC-7610")
+    from tests that bypass the real connect/disconnect lifecycle.
+
+    MOR-2121: ``timeout`` was ``0.05`` (giving ``_civ_get_timeout`` the
+    same 50ms), which raced real event-loop scheduling delay under
+    ``pytest -n auto`` on a loaded host -- a remote-testbed run caught
+    ``TestOperatorToggleParity::test_get_enum_operator_toggle[get_break_in]``
+    raising ``TimeoutError: CI-V response timed out`` from
+    ``_civ_rx.py:_execute_civ_raw``'s ``asyncio.wait_for(pending,
+    timeout=_civ_get_timeout)`` even though ``MockTransport.queue_response``
+    had already queued the answer before the call. ``2.0`` matches the
+    production default cap (``_civ_get_timeout = min(timeout, 2.0)`` in
+    ``runtime/radio.py``) and only widens the margin for a slow host --
+    every test here still resolves as soon as the queued response is
+    processed."""
+    r = IcomRadio("192.168.1.100", timeout=2.0, model="IC-7610")
     r._civ_transport = mock_transport
     r._ctrl_transport = mock_transport
     r._connected = True
@@ -3283,7 +3296,9 @@ class TestToneTsqlParity:
 
     @pytest.fixture
     def radio(self, mock_transport: MockTransport):
-        r = IcomRadio("192.168.1.104", timeout=0.05, model="IC-7300")
+        r = IcomRadio(
+            "192.168.1.104", timeout=2.0, model="IC-7300"
+        )  # MOR-2121: was 0.05, see radio() fixture above
         r._civ_transport = mock_transport
         r._ctrl_transport = mock_transport
         r._connected = True
@@ -3408,7 +3423,9 @@ class TestToneTsqlDualRxCmd29Guard:
 
     @pytest.fixture
     def ic9700_radio(self, mock_transport: MockTransport):
-        r = IcomRadio("192.168.1.102", timeout=0.05, model="IC-9700")
+        r = IcomRadio(
+            "192.168.1.102", timeout=2.0, model="IC-9700"
+        )  # MOR-2121: was 0.05, see radio() fixture above
         r._civ_transport = mock_transport
         r._ctrl_transport = mock_transport
         r._connected = True
@@ -3590,7 +3607,9 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
 
     @pytest.fixture
     def radio(self, mock_transport: MockTransport):
-        r = IcomRadio("192.168.1.104", timeout=0.05, model="IC-7300")
+        r = IcomRadio(
+            "192.168.1.104", timeout=2.0, model="IC-7300"
+        )  # MOR-2121: was 0.05, see radio() fixture above
         r._civ_transport = mock_transport
         r._ctrl_transport = mock_transport
         r._connected = True
@@ -3599,11 +3618,12 @@ class TestRepeaterToneDedupeKeyReceiverScoped:
 
     @pytest.fixture
     def ic9700_radio(self, mock_transport: MockTransport):
-        # Same shape as TestToneTsqlDualRxCmd29Guard.ic9700_radio above,
-        # including timeout=0.05. Whether a larger timeout would reduce
-        # this test's flake rate under -n auto is unmeasured and deferred
-        # -- not decided here.
-        r = IcomRadio("192.168.1.102", timeout=0.05, model="IC-9700")
+        # Same shape as TestToneTsqlDualRxCmd29Guard.ic9700_radio above.
+        # MOR-2121: was timeout=0.05 -- see radio() fixture above for the
+        # measured mechanism this was previously deferred pending.
+        r = IcomRadio(
+            "192.168.1.102", timeout=2.0, model="IC-9700"
+        )  # MOR-2121: was 0.05, see radio() fixture above
         r._civ_transport = mock_transport
         r._ctrl_transport = mock_transport
         r._connected = True
@@ -3699,7 +3719,9 @@ class TestRequireReceiverToneMethodsPin:
 
     @pytest.fixture
     def single_rx_radio(self, mock_transport: MockTransport):
-        r = IcomRadio("192.168.1.104", timeout=0.05, model="IC-7300")
+        r = IcomRadio(
+            "192.168.1.104", timeout=2.0, model="IC-7300"
+        )  # MOR-2121: was 0.05, see radio() fixture above
         r._civ_transport = mock_transport
         r._ctrl_transport = mock_transport
         r._connected = True

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3429,7 +3429,17 @@ class TestRadioPoller:
 
         poller.start()
         queue.put(SetBreakIn(1))
-        await asyncio.sleep(0.03)
+        # MOR-2121: a fixed ``asyncio.sleep(0.03)`` here raced the poller
+        # task's own scheduling under ``pytest -n auto`` on a loaded host --
+        # 30ms is not a guaranteed wall-clock budget for the task to run.
+        # Poll for the awaited call instead of assuming a fixed delay covers
+        # it (same idiom as ``TestHalfOpenWsReaper._wait_until`` above).
+        deadline = asyncio.get_running_loop().time() + 2.0
+        while (
+            radio.set_break_in.await_count == 0
+            and asyncio.get_running_loop().time() < deadline
+        ):
+            await asyncio.sleep(0.01)
         poller.stop()
 
         radio.set_break_in.assert_awaited_once_with(1)


### PR DESCRIPTION
Two tests failed intermittently on an unchanged tree under `pytest -n auto`, passing on re-run and passing serially. They turned out to have **two unrelated mechanisms**, not one.

## Mechanism 1 — a 50 ms wall-clock deadline

`tests/test_radio.py`, the module-level `radio` fixture and five class-local copies, build `IcomRadio(..., timeout=0.05, ...)`, so `_civ_get_timeout = min(0.05, 2.0)`. `_civ_rx.py: CivRuntime._execute_civ_raw` then awaits the response under `asyncio.wait_for(pending, timeout=_civ_get_timeout)`. `MockTransport` has already queued the correct answer before the call — but under `-n auto` on a contended host the event loop can take longer than 50 ms to be scheduled, so the wait times out legitimately.

Raised to `2.0`, matching the production cap, on the six GET-path fixtures **in that file**. The value only matters when something is already wrong, so no happy path changes.

## Mechanism 2 — a fixed sleep racing poller startup

`tests/test_web_server.py::TestRadioPoller::test_set_break_in_updates_radio_and_state` **never touches `MockTransport` at all** — it drives a `MagicMock` radio through `RadioPoller` and races `await asyncio.sleep(0.03)` against `RadioPoller._run()`s own background-task startup. Replaced with a bounded poll on the awaited call, matching the `TestHalfOpenWsReaper._wait_until` idiom already in the file.

## Why "one mechanism, two victims" was wrong

Both flaking tests happen to involve CI-V `0x16` operator toggles, and that looked like a shared cause. It is the base rate: `0x16` carries nearly all boolean and enum operator-toggle reads. The two failures resolve through disjoint code, and the web test emits no CI-V at all. MOR-2121 still carries the wrong framing and is being corrected.

## Verified in both directions

The independent review reproduced the mechanism rather than taking it, using a probe that delays delivery by construction:

- pre-change fixtures at 120 ms delivery delay: **14 failed**, same traceback and same test id
- post-change at 120 ms: **all pass**
- post-change at 2.5 s: **fails again** — the assertion still discriminates, only the threshold moved
- web test: fails at a 50 ms poller delay on the old code, passes on the new, **still fails at 3.0 s**
- no test got slower: `--durations=0` on both sides, 294 tests each, slowest 0.82 s vs 0.80 s

The deliberately-fast timeout sites were confirmed correctly left alone by control: `TestSetModeSelected0x26` + `TestGetFallbackToCache` + `TestGetFallbackCacheTTL`, 15 tests, all pass under the same delay — so none of them is a GET racing a queued response.

## The class is larger than this change

Deliberately not fixed here, and named rather than left silent. The same `timeout=0.05` shape is probe-verified exposed in `tests/test_mor1545_vfo_fallback_failure_paths.py`, `tests/test_per_receiver_vfo_roundtrip.py` and `tests/test_icom_receiver_tier.py` (11 failures under the probe), and present by grep in seven more files. `tests/test_web_server.py` retains **31 live `asyncio.sleep(0.03)` calls**, including `test_set_key_speed_updates_radio_and_state` — the immediate sibling of the fixed test, probe-verified still exposed.

Tracked as MOR-2132. Expanding this PR to cover them would put it far past the file guardrail.

## Scope

2 files, 56 changed lines, `tests/` only. `git diff origin/main...HEAD -- src/ docs/ rigs/` is empty.

Note the branch name says `mocktransport-flake` and the mechanism turned out **not** to be `MockTransport` — the commit subject and body carry the correct attribution, and `MockTransport` was ruled out by enumerating all ten fixture definitions (all function-scoped, fresh instance each) rather than by argument.