### PR TITLE
feat(MOR-2010): add a per-profile reverse command index for CI-V reply resolution

### DIFF
--- a/docs/plans/2026-09-01-reverse-command-index.md
+++ b/docs/plans/2026-09-01-reverse-command-index.md
@@ -40,7 +40,10 @@ re-derived rather than inherited from this ticket's 2026-08-29 numbers):
 Reverse lookup is not an inversion: at `(command, sub)` granularity — grouping
 by what `commands/_frame.py: parse_civ_frame` actually assigns to
 `frame.command`/`frame.sub` for each declared tuple, not a positional split of
-the tuple — the IC-7300 profile has 100 keys with 64 collisions (measured at
+the tuple. The current numeric counts are owned by
+`tests/reverse_command_index_census.txt`, which is the sole source of truth
+for that file's `(command, sub, prefix)` metric. A historical `(command, sub)`
+snapshot recorded 100 keys and 64 collisions for IC-7300 (measured at
 `bce3be1e`); on IC-705 and X6200 the tuple `1C 00` resolves to four names.
 
 ## 2. What the collision census actually showed
@@ -112,8 +115,9 @@ for an incoming frame is data-driven and conservative:
    a later consumer. The base index never infers direction from payload length
    and never gives a longer write-shaped prefix implicit priority.
 
-The index is constructed once per profile load; collision counts per profile
-are pinned by a census test so the numbers in this plan fail loudly when the
+The index is constructed once per profile load; the census test records the
+current counts in `tests/reverse_command_index_census.txt`. This plan does not
+duplicate those counts or claim that it independently fails loudly when the
 data moves.
 
 ### 4.2 Annotation vocabulary (TOML)

--- a/docs/plans/2026-09-01-reverse-command-index.md
+++ b/docs/plans/2026-09-01-reverse-command-index.md
@@ -1,6 +1,10 @@
 # Reverse command index and ingress decode rules (MOR-1993 → MOR-2010)
 
-Status: owner-ratified design, 2026-08-31/09-01. Companion to
+Status: owner-ratified programme boundaries, 2026-08-31/09-01. The original
+Z2 payload-length resolution hypothesis is retained below as superseded
+history and replaced by the conservative incoming-frame contract established
+by [PR #2941 exact-head review](https://github.com/rigplane/rigplane-core/pull/2941#issuecomment-5498902048).
+Companion to
 `docs/plans/2026-08-29-profile-driven-command-bytes.md` (the completed MOR-2000
 epic); this plan covers the reverse half that epic's §8.1 Q3 explicitly deferred.
 
@@ -41,28 +45,28 @@ the tuple — the IC-7300 profile has 100 keys with 64 collisions (measured at
 
 ## 2. What the collision census actually showed
 
-Programmatic inversion of all eight profiles, with every colliding key
-classified by what disambiguates it:
+The original census classified collisions by outbound request shape. Its
+resolution conclusion was wrong for incoming frames:
 
-- **(a) payload length** — the majority class. A `get_x`/`set_x` pair shares a
-  prefix; the read form has no payload, the write form carries one. The rule
-  "no payload = the read name" resolves it. This is *derivable from the
-  declared tuples*; no annotation needed.
-- **(b) payload value** — the on/off write pairs (`ptt_on`/`ptt_off`,
-  `power_on`/`power_off`, scope on/off) are distinct full tuples differing in
-  the trailing byte. Full-tuple matching resolves them; the class recurs
-  identically across unrelated families, confirming it is a CI-V-wide
-  convention, not a per-radio fact.
-- **(c) direction-only** — families that exist only as writes and never elicit
-  a reply (scan `0x0E`, CW keying `0x17`). Nothing derivable marks them; this
-  is the class that needs an *annotation*.
-- **(d) genuine residual** — exactly one: `set_transceiver_status` on
-  IC-705/X6200 is byte-identical to its get form and has no builder anywhere in
-  `src/`. Real ambiguity, no live consumer; annotated for honesty, decides
-  nothing.
+- **(a) shared getter/setter prefix** — the rejected hypothesis said payload
+  length selected the write form. An incoming getter reply also carries a
+  payload, so both declarations remain viable without request or direction
+  context. IC-7300 AF-level reply `14 01 01 28` is the keystone
+  counterexample.
+- **(b) literal on/off write prefixes** — the rejected hypothesis gave the
+  longer literal prefix priority. The same byte can be a value returned for a
+  shorter getter prefix, so all compatible prefixes remain viable. IC-9700
+  dual-watch replies `16 59 00` and `16 59 01` prove both shapes.
+- **(c) direction-only write families** — scan `0x0E` and CW keying `0x17`
+  require sourced protocol facts before a consumer can narrow candidates.
+- **(d) exact duplicate declarations** — byte-identical names remain
+  ambiguous until independently established context distinguishes them.
 
-Conclusion the owner ratified: the rule set is a property of the CI-V protocol,
-not of individual radios. There are no per-radio rule exceptions today.
+The superseding conclusion is narrower: per-profile command data determines
+which declarations are byte-compatible, but payload bytes alone do not
+determine request direction. The base index preserves every compatible
+candidate. A later consumer may narrow that set only with independently
+established request, direction, or sourced annotation context.
 
 ## 3. Owner rulings (2026-08-31, in-session; recorded on MOR-1993/MOR-2010)
 
@@ -81,6 +85,15 @@ not of individual radios. There are no per-radio rule exceptions today.
 4. The shared-ICOM-base-profile idea is filed separately (MOR-2088,
    unscheduled) and does not shape this design.
 
+### Superseding Z2 evidence (2026-09-01)
+
+The sequence and source-of-truth rulings above remain in force. The original
+payload-length/full-tuple priority algorithm did not survive adversarial review
+at PR #2941 head `5712e7a116d1a212a7e9de1e33210fbebea825b6`: valid getter
+replies were confidently labeled as writes. Z2 therefore uses the conservative
+contract below. This paragraph records the correction rather than silently
+rewriting the earlier decision as though it had never existed.
+
 ## 4. Design
 
 ### 4.1 Reverse index
@@ -88,21 +101,16 @@ not of individual radios. There are no per-radio rule exceptions today.
 Built by the rig loader beside `command_map`, exposed as a sibling field on the
 profile (the layer precedent: `RadioProfile.command_map`; `core/` is
 layer-illegal for profile-specific structures per `.importlinter`). Resolution
-order for an incoming frame, all steps data-driven. An annotation is a fact
-attached to its declared row, consulted at whichever step below examines that
-row — never a separate later step that a derivable rule can preempt with a
-confident wrong answer:
+for an incoming frame is data-driven and conservative:
 
-1. **Full-tuple match** — the frame's `(command, sub, leading payload)` against
-   declared tuples; a matching row's own annotation, if any, decides the
-   outcome directly (resolves class (b) pairs exactly as declared).
-2. **Prefix match** — for a `(command, sub)` prefix with no full-tuple match:
-   if the row(s) declared at that prefix carry an annotation (class (c)/(d)),
-   the annotation decides; otherwise the payload-length rule applies — no
-   payload beyond the declared prefix = the read name, payload present = the
-   write name (class (a)).
-3. **No match** — an explicit "unrecognized frame" outcome (never a silent
-   guess; mirrors the D1 unknown-command refusal philosophy).
+1. Select the current profile's bucket for `(command, sub)`.
+2. Keep every declared prefix in that bucket that is a byte-prefix of the
+   incoming `data`. Exact and shorter compatible prefixes have equal standing.
+3. One viable name resolves. Two or more names return the complete candidate
+   set. No viable name returns an explicit unrecognized result.
+4. Request/direction context or a sourced annotation may narrow candidates in
+   a later consumer. The base index never infers direction from payload length
+   and never gives a longer write-shaped prefix implicit priority.
 
 The index is constructed once per profile load; collision counts per profile
 are pinned by a census test so the numbers in this plan fail loudly when the
@@ -153,10 +161,10 @@ before EXECUTE).
   same method behind the 105 total), the 18 `_handle_XX` functions carry 23
   of them.
 - **Z2 — reverse index + census pins.** Loader builds the index; per-profile
-  collision censuses pinned; the full-tuple match and prefix + payload-length
-  rule implemented, with no annotation lookups yet (added in Z3). Unit
-  contract: every declared name round-trips (build → decode) on every
-  profile.
+  collision censuses are pinned. Every prefix-compatible declaration survives;
+  only a singleton resolves, while multiple candidates remain explicit until
+  later context can narrow them. Unit contract: independently derived incoming
+  probes return the complete viable candidate set on every CI-V profile.
 - **Z3 — annotation vocabulary.** Loader + validation (unknown = load error);
   `reply = "none"`/`"echo"` rows added to the profiles from the class (c)/(d)
   census (D2 discipline: each row's source is the recon classification, cited);
@@ -181,9 +189,9 @@ before EXECUTE).
   pattern from the epic applies unchanged.
 - The mirror deletion (Z1) is the riskiest single step: the equivalence
   evidence must enumerate mirror outputs, not sample them.
-- `1C 00` four-name collision: resolved by steps 1–2 of the resolution order
-  for the three live names; the fourth (`set_transceiver_status`) is class (d),
-  annotated, no consumer.
+- `1C 00` four-name collision: the bare transceiver-status declarations remain
+  viable beside matching `ptt_on`/`ptt_off` literal prefixes. A later consumer
+  needs request/direction or sourced annotation context before selecting one.
 - The two CAT radios (ftx1, tx500) are outside the CI-V index entirely; the
   Yaesu path already resolves parsers by name
   (`backends/yaesu_cat/radio.py: YaesuCatRadio._query`) — the property this

--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -42,6 +42,7 @@ from ._frame import (
     _SUB_SWR_METER,
     build_civ_frame,
     build_cmd29_frame,
+    command_carries_sub,
     parse_ack_nak,
     parse_civ_frame,
 )
@@ -451,6 +452,7 @@ __all__ = [
     "filter_index_to_hz",
     "table_index_to_hz",
     "hz_to_table_index",
+    "command_carries_sub",
     "parse_civ_frame",
     # TOML canonical names (primary)
     "get_freq",

--- a/src/rigplane/commands/command_map.py
+++ b/src/rigplane/commands/command_map.py
@@ -1,7 +1,7 @@
 """CommandMap — frozen lookup for CI-V wire bytes by command name.
 
 Also hosts :class:`ReverseCommandIndex`, the inverse of the map above:
-bytes off the wire to a declared command name (Z2 of
+bytes off the wire to compatible declared command names (Z2 of
 `docs/plans/2026-09-01-reverse-command-index.md`).
 
 **One index per profile, never a union across profiles.** Icom's top-level
@@ -88,19 +88,22 @@ class CommandMap:
 class ReverseLookupResult:
     """Outcome of :meth:`ReverseCommandIndex.resolve`.
 
-    Exactly one of two shapes: ``name`` set and ``candidates`` empty means
-    the frame resolved to exactly one declared command name; ``name`` is
-    ``None`` and ``candidates`` holds two or more names means the frame
-    matches a known ``(command, sub)`` and declared prefix but more than
-    one declared name shares it and nothing here can break the tie (the
-    class (c)/(d) collisions plan §2 describes -- a future annotation,
-    tracked as Z3, is what would decide these, not this step). Both empty
-    is CommandMap's own refuse-rather-than-guess posture applied to the
-    reverse direction: no declared row explains this frame at all.
+    Exactly one of three states is valid: ``name`` set with no candidates is
+    resolved; ``name`` unset with at least two candidates is ambiguous;
+    ``name`` unset with no candidates is unrecognized. Construction rejects
+    a singleton candidate set and any result carrying both shapes.
     """
 
     name: str | None = None
     candidates: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        candidates = frozenset(self.candidates)
+        object.__setattr__(self, "candidates", candidates)
+        if self.name is not None and candidates:
+            raise ValueError("a resolved result cannot also carry candidates")
+        if self.name is None and len(candidates) == 1:
+            raise ValueError("an ambiguous result requires at least two candidates")
 
     @property
     def resolved(self) -> bool:
@@ -108,7 +111,7 @@ class ReverseLookupResult:
 
     @property
     def ambiguous(self) -> bool:
-        return self.name is None and bool(self.candidates)
+        return self.name is None and len(self.candidates) >= 2
 
     @property
     def unrecognized(self) -> bool:
@@ -116,7 +119,7 @@ class ReverseLookupResult:
 
 
 class ReverseCommandIndex:
-    """Resolve an incoming ``(command, sub, data)`` frame to a declared name.
+    """Resolve an incoming ``(command, sub, data)`` frame to candidates.
 
     Built once per profile from that profile's own :class:`CommandMap`
     (module docstring: never a union across profiles). Every declared
@@ -145,12 +148,12 @@ class ReverseCommandIndex:
     __slots__ = ("_buckets",)
 
     def __init__(self, command_map: CommandMap) -> None:
-        raw: dict[tuple[int, int | None], dict[bytes, list[str]]] = {}
+        raw: dict[tuple[int, int | None], dict[bytes, set[str]]] = {}
         for name in command_map:
             command, sub, prefix = decode_wire_tuple(command_map.get(name))
-            raw.setdefault((command, sub), {}).setdefault(prefix, []).append(name)
-        self._buckets: dict[tuple[int, int | None], dict[bytes, tuple[str, ...]]] = {
-            key: {prefix: tuple(names) for prefix, names in group.items()}
+            raw.setdefault((command, sub), {}).setdefault(prefix, set()).add(name)
+        self._buckets: dict[tuple[int, int | None], dict[bytes, frozenset[str]]] = {
+            key: {prefix: frozenset(names) for prefix, names in group.items()}
             for key, group in raw.items()
         }
 
@@ -176,7 +179,7 @@ class ReverseCommandIndex:
     def resolve(
         self, command: int, sub: int | None, data: bytes
     ) -> ReverseLookupResult:
-        """Resolve one incoming frame's ``(command, sub, data)`` to a name."""
+        """Return the enforced candidate outcome for one incoming frame."""
         bucket = self._buckets.get((command, sub))
         if not bucket:
             return ReverseLookupResult()

--- a/src/rigplane/commands/command_map.py
+++ b/src/rigplane/commands/command_map.py
@@ -25,14 +25,6 @@ from ._frame import decode_wire_tuple
 
 __all__ = ["CommandMap", "ReverseCommandIndex", "ReverseLookupResult"]
 
-# Convention this index relies on to break a shared-prefix collision: every
-# read-form command name in this codebase is spelled ``get_<x>`` (see
-# `commands/__init__.py`'s exports). This is a fact about the profiles'
-# *declared names*, not a CI-V protocol byte -- the one signal available to
-# an index built purely from ``CommandMap`` contents, which never sees the
-# runtime payload a real ``set_<x>`` builder appends (MOR-1993 Z2 report).
-_READ_NAME_PREFIX = "get_"
-
 
 class CommandMap:
     """Immutable mapping from command names to CI-V wire byte tuples.
@@ -141,26 +133,13 @@ class ReverseCommandIndex:
     ``(command, sub)``-only index would collapse all of them into one
     bucket and could never name a single one back.
 
-    Resolution order, given an incoming frame's ``(command, sub, data)``:
-
-    1. Look up every declared prefix filed under this ``(command, sub)``
-       and keep the longest one that is a byte-prefix of ``data`` (an
-       *exact* length match, where ``data`` equals the declared prefix
-       with nothing left over, is the specific case of this that resolves
-       class (b) on/off pairs -- e.g. ``ptt_on``/``ptt_off`` -- directly,
-       since each declares its own complete, distinct prefix).
-    2. If nothing declared at this ``(command, sub)`` is a prefix of
-       ``data``, the frame is unrecognized.
-    3. If exactly one name declares the matched prefix, that name is the
-       answer, regardless of ``data``'s length past it.
-    4. If more than one name shares the matched prefix (class (a)/(c)/(d)):
-       partition that group by whether the name starts with ``get_`` --
-       the read-side names if ``data`` carries nothing past the declared
-       prefix, the write-side (everything else) names if it does not
-       ("no payload beyond the declared prefix = the read name, payload
-       present = the write name", plan §4.1 step 2). Whichever side
-       applies, a unique candidate resolves; two or more (or zero) is
-       reported ambiguous with that side's candidates -- never guessed.
+    Every declared prefix under the incoming ``(command, sub)`` that is a
+    byte-prefix of ``data`` remains viable. A single viable name resolves;
+    multiple names are returned as candidates; no viable name is
+    unrecognized. This deliberately retains both a shorter getter prefix and
+    a longer write prefix when the same incoming bytes can be either a getter
+    reply payload or an echoed write. Direction or request context can narrow
+    that set in a later consumer, but payload length alone cannot.
     """
 
     __slots__ = ("_buckets",)
@@ -202,24 +181,14 @@ class ReverseCommandIndex:
         if not bucket:
             return ReverseLookupResult()
 
-        longest: bytes | None = None
-        for prefix in bucket:
-            if data.startswith(prefix) and (
-                longest is None or len(prefix) > len(longest)
-            ):
-                longest = prefix
-        if longest is None:
+        candidates = frozenset(
+            name
+            for prefix, names in bucket.items()
+            if data.startswith(prefix)
+            for name in names
+        )
+        if not candidates:
             return ReverseLookupResult()
-
-        names = bucket[longest]
-        if len(names) == 1:
-            return ReverseLookupResult(name=names[0])
-
-        extra_present = len(data) > len(longest)
-        if extra_present:
-            candidates = [n for n in names if not n.startswith(_READ_NAME_PREFIX)]
-        else:
-            candidates = [n for n in names if n.startswith(_READ_NAME_PREFIX)]
         if len(candidates) == 1:
-            return ReverseLookupResult(name=candidates[0])
-        return ReverseLookupResult(candidates=frozenset(candidates))
+            return ReverseLookupResult(name=next(iter(candidates)))
+        return ReverseLookupResult(candidates=candidates)

--- a/src/rigplane/commands/command_map.py
+++ b/src/rigplane/commands/command_map.py
@@ -1,10 +1,37 @@
-"""CommandMap — frozen lookup for CI-V wire bytes by command name."""
+"""CommandMap — frozen lookup for CI-V wire bytes by command name.
+
+Also hosts :class:`ReverseCommandIndex`, the inverse of the map above:
+bytes off the wire to a declared command name (Z2 of
+`docs/plans/2026-09-01-reverse-command-index.md`).
+
+**One index per profile, never a union across profiles.** Icom's top-level
+opcodes (the CI-V command byte, e.g. 0x1A) are stable across the family,
+but the ``0x1A 0x05`` menu sub-address space is per-model: the identical
+wire prefix ``1A 05 01 12`` is ``get_scope_edge1_1p6mhz`` on IC-7300,
+``get_civ_transceive`` on IC-7610, and ``get_acc1_mod_level`` on IC-9700 --
+three different meanings, each independently sourced from its own radio's
+CI-V reference guide (verified by grepping ``rigs/ic7300.toml``,
+``rigs/ic7610.toml``, ``rigs/ic9700.toml`` for that exact byte tuple).
+Resolving a frame therefore requires knowing which radio sent it; nothing
+here ever merges two profiles' declared names into one lookup.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 
-__all__ = ["CommandMap"]
+from ._frame import decode_wire_tuple
+
+__all__ = ["CommandMap", "ReverseCommandIndex", "ReverseLookupResult"]
+
+# Convention this index relies on to break a shared-prefix collision: every
+# read-form command name in this codebase is spelled ``get_<x>`` (see
+# `commands/__init__.py`'s exports). This is a fact about the profiles'
+# *declared names*, not a CI-V protocol byte -- the one signal available to
+# an index built purely from ``CommandMap`` contents, which never sees the
+# runtime payload a real ``set_<x>`` builder appends (MOR-1993 Z2 report).
+_READ_NAME_PREFIX = "get_"
 
 
 class CommandMap:
@@ -63,3 +90,136 @@ class CommandMap:
 
     def __hash__(self) -> int:
         return hash(frozenset(self._commands.items()))
+
+
+@dataclass(frozen=True, slots=True)
+class ReverseLookupResult:
+    """Outcome of :meth:`ReverseCommandIndex.resolve`.
+
+    Exactly one of two shapes: ``name`` set and ``candidates`` empty means
+    the frame resolved to exactly one declared command name; ``name`` is
+    ``None`` and ``candidates`` holds two or more names means the frame
+    matches a known ``(command, sub)`` and declared prefix but more than
+    one declared name shares it and nothing here can break the tie (the
+    class (c)/(d) collisions plan §2 describes -- a future annotation,
+    tracked as Z3, is what would decide these, not this step). Both empty
+    is CommandMap's own refuse-rather-than-guess posture applied to the
+    reverse direction: no declared row explains this frame at all.
+    """
+
+    name: str | None = None
+    candidates: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def resolved(self) -> bool:
+        return self.name is not None
+
+    @property
+    def ambiguous(self) -> bool:
+        return self.name is None and bool(self.candidates)
+
+    @property
+    def unrecognized(self) -> bool:
+        return self.name is None and not self.candidates
+
+
+class ReverseCommandIndex:
+    """Resolve an incoming ``(command, sub, data)`` frame to a declared name.
+
+    Built once per profile from that profile's own :class:`CommandMap`
+    (module docstring: never a union across profiles). Every declared
+    name's wire tuple is decoded with :func:`commands._frame.decode_wire_tuple`
+    -- the same split :func:`commands._frame.parse_civ_frame` uses on a
+    received frame, via the shared :func:`commands._frame.command_carries_sub`
+    predicate, so a tuple grouped here and a frame handed to :meth:`resolve`
+    agree on where the sub-command byte ends and the constant prefix bytes
+    begin.
+
+    Names are grouped by their full ``(command, sub, prefix)`` key --
+    deliberately not collapsed to ``(command, sub)``: on IC-7300 alone the
+    ``0x1A 0x05`` menu family holds 84 distinct prefixes; a
+    ``(command, sub)``-only index would collapse all of them into one
+    bucket and could never name a single one back.
+
+    Resolution order, given an incoming frame's ``(command, sub, data)``:
+
+    1. Look up every declared prefix filed under this ``(command, sub)``
+       and keep the longest one that is a byte-prefix of ``data`` (an
+       *exact* length match, where ``data`` equals the declared prefix
+       with nothing left over, is the specific case of this that resolves
+       class (b) on/off pairs -- e.g. ``ptt_on``/``ptt_off`` -- directly,
+       since each declares its own complete, distinct prefix).
+    2. If nothing declared at this ``(command, sub)`` is a prefix of
+       ``data``, the frame is unrecognized.
+    3. If exactly one name declares the matched prefix, that name is the
+       answer, regardless of ``data``'s length past it.
+    4. If more than one name shares the matched prefix (class (a)/(c)/(d)):
+       partition that group by whether the name starts with ``get_`` --
+       the read-side names if ``data`` carries nothing past the declared
+       prefix, the write-side (everything else) names if it does not
+       ("no payload beyond the declared prefix = the read name, payload
+       present = the write name", plan §4.1 step 2). Whichever side
+       applies, a unique candidate resolves; two or more (or zero) is
+       reported ambiguous with that side's candidates -- never guessed.
+    """
+
+    __slots__ = ("_buckets",)
+
+    def __init__(self, command_map: CommandMap) -> None:
+        raw: dict[tuple[int, int | None], dict[bytes, list[str]]] = {}
+        for name in command_map:
+            command, sub, prefix = decode_wire_tuple(command_map.get(name))
+            raw.setdefault((command, sub), {}).setdefault(prefix, []).append(name)
+        self._buckets: dict[tuple[int, int | None], dict[bytes, tuple[str, ...]]] = {
+            key: {prefix: tuple(names) for prefix, names in group.items()}
+            for key, group in raw.items()
+        }
+
+    def __eq__(self, other: object) -> bool:
+        """Compare by contents -- the same MOR-2003 reason ``CommandMap.__eq__``
+        above gives: two instances built from the same profile twice (as
+        `tests/test_ftx1_control_domains.py:
+        test_ftx1_scalar_domains_are_exact_loader_published_capabilities`
+        does) must compare equal for ``RadioProfile``'s own field-by-field
+        equality sweep, not by identity.
+        """
+        if not isinstance(other, ReverseCommandIndex):
+            return NotImplemented
+        return self._buckets == other._buckets
+
+    def __hash__(self) -> int:
+        return hash(
+            frozenset(
+                (key, frozenset(group.items())) for key, group in self._buckets.items()
+            )
+        )
+
+    def resolve(
+        self, command: int, sub: int | None, data: bytes
+    ) -> ReverseLookupResult:
+        """Resolve one incoming frame's ``(command, sub, data)`` to a name."""
+        bucket = self._buckets.get((command, sub))
+        if not bucket:
+            return ReverseLookupResult()
+
+        longest: bytes | None = None
+        for prefix in bucket:
+            if data.startswith(prefix) and (
+                longest is None or len(prefix) > len(longest)
+            ):
+                longest = prefix
+        if longest is None:
+            return ReverseLookupResult()
+
+        names = bucket[longest]
+        if len(names) == 1:
+            return ReverseLookupResult(name=names[0])
+
+        extra_present = len(data) > len(longest)
+        if extra_present:
+            candidates = [n for n in names if not n.startswith(_READ_NAME_PREFIX)]
+        else:
+            candidates = [n for n in names if n.startswith(_READ_NAME_PREFIX)]
+        if len(candidates) == 1:
+            return ReverseLookupResult(name=candidates[0])
+        return ReverseLookupResult(candidates=frozenset(candidates))

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Never, NotRequired, Required, TypedDict
 
-from rigplane.commands.command_map import CommandMap
+from rigplane.commands.command_map import CommandMap, ReverseCommandIndex
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.tx_interlock_contract import (
     TxInterlockCommandFamily,
@@ -337,6 +337,16 @@ class RadioProfile:
     # treats both the same way: it binds an empty `CommandMap` rather than
     # raising.
     command_map: CommandMap | None = None
+    # Reverse of ``command_map`` above (MOR-1993 Z2, `docs/plans/
+    # 2026-09-01-reverse-command-index.md`): resolves an incoming
+    # ``(command, sub, data)`` frame back to a declared command name.
+    # ``None`` under the same rule as ``command_map`` -- a hand-built
+    # ``RadioProfile`` constructed outside ``profiles/rig_loader.py`` with
+    # no map supplied at all. Built from this profile's own
+    # ``command_map`` and only ever consulted for it -- never a union
+    # across profiles (`commands/command_map.py: ReverseCommandIndex`'s
+    # own module docstring has the per-radio-menu evidence for why).
+    reverse_index: ReverseCommandIndex | None = None
     filter_width_min: int = 50
     filter_width_max: int = 9999
     filter_width_encoding: str = "segmented_bcd_index"

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -30,7 +30,7 @@ from rigplane.core.tx_interlock_contract import (
     TxInterlockCommandFamily,
     TxInterlockDisposition,
 )
-from rigplane.commands.command_map import CommandMap
+from rigplane.commands.command_map import CommandMap, ReverseCommandIndex
 
 __all__ = [
     "RigConfig",
@@ -695,6 +695,8 @@ class RigConfig:
                 published_controls[name] = cast(ControlDomainSpec, published_domain)
             controls = published_controls
 
+        command_map = self.to_command_map()
+
         return RadioProfile(
             id=self.id,
             model=self.model,
@@ -729,7 +731,8 @@ class RigConfig:
                 for name, spec in self.commands.items()
                 if isinstance(spec, AbsentCommandSpec)
             },
-            command_map=self.to_command_map(),
+            command_map=command_map,
+            reverse_index=ReverseCommandIndex(command_map),
             filter_width_min=self.filter_width_min,
             filter_width_max=self.filter_width_max,
             filter_width_encoding=self.filter_width_encoding,

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -1,0 +1,23 @@
+# Reverse-command-index per-profile census baseline (MOR-1993 Z2,
+# docs/plans/2026-09-01-reverse-command-index.md). Tab separated:
+#   <model>  <names>  <keys>  <colliding>
+# names      = entries in that profile's CommandMap (== len(command_map)).
+# keys       = distinct (command, sub, prefix) groups -- the same grouping
+#              `commands/command_map.py: ReverseCommandIndex` builds, i.e.
+#              NOT collapsed to (command, sub) (see that class's docstring
+#              for why collapsing would be wrong).
+# colliding  = names that share a group of size > 1. Many of these still
+#              resolve cleanly via the read/write payload-length rule --
+#              "colliding" means "shares a declared prefix with another
+#              name", not "ambiguous"; see test_round_trip_contract for
+#              the resolved/ambiguous/wrong split this file does not carry.
+# Measured at aa96dfc3 (branch base) with:
+#   RIGPLANE_REGEN_REVERSE_COMMAND_INDEX_CENSUS=1 uv run pytest tests/test_reverse_command_index.py
+# Regenerate the same way after an intentional profile/command change --
+# do not hand-edit.
+IC-705	246	128	231
+IC-7300	330	185	287
+IC-7610	217	129	171
+IC-9700	230	137	183
+X6100	67	42	50
+X6200	68	43	50

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -6,12 +6,12 @@
 #              `commands/command_map.py: ReverseCommandIndex` builds, i.e.
 #              NOT collapsed to (command, sub) (see that class's docstring
 #              for why collapsing would be wrong).
-# colliding  = names that share a group of size > 1. Many of these still
-#              resolve cleanly via the read/write payload-length rule --
-#              "colliding" means "shares a declared prefix with another
-#              name", not "ambiguous"; see test_round_trip_contract for
-#              the resolved/ambiguous/wrong split this file does not carry.
-# Measured at aa96dfc3 (branch base) with:
+# colliding  = names that share an exact group of size > 1. Incoming lookup
+#              preserves every compatible exact or shorter prefix, so this
+#              count alone does not determine whether a frame resolves or is
+#              ambiguous. See
+#              test_all_profile_probe_census_returns_exact_viable_names.
+# Measured by test_census_matches_baseline; regenerate with:
 #   RIGPLANE_REGEN_REVERSE_COMMAND_INDEX_CENSUS=1 uv run pytest tests/test_reverse_command_index.py
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.

--- a/tests/test_reverse_command_index.py
+++ b/tests/test_reverse_command_index.py
@@ -21,6 +21,7 @@ parts:
 
 from __future__ import annotations
 
+import itertools
 import os
 import pathlib
 
@@ -31,6 +32,7 @@ from rigplane.commands._frame import parse_civ_frame
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import (
     CommandMap,
+    ReverseCommandIndex,
     ReverseLookupResult,
 )
 from rigplane.profiles import RadioProfile, get_radio_profile, reload_profiles
@@ -94,6 +96,63 @@ def _result_names(result: ReverseLookupResult) -> frozenset[str]:
     if result.name is not None:
         return frozenset({result.name})
     return result.candidates
+
+
+def test_result_contract_accepts_exactly_three_states() -> None:
+    unrecognized = ReverseLookupResult()
+    resolved = ReverseLookupResult(name="get_x")
+    ambiguous = ReverseLookupResult(candidates=frozenset({"get_x", "set_x"}))
+
+    assert unrecognized.unrecognized and not unrecognized.resolved
+    assert resolved.resolved and not resolved.ambiguous
+    assert ambiguous.ambiguous and not ambiguous.unrecognized
+    same_ambiguity = ReverseLookupResult(candidates=frozenset({"set_x", "get_x"}))
+    assert same_ambiguity == ambiguous
+    assert hash(same_ambiguity) == hash(ambiguous)
+
+
+@pytest.mark.parametrize(
+    ("name", "candidates"),
+    (
+        (None, frozenset({"get_x"})),
+        ("get_x", frozenset({"get_x", "set_x"})),
+    ),
+)
+def test_result_contract_rejects_invalid_states(
+    name: str | None, candidates: frozenset[str]
+) -> None:
+    with pytest.raises(ValueError):
+        ReverseLookupResult(name=name, candidates=candidates)
+
+
+def test_index_equality_hash_and_resolution_ignore_declaration_order() -> None:
+    declarations = (
+        ("get_x", (0x14, 0x01)),
+        ("set_x", (0x14, 0x01)),
+        ("set_x_on", (0x14, 0x01, 0x01)),
+    )
+    indexes = [
+        ReverseCommandIndex(CommandMap(dict(permutation)))
+        for permutation in itertools.permutations(declarations)
+    ]
+
+    assert all(index == indexes[0] for index in indexes)
+    assert len({hash(index) for index in indexes}) == 1
+    for index in indexes:
+        assert index.resolve(0x14, 0x01, b"\x01").candidates == frozenset(
+            {"get_x", "set_x", "set_x_on"}
+        )
+
+
+def test_index_equality_detects_semantic_prefix_difference() -> None:
+    baseline = ReverseCommandIndex(
+        CommandMap({"get_x": (0x14, 0x01), "set_x": (0x14, 0x01)})
+    )
+    changed = ReverseCommandIndex(
+        CommandMap({"get_x": (0x14, 0x01), "set_x": (0x14, 0x01, 0x01)})
+    )
+
+    assert baseline != changed
 
 
 def test_all_profile_probe_census_returns_exact_viable_names() -> None:

--- a/tests/test_reverse_command_index.py
+++ b/tests/test_reverse_command_index.py
@@ -1,0 +1,256 @@
+"""Reverse command index (MOR-1993 Z2,
+`docs/plans/2026-09-01-reverse-command-index.md` §4.1/§5).
+
+``ReverseCommandIndex`` (``commands/command_map.py``) is the inverse of
+``CommandMap``: given an incoming ``(command, sub, data)`` frame, resolve
+the declared name it came from. This file has three parts:
+
+- ``test_round_trip_contract``: for every declared name in every CI-V
+  profile, building a frame from that name's own declared tuple and
+  decoding it back must yield that name, or an explicitly-recorded
+  ambiguity -- never a *different*, wrong name. ``ftx1``/``tx500`` are CAT
+  radios (Yaesu text protocol) and carry no CI-V ``[commands]`` entries,
+  so they are excluded the same way ``tests/test_profile_command_coverage.py``
+  excludes them (``config.protocol_type == "civ"``).
+- ``TestKnownCollisionShapes``: a handful of structurally distinct cases
+  pinned individually, so a regression names the specific shape that broke
+  instead of only the aggregate counts below.
+- ``test_census_matches_baseline``: per-profile name/key/collision counts,
+  regenerable rather than hand-maintained::
+
+    RIGPLANE_REGEN_REVERSE_COMMAND_INDEX_CENSUS=1 uv run pytest tests/test_reverse_command_index.py
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands.command_map import CommandMap, ReverseCommandIndex
+from rigplane.profiles import RadioProfile, get_radio_profile, reload_profiles
+from rigplane.profiles.rig_loader import discover_rigs
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+RIGS_DIR = REPO_ROOT / "rigs"
+CENSUS_FILE = pathlib.Path(__file__).with_name("reverse_command_index_census.txt")
+REGEN_ENV = "RIGPLANE_REGEN_REVERSE_COMMAND_INDEX_CENSUS"
+
+Groups = dict[tuple[int, "int | None"], dict[bytes, tuple[str, ...]]]
+
+
+def _civ_profiles() -> dict[str, RadioProfile]:
+    """Every CI-V (non-CAT) profile, built fresh -- mirrors
+    `tests/test_profile_command_coverage.py: _civ_rigs`.
+    """
+    reload_profiles()
+    return {
+        model: config.to_profile()
+        for model, config in sorted(discover_rigs(RIGS_DIR).items())
+        if config.protocol_type == "civ"
+    }
+
+
+def _group_names(command_map: CommandMap) -> Groups:
+    """Group declared names by (command, sub, prefix).
+
+    An independent reference computation for this test file -- calls the
+    same `commands/_frame.py: decode_wire_tuple` the index itself uses,
+    but does not read `ReverseCommandIndex`'s internal buckets, so the
+    tests below exercise ``resolve()`` rather than just re-checking this
+    function's own output.
+    """
+    raw: dict[tuple[int, int | None], dict[bytes, list[str]]] = {}
+    for name in command_map:
+        command, sub, prefix = decode_wire_tuple(command_map.get(name))
+        raw.setdefault((command, sub), {}).setdefault(prefix, []).append(name)
+    return {
+        key: {prefix: tuple(names) for prefix, names in group.items()}
+        for key, group in raw.items()
+    }
+
+
+def _safe_write_probe(
+    index: ReverseCommandIndex,
+    command: int,
+    sub: int | None,
+    prefix: bytes,
+    group: frozenset[str],
+) -> bytes | None:
+    """A 1-byte suffix appended to *prefix* that resolves back into *group*.
+
+    Needed to round-trip a non-``get_`` group member: its own declared
+    tuple is byte-identical to its ``get_`` sibling's (that identity *is*
+    the collision), so testing it requires a frame with something past
+    the declared prefix -- but a naive fixed byte can collide with an
+    unrelated, longer sibling prefix at the same ``(command, sub)`` (e.g.
+    ``0x1C 0x00``'s bare group sits alongside ``ptt_on``/``ptt_off``'s own
+    longer, unique prefixes). Tries every byte and keeps the first one
+    ``resolve()`` itself confirms stays inside *group* (resolved to a
+    member, or ambiguous with candidates that are a subset of *group*).
+    Returns ``None`` if no byte in 0..255 is safe.
+    """
+    for value in range(256):
+        candidate = bytes([value])
+        result = index.resolve(command, sub, prefix + candidate)
+        if result.name in group or (result.ambiguous and result.candidates <= group):
+            return candidate
+    return None
+
+
+def test_round_trip_contract() -> None:
+    resolved = 0
+    ambiguous = 0
+    wrong: list[str] = []
+    for model, profile in _civ_profiles().items():
+        command_map = profile.command_map
+        index = profile.reverse_index
+        assert command_map is not None and index is not None, model
+        for (command, sub), prefix_groups in _group_names(command_map).items():
+            for prefix, names in prefix_groups.items():
+                group = frozenset(names)
+                for name in names:
+                    if len(names) == 1 or name.startswith("get_"):
+                        data = prefix
+                    else:
+                        suffix = _safe_write_probe(index, command, sub, prefix, group)
+                        assert suffix is not None, (
+                            f"{model}: no safe write probe for {name!r} at "
+                            f"command={command:#x} sub={sub} prefix={prefix!r}"
+                        )
+                        data = prefix + suffix
+                    result = index.resolve(command, sub, data)
+                    if result.name == name:
+                        resolved += 1
+                    elif result.ambiguous and name in result.candidates:
+                        ambiguous += 1
+                    else:
+                        wrong.append(f"{model}:{name} -> {result}")
+    assert not wrong, "resolved to the wrong name:\n" + "\n".join(wrong)
+    # Not vacuous: both outcomes are expected to occur across six profiles.
+    assert resolved > 0
+    assert ambiguous > 0
+
+
+class TestKnownCollisionShapes:
+    """Individually pinned, structurally distinct cases (established
+    directly from ``rigs/*.toml`` -- see each test's own docstring)."""
+
+    def test_ptt_on_off_are_distinct_full_tuples(self) -> None:
+        index = get_radio_profile("ic7300").reverse_index
+        assert index is not None
+        assert index.resolve(0x1C, 0x00, b"\x01").name == "ptt_on"
+        assert index.resolve(0x1C, 0x00, b"\x00").name == "ptt_off"
+
+    def test_get_set_pair_resolves_by_payload_length(self) -> None:
+        index = get_radio_profile("ic7300").reverse_index
+        assert index is not None
+        assert index.resolve(0x14, 0x01, b"").name == "get_af_level"
+        assert index.resolve(0x14, 0x01, b"\x50").name == "set_af_level"
+
+    def test_menu_family_does_not_collapse_to_one_key(self) -> None:
+        """IC-7300 declares 84 distinct prefixes under 0x1A 0x05 (168
+        names); a (command, sub)-blind index would answer every one of
+        them identically. Two different addresses must resolve
+        differently."""
+        index = get_radio_profile("ic7300").reverse_index
+        assert index is not None
+        first = index.resolve(0x1A, 0x05, b"\x00\x01")
+        second = index.resolve(0x1A, 0x05, b"\x00\x02")
+        assert first.name == "get_ssb_rx_hpflpf"
+        assert second.name == "get_ssb_rx_bass"
+
+    def test_direction_only_write_family_stays_ambiguous(self) -> None:
+        """Scan (0x0E, class (c)): five write-only names share one bare
+        tuple with nothing to break the tie until Z3's annotations."""
+        index = get_radio_profile("ic7300").reverse_index
+        assert index is not None
+        result = index.resolve(0x0E, None, b"\x01")
+        assert result.ambiguous
+        assert result.candidates == frozenset(
+            {
+                "scan_start",
+                "scan_stop",
+                "scan_start_type",
+                "scan_set_df_span",
+                "scan_set_resume",
+            }
+        )
+
+    def test_ic7610_antenna_bare_tuple_stays_ambiguous(self) -> None:
+        """rigs/ic7610.toml declares get_antenna/get_rx_antenna_ant2 (and
+        their setters) as the identical bare [0x12] tuple -- the ANT1/ANT2
+        selector is a runtime sub-byte the TOML never records for either."""
+        index = get_radio_profile("ic7610").reverse_index
+        assert index is not None
+        result = index.resolve(0x12, None, b"")
+        assert result.ambiguous
+        assert result.candidates == frozenset({"get_antenna", "get_rx_antenna_ant2"})
+
+    def test_transceiver_status_family_resolves_all_four_names(self) -> None:
+        """rigs/x6100.toml (and ic705/x6200) declares four names under
+        0x1C 0x00: get_/set_transceiver_status share the empty prefix,
+        ptt_on/ptt_off each declare their own longer, unique prefix at
+        the same (command, sub). The full-prefix (non-prefix-blind) index
+        this design requires resolves all four -- see this session's
+        report to the coordinator for why that reads against plan §2(d)'s
+        "genuine residual, decides nothing" framing of the fourth name."""
+        index = get_radio_profile("x6100").reverse_index
+        assert index is not None
+        assert index.resolve(0x1C, 0x00, b"").name == "get_transceiver_status"
+        assert index.resolve(0x1C, 0x00, b"\x02").name == "set_transceiver_status"
+        assert index.resolve(0x1C, 0x00, b"\x01").name == "ptt_on"
+        assert index.resolve(0x1C, 0x00, b"\x00").name == "ptt_off"
+
+    def test_unknown_command_is_unrecognized(self) -> None:
+        index = get_radio_profile("ic7300").reverse_index
+        assert index is not None
+        assert index.resolve(0xFF, None, b"").unrecognized
+
+
+# ── regenerable census baseline ──
+
+
+def _census_rows() -> dict[str, tuple[int, int, int]]:
+    rows: dict[str, tuple[int, int, int]] = {}
+    for model, profile in _civ_profiles().items():
+        command_map = profile.command_map
+        assert command_map is not None
+        groups = _group_names(command_map)
+        names = len(command_map)
+        keys = sum(len(prefix_groups) for prefix_groups in groups.values())
+        colliding = sum(
+            len(names_)
+            for prefix_groups in groups.values()
+            for names_ in prefix_groups.values()
+            if len(names_) > 1
+        )
+        rows[model] = (names, keys, colliding)
+    return rows
+
+
+def _render_census(rows: dict[str, tuple[int, int, int]]) -> str:
+    header = CENSUS_FILE.read_text(encoding="utf-8").splitlines()
+    header = [line for line in header if line.startswith("#")]
+    body = [f"{model}\t{n}\t{k}\t{c}" for model, (n, k, c) in sorted(rows.items())]
+    return "\n".join(header + body) + "\n"
+
+
+def _read_census() -> dict[str, tuple[int, int, int]]:
+    rows: dict[str, tuple[int, int, int]] = {}
+    for line in CENSUS_FILE.read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        model, names, keys, colliding = line.split("\t")
+        rows[model] = (int(names), int(keys), int(colliding))
+    return rows
+
+
+def test_census_matches_baseline() -> None:
+    measured = _census_rows()
+    if os.environ.get(REGEN_ENV, "") not in {"", "0"}:
+        CENSUS_FILE.write_text(_render_census(measured), encoding="utf-8")
+        pytest.skip(f"{REGEN_ENV} set: baseline rewritten, not checked")
+    assert measured == _read_census()

--- a/tests/test_reverse_command_index.py
+++ b/tests/test_reverse_command_index.py
@@ -1,17 +1,15 @@
 """Reverse command index (MOR-1993 Z2,
 `docs/plans/2026-09-01-reverse-command-index.md` §4.1/§5).
 
-``ReverseCommandIndex`` (``commands/command_map.py``) is the inverse of
-``CommandMap``: given an incoming ``(command, sub, data)`` frame, resolve
-the declared name it came from. This file has three parts:
+``ReverseCommandIndex`` (``commands/command_map.py``) is the conservative
+inverse of ``CommandMap``: given an incoming ``(command, sub, data)`` frame,
+return every declared name compatible with those bytes. This file has three
+parts:
 
-- ``test_round_trip_contract``: for every declared name in every CI-V
-  profile, building a frame from that name's own declared tuple and
-  decoding it back must yield that name, or an explicitly-recorded
-  ambiguity -- never a *different*, wrong name. ``ftx1``/``tx500`` are CAT
-  radios (Yaesu text protocol) and carry no CI-V ``[commands]`` entries,
-  so they are excluded the same way ``tests/test_profile_command_coverage.py``
-  excludes them (``config.protocol_type == "civ"``).
+- ``test_all_profile_probe_census_returns_exact_viable_names``: independently
+  derives the viable name set for every declared prefix plus representative
+  reply payloads on every CI-V profile. ``ftx1``/``tx500`` are CAT radios
+  (Yaesu text protocol) and carry no CI-V ``[commands]`` entries.
 - ``TestKnownCollisionShapes``: a handful of structurally distinct cases
   pinned individually, so a regression names the specific shape that broke
   instead of only the aggregate counts below.
@@ -29,7 +27,12 @@ import pathlib
 import pytest
 
 from rigplane.commands._frame import decode_wire_tuple
-from rigplane.commands.command_map import CommandMap, ReverseCommandIndex
+from rigplane.commands._frame import parse_civ_frame
+from rigplane.commands.bound import BoundCommands
+from rigplane.commands.command_map import (
+    CommandMap,
+    ReverseLookupResult,
+)
 from rigplane.profiles import RadioProfile, get_radio_profile, reload_profiles
 from rigplane.profiles.rig_loader import discover_rigs
 
@@ -72,83 +75,122 @@ def _group_names(command_map: CommandMap) -> Groups:
     }
 
 
-def _safe_write_probe(
-    index: ReverseCommandIndex,
+def _viable_names(
+    groups: Groups,
     command: int,
     sub: int | None,
-    prefix: bytes,
-    group: frozenset[str],
-) -> bytes | None:
-    """A 1-byte suffix appended to *prefix* that resolves back into *group*.
-
-    Needed to round-trip a non-``get_`` group member: its own declared
-    tuple is byte-identical to its ``get_`` sibling's (that identity *is*
-    the collision), so testing it requires a frame with something past
-    the declared prefix -- but a naive fixed byte can collide with an
-    unrelated, longer sibling prefix at the same ``(command, sub)`` (e.g.
-    ``0x1C 0x00``'s bare group sits alongside ``ptt_on``/``ptt_off``'s own
-    longer, unique prefixes). Tries every byte and keeps the first one
-    ``resolve()`` itself confirms stays inside *group* (resolved to a
-    member, or ambiguous with candidates that are a subset of *group*).
-    Returns ``None`` if no byte in 0..255 is safe.
-    """
-    for value in range(256):
-        candidate = bytes([value])
-        result = index.resolve(command, sub, prefix + candidate)
-        if result.name in group or (result.ambiguous and result.candidates <= group):
-            return candidate
-    return None
+    data: bytes,
+) -> frozenset[str]:
+    """Names whose independently grouped declared prefix matches *data*."""
+    return frozenset(
+        name
+        for prefix, names in groups.get((command, sub), {}).items()
+        if data.startswith(prefix)
+        for name in names
+    )
 
 
-def test_round_trip_contract() -> None:
-    resolved = 0
-    ambiguous = 0
-    wrong: list[str] = []
+def _result_names(result: ReverseLookupResult) -> frozenset[str]:
+    if result.name is not None:
+        return frozenset({result.name})
+    return result.candidates
+
+
+def test_all_profile_probe_census_returns_exact_viable_names() -> None:
+    probes = 0
     for model, profile in _civ_profiles().items():
         command_map = profile.command_map
         index = profile.reverse_index
         assert command_map is not None and index is not None, model
-        for (command, sub), prefix_groups in _group_names(command_map).items():
-            for prefix, names in prefix_groups.items():
-                group = frozenset(names)
-                for name in names:
-                    if len(names) == 1 or name.startswith("get_"):
-                        data = prefix
-                    else:
-                        suffix = _safe_write_probe(index, command, sub, prefix, group)
-                        assert suffix is not None, (
-                            f"{model}: no safe write probe for {name!r} at "
-                            f"command={command:#x} sub={sub} prefix={prefix!r}"
-                        )
-                        data = prefix + suffix
+        groups = _group_names(command_map)
+        for (command, sub), prefix_groups in groups.items():
+            for prefix in prefix_groups:
+                for data in (prefix, prefix + b"\x00", prefix + b"\x01"):
+                    probes += 1
                     result = index.resolve(command, sub, data)
-                    if result.name == name:
-                        resolved += 1
-                    elif result.ambiguous and name in result.candidates:
-                        ambiguous += 1
-                    else:
-                        wrong.append(f"{model}:{name} -> {result}")
-    assert not wrong, "resolved to the wrong name:\n" + "\n".join(wrong)
-    # Not vacuous: both outcomes are expected to occur across six profiles.
-    assert resolved > 0
-    assert ambiguous > 0
+                    expected = _viable_names(groups, command, sub, data)
+                    assert _result_names(result) == expected, (
+                        f"{model}: command={command:#x} sub={sub} data={data!r}"
+                    )
+                    assert result.resolved is (len(expected) == 1)
+                    assert result.ambiguous is (len(expected) > 1)
+    assert probes > 0
+
+
+def test_all_strict_prefix_overlaps_preserve_shorter_candidates() -> None:
+    overlaps = 0
+    for model, profile in _civ_profiles().items():
+        command_map = profile.command_map
+        index = profile.reverse_index
+        assert command_map is not None and index is not None, model
+        groups = _group_names(command_map)
+        for (command, sub), prefix_groups in groups.items():
+            prefixes = tuple(prefix_groups)
+            for shorter in prefixes:
+                for longer in prefixes:
+                    if len(shorter) >= len(longer) or not longer.startswith(shorter):
+                        continue
+                    overlaps += 1
+                    result = index.resolve(command, sub, longer)
+                    expected = _viable_names(groups, command, sub, longer)
+                    assert _result_names(result) == expected, (
+                        f"{model}: command={command:#x} sub={sub} "
+                        f"shorter={shorter!r} longer={longer!r}"
+                    )
+                    assert frozenset(prefix_groups[shorter]) <= expected
+    assert overlaps == 14
 
 
 class TestKnownCollisionShapes:
     """Individually pinned, structurally distinct cases (established
     directly from ``rigs/*.toml`` -- see each test's own docstring)."""
 
-    def test_ptt_on_off_are_distinct_full_tuples(self) -> None:
-        index = get_radio_profile("ic7300").reverse_index
-        assert index is not None
-        assert index.resolve(0x1C, 0x00, b"\x01").name == "ptt_on"
-        assert index.resolve(0x1C, 0x00, b"\x00").name == "ptt_off"
+    @pytest.mark.parametrize(
+        ("reply_data", "setter"),
+        ((b"\x00", "set_dual_watch_off"), (b"\x01", "set_dual_watch_on")),
+    )
+    def test_ic9700_dual_watch_reply_retains_getter(
+        self, reply_data: bytes, setter: str
+    ) -> None:
+        profile = get_radio_profile("ic9700")
+        command_map = profile.command_map
+        index = profile.reverse_index
+        assert command_map is not None and index is not None
 
-    def test_get_set_pair_resolves_by_payload_length(self) -> None:
-        index = get_radio_profile("ic7300").reverse_index
-        assert index is not None
-        assert index.resolve(0x14, 0x01, b"").name == "get_af_level"
-        assert index.resolve(0x14, 0x01, b"\x50").name == "set_af_level"
+        request = parse_civ_frame(
+            BoundCommands(command_map).get_dual_watch(to_addr=profile.civ_addr)
+        )
+        assert (request.command, request.sub, request.data) == (0x16, 0x59, b"")
+
+        result = index.resolve(0x16, 0x59, reply_data)
+        assert result.ambiguous
+        assert result.candidates == frozenset({"get_dual_watch", setter})
+
+    def test_ic7300_af_level_reply_retains_getter(self) -> None:
+        profile = get_radio_profile("ic7300")
+        command_map = profile.command_map
+        index = profile.reverse_index
+        assert command_map is not None and index is not None
+        commands = BoundCommands(command_map)
+
+        get_request = parse_civ_frame(commands.get_af_level(to_addr=profile.civ_addr))
+        set_request = parse_civ_frame(
+            commands.set_af_level(128, to_addr=profile.civ_addr)
+        )
+        assert (get_request.command, get_request.sub, get_request.data) == (
+            0x14,
+            0x01,
+            b"",
+        )
+        assert (set_request.command, set_request.sub, set_request.data) == (
+            0x14,
+            0x01,
+            b"\x01\x28",
+        )
+
+        result = index.resolve(0x14, 0x01, b"\x01\x28")
+        assert result.ambiguous
+        assert result.candidates == frozenset({"get_af_level", "set_af_level"})
 
     def test_menu_family_does_not_collapse_to_one_key(self) -> None:
         """IC-7300 declares 84 distinct prefixes under 0x1A 0x05 (168
@@ -159,8 +201,8 @@ class TestKnownCollisionShapes:
         assert index is not None
         first = index.resolve(0x1A, 0x05, b"\x00\x01")
         second = index.resolve(0x1A, 0x05, b"\x00\x02")
-        assert first.name == "get_ssb_rx_hpflpf"
-        assert second.name == "get_ssb_rx_bass"
+        assert first.candidates == frozenset({"get_ssb_rx_hpflpf", "set_ssb_rx_hpflpf"})
+        assert second.candidates == frozenset({"get_ssb_rx_bass", "set_ssb_rx_bass"})
 
     def test_direction_only_write_family_stays_ambiguous(self) -> None:
         """Scan (0x0E, class (c)): five write-only names share one bare
@@ -187,22 +229,38 @@ class TestKnownCollisionShapes:
         assert index is not None
         result = index.resolve(0x12, None, b"")
         assert result.ambiguous
-        assert result.candidates == frozenset({"get_antenna", "get_rx_antenna_ant2"})
+        assert result.candidates == frozenset(
+            {
+                "get_antenna",
+                "set_antenna",
+                "get_rx_antenna_ant2",
+                "set_rx_antenna_ant2",
+            }
+        )
 
-    def test_transceiver_status_family_resolves_all_four_names(self) -> None:
+    def test_transceiver_status_family_preserves_strict_prefix_candidates(
+        self,
+    ) -> None:
         """rigs/x6100.toml (and ic705/x6200) declares four names under
         0x1C 0x00: get_/set_transceiver_status share the empty prefix,
         ptt_on/ptt_off each declare their own longer, unique prefix at
         the same (command, sub). The full-prefix (non-prefix-blind) index
-        this design requires resolves all four -- see this session's
-        report to the coordinator for why that reads against plan §2(d)'s
-        "genuine residual, decides nothing" framing of the fourth name."""
+        this design requires keeps the bare names viable when the incoming
+        byte also matches either PTT tuple."""
         index = get_radio_profile("x6100").reverse_index
         assert index is not None
-        assert index.resolve(0x1C, 0x00, b"").name == "get_transceiver_status"
-        assert index.resolve(0x1C, 0x00, b"\x02").name == "set_transceiver_status"
-        assert index.resolve(0x1C, 0x00, b"\x01").name == "ptt_on"
-        assert index.resolve(0x1C, 0x00, b"\x00").name == "ptt_off"
+        assert index.resolve(0x1C, 0x00, b"").candidates == frozenset(
+            {"get_transceiver_status", "set_transceiver_status"}
+        )
+        assert index.resolve(0x1C, 0x00, b"\x02").candidates == frozenset(
+            {"get_transceiver_status", "set_transceiver_status"}
+        )
+        assert index.resolve(0x1C, 0x00, b"\x01").candidates == frozenset(
+            {"get_transceiver_status", "set_transceiver_status", "ptt_on"}
+        )
+        assert index.resolve(0x1C, 0x00, b"\x00").candidates == frozenset(
+            {"get_transceiver_status", "set_transceiver_status", "ptt_off"}
+        )
 
     def test_unknown_command_is_unrecognized(self) -> None:
         index = get_radio_profile("ic7300").reverse_index


### PR DESCRIPTION
# Summary

Step Z2 adds one per-profile reverse lookup beside `CommandMap`. `RigConfig.to_profile` builds it from the same canonical map through the shared `decode_wire_tuple`; no second profile union, decoder, or byte source exists. No runtime consumer uses the index yet.

# Incoming-frame contract

`resolve(command, sub, data)` has no request or direction context. It keeps every profile-declared name whose full `(command, sub, prefix)` is compatible with the incoming bytes. One viable name resolves; two or more return the complete candidate set; none is unrecognized. Payload length and longer write-shaped prefixes never imply direction.

Pinned cases include IC-9700 dual-watch replies `00` and `01`, IC-7300 AF-level reply `01 28`, and every strict-prefix overlap across the six shipped CI-V profiles. Production `BoundCommands` builders establish request shapes separately from the resolver oracle.

# Stable value contracts

`ReverseCommandIndex` stores each duplicate-prefix name group as a `frozenset`. All insertion permutations of semantically equal `CommandMap` data now compare equal, hash equally, and resolve identically; a real prefix change remains unequal.

`ReverseLookupResult` enforces exactly three public states:

- unrecognized: no name and no candidates
- resolved: one name and no candidates
- ambiguous: no name and at least two candidates

Singleton candidate sets and name-plus-candidate combinations raise `ValueError`.

# Canonical documentation

`docs/plans/2026-09-01-reverse-command-index.md` now marks the original payload-length/full-tuple priority algorithm as superseded by the exact-head counterexamples and records the conservative candidate-preservation contract for Z2 and later ingress work. `tests/reverse_command_index_census.txt` cites the real census test and no longer repeats the rejected rule.

# Census

At exact head `562afd13b4d6da9f8fb411b99fd9cf1b95b827b3`, an independent manual tuple split covered 1,158 names and 664 full keys. The specified 1,992 probes and broader 171,976 suffix probes both produced 0 candidate-set mismatches; all 14 strict-prefix overlaps were preserved. Reversing every profile declaration order preserved index equality and hash.

# Verification

Local checks are intentionally targeted only. Earlier local full-suite runs are withdrawn and are not merge or release evidence under owner policy.

- reverse-index plus response-shape tests: 297 passed, 149 skipped
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: 702 files formatted
- `lint-imports`: 5 contracts kept
- strict mypy: web 26 files and changed command-map module clean
- doc citation and link gates: passed
- Mac mini remote runner resolved `codex/z2-reverse-index` to `562afd13b4d6da9f8fb411b99fd9cf1b95b827b3`: 14,110 passed, 161 skipped, 48 xfailed, 6 warnings; remote ruff passed; `FINAL: PASS`

The documented remote runner excludes `tests/integration`; no hardware or TX path was exercised.

# Mandatory squash-body correction

Do not reuse the first pushed commit message claims that shared-prefix collisions resolve by payload length or that the census is `1109 resolved / 49 ambiguous`. The squash body must state the corrected contract: every compatible declared prefix remains viable, only a singleton resolves, and the independently reproduced census is 1,992 specified probes with 514 singleton outcomes, 1,478 explicit ambiguities, and 0 mismatches.

# Scope

Seven files in the complete PR, 601 insertions and 50 deletions. This crosses the 6-file/600-line soft threshold because the second independent review required the canonical plan and its checked-in census explanation to change in the same unit as the public result and equality contracts; leaving either prose source stale would preserve the defect. It remains below the hard ceiling. No profile rows, radio-specific bytes, runtime ingress consumers, web, FTX, acquisition, hardware, or TX paths changed.
