### PR TITLE
fix(MOR-2130): report both CTCSS booleans true for FTX-1 CT code 2

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -358,11 +358,11 @@ freshness_ttl_seconds = 120.0
 cadence_seconds = 30.0
 freshness_ttl_seconds = 120.0
 
-# Tone / CTCSS squelch-type (MOR-457). The MAIN-only CAT ``CT`` "SQL TYPE" read
-# (FTX-1_CAT_OM_ENG_2507) is mapped onto the neutral, mutually-exclusive CTCSS
-# booleans repeater_tone (CTCSS ENC, "TONE") and repeater_tsql (CTCSS ENC+DEC,
-# "TSQL"). Slow-changing per-receiver operator toggles, so they use the
-# slow-control cadence, matching the other receiver DSP toggles above.
+# Tone / CTCSS squelch-type (MOR-457, corrected MOR-2130). The MAIN-only CAT
+# ``CT`` "SQL TYPE" read (FTX-1_CAT_OM_ENG_2508-C) is mapped onto the neutral
+# CTCSS booleans repeater_tone (CTCSS ENC, "TONE") and repeater_tsql (CTCSS
+# ENC+DEC, "TSQL"). Slow-changing per-receiver operator toggles, so they use
+# the slow-control cadence, matching the other receiver DSP toggles above.
 [state_acquisition.field_policies."receiver.main.operator_toggles.repeater_tone"]
 cadence_seconds = 30.0
 freshness_ttl_seconds = 120.0
@@ -372,7 +372,7 @@ cadence_seconds = 30.0
 freshness_ttl_seconds = 120.0
 
 # CTCSS tone frequency (MOR-458). The MAIN-only CAT ``CN`` "CTCSS TONE
-# FREQUENCY" read (FTX-1_CAT_OM_ENG_2507) maps a 0-49 tone-chart index → Hz →
+# FREQUENCY" read (FTX-1_CAT_OM_ENG_2508-C) maps a 0-49 tone-chart index → Hz →
 # centiHz onto the neutral tone_freq/tsql_freq paths. The FTX-1 has a single
 # CTCSS tone shared by TONE (encode) and TSQL (decode), so both paths receive
 # the same centiHz value from one read. Slow-changing per-receiver operator

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -137,15 +137,19 @@ _CW_PITCH = FieldPath.global_("operator_controls", "cw_pitch")
 _BREAK_IN = FieldPath.global_("operator_controls", "break_in")
 _BREAK_IN_DELAY = FieldPath.global_("operator_controls", "break_in_delay")
 _CW_SPOT = FieldPath.global_("slow_state", "cw_spot")
-# Tone / CTCSS squelch-type (MOR-457). The FTX-1 CAT ``CT`` "SQL TYPE" command
-# (FTX-1_CAT_OM_ENG_2507) is a single MAIN-only read (CT0); its P2 code is
-# mapped onto the neutral, mutually-exclusive CTCSS booleans, matching the
-# Hamlib/Icom convention where ``repeater_tone`` = CTCSS tone ENCODE ("TONE")
-# and ``repeater_tsql`` = CTCSS tone SQUELCH (decode):
-#   P2 code 1 (ENC ON / DEC OFF, "TONE")  -> repeater_tone=True,  repeater_tsql=False
-#   P2 code 2 (ENC ON / DEC ON,  "TSQL")  -> repeater_tone=False, repeater_tsql=True
-#   P2 codes 0/3/4/5 (OFF / DCS / PR-FREQ / REV-TONE) -> both False (these have no
-#       neutral CTCSS-boolean representation, so they collapse to "neither on").
+# Tone / CTCSS squelch-type (MOR-457, corrected MOR-2130). The FTX-1 CAT ``CT``
+# "SQL TYPE" command (FTX-1_CAT_OM_ENG_2508-C) is a single MAIN-only read
+# (CT0); its P2 code is mapped onto ``RepeaterControlCapable``'s two
+# independent axes (the only written definition of these fields):
+# ``repeater_tone`` = CTCSS tone TX ENCODE, ``repeater_tsql`` = CTCSS tone RX
+# SQUELCH (decode):
+#   P2 code 0 (OFF)                      -> repeater_tone=False, repeater_tsql=False
+#   P2 code 1 (ENC ON / DEC OFF, "TONE") -> repeater_tone=True,  repeater_tsql=False
+#   P2 code 2 (ENC ON / DEC ON,  "TSQL") -> repeater_tone=True,  repeater_tsql=True
+#   P2 codes 3/4/5 (DCS / PR-FREQ / REV-TONE) -> both False (these select a
+#       non-CTCSS squelch mode; the two-boolean vocabulary has no
+#       representation for them — a limit of the representation, not of this
+#       derivation).
 # Both paths are emitted every cycle (including the False derivations) so the
 # store always reflects current state. Per-receiver ``operator_toggles`` like
 # nb/nr/auto_notch, emitted in the slow-control lane. MAIN only (CT0): the SUB
@@ -772,13 +776,14 @@ class YaesuObservationAdapter:
                         native_id="read_manual_notch_freq",
                     )
                 )
-        # Tone / CTCSS squelch-type (MOR-457) — MAIN-only per-receiver
-        # ``operator_toggles``, grouped with the other receiver toggles
-        # (nb/nr/auto_notch/manual_notch) above. A SINGLE ``read_sql_type(0)``
-        # CAT ``CT`` read (FTX-1_CAT_OM_ENG_2507) yields the P2 "SQL TYPE" code,
-        # from which the two mutually-exclusive neutral CTCSS booleans are
-        # DERIVED (Hamlib/Icom convention; see the module-level mapping comment):
-        # code 1 → tone only, code 2 → tsql only, codes 0/3/4/5 → both False.
+        # Tone / CTCSS squelch-type (MOR-457, corrected MOR-2130) — MAIN-only
+        # per-receiver ``operator_toggles``, grouped with the other receiver
+        # toggles (nb/nr/auto_notch/manual_notch) above. A SINGLE
+        # ``read_sql_type(0)`` CAT ``CT`` read (FTX-1_CAT_OM_ENG_2508-C) yields
+        # the P2 "SQL TYPE" code, from which the two independent neutral CTCSS
+        # booleans are DERIVED per ``RepeaterControlCapable``'s own docstrings
+        # (see the module-level mapping comment): code 1 -> encode only, code 2
+        # -> encode AND decode (both True), codes 0/3/4/5 -> both False.
         # Both paths are emitted every cycle (incl. the False derivations) so
         # the store always reflects current state. Gated on the ``sql_type``
         # runtime capability (``CAP_SQL_TYPE``), a dedicated readback capability:
@@ -798,7 +803,7 @@ class YaesuObservationAdapter:
                     observations.append(
                         adapter.observation(
                             _MAIN_REPEATER_TONE,
-                            sql_type == 1,
+                            sql_type in (1, 2),
                             native_id="read_sql_type",
                         )
                     )

--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -140,16 +140,14 @@ _CW_SPOT = FieldPath.global_("slow_state", "cw_spot")
 # Tone / CTCSS squelch-type (MOR-457, corrected MOR-2130). The FTX-1 CAT ``CT``
 # "SQL TYPE" command (FTX-1_CAT_OM_ENG_2508-C) is a single MAIN-only read
 # (CT0); its P2 code is mapped onto ``RepeaterControlCapable``'s two
-# independent axes (the only written definition of these fields):
-# ``repeater_tone`` = CTCSS tone TX ENCODE, ``repeater_tsql`` = CTCSS tone RX
-# SQUELCH (decode):
+# independent axes: ``repeater_tone`` = CTCSS tone TX ENCODE, ``repeater_tsql``
+# = CTCSS tone RX SQUELCH (decode):
 #   P2 code 0 (OFF)                      -> repeater_tone=False, repeater_tsql=False
 #   P2 code 1 (ENC ON / DEC OFF, "TONE") -> repeater_tone=True,  repeater_tsql=False
 #   P2 code 2 (ENC ON / DEC ON,  "TSQL") -> repeater_tone=True,  repeater_tsql=True
-#   P2 codes 3/4/5 (DCS / PR-FREQ / REV-TONE) -> both False (these select a
-#       non-CTCSS squelch mode; the two-boolean vocabulary has no
-#       representation for them — a limit of the representation, not of this
-#       derivation).
+#   P2 codes 3/4/5 (DCS / PR-FREQ / REV-TONE) -> both False (the two-boolean
+#       vocabulary has no representation for them — a limit of the
+#       representation, not of this derivation).
 # Both paths are emitted every cycle (including the False derivations) so the
 # store always reflects current state. Per-receiver ``operator_toggles`` like
 # nb/nr/auto_notch, emitted in the slow-control lane. MAIN only (CT0): the SUB
@@ -160,7 +158,7 @@ _CW_SPOT = FieldPath.global_("slow_state", "cw_spot")
 _MAIN_REPEATER_TONE = FieldPath.receiver("main", "operator_toggles", "repeater_tone")
 _MAIN_REPEATER_TSQL = FieldPath.receiver("main", "operator_toggles", "repeater_tsql")
 # CTCSS tone FREQUENCY (MOR-458). The FTX-1 CAT ``CN`` "CTCSS TONE FREQUENCY"
-# command (FTX-1_CAT_OM_ENG_2507) reports the MAIN tone as a 0-49 INDEX into
+# command (FTX-1_CAT_OM_ENG_2508-C) reports the MAIN tone as a 0-49 INDEX into
 # the standard 50-tone EIA chart (NOT an absolute frequency; cf. Icom 0x1B
 # BCD-Hz). The radio maps that index → Hz → centiHz (the index→Hz Tone Chart
 # is verbatim from the manual; see ``radio._CTCSS_TONE_CENTIHZ``). The neutral
@@ -818,7 +816,7 @@ class YaesuObservationAdapter:
         # CTCSS tone FREQUENCY (MOR-458) — MAIN-only per-receiver
         # ``operator_controls``, grouped with the CTCSS squelch-type toggles
         # above. A SINGLE ``read_ctcss_tone_index(0)`` CAT ``CN`` read
-        # (FTX-1_CAT_OM_ENG_2507) yields the 0-49 standard-EIA tone-chart index,
+        # (FTX-1_CAT_OM_ENG_2508-C) yields the 0-49 standard-EIA tone-chart index,
         # which ``_ctcss_index_to_centihz`` maps index → Hz → centiHz (the
         # index→Hz Tone Chart is verbatim from the manual). The neutral unit is
         # centiHz = round(Hz * 100), matching the Icom MOR-451 convention so

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -50,7 +50,7 @@ _RIGS_DIR = Path(__file__).parents[4] / "rigs"
 # command reports the tone as a 0-49 INDEX into the standard 50-tone EIA CTCSS
 # set, NOT as an absolute frequency (unlike the Icom 0x1B BCD-Hz encoding). The
 # index → Hz chart is verbatim from the official FTX-1 CAT manual
-# (``FTX-1_CAT_OM_ENG_2507``). Values are stored directly in centiHz
+# (``FTX-1_CAT_OM_ENG_2508-C``). Values are stored directly in centiHz
 # (round(Hz * 100)) so the neutral emission matches the Icom convention
 # (``round(_decode_tone_freq(...) * 100)``, MOR-451) with no float rounding
 # ambiguity at the call site. There is no shared cross-vendor CTCSS table in
@@ -2296,7 +2296,7 @@ class YaesuCatRadio:
         Pure CAT read used by the observation pipeline. Returns the FTX-1
         ``CT`` P2 code (0=CTCSS OFF, 1=ENC ON/DEC OFF "TONE", 2=ENC ON/DEC ON
         "TSQL", 3=DCS, 4=PR FREQ, 5=REV TONE) per the FTX-1 CAT Operation
-        Reference Manual (``FTX-1_CAT_OM_ENG_2507``). MAIN only (CT0).
+        Reference Manual (``FTX-1_CAT_OM_ENG_2508-C``). MAIN only (CT0).
         """
         result = await self._query("get_sql_type")
         return int(result["type"])
@@ -2314,7 +2314,7 @@ class YaesuCatRadio:
 
         Sends ``CN00;`` (P1=0 MAIN, P2=0 CTCSS) and parses the ``CN00nnn;``
         answer, returning the 000-049 tone-chart index per the FTX-1 CAT
-        Operation Reference Manual (``FTX-1_CAT_OM_ENG_2507``). Pure CAT read
+        Operation Reference Manual (``FTX-1_CAT_OM_ENG_2508-C``). Pure CAT read
         used by the observation pipeline: it does NOT mutate ``radio_state``.
         MAIN only (CN P1=0); the SUB receiver would need CN10, out of scope.
         """

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -1517,11 +1517,13 @@ async def test_read_sql_type_is_a_pure_read() -> None:
 @pytest.mark.parametrize(
     ("code", "expected_tone", "expected_tsql"),
     [
-        # CAT ``CT`` P2 "SQL TYPE" codes (FTX-1_CAT_OM_ENG_2507) → neutral
-        # mutually-exclusive CTCSS booleans (Hamlib/Icom convention):
+        # CAT ``CT`` P2 "SQL TYPE" codes (FTX-1_CAT_OM_ENG_2508-C) → the two
+        # independent axes defined by ``RepeaterControlCapable``: repeater_tone
+        # is TX tone ENCODE, repeater_tsql is RX tone-squelch DECODE. Code 2 has
+        # encode ON *and* decode ON, so both booleans are True (MOR-2130).
         (0, False, False),  # CTCSS OFF
         (1, True, False),  # CTCSS ENC ON / DEC OFF ("TONE")
-        (2, False, True),  # CTCSS ENC ON / DEC ON ("TSQL")
+        (2, True, True),  # CTCSS ENC ON / DEC ON ("TSQL")
         (3, False, False),  # DCS — no neutral CTCSS-boolean representation
         (4, False, False),  # PR FREQ — no neutral CTCSS-boolean representation
         (5, False, False),  # REV TONE — no neutral CTCSS-boolean representation

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -546,8 +546,10 @@ class _SideEffectingYaesuRadio:
     async def read_sql_type(self, receiver: int = 0) -> int:
         # CAT ``CT`` P2 code 1 = "TONE" (ENC ON / DEC OFF). Pure read: the
         # derived neutral booleans must come from the observation pipeline, not
-        # from any legacy-state write (the pre-seeded main.repeater_tone/tsql=True
-        # is the impossible-via-CT combination that proves no mutation).
+        # from any legacy-state write. The pre-seeded main.repeater_tone/tsql
+        # (True, True) differs from what code 1 actually derives (True, False,
+        # MOR-2130), so a leak into legacy state would flip repeater_tsql and
+        # be caught.
         return 1
 
     async def get_sql_type(self, receiver: int = 0) -> int:
@@ -1342,7 +1344,9 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
     assert radio.radio_state.break_in_delay == 888
     assert radio.radio_state.cw_spot is False
     # Tone/CTCSS read_sql_type must not mutate legacy state (MOR-457). The
-    # pre-seeded impossible-via-CT combination (both True) is preserved.
+    # pre-seeded sentinel pair (True, True) differs from what the fixture's
+    # fixed code 1 actually derives (True, False, MOR-2130), so it is
+    # preserved rather than overwritten.
     assert radio.radio_state.main.repeater_tone is True
     assert radio.radio_state.main.repeater_tsql is True
     # CTCSS tone freq read_ctcss_tone_index must not mutate legacy state
@@ -1494,19 +1498,26 @@ async def test_read_sql_type_is_a_pure_read() -> None:
     It delegates to the same ``CT0`` query/parse path as ``get_sql_type`` but
     must NOT write ``self._state`` — only the ``read_*`` variant feeds the
     observation pipeline (MOR-434 pattern). It returns the raw FTX-1 ``CT`` P2
-    "SQL TYPE" code (FTX-1_CAT_OM_ENG_2507); the neutral-boolean derivation
+    "SQL TYPE" code (FTX-1_CAT_OM_ENG_2508-C); the neutral-boolean derivation
     happens in the adapter, never here.
+
+    Pre-seeds ``(repeater_tone=False, repeater_tsql=True)`` — the one pair no
+    ``CT`` code can produce (MOR-2130's corrected mapping only reaches
+    (F,F)/(T,F)/(T,T)) — and feeds code 2, which derives (T,T). A leak of that
+    derived value into legacy state would flip ``repeater_tone`` to True,
+    which the assertion below catches; a pre-seed of (T,T) would not, since
+    code 2's derivation and the pre-seed would then be identical.
     """
     radio = YaesuCatRadio("/dev/null", audio_driver=MagicMock())
-    radio.radio_state.main.repeater_tone = True
+    radio.radio_state.main.repeater_tone = False
     radio.radio_state.main.repeater_tsql = True
     state_before = radio.radio_state
 
     radio._query = AsyncMock(return_value={"type": "02"})  # type: ignore[method-assign]
     assert await radio.read_sql_type() == 2
     assert radio.radio_state is state_before
-    # The impossible-via-CT pre-seeded combination is untouched.
-    assert radio.radio_state.main.repeater_tone is True
+    # The pre-seeded, not-representable-via-CT pair is untouched.
+    assert radio.radio_state.main.repeater_tone is False
     assert radio.radio_state.main.repeater_tsql is True
 
     # get_sql_type delegates to the same pure read.

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -134,10 +134,10 @@ _CW_SPOT_CASES = (("global.slow_state.cw_spot", "cwSpot", True),)
 # (store path, public fieldStatus key, expected value) for the tone / CTCSS
 # squelch-type booleans (MOR-457). MAIN-only per-receiver operator toggles
 # (public ``main.repeaterTone``/``main.repeaterTsql``) derived from a single CAT
-# ``CT`` read on the slow-control lane. The fixture returns P2 code 2 ("TSQL"),
-# so repeater_tone=False and repeater_tsql=True.
+# ``CT`` read on the slow-control lane. The fixture returns P2 code 2 ("TSQL":
+# ENC ON / DEC ON), so both repeater_tone and repeater_tsql are True (MOR-2130).
 _CTCSS_CASES = (
-    ("receiver.main.operator_toggles.repeater_tone", "main.repeaterTone", False),
+    ("receiver.main.operator_toggles.repeater_tone", "main.repeaterTone", True),
     ("receiver.main.operator_toggles.repeater_tsql", "main.repeaterTsql", True),
 )
 
@@ -250,8 +250,9 @@ def _make_radio() -> MagicMock:
     radio.read_break_in_delay = AsyncMock(return_value=300)
     radio.read_cw_spot = AsyncMock(return_value=True)
     # Tone / CTCSS squelch-type observation read (MOR-457). ``read_sql_type``
-    # returns the CAT ``CT`` P2 code; code 2 ("TSQL": ENC+DEC) derives
-    # repeater_tone=False, repeater_tsql=True. MAIN-only, slow-control lane.
+    # returns the CAT ``CT`` P2 code; code 2 ("TSQL": ENC ON / DEC ON) derives
+    # repeater_tone=True, repeater_tsql=True (MOR-2130). MAIN-only, slow-control
+    # lane.
     radio.read_sql_type = AsyncMock(return_value=2)
     # CTCSS tone frequency observation read (MOR-458). ``read_ctcss_tone_index``
     # returns the CAT ``CN`` P3 tone-chart index; index 8 (88.5 Hz) maps to 8850


### PR DESCRIPTION
The FTX-1 reports `repeater_tone=False` while the radio is transmitting a CTCSS tone.

`RepeaterControlCapable`'s docstrings are the governing definition of these two fields — *"repeater tone (CTCSS) TX on/off state"* and *"tone squelch (TSQL) RX on/off state"*, two independent axes. The Icom side satisfies it: `0x16 0x42` and `0x16 0x43` are independent toggles and `_civ_rx.py` decodes each bit with no interlock.

The FTX-1 derivation mapped `CT` code 2 — which the manual documents as **ENC "ON" / DEC "ON"** — to `repeater_tone=False`. So with the radio in TSQL mode it *is* transmitting a tone and the field that exists to answer that question says it is not.

This was a deliberate model, not a slip: the mapping was built as "neutral, mutually-exclusive CTCSS booleans". The docstring is the written contract and Icom honours it, so the FTX-1 side is the one that was wrong.

### Why this had to land before MOR-2111's tone half

Under the mutually-exclusive mapping the **write** direction was not a function — codes 0, 3, 4 and 5 all collapsed onto "both false" — so a setter would have needed read-modify-write and could still have silently destroyed a DCS configuration. Corrected, the write direction is a plain function: `(F,F)→0`, `(T,F)→1`, `(T,T)→2`, and `(F,T)` is not representable on this radio, so a setter refuses rather than guessing.

### Two review rounds, and what the first one caught

Round one returned BLOCKED on something a passing suite cannot show: **the change disarmed a neighbouring test.** `test_read_sql_type_is_a_pure_read` catches a read that leaks into state. It pre-seeded `(True, True)` and fed code 2 — a pair that was unreachable under the old mapping and *is the derived value* under the new one, so leaked and preserved state became indistinguishable. Reproduced with a control: pre-change the leak reddens it, post-change it passes. Re-seeded to `(False, True)`, the one pair no code can produce.

Round one also found four further sites asserting the removed model — one in `rigs/ftx1.toml`, three in the adapter test — because it swept for the *shape of the claim* rather than for the mapping's mechanism. And it refuted the first commit's own evidence for a citation fix.

### Verification

The second reviewer reproduced rather than read. The leak reddens the guard in two places; a behaviour-preserving rewrite stays green; reinstating the old derivation reddens exactly three tests. The derivation was diffed over the **entire input space** — code 2 is the only input whose output changes. Correctness was checked against the manual whose SHA-256 matches the one pinned in `docs/validation/cat-audits/ftx1.md`, and all 50 rows of the tone chart were diffed against `_CTCSS_TONE_CENTIHZ` with a control proving the comparison can report inequality.

The eight `2507`→`2508-C` citations were corrected as one set, after the first pass corrected two of eight and left two revisions cited for one radio in adjacent comments.

### Known, recorded, not fixed here

A leak using the *pre-change* formula would also produce `(False, True)` and go uncaught — `(T,T)` is unreachable under the old mapping and `(F,T)` under the new, so no single seed defends both. Theoretical, since that formula no longer exists in the tree. The reviewer measured a two-line alternative that defends both by re-asserting after the existing second read at code 1; worth doing, not done here.

Two `2507` citations remain in `tests/test_ftx1_radio.py`, outside this diff and byte-identical to `main`.

Two sentences in `observations.py` claiming `CN` is "a deferred follow-up, not emitted here" are false — `CN` is wired and emitted forty lines below in the same method. Pre-existing on `main`, outside these hunks, flagged for an audit follow-up.
