### PR TITLE
fix(MOR-2133): derive dual-watch state query from profile

### DIFF
--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -153,8 +153,10 @@ def build_state_queries(
     if profile.receiver_count > 1:
         queries.append((0x07, 0xD2, None))  # Active receiver
     if "dual_watch" in capabilities:
-        command, sub, _ = decode_wire_tuple(profile.command_map.get("get_dual_watch"))
-        queries.append((command, sub, None))
+        command, sub, prefix = decode_wire_tuple(
+            profile.command_map.get("get_dual_watch")
+        )
+        queries.append((command, sub if sub is not None else prefix[0], None))
 
     # Common feature queries (data-driven: if radio has the command, poll it)
     _COMMON_FEATURE_QUERIES: list[tuple[int, int]] = [

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 
+from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
@@ -152,7 +153,8 @@ def build_state_queries(
     if profile.receiver_count > 1:
         queries.append((0x07, 0xD2, None))  # Active receiver
     if "dual_watch" in capabilities:
-        queries.append((0x07, 0xC2, None))  # Dual Watch status
+        command, sub, _ = decode_wire_tuple(profile.command_map.get("get_dual_watch"))
+        queries.append((command, sub, None))
 
     # Common feature queries (data-driven: if radio has the command, poll it)
     _COMMON_FEATURE_QUERIES: list[tuple[int, int]] = [

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
+from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
@@ -138,6 +140,19 @@ class TestBuildStateQueries:
         q1 = build_state_queries(profile, caps)
         q2 = build_state_queries(profile, caps)
         assert q1 == q2
+
+    def test_ic9700_dual_watch_query_uses_profile_wire_tuple(self) -> None:
+        profile = resolve_radio_profile(model="IC-9700")
+        command, sub, prefix = decode_wire_tuple(
+            profile.command_map.get("get_dual_watch")
+        )
+        assert prefix == b""
+
+        dual_watch_delta = Counter(
+            build_state_queries(profile, {"dual_watch"})
+        ) - Counter(build_state_queries(profile, set()))
+
+        assert dual_watch_delta == Counter({(command, sub, None): 1})
 
 
 class TestScopeReceiverSelector:

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
-from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands._frame import build_civ_frame, decode_wire_tuple
 from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
@@ -146,13 +146,30 @@ class TestBuildStateQueries:
         command, sub, prefix = decode_wire_tuple(
             profile.command_map.get("get_dual_watch")
         )
-        assert prefix == b""
+        assert (command, sub, prefix) == (0x16, 0x59, b"")
 
         dual_watch_delta = Counter(
             build_state_queries(profile, {"dual_watch"})
         ) - Counter(build_state_queries(profile, set()))
 
-        assert dual_watch_delta == Counter({(command, sub, None): 1})
+        assert dual_watch_delta == Counter({(0x16, 0x59, None): 1})
+
+    def test_ic7610_dual_watch_query_preserves_wire_tuple(self) -> None:
+        profile = resolve_radio_profile(model="IC-7610")
+        command, sub, prefix = decode_wire_tuple(
+            profile.command_map.get("get_dual_watch")
+        )
+        assert (command, sub, prefix) == (0x07, None, b"\xc2")
+
+        dual_watch_delta = Counter(
+            build_state_queries(profile, {"dual_watch"})
+        ) - Counter(build_state_queries(profile, set()))
+
+        assert dual_watch_delta == Counter({(0x07, 0xC2, None): 1})
+        assert (0x07, None, None) not in dual_watch_delta
+        assert build_civ_frame(0x98, 0xE0, 0x07, sub=0xC2) == bytes.fromhex(
+            "FE FE 98 E0 07 C2 FD"
+        )
 
 
 class TestScopeReceiverSelector:


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-2133
- Compatibility impact: wire behavior for the shipped IC-9700 state query is corrected; IC-7610 is preserved. No public API, CLI, config, profile, or hardware changes.
- Revised Live scope: `build_state_queries` selects the dual-watch query from the profile for the shipped IC-9700 while preserving IC-7610. Structural `query_for_path` / generic acquisition-envelope work is separate.
- Implementation: decode the selected profile `get_dual_watch` declaration and normalize the two supported shipped shapes to the existing state-query tuple contract.
- File scope: 2 files; aggregate 37 additions / 1 deletion.

## Verification

- [x] Relevant local tests or checks run: exact-head `uv run pytest tests/test_state_queries.py -q` — 25 passed; narrow Ruff and diff checks passed.
- [x] Public/open-core boundary checked.
- [x] Release or migration impact documented if applicable: no release or migration impact.
- Discriminating RED evidence: before the first correction, the IC-9700 capability delta was actual `(0x07, 0xC2, None)` versus profile-decoded and explicit expected `(0x16, 0x59, None)`. A review-found IC-7610 regression was caught by the new preservation test before the second correction.
- Exact-head Mac mini full run: Python: 14,305 collected / 14,096 passed / 161 skipped / 48 xfailed / 0 failed/errors; Ruff PASS. Frontend: 373 files / 8,166 tests, lint and type-check PASS. Wrapper exit 0, `FINAL: PASS`. The first exact-head remote attempt reached 94% but lost its SSH summary and was classified UNKNOWN; one authorized retry used durable capture and passed.

## Agent Review

- [x] Independent agent review comment posted before merge.
- Reviewer: independent verifier
- Result: `Agent Review: PASS 0fa10cf209eaffd2df5464c62e019e65e423a22e`
- The independent code verdict exists for this exact head. The GitHub Agent Review Gate has not yet been claimed as passed.

## Notes

- Out of scope / follow-ups: loader-valid command-only or arbitrary multi-prefix `get_dual_watch` shapes are not established dual-watch semantics. Generic acquisition-envelope / full-prefix support is a separate structural gap and is not claimed fixed here.