### PR TITLE
fix(ic705): declare dual-watch setter absent

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -508,6 +508,7 @@ set_vfo = [0x07]
 get_dual_watch = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3: cmd 0x07 table is 00/01/A0/B0 only" }
 # set_dual_watch_off/set_dual_watch_on (not the bare set_dual_watch the
 # pre-migration fallback resolved -- MOR-2007 ruling 1 split the setter key)
+set_dual_watch = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3: cmd 0x07 table is 00/01/A0/B0 only" }
 set_dual_watch_off = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3: cmd 0x07 table is 00/01/A0/B0 only" }
 set_dual_watch_on = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3: cmd 0x07 table is 00/01/A0/B0 only" }
 get_main_sub_band = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.3: cmd 0x07 table has no D0/D1/D2" }

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2907,10 +2907,11 @@ class TestIc9700DeclaresAbsentCommands:
 
 class TestIc705DeclaresAbsentCommands:
     """MOR-2016 (D2): IC-705 is filled with the ``{ absent = "<source>" }``
-    spelling for 25 commands the IC-705 CI-V Reference Guide (A7560-8EX-1,
+    spelling for 26 commands the IC-705 CI-V Reference Guide (A7560-8EX-1,
     Jul.2020) confirms have no row on this radio (24 at D2 time; MOR-2007
     ruling 1 later split ``set_dual_watch`` into
-    ``set_dual_watch_off``/``set_dual_watch_on``, +1 net). Pinned by name,
+    ``set_dual_watch_off``/``set_dual_watch_on``, +1 net; MOR-2143 added the
+    bare ``set_dual_watch`` name, +1, for the current 26). Pinned by name,
     not just count, so a future D2 pass on another command can't silently
     swap one of these for a different one and still pass a bare-count
     check.
@@ -2931,6 +2932,7 @@ class TestIc705DeclaresAbsentCommands:
             "get_digisel",
             "set_digisel",
             "get_dual_watch",
+            "set_dual_watch",
             "set_dual_watch_off",
             "set_dual_watch_on",
             "get_ip_plus",


### PR DESCRIPTION
## Summary

- Resolves [MOR-2143](https://linear.app/morozsm/issue/MOR-2143): the normalized IC-705 profile now declares the dual-watch setter unavailable.
- Keeps canonical runtime and UI paths unchanged: manufacturer documentation -> profile truth -> one canonical implementation -> consumers.
- Reuses the existing adjacent profile citation; this PR does not claim an independent extraction of the historical manufacturer PDF.

## Validation

- `uv run pytest tests/test_rig_loader.py -q` (8 passed)
- Hardware validation: not applicable; this is a declarative normalized-profile correction.

## Scope

Two files only: `rigs/ic705.toml` and `tests/test_rig_loader.py`.