### PR TITLE
docs(MOR-1993): correct reverse-index SSOT claims

### DIFF
--- a/docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md
+++ b/docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md
@@ -582,7 +582,11 @@ or match a reply to a request the code itself just sent, so the code already
 knows which command it is dealing with. `_civ_rx.py` decodes frames the radio
 sends unprompted: it has bytes and must recover a name. `CommandMap`
 (`commands/command_map.py`) offers `get`, `has`, `__iter__`, `__len__` and
-`__repr__` — name to bytes only.
+`__repr__` — name to bytes only. This was the pre-Z2 surface observed for this
+historical census. It is superseded by merged [PR #2941](https://github.com/rigplane/rigplane-core/pull/2941):
+`commands/command_map.py: ReverseCommandIndex` now supplies the per-profile
+reverse surface described by
+[`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md).
 
 **The reverse index is not injective, and not marginally so.** *Measured* by
 loading each profile and inverting `RigConfig.to_command_map` twice — once into
@@ -612,12 +616,12 @@ names on one tuple. On IC-705, `0E` resolves to
 the ordinary get/set pair: `07` is `{get_vfo, set_vfo}`, `11` is
 `{get_attenuator, set_attenuator}`.
 
-**What that means for the design.** A reverse index alone answers neither
-consumer. What closes the gap is a small rule set — payload absent means a
-read, payload `00` or `01` distinguishes these two writes — and the important
-property is that those rules are **per radio language, not per model**: the
-get/set-by-payload convention is a fact about CI-V, not about an IC-7300. That
-is exactly the category C8.7 already lists as what a profile will never supply.
+**What that meant for the design at the time.** The payload-absence / `00` / `01`
+direction rule below was a historical hypothesis, not the current contract. It
+is superseded by merged [PR #2941](https://github.com/rigplane/rigplane-core/pull/2941)
+and [`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md):
+all prefix-compatible declared names remain candidates; only a singleton
+resolves; request or direction context is required to disambiguate the rest.
 
 So the reverse index and the per-language rules are **one deliverable with
 three customers**: `runtime/_civ_rx.py`, the single double of C8, and any
@@ -720,4 +724,3 @@ ordered, sized and pinned to named tests in:
 | All ten owner rulings — D1, D2, and Q3–Q8 | plan §8.1 |
 
 Neither document is complete on its own.
-

--- a/docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md
+++ b/docs/plans/2026-08-29-profile-driven-command-bytes-evidence.md
@@ -482,14 +482,17 @@ two more hardcoded command families into a test double, deepening the exact
 hole being filled. So this is recorded as a **known blind spot with a named
 closure** — the closure is C8, and C8 comes after plan Step Z.
 
-### C8.5 The shared missing piece
+### C8.5 The historical shared missing piece
 
-The double needs **bytes → name**. So does `runtime/_civ_rx.py`. Neither exists
-today. That is Q3 (plan §8.1), settled as one deliverable with three
-customers rather than as one decoder for one consumer — and ruled out of this
-programme's scope, tracked separately as **MOR-1993**, which now blocks
-**MOR-2010**. The measured finding behind that scoping — the reverse index is
-one-to-many and needs a small per-language rule set beside it — is §C9.
+At the pre-Z2 snapshot, the double and `runtime/_civ_rx.py` both needed
+**bytes → name**, and neither surface existed. Q3 (plan §8.1) therefore
+recorded a historical proposal for one deliverable with three customers, with
+a reverse index plus a small per-language rule set. That proposal is superseded
+by merged [PR #2941](https://github.com/rigplane/rigplane-core/pull/2941): the
+per-profile `commands/command_map.py: ReverseCommandIndex` preserves every
+prefix-compatible candidate and does not infer direction. The canonical current
+contract is in
+[`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md).
 
 ### C8.6 The state the double needs already exists — checked
 
@@ -570,7 +573,7 @@ and none should be inferred.
 
 ---
 
-## C9. The third population, and the reverse index it needs
+## C9. The third population, and the historical reverse-index requirement
 
 Plan §1.4 records that a third population of hardcoded command bytes exists —
 `runtime/_civ_rx.py` compares `frame.command` / `frame.sub` against integer
@@ -623,12 +626,13 @@ and [`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md)
 all prefix-compatible declared names remain candidates; only a singleton
 resolves; request or direction context is required to disambiguate the rest.
 
-So the reverse index and the per-language rules are **one deliverable with
-three customers**: `runtime/_civ_rx.py`, the single double of C8, and any
-future consumer that must interpret a frame it did not build. Whether that
-deliverable belongs to this programme or its own was plan §8.1 Q3, ruled
-separate — tracked as **MOR-1993**, which now blocks **MOR-2010** — precisely
-because it is one thing serving three, not one thing serving one.
+The historical proposal treated a reverse index and per-language rules as one
+deliverable for three customers: `runtime/_civ_rx.py`, the single double of C8,
+and future consumers that interpret frames they did not build. That proposal is
+superseded by the candidate-preservation contract above: the current resolver
+does not infer direction. Its source of truth is
+[`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md)
+and `commands/command_map.py: ReverseCommandIndex`.
 
 ---
 

--- a/docs/plans/2026-08-29-profile-driven-command-bytes.md
+++ b/docs/plans/2026-08-29-profile-driven-command-bytes.md
@@ -796,6 +796,12 @@ until MOR-1993 lands, unsolicited frames are still decoded against
 IC-7610-era literals, so a radio whose profile disagrees will have its own
 broadcasts misread even after every request and reply is profile-driven.
 
+This is the historical pre-Z2 state, not the current architecture. Merged
+[PR #2941](https://github.com/rigplane/rigplane-core/pull/2941) added the
+per-profile `commands/command_map.py: ReverseCommandIndex`; the current
+contract and remaining migration plan are canonical in
+[`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md).
+
 ---
 
 ## 7. What could go wrong
@@ -987,6 +993,12 @@ we send comes from the profile** (§2). Reading an unsolicited frame still
 resolves against `runtime/_civ_rx.py`'s literals until MOR-1993 lands, and
 evidence §C8's single test double stays unbuildable until then too, for the
 same reason.
+
+This Q3 ruling records the historical pre-Z2 state. Merged
+[PR #2941](https://github.com/rigplane/rigplane-core/pull/2941) established
+the per-profile `commands/command_map.py: ReverseCommandIndex`; consult
+[`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md)
+for the canonical current contract and migration sequence.
 
 **Q4 — The temporary measurement hook's charter exception is approved,
 bounded.** Step 1's logging wrapper installed over the exported builders at

--- a/docs/plans/2026-08-29-profile-driven-command-bytes.md
+++ b/docs/plans/2026-08-29-profile-driven-command-bytes.md
@@ -191,7 +191,12 @@ compares `frame.command` / `frame.sub` against integer literals **105 times**
 (census of `ast.Compare` nodes at `a2de2ab0`; the whole tree has 108, the other
 three being 2 in `runtime/radio.py` and 1 in `core/civ.py`). That code decodes
 *unsolicited* frames the radio sends on its own, so it needs the opposite
-lookup — bytes to name — which today's `CommandMap` does not offer. See Q3.
+lookup — bytes to name — which the pre-Z2 `CommandMap` did not offer. This is
+a historical observation at `a2de2ab0`: merged
+[PR #2941](https://github.com/rigplane/rigplane-core/pull/2941) now provides
+the per-profile `commands/command_map.py: ReverseCommandIndex`. Its canonical
+current contract is in
+[`2026-09-01-reverse-command-index.md`](2026-09-01-reverse-command-index.md).
 
 The good news, *observed*: `_builders.py: parse_level_response` and
 `_builders.py: parse_bool_response` take exactly `(command, sub, prefix)` — the
@@ -786,9 +791,9 @@ They disappear into `expect()` rather than being migrated.
 
 **Population 3 — `runtime/_civ_rx.py`, 105 comparisons.** Structurally
 different: it decodes frames the radio sends unprompted, so it needs bytes to
-name, and `CommandMap` offers only name to bytes. Building a reverse index is a
-change to `CommandMap`'s surface, which this design was told not to reopen. Q3
-(§8.1) settles it: the reverse index is a separate programme, tracked as
+name, and the pre-Z2 `CommandMap` offered only name to bytes. Building a reverse
+index was a change to `CommandMap`'s surface, which this design was told not to
+reopen. Q3 (§8.1) settles it: the reverse index is a separate programme, tracked as
 **MOR-1993**, which now blocks **MOR-2010**. The plan therefore stops at
 population 2, and this document's end state is *every byte we **send** comes
 from the profile* — narrower than "every byte" (§2). Leaving it is not free:
@@ -981,7 +986,8 @@ a second pass the same evening.
 **Q3 — The reverse index is a separate programme.** `runtime/_civ_rx.py`
 decodes what the radio sends unprompted by comparing against 105 hardcoded
 command/sub literals. Making that profile-driven needs a **bytes-to-name**
-lookup; the code can only go name-to-bytes today (`commands/command_map.py:
+lookup; at the pre-Z2 snapshot, the code could only go name-to-bytes
+(`commands/command_map.py:
 CommandMap` offers `get`, `has`, `__iter__`, `__len__`, `__repr__` and nothing
 else). It is real, non-trivial work: a reverse index is **not injective**, and
 not marginally so — on IC-7300, 142 of 177 wire tuples carry more than one


### PR DESCRIPTION
## Summary

- Corrects the two companion plans as one atomic SSOT follow-up to merged PR #2941.
- Retains all pre-Z2 measurements as historical evidence, while locating the current bytes-to-name authority in `commands/command_map.py: ReverseCommandIndex` and `docs/plans/2026-09-01-reverse-command-index.md`.
- States the conservative incoming-frame contract: every prefix-compatible declared name remains a candidate; only a singleton resolves; request or direction context is required to disambiguate.

## Contradiction census

Claim tested: no active repository prose may say that reverse lookup/index/surface is absent, that `CommandMap` is name-to-bytes-only, or that payload absence, `00`/`01`, payload length, longest prefix, or a per-language direction rule resolves an incoming frame.

Counterexample search: reviewed every matching occurrence in both companion plans and searched `docs/`, `src/`, and `tests/` for those variants. The follow-up commit `377634fd328718f647107c4451223cc58713f789` makes each retained 2026-08-29 assertion explicitly local historical pre-Z2 context and removes the active per-language-rule deliverable conclusion. No active contradiction was found outside these two documents. The canonical plan and `commands/command_map.py: ReverseCommandIndex` instead preserve candidates and reject payload-only direction inference.

Source evidence: merged [PR #2941](https://github.com/rigplane/rigplane-core/pull/2941), its [post-merge correction comment](https://github.com/rigplane/rigplane-core/pull/2941#issuecomment-5499665464), `commands/command_map.py: ReverseCommandIndex`, and `docs/plans/2026-09-01-reverse-command-index.md`.

## Control-plane follow-up

MOR-1993 is linked but not modified. Its live Linear description still says the reverse surface does not exist and repeats the rejected payload-direction rule; that field needs an owner-approved exact correction outside this PR.

## Checks

- `git diff --check`
- `.github/scripts/check-doc-citations.sh` — PASS
- `.github/scripts/check-doc-citations.sh --check-links` — PASS
- `.github/scripts/check-doc-citations.sh --check-growth origin/main` — PASS
- `.github/scripts/check-doc-citations.sh --check-links --check-growth origin/main` — PASS
- `.github/scripts/check-doc-citations.sh --check-dangling --check-growth origin/main` — PASS
- Whole-document and repository-wide contradiction census over `docs/`, `src/`, and `tests/`
- Boundary grep over the diff and this PR body

The independent verifier completed the non-growth dangling check successfully; the dangling baseline and growth gate both pass. No full test suite was run: this is documentation-only.