### PR TITLE
test(MOR-2157): decouple acquisition assertions from tuple shape

### DIFF
--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -18,6 +18,7 @@ which drives ``CoreRadio.select_receiver`` against a mocked commander.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import call as mock_call
 
@@ -67,6 +68,28 @@ def _wait_dispatch_of(call) -> object:
     return call.kwargs.get("wait_dispatch")
 
 
+def logical_civ_call(
+    call: Any, *, selected_unselected: bool = False
+) -> tuple[int | None, int, int | None, bytes]:
+    """Normalize a recorded send_civ call to route, command, sub, and data."""
+    command = call.args[0]
+    sub = call.kwargs["sub"]
+    data = call.kwargs["data"]
+    if command == 0x29:
+        receiver, command, *inner = data
+        return receiver, command, inner[0] if inner else None, bytes(inner[1:])
+    if (
+        selected_unselected
+        and command in (0x25, 0x26)
+        and sub is None
+        and data == b"\x01"
+    ):
+        return None, command, 0x01, b""
+    if command in (0x25, 0x26) and sub is None and data in (b"\x00", b"\x01"):
+        return data[0], command, None, b""
+    return None, command, sub, data
+
+
 @pytest.mark.asyncio
 async def test_meter_poll_sends_background_priority() -> None:
     radio = _make_radio(active="MAIN")
@@ -86,12 +109,17 @@ async def test_state_query_sends_background_priority() -> None:
     radio = _make_radio(active="MAIN")
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    poller._poll_index = 1  # noqa: SLF001
-    await poller._send_query()  # noqa: SLF001
+    for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+        poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
 
     assert radio.send_civ.await_count >= 1
+    calls = [logical_civ_call(call) for call in radio.send_civ.await_args_list]
+    assert any(receiver is not None for receiver, _, _, _ in calls)
+    assert any(command == 0x18 for _, command, _, _ in calls)
     for call in radio.send_civ.await_args_list:
         assert _priority_of(call) == Priority.BACKGROUND
+        assert _wait_dispatch_of(call) is False
 
 
 @pytest.mark.asyncio
@@ -116,10 +144,14 @@ async def test_state_query_sends_fire_and_forget() -> None:
     radio = _make_radio(active="MAIN")
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    poller._poll_index = 1  # noqa: SLF001
-    await poller._send_query()  # noqa: SLF001
+    for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+        poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
 
     assert radio.send_civ.await_count >= 1
+    calls = [logical_civ_call(call) for call in radio.send_civ.await_args_list]
+    assert any(receiver is not None for receiver, _, _, _ in calls)
+    assert any(command == 0x18 for _, command, _, _ in calls)
     for call in radio.send_civ.await_args_list:
         assert _priority_of(call) == Priority.BACKGROUND
         assert _wait_dispatch_of(call) is False

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -86,7 +86,8 @@ async def test_state_query_sends_background_priority() -> None:
     radio = _make_radio(active="MAIN")
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    await poller._send_one_state_query(0x03, None, None)  # noqa: SLF001
+    poller._poll_index = 1  # noqa: SLF001
+    await poller._send_query()  # noqa: SLF001
 
     assert radio.send_civ.await_count >= 1
     for call in radio.send_civ.await_args_list:
@@ -115,7 +116,8 @@ async def test_state_query_sends_fire_and_forget() -> None:
     radio = _make_radio(active="MAIN")
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    await poller._send_one_state_query(0x03, None, None)  # noqa: SLF001
+    poller._poll_index = 1  # noqa: SLF001
+    await poller._send_query()  # noqa: SLF001
 
     assert radio.send_civ.await_count >= 1
     for call in radio.send_civ.await_args_list:

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -73,9 +73,15 @@ def logical_civ_call(
 ) -> tuple[int | None, int, int | None, bytes]:
     """Normalize a recorded send_civ call to route, command, sub, and data."""
     command = call.args[0]
-    sub = call.kwargs["sub"]
-    data = call.kwargs["data"]
+    sub = call.kwargs.get("sub")
+    data = call.kwargs.get("data", b"")
+    if data is None:
+        data = b""
     if command == 0x29:
+        if sub is not None:
+            raise AssertionError("cmd29 outer sub must be absent")
+        if len(data) < 2:
+            raise AssertionError("cmd29 must carry receiver and inner command")
         receiver, command, *inner = data
         return receiver, command, inner[0] if inner else None, bytes(inner[1:])
     if (
@@ -88,6 +94,14 @@ def logical_civ_call(
     if command in (0x25, 0x26) and sub is None and data in (b"\x00", b"\x01"):
         return data[0], command, None, b""
     return None, command, sub, data
+
+
+def test_logical_civ_call_public_send_defaults_and_cmd29_validation() -> None:
+    assert logical_civ_call(mock_call(0x18)) == (None, 0x18, None, b"")
+    assert logical_civ_call(mock_call(0x16, sub=0x57)) == (None, 0x16, 0x57, b"")
+    assert logical_civ_call(mock_call(0x16, data=None)) == (None, 0x16, None, b"")
+    with pytest.raises(AssertionError, match="outer sub"):
+        logical_civ_call(mock_call(0x29, sub=0x42, data=b"\x00\x16"))
 
 
 @pytest.mark.asyncio

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -94,7 +94,14 @@ async def test_single_profile_poller_rejects_sub_receiver() -> None:
     with pytest.raises(CommandError, match="receiver=1"):
         await poller._execute(SetMode("USB", receiver=1))  # noqa: SLF001
 
-    assert all(receiver in {0, None} for _, _, receiver in poller._STATE_QUERIES)  # noqa: SLF001
+    for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+        poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+
+    assert all(
+        call.args[0] != 0x29 or call.kwargs["data"][0] != 0x01
+        for call in radio.send_civ.await_args_list
+    )
 
 
 async def test_control_handler_checks_capabilities_not_model_name() -> None:

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -103,7 +103,7 @@ async def test_single_profile_poller_rejects_sub_receiver() -> None:
         logical_civ_call(call, selected_unselected=True)
         for call in radio.send_civ.await_args_list
     ]
-    assert all(receiver != 1 for receiver, _, _, _ in calls)
+    assert {receiver for receiver, _, _, _ in calls} == {None, 0}
     assert calls.count((None, 0x25, 0x01, b"")) == 1
     assert calls.count((None, 0x26, 0x01, b"")) == 1
 

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -16,6 +16,7 @@ from rigplane.rigctld.state_cache import StateCache
 from rigplane.web import radio_poller as radio_poller_module
 from rigplane.web.handlers import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, RadioPoller, SetFreq, SetMode
+from test_poller_poll_priority import logical_civ_call
 
 # MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
 # dispatch bodies; the interlock seat now lives at its head, so the RF
@@ -98,10 +99,13 @@ async def test_single_profile_poller_rejects_sub_receiver() -> None:
         poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
         await poller._send_query()  # noqa: SLF001
 
-    assert all(
-        call.args[0] != 0x29 or call.kwargs["data"][0] != 0x01
+    calls = [
+        logical_civ_call(call, selected_unselected=True)
         for call in radio.send_civ.await_args_list
-    )
+    ]
+    assert all(receiver != 1 for receiver, _, _, _ in calls)
+    assert calls.count((None, 0x25, 0x01, b"")) == 1
+    assert calls.count((None, 0x26, 0x01, b"")) == 1
 
 
 async def test_control_handler_checks_capabilities_not_model_name() -> None:

--- a/tests/test_rig_ic705_mor1540.py
+++ b/tests/test_rig_ic705_mor1540.py
@@ -18,12 +18,15 @@ IC-705's declared capabilities, they pass.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from rigplane.radio import IcomRadio
 from rigplane.rig_loader import load_rig
-from rigplane.runtime._state_queries import build_state_queries
+from rigplane.rigctld.state_cache import StateCache
+from rigplane.web.radio_poller import CommandQueue, RadioPoller
 from test_radio import MockTransport
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
@@ -69,11 +72,24 @@ class TestDigiselCapabilityRemoved:
 class TestPollerSkipsDigiselQuery:
     """Cascade: the per-receiver state-query builder follows the capability."""
 
-    def test_no_0x16_0x4e_query_for_ic705(self, profile) -> None:
-        caps = set(profile.capabilities)
-        queries = build_state_queries(profile, caps, is_serial=False)
-        digisel_queries = [q for q in queries if q[0] == 0x16 and q[1] == 0x4E]
-        assert digisel_queries == []
+    @pytest.mark.asyncio
+    async def test_no_0x16_0x4e_query_for_ic705(self, profile) -> None:
+        radio = MagicMock()
+        radio.profile = profile
+        radio.model = profile.model
+        radio.capabilities = set(profile.capabilities)
+        radio._radio_state = SimpleNamespace(active="MAIN")
+        radio.send_civ = AsyncMock()
+        poller = RadioPoller(radio, StateCache(), CommandQueue())
+
+        for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+            poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+            await poller._send_query()  # noqa: SLF001
+
+        assert (0x16, 0x4E, b"") not in {
+            (call.args[0], call.kwargs["sub"], call.kwargs["data"])
+            for call in radio.send_civ.await_args_list
+        }
 
 
 class TestD2DocumentaryCommandBytes:

--- a/tests/test_rig_ic705_mor1540.py
+++ b/tests/test_rig_ic705_mor1540.py
@@ -27,6 +27,7 @@ from rigplane.radio import IcomRadio
 from rigplane.rig_loader import load_rig
 from rigplane.rigctld.state_cache import StateCache
 from rigplane.web.radio_poller import CommandQueue, RadioPoller
+from test_poller_poll_priority import logical_civ_call
 from test_radio import MockTransport
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
@@ -86,10 +87,12 @@ class TestPollerSkipsDigiselQuery:
             poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
             await poller._send_query()  # noqa: SLF001
 
-        assert (0x16, 0x4E, b"") not in {
-            (call.args[0], call.kwargs["sub"], call.kwargs["data"])
-            for call in radio.send_civ.await_args_list
-        }
+        assert not any(
+            command == 0x16 and sub == 0x4E
+            for _, command, sub, _ in map(
+                logical_civ_call, radio.send_civ.await_args_list
+            )
+        )
 
 
 class TestD2DocumentaryCommandBytes:

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -327,7 +327,8 @@ def test_civ_rx_0x1a_0x05_vox_delay(tmp_path: object) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_build_state_queries_omits_repeater_tone_and_tsql_on_ic7610() -> None:
+@pytest.mark.asyncio
+async def test_build_state_queries_omits_repeater_tone_and_tsql_on_ic7610() -> None:
     """MOR-661: the IC-7610 (HF/6m) has no FM-repeater CTCSS tone feature, so
     the capability-gated tone/tsql queries (0x16/0x42, 0x16/0x43, 0x1B/0x00,
     0x1B/0x01) are NOT polled — they read garbage (16.5 Hz) on this radio.
@@ -345,18 +346,31 @@ def test_build_state_queries_omits_repeater_tone_and_tsql_on_ic7610() -> None:
     radio.send_civ = AsyncMock()
     poller = RadioPoller(radio, StateCache(), CommandQueue())
 
-    queries = poller._STATE_QUERIES  # noqa: SLF001
-    cmd_sub_pairs = {(cmd, sub) for cmd, sub, _ in queries}
-    assert (0x16, 0x42) not in cmd_sub_pairs, "repeater_tone should not be polled"
-    assert (0x16, 0x43) not in cmd_sub_pairs, "repeater_tsql should not be polled"
-    assert (0x1B, 0x00) not in cmd_sub_pairs, "tone_freq should not be polled"
-    assert (0x1B, 0x01) not in cmd_sub_pairs, "tsql_freq should not be polled"
-    # vox queries are unrelated and must still be polled.
-    assert (0x14, 0x16) in cmd_sub_pairs, "vox_gain not polled"
-    assert (0x14, 0x17) in cmd_sub_pairs, "anti_vox_gain not polled"
+    async def send_state_queries() -> None:
+        for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+            poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+            await poller._send_query()  # noqa: SLF001
+
+    await send_state_queries()
+
+    frames = {
+        (call.args[0], call.kwargs["sub"], call.kwargs["data"])
+        for call in radio.send_civ.await_args_list
+    }
+    assert (0x29, None, b"\x00\x16\x42") not in frames, (
+        "repeater_tone should not be polled"
+    )
+    assert (0x29, None, b"\x00\x16\x43") not in frames, (
+        "repeater_tsql should not be polled"
+    )
+    assert (0x29, None, b"\x00\x1b\x00") not in frames, "tone_freq should not be polled"
+    assert (0x29, None, b"\x00\x1b\x01") not in frames, "tsql_freq should not be polled"
+    assert (0x14, 0x16, b"") in frames, "vox_gain not polled"
+    assert (0x14, 0x17, b"") in frames, "anti_vox_gain not polled"
 
 
-def test_build_state_queries_includes_notch_width() -> None:
+@pytest.mark.asyncio
+async def test_build_state_queries_includes_notch_width() -> None:
     """_build_state_queries includes 0x16/0x57 (manual notch width) for IC-7610."""
     profile = resolve_radio_profile(model="IC-7610")
     radio = MagicMock()
@@ -367,12 +381,18 @@ def test_build_state_queries_includes_notch_width() -> None:
     radio.send_civ = AsyncMock()
     poller = RadioPoller(radio, StateCache(), CommandQueue())
 
-    queries = poller._STATE_QUERIES  # noqa: SLF001
-    cmd_sub_pairs = {(cmd, sub) for cmd, sub, _ in queries}
-    assert (0x16, 0x57) in cmd_sub_pairs, "manual notch width (0x16/0x57) not polled"
+    for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+        poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+
+    assert (0x16, 0x57, b"") in {
+        (call.args[0], call.kwargs["sub"], call.kwargs["data"])
+        for call in radio.send_civ.await_args_list
+    }, "manual notch width (0x16/0x57) not polled"
 
 
-def test_build_state_queries_includes_break_in_delay() -> None:
+@pytest.mark.asyncio
+async def test_build_state_queries_includes_break_in_delay() -> None:
     """_build_state_queries includes 0x14/0x0F (break-in delay) as common query."""
     profile = resolve_radio_profile(model="IC-7610")
     radio = MagicMock()
@@ -383,9 +403,14 @@ def test_build_state_queries_includes_break_in_delay() -> None:
     radio.send_civ = AsyncMock()
     poller = RadioPoller(radio, StateCache(), CommandQueue())
 
-    queries = poller._STATE_QUERIES  # noqa: SLF001
-    cmd_sub_pairs = {(cmd, sub) for cmd, sub, _ in queries}
-    assert (0x14, 0x0F) in cmd_sub_pairs, "break_in_delay (0x14/0x0F) not polled"
+    for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+        poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
+
+    assert (0x14, 0x0F, b"") in {
+        (call.args[0], call.kwargs["sub"], call.kwargs["data"])
+        for call in radio.send_civ.await_args_list
+    }, "break_in_delay (0x14/0x0F) not polled"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -26,6 +26,7 @@ from rigplane.web.radio_poller import (
     SetVoxDelay,
     SetVoxGain,
 )
+from test_poller_poll_priority import logical_civ_call
 
 # MOR-1884: this suite drives ``RadioPoller._execute`` directly to exercise
 # dispatch bodies; the interlock seat now lives at its head, so the RF
@@ -346,27 +347,25 @@ async def test_build_state_queries_omits_repeater_tone_and_tsql_on_ic7610() -> N
     radio.send_civ = AsyncMock()
     poller = RadioPoller(radio, StateCache(), CommandQueue())
 
-    async def send_state_queries() -> None:
-        for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
-            poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
-            await poller._send_query()  # noqa: SLF001
+    for state_idx in range(len(poller._STATE_QUERIES)):  # noqa: SLF001
+        poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
+        await poller._send_query()  # noqa: SLF001
 
-    await send_state_queries()
-
-    frames = {
-        (call.args[0], call.kwargs["sub"], call.kwargs["data"])
-        for call in radio.send_civ.await_args_list
-    }
-    assert (0x29, None, b"\x00\x16\x42") not in frames, (
+    calls = set(map(logical_civ_call, radio.send_civ.await_args_list))
+    assert not any(command == 0x16 and sub == 0x42 for _, command, sub, _ in calls), (
         "repeater_tone should not be polled"
     )
-    assert (0x29, None, b"\x00\x16\x43") not in frames, (
+    assert not any(command == 0x16 and sub == 0x43 for _, command, sub, _ in calls), (
         "repeater_tsql should not be polled"
     )
-    assert (0x29, None, b"\x00\x1b\x00") not in frames, "tone_freq should not be polled"
-    assert (0x29, None, b"\x00\x1b\x01") not in frames, "tsql_freq should not be polled"
-    assert (0x14, 0x16, b"") in frames, "vox_gain not polled"
-    assert (0x14, 0x17, b"") in frames, "anti_vox_gain not polled"
+    assert not any(command == 0x1B and sub == 0x00 for _, command, sub, _ in calls), (
+        "tone_freq should not be polled"
+    )
+    assert not any(command == 0x1B and sub == 0x01 for _, command, sub, _ in calls), (
+        "tsql_freq should not be polled"
+    )
+    assert (None, 0x14, 0x16, b"") in calls, "vox_gain not polled"
+    assert (None, 0x14, 0x17, b"") in calls, "anti_vox_gain not polled"
 
 
 @pytest.mark.asyncio
@@ -385,10 +384,9 @@ async def test_build_state_queries_includes_notch_width() -> None:
         poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
         await poller._send_query()  # noqa: SLF001
 
-    assert (0x16, 0x57, b"") in {
-        (call.args[0], call.kwargs["sub"], call.kwargs["data"])
-        for call in radio.send_civ.await_args_list
-    }, "manual notch width (0x16/0x57) not polled"
+    assert (None, 0x16, 0x57, b"") in set(
+        map(logical_civ_call, radio.send_civ.await_args_list)
+    ), "manual notch width (0x16/0x57) not polled"
 
 
 @pytest.mark.asyncio
@@ -407,10 +405,9 @@ async def test_build_state_queries_includes_break_in_delay() -> None:
         poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
         await poller._send_query()  # noqa: SLF001
 
-    assert (0x14, 0x0F, b"") in {
-        (call.args[0], call.kwargs["sub"], call.kwargs["data"])
-        for call in radio.send_civ.await_args_list
-    }, "break_in_delay (0x14/0x0F) not polled"
+    assert (None, 0x14, 0x0F, b"") in set(
+        map(logical_civ_call, radio.send_civ.await_args_list)
+    ), "break_in_delay (0x14/0x0F) not polled"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Scope

- Linked issue / task: MOR-2157 (In Progress); MOR-2158 remains blocked.
- Compatibility impact: none. This is PR-A, test-only preparation for the subsequent canonical acquisition-envelope migration, not the implementation of that envelope.
- Only four test files changed; no production code or API behavior changed. Assertions now operate on emitted logical CI-V calls across plain and cmd29 wrappers and a full state-query rotation, preserving receiver, priority, fire-and-forget, and forbidden-query coverage.
- Two adversarial review rounds found and fixed alternate-wire, receiver-domain, outer-sub, and public-default gaps.

## Verification

- [x] Targeted normal order: 70 passed. Reverse order: 70 passed. Ruff, format, and diff checks passed.
- [x] Mac mini exact-head: Python 14,306 collected / 14,097 passed / 161 skipped / 48 xfailed / 0 failed or errors; frontend 373 files / 8,166 tests; lint/type PASS; exit 0.
- [x] Public/open-core boundary checked.
- [x] Aggregate diff: four test files, +127/-27. No local full suite was run.

## Agent Review

- [x] Independent exact-head code verdict exists.
- Reviewer result: PASS at 420e4bdd56769b3f602e5ee0ead0d417ce75f6f5.
- GitHub Agent Review Gate is not yet claimed green.

## Notes

- Out of scope / follow-ups: PR-B will introduce/remove the canonical production representation and `split_ctl_mem_sub`. MOR-2157 acceptance is not complete; no hardware validation is claimed.