### PR TITLE
feat(MOR-2147): add the shared ScaledStage fixed-native primitive

### DIFF
--- a/frontend/src/primitives/stage/ScaledStage.svelte
+++ b/frontend/src/primitives/stage/ScaledStage.svelte
@@ -1,0 +1,96 @@
+<!--
+  ScaledStage — the shared MOR-1160 "fixed-native" presentation primitive.
+
+  Renders `children` at a declared native size (`nativeW` x `nativeH`),
+  measures its own host box with `ResizeObserver`, and applies ONE uniform
+  `transform: scale(...)` (see `stage-scale.ts`), anchored to the top-left
+  corner, never growing past its authored size. Nothing inside the stage
+  reflows in response to the host resizing — only the transform on the
+  stage element changes.
+
+  CHROME MUST BE A SIBLING OF THE STAGE, NEVER A CHILD. `transform: scale()`
+  establishes a new containing block for `position: fixed` descendants, and
+  a scaled 44px touch target inside `children` is no longer 44px on screen.
+  Toolbars, buttons, or any chrome meant to stay real-sized belongs outside
+  `<ScaledStage>`, not inside its `children` snippet.
+
+  The outer "holder" element is what `ResizeObserver` measures; the caller
+  must give it a definite box on both axes — a parent that content-sizes its
+  rows leaves the holder at the native height, so the height axis never
+  constrains.
+
+  MOR-2147: ScaledStage must never write back onto the element it measures.
+  It used to collapse the holder's own height to the scaled native height
+  after every measurement, which desynchronized the holder's reported box
+  from its host's actual size — a shrink the observer then never reports
+  (the holder's real box didn't change), and a grow the observer reports on
+  the wrong axis (only width still tracked the host once height was pinned).
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { computeStageScale, type StageBox } from './stage-scale';
+
+  interface Props {
+    /** Native (authored) width of the stage content, in CSS pixels. */
+    nativeW: number;
+    /** Native (authored) height of the stage content, in CSS pixels. */
+    nativeH: number;
+    children: Snippet;
+  }
+
+  let { nativeW, nativeH, children }: Props = $props();
+
+  let holder: HTMLDivElement | undefined = $state();
+  let scale = $state(1);
+
+  $effect(() => {
+    if (!holder) return;
+
+    const native: StageBox = { width: nativeW, height: nativeH };
+
+    // Writes only to `scale` — never back onto `holder` (MOR-2147, see file
+    // header). `scale` is written but never read inside this effect.
+    const measure = (host: StageBox) => {
+      if (host.width <= 0 || host.height <= 0) return;
+      scale = computeStageScale(host, native);
+    };
+
+    const box = holder.getBoundingClientRect();
+    measure({ width: box.width, height: box.height });
+
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      measure({ width: entry.contentRect.width, height: entry.contentRect.height });
+    });
+    observer.observe(holder);
+
+    return () => observer.disconnect();
+  });
+</script>
+
+<div class="scaled-stage-holder" bind:this={holder}>
+  <div
+    class="scaled-stage"
+    style:width="{nativeW}px"
+    style:height="{nativeH}px"
+    style:transform="scale({scale})"
+  >
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .scaled-stage-holder {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .scaled-stage {
+    transform-origin: top left;
+  }
+</style>

--- a/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
+++ b/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
@@ -1,0 +1,191 @@
+/**
+ * MOR-2147 — component-level regression coverage for the ScaledStage
+ * measure/write defect: `ScaledStage` used to measure its "holder" element
+ * with `ResizeObserver` and then write `holder.style.height` back onto that
+ * same element, desynchronizing the reported box from the host's real size.
+ *
+ * jsdom implements neither layout nor `ResizeObserver`, so this file rebuilds
+ * the one piece of browser behavior the defect depends on: a real
+ * `ResizeObserver` reports an observed element's OWN content box, not its
+ * parent's. `effectiveHolderBox()` below models that box as CSS `100%` of
+ * the fake "parent" UNLESS the component has pinned an axis with an inline
+ * style — which is exactly the mechanism under test. `resizeContainer()`
+ * only invokes the fake observer's callback when that modeled box actually
+ * changed, mirroring a real `ResizeObserver`'s "no change, no callback"
+ * contract.
+ *
+ * Mounts a real component and stubs two globals (`ResizeObserver`,
+ * `getBoundingClientRect`), so this file is named `*.isolated.test.ts` per
+ * the pool-membership convention in `vite.config.ts`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync, type Snippet } from 'svelte';
+import ScaledStage from '../ScaledStage.svelte';
+
+interface Box {
+  readonly width: number;
+  readonly height: number;
+}
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  readonly callback: ResizeObserverCallback;
+  target: Element | null = null;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.target = target;
+  }
+
+  unobserve() {
+    this.target = null;
+  }
+
+  disconnect() {
+    this.target = null;
+  }
+}
+
+let components: ReturnType<typeof mount>[] = [];
+let containerSize: Box = { width: 0, height: 0 };
+let lastReportedHolderBox: Box | null = null;
+let holderEl: HTMLElement | null = null;
+let originalGetBoundingClientRect: typeof HTMLElement.prototype.getBoundingClientRect;
+let originalResizeObserver: typeof globalThis.ResizeObserver;
+
+/** What a real browser would report for the holder element right now: each
+ *  axis tracks the fake "parent" (`containerSize`) unless the component has
+ *  pinned that axis with an inline style, in which case the pinned value
+ *  wins regardless of the parent — the exact same-element measure/write bug
+ *  under test. Takes the element explicitly (rather than reading the
+ *  module-level `holderEl`) because it also runs from inside the
+ *  `getBoundingClientRect` stub during mount, before `mountStage` has had a
+ *  chance to capture `holderEl`. */
+function effectiveHolderBox(el: HTMLElement): Box {
+  const style = el.style;
+  return {
+    width: style.width ? parseFloat(style.width) : containerSize.width,
+    height: style.height ? parseFloat(style.height) : containerSize.height,
+  };
+}
+
+function stubRect(width: number, height: number): DOMRect {
+  return {
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return {};
+    },
+  } as DOMRect;
+}
+
+beforeEach(() => {
+  components = [];
+  containerSize = { width: 0, height: 0 };
+  lastReportedHolderBox = null;
+  holderEl = null;
+  FakeResizeObserver.instances = [];
+
+  originalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+
+  originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+  HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+    if (this.classList.contains('scaled-stage-holder')) {
+      const box = effectiveHolderBox(this);
+      return stubRect(box.width, box.height);
+    }
+    return stubRect(0, 0);
+  };
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+const noopChildren = ((_anchor: unknown) => ({
+  update: () => {},
+  destroy: () => {},
+})) as unknown as Snippet;
+
+/** Mounts `ScaledStage` at the given native size inside the current
+ *  `containerSize`, and captures the holder element for later resizes. */
+function mountStage(nativeW: number, nativeH: number): HTMLElement {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(ScaledStage, {
+    target,
+    props: { nativeW, nativeH, children: noopChildren },
+  });
+  flushSync();
+  components.push(component);
+  holderEl = target.querySelector<HTMLElement>('.scaled-stage-holder');
+  lastReportedHolderBox = effectiveHolderBox(holderEl!);
+  return target;
+}
+
+function readScale(target: HTMLElement): number {
+  const stage = target.querySelector<HTMLElement>('.scaled-stage');
+  const transform = stage?.style.transform ?? '';
+  const match = transform.match(/scale\(([-\d.]+)\)/);
+  return match ? Number(match[1]) : NaN;
+}
+
+/** Resizes the fake "parent" and, only if the holder's modeled box actually
+ *  changed as a result, fires the fake `ResizeObserver` callback for it. */
+function resizeContainer(width: number, height: number) {
+  containerSize = { width, height };
+  const box = effectiveHolderBox(holderEl!);
+  const unchanged =
+    lastReportedHolderBox &&
+    box.width === lastReportedHolderBox.width &&
+    box.height === lastReportedHolderBox.height;
+  if (unchanged) return;
+  lastReportedHolderBox = box;
+  for (const observer of FakeResizeObserver.instances) {
+    if (observer.target === holderEl) {
+      observer.callback(
+        [{ target: holderEl, contentRect: box } as unknown as ResizeObserverEntry],
+        observer as unknown as ResizeObserver,
+      );
+    }
+  }
+  flushSync();
+}
+
+describe('ScaledStage — measure/write regression (MOR-2147)', () => {
+  it('scale returns to 1 after the host grows from 100x100 to 4000x4000', () => {
+    containerSize = { width: 100, height: 100 };
+    const target = mountStage(200, 200);
+    expect(readScale(target)).toBe(0.5);
+
+    resizeContainer(4000, 4000);
+
+    expect(readScale(target)).toBe(1);
+  });
+
+  it('scale drops when only the host HEIGHT shrinks', () => {
+    containerSize = { width: 100, height: 100 };
+    const target = mountStage(200, 200);
+    expect(readScale(target)).toBe(0.5);
+
+    resizeContainer(100, 20);
+
+    expect(readScale(target)).toBeLessThan(0.5);
+  });
+});

--- a/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
+++ b/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { computeStageScale, MAX_STAGE_SCALE } from '../stage-scale';
+
+describe('computeStageScale', () => {
+  it('is width-constrained when the host is relatively narrow', () => {
+    // host fits 0.5x on width, 5x on height — the narrower ratio wins.
+    const scale = computeStageScale({ width: 100, height: 1000 }, { width: 200, height: 200 });
+    expect(scale).toBe(0.5);
+  });
+
+  it('is height-constrained when the host is relatively short', () => {
+    // host fits 5x on width, 0.5x on height — the narrower ratio wins.
+    const scale = computeStageScale({ width: 1000, height: 100 }, { width: 200, height: 200 });
+    expect(scale).toBe(0.5);
+  });
+
+  it('returns exactly 1 when the host matches the native size', () => {
+    const scale = computeStageScale({ width: 200, height: 200 }, { width: 200, height: 200 });
+    expect(scale).toBe(1);
+  });
+
+  it('caps at MAX_STAGE_SCALE (1) instead of growing past the native size', () => {
+    const scale = computeStageScale({ width: 2000, height: 2000 }, { width: 200, height: 200 });
+    expect(scale).toBe(MAX_STAGE_SCALE);
+    expect(scale).toBe(1);
+  });
+
+  it('returns 0 when the host has not been measured yet (zero size)', () => {
+    const scale = computeStageScale({ width: 0, height: 0 }, { width: 200, height: 200 });
+    expect(scale).toBe(0);
+  });
+
+  it('returns 0 when native width is zero', () => {
+    const scale = computeStageScale({ width: 200, height: 200 }, { width: 0, height: 200 });
+    expect(scale).toBe(0);
+  });
+
+  it('returns 0 when native height is zero', () => {
+    const scale = computeStageScale({ width: 200, height: 200 }, { width: 200, height: 0 });
+    expect(scale).toBe(0);
+  });
+
+  // MOR-2147: every non-degenerate case above uses a square 200x200 native
+  // box, so an axis swap (host.width/native.height paired with
+  // host.height/native.width) survives all of them undetected — a square
+  // box can't tell width from height apart.
+  // `presentation/layouts/lcd-declarations.ts` declares a 1280x540 native
+  // stage; these two pin that non-square shape.
+  describe('non-square native size (as declared in lcd-declarations.ts)', () => {
+    it('returns exactly 1 when a non-square host matches a non-square native size', () => {
+      const scale = computeStageScale({ width: 1280, height: 540 }, { width: 1280, height: 540 });
+      expect(scale).toBe(1);
+    });
+
+    it('is width-constrained on a non-square box', () => {
+      // host fits 0.5x on width, 1x on height — the narrower ratio wins.
+      const scale = computeStageScale({ width: 640, height: 540 }, { width: 1280, height: 540 });
+      expect(scale).toBe(0.5);
+    });
+  });
+});

--- a/frontend/src/primitives/stage/stage-scale.ts
+++ b/frontend/src/primitives/stage/stage-scale.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure arithmetic for the MOR-1160 "fixed-native" stage model: content is
+ * authored at one native size, then scaled UNIFORMLY (one ratio, not
+ * independent X/Y stretch) to fit whatever host box it is measured against,
+ * never larger than its authored size. Kept here, DOM-free, so the formula
+ * is unit-tested without mounting a component.
+ *
+ * This primitive does not resolve a minimum viable size (no `minScale`) —
+ * that decision belongs to the layout-resolution module under
+ * `presentation/layouts/`, which this file deliberately does not import,
+ * keeping the primitive free of the layout contract.
+ */
+
+export interface StageBox {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** The stage never grows past its authored (native) size. */
+export const MAX_STAGE_SCALE = 1;
+
+/**
+ * Returns the uniform scale factor that fits `native` inside `host` — the
+ * shorter of the two axis ratios wins — capped at `MAX_STAGE_SCALE` so the
+ * stage never grows past its authored size.
+ *
+ * Returns 0 for a host that has not been measured yet (zero-size box) or a
+ * degenerate native size (zero width or height).
+ */
+export function computeStageScale(host: StageBox, native: StageBox): number {
+  if (native.width <= 0 || native.height <= 0) return 0;
+  const fitWidth = host.width / native.width;
+  const fitHeight = host.height / native.height;
+  return Math.min(fitWidth, fitHeight, MAX_STAGE_SCALE);
+}


### PR DESCRIPTION
Linear: MOR-2147 · parent MOR-1162

Builds the shared primitive MOR-1160 assigned and that did not exist: `frontend/src/primitives/` held only `control-feedback/` and `frequency/`.

Full rationale is in the commit message, which becomes the squash body. Two points worth surfacing here:

**The MOR-1247 tripwire is NOT lifted.** The primitive takes its native size as props and reads no manifest field, so it names neither guarded identifier and `stage-sizing-boundary.test.ts` never fires on it — verified by running that test. My ticket text originally scoped the unfreeze into this change; that was wrong and is retracted in the ticket.

**Two independent review rounds returned BLOCKED, a third was prose-only under an explicit owner exception to the two-cycle limit.** Round 1 found the central defect — the component measured the same element it wrote to, so the height axis died after the first frame. Round 2 confirmed the fix correct and blocked on five prose claims, each falsified by measurement in real Chrome. Those five are deleted rather than softened.

Depends on nothing. Mergeable in any order.