### PR TITLE
feat(MOR-2155): make peer-split a loadable SkinId with a minimal shell

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -212,6 +212,9 @@ const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
   'lcd-cockpit': ['audio-fft'],
   'lcd-scope': ['audio-fft'],
   'mobile': ['hardware-scope'],
+  // MOR-2155: same reasoning as `dual-receiver-cockpit` above — the minimal
+  // shell mounts no scope panel of either kind.
+  'peer-split': [],
   'sdr-test': ['hardware-scope', 'audio-fft'],
 };
 
@@ -222,6 +225,7 @@ const WIDTH_FOR: Record<SkinId, number> = {
   'lcd-scope': 900,
   'sdr-test': 1400,
   'mobile': 390,
+  'peer-split': 1600,
 };
 function widthToSkin(): SkinId {
   const width = window.innerWidth;

--- a/frontend/src/__tests__/presentation-switch-tx.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-tx.component.test.ts
@@ -149,6 +149,11 @@ const WIDTH_FOR: Record<SkinId, number> = {
   'lcd-scope': 900,
   'sdr-test': 1400,
   'mobile': 390,
+  // MOR-2155: `peer-split` has no picker/resolveSkinId path (MOR-2152), so
+  // this file's TX-authority sweeps never request it directly — it is here
+  // only to satisfy `Record<SkinId, number>` exhaustiveness. 1600 is unused
+  // by every other entry in this table.
+  'peer-split': 1600,
 };
 function widthToSkin(): SkinId {
   const width = window.innerWidth;

--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -1,6 +1,6 @@
 /**
  * MOR-2038 — every `SkinId` registered in `skins/registry.ts` has a
- * behavioral entry-point pin: five directly in this file, the sixth
+ * behavioral entry-point pin: six directly in this file, one
  * (`dual-receiver-cockpit`) in its own dedicated suite, referenced and
  * guarded here (point 2 below) rather than duplicated. Generalized over the
  * registry instead of a hardcoded pair list (the previous version of this
@@ -52,6 +52,13 @@
  * `MobileRadioLayout.svelte` (the same technique as the `RadioLayout`/
  * `LcdLayout` mocks above) and asserts that loading `mobile` actually
  * mounts it.
+ *
+ * `peer-split` (MOR-2155) gets the same real-mount treatment: its entry
+ * component (`skins/segmentline/PeerSplitLayout.svelte`) is a zero-prop
+ * delegate straight to `SemanticRadioSurfaces` with `strips="dual"`, so its
+ * pin mocks `SemanticRadioSurfaces.svelte` and asserts the `strips` value
+ * actually forwarded — the same `variant`-forwarding shape the LCD wrappers
+ * pin above, one prop earlier in the chain.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { mount, unmount } from 'svelte';
@@ -61,6 +68,7 @@ import type { SkinId } from '../registry';
 const mountedSkinIds = vi.hoisted(() => [] as SkinId[]);
 const mountedLcdVariants = vi.hoisted(() => [] as Array<'cockpit' | 'scope'>);
 const mobileLayoutMounts = vi.hoisted(() => ({ count: 0 }));
+const mountedStrips = vi.hoisted(() => [] as Array<'single' | 'dual'>);
 
 vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
   default: (_anchor: unknown, props: { skinId?: SkinId }) => {
@@ -82,6 +90,14 @@ vi.mock('../../components-v2/layout/MobileRadioLayout.svelte', () => ({
   },
 }));
 
+// PeerSplitLayout takes no props (`<SemanticRadioSurfaces strips="dual" />`);
+// what is worth pinning is the `strips` literal it forwards.
+vi.mock('../../components-v2/wiring/SemanticRadioSurfaces.svelte', () => ({
+  default: (_anchor: unknown, props: { strips?: 'single' | 'dual' }) => {
+    mountedStrips.push(props.strips ?? 'single');
+  },
+}));
+
 import { loadSkin } from '../registry';
 
 const components: Record<string, unknown>[] = [];
@@ -91,12 +107,14 @@ afterEach(() => {
   mountedSkinIds.length = 0;
   mountedLcdVariants.length = 0;
   mobileLayoutMounts.count = 0;
+  mountedStrips.length = 0;
 });
 
 type EntrypointCoverage =
   | { readonly kind: 'radio-layout' }
   | { readonly kind: 'lcd-layout'; readonly variant: 'cockpit' | 'scope' }
   | { readonly kind: 'mobile-layout' }
+  | { readonly kind: 'semantic-radio-surfaces'; readonly strips: 'single' | 'dual' }
   | { readonly kind: 'covered-elsewhere'; readonly testFile: string; readonly entryComponentFile: string };
 
 /**
@@ -114,6 +132,7 @@ const SKIN_ENTRYPOINT_COVERAGE: Readonly<Record<SkinId, EntrypointCoverage>> = {
     entryComponentFile: 'DualReceiverCockpit.svelte',
   },
   mobile: { kind: 'mobile-layout' },
+  'peer-split': { kind: 'semantic-radio-surfaces', strips: 'dual' },
 };
 
 const allSkinIds = Object.keys(SKIN_ENTRYPOINT_COVERAGE) as SkinId[];
@@ -126,6 +145,11 @@ const lcdLayoutCases = allSkinIds.flatMap((id) => {
 });
 
 const mobileLayoutSkinIds = allSkinIds.filter((id) => SKIN_ENTRYPOINT_COVERAGE[id].kind === 'mobile-layout');
+
+const semanticRadioSurfacesCases = allSkinIds.flatMap((id) => {
+  const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
+  return coverage.kind === 'semantic-radio-surfaces' ? [[id, coverage.strips] as const] : [];
+});
 
 const coveredElsewhereCases = allSkinIds.flatMap((id) => {
   const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
@@ -165,6 +189,21 @@ describe('mobile skin entrypoint', () => {
     const target = document.createElement('div');
     components.push(mount(Component, { target }));
     expect(mobileLayoutMounts.count).toBe(1);
+  });
+});
+
+describe('semantic-radio-surfaces skin entrypoint', () => {
+  // Kills: PeerSplitLayout mounting SemanticRadioSurfaces with the wrong
+  // `strips` literal, forwarding a different skin's value, or dropping the
+  // prop (the mock's `?? 'single'` fallback then makes the equality fail for
+  // this table's `'dual'` case).
+  it.each(semanticRadioSurfacesCases)('mounts SemanticRadioSurfaces with its own strips value (%s -> %s)', async (
+    skinId, strips,
+  ) => {
+    const Component = await loadSkin(skinId);
+    const target = document.createElement('div');
+    components.push(mount(Component, { target }));
+    expect(mountedStrips).toEqual([strips]);
   });
 });
 

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -28,6 +28,7 @@ const entrypoints = vi.hoisted(() => {
     'lcd-cockpit': { name: 'lcd-cockpit' },
     'lcd-scope': { name: 'lcd-scope' },
     'mobile': { name: 'mobile' },
+    'peer-split': { name: 'peer-split' },
     'sdr-test': { name: 'sdr-test' },
     'dual-receiver-cockpit': { name: 'dual-receiver-cockpit' },
   };
@@ -40,6 +41,7 @@ const lazyImports = vi.hoisted(() => {
     'lcd-cockpit': vi.fn(() => ({ default: entrypoints['lcd-cockpit'] })),
     'lcd-scope': vi.fn(() => ({ default: entrypoints['lcd-scope'] })),
     'mobile': vi.fn(() => ({ default: entrypoints['mobile'] })),
+    'peer-split': vi.fn(() => ({ default: entrypoints['peer-split'] })),
     'sdr-test': vi.fn(() => ({ default: entrypoints['sdr-test'] })),
     'dual-receiver-cockpit': vi.fn(() => ({ default: entrypoints['dual-receiver-cockpit'] })),
   };
@@ -50,6 +52,7 @@ vi.mock('../desktop-v2/DesktopSkin.svelte', () => lazyImports['desktop-v2']());
 vi.mock('../lcd-cockpit/LcdCockpitSkin.svelte', () => lazyImports['lcd-cockpit']());
 vi.mock('../lcd-scope/LcdScopeSkin.svelte', () => lazyImports['lcd-scope']());
 vi.mock('../mobile/MobileSkin.svelte', () => lazyImports['mobile']());
+vi.mock('../segmentline/PeerSplitLayout.svelte', () => lazyImports['peer-split']());
 vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports['sdr-test']());
 vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports['dual-receiver-cockpit']());
 
@@ -111,6 +114,7 @@ describe('skin registry', () => {
     ['lcd-cockpit', entrypoints['lcd-cockpit'], lazyImports['lcd-cockpit']],
     ['lcd-scope', entrypoints['lcd-scope'], lazyImports['lcd-scope']],
     ['mobile', entrypoints['mobile'], lazyImports['mobile']],
+    ['peer-split', entrypoints['peer-split'], lazyImports['peer-split']],
     ['sdr-test', entrypoints['sdr-test'], lazyImports['sdr-test']],
   ] as const;
 
@@ -214,6 +218,7 @@ describe('presentation resource plan', () => {
   const EXPECTED_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
     'desktop-v2': ['audio-fft', 'hardware-scope'],
     'dual-receiver-cockpit': [],
+    'peer-split': [],
     'sdr-test': ['audio-fft', 'hardware-scope'],
     'lcd-cockpit': ['audio-fft'],
     'lcd-scope': ['audio-fft'],

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -16,7 +16,8 @@ import {
 } from '$lib/runtime/adapters/layout-mode-adapter';
 
 export type SkinId =
-  | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'sdr-test';
+  | 'desktop-v2' | 'dual-receiver-cockpit' | 'lcd-cockpit' | 'lcd-scope' | 'mobile' | 'peer-split'
+  | 'sdr-test';
 
 export interface SkinResolutionContext {
   capabilities: Capabilities | null;
@@ -83,6 +84,10 @@ const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
   'lcd-cockpit': () => import('./lcd-cockpit/LcdCockpitSkin.svelte'),
   'lcd-scope': () => import('./lcd-scope/LcdScopeSkin.svelte'),
   'mobile': () => import('./mobile/MobileSkin.svelte'),
+  // MOR-2155: makes `peer-split` addressable and loadable only — a minimal
+  // shell with no layout manifest (MOR-2151) and no `resolveSkinId` branch
+  // (MOR-2152), same precedent as the `dual-receiver-cockpit` entry above.
+  'peer-split': () => import('./segmentline/PeerSplitLayout.svelte'),
   'sdr-test': () => import('./sdr-test/SdrTestSkin.svelte'),
 };
 
@@ -121,6 +126,12 @@ const SKIN_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
   'lcd-cockpit': ['audio-fft'],
   'lcd-scope': ['audio-fft'],
   'mobile': ['hardware-scope'],
+  // Empty by construction, same reasoning as `dual-receiver-cockpit` above:
+  // the dual composition mounts neither SpectrumPanel nor AudioSpectrumPanel,
+  // and membership only permits bridging, so naming a resource this tree
+  // cannot consume would be a presentation manufacturing a live service (v3
+  // ADR invariant 12).
+  'peer-split': [],
   'sdr-test': ['hardware-scope', 'audio-fft'],
 };
 

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -1,0 +1,36 @@
+<!--
+  Peer Split Layout (MOR-2155) — the `peer-split` SkinId's minimal shell.
+  Makes the id addressable and loadable only: NOT backed by a layout
+  manifest (MOR-2151) and NOT reachable from `resolveSkinId` or the picker
+  (MOR-2152). Real composition is MOR-2153 — this mounts the dual-receiver
+  wiring (`SemanticRadioSurfaces` with `strips="dual"`) and nothing else,
+  same wiring `dual-receiver-cockpit/DualReceiverCockpit.svelte` reuses
+  unmodified. Only ONE `SemanticRadioSurfaces` may ever be mounted here: a
+  second would be a second TX lease source, and single TX authority is the
+  hardest invariant in this tree (see that file's header for the full
+  rationale).
+
+  Cannot be mounted standalone: `SemanticRadioSurfaces` calls
+  `getAppTxController()`, which throws `Error: App TxController host is not
+  provided` unless `provideAppTxControllerHost` ran higher in the tree — that
+  is `App.svelte`'s job, not this shell's. Confirmed by mounting this
+  component directly with no App-provided context: it throws before adding
+  anything to the DOM (empty `innerHTML`, zero children). Do not add a mock
+  or stub host here to paper over that — MOR-2153 owns real composition, and
+  a real render needs the same harness `DualReceiverCockpit.component.test.ts`
+  builds (App's runtime/tx-controller/command mocks), not a shortcut in this
+  file.
+-->
+<script lang="ts">
+  // MOR-1257 (N4): the components-v2 theme layer (fonts, base tokens, and
+  // the MOR-1232 focus-ring pair --v2-focus-ring-color/--v2-focus-ring) is
+  // code-split per skin. A standalone mount that skips this side-effect
+  // import never loads the theme layer, and app.css's
+  // `outline: var(--v2-focus-ring, var(--focus-ring))` silently falls back
+  // to the legacy ring (MOR-1070 evidence run finding N4, same reasoning
+  // `DualReceiverCockpit.svelte` documents for its own copy of this import).
+  import '../../components-v2/theme/index';
+  import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
+</script>
+
+<SemanticRadioSurfaces strips="dual" />


### PR DESCRIPTION
Linear: MOR-2155 · parent MOR-1162

Registers `peer-split` as addressable and loadable. Deliberately NOT selectable from the picker (MOR-2152) and not backed by a layout manifest (MOR-2151).

**MERGE THIS BEFORE #2951 (MOR-2148).** The design language's `layoutCompatibility` names `peer-split`, and activation matches the resolved `SkinId`. Nothing breaks in the other order — no test cross-checks a language's ids against the skin union — but for a window the comment there would name an id that does not exist.

This can land ahead of the layout manifest because the F8 check in `cockpit-topology-adaptation.test.ts` is one-directional: every registered manifest must name a loadable skin, with no reverse requirement. A review enumerated every reader of the `SkinId` union to confirm that.

Reviewed independently, PASS. Five mutations killed, two of them ones the author had not run. Prose findings recorded in the commit message rather than fixed, per the owner's 2026-09-01 decision that prose does not warrant further review rounds.

---

## Correction, added after review: the "precedent" claim is false

The commit message and the paragraph above say `dual-receiver-cockpit` is the precedent for an addressable id with **no** `resolveSkinId` branch. That is wrong, and the error is mine as coordinator, not the implementers.

`resolveSkinId` in `frontend/src/skins/registry.ts` returns `'dual-receiver-cockpit'` on its second body line, reachable in production through `lib/stores/qa-cockpit-override.ts` and `App.svelte`. Every member of the `SkinId` union is returnable. I trusted a stale comment in `SKIN_LOADERS` twelve lines below instead of reading the function above it — established by a reviewer enumerating the union, not by me.

**What this does NOT change.** The operative claim behind this PR is that a `SkinId` may exist with no layout MANIFEST, because the F8 check in `cockpit-topology-adaptation.test.ts` iterates manifests to skins and never the reverse. That was established independently, by enumerating every reader of the union text, and it stands. `peer-split` genuinely has no `resolveSkinId` branch here; what is false is only the claim that another skin set that precedent.

Not fixed by amending, because the commit is reviewed at this exact head and a re-cut would cost a full review cycle for one sentence — the owner ruled on 2026-09-01 that prose does not warrant that. Recorded here instead so the history carries the correction beside the claim.
