### PR TITLE
feat(MOR-2148): register the segmentline amber-LCD design language

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -17,12 +17,13 @@
   // does. Imported here too so the activation effect below cannot depend on a
   // lazily-loaded skin having pulled the barrel in first.
   import './presentation/languages/declarations';
-  // Both scoped language stylesheets ship with the production composition
+  // Every scoped language stylesheet ships with the production composition
   // root. They stay inert until the canonical activation attribute below is
   // present; loading them here prevents the fixture harness from being their
   // only build path.
   import './presentation/languages/studioline/studioline.css';
   import './presentation/languages/fieldline/fieldline.css';
+  import './presentation/languages/segmentline/segmentline.css';
   import { getLayout } from './presentation/layouts/contract';
   // MOR-1082, the layout half of the same idiom: a side-effect import that
   // populates the LAYOUT registry, so `getLayout(skinId)` below can resolve

--- a/frontend/src/presentation/languages/__tests__/activation-attribute.test.ts
+++ b/frontend/src/presentation/languages/__tests__/activation-attribute.test.ts
@@ -70,7 +70,7 @@ describe('MOR-1278 — the glob finds design-language stylesheets to pin', () =>
     // Named on purpose: a family whose sheet stopped being discovered (moved,
     // renamed) would otherwise silently drop out of every pin below.
     expect(SHEETS.map((s) => s.language)).toEqual(
-      expect.arrayContaining(['studioline', 'fieldline']),
+      expect.arrayContaining(['studioline', 'fieldline', 'segmentline']),
     );
   });
 });
@@ -87,10 +87,10 @@ describe.each(SHEETS)(
     });
 
     it('opens every selector with the sanctioned attribute, doubled for specificity', () => {
-      // The doubled attribute is the deliberate one-step raise both sheets use
-      // to outrank Svelte's own (0,2,0) component rules; a single attribute
-      // would tie and lose on order, i.e. the language would silently fail to
-      // restyle the surfaces it exists to restyle.
+      // The doubled attribute is the deliberate one-step raise all three
+      // sheets use; a single attribute would tie and lose on order, i.e. the
+      // language would silently fail to restyle the surfaces it exists to
+      // restyle.
       const unscoped = SELECTORS.filter(
         (s) => !s.startsWith(`${attribute}[data-design-language]`));
       expect(unscoped).toEqual([]);

--- a/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
+++ b/frontend/src/presentation/languages/__tests__/layout-compatibility-inventory.test.ts
@@ -113,10 +113,7 @@ describe('every shipped design-language manifest declares at least one compatibl
  * decided will never carry design-language chrome (`lcd-cockpit`,
  * `lcd-scope`, `mobile`, `sdr-test` below). The distinction is recorded here,
  * on the layout side, as `LAYOUT_EXEMPTIONS` — an explicit list with a reason
- * per entry — rather than as a full language×layout matrix, which was
- * considered and deferred under the rule of three (only two design languages
- * are shipped today; a matrix generalizes over a count that does not exist
- * yet).
+ * per entry — rather than as a full language×layout matrix.
  *
  * A layout counts as "mentioned" the moment ANY shipped language's
  * `layoutCompatibility` names it — a `compatible: true` entry and a

--- a/frontend/src/presentation/languages/__tests__/production-activation.test.ts
+++ b/frontend/src/presentation/languages/__tests__/production-activation.test.ts
@@ -4,18 +4,61 @@
  * The language stylesheets are intentionally scoped and inert until App owns
  * the canonical activation attributes. Keep this source-level guard close to
  * the language contract: the built-dist browser suite proves reachability,
- * while this prevents the production entrypoint from silently losing either
- * stylesheet or replacing the theme catalogue with a second polarity list.
+ * while this prevents the production entrypoint from silently losing a
+ * registered stylesheet or replacing the theme catalogue with a second
+ * polarity list.
+ *
+ * The expected import list is derived from the declarations barrel's own
+ * export surface, rather than hand-listed: a hand-listed literal per family
+ * is exactly what let a fourth registered family with no App.svelte import
+ * pass this check silently (MOR-2148 round-2 review). Deliberately NOT
+ * sourced from `listDesignLanguageIds()`/the live registry — same reason
+ * `../layout-compatibility-inventory.test.ts`'s own `SHIPPED_MANIFESTS`
+ * gives for the same choice: that registry is module-scope, mutable state
+ * a sibling test file can write a throwaway probe manifest into (e.g.
+ * `registry.test.ts`'s "no hardcoded family count" case), and this project
+ * runs under `isolate: false` (`vite.config.ts`), so such a probe can leak
+ * into this file's read of the registry. The barrel's own exports carry no
+ * such risk.
+ *
+ * This assumes the naming convention every family shipped so far follows —
+ * `presentation/languages/<id>/<id>.css` — which the assertion below itself
+ * enforces for every id the barrel currently exports.
  */
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import type { DesignLanguageManifest } from '../contract';
+// Namespace import used ONLY to derive the manifest list structurally, same
+// discipline as `../layout-compatibility-inventory.test.ts`'s
+// `languageDeclarationsBarrel` import.
+import * as languageDeclarationsBarrel from '../declarations';
 
 const app = readFileSync('src/App.svelte', 'utf8');
 
+/** Structural `DesignLanguageManifest` guard for filtering the barrel's
+ *  export surface — mirrors `layout-compatibility-inventory.test.ts`'s
+ *  local guard of the same name and shape. */
+function isDesignLanguageManifest(value: unknown): value is DesignLanguageManifest {
+  return (
+    typeof value === 'object' && value !== null &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    typeof (value as { displayName?: unknown }).displayName === 'string' &&
+    Array.isArray((value as { layoutCompatibility?: unknown }).layoutCompatibility) &&
+    typeof (value as { renderers?: unknown }).renderers === 'object'
+  );
+}
+
+const SHIPPED_MANIFESTS: readonly DesignLanguageManifest[] =
+  Object.values(languageDeclarationsBarrel).filter(isDesignLanguageManifest);
+
 describe('MOR-1400 A — production design-language activation', () => {
   it('production App imports every registered design-language stylesheet', () => {
-    expect(app).toContain("import './presentation/languages/studioline/studioline.css';");
-    expect(app).toContain("import './presentation/languages/fieldline/fieldline.css';");
+    // Guards the derivation itself: if the barrel filter ever matched
+    // nothing, every assertion below would pass vacuously.
+    expect(SHIPPED_MANIFESTS.length).toBeGreaterThan(0);
+    for (const { id } of SHIPPED_MANIFESTS) {
+      expect(app).toContain(`import './presentation/languages/${id}/${id}.css';`);
+    }
   });
 
   it('uses the existing theme catalogue for the canonical language-mode writer', () => {

--- a/frontend/src/presentation/languages/__tests__/registry.test.ts
+++ b/frontend/src/presentation/languages/__tests__/registry.test.ts
@@ -1,12 +1,11 @@
 /**
  * MOR-1072 registry: the two frozen family IDs (`studioline`/`fieldline`,
  * MOR-977 §4.6) are registered as declarations, and the registry does not
- * hardcode a family count — a third, hypothetical family registers and
+ * hardcode a family count — an arbitrary, hypothetical family registers and
  * validates the same way. MOR-1073 gave studioline its renderers and MOR-1074
  * gave fieldline its own, so BOTH declared families now fill every slot — the
  * "zero renderers declared" fallback path is exercised by the shared fixture
- * (`validManifest`) and by `renderer-contract.test.ts`, which is where it
- * belongs now that no real family is renderer-less.
+ * (`validManifest`) and by `renderer-contract.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -58,7 +57,7 @@ describe('the two frozen v3 declarations', () => {
 });
 
 describe('no hardcoded family count', () => {
-  it('registers a third, hypothetical family (fixed-scale, density not-applicable) the same way as studioline/fieldline', () => {
+  it('registers an arbitrary, hypothetical family (fixed-scale, density not-applicable) the same way as studioline/fieldline', () => {
     const before = listDesignLanguageIds().length;
     const thirdFamily = validManifest({ id: 'thirdline', displayName: 'Thirdline', density: { kind: 'not-applicable' } });
     expect(() => registerDesignLanguage(thirdFamily)).not.toThrow();

--- a/frontend/src/presentation/languages/declarations.ts
+++ b/frontend/src/presentation/languages/declarations.ts
@@ -3,18 +3,38 @@
  * (reference) and `fieldline` (proof). RX/TX namespace chosen here
  * (MOR-1231 note): `--dl-rx-*`/`--dl-tx-*`, distinct from the legacy
  * `--v2-tx-*` family. Registering here does not hardcode "two families":
- * contract.test.ts registers a third the same way.
+ * `segmentline` below is the real third.
  *
  * MOR-1073 landed studioline's real token set and its three renderers
  * (`./studioline`); MOR-1074 does the same for `fieldline` (`./fieldline`),
  * which retires the shared placeholder bundle that used to stand in for it.
- * Both families now supply their own contrast-proven ring tone, so nothing
- * here inherits `var(--accent)` — which carries no such guarantee — any more.
  * The contract's `var(--accent)` default is deliberately left untouched.
  *
  * The two bundles are imported under family-qualified aliases because they
  * export the same three renderer names: that symmetry IS the proof — the
  * second language plugs into identical slots with no contract change.
+ *
+ * MOR-2148 registers `segmentline`, the amber-LCD instrument family, as
+ * tokens + stylesheet + manifest only — `renderers: {}`, which
+ * `resolveRenderer` (`./contract.ts`) falls back on safely. Renderers are
+ * MOR-2149's job.
+ *
+ * `layoutCompatibility` declares `peer-split: true` and `desktop-v2:
+ * false`. Activation matches the resolved `SkinId`, not a
+ * `presentation/layouts/` manifest id: `App.svelte` calls
+ * `designLanguageActivation(language, skinId)` (`../workspace/activation.ts`),
+ * whose parameter is merely *named* `layoutId`. `peer-split` is a
+ * registered `SkinId` with a loadable shell (MOR-2155), but `resolveSkinId`
+ * (`../../skins/registry.ts`) has no branch that returns it and no
+ * `presentation/layouts/` manifest names it (MOR-2151), so segmentline
+ * cannot activate in production yet — that routing is later in MOR-1162's
+ * delivery order (`docs/plans/2026-09-01-segmentline-peer-split.md` §7:
+ * MOR-2151, MOR-2152), not an oversight here. `unified-instrument` and
+ * `panadapter-first`, the handoff's other two proposed directions, are
+ * named nowhere in this repository either — no `SkinId`, no layout
+ * manifest — so they are absent from this list too. `desktop-v2: false`
+ * is kept because segmentline's fixed-native glass and desktop-v2's fluid
+ * chrome are a real, current incompatibility.
  */
 import { registerDesignLanguage, type DesignLanguageManifest } from './contract';
 import { renderFrequency as studiolineFrequency } from './studioline/frequency-renderer';
@@ -25,6 +45,7 @@ import { renderFrequency as fieldlineFrequency } from './fieldline/frequency-ren
 import { renderMeter as fieldlineMeter } from './fieldline/meters-renderer';
 import { renderStateFeedback as fieldlineStateFeedback } from './fieldline/state-feedback-renderer';
 import { FIELDLINE_TOKENS } from './fieldline/tokens';
+import { SEGMENTLINE_TOKENS } from './segmentline/tokens';
 
 export const studioline: DesignLanguageManifest = {
   id: 'studioline',
@@ -67,5 +88,26 @@ export const fieldline: DesignLanguageManifest = {
   },
 };
 
+export const segmentline: DesignLanguageManifest = {
+  id: 'segmentline',
+  displayName: 'Segmentline',
+  tokens: SEGMENTLINE_TOKENS,
+  // Clamped out at dense — the outlined cells collide with the 7px meter
+  // pitch (tokens.ts `meters`).
+  density: { kind: 'clamped', supported: ['comfortable', 'compact'] },
+  layoutCompatibility: [
+    { layoutId: 'peer-split', compatible: true },
+    {
+      layoutId: 'desktop-v2',
+      compatible: false,
+      reason: 'segmentline assumes a fixed-native instrument glass; desktop-v2 is fluid chrome.',
+    },
+  ],
+  // MOR-2149 fills these three slots; `resolveRenderer` falls back to a
+  // safe no-op for an unfilled slot in the meantime.
+  renderers: {},
+};
+
 registerDesignLanguage(studioline);
 registerDesignLanguage(fieldline);
+registerDesignLanguage(segmentline);

--- a/frontend/src/presentation/languages/layout-compatibility-guard.ts
+++ b/frontend/src/presentation/languages/layout-compatibility-guard.ts
@@ -31,9 +31,9 @@
  * nothing, so both must warn.
  *
  * WHERE THIS IS WIRED: `registerDesignLanguage` (`./contract.ts`) is the
- * one choke point every manifest passes through — the two built-in
- * families (`./declarations.ts`) and any third-party skin's manifest
- * alike — so guarding there, once, covers every manifest that will ever
+ * one choke point every manifest passes through — the built-in families
+ * (`./declarations.ts`) and any third-party skin's manifest alike — so
+ * guarding there, once, covers every manifest that will ever
  * reach `designLanguageActivation`. Unlike `guardRadioViewModel`
  * (`components-v2/wiring/radio-view-model-guard.ts`, MOR-2040), no eslint
  * layering boundary forces this guard into a different directory than the

--- a/frontend/src/presentation/languages/segmentline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/stylesheet.test.ts
@@ -1,0 +1,205 @@
+/**
+ * MOR-2148 — structural pins for the `segmentline` stylesheet.
+ *
+ * The activation-attribute doubling (`[data-design-language='segmentline']
+ * [data-design-language]` on every selector) is already pinned, for every
+ * discovered language sheet including this one, by the general
+ * `../../__tests__/activation-attribute.test.ts` (MOR-1275) — not repeated
+ * here.
+ *
+ * Unlike `studioline`/`fieldline`, this file has no `.rx-tx-surface`/
+ * `.rx-tx-key`/`.rx-tx-state` cascade to rank: those rules style the
+ * stateFeedback renderer's output, and segmentline ships no renderers yet
+ * (MOR-2149). What exists today is the glass, the cell, the seven-segment
+ * readout cell, the segmented meter track and the DIM contrast preset —
+ * pinned below directly, by parsing declarations rather than by ranking a
+ * cascade collision (there is none yet to rank).
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { SEGMENTLINE_PALETTE, SEGMENTLINE_SURFACES, SEGMENTLINE_TOKENS } from '../tokens';
+
+const source = readFileSync('src/presentation/languages/segmentline/segmentline.css', 'utf8');
+// Comments name the very constructs several tests below forbid, so they are
+// stripped first: the pins are about DECLARATIONS, not about prose.
+const css = source.replace(/\/\*[\s\S]*?\*\//g, '');
+
+const ATTR = "[data-design-language='segmentline'][data-design-language]";
+
+interface Rule { selector: string; declarations: Record<string, string>; order: number }
+
+function parseRules(sheet: string): Rule[] {
+  const rules: Rule[] = [];
+  for (const [, selectorList, body] of sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const declarations: Record<string, string> = {};
+    for (const declaration of body.split(';')) {
+      const colon = declaration.indexOf(':');
+      if (colon > 0) declarations[declaration.slice(0, colon).trim()] = declaration.slice(colon + 1).trim();
+    }
+    // A comma-separated list is N rules that happen to share a body.
+    for (const selector of selectorList.split(',')) {
+      const trimmed = selector.trim();
+      if (trimmed) rules.push({ selector: trimmed, declarations, order: rules.length });
+    }
+  }
+  return rules;
+}
+
+const RULES = parseRules(css);
+/** Exact selector match — the base (non-media-query) copy, since `.find`
+ *  returns the first of the two identical selectors the reduced-motion
+ *  block at the bottom of the file repeats. */
+const findExact = (selector: string): Rule | undefined => RULES.find((r) => r.selector === selector);
+
+describe('the sheet parses into something worth asserting against', () => {
+  it('found the glass, cell, readout and meter rules it is about to pin', () => {
+    expect(RULES.length).toBeGreaterThan(20);
+    expect(RULES.some((r) => r.selector.includes('.dl-glass'))).toBe(true);
+    expect(RULES.some((r) => r.selector.includes('.dl-cell'))).toBe(true);
+    expect(RULES.some((r) => r.selector.includes('.dl-freq'))).toBe(true);
+    expect(RULES.some((r) => r.selector.includes('.dl-meter'))).toBe(true);
+  });
+});
+
+describe('the glass: fixed-native geometry over the amber ground', () => {
+  it('is the declared 14px padding inside a 2px bezel, 10px outer radius', () => {
+    const glass = findExact(`${ATTR} .dl-glass`)!;
+    expect(glass.declarations.padding).toBe('14px');
+    expect(glass.declarations.border).toBe('2px solid var(--dl-segmentline-bezel-edge)');
+    expect(glass.declarations['border-radius']).toBe('10px');
+    expect(glass.declarations.background).toBe('var(--dl-segmentline-glass)');
+  });
+
+  it('sets colour explicitly rather than inheriting it', () => {
+    const glass = findExact(`${ATTR} .dl-glass`)!;
+    expect(glass.declarations.color).toBe('var(--dl-segmentline-ink-strong)');
+  });
+
+  it('the TX perimeter requires the tx="active" attribute, and is geometry only (no colour emitted here)', () => {
+    const border = findExact(`${ATTR} .dl-glass[data-tx='active']`)!;
+    expect(border.declarations['border-color']).toBe('var(--dl-segmentline-tx-active)');
+    const glow = findExact(`${ATTR} .dl-glass[data-tx='active']::after`)!;
+    expect(glow.declarations['box-shadow']).toBeDefined();
+    // The renderer emits colour; this file emits only the frame — no `color`
+    // or `background` declared on the glow itself.
+    expect(glow.declarations.color).toBeUndefined();
+    expect(glow.declarations.background).toBeUndefined();
+  });
+});
+
+describe('cells: the family\'s only control shape, never a filled button', () => {
+  it('is outlined with no fill', () => {
+    const cell = findExact(`${ATTR} .dl-cell`)!;
+    expect(cell.declarations.background).toBe('none');
+    expect(cell.declarations.border).toBe('var(--dl-segmentline-cell-border) solid var(--dl-segmentline-ink-soft)');
+  });
+
+  it('the hot+active combination is required together — an inactive TX-capable cell stays dim ink (v3 ADR invariant 9)', () => {
+    const hot = findExact(`${ATTR} .dl-cell[data-tone='hot'][data-active='true']`)!;
+    expect(hot.declarations.color).toBe('var(--dl-segmentline-tx-mark)');
+    // No rule keys off [data-tone='hot'] alone (without [data-active]) —
+    // that shape is exactly what would mark TX-capability itself as hot,
+    // rather than the lit+capable combination.
+    expect(RULES.some((r) => /\[data-tone='hot'\]$/.test(r.selector))).toBe(false);
+  });
+});
+
+describe('the seven-segment readout is shrink-wrapped, per-glyph', () => {
+  it('the readout box is width:max-content — never a stretched flex child', () => {
+    const freq = findExact(`${ATTR} .dl-freq`)!;
+    expect(freq.declarations.width).toBe('max-content');
+    expect(freq.declarations['font-family']).toMatch(/DSEG7/);
+  });
+
+  it('each glyph is its own inline-block cell, so total width is font-size alone', () => {
+    const cell = findExact(`${ATTR} .dl-freq-cell`)!;
+    expect(cell.declarations.display).toBe('inline-block');
+  });
+});
+
+describe('the segmented meter track derives its pitch from the tokens, never a literal', () => {
+  it('declares the 7px/3px pitch as custom properties, and the fill reads them back', () => {
+    const root = findExact(ATTR)!;
+    expect(root.declarations['--dl-segmentline-track-width']).toBe('7px');
+    expect(root.declarations['--dl-segmentline-segment-gap']).toBe('3px');
+    const fill = findExact(`${ATTR} .dl-meter-fill`)!;
+    expect(fill.declarations['background-image']).toContain('var(--dl-segmentline-track-width)');
+    expect(fill.declarations['background-image']).toContain('var(--dl-segmentline-segment-pitch)');
+  });
+
+  it('an unread meter is marked unknown, never rendered as a gauge resting at zero', () => {
+    const unknown = findExact(`${ATTR} [data-dl-unknown='true']`)!;
+    expect(unknown.declarations.color).toBe('var(--dl-segmentline-ink-soft)');
+  });
+});
+
+describe('the root declares the HIGH ink ramp and cell geometry at their literal values', () => {
+  it('scales the ink ramp to the declared 1/0.65/0.34/0.09/0.5 alphas', () => {
+    const root = findExact(ATTR)!;
+    expect(root.declarations['--dl-segmentline-ink-strong']).toBe('rgba(var(--dl-segmentline-ink) / 1)');
+    expect(root.declarations['--dl-segmentline-ink-mid']).toBe('rgba(var(--dl-segmentline-ink) / 0.65)');
+    expect(root.declarations['--dl-segmentline-ink-soft']).toBe('rgba(var(--dl-segmentline-ink) / 0.34)');
+    expect(root.declarations['--dl-segmentline-ink-ghost']).toBe('rgba(var(--dl-segmentline-ink) / 0.09)');
+    expect(root.declarations['--dl-segmentline-ink-telemetry']).toBe('rgba(var(--dl-segmentline-ink) / 0.5)');
+  });
+
+  it('the cell border custom property is the declared 1.25px', () => {
+    const root = findExact(ATTR)!;
+    expect(root.declarations['--dl-segmentline-cell-border']).toBe('1.25px');
+  });
+});
+
+describe('the DIM contrast preset is an explicit opt-in, never density or an OS signal', () => {
+  it("keys off [data-dl-contrast='dim'], never [data-density] or prefers-color-scheme", () => {
+    expect(css).toMatch(/\[data-dl-contrast='dim'\]/);
+    expect(css).not.toMatch(/data-density/);
+    expect(css).not.toMatch(/prefers-color-scheme/);
+  });
+
+  it('scales the ink ramp to the declared 0.55/0.36/0.20/0.06/0.30 alphas', () => {
+    const dim = findExact(`${ATTR} [data-dl-contrast='dim']`)!;
+    expect(dim.declarations['--dl-segmentline-ink-strong']).toBe('rgba(var(--dl-segmentline-ink) / 0.55)');
+    expect(dim.declarations['--dl-segmentline-ink-mid']).toBe('rgba(var(--dl-segmentline-ink) / 0.36)');
+    expect(dim.declarations['--dl-segmentline-ink-soft']).toBe('rgba(var(--dl-segmentline-ink) / 0.2)');
+    expect(dim.declarations['--dl-segmentline-ink-ghost']).toBe('rgba(var(--dl-segmentline-ink) / 0.06)');
+    expect(dim.declarations['--dl-segmentline-ink-telemetry']).toBe('rgba(var(--dl-segmentline-ink) / 0.3)');
+  });
+});
+
+describe('the CSS half honours the same constraints as the token half', () => {
+  it('adds and removes nothing — a language may not become a capability fork', () => {
+    expect(css).not.toMatch(/display:\s*none/);
+    expect(css).not.toMatch(/visibility:\s*hidden/);
+    // Unlike studioline/fieldline (which declare no `content` at all),
+    // segmentline has two decorative pseudo-elements (the glass texture and
+    // the TX glow) and both must be empty strings — never text content.
+    const contentDeclarations = RULES.map((r) => r.declarations.content).filter((v) => v !== undefined);
+    expect(contentDeclarations.length).toBeGreaterThan(0);
+    for (const value of contentDeclarations) expect(value).toBe("''");
+  });
+
+  it('never re-suppresses the focus ring, and applies it as `outline` (MOR-977 §1.2.5)', () => {
+    expect(css).not.toMatch(/outline:\s*none/);
+    const focus = findExact(`${ATTR} .dl-cell:focus-visible`)!;
+    expect(focus.declarations.outline).toBe('2px solid var(--dl-segmentline-ink-strong)');
+  });
+
+  it('wins on specificity rather than on `!important`', () => {
+    expect(css).not.toMatch(/!important/);
+  });
+
+  it('declares every palette entry it references as a custom property', () => {
+    for (const hex of [
+      SEGMENTLINE_SURFACES.glass, SEGMENTLINE_SURFACES.bezel,
+      SEGMENTLINE_PALETTE.txHot, SEGMENTLINE_PALETTE.txMark, SEGMENTLINE_PALETTE.tuning,
+    ]) {
+      expect(css.toLowerCase()).toContain(hex.toLowerCase());
+    }
+  });
+
+  it('the meter pitch is the same 7px/3px pair on both halves of the slice', () => {
+    const root = findExact(ATTR)!;
+    expect(root.declarations['--dl-segmentline-track-width']).toBe(SEGMENTLINE_TOKENS.meters.trackWidth);
+    expect(root.declarations['--dl-segmentline-segment-gap']).toBe(SEGMENTLINE_TOKENS.meters.segmentGap);
+  });
+});

--- a/frontend/src/presentation/languages/segmentline/__tests__/tokens.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/tokens.test.ts
@@ -1,0 +1,143 @@
+/**
+ * MOR-2148 — the `segmentline` token slice.
+ *
+ * Unlike `studioline`/`fieldline`, segmentline's state tones are not flat
+ * hex swatches on two fixed grounds — every rx/tx tone falls back to one
+ * ink at a declared alpha (`SEGMENTLINE_INK`) or to the TX/tuning palette
+ * (`SEGMENTLINE_PALETTE`), composited over a single amber glass. The WCAG
+ * two-surface contrast arithmetic the sibling files run does not apply to
+ * that shape (there is one ground, and an alpha ink's effective colour
+ * depends on what it sits on), so this file pins the literal fallback each
+ * token resolves to instead of computing a contrast ratio.
+ *
+ * FOCUS-RING SYNTAX (MOR-1232 finding D5) still applies exactly as it does
+ * for studioline/fieldline: the contract stores the ring as one opaque
+ * string, and a box-shadow-shaped literal there is silently invalid CSS.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateManifest, REQUIRED_TOKEN_GROUPS } from '../../contract';
+import { segmentline, studioline, fieldline } from '../../declarations';
+import { SEGMENTLINE_INK, SEGMENTLINE_PALETTE, SEGMENTLINE_TOKENS } from '../tokens';
+
+/** `<width> <style> <color>` — the shorthand form `outline` actually accepts. */
+const OUTLINE_SHORTHAND = /^\d+(?:\.\d+)?px\s+(?:solid|dashed|dotted|double)\s+\S.*$/;
+
+/** The literal fallback inside `var(--dl-segmentline-<name>, <fallback>)`. */
+function fallbackLiteral(token: string): string {
+  const hit = /^var\(--dl-segmentline-[\w-]+,\s*(.+)\)$/.exec(token);
+  expect(hit, `expected a var(--dl-segmentline-*, <fallback>) token in "${token}"`).not.toBeNull();
+  return hit![1];
+}
+
+describe('focus ring is outline syntax (MOR-1232 D5)', () => {
+  it('declares a ring assignable to `outline`', () => {
+    expect(segmentline.tokens.focusRing).toMatch(OUTLINE_SHORTHAND);
+    // The shape that motivated the re-shape: a box-shadow spread list.
+    expect(segmentline.tokens.focusRing).not.toMatch(/^0 0 0 /);
+  });
+
+  it('falls back to the declared focus palette entry, not an invented literal', () => {
+    expect(fallbackLiteral(segmentline.tokens.focusRing.replace(/^2px solid /, ''))).toBe(SEGMENTLINE_PALETTE.focus);
+  });
+});
+
+describe('segmentline token set implements the MOR-2148 amber-LCD grammar', () => {
+  it('validates against the MOR-1072 contract', () => {
+    expect(() => validateManifest(segmentline)).not.toThrow();
+    expect(REQUIRED_TOKEN_GROUPS.every((g) => segmentline.tokens[g] !== undefined)).toBe(true);
+  });
+
+  it('is the manifest segmentline registers — not a copy', () => {
+    expect(segmentline.tokens).toBe(SEGMENTLINE_TOKENS);
+  });
+
+  it('the readout face is seven-segment, weight 700, and tabular', () => {
+    expect(SEGMENTLINE_TOKENS.typography.fontFamily).toMatch(/DSEG7/);
+    expect(SEGMENTLINE_TOKENS.typography.weight).toBe(700);
+    expect(SEGMENTLINE_TOKENS.typography.fontVariantNumeric).toBe('tabular-nums');
+  });
+
+  it('cells are hairline-outlined and barely rounded — a printed segment box, not a button', () => {
+    expect(SEGMENTLINE_TOKENS.geometry.radius).toBe('2px');
+    expect(SEGMENTLINE_TOKENS.geometry.borderWidth).toBe('1.25px');
+  });
+
+  it('the meter is a 7px segmented track with a 3px gap, not a continuous rail', () => {
+    expect(SEGMENTLINE_TOKENS.meters.trackWidth).toBe('7px');
+    expect(SEGMENTLINE_TOKENS.meters.segmentGap).toBe('3px');
+    expect(Number.parseFloat(SEGMENTLINE_TOKENS.meters.segmentGap)).toBeGreaterThan(0);
+  });
+
+  it('frequency groups are ranked at the numeral weight', () => {
+    expect(SEGMENTLINE_TOKENS.frequency.rankedGroups).toBe(true);
+    expect(SEGMENTLINE_TOKENS.frequency.digitWeight).toBe(SEGMENTLINE_TOKENS.typography.weight);
+  });
+
+  it('the glass steps rather than animates: a 90ms TX fade, reduced-motion safe', () => {
+    expect(SEGMENTLINE_TOKENS.motion.durationMs).toBe(90);
+    expect(SEGMENTLINE_TOKENS.motion.reducedMotionSafe).toBe(true);
+  });
+
+  it('every rx/tx token falls back to a declared ink or palette entry', () => {
+    const stateTokens = [...Object.values(SEGMENTLINE_TOKENS.rx), ...Object.values(SEGMENTLINE_TOKENS.tx)];
+    expect(stateTokens).toHaveLength(6);
+    const declared = [...Object.values(SEGMENTLINE_INK), ...Object.values(SEGMENTLINE_PALETTE)];
+    for (const token of stateTokens) {
+      expect(declared).toContain(fallbackLiteral(token));
+    }
+  });
+
+  it('rx/tx idle both fall back to the same soft ink — idle reads as absence, not as a colour choice', () => {
+    // Against the literal, not `SEGMENTLINE_INK.soft` itself: comparing a
+    // token to the very constant that builds it would let both sides drift
+    // together under a mutated ramp and never fail.
+    expect(fallbackLiteral(SEGMENTLINE_TOKENS.rx.idle)).toBe('rgba(26,16,0,0.34)');
+    expect(fallbackLiteral(SEGMENTLINE_TOKENS.tx.idle)).toBe('rgba(26,16,0,0.34)');
+  });
+
+  it('pins the HIGH ink ramp to its declared literal alphas', () => {
+    expect(SEGMENTLINE_INK.strong).toBe('rgba(26,16,0,1)');
+    expect(SEGMENTLINE_INK.mid).toBe('rgba(26,16,0,0.65)');
+    expect(SEGMENTLINE_INK.soft).toBe('rgba(26,16,0,0.34)');
+    expect(SEGMENTLINE_INK.ghost).toBe('rgba(26,16,0,0.09)');
+    expect(SEGMENTLINE_INK.telemetry).toBe('rgba(26,16,0,0.50)');
+  });
+
+  it('tx active is the hot TX red, never a scaled ink alpha', () => {
+    expect(fallbackLiteral(SEGMENTLINE_TOKENS.tx.active)).toBe(SEGMENTLINE_PALETTE.txHot);
+  });
+
+  it('clamps out "dense": the outlined cells collide with the 7px meter pitch', () => {
+    expect(segmentline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact'] });
+  });
+
+  it('declares ONLY peer-split compatible (MOR-2148 decision) — desktop-v2 stays explicitly incompatible', () => {
+    expect(segmentline.layoutCompatibility).toEqual([
+      { layoutId: 'peer-split', compatible: true },
+      {
+        layoutId: 'desktop-v2',
+        compatible: false,
+        reason: 'segmentline assumes a fixed-native instrument glass; desktop-v2 is fluid chrome.',
+      },
+    ]);
+  });
+
+  it('declares no renderers yet — MOR-2149 fills the three slots', () => {
+    expect(Object.keys(segmentline.renderers)).toEqual([]);
+  });
+});
+
+describe('does not lend its token set to studioline or fieldline — the family is independent', () => {
+  it('shares the contract, not the bundle: both satisfy every required token group', () => {
+    expect(segmentline.tokens).not.toBe(studioline.tokens);
+    expect(segmentline.tokens).not.toBe(fieldline.tokens);
+    for (const group of REQUIRED_TOKEN_GROUPS) {
+      expect(segmentline.tokens[group]).toBeDefined();
+    }
+  });
+
+  it('differs from both siblings on meter pitch — the shape the family is named for', () => {
+    expect(SEGMENTLINE_TOKENS.meters.trackWidth).not.toBe(studioline.tokens.meters.trackWidth);
+    expect(SEGMENTLINE_TOKENS.meters.trackWidth).not.toBe(fieldline.tokens.meters.trackWidth);
+  });
+});

--- a/frontend/src/presentation/languages/segmentline/segmentline.css
+++ b/frontend/src/presentation/languages/segmentline/segmentline.css
@@ -1,0 +1,245 @@
+/*
+  `segmentline` design language — the CSS half of the MOR-2148 token slice.
+  Its arithmetic half is `./tokens.ts`; the glass/bezel tones, ink ramp and
+  meter pitch below restate that file's literal values as custom properties.
+  The bezel-edge tone is this file's own addition — `tokens.ts`'s
+  `SEGMENTLINE_SURFACES` declares only `glass` and `bezel`, no edge tone.
+
+  SCOPING. Everything is rooted at the language attribute, so loading this
+  file changes nothing until a host opts in. Routing a language into the app
+  shell is cutover work (MOR-1048/MOR-1263), not this slice — so registering
+  the language (MOR-2148) does not by itself activate it.
+
+  WHAT IT MAY STYLE. Colour, type, spacing and geometry. Never which facts
+  appear, never whether a control is available: no rule here uses `display:
+  none` or `visibility` to add or remove a fact, and the only `content`
+  declarations are empty strings on decorative pseudo-elements (the glass
+  texture and the TX glow), never text.
+*/
+
+[data-design-language='segmentline'][data-design-language] {
+  --dl-segmentline-glass: #c8a030;
+  --dl-segmentline-bezel: #1a1410;
+  --dl-segmentline-bezel-edge: #8a7020;
+
+  /* Ink ramp — one ink, five alphas. HIGH contrast preset. */
+  --dl-segmentline-ink: 26 16 0;
+  --dl-segmentline-ink-strong: rgba(var(--dl-segmentline-ink) / 1);
+  --dl-segmentline-ink-mid: rgba(var(--dl-segmentline-ink) / 0.65);
+  --dl-segmentline-ink-soft: rgba(var(--dl-segmentline-ink) / 0.34);
+  --dl-segmentline-ink-ghost: rgba(var(--dl-segmentline-ink) / 0.09);
+  --dl-segmentline-ink-telemetry: rgba(var(--dl-segmentline-ink) / 0.5);
+
+  --dl-segmentline-tx-active: #d61c08;
+  --dl-segmentline-tx-mark: #7a1a0a;
+  --dl-segmentline-rx-tuning: #a97400;
+
+  --dl-segmentline-cell-border: 1.25px;
+  --dl-segmentline-cell-radius: 2px;
+  --dl-segmentline-grid-opacity: 1;
+
+  /* The meter pitch, republished from tokens.ts's `meters` group. Anything
+     that draws a segmented track derives from these two and never from a
+     literal — a hardcoded pitch drifts silently the moment a token moves. */
+  --dl-segmentline-track-width: 7px;
+  --dl-segmentline-segment-gap: 3px;
+  --dl-segmentline-segment-pitch: calc(var(--dl-segmentline-track-width) + var(--dl-segmentline-segment-gap));
+
+  color: var(--dl-segmentline-ink-strong);
+  font-family: 'Share Tech Mono', ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+/* DIM preset — sunlight-washed / night bench. Ratios travel, hexes do not.
+
+   CONTRAST ONLY, never density. Density is workspace-owned (`DensityClamp`)
+   and may change spacing; it must never change legibility, least of all on a
+   frequency readout — so this preset keys off the explicit
+   `[data-dl-contrast='dim']` attribute, never off `[data-density]`, and
+   tokens.ts records the DIM ramp as a theme concern for the same reason. */
+[data-design-language='segmentline'][data-design-language] [data-dl-contrast='dim'] {
+  --dl-segmentline-ink-strong: rgba(var(--dl-segmentline-ink) / 0.55);
+  --dl-segmentline-ink-mid: rgba(var(--dl-segmentline-ink) / 0.36);
+  --dl-segmentline-ink-soft: rgba(var(--dl-segmentline-ink) / 0.2);
+  --dl-segmentline-ink-ghost: rgba(var(--dl-segmentline-ink) / 0.06);
+  --dl-segmentline-ink-telemetry: rgba(var(--dl-segmentline-ink) / 0.3);
+}
+
+/* ── Glass ───────────────────────────────────────────────────────────── */
+
+[data-design-language='segmentline'][data-design-language] .dl-glass {
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  padding: 14px;
+  border: 2px solid var(--dl-segmentline-bezel-edge);
+  border-radius: 10px;
+  background: var(--dl-segmentline-glass);
+  /* Set explicitly, never inherited: `app.css` paints `body { color }`,
+     which would otherwise reach the glass ahead of this rule and override
+     it. */
+  color: var(--dl-segmentline-ink-strong);
+  box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.06), 0 0 8px rgba(0, 0, 0, 0.5);
+}
+
+/* Subpixel row texture. Decorative; the grid opacity is themeable to 0 for
+   contrast review, where the texture reads as noise. */
+[data-design-language='segmentline'][data-design-language] .dl-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: var(--dl-segmentline-grid-opacity);
+  background: repeating-linear-gradient(to bottom, transparent 0 3px, rgba(0, 0, 0, 0.04) 3px 6px);
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-glass > * {
+  position: relative;
+  z-index: 2;
+}
+
+/* TX perimeter. The renderer emits the colours; this is the geometry. */
+[data-design-language='segmentline'][data-design-language] .dl-glass[data-tx='active'] {
+  border-color: var(--dl-segmentline-tx-active);
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-glass[data-tx='active']::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  border-radius: 8px;
+  box-shadow: inset 0 0 38px 2px rgba(214, 28, 8, 0.46), inset 0 0 11px rgba(255, 80, 40, 0.55);
+}
+
+/* ── Cells: the family's only control shape ──────────────────────────── */
+
+[data-design-language='segmentline'][data-design-language] .dl-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 7px;
+  border: var(--dl-segmentline-cell-border) solid var(--dl-segmentline-ink-soft);
+  border-radius: var(--dl-segmentline-cell-radius);
+  background: none;
+  color: var(--dl-segmentline-ink-soft);
+  font: inherit;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-cell[aria-pressed='true'],
+[data-design-language='segmentline'][data-design-language] .dl-cell[data-active='true'] {
+  border-color: var(--dl-segmentline-ink-strong);
+  color: var(--dl-segmentline-ink-strong);
+}
+
+/* The hot tone marks a TX-capable control, NOT a keyed one. Only the lit
+   combination goes red — an unlit TX/TUNE chip stays ordinary dim ink like
+   every other inactive cell. Dropping the `[data-active='true']` half would
+   let this rule mark a TX-capable cell red while receiving, which on a
+   transceiver would be the worst class of lie the glass can tell (v3 ADR
+   invariant 9). */
+[data-design-language='segmentline'][data-design-language] .dl-cell[data-tone='hot'][data-active='true'] {
+  border-color: var(--dl-segmentline-tx-mark);
+  color: var(--dl-segmentline-tx-mark);
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-cell:focus-visible {
+  outline: 2px solid var(--dl-segmentline-ink-strong);
+  outline-offset: 1px;
+}
+
+/* ── Seven-segment readout ───────────────────────────────────────────── */
+
+[data-design-language='segmentline'][data-design-language] .dl-freq {
+  display: inline-flex;
+  align-items: baseline;
+  flex-shrink: 0;
+  /* Shrink-wrap, always. As a flex item this box would otherwise stretch to
+     the column's full width and the readout's advance would stop being a
+     function of font-size — which is the one property the per-glyph cells
+     below exist to guarantee. */
+  width: max-content;
+  align-self: start;
+  white-space: nowrap;
+  font-family: 'DSEG7 Classic', 'Share Tech Mono', ui-monospace, monospace;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+/* One cell per glyph, width from the renderer. This is what keeps the readout
+   from reflowing when DSEG7 is unavailable. */
+[data-design-language='segmentline'][data-design-language] .dl-freq-cell {
+  display: inline-block;
+  text-align: center;
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-freq [data-tone='muted'] {
+  color: var(--dl-segmentline-ink-mid);
+}
+
+/* ── Segmented meter ─────────────────────────────────────────────────── */
+
+[data-design-language='segmentline'][data-design-language] .dl-meter {
+  position: relative;
+  height: 26px;
+  border: 1px solid var(--dl-segmentline-ink-soft);
+  border-radius: 1px;
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-meter-fill {
+  height: 100%;
+  color: var(--dl-segmentline-ink-strong);
+  background-image: repeating-linear-gradient(
+    to right,
+    currentColor 0 var(--dl-segmentline-track-width),
+    transparent var(--dl-segmentline-track-width) var(--dl-segmentline-segment-pitch)
+  );
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-meter-fill[data-hot='true'] {
+  color: var(--dl-segmentline-tx-mark);
+}
+
+/* ── Design-language annotations on the shipped gauges ───────────────────
+   'renderSlot' spreads the meters renderer's flat primitives onto the tile as
+   'data-dl-*'. They are STRINGS: CSS can select on a discrete value but cannot
+   compute a width from one, so the gauge's geometry stays where it already is
+   (the shipped 'LinearSMeter'/'BarGauge' SVG components, ballistics included)
+   and this half only states the family's opinion about tone and texture. */
+
+[data-design-language='segmentline'][data-design-language] [data-dl-unknown='true'] {
+  /* Never a gauge resting at zero — an unread meter reads as unread. */
+  color: var(--dl-segmentline-ink-soft);
+}
+
+[data-design-language='segmentline'][data-design-language] [data-dl-hot='true'] {
+  color: var(--dl-segmentline-tx-mark);
+}
+
+[data-design-language='segmentline'][data-design-language] .dl-meter-scale {
+  margin-top: 2px;
+  color: var(--dl-segmentline-ink-mid);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+}
+
+/* ── Telemetry ───────────────────────────────────────────────────────── */
+
+[data-design-language='segmentline'][data-design-language] .dl-telemetry {
+  color: var(--dl-segmentline-ink-telemetry);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-design-language='segmentline'][data-design-language] .dl-glass,
+  [data-design-language='segmentline'][data-design-language] .dl-glass[data-tx='active'] {
+    transition: none;
+  }
+}

--- a/frontend/src/presentation/languages/segmentline/tokens.ts
+++ b/frontend/src/presentation/languages/segmentline/tokens.ts
@@ -1,0 +1,76 @@
+/**
+ * `segmentline` token set (MOR-2148) — the amber-LCD instrument family.
+ *
+ * Grammar: a single warm glass field, ink printed ON it rather than lit
+ * against black; every control is an outlined cell, never a filled button;
+ * hierarchy comes from ink opacity, not colour. The seven-segment readout
+ * and the segmented meter track are the two load-bearing shapes — hence the
+ * family name.
+ *
+ * Contract instance only. Declares no renderer, imports no runtime, store,
+ * transport or radio code. Renderers are MOR-2149's job: the manifest that
+ * registers this token set (`../declarations.ts`) ships `renderers: {}`
+ * until then, which `resolveRenderer` (`../contract.ts`) falls back on
+ * safely — no renderer slot is filled yet.
+ */
+import type { DesignLanguageTokens } from '../contract';
+
+/** The two grounds: the lit glass and the bezel it is set into. */
+export const SEGMENTLINE_SURFACES = { glass: '#C8A030', bezel: '#1A1410' } as const;
+
+/**
+ * Ink ramp at HIGH contrast. DIM (sunlight/night preset) scales the same
+ * ramp to 0.55 / 0.36 / 0.20 / 0.06 / 0.30 — a theme concern, not a language
+ * one, so only the reference ramp is declared here.
+ */
+export const SEGMENTLINE_INK = {
+  strong: 'rgba(26,16,0,1)',
+  mid: 'rgba(26,16,0,0.65)',
+  soft: 'rgba(26,16,0,0.34)',
+  ghost: 'rgba(26,16,0,0.09)',
+  telemetry: 'rgba(26,16,0,0.50)',
+} as const;
+
+export const SEGMENTLINE_PALETTE = {
+  focus: 'rgba(26,16,0,1)',
+  txHot: '#D61C08',
+  txMark: '#7A1A0A',
+  tuning: '#A97400',
+} as const;
+
+/** `var()` with the literal fallback, so a bundle mounted without the CSS still renders a defined colour. */
+const tone = (name: string, fallback: string): string => `var(--dl-segmentline-${name}, ${fallback})`;
+
+export const SEGMENTLINE_TOKENS: DesignLanguageTokens = {
+  // A seven-segment face for values, a squared mono for labels. The readout
+  // font is metric-critical: DSEG7's digit advance is fixed and its `.`
+  // advances zero, so a plain text run changes width when the webfont is
+  // missing. MOR-2149's frequency renderer is what lays each glyph in a
+  // declared-width cell to guarantee against that — not declared here.
+  typography: {
+    fontFamily: '"DSEG7 Classic", "Share Tech Mono", ui-monospace, monospace',
+    weight: 700,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  // Hairline outlined cells, barely rounded — a printed LCD segment box, not
+  // a UI button. 2px is the chassis bezel; cells use 1.25px.
+  geometry: { radius: '2px', borderWidth: '1.25px' },
+  // Segmented track: 7px bars with a 3px gap is what reads as an LCD bar
+  // graph rather than the continuous rail `studioline` owns.
+  meters: { trackWidth: '7px', segmentGap: '3px' },
+  frequency: { digitWeight: 700, rankedGroups: true },
+  // The glass does not animate. Value changes step; only the TX perimeter
+  // fades, and it is dropped entirely under prefers-reduced-motion.
+  motion: { durationMs: 90, reducedMotionSafe: true },
+  focusRing: `2px solid ${tone('focus', SEGMENTLINE_PALETTE.focus)}`,
+  rx: {
+    idle: tone('rx-idle', SEGMENTLINE_INK.soft),
+    active: tone('rx-active', SEGMENTLINE_INK.strong),
+    tuning: tone('rx-tuning', SEGMENTLINE_PALETTE.tuning),
+  },
+  tx: {
+    idle: tone('tx-idle', SEGMENTLINE_INK.soft),
+    active: tone('tx-active', SEGMENTLINE_PALETTE.txHot),
+    tuning: tone('tx-tuning', SEGMENTLINE_PALETTE.tuning),
+  },
+};


### PR DESCRIPTION
Linear: MOR-2148 · parent MOR-1162

Third design language beside studioline and fieldline. Renderers are MOR-2149; this ships `renderers: {}`, an already-exercised shape.

**Merge after #2950 (MOR-2155).**

**GUARDRAILS — owner exception required and granted.** 11 files, 799 changed lines. The 10-file hard ceiling is crossed under an explicit owner exception granted 2026-09-01 before the commit: the eleventh file removes a sentence that this same change makes false. The 6/600 soft threshold is crossed on both axes; this is one unit of work because four of the eleven files are the new family itself and the other seven are its registration plus the prose a third family falsifies.

**Three review rounds, the third also under an owner exception to the two-cycle limit.** Round 1 found the change's one real defect: the stylesheet reached no bundle, so the family would have registered and styled nothing. Rounds 2 and 3 found only prose.

Two known prose items are accepted knowingly and recorded in the commit message rather than fixed: a comment writes `../layout-compatibility-inventory.test.ts` where the file is a sibling, and a sentence calls two layout ids "named nowhere in this repository" when the plan doc names them.