### PR TITLE
test(MOR-2144): add profile completeness foundation

### DIFF
--- a/tests/support/command_builders.py
+++ b/tests/support/command_builders.py
@@ -1,14 +1,95 @@
-"""Shared public command-builder census for tests."""
+"""Shared command-source inventory for tests."""
 
 from __future__ import annotations
 
+import ast
 import functools
 import importlib
 import inspect
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 CommandBuilderKey = tuple[str, str]
+
+_IGNORED_TREE_PARTS = frozenset({".git", ".venv", "node_modules"})
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedPython:
+    """One successfully parsed Python source."""
+
+    path: Path
+    tree: ast.Module
+
+
+@dataclass(frozen=True, slots=True)
+class PythonSyntaxFailure:
+    """A syntax error retained with source provenance."""
+
+    path: Path
+    line: int | None
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class PythonParseHealth:
+    """Aggregate parse results exposed to completeness diagnostics."""
+
+    parsed: tuple[ParsedPython, ...]
+    syntax_errors: tuple[PythonSyntaxFailure, ...]
+
+    @property
+    def parsed_count(self) -> int:
+        return len(self.parsed)
+
+    @property
+    def syntax_error_count(self) -> int:
+        return len(self.syntax_errors)
+
+    def require_clean(self) -> None:
+        """Raise with measured counts and every syntax failure."""
+        if not self.syntax_errors:
+            return
+        details = "; ".join(
+            f"{failure.path}:{failure.line or '?'}: {failure.message}"
+            for failure in self.syntax_errors
+        )
+        raise AssertionError(
+            f"parse health: parsed={self.parsed_count} "
+            f"syntax_errors={self.syntax_error_count}: {details}"
+        )
+
+
+def repository_python_paths(repo_root: Path) -> tuple[Path, ...]:
+    """Return repository Python sources outside vendored and build trees."""
+    return tuple(
+        sorted(
+            path
+            for path in repo_root.rglob("*.py")
+            if not _IGNORED_TREE_PARTS.intersection(path.relative_to(repo_root).parts)
+        )
+    )
+
+
+def parse_python_paths(paths: tuple[Path, ...]) -> PythonParseHealth:
+    """Parse every path without silently dropping syntax errors."""
+    parsed: list[ParsedPython] = []
+    failures: list[PythonSyntaxFailure] = []
+    for path in sorted(paths):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            failures.append(
+                PythonSyntaxFailure(
+                    path=path,
+                    line=exc.lineno,
+                    message=exc.msg,
+                )
+            )
+        else:
+            parsed.append(ParsedPython(path=path, tree=tree))
+    return PythonParseHealth(tuple(parsed), tuple(failures))
 
 
 @functools.lru_cache(maxsize=4)

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -6,7 +6,7 @@ reached at runtime it falls back to logging and refusing (pinned by
 ``tests/test_undeclared_command_policy.py``); this is the guard that keeps
 that fallback from firing in production.
 
-Method, mirrored from ``tests/test_command_map_parity.py`` (the parity
+Method, shared with ``tests/test_command_map_parity.py`` (the parity
 harness) per the plan's own instruction to derive keys "the way the parity
 harness does": every public, ``cmd_map``-taking builder resolves its
 command-map key by exactly one of three routes -- statically, from a
@@ -42,6 +42,10 @@ Each profile's per-model ``TestXDeclaresAbsentCommands`` class in that same
 file is the durable record now, not restated here; this file's baseline is
 meant to shrink only, never grow silently.
 
+That baseline measures declaration completeness only: absent markers are not
+manual proof. The MOR-2144 foundation inventories normalized specs independently
+and reports implementation gaps without an allowlist.
+
 Regenerate after an intentional change (a profile gains or loses a
 declaration, or a builder's key changes)::
 
@@ -52,17 +56,36 @@ declaration, or a builder's key changes)::
 from __future__ import annotations
 
 import ast
+import enum
 import functools
+import inspect
 import os
 import pathlib
+import textwrap
 import typing
 from collections import defaultdict
+from dataclasses import dataclass
 
 import pytest
 
-from rigplane.commands.command_map import CommandMap
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
+from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands.command_map import CommandMap, ReverseLookupResult
+from rigplane.commands.command_spec import (
+    AbsentCommandSpec,
+    CatCommandSpec,
+    CivCommandSpec,
+)
+from rigplane.core.radio_protocol import DualReceiverCapable
 from rigplane.profiles.rig_loader import discover_rigs
-from support.command_builders import public_command_builders
+from rigplane.runtime.radio import CoreRadio
+from support.command_builders import (
+    PythonParseHealth,
+    parse_python_paths as _parse_python_paths,
+    public_command_builders,
+    repository_python_paths,
+)
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 COMMANDS_DIR = REPO_ROOT / "src" / "rigplane" / "commands"
@@ -254,6 +277,661 @@ def _report() -> _Report:
     )
 
 
+# ── implementation completeness foundation (MOR-2144) ──
+
+
+class _MethodStatus(enum.Enum):
+    IMPLEMENTED = "implemented"
+    STUB = "stub"
+    ABSENT = "absent"
+
+
+class _DeclarationRelation(enum.Enum):
+    IMPLEMENTED = "implemented"
+    PARTIAL = "partial"
+    STUB = "stub"
+    ABSENT = "absent"
+    COMPOSITE = "composite"
+    NAME_MISMATCH = "name_mismatch"
+
+
+class _ExecutionReachability(enum.Enum):
+    REACHABLE = "reachable"
+    UNREACHABLE = "unreachable"
+    UNKNOWN = "unknown"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True, slots=True)
+class _ImplementationFinding:
+    """One declaration result with implementation and reachability kept separate."""
+
+    profile_id: str
+    kind: str
+    name: str
+    relation: _DeclarationRelation
+    reachability: _ExecutionReachability
+    routes: tuple[str, ...] = ()
+    method_statuses: tuple[tuple[str, _MethodStatus], ...] = ()
+    declared_absent: bool = False
+    diagnostics: tuple[str, ...] = ()
+
+    @property
+    def fully_complete(self) -> bool:
+        return (
+            self.relation is _DeclarationRelation.IMPLEMENTED
+            and self.reachability
+            in {
+                _ExecutionReachability.REACHABLE,
+                _ExecutionReachability.NOT_APPLICABLE,
+            }
+        )
+
+
+def _finding_sort_key(finding: _ImplementationFinding) -> tuple[str, str, str]:
+    return finding.profile_id, finding.kind, finding.name
+
+
+@dataclass(frozen=True, slots=True)
+class _ImplementationReport:
+    """Deterministic census for later shipped-profile gate activation.
+
+    The foundation reports every observed gap; no allowlist or baseline
+    suppresses current shipped-profile failures.
+    """
+
+    parse_health: PythonParseHealth
+    findings: tuple[_ImplementationFinding, ...]
+
+    def find(self, profile_id: str, kind: str, name: str) -> _ImplementationFinding:
+        matches = tuple(
+            finding
+            for finding in self.findings
+            if (finding.profile_id, finding.kind, finding.name)
+            == (profile_id, kind, name)
+        )
+        if len(matches) != 1:
+            raise AssertionError(
+                f"expected one finding for {profile_id} {kind} {name}, "
+                f"found {len(matches)}"
+            )
+        return matches[0]
+
+    @property
+    def gaps(self) -> tuple[_ImplementationFinding, ...]:
+        return tuple(
+            sorted(
+                (finding for finding in self.findings if not finding.fully_complete),
+                key=_finding_sort_key,
+            )
+        )
+
+    def render_gaps(self) -> str:
+        return "\n".join(row for finding in self.gaps for row in finding.diagnostics)
+
+
+# Narrow by design: only an existing public Protocol may define a contract.
+_CAPABILITY_PROTOCOLS: dict[str, type[typing.Any]] = {
+    "dual_rx": DualReceiverCapable,
+}
+
+_IMPLEMENTATION_BY_PROTOCOL: dict[str, type[typing.Any]] = {
+    "civ": CoreRadio,
+    "yaesu_cat": YaesuCatRadio,
+}
+
+
+def _classify_method_node(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> _MethodStatus:
+    """Classify only a direct, unconditional ``NotImplementedError`` body."""
+    body = list(node.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body.pop(0)
+    if len(body) != 1 or not isinstance(body[0], ast.Raise):
+        return _MethodStatus.IMPLEMENTED
+    exc = body[0].exc
+    if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
+        return _MethodStatus.STUB
+    if (
+        isinstance(exc, ast.Call)
+        and isinstance(exc.func, ast.Name)
+        and exc.func.id == "NotImplementedError"
+    ):
+        return _MethodStatus.STUB
+    return _MethodStatus.IMPLEMENTED
+
+
+def _function_nodes(
+    parse_health: PythonParseHealth,
+) -> dict[pathlib.Path, tuple[ast.FunctionDef | ast.AsyncFunctionDef, ...]]:
+    return {
+        parsed.path.resolve(): tuple(
+            node
+            for node in ast.walk(parsed.tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+        for parsed in parse_health.parsed
+    }
+
+
+def _method_status(
+    implementation: type[typing.Any] | None,
+    method_name: str,
+    nodes_by_path: dict[
+        pathlib.Path, tuple[ast.FunctionDef | ast.AsyncFunctionDef, ...]
+    ],
+) -> _MethodStatus:
+    if implementation is None:
+        return _MethodStatus.ABSENT
+    marker = object()
+    descriptor = inspect.getattr_static(implementation, method_name, marker)
+    if descriptor is marker:
+        return _MethodStatus.ABSENT
+    if isinstance(descriptor, (classmethod, staticmethod)):
+        descriptor = descriptor.__func__
+    if not inspect.isfunction(descriptor):
+        return _MethodStatus.IMPLEMENTED
+    target = inspect.unwrap(descriptor)
+    source = inspect.getsourcefile(target)
+    code = getattr(target, "__code__", None)
+    if source is None or code is None:
+        return _MethodStatus.IMPLEMENTED
+    candidates = [
+        node
+        for node in nodes_by_path.get(pathlib.Path(source).resolve(), ())
+        if node.name == target.__name__
+    ]
+    if not candidates:
+        return _MethodStatus.IMPLEMENTED
+    node = min(
+        candidates, key=lambda candidate: abs(candidate.lineno - code.co_firstlineno)
+    )
+    return _classify_method_node(node)
+
+
+def _protocol_method_names(protocol: type[typing.Any]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            name
+            for name, value in protocol.__dict__.items()
+            if not name.startswith("_") and inspect.isfunction(value)
+        )
+    )
+
+
+def _capability_status(
+    method_statuses: tuple[tuple[str, _MethodStatus], ...],
+) -> _DeclarationRelation:
+    states = tuple(status for _name, status in method_statuses)
+    if states and all(status is _MethodStatus.IMPLEMENTED for status in states):
+        return _DeclarationRelation.IMPLEMENTED
+    if states and all(status is _MethodStatus.ABSENT for status in states):
+        return _DeclarationRelation.ABSENT
+    if states and all(status is _MethodStatus.STUB for status in states):
+        return _DeclarationRelation.STUB
+    return _DeclarationRelation.PARTIAL
+
+
+def _capability_finding(
+    *,
+    profile_id: str,
+    tag: str,
+    protocol: type[typing.Any],
+    implementation: type[typing.Any] | None,
+    nodes_by_path: dict[
+        pathlib.Path, tuple[ast.FunctionDef | ast.AsyncFunctionDef, ...]
+    ],
+) -> _ImplementationFinding:
+    method_statuses = tuple(
+        (name, _method_status(implementation, name, nodes_by_path))
+        for name in _protocol_method_names(protocol)
+    )
+    diagnostics = tuple(
+        f"{profile_id} capability {tag}: "
+        f"{'stub' if status is _MethodStatus.STUB else 'missing'} method {name}"
+        for name, status in method_statuses
+        if status is not _MethodStatus.IMPLEMENTED
+    )
+    return _ImplementationFinding(
+        profile_id=profile_id,
+        kind="capability",
+        name=tag,
+        relation=_capability_status(method_statuses),
+        reachability=_ExecutionReachability.NOT_APPLICABLE,
+        method_statuses=method_statuses,
+        diagnostics=diagnostics,
+    )
+
+
+def _string_values(
+    node: ast.AST,
+    assignments: dict[str, set[str]],
+) -> set[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return {node.value}
+    if isinstance(node, ast.Name):
+        return set(assignments.get(node.id, ()))
+    if isinstance(node, ast.IfExp):
+        return _string_values(node.body, assignments) | _string_values(
+            node.orelse, assignments
+        )
+    return set()
+
+
+def _cat_dispatch_routes(
+    class_node: ast.ClassDef,
+    method_names: frozenset[str] | None = None,
+) -> dict[str, frozenset[str]]:
+    """Trace selected radio methods transitively to canonical CAT wire calls."""
+    routes: dict[str, set[str]] = defaultdict(set)
+    methods = {
+        node.name: node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    pending = list(methods if method_names is None else method_names)
+    seen: set[str] = set()
+    while pending:
+        method_name = pending.pop()
+        if method_name in seen or method_name not in methods:
+            continue
+        seen.add(method_name)
+        method = methods[method_name]
+        pending.extend(
+            node.func.attr
+            for node in ast.walk(method)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr in methods
+        )
+        assignments: dict[str, set[str]] = defaultdict(set)
+        for node in ast.walk(method):
+            if isinstance(node, ast.Assign):
+                values = _string_values(node.value, assignments)
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        assignments[target.id].update(values)
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                if isinstance(node.target, ast.Name):
+                    assignments[node.target.id].update(
+                        _string_values(node.value, assignments)
+                    )
+        for node in ast.walk(method):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr in {"_query", "_write"}
+                and node.args
+            ):
+                continue
+            route = "cat_query" if node.func.attr == "_query" else "cat_write"
+            for name in _string_values(node.args[0], assignments):
+                routes[name].add(route)
+    return {name: frozenset(found) for name, found in routes.items()}
+
+
+def _yaesu_executor_methods(class_node: ast.ClassDef) -> frozenset[str]:
+    """Read radio-method roots from the real Yaesu queue executor."""
+    for method in class_node.body:
+        if (
+            isinstance(method, ast.AsyncFunctionDef)
+            and method.name == "_execute_command"
+        ):
+            return frozenset(
+                node.func.attr
+                for node in ast.walk(method)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "radio"
+            )
+    raise AssertionError("YaesuCatPoller._execute_command AST missing")
+
+
+def _class_node(
+    parse_health: PythonParseHealth,
+    implementation: type[typing.Any],
+) -> ast.ClassDef:
+    source = inspect.getsourcefile(implementation)
+    if source is None:
+        raise AssertionError(f"{implementation.__name__}: source file unavailable")
+    source_path = pathlib.Path(source).resolve()
+    for parsed in parse_health.parsed:
+        if parsed.path.resolve() != source_path:
+            continue
+        for node in parsed.tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == implementation.__name__:
+                return node
+    raise AssertionError(
+        f"{implementation.__name__}: class AST missing from {source_path}"
+    )
+
+
+def _literal_frame_value(node: ast.AST, field: str) -> int | None:
+    if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+        return None
+    if not isinstance(node.ops[0], ast.Eq) or len(node.comparators) != 1:
+        return None
+    pairs = ((node.left, node.comparators[0]), (node.comparators[0], node.left))
+    for candidate, value in pairs:
+        if (
+            isinstance(candidate, ast.Attribute)
+            and candidate.attr == field
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, int)
+        ):
+            return value.value
+    return None
+
+
+def _civ_inbound_pairs(parse_health: PythonParseHealth) -> frozenset[tuple[int, int]]:
+    pairs: set[tuple[int, int]] = set()
+    for parsed in parse_health.parsed:
+        if parsed.path.name != "_civ_rx.py" or "src" not in parsed.path.parts:
+            continue
+        handlers = (
+            node
+            for node in ast.walk(parsed.tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and any(word in node.name for word in ("handle", "observation", "route"))
+        )
+        for node in (child for handler in handlers for child in ast.walk(handler)):
+            if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.And):
+                continue
+            command: int | None = None
+            sub: int | None = None
+            for value in node.values:
+                command = (
+                    command
+                    if command is not None
+                    else _literal_frame_value(value, "command")
+                )
+                sub = sub if sub is not None else _literal_frame_value(value, "sub")
+            if command is not None and sub is not None:
+                pairs.add((command, sub))
+    return frozenset(pairs)
+
+
+def _reverse_result_names(result: ReverseLookupResult) -> frozenset[str]:
+    if result.name is not None:
+        return frozenset({result.name})
+    return typing.cast(frozenset[str], result.candidates)
+
+
+def _civ_routes(
+    config: typing.Any,
+    profile: typing.Any,
+    inbound_pairs: frozenset[tuple[int, int]],
+) -> dict[str, frozenset[str]]:
+    command_map = profile.command_map or CommandMap({})
+    reverse_index = profile.reverse_index
+    if reverse_index is None:
+        raise AssertionError(f"{profile.id}: loaded profile has no reverse index")
+    static_cache: dict[Key, str] = {}
+    builder_names = {
+        _key_for(key, builder, command_map, static_cache)
+        for key, builder in _builders().items()
+    }
+    routes: dict[str, set[str]] = defaultdict(set)
+    for name in builder_names:
+        if name in profile.command_names:
+            command, sub, prefix = decode_wire_tuple(command_map.get(name))
+            resolved = _reverse_result_names(
+                reverse_index.resolve(command, sub, prefix)
+            )
+            if name in resolved:
+                routes[name].add("civ_builder")
+        elif name in config.commands:
+            # Keep builder discovery independent from an untrusted absent marker.
+            routes[name].add("civ_builder")
+    for command, sub in inbound_pairs:
+        result = reverse_index.resolve(command, sub, b"")
+        for name in _reverse_result_names(result):
+            routes[name].add("civ_inbound")
+    return {name: frozenset(found) for name, found in routes.items()}
+
+
+def _command_finding(
+    *,
+    profile_id: str,
+    name: str,
+    spec: typing.Any,
+    routes: frozenset[str],
+    executor_routes: frozenset[str],
+    implementation: type[typing.Any] | None,
+    nodes_by_path: dict[
+        pathlib.Path, tuple[ast.FunctionDef | ast.AsyncFunctionDef, ...]
+    ],
+) -> _ImplementationFinding:
+    expected_routes: frozenset[str]
+    if isinstance(spec, CatCommandSpec):
+        expected_routes = frozenset(
+            route
+            for present, route in (
+                (spec.read is not None, "cat_query"),
+                (spec.write is not None, "cat_write"),
+            )
+            if present
+        )
+    elif isinstance(spec, CivCommandSpec):
+        expected_routes = frozenset({"civ_builder", "civ_inbound"})
+    else:
+        expected_routes = frozenset()
+
+    method_status = _method_status(implementation, name, nodes_by_path)
+    if isinstance(spec, CivCommandSpec):
+        complete = bool(routes & expected_routes)
+        partial = False
+    elif isinstance(spec, CatCommandSpec):
+        complete = expected_routes <= routes
+        partial = bool(expected_routes & routes) and not complete
+    else:
+        complete = bool(routes)
+        partial = False
+
+    if complete:
+        relation = _DeclarationRelation.IMPLEMENTED
+    elif partial:
+        relation = _DeclarationRelation.PARTIAL
+    elif method_status is _MethodStatus.STUB:
+        relation = _DeclarationRelation.STUB
+    else:
+        relation = _DeclarationRelation.ABSENT
+
+    if relation in {
+        _DeclarationRelation.ABSENT,
+        _DeclarationRelation.PARTIAL,
+        _DeclarationRelation.STUB,
+    }:
+        reachability = _ExecutionReachability.UNREACHABLE
+    elif not isinstance(spec, CatCommandSpec):
+        reachability = _ExecutionReachability.UNKNOWN
+    elif spec.write is None:
+        reachability = _ExecutionReachability.NOT_APPLICABLE
+    elif "cat_write" in executor_routes:
+        reachability = _ExecutionReachability.REACHABLE
+    else:
+        reachability = _ExecutionReachability.UNREACHABLE
+
+    diagnostics: tuple[str, ...] = ()
+    if relation is _DeclarationRelation.PARTIAL:
+        missing = sorted(expected_routes - routes)
+        diagnostics = tuple(
+            f"{profile_id} command {name}: missing method route {route}"
+            for route in missing
+        )
+    elif relation is _DeclarationRelation.STUB:
+        diagnostics = (f"{profile_id} command {name}: stub method {name}",)
+    elif relation is _DeclarationRelation.ABSENT:
+        diagnostics = (f"{profile_id} command {name}: missing method {name}",)
+    elif reachability is _ExecutionReachability.UNREACHABLE:
+        diagnostics = (
+            f"{profile_id} command {name}: backend execution route unreachable",
+        )
+    elif reachability is _ExecutionReachability.UNKNOWN:
+        diagnostics = (
+            f"{profile_id} command {name}: backend execution reachability unknown",
+        )
+
+    return _ImplementationFinding(
+        profile_id=profile_id,
+        kind="command",
+        name=name,
+        relation=relation,
+        reachability=reachability,
+        routes=tuple(sorted(routes)),
+        declared_absent=isinstance(spec, AbsentCommandSpec),
+        diagnostics=diagnostics,
+    )
+
+
+def implementation_completeness_report(
+    configs: typing.Mapping[str, typing.Any],
+    *,
+    repo_root: pathlib.Path,
+) -> _ImplementationReport:
+    """Return deterministic gaps without suppressing shipped failures."""
+    parse_health = _parse_python_paths(repository_python_paths(repo_root))
+    parse_health.require_clean()
+    nodes_by_path = _function_nodes(parse_health)
+    inbound_pairs = _civ_inbound_pairs(parse_health)
+    yaesu_class = _class_node(parse_health, YaesuCatRadio)
+    yaesu_routes = _cat_dispatch_routes(yaesu_class)
+    yaesu_executor_routes = _cat_dispatch_routes(
+        yaesu_class,
+        _yaesu_executor_methods(_class_node(parse_health, YaesuCatPoller)),
+    )
+    findings: list[_ImplementationFinding] = []
+
+    for _model, config in sorted(configs.items()):
+        profile = config.to_profile()
+        implementation = _IMPLEMENTATION_BY_PROTOCOL.get(config.protocol_type)
+        if config.protocol_type == "civ":
+            protocol_routes = _civ_routes(config, profile, inbound_pairs)
+        elif config.protocol_type == "yaesu_cat":
+            protocol_routes = yaesu_routes
+        else:
+            protocol_routes = {}
+
+        for tag, protocol in _CAPABILITY_PROTOCOLS.items():
+            if tag in profile.capabilities:
+                findings.append(
+                    _capability_finding(
+                        profile_id=profile.id,
+                        tag=tag,
+                        protocol=protocol,
+                        implementation=implementation,
+                        nodes_by_path=nodes_by_path,
+                    )
+                )
+        for name, spec in sorted(config.commands.items()):
+            findings.append(
+                _command_finding(
+                    profile_id=profile.id,
+                    name=name,
+                    spec=spec,
+                    routes=protocol_routes.get(name, frozenset()),
+                    executor_routes=yaesu_executor_routes.get(name, frozenset()),
+                    implementation=implementation,
+                    nodes_by_path=nodes_by_path,
+                )
+            )
+
+    return _ImplementationReport(
+        parse_health=parse_health,
+        findings=tuple(sorted(findings, key=_finding_sort_key)),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _ReverseCensusRow:
+    """One runtime name related back to normalized profile declarations."""
+
+    profile_id: str
+    runtime_name: str
+    relation: _DeclarationRelation
+    reachability: _ExecutionReachability
+    profile_names: tuple[str, ...] = ()
+    declared_absent: bool = False
+    absent_source: str | None = None
+
+
+def reverse_implementation_census(
+    profile: typing.Any,
+    runtime_names: typing.Iterable[str],
+    *,
+    composites: typing.Mapping[str, tuple[str, ...]] | None = None,
+    name_mismatches: typing.Mapping[str, str] | None = None,
+    executor_graph: typing.Mapping[str, _ExecutionReachability] | None = None,
+) -> tuple[_ReverseCensusRow, ...]:
+    """Relate runtime names to a profile without supplying the 52 rulings.
+
+    Composite and mismatch evidence must point only to present declarations;
+    explicit absent declarations remain distinct and retain their source.
+    """
+    composites = composites or {}
+    name_mismatches = name_mismatches or {}
+    executor_graph = executor_graph or {}
+    overlap = composites.keys() & name_mismatches.keys()
+    if overlap:
+        raise ValueError(f"runtime names have two relations: {sorted(overlap)}")
+    declared = profile.command_names
+    absent = profile.absent_command_names
+    masked_absent = (composites.keys() | name_mismatches.keys()) & absent
+    if masked_absent:
+        raise ValueError(f"runtime names explicitly absent: {sorted(masked_absent)}")
+    for runtime_name, targets in composites.items():
+        if not targets:
+            raise ValueError(f"{runtime_name}: composite evidence must be non-empty")
+        unknown_targets = sorted(set(targets) - declared)
+        if unknown_targets:
+            raise ValueError(f"{runtime_name}: undeclared targets {unknown_targets}")
+    for runtime_name, target in name_mismatches.items():
+        if target not in declared:
+            raise ValueError(f"{runtime_name}: undeclared target {target!r}")
+    rows: list[_ReverseCensusRow] = []
+    for runtime_name in sorted(set(runtime_names)):
+        if runtime_name in composites:
+            relation = _DeclarationRelation.COMPOSITE
+            profile_names = tuple(sorted(composites[runtime_name]))
+        elif runtime_name in name_mismatches:
+            relation = _DeclarationRelation.NAME_MISMATCH
+            profile_names = (name_mismatches[runtime_name],)
+        elif runtime_name in declared:
+            relation = _DeclarationRelation.IMPLEMENTED
+            profile_names = (runtime_name,)
+        elif runtime_name in absent:
+            relation = _DeclarationRelation.ABSENT
+            profile_names = (runtime_name,)
+        else:
+            relation = _DeclarationRelation.ABSENT
+            profile_names = ()
+        rows.append(
+            _ReverseCensusRow(
+                profile_id=profile.id,
+                runtime_name=runtime_name,
+                relation=relation,
+                reachability=executor_graph.get(
+                    runtime_name, _ExecutionReachability.UNKNOWN
+                ),
+                profile_names=profile_names,
+                declared_absent=runtime_name in absent,
+                absent_source=profile.absent_command_sources.get(runtime_name),
+            )
+        )
+    return tuple(rows)
+
+
 # ── baseline file ──
 
 
@@ -324,3 +1002,204 @@ def test_census_matches(report: _Report) -> None:
     rows = _read_rows(GAPS_FILE)
     census = {r[1]: int(r[2]) for r in rows if r[0] == "census"}
     assert census == report.census
+
+
+# ── MOR-2144 implementation-completeness foundation ──
+
+
+def test_parse_health_reports_syntax_errors(tmp_path: pathlib.Path) -> None:
+    good = tmp_path / "good.py"
+    bad = tmp_path / "bad.py"
+    good.write_text("answer = 42\n", encoding="utf-8")
+    bad.write_text("def broken(:\n", encoding="utf-8")
+
+    health = _parse_python_paths((good, bad))
+
+    assert health.parsed_count == 1
+    assert health.syntax_error_count == 1
+    with pytest.raises(
+        AssertionError,
+        match=r"parsed=1 syntax_errors=1.*bad\.py",
+    ):
+        health.require_clean()
+
+
+def test_method_classifier_distinguishes_unconditional_stub_from_real_body() -> None:
+    tree = ast.parse(
+        textwrap.dedent(
+            '''
+            class Example:
+                async def stub(self) -> None:
+                    """A docstring does not make the raise conditional."""
+                    raise NotImplementedError("not supported")
+
+                async def implemented(self) -> None:
+                    if self.ready:
+                        raise NotImplementedError("conditional fallback")
+                    await self.run()
+            '''
+        )
+    )
+    example = typing.cast(ast.ClassDef, tree.body[0])
+    methods = {
+        node.name: node
+        for node in example.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    assert _classify_method_node(methods["stub"]) is _MethodStatus.STUB
+    assert _classify_method_node(methods["implemented"]) is _MethodStatus.IMPLEMENTED
+
+
+@pytest.fixture(scope="module")
+def implementation_report() -> _ImplementationReport:
+    configs = discover_rigs(RIGS_DIR)
+    return implementation_completeness_report(configs, repo_root=REPO_ROOT)
+
+
+def test_foundation_parse_health_is_visible_and_clean(
+    implementation_report: _ImplementationReport,
+) -> None:
+    assert implementation_report.parse_health.parsed_count >= 700
+    assert implementation_report.parse_health.syntax_error_count == 0
+
+
+def test_capability_contract_map_is_deliberately_narrow() -> None:
+    assert _CAPABILITY_PROTOCOLS == {"dual_rx": DualReceiverCapable}
+
+
+def test_ftx1_dual_rx_reports_stub_and_absent_methods(
+    implementation_report: _ImplementationReport,
+) -> None:
+    finding = implementation_report.find("yaesu_ftx1", "capability", "dual_rx")
+
+    assert finding.relation is _DeclarationRelation.PARTIAL
+    assert finding.reachability is _ExecutionReachability.NOT_APPLICABLE
+    assert not finding.fully_complete
+    assert finding.method_statuses == (
+        ("equalize_main_sub", _MethodStatus.ABSENT),
+        ("get_main_sub_tracking", _MethodStatus.STUB),
+        ("set_main_sub_tracking", _MethodStatus.STUB),
+        ("swap_main_sub", _MethodStatus.ABSENT),
+    )
+    assert finding.diagnostics == (
+        "yaesu_ftx1 capability dual_rx: missing method equalize_main_sub",
+        "yaesu_ftx1 capability dual_rx: stub method get_main_sub_tracking",
+        "yaesu_ftx1 capability dual_rx: stub method set_main_sub_tracking",
+        "yaesu_ftx1 capability dual_rx: missing method swap_main_sub",
+    )
+
+
+def test_known_command_routes_use_protocol_specific_truth(
+    implementation_report: _ImplementationReport,
+) -> None:
+    civ = implementation_report.find("icom_ic7300", "command", "get_freq")
+    cat_get = implementation_report.find("yaesu_ftx1", "command", "get_freq")
+    cat_set = implementation_report.find("yaesu_ftx1", "command", "set_freq")
+
+    assert civ.relation is _DeclarationRelation.IMPLEMENTED
+    assert civ.routes == ("civ_builder",)
+    assert civ.reachability is _ExecutionReachability.UNKNOWN
+    assert cat_get.relation is _DeclarationRelation.IMPLEMENTED
+    assert cat_get.routes == ("cat_query",)
+    assert cat_get.reachability is _ExecutionReachability.NOT_APPLICABLE
+    assert cat_set.relation is _DeclarationRelation.IMPLEMENTED
+    assert cat_set.routes == ("cat_write",)
+    assert cat_set.reachability is _ExecutionReachability.REACHABLE
+
+
+def test_ic7300_scope_wave_inbound_uses_profile_reverse_index(
+    implementation_report: _ImplementationReport,
+) -> None:
+    finding = implementation_report.find("icom_ic7300", "command", "get_scope_wave")
+
+    assert finding.relation is _DeclarationRelation.IMPLEMENTED
+    assert finding.routes == ("civ_inbound",)
+    assert finding.reachability is _ExecutionReachability.UNKNOWN
+
+
+def test_declared_absent_marker_does_not_hide_existing_code_route(
+    implementation_report: _ImplementationReport,
+) -> None:
+    finding = implementation_report.find("icom_ic7300", "command", "get_powerstat")
+
+    assert finding.declared_absent
+    assert finding.relation is _DeclarationRelation.IMPLEMENTED
+    assert finding.routes == ("civ_builder",)
+    assert finding.reachability is _ExecutionReachability.UNKNOWN
+
+
+def test_real_yaesu_executor_exposes_missing_repeater_shift_route(
+    implementation_report: _ImplementationReport,
+) -> None:
+    finding = implementation_report.find("yaesu_ftx1", "command", "set_repeater_shift")
+    assert finding.relation is _DeclarationRelation.IMPLEMENTED
+    assert finding.reachability is _ExecutionReachability.UNREACHABLE
+    assert not finding.fully_complete
+    assert finding.diagnostics == (
+        "yaesu_ftx1 command set_repeater_shift: backend execution route unreachable",
+    )
+
+
+def test_real_yaesu_executor_follows_indirect_attenuator_helper(
+    implementation_report: _ImplementationReport,
+) -> None:
+    finding = implementation_report.find("yaesu_ftx1", "command", "set_attenuator")
+
+    assert finding.relation is _DeclarationRelation.IMPLEMENTED
+    assert finding.routes == ("cat_write",)
+    assert finding.reachability is _ExecutionReachability.REACHABLE
+    assert finding.fully_complete
+
+
+def test_reverse_census_hook_models_exact_composite_mismatch_and_gap() -> None:
+    profile = discover_rigs(RIGS_DIR)["IC-7300"].to_profile()
+    rows = reverse_implementation_census(
+        profile,
+        ("get_freq", "runtime_combo", "runtime_alias", "runtime_gap"),
+        composites={"runtime_combo": ("get_freq", "get_mode")},
+        name_mismatches={"runtime_alias": "set_freq"},
+    )
+
+    by_name = {row.runtime_name: row for row in rows}
+    assert by_name["get_freq"].relation is _DeclarationRelation.IMPLEMENTED
+    assert by_name["runtime_combo"].relation is _DeclarationRelation.COMPOSITE
+    assert by_name["runtime_combo"].profile_names == ("get_freq", "get_mode")
+    assert by_name["runtime_alias"].relation is _DeclarationRelation.NAME_MISMATCH
+    assert by_name["runtime_alias"].profile_names == ("set_freq",)
+    assert by_name["runtime_gap"].relation is _DeclarationRelation.ABSENT
+    assert all(row.reachability is _ExecutionReachability.UNKNOWN for row in rows)
+
+
+def test_reverse_census_preserves_absent_and_rejects_false_evidence() -> None:
+    profile = discover_rigs(RIGS_DIR)["IC-7300"].to_profile()
+    (absent,) = reverse_implementation_census(profile, ("get_powerstat",))
+
+    assert absent.relation is _DeclarationRelation.ABSENT
+    assert absent.profile_names == ("get_powerstat",)
+    assert absent.declared_absent
+    assert absent.absent_source
+
+    invalid_evidence = (
+        ({"composites": {"runtime_combo": ()}}, "non-empty"),
+        ({"composites": {"runtime_combo": ("not_declared",)}}, "undeclared"),
+        ({"name_mismatches": {"runtime_alias": "get_powerstat"}}, "undeclared"),
+        ({"composites": {"get_powerstat": ("get_freq",)}}, "explicitly absent"),
+    )
+    for kwargs, message in invalid_evidence:
+        with pytest.raises(ValueError, match=message):
+            reverse_implementation_census(profile, ("runtime_gap",), **kwargs)
+
+
+def test_future_activation_api_returns_full_deterministic_gap_list(
+    implementation_report: _ImplementationReport,
+) -> None:
+    gaps = implementation_report.gaps
+
+    assert gaps
+    assert gaps == tuple(sorted(gaps, key=_finding_sort_key))
+    assert all(not gap.fully_complete for gap in gaps)
+    assert (
+        "yaesu_ftx1 capability dual_rx: missing method swap_main_sub"
+        in implementation_report.render_gaps()
+    )

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -878,10 +878,19 @@ def reverse_implementation_census(
 
     Composite and mismatch evidence must point only to present declarations;
     explicit absent declarations remain distinct and retain their source.
+    Scanner-produced ``executor_graph`` may be a superset; unused rows are ignored.
     """
+    runtime_name_set = frozenset(runtime_names)
     composites = composites or {}
     name_mismatches = name_mismatches or {}
     executor_graph = executor_graph or {}
+    for label, evidence in (
+        ("composites", composites),
+        ("name_mismatches", name_mismatches),
+    ):
+        extra = sorted(evidence.keys() - runtime_name_set)
+        if extra:
+            raise ValueError(f"{label} keys outside runtime names: {extra}")
     overlap = composites.keys() & name_mismatches.keys()
     if overlap:
         raise ValueError(f"runtime names have two relations: {sorted(overlap)}")
@@ -900,7 +909,7 @@ def reverse_implementation_census(
         if target not in declared:
             raise ValueError(f"{runtime_name}: undeclared target {target!r}")
     rows: list[_ReverseCensusRow] = []
-    for runtime_name in sorted(set(runtime_names)):
+    for runtime_name in sorted(runtime_name_set):
         if runtime_name in composites:
             relation = _DeclarationRelation.COMPOSITE
             profile_names = tuple(sorted(composites[runtime_name]))
@@ -1171,6 +1180,22 @@ def test_reverse_census_hook_models_exact_composite_mismatch_and_gap() -> None:
     assert all(row.reachability is _ExecutionReachability.UNKNOWN for row in rows)
 
 
+def test_reverse_census_rejects_unused_composite_evidence() -> None:
+    profile = discover_rigs(RIGS_DIR)["IC-7300"].to_profile()
+    with pytest.raises(ValueError, match=r"composites.*runtime_typo"):
+        reverse_implementation_census(
+            profile, ("runtime_gap",), composites={"runtime_typo": ("get_freq",)}
+        )
+
+
+def test_reverse_census_rejects_unused_mismatch_evidence() -> None:
+    profile = discover_rigs(RIGS_DIR)["IC-7300"].to_profile()
+    with pytest.raises(ValueError, match=r"name_mismatches.*runtime_typo"):
+        reverse_implementation_census(
+            profile, ("runtime_gap",), name_mismatches={"runtime_typo": "get_freq"}
+        )
+
+
 def test_reverse_census_preserves_absent_and_rejects_false_evidence() -> None:
     profile = discover_rigs(RIGS_DIR)["IC-7300"].to_profile()
     (absent,) = reverse_implementation_census(profile, ("get_powerstat",))
@@ -1186,9 +1211,10 @@ def test_reverse_census_preserves_absent_and_rejects_false_evidence() -> None:
         ({"name_mismatches": {"runtime_alias": "get_powerstat"}}, "undeclared"),
         ({"composites": {"get_powerstat": ("get_freq",)}}, "explicitly absent"),
     )
+    runtime_names = ("runtime_gap", "runtime_combo", "runtime_alias", "get_powerstat")
     for kwargs, message in invalid_evidence:
         with pytest.raises(ValueError, match=message):
-            reverse_implementation_census(profile, ("runtime_gap",), **kwargs)
+            reverse_implementation_census(profile, runtime_names, **kwargs)
 
 
 def test_future_activation_api_returns_full_deterministic_gap_list(


### PR DESCRIPTION
Linear: https://linear.app/rigplane/issue/MOR-2144

## Summary

This is the foundation batch only. It extends the canonical profile command coverage mechanism so later MOR-2144 batches can audit implementation completeness without creating another source of truth.

- parses repository Python with explicit parse-health counts and syntax-error diagnostics;
- consumes normalized `RigConfig` and `RadioProfile` data;
- traces CI-V declarations through `CommandMap`, `decode_wire_tuple`, and the profile-owned `ReverseCommandIndex`;
- traces CAT wire implementation through `CatCommandSpec` and Yaesu `_query`/`_write`, then derives write reachability from the real `YaesuCatPoller._execute_command` route, including transitive radio helpers;
- records declaration/implementation relation separately from backend execution reachability;
- proves the real FTX controls `set_freq` and indirect `set_attenuator` reachable, read-only `get_freq` not applicable to the write executor, and `set_repeater_shift` implemented but unreachable and therefore not fully complete;
- exposes deterministic forward gap reporting and a reverse runtime-name census hook that preserves explicit absent provenance, validates composite/name-mismatch evidence, and fails closed on unused classification keys;
- intentionally accepts scanner-produced `executor_graph` supersets while applying exact-key validation to human classification evidence.

The shared public command-builder census was consolidated separately in #2955 and is now on `main`; this rebuilt diff consumes that single helper rather than duplicating it. No production code or profile TOML is changed.

## Truth-source boundary

Official manuals remain authoritative for whether a radio supports a feature. `AbsentCommandSpec` is treated only as a declaration and is not accepted as proof. This PR does not add an allowlist or baseline that suppresses actual implementation gaps, and it does not activate a shipped-profile gate while known gaps remain.

MOR-2144 must remain In Progress.

## Validation

- Targeted local set: 578 collected; 566 passed, 12 expected xfailed.
- Red-before/green-after: separate valid-target composite and name-mismatch typo controls first failed because no `ValueError` was raised; after the fail-closed runtime-set validation, both pass with labeled diagnostics.
- Mutation control: removing only the transitive executor-helper closure made the real FTX `set_attenuator` reachability test fail; restoring the closure made it pass.
- Ruff changed scope: PASS.
- Import contracts: 5 kept, 0 broken.
- Focused mypy: PASS.
- Full Python on the remote macOS testbed, exact SHA `1f60ff54fdd3f25744e86cb69b402db3f8e3dbba`: 14,142 passed, 161 skipped, 48 xfailed, 4 warnings; ruff PASS; FINAL PASS.
- No full suite was run locally.

## Scope size

The rebuilt diff is 2 test-only files: 990 additions and 4 deletions, 994 changed lines total. The shared discovery consolidation is no longer part of this PR. This foundation remains above the 600-line soft target because it keeps explicit parse health, protocol-specific route analyzers, the two-axis model, reverse-census API, contracts, fail-closed evidence validation, and adversarial real controls together. It remains strictly below the 1,000-line hard ceiling without compressing docstrings or formatting and does not touch production, profiles, frontend, or reserved scheduler/state-query paths.

## Remaining before MOR-2144 can close

1. The immediate next batch must classify all 52 `runtime/radio.py` `_KNOWN_COMMANDS` names exactly before MOR-2114 and MOR-2161 proceed.
2. Each profile declaration and absent marker must be ruled against official manuals; existing markers are not evidence.
3. Manual-confirmed profile errors, including unsupported IC-7300 antenna and APF declarations, still need profile correction in their owning batch.
4. The FTX-1 `dual_rx` declaration still needs its owner-approved profile correction after the manual and bench ruling.
5. Backend executor gaps must be corrected or truthfully reflected, then the shipped-profile completeness gate can be activated only when the deterministic gap list is cleared.

## Owner-provided bench provenance

These facts were provided by the owner and are recorded here for follow-up provenance only; this PR neither remeasures nor hardcodes them:

- FTX `dual_rx` was discarded live.
- MOR-2122 SM1 is a hardware-versus-manual anomaly.
- MOR-2160 `set_repeater_shift` is declared, implemented, and capability-enabled, but unreachable because the Yaesu executor has no branch.
- MOR-2125 established four-value auto shift and FM-only write acceptance.
