### PR TITLE
test(MOR-2157): centralize acquisition query fixtures

### DIFF
--- a/tests/_acquisition_query_helpers.py
+++ b/tests/_acquisition_query_helpers.py
@@ -1,0 +1,170 @@
+"""Current-shape-only acquisition query helpers for tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
+
+if TYPE_CHECKING:
+    from rigplane.web.radio_poller import RadioPoller
+
+
+AcquisitionQueryCase = tuple[int, int | bytes | None, int | None]
+
+
+@dataclass(frozen=True)
+class CivFrameParts:
+    """Representation-neutral meaning of one current acquisition query."""
+
+    command: int
+    sub: int | None = None
+    data: bytes = b""
+    receiver: int | None = None
+    selector: int | None = None
+
+
+def _require_legacy_query(query: AcquisitionQueryCase) -> AcquisitionQueryCase:
+    if type(query) is not tuple or len(query) != 3:
+        raise TypeError("acquisition query must be an exact legacy three-tuple")
+    command, packed_sub, route = query
+    if type(command) is not int:
+        raise TypeError("legacy query command must be int")
+    if packed_sub is not None and type(packed_sub) not in (int, bytes):
+        raise TypeError("legacy query packed sub must be int, bytes, or None")
+    if route is not None and type(route) is not int:
+        raise TypeError("legacy query route must be int or None")
+    return query
+
+
+def acquisition_query(
+    command: int,
+    *,
+    sub: int | None = None,
+    data: bytes = b"",
+    receiver: int | None = None,
+    selector: int | None = None,
+) -> AcquisitionQueryCase:
+    """Build the legacy tuple while keeping test intent explicit."""
+    if selector is not None:
+        if (
+            command not in (0x25, 0x26)
+            or sub is not None
+            or data
+            or receiver is not None
+        ):
+            raise ValueError("selector is exclusive to 0x25/0x26 queries")
+        return command, None, selector
+    if data:
+        if sub is None:
+            if len(data) != 1:
+                raise ValueError("legacy data-only queries require exactly one byte")
+            return command, data[0], receiver
+        return command, bytes([sub]) + data, receiver
+    return command, sub, receiver
+
+
+def civ_frame_parts(
+    query: AcquisitionQueryCase,
+) -> CivFrameParts:
+    """Expose semantic CI-V frame parts from the legacy tuple."""
+    command, packed_sub, route = _require_legacy_query(query)
+    if command in (0x25, 0x26):
+        if packed_sub is None and route is not None:
+            selector = route
+        elif type(packed_sub) is int and route is None:
+            selector = packed_sub
+        else:
+            raise ValueError("0x25/0x26 queries require exactly one selector")
+        return CivFrameParts(
+            command=command,
+            data=bytes([selector]),
+            selector=selector,
+        )
+    if isinstance(packed_sub, bytes):
+        if not packed_sub:
+            raise ValueError("packed legacy sub must not be empty")
+        return CivFrameParts(
+            command=command,
+            sub=packed_sub[0],
+            data=packed_sub[1:],
+            receiver=route,
+        )
+    if command == 0x07 and packed_sub is not None:
+        return CivFrameParts(command=command, data=bytes([packed_sub]), receiver=route)
+    return CivFrameParts(command=command, sub=packed_sub, receiver=route)
+
+
+def query_command(query: AcquisitionQueryCase) -> int:
+    return civ_frame_parts(query).command
+
+
+def query_receiver(query: AcquisitionQueryCase) -> int | None:
+    return civ_frame_parts(query).receiver
+
+
+def query_selector(query: AcquisitionQueryCase) -> int | None:
+    return civ_frame_parts(query).selector
+
+
+def recording_executor(
+    *,
+    supports_cmd29: Callable[[int, int | None], bool] | None = None,
+) -> tuple[IcomCivAcquisitionExecutor, list[AcquisitionQueryCase]]:
+    """Create an executor whose exact current sender records legacy tuples."""
+    sent: list[AcquisitionQueryCase] = []
+
+    async def send_query(
+        command: int, sub: int | bytes | None, receiver: int | None
+    ) -> None:
+        sent.append((command, sub, receiver))
+
+    return (
+        IcomCivAcquisitionExecutor(send_query, supports_cmd29=supports_cmd29),
+        sent,
+    )
+
+
+async def send_state_query(
+    poller: RadioPoller,
+    query: AcquisitionQueryCase,
+) -> None:
+    """Send one legacy query through the poller's exact current interface."""
+    command, sub, receiver = _require_legacy_query(query)
+    await poller._send_one_state_query(command, sub, receiver)  # noqa: SLF001
+
+
+def assert_acquisition_query_representation_contract() -> None:
+    """Pin the current legacy representation until the production migration."""
+    assert acquisition_query(0x18) == (0x18, None, None)
+    assert acquisition_query(0x16, sub=0x59) == (0x16, 0x59, None)
+    assert acquisition_query(0x1A, sub=0x05, data=b"\x01\x91") == (
+        0x1A,
+        b"\x05\x01\x91",
+        None,
+    )
+    assert acquisition_query(0x07, data=b"\xc2") == (0x07, 0xC2, None)
+    assert acquisition_query(0x25, selector=1) == (0x25, None, 1)
+
+    command_data = civ_frame_parts(acquisition_query(0x07, data=b"\xc2"))
+    assert command_data.sub is None
+    assert command_data.data == b"\xc2"
+    for selector_query in (
+        acquisition_query(0x25, selector=1),
+        acquisition_query(0x25, data=b"\x01"),
+    ):
+        selector_parts = civ_frame_parts(selector_query)
+        assert selector_parts.sub is None
+        assert selector_parts.data == b"\x01"
+        assert selector_parts.receiver is None
+        assert selector_parts.selector == 1
+
+    for invalid in ([0x18, None, None], CivFrameParts(command=0x18)):
+        try:
+            civ_frame_parts(invalid)  # type: ignore[arg-type]
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("helper accepted a non-tuple acquisition query")

--- a/tests/_acquisition_query_helpers.py
+++ b/tests/_acquisition_query_helpers.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 AcquisitionQueryCase = tuple[int, int | bytes | None, int | None]
+_DATA_ONLY_COMMAND = 0x07
+_SELECTOR_COMMANDS = frozenset((0x25, 0x26))
 
 
 @dataclass(frozen=True)
@@ -39,6 +41,15 @@ def _require_legacy_query(query: AcquisitionQueryCase) -> AcquisitionQueryCase:
     return query
 
 
+def _require_byte(name: str, value: int | None) -> None:
+    if value is None:
+        return
+    if type(value) is not int:
+        raise TypeError(f"{name} must be int or None")
+    if not 0 <= value <= 0xFF:
+        raise ValueError(f"{name} must fit in one byte")
+
+
 def acquisition_query(
     command: int,
     *,
@@ -48,20 +59,38 @@ def acquisition_query(
     selector: int | None = None,
 ) -> AcquisitionQueryCase:
     """Build the legacy tuple while keeping test intent explicit."""
+    _require_byte("command", command)
+    _require_byte("sub", sub)
+    _require_byte("receiver", receiver)
+    _require_byte("selector", selector)
+    if type(data) is not bytes:
+        raise TypeError("data must be exact bytes")
+
     if selector is not None:
         if (
-            command not in (0x25, 0x26)
+            command not in _SELECTOR_COMMANDS
             or sub is not None
             or data
             or receiver is not None
         ):
             raise ValueError("selector is exclusive to 0x25/0x26 queries")
         return command, None, selector
+
+    if command in _SELECTOR_COMMANDS:
+        if sub is not None or receiver is not None or len(data) != 1:
+            raise ValueError("0x25/0x26 require exactly one selector encoding")
+        return command, data[0], None
+
+    if command == _DATA_ONLY_COMMAND:
+        if sub is not None or receiver is not None or len(data) not in (0, 1):
+            raise ValueError("0x07 accepts only one semantic data byte")
+        return (command, None, None) if not data else (command, data[0], None)
+
     if data:
         if sub is None:
-            if len(data) != 1:
-                raise ValueError("legacy data-only queries require exactly one byte")
-            return command, data[0], receiver
+            raise ValueError("data-only queries are ambiguous for this command")
+        if receiver is not None:
+            raise ValueError("prefixed data cannot be combined with a receiver route")
         return command, bytes([sub]) + data, receiver
     return command, sub, receiver
 
@@ -71,7 +100,9 @@ def civ_frame_parts(
 ) -> CivFrameParts:
     """Expose semantic CI-V frame parts from the legacy tuple."""
     command, packed_sub, route = _require_legacy_query(query)
-    if command in (0x25, 0x26):
+    _require_byte("command", command)
+    _require_byte("receiver or selector", route)
+    if command in _SELECTOR_COMMANDS:
         if packed_sub is None and route is not None:
             selector = route
         elif type(packed_sub) is int and route is None:
@@ -83,17 +114,25 @@ def civ_frame_parts(
             data=bytes([selector]),
             selector=selector,
         )
+    if command == _DATA_ONLY_COMMAND:
+        if isinstance(packed_sub, bytes) or route is not None:
+            raise ValueError("0x07 legacy query must be bare or carry one data byte")
+        _require_byte("0x07 data", packed_sub)
+        if packed_sub is None:
+            return CivFrameParts(command=command)
+        return CivFrameParts(command=command, data=bytes([packed_sub]))
     if isinstance(packed_sub, bytes):
-        if not packed_sub:
-            raise ValueError("packed legacy sub must not be empty")
+        if len(packed_sub) < 2:
+            raise ValueError("packed legacy prefix must include semantic data")
+        if route is not None:
+            raise ValueError("packed legacy prefix cannot carry a receiver route")
         return CivFrameParts(
             command=command,
             sub=packed_sub[0],
             data=packed_sub[1:],
             receiver=route,
         )
-    if command == 0x07 and packed_sub is not None:
-        return CivFrameParts(command=command, data=bytes([packed_sub]), receiver=route)
+    _require_byte("sub", packed_sub)
     return CivFrameParts(command=command, sub=packed_sub, receiver=route)
 
 
@@ -161,10 +200,30 @@ def assert_acquisition_query_representation_contract() -> None:
         assert selector_parts.receiver is None
         assert selector_parts.selector == 1
 
-    for invalid in ([0x18, None, None], CivFrameParts(command=0x18)):
+    rejected_construction = (
+        lambda: acquisition_query(0x07, sub=0xC2),
+        lambda: acquisition_query(0x07, data=b"\xc2", receiver=0),
+        lambda: acquisition_query(0x25, sub=1),
+        lambda: acquisition_query(0x25, receiver=1),
+        lambda: acquisition_query(0x25, data=b"\x01", selector=1),
+        lambda: acquisition_query(0x16, data=b"\x59"),
+        lambda: acquisition_query(0x1A, sub=0x05, data=b"\x01", receiver=0),
+        lambda: acquisition_query(0x16, selector=1),
+    )
+    rejected_projection = (
+        lambda: civ_frame_parts([0x18, None, None]),  # type: ignore[arg-type]
+        lambda: civ_frame_parts(CivFrameParts(command=0x18)),  # type: ignore[arg-type]
+        lambda: civ_frame_parts((0x07, b"\xc2", None)),
+        lambda: civ_frame_parts((0x07, 0xC2, 0)),
+        lambda: civ_frame_parts((0x25, 1, 0)),
+        lambda: civ_frame_parts((0x25, None, None)),
+        lambda: civ_frame_parts((0x16, b"\x59", None)),
+        lambda: civ_frame_parts((0x1A, b"\x05\x01", 0)),
+    )
+    for rejected in rejected_construction + rejected_projection:
         try:
-            civ_frame_parts(invalid)  # type: ignore[arg-type]
-        except TypeError:
+            rejected()
+        except (TypeError, ValueError):
             pass
         else:
-            raise AssertionError("helper accepted a non-tuple acquisition query")
+            raise AssertionError("helper accepted an ambiguous acquisition query")

--- a/tests/_acquisition_query_helpers.py
+++ b/tests/_acquisition_query_helpers.py
@@ -59,6 +59,8 @@ def acquisition_query(
     selector: int | None = None,
 ) -> AcquisitionQueryCase:
     """Build the legacy tuple while keeping test intent explicit."""
+    if type(command) is not int:
+        raise TypeError("command must be int")
     _require_byte("command", command)
     _require_byte("sub", sub)
     _require_byte("receiver", receiver)
@@ -201,6 +203,7 @@ def assert_acquisition_query_representation_contract() -> None:
         assert selector_parts.selector == 1
 
     rejected_construction = (
+        lambda: acquisition_query(None),  # type: ignore[arg-type]
         lambda: acquisition_query(0x07, sub=0xC2),
         lambda: acquisition_query(0x07, data=b"\xc2", receiver=0),
         lambda: acquisition_query(0x25, sub=1),

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -39,6 +39,10 @@ from rigplane.core.state_pipeline_contracts import (
 from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
 from rigplane.profiles import get_radio_profile
 from rigplane.profiles.rig_loader import load_rig
+from _acquisition_query_helpers import (
+    acquisition_query,
+    recording_executor,
+)
 
 
 RIGS_DIR = Path(__file__).parents[1] / "rigs"
@@ -806,14 +810,7 @@ def test_ic7610_real_profile_stale_active_rit_xit_acquisition_can_send_queries()
     store.mark_stale_due()
     scheduler = AcquisitionScheduler(profile=acquisition, clock=clock)
     service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
+    executor, sent = recording_executor()
 
     result = service.ensure_fresh(
         tuple(path for path, _value in paths_and_values),
@@ -826,7 +823,6 @@ def test_ic7610_real_profile_stale_active_rit_xit_acquisition_can_send_queries()
     requests = scheduler.pending_requests()
     requested_paths = {path for request in requests for path in request.paths}
     assert requested_paths >= {path for path, _value in paths_and_values}
-    executor = IcomCivAcquisitionExecutor(send_query)
     for request in requests:
         execution = asyncio.run(
             executor.execute(request, already_sent_paths=frozenset())
@@ -835,10 +831,10 @@ def test_ic7610_real_profile_stale_active_rit_xit_acquisition_can_send_queries()
 
     assert len(sent) == 4
     assert set(sent) == {
-        (0x07, 0xD2, None),
-        (0x21, 0x00, None),
-        (0x21, 0x01, None),
-        (0x21, 0x02, None),
+        acquisition_query(0x07, data=b"\xd2"),
+        acquisition_query(0x21, sub=0x00),
+        acquisition_query(0x21, sub=0x01),
+        acquisition_query(0x21, sub=0x02),
     }
 
 
@@ -860,16 +856,7 @@ def test_ic7610_real_profile_freq_mode_are_pollable_and_emit_25_26() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(freq_mode_paths) <= due_paths
 
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, sent = recording_executor()
     for request in requests:
         if not any(path in freq_mode_paths for path in request.paths):
             continue
@@ -878,9 +865,12 @@ def test_ic7610_real_profile_freq_mode_are_pollable_and_emit_25_26() -> None:
         )
         assert execution.failed_paths == ()
 
-    assert {(0x25, None, 0), (0x25, None, 1), (0x26, None, 0), (0x26, None, 1)} <= set(
-        sent
-    )
+    assert {
+        acquisition_query(0x25, selector=0),
+        acquisition_query(0x25, selector=1),
+        acquisition_query(0x26, selector=0),
+        acquisition_query(0x26, selector=1),
+    } <= set(sent)
 
 
 def test_ic7610_real_profile_ptt_is_pollable_and_emits_bare_1c00_read() -> None:
@@ -905,21 +895,11 @@ def test_ic7610_real_profile_ptt_is_pollable_and_emits_bare_1c00_read() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert ptt in due_paths
 
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, sent = recording_executor()
 
     # The poll query is a pure READ of 0x1C 0x00 with no receiver/data byte;
-    # a data byte would key TX, and the third tuple element is the receiver
-    # index (None here), never a payload.
-    assert executor.query_for_path(ptt) == (0x1C, 0x00, None)
+    # a data byte would key TX, while this global read has no receiver route.
+    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
 
     for request in requests:
         if ptt not in request.paths:
@@ -928,28 +908,23 @@ def test_ic7610_real_profile_ptt_is_pollable_and_emits_bare_1c00_read() -> None:
             executor.execute(request, already_sent_paths=frozenset())
         )
         assert execution.failed_paths == ()
-    assert (0x1C, 0x00, None) in sent
+    assert acquisition_query(0x1C, sub=0x00) in sent
 
 
 def test_ic7610_real_profile_att_preamp_squelch_query_for_path() -> None:
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, sent = recording_executor()
 
     att = FieldPath.receiver("main", "operator_controls", "att")
     preamp = FieldPath.receiver("main", "operator_controls", "preamp")
     squelch = FieldPath.receiver("main", "operator_controls", "squelch")
 
-    assert executor.query_for_path(att) == (0x11, None, 0)
-    assert executor.query_for_path(preamp) == (0x16, 0x02, 0)
-    assert executor.query_for_path(squelch) == (0x14, 0x03, 0)
+    assert executor.query_for_path(att) == acquisition_query(0x11, receiver=0)
+    assert executor.query_for_path(preamp) == acquisition_query(
+        0x16, sub=0x02, receiver=0
+    )
+    assert executor.query_for_path(squelch) == acquisition_query(
+        0x14, sub=0x03, receiver=0
+    )
 
 
 def test_ic7610_global_meter_query_for_path() -> None:
@@ -958,16 +933,7 @@ def test_ic7610_global_meter_query_for_path() -> None:
     power/swr/alc already mapped; comp/vd/id were missing, so on a
     scheduler-only radio (IC-7610) they were never polled and rendered 0.
     """
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, sent = recording_executor()
 
     power = FieldPath.global_("meters", "power")
     swr = FieldPath.global_("meters", "swr")
@@ -976,12 +942,12 @@ def test_ic7610_global_meter_query_for_path() -> None:
     vd = FieldPath.global_("meters", "vd")
     id_ = FieldPath.global_("meters", "id")
 
-    assert executor.query_for_path(power) == (0x15, 0x11, None)
-    assert executor.query_for_path(swr) == (0x15, 0x12, None)
-    assert executor.query_for_path(alc) == (0x15, 0x13, None)
-    assert executor.query_for_path(comp) == (0x15, 0x14, None)
-    assert executor.query_for_path(vd) == (0x15, 0x15, None)
-    assert executor.query_for_path(id_) == (0x15, 0x16, None)
+    assert executor.query_for_path(power) == acquisition_query(0x15, sub=0x11)
+    assert executor.query_for_path(swr) == acquisition_query(0x15, sub=0x12)
+    assert executor.query_for_path(alc) == acquisition_query(0x15, sub=0x13)
+    assert executor.query_for_path(comp) == acquisition_query(0x15, sub=0x14)
+    assert executor.query_for_path(vd) == acquisition_query(0x15, sub=0x15)
+    assert executor.query_for_path(id_) == acquisition_query(0x15, sub=0x16)
 
 
 def test_ic7610_real_profile_comp_vd_id_meters_are_enrolled_and_sent() -> None:
@@ -1009,14 +975,7 @@ def test_ic7610_real_profile_comp_vd_id_meters_are_enrolled_and_sent() -> None:
     sent: list[FieldPath] = []
     failed: list[FieldPath] = []
 
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        return None
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, _queries = recording_executor()
     for request in requests:
         execution = asyncio.run(
             executor.execute(request, already_sent_paths=frozenset())
@@ -1035,16 +994,7 @@ def test_ic7610_real_profile_sub_operator_controls_query_for_path() -> None:
     rf_gain/af_level/squelch route through the 0x14 level subs; att/preamp
     through the non-level mappings — all with the SUB receiver byte (1).
     """
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, sent = recording_executor()
 
     rf_gain = FieldPath.receiver("sub", "operator_controls", "rf_gain")
     af_level = FieldPath.receiver("sub", "operator_controls", "af_level")
@@ -1052,11 +1002,19 @@ def test_ic7610_real_profile_sub_operator_controls_query_for_path() -> None:
     att = FieldPath.receiver("sub", "operator_controls", "att")
     preamp = FieldPath.receiver("sub", "operator_controls", "preamp")
 
-    assert executor.query_for_path(rf_gain) == (0x14, 0x02, 1)
-    assert executor.query_for_path(af_level) == (0x14, 0x01, 1)
-    assert executor.query_for_path(squelch) == (0x14, 0x03, 1)
-    assert executor.query_for_path(att) == (0x11, None, 1)
-    assert executor.query_for_path(preamp) == (0x16, 0x02, 1)
+    assert executor.query_for_path(rf_gain) == acquisition_query(
+        0x14, sub=0x02, receiver=1
+    )
+    assert executor.query_for_path(af_level) == acquisition_query(
+        0x14, sub=0x01, receiver=1
+    )
+    assert executor.query_for_path(squelch) == acquisition_query(
+        0x14, sub=0x03, receiver=1
+    )
+    assert executor.query_for_path(att) == acquisition_query(0x11, receiver=1)
+    assert executor.query_for_path(preamp) == acquisition_query(
+        0x16, sub=0x02, receiver=1
+    )
 
 
 def test_ic7610_real_profile_sql_att_pre_are_pollable_and_emit_reads() -> None:
@@ -1086,16 +1044,7 @@ def test_ic7610_real_profile_sql_att_pre_are_pollable_and_emit_reads() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    sent: list[tuple[int, int | None, int | None]] = []
-
-    async def send_query(
-        command: int,
-        sub: int | None,
-        receiver: int | None,
-    ) -> None:
-        sent.append((command, sub, receiver))
-
-    executor = IcomCivAcquisitionExecutor(send_query)
+    executor, sent = recording_executor()
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -1105,11 +1054,11 @@ def test_ic7610_real_profile_sql_att_pre_are_pollable_and_emit_reads() -> None:
         assert execution.failed_paths == ()
 
     assert {
-        (0x14, 0x02, 0),
-        (0x14, 0x01, 0),
-        (0x11, None, 0),
-        (0x16, 0x02, 0),
-        (0x14, 0x03, 0),
+        acquisition_query(0x14, sub=0x02, receiver=0),
+        acquisition_query(0x14, sub=0x01, receiver=0),
+        acquisition_query(0x11, receiver=0),
+        acquisition_query(0x16, sub=0x02, receiver=0),
+        acquisition_query(0x14, sub=0x03, receiver=0),
     } <= set(sent)
 
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -4024,8 +4024,8 @@ def test_state_queries_include_scope_vbw_rbw_edge_for_ic7610() -> None:
     poller = RadioPoller(_make_radio(), StateCache(), CommandQueue())
 
     queries = set(poller._STATE_QUERIES)  # noqa: SLF001
-    # The eight selector-carrying reads arrive as a two-byte ``sub``
-    # (sub-command + Main/Sub selector); the rest stay bare (MOR-1981).
+    # Eight reads carry a sub-command plus one-byte Main/Sub selector data;
+    # the rest carry only the bare sub-command (MOR-1981).
     assert acquisition_query(0x27, sub=0x16, data=b"\x00") in queries  # edge
     assert acquisition_query(0x27, sub=0x19, data=b"\x00") in queries  # REF
     assert acquisition_query(0x27, sub=0x1B) in queries  # during TX

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -108,6 +108,7 @@ from rigplane.web.radio_poller import (
     VfoEqualize,
     VfoSwap,
 )
+from _acquisition_query_helpers import acquisition_query, send_state_query
 from rigplane.core.tx_safety import (
     BACKEND_MAX_KEY_DOWN_SECONDS,
     TxOutcome,
@@ -2542,20 +2543,22 @@ async def test_send_query_even_and_odd_branch_variants() -> None:
     await poller._send_query()  # noqa: SLF001
     assert radio.send_civ.await_args.args[0] == 0x15
 
-    poller._STATE_QUERIES = [
-        (0x25, None, 0x01)
-    ]  # receiver in data payload  # noqa: SLF001
+    poller._STATE_QUERIES = [  # noqa: SLF001
+        acquisition_query(0x25, selector=0x01)
+    ]
     poller._poll_index = 1  # odd  # noqa: SLF001
     await poller._send_query()  # noqa: SLF001
     assert radio.send_civ.await_args.args[0] == 0x25
     assert radio.send_civ.await_args.kwargs["data"] == bytes([0x01])
 
-    poller._STATE_QUERIES = [(0x16, 0x22, 0x01)]  # cmd29 wrapper path  # noqa: SLF001
+    poller._STATE_QUERIES = [  # noqa: SLF001
+        acquisition_query(0x16, sub=0x22, receiver=0x01)
+    ]
     poller._poll_index = 1  # noqa: SLF001
     await poller._send_query()  # noqa: SLF001
     assert radio.send_civ.await_args.args[0] == 0x29
 
-    poller._STATE_QUERIES = [(0x0F, None, None)]  # global query  # noqa: SLF001
+    poller._STATE_QUERIES = [acquisition_query(0x0F)]  # noqa: SLF001
     poller._poll_index = 1  # noqa: SLF001
     await poller._send_query()  # noqa: SLF001
     assert radio.send_civ.await_args.args[0] == 0x0F
@@ -2657,29 +2660,29 @@ def test_state_queries_include_operator_toggle_reads_for_ic7610() -> None:
     poller = RadioPoller(_make_radio(), StateCache(), CommandQueue())
 
     assert {
-        (0x15, 0x01, 0x00),
-        (0x15, 0x01, 0x01),
-        (0x15, 0x07, None),
-        (0x16, 0x12, 0x00),
-        (0x16, 0x12, 0x01),
-        (0x16, 0x32, 0x00),
-        (0x16, 0x32, 0x01),
-        (0x16, 0x41, 0x00),
-        (0x16, 0x41, 0x01),
-        (0x16, 0x44, None),
-        (0x16, 0x45, None),
-        (0x16, 0x46, None),
-        (0x16, 0x47, None),
-        (0x16, 0x48, 0x00),
-        (0x16, 0x48, 0x01),
-        (0x16, 0x4F, 0x00),
-        (0x16, 0x4F, 0x01),
-        (0x16, 0x50, None),
-        (0x16, 0x56, 0x00),
-        (0x16, 0x56, 0x01),
-        (0x16, 0x58, None),
-        (0x1A, 0x04, 0x00),
-        (0x1A, 0x04, 0x01),
+        acquisition_query(0x15, sub=0x01, receiver=0x00),
+        acquisition_query(0x15, sub=0x01, receiver=0x01),
+        acquisition_query(0x15, sub=0x07),
+        acquisition_query(0x16, sub=0x12, receiver=0x00),
+        acquisition_query(0x16, sub=0x12, receiver=0x01),
+        acquisition_query(0x16, sub=0x32, receiver=0x00),
+        acquisition_query(0x16, sub=0x32, receiver=0x01),
+        acquisition_query(0x16, sub=0x41, receiver=0x00),
+        acquisition_query(0x16, sub=0x41, receiver=0x01),
+        acquisition_query(0x16, sub=0x44),
+        acquisition_query(0x16, sub=0x45),
+        acquisition_query(0x16, sub=0x46),
+        acquisition_query(0x16, sub=0x47),
+        acquisition_query(0x16, sub=0x48, receiver=0x00),
+        acquisition_query(0x16, sub=0x48, receiver=0x01),
+        acquisition_query(0x16, sub=0x4F, receiver=0x00),
+        acquisition_query(0x16, sub=0x4F, receiver=0x01),
+        acquisition_query(0x16, sub=0x50),
+        acquisition_query(0x16, sub=0x56, receiver=0x00),
+        acquisition_query(0x16, sub=0x56, receiver=0x01),
+        acquisition_query(0x16, sub=0x58),
+        acquisition_query(0x1A, sub=0x04, receiver=0x00),
+        acquisition_query(0x1A, sub=0x04, receiver=0x01),
     }.issubset(set(poller._STATE_QUERIES))  # noqa: SLF001
 
 
@@ -2687,11 +2690,11 @@ def test_state_queries_include_transceiver_status_reads_for_ic7610() -> None:
     poller = RadioPoller(_make_radio(), StateCache(), CommandQueue())
 
     assert {
-        (0x1C, 0x01, None),
-        (0x1C, 0x03, None),
-        (0x21, 0x00, None),
-        (0x21, 0x01, None),
-        (0x21, 0x02, None),
+        acquisition_query(0x1C, sub=0x01),
+        acquisition_query(0x1C, sub=0x03),
+        acquisition_query(0x21, sub=0x00),
+        acquisition_query(0x21, sub=0x01),
+        acquisition_query(0x21, sub=0x02),
     }.issubset(set(poller._STATE_QUERIES))  # noqa: SLF001
 
 
@@ -4023,12 +4026,12 @@ def test_state_queries_include_scope_vbw_rbw_edge_for_ic7610() -> None:
     queries = set(poller._STATE_QUERIES)  # noqa: SLF001
     # The eight selector-carrying reads arrive as a two-byte ``sub``
     # (sub-command + Main/Sub selector); the rest stay bare (MOR-1981).
-    assert (0x27, b"\x16\x00", None) in queries  # edge number
-    assert (0x27, b"\x19\x00", None) in queries  # REF level
-    assert (0x27, 0x1B, None) in queries  # during TX
-    assert (0x27, 0x1C, None) in queries  # center type
-    assert (0x27, b"\x1d\x00", None) in queries  # VBW
-    assert (0x27, b"\x1f\x00", None) in queries  # RBW
+    assert acquisition_query(0x27, sub=0x16, data=b"\x00") in queries  # edge
+    assert acquisition_query(0x27, sub=0x19, data=b"\x00") in queries  # REF
+    assert acquisition_query(0x27, sub=0x1B) in queries  # during TX
+    assert acquisition_query(0x27, sub=0x1C) in queries  # center type
+    assert acquisition_query(0x27, sub=0x1D, data=b"\x00") in queries  # VBW
+    assert acquisition_query(0x27, sub=0x1F, data=b"\x00") in queries  # RBW
 
 
 @pytest.mark.asyncio
@@ -4045,7 +4048,7 @@ async def test_scope_state_query_uses_the_live_scope_receiver() -> None:
     state.scope_controls.receiver = 1
     poller = RadioPoller(radio, StateCache(), CommandQueue(), radio_state=state)
 
-    await poller._send_one_state_query(0x27, b"\x14\x00", None)  # noqa: SLF001
+    await send_state_query(poller, acquisition_query(0x27, sub=0x14, data=b"\x00"))
 
     radio.send_civ.assert_awaited_once()
     assert radio.send_civ.await_args.args[0] == 0x27
@@ -4067,7 +4070,7 @@ async def test_scope_fixed_edge_query_carries_no_selector_byte() -> None:
     radio = _make_radio()
     poller = RadioPoller(radio, StateCache(), CommandQueue())
 
-    await poller._send_one_state_query(0x27, 0x1E, None)  # noqa: SLF001
+    await send_state_query(poller, acquisition_query(0x27, sub=0x1E))
 
     radio.send_civ.assert_awaited_once()
     assert radio.send_civ.await_args.kwargs["data"] == b""

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -20,6 +20,11 @@ from rigplane.core.state_acquisition_policy import (
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.profiles import get_radio_profile
 from rigplane.rig_loader import RigLoadError, discover_rigs, load_rig
+from _acquisition_query_helpers import (
+    AcquisitionQueryCase,
+    civ_frame_parts,
+    recording_executor,
+)
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
 
@@ -764,7 +769,7 @@ def _table_backed_ingress_spec(command: int, sub: int) -> tuple[str, str, str] |
 def _round_trip_observes(
     radio: Any,
     path: FieldPath,
-    query: tuple[int, int | bytes | None, int | None],
+    query: AcquisitionQueryCase,
 ) -> None:
     """Push a synthetic response for ``query`` through the REAL ingress
     decode and assert ``path`` comes out the other side.
@@ -778,20 +783,18 @@ def _round_trip_observes(
     could paper over.
     """
 
-    from rigplane.core.acquisition_scheduler import split_ctl_mem_sub
     from rigplane.commands import CONTROLLER_ADDR
     from rigplane.types import CivFrame
 
-    command, sub_raw, receiver = query
-    civ_sub, prefix = split_ctl_mem_sub(sub_raw)
+    parts = civ_frame_parts(query)
     payload = _HARDCODED_SYNTHETIC_PAYLOAD[path.name]
     frame = CivFrame(
         to_addr=CONTROLLER_ADDR,
         from_addr=0x94,  # IC-7300's civ_addr (rigs/ic7300.toml)
-        command=command,
-        sub=civ_sub,
-        data=prefix + payload,
-        receiver=receiver,
+        command=parts.command,
+        sub=parts.sub,
+        data=parts.data + payload,
+        receiver=parts.receiver,
     )
 
     observations = radio._civ_runtime._observations_from_frame(frame)  # noqa: SLF001
@@ -807,8 +810,9 @@ def _round_trip_observes(
         == expected
     ]
     assert matched, (
-        f"{path}: synthetic response (command=0x{command:02x}, sub={civ_sub!r}, "
-        f"data={(prefix + payload).hex()}) produced no matching observation -- "
+        f"{path}: synthetic response (command=0x{parts.command:02x}, "
+        f"sub={parts.sub!r}, data={(parts.data + payload).hex()}) produced no "
+        "matching observation -- "
         "either the ingress branch doesn't match what query_for_path actually "
         "sends, or a primed read for this path would never leave UNKNOWN"
     )
@@ -846,19 +850,13 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
     test either way.
     """
 
-    from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
     from rigplane.radio import IcomRadio
 
     profile = get_radio_profile("IC-7300")
     acquisition = profile.state_acquisition
     assert acquisition is not None
 
-    async def _noop_send(
-        command: int, sub: int | bytes | None, receiver: int | None
-    ) -> None:
-        return None
-
-    executor = IcomCivAcquisitionExecutor(_noop_send)
+    executor, _sent = recording_executor()
     radio = IcomRadio(host="192.168.1.100", model="IC-7300")
 
     non_polling_paths = [
@@ -889,15 +887,19 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
             _round_trip_observes(radio, path, query)
             continue
 
-        command, sub = query[0], query[1]
+        parts = civ_frame_parts(query)
+        sub = parts.sub
         assert isinstance(sub, int), (
             f"{path}: table-backed field must query with a plain int sub, "
             f"got {sub!r} -- extend _HARDCODED_OBSERVABLE_FIELDS if this is "
             "actually a new branch-shaped ingress mapping"
         )
-        resolved = _table_backed_ingress_spec(command, sub)
+        assert parts.data == b"", (
+            f"{path}: table-backed field must not carry data, got {parts.data!r}"
+        )
+        resolved = _table_backed_ingress_spec(parts.command, sub)
         assert resolved == key, (
-            f"{path}: query sends command=0x{command:02x} sub=0x{sub:02x}, "
+            f"{path}: query sends command=0x{parts.command:02x} sub=0x{sub:02x}, "
             f"but the ingress table at that exact key resolves to {resolved} "
             f"instead of {key} -- a primed read for this path would never "
             "leave UNKNOWN"

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -14,6 +14,14 @@ from rigplane.commands.scope import (
 )
 from rigplane.runtime._state_queries import build_state_queries
 from rigplane.profiles import resolve_radio_profile
+from _acquisition_query_helpers import (
+    AcquisitionQueryCase,
+    acquisition_query,
+    assert_acquisition_query_representation_contract,
+    civ_frame_parts,
+    query_command,
+    query_selector,
+)
 
 # The 0x27 read sub-commands the sweep sends, split by whether the frame
 # carries the one-byte Main/Sub scope selector.  Spelled out here rather
@@ -24,9 +32,9 @@ _BARE_SUBS = frozenset({0x12, 0x13, 0x1B, 0x1C})
 
 
 def _scope_queries(
-    queries: list[tuple[int, int | bytes | None, int | None]],
-) -> list[tuple[int, int | bytes | None, int | None]]:
-    return [q for q in queries if q[0] == 0x27]
+    queries: list[AcquisitionQueryCase],
+) -> list[AcquisitionQueryCase]:
+    return [query for query in queries if query_command(query) == 0x27]
 
 
 def _ic7610_caps() -> set[str]:
@@ -44,44 +52,49 @@ def _ic7300_caps() -> set[str]:
 class TestBuildStateQueries:
     """Verify build_state_queries produces correct query lists."""
 
-    def test_returns_list_of_3_tuples(self) -> None:
+    def test_returns_current_acquisition_query_representation(self) -> None:
+        assert_acquisition_query_representation_contract()
         profile = resolve_radio_profile(model="IC-7610")
         queries = build_state_queries(profile, _ic7610_caps())
         assert isinstance(queries, list)
         assert len(queries) > 0
-        for q in queries:
-            assert isinstance(q, tuple)
-            assert len(q) == 3
+        for query in queries:
+            civ_frame_parts(query)
 
     def test_ic7610_includes_dual_receiver_queries(self) -> None:
         """IC-7610 has 2 receivers — freq/mode must appear for rx 0 and rx 1."""
         profile = resolve_radio_profile(model="IC-7610")
         queries = build_state_queries(profile, _ic7610_caps())
-        freq_receivers = [q[2] for q in queries if q[0] == 0x25]
-        assert 0 in freq_receivers
-        assert 1 in freq_receivers
+        freq_selectors = [
+            query_selector(query) for query in queries if query_command(query) == 0x25
+        ]
+        assert 0 in freq_selectors
+        assert 1 in freq_selectors
 
     def test_ic7300_single_receiver(self) -> None:
         """IC-7300 has selected/unselected reads on its one receiver."""
         profile = resolve_radio_profile(model="IC-7300")
         queries = build_state_queries(profile, _ic7300_caps())
-        freq_queries = [q for q in queries if q[0] == 0x25]
-        assert freq_queries == [(0x25, None, 0), (0x25, 0x01, None)]
-        assert (0x07, 0xD2, None) not in queries
-        assert (0x07, 0xC2, None) not in queries
+        freq_queries = [query for query in queries if query_command(query) == 0x25]
+        assert freq_queries == [
+            acquisition_query(0x25, selector=0),
+            acquisition_query(0x25, data=b"\x01"),
+        ]
+        assert acquisition_query(0x07, data=b"\xd2") not in queries
+        assert acquisition_query(0x07, data=b"\xc2") not in queries
 
     def test_ic7610_includes_scope_queries(self) -> None:
         """IC-7610 should have scope sub-commands (0x27)."""
         profile = resolve_radio_profile(model="IC-7610")
         queries = build_state_queries(profile, _ic7610_caps())
-        scope_queries = [q for q in queries if q[0] == 0x27]
+        scope_queries = [query for query in queries if query_command(query) == 0x27]
         assert len(scope_queries) > 0
 
     def test_ic7300_has_scope_queries_if_capable(self) -> None:
         """IC-7300 has scope capability — should include 0x27 queries."""
         profile = resolve_radio_profile(model="IC-7300")
         queries = build_state_queries(profile, _ic7300_caps())
-        scope_queries = [q for q in queries if q[0] == 0x27]
+        scope_queries = [query for query in queries if query_command(query) == 0x27]
         if "scope" in _ic7300_caps():
             assert len(scope_queries) > 0
         else:
@@ -91,7 +104,8 @@ class TestBuildStateQueries:
         """Power, PTT, split, RIT etc. must be in every query list."""
         profile = resolve_radio_profile(model="IC-7610")
         queries = build_state_queries(profile, _ic7610_caps())
-        cmds = {(q[0], q[1]) for q in queries}
+        parts = map(civ_frame_parts, queries)
+        cmds = {(part.command, part.sub) for part in parts if not part.data}
         assert (0x18, None) in cmds  # Power status
         assert (0x1C, 0x00) in cmds  # PTT
         assert (0x0F, None) in cmds  # Split
@@ -104,7 +118,8 @@ class TestBuildStateQueries:
         serial_queries = build_state_queries(profile, _ic7610_caps(), is_serial=True)
         # Serial should have more queries (the extra meters)
         assert len(serial_queries) > len(lan_queries)
-        serial_cmds = {(q[0], q[1]) for q in serial_queries}
+        parts = map(civ_frame_parts, serial_queries)
+        serial_cmds = {(part.command, part.sub) for part in parts if not part.data}
         assert (0x15, 0x13) in serial_cmds  # ALC meter
         assert (0x15, 0x14) in serial_cmds  # Compressor meter
         assert (0x15, 0x15) in serial_cmds  # VD
@@ -118,11 +133,13 @@ class TestBuildStateQueries:
         reduced_caps = full_caps - {"nb"}
         full_queries = build_state_queries(profile, full_caps)
         reduced_queries = build_state_queries(profile, reduced_caps)
-        # NB queries (0x16/0x22 and 0x14/0x12) should be missing
-        nb_in_full = [q for q in full_queries if q[0] == 0x16 and q[1] == 0x22]
-        nb_in_reduced = [q for q in reduced_queries if q[0] == 0x16 and q[1] == 0x22]
-        assert len(nb_in_full) > 0
-        assert len(nb_in_reduced) == 0
+        # Both receiver-routed NB queries should disappear with the capability.
+        expected = {
+            acquisition_query(0x16, sub=0x22, receiver=0),
+            acquisition_query(0x16, sub=0x22, receiver=1),
+        }
+        assert expected.issubset(full_queries)
+        assert expected.isdisjoint(reduced_queries)
 
     def test_empty_capabilities_still_has_globals(self) -> None:
         """Even with no capabilities, global queries should be present."""
@@ -130,7 +147,8 @@ class TestBuildStateQueries:
         queries = build_state_queries(profile, set())
         # Should still have freq/mode + globals
         assert len(queries) > 0
-        cmds = {(q[0], q[1]) for q in queries}
+        parts = map(civ_frame_parts, queries)
+        cmds = {(part.command, part.sub) for part in parts if not part.data}
         assert (0x18, None) in cmds  # Power status
 
     def test_deterministic_output(self) -> None:
@@ -152,7 +170,7 @@ class TestBuildStateQueries:
             build_state_queries(profile, {"dual_watch"})
         ) - Counter(build_state_queries(profile, set()))
 
-        assert dual_watch_delta == Counter({(0x16, 0x59, None): 1})
+        assert dual_watch_delta == Counter({acquisition_query(0x16, sub=0x59): 1})
 
     def test_ic7610_dual_watch_query_preserves_wire_tuple(self) -> None:
         profile = resolve_radio_profile(model="IC-7610")
@@ -165,8 +183,8 @@ class TestBuildStateQueries:
             build_state_queries(profile, {"dual_watch"})
         ) - Counter(build_state_queries(profile, set()))
 
-        assert dual_watch_delta == Counter({(0x07, 0xC2, None): 1})
-        assert (0x07, None, None) not in dual_watch_delta
+        assert dual_watch_delta == Counter({acquisition_query(0x07, data=b"\xc2"): 1})
+        assert acquisition_query(0x07) not in dual_watch_delta
         assert build_civ_frame(0x98, 0xE0, 0x07, sub=0xC2) == bytes.fromhex(
             "FE FE 98 E0 07 C2 FD"
         )
@@ -203,30 +221,28 @@ class TestScopeReceiverSelector:
         profile = resolve_radio_profile(model="IC-7300")
         scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
 
-        with_selector = {
-            sub[0] for _, sub, _ in scope if isinstance(sub, (bytes, bytearray))
-        }
-        bare = {sub for _, sub, _ in scope if isinstance(sub, int)}
+        frame_parts = [civ_frame_parts(query) for query in scope]
+        with_selector = {part.sub for part in frame_parts if part.data}
+        bare = {part.sub for part in frame_parts if not part.data}
 
         assert with_selector == _SELECTOR_SUBS
         assert bare == _BARE_SUBS
         assert len(scope) == len(_SELECTOR_SUBS) + len(_BARE_SUBS) == 12
-        # The scope reads are the only queries this builder gives a
-        # payload-carrying sub element to.
+        # Scope reads are the only queries with both a sub-command and data.
         queries = build_state_queries(profile, _ic7300_caps())
+        parts = map(civ_frame_parts, queries)
         assert [
-            cmd for cmd, sub, _ in queries if isinstance(sub, (bytes, bytearray))
+            part.command for part in parts if part.sub is not None and part.data
         ] == [0x27] * len(_SELECTOR_SUBS)
 
     def test_sweep_selector_is_one_byte_and_main(self) -> None:
         profile = resolve_radio_profile(model="IC-7300")
         scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
 
-        carried = [sub for _, sub, _ in scope if isinstance(sub, (bytes, bytearray))]
+        carried = [part.data for part in map(civ_frame_parts, scope) if part.data]
         assert carried, "no scope read carried a selector"
-        for sub in carried:
-            assert len(sub) == 2
-            assert sub[1] == SCOPE_SELECTOR_MAIN
+        for data in carried:
+            assert data == bytes([SCOPE_SELECTOR_MAIN])
 
     @pytest.mark.parametrize("model", ["IC-7300", "IC-7610"])
     def test_a_payload_carrying_sub_is_never_paired_with_a_receiver(
@@ -234,9 +250,8 @@ class TestScopeReceiverSelector:
     ) -> None:
         """The selector is payload, not the cmd29 receiver slot.
 
-        A non-``None`` third element routes the query through cmd29 in both
-        senders, which is a different frame entirely, and neither carries
-        the payload half of the sub element down that path:
+        A receiver route uses cmd29 in both senders, which is a different
+        frame entirely and cannot carry scope selector data down that path:
         ``runtime/radio_initial_state.py: fetch_initial_state`` wraps the
         sub-command byte alone, and
         ``web/radio_poller.py: RadioPoller._send_one_state_query`` asserts
@@ -248,9 +263,7 @@ class TestScopeReceiverSelector:
 
         assert _scope_queries(queries), "no scope reads to check"
         assert all(
-            receiver is None
-            for _, sub, receiver in queries
-            if isinstance(sub, (bytes, bytearray))
+            part.receiver is None for part in map(civ_frame_parts, queries) if part.data
         )
 
 


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2157/preserve-the-full-commandmap-prefix-in-acquisition-query-envelopes

First of two test-only preparation PRs for MOR-2157.

Owned test-only scope:
- `tests/_acquisition_query_helpers.py` — shared acquisition-query fixture/helpers
- `tests/test_acquisition_scheduler.py` — scheduler fixture migration
- `tests/test_radio_poller_coverage.py` — poller fixture migration
- `tests/test_state_acquisition_policy.py` — policy fixture migration
- `tests/test_state_queries.py` — state-query fixture migration

Targeted evidence: 386 normal cases PASS; 386 reverse cases PASS; scoped Ruff/format PASS.

This PR does not implement or close MOR-2157. Production acceptance remains outstanding. It makes no full-suite or hardware claim.