### PR TITLE
test(MOR-2144): share command builder census

### DIFF
--- a/tests/support/command_builders.py
+++ b/tests/support/command_builders.py
@@ -1,0 +1,29 @@
+"""Shared public command-builder census for tests."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import inspect
+from pathlib import Path
+from typing import Any
+
+CommandBuilderKey = tuple[str, str]
+
+
+@functools.lru_cache(maxsize=4)
+def public_command_builders(command_dir: Path) -> dict[CommandBuilderKey, Any]:
+    """Return public command-package functions whose signature accepts ``cmd_map``."""
+    found: dict[CommandBuilderKey, Any] = {}
+    for path in sorted(command_dir.glob("*.py")):
+        if path.stem == "__init__":
+            continue
+        module = importlib.import_module(f"rigplane.commands.{path.stem}")
+        for value in vars(module).values():
+            if not inspect.isfunction(value) or value.__name__.startswith("_"):
+                continue
+            if value.__module__ != module.__name__:
+                continue
+            if "cmd_map" in inspect.signature(value).parameters:
+                found[(path.name, value.__name__)] = value
+    return found

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -85,6 +85,7 @@ import pytest
 from rigplane.commands.command_spec import CatCommandSpec
 from rigplane.profiles import resolve_radio_profile
 from rigplane.profiles.rig_loader import discover_rigs
+from support.command_builders import public_command_builders
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 COMMANDS_DIR = REPO_ROOT / "src" / "rigplane" / "commands"
@@ -213,19 +214,7 @@ def _builders() -> dict[Key, typing.Any]:
     collapses onto the function it aliases instead of being compared twice
     under both names.
     """
-    found: dict[Key, typing.Any] = {}
-    for path in sorted(COMMANDS_DIR.glob("*.py")):
-        if path.stem == "__init__":
-            continue
-        module = importlib.import_module(f"rigplane.commands.{path.stem}")
-        for value in vars(module).values():
-            if not inspect.isfunction(value) or value.__name__.startswith("_"):
-                continue
-            if value.__module__ != module.__name__:
-                continue
-            if "cmd_map" in inspect.signature(value).parameters:
-                found[(path.name, value.__name__)] = value
-    return found
+    return public_command_builders(COMMANDS_DIR)
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -53,8 +53,6 @@ from __future__ import annotations
 
 import ast
 import functools
-import importlib
-import inspect
 import os
 import pathlib
 import typing
@@ -64,6 +62,7 @@ import pytest
 
 from rigplane.commands.command_map import CommandMap
 from rigplane.profiles.rig_loader import discover_rigs
+from support.command_builders import public_command_builders
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 COMMANDS_DIR = REPO_ROOT / "src" / "rigplane" / "commands"
@@ -92,26 +91,8 @@ def _ast_index() -> dict[Key, ast.FunctionDef]:
 
 @functools.lru_cache(maxsize=1)
 def _builders() -> dict[Key, typing.Any]:
-    """Every public builder in the package that takes a ``cmd_map``.
-
-    Same filtering as ``tests/test_command_map_parity.py: _builders`` --
-    reimplemented rather than imported, since importing that module would
-    also run its own module-level baseline collection as a side effect of
-    collecting this file.
-    """
-    found: dict[Key, typing.Any] = {}
-    for path in sorted(COMMANDS_DIR.glob("*.py")):
-        if path.stem == "__init__":
-            continue
-        module = importlib.import_module(f"rigplane.commands.{path.stem}")
-        for value in vars(module).values():
-            if not inspect.isfunction(value) or value.__name__.startswith("_"):
-                continue
-            if value.__module__ != module.__name__:
-                continue
-            if "cmd_map" in inspect.signature(value).parameters:
-                found[(path.name, value.__name__)] = value
-    return found
+    """Return the shared builder inventory used by both coverage guards."""
+    return public_command_builders(COMMANDS_DIR)
 
 
 def _static_literal_key(node: ast.FunctionDef) -> str | None:


### PR DESCRIPTION
Linear: https://linear.app/rigplane/issue/MOR-2144

## Summary

- move the duplicated public cmd_map builder census into one test-support helper;
- make profile command coverage and command-map parity consume that shared inventory;
- retain each test module's distinct key-resolution and parity graph oracle;
- keep short module and function docstrings on the shared test-helper API.

## Scope

This is a purely mechanical single-source-of-truth consolidation: 3 test files, 34 additions, and 35 deletions. It does not add or change completeness classification, executor reachability, reverse census behavior, production code, or profile data.

PR #2953 is intentionally unchanged and is not stacked on this branch. After this helper PR lands, that foundation work will resume separately from a fresh main with its contracts and indirect executor controls restored.

MOR-2144 remains In Progress.

## Validation

- Targeted before and after: 9 passed.
- Ruff changed scope: PASS.
- Import contracts: 5 kept, 0 broken.
- Focused mypy: PASS.
- Full Python on the remote macOS testbed, exact SHA 78e16f6b5d4adbfe61e01d826cdd48ea5e0d5ee2: 14,127 passed, 161 skipped, 48 xfailed, 5 warnings; ruff PASS; FINAL PASS.
- No full suite was run locally.
