### PR TITLE
feat(MOR-2157): preserve lossless acquisition query envelopes

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -216,12 +216,10 @@ command_response_observable = [
     "global.tx_state.vox_on",
     "global.tx_state.monitor_on",
     # MOR-1483 (leg 2): voxDelay (1A-05 ctl-mem 01-91, this radio's control
-    # number — see docs/validation/cat-audits/ic7300.md) is now addable:
-    # AcquisitionQuerySender's ``sub`` element can carry the CI-V sub-command
-    # byte plus the 2-byte ctl-mem control number as ``bytes``
-    # (IcomCivAcquisitionExecutor._GLOBAL_CTL_MEM_QUERIES), and the ingress
-    # decode already matches this prefix too. Non-polling, same
-    # prime_unobserved mechanism as the toggles above.
+    # number — see docs/validation/cat-audits/ic7300.md) is now addable as
+    # sub=0x05 with data=01 91. The ingress decode already matches this
+    # prefix too. Non-polling, same prime_unobserved mechanism as the toggles
+    # above.
     "global.operator_controls.vox_delay",
     # MOR-1491 (field-policy membership wave, leg 2): filter/PBT facts.
     "receiver.main.active.freq_mode.filter_width",

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -36,6 +36,7 @@ from rigplane.core.state_store import (
 
 __all__ = [
     "AcquisitionMethod",
+    "AcquisitionQuery",
     "AcquisitionExecutionResult",
     "AcquisitionExecutor",
     "AcquisitionPriority",
@@ -48,38 +49,24 @@ __all__ = [
     "RadioStateModelService",
     "StateFreshnessService",
     "civ_acquisition_executor_for_provider",
-    "split_ctl_mem_sub",
 ]
 
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
-# ``sub`` is normally a single CI-V sub-command byte (or ``None`` for a
-# no-sub-byte read). It is ``bytes`` only for multi-byte ctl-mem
-# sub-addressing (0x1A/0x05 "quick set" reads, e.g. voxDelay's 2-byte control
-# number, MOR-1483): the first byte is the CI-V sub-command byte and any
-# remaining bytes are additional payload data that must follow it in the
-# frame. Both ``AcquisitionQuerySender`` implementations (web radio_poller,
-# rigctld) must split it via ``split_ctl_mem_sub`` before building the frame.
-AcquisitionQuerySender = Callable[
-    [int, int | bytes | None, int | None], Awaitable[None]
-]
+
+
+@dataclass(frozen=True, slots=True)
+class AcquisitionQuery:
+    """Lossless semantic envelope for one CI-V acquisition query."""
+
+    command: int
+    sub: int | None = None
+    data: bytes = b""
+    receiver: int | None = None
+
+
+AcquisitionQuerySender = Callable[[AcquisitionQuery], Awaitable[None]]
 CivCmd29Support = Callable[[int, int | None], bool]
-
-
-def split_ctl_mem_sub(sub: int | bytes | None) -> tuple[int | None, bytes]:
-    """Split an ``AcquisitionQuerySender`` ``sub`` element into CI-V parts.
-
-    Returns ``(civ_sub, extra_data)`` where ``civ_sub`` is the single byte to
-    pass as the CI-V frame's sub-command field and ``extra_data`` is any
-    additional payload bytes that must follow it (empty for the common
-    single-byte-or-none case). Shared by both backend executors so the
-    multi-byte ctl-mem representation (see ``AcquisitionQuerySender``) is
-    decoded identically everywhere.
-    """
-
-    if isinstance(sub, (bytes, bytearray)):
-        return (sub[0] if sub else None), bytes(sub[1:])
-    return sub, b""
 
 
 class AcquisitionPriority(StrEnum):
@@ -313,10 +300,8 @@ _GLOBAL_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
     "break_in": (0x16, 0x47),
 }
 # Global operator-control reads that need the 0x1A ctl-mem ("quick set")
-# multi-byte sub-address (MOR-1483): the CI-V sub-command byte (0x05)
-# followed by a 2-byte per-model control number, packed together as
-# ``bytes`` (see ``AcquisitionQuerySender``'s docstring for the split
-# convention). Pinned to IC-7300's control number -- the live reference
+# sub-command (0x05) followed by a 2-byte per-model control number
+# (MOR-1483). Pinned to IC-7300's control number -- the live reference
 # profile (``rigs/ic7300.toml``'s ``get_vox_delay`` = ``1A 05 01 91``). This
 # mapping is shared across every icom_civ/xiegu_civ profile and has no
 # per-instance radio-model injection, so it cannot vary the control number
@@ -324,8 +309,8 @@ _GLOBAL_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
 # (docs/validation/cat-audits/ic7610.md: ``1A 05 0292``) and unverifiable on
 # real hardware, so a primed voxDelay read routed through this mapping on an
 # IC-7610 profile would address the wrong ctl-mem register.
-_GLOBAL_CTL_MEM_QUERIES: dict[str, bytes] = {
-    "vox_delay": b"\x05\x01\x91",
+_GLOBAL_CTL_MEM_QUERIES: dict[str, AcquisitionQuery] = {
+    "vox_delay": AcquisitionQuery(0x1A, sub=0x05, data=b"\x01\x91"),
 }
 _GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
     "power": 0x11,
@@ -369,20 +354,17 @@ class IcomCivAcquisitionExecutor:
                 failed.append(path)
                 failure_reason = failure_reason or "no_civ_query_mapping"
                 continue
-            command, sub, receiver = query
             if (
-                receiver is not None
-                and command not in (0x25, 0x26)
+                query.receiver is not None
                 and self._supports_cmd29 is not None
-                and not isinstance(sub, (bytes, bytearray))
-                and not self._supports_cmd29(command, sub)
+                and not self._supports_cmd29(query.command, query.sub)
             ):
-                if receiver != 0:
+                if query.receiver != 0:
                     failed.append(path)
                     failure_reason = failure_reason or "no_civ_receiver_route"
                     continue
-                receiver = None
-            await self._send_query(command, sub, receiver)
+                query = replace(query, receiver=None)
+            await self._send_query(query)
             sent.append(path)
         return AcquisitionExecutionResult(
             sent_paths=tuple(sent),
@@ -393,7 +375,7 @@ class IcomCivAcquisitionExecutor:
     def query_for_path(
         self,
         path: FieldPath,
-    ) -> tuple[int, int | bytes | None, int | None] | None:
+    ) -> AcquisitionQuery | None:
         receiver = _RECEIVER_IDS.get(path.receiver_id or "")
         if path.scope.value == "receiver" and receiver is None:
             return None
@@ -405,13 +387,13 @@ class IcomCivAcquisitionExecutor:
             if slot == "unselected" and receiver != 0:
                 return None
             if path.name == "freq_hz":
-                return (0x25, None, selector)
+                return AcquisitionQuery(0x25, data=bytes([selector]))
             if path.name == "mode":
-                return (0x26, None, selector)
+                return AcquisitionQuery(0x26, data=bytes([selector]))
             if path.name == "filter_width":
                 if slot == "unselected":
                     return None
-                return (0x1A, 0x03, receiver)
+                return AcquisitionQuery(0x1A, sub=0x03, receiver=receiver)
             if path.name == "filter_num":
                 # MOR-1546: no dedicated CI-V read for the filter-selection
                 # fact -- it rides the SAME 0x26 selected/unselected mode
@@ -421,7 +403,7 @@ class IcomCivAcquisitionExecutor:
                 # ``filter_num`` observation alongside ``mode``/``data_mode``
                 # from that one response). Same selector, same command --
                 # this is an observation-side mapping, not a new query.
-                return (0x26, None, selector)
+                return AcquisitionQuery(0x26, data=bytes([selector]))
             if path.name == "data_mode":
                 # MOR-1546: unlike filter_num, DATA mode has its own
                 # dedicated read (CI-V 0x1A 0x06, ``get_data_mode`` in every
@@ -430,48 +412,65 @@ class IcomCivAcquisitionExecutor:
                 # queryable.
                 if slot == "unselected":
                     return None
-                return (0x1A, 0x06, receiver)
+                return AcquisitionQuery(0x1A, sub=0x06, receiver=receiver)
             return None
         if path.scope.value == "receiver" and path.family.value == "meters":
             if path.name == "s_meter":
-                return (0x15, 0x02, receiver)
+                return AcquisitionQuery(0x15, sub=0x02, receiver=receiver)
             return None
         if path.scope.value == "receiver" and path.family.value == "operator_toggles":
             toggle = _RECEIVER_TOGGLE_QUERIES.get(path.name)
-            return None if toggle is None else (toggle[0], toggle[1], receiver)
+            return (
+                None
+                if toggle is None
+                else AcquisitionQuery(toggle[0], sub=toggle[1], receiver=receiver)
+            )
         if path.scope.value == "receiver" and path.family.value == "operator_controls":
             nonlevel = _RECEIVER_NONLEVEL_QUERIES.get(path.name)
             if nonlevel is not None:
-                return (nonlevel[0], nonlevel[1], receiver)
+                return AcquisitionQuery(
+                    nonlevel[0],
+                    sub=nonlevel[1],
+                    receiver=receiver,
+                )
             sub = _RECEIVER_LEVEL_QUERY_SUBS.get(path.name)
-            return None if sub is None else (0x14, sub, receiver)
+            return (
+                None
+                if sub is None
+                else AcquisitionQuery(0x14, sub=sub, receiver=receiver)
+            )
         if path.scope.value == "global" and path.family.value == "meters":
             sub = _GLOBAL_METER_QUERY_SUBS.get(path.name)
-            return None if sub is None else (0x15, sub, None)
+            return None if sub is None else AcquisitionQuery(0x15, sub=sub)
         if path.scope.value == "global" and path.family.value == "slow_state":
             if path.name == "active":
-                return (0x07, 0xD2, None)
+                return AcquisitionQuery(0x07, data=b"\xd2")
             return None
         if path.scope.value == "global" and path.family.value == "tx_state":
             if path.name == "ptt":
-                return (0x1C, 0x00, None)
+                return AcquisitionQuery(0x1C, sub=0x00)
             if path.name == "rit_on":
-                return (0x21, 0x01, None)
+                return AcquisitionQuery(0x21, sub=0x01)
             if path.name == "rit_tx":
-                return (0x21, 0x02, None)
+                return AcquisitionQuery(0x21, sub=0x02)
             toggle = _GLOBAL_TX_TOGGLE_QUERIES.get(path.name)
-            return None if toggle is None else (toggle[0], toggle[1], None)
+            if toggle is not None and toggle[0] == 0x07:
+                assert toggle[1] is not None
+                return AcquisitionQuery(0x07, data=bytes([toggle[1]]))
+            return (
+                None if toggle is None else AcquisitionQuery(toggle[0], sub=toggle[1])
+            )
         if path.scope.value == "global" and path.family.value == "operator_controls":
             if path.name == "rit_freq":
-                return (0x21, 0x00, None)
+                return AcquisitionQuery(0x21, sub=0x00)
             ctl_mem = _GLOBAL_CTL_MEM_QUERIES.get(path.name)
             if ctl_mem is not None:
-                return (0x1A, ctl_mem, None)
+                return ctl_mem
             nonlevel = _GLOBAL_NONLEVEL_QUERIES.get(path.name)
             if nonlevel is not None:
-                return (nonlevel[0], nonlevel[1], None)
+                return AcquisitionQuery(nonlevel[0], sub=nonlevel[1])
             sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
-            return None if sub is None else (0x14, sub, None)
+            return None if sub is None else AcquisitionQuery(0x14, sub=sub)
         return None
 
 

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -380,6 +380,8 @@ class IcomCivAcquisitionExecutor:
         if path.scope.value == "receiver" and receiver is None:
             return None
         if path.scope.value == "receiver" and path.family.value == "freq_mode":
+            if receiver is None:
+                return None
             slot = None if path.slot is None else path.slot.value
             if slot in {"A", "B"}:
                 return None

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -28,10 +28,10 @@ from ..core.acquisition_scheduler import (
     AcquisitionExecutor,
     AcquisitionRequest,
     AcquisitionScheduler,
+    AcquisitionQuery,
     RadioStateModelService,
     StateFreshnessService,
     civ_acquisition_executor_for_provider,
-    split_ctl_mem_sub,
 )
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_pipeline_contracts import FieldPath
@@ -563,43 +563,32 @@ class RigctldServer:
 
     async def _send_one_state_query(
         self,
-        cmd_byte: int,
-        sub_byte: int | bytes | None,
-        receiver: int | None,
+        query: AcquisitionQuery,
     ) -> None:
         """Send a single acquisition-scheduler CI-V state query.
 
-        ``sub_byte`` is ``bytes`` only for multi-byte ctl-mem sub-addressing
-        (0x1A/0x05 "quick set" reads, e.g. voxDelay, MOR-1483) — always a
-        global (``receiver is None``) read today, so only the final branch
-        below needs to split it via ``split_ctl_mem_sub``.
+        The lossless query envelope keeps the CI-V sub-command, payload data,
+        and optional cmd29 receiver route separate.
         """
         radio = self._radio
         if not isinstance(radio, CivCommandCapable):
             raise _AcquisitionExecutorUnavailable(
                 "radio does not support CI-V state acquisition sends"
             )
-        if receiver is not None:
-            assert not isinstance(sub_byte, (bytes, bytearray)), (
-                "multi-byte ctl-mem sub-addressing is global-only (receiver=None)"
+        if query.receiver is not None:
+            inner = bytes([query.receiver, query.command])
+            if query.sub is not None:
+                inner += bytes([query.sub])
+            await radio.send_civ(
+                0x29,
+                data=inner + query.data,
+                wait_response=False,
             )
-            if cmd_byte in (0x25, 0x26):
-                await radio.send_civ(
-                    cmd_byte,
-                    data=bytes([receiver]),
-                    wait_response=False,
-                )
-                return
-            inner = bytes([receiver, cmd_byte])
-            if sub_byte is not None:
-                inner += bytes([sub_byte])
-            await radio.send_civ(0x29, data=inner, wait_response=False)
             return
-        civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
         await radio.send_civ(
-            cmd_byte,
-            sub=civ_sub,
-            data=extra_data,
+            query.command,
+            sub=query.sub,
+            data=query.data,
             wait_response=False,
         )
 

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -1,20 +1,9 @@
 """Shared state query list for populating RadioState.
 
 Used by RadioPoller (periodic polling) and by the one-shot sweep run at
-connect (``runtime/radio_initial_state.py: fetch_initial_state``).  Each
-query is a 3-tuple::
-
-    (cmd_byte, sub_byte | None, receiver | None)
-
-``receiver=None`` means the query is global (not per-receiver).
-``receiver=0`` or ``receiver=1`` targets a specific receiver and will
-be wrapped in cmd29 when the profile supports it.
-
-``sub_byte`` is ``bytes`` when the read needs payload of its own: the
-first byte is the CI-V sub-command and the rest follow it in the frame.
-Both senders decode that shape with
-``core/acquisition_scheduler.py: split_ctl_mem_sub``.  The scope reads
-below are the only queries built here that use it.
+connect (``runtime/radio_initial_state.py: fetch_initial_state``). Each query
+keeps its CI-V command, semantic sub-command, payload data, and optional
+cmd29 receiver route distinct.
 """
 
 from __future__ import annotations
@@ -26,12 +15,21 @@ from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
 )
+from rigplane.core.acquisition_scheduler import AcquisitionQuery
 from rigplane.profiles import RadioProfile
 
 logger = logging.getLogger(__name__)
 
-# Type alias for a single state query: (cmd, sub, receiver).
-StateQuery = tuple[int, int | bytes | None, int | None]
+
+def acquisition_query_from_wire_tuple(
+    wire: tuple[int, ...],
+    *,
+    receiver: int | None = None,
+) -> AcquisitionQuery:
+    """Decode a command-map wire tuple into a lossless acquisition query."""
+
+    command, sub, data = decode_wire_tuple(wire)
+    return AcquisitionQuery(command, sub=sub, data=data, receiver=receiver)
 
 
 def build_state_queries(
@@ -39,7 +37,7 @@ def build_state_queries(
     capabilities: set[str],
     *,
     is_serial: bool = False,
-) -> list[StateQuery]:
+) -> list[AcquisitionQuery]:
     """Build the full list of CI-V state queries for the given profile.
 
     Parameters
@@ -53,25 +51,23 @@ def build_state_queries(
 
     Returns
     -------
-    list[StateQuery]
-        Ordered list of ``(cmd_byte, sub_byte, receiver)`` tuples.
+    list[AcquisitionQuery]
+        Ordered list of lossless acquisition queries.
     """
     receivers = [0]
     if profile.receiver_count > 1:
         receivers.append(1)
 
-    queries: list[StateQuery] = []
+    queries: list[AcquisitionQuery] = []
 
     for receiver in receivers:
         # Freq/mode — needed even on serial for initial state and to pick up
         # filter/attenuator/preamp that don't come via transceive.
-        queries.append((0x25, None, receiver))  # frequency
-        queries.append((0x26, None, receiver))  # mode
+        queries.append(AcquisitionQuery(0x25, data=bytes([receiver])))  # frequency
+        queries.append(AcquisitionQuery(0x26, data=bytes([receiver])))  # mode
         if receiver == 0 and profile.vfo_readback == "selected_unselected":
-            # ``sub=1`` is an internal selector consumed by the senders below;
-            # receiver remains 0/None so it never invents a SUB topology.
-            queries.append((0x25, 0x01, None))  # unselected frequency
-            queries.append((0x26, 0x01, None))  # unselected mode
+            queries.append(AcquisitionQuery(0x25, data=b"\x01"))
+            queries.append(AcquisitionQuery(0x26, data=b"\x01"))
 
         # Per-receiver state queries.  On dual-receiver radios these use
         # cmd29 wrapping.  On single-receiver radios without cmd29 we send
@@ -112,10 +108,12 @@ def build_state_queries(
                 continue
             if profile.supports_cmd29(cmd_byte, sub_byte):
                 # Dual-receiver: cmd29-wrapped with receiver byte
-                queries.append((cmd_byte, sub_byte, receiver))
+                queries.append(
+                    AcquisitionQuery(cmd_byte, sub=sub_byte, receiver=receiver)
+                )
             elif receiver == 0:
                 # Single-receiver: plain CI-V query (only once, not per-rx)
-                queries.append((cmd_byte, sub_byte, None))
+                queries.append(AcquisitionQuery(cmd_byte, sub=sub_byte))
 
         # Per-receiver feature queries that use cmd29 wrapping.
         # Added for any radio whose profile declares cmd29 support for these.
@@ -129,34 +127,35 @@ def build_state_queries(
             (0x1A, 0x04),  # AGC time constant
         ):
             if profile.supports_cmd29(cmd_byte, sub_byte):
-                queries.append((cmd_byte, sub_byte, receiver))
+                queries.append(
+                    AcquisitionQuery(cmd_byte, sub=sub_byte, receiver=receiver)
+                )
 
     # Global queries (not per-receiver)
     queries.extend(
         [
-            (0x18, None, None),  # Power status (on/off)
-            (0x1C, 0x00, None),  # PTT (global)
-            (0x1C, 0x01, None),  # Tuner/ATU status
-            (0x1C, 0x03, None),  # TX frequency monitor
-            (0x14, 0x0A, None),  # Power level (global)
-            (0x14, 0x0B, None),  # Mic gain (global)
-            (0x14, 0x0E, None),  # Compressor level (global)
-            (0x14, 0x15, None),  # Monitor gain (global)
-            (0x14, 0x09, None),  # CW pitch (global)
-            (0x14, 0x0C, None),  # Key speed (global)
-            (0x0F, None, None),  # Split (global)
-            (0x21, 0x00, None),  # RIT frequency
-            (0x21, 0x01, None),  # RIT status
-            (0x21, 0x02, None),  # RIT TX status
+            AcquisitionQuery(0x18),  # Power status (on/off)
+            AcquisitionQuery(0x1C, sub=0x00),  # PTT (global)
+            AcquisitionQuery(0x1C, sub=0x01),  # Tuner/ATU status
+            AcquisitionQuery(0x1C, sub=0x03),  # TX frequency monitor
+            AcquisitionQuery(0x14, sub=0x0A),  # Power level (global)
+            AcquisitionQuery(0x14, sub=0x0B),  # Mic gain (global)
+            AcquisitionQuery(0x14, sub=0x0E),  # Compressor level (global)
+            AcquisitionQuery(0x14, sub=0x15),  # Monitor gain (global)
+            AcquisitionQuery(0x14, sub=0x09),  # CW pitch (global)
+            AcquisitionQuery(0x14, sub=0x0C),  # Key speed (global)
+            AcquisitionQuery(0x0F),  # Split (global)
+            AcquisitionQuery(0x21, sub=0x00),  # RIT frequency
+            AcquisitionQuery(0x21, sub=0x01),  # RIT status
+            AcquisitionQuery(0x21, sub=0x02),  # RIT TX status
         ]
     )
     if profile.receiver_count > 1:
-        queries.append((0x07, 0xD2, None))  # Active receiver
+        queries.append(AcquisitionQuery(0x07, data=b"\xd2"))
     if "dual_watch" in capabilities:
-        command, sub, prefix = decode_wire_tuple(
-            profile.command_map.get("get_dual_watch")
+        queries.append(
+            acquisition_query_from_wire_tuple(profile.command_map.get("get_dual_watch"))
         )
-        queries.append((command, sub if sub is not None else prefix[0], None))
 
     # Common feature queries (data-driven: if radio has the command, poll it)
     _COMMON_FEATURE_QUERIES: list[tuple[int, int]] = [
@@ -188,13 +187,13 @@ def build_state_queries(
         )
 
     for cmd, sub in _COMMON_FEATURE_QUERIES:
-        queries.append((cmd, sub, None))
+        queries.append(AcquisitionQuery(cmd, sub=sub))
 
     # Capability-gated optional queries
     if "meters" in capabilities:
-        queries.append((0x15, 0x07, None))  # Overflow status
+        queries.append(AcquisitionQuery(0x15, sub=0x07))  # Overflow status
     if "ssb_tx_bw" in capabilities:
-        queries.append((0x16, 0x58, None))  # SSB TX bandwidth
+        queries.append(AcquisitionQuery(0x16, sub=0x58))  # SSB TX bandwidth
     if "scope" in capabilities:
         # 0x27 reads come in two shapes.  The sub-commands in
         # SCOPE_RECEIVER_SELECTOR_SUBS carry a one-byte Main/Sub scope
@@ -223,8 +222,14 @@ def build_state_queries(
             0x1F,  # Scope RBW
         ):
             if scope_sub in SCOPE_RECEIVER_SELECTOR_SUBS:
-                queries.append((0x27, bytes([scope_sub, SCOPE_SELECTOR_MAIN]), None))
+                queries.append(
+                    AcquisitionQuery(
+                        0x27,
+                        sub=scope_sub,
+                        data=bytes([SCOPE_SELECTOR_MAIN]),
+                    )
+                )
             else:
-                queries.append((0x27, scope_sub, None))
+                queries.append(AcquisitionQuery(0x27, sub=scope_sub))
 
     return queries

--- a/src/rigplane/runtime/radio_initial_state.py
+++ b/src/rigplane/runtime/radio_initial_state.py
@@ -19,8 +19,6 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-from rigplane.core.acquisition_scheduler import split_ctl_mem_sub
-
 if TYPE_CHECKING:
     # Internal implementation module for IcomRadio — the TID251 ban targets
     # external consumers (web/, rigctld/), not radio.py's own helpers.
@@ -62,45 +60,22 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
             gap * 1000,
         )
         ok = 0
-        for cmd_byte, sub_byte, receiver in queries:
-            # A query's sub element carries payload of its own where the read
-            # needs one -- the scope reads that take a Main/Sub selector are
-            # built that way (``_state_queries.py: build_state_queries``).
-            civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
+        for query in queries:
             try:
-                if (
-                    receiver is None
-                    and cmd_byte in (0x25, 0x26)
-                    and civ_sub == 0x01
-                    and radio._profile.vfo_readback == "selected_unselected"
-                ):
+                if query.receiver is not None:
+                    inner = bytes([query.receiver, query.command])
+                    if query.sub is not None:
+                        inner += bytes([query.sub])
                     await radio.send_civ(
-                        cmd_byte,
-                        data=b"\x01",
+                        0x29,
+                        data=inner + query.data,
                         wait_response=False,
                     )
-                elif receiver is not None:
-                    if cmd_byte in (0x25, 0x26):
-                        # Freq/mode: receiver byte as data payload
-                        await radio.send_civ(
-                            cmd_byte,
-                            data=bytes([receiver]),
-                            wait_response=False,
-                        )
-                    else:
-                        # cmd29-wrapped: 0x29 with [receiver, cmd, sub?].
-                        # ``civ_sub`` and no ``extra_data``: a sub element
-                        # that carries payload is never paired with a
-                        # receiver, so there is nothing to append here.
-                        inner = bytes([receiver, cmd_byte])
-                        if civ_sub is not None:
-                            inner += bytes([civ_sub])
-                        await radio.send_civ(0x29, data=inner, wait_response=False)
                 else:
                     await radio.send_civ(
-                        cmd_byte,
-                        sub=civ_sub,
-                        data=extra_data,
+                        query.command,
+                        sub=query.sub,
+                        data=query.data,
                         wait_response=False,
                     )
                 ok += 1

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -84,11 +84,11 @@ from ..core.command_service import (
 from ..core.acquisition_scheduler import (
     AcquisitionExecutor,
     AcquisitionPriority,
+    AcquisitionQuery,
     AcquisitionRequest,
     AcquisitionScheduler,
     MeterObservationCoalescer,
     civ_acquisition_executor_for_provider,
-    split_ctl_mem_sub,
 )
 from ..core.state_pipeline_contracts import (
     CommandIntent,
@@ -1288,8 +1288,8 @@ class RadioPoller:
             f"{self._profile.model} (receivers={self._profile.receiver_count})"
         )
 
-    def _build_state_queries(self) -> list[tuple[int, int | bytes | None, int | None]]:
-        result: list[tuple[int, int | bytes | None, int | None]] = build_state_queries(
+    def _build_state_queries(self) -> list[AcquisitionQuery]:
+        result: list[AcquisitionQuery] = build_state_queries(
             self._profile,
             self._caps,
             is_serial=self._is_serial,
@@ -1298,9 +1298,7 @@ class RadioPoller:
 
     async def _send_one_state_query(
         self,
-        cmd_byte: int,
-        sub_byte: int | bytes | None,
-        receiver: int | None,
+        query: AcquisitionQuery,
         *,
         priority: Priority = Priority.BACKGROUND,
     ) -> None:
@@ -1313,44 +1311,30 @@ class RadioPoller:
         does not park the poll loop on the commander future (MOR-497ii); the
         response still arrives via the CI-V RX path.
 
-        ``sub_byte`` is ``bytes`` where the read carries payload of its own:
-        multi-byte ctl-mem sub-addressing (0x1A/0x05 "quick set" reads, e.g.
-        voxDelay, MOR-1483) and the 0x27 scope reads that take a Main/Sub
-        selector (MOR-1981). Both are global (``receiver is None``) reads
-        today, which is what the cmd29 branch below asserts.
+        The lossless query envelope keeps the CI-V sub-command, payload data,
+        and optional cmd29 receiver route separate.
         """
-        civ_sub, extra_data = split_ctl_mem_sub(sub_byte)
-        if (
-            receiver is None
-            and cmd_byte in (0x25, 0x26)
-            and civ_sub == 0x01
-            and self._profile.vfo_readback == "selected_unselected"
-        ):
-            await self._civ(
-                cmd_byte,
-                data=b"\x01",
-                priority=priority,
-                wait_dispatch=False,
-            )
-        elif receiver is not None:
-            assert not isinstance(sub_byte, (bytes, bytearray)), (
-                "a sub element carrying payload is global-only (receiver=None)"
-            )
-            if cmd_byte in (0x25, 0x26):
+        if query.receiver is not None:
+            inner = bytes([query.receiver, query.command])
+            if query.sub is None:
                 await self._civ(
-                    cmd_byte,
-                    data=bytes([receiver]),
+                    0x29,
+                    data=inner + query.data,
                     priority=priority,
                     wait_dispatch=False,
                 )
             else:
-                inner = bytes([receiver, cmd_byte])
-                if sub_byte is not None:
-                    inner += bytes([sub_byte])
                 await self._civ(
-                    0x29, data=inner, priority=priority, wait_dispatch=False
+                    0x29,
+                    data=inner + bytes([query.sub]) + query.data,
+                    priority=priority,
+                    wait_dispatch=False,
                 )
-        elif cmd_byte == 0x27 and civ_sub in SCOPE_RECEIVER_SELECTOR_SUBS:
+        elif (
+            query.command == 0x27
+            and query.sub in SCOPE_RECEIVER_SELECTOR_SUBS
+            and query.data
+        ):
             # Scope control queries need receiver prefix (00=MAIN, 01=SUB).
             # ``build_state_queries`` emits MAIN because it runs at connect,
             # before the radio has said which scope is selected; where the
@@ -1360,17 +1344,25 @@ class RadioPoller:
             if self._radio_state:
                 scope_rx = self._radio_state.scope_controls.receiver
             await self._civ(
-                cmd_byte,
-                sub=civ_sub,
-                data=bytes([scope_rx]),
+                query.command,
+                sub=query.sub,
+                data=bytes([scope_rx]) + query.data[1:],
+                priority=priority,
+                wait_dispatch=False,
+            )
+        elif query.sub is None:
+            await self._civ(
+                query.command,
+                sub=None,
+                data=query.data,
                 priority=priority,
                 wait_dispatch=False,
             )
         else:
             await self._civ(
-                cmd_byte,
-                sub=civ_sub,
-                data=extra_data,
+                query.command,
+                sub=query.sub,
+                data=query.data,
                 priority=priority,
                 wait_dispatch=False,
             )
@@ -3668,9 +3660,8 @@ class RadioPoller:
     _LOW_STRIDE: int = 5
 
     # State queries interleaved on odd cycles.
-    # Tuple: (cmd, sub, receiver) where receiver=None means global query.
     # Populated per instance from runtime profile/capabilities.
-    _STATE_QUERIES: list[tuple[int, int | bytes | None, int | None]] = []
+    _STATE_QUERIES: list[AcquisitionQuery] = []
 
     def _pick_high_meter(self, high_idx: int) -> tuple[int, int | None]:
         """Choose HIGH-tier meter based on PTT state."""
@@ -3961,21 +3952,16 @@ class RadioPoller:
                 self._poll_index += 1
                 return
             state_idx = (self._poll_index // 2) % len(self._STATE_QUERIES)
-            cmd_byte, state_sub, receiver = self._STATE_QUERIES[state_idx]
-            # ``sub`` reports the CI-V sub-command byte; a query that also
-            # carries payload in its sub element (see
-            # ``_send_one_state_query``) has that payload split off here
-            # rather than formatted as part of the byte.
-            diag_sub, _ = split_ctl_mem_sub(state_sub)
+            query = self._STATE_QUERIES[state_idx]
             self._record_state_diagnostic(
                 "backend_read",
                 "web.radio_poller",
                 family="state",
-                command=f"0x{cmd_byte:02x}",
-                sub=None if diag_sub is None else f"0x{diag_sub:02x}",
-                receiver=receiver,
+                command=f"0x{query.command:02x}",
+                sub=None if query.sub is None else f"0x{query.sub:02x}",
+                receiver=query.receiver,
             )
-            await self._send_one_state_query(cmd_byte, state_sub, receiver)
+            await self._send_one_state_query(query)
         self._poll_index += 1
 
     # Issue #2303: passive observation must never select or exchange a VFO.

--- a/tests/_acquisition_query_helpers.py
+++ b/tests/_acquisition_query_helpers.py
@@ -1,53 +1,41 @@
-"""Current-shape-only acquisition query helpers for tests."""
+"""Strict acquisition-query helpers shared by scheduler-facing tests."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionQuery,
+    IcomCivAcquisitionExecutor,
+)
 
 if TYPE_CHECKING:
     from rigplane.web.radio_poller import RadioPoller
 
 
-AcquisitionQueryCase = tuple[int, int | bytes | None, int | None]
-_DATA_ONLY_COMMAND = 0x07
+AcquisitionQueryCase = AcquisitionQuery
+
+
 _SELECTOR_COMMANDS = frozenset((0x25, 0x26))
 
 
-@dataclass(frozen=True)
-class CivFrameParts:
-    """Representation-neutral meaning of one current acquisition query."""
-
-    command: int
-    sub: int | None = None
-    data: bytes = b""
-    receiver: int | None = None
-    selector: int | None = None
-
-
-def _require_legacy_query(query: AcquisitionQueryCase) -> AcquisitionQueryCase:
-    if type(query) is not tuple or len(query) != 3:
-        raise TypeError("acquisition query must be an exact legacy three-tuple")
-    command, packed_sub, route = query
-    if type(command) is not int:
-        raise TypeError("legacy query command must be int")
-    if packed_sub is not None and type(packed_sub) not in (int, bytes):
-        raise TypeError("legacy query packed sub must be int, bytes, or None")
-    if route is not None and type(route) is not int:
-        raise TypeError("legacy query route must be int or None")
-    return query
-
-
-def _require_byte(name: str, value: int | None) -> None:
+def _require_byte(name: str, value: int | None, *, optional: bool = True) -> None:
     if value is None:
-        return
+        if optional:
+            return
+        raise TypeError(f"{name} must be int")
     if type(value) is not int:
-        raise TypeError(f"{name} must be int or None")
+        suffix = " or None" if optional else ""
+        raise TypeError(f"{name} must be int{suffix}")
     if not 0 <= value <= 0xFF:
         raise ValueError(f"{name} must fit in one byte")
+
+
+def _require_query(query: AcquisitionQueryCase) -> AcquisitionQueryCase:
+    if type(query) is not AcquisitionQueryCase:
+        raise TypeError("acquisition query must be the exact query dataclass")
+    return query
 
 
 def acquisition_query(
@@ -58,16 +46,13 @@ def acquisition_query(
     receiver: int | None = None,
     selector: int | None = None,
 ) -> AcquisitionQueryCase:
-    """Build the legacy tuple while keeping test intent explicit."""
-    if type(command) is not int:
-        raise TypeError("command must be int")
-    _require_byte("command", command)
+    """Build one explicit expected query without normalizing its fields."""
+    _require_byte("command", command, optional=False)
     _require_byte("sub", sub)
     _require_byte("receiver", receiver)
     _require_byte("selector", selector)
     if type(data) is not bytes:
         raise TypeError("data must be exact bytes")
-
     if selector is not None:
         if (
             command not in _SELECTOR_COMMANDS
@@ -75,92 +60,49 @@ def acquisition_query(
             or data
             or receiver is not None
         ):
-            raise ValueError("selector is exclusive to 0x25/0x26 queries")
-        return command, None, selector
-
-    if command in _SELECTOR_COMMANDS:
-        if sub is not None or receiver is not None or len(data) != 1:
-            raise ValueError("0x25/0x26 require exactly one selector encoding")
-        return command, data[0], None
-
-    if command == _DATA_ONLY_COMMAND:
-        if sub is not None or receiver is not None or len(data) not in (0, 1):
-            raise ValueError("0x07 accepts only one semantic data byte")
-        return (command, None, None) if not data else (command, data[0], None)
-
-    if data:
-        if sub is None:
-            raise ValueError("data-only queries are ambiguous for this command")
-        if receiver is not None:
-            raise ValueError("prefixed data cannot be combined with a receiver route")
-        return command, bytes([sub]) + data, receiver
-    return command, sub, receiver
+            raise ValueError("selector is exclusive to 0x25/0x26 query data")
+        data = bytes([selector])
+    elif command in _SELECTOR_COMMANDS and (
+        sub is not None or receiver is not None or len(data) != 1
+    ):
+        raise ValueError("0x25/0x26 require exactly one selector data byte")
+    return AcquisitionQueryCase(
+        command=command,
+        sub=sub,
+        data=data,
+        receiver=receiver,
+    )
 
 
-def civ_frame_parts(
-    query: AcquisitionQueryCase,
-) -> CivFrameParts:
-    """Expose semantic CI-V frame parts from the legacy tuple."""
-    command, packed_sub, route = _require_legacy_query(query)
-    _require_byte("command", command)
-    _require_byte("receiver or selector", route)
-    if command in _SELECTOR_COMMANDS:
-        if packed_sub is None and route is not None:
-            selector = route
-        elif type(packed_sub) is int and route is None:
-            selector = packed_sub
-        else:
-            raise ValueError("0x25/0x26 queries require exactly one selector")
-        return CivFrameParts(
-            command=command,
-            data=bytes([selector]),
-            selector=selector,
-        )
-    if command == _DATA_ONLY_COMMAND:
-        if isinstance(packed_sub, bytes) or route is not None:
-            raise ValueError("0x07 legacy query must be bare or carry one data byte")
-        _require_byte("0x07 data", packed_sub)
-        if packed_sub is None:
-            return CivFrameParts(command=command)
-        return CivFrameParts(command=command, data=bytes([packed_sub]))
-    if isinstance(packed_sub, bytes):
-        if len(packed_sub) < 2:
-            raise ValueError("packed legacy prefix must include semantic data")
-        if route is not None:
-            raise ValueError("packed legacy prefix cannot carry a receiver route")
-        return CivFrameParts(
-            command=command,
-            sub=packed_sub[0],
-            data=packed_sub[1:],
-            receiver=route,
-        )
-    _require_byte("sub", packed_sub)
-    return CivFrameParts(command=command, sub=packed_sub, receiver=route)
+def civ_frame_parts(query: AcquisitionQueryCase) -> AcquisitionQueryCase:
+    """Return the already-semantic fields of an exact query dataclass."""
+    return _require_query(query)
 
 
 def query_command(query: AcquisitionQueryCase) -> int:
-    return civ_frame_parts(query).command
+    return _require_query(query).command
 
 
 def query_receiver(query: AcquisitionQueryCase) -> int | None:
-    return civ_frame_parts(query).receiver
+    return _require_query(query).receiver
 
 
 def query_selector(query: AcquisitionQueryCase) -> int | None:
-    return civ_frame_parts(query).selector
+    query = _require_query(query)
+    if query.command not in _SELECTOR_COMMANDS or len(query.data) != 1:
+        return None
+    return query.data[0]
 
 
 def recording_executor(
     *,
     supports_cmd29: Callable[[int, int | None], bool] | None = None,
 ) -> tuple[IcomCivAcquisitionExecutor, list[AcquisitionQueryCase]]:
-    """Create an executor whose exact current sender records legacy tuples."""
+    """Create an executor whose exact one-object sender records queries."""
     sent: list[AcquisitionQueryCase] = []
 
-    async def send_query(
-        command: int, sub: int | bytes | None, receiver: int | None
-    ) -> None:
-        sent.append((command, sub, receiver))
+    async def send_query(query: AcquisitionQueryCase) -> None:
+        sent.append(_require_query(query))
 
     return (
         IcomCivAcquisitionExecutor(send_query, supports_cmd29=supports_cmd29),
@@ -172,61 +114,52 @@ async def send_state_query(
     poller: RadioPoller,
     query: AcquisitionQueryCase,
 ) -> None:
-    """Send one legacy query through the poller's exact current interface."""
-    command, sub, receiver = _require_legacy_query(query)
-    await poller._send_one_state_query(command, sub, receiver)  # noqa: SLF001
+    """Send one exact query through the poller's one-object interface."""
+    await poller._send_one_state_query(_require_query(query))  # noqa: SLF001
 
 
 def assert_acquisition_query_representation_contract() -> None:
-    """Pin the current legacy representation until the production migration."""
-    assert acquisition_query(0x18) == (0x18, None, None)
-    assert acquisition_query(0x16, sub=0x59) == (0x16, 0x59, None)
-    assert acquisition_query(0x1A, sub=0x05, data=b"\x01\x91") == (
-        0x1A,
-        b"\x05\x01\x91",
-        None,
+    """Pin the lossless dataclass representation used by all test helpers."""
+    assert acquisition_query(0x18) == AcquisitionQueryCase(command=0x18)
+    assert acquisition_query(0x16, sub=0x59) == AcquisitionQueryCase(
+        command=0x16,
+        sub=0x59,
     )
-    assert acquisition_query(0x07, data=b"\xc2") == (0x07, 0xC2, None)
-    assert acquisition_query(0x25, selector=1) == (0x25, None, 1)
+    assert acquisition_query(0x1A, sub=0x05, data=b"\x01\x91") == (
+        AcquisitionQueryCase(command=0x1A, sub=0x05, data=b"\x01\x91")
+    )
+    assert acquisition_query(0x07, data=b"\xc2") == AcquisitionQueryCase(
+        command=0x07,
+        data=b"\xc2",
+    )
+    assert acquisition_query(0x25, selector=1) == AcquisitionQueryCase(
+        command=0x25,
+        data=b"\x01",
+    )
+    assert acquisition_query(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x91",
+        receiver=0,
+    ) == AcquisitionQueryCase(
+        command=0x1A,
+        sub=0x05,
+        data=b"\x01\x91",
+        receiver=0,
+    )
 
-    command_data = civ_frame_parts(acquisition_query(0x07, data=b"\xc2"))
-    assert command_data.sub is None
-    assert command_data.data == b"\xc2"
-    for selector_query in (
-        acquisition_query(0x25, selector=1),
-        acquisition_query(0x25, data=b"\x01"),
-    ):
-        selector_parts = civ_frame_parts(selector_query)
-        assert selector_parts.sub is None
-        assert selector_parts.data == b"\x01"
-        assert selector_parts.receiver is None
-        assert selector_parts.selector == 1
-
-    rejected_construction = (
+    rejected = (
         lambda: acquisition_query(None),  # type: ignore[arg-type]
-        lambda: acquisition_query(0x07, sub=0xC2),
-        lambda: acquisition_query(0x07, data=b"\xc2", receiver=0),
         lambda: acquisition_query(0x25, sub=1),
         lambda: acquisition_query(0x25, receiver=1),
         lambda: acquisition_query(0x25, data=b"\x01", selector=1),
-        lambda: acquisition_query(0x16, data=b"\x59"),
-        lambda: acquisition_query(0x1A, sub=0x05, data=b"\x01", receiver=0),
         lambda: acquisition_query(0x16, selector=1),
+        lambda: civ_frame_parts((0x18, None, None)),  # type: ignore[arg-type]
     )
-    rejected_projection = (
-        lambda: civ_frame_parts([0x18, None, None]),  # type: ignore[arg-type]
-        lambda: civ_frame_parts(CivFrameParts(command=0x18)),  # type: ignore[arg-type]
-        lambda: civ_frame_parts((0x07, b"\xc2", None)),
-        lambda: civ_frame_parts((0x07, 0xC2, 0)),
-        lambda: civ_frame_parts((0x25, 1, 0)),
-        lambda: civ_frame_parts((0x25, None, None)),
-        lambda: civ_frame_parts((0x16, b"\x59", None)),
-        lambda: civ_frame_parts((0x1A, b"\x05\x01", 0)),
-    )
-    for rejected in rejected_construction + rejected_projection:
+    for invalid in rejected:
         try:
-            rejected()
+            invalid()
         except (TypeError, ValueError):
             pass
         else:
-            raise AssertionError("helper accepted an ambiguous acquisition query")
+            raise AssertionError("helper accepted an invalid acquisition query")

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -3,17 +3,25 @@
 from __future__ import annotations
 
 from collections import Counter
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
 from rigplane.commands._frame import build_civ_frame, decode_wire_tuple
+from rigplane.commands.commander import Priority
 from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
 )
-from rigplane.runtime._state_queries import build_state_queries
+from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.profiles import resolve_radio_profile
+from rigplane.rigctld.server import RigctldServer
+from rigplane.runtime import _state_queries as state_queries_module
+from rigplane.runtime._state_queries import build_state_queries
+from rigplane.runtime.radio_initial_state import fetch_initial_state
+from rigplane.web.radio_poller import RadioPoller
 from _acquisition_query_helpers import (
     AcquisitionQueryCase,
     acquisition_query,
@@ -29,6 +37,210 @@ from _acquisition_query_helpers import (
 # to be made twice, deliberately (MOR-1981).
 _SELECTOR_SUBS = frozenset({0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F})
 _BARE_SUBS = frozenset({0x12, 0x13, 0x1B, 0x1C})
+
+_FrameParts = tuple[int, int | None, bytes]
+
+
+class _RecordingCivRadio:
+    def __init__(self) -> None:
+        self.sent: list[_FrameParts] = []
+        self.options: list[tuple[bool, object, bool]] = []
+
+    async def send_civ(
+        self,
+        command: int,
+        sub: int | None = None,
+        data: bytes | None = None,
+        *,
+        wait_response: bool = True,
+        priority: object = None,
+        wait_dispatch: bool = True,
+    ) -> None:
+        self.sent.append((command, sub, b"" if data is None else data))
+        self.options.append((wait_response, priority, wait_dispatch))
+
+
+async def _send_through_initial(query: AcquisitionQueryCase) -> _FrameParts:
+    radio = _RecordingCivRadio()
+    radio._profile = SimpleNamespace(has_lan=True)
+    radio.capabilities = set()
+    radio._INITIAL_STATE_GAP_SERIAL = 0.0
+    radio._INITIAL_STATE_GAP_LAN = 0.0
+    radio._initial_state_fetched = False
+    with patch.object(
+        state_queries_module, "build_state_queries", return_value=[query]
+    ):
+        await fetch_initial_state(radio)  # type: ignore[arg-type]
+    assert radio.options == [(False, None, True)]
+    assert radio._initial_state_fetched is True
+    return radio.sent[0]
+
+
+async def _send_through_web(
+    query: AcquisitionQueryCase,
+    *,
+    scope_receiver: int | None = None,
+) -> _FrameParts:
+    poller = object.__new__(RadioPoller)
+    poller._radio_state = (
+        None
+        if scope_receiver is None
+        else SimpleNamespace(
+            scope_controls=SimpleNamespace(receiver=scope_receiver),
+        )
+    )
+    poller._civ = AsyncMock()
+    await RadioPoller._send_one_state_query(poller, query)  # noqa: SLF001
+    sent = poller._civ.await_args
+    assert sent.kwargs["priority"] is Priority.BACKGROUND
+    assert sent.kwargs["wait_dispatch"] is False
+    return (
+        sent.args[0],
+        sent.kwargs.get("sub"),
+        sent.kwargs.get("data", b""),
+    )
+
+
+async def _send_through_rigctld(query: AcquisitionQueryCase) -> _FrameParts:
+    radio = _RecordingCivRadio()
+    server = object.__new__(RigctldServer)
+    server._radio = radio
+    await RigctldServer._send_one_state_query(server, query)  # noqa: SLF001
+    assert radio.options == [(False, None, True)]
+    return radio.sent[0]
+
+
+@pytest.mark.parametrize(
+    ("wire", "receiver", "expected"),
+    [
+        ((0x18,), None, acquisition_query(0x18)),
+        ((0x16, 0x59), None, acquisition_query(0x16, sub=0x59)),
+        (
+            (0x1A, 0x05, 0x01, 0x91),
+            None,
+            acquisition_query(0x1A, sub=0x05, data=b"\x01\x91"),
+        ),
+        ((0x07, 0xC2), None, acquisition_query(0x07, data=b"\xc2")),
+        ((0x03, 0xAA, 0xBB), None, acquisition_query(0x03, data=b"\xaa\xbb")),
+        ((0x25, 0x01), None, acquisition_query(0x25, selector=1)),
+        ((0x26, 0x00), None, acquisition_query(0x26, selector=0)),
+        (
+            (0x1A, 0x05, 0x01, 0x91),
+            1,
+            acquisition_query(
+                0x1A,
+                sub=0x05,
+                data=b"\x01\x91",
+                receiver=1,
+            ),
+        ),
+    ],
+)
+def test_wire_tuple_converter_preserves_semantic_frame_parts(
+    wire: tuple[int, ...],
+    receiver: int | None,
+    expected: AcquisitionQueryCase,
+) -> None:
+    converter = state_queries_module.acquisition_query_from_wire_tuple
+    assert converter(wire, receiver=receiver) == expected
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        acquisition_query(0x18),
+        acquisition_query(0x16, sub=0x59),
+        acquisition_query(0x1A, sub=0x05, data=b"\x01\x91"),
+        acquisition_query(0x07, data=b"\xc2"),
+        acquisition_query(0x03, data=b"\xaa\xbb"),
+        acquisition_query(0x25, selector=1),
+        acquisition_query(0x26, selector=0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_nonrouting_senders_emit_identical_exact_frames(
+    query: AcquisitionQueryCase,
+) -> None:
+    expected = (query.command, query.sub, query.data)
+    assert await _send_through_initial(query) == expected
+    assert await _send_through_web(query) == expected
+    assert await _send_through_rigctld(query) == expected
+
+
+@pytest.mark.asyncio
+async def test_all_senders_preserve_cmd29_receiver_sub_and_suffix() -> None:
+    query = acquisition_query(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x91",
+        receiver=1,
+    )
+    expected = (0x29, None, b"\x01\x1a\x05\x01\x91")
+    assert await _send_through_initial(query) == expected
+    assert await _send_through_web(query) == expected
+    assert await _send_through_rigctld(query) == expected
+
+
+@pytest.mark.asyncio
+async def test_web_scope_receiver_rewrite_preserves_data_suffix() -> None:
+    query = acquisition_query(0x27, sub=0x14, data=b"\x00\xaa\xbb")
+    assert await _send_through_web(query, scope_receiver=1) == (
+        0x27,
+        0x14,
+        b"\x01\xaa\xbb",
+    )
+
+
+@pytest.mark.asyncio
+async def test_receiver_zero_fallback_preserves_sub_and_data() -> None:
+    path = FieldPath.receiver("main", "operator_controls", "vox_delay")
+    query = acquisition_query(
+        0x1A,
+        sub=0x05,
+        data=b"\x01\x91",
+        receiver=0,
+    )
+    sent: list[AcquisitionQueryCase] = []
+
+    async def sender(sent_query: AcquisitionQueryCase) -> None:
+        sent.append(sent_query)
+
+    class _PrefixExecutor(IcomCivAcquisitionExecutor):
+        def query_for_path(self, _path: FieldPath) -> AcquisitionQueryCase:
+            return query
+
+    executor = _PrefixExecutor(
+        sender,
+        supports_cmd29=lambda _command, _sub: False,
+    )
+    request = SimpleNamespace(paths=(path,))
+    result = await executor.execute(  # type: ignore[arg-type]
+        request,
+        already_sent_paths=frozenset(),
+    )
+
+    assert sent == [
+        acquisition_query(0x1A, sub=0x05, data=b"\x01\x91"),
+    ]
+    assert result.sent_paths == (path,)
+    assert result.failed_paths == ()
+
+
+@pytest.mark.asyncio
+async def test_executor_does_not_swallow_sender_exception() -> None:
+    path = FieldPath.global_("tx_state", "ptt")
+
+    async def sender(_query: AcquisitionQueryCase) -> None:
+        raise RuntimeError("send failed")
+
+    executor = IcomCivAcquisitionExecutor(sender)
+    request = SimpleNamespace(paths=(path,))
+
+    with pytest.raises(RuntimeError, match="send failed"):
+        await executor.execute(  # type: ignore[arg-type]
+            request,
+            already_sent_paths=frozenset(),
+        )
 
 
 def _scope_queries(
@@ -250,12 +462,9 @@ class TestScopeReceiverSelector:
     ) -> None:
         """The selector is payload, not the cmd29 receiver slot.
 
-        A receiver route uses cmd29 in both senders, which is a different
-        frame entirely and cannot carry scope selector data down that path:
-        ``runtime/radio_initial_state.py: fetch_initial_state`` wraps the
-        sub-command byte alone, and
-        ``web/radio_poller.py: RadioPoller._send_one_state_query`` asserts
-        the combination cannot arise.
+        A receiver route uses cmd29 in every sender, which is a different
+        frame entirely. The query envelope keeps selector data separate from
+        receiver routing, so no sender can confuse one for the other.
         """
         profile = resolve_radio_profile(model=model)
         caps = set(profile.capabilities)
@@ -310,11 +519,11 @@ class TestFetchInitialState:
         await radio._fetch_initial_state()
 
         assert (
-            call(0x25, data=b"\x01", wait_response=False)
+            call(0x25, sub=None, data=b"\x01", wait_response=False)
             in radio.send_civ.await_args_list
         )
         assert (
-            call(0x26, data=b"\x01", wait_response=False)
+            call(0x26, sub=None, data=b"\x01", wait_response=False)
             in radio.send_civ.await_args_list
         )
 
@@ -366,6 +575,7 @@ class TestFetchInitialState:
     @pytest.mark.asyncio
     async def test_send_failure_nonfatal(self, radio) -> None:
         call_count = 0
+        sleep = AsyncMock()
 
         async def flaky_send(*args, **kwargs):
             nonlocal call_count
@@ -374,6 +584,8 @@ class TestFetchInitialState:
                 raise RuntimeError("transient error")
 
         radio.send_civ = flaky_send
-        await radio._fetch_initial_state()
+        with patch("rigplane.runtime.radio_initial_state.asyncio.sleep", new=sleep):
+            await radio._fetch_initial_state()
         assert radio._initial_state_fetched is True
         assert call_count > 0
+        assert sleep.await_count == call_count


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2157/preserve-the-full-commandmap-prefix-in-acquisition-query-envelopes

Implements MOR-2157 production acceptance with an atomic frozen/slotted `AcquisitionQuery`, the sole `decode_wire_tuple` adapter, and exact one-object sender paths. It preserves full prefix, sub, data, and receiver semantics across initial, Web, and rigctld senders; deletes private `StateQuery` and `split_ctl_mem_sub`; updates profile prose only; and adds collected exact-frame acceptance tests. There is no compatibility shim and no hardware is required.

Changed paths (8):
- `rigs/ic7300.toml`
- `src/rigplane/core/acquisition_scheduler.py`
- `src/rigplane/rigctld/server.py`
- `src/rigplane/runtime/_state_queries.py`
- `src/rigplane/runtime/radio_initial_state.py`
- `src/rigplane/web/radio_poller.py`
- `tests/_acquisition_query_helpers.py`
- `tests/test_state_queries.py`

Soft-limit note: 867 changed lines are required because strict helper replacement, six production build/send paths, and collected cross-sender coverage are atomic. This remains below the 900-line stop point and 1000-line hard ceiling.

Evidence:
- RED: 33 failed / 10 passed
- GREEN: 475 normal/reverse; rigctld 55; mutation 23; Ruff, format, mypy, and import contracts PASS

This implements production acceptance but does not auto-close or declare MOR-2157 complete. Closure waits for independent exact-head review, the full Mac suite, merge, and a post-merge audit.