### PR TITLE
docs: drop the expiring reason from the segmentline stylesheet pin

### DIFF
--- a/frontend/src/presentation/languages/segmentline/__tests__/stylesheet.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/stylesheet.test.ts
@@ -7,13 +7,12 @@
  * `../../__tests__/activation-attribute.test.ts` (MOR-1275) — not repeated
  * here.
  *
- * Unlike `studioline`/`fieldline`, this file has no `.rx-tx-surface`/
- * `.rx-tx-key`/`.rx-tx-state` cascade to rank: those rules style the
- * stateFeedback renderer's output, and segmentline ships no renderers yet
- * (MOR-2149). What exists today is the glass, the cell, the seven-segment
- * readout cell, the segmented meter track and the DIM contrast preset —
- * pinned below directly, by parsing declarations rather than by ranking a
- * cascade collision (there is none yet to rank).
+ * Unlike `studioline`/`fieldline`, this file has no `.rx-tx-*` cascade to
+ * rank: `segmentline.css` declares no selector in that family at all, where
+ * both sibling sheets do. The glass, the cell, the seven-segment readout
+ * cell, the segmented meter track and the DIM contrast preset are pinned
+ * below directly, by parsing declarations rather than by ranking a cascade
+ * collision.
  */
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';


### PR DESCRIPTION
Deletes one expiring sentence from the block comment in
`segmentline/__tests__/stylesheet.test.ts`.

The old text justified the absence of a `.rx-tx-*` cascade check by saying
segmentline "ships no renderers yet (MOR-2149)". That is true at `main` today
and expires when MOR-2149 lands, at which point a reader cannot tell whether
the missing check is an oversight.

**The reason is deleted, not replaced.** What remains is the one fact that
holds either way: `segmentline.css` declares no selector in the `.rx-tx-*`
family at all, where both sibling sheets do.

Established at this head with `grep -c '\.rx-tx-'` per sheet — segmentline 0,
studioline 23, fieldline 33 — and `git show --name-only` on the MOR-2149
branch confirms it does not touch `segmentline.css`, so the count cannot move
under it.

The `.rx-tx-surface`/`.rx-tx-key`/`.rx-tx-state` enumeration is collapsed to
`.rx-tx-*` because `studioline.css` has zero `.rx-tx-state` rules, so naming
all three overstated what both siblings have. That was measured by the
review, not by me.

## Round 1 was BLOCKED, correctly

The first version of this commit replaced the expiring reason with a longer
explanation about the stateFeedback renderer's `perimeter` and `cell` fields
being nested objects that `renderSlot` never annotates. The review refuted it:
those fields exist only on the unmerged MOR-2149 branch. The replacement was
**false at `main`** and would have become true only later — the same defect as
the sentence it replaced, with the sign flipped. I had read them off a working
tree that had the unmerged commit checked out, rather than against an explicit
ref.

Two claims in this PR's own first body were false for the same reason and are
gone: that both new facts "were established by reading the files named", and
that the new text was "true before and after". Neither held for the renderer
sentence.

The review's other two findings stand and are unaffected: `renderSlot` does
annotate top-level primitives only, and the cited test name and file do
resolve as a pair — both were independently confirmed, one by mutation. They
are simply not needed here.

VERIFICATION. `npx vitest run src/presentation/languages/segmentline` — 2
files, 37 tests, exit code 0 taken directly.

GUARDRAILS. 1 file, 13 changed lines. Both thresholds clear.
