### PR TITLE
feat(MOR-2149): add the three segmentline renderers

### DIFF
--- a/frontend/src/presentation/languages/__tests__/registry.test.ts
+++ b/frontend/src/presentation/languages/__tests__/registry.test.ts
@@ -1,17 +1,20 @@
 /**
  * MOR-1072 registry: the two frozen family IDs (`studioline`/`fieldline`,
  * MOR-977 §4.6) are registered as declarations, and the registry does not
- * hardcode a family count — an arbitrary, hypothetical family registers and
- * validates the same way. MOR-1073 gave studioline its renderers and MOR-1074
- * gave fieldline its own, so BOTH declared families now fill every slot — the
- * "zero renderers declared" fallback path is exercised by the shared fixture
- * (`validManifest`) and by `renderer-contract.test.ts`.
+ * hardcode a family count — the "no hardcoded family count" block below
+ * proves that generically with an arbitrary fixture id, and MOR-2149's
+ * `segmentline` (below) is a real, non-hypothetical instance of the same
+ * claim. MOR-1073 gave studioline its renderers, MOR-1074 gave fieldline its
+ * own, and MOR-2149 gave segmentline its own, so all three declared families
+ * now fill every slot — the "zero renderers declared" fallback path is
+ * exercised by the shared fixture (`validManifest`) and by
+ * `renderer-contract.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
 import {
   listDesignLanguageIds, getDesignLanguage, registerDesignLanguage, RENDERER_SLOT_NAMES,
 } from '../contract';
-import { studioline, fieldline } from '../declarations';
+import { studioline, fieldline, segmentline } from '../declarations';
 import { validManifest } from './fixtures';
 
 describe('the two frozen v3 declarations', () => {
@@ -53,6 +56,28 @@ describe('the two frozen v3 declarations', () => {
 
   it('studioline holds all three density steps (MOR-977 §4.2.3)', () => {
     expect(studioline.density).toEqual({ kind: 'clamped', supported: ['comfortable', 'compact', 'dense'] });
+  });
+});
+
+describe('segmentline (MOR-2149) fills every slot, exactly as studioline and fieldline do', () => {
+  it('registers segmentline alongside studioline and fieldline', () => {
+    expect(listDesignLanguageIds()).toEqual(expect.arrayContaining(['segmentline']));
+    expect(getDesignLanguage('segmentline')).toBe(segmentline);
+  });
+
+  it('fills every renderer slot (MOR-2149)', () => {
+    expect(Object.keys(segmentline.renderers).sort()).toEqual([...RENDERER_SLOT_NAMES].sort());
+  });
+
+  // The inventory row that makes "third language" mean something: all three
+  // families occupy the same slots with DIFFERENT implementations, so no
+  // slot is silently shared and no family is a re-export of another.
+  it('shares no renderer instance with studioline or fieldline', () => {
+    for (const slot of RENDERER_SLOT_NAMES) {
+      expect(segmentline.renderers[slot]).toBeDefined();
+      expect(segmentline.renderers[slot]).not.toBe(studioline.renderers[slot]);
+      expect(segmentline.renderers[slot]).not.toBe(fieldline.renderers[slot]);
+    }
   });
 });
 

--- a/frontend/src/presentation/languages/declarations.ts
+++ b/frontend/src/presentation/languages/declarations.ts
@@ -10,14 +10,17 @@
  * which retires the shared placeholder bundle that used to stand in for it.
  * The contract's `var(--accent)` default is deliberately left untouched.
  *
- * The two bundles are imported under family-qualified aliases because they
- * export the same three renderer names: that symmetry IS the proof — the
- * second language plugs into identical slots with no contract change.
+ * Each bundle is imported under family-qualified aliases because all three
+ * export the same three renderer names: that symmetry IS the proof — every
+ * language plugs into identical slots with no contract change. Below,
+ * studioline and fieldline (MOR-1073/1074) illustrate the pattern first;
+ * segmentline (MOR-2148/2149) follows it identically further down.
  *
- * MOR-2148 registers `segmentline`, the amber-LCD instrument family, as
- * tokens + stylesheet + manifest only — `renderers: {}`, which
- * `resolveRenderer` (`./contract.ts`) falls back on safely. Renderers are
- * MOR-2149's job.
+ * MOR-2148 registered `segmentline`, the amber-LCD instrument family, as
+ * tokens + stylesheet + manifest only (`renderers: {}`, which
+ * `resolveRenderer` (`./contract.ts`) fell back on safely). MOR-2149 fills
+ * its three renderer slots below, the same way MOR-1073/1074 filled
+ * studioline's and fieldline's.
  *
  * `layoutCompatibility` declares `peer-split: true` and `desktop-v2:
  * false`. Activation matches the resolved `SkinId`, not a
@@ -45,6 +48,9 @@ import { renderFrequency as fieldlineFrequency } from './fieldline/frequency-ren
 import { renderMeter as fieldlineMeter } from './fieldline/meters-renderer';
 import { renderStateFeedback as fieldlineStateFeedback } from './fieldline/state-feedback-renderer';
 import { FIELDLINE_TOKENS } from './fieldline/tokens';
+import { renderFrequency as segmentlineFrequency } from './segmentline/frequency-renderer';
+import { renderMeter as segmentlineMeter } from './segmentline/meters-renderer';
+import { renderStateFeedback as segmentlineStateFeedback } from './segmentline/state-feedback-renderer';
 import { SEGMENTLINE_TOKENS } from './segmentline/tokens';
 
 export const studioline: DesignLanguageManifest = {
@@ -103,9 +109,11 @@ export const segmentline: DesignLanguageManifest = {
       reason: 'segmentline assumes a fixed-native instrument glass; desktop-v2 is fluid chrome.',
     },
   ],
-  // MOR-2149 fills these three slots; `resolveRenderer` falls back to a
-  // safe no-op for an unfilled slot in the meantime.
-  renderers: {},
+  renderers: {
+    frequencyDisplay: segmentlineFrequency,
+    meters: segmentlineMeter,
+    stateFeedback: segmentlineStateFeedback,
+  },
 };
 
 registerDesignLanguage(studioline);

--- a/frontend/src/presentation/languages/segmentline/__tests__/frequency-renderer.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/frequency-renderer.test.ts
@@ -1,0 +1,201 @@
+/**
+ * MOR-2149 — the `segmentline` VFO renderer slice, over the four canonical
+ * topology fixtures (MOR-1062 `semantic/fixtures/topologies`), mirroring
+ * `studioline/__tests__/frequency-renderer.test.ts`'s shape.
+ *
+ * The renderer is a pure projection of ONE frequency fact onto the
+ * seven-segment grammar: per-glyph cells of a declared em width (so the
+ * total advance is a function of font-size alone, independent of whichever
+ * font actually loads), a trailing-dot separator riding with the group it
+ * follows, and the Hz group demoted in size only (never in digit weight).
+ */
+import { describe, it, expect } from 'vitest';
+import { invokeRenderer, RendererInputError } from '../../contract';
+import type { DesignLanguageTokens } from '../../contract';
+import { topologyFixtures } from '../../../../semantic/fixtures/topologies';
+import { SEGMENTLINE_TOKENS } from '../tokens';
+import {
+  DIGIT_CELL_EM, DOT_CELL_EM, HERO_SIZE_PX, renderFrequency, type SegmentlineFrequency,
+} from '../frequency-renderer';
+
+const render = (
+  fields: Record<string, string | number | boolean | null>,
+): SegmentlineFrequency => renderFrequency({ kind: 'frequency', fields }, SEGMENTLINE_TOKENS);
+
+const groupText = (r: SegmentlineFrequency, group: 'mhz' | 'khz' | 'hz'): string =>
+  r.groups.find((g) => g.group === group)!.text;
+
+/** Every VFO the four topology fixtures declare — the real acceptance surface. */
+const topologyVfos = Object.entries(topologyFixtures).flatMap(([id, model]) =>
+  model.vfos.map((vfo) => [id, vfo.label, vfo.frequencyHz] as const));
+
+describe('four topology fixtures render under the segmentline grammar', () => {
+  it.each(topologyVfos)('%s / %s renders three groups', (_topology, _label, hz) => {
+    const r = render({ frequencyHz: hz });
+    expect(r.groups.map((g) => g.group)).toEqual(['mhz', 'khz', 'hz']);
+    expect(r.unknown).toBe(false);
+  });
+
+  it.each(topologyVfos)('%s / %s keeps the digits and the value in agreement', (_topology, _label, hz) => {
+    // Cells strip the dot separators, so the digit characters alone reconstruct the value.
+    const r = render({ frequencyHz: hz });
+    const digitsOnly = r.groups.flatMap((g) => g.cells.filter((c) => !c.isSeparator).map((c) => c.char)).join('');
+    expect(Number(digitsOnly)).toBe(hz);
+  });
+
+  it('renders each fixture at its declared active frequency', () => {
+    expect(groupText(render({ frequencyHz: topologyFixtures['1/single'].vfos[0].frequencyHz }), 'mhz')).toBe('14.');
+    expect(groupText(render({ frequencyHz: topologyFixtures['1/ab'].vfos[0].frequencyHz }), 'mhz')).toBe('7.');
+    expect(groupText(render({ frequencyHz: topologyFixtures['2/ab_shared'].vfos[0].frequencyHz }), 'mhz')).toBe('3.');
+    expect(groupText(render({ frequencyHz: topologyFixtures['2/main_sub'].vfos[0].frequencyHz }), 'mhz')).toBe('14.');
+  });
+});
+
+describe('the Hz group is demoted in SIZE only, never in digit weight', () => {
+  it('sizes the Hz group at hzSizePx/ranked/muted, everything else at heroSizePx/hero/primary', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    const hz = r.groups.find((g) => g.group === 'hz')!;
+    expect(hz).toMatchObject({ fontSizePx: r.hzSizePx, rank: 'ranked', tone: 'muted' });
+    for (const g of r.groups.filter((g) => g.group !== 'hz')) {
+      expect(g).toMatchObject({ fontSizePx: HERO_SIZE_PX, rank: 'hero', tone: 'primary' });
+    }
+  });
+
+  it('every cell in every group carries the SAME digit weight — nothing per-cell can quietly demote one', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    for (const g of r.groups) {
+      for (const c of g.cells) expect(Object.keys(c).sort()).toEqual(['char', 'isSeparator', 'widthEm']);
+    }
+  });
+});
+
+describe('the dot rides with the group it follows — mhz and khz carry it, hz carries none', () => {
+  it('marks exactly the trailing dot of the mhz and khz groups as the separator cell', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    const mhz = r.groups.find((g) => g.group === 'mhz')!;
+    const khz = r.groups.find((g) => g.group === 'khz')!;
+    const hzGroup = r.groups.find((g) => g.group === 'hz')!;
+    expect(mhz.cells.at(-1)).toMatchObject({ char: '.', isSeparator: true, widthEm: DOT_CELL_EM });
+    expect(khz.cells.at(-1)).toMatchObject({ char: '.', isSeparator: true, widthEm: DOT_CELL_EM });
+    expect(hzGroup.cells.some((c) => c.isSeparator)).toBe(false);
+  });
+
+  it('every non-separator cell is a digit at the full DIGIT_CELL_EM width', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    for (const g of r.groups) {
+      for (const c of g.cells.filter((c) => !c.isSeparator)) {
+        expect(c.widthEm).toBe(DIGIT_CELL_EM);
+        expect(c.char).toMatch(/^\d$/);
+      }
+    }
+  });
+
+  it('joins into a dot-separated run: "14.250.000"', () => {
+    expect(render({ frequencyHz: 14_250_000 }).text).toBe('14.250.000');
+  });
+});
+
+describe('leading MHz zeros shift off, matching splitFrequencyToDigits()', () => {
+  it.each([
+    [14_250_000, '14.'],
+    [7_100_000, '7.'],
+    [3_573_000, '3.'],
+    [144_300_000, '144.'],
+    [500_000, '0.'], // sub-MHz: the group never empties — one digit always remains
+  ])('%i MHz group renders as "%s"', (hz, expected) => {
+    expect(groupText(render({ frequencyHz: hz }), 'mhz')).toBe(expected);
+  });
+
+  it('does NOT strip zeros from the kHz or Hz groups — only the MHz group shifts', () => {
+    const r = render({ frequencyHz: 14_000_000 });
+    expect(groupText(r, 'khz')).toBe('000.');
+    expect(groupText(r, 'hz')).toBe('000');
+  });
+});
+
+describe('an unobserved frequency stays unobserved', () => {
+  it('renders a null frequency as an explicit unknown, never as 0 Hz', () => {
+    const r = render({ frequencyHz: null });
+    expect(r.unknown).toBe(true);
+    expect(r.groups).toEqual([]);
+    expect(r.widthPx).toBe(0);
+    expect(r.text).not.toMatch(/0/);
+  });
+
+  it('renders a missing frequency field the same way — absence is not zero', () => {
+    expect(render({}).unknown).toBe(true);
+  });
+
+  // The defect an earlier draft of this file carried: it read a
+  // `vfo0FrequencyHz` fallback field that `VfoSurface.svelte` (the one real
+  // caller) never supplies. If that fallback were still present, this input
+  // would render a known frequency instead of unknown.
+  it('does not read vfo0FrequencyHz — no real caller ever supplies it', () => {
+    expect(render({ vfo0FrequencyHz: 14_250_000 }).unknown).toBe(true);
+  });
+});
+
+describe('metric-critical width: total advance is a function of font-size alone', () => {
+  // Independent hand computation, not the renderer's own formula: mhz "14." =
+  // (0.816+0.816+0.29)*56, khz "250." = (0.816*3+0.29)*56, hz "000" =
+  // (0.816*3)*Math.round(56*0.62). A one-unit change to DIGIT_CELL_EM,
+  // DOT_CELL_EM, HERO_SIZE_PX or HZ_GROUP_RATIO moves this total detectably.
+  it('pins the exact total width for 14.25 MHz', () => {
+    expect(render({ frequencyHz: 14_250_000 }).widthPx).toBeCloseTo(346.64, 9);
+  });
+
+  it('pins the exported DSEG7 digit advance to the measured value (static/fonts/DSEG7Classic-Bold.woff2)', () => {
+    expect(DIGIT_CELL_EM).toBe(0.816);
+  });
+
+  // The constant→field WIRING, not just the constants: `widthPx` alone
+  // cannot prove digitCellEm/dotCellEm/heroSizePx individually reach the
+  // descriptor rather than being computed inline and discarded.
+  it('pins the constant-to-field wiring for digitCellEm, dotCellEm and heroSizePx', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    expect(r.digitCellEm).toBe(DIGIT_CELL_EM);
+    expect(r.dotCellEm).toBe(DOT_CELL_EM);
+    expect(r.heroSizePx).toBe(HERO_SIZE_PX);
+  });
+});
+
+describe('style carries the numeral typography the token set declares, not its own', () => {
+  it('pins fontFamily/fontWeight/fontVariantNumeric to SEGMENTLINE_TOKENS (mirrors studioline/fieldline\'s own pin)', () => {
+    const r = render({ frequencyHz: 14_250_000 });
+    expect(r.style.fontFamily).toBe(SEGMENTLINE_TOKENS.typography.fontFamily);
+    expect(r.style.fontWeight).toBe(String(SEGMENTLINE_TOKENS.frequency.digitWeight));
+    expect(r.style.fontVariantNumeric).toBe('tabular-nums');
+  });
+
+  // A token set that DIFFERS from SEGMENTLINE_TOKENS on exactly these two
+  // fields — a literal `{ mutated: 'yes' }` (or any other value the renderer
+  // did not actually read from `tokens`) cannot produce this output.
+  it('changes when the token set changes — the read is load-bearing, not a private default', () => {
+    const otherTokens: DesignLanguageTokens = {
+      ...SEGMENTLINE_TOKENS,
+      typography: { ...SEGMENTLINE_TOKENS.typography, fontFamily: 'Other Font, monospace' },
+      frequency: { ...SEGMENTLINE_TOKENS.frequency, digitWeight: 321 },
+    };
+    const r = renderFrequency({ kind: 'frequency', fields: { frequencyHz: 14_250_000 } }, otherTokens);
+    expect(r.style.fontFamily).toBe('Other Font, monospace');
+    expect(r.style.fontWeight).toBe('321');
+  });
+});
+
+describe('the renderer survives the MOR-1072 structural gate', () => {
+  it('renders through invokeRenderer', () => {
+    const viewModel = { kind: 'frequency', fields: { frequencyHz: 14_250_000 } };
+    expect(invokeRenderer(renderFrequency, viewModel, SEGMENTLINE_TOKENS)).toMatchObject({ unknown: false });
+  });
+
+  it('cannot be reached with a capability-shaped payload', () => {
+    const smuggled = { kind: 'frequency', fields: { frequencyHz: 14_250_000 }, capabilities: { modes: ['USB'] } };
+    expect(() => invokeRenderer(renderFrequency, smuggled, SEGMENTLINE_TOKENS)).toThrow(RendererInputError);
+  });
+
+  it('ignores any field it does not name — an extra field cannot alter the render', () => {
+    const plain = render({ frequencyHz: 14_250_000 });
+    const noisy = render({ frequencyHz: 14_250_000, radioModel: 'test-radio', ptt: true });
+    expect(noisy).toEqual(plain);
+  });
+});

--- a/frontend/src/presentation/languages/segmentline/__tests__/meters-renderer.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/meters-renderer.test.ts
@@ -1,0 +1,111 @@
+/**
+ * MOR-2149 — the `segmentline` meter form: a segmented LCD bar graph whose
+ * two fractions (`fillFraction`, `s9Fraction`) both divide by `max`, mirroring
+ * `studioline/__tests__/meters-renderer.test.ts`'s shape. The pin that
+ * matters most is the same one both sibling files end on: an unobserved
+ * reading must render as unknown, not as a track sitting at zero, which reads
+ * as "no signal" — a different fact.
+ */
+import { describe, it, expect } from 'vitest';
+import { invokeRenderer, RendererInputError } from '../../contract';
+import type { DesignLanguageTokens } from '../../contract';
+import { SEGMENTLINE_TOKENS } from '../tokens';
+import { HOT_THRESHOLD, renderMeter } from '../meters-renderer';
+
+const render = (fields: Record<string, number | null>) =>
+  renderMeter({ kind: 'meter', fields }, SEGMENTLINE_TOKENS);
+
+describe('the meter takes its segment pitch from the tokens, not a private default', () => {
+  it('reads the pitch off SEGMENTLINE_TOKENS.meters', () => {
+    const m = render({ value: 0.5, max: 1, s9: 0.6 });
+    expect(m.segmentWidthPx).toBe(Number.parseFloat(SEGMENTLINE_TOKENS.meters.trackWidth));
+    expect(m.segmentGapPx).toBe(Number.parseFloat(SEGMENTLINE_TOKENS.meters.segmentGap));
+  });
+
+  // SEGMENTLINE_TOKENS' own pitch is 7px/3px, which is numerically equal to
+  // a plausible fallback default — a test that only checks against
+  // SEGMENTLINE_TOKENS cannot tell "read the token" apart from "ignored the
+  // token and returned 7/3 anyway". A token set whose pitch does NOT equal
+  // 7/3 closes that gap: the output can only match if the renderer actually
+  // read the `tokens` parameter it was called with.
+  it('changes when the token set changes — the read is load-bearing, not a coincidence', () => {
+    const otherTokens: DesignLanguageTokens = {
+      ...SEGMENTLINE_TOKENS,
+      meters: { trackWidth: '11px', segmentGap: '5px' },
+    };
+    const m = renderMeter({ kind: 'meter', fields: { value: 0.5, max: 1, s9: 0.6 } }, otherTokens);
+    expect(m.segmentWidthPx).toBe(11);
+    expect(m.segmentGapPx).toBe(5);
+  });
+});
+
+describe('fillFraction and s9Fraction are two INDEPENDENT divisions by max', () => {
+  // A deliberately asymmetric fixture: value/max and s9/max produce two
+  // DIFFERENT fractions (0.25 vs 0.75). A symmetric fixture (e.g. value ===
+  // s9) cannot tell a swapped assignment apart from a correct one — this one
+  // can: if fillFraction and s9Fraction were transposed, or if either
+  // division read the wrong pair of operands, this test fails.
+  it('computes fillFraction from value/max and s9Fraction from s9/max, not the other way round', () => {
+    const m = render({ value: 3, max: 12, s9: 9 });
+    expect(m.fillFraction).toBe(0.25);
+    expect(m.s9Fraction).toBe(0.75);
+  });
+
+  it('at the real call-site scale (value/s9 already 0..1, max 1), the two fractions equal the raw inputs', () => {
+    const m = render({ value: 0.2, max: 1, s9: 0.6 });
+    expect(m.fillFraction).toBe(0.2);
+    expect(m.s9Fraction).toBe(0.6);
+  });
+
+  it('clamps an over-range reading to the track rather than overflowing it', () => {
+    expect(render({ value: 40, max: 15, s9: 9 }).fillFraction).toBe(1);
+    expect(render({ value: -3, max: 15, s9: 9 }).fillFraction).toBe(0);
+  });
+
+  it('s9Fraction defaults to 0 when s9 is absent, independent of the fill', () => {
+    expect(render({ value: 6, max: 12 }).s9Fraction).toBe(0);
+  });
+});
+
+describe('HOT_THRESHOLD is a literal boundary, not an approximation', () => {
+  it('is exactly 0.8', () => {
+    expect(HOT_THRESHOLD).toBe(0.8);
+  });
+
+  it('marks hot AT 0.8 exactly (>=, not >)', () => {
+    expect(render({ value: 0.8, max: 1, s9: 0.6 }).hot).toBe(true);
+  });
+
+  it('does not mark hot one hundredth below 0.8', () => {
+    expect(render({ value: 0.79, max: 1, s9: 0.6 }).hot).toBe(false);
+  });
+});
+
+describe('an unobserved reading stays unobserved', () => {
+  it('renders unknown, never a track resting at zero', () => {
+    const m = render({ value: null, max: 1, s9: 0.6 });
+    expect(m.unknown).toBe(true);
+    expect(m.fillFraction).toBe(0);
+    expect(m.hot).toBe(false);
+  });
+
+  it('still computes s9Fraction when the value itself is unobserved', () => {
+    expect(render({ value: null, max: 15, s9: 9 }).s9Fraction).toBe(0.6);
+  });
+
+  it('a genuine zero reading is a DIFFERENT fact from unobserved, and says so', () => {
+    expect(render({ value: 0, max: 1, s9: 0.6 })).toMatchObject({ unknown: false, fillFraction: 0 });
+  });
+});
+
+describe('the renderer survives the MOR-1072 structural gate', () => {
+  it('renders through invokeRenderer', () => {
+    const viewModel = { kind: 'meter', fields: { value: 0.5, max: 1, s9: 0.6 } };
+    expect(invokeRenderer(renderMeter, viewModel, SEGMENTLINE_TOKENS)).toMatchObject({ unknown: false });
+  });
+
+  it('cannot be reached with a capability-shaped payload', () => {
+    const smuggled = { kind: 'meter', fields: { value: 0.5 }, capabilities: { modes: ['USB'] } };
+    expect(() => invokeRenderer(renderMeter, smuggled, SEGMENTLINE_TOKENS)).toThrow(RendererInputError);
+  });
+});

--- a/frontend/src/presentation/languages/segmentline/__tests__/state-feedback-renderer.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/state-feedback-renderer.test.ts
@@ -1,0 +1,207 @@
+/**
+ * MOR-2149 — the `segmentline` TX renderer slice: the glass perimeter (a
+ * bezel tone plus an inward glow) as the always-visible TX carrier, mirroring
+ * `studioline/__tests__/state-feedback-renderer.test.ts`'s shape.
+ *
+ * SAFETY INVARIANT R9 is the spine of this file, exactly as it is of the two
+ * sibling renderers'. Every input below is produced by the real MOR-1064
+ * vocabulary (`rfState`/`txSessionState` over a `TxAuthoritySnapshot`) rather
+ * than by hand-written strings, so a renderer that quietly grew a second
+ * opinion — or started reading a raw `ptt`, or `channel`/`phase`/`treatment`
+ * fields no real caller supplies — fails here rather than in a shack.
+ */
+import { describe, it, expect } from 'vitest';
+import { invokeRenderer, RendererInputError } from '../../contract';
+import {
+  rfState, txSessionState, type TxAuthoritySnapshot,
+} from '../../../../semantic/rx-tx-surface';
+import { SEGMENTLINE_INK, SEGMENTLINE_PALETTE, SEGMENTLINE_TOKENS } from '../tokens';
+import { renderStateFeedback, type SegmentlineStateFeedback } from '../state-feedback-renderer';
+
+const authority = (over: Partial<TxAuthoritySnapshot> = {}): TxAuthoritySnapshot => ({
+  phase: 'idle', intent: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null, ...over,
+});
+
+/** Exactly the projection the real call site (`RxTxSurface.svelte`) performs: App-authority conclusions in, flat primitives out. */
+const fromAuthority = (
+  tx: TxAuthoritySnapshot, extra: Record<string, string | number | boolean | null> = {},
+): SegmentlineStateFeedback => renderStateFeedback({
+  kind: 'state-feedback',
+  fields: { rf: rfState(tx), session: txSessionState(tx), fault: tx.fault, keyBlocked: false, ...extra },
+}, SEGMENTLINE_TOKENS);
+
+const RX = authority();
+const PENDING = authority({ phase: 'key-confirm-pending', intent: 'latched', mayOwnKey: true, txRisk: 'uncertain' });
+const TX = authority({ phase: 'active', intent: 'latched', radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true });
+const RELEASING = authority({ phase: 'releasing', radioTx: 'on', txRisk: 'confirmed-on', mayOwnKey: true });
+const FAULT = authority({ phase: 'failed', radioTx: 'unknown', txRisk: 'uncertain', fault: 'audio-failed' });
+const UNKNOWN_RF = authority({ radioTx: 'unknown' });
+const ALL = [RX, PENDING, TX, RELEASING, FAULT, UNKNOWN_RF];
+
+describe('the perimeter is the always-visible TX carrier (segmentline\'s own grammar)', () => {
+  it('RX is quiet: unlit, no label, RX tone', () => {
+    const { perimeter, meterScaleLabel, numeralTone } = fromAuthority(RX);
+    expect(perimeter).toMatchObject({ lit: false, label: null, tone: SEGMENTLINE_TOKENS.rx.idle, insetShadow: '' });
+    expect(meterScaleLabel).toBe('S');
+    expect(numeralTone).toBe('primary');
+  });
+
+  it('pending lights the perimeter before any RF is out', () => {
+    const { perimeter, meterScaleLabel } = fromAuthority(PENDING);
+    expect(perimeter).toMatchObject({ lit: true, label: 'KEYING', tone: SEGMENTLINE_TOKENS.tx.tuning });
+    expect(perimeter.insetShadow).not.toBe('');
+    expect(meterScaleLabel).toBe('S');
+  });
+
+  it('TX lights the perimeter and re-zones the meter to power', () => {
+    const { perimeter, meterScaleLabel, numeralTone } = fromAuthority(TX);
+    expect(perimeter).toMatchObject({ lit: true, label: 'TX', tone: SEGMENTLINE_TOKENS.tx.active });
+    expect(meterScaleLabel).toBe('PO');
+    expect(numeralTone).toBe('tx-target');
+  });
+
+  it('releasing stays lit without pretending RX has resumed', () => {
+    const { perimeter, meterScaleLabel } = fromAuthority(RELEASING);
+    expect(perimeter).toMatchObject({ lit: true, label: 'UNKEYING' });
+    expect(meterScaleLabel).toBe('PO');
+  });
+
+  it('a fault reports its code via `micro` — an unheard-of code still shows', () => {
+    expect(fromAuthority(FAULT).perimeter).toMatchObject({ lit: true, label: 'TX FAULT' });
+    expect(fromAuthority(FAULT).micro).toBe('TX FAULT: audio-failed');
+    expect(fromAuthority(authority({ phase: 'failed', fault: 'no-such-code-4711' })).micro)
+      .toBe('TX FAULT: no-such-code-4711');
+  });
+
+  it('unknown RF is a THIRD thing — never collapsed into RX (MOR-977 §1.2.1)', () => {
+    const unknown = fromAuthority(UNKNOWN_RF);
+    expect(unknown.perimeter).toMatchObject({ lit: true, label: 'TX?' });
+    expect(unknown.perimeter).not.toEqual(fromAuthority(RX).perimeter);
+  });
+});
+
+describe('state survives forced-colors and colour-vision deficiency', () => {
+  it('no two states share the same lit/label pair — colour is never the only channel', () => {
+    const colourless = ALL.map((tx) => {
+      const { perimeter } = fromAuthority(tx);
+      return `${perimeter.lit}/${perimeter.label ?? 'RX'}`;
+    });
+    expect(new Set(colourless).size).toBe(ALL.length);
+  });
+});
+
+describe('the TX cell gets an intentional treatment (segmentline never fills a control)', () => {
+  it.each([
+    ['idle', RX, 'idle'], ['pending', PENDING, 'pending'],
+    ['keyed', TX, 'keyed'], ['fault', FAULT, 'fault'],
+  ])('%s renders the "%s" cell treatment', (_name, tx, treatment) => {
+    expect(fromAuthority(tx).cell.treatment).toBe(treatment);
+  });
+
+  it('is `active` only while actually keyed — pending is engaged-intent, not engaged-yet', () => {
+    expect(fromAuthority(TX).cell.active).toBe(true);
+    expect(fromAuthority(RELEASING).cell.active).toBe(true);
+    expect(fromAuthority(PENDING).cell.active).toBe(false);
+    expect(fromAuthority(RX).cell.active).toBe(false);
+  });
+
+  it('every treatment is present — no state hides the control', () => {
+    for (const tx of ALL) expect(fromAuthority(tx).cell.present).toBe(true);
+  });
+
+  it('carries the mandatory focus ring rather than re-suppressing it (MOR-977 §1.2.5)', () => {
+    expect(fromAuthority(RX).cell.focusRing).toBe(SEGMENTLINE_TOKENS.focusRing);
+    expect(fromAuthority(RX).cell.focusRing).not.toMatch(/none/);
+  });
+});
+
+describe('the cell tone pins to the exact declared ink/palette entries, not a scaled guess', () => {
+  // keyed and blocked resolve to two DIFFERENT declared constants — a swap
+  // between them (or a drift of either constant by a shade) fails here.
+  it('keyed is the txMark hot ink — the SAME constant segmentline.css\'s hot cell rule uses', () => {
+    expect(fromAuthority(TX).cell.tone).toBe(SEGMENTLINE_PALETTE.txMark);
+  });
+
+  it('a blocked cell is rendered inert-but-PRESENT, at the faintest ink (MOR-977 §1.2.3)', () => {
+    const blocked = renderStateFeedback({
+      kind: 'state-feedback',
+      fields: { rf: 'receiving', session: 'idle', fault: null, keyBlocked: true },
+    }, SEGMENTLINE_TOKENS);
+    expect(blocked.cell).toMatchObject({ treatment: 'blocked', present: true, active: false });
+    expect(blocked.cell.tone).toBe(SEGMENTLINE_INK.ghost);
+  });
+
+  it('idle and pending share the dim baseline ink, distinct from both keyed and blocked', () => {
+    expect(fromAuthority(RX).cell.tone).toBe(SEGMENTLINE_INK.soft);
+    expect(fromAuthority(PENDING).cell.tone).toBe(SEGMENTLINE_INK.soft);
+    expect(fromAuthority(RX).cell.tone).not.toBe(SEGMENTLINE_PALETTE.txMark);
+    expect(fromAuthority(RX).cell.tone).not.toBe(SEGMENTLINE_INK.ghost);
+  });
+
+  it('a cell disabled BECAUSE it is already keyed keeps the KEYED treatment (F3/N3)', () => {
+    const withCell = (over: Record<string, string | number | boolean | null>) =>
+      renderStateFeedback({
+        kind: 'state-feedback',
+        fields: { rf: 'receiving', session: 'idle', fault: null, keyBlocked: true, ...over },
+      }, SEGMENTLINE_TOKENS).cell;
+
+    expect(withCell({ rf: 'transmitting', session: 'keyed' })).toMatchObject({ treatment: 'keyed', active: true });
+    expect(withCell({ rf: 'transmitting', session: 'releasing' }).treatment).toBe('keyed');
+    // The one session where "you may not key" IS the whole story keeps it.
+    expect(withCell({}).treatment).toBe('blocked');
+  });
+});
+
+describe('perimeter.transition follows the token motion duration, not a private string', () => {
+  it('pins the exact string built from SEGMENTLINE_TOKENS.motion.durationMs (90ms)', () => {
+    expect(SEGMENTLINE_TOKENS.motion.durationMs).toBe(90);
+    expect(fromAuthority(TX).perimeter.transition).toBe('border-color 90ms linear, box-shadow 90ms linear');
+  });
+
+  // A token set whose duration differs from 90 — a literal replacement
+  // (e.g. a mutated constant string) cannot happen to match both this and
+  // the 90ms pin above.
+  it('changes when the token duration changes — the read is load-bearing', () => {
+    const otherTokens = { ...SEGMENTLINE_TOKENS, motion: { ...SEGMENTLINE_TOKENS.motion, durationMs: 250 } };
+    const r = renderStateFeedback({
+      kind: 'state-feedback',
+      fields: { rf: 'transmitting', session: 'keyed', fault: null, keyBlocked: false },
+    }, otherTokens);
+    expect(r.perimeter.transition).toBe('border-color 250ms linear, box-shadow 250ms linear');
+  });
+});
+
+describe('R9 — TX truth comes from App authority, never from the renderer', () => {
+  it('a raw ptt field cannot light the perimeter: authority says RX, so it renders RX', () => {
+    const withPtt = fromAuthority(RX, { ptt: true, radioStatePtt: true });
+    expect(withPtt).toEqual(fromAuthority(RX));
+    expect(withPtt.perimeter.lit).toBe(false);
+  });
+
+  // The defect an earlier draft of this file carried: it read `channel`,
+  // `phase` and `treatment` fields directly, which `RxTxSurface.svelte` (the
+  // real caller) never supplies — so it would have rendered every real input
+  // as the unlit RX default regardless of the authority's actual state. This
+  // pins the fix: those three field names are ignored, only rf/session/
+  // fault/keyBlocked move the render.
+  it('channel/phase/treatment fields cannot move the perimeter — only rf/session/fault/keyBlocked can', () => {
+    const spoofed = fromAuthority(TX, { channel: 'rx', phase: 'idle', treatment: 'wash' });
+    expect(spoofed).toEqual(fromAuthority(TX));
+    expect(spoofed.perimeter.lit).toBe(true);
+    expect(spoofed.perimeter.label).toBe('TX');
+  });
+
+  it('an unrecognised state fails CLOSED — doubt, never a quiet RX perimeter', () => {
+    const bogus = renderStateFeedback({
+      kind: 'state-feedback',
+      fields: { rf: 'who-knows', session: 'brand-new-phase', fault: null, keyBlocked: false },
+    }, SEGMENTLINE_TOKENS);
+    expect(bogus.perimeter).toMatchObject({ lit: true, label: 'TX?' });
+    expect(bogus.cell.treatment).not.toBe('idle');
+  });
+
+  it('is reachable only through the structural gate', () => {
+    const smuggled = { kind: 'state-feedback', fields: { rf: 'receiving' }, capabilities: { tx: true } };
+    expect(() => invokeRenderer(renderStateFeedback, smuggled, SEGMENTLINE_TOKENS)).toThrow(RendererInputError);
+  });
+});

--- a/frontend/src/presentation/languages/segmentline/__tests__/tokens.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/tokens.test.ts
@@ -121,10 +121,6 @@ describe('segmentline token set implements the MOR-2148 amber-LCD grammar', () =
       },
     ]);
   });
-
-  it('declares no renderers yet — MOR-2149 fills the three slots', () => {
-    expect(Object.keys(segmentline.renderers)).toEqual([]);
-  });
 });
 
 describe('does not lend its token set to studioline or fieldline — the family is independent', () => {

--- a/frontend/src/presentation/languages/segmentline/frequency-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/frequency-renderer.ts
@@ -1,0 +1,166 @@
+/**
+ * `segmentline` frequency renderer (MOR-2149, VFO slice) — the seven-segment
+ * readout.
+ *
+ * THREE OUTPUT CHANNELS, ONE DESCRIPTOR (`semantic/design-language-
+ * renderers.ts`'s `renderSlot`/`annotate`): `annotate` walks every top-level
+ * key EXCEPT `text` (its `if (key === 'text') continue;`) and turns each
+ * remaining PRIMITIVE into a `data-dl-<kebab>` attribute; nested objects and
+ * arrays are skipped entirely. So this descriptor is written on three levels
+ * at once —
+ *   - flat primitives that reach the DOM as `data-dl-*` (`kind`,
+ *     `digitCellEm`, `dotCellEm`, `heroSizePx`, `hzSizePx`, `widthPx`,
+ *     `unknown`);
+ *   - `text` is excluded from that walk on purpose and reaches only
+ *     `renderSlot`'s SEPARATE `.text` return channel, never a `data-dl-*`
+ *     attribute. `VfoSurface.svelte`'s own comment records that no
+ *     production caller reads it today (MOR-1482): a ranked grammar
+ *     flattened to a tile-sized string reads worse than the plain fallback
+ *     it would replace;
+ *   - `groups` (with its nested `cells`) and `style` are private structure
+ *     `annotate` skips because they are objects, not primitives — the same
+ *     role studioline's `groups` plays, for a future hero-scale mount that
+ *     can render ranked grouping (and the numeral typography) directly.
+ *
+ * WHY EVERY GLYPH GETS ITS OWN CELL. Measured against the bundled font
+ * (`static/fonts/DSEG7Classic-Bold.woff2`, via fontTools' `hmtx` table):
+ * every one of DSEG7 Classic Bold's ten digits advances 816/1000 em = 0.816em,
+ * and `.` advances exactly 0 — the glyph overprints whatever precedes it. A
+ * fallback face has neither property, so a plain text run would silently
+ * change width if the webfont failed to load. DSEG7 IS bundled in this repo
+ * (`static/fonts/`, `src/components-v2/theme/fonts/`), so that reflow is the
+ * documented REASON for the per-glyph-cell design here, not a live risk this
+ * file has to defend against. `DOT_CELL_EM` is not a font metric (the glyph
+ * itself advances zero) — it is the width segmentline's own grammar reserves
+ * for the separator's cell, so total advance stays a function of font-size
+ * alone.
+ *
+ * Digit semantics match `splitFrequencyToDigits()` and the other two
+ * languages: nine digits, leading MHz zeros shifted off but never below one
+ * digit, grouped 10^8..10^6 / 10^5..10^3 / 10^2..10^0.
+ *
+ * INPUT. The renderer's one production call site is `semantic/VfoSurface.
+ * svelte`'s `frequencyDisplay()`, which calls exactly
+ * `renderSlot('frequencyDisplay', { frequencyHz: vfo.frequencyHz })` — one
+ * named field. `presentation/languages/projection.ts`'s `vfo0FrequencyHz` is
+ * a real field NAME (it appears in that module's own output shape and its
+ * tests), but `projectRadioViewModel` has no production call site at all —
+ * it is called only from its own test file — so no caller ever hands this
+ * renderer a `vfo0FrequencyHz` field. Reading it here would be a fallback
+ * parameter nobody passes.
+ */
+import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+
+/** DSEG7 Classic Bold digit advance, in em — measured against
+ *  `static/fonts/DSEG7Classic-Bold.woff2` (fontTools `hmtx`: every digit
+ *  glyph is 816 units wide at 1000 unitsPerEm). */
+export const DIGIT_CELL_EM = 0.816;
+/** The separator's own reserved cell width. Not a font metric — DSEG7's `.`
+ *  itself advances zero; this is how much horizontal space the family's own
+ *  grammar sets aside for the cell instead. */
+export const DOT_CELL_EM = 0.29;
+export const HERO_SIZE_PX = 56;
+/** Hz group at 0.62 of the hero step: subordinate, still legible at arm's length. */
+export const HZ_GROUP_RATIO = 0.62;
+export const SEPARATOR = '.';
+const UNKNOWN_TEXT = '-------';
+const GROUP_NAMES = ['mhz', 'khz', 'hz'] as const;
+
+export type FrequencyGroupName = (typeof GROUP_NAMES)[number];
+
+export interface SegmentlineCell {
+  readonly char: string;
+  readonly widthEm: number;
+  readonly isSeparator: boolean;
+}
+
+export interface SegmentlineFrequencyGroup {
+  readonly group: FrequencyGroupName;
+  readonly text: string;
+  readonly cells: readonly SegmentlineCell[];
+  readonly fontSizePx: number;
+  readonly rank: 'hero' | 'ranked';
+  readonly tone: 'primary' | 'muted';
+}
+
+export interface SegmentlineFrequency {
+  // ── flat: these become data-dl-* annotations (annotate() excludes only `text`) ──
+  readonly kind: 'segmentline-frequency';
+  readonly unknown: boolean;
+  readonly digitCellEm: number;
+  readonly dotCellEm: number;
+  readonly heroSizePx: number;
+  readonly hzSizePx: number;
+  /** Total advance in px — deterministic and font-independent. */
+  readonly widthPx: number;
+  // ── `.text` channel only: excluded from data-dl-* by annotate()'s own `key === 'text'` check ──
+  readonly text: string;
+  // ── private structure: skipped by the annotator because these are objects, not primitives ──
+  readonly style: Readonly<Record<string, string>>;
+  readonly groups: readonly SegmentlineFrequencyGroup[];
+}
+
+const finite = (fields: RendererViewModel['fields'], key: string): number | null => {
+  const value = fields[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+};
+
+const mhzShift = (digits: string): number =>
+  Math.min(3 - digits.slice(0, 3).replace(/^0+/, '').length, 2);
+
+const toCells = (text: string): readonly SegmentlineCell[] =>
+  text.split('').map((char) => ({
+    char,
+    widthEm: char === SEPARATOR ? DOT_CELL_EM : DIGIT_CELL_EM,
+    isSeparator: char === SEPARATOR,
+  }));
+
+export function renderFrequency(
+  viewModel: RendererViewModel, tokens: DesignLanguageTokens,
+): SegmentlineFrequency {
+  const heroSizePx = HERO_SIZE_PX;
+  const hzSizePx = Math.round(heroSizePx * HZ_GROUP_RATIO);
+  const style = {
+    fontFamily: tokens.typography.fontFamily,
+    fontWeight: String(tokens.frequency.digitWeight),
+    fontVariantNumeric: tokens.typography.fontVariantNumeric,
+    letterSpacing: '0',
+  };
+  const base = { kind: 'segmentline-frequency' as const, digitCellEm: DIGIT_CELL_EM, dotCellEm: DOT_CELL_EM, heroSizePx, hzSizePx, style };
+
+  const hz = finite(viewModel.fields, 'frequencyHz');
+  if (hz === null) {
+    return { ...base, text: UNKNOWN_TEXT, unknown: true, widthPx: 0, groups: [] };
+  }
+
+  const digits = String(Math.max(0, Math.floor(hz))).padStart(9, '0');
+  const shift = mhzShift(digits);
+  const groups = GROUP_NAMES.map((group, index): SegmentlineFrequencyGroup => {
+    const start = index * 3;
+    const ranked = group === 'hz';
+    // The separator rides with the group it FOLLOWS, so mhz and khz carry
+    // their own trailing dot and hz carries none.
+    const body = digits.slice(group === 'mhz' ? shift : start, start + 3);
+    const text = ranked ? body : `${body}${SEPARATOR}`;
+    return {
+      group,
+      text,
+      cells: toCells(text),
+      fontSizePx: ranked ? hzSizePx : heroSizePx,
+      rank: ranked ? 'ranked' : 'hero',
+      tone: ranked ? 'muted' : 'primary',
+    };
+  });
+
+  const widthPx = groups.reduce(
+    (sum, g) => sum + g.cells.reduce((s, c) => s + c.widthEm * g.fontSizePx, 0), 0,
+  );
+
+  return {
+    ...base,
+    text: groups.map((g) => g.text).join(''),
+    unknown: false,
+    widthPx,
+    groups,
+  };
+}

--- a/frontend/src/presentation/languages/segmentline/meters-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/meters-renderer.ts
@@ -1,0 +1,88 @@
+/**
+ * `segmentline` meter renderer (MOR-2149, VFO slice) — the segmented LCD bar
+ * graph.
+ *
+ * READ THE SEAM BEFORE CHANGING THE FIELD NAMES. This renderer is consumed
+ * through `semantic/design-language-renderers.ts`'s `renderSlot('meters',
+ * ...)`, and its one production caller is `semantic/MetersSurface.svelte`'s
+ * `signalDisplay`, which calls it with exactly three fields:
+ *
+ *     { value: 0..1 | null, max: 1, s9: number }
+ *
+ * `value` is already calibrated onto the 0..1 UI scale by `meter-utils`
+ * (`sLevel`), `s9` is the S9 crossover expressed on that SAME scale, and an
+ * unobserved meter passes `value: null` rather than 0 — "not measured" and
+ * "zero signal" are different claims and this renderer must keep them apart.
+ *
+ * WHAT ACTUALLY REACHES THE DOM. `renderSlot` annotates only TOP-LEVEL
+ * PRIMITIVES onto the element as `data-dl-<kebab>`; nested objects and arrays
+ * are skipped, so every field below is flat on purpose. `segmentline.css`'s
+ * `[data-dl-unknown='true']`/`[data-dl-hot='true']` rules are what draw from
+ * `unknown`/`hot`.
+ *
+ * It does not draw, animate, or smooth. Ballistics belong to the shipped
+ * gauge components (`LinearSMeter`/`BarGauge` via `utils/smoothing.svelte`),
+ * which already snap rather than animate under prefers-reduced-motion; a
+ * second loop here would be an unaudited one.
+ */
+import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+
+/** Above this fraction of full scale the family marks the track hot. */
+export const HOT_THRESHOLD = 0.8;
+
+export interface SegmentlineMeter {
+  readonly kind: 'segmentline-meter';
+  /** Fill as a fraction of the track, or 0 when unobserved (see `unknown`). */
+  readonly fillFraction: number;
+  /** Where the two-tone handover sits, as a fraction of the track. */
+  readonly s9Fraction: number;
+  /** True when the reading was never observed — CSS renders an empty track
+   *  plus the unknown mark, never a gauge resting at zero. */
+  readonly unknown: boolean;
+  readonly hot: boolean;
+  /** Segment pitch, straight off the tokens, so the CSS gradient and the
+   *  language declaration can never disagree about what a segment is. */
+  readonly segmentWidthPx: number;
+  readonly segmentGapPx: number;
+}
+
+const finite = (fields: RendererViewModel['fields'], key: string): number | null => {
+  const value = fields[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+};
+
+export function renderMeter(
+  viewModel: RendererViewModel, tokens: DesignLanguageTokens,
+): SegmentlineMeter {
+  // No fallback: `tokens` is always a real, valid `DesignLanguageTokens` —
+  // this renderer is reachable only through `segmentline`'s own manifest
+  // (`resolveRenderer`/`invokeRenderer`, `../contract.ts`), which always
+  // supplies `SEGMENTLINE_TOKENS`. A silent fallback here would be dead code
+  // ("reachable errors only") and would let the token read stop being
+  // load-bearing without any test noticing.
+  const segmentWidthPx = Number.parseFloat(tokens.meters.trackWidth);
+  const segmentGapPx = Number.parseFloat(tokens.meters.segmentGap);
+
+  const value = finite(viewModel.fields, 'value');
+  const max = finite(viewModel.fields, 'max') ?? 1;
+  const s9 = finite(viewModel.fields, 's9');
+  const s9Fraction = s9 !== null && max > 0 ? Math.min(1, Math.max(0, s9 / max)) : 0;
+
+  if (value === null || max <= 0) {
+    return {
+      kind: 'segmentline-meter', fillFraction: 0, s9Fraction,
+      unknown: true, hot: false, segmentWidthPx, segmentGapPx,
+    };
+  }
+
+  const fillFraction = Math.min(1, Math.max(0, value / max));
+  return {
+    kind: 'segmentline-meter',
+    fillFraction,
+    s9Fraction,
+    unknown: false,
+    hot: fillFraction >= HOT_THRESHOLD,
+    segmentWidthPx,
+    segmentGapPx,
+  };
+}

--- a/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
@@ -1,0 +1,136 @@
+/**
+ * `segmentline` TX renderer (MOR-2149, TX slice) — how the glass says
+ * RX / TX / TUNE: the PERIMETER, not a field wash or a carrier rail. A hot
+ * bezel tone plus an inward glow; the data area stays untouched, which is
+ * what distinguishes this family's carrier from studioline's top rail and
+ * fieldline's flooding left rail.
+ *
+ * SAFETY INVARIANT R9, identical to the two sibling renderers. This renderer
+ * DISPLAYS the App TX authority's conclusions; it never forms its own. The
+ * only fields it reads are `rf` and `session` — the outputs of
+ * `semantic/rx-tx-surface.ts`'s `rfState()`/`txSessionState()`, themselves
+ * derived from the App-owned `TxAuthoritySnapshot` — plus `fault` and
+ * `keyBlocked`. It never reads a raw `ptt`. The fail-closed DECISION over
+ * those four fields is `resolveTxFeedbackState` (MOR-2031,
+ * `presentation/languages/tx-feedback-state.ts`), shared with studioline and
+ * fieldline; only the RAIL_TABLE below — segmentline's own lit/label per
+ * bucket — belongs to this family.
+ *
+ * INPUT CORRECTION. The real call site, `semantic/RxTxSurface.svelte`'s
+ * `stateFeedback` derived value, calls exactly
+ * `renderSlot('stateFeedback', { rf, session, fault: tx.fault, keyBlocked:
+ * blocked.length > 0 })` — the same four fields studioline/fieldline read.
+ * An earlier draft of this file instead read `channel`/`phase`/`treatment`
+ * fields directly off `viewModel.fields`; `RxTxSurface.svelte` never supplies
+ * any of the three, so that version would have rendered every state as the
+ * `channel==='rx'`/`phase==='idle'` default regardless of the real TX state —
+ * exactly the "nothing is happening" failure R9 exists to prevent. This
+ * version reads the same canonical fields the two sibling renderers do.
+ *
+ * WHAT ACTUALLY REACHES THE DOM. `renderSlot` annotates only TOP-LEVEL
+ * PRIMITIVES; `kind`, `numeralTone`, `meterScaleLabel` and `micro` (when
+ * non-null) are that surface. `micro` mirrors studioline's own top-level
+ * field, not fieldline's (whose fault text lives in nested `band.text`) —
+ * but the resulting three-vs-four attribute count differs from fieldline in
+ * only 1 of the 6 rail buckets (`failed` with a fault code), not generally.
+ * `perimeter` and `cell` are private structure, the same role `groups`
+ * plays for the frequency renderer — no stylesheet rule in this repo reads
+ * either through `renderSlot`'s `data-dl-*` mechanism.
+ */
+import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+import {
+  resolveTxFeedbackState, stringField, type TxFeedbackRail, type TxKeyTreatment,
+} from '../tx-feedback-state';
+import { SEGMENTLINE_INK, SEGMENTLINE_PALETTE } from './tokens';
+
+/** Matches `.dl-glass[data-tx='active']::after`'s box-shadow in `segmentline.css` exactly. */
+const FRAME_GLOW = 'inset 0 0 38px 2px rgba(214, 28, 8, 0.46), inset 0 0 11px rgba(255, 80, 40, 0.55)';
+
+export interface SegmentlinePerimeter {
+  /** Every non-idle rail bucket lights the perimeter; idle stays quiet. */
+  readonly lit: boolean;
+  readonly label: string | null;
+  readonly tone: string;
+  /** Empty string when not lit — never a partial glow. */
+  readonly insetShadow: string;
+  readonly transition: string;
+}
+
+export interface SegmentlineCell {
+  readonly treatment: TxKeyTreatment;
+  /** Denied/unknown permit renders inert-but-present — a hidden PTT reads as "no TX capability". */
+  readonly present: true;
+  /** Segmentline never fills a control (`tokens.ts`: "every control is an
+   *  outlined cell, never a filled button") — engagement is carried by ink
+   *  strength alone, via `segmentline.css`'s `[data-active='true']`. */
+  readonly active: boolean;
+  readonly tone: string;
+  readonly focusRing: string;
+}
+
+export interface SegmentlineStateFeedback {
+  readonly kind: 'segmentline-state-feedback';
+  readonly numeralTone: 'primary' | 'tx-target';
+  readonly meterScaleLabel: 'S' | 'PO';
+  readonly micro: string | null;
+  readonly perimeter: SegmentlinePerimeter;
+  readonly cell: SegmentlineCell;
+}
+
+/**
+ * segmentline's own lit/label per rail bucket — the bucket itself comes from
+ * `resolveTxFeedbackState`; only this table, and the choice to carry state on
+ * the perimeter rather than a rail or a band, belongs to segmentline. `null`
+ * label at `idle` is the RX baseline — the only silent state.
+ */
+const RAIL_TABLE: Record<TxFeedbackRail, { readonly lit: boolean; readonly label: string | null }> = {
+  idle: { lit: false, label: null },
+  pending: { lit: true, label: 'KEYING' },
+  keyed: { lit: true, label: 'TX' },
+  releasing: { lit: true, label: 'UNKEYING' },
+  failed: { lit: true, label: 'TX FAULT' },
+  doubt: { lit: true, label: 'TX?' },
+};
+
+export function renderStateFeedback(
+  viewModel: RendererViewModel, tokens: DesignLanguageTokens,
+): SegmentlineStateFeedback {
+  const resolved = resolveTxFeedbackState({
+    rf: stringField(viewModel.fields, 'rf'),
+    session: stringField(viewModel.fields, 'session'),
+    fault: stringField(viewModel.fields, 'fault'),
+    keyBlocked: viewModel.fields.keyBlocked === true,
+  });
+  const { treatment, keyed, faultText } = resolved;
+  const rail = RAIL_TABLE[resolved.rail];
+  const tone = resolved.tone === 'rx-idle' ? tokens.rx.idle
+    : resolved.tone === 'tx-active' ? tokens.tx.active
+      : tokens.tx.tuning;
+
+  return {
+    kind: 'segmentline-state-feedback',
+    numeralTone: keyed ? 'tx-target' : 'primary',
+    // The meter re-zones with the transmitter, not with the request to key.
+    meterScaleLabel: keyed ? 'PO' : 'S',
+    micro: faultText,
+    perimeter: {
+      lit: rail.lit,
+      label: rail.label,
+      tone,
+      insetShadow: rail.lit ? FRAME_GLOW : '',
+      transition: `border-color ${tokens.motion.durationMs}ms linear, box-shadow ${tokens.motion.durationMs}ms linear`,
+    },
+    cell: {
+      treatment,
+      present: true,
+      active: treatment === 'keyed',
+      // Same hot+active CONCEPT as segmentline.css's `.dl-cell[data-tone=
+      // 'hot'][data-active='true']` rule — but `tone` holds a colour value
+      // here, not the keyword 'hot'; no rule currently reads this field.
+      tone: treatment === 'blocked' ? SEGMENTLINE_INK.ghost
+        : treatment === 'keyed' ? SEGMENTLINE_PALETTE.txMark
+          : SEGMENTLINE_INK.soft,
+      focusRing: tokens.focusRing,
+    },
+  };
+}

--- a/frontend/src/presentation/languages/segmentline/tokens.ts
+++ b/frontend/src/presentation/languages/segmentline/tokens.ts
@@ -8,10 +8,7 @@
  * family name.
  *
  * Contract instance only. Declares no renderer, imports no runtime, store,
- * transport or radio code. Renderers are MOR-2149's job: the manifest that
- * registers this token set (`../declarations.ts`) ships `renderers: {}`
- * until then, which `resolveRenderer` (`../contract.ts`) falls back on
- * safely — no renderer slot is filled yet.
+ * transport or radio code.
  */
 import type { DesignLanguageTokens } from '../contract';
 


### PR DESCRIPTION
Adds the three `segmentline` renderers — frequency, meters, state feedback —
completing the family registered by MOR-2148. `declarations.ts` swaps the
empty `renderers: {}` placeholder for the real map.

Source is the externally authored handoff archived outside git. Two defects in
it were found by running rather than reading, and are fixed here:

- The state-feedback renderer read field names nobody passes (`channel`,
  `phase`, `treatment`) instead of the real `{rf, session, fault, keyBlocked}`.
  Left alone it would have rendered a constant not-transmitting state
  throughout transmit. It now calls the shared `resolveTxFeedbackState`
  (MOR-2031). An independent review confirmed the fix by reinstating the
  defect: 15 rows red, including the one named for it.
- `renderMeter` read the segment pitch through a fallback equal to the token's
  own value, so the test named for reading pitch off tokens compared a
  constant against an equal constant. The fallback is deleted and the
  assertion now runs against a different token set (11px/5px). Reinstating the
  fallback reddens exactly the new assertion and leaves the pre-existing
  sibling green — which measures the claim rather than asserting it.

## Corrections to this body after review

Three statements in its first version were false and are removed rather than
softened:

- It said `semantic/__tests__/tx-feedback-state.isolated.test.ts` pins the
  shared-resolver call **per family including segmentline**. It does not. Its
  three `vi.spyOn` rows cover `thirdline` (a synthetic in-file family),
  `fieldline` and `studioline`. That file is not in this diff, and segmentline
  is not pinned there. The review established this by reading the file; I had
  inferred it from the row names.
- It said four files are "the registration and the token additions those
  renderers consume". **No tokens were added** — `segmentline/tokens.ts`
  changes by -4/+1, entirely docstring.
- It described the meter fallback with a specific expression and helper name
  carried over from my reading of the handoff. That helper does not exist at
  base or head, so the claim was unverifiable from this repository. The
  behavioural description above is what the mutation actually established.

## Known limitation, not fixed here

`segmentline` cannot be activated in production. `presentation/workspace/
contract.ts` declares `WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline',
'fieldline']`, and an unrecognised id falls back to `'studioline'`. So an
operator selecting `peer-split` today gets studioline's renderers, not these.
The fixture harness sets the attribute directly, which is why the family is
observable there. Adding segmentline to that allowlist is its own change with
its own persisted-preference consequences; it is not folded in here.

## Also known, reported by the review, not fixed

A comment in `frequency-renderer.test.ts` claims a one-unit change to any of
four constants moves the measured total detectably. Measured false for
`HZ_GROUP_RATIO`: 0.62 → 0.63 leaves the file green, because
`Math.round(56*0.62)` and `Math.round(56*0.63)` are both 35. It is in the
diff and lands with it, under the owner's 2026-09-01 ruling that prose does
not warrant a further review round.

VERIFICATION. `npx vitest run src/presentation/languages src/semantic` on this
branch alone: exit 0, 64 files, 1955 tests — independently reproduced by the
review. `npm run check` exit 0, eslint exit 0. The review's control mutation
(`HOT_THRESHOLD` 0.8 → 0.7) exited 1 before any green reading was trusted, and
a behaviour-preserving refactor stayed green.

GUARDRAILS. 10 files, 983 changed lines — inside the 10-file / 1000-line hard
ceiling on both axes, with no exception invoked. The 6-file / 600-line soft
threshold is crossed on both axes; this is one unit of work because six of the
ten files are the three renderers with their three test suites, and the
remaining four are the registration and its inventory tests.

An owner ceiling exception was granted on 2026-09-01 and is deliberately NOT
used. It was weighed against folding a helper extraction in here at 11 files;
measurement showed that extraction touches two sibling renderers outside these
ten, making it 13. The extraction ships separately.
