### PR TITLE
feat(MOR-2151): register the peer-split layout manifest

### DIFF
--- a/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
@@ -25,7 +25,7 @@ import {
 // sibling files (the MOR-1092 lesson, restated on MOR-1067).
 import {
   desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
+  peerSplitLayout, sdrTestLayout,
 } from '../declarations';
 // Namespace import of the SAME barrel, used ONLY to derive the F8
 // completeness set structurally (MOR-2074) — never to register anything (a
@@ -128,7 +128,7 @@ describe('F8 — every registered layout manifest names a loadable skin', () => 
   // manifest, not just the ones that existed when F8 was written.
   const REAL_LAYOUTS: readonly LayoutManifest[] = [
     sdrTestLayout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-    desktopV2Layout,
+    desktopV2Layout, peerSplitLayout,
   ];
 
   // MOR-2074: REAL_LAYOUTS above is a hand-list, so a new manifest exported

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -64,6 +64,7 @@ const radioLayoutSource = readFileSync('src/components-v2/layout/RadioLayout.sve
 const lcdLayoutSource = readFileSync('src/components-v2/layout/LcdLayout.svelte', 'utf8');
 const mobileLayoutSource = readFileSync('src/components-v2/layout/MobileRadioLayout.svelte', 'utf8');
 const cockpitShellSource = readFileSync('src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte', 'utf8');
+const peerSplitShellSource = readFileSync('src/skins/segmentline/PeerSplitLayout.svelte', 'utf8');
 
 /**
  * MOR-1313. `sdr-test` and `desktop-v2` share the one shell whose semantic
@@ -86,9 +87,10 @@ const sharedShellMounts = (manifest: LayoutManifest): boolean =>
 
 /**
  * Per-manifest DOM-backing proof, read off the ACTUAL skin source — never a
- * hardcoded boolean. The four dedicated shells each mount
- * `SemanticRadioSurfaces` outright (verified unconditional — not wrapped in any
- * `{#if}` — by direct reading, MOR-1266 pin round).
+ * hardcoded boolean. Five dedicated shells each mount `SemanticRadioSurfaces`
+ * outright (verified unconditional — not wrapped in any `{#if}` — by direct
+ * reading: the original four in the MOR-1266 pin round, `peer-split` here in
+ * MOR-2151).
  */
 const DOM_BACKED: Readonly<Record<string, () => boolean>> = {
   'sdr-test': () => sharedShellMounts(sdrTestLayout),
@@ -97,6 +99,10 @@ const DOM_BACKED: Readonly<Record<string, () => boolean>> = {
   'lcd-scope': () => /<SemanticRadioSurfaces\s*\/>/.test(lcdLayoutSource),
   'mobile': () => /<SemanticRadioSurfaces\s*\/>/.test(mobileLayoutSource),
   'dual-receiver-cockpit': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(cockpitShellSource),
+  // MOR-2151: PeerSplitLayout.svelte (MOR-2155) mounts the same
+  // `strips="dual"` composition unconditionally, the identical shape
+  // `dual-receiver-cockpit` above proves DOM-backed with.
+  'peer-split': () => /<SemanticRadioSurfaces strips="dual"\s*\/>/.test(peerSplitShellSource),
 };
 
 describe('forward-declared vs DOM-backed manifest inventory (verify.md N2)', () => {

--- a/frontend/src/presentation/layouts/__tests__/loader-identity-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/loader-identity-inventory.test.ts
@@ -51,7 +51,7 @@ import { getLayout, type LayoutManifest } from '../contract';
 // `isolate: false`, would leak the registration into sibling files.
 import {
   desktopV2Layout, dualReceiverCockpitLayout, lcdCockpitLayout, lcdScopeLayout, mobileLayout,
-  sdrTestLayout,
+  peerSplitLayout, sdrTestLayout,
 } from '../declarations';
 // Namespace import of the SAME barrel, used ONLY to derive the completeness
 // set structurally (never to register anything — a namespace import has no
@@ -75,6 +75,7 @@ const ALL_MANIFESTS = {
   'lcd-scope': lcdScopeLayout,
   mobile: mobileLayout,
   'desktop-v2': desktopV2Layout,
+  'peer-split': peerSplitLayout,
 } as const;
 
 /**
@@ -93,6 +94,7 @@ const EXPECTED_LOADER_SPECIFIER: Readonly<Record<keyof typeof ALL_MANIFESTS, str
   'lcd-scope': '/src/skins/lcd-scope/LcdScopeSkin.svelte',
   mobile: '/src/skins/mobile/MobileSkin.svelte',
   'desktop-v2': '/src/skins/desktop-v2/DesktopSkin.svelte',
+  'peer-split': '/src/skins/segmentline/PeerSplitLayout.svelte',
 };
 
 /** Pulls the quoted argument out of a stringified `() => import('...')`

--- a/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * MOR-2151 — the `peer-split` presentation entrypoint, registered as a v1
+ * layout manifest (MOR-1066) and resolved through the REAL registry, not a
+ * fixture registry and not a stub loader.
+ *
+ * Mirrors `sdr-registration.test.ts` (MOR-1093)'s shape for a single
+ * manifest with no sibling family: topology honesty, the sizing axis, and
+ * — because this slice ships one minimal zone, not the finished
+ * composition — that the declared zone is exactly `vfo`+`rxTx`. Every claim
+ * is read back out of the shared registry rather than off the exported
+ * object, so a manifest that is written but never registered fails here.
+ * Each test's doc line names the mutation it exists to kill.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
+  TOPOLOGY_CLASSES,
+} from '../contract';
+// Deliberately through the shared aggregation entry, not `../segmentline-
+// declarations` directly: it pins that `declarations.ts` really registers
+// `peerSplitLayout` (nothing else does), and keeps this fast-pool file on
+// the SAME module entry point as `registry.test.ts` — under `isolate: false`
+// a second entry into a module that registers at import time is how a split
+// module graph (and a phantom "layout not registered") happens. See
+// vite.config.ts #771 and `sdr-registration.test.ts`'s identical note.
+import { peerSplitLayout } from '../declarations';
+// MOR-2151 review round: a new zone id has no guard of its own in this
+// ticket's files — it was caught only by `workspace/__tests__/contract.
+// test.ts`'s cross-file derivation (`WORKSPACE_ZONE_IDS` must equal the set
+// of every zone id every registered layout manifest declares), a file
+// nothing here otherwise touches. Imported for a read-only assertion below,
+// turning that cross-file accident into a local pin.
+import { WORKSPACE_ZONE_IDS } from '../../workspace/contract';
+
+describe('the peer-split entrypoint is registered in the real registry', () => {
+  // Kills: segmentline-declarations.ts defining the manifest but never
+  // calling registerLayout — the resolution below would then read undefined.
+  it('registers "peer-split" under its stable entrypoint id', () => {
+    expect(getLayout('peer-split')).toBe(peerSplitLayout);
+    expect(peerSplitLayout.id).toBe('peer-split');
+  });
+
+  // Kills: a manifest id that drifts from the SkinId PeerSplitLayout.svelte
+  // actually loads under. The manifest is only an entrypoint declaration if
+  // the two agree.
+  it('shares its id with the skin registry loader PeerSplitLayout.svelte resolves under', () => {
+    const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
+    expect(registrySource).toMatch(/'peer-split':\s*\(\)\s*=>\s*import\(['"]\.\/segmentline\/PeerSplitLayout\.svelte['"]\)/);
+  });
+
+  // Kills: a manifest that declares no compiled loader at all.
+  it('declares a compiled loader', () => {
+    expect(typeof peerSplitLayout.loader).toBe('function');
+  });
+});
+
+describe('declared semantic zones (minimal registration — MOR-2151)', () => {
+  // Kills: declaring a surface the layout does not mount, dropping rxTx, or
+  // shipping the archived draft's richer zone set (ten zones, three of them
+  // all naming `vfo` alone) instead of this slice's single minimal zone.
+  it('mounts vfo + rxTx in exactly one zone, under the stable `peer-columns` id', () => {
+    expect(peerSplitLayout.zones).toEqual([{ id: 'peer-columns', surfaces: ['vfo', 'rxTx'] }]);
+    expect([...peerSplitLayout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
+  });
+
+  // Kills: introducing a new zone id here without also registering it in
+  // `WORKSPACE_ZONE_IDS` (`presentation/workspace/contract.ts`) — the
+  // omission this review round found live. That file's own
+  // `zone ids are exactly the zones every registered layout manifest
+  // declares` test would still catch the drift, but only after this
+  // manifest is already registered into the shared registry; this pins it
+  // locally too.
+  it('declares its zone id in the workspace zone-id registry', () => {
+    for (const zone of peerSplitLayout.zones) {
+      expect(WORKSPACE_ZONE_IDS as readonly string[]).toContain(zone.id);
+    }
+  });
+});
+
+describe('topology honesty', () => {
+  // Kills: widening compatibleTopologies to a single-receiver pair — the
+  // dual composition PeerSplitLayout.svelte mounts has nothing to put in a
+  // second column for those.
+  it('resolves itself on the two dual-receiver topologies', () => {
+    expect(resolveLayoutForTopology('peer-split', '2/ab_shared')?.id).toBe('peer-split');
+    expect(resolveLayoutForTopology('peer-split', '2/main_sub')?.id).toBe('peer-split');
+  });
+
+  // Kills: narrowing away from a single-receiver pair's declared fallback —
+  // resolution would return undefined and a single-receiver radio would get
+  // no layout at all from this entrypoint.
+  it('falls back to lcd-cockpit on the two single-receiver topologies', () => {
+    expect(resolveLayoutForTopology('peer-split', '1/single')?.id).toBe('lcd-cockpit');
+    expect(resolveLayoutForTopology('peer-split', '1/ab')?.id).toBe('lcd-cockpit');
+  });
+
+  it('leaves no canonical topology unresolvable', () => {
+    for (const topology of TOPOLOGY_CLASSES) {
+      expect(resolveLayoutForTopology('peer-split', topology)).toBeDefined();
+    }
+  });
+});
+
+describe('sizing axis — peer-split shares the LCD family\'s fixed-native glass', () => {
+  // Kills: drifting off the 1280x540/0.5 stage `docs/plans/2026-09-01-
+  // segmentline-peer-split.md` §9 declares for this family.
+  it('declares the frozen fixed-native stage', () => {
+    expect(peerSplitLayout.stageSizing).toEqual({
+      mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
+    });
+  });
+
+  it('resolves on a desktop viewport', () => {
+    expect(resolveLayoutForViewport('peer-split', { width: 1440, height: 900 })?.id).toBe('peer-split');
+  });
+
+  // Kills: minScale set to 0 (or the mode flipped to fluid), which would let
+  // a fixed-native peer-split resolve on portrait mobile.
+  it('is excluded from portrait mobile arithmetically', () => {
+    expect(resolveLayoutForViewport('peer-split', { width: 390, height: 844 })).toBeUndefined();
+  });
+});
+
+describe('fallback to lcd-cockpit (MOR-2151 correction — the archived draft named unified-instrument)', () => {
+  // Kills: reverting to the archived draft's fallbackLayoutId, which names a
+  // layout this slice does not build.
+  it('declares lcd-cockpit as its one fallback hop', () => {
+    expect(peerSplitLayout.fallbackLayoutId).toBe('lcd-cockpit');
+    expect(getLayout(peerSplitLayout.fallbackLayoutId!)).toBeDefined();
+  });
+
+  // Kills: returning the fallback without re-applying the criterion — both
+  // layouts share the same native stage, so a viewport that fails peer-split
+  // fails lcd-cockpit too; resolution must report "unresolvable", not hand
+  // back a sibling that fails the same gate.
+  it('does not hand back lcd-cockpit for a viewport that fails it too', () => {
+    expect(resolveLayoutForViewport('peer-split', { width: 390, height: 844 })).toBeUndefined();
+  });
+});

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -48,3 +48,9 @@ export { mobileLayout } from './mobile-declarations';
 // a real binding to assert against (the M7 lesson — a bare side-effect
 // import would let this line be dropped without any test noticing).
 export { desktopV2Layout } from './desktop-declarations';
+// MOR-2151 registration — see that file. Re-exported for the same reason as
+// the other family imports above: this barrel is the ONLY thing that wires
+// peer-split's manifest into the app, and a named re-export gives every test
+// a real binding to assert against, so dropping this line cannot pass
+// unnoticed.
+export { peerSplitLayout } from './segmentline-declarations';

--- a/frontend/src/presentation/layouts/segmentline-declarations.ts
+++ b/frontend/src/presentation/layouts/segmentline-declarations.ts
@@ -1,0 +1,63 @@
+/**
+ * MOR-2151 — `peer-split` as a v1 layout manifest (schema, validator and
+ * registry: `./contract.ts`, MOR-1066). The first of the externally
+ * authored `segmentline` amber-glass directions to land; the other two
+ * (`unified-instrument`, `panadapter-first`) are excluded from this slice —
+ * see `docs/plans/2026-09-01-segmentline-peer-split.md` §3.1/§8.
+ *
+ * The FTX-1 has two genuinely different receivers (MAIN: HF, SUB: separate
+ * VHF/UHF) — not a VFO A/B swap. `peer-split` is the direction that says
+ * that about the radio: two equal columns, symmetry first.
+ *
+ * This is a minimal registration, not the finished composition. It declares
+ * exactly one zone (`vfo` + `rxTx`), the same shape `sdr-test` calls `main`
+ * and the LCD family calls `control-column` — deliberately, per the spec's
+ * delivery order (§7): the twelve OPTIONAL semantic surfaces each have a
+ * hand-listed `*-declarability.test.ts` inventory that a new declaring
+ * manifest must be added to by hand; `vfo`/`rxTx` have no such file. The
+ * richer zone set (the rails now mountable in the dual composition since
+ * MOR-2150) is deferred to a later PR, per the same spec.
+ *
+ * The archived handoff's `peerSplitLayout` draft (never executed by its
+ * author) needed three corrections:
+ *   1. `fallbackLayoutId` named `unified-instrument`, which is not being
+ *      built in this slice — retargeted to `lcd-cockpit`, where the
+ *      persisted amber preference already routes.
+ *   2. The draft's `dsp-rail`/`front-end-rail`/`offsets`/`band-rail` zone
+ *      ids did not match this repo's stable-id convention
+ *      (`dsp`/`rf-front-end`/`rit-xit-scan`/`band`) — moot here, since none
+ *      of those zones are declared in this minimal slice.
+ *   3. The draft's ten zones (three of them all carrying `vfo` alone) are
+ *      collapsed to the one minimal zone below.
+ */
+import { registerLayout, type LayoutManifest } from './contract';
+
+/**
+ * The `segmentline` family's canonical glass, matching the LCD family's own
+ * `LCD_NATIVE_STAGE` (`lcd-declarations.ts`) — same 1280x540 native size and
+ * 0.5 `minScale`, per `docs/plans/2026-09-01-segmentline-peer-split.md` §9.
+ */
+const SEGMENTLINE_GLASS_STAGE = {
+  mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
+} as const;
+
+export const peerSplitLayout: LayoutManifest = {
+  schemaVersion: 1,
+  id: 'peer-split',
+  displayName: 'Peer Split',
+  loader: () => import('../../skins/segmentline/PeerSplitLayout.svelte'),
+  // One zone: `vfo` + `rxTx`, mounted by `PeerSplitLayout.svelte`'s
+  // `<SemanticRadioSurfaces strips="dual" />` (MOR-2155). The dual
+  // composition hardcodes its own `primary-vfo`/`secondary-vfo`/`global`/
+  // `rx-tx` DOM zone ids regardless of what a manifest declares here (spec
+  // §4) — this id is a manifest-level label, not a DOM binding.
+  zones: [{ id: 'peer-columns', surfaces: ['vfo', 'rxTx'] }],
+  // FTX-1's `2/ab_shared` topology is one of these two; a single-receiver
+  // radio has nothing to put in a second column (spec §2).
+  compatibleTopologies: ['2/ab_shared', '2/main_sub'],
+  requiredSemanticSurfaces: ['vfo', 'rxTx'],
+  stageSizing: SEGMENTLINE_GLASS_STAGE,
+  fallbackLayoutId: 'lcd-cockpit',
+};
+
+registerLayout(peerSplitLayout);

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -50,7 +50,7 @@ export const WORKSPACE_THEME_IDS = [
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
 /** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'scope-controls'] as const;
+export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'scope-controls', 'peer-columns'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
Registers the `peer-split` layout manifest — the two-equal-columns layout for
a radio with two independent receivers, which is what FTX-1 is (HF and
UHF/VHF).

The manifest declares one zone, `peer-columns`, mounting `vfo` and `rxTx`.
After MOR-2150 the dual composition renders nine of the twelve other surfaces
only through a declared zone (`allowBare=false`), so this manifest mounts none
of those nine. The dual composition's own hardcoded zones and the three
default-bare surfaces (`txAux`, `meters`, `scopeDisplay`) are unchanged and
still render. The remaining zones arrive with the layout component in
MOR-2153.

`compatibleTopologies` is `['2/ab_shared', '2/main_sub']` and
`fallbackLayoutId` is `lcd-cockpit`, an id that exists today.

Three defects in the authored handoff are fixed here rather than carried:
two of its three manifests failed `validateLayoutManifest` outright; the
handoff's `peer-split` declared four zones the dual composition had no way to
mount; and `fallbackLayoutId` named a layout that is not being built.

ORDERING. This must merge before MOR-2152. The `WORKSPACE_ZONE_IDS` row in
`presentation/workspace/contract.ts` lands here, and MOR-2152 builds on it —
an independent reviewer built each alone on `main` and found mirror-image
failures when the row sat in the other one.

## Corrections to this body after review

Three statements in its first version were wrong and are replaced with what
was measured, not softened:

- It said "a manifest that declares nothing mounts nothing". **False.** The
  reviewer mounted the dual composition with peer-split's real resolved plan:
  the DOM carries `primary-vfo`, `secondary-vfo`, `global` and `rx-tx`, two
  channel strips, and `txAux` and `scopeDisplay` rendering bare. Only the nine
  `allowBare=false` surfaces are absent. The corrected sentence is above.
- It said the single zone is "the minimum that `validateLayoutManifest`
  accepts". **Not established.** The validator has no `vfo`-specific rule; it
  requires each `requiredSemanticSurfaces` entry to be mounted by some zone.
  A mutation reducing the manifest to a single `['vfo']` zone raised no
  `LayoutValidationError` at all — a strictly smaller manifest validates.
- It said the one pre-existing test failure "passes when run alone — it is
  order-sensitive". **Refuted.** Run alone it still fails on both sides:
  base `37323cb0` 26.7 s, base warm 24.2 s, head 32.5 s, against the test's
  own 15 s budget. It is a machine-speed-dependent timeout on a real Vite
  preflight. I inferred ordering from a single alone-run that happened to
  pass; the mechanism is different.
- Minor: the guardrail note enumerated three files while claiming four. The
  fourth is `presentation/workspace/contract.ts`.

## Carried forward to MOR-2153, not a defect here

`dual-receiver-cockpit.ts` declares a `tx-aux` zone; this manifest does not.
So under peer-split's plan `tx-aux-surface` renders bare, outside every
declared zone and after `rx-tx` in tab order — the shape MOR-1069 forbids.
Whichever change makes `peer-split` render for real must declare a `tx-aux`
zone or pass `allowBare={false}`. It is inert today because `resolveSkinId`
has no `peer-split` branch, so no operator reaches this DOM.

VERIFICATION. `npx vitest run src/presentation src/skins src/semantic
src/components-v2`, identical command and scope both sides, exit codes read
directly: head 1 failed / 4984 passed, base `37323cb0` 1 failed / 4956 passed.
Same file, same error. The review ran 17 control mutations, all red, including
dropping the new row from each of the four hand-maintained inventory lists —
every one is guarded by a derived completeness check. It also proved the
tripwire instrument: appending `stageSizing fitsViewport` to
`workspace/contract.ts` made `stage-sizing-boundary.test.ts` exit 1 and name
that file.

GUARDRAILS. 7 files, 231 changed lines. Inside the hard ceiling on both axes.
The 6-file soft threshold is crossed by one file; this is one unit of work
because four of the seven are the manifest, its test suite, the declarations
barrel and the `WORKSPACE_ZONE_IDS` row, and the other three are inventory
tests that enumerate every registered layout and therefore change whenever one
is added.
