### PR TITLE
feat(MOR-2152): make peer-split selectable by the operator

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -110,6 +110,7 @@
     { value: 'standard', label: 'Standard' },
     { value: 'lcd-cockpit', label: 'LCD Cockpit' },
     { value: 'lcd-scope', label: 'LCD Scope' },
+    { value: 'peer-split', label: 'Peer Split' },
     { value: 'sdr-test', label: 'SDR Screen (test)' },
   ];
 

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.skin-options.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.skin-options.test.ts
@@ -28,4 +28,16 @@ describe('StatusBar skinOptions (MOR-1257 F1)', () => {
     const source = readFileSync('src/components-v2/layout/StatusBar.svelte', 'utf8');
     expect(source).toMatch(/const skinOptions:\s*Array<\{\s*value:\s*CanonicalLayoutMode;/);
   });
+
+  // MOR-2152 — `skinOptions` is a plain array with no compile-time guard tying
+  // its membership to `CANONICAL_LAYOUT_MODES`: unlike the `contract.ts`
+  // sync pins (which fail `npm run check` on a missing key), an omitted skin
+  // here compiles cleanly and just leaves the id unreachable through the
+  // picker. This is that missing guard for `peer-split`.
+  it('lists peer-split with a Peer Split label', () => {
+    const source = readFileSync('src/components-v2/layout/StatusBar.svelte', 'utf8');
+    const match = source.match(/const skinOptions[^=]*=\s*\[([\s\S]*?)\n\s*\];/);
+    expect(match, 'expected to find the skinOptions array literal').not.toBeNull();
+    expect(match![1]).toMatch(/\{\s*value:\s*'peer-split',\s*label:\s*'Peer Split'\s*\}/);
+  });
 });

--- a/frontend/src/presentation/layout-mode.ts
+++ b/frontend/src/presentation/layout-mode.ts
@@ -12,6 +12,9 @@
  * 'lcd-cockpit' = force LCD cockpit (TS-990S-style dual-cockpit)
  * 'lcd-scope'   = force LCD scope (IC-7300-style scope-dominant)
  * 'standard'    = force standard layout
+ * 'peer-split'  = force the segmentline peer-split skin (MOR-2151/MOR-2155;
+ *                 two-column FTX-1 dual-receiver symmetry, see
+ *                 `skins/segmentline/PeerSplitLayout.svelte`)
  * 'dual-receiver-cockpit' = QA-ONLY (MOR-1257): reachable solely via the
  *                 exact `?layout=dual-receiver-cockpit` query param (see
  *                 `lib/stores/qa-cockpit-override.ts`) — deliberately NOT a
@@ -22,7 +25,7 @@
  */
 export type LayoutMode =
   | 'auto' | 'lcd' | 'lcd-cockpit' | 'lcd-scope' | 'standard' | 'sdr-test'
-  | 'dual-receiver-cockpit';
+  | 'peer-split' | 'dual-receiver-cockpit';
 export type CanonicalLayoutMode = Exclude<LayoutMode, 'lcd' | 'dual-receiver-cockpit'>;
 
 export const CANONICAL_LAYOUT_MODES = new Set<CanonicalLayoutMode>([
@@ -31,6 +34,7 @@ export const CANONICAL_LAYOUT_MODES = new Set<CanonicalLayoutMode>([
   'lcd-scope',
   'standard',
   'sdr-test',
+  'peer-split',
 ]);
 
 export const LEGACY_LAYOUT_ALIASES: Record<string, CanonicalLayoutMode> = {

--- a/frontend/src/presentation/workspace/__tests__/contract.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/contract.test.ts
@@ -229,6 +229,12 @@ describe('decision 1 — `auto` is first class and resolution is deferred', () =
     }
   });
 
+  // MOR-2152: peer-split's manifest id matches the exact string, not merely
+  // "is a string" (the generic loop above would pass on any typo'd value).
+  it('bridges peer-split to its own manifest id', () => {
+    expect(workspaceLayoutManifestId('peer-split')).toBe('peer-split');
+  });
+
   it('normalizes a legacy alias on read instead of rejecting it', () => {
     const result = readWorkspace({ ...VALID, layout: 'amber-lcd' });
     expect(result.workspace.layout).toBe('lcd-cockpit');

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -30,7 +30,7 @@ const LAYOUT_ALIASES: Readonly<Record<string, WorkspaceLayoutId>> = LEGACY_LAYOU
 /** Workspace id space → layout-manifest id space. `auto` is resolved by the existing
  *  `skins/registry.ts::resolveSkinId()` (it needs live scope facts this module must not
  *  see), so it maps to null — "defer", not "unknown". */
-const LAYOUT_MANIFEST_ID: Readonly<Record<WorkspaceLayoutId, string | null>> = { auto: null, 'lcd-cockpit': 'lcd-cockpit', 'lcd-scope': 'lcd-scope', standard: 'desktop-v2', 'sdr-test': 'sdr-test' };
+const LAYOUT_MANIFEST_ID: Readonly<Record<WorkspaceLayoutId, string | null>> = { auto: null, 'lcd-cockpit': 'lcd-cockpit', 'lcd-scope': 'lcd-scope', standard: 'desktop-v2', 'sdr-test': 'sdr-test', 'peer-split': 'peer-split' };
 
 /** Decision 2: frozen by MOR-977 §4.6. */
 export const WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline', 'fieldline'] as const;

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -69,7 +69,7 @@ const resolve = (overrides: Partial<Parameters<typeof resolveSkinId>[0]> = {}) =
 
 describe('skin registry', () => {
   it('gives mobile precedence over every forced layout preference', () => {
-    for (const layoutPreference of ['auto', 'lcd', 'lcd-cockpit', 'lcd-scope', 'standard', 'sdr-test'] as const) {
+    for (const layoutPreference of ['auto', 'lcd', 'lcd-cockpit', 'lcd-scope', 'standard', 'sdr-test', 'peer-split'] as const) {
       expect(resolve({ isMobile: true, layoutPreference, hasAnyScope: true })).toBe('mobile');
     }
   });
@@ -80,6 +80,9 @@ describe('skin registry', () => {
     ['lcd-cockpit', 'lcd-cockpit'],
     ['lcd-scope', 'lcd-scope'],
     ['sdr-test', 'sdr-test'],
+    // MOR-2152: peer-split becomes a forced, selectable preference — the
+    // resolveSkinId branch this ticket adds.
+    ['peer-split', 'peer-split'],
   ] as const)('resolves forced %s preference to %s', (layoutPreference, skinId) => {
     expect(resolve({ layoutPreference, hasAnyScope: false })).toBe(skinId);
   });

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -38,6 +38,7 @@ export interface SkinResolutionContext {
  * - User forced 'lcd' or 'lcd-cockpit' → lcd-cockpit
  * - User forced 'lcd-scope' → lcd-scope
  * - User forced 'standard' → desktop-v2
+ * - User forced 'peer-split' → peer-split
  * - Auto: use desktop-v2 (the v3 default); explicit LCD choices are the
  *   recoverable compatibility-window opt-out
  */
@@ -55,6 +56,7 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
   if (layoutPreference === 'lcd-cockpit') return 'lcd-cockpit';
   if (layoutPreference === 'lcd-scope') return 'lcd-scope';
   if (layoutPreference === 'standard') return 'desktop-v2';
+  if (layoutPreference === 'peer-split') return 'peer-split';
   // MOR-1097 cutover: every non-mobile auto start uses the reworked
   // desktop-v2 composition. Scope availability remains presentation data, not
   // default-selection policy; explicit LCD preferences stay selectable.
@@ -84,9 +86,9 @@ const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
   'lcd-cockpit': () => import('./lcd-cockpit/LcdCockpitSkin.svelte'),
   'lcd-scope': () => import('./lcd-scope/LcdScopeSkin.svelte'),
   'mobile': () => import('./mobile/MobileSkin.svelte'),
-  // MOR-2155: makes `peer-split` addressable and loadable only — a minimal
-  // shell with no layout manifest (MOR-2151) and no `resolveSkinId` branch
-  // (MOR-2152), same precedent as the `dual-receiver-cockpit` entry above.
+  // MOR-2155 made `peer-split` addressable and loadable; MOR-2152 (see the
+  // `resolveSkinId` branch below) is what makes a forced 'peer-split'
+  // preference actually resolve to it.
   'peer-split': () => import('./segmentline/PeerSplitLayout.svelte'),
   'sdr-test': () => import('./sdr-test/SdrTestSkin.svelte'),
 };


### PR DESCRIPTION
Makes `peer-split` selectable by the operator: it joins the skin options in
the status bar, `layout-mode.ts`, and the skin registry.

MOR-2155 already made `peer-split` a loadable `SkinId` with a minimal shell,
and MOR-2151 registered its layout manifest. This is the step that puts it in
front of a person — before it, the layout existed but nothing could reach it.

Activation matches the resolved `SkinId`, which is why this ordering is
forced rather than incidental: the `layoutCompatibility` entry MOR-2148 wrote
naming `peer-split` cannot activate anything until a `resolveSkinId` branch
returns that id.

DEPENDS ON MOR-2151 (#2960, merged as `5edef508`): the `WORKSPACE_ZONE_IDS`
row this change edits is added there.

## Correction to this body, made before review rather than after

The first version said the one pre-existing test failure
(`components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts`) "passes
when run alone" and is therefore order-sensitive. **That explanation is
refuted** and is removed here rather than left for a reviewer to catch. The
MOR-2151 reviewer timed it alone on both sides: base `37323cb0` 26.7 s, base
warm 24.2 s, head 32.5 s — all against the test's own 15 s budget. It is a
machine-speed-dependent timeout on a real Vite preflight, not an ordering
artefact. I had inferred ordering from one alone-run that happened to pass.

The load-bearing half is unaffected and still measured: the failure is
identical on clean `main` under the identical command and scope, so it is not
introduced here.

## Known limitation this change does not remove

Selecting `peer-split` does not give the operator the `segmentline` design
language. `presentation/workspace/contract.ts` declares
`WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline', 'fieldline']` and `pickId`
falls back to `'studioline'` for an unrecognised id, so segmentline's
renderers stay unreachable in production. This PR makes the LAYOUT
selectable, not the family. Adding segmentline to that allowlist is its own
change with its own persisted-preference consequences.

Carried forward from MOR-2151's review, for whichever change makes peer-split
render for real: the manifest declares no `tx-aux` zone where
`dual-receiver-cockpit.ts` does, so `tx-aux-surface` would render bare,
outside every declared zone and after `rx-tx` in tab order — the shape
MOR-1069 forbids.

VERIFICATION. `npx vitest run src/presentation src/skins src/semantic
src/components-v2` on this branch alone on `main`, exit code read directly:
1 failed / 4959 passed, the failure being the pre-existing timeout above.

GUARDRAILS. 7 files, 40 changed lines. Inside the hard ceiling on both axes.
The 6-file soft threshold is crossed by one file at 40 changed lines total;
this is one unit of work because every file is one registration site for the
same id — status bar, layout mode, skin registry — plus the three test suites
that enumerate them.
