### PR TITLE
fix: type-correct the fixture harness's setCapabilities call

### DIFF
--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -31,7 +31,7 @@ import ReferenceLayout from './ReferenceLayout.svelte';
 import {
   runAssertions, styleProbe, tokenSnapshot, type AssertionOptions,
 } from './assertions';
-import { setCapabilities } from '../src/lib/stores/capabilities.svelte';
+import { clearCapabilities, setCapabilities } from '../src/lib/stores/capabilities.svelte';
 import { fixtureById } from './catalog';
 import { DEFAULT_AUDIO_RUNTIME, harness, IDLE_TX } from './harness-state';
 
@@ -87,7 +87,12 @@ harness.caps = fixture.caps();
 // singleton must be populated directly here for the S-meter (or any other
 // capabilities-calibrated readout) to render as the fixture intends rather
 // than falling back to the honest-uncalibrated path.
-setCapabilities(fixture.caps());
+// `Fixture.caps` is nullable — `caps-unloaded` returns null — so the unloaded
+// case clears the singleton instead of pushing null through `setCapabilities`,
+// which takes a non-null `Capabilities`.
+const fixtureCaps = fixture.caps();
+if (fixtureCaps) setCapabilities(fixtureCaps);
+else clearCapabilities();
 harness.tx = { ...IDLE_TX, ...fixture.tx };
 harness.modGuard = fixture.modGuard ?? { visible: false, sourceLabel: null };
 harness.audioRuntime = { ...DEFAULT_AUDIO_RUNTIME, ...fixture.audioRuntime };


### PR DESCRIPTION
## What

`frontend/fixtures/main.ts` passed `fixture.caps()` — typed `Capabilities | null` by the `Fixture` interface in `fixtures/catalog.ts` — straight into `setCapabilities`, whose parameter is a non-null `Capabilities`. Two fixture entries actually return null: the authored `caps-unloaded` and the `caps-unloaded--reference` twin derived from it via `caps: f.caps`. (Enumerated by the reviewer over all 39 entries, by building `catalog.ts` with esbuild rather than by grep. No entry returns a falsy-but-not-null value, so the truthiness guard used here is equivalent to a null check.)

## This is not a crash fix

Read `hasCurrentEpoch` (`src/lib/stores/capabilities.svelte.ts`): it takes `unknown` and starts with `if (!value || typeof value !== 'object') return false`. So `null` already took the reject path — store cleared, subscribers notified, `false` returned. **Nothing was breaking at runtime.** This is a type error over already-correct behaviour, and the change preserves that behaviour exactly: `setCapabilities`'s reject branch is the body of `clearCapabilities` plus a `return false` that the call site already discarded.

## Why not widen the parameter type

The alternative was widening `setCapabilities` to `Capabilities | null`. Declined: that drops the compile-time guarantee at its sole production caller, `ws-client.ts`, and no test would catch the loss — `architecture-boundaries.test.ts` pins the caller list by matching call-site text, not types (verified: widening the parameter and running that suite gives 92/92 passing).

That verification exists because the first version of this rationale was wrong. It credited `architecture-boundaries.test.ts` with guarding the signature. It does not, and cannot: it matches `/\b(?:setCapabilities|clearCapabilities)\s*\(/` against file contents and excludes the store file itself via `file !== storePath`. The decision was right, the reason given for it was not, and it was established as wrong by making the change the test supposedly forbids and watching it stay green.

## Why this was invisible

Nothing typechecks `fixtures/`: `tsconfig.app.json`'s `include` is `src/**` only, and `npm run lint` is `eslint src/` — running eslint on the file directly reports `File ignored because no matching configuration was supplied`. Closing that gap is a separate, larger question and is deliberately **not** in this PR.

## Verification

Measured on the rebased head, with a control run rather than a bare green reading:

- Scratch tsconfig extending `tsconfig.app.json` with `fixtures/**/*.ts` added to `include`, then `npx svelte-check --tsconfig <scratch>`:
  - **without** this change → `1 error`, `Argument of type 'Capabilities | null' is not assignable to parameter of type 'Capabilities'` at `fixtures/main.ts:90`
  - **with** it → `0 errors and 0 warnings`
  - Re-run independently by the reviewer, who also added `fixtures/**/*.svelte` and got 0 errors — so the whole class of this defect in `fixtures/` is closed, not just the one instance.
  - The scratch config is not committed.
- `npm run check` → `4615 FILES 0 ERRORS 0 WARNINGS`
- `npm run test` → `377 passed (377)` files, `8225 passed (8225)` tests

`fixture-capture-root-cwd.test.ts` timed out once during an earlier local run on a loaded machine. Controlled: its subprocess preflight takes 9.7s **with** this change and 13.3s at HEAD **without** it, against a 15s test timeout — pre-existing timing fragility, not caused here. It passes on the rebased head.

The Python suite was not run locally: this change is confined to `frontend/fixtures/` and cannot affect it. CI does run pytest for this PR — `quick.yml`'s `core` path filter includes `frontend/**`.

## Guardrails

1 file, 9 changed lines — well inside the soft threshold of 6 files / 600 lines.
