### PR TITLE
refactor: share the TX tone-to-palette mapping across design languages

### DIFF
--- a/frontend/src/presentation/languages/fieldline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/fieldline/state-feedback-renderer.ts
@@ -31,7 +31,7 @@
  */
 import type { DesignLanguageTokens, RendererViewModel } from '../contract';
 import {
-  resolveTxFeedbackState, stringField, type TxFeedbackRail, type TxKeyTreatment,
+  resolveTxFeedbackState, stringField, toneFor, type TxFeedbackRail, type TxKeyTreatment,
 } from '../tx-feedback-state';
 import { FIELDLINE_KNOCKOUT, FIELDLINE_PALETTE } from './tokens';
 
@@ -107,9 +107,7 @@ export function renderStateFeedback(
   });
   const { treatment, keyed, faultText } = resolved;
   const rail = RAIL_TABLE[resolved.rail];
-  const tone = resolved.tone === 'rx-idle' ? tokens.rx.idle
-    : resolved.tone === 'tx-active' ? tokens.tx.active
-      : tokens.tx.tuning;
+  const tone = toneFor(resolved.tone, tokens);
 
   return {
     kind: 'fieldline-state-feedback',

--- a/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
@@ -39,7 +39,7 @@
  */
 import type { DesignLanguageTokens, RendererViewModel } from '../contract';
 import {
-  resolveTxFeedbackState, stringField, type TxFeedbackRail, type TxKeyTreatment,
+  resolveTxFeedbackState, stringField, toneFor, type TxFeedbackRail, type TxKeyTreatment,
 } from '../tx-feedback-state';
 import { SEGMENTLINE_INK, SEGMENTLINE_PALETTE } from './tokens';
 
@@ -103,9 +103,7 @@ export function renderStateFeedback(
   });
   const { treatment, keyed, faultText } = resolved;
   const rail = RAIL_TABLE[resolved.rail];
-  const tone = resolved.tone === 'rx-idle' ? tokens.rx.idle
-    : resolved.tone === 'tx-active' ? tokens.tx.active
-      : tokens.tx.tuning;
+  const tone = toneFor(resolved.tone, tokens);
 
   return {
     kind: 'segmentline-state-feedback',

--- a/frontend/src/presentation/languages/studioline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/studioline/state-feedback-renderer.ts
@@ -28,7 +28,7 @@
  */
 import type { DesignLanguageTokens, RendererViewModel } from '../contract';
 import {
-  resolveTxFeedbackState, stringField, type TxFeedbackRail, type TxKeyTreatment,
+  resolveTxFeedbackState, stringField, toneFor, type TxFeedbackRail, type TxKeyTreatment,
 } from '../tx-feedback-state';
 import { STUDIOLINE_PALETTE } from './tokens';
 
@@ -87,9 +87,7 @@ export function renderStateFeedback(
   });
   const { treatment, keyed, faultText } = resolved;
   const rail = RAIL_TABLE[resolved.rail];
-  const tone = resolved.tone === 'rx-idle' ? tokens.rx.idle
-    : resolved.tone === 'tx-active' ? tokens.tx.active
-      : tokens.tx.tuning;
+  const tone = toneFor(resolved.tone, tokens);
 
   return {
     kind: 'studioline-state-feedback',

--- a/frontend/src/presentation/languages/tx-feedback-state.ts
+++ b/frontend/src/presentation/languages/tx-feedback-state.ts
@@ -1,15 +1,15 @@
 /**
  * MOR-2031 — the design-language-agnostic half of TX state feedback.
  *
- * `fieldline` and `studioline` each render TX state as a rail plus a
- * key/slab control, and until this ticket each language's own
- * `state-feedback-renderer.ts` re-derived the identical fail-closed decision
- * over its own private copy of the logic — `resolveTxFeedbackState` is that
- * one decision, extracted. (The `KEY_TREATMENT` ordering below — the F3/N3
- * fix that makes `keyBlocked` lose to a louder session — was itself
- * hand-duplicated into both files in a single commit, MOR-1275.)
+ * Each design language renders TX state in its own vocabulary, and until
+ * this ticket each language's own `state-feedback-renderer.ts` re-derived
+ * the identical fail-closed decision over its own private copy of the
+ * logic — `resolveTxFeedbackState` is that one decision, extracted. (The
+ * `KEY_TREATMENT` ordering below — the F3/N3 fix that makes `keyBlocked`
+ * lose to a louder session — was itself hand-duplicated into both files in
+ * a single commit, MOR-1275.)
  *
- * Lives under `presentation/languages/`, not `semantic/`: both renderers
+ * Lives under `presentation/languages/`, not `semantic/`: the renderers
  * that consume it are `presentation/` modules, and the v3 ADR's one-way
  * dependency direction only lets `presentation/` depend on `semantic/`
  * type-only (see `projection.ts`, pinned by `projection.test.ts`'s "imports
@@ -24,8 +24,8 @@
  * rail floods `pending` to a MID-tier 16px; studioline's rail thickens
  * `pending` to its TOP-tier 3px — both pinned in each language's own
  * `state-feedback-renderer.test.ts`), so a shared ordinal could not serve
- * both. Each language keeps its own `Record<TxFeedbackRail, …>` for
- * width/thickness/label/band, indexed by the bucket this function resolves.
+ * both. Each language keeps its own `Record<TxFeedbackRail, …>`, indexed
+ * by the bucket this function resolves.
  *
  * SAFETY INVARIANT R9, identical to `semantic/rx-tx-surface.ts`'s `rfState`/
  * `txSessionState`: this function DISPLAYS the App TX authority's
@@ -35,12 +35,24 @@
  * Unrecognised values fail CLOSED to the `'doubt'` rail, never to `'idle'`:
  * "nothing is happening" is the dangerous claim.
  */
+import type { DesignLanguageTokens } from './contract';
 import type { TxSessionState } from '../../semantic/rx-tx-surface';
 
 export type TxFeedbackRail = 'idle' | 'pending' | 'keyed' | 'releasing' | 'failed' | 'doubt';
 export type TxKeyTreatment = 'idle' | 'pending' | 'keyed' | 'fault' | 'blocked';
-/** Symbolic only — NOT a token value. Each language maps this to its own `tokens.rx.idle` / `tokens.tx.active` / `tokens.tx.tuning`. */
+/** Symbolic only — NOT a token value; `toneFor` below maps it onto a language's palette. */
 export type TxFeedbackTone = 'rx-idle' | 'tx-active' | 'tx-tuning';
+
+/**
+ * The symbolic tone, resolved against one language's palette. Extracted
+ * once a third `state-feedback-renderer.ts` carried a literal copy of this
+ * three-way choice (MOR-2149 added segmentline's). Each language still owns
+ * its own palette; only the choice between the three token slots is shared.
+ */
+export const toneFor = (tone: TxFeedbackTone, tokens: DesignLanguageTokens): string =>
+  tone === 'rx-idle' ? tokens.rx.idle
+    : tone === 'tx-active' ? tokens.tx.active
+      : tokens.tx.tuning;
 
 export interface TxFeedbackState {
   readonly rail: TxFeedbackRail;


### PR DESCRIPTION
The three-way choice from a resolved `TxFeedbackTone` onto a language's
token slots was a literal, byte-identical copy in all three
`state-feedback-renderer.ts` files. It becomes `toneFor` in
`tx-feedback-state.ts`, beside the decision that produces the keyword.

WHY NOW. Rule of three. The mapping was a deliberate 2x duplication while
only studioline and fieldline existed; MOR-2149 (merged as `07604e80`)
added segmentline's renderer and with it the third literal copy. A reviewer
reading this change alone would otherwise see a helper with three call
sites and no reason why now.

WHY IT WAS NOT FOLDED INTO MOR-2149. The extraction touches
`tx-feedback-state.ts` and the studioline and fieldline renderers, none of
which are among `06877be8`'s ten files, so folding it in would have taken
that change to 13 files against a 10-file hard ceiling. An owner exception
was granted on 2026-09-01 and is deliberately NOT used: the change fits
inside the ceiling as a follow-up, so the exception stays unspent rather
than being taken quietly.

WHAT PINS IT. Each language's own `state-feedback-renderer.test.ts` already
asserts exact tone values per state, so no new test is added. That those
pins discriminate was established rather than assumed: swapping
`tx-active` and `tx-tuning` inside the new helper fails 10 tests across 3
files; restored, 551 pass in 25 files.

Verified alongside: `npm run check` clean (4621 files, 0 errors) and
`eslint` clean on all four files.

PROSE DELETED, NOT REWRITTEN. Three statements in `tx-feedback-state.ts`
were falsified by segmentline's arrival and could not be seen by MOR-2149's
own review, because that change does not touch this file: the header
enumerated two families and described their shape as "a rail plus a
key/slab control", which segmentline's perimeter is not; "both renderers"
where there are three; and a `Record<TxFeedbackRail, …>` described as
holding "width/thickness/label/band", where segmentline's holds `lit` and
`label`. Each is deleted or has the stale half removed, not restated with a
new count that the fourth family would falsify again. The MOR-1275
parenthetical about "both files" is historical and correct, so it stands.

The `TxFeedbackTone` doc comment said each language maps the keyword to its
own tokens. This change makes that false and it now names `toneFor`.

NOT CLAIMED HERE. `semantic/__tests__/tx-feedback-state.isolated.test.ts`
carries three `vi.spyOn` rows for `thirdline`, `fieldline` and `studioline`;
`segmentline` does not appear in that file at all. So no existing pin
watched segmentline's use of the shared resolver. Separately,
`WORKSPACE_DESIGN_LANGUAGE_IDS` is `['studioline', 'fieldline']` and
`pickId` falls back to `'studioline'`, so segmentline is not selectable in
production today; this mapping is live for it only under the fixture
harness.

GUARDRAILS. 4 files, 52 changed lines — inside both the 6/600 soft
threshold and the 10/1000 ceiling.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>