### PR TITLE
docs(MOR-2144): correct IC-7300 APF support

### DIFF
--- a/docs/capabilities-matrix.md
+++ b/docs/capabilities-matrix.md
@@ -5,7 +5,7 @@ robots: noindex, follow
 # Capabilities Matrix — Verified from CI-V Reference
 
 Sources:
-- IC-7300MK2 CI-V Reference Guide (PDF)
+- IC-7300 Advanced Manual (11a), §19 CONTROL COMMAND
 - IC-7610 wfview rig file (`.rig` format, verified against wfview 2.20)
 - Actual hardware testing (IC-7610 firmware 1.42, IC-7300)
 
@@ -80,7 +80,7 @@ has_ant_memory = false
 | Auto notch | 0x16 0x41 (0/1) | 0x16 0x41 (0/1) | Same | |
 | Manual notch | 0x16 0x48 (0/1) | 0x16 0x48 (0/1) | Same | |
 | Notch freq | 0x14 0x0D (0-255) | 0x14 0x0D (0-255) | Same | |
-| APF | 0x16 0x32 (0/1/2/3) | 0x16 0x32 (0/1) | Different! | IC-7610: OFF/WIDE/MID/NAR. IC-7300: ON/OFF |
+| APF | 0x16 0x32 (0/1/2/3) | ❌ | IC-7610 only | IC-7300 Manual 11a omits 0x16 0x32; live GET NAK'd twice with 0x16 0x22 DATA as control |
 | Twin Peak | 0x16 0x4F (0/1) | 0x16 0x4F (0/1) | Same | |
 
 **NR modes:** Both IC-7610 and IC-7300 have NR as simple ON/OFF via CI-V (0x16 0x40).

--- a/docs/capabilities-matrix.md
+++ b/docs/capabilities-matrix.md
@@ -62,10 +62,11 @@ has_ant_memory = false
 | Preamp | OFF/P1/P2 | OFF/P1/P2 | 0x16 0x02 (0/1/2) | `[preamp] values` |
 | RF Gain | 0-255 | 0-255 | 0x14 0x02 | `rf_gain` in features |
 | DIGI-SEL | ✅ | ❌ | 0x16 0x4E | `digisel` in features |
-| IP+ | ✅ | ❌ | 0x16 0x65 | `ip_plus` in features |
+| IP+ | ✅ | ✅ | 0x16 0x65 | `ip_plus` in features |
 
 **IC-7610 ATT:** CI-V reference shows 16 discrete values: 0/3/6/9/12/15/18/21/24/27/30/33/36/39/42/45 dB. Each sent as its dB value (e.g. 0x00=OFF, 0x03=3dB, 0x06=6dB, ..., 0x45=45dB). The current TOML `[0, 6, 12, 18]` is **WRONG** — must be updated to full range.
 **IC-7300 ATT:** Only 0x00=OFF, 0x20=ON (20 dB). Binary toggle.
+**IC-7300 IP+:** Advanced Manual (11a) p.19-4 documents `0x16 0x65` as IP+ on/off.
 
 ## DSP / Noise
 
@@ -158,19 +159,18 @@ TOML: both get `rit` and `xit` in features.
 ```
 audio, scope, meters, tx, cw, attenuator, preamp, rf_gain, af_level,
 squelch, nb, nr, rit, xit, tuner, split, notch, pbt, vox, compressor,
-monitor, bsr, data_mode, power_control, break_in, apf, twin_peak,
+monitor, bsr, data_mode, power_control, break_in, twin_peak, ip_plus,
 dial_lock, scan, filter_shape, antenna
 ```
 
 ### IC-7610 only
 ```
-dual_rx, digisel, ip_plus, dual_watch, rx_antenna, drive_gain,
+dual_rx, digisel, apf, dual_watch, rx_antenna, drive_gain,
 main_sub_tracking, tx_inhibit, dpd, lcd_backlight
 ```
 
 **IC-7610-specific CI-V commands not in IC-7300:**
 - `0x16 0x4E` — DIGI-SEL on/off
-- `0x16 0x65` — IP+ on/off
 - `0x14 0x13` — DIGI-SEL shift level (0-255)
 - `0x14 0x14` — DRIVE gain (0-255)
 - `0x16 0x5E` — MAIN/SUB Tracking on/off

--- a/docs/guide/ic7300-usb-setup.md
+++ b/docs/guide/ic7300-usb-setup.md
@@ -136,7 +136,7 @@ rigplane web --backend serial --model IC-7300 --serial-port /dev/cu.usbserial-A6
 | **Audio RX/TX** | ✅ Full | PCM and Opus codecs |
 | **Meters** | ✅ Full | S-meter, SWR, ALC, Power, Vd, Id |
 | **Filters** | ✅ Full | Filter width selection |
-| **DSP** | ✅ Full | NB, NR, APF, Twin Peak, PBT |
+| **DSP** | ✅ Full | NB, NR, Twin Peak, PBT |
 | **Dual Watch** | ⚠️ Single RX | IC-7300 has single receiver only |
 
 ## Audio Subsystem

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -47,7 +47,7 @@ RigPlane capabilities through an external `rigctld` process.
 - **Rig profile:** `rigs/ic7300.toml`
 - **Features verified:** frequency, mode, power, S-meter, SWR, ALC, PTT, CW keying,
   VFO A/B select, attenuator, preamp, NB, NR, scope/waterfall, audio RX/TX
-- **Not available:** DIGI-SEL, IP+, LAN, dual receiver
+- **Not available:** DIGI-SEL, LAN, dual receiver
 
 !!! tip "Setup Guide"
     **[IC-7300 USB Serial Backend Setup](ic7300-usb-setup.md)** — Complete USB configuration guide
@@ -60,12 +60,12 @@ RigPlane capabilities through an external `rigctld` process.
 | Receivers | 2 (MAIN/SUB) | 1 (VFO A/B) |
 | VFO labels | MAIN / SUB | VFO A / VFO B |
 | DIGI-SEL | ✅ | ❌ |
-| IP+ | ✅ | ❌ |
+| IP+ | ✅ | ✅ |
 | LAN | ✅ | ❌ |
 | Scope | ✅ | ✅ |
 | USB Serial | ✅ | ✅ |
 
-The Web UI automatically hides DIGI-SEL and IP+ controls when connected to an IC-7300
+The Web UI automatically hides the DIGI-SEL control when connected to an IC-7300
 (capability-based UI guards). VFO labels switch to "VFO A" / "VFO B" automatically.
 
 ### Yaesu FTX-1

--- a/docs/release-notes/2026-beta-known-limitations.md
+++ b/docs/release-notes/2026-beta-known-limitations.md
@@ -36,9 +36,10 @@ that class of defect is release-blocking by definition and is not on this list.
 - **AF/RF/SQL slider steps do not always restore the exact original raw
   value** after a reversible up/down step pair; drift is within one raw step.
   (MOR-1676)
-- **The CW APF toggle is not connected to the IC-7300's observable
-  audio-peak-filter field**; its rendered state may not reflect the radio.
-  (MOR-1647)
+- **IC-7300 has no APF.** Advanced Manual (11a) omits `16 32`, and a
+  read-only remote-testbed GET NAK'd twice with documented `16 22` DATA as
+  the adjacent control. Any build or profile advertising CW APF for IC-7300
+  exposes a nonfunctional control. (MOR-2144)
 - **A power-state control is offered on radios whose power cannot be switched
   over CAT**; it presents a readiness the radio does not have, and unknown
   power state is not always rendered neutrally. (MOR-1673)

--- a/docs/validation/cat-audits/ic7300.md
+++ b/docs/validation/cat-audits/ic7300.md
@@ -1,16 +1,16 @@
 # IC-7300 (Icom) — CI-V manual vs implementation
 
-**Manual:** Icom IC-7300 **Full Manual (English) v6**, §19 CONTROL COMMAND command table (`manuals/ic7300.txt`, extracted from the official Icom UK PDF). The standalone "CI-V Reference Guide" PDF that Icom now ships only covers the **IC-7300MK2**; the original IC-7300 CI-V table is published inside the Full Manual §19 — that is the authoritative source used here. (The profile header cites "IC-7300MK2 CI-V Reference Guide" + wfview `IC-7300.rig`; sub-command numbering matches the original §19 table.)
+**Manual:** Icom IC-7300 **Advanced Manual (11a)**, §19 CONTROL COMMAND. The command table on printed pp.19-3/19-4 is the source for the APF ruling below: its `0x16` rows run through `22`, continue at `40`, and later continue from `4F`; it has no `32` row or Audio Peak Filter entry.
 **Driver:** shared Icom CI-V core — `src/rigplane/backends/ic7300/{serial,core}.py` are 22-line shims over `backends/_icom_serial_base._IcomSerialRadioBase` + `runtime/radio.CoreRadio` (185 `get_/set_`) + `_scope_runtime` mixin (26) + `_dual_rx_runtime` (3). **Zero IC-7300-specific command code** — every method is shared with IC-7610 / IC-705 / IC-9700 / X6200 and routed by `rigs/ic7300.toml`.
 **Profile:** `rigs/ic7300.toml`. **Validation:** `src/rigplane/validation/registry/*` (capability-gated template; see `_builders.py`).
-**Live run:** none — this is a **template/static audit**. No `/tmp/ic7300.live.json` hardware run was performed; "Validation" column reflects the generated matrix declaration, not observed pass/fail.
+**Live evidence:** an APF-specific read-only run on the remote testbed sent `16 32` GET twice and received protocol NAK (`FA`) both times. The adjacent documented `16 22` GET returned DATA before and after. No SET or TX command was sent. This was not a full validation-matrix run; other "Validation" entries below still describe declarations rather than observed pass/fail.
 
 Protocol: Icom CI-V, `FE FE 94 E0 … FD`, transceiver address **0x94**. Default baud 115200 (required for serial scope data).
 
 ### IC-7300 vs IC-7610 divergence (7300-specific)
 - **Single receiver** — no dual-watch, no MAIN/SUB band select, no `0x29` (cmd29). Scope is `27 12`=Main-only, `27 13`=Single-only.
 - **Single antenna + ATU, no antenna-select command** — no `0x12` row in the IC-7300 Advanced Manual (11a) command table pp.19-3..19-8, no ANT1/ANT2 selection documented; bench 2026-09-01 NAK'd `12 00`/`12`/`12 01`, with `03` answering DATA before and after (`get_antenna`/`set_antenna` declared absent). **No RX antenna**, no ANT1/ANT2 (profile `has_rx_ant=false`, `tx_count=1`).
-- **APF is a plain ON/OFF toggle** (`16 32`, 0/1) — *not* the IC-7610 WIDE/MID/NAR 3-level. Profile maps `audio_peak_filter`→`16 32`; the 3-level `apf_type_level`→`14 05` is flagged `NOT_IMPLEMENTED` in-profile.
+- **No APF** — Advanced Manual (11a) pp.19-3/19-4 omit `16 32`, and the read-only remote-testbed probe NAK'd an exactly framed `16 32` GET twice while adjacent `16 22` returned DATA. The IC-7300 support contract must not declare an `apf` capability, domain, acquisition field, or `get_/set_audio_peak_filter` command.
 - **2 preamp levels** (`16 02`: 0/1/2), no DIGI-SEL, no drive_gain, single DATA sub-mode.
 
 ---
@@ -64,7 +64,7 @@ Legend — Backend: method name or `—`. Profile: `[commands]` key or cap. Vali
 | `16 56` | DSP filter type | `get_/set_filter_shape` | `filter_shape` | `filter_shape.presence` **—** |
 | `16 57` | manual notch width | `get_/set_manual_notch_width` | `notch` | (covered by `notch.set`) |
 | `16 58` | SSB TX bandwidth | `get_/set_ssb_tx_bandwidth` | `ssb_tx_bw` | `ssb_tx_bw.presence` **—** |
-| `16 32` | APF ON/OFF (7300: toggle) | `get_/set_audio_peak_filter` | `apf` | `apf.presence` **—** |
+| `16 32` | **Not documented; live GET NAK twice** | generic shared-Icom methods remain for radios that support APF | unsupported for IC-7300 | — |
 | `16 65` | IP+ | `get_/set_ip_plus` | `ip_plus` | `ip_plus.presence` **—** |
 | `17` | send/stop CW msg | `send_cw`/`stop_cw` | `send_cw`/`stop_cw` | — (feature) |
 | `18` | power on/off | `get_/set_powerstat` | `power_control` | `power_control.presence` **—** |
@@ -136,7 +136,6 @@ Per `_builders.py`, a declared capability with **no registry CheckSpec** gets on
 | `monitor` (+gain) | `16 45` / `14 15` | `get_/set_monitor`(+`_gain`) | Add `monitor.set` RMVR | **NEW** |
 | `break_in` (+delay) | `16 47` / `14 0F` | `get_/set_break_in`(+`_delay`) | Add `break_in.set` RMVR | **NEW** |
 | `twin_peak` | `16 4F` | `get_/set_twin_peak_filter` | Add `twin_peak.set` RMVR | **NEW** |
-| `apf` (7300 toggle) | `16 32` | `get_/set_audio_peak_filter` | Add `apf.set` RMVR (0/1) | **NEW** |
 | `ip_plus` | `16 65` | `get_/set_ip_plus` | Add `ip_plus.set` RMVR | **NEW** |
 | `filter_shape` | `16 56` | `get_/set_filter_shape` | Add `filter_shape.set` RMVR (SHARP/SOFT) | **NEW** |
 | `ssb_tx_bw` | `16 58` | `get_/set_ssb_tx_bandwidth` | Add `ssb_tx_bw.set` RMVR | **NEW** |
@@ -161,15 +160,14 @@ Per `_builders.py`, a declared capability with **no registry CheckSpec** gets on
 
 | CI-V | rigplane symbol | Issue | Ticket |
 |---|---|---|---|
-| `14 05` APF type/level | `get_/set_apf_type_level` | Method sends `0x14` (REAL on IC-7610's 3-level APF), but the **IC-7300 has no `14 05` APF position** — it is a plain `16 32` toggle. Profile correctly maps `apf`→`16 32` and flags `get_apf_type_level=[0x14,0x05]` as `NOT_IMPLEMENTED`. Calling `apf_type_level` on a 7300 would emit a command the radio ignores. Cosmetic (method unreachable via 7300 UI) but the cmd string should be removed, not just commented. | **NEW** (low) |
+| `14 05` / `16 32` APF | shared APF methods | Advanced Manual (11a) documents neither IC-7610-style `14 05` APF position nor `16 32` APF mode for the IC-7300. Any IC-7300 `apf` capability/domain/acquisition/active-command declaration is therefore an unsupported profile over-declaration; generic shared methods remain valid for radios whose manuals declare APF. | **MOR-2144** |
 | `1A 01` `get_bsr` | band-stack read | `get_bsr` `raise NotImplementedError(...)` cites "IC-7610 does not support reading band stack" — inherited verbatim by the 7300 even though the 7300 §19 table documents `1A 01` as **Send/read**. Driver-wide stale assumption (see list C). | **NEW** |
-| header provenance | `rigs/ic7300.toml` | Header & two `[commands]` comments cite **"IC-7300MK2 CI-V Reference Guide"** as source, but the profile targets the **original IC-7300** (addr 0x94, 2-level preamp, single DATA). MK2 has a different command set. Update provenance to the IC-7300 Full Manual §19 to avoid future mis-merges. | **NEW** (doc) |
 
 ---
 
 ## Summary
 
-- **No live hardware validation** was run for the IC-7300 — this is a static/template audit. Recommend an `/tmp/ic7300.live.json` run to confirm the ~26 RMVR checks and resolve list-B presence-only items.
+- **Only the APF ruling has live hardware evidence**: two `16 32` GET NAKs with an adjacent `16 22` DATA positive control, read-only and without TX. No full IC-7300 validation-matrix run was performed.
 - The IC-7300 is **100% shared-backend** with the IC-7610 — every gap in lists A/B is also an IC-7610/IC-705/IC-9700 gap; fixes are one CheckSpec per capability, rig-agnostic.
-- **Biggest single lever:** list B — ~14 declared+implemented capabilities (pbt, compressor, monitor, break_in, twin_peak, apf, ip_plus, filter_shape, ssb_tx_bw, data_mode, tuning_step, xfc, power_control, cw_pitch) have a working backend method but only a synthetic `.presence` stub, so they can never validate green. Add functional `_levels`/`_dsp`/`_tx` CheckSpecs.
-- **Real bugs:** `get_bsr` NIE blocks `1A 01` read on hardware that supports it (lists C+D); `apf_type_level`→`14 05` is a dead command on the 7300 (list D).
+- **Biggest single lever:** list B — ~13 declared+implemented capabilities (pbt, compressor, monitor, break_in, twin_peak, ip_plus, filter_shape, ssb_tx_bw, data_mode, tuning_step, xfc, power_control, cw_pitch) have a working backend method but only a synthetic `.presence` stub, so they can never validate green. Add functional `_levels`/`_dsp`/`_tx` CheckSpecs.
+- **Real bugs:** `get_bsr` NIE blocks `1A 01` read on hardware that supports it (lists C+D); IC-7300 APF is an unsupported profile over-declaration, not a missing validation check.


### PR DESCRIPTION
## Summary

- correct the IC-7300 APF source of truth to Advanced Manual 11a, printed pp. 19-3/19-4
- remove APF from IC-7300 capability and setup claims while preserving generic and IC-7610 APF support
- correct the IC-7300 IP+ support status to documented CI-V `16 65` across the capability matrix and active radio guide
- align the CAT audit, capability matrix, operator guides, and beta known-limitation wording

## Evidence

Official manual evidence and live bench evidence are distinct:

- Manual: IC-7300 Advanced Manual 11a, SHA-256 `a73a9600899e1e900bc5fbb0ecbec33d1883f68b5ff54905a660013f5f00c66c`; the `0x16` table runs from `22` to `40` and later `4F`, with no `32` row or APF entry. Printed p. 19-4 documents IP+ at `16 65`.
- Remote testbed: read-only `16 32` GET returned protocol NAK twice; documented adjacent `16 22` returned DATA before and after. No SET or TX command was sent.

## Verification

- `git diff --check`
- `.github/scripts/check-doc-citations.sh`
- `.github/scripts/check-doc-citations.sh --check-links`
- repo-wide IC-7300/APF/IP+ claim sweep; remaining APF references are explicit absence evidence, generic/IC-7610 support, or the profile declaration reserved for the follow-up code PR

All passed. No full remote Python run was performed because this PR changes documentation only.

## Scope

This is the documentation-only first half of MOR-2144. Five source-of-truth and active operator documents change atomically so the APF and IP+ support statements agree. It does not change the radio profile or generic shared APF implementation. The profile/test correction will follow from fresh `main` after this PR lands. MOR-2144 remains **In Progress**.
