### PR TITLE
docs(MOR-2144): correct IC-7300 capability prose

### DIFF
--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -60,7 +60,7 @@ RigPlane capabilities through an external `rigctld` process.
 | Receivers | 2 (MAIN/SUB) | 1 (VFO A/B) |
 | VFO labels | MAIN / SUB | VFO A / VFO B |
 | DIGI-SEL | ✅ | ❌ |
-| IP+ | ✅ | ✅ |
+| IP+ | ✅ | ✅ (supported) |
 | LAN | ✅ | ❌ |
 | Scope | ✅ | ✅ |
 | USB Serial | ✅ | ✅ |

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -66,7 +66,8 @@ RigPlane capabilities through an external `rigctld` process.
 | USB Serial | ✅ | ✅ |
 
 The Web UI automatically hides the DIGI-SEL control when connected to an IC-7300
-(capability-based UI guards). VFO labels switch to "VFO A" / "VFO B" automatically.
+(capability-based UI guards), while the documented IP+ control is supported and
+visible on both radios. VFO labels switch to "VFO A" / "VFO B" automatically.
 
 ### Yaesu FTX-1
 

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -740,7 +740,7 @@ active radio profile doesn't support them:
 | Control | Capability flag | Visible on IC-7610 | Visible on IC-7300 |
 |---------|----------------|--------------------|--------------------|
 | DIGI-SEL toggle | `digisel` | ✅ | ❌ hidden |
-| IP+ toggle | `ip_plus` | ✅ | ❌ hidden |
+| IP+ toggle | `ip_plus` | ✅ | ✅ |
 | SUB receiver panel | `dual_rx` | ✅ | ❌ hidden |
 | TX controls, PTT | `tx` | ✅ | ✅ |
 | Audio RX/TX | `audio` | ✅ | ✅ |

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -711,7 +711,7 @@ ant_modes = ["off", "manual", "auto"]
 
 [apf]
 # CI-V 0x16 0x32: 0=OFF, 1=WIDE(320Hz), 2=MID(160Hz), 3=NAR(80Hz)
-# Note: IC-7300 only has ON/OFF (0/1)
+# IC-7300 does not declare APF; this four-value APF domain is IC-7610-specific.
 values = [0, 1, 2, 3]
 labels = { "0" = "OFF", "1" = "WIDE", "2" = "MID", "3" = "NAR" }
 


### PR DESCRIPTION
Follow-up to #2964 post-merge audit for MOR-2144.

- mark IC-7300 IP+ as supported and visible in both capability guides
- remove the false IC-7300 APF statement from the IC-7610 profile while preserving IC-7610 APF semantics
- no TOML semantic row changes

Validation: git diff --check; Python TOML parse for IC-7300 and IC-7610; repo-wide active APF/IP+ wording census.