### PR TITLE
fix(MOR-2144): remove IC-7300 APF declarations

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -53,7 +53,6 @@ features = [
     "nb",
     "nr",
     "notch",
-    "apf",
     "twin_peak",
     # Filter
     "pbt",
@@ -257,7 +256,6 @@ command_response_observable = [
     "global.operator_controls.break_in_delay",
     "global.operator_controls.key_speed",
     "global.operator_controls.cw_pitch",
-    "receiver.main.operator_controls.audio_peak_filter",
     "receiver.main.operator_toggles.twin_peak_filter",
 ]
 supported_controls = [
@@ -640,12 +638,6 @@ freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"
 adaptive_decay = false
 
-[state_acquisition.field_policies."receiver.main.operator_controls.audio_peak_filter"]
-cadence_seconds = 25.0
-freshness_ttl_seconds = 25.0
-reconciliation_priority = "command_response"
-adaptive_decay = false
-
 [state_acquisition.field_policies."receiver.main.operator_toggles.twin_peak_filter"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
@@ -685,12 +677,6 @@ values = [0xD0, 0xD3]
 [antenna]
 tx_count = 1
 has_rx_ant = false
-
-[apf]
-# CI-V 0x16 0x32: 0=OFF, 1=ON (simple toggle, no WIDE/MID/NAR)
-# Different from IC-7610 which has 0-3!
-values = [0, 1]
-labels = { "0" = "OFF", "1" = "ON" }
 
 [notch]
 # CI-V 0x16 0x57: Manual notch width
@@ -1028,12 +1014,6 @@ get_notch_filter = [0x14, 0x0D]           # Notch position 0-255
 set_notch_filter = [0x14, 0x0D]
 get_manual_notch_width = [0x16, 0x57]     # 0=WIDE, 1=MID, 2=NAR
 set_manual_notch_width = [0x16, 0x57]
-get_audio_peak_filter = [0x16, 0x32]      # IC-7300: 0=OFF, 1=ON only
-set_audio_peak_filter = [0x16, 0x32]
-# The 7300 APF is a plain 0x16 0x32 ON/OFF toggle (above); there is no 0x14 0x05
-# APF position like the IC-7610's WIDE/MID/NAR 3-level control. The dead 0x14
-# 0x05 command string was removed (MOR-681) so it cannot be emitted to a radio
-# that ignores it.
 get_apf_type_level = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family skips 04/05" }
 set_apf_type_level = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family skips 04/05" }
 get_twin_peak_filter = [0x16, 0x4F]

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -361,8 +361,6 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             "set_manual_notch",
             "get_manual_notch_width",
             "set_manual_notch_width",
-            "get_audio_peak_filter",
-            "set_audio_peak_filter",
             "get_twin_peak_filter",
             "set_twin_peak_filter",
             # Levels

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -2,13 +2,14 @@
 #   census  <name>              <count>
 #   gap     <command-map key>   <profiles missing it, comma sep.>
 # One 'gap' row per key: neither declared nor declared absent for
-# every profile named -- D1's state 3. Fails on a pair missing here
+# every profile named, unless its contracted optional capability is
+# omitted -- D1's state 3. Fails on a pair missing here
 # or a row no longer a gap -- delete it, never keep it. Fill a gap
 # via { absent = "<source>" } (plan §8.1 D2) or a real command-byte
 # entry in the profile's own TOML. Regenerate, do not hand-edit.
 census	civ_profiles	6
-census	distinct_gap_keys	148
-census	profile_key_gaps	302
+census	distinct_gap_keys	146
+census	profile_key_gaps	298
 census	public_builders	243
 gap	get_acc1_mod_level	X6100,X6200
 gap	get_af_mute	X6100,X6200
@@ -17,7 +18,6 @@ gap	get_alc	X6100,X6200
 gap	get_antenna	X6100,X6200
 gap	get_anti_vox_gain	X6100,X6200
 gap	get_apf_type_level	X6100,X6200
-gap	get_audio_peak_filter	X6100,X6200
 gap	get_break_in_delay	X6100,X6200
 gap	get_civ_output_ant	X6100,X6200
 gap	get_civ_transceive	X6100,X6200
@@ -105,7 +105,6 @@ gap	set_agc_time_constant	X6100,X6200
 gap	set_antenna	X6100,X6200
 gap	set_anti_vox_gain	X6100,X6200
 gap	set_apf_type_level	X6100,X6200
-gap	set_audio_peak_filter	X6100,X6200
 gap	set_break_in_delay	X6100,X6200
 gap	set_civ_output_ant	X6100,X6200
 gap	set_civ_transceive	X6100,X6200

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -16,7 +16,7 @@
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.
 IC-705	246	128	231
-IC-7300	330	185	287
+IC-7300	328	184	285
 IC-7610	217	129	171
 IC-9700	230	137	183
 X6100	67	42	50

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -2062,11 +2062,11 @@ def test_state_freshness_service_ic7300_non_polling_populate_completes_within_25
 ):
     """MOR-1501 acceptance criterion.
 
-    Simulates the real IC-7300 acquisition profile's 23 non-polling
+    Simulates the real IC-7300 acquisition profile's 22 non-polling
     ``field_policies`` fields populating from a cold connect (empty store).
     Before adaptive pacing, the flat 30s re-derivation interval combined
     with the unchanged 5-field burst cap gave this profile a ~120s tail
-    (``ceil(23 / 5) == 5`` waves, 30s apart), even though each field's true
+    (``ceil(22 / 5) == 5`` waves, 30s apart), even though each field's true
     CI-V round-trip cost is ~1.1s — the interval, not the serial link, was
     the bottleneck. With the 5s adaptive interval the same 5 waves complete
     in ~20-25s. This drives the scheduler/service pair directly (no real
@@ -2085,10 +2085,15 @@ def test_state_freshness_service_ic7300_non_polling_populate_completes_within_25
         for path in acquisition.field_policies
         if not acquisition.capability_for(path).can_poll
     )
+    apf_path = FieldPath.receiver("main", "operator_controls", "audio_peak_filter")
+    nb_level_path = FieldPath.receiver("main", "operator_controls", "nb_level")
     # Measured baseline this ticket's motivation is stated against
     # (MOR-1501) — guards against silent membership drift changing the
-    # shape of this regression test without anyone noticing.
-    assert len(non_polling_paths) == 23
+    # shape of this regression test without anyone noticing. MOR-2144 removes
+    # only the unsupported APF path; the supported NB level stays scheduled.
+    assert apf_path not in acquisition.field_policies
+    assert nb_level_path in acquisition.field_policies
+    assert len(non_polling_paths) == 22
 
     clock = FreshnessClock(start=2000.0)
     store = StateStore(freshness_clock=clock)

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -377,8 +377,8 @@ class TestNbLevelGating:
 
 
 class TestApfTypeLevelGating:
-    """IC-7300 doesn't declare apf_type_level at all, but IC-705 does (and
-    has no [cmd29] section) -- IC-705 is the unwrapped case here."""
+    """IC-7300 marks apf_type_level absent, but IC-705 declares it (and has
+    no [cmd29] section) -- IC-705 is the unwrapped case here."""
 
     @pytest.mark.asyncio
     async def test_set_apf_type_level_unwrapped_on_ic705(self) -> None:
@@ -430,20 +430,6 @@ class TestDigiselShiftGating:
 
 
 class TestAudioPeakFilterGating:
-    @pytest.mark.asyncio
-    async def test_set_audio_peak_filter_unwrapped_on_ic7300(self) -> None:
-        radio = _connected_icom(model="IC-7300")
-        mock = _mock_raw(radio)
-        await radio.set_audio_peak_filter(AudioPeakFilter.WIDE, receiver=0)
-        expected = set_audio_peak_filter(
-            AudioPeakFilter.WIDE,
-            to_addr=_IC7300_ADDR,
-            receiver=0,
-            command29=False,
-            cmd_map=_IC7300_CMD_MAP,
-        )
-        assert _sent_civ(mock) == expected
-
     @pytest.mark.asyncio
     async def test_set_audio_peak_filter_wrapped_on_ic7610(self) -> None:
         radio = _connected_icom(model="IC-7610")

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -25,6 +25,9 @@ to an assertion rather than a count that would rot silently here.
 
 A resolved key is a gap for a profile when it is neither in
 ``RadioProfile.command_names`` nor in ``RadioProfile.absent_command_names``.
+The exception is a key contracted to an optional capability the profile does
+not declare: that is model-level hardware absence, while declaring the
+capability makes every contracted key mandatory again.
 Known gaps live in ``tests/profile_command_coverage_gaps.txt``, one row per
 command-map key -- deduplicated by key, per the plan's own phrasing
 ("enumerate every public builder KEY") -- with the profiles missing that
@@ -43,8 +46,9 @@ file is the durable record now, not restated here; this file's baseline is
 meant to shrink only, never grow silently.
 
 That baseline measures declaration completeness only: absent markers are not
-manual proof. The MOR-2144 foundation inventories normalized specs independently
-and reports implementation gaps without an allowlist.
+manual proof, and an omitted optional capability is the authority for excluding
+its contracted keys. The MOR-2144 foundation inventories normalized specs
+independently and reports implementation gaps without an allowlist.
 
 Regenerate after an intentional change (a profile gains or loses a
 declaration, or a builder's key changes)::
@@ -64,7 +68,7 @@ import pathlib
 import textwrap
 import typing
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import pytest
 
@@ -237,6 +241,39 @@ class _Report(typing.NamedTuple):
     census: dict[str, int]
 
 
+# A feature that is absent from a model must not force that model to declare
+# command-map keys for hardware it does not have. Conversely, once a profile
+# declares the feature, these keys are required and the state-3 guard below
+# remains red until each is implemented or explicitly declared absent.
+_REQUIRED_COMMAND_KEYS_BY_CAPABILITY: dict[str, frozenset[str]] = {
+    "apf": frozenset({"get_audio_peak_filter", "set_audio_peak_filter"}),
+    "nb": frozenset({"get_nb", "set_nb"}),
+}
+_REQUIRED_CAPABILITY_BY_COMMAND_KEY = {
+    key: capability
+    for capability, keys in _REQUIRED_COMMAND_KEYS_BY_CAPABILITY.items()
+    for key in keys
+}
+
+
+def _profile_gap_keys(
+    profile: typing.Any,
+    command_keys: typing.Iterable[str],
+) -> set[str]:
+    gaps: set[str] = set()
+    for name in command_keys:
+        if name in profile.command_names or name in profile.absent_command_names:
+            continue
+        required_capability = _REQUIRED_CAPABILITY_BY_COMMAND_KEY.get(name)
+        if (
+            required_capability is not None
+            and required_capability not in profile.capabilities
+        ):
+            continue
+        gaps.add(name)
+    return gaps
+
+
 @functools.lru_cache(maxsize=1)
 def _civ_rigs() -> dict[str, typing.Any]:
     return {
@@ -259,13 +296,9 @@ def _report() -> _Report:
             _key_for(key, builder, command_map, static_cache)
             for key, builder in builders.items()
         }
-        for name in keys:
-            if (
-                name not in profile.command_names
-                and name not in profile.absent_command_names
-            ):
-                gaps[name].add(model)
-                total_pairs += 1
+        for name in _profile_gap_keys(profile, keys):
+            gaps[name].add(model)
+            total_pairs += 1
     return _Report(
         gaps={name: tuple(sorted(models)) for name, models in gaps.items()},
         census={
@@ -958,7 +991,8 @@ def _render(report: _Report) -> str:
         "#   census  <name>              <count>",
         "#   gap     <command-map key>   <profiles missing it, comma sep.>",
         "# One 'gap' row per key: neither declared nor declared absent for",
-        "# every profile named -- D1's state 3. Fails on a pair missing here",
+        "# every profile named, unless its contracted optional capability is",
+        "# omitted -- D1's state 3. Fails on a pair missing here",
         "# or a row no longer a gap -- delete it, never keep it. Fill a gap",
         '# via { absent = "<source>" } (plan §8.1 D2) or a real command-byte',
         "# entry in the profile's own TOML. Regenerate, do not hand-edit.",
@@ -1011,6 +1045,33 @@ def test_census_matches(report: _Report) -> None:
     rows = _read_rows(GAPS_FILE)
     census = {r[1]: int(r[2]) for r in rows if r[0] == "census"}
     assert census == report.census
+
+
+def test_capability_required_commands_only_gap_when_feature_is_declared() -> None:
+    profile = _civ_rigs()["IC-7300"].to_profile()
+    apf_keys = _REQUIRED_COMMAND_KEYS_BY_CAPABILITY["apf"]
+    nb_keys = _REQUIRED_COMMAND_KEYS_BY_CAPABILITY["nb"]
+
+    assert len(_REQUIRED_CAPABILITY_BY_COMMAND_KEY) == sum(
+        len(keys) for keys in _REQUIRED_COMMAND_KEYS_BY_CAPABILITY.values()
+    )
+
+    assert "apf" not in profile.capabilities
+    assert _profile_gap_keys(profile, apf_keys) == set()
+
+    apf_without_commands = replace(
+        profile,
+        capabilities=profile.capabilities | {"apf"},
+    )
+    assert _profile_gap_keys(apf_without_commands, apf_keys) == set(apf_keys)
+
+    assert "nb" in profile.capabilities
+    assert _profile_gap_keys(profile, nb_keys) == set()
+    nb_without_commands = replace(
+        profile,
+        command_names=profile.command_names - nb_keys,
+    )
+    assert _profile_gap_keys(nb_without_commands, nb_keys) == set(nb_keys)
 
 
 # ── MOR-2144 implementation-completeness foundation ──
@@ -1215,6 +1276,23 @@ def test_reverse_census_preserves_absent_and_rejects_false_evidence() -> None:
     for kwargs, message in invalid_evidence:
         with pytest.raises(ValueError, match=message):
             reverse_implementation_census(profile, runtime_names, **kwargs)
+
+
+def test_ic7300_apf_runtime_names_are_reverse_absent_without_profile_markers() -> None:
+    profile = _civ_rigs()["IC-7300"].to_profile()
+    rows = reverse_implementation_census(
+        profile,
+        ("get_audio_peak_filter", "set_audio_peak_filter"),
+    )
+
+    assert {row.runtime_name for row in rows} == {
+        "get_audio_peak_filter",
+        "set_audio_peak_filter",
+    }
+    assert all(row.relation is _DeclarationRelation.ABSENT for row in rows)
+    assert all(row.profile_names == () for row in rows)
+    assert all(row.declared_absent is False for row in rows)
+    assert all(row.absent_source is None for row in rows)
 
 
 def test_future_activation_api_returns_full_deterministic_gap_list(

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -5,18 +5,22 @@ TDD: these tests were written FIRST, then the TOML was created to pass them.
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from rigplane.commands._codec import filter_hz_to_index, filter_index_to_hz
+from rigplane.core.exceptions import CommandError
 from rigplane.meter_cal import interpolate_meter
+from rigplane.radio import CoreRadio
 from rigplane.rig_loader import load_rig
 
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
 IC7300_PATH = RIGS_DIR / "ic7300.toml"
 
-EXPECTED_41_BASELINE = {
+EXPECTED_BASELINE_CAPABILITIES = {
     "audio",
     "af_level",
     "rf_gain",
@@ -28,7 +32,6 @@ EXPECTED_41_BASELINE = {
     "nb",
     "nr",
     "notch",
-    "apf",
     "twin_peak",
     "pbt",
     "filter_width",
@@ -197,7 +200,7 @@ class TestVFOScheme:
 
 
 class TestCapabilities:
-    """IC-7300 capabilities: no dual_rx, digisel; includes ip_plus per wfview."""
+    """IC-7300 capabilities follow the radio-specific profile evidence."""
 
     def test_has_audio(self, profile):
         assert "audio" in profile.capabilities
@@ -213,6 +216,56 @@ class TestCapabilities:
 
     def test_has_nb(self, profile):
         assert "nb" in profile.capabilities
+
+    def test_no_apf_declarations_while_nb_remains_supported(self, profile, cmdmap):
+        raw = tomllib.loads(IC7300_PATH.read_text())
+        acquisition = raw["state_acquisition"]
+        apf_path = "receiver.main.operator_controls.audio_peak_filter"
+
+        assert "apf" not in profile.capabilities
+        assert "apf" not in raw
+        assert not cmdmap.has("get_audio_peak_filter")
+        assert not cmdmap.has("set_audio_peak_filter")
+        assert (
+            apf_path not in acquisition["capabilities"]["command_response_observable"]
+        )
+        assert apf_path not in acquisition["field_policies"]
+
+        assert "nb" in profile.capabilities
+        assert "nb" in raw
+        assert cmdmap.has("get_nb")
+        assert cmdmap.has("set_nb")
+
+    def test_apf_support_is_profile_driven(self, profile):
+        ic7300 = CoreRadio("127.0.0.1", profile=profile)
+        ic7610_profile = load_rig(RIGS_DIR / "ic7610.toml").to_profile()
+        ic7610 = CoreRadio("127.0.0.1", profile=ic7610_profile)
+
+        for command in ("get_audio_peak_filter", "set_audio_peak_filter"):
+            assert command not in CoreRadio._KNOWN_COMMANDS
+            assert command not in profile.command_names
+            assert not ic7300.supports_command(command)
+
+            assert command in ic7610_profile.command_names
+            assert ic7610.supports_command(command)
+
+    @pytest.mark.asyncio
+    async def test_apf_calls_fail_before_wire_when_profile_omits_commands(
+        self, profile
+    ):
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        get_wire = AsyncMock()
+        set_wire = AsyncMock()
+        radio._get_bcd_level = get_wire
+        radio._send_fire_and_forget = set_wire
+
+        with pytest.raises(CommandError, match="not declared by this profile"):
+            await radio.get_audio_peak_filter()
+        with pytest.raises(CommandError, match="not declared by this profile"):
+            await radio.set_audio_peak_filter(1)
+
+        get_wire.assert_not_awaited()
+        set_wire.assert_not_awaited()
 
     def test_has_nr(self, profile):
         assert "nr" in profile.capabilities
@@ -233,7 +286,7 @@ class TestCapabilities:
         assert "ip_plus" in profile.capabilities
 
     def test_capabilities_match_pre_speech_baseline(self, profile):
-        assert profile.capabilities - {"speech"} == EXPECTED_41_BASELINE
+        assert profile.capabilities - {"speech"} == EXPECTED_BASELINE_CAPABILITIES
 
 
 # ── Command overrides ──────────────────────────────────────────

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -366,13 +366,15 @@ class TestMultiVendorProfiles:
             .capabilities
         )
 
-    def test_ic7300_speech_is_the_42nd_profile_capability(self):
-        """MOR-1609: speech is the sole post-A0 IC-7300 capability."""
+    def test_ic7300_speech_remains_after_unsupported_apf_is_removed(self):
+        """MOR-1609/MOR-2144: remove only APF, not supported capabilities."""
         rig = load_rig(RIGS_DIR / "ic7300.toml")
         profile = rig.to_profile()
 
         assert "speech" in profile.capabilities
-        assert len(profile.capabilities) == 42
+        assert "nb" in profile.capabilities
+        assert "apf" not in profile.capabilities
+        assert len(profile.capabilities) == 41
         assert rig.commands["set_speech"].bytes == (0x13,)
 
     def test_ftx1_without_announcement_routes_does_not_advertise_speech(self):


### PR DESCRIPTION
## Summary

- remove the unsupported IC-7300 `apf` capability, `[apf]` domain, acquisition declarations, and `get_/set_audio_peak_filter` command-map entries
- remove those two profile-bound operations from CoreRadio's profile-independent `_KNOWN_COMMANDS` fallback, so IC-7300 reports them unsupported and refuses both before wire I/O
- keep generic shared-Icom APF methods and IC-7610 profile declarations intact; IC-7610 remains supported through its real profile
- make the canonical state-3 coverage guard capability-aware: an omitted optional capability is hardware absence, while a profile that declares the capability but omits required commands remains red
- preserve a declared/supported NB positive control and update only deterministic APF-driven profile baselines

## Evidence

Official manual evidence and live bench evidence are distinct:

- Manual: IC-7300 Advanced Manual 11a, SHA-256 `a73a9600899e1e900bc5fbb0ecbec33d1883f68b5ff54905a660013f5f00c66c`; printed pp. 19-3/19-4 omit `16 32` and any Audio Peak Filter entry.
- Remote testbed: read-only `16 32` GET returned protocol NAK twice; documented adjacent `16 22` returned DATA before and after. No SET or TX command was sent.

Prerequisites already merged to `main`:

- documentation source-of-truth correction: #2964, `33fb34fed4fe8afcf8df1660d942d110721d6346`
- documentation tail correction: #2966, `0d7a399be577cc344ca3841b11476530e9598034`
- frontend fixture/conformance correction: #2970, `c3729d2cb8a57cda0552d7b909d57e0815685b29`

## Baseline changes

- command-coverage distinct gap keys: `148 -> 146`
- command-coverage profile/key gap pairs: `302 -> 298`
- removed rows only: X6100/X6200 `get_audio_peak_filter` and `set_audio_peak_filter`
- IC-7300 reverse-index census: `(330, 185, 287) -> (328, 184, 285)`
- IC-7300 non-polling acquisition fields: `23 -> 22`
- IC-7300 capabilities: `42 -> 41`

No TOML absent marker or allowlist entry was added.

## Verification

Final exact head: `69d5e158bb3a1b2ec3da3cbf0b1b11b75d5ff31d`

Local focused checks after the final re-anchor:

- retained focused pytest set plus supports-command coverage: `354 passed`
- assertions pin IC-7300 `supports_command=False`, get/set refusal before wire I/O, and IC-7610 `supports_command=True` through its real profile
- Ruff check: passed
- Ruff format check: passed
- import-linter: 5 contracts kept, 0 broken
- strict web mypy: passed
- diff check: passed

Mac mini exact-head Python verification:

- command: `~/bin/rp-remote-test.sh 69d5e158bb3a1b2ec3da3cbf0b1b11b75d5ff31d py`
- pytest: `14160 passed, 162 skipped, 48 xfailed` in 86.11s
- Ruff: passed
- final result: PASS
- the runner emits the terminal transcript directly and does not expose or persist a primary log path

## Scope

Nine files, `+167/-66`; profile, one runtime fallback, and canonical tests/baselines only. No documentation or frontend changes are included. MOR-2144 remains **In Progress** pending independent review and merge coordination.
