### PR TITLE
fix(MOR-2144): remove unsupported IC-7300 APF capability

### DIFF
--- a/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/conformance/claimed.ts
@@ -98,8 +98,9 @@
  * `expectRefusal` (every field this family reads — `voxOn`, `voxGain`,
  * `antiVoxGain`, `voxDelay`, `cwPitch`, `keySpeed`, `breakIn`,
  * `breakInDelay`, `main.apfTypeLevel`, `main.twinPeakFilter`, `dashRatio` —
- * is unobserved on the real IC-7300 fixture, though every base capability
- * the family needs IS declared); only `cw_auto_tune` genuinely DISPATCHES —
+ * is unobserved on the real IC-7300 fixture. The applicable base capabilities
+ * are declared, while IC-7300 intentionally does not declare `apf`; the APF
+ * handler remains fail-closed. Only `cw_auto_tune` genuinely DISPATCHES —
  * its gate (`hasCapability('cw') && knownActiveReceiver() !== null`) does
  * read one field-status leaf (`active`, via `knownActiveReceiver`'s own
  * `isFieldAvailable(state, 'active')` check), which IS unobserved on this

--- a/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-capabilities.json
+++ b/frontend/src/lib/runtime/adapters/__tests__/fixtures/ic7300-capabilities.json
@@ -33,7 +33,6 @@
     "af_level",
     "agc",
     "antenna",
-    "apf",
     "attenuator",
     "audio",
     "band_edge",

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1562-adapter-seams-conformance.isolated.test.ts
@@ -296,14 +296,14 @@ describe('panel-adapters.ts derive*Props over the live ic7300 fixture (MOR-1562)
     expect(deriveScanProps()).toEqual({ scanning: false, scanType: 0, scanResumeMode: 0 });
   });
 
-  it('deriveCwProps: mode-gated APF/TPF disable + full capability catalog for the live USB reading', () => {
+  it('deriveCwProps: mode-gated APF/TPF disable + honest capability catalog for the live USB reading', () => {
     expect(deriveCwProps()).toMatchObject({
       currentMode: 'USB',
       apfDisabled: true, // active mode is USB, not CW/CW-R
       tpfDisabled: true, // active mode is USB, not RTTY/RTTY-R
       hasCw: true,
       hasBreakIn: true,
-      hasApf: true,
+      hasApf: false, // IC-7300 manual/bench evidence does not declare APF
       hasTwinPeak: true,
     });
   });

--- a/frontend/src/lib/runtime/adapters/__tests__/mor1565-vox-cw-family-conformance.isolated.test.ts
+++ b/frontend/src/lib/runtime/adapters/__tests__/mor1565-vox-cw-family-conformance.isolated.test.ts
@@ -17,11 +17,12 @@
  * `antiVoxGain`, `voxDelay`, `cwPitch`, `keySpeed`, `breakIn`,
  * `breakInDelay`, `main.apfTypeLevel`, `main.twinPeakFilter`, `dashRatio` —
  * all `fieldStatus.*.observed === false`), even though every base
- * capability the family needs (`tx`, `vox`, `cw`, `break_in`, `apf`,
- * `twin_peak`) IS declared on this profile — the same MOR-988 §3.2
- * fail-closed shape MOR-1560's DSP walk already established: capability
- * present, sub-parameter never confirmed on the bench, so the handler
- * refuses. `cw_auto_tune` is the sole exception: it is an empty-params RX
+ * capabilities needed by the applicable IC-7300 paths (`tx`, `vox`, `cw`,
+ * `break_in`, `twin_peak`) are declared on this profile. IC-7300 does not
+ * declare `apf`; its APF handler therefore remains fail-closed — the same MOR-988 §3.2
+ * fail-closed shape MOR-1560's DSP walk already established: where a
+ * capability is present, its sub-parameter must still be confirmed on the
+ * bench; otherwise the handler refuses. `cw_auto_tune` is the sole exception: it is an empty-params RX
  * frequency-correction intent. Its gate requires `cw` and `audio` tags,
  * `audioFftAvailable === true`, and an observed active receiver frequency.
  * The IC-7300 fixture satisfies those RX-analysis prerequisites: its single
@@ -254,9 +255,9 @@ describe('IC-7300 fixture — VOX/CW family conformance (MOR-1565)', () => {
     }
   });
 
-  it("set_apf: REFUSES — main.apfTypeLevel is unobserved (onApfChange is the only dispatch site; mode is a binary toggle in CwPanel.svelte's own handler, not a range slider)", () => {
+  it("set_apf: REFUSES — APF is not declared on the IC-7300 fixture and main.apfTypeLevel is unobserved (onApfChange is the only dispatch site; mode is a binary toggle in CwPanel.svelte's own handler, not a range slider)", () => {
     expect(IC7300_CAPABILITIES.capabilities).toContain('cw');
-    expect(IC7300_CAPABILITIES.capabilities).toContain('apf');
+    expect(IC7300_CAPABILITIES.capabilities).not.toContain('apf');
     expect(IC7300_STATE.fieldStatus?.['main.apfTypeLevel']?.observed).toBe(false);
     expectRefusal(() => makeCwPanelHandlers().onApfChange(1));
   });


### PR DESCRIPTION
## Summary
- remove unsupported `apf` from the IC-7300 capability fixture
- keep APF conformance fail-closed and document the manual/bench-backed absence
- align IC-7300 adapter-seam and conformance summary expectations with the corrected capability catalog

Linear: MOR-2144
Status: In Progress

Evidence: the IC-7300 manual and owner-present bench evidence do not expose APF on this model; APF coverage for IC-7610 and generic profiles remains unchanged.

Dependency: intended to land before #2969.

## Verification
- Exact head: `577baedf89b3b3916e24f9459ac0d0759db1bddf`.
- Mac mini command: `~/bin/rp-remote-test.sh 577baedf89b3b3916e24f9459ac0d0759db1bddf fe`.
- Result: `FINAL: PASS`.
- Full frontend Vitest: 381 test files passed; 8,337 tests passed.
- Mac mini lint: PASS.
- Mac mini Svelte/type check: PASS, 0 errors, 0 warnings.
- MOR-1562 and MOR-1565 targeted conformance suites passed within the full run.
- The remote runner did not emit a persistent primary log path or run ID in its final summary.