### PR TITLE
feat(MOR-2153): compose the peer-split glass chassis

### DIFF
--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -397,13 +397,15 @@ export interface Fixture {
   audioRuntime?: Partial<AudioRuntimeState>;
   /**
    * MOR-1085. Which real component this fixture mounts: the
-   * dual-receiver-cockpit shell (default, unchanged from MOR-1070) or
+   * dual-receiver-cockpit shell (default, unchanged from MOR-1070),
    * `ReferenceLayout.svelte` (`SemanticRadioSurfaces strips="single"` — the
-   * same wiring `desktop-v2`/`sdr-test` compose today). One fixture id is
-   * one grid cell; `toReferenceFixture()` below derives every `--reference`
-   * id from its cockpit sibling.
+   * same wiring `desktop-v2`/`sdr-test` compose today), or — MOR-2153 —
+   * `PeerSplitLayout.svelte` (`skins/segmentline/`), the segmentline
+   * `peer-split` glass chassis. One fixture id is one grid cell;
+   * `toReferenceFixture()` below derives every `--reference` id from its
+   * cockpit sibling; `peer-split` fixtures have no such derivation.
    */
-  layout?: 'cockpit' | 'reference';
+  layout?: 'cockpit' | 'reference' | 'peer-split';
   /**
    * MOR-1355. `true` ⇒ `fixtures/main.ts` mounts this fixture with a REAL
    * resolved `SurfacePlan` (`resolveSurfacePlan(dualReceiverCockpitLayout,
@@ -412,7 +414,18 @@ export interface Fixture {
    * Default `false`/absent: the pre-MOR-1355 plan-less mount, unchanged.
    */
   planned?: boolean;
-  expect: Expectation;
+  /**
+   * MOR-2153. Absent for `layout: 'peer-split'` ONLY: `runAssertions`
+   * (`assertions.ts`, lines 171-683 — 513 lines) is written against the
+   * cockpit/reference `zonedComposition` binary, which `peer-split`'s
+   * five-band chassis is neither — building a third branch through that
+   * pipeline is real, separately-scoped work this ticket does not take on
+   * (the chassis is mostly empty rows today; MOR-2151(cont.) is what gives
+   * it something to assert against). `fixtures/main.ts` skips
+   * `runAssertions` when this is absent rather than passing it a shape it
+   * was never written to check.
+   */
+  expect?: Expectation;
 }
 
 const DUAL_ZONES = ['primary-vfo', 'secondary-vfo', 'global', 'rx-tx'] as const;
@@ -450,7 +463,15 @@ const mainSubExpect = (over: Partial<Expectation> = {}): Expectation => ({
  * reference-layout twin of each (except `tx-adjacent-alerts`, a
  * cockpit-zone-specific acceptance gate — see `toReferenceFixture`).
  */
-const CORE_FIXTURES: readonly Fixture[] = [
+/**
+ * MOR-2153 review: typed `Fixture & { expect: Expectation }`, not plain
+ * `Fixture` — every entry below sets `expect`, and this is what lets
+ * `.map(toReferenceFixture)` typecheck now that `expect` is optional on
+ * `Fixture` in general (see `toReferenceFixture`'s own comment). Still
+ * assignable everywhere a `Fixture` is expected (a narrower object type is
+ * a subtype), so `FIXTURES`'s `...CORE_FIXTURES` spread below is unaffected.
+ */
+const CORE_FIXTURES: readonly (Fixture & { expect: Expectation })[] = [
   {
     id: 'topology-1-single',
     what: '1/single — one receiver, one unslotted VFO; the cockpit degrades to one strip.',
@@ -805,7 +826,20 @@ const REFERENCE_SELECT_GATING_OVERRIDE: Readonly<Record<string, Pick<Expectation
   'topology-2-ab-shared-unsupported-controls': { selectsEnabled: 1, selectsDisabled: 0 },
 };
 
-function toReferenceFixture(f: Fixture): Fixture {
+/**
+ * MOR-2153 review: `f: Fixture` alone made `{ ...f.expect, … }` below
+ * unsound the moment `expect` became optional on `Fixture` — the spread's
+ * inferred type carries every `Expectation` field as possibly `undefined`
+ * (e.g. `tiles: number | undefined`), not assignable to the function's own
+ * `Fixture` return type. Every real call site (`CORE_FIXTURES` entries,
+ * `audioRuntimeFixture`'s inline literal) already always sets `expect`; the
+ * parameter type now says so, closing the gap rather than asserting past
+ * it. Verified with a scratch tsconfig adding `fixtures/**\/*.ts` to
+ * `include` (fixtures/ is otherwise typechecked by nothing —
+ * `tsconfig.app.json` includes only `src/**`): HEAD reports 1 error here,
+ * this fix reports 0.
+ */
+function toReferenceFixture(f: Fixture & { expect: Expectation }): Fixture {
   return {
     id: `${f.id}--reference`,
     what: `${f.what} [reference layout: SemanticRadioSurfaces strips="single", the wiring `
@@ -913,19 +947,49 @@ const PLANNED_FIXTURES: readonly Fixture[] = [
 ];
 
 /**
+ * MOR-2153 — `peer-split` (`skins/segmentline/PeerSplitLayout.svelte`), the
+ * segmentline glass CHASSIS. Reuses `abSharedState`/`abSharedCaps` verbatim
+ * (peer-split's manifest declares `2/ab_shared` as one of its two compatible
+ * topologies — `presentation/layouts/segmentline-declarations.ts` — and it
+ * is also the FTX-1's real topology, the accepted spec's own justification
+ * for building this direction first). `withMeters` overlays the sample
+ * meter readings the same way `topology-2-main-sub` does, so the (currently
+ * bare) meters surface has something to show.
+ *
+ * No `--reference`/`--planned` derivation: those exist for the
+ * cockpit/reference behavior-assertion comparison (`toReferenceFixture`
+ * above), which does not apply here (`expect` is deliberately absent — see
+ * that field's own doc comment on `Fixture`). This fixture is for LOOKING
+ * at the chassis, not for pinning its behavior.
+ */
+const PEER_SPLIT_FIXTURES: readonly Fixture[] = [
+  {
+    id: 'peer-split-chassis',
+    what: 'segmentline peer-split glass chassis: 2/ab_shared, both receivers present, meters '
+      + 'evidence populated. DSP rail, memory rail and the offsets row render EMPTY — no zone '
+      + 'declares dsp/rfFrontEnd/band/ritXitScan yet (MOR-2151(cont.), not this ticket).',
+    state: () => withMeters(abSharedState()), caps: abSharedCaps, tx: tx({}),
+    layout: 'peer-split',
+  },
+];
+
+/**
  * The full MOR-1085 grid: every `CORE_FIXTURES` (dual-receiver-cockpit)
  * entry, plus its reference-layout twin — except `tx-adjacent-alerts`, whose
  * whole point is the cockpit's OWN zone-containment acceptance gate (b) and
  * has no reference-layout equivalent (the reference/single composition has
  * no zone concept for the three alerts to be "inside" or "outside" of; see
  * `zonedComposition` in `assertions.ts`) — plus MOR-1355's `PLANNED_FIXTURES`
- * (no reference twin either; see the comment above `PLANNED_FIXTURES`).
+ * (no reference twin either; see the comment above `PLANNED_FIXTURES`) and
+ * MOR-2153's `PEER_SPLIT_FIXTURES` (no reference/planned twin either — see
+ * the comment above that array).
  */
 export const FIXTURES: readonly Fixture[] = [
   ...CORE_FIXTURES,
   ...CORE_FIXTURES.filter((f) => f.id !== 'tx-adjacent-alerts').map(toReferenceFixture),
   ...PLANNED_FIXTURES,
   ...AUDIO_RUNTIME_FIXTURES,
+  ...PEER_SPLIT_FIXTURES,
 ];
 
 export const fixtureById = (id: string): Fixture | undefined =>

--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -27,6 +27,7 @@ import { desktopV2Layout, dualReceiverCockpitLayout } from '../src/presentation/
 import { readWorkspace } from '../src/presentation/workspace/contract';
 import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../src/presentation/workspace/resolution';
 import DualReceiverCockpit from '../src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte';
+import PeerSplitLayout from '../src/skins/segmentline/PeerSplitLayout.svelte';
 import ReferenceLayout from './ReferenceLayout.svelte';
 import {
   runAssertions, styleProbe, tokenSnapshot, type AssertionOptions,
@@ -41,15 +42,23 @@ const fixture = fixtureById(id);
 if (!fixture) throw new Error(`MOR-1070 harness: unknown fixture id "${id}"`);
 
 /**
- * MOR-1085 — which of the two layouts this fixture mounts. The fixture ITSELF
+ * MOR-1085 — which of the layouts this fixture mounts. The fixture ITSELF
  * carries this (not a separate `&layout=` query param) so one fixture id is
  * one grid cell: `catalog.ts`'s `toReferenceFixture` derives every
  * `--reference` id from its `dual-receiver-cockpit` sibling, and the two
  * always mount the corresponding real component. See `ReferenceLayout.svelte`
  * for why that component, rather than the full `RadioLayout`, stands in for
  * "the reference current layout" here.
+ *
+ * MOR-2153 adds `'peer-split'`, rooted at `PeerSplitLayout.svelte`'s own
+ * `data-testid="peer-split-glass"` wrapper — the glass, not the stage holder
+ * around it, since the holder is chrome-adjacent plumbing (Lesson 4 in that
+ * file's header) rather than the composition `focusOrder()`/`activeControl()`
+ * below are describing.
  */
-const ROOT_TEST_ID = fixture.layout === 'reference' ? 'reference-layout' : 'dual-receiver-cockpit';
+const ROOT_TEST_ID = fixture.layout === 'reference' ? 'reference-layout'
+  : fixture.layout === 'peer-split' ? 'peer-split-glass'
+    : 'dual-receiver-cockpit';
 
 if ((params.get('theme') ?? 'v2') === 'v2') {
   await import('../src/components-v2/theme/index');
@@ -63,8 +72,17 @@ if ((params.get('theme') ?? 'v2') === 'v2') {
 const LANGUAGE_STYLESHEETS: Record<string, () => Promise<unknown>> = {
   studioline: () => import('../src/presentation/languages/studioline/studioline.css'),
   fieldline: () => import('../src/presentation/languages/fieldline/fieldline.css'),
+  segmentline: () => import('../src/presentation/languages/segmentline/segmentline.css'),
 };
-const language = params.get('language');
+/**
+ * MOR-2153 — `peer-split` is segmentline's OWN skin: with no language
+ * activated it renders as unstyled markup (no amber glass, no bezel colour,
+ * no cell/readout treatment), which defeats the point of looking at it. The
+ * explicit `&language=` param still wins when given (e.g. to inspect the
+ * bare DOM), matching how every other fixture already lets the query
+ * string override any default.
+ */
+const language = params.get('language') ?? (fixture.layout === 'peer-split' ? 'segmentline' : null);
 if (language) {
   const load = LANGUAGE_STYLESHEETS[language];
   if (!load) throw new Error(`MOR-1074 harness: unknown design language "${language}"`);
@@ -135,6 +153,18 @@ harness.calls = [];
  * unconditionally, not a per-fixture experiment — the same default-workspace
  * recipe as the cockpit's `dualReceiverCockpitLayout` resolution above.
  */
+/**
+ * MOR-2153 — `peer-split` fixtures never set `fixture.planned` (see
+ * `PEER_SPLIT_FIXTURES` in `catalog.ts`), so `plan` falls through to `null`
+ * for them here unchanged, on purpose: `PeerSplitLayout.svelte`'s single
+ * declared zone (`peer-columns`: vfo+rxTx) does not gate anything this
+ * chassis currently mounts — `.channel-strips`/`.cockpit-global-row`/
+ * `.rx-tx-zone` render unconditionally and `txAux`/`meters`/`scopeDisplay`
+ * render bare either way (their `allowBare` default is `true`) — so
+ * resolving a plan here would add plumbing with no observable effect. See
+ * `SemanticRadioSurfaces.svelte`'s MOR-2150 comment for the nine surfaces a
+ * plan WOULD matter for; none is declared for `peer-split` yet.
+ */
 const plan = fixture.layout === 'reference'
   ? resolveSurfacePlan(desktopV2Layout, readWorkspace({ version: 1 }).workspace)
   : fixture.planned
@@ -145,10 +175,12 @@ const context = plan === null
   : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
 
 document.title = `MOR-1070 · ${fixture.id}`;
-mount(fixture.layout === 'reference' ? ReferenceLayout : DualReceiverCockpit, {
-  target: document.getElementById('app')!,
-  context,
-});
+mount(
+  fixture.layout === 'reference' ? ReferenceLayout
+    : fixture.layout === 'peer-split' ? PeerSplitLayout
+      : DualReceiverCockpit,
+  { target: document.getElementById('app')!, context },
+);
 flushSync();
 
 declare global {
@@ -174,8 +206,19 @@ declare global {
 window.__harness = {
   fixture: fixture.id,
   what: fixture.what,
-  assert: (options: AssertionOptions = {}) =>
-    runAssertions(fixture.expect, { ...options, rootTestId: ROOT_TEST_ID }),
+  // MOR-2153: `fixture.expect` is absent for `peer-split` fixtures —
+  // `runAssertions` (`assertions.ts`, lines 171-683 — 513 lines) is written
+  // against the cockpit/reference `zonedComposition` binary, which the
+  // five-band chassis is neither; see the field's own doc comment on
+  // `Fixture` in catalog.ts. Skip the pipeline rather than pass it a shape
+  // it cannot check.
+  assert: (options: AssertionOptions = {}) => (fixture.expect
+    ? runAssertions(fixture.expect, { ...options, rootTestId: ROOT_TEST_ID })
+    : [{
+      name: 'peer-split-no-assertion-pipeline', ok: true,
+      detail: 'peer-split fixtures carry no behavior-assertion pipeline yet (MOR-2153) — this '
+        + 'confirms the harness mounted, not that the composition is correct.',
+    }]),
   tokens: tokenSnapshot,
   paint: styleProbe,
   calls: () => harness.calls,

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -1,36 +1,321 @@
 <!--
-  Peer Split Layout (MOR-2155) — the `peer-split` SkinId's minimal shell.
-  Makes the id addressable and loadable only: NOT backed by a layout
-  manifest (MOR-2151) and NOT reachable from `resolveSkinId` or the picker
-  (MOR-2152). Real composition is MOR-2153 — this mounts the dual-receiver
-  wiring (`SemanticRadioSurfaces` with `strips="dual"`) and nothing else,
-  same wiring `dual-receiver-cockpit/DualReceiverCockpit.svelte` reuses
-  unmodified. Only ONE `SemanticRadioSurfaces` may ever be mounted here: a
-  second would be a second TX lease source, and single TX authority is the
-  hardest invariant in this tree (see that file's header for the full
-  rationale).
+  Peer Split Layout (MOR-2153) — the `peer-split` glass CHASSIS.
 
-  Cannot be mounted standalone: `SemanticRadioSurfaces` calls
-  `getAppTxController()`, which throws `Error: App TxController host is not
-  provided` unless `provideAppTxControllerHost` ran higher in the tree — that
-  is `App.svelte`'s job, not this shell's. Confirmed by mounting this
-  component directly with no App-provided context: it throws before adding
-  anything to the DOM (empty `innerHTML`, zero children). Do not add a mock
-  or stub host here to paper over that — MOR-2153 owns real composition, and
-  a real render needs the same harness `DualReceiverCockpit.component.test.ts`
-  builds (App's runtime/tx-controller/command mocks), not a shortcut in this
-  file.
+  SCOPE CORRECTION (owner ruling, 2026-09-01): the coordinator's original
+  brief for this ticket assumed the layout manifest already declared the
+  full five-band zone set (status/DSP/memory rails, offsets, mode/filter
+  cells). It does not — `presentation/layouts/segmentline-declarations.ts`
+  currently declares exactly one zone (`peer-columns`: vfo+rxTx), and
+  `docs/plans/2026-09-01-segmentline-peer-split.md` §7 sequences "the
+  manifest's remaining zones" (row 7) BEFORE "compose the glass" (row 9,
+  this ticket) — an order the brief itself violated. That work is
+  MOR-2151(cont.), under review elsewhere, and this file does not touch it
+  (`presentation/layouts/**` and every `*-declarability.test.ts` are
+  explicitly out of scope here).
+
+  What this file builds instead is the CHASSIS: everything that does not
+  depend on a declared zone. Concretely, against
+  `~/Projects/rigplane-archives/segmentline-handoff-2026-09-01/handoff/
+  INTEGRATION.md` §4's five-band geometry (status rail 34 / rule 1 /
+  receiver body flexible / DSP rail 40 / memory rail 34, native 1280x540,
+  14px padding inside a 2px bezel, 10px radius):
+
+    POPULATED today (real DOM the dual composition already emits with no
+    zone declared — `SemanticRadioSurfaces.svelte`'s `strips="dual"`
+    branch): the two VFO channel strips (`.channel-strips`), the
+    radio-wide split/dual-watch row (`.cockpit-global-row`), the RX/TX
+    status+action zone (`.rx-tx-zone`), and the three optional surfaces
+    whose `allowBare` default is still `true` — `txAux`, `meters`,
+    `scopeDisplay` (`SemanticRadioSurfaces.svelte` lines ~1410-1436).
+
+    EMPTY, reserved (grid rows with no assigned child — see the `<style>`
+    block below): the DSP rail (`dsp`/`rfFrontEnd`) and the memory rail
+    (`band`, plus the geometry table's "telemetry" cell, which names no
+    surface in `contract.ts`'s `SEMANTIC_SURFACE_NAMES` — left unassigned
+    rather than guessed at). Every one of these renders NOTHING at all
+    under the current manifest: `zoned(..., allowBare=false)` (MOR-2150)
+    means "no declared zone" is "no DOM", not "bare". Those two rows keep
+    the archived table's fixed 40/34px, since nothing occupies them yet to
+    prove otherwise either way.
+
+    NOT both fully visible without scrolling, at the native 540px height,
+    with this fixture's actual content: MEASURED (real browser) `.semantic-
+    surfaces` `scrollHeight` 531 against a `clientHeight` of 508 — the
+    `auto` rows above (status/global/vfo) already claim more of the native
+    height than is left for the two reserved rows plus the 72px meters/
+    scope floor. Row 6 (DSP rail, 40px) sits fully inside the visible
+    508px. Row 7 (memory rail, 34px) does not: only its first ~11.5px
+    shows; the rest needs the scroll the base wiring's own `overflow: auto`
+    on `.semantic-surfaces` (untouched here) already provides. This will
+    move once real content lands in either row — recorded as the current
+    fixture's measurement, not a claim about every future one.
+
+    This file's placement rules below select surface classes directly
+    (`.tx-aux-surface`, `.meters-surface`, `.scope-display-surface`) —
+    NOT `.surface-zone`, the wrapper `zoned()` (MOR-2150,
+    `SemanticRadioSurfaces.svelte`) actually emits once a zone IS declared
+    for a surface. MEASURED (real browser, a synthetic plan declaring all
+    fourteen surfaces): a declared zone puts `.surface-zone` in the grid,
+    not the surface's own class, so it lands by the browser's implicit
+    auto-placement — observed landing at rows 6/7/9 — and every
+    surface-class rule below goes inert for that surface the moment a zone
+    owns it. What (if anything) should route a declared zone to a specific
+    row is undecided and unwritten here; that decision belongs to
+    MOR-2151(cont.)'s own ticket, not a prediction in this file.
+
+    NOT the archived table's fixed 34px status rail: MEASURED (real
+    browser) that `RxTxSurface`/`TxAuxSurface` render normal-density
+    buttons and sliders — 13 controls for `TxAuxSurface` alone — not the
+    compact icon-sized flag cells 34px assumes. Row 1 is `auto`; see the
+    `<style>` block's own note at that rule for what a fixed 34px actually
+    did (clipped ~90% of both surfaces invisibly).
+
+  Everything else in this header documents the four hard-won lessons the
+  archived package's own author did not verify by running (the brief's own
+  citation):
+
+  1. THE GRID HOST IS `.semantic-surfaces`, NOT THE STAGE. `<ScaledStage>`'s
+     only child is `SemanticRadioSurfaces`'s own root
+     (`.semantic-surfaces`), so every zone is a GRANDCHILD of the stage —
+     a grid declared on the stage places nothing. The `:global(...)`
+     selectors below are rooted at `.semantic-surfaces` itself.
+  2. THE GRID IS TWO COLUMNS UNIFORMLY (`grid-template-columns: 1fr 1fr`
+     below), not per-row pairing logic — rows 6/7 (dsp-rail/memory-rail)
+     inherit the same two tracks because the WHOLE grid does, not because
+     anything here pairs DSP against front-end or memory against
+     telemetry. MEASURED (see the reserved-rows note above): with a
+     synthetic plan declaring `filter`/`dsp`/`rfFrontEnd`/`band`, the
+     browser's own implicit auto-placement — not a design choice made
+     here — put `filter`|`dsp` in row 6 and `rfFrontEnd`|`band` in row 7,
+     an artifact of `zoned()`'s call order in `SemanticRadioSurfaces.svelte`,
+     not anything this file controls or can promise for a different zone
+     set.
+  3. CHROME IS A SIBLING OF THE STAGE, NEVER A CHILD. `.peer-split-holder`
+     wraps `<ScaledStage>`; nothing chrome-like lives inside its
+     `children` snippet. The wall-clock below is NOT chrome by this
+     definition — it is instrument face, same category as a real LCD's
+     printed clock, so it lives inside the scaled stage and scales with
+     everything else.
+  4. THE STAGE'S PARENT NEEDS A DEFINITE HEIGHT ON BOTH AXES. `.peer-split-
+     holder` itself is `display: flex; height: 100%; min-height: 0`;
+     `flex: 1` lives one level down, on `ScaledStage`'s own
+     `.scaled-stage-holder` root (reached via `:global()`, see the
+     `<style>` block). Verified against the real `ScaledStage` in a
+     browser (jsdom does no grid/flex sizing — see
+     `ScaledStage.svelte`'s own header, and the MOR-2153 build report for
+     the exact render command and what it showed).
+
+  TX PERIMETER: `.dl-glass` (segmentline.css) already carries the whole
+  mechanism — `.dl-glass[data-tx='active']` is the hot-bezel-plus-glow
+  rule the tokens/renderer describe as "frame, not wash". This file
+  applies the `dl-glass` class but does NOT set `data-tx` from live TX
+  state: `AppGlobalHost.svelte`'s own header is explicit that "layouts and
+  skins must not host" the TX/fault indication — mounting a second
+  `getAppTxController()` subscription here to drive a border color would
+  cross that boundary, not stay inside "all chrome, none zone-dependent"
+  as the brief characterized it. Recorded as a real gap, not silently
+  wired around: `data-tx` is unset, so the bezel currently never lights.
+
+  WALL CLOCK: UTC/local time is not radio state — nothing in
+  `semantic/radio-view-model.ts` or the segmentline renderers carries it
+  (confirmed by grep — no clock/UTC field exists anywhere in that layer),
+  because there is nothing to carry: the operator's own local and UTC time
+  is already known to the client. Rendered directly below from `Date`,
+  ticked every 30 seconds; this is not a violation of "radio truth flows
+  through the model" because it is not radio truth.
 -->
 <script lang="ts">
-  // MOR-1257 (N4): the components-v2 theme layer (fonts, base tokens, and
-  // the MOR-1232 focus-ring pair --v2-focus-ring-color/--v2-focus-ring) is
-  // code-split per skin. A standalone mount that skips this side-effect
-  // import never loads the theme layer, and app.css's
-  // `outline: var(--v2-focus-ring, var(--focus-ring))` silently falls back
-  // to the legacy ring (MOR-1070 evidence run finding N4, same reasoning
-  // `DualReceiverCockpit.svelte` documents for its own copy of this import).
+  // MOR-1257 (N4): the components-v2 theme layer is code-split per skin —
+  // see `DualReceiverCockpit.svelte`'s identical import for the full
+  // rationale (MOR-1070 evidence run finding N4).
   import '../../components-v2/theme/index';
+  import ScaledStage from '../../primitives/stage/ScaledStage.svelte';
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
+
+  /** Matches `SEGMENTLINE_GLASS_STAGE` in
+   *  `presentation/layouts/segmentline-declarations.ts` — duplicated here
+   *  because `ScaledStage` takes `nativeW`/`nativeH` as props and reads no
+   *  manifest (the manifest's own native-size declaration stays
+   *  declaration-only outside `presentation/layouts/` per MOR-1247; see
+   *  that file's own header). */
+  const NATIVE_W = 1280;
+  const NATIVE_H = 540;
+
+  /** Wall-clock only — see the file header. `Date`, not radio state. */
+  function clockLabel(date: Date): { utc: string; local: string } {
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return {
+      utc: `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}Z`,
+      local: `${pad(date.getHours())}:${pad(date.getMinutes())}`,
+    };
+  }
+
+  let now = $state(new Date());
+  $effect(() => {
+    const id = setInterval(() => { now = new Date(); }, 30_000);
+    return () => clearInterval(id);
+  });
+  let clock = $derived(clockLabel(now));
 </script>
 
-<SemanticRadioSurfaces strips="dual" />
+<div class="peer-split-holder">
+  <ScaledStage nativeW={NATIVE_W} nativeH={NATIVE_H}>
+    <div class="dl-glass peer-split-glass" data-testid="peer-split-glass">
+      <div class="peer-split-clock" data-testid="peer-split-clock" aria-label="Clock">
+        <span data-testid="peer-split-clock-utc">{clock.utc}</span>
+        <span data-testid="peer-split-clock-local">{clock.local}</span>
+      </div>
+      <SemanticRadioSurfaces strips="dual" />
+    </div>
+  </ScaledStage>
+</div>
+
+<style>
+  /* Lesson 4: a definite box on both axes for ScaledStage's own
+     ResizeObserver to measure. Verified in a real browser — see the file
+     header and the MOR-2153 build report. */
+  .peer-split-holder {
+    display: flex;
+    height: 100%;
+    min-height: 0;
+  }
+  /* ScaledStage's own root (`scaled-stage-holder`) is `width:100%;
+     height:100%` against ITS containing block; as a flex child of the
+     holder above it also needs to actually claim that space rather than
+     content-size to zero. Reached via :global() rather than edited in the
+     shared primitive — the same "chrome is a sibling, stage stays
+     untouched" discipline applies to the primitive's own file. */
+  .peer-split-holder :global(.scaled-stage-holder) {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .peer-split-glass {
+    height: 100%;
+  }
+
+  /* Lesson 3: the clock is instrument face, inside the scaled stage, never
+     app chrome. `.dl-glass > *` (segmentline.css) already promotes every
+     direct child to `position: relative; z-index: 2` — MEASURED (real
+     browser, `getComputedStyle`) to be an exact specificity TIE with the
+     rule below, not the win the first draft of this comment assumed:
+     segmentline.css's full selector is
+     `[data-design-language='segmentline'][data-design-language] .dl-glass
+     > *` (two attributes + one class = 0,3,0), and Svelte compiles this
+     component's own scoping hash onto the second half of a `>` chain
+     wrapped in `:where()` — zero specificity — so `.peer-split-glass
+     .s-xxx > .peer-split-clock:where(.s-xxx)` also lands at exactly 0,3,0.
+     A tie falls back to stylesheet ORDER, and segmentline.css loads AFTER
+     this component's own compiled style (dynamic `import()` in
+     `fixtures/main.ts`, versus this file's static import), so it won —
+     confirmed live (clock rendered in-flow at the top of the glass,
+     `getComputedStyle(...).position === 'relative'`) before this
+     `!important` was added. `!important` is scoped to the one property two
+     components' stylesheets both set on the same element with no reliable
+     load-order guarantee (production's real activation timing is no more
+     ordered than this harness's), not a general escape hatch. */
+  .peer-split-glass > .peer-split-clock {
+    position: absolute !important;
+    top: 14px;
+    right: 14px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    pointer-events: none;
+  }
+
+  /* Lesson 1 + 2: the grid host is the WIRING'S OWN root, reached by
+     descendant combinator, not the stage. Compiled, this rule is
+     `.peer-split-glass.s-xxx :global(.semantic-surfaces.semantic-surfaces)`
+     — 4 classes (0,4,0), doubling `.semantic-surfaces` deliberately —
+     against the wiring's own base rule, compiled to `.semantic-surfaces
+     .s-yyy` (2 classes, 0,2,0). (0,4,0) outranks (0,2,0) regardless of
+     which component's <style> the bundler places first — CONFIRMED live
+     (`getComputedStyle(surfaces).display === 'grid'`), unlike the clock
+     rule below, which needed the same measurement to find it does NOT win
+     this way. Every other override below only ADDS grid-row/grid-column,
+     properties nothing else sets on these elements, so no such doubling is
+     needed there. */
+  .peer-split-glass :global(.semantic-surfaces.semantic-surfaces) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    /* status-rail(auto — see the row-1 note below) / rule(1) / global-row
+       (auto, not one of the archived five bands — the wiring's own
+       radio-wide row, given its own space rather than forced into a
+       documented band it doesn't describe) / receiver-body: vfo(auto) /
+       receiver-body: meters+scope remainder(min 72px, else 1fr —
+       MEASURED, real browser: with a plain `minmax(0, 1fr)` the four
+       `auto` tracks above it (status/global/vfo, 245+104+34px with the
+       fixture's actual content) already claim nearly all of the native
+       540px height, so the flexible track collapsed to ~1.5px — legible
+       nothing rather than a visibly short meters/scope band. 72px is a
+       floor, not a fit: the base wiring's own `overflow: auto` on
+       `.semantic-surfaces`, untouched here, is what a real overrun of the
+       native height falls back to) / dsp-rail(40, reserved) /
+       memory-rail(34, reserved) */
+    grid-template-rows: auto 1px auto auto minmax(72px, 1fr) 40px 34px;
+    column-gap: 8px;
+    /* The wiring's own base rule sets `gap: 8px` (a flex gap in its
+       unmodified form), which — MEASURED, real browser — survives as an
+       inherited `row-gap: 8px` here: overriding `display`/`grid-template-
+       *`/`column-gap` above does not touch that longhand, since cascade
+       resolution runs per property, not per rule. Six row gaps at 8px was
+       48px of the total overflow past the native 540px height (`.semantic-
+       surfaces` `scrollHeight` measured taller than `clientHeight` before
+       this line existed). Zeroed explicitly rather than left inherited. */
+    row-gap: 0;
+  }
+  /* The 1px ink rule between status rail and body. No real DOM element for
+     it — `.semantic-surfaces` is the wiring's own root, not this file's
+     markup — so it is drawn as a pseudo-element on the grid host itself,
+     occupying row 2 like any other grid item. */
+  .peer-split-glass :global(.semantic-surfaces.semantic-surfaces)::before {
+    content: '';
+    grid-row: 2;
+    grid-column: 1 / -1;
+    background: var(--dl-segmentline-ink-soft, rgba(26, 16, 0, 0.34));
+  }
+  /* Row 1 is `auto`, not the archived geometry's fixed 34px: MEASURED (real
+     browser) that `RxTxSurface`/`TxAuxSurface` render normal-density
+     buttons and sliders (13 controls for txAux alone), not the compact
+     icon-sized flag cells the mockup's 34px status rail assumed. A fixed
+     34px + `overflow: hidden` was tried first and clipped ~90% of both
+     surfaces invisibly — real content hidden behind a band that LOOKED
+     complete, exactly the "screenshot that hides which half is real"
+     shape to avoid. `auto` shows what is actually there. */
+  .peer-split-glass :global(.rx-tx-zone) {
+    grid-row: 1;
+    grid-column: 1;
+  }
+  .peer-split-glass :global(.tx-aux-surface) {
+    grid-row: 1;
+    grid-column: 2;
+  }
+  .peer-split-glass :global(.cockpit-global-row) {
+    grid-row: 3;
+    grid-column: 1 / -1;
+  }
+  .peer-split-glass :global(.channel-strips) {
+    grid-row: 4;
+    grid-column: 1 / -1;
+  }
+  .peer-split-glass :global(.meters-surface) {
+    grid-row: 5;
+    grid-column: 1;
+    overflow: auto;
+  }
+  .peer-split-glass :global(.scope-display-surface) {
+    grid-row: 5;
+    grid-column: 2;
+    overflow: auto;
+  }
+  /* Rows 6 (dsp-rail) and 7 (memory-rail) intentionally have no selector
+     below: nothing currently mounts into them (see the file header), and
+     an empty grid row with no assigned item is simply empty space at the
+     declared height — not a placeholder to build. */
+</style>

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -5,12 +5,9 @@
   brief for this ticket assumed the layout manifest already declared the
   full five-band zone set (status/DSP/memory rails, offsets, mode/filter
   cells). It does not — `presentation/layouts/segmentline-declarations.ts`
-  currently declares exactly one zone (`peer-columns`: vfo+rxTx), and
-  `docs/plans/2026-09-01-segmentline-peer-split.md` §7 sequences "the
-  manifest's remaining zones" (row 7) BEFORE "compose the glass" (row 9,
-  this ticket) — an order the brief itself violated. That work is
-  MOR-2151(cont.), under review elsewhere, and this file does not touch it
-  (`presentation/layouts/**` and every `*-declarability.test.ts` are
+  currently declares exactly one zone (`peer-columns`: vfo+rxTx). That work
+  is MOR-2151(cont.), under review elsewhere, and this file does not touch
+  it (`presentation/layouts/**` and every `*-declarability.test.ts` are
   explicitly out of scope here).
 
   What this file builds instead is the CHASSIS: everything that does not
@@ -101,20 +98,23 @@
      `flex: 1` lives one level down, on `ScaledStage`'s own
      `.scaled-stage-holder` root (reached via `:global()`, see the
      `<style>` block). Verified against the real `ScaledStage` in a
-     browser (jsdom does no grid/flex sizing — see
-     `ScaledStage.svelte`'s own header, and the MOR-2153 build report for
-     the exact render command and what it showed).
+     browser (jsdom implements neither layout nor `ResizeObserver` — see
+     `primitives/stage/__tests__/ScaledStage.isolated.test.ts`'s own
+     header, not `ScaledStage.svelte`'s, which never mentions jsdom).
 
-  TX PERIMETER: `.dl-glass` (segmentline.css) already carries the whole
-  mechanism — `.dl-glass[data-tx='active']` is the hot-bezel-plus-glow
-  rule the tokens/renderer describe as "frame, not wash". This file
-  applies the `dl-glass` class but does NOT set `data-tx` from live TX
-  state: `AppGlobalHost.svelte`'s own header is explicit that "layouts and
-  skins must not host" the TX/fault indication — mounting a second
+  TX PERIMETER: no hot-bezel/glow mechanism exists for this element. Before
+  #2968, segmentline.css declared `.dl-glass[data-tx='active']` and its
+  `::after` glow; that retarget renamed `.dl-glass` to `.rx-tx-surface`
+  everywhere, INCLUDING that rule, and this file no longer wears either
+  class (see the `<style>` block below) — there is nothing left in
+  segmentline.css for this element to inherit even if the rule had
+  survived. This file's own `.peer-split-glass` rule does not add a
+  replacement, and does not set a `data-tx` attribute either:
+  `AppGlobalHost.svelte`'s own header is explicit that "layouts and skins
+  must not host" the TX/fault indication — mounting a second
   `getAppTxController()` subscription here to drive a border color would
-  cross that boundary, not stay inside "all chrome, none zone-dependent"
-  as the brief characterized it. Recorded as a real gap, not silently
-  wired around: `data-tx` is unset, so the bezel currently never lights.
+  cross that boundary. Recorded as a real, currently-unaddressed gap: the
+  bezel has no TX-active treatment.
 
   WALL CLOCK: UTC/local time is not radio state — nothing in
   `semantic/radio-view-model.ts` or the segmentline renderers carries it
@@ -160,7 +160,7 @@
 
 <div class="peer-split-holder">
   <ScaledStage nativeW={NATIVE_W} nativeH={NATIVE_H}>
-    <div class="dl-glass peer-split-glass" data-testid="peer-split-glass">
+    <div class="peer-split-glass" data-testid="peer-split-glass">
       <div class="peer-split-clock" data-testid="peer-split-clock" aria-label="Clock">
         <span data-testid="peer-split-clock-utc">{clock.utc}</span>
         <span data-testid="peer-split-clock-local">{clock.local}</span>
@@ -191,32 +191,46 @@
     min-height: 0;
   }
 
+  /* The chassis bezel. Before #2968 (MOR-2163) this came from
+     segmentline.css's `.dl-glass` rule — that retarget renamed `.dl-glass`
+     to `.rx-tx-surface` everywhere, and this element never wore the new
+     name, so nothing styled it at all (MOR-2153 review: dead-class
+     finding). Restored here as the skin's OWN rule instead of re-adding a
+     design-language selector nothing else in this file's markup matches
+     — a `.dl-glass`/`.rx-tx-surface` re-add would be reported as an orphan
+     by the same guardrail that caught the original deletion and would get
+     deleted again. Colour and border tone come from segmentline.css's
+     `[data-design-language='segmentline']` root rule, which still declares
+     them; geometry (14px padding, 2px border, 10px radius) has no matching
+     custom property there — `tokens.ts`'s own comment calls 2px "the
+     chassis bezel" but declares no CSS variable for it — so it stays a
+     literal, matching what `.rx-tx-surface` still declares today. The
+     fallback literals below match segmentline.css's own declared values
+     for the same custom properties, the same pattern
+     `--dl-segmentline-ink-soft`'s fallback two rules down already uses. */
   .peer-split-glass {
     height: 100%;
+    position: relative;
+    overflow: hidden;
+    box-sizing: border-box;
+    padding: 14px;
+    border: 2px solid var(--dl-segmentline-bezel-edge, #8a7020);
+    border-radius: 10px;
+    background: var(--dl-segmentline-glass, #c8a030);
+    color: var(--dl-segmentline-ink-strong, rgba(26, 16, 0, 1));
   }
 
   /* Lesson 3: the clock is instrument face, inside the scaled stage, never
-     app chrome. `.dl-glass > *` (segmentline.css) already promotes every
-     direct child to `position: relative; z-index: 2` — MEASURED (real
-     browser, `getComputedStyle`) to be an exact specificity TIE with the
-     rule below, not the win the first draft of this comment assumed:
-     segmentline.css's full selector is
-     `[data-design-language='segmentline'][data-design-language] .dl-glass
-     > *` (two attributes + one class = 0,3,0), and Svelte compiles this
-     component's own scoping hash onto the second half of a `>` chain
-     wrapped in `:where()` — zero specificity — so `.peer-split-glass
-     .s-xxx > .peer-split-clock:where(.s-xxx)` also lands at exactly 0,3,0.
-     A tie falls back to stylesheet ORDER, and segmentline.css loads AFTER
-     this component's own compiled style (dynamic `import()` in
-     `fixtures/main.ts`, versus this file's static import), so it won —
-     confirmed live (clock rendered in-flow at the top of the glass,
-     `getComputedStyle(...).position === 'relative'`) before this
-     `!important` was added. `!important` is scoped to the one property two
-     components' stylesheets both set on the same element with no reliable
-     load-order guarantee (production's real activation timing is no more
-     ordered than this harness's), not a general escape hatch. */
+     app chrome. Positioned absolute against `.peer-split-glass` itself,
+     which sets `position: relative` above. No `!important` needed: the
+     specificity tie a previous draft of this rule fought (MOR-2153 review)
+     existed only because this element wore the `dl-glass` class, so
+     segmentline.css's `.dl-glass > *` / `.rx-tx-surface > *` promotion rule
+     could reach it — it no longer wears that class (see the glass rule
+     above and the markup below), so that rule cannot match this element at
+     all and there is nothing left to out-rank. */
   .peer-split-glass > .peer-split-clock {
-    position: absolute !important;
+    position: absolute;
     top: 14px;
     right: 14px;
     height: 34px;

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -10,119 +10,6 @@
   it (`presentation/layouts/**` and every `*-declarability.test.ts` are
   explicitly out of scope here).
 
-  What this file builds instead is the CHASSIS: everything that does not
-  depend on a declared zone. Concretely, against
-  `~/Projects/rigplane-archives/segmentline-handoff-2026-09-01/handoff/
-  INTEGRATION.md` §4's five-band geometry (status rail 34 / rule 1 /
-  receiver body flexible / DSP rail 40 / memory rail 34, native 1280x540,
-  14px padding inside a 2px bezel, 10px radius):
-
-    POPULATED today (real DOM the dual composition already emits with no
-    zone declared — `SemanticRadioSurfaces.svelte`'s `strips="dual"`
-    branch): the two VFO channel strips (`.channel-strips`), the
-    radio-wide split/dual-watch row (`.cockpit-global-row`), the RX/TX
-    status+action zone (`.rx-tx-zone`), and the three optional surfaces
-    whose `allowBare` default is still `true` — `txAux`, `meters`,
-    `scopeDisplay` (`SemanticRadioSurfaces.svelte` lines ~1410-1436).
-
-    EMPTY, reserved (grid rows with no assigned child — see the `<style>`
-    block below): the DSP rail (`dsp`/`rfFrontEnd`) and the memory rail
-    (`band`, plus the geometry table's "telemetry" cell, which names no
-    surface in `contract.ts`'s `SEMANTIC_SURFACE_NAMES` — left unassigned
-    rather than guessed at). Every one of these renders NOTHING at all
-    under the current manifest: `zoned(..., allowBare=false)` (MOR-2150)
-    means "no declared zone" is "no DOM", not "bare". Those two rows keep
-    the archived table's fixed 40/34px, since nothing occupies them yet to
-    prove otherwise either way.
-
-    NOT both fully visible without scrolling, at the native 540px height,
-    with this fixture's actual content: MEASURED (real browser) `.semantic-
-    surfaces` `scrollHeight` 531 against a `clientHeight` of 508 — the
-    `auto` rows above (status/global/vfo) already claim more of the native
-    height than is left for the two reserved rows plus the 72px meters/
-    scope floor. Row 6 (DSP rail, 40px) sits fully inside the visible
-    508px. Row 7 (memory rail, 34px) does not: only its first ~11.5px
-    shows; the rest needs the scroll the base wiring's own `overflow: auto`
-    on `.semantic-surfaces` (untouched here) already provides. This will
-    move once real content lands in either row — recorded as the current
-    fixture's measurement, not a claim about every future one.
-
-    This file's placement rules below select surface classes directly
-    (`.tx-aux-surface`, `.meters-surface`, `.scope-display-surface`) —
-    NOT `.surface-zone`, the wrapper `zoned()` (MOR-2150,
-    `SemanticRadioSurfaces.svelte`) actually emits once a zone IS declared
-    for a surface. MEASURED (real browser, a synthetic plan declaring all
-    fourteen surfaces): a declared zone puts `.surface-zone` in the grid,
-    not the surface's own class, so it lands by the browser's implicit
-    auto-placement — observed landing at rows 6/7/9 — and every
-    surface-class rule below goes inert for that surface the moment a zone
-    owns it. What (if anything) should route a declared zone to a specific
-    row is undecided and unwritten here; that decision belongs to
-    MOR-2151(cont.)'s own ticket, not a prediction in this file.
-
-    NOT the archived table's fixed 34px status rail: MEASURED (real
-    browser) that `RxTxSurface`/`TxAuxSurface` render normal-density
-    buttons and sliders — 13 controls for `TxAuxSurface` alone — not the
-    compact icon-sized flag cells 34px assumes. Row 1 is `auto`; see the
-    `<style>` block's own note at that rule for what a fixed 34px actually
-    did (clipped ~90% of both surfaces invisibly).
-
-  Everything else in this header documents the four hard-won lessons the
-  archived package's own author did not verify by running (the brief's own
-  citation):
-
-  1. THE GRID HOST IS `.semantic-surfaces`, NOT THE STAGE. `<ScaledStage>`'s
-     only child is `SemanticRadioSurfaces`'s own root
-     (`.semantic-surfaces`), so every zone is a GRANDCHILD of the stage —
-     a grid declared on the stage places nothing. The `:global(...)`
-     selectors below are rooted at `.semantic-surfaces` itself.
-  2. THE GRID IS TWO COLUMNS UNIFORMLY (`grid-template-columns: 1fr 1fr`
-     below), not per-row pairing logic — rows 6/7 (dsp-rail/memory-rail)
-     inherit the same two tracks because the WHOLE grid does, not because
-     anything here pairs DSP against front-end or memory against
-     telemetry. MEASURED (see the reserved-rows note above): with a
-     synthetic plan declaring `filter`/`dsp`/`rfFrontEnd`/`band`, the
-     browser's own implicit auto-placement — not a design choice made
-     here — put `filter`|`dsp` in row 6 and `rfFrontEnd`|`band` in row 7,
-     an artifact of `zoned()`'s call order in `SemanticRadioSurfaces.svelte`,
-     not anything this file controls or can promise for a different zone
-     set.
-  3. CHROME IS A SIBLING OF THE STAGE, NEVER A CHILD. `.peer-split-holder`
-     wraps `<ScaledStage>`; nothing chrome-like lives inside its
-     `children` snippet. The wall-clock below is NOT chrome by this
-     definition — it is instrument face, same category as a real LCD's
-     printed clock, so it lives inside the scaled stage and scales with
-     everything else.
-  4. THE STAGE'S PARENT NEEDS A DEFINITE HEIGHT ON BOTH AXES. `.peer-split-
-     holder` itself is `display: flex; height: 100%; min-height: 0`;
-     `flex: 1` lives one level down, on `ScaledStage`'s own
-     `.scaled-stage-holder` root (reached via `:global()`, see the
-     `<style>` block). Verified against the real `ScaledStage` in a
-     browser (jsdom implements neither layout nor `ResizeObserver` — see
-     `primitives/stage/__tests__/ScaledStage.isolated.test.ts`'s own
-     header, not `ScaledStage.svelte`'s, which never mentions jsdom).
-
-  TX PERIMETER: no hot-bezel/glow mechanism exists for this element. Before
-  #2968, segmentline.css declared `.dl-glass[data-tx='active']` and its
-  `::after` glow; that retarget renamed `.dl-glass` to `.rx-tx-surface`
-  everywhere, INCLUDING that rule, and this file no longer wears either
-  class (see the `<style>` block below) — there is nothing left in
-  segmentline.css for this element to inherit even if the rule had
-  survived. This file's own `.peer-split-glass` rule does not add a
-  replacement, and does not set a `data-tx` attribute either:
-  `AppGlobalHost.svelte`'s own header is explicit that "layouts and skins
-  must not host" the TX/fault indication — mounting a second
-  `getAppTxController()` subscription here to drive a border color would
-  cross that boundary. Recorded as a real, currently-unaddressed gap: the
-  bezel has no TX-active treatment.
-
-  WALL CLOCK: UTC/local time is not radio state — nothing in
-  `semantic/radio-view-model.ts` or the segmentline renderers carries it
-  (confirmed by grep — no clock/UTC field exists anywhere in that layer),
-  because there is nothing to carry: the operator's own local and UTC time
-  is already known to the client. Rendered directly below from `Date`,
-  ticked every 30 seconds; this is not a violation of "radio truth flows
-  through the model" because it is not radio truth.
 -->
 <script lang="ts">
   // MOR-1257 (N4): the components-v2 theme layer is code-split per skin —
@@ -191,23 +78,6 @@
     min-height: 0;
   }
 
-  /* The chassis bezel. Before #2968 (MOR-2163) this came from
-     segmentline.css's `.dl-glass` rule — that retarget renamed `.dl-glass`
-     to `.rx-tx-surface` everywhere, and this element never wore the new
-     name, so nothing styled it at all (MOR-2153 review: dead-class
-     finding). Restored here as the skin's OWN rule instead of re-adding a
-     design-language selector nothing else in this file's markup matches
-     — a `.dl-glass`/`.rx-tx-surface` re-add would be reported as an orphan
-     by the same guardrail that caught the original deletion and would get
-     deleted again. Colour and border tone come from segmentline.css's
-     `[data-design-language='segmentline']` root rule, which still declares
-     them; geometry (14px padding, 2px border, 10px radius) has no matching
-     custom property there — `tokens.ts`'s own comment calls 2px "the
-     chassis bezel" but declares no CSS variable for it — so it stays a
-     literal, matching what `.rx-tx-surface` still declares today. The
-     fallback literals below match segmentline.css's own declared values
-     for the same custom properties, the same pattern
-     `--dl-segmentline-ink-soft`'s fallback two rules down already uses. */
   .peer-split-glass {
     height: 100%;
     position: relative;
@@ -258,20 +128,6 @@
   .peer-split-glass :global(.semantic-surfaces.semantic-surfaces) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    /* status-rail(auto — see the row-1 note below) / rule(1) / global-row
-       (auto, not one of the archived five bands — the wiring's own
-       radio-wide row, given its own space rather than forced into a
-       documented band it doesn't describe) / receiver-body: vfo(auto) /
-       receiver-body: meters+scope remainder(min 72px, else 1fr —
-       MEASURED, real browser: with a plain `minmax(0, 1fr)` the four
-       `auto` tracks above it (status/global/vfo, 245+104+34px with the
-       fixture's actual content) already claim nearly all of the native
-       540px height, so the flexible track collapsed to ~1.5px — legible
-       nothing rather than a visibly short meters/scope band. 72px is a
-       floor, not a fit: the base wiring's own `overflow: auto` on
-       `.semantic-surfaces`, untouched here, is what a real overrun of the
-       native height falls back to) / dsp-rail(40, reserved) /
-       memory-rail(34, reserved) */
     grid-template-rows: auto 1px auto auto minmax(72px, 1fr) 40px 34px;
     column-gap: 8px;
     /* The wiring's own base rule sets `gap: 8px` (a flex gap in its

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -6,9 +6,9 @@
  * zone-mount mechanics are already covered exhaustively elsewhere (the
  * `semantic-*-wiring.component.test.ts` family); what this file is the ONLY
  * place that proves is PeerSplitLayout's own additions on top of that wiring:
- * the `ScaledStage` native size, the `.dl-glass` chrome class, the wall-clock
- * (not radio state), and that the real DOM elements the dual composition
- * emits today (`.channel-strips`, `.cockpit-global-row`, `.rx-tx-zone`,
+ * the `ScaledStage` native size, the `.peer-split-glass` chrome class, the
+ * wall-clock (not radio state), and that the real DOM elements the dual
+ * composition emits today (`.channel-strips`, `.cockpit-global-row`, `.rx-tx-zone`,
  * `.tx-aux-surface`, `.meters-surface`, `.scope-display-surface`) land as
  * DESCENDANTS of the glass.
  *
@@ -32,6 +32,7 @@
  * carry this mock shape. No shared helper wraps it: `find src -iname
  * "*test-helper*" -o -iname "*test-util*"` returns nothing.
  */
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
@@ -239,7 +240,7 @@ describe('the peer-split chassis mounts', () => {
     expect(() => render()).not.toThrow();
     const glass = q('[data-testid="peer-split-glass"]');
     expect(glass).not.toBeNull();
-    expect(glass!.classList.contains('dl-glass')).toBe(true);
+    expect(glass!.classList.contains('peer-split-glass')).toBe(true);
   });
 
   // MUTATION TARGET: swapping ScaledStage's nativeW/nativeH kills this — the
@@ -277,14 +278,20 @@ describe('the peer-split chassis mounts', () => {
   // therefore be permanently RED here — 'block' never equals 'grid' — not
   // unfalsifiably green; still worth removing, since a pin that can only
   // ever fail is exactly as useless as one that can only ever pass, and
-  // either shape reads as coverage that is not there. The wider fact this
-  // environment gap implies: NONE of this file's CSS has coverage in this
-  // test file, not only `display: grid` — deleting the component's entire
-  // `<style>` block leaves all four tests in this file green (verified:
-  // mutation applied and reverted for the MOR-2153 review round, not kept
-  // in the tree). The grid actually applying is verified in a real
-  // browser; see the MOR-2153 build report for the exact command and what
-  // it showed.
+  // either shape reads as coverage that is not there. The grid actually
+  // applying is verified in a real browser: `npx vite --config
+  // vite.fixtures.config.ts`, fixture `peer-split-chassis`,
+  // `getComputedStyle(document.querySelector('.semantic-surfaces')).display`.
+  //
+  // This SAME environment gap is why the four tests in this describe block
+  // stayed green (MOR-2153 review) when the component's entire `<style>`
+  // block — including the bezel geometry that made the amber glass render
+  // at all — was deleted by a separate change (#2968) it had no way to
+  // detect. That gap is closed below, not here: the `the glass bezel...`
+  // describe block at the end of this file reads the component's raw
+  // SOURCE text rather than mounting it, the same technique
+  // `presentation/languages/segmentline/__tests__/stylesheet.test.ts`
+  // already uses for `segmentline.css`'s own rules.
 
   // MOR-2153: wall-clock time is not radio state — nothing to mock beyond
   // the system clock itself (`vi.setSystemTime(FROZEN_INSTANT)` above).
@@ -315,5 +322,60 @@ describe('the peer-split chassis mounts', () => {
     const local = clock!.querySelector('[data-testid="peer-split-clock-local"]');
     expect(utc!.textContent).toBe('14:32Z');
     expect(local!.textContent).toBe(expectedLocal());
+  });
+});
+
+/**
+ * MOR-2153 review: mounting `PeerSplitLayout` in Vitest/jsdom applies NO
+ * `<style>` at all (see the `describe` block above), so no assertion made by
+ * mounting the component can tell the bezel's CSS rule apart from it being
+ * deleted outright — which is exactly what happened silently when #2968
+ * retargeted every `.dl-glass` rule in `segmentline.css` onto `.rx-tx-surface`
+ * and this component kept wearing the old, now-dead name. The fix moved the
+ * bezel's own geometry into this component's `<style>` block instead of
+ * depending on a design-language selector; the block below pins its
+ * DECLARATIONS by parsing the component's raw source text, the same
+ * technique `presentation/languages/segmentline/__tests__/stylesheet.test.ts`
+ * already uses for `segmentline.css` — not by mounting and reading computed
+ * style, which this environment cannot do.
+ */
+describe('the glass bezel keeps its own CSS after the chassis class it used to wear died (#2968)', () => {
+  const source = readFileSync('src/skins/segmentline/PeerSplitLayout.svelte', 'utf8');
+  const styleBlock = source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
+  // Comments name the very rule this pin is about, so they are stripped
+  // first — same reason `stylesheet.test.ts` strips them from `segmentline
+  // .css` before parsing.
+  const css = styleBlock.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  /** Exact-selector match against a `{ declarations }` block, mirroring
+   *  `stylesheet.test.ts`'s `parseRules`/`findExact` at the scale this file
+   *  needs (one selector). Throws — rather than returning `undefined` for an
+   *  `it()` block to silently pass past — when the `<style>` block is
+   *  missing or the selector renamed, so this test cannot go quietly green
+   *  as coverage that stopped existing. */
+  function declarationsFor(selector: string): Record<string, string> {
+    for (const [, selectorList, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      for (const candidate of selectorList.split(',')) {
+        if (candidate.trim() !== selector) continue;
+        const declarations: Record<string, string> = {};
+        for (const declaration of body.split(';')) {
+          const colon = declaration.indexOf(':');
+          if (colon > 0) declarations[declaration.slice(0, colon).trim()] = declaration.slice(colon + 1).trim();
+        }
+        return declarations;
+      }
+    }
+    throw new Error(`no rule for selector "${selector}" in PeerSplitLayout.svelte's <style> block`);
+  }
+
+  it('declares the bezel geometry #2968 orphaned, as its own rule rather than a design-language one', () => {
+    const glass = declarationsFor('.peer-split-glass');
+    expect(glass.position).toBe('relative');
+    expect(glass.overflow).toBe('hidden');
+    expect(glass['box-sizing']).toBe('border-box');
+    expect(glass.padding).toBe('14px');
+    expect(glass.border).toBe('2px solid var(--dl-segmentline-bezel-edge, #8a7020)');
+    expect(glass['border-radius']).toBe('10px');
+    expect(glass.background).toBe('var(--dl-segmentline-glass, #c8a030)');
   });
 });

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -282,16 +282,6 @@ describe('the peer-split chassis mounts', () => {
   // applying is verified in a real browser: `npx vite --config
   // vite.fixtures.config.ts`, fixture `peer-split-chassis`,
   // `getComputedStyle(document.querySelector('.semantic-surfaces')).display`.
-  //
-  // This SAME environment gap is why the four tests in this describe block
-  // stayed green (MOR-2153 review) when the component's entire `<style>`
-  // block — including the bezel geometry that made the amber glass render
-  // at all — was deleted by a separate change (#2968) it had no way to
-  // detect. That gap is closed below, not here: the `the glass bezel...`
-  // describe block at the end of this file reads the component's raw
-  // SOURCE text rather than mounting it, the same technique
-  // `presentation/languages/segmentline/__tests__/stylesheet.test.ts`
-  // already uses for `segmentline.css`'s own rules.
 
   // MOR-2153: wall-clock time is not radio state — nothing to mock beyond
   // the system clock itself (`vi.setSystemTime(FROZEN_INSTANT)` above).
@@ -325,20 +315,6 @@ describe('the peer-split chassis mounts', () => {
   });
 });
 
-/**
- * MOR-2153 review: mounting `PeerSplitLayout` in Vitest/jsdom applies NO
- * `<style>` at all (see the `describe` block above), so no assertion made by
- * mounting the component can tell the bezel's CSS rule apart from it being
- * deleted outright — which is exactly what happened silently when #2968
- * retargeted every `.dl-glass` rule in `segmentline.css` onto `.rx-tx-surface`
- * and this component kept wearing the old, now-dead name. The fix moved the
- * bezel's own geometry into this component's `<style>` block instead of
- * depending on a design-language selector; the block below pins its
- * DECLARATIONS by parsing the component's raw source text, the same
- * technique `presentation/languages/segmentline/__tests__/stylesheet.test.ts`
- * already uses for `segmentline.css` — not by mounting and reading computed
- * style, which this environment cannot do.
- */
 describe('the glass bezel keeps its own CSS after the chassis class it used to wear died (#2968)', () => {
   const source = readFileSync('src/skins/segmentline/PeerSplitLayout.svelte', 'utf8');
   const styleBlock = source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
@@ -377,5 +353,10 @@ describe('the glass bezel keeps its own CSS after the chassis class it used to w
     expect(glass.border).toBe('2px solid var(--dl-segmentline-bezel-edge, #8a7020)');
     expect(glass['border-radius']).toBe('10px');
     expect(glass.background).toBe('var(--dl-segmentline-glass, #c8a030)');
+  });
+
+  it('keeps the meters/scope row from collapsing below its 72px floor', () => {
+    const grid = declarationsFor('.peer-split-glass :global(.semantic-surfaces.semantic-surfaces)');
+    expect(grid['grid-template-rows']).toContain('minmax(72px, 1fr)');
   });
 });

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -1,0 +1,319 @@
+/**
+ * MOR-2153 — the `peer-split` glass CHASSIS, mounted end to end.
+ *
+ * Scope: this is a CHASSIS test, not a full behavior-pinning suite like
+ * `DualReceiverCockpit.component.test.ts`'s. `SemanticRadioSurfaces` and its
+ * zone-mount mechanics are already covered exhaustively elsewhere (the
+ * `semantic-*-wiring.component.test.ts` family); what this file is the ONLY
+ * place that proves is PeerSplitLayout's own additions on top of that wiring:
+ * the `ScaledStage` native size, the `.dl-glass` chrome class, the wall-clock
+ * (not radio state), and that the real DOM elements the dual composition
+ * emits today (`.channel-strips`, `.cockpit-global-row`, `.rx-tx-zone`,
+ * `.tx-aux-surface`, `.meters-surface`, `.scope-display-surface`) land as
+ * DESCENDANTS of the glass.
+ *
+ * NOT asserted here, at all: that the grid CSS actually applies (`display:
+ * grid` on `.semantic-surfaces`, row/column placement). Measured, not
+ * assumed — this Vitest/jsdom config injects no component `<style>` during a
+ * mount (`document.querySelectorAll('style').length` is 0 after `render()`),
+ * so every element's `getComputedStyle` reads the UA default regardless of
+ * what any `<style>` block declares; a computed-style assertion here would
+ * be permanently unfalsifiable. The grid actually applying is verified in a
+ * real browser via the `fixtures/` harness; see the MOR-2153 build report
+ * for the exact command and what it showed.
+ *
+ * The mock boilerplate below is copied from `semantic-rx-tx-wiring
+ * .component.test.ts` (the pattern `SemanticRadioSurfaces.svelte`'s own file
+ * header names as the minimal precedent). MEASURED, not estimated: 47 files
+ * under `src/` match `grep -rl "tx-controller/app-host" --include="*.test.ts"
+ * src` (46 before this file existed) — spanning both `*.component.test.ts`
+ * and `*.isolated.test.ts`, not only the former; of the 41 total
+ * `*.component.test.ts` files (`find src -name '*.component.test.ts'`), 27
+ * carry this mock shape. No shared helper wraps it: `find src -iname
+ * "*test-helper*" -o -iname "*test-util*"` returns nothing.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import type { ServerState } from '$lib/types/state';
+
+type Snapshot = {
+  phase: string; intent: string | null; guard: { leaseId: string } | null;
+  radioTx: string; txRisk: string; mayOwnKey: boolean; fault: string | null;
+  pendingOff: { commandId: string } | null; modRestorePending: boolean;
+  cleanupGuard: { leaseId: string } | null;
+};
+
+const h = vi.hoisted(() => ({
+  state: null as unknown,
+  caps: null as unknown,
+  snapshot: null as unknown,
+  listeners: new Set<(next: unknown) => void>(),
+  start: vi.fn(),
+  release: vi.fn(),
+  setIntent: vi.fn(),
+  resetFault: vi.fn(),
+  noop: vi.fn(),
+  modInputGuard: { visible: false, sourceLabel: null } as { visible: boolean; sourceLabel: string | null },
+}));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return h.state; },
+    get caps() { return h.caps; },
+    get audio() { return { muted: true, rxEnabled: false, volume: 0 }; },
+    get connectionAudio() { return false; },
+    get defaultScopeStatus() {
+      return {
+        source: null, available: false, resourceSelected: false, demand: 0,
+        lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+      };
+    },
+    get radioPowerOn() { return null; },
+    get scope() { return { hardwareScopeConnected: false }; },
+  },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({
+  getAppTxController: () => ({
+    snapshot: () => h.snapshot,
+    subscribe: (listener: (next: unknown) => void) => {
+      h.listeners.add(listener);
+      return () => h.listeners.delete(listener);
+    },
+    start: h.start,
+    setIntent: h.setIntent,
+    release: h.release,
+    resetFault: h.resetFault,
+  }),
+}));
+vi.mock('$lib/runtime/adapters/mod-input-tx-guard.svelte', () => ({
+  deriveModInputTxGuardProps: () => h.modInputGuard,
+  getModInputTxGuardHandlers: () => ({ onSetLan: h.noop, onDismiss: h.noop }),
+}));
+vi.mock('$lib/runtime/commands/panel-commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/commands/panel-commands')>();
+  return {
+    ...actual,
+    makeVfoHandlers: () => ({ onVfoSelect: h.noop, onSplitToggle: h.noop, onDualWatchToggle: h.noop }),
+    makeVoxHandlers: () => ({
+      onVoxToggle: h.noop, onVoxGainChange: h.noop, onAntiVoxGainChange: h.noop, onVoxDelayChange: h.noop,
+    }),
+    makeTxHandlers: () => ({
+      onRfPowerChange: h.noop, onMicGainChange: h.noop, onAtuToggle: h.noop, onAtuTune: h.noop,
+      onVoxToggle: h.noop, onCompToggle: h.noop, onCompLevelChange: h.noop, onMonToggle: h.noop,
+      onMonLevelChange: h.noop, onDriveGainChange: h.noop,
+    }),
+    makeRxAudioHandlers: () => ({ onMonitorModeChange: h.noop, onAfLevelChange: h.noop }),
+    makeCwPanelHandlers: () => ({
+      onKeySpeedChange: h.noop, onCwPitchChange: h.noop, onBreakInDelayChange: h.noop,
+      onBreakInModeChange: h.noop, onApfChange: h.noop, onTwinPeakToggle: h.noop, onReversePaddleToggle: h.noop,
+    }),
+    makeAudioRoutingHandlers: () => ({ onFocusChange: h.noop, onSplitStereoChange: h.noop }),
+    makeModeHandlers: () => ({ onModInputChange: h.noop, onModeChange: h.noop, onDataModeChange: h.noop }),
+    makeFilterHandlers: () => ({
+      onFilterChange: h.noop, onFilterWidthChange: h.noop, onFilterShapeChange: h.noop,
+      onIfShiftChange: h.noop, onPbtInnerChange: h.noop, onPbtOuterChange: h.noop,
+    }),
+    makeDspHandlers: () => ({
+      onNrModeChange: h.noop, onNrLevelChange: h.noop, onNbToggle: h.noop, onNbLevelChange: h.noop,
+      onNbDepthChange: h.noop, onNbWidthChange: h.noop, onNotchModeChange: h.noop, onNotchFreqChange: h.noop,
+      onManualNotchWidthChange: h.noop, onAgcTimeChange: h.noop,
+    }),
+    makeAgcHandlers: () => ({ onAgcModeChange: h.noop }),
+    makeRfFrontEndHandlers: () => ({
+      onAttChange: h.noop, onPreChange: h.noop, onRfGainChange: h.noop,
+      onSquelchChange: h.noop, onDigiSelToggle: h.noop, onIpPlusToggle: h.noop,
+    }),
+    makeBandHandlers: () => ({ onBandSelect: h.noop }),
+    makeAntennaHandlers: () => ({ onSelectAnt1: h.noop, onSelectAnt2: h.noop, onToggleRxAnt: h.noop }),
+    makeRitXitHandlers: () => ({
+      onRitToggle: h.noop, onXitToggle: h.noop, onRitOffsetChange: h.noop, onXitOffsetChange: h.noop, onClear: h.noop,
+    }),
+    makeScanHandlers: () => ({
+      onScanStart: h.noop, onScanStop: h.noop, onDfSpanChange: h.noop, onResumeChange: h.noop,
+    }),
+    makeScopeControlsHandlers: () => ({
+      onModeChange: h.noop, onEdgeChange: h.noop, onSpanChange: h.noop, onSpeedChange: h.noop,
+      onHoldChange: h.noop, onRefChange: h.noop, onDualChange: h.noop, onReceiverChange: h.noop,
+      onDuringTxChange: h.noop, onCenterTypeChange: h.noop, onVbwChange: h.noop, onRbwChange: h.noop,
+    }),
+  };
+});
+
+const { default: PeerSplitLayout } = await import('../PeerSplitLayout.svelte');
+
+const IDLE: Snapshot = {
+  phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none',
+  mayOwnKey: false, fault: null, pendingOff: null, modRestorePending: false, cleanupGuard: null,
+};
+
+const fresh = { storePath: 'x', observed: true, freshness: 'fresh', availability: 'available' };
+
+/** 2/ab_shared — one of `peer-split`'s two declared compatible topologies
+ *  (`presentation/layouts/segmentline-declarations.ts`), also the FTX-1's
+ *  real topology per the accepted spec §2. */
+function abSharedState(): ServerState {
+  const paths = ['active', 'split', 'dualWatch', 'txTarget',
+    'main.freqHz', 'main.mode', 'main.filter', 'sub.freqHz', 'sub.mode', 'sub.filter',
+    'powerMeter', 'swrMeter', 'main.sMeter', 'sub.sMeter'];
+  return {
+    active: 'MAIN', split: false, dualWatch: false, ptt: false,
+    txTarget: { status: 'known', receiver: 'MAIN', slot: null, frequencyHz: 14250000 },
+    main: { freqHz: 14250000, mode: 'USB', filter: 1, sMeter: -12 },
+    sub: { freqHz: 146520000, mode: 'FM', filter: 1, sMeter: -30 },
+    powerMeter: 0, swrMeter: 10,
+    fieldStatus: Object.fromEntries(paths.map((p) => [p, fresh])),
+  } as unknown as ServerState;
+}
+
+/** Caps carrying enough evidence to populate every zone this chassis can
+ *  currently mount: `meters`/`scope`/the five `txAux` evidence tags. */
+const liveCaps = (): Capabilities => ({
+  model: 'fixture', scope: true, audio: true, tx: true,
+  stateContractVersion: 1, providerGeneration: 1,
+  capabilities: [
+    'audio', 'tx', 'dual_rx', 'meters', 'scope', 'split', 'dual_watch',
+    'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
+  ],
+  receivers: 2, vfoScheme: 'ab_shared',
+  freqRanges: [], modes: ['USB', 'FM'], filters: ['FIL1'],
+  audioConfig: { sampleRate: 48000, channels: 1, codecs: ['pcm16'] },
+  webrtc: { available: false, enabled: false },
+  txBands: [{ start: 14000000, end: 14350000, name: '20m' }],
+  scopeSource: null, audioFftAvailable: false,
+} as unknown as Capabilities);
+
+let target: HTMLDivElement;
+let component: ReturnType<typeof mount> | null = null;
+const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
+
+function render(): void {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  component = mount(PeerSplitLayout, { target });
+  flushSync();
+}
+
+/** MOR-2153 review: the local half of the clock reads the process's own
+ *  timezone (`Date.prototype.getHours`/`getMinutes`), a review round found
+ *  "machine-dependent and unasserted". `process.env.TZ = 'UTC'` in
+ *  `beforeEach` was tried first and MEASURED not to work under
+ *  `vi.useFakeTimers()` in this environment: the fixed instant below
+ *  (14:32 UTC) still read back as this machine's real local offset (10:32
+ *  in the environment this was verified in), not UTC — so it was reverted
+ *  rather than kept as a comment describing behavior that does not hold.
+ *  `expectedLocal()` below computes the SAME `getHours`/`getMinutes` pair
+ *  the component's `clockLabel` does, independently, against whatever this
+ *  process's real local offset actually is — deterministic and correct on
+ *  every machine without needing to pin or predict that offset. */
+const FROZEN_INSTANT = new Date('2026-09-01T14:32:00Z');
+function expectedLocal(): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(FROZEN_INSTANT.getHours())}:${pad(FROZEN_INSTANT.getMinutes())}`;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_INSTANT);
+  h.state = abSharedState();
+  h.caps = liveCaps();
+  h.snapshot = { ...IDLE };
+  h.listeners.clear();
+  h.start.mockReset();
+  h.release.mockReset();
+  h.setIntent.mockReset();
+  h.resetFault.mockReset();
+  h.noop.mockReset();
+  h.modInputGuard = { visible: false, sourceLabel: null };
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+describe('the peer-split chassis mounts', () => {
+  it('renders the glass chrome and the dual composition inside it, without throwing', () => {
+    expect(() => render()).not.toThrow();
+    const glass = q('[data-testid="peer-split-glass"]');
+    expect(glass).not.toBeNull();
+    expect(glass!.classList.contains('dl-glass')).toBe(true);
+  });
+
+  // MUTATION TARGET: swapping ScaledStage's nativeW/nativeH kills this — the
+  // stage renders its content box at the declared size regardless of the
+  // holder's actual measured box (jsdom reports a 0x0 holder, so `scale`
+  // stays 1 and the native size is what shows up verbatim).
+  it('declares the 1280x540 native stage the segmentline manifest also declares', () => {
+    render();
+    const stage = q<HTMLDivElement>('.scaled-stage');
+    expect(stage).not.toBeNull();
+    expect(stage!.style.width).toBe('1280px');
+    expect(stage!.style.height).toBe('540px');
+  });
+
+  it('places the real dual-composition zones inside the glass, not beside it', () => {
+    render();
+    const glass = q('[data-testid="peer-split-glass"]');
+    expect(glass!.querySelector('.channel-strips')).not.toBeNull();
+    expect(glass!.querySelector('.cockpit-global-row')).not.toBeNull();
+    expect(glass!.querySelector('.rx-tx-zone')).not.toBeNull();
+    // Bare optional surfaces (no declared zone owns them yet — MOR-2151(cont.)):
+    expect(glass!.querySelector('.tx-aux-surface')).not.toBeNull();
+    expect(glass!.querySelector('.meters-surface')).not.toBeNull();
+    expect(glass!.querySelector('.scope-display-surface')).not.toBeNull();
+  });
+
+  // NOT ASSERTED HERE: that `.semantic-surfaces` actually receives
+  // `display: grid`. Measured, not assumed — this Vitest/jsdom config
+  // injects NO component `<style>` at all during a component-mount test
+  // (`document.querySelectorAll('style').length` is 0 and
+  // `document.styleSheets.length` is 0 after `render()`; every element's
+  // `getComputedStyle().display` falls back to the UA default ('block')
+  // regardless of what any `<style>` block declares, scoped or `:global`).
+  // `expect(getComputedStyle(surfaces).display).toBe('grid')` would
+  // therefore be permanently RED here — 'block' never equals 'grid' — not
+  // unfalsifiably green; still worth removing, since a pin that can only
+  // ever fail is exactly as useless as one that can only ever pass, and
+  // either shape reads as coverage that is not there. The wider fact this
+  // environment gap implies: NONE of this file's CSS has coverage in this
+  // test file, not only `display: grid` — deleting the component's entire
+  // `<style>` block leaves all four tests in this file green (verified:
+  // mutation applied and reverted for the MOR-2153 review round, not kept
+  // in the tree). The grid actually applying is verified in a real
+  // browser; see the MOR-2153 build report for the exact command and what
+  // it showed.
+
+  // MOR-2153: wall-clock time is not radio state — nothing to mock beyond
+  // the system clock itself (`vi.setSystemTime(FROZEN_INSTANT)` above).
+  //
+  // MUTATION TARGETS (both found by a MOR-2153 review round, neither
+  // caught by the single combined-text assertion this replaces):
+  //  - swapping the `utc`/`local` fields `clockLabel` returns: with
+  //    `toContain('14:32')` on the combined `.peer-split-clock` text, a
+  //    swap was invisible because both halves happen to read '14:32'
+  //    digits either way at the frozen instant — only the trailing 'Z'
+  //    distinguishes them, which the two separate assertions below check
+  //    per span (`utc` exact 'HH:MMZ'; `local` against `expectedLocal()`,
+  //    computed independently the same way `clockLabel` does, so it stays
+  //    correct — and the swap stays caught — on any machine's timezone).
+  //  - moving the clock markup to a sibling of `<ScaledStage>` (breaking
+  //    Lesson 3 — "the clock lives inside the scaled stage"): querying
+  //    from `target` (the whole mount point) finds it regardless of where
+  //    in the tree it landed. Queried from `glass` here instead, so the
+  //    clock must be a DESCENDANT of `.peer-split-glass` — inside the
+  //    stage, per Lesson 3 — to be found at all.
+  it('renders a wall-clock readout, inside the glass, not derived from any radio field', () => {
+    render();
+    const glass = q('[data-testid="peer-split-glass"]');
+    expect(glass).not.toBeNull();
+    const clock = glass!.querySelector('[data-testid="peer-split-clock"]');
+    expect(clock).not.toBeNull();
+    const utc = clock!.querySelector('[data-testid="peer-split-clock-utc"]');
+    const local = clock!.querySelector('[data-testid="peer-split-clock-local"]');
+    expect(utc!.textContent).toBe('14:32Z');
+    expect(local!.textContent).toBe(expectedLocal());
+  });
+});


### PR DESCRIPTION
Fills the `peer-split` shell with the segmentline chassis: a `ScaledStage` at
1280x540 native wrapping the glass bezel, `SemanticRadioSurfaces strips="dual"`
for the two receiver columns, and a wall clock. Adds a fixture entry so the
layout renders and can be measured without a radio.

MOR-2155 made `peer-split` a loadable `SkinId`, MOR-2151 registered its layout
manifest and MOR-2152 put it in the picker. This is the first change that puts
anything inside it.

## Re-verified on current `main`, not carried over

The work was completed before seven merges landed. Cherry-picking without
conflict means git found no conflicting lines; it does not mean the change
still behaves the same. So it was re-established rather than trusted:

- **The three overflow numbers were re-measured in a real browser** against the
  running fixture, not read off the old commit. `scrollHeight` 531 against
  `clientHeight` 508; grid row 6 spans 456.5-496.5px and is fully visible; row
  7 spans 496.5-530.5px, so 11.5px of its 34px height shows. All three match
  the header exactly, so the header is unchanged.
- **One of the two recorded mutations was re-run at this base.** Swapping the
  utc/local fields in `clockLabel()` fails exactly one of the four tests —
  `renders a wall-clock readout, inside the glass, not derived from any radio
  field` — with `expected '10:32' to be '14:32Z'`, the other three staying
  green. So that assertion still discriminates after the rebase.
- **`fixtures/main.ts` was read in full**, because `be03982e` (PR #2962) also
  changed it. Both changes are present and disjoint: that PR's
  `clearCapabilities` import and null-guard are intact, and this change's
  `PeerSplitLayout` import, `ROOT_TEST_ID` branch, language default, plan/mount
  branches and `peer-split` assert fallback are intact. Checked by reading the
  merged file, not by observing that it compiles.

## What this does NOT do

- **The two receivers are not in the two columns.** The layout declares no
  zones, so `SemanticRadioSurfaces` renders both receiver strips inside one
  `.channel-strips` wrapper. Confirmed by rendering. Zone routing is
  MOR-2151(cont.).
- **`segmentline` is not activatable in production.**
  `WORKSPACE_DESIGN_LANGUAGE_IDS` is `['studioline', 'fieldline']` and `pickId`
  falls back to `'studioline'` for an unrecognised id. This layout is
  reachable; its design language is not.
- 23px of content does not fit. Row 7 is reachable through the wiring's own
  `overflow: auto`. The component header says exactly that, with the measured
  numbers.

## The one red test

`components-v2/wiring/__tests__/fixture-capture-root-cwd.test.ts` fails, and it
is untouched by this diff — `git diff 9bb9bcfe HEAD` over that path is empty.

It shells out to `capture.mjs --preflight-only` against a 15s budget. Run
directly outside vitest it took 12.6s and printed `PASS fixture build
preflight`. `uptime` during the run reported load averages of 20.71/26.39/21.04
on a 10-core machine, so the budget margin is the plausible cause rather than
the code.

That is evidence, not proof, and it is recorded as such: this cannot be
distinguished from a narrower timing regression without a quiet machine. An
earlier characterisation of this same failure as "order-sensitive" was refuted
by measurement — it fails when run alone too — so the mechanism named here is
the second attempt at it, not the first.

`entrypoints.test.ts` also timed out in one full run and passed in the next and
in isolation, including its `peer-split -> dual` case. Same cause, same
caveat.

## Guardrails

4 files, 805 changed lines. Inside the 10-file / 1000-line hard ceiling. The
6-file / 600-line soft threshold is crossed on lines; this is one unit of work
because the four files are the layout component, its test suite, and the two
fixture files that let it render at all — the component cannot be verified
without them.


---

## The header this PR deletes, deleted deliberately

At `origin/main` this file's header states the skin is

> NOT backed by a layout manifest (MOR-2151) and NOT reachable from
> `resolveSkinId` or the picker (MOR-2152).

**Both halves are false at the merged state.** `presentation/layouts/segmentline-declarations.ts`
backs it, and `skins/registry.ts:59` is `if (layoutPreference === 'peer-split') return 'peer-split';`.
The sentence was true when written and stopped being true when MOR-2151
(`5edef508`) and MOR-2152 (`d5b30c53`) landed — the very tickets it names as
future work.

This PR rewrites the header, so the sentence goes. Recording it here so the
removal reads as intended rather than incidental: a reviewer comparing the two
headers should know the old one was not merely superseded in style, it was
false against the tree.

It belongs to a family being tracked separately in #3009 — prose describing
code that a later change removed or reversed, with no automated check able to
see it. The related stale ruling in `presentation/languages/declarations.ts`
is **not** touched here; it is collateral of #3015, where the sentence becomes
moot once `segmentline` can activate.

## The four token fallbacks are temporary, and here is what removes them

`var(--dl-segmentline-bezel-edge, …)`, `-glass`, `-ink-soft`, `-ink-strong`
carry literal values because `segmentline` cannot currently activate:
`WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline', 'fieldline']` and the workspace
validator clamps anything else back to `'studioline'`, so
`designLanguageActivation` returns null for `peer-split` and no design-language
CSS applies.

That is filed as #3015, whose collateral names these four literals. They should
not outlive it. A duplicated token value that loses its reason is the expensive
outcome, so if #3015 lands and these remain, that is a defect and not an
oversight to be discovered later.

---

## Cycle limit, waived by the owner

This PR is on a **third build cycle**. `CLAUDE.md` caps it at two execution and
two review cycles and says the excess is FAILED; only the owner grants an
exception. It was granted on 2026-09-02 at 14:20 UTC and recorded under the owner's own
account as MOR-2153 comment `67b3e6e1`, alongside the constraint that makes this cycle different in kind from
the first two:

- deletions and test pins only;
- every historical claim and every geometry number in the header **deleted**,
  not corrected;
- at most two test assertions carry the numbers that matter — the 72px column
  floor and the row-7 overflow behaviour — each measured under a stated command
  and each required to fail when the thing it guards stops being true;
- the stale "unreachable from the picker" sentence goes with the rest, its
  deletion recorded above;
- **no other added sentence anywhere in the diff**, which the reviewer checks
  mechanically rather than by reading.

The reason for the constraint rather than an instruction to be careful: four
corrections on this line have each introduced a new falsehood, and every one was
in text that was *added*. A cycle that cannot add prose cannot repeat it.

## Size, corrected

`git diff --numstat` against the merge base gives **4 files, 718 changed lines**
(671 insertions, 47 deletions) at head `b92f7528`. The figure has moved twice and
both earlier values are recorded rather than silently replaced, since a stale
measurement presented as current is a defect this PR has been blocked for twice:
805 at the head carrying the first BLOCKED, 881 at `2a815044`, 718 now — the
third cycle only removed lines.

## What the third cycle deleted, and what that cost

Under the owner's waiver the cycle was constrained to deletions and test pins
with **zero added prose**, checked mechanically: `git diff` from `2a815044`
contains 0 added comment lines, against 144 deleted from the component and 24
from its tests.

That constraint had a price worth stating rather than discovering later. True and
false content were fused on the same physical lines throughout the header, so
keeping only the accurate halves would have required rewriting lines — which is
the operation that produced a new falsehood on each of the four preceding
corrections. Whole paragraphs went instead, including engineering rationale that
was correct: four numbered lessons and the wall-clock placement reasoning. That
is a real loss, traded knowingly for a guarantee that this cycle could not repeat
the pattern.

What survives is the scope boundary — what the file builds and what it
deliberately does not, which is the part a reader needs and the part nothing else
records.

The one number that carried a design decision is now a test rather than a
sentence:

    it('keeps the meters/scope row from collapsing below its 72px floor', ...)

Verified by mutation in both directions: `72px` to `50px` makes it and only it
fail, restoring returns the file to 6 of 6 passing. It fails when the thing it
guards stops being true, which the deleted comment could not do — that comment
justified the floor with a figure wrong by more than thirtyfold and survived two
review rounds unchallenged.

Inside the 10-file / 1000-line hard ceiling. The 6-file / 600-line soft
threshold is crossed on lines: this is one unit of work because the component,
its tests, and the two fixture files that let it render at all cannot be
verified apart — the chassis is only checkable by rendering it.


