### PR TITLE
refactor(MOR-2176): retire obsolete TransmitTruth projection

### DIFF
--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -36,8 +36,6 @@ from functools import lru_cache
 from types import MappingProxyType
 from typing import Final, Literal, NoReturn
 
-from rigplane.core.state_pipeline_contracts import FieldPath
-from rigplane.core.state_store import StateSnapshot
 from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,9 +49,6 @@ TX_READ_DEADLINE_SECONDS: float = 0.3
 #: Decision records retained per radio.
 DECISION_LOG_CAPACITY: int = 256
 
-#: The only observation provenance that may feed :class:`TransmitTruth`. Our
-#: own command responses, the state poller, local reconciliation and test
-#: fixtures have no intake — a write outcome is never evidence of receiving.
 RADIO_READBACK_SOURCES: frozenset[str] = frozenset(
     {"poll_response", "civ_unsolicited", "hamlib_response", "yaesu_poll_response"}
 )
@@ -71,8 +66,6 @@ TX_ENGINE_FAILURE_TAGS: frozenset[str] = frozenset(
 RAW_EXCLUDED: frozenset[str] = frozenset(
     {"send_civ", "send_civ_transaction", "send_civ_raw_fire_and_forget"}
 )
-
-_PTT_FIELD_PATH = FieldPath.global_("tx_state", "ptt")
 
 
 class TxWriteClass(StrEnum):
@@ -191,53 +184,6 @@ class TxStateReading:
     source: str | None = None
     verified_readback: bool = False
     failure: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class TransmitTruth:
-    """Display/UX-grade transmit truth. Never used for a hazard decision."""
-
-    value: bool | None
-    attributed: str | None
-    age_seconds: float | None
-    source: str | None
-    generation_current: bool
-
-
-EMPTY_TRANSMIT_TRUTH = TransmitTruth(
-    value=None,
-    attributed=None,
-    age_seconds=None,
-    source=None,
-    generation_current=False,
-)
-
-
-def build_transmit_truth(
-    snapshot: StateSnapshot, *, provider_generation: int
-) -> TransmitTruth:
-    """Project ``global.tx_state.ptt`` through the provenance pin.
-
-    Freshness is deliberately not pre-collapsed: the age travels out and each
-    consumer applies its own tolerance.
-    """
-    try:
-        field = snapshot.field(_PTT_FIELD_PATH)
-    except KeyError:
-        return EMPTY_TRANSMIT_TRUTH
-    if str(field.source.source) not in RADIO_READBACK_SOURCES:
-        return EMPTY_TRANSMIT_TRUTH
-    if type(field.value) is not bool:
-        return EMPTY_TRANSMIT_TRUTH
-    age = snapshot.generated_at_monotonic - field.last_observed_monotonic
-    return TransmitTruth(
-        value=field.value,
-        # Row 6 routes Yaesu's ``tx_state_map`` attribution into this field.
-        attributed=None,
-        age_seconds=age if age >= 0.0 else None,
-        source=str(field.source.source),
-        generation_current=field.provider_generation == provider_generation,
-    )
 
 
 # Band relation — data in, no profile import
@@ -553,7 +499,6 @@ class TxAuthorityView:
     """Read-only debuggability surface: why did it decide that."""
 
     records: tuple[TxDecisionRecord, ...]
-    truth: TransmitTruth | None
     own_transmit_holds: tuple[str, ...]
     deadline_monotonic: float | None
     lease_active: bool
@@ -592,7 +537,6 @@ class TransmitAuthority:
         bands: Sequence[tuple[int, int]] = (),
         current_frequency_hz: Callable[[], float | None] | None = None,
         lease_active: Callable[[], bool] | None = None,
-        truth_provider: Callable[[], TransmitTruth] | None = None,
         provider_generation: Callable[[], int] | None = None,
         cw_hold_duration: Callable[[TxArgumentContext], float] | None = None,
         read_deadline_seconds: float = TX_READ_DEADLINE_SECONDS,
@@ -605,7 +549,6 @@ class TransmitAuthority:
         self._bands = tuple(bands)
         self._current_frequency_hz = current_frequency_hz
         self._lease_active = lease_active
-        self._truth_provider = truth_provider
         self._provider_generation = provider_generation
         self._cw_hold_duration = cw_hold_duration
         self._read_deadline_seconds = read_deadline_seconds
@@ -639,7 +582,6 @@ class TransmitAuthority:
     def view(self) -> TxAuthorityView:
         return TxAuthorityView(
             records=tuple(self._records),
-            truth=self._truth_provider() if self._truth_provider else None,
             own_transmit_holds=tuple(
                 hold.kind for hold in self._active_holds(self._clock())
             ),

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -71,7 +71,6 @@ from rigplane.core.tx_authority import (
     TxRefusal,
     TxRefusalCode,
     TxStateReading,
-    build_transmit_truth,
 )
 from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 
@@ -692,10 +691,9 @@ async def test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth(
     await asyncio.sleep(0)
 
     store = harness.radio._state_store
-    truth = build_transmit_truth(
-        store.snapshot(), provider_generation=store.provider_generation
-    )
-    assert truth.value is None, f"{harness.name}: our own set_ptt became transmit truth"
+    assert "global.tx_state.ptt" not in {
+        str(field.path) for field in store.snapshot().fields
+    }, f"{harness.name}: our own set_ptt became a store observation"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -13,11 +13,6 @@ from collections.abc import Mapping, Sequence
 
 import pytest
 
-from rigplane.core.state_pipeline_contracts import (
-    FieldPath,
-    SourceMetadata,
-)
-from rigplane.core.state_store import FieldSnapshot, FreshnessState, StateSnapshot
 from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 from rigplane.core.tx_authority import (
     DECISION_LOG_CAPACITY,
@@ -30,7 +25,6 @@ from rigplane.core.tx_authority import (
     UNRESOLVED_ARGUMENT,
     BandRelation,
     TransmitAuthority,
-    TransmitTruth,
     TxArgumentContext,
     TxFamily,
     TxMethodEntry,
@@ -39,13 +33,10 @@ from rigplane.core.tx_authority import (
     TxStateReading,
     TxWriteClass,
     band_relation,
-    build_transmit_truth,
     first_parameter_name,
     resolve_band,
     short_circuit_family,
 )
-
-PTT_PATH = FieldPath.global_("tx_state", "ptt")
 
 BANDS: tuple[tuple[int, int], ...] = (
     (14_000_000, 14_350_000),
@@ -262,6 +253,17 @@ def test_key_down_bound_is_imported_not_respelled() -> None:
 
 def test_read_deadline_is_its_own_named_bound() -> None:
     assert TX_READ_DEADLINE_SECONDS == 0.3
+
+
+def test_transmit_truth_projection_is_absent() -> None:
+    from rigplane.core import tx_authority
+
+    for name in (
+        "TransmitTruth",
+        "EMPTY_TRANSMIT_TRUTH",
+        "build_transmit_truth",
+    ):
+        assert not hasattr(tx_authority, name)
 
 
 def test_argument_predicate_registry_is_named_and_pure() -> None:
@@ -931,28 +933,19 @@ async def test_decision_ring_is_bounded() -> None:
     assert len(authority.view().records) == DECISION_LOG_CAPACITY
 
 
-async def test_view_reports_truth_holds_and_deadline() -> None:
+async def test_view_reports_holds_and_deadline() -> None:
     clock = Clock()
     link = FakeTransmitStateLink(clock)
-    truth = TransmitTruth(
-        value=False,
-        attributed="rx",
-        age_seconds=0.2,
-        source="poll_response",
-        generation_current=True,
-    )
     authority = TransmitAuthority(
         read_transmit_state=link.read,
         last_resort_unkey=FakeUnkey(),
         method_map=METHOD_MAP,
         clock=clock,
         bands=BANDS,
-        truth_provider=lambda: truth,
     )
     async with authority.admit("set_ptt", (True,)):
         pass
     view = authority.view()
-    assert view.truth is truth
     assert view.own_transmit_holds == ("key",)
     assert view.deadline_monotonic is not None
     assert view.records[-1].method == "set_ptt"
@@ -980,91 +973,6 @@ async def test_raw_excluded_methods_are_not_classified() -> None:
             assert admission.family is None  # bytes are not classified
     assert authority.view().records == ()
     assert link.reads == []
-
-
-# --------------------------------------------------------------------------
-# TransmitTruth builder (§3.7)
-# --------------------------------------------------------------------------
-
-
-def _snapshot(
-    *,
-    value: object,
-    source: str,
-    observed: float,
-    generated: float,
-    provider_generation: int = 3,
-) -> StateSnapshot:
-    field = FieldSnapshot(
-        path=PTT_PATH,
-        value=value,
-        freshness=FreshnessState.FRESH,
-        last_observed_monotonic=observed,
-        max_age=1.0,
-        source=SourceMetadata(source=source, provider="fake"),  # type: ignore[arg-type]
-        provider_generation=provider_generation,
-    )
-    return StateSnapshot(
-        state_revision=1,
-        freshness_revision=1,
-        observation_seq=1,
-        generated_at_monotonic=generated,
-        fields=(field,),
-        provider_generation=provider_generation,
-    )
-
-
-def test_transmit_truth_accepts_radio_readback_provenance() -> None:
-    snapshot = _snapshot(
-        value=True, source="poll_response", observed=9.5, generated=10.0
-    )
-    truth = build_transmit_truth(snapshot, provider_generation=3)
-    assert truth.value is True
-    assert truth.source == "poll_response"
-    assert truth.age_seconds == pytest.approx(0.5)
-    assert truth.generation_current is True
-
-
-@pytest.mark.parametrize(
-    "source", ["state_poller", "command_response", "local_reconcile", "test"]
-)
-def test_transmit_truth_rejects_non_readback_provenance(source: str) -> None:
-    snapshot = _snapshot(value=True, source=source, observed=9.5, generated=10.0)
-    truth = build_transmit_truth(snapshot, provider_generation=3)
-    assert truth.value is None
-    assert truth.source is None
-    assert truth.age_seconds is None
-
-
-def test_transmit_truth_requires_a_strict_bool() -> None:
-    snapshot = _snapshot(value=1, source="poll_response", observed=9.5, generated=10.0)
-    assert build_transmit_truth(snapshot, provider_generation=3).value is None
-
-
-def test_transmit_truth_is_empty_without_the_field() -> None:
-    empty = StateSnapshot.empty()
-    truth = build_transmit_truth(empty, provider_generation=0)
-    assert truth == TransmitTruth(
-        value=None,
-        attributed=None,
-        age_seconds=None,
-        source=None,
-        generation_current=False,
-    )
-
-
-def test_transmit_truth_marks_a_stale_generation_without_discarding_it() -> None:
-    snapshot = _snapshot(
-        value=False,
-        source="civ_unsolicited",
-        observed=9.0,
-        generated=10.0,
-        provider_generation=2,
-    )
-    truth = build_transmit_truth(snapshot, provider_generation=3)
-    assert truth.value is False
-    assert truth.generation_current is False
-    assert truth.age_seconds == pytest.approx(1.0)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- remove the unused `TransmitTruth`, `EMPTY_TRANSMIT_TRUTH`, and `build_transmit_truth` projection surface from the dormant authority module
- remove only projection-specific tests and plumbing
- preserve `TxStateReading`, the observation constants, and every remaining authority/runtime behavior

Linear owner: [MOR-2176](https://linear.app/morozsm/issue/MOR-2176/mor-21672-retire-obsolete-transmittruth-projection)
Parent: [MOR-2167](https://linear.app/morozsm/issue/MOR-2167/tx-authority-remove-dormant-duplicate-authority-and-isolate-observed)
Architecture: PR #2965 / `docs/plans/2026-09-01-runtime-transmit-authority.md`

## TDD and mutation evidence

- RED first: the new absence pin failed while `TransmitTruth` was still present
- GREEN after implementation: targeted suite `254 passed, 32 xfailed`
- mutation: temporarily restoring `TransmitTruth = object` made the absence pin fail; removing the mutation restored green
- independent verifier repeated the mutation proof and accounted for every removed test case

## Regression check

Same Mac test host and Python environment:

- base `e79ccc6593b72cb470080b93849c1f13bbc0de6e`: `14160 passed, 162 skipped, 48 xfailed`, zero failures
- head `cbbe7c71b1c3289683dcf66d2e51da666b20202f`: `14153 passed, 162 skipped, 48 xfailed`, zero failures

The exact seven-test decrease is the intentional removal of eight projection-only cases plus one new absence case. No new failures were introduced.

Additional gates:

- `ruff check`: PASS
- `ruff format --check`: PASS, 704 files already formatted
- `mypy --strict src/rigplane/web`: PASS, 0 issues in 26 files
- import-linter: PASS, 5 contracts kept
- `git diff --check`: PASS

## Size

Exactly 3 files, 15 additions, 167 deletions. This is below both repository guardrails.
