### PR TITLE
feat(MOR-2158): resolve acquisition queries from active profiles

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -40,6 +40,7 @@ __all__ = [
     "AcquisitionExecutionResult",
     "AcquisitionExecutor",
     "AcquisitionPriority",
+    "AcquisitionQueryResolver",
     "AcquisitionRequest",
     "AcquisitionScheduler",
     "AcquisitionStatus",
@@ -49,6 +50,7 @@ __all__ = [
     "RadioStateModelService",
     "StateFreshnessService",
     "civ_acquisition_executor_for_provider",
+    "provider_uses_civ_acquisition",
 ]
 
 
@@ -66,6 +68,7 @@ class AcquisitionQuery:
 
 
 AcquisitionQuerySender = Callable[[AcquisitionQuery], Awaitable[None]]
+AcquisitionQueryResolver = Callable[[FieldPath], AcquisitionQuery | None]
 CivCmd29Support = Callable[[int, int | None], bool]
 
 
@@ -224,116 +227,22 @@ class _PendingMeterSample:
     policy: MeterCoalescingPolicy
 
 
-_RECEIVER_IDS: dict[str, int] = {
-    "0": 0,
-    "main": 0,
-    "1": 1,
-    "sub": 1,
-}
-_RECEIVER_LEVEL_QUERY_SUBS: dict[str, int] = {
-    "af_level": 0x01,
-    "rf_gain": 0x02,
-    "squelch": 0x03,
-    "apf_type_level": 0x05,
-    "nr_level": 0x06,
-    "pbt_inner": 0x07,
-    "pbt_outer": 0x08,
-    # notch_filter (MOR-1548): reclassified from global to receiver-scoped,
-    # matching the ic7610.toml cmd29 route's own per-receiver rationale.
-    "notch_filter": 0x0D,
-    "nb_level": 0x12,
-    "digisel_shift": 0x13,
-}
-_RECEIVER_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
-    "att": (0x11, None),
-    "preamp": (0x16, 0x02),
-    "agc": (0x16, 0x12),
-    "audio_peak_filter": (0x16, 0x32),
-    # filter_shape (MOR-1491) / manual_notch_width (MOR-1492): documented
-    # BCD-nibble 0x16 value reads, same query shape as audio_peak_filter/agc
-    # above.
-    "filter_shape": (0x16, 0x56),
-    "manual_notch_width": (0x16, 0x57),
-    "agc_time_constant": (0x1A, 0x04),
-    "tone_freq": (0x1B, 0x00),
-    "tsql_freq": (0x1B, 0x01),
-}
-_GLOBAL_TX_TOGGLE_QUERIES: dict[str, tuple[int, int | None]] = {
-    "compressor_on": (0x16, 0x44),
-    "monitor_on": (0x16, 0x45),
-    "vox_on": (0x16, 0x46),
-    "split": (0x0F, None),
-    "dual_watch": (0x07, 0xC2),
-}
-_RECEIVER_TOGGLE_QUERIES: dict[str, tuple[int, int | None]] = {
-    "digisel": (0x16, 0x4E),
-    "ipplus": (0x16, 0x65),
-    "nb": (0x16, 0x22),
-    "nr": (0x16, 0x40),
-    "auto_notch": (0x16, 0x41),
-    "manual_notch": (0x16, 0x48),
-    "twin_peak_filter": (0x16, 0x4F),
-    "repeater_tone": (0x16, 0x42),
-    "repeater_tsql": (0x16, 0x43),
-}
-_GLOBAL_LEVEL_QUERY_SUBS: dict[str, int] = {
-    "power_level": 0x0A,
-    "mic_gain": 0x0B,
-    "cw_pitch": 0x09,
-    "key_speed": 0x0C,
-    "compressor_level": 0x0E,
-    "break_in_delay": 0x0F,
-    "drive_gain": 0x14,
-    "monitor_gain": 0x15,
-    "vox_gain": 0x16,
-    "anti_vox_gain": 0x17,
-}
-# Global operator-control reads that are NOT 0x14 levels. tuner_status is a
-# 0x1C 0x01 read with NO data byte; the set form (0x1C 0x01 + 0x00/0x01/0x02)
-# is never used here, so a poll only READS ATU status and can never turn the
-# tuner on or start a tune (MOR-488 batch 5).
-_GLOBAL_NONLEVEL_QUERIES: dict[str, tuple[int, int | None]] = {
-    "tuner_status": (0x1C, 0x01),
-    # break_in (MOR-1493): documented BCD-nibble 0x16 value read (OFF/SEMI/
-    # FULL), same query shape as compressor_on/monitor_on/vox_on above but
-    # 3-valued rather than a plain toggle.
-    "break_in": (0x16, 0x47),
-}
-# Global operator-control reads that need the 0x1A ctl-mem ("quick set")
-# sub-command (0x05) followed by a 2-byte per-model control number
-# (MOR-1483). Pinned to IC-7300's control number -- the live reference
-# profile (``rigs/ic7300.toml``'s ``get_vox_delay`` = ``1A 05 01 91``). This
-# mapping is shared across every icom_civ/xiegu_civ profile and has no
-# per-instance radio-model injection, so it cannot vary the control number
-# per model; IC-7610 is retired hardware
-# (docs/validation/cat-audits/ic7610.md: ``1A 05 0292``) and unverifiable on
-# real hardware, so a primed voxDelay read routed through this mapping on an
-# IC-7610 profile would address the wrong ctl-mem register.
-_GLOBAL_CTL_MEM_QUERIES: dict[str, AcquisitionQuery] = {
-    "vox_delay": AcquisitionQuery(0x1A, sub=0x05, data=b"\x01\x91"),
-}
-_GLOBAL_METER_QUERY_SUBS: dict[str, int] = {
-    "power": 0x11,
-    "swr": 0x12,
-    "alc": 0x13,
-    "comp": 0x14,
-    "vd": 0x15,
-    "id": 0x16,
-}
 _CIV_ACQUISITION_PROVIDERS = frozenset(("icom_civ", "xiegu_civ"))
 
 
 class IcomCivAcquisitionExecutor:
     """CI-V path-to-query executor for compatible CI-V acquisition profiles."""
 
-    __slots__ = ("_send_query", "_supports_cmd29")
+    __slots__ = ("_resolve_query", "_send_query", "_supports_cmd29")
 
     def __init__(
         self,
         send_query: AcquisitionQuerySender,
         *,
+        resolve_query: AcquisitionQueryResolver,
         supports_cmd29: CivCmd29Support | None = None,
     ) -> None:
+        self._resolve_query = resolve_query
         self._send_query = send_query
         self._supports_cmd29 = supports_cmd29
 
@@ -376,118 +285,29 @@ class IcomCivAcquisitionExecutor:
         self,
         path: FieldPath,
     ) -> AcquisitionQuery | None:
-        receiver = _RECEIVER_IDS.get(path.receiver_id or "")
-        if path.scope.value == "receiver" and receiver is None:
-            return None
-        if path.scope.value == "receiver" and path.family.value == "freq_mode":
-            if receiver is None:
-                return None
-            slot = None if path.slot is None else path.slot.value
-            if slot in {"A", "B"}:
-                return None
-            selector = 1 if slot == "unselected" else receiver
-            if slot == "unselected" and receiver != 0:
-                return None
-            if path.name == "freq_hz":
-                return AcquisitionQuery(0x25, data=bytes([selector]))
-            if path.name == "mode":
-                return AcquisitionQuery(0x26, data=bytes([selector]))
-            if path.name == "filter_width":
-                if slot == "unselected":
-                    return None
-                return AcquisitionQuery(0x1A, sub=0x03, receiver=receiver)
-            if path.name == "filter_num":
-                # MOR-1546: no dedicated CI-V read for the filter-selection
-                # fact -- it rides the SAME 0x26 selected/unselected mode
-                # readback as ``mode`` above (``frame.data[3]``, see
-                # ``parse_selected_mode_response`` / ``_civ_rx.py``'s cmd
-                # 0x26 observation branch, which already emits a
-                # ``filter_num`` observation alongside ``mode``/``data_mode``
-                # from that one response). Same selector, same command --
-                # this is an observation-side mapping, not a new query.
-                return AcquisitionQuery(0x26, data=bytes([selector]))
-            if path.name == "data_mode":
-                # MOR-1546: unlike filter_num, DATA mode has its own
-                # dedicated read (CI-V 0x1A 0x06, ``get_data_mode`` in every
-                # profile's ``[commands]`` table) -- no VFO-selector variant,
-                # so (like filter_width) only the selected/active slot is
-                # queryable.
-                if slot == "unselected":
-                    return None
-                return AcquisitionQuery(0x1A, sub=0x06, receiver=receiver)
-            return None
-        if path.scope.value == "receiver" and path.family.value == "meters":
-            if path.name == "s_meter":
-                return AcquisitionQuery(0x15, sub=0x02, receiver=receiver)
-            return None
-        if path.scope.value == "receiver" and path.family.value == "operator_toggles":
-            toggle = _RECEIVER_TOGGLE_QUERIES.get(path.name)
-            return (
-                None
-                if toggle is None
-                else AcquisitionQuery(toggle[0], sub=toggle[1], receiver=receiver)
-            )
-        if path.scope.value == "receiver" and path.family.value == "operator_controls":
-            nonlevel = _RECEIVER_NONLEVEL_QUERIES.get(path.name)
-            if nonlevel is not None:
-                return AcquisitionQuery(
-                    nonlevel[0],
-                    sub=nonlevel[1],
-                    receiver=receiver,
-                )
-            sub = _RECEIVER_LEVEL_QUERY_SUBS.get(path.name)
-            return (
-                None
-                if sub is None
-                else AcquisitionQuery(0x14, sub=sub, receiver=receiver)
-            )
-        if path.scope.value == "global" and path.family.value == "meters":
-            sub = _GLOBAL_METER_QUERY_SUBS.get(path.name)
-            return None if sub is None else AcquisitionQuery(0x15, sub=sub)
-        if path.scope.value == "global" and path.family.value == "slow_state":
-            if path.name == "active":
-                return AcquisitionQuery(0x07, data=b"\xd2")
-            return None
-        if path.scope.value == "global" and path.family.value == "tx_state":
-            if path.name == "ptt":
-                return AcquisitionQuery(0x1C, sub=0x00)
-            if path.name == "rit_on":
-                return AcquisitionQuery(0x21, sub=0x01)
-            if path.name == "rit_tx":
-                return AcquisitionQuery(0x21, sub=0x02)
-            toggle = _GLOBAL_TX_TOGGLE_QUERIES.get(path.name)
-            if toggle is not None and toggle[0] == 0x07:
-                assert toggle[1] is not None
-                return AcquisitionQuery(0x07, data=bytes([toggle[1]]))
-            return (
-                None if toggle is None else AcquisitionQuery(toggle[0], sub=toggle[1])
-            )
-        if path.scope.value == "global" and path.family.value == "operator_controls":
-            if path.name == "rit_freq":
-                return AcquisitionQuery(0x21, sub=0x00)
-            ctl_mem = _GLOBAL_CTL_MEM_QUERIES.get(path.name)
-            if ctl_mem is not None:
-                return ctl_mem
-            nonlevel = _GLOBAL_NONLEVEL_QUERIES.get(path.name)
-            if nonlevel is not None:
-                return AcquisitionQuery(nonlevel[0], sub=nonlevel[1])
-            sub = _GLOBAL_LEVEL_QUERY_SUBS.get(path.name)
-            return None if sub is None else AcquisitionQuery(0x14, sub=sub)
-        return None
+        return self._resolve_query(path)
+
+
+def provider_uses_civ_acquisition(provider: str) -> bool:
+    """Return whether *provider* uses the shared CI-V query envelope."""
+
+    return provider in _CIV_ACQUISITION_PROVIDERS
 
 
 def civ_acquisition_executor_for_provider(
     provider: str,
     send_query: AcquisitionQuerySender,
     *,
+    resolve_query: AcquisitionQueryResolver,
     supports_cmd29: CivCmd29Support | None = None,
 ) -> AcquisitionExecutor | None:
     """Return the shared CI-V executor for providers using this query envelope."""
 
-    if provider not in _CIV_ACQUISITION_PROVIDERS:
+    if not provider_uses_civ_acquisition(provider):
         return None
     return IcomCivAcquisitionExecutor(
         send_query,
+        resolve_query=resolve_query,
         supports_cmd29=supports_cmd29,
     )
 

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -32,7 +32,9 @@ from ..core.acquisition_scheduler import (
     RadioStateModelService,
     StateFreshnessService,
     civ_acquisition_executor_for_provider,
+    provider_uses_civ_acquisition,
 )
+from ..profiles import RadioProfile
 from ..core.state_diagnostics import StateDiagnosticsRecorder
 from ..core.state_pipeline_contracts import FieldPath
 from ..core.state_acquisition_policy import RadioAcquisitionProfile
@@ -44,6 +46,7 @@ from ..radio_protocol import (
     StateStoreCapable,
 )
 from ..runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
+from ..runtime._state_queries import acquisition_query_resolver_for_profile
 from ..startup_checks import assert_radio_startup_ready
 from . import audit as _audit  # noqa: TID251
 from .circuit_breaker import CircuitBreaker, CircuitState  # noqa: TID251
@@ -355,13 +358,7 @@ class RigctldServer:
         return None
 
     def _provider_uses_civ_executor(self, provider: str) -> bool:
-        return (
-            civ_acquisition_executor_for_provider(
-                provider,
-                self._send_one_state_query,
-            )
-            is not None
-        )
+        return provider_uses_civ_acquisition(provider)
 
     def _default_acquisition_executor_for_scheduler(
         self,
@@ -372,10 +369,13 @@ class RigctldServer:
         if not isinstance(self._radio, CivCommandCapable):
             return None
         profile = self._resolved_radio_profile()
+        if not isinstance(profile, RadioProfile):
+            return None
         supports_cmd29 = getattr(profile, "supports_cmd29", None)
         return civ_acquisition_executor_for_provider(
             scheduler.provider,
             self._send_one_state_query,
+            resolve_query=acquisition_query_resolver_for_profile(profile),
             supports_cmd29=supports_cmd29 if callable(supports_cmd29) else None,
         )
 

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -15,10 +15,82 @@ from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
 )
-from rigplane.core.acquisition_scheduler import AcquisitionQuery
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionQuery,
+    AcquisitionQueryResolver,
+)
+from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.profiles import RadioProfile
 
 logger = logging.getLogger(__name__)
+
+_RECEIVER_IDS = {"0": 0, "main": 0, "1": 1, "sub": 1}
+_RECEIVER_TOGGLE_GETTERS = {
+    "digisel": "get_digisel",
+    "ipplus": "get_ip_plus",
+    "nb": "get_nb",
+    "nr": "get_nr",
+    "auto_notch": "get_auto_notch",
+    "manual_notch": "get_manual_notch",
+    "twin_peak_filter": "get_twin_peak_filter",
+    "repeater_tone": "get_repeater_tone",
+    "repeater_tsql": "get_repeater_tsql",
+}
+_RECEIVER_CONTROL_GETTERS = {
+    "af_level": "get_af_level",
+    "rf_gain": "get_rf_gain",
+    "squelch": "get_squelch",
+    "apf_type_level": "get_apf_type_level",
+    "nr_level": "get_nr_level",
+    "pbt_inner": "get_pbt_inner",
+    "pbt_outer": "get_pbt_outer",
+    "notch_filter": "get_notch_filter",
+    "nb_level": "get_nb_level",
+    "digisel_shift": "get_digisel_shift",
+    "att": "get_attenuator",
+    "preamp": "get_preamp",
+    "agc": "get_agc",
+    "audio_peak_filter": "get_audio_peak_filter",
+    "filter_shape": "get_filter_shape",
+    "manual_notch_width": "get_manual_notch_width",
+    "agc_time_constant": "get_agc_time_constant",
+    "tone_freq": "get_tone_freq",
+    "tsql_freq": "get_tsql_freq",
+}
+_GLOBAL_METER_GETTERS = {
+    "power": "get_power_meter",
+    "swr": "get_swr",
+    "alc": "get_alc",
+    "comp": "get_comp_meter",
+    "vd": "get_vd_meter",
+    "id": "get_id_meter",
+}
+_GLOBAL_TX_STATE_GETTERS = {
+    "ptt": "get_transceiver_status",
+    "rit_on": "get_rit_status",
+    "rit_tx": "get_rit_tx_status",
+    "compressor_on": "get_compressor",
+    "monitor_on": "get_monitor",
+    "vox_on": "get_vox",
+    "split": "get_split",
+    "dual_watch": "get_dual_watch",
+}
+_GLOBAL_CONTROL_GETTERS = {
+    "rit_freq": "get_rit_frequency",
+    "vox_delay": "get_vox_delay",
+    "tuner_status": "get_tuner_status",
+    "break_in": "get_break_in",
+    "power_level": "get_rf_power",
+    "mic_gain": "get_mic_gain",
+    "cw_pitch": "get_cw_pitch",
+    "key_speed": "get_key_speed",
+    "compressor_level": "get_compressor_level",
+    "break_in_delay": "get_break_in_delay",
+    "drive_gain": "get_drive_gain",
+    "monitor_gain": "get_monitor_gain",
+    "vox_gain": "get_vox_gain",
+    "anti_vox_gain": "get_anti_vox_gain",
+}
 
 
 def acquisition_query_from_wire_tuple(
@@ -30,6 +102,83 @@ def acquisition_query_from_wire_tuple(
 
     command, sub, data = decode_wire_tuple(wire)
     return AcquisitionQuery(command, sub=sub, data=data, receiver=receiver)
+
+
+def acquisition_query_resolver_for_profile(
+    profile: RadioProfile,
+) -> AcquisitionQueryResolver:
+    """Bind acquisition FieldPaths to one profile's declared getter bytes."""
+
+    command_map = profile.command_map
+
+    def from_getter(
+        getter: str | None,
+        *,
+        receiver: int | None = None,
+    ) -> AcquisitionQuery | None:
+        if getter is None or command_map is None or not command_map.has(getter):
+            return None
+        return acquisition_query_from_wire_tuple(
+            command_map.get(getter),
+            receiver=receiver,
+        )
+
+    def resolve_freq_mode(path: FieldPath, receiver: int) -> AcquisitionQuery | None:
+        slot = None if path.slot is None else path.slot.value
+        if slot in {"A", "B"} or (slot == "unselected" and receiver != 0):
+            return None
+        selected = receiver == 0 and slot != "unselected"
+        if path.name == "freq_hz":
+            getter = "get_selected_freq" if selected else "get_unselected_freq"
+        elif path.name in {"mode", "filter_num"}:
+            getter = "get_selected_mode" if selected else "get_unselected_mode"
+        elif path.name == "filter_width":
+            return from_getter(
+                "get_filter_width" if slot != "unselected" else None,
+                receiver=receiver,
+            )
+        elif path.name == "data_mode":
+            return from_getter(
+                "get_data_mode" if slot != "unselected" else None,
+                receiver=receiver,
+            )
+        else:
+            getter = None
+        return from_getter(getter)
+
+    def resolve(path: FieldPath) -> AcquisitionQuery | None:
+        scope = path.scope.value
+        family = path.family.value
+        if scope == "receiver":
+            receiver = _RECEIVER_IDS.get(path.receiver_id or "")
+            if receiver is None or not profile.supports_receiver(receiver):
+                return None
+            if family == "freq_mode":
+                return resolve_freq_mode(path, receiver)
+            if family == "meters":
+                getter = "get_s_meter" if path.name == "s_meter" else None
+            elif family == "operator_toggles":
+                getter = _RECEIVER_TOGGLE_GETTERS.get(path.name)
+            elif family == "operator_controls":
+                getter = _RECEIVER_CONTROL_GETTERS.get(path.name)
+            else:
+                getter = None
+            return from_getter(getter, receiver=receiver)
+        if scope != "global":
+            return None
+        if family == "meters":
+            getter = _GLOBAL_METER_GETTERS.get(path.name)
+        elif family == "slow_state":
+            getter = "get_main_sub_band" if path.name == "active" else None
+        elif family == "tx_state":
+            getter = _GLOBAL_TX_STATE_GETTERS.get(path.name)
+        elif family == "operator_controls":
+            getter = _GLOBAL_CONTROL_GETTERS.get(path.name)
+        else:
+            getter = None
+        return from_getter(getter)
+
+    return resolve
 
 
 def build_state_queries(

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -111,7 +111,10 @@ from ..core.tx_target import (
     TxTarget,
     UnknownTxTarget,
 )
-from .._state_queries import build_state_queries
+from .._state_queries import (
+    acquisition_query_resolver_for_profile,
+    build_state_queries,
+)
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..runtime.tx_interlock import (
@@ -706,6 +709,7 @@ class RadioPoller:
             self._acquisition_executor = civ_acquisition_executor_for_provider(
                 self._acquisition_scheduler.provider,
                 self._send_one_state_query,
+                resolve_query=acquisition_query_resolver_for_profile(self._profile),
                 supports_cmd29=self._profile.supports_cmd29,
             )
         # Set by default — cleared at _run() start, re-set after initial fetch.

--- a/tests/_acquisition_query_helpers.py
+++ b/tests/_acquisition_query_helpers.py
@@ -11,7 +11,10 @@ from rigplane.core.acquisition_scheduler import (
 )
 
 if TYPE_CHECKING:
+    from rigplane.profiles import RadioProfile
     from rigplane.web.radio_poller import RadioPoller
+
+from rigplane.runtime._state_queries import acquisition_query_resolver_for_profile
 
 
 AcquisitionQueryCase = AcquisitionQuery
@@ -95,6 +98,7 @@ def query_selector(query: AcquisitionQueryCase) -> int | None:
 
 
 def recording_executor(
+    profile: RadioProfile,
     *,
     supports_cmd29: Callable[[int, int | None], bool] | None = None,
 ) -> tuple[IcomCivAcquisitionExecutor, list[AcquisitionQueryCase]]:
@@ -105,7 +109,11 @@ def recording_executor(
         sent.append(_require_query(query))
 
     return (
-        IcomCivAcquisitionExecutor(send_query, supports_cmd29=supports_cmd29),
+        IcomCivAcquisitionExecutor(
+            send_query,
+            resolve_query=acquisition_query_resolver_for_profile(profile),
+            supports_cmd29=supports_cmd29,
+        ),
         sent,
     )
 

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -36,7 +36,9 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
+from rigplane.commands.command_map import CommandMap
 from rigplane.profiles import get_radio_profile
+from rigplane.runtime._state_queries import acquisition_query_from_wire_tuple
 from rigplane.profiles.rig_loader import load_rig
 from _acquisition_query_helpers import (
     acquisition_query,
@@ -46,6 +48,103 @@ from _acquisition_query_helpers import (
 
 
 RIGS_DIR = Path(__file__).parents[1] / "rigs"
+
+
+@pytest.mark.parametrize(
+    ("model", "path", "getter"),
+    [
+        ("IC-9700", FieldPath.global_("tx_state", "dual_watch"), "get_dual_watch"),
+        (
+            "IC-705",
+            FieldPath.global_("operator_controls", "vox_delay"),
+            "get_vox_delay",
+        ),
+        (
+            "IC-7610",
+            FieldPath.global_("operator_controls", "vox_delay"),
+            "get_vox_delay",
+        ),
+        (
+            "IC-9700",
+            FieldPath.global_("operator_controls", "vox_delay"),
+            "get_vox_delay",
+        ),
+    ],
+)
+def test_profile_query_bytes_replace_scheduler_literals(
+    model: str,
+    path: FieldPath,
+    getter: str,
+) -> None:
+    profile = get_radio_profile(model)
+    assert profile.command_map is not None
+    expected = acquisition_query_from_wire_tuple(profile.command_map.get(getter))
+    executor, _sent = recording_executor(profile)
+
+    assert executor.query_for_path(path) == expected
+
+
+@pytest.mark.parametrize("model", ["IC-7300", "IC-7610", "IC-9700"])
+def test_missing_ptt_getter_fails_closed(model: str) -> None:
+    profile = get_radio_profile(model)
+    assert "get_transceiver_status" not in profile.command_names
+    executor, _sent = recording_executor(profile)
+
+    assert executor.query_for_path(FieldPath.global_("tx_state", "ptt")) is None
+
+
+def test_profile_command_map_mutation_changes_resolved_query() -> None:
+    profile = get_radio_profile("IC-9700")
+    assert profile.command_map is not None
+    changed = replace(
+        profile,
+        command_map=CommandMap(
+            {
+                **{name: profile.command_map.get(name) for name in profile.command_map},
+                "get_dual_watch": (0x16, 0x5A),
+            }
+        ),
+    )
+    executor, _sent = recording_executor(changed)
+    path = FieldPath.global_("tx_state", "dual_watch")
+
+    assert changed.command_map is not None
+    assert executor.query_for_path(path) == acquisition_query_from_wire_tuple(
+        changed.command_map.get("get_dual_watch")
+    )
+
+
+def test_profile_resolvers_used_sequentially_do_not_leak_queries() -> None:
+    path = FieldPath.global_("operator_controls", "vox_delay")
+    ic705 = get_radio_profile("IC-705")
+    ic9700 = get_radio_profile("IC-9700")
+    first, _sent = recording_executor(ic705)
+    second, _sent = recording_executor(ic9700)
+
+    assert first.query_for_path(path) == acquisition_query(
+        0x1A, sub=0x05, data=b"\x03\x59"
+    )
+    assert second.query_for_path(path) == acquisition_query(
+        0x1A, sub=0x05, data=b"\x03\x30"
+    )
+    assert first.query_for_path(path) == acquisition_query(
+        0x1A, sub=0x05, data=b"\x03\x59"
+    )
+
+
+def test_ic7300_removed_apf_getters_resolve_none() -> None:
+    profile = get_radio_profile("IC-7300")
+    executor, _sent = recording_executor(profile)
+    audio_peak = FieldPath.receiver("main", "operator_controls", "audio_peak_filter")
+    apf_level = FieldPath.receiver("main", "operator_controls", "apf_type_level")
+
+    assert profile.command_map is not None
+    assert not profile.command_map.has("get_audio_peak_filter")
+    assert "get_apf_type_level" in profile.absent_command_names
+    assert executor.query_for_path(audio_peak) is None
+    assert executor.query_for_path(apf_level) is None
+    assert profile.state_acquisition is not None
+    assert audio_peak not in profile.state_acquisition.capabilities
 
 
 def _source() -> SourceMetadata:
@@ -810,7 +909,7 @@ def test_ic7610_real_profile_stale_active_rit_xit_acquisition_can_send_queries()
     store.mark_stale_due()
     scheduler = AcquisitionScheduler(profile=acquisition, clock=clock)
     service = RadioStateModelService(store=store, scheduler=scheduler, clock=clock)
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     result = service.ensure_fresh(
         tuple(path for path, _value in paths_and_values),
@@ -856,7 +955,7 @@ def test_ic7610_real_profile_freq_mode_are_pollable_and_emit_25_26() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(freq_mode_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in freq_mode_paths for path in request.paths):
             continue
@@ -873,16 +972,7 @@ def test_ic7610_real_profile_freq_mode_are_pollable_and_emit_25_26() -> None:
     } <= set(sent)
 
 
-def test_ic7610_real_profile_ptt_is_pollable_and_emits_bare_1c00_read() -> None:
-    """MOR-496: front-panel TX must reach the v2 UI, so ptt must be polled.
-
-    The IC-7610 does NOT emit unsolicited 0x1C/00 transceive frames, so ptt
-    only refreshed via slow one-shot stale reconciliation and the STATION
-    METERS header stayed "RX" while keying from the front panel. Adding ptt to
-    ``polling_only`` + a fast field policy enrolls it in the poll cadence
-    groups. The poll query MUST be a bare 0x1C 0x00 READ (no data byte) so a
-    poll can never key the transmitter.
-    """
+def test_ic7610_real_profile_ptt_without_getter_fails_closed() -> None:
     acquisition = load_rig(RIGS_DIR / "ic7610.toml").to_profile().state_acquisition
     assert acquisition is not None
 
@@ -895,11 +985,9 @@ def test_ic7610_real_profile_ptt_is_pollable_and_emits_bare_1c00_read() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert ptt in due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
-    # The poll query is a pure READ of 0x1C 0x00 with no receiver/data byte;
-    # a data byte would key TX, while this global read has no receiver route.
-    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
+    assert executor.query_for_path(ptt) is None
 
     for request in requests:
         if ptt not in request.paths:
@@ -907,12 +995,14 @@ def test_ic7610_real_profile_ptt_is_pollable_and_emits_bare_1c00_read() -> None:
         execution = asyncio.run(
             executor.execute(request, already_sent_paths=frozenset())
         )
-        assert execution.failed_paths == ()
-    assert acquisition_query(0x1C, sub=0x00) in sent
+        assert execution.sent_paths == ()
+        assert execution.failed_paths == (ptt,)
+        assert execution.failure_reason == "no_civ_query_mapping"
+    assert sent == []
 
 
 def test_ic7610_real_profile_att_preamp_squelch_query_for_path() -> None:
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     att = FieldPath.receiver("main", "operator_controls", "att")
     preamp = FieldPath.receiver("main", "operator_controls", "preamp")
@@ -933,7 +1023,7 @@ def test_ic7610_global_meter_query_for_path() -> None:
     power/swr/alc already mapped; comp/vd/id were missing, so on a
     scheduler-only radio (IC-7610) they were never polled and rendered 0.
     """
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     power = FieldPath.global_("meters", "power")
     swr = FieldPath.global_("meters", "swr")
@@ -975,7 +1065,7 @@ def test_ic7610_real_profile_comp_vd_id_meters_are_enrolled_and_sent() -> None:
     sent: list[FieldPath] = []
     failed: list[FieldPath] = []
 
-    executor, _queries = recording_executor()
+    executor, _queries = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         execution = asyncio.run(
             executor.execute(request, already_sent_paths=frozenset())
@@ -994,7 +1084,7 @@ def test_ic7610_real_profile_sub_operator_controls_query_for_path() -> None:
     rf_gain/af_level/squelch route through the 0x14 level subs; att/preamp
     through the non-level mappings — all with the SUB receiver byte (1).
     """
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     rf_gain = FieldPath.receiver("sub", "operator_controls", "rf_gain")
     af_level = FieldPath.receiver("sub", "operator_controls", "af_level")
@@ -1044,7 +1134,7 @@ def test_ic7610_real_profile_sql_att_pre_are_pollable_and_emit_reads() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -1087,7 +1177,7 @@ def test_ic7610_real_profile_sub_operator_controls_pollable_and_emit_reads() -> 
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -2479,7 +2569,7 @@ def test_meter_coalescing_flush_due_defers_same_path_until_latest_window() -> No
 
 
 def test_ic7610_real_profile_rf_dsp_toggle_query_for_path() -> None:
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     # cmd16 receiver toggles (operator_toggles family) — MAIN (receiver 0).
     digisel = FieldPath.receiver("main", "operator_toggles", "digisel")
@@ -2573,7 +2663,7 @@ def test_ic7610_real_profile_rf_dsp_toggles_pollable_and_emit_reads() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -2606,7 +2696,7 @@ def test_ic7610_real_profile_rf_dsp_toggles_pollable_and_emit_reads() -> None:
 
 
 def test_ic7610_real_profile_level_query_for_path() -> None:
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     # Receiver levels (cmd 0x14, operator_controls family) — MAIN (receiver 0).
     nr_level = FieldPath.receiver("main", "operator_controls", "nr_level")
@@ -2718,7 +2808,7 @@ def test_ic7610_real_profile_levels_pollable_and_emit_reads() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -2753,7 +2843,7 @@ def test_ic7610_real_profile_levels_pollable_and_emit_reads() -> None:
 
 
 def test_ic7610_real_profile_filter_width_query_for_path() -> None:
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     filter_width_main = FieldPath.active("main", "freq_mode", "filter_width")
     filter_width_sub = FieldPath.active("sub", "freq_mode", "filter_width")
@@ -2782,7 +2872,7 @@ def test_filter_num_and_data_mode_query_for_path() -> None:
     profile's ``[commands]`` table), matching ``filter_width``'s
     selected-only (no "unselected") shape rather than ``mode``'s.
     """
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     filter_num_main = FieldPath.active("main", "freq_mode", "filter_num")
     filter_num_sub = FieldPath.active("sub", "freq_mode", "filter_num")
@@ -2865,7 +2955,7 @@ def test_ic7610_real_profile_filter_width_pollable_and_emit_reads() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -2881,7 +2971,7 @@ def test_ic7610_real_profile_filter_width_pollable_and_emit_reads() -> None:
 
 
 def test_ic7610_real_profile_tx_vox_toggle_query_for_path() -> None:
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     # GLOBAL cmd16 tx_state toggles — receiver is None (global path).
     compressor_on = FieldPath.global_("tx_state", "compressor_on")
@@ -2905,7 +2995,7 @@ def test_ic7610_real_profile_tx_vox_toggle_query_for_path() -> None:
     ptt = FieldPath.global_("tx_state", "ptt")
     rit_on = FieldPath.global_("tx_state", "rit_on")
     rit_tx = FieldPath.global_("tx_state", "rit_tx")
-    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
+    assert executor.query_for_path(ptt) is None
     assert executor.query_for_path(rit_on) == acquisition_query(0x21, sub=0x01)
     assert executor.query_for_path(rit_tx) == acquisition_query(0x21, sub=0x02)
 
@@ -2959,7 +3049,7 @@ def test_ic7610_real_profile_tx_vox_pollable_and_emit_reads() -> None:
     due_paths = {path for request in requests for path in request.paths}
     assert set(target_paths) <= due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -2987,7 +3077,7 @@ def test_ic7300_vox_delay_query_for_path_ctl_mem_multibyte_sub() -> None:
     """
 
     vox_delay = FieldPath.global_("operator_controls", "vox_delay")
-    executor, _sent = recording_executor()
+    executor, _sent = recording_executor(get_radio_profile("IC-7300"))
 
     query = executor.query_for_path(vox_delay)
 
@@ -3021,14 +3111,14 @@ def test_ic7300_real_profile_vox_delay_is_primed_and_executor_builds_multibyte_f
     request = next(req for req in queued if vox_delay in req.paths)
     assert request.acquisition_method == "command_response"
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7300"))
     execution = asyncio.run(executor.execute(request, already_sent_paths=frozenset()))
     assert execution.failed_paths == ()
     assert acquisition_query(0x1A, sub=0x05, data=b"\x01\x91") in sent
 
 
 def test_ic7610_real_profile_vfo_global_query_for_path() -> None:
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
     # GLOBAL tx_state split — cmd 0x0F, no sub (no-data read), receiver None.
     split = FieldPath.global_("tx_state", "split")
@@ -3050,7 +3140,7 @@ def test_ic7610_real_profile_vfo_global_query_for_path() -> None:
     compressor_on = FieldPath.global_("tx_state", "compressor_on")
     monitor_on = FieldPath.global_("tx_state", "monitor_on")
     vox_on = FieldPath.global_("tx_state", "vox_on")
-    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
+    assert executor.query_for_path(ptt) is None
     assert executor.query_for_path(rit_on) == acquisition_query(0x21, sub=0x01)
     assert executor.query_for_path(rit_tx) == acquisition_query(0x21, sub=0x02)
     assert executor.query_for_path(compressor_on) == acquisition_query(0x16, sub=0x44)
@@ -3091,7 +3181,7 @@ def test_ic7610_real_profile_vfo_global_pollable_and_emit_reads() -> None:
     assert set(target_paths) <= due_paths
     assert tuning_step not in due_paths
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in target_paths for path in request.paths):
             continue
@@ -3109,8 +3199,8 @@ def test_ic7610_real_profile_vfo_global_pollable_and_emit_reads() -> None:
     assert acquisition_query(0x10) not in set(sent)
 
 
-def test_ic7610_real_profile_tone_tuner_query_for_path() -> None:
-    executor, sent = recording_executor()
+def test_ic9700_real_profile_tone_tuner_query_for_path() -> None:
+    executor, sent = recording_executor(get_radio_profile("IC-9700"))
 
     # cmd16 receiver toggles (operator_toggles family) — MAIN (receiver 0).
     repeater_tone = FieldPath.receiver("main", "operator_toggles", "repeater_tone")
@@ -3163,9 +3253,7 @@ def test_ic7610_real_profile_tone_tuner_query_for_path() -> None:
     agc_time_constant = FieldPath.receiver(
         "main", "operator_controls", "agc_time_constant"
     )
-    assert executor.query_for_path(digisel) == acquisition_query(
-        0x16, sub=0x4E, receiver=0
-    )
+    assert executor.query_for_path(digisel) is None
     assert executor.query_for_path(att) == acquisition_query(0x11, receiver=0)
     assert executor.query_for_path(preamp) == acquisition_query(
         0x16, sub=0x02, receiver=0
@@ -3219,7 +3307,7 @@ def test_ic7610_real_profile_tuner_pollable_tone_absent() -> None:
     # No removed tone/tsql path is ever scheduled.
     assert not (set(removed_tone_paths) & due_paths)
 
-    executor, sent = recording_executor()
+    executor, sent = recording_executor(get_radio_profile("IC-7610"))
     for request in requests:
         if not any(path in fast_paths for path in request.paths):
             continue
@@ -3240,10 +3328,12 @@ def test_ic7610_real_profile_tuner_pollable_tone_absent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ic7300_route_uses_plain_main_reads_and_fails_closed_for_sub() -> None:
-    """A no-cmd29 profile must never wrap MAIN reads or invent SUB routing."""
+async def test_unsupported_cmd29_route_falls_back_main_and_refuses_sub() -> None:
 
-    executor, sent = recording_executor(supports_cmd29=lambda _command, _sub: False)
+    executor, sent = recording_executor(
+        get_radio_profile("IC-7610"),
+        supports_cmd29=lambda _command, _sub: False,
+    )
     main_af = FieldPath.receiver("main", "operator_controls", "af_level")
     sub_af = FieldPath.receiver("sub", "operator_controls", "af_level")
     scheduler = AcquisitionScheduler(profile=_profile([main_af, sub_af]))
@@ -3263,7 +3353,10 @@ async def test_ic7300_route_uses_plain_main_reads_and_fails_closed_for_sub() -> 
 
 
 def test_ic7300_relative_vfo_paths_use_selected_unselected_25_26_selectors() -> None:
-    executor, _sent = recording_executor(supports_cmd29=lambda _command, _sub: False)
+    executor, _sent = recording_executor(
+        get_radio_profile("IC-7300"),
+        supports_cmd29=lambda _command, _sub: False,
+    )
 
     assert executor.query_for_path(
         FieldPath.active("main", "freq_mode", "freq_hz")
@@ -3284,7 +3377,10 @@ async def test_ic7300_executor_preserves_dedupe_for_plain_profile_route() -> Non
     power = FieldPath.global_("operator_controls", "power_level")
     compressor = FieldPath.global_("tx_state", "compressor_on")
     scheduler = AcquisitionScheduler(profile=_profile([power, compressor]))
-    executor, sent = recording_executor(supports_cmd29=lambda _command, _sub: False)
+    executor, sent = recording_executor(
+        get_radio_profile("IC-7300"),
+        supports_cmd29=lambda _command, _sub: False,
+    )
 
     for request in scheduler.due_requests():
         result = await executor.execute(

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -981,8 +981,8 @@ async def test_scheduler_unknown_query_mapping_is_recorded_and_failed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
-    radio = _make_radio(active="MAIN")
+async def test_scheduler_ptt_request_uses_ic705_declared_getter() -> None:
+    radio = _make_radio(active="MAIN", model="IC-705")
     path = FieldPath.global_("tx_state", "ptt")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
     radio._acquisition_scheduler = scheduler
@@ -999,6 +999,22 @@ async def test_scheduler_ptt_request_sends_civ_ptt_query() -> None:
         wait_dispatch=False,
     )
     assert scheduler.pending_requests()[0].paths == (path,)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_ptt_without_profile_getter_fails_closed() -> None:
+    radio = _make_radio(active="MAIN", model="IC-7610")
+    path = FieldPath.global_("tx_state", "ptt")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    await poller._send_query()  # noqa: SLF001
+
+    radio.send_civ.assert_not_awaited()
+    assert scheduler.diagnostics()["failureCountByReason"] == {
+        "no_civ_query_mapping": 1
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1135,6 +1151,22 @@ async def test_execute_set_attenuator_readback_does_not_depend_on_slowed_cadence
     # confirming read is dispatched on the very next drain, not gated by the
     # 3.0s tier at all.
     assert pending[0].priority is AcquisitionPriority.USER
+
+
+def test_web_scheduler_executor_uses_active_ic9700_profile_query() -> None:
+    path = FieldPath.global_("tx_state", "dual_watch")
+    radio = _make_radio(model="IC-9700")
+    radio._acquisition_scheduler = AcquisitionScheduler(
+        profile=_acquisition_profile(path, provider="icom_civ")
+    )
+
+    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
+
+    assert poller._acquisition_executor is not None  # noqa: SLF001
+    assert poller._acquisition_executor.query_for_path(path) == acquisition_query(  # type: ignore[attr-defined]  # noqa: SLF001
+        0x16,
+        sub=0x59,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -24,9 +25,11 @@ from serial_stub import SerialMockRadio
 from rigplane.core.acquisition_scheduler import (
     AcquisitionExecutionResult,
     AcquisitionPriority,
+    AcquisitionQuery,
     AcquisitionRequest,
     AcquisitionScheduler,
     AcquisitionStatus,
+    IcomCivAcquisitionExecutor,
     RadioStateModelService,
     StateFreshnessService,
 )
@@ -51,6 +54,7 @@ from rigplane.rigctld.contract import (
     RigctldResponse,
 )
 from rigplane.rigctld.server import RigctldServer, run_rigctld_server
+from rigplane.profiles import resolve_radio_profile
 from rigplane.types import Mode
 
 # ---------------------------------------------------------------------------
@@ -1108,16 +1112,10 @@ class TestLifecycle:
     ) -> None:
         freq = FieldPath.active("main", "freq_mode", "freq_hz")
         radio = _CivProfiledStandaloneRadio(
-            profile=type(
-                "Profile",
-                (),
-                {
-                    "state_acquisition": _acquisition_profile(
-                        freq,
-                        provider="icom_civ",
-                    )
-                },
-            )(),
+            profile=replace(
+                resolve_radio_profile(model="IC-705"),
+                state_acquisition=_acquisition_profile(freq, provider="icom_civ"),
+            ),
             observed_freq=14_110_000,
         )
         fake_server = _FakeAsyncServer()
@@ -1176,6 +1174,23 @@ class TestLifecycle:
                 assert srv._acquisition_scheduler.pending_requests() == ()
             finally:
                 await srv.stop()
+
+    async def test_civ_executor_uses_active_ic9700_profile_query(
+        self, cfg: RigctldConfig
+    ) -> None:
+        path = FieldPath.global_("tx_state", "dual_watch")
+        profile = replace(
+            resolve_radio_profile(model="IC-9700"),
+            state_acquisition=_acquisition_profile(path, provider="icom_civ"),
+        )
+        radio = _CivProfiledStandaloneRadio(profile=profile, observed_freq=0)
+        srv = RigctldServer(radio, cfg)
+        scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+
+        executor = srv._default_acquisition_executor_for_scheduler(scheduler)
+
+        assert isinstance(executor, IcomCivAcquisitionExecutor)
+        assert executor.query_for_path(path) == AcquisitionQuery(0x16, sub=0x59)
 
     async def test_unavailable_field_records_distinct_acquisition_diagnostic(
         self, cfg: RigctldConfig

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -856,7 +856,7 @@ def test_ic7300_non_polling_field_policies_have_full_acquisition_chain() -> None
     acquisition = profile.state_acquisition
     assert acquisition is not None
 
-    executor, _sent = recording_executor()
+    executor, _sent = recording_executor(profile)
     radio = IcomRadio(host="192.168.1.100", model="IC-7300")
 
     non_polling_paths = [

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -20,6 +20,7 @@ from rigplane.profiles import resolve_radio_profile
 from rigplane.rigctld.server import RigctldServer
 from rigplane.runtime import _state_queries as state_queries_module
 from rigplane.runtime._state_queries import build_state_queries
+from rigplane.runtime._state_queries import acquisition_query_resolver_for_profile
 from rigplane.runtime.radio_initial_state import fetch_initial_state
 from rigplane.web.radio_poller import RadioPoller
 from _acquisition_query_helpers import (
@@ -39,6 +40,185 @@ _SELECTOR_SUBS = frozenset({0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F})
 _BARE_SUBS = frozenset({0x12, 0x13, 0x1B, 0x1C})
 
 _FrameParts = tuple[int, int | None, bytes]
+
+
+def _profile_resolver_cases() -> list[tuple[FieldPath, str]]:
+    cases = [
+        (FieldPath.active("main", "freq_mode", "freq_hz"), "get_selected_freq"),
+        (
+            FieldPath.unselected("main", "freq_mode", "freq_hz"),
+            "get_unselected_freq",
+        ),
+        (FieldPath.active("main", "freq_mode", "mode"), "get_selected_mode"),
+        (
+            FieldPath.unselected("main", "freq_mode", "mode"),
+            "get_unselected_mode",
+        ),
+        (
+            FieldPath.active("main", "freq_mode", "filter_width"),
+            "get_filter_width",
+        ),
+        (
+            FieldPath.active("main", "freq_mode", "filter_num"),
+            "get_selected_mode",
+        ),
+        (
+            FieldPath.unselected("main", "freq_mode", "filter_num"),
+            "get_unselected_mode",
+        ),
+        (FieldPath.active("main", "freq_mode", "data_mode"), "get_data_mode"),
+        (FieldPath.receiver("main", "meters", "s_meter"), "get_s_meter"),
+    ]
+    cases.extend(
+        (FieldPath.receiver("main", "operator_toggles", field), getter)
+        for field, getter in {
+            "digisel": "get_digisel",
+            "ipplus": "get_ip_plus",
+            "nb": "get_nb",
+            "nr": "get_nr",
+            "auto_notch": "get_auto_notch",
+            "manual_notch": "get_manual_notch",
+            "twin_peak_filter": "get_twin_peak_filter",
+            "repeater_tone": "get_repeater_tone",
+            "repeater_tsql": "get_repeater_tsql",
+        }.items()
+    )
+    cases.extend(
+        (FieldPath.receiver("main", "operator_controls", field), getter)
+        for field, getter in {
+            "af_level": "get_af_level",
+            "rf_gain": "get_rf_gain",
+            "squelch": "get_squelch",
+            "apf_type_level": "get_apf_type_level",
+            "nr_level": "get_nr_level",
+            "pbt_inner": "get_pbt_inner",
+            "pbt_outer": "get_pbt_outer",
+            "notch_filter": "get_notch_filter",
+            "nb_level": "get_nb_level",
+            "digisel_shift": "get_digisel_shift",
+            "att": "get_attenuator",
+            "preamp": "get_preamp",
+            "agc": "get_agc",
+            "audio_peak_filter": "get_audio_peak_filter",
+            "filter_shape": "get_filter_shape",
+            "manual_notch_width": "get_manual_notch_width",
+            "agc_time_constant": "get_agc_time_constant",
+            "tone_freq": "get_tone_freq",
+            "tsql_freq": "get_tsql_freq",
+        }.items()
+    )
+    cases.extend(
+        (FieldPath.global_("meters", field), getter)
+        for field, getter in {
+            "power": "get_power_meter",
+            "swr": "get_swr",
+            "alc": "get_alc",
+            "comp": "get_comp_meter",
+            "vd": "get_vd_meter",
+            "id": "get_id_meter",
+        }.items()
+    )
+    cases.append((FieldPath.global_("slow_state", "active"), "get_main_sub_band"))
+    cases.extend(
+        (FieldPath.global_("tx_state", field), getter)
+        for field, getter in {
+            "ptt": "get_transceiver_status",
+            "rit_on": "get_rit_status",
+            "rit_tx": "get_rit_tx_status",
+            "compressor_on": "get_compressor",
+            "monitor_on": "get_monitor",
+            "vox_on": "get_vox",
+            "split": "get_split",
+            "dual_watch": "get_dual_watch",
+        }.items()
+    )
+    cases.extend(
+        (FieldPath.global_("operator_controls", field), getter)
+        for field, getter in {
+            "rit_freq": "get_rit_frequency",
+            "vox_delay": "get_vox_delay",
+            "tuner_status": "get_tuner_status",
+            "break_in": "get_break_in",
+            "power_level": "get_rf_power",
+            "mic_gain": "get_mic_gain",
+            "cw_pitch": "get_cw_pitch",
+            "key_speed": "get_key_speed",
+            "compressor_level": "get_compressor_level",
+            "break_in_delay": "get_break_in_delay",
+            "drive_gain": "get_drive_gain",
+            "monitor_gain": "get_monitor_gain",
+            "vox_gain": "get_vox_gain",
+            "anti_vox_gain": "get_anti_vox_gain",
+        }.items()
+    )
+    assert len(cases) == 66
+    return cases
+
+
+def test_acquisition_profile_resolver_six_profile_census_and_exact_declared_bytes() -> (
+    None
+):
+    models = ("IC-705", "IC-7300", "IC-7610", "IC-9700", "X6100", "X6200")
+    former_divergences = {
+        ("IC-705", "get_vox_delay"),
+        ("IC-7610", "get_vox_delay"),
+        ("IC-9700", "get_dual_watch"),
+        ("IC-9700", "get_vox_delay"),
+    }
+    census = Counter()
+    selector_getters = {
+        "get_selected_freq",
+        "get_unselected_freq",
+        "get_selected_mode",
+        "get_unselected_mode",
+    }
+
+    for model in models:
+        profile = resolve_radio_profile(model=model)
+        resolver = acquisition_query_resolver_for_profile(profile)
+        assert profile.command_map is not None
+        for path, getter in _profile_resolver_cases():
+            if profile.command_map.has(getter):
+                census[
+                    "diverge" if (model, getter) in former_divergences else "agree"
+                ] += 1
+                receiver = (
+                    0
+                    if path.scope.value == "receiver" and getter not in selector_getters
+                    else None
+                )
+                assert resolver(
+                    path
+                ) == state_queries_module.acquisition_query_from_wire_tuple(
+                    profile.command_map.get(getter), receiver=receiver
+                )
+            elif getter in profile.absent_command_names:
+                census["absent"] += 1
+                assert resolver(path) is None
+            else:
+                census["missing"] += 1
+                assert resolver(path) is None
+
+    assert census == Counter(agree=299, diverge=4, absent=23, missing=70)
+
+
+def test_acquisition_profile_resolver_relative_vfo_and_refusal_rules() -> None:
+    resolver = acquisition_query_resolver_for_profile(
+        resolve_radio_profile(model="IC-7610")
+    )
+    assert resolver(FieldPath.active("main", "freq_mode", "mode")) == acquisition_query(
+        0x26, selector=0
+    )
+    assert resolver(FieldPath.active("sub", "freq_mode", "mode")) == acquisition_query(
+        0x26, selector=1
+    )
+    assert resolver(FieldPath.unselected("main", "freq_mode", "mode")) == (
+        acquisition_query(0x26, selector=1)
+    )
+    assert resolver(FieldPath.unselected("sub", "freq_mode", "mode")) is None
+    assert resolver(FieldPath.vfo_slot("main", "A", "freq_mode", "mode")) is None
+    assert resolver(FieldPath.unselected("main", "freq_mode", "filter_width")) is None
+    assert resolver(FieldPath.unselected("main", "freq_mode", "data_mode")) is None
 
 
 class _RecordingCivRadio:
@@ -205,12 +385,9 @@ async def test_receiver_zero_fallback_preserves_sub_and_data() -> None:
     async def sender(sent_query: AcquisitionQueryCase) -> None:
         sent.append(sent_query)
 
-    class _PrefixExecutor(IcomCivAcquisitionExecutor):
-        def query_for_path(self, _path: FieldPath) -> AcquisitionQueryCase:
-            return query
-
-    executor = _PrefixExecutor(
+    executor = IcomCivAcquisitionExecutor(
         sender,
+        resolve_query=lambda _path: query,
         supports_cmd29=lambda _command, _sub: False,
     )
     request = SimpleNamespace(paths=(path,))
@@ -233,7 +410,10 @@ async def test_executor_does_not_swallow_sender_exception() -> None:
     async def sender(_query: AcquisitionQueryCase) -> None:
         raise RuntimeError("send failed")
 
-    executor = IcomCivAcquisitionExecutor(sender)
+    executor = IcomCivAcquisitionExecutor(
+        sender,
+        resolve_query=lambda _path: acquisition_query(0x1C, sub=0x00),
+    )
     request = SimpleNamespace(paths=(path,))
 
     with pytest.raises(RuntimeError, match="send failed"):


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2158/resolve-acquisition-scheduler-ci-v-queries-from-the-active-profile
Parent: https://linear.app/morozsm/issue/MOR-2133/acquisition-scheduler-hardcodes-ci-v-wire-bytes-and-takes-no-profile

Implements the remaining MOR-2158 child acceptance with a required profile-bound resolver injected into the Core executor/factory and a complete explicit 66-row canonical-getter mapping in runtime. Web and rigctld bind their active profile. There is zero literal fallback, compatibility fallback, cache, or setter borrowing. Missing and absent getters fail closed, including IC-7300/IC-7610/IC-9700 PTT; selector, receiver, and existing receiver-fallback semantics are preserved.

Public API break: low-level `IcomCivAcquisitionExecutor` and `civ_acquisition_executor_for_provider` now require keyword-only `resolve_query`. Acceptance forbids a shim.

Changed paths (10):
- `src/rigplane/core/acquisition_scheduler.py`
- `src/rigplane/rigctld/server.py`
- `src/rigplane/runtime/_state_queries.py`
- `src/rigplane/web/radio_poller.py`
- `tests/_acquisition_query_helpers.py`
- `tests/test_acquisition_scheduler.py`
- `tests/test_radio_poller_coverage.py`
- `tests/test_rigctld_server.py`
- `tests/test_state_acquisition_policy.py`
- `tests/test_state_queries.py`

Soft-limit rationale: 854 changed lines are atomic API, construction, helper, and complete-census coverage; this is below the 900-line stop point and 1000-line hard ceiling.

Evidence:
- RED: 8 intended failures
- Census: 299/4/23/70
- GREEN: 475 normal/reverse; 489 MOR-2157 set; 23 mutation; Ruff, format, mypy, and import checks PASS
- No hardware required

This implements remaining child acceptance but does not declare or auto-close MOR-2158 or MOR-2133. Closure waits for independent exact-head review, Mac full evidence, merge, and a post-merge parent audit.