### PR TITLE
refactor: extract canonical TX observation contract (MOR-2180)

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -21,7 +21,7 @@ from ...core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from ...core.tx_authority import TxStateReading
+from ...core.tx_observation import TxStateReading
 from ...radio_state import RadioState
 from .transport import RigctldTransport
 
@@ -748,18 +748,11 @@ class RigctldClientRadio:
         await self._transport.command(f"T {1 if on else 0}")
 
     async def read_transmit_state(self) -> TxStateReading:
-        """One solicited transmit-state read (ADR row 5).
+        """One solicited transmit-state observation.
 
-        Implements :class:`~rigplane.core.radio_protocol.TransmitStateReadable`
-        by adapting the existing :meth:`get_ptt`, but ``verified_readback``
-        is permanently ``False`` (§3.7): the ``t`` command answers from
-        upstream Hamlib's own cache, or from an external rigplane's retained
-        fallback state -- never from a fresh radio read. Claiming otherwise
-        would be exactly the fabricated-freshness class this design exists
-        to forbid, so this backend's hazard families are fail-closed by
-        provenance as a stated consequence, not a defect to fix later.
-        Never raises: a failed or malformed read comes back as a
-        :class:`TxStateReading` with a ``failure`` tag.
+        It adapts :meth:`get_ptt`; ``verified_readback`` remains ``False``
+        because the rigctld ``t`` reply carries no proof that the value came
+        from a fresh physical-radio read. Errors return a ``failure`` tag.
         """
         try:
             value = await self.get_ptt()

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -15,7 +15,7 @@ from ...audio import AudioPacket
 from ...audio.lan_stream import SYNTHETIC_RX_IDENT
 from ...command_spec import CatCommandSpec
 from ...commands import hz_to_table_index, table_index_to_hz
-from ...core.tx_authority import TxStateReading
+from ...core.tx_observation import TxStateReading
 from ...types import AudioCodec, BreakInMode, RepeaterShiftDirection
 from ...exceptions import AudioFormatError, CommandError, CommandRejectedError
 from ...exceptions import ConnectionError as RadioConnectionError
@@ -1115,28 +1115,11 @@ class YaesuCatRadio:
         return ptt
 
     async def read_transmit_state(self) -> TxStateReading:
-        """One solicited transmit-state read (ADR row 5).
+        """One solicited transmit-state observation.
 
-        Implements :class:`~rigplane.core.radio_protocol.TransmitStateReadable`
-        on :meth:`read_ptt_token` and :meth:`_interpret_ptt_token` -- the
-        same fail-closed mapping :meth:`read_ptt` uses, not a second copy of
-        it -- plus the per-vendor attribution (``tx_cat`` / ``tx_other``)
-        §3.7 requires be carried, not discarded.
-
-        The real :class:`~.transport.YaesuCatTransport` raises a typed
-        exception per outcome rather than returning a sentinel string, so
-        this never trusts a raw ``"?"`` token -- it catches the transport's
-        own vocabulary instead. A rejected, unanswered, or malformed-but-
-        delivered read is never raised -- it comes back as a
-        :class:`TxStateReading` with a ``failure`` tag -- but a
-        precondition failure ahead of the wire (``read_ptt_token`` ->
-        ``_query`` -> ``_require_connected``, not connected at all) still
-        raises, the same convention every other read on this class
-        follows. A malformed reply that gets past ``query()``'s ``?``-
-        prefix rejection but fails the response template (a noisy serial
-        line) raises :class:`~.parser.CatParseError`, a ``ValueError``
-        subclass outside the ``transport.py`` ``Cat*Error`` family -- also
-        caught here, not a precondition failure.
+        It uses the same token interpretation as :meth:`read_ptt` and carries
+        the profile's attribution. Transport outcomes return a ``failure``
+        tag; connection preconditions still raise.
         """
         try:
             token = await self.read_ptt_token()

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     from rigplane.audio_bus import AudioBus
     from rigplane.runtime._poller_types import CommandQueue
     from rigplane.scope import ScopeFrame
-    from .tx_authority import TxStateReading
+    from .tx_observation import TxStateReading
     from .types import BandStackRegister, MemoryChannel, ScopeFixedEdge
 
 __all__ = [
@@ -516,46 +516,32 @@ class SplitCapable(Protocol):
         ...
 
 
-# --- Transmit-state read primitive (ADR row 5) ------------------------------
+# --- Transmit-state observation primitive -----------------------------------
 
 
 @runtime_checkable
 class TransmitStateReadable(Protocol):
-    """A backend that can perform one solicited, radio-truth transmit read.
+    """A backend that can request one solicited transmit-state observation.
 
     Deliberately **not** a member of :class:`Radio`: ``Radio`` is
     ``@runtime_checkable``, so a new required member would silently break
     ``isinstance`` for every implementer that lacks it — the identical
-    capability-loss mechanism the transmit-authority design's facade
-    refutation relies on (``docs/architecture/open-core-policy.md:178-180``
-    classes a new required method as a breaking change). A backend that does
-    not publish this capability is not degraded gracefully: the transmit
-    authority refuses every HAZARD admission — the four owner-ruled hazard
-    families unconditionally, and ``set_freq`` when its band relation
-    resolves to a crossing — with ``tx-truth-unavailable`` /
-    ``failure="no-capability"`` rather than guessing.
-
-    ``docs/plans/2026-08-20-transmit-authority.md`` §3.9 item 1, §4 row 5.
+    capability-loss mechanism caused by adding a required protocol member.
     """
 
     async def read_transmit_state(self) -> TxStateReading:
-        """Return one fresh, solicited transmit-state reading.
+        """Return one solicited transmit-state observation.
 
         A read that reaches the wire and fails, is refused, or is
         unverifiable comes back as an ordinary
-        :class:`~rigplane.core.tx_authority.TxStateReading` with ``value``
+        :class:`~rigplane.core.tx_observation.TxStateReading` with ``value``
         left ``None`` (or ``verified_readback=False``) and a ``failure``
-        tag — never as an exception for *that* outcome. This is **not** a
+        tag — never as an exception for *that* outcome. A returned value does
+        not by itself prove a fresh physical-radio read; callers must inspect
+        ``verified_readback`` and provenance. This is **not** a
         blanket "never raises" guarantee, though: a precondition failure
         ahead of the wire — not connected at all — follows the same
-        convention every other read on this class uses and raises, on two
-        of the three shipped implementations (the third, the rigctld-client
-        adapter, wraps everything in ``except Exception``). The transmit
-        authority's hazard admission is the caller, and its own blanket
-        ``except Exception`` around the whole call
-        (``core/tx_authority.py``) is what actually makes this fail-closed
-        end to end — not a per-implementer promise this protocol cannot
-        enforce structurally.
+        convention every other read on the implementation uses and may raise.
         """
         ...
 

--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -37,21 +37,16 @@ from types import MappingProxyType
 from typing import Final, Literal, NoReturn
 
 from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
+from .tx_observation import (
+    RADIO_READBACK_SOURCES,  # noqa: F401
+    TX_READ_DEADLINE_SECONDS,
+    TxStateReading,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-#: Ceiling on the one solicited transmit-state read a hazard admission makes.
-#: Deliberately not the backend's generic 2.0 s GET bound: a relay throw waits
-#: for this, and an order of magnitude under the measured unkey barrier keeps
-#: a same-connection command from queueing behind it.
-TX_READ_DEADLINE_SECONDS: float = 0.3
-
 #: Decision records retained per radio.
 DECISION_LOG_CAPACITY: int = 256
-
-RADIO_READBACK_SOURCES: frozenset[str] = frozenset(
-    {"poll_response", "civ_unsolicited", "hamlib_response", "yaesu_poll_response"}
-)
 
 #: Every ``TxEvidence.failure`` tag this engine produces itself. A backend's
 #: read primitive may supply its own through ``TxStateReading.failure`` (for
@@ -173,17 +168,6 @@ class TxRefusal(Exception):
         super().__init__(str(code))
         self.code = code
         self.evidence = evidence
-
-
-@dataclass(frozen=True, slots=True)
-class TxStateReading:
-    """One answer from the injected solicited transmit-state read."""
-
-    value: bool | None
-    attributed: str | None = None
-    source: str | None = None
-    verified_readback: bool = False
-    failure: str | None = None
 
 
 # Band relation — data in, no profile import

--- a/src/rigplane/core/tx_observation.py
+++ b/src/rigplane/core/tx_observation.py
@@ -1,0 +1,23 @@
+"""Canonical transmit-state observation contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+TX_READ_DEADLINE_SECONDS: float = 0.3
+
+RADIO_READBACK_SOURCES: frozenset[str] = frozenset(
+    {"poll_response", "civ_unsolicited", "hamlib_response", "yaesu_poll_response"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TxStateReading:
+    """One solicited transmit-state observation."""
+
+    value: bool | None
+    attributed: str | None = None
+    source: str | None = None
+    verified_readback: bool = False
+    failure: str | None = None

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -167,7 +167,7 @@ from rigplane.commands import get_repeater_tsql as _get_repeater_tsql_cmd
 from rigplane.core.env_config import get_managed_tx_enabled
 from rigplane.core.exceptions import CommandError, TimeoutError
 from rigplane.core.state_store import StateStore
-from rigplane.core.tx_authority import (
+from rigplane.core.tx_observation import (
     RADIO_READBACK_SOURCES,
     TX_READ_DEADLINE_SECONDS,
     TxStateReading,
@@ -3714,34 +3714,12 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         logger.debug("set_ptt(%s) sent (fire-and-forget)", on)
 
     async def read_transmit_state(self) -> TxStateReading:
-        """One solicited CI-V transmit-state read (ADR row 5).
+        """One solicited CI-V transmit-state observation.
 
-        Implements :class:`~rigplane.core.radio_protocol.TransmitStateReadable`
-        over the directed-exact-reply discipline, applying the shape check
-        *itself* rather than inheriting it: ``CivRequestTracker`` matches a
-        pending request only on ``(command, sub, receiver)`` with no address
-        check (``core/civ.py:76-82,380-393``), so a well-addressed but
-        wrong-shaped reply — e.g. an unmapped two-byte ``1C 00`` payload —
-        would otherwise resolve this read as if it were a real answer. The
-        reply is instead re-validated through the shared ``_observation``
-        shape check (``_civ_rx.py:2636-2650``) via ``_observations_from_frame``
-        — the same discrimination the live RX pump applies to unsolicited
-        traffic — so an ACK, our own setter echo, or a mis-addressed frame
-        can never satisfy the read (INV-13).
-
-        Deliberately not built on ``execute_civ_transaction`` (single slot,
-        raises on concurrent use, ``_civ_rx.py:1027-1028``), nor on the
-        poller's ``Commander.send(dedupe=True)`` key
-        (``commander.py:151-156`` — would hand back a pre-decision in-flight
-        read and gut INV-4), nor on the observer-bound
-        ``_request_authoritative_ptt_read`` (``_civ_rx.py:679,718-732``).
-
-        Icom carries no keying attribution on this wire (§3.7): ``attributed``
-        is honestly ``None``. A read that reaches the wire and fails is
-        never raised — it comes back as a :class:`TxStateReading` with a
-        ``failure`` tag — but ``self._check_connected()`` above still
-        raises on a precondition failure (not connected at all), the same
-        convention every other read on this class follows.
+        The directed reply is parsed through the shared observation decoder;
+        only a matching PTT observation supplies a value. Icom provides no
+        keying attribution. Wire-level failures return a ``failure`` tag;
+        connection preconditions still raise.
         """
         self._check_connected()
         frame = build_civ_frame(self._radio_addr, CONTROLLER_ADDR, 0x1C, sub=0x00)

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -63,14 +63,13 @@ from tx_authority_fakes import (
 
 from rigplane.backends.rigctld_client.radio import RigctldClientRadio
 from rigplane.backends.yaesu_cat import YaesuCatRadio
+from rigplane.core.tx_observation import RADIO_READBACK_SOURCES, TxStateReading
 from rigplane.core.tx_authority import (
-    RADIO_READBACK_SOURCES,
     TransmitAuthority,
     TxFamily,
     TxMethodEntry,
     TxRefusal,
     TxRefusalCode,
-    TxStateReading,
 )
 from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -10,18 +10,24 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import MISSING, FrozenInstanceError, fields
+from typing import get_type_hints
 
 import pytest
 
 from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
+from rigplane.core.tx_observation import (
+    RADIO_READBACK_SOURCES,
+    TX_READ_DEADLINE_SECONDS,
+    TxStateReading,
+)
+from rigplane.core import tx_authority
 from rigplane.core.tx_authority import (
     DECISION_LOG_CAPACITY,
     FAMILY_WRITE_CLASS,
-    RADIO_READBACK_SOURCES,
     RAW_EXCLUDED,
     TX_ARGUMENT_PREDICATES,
     TX_ENGINE_FAILURE_TAGS,
-    TX_READ_DEADLINE_SECONDS,
     UNRESOLVED_ARGUMENT,
     BandRelation,
     TransmitAuthority,
@@ -30,13 +36,52 @@ from rigplane.core.tx_authority import (
     TxMethodEntry,
     TxRefusal,
     TxRefusalCode,
-    TxStateReading,
     TxWriteClass,
     band_relation,
     first_parameter_name,
     resolve_band,
     short_circuit_family,
 )
+
+
+def test_tx_observation_contract_is_canonical_and_authority_reexports_it() -> None:
+    """The observation value has one canonical definition during migration."""
+    import rigplane.core.tx_observation as tx_observation
+
+    reading_type = tx_observation.TxStateReading
+    reading_fields = fields(reading_type)
+    assert [field.name for field in reading_fields] == [
+        "value",
+        "attributed",
+        "source",
+        "verified_readback",
+        "failure",
+    ]
+    assert get_type_hints(reading_type) == {
+        "value": bool | None,
+        "attributed": str | None,
+        "source": str | None,
+        "verified_readback": bool,
+        "failure": str | None,
+    }
+    assert reading_fields[0].default is MISSING
+    assert [field.default for field in reading_fields[1:]] == [None, None, False, None]
+
+    reading = reading_type(value=False)
+    assert not hasattr(reading, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        reading.value = True  # type: ignore[misc]
+
+    assert tx_observation.TX_READ_DEADLINE_SECONDS == 0.3
+    assert tx_observation.RADIO_READBACK_SOURCES == frozenset(
+        {"poll_response", "civ_unsolicited", "hamlib_response", "yaesu_poll_response"}
+    )
+    assert tx_authority.TxStateReading is reading_type
+    assert (
+        tx_authority.TX_READ_DEADLINE_SECONDS is tx_observation.TX_READ_DEADLINE_SECONDS
+    )
+    assert tx_authority.RADIO_READBACK_SOURCES is tx_observation.RADIO_READBACK_SOURCES
+
 
 BANDS: tuple[tuple[int, int], ...] = (
     (14_000_000, 14_350_000),

--- a/tests/tx_authority_fakes.py
+++ b/tests/tx_authority_fakes.py
@@ -64,7 +64,7 @@ from rigplane.backends.rigctld_client.radio import RigctldClientRadio
 from rigplane.backends.yaesu_cat import YaesuCatRadio
 from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTimeoutError
 from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
-from rigplane.core.tx_authority import TxStateReading
+from rigplane.core.tx_observation import TxStateReading
 from rigplane.radio import IcomRadio
 
 # ---------------------------------------------------------------------------

--- a/tests/validation/test_tx_actuate.py
+++ b/tests/validation/test_tx_actuate.py
@@ -17,7 +17,7 @@ import pytest
 from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTimeoutError
 from rigplane.core.radio_protocol import Radio
 from rigplane.core.radio_state import RadioState
-from rigplane.core.tx_authority import TxStateReading
+from rigplane.core.tx_observation import TxStateReading
 from rigplane.validation.hardware import execute_hardware_checks
 from rigplane.validation.interactive import InteractivePrompter
 from rigplane.validation.schema import (


### PR DESCRIPTION
## Summary

- move `TxStateReading`, `TX_READ_DEADLINE_SECONDS`, and `RADIO_READBACK_SOURCES` into canonical `core.tx_observation`
- migrate all runtime, provider, and test consumers to that single source
- keep an identity-preserving transitional re-export from dormant `tx_authority`
- correct observation prose so it does not claim unproved physical-radio freshness or a shipping authority caller

Linear: MOR-2180 (child of MOR-2167 / MOR-2163)

## TDD evidence

- RED before implementation: contract collection failed because `rigplane.core.tx_observation` did not exist
- GREEN after extraction
- mutation REDs independently covered field order/type/default, source membership, deadline, and re-export identity

## Verification

- exact-head targeted: 876 passed, 32 xfailed
- same-platform Mac REGCHECK: base and head both 14168 passed, 162 skipped, 48 xfailed, 7 warnings, zero failures
- Ruff check / format: PASS
- Import Linter: 5 contracts kept
- strict web mypy: 0 issues in 26 files
- independent review: Agent Review PASS for exact head `d4b4c1c779022b705c96caa5433d5a2f0b5c254c`

## Scope

Exactly 10 files, 225 changed lines. No runtime behavior change and no hardware validation required.