### PR TITLE
refactor: retire dormant TX authority watchdog (MOR-2182)

### DIFF
--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -7,10 +7,9 @@ consult transmit truth; everything the manufacturers permit passes without
 consulting it at all.
 
 The engine performs no I/O of its own: a backend injects the solicited
-transmit-state read and a last-resort unkey, drives :meth:`poll` from a loop it
-already owns, and receives due effects as data. Nothing in the product consumes
-this module yet — it lands ahead of the backend admission rows so the contracts
-exist before any call site cites them.
+transmit-state read. Nothing in the product consumes this module yet — it lands
+ahead of the backend admission rows so the contracts exist before any call site
+cites them.
 
 One requirement those rows inherit: an admission that passes its argument by
 keyword must also pass ``target``, so classification reads the method's real
@@ -30,13 +29,12 @@ import time
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
-from dataclasses import asdict, dataclass, field as dataclass_field, replace
+from dataclasses import asdict, dataclass, replace
 from enum import StrEnum
 from functools import lru_cache
 from types import MappingProxyType
 from typing import Final, Literal, NoReturn
 
-from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 from .tx_observation import (
     RADIO_READBACK_SOURCES,  # noqa: F401
     TX_READ_DEADLINE_SECONDS,
@@ -144,7 +142,6 @@ class TxEvidence:
     solicited: bool = False
     verified_readback: bool = False
     failure: str | None = None
-    own_transmit_hold: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -233,27 +230,6 @@ class _UnresolvedArgument:
 #: permissive branch — the unkey short-circuit, a PASS retune — is exactly what
 #: a mis-spelled admission must never reach (MOR-1954).
 #:
-#: **This path is the expensive one, deliberately.** Measured against a de-key
-#: that would otherwise have taken the UNKEY branch — the two latencies below
-#: are constants of the harness that produced them, never properties of this
-#: module; only the *bound* stated with them is:
-#:
-#: * it classifies KEYING, so it enters the admission lock that the UNKEY
-#:   branch never takes — 0.199 s behind a single in-flight hazard read where
-#:   the resolvable spelling waited 0.000 s, bounded by that admission's
-#:   solicited read (:data:`TX_READ_DEADLINE_SECONDS`) *plus its write body*,
-#:   which the lock also spans;
-#: * it neither clears the live deadline nor the live hold, and stacks a
-#:   second one: holds ``("key", "key")`` and a whole
-#:   :data:`BACKEND_MAX_KEY_DOWN_SECONDS` of deadline, for whose duration
-#:   hazard writes are then refused with ``own_transmit_hold="key"`` — after a
-#:   de-key that really did happen.
-#:
-#: That is the correct direction to be expensive in. The other reading of an
-#: argument nobody can read is that a key-down passes as an unkey, and RF into
-#: a load nobody chose has no such bound. Latency and a stuck hold expire; that
-#: does not. The way to not pay it is to admit positionally, or to pass
-#: ``target`` — see :meth:`TransmitAuthority.admit`.
 UNRESOLVED_ARGUMENT: Final = _UnresolvedArgument()
 
 #: How many gated signatures the resolver keeps. A backend gates on the order
@@ -347,9 +323,7 @@ def ptt_family(context: TxArgumentContext) -> TxFamily:
     An unresolved argument is read as the key, not the unkey: PTT_ON is the
     KEYING branch, which has no refusal path, so answering it can never turn
     an admission into a refusal — while answering PTT_OFF would walk a
-    key-down straight through the gate. That is not the same as free: the
-    KEYING branch takes the admission lock and leaves a hold and a deadline
-    behind it, which :data:`UNRESOLVED_ARGUMENT` prices.
+    key-down straight through the gate.
     """
     value = context.first()
     if value is UNRESOLVED_ARGUMENT:
@@ -380,16 +354,6 @@ def frequency_family(context: TxArgumentContext) -> TxFamily:
     target_hz = float(target) if isinstance(target, (int, float)) else None
     relation = band_relation(context.current_frequency_hz, target_hz, context.bands)
     return TxFamily.BAND if relation is BandRelation.CROSS_BAND else TxFamily.FREQUENCY
-
-
-def is_tune_start(context: TxArgumentContext) -> bool:
-    """``set_tuner_status(2)`` starts a tune cycle — a transmission we asked for.
-
-    Unresolved counts as a tune start: holding the key-down bound over a write
-    that turned out to be a plain tuner toggle is the survivable error.
-    """
-    value = context.first()
-    return value is UNRESOLVED_ARGUMENT or value == 2
 
 
 TX_ARGUMENT_PREDICATES: Mapping[str, ArgumentPredicate] = MappingProxyType(
@@ -442,8 +406,8 @@ def short_circuit_family(method: str, context: TxArgumentContext) -> TxFamily | 
             # because of how its argument was spelled (MOR-1954). Each is safe
             # for its own reason, and the two reasons are not interchangeable:
             #   set_ptt       — PTT_ON is KEYING, a branch with no refusal path
-            #                   at all; the strict answer arms the watchdog and
-            #                   cannot become a refusal.
+            #                   at all, so the strict answer cannot become a
+            #                   refusal.
             #   set_powerstat — POWER_ON and POWER_OFF are *both* PASS in
             #                   FAMILY_WRITE_CLASS, so the branch is inert here
             #                   whichever way it answers. The KEYING argument
@@ -467,31 +431,11 @@ class TxMethodEntry:
     predicate: str | None = None
 
 
-# Effects and view
-
-
-@dataclass(frozen=True, slots=True)
-class TxDeadlineExpiry:
-    """A due key-down deadline, returned as data for a driver to execute."""
-
-    monotonic: float
-    reason: str = "backend_max_key_down"
-
-
 @dataclass(frozen=True, slots=True)
 class TxAuthorityView:
     """Read-only debuggability surface: why did it decide that."""
 
     records: tuple[TxDecisionRecord, ...]
-    own_transmit_holds: tuple[str, ...]
-    deadline_monotonic: float | None
-    lease_active: bool
-
-
-@dataclass
-class _Hold:
-    kind: str
-    expires_at: float | None = None
 
 
 @dataclass
@@ -505,7 +449,6 @@ class TxAdmission:
     family: TxFamily | None
     write_class: TxWriteClass
     evidence: TxEvidence | None = None
-    holds: list[_Hold] = dataclass_field(default_factory=list)
 
 
 class TransmitAuthority:
@@ -515,33 +458,23 @@ class TransmitAuthority:
         self,
         *,
         read_transmit_state: Callable[[], Awaitable[TxStateReading]],
-        last_resort_unkey: Callable[[], Awaitable[None]],
         method_map: Mapping[str, TxMethodEntry],
         clock: Callable[[], float] = time.monotonic,
         bands: Sequence[tuple[int, int]] = (),
         current_frequency_hz: Callable[[], float | None] | None = None,
-        lease_active: Callable[[], bool] | None = None,
         provider_generation: Callable[[], int] | None = None,
-        cw_hold_duration: Callable[[TxArgumentContext], float] | None = None,
         read_deadline_seconds: float = TX_READ_DEADLINE_SECONDS,
-        max_key_down_seconds: float = BACKEND_MAX_KEY_DOWN_SECONDS,
     ) -> None:
         self._read_transmit_state = read_transmit_state
-        self._last_resort_unkey = last_resort_unkey
         self._method_map = dict(method_map)
         self._clock = clock
         self._bands = tuple(bands)
         self._current_frequency_hz = current_frequency_hz
-        self._lease_active = lease_active
         self._provider_generation = provider_generation
-        self._cw_hold_duration = cw_hold_duration
         self._read_deadline_seconds = read_deadline_seconds
-        self._max_key_down_seconds = max_key_down_seconds
 
         self._lock = asyncio.Lock()
         self._records: deque[TxDecisionRecord] = deque(maxlen=DECISION_LOG_CAPACITY)
-        self._holds: list[_Hold] = []
-        self._deadline: float | None = None
         self._transmit_epoch = 0
 
     # -- intake ------------------------------------------------------------
@@ -557,30 +490,12 @@ class TransmitAuthority:
         if transmitting:
             self._transmit_epoch += 1
 
-    async def fire_last_resort_unkey(self) -> None:
-        """The last-resort OFF rail, for a driver with no better one."""
-        await self._last_resort_unkey()
-
     # -- inspection --------------------------------------------------------
 
     def view(self) -> TxAuthorityView:
         return TxAuthorityView(
             records=tuple(self._records),
-            own_transmit_holds=tuple(
-                hold.kind for hold in self._active_holds(self._clock())
-            ),
-            deadline_monotonic=self._deadline,
-            lease_active=bool(self._lease_active and self._lease_active()),
         )
-
-    def poll(self, now: float) -> tuple[TxDeadlineExpiry, ...]:
-        """Return due effects and disarm. Drivers execute them on their rails."""
-        deadline = self._deadline
-        if deadline is None or now < deadline:
-            return ()
-        self._deadline = None
-        self._holds = [hold for hold in self._holds if hold.kind == "cw"]
-        return (TxDeadlineExpiry(monotonic=deadline),)
 
     # -- admission ---------------------------------------------------------
 
@@ -656,22 +571,20 @@ class TransmitAuthority:
             return
 
         if write_class is TxWriteClass.UNKEY:
-            self._deadline = None
-            self._holds = []
             yield TxAdmission(family, write_class)
             self._record(method, family, write_class, "sent", None, None)
             return
 
         async with self._lock:
             if write_class is TxWriteClass.KEYING:
-                ticket = self._admit_keying(family, context)
+                ticket = self._admit_keying(family)
             else:
-                ticket = await self._admit_hazard(method, family, context)
+                ticket = await self._admit_hazard(method, family)
             try:
                 yield ticket
             finally:
                 # A write that raised may already have reached the radio, so
-                # the hold, the deadline and the record land either way.
+                # the decision record lands either way.
                 self._commit(method, ticket)
 
     # -- internals ---------------------------------------------------------
@@ -683,8 +596,7 @@ class TransmitAuthority:
         entry = self._method_map.get(method)
         if entry is None:
             return False
-        # TUNER carries no predicate but `is_tune_start` reads the argument.
-        return entry.predicate is not None or entry.family is TxFamily.TUNER
+        return entry.predicate is not None
 
     def _classify(self, method: str, context: TxArgumentContext) -> TxFamily | None:
         entry = self._method_map.get(method)
@@ -694,38 +606,17 @@ class TransmitAuthority:
             return entry.family
         return TX_ARGUMENT_PREDICATES[entry.predicate](context)
 
-    def _admit_keying(
-        self, family: TxFamily, context: TxArgumentContext
-    ) -> TxAdmission:
+    def _admit_keying(self, family: TxFamily) -> TxAdmission:
         self._transmit_epoch += 1
-        if family is TxFamily.CW_TEXT:
-            duration = (
-                self._cw_hold_duration(context) if self._cw_hold_duration else None
-            )
-            hold = _Hold(
-                "cw", None if duration is None else self._clock() + float(duration)
-            )
-        else:
-            hold = _Hold("key")
-        return TxAdmission(family, TxWriteClass.KEYING, holds=[hold])
+        return TxAdmission(family, TxWriteClass.KEYING)
 
-    async def _admit_hazard(
-        self, method: str, family: TxFamily, context: TxArgumentContext
-    ) -> TxAdmission:
+    async def _admit_hazard(self, method: str, family: TxFamily) -> TxAdmission:
         def refuse(code: TxRefusalCode, evidence: TxEvidence) -> NoReturn:
             self._refuse(method, family, TxWriteClass.HAZARD, code, evidence)
 
         unavailable = TxRefusalCode.TX_TRUTH_UNAVAILABLE
 
-        # Step 1 — our own transmission, refused with no wire read at all.
-        held = self._own_transmit_hold(self._clock())
-        if held is not None:
-            refuse(
-                TxRefusalCode.REFUSED_WHILE_TRANSMITTING,
-                TxEvidence(own_transmit_hold=held),
-            )
-
-        # Step 2 — one solicited read on this admission's own deadline.
+        # One solicited read on this admission's own deadline.
         epoch = self._transmit_epoch
         started = self._clock()
         try:
@@ -753,7 +644,7 @@ class TransmitAuthority:
         if reading.value is None:
             refuse(unavailable, evidence)
         if not reading.verified_readback:
-            # The rigctld-client answer is an upstream cache, not radio truth.
+            # This admission has no verified-readback evidence.
             refuse(
                 unavailable,
                 replace(evidence, failure="unverifiable-provenance"),
@@ -761,36 +652,10 @@ class TransmitAuthority:
         if reading.value or epoch != self._transmit_epoch:
             refuse(TxRefusalCode.REFUSED_WHILE_TRANSMITTING, evidence)
 
-        holds: list[_Hold] = []
-        if family is TxFamily.TUNER and is_tune_start(context):
-            holds.append(_Hold("tune"))
-        return TxAdmission(family, TxWriteClass.HAZARD, evidence=evidence, holds=holds)
-
-    def _own_transmit_hold(self, now: float) -> str | None:
-        if self._lease_active is not None and self._lease_active():
-            return "lease"
-        active = self._active_holds(now)
-        return active[0].kind if active else None
-
-    def _active_holds(self, now: float) -> list[_Hold]:
-        self._holds = [
-            hold
-            for hold in self._holds
-            if hold.expires_at is None or now < hold.expires_at
-        ]
-        return self._holds
+        return TxAdmission(family, TxWriteClass.HAZARD, evidence=evidence)
 
     def _commit(self, method: str, ticket: TxAdmission) -> None:
         """Called once the caller's write has been handed off."""
-        if ticket.holds:
-            # `cw` keeps its computed duration; `key` and `tune` inherit the
-            # key-down bound, so `_active_holds` clears them on the injected
-            # clock even where no driver ever calls `poll()`.
-            deadline = self._clock() + self._max_key_down_seconds
-            for hold in ticket.holds:
-                hold.expires_at = hold.expires_at or deadline
-                self._holds.append(hold)
-            self._deadline = deadline
         family = str(ticket.family)
         self._record(method, family, ticket.write_class, "sent", None, ticket.evidence)
 

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -16,8 +16,7 @@ so the matrix runs each ADR-named row twice:
 fake wire, with the admission driven from the test. These prove the component
 composes: a hazard write at scripted TX is refused and nothing reaches the
 wire; at scripted RX the solicited read precedes the write; an unmapped value
-is never receiving; an unkey is never refused; a key arms the one deadline and
-the last-resort rail fires the OFF on a fake clock.
+is never receiving; and an unkey is never refused.
 
 *Cutover rows (``xfail(strict=True)``).* The same behaviours driven the way a
 consumer will drive them — a plain method call, or a command through
@@ -71,7 +70,6 @@ from rigplane.core.tx_authority import (
     TxRefusal,
     TxRefusalCode,
 )
-from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 
 # ---------------------------------------------------------------------------
 # Pinned literals
@@ -127,28 +125,14 @@ class FakeClock:
         self.now += seconds
 
 
-class RecordingUnkey:
-    """The authority's injected last-resort OFF rail, wired to a real backend."""
-
-    def __init__(self, harness: TxConformanceHarness) -> None:
-        self._harness = harness
-        self.calls = 0
-
-    async def __call__(self) -> None:
-        self.calls += 1
-        await self._harness.unkey()
-
-
 def build_authority(
     harness: TxConformanceHarness,
     *,
     clock: FakeClock | None = None,
-    unkey: RecordingUnkey | None = None,
 ) -> TransmitAuthority:
     """The real engine over a real backend's real fake wire."""
     return TransmitAuthority(
         read_transmit_state=harness.read_transmit_state,
-        last_resort_unkey=unkey or RecordingUnkey(harness),
         method_map=CONFORMANCE_METHOD_MAP,
         clock=clock or FakeClock(),
     )
@@ -417,8 +401,8 @@ async def test_a_hazard_write_at_scripted_tx_is_refused_and_no_wire_write_occurs
     if harness.verified_readback:
         assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
     else:
-        # §3.7: the hamlib-provider answer is an upstream cache, never radio
-        # truth, so its hazard families are fail-closed by provenance.
+        # §3.7: this column supplies no verified-readback evidence, so its
+        # hazard families are fail-closed by provenance.
         assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
         assert excinfo.value.evidence.failure == "unverifiable-provenance"
 
@@ -430,12 +414,12 @@ async def test_a_hazard_write_at_scripted_rx_reads_before_it_writes(
     """§3.10 item 3, row 2: on the wire, the read precedes the write.
 
     Counts cannot see this — both happen either way. Only the order on the
-    wire distinguishes a solicited read from a cached one (T3/INV-4).
+    wire proves that the backend read preceded the write (T3/INV-4).
 
     The ``rigctld-client`` column is absent by design, not by omission: its
-    readback is permanently unverifiable (§3.7), so it never reaches a write
-    to order the read against. ``test_..._refused_and_no_wire_write_occurs``
-    covers it instead.
+    current contract supplies ``verified_readback=False`` (§3.7), so it never
+    reaches a write to order the read against.
+    ``test_..._refused_and_no_wire_write_occurs`` covers it instead.
 
     # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
     # `if write_class is TxWriteClass.PASS:` at :522 to
@@ -486,79 +470,6 @@ async def test_an_unkey_is_never_refused(
 
 
 @every_backend()
-async def test_our_own_key_makes_the_gate_stricter_never_looser(
-    harness: TxConformanceHarness,
-) -> None:
-    """INV-16 / §3.7's own-commands rule, composed over a real backend.
-
-    The wire is scripted to answer *receiving* throughout — the B6 blind spot,
-    where the IC-7300 reported RX while audibly still sending. Our own key
-    must refuse the hazard write anyway, with no wire read at all.
-
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_admit_hazard`,
-    # delete the step-1 `if held is not None:` refusal at :580-584 -> this row
-    # goes red on every column: the scripted RX answer clears our own key.
-    """
-    harness.script("rx")
-    authority = build_authority(harness)
-
-    async with authority.admit("set_ptt", (True,)):
-        await harness.key()
-
-    reads_before = len(harness.reads())
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit(harness.hazard_method, harness.hazard_args):
-            pytest.fail(f"{harness.name}: a hazard write ran during our own key")
-
-    assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    assert excinfo.value.evidence.own_transmit_hold == "key"
-    assert harness.reads()[reads_before:] == [], (
-        f"{harness.name}: the own-transmit refusal touched the wire"
-    )
-
-
-@every_backend()
-async def test_a_key_arms_the_one_deadline_and_the_off_fires_on_a_fake_clock(
-    harness: TxConformanceHarness,
-) -> None:
-    """§3.10 item 3, row 5, backend half: the arm and the last-resort rail.
-
-    The three *shipped* drivers (web ``call_later``, the observation poller's
-    drain, the rigctld drain) arrive at rows 12a/12b and are reserved below;
-    what is live here is that a key through the authority arms the one
-    deadline and that the OFF, once due, reaches the real backend's real
-    unkey on the real wire.
-
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_commit`, change
-    # `self._deadline = deadline` at :651 to `self._deadline = None` -> this
-    # row goes red on every column: the key arms nothing and no OFF is due.
-    """
-    harness.script("rx")
-    clock = FakeClock()
-    unkey = RecordingUnkey(harness)
-    authority = build_authority(harness, clock=clock, unkey=unkey)
-
-    async with authority.admit("set_ptt", (True,)):
-        await harness.key()
-
-    assert authority.view().deadline_monotonic == pytest.approx(
-        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
-    )
-    assert authority.poll(clock.now) == (), "the deadline fired early"
-
-    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS + 0.001)
-    due = authority.poll(clock.now)
-    assert len(due) == 1
-
-    writes_before = len(harness.writes())
-    await authority.fire_last_resort_unkey()
-    assert unkey.calls == 1
-    assert harness.writes()[writes_before:], (
-        f"{harness.name}: the due OFF never reached the wire"
-    )
-
-
-@every_backend()
 async def test_a_pass_class_write_never_consults_transmit_truth(
     harness: TxConformanceHarness,
 ) -> None:
@@ -574,7 +485,6 @@ async def test_a_pass_class_write_never_consults_transmit_truth(
 
     authority = TransmitAuthority(
         read_transmit_state=poisoned,
-        last_resort_unkey=RecordingUnkey(harness),
         method_map=CONFORMANCE_METHOD_MAP,
         clock=FakeClock(),
     )
@@ -630,12 +540,12 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
     drives one for real — the same method the production polling loop calls
     (``YaesuCatPoller._emit_medium_observations`` /
     ``RigctldClientObservationPoller._poll_medium``), over the same scripted
-    wire the bare write just used, no sleep and no mock. A genuine
-    ``yaesu_poll_response`` / ``hamlib_response`` readback of the current PTT
-    state is expected and correct — §3.7's ``verified_readback`` is what
-    decides whether that readback may be trusted, not this row. What must
-    never appear is a ``global.tx_state.ptt`` observation under any other
-    source: that would be a write outcome wearing a readback's clothes.
+    wire the bare write just used, no sleep and no mock. A
+    ``yaesu_poll_response`` / ``hamlib_response`` observation is expected —
+    §3.7's ``verified_readback`` decides whether it can admit a hazard write,
+    not this row. What must never appear is a ``global.tx_state.ptt``
+    observation under any other source: that would be a write outcome wearing
+    a readback's clothes.
 
     # MUTATION: in `src/rigplane/backends/yaesu_cat/observations.py`, in
     # `YaesuObservationAdapter._adapter` at :1141, change
@@ -1010,20 +920,3 @@ async def test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere(
     before = harness.radio._state.ptt
     await harness.key()
     assert harness.radio._state.ptt == before
-
-
-@every_backend()
-@pytest.mark.xfail(
-    strict=True,
-    reason="rows 12a/12b: the shipped deadline drivers. 12a wires the web "
-    "`call_later` (Icom branch) and the observation poller's drain to the "
-    "authority's deadline, both enqueuing `PttOff`; 12b wires the rigctld "
-    "drain and the Icom backend loops. Until then the only rail is the "
-    "authority's own last resort, which the live row above already exercises.",
-)
-async def test_a_shipped_driver_polls_the_authority_deadline(
-    harness: TxConformanceHarness,
-) -> None:
-    """INV-7: every delivery carries a driver for the one deadline."""
-    driver = getattr(harness.radio, "_tx_authority_deadline_driver", None)
-    assert driver is not None

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -8,6 +8,7 @@ MagicMock anywhere near the authority (repo hard rule).
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import MISSING, FrozenInstanceError, fields
@@ -15,7 +16,6 @@ from typing import get_type_hints
 
 import pytest
 
-from rigplane.core.tx_safety import BACKEND_MAX_KEY_DOWN_SECONDS
 from rigplane.core.tx_observation import (
     RADIO_READBACK_SOURCES,
     TX_READ_DEADLINE_SECONDS,
@@ -168,14 +168,6 @@ class PoisonedLink:
         raise AssertionError("transmit truth was consulted on a PASS write")
 
 
-class FakeUnkey:
-    def __init__(self) -> None:
-        self.calls = 0
-
-    async def __call__(self) -> None:
-        self.calls += 1
-
-
 RX = TxStateReading(
     value=False,
     attributed="rx",
@@ -210,24 +202,16 @@ def build_authority(
     clock: Clock,
     link: FakeTransmitStateLink | PoisonedLink,
     *,
-    unkey: FakeUnkey | None = None,
     method_map: Mapping[str, TxMethodEntry] | None = None,
     bands: Sequence[tuple[int, int]] = BANDS,
     current_frequency_hz: float | None = 14_200_000,
-    lease_active: bool = False,
-    cw_hold_seconds: float | None = 5.0,
 ) -> TransmitAuthority:
     return TransmitAuthority(
         read_transmit_state=link.read,
-        last_resort_unkey=unkey or FakeUnkey(),
         method_map=METHOD_MAP if method_map is None else method_map,
         clock=clock,
         bands=tuple(bands),
         current_frequency_hz=lambda: current_frequency_hz,
-        lease_active=lambda: lease_active,
-        cw_hold_duration=(
-            None if cw_hold_seconds is None else (lambda _ctx: cw_hold_seconds)
-        ),
     )
 
 
@@ -285,17 +269,6 @@ def test_family_class_table_is_total_and_pinned() -> None:
     assert FAMILY_WRITE_CLASS[TxFamily.CW_STOP] is TxWriteClass.PASS
 
 
-def test_key_down_bound_is_imported_not_respelled() -> None:
-    from rigplane.core import tx_authority
-
-    assert tx_authority.BACKEND_MAX_KEY_DOWN_SECONDS is BACKEND_MAX_KEY_DOWN_SECONDS
-    source = tx_authority.__file__ or ""
-    assert source.endswith("tx_authority.py")
-    with open(source, encoding="utf-8") as handle:
-        text = handle.read()
-    assert "180" not in text
-
-
 def test_read_deadline_is_its_own_named_bound() -> None:
     assert TX_READ_DEADLINE_SECONDS == 0.3
 
@@ -309,6 +282,38 @@ def test_transmit_truth_projection_is_absent() -> None:
         "build_transmit_truth",
     ):
         assert not hasattr(tx_authority, name)
+
+
+def test_dormant_authority_watchdog_surface_is_absent() -> None:
+    """The authority retains admission records, not a second TX watchdog."""
+    for name in ("_Hold", "TxDeadlineExpiry"):
+        assert not hasattr(tx_authority, name)
+    assert not hasattr(TransmitAuthority, "poll")
+    assert not hasattr(TransmitAuthority, "fire_last_resort_unkey")
+
+    parameters = inspect.signature(TransmitAuthority).parameters
+    for name in (
+        "last_resort_unkey",
+        "lease_active",
+        "cw_hold_duration",
+        "max_key_down_seconds",
+    ):
+        assert name not in parameters
+
+    authority = TransmitAuthority(
+        read_transmit_state=PoisonedLink().read,
+        method_map=METHOD_MAP,
+        clock=Clock(),
+    )
+    for name in ("_last_resort_unkey", "_holds", "_deadline", "_lease_active"):
+        assert not hasattr(authority, name)
+    assert [field.name for field in fields(tx_authority.TxAuthorityView)] == ["records"]
+    assert [field.name for field in fields(tx_authority.TxAdmission)] == [
+        "family",
+        "write_class",
+        "evidence",
+    ]
+    assert "own_transmit_hold" not in get_type_hints(tx_authority.TxEvidence)
 
 
 def test_argument_predicate_registry_is_named_and_pure() -> None:
@@ -458,7 +463,6 @@ async def test_hazard_at_transmit_is_refused_with_evidence() -> None:
     assert refusal.evidence.attributed == "tx_other"
     assert refusal.evidence.source == "poll_response"
     assert refusal.evidence.solicited is True
-    assert refusal.evidence.own_transmit_hold is None
     record = authority.view().records[-1]
     assert record.action == "refused"
     assert record.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
@@ -536,7 +540,7 @@ async def test_hazard_without_capability_fails_closed() -> None:
 
 
 async def test_unverifiable_readback_fails_closed() -> None:
-    """§3.7: the rigctld-client answer is an upstream cache, not radio truth."""
+    """§3.7: an unverified readback cannot admit a hazard write."""
     clock = Clock()
     link = FakeTransmitStateLink(clock)
     link.script(UNVERIFIED_RX)
@@ -568,99 +572,6 @@ async def test_every_refusal_carries_evidence(answer: TxStateReading | str) -> N
     assert evidence is not None
     assert (evidence.value is not None) or (evidence.failure is not None)
     assert authority.view().records[-1].evidence is evidence
-
-
-# --------------------------------------------------------------------------
-# Own-transmit holds — the B6 golden (§3.5 step 1, INV-16)
-# --------------------------------------------------------------------------
-
-
-async def test_b6_golden_own_cw_hold_refuses_without_any_wire_read() -> None:
-    """A scripted RX answer during our own CW message must not admit a hazard.
-
-    B6, on the bench: the radio reported *receiving* while it was audibly
-    still sending a CAT-issued CW message. The hold is the evidence; the wire
-    is not consulted at all.
-    """
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX, RX)  # the radio would answer "receiving" if asked
-    authority = build_authority(clock, link, cw_hold_seconds=5.0)
-
-    async with authority.admit("send_cw_text", ("CQ CQ DE TEST",)):
-        pass
-    assert link.reads == []
-
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit("set_band", (15,)):
-            pytest.fail("hazard write admitted during our own CW message")
-
-    refusal = excinfo.value
-    assert refusal.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    assert refusal.evidence.own_transmit_hold == "cw"
-    assert refusal.evidence.solicited is False
-    assert refusal.evidence.value is None
-    assert link.reads == []  # no wire read at all
-    assert authority.view().records[-1].evidence.own_transmit_hold == "cw"
-
-    clock.advance(6.0)  # the computed message duration elapses
-    async with authority.admit("set_band", (15,)):
-        pass
-    assert len(link.reads) == 1
-
-
-@pytest.mark.parametrize(
-    ("setup_method", "setup_args", "hold"),
-    [
-        ("set_ptt", (True,), "key"),
-        ("set_tuner_status", (2,), "tune"),
-    ],
-)
-async def test_own_transmit_holds_refuse_hazard_writes(
-    setup_method: str, setup_args: tuple[object, ...], hold: str
-) -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX, RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit(setup_method, setup_args):
-        pass
-    reads_after_setup = len(link.reads)
-
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit("set_antenna_1", ()):
-            pytest.fail("hazard write admitted while we hold our own transmission")
-    assert excinfo.value.evidence.own_transmit_hold == hold
-    assert len(link.reads) == reads_after_setup  # step 1 makes no wire read
-
-
-async def test_supervisor_lease_is_an_own_transmit_hold() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX)
-    authority = build_authority(clock, link, lease_active=True)
-
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit("set_antenna_1", ()):
-            pytest.fail("hazard write admitted under an active managed lease")
-    assert excinfo.value.evidence.own_transmit_hold == "lease"
-    assert link.reads == []
-
-
-async def test_an_admitted_unkey_clears_the_key_hold() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    async with authority.admit("set_ptt", (False,)):
-        pass
-    async with authority.admit("set_antenna_1", ()):
-        pass
-    assert len(link.reads) == 1
 
 
 # --------------------------------------------------------------------------
@@ -696,30 +607,11 @@ async def test_unkey_is_never_refused_even_with_a_poisoned_table() -> None:
             pass
 
     assert link.reads == []  # not one of the three consulted the radio
-    assert authority.view().deadline_monotonic is None
     assert authority.view().records[-1].write_class is TxWriteClass.UNKEY
 
 
-async def test_unkey_clears_the_deadline_and_the_holds() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    assert authority.view().deadline_monotonic == pytest.approx(
-        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
-    )
-    assert authority.view().own_transmit_holds == ("key",)
-
-    async with authority.admit("set_ptt", (False,)):
-        pass
-    assert authority.view().deadline_monotonic is None
-    assert authority.view().own_transmit_holds == ()
-
-
 # --------------------------------------------------------------------------
-# KEYING and the one deadline (§3.6, INV-7)
+# KEYING
 # --------------------------------------------------------------------------
 
 
@@ -741,107 +633,7 @@ async def test_keying_is_admitted_on_every_truth_answer(
     assert record.evidence is None
 
 
-async def test_deadline_fires_once_and_is_disarmed() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    assert authority.poll(clock.now) == ()
-
-    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS - 0.001)
-    assert authority.poll(clock.now) == ()
-
-    clock.advance(0.002)
-    effects = authority.poll(clock.now)
-    assert len(effects) == 1
-    assert effects[0].reason == "backend_max_key_down"
-    assert authority.poll(clock.now) == ()
-    assert authority.view().deadline_monotonic is None
-    assert authority.view().own_transmit_holds == ()
-
-
-async def test_a_newer_key_rearms_the_deadline() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    clock.advance(60.0)
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    assert authority.view().deadline_monotonic == pytest.approx(
-        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
-    )
-
-
-async def test_admitted_tune_start_holds_and_arms_but_a_bypass_throw_does_not() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX, RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_tuner_status", (0,)):
-        pass
-    assert authority.view().deadline_monotonic is None
-    assert authority.view().own_transmit_holds == ()
-
-    async with authority.admit("set_tuner_status", (2,)):
-        pass
-    assert authority.view().own_transmit_holds == ("tune",)
-    assert authority.view().deadline_monotonic == pytest.approx(
-        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
-    )
-
-
-async def test_a_refused_tune_start_neither_holds_nor_arms() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(TX)
-    authority = build_authority(clock, link)
-
-    with pytest.raises(TxRefusal):
-        async with authority.admit("set_tuner_status", (2,)):
-            pytest.fail("tune start admitted while transmitting")
-    assert authority.view().deadline_monotonic is None
-    assert authority.view().own_transmit_holds == ()
-
-
-@pytest.mark.parametrize(
-    ("method", "args", "hold"),
-    [("set_ptt", (True,), "key"), ("set_tuner_status", (2,), "tune")],
-)
-async def test_own_transmit_holds_do_not_outlive_the_deadline_without_a_driver(
-    method: str, args: tuple[object, ...], hold: str
-) -> None:
-    """The bound the ADR already specifies, evaluated without a ``poll()`` caller.
-
-    Rows 7-11 arm no deadline driver, and a tune start has no natural unkey at
-    all, so a hold that only ``poll()`` could clear would refuse the whole
-    hazard set for the life of the connection. An expired hold does not go
-    blind: it falls through to the solicited read.
-    """
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX, RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit(method, args):
-        pass
-    assert authority.view().own_transmit_holds == (hold,)
-
-    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS + 1.0)
-    assert authority.view().own_transmit_holds == ()  # poll() was never called
-
-    reads_before = len(link.reads)
-    async with authority.admit("set_antenna_1", ()):
-        pass
-    assert len(link.reads) == reads_before + 1
-
-
-async def test_a_failed_key_write_still_records_its_hold() -> None:
+async def test_a_failed_key_write_still_records_its_decision() -> None:
     """A write that raised may already have reached the radio."""
     clock = Clock()
     link = FakeTransmitStateLink(clock)
@@ -851,18 +643,10 @@ async def test_a_failed_key_write_still_records_its_hold() -> None:
         async with authority.admit("set_ptt", (True,)):
             raise OSError("the transport died after the frame went out")
 
-    assert authority.view().own_transmit_holds == ("key",)
-    assert authority.view().deadline_monotonic is not None
-
-
-async def test_last_resort_unkey_is_the_only_other_injected_effect() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    unkey = FakeUnkey()
-    authority = build_authority(clock, link, unkey=unkey)
-
-    await authority.fire_last_resort_unkey()
-    assert unkey.calls == 1
+    record = authority.view().records[-1]
+    assert record.action == "sent"
+    assert record.method == "set_ptt"
+    assert record.write_class is TxWriteClass.KEYING
 
 
 # --------------------------------------------------------------------------
@@ -930,21 +714,6 @@ async def test_a_key_cannot_slip_between_a_hazard_read_and_its_write() -> None:
     assert order == ["hazard-relay-throw", "key-write"]
 
 
-async def test_a_receive_observation_never_clears_anything() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    authority.note_transmit_observation(False)
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit("set_antenna_1", ()):
-            pytest.fail("a radio RX report cleared our own key hold")
-    assert excinfo.value.evidence.own_transmit_hold == "key"
-
-
 async def test_concurrent_hazard_admissions_do_not_share_a_read() -> None:
     clock = Clock()
     link = FakeTransmitStateLink(clock)
@@ -978,12 +747,11 @@ async def test_decision_ring_is_bounded() -> None:
     assert len(authority.view().records) == DECISION_LOG_CAPACITY
 
 
-async def test_view_reports_holds_and_deadline() -> None:
+async def test_view_reports_keying_decisions() -> None:
     clock = Clock()
     link = FakeTransmitStateLink(clock)
     authority = TransmitAuthority(
         read_transmit_state=link.read,
-        last_resort_unkey=FakeUnkey(),
         method_map=METHOD_MAP,
         clock=clock,
         bands=BANDS,
@@ -991,8 +759,6 @@ async def test_view_reports_holds_and_deadline() -> None:
     async with authority.admit("set_ptt", (True,)):
         pass
     view = authority.view()
-    assert view.own_transmit_holds == ("key",)
-    assert view.deadline_monotonic is not None
     assert view.records[-1].method == "set_ptt"
 
 
@@ -1065,7 +831,7 @@ async def test_keyword_key_down_is_never_read_as_an_unkey() -> None:
 
     Before this fix the predicate read ``kwargs["value"]``; the Icom body
     declares ``on``, so a keyword key-down resolved to ``None``, classified
-    PTT_OFF and was short-circuited past the gate built to arm the watchdog.
+    PTT_OFF and was short-circuited past the gate.
     No signature is supplied here on purpose — even with nothing to resolve
     from, the engine must fail towards the key, never towards the unkey.
     """
@@ -1077,11 +843,9 @@ async def test_keyword_key_down_is_never_read_as_an_unkey() -> None:
         assert admission.family is TxFamily.PTT_ON
         assert admission.write_class is TxWriteClass.KEYING
 
-    view = authority.view()
-    assert view.own_transmit_holds == ("key",)
-    assert view.deadline_monotonic == pytest.approx(
-        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
-    )
+    record = authority.view().records[-1]
+    assert record.method == "set_ptt"
+    assert record.write_class is TxWriteClass.KEYING
 
 
 @pytest.mark.parametrize(
@@ -1152,18 +916,6 @@ async def test_an_unresolvable_keyword_argument_fails_closed_and_is_loud(
     assert any("could not resolve" in record.getMessage() for record in caplog.records)
 
 
-async def test_an_unresolvable_tuner_argument_still_holds_the_tune() -> None:
-    """``set_tuner_status`` with nothing to resolve holds as if a tune started."""
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_tuner_status", (), {"value": 2}):
-        pass
-    assert authority.view().own_transmit_holds == ("tune",)
-
-
 @pytest.mark.parametrize("spelling", ["positional", "keyword", "unresolvable"])
 async def test_the_unkey_is_still_never_refused_in_any_spelling(
     spelling: str,
@@ -1201,24 +953,6 @@ async def test_the_unkey_is_still_never_refused_in_any_spelling(
         assert admission.write_class is TxWriteClass.UNKEY
 
 
-async def test_a_keyword_unkey_clears_the_deadline_and_the_holds() -> None:
-    """The UNKEY branch's whole effect, reached by the keyword spelling."""
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    assert authority.view().own_transmit_holds == ("key",)
-
-    async with authority.admit(
-        "set_ptt", (), {"on": False}, target=SignatureMirror.set_ptt
-    ):
-        pass
-    assert authority.view().deadline_monotonic is None
-    assert authority.view().own_transmit_holds == ()
-
-
 def test_predicates_resolve_the_argument_by_signature_not_by_guess() -> None:
     """Predicate-level twin of the admission pins, including the sentinel."""
     keyed = TxArgumentContext(
@@ -1250,40 +984,3 @@ def test_predicates_resolve_the_argument_by_signature_not_by_guess() -> None:
     assert short_circuit_family("set_ptt", blind) is TxFamily.PTT_ON
     assert short_circuit_family("set_powerstat", blind) is TxFamily.POWER_ON
     assert short_circuit_family("stop_cw_text", blind) is TxFamily.CW_STOP
-
-
-async def test_an_unresolvable_unkey_keeps_the_hold_it_could_not_read() -> None:
-    """The price of the fail-closed path, pinned so the comment cannot drift.
-
-    An unreadable de-key is admitted (never refused) but is not *believed*: it
-    takes the KEYING branch, so the live hold and deadline survive and a second
-    hold stacks, and hazard writes stay refused for the key-down bound. That is
-    the documented cost of :data:`UNRESOLVED_ARGUMENT`, and it is the direction
-    worth being expensive in.
-    """
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(RX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (True,)):
-        pass
-    async with authority.admit("set_ptt", (), {"on": False}) as admission:
-        assert admission.write_class is TxWriteClass.KEYING  # admitted, not refused
-
-    view = authority.view()
-    assert view.own_transmit_holds == ("key", "key")
-    assert view.deadline_monotonic == pytest.approx(
-        clock.now + BACKEND_MAX_KEY_DOWN_SECONDS
-    )
-
-    with pytest.raises(TxRefusal) as refusal:
-        async with authority.admit("set_antenna_1", ()):
-            pass  # pragma: no cover - the admission refuses first
-    assert refusal.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    assert refusal.value.evidence.own_transmit_hold == "key"
-    assert link.reads == []  # refused on our own hold, with no wire read at all
-
-    clock.advance(BACKEND_MAX_KEY_DOWN_SECONDS + 0.1)
-    async with authority.admit("set_antenna_1", ()):
-        pass  # the hold expires on the key-down bound; it is not permanent


### PR DESCRIPTION
## Summary

- remove the unused hold, key-down deadline, poll, lease, and last-resort unkey lifecycle from dormant `TransmitAuthority`
- remove only the dedicated unit/conformance rows for that retired lifecycle
- preserve the canonical observation contract, solicited-read deadline, lock/epoch invalidation, classification, provenance, and decision records
- leave shipping `TxSafetySupervisor`, `ManagedRadioRuntime`, provider lifecycle, retries, and release debt untouched
- correct scoped provenance prose so it does not claim unproved rigctld/Hamlib cache or physical-radio freshness

Linear: MOR-2182 (child of MOR-2167 / MOR-2163)

## TDD evidence

- RED first: runtime/introspection absence contract failed on existing `_Hold`
- GREEN after deletion
- independent mutation REDs for restored `_Hold`, `TransmitAuthority.poll`, `TxAuthorityView.deadline_monotonic` / `_deadline`, and constructor `last_resort_unkey`
- control mutation outside the retired surface stayed GREEN

## Verification

- targeted suite: 224 passed, 25 xfailed
- final exact-head Mac: 14138 passed, 162 skipped, 41 xfailed, 5 warnings, zero failures
- same-platform base: 14169 passed, 162 skipped, 48 xfailed, 6 warnings, zero failures; collection delta maps to deleted watchdog-only tests
- Ruff check and format: PASS
- Import Linter: 5 contracts kept
- independent review: Agent Review PASS for exact head `3c2815ed2c5edaf0d141c2babb8c20d6b449951d`

## Scope

Exactly 3 files, +75/-620 (695 changed lines). This exceeds the 600-line soft threshold but is below the 1000-line hard limit. The production deletion and its two dedicated test suites form one atomic lifecycle removal; splitting would leave live behavior with deleted coverage or deleted behavior with stale tests.