### PR TITLE
docs: correct historical MOR-2158 hold status

### DIFF
--- a/docs/validation/cat-audits/ftx1.md
+++ b/docs/validation/cat-audits/ftx1.md
@@ -97,7 +97,11 @@ The official Yaesu **FTX-1 Series CAT Operation Reference Manual 2508-C** is the
 command authority; `rigs/ftx1.toml` is the runtime radio-fact SSOT. The companion
 [family/domain gap CSV](ftx1-command-gaps.csv) is a dated derived audit snapshot,
 not an implementation source or a second profile SSOT. It does not approve a bulk
-profile/API update and it does not alter the active IC-7300 MOR-2158 profile HOLD.
+profile/API update. The IC-7300 MOR-2158 hold applied during this census and review;
+this census PR did not change that profile. It was released after MOR-2158/MOR-2133
+closure at main `bf66038c8b0ac74020d9f985677542cc3aba167d` (PR #2975 merge and
+post-merge PASS). Any future implementation must re-read current ownership and
+re-anchor from fresh main; this history does not make the profile permanently free.
 
 This snapshot is pinned to census ref
 `8cc5471dbb60f246ccb7a17a5e29f75fd6f20a00`, manual SHA-256

--- a/docs/validation/cat-audits/ic7300.md
+++ b/docs/validation/cat-audits/ic7300.md
@@ -180,8 +180,12 @@ The official Icom **IC-7300 Advanced Manual (11a), §19**, remains the command
 authority. `rigs/ic7300.toml` remains the runtime radio-fact SSOT. The companion
 [family/domain gap CSV](ic7300-command-gaps.csv) is a dated, derived audit snapshot:
 it is neither an implementation source nor a second profile SSOT. In particular, it
-does not authorize bulk additions. `rigs/ic7300.toml` is under the active MOR-2158
-HOLD and is deliberately untouched here.
+does not authorize bulk additions. The MOR-2158 hold applied during this census and
+review, and this census PR deliberately did not change `rigs/ic7300.toml`. It was
+released after MOR-2158/MOR-2133 closure at main
+`bf66038c8b0ac74020d9f985677542cc3aba167d` (PR #2975 merge and post-merge PASS).
+Any future implementation must re-read current ownership and re-anchor from fresh
+main; this history does not make the profile permanently free.
 
 This snapshot is pinned to census ref
 `8cc5471dbb60f246ccb7a17a5e29f75fd6f20a00`, manual SHA-256


### PR DESCRIPTION
## Summary

Follow-up for the sole post-merge documentation blocker on #2977.

- Replaces stale claims that the MOR-2158 hold is currently active.
- Records that the hold applied during the 2026-09-01 census/review, then was released after MOR-2158/MOR-2133 closure at `bf66038c8b0ac74020d9f985677542cc3aba167d` / PR #2975 merge and post-merge PASS.
- Preserves the boundary that future implementation must re-read current ownership and re-anchor from fresh `main`; it does not imply the profile is permanently free.

## Scope

Only `docs/validation/cat-audits/ic7300.md` and `docs/validation/cat-audits/ftx1.md` changed (11 additions, 3 deletions). Census counts, CSVs, source hashes, and semantic findings are unchanged. No profile, runtime, test, or Linear mutation occurred.

## Verification

- `git diff --check`
- no active-HOLD wording remains in either audit
- doc citation, link, dangling-citation-floor, and all corresponding growth gates
- `uv run mkdocs build --strict`

References the #2977 post-merge audit blocker only; this PR does not merge or close any ticket.
