### PR TITLE
fix(MOR-2190): fail closed wrong IC-7300 bindings

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1060,8 +1060,12 @@ get_ssb_tx_bandwidth = [0x16, 0x58]
 set_ssb_tx_bandwidth = [0x16, 0x58]
 
 # ── Split ──
-get_tx_freq_monitor = [0x1C, 0x03]
-set_tx_freq_monitor = [0x1C, 0x03]
+# MOR-2190 temporary fail-closed override: direct official-manual evidence,
+# not an inherited unsupported marker. Keep these names explicit while the
+# legacy CoreRadio._KNOWN_COMMANDS fallback still exists; replacement APIs are
+# deliberately outside this slice.
+get_tx_freq_monitor = { absent = "IC-7300 Advanced Manual (11a) command table p.19-7: 1C 03 is Read transmit frequency, not transmit-frequency monitor; no SET form is documented" }
+set_tx_freq_monitor = { absent = "IC-7300 Advanced Manual (11a) command table p.19-7: 1C 03 is Read transmit frequency, not transmit-frequency monitor; no SET form is documented" }
 get_xfc_status = [0x1C, 0x02]             # XFC = transmit frequency monitor
 set_xfc_status = [0x1C, 0x02]
 
@@ -1368,10 +1372,14 @@ get_nb_width = [0x1A, 0x05, 0x01, 0x90]
 set_nb_width = [0x1A, 0x05, 0x01, 0x90]
 get_vox_delay = [0x1A, 0x05, 0x01, 0x91]     # 0-20 (0.0-2.0 sec)
 set_vox_delay = [0x1A, 0x05, 0x01, 0x91]     # 0-20 (0.0-2.0 sec)
-get_scope_marker_position = [0x1A, 0x05, 0x00, 0x40]  # 00=Filter Center, 01=Carrier Point
-set_scope_marker_position = [0x1A, 0x05, 0x00, 0x40]
-get_ref_adjust = [0x1A, 0x05, 0x00, 0x70]    # NOT_IMPLEMENTED — not listed in wfview IC-7300.rig
-set_ref_adjust = [0x1A, 0x05, 0x00, 0x70]    # NOT_IMPLEMENTED — not listed in wfview IC-7300.rig
+# MOR-2190 temporary fail-closed overrides: these are direct findings from the
+# official manual, not inherited unsupported markers. The explicit entries
+# keep the profile's negative knowledge inspectable while replacement APIs are
+# deliberately deferred.
+get_scope_marker_position = { absent = "IC-7300 Advanced Manual (11a) command table p.19-4: 1A 05 0040 is Speech Speed (00=Low, 01=High), not scope marker position" }
+set_scope_marker_position = { absent = "IC-7300 Advanced Manual (11a) command table p.19-4: 1A 05 0040 is Speech Speed (00=Low, 01=High), not scope marker position" }
+get_ref_adjust = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-5: 1A 05 0070 is external-keypad RTTY Memory; reference frequency is 0058 with 0000..0255 domain" }
+set_ref_adjust = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-5: 1A 05 0070 is external-keypad RTTY Memory; reference frequency is 0058 with 0000..0255 domain" }
 
 [protocol]
 type = "civ"

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -16,7 +16,7 @@
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.
 IC-705	246	128	231
-IC-7300	328	184	285
+IC-7300	322	181	279
 IC-7610	217	129	171
 IC-9700	230	137	183
 X6100	67	42	50

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -20,6 +20,36 @@ from rigplane.rig_loader import load_rig
 RIGS_DIR = Path(__file__).resolve().parent.parent / "rigs"
 IC7300_PATH = RIGS_DIR / "ic7300.toml"
 
+_WRONG_MANUAL_BINDINGS = {
+    "get_tx_freq_monitor": ((0x1C, 0x03), "1C 03 is Read transmit frequency"),
+    "set_tx_freq_monitor": ((0x1C, 0x03), "1C 03 is Read transmit frequency"),
+    "get_scope_marker_position": (
+        (0x1A, 0x05, 0x00, 0x40),
+        "1A 05 0040 is Speech Speed",
+    ),
+    "set_scope_marker_position": (
+        (0x1A, 0x05, 0x00, 0x40),
+        "1A 05 0040 is Speech Speed",
+    ),
+    "get_ref_adjust": (
+        (0x1A, 0x05, 0x00, 0x70),
+        "1A 05 0070 is external-keypad RTTY Memory",
+    ),
+    "set_ref_adjust": (
+        (0x1A, 0x05, 0x00, 0x70),
+        "1A 05 0070 is external-keypad RTTY Memory",
+    ),
+}
+_PUBLIC_FAIL_BEFORE_WIRE_CALLS = {
+    "get_tx_freq_monitor": (),
+    "set_tx_freq_monitor": (True,),
+    "get_ref_adjust": (),
+    "set_ref_adjust": (128,),
+}
+_PROFILE_ONLY_FAIL_BEFORE_WIRE_NAMES = frozenset(
+    {"get_scope_marker_position", "set_scope_marker_position"}
+)
+
 EXPECTED_BASELINE_CAPABILITIES = {
     "audio",
     "af_level",
@@ -287,6 +317,87 @@ class TestCapabilities:
 
     def test_capabilities_match_pre_speech_baseline(self, profile):
         assert profile.capabilities - {"speech"} == EXPECTED_BASELINE_CAPABILITIES
+
+
+class TestWrongManualBindingsFailClosed:
+    """MOR-2190: direct official-manual corrections, not inherited markers."""
+
+    def test_all_six_names_are_explicitly_absent_and_unbound(self, profile, cmdmap):
+        assert len(_WRONG_MANUAL_BINDINGS) == 6
+        for name, (wrong_wire, semantic) in _WRONG_MANUAL_BINDINGS.items():
+            assert name not in profile.command_names
+            assert name in profile.absent_command_names
+            source = profile.absent_command_sources[name]
+            assert source.startswith("IC-7300 Advanced Manual (11a)")
+            assert semantic in source
+            assert not cmdmap.has(name), f"{name} still serializes {wrong_wire!r}"
+
+    def test_all_six_names_are_unsupported_by_the_shipped_radio(self, profile):
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        assert {
+            name for name in _WRONG_MANUAL_BINDINGS if not radio.supports_command(name)
+        } == set(_WRONG_MANUAL_BINDINGS)
+
+    @pytest.mark.asyncio
+    async def test_public_operations_refuse_before_any_wire_call(
+        self, profile, monkeypatch
+    ):
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        send_raw = AsyncMock()
+        send_expect = AsyncMock()
+        send_fire_and_forget = AsyncMock()
+        get_bcd_level = AsyncMock()
+        monkeypatch.setattr(radio, "_check_connected", lambda: None)
+        monkeypatch.setattr(radio, "_send_civ_raw", send_raw)
+        monkeypatch.setattr(radio, "_send_civ_expect", send_expect)
+        monkeypatch.setattr(radio, "_send_fire_and_forget", send_fire_and_forget)
+        monkeypatch.setattr(radio, "_get_bcd_level", get_bcd_level)
+
+        visited: set[str] = set()
+        for name, args in _PUBLIC_FAIL_BEFORE_WIRE_CALLS.items():
+            visited.add(name)
+            with pytest.raises(CommandError, match="declared absent by this profile"):
+                await getattr(radio, name)(*args)
+
+        assert visited == set(_PUBLIC_FAIL_BEFORE_WIRE_CALLS)
+        send_raw.assert_not_awaited()
+        send_expect.assert_not_awaited()
+        send_fire_and_forget.assert_not_awaited()
+        get_bcd_level.assert_not_awaited()
+
+    def test_profile_only_operations_have_no_callable_wire_path(self, profile):
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        visited: set[str] = set()
+        for name in _PROFILE_ONLY_FAIL_BEFORE_WIRE_NAMES:
+            visited.add(name)
+            assert not hasattr(CoreRadio, name)
+            with pytest.raises(AttributeError, match="no builder named"):
+                getattr(radio._commands, name)  # noqa: B009, SLF001
+
+        assert visited == set(_PROFILE_ONLY_FAIL_BEFORE_WIRE_NAMES)
+        assert visited | set(_PUBLIC_FAIL_BEFORE_WIRE_CALLS) == set(
+            _WRONG_MANUAL_BINDINGS
+        )
+
+    def test_unrelated_positive_bindings_and_tx_band_builders_remain(self, profile):
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        for name in (
+            "get_freq",
+            "set_filter_width",
+            "get_tx_band_count",
+            "get_tx_band_edge",
+        ):
+            assert name in profile.command_names
+            assert name not in profile.absent_command_names
+            assert profile.command_map is not None and profile.command_map.has(name)
+
+        assert radio._commands.get_freq(to_addr=0x94)[4:-1] == b"\x03"  # noqa: SLF001
+        assert radio._commands.get_tx_band_count(to_addr=0x94)[4:-1] == (  # noqa: SLF001
+            b"\x1e\x00"
+        )
+        assert radio._commands.get_tx_band_edge(1, to_addr=0x94)[4:-1] == (  # noqa: SLF001
+            b"\x1e\x01\x01"
+        )
 
 
 # ── Command overrides ──────────────────────────────────────────

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2785,7 +2785,9 @@ class TestIc7300DeclaresAbsentCommands:
     MOR-2118 added ``get_antenna``/``set_antenna`` (no 0x12 row on this
     radio) and MOR-2117 added the bare ``set_dual_watch`` (dispatches to
     the two split names above, already absent, but was itself in neither
-    list) (+3, to 32 -- the current count, per ``len(_EXPECTED_ABSENT)``).
+    list) (+3, to 32), then MOR-2190 replaced six proven-wrong positive
+    bindings with direct official-manual absent entries (+6, to 38 -- the
+    current count, per ``len(_EXPECTED_ABSENT)``).
     Pinned by name, not just count, so a future D2 pass on another command
     can't silently swap one of these for a different one and still pass a
     bare-count check.
@@ -2826,6 +2828,9 @@ class TestIc7300DeclaresAbsentCommands:
             "get_powerstat",
             "get_quick_dual_watch",
             "set_quick_dual_watch",
+            # MOR-2190: direct IC-7300 Advanced Manual (11a) findings.
+            "get_ref_adjust",
+            "set_ref_adjust",
             # Bare "quick_dual_watch" removed here (MOR-2008 batch 1): no
             # builder resolved it, only get_/set_quick_dual_watch above do.
             "get_rx_antenna_ant2",
@@ -2834,6 +2839,10 @@ class TestIc7300DeclaresAbsentCommands:
             # (pp.19-7..19-8) runs 1E then 20 -- no 1F row.
             "get_scope_rbw",
             "set_scope_rbw",
+            "get_scope_marker_position",
+            "set_scope_marker_position",
+            "get_tx_freq_monitor",
+            "set_tx_freq_monitor",
         }
     )
 


### PR DESCRIPTION
## Summary

Linear: [MOR-2190](https://linear.app/morozsm/issue/MOR-2190)

Fail closed exactly six IC-7300 profile operation names that were positively bound to three official-manual semantics belonging to different commands.

## Evidence boundary

This change is grounded in direct read-only review of IC-7300 Advanced Manual (11a), not live bench evidence:

- p.19-7: 1C 03 is Read transmit frequency. It is not transmit-frequency monitor, and no setter form is documented.
- p.19-4: 1A 05 0040 is Speech Speed.
- pp.19-4..19-5: 1A 05 0070 is external-keypad RTTY Memory; reference frequency is 0058 with domain 0000..0255.

No hardware gate is claimed or required for this fail-closed removal.

## Exact removals

- get_tx_freq_monitor / set_tx_freq_monitor from 1C 03
- get_scope_marker_position / set_scope_marker_position from 1A 05 0040
- get_ref_adjust / set_ref_adjust from 1A 05 0070

Each name is now a sourced explicit-negative profile entry, excluded from command_names and command_map, present in absent_command_names, and reported unsupported by the shipped IC-7300 radio.

The explicit negatives are temporary compatibility overrides. CoreRadio.supports_command still falls back to the current known-command set for names the profile does not mention, so the four existing public runtime operations must be explicitly absent to fail closed. The two scope-marker names are profile-only and have no exported builder/runtime method; their explicit entries still preserve direct manual negative knowledge rather than an inherited or untrusted marker.

No replacement API or corrected mapping is added here: no get_tx_frequency, marker-position replacement, speech-speed API, external-keypad API, or reference-frequency API. MOR-2188, MOR-2114, and MOR-2161 remain outside this PR.

## Verification

RED-first focused tests failed 5 times before the profile edit, covering positive membership/support, public invocation, absent-set membership, and command-map exclusion. After the change:

- Focused fail-closed and loader set: 7 passed.
- Nearby profile, binding, refusal, coverage, and response-shape suite: 1,318 passed, 152 skipped.
- Reverse-index plus focused set after the baseline update: 23 passed.
- All three mutation checks went red when independently restoring 1C 03, 1A 05 0040, or 1A 05 0070.
- Repository-wide Ruff check and format check passed.
- Import-linter: 5 contracts kept, 0 broken.
- Mac mini exact head 41288331509cfe49aa1a497125a51deb80481665: 14,130 passed, 163 skipped, 41 xfailed; Ruff passed.

The first Mac run at debbc07e1360187b782b141dd3cc4c627903ec7b exposed only the deterministic reverse-index census. Arithmetic is mechanical: six removed names, three removed unique prefixes because each wrong getter/setter pair shared one tuple, and six removed colliding names, so IC-7300 moves 328/184/285 to 322/181/279.

The Mac mini runner scripts do not persist a dedicated log file; output is retained in this task transcript. The full run verified exact head 41288331509cfe49aa1a497125a51deb80481665 at run time. The testbed later moved to fc4cfe357507fcd16c1dc0591b26cc7f1fdae062, which does not invalidate the transcript-backed earlier run.

Exact Mac commands:

- /Users/moroz/bin/rp-remote-test.sh debbc07e1360187b782b141dd3cc4c627903ec7b py
- /Users/moroz/bin/rp-remote-test.sh 41288331509cfe49aa1a497125a51deb80481665 py

## Scope

Four files, 136 insertions and 8 deletions (144 changed lines). No runtime/backend/frontend/docs changes and no coverage-gap baseline expansion.