### PR TITLE
refactor: retire dormant TX band classifier (MOR-2181)

### DIFF
--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -167,52 +167,6 @@ class TxRefusal(Exception):
         self.evidence = evidence
 
 
-# Band relation — data in, no profile import
-
-
-class BandRelation(StrEnum):
-    """How a target frequency relates to the current one."""
-
-    SAME_BAND = "same-band"
-    CROSS_BAND = "cross-band"
-    UNRESOLVED = "unresolved"
-
-
-def resolve_band(
-    frequency_hz: float | None, bands: Sequence[tuple[int, int]]
-) -> int | None:
-    """Index of the declared band holding ``frequency_hz``, else ``None``.
-
-    ``bands`` arrives as plain ``(low_hz, high_hz)`` tuples built by the
-    backend from its profile — this module imports nothing from ``profiles``.
-    """
-    if frequency_hz is None:
-        return None
-    for index, (low, high) in enumerate(bands):
-        if low <= frequency_hz <= high:
-            return index
-    return None
-
-
-def band_relation(
-    current_hz: float | None,
-    target_hz: float | None,
-    bands: Sequence[tuple[int, int]],
-) -> BandRelation:
-    """Cross-band detection is best-effort extra strictness, never a new gate.
-
-    A gap value, a missing current frequency or a profile with no band data
-    resolves to :attr:`BandRelation.UNRESOLVED` — the manufacturer-permitted
-    floor, because a rule that re-refused whenever the relation is murky would
-    re-enter fail-closed through the back door.
-    """
-    current = resolve_band(current_hz, bands)
-    target = resolve_band(target_hz, bands)
-    if current is None or target is None:
-        return BandRelation.UNRESOLVED
-    return BandRelation.SAME_BAND if current == target else BandRelation.CROSS_BAND
-
-
 # Argument predicates — named and pure
 
 
@@ -226,9 +180,7 @@ class _UnresolvedArgument:
 
 
 #: Returned by :meth:`TxArgumentContext.first` when the engine cannot say what
-#: the caller passed. Every predicate that meets it must fail *closed*: the
-#: permissive branch — the unkey short-circuit, a PASS retune — is exactly what
-#: a mis-spelled admission must never reach (MOR-1954).
+#: the caller passed, distinct from a supplied falsey argument.
 #:
 UNRESOLVED_ARGUMENT: Final = _UnresolvedArgument()
 
@@ -286,8 +238,6 @@ class TxArgumentContext:
 
     args: tuple[object, ...]
     kwargs: Mapping[str, object]
-    current_frequency_hz: float | None
-    bands: tuple[tuple[int, int], ...]
     target: Callable[..., object] | None = None
 
     def first(self) -> object:
@@ -339,28 +289,10 @@ def powerstat_family(context: TxArgumentContext) -> TxFamily:
     return TxFamily.POWER_ON if bool(value) else TxFamily.POWER_OFF
 
 
-def frequency_family(context: TxArgumentContext) -> TxFamily:
-    """HAZARD only when both endpoints resolve to declared bands and differ.
-
-    An unresolved *argument* is a hazard: a retune whose target the engine
-    cannot read may be the cross-band one. An unresolved *band relation* is
-    not — a gap, a missing current frequency or a profile with no band data
-    stays PASS, or the fail-closed direction would re-enter through the back
-    door (see :func:`band_relation`).
-    """
-    target = context.first()
-    if target is UNRESOLVED_ARGUMENT:
-        return TxFamily.BAND
-    target_hz = float(target) if isinstance(target, (int, float)) else None
-    relation = band_relation(context.current_frequency_hz, target_hz, context.bands)
-    return TxFamily.BAND if relation is BandRelation.CROSS_BAND else TxFamily.FREQUENCY
-
-
 TX_ARGUMENT_PREDICATES: Mapping[str, ArgumentPredicate] = MappingProxyType(
     {
         "ptt": ptt_family,
         "powerstat": powerstat_family,
-        "frequency": frequency_family,
     }
 )
 
@@ -388,13 +320,6 @@ def short_circuit_family(method: str, context: TxArgumentContext) -> TxFamily | 
     readable de-key, or an unreadable ``set_ptt`` / ``set_powerstat`` argument
     into a refusal.
 
-    It says nothing about any other method, and the general rule runs the
-    other way: everywhere else an unreadable argument fails **closed** and may
-    well refuse. ``set_freq`` becomes BAND and is refused at TX where the
-    readable in-band value would have passed — pinned by
-    ``test_an_unresolvable_keyword_argument_fails_closed_and_is_loud`` — and
-    an unreadable ``set_tuner_status`` is refused at TX like any other hazard.
-    Omitting ``target`` is never free; :data:`UNRESOLVED_ARGUMENT` prices it.
     """
     if method == "stop_cw_text":
         return TxFamily.CW_STOP
@@ -460,16 +385,12 @@ class TransmitAuthority:
         read_transmit_state: Callable[[], Awaitable[TxStateReading]],
         method_map: Mapping[str, TxMethodEntry],
         clock: Callable[[], float] = time.monotonic,
-        bands: Sequence[tuple[int, int]] = (),
-        current_frequency_hz: Callable[[], float | None] | None = None,
         provider_generation: Callable[[], int] | None = None,
         read_deadline_seconds: float = TX_READ_DEADLINE_SECONDS,
     ) -> None:
         self._read_transmit_state = read_transmit_state
         self._method_map = dict(method_map)
         self._clock = clock
-        self._bands = tuple(bands)
-        self._current_frequency_hz = current_frequency_hz
         self._provider_generation = provider_generation
         self._read_deadline_seconds = read_deadline_seconds
 
@@ -533,10 +454,6 @@ class TransmitAuthority:
         context = TxArgumentContext(
             args=tuple(args),
             kwargs=dict(kwargs or {}),
-            current_frequency_hz=(
-                self._current_frequency_hz() if self._current_frequency_hz else None
-            ),
-            bands=self._bands,
             target=target,
         )
         if self._consults_argument(method) and context.first() is UNRESOLVED_ARGUMENT:

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import MISSING, FrozenInstanceError, fields
 from typing import get_type_hints
 
@@ -29,7 +28,6 @@ from rigplane.core.tx_authority import (
     TX_ARGUMENT_PREDICATES,
     TX_ENGINE_FAILURE_TAGS,
     UNRESOLVED_ARGUMENT,
-    BandRelation,
     TransmitAuthority,
     TxArgumentContext,
     TxFamily,
@@ -37,9 +35,7 @@ from rigplane.core.tx_authority import (
     TxRefusal,
     TxRefusalCode,
     TxWriteClass,
-    band_relation,
     first_parameter_name,
-    resolve_band,
     short_circuit_family,
 )
 
@@ -83,16 +79,10 @@ def test_tx_observation_contract_is_canonical_and_authority_reexports_it() -> No
     assert tx_authority.RADIO_READBACK_SOURCES is tx_observation.RADIO_READBACK_SOURCES
 
 
-BANDS: tuple[tuple[int, int], ...] = (
-    (14_000_000, 14_350_000),
-    (21_000_000, 21_450_000),
-    (28_000_000, 29_700_000),
-)
-
 METHOD_MAP: Mapping[str, TxMethodEntry] = {
     "set_ptt": TxMethodEntry(TxFamily.PTT_ON, predicate="ptt"),
     "set_powerstat": TxMethodEntry(TxFamily.POWER_ON, predicate="powerstat"),
-    "set_freq": TxMethodEntry(TxFamily.FREQUENCY, predicate="frequency"),
+    "set_freq": TxMethodEntry(TxFamily.FREQUENCY),
     "set_mode": TxMethodEntry(TxFamily.MODE),
     "set_split": TxMethodEntry(TxFamily.VFO_TOPOLOGY),
     "set_power": TxMethodEntry(TxFamily.LEVELS),
@@ -203,15 +193,11 @@ def build_authority(
     link: FakeTransmitStateLink | PoisonedLink,
     *,
     method_map: Mapping[str, TxMethodEntry] | None = None,
-    bands: Sequence[tuple[int, int]] = BANDS,
-    current_frequency_hz: float | None = 14_200_000,
 ) -> TransmitAuthority:
     return TransmitAuthority(
         read_transmit_state=link.read,
         method_map=METHOD_MAP if method_map is None else method_map,
         clock=clock,
-        bands=tuple(bands),
-        current_frequency_hz=lambda: current_frequency_hz,
     )
 
 
@@ -316,89 +302,41 @@ def test_dormant_authority_watchdog_surface_is_absent() -> None:
     assert "own_transmit_hold" not in get_type_hints(tx_authority.TxEvidence)
 
 
+def test_dormant_band_classification_surface_is_absent() -> None:
+    """Frequency remains a PASS family without a second band classifier."""
+    for name in (
+        "BandRelation",
+        "resolve_band",
+        "band_relation",
+        "frequency_family",
+    ):
+        assert not hasattr(tx_authority, name)
+    assert "frequency" not in TX_ARGUMENT_PREDICATES
+
+    context_fields = {field.name for field in fields(TxArgumentContext)}
+    assert "current_frequency_hz" not in context_fields
+    assert "bands" not in context_fields
+
+    parameters = inspect.signature(TransmitAuthority).parameters
+    assert "bands" not in parameters
+    assert "current_frequency_hz" not in parameters
+
+    authority = TransmitAuthority(
+        read_transmit_state=PoisonedLink().read,
+        method_map=METHOD_MAP,
+        clock=Clock(),
+    )
+    assert not hasattr(authority, "_bands")
+    assert not hasattr(authority, "_current_frequency_hz")
+
+
 def test_argument_predicate_registry_is_named_and_pure() -> None:
-    assert set(TX_ARGUMENT_PREDICATES) == {"ptt", "powerstat", "frequency"}
-    ctx = TxArgumentContext(
-        args=(True,), kwargs={}, current_frequency_hz=None, bands=()
-    )
+    assert set(TX_ARGUMENT_PREDICATES) == {"ptt", "powerstat"}
+    ctx = TxArgumentContext(args=(True,), kwargs={})
     assert TX_ARGUMENT_PREDICATES["ptt"](ctx) is TxFamily.PTT_ON
-    off = TxArgumentContext(
-        args=(False,), kwargs={}, current_frequency_hz=None, bands=()
-    )
+    off = TxArgumentContext(args=(False,), kwargs={})
     assert TX_ARGUMENT_PREDICATES["ptt"](off) is TxFamily.PTT_OFF
     assert TX_ARGUMENT_PREDICATES["powerstat"](off) is TxFamily.POWER_OFF
-
-
-# --------------------------------------------------------------------------
-# Band relation arithmetic (§3.3)
-# --------------------------------------------------------------------------
-
-
-def test_resolve_band_hits_gap_and_missing_data() -> None:
-    assert resolve_band(14_200_000, BANDS) == 0
-    assert resolve_band(21_100_000, BANDS) == 1
-    assert resolve_band(18_100_000, BANDS) is None  # gap between declared bands
-    assert resolve_band(None, BANDS) is None
-    assert resolve_band(14_200_000, ()) is None
-
-
-@pytest.mark.parametrize(
-    ("current", "target", "bands", "expected"),
-    [
-        (14_200_000, 14_300_000, BANDS, BandRelation.SAME_BAND),
-        (14_200_000, 21_100_000, BANDS, BandRelation.CROSS_BAND),
-        (14_200_000, 18_100_000, BANDS, BandRelation.UNRESOLVED),
-        (18_100_000, 21_100_000, BANDS, BandRelation.UNRESOLVED),
-        (None, 21_100_000, BANDS, BandRelation.UNRESOLVED),
-        (14_200_000, 21_100_000, (), BandRelation.UNRESOLVED),
-    ],
-)
-def test_band_relation(
-    current: float | None,
-    target: float,
-    bands: tuple[tuple[int, int], ...],
-    expected: BandRelation,
-) -> None:
-    assert band_relation(current, target, bands) is expected
-
-
-@pytest.mark.parametrize(
-    ("current", "target", "bands", "family"),
-    [
-        (14_200_000, 14_300_000, BANDS, TxFamily.FREQUENCY),
-        (14_200_000, 21_100_000, BANDS, TxFamily.BAND),
-        (14_200_000, 18_100_000, BANDS, TxFamily.FREQUENCY),
-        (None, 21_100_000, BANDS, TxFamily.FREQUENCY),
-        (14_200_000, 21_100_000, (), TxFamily.FREQUENCY),
-    ],
-)
-def test_frequency_predicate_only_gates_a_resolved_crossing(
-    current: float | None,
-    target: float,
-    bands: tuple[tuple[int, int], ...],
-    family: TxFamily,
-) -> None:
-    ctx = TxArgumentContext(
-        args=(target,), kwargs={}, current_frequency_hz=current, bands=bands
-    )
-    assert TX_ARGUMENT_PREDICATES["frequency"](ctx) is family
-
-
-async def test_cross_band_set_freq_is_gated_and_in_band_is_not() -> None:
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(TX)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_freq", (14_250_000,)):
-        pass
-    assert link.reads == []  # in-band frequency never consults truth
-
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit("set_freq", (21_100_000,)):
-            pytest.fail("cross-band write must not reach the wire")
-    assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    assert len(link.reads) == 1
 
 
 # --------------------------------------------------------------------------
@@ -754,7 +692,6 @@ async def test_view_reports_keying_decisions() -> None:
         read_transmit_state=link.read,
         method_map=METHOD_MAP,
         clock=clock,
-        bands=BANDS,
     )
     async with authority.admit("set_ptt", (True,)):
         pass
@@ -795,10 +732,9 @@ class SignatureMirror:
     """The parameter names the shipping Icom bodies actually declare.
 
     Not a radio stand-in: these pins need the *names* `runtime/radio.py`
-    declares (`on`, `freq_hz`, `value`), because the defect being closed was
-    the engine guessing them (`"value"`, `"frequency"`) in the predicate table.
-    ``test_first_parameter_names_mirror_the_shipping_bodies`` keeps this class
-    honest against the real methods.
+    declares (`on`, `freq_hz`, `value`).
+    ``test_first_parameter_names_mirror_the_shipping_bodies`` keeps this
+    class honest against the real methods.
     """
 
     async def set_ptt(self, on: bool) -> None: ...
@@ -854,8 +790,6 @@ async def test_keyword_key_down_is_never_read_as_an_unkey() -> None:
         ("set_ptt", True, TxFamily.PTT_ON),
         ("set_ptt", False, TxFamily.PTT_OFF),
         ("set_powerstat", False, TxFamily.POWER_OFF),
-        ("set_freq", 14_250_000, TxFamily.FREQUENCY),
-        ("set_freq", 21_100_000, TxFamily.BAND),
     ],
 )
 async def test_classification_is_independent_of_argument_spelling(
@@ -879,41 +813,6 @@ async def test_classification_is_independent_of_argument_spelling(
 
     assert families == [expected, expected]
     assert classes[0] is classes[1]
-
-
-async def test_keyword_retune_reads_the_real_frequency_argument() -> None:
-    """A same-band keyword retune stays PASS only if ``freq_hz`` resolved."""
-    clock = Clock()
-    link = PoisonedLink()
-    authority = build_authority(clock, link)
-
-    async with authority.admit(
-        "set_freq",
-        (),
-        {"freq_hz": 14_250_000, "receiver": 1},
-        target=SignatureMirror.set_freq,
-    ) as admission:
-        assert admission.write_class is TxWriteClass.PASS
-        assert admission.family is TxFamily.FREQUENCY
-
-
-async def test_an_unresolvable_keyword_argument_fails_closed_and_is_loud(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """No signature to resolve from must never mean a silent permissive PASS."""
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(TX)
-    authority = build_authority(clock, link)
-
-    with caplog.at_level(logging.WARNING, logger="rigplane.core.tx_authority"):
-        with pytest.raises(TxRefusal) as refusal:
-            async with authority.admit("set_freq", (), {"freq_hz": 14_250_000}):
-                pass  # pragma: no cover - the admission refuses first
-
-    assert refusal.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    assert authority.view().records[-1].family == str(TxFamily.BAND)
-    assert any("could not resolve" in record.getMessage() for record in caplog.records)
 
 
 @pytest.mark.parametrize("spelling", ["positional", "keyword", "unresolvable"])
@@ -958,8 +857,6 @@ def test_predicates_resolve_the_argument_by_signature_not_by_guess() -> None:
     keyed = TxArgumentContext(
         args=(),
         kwargs={"on": True},
-        current_frequency_hz=None,
-        bands=(),
         target=SignatureMirror.set_ptt,
     )
     assert TX_ARGUMENT_PREDICATES["ptt"](keyed) is TxFamily.PTT_ON
@@ -967,20 +864,15 @@ def test_predicates_resolve_the_argument_by_signature_not_by_guess() -> None:
     unkeyed = TxArgumentContext(
         args=(),
         kwargs={"on": False},
-        current_frequency_hz=None,
-        bands=(),
         target=SignatureMirror.set_ptt,
     )
     assert TX_ARGUMENT_PREDICATES["ptt"](unkeyed) is TxFamily.PTT_OFF
     assert unkeyed.first() is False
 
-    blind = TxArgumentContext(
-        args=(), kwargs={"on": False}, current_frequency_hz=None, bands=()
-    )
+    blind = TxArgumentContext(args=(), kwargs={"on": False})
     assert blind.first() is UNRESOLVED_ARGUMENT
     assert TX_ARGUMENT_PREDICATES["ptt"](blind) is TxFamily.PTT_ON
     assert TX_ARGUMENT_PREDICATES["powerstat"](blind) is TxFamily.POWER_ON
-    assert TX_ARGUMENT_PREDICATES["frequency"](blind) is TxFamily.BAND
     assert short_circuit_family("set_ptt", blind) is TxFamily.PTT_ON
     assert short_circuit_family("set_powerstat", blind) is TxFamily.POWER_ON
     assert short_circuit_family("stop_cw_text", blind) is TxFamily.CW_STOP


### PR DESCRIPTION
## Summary

- remove dormant `BandRelation`, band resolution, and cross-frequency predicate logic from `TransmitAuthority`
- remove the unused band/current-frequency constructor and context plumbing
- delete only matching classifier tests
- preserve fixed `TxFamily.FREQUENCY` / `TxFamily.BAND` mappings, argument resolution, unkey classification, and all live profile/runtime/UI band mechanisms
- remove stale prose that still promised the retired fail-closed retune behavior

Linear: MOR-2181 (child of MOR-2167 / MOR-2163)

## TDD evidence

- RED first: runtime/introspection absence contract failed on existing `BandRelation`
- GREEN after deletion
- independent mutation REDs for four definitions, the frequency registry entry, two context fields, two constructor parameters, and two instance attributes
- unrelated semantic control mutation stayed GREEN

## Verification

- targeted authority/conformance/characterisation: 244 passed, 25 xfailed
- exact-head Mac: 14122 passed, 162 skipped, 41 xfailed, 5 warnings, zero failures
- same-platform base: 14138 passed, 162 skipped, 41 xfailed, 5 warnings, zero failures
- Ruff check / format: PASS
- Import Linter: 5 contracts kept
- independent review: Agent Review PASS for exact head `fc4cfe357507fcd16c1dc0591b26cc7f1fdae062`

## Scope

Exactly 2 files, +36/-227. No shipping runtime behavior or public supported API is changed; the retired module surface had zero production or known downstream consumers.