### PR TITLE
refactor: retire dormant TX argument resolver (MOR-2178)

### DIFF
--- a/src/rigplane/core/tx_authority.py
+++ b/src/rigplane/core/tx_authority.py
@@ -11,19 +11,12 @@ transmit-state read. Nothing in the product consumes this module yet — it land
 ahead of the backend admission rows so the contracts exist before any call site
 cites them.
 
-One requirement those rows inherit: an admission that passes its argument by
-keyword must also pass ``target``, so classification reads the method's real
-signature rather than a guessed parameter name.
-:meth:`TransmitAuthority.admit` states it and :data:`UNRESOLVED_ARGUMENT`
-records what failing it costs.
-
 Design: ``docs/plans/2026-08-20-transmit-authority.md`` §3.3-§3.7.
 """
 
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 import time
 from collections import deque
@@ -31,9 +24,8 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequenc
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, replace
 from enum import StrEnum
-from functools import lru_cache
 from types import MappingProxyType
-from typing import Final, Literal, NoReturn
+from typing import Literal, NoReturn
 
 from .tx_observation import (
     RADIO_READBACK_SOURCES,  # noqa: F401
@@ -67,7 +59,6 @@ class TxWriteClass(StrEnum):
     PASS = "pass"
     HAZARD = "hazard"
     KEYING = "keying"
-    UNKEY = "unkey"
 
 
 class TxFamily(StrEnum):
@@ -83,7 +74,6 @@ class TxFamily(StrEnum):
     SCAN_START = "scan-start"
     SCAN_STOP = "scan-stop"
     POWER_ON = "power-on"
-    POWER_OFF = "power-off"
     CW_STOP = "cw-stop"
     BAND = "band"
     TUNER = "tuner"
@@ -91,7 +81,6 @@ class TxFamily(StrEnum):
     VFO_SELECT = "vfo-select"
     PTT_ON = "ptt-on"
     CW_TEXT = "cw-text"
-    PTT_OFF = "ptt-off"
 
 
 #: The neutral family → class table. Pinned literal, never computed: PASS is
@@ -111,7 +100,6 @@ FAMILY_WRITE_CLASS: Mapping[TxFamily, TxWriteClass] = MappingProxyType(
         TxFamily.SCAN_START: TxWriteClass.PASS,
         TxFamily.SCAN_STOP: TxWriteClass.PASS,
         TxFamily.POWER_ON: TxWriteClass.PASS,
-        TxFamily.POWER_OFF: TxWriteClass.PASS,
         TxFamily.CW_STOP: TxWriteClass.PASS,
         TxFamily.BAND: TxWriteClass.HAZARD,
         TxFamily.TUNER: TxWriteClass.HAZARD,
@@ -119,7 +107,6 @@ FAMILY_WRITE_CLASS: Mapping[TxFamily, TxWriteClass] = MappingProxyType(
         TxFamily.VFO_SELECT: TxWriteClass.HAZARD,
         TxFamily.PTT_ON: TxWriteClass.KEYING,
         TxFamily.CW_TEXT: TxWriteClass.KEYING,
-        TxFamily.PTT_OFF: TxWriteClass.UNKEY,
     }
 )
 
@@ -167,184 +154,6 @@ class TxRefusal(Exception):
         self.evidence = evidence
 
 
-# Argument predicates — named and pure
-
-
-class _UnresolvedArgument:
-    """The value of an argument the engine could not determine."""
-
-    __slots__ = ()
-
-    def __repr__(self) -> str:  # pragma: no cover - debugging aid
-        return "UNRESOLVED_ARGUMENT"
-
-
-#: Returned by :meth:`TxArgumentContext.first` when the engine cannot say what
-#: the caller passed, distinct from a supplied falsey argument.
-#:
-UNRESOLVED_ARGUMENT: Final = _UnresolvedArgument()
-
-#: How many gated signatures the resolver keeps. A backend gates on the order
-#: of a hundred methods, so one entry per method fits many times over.
-SIGNATURE_CACHE_SIZE: Final = 512
-
-#: Methods the T5 short-circuit resolves from their argument rather than from
-#: any table. Named once so the engine and the short-circuit agree on which
-#: admissions actually consult an argument.
-ARGUMENT_SHORT_CIRCUIT_METHODS: frozenset[str] = frozenset({"set_ptt", "set_powerstat"})
-
-
-@lru_cache(maxsize=SIGNATURE_CACHE_SIZE)
-def _first_parameter_name(function: Callable[..., object]) -> str | None:
-    try:
-        parameters = list(inspect.signature(function).parameters.values())
-    except (TypeError, ValueError):  # pragma: no cover - builtins, C callables
-        return None
-    for index, parameter in enumerate(parameters):
-        if parameter.kind in (
-            inspect.Parameter.VAR_POSITIONAL,
-            inspect.Parameter.VAR_KEYWORD,
-        ):
-            continue
-        if index == 0 and parameter.name in ("self", "cls"):
-            continue
-        return parameter.name
-    return None
-
-
-def first_parameter_name(target: Callable[..., object] | None) -> str | None:
-    """The gated method's first caller-supplied parameter, from its signature.
-
-    The point of reading the *real* signature is that classification cannot
-    depend on how a call site happened to spell its argument. Reflection runs
-    once per underlying function and is cached, bounded at
-    :data:`SIGNATURE_CACHE_SIZE` — enough for a whole backend's write surface,
-    though a caller that resolves more distinct callables than that will evict
-    and pay for the reflection again. A bound method is normalised onto its
-    function, so the cache holds no radio instances.
-    """
-    if target is None:
-        return None
-    function = getattr(target, "__func__", target)
-    try:
-        return _first_parameter_name(function)
-    except TypeError:  # pragma: no cover - unhashable callable
-        return None
-
-
-@dataclass(frozen=True, slots=True)
-class TxArgumentContext:
-    """Everything a predicate may look at. No I/O, no globals."""
-
-    args: tuple[object, ...]
-    kwargs: Mapping[str, object]
-    target: Callable[..., object] | None = None
-
-    def first(self) -> object:
-        """The gated method's first argument, however the call spelled it.
-
-        Positionally it is simply the first of :attr:`args`; by keyword it is
-        read under the name :attr:`target`'s own signature declares. With no
-        signature to read, or a keyword the signature does not name, it is
-        :data:`UNRESOLVED_ARGUMENT` — never a name guessed on the method's
-        behalf, and a sentinel rather than ``None`` so that it stays
-        distinguishable from an argument the caller really did pass as
-        ``None``, or as ``0``, or as ``False``.
-
-        A predicate for a method whose interesting argument is *not* the first
-        one must read :attr:`args` / :attr:`kwargs` directly.
-        """
-        if self.args:
-            return self.args[0]
-        if not self.kwargs:
-            return UNRESOLVED_ARGUMENT
-        name = first_parameter_name(self.target)
-        if name is not None and name in self.kwargs:
-            return self.kwargs[name]
-        return UNRESOLVED_ARGUMENT
-
-
-ArgumentPredicate = Callable[[TxArgumentContext], TxFamily]
-
-
-def ptt_family(context: TxArgumentContext) -> TxFamily:
-    """``set_ptt(True)`` keys; ``set_ptt(False)`` is the one-sided unkey.
-
-    An unresolved argument is read as the key, not the unkey: PTT_ON is the
-    KEYING branch, which has no refusal path, so answering it can never turn
-    an admission into a refusal — while answering PTT_OFF would walk a
-    key-down straight through the gate.
-    """
-    value = context.first()
-    if value is UNRESOLVED_ARGUMENT:
-        return TxFamily.PTT_ON
-    return TxFamily.PTT_ON if bool(value) else TxFamily.PTT_OFF
-
-
-def powerstat_family(context: TxArgumentContext) -> TxFamily:
-    """``set_powerstat(False)`` joins the short-circuit set, never gated."""
-    value = context.first()
-    if value is UNRESOLVED_ARGUMENT:
-        return TxFamily.POWER_ON
-    return TxFamily.POWER_ON if bool(value) else TxFamily.POWER_OFF
-
-
-TX_ARGUMENT_PREDICATES: Mapping[str, ArgumentPredicate] = MappingProxyType(
-    {
-        "ptt": ptt_family,
-        "powerstat": powerstat_family,
-    }
-)
-
-
-def short_circuit_family(method: str, context: TxArgumentContext) -> TxFamily | None:
-    """T5: resolve de-key / power-off / stop-CW ahead of every table.
-
-    A corrupt or incomplete classification table must never make an unkey
-    harder, so this consults no map and no profile data.
-
-    Exactly which admissions bypass the table, stated narrowly because the
-    code is narrow: ``stop_cw_text`` always; ``set_ptt`` / ``set_powerstat``
-    when their argument reads falsy, and when it cannot be read at all. A
-    *readable truthy* argument returns ``None`` and goes on to the table like
-    any other write — deliberately, and what the table then does with it is
-    the table's business, measured rather than assumed: with **no entry** the
-    key-down is refused ``unclassified`` (INV-1's fail direction, at RX and at
-    TX alike); with an entry that **misclassifies** it into a hazard family it
-    is refused at a scripted TX but **admitted as that hazard at RX** — not
-    refused at all. Neither case is rescued here, and neither is safe to
-    describe as one.
-
-    The guarantee this function carries is one sentence, and it is about
-    **these three methods only**: no table can turn ``stop_cw_text``, a
-    readable de-key, or an unreadable ``set_ptt`` / ``set_powerstat`` argument
-    into a refusal.
-
-    """
-    if method == "stop_cw_text":
-        return TxFamily.CW_STOP
-    if method in ARGUMENT_SHORT_CIRCUIT_METHODS:
-        value = context.first()
-        if value is UNRESOLVED_ARGUMENT:
-            # An unreadable argument takes the strict twin, still ahead of the
-            # table, so a key-down can never hide in the unkey branch merely
-            # because of how its argument was spelled (MOR-1954). Each is safe
-            # for its own reason, and the two reasons are not interchangeable:
-            #   set_ptt       — PTT_ON is KEYING, a branch with no refusal path
-            #                   at all, so the strict answer cannot become a
-            #                   refusal.
-            #   set_powerstat — POWER_ON and POWER_OFF are *both* PASS in
-            #                   FAMILY_WRITE_CLASS, so the branch is inert here
-            #                   whichever way it answers. The KEYING argument
-            #                   above says nothing about powerstat: anyone who
-            #                   reclassifies POWER_ON must re-derive this, not
-            #                   inherit it.
-            return TxFamily.PTT_ON if method == "set_ptt" else TxFamily.POWER_ON
-        if not bool(value):
-            return TxFamily.PTT_OFF if method == "set_ptt" else TxFamily.POWER_OFF
-    return None
-
-
 @dataclass(frozen=True, slots=True)
 class TxMethodEntry:
     """One row of a per-backend method-name → family map.
@@ -353,7 +162,6 @@ class TxMethodEntry:
     """
 
     family: TxFamily
-    predicate: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -426,51 +234,13 @@ class TransmitAuthority:
         method: str,
         args: Sequence[object] = (),
         kwargs: Mapping[str, object] | None = None,
-        *,
-        target: Callable[..., object] | None = None,
     ) -> AsyncIterator[TxAdmission]:
-        """Gate one write. The body performs the write; the lock spans both.
-
-        ``target`` is the gated method itself. It is how a keyword admission
-        resolves its argument by the method's real signature instead of a name
-        guessed in the predicate table (MOR-1954).
-
-        **Requirement on every call site that admits an argument by keyword**,
-        row 7 onward: pass ``target``. INV-2 form A — the bare ``@tx_admit``
-        decorator — passes the function it wraps; INV-2 form B — the in-body
-        ``async with ... admit(...)`` block — passes ``self.<method>``, or
-        forwards the argument positionally and needs no ``target`` at all.
-        Failing to is not silent: the argument resolves to
-        :data:`UNRESOLVED_ARGUMENT`, and wherever classifying the method
-        actually reads an argument, a warning names it and the keywords it
-        saw and every predicate then fails closed — which for every family
-        except the two the T5 short-circuit owns can mean a refusal. That
-        constant records what the fail-closed path costs; it is not free.
-        """
+        """Gate one write. The body performs the write; the lock spans both."""
         if method in RAW_EXCLUDED:
             yield TxAdmission(None, TxWriteClass.PASS)
             return
 
-        context = TxArgumentContext(
-            args=tuple(args),
-            kwargs=dict(kwargs or {}),
-            target=target,
-        )
-        if self._consults_argument(method) and context.first() is UNRESOLVED_ARGUMENT:
-            # Loud, because the predicates below now fail closed on it and a
-            # silently mis-spelled admission is what MOR-1954 closed.
-            _LOGGER.warning(
-                "transmit authority could not resolve the admission argument",
-                extra={
-                    "method": method,
-                    "keywords": sorted(context.kwargs),
-                    "signature": first_parameter_name(target),
-                },
-            )
-
-        family = short_circuit_family(method, context)
-        if family is None:
-            family = self._classify(method, context)
+        family = self._classify(method)
         if family is None:
             # INV-1's fail direction: nothing defaults to PASS by omission.
             self._refuse(
@@ -487,11 +257,6 @@ class TransmitAuthority:
             yield TxAdmission(family, write_class)
             return
 
-        if write_class is TxWriteClass.UNKEY:
-            yield TxAdmission(family, write_class)
-            self._record(method, family, write_class, "sent", None, None)
-            return
-
         async with self._lock:
             if write_class is TxWriteClass.KEYING:
                 ticket = self._admit_keying(family)
@@ -506,22 +271,11 @@ class TransmitAuthority:
 
     # -- internals ---------------------------------------------------------
 
-    def _consults_argument(self, method: str) -> bool:
-        """Does classifying this method read an argument at all?"""
-        if method in ARGUMENT_SHORT_CIRCUIT_METHODS:
-            return True
-        entry = self._method_map.get(method)
-        if entry is None:
-            return False
-        return entry.predicate is not None
-
-    def _classify(self, method: str, context: TxArgumentContext) -> TxFamily | None:
+    def _classify(self, method: str) -> TxFamily | None:
         entry = self._method_map.get(method)
         if entry is None:
             return None
-        if entry.predicate is None:
-            return entry.family
-        return TX_ARGUMENT_PREDICATES[entry.predicate](context)
+        return entry.family
 
     def _admit_keying(self, family: TxFamily) -> TxAdmission:
         self._transmit_epoch += 1

--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -16,7 +16,7 @@ so the matrix runs each ADR-named row twice:
 fake wire, with the admission driven from the test. These prove the component
 composes: a hazard write at scripted TX is refused and nothing reaches the
 wire; at scripted RX the solicited read precedes the write; an unmapped value
-is never receiving; and an unkey is never refused.
+is never receiving.
 
 *Cutover rows (``xfail(strict=True)``).* The same behaviours driven the way a
 consumer will drive them — a plain method call, or a command through
@@ -107,7 +107,7 @@ CONFORMANCE_METHOD_MAP: Mapping[str, TxMethodEntry] = {
     "set_tuner_status": TxMethodEntry(TxFamily.TUNER),
     "set_tuner": TxMethodEntry(TxFamily.TUNER),
     "set_vfo_slot": TxMethodEntry(TxFamily.VFO_SELECT),
-    "set_ptt": TxMethodEntry(TxFamily.PTT_ON, predicate="ptt"),
+    "set_ptt": TxMethodEntry(TxFamily.PTT_ON),
 }
 
 
@@ -443,55 +443,6 @@ async def test_a_hazard_write_at_scripted_rx_reads_before_it_writes(
     )
 
 
-@every_backend()
-@pytest.mark.parametrize("answer", ["tx_cat", "silence", "unmapped"])
-async def test_an_unkey_is_never_refused(
-    harness: TxConformanceHarness, answer: str
-) -> None:
-    """§3.10 item 3, row 6 / INV-5: the one-sided unkey, on every column.
-
-    Driven under the most hostile truth each wire can produce — keyed, silent,
-    unmapped — because an unkey that only works when truth is healthy is not
-    the doctrine (``managed_tx_ingress.py:1-21``).
-
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, insert
-    # `raise TxRefusal(TxRefusalCode.TX_TRUTH_UNAVAILABLE, TxEvidence())` as
-    # the first statement of the `if write_class is TxWriteClass.UNKEY:`
-    # branch at :526 -> this row goes red on every column.
-    """
-    harness.script(answer)
-    authority = build_authority(harness)
-    writes_before = len(harness.writes())
-
-    async with authority.admit("set_ptt", (False,)):
-        await harness.unkey()
-
-    assert harness.writes()[writes_before:], f"{harness.name}: the unkey never landed"
-
-
-@every_backend()
-async def test_a_pass_class_write_never_consults_transmit_truth(
-    harness: TxConformanceHarness,
-) -> None:
-    """INV-3, composed: a poisoned read must not be reachable from PASS.
-
-    ``set_ptt(False)`` resolves through the T5 short circuit and ``set_freq``
-    is absent from the matrix map, so the row uses the unkey — the one write
-    that is structurally ahead of every table.
-    """
-
-    async def poisoned() -> TxStateReading:  # pragma: no cover - must not run
-        raise AssertionError("transmit truth was consulted on a non-hazard write")
-
-    authority = TransmitAuthority(
-        read_transmit_state=poisoned,
-        method_map=CONFORMANCE_METHOD_MAP,
-        clock=FakeClock(),
-    )
-    async with authority.admit("set_ptt", (False,)):
-        await harness.unkey()
-
-
 @pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
 async def test_the_queue_drain_reaches_the_backend_write_method(
     harness: TxConformanceHarness,
@@ -499,10 +450,8 @@ async def test_the_queue_drain_reaches_the_backend_write_method(
     """The D1 ingress is real, and this file can drive it.
 
     Live on purpose: the queue-path cutover rows below are ``xfail``, and an
-    xfail proves nothing if the plumbing under it never worked. ``PttOff`` is
-    the probe because it is ``ALWAYS_PASS`` at the old seat still standing
-    above the authority (row 11 deletes that seat), so this row measures the
-    drain rather than the seat.
+    xfail proves nothing if the plumbing under it never worked. The queued
+    command is the probe, so this row measures the drain rather than admission.
     """
     harness.script("rx")
     queue = harness.extras["queue"]

--- a/tests/test_tx_authority.py
+++ b/tests/test_tx_authority.py
@@ -25,18 +25,13 @@ from rigplane.core.tx_authority import (
     DECISION_LOG_CAPACITY,
     FAMILY_WRITE_CLASS,
     RAW_EXCLUDED,
-    TX_ARGUMENT_PREDICATES,
     TX_ENGINE_FAILURE_TAGS,
-    UNRESOLVED_ARGUMENT,
     TransmitAuthority,
-    TxArgumentContext,
     TxFamily,
     TxMethodEntry,
     TxRefusal,
     TxRefusalCode,
     TxWriteClass,
-    first_parameter_name,
-    short_circuit_family,
 )
 
 
@@ -80,8 +75,8 @@ def test_tx_observation_contract_is_canonical_and_authority_reexports_it() -> No
 
 
 METHOD_MAP: Mapping[str, TxMethodEntry] = {
-    "set_ptt": TxMethodEntry(TxFamily.PTT_ON, predicate="ptt"),
-    "set_powerstat": TxMethodEntry(TxFamily.POWER_ON, predicate="powerstat"),
+    "set_ptt": TxMethodEntry(family=TxFamily.PTT_ON),
+    "set_powerstat": TxMethodEntry(family=TxFamily.POWER_ON),
     "set_freq": TxMethodEntry(TxFamily.FREQUENCY),
     "set_mode": TxMethodEntry(TxFamily.MODE),
     "set_split": TxMethodEntry(TxFamily.VFO_TOPOLOGY),
@@ -246,12 +241,10 @@ def test_family_class_table_is_total_and_pinned() -> None:
     }
     keying = {f for f, c in FAMILY_WRITE_CLASS.items() if c is TxWriteClass.KEYING}
     assert keying == {TxFamily.PTT_ON, TxFamily.CW_TEXT}
-    unkey = {f for f, c in FAMILY_WRITE_CLASS.items() if c is TxWriteClass.UNKEY}
-    assert unkey == {TxFamily.PTT_OFF}
     assert FAMILY_WRITE_CLASS[TxFamily.FREQUENCY] is TxWriteClass.PASS
     assert FAMILY_WRITE_CLASS[TxFamily.MODE] is TxWriteClass.PASS
     assert FAMILY_WRITE_CLASS[TxFamily.VFO_TOPOLOGY] is TxWriteClass.PASS
-    assert FAMILY_WRITE_CLASS[TxFamily.POWER_OFF] is TxWriteClass.PASS
+    assert FAMILY_WRITE_CLASS[TxFamily.POWER_ON] is TxWriteClass.PASS
     assert FAMILY_WRITE_CLASS[TxFamily.CW_STOP] is TxWriteClass.PASS
 
 
@@ -302,6 +295,53 @@ def test_dormant_authority_watchdog_surface_is_absent() -> None:
     assert "own_transmit_hold" not in get_type_hints(tx_authority.TxEvidence)
 
 
+def test_dormant_argument_resolution_surface_is_absent() -> None:
+    for name in (
+        "_UnresolvedArgument",
+        "UNRESOLVED_ARGUMENT",
+        "SIGNATURE_CACHE_SIZE",
+        "_first_parameter_name",
+        "first_parameter_name",
+        "TxArgumentContext",
+        "ArgumentPredicate",
+        "ptt_family",
+        "powerstat_family",
+        "TX_ARGUMENT_PREDICATES",
+        "ARGUMENT_SHORT_CIRCUIT_METHODS",
+        "short_circuit_family",
+    ):
+        assert not hasattr(tx_authority, name)
+
+    assert [field.name for field in fields(TxMethodEntry)] == ["family"]
+    assert "target" not in inspect.signature(TransmitAuthority.admit).parameters
+    assert "UNKEY" not in TxWriteClass.__members__
+    assert "PTT_OFF" not in TxFamily.__members__
+    assert "POWER_OFF" not in TxFamily.__members__
+
+
+@pytest.mark.parametrize(
+    ("method", "args", "kwargs", "family", "write_class"),
+    (
+        ("set_ptt", (False,), {}, TxFamily.PTT_ON, TxWriteClass.KEYING),
+        ("set_ptt", (), {"on": False}, TxFamily.PTT_ON, TxWriteClass.KEYING),
+        ("set_powerstat", (False,), {}, TxFamily.POWER_ON, TxWriteClass.PASS),
+        ("set_powerstat", (), {"on": False}, TxFamily.POWER_ON, TxWriteClass.PASS),
+    ),
+)
+async def test_fixed_ptt_and_powerstat_families_ignore_arguments(
+    method: str,
+    args: tuple[object, ...],
+    kwargs: Mapping[str, object],
+    family: TxFamily,
+    write_class: TxWriteClass,
+) -> None:
+    authority = build_authority(Clock(), PoisonedLink())
+
+    async with authority.admit(method, args, kwargs) as admission:
+        assert admission.family is family
+        assert admission.write_class is write_class
+
+
 def test_dormant_band_classification_surface_is_absent() -> None:
     """Frequency remains a PASS family without a second band classifier."""
     for name in (
@@ -311,11 +351,6 @@ def test_dormant_band_classification_surface_is_absent() -> None:
         "frequency_family",
     ):
         assert not hasattr(tx_authority, name)
-    assert "frequency" not in TX_ARGUMENT_PREDICATES
-
-    context_fields = {field.name for field in fields(TxArgumentContext)}
-    assert "current_frequency_hz" not in context_fields
-    assert "bands" not in context_fields
 
     parameters = inspect.signature(TransmitAuthority).parameters
     assert "bands" not in parameters
@@ -328,15 +363,6 @@ def test_dormant_band_classification_surface_is_absent() -> None:
     )
     assert not hasattr(authority, "_bands")
     assert not hasattr(authority, "_current_frequency_hz")
-
-
-def test_argument_predicate_registry_is_named_and_pure() -> None:
-    assert set(TX_ARGUMENT_PREDICATES) == {"ptt", "powerstat"}
-    ctx = TxArgumentContext(args=(True,), kwargs={})
-    assert TX_ARGUMENT_PREDICATES["ptt"](ctx) is TxFamily.PTT_ON
-    off = TxArgumentContext(args=(False,), kwargs={})
-    assert TX_ARGUMENT_PREDICATES["ptt"](off) is TxFamily.PTT_OFF
-    assert TX_ARGUMENT_PREDICATES["powerstat"](off) is TxFamily.POWER_OFF
 
 
 # --------------------------------------------------------------------------
@@ -513,42 +539,6 @@ async def test_every_refusal_carries_evidence(answer: TxStateReading | str) -> N
 
 
 # --------------------------------------------------------------------------
-# T5 / INV-5 / INV-6 — the unkey is never made harder
-# --------------------------------------------------------------------------
-
-
-#: A table that classifies all three T5 methods into HAZARD families. An empty
-#: map is not a poisoned one — it leaves the short-circuit as the only path and
-#: so cannot catch INV-6's mutation ("reorder the short-circuit after the
-#: table"). This map can: with the table consulted first, every de-key path
-#: becomes a hazard write and is refused at a scripted TX.
-POISONED_MAP: Mapping[str, TxMethodEntry] = {
-    "set_ptt": TxMethodEntry(TxFamily.TUNER),
-    "set_powerstat": TxMethodEntry(TxFamily.ANTENNA),
-    "stop_cw_text": TxMethodEntry(TxFamily.BAND),
-}
-
-
-async def test_unkey_is_never_refused_even_with_a_poisoned_table() -> None:
-    """INV-5/INV-6: the T5 short-circuit precedes the table and the wire."""
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(TX, TX, TX)
-    authority = build_authority(clock, link, method_map=POISONED_MAP)
-
-    for method, args in (
-        ("set_ptt", (False,)),
-        ("set_powerstat", (False,)),
-        ("stop_cw_text", ()),
-    ):
-        async with authority.admit(method, args):
-            pass
-
-    assert link.reads == []  # not one of the three consulted the radio
-    assert authority.view().records[-1].write_class is TxWriteClass.UNKEY
-
-
-# --------------------------------------------------------------------------
 # KEYING
 # --------------------------------------------------------------------------
 
@@ -721,158 +711,3 @@ async def test_raw_excluded_methods_are_not_classified() -> None:
             assert admission.family is None  # bytes are not classified
     assert authority.view().records == ()
     assert link.reads == []
-
-
-# --------------------------------------------------------------------------
-# MOR-1954 — classification never depends on how the call spelled the argument
-# --------------------------------------------------------------------------
-
-
-class SignatureMirror:
-    """The parameter names the shipping Icom bodies actually declare.
-
-    Not a radio stand-in: these pins need the *names* `runtime/radio.py`
-    declares (`on`, `freq_hz`, `value`).
-    ``test_first_parameter_names_mirror_the_shipping_bodies`` keeps this
-    class honest against the real methods.
-    """
-
-    async def set_ptt(self, on: bool) -> None: ...
-
-    async def set_powerstat(self, on: bool) -> None: ...
-
-    async def set_freq(self, freq_hz: int, receiver: int = 0) -> None: ...
-
-    async def set_tuner_status(self, value: int) -> None: ...
-
-
-def test_first_parameter_names_mirror_the_shipping_bodies() -> None:
-    """The resolver reads real signatures, and the mirror matches them."""
-    from rigplane.runtime.radio import IcomRadio
-
-    assert first_parameter_name(IcomRadio.set_ptt) == "on"
-    assert first_parameter_name(IcomRadio.set_powerstat) == "on"
-    assert first_parameter_name(IcomRadio.set_freq) == "freq_hz"
-    assert first_parameter_name(IcomRadio.set_tuner_status) == "value"
-
-    for method in ("set_ptt", "set_powerstat", "set_freq", "set_tuner_status"):
-        assert first_parameter_name(getattr(SignatureMirror, method)) == (
-            first_parameter_name(getattr(IcomRadio, method))
-        )
-    assert first_parameter_name(None) is None
-
-
-async def test_keyword_key_down_is_never_read_as_an_unkey() -> None:
-    """The load-bearing pin: ``set_ptt(on=True)`` keys, however it is spelled.
-
-    Before this fix the predicate read ``kwargs["value"]``; the Icom body
-    declares ``on``, so a keyword key-down resolved to ``None``, classified
-    PTT_OFF and was short-circuited past the gate.
-    No signature is supplied here on purpose — even with nothing to resolve
-    from, the engine must fail towards the key, never towards the unkey.
-    """
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    authority = build_authority(clock, link)
-
-    async with authority.admit("set_ptt", (), {"on": True}) as admission:
-        assert admission.family is TxFamily.PTT_ON
-        assert admission.write_class is TxWriteClass.KEYING
-
-    record = authority.view().records[-1]
-    assert record.method == "set_ptt"
-    assert record.write_class is TxWriteClass.KEYING
-
-
-@pytest.mark.parametrize(
-    ("method", "value", "expected"),
-    [
-        ("set_ptt", True, TxFamily.PTT_ON),
-        ("set_ptt", False, TxFamily.PTT_OFF),
-        ("set_powerstat", False, TxFamily.POWER_OFF),
-    ],
-)
-async def test_classification_is_independent_of_argument_spelling(
-    method: str, value: object, expected: TxFamily
-) -> None:
-    """Positional and keyword admissions of the same write agree, always."""
-    target = getattr(SignatureMirror, method)
-    name = first_parameter_name(target)
-    assert name is not None
-
-    families: list[TxFamily | None] = []
-    classes: list[TxWriteClass] = []
-    for args, kwargs in (((value,), {}), ((), {name: value})):
-        clock = Clock()
-        link = FakeTransmitStateLink(clock)
-        link.script(RX, RX)
-        authority = build_authority(clock, link)
-        async with authority.admit(method, args, kwargs, target=target) as admission:
-            families.append(admission.family)
-            classes.append(admission.write_class)
-
-    assert families == [expected, expected]
-    assert classes[0] is classes[1]
-
-
-@pytest.mark.parametrize("spelling", ["positional", "keyword", "unresolvable"])
-async def test_the_unkey_is_still_never_refused_in_any_spelling(
-    spelling: str,
-) -> None:
-    """INV-5 survives the fix: no spelling makes an unkey harder.
-
-    The poisoned table would refuse every de-key as a hazard at the scripted
-    TX if the T5 short-circuit stopped reaching it. The keyword unkey resolves
-    through the real signature and short-circuits; the unresolvable one may
-    not be *called* an unkey, but it must still not be refused — it lands on
-    the keying branch, which has no refusal path and consults no truth.
-    """
-    clock = Clock()
-    link = FakeTransmitStateLink(clock)
-    link.script(TX, TX)
-    authority = build_authority(clock, link, method_map=POISONED_MAP)
-
-    if spelling == "positional":
-        call = authority.admit("set_ptt", (False,))
-    elif spelling == "keyword":
-        call = authority.admit(
-            "set_ptt", (), {"on": False}, target=SignatureMirror.set_ptt
-        )
-    else:
-        call = authority.admit("set_ptt", (), {"on": False})
-
-    async with call as admission:
-        pass
-
-    assert link.reads == []  # no spelling made the unkey consult the radio
-    if spelling == "unresolvable":
-        assert admission.write_class is TxWriteClass.KEYING
-    else:
-        assert admission.family is TxFamily.PTT_OFF
-        assert admission.write_class is TxWriteClass.UNKEY
-
-
-def test_predicates_resolve_the_argument_by_signature_not_by_guess() -> None:
-    """Predicate-level twin of the admission pins, including the sentinel."""
-    keyed = TxArgumentContext(
-        args=(),
-        kwargs={"on": True},
-        target=SignatureMirror.set_ptt,
-    )
-    assert TX_ARGUMENT_PREDICATES["ptt"](keyed) is TxFamily.PTT_ON
-
-    unkeyed = TxArgumentContext(
-        args=(),
-        kwargs={"on": False},
-        target=SignatureMirror.set_ptt,
-    )
-    assert TX_ARGUMENT_PREDICATES["ptt"](unkeyed) is TxFamily.PTT_OFF
-    assert unkeyed.first() is False
-
-    blind = TxArgumentContext(args=(), kwargs={"on": False})
-    assert blind.first() is UNRESOLVED_ARGUMENT
-    assert TX_ARGUMENT_PREDICATES["ptt"](blind) is TxFamily.PTT_ON
-    assert TX_ARGUMENT_PREDICATES["powerstat"](blind) is TxFamily.POWER_ON
-    assert short_circuit_family("set_ptt", blind) is TxFamily.PTT_ON
-    assert short_circuit_family("set_powerstat", blind) is TxFamily.POWER_ON
-    assert short_circuit_family("stop_cw_text", blind) is TxFamily.CW_STOP


### PR DESCRIPTION
## Summary

- remove dormant signature reflection/cache, argument context, predicates, and target plumbing from `TransmitAuthority`
- remove the old one-sided `UNKEY` / `PTT_OFF` / `POWER_OFF` classification
- retain the temporary fixed method/family skeleton and later observation/hazard/decision surfaces
- leave shipping managed/interlock unkey paths and their characterisation tests byte-identical

Linear: MOR-2178 (child of MOR-2167 / MOR-2163)

## Intentional compatibility boundary

This intentionally breaks only undocumented direct imports and signature use from internal `rigplane.core.tx_authority`: removed resolver/context/predicate/short-circuit/OFF names and `admit(target=...)`. No supported public Radio API, CLI, config, protocol, or wire contract changes.

The fixed `PTT_ON` / `POWER_ON` classification is an intentional intermediate state of a dormant module scheduled for complete retirement. It does not replace or redefine the shipping managed/interlock unkey paths.

## TDD evidence

- RED first: existing false positional arguments selected `PTT_OFF/UNKEY` and `POWER_OFF/PASS`; structural test found `_UnresolvedArgument`
- GREEN after deletion
- mutation REDs cover resolver/cache/context/predicate/target, `UNKEY`, `PTT_OFF`, `POWER_OFF`, inline positional and keyword argument classification, and both fixed-map drifts
- retained FREQUENCY-class control remains covered

## Verification

- authority/conformance: 174 passed, 25 xfailed
- untouched shipping characterisation: 36 passed
- final exact-head Mac: 14088 passed, 162 skipped, 41 xfailed, 5 warnings, zero failures
- same-platform pre-change base: 14122 passed, 162 skipped, 41 xfailed, 5 warnings, zero failures
- Ruff check / format: PASS
- Import Linter: 5 contracts kept
- independent review: Agent Review PASS for exact head `511d2ebc05fa9b0b861f71aa6048bf7b1994d1c2`

## Scope

Exactly 3 files, +59/-521 = 580 changed lines. This is strictly below the mandatory 600-line split threshold and below the hard ceiling.