### PR TITLE
docs: delete three dead-selector citations in segmentline's state-feedback renderer

### DIFF
--- a/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
@@ -43,7 +43,6 @@ import {
 } from '../tx-feedback-state';
 import { SEGMENTLINE_INK, SEGMENTLINE_PALETTE } from './tokens';
 
-/** Matches `.dl-glass[data-tx='active']::after`'s box-shadow in `segmentline.css` exactly. */
 const FRAME_GLOW = 'inset 0 0 38px 2px rgba(214, 28, 8, 0.46), inset 0 0 11px rgba(255, 80, 40, 0.55)';
 
 export interface SegmentlinePerimeter {

--- a/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts
@@ -61,7 +61,7 @@ export interface SegmentlineCell {
   readonly present: true;
   /** Segmentline never fills a control (`tokens.ts`: "every control is an
    *  outlined cell, never a filled button") — engagement is carried by ink
-   *  strength alone, via `segmentline.css`'s `[data-active='true']`. */
+   *  strength alone. */
   readonly active: boolean;
   readonly tone: string;
   readonly focusRing: string;
@@ -121,9 +121,7 @@ export function renderStateFeedback(
       treatment,
       present: true,
       active: treatment === 'keyed',
-      // Same hot+active CONCEPT as segmentline.css's `.dl-cell[data-tone=
-      // 'hot'][data-active='true']` rule — but `tone` holds a colour value
-      // here, not the keyword 'hot'; no rule currently reads this field.
+      // No rule currently reads this field.
       tone: treatment === 'blocked' ? SEGMENTLINE_INK.ghost
         : treatment === 'keyed' ? SEGMENTLINE_PALETTE.txMark
           : SEGMENTLINE_INK.soft,


### PR DESCRIPTION
## What

Three prose citations in
`frontend/src/presentation/languages/segmentline/state-feedback-renderer.ts`
name CSS selectors that no longer exist. All three are removed. `FRAME_GLOW`'s
value, the renderer's behaviour and `segmentline.css` are untouched.

1 file, +2 / -5.

| Line (at merge base `aab9ce42`) | Dead citation | Disposition |
|---|---|---|
| 46 | ``Matches `.dl-glass[data-tx='active']::after`'s box-shadow in `segmentline.css` exactly.`` | whole comment deleted — nothing true remained |
| 65 | ``via `segmentline.css`'s `[data-active='true']``` | clause deleted; the `tokens.ts`-anchored half kept |
| 125-127 | ``Same hot+active CONCEPT as segmentline.css's `.dl-cell[data-tone='hot'][data-active='true']` rule`` | clause deleted; the verified `no rule currently reads this field` kept |

## One cause

`8cc5471d` — "test(MOR-2163): check design-language selectors reach real
markup, and fix the three that do not" (#2968) — removed 105 lines from
`segmentline.css` (`git show 8cc5471d --numstat`) and swept none of the prose
citing them. Its diff deletes the glow rule character-for-character:

```
-[data-design-language='segmentline'][data-design-language] .dl-glass[data-tx='active']::after {
-  box-shadow: inset 0 0 38px 2px rgba(214, 28, 8, 0.46), inset 0 0 11px rgba(255, 80, 40, 0.55);
```

and `.dl-cell[data-active='true']` and
`.dl-cell[data-tone='hot'][data-active='true']` alongside it. So all three
comments were **true when written** and went false at one commit — confirmed
at `8cc5471d~1` (`91f9d070`), where all three comments and all three cited
rules coexist.

## Why deletion, not a corrected citation

The rules were deleted, not renamed — so there is no surviving counterpart to
re-point at. Established against explicit refs, searching **by value** rather
than by name, so a rename could not have hidden one:

| Command | Result |
|---|---|
| `git grep -nEi '214[, ]+28[, ]+8' origin/main` | one hit: `FRAME_GLOW` itself |
| `git grep -nE 'inset 0 0 11px' origin/main` | one hit: `FRAME_GLOW` itself |
| `git grep -n 'dl-glass' origin/main` | one hit: the comment being deleted |
| `segmentline.css \| grep box-shadow` | one rule, `inset 0 0 50px rgba(0,0,0,0.06), 0 0 8px rgba(0,0,0,0.5)` on `.rx-tx-surface` — not `FRAME_GLOW` |
| `segmentline.css \| grep -c 'data-active'` | `0` |
| `segmentline.css \| grep -c 'dl-cell'` | `0` |

Main moved three times while this was open; every row was re-checked at each,
most recently `248cfc92`.

## Why deletion, not narrowing

CLAUDE.md's Testing rule ("Delete before you narrow; never weaken", owner
ruling 2026-08-31) reserves narrowing for prose whose reader does not have the
code. These are comments sitting on the constant and the object literal they
describe. For line 46 nothing true remained. For the other two the false half
was cut and the established half left standing — deletion of a clause, with no
word softened to make the remainder survive:

- line 64's survivor is anchored in `segmentline/tokens.ts:5-6` — "every
  control is an outlined cell, never a filled button", "hierarchy comes from
  ink opacity, not colour" — and its mechanism survived `8cc5471d` under a
  different selector: `.rx-tx-key[aria-pressed='true']` still moves
  `border-color`/`color` from `--dl-segmentline-ink-soft` to `-ink-strong`,
  two opacities of one ink, setting nothing else.
- line 126's survivor, "no rule currently reads this field", is established by
  `annotate()` in `semantic/design-language-renderers.ts`, which emits
  `data-dl-*` only for top-level `string | number | boolean`. `cell` is a
  nested object, so it is skipped whole and `tone` never becomes an attribute
  under any name.

The remaining candidate for line 46 — "this matches a rule that MOR-2153 will
restore" — is what MOR-1958 assigns to the ticket rather than the comment, and
is false anyway: at `codex/mor-2153-peer-split-chassis`'s head `2a815044` the
rule is absent and that branch's own `PeerSplitLayout.svelte` says "no
hot-bezel/glow mechanism exists for this element".

## Class closed for this file

`grep -nE "\.dl-|data-[a-z-]+=|\[data-|segmentline\.css"` over the file now
returns nothing. No `state-feedback-renderer.ts` in any other design language
carries a citation of this shape. `segmentline/meters-renderer.ts`'s two
`data-dl-*` citations were checked and are **live** —
`[data-dl-unknown='true']` and `[data-dl-hot='true']` are both still in the
stylesheet.

## Tests

None changed, because nothing pinned any of the three — which is why they went
stale silently. `state-feedback-renderer.test.ts` pins `insetShadow: ''` at
idle and `!== ''` when lit, never comparing the string to CSS;
`__tests__/stylesheet.test.ts` strips comments before parsing
(`source.replace(/\/\*[\s\S]*?\*\//g, '')`) and has no notion of `FRAME_GLOW`.
A pin tying a constant to a stylesheet rule cannot be written while no such
rule exists, so none is added.

## Reported, not fixed

For a ticket rather than scope creep here. The first two share this PR's cause;
the third does not and is listed only because it was found alongside them:

- `segmentline.css`'s header still describes `content` declarations on "the
  glass texture and the TX glow"; only the `::before` texture survives
  `8cc5471d`.
- `@media (prefers-reduced-motion: reduce)` sets `transition: none` on
  `.rx-tx-surface`, whose base rule declares no `transition` — a dead remnant.
- No `.svelte` file on `main` reads `perimeter`, so `FRAME_GLOW` reaches no
  DOM node today. This predates `8cc5471d` — no `.svelte` read it at
  `8cc5471d~1` either, and the file header calls `perimeter` private
  structure by design. The renderer's own tests do read `insetShadow`
  (`state-feedback-renderer.test.ts:44`, `:52`).
