### PR TITLE
MOR-2192: prune dormant TX authority conformance

### DIFF
--- a/tests/contracts/test_tx_authority_conformance.py
+++ b/tests/contracts/test_tx_authority_conformance.py
@@ -1,50 +1,13 @@
-"""Transmit-authority conformance matrix over every shipping backend.
+"""Transmit-observation conformance contracts over every shipping backend.
 
-ADR row 4 (``docs/plans/2026-08-20-transmit-authority.md`` §4 row 4, §3.10
-item 3), following the audio precedent
-(``tests/contracts/test_audio_lifecycle_conformance.py``): one scenario matrix,
-run for every shipping backend class against its fake link, with the scripted
-transmit-state answers this row also lands
-(``tests/tx_authority_fakes.py``, §3.10 item 1).
-
-**What this file proves today, and what it merely reserves.**
-
-No backend constructs a :class:`TransmitAuthority` yet — that is rows 7 and 8 —
-so the matrix runs each ADR-named row twice:
-
-*Composed rows (live).* The real engine, the real backend class and the real
-fake wire, with the admission driven from the test. These prove the component
-composes: a hazard write at scripted TX is refused and nothing reaches the
-wire; at scripted RX the solicited read precedes the write; an unmapped value
-is never receiving.
-
-*Cutover rows (``xfail(strict=True)``).* The same behaviours driven the way a
-consumer will drive them — a plain method call, or a command through
-``create_observation_poller``'s queue drain — with **no** test-side admission.
-They fail today because the admission is not in the backend. Each names the
-migration row that turns it green. ``strict=True`` is the point: the day a
-cutover lands, the row goes red as an XPASS, which is the signal rows 7/8 need
-that their conformance obligation is met. A row is never weakened to pass
-today: an honest xfail says more than an assertion-free green.
-
-**The queue path is not optional.** §3.2's refutation of the wrapping facade
-turns on item 2: on FTX-1 and hamlib-provider radios the web write path never
-touches the radio object from outside — ``web_startup.py:126-128`` hands the
-``CommandQueue`` into ``create_observation_poller`` and the backend drains it
-against raw ``self``. A matrix that only called backend methods directly would
-prove less than it appears to, so every queue-capable column carries the same
-rows again through the drain, plus a live row proving the drain really does
-reach the backend write method — so the xfails above it rest on working
-plumbing rather than on broken test wiring.
-
-No MagicMock anywhere near the authority (CLAUDE.md hard rule, restated by
-§3.10 item 1); the fakes are plain objects and the clock is injected.
+The rows pin observation primitives, parser discrimination, provenance, and
+queue liveness against every backend's real fake wire.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator
 
 import pytest
 from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
@@ -63,13 +26,6 @@ from tx_authority_fakes import (
 from rigplane.backends.rigctld_client.radio import RigctldClientRadio
 from rigplane.backends.yaesu_cat import YaesuCatRadio
 from rigplane.core.tx_observation import RADIO_READBACK_SOURCES, TxStateReading
-from rigplane.core.tx_authority import (
-    TransmitAuthority,
-    TxFamily,
-    TxMethodEntry,
-    TxRefusal,
-    TxRefusalCode,
-)
 
 # ---------------------------------------------------------------------------
 # Pinned literals
@@ -98,44 +54,6 @@ CIV_BACKENDS: tuple[str, ...] = (
     "ic7300-serial",
     "ic9700-serial",
 )
-
-#: The matrix's own method map. The shipped per-backend maps land at rows 7/8
-#: beside the methods they pin (§3.3); this literal covers exactly the methods
-#: the matrix drives, and like every other classification literal it is
-#: written out, never derived.
-CONFORMANCE_METHOD_MAP: Mapping[str, TxMethodEntry] = {
-    "set_tuner_status": TxMethodEntry(TxFamily.TUNER),
-    "set_tuner": TxMethodEntry(TxFamily.TUNER),
-    "set_vfo_slot": TxMethodEntry(TxFamily.VFO_SELECT),
-    "set_ptt": TxMethodEntry(TxFamily.PTT_ON),
-}
-
-
-class FakeClock:
-    """Deterministic monotonic clock — the same shape ``TxSafetySupervisor``'s
-    own tests inject, and the reason no row here sleeps."""
-
-    def __init__(self, start: float = 1_000.0) -> None:
-        self.now = start
-
-    def __call__(self) -> float:
-        return self.now
-
-    def advance(self, seconds: float) -> None:
-        self.now += seconds
-
-
-def build_authority(
-    harness: TxConformanceHarness,
-    *,
-    clock: FakeClock | None = None,
-) -> TransmitAuthority:
-    """The real engine over a real backend's real fake wire."""
-    return TransmitAuthority(
-        read_transmit_state=harness.read_transmit_state,
-        method_map=CONFORMANCE_METHOD_MAP,
-        clock=clock or FakeClock(),
-    )
 
 
 @pytest.fixture
@@ -205,42 +123,16 @@ def test_scripted_answer_vocabulary_pin() -> None:
 async def test_every_backend_answers_every_scripted_answer(
     harness: TxConformanceHarness, answer: str
 ) -> None:
-    """The gate's solicited read runs the backend's real read code for each
-    scripted answer, and only a confirmed RX admits a hazard write.
-
-    This is the row that makes every other row in the file meaningful: if a
-    column could not produce the answer, its conformance rows would be
-    vacuous.
-
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `_admit_hazard`,
-    # replace `if reading.value or epoch != self._transmit_epoch:` at :619
-    # with `if epoch != self._transmit_epoch:` -> this row goes red for both
-    # transmitting answers on every column: the gate admits a hazard write
-    # while the radio answers "transmitting".
-    """
+    """Every column produces each declared answer through its real read path."""
     harness.script(answer)
-    authority = build_authority(harness)
+    reading = await harness.read_transmit_state()
 
-    if answer == "rx" and harness.verified_readback:
-        async with authority.admit(harness.hazard_method, harness.hazard_args):
-            pass  # admitted: the one answer that may proceed
-        return
-
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit(harness.hazard_method, harness.hazard_args):
-            pytest.fail(f"{harness.name}: a hazard write was admitted at {answer!r}")
-
-    if answer in TRANSMITTING_ANSWERS and harness.verified_readback:
-        assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    elif answer == "unmapped":
-        # Either fail-closed direction is correct and the columns differ:
-        # Yaesu's positive map has no entry for `TX9`, so `read_ptt` answers
-        # *transmitting*; the CI-V and hamlib-provider columns produce no
-        # value at all. What must never happen is admission.
-        assert excinfo.value.code in tuple(TxRefusalCode)
+    if answer == "rx":
+        assert reading.value is False
+    elif answer in TRANSMITTING_ANSWERS:
+        assert reading.value is True
     else:
-        assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
-    assert excinfo.value.evidence is not None  # INV-14
+        assert reading.value is not False
 
 
 @every_backend()
@@ -298,12 +190,6 @@ async def test_a_civ_read_is_not_satisfied_by_an_ack_echo_or_misaddressed_frame(
     reading = await harness.read_transmit_state()
     assert reading.value is None, f"{harness.name}: {shape} satisfied the read"
 
-    authority = build_authority(harness)
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit(harness.hazard_method, harness.hazard_args):
-            pytest.fail(f"{harness.name}: {shape} admitted a hazard write")
-    assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
-
 
 @pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
 async def test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed(
@@ -312,8 +198,8 @@ async def test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed(
     """The unmapped CI-V answer is a fail-open canary, not junk.
 
     ``1C 00`` + ``00 00`` carries a leading ``0x00``: if the exact-shape check
-    were loosened it would decode as *receiving* and admit a relay throw. A
-    junk byte would decode as transmitting and could never catch that.
+    were loosened it would decode as *receiving*. A junk byte would decode as
+    transmitting and could never catch that.
 
     # MUTATION: in `src/rigplane/runtime/_civ_rx.py`, delete the
     # `and len(frame.data) == 1` conjunct at :2643 -> this row goes red: the
@@ -335,9 +221,9 @@ async def test_an_unmapped_transmit_state_value_is_never_receiving(
 ) -> None:
     """INV-9 / §3.7: RX is only ever produced by a positive mapping.
 
-    On Yaesu the unmapped ``TX9`` fails closed to *transmitting*; on the CI-V
-    and hamlib-provider columns it produces no value at all. Both are "not
-    receiving"; neither may admit a hazard write.
+    On Yaesu the unmapped ``TX9`` resolves to *transmitting*; on the CI-V and
+    hamlib-provider columns it produces no value at all. Both are "not
+    receiving".
 
     # MUTATION (MOR-1914, restated -- the predicate moved out of `read_ptt`
     # into a shared helper both `read_ptt` and `read_transmit_state` call):
@@ -354,11 +240,6 @@ async def test_an_unmapped_transmit_state_value_is_never_receiving(
     reading = await harness.read_transmit_state()
     assert reading.value is not False, f"{harness.name}: unmapped value read as RX"
 
-    authority = build_authority(harness)
-    with pytest.raises(TxRefusal):
-        async with authority.admit(harness.hazard_method, harness.hazard_args):
-            pytest.fail(f"{harness.name}: an unmapped value admitted a hazard write")
-
 
 @every_backend()
 @pytest.mark.parametrize("answer", NON_RECEIVING_ANSWERS)
@@ -371,76 +252,8 @@ async def test_no_failing_answer_ever_resolves_to_receiving(
 
 
 # ---------------------------------------------------------------------------
-# 2. Composed conformance — the real engine over the real backend, live
+# 2. Queue liveness and self-write provenance
 # ---------------------------------------------------------------------------
-
-
-@every_backend()
-async def test_a_hazard_write_at_scripted_tx_is_refused_and_no_wire_write_occurs(
-    harness: TxConformanceHarness,
-) -> None:
-    """§3.10 item 3, row 1. The refusal is worthless if the bytes went anyway.
-
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
-    # `if write_class is TxWriteClass.PASS:` at :522 to
-    # `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` -> this
-    # row goes red: the hazard write is yielded with no truth consulted and
-    # the tuner frame reaches the wire during transmit.
-    """
-    harness.script("tx_cat")
-    authority = build_authority(harness)
-    writes_before = len(harness.writes())
-
-    with pytest.raises(TxRefusal) as excinfo:
-        async with authority.admit(harness.hazard_method, harness.hazard_args):
-            await harness.hazard()
-
-    assert harness.writes()[writes_before:] == [], (
-        f"{harness.name}: a refused hazard write still reached the wire"
-    )
-    if harness.verified_readback:
-        assert excinfo.value.code is TxRefusalCode.REFUSED_WHILE_TRANSMITTING
-    else:
-        # §3.7: this column supplies no verified-readback evidence, so its
-        # hazard families are fail-closed by provenance.
-        assert excinfo.value.code is TxRefusalCode.TX_TRUTH_UNAVAILABLE
-        assert excinfo.value.evidence.failure == "unverifiable-provenance"
-
-
-@every_backend(*CIV_BACKENDS, "yaesu-ftx1")
-async def test_a_hazard_write_at_scripted_rx_reads_before_it_writes(
-    harness: TxConformanceHarness,
-) -> None:
-    """§3.10 item 3, row 2: on the wire, the read precedes the write.
-
-    Counts cannot see this — both happen either way. Only the order on the
-    wire proves that the backend read preceded the write (T3/INV-4).
-
-    The ``rigctld-client`` column is absent by design, not by omission: its
-    current contract supplies ``verified_readback=False`` (§3.7), so it never
-    reaches a write to order the read against.
-    ``test_..._refused_and_no_wire_write_occurs`` covers it instead.
-
-    # MUTATION: in `src/rigplane/core/tx_authority.py`, in `admit()`, change
-    # `if write_class is TxWriteClass.PASS:` at :522 to
-    # `if write_class in (TxWriteClass.PASS, TxWriteClass.HAZARD):` -> this
-    # row goes red: no read frame precedes the write on any column.
-    """
-    harness.script("rx")
-    authority = build_authority(harness)
-    baseline = len(harness.wire())
-
-    async with authority.admit(harness.hazard_method, harness.hazard_args):
-        await harness.hazard()
-
-    wire = list(harness.wire())[baseline:]
-    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
-    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
-    assert reads, f"{harness.name}: the hazard admission performed no read"
-    assert writes, f"{harness.name}: the admitted hazard write never happened"
-    assert reads[-1] < writes[0], (
-        f"{harness.name}: the write preceded the read it was authorised by: {wire}"
-    )
 
 
 @pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
@@ -449,9 +262,7 @@ async def test_the_queue_drain_reaches_the_backend_write_method(
 ) -> None:
     """The D1 ingress is real, and this file can drive it.
 
-    Live on purpose: the queue-path cutover rows below are ``xfail``, and an
-    xfail proves nothing if the plumbing under it never worked. The queued
-    command is the probe, so this row measures the drain rather than admission.
+    The queued command is the probe, so this row measures the drain itself.
     """
     harness.script("rx")
     queue = harness.extras["queue"]
@@ -490,11 +301,9 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
     (``YaesuCatPoller._emit_medium_observations`` /
     ``RigctldClientObservationPoller._poll_medium``), over the same scripted
     wire the bare write just used, no sleep and no mock. A
-    ``yaesu_poll_response`` / ``hamlib_response`` observation is expected —
-    §3.7's ``verified_readback`` decides whether it can admit a hazard write,
-    not this row. What must never appear is a ``global.tx_state.ptt``
-    observation under any other source: that would be a write outcome wearing
-    a readback's clothes.
+    ``yaesu_poll_response`` / ``hamlib_response`` observation is expected.
+    What must never appear is a ``global.tx_state.ptt`` observation under any
+    other source: that would be a write outcome wearing a readback's clothes.
 
     # MUTATION: in `src/rigplane/backends/yaesu_cat/observations.py`, in
     # `YaesuObservationAdapter._adapter` at :1141, change
@@ -552,115 +361,6 @@ async def test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth(
     assert "global.tx_state.ptt" not in {
         str(field.path) for field in store.snapshot().fields
     }, f"{harness.name}: our own set_ptt became a store observation"
-
-
-# ---------------------------------------------------------------------------
-# 3. Cutover rows — reserved, individually reasoned, strict
-# ---------------------------------------------------------------------------
-
-
-@every_backend()
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 7 (Icom) / row 8 (Yaesu, rigctld-client): no backend "
-    "constructs a TransmitAuthority yet, so INV-15 cannot hold. Turns green "
-    "when the admission is constructed in every connect path.",
-)
-async def test_a_backend_constructs_its_own_transmit_authority(
-    harness: TxConformanceHarness,
-) -> None:
-    """INV-15: no gated write executes without a constructed authority."""
-    authority = getattr(harness.radio, "_tx_authority", None)
-    assert isinstance(authority, TransmitAuthority)
-
-
-@every_backend()
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 7 (Icom) / row 8 (Yaesu, rigctld-client): the admission call "
-    "is not yet at the top of the gated write methods, so a plain method "
-    "call is ungated. The composed row above already proves the engine "
-    "refuses; this reserves the seat inside the backend.",
-)
-async def test_a_backend_method_call_is_refused_at_scripted_tx(
-    harness: TxConformanceHarness,
-) -> None:
-    """The ADR's row 1, driven the way every consumer drives it."""
-    harness.script("tx_cat")
-    writes_before = len(harness.writes())
-    with pytest.raises(TxRefusal):
-        await harness.hazard()
-    assert harness.writes()[writes_before:] == []
-
-
-@every_backend()
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 5 (the read primitive) + row 7/8 (the admission): a plain "
-    "method call performs no solicited read, so nothing precedes the write.",
-)
-async def test_a_backend_method_call_reads_before_it_writes_at_scripted_rx(
-    harness: TxConformanceHarness,
-) -> None:
-    """The ADR's row 2, driven the way every consumer drives it."""
-    harness.script("rx")
-    baseline = len(harness.wire())
-    await harness.hazard()
-    wire = list(harness.wire())[baseline:]
-    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
-    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
-    assert reads and writes and reads[-1] < writes[0]
-
-
-@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 8 (the admission at each backend's real write surface) and, "
-    "on Yaesu, row 11 (deleting the poller's own seat above it): the queue "
-    "drain reaches an ungated backend body. This is the D1 ingress §3.2 "
-    "item 2 names — the one a wrapping facade could never have seen.",
-)
-async def test_a_queued_hazard_write_is_refused_at_scripted_tx(
-    harness: TxConformanceHarness,
-) -> None:
-    """The ADR's row 1 again, through ``create_observation_poller``'s drain."""
-    harness.script("tx_cat")
-    queue = harness.extras["queue"]
-    assert harness.drain is not None
-
-    writes_before = len(harness.writes())
-    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-    queue.put_ordered(harness.queue_command, future=future)
-    await harness.drain()
-
-    assert future.done()
-    assert isinstance(future.exception(), TxRefusal)
-    assert harness.writes()[writes_before:] == []
-
-
-@pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
-@pytest.mark.xfail(
-    strict=True,
-    reason="row 5 (the read primitive) + row 8 (the admission) and, on "
-    "Yaesu, row 11: the drain reaches the backend body with no solicited "
-    "read in front of it.",
-)
-async def test_a_queued_hazard_write_reads_before_it_writes_at_scripted_rx(
-    harness: TxConformanceHarness,
-) -> None:
-    """The ADR's row 2 again, through the queue ingress."""
-    harness.script("rx")
-    queue = harness.extras["queue"]
-    assert harness.drain is not None
-
-    baseline = len(harness.wire())
-    queue.put_ordered(harness.queue_command)
-    await harness.drain()
-
-    wire = list(harness.wire())[baseline:]
-    reads = [i for i, entry in enumerate(wire) if harness.is_read(entry)]
-    writes = [i for i, entry in enumerate(wire) if not harness.is_read(entry)]
-    assert reads and writes and reads[-1] < writes[0]
 
 
 @every_backend()


### PR DESCRIPTION
## Summary

- remove rejected dormant-authority construction, admission, and cutover ownership from the cross-backend conformance module
- preserve all seven backend observation harnesses and their parser, provenance, readback-verification, and liveness contracts
- leave production behavior unchanged; the existing authority unit suite remains the temporary owner of the old dormant gate until MOR-2185

Linear: MOR-2192

## Scope

Exactly one test file: `tests/contracts/test_tx_authority_conformance.py`, +23/-323 (346 changed lines). No production or authority-unit file changed.

This is the required preparatory split from MOR-2185. The original minimal three-file candidate measured 982 changed lines and stopped at the explicit split gate before GREEN or commit. Landing this test-only ownership prune first reduces the subsequent source/unit/conformance inversion to an estimated 712 changed lines.

## Verification

- complete conformance module plus existing authority unit module: 159 passed
- import architecture: 5 contracts kept, 0 broken
- focused Ruff check/format and `git diff --check`: pass
- reverse mutation: CI-V exact-frame discrimination killed 5/5 selected backend rows
- reverse mutation: Yaesu positive mapping killed the Yaesu row while six control rows passed
- reverse mutation: self-write provenance killed the Yaesu provenance row

## Compatibility

Tests only. No runtime behavior, supported API, CLI, configuration, backend observation value, profile, or wire-protocol change.
