### PR TITLE
MOR-2194: correct stale TX authority claims before deletion

### DIFF
--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -989,9 +989,9 @@ label = "6.0+"
 # because an absent section and an empty one load identically — only a
 # written section records that this was decided.
 # Nothing on this radio's path reads this map today: the CI-V reply is
-# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
-# the read primitive, not the map. The section is declared so that a later
-# row consumes a stated ruling instead of an absence.
+# decoded natively in runtime/radio.py into the canonical
+# core/tx_observation.py TxStateReading contract. The section records the
+# profile ruling even though the current Icom read path does not consult it.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1602,9 +1602,9 @@ reason = "DIGI-SEL overrides preamp"
 # because an absent section and an empty one load identically — only a
 # written section records that this was decided.
 # Nothing on this radio's path reads this map today: the CI-V reply is
-# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
-# the read primitive, not the map. The section is declared so that a later
-# row consumes a stated ruling instead of an absence.
+# decoded natively in runtime/radio.py into the canonical
+# core/tx_observation.py TxStateReading contract. The section records the
+# profile ruling even though the current Icom read path does not consult it.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -1003,9 +1003,9 @@ label = "6.0+"
 # because an absent section and an empty one load identically — only a
 # written section records that this was decided.
 # Nothing on this radio's path reads this map today: the CI-V reply is
-# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
-# the read primitive, not the map. The section is declared so that a later
-# row consumes a stated ruling instead of an absence.
+# decoded natively in runtime/radio.py into the canonical
+# core/tx_observation.py TxStateReading contract. The section records the
+# profile ruling even though the current Icom read path does not consult it.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -690,9 +690,9 @@ get_tx_band_edge     = { absent = "Radioddity X6200 CI-V implementation V1.0.6, 
 # because an absent section and an empty one load identically — only a
 # written section records that this was decided.
 # Nothing on this radio's path reads this map today: the CI-V reply is
-# decoded natively in runtime/radio.py, and core/tx_authority.py is handed
-# the read primitive, not the map. The section is declared so that a later
-# row consumes a stated ruling instead of an absence.
+# decoded natively in runtime/radio.py into the canonical
+# core/tx_observation.py TxStateReading contract. The section records the
+# profile ruling even though the current Icom read path does not consult it.
 # No write-during-transmit battery was run on this radio, so no radio-side
 # refusal is claimed. Empty means "nothing measured", not "nothing refuses".
 refused_during_tx = []

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -241,16 +241,16 @@ class TxPolicy:
 
     ``refused_during_tx`` names the command families this radio refuses on
     its own while transmitting. Entries are opaque, validated strings: the
-    single source of truth for the family vocabulary is
-    ``core/tx_authority.py`` (landing separately), so this type does not
-    check membership, only shape.
+    profile type owns their measured representation and checks shape, not
+    membership in a runtime command-family vocabulary.
 
     ``tx_state_map`` is the positive transmit-state map for the radio's PTT
     read-back: it lists the raw values that mean the radio is receiving.
     Everything else — including a raw value with no entry at all — must be
-    treated as *not receiving* (§3.7 of the transmit-authority ADR). Use
-    :meth:`is_receiving` rather than testing the map directly so that rule
-    cannot be quietly inverted by a later reader.
+    treated as *not receiving*. Backend reads carry that result in the
+    canonical :class:`~rigplane.core.tx_observation.TxStateReading` contract.
+    Use :meth:`is_receiving` rather than testing the map directly so that
+    rule cannot be quietly inverted by a later reader.
     """
 
     refused_during_tx: frozenset[str] = frozenset()
@@ -268,13 +268,13 @@ class TxPolicy:
     def attribution(self, raw_value: str) -> str | None:
         """The vendor label mapped to ``raw_value``, or ``None`` if unmapped.
 
-        Display-grade only (MOR-1941, §3.7 of the transmit-authority ADR):
-        unlike :meth:`is_receiving`, this carries no fail-closed safety
-        rule — an unmapped value is simply ``None``, not a hazard answer.
-        Yaesu's three-valued ``TX;`` answer surfaces here as ``"rx"`` /
-        ``"tx_cat"`` / ``"tx_other"``; a vendor with no attribution (e.g.
-        Icom) never populates ``tx_state_map`` with more than ``"rx"``, so
-        this is honestly ``None`` for every other raw value.
+        Display-grade only (MOR-1941): unlike :meth:`is_receiving`, this
+        carries no fail-closed safety rule — an unmapped value is simply
+        ``None``, not a hazard answer. Yaesu's three-valued ``TX;`` answer
+        surfaces here as ``"rx"`` / ``"tx_cat"`` / ``"tx_other"``; a vendor
+        with no attribution (e.g. Icom) never populates ``tx_state_map`` with
+        more than ``"rx"``, so this is honestly ``None`` for every other raw
+        value.
         """
         return self.tx_state_map.get(raw_value)
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -1822,11 +1822,9 @@ def _parse_tx_policy(filename: str, raw: Any) -> TxPolicy:
     """Parse the measured per-radio ``[tx_policy]`` section (MOR-1912).
 
     ``refused_during_tx`` entries are validated for shape only — a list of
-    unique, non-empty strings — never against a fixed vocabulary. The
-    command-family vocabulary's single source of truth is
-    ``core/tx_authority.py``, which is not yet on ``main``; duplicating its
-    membership list here would create a second copy with no mechanism
-    keeping it in step with the first.
+    unique, non-empty strings — never against a fixed vocabulary. The parser
+    owns only shape and uniqueness; it does not couple profile loading to a
+    runtime command-family membership list.
     """
     if raw is None:
         return TxPolicy()

--- a/src/rigplane/validation/hardware.py
+++ b/src/rigplane/validation/hardware.py
@@ -808,15 +808,15 @@ async def _actuate_tx_ptt(
             # means ``set_ptt(True)`` did not raise) -- reporting
             # ``keyed: false`` from a measurement that never happened would
             # be a fabricated observation, and a false negative at that, not
-            # merely an unconfirmed positive. Note what this reasoning does
-            # and does not lean on: the transmit-authority ADR's rule that
-            # our own commands may source "transmitting" but never
-            # "receiving" licenses declining to say ``False`` here. It does
-            # not license claiming the value was verified, which is why the
-            # provenance tag below is not optional. So either failure falls
-            # back to trusting the accepted write (``ptt_state = True``),
-            # not to the mirror -- as fabricated a signal as a bare
-            # ``False`` would be.
+            # merely an unconfirmed positive. The canonical
+            # ``core.tx_observation.TxStateReading`` contract distinguishes
+            # an unavailable observation (``value is None``) from receiving
+            # (``False``), so declining to say ``False`` follows the read
+            # result. It does not license claiming the value was verified,
+            # which is why the provenance tag below is not optional. So
+            # either failure falls back to trusting the accepted write
+            # (``ptt_state = True``), not to the mirror -- as fabricated a
+            # signal as a bare ``False`` would be.
             #
             # A radio that does not implement ``TransmitStateReadable`` at
             # all is a distinct case: the mirror is reported (unchanged from

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -323,9 +323,9 @@ async def test_set_powerstat_off(connected_radio):
 @pytest.mark.asyncio
 async def test_set_ptt_on(connected_radio):
     """MOR-1941: ``set_ptt`` no longer self-writes the legacy mirror. Our
-    own command is a claim about the wire, never receive/transmit truth
-    (§3.7 of the transmit-authority ADR) -- the mirror is left exactly as
-    it was, and only a real read-back (``get_ptt``) may change it.
+    own command is a wire-write outcome, not a ``TxStateReading`` from
+    ``core.tx_observation``. The mirror is left exactly as it was, and only
+    a real read-back (``get_ptt``) may change it.
     """
     connected_radio._transport.write = AsyncMock()
     await connected_radio.set_ptt(True)

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -707,8 +707,8 @@ tx_state_map = { "0" = "rx", "1" = "tx_cat", "2" = "tx_other" }
 
     def test_refused_during_tx_entries_are_opaque(self, tmp_path):
         """No membership check against any family vocabulary (deliberate,
-        see the loader's `_parse_tx_policy` docstring): the vocabulary's
-        single source of truth lands separately in `core/tx_authority.py`.
+        see the loader's `_parse_tx_policy` docstring): the parser owns only
+        shape and uniqueness, so entries remain opaque profile metadata.
         """
         p = _write_toml(
             tmp_path,

--- a/tests/test_tx_policy_shipped_profiles.py
+++ b/tests/test_tx_policy_shipped_profiles.py
@@ -4,12 +4,12 @@ MOR-1912 (ADR row 3a) landed the section for the two bench-measured rigs.
 MOR-1947 settles what the remaining six declare, so each shipped rig carries
 a written ruling instead of an absence.
 
-What consumes the data is deliberately not asserted here. Only the Yaesu
-backend reads ``tx_state_map`` today (``yaesu_cat/radio.py:1083-1090``, where
-an undeclared profile falls back to the vendor ``!= "0"`` default); the Icom
-read decodes its ``1C 00`` reply natively (``runtime/radio.py``), and
-``core/tx_authority.py`` is handed the read primitive, never the map. Which
-of those paths a later row changes is that row's business, not this one's.
+Current consumption is narrow. Only the Yaesu backend reads ``tx_state_map`` today
+(``yaesu_cat/radio.py: YaesuCatRadio._interpret_ptt_token``); the Icom read
+decodes its ``1C 00`` reply natively into the canonical
+``core.tx_observation.TxStateReading`` contract
+(``runtime/radio.py: CoreRadio.read_transmit_state``). ``refused_during_tx``
+currently remains profile metadata. This test pins values, not consumers.
 
 The owner ruling, per radio:
 


### PR DESCRIPTION
## Summary

- rewrite stale live-tree comments/docstrings that claimed the dormant TX authority existed, would land later, or consumed backend read primitives
- name the canonical `core.tx_observation.TxStateReading`, backend read implementations, and profile metadata ownership truthfully
- preserve every executable AST (excluding docstrings) and every parsed TOML profile value

Linear: MOR-2194

## Why this precedes MOR-2177

Independent review correctly blocked MOR-2177 PR #2993: deleting `core/tx_authority.py` would make these live-tree claims false. The cleanup cannot be added to #2993 because that would expand it from four to fourteen files, over the ten-file hard cap. This atomic prose-only slice lands first; #2993 will then rebase and receive a fresh exact-head review.

## Scope and semantic proof

Exactly the ten authorized files, +48/-50 = 98 changed lines.

- pre-change scoped scan: 12 stale claim lines
- post-change scoped scan: zero stale claim lines
- reverse restoration of one original claim: exactly one RED match
- all six Python executable ASTs are identical after removing docstrings
- all four parsed TOML profile dictionaries are identical
- word diff is confined to comments/docstrings

## Verification

- targeted profile, loader, policy, FTX-1, and TX-actuation tests: 697 passed, 1 skipped
- final policy control: 5 passed
- import architecture: 5 contracts kept, 0 broken
- focused Ruff check/format and `git diff --check`: pass
- citation, dangling-citation, and link modes: pass

## Compatibility

No API, CLI, profile value, configuration, validation behavior, command bytes, or wire-protocol change. IC-7300/MOR-2114 ownership is untouched.
