### PR TITLE
test(MOR-2183): rename TX observation conformance

### DIFF
--- a/.github/scripts/doc-citation-baseline.txt
+++ b/.github/scripts/doc-citation-baseline.txt
@@ -639,7 +639,6 @@ docs/plans/2026-08-20-transmit-authority.md	sync.py:375-397
 docs/plans/2026-08-20-transmit-authority.md	sync.py:49-90
 docs/plans/2026-08-20-transmit-authority.md	sync.py:92-101
 docs/plans/2026-08-20-transmit-authority.md	test_audio_transport_conformance.py:65-81
-docs/plans/2026-08-20-transmit-authority.md	tests/contracts/test_tx_authority_conformance.py:109-114
 docs/plans/2026-08-20-transmit-authority.md	tests/test_rigctld_managed_tx.py:223-244
 docs/plans/2026-08-20-transmit-authority.md	tests/test_tx_safety_diagnostics.py:20
 docs/plans/2026-08-20-transmit-authority.md	transport.py:71

--- a/docs/plans/2026-08-20-transmit-authority.md
+++ b/docs/plans/2026-08-20-transmit-authority.md
@@ -619,8 +619,7 @@ admission there would gate reads that INV-1 pins to the non-write allow-list
 and would make PASS writes consult transmit truth, which INV-3 forbids
 outright. The method's own docstring (`runtime/radio.py:3948-3954`) enumerates
 only `select_receiver`, `_run_with_receiver_vfo_fallback`, `swap_vfo_ab` and
-`equalize_vfo_ab`, and the merged conformance map pins `"set_vfo_slot"`, never
-`_set_vfo_wire` (`tests/contracts/test_tx_authority_conformance.py:109-114`).
+`equalize_vfo_ab`.
 One residual follows from placing the admissions outside and is named rather
 than hidden: the cross-module profile-restore path calls `_set_vfo_wire`
 directly (`runtime/radio_state_snapshot.py:105`) and no outer-method admission
@@ -1302,8 +1301,9 @@ Designed before any component ships (rows 1–6 precede every cutover):
    no-`freq_ranges` profile), the own-transmit hold (the **B6 golden**: a
    scripted RX answer during an in-progress own CW message must not admit a
    hazard write), and decision log contents.
-3. **Conformance matrix** (`tests/contracts/test_tx_authority_conformance.py`)
-   over **every shipping backend class** with its fake link — the audio
+3. **Conformance matrix** (historical authority rows; the surviving observation
+   subset is `tests/contracts/test_tx_observation_conformance.py`) over **every
+   shipping backend class** with its fake link — the audio
    precedent (`test_audio_lifecycle_conformance.py`): a HAZARD write at
    scripted TX is refused and **no wire write occurs**; at scripted RX the
    read precedes the write on the wire; **the same rows driven through

--- a/tests/contracts/test_tx_observation_conformance.py
+++ b/tests/contracts/test_tx_observation_conformance.py
@@ -8,17 +8,19 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
+from dataclasses import fields
+from pathlib import Path
 
 import pytest
 from fake_rigctld import FakeRigctldBehavior, FakeRigctldServer
-from tx_authority_fakes import (
+from tx_observation_fakes import (
     CIV_NON_ANSWERS,
     CONFORMANCE_BACKENDS,
     NON_RECEIVING_ANSWERS,
     QUEUE_PATH_BACKENDS,
     TRANSMITTING_ANSWERS,
     TX_ANSWER_VOCABULARY,
-    TxConformanceHarness,
+    TxObservationHarness,
     build_harness,
     civ_transmit_state_reply,
 )
@@ -59,7 +61,7 @@ CIV_BACKENDS: tuple[str, ...] = (
 @pytest.fixture
 async def harness(
     request: pytest.FixtureRequest,
-) -> AsyncIterator[TxConformanceHarness]:
+) -> AsyncIterator[TxObservationHarness]:
     built = await build_harness(request.param)
     try:
         yield built
@@ -81,6 +83,29 @@ def test_backend_columns_are_an_explicit_literal() -> None:
     assert CONFORMANCE_BACKENDS == EXPECTED_BACKENDS
     assert set(CIV_BACKENDS) | {"yaesu-ftx1", "rigctld-client"} == set(
         EXPECTED_BACKENDS
+    )
+
+
+def test_observation_harness_surface_is_named_for_its_surviving_contract() -> None:
+    assert (
+        Path(__file__).name,
+        tuple(field.name for field in fields(TxObservationHarness)),
+    ) == (
+        "test_tx_observation_conformance.py",
+        (
+            "name",
+            "radio",
+            "script",
+            "read_transmit_state",
+            "wire",
+            "is_read",
+            "key",
+            "unkey",
+            "close",
+            "queue_unkey",
+            "drain",
+            "extras",
+        ),
     )
 
 
@@ -121,7 +146,7 @@ def test_scripted_answer_vocabulary_pin() -> None:
 @every_backend()
 @pytest.mark.parametrize("answer", TX_ANSWER_VOCABULARY)
 async def test_every_backend_answers_every_scripted_answer(
-    harness: TxConformanceHarness, answer: str
+    harness: TxObservationHarness, answer: str
 ) -> None:
     """Every column produces each declared answer through its real read path."""
     harness.script(answer)
@@ -137,7 +162,7 @@ async def test_every_backend_answers_every_scripted_answer(
 
 @every_backend()
 async def test_a_confirmed_rx_and_a_keyed_radio_read_their_values(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """The scripted answers are distinguishable on the wire, not merely named."""
     harness.script("rx")
@@ -151,7 +176,7 @@ async def test_a_confirmed_rx_and_a_keyed_radio_read_their_values(
 @pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
 @pytest.mark.parametrize("shape", CIV_NON_ANSWERS)
 async def test_a_civ_read_is_not_satisfied_by_an_ack_echo_or_misaddressed_frame(
-    harness: TxConformanceHarness, shape: str
+    harness: TxObservationHarness, shape: str
 ) -> None:
     """INV-13 on the CI-V family: the read is directed and exact.
 
@@ -193,7 +218,7 @@ async def test_a_civ_read_is_not_satisfied_by_an_ack_echo_or_misaddressed_frame(
 
 @pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
 async def test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """The unmapped CI-V answer is a fail-open canary, not junk.
 
@@ -217,7 +242,7 @@ async def test_the_civ_unmapped_shape_would_read_receiving_if_the_check_lapsed(
 
 @every_backend()
 async def test_an_unmapped_transmit_state_value_is_never_receiving(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """INV-9 / §3.7: RX is only ever produced by a positive mapping.
 
@@ -244,7 +269,7 @@ async def test_an_unmapped_transmit_state_value_is_never_receiving(
 @every_backend()
 @pytest.mark.parametrize("answer", NON_RECEIVING_ANSWERS)
 async def test_no_failing_answer_ever_resolves_to_receiving(
-    harness: TxConformanceHarness, answer: str
+    harness: TxObservationHarness, answer: str
 ) -> None:
     """Silence, a refusal and an unmapped value all fail closed (§3.3 table)."""
     harness.script(answer)
@@ -258,7 +283,7 @@ async def test_no_failing_answer_ever_resolves_to_receiving(
 
 @pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
 async def test_the_queue_drain_reaches_the_backend_write_method(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """The D1 ingress is real, and this file can drive it.
 
@@ -279,7 +304,7 @@ async def test_the_queue_drain_reaches_the_backend_write_method(
 
 @pytest.mark.parametrize("harness", QUEUE_PATH_BACKENDS, indirect=True)
 async def test_a_set_ptt_write_alone_produces_no_observation(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """§3.10 item 3, row 7 / INV-8: a write outcome is never evidence of RF.
 
@@ -350,7 +375,7 @@ async def test_a_set_ptt_write_alone_produces_no_observation(
 
 @pytest.mark.parametrize("harness", CIV_BACKENDS, indirect=True)
 async def test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """The same row on the CI-V columns, read off the canonical store."""
     await harness.key()
@@ -365,7 +390,7 @@ async def test_an_icom_self_write_leaves_the_store_silent_on_transmit_truth(
 
 @every_backend()
 async def test_a_backend_exposes_the_row_five_read_primitive(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """INV-13's home: one primitive, per backend, returning typed evidence.
 
@@ -380,7 +405,7 @@ async def test_a_backend_exposes_the_row_five_read_primitive(
 
 @pytest.mark.parametrize("harness", ["rigctld-client"], indirect=True)
 async def test_the_rigctld_client_primitive_marks_its_readback_unverified(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     harness.script("rx")
     reading = await harness.radio.read_transmit_state()
@@ -394,7 +419,7 @@ async def test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout() 
     Deliberately not driven through the shared ``rigctld-client`` harness:
     that harness's ``"silence"`` answer is realised as the upstream
     dropping the connection (``server.behavior.disconnect_commands``, by
-    design -- see its own comment in ``tx_authority_fakes.py`` -- to avoid a
+    design -- see its own comment in ``tx_observation_fakes.py`` -- to avoid a
     late line answering the *next* read on the shared socket), which the
     transport reports as ``RadioConnectionError``, not a timeout. That
     exercises a different exception path than the one this pin is about.
@@ -437,12 +462,12 @@ async def test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout() 
 
 @pytest.mark.parametrize("harness", ["rigctld-client"], indirect=True)
 async def test_the_vocabulary_table_does_not_claim_a_delay_it_does_not_deliver(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """MOR-1953: the vocabulary table's own words must match what its
     ``script`` function does, not what would be convenient to believe.
 
-    A prior version of the module docstring's table (``tx_authority_fakes.py``
+    A prior version of the module docstring's table (``tx_observation_fakes.py``
     top) described the rigctld-client ``silence`` answer as "delayed past
     the deadline". ``_build_rigctld_client``'s ``script`` does something
     else: it makes the upstream *drop the connection*
@@ -466,13 +491,13 @@ async def test_the_vocabulary_table_does_not_claim_a_delay_it_does_not_deliver(
     above -- deliberately not driven through this harness; see that test's
     own docstring for why.
 
-    # MUTATION: in `tests/tx_authority_fakes.py`, revert the rigctld-client
+    # MUTATION: in `tests/tx_observation_fakes.py`, revert the rigctld-client
     # `silence` cell in the module docstring's table back to "delayed past
     # the deadline" -> this row goes red on the docstring assertion below.
     """
-    import tx_authority_fakes
+    import tx_observation_fakes
 
-    doc = tx_authority_fakes.__doc__ or ""
+    doc = tx_observation_fakes.__doc__ or ""
     assert "delayed past" not in doc and "the deadline" not in doc, (
         "the vocabulary table still claims the rigctld-client 'silence' "
         "answer is a delay past the deadline -- it is not; "
@@ -541,7 +566,7 @@ async def test_the_yaesu_primitive_reports_a_malformed_reply_as_read_error() -> 
 
 @pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
 async def test_yaesu_attribution_reaches_the_evidence(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """§3.7: attribution is a per-vendor capability, carried not discarded.
 
@@ -557,7 +582,7 @@ async def test_yaesu_attribution_reaches_the_evidence(
 
 @pytest.mark.parametrize("harness", ["yaesu-ftx1"], indirect=True)
 async def test_a_yaesu_self_write_leaves_no_transmit_truth_claim_anywhere(
-    harness: TxConformanceHarness,
+    harness: TxObservationHarness,
 ) -> None:
     """The self-write launder, at its last surviving Yaesu address.
 

--- a/tests/tx_observation_fakes.py
+++ b/tests/tx_observation_fakes.py
@@ -1,8 +1,8 @@
-"""Scripted transmit-state fakes for the transmit-authority conformance matrix.
+"""Scripted transmit-state fakes for the transmit-observation conformance matrix.
 
 ADR row 4, ``docs/plans/2026-08-20-transmit-authority.md`` §3.10 item 1: the
 existing fake harnesses, extended with a **scripted transmit-state answer** so
-the hazard gate's solicited read exercises the real code path rather than a
+the observation primitive exercises the real code path rather than a
 hand-written stub of it.
 
 One vocabulary, three wires. Each backend family answers the same six scripted
@@ -26,7 +26,7 @@ reply -- see ``_build_rigctld_client``'s ``script`` function below for why
 (the socket is shared with every later read). The genuine wire-level-timeout
 path is a different scenario, covered separately by
 ``test_the_rigctld_client_primitive_reports_a_real_timeout_as_timeout`` in
-``tests/contracts/test_tx_authority_conformance.py``, which is deliberately
+``tests/contracts/test_tx_observation_conformance.py``, which is deliberately
 not driven through this harness.
 
 The CI-V column additionally scripts three shapes that must **never** satisfy a
@@ -270,7 +270,7 @@ class ScriptedCatTransport:
 
 
 @dataclass
-class TxConformanceHarness:
+class TxObservationHarness:
     """One backend column of the matrix: a real radio on a scripted wire."""
 
     name: str
@@ -279,26 +279,17 @@ class TxConformanceHarness:
     read_transmit_state: Callable[[], Awaitable[TxStateReading]]
     wire: Callable[[], Sequence[str]]
     is_read: Callable[[str], bool]
-    hazard_method: str
-    hazard_args: tuple[Any, ...]
-    hazard: Callable[[], Awaitable[None]]
     key: Callable[[], Awaitable[None]]
     unkey: Callable[[], Awaitable[None]]
     close: Callable[[], Awaitable[None]]
-    #: rigctld-client answers from an upstream cache, never the radio (§3.7).
-    verified_readback: bool = True
     #: Only the ``ObservationPollable`` backends have the queue ingress the
     #: facade design missed (the D1 lesson, §3.2 item 2).
-    queue_command: Any | None = None
     queue_unkey: Any | None = None
     drain: Callable[[], Awaitable[None]] | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
     def writes(self) -> list[str]:
         return [entry for entry in self.wire() if not self.is_read(entry)]
-
-    def reads(self) -> list[str]:
-        return [entry for entry in self.wire() if self.is_read(entry)]
 
 
 # ---------------------------------------------------------------------------
@@ -331,7 +322,7 @@ CONFORMANCE_BACKENDS: tuple[str, ...] = (
 QUEUE_PATH_BACKENDS: tuple[str, ...] = ("yaesu-ftx1", "rigctld-client")
 
 
-async def _build_lan_icom() -> TxConformanceHarness:
+async def _build_lan_icom() -> TxObservationHarness:
     transport = ScriptedLanTransport()
     radio = IcomRadio("192.168.99.1", timeout=0.2, model="IC-7610")
     radio._civ_transport = transport
@@ -353,16 +344,13 @@ async def _build_lan_icom() -> TxConformanceHarness:
         radio._civ_transport = None
         radio._ctrl_transport = None
 
-    return TxConformanceHarness(
+    return TxObservationHarness(
         name="lan-icom",
         radio=radio,
         script=lambda answer: setattr(transport, "answer", answer),
         read_transmit_state=radio.read_transmit_state,
         wire=lambda: [payload.hex() for payload in transport.civ_wire()],
         is_read=_is_hex_civ_read,
-        hazard_method="set_tuner_status",
-        hazard_args=(2,),
-        hazard=lambda: radio.set_tuner_status(2),
         key=lambda: radio.set_ptt(True),
         unkey=lambda: radio.set_ptt(False),
         close=close,
@@ -373,29 +361,26 @@ def _is_hex_civ_read(entry: str) -> bool:
     return _is_civ_transmit_state_read(bytes.fromhex(entry))
 
 
-async def _build_icom_serial(name: str) -> TxConformanceHarness:
+async def _build_icom_serial(name: str) -> TxObservationHarness:
     link = ScriptedCivLink()
     radio = _ICOM_SERIAL_CLASSES[name](device="/dev/ttyUSB0", civ_link=link)
     await radio.connect()
     link.radio_addr = radio._radio_addr
 
-    return TxConformanceHarness(
+    return TxObservationHarness(
         name=name,
         radio=radio,
         script=lambda answer: setattr(link, "answer", answer),
         read_transmit_state=radio.read_transmit_state,
         wire=lambda: [payload.hex() for payload in link.sent_frames],
         is_read=_is_hex_civ_read,
-        hazard_method="set_tuner_status",
-        hazard_args=(2,),
-        hazard=lambda: radio.set_tuner_status(2),
         key=lambda: radio.set_ptt(True),
         unkey=lambda: radio.set_ptt(False),
         close=radio.disconnect,
     )
 
 
-async def _build_yaesu() -> TxConformanceHarness:
+async def _build_yaesu() -> TxObservationHarness:
     radio = YaesuCatRadio("/dev/null", profile="ftx1")
     cat = ScriptedCatTransport(radio)
 
@@ -405,7 +390,7 @@ async def _build_yaesu() -> TxConformanceHarness:
     # not a harness-local reimplementation -- so a regression in that shared
     # predicate (the MOR-1905 inversion class) reddens this column the same
     # way the MOR-1941 review pin wanted the matrix to catch it (BLOCKED-2).
-    from rigplane.runtime._poller_types import CommandQueue, PttOff, SetTunerStatus
+    from rigplane.runtime._poller_types import CommandQueue, PttOff
 
     queue = CommandQueue()
     seen: list[Any] = []
@@ -414,30 +399,23 @@ async def _build_yaesu() -> TxConformanceHarness:
     async def close() -> None:
         return None
 
-    return TxConformanceHarness(
+    return TxObservationHarness(
         name="yaesu-ftx1",
         radio=radio,
         script=lambda answer: setattr(cat, "answer", answer),
         read_transmit_state=radio.read_transmit_state,
         wire=lambda: list(cat.wire),
         is_read=lambda entry: entry.startswith("?"),
-        # The alias chain's innermost body: ``set_tuner_status`` is a pure
-        # alias onto ``set_tuner`` (§3.2), and the queue drain calls the
-        # latter directly (``yaesu_cat/poller.py:1099-1100``).
-        hazard_method="set_tuner",
-        hazard_args=(1,),
-        hazard=lambda: radio.set_tuner(1),
         key=lambda: radio.set_ptt(True),
         unkey=lambda: radio.set_ptt(False),
         close=close,
-        queue_command=SetTunerStatus(1),
         queue_unkey=PttOff(),
         drain=poller._drain_commands,
         extras={"queue": queue, "poller": poller, "cat": cat, "observations": seen},
     )
 
 
-async def _build_rigctld_client() -> TxConformanceHarness:
+async def _build_rigctld_client() -> TxObservationHarness:
     server = FakeRigctldServer(state=FakeRigctldState(), behavior=FakeRigctldBehavior())
     await server.start()
     radio = RigctldClientRadio(host=server.host, port=server.port)
@@ -454,9 +432,9 @@ async def _build_rigctld_client() -> TxConformanceHarness:
         elif answer == "silence":
             # Realised as the upstream dropping the connection rather than a
             # bare delay: this socket is shared with every later read, and a
-            # late line arriving after the gate cancelled its ``wait_for``
+            # late line arriving after the read timed out its ``wait_for``
             # would answer the *next* read. Same fail direction either way —
-            # no answer, so the hazard gate refuses ``tx-truth-unavailable``.
+            # no answer, so the observation primitive reports no value.
             server.behavior.disconnect_commands.add("t")
         elif answer == "refusal":
             server.behavior.malformed_responses["t"] = b"RPRT -1\n"
@@ -465,7 +443,7 @@ async def _build_rigctld_client() -> TxConformanceHarness:
         else:  # pragma: no cover - guards a typo in a new row
             raise AssertionError(f"unscripted transmit-state answer {answer!r}")
 
-    from rigplane.runtime._poller_types import CommandQueue, PttOff, SelectVfo
+    from rigplane.runtime._poller_types import CommandQueue, PttOff
 
     queue = CommandQueue()
     seen: list[Any] = []
@@ -475,22 +453,16 @@ async def _build_rigctld_client() -> TxConformanceHarness:
         await radio.disconnect()
         await server.stop()
 
-    return TxConformanceHarness(
+    return TxObservationHarness(
         name="rigctld-client",
         radio=radio,
         script=script,
         read_transmit_state=radio.read_transmit_state,
         wire=lambda: list(server.commands_seen),
         is_read=lambda entry: entry.split(" ")[0] in ("t", r"\get_ptt"),
-        # External rigctld ships no tuner; VFO select is its hazard family.
-        hazard_method="set_vfo_slot",
-        hazard_args=("B",),
-        hazard=lambda: radio.set_vfo_slot("B"),
         key=lambda: radio.set_ptt(True),
         unkey=lambda: radio.set_ptt(False),
         close=close,
-        verified_readback=False,
-        queue_command=SelectVfo("B"),
         queue_unkey=PttOff(),
         drain=poller._drain_commands,
         extras={
@@ -502,7 +474,7 @@ async def _build_rigctld_client() -> TxConformanceHarness:
     )
 
 
-async def build_harness(name: str) -> TxConformanceHarness:
+async def build_harness(name: str) -> TxObservationHarness:
     """Build one backend column. Explicit dispatch, never a registry lookup."""
     if name == "lan-icom":
         return await _build_lan_icom()

--- a/tests/validation/test_hardware_ftx1.py
+++ b/tests/validation/test_hardware_ftx1.py
@@ -657,7 +657,7 @@ def test_rmvr_outcome_is_pinned() -> None:
 # Drives a REAL YaesuCatTransport + YaesuCatRadio (not a MagicMock(spec=Radio),
 # unlike the fixtures above) against a scripted serial wire, so the fix under
 # test -- YaesuCatTransport._drain_responses inspecting the drained line for
-# "?;" -- runs for real. tests/tx_authority_fakes.py: ScriptedCatTransport is
+# "?;" -- runs for real. tests/tx_observation_fakes.py: ScriptedCatTransport is
 # a pattern to copy, not an object to reuse here: it fakes the whole
 # transport and its write() never raises. The rejection below comes from
 # this fake's own scripting, independent of any shipped rigs/ftx1.toml entry


### PR DESCRIPTION
## Summary

- rename the surviving TX conformance matrix and fake harness for their observation-only responsibility
- prune authority-only harness fields while preserving all seven backend columns, read primitives, parser discrimination, queue liveness, and provenance checks
- retire the superseded ADR line citation, shrink the citation baseline, and update the FTX-1 fake-name comment

Linear: https://linear.app/rigplane/issue/MOR-2183

## TDD evidence

RED on exact base `d7d6d09a3c69066984b9673eca48a1bedb634bdc`:

- `uv run pytest tests/contracts/test_tx_authority_conformance.py::test_observation_harness_surface_is_named_for_its_surviving_contract -vv --tb=short`
- `1 failed`; the diff showed the old filename plus `hazard_method`, `hazard_args`, `hazard`, `verified_readback`, and `queue_command`

GREEN:

- `uv run pytest tests/contracts/test_tx_observation_conformance.py tests/validation/test_hardware_ftx1.py -q --tb=short` — `152 passed`
- `uv run lint-imports` — 5 contracts kept, 0 broken
- focused Ruff check and format check — clean
- doc citation normal, dangling, and link modes — clean
- citation/dangling/link growth checks against the exact base — no growth
- `git diff --check` — clean

Mutation probes (process-local and automatically restored):

- changed Yaesu readback attribution from `yaesu_poll_response` to `command_response` — provenance row failed
- changed rigctld `verified_readback` from false to true — verification row failed

## Scope and compatibility

Five logical files, `+69/-73` (142 changed lines). Production code is untouched. There is no supported API, CLI, configuration, backend observation, or wire behavior change; only internal test module/helper names change. The historical mechanism-audit snapshot remains unchanged outside this issue's inventory.

The local full suite was intentionally not run; the coordinator owns the Mac full-suite gate.
