### PR TITLE
test(MOR-2184): guard retired TX authority references

### DIFF
--- a/tests/test_tx_observation.py
+++ b/tests/test_tx_observation.py
@@ -1,7 +1,10 @@
 """Unit contracts for the canonical transmit-observation vocabulary."""
 
+import re
+import subprocess
 from dataclasses import MISSING, FrozenInstanceError, fields
 from importlib import import_module, util
+from pathlib import Path
 from typing import get_type_hints
 
 import pytest
@@ -12,11 +15,60 @@ from rigplane.core.tx_observation import (
     TxStateReading,
 )
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LIVE_ROOTS = ("src/rigplane", "tests", "rigs")
+
+
+def _retired_reference_patterns() -> tuple[bytes, ...]:
+    retired_module = "tx_" + "authority"
+    return (
+        f"core/{retired_module}.py".encode(),
+        f"core.{retired_module}".encode(),
+        ("Transmit" + "Authority").encode(),
+    )
+
+
+def _retired_references(content: bytes) -> tuple[bytes, ...]:
+    return tuple(
+        pattern for pattern in _retired_reference_patterns() if pattern in content
+    )
+
+
+def _tracked_live_paths() -> tuple[Path, ...]:
+    result = subprocess.run(
+        ("git", "ls-files", "-z", "--", *_LIVE_ROOTS),
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return tuple(
+        _REPO_ROOT / raw_path.decode()
+        for raw_path in result.stdout.split(b"\0")
+        if raw_path
+    )
+
+
+def test_live_tree_has_no_retired_transmit_authority_references() -> None:
+    violations = [
+        f"{path.relative_to(_REPO_ROOT)}: {pattern.decode()}"
+        for path in _tracked_live_paths()
+        for pattern in _retired_references(path.read_bytes())
+    ]
+    assert violations == [], "retired TX authority references found:\n" + "\n".join(
+        violations
+    )
+
+
+def test_retired_reference_guard_allows_observation_and_generic_authority() -> None:
+    valid_references = b"authority tx_observation rigplane.core.tx_observation"
+    assert _retired_references(valid_references) == ()
+
 
 def test_retired_tx_authority_module_does_not_resolve() -> None:
-    assert util.find_spec("rigplane.core.tx_authority") is None
-    with pytest.raises(ModuleNotFoundError, match="rigplane.core.tx_authority"):
-        import_module("rigplane.core.tx_authority")
+    retired_module = ".".join(("rigplane", "core", "tx_" + "authority"))
+    assert util.find_spec(retired_module) is None
+    with pytest.raises(ModuleNotFoundError, match=re.escape(retired_module)):
+        import_module(retired_module)
 
 
 def test_tx_observation_contract_is_pinned() -> None:


### PR DESCRIPTION
## Summary

- add a tracked-file guard over `src/rigplane`, `tests`, and `rigs` for the three retired authority reference forms
- construct retired tokens at runtime so the guard scans its own file without an allowlist or self-exclusion
- preserve the module-absence contract while allowing generic authority wording and canonical `tx_observation` references

Linear: https://linear.app/morozsm/issue/MOR-2184/mor-216710-remove-stale-live-tree-references-to-the-retired-authority

## TDD and mutation evidence

The test was authored on the requested base `5fa42d4e49392906872983ca129c9f5c389c1bd8`, then rebased without conflict onto current `main` `8355bd34acf016eef9b735510e482e69eb77c03d` before push.

Each forbidden pattern was injected independently into the tracked test file, the focused guard was run, and the probe was restored:

- retired slash-path form — RED, reported the test path and exact token
- retired dotted-module form — RED, reported the test path and exact token
- retired class-name form — RED, reported the test path and exact token

The final tree contains none of the probes. Historical references in the superseded ADR, accepted replacement ADR, and accepted audit/removal record are intentionally outside the scanned live roots.

## Verification

Post-rebase:

- `uv run pytest tests/test_tx_observation.py -q --tb=short` — 4 passed
- focused Ruff check and format check — clean
- `uv run lint-imports` — 5 contracts kept, 0 broken
- doc citation normal, dangling, and link modes — clean
- `git diff --check` — clean

## Scope and compatibility

One test file, `+55/-3`. No production code, supported API, CLI, configuration, backend behavior, profile value, or wire behavior changes. The local full suite was intentionally not run; the coordinator owns the Mac full-suite gate.
