### PR TITLE
MOR-2202: add managed TX abort fence

### DIFF
--- a/src/rigplane/runtime/managed_tx_fence.py
+++ b/src/rigplane/runtime/managed_tx_fence.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from inspect import isawaitable
+
+
+Cancellation = Callable[[], Awaitable[None] | None]
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class TxAbortToken:
+    epoch: int
+    _fence: object = field(repr=False, compare=False)
+    _number: int = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class TxAbortFailure:
+    token: TxAbortToken
+    error: BaseException
+
+
+@dataclass(frozen=True, slots=True)
+class TxAbortResult:
+    epoch: int
+    failures: tuple[TxAbortFailure, ...]
+
+
+class TxAbortFence:
+    def __init__(self) -> None:
+        self._epoch = 0
+        self._next_number = 0
+        self._cancellations: dict[TxAbortToken, Cancellation] = {}
+
+    @property
+    def epoch(self) -> int:
+        return self._epoch
+
+    def issue(self) -> TxAbortToken:
+        token = TxAbortToken(self._epoch, self, self._next_number)
+        self._next_number += 1
+        return token
+
+    def is_current(self, token: TxAbortToken) -> bool:
+        return token._fence is self and token.epoch == self._epoch
+
+    def register(self, token: TxAbortToken, cancellation: Cancellation) -> None:
+        if not self.is_current(token):
+            raise ValueError("cancellation requires a current token")
+        if token in self._cancellations:
+            raise ValueError("token is already registered")
+        self._cancellations[token] = cancellation
+
+    def remove(self, token: TxAbortToken) -> bool:
+        return self._cancellations.pop(token, None) is not None
+
+    async def force_off(self) -> TxAbortResult:
+        self._epoch += 1
+        cancellations = tuple(self._cancellations.items())
+        self._cancellations.clear()
+        failures: list[TxAbortFailure] = []
+        for token, cancellation in cancellations:
+            try:
+                result = cancellation()
+                if isawaitable(result):
+                    await result
+            except BaseException as error:
+                failures.append(TxAbortFailure(token, error))
+        return TxAbortResult(self._epoch, tuple(failures))

--- a/tests/test_managed_tx_fence.py
+++ b/tests/test_managed_tx_fence.py
@@ -1,0 +1,127 @@
+import asyncio
+
+import pytest
+
+from rigplane.runtime.managed_tx_fence import TxAbortFence, TxAbortFailure
+
+
+def test_token_is_current_only_for_its_fence_epoch() -> None:
+    fence = TxAbortFence()
+    token = fence.issue()
+
+    assert fence.is_current(token)
+
+
+@pytest.mark.asyncio
+async def test_force_off_advances_before_every_registered_cancellation() -> None:
+    fence = TxAbortFence()
+    old = fence.issue()
+    seen: list[bool] = []
+
+    async def cancel() -> None:
+        seen.append(fence.is_current(old))
+
+    fence.register(old, cancel)
+
+    result = await fence.force_off()
+
+    assert result.epoch == 1
+    assert result.failures == ()
+    assert seen == [False]
+    assert not fence.is_current(old)
+
+
+@pytest.mark.asyncio
+async def test_force_off_collects_sync_and_async_failures_and_continues() -> None:
+    fence = TxAbortFence()
+    first, second, third = fence.issue(), fence.issue(), fence.issue()
+    calls: list[str] = []
+
+    def sync_failure() -> None:
+        calls.append("sync")
+        raise RuntimeError("sync failure")
+
+    async def async_failure() -> None:
+        calls.append("async")
+        raise ValueError("async failure")
+
+    def succeeds() -> None:
+        calls.append("success")
+
+    fence.register(first, sync_failure)
+    fence.register(second, async_failure)
+    fence.register(third, succeeds)
+
+    result = await fence.force_off()
+
+    assert calls == ["sync", "async", "success"]
+    assert [type(failure) for failure in result.failures] == [
+        TxAbortFailure,
+        TxAbortFailure,
+    ]
+    assert [type(failure.error) for failure in result.failures] == [
+        RuntimeError,
+        ValueError,
+    ]
+    assert [failure.token for failure in result.failures] == [first, second]
+
+
+def test_registration_and_removal_are_token_specific_and_deterministic() -> None:
+    fence = TxAbortFence()
+    token = fence.issue()
+
+    fence.register(token, lambda: None)
+    with pytest.raises(ValueError, match="already registered"):
+        fence.register(token, lambda: None)
+    assert fence.remove(token) is True
+    assert fence.remove(token) is False
+
+
+@pytest.mark.asyncio
+async def test_fenced_work_is_cancelled_once_and_repeated_force_off_is_local_noop() -> (
+    None
+):
+    fence = TxAbortFence()
+    token = fence.issue()
+    calls: list[int] = []
+    fence.register(token, lambda: calls.append(1))
+
+    first = await fence.force_off()
+    second = await fence.force_off()
+
+    assert first.epoch == 1
+    assert second.epoch == 2
+    assert calls == [1]
+    assert first.failures == second.failures == ()
+
+
+@pytest.mark.asyncio
+async def test_late_old_token_completion_cannot_become_current() -> None:
+    fence = TxAbortFence()
+    token = fence.issue()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    completion_is_current: list[bool] = []
+
+    async def work() -> None:
+        started.set()
+        await release.wait()
+        completion_is_current.append(fence.is_current(token))
+
+    task = asyncio.create_task(work())
+    await started.wait()
+    await fence.force_off()
+    release.set()
+    await task
+
+    assert completion_is_current == [False]
+
+
+def test_another_fence_cannot_accept_this_fences_token() -> None:
+    fence = TxAbortFence()
+    another = TxAbortFence()
+    token = fence.issue()
+
+    assert another.is_current(token) is False
+    with pytest.raises(ValueError, match="current token"):
+        another.register(token, lambda: None)


### PR DESCRIPTION
## Summary

- add a standalone runtime epoch/token registry for locally cancellable managed TX work
- advance the sole fence before registered cancellations, collect callback failures, and make late tokens stale
- pin deterministic registration/removal and repeated ForceOff behavior with focused tests

## Scope and compatibility

This is additive private runtime support only. It changes no public API, provider I/O, wire bytes, Web/API assembly, state reducer, scheduler, timer, or MOR-2161 command path. PTT_UP behavior is intentionally absent; this module is only the global ForceOff mechanism.

Linear: https://linear.app/morozsm/issue/MOR-2202/mor-21663-implement-the-sole-runtime-tx-abort-fence

## Validation

- RED: `uv run pytest tests/test_managed_tx_fence.py -q` failed at collection before implementation with `ModuleNotFoundError: rigplane.runtime.managed_tx_fence`.
- GREEN: `uv run pytest tests/test_managed_tx_fence.py -q` — 7 passed.
- `uv run ruff check src/rigplane/runtime/managed_tx_fence.py tests/test_managed_tx_fence.py`
- `uv run ruff format --check src/rigplane/runtime/managed_tx_fence.py tests/test_managed_tx_fence.py`
- `uv run lint-imports`
- `.github/scripts/check-doc-citations.sh`
- `.github/scripts/check-doc-citations.sh --check-links`
- `git diff --check`

The tests mutation-pin epoch advance before callbacks, old-token invalidation, continued sync/async callback execution after failures, duplicate registration/removal, late completion, and repeated ForceOff.