### PR TITLE
feat(MOR-2196): persist managed TX software TOT config

### DIFF
--- a/src/rigplane/runtime/managed_tx_config.py
+++ b/src/rigplane/runtime/managed_tx_config.py
@@ -1,0 +1,98 @@
+"""Durable configuration for the managed-transmit software time-out."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MANAGED_TX_TOT_SECONDS = 180.0
+_FORMAT_VERSION = 1
+_Replace = Callable[[Path, Path], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxTotConfig:
+    """The one app-level software-TOT input supplied to later authority wiring."""
+
+    timeout_seconds: float | None
+
+
+class ManagedTxTotConfigStore:
+    """Load and atomically replace only the app-level software-TOT setting."""
+
+    def __init__(self, path: Path, *, replace: _Replace | None = None) -> None:
+        self._path = path
+        self._replace = replace or os.replace
+        self._config = self._load()
+
+    @property
+    def config(self) -> ManagedTxTotConfig:
+        return self._config
+
+    def set_timeout_seconds(self, value: object) -> ManagedTxTotConfig:
+        config = ManagedTxTotConfig(_normalize_timeout_seconds(value))
+        self._persist(config)
+        self._config = config
+        return config
+
+    def _load(self) -> ManagedTxTotConfig:
+        try:
+            document = json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return ManagedTxTotConfig(DEFAULT_MANAGED_TX_TOT_SECONDS)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ValueError("managed TX TOT config is invalid") from exc
+        return _parse_document(document)
+
+    def _persist(self, config: ManagedTxTotConfig) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self._path.with_name(f".{self._path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            with temporary.open("x", encoding="utf-8") as stream:
+                json.dump(_document_for(config), stream, sort_keys=True)
+                stream.flush()
+                os.fsync(stream.fileno())
+            self._replace(temporary, self._path)
+        except Exception:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+
+
+def _parse_document(document: Any) -> ManagedTxTotConfig:
+    if not isinstance(document, dict) or set(document) != {
+        "software_tot_seconds",
+        "version",
+    }:
+        raise ValueError("managed TX TOT config is invalid")
+    version = document["version"]
+    if type(version) is not int or version != _FORMAT_VERSION:
+        raise ValueError("managed TX TOT config is invalid")
+    try:
+        timeout_seconds = _normalize_timeout_seconds(document["software_tot_seconds"])
+    except ValueError as exc:
+        raise ValueError("managed TX TOT config is invalid") from exc
+    return ManagedTxTotConfig(timeout_seconds)
+
+
+def _document_for(config: ManagedTxTotConfig) -> dict[str, float | int | None]:
+    return {"version": _FORMAT_VERSION, "software_tot_seconds": config.timeout_seconds}
+
+
+def _normalize_timeout_seconds(value: object) -> float | None:
+    if type(value) not in (int, float):
+        raise ValueError("timeout seconds must be finite-positive or zero")
+    seconds = float(value)
+    if seconds == 0:
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        raise ValueError("timeout seconds must be finite-positive or zero")
+    return seconds

--- a/src/rigplane/runtime/managed_tx_config.py
+++ b/src/rigplane/runtime/managed_tx_config.py
@@ -88,6 +88,8 @@ def _document_for(config: ManagedTxTotConfig) -> dict[str, float | int | None]:
 
 
 def _normalize_timeout_seconds(value: object) -> float | None:
+    if value is None:
+        return None
     if type(value) not in (int, float):
         raise ValueError("timeout seconds must be finite-positive or zero")
     seconds = float(value)

--- a/tests/test_managed_tx_config.py
+++ b/tests/test_managed_tx_config.py
@@ -30,6 +30,20 @@ def test_zero_normalizes_to_disabled_and_persists_only_config(tmp_path: Path) ->
         "software_tot_seconds": None,
         "version": 1,
     }
+    assert ManagedTxTotConfigStore(path).config == ManagedTxTotConfig(None)
+
+
+def test_none_disables_directly(tmp_path: Path) -> None:
+    store = ManagedTxTotConfigStore(tmp_path / "managed-tx.json")
+
+    assert store.set_timeout_seconds(None) == ManagedTxTotConfig(None)
+
+
+def test_preexisting_canonical_null_document_disables(tmp_path: Path) -> None:
+    path = tmp_path / "managed-tx.json"
+    path.write_text('{"software_tot_seconds": null, "version": 1}', encoding="utf-8")
+
+    assert ManagedTxTotConfigStore(path).config == ManagedTxTotConfig(None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_managed_tx_config.py
+++ b/tests/test_managed_tx_config.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from rigplane.runtime.managed_tx_config import (
+    DEFAULT_MANAGED_TX_TOT_SECONDS,
+    ManagedTxTotConfig,
+    ManagedTxTotConfigStore,
+)
+
+
+def test_missing_config_defaults_to_180_seconds(tmp_path: Path) -> None:
+    store = ManagedTxTotConfigStore(tmp_path / "managed-tx.json")
+
+    assert store.config == ManagedTxTotConfig(DEFAULT_MANAGED_TX_TOT_SECONDS)
+    assert store.config.timeout_seconds == 180.0
+
+
+def test_zero_normalizes_to_disabled_and_persists_only_config(tmp_path: Path) -> None:
+    path = tmp_path / "managed-tx.json"
+    store = ManagedTxTotConfigStore(path)
+
+    assert store.set_timeout_seconds(0) == ManagedTxTotConfig(None)
+    assert store.config == ManagedTxTotConfig(None)
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "software_tot_seconds": None,
+        "version": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [True, "180", -1, -0.5, math.inf, -math.inf, math.nan, object()],
+)
+def test_invalid_value_does_not_change_active_config(
+    tmp_path: Path, invalid: object
+) -> None:
+    store = ManagedTxTotConfigStore(tmp_path / "managed-tx.json")
+    previous = store.set_timeout_seconds(12.5)
+
+    with pytest.raises(ValueError, match="finite-positive"):
+        store.set_timeout_seconds(invalid)
+
+    assert store.config == previous
+
+
+def test_positive_int_and_float_values_are_stored_as_seconds(tmp_path: Path) -> None:
+    store = ManagedTxTotConfigStore(tmp_path / "managed-tx.json")
+
+    assert store.set_timeout_seconds(12) == ManagedTxTotConfig(12.0)
+    assert store.set_timeout_seconds(12.5) == ManagedTxTotConfig(12.5)
+
+
+def test_failed_persistence_leaves_live_config_unchanged(tmp_path: Path) -> None:
+    def fail_replace(_source: Path, _destination: Path) -> None:
+        raise OSError("disk failed")
+
+    store = ManagedTxTotConfigStore(tmp_path / "managed-tx.json", replace=fail_replace)
+    previous = store.config
+
+    with pytest.raises(OSError, match="disk failed"):
+        store.set_timeout_seconds(45)
+
+    assert store.config == previous
+
+
+def test_restart_restores_configuration_but_no_tx_intent_or_release_debt(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "managed-tx.json"
+    first = ManagedTxTotConfigStore(path)
+    first.set_timeout_seconds(45)
+
+    restarted = ManagedTxTotConfigStore(path)
+
+    assert restarted.config == ManagedTxTotConfig(45.0)
+    assert set(json.loads(path.read_text(encoding="utf-8"))) == {
+        "software_tot_seconds",
+        "version",
+    }
+
+
+@pytest.mark.parametrize(
+    "contents",
+    ["not json", '{"software_tot_seconds": true, "version": 1}', "[]"],
+)
+def test_malformed_durable_config_fails_closed_on_load(
+    tmp_path: Path, contents: str
+) -> None:
+    path = tmp_path / "managed-tx.json"
+    path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="managed TX TOT config is invalid"):
+        ManagedTxTotConfigStore(path)


### PR DESCRIPTION
## Summary
- add the injected-path private runtime store for the managed-TX software TOT
- default absent configuration to 180 seconds; normalize numeric zero and direct null to disabled
- atomically persist validated config before activation and fail closed on malformed durable data

## Scope and compatibility
Additive private runtime configuration only. No public API, Web/API endpoint, scheduler, native-radio/profile TOT, provider bytes, TX intent/debt persistence, or MOR-2161 path is changed.

## Verification
- `uv run pytest tests/test_managed_tx_config.py -q --tb=short` (18 passed)
- `uv run ruff check src/rigplane/runtime/managed_tx_config.py tests/test_managed_tx_config.py`
- `uv run ruff format --check src/rigplane/runtime/managed_tx_config.py tests/test_managed_tx_config.py`
- `uv run lint-imports`
- `.github/scripts/check-doc-citations.sh`, `--check-links`, and `--check-dangling`
- citation, link, and dangling growth checks against `origin/main` at `79ceadd8`
- `git diff --check`

## TDD evidence
Initial RED: focused test collection failed with `ModuleNotFoundError: rigplane.runtime.managed_tx_config` before implementation. Review-fix RED: the new null controls produced 3 failures (direct null, persisted-zero restart, and pre-existing canonical null document). GREEN: all 18 focused tests pass, including default, zero/null normalization and round-trip, bool/nonfinite/negative rejection, write failure, restart, and persisted-schema controls.

Linear: MOR-2196