### PR TITLE
MOR-2195: define managed TX state reducer

### DIFF
--- a/src/rigplane/runtime/managed_tx_state.py
+++ b/src/rigplane/runtime/managed_tx_state.py
@@ -1,0 +1,326 @@
+"""Pure state transitions for managed transmit intent and release debt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from typing import TypeAlias, assert_never
+
+
+class ManagedTxIntentKind(StrEnum):
+    RX = "rx"
+    PTT = "ptt"
+    TRANSMIT = "transmit"
+
+
+class ManagedTxOutcome(StrEnum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    APPLIED = "applied"
+    STALE = "stale"
+
+
+class ReleasePlan(StrEnum):
+    PTT_RELEASE = "ptt_release"
+    FORCE_RELEASE = "force_release"
+
+
+class ActuationOperation(StrEnum):
+    PTT_ON = "ptt_on"
+    TRANSMIT_ON = "transmit_on"
+    FORCE_RECEIVE = "force_receive"
+
+
+class AbortOperation(StrEnum):
+    STOP_CW = "stop_cw"
+    STOP_TUNE = "stop_tune"
+
+
+class ActuationResult(StrEnum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxIntent:
+    kind: ManagedTxIntentKind
+    owner_token: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind is ManagedTxIntentKind.PTT and not self.owner_token:
+            raise ValueError("PTT intent requires an owner token")
+        if self.kind is not ManagedTxIntentKind.PTT and self.owner_token is not None:
+            raise ValueError("only PTT intent may have an owner token")
+
+    @classmethod
+    def rx(cls) -> ManagedTxIntent:
+        return cls(ManagedTxIntentKind.RX)
+
+    @classmethod
+    def ptt(cls, owner_token: str) -> ManagedTxIntent:
+        return cls(ManagedTxIntentKind.PTT, owner_token)
+
+
+@dataclass(frozen=True, slots=True)
+class EffectToken:
+    provider_generation: int
+    effect_epoch: int
+    attempt_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxEffect:
+    operation: ActuationOperation
+    token: EffectToken
+
+
+@dataclass(frozen=True, slots=True)
+class ActuationDiagnostic:
+    operation: ActuationOperation
+    result: ActuationResult
+    attempt_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class AbortError:
+    operation: AbortOperation
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxState:
+    intent: ManagedTxIntent = field(default_factory=ManagedTxIntent.rx)
+    release_plan: ReleasePlan | None = None
+    tx_started_at_monotonic: float | None = None
+    tot_deadline_monotonic: float | None = None
+    effect_epoch: int = 0
+    pending_effect: ManagedTxEffect | None = None
+    last_actuation: ActuationDiagnostic | None = None
+    last_error: str | None = None
+    abort_errors: tuple[AbortError, ...] = ()
+
+    def __post_init__(self) -> None:
+        active = self.intent.kind is not ManagedTxIntentKind.RX
+        has_times = (
+            self.tx_started_at_monotonic is not None
+            and self.tot_deadline_monotonic is not None
+        )
+        if active and (self.release_plan is None or not has_times):
+            raise ValueError("active intent requires release debt and TOT times")
+        if not active and has_times:
+            raise ValueError("RX state cannot retain TOT times")
+
+    @property
+    def release_required(self) -> bool:
+        return self.release_plan is not None
+
+
+@dataclass(frozen=True, slots=True)
+class PttDown:
+    owner_token: str
+    provider_generation: int
+    attempt_id: str
+    tx_started_at_monotonic: float
+    tot_deadline_monotonic: float
+
+
+@dataclass(frozen=True, slots=True)
+class PttUp:
+    owner_token: str
+    provider_generation: int
+    attempt_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransmitOn:
+    provider_generation: int
+    attempt_id: str
+    tx_started_at_monotonic: float
+    tot_deadline_monotonic: float
+
+
+@dataclass(frozen=True, slots=True)
+class ForceOff:
+    provider_generation: int | None
+    attempt_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ActuationSettled:
+    token: EffectToken
+    operation: ActuationOperation
+    result: ActuationResult
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AbortFailed:
+    operation: AbortOperation
+    error: str
+
+
+ManagedTxEvent: TypeAlias = (
+    PttDown | PttUp | TransmitOn | ForceOff | ActuationSettled | AbortFailed
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxTransition:
+    state: ManagedTxState
+    outcome: ManagedTxOutcome
+    effects: tuple[ManagedTxEffect, ...] = ()
+
+
+def _token(
+    state: ManagedTxState,
+    provider_generation: int,
+    attempt_id: str,
+    effect_epoch: int | None = None,
+) -> EffectToken:
+    return EffectToken(
+        provider_generation,
+        state.effect_epoch if effect_epoch is None else effect_epoch,
+        attempt_id,
+    )
+
+
+def _on(
+    state: ManagedTxState,
+    event: PttDown | TransmitOn,
+    intent: ManagedTxIntent,
+    operation: ActuationOperation,
+) -> ManagedTxTransition:
+    token = _token(state, event.provider_generation, event.attempt_id)
+    effect = ManagedTxEffect(operation, token)
+    next_state = replace(
+        state,
+        intent=intent,
+        release_plan=ReleasePlan.PTT_RELEASE,
+        tx_started_at_monotonic=event.tx_started_at_monotonic,
+        tot_deadline_monotonic=event.tot_deadline_monotonic,
+        pending_effect=effect,
+        last_error=None,
+    )
+    return ManagedTxTransition(next_state, ManagedTxOutcome.ACCEPTED, (effect,))
+
+
+def _settle(state: ManagedTxState, event: ActuationSettled) -> ManagedTxTransition:
+    pending = state.pending_effect
+    if (
+        pending is None
+        or event.token != pending.token
+        or event.operation is not pending.operation
+    ):
+        return ManagedTxTransition(state, ManagedTxOutcome.STALE)
+
+    diagnostic = ActuationDiagnostic(
+        event.operation, event.result, event.token.attempt_id
+    )
+    settled = replace(state, pending_effect=None, last_actuation=diagnostic)
+    if event.operation is ActuationOperation.FORCE_RECEIVE:
+        settled = replace(
+            settled,
+            release_plan=(
+                None
+                if event.result is ActuationResult.ACCEPTED
+                else settled.release_plan
+            ),
+            last_error=(
+                None
+                if event.result is ActuationResult.ACCEPTED
+                else event.error or event.result.value
+            ),
+        )
+    elif event.result is ActuationResult.ACCEPTED:
+        settled = replace(settled, last_error=None)
+    else:
+        settled = replace(
+            settled,
+            intent=ManagedTxIntent.rx(),
+            release_plan=ReleasePlan.FORCE_RELEASE,
+            tx_started_at_monotonic=None,
+            tot_deadline_monotonic=None,
+            last_error=event.error or event.result.value,
+        )
+    return ManagedTxTransition(settled, ManagedTxOutcome.APPLIED)
+
+
+def reduce_managed_tx(
+    state: ManagedTxState, event: ManagedTxEvent
+) -> ManagedTxTransition:
+    """Return the next immutable state and its declarative effect plan."""
+    if isinstance(event, PttDown):
+        if state.intent == ManagedTxIntent.ptt(event.owner_token):
+            return ManagedTxTransition(state, ManagedTxOutcome.ACCEPTED)
+        if state.intent.kind is not ManagedTxIntentKind.RX or state.release_required:
+            return ManagedTxTransition(state, ManagedTxOutcome.REJECTED)
+        return _on(
+            state,
+            event,
+            ManagedTxIntent.ptt(event.owner_token),
+            ActuationOperation.PTT_ON,
+        )
+
+    if isinstance(event, TransmitOn):
+        if state.intent.kind is ManagedTxIntentKind.TRANSMIT:
+            return ManagedTxTransition(state, ManagedTxOutcome.ACCEPTED)
+        if state.intent.kind is not ManagedTxIntentKind.RX or state.release_required:
+            return ManagedTxTransition(state, ManagedTxOutcome.REJECTED)
+        return _on(
+            state,
+            event,
+            ManagedTxIntent(ManagedTxIntentKind.TRANSMIT),
+            ActuationOperation.TRANSMIT_ON,
+        )
+
+    if isinstance(event, PttUp):
+        if state.intent != ManagedTxIntent.ptt(event.owner_token):
+            return ManagedTxTransition(state, ManagedTxOutcome.REJECTED)
+        effect = ManagedTxEffect(
+            ActuationOperation.FORCE_RECEIVE,
+            _token(state, event.provider_generation, event.attempt_id),
+        )
+        next_state = replace(
+            state,
+            intent=ManagedTxIntent.rx(),
+            tx_started_at_monotonic=None,
+            tot_deadline_monotonic=None,
+            pending_effect=effect,
+        )
+        return ManagedTxTransition(next_state, ManagedTxOutcome.ACCEPTED, (effect,))
+
+    if isinstance(event, ForceOff):
+        epoch = state.effect_epoch + 1
+        effect = (
+            None
+            if event.provider_generation is None
+            else ManagedTxEffect(
+                ActuationOperation.FORCE_RECEIVE,
+                _token(state, event.provider_generation, event.attempt_id, epoch),
+            )
+        )
+        next_state = replace(
+            state,
+            intent=ManagedTxIntent.rx(),
+            release_plan=ReleasePlan.FORCE_RELEASE,
+            tx_started_at_monotonic=None,
+            tot_deadline_monotonic=None,
+            effect_epoch=epoch,
+            pending_effect=effect,
+            abort_errors=(),
+        )
+        effects = () if effect is None else (effect,)
+        return ManagedTxTransition(next_state, ManagedTxOutcome.ACCEPTED, effects)
+
+    if isinstance(event, ActuationSettled):
+        return _settle(state, event)
+
+    if isinstance(event, AbortFailed):
+        error = AbortError(event.operation, event.error)
+        return ManagedTxTransition(
+            replace(state, abort_errors=(*state.abort_errors, error)),
+            ManagedTxOutcome.APPLIED,
+        )
+
+    assert_never(event)

--- a/src/rigplane/runtime/managed_tx_state.py
+++ b/src/rigplane/runtime/managed_tx_state.py
@@ -102,13 +102,14 @@ class ManagedTxState:
 
     def __post_init__(self) -> None:
         active = self.intent.kind is not ManagedTxIntentKind.RX
-        has_times = (
+        if active and (
+            self.release_plan is None or self.tx_started_at_monotonic is None
+        ):
+            raise ValueError("active intent requires release debt and a start time")
+        if not active and (
             self.tx_started_at_monotonic is not None
-            and self.tot_deadline_monotonic is not None
-        )
-        if active and (self.release_plan is None or not has_times):
-            raise ValueError("active intent requires release debt and TOT times")
-        if not active and has_times:
+            or self.tot_deadline_monotonic is not None
+        ):
             raise ValueError("RX state cannot retain TOT times")
 
     @property
@@ -122,7 +123,7 @@ class PttDown:
     provider_generation: int
     attempt_id: str
     tx_started_at_monotonic: float
-    tot_deadline_monotonic: float
+    tot_deadline_monotonic: float | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,7 +138,7 @@ class TransmitOn:
     provider_generation: int
     attempt_id: str
     tx_started_at_monotonic: float
-    tot_deadline_monotonic: float
+    tot_deadline_monotonic: float | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,6 +157,7 @@ class ActuationSettled:
 
 @dataclass(frozen=True, slots=True)
 class AbortFailed:
+    token: EffectToken
     operation: AbortOperation
     error: str
 
@@ -317,6 +319,8 @@ def reduce_managed_tx(
         return _settle(state, event)
 
     if isinstance(event, AbortFailed):
+        if event.token.effect_epoch != state.effect_epoch:
+            return ManagedTxTransition(state, ManagedTxOutcome.STALE)
         error = AbortError(event.operation, event.error)
         return ManagedTxTransition(
             replace(state, abort_errors=(*state.abort_errors, error)),

--- a/tests/test_managed_tx_state.py
+++ b/tests/test_managed_tx_state.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import fields, replace
 from typing import get_args
 
@@ -49,10 +47,10 @@ def settle(
 ):
     pending = state.pending_effect
     assert pending is not None
-    return reduce_managed_tx(
-        state,
-        ActuationSettled(pending.token, operation or pending.operation, result, error),
+    event = ActuationSettled(
+        pending.token, operation or pending.operation, result, error
     )
+    return reduce_managed_tx(state, event)
 
 
 def test_state_vocabulary_cannot_encode_invalid_authority_or_debt() -> None:
@@ -66,16 +64,26 @@ def test_state_vocabulary_cannot_encode_invalid_authority_or_debt() -> None:
     assert "release_required" not in {field.name for field in fields(ManagedTxState)}
 
 
+@pytest.mark.parametrize(
+    "event", [PttDown("web-1", 7, "ptt", 10, None), TransmitOn(7, "tx", 10, None)]
+)
+def test_active_intent_allows_disabled_tot_deadline(event: ManagedTxEvent) -> None:
+    state = reduce_managed_tx(ManagedTxState(), event).state
+    assert state.tx_started_at_monotonic == 10
+    assert state.tot_deadline_monotonic is None
+
+
+@pytest.mark.parametrize(
+    "timing", [{"tx_started_at_monotonic": 10}, {"tot_deadline_monotonic": 190}]
+)
+def test_rx_rejects_either_retained_timing_field(timing: dict[str, float]) -> None:
+    with pytest.raises(ValueError):
+        ManagedTxState(**timing)
+
+
 def test_observation_is_structurally_not_an_authority_event() -> None:
     assert not hasattr(subject, "ObservedPtt")
-    assert set(get_args(ManagedTxEvent)) == {
-        PttDown,
-        PttUp,
-        TransmitOn,
-        ForceOff,
-        ActuationSettled,
-        AbortFailed,
-    }
+    assert len(get_args(ManagedTxEvent)) == 6
     assert "IGNORED" not in ManagedTxOutcome.__members__
 
 
@@ -105,14 +113,12 @@ def test_incompatible_on_is_rejected_while_ptt_active(event: ManagedTxEvent) -> 
 
 
 def test_idempotent_on_preserves_tot_debt_pending_effect_and_diagnostics() -> None:
-    for event in (ptt_down(attempt="again"), TransmitOn(7, "again", 90, 270)):
-        first = (
-            keyed()
-            if isinstance(event, PttDown)
-            else reduce_managed_tx(
-                ManagedTxState(), TransmitOn(7, "first", 10, 190)
-            ).state
-        )
+    starts = (
+        keyed(),
+        reduce_managed_tx(ManagedTxState(), TransmitOn(7, "first", 10, 190)).state,
+    )
+    repeats = (ptt_down(attempt="again"), TransmitOn(7, "again", 90, 270))
+    for first, event in zip(starts, repeats, strict=True):
         marked = replace(first, last_error="old")
         result = reduce_managed_tx(marked, event)
         assert result.outcome is ManagedTxOutcome.ACCEPTED
@@ -120,20 +126,11 @@ def test_idempotent_on_preserves_tot_debt_pending_effect_and_diagnostics() -> No
         assert result.effects == ()
 
 
-@pytest.mark.parametrize(
-    "state,owner",
-    [
-        (ManagedTxState(), "web-1"),
-        (keyed(), "web-2"),
-        (
-            reduce_managed_tx(ManagedTxState(), TransmitOn(7, "tx", 10, 190)).state,
-            "web-1",
-        ),
-    ],
-)
-def test_ptt_up_requires_the_current_ptt_owner(
-    state: ManagedTxState, owner: str
-) -> None:
+@pytest.mark.parametrize("kind", ["rx", "ptt", "transmit"])
+def test_ptt_up_requires_the_current_ptt_owner(kind: str) -> None:
+    transmit = reduce_managed_tx(ManagedTxState(), TransmitOn(7, "tx", 10, 190)).state
+    state = {"rx": ManagedTxState(), "ptt": keyed(), "transmit": transmit}[kind]
+    owner = "web-2" if kind == "ptt" else "web-1"
     result = reduce_managed_tx(state, PttUp(owner, 7, "off"))
     assert result.outcome is ManagedTxOutcome.REJECTED
     assert result.state == state
@@ -143,7 +140,6 @@ def test_matching_ptt_up_returns_rx_with_release_effect_and_debt() -> None:
     result = reduce_managed_tx(keyed(), PttUp("web-1", 7, "off"))
     assert result.state.intent == ManagedTxIntent.rx()
     assert result.state.release_plan is ReleasePlan.PTT_RELEASE
-    assert result.state.release_required is True
     assert result.state.tx_started_at_monotonic is None
     assert result.effects == (result.state.pending_effect,)
     assert result.effects[0].operation is ActuationOperation.FORCE_RECEIVE
@@ -162,7 +158,6 @@ def test_force_off_always_fences_debt_and_repeated_call_replaces_effect() -> Non
     first = reduce_managed_tx(state, ForceOff(None, "offline"))
     second = reduce_managed_tx(first.state, ForceOff(9, "online"))
     assert first.state.release_plan is ReleasePlan.FORCE_RELEASE
-    assert first.state.release_required is True
     assert first.state.intent == ManagedTxIntent.rx()
     assert first.state.pending_effect is None
     assert first.effects == ()
@@ -181,14 +176,10 @@ def test_stale_token_cannot_settle_or_clear_debt(field: str, value: object) -> N
     pending = state.pending_effect
     assert pending is not None
     token = replace(pending.token, **{field: value})
-    result = reduce_managed_tx(
-        state,
-        ActuationSettled(
-            token,
-            ActuationOperation.FORCE_RECEIVE,
-            ActuationResult.ACCEPTED,
-        ),
+    event = ActuationSettled(
+        token, ActuationOperation.FORCE_RECEIVE, ActuationResult.ACCEPTED
     )
+    result = reduce_managed_tx(state, event)
     assert result.outcome is ManagedTxOutcome.STALE
     assert result.state == state
 
@@ -202,9 +193,7 @@ def test_current_token_with_wrong_operation_is_stale_and_keeps_debt() -> None:
 
 
 @pytest.mark.parametrize("result", list(ActuationResult))
-def test_force_receive_results_have_exact_debt_and_diagnostics(
-    result: ActuationResult,
-) -> None:
+def test_force_receive_result_matrix(result: ActuationResult) -> None:
     prior = ActuationDiagnostic(
         ActuationOperation.PTT_ON, ActuationResult.ACCEPTED, "old"
     )
@@ -224,9 +213,7 @@ def test_force_receive_results_have_exact_debt_and_diagnostics(
     "operation", [ActuationOperation.PTT_ON, ActuationOperation.TRANSMIT_ON]
 )
 @pytest.mark.parametrize("result", list(ActuationResult))
-def test_on_results_have_exact_state_deltas(
-    operation: ActuationOperation, result: ActuationResult
-) -> None:
+def test_on_matrix(operation: ActuationOperation, result: ActuationResult) -> None:
     state = (
         keyed()
         if operation is ActuationOperation.PTT_ON
@@ -235,7 +222,6 @@ def test_on_results_have_exact_state_deltas(
     settled = settle(state, result)
     accepted = result is ActuationResult.ACCEPTED
     assert settled.state.intent == (state.intent if accepted else ManagedTxIntent.rx())
-    assert settled.state.release_required is True
     assert settled.state.release_plan is (
         ReleasePlan.PTT_RELEASE if accepted else ReleasePlan.FORCE_RELEASE
     )
@@ -264,7 +250,20 @@ def test_transition_diagnostic_reset_and_preservation_follow_field_table() -> No
 @pytest.mark.parametrize("operation", list(AbortOperation))
 def test_typed_abort_failures_are_diagnostic_only(operation: AbortOperation) -> None:
     state = force_off().state
-    recorded = reduce_managed_tx(state, AbortFailed(operation, "stuck"))
+    assert state.pending_effect is not None
+    recorded = reduce_managed_tx(
+        state, AbortFailed(state.pending_effect.token, operation, "stuck")
+    )
     assert recorded.outcome is ManagedTxOutcome.APPLIED
     assert replace(recorded.state, abort_errors=()) == state
     assert recorded.state.abort_errors == (AbortError(operation, "stuck"),)
+
+
+def test_abort_failure_from_prior_force_off_epoch_is_stale() -> None:
+    first = force_off().state
+    assert first.pending_effect is not None
+    second = reduce_managed_tx(first, ForceOff(9, "new")).state
+    late = AbortFailed(first.pending_effect.token, AbortOperation.STOP_TUNE, "late")
+    result = reduce_managed_tx(second, late)
+    assert result.outcome is ManagedTxOutcome.STALE
+    assert result.state == second

--- a/tests/test_managed_tx_state.py
+++ b/tests/test_managed_tx_state.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from dataclasses import fields, replace
+from typing import get_args
+
+import pytest
+
+import rigplane.runtime.managed_tx_state as subject
+from rigplane.runtime.managed_tx_state import (
+    AbortFailed,
+    AbortError,
+    AbortOperation,
+    ActuationDiagnostic,
+    ActuationOperation,
+    ActuationResult,
+    ActuationSettled,
+    ForceOff,
+    ManagedTxEvent,
+    ManagedTxIntent,
+    ManagedTxIntentKind,
+    ManagedTxOutcome,
+    ManagedTxState,
+    PttDown,
+    PttUp,
+    ReleasePlan,
+    TransmitOn,
+    reduce_managed_tx,
+)
+
+
+def ptt_down(owner: str = "web-1", attempt: str = "on-1") -> PttDown:
+    return PttDown(owner, 7, attempt, 10.0, 190.0)
+
+
+def keyed() -> ManagedTxState:
+    return reduce_managed_tx(ManagedTxState(), ptt_down()).state
+
+
+def force_off(state: ManagedTxState | None = None, attempt: str = "off-1"):
+    return reduce_managed_tx(state or ManagedTxState(), ForceOff(9, attempt))
+
+
+def settle(
+    state: ManagedTxState,
+    result: ActuationResult,
+    *,
+    operation: ActuationOperation | None = None,
+    error: str | None = "failed",
+):
+    pending = state.pending_effect
+    assert pending is not None
+    return reduce_managed_tx(
+        state,
+        ActuationSettled(pending.token, operation or pending.operation, result, error),
+    )
+
+
+def test_state_vocabulary_cannot_encode_invalid_authority_or_debt() -> None:
+    assert ManagedTxIntent.rx() == ManagedTxIntent(ManagedTxIntentKind.RX)
+    with pytest.raises(ValueError):
+        ManagedTxIntent(ManagedTxIntentKind.PTT)
+    with pytest.raises(ValueError):
+        ManagedTxIntent(ManagedTxIntentKind.TRANSMIT, "owner")
+    with pytest.raises(ValueError):
+        ManagedTxState(intent=ManagedTxIntent.ptt("owner"))
+    assert "release_required" not in {field.name for field in fields(ManagedTxState)}
+
+
+def test_observation_is_structurally_not_an_authority_event() -> None:
+    assert not hasattr(subject, "ObservedPtt")
+    assert set(get_args(ManagedTxEvent)) == {
+        PttDown,
+        PttUp,
+        TransmitOn,
+        ForceOff,
+        ActuationSettled,
+        AbortFailed,
+    }
+    assert "IGNORED" not in ManagedTxOutcome.__members__
+
+
+def test_ptt_down_records_debt_before_returning_non_optional_effect() -> None:
+    result = reduce_managed_tx(ManagedTxState(), ptt_down())
+    assert result.outcome is ManagedTxOutcome.ACCEPTED
+    assert result.state.intent == ManagedTxIntent.ptt("web-1")
+    assert result.state.release_required is True
+    assert result.state.release_plan is ReleasePlan.PTT_RELEASE
+    assert result.state.tx_started_at_monotonic == 10.0
+    assert result.state.tot_deadline_monotonic == 190.0
+    assert result.effects == (result.state.pending_effect,)
+    effect = result.effects[0]
+    assert effect.operation is ActuationOperation.PTT_ON
+    assert effect.token.effect_epoch == result.state.effect_epoch == 0
+
+
+@pytest.mark.parametrize(
+    "event", [ptt_down(owner="web-2"), TransmitOn(7, "tx", 20, 200)]
+)
+def test_incompatible_on_is_rejected_while_ptt_active(event: ManagedTxEvent) -> None:
+    state = keyed()
+    result = reduce_managed_tx(state, event)
+    assert result.outcome is ManagedTxOutcome.REJECTED
+    assert result.state == state
+    assert result.effects == ()
+
+
+def test_idempotent_on_preserves_tot_debt_pending_effect_and_diagnostics() -> None:
+    for event in (ptt_down(attempt="again"), TransmitOn(7, "again", 90, 270)):
+        first = (
+            keyed()
+            if isinstance(event, PttDown)
+            else reduce_managed_tx(
+                ManagedTxState(), TransmitOn(7, "first", 10, 190)
+            ).state
+        )
+        marked = replace(first, last_error="old")
+        result = reduce_managed_tx(marked, event)
+        assert result.outcome is ManagedTxOutcome.ACCEPTED
+        assert result.state == marked
+        assert result.effects == ()
+
+
+@pytest.mark.parametrize(
+    "state,owner",
+    [
+        (ManagedTxState(), "web-1"),
+        (keyed(), "web-2"),
+        (
+            reduce_managed_tx(ManagedTxState(), TransmitOn(7, "tx", 10, 190)).state,
+            "web-1",
+        ),
+    ],
+)
+def test_ptt_up_requires_the_current_ptt_owner(
+    state: ManagedTxState, owner: str
+) -> None:
+    result = reduce_managed_tx(state, PttUp(owner, 7, "off"))
+    assert result.outcome is ManagedTxOutcome.REJECTED
+    assert result.state == state
+
+
+def test_matching_ptt_up_returns_rx_with_release_effect_and_debt() -> None:
+    result = reduce_managed_tx(keyed(), PttUp("web-1", 7, "off"))
+    assert result.state.intent == ManagedTxIntent.rx()
+    assert result.state.release_plan is ReleasePlan.PTT_RELEASE
+    assert result.state.release_required is True
+    assert result.state.tx_started_at_monotonic is None
+    assert result.effects == (result.state.pending_effect,)
+    assert result.effects[0].operation is ActuationOperation.FORCE_RECEIVE
+
+
+def test_on_is_rejected_while_release_debt_is_outstanding() -> None:
+    state = ManagedTxState(release_plan=ReleasePlan.FORCE_RELEASE)
+    result = reduce_managed_tx(state, TransmitOn(1, "tx", 10, 190))
+    assert result.outcome is ManagedTxOutcome.REJECTED
+    assert result.state == state
+
+
+def test_force_off_always_fences_debt_and_repeated_call_replaces_effect() -> None:
+    error = AbortError(AbortOperation.STOP_CW, "cw")
+    state = replace(keyed(), abort_errors=(error,))
+    first = reduce_managed_tx(state, ForceOff(None, "offline"))
+    second = reduce_managed_tx(first.state, ForceOff(9, "online"))
+    assert first.state.release_plan is ReleasePlan.FORCE_RELEASE
+    assert first.state.release_required is True
+    assert first.state.intent == ManagedTxIntent.rx()
+    assert first.state.pending_effect is None
+    assert first.effects == ()
+    assert first.state.abort_errors == ()
+    assert second.state.effect_epoch == state.effect_epoch + 2
+    assert second.effects == (second.state.pending_effect,)
+    assert second.effects[0].token.attempt_id == "online"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("provider_generation", 8), ("effect_epoch", 0), ("attempt_id", "old")],
+)
+def test_stale_token_cannot_settle_or_clear_debt(field: str, value: object) -> None:
+    state = force_off().state
+    pending = state.pending_effect
+    assert pending is not None
+    token = replace(pending.token, **{field: value})
+    result = reduce_managed_tx(
+        state,
+        ActuationSettled(
+            token,
+            ActuationOperation.FORCE_RECEIVE,
+            ActuationResult.ACCEPTED,
+        ),
+    )
+    assert result.outcome is ManagedTxOutcome.STALE
+    assert result.state == state
+
+
+def test_current_token_with_wrong_operation_is_stale_and_keeps_debt() -> None:
+    state = force_off().state
+    wrong = ActuationOperation.PTT_ON
+    result = settle(state, ActuationResult.ACCEPTED, operation=wrong)
+    assert result.outcome is ManagedTxOutcome.STALE
+    assert result.state == state
+
+
+@pytest.mark.parametrize("result", list(ActuationResult))
+def test_force_receive_results_have_exact_debt_and_diagnostics(
+    result: ActuationResult,
+) -> None:
+    prior = ActuationDiagnostic(
+        ActuationOperation.PTT_ON, ActuationResult.ACCEPTED, "old"
+    )
+    state = replace(force_off().state, last_actuation=prior, last_error="old")
+    settled = settle(state, result)
+    accepted = result is ActuationResult.ACCEPTED
+    assert settled.outcome is ManagedTxOutcome.APPLIED
+    assert settled.state.release_required is not accepted
+    assert settled.state.pending_effect is None
+    assert settled.state.last_actuation == ActuationDiagnostic(
+        ActuationOperation.FORCE_RECEIVE, result, "off-1"
+    )
+    assert settled.state.last_error == (None if accepted else "failed")
+
+
+@pytest.mark.parametrize(
+    "operation", [ActuationOperation.PTT_ON, ActuationOperation.TRANSMIT_ON]
+)
+@pytest.mark.parametrize("result", list(ActuationResult))
+def test_on_results_have_exact_state_deltas(
+    operation: ActuationOperation, result: ActuationResult
+) -> None:
+    state = (
+        keyed()
+        if operation is ActuationOperation.PTT_ON
+        else reduce_managed_tx(ManagedTxState(), TransmitOn(7, "on-1", 10, 190)).state
+    )
+    settled = settle(state, result)
+    accepted = result is ActuationResult.ACCEPTED
+    assert settled.state.intent == (state.intent if accepted else ManagedTxIntent.rx())
+    assert settled.state.release_required is True
+    assert settled.state.release_plan is (
+        ReleasePlan.PTT_RELEASE if accepted else ReleasePlan.FORCE_RELEASE
+    )
+    assert settled.state.tx_started_at_monotonic == (10 if accepted else None)
+    assert settled.state.tot_deadline_monotonic == (190 if accepted else None)
+    assert settled.state.last_error == (None if accepted else "failed")
+    assert settled.state.last_actuation == ActuationDiagnostic(
+        operation, result, "on-1"
+    )
+
+
+def test_transition_diagnostic_reset_and_preservation_follow_field_table() -> None:
+    settled = settle(keyed(), ActuationResult.REJECTED).state
+    on = reduce_managed_tx(
+        replace(settled, release_plan=None), TransmitOn(7, "new", 20, 200)
+    ).state
+    released = reduce_managed_tx(
+        replace(on, last_error="keep"), ForceOff(None, "off")
+    ).state
+    assert on.last_error is None
+    assert on.last_actuation == settled.last_actuation
+    assert released.last_error == "keep"
+    assert released.last_actuation == settled.last_actuation
+
+
+@pytest.mark.parametrize("operation", list(AbortOperation))
+def test_typed_abort_failures_are_diagnostic_only(operation: AbortOperation) -> None:
+    state = force_off().state
+    recorded = reduce_managed_tx(state, AbortFailed(operation, "stuck"))
+    assert recorded.outcome is ManagedTxOutcome.APPLIED
+    assert replace(recorded.state, abort_errors=()) == state
+    assert recorded.state.abort_errors == (AbortError(operation, "stuck"),)


### PR DESCRIPTION
## Summary

- add the pure immutable `ManagedTxState` vocabulary and reducer
- record release debt before emitting any ON effect
- bind actuation settlement to provider generation, effect epoch, attempt ID, and operation
- allow active intent with a retained start time and disabled (`None`) TOT deadline while rejecting either RX timing residue
- scope abort-failure diagnostics to the originating effect token epoch
- keep observed PTT outside the authority event surface

## TDD evidence

- initial RED: focused pytest failed at collection before the reducer module existed
- hostile-review RED: focused pytest failed at collection before the corrected operation-bound interface existed
- exact-head review-fix RED on `5d46eded199d7142afe04e94b294693103536a04`: 7 failed / 26 passed — both disabled-TOT active states raised, both partial RX timing states were admitted, and token-scoped abort failures could not be represented
- GREEN on `6089702a153fcfa440746a145e9630d40536501a`: 33 passed
- expanded process-local invariant battery: PASS, 12 invariants / 31 variants, including nullable-TOT/RX residue and stale prior-ForceOff abort diagnostics

## Verification

- `uv run pytest tests/test_managed_tx_state.py -q --tb=short`
- `uv run ruff format --check src/rigplane/runtime/managed_tx_state.py tests/test_managed_tx_state.py`
- `uv run ruff check src/rigplane/runtime/managed_tx_state.py tests/test_managed_tx_state.py`
- `uv run lint-imports`
- `.github/scripts/check-doc-citations.sh`
- `.github/scripts/check-doc-citations.sh --check-links`
- `.github/scripts/check-doc-citations.sh --check-dangling`
- `git diff origin/main...HEAD --check`

Exactly two files and 599 inserted lines. No full local suite was run, per scope.

## Compatibility

Additive/private compatibility only: this introduces a new internal runtime module and focused tests without changing existing public API, CLI, configuration, persistence, provider bytes, web/API construction, or current runtime composition.

Linear: https://linear.app/rigplane/issue/MOR-2195