### PR TITLE
feat: add managed TX effect lane (MOR-2198)

### DIFF
--- a/src/rigplane/runtime/managed_tx_effect_lane.py
+++ b/src/rigplane/runtime/managed_tx_effect_lane.py
@@ -19,7 +19,6 @@ from rigplane.runtime.managed_tx_state import (
 )
 
 _Operation: TypeAlias = ActuationOperation | AbortOperation
-_ClaimKey: TypeAlias = tuple[EffectToken, _Operation]
 _Clock: TypeAlias = Callable[[], float]
 _PoisonGeneration: TypeAlias = Callable[[int], Awaitable[None]]
 _ON_OPERATIONS = frozenset({ActuationOperation.PTT_ON, ActuationOperation.TRANSMIT_ON})
@@ -49,6 +48,8 @@ class _Claim:
     driver: asyncio.Task[None] | None = None
     provider: asyncio.Task[ActuationResult] | None = None
     started: bool = False
+    order: int = 0
+    isolation: tuple[asyncio.Task[None], ...] = ()
 
 
 async def _ignore_poison(_: int) -> None:
@@ -70,13 +71,18 @@ class ManagedTxEffectLane:
         self._poison_generation = poison_generation or _ignore_poison
         self._lock = asyncio.Lock()
         self._on_lane = asyncio.Lock()
-        self._claims: dict[_ClaimKey, _Claim] = {}
-        self._poisoned_through_generation = -1
+        self._claims: dict[EffectToken, _Claim] = {}
+        self._records: dict[EffectToken, tuple[_Operation, int]] = {}
+        self._scope = (-1, -1)
+        self._next_order = 0
+        self._isolations: dict[int, asyncio.Task[None]] = {}
 
     async def settle(
         self, effect: ManagedTxEffect, *, deadline_monotonic: float
-    ) -> ActuationSettled:
+    ) -> ActuationSettled | None:
         outcome = await self._settle(effect.token, effect.operation, deadline_monotonic)
+        if outcome is None:
+            return None
         return ActuationSettled(
             effect.token, effect.operation, outcome.result, outcome.error
         )
@@ -89,14 +95,18 @@ class ManagedTxEffectLane:
         deadline_monotonic: float,
     ) -> AbortFailed | None:
         outcome = await self._settle(token, operation, deadline_monotonic)
+        if outcome is None:
+            return None
         if outcome.result is ActuationResult.ACCEPTED:
             return None
         return AbortFailed(token, operation, outcome.error or outcome.result.value)
 
     async def _settle(
         self, token: EffectToken, operation: _Operation, deadline: float
-    ) -> _Outcome:
+    ) -> _Outcome | None:
         claim = await self._claim(token, operation, deadline)
+        if claim is None:
+            return None
         try:
             return await asyncio.shield(claim.result)
         except asyncio.CancelledError:
@@ -104,27 +114,50 @@ class ManagedTxEffectLane:
 
     async def _claim(
         self, token: EffectToken, operation: _Operation, deadline: float
-    ) -> _Claim:
-        key = (token, operation)
+    ) -> _Claim | None:
         async with self._lock:
-            if existing := self._claims.get(key):
-                return existing
+            scope = (token.provider_generation, token.effect_epoch)
+            if scope < self._scope or token in self._records:
+                return None
+            if scope > self._scope:
+                self._scope, self._next_order = scope, 0
+                self._records.clear()
+                self._isolations = {
+                    generation: task
+                    for generation, task in self._isolations.items()
+                    if not task.done() or generation >= token.provider_generation
+                }
+                for active in tuple(self._claims.values()):
+                    active_scope = (
+                        active.token.provider_generation,
+                        active.token.effect_epoch,
+                    )
+                    if active.operation in _ON_OPERATIONS and active_scope < scope:
+                        self._displace_locked(active)
+            self._next_order += 1
+            self._records[token] = (operation, self._next_order)
             loop = asyncio.get_running_loop()
-            claim = _Claim(token, operation, deadline, loop.create_future())
-            self._claims[key] = claim
+            claim = _Claim(
+                token, operation, deadline, loop.create_future(), order=self._next_order
+            )
+            self._claims[token] = claim
             if operation is ActuationOperation.FORCE_RECEIVE:
                 active_ons = tuple(
                     active
                     for active in self._claims.values()
                     if active is not claim and active.operation in _ON_OPERATIONS
                 )
-                token_order = (token.provider_generation, token.effect_epoch)
+                token_order = (*scope, claim.order)
                 if any(
-                    (item.token.provider_generation, item.token.effect_epoch)
+                    (
+                        item.token.provider_generation,
+                        item.token.effect_epoch,
+                        item.order,
+                    )
                     > token_order
                     for item in active_ons
                 ):
-                    self._claims.pop(key)
+                    self._claims.pop(token)
                     claim.result.set_result(
                         _Outcome(
                             ActuationResult.REJECTED, "stale attempt before dispatch"
@@ -132,7 +165,14 @@ class ManagedTxEffectLane:
                     )
                     return claim
                 for active in active_ons:
-                    self._displace_locked(active)
+                    if barrier := self._displace_locked(active):
+                        claim.isolation += (barrier,)
+                claim.isolation += tuple(
+                    task
+                    for generation, task in self._isolations.items()
+                    if generation <= token.provider_generation
+                    and task not in claim.isolation
+                )
             claim.driver = asyncio.create_task(self._drive(claim))
             claim.driver.add_done_callback(self._harvest)
             return claim
@@ -187,6 +227,11 @@ class ManagedTxEffectLane:
                 poison=claim.operation in _ON_OPERATIONS,
             )
             return
+        if result is ActuationResult.ACCEPTED and claim.isolation:
+            if isolation_error := await self._await_isolation(claim.isolation):
+                result = ActuationResult.UNCERTAIN
+                await self._finish(claim, _Outcome(result, isolation_error))
+                return
         await self._finish(
             claim,
             _Outcome(
@@ -202,13 +247,19 @@ class ManagedTxEffectLane:
     async def _finish(
         self, claim: _Claim, outcome: _Outcome, *, poison: bool = False
     ) -> None:
+        isolation: asyncio.Task[None] | None = None
         async with self._lock:
             if claim.result.done():
                 return
-            self._claims.pop((claim.token, claim.operation), None)
-            claim.result.set_result(outcome)
+            self._claims.pop(claim.token, None)
             if poison:
-                self._poison_locked(claim.token.provider_generation)
+                isolation = self._isolate_locked(claim.token.provider_generation)
+        if isolation is not None:
+            await self._await_isolation((isolation,))
+        async with self._lock:
+            if claim.result.done():
+                return
+            claim.result.set_result(outcome)
 
     async def _cancel_waiter(self, claim: _Claim) -> _Outcome:
         async with self._lock:
@@ -226,10 +277,10 @@ class ManagedTxEffectLane:
         *,
         before: str = "superseded before dispatch",
         after: str = "superseded after dispatch",
-    ) -> None:
+    ) -> asyncio.Task[None] | None:
         if claim.result.done():
-            return
-        self._claims.pop((claim.token, claim.operation), None)
+            return None
+        self._claims.pop(claim.token, None)
         if claim.provider is not None:
             claim.provider.cancel()
             claim.provider.add_done_callback(self._harvest)
@@ -240,14 +291,24 @@ class ManagedTxEffectLane:
         )
         claim.result.set_result(_Outcome(result, after if claim.started else before))
         if claim.started and claim.operation in _ON_OPERATIONS:
-            self._poison_locked(claim.token.provider_generation)
+            return self._isolate_locked(claim.token.provider_generation)
+        return None
 
-    def _poison_locked(self, provider_generation: int) -> None:
-        if provider_generation <= self._poisoned_through_generation:
-            return
-        self._poisoned_through_generation = provider_generation
+    def _isolate_locked(self, provider_generation: int) -> asyncio.Task[None]:
+        if task := self._isolations.get(provider_generation):
+            return task
         task = asyncio.ensure_future(self._poison_generation(provider_generation))
         task.add_done_callback(self._harvest)
+        self._isolations[provider_generation] = task
+        return task
+
+    @staticmethod
+    async def _await_isolation(tasks: tuple[asyncio.Task[None], ...]) -> str | None:
+        try:
+            await asyncio.gather(*(asyncio.shield(task) for task in tasks))
+        except BaseException as error:
+            return _error_text(error)
+        return None
 
     @staticmethod
     def _harvest(task: asyncio.Future[Any]) -> None:

--- a/src/rigplane/runtime/managed_tx_effect_lane.py
+++ b/src/rigplane/runtime/managed_tx_effect_lane.py
@@ -19,9 +19,13 @@ from rigplane.runtime.managed_tx_state import (
 )
 
 _Operation: TypeAlias = ActuationOperation | AbortOperation
+_ClaimKey: TypeAlias = tuple[EffectToken, _Operation]
+_Slot: TypeAlias = str | AbortOperation
 _Clock: TypeAlias = Callable[[], float]
 _PoisonGeneration: TypeAlias = Callable[[int], Awaitable[None]]
 _ON_OPERATIONS = frozenset({ActuationOperation.PTT_ON, ActuationOperation.TRANSMIT_ON})
+_ON_SLOT = "on"
+_FORCE_SLOT = "force_receive"
 
 
 @runtime_checkable
@@ -48,7 +52,6 @@ class _Claim:
     driver: asyncio.Task[None] | None = None
     provider: asyncio.Task[ActuationResult] | None = None
     started: bool = False
-    order: int = 0
     isolation: tuple[asyncio.Task[None], ...] = ()
 
 
@@ -71,11 +74,11 @@ class ManagedTxEffectLane:
         self._poison_generation = poison_generation or _ignore_poison
         self._lock = asyncio.Lock()
         self._on_lane = asyncio.Lock()
-        self._claims: dict[EffectToken, _Claim] = {}
-        self._records: dict[EffectToken, tuple[_Operation, int]] = {}
+        self._claims: dict[_ClaimKey, _Claim] = {}
+        self._slots: dict[_Slot, tuple[EffectToken, _Operation]] = {}
         self._scope = (-1, -1)
-        self._next_order = 0
-        self._isolations: dict[int, asyncio.Task[None]] = {}
+        self._release_token: EffectToken | None = None
+        self._isolation: tuple[int, asyncio.Task[None]] | None = None
 
     async def settle(
         self, effect: ManagedTxEffect, *, deadline_monotonic: float
@@ -117,65 +120,60 @@ class ManagedTxEffectLane:
     ) -> _Claim | None:
         async with self._lock:
             scope = (token.provider_generation, token.effect_epoch)
-            if scope < self._scope or token in self._records:
+            if scope < self._scope:
                 return None
             if scope > self._scope:
-                self._scope, self._next_order = scope, 0
-                self._records.clear()
-                self._isolations = {
-                    generation: task
-                    for generation, task in self._isolations.items()
-                    if not task.done() or generation >= token.provider_generation
-                }
+                self._scope = scope
+                self._slots.clear()
+                self._release_token = None
                 for active in tuple(self._claims.values()):
                     active_scope = (
                         active.token.provider_generation,
                         active.token.effect_epoch,
                     )
-                    if active.operation in _ON_OPERATIONS and active_scope < scope:
+                    if active_scope < scope:
                         self._displace_locked(active)
-            self._next_order += 1
-            self._records[token] = (operation, self._next_order)
+            slot = _slot(operation)
+            if slot in self._slots or not self._bind_family_locked(token, operation):
+                return None
+            self._slots[slot] = (token, operation)
             loop = asyncio.get_running_loop()
-            claim = _Claim(
-                token, operation, deadline, loop.create_future(), order=self._next_order
-            )
-            self._claims[token] = claim
+            claim = _Claim(token, operation, deadline, loop.create_future())
+            self._claims[(token, operation)] = claim
             if operation is ActuationOperation.FORCE_RECEIVE:
                 active_ons = tuple(
                     active
                     for active in self._claims.values()
                     if active is not claim and active.operation in _ON_OPERATIONS
                 )
-                token_order = (*scope, claim.order)
-                if any(
-                    (
-                        item.token.provider_generation,
-                        item.token.effect_epoch,
-                        item.order,
-                    )
-                    > token_order
-                    for item in active_ons
-                ):
-                    self._claims.pop(token)
-                    claim.result.set_result(
-                        _Outcome(
-                            ActuationResult.REJECTED, "stale attempt before dispatch"
-                        )
-                    )
-                    return claim
                 for active in active_ons:
                     if barrier := self._displace_locked(active):
                         claim.isolation += (barrier,)
-                claim.isolation += tuple(
-                    task
-                    for generation, task in self._isolations.items()
-                    if generation <= token.provider_generation
-                    and task not in claim.isolation
-                )
+                if self._isolation is not None:
+                    generation, task = self._isolation
+                    if (
+                        generation <= token.provider_generation
+                        and task not in claim.isolation
+                    ):
+                        claim.isolation += (task,)
             claim.driver = asyncio.create_task(self._drive(claim))
             claim.driver.add_done_callback(self._harvest)
             return claim
+
+    def _bind_family_locked(self, token: EffectToken, operation: _Operation) -> bool:
+        if operation in _ON_OPERATIONS:
+            return self._release_token is None
+        if (
+            operation is ActuationOperation.FORCE_RECEIVE
+            and (primary := self._slots.get(_ON_SLOT))
+            and primary[0] == token
+        ):
+            return False
+        if self._release_token is None:
+            if _ON_SLOT in self._slots and isinstance(operation, AbortOperation):
+                return False
+            self._release_token = token
+        return bool(self._release_token == token)
 
     async def _drive(self, claim: _Claim) -> None:
         try:
@@ -228,7 +226,9 @@ class ManagedTxEffectLane:
             )
             return
         if result is ActuationResult.ACCEPTED and claim.isolation:
-            if isolation_error := await self._await_isolation(claim.isolation):
+            if isolation_error := await self._await_isolation(
+                claim.isolation, claim.deadline
+            ):
                 result = ActuationResult.UNCERTAIN
                 await self._finish(claim, _Outcome(result, isolation_error))
                 return
@@ -251,11 +251,11 @@ class ManagedTxEffectLane:
         async with self._lock:
             if claim.result.done():
                 return
-            self._claims.pop(claim.token, None)
+            self._claims.pop((claim.token, claim.operation), None)
             if poison:
                 isolation = self._isolate_locked(claim.token.provider_generation)
         if isolation is not None:
-            await self._await_isolation((isolation,))
+            await self._await_isolation((isolation,), claim.deadline)
         async with self._lock:
             if claim.result.done():
                 return
@@ -280,7 +280,7 @@ class ManagedTxEffectLane:
     ) -> asyncio.Task[None] | None:
         if claim.result.done():
             return None
-        self._claims.pop(claim.token, None)
+        self._claims.pop((claim.token, claim.operation), None)
         if claim.provider is not None:
             claim.provider.cancel()
             claim.provider.add_done_callback(self._harvest)
@@ -295,19 +295,26 @@ class ManagedTxEffectLane:
         return None
 
     def _isolate_locked(self, provider_generation: int) -> asyncio.Task[None]:
-        if task := self._isolations.get(provider_generation):
-            return task
+        if self._isolation is not None and self._isolation[0] == provider_generation:
+            return self._isolation[1]
         task = asyncio.ensure_future(self._poison_generation(provider_generation))
         task.add_done_callback(self._harvest)
-        self._isolations[provider_generation] = task
+        self._isolation = (provider_generation, task)
         return task
 
-    @staticmethod
-    async def _await_isolation(tasks: tuple[asyncio.Task[None], ...]) -> str | None:
-        try:
-            await asyncio.gather(*(asyncio.shield(task) for task in tasks))
-        except BaseException as error:
-            return _error_text(error)
+    async def _await_isolation(
+        self, tasks: tuple[asyncio.Task[None], ...], deadline: float
+    ) -> str | None:
+        done, pending = await asyncio.wait(
+            tasks, timeout=max(0.0, deadline - self._clock())
+        )
+        if pending:
+            return "isolation deadline expired"
+        for task in done:
+            if task.cancelled():
+                return "CancelledError"
+            if error := task.exception():
+                return _error_text(error)
         return None
 
     @staticmethod
@@ -318,3 +325,11 @@ class ManagedTxEffectLane:
 
 def _error_text(error: BaseException) -> str:
     return str(error) or type(error).__name__
+
+
+def _slot(operation: _Operation) -> _Slot:
+    if operation in _ON_OPERATIONS:
+        return _ON_SLOT
+    if operation is ActuationOperation.FORCE_RECEIVE:
+        return _FORCE_SLOT
+    return operation

--- a/src/rigplane/runtime/managed_tx_effect_lane.py
+++ b/src/rigplane/runtime/managed_tx_effect_lane.py
@@ -1,0 +1,259 @@
+"""Provider-neutral execution lane for managed-transmit effects."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, TypeAlias, runtime_checkable
+
+from rigplane.runtime.managed_tx_state import (
+    AbortFailed,
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    ActuationSettled,
+    EffectToken,
+    ManagedTxEffect,
+)
+
+_Operation: TypeAlias = ActuationOperation | AbortOperation
+_ClaimKey: TypeAlias = tuple[EffectToken, _Operation]
+_Clock: TypeAlias = Callable[[], float]
+_PoisonGeneration: TypeAlias = Callable[[int], Awaitable[None]]
+_ON_OPERATIONS = frozenset({ActuationOperation.PTT_ON, ActuationOperation.TRANSMIT_ON})
+
+
+@runtime_checkable
+class ManagedTxActuator(Protocol):
+    """Execute one runtime-tokened semantic operation."""
+
+    async def actuate(
+        self, token: EffectToken, operation: _Operation
+    ) -> ActuationResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _Outcome:
+    result: ActuationResult
+    error: str | None
+
+
+@dataclass(slots=True)
+class _Claim:
+    token: EffectToken
+    operation: _Operation
+    deadline: float
+    result: asyncio.Future[_Outcome]
+    driver: asyncio.Task[None] | None = None
+    provider: asyncio.Task[ActuationResult] | None = None
+    started: bool = False
+
+
+async def _ignore_poison(_: int) -> None:
+    return None
+
+
+class ManagedTxEffectLane:
+    """Claim, prioritize, and normalize managed actuator attempts."""
+
+    def __init__(
+        self,
+        actuator: ManagedTxActuator,
+        *,
+        clock: _Clock | None = None,
+        poison_generation: _PoisonGeneration | None = None,
+    ) -> None:
+        self._actuator = actuator
+        self._clock = clock or time.monotonic
+        self._poison_generation = poison_generation or _ignore_poison
+        self._lock = asyncio.Lock()
+        self._on_lane = asyncio.Lock()
+        self._claims: dict[_ClaimKey, _Claim] = {}
+        self._poisoned_through_generation = -1
+
+    async def settle(
+        self, effect: ManagedTxEffect, *, deadline_monotonic: float
+    ) -> ActuationSettled:
+        outcome = await self._settle(effect.token, effect.operation, deadline_monotonic)
+        return ActuationSettled(
+            effect.token, effect.operation, outcome.result, outcome.error
+        )
+
+    async def settle_abort(
+        self,
+        token: EffectToken,
+        operation: AbortOperation,
+        *,
+        deadline_monotonic: float,
+    ) -> AbortFailed | None:
+        outcome = await self._settle(token, operation, deadline_monotonic)
+        if outcome.result is ActuationResult.ACCEPTED:
+            return None
+        return AbortFailed(token, operation, outcome.error or outcome.result.value)
+
+    async def _settle(
+        self, token: EffectToken, operation: _Operation, deadline: float
+    ) -> _Outcome:
+        claim = await self._claim(token, operation, deadline)
+        try:
+            return await asyncio.shield(claim.result)
+        except asyncio.CancelledError:
+            return await self._cancel_waiter(claim)
+
+    async def _claim(
+        self, token: EffectToken, operation: _Operation, deadline: float
+    ) -> _Claim:
+        key = (token, operation)
+        async with self._lock:
+            if existing := self._claims.get(key):
+                return existing
+            loop = asyncio.get_running_loop()
+            claim = _Claim(token, operation, deadline, loop.create_future())
+            self._claims[key] = claim
+            if operation is ActuationOperation.FORCE_RECEIVE:
+                active_ons = tuple(
+                    active
+                    for active in self._claims.values()
+                    if active is not claim and active.operation in _ON_OPERATIONS
+                )
+                token_order = (token.provider_generation, token.effect_epoch)
+                if any(
+                    (item.token.provider_generation, item.token.effect_epoch)
+                    > token_order
+                    for item in active_ons
+                ):
+                    self._claims.pop(key)
+                    claim.result.set_result(
+                        _Outcome(
+                            ActuationResult.REJECTED, "stale attempt before dispatch"
+                        )
+                    )
+                    return claim
+                for active in active_ons:
+                    self._displace_locked(active)
+            claim.driver = asyncio.create_task(self._drive(claim))
+            claim.driver.add_done_callback(self._harvest)
+            return claim
+
+    async def _drive(self, claim: _Claim) -> None:
+        try:
+            if claim.operation in _ON_OPERATIONS:
+                async with self._on_lane:
+                    await self._invoke(claim)
+            else:
+                await self._invoke(claim)
+        except asyncio.CancelledError:
+            pass
+
+    async def _invoke(self, claim: _Claim) -> None:
+        if claim.result.done():
+            return
+        if claim.deadline <= self._clock():
+            await self._finish(
+                claim,
+                _Outcome(ActuationResult.REJECTED, "deadline expired before dispatch"),
+            )
+            return
+        async with self._lock:
+            if claim.result.done():
+                return
+            claim.started = True
+            claim.provider = asyncio.create_task(
+                self._actuator.actuate(claim.token, claim.operation)
+            )
+            provider = claim.provider
+        done, _ = await asyncio.wait(
+            (provider,), timeout=max(0.0, claim.deadline - self._clock())
+        )
+        if not done:
+            provider.cancel()
+            provider.add_done_callback(self._harvest)
+            await self._finish(
+                claim,
+                _Outcome(ActuationResult.UNCERTAIN, "attempt deadline expired"),
+                poison=claim.operation in _ON_OPERATIONS,
+            )
+            return
+        try:
+            result = provider.result()
+            if not isinstance(result, ActuationResult):
+                raise TypeError("actuator returned a non-normalized result")
+        except BaseException as error:
+            await self._finish(
+                claim,
+                _Outcome(ActuationResult.UNCERTAIN, _error_text(error)),
+                poison=claim.operation in _ON_OPERATIONS,
+            )
+            return
+        await self._finish(
+            claim,
+            _Outcome(
+                result,
+                None if result is ActuationResult.ACCEPTED else result.value,
+            ),
+            poison=(
+                claim.operation in _ON_OPERATIONS
+                and result is ActuationResult.UNCERTAIN
+            ),
+        )
+
+    async def _finish(
+        self, claim: _Claim, outcome: _Outcome, *, poison: bool = False
+    ) -> None:
+        async with self._lock:
+            if claim.result.done():
+                return
+            self._claims.pop((claim.token, claim.operation), None)
+            claim.result.set_result(outcome)
+            if poison:
+                self._poison_locked(claim.token.provider_generation)
+
+    async def _cancel_waiter(self, claim: _Claim) -> _Outcome:
+        async with self._lock:
+            if not claim.result.done():
+                self._displace_locked(
+                    claim,
+                    before="attempt cancelled before dispatch",
+                    after="attempt cancelled after dispatch",
+                )
+            return claim.result.result()
+
+    def _displace_locked(
+        self,
+        claim: _Claim,
+        *,
+        before: str = "superseded before dispatch",
+        after: str = "superseded after dispatch",
+    ) -> None:
+        if claim.result.done():
+            return
+        self._claims.pop((claim.token, claim.operation), None)
+        if claim.provider is not None:
+            claim.provider.cancel()
+            claim.provider.add_done_callback(self._harvest)
+        if claim.driver is not None:
+            claim.driver.cancel()
+        result = (
+            ActuationResult.UNCERTAIN if claim.started else ActuationResult.REJECTED
+        )
+        claim.result.set_result(_Outcome(result, after if claim.started else before))
+        if claim.started and claim.operation in _ON_OPERATIONS:
+            self._poison_locked(claim.token.provider_generation)
+
+    def _poison_locked(self, provider_generation: int) -> None:
+        if provider_generation <= self._poisoned_through_generation:
+            return
+        self._poisoned_through_generation = provider_generation
+        task = asyncio.ensure_future(self._poison_generation(provider_generation))
+        task.add_done_callback(self._harvest)
+
+    @staticmethod
+    def _harvest(task: asyncio.Future[Any]) -> None:
+        if not task.cancelled():
+            task.exception()
+
+
+def _error_text(error: BaseException) -> str:
+    return str(error) or type(error).__name__

--- a/tests/test_managed_tx_effect_lane.py
+++ b/tests/test_managed_tx_effect_lane.py
@@ -1,0 +1,291 @@
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from rigplane.runtime.managed_tx_effect_lane import (
+    ManagedTxActuator,
+    ManagedTxEffectLane,
+)
+from rigplane.runtime.managed_tx_state import (
+    AbortFailed,
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    ActuationSettled,
+    EffectToken,
+    ForceOff,
+    ManagedTxEffect,
+    ManagedTxOutcome,
+    ManagedTxState,
+    reduce_managed_tx,
+)
+
+_Action = Callable[[], Awaitable[ActuationResult]]
+_Operation = ActuationOperation | AbortOperation
+
+
+class FakeActuator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[EffectToken, _Operation]] = []
+        self.actions: dict[_Operation, ActuationResult | BaseException | _Action] = {}
+
+    async def actuate(self, token: EffectToken, op: _Operation) -> ActuationResult:
+        self.calls.append((token, op))
+        action = self.actions.get(op, ActuationResult.ACCEPTED)
+        if isinstance(action, BaseException):
+            raise action
+        if callable(action):
+            return await action()
+        return action
+
+
+def effect(
+    operation: ActuationOperation = ActuationOperation.PTT_ON,
+    generation: int = 7,
+    epoch: int = 3,
+    attempt: str = "attempt-1",
+) -> ManagedTxEffect:
+    return ManagedTxEffect(operation, EffectToken(generation, epoch, attempt))
+
+
+async def settle(
+    lane: ManagedTxEffectLane,
+    requested: ManagedTxEffect,
+    timeout: float = 1,
+) -> ActuationSettled:
+    deadline = time.monotonic() + timeout
+    return await lane.settle(requested, deadline_monotonic=deadline)
+
+
+def blocking_action(
+    started: asyncio.Event,
+    release: asyncio.Event,
+    resist_cancellation: bool = False,
+    cancelled: asyncio.Event | None = None,
+) -> _Action:
+    async def action() -> ActuationResult:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            if not resist_cancellation:
+                raise
+            if cancelled is not None:
+                cancelled.set()
+            await release.wait()
+        return ActuationResult.ACCEPTED
+
+    return action
+
+
+def poison_lane(actuator: FakeActuator, poisoned: list[int]) -> ManagedTxEffectLane:
+    async def poison(generation: int) -> None:
+        poisoned.append(generation)
+
+    return ManagedTxEffectLane(actuator, poison_generation=poison)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", list(ActuationResult))
+async def test_preserves_explicit_normalized_result(result: ActuationResult) -> None:
+    actuator = FakeActuator()
+    actuator.actions[ActuationOperation.PTT_ON] = result
+    lane = ManagedTxEffectLane(actuator)
+    requested = effect()
+    settled = await settle(lane, requested)
+    assert isinstance(actuator, ManagedTxActuator)
+    assert settled == ActuationSettled(
+        requested.token,
+        requested.operation,
+        result,
+        None if result is ActuationResult.ACCEPTED else result.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_claim_executes_actuator_exactly_once() -> None:
+    actuator = FakeActuator()
+    started, release = asyncio.Event(), asyncio.Event()
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(started, release)
+    lane = ManagedTxEffectLane(actuator)
+    requested = effect()
+    calls = [asyncio.create_task(settle(lane, requested)) for _ in range(3)]
+    await asyncio.wait_for(started.wait(), 0.2)
+    assert actuator.calls == [(requested.token, requested.operation)]
+    release.set()
+    results = await asyncio.gather(*calls)
+    assert results == [results[0]] * 3
+
+
+@pytest.mark.asyncio
+async def test_claim_identity_includes_every_token_field_and_operation() -> None:
+    actuator = FakeActuator()
+    lane = ManagedTxEffectLane(actuator)
+    requests = (
+        effect(attempt="base"),
+        effect(generation=8, attempt="base"),
+        effect(epoch=4, attempt="base"),
+        effect(attempt="other"),
+        effect(ActuationOperation.TRANSMIT_ON, attempt="base"),
+    )
+    await asyncio.gather(*(settle(lane, item) for item in requests))
+    assert actuator.calls == [(item.token, item.operation) for item in requests]
+
+
+@pytest.mark.asyncio
+async def test_expired_before_entry_is_rejected_without_provider_call() -> None:
+    actuator = FakeActuator()
+    lane = ManagedTxEffectLane(actuator, clock=lambda: 20.0)
+    settled = await lane.settle(effect(), deadline_monotonic=20.0)
+    assert settled.result is ActuationResult.REJECTED
+    assert settled.error == "deadline expired before dispatch"
+    assert actuator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_started_timeout_is_uncertain_and_poisons_generation_once() -> None:
+    actuator = FakeActuator()
+    started, release, ignored_cancel = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    poisoned: list[int] = []
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
+        started, release, resist_cancellation=True, cancelled=ignored_cancel
+    )
+    lane = poison_lane(actuator, poisoned)
+    settled = await settle(lane, effect(), 0.01)
+    assert started.is_set() and settled.result is ActuationResult.UNCERTAIN
+    assert settled.error == "attempt deadline expired"
+    await asyncio.wait_for(ignored_cancel.wait(), 0.2)
+    await asyncio.sleep(0)
+    assert poisoned == [7]
+    assert not lane._claims
+    release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [ConnectionError("provider disconnected"), asyncio.CancelledError()],
+)
+async def test_provider_failure_is_uncertain(failure: BaseException) -> None:
+    actuator = FakeActuator()
+    poisoned: list[int] = []
+    actuator.actions[ActuationOperation.PTT_ON] = failure
+    lane = poison_lane(actuator, poisoned)
+    settled = await settle(lane, effect())
+    await asyncio.sleep(0)
+    assert settled.result is ActuationResult.UNCERTAIN
+    assert poisoned == [7]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_waiter_after_dispatch_returns_uncertain() -> None:
+    actuator = FakeActuator()
+    started, release = asyncio.Event(), asyncio.Event()
+    poisoned: list[int] = []
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(started, release)
+    lane = poison_lane(actuator, poisoned)
+    task = asyncio.create_task(settle(lane, effect()))
+    await asyncio.wait_for(started.wait(), 0.2)
+    task.cancel()
+    settled = await task
+    await asyncio.sleep(0)
+    assert settled.result is ActuationResult.UNCERTAIN
+    assert settled.error == "attempt cancelled after dispatch"
+    assert poisoned == [7]
+    release.set()
+
+
+@pytest.mark.asyncio
+async def test_force_receive_bypasses_and_poisons_inflight_on() -> None:
+    actuator = FakeActuator()
+    started, release, force_started = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    poisoned: list[int] = []
+
+    async def force_receive() -> ActuationResult:
+        force_started.set()
+        return ActuationResult.ACCEPTED
+
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
+        started, release, resist_cancellation=True
+    )
+    actuator.actions[ActuationOperation.FORCE_RECEIVE] = force_receive
+    lane = poison_lane(actuator, poisoned)
+    on_task = asyncio.create_task(settle(lane, effect()))
+    await asyncio.wait_for(started.wait(), 0.2)
+    stale = effect(ActuationOperation.FORCE_RECEIVE, generation=6, attempt="stale")
+    rejected = await settle(lane, stale)
+    assert rejected.result is ActuationResult.REJECTED and not on_task.done()
+    force = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="off")
+    forced = await asyncio.wait_for(settle(lane, force), 0.2)
+    displaced = await asyncio.wait_for(on_task, 0.2)
+    assert force_started.is_set() and not release.is_set()
+    assert forced.result is ActuationResult.ACCEPTED
+    assert displaced.result is ActuationResult.UNCERTAIN
+    assert displaced.error == "superseded after dispatch"
+    await asyncio.sleep(0)
+    assert poisoned == [7]
+    release.set()
+
+
+@pytest.mark.asyncio
+async def test_force_receive_rejects_queued_on_without_dispatch_or_poison() -> None:
+    actuator = FakeActuator()
+    started, release = asyncio.Event(), asyncio.Event()
+    poisoned: list[int] = []
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
+        started, release, resist_cancellation=True
+    )
+    lane = poison_lane(actuator, poisoned)
+    active = asyncio.create_task(settle(lane, effect(attempt="active")))
+    await asyncio.wait_for(started.wait(), 0.2)
+    queued_effect = effect(attempt="queued")
+    queued = asyncio.create_task(settle(lane, queued_effect))
+    await asyncio.sleep(0)
+    force = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="off")
+    await settle(lane, force)
+    _, queued_result = await asyncio.gather(active, queued)
+    assert queued_result.result is ActuationResult.REJECTED
+    assert queued_result.error == "superseded before dispatch"
+    assert queued_effect.token not in [token for token, _ in actuator.calls]
+    await asyncio.sleep(0)
+    assert poisoned == [7]
+    release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result,error",
+    [
+        (ActuationResult.ACCEPTED, None),
+        (ActuationResult.REJECTED, "rejected"),
+        (ActuationResult.UNCERTAIN, "uncertain"),
+    ],
+)
+async def test_abort_binding(result: ActuationResult, error: str | None) -> None:
+    actuator = FakeActuator()
+    actuator.actions[AbortOperation.STOP_CW] = result
+    lane = ManagedTxEffectLane(actuator)
+    token = EffectToken(9, 5, "force")
+    failed = await lane.settle_abort(
+        token,
+        AbortOperation.STOP_CW,
+        deadline_monotonic=time.monotonic() + 1,
+    )
+    assert failed == (
+        None if error is None else AbortFailed(token, AbortOperation.STOP_CW, error)
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_lane_settlement_cannot_clear_current_release_debt() -> None:
+    lane = ManagedTxEffectLane(FakeActuator())
+    transition = reduce_managed_tx(ManagedTxState(), ForceOff(8, "current"))
+    current = transition.state.pending_effect
+    assert current is not None
+    stale = effect(current.operation, 8, current.token.effect_epoch - 1, "stale")
+    stale_settlement = await settle(lane, stale)
+    reduced = reduce_managed_tx(transition.state, stale_settlement)
+    assert reduced.outcome is ManagedTxOutcome.STALE
+    assert reduced.state.release_required

--- a/tests/test_managed_tx_effect_lane.py
+++ b/tests/test_managed_tx_effect_lane.py
@@ -116,22 +116,39 @@ async def test_concurrent_duplicate_claim_executes_actuator_exactly_once() -> No
     assert actuator.calls == [(requested.token, requested.operation)]
     release.set()
     results = await asyncio.gather(*calls)
-    assert results == [results[0]] * 3
+    assert isinstance(results[0], ActuationSettled)
+    assert results[1:] == [None, None]
 
 
 @pytest.mark.asyncio
-async def test_claim_identity_includes_every_token_field_and_operation() -> None:
+async def test_replay_conflict_stale_scope_and_attempt_order_do_not_execute() -> None:
     actuator = FakeActuator()
     lane = ManagedTxEffectLane(actuator)
-    requests = (
-        effect(attempt="base"),
-        effect(generation=8, attempt="base"),
-        effect(epoch=4, attempt="base"),
-        effect(attempt="other"),
-        effect(ActuationOperation.TRANSMIT_ON, attempt="base"),
-    )
-    await asyncio.gather(*(settle(lane, item) for item in requests))
-    assert actuator.calls == [(item.token, item.operation) for item in requests]
+    base = effect(ActuationOperation.FORCE_RECEIVE, attempt="opaque-old")
+    assert (await settle(lane, base)).result is ActuationResult.ACCEPTED
+    assert await settle(lane, base) is None
+    assert await settle(lane, effect(attempt="opaque-old")) is None
+    started, release = asyncio.Event(), asyncio.Event()
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(started, release)
+    current = effect(attempt="opaque-new")
+    on = asyncio.create_task(settle(lane, current))
+    await asyncio.wait_for(started.wait(), 0.2)
+    assert await settle(lane, base) is None and not on.done()
+    queued = asyncio.create_task(settle(lane, effect(attempt="queued")))
+    await asyncio.sleep(0)
+    actuator.actions[ActuationOperation.PTT_ON] = ActuationResult.ACCEPTED
+    newer = effect(generation=8, attempt="newer")
+    assert (await settle(lane, newer)).result is ActuationResult.ACCEPTED
+    assert [item.result for item in await asyncio.gather(on, queued)] == [
+        ActuationResult.UNCERTAIN,
+        ActuationResult.REJECTED,
+    ]
+    assert await settle(lane, effect(attempt="late-old")) is None
+    assert [token for token, _ in actuator.calls] == [
+        base.token,
+        current.token,
+        newer.token,
+    ]
 
 
 @pytest.mark.asyncio
@@ -180,53 +197,75 @@ async def test_provider_failure_is_uncertain(failure: BaseException) -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancelling_waiter_after_dispatch_returns_uncertain() -> None:
+async def test_force_receive_bypasses_and_poisons_inflight_on() -> None:
     actuator = FakeActuator()
     started, release = asyncio.Event(), asyncio.Event()
     poisoned: list[int] = []
-    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(started, release)
-    lane = poison_lane(actuator, poisoned)
-    task = asyncio.create_task(settle(lane, effect()))
-    await asyncio.wait_for(started.wait(), 0.2)
-    task.cancel()
-    settled = await task
-    await asyncio.sleep(0)
-    assert settled.result is ActuationResult.UNCERTAIN
-    assert settled.error == "attempt cancelled after dispatch"
-    assert poisoned == [7]
-    release.set()
-
-
-@pytest.mark.asyncio
-async def test_force_receive_bypasses_and_poisons_inflight_on() -> None:
-    actuator = FakeActuator()
-    started, release, force_started = asyncio.Event(), asyncio.Event(), asyncio.Event()
-    poisoned: list[int] = []
-
-    async def force_receive() -> ActuationResult:
-        force_started.set()
-        return ActuationResult.ACCEPTED
 
     actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
         started, release, resist_cancellation=True
     )
-    actuator.actions[ActuationOperation.FORCE_RECEIVE] = force_receive
     lane = poison_lane(actuator, poisoned)
     on_task = asyncio.create_task(settle(lane, effect()))
     await asyncio.wait_for(started.wait(), 0.2)
     stale = effect(ActuationOperation.FORCE_RECEIVE, generation=6, attempt="stale")
-    rejected = await settle(lane, stale)
-    assert rejected.result is ActuationResult.REJECTED and not on_task.done()
+    assert await settle(lane, stale) is None
+    assert not on_task.done()
     force = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="off")
     forced = await asyncio.wait_for(settle(lane, force), 0.2)
     displaced = await asyncio.wait_for(on_task, 0.2)
-    assert force_started.is_set() and not release.is_set()
+    assert not release.is_set()
     assert forced.result is ActuationResult.ACCEPTED
     assert displaced.result is ActuationResult.UNCERTAIN
     assert displaced.error == "superseded after dispatch"
     await asyncio.sleep(0)
     assert poisoned == [7]
     release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "isolation_fails,preexisting", [(False, False), (True, False), (False, True)]
+)
+async def test_force_receive_awaits_isolation_and_maps_failure(
+    isolation_fails: bool, preexisting: bool
+) -> None:
+    actuator = FakeActuator()
+    on_started, on_release = asyncio.Event(), asyncio.Event()
+    isolation_started, isolated = asyncio.Event(), asyncio.Event()
+
+    async def isolate(_: int) -> None:
+        isolation_started.set()
+        if isolation_fails:
+            raise RuntimeError("isolation failed")
+        await isolated.wait()
+
+    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
+        on_started, on_release, resist_cancellation=True
+    )
+    lane = ManagedTxEffectLane(actuator, poison_generation=isolate)
+    on = asyncio.create_task(settle(lane, effect(attempt="on")))
+    await asyncio.wait_for(on_started.wait(), 0.2)
+    if preexisting:
+        on.cancel()
+        assert (await on).error == "attempt cancelled after dispatch"
+        await asyncio.wait_for(isolation_started.wait(), 0.2)
+    force = asyncio.create_task(
+        settle(lane, effect(ActuationOperation.FORCE_RECEIVE, attempt="off"))
+    )
+    await asyncio.wait_for(isolation_started.wait(), 0.2)
+    if not isolation_fails:
+        assert not force.done() and not on_release.is_set()
+        isolated.set()
+    forced = await asyncio.wait_for(force, 0.2)
+    expected = (
+        ActuationResult.UNCERTAIN if isolation_fails else ActuationResult.ACCEPTED
+    )
+    assert forced.result is expected
+    assert forced.error == ("isolation failed" if isolation_fails else None)
+    if not preexisting:
+        assert (await on).result is ActuationResult.UNCERTAIN
+    on_release.set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_effect_lane.py
+++ b/tests/test_managed_tx_effect_lane.py
@@ -19,6 +19,7 @@ from rigplane.runtime.managed_tx_state import (
     ManagedTxEffect,
     ManagedTxOutcome,
     ManagedTxState,
+    RetryForceReceive,
     reduce_managed_tx,
 )
 
@@ -121,32 +122,26 @@ async def test_concurrent_duplicate_claim_executes_actuator_exactly_once() -> No
 
 
 @pytest.mark.asyncio
-async def test_replay_conflict_stale_scope_and_attempt_order_do_not_execute() -> None:
+async def test_fixed_primary_slots_bound_replay_and_conflicts() -> None:
     actuator = FakeActuator()
     lane = ManagedTxEffectLane(actuator)
-    base = effect(ActuationOperation.FORCE_RECEIVE, attempt="opaque-old")
-    assert (await settle(lane, base)).result is ActuationResult.ACCEPTED
-    assert await settle(lane, base) is None
-    assert await settle(lane, effect(attempt="opaque-old")) is None
-    started, release = asyncio.Event(), asyncio.Event()
-    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(started, release)
-    current = effect(attempt="opaque-new")
-    on = asyncio.create_task(settle(lane, current))
-    await asyncio.wait_for(started.wait(), 0.2)
-    assert await settle(lane, base) is None and not on.done()
-    queued = asyncio.create_task(settle(lane, effect(attempt="queued")))
-    await asyncio.sleep(0)
-    actuator.actions[ActuationOperation.PTT_ON] = ActuationResult.ACCEPTED
-    newer = effect(generation=8, attempt="newer")
+    on = effect(attempt="on")
+    force = effect(ActuationOperation.FORCE_RECEIVE, attempt="off")
+    assert (await settle(lane, on)).result is ActuationResult.ACCEPTED
+    assert (await settle(lane, force)).result is ActuationResult.ACCEPTED
+    for attempt in range(1_000):
+        retry = effect(ActuationOperation.FORCE_RECEIVE, attempt=str(attempt))
+        assert await settle(lane, retry) is None
+    assert (
+        await settle(lane, effect(ActuationOperation.TRANSMIT_ON, attempt="on")) is None
+    )
+    assert len(lane._slots) == 2 and not lane._claims
+    newer = effect(generation=8, epoch=4, attempt="newer")
     assert (await settle(lane, newer)).result is ActuationResult.ACCEPTED
-    assert [item.result for item in await asyncio.gather(on, queued)] == [
-        ActuationResult.UNCERTAIN,
-        ActuationResult.REJECTED,
-    ]
     assert await settle(lane, effect(attempt="late-old")) is None
     assert [token for token, _ in actuator.calls] == [
-        base.token,
-        current.token,
+        on.token,
+        force.token,
         newer.token,
     ]
 
@@ -225,10 +220,17 @@ async def test_force_receive_bypasses_and_poisons_inflight_on() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "isolation_fails,preexisting", [(False, False), (True, False), (False, True)]
+    "mode,preexisting",
+    [
+        ("success", False),
+        ("failure", False),
+        ("success", True),
+        ("deadline", False),
+        ("cancel", False),
+    ],
 )
 async def test_force_receive_awaits_isolation_and_maps_failure(
-    isolation_fails: bool, preexisting: bool
+    mode: str, preexisting: bool
 ) -> None:
     actuator = FakeActuator()
     on_started, on_release = asyncio.Event(), asyncio.Event()
@@ -236,8 +238,10 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
 
     async def isolate(_: int) -> None:
         isolation_started.set()
-        if isolation_fails:
+        if mode == "failure":
             raise RuntimeError("isolation failed")
+        if mode == "cancel":
+            raise asyncio.CancelledError
         await isolated.wait()
 
     actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
@@ -251,18 +255,30 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
         assert (await on).error == "attempt cancelled after dispatch"
         await asyncio.wait_for(isolation_started.wait(), 0.2)
     force = asyncio.create_task(
-        settle(lane, effect(ActuationOperation.FORCE_RECEIVE, attempt="off"))
+        settle(
+            lane,
+            effect(ActuationOperation.FORCE_RECEIVE, attempt="off"),
+            0.01 if mode == "deadline" else 1,
+        )
     )
     await asyncio.wait_for(isolation_started.wait(), 0.2)
-    if not isolation_fails:
+    if mode == "success":
         assert not force.done() and not on_release.is_set()
         isolated.set()
     forced = await asyncio.wait_for(force, 0.2)
     expected = (
-        ActuationResult.UNCERTAIN if isolation_fails else ActuationResult.ACCEPTED
+        ActuationResult.ACCEPTED if mode == "success" else ActuationResult.UNCERTAIN
     )
     assert forced.result is expected
-    assert forced.error == ("isolation failed" if isolation_fails else None)
+    errors = {
+        "failure": "isolation failed",
+        "deadline": "isolation deadline expired",
+        "cancel": "CancelledError",
+    }
+    assert forced.error == errors.get(mode)
+    if mode == "deadline":
+        assert lane._isolation is not None and not lane._isolation[1].cancelled()
+    isolated.set()
     if not preexisting:
         assert (await on).result is ActuationResult.UNCERTAIN
     on_release.set()
@@ -271,26 +287,21 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
 @pytest.mark.asyncio
 async def test_force_receive_rejects_queued_on_without_dispatch_or_poison() -> None:
     actuator = FakeActuator()
-    started, release = asyncio.Event(), asyncio.Event()
     poisoned: list[int] = []
-    actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
-        started, release, resist_cancellation=True
-    )
     lane = poison_lane(actuator, poisoned)
-    active = asyncio.create_task(settle(lane, effect(attempt="active")))
-    await asyncio.wait_for(started.wait(), 0.2)
+    await lane._on_lane.acquire()
     queued_effect = effect(attempt="queued")
     queued = asyncio.create_task(settle(lane, queued_effect))
     await asyncio.sleep(0)
-    force = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="off")
+    force = effect(ActuationOperation.FORCE_RECEIVE, attempt="off")
     await settle(lane, force)
-    _, queued_result = await asyncio.gather(active, queued)
+    queued_result = await queued
     assert queued_result.result is ActuationResult.REJECTED
     assert queued_result.error == "superseded before dispatch"
     assert queued_effect.token not in [token for token, _ in actuator.calls]
     await asyncio.sleep(0)
-    assert poisoned == [7]
-    release.set()
+    assert poisoned == []
+    lane._on_lane.release()
 
 
 @pytest.mark.asyncio
@@ -318,6 +329,37 @@ async def test_abort_binding(result: ActuationResult, error: str | None) -> None
 
 
 @pytest.mark.asyncio
+async def test_force_receive_and_both_aborts_have_independent_slots() -> None:
+    actuator = FakeActuator()
+    actuator.actions.update(
+        {
+            AbortOperation.STOP_CW: ActuationResult.REJECTED,
+            AbortOperation.STOP_TUNE: ActuationResult.UNCERTAIN,
+        }
+    )
+    lane = ManagedTxEffectLane(actuator)
+    token = EffectToken(9, 5, "force")
+    primary, cw, tune = await asyncio.gather(
+        lane.settle(
+            ManagedTxEffect(ActuationOperation.FORCE_RECEIVE, token),
+            deadline_monotonic=time.monotonic() + 1,
+        ),
+        lane.settle_abort(
+            token, AbortOperation.STOP_CW, deadline_monotonic=time.monotonic() + 1
+        ),
+        lane.settle_abort(
+            token, AbortOperation.STOP_TUNE, deadline_monotonic=time.monotonic() + 1
+        ),
+    )
+    assert primary.result is ActuationResult.ACCEPTED
+    assert (cw, tune) == (
+        AbortFailed(token, AbortOperation.STOP_CW, "rejected"),
+        AbortFailed(token, AbortOperation.STOP_TUNE, "uncertain"),
+    )
+    assert len(actuator.calls) == len(lane._slots) == 3
+
+
+@pytest.mark.asyncio
 async def test_stale_lane_settlement_cannot_clear_current_release_debt() -> None:
     lane = ManagedTxEffectLane(FakeActuator())
     transition = reduce_managed_tx(ManagedTxState(), ForceOff(8, "current"))
@@ -328,3 +370,42 @@ async def test_stale_lane_settlement_cannot_clear_current_release_debt() -> None
     reduced = reduce_managed_tx(transition.state, stale_settlement)
     assert reduced.outcome is ManagedTxOutcome.STALE
     assert reduced.state.release_required
+
+
+@pytest.mark.asyncio
+async def test_ten_thousand_authority_epochs_keep_lane_bounded() -> None:
+    actuator = FakeActuator()
+    actuator.actions[ActuationOperation.FORCE_RECEIVE] = ActuationResult.REJECTED
+    lane = ManagedTxEffectLane(actuator)
+    state = reduce_managed_tx(ManagedTxState(), ForceOff(8, "initial")).state
+    for attempt in range(10_000):
+        assert state.pending_effect is not None
+        settled = await settle(lane, state.pending_effect)
+        state = reduce_managed_tx(state, settled).state
+        transition = reduce_managed_tx(state, RetryForceReceive(8, str(attempt)))
+        assert transition.outcome is ManagedTxOutcome.ACCEPTED
+        state = transition.state
+        assert len(lane._slots) == 1 and not lane._claims
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", list(ActuationResult))
+async def test_retry_epoch_prevents_stale_release_clear(
+    result: ActuationResult,
+) -> None:
+    actuator = FakeActuator()
+    actuator.actions[ActuationOperation.FORCE_RECEIVE] = result
+    lane = ManagedTxEffectLane(actuator)
+    forced = reduce_managed_tx(ManagedTxState(), ForceOff(8, "force"))
+    assert forced.state.pending_effect is not None
+    settled = await settle(lane, forced.state.pending_effect)
+    state = reduce_managed_tx(forced.state, settled).state
+    retry = reduce_managed_tx(state, RetryForceReceive(8, "retry"))
+    if result is ActuationResult.ACCEPTED:
+        assert retry.outcome is ManagedTxOutcome.REJECTED
+        assert not state.release_required
+    else:
+        stale = reduce_managed_tx(retry.state, settled)
+        assert retry.outcome is ManagedTxOutcome.ACCEPTED
+        assert stale.outcome is ManagedTxOutcome.STALE
+        assert stale.state.release_required


### PR DESCRIPTION
## Summary
- add a provider-neutral managed TX actuator protocol and token-bound effect lane
- normalize semantic actuation results and bounded deadlines
- use the authority-issued `(provider_generation, effect_epoch)` contract from MOR-2205 with four fixed current-scope slots: one ON, one ForceReceive, STOP_CW, and STOP_TUNE
- allow the primary release and both subordinate aborts to execute independently for the exact ForceOff family token
- suppress stale scopes, slot replay, conflicting primary use, and duplicate settlement fan-out without unbounded attempt history
- await shared generation isolation only through each caller deadline; timeout/failure/cancellation maps the original ForceReceive identity to UNCERTAIN without cancelling the shared task

Linear: https://linear.app/morozsm/issue/MOR-2198/mor-21664-normalize-managed-tx-actuation-outcomes-and-effect-lane

## TDD evidence
Initial RED:
- collection failed with `ModuleNotFoundError` before the production module existed.

First review-fix RED at `141901a0047d8b9feea1459ef580cd7c3ad74ccf`:
- 4 deterministic failures reproduced duplicate settlement fan-out, completed replay, isolation failure incorrectly returning ACCEPTED, and stale-attempt behavior.

Canonical-epoch review-fix RED after MOR-2205:
- 4 deterministic failures / 17 passing cases reproduced unbounded same-scope retries, missing fixed slots, token-wide abort collision, and hung isolation exceeding its deadline.

GREEN after rebase onto `3663603c600522c929215c87cde81e76c0a2a314`:
- focused asyncio-debug suite with warnings as errors: 25 passed
- 1,000 hostile same-scope retry attempts retain exactly two used primary slots and execute each primary once
- 10,000 authority-issued RetryForceReceive epochs retain one current slot and zero drained claims per cycle
- reducer result matrix proves old release settlement cannot clear a newer retry epoch
- 25 repeated race/mutation runs cover slot identity, duplicate ownership, abort siblings, ForceReceive priority, isolation deadline/failure/cancellation, shared-task joining, and late harvesting: PASS
- Ruff check and format check: PASS
- targeted strict mypy: PASS
- import contracts: 5/5 kept
- doc citation/link, rebrand, diff, exact-scope, and corrected word-boundary retired-name gates: PASS

## Scope
Exactly two new files, 746 insertions: 335 production and 411 tests. No modifications to reducer/MOR-2205, legacy effect service, providers, Web/UI, dispatch/admission, configuration, or MOR-2161 reserved paths.

No hardware required: provider-neutral fake-actuator unit scope only.

This PR is not approved for merge by its implementation agent.