### PR TITLE
refactor(runtime): add canonical command dispatch path

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -11,11 +11,13 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from ...exceptions import CommandError
 from ...exceptions import TimeoutError as RadioTimeoutError
+from ...core.command_dispatch import execute_command_intent
 from ...core.radio_protocol import (
     PhysicalWriteReadbackResult,
     PhysicalWriteReadbackStatus,
 )
 from ...core.state_pipeline_contracts import (
+    CommandIntent,
     CommandSource,
     FieldPath,
     Observation,
@@ -319,6 +321,9 @@ class RigctldClientObservationPoller:
         return tuple(annotated)
 
     async def _execute_command(self, cmd: Any) -> None:
+        if isinstance(cmd, CommandIntent):
+            await execute_command_intent(self._radio, cmd)
+            return
         from ..._poller_types import (
             PttOff,
             PttOn,

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -29,6 +29,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from rigplane.core.command_service import _is_yaesu_cat_readback, _yaesu_receiver_alias
+from rigplane.core.command_dispatch import execute_command_intent
 from rigplane.core.observation_adapter import ProviderObservationAdapter
 from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
@@ -895,6 +896,9 @@ class YaesuCatPoller:
         Commands come from the web UI CommandQueue.  The dispatcher handles
         all command types; unsupported commands fail truthfully.
         """
+        if isinstance(cmd, CommandIntent):
+            await execute_command_intent(self._radio, cmd)
+            return
         decision = evaluate_tx_interlock(
             cmd,
             rf_state=self._current_rf_state(),

--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -1,0 +1,150 @@
+"""Descriptor-backed command dispatch shared by every runtime drain.
+
+Profiles remain authoritative for radio/model support and wire facts.  This
+module owns only backend-neutral operation mechanics: public name, reviewed
+Radio method, parameter binding, semantic target, timeout, and queue policy.
+Every migrated operation is admitted, queued, invoked, and audited through the
+same descriptor; drains must not add operation-specific branches.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Literal, Protocol
+
+from rigplane.core.exceptions import CommandError
+from rigplane.core.state_pipeline_contracts import (
+    CommandIntent,
+    CommandSource,
+    FieldPath,
+)
+
+__all__ = [
+    "CommandDescriptor",
+    "CommandUnsupportedError",
+    "command_descriptor",
+    "command_descriptors",
+    "execute_command_intent",
+    "prepare_command_intent",
+]
+
+
+class CommandUnsupportedError(CommandError):
+    """Raised before queueing when the active profile rejects an operation."""
+
+
+class DispatchRadio(Protocol):
+    def supports_command(self, command: str) -> bool: ...
+
+
+Binder = Callable[[Mapping[str, Any]], dict[str, Any]]
+TargetBuilder = Callable[[Mapping[str, Any]], FieldPath]
+
+
+@dataclass(frozen=True, slots=True)
+class CommandDescriptor:
+    """One operation's backend-neutral execution mechanics."""
+
+    name: str
+    method_name: str
+    bind: Binder
+    target: TargetBuilder
+    argument_names: tuple[str, ...]
+    timeout: float = 10.0
+    queue_policy: Literal["ordered"] = "ordered"
+
+    def result(self, intent: CommandIntent) -> dict[str, Any]:
+        return {name: intent.params[name] for name in self.argument_names}
+
+
+def _bind_repeater_shift(params: Mapping[str, Any]) -> dict[str, Any]:
+    raw_direction = params["direction"]
+    raw_receiver = params.get("receiver", 0)
+    if isinstance(raw_direction, bool) or not isinstance(raw_direction, int):
+        raise ValueError("direction must be an integer 0-3")
+    if not 0 <= raw_direction <= 3:
+        raise ValueError("direction must be an integer 0-3")
+    if isinstance(raw_receiver, bool) or not isinstance(raw_receiver, int):
+        raise ValueError("receiver must be 0 or 1")
+    if raw_receiver not in (0, 1):
+        raise ValueError("receiver must be 0 or 1")
+    return {
+        "direction": int(raw_direction),
+        "receiver": int(raw_receiver),
+        "repeater_shift": int(raw_direction),
+    }
+
+
+def _repeater_shift_target(params: Mapping[str, Any]) -> FieldPath:
+    return FieldPath.receiver(
+        str(params["receiver"]), "operator_controls", "repeater_shift"
+    )
+
+
+_COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
+    {
+        "set_repeater_shift": CommandDescriptor(
+            name="set_repeater_shift",
+            method_name="set_repeater_shift",
+            bind=_bind_repeater_shift,
+            target=_repeater_shift_target,
+            argument_names=("direction", "receiver"),
+        )
+    }
+)
+
+
+def command_descriptors() -> Mapping[str, CommandDescriptor]:
+    return _COMMAND_DESCRIPTORS
+
+
+def command_descriptor(name: str) -> CommandDescriptor | None:
+    return _COMMAND_DESCRIPTORS.get(name)
+
+
+def prepare_command_intent(
+    radio: DispatchRadio,
+    name: str,
+    params: Mapping[str, Any],
+    *,
+    source: CommandSource,
+    command_id: str | None = None,
+    session_id: str | None = None,
+) -> CommandIntent:
+    """Bind and admit one descriptor operation before CommandService state."""
+
+    descriptor = command_descriptor(name)
+    if descriptor is None:
+        raise KeyError(f"no command descriptor for {name!r}")
+    normalized = descriptor.bind(params)
+    if session_id is not None:
+        normalized["session_id"] = session_id
+    if not radio.supports_command(descriptor.name):
+        raise CommandUnsupportedError(
+            f"command {descriptor.name!r} is not supported by active profile"
+        )
+    target = descriptor.target(normalized)
+    return CommandIntent(
+        id=command_id or f"{source}-{time.monotonic_ns()}",
+        name=descriptor.name,
+        params=normalized,
+        source=source,
+        target=target,
+        priority="user",
+        timeout=descriptor.timeout,
+        pending_policy="scoped",
+        expected_observations=(target,),
+    )
+
+
+async def execute_command_intent(radio: Any, intent: CommandIntent) -> None:
+    """Invoke the reviewed Radio method for a descriptor-built intent."""
+
+    descriptor = command_descriptor(intent.name)
+    if descriptor is None:
+        raise CommandError(f"no command descriptor for {intent.name!r}")
+    method = getattr(radio, descriptor.method_name)
+    await method(**{name: intent.params[name] for name in descriptor.argument_names})

--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -9,6 +9,7 @@ same descriptor; drains must not add operation-specific branches.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -27,6 +28,7 @@ __all__ = [
     "CommandUnsupportedError",
     "command_descriptor",
     "command_descriptors",
+    "enqueue_command_intent",
     "execute_command_intent",
     "prepare_command_intent",
 ]
@@ -38,6 +40,15 @@ class CommandUnsupportedError(CommandError):
 
 class DispatchRadio(Protocol):
     def supports_command(self, command: str) -> bool: ...
+
+
+class DispatchQueue(Protocol):
+    def put_ordered(
+        self,
+        command: Any,
+        *,
+        future: asyncio.Future[None] | None = None,
+    ) -> None: ...
 
 
 Binder = Callable[[Mapping[str, Any]], dict[str, Any]]
@@ -103,6 +114,25 @@ def command_descriptors() -> Mapping[str, CommandDescriptor]:
 
 def command_descriptor(name: str) -> CommandDescriptor | None:
     return _COMMAND_DESCRIPTORS.get(name)
+
+
+def enqueue_command_intent(
+    queue: DispatchQueue,
+    intent: CommandIntent,
+    *,
+    future: asyncio.Future[None],
+) -> None:
+    """Enqueue through the policy owned by the command descriptor."""
+
+    descriptor = command_descriptor(intent.name)
+    if descriptor is None:
+        raise CommandError(f"no command descriptor for {intent.name!r}")
+    if descriptor.queue_policy == "ordered":
+        queue.put_ordered(intent, future=future)
+        return
+    raise CommandError(
+        f"unsupported queue policy {descriptor.queue_policy!r} for {descriptor.name!r}"
+    )
 
 
 def prepare_command_intent(

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -178,6 +178,15 @@ class CommandService:
 
         try:
             executor_result = await self._executor.execute(intent)
+        except asyncio.CancelledError:
+            if self._active_commands.get(key) is sent_event:
+                self.expire_command(
+                    intent.id,
+                    source=intent.source,
+                    session_id=_session_id(intent),
+                )
+                self.emit_lifecycle(intent, "failed", message="command cancelled")
+            raise
         except (TimeoutError, RigplaneTimeoutError) as exc:
             if self._active_commands.get(key) is sent_event:
                 self.expire_command(

--- a/src/rigplane/runtime/_poller_types.py
+++ b/src/rigplane/runtime/_poller_types.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
-from rigplane.core.state_pipeline_contracts import CommandSource
+from rigplane.core.state_pipeline_contracts import CommandIntent, CommandSource
 
 __all__ = [
     "Command",
@@ -98,7 +98,6 @@ __all__ = [
     "SetQuickDualWatch",
     "SetQuickSplit",
     "SetRefAdjust",
-    "SetRepeaterShift",
     "SetRepeaterTone",
     "SetRepeaterTsql",
     "SetRfGain",
@@ -679,12 +678,6 @@ class SetDashRatio:
 
 
 @dataclass(frozen=True, slots=True)
-class SetRepeaterShift:
-    direction: int
-    receiver: int = 0
-
-
-@dataclass(frozen=True, slots=True)
 class SetRepeaterTone:
     on: bool
     receiver: int = 0
@@ -850,8 +843,9 @@ class Speak:
     mode: int = 0
 
 
-Command = (
-    SetFreq
+Command: TypeAlias = (
+    CommandIntent
+    | SetFreq
     | SetMode
     | SendCiv
     | SetFilter

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -17,7 +17,14 @@ from ...core.command_service import (
     _raw_int_level_from_param,
     command_intent_from_request,
 )
-from ...core.exceptions import CommandError
+from ...core.command_dispatch import (
+    CommandUnsupportedError,
+    command_descriptor,
+    command_descriptors,
+    prepare_command_intent,
+)
+from ...core.exceptions import CommandError, CommandRejectedError
+from ...core.exceptions import TimeoutError as RigplaneTimeoutError
 from ...core.state_pipeline_contracts import CommandIntent, CommandSource, FieldPath
 from ...core.state_store import FreshnessState, StateStore
 from ...profiles import RadioProfile, resolve_radio_profile
@@ -119,7 +126,6 @@ from ..radio_poller import (  # noqa: TID251
     SetNbDepth,
     SetNbWidth,
     SetDashRatio,
-    SetRepeaterShift,
     SetRepeaterTone,
     SetRepeaterTsql,
     SetRxAntenna,
@@ -214,16 +220,7 @@ class _ControlCommandExecutor:
     handler: "ControlHandler"
 
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
-        params = dict(intent.params)
-        params.pop("_control_server", None)
-        result = await self.handler._enqueue_legacy_command(  # noqa: SLF001
-            intent.name,
-            params,
-            command_id=intent.id,
-            source=intent.source,
-            command_service=self.handler._command_service,  # noqa: SLF001
-        )
-        return CommandExecutionResult(details=result)
+        return await self.handler._execute_intent(intent)  # noqa: SLF001
 
 
 @dataclass(frozen=True, slots=True)
@@ -425,7 +422,6 @@ class ControlHandler:
             "set_nb_depth",
             "set_nb_width",
             "set_dash_ratio",
-            "set_repeater_shift",
             "set_repeater_tone",
             "set_repeater_tsql",
             "set_rx_antenna",
@@ -482,7 +478,7 @@ class ControlHandler:
             # Issue #677 — CW auto-tune via FFT peak detection
             "cw_auto_tune",
         ]
-    )
+    ) | frozenset(command_descriptors())
 
     # Commands that can transmit or send arbitrary radio writes — rejected when read_only=True.
     # set_tuner_status value=2 (TUNING) is handled inline in _enqueue_read_only.
@@ -1252,6 +1248,14 @@ class ControlHandler:
             message = str(exc)
             if isinstance(exc, RadioNotReadyError):
                 error = "radio_not_ready"
+            elif isinstance(exc, CommandUnsupportedError):
+                error = "unsupported_command"
+            elif isinstance(exc, CommandRejectedError):
+                error = "radio_nak"
+            elif isinstance(exc, (TimeoutError, RigplaneTimeoutError)):
+                error = "command_timeout"
+            elif isinstance(exc, CommandError):
+                error = "command_failed"
             elif "does not support" in message or "not supported" in message:
                 error = "unsupported_command"
             else:
@@ -1424,16 +1428,57 @@ class ControlHandler:
             power_max_watts = getattr(
                 getattr(self._radio, "profile", None), "max_watts", None
             )
-        intent = command_intent_from_request(
-            name,
-            intent_params,
-            source=source,
-            command_id=command_id,
-            session_id=self._session_id if source == "websocket" else None,
-            power_max_watts=power_max_watts,
-        )
+        descriptor = command_descriptor(name)
+        if descriptor is not None:
+            intent = prepare_command_intent(
+                self._radio,
+                name,
+                intent_params,
+                source=source,
+                command_id=command_id,
+                session_id=self._session_id if source == "websocket" else None,
+            )
+        else:
+            intent = command_intent_from_request(
+                name,
+                intent_params,
+                source=source,
+                command_id=command_id,
+                session_id=self._session_id if source == "websocket" else None,
+                power_max_watts=power_max_watts,
+            )
         result = await self._command_service.execute(intent)
         return dict(result.executor_result.details or {})
+
+    async def _execute_intent(self, intent: CommandIntent) -> CommandExecutionResult:
+        descriptor = command_descriptor(intent.name)
+        if descriptor is not None:
+            if self._server is None:
+                raise RuntimeError("no command queue available")
+            queue = self._server.command_queue
+            future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            queue.put_ordered(intent, future=future)
+            try:
+                await asyncio.wait_for(future, timeout=intent.timeout)
+            except asyncio.CancelledError:
+                if not future.done():
+                    future.cancel()
+                raise
+            finally:
+                if not future.done():
+                    future.cancel()
+            return CommandExecutionResult(details=descriptor.result(intent))
+
+        params = dict(intent.params)
+        params.pop("_control_server", None)
+        result = await self._enqueue_legacy_command(
+            intent.name,
+            params,
+            command_id=intent.id,
+            source=intent.source,
+            command_service=self._command_service,
+        )
+        return CommandExecutionResult(details=result)
 
     async def _enqueue_legacy_command(
         self,
@@ -2729,13 +2774,6 @@ class ControlHandler:
                 self._ensure_receiver_supported(rx)
                 q.put(SetTsqlFreq(freq, receiver=rx))
                 return {"freq": freq, "receiver": rx}
-            case "set_repeater_shift":
-                direction = int(params["direction"])
-                rx = int(params.get("receiver", 0))
-                self._ensure_capability("repeater_shift", "set_repeater_shift")
-                self._ensure_receiver_supported(rx)
-                q.put(SetRepeaterShift(direction, receiver=rx))
-                return {"direction": direction, "receiver": rx}
             case "set_ref_adjust":
                 value = int(params["value"])
                 q.put(SetRefAdjust(value))

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -21,6 +21,7 @@ from ...core.command_dispatch import (
     CommandUnsupportedError,
     command_descriptor,
     command_descriptors,
+    enqueue_command_intent,
     prepare_command_intent,
 )
 from ...core.exceptions import CommandError, CommandRejectedError
@@ -1457,7 +1458,7 @@ class ControlHandler:
                 raise RuntimeError("no command queue available")
             queue = self._server.command_queue
             future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-            queue.put_ordered(intent, future=future)
+            enqueue_command_intent(queue, intent, future=future)
             try:
                 await asyncio.wait_for(future, timeout=intent.timeout)
             except asyncio.CancelledError:

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1257,7 +1257,9 @@ class ControlHandler:
                 error = "command_timeout"
             elif isinstance(exc, CommandError):
                 error = "command_failed"
-            elif "does not support" in message or "not supported" in message:
+            elif command_descriptor(name) is None and (
+                "does not support" in message or "not supported" in message
+            ):
                 error = "unsupported_command"
             else:
                 error = "command_failed"

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -61,7 +61,6 @@ from ..capabilities import (
     CAP_NR,
     CAP_POWER_CONTROL,
     CAP_PREAMP,
-    CAP_REPEATER_SHIFT,
     CAP_REPEATER_TONE,
     CAP_RF_GAIN,
     CAP_RX_ANTENNA,
@@ -81,6 +80,7 @@ from ..commands.scope import SCOPE_RECEIVER_SELECTOR_SUBS
 from ..core.command_service import (
     CommandService,
 )
+from ..core.command_dispatch import execute_command_intent
 from ..core.acquisition_scheduler import (
     AcquisitionExecutor,
     AcquisitionPriority,
@@ -194,7 +194,6 @@ __all__ = [
     "SetNbDepth",
     "SetNbWidth",
     "SetDashRatio",
-    "SetRepeaterShift",
     "SetRepeaterTone",
     "SetRepeaterTsql",
     "SetRxAntenna",
@@ -443,7 +442,6 @@ from .._poller_types import (  # noqa: E402
     SetQuickDualWatch,
     SetQuickSplit,
     SetRefAdjust,
-    SetRepeaterShift,
     SetRepeaterTone,
     SetRepeaterTsql,
     SetRfGain,
@@ -2238,6 +2236,9 @@ class RadioPoller:
         command_service: CommandService | None = None,
         connection_epoch_bootstrap: bool = False,
     ) -> None:
+        if isinstance(cmd, CommandIntent):
+            await execute_command_intent(self._radio, cmd)
+            return
         # MOR-1884 (MOR-1626 criterion 7): the enforcement seat guards EVERY
         # write this poller issues — queued commands and uncommanded internal
         # emits alike. The single exemption is the connection-epoch bootstrap
@@ -3447,15 +3448,6 @@ class RadioPoller:
                     await radio.set_dash_ratio(value)
                 if self._radio_state:
                     self._radio_state.dash_ratio = value
-            case SetRepeaterShift(direction=direction, receiver=rx):
-                self._ensure_receiver_supported(rx, operation="set_repeater_shift")
-                if CAP_REPEATER_SHIFT in self._caps:
-                    await radio.set_repeater_shift(direction, receiver=rx)
-                if self._radio_state:
-                    target = (
-                        self._radio_state.sub if rx != 0 else self._radio_state.main
-                    )
-                    target.repeater_shift = direction
             case SetRepeaterTone(on=on, receiver=rx):
                 self._ensure_receiver_supported(rx, operation="set_repeater_tone")
                 if CAP_REPEATER_TONE in self._caps:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -4304,7 +4304,11 @@ class WebServer:
                 writer,
                 status,
                 reason,
-                {"error": code, "message": str(exc) or type(exc).__name__},
+                {
+                    "ok": False,
+                    "error": code,
+                    "message": str(exc) or type(exc).__name__,
+                },
             )
             return
         except (ValueError, KeyError, TypeError) as exc:

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -52,6 +52,12 @@ from ..core.command_service import (
     CommandService,
     command_intent_from_request,
 )
+from ..core.command_dispatch import (
+    CommandUnsupportedError,
+    command_descriptor,
+    prepare_command_intent,
+)
+from ..core.exceptions import CommandError, CommandRejectedError
 from ..core.state_pipeline_contracts import (
     CommandIntent,
     CommandLifecycleEvent,
@@ -396,6 +402,16 @@ class _HttpCommandCollector:
         )
 
 
+def _command_error_code(exc: BaseException) -> str:
+    if isinstance(exc, CommandUnsupportedError):
+        return "unsupported_command"
+    if isinstance(exc, CommandRejectedError):
+        return "radio_nak"
+    if isinstance(exc, (RigplaneTimeoutError, TimeoutError)):
+        return "command_timeout"
+    return "command_failed"
+
+
 @dataclass(slots=True)
 class _HttpCommandExecutor:
     server: "WebServer"
@@ -431,16 +447,9 @@ class _SharedControlCommandExecutor:
     async def execute(self, intent: CommandIntent) -> CommandExecutionResult:
         params = dict(intent.params)
         control_server = params.pop("_control_server", None)
-        result = await self.server._control_handler_for(  # noqa: SLF001
+        return await self.server._control_handler_for(  # noqa: SLF001
             server=control_server,
-        )._enqueue_legacy_command(
-            intent.name,
-            params,
-            command_id=intent.id,
-            source=intent.source,
-            command_service=self.server.command_service,
-        )
-        return CommandExecutionResult(details=result)
+        )._execute_intent(intent)
 
 
 async def _read_capped_body(
@@ -4277,6 +4286,27 @@ class WebServer:
                 {"error": "read_only", "message": str(exc)},
             )
             return
+        except (
+            CommandUnsupportedError,
+            CommandRejectedError,
+            RigplaneTimeoutError,
+            TimeoutError,
+            CommandError,
+        ) as exc:
+            code = _command_error_code(exc)
+            if code == "command_timeout":
+                status, reason = 504, "Gateway Timeout"
+            elif code in {"unsupported_command", "radio_nak"}:
+                status, reason = 409, "Conflict"
+            else:
+                status, reason = 500, "Internal Server Error"
+            await self._send_json(
+                writer,
+                status,
+                reason,
+                {"error": code, "message": str(exc) or type(exc).__name__},
+            )
+            return
         except (ValueError, KeyError, TypeError) as exc:
             await self._send_json(
                 writer,
@@ -4340,6 +4370,28 @@ class WebServer:
             raise _HttpBatchValidationError(
                 "unsupported_in_batch",
                 f"command {raw_name!r} bypasses the command queue",
+            )
+
+        descriptor = command_descriptor(raw_name)
+        if descriptor is not None:
+            assert self._radio is not None
+            intent = prepare_command_intent(
+                self._radio,
+                raw_name,
+                raw_params,
+                source="http",
+                command_id=(
+                    None if raw_step.get("id") is None else str(raw_step["id"])
+                ),
+            )
+            return _HttpBatchStep(
+                index=index,
+                name=raw_name,
+                command=intent,
+                result=descriptor.result(intent),
+                command_id=intent.id,
+                source=intent.source,
+                command_service=self.command_service,
             )
 
         collector = _HttpCommandCollector()
@@ -4723,6 +4775,18 @@ class WebServer:
                     }
                 )
                 step = None
+            except CommandUnsupportedError as exc:
+                results.append(
+                    {
+                        "index": index,
+                        "name": name,
+                        "ok": False,
+                        "status": "failed_validation",
+                        "error": "unsupported_command",
+                        "message": str(exc),
+                    }
+                )
+                step = None
             except _HttpBatchValidationError as exc:
                 results.append(
                     {
@@ -4767,19 +4831,27 @@ class WebServer:
                 await self._send_batch_response(writer, payload, results)
                 return
 
-            loop = asyncio.get_running_loop()
-            future: asyncio.Future[None] = loop.create_future()
-            self._command_queue.put_ordered(
-                step.command,
-                future=future,
-                command_id=step.command_id,
-                source=step.source,
-                command_service=step.command_service,
-            )
             try:
-                await asyncio.wait_for(future, timeout=_COMMAND_BATCH_STEP_TIMEOUT)
-            except TimeoutError as exc:
-                if step.command_service is not None and step.command_id is not None:
+                if isinstance(step.command, CommandIntent):
+                    await self.command_service.execute(step.command)
+                else:
+                    future: asyncio.Future[None] = (
+                        asyncio.get_running_loop().create_future()
+                    )
+                    self._command_queue.put_ordered(
+                        step.command,
+                        future=future,
+                        command_id=step.command_id,
+                        source=step.source,
+                        command_service=step.command_service,
+                    )
+                    await asyncio.wait_for(future, timeout=_COMMAND_BATCH_STEP_TIMEOUT)
+            except (RigplaneTimeoutError, TimeoutError) as exc:
+                if (
+                    not isinstance(step.command, CommandIntent)
+                    and step.command_service is not None
+                    and step.command_id is not None
+                ):
                     step.command_service.fail_command(
                         step.command_id,
                         message=str(exc) or type(exc).__name__,
@@ -4802,6 +4874,26 @@ class WebServer:
                             self._skipped_batch_result_for_raw_step(
                                 skip_index,
                                 raw_steps[skip_index],
+                            )
+                        )
+                    await self._send_batch_response(writer, payload, results)
+                    return
+            except CommandError as exc:
+                results.append(
+                    {
+                        "index": step.index,
+                        "name": step.name,
+                        "ok": False,
+                        "status": "failed_execution",
+                        "error": _command_error_code(exc),
+                        "message": str(exc) or type(exc).__name__,
+                    }
+                )
+                if not continue_on_error:
+                    for skip_index in range(step.index + 1, len(raw_steps)):
+                        results.append(
+                            self._skipped_batch_result_for_raw_step(
+                                skip_index, raw_steps[skip_index]
                             )
                         )
                     await self._send_batch_response(writer, payload, results)

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -4323,14 +4323,15 @@ class WebServer:
             message = str(exc)
             status, reason, code = (
                 (409, "Conflict", "unsupported_command")
-                if "does not support" in message
+                if command_descriptor(raw_name) is None
+                and "does not support" in message
                 else (500, "Internal Server Error", "command_failed")
             )
             await self._send_json(
                 writer,
                 status,
                 reason,
-                {"error": code, "message": message},
+                {"ok": False, "error": code, "message": message},
             )
             return
 
@@ -4807,7 +4808,9 @@ class WebServer:
                 message = str(exc)
                 error = (
                     "unsupported_command"
-                    if "does not support" in message or "not supported" in message
+                    if isinstance(name, str)
+                    and command_descriptor(name) is None
+                    and ("does not support" in message or "not supported" in message)
                     else "invalid_request"
                 )
                 results.append(

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from dataclasses import replace
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,7 +16,7 @@ from rigplane.backends.rigctld_client.radio import (
     RigctldClientRadio,
 )
 from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
-from rigplane.core.exceptions import CommandRejectedError
+from rigplane.core.exceptions import CommandError, CommandRejectedError
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.profiles import resolve_radio_profile
@@ -118,21 +119,37 @@ async def test_success_waits_for_real_yaesu_drain(surface: str) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["http", "batch", "ws"])
 @pytest.mark.parametrize(
-    ("surface", "error", "expected"),
+    ("error", "supported", "http_status", "error_code", "batch_status"),
     [
-        ("http", CommandRejectedError("radio returned ?;"), (409, "radio_nak")),
-        ("batch", CommandRejectedError("radio returned ?;"), (200, "radio_nak")),
-        ("ws", CommandRejectedError("radio returned ?;"), (None, "radio_nak")),
-        ("http", RigplaneTimeoutError("late"), (504, "command_timeout")),
-        ("batch", RigplaneTimeoutError("late"), (200, "command_timeout")),
-        ("ws", RigplaneTimeoutError("late"), (None, "command_timeout")),
+        (None, False, 409, "unsupported_command", "failed_validation"),
+        (
+            CommandRejectedError("radio returned ?;"),
+            True,
+            409,
+            "radio_nak",
+            "failed_execution",
+        ),
+        (
+            CommandError("backend failed"),
+            True,
+            500,
+            "command_failed",
+            "failed_execution",
+        ),
+        (RigplaneTimeoutError("late"), True, 504, "command_timeout", "timed_out"),
     ],
 )
 async def test_structured_error_reaches_every_surface(
-    surface: str, error: Exception, expected: tuple[int | None, str]
+    surface: str,
+    error: Exception | None,
+    supported: bool,
+    http_status: int,
+    error_code: str,
+    batch_status: str,
 ) -> None:
-    radio = _radio(error=error)
+    radio = _radio(error=error, supported=supported)
     server = WebServer(radio, WebConfig())
     payload = {"id": "shift", "name": "set_repeater_shift", "params": {"direction": 2}}
     if surface == "http":
@@ -155,16 +172,20 @@ async def test_structured_error_reaches_every_surface(
         )
 
     await asyncio.sleep(0)
-    await _drain_yaesu(server, radio)
+    if server.command_queue.has_commands:
+        await _drain_yaesu(server, radio)
     await request
     if surface == "ws":
         body = ws.messages[-1]
     else:
-        assert writer.status == expected[0]
+        assert writer.status == (200 if surface == "batch" else http_status)
         body = writer.body
         if surface == "batch":
+            assert body["ok"] is False
             body = body["results"][0]  # type: ignore[index,assignment]
-    assert body["error"] == expected[1]
+            assert body["status"] == batch_status
+    assert body["ok"] is False
+    assert body["error"] == error_code
 
 
 @pytest.mark.asyncio
@@ -192,8 +213,12 @@ async def test_all_three_drains_execute_the_same_neutral_intent() -> None:
     for drain in ("icom", "yaesu", "rigctld"):
         radio = _radio()
         intent = prepare_command_intent(
-            radio, "set_repeater_shift", {"direction": 3}, source="http"
+            radio,
+            "set_repeater_shift",
+            {"direction": 3, "receiver": 1},
+            source="http",
         )
+        assert str(intent.target) == "receiver.1.operator_controls.repeater_shift"
         if drain == "icom":
             poller = SimpleNamespace(
                 _radio=radio,
@@ -211,7 +236,7 @@ async def test_all_three_drains_execute_the_same_neutral_intent() -> None:
             )
             poller._radio = radio  # type: ignore[attr-defined]
             await poller._execute_command(intent)  # noqa: SLF001
-        radio.set_repeater_shift.assert_awaited_once_with(direction=3, receiver=0)
+        radio.set_repeater_shift.assert_awaited_once_with(direction=3, receiver=1)
 
 
 @pytest.mark.asyncio
@@ -222,14 +247,16 @@ async def test_descriptor_timeout_and_cancellation_cleanup_is_exact_once() -> No
     intent = prepare_command_intent(
         radio,
         "set_repeater_shift",
-        {"direction": 1, "session_id": "ws-a"},
+        {"direction": 1},
         source="websocket",
         command_id="cancel-me",
+        session_id="ws-a",
     )
     server = WebServer(radio, WebConfig())
     service = server.command_service
     task = asyncio.create_task(service.execute(intent))
     await asyncio.sleep(0)
+    assert ("websocket", "ws-a", "cancel-me") in service._active_commands  # noqa: SLF001
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
@@ -240,26 +267,77 @@ async def test_descriptor_timeout_and_cancellation_cleanup_is_exact_once() -> No
         )
         == ()
     )
-    assert [event.state for event in service.lifecycle_events()].count("failed") == 1
-    assert service.terminate_active_commands("late") == 0
+    assert ("websocket", "ws-a", "cancel-me") not in service._active_commands  # noqa: SLF001
+    assert [
+        event.state
+        for event in service.lifecycle_events()
+        if event.command_id == "cancel-me"
+        and event.state in {"acknowledged", "failed", "timed_out"}
+    ] == ["failed"]
+    assert (
+        service.terminate_active_commands("late", source="websocket", session_id="ws-a")
+        == 0
+    )
     await _drain_yaesu(server, radio)
+    assert [
+        event.state
+        for event in service.lifecycle_events()
+        if event.command_id == "cancel-me"
+        and event.state in {"acknowledged", "failed", "timed_out"}
+    ] == ["failed"]
     radio.set_repeater_shift.assert_not_awaited()
 
     timed = replace(intent, id="time-me", timeout=0.001)
     timed_service = server.command_service
     with pytest.raises(TimeoutError):
         await timed_service.execute(timed)
-    assert [event.state for event in timed_service.lifecycle_events()].count(
-        "timed_out"
-    ) == 1
+    assert [
+        event.state
+        for event in timed_service.lifecycle_events()
+        if event.command_id == "time-me"
+        and event.state in {"acknowledged", "failed", "timed_out"}
+    ] == ["timed_out"]
     assert (
         timed_service.pending_overlays(
             source="websocket", session_id="ws-a", command_id="time-me"
         )
         == ()
     )
+    assert ("websocket", "ws-a", "time-me") not in service._active_commands  # noqa: SLF001
     await _drain_yaesu(server, radio)
+    assert [
+        event.state
+        for event in timed_service.lifecycle_events()
+        if event.command_id == "time-me"
+        and event.state in {"acknowledged", "failed", "timed_out"}
+    ] == ["timed_out"]
     radio.set_repeater_shift.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_descriptor_queue_policy_controls_enqueue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.core import command_dispatch
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    descriptor = command_dispatch.command_descriptor("set_repeater_shift")
+    assert descriptor is not None
+    mutated = replace(descriptor, queue_policy=cast(Any, "unknown"))
+    monkeypatch.setattr(
+        command_dispatch,
+        "_COMMAND_DESCRIPTORS",
+        {mutated.name: mutated},
+    )
+    server = WebServer(radio, WebConfig())
+    intent = prepare_command_intent(
+        radio, mutated.name, {"direction": 1}, source="http"
+    )
+
+    with pytest.raises(CommandError, match="unsupported queue policy 'unknown'"):
+        await server.command_service.execute(intent)
+    assert not server.command_queue.has_commands
 
 
 @pytest.mark.asyncio

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -138,6 +138,13 @@ async def test_success_waits_for_real_yaesu_drain(surface: str) -> None:
             "command_failed",
             "failed_execution",
         ),
+        (
+            RuntimeError("temporarily not supported by transport"),
+            True,
+            500,
+            "command_failed",
+            "failed_execution",
+        ),
         (RigplaneTimeoutError("late"), True, 504, "command_timeout", "timed_out"),
     ],
 )

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -1,0 +1,298 @@
+"""MOR-2161 Slice 1: one descriptor-backed command reaches every drain."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rigplane.backends.rigctld_client.radio import (
+    RigctldClientObservationPoller,
+    RigctldClientRadio,
+)
+from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
+from rigplane.core.exceptions import CommandRejectedError
+from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
+from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.profiles import resolve_radio_profile
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.radio_poller import RadioPoller
+from rigplane.web.server import WebConfig, WebServer
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    @property
+    def status(self) -> int:
+        return int(self.buffer.split(b"\r\n", 1)[0].split()[1])
+
+    @property
+    def body(self) -> dict[str, object]:
+        return json.loads(self.buffer.split(b"\r\n\r\n", 1)[1])
+
+
+class _Ws:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, object]] = []
+
+    async def send_text(self, payload: str) -> None:
+        self.messages.append(json.loads(payload))
+
+
+def _radio(
+    *, error: Exception | None = None, model: str = "FTX-1", supported: bool = True
+) -> MagicMock:
+    profile = resolve_radio_profile(model=model)
+    radio = MagicMock()
+    radio.profile = profile
+    radio.model = profile.model
+    radio.capabilities = set(profile.capabilities)
+    radio.supports_command = MagicMock(return_value=supported)
+    radio.set_repeater_shift = AsyncMock(side_effect=error)
+    return radio
+
+
+async def _drain_yaesu(server: WebServer, radio: object) -> None:
+    await server.command_queue.wait(timeout=1.0)
+    poller = YaesuCatPoller.__new__(YaesuCatPoller)
+    poller._radio = radio  # type: ignore[attr-defined]
+    for entry in server.command_queue.drain_entries():
+        if entry.future is not None and entry.future.cancelled():
+            continue
+        try:
+            await poller._execute_command(entry.command)  # noqa: SLF001
+        except BaseException as exc:
+            if entry.future is not None and not entry.future.done():
+                entry.future.set_exception(exc)
+        else:
+            if entry.future is not None and not entry.future.done():
+                entry.future.set_result(None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["http", "ws"])
+async def test_success_waits_for_real_yaesu_drain(surface: str) -> None:
+    radio = _radio()
+    server = WebServer(radio, WebConfig())
+    if surface == "http":
+        writer = _Writer()
+        request = asyncio.create_task(
+            server._handle_http_single_command(  # noqa: SLF001
+                writer,  # type: ignore[arg-type]
+                {
+                    "id": "shift",
+                    "name": "set_repeater_shift",
+                    "params": {"direction": 1},
+                },
+            )
+        )
+    else:
+        ws = _Ws()
+        handler = ControlHandler(ws, radio, "test", "FTX-1", server=server)  # type: ignore[arg-type]
+        request = asyncio.create_task(
+            handler._dispatch_command("shift", "set_repeater_shift", {"direction": 1})  # noqa: SLF001
+        )
+
+    await asyncio.sleep(0)
+    assert not request.done()
+    await _drain_yaesu(server, radio)
+    await request
+    radio.set_repeater_shift.assert_awaited_once_with(direction=1, receiver=0)
+    radio.supports_command.assert_called_once_with("set_repeater_shift")
+    with pytest.raises(KeyError):
+        server.command_state_store.snapshot().field(
+            "receiver.0.operator_controls.repeater_shift"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("surface", "error", "expected"),
+    [
+        ("http", CommandRejectedError("radio returned ?;"), (409, "radio_nak")),
+        ("batch", CommandRejectedError("radio returned ?;"), (200, "radio_nak")),
+        ("ws", CommandRejectedError("radio returned ?;"), (None, "radio_nak")),
+        ("http", RigplaneTimeoutError("late"), (504, "command_timeout")),
+        ("batch", RigplaneTimeoutError("late"), (200, "command_timeout")),
+        ("ws", RigplaneTimeoutError("late"), (None, "command_timeout")),
+    ],
+)
+async def test_structured_error_reaches_every_surface(
+    surface: str, error: Exception, expected: tuple[int | None, str]
+) -> None:
+    radio = _radio(error=error)
+    server = WebServer(radio, WebConfig())
+    payload = {"id": "shift", "name": "set_repeater_shift", "params": {"direction": 2}}
+    if surface == "http":
+        writer = _Writer()
+        request = asyncio.create_task(
+            server._handle_http_single_command(writer, payload)  # type: ignore[arg-type] # noqa: SLF001
+        )
+    elif surface == "batch":
+        writer = _Writer()
+        request = asyncio.create_task(
+            server._handle_http_command_batch(  # type: ignore[arg-type] # noqa: SLF001
+                writer, {"steps": [payload]}
+            )
+        )
+    else:
+        ws = _Ws()
+        handler = ControlHandler(ws, radio, "test", "FTX-1", server=server)  # type: ignore[arg-type]
+        request = asyncio.create_task(
+            handler._dispatch_command("shift", "set_repeater_shift", {"direction": 2})  # noqa: SLF001
+        )
+
+    await asyncio.sleep(0)
+    await _drain_yaesu(server, radio)
+    await request
+    if surface == "ws":
+        body = ws.messages[-1]
+    else:
+        assert writer.status == expected[0]
+        body = writer.body
+        if surface == "batch":
+            body = body["results"][0]  # type: ignore[index,assignment]
+    assert body["error"] == expected[1]
+
+
+@pytest.mark.asyncio
+async def test_descriptor_preflight_rejects_without_queue_or_overlay() -> None:
+    from rigplane.core.command_dispatch import CommandUnsupportedError
+
+    radios = (
+        _radio(model="IC-7300", supported=False),
+        RigctldClientRadio(host="127.0.0.1", port=4532),
+    )
+    for radio in radios:
+        server = WebServer(radio, WebConfig())
+        with pytest.raises(CommandUnsupportedError):
+            await server._control_handler_for()._enqueue_command(  # noqa: SLF001
+                "set_repeater_shift", {"direction": 1}, source="http"
+            )
+        assert not server.command_queue.has_commands
+        assert server.command_service.lifecycle_events() == ()
+
+
+@pytest.mark.asyncio
+async def test_all_three_drains_execute_the_same_neutral_intent() -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    for drain in ("icom", "yaesu", "rigctld"):
+        radio = _radio()
+        intent = prepare_command_intent(
+            radio, "set_repeater_shift", {"direction": 3}, source="http"
+        )
+        if drain == "icom":
+            poller = SimpleNamespace(
+                _radio=radio,
+                _enforce_tx_interlock=lambda command: None,
+                _provider_generation=lambda: 0,
+            )
+            await RadioPoller._execute(poller, intent)  # type: ignore[arg-type] # noqa: SLF001
+        elif drain == "yaesu":
+            poller = YaesuCatPoller.__new__(YaesuCatPoller)
+            poller._radio = radio  # type: ignore[attr-defined]
+            await poller._execute_command(intent)  # noqa: SLF001
+        else:
+            poller = RigctldClientObservationPoller.__new__(
+                RigctldClientObservationPoller
+            )
+            poller._radio = radio  # type: ignore[attr-defined]
+            await poller._execute_command(intent)  # noqa: SLF001
+        radio.set_repeater_shift.assert_awaited_once_with(direction=3, receiver=0)
+
+
+@pytest.mark.asyncio
+async def test_descriptor_timeout_and_cancellation_cleanup_is_exact_once() -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    intent = prepare_command_intent(
+        radio,
+        "set_repeater_shift",
+        {"direction": 1, "session_id": "ws-a"},
+        source="websocket",
+        command_id="cancel-me",
+    )
+    server = WebServer(radio, WebConfig())
+    service = server.command_service
+    task = asyncio.create_task(service.execute(intent))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert (
+        service.pending_overlays(
+            source="websocket", session_id="ws-a", command_id="cancel-me"
+        )
+        == ()
+    )
+    assert [event.state for event in service.lifecycle_events()].count("failed") == 1
+    assert service.terminate_active_commands("late") == 0
+    await _drain_yaesu(server, radio)
+    radio.set_repeater_shift.assert_not_awaited()
+
+    timed = replace(intent, id="time-me", timeout=0.001)
+    timed_service = server.command_service
+    with pytest.raises(TimeoutError):
+        await timed_service.execute(timed)
+    assert [event.state for event in timed_service.lifecycle_events()].count(
+        "timed_out"
+    ) == 1
+    assert (
+        timed_service.pending_overlays(
+            source="websocket", session_id="ws-a", command_id="time-me"
+        )
+        == ()
+    )
+    await _drain_yaesu(server, radio)
+    radio.set_repeater_shift.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_batch_preparation_is_capture_only_then_executes_once() -> None:
+    radio = _radio()
+    server = WebServer(radio, WebConfig())
+    before = server.command_service.lifecycle_events()
+
+    step = await server._prepare_http_batch_step(  # noqa: SLF001
+        0, {"name": "set_repeater_shift", "params": {"direction": 1}}
+    )
+
+    assert server.command_service.lifecycle_events() == before
+    assert not server.command_queue.has_commands
+    assert isinstance(step.command, CommandIntent)
+    radio.supports_command.assert_called_once_with("set_repeater_shift")
+    execution = asyncio.create_task(server.command_service.execute(step.command))
+    await asyncio.sleep(0)
+    await _drain_yaesu(server, radio)
+    result = await execution
+    assert result.executor_result.details == {"direction": 1, "receiver": 0}
+    radio.set_repeater_shift.assert_awaited_once()
+    radio.supports_command.assert_called_once_with("set_repeater_shift")
+
+
+def test_descriptor_is_the_only_migrated_name_source() -> None:
+    from rigplane.core.command_dispatch import command_descriptors
+    from rigplane import _poller_types
+    from rigplane.runtime import _poller_types as runtime_types
+    from rigplane.web import radio_poller
+
+    assert set(command_descriptors()) == {"set_repeater_shift"}
+    assert "set_repeater_shift" in ControlHandler._COMMANDS  # noqa: SLF001
+    assert not hasattr(runtime_types, "SetRepeaterShift")
+    assert not hasattr(_poller_types, "SetRepeaterShift")
+    assert not hasattr(radio_poller, "SetRepeaterShift")

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -74,6 +74,7 @@ import pytest
 
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
+from rigplane.backends.rigctld_client.radio import RigctldClientObservationPoller
 from rigplane.commands._frame import decode_wire_tuple
 from rigplane.commands.command_map import CommandMap, ReverseLookupResult
 from rigplane.commands.command_spec import (
@@ -82,8 +83,10 @@ from rigplane.commands.command_spec import (
     CivCommandSpec,
 )
 from rigplane.core.radio_protocol import DualReceiverCapable
+from rigplane.core.command_dispatch import command_descriptors
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.runtime.radio import CoreRadio
+from rigplane.web.radio_poller import RadioPoller
 from support.command_builders import (
     PythonParseHealth,
     parse_python_paths as _parse_python_paths,
@@ -631,6 +634,38 @@ def _yaesu_executor_methods(class_node: ast.ClassDef) -> frozenset[str]:
     raise AssertionError("YaesuCatPoller._execute_command AST missing")
 
 
+def _has_neutral_intent_hook(class_node: ast.ClassDef, method_name: str) -> bool:
+    method = next(
+        (
+            node
+            for node in class_node.body
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == method_name
+        ),
+        None,
+    )
+    return method is not None and any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "execute_command_intent"
+        for node in ast.walk(method)
+    )
+
+
+def _neutral_intent_hooks(parse_health: PythonParseHealth) -> dict[str, bool]:
+    return {
+        "icom": _has_neutral_intent_hook(
+            _class_node(parse_health, RadioPoller), "_execute"
+        ),
+        "yaesu": _has_neutral_intent_hook(
+            _class_node(parse_health, YaesuCatPoller), "_execute_command"
+        ),
+        "rigctld": _has_neutral_intent_hook(
+            _class_node(parse_health, RigctldClientObservationPoller),
+            "_execute_command",
+        ),
+    }
+
+
 def _class_node(
     parse_health: PythonParseHealth,
     implementation: type[typing.Any],
@@ -840,10 +875,23 @@ def implementation_completeness_report(
     inbound_pairs = _civ_inbound_pairs(parse_health)
     yaesu_class = _class_node(parse_health, YaesuCatRadio)
     yaesu_routes = _cat_dispatch_routes(yaesu_class)
-    yaesu_executor_routes = _cat_dispatch_routes(
+    legacy_executor_routes = _cat_dispatch_routes(
         yaesu_class,
         _yaesu_executor_methods(_class_node(parse_health, YaesuCatPoller)),
     )
+    descriptor_executor_routes = (
+        _cat_dispatch_routes(
+            yaesu_class,
+            frozenset(item.method_name for item in command_descriptors().values()),
+        )
+        if _neutral_intent_hooks(parse_health)["yaesu"]
+        else {}
+    )
+    yaesu_executor_routes = {
+        name: legacy_executor_routes.get(name, frozenset())
+        | descriptor_executor_routes.get(name, frozenset())
+        for name in legacy_executor_routes.keys() | descriptor_executor_routes.keys()
+    }
     findings: list[_ImplementationFinding] = []
 
     for _model, config in sorted(configs.items()):
@@ -1199,16 +1247,21 @@ def test_declared_absent_marker_does_not_hide_existing_code_route(
     assert finding.reachability is _ExecutionReachability.UNKNOWN
 
 
-def test_real_yaesu_executor_exposes_missing_repeater_shift_route(
+def test_descriptor_route_reaches_real_yaesu_repeater_shift_executor(
     implementation_report: _ImplementationReport,
 ) -> None:
     finding = implementation_report.find("yaesu_ftx1", "command", "set_repeater_shift")
     assert finding.relation is _DeclarationRelation.IMPLEMENTED
-    assert finding.reachability is _ExecutionReachability.UNREACHABLE
-    assert not finding.fully_complete
-    assert finding.diagnostics == (
-        "yaesu_ftx1 command set_repeater_shift: backend execution route unreachable",
-    )
+    assert finding.reachability is _ExecutionReachability.REACHABLE
+    assert finding.fully_complete
+    assert finding.diagnostics == ()
+
+
+@pytest.mark.parametrize("provider", ("icom", "yaesu", "rigctld"))
+def test_every_selected_drain_has_the_generic_neutral_intent_hook(
+    implementation_report: _ImplementationReport, provider: str
+) -> None:
+    assert _neutral_intent_hooks(implementation_report.parse_health)[provider]
 
 
 def test_real_yaesu_executor_follows_indirect_attenuator_helper(


### PR DESCRIPTION
## Summary

- add one backend-neutral core descriptor for `set_repeater_shift` and use it for admission, binding, ordered queue policy, invocation, and reachability coverage
- carry one neutral intent through the generic Icom, Yaesu, and rigctld-client drains
- wait for real backend completion with bounded timeout/cancellation and exact-key lifecycle cleanup
- return typed unsupported/NAK/failure/timeout results through WebSocket, HTTP single, and HTTP batch
- remove the bespoke internal `SetRepeaterShift` queue class and all of its exports/arms

## Single-source-of-truth boundary

Radio/model/wire facts remain in profiles. The merged FTX-1 profile owns `OS{receiver}` and its official MAIN/SUB routing. The descriptor owns only operation mechanics and contains no radio model or CAT bytes. Its queue policy is a live production input, not duplicated Web metadata.

## Verification

- independent Agent Review: PASS at `c3889b54797c056b83104f18a083908f85c23a38`
- builder affected set: 1008 passed, 2 skipped
- independent exact-head affected set: 571 passed
- Ruff/format, strict Web mypy, import-linter, diff-check: PASS
- descriptor and each of three drain-hook deletion mutations: RED as intended
- exact scope: 10 files, 844 insertions / 84 deletions; below the reviewed 1000-line hard stop

Full repository suites are intentionally not run locally and must pass through the normal Mac mini Actions queue at this exact head. Hardware validation remains separate; the FTX-1 currently does not enumerate after the Mac mini reboot.

## Compatibility

This intentionally removes the private/internal `SetRepeaterShift` symbol from runtime and Web compatibility exports. No documented public import was found. Public `set_repeater_shift` behavior becomes stricter: success waits for backend completion, and typed failures now reach the caller.

## Scope

This is MOR-2161 Slice 1 only. `availableCommands` publication, other command families, CLI, rigctld-server migration, MOR-2189, and bulk profile population remain follow-up work. MOR-2161 must not be closed by this PR.

Linear: MOR-2161; completes the caller/executor half of MOR-2160 once live hardware evidence is available.