### PR TITLE
fix(runtime): retry both managed release plans [MOR-2206]

### DIFF
--- a/src/rigplane/runtime/managed_tx_state.py
+++ b/src/rigplane/runtime/managed_tx_state.py
@@ -311,7 +311,7 @@ def reduce_managed_tx(
     if isinstance(event, RetryForceReceive):
         if (
             state.intent.kind is not ManagedTxIntentKind.RX
-            or state.release_plan is not ReleasePlan.FORCE_RELEASE
+            or state.release_plan is None
             or state.pending_effect is not None
         ):
             return ManagedTxTransition(state, ManagedTxOutcome.REJECTED)

--- a/tests/test_managed_tx_state.py
+++ b/tests/test_managed_tx_state.py
@@ -193,10 +193,45 @@ def test_retry_force_receive_advances_epoch_for_force_release_debt() -> None:
 
 
 @pytest.mark.parametrize(
+    "settlement", [ActuationResult.REJECTED, ActuationResult.UNCERTAIN]
+)
+def test_retry_force_receive_preserves_ptt_release_debt(
+    settlement: ActuationResult,
+) -> None:
+    keyed_on = settle(keyed(), ActuationResult.ACCEPTED).state
+    releasing = reduce_managed_tx(keyed_on, PttUp("web-1", 7, "off")).state
+    debt = settle(releasing, settlement).state
+
+    result = reduce_managed_tx(debt, subject.RetryForceReceive(8, "retry"))
+
+    assert debt.release_plan is ReleasePlan.PTT_RELEASE
+    assert result.outcome is ManagedTxOutcome.ACCEPTED
+    assert result.state.release_plan is ReleasePlan.PTT_RELEASE
+    assert result.state.effect_epoch == debt.effect_epoch + 1
+    assert result.effects == (result.state.pending_effect,)
+    assert result.effects[0] == subject.ManagedTxEffect(
+        ActuationOperation.FORCE_RECEIVE,
+        subject.EffectToken(8, result.state.effect_epoch, "retry"),
+    )
+    assert result.state.current_abort_token is None
+    assert result.state.abort_errors == ()
+    assert (
+        settle(result.state, settlement).state.release_plan is ReleasePlan.PTT_RELEASE
+    )
+
+
+def test_accepted_ptt_release_retry_settlement_clears_debt() -> None:
+    keyed_on = settle(keyed(), ActuationResult.ACCEPTED).state
+    releasing = reduce_managed_tx(keyed_on, PttUp("web-1", 7, "off")).state
+    debt = settle(releasing, ActuationResult.REJECTED).state
+    retried = reduce_managed_tx(debt, subject.RetryForceReceive(8, "retry"))
+    assert settle(retried.state, ActuationResult.ACCEPTED).state.release_plan is None
+
+
+@pytest.mark.parametrize(
     "state",
     [
         ManagedTxState(),
-        ManagedTxState(release_plan=ReleasePlan.PTT_RELEASE),
         keyed(),
         reduce_managed_tx(ManagedTxState(), TransmitOn(7, "tx", 10, None)).state,
         force_off().state,


### PR DESCRIPTION
## Summary

- Admit `RetryForceReceive` for either existing managed release plan while RX and without a live effect.
- Preserve `PTT_RELEASE` across retry issuance and rejected or uncertain retry settlement.
- Keep accepted settlement clearing debt and retain all existing invalid admission, stale-token, operation-binding, and ForceOff abort-parent behavior.

Linear: [MOR-2206](https://linear.app/morozsm/issue/MOR-2206/mor-21661b-retry-both-managed-release-plans-through-the-canonical)

## TDD evidence

RED before implementation:

`uv run pytest tests/test_managed_tx_state.py -q --tb=short`

Result: 2 failed, 45 passed. Both rejected and uncertain normal PTT-release paths demonstrated that `RetryForceReceive` rejected `PTT_RELEASE`.

GREEN after implementation:

`uv run pytest tests/test_managed_tx_state.py -q --tb=short`

Result: 48 passed.

Process-local mutation probes: 11 invariant groups passed; 6 mutants killed, covering FORCE_RELEASE-only admission, plan rewrite, invalid pending/clean/active admission, and missing epoch increment.

## Gates

- Full local suite: 14,426 passed, 281 skipped, 16 xfailed
- Ruff format/check: passed
- strict mypy for the changed runtime module: passed
- import contracts: 5 kept, 0 broken
- doc citation, link, dangling citation, and rebrand gates: passed
- diff, scope, and retired-name gates: passed
- exact scope: 2 files, 37 insertions, 2 deletions

## Compatibility and exclusions

This is a narrow additive change to the private pure reducer. It adds no I/O, provider, Web/UI, runtime composition, watchdog, ForceOff escalation, abort effect, or new authority state. No hardware validation is required.