### PR TITLE
MOR-2204: compose managed TX authority

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import Protocol
+
+from rigplane.runtime.managed_tx_config import (
+    ManagedTxTotConfig,
+    ManagedTxTotConfigStore,
+)
+from rigplane.runtime.managed_tx_effect_lane import ManagedTxEffectLane
+from rigplane.runtime.managed_tx_fence import TxAbortFence
+from rigplane.runtime.managed_tx_state import (
+    AbortOperation,
+    ForceOff,
+    ManagedTxEffect,
+    ManagedTxEvent,
+    ManagedTxIntent,
+    ManagedTxIntentKind,
+    ManagedTxOutcome,
+    ManagedTxState,
+    ManagedTxTransition,
+    PttDown,
+    PttUp,
+    RetryForceReceive,
+    TransmitOn,
+    reduce_managed_tx,
+)
+
+
+class _Wakeup(Protocol):
+    async def wait_until(self, deadline: float | None) -> None: ...
+
+    def wake(self) -> None: ...
+
+
+class _EventWakeup:
+    def __init__(self, clock: Callable[[], float]) -> None:
+        self._clock = clock
+        self._event = asyncio.Event()
+
+    async def wait_until(self, deadline: float | None) -> None:
+        event = self._event
+        if deadline is None:
+            await event.wait()
+        else:
+            timeout = max(0.0, deadline - self._clock())
+            if timeout:
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(event.wait(), timeout)
+        if self._event is event:
+            self._event = asyncio.Event()
+
+    def wake(self) -> None:
+        self._event.set()
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxProjection:
+    state: ManagedTxState
+    configured_tot_seconds: float | None
+    remaining_tot_seconds: float | None
+    provider_generation: int | None
+
+
+class ManagedTxAuthority:
+    def __init__(
+        self,
+        lane: ManagedTxEffectLane,
+        config_store: ManagedTxTotConfigStore,
+        abort_fence: TxAbortFence,
+        *,
+        provider_generation: int | None,
+        clock: Callable[[], float] | None = None,
+        wakeup: _Wakeup | None = None,
+        attempt_timeout_seconds: float = 3.0,
+        retry_delay_seconds: float = 1.0,
+    ) -> None:
+        if not 0 < attempt_timeout_seconds < float("inf") or not 0 < (
+            retry_delay_seconds
+        ) < float("inf"):
+            raise ValueError("managed TX timeouts must be positive")
+        if provider_generation is not None and provider_generation < 0:
+            raise ValueError("provider generation must be non-negative")
+        self._lane = lane
+        self._config_store = config_store
+        self._abort_fence = abort_fence
+        self._clock = clock or time.monotonic
+        self._wakeup = wakeup or _EventWakeup(self._clock)
+        self._attempt_timeout = attempt_timeout_seconds
+        self._retry_delay = retry_delay_seconds
+        self._lock = asyncio.Lock()
+        self._state = ManagedTxState()
+        self._provider_generation = provider_generation
+        self._generation_high_water = (
+            provider_generation if provider_generation is not None else -1
+        )
+        self._attempt = 0
+        self._retry_due: float | None = None
+        self._closing = False
+        self._closed = False
+        self._scheduler_task = asyncio.create_task(self._scheduler())
+
+    async def ptt_down(self, owner: str) -> ManagedTxOutcome:
+        return await self._ingress("ptt_down", owner)
+
+    async def ptt_up(self, owner: str) -> ManagedTxOutcome:
+        return await self._ingress("ptt_up", owner)
+
+    async def transmit_on(self) -> ManagedTxOutcome:
+        return await self._ingress("transmit_on")
+
+    async def force_off(self) -> ManagedTxOutcome:
+        return await self._ingress("force_off")
+
+    async def owner_disconnect(self, owner: str) -> ManagedTxOutcome:
+        async with self._lock:
+            self._require_open_locked()
+            if self._state.intent != ManagedTxIntent.ptt(owner):
+                return ManagedTxOutcome.REJECTED
+            transition = self._force_off_locked()
+            self._wakeup.wake()
+        await self._execute(transition.effects, full_force=True)
+        return transition.outcome
+
+    async def get_tot_config(self) -> ManagedTxTotConfig:
+        async with self._lock:
+            return self._config_store.config
+
+    async def set_tot_seconds(self, value: object) -> ManagedTxTotConfig:
+        transition = None
+        async with self._lock:
+            self._require_open_locked()
+            config = self._config_store.set_timeout_seconds(value)
+            deadline = self._tot_deadline_locked(config.timeout_seconds)
+            if deadline is not None and deadline <= self._clock():
+                transition = self._force_off_locked()
+            self._wakeup.wake()
+        if transition is not None:
+            await self._execute(transition.effects, full_force=True)
+        return config
+
+    async def snapshot(self) -> ManagedTxProjection:
+        async with self._lock:
+            deadline = self._tot_deadline_locked()
+            state = replace(self._state, tot_deadline_monotonic=deadline)
+            remaining = None if deadline is None else max(0.0, deadline - self._clock())
+            return ManagedTxProjection(
+                state,
+                self._config_store.config.timeout_seconds,
+                remaining,
+                self._provider_generation,
+            )
+
+    async def set_provider_generation(self, generation: int | None) -> None:
+        async with self._lock:
+            self._require_open_locked()
+            if generation is not None:
+                if generation <= self._generation_high_water:
+                    if generation == self._provider_generation:
+                        return
+                    raise ValueError("provider generation must increase")
+                self._generation_high_water = generation
+            self._provider_generation = generation
+            if generation is None:
+                self._retry_due = None
+            elif self._release_is_retryable_locked():
+                self._retry_due = self._clock()
+            self._wakeup.wake()
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._closed or self._closing:
+                return
+            if (
+                self._state.intent.kind is not ManagedTxIntentKind.RX
+                or self._state.release_required
+                or self._state.pending_effect is not None
+            ):
+                raise RuntimeError("managed TX disposal requires clean RX state")
+            self._closing = True
+            scheduler = self._scheduler_task
+        scheduler.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await scheduler
+        async with self._lock:
+            self._closed = True
+            self._closing = False
+
+    async def _ingress(self, action: str, owner: str | None = None) -> ManagedTxOutcome:
+        async with self._lock:
+            self._require_open_locked()
+            transition, full_force = self._transition_locked(action, owner)
+            self._wakeup.wake()
+        if transition is None:
+            return ManagedTxOutcome.REJECTED
+        await self._execute(transition.effects, full_force=full_force)
+        return transition.outcome
+
+    def _transition_locked(
+        self, action: str, owner: str | None
+    ) -> tuple[ManagedTxTransition | None, bool]:
+        generation = self._provider_generation
+        if action == "force_off":
+            return self._force_off_locked(), True
+        if owner is not None and self._state.intent == ManagedTxIntent.ptt(owner):
+            if action == "ptt_down":
+                return self._reduce_locked(
+                    PttDown(owner, generation or 0, self._attempt_id_locked(), 0, None)
+                ), False
+            if action == "ptt_up" and generation is None:
+                return self._force_off_locked(), True
+        if (
+            action == "transmit_on"
+            and self._state.intent.kind is ManagedTxIntentKind.TRANSMIT
+        ):
+            return self._reduce_locked(
+                TransmitOn(
+                    generation or max(0, self._generation_high_water),
+                    self._attempt_id_locked(),
+                    0,
+                    None,
+                )
+            ), False
+        if generation is None:
+            return None, False
+        now = self._clock()
+        attempt = self._attempt_id_locked()
+        if action == "ptt_down":
+            assert owner is not None
+            event: ManagedTxEvent = PttDown(
+                owner, generation, attempt, now, self._deadline_from(now)
+            )
+        elif action == "ptt_up":
+            assert owner is not None
+            event = PttUp(owner, generation, attempt)
+        else:
+            event = TransmitOn(generation, attempt, now, self._deadline_from(now))
+        return self._reduce_locked(event), False
+
+    def _force_off_locked(self) -> ManagedTxTransition:
+        self._retry_due = None
+        return self._reduce_locked(
+            ForceOff(self._provider_generation, self._attempt_id_locked())
+        )
+
+    def _reduce_locked(self, event: ManagedTxEvent) -> ManagedTxTransition:
+        transition = reduce_managed_tx(self._state, event)
+        self._state = transition.state
+        return transition
+
+    async def _execute(
+        self, effects: tuple[ManagedTxEffect, ...], *, full_force: bool
+    ) -> None:
+        deadline = self._clock() + self._attempt_timeout
+        events: list[ManagedTxEvent] = []
+        if full_force:
+            await self._abort_fence.force_off()
+        for effect in effects:
+            if full_force:
+                aborts = [
+                    asyncio.create_task(
+                        self._lane.settle_abort(
+                            effect.token, operation, deadline_monotonic=deadline
+                        )
+                    )
+                    for operation in AbortOperation
+                ]
+            if settled := await self._lane.settle(effect, deadline_monotonic=deadline):
+                events.append(settled)
+            if full_force:
+                events.extend(item for item in await asyncio.gather(*aborts) if item)
+        async with self._lock:
+            for event in events:
+                self._reduce_locked(event)
+            self._refresh_retry_locked()
+            self._wakeup.wake()
+
+    async def _scheduler(self) -> None:
+        while True:
+            async with self._lock:
+                deadline = self._next_due_locked()
+            await self._wakeup.wait_until(deadline)
+            await self._process_due()
+
+    async def _process_due(self) -> None:
+        transition = None
+        full_force = False
+        async with self._lock:
+            now = self._clock()
+            tot_due = self._tot_deadline_locked()
+            if tot_due is not None and tot_due <= now:
+                transition = self._force_off_locked()
+                full_force = True
+            elif self._retry_due is not None and self._retry_due <= now:
+                generation = self._provider_generation
+                self._retry_due = None
+                if generation is not None and self._release_is_retryable_locked():
+                    transition = self._reduce_locked(
+                        RetryForceReceive(generation, self._attempt_id_locked())
+                    )
+        if transition is not None:
+            await self._execute(transition.effects, full_force=full_force)
+
+    def _tot_deadline_locked(self, seconds: float | None = None) -> float | None:
+        if seconds is None:
+            seconds = self._config_store.config.timeout_seconds
+        started = self._state.tx_started_at_monotonic
+        return None if seconds is None or started is None else started + seconds
+
+    def _deadline_from(self, started: float) -> float | None:
+        seconds = self._config_store.config.timeout_seconds
+        return None if seconds is None else started + seconds
+
+    def _next_due_locked(self) -> float | None:
+        due = [
+            item
+            for item in (self._tot_deadline_locked(), self._retry_due)
+            if item is not None
+        ]
+        return min(due, default=None)
+
+    def _release_is_retryable_locked(self) -> bool:
+        return (
+            self._state.intent.kind is ManagedTxIntentKind.RX
+            and self._state.release_required
+            and self._state.pending_effect is None
+        )
+
+    def _refresh_retry_locked(self) -> None:
+        if (
+            self._provider_generation is not None
+            and self._release_is_retryable_locked()
+        ):
+            if self._retry_due is None:
+                self._retry_due = self._clock() + self._retry_delay
+        else:
+            self._retry_due = None
+
+    def _attempt_id_locked(self) -> str:
+        self._attempt += 1
+        return str(self._attempt)
+
+    def _require_open_locked(self) -> None:
+        if self._closing or self._closed:
+            raise RuntimeError("managed TX authority is closed")

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -15,6 +15,9 @@ from rigplane.runtime.managed_tx_effect_lane import ManagedTxEffectLane
 from rigplane.runtime.managed_tx_fence import TxAbortFence
 from rigplane.runtime.managed_tx_state import (
     AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    ActuationSettled,
     ForceOff,
     ManagedTxEffect,
     ManagedTxEvent,
@@ -255,29 +258,46 @@ class ManagedTxAuthority:
     async def _execute(
         self, effects: tuple[ManagedTxEffect, ...], *, full_force: bool
     ) -> None:
-        deadline = self._clock() + self._attempt_timeout
-        events: list[ManagedTxEvent] = []
-        if full_force:
-            await self._abort_fence.force_off()
-        for effect in effects:
+        while True:
+            deadline = self._clock() + self._attempt_timeout
+            events: list[ManagedTxEvent] = []
             if full_force:
-                aborts = [
-                    asyncio.create_task(
-                        self._lane.settle_abort(
-                            effect.token, operation, deadline_monotonic=deadline
+                await self._abort_fence.force_off()
+            for effect in effects:
+                if full_force:
+                    aborts = [
+                        asyncio.create_task(
+                            self._lane.settle_abort(
+                                effect.token, operation, deadline_monotonic=deadline
+                            )
                         )
+                        for operation in AbortOperation
+                    ]
+                if settled := await self._lane.settle(
+                    effect, deadline_monotonic=deadline
+                ):
+                    events.append(settled)
+                if full_force:
+                    events.extend(
+                        item for item in await asyncio.gather(*aborts) if item
                     )
-                    for operation in AbortOperation
-                ]
-            if settled := await self._lane.settle(effect, deadline_monotonic=deadline):
-                events.append(settled)
-            if full_force:
-                events.extend(item for item in await asyncio.gather(*aborts) if item)
-        async with self._lock:
-            for event in events:
-                self._reduce_locked(event)
-            self._refresh_retry_locked()
-            self._wakeup.wake()
+            followup = None
+            async with self._lock:
+                for event in events:
+                    transition = self._reduce_locked(event)
+                    if (
+                        transition.outcome is ManagedTxOutcome.APPLIED
+                        and isinstance(event, ActuationSettled)
+                        and event.operation
+                        in (ActuationOperation.PTT_ON, ActuationOperation.TRANSMIT_ON)
+                        and event.result is ActuationResult.UNCERTAIN
+                    ):
+                        followup = self._force_off_locked()
+                self._refresh_retry_locked()
+                self._wakeup.wake()
+            if followup is None:
+                return
+            effects, full_force = followup.effects, True
 
     async def _scheduler(self) -> None:
         while True:

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -1,0 +1,394 @@
+import asyncio
+from collections import deque
+from dataclasses import dataclass
+
+import pytest
+
+from rigplane.runtime.managed_tx_authority import ManagedTxAuthority
+from rigplane.runtime.managed_tx_config import ManagedTxTotConfig
+from rigplane.runtime.managed_tx_state import (
+    AbortFailed,
+    AbortOperation,
+    ActuationOperation,
+    ActuationResult,
+    ActuationSettled,
+    EffectToken,
+    ManagedTxEffect,
+    ManagedTxIntentKind,
+    ManagedTxOutcome,
+    ReleasePlan,
+)
+
+
+@dataclass
+class FakeClock:
+    now: float = 100.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class FakeWakeup:
+    def __init__(self) -> None:
+        self.revision = 0
+        self.deadline: float | None = None
+        self._entered: asyncio.Queue[int] = asyncio.Queue()
+        self._gate = asyncio.Event()
+
+    async def wait_until(self, deadline: float | None) -> None:
+        self.revision += 1
+        self.deadline = deadline
+        self._entered.put_nowait(self.revision)
+        gate = self._gate
+        await gate.wait()
+        if self._gate is gate:
+            self._gate = asyncio.Event()
+
+    def wake(self) -> None:
+        self._gate.set()
+
+    async def wait_after(self, revision: int) -> float | None:
+        while self.revision <= revision:
+            await asyncio.wait_for(self._entered.get(), 0.2)
+        return self.deadline
+
+
+class FakeConfigStore:
+    def __init__(self, seconds: float | None = 10.0) -> None:
+        self._config = ManagedTxTotConfig(seconds)
+        self.values: list[object] = []
+        self.fail = False
+
+    @property
+    def config(self) -> ManagedTxTotConfig:
+        return self._config
+
+    def set_timeout_seconds(self, value: object) -> ManagedTxTotConfig:
+        self.values.append(value)
+        if self.fail:
+            raise OSError("persistence failed")
+        seconds = None if value in (None, 0) else float(value)
+        self._config = ManagedTxTotConfig(seconds)
+        return self._config
+
+
+class FakeFence:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def force_off(self) -> None:
+        self.calls += 1
+
+
+class FakeLane:
+    def __init__(self) -> None:
+        self.results: deque[ActuationResult] = deque()
+        self.effects: list[ManagedTxEffect] = []
+        self.aborts: list[tuple[EffectToken, AbortOperation]] = []
+        self.abort_results: dict[AbortOperation, ActuationResult] = {}
+        self.stale_once = False
+
+    async def settle(
+        self, effect: ManagedTxEffect, *, deadline_monotonic: float
+    ) -> ActuationSettled:
+        self.effects.append(effect)
+        result = self.results.popleft() if self.results else ActuationResult.ACCEPTED
+        token = effect.token
+        if self.stale_once:
+            self.stale_once = False
+            token = EffectToken(
+                token.provider_generation, token.effect_epoch - 1, "stale"
+            )
+        return ActuationSettled(
+            token,
+            effect.operation,
+            result,
+            None if result is ActuationResult.ACCEPTED else result.value,
+        )
+
+    async def settle_abort(
+        self,
+        token: EffectToken,
+        operation: AbortOperation,
+        *,
+        deadline_monotonic: float,
+    ) -> AbortFailed | None:
+        self.aborts.append((token, operation))
+        result = self.abort_results.get(operation, ActuationResult.ACCEPTED)
+        return (
+            None
+            if result is ActuationResult.ACCEPTED
+            else AbortFailed(token, operation, result.value)
+        )
+
+
+def authority(
+    *,
+    generation: int | None = 7,
+    seconds: float | None = 10.0,
+) -> tuple[
+    ManagedTxAuthority, FakeClock, FakeWakeup, FakeConfigStore, FakeFence, FakeLane
+]:
+    clock, wakeup = FakeClock(), FakeWakeup()
+    store, fence, lane = FakeConfigStore(seconds), FakeFence(), FakeLane()
+    managed = ManagedTxAuthority(
+        lane,
+        store,
+        fence,
+        provider_generation=generation,
+        clock=clock,
+        wakeup=wakeup,
+        attempt_timeout_seconds=1.0,
+        retry_delay_seconds=2.0,
+    )
+    return managed, clock, wakeup, store, fence, lane
+
+
+@pytest.mark.asyncio
+async def test_ptt_owner_idempotency_and_disconnect_force_off() -> None:
+    managed, clock, _, _, fence, lane = authority()
+    assert await managed.ptt_down("owner-a") is ManagedTxOutcome.ACCEPTED
+    first = await managed.snapshot()
+    clock.now = 105
+    assert await managed.ptt_down("owner-a") is ManagedTxOutcome.ACCEPTED
+    assert await managed.ptt_down("owner-b") is ManagedTxOutcome.REJECTED
+    assert await managed.ptt_up("owner-b") is ManagedTxOutcome.REJECTED
+    assert (await managed.snapshot()).state == first.state
+    assert await managed.owner_disconnect("owner-a") is ManagedTxOutcome.ACCEPTED
+    released = await managed.snapshot()
+    assert released.state.intent.kind is ManagedTxIntentKind.RX
+    assert not released.state.release_required
+    assert fence.calls == 1
+    assert [item.operation for item in lane.effects] == [
+        ActuationOperation.PTT_ON,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    force = lane.effects[-1]
+    assert lane.aborts == [
+        (force.token, AbortOperation.STOP_CW),
+        (force.token, AbortOperation.STOP_TUNE),
+    ]
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_transmit_is_latched_and_force_off_runs_one_abort_family() -> None:
+    managed, clock, _, _, fence, lane = authority()
+    assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+    started = await managed.snapshot()
+    clock.now = 106
+    assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+    assert await managed.owner_disconnect("browser") is ManagedTxOutcome.REJECTED
+    assert (await managed.snapshot()).state == started.state
+    assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    assert fence.calls == 1
+    force = lane.effects[-1]
+    assert force.operation is ActuationOperation.FORCE_RECEIVE
+    assert lane.aborts == [
+        (force.token, AbortOperation.STOP_CW),
+        (force.token, AbortOperation.STOP_TUNE),
+    ]
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_offline_force_off_retries_when_provider_appears() -> None:
+    managed, _, wakeup, _, fence, lane = authority(generation=None)
+    assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    assert (await managed.snapshot()).state.release_required
+    assert lane.effects == [] and fence.calls == 1
+    revision = wakeup.revision
+    await managed.set_provider_generation(8)
+    await wakeup.wait_after(revision + 1)
+    assert not (await managed.snapshot()).state.release_required
+    assert lane.effects[-1].operation is ActuationOperation.FORCE_RECEIVE
+    await managed.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure", [ActuationResult.REJECTED, ActuationResult.UNCERTAIN]
+)
+async def test_failed_on_retries_release_with_new_epoch(
+    failure: ActuationResult,
+) -> None:
+    managed, clock, wakeup, _, _, lane = authority()
+    lane.results.extend((failure, ActuationResult.ACCEPTED))
+    assert await managed.ptt_down("owner") is ManagedTxOutcome.ACCEPTED
+    failed = await managed.snapshot()
+    assert failed.state.intent.kind is ManagedTxIntentKind.RX
+    assert failed.state.release_plan is ReleasePlan.FORCE_RELEASE
+    retry_epoch = failed.state.effect_epoch + 1
+    revision = wakeup.revision
+    clock.now += 2
+    wakeup.wake()
+    await wakeup.wait_after(revision + 1)
+    assert lane.effects[-1].token.effect_epoch == retry_epoch
+    assert not (await managed.snapshot()).state.release_required
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_effect_settlement_cannot_clear_current_debt() -> None:
+    managed, _, _, _, _, lane = authority()
+    lane.stale_once = True
+    await managed.force_off()
+    projected = await managed.snapshot()
+    assert projected.state.release_required
+    assert projected.state.pending_effect is not None
+    await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_tot_expiry_uses_the_single_scheduler_and_force_off() -> None:
+    managed, clock, wakeup, _, fence, lane = authority(seconds=10)
+    await managed.ptt_down("owner")
+    revision = wakeup.revision
+    assert (await managed.snapshot()).remaining_tot_seconds == 10
+    clock.now = 110
+    wakeup.wake()
+    await wakeup.wait_after(revision + 1)
+    projected = await managed.snapshot()
+    assert projected.state.intent.kind is ManagedTxIntentKind.RX
+    assert projected.remaining_tot_seconds is None
+    assert fence.calls == 1
+    assert lane.effects[-1].operation is ActuationOperation.FORCE_RECEIVE
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_live_tot_edit_persists_then_recomputes_from_original_start() -> None:
+    managed, clock, _, store, _, _ = authority(seconds=10)
+    await managed.ptt_down("owner")
+    original_start = (await managed.snapshot()).state.tx_started_at_monotonic
+    clock.now = 105
+    assert (await managed.set_tot_seconds(20)).timeout_seconds == 20
+    projected = await managed.snapshot()
+    assert store.values == [20]
+    assert projected.state.tx_started_at_monotonic == original_start
+    assert projected.state.tot_deadline_monotonic == 120
+    assert projected.remaining_tot_seconds == 15
+    assert (await managed.set_tot_seconds(None)).timeout_seconds is None
+    assert (await managed.snapshot()).remaining_tot_seconds is None
+    await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_live_tot_edit_at_or_below_elapsed_forces_off_immediately() -> None:
+    managed, clock, _, store, fence, lane = authority(seconds=20)
+    await managed.ptt_down("owner")
+    clock.now = 105
+    assert (await managed.set_tot_seconds(5)).timeout_seconds == 5
+    projected = await managed.snapshot()
+    assert store.values == [5]
+    assert projected.state.intent.kind is ManagedTxIntentKind.RX
+    assert projected.remaining_tot_seconds is None
+    assert fence.calls == 1
+    assert lane.effects[-1].operation is ActuationOperation.FORCE_RECEIVE
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_config_failure_does_not_activate_value() -> None:
+    managed, _, _, store, _, _ = authority(seconds=10)
+    await managed.ptt_down("owner")
+    before = await managed.snapshot()
+    store.fail = True
+    with pytest.raises(OSError, match="persistence failed"):
+        await managed.set_tot_seconds(30)
+    after = await managed.snapshot()
+    assert after.configured_tot_seconds == 10
+    assert after.state.tot_deadline_monotonic == before.state.tot_deadline_monotonic
+    await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_simultaneous_tot_and_retry_due_chooses_force_off() -> None:
+    managed, clock, _, _, fence, lane = authority()
+    await managed.ptt_down("owner")
+    managed._retry_due = 110
+    clock.now = 110
+    await managed._process_due()
+    assert fence.calls == 1
+    assert lane.effects[-1].operation is ActuationOperation.FORCE_RECEIVE
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_repeated_force_off_is_accepted_and_advances_epoch() -> None:
+    managed, _, _, _, fence, lane = authority()
+    assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    first = lane.effects[-1].token.effect_epoch
+    assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    assert lane.effects[-1].token.effect_epoch == first + 1
+    assert fence.calls == 2
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_generation_is_monotonic_and_wakes_debt() -> None:
+    managed, _, _, _, _, _ = authority(generation=7)
+    await managed.set_provider_generation(None)
+    with pytest.raises(ValueError, match="increase"):
+        await managed.set_provider_generation(6)
+    await managed.set_provider_generation(8)
+    assert (await managed.snapshot()).provider_generation == 8
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_close_refuses_active_debt_or_pending_without_mutation() -> None:
+    managed, _, _, _, fence, lane = authority()
+    scheduler = managed._scheduler_task
+    await managed.transmit_on()
+    for prepare in (
+        None,
+        ActuationResult.REJECTED,
+        "stale",
+    ):
+        if prepare is ActuationResult.REJECTED:
+            await managed.force_off()
+            lane.results.append(prepare)
+            await managed.ptt_down("owner")
+        elif prepare == "stale":
+            await managed.force_off()
+            lane.stale_once = True
+            await managed.force_off()
+        state, calls, effects = managed._state, fence.calls, tuple(lane.effects)
+        with pytest.raises(RuntimeError, match="clean RX state"):
+            await managed.close()
+        assert managed._state is state
+        assert managed._scheduler_task is scheduler and not scheduler.done()
+        assert (fence.calls, tuple(lane.effects)) == (calls, effects)
+    await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_close_disposes_clean_scheduler_idempotently_without_effects() -> None:
+    managed, _, _, _, fence, lane = authority()
+    scheduler, state = managed._scheduler_task, managed._state
+    await managed.close()
+    assert scheduler.done() and managed._state is state
+    assert fence.calls == 0 and lane.effects == [] and lane.aborts == []
+    await managed.close()
+    assert fence.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_ten_thousand_idempotent_commands_keep_one_scheduler() -> None:
+    managed, _, _, _, _, lane = authority()
+    scheduler = managed._scheduler_task
+    await managed.transmit_on()
+    for _ in range(10_000):
+        assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+    assert managed._scheduler_task is scheduler and not scheduler.done()
+    assert [effect.operation for effect in lane.effects] == [
+        ActuationOperation.TRANSMIT_ON
+    ]
+    assert not hasattr(managed, "observed_ptt")
+    await managed.force_off()
+    await managed.close()

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -206,14 +206,9 @@ async def test_offline_force_off_retries_when_provider_appears() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "failure", [ActuationResult.REJECTED, ActuationResult.UNCERTAIN]
-)
-async def test_failed_on_retries_release_with_new_epoch(
-    failure: ActuationResult,
-) -> None:
+async def test_rejected_on_retries_release_with_new_epoch() -> None:
     managed, clock, wakeup, _, _, lane = authority()
-    lane.results.extend((failure, ActuationResult.ACCEPTED))
+    lane.results.extend((ActuationResult.REJECTED, ActuationResult.ACCEPTED))
     assert await managed.ptt_down("owner") is ManagedTxOutcome.ACCEPTED
     failed = await managed.snapshot()
     assert failed.state.intent.kind is ManagedTxIntentKind.RX
@@ -225,6 +220,60 @@ async def test_failed_on_retries_release_with_new_epoch(
     await wakeup.wait_after(revision + 1)
     assert lane.effects[-1].token.effect_epoch == retry_epoch
     assert not (await managed.snapshot()).state.release_required
+    await managed.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ingress", "operation"),
+    [
+        ("ptt", ActuationOperation.PTT_ON),
+        ("transmit", ActuationOperation.TRANSMIT_ON),
+    ],
+)
+@pytest.mark.parametrize(
+    ("release", "cleared"),
+    [
+        (ActuationResult.ACCEPTED, True),
+        (ActuationResult.REJECTED, False),
+        (ActuationResult.UNCERTAIN, False),
+    ],
+)
+async def test_uncertain_on_immediately_runs_one_force_off_family(
+    ingress: str,
+    operation: ActuationOperation,
+    release: ActuationResult,
+    cleared: bool,
+) -> None:
+    managed, _, _, _, fence, lane = authority()
+    lane.results.extend((ActuationResult.UNCERTAIN, release))
+    outcome = (
+        await managed.ptt_down("owner")
+        if ingress == "ptt"
+        else await managed.transmit_on()
+    )
+    assert outcome is ManagedTxOutcome.ACCEPTED
+    assert fence.calls == 1
+    assert [effect.operation for effect in lane.effects] == [
+        operation,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    force = lane.effects[-1]
+    assert force.token.effect_epoch == lane.effects[0].token.effect_epoch + 1
+    assert lane.aborts == [(force.token, operation) for operation in AbortOperation]
+    assert (await managed.snapshot()).state.release_required is not cleared
+    if not cleared:
+        await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_on_settlement_does_not_run_force_off() -> None:
+    managed, _, _, _, fence, lane = authority()
+    lane.stale_once = True
+    await managed.ptt_down("owner")
+    assert fence.calls == 0 and len(lane.effects) == 1
+    await managed.force_off()
     await managed.close()
 
 


### PR DESCRIPTION
## Summary

- add the internal ManagedTxAuthority composition for canonical reducer state, managed effect-lane settlement, ForceOff abort-family dispatch, software TOT, and release retry scheduling
- serialize ingress through one lock and use one scheduler for the nearest TOT or retry deadline
- keep the authority internal and currently uncomposed: this PR adds no Web, provider, backend, or runtime composition wiring

Linear: https://linear.app/morozsm/issue/MOR-2204

## TDD and review evidence

Initial RED before production existed: focused collection failed with ModuleNotFoundError for rigplane.runtime.managed_tx_authority.

The mechanism-audit F3 correction added two deterministic RED failures against the first implementation: unsafe close did not raise, and clean close incorrectly invoked ForceOff and changed managed state. The corrected close is clean-state disposal only.

Exact-head BLOCKED reproduction for current ON UNCERTAIN settlement: the PTT and TRANSMIT oracles failed because the abort fence was not invoked. The stale-ON control remained green. The fix applies the exact settlement through the canonical reducer, then iteratively creates one canonical ForceOff only for current APPLIED ON UNCERTAIN. REJECTED remains on delayed reducer retry and STALE remains inert.

GREEN at exact head:

- focused authority suite under asyncio debug and warnings as errors: 22 passed
- broader reducer, config, fence, effect-lane, and authority scope: 120 passed
- updated race and boundedness subset: 25 of 25 repeated runs passed
- Ruff check and format check: passed
- strict mypy for managed_tx_authority.py: passed
- import-linter: 5 contracts kept
- doc citation, link, dangling-citation, rebrand, diff, and retired-name gates: passed

## Scope boundary

Exactly two new files. The authority consumes the canonical reducer, persisted TOT configuration, abort fence, and effect lane. It does not duplicate provider semantics or observed-PTT admission.

No Web/UI wiring, provider/backend changes, neutral dispatch changes, native-radio TOT, new watchdog, legacy supervisor changes, or hardware requirement are included.

close() is deliberately only clean-state disposal. It refuses active intent, release debt, or a pending effect without changing state or scheduler identity. It does not perform ForceOff, invoke the abort fence or effect lane, schedule retry, or claim to drain shutdown work; full runtime shutdown/provider replacement remains outside this PR.

## Size exception

Linear MOR-2204 records the coordinator-approved exception to the original 350 production / 750 total target. Final scope remains exactly two cohesive new files: 369 production lines and 443 test lines, 812 additions total. The additional readable control flow is the non-recursive exact-settlement to canonical-ForceOff handoff, and the additional oracles cover both PTT_ON and TRANSMIT_ON with every normalized immediate release result plus separate REJECTED and stale controls. No cosmetic compaction was applied.