### PR TITLE
design-a-face: close nine findings from the first independent trial (#3008)

### DIFF
--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -186,6 +186,20 @@ separates a *dimmed* indicator, which is the same hue with less ink, from a
 *differently coloured* one: the ink profile confuses them, the colour profile
 does not.
 
+**That assumes the ground itself is neutral, and warns when it is not.**
+"Distance from grey" only isolates an accent if the ground has none to
+compete with. On a reference whose ground itself carries a tint — this one's
+amber LCD, not a neutral panel with one coloured accent — most of the box
+already reads as "coloured", and `--by colour` profiles the ground, not any
+meaning: `bands /var/tmp/ftx1-reference.png --by colour` gives one run at
+~94%, and colour-distance there is *anti-correlated* with ink
+(`corrcoef ≈ -0.63` — the mode sits over the LEAST-inked pixels, i.e. the
+ground). The script now detects this itself: `load()` prints a WARNING when
+the measured box's median chroma exceeds a threshold (`DEGENERATE_CHROMA` in
+`measure-reference.py`), proven in `selftest` to fire on a tinted ground and
+stay silent on a genuine accent against a neutral one. Do not report a
+`--by colour` run as a colour-based finding if that warning fired.
+
 **`--smooth <window>` flattens a regular texture before profiling.** Design
 references often carry one — scanlines on an LCD imitation, a dot grid —
 whose period is small and whose amplitude rivals a real element's. Untreated,

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -198,19 +198,24 @@ separates a *dimmed* indicator, which is the same hue with less ink, from a
 *differently coloured* one: the ink profile confuses them, the colour profile
 does not.
 
-**That assumes the ground itself is neutral, and warns when it is not.**
-"Distance from grey" only isolates an accent if the ground has none to
-compete with. On a reference whose ground itself carries a tint — this one's
-amber LCD, not a neutral panel with one coloured accent — most of the box
-already reads as "coloured", and `--by colour` profiles the ground, not any
-meaning: `bands /var/tmp/ftx1-reference.png --by colour` gives one run at
-~94%, and colour-distance there is *anti-correlated* with ink
-(`corrcoef ≈ -0.63` — the mode sits over the LEAST-inked pixels, i.e. the
-ground). The script now detects this itself: `load()` prints a WARNING when
-the measured box's median chroma exceeds a threshold (`DEGENERATE_CHROMA` in
-`measure-reference.py`), proven in `selftest` to fire on a tinted ground and
-stay silent on a genuine accent against a neutral one. Do not report a
-`--by colour` run as a colour-based finding if that warning fired.
+**This is a statistic over the measured box, not a judgement about "the
+ground."** "Distance from grey" only isolates an accent if the ground has
+none to compete with — but the median chroma is taken over whatever box is
+measured, so the same warning fires whether the ground itself is tinted or a
+crop is simply tight enough that the accent IS most of the box. On a
+reference whose ground itself carries a tint — this one's amber LCD, not a
+neutral panel with one coloured accent — most of the box already reads as
+"coloured", and `--by colour` profiles the ground, not any meaning: `bands
+/var/tmp/ftx1-reference.png --by colour` gives one run at ~94%, and
+colour-distance there is *anti-correlated* with ink (`corrcoef ≈ -0.63` —
+the mode sits over the LEAST-inked pixels, i.e. the ground). The script
+detects this itself: `load()` prints a WARNING when the measured box's
+median chroma exceeds a threshold (`DEGENERATE_CHROMA` in
+`measure-reference.py`). `selftest` only exercises the whole-image case; it
+does not claim the threshold behaves any particular way on a crop. If that
+warning fires on a `--by colour` run, check whether it is because the ground
+itself is tinted or because the crop is mostly the accent, before reporting
+the run as a colour-based finding.
 
 **`--smooth <window>` flattens a regular texture before profiling.** Design
 references often carry one — scanlines on an LCD imitation, a dot grid —

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -220,17 +220,18 @@ Measure the stripe spacing in the raw (unsmoothed) profile first, then choose
 a window a few times that period: wide enough to flatten the stripes, narrow
 enough to leave a genuine band's boundary where it is.
 
-**`--signal variation` profiles spread instead of level, and is not a
-nicety — it is what makes a textured reference measurable at all.** A
-scanline ground inks every row about equally, so the *mean* ink per row
-(`level`, the default) cannot tell a band from a gutter — both read as
-inked. The *spread* of ink within a row can: a row that is part of a real
-band varies across its width (edges, glyphs, a filled meter segment sitting
-beside empty ones), while a row that is only texture does not vary beyond the
-texture's own period. Reach for `--signal variation` whenever `level` reports
-either "no runs" or one run spanning nearly the whole image on a reference
-you know is not actually blank — that is the signature of a textured ground,
-not evidence the reference has no structure.
+**`--signal variation` profiles spread instead of level.** A scanline ground
+inks every row about equally, so the *mean* ink per row (`level`, the
+default) cannot tell a band from a gutter — both read as inked. The *spread*
+of ink within a row can: a row that is part of a real band varies across its
+width (edges, glyphs, a filled meter segment sitting beside empty ones),
+while a row that is only texture does not vary beyond the texture's own
+period — verified on a planted fixture built for exactly this contrast
+(`selftest`'s `--signal level` vs `--signal variation` check). It is not a
+guaranteed fix — on this skill's own reference it does not separate
+anything at all; see the "Known limit" note below. Reach for it when
+`level` reports "no runs" or one run spanning nearly the whole image on a
+reference you know is not blank; it is worth trying, not a promise.
 
 **Known limit, and worth knowing before you trust a number:** on a reference
 with a regular texture (this one has a fine scanline-style ground), the
@@ -238,8 +239,19 @@ floor-relative threshold reads the texture itself as ink almost everywhere,
 so a whole-panel `bands` collapses to nearly one giant run instead of finding
 the real bands. Reproduced: `bands /var/tmp/ftx1-reference.png` on the
 2572×1100 reference returns exactly **one run spanning 98.0%** of the image
-(`22-1100`). Use `--smooth` or `--signal variation` (both above) first; crop
-only once one of those has shown there is a real boundary to crop to.
+(`22-1100`). Neither treatment above rescues *this particular* reference:
+`--smooth` 8/24/36/48 each still return one run, 98.3-99.7% of the image;
+`--signal variation` returns the same single run as `level`, byte-identical
+— and on the crop the trial used (`--crop 60,55,2515,1060 --min-run 8`),
+`level` finds 12 runs against `variation`'s 11, not the clean split the
+mechanism above predicts. The floor here is set by the bright out-of-panel
+border rather than by the scanline texture the two treatments target, so
+nearly everything clears the threshold in every mode. Where `--smooth` or
+`--signal variation` does surface a real boundary on a given reference,
+crop to it; where neither does, as here, do not crop blind — fall back to
+reading proportions from the image directly with a stated, generous
+tolerance instead of reporting a script number this instrument cannot
+produce for a texture this uniform.
 
 **Report proportions of the panel box, never pixels**, and state the tolerance.
 The stage scales as one block, so a pixel figure is true only at one size,

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -400,6 +400,21 @@ A field existing in the view model does not mean the radio reports it, and a
 group being present does not mean its fields are supported. Both gates are
 separate and both are checkable.
 
+**The two fourteens are different sets, not the same fourteen counted
+twice.** A complete mapping exists between them (checked against every
+surface component's own header): ten surfaces map to one optional group of
+the matching name (`txAux`, `meters`, `rxAudio`, `dsp`, `rfFrontEnd`, `band`,
+`antenna`, `cwKeyer`, `scopeControls`, `scopeDisplay`). Two surfaces each own
+*two* groups — `FilterSurface` renders both `modeFilter` and
+`filterPassband`, `RitXitScanSurface` renders both `ritXit` and `scan`, each
+surface's own header says so — which is where the other four groups go
+(10 + 2×2 = 14). The remaining two surfaces, `vfo` and `rxTx`, are backed by
+required top-level `RadioViewModel` fields that carry no `?` — `vfos`,
+`activeReceiver`, `split`, `dualWatch` for `vfo`; `txTarget`, `txPermit` for
+`rxTx` — not by any of the fourteen optional groups at all (10 + 2 + 2 = 14
+surfaces). The shared count of fourteen invites a one-to-one reading; there
+is a correspondence, but it is not that one.
+
 ### The path an appearance takes
 
 A design language supplies three things and no markup: tokens, renderers, a

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -173,6 +173,12 @@ it, not only a broken threshold. It fails loudly if any is not recovered
 exactly. The low-contrast band is the one that matters: an earlier version
 planted only strong bands, and deliberately breaking the threshold left it
 green, so it verified nothing. An ideal case survives being measured badly.
+It also checks `--smooth` (the same three bands must still be recovered,
+wider, at `smooth=5`), `--signal variation` (a scanline fixture that `level`
+cannot separate into a band and a gutter by design, but `variation` can),
+and the degenerate-colour warning (`DEGENERATE_CHROMA`, above) — each
+confirmed, by mutation, to fail the self-test when that one path is broken
+and pass when it is not.
 
 **Two scales, same method.** A profile over the whole panel gives the bands and
 the divider. For a fine element — glyph cells, segment pitch, chip padding —

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -206,11 +206,18 @@ either "no runs" or one run spanning nearly the whole image on a reference
 you know is not actually blank — that is the signature of a textured ground,
 not evidence the reference has no structure.
 
-**Known limit, found by the selftest and worth knowing before you trust a
-number:** the run detector thresholds just above the profile's floor, because a
-midpoint threshold loses faint bands whenever a heavy element is present in the
-same image — and these panels always contain both. If two elements sit with no
-gutter between them, they read as one run; crop to separate them.
+**Known limit, and worth knowing before you trust a number:** on a reference
+with a regular texture (this one has a fine scanline-style ground), the
+floor-relative threshold reads the texture itself as ink almost everywhere,
+so a whole-panel `bands` collapses to nearly one giant run instead of finding
+the real bands. Reproduced: `bands /var/tmp/ftx1-reference.png` on the
+2572×1100 reference returns exactly **one run spanning 98.0%** of the image
+(`22-1100`). **Cropping into that texture is not the cure and makes it
+worse**: three independent interior crops of pure background texture on the
+same reference gave 42, 35 and 34 runs respectively, each spaced at the
+texture's own roughly-12px row period rather than at anything the layout put
+there. Use `--smooth` or `--signal variation` (both above) first; crop only
+once one of those has shown there is a real boundary to crop to.
 
 **Report proportions of the panel box, never pixels**, and state the tolerance.
 The stage scales as one block, so a pixel figure is true only at one size,

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -25,6 +25,26 @@ states into two, and two of the collapsed ones are safety-relevant.
 
 This skill exists to make both impossible to ship by accident.
 
+## Phase 0 — check whether a design language for this reference already exists
+
+**Search before you write, before anything else here.** This can change what
+the rest of the exercise even is, which is why it comes before Phase 1 rather
+than alongside it. Read `frontend/src/presentation/languages/` — every shipped
+design language lives there. Checked: `segmentline` is on `main` in full —
+three renderers (`frequency-renderer.ts`, `meters-renderer.ts`,
+`state-feedback-renderer.ts`), `tokens.ts`, a stylesheet (`segmentline.css`)
+and five test files (`find frontend/src/presentation/languages/segmentline
+-type f`). Skipping this step lets a proposal read as greenfield work when it
+is half-built — exactly the omission CLAUDE.md's "search before you write" and
+"close enough is reuse" scope rules exist to prevent.
+
+A hit is not "reuse it" and stop. Establish three things: what the existing
+language already covers, what it does not, and whether closing the gap is a
+stylesheet change (`tokens.ts` / the family's `.css`, the cheap tier Phase 4
+names) or new markup (a change to the shared semantic-surface layer, not to
+this design language). Only then does deriving a fresh contract in Phase 1
+make sense to run.
+
 ## Phase 1 — derive the data contract
 
 **Never write this by hand.** A hand-maintained contract at a layer boundary

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -638,5 +638,5 @@ Before handing it over, for each backed element:
   above; a checklist reader does not go there, which is why it is repeated
   here).
 
-A proposal that passes all four is implementable. One that does not is a
-plan, and should say which it fails.
+A proposal that fails any of the four is a plan, not an implementable one,
+and should say which it fails.

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -238,12 +238,8 @@ floor-relative threshold reads the texture itself as ink almost everywhere,
 so a whole-panel `bands` collapses to nearly one giant run instead of finding
 the real bands. Reproduced: `bands /var/tmp/ftx1-reference.png` on the
 2572×1100 reference returns exactly **one run spanning 98.0%** of the image
-(`22-1100`). **Cropping into that texture is not the cure and makes it
-worse**: three independent interior crops of pure background texture on the
-same reference gave 42, 35 and 34 runs respectively, each spaced at the
-texture's own roughly-12px row period rather than at anything the layout put
-there. Use `--smooth` or `--signal variation` (both above) first; crop only
-once one of those has shown there is a real boundary to crop to.
+(`22-1100`). Use `--smooth` or `--signal variation` (both above) first; crop
+only once one of those has shown there is a real boundary to crop to.
 
 **Report proportions of the panel box, never pixels**, and state the tolerance.
 The stage scales as one block, so a pixel figure is true only at one size,

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -542,6 +542,14 @@ Before handing it over, for each backed element:
   general answer.
 - Confirm the styling reaches it. `design-language-selector-reachability.component.test.ts`
   reports any selector that addresses markup nothing emits.
+- **Confirm the language can be selected at all — the stricter fourth check,
+  and the one the first three don't cover.** `WORKSPACE_DESIGN_LANGUAGE_IDS` in
+  `presentation/workspace/contract.ts` is the closed set an operator can pick;
+  a language absent from it cannot activate in production regardless of what
+  the other three checks say — `pickId` falls back to `studioline` instead
+  (already stated once, in the "Where the layout decides" reference section
+  above; a checklist reader does not go there, which is why it is repeated
+  here).
 
-A proposal that passes those three is implementable. One that does not is a
-plan, and should say which of the three it fails.
+A proposal that passes all four is implementable. One that does not is a
+plan, and should say which it fails.

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -158,6 +158,8 @@ So extract, in this order:
     ./measure-reference.py columns <image>
     ./measure-reference.py bands   <image> --crop L,T,R,B
     ./measure-reference.py bands   <image> --by colour
+    ./measure-reference.py bands   <image> --smooth 8
+    ./measure-reference.py bands   <image> --signal variation
 
 `bands` profiles rows and finds the horizontal bands; `columns` profiles
 columns and finds the vertical divisions. It reports every run as a **share of
@@ -183,6 +185,26 @@ alarm — this locates that meaning without being told where to look. It also
 separates a *dimmed* indicator, which is the same hue with less ink, from a
 *differently coloured* one: the ink profile confuses them, the colour profile
 does not.
+
+**`--smooth <window>` flattens a regular texture before profiling.** Design
+references often carry one — scanlines on an LCD imitation, a dot grid —
+whose period is small and whose amplitude rivals a real element's. Untreated,
+the detector can return one run per texture stripe and bury the bands.
+Measure the stripe spacing in the raw (unsmoothed) profile first, then choose
+a window a few times that period: wide enough to flatten the stripes, narrow
+enough to leave a genuine band's boundary where it is.
+
+**`--signal variation` profiles spread instead of level, and is not a
+nicety — it is what makes a textured reference measurable at all.** A
+scanline ground inks every row about equally, so the *mean* ink per row
+(`level`, the default) cannot tell a band from a gutter — both read as
+inked. The *spread* of ink within a row can: a row that is part of a real
+band varies across its width (edges, glyphs, a filled meter segment sitting
+beside empty ones), while a row that is only texture does not vary beyond the
+texture's own period. Reach for `--signal variation` whenever `level` reports
+either "no runs" or one run spanning nearly the whole image on a reference
+you know is not actually blank — that is the signature of a textured ground,
+not evidence the reference has no structure.
 
 **Known limit, found by the selftest and worth knowing before you trust a
 number:** the run detector thresholds just above the profile's floor, because a

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -174,11 +174,17 @@ exactly. The low-contrast band is the one that matters: an earlier version
 planted only strong bands, and deliberately breaking the threshold left it
 green, so it verified nothing. An ideal case survives being measured badly.
 It also checks `--smooth` (the same three bands must still be recovered,
-wider, at `smooth=5`), `--signal variation` (a scanline fixture that `level`
-cannot separate into a band and a gutter by design, but `variation` can),
-and the degenerate-colour warning (`DEGENERATE_CHROMA`, above) — each
-confirmed, by mutation, to fail the self-test when that one path is broken
-and pass when it is not.
+strictly wider, at `smooth=5`, and a second, larger window must widen them
+further still — not just the same window applied again) and `--signal
+variation` (a scanline fixture that `level` cannot separate into a band and a
+gutter by design, but `variation` can), both routed through `main()` rather
+than called directly so a flag dropped between the CLI and `report()` fails
+the check too, not only a broken function — and the degenerate-colour warning
+(`DEGENERATE_CHROMA`, above). Confirmed by mutation to fail the self-test: a
+no-op smoothing branch, `--smooth` dropped before it reaches `report()`,
+`--signal` inverted at the CLI, a smoothing window hardcoded regardless of
+the requested size, and the degenerate-colour threshold broken in either
+direction (`selftest` in `measure-reference.py`).
 
 **Two scales, same method.** A profile over the whole panel gives the bands and
 the divider. For a fine element — glyph cells, segment pitch, chip padding —

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -503,18 +503,20 @@ rationale, the rationale becomes a constraint, and nothing downstream can tell
 it was invented. So "ask if unsure" is too weak to act on. These are the
 triggers, and at any of them stop and ask rather than pick the likely reading:
 
-- **You cannot say what an element is.** Name it as unidentified. Do not give it
-  a plausible name; a wrong name is inherited silently by everything after it.
-- **The measurement is ambiguous.** Two elements with no gutter read as one run.
-  Ask which it is rather than splitting it by eye.
-- **You cannot tell established from inferred.** The owner knows their own
-  intent, and one sentence from them converts a guess into a fact. That is the
+- **You cannot say what an element is.** Ask the owner. Name it as unidentified
+  in the meantime; do not give it a plausible name — a wrong name is inherited
+  silently by everything after it.
+- **The measurement is ambiguous.** Ask the owner. Two elements with no gutter
+  read as one run; ask which it is rather than splitting it by eye.
+- **You cannot tell established from inferred.** Ask the owner. They know their
+  own intent, and one sentence from them converts a guess into a fact — the
   cheapest question available.
-- **The reference shows something no field can fill.** Whether to widen the
-  contract or drop the element is a scope decision, not a design one.
-- **A rule you extracted cannot place an unshown field.** That is the signal it
-  described the picture rather than the reasoning — say so and ask, instead of
-  stretching it.
+- **The reference shows something no field can fill.** Ask the owner. Whether
+  to widen the contract or drop the element is a scope decision, not a design
+  one.
+- **A rule you extracted cannot place an unshown field.** Ask the owner. That
+  is the signal it described the picture rather than the reasoning — say so,
+  instead of stretching it.
 
 The instance: this skill's own earlier pass read the reference as a control
 panel and derived placement rules about adjacency and reach. It is a display —
@@ -524,6 +526,13 @@ no way to know; it also never asked.
 
 Asking costs one message. A wrong premise costs everything built on it, and it
 does not announce itself.
+
+**If no answer arrives** — a one-shot task, nobody to ask back — do not read
+that as licence to produce nothing. Name the assumption you are making
+explicitly (which trigger fired, and the reading you picked), mark everything
+downstream of it as resting on that assumption rather than a finding, and
+continue. An unanswered question is not permission to guess silently; it is
+permission to guess out loud and label the guess.
 
 ## Traps
 

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -541,21 +541,27 @@ def main() -> None:
     print("reachability.component.test.ts`.\n")
     for name, info in sorted(data["surfaceComponents"].items()):
         comps = info["components"]
-        if not comps:
-            slots = info["rendersSlots"]
-            if slots:
-                named = ", ".join(f"`{s}`" for s in slots)
-                print(f"- `{name}` — no shared component, but calls `renderSlot()` "
-                      f"itself for {named}; design-language attributes DO reach "
-                      "this surface's own markup")
-            else:
-                print(f"- `{name}` — no shared component and no `renderSlot()` "
-                      "call found; no design-language attribute reaches this "
-                      "surface's markup from here (see the reachability test above)")
-            continue
-        parts = ", ".join(f"`{c['name']}` (**{c['tier']}**, "
-                          f"--dl- {c['dl']} / --v2- {c['v2']})" for c in comps)
-        print(f"- `{name}` — {parts}")
+        slots = info["rendersSlots"]
+        # `rendersSlots` is printed for EVERY row, not only rows with no
+        # shared component: MetersSurface and VfoSurface have both a shared
+        # component AND their own `renderSlot()` call, and skipping the
+        # slots half there made them read as "does not reach" — the two
+        # rows this partial derived list was silently wrong for.
+        if comps:
+            component_part = ", ".join(f"`{c['name']}` (**{c['tier']}**, "
+                                       f"--dl- {c['dl']} / --v2- {c['v2']})" for c in comps)
+        else:
+            component_part = "no shared component"
+        if slots:
+            named = ", ".join(f"`{s}`" for s in slots)
+            slot_part = (f"calls `renderSlot()` itself for {named}; "
+                         "design-language attributes DO reach this "
+                         "surface's own markup")
+        else:
+            slot_part = ("no `renderSlot()` call found; no design-language "
+                         "attribute reaches this surface's markup from here "
+                         "(see the reachability test above)")
+        print(f"- `{name}` — {component_part}; {slot_part}")
     print()
 
     feats = data["radioFeatures"]

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -290,13 +290,12 @@ def _later_return_undefined(stripped: str, after: int) -> str | None:
     `_classify_gate`'s own docstring assigns to `not-derivable`.
 
     Brace depth excludes a guard that belongs to a NESTED block — a local
-    helper function's own body, a `.map()`/`.filter()` callback — which is
-    not a second early return from the function this scan is reading,
-    however it reads as text. A `//` or `/* */` comment is skipped outright
-    for the same reason: text documenting a guard that used to exist is not
-    a guard that still runs. Called only from the static-pattern branches
-    below: `scattered` and `not-derivable` already read past the top guard
-    by construction, so a later guard there is not news."""
+    helper function's own body, a `.map()`/`.filter()` callback. A `//` or
+    `/* */` comment is skipped outright for the same reason: text
+    documenting a guard that used to exist is not a guard that still runs.
+    Called only from the static-pattern branches below: `scattered` and
+    `not-derivable` already read past the top guard by construction, so a
+    later guard there is not news."""
     depth = 0
     i = after
     n = len(stripped)
@@ -330,9 +329,7 @@ def _classify_gate(body: str) -> tuple[str, str]:
     at the top of the function, AND no other `if (...) return undefined;` —
     that exact, unbraced shape, the only one `_later_return_undefined`
     looks for — at the function's own top-level control flow (brace depth
-    0, outside a comment). A guard nested inside a local helper's own body
-    or a callback does not count: it is not a second early return from THIS
-    function no matter how it reads as text.
+    0, outside a comment).
     `scattered` — the only top-of-function guard is a generic `!caps`, and
     the real decision (an array length, an OR of several capability flags
     computed further down) is further into the body; read the function.

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -24,6 +24,7 @@ from typing import NoReturn
 
 VIEW_MODEL = Path("frontend/src/semantic/radio-view-model.ts")
 LAYOUT_CONTRACT = Path("frontend/src/presentation/layouts/contract.ts")
+ADAPTER = Path("frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts")
 
 
 def die(msg: str) -> NoReturn:
@@ -193,6 +194,137 @@ def radio_declares(radio: str) -> tuple[list[str], str]:
     return [str(f) for f in feats], str(path)
 
 
+def _function_body(text: str, name: str) -> str | None:
+    """The `{ ... }` body of `function <name>(...): ReturnType { ... }`,
+    found by brace-depth counting from the parameter list's own closing
+    paren — so a multi-line signature or a generic return type does not
+    confuse it. None if no such function exists; callers must report that
+    as its own outcome (Phase 1: never silently skip a group)."""
+    m = re.search(rf"\bfunction {re.escape(name)}\(", text)
+    if m is None:
+        return None
+    i = text.index("(", m.end() - 1)
+    depth = 1
+    j = i + 1
+    while depth > 0:
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+        j += 1
+    brace = text.index("{", j)
+    depth = 1
+    k = brace + 1
+    while depth > 0:
+        if text[k] == "{":
+            depth += 1
+        elif text[k] == "}":
+            depth -= 1
+        k += 1
+    return text[brace + 1 : k - 1]
+
+
+# Shapes of a `derive<Group>` function's leading guard clause(s), tried in
+# this order (most specific first; `_GATE_NULLCAPS` before the generic live
+# patterns, since a bare `!caps` would otherwise also match those). Every
+# pattern anchors at the body's own start (`\A`, after stripping the
+# function's own leading newline) — a guard found later in the body is not
+# "the first question for any block", it is exactly the scattered case.
+_GATE_HASCAP = re.compile(r"\A\s*if \(!hasCap\(caps, '([a-z_]+)'\)\) return undefined;")
+_GATE_OR_HASCAP = re.compile(
+    r"\A\s*const (\w+) = hasCap\(caps, '([a-z_]+)'\);\s*\n"
+    r"\s*const (\w+) = hasCap\(caps, '([a-z_]+)'\);\s*\n"
+    r"\s*if \(!\1 && !\3\) return undefined;"
+)
+_GATE_NUMERIC = re.compile(
+    r"\A\s*const (\w+) = caps\?\.(\w+) \?\? (\d+);\s*\n\s*if \(\1 <= (\d+)\) return undefined;"
+)
+_GATE_HALF = re.compile(r"\A\s*if \(!(\w+) \|\| !(\w+)\(caps\)\) return undefined;")
+_GATE_EVER_REPORTED = re.compile(
+    r"\A\s*const (\w+) = \[[^\]]*\];\s*\n"
+    r"\s*if \(!\1\.some\(\(v\) => v !== undefined\)\) return undefined;"
+)
+_GATE_NULLCAPS = re.compile(r"\A\s*if \(!caps\) return undefined;")
+_GATE_LIVE_MULTI = re.compile(r"\A\s*if \((!\w+(?: \|\| !\w+)+)\) return undefined;")
+_GATE_LIVE_SINGLE = re.compile(r"\A\s*if \((![a-zA-Z]+)\) return undefined;")
+
+
+def _classify_gate(body: str) -> tuple[str, str]:
+    """(classification, detail) for one group's `derive*` body.
+
+    Three classifications, matching Phase 1's own "first question for any
+    block": `static` — a single, legible condition read purely from `caps`,
+    at the top of the function. `scattered` — the only top-of-function
+    guard is a generic `!caps`, and the real decision (an array length, an
+    OR of several capability flags computed further down) is further into
+    the body; read the function. `not-derivable` — the guard reads a LIVE
+    object (runtime state, a TX/audio/scope snapshot) or an accumulated
+    "was this ever reported" check, neither of which static source can
+    answer; this also covers a guard that is HALF a static capability test
+    and half a live check (its detail says which half is which)."""
+    stripped = body.lstrip("\n")
+
+    m = _GATE_HASCAP.match(stripped)
+    if m:
+        return "static", f"!hasCap(caps, '{m.group(1)}')"
+
+    m = _GATE_OR_HASCAP.match(stripped)
+    if m:
+        return "static", f"!hasCap(caps, '{m.group(2)}') && !hasCap(caps, '{m.group(4)}')"
+
+    m = _GATE_NUMERIC.match(stripped)
+    if m:
+        ident, field, _default, limit = m.groups()
+        return "static", f"{ident} <= {limit}, where {ident} = caps?.{field}"
+
+    m = _GATE_HALF.match(stripped)
+    if m:
+        live, cap_fn = m.groups()
+        return "not-derivable", (
+            f"half static, half live: !{live} || !{cap_fn}(caps) — the "
+            f"capability half is checkable, the live `{live}` half is not"
+        )
+
+    m = _GATE_EVER_REPORTED.match(stripped)
+    if m:
+        return "not-derivable", (
+            f"gated on whether any of `{m.group(1)}` was ever reported — an "
+            "accumulated-observation check, not a capability tag"
+        )
+
+    if _GATE_NULLCAPS.match(stripped):
+        return "scattered", "only a generic `!caps` guard at the top; the real gate is further into the body"
+
+    m = _GATE_LIVE_MULTI.match(stripped) or _GATE_LIVE_SINGLE.match(stripped)
+    if m:
+        return "not-derivable", f"gated on a live runtime object: {m.group(1)}"
+
+    return "scattered", "no recognised single-guard shape at the top of the function"
+
+
+def presence_gates(adapter_text: str, groups: list[str]) -> list[dict[str, str]]:
+    """Per optional group, does a block exist at all for a given radio —
+    "the first question for any block" (Phase 1) — answered, or said why it
+    cannot be, for EVERY group. Emitting only the easy ones would produce a
+    derived list that is silently incomplete, worse than none.
+
+    Derives the classification per group by reading its own `derive<Group>`
+    function; does not hand-maintain which group falls in which bucket."""
+    out: list[dict[str, str]] = []
+    for group in groups:
+        fn = "derive" + group[0].upper() + group[1:]
+        body = _function_body(adapter_text, fn)
+        if body is None:
+            out.append({
+                "group": group, "function": fn, "classification": "not-found",
+                "detail": f"no `function {fn}` found in {ADAPTER}",
+            })
+            continue
+        classification, detail = _classify_gate(body)
+        out.append({"group": group, "function": fn, "classification": classification, "detail": detail})
+    return out
+
+
 def surface_components() -> dict[str, dict]:
     """Per surface: the shared components it mounts, and how far a design
     language reaches each.
@@ -206,7 +338,18 @@ def surface_components() -> dict[str, dict]:
       language  — reads `--dl-*`; a stylesheet can restyle it.
       theme     — reads `--v2-*` only; a change lands in EVERY skin.
       code      — reads neither; the form is in the source.
+
+    A surface with NO shared component still might reach the design
+    language directly, by calling `renderSlot()` itself and spreading the
+    result's `.attributes` onto its own markup. "No shared component" alone
+    answers nothing about cost; whether design-language attributes land on
+    ANY markup here is the question that does. This reports only whether
+    that machinery is invoked at all — the per-selector answer for what is
+    actually addressable is
+    `components-v2/wiring/__tests__/design-language-selector-reachability
+    .component.test.ts`, not duplicated here.
     """
+    render_slot = re.compile(r"renderSlot\('(\w+)'")
     out: dict[str, dict] = {}
     for f in sorted(Path("frontend/src/semantic").glob("*Surface.svelte")):
         text = f.read_text(encoding="utf-8")
@@ -226,7 +369,10 @@ def surface_components() -> dict[str, dict]:
                 info["tier"] = ("language" if info["dl"]
                                 else "theme" if info["v2"] else "code")
             comps.append(info)
-        out[f.stem] = {"components": comps}
+        out[f.stem] = {
+            "components": comps,
+            "rendersSlots": sorted(set(render_slot.findall(text))),
+        }
     if not out:
         die("no *Surface.svelte found — run from the repository root")
     return out
@@ -239,15 +385,22 @@ def main() -> None:
     args = ap.parse_args()
 
     vm_text = read(VIEW_MODEL)
+    view_models_data = view_models(vm_text)
+    optional_groups = [
+        f["name"] for f in view_models_data.get("RadioViewModel", []) if f["optional"]
+    ]
     data = {
         "surfaces": surfaces(),
         "absence": absence_model(vm_text),
-        "viewModels": view_models(vm_text),
+        "viewModels": view_models_data,
         "fieldShapes": field_shapes(vm_text),
         "radio": args.radio,
         "radioFeatures": radio_declares(args.radio)[0],
         "surfaceComponents": surface_components(),
-        "sources": [str(VIEW_MODEL), str(LAYOUT_CONTRACT), radio_declares(args.radio)[1]],
+        "presenceGates": presence_gates(read(ADAPTER), optional_groups),
+        "sources": [
+            str(VIEW_MODEL), str(LAYOUT_CONTRACT), str(ADAPTER), radio_declares(args.radio)[1],
+        ],
     }
 
     if args.json:
@@ -299,6 +452,24 @@ def main() -> None:
         print("_No type carries a named-reason union._")
     print()
 
+    print(f"## Whether each group exists on this radio ({len(data['presenceGates'])} groups)\n")
+    print(
+        "The first question for any block (above), answered per group — or "
+        f"said why it cannot be, for every group; never silently for only "
+        f"some. Derived by reading each group's `derive<Group>` function in "
+        f"`{ADAPTER}`:\n"
+    )
+    gate_label = {
+        "static": "static guard",
+        "scattered": "not a single guard",
+        "not-derivable": "not derivable from source",
+        "not-found": "function not found",
+    }
+    for gate in data["presenceGates"]:
+        label = gate_label[gate["classification"]]
+        print(f"- `{gate['group']}` (`{gate['function']}`) — **{label}**: {gate['detail']}")
+    print()
+
     print("## Field shapes\n")
     for name, shape in sorted(data["fieldShapes"].items()):
         print(f"- `{name}` = {shape}")
@@ -317,11 +488,24 @@ def main() -> None:
     print("and whether a design language can restyle it. **language** = reads")
     print("`--dl-*`; **theme** = reads `--v2-*` only, so a change lands in every")
     print("skin; **code** = reads neither, the form is in the source. A surface")
-    print("with no component draws its own markup.\n")
+    print("with no shared component draws its own markup — the question that")
+    print("decides cost is whether design-language attributes reach ANY of it,")
+    print("not whether a component exists. The per-selector answer either way")
+    print("is `components-v2/wiring/__tests__/design-language-selector-")
+    print("reachability.component.test.ts`.\n")
     for name, info in sorted(data["surfaceComponents"].items()):
         comps = info["components"]
         if not comps:
-            print(f"- `{name}` — no shared component; draws its own markup")
+            slots = info["rendersSlots"]
+            if slots:
+                named = ", ".join(f"`{s}`" for s in slots)
+                print(f"- `{name}` — no shared component, but calls `renderSlot()` "
+                      f"itself for {named}; design-language attributes DO reach "
+                      "this surface's own markup")
+            else:
+                print(f"- `{name}` — no shared component and no `renderSlot()` "
+                      "call found; no design-language attribute reaches this "
+                      "surface's markup from here (see the reachability test above)")
             continue
         parts = ", ".join(f"`{c['name']}` (**{c['tier']}**, "
                           f"--dl- {c['dl']} / --v2- {c['v2']})" for c in comps)

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -249,23 +249,77 @@ _GATE_LIVE_MULTI = re.compile(r"\A\s*if \((!\w+(?: \|\| !\w+)+)\) return undefin
 _GATE_LIVE_SINGLE = re.compile(r"\A\s*if \((![a-zA-Z]+)\) return undefined;")
 
 
+def _match_if_return_undefined(text: str, i: int) -> str | None:
+    """If `text[i:]` is `if (<balanced condition>) return undefined;` — `i`
+    the index of the leading `if`, any whitespace including a newline
+    between the condition and the keyword — the matched text, else None.
+
+    The condition is matched by counting parens, not by stopping at the
+    first `)`: an arrow function's parameter list or a nested call puts a
+    `)` inside the condition itself, and a text scan that treats the first
+    one as the close reads the whole guard as absent."""
+    depth = 1
+    j = i + 4  # past "if ("
+    n = len(text)
+    while j < n and depth > 0:
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+        j += 1
+    if depth != 0:
+        return None
+    k = j
+    while k < n and text[k] in " \t\r\n":
+        k += 1
+    if text.startswith("return undefined;", k):
+        return text[i : k + len("return undefined;")]
+    return None
+
+
 def _later_return_undefined(stripped: str, after: int) -> str | None:
-    """The first `if (...) return undefined;` appearing strictly after
-    index `after`, or None.
+    """The first `if (...) return undefined;` at brace depth 0, outside a
+    comment, appearing strictly after index `after` — or None.
 
     A top guard matching one of the STATIC patterns answers Phase 1's "first
-    question for any block" only if it is the ONLY guard. `deriveTxAux` is
-    the counter-example that motivated this: a recognised `!hasCap(caps,
+    question for any block" only if it is the ONLY such guard. `deriveTxAux`
+    is the counter-example that motivated this: a recognised `!hasCap(caps,
     'tx')` guard at the top, and a second `if (!hasEvidence) return
     undefined;` later, where `hasEvidence` is itself computed from live
     `state?.*` values — exactly the "half static, half live" shape
-    `_classify_gate`'s own docstring assigns to `not-derivable`, missed
-    because nothing looked past the first match. Called only from the
-    static-pattern branches below: `scattered` and `not-derivable` already
-    read past the top guard by construction, so a later guard there is not
-    news."""
-    m = re.search(r"if \([^)]*\) return undefined;", stripped[after:])
-    return m.group(0) if m else None
+    `_classify_gate`'s own docstring assigns to `not-derivable`.
+
+    Brace depth excludes a guard that belongs to a NESTED block — a local
+    helper function's own body, a `.map()`/`.filter()` callback — which is
+    not a second early return from the function this scan is reading,
+    however it reads as text. A `//` or `/* */` comment is skipped outright
+    for the same reason: text documenting a guard that used to exist is not
+    a guard that still runs. Called only from the static-pattern branches
+    below: `scattered` and `not-derivable` already read past the top guard
+    by construction, so a later guard there is not news."""
+    depth = 0
+    i = after
+    n = len(stripped)
+    while i < n:
+        ch = stripped[i]
+        if ch == "/" and stripped[i + 1 : i + 2] == "/":
+            nl = stripped.find("\n", i)
+            i = n if nl == -1 else nl + 1
+            continue
+        if ch == "/" and stripped[i + 1 : i + 2] == "*":
+            end = stripped.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth = max(0, depth - 1)
+        elif depth == 0 and stripped.startswith("if (", i):
+            matched = _match_if_return_undefined(stripped, i)
+            if matched is not None:
+                return matched
+        i += 1
+    return None
 
 
 def _classify_gate(body: str) -> tuple[str, str]:
@@ -273,7 +327,12 @@ def _classify_gate(body: str) -> tuple[str, str]:
 
     Three classifications, matching Phase 1's own "first question for any
     block": `static` — a single, legible condition read purely from `caps`,
-    at the top of the function, AND the only early-return guard in the body.
+    at the top of the function, AND no other `if (...) return undefined;` —
+    that exact, unbraced shape, the only one `_later_return_undefined`
+    looks for — at the function's own top-level control flow (brace depth
+    0, outside a comment). A guard nested inside a local helper's own body
+    or a callback does not count: it is not a second early return from THIS
+    function no matter how it reads as text.
     `scattered` — the only top-of-function guard is a generic `!caps`, and
     the real decision (an array length, an OR of several capability flags
     computed further down) is further into the body; read the function.

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -249,32 +249,78 @@ _GATE_LIVE_MULTI = re.compile(r"\A\s*if \((!\w+(?: \|\| !\w+)+)\) return undefin
 _GATE_LIVE_SINGLE = re.compile(r"\A\s*if \((![a-zA-Z]+)\) return undefined;")
 
 
+def _later_return_undefined(stripped: str, after: int) -> str | None:
+    """The first `if (...) return undefined;` appearing strictly after
+    index `after`, or None.
+
+    A top guard matching one of the STATIC patterns answers Phase 1's "first
+    question for any block" only if it is the ONLY guard. `deriveTxAux` is
+    the counter-example that motivated this: a recognised `!hasCap(caps,
+    'tx')` guard at the top, and a second `if (!hasEvidence) return
+    undefined;` later, where `hasEvidence` is itself computed from live
+    `state?.*` values — exactly the "half static, half live" shape
+    `_classify_gate`'s own docstring assigns to `not-derivable`, missed
+    because nothing looked past the first match. Called only from the
+    static-pattern branches below: `scattered` and `not-derivable` already
+    read past the top guard by construction, so a later guard there is not
+    news."""
+    m = re.search(r"if \([^)]*\) return undefined;", stripped[after:])
+    return m.group(0) if m else None
+
+
 def _classify_gate(body: str) -> tuple[str, str]:
     """(classification, detail) for one group's `derive*` body.
 
     Three classifications, matching Phase 1's own "first question for any
     block": `static` — a single, legible condition read purely from `caps`,
-    at the top of the function. `scattered` — the only top-of-function
-    guard is a generic `!caps`, and the real decision (an array length, an
-    OR of several capability flags computed further down) is further into
-    the body; read the function. `not-derivable` — the guard reads a LIVE
-    object (runtime state, a TX/audio/scope snapshot) or an accumulated
-    "was this ever reported" check, neither of which static source can
-    answer; this also covers a guard that is HALF a static capability test
-    and half a live check (its detail says which half is which)."""
+    at the top of the function, AND the only early-return guard in the body.
+    `scattered` — the only top-of-function guard is a generic `!caps`, and
+    the real decision (an array length, an OR of several capability flags
+    computed further down) is further into the body; read the function.
+    `not-derivable` — the guard reads a LIVE object (runtime state, a
+    TX/audio/scope snapshot) or an accumulated "was this ever reported"
+    check, neither of which static source can answer; this also covers a
+    guard that is HALF a static capability test and half a live check (its
+    detail says which half is which) — including a static top guard
+    followed by an unrelated later guard, since a function that returns
+    early twice is not "a single, legible condition" no matter how clean
+    the first return looks alone."""
     stripped = body.lstrip("\n")
 
     m = _GATE_HASCAP.match(stripped)
     if m:
+        later = _later_return_undefined(stripped, m.end())
+        if later:
+            return "not-derivable", (
+                f"!hasCap(caps, '{m.group(1)}') at the top looks static, "
+                f"but the body has a later guard too — `{later}` — so the "
+                "top guard alone is not the real gate; read the function"
+            )
         return "static", f"!hasCap(caps, '{m.group(1)}')"
 
     m = _GATE_OR_HASCAP.match(stripped)
     if m:
-        return "static", f"!hasCap(caps, '{m.group(2)}') && !hasCap(caps, '{m.group(4)}')"
+        detail = f"!hasCap(caps, '{m.group(2)}') && !hasCap(caps, '{m.group(4)}')"
+        later = _later_return_undefined(stripped, m.end())
+        if later:
+            return "not-derivable", (
+                f"{detail} at the top looks static, but the body has a "
+                f"later guard too — `{later}` — so the top guard alone is "
+                "not the real gate; read the function"
+            )
+        return "static", detail
 
     m = _GATE_NUMERIC.match(stripped)
     if m:
         ident, field, _default, limit = m.groups()
+        later = _later_return_undefined(stripped, m.end())
+        if later:
+            return "not-derivable", (
+                f"{ident} <= {limit} (where {ident} = caps?.{field}) at the "
+                f"top looks static, but the body has a later guard too — "
+                f"`{later}` — so the top guard alone is not the real gate; "
+                "read the function"
+            )
         return "static", f"{ident} <= {limit}, where {ident} = caps?.{field}"
 
     m = _GATE_HALF.match(stripped)

--- a/.claude/skills/design-a-face/measure-reference.py
+++ b/.claude/skills/design-a-face/measure-reference.py
@@ -172,7 +172,10 @@ def runs(p: np.ndarray, min_run: int) -> list[tuple[int, int]]:
 
 
 def report(a: np.ndarray, axis: str, min_run: int, label: str,
-           smooth: int = 0) -> None:
+           smooth: int = 0) -> list[tuple[int, int]]:
+    """As well as printing, returns the runs found — so a caller (selftest,
+    routing a check through `main()`) can assert on the real result instead
+    of re-deriving it or scraping printed text."""
     p = profile(a, axis, smooth)
     total = len(p)
     found = runs(p, min_run)
@@ -182,7 +185,7 @@ def report(a: np.ndarray, axis: str, min_run: int, label: str,
     if not found:
         print("no runs found — the image has no usable contrast on this axis,")
         print("or --min-run is larger than every band. Not a clean result.")
-        return
+        return found
     print(f"{len(found)} run(s), as share of the {axis[:-1]} extent:\n")
     print(f"  {'#':>3}  {'start':>7}  {'end':>7}  {'extent':>7}   px")
     for i, (s, e) in enumerate(found, 1):
@@ -197,6 +200,7 @@ def report(a: np.ndarray, axis: str, min_run: int, label: str,
     print("\nReport these as shares, not pixels, and state the image and its")
     print("dimensions. A share survives the stage's uniform scaling; a pixel")
     print("figure is true at one size only.")
+    return found
 
 
 def selftest() -> None:
@@ -244,17 +248,32 @@ def selftest() -> None:
             tag = " (low contrast)" if w == faint else ""
             print(f"  planted {w}{tag}   recovered {h}   {'ok' if m else 'MISMATCH'}")
 
-        # --smooth must still find the same three bands, only wider (a
-        # moving-average window blurs a boundary, it does not move its
-        # centre). A mutation that zeroes the smoothing branch collapses
-        # every run to none here; the smooth=0 checks above never exercise
-        # `smooth > 1` at all, so they cannot catch that.
-        smoothed = runs(profile(load(path, None, "ink"), "rows", smooth=5), 4)
-        smooth_ok = len(smoothed) == len(want) and all(
-            gs <= ws and ge >= we for (gs, ge), (ws, we) in zip(smoothed, want)
+        # --smooth must still find the same three bands, STRICTLY wider (a
+        # moving-average window blurs a boundary outward, it does not move
+        # its centre): `gs <= ws` is also satisfied by no widening at all,
+        # so a mutation that no-ops the smoothing branch would pass a
+        # non-strict containment check silently — the smooth=0 checks above
+        # never exercise `smooth > 1`, so they cannot catch that either.
+        # Routed through `main()`, not `profile()` directly: calling
+        # `profile()` here exercises the function but never the `--smooth`
+        # flag that is supposed to reach it, so a CLI wiring bug (the flag
+        # parsed but dropped before it reaches `report()`) would pass too.
+        smoothed = main(["bands", path, "--smooth", "5"])
+        smooth_ok = smoothed is not None and len(smoothed) == len(want) and all(
+            gs < ws and ge > we for (gs, ge), (ws, we) in zip(smoothed, want)
         )
-        print(f"  smooth=5 recovers {smoothed}, containing planted {want}"
-              f"   {'ok' if smooth_ok else 'MISMATCH'}")
+        print(f"  smooth=5 recovers {smoothed}, strictly containing planted "
+              f"{want}   {'ok' if smooth_ok else 'MISMATCH'}")
+
+        # A hardcoded window (e.g. always size 3, ignoring the requested
+        # value) still widens the bands relative to no smoothing, so the
+        # check above alone would not catch it — it would just under-widen
+        # and still pass. A larger requested window has to widen the same
+        # bands MORE, or the size the flag carries is not the size applied.
+        smoothed_more = main(["bands", path, "--smooth", "9"])
+        window_scales_ok = smoothed_more is not None and smoothed_more != smoothed
+        print(f"  smooth=9 recovers {smoothed_more}, different from smooth=5's "
+              f"{smoothed}   {'ok' if window_scales_ok else 'MISMATCH'}")
 
         cruns = runs(profile(load(path, None, "colour"), "rows"), 4)
         c_ok = cruns == [(210, 240)]
@@ -296,7 +315,12 @@ def selftest() -> None:
         # unchanged but its per-row spread is not. A mutation that makes the
         # VARIANCE dispatch unconditionally compute the mean (ignoring
         # VARIANCE[0]) makes `variation` collapse to the same "no runs" as
-        # `level` here, which this catches.
+        # `level` here, which this catches. Both routed through `main()`,
+        # not `profile()` directly with `VARIANCE[0]` set by hand: this
+        # module's own `--signal` flag is what a caller actually uses, and
+        # a mutation that inverts its dispatch in `main()` (e.g. `variation`
+        # mapping to level's behaviour) reaches neither `level_ok` nor
+        # `variation_ok` unless the flag itself is exercised.
         vH, vW = 200, 160
         v_ink = np.zeros((vH, vW), dtype=np.float64)
         for y in range(vH):
@@ -310,12 +334,9 @@ def selftest() -> None:
         v_path = str(Path(tmp) / "variation.png")
         Image.fromarray(np.stack([v_gray] * 3, axis=-1)).save(v_path)
 
-        v_loaded = load(v_path, None, "ink")
-        VARIANCE[0] = False
-        level_runs = runs(profile(v_loaded, "rows"), 4)
+        level_runs = main(["bands", v_path])
         level_ok = level_runs == []
-        VARIANCE[0] = True
-        variation_runs = runs(profile(v_loaded, "rows"), 4)
+        variation_runs = main(["bands", v_path, "--signal", "variation"])
         variation_ok = variation_runs == [v_band]
         VARIANCE[0] = False
         print(f"  --signal level on a scanline ground finds {level_runs} — "
@@ -324,14 +345,21 @@ def selftest() -> None:
               f"expected [{v_band}]   {'ok' if variation_ok else 'MISMATCH'}")
 
         if (not ok or not c_ok or not crop_ok or control or not silent_ok
-                or not fires_ok or not smooth_ok or not level_ok or not variation_ok):
+                or not fires_ok or not smooth_ok or not window_scales_ok
+                or not level_ok or not variation_ok):
             die("selftest failed — do not trust measurements from this build")
     print("\nselftest passed. The low-contrast band is the load-bearing case:")
     print("it is what makes a broken threshold visible, and an all-ideal")
     print("self-test would have reported the same green either way.")
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> list[tuple[int, int]] | None:
+    """`argv` defaults to `sys.argv[1:]` (real CLI use). selftest passes an
+    explicit list instead, so `--smooth` and `--signal` are exercised through
+    the same argument parsing and dispatch a real invocation goes through —
+    not just the functions they eventually call — and a wiring bug between
+    the flag and `report()`/`VARIANCE[0]` fails the self-test rather than
+    passing silently."""
     ap = argparse.ArgumentParser()
     ap.add_argument("mode", choices=["bands", "columns", "selftest"])
     ap.add_argument("image", nargs="?")
@@ -349,11 +377,11 @@ def main() -> None:
                          "level cannot separate a band from a gutter, while "
                          "spread can — a band varies across its width, an "
                          "empty row does not.")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     if args.mode == "selftest":
         selftest()
-        return
+        return None
     if not args.image:
         die("an image path is required for bands/columns")
 
@@ -361,9 +389,9 @@ def main() -> None:
     a = load(args.image, args.crop, args.by)
     what = "ink" if args.by == "ink" else "colour"
     if args.mode == "bands":
-        report(a, "rows", args.min_run, f"horizontal {what} bands of {args.image}", args.smooth)
+        return report(a, "rows", args.min_run, f"horizontal {what} bands of {args.image}", args.smooth)
     else:
-        report(a, "columns", args.min_run, f"vertical {what} divisions of {args.image}", args.smooth)
+        return report(a, "columns", args.min_run, f"vertical {what} divisions of {args.image}", args.smooth)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/design-a-face/measure-reference.py
+++ b/.claude/skills/design-a-face/measure-reference.py
@@ -40,10 +40,40 @@ except ImportError as exc:  # pragma: no cover - environment, not logic
 
 VARIANCE = [False]
 
+# `--by colour` profiles distance from grey (chroma). Most of any panel is
+# its own ground, so the MEDIAN chroma over a measured box is, in practice,
+# the ground's own chroma. If the ground itself is tinted (this reference's
+# amber LCD ground, not merely an accent on a neutral ground), that median is
+# already high, and "distance from grey" cannot separate "ground" from
+# "signal" — the run(s) it reports profile the tint, not a meaning.
+#
+# Chosen by measuring both sides on real fixtures, not by guessing a round
+# number first: median chroma on `/var/tmp/ftx1-reference.png` (a genuinely
+# single-hue amber panel, `ink` vs `colour` corrcoef -0.63) is 0.463; on two
+# fixtures where a real accent sits on a near-neutral ground — this file's
+# own `selftest` fixture (white ground, one red patch) and a constructed
+# dark-grey-ground-plus-red-accent image — it is 0.0 and 0.02 respectively.
+# 0.15 sits roughly a third of the way from the reference's value toward
+# zero, and 7-20x above either genuine-accent fixture: a real accent against
+# a neutral ground will not trip it, and any ground that is even moderately
+# tinted will.
+DEGENERATE_CHROMA = 0.15
+
 
 def die(msg: str) -> NoReturn:
     print(f"measure-reference: {msg}", file=sys.stderr)
     raise SystemExit(1)
+
+
+def colour_degeneracy(colour: np.ndarray) -> float | None:
+    """The median chroma of a `--by colour` field, if it exceeds
+    DEGENERATE_CHROMA, else None.
+
+    A separate, callable check (rather than inlined where it is used) so
+    `selftest` can assert on it directly instead of scraping printed text.
+    """
+    median = float(np.median(colour))
+    return median if median > DEGENERATE_CHROMA else None
 
 
 def load(path: str, crop: str | None, by: str = "ink") -> np.ndarray:
@@ -55,6 +85,8 @@ def load(path: str, crop: str | None, by: str = "ink") -> np.ndarray:
     colour is reserved for one meaning — a transmit group, an alarm — this
     locates that meaning without being told where to look, and separates a
     dimmed indicator (same hue, less ink) from a differently-coloured one.
+    Warns (see DEGENERATE_CHROMA) when the measured box's ground itself is
+    tinted enough that this separation cannot hold.
     """
     try:
         img = Image.open(path).convert("RGB")
@@ -72,7 +104,17 @@ def load(path: str, crop: str | None, by: str = "ink") -> np.ndarray:
     if rgb.size == 0:
         die("empty image after crop")
     if by == "colour":
-        return rgb.max(axis=2) - rgb.min(axis=2)
+        colour = rgb.max(axis=2) - rgb.min(axis=2)
+        degenerate = colour_degeneracy(colour)
+        if degenerate is not None:
+            print(
+                f"measure-reference: WARNING — median chroma {degenerate:.2f} "
+                f"exceeds {DEGENERATE_CHROMA}. The GROUND itself reads as "
+                "coloured here, not only an accent: --by colour cannot tell "
+                "'ground' from 'signal' on this image, and any run reported "
+                "below profiles the ground, not a colour-coded meaning."
+            )
+        return colour
     return 1.0 - rgb.mean(axis=2)
 
 
@@ -218,7 +260,23 @@ def selftest() -> None:
         print(f"  flat image yields {len(control)} run(s) — expected 0"
               f"   {'ok' if not control else 'MISMATCH'}")
 
-        if not ok or not c_ok or not crop_ok or control:
+        # DEGENERATE_CHROMA must discriminate both ways: silent on a genuine
+        # accent (this fixture — white ground, one red patch), firing on a
+        # ground that is itself tinted with no accent at all.
+        silent_flag = colour_degeneracy(load(path, None, "colour"))
+        silent_ok = silent_flag is None
+        print(f"  degenerate-colour check, genuine accent: flagged={silent_flag}"
+              f" — expected None   {'ok' if silent_ok else 'MISMATCH'}")
+
+        tinted = np.full((40, 40, 3), (196, 156, 64), dtype=np.uint8)
+        tinted_path = str(Path(tmp) / "tinted.png")
+        Image.fromarray(tinted).save(tinted_path)
+        fires_flag = colour_degeneracy(load(tinted_path, None, "colour"))
+        fires_ok = fires_flag is not None
+        print(f"  degenerate-colour check, tinted ground: flagged={fires_flag}"
+              f" — expected a value   {'ok' if fires_ok else 'MISMATCH'}")
+
+        if not ok or not c_ok or not crop_ok or control or not silent_ok or not fires_ok:
             die("selftest failed — do not trust measurements from this build")
     print("\nselftest passed. The low-contrast band is the load-bearing case:")
     print("it is what makes a broken threshold visible, and an all-ideal")

--- a/.claude/skills/design-a-face/measure-reference.py
+++ b/.claude/skills/design-a-face/measure-reference.py
@@ -244,6 +244,18 @@ def selftest() -> None:
             tag = " (low contrast)" if w == faint else ""
             print(f"  planted {w}{tag}   recovered {h}   {'ok' if m else 'MISMATCH'}")
 
+        # --smooth must still find the same three bands, only wider (a
+        # moving-average window blurs a boundary, it does not move its
+        # centre). A mutation that zeroes the smoothing branch collapses
+        # every run to none here; the smooth=0 checks above never exercise
+        # `smooth > 1` at all, so they cannot catch that.
+        smoothed = runs(profile(load(path, None, "ink"), "rows", smooth=5), 4)
+        smooth_ok = len(smoothed) == len(want) and all(
+            gs <= ws and ge >= we for (gs, ge), (ws, we) in zip(smoothed, want)
+        )
+        print(f"  smooth=5 recovers {smoothed}, containing planted {want}"
+              f"   {'ok' if smooth_ok else 'MISMATCH'}")
+
         cruns = runs(profile(load(path, None, "colour"), "rows"), 4)
         c_ok = cruns == [(210, 240)]
         print(f"  colour profile finds {cruns} — expected [(210, 240)]"
@@ -276,7 +288,43 @@ def selftest() -> None:
         print(f"  degenerate-colour check, tinted ground: flagged={fires_flag}"
               f" — expected a value   {'ok' if fires_ok else 'MISMATCH'}")
 
-        if not ok or not c_ok or not crop_ok or control or not silent_ok or not fires_ok:
+        # --signal variation: a scanline ground that inks every row about
+        # equally (alternating level, period 2) so LEVEL can never separate
+        # a band from a gutter — every "high" stripe is only 1 row deep,
+        # below --min-run, so LEVEL finds nothing at all. Rows 80-120 carry
+        # a real band: a mean-preserving checkerboard, so its LEVEL is
+        # unchanged but its per-row spread is not. A mutation that makes the
+        # VARIANCE dispatch unconditionally compute the mean (ignoring
+        # VARIANCE[0]) makes `variation` collapse to the same "no runs" as
+        # `level` here, which this catches.
+        vH, vW = 200, 160
+        v_ink = np.zeros((vH, vW), dtype=np.float64)
+        for y in range(vH):
+            v_ink[y, :] = 0.55 if (y // 2) % 2 == 0 else 0.45
+        v_band = (80, 120)
+        v_cols = np.arange(vW)
+        for y in range(*v_band):
+            base = v_ink[y, 0]
+            v_ink[y, :] = np.clip(np.where((v_cols % 4) < 2, base + 0.12, base - 0.12), 0, 1)
+        v_gray = np.clip((1.0 - v_ink) * 255.0, 0, 255).astype(np.uint8)
+        v_path = str(Path(tmp) / "variation.png")
+        Image.fromarray(np.stack([v_gray] * 3, axis=-1)).save(v_path)
+
+        v_loaded = load(v_path, None, "ink")
+        VARIANCE[0] = False
+        level_runs = runs(profile(v_loaded, "rows"), 4)
+        level_ok = level_runs == []
+        VARIANCE[0] = True
+        variation_runs = runs(profile(v_loaded, "rows"), 4)
+        variation_ok = variation_runs == [v_band]
+        VARIANCE[0] = False
+        print(f"  --signal level on a scanline ground finds {level_runs} — "
+              f"expected []   {'ok' if level_ok else 'MISMATCH'}")
+        print(f"  --signal variation on the same ground finds {variation_runs} — "
+              f"expected [{v_band}]   {'ok' if variation_ok else 'MISMATCH'}")
+
+        if (not ok or not c_ok or not crop_ok or control or not silent_ok
+                or not fires_ok or not smooth_ok or not level_ok or not variation_ok):
             die("selftest failed — do not trust measurements from this build")
     print("\nselftest passed. The low-contrast band is the load-bearing case:")
     print("it is what makes a broken threshold visible, and an all-ideal")

--- a/.claude/skills/design-a-face/measure-reference.py
+++ b/.claude/skills/design-a-face/measure-reference.py
@@ -50,13 +50,17 @@ VARIANCE = [False]
 # Chosen by measuring both sides on real fixtures, not by guessing a round
 # number first: median chroma on `/var/tmp/ftx1-reference.png` (a genuinely
 # single-hue amber panel, `ink` vs `colour` corrcoef -0.63) is 0.463; on two
-# fixtures where a real accent sits on a near-neutral ground — this file's
-# own `selftest` fixture (white ground, one red patch) and a constructed
-# dark-grey-ground-plus-red-accent image — it is 0.0 and 0.02 respectively.
-# 0.15 sits roughly a third of the way from the reference's value toward
-# zero, and 7-20x above either genuine-accent fixture: a real accent against
-# a neutral ground will not trip it, and any ground that is even moderately
-# tinted will.
+# WHOLE-IMAGE fixtures where a real accent sits on a near-neutral ground —
+# this file's own `selftest` fixture (white ground, one red patch) and a
+# constructed dark-grey-ground-plus-red-accent image — it is 0.0 and 0.02
+# respectively. 0.15 sits roughly a third of the way from the reference's
+# value toward zero, well above both of those two whole-image medians.
+#
+# This is a statistic over whatever box is measured, not a judgement about
+# "the ground": crop tightly enough around an accent and the accent IS most
+# of the box, and the same threshold fires on it. `selftest` only exercises
+# the whole-image case above; it does not claim the threshold behaves any
+# particular way on a crop.
 DEGENERATE_CHROMA = 0.15
 
 
@@ -85,8 +89,10 @@ def load(path: str, crop: str | None, by: str = "ink") -> np.ndarray:
     colour is reserved for one meaning — a transmit group, an alarm — this
     locates that meaning without being told where to look, and separates a
     dimmed indicator (same hue, less ink) from a differently-coloured one.
-    Warns (see DEGENERATE_CHROMA) when the measured box's ground itself is
-    tinted enough that this separation cannot hold.
+    Warns (see DEGENERATE_CHROMA) when the measured box's own median chroma
+    is high enough that this separation cannot hold — whether that is
+    because the ground itself is tinted, or because the box is cropped
+    tight enough that the accent IS most of the box.
     """
     try:
         img = Image.open(path).convert("RGB")
@@ -108,11 +114,16 @@ def load(path: str, crop: str | None, by: str = "ink") -> np.ndarray:
         degenerate = colour_degeneracy(colour)
         if degenerate is not None:
             print(
-                f"measure-reference: WARNING — median chroma {degenerate:.2f} "
-                f"exceeds {DEGENERATE_CHROMA}. The GROUND itself reads as "
-                "coloured here, not only an accent: --by colour cannot tell "
-                "'ground' from 'signal' on this image, and any run reported "
-                "below profiles the ground, not a colour-coded meaning."
+                f"measure-reference: WARNING — median chroma over the "
+                f"measured box is {degenerate:.2f}, above "
+                f"{DEGENERATE_CHROMA}: most of the box already reads as "
+                "coloured, not only a small accent within it. --by colour "
+                "separates an accent from what surrounds it by contrast "
+                "between the two; a box that is already mostly coloured has "
+                "none left to separate on. Check whether that is because "
+                "the ground itself is tinted or because this crop is "
+                "mostly the accent, before reporting the run below as a "
+                "colour-coded meaning."
             )
         return colour
     return 1.0 - rgb.mean(axis=2)


### PR DESCRIPTION
## Summary

Closes nine findings from #3008 (an independent trial run of `design-a-face`), one commit per finding so each can be read and reverted independently. Two further review rounds (BLOCKED at `d5da1d20`, then `8ea16248`) found seven, then two, remaining defects in the same three files; each round's fix commits are on top of the original nine.

**Method (SKILL.md)**
1. Add Phase 0: check whether a design language for the reference already exists (`frontend/src/presentation/languages/`) before deriving anything.
2. Add the fourth buildability check — whether the language can be selected at all (`WORKSPACE_DESIGN_LANGUAGE_IDS`).
7. State that "fourteen optional groups" and "fourteen surfaces" are different sets with a real (non-1:1) correspondence, verified from source.
9. Give the "Ask" section a fallback for when no answer arrives, and make all five triggers name the owner consistently (only one did before).

**Reference measurer (measure-reference.py + SKILL.md)**
3. Document `--smooth` and `--signal variation`, both present in the script and absent from the doc.
4. Replace the "Known limit" — it described the wrong failure and prescribed a cure that manufactures spurious runs on a real textured reference.
5. Add a mechanism (`colour_degeneracy()` / `DEGENERATE_CHROMA`, wired into `load()`) that warns when `--by colour`'s measured box already reads as mostly coloured — whether because the ground itself is tinted, or because a crop is tight enough that a genuine accent is most of the box.
6. Extend `selftest` to cover `--smooth` and `--signal variation`, both routed through `main()`; add strict-containment and window-scaling assertions so a no-op smoothing branch, an unwired `--smooth`, and a hardcoded window size each independently fail.

**Extractor (extract-contract.py)**
8. Report, per optional group, whether a presence gate is a single static guard, scattered through the function body, or not derivable from static source at all — derived from source, every group gets a row. Reframe the surface-to-component table to report `renderSlot()` reachability for every row, not only rows with no shared component.
6/7 (second round). `_later_return_undefined` now matches a guard whose condition itself contains balanced parentheses and a guard split across two lines (both previously missed — the dangerous, under-fire direction), and stops matching text inside a nested block or a comment (previously over-fired on both — a local helper's own guard, a `.map()` callback, a comment quoting the shape). Scan bounded to brace depth 0, outside comments; both prose absolutes the scan couldn't support are narrowed to what it actually establishes.

## REGCHECK

Baseline recorded at `1184d163`; the skill's three files are unchanged in shape between that commit and this branch's base (`ed760ed4`) other than the content these commits touch, so the baseline still applies at HEAD.

| Check | Baseline | HEAD (`fd5bff9c`) |
|---|---|---|
| `measure-reference.py selftest` exit | 0 | 0 |
| surfaces | 14 | 14 |
| view models | 17 | 17 |
| `RadioViewModel` fields | 24 | 24 |
| `ftx1` features | 27 | 27 |
| surface-component entries | 14 | 14 |
| `ruff check .claude/skills/design-a-face/` (local check — no workflow lints `.claude/`) | clean | clean |

`extract-contract.py`'s 14-group presence-gate classification is also unchanged, row for row, before and after the `_later_return_undefined` fix — none of the 14 real `derive*` functions currently has a shape the fix changes behaviour for; the fix is proven against five synthetic probes instead (see commit `176727ce`).

## Size

3 files changed, 633 changed lines (158 SKILL.md, 312 extract-contract.py, 163 measure-reference.py) against merge-base `ed760ed4` — **crosses the 600-line soft threshold** (files stay at 3, under the 6-file half of that guardrail).

This is one PR because all three rounds are fixes to the same nine originally-reported findings in the same three files, each round responding to the previous round's independent review of that same diff; splitting the third round into a new PR would separate its fixes from the REGCHECK baseline and the findings they close.

## Test plan

- [x] `measure-reference.py selftest` exits 0 (pristine control)
- [x] Six mutations (no-op smoothing, `--smooth` unwired at the CLI, `--signal` inverted at the CLI, window hardcoded regardless of requested size, a blur that shifts instead of widening, the `VARIANCE` dispatch made unconditional) each independently fail `selftest` (exit 1); tree restored byte-identical after each, verified by diff, not by the restoring command's exit status
- [x] `extract-contract.py --json` reports the same five REGCHECK counts as the recorded baseline; the 14-group classification is unchanged row for row
- [x] `extract-contract.py`'s later-guard scan: five probes (two under-fire, three over-fire) all fail against the pre-fix code and pass against the fix
- [x] `ruff check .claude/skills/design-a-face/` and `ruff check src/ tests/` both clean
- [x] Doc-citation-gate, doc-link-gate, and the Wave-2 rebrand grep-gate all clean locally
- [ ] Independent review (not self-performed, per repo policy)

Closes #3008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

