### PR TITLE
fix(ic7300): remove false antenna capability

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -46,8 +46,7 @@ features = [
     "preamp",
     "ip_plus",
     # NOTE: no digisel on IC-7300
-    # Antenna
-    "antenna",
+    # Antenna topology is declared below; IC-7300 has no antenna-selection control.
     # NOTE: no rx_antenna on IC-7300 (single antenna)
     # DSP / Noise
     "nb",

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -58,7 +58,6 @@ EXPECTED_BASELINE_CAPABILITIES = {
     "attenuator",
     "preamp",
     "ip_plus",
-    "antenna",
     "nb",
     "nr",
     "notch",

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1366,6 +1366,17 @@ class TestToProfile:
         profile = load_rig(ftx1_path).to_profile()
         assert profile.transceiver_count == 2
 
+    def test_ic7300_antenna_topology_without_control_capability(self):
+        """MOR-2118: topology metadata must not imply antenna selection."""
+        rig = load_rig(RIGS_DIR / "ic7300.toml")
+        profile = rig.to_profile()
+
+        assert "antenna" not in profile.capabilities
+        assert profile.antenna_tx_count == 1
+        assert rig.antenna_has_rx_ant is False
+        assert profile.supports_command("get_antenna") is False
+        assert profile.supports_command("set_antenna") is False
+
     def test_capabilities_frozenset(self):
         profile = load_rig(TEMPLATE_PATH).to_profile()
         assert isinstance(profile.capabilities, frozenset)

--- a/tests/test_rig_multi_vendor.py
+++ b/tests/test_rig_multi_vendor.py
@@ -374,7 +374,7 @@ class TestMultiVendorProfiles:
         assert "speech" in profile.capabilities
         assert "nb" in profile.capabilities
         assert "apf" not in profile.capabilities
-        assert len(profile.capabilities) == 41
+        assert len(profile.capabilities) == 40
         assert rig.commands["set_speech"].bytes == (0x13,)
 
     def test_ftx1_without_announcement_routes_does_not_advertise_speech(self):


### PR DESCRIPTION
## Summary
- remove the false IC-7300 `antenna` control capability tag
- preserve single-TX/no-RX topology and explicit absent antenna commands
- add regression coverage for capability, topology, and fail-closed command support

## Verification
- `PYTHONPATH=src python -m pytest tests/test_rig_loader.py -k ic7300_antenna_topology_without_control_capability -q`
- `git diff --check`

Fixes MOR-2118