### PR TITLE
refactor(MOR-2208): share callable support evaluation

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -42,8 +42,6 @@ _SUPPORTED_COMMANDS = {
     "set_mode",
     "get_ptt",
     "set_ptt",
-    "get_vfo_slot",
-    "set_vfo_slot",
     "get_rf_gain",
     "set_rf_gain",
     "get_af_level",

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -25,6 +25,7 @@ from ...core.state_pipeline_contracts import (
 )
 from ...core.tx_observation import TxStateReading
 from ...radio_state import RadioState
+from ...runtime.callable_support import supports_explicit_callable
 from .transport import RigctldTransport
 
 if TYPE_CHECKING:
@@ -655,9 +656,14 @@ class RigctldClientRadio:
         return caps
 
     def supports_command(self, command: str) -> bool:
-        if command in {"get_vfo_slot", "set_vfo_slot"}:
-            return self._vfo_supported
-        return command in _SUPPORTED_COMMANDS
+        supported = set(_SUPPORTED_COMMANDS)
+        if self._vfo_supported:
+            supported.update({"get_vfo_slot", "set_vfo_slot"})
+        return supports_explicit_callable(
+            command,
+            supported,
+            lambda name: callable(getattr(self, name, None)),
+        )
 
     def create_observation_poller(
         self,

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 from ...audio import AudioPacket
 from ...audio.lan_stream import SYNTHETIC_RX_IDENT
 from ...command_spec import CatCommandSpec
+from ...runtime.callable_support import supports_callable
 from ...commands import hz_to_table_index, table_index_to_hz
 from ...core.tx_observation import TxStateReading
 from ...types import AudioCodec, BreakInMode, RepeaterShiftDirection
@@ -727,8 +728,10 @@ class YaesuCatRadio:
         )
 
     def supports_command(self, command: str) -> bool:
-        """Check if a command is defined in the rig profile."""
-        return self._has_command(command)
+        """Return profile-derived support only for an executable operation."""
+        return supports_callable(self.profile, command) and callable(
+            getattr(self, command, None)
+        )
 
     def _default_nb_level(self) -> int:
         """Default NB level for turning on when current level is 0."""

--- a/src/rigplane/runtime/callable_support.py
+++ b/src/rigplane/runtime/callable_support.py
@@ -7,7 +7,7 @@ derived from those two sources rather than declared directly by a profile.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Collection, Iterable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Literal, TypeAlias
@@ -197,3 +197,12 @@ def supports_callable(profile: RadioProfile, operation: str) -> bool:
     if relation is None:
         return False
     return _relation_supported(relation, profile, set(CALLABLE_RELATIONS))
+
+
+def supports_explicit_callable(
+    operation: str,
+    supported_operations: Collection[str],
+    executable: Callable[[str], bool],
+) -> bool:
+    """Evaluate an external provider's explicit support declaration safely."""
+    return operation in supported_operations and executable(operation)

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -21,6 +21,19 @@ from rigplane.exceptions import ConnectionError as RadioConnectionError
 from rigplane.exceptions import TimeoutError as RadioTimeoutError
 
 
+def test_supports_command_gates_vfo_operations_on_observed_provider_support() -> None:
+    radio = RigctldClientRadio(host="127.0.0.1", port=4532)
+
+    assert radio.supports_command("get_freq")
+    assert not radio.supports_command("get_vfo_slot")
+    assert not radio.supports_command("set_vfo_slot")
+    assert not radio.supports_command("unknown_operation")
+
+    radio._vfo_supported = True
+    assert radio.supports_command("get_vfo_slot")
+    assert radio.supports_command("set_vfo_slot")
+
+
 async def test_transport_connect_query_and_close() -> None:
     async with FakeRigctldServer() as server:
         transport = RigctldTransport(host=server.host, port=server.port)

--- a/tests/test_supports_command.py
+++ b/tests/test_supports_command.py
@@ -390,7 +390,7 @@ def yaesu_radio(ftx1_config):
 
 
 class TestYaesuSupportsCommand:
-    """YaesuCatRadio.supports_command delegates to _has_command."""
+    """YaesuCatRadio support follows its loaded profile and call graph."""
 
     def test_defined_commands_return_true(self, yaesu_radio):
         for cmd in (
@@ -413,10 +413,8 @@ class TestYaesuSupportsCommand:
                 f"{cmd!r} should NOT be supported on FTX-1"
             )
 
-    def test_matches_has_command(self, yaesu_radio, ftx1_config):
-        """supports_command must agree with _has_command for every TOML key."""
-        for name in ftx1_config.commands:
-            assert yaesu_radio.supports_command(name) == yaesu_radio._has_command(name)
+    def test_set_repeater_shift_is_profile_derived_and_executable(self, yaesu_radio):
+        assert yaesu_radio.supports_command("set_repeater_shift")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Linear: MOR-2208
Parent: MOR-2161

Unifies profile-backed callable support through `runtime/callable_support.py`; Yaesu now evaluates its loaded profile plus executable method, while external rigctld routes its explicit provider set through the shared evaluator.

Scope: runtime callable support, Yaesu CAT, external rigctld client, focused support tests. No profiles, dispatch, pollers, UI, or dual-RX changes.

Verification: focused supports/rigctld tests (65 passed; one unrelated connection-timeout test passed on a single isolated retry), ruff, and `git diff --check`.