### PR TITLE
MOR-2207: make descriptor TX policy fail closed

### DIFF
--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -2,9 +2,10 @@
 
 Profiles remain authoritative for radio/model support and wire facts.  This
 module owns only backend-neutral operation mechanics: public name, reviewed
-Radio method, parameter binding, semantic target, timeout, and queue policy.
-Every migrated operation is admitted, queued, invoked, and audited through the
-same descriptor; drains must not add operation-specific branches.
+Radio method, parameter binding, semantic target, timeout, queue policy, and
+explicit TX-interlock disposition.  Every migrated operation is admitted,
+queued, invoked, and audited through the same descriptor; drains must not add
+operation-specific branches.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from rigplane.core.state_pipeline_contracts import (
     CommandSource,
     FieldPath,
 )
+from rigplane.core.tx_interlock_contract import TxInterlockDisposition
 
 __all__ = [
     "CommandDescriptor",
@@ -48,6 +50,10 @@ class DispatchQueue(Protocol):
         command: Any,
         *,
         future: asyncio.Future[None] | None = None,
+        command_id: str | None = None,
+        source: CommandSource | None = None,
+        session_id: str | None = None,
+        command_service: Any | None = None,
     ) -> None: ...
 
 
@@ -64,6 +70,7 @@ class CommandDescriptor:
     bind: Binder
     target: TargetBuilder
     argument_names: tuple[str, ...]
+    tx_interlock_disposition: TxInterlockDisposition
     timeout: float = 10.0
     queue_policy: Literal["ordered"] = "ordered"
 
@@ -103,9 +110,31 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             bind=_bind_repeater_shift,
             target=_repeater_shift_target,
             argument_names=("direction", "receiver"),
+            tx_interlock_disposition=TxInterlockDisposition.TX_SAFE,
         )
     }
 )
+
+
+_DESCRIPTOR_POLICIES_WITHOUT_SHARED_SEAT = frozenset(
+    {
+        TxInterlockDisposition.ALWAYS_PASS,
+        TxInterlockDisposition.TX_SAFE,
+    }
+)
+
+
+def _require_descriptor_policy_seat(descriptor: CommandDescriptor) -> None:
+    """Reject disruptive descriptors until every drain has one shared seat."""
+
+    policy = descriptor.tx_interlock_disposition
+    if not isinstance(policy, TxInterlockDisposition) or policy not in (
+        _DESCRIPTOR_POLICIES_WITHOUT_SHARED_SEAT
+    ):
+        raise CommandError(
+            f"descriptor {descriptor.name!r} policy "
+            f"{policy!r} has no shared enforcement seat"
+        )
 
 
 def command_descriptors() -> Mapping[str, CommandDescriptor]:
@@ -121,14 +150,38 @@ def enqueue_command_intent(
     intent: CommandIntent,
     *,
     future: asyncio.Future[None],
+    command_id: str,
+    source: CommandSource,
+    session_id: str | None,
+    command_service: Any,
+    timeout: float | None,
 ) -> None:
-    """Enqueue through the policy owned by the command descriptor."""
+    """Enqueue with descriptor policy and exact lifecycle identity preserved."""
 
     descriptor = command_descriptor(intent.name)
     if descriptor is None:
         raise CommandError(f"no command descriptor for {intent.name!r}")
+    _require_descriptor_policy_seat(descriptor)
+    intent_session_id = intent.params.get("session_id")
+    intent_session_id = None if intent_session_id is None else str(intent_session_id)
+    if (
+        command_id != intent.id
+        or source != intent.source
+        or session_id != intent_session_id
+        or timeout != intent.timeout
+    ):
+        raise CommandError(f"queue metadata does not match intent {intent.id!r}")
+    if command_service is None:
+        raise CommandError(f"command service is required for intent {intent.id!r}")
     if descriptor.queue_policy == "ordered":
-        queue.put_ordered(intent, future=future)
+        queue.put_ordered(
+            intent,
+            future=future,
+            command_id=command_id,
+            source=source,
+            session_id=session_id,
+            command_service=command_service,
+        )
         return
     raise CommandError(
         f"unsupported queue policy {descriptor.queue_policy!r} for {descriptor.name!r}"
@@ -149,6 +202,7 @@ def prepare_command_intent(
     descriptor = command_descriptor(name)
     if descriptor is None:
         raise KeyError(f"no command descriptor for {name!r}")
+    _require_descriptor_policy_seat(descriptor)
     normalized = descriptor.bind(params)
     if session_id is not None:
         normalized["session_id"] = session_id
@@ -176,5 +230,6 @@ async def execute_command_intent(radio: Any, intent: CommandIntent) -> None:
     descriptor = command_descriptor(intent.name)
     if descriptor is None:
         raise CommandError(f"no command descriptor for {intent.name!r}")
+    _require_descriptor_policy_seat(descriptor)
     method = getattr(radio, descriptor.method_name)
     await method(**{name: intent.params[name] for name in descriptor.argument_names})

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -1460,7 +1460,18 @@ class ControlHandler:
                 raise RuntimeError("no command queue available")
             queue = self._server.command_queue
             future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-            enqueue_command_intent(queue, intent, future=future)
+            raw_session_id = intent.params.get("session_id")
+            session_id = None if raw_session_id is None else str(raw_session_id)
+            enqueue_command_intent(
+                queue,
+                intent,
+                future=future,
+                command_id=intent.id,
+                source=intent.source,
+                session_id=session_id,
+                command_service=self._command_service,
+                timeout=intent.timeout,
+            )
             try:
                 await asyncio.wait_for(future, timeout=intent.timeout)
             except asyncio.CancelledError:

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -19,6 +19,7 @@ from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
 from rigplane.core.exceptions import CommandError, CommandRejectedError
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.core.tx_interlock_contract import TxInterlockDisposition
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import RadioPoller
@@ -246,6 +247,149 @@ async def test_all_three_drains_execute_the_same_neutral_intent() -> None:
         radio.set_repeater_shift.assert_awaited_once_with(direction=3, receiver=1)
 
 
+@pytest.mark.parametrize(
+    "policy",
+    [
+        TxInterlockDisposition.DEFER,
+        TxInterlockDisposition.BLOCK,
+        cast(Any, None),
+    ],
+)
+def test_descriptor_admission_rejects_policy_without_shared_seat(
+    monkeypatch: pytest.MonkeyPatch,
+    policy: TxInterlockDisposition,
+) -> None:
+    from rigplane.core import command_dispatch
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    descriptor = command_dispatch.command_descriptor("set_repeater_shift")
+    assert descriptor is not None
+    mutated = replace(descriptor, tx_interlock_disposition=policy)
+    monkeypatch.setattr(
+        command_dispatch, "_COMMAND_DESCRIPTORS", {mutated.name: mutated}
+    )
+
+    with pytest.raises(CommandError, match="has no shared enforcement seat"):
+        prepare_command_intent(_radio(), mutated.name, {"direction": 1}, source="http")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "policy", [TxInterlockDisposition.DEFER, TxInterlockDisposition.BLOCK]
+)
+async def test_all_three_drains_reject_unsafe_descriptor_before_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+    policy: TxInterlockDisposition,
+) -> None:
+    from rigplane.core import command_dispatch
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    intent = prepare_command_intent(
+        radio, "set_repeater_shift", {"direction": 3}, source="http"
+    )
+    descriptor = command_dispatch.command_descriptor(intent.name)
+    assert descriptor is not None
+    mutated = replace(descriptor, tx_interlock_disposition=policy)
+    monkeypatch.setattr(
+        command_dispatch, "_COMMAND_DESCRIPTORS", {mutated.name: mutated}
+    )
+
+    for drain in ("icom", "yaesu", "rigctld"):
+        with pytest.raises(CommandError, match="has no shared enforcement seat"):
+            if drain == "icom":
+                poller = SimpleNamespace(
+                    _radio=radio,
+                    _enforce_tx_interlock=lambda command: None,
+                    _provider_generation=lambda: 0,
+                )
+                await RadioPoller._execute(poller, intent)  # type: ignore[arg-type] # noqa: SLF001
+            elif drain == "yaesu":
+                poller = YaesuCatPoller.__new__(YaesuCatPoller)
+                poller._radio = radio  # type: ignore[attr-defined]
+                await poller._execute_command(intent)  # noqa: SLF001
+            else:
+                poller = RigctldClientObservationPoller.__new__(
+                    RigctldClientObservationPoller
+                )
+                poller._radio = radio  # type: ignore[attr-defined]
+                await poller._execute_command(intent)  # noqa: SLF001
+    radio.set_repeater_shift.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_descriptor_enqueue_preserves_queue_lifecycle_metadata() -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    server = WebServer(radio, WebConfig())
+    intent = prepare_command_intent(
+        radio,
+        "set_repeater_shift",
+        {"direction": 2},
+        source="websocket",
+        command_id="metadata-shift",
+        session_id="ws-metadata",
+    )
+    execution = asyncio.create_task(server.command_service.execute(intent))
+    await asyncio.sleep(0)
+
+    entries = server.command_queue.drain_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.command is intent
+    assert entry.command_id == intent.id
+    assert entry.source == intent.source
+    assert entry.session_id == "ws-metadata"
+    assert entry.command_service is server.command_service
+    assert entry.future is not None
+    assert entry.command.timeout == intent.timeout == 10.0
+
+    entry.future.set_result(None)
+    await execution
+    terminal = [
+        event.state
+        for event in server.command_service.lifecycle_events()
+        if event.command_id == intent.id
+        and event.state in {"acknowledged", "failed", "timed_out"}
+    ]
+    assert terminal == ["acknowledged"]
+
+
+@pytest.mark.asyncio
+async def test_descriptor_queue_failure_completes_lifecycle_exactly_once() -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    server = WebServer(radio, WebConfig())
+    intent = prepare_command_intent(
+        radio,
+        "set_repeater_shift",
+        {"direction": 2},
+        source="websocket",
+        command_id="failed-shift",
+        session_id="ws-failure",
+    )
+    execution = asyncio.create_task(server.command_service.execute(intent))
+    await asyncio.sleep(0)
+    (entry,) = server.command_queue.drain_entries()
+
+    error = CommandError("radio write failed")
+    YaesuCatPoller._mark_queued_command_failed(entry, error)  # noqa: SLF001
+    assert entry.future is not None
+    entry.future.set_exception(error)
+    with pytest.raises(CommandError, match="radio write failed"):
+        await execution
+
+    terminal = [
+        event.state
+        for event in server.command_service.lifecycle_events()
+        if event.command_id == intent.id
+        and event.state in {"acknowledged", "failed", "timed_out"}
+    ]
+    assert terminal == ["failed"]
+
+
 @pytest.mark.asyncio
 async def test_descriptor_timeout_and_cancellation_cleanup_is_exact_once() -> None:
     from rigplane.core.command_dispatch import prepare_command_intent
@@ -371,12 +515,22 @@ async def test_batch_preparation_is_capture_only_then_executes_once() -> None:
 
 
 def test_descriptor_is_the_only_migrated_name_source() -> None:
-    from rigplane.core.command_dispatch import command_descriptors
+    from dataclasses import MISSING, fields
+
+    from rigplane.core.command_dispatch import CommandDescriptor, command_descriptors
     from rigplane import _poller_types
     from rigplane.runtime import _poller_types as runtime_types
     from rigplane.web import radio_poller
 
     assert set(command_descriptors()) == {"set_repeater_shift"}
+    descriptor = command_descriptors()["set_repeater_shift"]
+    assert descriptor.tx_interlock_disposition is TxInterlockDisposition.TX_SAFE
+    policy_field = next(
+        field
+        for field in fields(CommandDescriptor)
+        if field.name == "tx_interlock_disposition"
+    )
+    assert policy_field.default is MISSING
     assert "set_repeater_shift" in ControlHandler._COMMANDS  # noqa: SLF001
     assert not hasattr(runtime_types, "SetRepeaterShift")
     assert not hasattr(_poller_types, "SetRepeaterShift")


### PR DESCRIPTION
## Summary

- add mandatory backend-neutral TX-interlock policy to every command descriptor
- reject DEFER/BLOCK or malformed descriptor policies at admission, enqueue, and the shared invocation seam until a shared enforcement seat exists
- preserve command id, source, session, command service, future, and intent timeout through ordered queue admission
- keep set_repeater_shift behavior unchanged across HTTP single/batch, WebSocket, and all three runtime drains

## Verification

- uv run pytest tests/test_mor2161_command_dispatch.py -q --tb=short --timeout=60 (30 passed)
- uv run ruff check src/rigplane/core/command_dispatch.py src/rigplane/web/handlers/control.py tests/test_mor2161_command_dispatch.py
- git diff --check
- focused strict mypy reported four pre-existing errors outside the changed lines; no new changed-line error

Linear: https://linear.app/morozsm/issue/MOR-2207
Parent: https://linear.app/morozsm/issue/MOR-2161

Do not merge before independent Agent Review and exact-head required checks.