### PR TITLE
Decouple descriptor TX policy vocabulary

### DIFF
--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -3,9 +3,9 @@
 Profiles remain authoritative for radio/model support and wire facts.  This
 module owns only backend-neutral operation mechanics: public name, reviewed
 Radio method, parameter binding, semantic target, timeout, queue policy, and
-explicit TX-interlock disposition.  Every migrated operation is admitted,
-queued, invoked, and audited through the same descriptor; drains must not add
-operation-specific branches.
+explicit TX policy.  Every migrated operation is admitted, queued, invoked,
+and audited through the same descriptor; drains must not add operation-specific
+branches.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import asyncio
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 from types import MappingProxyType
 from typing import Any, Literal, Protocol
 
@@ -23,11 +24,11 @@ from rigplane.core.state_pipeline_contracts import (
     CommandSource,
     FieldPath,
 )
-from rigplane.core.tx_interlock_contract import TxInterlockDisposition
 
 __all__ = [
     "CommandDescriptor",
     "CommandUnsupportedError",
+    "DescriptorTxPolicy",
     "command_descriptor",
     "command_descriptors",
     "enqueue_command_intent",
@@ -61,6 +62,13 @@ Binder = Callable[[Mapping[str, Any]], dict[str, Any]]
 TargetBuilder = Callable[[Mapping[str, Any]], FieldPath]
 
 
+class DescriptorTxPolicy(StrEnum):
+    """TX policies admitted by descriptor-backed dispatch."""
+
+    ALWAYS_PASS = "always_pass"
+    TX_SAFE = "tx_safe"
+
+
 @dataclass(frozen=True, slots=True)
 class CommandDescriptor:
     """One operation's backend-neutral execution mechanics."""
@@ -70,7 +78,7 @@ class CommandDescriptor:
     bind: Binder
     target: TargetBuilder
     argument_names: tuple[str, ...]
-    tx_interlock_disposition: TxInterlockDisposition
+    tx_policy: DescriptorTxPolicy
     timeout: float = 10.0
     queue_policy: Literal["ordered"] = "ordered"
 
@@ -110,30 +118,29 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             bind=_bind_repeater_shift,
             target=_repeater_shift_target,
             argument_names=("direction", "receiver"),
-            tx_interlock_disposition=TxInterlockDisposition.TX_SAFE,
+            tx_policy=DescriptorTxPolicy.TX_SAFE,
         )
     }
 )
 
 
-_DESCRIPTOR_POLICIES_WITHOUT_SHARED_SEAT = frozenset(
+_ADMITTED_DESCRIPTOR_TX_POLICIES = frozenset(
     {
-        TxInterlockDisposition.ALWAYS_PASS,
-        TxInterlockDisposition.TX_SAFE,
+        DescriptorTxPolicy.ALWAYS_PASS,
+        DescriptorTxPolicy.TX_SAFE,
     }
 )
 
 
 def _require_descriptor_policy_seat(descriptor: CommandDescriptor) -> None:
-    """Reject disruptive descriptors until every drain has one shared seat."""
+    """Reject values outside the descriptor-local admitted vocabulary."""
 
-    policy = descriptor.tx_interlock_disposition
-    if not isinstance(policy, TxInterlockDisposition) or policy not in (
-        _DESCRIPTOR_POLICIES_WITHOUT_SHARED_SEAT
+    policy = descriptor.tx_policy
+    if not isinstance(policy, DescriptorTxPolicy) or policy not in (
+        _ADMITTED_DESCRIPTOR_TX_POLICIES
     ):
         raise CommandError(
-            f"descriptor {descriptor.name!r} policy "
-            f"{policy!r} has no shared enforcement seat"
+            f"descriptor {descriptor.name!r} policy {policy!r} is not admitted"
         )
 
 

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -19,7 +19,7 @@ from rigplane.backends.yaesu_cat.poller import YaesuCatPoller
 from rigplane.core.exceptions import CommandError, CommandRejectedError
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import CommandIntent
-from rigplane.core.tx_interlock_contract import TxInterlockDisposition
+from rigplane.core.command_dispatch import DescriptorTxPolicy
 from rigplane.profiles import resolve_radio_profile
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import RadioPoller
@@ -250,39 +250,41 @@ async def test_all_three_drains_execute_the_same_neutral_intent() -> None:
 @pytest.mark.parametrize(
     "policy",
     [
-        TxInterlockDisposition.DEFER,
-        TxInterlockDisposition.BLOCK,
+        cast(Any, "defer"),
+        cast(Any, "block"),
         cast(Any, None),
     ],
 )
-def test_descriptor_admission_rejects_policy_without_shared_seat(
+def test_descriptor_admission_rejects_non_admitted_policy(
     monkeypatch: pytest.MonkeyPatch,
-    policy: TxInterlockDisposition,
+    policy: DescriptorTxPolicy,
 ) -> None:
     from rigplane.core import command_dispatch
     from rigplane.core.command_dispatch import prepare_command_intent
 
     descriptor = command_dispatch.command_descriptor("set_repeater_shift")
     assert descriptor is not None
-    mutated = replace(descriptor, tx_interlock_disposition=policy)
+    mutated = replace(descriptor, tx_policy=policy)
     monkeypatch.setattr(
         command_dispatch, "_COMMAND_DESCRIPTORS", {mutated.name: mutated}
     )
 
-    with pytest.raises(CommandError, match="has no shared enforcement seat"):
-        prepare_command_intent(_radio(), mutated.name, {"direction": 1}, source="http")
+    radio = _radio()
+    with pytest.raises(CommandError, match="is not admitted"):
+        prepare_command_intent(radio, mutated.name, {"direction": 1}, source="http")
+    radio.supports_command.assert_not_called()
+    radio.set_repeater_shift.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "policy", [TxInterlockDisposition.DEFER, TxInterlockDisposition.BLOCK]
-)
-async def test_all_three_drains_reject_unsafe_descriptor_before_invocation(
+async def test_descriptor_enqueue_rejects_non_admitted_policy(
     monkeypatch: pytest.MonkeyPatch,
-    policy: TxInterlockDisposition,
 ) -> None:
     from rigplane.core import command_dispatch
-    from rigplane.core.command_dispatch import prepare_command_intent
+    from rigplane.core.command_dispatch import (
+        enqueue_command_intent,
+        prepare_command_intent,
+    )
 
     radio = _radio()
     intent = prepare_command_intent(
@@ -290,30 +292,96 @@ async def test_all_three_drains_reject_unsafe_descriptor_before_invocation(
     )
     descriptor = command_dispatch.command_descriptor(intent.name)
     assert descriptor is not None
-    mutated = replace(descriptor, tx_interlock_disposition=policy)
+    mutated = replace(descriptor, tx_policy=cast(Any, "defer"))
+    monkeypatch.setattr(
+        command_dispatch, "_COMMAND_DESCRIPTORS", {mutated.name: mutated}
+    )
+    queue = MagicMock()
+    future = asyncio.get_running_loop().create_future()
+
+    with pytest.raises(CommandError, match="is not admitted"):
+        enqueue_command_intent(
+            queue,
+            intent,
+            future=future,
+            command_id=intent.id,
+            source=intent.source,
+            session_id=None,
+            command_service=object(),
+            timeout=intent.timeout,
+        )
+    queue.put_ordered.assert_not_called()
+    radio.set_repeater_shift.assert_not_awaited()
+
+
+def _install_non_admitted_descriptor(monkeypatch: pytest.MonkeyPatch) -> None:
+    from rigplane.core import command_dispatch
+
+    descriptor = command_dispatch.command_descriptor("set_repeater_shift")
+    assert descriptor is not None
+    mutated = replace(descriptor, tx_policy=cast(Any, "block"))
     monkeypatch.setattr(
         command_dispatch, "_COMMAND_DESCRIPTORS", {mutated.name: mutated}
     )
 
-    for drain in ("icom", "yaesu", "rigctld"):
-        with pytest.raises(CommandError, match="has no shared enforcement seat"):
-            if drain == "icom":
-                poller = SimpleNamespace(
-                    _radio=radio,
-                    _enforce_tx_interlock=lambda command: None,
-                    _provider_generation=lambda: 0,
-                )
-                await RadioPoller._execute(poller, intent)  # type: ignore[arg-type] # noqa: SLF001
-            elif drain == "yaesu":
-                poller = YaesuCatPoller.__new__(YaesuCatPoller)
-                poller._radio = radio  # type: ignore[attr-defined]
-                await poller._execute_command(intent)  # noqa: SLF001
-            else:
-                poller = RigctldClientObservationPoller.__new__(
-                    RigctldClientObservationPoller
-                )
-                poller._radio = radio  # type: ignore[attr-defined]
-                await poller._execute_command(intent)  # noqa: SLF001
+
+@pytest.mark.asyncio
+async def test_icom_drain_rejects_non_admitted_policy_before_radio_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    intent = prepare_command_intent(
+        radio, "set_repeater_shift", {"direction": 3}, source="http"
+    )
+    _install_non_admitted_descriptor(monkeypatch)
+    poller = SimpleNamespace(
+        _radio=radio,
+        _enforce_tx_interlock=lambda command: None,
+        _provider_generation=lambda: 0,
+    )
+
+    with pytest.raises(CommandError, match="is not admitted"):
+        await RadioPoller._execute(poller, intent)  # type: ignore[arg-type] # noqa: SLF001
+    radio.set_repeater_shift.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_yaesu_drain_rejects_non_admitted_policy_before_radio_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    intent = prepare_command_intent(
+        radio, "set_repeater_shift", {"direction": 3}, source="http"
+    )
+    _install_non_admitted_descriptor(monkeypatch)
+    poller = YaesuCatPoller.__new__(YaesuCatPoller)
+    poller._radio = radio  # type: ignore[attr-defined]
+
+    with pytest.raises(CommandError, match="is not admitted"):
+        await poller._execute_command(intent)  # noqa: SLF001
+    radio.set_repeater_shift.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rigctld_drain_rejects_non_admitted_policy_before_radio_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rigplane.core.command_dispatch import prepare_command_intent
+
+    radio = _radio()
+    intent = prepare_command_intent(
+        radio, "set_repeater_shift", {"direction": 3}, source="http"
+    )
+    _install_non_admitted_descriptor(monkeypatch)
+    poller = RigctldClientObservationPoller.__new__(RigctldClientObservationPoller)
+    poller._radio = radio  # type: ignore[attr-defined]
+
+    with pytest.raises(CommandError, match="is not admitted"):
+        await poller._execute_command(intent)  # noqa: SLF001
     radio.set_repeater_shift.assert_not_awaited()
 
 
@@ -524,11 +592,9 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
 
     assert set(command_descriptors()) == {"set_repeater_shift"}
     descriptor = command_descriptors()["set_repeater_shift"]
-    assert descriptor.tx_interlock_disposition is TxInterlockDisposition.TX_SAFE
+    assert descriptor.tx_policy is DescriptorTxPolicy.TX_SAFE
     policy_field = next(
-        field
-        for field in fields(CommandDescriptor)
-        if field.name == "tx_interlock_disposition"
+        field for field in fields(CommandDescriptor) if field.name == "tx_policy"
     )
     assert policy_field.default is MISSING
     assert "set_repeater_shift" in ControlHandler._COMMANDS  # noqa: SLF001


### PR DESCRIPTION
## Linear

MOR-2207 follow-up; no new ticket.

## Owner ruling and acceptance boundary

Owner ruling, 2026-09-02 (supplied directly in the task context): the observed-RF interlock is retiring under MOR-2172 after MOR-2171 and the MOR-2168 authority cutover. Managed-TX write admission belongs inside `ManagedTxAuthority`, keyed on managed PTT/TRANSMIT intent rather than observed RF. Relay-family ownership remains with MOR-2169; MOR-1500 and MOR-1888 are superseded.

This PR closes only the descriptor fail-closed invariant from MOR-2207:

- keep `_require_descriptor_policy_seat` at admission, enqueue, and invocation;
- admit only descriptor-local `always_pass` and `tx_safe` values;
- make DEFER/BLOCK unrepresentable in the valid descriptor vocabulary and reject corrupted/non-admitted values before command invocation;
- do not build a shared enforcement seat on `evaluate_tx_interlock`, `rf_state`, or `DeferredTxCommandLane`;
- do not add a consumer of the retiring interlock.

## Change

- Replace `CommandDescriptor.tx_interlock_disposition: TxInterlockDisposition` with `CommandDescriptor.tx_policy: DescriptorTxPolicy`.
- Define the two-member `DescriptorTxPolicy` vocabulary in `core/command_dispatch.py`.
- Add distinct fail-closed tests for admission, enqueue, and each Icom/Yaesu/rigctld invocation drain.

Public compatibility note: `CommandDescriptor` was introduced by merged PR #3014; this follow-up intentionally renames its policy field before further descriptor adoption so it no longer depends on the contract scheduled for deletion.

## Search before write

Search-before-write command run against the fresh `origin/main` worktree before editing:

```text
git grep -n -E 'CommandDescriptor|_require_descriptor_policy_seat|TxInterlockDisposition|tx_interlock_disposition' -- src/rigplane/core/command_dispatch.py tests src/rigplane/runtime/command\*.py src/rigplane/web/handlers/control.py
```

Exact output:

```text
src/rigplane/core/command_dispatch.py:26:from rigplane.core.tx_interlock_contract import TxInterlockDisposition
src/rigplane/core/command_dispatch.py:29:    "CommandDescriptor",
src/rigplane/core/command_dispatch.py:65:class CommandDescriptor:
src/rigplane/core/command_dispatch.py:73:    tx_interlock_disposition: TxInterlockDisposition
src/rigplane/core/command_dispatch.py:105:_COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
src/rigplane/core/command_dispatch.py:107:        "set_repeater_shift": CommandDescriptor(
src/rigplane/core/command_dispatch.py:113:            tx_interlock_disposition=TxInterlockDisposition.TX_SAFE,
src/rigplane/core/command_dispatch.py:121:        TxInterlockDisposition.ALWAYS_PASS,
src/rigplane/core/command_dispatch.py:122:        TxInterlockDisposition.TX_SAFE,
src/rigplane/core/command_dispatch.py:127:def _require_descriptor_policy_seat(descriptor: CommandDescriptor) -> None:
src/rigplane/core/command_dispatch.py:130:    policy = descriptor.tx_interlock_disposition
src/rigplane/core/command_dispatch.py:131:    if not isinstance(policy, TxInterlockDisposition) or policy not in (
src/rigplane/core/command_dispatch.py:140:def command_descriptors() -> Mapping[str, CommandDescriptor]:
src/rigplane/core/command_dispatch.py:144:def command_descriptor(name: str) -> CommandDescriptor | None:
src/rigplane/core/command_dispatch.py:164:    _require_descriptor_policy_seat(descriptor)
src/rigplane/core/command_dispatch.py:205:    _require_descriptor_policy_seat(descriptor)
src/rigplane/core/command_dispatch.py:233:    _require_descriptor_policy_seat(descriptor)
tests/test_mor2161_command_dispatch.py:22:from rigplane.core.tx_interlock_contract import TxInterlockDisposition
tests/test_mor2161_command_dispatch.py:253:        TxInterlockDisposition.DEFER,
tests/test_mor2161_command_dispatch.py:254:        TxInterlockDisposition.BLOCK,
tests/test_mor2161_command_dispatch.py:260:    policy: TxInterlockDisposition,
tests/test_mor2161_command_dispatch.py:267:    mutated = replace(descriptor, tx_interlock_disposition=policy)
tests/test_mor2161_command_dispatch.py:278:    "policy", [TxInterlockDisposition.DEFER, TxInterlockDisposition.BLOCK]
tests/test_mor2161_command_dispatch.py:282:    policy: TxInterlockDisposition,
tests/test_mor2161_command_dispatch.py:293:    mutated = replace(descriptor, tx_interlock_disposition=policy)
tests/test_mor2161_command_dispatch.py:520:    from rigplane.core.command_dispatch import CommandDescriptor, command_descriptors
tests/test_mor2161_command_dispatch.py:527:    assert descriptor.tx_interlock_disposition is TxInterlockDisposition.TX_SAFE
tests/test_mor2161_command_dispatch.py:530:        for field in fields(CommandDescriptor)
tests/test_mor2161_command_dispatch.py:531:        if field.name == "tx_interlock_disposition"
tests/test_radio_poller_tx_interlock.py:35:    TxInterlockDisposition,
tests/test_radio_poller_tx_interlock.py:497:    assert metadata.base_disposition is TxInterlockDisposition.BLOCK
tests/test_rig_loader.py:20:    TxInterlockDisposition,
tests/test_rig_loader.py:107:        assert rig.tx_interlock_disposition_overrides == {}
tests/test_rig_loader.py:108:        assert rig.to_profile().tx_interlock_disposition_overrides == {}
tests/test_rig_loader.py:132:            TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
tests/test_rig_loader.py:135:        assert rig.tx_interlock_disposition_overrides == expected
tests/test_rig_loader.py:136:        assert rig.to_profile().tx_interlock_disposition_overrides == expected
tests/test_rig_loader.py:143:            if metadata.base_disposition is not TxInterlockDisposition.TX_SAFE
tests/test_rig_loader.py:242:        assert rig.tx_interlock_disposition_overrides == {}
tests/test_rig_loader.py:252:        assert load_rig(p).tx_interlock_disposition_overrides == {}
tests/test_rig_loader.py:278:        assert load_rig(p).tx_interlock_disposition_overrides == {}
tests/test_rigctld_tx_interlock.py:21:from rigplane.core.tx_interlock_contract import TxInterlockDisposition
tests/test_rigctld_tx_interlock.py:78:        assert classified.disposition is TxInterlockDisposition.TX_SAFE
tests/test_rigctld_tx_interlock.py:90:        assert classified.disposition is TxInterlockDisposition.TX_SAFE
tests/test_tx_authority_characterisation.py:42:from rigplane.core.tx_interlock_contract import TxInterlockDisposition
tests/test_tx_authority_characterisation.py:363:        # `classification.disposition is TxInterlockDisposition.BLOCK`
tests/test_tx_authority_characterisation.py:488:        assert classify_tx_interlock(PttOff()) is TxInterlockDisposition.ALWAYS_PASS
tests/test_tx_authority_characterisation.py:492:        assert classify_tx_interlock(PttOn()) is TxInterlockDisposition.BLOCK
tests/test_tx_interlock_policy.py:17:    TxInterlockDisposition as CoreTxInterlockDisposition,
tests/test_tx_interlock_policy.py:51:    TxInterlockDisposition,
tests/test_tx_interlock_policy.py:59:    assert TxInterlockDisposition is CoreTxInterlockDisposition
tests/test_tx_interlock_policy.py:68:        TxInterlockDisposition.BLOCK,
tests/test_tx_interlock_policy.py:75:        "disposition": TxInterlockDisposition.BLOCK,
tests/test_tx_interlock_policy.py:83:        assert classify_tx_interlock(command) is TxInterlockDisposition.ALWAYS_PASS
tests/test_tx_interlock_policy.py:97:        assert classify_tx_interlock(command) is TxInterlockDisposition.BLOCK
tests/test_tx_interlock_policy.py:100:        classify_tx_interlock(SetPowerstat(on=True)) is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:106:        classify_tx_interlock(SetTunerStatus(0)) is TxInterlockDisposition.ALWAYS_PASS
tests/test_tx_interlock_policy.py:108:    assert classify_tx_interlock(SetTunerStatus(1)) is TxInterlockDisposition.BLOCK
tests/test_tx_interlock_policy.py:109:    assert classify_tx_interlock(SetTunerStatus(2)) is TxInterlockDisposition.BLOCK
tests/test_tx_interlock_policy.py:110:    assert classify_tx_interlock(SetTunerStatus(3)) is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:116:    assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:151:        assert classify_tx_interlock(command) is TxInterlockDisposition.DEFER
tests/test_tx_interlock_policy.py:167:        assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:171:            assert decision.disposition is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:177:    assert decision.disposition is TxInterlockDisposition.DEFER
tests/test_tx_interlock_policy.py:188:        assert classify_tx_interlock(command) is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:195:        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
tests/test_tx_interlock_policy.py:199:    assert base.disposition is TxInterlockDisposition.TX_SAFE
tests/test_tx_interlock_policy.py:212:        TxInterlockDisposition.DEFER,
tests/test_tx_interlock_policy.py:216:        TxInterlockDisposition.DEFER,
tests/test_tx_interlock_policy.py:220:        TxInterlockDisposition.DEFER,
tests/test_tx_interlock_policy.py:228:        {TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.TX_SAFE},
tests/test_tx_interlock_policy.py:229:        {TxInterlockCommandFamily.PTT_ON: TxInterlockDisposition.DEFER},
tests/test_tx_interlock_policy.py:230:        {"power-on": TxInterlockDisposition.DEFER},
tests/test_tx_interlock_policy.py:244:    assert emergency.disposition is TxInterlockDisposition.ALWAYS_PASS
tests/test_tx_interlock_policy.py:310:        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER,
tests/test_tx_interlock_policy.py:345:        TxInterlockDisposition.DEFER,
tests/test_yaesu_cat_poller.py:26:    TxInterlockDisposition,
tests/test_yaesu_cat_poller.py:100:    radio.profile.tx_interlock_disposition_overrides = {}
tests/test_yaesu_cat_poller.py:652:    override = {TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER}
tests/test_yaesu_cat_poller.py:653:    radio.profile.tx_interlock_disposition_overrides = override
tests/test_yaesu_cat_poller.py:668:    radio.profile.tx_interlock_disposition_overrides = trapping
tests/test_yaesu_cat_poller.py:695:    radio.profile.tx_interlock_disposition_overrides = {
tests/test_yaesu_cat_poller.py:696:        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER
tests/test_yaesu_cat_poller.py:704:    radio.profile.tx_interlock_disposition_overrides = {
tests/test_yaesu_cat_poller.py:705:        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.ALWAYS_PASS
tests/test_yaesu_cat_poller.py:725:        def tx_interlock_disposition_overrides(self) -> object:
tests/test_yaesu_cat_poller.py:764:    radio.profile.tx_interlock_disposition_overrides = {
tests/test_yaesu_cat_poller.py:765:        TxInterlockCommandFamily.POWER_ON: TxInterlockDisposition.DEFER
```

## Required pre-push interlock-consumer check

Command:

```text
git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py src/rigplane/runtime/command\*.py src/rigplane/web/handlers/control.py
```

Complete output before the only push:

```text
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1732:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1982:            decision = evaluate_tx_interlock(
```

There are zero hits in `src/rigplane/core/command_dispatch.py`; this PR adds no hit anywhere in the searched surface.

## TDD and mutation evidence

- RED: after adding the descriptor-local tests first, `uv run pytest tests/test_mor2161_command_dispatch.py -q --tb=short` stopped at collection with `ImportError: cannot import name 'DescriptorTxPolicy'`.
- GREEN: after implementation and restoration of the mutation, the same command reports `32 passed`.
- Mutation: temporarily removed `_require_descriptor_policy_seat(descriptor)` from the invocation seam in `execute_command_intent`, then ran only `uv run pytest tests/test_mor2161_command_dispatch.py::test_icom_drain_rejects_non_admitted_policy_before_radio_invocation -q --tb=short`. Result: exactly `1 failed`; the failure was `Failed: DID NOT RAISE <class 'rigplane.core.exceptions.CommandError'>`. The check was restored immediately; the focused file then returned to `32 passed`.

## Local checks

- `uv run pytest tests/test_mor2161_command_dispatch.py -q --tb=short` — 32 passed.
- `uv run ruff check src/ tests/` — passed.
- `uv run ruff format --check src/ tests/` — 717 files already formatted.
- `uv run lint-imports` — 5 contracts kept, 0 broken.
- `uv run mypy --strict src/rigplane/web` — success, 26 source files.

The full pytest suite was not run locally per owner instruction; it is left to the normal PR CI queue.

## Guardrails

`git diff --numstat origin/main...HEAD` at the pushed head: 2 files, 126 additions, 53 deletions, 179 changed lines. This is below both the 6 files / 600 lines soft threshold and 10 files / 1000 lines hard ceiling.
