### PR TITLE
MOR-2197: prove provider replacement and shutdown drain

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -116,6 +116,7 @@ class ManagedTxAuthority:
         self._release_drained.set()
         self._shutting_down = False
         self._terminated = False
+        self._shutdown_termination: asyncio.Event | None = None
         self._shutdown_task: asyncio.Task[ShutdownResult] | None = None
         self._closing = False
         self._closed = False
@@ -219,6 +220,7 @@ class ManagedTxAuthority:
             if task is None:
                 self._require_open_locked()
                 self._shutting_down = True
+                self._shutdown_termination = termination
                 transition = self._force_off_locked()
                 self._wakeup.wake()
                 task = asyncio.create_task(
@@ -277,6 +279,7 @@ class ManagedTxAuthority:
             async with self._lock:
                 self._shutting_down = False
                 if self._shutdown_task is asyncio.current_task():
+                    self._shutdown_termination = None
                     self._shutdown_task = None
             raise
 
@@ -289,14 +292,18 @@ class ManagedTxAuthority:
         drained = asyncio.create_task(self._release_drained.wait())
         terminated = asyncio.create_task(termination.wait())
         try:
-            await asyncio.wait(
+            done, _ = await asyncio.wait(
                 (drained, terminated), return_when=asyncio.FIRST_COMPLETED
             )
             async with self._lock:
+                if self._terminated:
+                    return False
                 if self._state_is_clean_locked():
                     return True
-                self._terminated = True
-                return False
+                if terminated in done:
+                    self._terminated = True
+                    return False
+                raise RuntimeError("managed TX drain signalled before clean RX state")
         finally:
             for waiter in (drained, terminated):
                 if not waiter.done():
@@ -418,7 +425,11 @@ class ManagedTxAuthority:
                     )
             followup = None
             async with self._lock:
-                if self._terminated:
+                if self._terminated or (
+                    self._shutdown_termination is not None
+                    and self._shutdown_termination.is_set()
+                ):
+                    self._terminated = True
                     return
                 for event in events:
                     transition = self._reduce_locked(event)

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
+from enum import StrEnum
 from typing import Protocol
 
 from rigplane.runtime.managed_tx_config import (
@@ -69,6 +70,14 @@ class ManagedTxProjection:
     provider_generation: int | None
 
 
+class ShutdownResult(StrEnum):
+    DRAINED = "drained"
+    TERMINATED = "terminated"
+
+
+_ProviderRetirement = Callable[[int], Awaitable[None]]
+
+
 class ManagedTxAuthority:
     def __init__(
         self,
@@ -103,6 +112,11 @@ class ManagedTxAuthority:
         )
         self._attempt = 0
         self._retry_due: float | None = None
+        self._release_drained = asyncio.Event()
+        self._release_drained.set()
+        self._shutting_down = False
+        self._terminated = False
+        self._shutdown_task: asyncio.Task[ShutdownResult] | None = None
         self._closing = False
         self._closed = False
         self._scheduler_task = asyncio.create_task(self._scheduler())
@@ -121,7 +135,7 @@ class ManagedTxAuthority:
 
     async def owner_disconnect(self, owner: str) -> ManagedTxOutcome:
         async with self._lock:
-            self._require_open_locked()
+            self._require_ingress_open_locked()
             if self._state.intent != ManagedTxIntent.ptt(owner):
                 return ManagedTxOutcome.REJECTED
             transition = self._force_off_locked()
@@ -136,7 +150,7 @@ class ManagedTxAuthority:
     async def set_tot_seconds(self, value: object) -> ManagedTxTotConfig:
         transition = None
         async with self._lock:
-            self._require_open_locked()
+            self._require_ingress_open_locked()
             config = self._config_store.set_timeout_seconds(value)
             deadline = self._tot_deadline_locked(config.timeout_seconds)
             if deadline is not None and deadline <= self._clock():
@@ -158,44 +172,161 @@ class ManagedTxAuthority:
                 self._provider_generation,
             )
 
-    async def set_provider_generation(self, generation: int | None) -> None:
+    async def provider_unavailable(self) -> None:
+        transition = None
         async with self._lock:
             self._require_open_locked()
-            if generation is not None:
-                if generation <= self._generation_high_water:
-                    if generation == self._provider_generation:
-                        return
-                    raise ValueError("provider generation must increase")
-                self._generation_high_water = generation
-            self._provider_generation = generation
-            if generation is None:
-                self._retry_due = None
-            elif self._release_is_retryable_locked():
-                self._retry_due = self._clock()
+            self._require_provider_change_locked()
+            if self._provider_generation is None:
+                return
+            self._provider_generation = None
+            self._retry_due = None
+            if self._state.release_required:
+                transition = self._force_off_locked()
             self._wakeup.wake()
+        if transition is not None:
+            await self._execute(transition.effects, full_force=True)
+
+    async def provider_available(self, generation: int) -> None:
+        transition = None
+        async with self._lock:
+            self._require_open_locked()
+            self._require_provider_change_locked()
+            if generation == self._provider_generation:
+                return
+            if self._provider_generation is not None:
+                raise RuntimeError("current provider must become unavailable first")
+            if generation <= self._generation_high_water:
+                raise ValueError("provider generation must increase")
+            self._generation_high_water = generation
+            self._provider_generation = generation
+            if self._release_is_retryable_locked():
+                transition = self._reduce_locked(
+                    RetryForceReceive(generation, self._attempt_id_locked())
+                )
+            self._wakeup.wake()
+        if transition is not None:
+            await self._execute(transition.effects, full_force=False)
+
+    async def shutdown(
+        self,
+        *,
+        retire_provider: _ProviderRetirement,
+        termination: asyncio.Event,
+    ) -> ShutdownResult:
+        async with self._lock:
+            task = self._shutdown_task
+            if task is None:
+                self._require_open_locked()
+                self._shutting_down = True
+                transition = self._force_off_locked()
+                self._wakeup.wake()
+                task = asyncio.create_task(
+                    self._complete_shutdown(transition, retire_provider, termination)
+                )
+                self._shutdown_task = task
+        return await asyncio.shield(task)
 
     async def close(self) -> None:
+        await self._dispose_clean(from_shutdown=False)
+
+    async def _complete_shutdown(
+        self,
+        transition: ManagedTxTransition,
+        retire_provider: _ProviderRetirement,
+        termination: asyncio.Event,
+    ) -> ShutdownResult:
+        try:
+            drain = asyncio.create_task(
+                self._wait_for_release_or_termination(termination)
+            )
+            release = asyncio.create_task(
+                self._execute(transition.effects, full_force=True)
+            )
+            try:
+                done, _ = await asyncio.wait(
+                    (drain, release), return_when=asyncio.FIRST_COMPLETED
+                )
+                if release in done:
+                    await release
+                drained = await drain
+            finally:
+                for task in (drain, release):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(drain, release, return_exceptions=True)
+            if not drained:
+                async with self._lock:
+                    scheduler = self._scheduler_task
+                await self._stop_scheduler(scheduler)
+                return ShutdownResult.TERMINATED
+
+            async with self._lock:
+                if not self._state_is_clean_locked():
+                    raise RuntimeError("managed TX shutdown drain lost clean state")
+                generation = self._provider_generation
+            if generation is not None:
+                await retire_provider(generation)
+            async with self._lock:
+                if self._provider_generation != generation:
+                    raise RuntimeError("managed TX provider changed during retirement")
+                self._provider_generation = None
+            await self._dispose_clean(from_shutdown=True)
+            return ShutdownResult.DRAINED
+        except BaseException:
+            async with self._lock:
+                self._shutting_down = False
+                if self._shutdown_task is asyncio.current_task():
+                    self._shutdown_task = None
+            raise
+
+    async def _wait_for_release_or_termination(
+        self, termination: asyncio.Event
+    ) -> bool:
+        async with self._lock:
+            if self._state_is_clean_locked():
+                return True
+        drained = asyncio.create_task(self._release_drained.wait())
+        terminated = asyncio.create_task(termination.wait())
+        try:
+            await asyncio.wait(
+                (drained, terminated), return_when=asyncio.FIRST_COMPLETED
+            )
+            async with self._lock:
+                if self._state_is_clean_locked():
+                    return True
+                self._terminated = True
+                return False
+        finally:
+            for waiter in (drained, terminated):
+                if not waiter.done():
+                    waiter.cancel()
+            await asyncio.gather(drained, terminated, return_exceptions=True)
+
+    async def _dispose_clean(self, *, from_shutdown: bool) -> None:
         async with self._lock:
             if self._closed or self._closing:
                 return
-            if (
-                self._state.intent.kind is not ManagedTxIntentKind.RX
-                or self._state.release_required
-                or self._state.pending_effect is not None
-            ):
+            if not self._state_is_clean_locked():
                 raise RuntimeError("managed TX disposal requires clean RX state")
+            if self._shutting_down and not from_shutdown:
+                raise RuntimeError("managed TX shutdown is in progress")
             self._closing = True
             scheduler = self._scheduler_task
-        scheduler.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await scheduler
+        await self._stop_scheduler(scheduler)
         async with self._lock:
             self._closed = True
             self._closing = False
 
+    @staticmethod
+    async def _stop_scheduler(scheduler: asyncio.Task[None]) -> None:
+        scheduler.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await scheduler
+
     async def _ingress(self, action: str, owner: str | None = None) -> ManagedTxOutcome:
         async with self._lock:
-            self._require_open_locked()
+            self._require_ingress_open_locked()
             transition, full_force = self._transition_locked(action, owner)
             self._wakeup.wake()
         if transition is None:
@@ -253,6 +384,10 @@ class ManagedTxAuthority:
     def _reduce_locked(self, event: ManagedTxEvent) -> ManagedTxTransition:
         transition = reduce_managed_tx(self._state, event)
         self._state = transition.state
+        if self._state_is_clean_locked():
+            self._release_drained.set()
+        else:
+            self._release_drained.clear()
         return transition
 
     async def _execute(
@@ -283,6 +418,8 @@ class ManagedTxAuthority:
                     )
             followup = None
             async with self._lock:
+                if self._terminated:
+                    return
                 for event in events:
                     transition = self._reduce_locked(event)
                     if (
@@ -302,6 +439,8 @@ class ManagedTxAuthority:
     async def _scheduler(self) -> None:
         while True:
             async with self._lock:
+                if self._closing or self._closed or self._terminated:
+                    return
                 deadline = self._next_due_locked()
             await self._wakeup.wait_until(deadline)
             await self._process_due()
@@ -365,5 +504,23 @@ class ManagedTxAuthority:
         return str(self._attempt)
 
     def _require_open_locked(self) -> None:
+        if self._terminated:
+            raise RuntimeError("managed TX authority runtime has terminated")
         if self._closing or self._closed:
             raise RuntimeError("managed TX authority is closed")
+
+    def _require_ingress_open_locked(self) -> None:
+        self._require_open_locked()
+        if self._shutting_down:
+            raise RuntimeError("managed TX authority is shutting down")
+
+    def _require_provider_change_locked(self) -> None:
+        if self._shutting_down and self._state_is_clean_locked():
+            raise RuntimeError("managed TX shutdown drain is complete")
+
+    def _state_is_clean_locked(self) -> bool:
+        return (
+            self._state.intent.kind is ManagedTxIntentKind.RX
+            and not self._state.release_required
+            and self._state.pending_effect is None
+        )

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -598,7 +598,7 @@ async def test_replacement_during_shutdown_stales_old_release() -> None:
 
 
 @pytest.mark.asyncio
-async def test_termination_during_initial_release_skips_retirement() -> None:
+async def test_termination_before_initial_release_acceptance_preserves_debt() -> None:
     managed, _, _, _, _, lane = authority(generation=7)
     release_gate = lane.block_next()
     termination = asyncio.Event()
@@ -610,19 +610,17 @@ async def test_termination_during_initial_release_skips_retirement() -> None:
         )
     )
     await asyncio.wait_for(lane.started.get(), 0.2)
+    before = await managed.snapshot()
     termination.set()
-
-    try:
-        result = await asyncio.wait_for(asyncio.shield(shutdown), 0.2)
-    finally:
-        release_gate.set()
-        if not shutdown.done():
-            await shutdown
+    asyncio.get_running_loop().call_soon(release_gate.set)
+    result = await asyncio.wait_for(shutdown, 0.2)
 
     assert result is ShutdownResult.TERMINATED
     assert retired == []
-    assert (await managed.snapshot()).state.release_required
+    assert await managed.snapshot() == before
     assert managed._scheduler_task.done()
+    with pytest.raises(RuntimeError, match="clean RX state"):
+        await managed.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from rigplane.runtime.managed_tx_authority import ManagedTxAuthority
+from rigplane.runtime.managed_tx_authority import ManagedTxAuthority, ShutdownResult
 from rigplane.runtime.managed_tx_config import ManagedTxTotConfig
 from rigplane.runtime.managed_tx_state import (
     AbortFailed,
@@ -87,12 +87,23 @@ class FakeLane:
         self.aborts: list[tuple[EffectToken, AbortOperation]] = []
         self.abort_results: dict[AbortOperation, ActuationResult] = {}
         self.stale_once = False
+        self.gates: deque[asyncio.Event | None] = deque()
+        self.started: asyncio.Queue[ManagedTxEffect] = asyncio.Queue()
+
+    def block_next(self) -> asyncio.Event:
+        gate = asyncio.Event()
+        self.gates.append(gate)
+        return gate
 
     async def settle(
         self, effect: ManagedTxEffect, *, deadline_monotonic: float
     ) -> ActuationSettled:
         self.effects.append(effect)
+        self.started.put_nowait(effect)
         result = self.results.popleft() if self.results else ActuationResult.ACCEPTED
+        gate = self.gates.popleft() if self.gates else None
+        if gate is not None:
+            await gate.wait()
         token = effect.token
         if self.stale_once:
             self.stale_once = False
@@ -192,16 +203,17 @@ async def test_transmit_is_latched_and_force_off_runs_one_abort_family() -> None
 
 
 @pytest.mark.asyncio
-async def test_offline_force_off_retries_when_provider_appears() -> None:
-    managed, _, wakeup, _, fence, lane = authority(generation=None)
+async def test_offline_force_off_retries_immediately_when_provider_appears() -> None:
+    managed, _, _, _, fence, lane = authority(generation=None)
     assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
     assert (await managed.snapshot()).state.release_required
     assert lane.effects == [] and fence.calls == 1
-    revision = wakeup.revision
-    await managed.set_provider_generation(8)
-    await wakeup.wait_after(revision + 1)
+    await managed.provider_available(8)
     assert not (await managed.snapshot()).state.release_required
-    assert lane.effects[-1].operation is ActuationOperation.FORCE_RECEIVE
+    assert [effect.operation for effect in lane.effects] == [
+        ActuationOperation.FORCE_RECEIVE
+    ]
+    assert lane.effects[-1].token.provider_generation == 8
     await managed.close()
 
 
@@ -379,13 +391,321 @@ async def test_repeated_force_off_is_accepted_and_advances_epoch() -> None:
 
 @pytest.mark.asyncio
 async def test_generation_is_monotonic_and_wakes_debt() -> None:
-    managed, _, _, _, _, _ = authority(generation=7)
-    await managed.set_provider_generation(None)
+    managed, _, _, _, fence, lane = authority(generation=7)
+    await managed.provider_unavailable()
+    await managed.provider_unavailable()
+    assert fence.calls == 0 and lane.effects == []
     with pytest.raises(ValueError, match="increase"):
-        await managed.set_provider_generation(6)
-    await managed.set_provider_generation(8)
+        await managed.provider_available(6)
+    await managed.provider_available(8)
     assert (await managed.snapshot()).provider_generation == 8
+    with pytest.raises(RuntimeError, match="unavailable first"):
+        await managed.provider_available(9)
     await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_old_release_acceptance_cannot_clear_replacement_debt() -> None:
+    managed, _, _, _, _, lane = authority(generation=7)
+    lane.results.extend((ActuationResult.ACCEPTED, ActuationResult.REJECTED))
+    old_gate = lane.block_next()
+    old_release = asyncio.create_task(managed.force_off())
+    old_effect = await asyncio.wait_for(lane.started.get(), 0.2)
+    assert old_effect.token.provider_generation == 7
+
+    await managed.provider_unavailable()
+    await managed.provider_available(8)
+    current = lane.effects[-1]
+    assert current.operation is ActuationOperation.FORCE_RECEIVE
+    assert current.token.provider_generation == 8
+    assert (await managed.snapshot()).state.release_required
+
+    old_gate.set()
+    await old_release
+    projected = await managed.snapshot()
+    assert (
+        projected.state.release_required and projected.state.last_actuation is not None
+    )
+    assert projected.state.last_actuation.attempt_id == current.token.attempt_id
+
+    await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ingress", "operation"),
+    [
+        ("ptt", ActuationOperation.PTT_ON),
+        ("transmit", ActuationOperation.TRANSMIT_ON),
+    ],
+)
+@pytest.mark.parametrize("shutdown", [False, True], ids=["replacement", "shutdown"])
+async def test_active_replacement_never_replays_on(
+    ingress: str, operation: ActuationOperation, shutdown: bool
+) -> None:
+    managed, _, _, _, fence, lane = authority(generation=7)
+    outcome = (
+        await managed.ptt_down("owner")
+        if ingress == "ptt"
+        else await managed.transmit_on()
+    )
+    assert outcome is ManagedTxOutcome.ACCEPTED
+
+    retired: list[int] = []
+    if shutdown:
+        assert (
+            await managed.shutdown(
+                retire_provider=lambda generation: _append_async(retired, generation),
+                termination=asyncio.Event(),
+            )
+            is ShutdownResult.DRAINED
+        )
+    else:
+        await managed.provider_unavailable()
+        assert (await managed.snapshot()).provider_generation is None
+        assert (await managed.snapshot()).state.release_required
+        await managed.provider_available(8)
+
+    assert [effect.operation for effect in lane.effects] == [
+        operation,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    assert lane.effects[-1].token.provider_generation == (7 if shutdown else 8)
+    assert fence.calls == 1
+    assert retired == ([7] if shutdown else [])
+    assert not (await managed.snapshot()).state.release_required
+    if not shutdown:
+        await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_inflight_on_settlement_is_stale_after_replacement() -> None:
+    managed, _, _, _, fence, lane = authority(generation=7)
+    on_gate = lane.block_next()
+    pending_on = asyncio.create_task(managed.transmit_on())
+    old_on = await asyncio.wait_for(lane.started.get(), 0.2)
+    assert old_on.operation is ActuationOperation.TRANSMIT_ON
+
+    await managed.provider_unavailable()
+    await managed.provider_available(8)
+    on_gate.set()
+    assert await pending_on is ManagedTxOutcome.ACCEPTED
+
+    assert [effect.operation for effect in lane.effects] == [
+        ActuationOperation.TRANSMIT_ON,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    assert lane.effects[-1].token.provider_generation == 8
+    assert fence.calls == 1
+    assert not (await managed.snapshot()).state.release_required
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_arrival_wins_retry_tie_without_duplicate_effect() -> None:
+    managed, clock, _, _, _, lane = authority(generation=None)
+    await managed.force_off()
+    managed._retry_due = clock.now
+
+    await asyncio.gather(managed.provider_available(8), managed._process_due())
+
+    assert len(lane.effects) == 1
+    assert lane.effects[0].operation is ActuationOperation.FORCE_RECEIVE
+    assert lane.effects[0].token.provider_generation == 8
+    await managed.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "first_result", [ActuationResult.REJECTED, ActuationResult.UNCERTAIN]
+)
+async def test_shutdown_retries_each_nonacceptance_before_retirement(
+    first_result: ActuationResult,
+) -> None:
+    managed, clock, wakeup, _, _, lane = authority(generation=7)
+    lane.results.extend((first_result, ActuationResult.ACCEPTED))
+    retired: list[int] = []
+
+    async def retire(generation: int) -> None:
+        retired.append(generation)
+
+    task = asyncio.create_task(
+        managed.shutdown(retire_provider=retire, termination=asyncio.Event())
+    )
+    await asyncio.wait_for(lane.started.get(), 0.2)
+    while managed._retry_due is None:
+        await asyncio.sleep(0)
+    assert retired == []
+    revision = wakeup.revision
+    clock.now = managed._retry_due
+    wakeup.wake()
+    await wakeup.wait_after(revision + 1)
+
+    assert await asyncio.wait_for(task, 0.2) is ShutdownResult.DRAINED
+    assert retired == [7]
+    assert [effect.operation for effect in lane.effects] == [
+        ActuationOperation.FORCE_RECEIVE,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    assert not (await managed.snapshot()).state.release_required
+    assert managed._scheduler_task.done()
+
+
+@pytest.mark.asyncio
+async def test_offline_shutdown_drains_after_replacement_arrives() -> None:
+    managed, _, _, _, _, lane = authority(generation=None)
+    retired: list[int] = []
+
+    async def retire(generation: int) -> None:
+        retired.append(generation)
+
+    task = asyncio.create_task(
+        managed.shutdown(retire_provider=retire, termination=asyncio.Event())
+    )
+    await asyncio.sleep(0)
+    assert (await managed.snapshot()).state.release_required
+    assert retired == [] and not task.done()
+
+    await managed.provider_available(8)
+    assert await asyncio.wait_for(task, 0.2) is ShutdownResult.DRAINED
+    assert retired == [8]
+    assert [effect.operation for effect in lane.effects] == [
+        ActuationOperation.FORCE_RECEIVE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_replacement_during_shutdown_stales_old_release() -> None:
+    managed, _, _, _, _, lane = authority(generation=7)
+    old_gate = lane.block_next()
+    shutdown = asyncio.create_task(
+        managed.shutdown(
+            retire_provider=lambda _generation: asyncio.sleep(0),
+            termination=asyncio.Event(),
+        )
+    )
+    old = await asyncio.wait_for(lane.started.get(), 0.2)
+    assert old.token.provider_generation == 7
+
+    await managed.provider_unavailable()
+    await managed.provider_available(8)
+    old_gate.set()
+
+    assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.DRAINED
+    assert lane.effects[-1].token.provider_generation == 8
+    assert not (await managed.snapshot()).state.release_required
+
+
+@pytest.mark.asyncio
+async def test_termination_during_initial_release_skips_retirement() -> None:
+    managed, _, _, _, _, lane = authority(generation=7)
+    release_gate = lane.block_next()
+    termination = asyncio.Event()
+    retired: list[int] = []
+    shutdown = asyncio.create_task(
+        managed.shutdown(
+            retire_provider=lambda generation: _append_async(retired, generation),
+            termination=termination,
+        )
+    )
+    await asyncio.wait_for(lane.started.get(), 0.2)
+    termination.set()
+
+    try:
+        result = await asyncio.wait_for(asyncio.shield(shutdown), 0.2)
+    finally:
+        release_gate.set()
+        if not shutdown.done():
+            await shutdown
+
+    assert result is ShutdownResult.TERMINATED
+    assert retired == []
+    assert (await managed.snapshot()).state.release_required
+    assert managed._scheduler_task.done()
+
+
+@pytest.mark.asyncio
+async def test_termination_poisons_a_concurrent_arrival_settlement() -> None:
+    managed, _, _, _, _, lane = authority(generation=7)
+    lane.results.append(ActuationResult.REJECTED)
+    termination = asyncio.Event()
+    retired: list[int] = []
+    shutdown = asyncio.create_task(
+        managed.shutdown(
+            retire_provider=lambda generation: _append_async(retired, generation),
+            termination=termination,
+        )
+    )
+    await asyncio.wait_for(lane.started.get(), 0.2)
+    while managed._retry_due is None:
+        await asyncio.sleep(0)
+
+    await managed.provider_unavailable()
+    arrival_gate = lane.block_next()
+    arrival = asyncio.create_task(managed.provider_available(8))
+    current_release = await asyncio.wait_for(lane.started.get(), 0.2)
+    assert current_release.token.provider_generation == 8
+    termination.set()
+
+    assert await asyncio.wait_for(shutdown, 0.2) is ShutdownResult.TERMINATED
+    before = await managed.snapshot()
+    assert before.state.release_required and retired == []
+    assert managed._scheduler_task.done()
+    arrival_gate.set()
+    await arrival
+    assert await managed.snapshot() == before
+    with pytest.raises(RuntimeError, match="clean RX state"):
+        await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_retirement_failure_does_not_close_authority() -> None:
+    managed, _, _, _, _, _ = authority(generation=7)
+    failure = RuntimeError("retirement failed")
+
+    async def fail_retirement(_generation: int) -> None:
+        raise failure
+
+    with pytest.raises(RuntimeError, match="retirement failed") as raised:
+        await managed.shutdown(
+            retire_provider=fail_retirement, termination=asyncio.Event()
+        )
+    assert raised.value is failure
+    assert not managed._scheduler_task.done()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_shielded_idempotent_and_blocks_new_ingress() -> None:
+    managed, _, _, _, _, lane = authority(generation=7)
+    gate = lane.block_next()
+    retired: list[int] = []
+    termination = asyncio.Event()
+
+    async def retire(generation: int) -> None:
+        retired.append(generation)
+
+    first = asyncio.create_task(
+        managed.shutdown(retire_provider=retire, termination=termination)
+    )
+    await asyncio.wait_for(lane.started.get(), 0.2)
+    first.cancel()
+    await asyncio.gather(first, return_exceptions=True)
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        await managed.ptt_down("owner")
+    second = asyncio.create_task(
+        managed.shutdown(retire_provider=retire, termination=termination)
+    )
+    gate.set()
+
+    assert await asyncio.wait_for(second, 0.2) is ShutdownResult.DRAINED
+    assert retired == [7]
+
+
+async def _append_async(values: list[int], value: int) -> None:
+    values.append(value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- split provider lifecycle into explicit unavailable/available transitions with monotonic generations
- preserve and immediately service managed ForceOff/release debt on a replacement without replaying ON
- ignore stale generation/epoch settlements through the existing reducer and effect lane
- drain REJECTED/UNCERTAIN release retries during shutdown, retire the provider only after current-generation acceptance, then perform clean disposal
- return `TERMINATED` without retiring or clearing debt when the external runtime termination boundary wins, including during the initial in-flight release

This remains a provider-neutral, uncomposed authority slice. It adds no Web/backend wiring, provider registry, watchdog, scheduler, reducer, or second truth owner.

## Recovery and RED/GREEN evidence

The saved dirty worktree was recovered after a Codex crash. The path, branch, and two-file scope matched; local session history established that the saved `466 additions / 34 deletions` and 36-test state was the deliberate post-deduplication state rather than a truncated write. The branch was then fast-forwarded from `41ba8dff` to current `origin/main` `0cf53082` through a scoped stash; upstream changes touched other files and the two-file diff restored without conflict.

Self-review found one uncovered termination race. Before the fix, a gated initial shutdown release ignored termination, eventually reported `DRAINED`, and retired generation 7. The new regression failed with a timeout before the implementation change and passes after shutdown begins observing the drain boundary concurrently with that first release.

## Verification

- `PYTHONASYNCIODEBUG=1 uv run --frozen pytest tests/test_managed_tx_authority.py -q -W error --tb=short` — 37 passed
- managed TX state/config/fence/effect-lane/authority suite with asyncio debug and warnings-as-errors — 135 passed
- 25 repeated focused authority race runs — passed
- `uv run --frozen pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread` — 14,498 passed, 281 skipped, 16 xfailed
- `uv run --frozen ruff check src/ tests/` — passed
- `uv run --frozen ruff format --check src/ tests/` — 717 files already formatted
- strict mypy for the changed runtime module and the configured Web gate — passed
- import-linter — 5 contracts kept, 0 broken
- state-type generation check and consumer contracts — passed
- doc citation/link/dangling growth gates and rebrand gate — passed
- `git diff --check` — passed

## Scope

Exactly 2 files, 545 changed lines (`511 additions / 34 deletions`). This is 45 lines above the Linear target range because the final self-review added the missing initial-release termination race and its bounded task cleanup; it remains below the repository's 600-line soft threshold and far below the hard ceiling.

Linear: https://linear.app/morozsm/issue/MOR-2197/mor-21666-prove-provider-replacement-epoch-debt-and-shutdown-drain
