### PR TITLE
fix(MOR-2171): remove observed RF admission for safe controls

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -127,14 +127,16 @@ The current stable family identifiers and their fixed base dispositions are:
 | Base disposition | Family identifiers |
 |------------------|--------------------|
 | `always-pass` | `ptt-off`, `power-off`, `scan-stop`, `tuner-off` |
-| `tx-safe` | `power-on`, `frequency`, `rit-xit` |
+| `tx-safe` | `power-on`, `frequency`, `mode`, `band`, `vfo-select`, `vfo-contents`, `rit-xit` |
 | `block` | `ptt-on`, `raw-civ`, `scan-start`, `antenna-switch`, `tuner-engage` |
-| `defer` | `mode`, `band`, `vfo-select`, `vfo-topology`, `memory` |
+| `defer` | `vfo-topology`, `memory` |
 
 Only a known family whose fixed base disposition is `tx-safe` may appear in
-`disposition_overrides`, and its value must be `"defer"`. This is a one-way
-tightening: it causes a TX-SAFE family to use the existing deferred handling;
-it cannot create a new disposition or override any other base disposition.
+`disposition_overrides`, and its value must be `"defer"`. For `power-on` and
+`rit-xit`, this is a one-way tightening that uses the existing deferred
+handling. Overrides for `frequency`, `mode`, `band`, `vfo-select`, and
+`vfo-contents` are accepted as input but ignored: observed RF state cannot own
+admission for those authority-approved families.
 
 Structural `always-pass` families and hard `block` families are
 non-negotiable. A profile must not list them, alter them, or make them less

--- a/src/rigplane/core/tx_interlock_contract.py
+++ b/src/rigplane/core/tx_interlock_contract.py
@@ -37,6 +37,7 @@ class TxInterlockCommandFamily(StrEnum):
     MODE = "mode"
     BAND = "band"
     VFO_SELECT = "vfo-select"
+    VFO_CONTENTS = "vfo-contents"
     VFO_TOPOLOGY = "vfo-topology"
     MEMORY = "memory"
     RIT_XIT = "rit-xit"
@@ -85,13 +86,16 @@ TX_INTERLOCK_COMMAND_FAMILY_METADATA = (
         TxInterlockCommandFamily.FREQUENCY, TxInterlockDisposition.TX_SAFE
     ),
     TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.MODE, TxInterlockDisposition.DEFER
+        TxInterlockCommandFamily.MODE, TxInterlockDisposition.TX_SAFE
     ),
     TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.BAND, TxInterlockDisposition.DEFER
+        TxInterlockCommandFamily.BAND, TxInterlockDisposition.TX_SAFE
     ),
     TxInterlockCommandFamilyMetadata(
-        TxInterlockCommandFamily.VFO_SELECT, TxInterlockDisposition.DEFER
+        TxInterlockCommandFamily.VFO_SELECT, TxInterlockDisposition.TX_SAFE
+    ),
+    TxInterlockCommandFamilyMetadata(
+        TxInterlockCommandFamily.VFO_CONTENTS, TxInterlockDisposition.TX_SAFE
     ),
     TxInterlockCommandFamilyMetadata(
         TxInterlockCommandFamily.VFO_TOPOLOGY, TxInterlockDisposition.DEFER

--- a/src/rigplane/runtime/tx_interlock.py
+++ b/src/rigplane/runtime/tx_interlock.py
@@ -255,16 +255,6 @@ class DeferredTxCommandLane:
 _ALWAYS_PASS_TYPES = (PttOff, ScanStop)
 
 _DEFER_TYPES = (
-    # MOR-1940: FREQUENCY and RIT_XIT were removed (both bench radios accept
-    # and apply these writes while keyed; ADR
-    # docs/plans/2026-08-20-transmit-authority.md S3.3 groups them as
-    # manufacturer-permitted). They fall through to the TX_SAFE default
-    # below. MODE, BAND, VFO_SELECT, VFO_TOPOLOGY and MEMORY are untouched.
-    SetMode,
-    SetBand,
-    SelectVfo,
-    VfoSwap,
-    VfoEqualize,
     SetSplit,
     SetDualWatch,
     SetMainSubTracking,
@@ -274,6 +264,16 @@ _DEFER_TYPES = (
     QuickSplitTrigger,
     SetMemoryMode,
     MemoryToVfo,
+)
+
+_OBSERVED_RF_ADMISSION_FREE_FAMILIES = frozenset(
+    {
+        TxInterlockCommandFamily.FREQUENCY,
+        TxInterlockCommandFamily.MODE,
+        TxInterlockCommandFamily.BAND,
+        TxInterlockCommandFamily.VFO_SELECT,
+        TxInterlockCommandFamily.VFO_CONTENTS,
+    }
 )
 
 _HARD_BLOCK_TYPES = (
@@ -329,11 +329,11 @@ def get_tx_interlock_command_family_metadata(
         family = TxInterlockCommandFamily.BAND
     elif isinstance(command, SelectVfo):
         family = TxInterlockCommandFamily.VFO_SELECT
+    elif isinstance(command, (VfoSwap, VfoEqualize)):
+        family = TxInterlockCommandFamily.VFO_CONTENTS
     elif isinstance(
         command,
         (
-            VfoSwap,
-            VfoEqualize,
             SetSplit,
             SetDualWatch,
             SetMainSubTracking,
@@ -395,6 +395,8 @@ def _effective_tx_interlock_disposition(
             raise ValueError("invalid or loosening TX interlock override")
     metadata = get_tx_interlock_command_family_metadata(command)
     if metadata is None:
+        return base
+    if metadata.family in _OBSERVED_RF_ADMISSION_FREE_FAMILIES:
         return base
     return disposition_overrides.get(metadata.family, base)
 

--- a/tests/integration/test_rigctld_audio_pipeline.py
+++ b/tests/integration/test_rigctld_audio_pipeline.py
@@ -70,6 +70,7 @@ class RecordingLanRadio(IcomRadio):
         self._mode: str = "USB"
         self._filter_width: int | None = None
         self._data_mode: int | bool = False
+        self._split = False
         self._ptt = False
 
     def fake_connect_audio(self, transport: _RecordingAudioTransport) -> None:
@@ -109,6 +110,10 @@ class RecordingLanRadio(IcomRadio):
 
     async def get_data_mode(self) -> bool:
         return bool(self._data_mode)
+
+    async def set_split(self, on: bool) -> None:
+        self.calls.append(("set_split", (on,)))
+        self._split = on
 
     async def set_data1_mod_input(self, source: int) -> None:
         self.calls.append(("set_data1_mod_input", (source,)))
@@ -247,7 +252,7 @@ async def rigctld_audio_setup() -> AsyncGenerator[
         radio._connected = False
 
 
-async def test_defer_write_is_dropped_while_the_radio_transmits(
+async def test_defer_split_is_dropped_while_the_radio_transmits(
     rigctld_audio_setup: tuple[
         RecordingLanRadio,
         RigctldServer,
@@ -256,7 +261,7 @@ async def test_defer_write_is_dropped_while_the_radio_transmits(
         _RecordingAudioTransport,
     ],
 ) -> None:
-    """The PTT re-read reports TX, so the DEFER gate drops a MODE write.
+    """The PTT re-read reports TX, so the DEFER gate drops a split write.
 
     This is the discriminating half of the fixture in
     ``_ptt_reread_fixtures.py``: it can only reach the ``rf_state is TX``
@@ -280,23 +285,21 @@ async def test_defer_write_is_dropped_while_the_radio_transmits(
         # The key state reaches the gate only via the next re-read tick.
         await wait_for_rf_state(server, tx_interlock.RfState.TX)
 
-        def mode_writes() -> list[tuple[str, tuple[Any, ...]]]:
-            return [
-                call for call in radio.calls if call[0] in ("set_mode", "set_data_mode")
-            ]
+        def split_writes() -> list[tuple[str, tuple[Any, ...]]]:
+            return [call for call in radio.calls if call[0] == "set_split"]
 
-        dropped_from = mode_writes()
-        assert await client.send("M PKTUSB") == "RPRT 0"
-        assert mode_writes() == dropped_from
+        dropped_from = split_writes()
+        assert await client.send("S 1 VFOA") == "RPRT 0"
+        assert split_writes() == dropped_from
 
         assert await client.send("T 0") == "RPRT 0"
         await wait_for_rf_state(server, tx_interlock.RfState.RX)
 
         # Same command, same client, RX now — it reaches the radio, so the
         # drop above was the TX branch and not a fixture that never writes.
-        assert await client.send("M PKTUSB") == "RPRT 0"
-        assert mode_writes() != dropped_from
-        assert ("set_mode", ("USB", None, 0)) in radio.calls
+        assert await client.send("S 1 VFOA") == "RPRT 0"
+        assert split_writes() != dropped_from
+        assert ("set_split", (True,)) in radio.calls
     finally:
         await client.close()
 
@@ -317,9 +320,6 @@ async def test_rigctld_wsjtx_replay_drives_data2_lan_tx_audio_pipeline(
 
     client = await _make_client(server)
     try:
-        # ``M`` (SET MODE) is DEFER-classified; wait out the same startup
-        # window a real hamlib client would (see _ptt_reread_fixtures.py)
-        # before the gate can know the radio is not transmitting.
         await wait_for_known_rf_state(server)
         assert await client.send("M PKTUSB") == "RPRT 0"
         assert await client.send("T 1") == "RPRT 0"

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -24,10 +24,14 @@ from rigplane.runtime._poller_types import (
     SelectVfo,
     SendCiv,
     SetAntenna1,
+    SetBand,
     SetFreq,
     SetMode,
     SetPowerstat,
+    SetSplit,
     SetTunerStatus,
+    VfoEqualize,
+    VfoSwap,
 )
 from rigplane.runtime.tx_interlock import (
     RfState,
@@ -46,11 +50,7 @@ from rigplane.web.radio_poller import (
 
 
 _PTT = FieldPath.global_("tx_state", "ptt")
-# MOR-1940: still-DEFER exemplar for the deferred-lane mechanics below
-# (FREQUENCY was reclassified TX_SAFE -- see
-# test_frequency_now_dispatches_without_entering_the_deferred_lane, which
-# pins that contrast directly).
-_MODE = FieldPath.active("main", "freq_mode", "mode")
+_SPLIT = FieldPath.global_("tx_state", "split")
 
 
 def _radio() -> SimpleNamespace:
@@ -63,6 +63,7 @@ def _radio() -> SimpleNamespace:
         set_antenna_1=AsyncMock(),
         set_freq=AsyncMock(),
         set_mode=AsyncMock(),
+        set_split=AsyncMock(),
         set_tuner_status=AsyncMock(),
         set_powerstat=AsyncMock(),
         set_ptt=AsyncMock(),
@@ -105,22 +106,22 @@ async def _lifecycle_entry(
     service: CommandService,
     *,
     command_id: str,
-    mode: str,
+    on: bool,
 ) -> CommandQueueEntry:
     await service.execute(
         CommandIntent(
             id=command_id,
-            name="set_mode",
-            params={"mode": mode, "session_id": "ws-a"},
+            name="set_split",
+            params={"split": on, "session_id": "ws-a"},
             source="websocket",
-            target=_MODE,
+            target=_SPLIT,
             timeout=3.0,
             pending_policy="scoped",
-            expected_observations=(_MODE,),
+            expected_observations=(_SPLIT,),
         )
     )
     return CommandQueueEntry(
-        SetMode(mode),
+        SetSplit(on),
         future=asyncio.get_running_loop().create_future(),
         command_id=command_id,
         source="websocket",
@@ -226,11 +227,11 @@ async def test_deferred_entry_releases_once_with_its_original_future() -> None:
     poller = RadioPoller(radio, queue, state_store=store)
     _observe_ptt(store, True, observed_at=clock.now())
     future = asyncio.get_running_loop().create_future()
-    entry = CommandQueueEntry(SetMode("USB"), future=future)
+    entry = CommandQueueEntry(SetSplit(True), future=future)
 
     assert poller._stage_tx_interlocked_entries([entry]) == []  # noqa: SLF001
     assert future.done() is False
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
     clock.advance(0.1)
     _observe_ptt(store, False, observed_at=clock.now())
@@ -244,9 +245,9 @@ async def test_deferred_entry_releases_once_with_its_original_future() -> None:
 
     await poller._execute_queued_entry(entry)  # noqa: SLF001
     assert future.result() is None
-    radio.set_mode.assert_awaited_once_with("USB", None)
+    radio.set_split.assert_awaited_once_with(True)
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
-    radio.set_mode.assert_awaited_once()
+    radio.set_split.assert_awaited_once()
 
 
 async def test_supersession_keeps_deadline_and_expiry_wins_over_release() -> None:
@@ -256,22 +257,22 @@ async def test_supersession_keeps_deadline_and_expiry_wins_over_release() -> Non
     poller = RadioPoller(radio, queue, state_store=store)
     _observe_ptt(store, True, observed_at=clock.now())
     old_future = asyncio.get_running_loop().create_future()
-    old = CommandQueueEntry(SetMode("LSB"), future=old_future)
+    old = CommandQueueEntry(SetSplit(False), future=old_future)
     assert poller._stage_tx_interlocked_entries([old]) == []  # noqa: SLF001
 
     clock.advance(2.5)
     _observe_ptt(store, False, observed_at=clock.now())
     new_future = asyncio.get_running_loop().create_future()
-    new = CommandQueueEntry(SetMode("USB"), future=new_future)
+    new = CommandQueueEntry(SetSplit(True), future=new_future)
     assert poller._stage_tx_interlocked_entries([new]) == []  # noqa: SLF001
     assert "superseded" in str(old_future.exception())
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
     clock.advance(0.5)
     _observe_ptt(store, False, observed_at=clock.now())
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     assert "expired" in str(new_future.exception())
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
 async def test_unknown_deferred_command_fails_closed_without_entering_lane() -> None:
@@ -280,7 +281,7 @@ async def test_unknown_deferred_command_fails_closed_without_entering_lane() -> 
     store.begin_provider_generation()
     poller = RadioPoller(radio, CommandQueue(), state_store=store)
     service = _service(clock, store)
-    entry = await _lifecycle_entry(service, command_id="unknown", mode="USB")
+    entry = await _lifecycle_entry(service, command_id="unknown", on=True)
     before = service.lifecycle_events()
 
     assert poller._stage_tx_interlocked_entries([entry]) == [entry]  # noqa: SLF001
@@ -289,29 +290,42 @@ async def test_unknown_deferred_command_fails_closed_without_entering_lane() -> 
 
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     assert service.lifecycle_events() == before
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
 async def test_fresh_rx_deferred_class_dispatches_immediately_once() -> None:
     poller, radio, store = _poller()
     _observe_ptt(store, False)
     future = asyncio.get_running_loop().create_future()
-    entry = CommandQueueEntry(SetMode("USB"), future=future)
+    entry = CommandQueueEntry(SetSplit(True), future=future)
 
     assert poller._stage_tx_interlocked_entries([entry]) == [entry]  # noqa: SLF001
     await poller._execute_queued_entry(entry)  # noqa: SLF001
 
     assert future.result() is None
-    radio.set_mode.assert_awaited_once_with("USB", None)
+    radio.set_split.assert_awaited_once_with(True)
 
 
-async def test_frequency_now_dispatches_without_entering_the_deferred_lane() -> None:
-    """MOR-1940: the exact contrast to the tests above. FREQUENCY was
-    reclassified DEFER -> tx-safe at this seat too (both bench radios accept
-    and apply it while keyed), so it no longer enters
-    ``_stage_tx_interlocked_entries`` at all -- not even under known TX --
-    unlike MODE (still DEFER) above.
-    """
+def test_authority_approved_commands_do_not_inspect_observed_rf() -> None:
+    commands = [
+        CommandQueueEntry(SetFreq(14_074_000)),
+        CommandQueueEntry(SetMode("USB")),
+        CommandQueueEntry(SetBand(5)),
+        CommandQueueEntry(SelectVfo("A")),
+        CommandQueueEntry(VfoSwap()),
+        CommandQueueEntry(VfoEqualize()),
+    ]
+    poller, _radio, _store = _poller()
+    poller._current_rf_state = lambda *_: pytest.fail(  # type: ignore[method-assign] # noqa: SLF001
+        "observed RF was inspected"
+    )
+
+    for entry in commands:
+        poller._enforce_tx_interlock(entry.command)  # type: ignore[arg-type] # noqa: SLF001
+    assert poller._stage_tx_interlocked_entries(commands) == commands  # noqa: SLF001
+
+
+async def test_frequency_dispatches_without_entering_the_deferred_lane() -> None:
     clock = FreshnessClock(start=10.0)
     radio, store, queue = _radio(), StateStore(freshness_clock=clock), CommandQueue()
     store.begin_provider_generation()
@@ -335,7 +349,7 @@ async def test_deferred_hold_lifecycle_is_single_and_release_stays_unconfirmed()
     store.begin_provider_generation()
     poller = RadioPoller(radio, CommandQueue(), state_store=store)
     service = _service(clock, store)
-    entry = await _lifecycle_entry(service, command_id="held", mode="USB")
+    entry = await _lifecycle_entry(service, command_id="held", on=True)
     _observe_ptt(store, True, observed_at=clock.now())
 
     assert poller._stage_tx_interlocked_entries([entry]) == []  # noqa: SLF001
@@ -344,7 +358,7 @@ async def test_deferred_hold_lifecycle_is_single_and_release_stays_unconfirmed()
         "held",
         "queued",
         "websocket",
-        _MODE,
+        _SPLIT,
     )
     assert held.details == {
         "heldBy": "tx_interlock",
@@ -365,7 +379,7 @@ async def test_deferred_hold_lifecycle_is_single_and_release_stays_unconfirmed()
 
     assert service.lifecycle_events()[-1] is held
     assert service.pending_overlays(source="websocket", session_id="ws-a")
-    radio.set_mode.assert_awaited_once_with("USB", None)
+    radio.set_split.assert_awaited_once_with(True)
 
 
 async def test_deferred_replacement_and_expiry_emit_ordered_terminal_truth() -> None:
@@ -374,12 +388,12 @@ async def test_deferred_replacement_and_expiry_emit_ordered_terminal_truth() -> 
     store.begin_provider_generation()
     poller = RadioPoller(radio, CommandQueue(), state_store=store)
     service = _service(clock, store)
-    first = await _lifecycle_entry(service, command_id="first", mode="LSB")
+    first = await _lifecycle_entry(service, command_id="first", on=False)
     _observe_ptt(store, True, observed_at=clock.now())
     assert poller._stage_tx_interlocked_entries([first]) == []  # noqa: SLF001
 
     clock.advance(2.5)
-    replacement = await _lifecycle_entry(service, command_id="replacement", mode="USB")
+    replacement = await _lifecycle_entry(service, command_id="replacement", on=True)
     _observe_ptt(store, True, observed_at=clock.now())
     snapshots: list[tuple[str, str, tuple[str, ...]]] = []
     service.subscribe_lifecycle(
@@ -419,7 +433,7 @@ async def test_deferred_replacement_and_expiry_emit_ordered_terminal_truth() -> 
     terminal_count = len(service.lifecycle_events())
     assert poller._stage_tx_interlocked_entries([]) == []  # noqa: SLF001
     assert len(service.lifecycle_events()) == terminal_count
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
 # ── MOR-1884 (MOR-1500 B1-e): the seat guards _execute itself ────────────────
@@ -431,36 +445,25 @@ async def test_direct_defer_family_emit_is_refused_at_the_execute_seat(
 ) -> None:
     """An uncommanded internal emit shares the queued commands' seat."""
     poller, radio, store = _poller()
-    radio.set_vfo_slot = AsyncMock()
     if ptt is not None:
         _observe_ptt(store, ptt)
 
     with pytest.raises(CommandError, match="RF state is (unknown|TX)"):
-        await poller._execute(SelectVfo(vfo="A"))  # noqa: SLF001
+        await poller._execute(SetSplit(on=True))  # noqa: SLF001
 
-    radio.set_vfo_slot.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
-async def test_bootstrap_exemption_passes_the_seat_under_unknown_rf() -> None:
-    """At connection start RF is structurally UNKNOWN; the one exempted write
-    must reach the dispatch body instead of being refused (MOR-1443).
-
-    Discriminated by WHICH failure it hits: the same command without the
-    exemption never leaves the seat ("RF state is unknown"), while the
-    exempted one gets all the way into the SelectVfo dispatch and fails on
-    that command's own readback contract — proof it passed the interlock.
-    """
-    poller, _radio, _store = _poller()
-
-    with pytest.raises(CommandError, match="RF state is unknown"):
-        await poller._execute(SelectVfo(vfo="A"))  # noqa: SLF001
-
-    with pytest.raises(CommandError) as exempted:
-        await poller._execute(  # noqa: SLF001
-            SelectVfo(vfo="A"), connection_epoch_bootstrap=True
-        )
-    assert "RF state" not in str(exempted.value)
-    assert "VFO selection" in str(exempted.value)
+async def test_vfo_selection_is_not_observed_rf_gated_at_bootstrap() -> None:
+    for connection_epoch_bootstrap in (False, True):
+        poller, _radio, _store = _poller()
+        with pytest.raises(CommandError) as dispatched:
+            await poller._execute(  # noqa: SLF001
+                SelectVfo(vfo="A"),
+                connection_epoch_bootstrap=connection_epoch_bootstrap,
+            )
+        assert "RF state" not in str(dispatched.value)
+        assert "VFO selection" in str(dispatched.value)
 
 
 def test_bootstrap_exemption_has_exactly_one_production_call_site() -> None:

--- a/tests/test_rigctld_ptt_reread.py
+++ b/tests/test_rigctld_ptt_reread.py
@@ -4,10 +4,10 @@
 Standalone ``rigplane serve`` had no cadence poller at all: ``due_requests()``
 is called only by the web radio poller, so nothing ever sent a ``0x1C/0x00``
 read after connect, the strict resolver behind the MOR-1881 DEFER gate stayed
-UNKNOWN forever, and every frequency, mode, VFO and key-down command was
-refused with ``RPRT -9``. These tests pin the missing *request*, never new
-data: the value that clears the gate may only arrive through the existing CI-V
-ingress, from a real radio reply (MOR-1900).
+UNKNOWN forever, and every split and key-down command was refused with
+``RPRT -9``. These tests pin the missing *request*, never new data: the value
+that clears the gate may only arrive through the existing CI-V ingress, from a
+real radio reply (MOR-1900).
 """
 
 from __future__ import annotations
@@ -160,10 +160,7 @@ async def test_writes_succeed_after_the_radio_answers_the_reread(model: str) -> 
     server._client_count = 1  # noqa: SLF001
     server._start_ptt_reread_task()  # noqa: SLF001
     try:
-        # ``F`` is excluded here: MOR-1940 reclassified FREQUENCY as
-        # TX-SAFE, so it is never gated by the re-read and would already
-        # succeed before the radio has answered at all.
-        for wire in (b"M USB 2400", b"V VFOB", b"T 1"):
+        for wire in (b"S 1 VFOA", b"T 1"):
             refused = await handler.execute(parse_line(wire), session_id="s1")
             assert refused.error is not None and int(refused.error) == -9, wire
 
@@ -173,13 +170,12 @@ async def test_writes_succeed_after_the_radio_answers_the_reread(model: str) -> 
         await _deliver(radio, _ptt_reply(radio, transmitting=False))
         assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.RX  # noqa: SLF001
 
-        # ``V`` on a dual-RX rig (IC-9700) needs an ACK the stub cannot give:
-        # pin only that the interlock stopped refusing, and run it last — its
-        # ~1s stall would age the observation past its TTL for the next wire.
-        for wire in (b"F 14074000", b"M USB 2400", b"T 1", b"V VFOB"):
+        # Run split last: the stub cannot ACK it, so the write may time out
+        # after proving that the interlock no longer rejects it.
+        for wire in (b"T 1", b"S 1 VFOA"):
             got = await handler.execute(parse_line(wire), session_id="s1")
             code = 0 if got.error is None else int(got.error)
-            assert code == 0 or (wire == b"V VFOB" and code != -9), (wire, got)
+            assert code != -9, (wire, got)
     finally:
         handler.stop_key_down_backstop()
         await server._stop_ptt_reread_task()  # noqa: SLF001
@@ -209,10 +205,7 @@ async def test_unanswered_reread_never_produces_rf_truth(
             store.snapshot().field(_PTT_PATH)
         assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.UNKNOWN  # noqa: SLF001
 
-        # ``F`` is excluded here: MOR-1940 reclassified FREQUENCY as
-        # TX-SAFE, so an unresolved re-read never gates it in the first
-        # place.
-        for wire in (b"M USB 2400", b"V VFOB", b"T 1"):
+        for wire in (b"S 1 VFOA", b"T 1"):
             refused = await handler.execute(parse_line(wire), session_id="s1")
             assert refused.error is not None and int(refused.error) == -9, wire
     finally:
@@ -262,16 +255,13 @@ async def test_started_server_drives_reads_only_while_a_client_is_connected(
             await asyncio.sleep(PTT_REREAD_INTERVAL_SECONDS * 6.0)
             assert len(_ptt_read_calls(send_civ)) >= 2
 
-            # Unanswered so far: the seat is still fail-closed on the wire.
-            # ``M`` (mode), not ``F``: MOR-1940 reclassified FREQUENCY as
-            # TX-SAFE, so it would already succeed before any answer and
-            # could no longer demonstrate the fail-closed-then-clears shape.
-            writer.write(b"M USB 2400\n")
+            # Unanswered so far: key-down remains fail-closed on the wire.
+            writer.write(b"T 1\n")
             await writer.drain()
             assert await reader.readline() == b"RPRT -9\n"
 
             await _deliver(civ_radio, _ptt_reply(civ_radio, transmitting=False))
-            writer.write(b"M USB 2400\n")
+            writer.write(b"T 1\n")
             await writer.drain()
             assert await reader.readline() == b"RPRT 0\n"
         finally:
@@ -293,7 +283,7 @@ async def test_client_connecting_at_server_start_gets_known_state_before_first_w
     -- worst case, right after start, a full ``PTT_REREAD_INTERVAL_SECONDS``
     from the next scheduled tick -- left RF truth UNKNOWN for that whole
     window pre-fix, so a client that writes soon after connecting (as
-    WSJT-X's "Test CAT" does) got its first DEFER-classified write refused
+    WSJT-X's "Test CAT" does) got its first RF-gated write refused
     with ``RPRT -9``. Six connect-and-immediately-write runs on real
     hardware hit this in 2/6: first refusal ~0.06s after connect, first
     success only at ~0.26-0.277s -- essentially one whole tick later.
@@ -322,10 +312,7 @@ async def test_client_connecting_at_server_start_gets_known_state_before_first_w
         reader, writer = await asyncio.open_connection("127.0.0.1", port)
         try:
             await asyncio.sleep(0.01)
-            # ``M`` (mode), not ``F``: MOR-1940 reclassified FREQUENCY as
-            # TX-SAFE, so it would already succeed before any answer and
-            # could not demonstrate this race.
-            writer.write(b"M USB 2400\n")
+            writer.write(b"T 1\n")
             await writer.drain()
             response = await asyncio.wait_for(
                 reader.readline(), timeout=PTT_REREAD_INTERVAL_SECONDS * 0.5

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -391,8 +391,7 @@ async def server_serial_radio(
     await radio.connect()
     srv = RigctldServer(radio, cfg)
     await srv.start()
-    # MOR-1881: DEFER-classified rigctld writes (F/M/V/S/RIT/XIT) now fail
-    # closed on unknown RF state instead of executing unconditionally. This
+    # DEFER-classified split writes fail closed on unknown RF state. This
     # bootstrapped fallback StateStore never observes a real PTT sample, so
     # seed a known-RX one (a huge max_age so it never ages out against the
     # real monotonic clock) to keep the TX interlock out of these tests'
@@ -1417,18 +1416,12 @@ async def test_deferred_write_and_unkey_both_answer_immediately_on_one_connectio
     """MOR-1881: the exact regression the rejected deferred-lane design
     failed at (PR #2755).
 
-    One connection, ``M <mode>`` then ``T 0``, PTT seeded known TX. The lane
-    build held the mode command in-band and answered the unkey at +2.003s.
+    One connection, ``S <split>`` then ``T 0``, PTT seeded known TX. The lane
+    build held the split command in-band and answered the unkey at +2.003s.
     This seat now never holds anything in-band for a DEFER-classified write
     -- known TX is dropped immediately (``RPRT 0``, radio untouched) -- so
-    both replies must land essentially instantly, and the mode write must
+    both replies must land essentially instantly, and the split write must
     never have reached the radio.
-
-    MOR-1940: uses ``M`` (mode), not ``F`` (frequency) -- frequency was
-    reclassified tx-safe and no longer drops during TX (both bench radios
-    accept and apply it while keyed). This test is about the drop's shape,
-    not about which family triggers it, so the exemplar moved; the property
-    it pins is unchanged.
     """
     radio = SerialMockRadio()
     await radio.connect()
@@ -1440,13 +1433,13 @@ async def test_deferred_write_and_unkey_both_answer_immediately_on_one_connectio
     try:
         reader, writer = await _connect(srv)
         try:
-            mode_before = await radio.get_mode()
+            split_before = radio._split  # noqa: SLF001
 
             start = time.monotonic()
-            writer.write(b"M LSB 2400\n")
+            writer.write(b"S 1 VFOA\n")
             await writer.drain()
-            data_mode = await asyncio.wait_for(reader.read(4096), timeout=1.0)
-            elapsed_mode = time.monotonic() - start
+            data_split = await asyncio.wait_for(reader.read(4096), timeout=1.0)
+            elapsed_split = time.monotonic() - start
 
             start_ptt = time.monotonic()
             writer.write(b"T 0\n")
@@ -1458,13 +1451,11 @@ async def test_deferred_write_and_unkey_both_answer_immediately_on_one_connectio
     finally:
         await srv.stop()
 
-    assert data_mode == b"RPRT 0\n"
-    assert elapsed_mode < 0.1
+    assert data_split == b"RPRT 0\n"
+    assert elapsed_split < 0.1
     assert data_ptt == b"RPRT 0\n"
     assert elapsed_ptt < 0.1
-    # The write was dropped, not applied: SerialMockRadio's mode is unchanged
-    # from before the request, not the LSB/2400 that was requested.
-    assert await radio.get_mode() == mode_before
+    assert radio._split is split_before  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rigctld_tx_interlock.py
+++ b/tests/test_rigctld_tx_interlock.py
@@ -39,18 +39,19 @@ def _intent(name: str, **params: object) -> CommandIntent:
 
 
 def test_material_intents_use_shared_policy() -> None:
-    # MOR-1940: set_freq/set_rit/set_xit moved DEFER -> tx-safe (both bench
-    # radios accept and apply these writes while keyed; ADR
-    # docs/plans/2026-08-20-transmit-authority.md S3.3). set_mode/set_vfo/
-    # set_split_vfo are untouched.
     cases = (
         (_intent("set_freq", freq_hz=1), commands.SetFreq, "tx-safe", "frequency"),
-        (_intent("set_mode", mode="USB"), commands.SetMode, "defer", "mode"),
+        (_intent("set_mode", mode="USB"), commands.SetMode, "tx-safe", "mode"),
         (_intent("set_ptt", ptt=False), commands.PttOff, "always-pass", "ptt-off"),
         (_intent("set_ptt", ptt=True), commands.PttOn, "block", "ptt-on"),
         (_intent("set_rit", hz=50), commands.SetRitFrequency, "tx-safe", "rit-xit"),
         (_intent("set_xit", hz=-50), commands.SetRitFrequency, "tx-safe", "rit-xit"),
-        (_intent("set_vfo", vfo="VFOA"), commands.SelectVfo, "defer", "vfo-select"),
+        (
+            _intent("set_vfo", vfo="VFOA"),
+            commands.SelectVfo,
+            "tx-safe",
+            "vfo-select",
+        ),
         (_intent("set_split_vfo", on=True), commands.SetSplit, "defer", "vfo-topology"),
         (
             _intent("send_raw", frame_bytes=b"\xfe\xfd"),
@@ -283,17 +284,10 @@ async def test_structural_exemptions_never_resolve_rf_truth(
 # stale RF -- never held in-band. See ``RigctldHandler._defer_write_gate``.
 
 
-# MOR-1940: "F" (set_freq) was dropped from this set -- frequency is now
-# tx-safe, not DEFER (see test_frequency_now_dispatches_in_every_rf_state
-# below, which pins the opposite contrast for exactly this wire).
-_DEFER_WIRES = (b"M USB 2400", b"V VFOA", b"S 1 VFOA", b"U SPLIT 1")
+_DEFER_WIRES = (b"S 1 VFOA", b"U SPLIT 1")
 
 
 def _defer_wire_method(radio: AsyncMock, wire: bytes) -> AsyncMock:
-    if wire.startswith(b"M"):
-        return radio.set_mode
-    if wire.startswith(b"V"):
-        return radio.set_vfo
     return radio.set_split  # b"S ..." (set_split_vfo) and b"U SPLIT ..."
 
 
@@ -346,24 +340,34 @@ async def test_defer_writes_are_dropped_silently_during_known_tx(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("case", ["tx", "absent", "stale", "generation"])
-async def test_frequency_now_dispatches_in_every_rf_state(
-    case: str, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("wire", "method", "expected_args"),
+    (
+        (b"F 14074000", "set_freq", (14_074_000,)),
+        (b"M USB 2400", "set_mode", ("USB",)),
+        (b"V VFOA", None, ()),
+    ),
+)
+async def test_authority_approved_writes_dispatch_in_every_rf_state(
+    case: str,
+    monkeypatch: pytest.MonkeyPatch,
+    wire: bytes,
+    method: str | None,
+    expected_args: tuple[object, ...],
 ) -> None:
-    """MOR-1940: the exact contrast to the DEFER wires above. Frequency was
-    reclassified DEFER -> tx-safe (both bench radios accept and apply it
-    while keyed), so ``F`` no longer fails closed under UNKNOWN/stale RF and
-    no longer gets silently dropped during known TX -- it reaches the radio
-    unconditionally, same as a plain TX-SAFE write.
-    """
     store, forced = _store(case)
     handler, radio, _routing = _handler(store)
     if forced is not None:
         monkeypatch.setattr(StateStore, "snapshot", lambda _: forced)
 
-    response = await handler.execute(parse_line(b"F 14074000"))
+    response = await handler.execute(parse_line(wire))
 
     assert response.ok
-    radio.set_freq.assert_awaited_once_with(14_074_000, receiver=0)
+    if method is not None:
+        called = getattr(radio, method)
+        called.assert_awaited_once()
+        assert called.await_args.args == expected_args
+    assert handler._command_service.lifecycle_events()[-1].state == "acknowledged"  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -378,19 +382,16 @@ async def test_dropped_write_leaves_state_store_and_lifecycle_untouched() -> Non
     lifecycle events run INSIDE ``execute``, so a write that never reaches
     ``execute`` cannot produce any of them.
 
-    MOR-1940: uses ``M`` (mode), not ``F`` (frequency) -- frequency is no
-    longer DEFER and no longer drops during TX (see
-    test_frequency_now_dispatches_in_every_rf_state above). This test is
-    about the drop's shape, not about which family triggers it, so the
-    exemplar moved; the property it pins is unchanged.
+    Split remains DEFER, so it continues to pin the drop's shape while
+    band/frequency, mode, and pure VFO commands bypass observed RF state.
     """
     store = _store("tx")[0]
     handler, radio, _routing = _handler(store)
 
-    response = await handler.execute(parse_line(b"M USB 2400"))
+    response = await handler.execute(parse_line(b"S 1 VFOA"))
 
     assert response.ok
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
     assert handler._command_service.lifecycle_events() == ()  # noqa: SLF001
     assert (
         handler._command_service.pending_overlays(  # noqa: SLF001
@@ -399,27 +400,24 @@ async def test_dropped_write_leaves_state_store_and_lifecycle_untouched() -> Non
         == ()
     )
     with pytest.raises(KeyError):
-        store.snapshot().field("receiver.main.active.freq_mode.mode")
+        store.snapshot().field("global.tx_state.split")
 
 
 @pytest.mark.asyncio
 async def test_known_tx_drop_is_logged_once(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """MOR-1940: uses ``M`` (mode), not ``F`` -- see the note on
-    test_dropped_write_leaves_state_store_and_lifecycle_untouched above.
-    """
     caplog.set_level(logging.WARNING, logger="rigplane.rigctld.handler")
     handler, _radio, _routing = _handler(_store("tx")[0])
 
-    response = await handler.execute(parse_line(b"M USB 2400"))
+    response = await handler.execute(parse_line(b"S 1 VFOA"))
 
     assert response.ok
     drop_records = [r for r in caplog.records if "dropped" in r.getMessage()]
     assert len(drop_records) == 1
     assert drop_records[0].levelno == logging.WARNING
     message = drop_records[0].getMessage()
-    assert "set_mode" in message
+    assert "set_split_vfo" in message
     assert "transmitting" in message
 
 
@@ -641,14 +639,13 @@ async def test_success_without_a_lifecycle_record_is_only_the_tx_drop() -> None:
     this property from the other side, because that decision is taken inside
     the executor and does leave an ``acknowledged`` record.
 
-    MOR-1940: the dropped half uses ``M`` (mode), not ``F`` -- frequency no
-    longer drops during TX. The applied/RX half keeps ``F``: an ordinary RX
-    dispatch is unaffected by the reclassification either way.
+    The dropped half uses split, which remains DEFER. The applied half keeps
+    frequency, an authority-approved family that no longer consults RF state.
     """
     dropped_handler, dropped_radio, _ = _handler(_store("tx")[0])
-    dropped = await dropped_handler.execute(parse_line(b"M USB 2400"))
+    dropped = await dropped_handler.execute(parse_line(b"S 1 VFOA"))
     assert dropped.ok
-    dropped_radio.set_mode.assert_not_awaited()
+    dropped_radio.set_split.assert_not_awaited()
     assert dropped_handler._command_service.lifecycle_events() == ()  # noqa: SLF001
 
     applied_handler, applied_radio, _ = _handler(_store("rx")[0])
@@ -732,16 +729,13 @@ async def test_unkey_asks_the_radio_to_re_observe_rf_truth() -> None:
 
 @pytest.mark.asyncio
 async def test_dropped_write_asks_for_nothing() -> None:
-    """A write that never reached the radio changed no field to re-observe.
-
-    MOR-1940: uses ``M`` (mode), not ``F`` -- frequency no longer drops.
-    """
+    """A write that never reached the radio changed no field to re-observe."""
     handler, radio, freshness = _handler_with_freshness(_store("tx")[0])
 
-    response = await handler.execute(parse_line(b"M USB 2400"))
+    response = await handler.execute(parse_line(b"S 1 VFOA"))
 
     assert response.ok
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
     assert freshness.requests == []
 
 
@@ -830,9 +824,8 @@ async def test_ptt_poll_leaves_a_stale_canonical_field_untouched() -> None:
 async def test_ptt_poll_does_not_unlock_a_deferred_write() -> None:
     """Refusal replaces fabrication: a poll cannot create RX truth.
 
-    MOR-1940: uses ``M`` (mode), not ``F`` -- frequency is tx-safe now and no
-    longer fails closed under UNKNOWN, so it can no longer probe this
-    property (the poll not fabricating RX truth for a still-DEFER write).
+    Split remains DEFER and therefore probes that the poll cannot fabricate
+    RX truth.
     """
     store = StateStore()
     handler, radio = _mirror_handler(store)
@@ -842,12 +835,12 @@ async def test_ptt_poll_does_not_unlock_a_deferred_write() -> None:
 
     assert handler._resolve_rigctld_rf_state() is tx_interlock.RfState.UNKNOWN
 
-    command = parse_line(b"M USB 2400")
+    command = parse_line(b"S 1 VFOA")
     response = await handler.execute(command)
 
     assert response.error is HamlibError.ERJCTED
     assert format_response(command, response, ClientSession()) == b"RPRT -9\n"
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tx_authority_characterisation.py
+++ b/tests/test_tx_authority_characterisation.py
@@ -247,12 +247,12 @@ class _AsyncSupervisorFacade:
 class TestPin1RprtZeroDuringConfirmedTx:
     """A write withheld during confirmed TX renders as success on the wire.
 
-    Hamlib's own core answers OK without writing for mode/split during PTT
+    Hamlib's own core answers OK without writing for split during PTT
     (``rig.c``); a non-zero RPRT mid-sequence tears WSJT-X down. That
     *rendering* is what the cutover must preserve.
 
     **Divergence from the ADR, pinned as found.** §3.10 item 6 describes this
-    as "a refusal *by the radio itself* on mode/split renders as success".
+    as "a refusal *by the radio itself* on split renders as success".
     No such seat exists in the tree today. What exists is
     ``RigctldHandler._defer_write_gate`` (``src/rigplane/rigctld/handler.py:770-833``):
     a *policy* drop taken before ``CommandService`` is entered, so the radio
@@ -268,14 +268,14 @@ class TestPin1RprtZeroDuringConfirmedTx:
         # `return _ok()` with `return _err(HamlibError.ERJCTED)`
         # -> this test goes red.
         handler, radio, _routing = _rigctld_handler(_ptt_store(True))
-        command = parse_line(b"M USB 2400")
+        command = parse_line(b"S 1 VFOA")
 
         response = await handler.execute(command)
 
         assert response.ok
         assert response.error == HamlibError.OK
         assert format_response(command, response, ClientSession()) == b"RPRT 0\n"
-        radio.set_mode.assert_not_awaited()
+        radio.set_split.assert_not_awaited()
 
     async def test_unknown_rf_truth_is_not_laundered_into_the_same_success(
         self,
@@ -287,22 +287,22 @@ class TestPin1RprtZeroDuringConfirmedTx:
         self-clearing policy state, so it refuses honestly.
         """
         handler, radio, _routing = _rigctld_handler(_ptt_store(None))
-        command = parse_line(b"M USB 2400")
+        command = parse_line(b"S 1 VFOA")
 
         response = await handler.execute(command)
 
         assert response.error is HamlibError.ERJCTED
         assert format_response(command, response, ClientSession()) == b"RPRT -9\n"
-        radio.set_mode.assert_not_awaited()
+        radio.set_split.assert_not_awaited()
 
     async def test_fresh_rx_still_dispatches_the_write(self) -> None:
         """And the third arm: known RX writes normally."""
         handler, radio, _routing = _rigctld_handler(_ptt_store(False))
 
-        response = await handler.execute(parse_line(b"M USB 2400"))
+        response = await handler.execute(parse_line(b"S 1 VFOA"))
 
         assert response.ok
-        radio.set_mode.assert_awaited_once()
+        radio.set_split.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tx_interlock_policy.py
+++ b/tests/test_tx_interlock_policy.py
@@ -20,6 +20,8 @@ from rigplane.runtime._poller_types import (
     MemoryToVfo,
     PttOff,
     PttOn,
+    QuickSplit,
+    QuickSplitTrigger,
     ScanStart,
     ScanStop,
     SendCiv,
@@ -30,6 +32,7 @@ from rigplane.runtime._poller_types import (
     SetData1ModInput,
     SetDualWatch,
     SetFreq,
+    SetMainSubTracking,
     SetMode,
     SetPowerstat,
     SetRitFrequency,
@@ -131,36 +134,26 @@ def test_hard_block_is_allowed_only_when_rx_is_known() -> None:
     assert evaluate_tx_interlock(PttOn(), rf_state=RfState.TX).allowed is False
 
 
-def test_disruptive_operations_defer() -> None:
-    """MOR-1940: this is also the widening guard -- FREQUENCY and RIT_XIT
-    were removed from this list (see
-    ``test_frequency_and_rit_xit_are_reclassified_tx_safe`` below); MODE,
-    BAND, VFO_SELECT, VFO_TOPOLOGY and MEMORY stay DEFER and must stay
-    pinned here so the reclassification cannot silently widen.
-    """
+def test_unapproved_disruptive_operations_still_defer() -> None:
     for command in (
-        SetMode("USB"),
-        SetBand(4),
-        SelectVfo("MAIN"),
-        VfoSwap(),
-        VfoEqualize(),
         SetSplit(on=True),
         SetDualWatch(on=True),
+        SetMainSubTracking(on=True),
+        QuickSplit(),
+        QuickSplitTrigger(),
         MemoryToVfo(channel=1),
     ):
         assert classify_tx_interlock(command) is TxInterlockDisposition.DEFER
 
 
-def test_frequency_and_rit_xit_are_reclassified_tx_safe() -> None:
-    """MOR-1940: both bench radios accept and apply a frequency write while
-    keyed, and RIT/XIT (bench item B3) closed the same way -- accepted and
-    applied during transmit, confirmed by read-back (ADR
-    docs/plans/2026-08-20-transmit-authority.md S3.3). Neither family may
-    hold a write pending a state change any more: TX_SAFE means the write
-    is sent unconditionally, in every RF state including UNKNOWN.
-    """
+def test_authority_approved_control_families_are_tx_safe_in_every_rf_state() -> None:
     for command in (
         SetFreq(7_100_000),
+        SetMode("USB"),
+        SetBand(4),
+        SelectVfo("MAIN"),
+        VfoSwap(),
+        VfoEqualize(),
         SetRitTxStatus(on=True),
         SetRitFrequency(freq=100),
     ):
@@ -171,8 +164,29 @@ def test_frequency_and_rit_xit_are_reclassified_tx_safe() -> None:
             assert decision.disposition is TxInterlockDisposition.TX_SAFE
 
 
+def test_profile_overrides_cannot_restore_observed_rf_admission() -> None:
+    cases = (
+        (SetFreq(7_100_000), TxInterlockCommandFamily.FREQUENCY),
+        (SetMode("USB"), TxInterlockCommandFamily.MODE),
+        (SetBand(4), TxInterlockCommandFamily.BAND),
+        (SelectVfo("MAIN"), TxInterlockCommandFamily.VFO_SELECT),
+        (VfoSwap(), TxInterlockCommandFamily.VFO_CONTENTS),
+        (VfoEqualize(), TxInterlockCommandFamily.VFO_CONTENTS),
+    )
+    for command, family in cases:
+        overrides = {family: TxInterlockDisposition.DEFER}
+        for rf_state in (RfState.RX, RfState.TX, RfState.UNKNOWN):
+            decision = evaluate_tx_interlock(
+                command,
+                rf_state=rf_state,
+                disposition_overrides=overrides,
+            )
+            assert decision.disposition is TxInterlockDisposition.TX_SAFE
+            assert decision.allowed is True
+
+
 def test_defer_does_not_loosen_when_rf_state_is_unknown() -> None:
-    decision = evaluate_tx_interlock(SetBand(4), rf_state=RfState.UNKNOWN)
+    decision = evaluate_tx_interlock(SetSplit(on=True), rf_state=RfState.UNKNOWN)
 
     assert decision.disposition is TxInterlockDisposition.DEFER
     assert decision.allowed is False
@@ -264,7 +278,8 @@ def test_command_family_metadata_pins_typed_policy_without_classifying_defaults(
         (SetMode("USB"), TxInterlockCommandFamily.MODE),
         (SetBand(4), TxInterlockCommandFamily.BAND),
         (SelectVfo("MAIN"), TxInterlockCommandFamily.VFO_SELECT),
-        (VfoSwap(), TxInterlockCommandFamily.VFO_TOPOLOGY),
+        (VfoSwap(), TxInterlockCommandFamily.VFO_CONTENTS),
+        (VfoEqualize(), TxInterlockCommandFamily.VFO_CONTENTS),
         (SetSplit(on=True), TxInterlockCommandFamily.VFO_TOPOLOGY),
         (MemoryToVfo(channel=1), TxInterlockCommandFamily.MEMORY),
         (SetRitTxStatus(on=True), TxInterlockCommandFamily.RIT_XIT),
@@ -283,7 +298,7 @@ def test_command_family_metadata_pins_typed_policy_without_classifying_defaults(
 
 def test_deferred_lane_holds_then_releases_after_continuous_known_rx() -> None:
     lane = DeferredTxCommandLane()
-    command = SetBand(4)
+    command = SetSplit(on=True)
 
     held = lane.defer(command, now=10.0)
     assert held.outcome is TxInterlockDeferredOutcome.HELD
@@ -353,7 +368,7 @@ def test_deferred_lane_rejects_unbound_forged_decision(command: object) -> None:
 
 def test_deferred_lane_resets_only_quiet_progress_for_unknown_or_renewed_tx() -> None:
     lane = DeferredTxCommandLane()
-    command = SetBand(4)
+    command = SetSplit(on=True)
     lane.defer(command, now=10.0)
 
     lane.observe(rf_state=RfState.RX, now=10.2)
@@ -382,7 +397,7 @@ def test_deferred_lane_resets_only_quiet_progress_for_unknown_or_renewed_tx() ->
 
 def test_deferred_lane_ttl_never_restarts_on_ptt_qsk_transitions() -> None:
     lane = DeferredTxCommandLane()
-    command = SetBand(4)
+    command = SetSplit(on=True)
     lane.defer(command, now=0.0)
 
     lane.observe(rf_state=RfState.TX, now=2.8)
@@ -397,8 +412,8 @@ def test_deferred_lane_ttl_never_restarts_on_ptt_qsk_transitions() -> None:
 
 def test_newer_deferred_command_explicitly_supersedes_the_single_slot() -> None:
     lane = DeferredTxCommandLane()
-    first = SetBand(4)
-    second = SetMode("USB")
+    first = SetSplit(on=True)
+    second = SetSplit(on=False)
     lane.defer(first, now=10.0)
     assert (
         lane.observe(rf_state=RfState.RX, now=10.0).outcome
@@ -428,8 +443,8 @@ def test_newer_deferred_command_explicitly_supersedes_the_single_slot() -> None:
 
 def test_superseding_deferred_command_retains_the_original_deadline() -> None:
     lane = DeferredTxCommandLane()
-    first = SetBand(4)
-    second = SetMode("USB")
+    first = SetSplit(on=True)
+    second = SetSplit(on=False)
     lane.defer(first, now=10.0)
 
     superseded = lane.defer(second, now=12.5)
@@ -454,8 +469,8 @@ def test_superseding_deferred_command_retains_the_original_deadline() -> None:
 
 def test_command_after_expired_entry_starts_a_new_deadline() -> None:
     lane = DeferredTxCommandLane()
-    first = SetBand(4)
-    second = SetMode("USB")
+    first = SetSplit(on=True)
+    second = SetSplit(on=False)
     lane.defer(first, now=10.0)
 
     expired = lane.defer(second, now=13.0)

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -35,8 +35,11 @@ from rigplane.radio_state import RadioState
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import (
     CommandQueue,
+    SelectVfo,
+    SetBand,
     SetFreq,
     SetMode,
+    SetSplit,
     VfoEqualize,
     VfoSwap,
 )
@@ -781,28 +784,25 @@ async def test_yaesu_profile_override_cannot_change_structural_floors(
 async def test_yaesu_deferred_command_supersedes_without_extending_expiry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # MOR-1940: MODE is the DEFER exemplar here -- FREQUENCY was reclassified
-    # tx-safe (see test_yaesu_frequency_now_dispatches_without_entering_the_
-    # deferred_lane below, which pins the opposite contrast for SetFreq).
     clock = [10.0]
     monkeypatch.setattr(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
     )
     radio, queue = make_radio(), CommandQueue()
-    radio.set_mode = AsyncMock()
+    radio.set_split = AsyncMock()
     poller = YaesuCatPoller(radio, command_queue=queue)
     service = MagicMock()
     first = asyncio.get_running_loop().create_future()
     second = asyncio.get_running_loop().create_future()
     queue.put_ordered(
-        SetMode("LSB"),
+        SetSplit(False),
         future=first,
         command_id="first",
         command_service=service,
     )
     await _drain_with_ptt(poller, clock, 10.0, True)
     assert not first.done()
-    queue.put_ordered(SetMode("USB"), future=second)
+    queue.put_ordered(SetSplit(True), future=second)
     await _drain_with_ptt(poller, clock, 12.5, True)
     assert isinstance(first.exception(), CommandError)
     assert "superseded" in str(first.exception())
@@ -810,7 +810,7 @@ async def test_yaesu_deferred_command_supersedes_without_extending_expiry(
     assert service.emit_lifecycle.call_args.args[1] == "superseded"
     await _drain_with_ptt(poller, clock, 13.0, False)
     assert isinstance(second.exception(), TimeoutError)
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -826,7 +826,7 @@ async def test_yaesu_deferred_command_emits_held_lifecycle_once(
         executor=MagicMock(), state_store=StateStore(), clock=lambda: clock[0]
     )
     poller = YaesuCatPoller(radio, command_queue=queue)
-    queue.put_ordered(SetMode("USB"), command_id="held", command_service=service)
+    queue.put_ordered(SetSplit(True), command_id="held", command_service=service)
 
     await _drain_with_ptt(poller, clock, 10.0, True)
     event = service.lifecycle_events()[0]
@@ -866,14 +866,11 @@ async def test_ftx1_web_deferred_hold_preserves_ingress_lifecycle_context(
     )
     radio, handler, poller, _store, _accept = _real_ftx1_control_path()
     service = handler._command_service  # noqa: SLF001
-    # MOR-1940: MODE is the DEFER exemplar (FREQUENCY was reclassified
-    # tx-safe); the assertions below compare `held` against `ingress`
-    # generically, so the swap needs no other change in this test.
-    params = {"mode": "USB", "receiver": 1}
+    params = {"on": True}
     original_params = dict(params)
 
     await handler._enqueue_command(  # noqa: SLF001
-        "set_mode", params, command_id=f"held-{source}", source=source
+        "set_split", params, command_id=f"held-{source}", source=source
     )
     ingress = service.lifecycle_events()[0]
     assert params == original_params
@@ -919,13 +916,13 @@ async def test_yaesu_deferred_replacement_lifecycle_preserves_deadline_truth(
     poller = YaesuCatPoller(radio, command_queue=queue)
     first = asyncio.get_running_loop().create_future()
     queue.put_ordered(
-        SetMode("LSB"),
+        SetSplit(False),
         future=first,
         command_id="first",
         command_service=service,
     )
     await _drain_with_ptt(poller, clock, 20.0, True)
-    queue.put_ordered(SetMode("USB"), command_id="replacement", command_service=service)
+    queue.put_ordered(SetSplit(True), command_id="replacement", command_service=service)
     await _drain_with_ptt(poller, clock, replacement_at, True)
 
     events = service.lifecycle_events()
@@ -952,32 +949,27 @@ async def test_yaesu_deferred_release_requires_continuous_fresh_rx(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
     )
     radio, queue = make_radio(), CommandQueue()
-    radio.set_mode = AsyncMock()
+    radio.set_split = AsyncMock()
     poller = YaesuCatPoller(radio, command_queue=queue)
     future = asyncio.get_running_loop().create_future()
-    queue.put_ordered(SetMode("USB"), future=future)
+    queue.put_ordered(SetSplit(True), future=future)
     await _drain_with_ptt(poller, clock, 20.0, True)
     await _drain_with_ptt(poller, clock, 20.5, False)
     await _drain_with_ptt(poller, clock, 21.0, None)
     await _drain_with_ptt(poller, clock, 21.1, False)
     await _drain_with_ptt(poller, clock, 22.099, False)
     assert not future.done()
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
     await _drain_with_ptt(poller, clock, 22.1, False)
     await poller._drain_commands()  # noqa: SLF001
     assert future.result() is None
-    radio.set_mode.assert_awaited_once_with("USB", receiver=0)
+    radio.set_split.assert_awaited_once_with(True)
 
 
 @pytest.mark.asyncio
 async def test_yaesu_frequency_now_dispatches_without_entering_the_deferred_lane(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MOR-1940: the exact contrast to the MODE tests above. FREQUENCY was
-    reclassified DEFER -> tx-safe (both bench radios accept and apply it
-    while keyed), so it dispatches immediately even under known TX -- it
-    never reaches ``poller._deferred_tx_lane`` at all.
-    """
     clock = [20.0]
     monkeypatch.setattr(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
@@ -996,6 +988,60 @@ async def test_yaesu_frequency_now_dispatches_without_entering_the_deferred_lane
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "family", "method", "expected_args"),
+    (
+        (
+            SetFreq(7_100_000),
+            TxInterlockCommandFamily.FREQUENCY,
+            "set_freq",
+            (7_100_000,),
+        ),
+        (SetMode("USB"), TxInterlockCommandFamily.MODE, "set_mode", ("USB",)),
+        (SetBand(3), TxInterlockCommandFamily.BAND, "set_band", (3,)),
+        (
+            SelectVfo("A"),
+            TxInterlockCommandFamily.VFO_SELECT,
+            "set_vfo_select",
+            (0,),
+        ),
+        (
+            VfoSwap(),
+            TxInterlockCommandFamily.VFO_CONTENTS,
+            "swap_vfo_ab",
+            (0,),
+        ),
+        (
+            VfoEqualize(),
+            TxInterlockCommandFamily.VFO_CONTENTS,
+            "equalize_vfo_ab",
+            (0,),
+        ),
+    ),
+)
+async def test_yaesu_authority_approved_commands_dispatch_during_observed_tx(
+    command: object,
+    family: TxInterlockCommandFamily,
+    method: str,
+    expected_args: tuple[object, ...],
+) -> None:
+    radio = make_radio()
+    radio.receiver_count = 1
+    radio.profile.tx_interlock_disposition_overrides = {
+        family: TxInterlockDisposition.DEFER
+    }
+    setattr(radio, method, AsyncMock())
+    poller = YaesuCatPoller(radio)
+    _set_fresh_ptt_observation(poller, active=True)
+
+    await poller._execute_command(command)  # type: ignore[arg-type] # noqa: SLF001
+
+    getattr(radio, method).assert_awaited_once()
+    assert getattr(radio, method).await_args.args == expected_args
+    assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("knownness", ("missing", "stale", "generation_mismatch"))
 async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
     monkeypatch: pytest.MonkeyPatch,
@@ -1005,7 +1051,7 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: 30.0
     )
     radio, queue = make_radio(), CommandQueue()
-    radio.set_mode = AsyncMock()
+    radio.set_split = AsyncMock()
     poller = YaesuCatPoller(radio, command_queue=queue)
     service = MagicMock()
     if knownness == "stale":
@@ -1021,7 +1067,7 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
         )
     future = asyncio.get_running_loop().create_future()
     queue.put_ordered(
-        SetMode("USB"),
+        SetSplit(True),
         future=future,
         command_id="unknown",
         command_service=service,
@@ -1030,7 +1076,7 @@ async def test_yaesu_unknown_deferred_command_fails_without_entering_lane(
     error = future.exception()
     assert isinstance(error, CommandError)
     assert "unknown" in str(error)
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
     assert poller._deferred_tx_lane.pending is None  # noqa: SLF001
     service.emit_lifecycle.assert_not_called()
 
@@ -1058,7 +1104,7 @@ async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
         "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
     )
     radio, queue, store = _tx_target_radio(), CommandQueue(), StateStore()
-    radio.set_mode = AsyncMock()
+    radio.set_split = AsyncMock()
     poller = YaesuCatPoller(radio, command_queue=queue)
     poller.bind_provider_generation(
         capture=lambda: store.provider_generation,
@@ -1068,7 +1114,7 @@ async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
     service = MagicMock()
     queue.register_session("ws")
     queue.put_ordered(
-        SetMode("USB"),
+        SetSplit(True),
         future=future,
         command_id="held",
         source="websocket",
@@ -1114,7 +1160,7 @@ async def test_yaesu_lifecycle_boundary_retires_held_deferred_command(
     clock[0] = 11.5
     _set_fresh_ptt_observation(poller, active=False)
     await poller._drain_commands()  # noqa: SLF001
-    radio.set_mode.assert_not_awaited()
+    radio.set_split.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reclassify frequency, mode, band, and VFO selection as TX-safe independently of observed RF state
- classify VFO swap/equalize under a new pure `vfo-contents` family while keeping mixed `vfo-topology` operations deferred
- prevent profile `TX_SAFE -> DEFER` overrides from restoring observed-RF admission for the authority-approved families
- preserve split, quick split/trigger, dual-watch/tracking, tuner, antenna, invalid receiver, unsupported operation, and backend rejection behavior
- update the canonical rig schema reference and direct conformance/characterisation fallout

Linear: [MOR-2171](https://linear.app/morozsm/issue/MOR-2171)

## TDD evidence

RED on tests first:

- `uv run pytest tests/test_tx_interlock_policy.py -q --tb=short`
- result: 3 policy/metadata failures after correcting one malformed test setup; mode remained DEFER, `VFO_CONTENTS` was absent, and the profile-override seam was unprotected
- expanded consumer RED then failed collection because `VFO_CONTENTS` did not exist

GREEN:

- focused shared/Web/Yaesu/rigctld suite: `273 passed`
- expanded conformance suite: `399 passed, 1 xfailed` after replacing obsolete mode-as-DEFER pins with split/RF-gated equivalents
- full suite: `14548 passed, 219 skipped, 16 xfailed`
- `uv run ruff format --check ...`: pass for all changed Python files
- `uv run ruff check src/ tests/`: pass
- `uv run lint-imports`: 5 contracts kept, 0 broken
- `uv run mypy --strict src/rigplane/web`: pass, 26 files
- `uv run pytest tests/test_rig_schema.py -q --tb=short`: 26 passed

## Guardrail exception required before merge

This PR changes 11 files and 571 lines (307 additions, 264 deletions). It exceeds the 10-file hard ceiling by one file because the six scoped implementation/cross-consumer files require four stale out-of-scope characterisation files plus the canonical `rigs/_schema.md` contract artifact to keep the full suite and schema conformance truthful. No consumer production source was changed. Owner exception must be recorded in this PR before merge.

## Compatibility

No API, CLI, config grammar, or rigctld wire-format break. Existing profile entries that name an authority-approved TX-safe family with `defer` remain parseable but no longer restore observed-RF admission.
