### PR TITLE
fix: derive state sweep from profile declarations (MOR-1983)

### DIFF
--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -2458,8 +2458,8 @@
       "family": "transceiver_status",
       "status": "implemented",
       "runtime_symbols": [
-        "rigplane.commands:parse_frequency_response",
-        "rigplane._civ_rx:CivRuntime._update_state_cache_from_frame",
+        "rigplane._civ_rx:CivRuntime._observations_from_frame",
+        "rigplane.core.types:bcd_decode",
         "rigplane.core.tx_target:KnownTxTarget"
       ],
       "test_patterns": [

--- a/docs/parity/ic7610_command_matrix.json
+++ b/docs/parity/ic7610_command_matrix.json
@@ -2458,20 +2458,17 @@
       "family": "transceiver_status",
       "status": "implemented",
       "runtime_symbols": [
-        "rigplane.commands:get_tx_freq_monitor",
-        "rigplane.commands:set_tx_freq_monitor",
-        "rigplane.radio:IcomRadio.get_tx_freq_monitor",
-        "rigplane.radio:IcomRadio.set_tx_freq_monitor",
-        "rigplane._civ_rx:_CivRxMixin._update_radio_state_from_frame",
-        "rigplane.web.radio_poller:RadioPoller._build_state_queries"
+        "rigplane.commands:parse_frequency_response",
+        "rigplane._civ_rx:CivRuntime._update_state_cache_from_frame",
+        "rigplane.core.tx_target:KnownTxTarget"
       ],
       "test_patterns": [
-        "tests/test_commands.py::test_get_tx_freq_monitor",
-        "tests/test_commands.py::test_set_tx_freq_monitor_on",
-        "tests/test_civ_rx_coverage.py::test_update_radio_state_tx_freq_monitor",
-        "tests/test_radio_poller_coverage.py::test_state_queries_include_transceiver_status_reads_for_ic7610"
+        "tests/test_civ_rx_coverage.py::test_update_radio_state_tx_freq_monitor_decodes_transmit_frequency_not_boolean",
+        "tests/test_commands.py::test_get_tx_freq_monitor_fails_closed",
+        "tests/test_commands.py::test_set_tx_freq_monitor_fails_closed",
+        "tests/test_state_queries.py::test_legacy_tx_freq_monitor_builders_fail_closed"
       ],
-      "notes": ""
+      "notes": "The official IC-7610 CI-V guide documents 1C 03 as a read-only five-byte transmit-frequency payload despite wfview marking set=true. Runtime decodes it into the existing tx_target state with finite profile freshness; the legacy boolean get/set_tx_freq_monitor APIs are explicitly absent and fail closed. XFC boolean read/write remains 1C 02."
     },
     {
       "id": 110,

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -787,8 +787,8 @@ get_tuner_status = [0x1C, 0x01]
 set_tuner_status = [0x1C, 0x01]
 get_xfc_status = [0x1C, 0x02]
 set_xfc_status = [0x1C, 0x02]
-get_tx_freq_monitor = [0x1C, 0x03]
-set_tx_freq_monitor = [0x1C, 0x03]
+get_tx_freq_monitor = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) pp.7,16: 1C 03 is Read transmit frequency, not the XFC boolean at 1C 02; no SET form is documented" }
+set_tx_freq_monitor = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) pp.7,16: 1C 03 is Read transmit frequency, not the XFC boolean at 1C 02; no SET form is documented" }
 
 # ── RIT / XIT ──
 get_rit_frequency = [0x21, 0x00]

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -165,7 +165,6 @@ polling_only = [
     "scope_controls.global.display.center_type",
     "scope_controls.global.display.vbw_narrow",
     "scope_controls.global.display.fixed_edge",
-    "scope_controls.global.display.rbw",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -846,8 +845,8 @@ get_scope_vbw = [0x27, 0x1D]
 set_scope_vbw = [0x27, 0x1D]
 get_scope_fixed_edge = [0x27, 0x1E]
 set_scope_fixed_edge = [0x27, 0x1E]
-get_scope_rbw = [0x27, 0x1F]
-set_scope_rbw = [0x27, 0x1F]
+get_scope_rbw = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15: the 0x27 scope table ends at 1E, with no 1F RBW command" }
+set_scope_rbw = { absent = "IC-705 CI-V Reference Guide (A7560-8EX-1, Jul.2020) p.15: the 0x27 scope table ends at 1E, with no 1F RBW command" }
 
 # ── D-STAR voice / protocol ack ──
 get_voice_tx = [0x28]

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -118,6 +118,75 @@ features = [
     "system_settings",
 ]
 
+# MOR-1983: initial and legacy periodic state acquisition is declared here,
+# using getters already sourced to the IC-705 CI-V Reference Guide below.
+# The runtime resolves these semantic paths through this profile's CommandMap;
+# no model-specific query list exists in code.
+[state_acquisition]
+provider = "icom_civ"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "poll"
+adaptive_decay = true
+adaptive_decay_idle_multiplier = 4.0
+adaptive_decay_max_cadence_seconds = 30.0
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.capabilities]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.main.unselected.freq_mode.freq_hz",
+    "receiver.main.unselected.freq_mode.mode",
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+    "receiver.main.operator_controls.squelch",
+    "receiver.main.operator_controls.att",
+    "receiver.main.operator_controls.preamp",
+    "receiver.main.operator_controls.agc",
+    "receiver.main.operator_toggles.nb",
+    "receiver.main.operator_toggles.nr",
+    "global.operator_controls.power_level",
+    "global.tx_state.compressor_on",
+    "global.operator_controls.compressor_level",
+    "global.tx_state.ptt",
+    "global.operator_controls.tuner_status",
+    "global.tx_state.split",
+    "scope_controls.global.display.receiver",
+    "scope_controls.global.display.dual",
+    "scope_controls.global.display.mode",
+    "scope_controls.global.display.span",
+    "scope_controls.global.display.edge",
+    "scope_controls.global.display.hold",
+    "scope_controls.global.display.ref_db",
+    "scope_controls.global.display.speed",
+    "scope_controls.global.display.during_tx",
+    "scope_controls.global.display.center_type",
+    "scope_controls.global.display.vbw_narrow",
+    "scope_controls.global.display.fixed_edge",
+    "scope_controls.global.display.rbw",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+    "global.meters.power",
+    "global.meters.swr",
+    "global.meters.alc",
+    "global.meters.comp",
+    "global.meters.vd",
+    "global.meters.id",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+
 # ── Parameterized Capabilities ───────────────────────────────────
 
 [attenuator]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -186,6 +186,18 @@ polling_only = [
     "global.meters.comp",
     "global.meters.vd",
     "global.meters.id",
+    "scope_controls.global.display.receiver",
+    "scope_controls.global.display.dual",
+    "scope_controls.global.display.mode",
+    "scope_controls.global.display.span",
+    "scope_controls.global.display.edge",
+    "scope_controls.global.display.hold",
+    "scope_controls.global.display.ref_db",
+    "scope_controls.global.display.speed",
+    "scope_controls.global.display.during_tx",
+    "scope_controls.global.display.center_type",
+    "scope_controls.global.display.vbw_narrow",
+    "scope_controls.global.display.fixed_edge",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -444,7 +456,7 @@ adaptive_decay = false
 # 1.5s-or-faster tier for everything else that matters live; it only ever
 # fires during a TX segment, transiently adding 4 fields / 1.0s = 4.0 q/s on
 # top of this profile's RX-state demand (see vd/id below; 19.967 q/s when
-# this was written, 19.433 q/s after the MOR-1484 cadence tightening above)
+# this was written, 19.833 q/s after the MOR-1484 and MOR-1983 cadence changes)
 # for as long as the key is down -- an accepted, TX-scoped tradeoff, not a
 # steady-state regression of the MOR-1484 serial medians.
 [state_acquisition.field_policies."global.meters.power"]
@@ -484,7 +496,7 @@ tx_only = true
 # a slowly-varying supply rail/current reading roughly once a minute --
 # "live", just not fast. (These 19.933/19.967 figures predate the MOR-1484
 # cadence tightening above/below this block -- see that block's comment for
-# the current total, 19.433 q/s.)
+# the current total, 19.833 q/s.)
 [state_acquisition.field_policies."global.meters.vd"]
 cadence_seconds = 60.0
 freshness_ttl_seconds = 90.0
@@ -641,6 +653,66 @@ adaptive_decay = false
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.receiver"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.dual"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.mode"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.span"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.edge"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.hold"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.ref_db"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.speed"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.during_tx"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.center_type"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.vbw_narrow"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.fixed_edge"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
 adaptive_decay = false
 
 # ── Parameterized Capabilities ───────────────────────────────────
@@ -1035,6 +1107,7 @@ set_agc_time_constant = [0x1A, 0x04]
 # ── TX Controls (Power, Mic, Compressor, Monitor, VOX) ──
 ptt_on = [0x1C, 0x00, 0x01]
 ptt_off = [0x1C, 0x00, 0x00]
+get_transceiver_status = [0x1C, 0x00]     # source: IC-7300 Advanced Manual (11a) command table p.19-7
 get_rf_power = [0x14, 0x0A]
 set_rf_power = [0x14, 0x0A]
 get_mic_gain = [0x14, 0x0B]

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -247,6 +247,19 @@ polling_only = [
     # needed for those.
     "global.operator_controls.break_in",
     "global.operator_controls.break_in_delay",
+    "scope_controls.global.display.receiver",
+    "scope_controls.global.display.dual",
+    "scope_controls.global.display.mode",
+    "scope_controls.global.display.span",
+    "scope_controls.global.display.edge",
+    "scope_controls.global.display.hold",
+    "scope_controls.global.display.ref_db",
+    "scope_controls.global.display.speed",
+    "scope_controls.global.display.during_tx",
+    "scope_controls.global.display.center_type",
+    "scope_controls.global.display.vbw_narrow",
+    "scope_controls.global.display.fixed_edge",
+    "scope_controls.global.display.rbw",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -666,6 +679,71 @@ adaptive_decay = false
 cadence_seconds = 3.0
 freshness_ttl_seconds = 5.0
 adaptive_decay = false
+
+[state_acquisition.field_policies."scope_controls.global.display.receiver"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.dual"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.mode"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.span"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.edge"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.hold"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.ref_db"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.speed"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.during_tx"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.center_type"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.vbw_narrow"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.fixed_edge"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
+
+[state_acquisition.field_policies."scope_controls.global.display.rbw"]
+cadence_seconds = 30.0
+freshness_ttl_seconds = 60.0
+adaptive_decay = true
 
 # ── Parameterized Capabilities ───────────────────────────────────
 
@@ -1165,6 +1243,7 @@ set_agc_time_constant = [0x1A, 0x04]
 # ── TX Controls (Power, Mic, Compressor, Monitor, VOX) ──
 ptt_on = [0x1C, 0x00, 0x01]
 ptt_off = [0x1C, 0x00, 0x00]
+get_transceiver_status = [0x1C, 0x00]     # source: IC-7610 CI-V Reference Guide (May.2021) p.9
 get_rf_power = [0x14, 0x0A]
 set_rf_power = [0x14, 0x0A]
 get_mic_gain = [0x14, 0x0B]

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -1104,6 +1104,7 @@ routes = [
     [0x16, 0x4F],     # Twin Peak Filter
     [0x16, 0x53],     # RX Antenna
     [0x16, 0x56],     # Filter Shape
+    [0x16, 0x57],     # Manual Notch Width (PDF p.4 29-glyph)
     [0x16, 0x65],     # IP+
     [0x1A, 0x03],     # Filter Width
     [0x1A, 0x04],     # AGC Time Constant
@@ -1270,8 +1271,8 @@ set_ssb_tx_bandwidth = [0x16, 0x58]
 # ── Split ──
 get_xfc_status = [0x1C, 0x02]             # Transmit frequency monitor (XFC)
 set_xfc_status = [0x1C, 0x02]
-get_tx_freq_monitor = [0x1C, 0x03]
-set_tx_freq_monitor = [0x1C, 0x03]
+get_tx_freq_monitor = { absent = "IC-7610 CI-V Reference Guide (2021) pp.9,14: 1C 03 is Read transmit frequency, not the XFC boolean at 1C 02; no SET form is documented" }
+set_tx_freq_monitor = { absent = "IC-7610 CI-V Reference Guide (2021) pp.9,14: 1C 03 is Read transmit frequency, not the XFC boolean at 1C 02; no SET form is documented" }
 
 # ── CW ──
 send_cw = [0x17]

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -106,6 +106,85 @@ features = [
     "speech",
 ]
 
+# MOR-1983: initial and legacy periodic state acquisition is declared here,
+# using getters sourced to the IC-9700 CI-V Reference Guide below. Receiver
+# routing remains data-driven through this profile's cmd29 declarations.
+[state_acquisition]
+provider = "icom_civ"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "poll"
+adaptive_decay = true
+adaptive_decay_idle_multiplier = 4.0
+adaptive_decay_max_cadence_seconds = 30.0
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.2
+
+[state_acquisition.capabilities]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.sub.active.freq_mode.freq_hz",
+    "receiver.sub.active.freq_mode.mode",
+    "receiver.main.operator_controls.af_level",
+    "receiver.main.operator_controls.rf_gain",
+    "receiver.main.operator_controls.squelch",
+    "receiver.main.operator_controls.att",
+    "receiver.main.operator_controls.preamp",
+    "receiver.sub.operator_controls.af_level",
+    "receiver.sub.operator_controls.rf_gain",
+    "receiver.sub.operator_controls.squelch",
+    "receiver.sub.operator_controls.att",
+    "receiver.sub.operator_controls.preamp",
+    "receiver.main.operator_controls.agc",
+    "receiver.sub.operator_controls.agc",
+    "receiver.main.operator_toggles.nb",
+    "receiver.main.operator_toggles.nr",
+    "receiver.sub.operator_toggles.nb",
+    "receiver.sub.operator_toggles.nr",
+    "global.operator_controls.power_level",
+    "global.tx_state.compressor_on",
+    "global.operator_controls.compressor_level",
+    "global.tx_state.ptt",
+    "global.tx_state.split",
+    "scope_controls.global.display.receiver",
+    "scope_controls.global.display.dual",
+    "scope_controls.global.display.mode",
+    "scope_controls.global.display.span",
+    "scope_controls.global.display.edge",
+    "scope_controls.global.display.hold",
+    "scope_controls.global.display.ref_db",
+    "scope_controls.global.display.speed",
+    "scope_controls.global.display.during_tx",
+    "scope_controls.global.display.center_type",
+    "scope_controls.global.display.vbw_narrow",
+    "scope_controls.global.display.fixed_edge",
+    "scope_controls.global.display.rbw",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+    "global.meters.power",
+    "global.meters.swr",
+    "global.meters.alc",
+    "global.meters.comp",
+    "global.meters.vd",
+    "global.meters.id",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.sub.active.freq_mode.freq_hz",
+    "receiver.sub.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+    "receiver.sub.active.freq_mode.freq_hz",
+    "receiver.sub.active.freq_mode.mode",
+    "global.tx_state.ptt",
+]
+
 # ── Parameterized Capabilities ───────────────────────────────────
 
 [attenuator]
@@ -587,6 +666,7 @@ set_agc_time_constant = [0x1A, 0x04]
 # ── TX Controls (Power, Mic, Compressor, Monitor, VOX) ──
 ptt_on = [0x1C, 0x00, 0x01]
 ptt_off = [0x1C, 0x00, 0x00]
+get_transceiver_status = [0x1C, 0x00]      # source: IC-9700 CI-V Reference Guide (Icom, 2019) p.10, S/R transceiver status
 get_rf_power = [0x14, 0x0A]
 set_rf_power = [0x14, 0x0A]
 get_mic_gain = [0x14, 0x0B]

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -131,17 +131,9 @@ polling_only = [
     "receiver.main.operator_controls.squelch",
     "receiver.main.operator_controls.att",
     "receiver.main.operator_controls.preamp",
-    "receiver.sub.operator_controls.af_level",
-    "receiver.sub.operator_controls.rf_gain",
-    "receiver.sub.operator_controls.squelch",
-    "receiver.sub.operator_controls.att",
-    "receiver.sub.operator_controls.preamp",
     "receiver.main.operator_controls.agc",
-    "receiver.sub.operator_controls.agc",
     "receiver.main.operator_toggles.nb",
     "receiver.main.operator_toggles.nr",
-    "receiver.sub.operator_toggles.nb",
-    "receiver.sub.operator_toggles.nr",
     "global.operator_controls.power_level",
     "global.tx_state.compressor_on",
     "global.operator_controls.compressor_level",
@@ -693,8 +685,8 @@ get_ssb_tx_bandwidth = [0x16, 0x58]
 set_ssb_tx_bandwidth = [0x16, 0x58]
 
 # ── Split ──
-get_tx_freq_monitor = [0x1C, 0x03]
-set_tx_freq_monitor = [0x1C, 0x03]
+get_tx_freq_monitor = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) pp.10,13: 1C 03 is Read transmit frequency, not the XFC boolean at 1C 02; no SET form is documented" }
+set_tx_freq_monitor = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) pp.10,13: 1C 03 is Read transmit frequency, not the XFC boolean at 1C 02; no SET form is documented" }
 get_xfc_status = [0x1C, 0x02]             # XFC = transmit frequency monitor
 set_xfc_status = [0x1C, 0x02]
 

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -124,8 +124,6 @@ meter_coalescing_window_seconds = 0.2
 polling_only = [
     "receiver.main.active.freq_mode.freq_hz",
     "receiver.main.active.freq_mode.mode",
-    "receiver.sub.active.freq_mode.freq_hz",
-    "receiver.sub.active.freq_mode.mode",
     "receiver.main.operator_controls.af_level",
     "receiver.main.operator_controls.rf_gain",
     "receiver.main.operator_controls.squelch",
@@ -151,7 +149,6 @@ polling_only = [
     "scope_controls.global.display.center_type",
     "scope_controls.global.display.vbw_narrow",
     "scope_controls.global.display.fixed_edge",
-    "scope_controls.global.display.rbw",
 ]
 stream_like_meters = [
     "receiver.main.meters.s_meter",
@@ -503,7 +500,7 @@ routes = []
 
 [commands]
 
-# PROVENANCE OPEN (D2, MOR-2015): the following 8 declared base-family
+# PROVENANCE OPEN (D2, MOR-2015): the following 7 declared base-family
 # entries were NOT covered by this ticket's documentary audit (Part 3 of
 # the audit report was a spot-check, not exhaustive, over the base-opcode
 # families) and are not independently confirmed against the IC-9700 CI-V
@@ -518,7 +515,6 @@ routes = []
 #   - get_rit_tx_status / set_rit_tx_status [0x21, 0x02]
 #   - get_audio_peak_filter / set_audio_peak_filter [0x16, 0x32]
 #   - get_scope_single_dual                 [0x27, 0x13]
-#   - get_scope_rbw                         [0x27, 0x1F]
 #
 # Added (D2, MOR-2008 batch 4), left deliberately undeclared rather than
 # guessed:
@@ -765,7 +761,8 @@ get_scope_during_tx = [0x27, 0x1B]
 get_scope_center_type = [0x27, 0x1C]
 get_scope_vbw = [0x27, 0x1D]
 get_scope_fixed_edge = [0x27, 0x1E]
-get_scope_rbw = [0x27, 0x1F]
+get_scope_rbw = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) p.12: the 0x27 scope table ends at 1E, with no 1F RBW command" }
+set_scope_rbw = { absent = "IC-9700 CI-V Reference Guide (Icom, 2019) p.12: the 0x27 scope table ends at 1E, with no 1F RBW command" }
 
 # ── Scan ──
 scan_start = [0x0E]

--- a/rigs/x6100.toml
+++ b/rigs/x6100.toml
@@ -139,6 +139,40 @@ features = [
     "dial_lock",
 ]
 
+# MOR-1983: mirror the conservative X6200 acquisition envelope. This inherits
+# the same shared-firmware rationale as the command declarations below; it does
+# not claim direct X6100 hardware evidence. Every polled path resolves through
+# this profile's own explicitly declared getter.
+[state_acquisition]
+provider = "xiegu_civ"
+default_cadence_seconds = 2.0
+default_freshness_ttl_seconds = 8.0
+default_reconciliation_priority = "poll"
+adaptive_decay = true
+adaptive_decay_idle_multiplier = 4.0
+adaptive_decay_max_cadence_seconds = 30.0
+external_cat_pause = "pause_polling"
+meter_coalescing_window_seconds = 0.25
+
+[state_acquisition.capabilities]
+polling_only = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+stream_like_meters = [
+    "receiver.main.meters.s_meter",
+    "global.meters.power",
+]
+command_response_observable = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+supported_controls = [
+    "receiver.main.active.freq_mode.freq_hz",
+    "receiver.main.active.freq_mode.mode",
+]
+unsupported = ["global.tx_state.power_on"]
+
 [modes]
 list = ["USB", "LSB", "CW", "CW-R", "AM", "FM", "RTTY", "DIGI"]
 
@@ -348,13 +382,9 @@ end_hz = 136000000
 #   written, and this profile declares neither key present nor
 #   declared-absent -- so both now refuse with ``CommandError`` (the
 #   undeclared-command policy, D1, MOR-2005) instead of reaching the wire.
-#   [0x14, 0x0F] is reached today by exactly ONE path: the unconditional
-#   poll in ``runtime/_state_queries.py: build_state_queries``'s
-#   ``_COMMON_FEATURE_QUERIES`` list, which every CI-V radio using this
-#   query builder sends regardless of capability. That poll does not read
-#   this profile's civ_addr or [commands] table either -- it is reached
-#   only if something ever constructs a CI-V radio object against this
-#   profile, per the Reachability note in the file header above.
+#   MOR-1983 removed the former unconditional [0x14, 0x0F] state poll;
+#   profile-derived acquisition now suppresses it because this profile
+#   declares neither a pollable path nor a getter.
 # - rit / xit -> hardcoded [0x21] in the RIT/XIT command builders
 #   (commands/_frame.py: _CMD_RIT, consumed by commands/system.py), no
 #   [commands] key here or on X6200. X6200's write-only *behavior* (SET

--- a/rigs/x6200.toml
+++ b/rigs/x6200.toml
@@ -83,13 +83,10 @@ codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 #     documented CI-V table at all — the X6200 PDF only documents QSK hang
 #     time (``0x14 0x0F``), not a BK-IN-mode register. This profile declares
 #     no ``break_in_delay`` key, control or feature either (unlike its four
-#     IC-7300/7610/9700/705 siblings, which all do). ``0x14 0x0F`` on X6200
-#     is reached today by exactly ONE path: the unconditional poll in
-#     ``runtime/_state_queries.py: build_state_queries``'s
-#     ``_COMMON_FEATURE_QUERIES`` list, which every CI-V radio built
-#     through this query builder sends regardless of declared capability
-#     or this profile's ``[commands]`` table — the same undeclared-hardcode
-#     class this bullet warns about, not an exception to it.
+#     IC-7300/7610/9700/705 siblings, which all do). MOR-1983 removed the
+#     former unconditional ``0x14 0x0F`` state poll: the sweep now follows
+#     ``[state_acquisition]`` plus ``[commands]``, neither of which declares
+#     a break-in-delay read for this profile, so the frame is suppressed.
 #     ``CoreRadio.get_break_in_delay`` / ``CoreRadio.set_break_in_delay``
 #     (``commands/levels.py: get_break_in_delay`` / ``set_break_in_delay``)
 #     do NOT reach it: both route through the bound command map
@@ -474,11 +471,9 @@ end_hz = 136000000
 #   BK-IN-mode register (MOR-1534, docs/validation/cat-audits/x6200.md
 #   § "D. MISMATCH / WRONG", break-in row). This profile declares no
 #   break_in_delay key either (unlike its four IC-7300/7610/9700/705
-#   siblings). [0x14, 0x0F] is reached today by exactly one path: the
-#   unconditional poll in runtime/_state_queries.py: build_state_queries's
-#   _COMMON_FEATURE_QUERIES list, sent regardless of declared capability
-#   or this profile's [commands] table -- a separate undeclared-hardcode
-#   path, not one this bullet's promotion touches. CoreRadio.
+#   siblings). MOR-1983 removed the former unconditional [0x14, 0x0F]
+#   state poll; profile-derived acquisition now suppresses it because this
+#   profile declares neither a pollable path nor a getter. CoreRadio.
 #   get_break_in_delay / CoreRadio.set_break_in_delay (commands/levels.py)
 #   do NOT reach it either: both route through the bound command map
 #   (commands/bound.py: BoundCommands, MOR-2006), and since this profile

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -113,10 +113,9 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 # no selector byte -- except 0x1E, which carries a ``<range><edge>`` selector
 # of its own; see ``get_scope_fixed_edge`` below.
 #
-# Imported by ``runtime/_state_queries.py: build_state_queries``, whose list
-# ``runtime/radio_initial_state.py: fetch_initial_state`` then sends, and by
-# ``web/radio_poller.py: RadioPoller._send_one_state_query``.  Those are the
-# senders that consult this set.
+# Imported by ``runtime/_state_queries.py`` when it resolves profile-declared
+# scope paths.  The resulting shared query list is sent by initial acquisition,
+# legacy periodic polling, and rigctld through their common semantic envelope.
 #
 # Two further places hold this membership and do NOT import it, so an edit
 # here does not reach them -- change all three together:
@@ -130,31 +129,21 @@ _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
 # Nothing asserts that the three agree.  Making the RX path import this
 # constant is the real fix and is deliberately not done here (MOR-1981).
 #
-# ``rigctld/server.py: RigctldServer._send_one_state_query`` has the same
-# shape and does NOT consult this set.  It cannot reach 0x27 today because
-# ``core/acquisition_scheduler.py: IcomCivAcquisitionExecutor.query_for_path``
-# has no ``scope_controls`` branch, so every scope field resolves to None.
-# Nothing pins that.  If that branch is ever added, this set is the third
-# place to wire up, or rigctld will send ``27 14`` bare while web does not.
-#
 # Membership (MOR-1981).  Measured on a live IC-7300, six runs with no
 # variance: each sub-command below is refused with a NAK when sent bare,
 # while 0x12, 0x13, 0x1B and 0x1C answer.  Icom's CI-V Reference Guide for
 # the IC-705 -- the same single-scope architecture -- prints a two-byte data
 # field for 0x14, 0x15, 0x16, 0x17, 0x19, 0x1A and 0x1D and a one-byte field
 # for 0x12, 0x13, 0x1B and 0x1C, matching that bench result with no
-# exception.  0x1F (RBW) has no row in that guide, but Hamlib supplies the
-# selector for it and the bare form NAKs, so it is the same class.  The
-# IC-7300's own command table (advanced manual, table 19-8) and the
-# IC-7610 and IC-9700 CI-V Reference Guides have since been read directly
-# and print the same split: the IC-7300 leg now has both the bench
-# measurement and its own manual behind it, and the IC-7610 leg is
-# confirmed from its guide.  Documentary evidence exists for the IC-9700
-# (its CI-V Reference Guide); no bench evidence exists for the IC-9700.
-# The de-risking fact is that ``web/radio_poller.py`` has been putting this
-# exact split on the wire to all four scope-capable profiles since long
-# before this constant existed: the connect sweep is catching up to
-# shipped behaviour, not trying something new.
+# exception. The IC-7300 manual and IC-705/IC-9700 guides have no 0x1F row,
+# so those profiles fail closed for RBW. The IC-7610 guide documents 0x1F
+# and its selector shape, which is why the shared selector set retains it.
+# The other documented scope reads use the same split across these profiles.
+# The IC-7300 leg has both bench and manual evidence; IC-9700 has documentary
+# evidence but no bench evidence.
+# Profile declaration remains the final gate: a selector shape in this shared
+# set is emitted only when that profile also declares the corresponding getter
+# and pollable field.
 #
 # The exclusions are not omissions -- on a sub-command that takes no
 # selector the extra byte is a WRITE, not a no-op:

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2466,13 +2466,7 @@ class CivRuntime:
                 )
             )
         elif frame.command == 0x1C and frame.sub == 0x03 and frame.data:
-            observations.append(
-                self._observation(
-                    FieldPath.global_("tx_state", "tx_freq_monitor"),
-                    bool(frame.data[0]),
-                    frame=frame,
-                )
-            )
+            parse_frequency_response(frame)
         elif frame.command == 0x07 and len(frame.data) >= 2:
             sub07 = frame.data[0]
             val07 = frame.data[1]

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -49,6 +49,7 @@ from rigplane.commands import (
 from rigplane.commands.levels import _cw_pitch_from_level, _key_speed_from_level
 from rigplane.core.exceptions import ConnectionError, TimeoutError
 from rigplane.core.tx_safety import ProviderPttObservation, RadioTx
+from rigplane.core.tx_target import KnownTxTarget
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
     FieldChange,
@@ -59,7 +60,7 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.scope import ScopeFrame
-from rigplane.core.types import CivFrame, Mode
+from rigplane.core.types import CivFrame, Mode, bcd_decode
 from rigplane.runtime.meter_cal import interpolate_meter
 
 if TYPE_CHECKING:
@@ -2111,7 +2112,7 @@ class CivRuntime:
     def _observations_from_frame(self, frame: CivFrame) -> tuple[Observation, ...]:
         """Decode one CI-V frame into supported observation contracts."""
 
-        receiver_id, _, slot_override = self._receiver_context(frame)
+        receiver_id, receiver_name, slot_override = self._receiver_context(frame)
         observations: list[Observation] = []
 
         if (
@@ -2166,8 +2167,6 @@ class CivRuntime:
                     )
                 )
         elif frame.command == 0x25 and len(frame.data) >= 6:
-            from rigplane.types import bcd_decode
-
             relative = (
                 getattr(self._host._profile, "vfo_readback", "none")
                 == "selected_unselected"
@@ -2465,8 +2464,23 @@ class CivRuntime:
                     frame=frame,
                 )
             )
-        elif frame.command == 0x1C and frame.sub == 0x03 and frame.data:
-            parse_frequency_response(frame)
+        elif frame.command == 0x1C and frame.sub == 0x03 and len(frame.data) == 5:
+            # Icom documents 1C/03 as the current transmit frequency, not the
+            # boolean "TX frequency monitor" control exposed by older shared
+            # command names.  Publish the decoded value through the existing
+            # backend-neutral TX-target contract; this response does not carry
+            # a VFO-slot identity, so keep that portion deliberately unknown.
+            observations.append(
+                self._observation(
+                    FieldPath.global_("tx_state", "tx_target"),
+                    KnownTxTarget(
+                        receiver="SUB" if receiver_name == "SUB" else "MAIN",
+                        slot=None,
+                        frequency_hz=bcd_decode(frame.data),
+                    ),
+                    frame=frame,
+                )
+            )
         elif frame.command == 0x07 and len(frame.data) >= 2:
             sub07 = frame.data[0]
             val07 = frame.data[1]

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2725,6 +2725,14 @@ class CivRuntime:
             # responses so the Web TX authority gate cannot treat an ACK, setter
             # success, or unrelated response as radio truth.
             source = "poll_response"
+        max_age = _OBSERVATION_MAX_AGE_SECONDS.get(
+            (path.scope.value, path.family.value, path.name)
+        )
+        if path == FieldPath.global_("tx_state", "tx_target"):
+            acquisition = getattr(self._host._profile, "state_acquisition", None)
+            if acquisition is not None:
+                policy_ttl = acquisition.policy_for(path).freshness_ttl_seconds
+                max_age = policy_ttl
         return Observation(
             path=path,
             value=value,
@@ -2736,9 +2744,7 @@ class CivRuntime:
                 capability_id=str(path),
             ),
             timestamp_monotonic=time.monotonic(),
-            max_age=_OBSERVATION_MAX_AGE_SECONDS.get(
-                (path.scope.value, path.family.value, path.name)
-            ),
+            max_age=max_age,
             quality=quality,
         )
 

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -8,12 +8,13 @@ cmd29 receiver route distinct.
 
 from __future__ import annotations
 
-import logging
+from dataclasses import replace
 
-from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands._frame import decode_wire_tuple, parse_civ_frame
 from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
     SCOPE_SELECTOR_MAIN,
+    get_scope_fixed_edge,
 )
 from rigplane.core.acquisition_scheduler import (
     AcquisitionQuery,
@@ -21,8 +22,6 @@ from rigplane.core.acquisition_scheduler import (
 )
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.profiles import RadioProfile
-
-logger = logging.getLogger(__name__)
 
 _RECEIVER_IDS = {"0": 0, "main": 0, "1": 1, "sub": 1}
 _RECEIVER_TOGGLE_GETTERS = {
@@ -90,6 +89,21 @@ _GLOBAL_CONTROL_GETTERS = {
     "monitor_gain": "get_monitor_gain",
     "vox_gain": "get_vox_gain",
     "anti_vox_gain": "get_anti_vox_gain",
+}
+_SCOPE_CONTROL_GETTERS = {
+    "receiver": "get_scope_main_sub",
+    "dual": "get_scope_single_dual",
+    "mode": "get_scope_mode",
+    "span": "get_scope_span",
+    "edge": "get_scope_edge",
+    "hold": "get_scope_hold",
+    "ref_db": "get_scope_ref",
+    "speed": "get_scope_speed",
+    "during_tx": "get_scope_during_tx",
+    "center_type": "get_scope_center_type",
+    "vbw_narrow": "get_scope_vbw",
+    "fixed_edge": "get_scope_fixed_edge",
+    "rbw": "get_scope_rbw",
 }
 
 
@@ -164,6 +178,31 @@ def acquisition_query_resolver_for_profile(
             else:
                 getter = None
             return from_getter(getter, receiver=receiver)
+        if scope == "scope_controls":
+            getter = _SCOPE_CONTROL_GETTERS.get(path.name)
+            query = from_getter(getter)
+            if query is None:
+                return None
+            if getter == "get_scope_fixed_edge":
+                frame = parse_civ_frame(
+                    get_scope_fixed_edge(
+                        0x00,
+                        from_addr=0x00,
+                        cmd_map=command_map,
+                    )
+                )
+                return AcquisitionQuery(
+                    frame.command,
+                    sub=frame.sub,
+                    data=frame.data,
+                )
+            if query.command == 0x27 and query.sub in SCOPE_RECEIVER_SELECTOR_SUBS:
+                return AcquisitionQuery(
+                    query.command,
+                    sub=query.sub,
+                    data=bytes([SCOPE_SELECTOR_MAIN]) + query.data,
+                )
+            return query
         if scope != "global":
             return None
         if family == "meters":
@@ -187,198 +226,44 @@ def build_state_queries(
     *,
     is_serial: bool = False,
 ) -> list[AcquisitionQuery]:
-    """Build the full list of CI-V state queries for the given profile.
+    """Build the profile-declared list of CI-V state queries.
 
     Parameters
     ----------
     profile:
         Radio profile (model, cmd29 support, receiver count).
     capabilities:
-        Set of capability strings the radio exposes.
+        Legacy caller input retained for compatibility. Query membership comes
+        from the profile's field-level acquisition capabilities.
     is_serial:
-        True for serial backends (adds extra meter queries).
+        Legacy caller input retained for compatibility. Transport does not
+        override profile-declared query membership.
 
     Returns
     -------
     list[AcquisitionQuery]
         Ordered list of lossless acquisition queries.
     """
-    receivers = [0]
-    if profile.receiver_count > 1:
-        receivers.append(1)
+    _ = capabilities, is_serial
+    acquisition = profile.state_acquisition
+    if acquisition is None:
+        return []
 
+    resolve = acquisition_query_resolver_for_profile(profile)
     queries: list[AcquisitionQuery] = []
-
-    for receiver in receivers:
-        # Freq/mode — needed even on serial for initial state and to pick up
-        # filter/attenuator/preamp that don't come via transceive.
-        queries.append(AcquisitionQuery(0x25, data=bytes([receiver])))  # frequency
-        queries.append(AcquisitionQuery(0x26, data=bytes([receiver])))  # mode
-        if receiver == 0 and profile.vfo_readback == "selected_unselected":
-            queries.append(AcquisitionQuery(0x25, data=b"\x01"))
-            queries.append(AcquisitionQuery(0x26, data=b"\x01"))
-
-        # Per-receiver state queries.  On dual-receiver radios these use
-        # cmd29 wrapping.  On single-receiver radios without cmd29 we send
-        # plain CI-V queries (receiver=None).
-        _PER_RX_QUERIES: list[tuple[str, int, int | None]] = [
-            ("attenuator", 0x11, None),
-            ("af_level", 0x14, 0x01),
-            ("rf_gain", 0x14, 0x02),
-            ("squelch", 0x14, 0x03),
-            ("preamp", 0x16, 0x02),
-            ("nb", 0x16, 0x22),
-            ("nr", 0x16, 0x40),
-            ("digisel", 0x16, 0x4E),
-            ("ip_plus", 0x16, 0x65),
-            ("repeater_tone", 0x16, 0x42),
-            ("tsql", 0x16, 0x43),
-            ("repeater_tone", 0x1B, 0x00),  # Tone frequency
-            ("tsql", 0x1B, 0x01),  # TSQL frequency
-            ("nr", 0x14, 0x06),  # NR Level
-            ("nb", 0x14, 0x12),  # NB Level
-            ("notch", 0x14, 0x0D),  # Notch position
-            ("filter_width", 0x1A, 0x03),
-            ("pbt", 0x14, 0x07),  # PBT Inner
-            ("pbt", 0x14, 0x08),  # PBT Outer
-            ("notch", 0x16, 0x57),  # Manual notch width
-            ("squelch", 0x15, 0x01),  # S-meter squelch status
-        ]
-        for cap, cmd_byte, sub_byte in _PER_RX_QUERIES:
-            if cap not in capabilities:
-                logger.debug(
-                    "Skipping %s: capability '%s' not supported by %s",
-                    f"query 0x{cmd_byte:02X}/0x{sub_byte:02X}"
-                    if sub_byte is not None
-                    else f"query 0x{cmd_byte:02X}",
-                    cap,
-                    profile.model,
-                )
+    seen: set[AcquisitionQuery] = set()
+    for path in acquisition.pollable_paths():
+        query = resolve(path)
+        if query is None:
+            continue
+        if query.receiver is not None and not profile.supports_cmd29(
+            query.command, query.sub
+        ):
+            if query.receiver != 0:
                 continue
-            if profile.supports_cmd29(cmd_byte, sub_byte):
-                # Dual-receiver: cmd29-wrapped with receiver byte
-                queries.append(
-                    AcquisitionQuery(cmd_byte, sub=sub_byte, receiver=receiver)
-                )
-            elif receiver == 0:
-                # Single-receiver: plain CI-V query (only once, not per-rx)
-                queries.append(AcquisitionQuery(cmd_byte, sub=sub_byte))
-
-        # Per-receiver feature queries that use cmd29 wrapping.
-        # Added for any radio whose profile declares cmd29 support for these.
-        for cmd_byte, sub_byte in (
-            (0x16, 0x12),  # AGC mode
-            (0x16, 0x32),  # Audio peak filter
-            (0x16, 0x41),  # Auto notch
-            (0x16, 0x48),  # Manual notch
-            (0x16, 0x4F),  # Twin peak filter
-            (0x16, 0x56),  # Filter shape
-            (0x1A, 0x04),  # AGC time constant
-        ):
-            if profile.supports_cmd29(cmd_byte, sub_byte):
-                queries.append(
-                    AcquisitionQuery(cmd_byte, sub=sub_byte, receiver=receiver)
-                )
-
-    # Global queries (not per-receiver)
-    queries.extend(
-        [
-            AcquisitionQuery(0x18),  # Power status (on/off)
-            AcquisitionQuery(0x1C, sub=0x00),  # PTT (global)
-            AcquisitionQuery(0x1C, sub=0x01),  # Tuner/ATU status
-            AcquisitionQuery(0x1C, sub=0x03),  # TX frequency monitor
-            AcquisitionQuery(0x14, sub=0x0A),  # Power level (global)
-            AcquisitionQuery(0x14, sub=0x0B),  # Mic gain (global)
-            AcquisitionQuery(0x14, sub=0x0E),  # Compressor level (global)
-            AcquisitionQuery(0x14, sub=0x15),  # Monitor gain (global)
-            AcquisitionQuery(0x14, sub=0x09),  # CW pitch (global)
-            AcquisitionQuery(0x14, sub=0x0C),  # Key speed (global)
-            AcquisitionQuery(0x0F),  # Split (global)
-            AcquisitionQuery(0x21, sub=0x00),  # RIT frequency
-            AcquisitionQuery(0x21, sub=0x01),  # RIT status
-            AcquisitionQuery(0x21, sub=0x02),  # RIT TX status
-        ]
-    )
-    if profile.receiver_count > 1:
-        queries.append(AcquisitionQuery(0x07, data=b"\xd2"))
-    if "dual_watch" in capabilities:
-        queries.append(
-            acquisition_query_from_wire_tuple(profile.command_map.get("get_dual_watch"))
-        )
-
-    # Common feature queries (data-driven: if radio has the command, poll it)
-    _COMMON_FEATURE_QUERIES: list[tuple[int, int]] = [
-        (0x16, 0x44),  # Compressor status
-        (0x16, 0x45),  # Monitor status
-        (0x16, 0x46),  # VOX status
-        (0x16, 0x47),  # Break-in mode
-        (0x16, 0x50),  # Dial lock status
-        (0x14, 0x16),  # VOX gain
-        (0x14, 0x17),  # Anti-VOX gain
-        (0x14, 0x0F),  # Break-in delay
-    ]
-    # NOTE: Antenna status (0x12) is NOT polled.
-    # CI-V 0x12 sub-commands are SET-only on IC-7610 (0x12 0x00 = select
-    # ANT1, 0x12 0x01 = select ANT2).  Polling them would toggle the
-    # antenna every cycle.
-    if not profile.supports_cmd29(0x16, 0x12):
-        _COMMON_FEATURE_QUERIES.insert(0, (0x16, 0x12))  # AGC mode
-
-    # For serial: ALC/comp/VD/Id meters move to slow state queries
-    if is_serial:
-        _COMMON_FEATURE_QUERIES.extend(
-            [
-                (0x15, 0x13),  # ALC meter
-                (0x15, 0x14),  # Compressor meter
-                (0x15, 0x15),  # VD (voltage)
-                (0x15, 0x16),  # Id (PA drain current)
-            ]
-        )
-
-    for cmd, sub in _COMMON_FEATURE_QUERIES:
-        queries.append(AcquisitionQuery(cmd, sub=sub))
-
-    # Capability-gated optional queries
-    if "meters" in capabilities:
-        queries.append(AcquisitionQuery(0x15, sub=0x07))  # Overflow status
-    if "ssb_tx_bw" in capabilities:
-        queries.append(AcquisitionQuery(0x16, sub=0x58))  # SSB TX bandwidth
-    if "scope" in capabilities:
-        # 0x27 reads come in two shapes.  The sub-commands in
-        # SCOPE_RECEIVER_SELECTOR_SUBS carry a one-byte Main/Sub scope
-        # selector; the rest must go out bare, where the same byte would be
-        # read as the first data byte of a WRITE (see commands/scope.py).
-        #
-        # SCOPE_SELECTOR_MAIN is what this list can legitimately name: it is
-        # built at connect, before any 0x27 0x12 response has said which
-        # scope the radio has selected, and MAIN is the value every profile
-        # accepts -- on a single-scope radio it is the only legal one, and
-        # per-model selector ranges are MOR-1988.  A sender that does know
-        # the live selection substitutes it
-        # (web/radio_poller.py: RadioPoller._send_one_state_query).
-        for scope_sub in (
-            0x12,  # Scope receiver selection
-            0x13,  # Scope single/dual mode
-            0x14,  # Scope mode (center/fixed)
-            0x15,  # Scope span
-            0x16,  # Scope edge number
-            0x17,  # Scope hold
-            0x19,  # Scope REF level
-            0x1A,  # Scope sweep speed
-            0x1B,  # Scope during TX
-            0x1C,  # Scope center type
-            0x1D,  # Scope VBW
-            0x1F,  # Scope RBW
-        ):
-            if scope_sub in SCOPE_RECEIVER_SELECTOR_SUBS:
-                queries.append(
-                    AcquisitionQuery(
-                        0x27,
-                        sub=scope_sub,
-                        data=bytes([SCOPE_SELECTOR_MAIN]),
-                    )
-                )
-            else:
-                queries.append(AcquisitionQuery(0x27, sub=scope_sub))
-
+            query = replace(query, receiver=None)
+        if query in seen:
+            continue
+        seen.add(query)
+        queries.append(query)
     return queries

--- a/tests/fixtures/civ_rx_frames.json
+++ b/tests/fixtures/civ_rx_frames.json
@@ -178,8 +178,8 @@
     }
   },
   {
-    "name": "cmd1C_sub03_tx_freq_monitor",
-    "comment": "0x1C/0x03 TX-frequency-monitor is observation-backed (MOR-437); the legacy RadioState mirror is no longer written and stays at its default.",
+    "name": "cmd1C_sub03_transmit_frequency",
+    "comment": "0x1C/0x03 is a transmit-frequency payload; it does not update the legacy tx_freq_monitor boolean, which stays at its default.",
     "frame": {"command": 28, "sub": 3, "data": "01"},
     "expected_state": {
       "tx_freq_monitor": false

--- a/tests/integration/test_rit_tuner_integration.py
+++ b/tests/integration/test_rit_tuner_integration.py
@@ -8,7 +8,7 @@ Commands under test:
   2. RIT Status (0x21 sub 0x01) — get/set on/off
   3. RIT TX Status (0x21 sub 0x02) — get/set on/off
   4. Tuner Status (0x1C sub 0x01) — get/set 0/1/2
-  5. TX Freq Monitor (0x1C sub 0x05) — get/set on/off
+  5. Legacy TX Freq Monitor API — fails closed; XFC is 0x1C sub 0x02
 
 Run with::
 
@@ -31,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 pytestmark = pytest.mark.mock_integration
 
 from rigplane.radio import IcomRadio  # noqa: E402, TID251
+from rigplane.exceptions import CommandError  # noqa: E402
 from _perf_helpers import fast_connect  # noqa: E402
 from mock_server import MockIcomRadio  # noqa: E402
 
@@ -45,7 +46,6 @@ _SUB_RIT_TX = 0x02
 
 _CMD_TUNER = 0x1C
 _SUB_TUNER_STATUS = 0x01
-_SUB_TX_FREQ_MON = 0x03
 
 _SETTLE = 0.05  # seconds: wait after fire-and-forget SET before GET
 
@@ -100,7 +100,6 @@ class RitTunerMockRadio(MockIcomRadio):
       - 0x21 / sub 0x01: RIT on/off
       - 0x21 / sub 0x02: RIT TX on/off
       - 0x1C / sub 0x01: tuner status get/set (0=off, 1=on, 2=tuning)
-      - 0x1C / sub 0x05: TX freq monitor on/off
 
     All other commands are forwarded to the parent MockIcomRadio.
     """
@@ -111,7 +110,6 @@ class RitTunerMockRadio(MockIcomRadio):
         self._rit_on: int = 0  # 0=off, 1=on
         self._rit_tx_on: int = 0  # 0=off, 1=on
         self._tuner_status: int = 0  # 0=off, 1=on, 2=tuning
-        self._tx_freq_mon: int = 0  # 0=off, 1=on
 
     # ------------------------------------------------------------------
     # CI-V dispatch override
@@ -200,11 +198,11 @@ class RitTunerMockRadio(MockIcomRadio):
         )
 
     # ------------------------------------------------------------------
-    # Tuner / TX freq monitor dispatch (0x1C)
+    # Tuner dispatch (0x1C)
     # ------------------------------------------------------------------
 
     def _dispatch_tuner(self, payload: bytes, from_addr: int) -> bytes:
-        """Dispatch tuner/TX-freq-monitor commands (cmd 0x1C)."""
+        """Dispatch tuner commands (cmd 0x1C)."""
         if not payload:
             return self._civ_nak(from_addr, self._radio_addr)
 
@@ -213,8 +211,6 @@ class RitTunerMockRadio(MockIcomRadio):
 
         if sub == _SUB_TUNER_STATUS:
             return self._handle_tuner_status(rest, from_addr)
-        if sub == _SUB_TX_FREQ_MON:
-            return self._handle_tx_freq_mon(rest, from_addr)
         return self._civ_nak(from_addr, self._radio_addr)
 
     def _handle_tuner_status(self, rest: bytes, from_addr: int) -> bytes:
@@ -233,24 +229,6 @@ class RitTunerMockRadio(MockIcomRadio):
             _CMD_TUNER,
             sub=_SUB_TUNER_STATUS,
             data=bytes([self._tuner_status]),
-        )
-
-    def _handle_tx_freq_mon(self, rest: bytes, from_addr: int) -> bytes:
-        """Handle TX freq monitor on/off (0x1C sub 0x05)."""
-        to = from_addr
-        frm = self._radio_addr
-
-        if rest:  # SET
-            self._tx_freq_mon = rest[0]
-            return self._civ_ack(to, frm)
-
-        # GET
-        return self._civ_frame(
-            to,
-            frm,
-            _CMD_TUNER,
-            sub=_SUB_TX_FREQ_MON,
-            data=bytes([self._tx_freq_mon]),
         )
 
 
@@ -536,51 +514,15 @@ class TestTunerStatus:
 
 
 class TestTxFreqMonitor:
-    """TX frequency monitor on/off roundtrip tests."""
+    """Legacy boolean API must not write the read-only 1C/03 command."""
 
-    async def test_default_off(self, rit_tuner_radio: IcomRadio) -> None:
-        """Default TX freq monitor is OFF."""
-        result = await rit_tuner_radio.get_tx_freq_monitor()
-        assert result is False
+    async def test_get_fails_closed(self, rit_tuner_radio: IcomRadio) -> None:
+        with pytest.raises(CommandError, match="declared absent"):
+            await rit_tuner_radio.get_tx_freq_monitor()
 
-    async def test_set_on(
-        self, rit_tuner_radio: IcomRadio, rit_tuner_mock: RitTunerMockRadio
-    ) -> None:
-        """Set TX freq monitor ON and verify via GET."""
-        await rit_tuner_radio.set_tx_freq_monitor(True)
-        await asyncio.sleep(_SETTLE)
-
-        result = await rit_tuner_radio.get_tx_freq_monitor()
-        assert result is True
-        assert rit_tuner_mock._tx_freq_mon == 1
-
-    async def test_set_off_after_on(
-        self, rit_tuner_radio: IcomRadio, rit_tuner_mock: RitTunerMockRadio
-    ) -> None:
-        """Set TX freq monitor ON then OFF; GET returns False."""
-        await rit_tuner_radio.set_tx_freq_monitor(True)
-        await asyncio.sleep(_SETTLE)
-
-        await rit_tuner_radio.set_tx_freq_monitor(False)
-        await asyncio.sleep(_SETTLE)
-
-        result = await rit_tuner_radio.get_tx_freq_monitor()
-        assert result is False
-        assert rit_tuner_mock._tx_freq_mon == 0
-
-    async def test_toggle_on_off_on(self, rit_tuner_radio: IcomRadio) -> None:
-        """Toggle TX freq monitor on → off → on."""
-        await rit_tuner_radio.set_tx_freq_monitor(True)
-        await asyncio.sleep(_SETTLE)
-        assert await rit_tuner_radio.get_tx_freq_monitor() is True
-
-        await rit_tuner_radio.set_tx_freq_monitor(False)
-        await asyncio.sleep(_SETTLE)
-        assert await rit_tuner_radio.get_tx_freq_monitor() is False
-
-        await rit_tuner_radio.set_tx_freq_monitor(True)
-        await asyncio.sleep(_SETTLE)
-        assert await rit_tuner_radio.get_tx_freq_monitor() is True
+    async def test_set_fails_closed(self, rit_tuner_radio: IcomRadio) -> None:
+        with pytest.raises(CommandError, match="declared absent"):
+            await rit_tuner_radio.set_tx_freq_monitor(True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -16,8 +16,8 @@
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.
 IC-705	246	128	231
-IC-7300	322	181	279
-IC-7610	217	129	171
-IC-9700	230	137	183
+IC-7300	323	182	279
+IC-7610	218	130	171
+IC-9700	231	138	183
 X6100	67	42	50
 X6200	68	43	50

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -15,9 +15,9 @@
 #   RIGPLANE_REGEN_REVERSE_COMMAND_INDEX_CENSUS=1 uv run pytest tests/test_reverse_command_index.py
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.
-IC-705	244	127	229
+IC-705	242	126	227
 IC-7300	323	182	279
 IC-7610	216	129	169
-IC-9700	229	137	181
+IC-9700	228	136	181
 X6100	67	42	50
 X6200	68	43	50

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -15,9 +15,9 @@
 #   RIGPLANE_REGEN_REVERSE_COMMAND_INDEX_CENSUS=1 uv run pytest tests/test_reverse_command_index.py
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.
-IC-705	246	128	231
+IC-705	244	127	229
 IC-7300	323	182	279
-IC-7610	218	130	171
-IC-9700	231	138	183
+IC-7610	216	129	169
+IC-9700	229	137	181
 X6100	67	42	50
 X6200	68	43	50

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -87,8 +87,18 @@ def test_profile_query_bytes_replace_scheduler_literals(
 @pytest.mark.parametrize("model", ["IC-7300", "IC-7610", "IC-9700"])
 def test_missing_ptt_getter_fails_closed(model: str) -> None:
     profile = get_radio_profile(model)
-    assert "get_transceiver_status" not in profile.command_names
-    executor, _sent = recording_executor(profile)
+    assert profile.command_map is not None
+    without_getter = replace(
+        profile,
+        command_map=CommandMap(
+            {
+                name: profile.command_map.get(name)
+                for name in profile.command_map
+                if name != "get_transceiver_status"
+            }
+        ),
+    )
+    executor, _sent = recording_executor(without_getter)
 
     assert executor.query_for_path(FieldPath.global_("tx_state", "ptt")) is None
 
@@ -972,7 +982,7 @@ def test_ic7610_real_profile_freq_mode_are_pollable_and_emit_25_26() -> None:
     } <= set(sent)
 
 
-def test_ic7610_real_profile_ptt_without_getter_fails_closed() -> None:
+def test_ic7610_real_profile_ptt_getter_emits_declared_read() -> None:
     acquisition = load_rig(RIGS_DIR / "ic7610.toml").to_profile().state_acquisition
     assert acquisition is not None
 
@@ -987,7 +997,7 @@ def test_ic7610_real_profile_ptt_without_getter_fails_closed() -> None:
 
     executor, sent = recording_executor(get_radio_profile("IC-7610"))
 
-    assert executor.query_for_path(ptt) is None
+    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
 
     for request in requests:
         if ptt not in request.paths:
@@ -995,10 +1005,9 @@ def test_ic7610_real_profile_ptt_without_getter_fails_closed() -> None:
         execution = asyncio.run(
             executor.execute(request, already_sent_paths=frozenset())
         )
-        assert execution.sent_paths == ()
-        assert execution.failed_paths == (ptt,)
-        assert execution.failure_reason == "no_civ_query_mapping"
-    assert sent == []
+        assert ptt in execution.sent_paths
+        assert ptt not in execution.failed_paths
+    assert acquisition_query(0x1C, sub=0x00) in sent
 
 
 def test_ic7610_real_profile_att_preamp_squelch_query_for_path() -> None:
@@ -2995,7 +3004,7 @@ def test_ic7610_real_profile_tx_vox_toggle_query_for_path() -> None:
     ptt = FieldPath.global_("tx_state", "ptt")
     rit_on = FieldPath.global_("tx_state", "rit_on")
     rit_tx = FieldPath.global_("tx_state", "rit_tx")
-    assert executor.query_for_path(ptt) is None
+    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
     assert executor.query_for_path(rit_on) == acquisition_query(0x21, sub=0x01)
     assert executor.query_for_path(rit_tx) == acquisition_query(0x21, sub=0x02)
 
@@ -3140,7 +3149,7 @@ def test_ic7610_real_profile_vfo_global_query_for_path() -> None:
     compressor_on = FieldPath.global_("tx_state", "compressor_on")
     monitor_on = FieldPath.global_("tx_state", "monitor_on")
     vox_on = FieldPath.global_("tx_state", "vox_on")
-    assert executor.query_for_path(ptt) is None
+    assert executor.query_for_path(ptt) == acquisition_query(0x1C, sub=0x00)
     assert executor.query_for_path(rit_on) == acquisition_query(0x21, sub=0x01)
     assert executor.query_for_path(rit_tx) == acquisition_query(0x21, sub=0x02)
     assert executor.query_for_path(compressor_on) == acquisition_query(0x16, sub=0x44)

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -1738,12 +1738,6 @@ _SLOW_STATE_TOGGLE_CASES = (
         "tunerStatus",
         2,
     ),
-    (
-        _make_frame(cmd=0x1C, sub=0x03, data=b"\x01"),
-        "global.tx_state.tx_freq_monitor",
-        "txFreqMonitor",
-        True,
-    ),
     # 0x12 0x00 0x01 RX-ANT for ANT1 ON → global slow-state bool (MOR-462).
     (
         _make_frame(cmd=0x12, sub=0x00, data=b"\x01"),
@@ -4167,14 +4161,18 @@ def test_update_radio_state_tuner_status(radio_with_state: IcomRadio) -> None:
     assert field.value == 2
 
 
-def test_update_radio_state_tx_freq_monitor(radio_with_state: IcomRadio) -> None:
-    """TX freq monitor (0x1C 0x03) is observation-backed (MOR-437)."""
-    frame = CivFrame(0xE0, 0x98, 0x1C, 0x03, b"\x01")
-    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
-    field = radio_with_state._state_store.snapshot().field(
-        "global.tx_state.tx_freq_monitor"
-    )
-    assert field.value is True
+def test_transmit_frequency_does_not_update_boolean_monitor_state(
+    radio_with_state: IcomRadio,
+) -> None:
+    frame = CivFrame(0xE0, 0x98, 0x1C, 0x03, b"\x00\x00\x10\x07\x00")
+    with patch(
+        "rigplane.runtime._civ_rx.parse_frequency_response",
+        return_value=7_100_000,
+    ) as parse_frequency:
+        radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
+
+    parse_frequency.assert_called_once_with(frame)
+    assert radio_with_state._state_store.snapshot().fields == ()
 
 
 def test_update_radio_state_rit_frequency(radio_with_state: IcomRadio) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -41,7 +41,7 @@ from test_radio import MockTransport, _wrap_civ_in_udp
 
 from rigplane import IC_7610_ADDR
 from rigplane.runtime._civ_rx import CIV_HEADER_SIZE
-from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
+from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, parse_civ_frame
 from rigplane.commands.tone import _encode_tone_freq
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
@@ -56,6 +56,7 @@ from rigplane.core.state_acquisition_policy import (
     RadioAcquisitionProfile,
 )
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
+from rigplane.core.tx_target import KnownTxTarget
 from rigplane.core.state_pipeline_contracts import (
     FieldPath,
     Observation,
@@ -4161,18 +4162,19 @@ def test_update_radio_state_tuner_status(radio_with_state: IcomRadio) -> None:
     assert field.value == 2
 
 
-def test_transmit_frequency_does_not_update_boolean_monitor_state(
+def test_update_radio_state_tx_freq_monitor_decodes_transmit_frequency_not_boolean(
     radio_with_state: IcomRadio,
 ) -> None:
-    frame = CivFrame(0xE0, 0x98, 0x1C, 0x03, b"\x00\x00\x10\x07\x00")
-    with patch(
-        "rigplane.runtime._civ_rx.parse_frequency_response",
-        return_value=7_100_000,
-    ) as parse_frequency:
-        radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
+    # Full directed IC-7610 response: 1C/03 + 7.100 MHz in five-byte BCD.
+    frame = parse_civ_frame(bytes.fromhex("FE FE E0 98 1C 03 00 00 10 07 00 FD"))
+    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
 
-    parse_frequency.assert_called_once_with(frame)
-    assert radio_with_state._state_store.snapshot().fields == ()
+    snapshot = radio_with_state._state_store.snapshot()
+    assert snapshot.field("global.tx_state.tx_target").value == KnownTxTarget(
+        receiver="MAIN", slot=None, frequency_hz=7_100_000
+    )
+    with pytest.raises(KeyError):
+        snapshot.field("global.tx_state.tx_freq_monitor")
 
 
 def test_update_radio_state_rit_frequency(radio_with_state: IcomRadio) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -4170,11 +4170,56 @@ def test_update_radio_state_tx_freq_monitor_decodes_transmit_frequency_not_boole
     radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
 
     snapshot = radio_with_state._state_store.snapshot()
-    assert snapshot.field("global.tx_state.tx_target").value == KnownTxTarget(
+    field = snapshot.field("global.tx_state.tx_target")
+    assert field.value == KnownTxTarget(
         receiver="MAIN", slot=None, frequency_hz=7_100_000
+    )
+    assert field.max_age == 8.0
+    radio_with_state._state_store.mark_stale_due(
+        now=field.last_observed_monotonic + field.max_age + 0.001
+    )
+    assert (
+        radio_with_state._state_store.snapshot()
+        .field("global.tx_state.tx_target")
+        .freshness
+        is FreshnessState.STALE
     )
     with pytest.raises(KeyError):
         snapshot.field("global.tx_state.tx_freq_monitor")
+
+
+def test_direct_tx_frequency_coexists_with_ic7300_derived_target() -> None:
+    radio = IcomRadio("192.0.2.1", model="IC-7300")
+    radio._radio_state = RadioState()
+    frame = parse_civ_frame(bytes.fromhex("FE FE E0 94 1C 03 00 00 50 14 00 FD"))
+    radio._civ_runtime._update_state_cache_from_frame(frame)
+
+    path = FieldPath.global_("tx_state", "tx_target")
+    direct = radio._state_store.snapshot().field(path)
+    assert direct.value == KnownTxTarget(
+        receiver="MAIN", slot=None, frequency_hz=14_500_000
+    )
+    assert direct.max_age == 3.0
+
+    # The ordinary IC-7300 derivation remains authoritative when it follows a
+    # one-off direct response, and retains the same finite profile TTL.
+    derived_at = direct.last_observed_monotonic + 0.1
+    radio._state_store.apply(
+        Observation(
+            path=path,
+            value=KnownTxTarget(receiver="MAIN", slot="A", frequency_hz=14_250_000),
+            source=SourceMetadata(source="local_reconcile", provider="icom_civ"),
+            timestamp_monotonic=derived_at,
+            max_age=direct.max_age,
+            provider_generation=radio._state_store.provider_generation,
+        )
+    )
+    derived = radio._state_store.snapshot().field(path)
+    assert derived.value == KnownTxTarget(
+        receiver="MAIN", slot="A", frequency_hz=14_250_000
+    )
+    radio._state_store.mark_stale_due(now=derived_at + derived.max_age + 0.001)
+    assert radio._state_store.snapshot().field(path).freshness is FreshnessState.STALE
 
 
 def test_update_radio_state_rit_frequency(radio_with_state: IcomRadio) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -31,6 +31,8 @@ from rigplane.commands import (
     set_mode,
     set_rf_power,
 )
+from rigplane.commands.bound import BoundCommands
+from rigplane.exceptions import CommandError
 from rigplane.types import (
     AgcMode,
     AudioPeakFilter,
@@ -1304,9 +1306,9 @@ class TestTransceiverStatusBuilders:
     batch 1 for the system.py builders here -- band edge, tuner/XFC/
     TX-freq-monitor status, RIT/XIT; batch 2 for the meters.py builders --
     various-squelch and the power/comp/Vd/Id meters. Every builder here now
-    requires ``cmd_map`` -- zero divergence rows, so IC-7610's own map
-    declares the identical bytes the fallback used to build, and the
-    expected frames below are unchanged.
+    requires ``cmd_map``. The legacy TX-frequency-monitor pair is explicitly
+    absent on IC-7610 because 1C/03 is a read-only frequency payload; the
+    remaining builders use the profile-declared bytes below.
     """
 
     @pytest.fixture()
@@ -1404,23 +1406,28 @@ class TestTransceiverStatusBuilders:
         with pytest.raises(TypeError, match="MOR-2006"):
             set_tuner_status(1, cmd_map=None)
 
-    def test_get_tx_freq_monitor(self, cmd_map) -> None:
-        from rigplane.commands import get_tx_freq_monitor
+    def test_get_tx_freq_monitor_fails_closed(self) -> None:
+        profile = load_rig(RIG_DIR / "ic7610.toml").to_profile()
+        assert profile.command_map is not None
+        commands = BoundCommands(
+            profile.command_map,
+            profile.absent_command_sources,
+        )
 
-        frame = get_tx_freq_monitor(cmd_map=cmd_map)
-        assert b"\xfe\xfe\x98\xe0\x1c\x03\xfd" == frame
+        with pytest.raises(CommandError, match="declared absent"):
+            commands.get_tx_freq_monitor(to_addr=profile.civ_addr)
 
-    def test_set_tx_freq_monitor_on(self, cmd_map) -> None:
-        from rigplane.commands import set_tx_freq_monitor
+    @pytest.mark.parametrize("on", (True, False))
+    def test_set_tx_freq_monitor_fails_closed(self, on: bool) -> None:
+        profile = load_rig(RIG_DIR / "ic7610.toml").to_profile()
+        assert profile.command_map is not None
+        commands = BoundCommands(
+            profile.command_map,
+            profile.absent_command_sources,
+        )
 
-        frame = set_tx_freq_monitor(True, cmd_map=cmd_map)
-        assert b"\x1c\x03\x01" in frame
-
-    def test_set_tx_freq_monitor_off(self, cmd_map) -> None:
-        from rigplane.commands import set_tx_freq_monitor
-
-        frame = set_tx_freq_monitor(False, cmd_map=cmd_map)
-        assert b"\x1c\x03\x00" in frame
+        with pytest.raises(CommandError, match="declared absent"):
+            commands.set_tx_freq_monitor(on, to_addr=profile.civ_addr)
 
     def test_get_rit_frequency(self, cmd_map) -> None:
         from rigplane.commands import get_rit_frequency

--- a/tests/test_mor1517_cmd29_gating.py
+++ b/tests/test_mor1517_cmd29_gating.py
@@ -506,9 +506,7 @@ class TestManualNotchGating:
 
 
 class TestManualNotchWidthGating:
-    """0x16/0x57 (manual notch width) is not in IC-7610's [cmd29] routes
-    either — it must go out unwrapped on BOTH profiles. Before this fix it
-    was silently broken on IC-7610 too, not just IC-7300."""
+    """IC-7610 marks 0x16/0x57 command-29 capable; IC-7300 does not."""
 
     @pytest.mark.asyncio
     async def test_set_manual_notch_width_unwrapped_on_ic7300(self) -> None:
@@ -525,19 +523,22 @@ class TestManualNotchWidthGating:
         assert _sent_civ(mock) == expected
 
     @pytest.mark.asyncio
-    async def test_set_manual_notch_width_unwrapped_on_ic7610(self) -> None:
+    @pytest.mark.parametrize("receiver", (0, 1))
+    async def test_set_manual_notch_width_wrapped_on_ic7610(
+        self, receiver: int
+    ) -> None:
         radio = _connected_icom(model="IC-7610")
         mock = _mock_raw(radio)
-        await radio.set_manual_notch_width(2, receiver=0)
+        await radio.set_manual_notch_width(2, receiver=receiver)
         expected = set_manual_notch_width(
             2,
             to_addr=_IC7610_ADDR,
-            receiver=0,
-            command29=False,
+            receiver=receiver,
+            command29=True,
             cmd_map=_IC7610_CMD_MAP,
         )
         assert _sent_civ(mock) == expected
-        assert radio._profile.supports_cmd29(0x16, 0x57) is False
+        assert radio._profile.supports_cmd29(0x16, 0x57) is True
 
 
 class TestTwinPeakFilterGating:

--- a/tests/test_mor1545_dedupe_key_inventory.py
+++ b/tests/test_mor1545_dedupe_key_inventory.py
@@ -31,19 +31,10 @@ What is pinned here, and what is not:
 
 * :func:`test_no_receiver_scoped_read_authors_a_bare_dedupe_key` covers all
   27 sites at once -- it fails on any one of them reverting to a bare key.
-* The race tests *execute* 26 of the 27 sites, which is not the same as
-  *detecting* a regression at each. Reverting one site at a time, 6 of the 27
-  redden the invariant alone and no race test: both ``get_repeater_tone``
-  sites, both ``get_repeater_tsql`` sites, ``get_filter_width``'s VFO-select
-  fallback site, and ``get_manual_notch_width``. Two sites sharing a family
-  only collide when *both* lose their scoping, and tone/TSQL are not declared
-  on IC-7610 at all, so no row can pin either of their sites alone.
-* ``get_manual_notch_width`` is the one site no race row even executes: its
-  0x16/0x57 is absent from the IC-7610 ``[cmd29] routes`` and IC-9700 has
-  ``routes = []``, so ``_dual_rx_runtime.py: _require_cmd29_route`` rejects
-  ``receiver=1``. That is measured against every profile declaring
-  ``receiver_count = 2`` -- read from ``rigs/``, not listed here -- by
-  :func:`test_declared_exception_cannot_host_a_dual_receiver_race`.
+* The race table now executes all 27 sites. Some families have both a direct
+  and VFO-fallback call site, so the source-derived inventory assertion remains
+  necessary alongside the wire races. ``get_manual_notch_width`` is raced on
+  IC-7610 because its official guide marks 0x16/0x57 as Command 29 supported.
 * That ``IcomCommander.send`` coalesces at all is *not* pinned here; the
   same-receiver control tests only keep a change that stopped deduping
   altogether from passing this file silently.
@@ -320,6 +311,13 @@ _IC7610_ROWS = [
         main=(b"\x01", FilterShape.SOFT),
         sub_rx=(b"\x00", FilterShape.SHARP),
     ),
+    _byte(
+        "get_manual_notch_width",
+        0x16,
+        0x57,
+        main=(b"\x00", 0),
+        sub_rx=(b"\x02", 2),
+    ),
     _byte("get_filter_width", 0x1A, 0x03, main=(b"\x01", 100), sub_rx=(b"\x02", 150)),
 ]
 
@@ -335,14 +333,7 @@ _IC9700_ROWS = [
 
 _RACE_TABLE = [*_IC7610_ROWS, *_IC9700_ROWS]
 
-_NO_DUAL_RX_HOST = {
-    # 0x16/0x57 is absent from IC-7610's [cmd29] routes and IC-9700 declares
-    # none at all, so ``_dual_rx_runtime.py: _require_cmd29_route`` rejects
-    # receiver=1 on both: there is no profile on which this family's two
-    # receivers can race. Held to that claim by
-    # test_declared_exception_cannot_host_a_dual_receiver_race.
-    "get_manual_notch_width",
-}
+_NO_DUAL_RX_HOST: set[str] = set()
 
 
 def _dual_rx_models() -> list[str]:

--- a/tests/test_poller_poll_priority.py
+++ b/tests/test_poller_poll_priority.py
@@ -130,7 +130,8 @@ async def test_state_query_sends_background_priority() -> None:
     assert radio.send_civ.await_count >= 1
     calls = [logical_civ_call(call) for call in radio.send_civ.await_args_list]
     assert any(receiver is not None for receiver, _, _, _ in calls)
-    assert any(command == 0x18 for _, command, _, _ in calls)
+    assert any(command == 0x1C and sub == 0x00 for _, command, sub, _ in calls)
+    assert all(command != 0x18 for _, command, _, _ in calls)
     for call in radio.send_civ.await_args_list:
         assert _priority_of(call) == Priority.BACKGROUND
         assert _wait_dispatch_of(call) is False
@@ -165,7 +166,8 @@ async def test_state_query_sends_fire_and_forget() -> None:
     assert radio.send_civ.await_count >= 1
     calls = [logical_civ_call(call) for call in radio.send_civ.await_args_list]
     assert any(receiver is not None for receiver, _, _, _ in calls)
-    assert any(command == 0x18 for _, command, _, _ in calls)
+    assert any(command == 0x1C and sub == 0x00 for _, command, sub, _ in calls)
+    assert all(command != 0x18 for _, command, _, _ in calls)
     for call in radio.send_civ.await_args_list:
         assert _priority_of(call) == Priority.BACKGROUND
         assert _wait_dispatch_of(call) is False

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -2222,7 +2222,7 @@ async def test_relative_vfo_epoch_reset_discards_vfo_facts_but_not_ptt() -> None
 
 @pytest.mark.parametrize(
     ("model", "expected_seconds"),
-    (("IC-7300", 8.0), ("IC-705", 5.0)),
+    (("IC-7300", 8.0), ("IC-705", 9.0)),
 )
 def test_relative_vfo_retention_window_follows_provider_poll_cadence(
     model: str,
@@ -5978,14 +5978,10 @@ async def test_tx_target_unsupported_for_non_selected_unselected_profile() -> No
 async def test_tx_target_max_age_floors_fallback_for_profile_without_acquisition() -> (
     None
 ):
-    """Review R3: IC-705 has ``vfo_readback == "selected_unselected"`` (so
-    it DOES get a derivation) but currently ships no ``[state_acquisition]``
-    block, so the old bare ``4 * self._fast_interval`` fallback floored at
-    0.1s on its LAN profile (25ms fast interval) — the verifier measured
-    6.6 stale-transitions/s from that on an otherwise-idle radio. The
-    fallback must floor at ``_TX_TARGET_FALLBACK_MAX_AGE`` instead."""
+    """Profiles constructed without acquisition policy retain the safe floor."""
 
     radio = _make_radio(model="IC-705")
+    radio.profile = dataclasses.replace(radio.profile, state_acquisition=None)
     assert radio.profile.state_acquisition is None
     assert radio.profile.vfo_readback == "selected_unselected"
     poller = RadioPoller(radio, CommandQueue(), state_store=StateStore())

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -1004,6 +1004,16 @@ async def test_scheduler_ptt_request_uses_ic705_declared_getter() -> None:
 @pytest.mark.asyncio
 async def test_scheduler_ptt_without_profile_getter_fails_closed() -> None:
     radio = _make_radio(active="MAIN", model="IC-7610")
+    profile = radio.profile
+    assert profile.command_map is not None
+    command_map = CommandMap(
+        {
+            name: profile.command_map.get(name)
+            for name in profile.command_map
+            if name != "get_transceiver_status"
+        }
+    )
+    radio.profile = dataclasses.replace(profile, command_map=command_map)
     path = FieldPath.global_("tx_state", "ptt")
     scheduler = AcquisitionScheduler(profile=_acquisition_profile(path))
     radio._acquisition_scheduler = scheduler
@@ -2212,10 +2222,7 @@ async def test_relative_vfo_epoch_reset_discards_vfo_facts_but_not_ptt() -> None
 
 @pytest.mark.parametrize(
     ("model", "expected_seconds"),
-    # IC-705 dropped from 11.1s to 11.0s (one fewer query per rotation) when
-    # MOR-1540 removed the over-declared "digisel" capability, which had
-    # been adding an unanswerable 0x16/0x4E poll to every rotation.
-    (("IC-7300", 8.0), ("IC-705", 11.0)),
+    (("IC-7300", 8.0), ("IC-705", 5.0)),
 )
 def test_relative_vfo_retention_window_follows_provider_poll_cadence(
     model: str,
@@ -2692,9 +2699,6 @@ def test_state_queries_include_operator_toggle_reads_for_ic7610() -> None:
     poller = RadioPoller(_make_radio(), StateCache(), CommandQueue())
 
     assert {
-        acquisition_query(0x15, sub=0x01, receiver=0x00),
-        acquisition_query(0x15, sub=0x01, receiver=0x01),
-        acquisition_query(0x15, sub=0x07),
         acquisition_query(0x16, sub=0x12, receiver=0x00),
         acquisition_query(0x16, sub=0x12, receiver=0x01),
         acquisition_query(0x16, sub=0x32, receiver=0x00),
@@ -2709,13 +2713,17 @@ def test_state_queries_include_operator_toggle_reads_for_ic7610() -> None:
         acquisition_query(0x16, sub=0x48, receiver=0x01),
         acquisition_query(0x16, sub=0x4F, receiver=0x00),
         acquisition_query(0x16, sub=0x4F, receiver=0x01),
-        acquisition_query(0x16, sub=0x50),
         acquisition_query(0x16, sub=0x56, receiver=0x00),
         acquisition_query(0x16, sub=0x56, receiver=0x01),
-        acquisition_query(0x16, sub=0x58),
         acquisition_query(0x1A, sub=0x04, receiver=0x00),
         acquisition_query(0x1A, sub=0x04, receiver=0x01),
     }.issubset(set(poller._STATE_QUERIES))  # noqa: SLF001
+    assert {
+        acquisition_query(0x15, sub=0x01, receiver=0x00),
+        acquisition_query(0x15, sub=0x07),
+        acquisition_query(0x16, sub=0x50),
+        acquisition_query(0x16, sub=0x58),
+    }.isdisjoint(set(poller._STATE_QUERIES))  # noqa: SLF001
 
 
 def test_state_queries_include_transceiver_status_reads_for_ic7610() -> None:
@@ -2723,11 +2731,11 @@ def test_state_queries_include_transceiver_status_reads_for_ic7610() -> None:
 
     assert {
         acquisition_query(0x1C, sub=0x01),
-        acquisition_query(0x1C, sub=0x03),
         acquisition_query(0x21, sub=0x00),
         acquisition_query(0x21, sub=0x01),
         acquisition_query(0x21, sub=0x02),
     }.issubset(set(poller._STATE_QUERIES))  # noqa: SLF001
+    assert acquisition_query(0x1C, sub=0x03) not in poller._STATE_QUERIES  # noqa: SLF001
 
 
 def test_fast_cmds_include_comp_meter_for_ic7610() -> None:

--- a/tests/test_reverse_command_index.py
+++ b/tests/test_reverse_command_index.py
@@ -197,7 +197,7 @@ def test_all_strict_prefix_overlaps_preserve_shorter_candidates() -> None:
                         f"shorter={shorter!r} longer={longer!r}"
                     )
                     assert frozenset(prefix_groups[shorter]) <= expected
-    assert overlaps == 14
+    assert overlaps == 20
 
 
 class TestKnownCollisionShapes:

--- a/tests/test_rig_ic705.py
+++ b/tests/test_rig_ic705.py
@@ -39,4 +39,5 @@ class TestNoStrayCivOutputKeys:
 
     def test_neighboring_key_still_present(self, cmdmap) -> None:
         """Discrimination guard: the map is loaded and non-empty."""
-        assert cmdmap.has("get_tx_freq_monitor")
+        assert cmdmap.has("get_xfc_status")
+        assert not cmdmap.has("get_tx_freq_monitor")

--- a/tests/test_rig_ic7610.py
+++ b/tests/test_rig_ic7610.py
@@ -170,6 +170,7 @@ class TestProfileParity:
                 (0x16, 0x4F),
                 (0x16, 0x53),
                 (0x16, 0x56),
+                (0x16, 0x57),
                 (0x16, 0x65),
                 (0x1A, 0x03),
                 (0x1A, 0x04),
@@ -181,7 +182,7 @@ class TestProfileParity:
         assert profile.cmd29_routes == expected
 
     def test_cmd29_routes_count(self, profile):
-        assert len(profile.cmd29_routes) == 34
+        assert len(profile.cmd29_routes) == 35
 
     def test_vfo_main_code(self, profile):
         assert profile.vfo_main_code == 0xD0

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2869,7 +2869,7 @@ class TestIc7300DeclaresAbsentCommands:
 
 class TestIc9700DeclaresAbsentCommands:
     """MOR-2015 (D2): IC-9700 is filled with the ``{ absent = "<source>" }``
-    spelling for 25 commands the IC-9700 CI-V Reference Guide (Icom, 2019)
+    spelling for commands the IC-9700 CI-V Reference Guide (Icom, 2019)
     confirms have no row on this radio (26 at D2 time; MOR-2008 batch 1
     later deleted the dead bare ``quick_dual_watch`` entry, -1 net -- see
     ``rigs/ic9700.toml``'s own comment on that section) -- 10 unique
@@ -2878,6 +2878,8 @@ class TestIc9700DeclaresAbsentCommands:
     quick_dual_watch, rx_antenna_ant2), plus civ_output_ant (a
     copied-but-wrong 1A05 address with no real replacement) and the
     nb_depth/nb_width pair (no single global control, per-band only).
+    MOR-1983 adds the two legacy TX-frequency-monitor boolean names because
+    1C/03 is a read-only frequency payload, not a boolean get/set command.
     Pinned by name, not just count, so a future D2 pass on another
     command can't silently swap one of these for a different one and
     still pass a bare-count check.
@@ -2908,6 +2910,8 @@ class TestIc9700DeclaresAbsentCommands:
             "get_powerstat",
             "get_quick_dual_watch",
             "set_quick_dual_watch",
+            "get_tx_freq_monitor",
+            "set_tx_freq_monitor",
             # Bare "quick_dual_watch" removed here (MOR-2008 batch 1): no
             # builder resolved it, only get_/set_quick_dual_watch above do.
             "get_rx_antenna_ant2",
@@ -2927,11 +2931,12 @@ class TestIc9700DeclaresAbsentCommands:
 
 class TestIc705DeclaresAbsentCommands:
     """MOR-2016 (D2): IC-705 is filled with the ``{ absent = "<source>" }``
-    spelling for 26 commands the IC-705 CI-V Reference Guide (A7560-8EX-1,
+    spelling for commands the IC-705 CI-V Reference Guide (A7560-8EX-1,
     Jul.2020) confirms have no row on this radio (24 at D2 time; MOR-2007
     ruling 1 later split ``set_dual_watch`` into
     ``set_dual_watch_off``/``set_dual_watch_on``, +1 net; MOR-2143 added the
-    bare ``set_dual_watch`` name, +1, for the current 26). Pinned by name,
+    bare ``set_dual_watch`` name, +1). MOR-1983 adds the two legacy boolean
+    TX-frequency-monitor names because 1C/03 is read-only. Pinned by name,
     not just count, so a future D2 pass on another command can't silently
     swap one of these for a different one and still pass a bare-count
     check.
@@ -2963,6 +2968,8 @@ class TestIc705DeclaresAbsentCommands:
             "get_quick_dual_watch",
             "set_quick_dual_watch",
             "quick_dual_watch",
+            "get_tx_freq_monitor",
+            "set_tx_freq_monitor",
             "get_rx_antenna_ant2",
             "set_rx_antenna_ant2",
         }
@@ -2989,7 +2996,9 @@ class TestIc7610DeclaresAbsentCommands:
     IC-9700/IC-705 above, this is not a documentary D2 pass over the
     whole command table -- it is one feature family's absence, already
     established by MOR-660/661/682 well before this ticket, just not
-    previously spelled with the formal marker. Pinned by name, not just
+    previously spelled with the formal marker. MOR-1983 also marks the legacy
+    TX-frequency-monitor boolean names absent because 1C/03 is read-only.
+    Pinned by name, not just
     count, so a future D2 pass on another command can't silently swap
     one of these for a different one and still pass a bare-count check.
     """
@@ -3004,6 +3013,8 @@ class TestIc7610DeclaresAbsentCommands:
             "set_tone_freq",
             "get_tsql_freq",
             "set_tsql_freq",
+            "get_tx_freq_monitor",
+            "set_tx_freq_monitor",
         }
     )
 

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -2879,7 +2879,8 @@ class TestIc9700DeclaresAbsentCommands:
     copied-but-wrong 1A05 address with no real replacement) and the
     nb_depth/nb_width pair (no single global control, per-band only).
     MOR-1983 adds the two legacy TX-frequency-monitor boolean names because
-    1C/03 is a read-only frequency payload, not a boolean get/set command.
+    1C/03 is a read-only frequency payload, plus RBW because the scope table
+    ends at 1E.
     Pinned by name, not just count, so a future D2 pass on another
     command can't silently swap one of these for a different one and
     still pass a bare-count check.
@@ -2910,6 +2911,8 @@ class TestIc9700DeclaresAbsentCommands:
             "get_powerstat",
             "get_quick_dual_watch",
             "set_quick_dual_watch",
+            "get_scope_rbw",
+            "set_scope_rbw",
             "get_tx_freq_monitor",
             "set_tx_freq_monitor",
             # Bare "quick_dual_watch" removed here (MOR-2008 batch 1): no
@@ -2936,7 +2939,8 @@ class TestIc705DeclaresAbsentCommands:
     ruling 1 later split ``set_dual_watch`` into
     ``set_dual_watch_off``/``set_dual_watch_on``, +1 net; MOR-2143 added the
     bare ``set_dual_watch`` name, +1). MOR-1983 adds the two legacy boolean
-    TX-frequency-monitor names because 1C/03 is read-only. Pinned by name,
+    TX-frequency-monitor names because 1C/03 is read-only and the two RBW
+    names because the scope table ends at 1E. Pinned by name,
     not just count, so a future D2 pass on another command can't silently
     swap one of these for a different one and still pass a bare-count
     check.
@@ -2968,6 +2972,8 @@ class TestIc705DeclaresAbsentCommands:
             "get_quick_dual_watch",
             "set_quick_dual_watch",
             "quick_dual_watch",
+            "get_scope_rbw",
+            "set_scope_rbw",
             "get_tx_freq_monitor",
             "set_tx_freq_monitor",
             "get_rx_antenna_ant2",

--- a/tests/test_state_acquisition_policy.py
+++ b/tests/test_state_acquisition_policy.py
@@ -565,6 +565,18 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
         FieldPath.global_("meters", "comp"),
         FieldPath.global_("meters", "vd"),
         FieldPath.global_("meters", "id"),
+        FieldPath.scope_control("display", "receiver"),
+        FieldPath.scope_control("display", "dual"),
+        FieldPath.scope_control("display", "mode"),
+        FieldPath.scope_control("display", "span"),
+        FieldPath.scope_control("display", "edge"),
+        FieldPath.scope_control("display", "hold"),
+        FieldPath.scope_control("display", "ref_db"),
+        FieldPath.scope_control("display", "speed"),
+        FieldPath.scope_control("display", "during_tx"),
+        FieldPath.scope_control("display", "center_type"),
+        FieldPath.scope_control("display", "vbw_narrow"),
+        FieldPath.scope_control("display", "fixed_edge"),
     }
 
     assert set(acquisition.pollable_paths()) == expected_pollable
@@ -674,18 +686,17 @@ def test_ic7300_profile_enrolls_exact_supported_observation_rows() -> None:
     # +0.4 = +0.133 q/s), funded by giving six rarely-touched settings
     # (tuner_status, power_level, compressor_on/level, att, preamp; 6 fields)
     # back from 1.5s to 3.0s (-4.0 -> -2.0 = -2.0 q/s). Net:
-    # 19.967 + 1.333 + 0.133 - 2.0 = 19.433 q/s, comfortably BELOW the 20 q/s
-    # ceiling — required, not just desirable, since exceeding it would
-    # necessarily slow every other polled field's real throughput and risk
-    # regressing the very medians this tightening is meant to improve.
-    assert rx_state_demand_hz == pytest.approx(19.433, abs=0.001)
+    # 19.967 + 1.333 + 0.133 - 2.0 = 19.433 q/s before the twelve 30s scope
+    # reads declared by MOR-1983 add 0.4 q/s. The resulting 19.833 q/s stays
+    # below the 20 q/s ceiling.
+    assert rx_state_demand_hz == pytest.approx(19.833, abs=0.001)
     assert rx_state_demand_hz < serial_ceiling_hz
     # Po/SWR/ALC/COMP: 4 fields / 1.0s = 4.0 q/s, ONLY while tx_only gating
     # lets them through (PTT observed true) — a transient TX-window cost, not
     # a steady-state one. Untouched by MOR-1484.
     assert tx_only_demand_hz == pytest.approx(4.0, abs=0.001)
     total_during_tx_hz = rx_state_demand_hz + tx_only_demand_hz
-    assert total_during_tx_hz == pytest.approx(23.433, abs=0.001)
+    assert total_during_tx_hz == pytest.approx(23.833, abs=0.001)
 
     assert (
         acquisition.capability_for(

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -650,12 +650,53 @@ class TestBuildStateQueries:
         } | {
             FieldPath.receiver("sub", "operator_toggles", name) for name in ("nb", "nr")
         }
+        excluded_sub_freq_mode = {
+            FieldPath.active("sub", "freq_mode", name) for name in ("freq_hz", "mode")
+        }
 
         assert profile.cmd29_routes == frozenset()
         assert not excluded_sub_controls.intersection(pollable)
+        assert not excluded_sub_freq_mode.intersection(pollable)
         queries = build_state_queries(profile, set(profile.capabilities))
-        assert len(pollable) == len(queries) == 37
+        assert len(pollable) == len(queries) == 34
         assert all(query.receiver is None for query in queries)
+        assert not any(
+            query.command in {0x25, 0x26} and query.data == b"\x01" for query in queries
+        )
+
+    @pytest.mark.parametrize("model", ("IC-705", "IC-9700"))
+    def test_profiles_without_documented_scope_rbw_emit_no_271f(
+        self, model: str
+    ) -> None:
+        profile = resolve_radio_profile(model=model)
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        rbw_path = FieldPath.scope_control("display", "rbw")
+        commands = BoundCommands(
+            profile.command_map or CommandMap({}),
+            profile.absent_command_sources,
+        )
+
+        assert rbw_path not in acquisition.pollable_paths()
+        assert not any(
+            query.command == 0x27 and query.sub == 0x1F
+            for query in build_state_queries(profile, set(profile.capabilities))
+        )
+        with pytest.raises(CommandError, match="get_scope_rbw is not supported"):
+            commands.get_scope_rbw(to_addr=profile.civ_addr)
+        with pytest.raises(CommandError, match="get_scope_rbw is not supported"):
+            commands.scope_set_rbw(1, to_addr=profile.civ_addr)
+
+    def test_ic7610_documented_scope_rbw_remains_pollable(self) -> None:
+        profile = resolve_radio_profile(model="IC-7610")
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        rbw_path = FieldPath.scope_control("display", "rbw")
+
+        assert rbw_path in acquisition.pollable_paths()
+        assert acquisition_query(0x27, sub=0x1F, data=b"\x00") in build_state_queries(
+            profile, set(profile.capabilities)
+        )
 
     @pytest.mark.parametrize("model", _shipped_civ_models())
     def test_legacy_tx_freq_monitor_builders_fail_closed(self, model: str) -> None:

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, call, patch
 import pytest
 
 from rigplane.commands._frame import build_civ_frame, decode_wire_tuple
+from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
 from rigplane.commands.commander import Priority
 from rigplane.commands.scope import (
@@ -19,6 +20,7 @@ from rigplane.commands.scope import (
 )
 from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
 from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.exceptions import CommandError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.rigctld.server import RigctldServer
@@ -596,8 +598,10 @@ class TestBuildStateQueries:
             if query.receiver is not None and not profile.supports_cmd29(
                 query.command, query.sub
             ):
-                if query.receiver != 0:
-                    continue
+                assert query.receiver == 0, (
+                    f"{model}: declared pollable path {path} has no "
+                    "executable receiver route"
+                )
                 query = replace(query, receiver=None)
             if query not in expected:
                 expected.append(query)
@@ -606,6 +610,80 @@ class TestBuildStateQueries:
         assert queries
         assert queries == expected
         assert len(queries) == len(set(queries))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", _shipped_civ_models())
+    async def test_every_shipped_civ_pollable_path_is_scheduler_executable(
+        self, model: str
+    ) -> None:
+        profile = resolve_radio_profile(model=model)
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        pollable = acquisition.pollable_paths()
+        sent: list[AcquisitionQueryCase] = []
+
+        async def sender(query: AcquisitionQueryCase) -> None:
+            sent.append(query)
+
+        executor = IcomCivAcquisitionExecutor(
+            sender,
+            resolve_query=acquisition_query_resolver_for_profile(profile),
+            supports_cmd29=profile.supports_cmd29,
+        )
+        result = await executor.execute(  # type: ignore[arg-type]
+            SimpleNamespace(paths=pollable),
+            already_sent_paths=frozenset(),
+        )
+
+        assert result.sent_paths == pollable
+        assert result.failed_paths == ()
+        assert sent == build_state_queries(profile, set(profile.capabilities))
+
+    def test_ic9700_polling_paths_have_exact_executable_query_parity(self) -> None:
+        profile = resolve_radio_profile(model="IC-9700")
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        pollable = acquisition.pollable_paths()
+        excluded_sub_controls = {
+            FieldPath.receiver("sub", "operator_controls", name)
+            for name in ("af_level", "rf_gain", "squelch", "att", "preamp", "agc")
+        } | {
+            FieldPath.receiver("sub", "operator_toggles", name) for name in ("nb", "nr")
+        }
+
+        assert profile.cmd29_routes == frozenset()
+        assert not excluded_sub_controls.intersection(pollable)
+        queries = build_state_queries(profile, set(profile.capabilities))
+        assert len(pollable) == len(queries) == 37
+        assert all(query.receiver is None for query in queries)
+
+    @pytest.mark.parametrize("model", _shipped_civ_models())
+    def test_legacy_tx_freq_monitor_builders_fail_closed(self, model: str) -> None:
+        profile = resolve_radio_profile(model=model)
+        commands = BoundCommands(
+            profile.command_map or CommandMap({}),
+            profile.absent_command_sources,
+        )
+
+        with pytest.raises(CommandError, match="get_tx_freq_monitor is not supported"):
+            commands.get_tx_freq_monitor(to_addr=profile.civ_addr)
+        with pytest.raises(CommandError, match="set_tx_freq_monitor is not supported"):
+            commands.set_tx_freq_monitor(True, to_addr=profile.civ_addr)
+
+    @pytest.mark.parametrize("model", ("IC-705", "IC-7300", "IC-7610", "IC-9700"))
+    def test_xfc_builders_remain_bound_to_boolean_1c02(self, model: str) -> None:
+        profile = resolve_radio_profile(model=model)
+        commands = BoundCommands(
+            profile.command_map or CommandMap({}),
+            profile.absent_command_sources,
+        )
+
+        assert commands.get_xfc_status(to_addr=profile.civ_addr) == build_civ_frame(
+            profile.civ_addr, 0xE0, 0x1C, sub=0x02
+        )
+        assert commands.set_xfc_status(
+            True, to_addr=profile.civ_addr
+        ) == build_civ_frame(profile.civ_addr, 0xE0, 0x1C, sub=0x02, data=b"\x01")
 
     def test_deterministic_output(self) -> None:
         """Same inputs should produce identical output."""

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call, patch
 
@@ -19,6 +20,7 @@ from rigplane.commands.scope import (
 from rigplane.core.acquisition_scheduler import IcomCivAcquisitionExecutor
 from rigplane.core.state_pipeline_contracts import FieldPath
 from rigplane.profiles import resolve_radio_profile
+from rigplane.profiles.rig_loader import discover_rigs
 from rigplane.rigctld.server import RigctldServer
 from rigplane.runtime import _state_queries as state_queries_module
 from rigplane.runtime._state_queries import build_state_queries
@@ -42,6 +44,15 @@ _SELECTOR_SUBS = frozenset({0x14, 0x15, 0x16, 0x17, 0x19, 0x1A, 0x1D, 0x1F})
 _BARE_SUBS = frozenset({0x12, 0x13, 0x1B, 0x1C})
 
 _FrameParts = tuple[int, int | None, bytes]
+_RIGS_DIR = Path(__file__).resolve().parents[1] / "rigs"
+
+
+def _shipped_civ_models() -> tuple[str, ...]:
+    return tuple(
+        model
+        for model, config in sorted(discover_rigs(_RIGS_DIR).items())
+        if config.protocol_type == "civ"
+    )
 
 
 def _profile_resolver_cases() -> list[tuple[FieldPath, str]]:
@@ -201,7 +212,7 @@ def test_acquisition_profile_resolver_six_profile_census_and_exact_declared_byte
                 census["missing"] += 1
                 assert resolver(path) is None
 
-    assert census == Counter(agree=301, diverge=4, absent=23, missing=68)
+    assert census == Counter(agree=302, diverge=4, absent=23, missing=67)
 
 
 def test_acquisition_profile_resolver_relative_vfo_and_refusal_rules() -> None:
@@ -567,13 +578,34 @@ class TestBuildStateQueries:
             == expected
         )
 
-    @pytest.mark.parametrize("model", ["IC-705", "IC-9700", "X6100"])
-    def test_profile_without_state_acquisition_emits_no_queries(
+    @pytest.mark.parametrize("model", _shipped_civ_models())
+    def test_every_shipped_civ_profile_has_traceable_acquisition(
         self, model: str
     ) -> None:
         profile = resolve_radio_profile(model=model)
-        assert profile.state_acquisition is None
-        assert build_state_queries(profile, set(profile.capabilities)) == []
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        pollable = acquisition.pollable_paths()
+        assert pollable
+
+        resolver = acquisition_query_resolver_for_profile(profile)
+        expected = []
+        for path in pollable:
+            query = resolver(path)
+            assert query is not None, f"{model}: unresolved declared path {path}"
+            if query.receiver is not None and not profile.supports_cmd29(
+                query.command, query.sub
+            ):
+                if query.receiver != 0:
+                    continue
+                query = replace(query, receiver=None)
+            if query not in expected:
+                expected.append(query)
+
+        queries = build_state_queries(profile, set(profile.capabilities))
+        assert queries
+        assert queries == expected
+        assert len(queries) == len(set(queries))
 
     def test_deterministic_output(self) -> None:
         """Same inputs should produce identical output."""
@@ -724,8 +756,11 @@ class TestFetchInitialState:
             return r
 
     @pytest.mark.asyncio
-    async def test_dispatches_all_queries(self, radio) -> None:
+    @pytest.mark.parametrize("model", _shipped_civ_models())
+    async def test_dispatches_all_queries(self, radio, model: str) -> None:
+        radio._profile = resolve_radio_profile(model=model)
         queries = build_state_queries(radio._profile, set(radio._profile.capabilities))
+        assert queries, f"{model}: initial/periodic acquisition must not be empty"
         poller = object.__new__(RadioPoller)
         poller._profile = radio._profile
         poller._caps = set(radio._profile.capabilities)

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
 from rigplane.commands._frame import build_civ_frame, decode_wire_tuple
+from rigplane.commands.command_map import CommandMap
 from rigplane.commands.commander import Priority
 from rigplane.commands.scope import (
     SCOPE_RECEIVER_SELECTOR_SUBS,
@@ -199,7 +201,7 @@ def test_acquisition_profile_resolver_six_profile_census_and_exact_declared_byte
                 census["missing"] += 1
                 assert resolver(path) is None
 
-    assert census == Counter(agree=299, diverge=4, absent=23, missing=70)
+    assert census == Counter(agree=301, diverge=4, absent=23, missing=68)
 
 
 def test_acquisition_profile_resolver_relative_vfo_and_refusal_rules() -> None:
@@ -474,6 +476,8 @@ class TestBuildStateQueries:
         ]
         assert acquisition_query(0x07, data=b"\xd2") not in queries
         assert acquisition_query(0x07, data=b"\xc2") not in queries
+        assert acquisition_query(0x14, sub=0x01) in queries
+        assert acquisition_query(0x14, sub=0x01, receiver=0) not in queries
 
     def test_ic7610_includes_scope_queries(self) -> None:
         """IC-7610 should have scope sub-commands (0x27)."""
@@ -492,56 +496,84 @@ class TestBuildStateQueries:
         else:
             assert len(scope_queries) == 0
 
-    def test_global_queries_present(self) -> None:
-        """Power, PTT, split, RIT etc. must be in every query list."""
+    def test_queries_follow_profile_field_capabilities_and_command_map(self) -> None:
         profile = resolve_radio_profile(model="IC-7610")
         queries = build_state_queries(profile, _ic7610_caps())
-        parts = map(civ_frame_parts, queries)
-        cmds = {(part.command, part.sub) for part in parts if not part.data}
-        assert (0x18, None) in cmds  # Power status
-        assert (0x1C, 0x00) in cmds  # PTT
-        assert (0x0F, None) in cmds  # Split
-        assert (0x21, 0x00) in cmds  # RIT frequency
+        assert profile.state_acquisition is not None
+        pollable = profile.state_acquisition.pollable_paths()
+        resolve = acquisition_query_resolver_for_profile(profile)
+        expected = []
+        for path in pollable:
+            query = resolve(path)
+            if query is None:
+                continue
+            if query.receiver is not None and not profile.supports_cmd29(
+                query.command, query.sub
+            ):
+                if query.receiver != 0:
+                    continue
+                query = replace(query, receiver=None)
+            if query not in expected:
+                expected.append(query)
 
-    def test_serial_adds_meter_queries(self) -> None:
-        """Serial backends should include ALC/comp/VD/Id meter queries."""
-        profile = resolve_radio_profile(model="IC-7610")
-        lan_queries = build_state_queries(profile, _ic7610_caps(), is_serial=False)
-        serial_queries = build_state_queries(profile, _ic7610_caps(), is_serial=True)
-        # Serial should have more queries (the extra meters)
-        assert len(serial_queries) > len(lan_queries)
-        parts = map(civ_frame_parts, serial_queries)
-        serial_cmds = {(part.command, part.sub) for part in parts if not part.data}
-        assert (0x15, 0x13) in serial_cmds  # ALC meter
-        assert (0x15, 0x14) in serial_cmds  # Compressor meter
-        assert (0x15, 0x15) in serial_cmds  # VD
-        assert (0x15, 0x16) in serial_cmds  # Id
+        assert queries == expected
+        assert acquisition_query(0x18) not in queries
+        assert acquisition_query(0x1C, sub=0x03) not in queries
 
-    def test_missing_capability_skips_query(self) -> None:
-        """If a capability is missing, its per-rx queries should be skipped."""
-        profile = resolve_radio_profile(model="IC-7610")
-        full_caps = _ic7610_caps()
-        # Remove 'nb' capability
-        reduced_caps = full_caps - {"nb"}
-        full_queries = build_state_queries(profile, full_caps)
-        reduced_queries = build_state_queries(profile, reduced_caps)
-        # Both receiver-routed NB queries should disappear with the capability.
-        expected = {
-            acquisition_query(0x16, sub=0x22, receiver=0),
-            acquisition_query(0x16, sub=0x22, receiver=1),
-        }
-        assert expected.issubset(full_queries)
-        assert expected.isdisjoint(reduced_queries)
+    def test_command_map_mutation_changes_built_query(self) -> None:
+        profile = resolve_radio_profile(model="IC-7300")
+        assert profile.command_map is not None
+        commands = {name: profile.command_map.get(name) for name in profile.command_map}
+        commands["get_rf_power"] = (0x14, 0x7E)
+        mutated = replace(profile, command_map=CommandMap(commands))
 
-    def test_empty_capabilities_still_has_globals(self) -> None:
-        """Even with no capabilities, global queries should be present."""
+        original_queries = build_state_queries(profile, set())
+        mutated_queries = build_state_queries(mutated, set())
+
+        assert acquisition_query(0x14, sub=0x0A) in original_queries
+        assert acquisition_query(0x14, sub=0x7E) not in original_queries
+        assert acquisition_query(0x14, sub=0x0A) not in mutated_queries
+        assert acquisition_query(0x14, sub=0x7E) in mutated_queries
+
+    def test_polling_membership_mutation_changes_built_query(self) -> None:
+        profile = resolve_radio_profile(model="IC-7300")
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        power_path = FieldPath.global_("operator_controls", "power_level")
+        capabilities = tuple(
+            capability
+            for capability in acquisition.capabilities
+            if capability.path != power_path
+        )
+        mutated = replace(
+            profile,
+            state_acquisition=replace(acquisition, capabilities=capabilities),
+        )
+
+        assert acquisition_query(0x14, sub=0x0A) in build_state_queries(profile, set())
+        assert acquisition_query(0x14, sub=0x0A) not in build_state_queries(
+            mutated, set()
+        )
+
+    def test_legacy_arguments_do_not_override_profile_declarations(self) -> None:
         profile = resolve_radio_profile(model="IC-7610")
-        queries = build_state_queries(profile, set())
-        # Should still have freq/mode + globals
-        assert len(queries) > 0
-        parts = map(civ_frame_parts, queries)
-        cmds = {(part.command, part.sub) for part in parts if not part.data}
-        assert (0x18, None) in cmds  # Power status
+        expected = build_state_queries(profile, set(), is_serial=False)
+        assert (
+            build_state_queries(
+                profile,
+                set(profile.capabilities),
+                is_serial=True,
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize("model", ["IC-705", "IC-9700", "X6100"])
+    def test_profile_without_state_acquisition_emits_no_queries(
+        self, model: str
+    ) -> None:
+        profile = resolve_radio_profile(model=model)
+        assert profile.state_acquisition is None
+        assert build_state_queries(profile, set(profile.capabilities)) == []
 
     def test_deterministic_output(self) -> None:
         """Same inputs should produce identical output."""
@@ -551,35 +583,39 @@ class TestBuildStateQueries:
         q2 = build_state_queries(profile, caps)
         assert q1 == q2
 
-    def test_ic9700_dual_watch_query_uses_profile_wire_tuple(self) -> None:
-        profile = resolve_radio_profile(model="IC-9700")
-        command, sub, prefix = decode_wire_tuple(
-            profile.command_map.get("get_dual_watch")
-        )
-        assert (command, sub, prefix) == (0x16, 0x59, b"")
-
-        dual_watch_delta = Counter(
-            build_state_queries(profile, {"dual_watch"})
-        ) - Counter(build_state_queries(profile, set()))
-
-        assert dual_watch_delta == Counter({acquisition_query(0x16, sub=0x59): 1})
-
     def test_ic7610_dual_watch_query_preserves_wire_tuple(self) -> None:
         profile = resolve_radio_profile(model="IC-7610")
         command, sub, prefix = decode_wire_tuple(
             profile.command_map.get("get_dual_watch")
         )
         assert (command, sub, prefix) == (0x07, None, b"\xc2")
-
-        dual_watch_delta = Counter(
-            build_state_queries(profile, {"dual_watch"})
-        ) - Counter(build_state_queries(profile, set()))
-
-        assert dual_watch_delta == Counter({acquisition_query(0x07, data=b"\xc2"): 1})
-        assert acquisition_query(0x07) not in dual_watch_delta
+        queries = build_state_queries(profile, set())
+        assert queries.count(acquisition_query(0x07, data=b"\xc2")) == 1
+        assert acquisition_query(0x07) not in queries
         assert build_civ_frame(0x98, 0xE0, 0x07, sub=0xC2) == bytes.fromhex(
             "FE FE 98 E0 07 C2 FD"
         )
+
+    def test_duplicate_query_resolution_is_deduplicated_in_profile_order(self) -> None:
+        profile = resolve_radio_profile(model="IC-7300")
+        acquisition = profile.state_acquisition
+        assert acquisition is not None
+        filter_num = FieldPath.active("main", "freq_mode", "filter_num")
+        capabilities = tuple(
+            replace(capability, polling=True)
+            if capability.path == filter_num
+            else capability
+            for capability in acquisition.capabilities
+        )
+        assert any(capability.path == filter_num for capability in capabilities)
+        mutated = replace(
+            profile,
+            state_acquisition=replace(acquisition, capabilities=capabilities),
+        )
+
+        queries = build_state_queries(mutated, set())
+        assert len(queries) == len(set(queries))
+        assert queries.count(acquisition_query(0x26, selector=0)) == 1
 
 
 class TestScopeReceiverSelector:
@@ -609,29 +645,33 @@ class TestScopeReceiverSelector:
         """
         assert 0x1E not in SCOPE_RECEIVER_SELECTOR_SUBS
 
-    def test_sweep_splits_scope_reads_eight_selector_four_bare(self) -> None:
+    def test_sweep_scope_reads_follow_declared_commands_and_shapes(self) -> None:
         profile = resolve_radio_profile(model="IC-7300")
         scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
 
         frame_parts = [civ_frame_parts(query) for query in scope]
-        with_selector = {part.sub for part in frame_parts if part.data}
+        with_selector = {
+            part.sub
+            for part in frame_parts
+            if len(part.data) == 1 and part.data == bytes([SCOPE_SELECTOR_MAIN])
+        }
         bare = {part.sub for part in frame_parts if not part.data}
 
-        assert with_selector == _SELECTOR_SUBS
+        assert with_selector == _SELECTOR_SUBS - {0x1F}
         assert bare == _BARE_SUBS
-        assert len(scope) == len(_SELECTOR_SUBS) + len(_BARE_SUBS) == 12
-        # Scope reads are the only queries with both a sub-command and data.
-        queries = build_state_queries(profile, _ic7300_caps())
-        parts = map(civ_frame_parts, queries)
-        assert [
-            part.command for part in parts if part.sub is not None and part.data
-        ] == [0x27] * len(_SELECTOR_SUBS)
+        assert acquisition_query(0x27, sub=0x1E, data=b"\x01\x01") in scope
+        assert acquisition_query(0x27, sub=0x1F, data=b"\x00") not in scope
+        assert len(scope) == 12
 
     def test_sweep_selector_is_one_byte_and_main(self) -> None:
         profile = resolve_radio_profile(model="IC-7300")
         scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
 
-        carried = [part.data for part in map(civ_frame_parts, scope) if part.data]
+        carried = [
+            part.data
+            for part in map(civ_frame_parts, scope)
+            if part.sub in SCOPE_RECEIVER_SELECTOR_SUBS
+        ]
         assert carried, "no scope read carried a selector"
         for data in carried:
             assert data == bytes([SCOPE_SELECTOR_MAIN])
@@ -686,8 +726,37 @@ class TestFetchInitialState:
     @pytest.mark.asyncio
     async def test_dispatches_all_queries(self, radio) -> None:
         queries = build_state_queries(radio._profile, set(radio._profile.capabilities))
+        poller = object.__new__(RadioPoller)
+        poller._profile = radio._profile
+        poller._caps = set(radio._profile.capabilities)
+        poller._is_serial = not radio._profile.has_lan
+
+        assert RadioPoller._build_state_queries(poller) == queries
+
         await radio._fetch_initial_state()
-        assert radio.send_civ.call_count == len(queries)
+        expected_calls = []
+        for query in queries:
+            if query.receiver is not None:
+                inner = bytes([query.receiver, query.command])
+                if query.sub is not None:
+                    inner += bytes([query.sub])
+                expected_calls.append(
+                    call(
+                        0x29,
+                        data=inner + query.data,
+                        wait_response=False,
+                    )
+                )
+            else:
+                expected_calls.append(
+                    call(
+                        query.command,
+                        sub=query.sub,
+                        data=query.data,
+                        wait_response=False,
+                    )
+                )
+        assert radio.send_civ.await_args_list == expected_calls
         assert radio._initial_state_fetched is True
 
     @pytest.mark.asyncio
@@ -711,19 +780,12 @@ class TestFetchInitialState:
     async def test_scope_reads_carry_the_selector_only_where_it_is_legal(
         self, radio
     ) -> None:
-        """MOR-1981: the eight get ``<sub> 00``, the four go out bare.
-
-        Measured on a live IC-7300: the bare form of each of the eight is
-        refused with a NAK, and the four answer.  A mutation that adds the
-        byte to one of the four -- 0x1C above all, where ``27 1C 00`` is a
-        SET -- fails here.
-        """
         radio._profile = resolve_radio_profile(model="IC-7300")
 
         await radio._fetch_initial_state()
 
         sent = radio.send_civ.await_args_list
-        for sub in sorted(_SELECTOR_SUBS):
+        for sub in sorted(_SELECTOR_SUBS - {0x1F}):
             assert (
                 call(
                     0x27,
@@ -737,6 +799,24 @@ class TestFetchInitialState:
             assert call(0x27, sub=sub, data=b"", wait_response=False) in sent, (
                 f"0x27/0x{sub:02X} was not sent bare"
             )
+        assert (
+            call(
+                0x27,
+                sub=0x1E,
+                data=b"\x01\x01",
+                wait_response=False,
+            )
+            in sent
+        )
+        assert (
+            call(
+                0x27,
+                sub=0x1F,
+                data=b"\x00",
+                wait_response=False,
+            )
+            not in sent
+        )
 
     @pytest.mark.asyncio
     async def test_sets_flag_on_success(self, radio) -> None:

--- a/tests/test_vox_tone_state.py
+++ b/tests/test_vox_tone_state.py
@@ -384,9 +384,9 @@ async def test_build_state_queries_includes_notch_width() -> None:
         poller._poll_index = 2 * state_idx + 1  # noqa: SLF001
         await poller._send_query()  # noqa: SLF001
 
-    assert (None, 0x16, 0x57, b"") in set(
+    assert (0, 0x16, 0x57, b"") in set(
         map(logical_civ_call, radio.send_civ.await_args_list)
-    ), "manual notch width (0x16/0x57) not polled"
+    ), "manual notch width (0x16/0x57) not polled through command 29"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- derive initial and legacy periodic CI-V state-query membership from each active profile state-acquisition declaration and the existing profile-bound resolver
- preserve profile order, deduplicate identical queries, normalize command-29 routing, suppress undeclared or absent getters, and remove the bare 0x18 and misclassified 0x1C/0x03 reads from the sweep
- declare non-empty acquisition for every shipped CI-V profile while keeping each profile within its documented command and receiver-routing envelope
- decode a real incoming 0x1C/0x03 five-byte BCD payload into the existing backend-neutral tx_target state contract, without updating the legacy tx_freq_monitor boolean, and apply the finite profile freshness TTL
- fail closed for the legacy boolean get/set_tx_freq_monitor APIs on IC-705, IC-7610, and IC-9700 while preserving XFC on 0x1C/0x02
- remove IC-9700 SUB active-frequency/mode polling because 0x25/0x26 selector 01 is MAIN unselected VFO, not SUB, and remove its other unrouteable SUB polling claims
- fail closed for undocumented 0x27/0x1F RBW on IC-705 and IC-9700 while retaining the documented IC-7610 query
- correct the IC-7610 parity matrix so 0x1C/0x03 evidence describes read-only tx_target decoding and legacy API refusal rather than a writable boolean
- add a shipped-profile census proving every declared pollable path resolves and executes through the scheduler, with initial/legacy periodic ordered and deduplicated parity

Linear: https://linear.app/morozsm/issue/MOR-1983/the-initial-sweep-carries-its-own-hardcoded-query-list-and-never-reads

## Evidence

Manual reconciliation used the local official IC-705, IC-7300, IC-7610, and IC-9700 CI-V guides plus repository CAT audits. The guides document 0x1C/0x02 as XFC and 0x1C/0x03 as a read-only transmit-frequency payload. IC-9700 0x25/0x26 applies only to selected/unselected VFO on MAIN, and its guide has no command-29 route. The IC-705 and IC-9700 scope tables end at 0x27/0x1E, so their 0x27/0x1F command bindings are explicit absences. The IC-7610 guide marks both 0x16/0x57 manual-notch width and 0x27/0x1F RBW as command-29/receiver-selector capable where applicable. X6100 acquisition remains within the existing X6200 shared-firmware evidence boundary and does not claim direct X6100 hardware proof.

Focused exact-head local verification after rebasing onto origin/main 4422da5c0bc0f9856aa26f13bdef8ccdff8145c1:

- exact parity evidence failure plus real 1C/03 decode and fail-closed regressions: 12 passed
- complete IC-7610 parity matrix test file: 5 passed, 1 skipped because the optional GPL wfview fixture is absent
- direct replacements for the preceding six failed quick checks plus semantic query and fail-closed probes: 61 passed
- state, acquisition, poller, profile, command, command-29, dedupe-race, and CI-V receive aggregate: 1827 passed, 4 skipped
- profile command binding, response-shape, coverage, support, parity, and affected integration aggregate: 889 passed, 153 skipped
- targeted Ruff lint and format checks: passed
- import-linter: 5 contracts kept, 0 broken
- diff check: passed

Direct construction evidence: IC-9700 emits 34 ordered/deduplicated acquisition queries with no 0x25/0x26 selector-01 read and no 0x27/0x1F read. IC-705 and IC-9700 get/set RBW paths raise profile-declared CommandError before frame construction. IC-7610 0x16/0x57 emits command-29 MAIN as FE FE 98 E0 29 00 16 57 02 FD and SUB as FE FE 98 E0 29 01 16 57 02 FD. A real raw 0x1C/0x03 frame decodes to KnownTxTarget with finite profile freshness and never updates the legacy boolean field.

The full suite was not run locally; project instructions require focused local tests and the ordinary GitHub Actions queue.

## Size

This remediation expands the PR to 27 files and 1507 changed lines, beyond the normal 10-file and 1000-line ceilings. The overage is disclosed rather than hidden: independent review required restoring declarations for every shipped profile, adding real ingress and freshness regressions, removing false command bindings and receiver claims, reconciling executable command-29 routing, updating canonical parity evidence, and updating exact CI baselines. Splitting those changes would leave either the shared profile-derived runtime or shipped-profile/CI acceptance broken at an intermediate PR head. src/rigplane/web/radio_poller.py remains intentionally unchanged.