### PR TITLE
docs: delete two false comments in the v3 semantic layer

### DIFF
--- a/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
@@ -366,9 +366,7 @@ const SCENES: readonly Scene[] = [
     // with it, the `.digit`/`.sep` spans that render the actual per-glyph
     // frequency readout. No scene above ever supplies it, so without this one
     // a selector targeting `.digit`/`.sep` would misreport as an orphan
-    // regardless of whether it is one. `grep -c '.digit\|\.sep\b'` over all
-    // three stylesheets returns 0 today (verified above), so this closes a
-    // latent coverage gap rather than changing any current orphan verdict.
+    // regardless of whether it is one.
     name: 'vfo-surface (2/main_sub, tunable — FrequencyDisplayInteractive mounts)',
     render: () => mountInto(VfoSurface, {
       viewModel: topologyFixtures['2/main_sub'], hasDualReceiver: true,

--- a/frontend/src/semantic/pressed-of.ts
+++ b/frontend/src/semantic/pressed-of.ts
@@ -5,9 +5,8 @@
  * Extracted from `TxAuxSurface.svelte` (MOR-1265, slice 1B), which held the
  * correct shape from the start. Three later slices (`DspSurface` 5B,
  * `RitXitScanSurface` 8B, `CwKeyerSurface` 9B) independently re-derived and
- * pinned the same rule — `RfFrontEndSurface` (6B) has the same inline shape
- * unpinned — instead of importing one answer: on an UNOBSERVED reading,
- * `aria-pressed` must be OMITTED (`undefined`), never `"false"`.
+ * pinned the same rule instead of importing one answer: on an UNOBSERVED
+ * reading, `aria-pressed` must be OMITTED (`undefined`), never `"false"`.
  * `aria-pressed="false"` is not the absence of a claim, it is the claim
  * "this control is OFF" about a reading the radio never reported — the same
  * fail-closed-presentation doctrine every semantic surface in this directory


### PR DESCRIPTION
Two comments in the v3 semantic layer state things that are false at this PR's **merge base `2158205c`** (and still at `origin/main`, which has since moved on only in `src/rigplane/runtime/` — nothing under `frontend/`). Per CLAUDE.md ("Prose is a claim" — delete a false claim, do not reword it), both are **deleted, not corrected**. No replacement sentence, no number fixed, no import touched.

Ticket: MOR-2212. Found by the MOR-2187 adjudication (Linear comment `80b1973d`).

## Deletion 1 — `frontend/src/semantic/pressed-of.ts`

Deleted clause, verbatim:

> — `RfFrontEndSurface` (6B) has the same inline shape unpinned —

**Refuted by:**

```
$ git show 2158205c:frontend/src/semantic/RfFrontEndSurface.svelte | grep -n 'pressed-of\|pressedOf'
53:  import { pressedOf } from './pressed-of';
310:          aria-pressed={pressedOf(rf[field])}
```

The clause claimed the surface still carried its own inline copy with no test pinning it. It was **false from authorship**: `e57c4ee7` (#2277, MOR-1358) is the same commit that added this import *and* wrote the clause.

```
$ git log -S"import { pressedOf }" --format='%h %ad %s' --date=short 2158205c -- frontend/src/semantic/RfFrontEndSurface.svelte
e57c4ee7 2026-08-06 refactor(MOR-1358): shared pressedOf helper … (#2277)     # one hit
$ git log -S'has the same inline shape' --format='%h' 2158205c -- frontend/src/semantic/pressed-of.ts
e57c4ee7                                                                       # same commit wrote the clause
$ git show 69046b48 -- frontend/src/semantic/RfFrontEndSurface.svelte | grep -c pressedOf   # unrelated commit
0
```

The surrounding sentence about the three later slices **stays** — it is a historical claim and it remains true. Verified each named surface still imports the helper at `2158205c`:

```
$ for f in DspSurface RitXitScanSurface CwKeyerSurface; do \
    printf "%-20s %s\n" "$f" "$(git show 2158205c:frontend/src/semantic/$f.svelte | grep -c 'pressed-of')"; done
DspSurface           1
RitXitScanSurface    1
CwKeyerSurface       1
```

## Deletion 2 — `frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts`

Deleted sentence, verbatim:

> `grep -c '.digit\|\.sep\b'` over all three stylesheets returns 0 today (verified above), so this closes a latent coverage gap rather than changing any current orphan verdict.

**Refuted by reproducing the comment's own command at `2158205c`:**

```
fieldline/fieldline.css          0
studioline/studioline.css        0
segmentline/segmentline.css      2
```

The two hits are the `.digit, .sep` rule at `segmentline.css:127-128`. It was added by **`8cc5471d` itself — the same commit that wrote the sentence denying it**:

```
$ git show 37323cb0:frontend/src/presentation/languages/segmentline/segmentline.css | grep -c '\.digit\|\.sep\b'
0
$ git show 8cc5471d -- frontend/src/presentation/languages/segmentline/segmentline.css | grep -nE '^\+.*(\.digit|\.sep)'
278:+[data-design-language='segmentline'][data-design-language] .digit,
279:+[data-design-language='segmentline'][data-design-language] .sep {
$ git log -S"returns 0 today" --format='%h' 2158205c -- frontend/src/components-v2/wiring/__tests__/design-language-selector-reachability.component.test.ts
8cc5471d                                                                       # same commit wrote the sentence
```

False at authorship, not merely stale. Every command above pins `2158205c`: run without a ref from an older checkout they return zero hits and read as a refutation.

The conclusion clause ("so this closes a latent coverage gap…") goes with it: it rests entirely on the false premise. The preceding sentences — `hasTunableFrequency`, `onTuneFrequency`, and why a `.digit`/`.sep` selector would misreport as an orphan without this scene — are true and stay.

## Deliberately not in this PR

- `frontend/src/semantic/ScopeDisplaySurface.svelte:40-41` — its "`semantic/` may not import `components-v2/*`" clause was a third candidate and was **withdrawn**. The ADR's "Import boundary rules — Allowed" table gives Semantic an allow-list (`Adapter types, primitives, Svelte, types`) that excludes `components-v2`, so the comment may be citing the ADR correctly while **four** non-test semantic files deviate from it unenforced (`git grep -ln "from '[^']*components-v2" 2158205c -- frontend/src/semantic | grep -v __tests__` → DspSurface, MetersSurface, RfFrontEndSurface, TxAuxSurface). An earlier count of "six" came from grepping mentions rather than imports and wrongly included `ScopeDisplaySurface.svelte` itself — the one file whose comment says it reproduces rather than imports. Which side is stale is an owner question, not a prose deletion.
- `segmentline.css` prose — that is GitHub #3009.
- `pressed-of.ts`'s adoption count, and any import change.

## Verification at head `c0d0b8c3`

Behaviour is unchanged — both edits are comments only.

```
$ npx vitest run src/semantic src/components-v2/wiring
Test Files  72 passed (72)
     Tests  1950 passed (1950)
```

Identical to the pre-edit baseline recorded on `2158205c` before the change (72 files / 1950 tests). `npx eslint` on both changed files: clean. No `src/rigplane/web/**` paths touched, so the mypy gate does not apply.

`c0d0b8c3` amends `9de7da8a`'s **commit message only** — `git diff --stat 9de7da8a c0d0b8c3` is empty. The two commit-attribution sentences above were wrong in the first message and are corrected there too, since the squash body is built from commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
