### PR TITLE
refactor(segmentline): drop unread meter geometry fields

### DIFF
--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -474,17 +474,6 @@ Measured: `components-v2/meters/LinearSMeter.svelte` has eighteen `var(--v2-*)`
 and zero `var(--dl-*)`; `primitives/frequency/FrequencyDisplayInteractive.svelte`
 has fourteen and zero.
 
-`LinearSMeter` draws SVG with `SEG_COUNT = 20` and a peak-decay constant, and
-takes `{value, compact, label, variant}` — a raw reading. The design language's
-meter renderer already computes `fillFraction`, `s9Fraction`, `segmentWidthPx`,
-`segmentGapPx`, `hot`, `unknown`; `MetersSurface` spreads those onto the
-wrapper as attributes and does **not** pass them into the component, which
-recomputes its own fill.
-
-So the producing side is built and the consuming side is not connected. That is
-the gap behind "the instruments do not listen": one missing prop, not a missing
-design.
-
 `FrequencyDisplayInteractive` emits one element per glyph — `.digit`, `.sep`,
 inside `.freq` — and mounts only when `onTuneFrequency` is supplied. The readout
 slot `studioline.css` targets is `.vfo-freq` on `VfoSurface`, which is a

--- a/frontend/src/presentation/languages/segmentline/__tests__/meters-renderer.test.ts
+++ b/frontend/src/presentation/languages/segmentline/__tests__/meters-renderer.test.ts
@@ -1,71 +1,10 @@
-/**
- * MOR-2149 — the `segmentline` meter form: a segmented LCD bar graph whose
- * two fractions (`fillFraction`, `s9Fraction`) both divide by `max`, mirroring
- * `studioline/__tests__/meters-renderer.test.ts`'s shape. The pin that
- * matters most is the same one both sibling files end on: an unobserved
- * reading must render as unknown, not as a track sitting at zero, which reads
- * as "no signal" — a different fact.
- */
 import { describe, it, expect } from 'vitest';
 import { invokeRenderer, RendererInputError } from '../../contract';
-import type { DesignLanguageTokens } from '../../contract';
 import { SEGMENTLINE_TOKENS } from '../tokens';
 import { HOT_THRESHOLD, renderMeter } from '../meters-renderer';
 
 const render = (fields: Record<string, number | null>) =>
   renderMeter({ kind: 'meter', fields }, SEGMENTLINE_TOKENS);
-
-describe('the meter takes its segment pitch from the tokens, not a private default', () => {
-  it('reads the pitch off SEGMENTLINE_TOKENS.meters', () => {
-    const m = render({ value: 0.5, max: 1, s9: 0.6 });
-    expect(m.segmentWidthPx).toBe(Number.parseFloat(SEGMENTLINE_TOKENS.meters.trackWidth));
-    expect(m.segmentGapPx).toBe(Number.parseFloat(SEGMENTLINE_TOKENS.meters.segmentGap));
-  });
-
-  // SEGMENTLINE_TOKENS' own pitch is 7px/3px, which is numerically equal to
-  // a plausible fallback default — a test that only checks against
-  // SEGMENTLINE_TOKENS cannot tell "read the token" apart from "ignored the
-  // token and returned 7/3 anyway". A token set whose pitch does NOT equal
-  // 7/3 closes that gap: the output can only match if the renderer actually
-  // read the `tokens` parameter it was called with.
-  it('changes when the token set changes — the read is load-bearing, not a coincidence', () => {
-    const otherTokens: DesignLanguageTokens = {
-      ...SEGMENTLINE_TOKENS,
-      meters: { trackWidth: '11px', segmentGap: '5px' },
-    };
-    const m = renderMeter({ kind: 'meter', fields: { value: 0.5, max: 1, s9: 0.6 } }, otherTokens);
-    expect(m.segmentWidthPx).toBe(11);
-    expect(m.segmentGapPx).toBe(5);
-  });
-});
-
-describe('fillFraction and s9Fraction are two INDEPENDENT divisions by max', () => {
-  // A deliberately asymmetric fixture: value/max and s9/max produce two
-  // DIFFERENT fractions (0.25 vs 0.75). A symmetric fixture (e.g. value ===
-  // s9) cannot tell a swapped assignment apart from a correct one — this one
-  // can: if fillFraction and s9Fraction were transposed, or if either
-  // division read the wrong pair of operands, this test fails.
-  it('computes fillFraction from value/max and s9Fraction from s9/max, not the other way round', () => {
-    const m = render({ value: 3, max: 12, s9: 9 });
-    expect(m.fillFraction).toBe(0.25);
-    expect(m.s9Fraction).toBe(0.75);
-  });
-
-  it('at the real call-site scale (value/s9 already 0..1, max 1), the two fractions equal the raw inputs', () => {
-    const m = render({ value: 0.2, max: 1, s9: 0.6 });
-    expect(m.fillFraction).toBe(0.2);
-    expect(m.s9Fraction).toBe(0.6);
-  });
-
-  it('clamps an over-range reading to the track rather than overflowing it', () => {
-    expect(render({ value: 40, max: 15, s9: 9 }).fillFraction).toBe(1);
-    expect(render({ value: -3, max: 15, s9: 9 }).fillFraction).toBe(0);
-  });
-
-  it('s9Fraction defaults to 0 when s9 is absent, independent of the fill', () => {
-    expect(render({ value: 6, max: 12 }).s9Fraction).toBe(0);
-  });
-});
 
 describe('HOT_THRESHOLD is a literal boundary, not an approximation', () => {
   it('is exactly 0.8', () => {
@@ -85,16 +24,11 @@ describe('an unobserved reading stays unobserved', () => {
   it('renders unknown, never a track resting at zero', () => {
     const m = render({ value: null, max: 1, s9: 0.6 });
     expect(m.unknown).toBe(true);
-    expect(m.fillFraction).toBe(0);
     expect(m.hot).toBe(false);
   });
 
-  it('still computes s9Fraction when the value itself is unobserved', () => {
-    expect(render({ value: null, max: 15, s9: 9 }).s9Fraction).toBe(0.6);
-  });
-
   it('a genuine zero reading is a DIFFERENT fact from unobserved, and says so', () => {
-    expect(render({ value: 0, max: 1, s9: 0.6 })).toMatchObject({ unknown: false, fillFraction: 0 });
+    expect(render({ value: 0, max: 1, s9: 0.6 })).toMatchObject({ unknown: false });
   });
 });
 

--- a/frontend/src/presentation/languages/segmentline/meters-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/meters-renderer.ts
@@ -32,18 +32,10 @@ export const HOT_THRESHOLD = 0.8;
 
 export interface SegmentlineMeter {
   readonly kind: 'segmentline-meter';
-  /** Fill as a fraction of the track, or 0 when unobserved (see `unknown`). */
-  readonly fillFraction: number;
-  /** Where the two-tone handover sits, as a fraction of the track. */
-  readonly s9Fraction: number;
   /** True when the reading was never observed — CSS renders an empty track
    *  plus the unknown mark, never a gauge resting at zero. */
   readonly unknown: boolean;
   readonly hot: boolean;
-  /** Segment pitch, straight off the tokens, so the CSS gradient and the
-   *  language declaration can never disagree about what a segment is. */
-  readonly segmentWidthPx: number;
-  readonly segmentGapPx: number;
 }
 
 const finite = (fields: RendererViewModel['fields'], key: string): number | null => {
@@ -54,35 +46,17 @@ const finite = (fields: RendererViewModel['fields'], key: string): number | null
 export function renderMeter(
   viewModel: RendererViewModel, tokens: DesignLanguageTokens,
 ): SegmentlineMeter {
-  // No fallback: `tokens` is always a real, valid `DesignLanguageTokens` —
-  // this renderer is reachable only through `segmentline`'s own manifest
-  // (`resolveRenderer`/`invokeRenderer`, `../contract.ts`), which always
-  // supplies `SEGMENTLINE_TOKENS`. A silent fallback here would be dead code
-  // ("reachable errors only") and would let the token read stop being
-  // load-bearing without any test noticing.
-  const segmentWidthPx = Number.parseFloat(tokens.meters.trackWidth);
-  const segmentGapPx = Number.parseFloat(tokens.meters.segmentGap);
-
   const value = finite(viewModel.fields, 'value');
   const max = finite(viewModel.fields, 'max') ?? 1;
-  const s9 = finite(viewModel.fields, 's9');
-  const s9Fraction = s9 !== null && max > 0 ? Math.min(1, Math.max(0, s9 / max)) : 0;
 
   if (value === null || max <= 0) {
-    return {
-      kind: 'segmentline-meter', fillFraction: 0, s9Fraction,
-      unknown: true, hot: false, segmentWidthPx, segmentGapPx,
-    };
+    return { kind: 'segmentline-meter', unknown: true, hot: false };
   }
 
   const fillFraction = Math.min(1, Math.max(0, value / max));
   return {
     kind: 'segmentline-meter',
-    fillFraction,
-    s9Fraction,
     unknown: false,
     hot: fillFraction >= HOT_THRESHOLD,
-    segmentWidthPx,
-    segmentGapPx,
   };
 }


### PR DESCRIPTION
## Summary

Deletes `fillFraction`, `s9Fraction`, `segmentWidthPx`, `segmentGapPx` from `SegmentlineMeter` (`frontend/src/presentation/languages/segmentline/meters-renderer.ts`) and their feeding local computations/constants, plus the test assertions and now-empty tests that covered only those four fields (`__tests__/meters-renderer.test.ts`). `kind`, `unknown`, and `hot` — and their computation — are untouched. No prose was added; only code and stale assertions were removed. The test file's top-of-file header comment, which described the file as covering "two fractions (`fillFraction`, `s9Fraction`)," is deleted in full: git diff is line-based, so partially editing that wrapped, multi-sentence comment to remove only the false clause would itself show as an added comment line (a rewritten line, even reusing only pre-existing words, is still an "added" line in a line-based diff) — deleting the whole block is the only edit that removes the false claim while adding zero comment lines. The remaining `describe`/`it` strings already document current behavior. `.claude/skills/design-a-face/SKILL.md` also had a paragraph naming the same four fields as things the segmentline meter renderer "already computes," concluding from that list that "the producing side is built and the consuming side is not connected... one missing prop, not a missing design" — a review caught that this PR falsifies that paragraph and its conclusion now reads as an invitation to re-add the fields this PR removes. That paragraph is deleted in full (whole-line deletion, no replacement text), located by its closing phrase "one missing prop" after a rebase moved its line numbers (see Why).

## Why

Owner decision, 2026-09-02: this channel is internal, and only `unknown`/`hot` are read by any stylesheet.

Grep at the base SHA (`81e0bde4fc8fd5b72a507e842a896738f7c84af6`) confirms:

```
$ git show 81e0bde4fc8fd5b72a507e842a896738f7c84af6:frontend/src/presentation/languages/segmentline/segmentline.css | grep -n "data-dl"
135:   'data-dl-*'. They are STRINGS: CSS can select on a discrete value but cannot
140:[data-design-language='segmentline'][data-design-language] [data-dl-unknown='true'] {
145:[data-design-language='segmentline'][data-design-language] [data-dl-hot='true'] {
```

Only two `data-dl-*` attribute selectors exist for `segmentline`: `data-dl-unknown` and `data-dl-hot`. No selector reads `data-dl-fill-fraction`, `data-dl-s9-fraction`, `data-dl-segment-width-px`, or `data-dl-segment-gap-px`.

A repo-wide `git grep`, run from the repo root (not just `frontend/src`), at head SHA `7392ac656bd03e90720e9ebb4bd3eeff39d04c31` (post-rebase):

```
$ git grep -n "fillFraction\|s9Fraction\|segmentWidthPx\|segmentGapPx"
frontend/src/presentation/languages/segmentline/meters-renderer.ts:56:  const fillFraction = Math.min(1, Math.max(0, value / max));
frontend/src/presentation/languages/segmentline/meters-renderer.ts:60:    hot: fillFraction >= HOT_THRESHOLD,
```

Both hits are the same local variable in `meters-renderer.ts` — it feeds `hot` and is not returned. No other file in the repository names any of the four fields.

Two corrections folded into this revision, both from independent review:
- An earlier revision ran this grep scoped to `frontend/src` only and described it as "repo-wide." The repo-root run above is what caught the stale `SKILL.md` paragraph.
- Before the `SKILL.md` fix landed, `#3011` merged to `main` as commit `76b7e9cb` and rewrote `SKILL.md` — 158 changed lines there specifically (139 insertions + 19 deletions, per `git show --numstat 76b7e9cb -- .claude/skills/design-a-face/SKILL.md`; the PR as a whole touched 633 lines across three files, `SKILL.md`, `extract-contract.py`, and `measure-reference.py`) — which moved the stale paragraph off its originally-cited line numbers (374-383 → 477-486). This branch was rebased onto `main` post-#3011 (base now `81e0bde4`, a descendant of `76b7e9cb`); the paragraph was re-located by its closing phrase `"one missing prop"` rather than the full sentence `"one missing prop, not a missing design"`, because the full sentence wraps a line break in the source (line 485 ends "…not a missing", "design." continues on 486) and so has zero `git grep` matches at any ref. `git grep -n "one missing prop"` across the whole repository:
  ```
  $ git grep -n "one missing prop" 76b7e9cb
  76b7e9cb:.claude/skills/design-a-face/SKILL.md:485:the gap behind "the instruments do not listen": one missing prop, not a missing
  ```
  One match, at `76b7e9cb` (base commit and its descendants before this branch's fix); the same command against the current head (`7392ac65`) returns nothing.

## Verification

All commands run from the worktree's `frontend/`, at head SHA `7392ac656bd03e90720e9ebb4bd3eeff39d04c31`, rebased onto base SHA `81e0bde4fc8fd5b72a507e842a896738f7c84af6`.

- `npx vitest run src/presentation/languages/segmentline src/semantic/__tests__/MetersSurface.test.ts`
  - Baseline (re-run at the current base after the rebase): 6 test files, 185 tests, all passing.
  - Head: 6 test files, 178 tests, all passing. The 7-test drop is exactly the deleted tests: 2 in the "segment pitch from the tokens" describe block, 4 in the "fillFraction and s9Fraction are two INDEPENDENT divisions" describe block, 1 ("still computes s9Fraction when the value itself is unobserved") in the "unobserved reading" block — nothing else changed.
- `npm run check` (svelte-check + tsc): `COMPLETED 4625 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- `npx eslint src/presentation/languages/segmentline`: no output, zero violations.
- `grep -rn "data-dl" src --include="*.css"`: prints the same three lines as the base-SHA grep above (two selectors + one unrelated comment line) — CSS was not touched by this PR.
- `git diff <base>..HEAD | grep '^+' | grep -v '^+++'`: shows exactly two added lines, both code, neither a comment — `return { kind: 'segmentline-meter', unknown: true, hot: false };` and the trimmed `toMatchObject({ unknown: false })` assertion. Zero added comment or prose lines anywhere in the PR, including both the test-file header deletion and the `SKILL.md` deletion above.
- Mutation check: changed `hot: fillFraction >= HOT_THRESHOLD` to `> HOT_THRESHOLD` and reran the target suite — `marks hot AT 0.8 exactly (>=, not >)` failed as expected (1 failed / 177 passed), confirming the surviving `hot`/`unknown` tests still discriminate real behavior after the field deletions. Reverted the mutation before the final green run above; `git diff` at the time of this PR shows only the intended change.

Independently reviewed and PASSED at `7392ac65` (PR comment).

## Squash body

The merger should use an explicit `--subject`/`--body` rather than this branch's own commit message. Suggested:

**Subject:** `refactor(segmentline): drop unread meter geometry fields`

**Body:**
```
Delete fillFraction, s9Fraction, segmentWidthPx, and segmentGapPx from
SegmentlineMeter and their feeding computations in meters-renderer.ts,
plus the test assertions/tests that covered only those fields; kind,
unknown, and hot are untouched.

Also delete the .claude/skills/design-a-face/SKILL.md paragraph that
named the same four fields as things the segmentline meter renderer
"already computes" and concluded from that list that one field was a
missing prop away from working — a claim this PR reverses, since the
producing side (those four fields) is what got deleted, not connected.
Left uncorrected, the paragraph would have invited re-adding the
fields this PR removes.

Linear: MOR-2214 slice 1
```

Files: `frontend/src/presentation/languages/segmentline/meters-renderer.ts`, `frontend/src/presentation/languages/segmentline/__tests__/meters-renderer.test.ts`, `.claude/skills/design-a-face/SKILL.md`.

## Guardrails

3 files changed, 107 changed lines (2 insertions + 105 deletions) — well under both the soft threshold (6 files / 600 lines) and the hard ceiling (10 files / 1000 lines).

Linear: MOR-2214 slice 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
