### PR TITLE
fix: preserve owner-scoped PTT release debt

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -353,7 +353,17 @@ class ManagedTxAuthority:
                     PttDown(owner, generation or 0, self._attempt_id_locked(), 0, None)
                 ), False
             if action == "ptt_up" and generation is None:
-                return self._force_off_locked(), True
+                state = replace(
+                    self._state,
+                    intent=ManagedTxIntent.rx(),
+                    tx_started_at_monotonic=None,
+                    tot_deadline_monotonic=None,
+                    pending_effect=None,
+                )
+                transition = ManagedTxTransition(state, ManagedTxOutcome.ACCEPTED)
+                self._state = state
+                self._release_drained.clear()
+                return transition, False
         if (
             action == "transmit_on"
             and self._state.intent.kind is ManagedTxIntentKind.TRANSMIT

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -218,6 +218,31 @@ async def test_offline_force_off_retries_immediately_when_provider_appears() -> 
 
 
 @pytest.mark.asyncio
+async def test_ptt_up_without_provider_retains_owner_scoped_release_debt() -> None:
+    managed, _, _, _, fence, lane = authority(generation=7)
+    assert await managed.ptt_down("owner-a") is ManagedTxOutcome.ACCEPTED
+
+    async with managed._lock:
+        managed._provider_generation = None
+
+    assert await managed.ptt_up("owner-a") is ManagedTxOutcome.ACCEPTED
+    released = await managed.snapshot()
+    assert released.state.intent.kind is ManagedTxIntentKind.RX
+    assert released.state.release_plan is ReleasePlan.PTT_RELEASE
+    assert released.state.pending_effect is None
+    assert fence.calls == 0
+    assert [effect.operation for effect in lane.effects] == [ActuationOperation.PTT_ON]
+
+    await managed.provider_available(8)
+    assert [effect.operation for effect in lane.effects] == [
+        ActuationOperation.PTT_ON,
+        ActuationOperation.FORCE_RECEIVE,
+    ]
+    assert not (await managed.snapshot()).state.release_required
+    await managed.close()
+
+
+@pytest.mark.asyncio
 async def test_rejected_on_retries_release_with_new_epoch() -> None:
     managed, clock, wakeup, _, _, lane = authority()
     lane.results.extend((ActuationResult.REJECTED, ActuationResult.ACCEPTED))


### PR DESCRIPTION
Linear: [MOR-2209](https://linear.app/morozsm/issue/MOR-2209/mor-21665b-pttup-with-no-provider-generation-enters-global-forceoff-which-the)

## Authority

This change follows the owner ruling supplied directly on 2026-09-02 in the MOR-2161 coordination thread: an owner-matched PTT_UP invalidates only its matching ON attempt, retains PTT_RELEASE debt, and does not run the global abort fence. Explicit ForceOff remains the only upgrade to FORCE_RELEASE.

## Search before write

`gh pr list --repo rigplane/rigplane-core --state open --json ...` showed no open PR touching either owned file. A scan of every registered worktree with `git status --porcelain -- src/rigplane/runtime/managed_tx_authority.py tests/test_managed_tx_authority.py` found no dirty writer. Work then started in a fresh worktree from `origin/main` at `6e05cb51cd937c6d347f59a5a61b47eee12be94a`.

## Change

- Reduce owner-matched PTT_UP locally when the provider generation is absent.
- Preserve PTT_RELEASE debt and invalidate the pending ON attempt without dispatching a provider effect.
- Leave the global abort fence untouched.
- Reuse the existing provider-arrival retry path to service the retained debt.

No new state, scheduler, watchdog, registry, helper layer, or ForceOff behavior is introduced.

## TDD and verification

RED on unchanged production behavior:

```text
1 failed
test_ptt_up_without_provider_retains_owner_scoped_release_debt
expected ReleasePlan.PTT_RELEASE; observed ReleasePlan.FORCE_RELEASE
```

GREEN:

- `uv run pytest tests/test_managed_tx_authority.py::test_ptt_up_without_provider_retains_owner_scoped_release_debt -q --tb=short` — 1 passed.
- Focused managed-TX suite across 14 files — 332 passed.
- Five provider/shutdown race cases repeated 100 times — 500 test executions passed.
- `uv run ruff check src/ tests/` — passed.
- `uv run ruff format --check src/ tests/` — 717 files already formatted.
- `uv run mypy --strict src/rigplane/runtime/managed_tx_authority.py` — no issues.
- `uv run lint-imports` — 5 contracts kept, 0 broken.

Full matrix is intentionally not run locally; it is submitted to the normal CI queue for this exact branch head.

## Mutation proof

Temporarily replacing the new provider-absent PTT_UP reduction with `return self._force_off_locked(), True` produced exit 1 and exactly one failed test: `test_ptt_up_without_provider_retains_owner_scoped_release_debt`, at the assertion that the plan remains `PTT_RELEASE`. Restoring the implementation returned the test to green.

## Pre-push interlock dependency grep

Command:

```bash
git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py \
  src/rigplane/runtime/command\*.py src/rigplane/web/handlers/control.py
```

Output:

```text
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1732:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1982:            decision = evaluate_tx_interlock(
```

There are zero hits in `core/command_dispatch.py` and `runtime/command*.py`; the three existing Web control hits are outside this two-file fix and remain owned by the scheduled interlock retirement.

## Guardrails

- 2 files changed
- +36 / -1
- Below the 6-file / 600-line soft threshold and 10-file / 1000-line hard ceiling
