### PR TITLE
fix(MOR-2154): make segmentline selectable and add the incompatible-pair fallback

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,7 +11,7 @@
   import { getLayoutMode } from './lib/stores/layout.svelte';
   import { readQaCockpitLayoutOverride } from './lib/stores/qa-cockpit-override';
   import { getAvailableThemes } from './components-v2/theme/theme-switcher';
-  import { getDesignLanguage } from './presentation/languages/contract';
+  import { getDesignLanguage, listDesignLanguageIds } from './presentation/languages/contract';
   // Side-effect import: populates the design-language registry the lookup
   // above resolves against, exactly as `semantic/design-language-renderers.ts`
   // does. Imported here too so the activation effect below cannot depend on a
@@ -89,8 +89,30 @@
   // rules arrive with the cutover — and it is absent entirely wherever the
   // language is not active, so no shipped v2 skin sees a new attribute.
   $effect(() => {
-    const language = getDesignLanguage(getWorkspace().designLanguage);
-    const activated = designLanguageActivation(language, skinId);
+    const stored = getDesignLanguage(getWorkspace().designLanguage);
+    let language = stored;
+    let activated = designLanguageActivation(stored, skinId);
+    if (activated === null) {
+      // MOR-2154: the stored preference cannot activate on the resolved skin
+      // (e.g. `segmentline` off `peer-split`, or the default `studioline` ON
+      // `peer-split`, which no v2 skin's default ever declared compatible).
+      // Falls back to the FIRST registered language whose `layoutCompatibility`
+      // declares this skin, in `presentation/languages/declarations.ts`
+      // registration order (studioline, fieldline, segmentline) — today that
+      // is `studioline` for every shipped v2 skin and `segmentline` for
+      // `peer-split`, the only language that declares it. The STORED
+      // preference itself is untouched here — only this render's activation
+      // falls back, so leaving `peer-split` restores it without a re-choice.
+      for (const id of listDesignLanguageIds()) {
+        const candidate = getDesignLanguage(id);
+        const candidateActivated = designLanguageActivation(candidate, skinId);
+        if (candidateActivated !== null) {
+          language = candidate;
+          activated = candidateActivated;
+          break;
+        }
+      }
+    }
     if (activated === null) {
       delete document.documentElement.dataset.designLanguage;
       delete document.documentElement.dataset.languageMode;

--- a/frontend/src/__tests__/design-language-activation.component.test.ts
+++ b/frontend/src/__tests__/design-language-activation.component.test.ts
@@ -1,0 +1,191 @@
+/**
+ * MOR-2154 — `peer-split` was selectable and `segmentline` was registered,
+ * but no operator flow could ever get from one to the other:
+ * `WORKSPACE_DESIGN_LANGUAGE_IDS` (`../presentation/workspace/contract.ts`)
+ * excluded `segmentline`, so a stored `designLanguage: 'segmentline'` could
+ * never exist, and even where the resolved skin can't activate a stored
+ * language, `App.svelte`'s activation effect used to just delete the
+ * attribute — an unstyled surface.
+ *
+ * These tests mount the REAL `App.svelte` — the real workspace store, the
+ * real `skins/registry.ts::resolveSkinId`, the real design-language and
+ * layout registries — and read `document.documentElement.dataset` the way an
+ * operator's browser would. Only the pieces with no bearing on design-language
+ * activation (transport bootstrap, TX controller, battery, media session, the
+ * App-global host) are stubbed, following the same recipe
+ * `lazy-presentation.component.test.ts` already uses for a full `App.svelte`
+ * mount. A test asserting `WORKSPACE_DESIGN_LANGUAGE_IDS` merely CONTAINS
+ * `'segmentline'` would prove nothing about activation — this file proves the
+ * attribute itself, end to end.
+ *
+ * Three properties, each naming the mutation it kills:
+ *
+ *  A. STORABLE (change (a)). `segmentline` explicitly selected + `peer-split`
+ *     resolved activates `segmentline`. Kill: reverting
+ *     `WORKSPACE_DESIGN_LANGUAGE_IDS` to `['studioline', 'fieldline']` makes
+ *     `setDesignLanguage('segmentline')` clamp to `'studioline'` (the real
+ *     `pickId` in `contract.ts`), so the attribute becomes `'studioline'`,
+ *     not `'segmentline'`.
+ *  B. THE LITERAL ACCEPTANCE. An operator who selects ONLY the `peer-split`
+ *     layout, with no explicit design-language choice, still gets
+ *     `segmentline` — `segmentline` is the only registered language whose
+ *     `layoutCompatibility` names `peer-split` at all. Kill: removing the
+ *     fallback loop in `App.svelte`'s activation effect leaves the attribute
+ *     absent (the default `studioline` doesn't declare `peer-split`).
+ *  C. THE FALLBACK (change (b)), plus the hard boundary that resolution must
+ *     NOT touch the stored preference. `segmentline` stored + a skin it can't
+ *     activate on (`desktop-v2`) still yields a styled surface (`studioline`,
+ *     the first language in registration order that declares `desktop-v2`),
+ *     `getWorkspace().designLanguage` stays `'segmentline'` throughout, and
+ *     returning to `peer-split` restores `segmentline` with no re-choice.
+ *     Kill: removing the same fallback loop leaves the attribute absent once
+ *     `desktop-v2` is resolved.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import { getWorkspace, initWorkspaceStore, setDesignLanguage, setLayout } from '../presentation/workspace/store.svelte';
+
+const h = vi.hoisted(() => ({
+  pending: [] as Array<{ id: string; resolve: (c: unknown) => void }>,
+  loadSkin: vi.fn(),
+  plan: vi.fn(),
+  bootstrap: vi.fn(),
+  initBattery: vi.fn(),
+  provide: vi.fn(),
+  registerBarrier: vi.fn(),
+}));
+
+// The only mock in this file with production logic left in: keeps the real
+// `resolveSkinId` (what actually turns a workspace layout preference into a
+// SkinId), and replaces only the two members that would otherwise pull in a
+// real skin's whole component tree.
+vi.mock('../skins/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../skins/registry')>();
+  return { ...actual, loadSkin: h.loadSkin, presentationResourcePlan: h.plan };
+});
+
+vi.mock('../lib/runtime/frontend-runtime', () => ({
+  runtime: {
+    get state() { return { stateRevision: 1, freshnessRevision: 1, observationSeq: 1, ptt: false }; },
+    get caps() { return { tx: true, capabilities: ['tx'] }; },
+    bootstrap: h.bootstrap,
+  },
+  presentationResources: {
+    snapshot: () => ({ demand: 0 }),
+    acquire: () => ({}),
+    release: () => true,
+  },
+}));
+vi.mock('$lib/runtime/system-controller', () => ({
+  systemController: { registerPreDisconnectBarrier: h.registerBarrier },
+}));
+vi.mock('$lib/runtime/tx-controller/app-host', () => ({ provideAppTxControllerHost: h.provide }));
+vi.mock('$lib/i18n', () => ({ t: (key: string) => key }));
+vi.mock('$lib/stores/capabilities.svelte', () => ({ hasAnyScope: () => false }));
+vi.mock('../lib/media/media-session', () => ({ initMediaSession: vi.fn(), destroyMediaSession: vi.fn() }));
+vi.mock('../AppGlobalHost.svelte', async () => {
+  const stub = await import('../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+
+import App from '../App.svelte';
+
+/**
+ * `App.svelte`'s own top-level `initWorkspaceStore()` call is inside its
+ * `<script>` body, which Svelte re-runs on every component INSTANTIATION
+ * (unlike a plain module's top level, which runs once at import) — so it
+ * fires fresh on every `mount()`, reading the real `localStorage` (empty in
+ * this jsdom environment) and overwriting any workspace state set BEFORE the
+ * mount. Seeding therefore happens AFTER `mountApp()`, through the same real
+ * `setLayout`/`setDesignLanguage` setters an operator's own selection would
+ * call, followed by `flushSync()` so the mounted effects re-run.
+ */
+function mountApp() {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const instance = mount(App, { target });
+  flushSync();
+  return instance;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.pending.length = 0;
+  document.body.innerHTML = '';
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-design-language');
+  document.documentElement.removeAttribute('data-language-mode');
+  document.documentElement.removeAttribute('data-density');
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+  h.provide.mockImplementation(() => ({ refreshAuthority: vi.fn(), dispose: vi.fn() }));
+  h.bootstrap.mockResolvedValue(vi.fn());
+  h.loadSkin.mockImplementation(
+    (id: string) => new Promise((resolve) => { h.pending.push({ id, resolve }); }),
+  );
+  h.plan.mockReturnValue([]);
+});
+
+afterEach(() => {
+  initWorkspaceStore(null);
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-design-language');
+  document.documentElement.removeAttribute('data-language-mode');
+  document.documentElement.removeAttribute('data-density');
+});
+
+describe('MOR-2154 — segmentline activation, in a rendered App', () => {
+  it('A: segmentline explicitly selected, peer-split resolved -> [data-design-language="segmentline"]', () => {
+    const instance = mountApp();
+
+    setLayout('peer-split');
+    setDesignLanguage('segmentline');
+    flushSync();
+
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+
+    unmount(instance);
+  });
+
+  it('B: selecting only the peer-split LAYOUT (no explicit language) still activates segmentline', () => {
+    const instance = mountApp();
+    expect(getWorkspace().designLanguage).toBe('studioline'); // the DEFAULT_WORKSPACE value
+
+    setLayout('peer-split');
+    flushSync();
+
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+
+    unmount(instance);
+  });
+
+  it('C: segmentline stored + a skin it cannot activate on still yields a styled surface, and the stored preference survives the round trip', () => {
+    const instance = mountApp();
+
+    setLayout('peer-split');
+    setDesignLanguage('segmentline');
+    flushSync();
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+
+    setLayout('standard'); // resolves to desktop-v2, which segmentline declares incompatible
+    flushSync();
+
+    // Styled, not absent — the operator must never see an unstyled surface as
+    // a result of a stored preference.
+    expect(document.documentElement.dataset.designLanguage).toBe('studioline');
+    // The hard boundary: resolution never rewrites the STORED preference.
+    expect(getWorkspace().designLanguage).toBe('segmentline');
+
+    setLayout('peer-split');
+    flushSync();
+
+    // No re-choice needed: the untouched stored preference reactivates on its own.
+    expect(document.documentElement.dataset.designLanguage).toBe('segmentline');
+
+    unmount(instance);
+  });
+});

--- a/frontend/src/presentation/languages/declarations.ts
+++ b/frontend/src/presentation/languages/declarations.ts
@@ -26,13 +26,7 @@
  * false`. Activation matches the resolved `SkinId`, not a
  * `presentation/layouts/` manifest id: `App.svelte` calls
  * `designLanguageActivation(language, skinId)` (`../workspace/activation.ts`),
- * whose parameter is merely *named* `layoutId`. `peer-split` is a
- * registered `SkinId` with a loadable shell (MOR-2155), but `resolveSkinId`
- * (`../../skins/registry.ts`) has no branch that returns it and no
- * `presentation/layouts/` manifest names it (MOR-2151), so segmentline
- * cannot activate in production yet — that routing is later in MOR-1162's
- * delivery order (`docs/plans/2026-09-01-segmentline-peer-split.md` §7:
- * MOR-2151, MOR-2152), not an oversight here. `unified-instrument` and
+ * whose parameter is merely *named* `layoutId`. `unified-instrument` and
  * `panadapter-first`, the handoff's other two proposed directions, are
  * named nowhere in this repository either — no `SkinId`, no layout
  * manifest — so they are absent from this list too. `desktop-v2: false`

--- a/frontend/src/presentation/workspace/__tests__/contract.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/contract.test.ts
@@ -19,7 +19,7 @@ import {
 // still matches the live declaration — never used by production code here.
 import * as layoutDeclarations from '../../layouts/declarations';
 import type { LayoutManifest } from '../../layouts/contract';
-import { fieldline, studioline } from '../../languages/declarations';
+import { fieldline, segmentline, studioline } from '../../languages/declarations';
 import { getAvailableThemes } from '../../../components-v2/theme/theme-switcher';
 // MOR-2059: the layout id space is a LIVE import now — `../contract` derives
 // `WORKSPACE_LAYOUT_IDS`/its alias table from this same module, so there is
@@ -52,14 +52,17 @@ describe('registry sync — the pinned id spaces still match their live owners',
   });
 
   it('design-language ids and their density clamps match the live manifests', () => {
-    expect([...WORKSPACE_DESIGN_LANGUAGE_IDS]).toEqual([studioline.id, fieldline.id]);
-    for (const manifest of [studioline, fieldline]) {
+    expect([...WORKSPACE_DESIGN_LANGUAGE_IDS]).toEqual([studioline.id, fieldline.id, segmentline.id]);
+    for (const manifest of [studioline, fieldline, segmentline]) {
       expect(manifest.density.kind).toBe('clamped');
       const supported = manifest.density.kind === 'clamped' ? manifest.density.supported : [];
       expect(WORKSPACE_DENSITY_CLAMP[manifest.id as 'studioline']).toEqual(supported);
     }
-    // fieldline clamps `dense` out at 0.6 relative density (MOR-977 §4.4).
+    // fieldline and segmentline both clamp `dense` out (0.6 relative density
+    // for fieldline, MOR-977 §4.4; segmentline's 7px meter pitch collides
+    // with the dense cell outline, `../../languages/declarations.ts`).
     expect(WORKSPACE_DENSITY_CLAMP.fieldline).not.toContain('dense');
+    expect(WORKSPACE_DENSITY_CLAMP.segmentline).not.toContain('dense');
   });
 
   it('theme ids are exactly the switcher\'s 21-id list, in order', () => {

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -32,13 +32,19 @@ const LAYOUT_ALIASES: Readonly<Record<string, WorkspaceLayoutId>> = LEGACY_LAYOU
  *  see), so it maps to null — "defer", not "unknown". */
 const LAYOUT_MANIFEST_ID: Readonly<Record<WorkspaceLayoutId, string | null>> = { auto: null, 'lcd-cockpit': 'lcd-cockpit', 'lcd-scope': 'lcd-scope', standard: 'desktop-v2', 'sdr-test': 'sdr-test', 'peer-split': 'peer-split' };
 
-/** Decision 2: frozen by MOR-977 §4.6. */
-export const WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline', 'fieldline'] as const;
+/**
+ * Decision 2: frozen by MOR-977 §4.6 for `studioline`/`fieldline`.
+ * `segmentline` added by MOR-2154 — its `peer-split`-only `layoutCompatibility`
+ * (`../languages/declarations.ts`) is what keeps it from activating on any
+ * currently-shipped v2 skin, not exclusion from this set.
+ */
+export const WORKSPACE_DESIGN_LANGUAGE_IDS = ['studioline', 'fieldline', 'segmentline'] as const;
 export type WorkspaceDesignLanguageId = (typeof WORKSPACE_DESIGN_LANGUAGE_IDS)[number];
 /** Decision 4: each language's `DensityClamp.supported`; index 0 is that language's default. */
 export const WORKSPACE_DENSITY_CLAMP: Readonly<Record<WorkspaceDesignLanguageId, readonly DensityLevel[]>> = {
   studioline: ['comfortable', 'compact', 'dense'],
   fieldline: ['comfortable', 'compact'],
+  segmentline: ['comfortable', 'compact'],
 };
 
 /** Decision 3: the flat 21-id theme list, allow-list validated ON READ. */


### PR DESCRIPTION
## Summary

`peer-split` was selectable but activated **no design language for anyone**: `WORKSPACE_DESIGN_LANGUAGE_IDS` excluded `segmentline`, so `designLanguage: 'segmentline'` could never be stored. This is two changes, and neither is complete alone:

- **(a)** `segmentline` added to `WORKSPACE_DESIGN_LANGUAGE_IDS` (`presentation/workspace/contract.ts`), plus the matching `WORKSPACE_DENSITY_CLAMP.segmentline` entry the `Record` type requires and the registry-sync test in `contract.test.ts` that pins it against the live manifests.
- **(b)** `App.svelte`'s activation effect (the composition root — already documented as "the only caller that writes" `[data-design-language]`) no longer just deletes the attribute when the stored language can't activate on the resolved skin. It falls back to the **first registered language (registration order: studioline, fieldline, segmentline) whose `layoutCompatibility` declares the resolved skin**. `resolution.ts` needed zero changes — `densityActivation` already takes the manifest as a parameter, so it just follows whichever one the effect resolved; there's one owner, and the other follows by construction, not by a second edit.

The fallback is a per-render computation and writes nothing to the workspace store — `getWorkspace().designLanguage` is only ever read here, never set, so a stored preference always survives a skin switch untouched.

**Acceptance, stated as the rendered result:** an operator with `designLanguage: 'segmentline'` and the `peer-split` layout selected gets `[data-design-language="segmentline"]` on `document.documentElement` in a mounted `App.svelte` — proven by mounting the real component (real workspace store, real `resolveSkinId`, real language/layout registries), not by asserting the allowlist's contents.

**Operator answer:** with `segmentline` stored, switching to any other skin (e.g. `standard` / `desktop-v2`) yields **`studioline`** — first in registration order, and the only other language currently declaring `desktop-v2`/`dual-receiver-cockpit` compatible. Unchanged from today's default on those skins.

Also deletes the now-stale MOR-2151 ruling comment in `declarations.ts` (both of its claims — no `resolveSkinId` branch, no layout manifest — are false today: `skins/registry.ts:59` and `presentation/layouts/segmentline-declarations.ts`). Deleted, not rewritten.

Closes #3015

## Collateral disclosures

**Mutation 1 gave partial, not full, coverage — read this before trusting test A/B alone.** Reverting `WORKSPACE_DESIGN_LANGUAGE_IDS` to `['studioline', 'fieldline']` left tests A and B green. That is not a gap in those tests: the fallback loop independently re-derives `segmentline` as the only *registered* language declaring `peer-split`, regardless of what can be *stored* — so whenever `skinId` is `peer-split`, the loop masks the allowlist mutation on its own. Only test C caught it (`getWorkspace().designLanguage` clamped to `'studioline'` instead of holding `'segmentline'`). A reader who assumes all three tests cover the allowlist edit would be wrong; the masking is a property of this design, not a hole in the suite. Exit codes: reverted → 1 (test C fails); restored → 0 (all three pass).

**That same run is the downgrade proof, empirically, not by inspection.** The reverted array stands in for an older build's `pickId`, and `setDesignLanguage('segmentline')` was *observed* clamping to `'studioline'` under it (test C's own failure) — not reasoned from reading `pickId`'s source.

**Mutation 2 (the fallback loop removed) is the clean discriminator for change (b).** Restoring `App.svelte`'s original 2-line effect: tests B and C both go red (`undefined` instead of `'segmentline'`/`'studioline'`); test A stays green, since explicit `segmentline` + `peer-split` activates directly without needing the loop. Exit codes: mutated → 1; restored → 0.

**Why the four `var(--dl-segmentline-*, <literal>)` fallbacks in `PeerSplitLayout.svelte` stayed.** The bar is live resolution in a *rendered* `peer-split` with `segmentline` active, not merely "the tokens exist somewhere." jsdom has no CSS cascade engine to establish that, and the chassis file is explicitly out of this issue's scope regardless. By inspection, the four literal values are byte-identical to `segmentline.css`'s own definitions (`--dl-segmentline-glass: #c8a030`, etc.) — but static-value equality is **not** the same claim as proving the `var()` actually resolves to the token at render time, and that distinction is the whole reason they were left in place rather than removed on the strength of the inspection alone.

**Corollary, disclosed not fixed.** The same general "first compatible language in registration order" rule also resolves a `fieldline`-stored preference on the QA-only `dual-receiver-cockpit` skin (reachable only via the exact `?layout=dual-receiver-cockpit` query param, MOR-1257 — never settings-panel-selectable) to `studioline`, where it used to stay unstyled. This is a direct consequence of the general rule, not a special case added for it.

**Open obligation for a future per-skin storage design.** If design language ever becomes per-skin (each skin declaring its own supported set plus one default), "never an unstyled surface from a stored preference" does not fall out for free — it moves from this activation-effect fallback into the read/validation layer, and holds only if that future validator clamps an invalid stored per-skin choice to the skin's own declared default, mirroring how `pickId`/`pickDensity` already clamp today. That clamp is an implementation obligation on whoever builds the per-skin validator, not an automatic property of the shape.

## Test plan

- [x] `npx vitest run` (frontend): 384 files / 8344 tests passing
- [x] `npx eslint src/App.svelte <other touched files>` — clean
- [x] `npx svelte-check --tsconfig ./tsconfig.app.json` — 0 warnings; 2 pre-existing errors in an untouched, unrelated file
- [x] `npx tsc -p tsconfig.node.json` — clean
- [x] Mutation 1 (allowlist reverted): red (exit 1) → restored green (exit 0)
- [x] Mutation 2 (fallback loop removed): red (exit 1) → restored green (exit 0)
- [x] `git diff --numstat` against merge base `89776518`: 5 files, 248 changed lines — under both the 6-file/600-line soft threshold and the 10/1000 hard ceiling

## numstat (vs merge base 89776518)

```
25	3	frontend/src/App.svelte
191	0	frontend/src/__tests__/design-language-activation.component.test.ts
1	7	frontend/src/presentation/languages/declarations.ts
7	4	frontend/src/presentation/workspace/__tests__/contract.test.ts
8	2	frontend/src/presentation/workspace/contract.ts
```
