### PR TITLE
docs(design-a-face): derive the send side and wiring facts from code

### DIFF
--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -19,9 +19,8 @@ never reports. This is not caught by taste, review, or types — it is caught by
 asking, per element, which field feeds it.
 
 **It draws only the happy state.** Every value in this system is a pair —
-a reading and an availability — and a reading that is not `known` carries one
-of four reasons. A design that shows a number and a dash has collapsed five
-states into two, and two of the collapsed ones are safety-relevant.
+a reading and an availability. A design that shows a number and a dash has collapsed three
+states into two.
 
 This skill exists to make both impossible to ship by accident.
 
@@ -376,13 +375,9 @@ document and weeks in the tree:
   skin renders.
 
 The worked example: `components-v2/meters/LinearSMeter.svelte` reads `--v2-*`
-variables — run `./extract-contract.py` and check its "What already draws each
-surface" section for the current count — so its colours are theme-restylable,
-but its segment count and bar geometry are computed in code, and its peak
-decay is a constant. A design language declaring a meter track width and
-segment gap cannot move any of it. That is why segmentline's meter tokens
-could not have worked even with a functioning value channel: there was
-nothing on the other end reading them.
+variables so its colours are theme-restylable,
+but bar geometry is computed in code, and its peak
+decay is a constant.
 
 Check the tier per element **before** proposing its appearance. An element in
 tier three whose proposed look differs from what the component draws is not a

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -318,6 +318,22 @@ First, three lists:
 3. **Unshown.** Fields that exist, that the reference has no element for.
    Usually the larger list, and usually where the real work is.
 
+**Two mechanical checks the Backed list must pass, not two more things to
+remember:**
+
+1. Every drawn element names the field backing it, from the contract
+   `extract-contract.py` emitted — or is marked `unavailable` with a reason.
+2. Every drawn control names the intent it dispatches, from
+   `RADIO_INTENT_NAMES` (the extractor's "Send side" section) — and the
+   feedback mechanism for it — or is marked `display only`.
+
+A proposal failing either is a plan, not an implementable one. `./extract-
+contract.py --checklist` emits a skeleton with one line per field and per
+intent to fill in; `--checklist --validate <file>` fails, naming what is
+missing, when a filled-in proposal drops one (`./extract-contract.py
+--selftest` proves this discriminates: a complete proposal exits 0, one
+with a field or an intent struck exits non-zero).
+
 ## Phase 4 — place, by the reasoning rather than by the picture
 
 Group the backed fields into functional blocks — things operated together,
@@ -401,107 +417,6 @@ horizon or argue explicitly that it should not vary.
 states. Stale, unsupported, contradictory and disconnected are usually drawn
 nowhere in it — which means everything proposed for them is new work rather than
 adaptation, and must be labelled that way when it lands.
-
-## Reference — how this is actually wired
-
-Established by reading and measuring, not by reasoning from the architecture
-document. Start here rather than rediscovering it; verify anything you are about
-to depend on, because the tree moves.
-
-### The path a value takes
-
-`rigs/<radio>.toml` declares features and per-field acquisition policies →
-capabilities → `semantic/radio-view-model.ts` (fourteen **optional** groups) →
-`lib/runtime/adapters/radio-view-model-adapter.ts` → the fourteen surfaces in
-`semantic/` → shared components in `components-v2/` and `primitives/`.
-
-A field existing in the view model does not mean the radio reports it, and a
-group being present does not mean its fields are supported. Both gates are
-separate and both are checkable.
-
-**The two fourteens are different sets, not the same fourteen counted
-twice.** A complete mapping exists between them (checked against every
-surface component's own header): ten surfaces map to one optional group of
-the matching name (`txAux`, `meters`, `rxAudio`, `dsp`, `rfFrontEnd`, `band`,
-`antenna`, `cwKeyer`, `scopeControls`, `scopeDisplay`). Two surfaces each own
-*two* groups — `FilterSurface` renders both `modeFilter` and
-`filterPassband`, `RitXitScanSurface` renders both `ritXit` and `scan`, each
-surface's own header says so — which is where the other four groups go
-(10 + 2×2 = 14). The remaining two surfaces, `vfo` and `rxTx`, are backed by
-required top-level `RadioViewModel` fields that carry no `?` — `vfos`,
-`activeReceiver`, `split`, `dualWatch` for `vfo`; `txTarget`, `txPermit` for
-`rxTx` — not by any of the fourteen optional groups at all (10 + 2 + 2 = 14
-surfaces). The shared count of fourteen invites a one-to-one reading; there
-is a correspondence, but it is not that one.
-
-### The path an appearance takes
-
-A design language supplies three things and no markup: tokens, renderers, a
-stylesheet.
-
-- **Custom properties** carry values CSS must *consume* — a length, a colour.
-  Each family's root rule declares `--dl-<family>-*`; `tokens.ts` wraps them in
-  a local `tone()` helper with fallbacks.
-- **Data attributes** carry values CSS only *selects on*. `annotate()` in
-  `semantic/design-language-renderers.ts` copies **top-level primitives only**,
-  skips `text`, and `String()`s the value. Nested objects and arrays are
-  dropped with no `else` branch, so anything nested reaches no attribute in any
-  state.
-- The surfaces spread the result: `{...<slot>?.attributes ?? {}}` in
-  `RxTxSurface`, `MetersSurface`, `VfoSurface`.
-
-An attribute is a string. A length sent that way arrives as `"7"` and no rule
-can make a width of it.
-
-### Where the layout decides
-
-`presentation/layouts/contract.ts` holds `SEMANTIC_SURFACE_NAMES` — fourteen,
-closed. A manifest declares zones; `zoned()` in
-`components-v2/wiring/SemanticRadioSurfaces.svelte` mounts a surface into its
-zone. Nine surfaces in the dual composition pass `allowBare={false}` and vanish
-when undeclared; the rest render bare. `zoneShowsSurface`
-(`presentation/workspace/resolution.ts`) is fail-open.
-
-`presentation/workspace/contract.ts` gates what an operator can pick:
-`WORKSPACE_DESIGN_LANGUAGE_IDS` and `WORKSPACE_ZONE_IDS`. A language absent from
-that list cannot activate — `pickId` falls back — regardless of what any
-manifest says.
-
-### The instruments, and how far a design language reaches them
-
-The shared components read the **theme** vocabulary, not the design language's.
-Measured: `components-v2/meters/LinearSMeter.svelte` has eighteen `var(--v2-*)`
-and zero `var(--dl-*)`; `primitives/frequency/FrequencyDisplayInteractive.svelte`
-has fourteen and zero.
-
-`FrequencyDisplayInteractive` emits one element per glyph — `.digit`, `.sep`,
-inside `.freq` — and mounts only when `onTuneFrequency` is supplied. The readout
-slot `studioline.css` targets is `.vfo-freq` on `VfoSurface`, which is a
-different element from `.freq`.
-
-### The shared control layer, and how far adoption got
-
-It exists and works: `components-v2/controls/control-button.css` and
-`button-tokens.css`, `primitives/control-feedback/control-feedback-presentation.ts`,
-and helpers in `semantic/` — `pressed-of.ts`, `disabled-reason.ts`,
-`format-level.ts`, `pbt-presentation-continuity.ts`.
-
-Adoption by the fourteen v3 surfaces, measured: `pressedOf` **7 of 14**,
-`control-feedback-presentation` **1 of 14**, the shared button class **0 of 12**
-that render a `<button>`. `semantic/controls/` is named by an eslint boundary
-rule and does not exist.
-
-`pressed-of.ts`'s own header records four independent re-derivations of one
-rule, one of them unpinned. Assume a control behaviour you need already exists
-somewhere and look for it before proposing that a design introduce it.
-
-### Import boundaries
-
-`semantic/` may not import skins. It already imports from
-`components-v2/controls`, `panels` and `meters`, so reaching the shared control
-layer is allowed. `presentation/` may not import transport, stores or the
-runtime barrel. Rules are in `frontend/eslint.config.js`; `lint-imports` covers
-the Python side.
 
 ## Ask, and here is exactly when
 
@@ -602,9 +517,27 @@ reaches no attribute in any state.
 symbol opened. A count with no adjacent command is a claim, not a measurement,
 and the grammar of a ratio makes it read as though it had already been counted.
 
+**Import boundaries are enforced, not advisory.** `semantic/` may not import
+skins or runtime internals (`FORBIDDEN_SEMANTIC_IMPORTS`,
+`frontend/eslint.config.js`); `presentation/` may not import transport,
+stores, the runtime barrel, or `lib/runtime/commands/*`
+(`FORBIDDEN_PRESENTATION_IMPORTS`, same file). A proposal that would need
+either is a change to a lower layer, not a design-language change. Run
+`./extract-contract.py` for the current send-side and feedback-adoption
+facts these rules used to be typed out from by hand — they rot the same way
+any hand-maintained count does.
+
 ## Verifying a proposal is buildable
 
-Before handing it over, for each backed element:
+Before handing it over, run the two mechanical checks Phase 3 states:
+
+1. Every drawn element names its backing field from the extractor's output,
+   or is marked `unavailable` with a reason.
+2. Every drawn control names the intent it dispatches and the feedback
+   mechanism for it, or is marked `display only`.
+
+A proposal failing either is a plan, not an implementable one. Then, for
+each backed element:
 
 - Name the surface it mounts on and confirm that surface is in
   `SEMANTIC_SURFACE_NAMES`.
@@ -627,10 +560,8 @@ Before handing it over, for each backed element:
   and the one the first three don't cover.** `WORKSPACE_DESIGN_LANGUAGE_IDS` in
   `presentation/workspace/contract.ts` is the closed set an operator can pick;
   a language absent from it cannot activate in production regardless of what
-  the other three checks say — `pickId` falls back to `studioline` instead
-  (already stated once, in the "Where the layout decides" reference section
-  above; a checklist reader does not go there, which is why it is repeated
-  here).
+  the other three checks say — `pickId` falls back to `studioline` instead.
 
-A proposal that fails any of the four is a plan, not an implementable one,
-and should say which it fails.
+A proposal that fails any of these four mount checks, or either of the two
+mechanical checks above, is a plan, not an implementable one, and should say
+which it fails.

--- a/.claude/skills/design-a-face/SKILL.md
+++ b/.claude/skills/design-a-face/SKILL.md
@@ -65,8 +65,10 @@ The state vocabulary is the part designs get wrong, and there are **three
 mechanisms**. Do not generalise any of them.
 
 **The one that decides whether a block exists at all.** `RadioViewModel`
-declares its fourteen groups optional — `readonly meters?:`, `readonly dsp?:`.
-An absent group is not the same fact as every field in it being unsupported: a
+declares some of its groups optional — `readonly meters?:`, `readonly dsp?:`.
+Run the extractor; its "How absence is expressed" section states exactly how
+many, freshly, every time. An absent group is not the same fact as every field
+in it being unsupported: a
 present group can hold nothing but unsupported fields, and a design reaching
 into an absent one throws. Each group's docstring names its own gate. This is
 the first question for any block, before any question about its contents.
@@ -82,10 +84,11 @@ are the only way to tell them apart.
 `reason` union of `not-observed`, `stale`, `unsupported`, `contradiction`.
 It is the only one. An earlier version of the extractor took the first
 occurrence of that union and printed it as the model-wide vocabulary; the
-resulting document told a designer to distinguish four states that twelve of
-fourteen surfaces cannot express — `RxTxSurface` and `VfoSurface` are the two
-that read `txTarget`. Run the extractor and read what it reports per type;
-never carry a vocabulary across from one field to the rest.
+resulting document told a designer to distinguish four states that most
+surfaces cannot express — `RxTxSurface` and `VfoSurface` are the only two
+that read `txTarget` (`grep -rl txTarget frontend/src/semantic/*Surface.svelte`
+names exactly these two). Run the extractor and read what it reports per
+type; never carry a vocabulary across from one field to the rest.
 
 If a design needs *never asked* distinguished from *answer aged out* on a field
 that does not carry the reason union, that is a request for a state the model
@@ -327,12 +330,12 @@ remember:**
    `RADIO_INTENT_NAMES` (the extractor's "Send side" section) — and the
    feedback mechanism for it — or is marked `display only`.
 
-A proposal failing either is a plan, not an implementable one. `./extract-
-contract.py --checklist` emits a skeleton with one line per field and per
-intent to fill in; `--checklist --validate <file>` fails, naming what is
-missing, when a filled-in proposal drops one (`./extract-contract.py
---selftest` proves this discriminates: a complete proposal exits 0, one
-with a field or an intent struck exits non-zero).
+A proposal failing either is a plan, not an implementable one.
+`./extract-contract.py --checklist` emits a skeleton with one line per field
+and per intent to fill in; `--checklist --validate <file>` fails, naming
+what is missing, when a filled-in proposal drops one (`./extract-contract.py
+--selftest` proves this discriminates: a complete proposal exits 0, one with
+a field or an intent struck exits non-zero).
 
 ## Phase 4 — place, by the reasoning rather than by the picture
 
@@ -372,12 +375,14 @@ document and weeks in the tree:
   decay constant. Changing the look means changing a shared component that every
   skin renders.
 
-The worked example: `components-v2/meters/LinearSMeter.svelte` reads eighteen
-`--v2-*` variables, so its colours are theme-restylable — but `SEG_COUNT = 20`
-and its bar geometry are computed in code, and its peak decay is a constant. A
-design language declaring a meter track width and segment gap cannot move any of
-it. That is why segmentline's meter tokens could not have worked even with a
-functioning value channel: there was nothing on the other end reading them.
+The worked example: `components-v2/meters/LinearSMeter.svelte` reads `--v2-*`
+variables — run `./extract-contract.py` and check its "What already draws each
+surface" section for the current count — so its colours are theme-restylable,
+but its segment count and bar geometry are computed in code, and its peak
+decay is a constant. A design language declaring a meter track width and
+segment gap cannot move any of it. That is why segmentline's meter tokens
+could not have worked even with a functioning value channel: there was
+nothing on the other end reading them.
 
 Check the tier per element **before** proposing its appearance. An element in
 tier three whose proposed look differs from what the component draws is not a

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -661,8 +661,7 @@ class _SendSideIndex:
         helper rather than in the exposed handler; and `onVoxToggle:
         toggleVox` (`makeTxHandlers`/`makeVoxHandlers`), a BARE reference —
         the property's whole value text IS the function's name, no `(`
-        anywhere in it, so a call-only pattern silently drops it and the
-        surface that binds it prints as though it dispatches nothing. A
+        anywhere in it, so a call-only pattern silently drops it. A
         `name:` that is not a string literal (`onModInputChange`'s
         `modInputCommand(dataMode)` — the one dynamic call site inside THIS
         file; `adapters/mod-input-auto.svelte.ts` has a second, out of this
@@ -987,7 +986,18 @@ def _run_selftest() -> int:
     non-zero and name both. Both runs go through this script's own `argv`
     entry point via `subprocess` — not a direct call into
     `validate_checklist` — so a flag wired to nothing still fails this, the
-    same discipline `measure-reference.py`'s `selftest` uses."""
+    same discipline `measure-reference.py`'s `selftest` uses.
+
+    Also asserts `resolve_panel`'s bare-identifier case above (`onVoxToggle:
+    toggleVox`) still resolves."""
+    tx_aux = [
+        row for row in send_side(read(SURFACES_WIRING), read(PANEL_COMMANDS), read(PANEL_ADAPTERS))
+        if row["surface"] == "txAux"
+    ][0]
+    on_toggle = [cb for cb in tx_aux["callbacks"] if cb["prop"] == "onToggle"][0]
+    tracer_ok = "set_vox" in on_toggle["intents"]
+    print(f"selftest: txAux.onToggle intents include set_vox: {tracer_ok} (want True)")
+
     import tempfile
 
     field_keys, intent_keys = _checklist_keys()
@@ -1014,7 +1024,7 @@ def _run_selftest() -> int:
           f"exit={bad.returncode} (want non-zero)")
     if bad.stderr.strip():
         print(bad.stderr.strip())
-    ok = good.returncode == 0 and bad.returncode != 0
+    ok = tracer_ok and good.returncode == 0 and bad.returncode != 0
     print("selftest: PASS" if ok else "selftest: FAIL")
     return 0 if ok else 1
 
@@ -1230,8 +1240,8 @@ def main() -> None:
         "radio reading; `control-feedback-presentation` "
         "(`primitives/control-feedback/`) projects the in-flight command "
         "phase; a `pending*`/`*Feedback` prop on the mount tag (from the "
-        "'Send side' section above) is the pending/confirmation contract "
-        "where neither of those is adopted. None of the three is "
+        "'Send side' section above) is the pending/confirmation contract. "
+        "None of the three is "
         "universal — check per surface, not per intent.\n"
     )
     fa = data["feedbackAdoption"]

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -531,8 +531,10 @@ def _decl_body(text: str, name: str) -> str | None:
     brace-balancing from the parameter list. None if no such declaration
     exists. Matches the FIRST occurrence only; two same-named `function`
     declarations in one file would make this ambiguous, and none exist in
-    either source file this is run against today (checked by grepping
-    `function \\w+` and diffing against its own `sort | uniq -c`)."""
+    any of the three source files this is run against today —
+    `panel-commands.ts`, `panel-adapters.ts`, `SemanticRadioSurfaces.svelte`
+    (checked by grepping `function \\w+` in each and diffing against its own
+    `sort | uniq -c`)."""
     m = re.search(rf"\bfunction {re.escape(name)}\s*\(", text)
     if m is None:
         return None
@@ -652,13 +654,19 @@ class _SendSideIndex:
     ) -> set[str]:
         """Radio intents reachable from `text` (panel-commands.ts territory):
         literal `dispatchRadioIntent({name: '<x>', ...})` calls, plus one
-        level of recursion per bare call to a `function` declared anywhere in
-        `panel-commands.ts` that `text` names — the `tuningAccumulator()` /
-        `activateReceiver()` shape, where the literal dispatch sits in a
-        helper rather than in the exposed handler itself. A `name:` that is
-        not a string literal (`onModInputChange`'s `modInputCommand(dataMode)`
-        — the one dynamic call site, also called out by this repo's own
-        `waived.ts`) is reported via `unresolved`, never guessed."""
+        level of recursion per reference — call OR bare identifier — to a
+        `function` declared anywhere in `panel-commands.ts` that `text`
+        names. Two distinct shapes need this: `tuningAccumulator()` /
+        `activateReceiver()`, a CALL where the literal dispatch sits in a
+        helper rather than in the exposed handler; and `onVoxToggle:
+        toggleVox` (`makeTxHandlers`/`makeVoxHandlers`), a BARE reference —
+        the property's whole value text IS the function's name, no `(`
+        anywhere in it, so a call-only pattern silently drops it and the
+        surface that binds it prints as though it dispatches nothing. A
+        `name:` that is not a string literal (`onModInputChange`'s
+        `modInputCommand(dataMode)` — the one dynamic call site inside THIS
+        file; `adapters/mod-input-auto.svelte.ts` has a second, out of this
+        function's reach) is reported via `unresolved`, never guessed."""
         intents: set[str] = set()
         if depth > 12:
             unresolved.append("resolution depth exceeded 12 — likely a reference cycle")
@@ -675,7 +683,7 @@ class _SendSideIndex:
                 + _value_span(text, i) + "`"
             )
         for name, body in self.panel_fns.items():
-            if re.search(rf"\b{re.escape(name)}\s*\(", text) is None:
+            if re.search(rf"\b{re.escape(name)}\b", text) is None:
                 continue
             key = ("panel", name)
             if key in visited:
@@ -873,8 +881,13 @@ def send_side(svelte_text: str, panel_text: str, panel_adapters_text: str) -> li
             continue
         props = _parse_tag_props(tag_text)
         callback_props = {k: v for k, v in props.items() if re.match(r"^on[A-Z]", k)}
+        # `pending*` (e.g. `pendingFrequencyHz`) and `*Feedback` (e.g.
+        # `breakInDelayFeedback`, `cwKeyer`'s prop for
+        # `getBreakInDelayControlFeedback()`) — a naming check over the
+        # props this specific surface's mount tag actually receives, not a
+        # hand-typed per-surface list.
         pending_props = sorted(
-            k for k in props if re.match(r"^pending[A-Z]", k) or k.endswith("ControlFeedback")
+            k for k in props if re.match(r"^pending[A-Za-z]*$", k) or k.endswith("Feedback")
         )
         callbacks = []
         for prop, value in sorted(callback_props.items()):
@@ -968,14 +981,13 @@ def validate_checklist(path: Path) -> list[str]:
 
 
 def _run_selftest() -> int:
-    """Proves the checklist validator discriminates, per the MOR-2217 owner
-    ruling that an acceptance check must be shown failing, not just passing:
-    a good proposal (every expected key present with a non-empty value)
-    must exit 0; the same proposal with one FIELD line and one INTENT line
-    struck must exit non-zero and name both. Both runs go through this
-    script's own `argv` entry point via `subprocess` — not a direct call
-    into `validate_checklist` — so a flag wired to nothing still fails this,
-    the same discipline `measure-reference.py`'s `selftest` uses."""
+    """Proves the checklist validator discriminates: a good proposal (every
+    expected key present with a non-empty value) must exit 0; the same
+    proposal with one FIELD line and one INTENT line struck must exit
+    non-zero and name both. Both runs go through this script's own `argv`
+    entry point via `subprocess` — not a direct call into
+    `validate_checklist` — so a flag wired to nothing still fails this, the
+    same discipline `measure-reference.py`'s `selftest` uses."""
     import tempfile
 
     field_keys, intent_keys = _checklist_keys()
@@ -1189,11 +1201,15 @@ def main() -> None:
         "is display-only; where the trace cannot resolve part of the chain, "
         "the reason is printed instead of a guess.\n"
     )
+    pending_by_surface = {row["surface"]: row.get("pendingProps", []) for row in data["sendSide"]}
     for row in data["sendSide"]:
         print(f"### `{row['surface']}` (`{row['tag']}`)\n")
         if row.get("notDerivable"):
             print(f"**not derivable from source**: {row['notDerivable']}\n")
             continue
+        if row["pendingProps"]:
+            print("Pending/confirmation props on its mount tag: "
+                  + ", ".join(f"`{p}`" for p in row["pendingProps"]) + "\n")
         if not row["callbacks"]:
             print("_display only — no callback props on its mount tag._\n")
             continue
@@ -1210,20 +1226,25 @@ def main() -> None:
 
     print("## Feedback adoption per surface\n")
     print(
-        "`pressedOf` (`semantic/pressed-of.ts`) reflects the last CONFIRMED "
+        "`pressedOf` (`semantic/pressed-of.ts`) reflects the last OBSERVED "
         "radio reading; `control-feedback-presentation` "
         "(`primitives/control-feedback/`) projects the in-flight command "
-        "phase. Neither is universal — check per surface, not per intent.\n"
+        "phase; a `pending*`/`*Feedback` prop on the mount tag (from the "
+        "'Send side' section above) is the pending/confirmation contract "
+        "where neither of those is adopted. None of the three is "
+        "universal — check per surface, not per intent.\n"
     )
     fa = data["feedbackAdoption"]
     pressed_n = sum(1 for v in fa.values() if v["pressedOf"])
     cfp_n = sum(1 for v in fa.values() if v["controlFeedbackPresentation"])
     button_n = sum(1 for v in fa.values() if v["rendersButton"])
     shared_button_n = sum(1 for v in fa.values() if v["sharedButtonClass"])
+    pending_n = sum(1 for p in pending_by_surface.values() if p)
     print(f"`pressedOf`: {pressed_n} of {len(fa)}. "
           f"`control-feedback-presentation`: {cfp_n} of {len(fa)}. "
           f"Shared `v2-control-button` class: {shared_button_n} of {button_n} "
-          "surfaces that render a `<button>`.\n")
+          f"surfaces that render a `<button>`. Pending/confirmation props: "
+          f"{pending_n} of {len(fa)}.\n")
     for name, info in sorted(fa.items()):
         marks = []
         if info["pressedOf"]:
@@ -1232,6 +1253,9 @@ def main() -> None:
             marks.append("control-feedback-presentation")
         if info["rendersButton"]:
             marks.append("shared button class" if info["sharedButtonClass"] else "own button markup")
+        pending = pending_by_surface.get(name, [])
+        if pending:
+            marks.append("pending props: " + ", ".join(f"`{p}`" for p in pending))
         print(f"- `{name}` — " + (", ".join(marks) if marks else "none of the above"))
     print()
 

--- a/.claude/skills/design-a-face/extract-contract.py
+++ b/.claude/skills/design-a-face/extract-contract.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -25,6 +26,12 @@ from typing import NoReturn
 VIEW_MODEL = Path("frontend/src/semantic/radio-view-model.ts")
 LAYOUT_CONTRACT = Path("frontend/src/presentation/layouts/contract.ts")
 ADAPTER = Path("frontend/src/lib/runtime/adapters/radio-view-model-adapter.ts")
+PANEL_COMMANDS = Path("frontend/src/lib/runtime/commands/panel-commands.ts")
+PANEL_ADAPTERS = Path("frontend/src/lib/runtime/adapters/panel-adapters.ts")
+RADIO_INTENTS = Path("frontend/src/lib/runtime/commands/radio-intents.ts")
+SURFACES_WIRING = Path("frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte")
+SEMANTIC_DIR = Path("frontend/src/semantic")
+LANGUAGES_DIR = Path("frontend/src/presentation/languages")
 
 
 def die(msg: str) -> NoReturn:
@@ -480,17 +487,561 @@ def surface_components() -> dict[str, dict]:
     return out
 
 
+def radio_intent_names(text: str) -> list[str]:
+    """The closed set `dispatchRadioIntent` accepts — `radio-intents.ts`'s
+    own `intentSpecs` table. PTT is excluded by that module's own contract
+    ("Only a known non-PTT radio intent may be dispatched"); a callback that
+    keys or unkeys the radio reaches no name in this set by construction,
+    not by an omission of this parser."""
+    m = re.search(r"const intentSpecs = \[(.*?)\]\s*as const satisfies", text, re.S)
+    if m is None:
+        die(f"intentSpecs not found in {RADIO_INTENTS}")
+    names: list[str] = []
+    for block in re.finditer(r"names:\s*\[(.*?)\]", m.group(1), re.S):
+        names += re.findall(r"'([a-z_0-9]+)'", block.group(1))
+    if not names:
+        die("intentSpecs parsed to zero intent names")
+    return sorted(set(names))
+
+
+def _strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def _balanced(text: str, i: int, open_ch: str, close_ch: str) -> int:
+    """Index just past the `close_ch` matching the `open_ch` at `text[i]`,
+    or -1 if the text runs out unbalanced."""
+    depth = 0
+    n = len(text)
+    while i < n:
+        if text[i] == open_ch:
+            depth += 1
+        elif text[i] == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return -1
+
+
+def _decl_body(text: str, name: str) -> str | None:
+    """Body of `function <name>(...) {...}`, found anywhere in `text` —
+    module scope or nested inside another function — by paren- then
+    brace-balancing from the parameter list. None if no such declaration
+    exists. Matches the FIRST occurrence only; two same-named `function`
+    declarations in one file would make this ambiguous, and none exist in
+    either source file this is run against today (checked by grepping
+    `function \\w+` and diffing against its own `sort | uniq -c`)."""
+    m = re.search(rf"\bfunction {re.escape(name)}\s*\(", text)
+    if m is None:
+        return None
+    paren_open = text.index("(", m.end() - 1)
+    paren_end = _balanced(text, paren_open, "(", ")")
+    if paren_end < 0:
+        return None
+    brace_open = text.find("{", paren_end)
+    if brace_open < 0:
+        return None
+    brace_end = _balanced(text, brace_open, "{", "}")
+    if brace_end < 0:
+        return None
+    return text[brace_open + 1 : brace_end - 1]
+
+
+def _value_span(text: str, i: int) -> str:
+    """From index `i`, the value text up to the next top-level `,`/`;` or
+    the enclosing bracket's own close. Bracket-depth-aware over `(){}[]`
+    only — deliberately not a JS-grammar parser — so it finds where one
+    object property or `const` value ends whether that value is an arrow
+    function, a bare reference, or an IIFE (`onFilterWidthChange`'s
+    debounce wrapper in `panel-commands.ts`, which a stricter "(params) =>
+    body" pattern does not match at all)."""
+    n = len(text)
+    while i < n and text[i] in " \t\r\n":
+        i += 1
+    start = i
+    depth = 0
+    while i < n:
+        c = text[i]
+        if c in "({[":
+            depth += 1
+        elif c in ")}]":
+            if depth == 0:
+                break
+            depth -= 1
+        elif c in ",;" and depth == 0:
+            break
+        i += 1
+    return text[start:i].strip()
+
+
+def _prop_value(text: str, prop: str) -> str | None:
+    """Value text of the first `<prop>: <value>` in `text`. The negative
+    lookbehind excludes `x.<prop>:` (a property ACCESS, not a definition)
+    and a longer identifier ending in `<prop>`."""
+    m = re.search(rf"(?<![\w.]){re.escape(prop)}\s*:\s*", text)
+    return None if m is None else _value_span(text, m.end())
+
+
+def _const_value(text: str, name: str) -> str | None:
+    m = re.search(rf"\bconst {re.escape(name)}\s*=\s*", text)
+    return None if m is None else _value_span(text, m.end())
+
+
+class _SendSideIndex:
+    """The svelte-wiring and panel-commands symbol tables needed to trace a
+    surface's callback prop to the `RADIO_INTENT_NAMES` it can reach — built
+    once from the three files that actually wire surfaces to commands, never
+    hand-typed. See `send_side()`."""
+
+    def __init__(self, svelte_text: str, panel_text: str, panel_adapters_text: str) -> None:
+        self.panel_text = panel_text
+        self.aliases: dict[str, list[str]] = {}
+        for m in re.finditer(r"const (\w+) = semanticHandlers\.(\w+);", svelte_text):
+            self.aliases[m.group(1)] = [m.group(2)]
+        for m in re.finditer(
+            r"const (\w+) = \{\s*\.\.\.semanticHandlers\.(\w+),\s*\.\.\.semanticHandlers\.(\w+)\s*\};",
+            svelte_text,
+        ):
+            self.aliases[m.group(1)] = [m.group(2), m.group(3)]
+
+        self.records: dict[str, str] = {}
+        for m in re.finditer(r"const ([A-Z][A-Z0-9_]+):\s*Record<", svelte_text):
+            eq = svelte_text.index("=", m.end())
+            brace = svelte_text.index("{", eq)
+            end = _balanced(svelte_text, brace, "{", "}")
+            self.records[m.group(1)] = svelte_text[brace + 1 : end - 1]
+
+        self.local_fns: dict[str, str] = {}
+        for m in re.finditer(r"\bfunction (\w+)\s*\(", svelte_text):
+            body = _decl_body(svelte_text, m.group(1))
+            if body is not None:
+                self.local_fns.setdefault(m.group(1), body)
+        for m in re.finditer(r"\bconst (\w+)\s*=\s*\(", svelte_text):
+            name = m.group(1)
+            if name in self.local_fns:
+                continue
+            value = _const_value(svelte_text, name)
+            if value is not None and "=>" in value[:200]:
+                self.local_fns[name] = value
+
+        self.panel_fns: dict[str, str] = {}
+        for m in re.finditer(r"\bfunction (\w+)\s*\(", panel_text):
+            name = m.group(1)
+            if name not in self.panel_fns:
+                body = _decl_body(panel_text, name)
+                if body is not None:
+                    self.panel_fns[name] = body
+
+        bind_body = _decl_body(panel_adapters_text, "bindSemanticSurfaceHandlers")
+        if bind_body is None:
+            die(f"bindSemanticSurfaceHandlers not found in {PANEL_ADAPTERS}")
+        self.family_factory: dict[str, str] = dict(re.findall(r"(\w+):\s*(make\w+)\(\)", bind_body))
+        if not self.family_factory:
+            die(f"bindSemanticSurfaceHandlers parsed to zero families in {PANEL_ADAPTERS}")
+        self._factory_body_cache: dict[str, str | None] = {}
+
+    def _factory_body(self, factory: str) -> str | None:
+        if factory not in self._factory_body_cache:
+            self._factory_body_cache[factory] = _decl_body(self.panel_text, factory)
+        return self._factory_body_cache[factory]
+
+    def resolve_panel(
+        self, text: str, visited: set[tuple], unresolved: list[str], depth: int = 0
+    ) -> set[str]:
+        """Radio intents reachable from `text` (panel-commands.ts territory):
+        literal `dispatchRadioIntent({name: '<x>', ...})` calls, plus one
+        level of recursion per bare call to a `function` declared anywhere in
+        `panel-commands.ts` that `text` names — the `tuningAccumulator()` /
+        `activateReceiver()` shape, where the literal dispatch sits in a
+        helper rather than in the exposed handler itself. A `name:` that is
+        not a string literal (`onModInputChange`'s `modInputCommand(dataMode)`
+        — the one dynamic call site, also called out by this repo's own
+        `waived.ts`) is reported via `unresolved`, never guessed."""
+        intents: set[str] = set()
+        if depth > 12:
+            unresolved.append("resolution depth exceeded 12 — likely a reference cycle")
+            return intents
+        text = _strip_comments(text)
+        for m in re.finditer(r"dispatchRadioIntent\(\{\s*name:\s*", text):
+            i = m.end()
+            if i < len(text) and text[i] == "'":
+                j = text.index("'", i + 1)
+                intents.add(text[i + 1 : j])
+                continue
+            unresolved.append(
+                "dispatchRadioIntent's name is computed, not a literal: `"
+                + _value_span(text, i) + "`"
+            )
+        for name, body in self.panel_fns.items():
+            if re.search(rf"\b{re.escape(name)}\s*\(", text) is None:
+                continue
+            key = ("panel", name)
+            if key in visited:
+                continue
+            visited.add(key)
+            intents |= self.resolve_panel(body, visited, unresolved, depth + 1)
+        return intents
+
+    def resolve_svelte(
+        self, text: str, visited: set[tuple], unresolved: list[str], depth: int = 0
+    ) -> set[str]:
+        """Radio intents reachable from `text` (svelte-wiring territory):
+        follows `alias.method` / `semanticHandlers.<family>.<method>`
+        references into their factory in `panel-commands.ts`, `RECORD[field]`
+        maps (unioned over every field, since the field is chosen at
+        runtime), and local wrapper functions — recursively, since one
+        wrapper can call another (`selectBand` -> `tuneFrequency`)."""
+        intents: set[str] = set()
+        if depth > 12:
+            unresolved.append("resolution depth exceeded 12 — likely a reference cycle")
+            return intents
+        text = _strip_comments(text)
+
+        def follow(family: str, method: str) -> bool:
+            """True if `method` was located (and resolved) in `family`'s
+            factory. A merged alias (`txAuxIntents` = vox + tx) means only
+            ONE of several tried families is expected to declare a given
+            method — so the caller decides whether to report `unresolved`,
+            only once no family in the whole set found it."""
+            factory = self.family_factory.get(family)
+            if factory is None:
+                return False
+            body = self._factory_body(factory)
+            if body is None:
+                return False
+            value = _prop_value(body, method)
+            if value is None:
+                return False
+            intents.update(self.resolve_panel(value, visited, unresolved, depth + 1))
+            return True
+
+        for alias, families in self.aliases.items():
+            for m in re.finditer(rf"\b{re.escape(alias)}\.(\w+)", text):
+                method = m.group(1)
+                key = ("alias", alias, method)
+                if key in visited:
+                    continue
+                visited.add(key)
+                # Not `any(...)`: a short-circuiting generator would skip
+                # calling `follow` for the second family once the first
+                # resolves, silently dropping that family's intents if the
+                # method existed (rarely) in both.
+                if not any([follow(family, method) for family in families]):
+                    unresolved.append(
+                        f"`{alias}.{method}` — no `{method}:` property found in any of "
+                        + ", ".join(self.family_factory.get(f, f"<no factory for {f}>") for f in families)
+                    )
+        for m in re.finditer(r"\bsemanticHandlers\.(\w+)\.(\w+)", text):
+            family, method = m.group(1), m.group(2)
+            key = ("direct", family, method)
+            if key in visited:
+                continue
+            visited.add(key)
+            if not follow(family, method):
+                factory = self.family_factory.get(family)
+                unresolved.append(
+                    f"`semanticHandlers.{family}.{method}` — "
+                    + (f"no factory registered for family `{family}`" if factory is None
+                       else f"no `{method}:` property found in `{factory}`")
+                )
+        for rname, rbody in self.records.items():
+            if re.search(rf"\b{re.escape(rname)}\b", text) is None:
+                continue
+            key = ("record", rname)
+            if key in visited:
+                continue
+            visited.add(key)
+            intents |= self.resolve_svelte(rbody, visited, unresolved, depth + 1)
+        for fname, fbody in self.local_fns.items():
+            if re.search(rf"\b{re.escape(fname)}\b", text) is None:
+                continue
+            key = ("localfn", fname)
+            if key in visited:
+                continue
+            visited.add(key)
+            intents |= self.resolve_svelte(fbody, visited, unresolved, depth + 1)
+        return intents
+
+
+def _extract_open_tag(block: str, tag_name: str) -> str | None:
+    """The attribute text of the first `<tag_name ...>` or `<tag_name .../>`
+    in `block`, brace-depth-aware so a `>` inside a `{...}` expression prop
+    does not end the tag early."""
+    m = re.search(rf"<{re.escape(tag_name)}\b", block)
+    if m is None:
+        return None
+    i = m.end()
+    n = len(block)
+    depth = 0
+    j = i
+    while j < n:
+        c = block[j]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        elif c == ">" and depth == 0:
+            break
+        j += 1
+    tag_text = block[i:j]
+    return tag_text[:-1] if tag_text.endswith("/") else tag_text
+
+
+def _parse_tag_props(tag_text: str) -> dict[str, str]:
+    """`name={expr}`, `name="literal"` and svelte shorthand `{name}` props,
+    as a name -> value-text dict. `{name}` shorthand stores the same text as
+    both key and value, matching how `<VfoSurface ... {pendingFrequencyHz}
+    />` binds a prop whose name equals the variable it carries."""
+    props: dict[str, str] = {}
+    i = 0
+    n = len(tag_text)
+    while i < n:
+        while i < n and tag_text[i] in " \t\r\n":
+            i += 1
+        if i >= n:
+            break
+        if tag_text[i] == "{":
+            end = _balanced(tag_text, i, "{", "}")
+            if end < 0:
+                break
+            content = tag_text[i + 1 : end - 1].strip()
+            props[content] = content
+            i = end
+            continue
+        m = re.match(r"[A-Za-z][\w-]*", tag_text[i:])
+        if m is None:
+            i += 1
+            continue
+        name = m.group(0)
+        i += len(name)
+        while i < n and tag_text[i] in " \t\r\n":
+            i += 1
+        if i < n and tag_text[i] == "=":
+            i += 1
+            while i < n and tag_text[i] in " \t\r\n":
+                i += 1
+            if i < n and tag_text[i] == "{":
+                end = _balanced(tag_text, i, "{", "}")
+                if end < 0:
+                    break
+                props[name] = tag_text[i + 1 : end - 1].strip()
+                i = end
+            elif i < n and tag_text[i] in "\"'":
+                q = tag_text[i]
+                j = i + 1
+                while j < n and tag_text[j] != q:
+                    j += 1
+                props[name] = tag_text[i + 1 : j]
+                i = j + 1
+            else:
+                i += 1
+        else:
+            props[name] = "true"
+    return props
+
+
+def send_side(svelte_text: str, panel_text: str, panel_adapters_text: str) -> list[dict]:
+    """Per surface, in `SEMANTIC_SURFACE_NAMES` order (all 14 — a surface
+    with no callback props reports zero `callbacks`; a surface whose mount
+    site cannot be found reports `notDerivable` — never silently dropped):
+    every callback prop `SemanticRadioSurfaces.svelte` binds on its mount
+    tag, the `RADIO_INTENT_NAMES` it can reach, and — when the trace cannot
+    resolve part of the chain — exactly why not, in `unresolved`."""
+    index = _SendSideIndex(svelte_text, panel_text, panel_adapters_text)
+    out: list[dict] = []
+    for surface in surfaces():
+        tag = surface[0].upper() + surface[1:] + "Surface"
+        tag_path = SEMANTIC_DIR / f"{tag}.svelte"
+        if not tag_path.is_file():
+            die(f"{tag_path} does not exist — the surface-name-to-tag convention broke")
+        snippet = surface + "Surface"
+        m = re.search(rf"\{{#snippet {re.escape(snippet)}\(\)\}}(.*?)\{{/snippet\}}", svelte_text, re.S)
+        if m is None:
+            out.append({
+                "surface": surface, "tag": tag, "callbacks": [],
+                "notDerivable": f"no `{{#snippet {snippet}()}}` block found in {SURFACES_WIRING}",
+            })
+            continue
+        tag_text = _extract_open_tag(m.group(1), tag)
+        if tag_text is None:
+            out.append({
+                "surface": surface, "tag": tag, "callbacks": [],
+                "notDerivable": f"no `<{tag}` mount found inside `{{#snippet {snippet}()}}`",
+            })
+            continue
+        props = _parse_tag_props(tag_text)
+        callback_props = {k: v for k, v in props.items() if re.match(r"^on[A-Z]", k)}
+        pending_props = sorted(
+            k for k in props if re.match(r"^pending[A-Z]", k) or k.endswith("ControlFeedback")
+        )
+        callbacks = []
+        for prop, value in sorted(callback_props.items()):
+            visited: set[tuple] = set()
+            unresolved: list[str] = []
+            intents = index.resolve_svelte(value, visited, unresolved)
+            callbacks.append({
+                "prop": prop, "expression": value,
+                "intents": sorted(intents), "unresolved": unresolved,
+            })
+        out.append({
+            "surface": surface, "tag": tag, "callbacks": callbacks, "pendingProps": pending_props,
+        })
+    return out
+
+
+def feedback_adoption() -> dict[str, dict]:
+    """Per surface: does its own component file adopt `pressedOf`
+    (`semantic/pressed-of.ts`) or `control-feedback-presentation`
+    (`primitives/control-feedback/`), does it render a `<button>`, and with
+    the shared `v2-control-button` class (`components-v2/controls/
+    control-button.css`) or its own markup. Replaces the hand-typed counts
+    the SKILL.md's deleted Reference section used to carry."""
+    out: dict[str, dict] = {}
+    for surface in surfaces():
+        tag = surface[0].upper() + surface[1:] + "Surface"
+        path = SEMANTIC_DIR / f"{tag}.svelte"
+        if not path.is_file():
+            die(f"{path} does not exist — the surface-name-to-tag convention broke")
+        text = path.read_text(encoding="utf-8")
+        out[surface] = {
+            "pressedOf": "pressed-of'" in text or 'pressed-of"' in text,
+            "controlFeedbackPresentation": "control-feedback-presentation" in text,
+            "rendersButton": bool(re.search(r"<button\b", text)),
+            "sharedButtonClass": "v2-control-button" in text,
+        }
+    return out
+
+
+def stylesheet_dl_selectors() -> dict[str, bool]:
+    """Which design-language stylesheets under `LANGUAGES_DIR` select on
+    `data-dl-*` (the attribute channel `annotate()` in `semantic/design-
+    language-renderers.ts` writes) — distinct from merely consuming
+    `--dl-*` custom properties, which `surface_components()` already
+    reports per component."""
+    paths = sorted(LANGUAGES_DIR.glob("*/*.css"))
+    if not paths:
+        die(f"no stylesheets found under {LANGUAGES_DIR}")
+    return {str(p): "data-dl-" in p.read_text(encoding="utf-8") for p in paths}
+
+
+def _checklist_keys() -> tuple[list[str], list[str]]:
+    """(field keys, intent keys) a face-design proposal must account for —
+    every field of every `*ViewModel` interface, and every name in
+    `RADIO_INTENT_NAMES`. Radio-agnostic by design: the checklist is filled
+    out per-proposal, and a proposal may legitimately draw a field or an
+    intent the CURRENT `--radio` does not declare, marking it `unavailable`."""
+    field_keys = sorted(
+        f"{name}.{f['name']}" for name, fields in view_models(read(VIEW_MODEL)).items() for f in fields
+    )
+    intent_keys = radio_intent_names(read(RADIO_INTENTS))
+    return field_keys, intent_keys
+
+
+def checklist_skeleton() -> str:
+    field_keys, intent_keys = _checklist_keys()
+    lines = [
+        "# Buildability checklist (MOR-2217) — fill every line; do not delete any.",
+        "# FIELD <name>: the drawn element, or `unavailable: <reason>`.",
+        "# INTENT <name>: the feedback mechanism, or `display-only`.",
+    ]
+    lines += [f"FIELD {k}: TODO" for k in field_keys]
+    lines += [f"INTENT {k}: TODO" for k in intent_keys]
+    return "\n".join(lines) + "\n"
+
+
+def validate_checklist(path: Path) -> list[str]:
+    """`FIELD <key>`/`INTENT <key>` entries the filled proposal at `path` is
+    missing — present with an empty value counts as missing too. Empty list
+    means every field and every intent this contract knows about was named."""
+    field_keys, intent_keys = _checklist_keys()
+    text = path.read_text(encoding="utf-8")
+    found: dict[str, set[str]] = {"FIELD": set(), "INTENT": set()}
+    for m in re.finditer(r"^(FIELD|INTENT) ([\w.]+):[ \t]*(.*)$", text, re.M):
+        kind, key, value = m.group(1), m.group(2), m.group(3).strip()
+        if value:
+            found[kind].add(key)
+    missing = [f"FIELD {k}" for k in field_keys if k not in found["FIELD"]]
+    missing += [f"INTENT {k}" for k in intent_keys if k not in found["INTENT"]]
+    return missing
+
+
+def _run_selftest() -> int:
+    """Proves the checklist validator discriminates, per the MOR-2217 owner
+    ruling that an acceptance check must be shown failing, not just passing:
+    a good proposal (every expected key present with a non-empty value)
+    must exit 0; the same proposal with one FIELD line and one INTENT line
+    struck must exit non-zero and name both. Both runs go through this
+    script's own `argv` entry point via `subprocess` — not a direct call
+    into `validate_checklist` — so a flag wired to nothing still fails this,
+    the same discipline `measure-reference.py`'s `selftest` uses."""
+    import tempfile
+
+    field_keys, intent_keys = _checklist_keys()
+    good_lines = [f"FIELD {k}: backed by <element>" for k in field_keys]
+    good_lines += [f"INTENT {k}: display-only" for k in intent_keys]
+    bad_lines = good_lines[1:-1]  # drops the first FIELD line and the last INTENT line
+
+    script = str(Path(__file__).resolve())
+    with tempfile.TemporaryDirectory() as tmp:
+        good_path = Path(tmp) / "good.txt"
+        bad_path = Path(tmp) / "bad.txt"
+        good_path.write_text("\n".join(good_lines) + "\n", encoding="utf-8")
+        bad_path.write_text("\n".join(bad_lines) + "\n", encoding="utf-8")
+        good = subprocess.run(
+            [sys.executable, script, "--checklist", "--validate", str(good_path)],
+            capture_output=True, text=True,
+        )
+        bad = subprocess.run(
+            [sys.executable, script, "--checklist", "--validate", str(bad_path)],
+            capture_output=True, text=True,
+        )
+    print(f"selftest: good proposal ({len(good_lines)} lines) exit={good.returncode} (want 0)")
+    print(f"selftest: bad proposal ({len(bad_lines)} lines, one FIELD + one INTENT dropped) "
+          f"exit={bad.returncode} (want non-zero)")
+    if bad.stderr.strip():
+        print(bad.stderr.strip())
+    ok = good.returncode == 0 and bad.returncode != 0
+    print("selftest: PASS" if ok else "selftest: FAIL")
+    return 0 if ok else 1
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--radio", default="ftx1")
     ap.add_argument("--json", action="store_true")
+    ap.add_argument("--checklist", action="store_true",
+                     help="emit a buildability-checklist skeleton instead of the contract")
+    ap.add_argument("--validate", metavar="PATH",
+                     help="with --checklist: check a filled-in checklist file instead of emitting one")
+    ap.add_argument("--selftest", action="store_true",
+                     help="prove the checklist validator discriminates, then exit")
     args = ap.parse_args()
+
+    if args.selftest:
+        raise SystemExit(_run_selftest())
+
+    if args.checklist:
+        if args.validate:
+            missing = validate_checklist(Path(args.validate))
+            if missing:
+                for line in missing:
+                    print(f"missing: {line}", file=sys.stderr)
+                raise SystemExit(1)
+            print("checklist: complete")
+            return
+        print(checklist_skeleton(), end="")
+        return
 
     vm_text = read(VIEW_MODEL)
     view_models_data = view_models(vm_text)
     optional_groups = [
         f["name"] for f in view_models_data.get("RadioViewModel", []) if f["optional"]
     ]
+    panel_text = read(PANEL_COMMANDS)
+    panel_adapters_text = read(PANEL_ADAPTERS)
+    svelte_text = read(SURFACES_WIRING)
     data = {
         "surfaces": surfaces(),
         "absence": absence_model(vm_text),
@@ -500,8 +1051,12 @@ def main() -> None:
         "radioFeatures": radio_declares(args.radio)[0],
         "surfaceComponents": surface_components(),
         "presenceGates": presence_gates(read(ADAPTER), optional_groups),
+        "sendSide": send_side(svelte_text, panel_text, panel_adapters_text),
+        "feedbackAdoption": feedback_adoption(),
+        "stylesheetDlSelectors": stylesheet_dl_selectors(),
         "sources": [
             str(VIEW_MODEL), str(LAYOUT_CONTRACT), str(ADAPTER), radio_declares(args.radio)[1],
+            str(PANEL_COMMANDS), str(PANEL_ADAPTERS), str(RADIO_INTENTS), str(SURFACES_WIRING),
         ],
     }
 
@@ -624,6 +1179,65 @@ def main() -> None:
     print(f"## What `{args.radio}` declares ({len(feats)} features)\n")
     print("A field in the view model does not mean this radio reports it.\n")
     print(", ".join(f"`{f}`" for f in feats) if feats else "_none parsed_")
+    print()
+
+    print(f"## Send side: what each surface can dispatch ({len(data['sendSide'])} surfaces)\n")
+    print(
+        "Per surface: every callback prop `SemanticRadioSurfaces.svelte` binds "
+        "on its mount tag, traced to the names in `RADIO_INTENT_NAMES` "
+        f"(`{RADIO_INTENTS}`) it can reach. A surface with no callback props "
+        "is display-only; where the trace cannot resolve part of the chain, "
+        "the reason is printed instead of a guess.\n"
+    )
+    for row in data["sendSide"]:
+        print(f"### `{row['surface']}` (`{row['tag']}`)\n")
+        if row.get("notDerivable"):
+            print(f"**not derivable from source**: {row['notDerivable']}\n")
+            continue
+        if not row["callbacks"]:
+            print("_display only — no callback props on its mount tag._\n")
+            continue
+        for cb in row["callbacks"]:
+            if cb["unresolved"]:
+                for reason in cb["unresolved"]:
+                    print(f"- `{cb['prop']}` — **not derivable from source**: {reason}")
+            if cb["intents"]:
+                print(f"- `{cb['prop']}` -> " + ", ".join(f"`{i}`" for i in cb["intents"]))
+            elif not cb["unresolved"]:
+                print(f"- `{cb['prop']}` — no `RADIO_INTENT_NAMES` intent reached "
+                      f"(expression: `{cb['expression']}`)")
+        print()
+
+    print("## Feedback adoption per surface\n")
+    print(
+        "`pressedOf` (`semantic/pressed-of.ts`) reflects the last CONFIRMED "
+        "radio reading; `control-feedback-presentation` "
+        "(`primitives/control-feedback/`) projects the in-flight command "
+        "phase. Neither is universal — check per surface, not per intent.\n"
+    )
+    fa = data["feedbackAdoption"]
+    pressed_n = sum(1 for v in fa.values() if v["pressedOf"])
+    cfp_n = sum(1 for v in fa.values() if v["controlFeedbackPresentation"])
+    button_n = sum(1 for v in fa.values() if v["rendersButton"])
+    shared_button_n = sum(1 for v in fa.values() if v["sharedButtonClass"])
+    print(f"`pressedOf`: {pressed_n} of {len(fa)}. "
+          f"`control-feedback-presentation`: {cfp_n} of {len(fa)}. "
+          f"Shared `v2-control-button` class: {shared_button_n} of {button_n} "
+          "surfaces that render a `<button>`.\n")
+    for name, info in sorted(fa.items()):
+        marks = []
+        if info["pressedOf"]:
+            marks.append("pressedOf")
+        if info["controlFeedbackPresentation"]:
+            marks.append("control-feedback-presentation")
+        if info["rendersButton"]:
+            marks.append("shared button class" if info["sharedButtonClass"] else "own button markup")
+        print(f"- `{name}` — " + (", ".join(marks) if marks else "none of the above"))
+    print()
+
+    print("## Design-language stylesheets selecting on `data-dl-*`\n")
+    for path, selects in sorted(data["stylesheetDlSelectors"].items()):
+        print(f"- `{path}` — {'selects on `data-dl-*`' if selects else 'does not'}")
     print()
 
 


### PR DESCRIPTION
## Summary

- Adds a `send_side()` pass to `extract-contract.py` that traces each of the 14 surfaces' callback props (`SemanticRadioSurfaces.svelte`) through `panel-commands.ts` to the `RADIO_INTENT_NAMES` (`radio-intents.ts`) they dispatch — every surface gets a row; where a binding can't be resolved statically the row says why, instead of being silently dropped.
- Deletes the hand-written "Reference — how this is actually wired" section from `SKILL.md`. Its per-surface counts (`pressedOf`/`control-feedback-presentation`/shared-button-class adoption, which design-language stylesheets select on `data-dl-*`) now come from two new extractor functions (`feedback_adoption()`, `stylesheet_dl_selectors()`) instead of being typed by hand. What stays in prose is rules only — import boundaries now cite `FORBIDDEN_SEMANTIC_IMPORTS`/`FORBIDDEN_PRESENTATION_IMPORTS` by name from `frontend/eslint.config.js`, no counts.
- Adds a `--checklist` / `--checklist --validate <path>` mode: emits a skeleton (one line per `*ViewModel` field, one per `RADIO_INTENT_NAMES` entry) a proposal must fill in, and validates a filled-in proposal against it. Phase 3 and "Verifying a proposal is buildable" both state the two mechanical checks this backs: every drawn element names its backing field or is `unavailable`; every drawn control names its intent and feedback mechanism or is `display only`.
- Adds `--selftest`, which proves the validator discriminates by running the real CLI (via `subprocess`, real `argv`) against a complete proposal and the same proposal with one field and one intent struck.

## Round 2

Independent review at `a217a343` returned BLOCKED (PR comment 5512784822) with four findings. All four are fixed in the head commit; this section documents each.

**B1 — `txAux`'s `onToggle` silently dropped `set_vox`.** `_SendSideIndex.resolve_panel` only recursed into a `panel-commands.ts` helper on a *call* (`\b<name>\s*\(`). `onVoxToggle: toggleVox` (`makeTxHandlers`/`makeVoxHandlers`) is a *bare* reference — the property's whole value text is the identifier, no `(` anywhere — so `toggleVox` (which dispatches `set_vox`) was never followed, and the row printed as complete rather than wrong. Fixed by matching `\b<name>\b` instead of requiring a trailing `(`. Verified: `txAux`'s `onToggle` now reads:
```
- `onToggle` -> `set_compressor`, `set_monitor`, `set_tuner_status`, `set_vox`
```
Swept the class per the review's own method: enumerated every top-level property of every one of the 16 family factories' returned object whose value is a bare identifier (not a call, not a `Record` lookup). Found exactly 2 — both `onVoxToggle: toggleVox` (one per family in the merged `txAuxIntents` alias) — both now resolve via `panel_fns`; zero remain unresolved. Full-depth count across all 56 callback props after the fix: 51 resolve to ≥1 intent, 1 resolves with a reason (`onSetModInputLan`'s dynamic dispatch), 4 resolve to zero intents with zero reason — and those 4 (`rxTx`'s `onRequestKey`/`onRequestUnkey`, `rxAudio`'s `onRoutingFocus`/`onRoutingSplit`) are the ones the review itself confirmed as genuinely correct (TX-authority controller / `audioManager`, not gaps). Mutation-killed: reverted the fix locally, confirmed `set_vox` disappears from `txAux`'s `onToggle` again, then restored.

**B4 — `pendingProps` was computed and never printed.** `send_side()` populated `pendingProps` per surface but nothing in `main()` printed it outside `--json`. Now prints under each surface in the "Send side" section and as a `pending props:` note per surface in "Feedback adoption", with a summary count. Also broadened the prop-name predicate (`^pending[A-Za-z]*$` or ends with `Feedback`, was `^pending[A-Z]` or ends with `ControlFeedback`) so it catches `cwKeyer`'s `breakInDelayFeedback` — the one surface that actually imports `control-feedback-presentation`, which the old pattern missed entirely. 5 of 14 surfaces now report a pending prop (was 4, silently, and only in `--json`).

**B2 — a hand-written count in SKILL.md Phase 4 was false as worded, and Change 2's sweep only checked ratio-shaped numbers.** "`LinearSMeter.svelte` reads eighteen `--v2-*` variables" was the *occurrence* count (18); the file reads 11 *distinct* variables (`grep -o 'var(--v2-[a-z0-9-]*' … | sort -u | wc -l` → 11). `SEG_COUNT = 20` was also hand-written. Deleted both numbers; the sentence now points at `./extract-contract.py`'s "What already draws each surface" section instead of restating a count that can drift. (This paragraph's own ground shifted under it mid-review: PR #3030, merged to `main` while this was in flight, changed `LinearSMeter.svelte` so segment count comes from a `display` prop defaulting to `DEFAULT_METER_DISPLAY` rather than a bare `SEG_COUNT` constant — the rewritten sentence, having no number to go stale, survives that change without further edit; verified `--v2-*` distinct count is still 11 and peak decay is still a constant after rebasing onto the new `main`.) Also swept the rest of the document for spelled-out numbers and digits (the review noted the original ratio-only regex is blind to prose like "eighteen"): fixed two more instances of the same shape in Phase 1 — "`RadioViewModel` declares its fourteen groups optional" now points at the extractor's own "How absence is expressed" section instead of restating the count, and "twelve of fourteen surfaces cannot express [`txTarget`]" now says "most surfaces" with an inline `grep -rl txTarget frontend/src/semantic/*Surface.svelte` establishing the "only two" claim it keeps. Everything else the sweep turned up is either self-citing (Phase 0's renderer/test-file counts, given inline as a `find` command right next to them — verified still accurate), self-verifying (Phase 2's `measure-reference.py` CLI examples and its own `selftest` description — run the tool), already past-tense "Reproduced:" history with a command attached (the "Known limit" section), grammatical use of small numbers (list markers, "one of two ways", CLI example flag values), or a ticket/commit/SHA reference (exempt). One pre-existing instance of the *same* "twelve of fourteen" phrase also lives in `extract-contract.py`'s own `absence_model()` docstring (confirmed on `main` before this PR — `git show 573c773a:.claude/skills/design-a-face/extract-contract.py | grep -n 'twelve of fourteen'`); it is not part of this PR's diff and I left it, flagging it here rather than expanding scope into an unrelated function.

**B3 — a code span broke across a hyphen line break.** `` `./extract-\ncontract.py --checklist` `` rendered as `./extract- contract.py --checklist` (a soft line break inside a code span renders as a space). Reflowed so the break falls at a word boundary outside the span.

**Prose findings inside the diff, fixed in the same commit:**
- `_run_selftest`'s docstring cited "the MOR-2217 owner ruling" — no such ruling exists in the ticket text I was given. Deleted the citation; the behavior needs none.
- `_decl_body`'s docstring said "either source file" — it runs against three (`panel-commands.ts`, `panel-adapters.ts`, `SemanticRadioSurfaces.svelte`); named all three, re-verified no duplicate `function` names in any of them.
- `resolve_panel`'s docstring said "the one dynamic call site" — true only inside `panel-commands.ts`; `adapters/mod-input-auto.svelte.ts` has a second. Scoped the sentence to the file, named the second site as out of this function's reach.
- The emitted "Feedback adoption" prose said `pressedOf` reflects the last CONFIRMED radio reading — `pressed-of.ts`'s own header says observed. Changed to "observed".

## Round 3

Review at `4b6f94df` returned BLOCKED (comment 5513131352) with two new false statements introduced while fixing round 2, plus three carry-over items. This round's governing rule (owner's ruling): delete text, or replace a single number/word with the measured value — no new sentences, verified with `git diff --word-diff=plain` against the previous head. Fixed in commit `d883963f`:

- **B5** — the "Feedback adoption" preamble claimed a `pending*`/`*Feedback` prop is the pending/confirmation contract "where neither of those is adopted." False for 3 of 5 surfaces: `cwKeyer`/`dsp`/`rfFrontEnd` carry a pending prop *and* `pressedOf`, and `cwKeyer` adopts all three mechanisms at once. Deleted the clause; the per-surface rows already show the actual combination.
- **B6** — the LinearSMeter worked example said segment count is "computed in code" and "a design language declaring a meter track width and segment gap cannot move any of it." Both false at this PR's own base (`573c773a` = #3030): `SEG_COUNT = $derived(display.segmentCount)`, and `MeterDisplay` is declared in `presentation/languages/contract.ts` — the design-language contract itself. Deleted both clauses.
- Deleted the unlabelled `--v2- 18` pointer SKILL.md added in round 2 to work around round 1's same ambiguity (18 occurrences vs. 11 distinct) — round 2 fixed the hand-written number, then re-created the same ambiguity by reference.
- Deleted `resolve_panel`'s docstring claim that a dropped bare reference makes "the surface ... print as though it dispatches nothing" — `txAux` printed three intents, not zero; the row was partial, not empty.
- Corrected SKILL.md's intro ("a reading that is not `known` carries one of four reasons," "collapsed five states into two") to match the document's own later statement that only one type carries a reason union, and the extractor's own "Not five — three."
- Added the check round 2 was missing: `--selftest` now asserts the send-side tracer resolves `txAux`'s `onToggle` to a set containing `set_vox`. Reverted the round-2 fix on a copy (`\b<name>\s*\(` instead of `\b<name>\b`) and reran: `selftest: txAux.onToggle intents include set_vox: False` / `selftest: FAIL`, exit 1. Restored and reran: `True` / `selftest: PASS`, exit 0.

Word-diff against the previous head (`git diff --word-diff=plain 4b6f94df -- .claude/skills/design-a-face/SKILL.md`) shows the SKILL.md changes are two number/word substitutions (`five`→`three`, `are`→`is`) plus sentence-closing punctuation, with everything else a deletion — no new clause. The same command against `extract-contract.py` shows one required new docstring sentence naming what the new `--selftest` assertion checks (item 6 explicitly asked for the assertion) plus the code implementing it; the two prose fixes (B5's clause, the false "prints as though" claim) are deletions plus one closing period each.

## What the extractor now prints (ftx1, "Send side" section, `txAux` after the B1 fix)

```
### `txAux` (`TxAuxSurface`)

- `onAtuTune` -> `set_tuner_status`
- `onLevelChange` -> `set_anti_vox_gain`, `set_compressor_level`, `set_drive_gain`, `set_mic_gain`, `set_monitor_gain`, `set_rf_power`, `set_vox_delay`, `set_vox_gain`
- `onToggle` -> `set_compressor`, `set_monitor`, `set_tuner_status`, `set_vox`
```

`rxTx`'s two callbacks still resolve to zero radio intents — genuinely, not a parse failure: `requestKey`/`requestUnkey` call the App-owned TX authority controller (`tx.start`/`tx.release`/`tx.resetFault`) directly, matching `radio-intents.ts`'s own "Only a known non-PTT radio intent may be dispatched" contract. `meters` and `scopeDisplay` report `display only`. One binding remains genuinely not derivable: `rxAudio`'s `onSetModInputLan` builds its intent name at runtime via `modInputCommand(dataMode)`, not a string literal — the one dynamic call site inside `panel-commands.ts` (a second, unrelated one lives in `adapters/mod-input-auto.svelte.ts`, out of this function's reach), matching this repo's own `frontend/src/lib/runtime/adapters/__tests__/conformance/waived.ts`.

`vfo` now prints its pending prop:
```
### `vfo` (`VfoSurface`)

Pending/confirmation props on its mount tag: `pendingFrequencyHz`
```
and the "Feedback adoption" summary line reads `Pending/confirmation props: 5 of 14.`

## What was deleted from SKILL.md

The full "## Reference — how this is actually wired" section (the value-path/appearance-path/layout/instruments/control-layer/import-boundaries subsections) — every count and who-reads-what fact it carried is now either computed by the extractor (adoption/stylesheet facts, this PR; `--dl-`/`--v2-` counts and `renderSlot` callers were already computed by `surface_components()` before this PR) or was pure architecture description with no counter to derive it from. The two import-boundary RULES moved into "## Rules", citing the `FORBIDDEN_SEMANTIC_IMPORTS`/`FORBIDDEN_PRESENTATION_IMPORTS` eslint constants by name instead of restating the same prose. Two dangling references to the deleted section's "Where the layout decides" subsection were fixed in the same pass. Round 2 additionally deleted the LinearSMeter/`SEG_COUNT` and "fourteen"/"twelve of fourteen" hand-typed counts described above.

## Verification (at head `d883963f`, base `main` at `573c773a`, unchanged since round 2)

```
$ python3 -m py_compile .claude/skills/design-a-face/extract-contract.py .claude/skills/design-a-face/measure-reference.py
$ echo $?
0
```

```
$ python3 .claude/skills/design-a-face/extract-contract.py --radio ftx1 >/dev/null; echo $?
0
$ python3 .claude/skills/design-a-face/extract-contract.py --radio ic7300 >/dev/null; echo $?
0
$ python3 .claude/skills/design-a-face/extract-contract.py --radio ftx1 --json >/dev/null; echo $?
0
```

`--selftest` (now also asserts the tracer, not just the checklist validator):
```
$ python3 .claude/skills/design-a-face/extract-contract.py --selftest
selftest: txAux.onToggle intents include set_vox: True (want True)
selftest: good proposal (225 lines) exit=0 (want 0)
selftest: bad proposal (223 lines, one FIELD + one INTENT dropped) exit=1 (want non-zero)
missing: FIELD AntennaViewModel.antennaCount
missing: INTENT vfo_swap
selftest: PASS
```
Reverted the tracer fix on a copy (`\b<name>\s*\(` instead of `\b<name>\b`) and reran: `txAux.onToggle intents include set_vox: False`, `selftest: FAIL`, exit 1. Restored, reran, got the PASS output above again.

```
$ uv run ruff check .claude/skills/design-a-face/extract-contract.py
All checks passed!
$ .github/scripts/check-doc-citations.sh
Doc-citation gate: clean (841 grandfathered citations).
$ .github/scripts/check-doc-citations.sh --check-links
Doc-link gate: clean (2 grandfathered dead link(s), repo-wide *.md scope).
$ git diff origin/main --check; echo $?
0
```

Spot-checks against fresh greps, independent of the extractor — the four counts the round-1 review's own "Confirmed" section reproduced, re-run at this head:
```
$ grep -l "pressed-of'" frontend/src/semantic/*Surface.svelte | wc -l
7
$ grep -l "control-feedback-presentation" frontend/src/semantic/*Surface.svelte | wc -l
1
$ grep -lE "<button\b" frontend/src/semantic/*Surface.svelte | wc -l
12
$ grep -l "v2-control-button" frontend/src/semantic/*Surface.svelte | wc -l
0
```
All four match the extractor's `## Feedback adoption per surface` output (`pressedOf: 7 of 14`, `control-feedback-presentation: 1 of 14`, shared class `0 of 12`).

No local test suites were run — none exist for this PR's diff; the standard `uv run pytest` suite is untouched by these two files.

## Guardrails

Combined diff at this head (both commits, vs `main` at `573c773a`): 2 files, 694 insertions / 120 deletions. Both halves are bundled in one PR because MOR-2217 is one ticket with three named changes (send-side tracing, the SKILL.md deletion, the two acceptance checks), not because both are inseparable from each other. Judged separately: the send-side tracer (`_SendSideIndex`, `send_side()`) *is* inseparable from the SKILL.md deletion — deleting the Reference section without it would make the same facts underivable again, which is the opposite of what Change 2 asks. The checklist validator (`checklist_skeleton()`/`validate_checklist()`/`_run_selftest()`, ~120 lines) is separable — it could have shipped as its own PR without making the deletion dishonest — but Change 3 asks for exactly this mechanism to back the two acceptance checks, so it stays with the rest of the ticket rather than becoming a second review cycle for one document.

## Not derivable / known limitations

- `rxAudio`'s `onSetModInputLan` (mod-input intent name built via `modInputCommand(dataMode)`, not a literal) — reported, not resolved; matches this repo's own documented exclusion.
- "Feedback mechanism" is reported per SURFACE — does the surface's own component import `pressedOf`/`control-feedback-presentation`, does the wiring pass it a `pending*`/`*Feedback` prop (now printed in both stdout and `--json`, after the B4 fix) — not per individual intent. The source does not expose finer-grained, per-intent feedback wiring statically without parsing each surface's own template, which is out of this ticket's scope.
- `stylesheet_dl_selectors()` decides by substring match (`"data-dl-" in text`), so a stylesheet that only *mentions* `data-dl-` in a comment would report as selecting on it. Today's answer is right for all three stylesheets regardless (verified: `segmentline.css` has both a comment and real selectors using the string), so this is a latent-instrument note rather than a wrong output today — flagged, not fixed, since fixing it wasn't part of round 2's required items.

Linear: MOR-2217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

