### PR TITLE
test: pin fence-before-provider-IO ordering in managed TX authority

### DIFF
--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -169,24 +169,30 @@ def authority(
     return managed, clock, wakeup, store, fence, lane
 
 
-def _assert_force_off_precedes_provider_io(log: FenceOrderLog, since: int) -> None:
+def _assert_force_off_precedes_provider_io(
+    log: FenceOrderLog, since: int, *, prefix: tuple[str, ...] = ()
+) -> None:
     """Pin the ForceOff ordering rule: within one full-force pass, the fence
     entry must be logged before the provider I/O (settle/settle_abort) that
-    pass performs.
+    pass performs, and nothing but `prefix` may precede the fence.
 
     `since` bookmarks the log length right before the action that triggers
-    the pass. An entry logged earlier in the window (e.g. the on-attempt
-    settle that itself decided to force off, in the UNCERTAIN-followup
-    case) is not provider I/O this fence guards, so only entries after the
-    *last* fence entry in the window are checked -- which is exactly the
-    entries this same pass produced.
+    the pass. `prefix` names the tags permitted before the fence entry in
+    the window -- empty for a pass that starts with the fence, or
+    `("effect",)` for the UNCERTAIN-followup case, where the on-attempt
+    settle that itself decided to force off is logged first. Exactly one
+    fence entry is required, everything before it must equal `prefix`
+    exactly, and at least one provider-I/O entry must follow it.
     """
     window = log[since:]
-    fence_positions = [i for i, entry in enumerate(window) if entry[0] == "fence"]
-    assert fence_positions, "expected a fence entry recorded in this window"
-    after = window[fence_positions[-1] + 1 :]
+    tags = [entry[0] for entry in window]
+    assert tags.count("fence") == 1, f"expected exactly one fence entry, got {tags}"
+    index = tags.index("fence")
+    assert tuple(tags[:index]) == prefix, (
+        f"unexpected provider I/O before the fence: {tags}"
+    )
+    after = window[index + 1 :]
     assert after, "expected provider I/O logged after the fence"
-    assert all(entry[0] in ("effect", "abort") for entry in after)
 
 
 @pytest.mark.asyncio
@@ -335,7 +341,7 @@ async def test_uncertain_on_immediately_runs_one_force_off_family(
         else await managed.transmit_on()
     )
     assert outcome is ManagedTxOutcome.ACCEPTED
-    _assert_force_off_precedes_provider_io(fence.log, since)
+    _assert_force_off_precedes_provider_io(fence.log, since, prefix=("effect",))
     assert fence.calls == 1
     assert [effect.operation for effect in lane.effects] == [
         operation,

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -72,16 +72,26 @@ class FakeConfigStore:
         return self._config
 
 
+# Event log shared between FakeFence and FakeLane within one test. Each
+# entry is appended synchronously at the top of the corresponding fake
+# method, before any gate/await, so its position in the log reflects call
+# order rather than completion order -- what the fence-before-provider-I/O
+# rule is actually about.
+FenceOrderLog = list[tuple[str, object] | tuple[str]]
+
+
 class FakeFence:
-    def __init__(self) -> None:
+    def __init__(self, log: FenceOrderLog | None = None) -> None:
         self.calls = 0
+        self.log: FenceOrderLog = log if log is not None else []
 
     async def force_off(self) -> None:
         self.calls += 1
+        self.log.append(("fence",))
 
 
 class FakeLane:
-    def __init__(self) -> None:
+    def __init__(self, log: FenceOrderLog | None = None) -> None:
         self.results: deque[ActuationResult] = deque()
         self.effects: list[ManagedTxEffect] = []
         self.aborts: list[tuple[EffectToken, AbortOperation]] = []
@@ -89,6 +99,7 @@ class FakeLane:
         self.stale_once = False
         self.gates: deque[asyncio.Event | None] = deque()
         self.started: asyncio.Queue[ManagedTxEffect] = asyncio.Queue()
+        self.log: FenceOrderLog = log if log is not None else []
 
     def block_next(self) -> asyncio.Event:
         gate = asyncio.Event()
@@ -99,6 +110,7 @@ class FakeLane:
         self, effect: ManagedTxEffect, *, deadline_monotonic: float
     ) -> ActuationSettled:
         self.effects.append(effect)
+        self.log.append(("effect", effect.operation))
         self.started.put_nowait(effect)
         result = self.results.popleft() if self.results else ActuationResult.ACCEPTED
         gate = self.gates.popleft() if self.gates else None
@@ -125,6 +137,7 @@ class FakeLane:
         deadline_monotonic: float,
     ) -> AbortFailed | None:
         self.aborts.append((token, operation))
+        self.log.append(("abort", operation))
         result = self.abort_results.get(operation, ActuationResult.ACCEPTED)
         return (
             None
@@ -141,7 +154,8 @@ def authority(
     ManagedTxAuthority, FakeClock, FakeWakeup, FakeConfigStore, FakeFence, FakeLane
 ]:
     clock, wakeup = FakeClock(), FakeWakeup()
-    store, fence, lane = FakeConfigStore(seconds), FakeFence(), FakeLane()
+    log: FenceOrderLog = []
+    store, fence, lane = FakeConfigStore(seconds), FakeFence(log), FakeLane(log)
     managed = ManagedTxAuthority(
         lane,
         store,
@@ -155,6 +169,26 @@ def authority(
     return managed, clock, wakeup, store, fence, lane
 
 
+def _assert_force_off_precedes_provider_io(log: FenceOrderLog, since: int) -> None:
+    """Pin the ForceOff ordering rule: within one full-force pass, the fence
+    entry must be logged before the provider I/O (settle/settle_abort) that
+    pass performs.
+
+    `since` bookmarks the log length right before the action that triggers
+    the pass. An entry logged earlier in the window (e.g. the on-attempt
+    settle that itself decided to force off, in the UNCERTAIN-followup
+    case) is not provider I/O this fence guards, so only entries after the
+    *last* fence entry in the window are checked -- which is exactly the
+    entries this same pass produced.
+    """
+    window = log[since:]
+    fence_positions = [i for i, entry in enumerate(window) if entry[0] == "fence"]
+    assert fence_positions, "expected a fence entry recorded in this window"
+    after = window[fence_positions[-1] + 1 :]
+    assert after, "expected provider I/O logged after the fence"
+    assert all(entry[0] in ("effect", "abort") for entry in after)
+
+
 @pytest.mark.asyncio
 async def test_ptt_owner_idempotency_and_disconnect_force_off() -> None:
     managed, clock, _, _, fence, lane = authority()
@@ -165,7 +199,9 @@ async def test_ptt_owner_idempotency_and_disconnect_force_off() -> None:
     assert await managed.ptt_down("owner-b") is ManagedTxOutcome.REJECTED
     assert await managed.ptt_up("owner-b") is ManagedTxOutcome.REJECTED
     assert (await managed.snapshot()).state == first.state
+    since = len(fence.log)
     assert await managed.owner_disconnect("owner-a") is ManagedTxOutcome.ACCEPTED
+    _assert_force_off_precedes_provider_io(fence.log, since)
     released = await managed.snapshot()
     assert released.state.intent.kind is ManagedTxIntentKind.RX
     assert not released.state.release_required
@@ -191,7 +227,9 @@ async def test_transmit_is_latched_and_force_off_runs_one_abort_family() -> None
     assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
     assert await managed.owner_disconnect("browser") is ManagedTxOutcome.REJECTED
     assert (await managed.snapshot()).state == started.state
+    since = len(fence.log)
     assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    _assert_force_off_precedes_provider_io(fence.log, since)
     assert fence.calls == 1
     force = lane.effects[-1]
     assert force.operation is ActuationOperation.FORCE_RECEIVE
@@ -205,7 +243,13 @@ async def test_transmit_is_latched_and_force_off_runs_one_abort_family() -> None
 @pytest.mark.asyncio
 async def test_offline_force_off_retries_immediately_when_provider_appears() -> None:
     managed, _, _, _, fence, lane = authority(generation=None)
+    since = len(fence.log)
     assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    # Provider offline: ForceOff's reducer emits no effect (see ForceOff
+    # handling in managed_tx_state.reduce_managed_tx), so this full-force
+    # pass has no provider I/O for the fence to precede -- only the fence
+    # call itself is logged.
+    assert fence.log[since:] == [("fence",)]
     assert (await managed.snapshot()).state.release_required
     assert lane.effects == [] and fence.calls == 1
     await managed.provider_available(8)
@@ -284,12 +328,14 @@ async def test_uncertain_on_immediately_runs_one_force_off_family(
 ) -> None:
     managed, _, _, _, fence, lane = authority()
     lane.results.extend((ActuationResult.UNCERTAIN, release))
+    since = len(fence.log)
     outcome = (
         await managed.ptt_down("owner")
         if ingress == "ptt"
         else await managed.transmit_on()
     )
     assert outcome is ManagedTxOutcome.ACCEPTED
+    _assert_force_off_precedes_provider_io(fence.log, since)
     assert fence.calls == 1
     assert [effect.operation for effect in lane.effects] == [
         operation,
@@ -333,8 +379,10 @@ async def test_tot_expiry_uses_the_single_scheduler_and_force_off() -> None:
     revision = wakeup.revision
     assert (await managed.snapshot()).remaining_tot_seconds == 10
     clock.now = 110
+    since = len(fence.log)
     wakeup.wake()
     await wakeup.wait_after(revision + 1)
+    _assert_force_off_precedes_provider_io(fence.log, since)
     projected = await managed.snapshot()
     assert projected.state.intent.kind is ManagedTxIntentKind.RX
     assert projected.remaining_tot_seconds is None
@@ -366,7 +414,9 @@ async def test_live_tot_edit_at_or_below_elapsed_forces_off_immediately() -> Non
     managed, clock, _, store, fence, lane = authority(seconds=20)
     await managed.ptt_down("owner")
     clock.now = 105
+    since = len(fence.log)
     assert (await managed.set_tot_seconds(5)).timeout_seconds == 5
+    _assert_force_off_precedes_provider_io(fence.log, since)
     projected = await managed.snapshot()
     assert store.values == [5]
     assert projected.state.intent.kind is ManagedTxIntentKind.RX
@@ -397,7 +447,9 @@ async def test_simultaneous_tot_and_retry_due_chooses_force_off() -> None:
     await managed.ptt_down("owner")
     managed._retry_due = 110
     clock.now = 110
+    since = len(fence.log)
     await managed._process_due()
+    _assert_force_off_precedes_provider_io(fence.log, since)
     assert fence.calls == 1
     assert lane.effects[-1].operation is ActuationOperation.FORCE_RECEIVE
     await managed.close()
@@ -406,9 +458,13 @@ async def test_simultaneous_tot_and_retry_due_chooses_force_off() -> None:
 @pytest.mark.asyncio
 async def test_repeated_force_off_is_accepted_and_advances_epoch() -> None:
     managed, _, _, _, fence, lane = authority()
+    since = len(fence.log)
     assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    _assert_force_off_precedes_provider_io(fence.log, since)
     first = lane.effects[-1].token.effect_epoch
+    since = len(fence.log)
     assert await managed.force_off() is ManagedTxOutcome.ACCEPTED
+    _assert_force_off_precedes_provider_io(fence.log, since)
     assert lane.effects[-1].token.effect_epoch == first + 1
     assert fence.calls == 2
     await managed.close()


### PR DESCRIPTION
Linear: MOR-2211.

The ForceOff ordering rule "fence before provider I/O" was unpinned: `FakeFence` recorded a counter, so every assertion was `fence.calls == N` — a count, never an order.

**Test-only.** `git diff --stat 4422da5c HEAD -- src/` is empty; production byte-identical. One file.

---

## Response to the review at 16:27 (rounds 1–2 were not enough — the finding was right)

**P1 — "the helper still accepts provider I/O before the fence": CONFIRMED and FIXED.** The finding was correct, and it was correct against a pin two review passes had cleared. The old helper took the last fence entry and checked only the suffix after it, so `[("effect",…), ("fence",), ("abort",…)]` passed.

The measurement that settles it, run at `6bba69d7` before the fix:

- **V1**, the literal move (fence inside the `full_force` block, after `settle`, before the abort gather): 12 tests should have caught it; **not one ordering assertion fired**. The 4 failures were all `fence.calls`/log-*count* assertions in zero-effect passes, where the relocation means the fence is never called at all. All 7 ordering-pinned tests passed. The only thing that noticed was the count — which is precisely the surface this ticket exists because it cannot express order.
- **V2**, the same reordering with count semantics preserved (`if full_force and not effects: await self._abort_fence.force_off()` retained, so every test still sees exactly one fence call): **38 passed, fully green.** Instrumented, every pinned window became `['effect','fence','abort','abort']` — `force_receive` reaching the provider *before* the fence advanced.

The strict reading is the repository's own, not the reviewer's tightening. `docs/plans/2026-09-01-runtime-transmit-authority.md`, "ForceOff and the one abort fence": FORCE_OFF performs, in order, (1) set `intent=RX`, create/upgrade `FORCE_RELEASE` debt, clear TOT, and **increment the fence before provider I/O**; (3) request `stop_cw`/`stop_tune`; (4) submit highest-priority `force_receive`. Steps 3–4 are the provider I/O.

**The fix** replaces the suffix-only check with an explicit permitted prefix plus an exact fence count: exactly one fence entry per window, everything before it must equal `prefix`, and at least one provider-I/O entry must follow. `prefix=("effect",)` at the one UNCERTAIN-followup call site — where the on-attempt settle itself decided to force off — and the default `()` at the other seven. (The brief said six; the file has **8** call sites, so 7 keep the default. Corrected by counting rather than by assuming.) The old inert third assertion (`all(entry[0] in ("effect","abort"))`, unable to fail since `after` begins past the fence) is deleted with it.

**Both directions measured**, on throwaway `git archive` copies under /tmp with `PYTHONDONTWRITEBYTECODE=1`:

| production code | helper | result |
|---|---|---|
| clean | tightened | **38 passed** — does not redden correct work |
| V2 (fence after settle, count preserved) | tightened | **12 failed, 26 passed** |
| original (fence after the whole loop) | tightened | **12 failed, 26 passed** |

Both mutations fail on the same 12 node IDs: `test_ptt_owner_idempotency_and_disconnect_force_off`, `test_transmit_is_latched_and_force_off_runs_one_abort_family`, the six `test_uncertain_on_immediately_runs_one_force_off_family[…]` ids, `test_tot_expiry_uses_the_single_scheduler_and_force_off`, `test_live_tot_edit_at_or_below_elapsed_forces_off_immediately`, `test_simultaneous_tot_and_retry_due_chooses_force_off`, `test_repeated_force_off_is_accepted_and_advances_epoch`.

### Why the fake's log point is a faithful model of the real fence, not an approximation

This pin only means anything if `FakeFence.force_off`'s log append happens where the real fence actually advances. It does, and the reason is load-bearing enough to record rather than assume:

```
$ git show origin/main:src/rigplane/runtime/managed_tx_fence.py | grep -n -A2 'async def force_off'
58:    async def force_off(self) -> TxAbortResult:
59-        self._epoch += 1
60-        cancellations = tuple(self._cancellations.items())
```

`TxAbortFence.force_off` increments the epoch as its **first statement, before any `await`**. So the epoch advances the instant the coroutine is entered, and coroutines scheduled with `create_task` cannot slip in front of it. `FakeFence.force_off` appends its log entry at the same position, which is what makes entry-order logging model the real increment point.

This was established by chasing a probe that *survived* rather than filing it as a hole: the round-3 reviewer reordered `_execute` so the abort tasks are created, then the fence runs, then `settle` — and all 38 stayed green. That is correct behaviour, not a missed violation, precisely because of line 59. Confirmed by strengthening the fake with `await asyncio.sleep(0)` after the append: still green under the same reordering.

**P2 — "the sweep remains incomplete": ACCEPTED and FINISHED.** The earlier partial sweep was my scope call, not the ticket's: I told the builder an honestly-reported partial beats a claimed complete one, and MOR-2211 says *every* test asserting on those four surfaces gets a named mutation and a yes/no. The three outstanding rows:

- **`test_active_replacement_never_replays_on`** — split by id. The 2 "replacement" ids reddened under the `provider_unavailable` mutation already recorded. The 2 "shutdown" ids route through `_complete_shutdown`, which that mutation never touches; mutating `_complete_shutdown`'s `self._execute(transition.effects, full_force=True)` → `full_force=False` reddens both (`fence.calls == 1` fails as `0 == 1`). All 4 ids now have a named, verified mutation.
- **`test_shutdown_retries_each_nonacceptance_before_retirement`** — the first mutation tried (`_refresh_retry_locked` sets `self._retry_due = None` unconditionally) **hangs**: bounded with `pytest --timeout=120 --timeout-method=thread`, it ran the full bound and was killed without completing (121s elapsed). A *bounded discriminating* mutation of the same scheduling path does exist and was measured by the round-3 reviewer: in `_process_due`, `elif self._retry_due is not None and self._retry_due <= now:` → `< now` (the test sets `clock.now` to exactly `_retry_due`). Result: **3 failed, 35 passed in 0.55s**, reddening both `[rejected]` and `[uncertain]` ids of this test via `TimeoutError`, plus `test_rejected_on_retries_release_with_new_epoch`. **Row closed: yes.**
- **The two `close()` rows** — re-derived independently rather than restated: `self._lane.` and `self._abort_fence.` have exactly 3 call sites in the production file, all inside `_execute` (`force_off`, `settle_abort`, `settle`). `close()` → `_dispose_clean()` → `_stop_scheduler()` reaches none of them and never calls `_execute`. So no single-line mutation of the code these tests reach can move `fence.calls`/`lane.effects`/`lane.aborts`. This was offered as a claim about the code rather than a measurement, and the second opinion has since arrived: the round-3 reviewer re-derived it by independent grep (`self._lane.` → 2 sites, lines 422/428; `self._abort_fence.` → 1 site, line 417; all three inside `_execute`, which starts at 410) and read `close()` → `_dispose_clean()` → `_stop_scheduler()` confirming none of them is reachable. Count agrees.

Rows that stayed green are reported, not fixed, per the ticket: `test_stale_on_settlement_does_not_run_force_off` is explicitly owned by [MOR-2210](https://linear.app/morozsm/issue/MOR-2210/mor-21665c-the-applied-guard-on-on-uncertain-settlement-is-unpinned); `test_provider_arrival_wins_retry_tie_without_duplicate_effect` is explicitly owned by [MOR-2226](https://linear.app/morozsm/issue/MOR-2226/mor-21665e-pin-provider-arrivalretry-tie-against-duplicate-release). The latter fake settles without a controllable gate, so the intended race is not contested.

**P3 — "no admissible evidence": the principle is taken, and my first rebuttal of it was FALSE.**

I previously wrote here that `Tests (quick)` at `6bba69d7` "completed success at 16:20:41Z — seven minutes before that review reported it as queued with no runner." That is wrong and inverted, and it was my error. Measured:

```
$ gh api repos/rigplane/rigplane-core/actions/runs/33654325331 --jq '.created_at, .updated_at'
2026-09-02T16:20:41Z
2026-09-02T16:28:50Z
$ gh api repos/rigplane/rigplane-core/actions/runs/33654325331/jobs --jq '.jobs[] | "\(.name) started=\(.started_at) completed=\(.completed_at)"'
quick started=2026-09-02T16:27:00Z completed=2026-09-02T16:28:50Z
```

`16:20:41Z` is when the run was **created and queued**, not when it finished. The job sat queued 6m19s, began executing at 16:27:00Z and completed at 16:28:50Z. The review was posted at 16:27:28Z — 28 seconds into execution, with nothing completed. **The reviewer's "queued with no runner" was right when written; my rebuttal read `created_at` from `gh run list` and reported it as a completion time.** Withdrawn.

The earlier remote testbed and throwaway-copy mutation evidence had no inspectable CI artifacts. That evidence is retained above as history, but the canonical evidence is now the complete Mini-only ledger below: one clean control plus M1–M15, each with run, job, and artifact links. The ledger reports 13 RED mutations and 2 SURVIVED mutations; it does not claim that all mutations were killed.

---

## Verification at head `88747959`

Remote testbed (`rp-remote-test.sh codex/fence-ordering-pins py`) — this repository's suites do not run on the workstation, where load produces false reds:

```
14283 passed, 163 skipped, 16 xfailed in 86.45s
ruff check: All checks passed!
FINAL: PASS
```

Focused `tests/test_managed_tx_authority.py`: 38 passed, matching the baseline recorded on `4422da5c` before any edit.

Inspectable CI at this exact head: `Tests (quick)` **success**, https://github.com/rigplane/rigplane-core/actions/runs/33657105018 — and `Tests (full matrix)` **success** across 3.11/3.12/3.13, https://github.com/rigplane/rigplane-core/actions/runs/33657240696.

## Canonical Mini-only mutation ledger

Denominator: **22 test functions / 31 collected parametrized nodes** covering every MOR-2211 assertion surface (`fence.calls`, `lane.effects`, `lane.aborts`, `_retry_due`). Clean control `4c531e0ed8e15acc8c58cf26a5fa6298114b991e`: **PASS, 31/31** — [run 33659629810](https://github.com/rigplane/rigplane-core/actions/runs/33659629810) · [job 100346704699](https://github.com/rigplane/rigplane-core/actions/runs/33659629810/job/100346704699) · [artifact 9858174839](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858174839/zip).

Result: **13 RED, 2 SURVIVED**. Every proof job ran on `mm-build-core-1` or `mm-build-core-2`; no route or infrastructure failure was counted as a product result.

| ID | Production mutation and covered test claim | Result | Mini evidence |
|---|---|---|---|
| M1 | `9e80ba9971961ea4d7d90e09e1a595fdb74e1af3`: move fence after all provider I/O; owner/disconnect, latched TRANSMIT, UNCERTAIN-ON ×6 | **RED** | [run 33658772676](https://github.com/rigplane/rigplane-core/actions/runs/33658772676) · [job 100343855992](https://github.com/rigplane/rigplane-core/actions/runs/33658772676/job/100343855992) · [artifact 9857915462](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9857915462/zip) |
| M2 | `997afe8efd06d16cfc886c3e6531cac8a18b7a39`: move fence between effect and abort; same ordering families | **RED** | [run 33658903770](https://github.com/rigplane/rigplane-core/actions/runs/33658903770) · [job 100344293641](https://github.com/rigplane/rigplane-core/actions/runs/33658903770/job/100344293641) · [artifact 9857924466](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9857924466/zip) |
| M3 | `79af109a57d221035bf69979d8cbc149c9bb0250`: skip fence for an empty effect plan; offline ForceOff/replacement | **RED** | [run 33658951275](https://github.com/rigplane/rigplane-core/actions/runs/33658951275) · [job 100344444603](https://github.com/rigplane/rigplane-core/actions/runs/33658951275/job/100344444603) · [artifact 9857948695](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9857948695/zip) |
| M4 | `c03f8e656477ffec7dd61a7bcdbf2be4423ca4bf`: suppress provider-arrival retry; no-provider PTT_UP, stale release debt, offline shutdown | **RED** | [run 33659024894](https://github.com/rigplane/rigplane-core/actions/runs/33659024894) · [job 100344683599](https://github.com/rigplane/rigplane-core/actions/runs/33659024894/job/100344683599) · [artifact 9857982142](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9857982142/zip); bounded offline-shutdown repeat: [run 33659793835](https://github.com/rigplane/rigplane-core/actions/runs/33659793835) · [job 100347266482](https://github.com/rigplane/rigplane-core/actions/runs/33659793835/job/100347266482) · [artifact 9858212600](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858212600/zip) |
| M5 | `dcdfc1405b44a5aa0e4aa7f5e835316936d960d8`: remove token-staleness / `APPLIED` guard; stale ON settlement | **SURVIVED** — owned by [MOR-2210](https://linear.app/morozsm/issue/MOR-2210/mor-21665c-the-applied-guard-on-on-uncertain-settlement-is-unpinned) | [run 33659074665](https://github.com/rigplane/rigplane-core/actions/runs/33659074665) · [job 100344848582](https://github.com/rigplane/rigplane-core/actions/runs/33659074665/job/100344848582) · [artifact 9858017510](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858017510/zip) |
| M6 | `26163e065deb29866a544fe14c8c5435c5e3cf15`: suppress due-TOT branch; TOT expiry and simultaneous TOT/retry | **RED** | [run 33659129742](https://github.com/rigplane/rigplane-core/actions/runs/33659129742) · [job 100345032189](https://github.com/rigplane/rigplane-core/actions/runs/33659129742/job/100345032189) · [artifact 9857982424](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9857982424/zip) |
| M7 | `d5d772cf097b83f885af77cd03027c17673ad837`: suppress immediate live-TOT expiry | **RED** | [run 33659173841](https://github.com/rigplane/rigplane-core/actions/runs/33659173841) · [job 100345179879](https://github.com/rigplane/rigplane-core/actions/runs/33659173841/job/100345179879) · [artifact 9858017627](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858017627/zip) |
| M8 | `b075c463e655258a6739e68fac18e7f5f71e29d9`: omit ForceOff epoch increment; repeated ForceOff / monotonic generation | **RED** | [run 33659251127](https://github.com/rigplane/rigplane-core/actions/runs/33659251127) · [job 100345436667](https://github.com/rigplane/rigplane-core/actions/runs/33659251127/job/100345436667) · [artifact 9858050757](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858050757/zip) |
| M9 | `7dbfa2b0372e1db1820194452b55fcd972b74568`: invoke ForceOff on every provider loss; active replacement | **RED** | [run 33659292884](https://github.com/rigplane/rigplane-core/actions/runs/33659292884) · [job 100345579317](https://github.com/rigplane/rigplane-core/actions/runs/33659292884/job/100345579317) · [artifact 9858050831](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858050831/zip) |
| M10 | `88a0bf303db8bc60caeaacae48af7b40d95f5bcd`: omit release on provider loss; replacement ×2, in-flight settlement, replacement during shutdown | **RED** | [run 33659336611](https://github.com/rigplane/rigplane-core/actions/runs/33659336611) · [job 100345726008](https://github.com/rigplane/rigplane-core/actions/runs/33659336611/job/100345726008) · [artifact 9858087330](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858087330/zip) |
| M11 | `6002a4fd60a1ed02dbca63c2edb812fc81044b22`: shutdown `_execute(..., full_force=False)`; shutdown params ×2 | **RED** | [run 33659387720](https://github.com/rigplane/rigplane-core/actions/runs/33659387720) · [job 100345898475](https://github.com/rigplane/rigplane-core/actions/runs/33659387720/job/100345898475) · [artifact 9858120115](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858120115/zip) |
| M12 | `ff9efa6fc561cce38cde34b0566acdb196f59642`: delete `pending_effect is None`; provider-arrival/retry tie | **SURVIVED** — owned by [MOR-2226](https://linear.app/morozsm/issue/MOR-2226/mor-21665e-pin-provider-arrivalretry-tie-against-duplicate-release) | [run 33659433037](https://github.com/rigplane/rigplane-core/actions/runs/33659433037) · [job 100346063790](https://github.com/rigplane/rigplane-core/actions/runs/33659433037/job/100346063790) · [artifact 9858124335](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858124335/zip) |
| M13 | `38b9bbf4e912afe5d22429b0f70bd6f957674e59`: retry deadline `<=` → `<`; rejected-ON retry and shutdown nonacceptance ×2 | **RED** (bounded 0.53 s) | [run 33659481172](https://github.com/rigplane/rigplane-core/actions/runs/33659481172) · [job 100346208926](https://github.com/rigplane/rigplane-core/actions/runs/33659481172/job/100346208926) · [artifact 9858086483](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858086483/zip) |
| M14 | `8f1b7cd0cb9c4c6dd916ae03eab546296df5b370`: add provider side effect to `close()`; both close tests | **RED** | [run 33659531060](https://github.com/rigplane/rigplane-core/actions/runs/33659531060) · [job 100346375038](https://github.com/rigplane/rigplane-core/actions/runs/33659531060/job/100346375038) · [artifact 9858155387](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858155387/zip) |
| M15 | `7147c1bea4698a1ac01332df4466228e03778338`: remove latched TRANSMIT acceptance; 10,000-command idempotency | **RED** | [run 33659578420](https://github.com/rigplane/rigplane-core/actions/runs/33659578420) · [job 100346535794](https://github.com/rigplane/rigplane-core/actions/runs/33659578420/job/100346535794) · [artifact 9858191155](https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858191155/zip) |

Exact-head stock CI for `887479597aa5bede5d7bbb618cb500782edff37f` is green on Mini: [quick run 33657105018](https://github.com/rigplane/rigplane-core/actions/runs/33657105018) / [job 100338270787](https://github.com/rigplane/rigplane-core/actions/runs/33657105018/job/100338270787) on `mm-build-core-2`; [full run 33657240696](https://github.com/rigplane/rigplane-core/actions/runs/33657240696) with [3.11](https://github.com/rigplane/rigplane-core/actions/runs/33657240696/job/100338733741), [3.12](https://github.com/rigplane/rigplane-core/actions/runs/33657240696/job/100338733950), and [3.13](https://github.com/rigplane/rigplane-core/actions/runs/33657240696/job/100338733997) on `mm-build-core-2`, plus [capture-harness](https://github.com/rigplane/rigplane-core/actions/runs/33657240696/job/100338734046) on `mm-build-core-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
