### PR TITLE
refactor(meters): draw LinearSMeter geometry from a display prop

### DIFF
--- a/frontend/src/components-v2/meters/LinearSMeter.svelte
+++ b/frontend/src/components-v2/meters/LinearSMeter.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import { createSmoother, prefersReducedMotion, onReducedMotionChange } from '$lib/utils/smoothing.svelte';
+  import type { MeterDisplay } from '../../presentation/languages/contract';
+  import { DEFAULT_METER_DISPLAY } from './meter-display';
   import {
     calibratedToSegments,
     calibratedToSUnit,
     calibratedToDbm,
     formatDbm,
     getScaleMarks,
+    getS9Raw,
     rawToSegments,
   } from './smeter-scale';
 
@@ -15,16 +18,24 @@
     compact?: boolean;
     label?: string;
     variant?: string;
+    display?: MeterDisplay;
   }
 
-  let { value, compact = false, label, variant }: Props = $props();
+  let { value, compact = false, label, variant, display = DEFAULT_METER_DISPLAY }: Props = $props();
 
   const isVfoVariant = $derived(variant === 'vfo' || variant === 'vfo-wide');
   const isWideVfoVariant = $derived(variant === 'vfo-wide');
 
   // ── Segment geometry ────────────────────────────────────────────────────────
-  const SEG_COUNT = 20;
-  const SEG_GAP = 1;
+  // `smeter-scale.ts`'s rawToSegments/calibratedToSegments always report a
+  // position on a fixed 0-20 domain (that file's `rawToSegments` tops out at
+  // 20 for any input, regardless of caller) — independent of how many visual
+  // segments this component draws. RAW_SEGMENT_DOMAIN names that fixed width
+  // so a raw-domain reading can be rescaled onto the `display.segmentCount`
+  // visual domain below.
+  const RAW_SEGMENT_DOMAIN = 20;
+  const SEG_COUNT = $derived(display.segmentCount);
+  const SEG_GAP = $derived(display.segmentGapPx);
   const BAR_X = $derived(compact && isVfoVariant ? (isWideVfoVariant ? 14 : 12) : 8);
   const BAR_WIDTH = $derived(compact && isVfoVariant ? (isWideVfoVariant ? 498 : 492) : 484);
   const SEG_W = $derived((BAR_WIDTH - (SEG_COUNT - 1) * SEG_GAP) / SEG_COUNT);
@@ -35,10 +46,21 @@
     return BAR_X + i * (SEG_W + SEG_GAP);
   }
 
-  // x position (from bar left) for a given raw value
+  // x position (from bar left) for a given raw value — rawToSegments(raw) is
+  // on the fixed RAW_SEGMENT_DOMAIN, rescaled here onto SEG_COUNT segments.
   function rawToX(raw: number): number {
-    return BAR_X + rawToSegments(raw) * (SEG_W + SEG_GAP);
+    return BAR_X + (rawToSegments(raw) / RAW_SEGMENT_DOMAIN) * SEG_COUNT * (SEG_W + SEG_GAP);
   }
+
+  // Index of the first visual segment at or above the calibrated S9 anchor.
+  // `rawToSegments(getS9Raw())` is exactly 11 on the raw 0-20 domain — S9 is
+  // the last S-unit knot, so `rawToSegments` (via `rawToSFloat`) resolves it
+  // to exactly (9/9)*11 — rescaled here by SEG_COUNT so this index tracks a
+  // non-20 segment count instead of the fixed literal 11 the
+  // pre-display-prop code used.
+  const s9SegmentIndex = $derived(
+    Math.round((rawToSegments(getS9Raw()) / RAW_SEGMENT_DOMAIN) * SEG_COUNT),
+  );
 
   // ── Colors ──────────────────────────────────────────────────────────────────
   const ACTIVE_COLORS: ReadonlyArray<string> = [
@@ -49,8 +71,14 @@
     '#E57010', '#EB6210', '#F05418', '#F44820', '#F83C28',
   ];
 
+  // Samples the 20-entry ramp above by fraction of SEG_COUNT, so a non-20
+  // segment count still walks the same color progression start-to-end.
+  function activeColor(i: number): string {
+    return ACTIVE_COLORS[Math.round((i / (SEG_COUNT - 1)) * (ACTIVE_COLORS.length - 1))];
+  }
+
   function dimColor(i: number): string {
-    return i < 11 ? '#0A2415' : '#1A1008';
+    return i < s9SegmentIndex ? '#0A2415' : '#1A1008';
   }
 
   // ── Label marks ─────────────────────────────────────────────────────────────
@@ -140,7 +168,7 @@
   const smoother = createSmoother(0.06, 0.1);
 
   $effect(() => {
-    smoother.update(calibratedToSegments(value));
+    smoother.update((calibratedToSegments(value) / RAW_SEGMENT_DOMAIN) * SEG_COUNT);
   });
 
   onMount(() => {
@@ -150,9 +178,13 @@
 
   // ── Peak hold ───────────────────────────────────────────────────────────────
   const PEAK_HOLD_MS = 1000;   // hold at peak for 1 second
-  const PEAK_DECAY   = 0.0195; // segments per frame to drop after hold expires (~30% faster)
+  // Fraction of full scale to drop per frame once the hold window expires
+  // (~30% faster), scaled by SEG_COUNT below — peakSegs lives on the
+  // SEG_COUNT-wide visual domain (fed by the rescaled smoother.update()
+  // above), not the fixed RAW_SEGMENT_DOMAIN.
+  const PEAK_DECAY_FRACTION = 0.0195 / RAW_SEGMENT_DOMAIN;
 
-  let peakSegs   = $state(0);  // peak position in segments (0-20)
+  let peakSegs   = $state(0);  // peak position in segments (0-SEG_COUNT)
   let peakTime   = $state(0);  // timestamp when peak was set
   let peakFrameId = 0;
 
@@ -203,7 +235,7 @@
         peakTime = now;
       } else if (elapsed > PEAK_HOLD_MS) {
         // Hold expired — decay toward current level
-        peakSegs = Math.max(current, peakSegs - PEAK_DECAY * 16.67); // ~1 seg/sec at 60fps
+        peakSegs = Math.max(current, peakSegs - PEAK_DECAY_FRACTION * SEG_COUNT * 16.67); // ~1 seg/sec at 60fps
       }
       // else: holding — do nothing
 
@@ -238,8 +270,14 @@
   // Only show peak line if it's meaningfully ahead of current bar
   let showPeak = $derived(peakSegs - smoother.value > 0.3);
 
+  // Peak-line color zones as fractions of the raw 20-segment domain — 15/20
+  // and 18/20 are visual gradient stops with no calibration anchor (unlike
+  // s9SegmentIndex above), rescaled the same way so they track SEG_COUNT.
+  const peakZoneYellow = $derived(Math.round((15 / RAW_SEGMENT_DOMAIN) * SEG_COUNT));
+  const peakZoneOrange = $derived(Math.round((18 / RAW_SEGMENT_DOMAIN) * SEG_COUNT));
+
   // Color of peak line based on zone
-  let peakColor = $derived(peakSegs <= 11 ? 'var(--v2-accent-cyan-bright)' : peakSegs <= 15 ? 'var(--v2-accent-yellow)' : peakSegs <= 18 ? 'var(--v2-accent-orange-alt)' : 'var(--v2-accent-red-alt)');
+  let peakColor = $derived(peakSegs <= s9SegmentIndex ? 'var(--v2-accent-cyan-bright)' : peakSegs <= peakZoneYellow ? 'var(--v2-accent-yellow)' : peakSegs <= peakZoneOrange ? 'var(--v2-accent-orange-alt)' : 'var(--v2-accent-red-alt)');
 
   // ── Reactive display values ─────────────────────────────────────────────────
   let fullSegs = $derived(Math.floor(smoother.value));
@@ -324,6 +362,7 @@
 
     <!-- Dim (inactive) -->
     <rect
+      data-segment={i}
       {x} y={TRACK_Y + 1}
       width={SEG_W} height={TRACK_H - 2}
       fill={dimColor(i)}
@@ -334,13 +373,13 @@
       <rect
         {x} y={TRACK_Y + 1}
         width={SEG_W} height={TRACK_H - 2}
-        fill={ACTIVE_COLORS[i]}
+        fill={activeColor(i)}
       />
     {:else if i === fullSegs && fracSeg > 0.01}
       <rect
         {x} y={TRACK_Y + 1}
         width={Math.max(1, SEG_W * fracSeg)} height={TRACK_H - 2}
-        fill={ACTIVE_COLORS[i]}
+        fill={activeColor(i)}
       />
     {/if}
   {/each}

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.display.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.display.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import type { Capabilities } from '$lib/types/capabilities';
+import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
+import LinearSMeter from '../LinearSMeter.svelte';
+
+// Minimal calibration table with an S9 knot — enough for `getS9Raw()` to
+// resolve to a real anchor (raw 130) and for `rawToSegments` to place it at
+// exactly 11 on the raw 0-20 domain (S9 is the last S-unit knot).
+const CAL = [
+  { raw: 0, actual: -54, label: 'S0' },
+  { raw: 130, actual: 0, label: 'S9' },
+];
+
+function makeCaps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    model: 'test-radio',
+    scope: true,
+    audio: true,
+    tx: true,
+    capabilities: ['scope', 'tx'],
+    receivers: 2,
+    vfoScheme: 'main_sub',
+    freqRanges: [{ start: 1800000, end: 30000000, label: 'HF' }],
+    modes: ['USB', 'LSB', 'CW', 'AM', 'FM'],
+    filters: ['FIL1'],
+    audioConfig: { sampleRate: 48000, channels: 1, codecs: ['opus'] },
+    webrtc: { available: true, enabled: false },
+    txBands: null,
+    stateContractVersion: 1,
+    providerGeneration: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setCapabilities(makeCaps({ meterCalibrations: { s_meter: CAL } }));
+});
+
+let components: ReturnType<typeof mount>[] = [];
+let roots: HTMLElement[] = [];
+
+function mountMeter(props: ComponentProps<typeof LinearSMeter>) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  roots.push(target);
+  const component = mount(LinearSMeter, { target, props });
+  flushSync();
+  components.push(component);
+  return target;
+}
+
+afterEach(() => {
+  components.forEach((component) => unmount(component));
+  roots.forEach((root) => root.remove());
+  components = [];
+  roots = [];
+  clearCapabilities();
+});
+
+function segmentRects(target: HTMLElement): SVGRectElement[] {
+  return Array.from(target.querySelectorAll('[data-segment]')) as SVGRectElement[];
+}
+
+describe('LinearSMeter display prop', () => {
+  it('default mount (no display prop) renders exactly 20 segment rects', () => {
+    const target = mountMeter({ value: 0 });
+    expect(segmentRects(target)).toHaveLength(20);
+  });
+
+  it('display={{ segmentCount: 12, segmentGapPx: 3 }} renders exactly 12 segment rects', () => {
+    const target = mountMeter({ value: 0, display: { segmentCount: 12, segmentGapPx: 3 } });
+    expect(segmentRects(target)).toHaveLength(12);
+  });
+
+  it('honors segmentGapPx: the measured gap between adjacent rects changes by exactly the requested delta', () => {
+    // The gap between rect i's right edge and rect i+1's left edge is
+    // exactly SEG_GAP regardless of SEG_W's own normalization (SEG_W
+    // cancels out of that difference), so this is a direct read of
+    // segmentGapPx off the rendered geometry, not an inferred pitch.
+    function measuredGap(target: HTMLElement): number {
+      const [r0, r1] = segmentRects(target);
+      const x0 = Number(r0.getAttribute('x'));
+      const w0 = Number(r0.getAttribute('width'));
+      const x1 = Number(r1.getAttribute('x'));
+      return x1 - (x0 + w0);
+    }
+
+    const gap1 = measuredGap(mountMeter({ value: 0, display: { segmentCount: 12, segmentGapPx: 1 } }));
+    const gap3 = measuredGap(mountMeter({ value: 0, display: { segmentCount: 12, segmentGapPx: 3 } }));
+
+    expect(gap3 - gap1).toBe(2);
+  });
+
+  it('rescales the S9 crossover from the raw 20-segment domain instead of the literal 11', () => {
+    const target = mountMeter({ value: 0, display: { segmentCount: 12, segmentGapPx: 1 } });
+    const rects = segmentRects(target);
+    // dimColor renders '#1A1008' from the first segment at/above the S9
+    // crossover onward, '#0A2415' before it — read that switch off the DOM.
+    const firstAboveS9 = rects.findIndex((r) => r.getAttribute('fill') === '#1A1008');
+
+    expect(firstAboveS9).toBe(Math.round((11 / 20) * 12));
+    expect(firstAboveS9).not.toBe(11);
+  });
+});

--- a/frontend/src/components-v2/meters/meter-display.ts
+++ b/frontend/src/components-v2/meters/meter-display.ts
@@ -1,0 +1,5 @@
+import type { MeterDisplay } from '../../presentation/languages/contract';
+
+/** LinearSMeter's default segment geometry — 20 segments, 1px gap — matching
+ *  the literal constants it drew from before this prop existed. */
+export const DEFAULT_METER_DISPLAY: MeterDisplay = { segmentCount: 20, segmentGapPx: 1 };

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -51,6 +51,11 @@ export function isValidLanguageId(id: string): boolean {
 /** Required groups: typography, geometry, meters, frequency, motion, focus ring, RX/TX. Density and renderer slots are manifest-level, not tokens. */
 export interface StateFeedbackTokens { readonly idle: string; readonly active: string; readonly tuning: string }
 
+export interface MeterDisplay {
+  readonly segmentCount: number; // integer >= 2
+  readonly segmentGapPx: number; // >= 0
+}
+
 export const REQUIRED_TOKEN_GROUPS = [
   'typography', 'geometry', 'meters', 'frequency', 'motion', 'focusRing', 'rx', 'tx',
 ] as const;


### PR DESCRIPTION
## Summary

- Add `MeterDisplay` (`segmentCount`, `segmentGapPx`) to `frontend/src/presentation/languages/contract.ts`.
- Add `DEFAULT_METER_DISPLAY` (`{ segmentCount: 20, segmentGapPx: 1 }`) in the new `frontend/src/components-v2/meters/meter-display.ts`.
- `LinearSMeter.svelte` now takes an optional `display: MeterDisplay` prop (defaulting to `DEFAULT_METER_DISPLAY`) and derives segment geometry, the S9 crossover index, the active-color ramp sampling, and the peak-decay ballistics from it instead of the literal `SEG_COUNT = 20` / `SEG_GAP = 1` constants. `smeter-scale.ts` is untouched; its 0–20 raw-segment-domain outputs are rescaled onto `display.segmentCount` at the point of use.
- No caller passes the prop yet — this is step B of 3; wiring a caller is a later step.

## Test plan

Local (laptop), targeted per the coordinator's runtime instruction to keep routine/full runs off the laptop:
- `npx eslint src/components-v2/meters src/presentation/languages/contract.ts` — zero output (zero violations).
- `npm run check` (`svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json`) — `COMPLETED 4627 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- `npx vitest run src/components-v2/meters/__tests__/LinearSMeter.display.test.ts` — `Test Files 1 passed (1)`, `Tests 4 passed (4)`.
- `npx vitest run src/components-v2/meters/__tests__/LinearSMeter.test.ts` — `Test Files 1 passed (1)`, `Tests 44 passed (44)` (unchanged, still green).

Remote (Mac mini), full frontend suite: `~/bin/rp-remote-test.sh codex/smeter-display-prop fe` —
- vitest: `Test Files 384 passed (384)`, `Tests 8345 passed (8345)` (includes `meter-contract.test.ts`'s census/conformance suite).
- `npm run lint` (`eslint src/`) — no errors reported.
- `npm run check` — `svelte-check found 0 errors and 0 warnings`.
- `FINAL: PASS`.

### Deliberate-break confirmations (spec 4c/4d), both run locally on the single display-test file per the coordinator's clarification that targeted single-file runs are allowed for this kind of decision:

- **4c (gap discriminator)**: temporarily hard-coded `SEG_GAP` to the literal `1` (ignoring `display.segmentGapPx`), ran `npx vitest run src/components-v2/meters/__tests__/LinearSMeter.display.test.ts` — 1 failed / 3 passed: `honors segmentGapPx: the measured gap between adjacent rects changes by exactly the requested delta` failed with `expected +0 to be 2`. Reverted the file back to the clean commit content before continuing.
- **4d (crossover discriminator)**: temporarily hard-coded `s9SegmentIndex` to the literal `11` (ignoring `SEG_COUNT`), ran the same file — 1 failed / 3 passed: `rescales the S9 crossover from the raw 20-segment domain instead of the literal 11` failed with `expected 11 to be 7`. Reverted the file back to the clean commit content before continuing.

After each break, `git diff` against the clean commit showed no residual change before the next step.

Linear: MOR-2214 (slice 2, step B of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
