### PR TITLE
fix(segmentline): subgrid the peer-split channel strips onto the chassis columns

### DIFF
--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -122,9 +122,10 @@
      which component's <style> the bundler places first — CONFIRMED live
      (`getComputedStyle(surfaces).display === 'grid'`), unlike the clock
      rule below, which needed the same measurement to find it does NOT win
-     this way. Every other override below only ADDS grid-row/grid-column,
-     properties nothing else sets on these elements, so no such doubling is
-     needed there. */
+     this way. Every other override below only adds grid-row/grid-column,
+     properties nothing else sets on these elements — except the
+     `.channel-strips` override further down, which is doubled for a
+     different, same-file reason (see its own comment). */
   .peer-split-glass :global(.semantic-surfaces.semantic-surfaces) {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -180,11 +181,20 @@
      columns. `subgrid` makes the receiver strips occupy THIS grid's column 1
      / column 2 tracks directly, the same tracks `.rx-tx-zone`/`.tx-aux-
      surface` and `.meters-surface`/`.scope-display-surface` already place
-     into above, rather than a separate track list an unrelated content
-     change could throw out of alignment. Doubled class for specificity,
-     same reason as the `.semantic-surfaces.semantic-surfaces` rule above:
-     this overrides a property (`grid-template-columns`) the base rule also
-     sets, so a single-class selector would tie and lose to source order. */
+     into, rather than a separate track list an unrelated content change
+     could throw out of alignment. Doubled class, same technique as the
+     `.semantic-surfaces.semantic-surfaces` rule above, but a different
+     reason: compiled (`svelte.compile(src, { css: 'external' })`), a
+     single-class `.peer-split-glass.s-xxx :global(.channel-strips)`
+     selector here is text-identical to the grid-row/grid-column rule
+     above — both 3 classes (0,3,0), already ahead of the wiring's base
+     rule (2 classes, 0,2,0) with no tie either way. The doubling isn't
+     about winning specificity; it keeps this rule's selector text distinct
+     from the grid-row/grid-column rule's, which this file's own test
+     depends on: `declarationsFor` reads the raw, uncompiled <style> block
+     and returns the FIRST rule matching a given selector string, so a
+     text-identical selector here would make it keep reading the other
+     rule's declarations and never see `grid-template-columns`. */
   .peer-split-glass :global(.channel-strips.channel-strips) {
     grid-template-columns: subgrid;
   }

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -174,6 +174,20 @@
     grid-row: 4;
     grid-column: 1 / -1;
   }
+  /* The wiring's own `.channel-strips` rule (SemanticRadioSurfaces
+     .svelte) sets `grid-template-columns: repeat(auto-fit, minmax(0, 1fr))`
+     — a nested grid computed independently of this chassis's own two
+     columns. `subgrid` makes the receiver strips occupy THIS grid's column 1
+     / column 2 tracks directly, the same tracks `.rx-tx-zone`/`.tx-aux-
+     surface` and `.meters-surface`/`.scope-display-surface` already place
+     into above, rather than a separate track list an unrelated content
+     change could throw out of alignment. Doubled class for specificity,
+     same reason as the `.semantic-surfaces.semantic-surfaces` rule above:
+     this overrides a property (`grid-template-columns`) the base rule also
+     sets, so a single-class selector would tie and lose to source order. */
+  .peer-split-glass :global(.channel-strips.channel-strips) {
+    grid-template-columns: subgrid;
+  }
   .peer-split-glass :global(.meters-surface) {
     grid-row: 5;
     grid-column: 1;

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -359,4 +359,19 @@ describe('the glass bezel keeps its own CSS after the chassis class it used to w
     const grid = declarationsFor('.peer-split-glass :global(.semantic-surfaces.semantic-surfaces)');
     expect(grid['grid-template-rows']).toContain('minmax(72px, 1fr)');
   });
+
+  // The receiver strips must occupy THIS chassis's own two column
+  // tracks (subgrid), not a separately-computed nested grid that only looks
+  // aligned at an even split — MEASURED live (`vite.fixtures.config.ts`,
+  // `peer-split-chassis` fixture): forcing the parent's `grid-template-
+  // columns` to `2fr 1fr` moved both `.channel-strip` elements to the exact
+  // same widths as `.rx-tx-zone`/`.tx-aux-surface` (826.66px / 413.34px);
+  // reverting `.channel-strips`'s own `grid-template-columns` to the
+  // wiring's un-overridden `repeat(auto-fit, minmax(0, 1fr))` kept both
+  // strips at an even 50/50 split regardless, which is exactly the
+  // collapse-back this pin catches.
+  it('subgrids the channel strips onto the chassis columns instead of a separately-computed split', () => {
+    const strips = declarationsFor('.peer-split-glass :global(.channel-strips.channel-strips)');
+    expect(strips['grid-template-columns']).toBe('subgrid');
+  });
 });


### PR DESCRIPTION
Closes #3016

## Phase 1 — rendered, not re-litigated

Rendered `peer-split-chassis` (`vite.fixtures.config.ts` fixture harness,
real browser) and measured the DOM directly.

- The two `.channel-strip` elements (MAIN, SUB) **do** sit side by side —
  the first eliminated candidate from the ticket holds; this confirms it,
  it does not reopen it.
- The chassis grid (`.semantic-surfaces`, 2 columns × 7 rows) splits only
  **rows 1 and 5** into per-column content (`.rx-tx-zone`/`.tx-aux-surface`,
  `.meters-surface`/`.scope-display-surface` — none of which is
  per-receiver; each is a single shared panel per
  `SemanticRadioSurfaces.svelte`'s own header comment). The one row that
  *is* genuinely per-receiver, `.channel-strips`, spans `grid-column: 1 /
  -1` — a single full-width band, exactly as the ticket's own CSS reading
  already established.

So this rendering **confirms** the ticket's resolution rather than
contradicting it: the strips render correctly at the strip level, and the
defect is structural — the receiver row doesn't share the chassis's own
column tracks the way the other two-column rows do.

## Fix

Scoped to `PeerSplitLayout.svelte`'s `<style>` block only — no change to
`SemanticRadioSurfaces.svelte`, composition, or zone handling.
`.channel-strips`'s own `grid-template-columns`
(`repeat(auto-fit, minmax(0, 1fr))`) computes a 2-column split
independently of the chassis grid. `grid-template-columns: subgrid` links
the two receiver strips to the chassis's own column 1 / column 2 tracks —
the same tracks `.rx-tx-zone`/`.tx-aux-surface` and
`.meters-surface`/`.scope-display-surface` already use.

**Why this is invisible at the shipped configuration.** At the shipped
`1fr 1fr` chassis split, before/after pixel positions are identical
(620px each, x=16 / x=644) — a naive visual check reports no change. The
linkage is established by a probe, not by the default render: temporarily
forcing the chassis's `grid-template-columns` to `2fr 1fr` and
re-rendering moved both `.channel-strip` elements to 826.66px / 413.34px,
exactly matching `.rx-tx-zone`/`.tx-aux-surface` at that same split. The
pre-fix `auto-fit` approach cannot do this — its own 1fr/1fr subdivision
is computed independently of the parent and stays an even 50/50 split
regardless of what the parent's columns do. Probe reverted before
finishing; the shipped chassis stays `1fr 1fr`.

## Test

Added one assertion to the existing `declarationsFor`-based describe
block in `PeerSplitLayout.component.test.ts`, asserting the new rule's
declared `grid-template-columns` is `subgrid`.

Ran only this file (`npx vitest run
src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts`):
- Clean: 7 passed, exit 0.
- Mutation (removed the new CSS rule, i.e. the columns collapsing back to
  the ticket's original defect): 1 failed / 6 passed, exit 1 — only the
  new test reddened.
- Restored, diffed byte-identical against a pre-mutation backup, reran:
  7 passed, exit 0.

No wider suite was run (Python suite runs on the dedicated Mac mini only;
full frontend suites are not run on this laptop).

## Environment hazard found along the way

`mcp__Claude_Browser__preview_start` resolves `.claude/launch.json`
against the **main checkout** (`rigplane-core`), not the calling worktree,
regardless of which worktree's `.claude/launch.json` exists. Starting a
named config from a worktree silently launched a dev server rooted in the
shared main checkout. Caught via `preview_list`'s reported `cwd` before it
ran meaningfully; stopped immediately and used a manually-started,
worktree-scoped `vite` process instead (PID tracked, killed at the end).
Worth knowing for the next agent working from a worktree.
