### PR TITLE
test: pin the stale UNCERTAIN settlement control

### DIFF
--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -360,6 +360,7 @@ async def test_uncertain_on_immediately_runs_one_force_off_family(
 async def test_stale_on_settlement_does_not_run_force_off() -> None:
     managed, _, _, _, fence, lane = authority()
     lane.stale_once = True
+    lane.results.append(ActuationResult.UNCERTAIN)
     await managed.ptt_down("owner")
     assert fence.calls == 0 and len(lane.effects) == 1
     await managed.force_off()


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2210/mor-21665c-the-applied-guard-on-on-uncertain-settlement-is-unpinned

## Summary

- make the stale ON settlement control exercise `UNCERTAIN`, the branch guarded by `ManagedTxOutcome.APPLIED`
- retain the existing assertions that no ForceOff fence runs and exactly one provider effect is emitted
- keep production code unchanged

## Scope

One test file, one added line. This PR does not change the managed TX authority or any runtime behavior.

## Search before write

Command run before the edit was finalized:

```text
rg -n "test_stale_on_settlement_does_not_run_force_off|transition\.outcome is ManagedTxOutcome\.APPLIED" tests/test_managed_tx_authority.py src/rigplane/runtime/managed_tx_authority.py
```

It located the single stale control and the production guard that the control must discriminate.

Required legacy-reference census immediately before push:

```text
$ git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py 'src/rigplane/runtime/command*.py' src/rigplane/web/handlers/control.py
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1732:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1982:            decision = evaluate_tx_interlock(
```

There are zero hits in `src/rigplane/core/command_dispatch.py` and `src/rigplane/runtime/command*.py`. The three pre-existing Web-handler hits are outside this test-only scope and remain owned by the planned legacy interlock retirement.

## Mini-only evidence

- final PR head: `a2134535be663fa19c94259ef5a1732de2a7cc22`
- local test/static-analysis execution: none
- isolated mutation ref: `90694106acbee79278d0dfe566548caa4152c5bb`
- mutation workflow: https://github.com/rigplane/rigplane-core/actions/runs/33661653639
- mutation job: https://github.com/rigplane/rigplane-core/actions/runs/33661653639/job/100353380298
- mutation: remove only the `transition.outcome is ManagedTxOutcome.APPLIED` guard from production
- result on `mm-build-core-2` (ARM64): exactly one test collected and failed, `test_stale_on_settlement_does_not_run_force_off`, because `fence.calls` became 1 instead of 0; pytest rc=1
- artifact: `applied-guard-mutation-proof`, artifact ID `9858920043`, records mutation SHA, runner, exact command, failure output, and rc: https://api.github.com/repos/rigplane/rigplane-core/actions/artifacts/9858920043/zip
- workflow conclusion is red as expected for a mutation run; its final recognition clause also expected the summary to start with `1 failed`, while pytest decorates that summary with `=` characters. This harness recognition mismatch does not change the recorded test result above.
- normal PR quick for the exact final head: https://github.com/rigplane/rigplane-core/actions/runs/33662195629 (passed on Mini)
- one normal full-matrix dispatch for the exact final head: https://github.com/rigplane/rigplane-core/actions/runs/33662215171 (all jobs passed: 3.11 and 3.13 on `mm-build-core-1`; 3.12 and capture-harness on `mm-build-core-2`)

## Review directive contract

Independent review must post a normal PR comment whose first non-blank line is exactly `Agent Review: PASS <40-hex head SHA>` or `Agent Review: BLOCKED <40-hex head SHA>`.
