### PR TITLE
test: make the stale-settlement control discriminate the APPLIED guard

### DIFF
--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -360,6 +360,7 @@ async def test_uncertain_on_immediately_runs_one_force_off_family(
 async def test_stale_on_settlement_does_not_run_force_off() -> None:
     managed, _, _, _, fence, lane = authority()
     lane.stale_once = True
+    lane.results.append(ActuationResult.UNCERTAIN)
     await managed.ptt_down("owner")
     assert fence.calls == 0 and len(lane.effects) == 1
     await managed.force_off()


### PR DESCRIPTION
Linear: MOR-2210.

`test_stale_on_settlement_does_not_run_force_off` claimed to pin that a STALE settlement stays inert. It could not discriminate: the PR body of the ticket's own source review cited it as the evidence that "STALE remains inert", and that was the one assertion the suite could not make.

**Test-only.** `git diff --stat 18e2a1e9 HEAD -- src/` is empty; production byte-identical. One file, one line added.

## Why it could not discriminate

The follow-up condition in `ManagedTxAuthority._execute` is a four-way conjunction:

```
transition.outcome is ManagedTxOutcome.APPLIED
and isinstance(event, ActuationSettled)
and event.operation in (PTT_ON, TRANSMIT_ON)
and event.result is ActuationResult.UNCERTAIN
```

The test set `lane.stale_once = True` but left `lane.results` **empty**, so `FakeLane.settle` fell back to `ActuationResult.ACCEPTED`. The `event.result is UNCERTAIN` conjunct was therefore already False, and the row exited by the same path with or without the `APPLIED` guard. Removing the guard changed nothing the test could see.

## The change

```diff
 async def test_stale_on_settlement_does_not_run_force_off() -> None:
     managed, _, _, _, fence, lane = authority()
     lane.stale_once = True
+    lane.results.append(ActuationResult.UNCERTAIN)
     await managed.ptt_down("owner")
     assert fence.calls == 0 and len(lane.effects) == 1
```

With UNCERTAIN queued, the only thing still holding the follow-up back is `transition.outcome is APPLIED` being False for a stale settlement — so dropping the guard must make the follow-up fire and the fence advance.

## Mutation proof, both directions

Mutation: drop `transition.outcome is ManagedTxOutcome.APPLIED` from that condition. Run on throwaway `git archive` copies under /tmp with `PYTHONDONTWRITEBYTECODE=1`.

| production | test | result |
|---|---|---|
| mutated | this PR's fixed test | **1 failed, 37 passed** — `test_stale_on_settlement_does_not_run_force_off`, `fence.calls == 0` failing as `1 == 0` |
| mutated | base `18e2a1e9` unfixed test | **38 passed** — the defect reproduced, not assumed |
| clean | this PR's fixed test | **38 passed** — no other assertion in the test broke from queuing UNCERTAIN |

The second row is the ticket's own falsifier ("the mutation reddening at head before any change — it did not, twice"), and it is the row that makes this PR worth merging rather than plausible.

## Provenance of the remote-testbed run — read this before citing it

The suite run below was executed against commit `a2134535`, **not** against this PR's head `b386e361`. They are different commits with **identical trees**:

```
$ git rev-parse a2134535^{tree} b386e361^{tree}
73f2d5838d089606e3f65496fefa8ce3b9b12b3b
73f2d5838d089606e3f65496fefa8ce3b9b12b3b
```

Same parent (`18e2a1e9`), same one-line diff; the two differ only in commit message. `a2134535` reached `origin/codex/applied-guard-pin` through a push this session cannot attribute to any command it or its builder issued — the local reflog records `update by push` at 17:30:14Z, exactly one ref moved, and the builder's own history scan turns up no push. Rather than force-push over an artifact of unknown origin, this PR comes from a fresh branch and leaves `codex/applied-guard-pin` at `a2134535` untouched for inspection.

So: the testbed result is valid **for the code**, because the tree is byte-identical, and it is recorded against a SHA that is not this PR's head. Stated here rather than left for someone to discover.

```
14283 passed, 163 skipped, 16 xfailed
ruff check: All checks passed!
FINAL: PASS
```

Focused `tests/test_managed_tx_authority.py`: 38 passed, matching the baseline recorded on `18e2a1e9` before any edit. CI at this PR's head is the artifact recorded against `b386e361`; its run URL goes in the review directive.

## Not in this PR

The MOR-2211 sweep survivor `test_provider_arrival_wins_retry_tie_without_duplicate_effect` is a separate defect and gets its own ticket: `FakeLane.settle` with no configured gate never yields to the event loop, so `provider_available` runs to completion before `_process_due` is scheduled and the intended race is never contested. That is a defect in what the test *exercises*, not in what it asserts, and strengthening assertions would not fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
