### PR TITLE
fix(web): keep passive VFO startup non-mutating

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1676,12 +1676,7 @@ class RadioPoller:
         known before it will enable the button that would send the very
         first command. Nothing breaks that cycle without an explicit seed.
 
-        PURE LOCAL SEED — never sends anything to the radio. Unlike
-        :meth:`establish_vfo_identity` (its sibling call site in
-        :meth:`_run`'s startup section and in the server's reconnect path),
-        which commands VFO A over the wire and therefore pauses while an
-        external CAT session owns it, this seed touches only the local
-        StateStore and needs no such guard.
+        PURE LOCAL SEED — never sends anything to the radio.
 
         "Not scanning until we command it" is an ASSUMED-UNTIL-COMMANDED
         fact — the same accepted-dishonesty class as this PR's documented
@@ -1849,17 +1844,6 @@ class RadioPoller:
             await self._fetch_mod_inputs()
         except Exception:
             logger.debug("radio-poller: MOD-input initial fetch failed", exc_info=True)
-
-        # MOR-1443: some CI-V radios can never passively report which VFO
-        # slot (A/B) is active; command VFO A once so identity is known.
-        try:
-            await self.establish_vfo_identity()
-        except Exception:
-            # A ruled behaviour (owner decision, MOR-1443) silently not
-            # happening is worth surfacing above debug (review R2).
-            logger.warning(
-                "radio-poller: auto VFO identity establish failed", exc_info=True
-            )
 
         # MOR-1495 review R2: scan (CI-V 0x0E) is SET-ONLY, so nothing else
         # ever seeds scanning/scan_resume_mode — without this, the web UI's
@@ -2234,21 +2218,16 @@ class RadioPoller:
         source: CommandSource = "websocket",
         session_id: str | None = None,
         command_service: CommandService | None = None,
-        connection_epoch_bootstrap: bool = False,
     ) -> None:
         if isinstance(cmd, CommandIntent):
             await execute_command_intent(self._radio, cmd)
             return
         # MOR-1884 (MOR-1626 criterion 7): the enforcement seat guards EVERY
         # write this poller issues — queued commands and uncommanded internal
-        # emits alike. The single exemption is the connection-epoch bootstrap
-        # ``SelectVfo`` in :meth:`establish_vfo_identity`: at connection start
-        # RF is structurally UNKNOWN, and that one ruled write (MOR-1443) is
-        # what makes RF/VFO truth observable at all. Emergency commands need
-        # no exemption — ``_enforce_tx_interlock`` is structurally incapable
-        # of blocking them before any table is consulted.
-        if not connection_epoch_bootstrap:
-            self._enforce_tx_interlock(cmd)
+        # emits alike. Emergency commands need no exemption —
+        # ``_enforce_tx_interlock`` is structurally incapable of blocking them
+        # before any table is consulted.
+        self._enforce_tx_interlock(cmd)
         radio = self._radio
         provider_generation = self._provider_generation()
         _r: Any = radio  # cast for capability methods not on base Radio protocol
@@ -3979,78 +3958,6 @@ class RadioPoller:
     def _relative_vfo_fields() -> tuple[str, ...]:
         return ("freq_hz", "mode", "filter_num", "data_mode")
 
-    async def establish_vfo_identity(self) -> None:
-        """Command VFO A once, but only when the radio cannot ever report
-        which slot (A/B) is active on its own (MOR-1443).
-
-        Discriminator: ``vfo_readback == "selected_unselected"`` is
-        profile/capability data (``rigs/<model>.toml``), not a hardcoded
-        model check. It already means "this CI-V radio can read the
-        selected/unselected VFO's frequency+mode, but never which physical
-        slot is selected" — issue #2303 forbids learning that passively
-        (a swap-based probe would itself mutate the radio), so absent a
-        commanded write, ``activeSlot`` stays unknown forever and the UI is
-        stuck behind the manual "Select VFO A/B" fallback.
-
-        Ruled exception to the no-uncommanded-writes doctrine (owner
-        decision, MOR-1443, session 19): the owner explicitly accepted the
-        radio-visible side effect — a radio left on VFO B at app start gets
-        switched to A once. Radios that CAN report identity on their own
-        (absolute CI-V VFO readback, Yaesu CAT ``get_vfo_select``, the
-        rigctld client) declare a different ``vfo_readback`` value (or use a
-        backend that never touches this poller at all) and never reach this
-        branch — they keep reading, never writing.
-
-        Called once per connect from the one-time startup section of
-        :meth:`_run`, and again from the web server's reconnect path
-        (``WebServer._on_radio_reconnect`` → its ``_refetch_and_reenable``
-        closure, right after the poller readiness gate is re-set) so that a
-        soft-reconnect re-establishes identity too, instead of staying
-        unknown until process restart (MOR-1443 review R2, finding 1).
-        ``reset_vfo_session()`` always runs first on that path and
-        unconditionally discards ``active_slot`` — no reconnect path
-        retains it. The already-observed gate below therefore is not about
-        surviving a reconnect: between ``reset_vfo_session()`` clearing
-        identity and this coroutine's own read of the state store, the
-        poll loop is still running and may drain an operator-initiated
-        ``SelectVfo`` in that window, legitimately observing identity again
-        first — the gate exists to avoid a redundant second commanded
-        write over that observation (and to guard any future retention
-        path). Also paused, like the rest of this poller's writes, while an
-        external CAT session owns the wire (MOR-166 slice 2) — a commanded
-        VFO A here would collide with the owner's byte stream.
-
-        Goes through the normal :class:`SelectVfo` command path so the
-        existing confirmed-select readback is what marks identity observed,
-        exactly like an operator-issued "Select VFO A/B" would.
-        """
-
-        # External CAT session (e.g. Hamlib A1 bridge) owns the wire — this
-        # write must not escape that pause any more than the poll loop's own
-        # writes do (MOR-1443 review R2, finding 2). ``is True`` (not just
-        # truthy), matching the poll loop's own guard, so duck-typed / mock
-        # radios never quiesce by accident — only a real bool flag does.
-        if getattr(self._radio, "external_cat_session_active", False) is True:
-            return
-        if self._profile.vfo_readback != "selected_unselected":
-            return
-        receiver = 1 if self._current_active().upper() == "SUB" else 0
-        try:
-            self._state_store.snapshot().field(FieldPath.active_slot(str(receiver)))
-        except KeyError:
-            pass
-        else:
-            return  # identity already observed — nothing to establish
-        logger.info(
-            "radio-poller: active-VFO identity unqueryable and unobserved; "
-            "auto-commanding VFO A once (MOR-1443, receiver=%d)",
-            receiver,
-        )
-        # MOR-1884: the ONE exempted write. RF is structurally UNKNOWN at
-        # connection start, and this ruled bootstrap (MOR-1443) is what makes
-        # identity observable — the seat would otherwise fail it closed forever.
-        await self._execute(SelectVfo(vfo="A"), connection_epoch_bootstrap=True)
-
     def _vfo_identity_paths(self, receiver: int) -> tuple[FieldPath, ...]:
         receiver_id = str(receiver)
         paths: list[FieldPath] = [FieldPath.active_slot(receiver_id)]
@@ -4093,10 +4000,7 @@ class RadioPoller:
         self._state_store.discard(self._vfo_identity_paths(receiver))
 
     def _tx_target_receiver(self) -> tuple[int, TxReceiver]:
-        """Resolve the receiver index + MAIN/SUB label carrying TX.
-
-        Mirrors :meth:`establish_vfo_identity`'s own resolution (MOR-1443).
-        """
+        """Resolve the receiver index + MAIN/SUB label carrying TX."""
         receiver = 1 if self._current_active().upper() == "SUB" else 0
         label: TxReceiver = "SUB" if receiver == 1 else "MAIN"
         return receiver, label
@@ -4124,9 +4028,7 @@ class RadioPoller:
         ``backends/yaesu_cat/observations.py``), Icom CI-V never reports a TX
         target directly. The facts that determine it are already tracked
         independently in the state store: active-VFO identity
-        (``receiver.<rx>.vfo.active_slot``, established once per connect by
-        :meth:`establish_vfo_identity`, MOR-1443, since this CI-V scheme can
-        never passively report which slot is active), split
+        (``receiver.<rx>.vfo.active_slot``), split
         (``global.tx_state.split``, cmd 0x0F), and the selected/unselected
         frequencies (``receiver.<rx>.[active|unselected].freq_mode.freq_hz``,
         cmd 0x25).
@@ -4139,10 +4041,10 @@ class RadioPoller:
         only ever as good as its weakest input.
 
         Only radios that can never passively report VFO identity
-        (``vfo_readback == "selected_unselected"``, the exact gate
-        :meth:`establish_vfo_identity` uses) get a derivation; other CI-V VFO
-        schemes (absolute readback, MAIN/SUB-only radios like IC-9700/IC-7610)
-        stay ``unsupported`` rather than guess at unvalidated split semantics.
+        (``vfo_readback == "selected_unselected"``) get a derivation; other
+        CI-V VFO schemes (absolute readback, MAIN/SUB-only radios like
+        IC-9700/IC-7610) stay ``unsupported`` rather than guess at unvalidated
+        split semantics.
         """
         if self._profile.vfo_readback != "selected_unselected":
             return UnknownTxTarget(reason="unsupported")

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -2390,41 +2390,16 @@ class WebServer:
                 # attached poller-like object (MOR-1187/1196 invariant —
                 # ``_refetch_and_reenable`` is the only thing in ``src/``
                 # that ever re-sets it; ``test_web_recovery_durable_off``
-                # pins this with a non-RadioPoller stub). Only the identity
-                # establish below is narrowed to real ``RadioPoller``s
-                # (MOR-1443 review R3, N2: keeps MagicMock doubles from
-                # raising a spurious warning inside the try/except).
+                # pins this with a non-RadioPoller stub).
                 if self._radio_poller is not None:
                     self._radio_poller._initial_fetch_done.set()
                 if isinstance(self._radio_poller, RadioPoller):
-                    # MOR-1443 review R2, finding 1: reset_vfo_session() above
-                    # discarded active_slot for this new connection epoch, and
-                    # unlike the process-startup call site, RadioPoller._run()
-                    # never re-fires after a soft-reconnect (it only runs its
-                    # one-time startup section once). Without this call,
-                    # identity stays unknown until the process restarts even
-                    # though the readback is unqueryable again. The gate reads
-                    # unobserved here (reset just cleared it), so this emits
-                    # the same confirmed VFO-A select the startup path does.
-                    try:
-                        await self._radio_poller.establish_vfo_identity()
-                    except Exception:
-                        logger.warning(
-                            "reconnect: auto VFO identity establish failed",
-                            exc_info=True,
-                        )
                     # MOR-1495 review R2: RadioPoller._run()'s one-time
-                    # startup section (same reasoning as
-                    # establish_vfo_identity above) never re-fires after a
-                    # soft-reconnect either, so re-seed scanning/
-                    # scan_resume_mode here too — otherwise a reconnect after
-                    # any scan command would leave the web trusting a
-                    # possibly-stale pre-reconnect value forever. Pure local
-                    # seed, unlike the VFO-identity call above — never writes
-                    # to the radio, so it needs no external-CAT-session guard
-                    # and cannot itself fail against the wire; the try/except
-                    # here only guards the StateStore call for consistency
-                    # with its sibling.
+                    # startup section never re-fires after a soft-reconnect,
+                    # so re-seed scanning/scan_resume_mode here too — otherwise
+                    # a reconnect after any scan command would leave the web
+                    # trusting a possibly-stale pre-reconnect value forever.
+                    # This is a pure local seed and never writes to the radio.
                     try:
                         self._radio_poller._seed_scan_facts_at_connect()
                     except Exception:

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
-from rigplane.commands._frame import decode_wire_tuple
+from rigplane.commands._frame import build_civ_frame, decode_wire_tuple
 from rigplane.commands.command_map import CommandMap
 from rigplane.commands.commander import IcomCommander, Priority
 from rigplane.core.capabilities import CAP_AGC, CAP_SCOPE
@@ -5556,7 +5556,7 @@ async def test_a_lost_operator_unkey_keeps_the_backstop_armed() -> None:
 
 
 # ---------------------------------------------------------------------------
-# MOR-1443: auto-command VFO A once when active-VFO identity is unqueryable.
+# Passive startup must not select or exchange a VFO.
 # ---------------------------------------------------------------------------
 
 
@@ -5574,152 +5574,92 @@ async def _run_once(poller: RadioPoller) -> None:
         await poller._run()  # noqa: SLF001
 
 
-@pytest.mark.asyncio
-async def test_run_auto_commands_vfo_a_when_identity_unqueryable() -> None:
-    """IC-7300 (``vfo_readback == "selected_unselected"``) cannot passively
-    report which slot (A/B) is active (issue #2303 forbids probing via
-    swap). MOR-1443: on connect, with activeSlot still unobserved, the
-    poller must command VFO A exactly once through the normal confirmed
-    select path so identity becomes known."""
+@dataclasses.dataclass
+class _GuardedVfoWireLedger:
+    radio_address: int
+    attempted_guard_blocked: list[bytes] = dataclasses.field(default_factory=list)
+    actual_admitted: list[bytes] = dataclasses.field(default_factory=list)
 
-    radio = _make_radio(model="IC-7300")
-    store = StateStore()
-    store.begin_provider_generation()
-    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+    _SELECTORS = (0x00, 0x01, 0xB0)
 
-    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
-
-    await _run_once(poller)
-
-    radio._set_vfo_slot_confirmed.assert_awaited_once_with("A", receiver=0)
-    assert store.snapshot().field("receiver.0.vfo.active_slot").value == "A"
-
-
-@pytest.mark.asyncio
-async def test_run_does_not_auto_command_vfo_when_identity_queryable() -> None:
-    """A profile that CAN report active-VFO identity (any ``vfo_readback``
-    other than ``selected_unselected`` — e.g. absolute CI-V readback, or a
-    Yaesu CAT / rigctld backend that reads it directly) must never have the
-    poller emit an uncommanded VFO write; it should keep reading."""
-
-    radio = _make_radio(model="IC-7610")  # vfo_readback defaults to "none"
-    assert radio.profile.vfo_readback != "selected_unselected"
-    store = StateStore()
-    store.begin_provider_generation()
-    poller = RadioPoller(radio, CommandQueue(), state_store=store)
-
-    await _run_once(poller)
-
-    radio._set_vfo_slot_confirmed.assert_not_awaited()
-    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
-
-
-@pytest.mark.asyncio
-async def test_run_skips_auto_vfo_command_when_identity_already_observed() -> None:
-    """activeSlot is already known when the establish check runs — no
-    reconnect path retains it across a drop, ``reset_vfo_session()``
-    unconditionally discards it (MOR-1443 review R2, finding 3). This
-    models the window it legitimately reappears in: an operator-issued
-    "Select VFO A/B" drained by the still-running poll loop between
-    ``reset_vfo_session()`` and the reconnect-path establish call can
-    observe identity again first. The poller must not re-command VFO A
-    over that observation — no write when identity is already
-    established."""
-
-    radio = _make_radio(model="IC-7300")
-    store = StateStore()
-    generation = store.begin_provider_generation()
-    store.apply(
-        Observation(
-            path=FieldPath.active_slot("0"),
-            value="B",
-            source=SourceMetadata(
-                source="command_response",
-                provider="vfo_binding",
-                native_id="explicit_slot_ack_readback",
-            ),
-            timestamp_monotonic=time.monotonic(),
-            provider_generation=generation,
+    async def send(self, selector: int) -> None:
+        frame = build_civ_frame(
+            self.radio_address,
+            0xE0,
+            0x07,
+            data=bytes([selector]),
         )
-    )
-    poller = RadioPoller(radio, CommandQueue(), state_store=store)
+        self.attempted_guard_blocked.append(frame)
+        if selector in self._SELECTORS:
+            raise CommandError(f"fake transport blocked VFO mutation {frame.hex()}")
+        self.actual_admitted.append(frame)
 
-    await _run_once(poller)
+    def mutation_counts(self) -> dict[str, dict[str, int]]:
+        def _counts(frames: list[bytes]) -> dict[str, int]:
+            return {
+                f"07 {selector:02X}": sum(
+                    frame[4:6] == bytes((0x07, selector)) for frame in frames
+                )
+                for selector in self._SELECTORS
+            }
 
-    radio._set_vfo_slot_confirmed.assert_not_awaited()
-    assert store.snapshot().field("receiver.0.vfo.active_slot").value == "B"
+        return {
+            "attempted_guard_blocked": _counts(self.attempted_guard_blocked),
+            "actual_admitted": _counts(self.actual_admitted),
+        }
 
 
-@pytest.mark.asyncio
-async def test_establish_vfo_identity_refires_after_reconnect_reset() -> None:
-    """MOR-1443 review R2, finding 1: ``RadioPoller._run()`` only fires its
-    one-time startup section once, so after a soft-reconnect discards
-    ``active_slot`` via ``reset_vfo_session()`` identity would otherwise
-    stay unknown until process restart. ``WebServer._on_radio_reconnect()``
-    /``_refetch_and_reenable()`` (server.py) now call the public
-    ``establish_vfo_identity()`` itself, in the ``finally`` right after
-    re-setting the poller readiness gate. This test reproduces that exact
-    sequence directly against ``RadioPoller`` — run startup once, reset
-    the VFO session, clear+set ``_initial_fetch_done`` the way the server
-    does, then invoke the reconnect-path establish call — and asserts a
-    second confirmed ``SelectVfo("A")`` emits, with ``active_slot``
-    observed again afterward."""
+def _instrument_guarded_vfo_wire(radio: MagicMock) -> _GuardedVfoWireLedger:
+    ledger = _GuardedVfoWireLedger(radio.profile.civ_addr)
 
-    radio = _make_radio(model="IC-7300")
-    store = StateStore()
-    store.begin_provider_generation()
-    poller = RadioPoller(radio, CommandQueue(), state_store=store)
-
-    await _run_once(poller)
-    radio._set_vfo_slot_confirmed.assert_awaited_once_with("A", receiver=0)
-    assert store.snapshot().field("receiver.0.vfo.active_slot").value == "A"
-
-    # Reconnect sequence: reset_vfo_session() discards the connection-epoch
-    # identity fact, then the server clears and re-sets the poller
-    # readiness gate around the refetch — mirroring
-    # WebServer._on_radio_reconnect() / _refetch_and_reenable() exactly.
-    poller.reset_vfo_session()
-    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
-    poller._initial_fetch_done.clear()  # noqa: SLF001
-    poller._initial_fetch_done.set()  # noqa: SLF001
-
-    # The first establish call already drained the fixture's two-value
-    # ``read_relative_vfo`` side_effect (selected + unselected); the
-    # reconnect-path establish drives another confirmed select-and-bind
-    # round, which reads both again.
-    radio.read_relative_vfo = AsyncMock(
-        side_effect=(
-            RelativeVfoState(14_200_000, "USB", 1, 0),
-            RelativeVfoState(7_100_000, "LSB", 2, 0),
+    async def _select(slot: str, *, receiver: int = 0) -> None:
+        _ = receiver
+        selector = (
+            radio.profile.vfo_main_code
+            if slot.upper() == "A"
+            else radio.profile.vfo_sub_code
         )
-    )
+        assert selector is not None
+        await ledger.send(selector)
 
-    await poller.establish_vfo_identity()
+    async def _swap(receiver: int = 0) -> None:
+        _ = receiver
+        selector = radio.profile.swap_ab_code
+        assert selector is not None
+        await ledger.send(selector)
 
-    assert radio._set_vfo_slot_confirmed.await_args_list == [
-        call("A", receiver=0),
-        call("A", receiver=0),
-    ]
-    assert store.snapshot().field("receiver.0.vfo.active_slot").value == "A"
+    async def _send_civ(
+        command: int,
+        sub: int | None = None,
+        data: bytes | None = None,
+        *,
+        wait_response: bool = False,
+    ) -> None:
+        _ = (sub, wait_response)
+        if command == 0x07 and data and data[0] in ledger._SELECTORS:
+            await ledger.send(data[0])
+
+    radio._set_vfo_slot_confirmed = AsyncMock(side_effect=_select)
+    radio.set_vfo_slot = AsyncMock(side_effect=_select)
+    radio.swap_vfo_ab = AsyncMock(side_effect=_swap)
+    radio.send_civ = AsyncMock(side_effect=_send_civ)
+    return ledger
 
 
 @pytest.mark.asyncio
-async def test_establish_vfo_identity_skips_during_external_cat_session() -> None:
-    """MOR-1443 review R2, finding 2: the poll loop's external-CAT
-    ownership pause (:1256, ``is True`` on ``external_cat_session_active``)
-    must also gate the establish-once write, or this PR's write escapes
-    it. An external CAT session (e.g. Hamlib A1 bridge) owns the wire, so
-    the auto-commanded VFO A must not fire while it is active."""
-
+async def test_passive_startup_attempts_no_vfo_select_or_swap() -> None:
     radio = _make_radio(model="IC-7300")
-    radio.external_cat_session_active = True
+    ledger = _instrument_guarded_vfo_wire(radio)
     store = StateStore()
     store.begin_provider_generation()
     poller = RadioPoller(radio, CommandQueue(), state_store=store)
 
-    await poller.establish_vfo_identity()
+    await _run_once(poller)
 
-    radio._set_vfo_slot_confirmed.assert_not_awaited()
+    assert ledger.mutation_counts() == {
+        "attempted_guard_blocked": {"07 00": 0, "07 01": 0, "07 B0": 0},
+        "actual_admitted": {"07 00": 0, "07 01": 0, "07 B0": 0},
+    }
     assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
 
 
@@ -6333,15 +6273,11 @@ async def test_scan_command_echo_is_not_labelled_a_poll_readback() -> None:
 # scan command, because nothing can enable the button that sends it.
 #
 # Fix: seed ``scanning=False`` and ``scan_resume_mode=<assumed default>``
-# ONCE at connect (poller startup) and again on soft-reconnect — the same
-# call-site pattern ``establish_vfo_identity`` already uses for the
-# analogous "some radios can never learn X passively" problem (MOR-1443).
-# This is a PURE LOCAL SEED: it never sends anything to the radio, so
-# (unlike ``establish_vfo_identity``, which writes VFO A over the wire) it
-# needs no external-CAT-session guard. "Not scanning until we command it"
-# is an ASSUMED-UNTIL-COMMANDED fact, the same accepted-dishonesty class as
-# the front-panel-scan-stop-is-invisible limitation this PR already
-# documents.
+# ONCE at connect (poller startup) and again on soft-reconnect. This is a
+# PURE LOCAL SEED: it never sends anything to the radio and needs no
+# external-CAT-session guard. "Not scanning until we command it" is an
+# ASSUMED-UNTIL-COMMANDED fact, the same accepted-dishonesty class as the
+# front-panel-scan-stop-is-invisible limitation this PR already documents.
 #
 # ``scan_type`` is deliberately NOT seeded — an assumed type would let an
 # unconfirmed guess masquerade as an observed radio fact, which is exactly
@@ -6386,9 +6322,7 @@ async def test_scan_facts_seeded_at_connect_break_the_bootstrap_deadlock() -> No
 
 @pytest.mark.asyncio
 async def test_scan_facts_seed_is_a_pure_local_seed_no_radio_write() -> None:
-    """The seed must never touch the wire — only ``establish_vfo_identity``
-    (which this call site sits beside) is a commanded radio write; this is
-    the opposite case by design (MOR-1495 review R2 point 5)."""
+    """The scan-facts seed must never touch the radio wire."""
     radio = _make_radio(active="MAIN", model="IC-7300")
     store = StateStore()
     poller = RadioPoller(

--- a/tests/test_radio_poller_tx_interlock.py
+++ b/tests/test_radio_poller_tx_interlock.py
@@ -454,25 +454,21 @@ async def test_direct_defer_family_emit_is_refused_at_the_execute_seat(
     radio.set_split.assert_not_awaited()
 
 
-async def test_vfo_selection_is_not_observed_rf_gated_at_bootstrap() -> None:
-    for connection_epoch_bootstrap in (False, True):
-        poller, _radio, _store = _poller()
-        with pytest.raises(CommandError) as dispatched:
-            await poller._execute(  # noqa: SLF001
-                SelectVfo(vfo="A"),
-                connection_epoch_bootstrap=connection_epoch_bootstrap,
-            )
-        assert "RF state" not in str(dispatched.value)
-        assert "VFO selection" in str(dispatched.value)
+async def test_vfo_selection_is_not_observed_rf_gated() -> None:
+    poller, _radio, _store = _poller()
+    with pytest.raises(CommandError) as dispatched:
+        await poller._execute(SelectVfo(vfo="A"))  # noqa: SLF001
+    assert "RF state" not in str(dispatched.value)
+    assert "VFO selection" in str(dispatched.value)
 
 
-def test_bootstrap_exemption_has_exactly_one_production_call_site() -> None:
+def test_connection_epoch_bootstrap_exemption_is_absent_from_production() -> None:
     from pathlib import Path
 
     import rigplane.web.radio_poller as radio_poller_module
 
     source = Path(radio_poller_module.__file__).read_text()
-    assert source.count("connection_epoch_bootstrap=True") == 1
+    assert "connection_epoch_bootstrap" not in source
 
 
 async def test_teardown_drain_unkey_stays_outside_the_execute_seat() -> None:

--- a/tests/test_web_server_coverage.py
+++ b/tests/test_web_server_coverage.py
@@ -38,6 +38,10 @@ from rigplane.web import server as server_module
 from rigplane.web.handlers.control import ControlHandler
 from rigplane.web.radio_poller import CommandQueue, EnableScope, RadioPoller
 from rigplane.web.server import WebConfig, WebServer, _send_response, run_web_server
+from test_radio_poller_coverage import (
+    _instrument_guarded_vfo_wire,
+    _make_radio,
+)
 
 
 class _FakeSocket:
@@ -2846,56 +2850,41 @@ async def test_on_radio_reconnect_enables_scope_without_waiting_for_broadcast() 
 
 
 @pytest.mark.asyncio
-async def test_on_radio_reconnect_establishes_vfo_identity_after_readiness_gate() -> (
-    None
-):
-    """MOR-1443 review R3, finding F4: the F1 server-side fix — calling
-    ``RadioPoller.establish_vfo_identity()`` from
-    ``_refetch_and_reenable()``'s ``finally`` block — had zero test
-    coverage. Every other reconnect test above leaves ``srv._radio_poller``
-    as ``None``, so deleting the fix's ``server.py`` lines left the whole
-    suite green. Wire a real ``RadioPoller`` (IC-7300 profile, so
-    ``vfo_readback == "selected_unselected"``) onto the server, replace its
-    ``establish_vfo_identity`` with an ``AsyncMock`` that captures whether
-    the poller readiness gate was already re-set at call time, fire the
-    reconnect hook, and assert the establish call happened — and happened
-    after ``_initial_fetch_done.set()``, not before.
-    """
-    radio = _scope_radio(ready=False)
+async def test_passive_reconnect_attempts_no_vfo_select_or_swap() -> None:
+    radio = _make_radio(model="IC-7300")
+    radio.radio_ready = False
     radio._fetch_initial_state = AsyncMock()
-    radio.profile = resolve_radio_profile(model="IC-7300")
-    radio.model = radio.profile.model
+    ledger = _instrument_guarded_vfo_wire(radio)
     srv = WebServer(radio)
 
-    poller = RadioPoller(radio, CommandQueue(), state_store=StateStore())
-    gate_set_at_call_time: bool | None = None
-
-    async def _fake_establish() -> None:
-        nonlocal gate_set_at_call_time
-        gate_set_at_call_time = poller._initial_fetch_done.is_set()  # noqa: SLF001
-
-    poller.establish_vfo_identity = AsyncMock(  # type: ignore[method-assign]
-        side_effect=_fake_establish
+    store = StateStore()
+    generation = store.begin_provider_generation()
+    store.apply(
+        Observation(
+            path=FieldPath.active_slot("0"),
+            value="B",
+            source=SourceMetadata(source="command_response", provider="test"),
+            timestamp_monotonic=time.monotonic(),
+            provider_generation=generation,
+        )
     )
+    poller = RadioPoller(radio, CommandQueue(), state_store=store)
     srv._radio_poller = poller  # noqa: SLF001
 
     srv._on_radio_reconnect()  # noqa: SLF001
     await asyncio.sleep(0.05)  # let the refetch task complete
 
-    poller.establish_vfo_identity.assert_awaited_once()  # type: ignore[attr-defined]
-    assert gate_set_at_call_time is True
+    assert poller._initial_fetch_done.is_set()  # noqa: SLF001
+    assert ledger.mutation_counts() == {
+        "attempted_guard_blocked": {"07 00": 0, "07 01": 0, "07 B0": 0},
+        "actual_admitted": {"07 00": 0, "07 01": 0, "07 B0": 0},
+    }
+    assert "receiver.0.vfo.active_slot" not in store.snapshot().as_dict()
 
 
 @pytest.mark.asyncio
 async def test_on_radio_reconnect_reseeds_scan_facts() -> None:
-    """MOR-1495 review R2: the scan-facts seed must re-run on every
-    soft-reconnect too, sitting right beside ``establish_vfo_identity`` in
-    the same ``finally`` block. ``RadioPoller._run()``'s one-time startup
-    section never fires again after a soft-reconnect (same reasoning as the
-    VFO-identity call above), so without this the scan controls would only
-    ever unlock once, at process start, and a reconnect would leave the web
-    trusting whatever pre-reconnect value happened to survive forever.
-    """
+    """The scan-facts seed must re-run on every soft-reconnect."""
     radio = _scope_radio(ready=False)
     radio._fetch_initial_state = AsyncMock()
     radio.profile = resolve_radio_profile(model="IC-7300")
@@ -2904,7 +2893,6 @@ async def test_on_radio_reconnect_reseeds_scan_facts() -> None:
 
     store = StateStore()
     poller = RadioPoller(radio, CommandQueue(), state_store=store)
-    poller.establish_vfo_identity = AsyncMock()  # type: ignore[method-assign]
     seed_call_count = 0
     real_seed = poller._seed_scan_facts_at_connect  # noqa: SLF001
 


### PR DESCRIPTION
Linear: MOR-2225

## Behavior and compatibility

Passive IC-7300 Web startup and soft reconnect no longer request an automatic VFO-A selection. A/B identity remains unobserved after startup or reconnect until an operator uses the existing explicit typed `SelectVfo` path and the provider confirms it. Relative selected/unselected reads, reconnect identity reset, explicit A/B selection, ACK/error handling, and identity binding remain unchanged.

This is an intentional compatibility change only for the passive startup/reconnect side effect. It does not change the public API, CLI, configuration schema, or the explicit CI-V A/B/swap byte mappings.

## Mutation ledger evidence

Base `9b496d8fb1338eeeb74c04fb482a0205bf69bb60`, production unmodified with the new fake-transport guard tests:

- Startup RED: attempted/guard-blocked `07 00=1`, `07 01=0`, `07 B0=0`; actual/admitted `07 00=0`, `07 01=0`, `07 B0=0`.
- Reconnect RED: attempted/guard-blocked `07 00=1`, `07 01=0`, `07 B0=0`; actual/admitted `07 00=0`, `07 01=0`, `07 B0=0`.
- The failing traces resolve the attempted frame to `FEFE94E00700FD`; both guards raised before admission.

Head `c8832b2ced3c63371a2d2b4bed7cff409f512104`:

- Startup GREEN: attempted/guard-blocked `07 00=0`, `07 01=0`, `07 B0=0`; actual/admitted `07 00=0`, `07 01=0`, `07 B0=0`.
- Reconnect GREEN: attempted/guard-blocked `07 00=0`, `07 01=0`, `07 B0=0`; actual/admitted `07 00=0`, `07 01=0`, `07 B0=0`.
- Both identities remained unobserved.

## Focused verification

Run locally in this isolated worktree; no service or hardware was started:

- `uv run pytest tests/test_radio_poller_coverage.py::test_passive_startup_attempts_no_vfo_select_or_swap tests/test_web_server_coverage.py::test_passive_reconnect_attempts_no_vfo_select_or_swap -q --tb=short` — 2 passed.
- Focused explicit selection nodes covering B, B to A, stale generation success/error, NAK, timeout, cancellation, and readback failure — 8 passed.
- Focused interlock nodes covering the ordinary execute seat, VFO classification, and absence of the connection-epoch exemption — 4 passed.
- Focused scan seed startup/reconnect nodes — 3 passed.
- `uv run ruff check` scoped to the five changed files — passed.
- `uv run ruff format --check` scoped to the five changed files — 5 files already formatted.
- `uv run mypy --strict src/rigplane/web` — success, 26 source files.

The task explicitly limited local pytest to focused nodes, so the full suite was not run locally. Normal PR CI remains required.

## Hardware context

Owner-provided bench evidence used checkout `573c773acb3bafba226bba0b255b6a23fae99daf` and IC-7300 profile SHA-256 `746d6a951800e103b9e7e2420cec1032c5deb309c71926a8816e4f47429c1a4c`. Its guard recorded candidate `FEFE94E00700FD` and raised before the original `SerialCivLink.send`; actual transmission count was zero and the radio was not mutated.

## Explicit exclusions

- No IC-7300 model-name special case or profile change.
- No fabricated A/B identity, MAIN/SUB alias, frequency/mode replay, or unrelated polling refactor.
- No weakening or removal of the runtime interlock; the dead connection-bootstrap exemption is removed.
- No hardware access, service start, API-timeout investigation, merge, or issue closure.
