### PR TITLE
test: contest the provider-arrival retry tie

### DIFF
--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -596,11 +596,26 @@ async def test_provider_arrival_wins_retry_tie_without_duplicate_effect() -> Non
     await managed.force_off()
     managed._retry_due = clock.now
 
-    await asyncio.gather(managed.provider_available(8), managed._process_due())
+    release_gate = lane.block_next()
+    arrival = asyncio.create_task(managed.provider_available(8))
+    try:
+        pending = await asyncio.wait_for(lane.started.get(), 0.2)
+        due = asyncio.create_task(managed._process_due())
+        await asyncio.wait_for(due, 0.2)
+        retry_due_while_pending = managed._retry_due
+    finally:
+        release_gate.set()
+        await arrival
 
     assert len(lane.effects) == 1
-    assert lane.effects[0].operation is ActuationOperation.FORCE_RECEIVE
-    assert lane.effects[0].token.provider_generation == 8
+    assert lane.effects[0] == pending
+    assert pending.operation is ActuationOperation.FORCE_RECEIVE
+    assert pending.token.provider_generation == 8
+    assert retry_due_while_pending is None
+    settled = await managed.snapshot()
+    assert not settled.state.release_required
+    assert settled.state.pending_effect is None
+    assert managed._retry_due is None
     await managed.close()
 
 

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -593,6 +593,7 @@ async def test_inflight_on_settlement_is_stale_after_replacement() -> None:
 @pytest.mark.asyncio
 async def test_provider_arrival_wins_retry_tie_without_duplicate_effect() -> None:
     managed, clock, _, _, _, lane = authority(generation=None)
+    await managed._stop_scheduler(managed._scheduler_task)
     await managed.force_off()
     managed._retry_due = clock.now
 


### PR DESCRIPTION
Linear: https://linear.app/morozsm/issue/MOR-2226/mor-21665e-pin-provider-arrivalretry-tie-against-duplicate-release

## Summary

- quiesce the background scheduler in the direct `_process_due()` unit test so it cannot consume the synthetic due time before the intended contender
- hold the provider-arrival release effect between pending-effect creation and settlement using the existing `FakeLane.block_next()` gate
- run `_process_due()` while that effect is pending, then assert one replacement-generation effect, no extra retry deadline, and clean release state after settlement

## Boundary

Test-only: `tests/test_managed_tx_authority.py`, +19/-3 relative to current `main`. Production is unchanged. No new fake, state, scheduler, watchdog, registry, or helper layer was added; the test reuses the existing gated lane and append-only event recording.

## Search before write

```text
$ rg -n "test_provider_arrival_wins_retry_tie_without_duplicate_effect|pending_effect is None|class FakeLane|class FakeFence|provider_available|_process_due|settle" tests/test_managed_tx_authority.py src/rigplane/runtime/managed_tx_authority.py
src/rigplane/runtime/managed_tx_authority.py:191:    async def provider_available(self, generation: int) -> None:
src/rigplane/runtime/managed_tx_authority.py:469:    async def _process_due(self) -> None:
src/rigplane/runtime/managed_tx_authority.py:510:            and self._state.pending_effect is None
tests/test_managed_tx_authority.py:83:class FakeFence:
tests/test_managed_tx_authority.py:93:class FakeLane:
tests/test_managed_tx_authority.py:109:    async def settle(
tests/test_managed_tx_authority.py:594:async def test_provider_arrival_wins_retry_tie_without_duplicate_effect() -> None:
```

Required legacy-reference census immediately before each final-branch push:

```text
$ git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py 'src/rigplane/runtime/command*.py' src/rigplane/web/handlers/control.py
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1732:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1982:            decision = evaluate_tx_interlock(
```

There are zero hits in `command_dispatch.py` and `runtime/command*.py`. The three pre-existing Web-handler hits are outside this test-only scope and remain in the planned legacy interlock retirement.

## Mini-only causal proof

Final test head: `cc578c5c053f95ea9f10bb241912361255a2ca0f`. No local test or static-analysis command was run.

First attempt, retained because it exposed the scheduling flaw:

- clean control PASS: run https://github.com/rigplane/rigplane-core/actions/runs/33664224827, job https://github.com/rigplane/rigplane-core/actions/runs/33664224827/job/100361871389, `mm-build-core-1`, artifact `9859905938`
- mutant unexpectedly SURVIVED: run https://github.com/rigplane/rigplane-core/actions/runs/33664227886, job https://github.com/rigplane/rigplane-core/actions/runs/33664227886/job/100361881511, `mm-build-core-2`, artifact `9859905979`
- cause: `provider_available()` wakes the live background scheduler, which could consume the manually assigned `_retry_due` while the provider was still absent, before the test-created `_process_due()` became the contender

Corrected deterministic proof, after quiescing that background scheduler:

- clean control PASS, exactly one target, rc=0: run https://github.com/rigplane/rigplane-core/actions/runs/33664720958, job https://github.com/rigplane/rigplane-core/actions/runs/33664720958/job/100363518744, `mm-build-core-1`, artifact https://github.com/rigplane/rigplane-core/actions/runs/33664720958/artifacts/9860094178
- mutant proof PASS because the expected mutation RED was recognized, exactly one target failed, rc=1: run https://github.com/rigplane/rigplane-core/actions/runs/33664723921, job https://github.com/rigplane/rigplane-core/actions/runs/33664723921/job/100363530092, `mm-build-core-2`, artifact https://github.com/rigplane/rigplane-core/actions/runs/33664723921/artifacts/9860095566
- mutation SHA `00cc42cb02ace0390825fd9c5f43136c532792dd` deletes exactly `_state.pending_effect is None` from `ManagedTxAuthority._release_is_retryable_locked`
- failure: `assert retry_due_while_pending is None` reddens as `assert 102.0 is None`

The mutation does not emit a second provider effect because `reduce_managed_tx(RetryForceReceive)` independently rejects a retry while an effect is pending. The proof therefore establishes the exact authority-level responsibility of this guard: it prevents scheduling another due retry while the current release effect is in flight. The test separately retains the lane-level assertion that exactly one replacement-generation `FORCE_RECEIVE` effect is emitted and verifies that accepted settlement clears the obligation and leaves no retry.

## CI

- PR quick on the exact final head: https://github.com/rigplane/rigplane-core/actions/runs/33664941204 — PASS on `mm-build-core-2`
- one normal full-matrix dispatch on the exact final head: https://github.com/rigplane/rigplane-core/actions/runs/33664958290 — PASS: Python 3.11 and 3.12 on `mm-build-core-2`; Python 3.13 and capture-harness on `mm-build-core-1`

## Review directive contract

Independent review must post a normal PR comment whose first non-blank line is exactly `Agent Review: PASS cc578c5c053f95ea9f10bb241912361255a2ca0f` or `Agent Review: BLOCKED cc578c5c053f95ea9f10bb241912361255a2ca0f`.
