### PR TITLE
refactor: drop the unread capabilities/is_serial parameters from build_state_queries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -488,6 +488,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set_attenuator_level` as the call to make instead of guessing a step;
   the same refusal applies to a profile that declares no `[attenuator]
   values` at all. `set_attenuator_level` itself is unchanged.
+- **`rigplane.runtime._state_queries.build_state_queries(profile,
+  capabilities, *, is_serial=False)` drops the `capabilities` and
+  `is_serial` parameters (MOR-2244).** After MOR-1983 (#3020, merge
+  `3683b297`) rewrote query membership to come from the profile's own
+  field-level acquisition capabilities, both parameters went unread in the
+  function body. The two production callers,
+  `runtime/radio_initial_state.py: fetch_initial_state` and
+  `web/radio_poller.py: RadioPoller._build_state_queries`, now call
+  `build_state_queries(profile)`; a call still passing either as a keyword
+  now raises `TypeError`. The compatibility re-export at
+  `rigplane._state_queries` (a `sys.modules` alias of the canonical module)
+  carries the same signature change.
 
 ### Changed
 

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -220,31 +220,19 @@ def acquisition_query_resolver_for_profile(
     return resolve
 
 
-def build_state_queries(
-    profile: RadioProfile,
-    capabilities: set[str],
-    *,
-    is_serial: bool = False,
-) -> list[AcquisitionQuery]:
+def build_state_queries(profile: RadioProfile) -> list[AcquisitionQuery]:
     """Build the profile-declared list of CI-V state queries.
 
     Parameters
     ----------
     profile:
         Radio profile (model, cmd29 support, receiver count).
-    capabilities:
-        Legacy caller input retained for compatibility. Query membership comes
-        from the profile's field-level acquisition capabilities.
-    is_serial:
-        Legacy caller input retained for compatibility. Transport does not
-        override profile-declared query membership.
 
     Returns
     -------
     list[AcquisitionQuery]
         Ordered list of lossless acquisition queries.
     """
-    _ = capabilities, is_serial
     acquisition = profile.state_acquisition
     if acquisition is None:
         return []

--- a/src/rigplane/runtime/radio_initial_state.py
+++ b/src/rigplane/runtime/radio_initial_state.py
@@ -3,8 +3,8 @@
 Extracted from ``radio.py`` (issue #1260, Tier 3 wave 3 of #1063) to slim down
 the god-object module. The single function here drives a one-shot population
 of :class:`RadioState` immediately after connect by iterating CI-V state
-queries built from the radio profile and capabilities and dispatching them as
-fire-and-forget reads.
+queries built from the radio profile and dispatching them as fire-and-forget
+reads.
 
 Behaviour is intentionally identical to the previous
 ``IcomRadio._fetch_initial_state`` method: per-query failures are swallowed,
@@ -45,11 +45,7 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
             if is_serial
             else radio._INITIAL_STATE_GAP_LAN
         )
-        queries = build_state_queries(
-            radio._profile,
-            radio.capabilities,
-            is_serial=is_serial,
-        )
+        queries = build_state_queries(radio._profile)
         if not queries:
             radio._initial_state_fetched = True
             return

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1291,11 +1291,7 @@ class RadioPoller:
         )
 
     def _build_state_queries(self) -> list[AcquisitionQuery]:
-        result: list[AcquisitionQuery] = build_state_queries(
-            self._profile,
-            self._caps,
-            is_serial=self._is_serial,
-        )
+        result: list[AcquisitionQuery] = build_state_queries(self._profile)
         return result
 
     async def _send_one_state_query(

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -444,12 +444,6 @@ def _scope_queries(
     return [query for query in queries if query_command(query) == 0x27]
 
 
-def _ic7610_caps() -> set[str]:
-    """Return the full capability set for IC-7610."""
-    profile = resolve_radio_profile(model="IC-7610")
-    return set(profile.capabilities)
-
-
 def _ic7300_caps() -> set[str]:
     """Return the full capability set for IC-7300."""
     profile = resolve_radio_profile(model="IC-7300")
@@ -462,7 +456,7 @@ class TestBuildStateQueries:
     def test_returns_current_acquisition_query_representation(self) -> None:
         assert_acquisition_query_representation_contract()
         profile = resolve_radio_profile(model="IC-7610")
-        queries = build_state_queries(profile, _ic7610_caps())
+        queries = build_state_queries(profile)
         assert isinstance(queries, list)
         assert len(queries) > 0
         for query in queries:
@@ -471,7 +465,7 @@ class TestBuildStateQueries:
     def test_ic7610_includes_dual_receiver_queries(self) -> None:
         """IC-7610 has 2 receivers — freq/mode must appear for rx 0 and rx 1."""
         profile = resolve_radio_profile(model="IC-7610")
-        queries = build_state_queries(profile, _ic7610_caps())
+        queries = build_state_queries(profile)
         freq_selectors = [
             query_selector(query) for query in queries if query_command(query) == 0x25
         ]
@@ -481,7 +475,7 @@ class TestBuildStateQueries:
     def test_ic7300_single_receiver(self) -> None:
         """IC-7300 has selected/unselected reads on its one receiver."""
         profile = resolve_radio_profile(model="IC-7300")
-        queries = build_state_queries(profile, _ic7300_caps())
+        queries = build_state_queries(profile)
         freq_queries = [query for query in queries if query_command(query) == 0x25]
         assert freq_queries == [
             acquisition_query(0x25, selector=0),
@@ -495,14 +489,14 @@ class TestBuildStateQueries:
     def test_ic7610_includes_scope_queries(self) -> None:
         """IC-7610 should have scope sub-commands (0x27)."""
         profile = resolve_radio_profile(model="IC-7610")
-        queries = build_state_queries(profile, _ic7610_caps())
+        queries = build_state_queries(profile)
         scope_queries = [query for query in queries if query_command(query) == 0x27]
         assert len(scope_queries) > 0
 
     def test_ic7300_has_scope_queries_if_capable(self) -> None:
         """IC-7300 has scope capability — should include 0x27 queries."""
         profile = resolve_radio_profile(model="IC-7300")
-        queries = build_state_queries(profile, _ic7300_caps())
+        queries = build_state_queries(profile)
         scope_queries = [query for query in queries if query_command(query) == 0x27]
         if "scope" in _ic7300_caps():
             assert len(scope_queries) > 0
@@ -511,7 +505,7 @@ class TestBuildStateQueries:
 
     def test_queries_follow_profile_field_capabilities_and_command_map(self) -> None:
         profile = resolve_radio_profile(model="IC-7610")
-        queries = build_state_queries(profile, _ic7610_caps())
+        queries = build_state_queries(profile)
         assert profile.state_acquisition is not None
         pollable = profile.state_acquisition.pollable_paths()
         resolve = acquisition_query_resolver_for_profile(profile)
@@ -540,8 +534,8 @@ class TestBuildStateQueries:
         commands["get_rf_power"] = (0x14, 0x7E)
         mutated = replace(profile, command_map=CommandMap(commands))
 
-        original_queries = build_state_queries(profile, set())
-        mutated_queries = build_state_queries(mutated, set())
+        original_queries = build_state_queries(profile)
+        mutated_queries = build_state_queries(mutated)
 
         assert acquisition_query(0x14, sub=0x0A) in original_queries
         assert acquisition_query(0x14, sub=0x7E) not in original_queries
@@ -563,22 +557,18 @@ class TestBuildStateQueries:
             state_acquisition=replace(acquisition, capabilities=capabilities),
         )
 
-        assert acquisition_query(0x14, sub=0x0A) in build_state_queries(profile, set())
-        assert acquisition_query(0x14, sub=0x0A) not in build_state_queries(
-            mutated, set()
-        )
+        assert acquisition_query(0x14, sub=0x0A) in build_state_queries(profile)
+        assert acquisition_query(0x14, sub=0x0A) not in build_state_queries(mutated)
 
-    def test_legacy_arguments_do_not_override_profile_declarations(self) -> None:
+    def test_removed_capabilities_and_is_serial_arguments_raise_type_error(
+        self,
+    ) -> None:
+        """MOR-2244: both legacy arguments were unread and are now removed."""
         profile = resolve_radio_profile(model="IC-7610")
-        expected = build_state_queries(profile, set(), is_serial=False)
-        assert (
-            build_state_queries(
-                profile,
-                set(profile.capabilities),
-                is_serial=True,
-            )
-            == expected
-        )
+        with pytest.raises(TypeError):
+            build_state_queries(profile, capabilities=set())  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            build_state_queries(profile, is_serial=False)  # type: ignore[call-arg]
 
     @pytest.mark.parametrize("model", _shipped_civ_models())
     def test_every_shipped_civ_profile_has_traceable_acquisition(
@@ -606,7 +596,7 @@ class TestBuildStateQueries:
             if query not in expected:
                 expected.append(query)
 
-        queries = build_state_queries(profile, set(profile.capabilities))
+        queries = build_state_queries(profile)
         assert queries
         assert queries == expected
         assert len(queries) == len(set(queries))
@@ -637,7 +627,7 @@ class TestBuildStateQueries:
 
         assert result.sent_paths == pollable
         assert result.failed_paths == ()
-        assert sent == build_state_queries(profile, set(profile.capabilities))
+        assert sent == build_state_queries(profile)
 
     def test_ic9700_polling_paths_have_exact_executable_query_parity(self) -> None:
         profile = resolve_radio_profile(model="IC-9700")
@@ -657,7 +647,7 @@ class TestBuildStateQueries:
         assert profile.cmd29_routes == frozenset()
         assert not excluded_sub_controls.intersection(pollable)
         assert not excluded_sub_freq_mode.intersection(pollable)
-        queries = build_state_queries(profile, set(profile.capabilities))
+        queries = build_state_queries(profile)
         assert len(pollable) == len(queries) == 34
         assert all(query.receiver is None for query in queries)
         assert not any(
@@ -680,7 +670,7 @@ class TestBuildStateQueries:
         assert rbw_path not in acquisition.pollable_paths()
         assert not any(
             query.command == 0x27 and query.sub == 0x1F
-            for query in build_state_queries(profile, set(profile.capabilities))
+            for query in build_state_queries(profile)
         )
         with pytest.raises(CommandError, match="get_scope_rbw is not supported"):
             commands.get_scope_rbw(to_addr=profile.civ_addr)
@@ -695,7 +685,7 @@ class TestBuildStateQueries:
 
         assert rbw_path in acquisition.pollable_paths()
         assert acquisition_query(0x27, sub=0x1F, data=b"\x00") in build_state_queries(
-            profile, set(profile.capabilities)
+            profile
         )
 
     @pytest.mark.parametrize("model", _shipped_civ_models())
@@ -729,9 +719,8 @@ class TestBuildStateQueries:
     def test_deterministic_output(self) -> None:
         """Same inputs should produce identical output."""
         profile = resolve_radio_profile(model="IC-7610")
-        caps = _ic7610_caps()
-        q1 = build_state_queries(profile, caps)
-        q2 = build_state_queries(profile, caps)
+        q1 = build_state_queries(profile)
+        q2 = build_state_queries(profile)
         assert q1 == q2
 
     def test_ic7610_dual_watch_query_preserves_wire_tuple(self) -> None:
@@ -740,7 +729,7 @@ class TestBuildStateQueries:
             profile.command_map.get("get_dual_watch")
         )
         assert (command, sub, prefix) == (0x07, None, b"\xc2")
-        queries = build_state_queries(profile, set())
+        queries = build_state_queries(profile)
         assert queries.count(acquisition_query(0x07, data=b"\xc2")) == 1
         assert acquisition_query(0x07) not in queries
         assert build_civ_frame(0x98, 0xE0, 0x07, sub=0xC2) == bytes.fromhex(
@@ -764,7 +753,7 @@ class TestBuildStateQueries:
             state_acquisition=replace(acquisition, capabilities=capabilities),
         )
 
-        queries = build_state_queries(mutated, set())
+        queries = build_state_queries(mutated)
         assert len(queries) == len(set(queries))
         assert queries.count(acquisition_query(0x26, selector=0)) == 1
 
@@ -798,7 +787,7 @@ class TestScopeReceiverSelector:
 
     def test_sweep_scope_reads_follow_declared_commands_and_shapes(self) -> None:
         profile = resolve_radio_profile(model="IC-7300")
-        scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
+        scope = _scope_queries(build_state_queries(profile))
 
         frame_parts = [civ_frame_parts(query) for query in scope]
         with_selector = {
@@ -816,7 +805,7 @@ class TestScopeReceiverSelector:
 
     def test_sweep_selector_is_one_byte_and_main(self) -> None:
         profile = resolve_radio_profile(model="IC-7300")
-        scope = _scope_queries(build_state_queries(profile, _ic7300_caps()))
+        scope = _scope_queries(build_state_queries(profile))
 
         carried = [
             part.data
@@ -838,8 +827,7 @@ class TestScopeReceiverSelector:
         receiver routing, so no sender can confuse one for the other.
         """
         profile = resolve_radio_profile(model=model)
-        caps = set(profile.capabilities)
-        queries = build_state_queries(profile, caps)
+        queries = build_state_queries(profile)
 
         assert _scope_queries(queries), "no scope reads to check"
         assert all(
@@ -878,7 +866,7 @@ class TestFetchInitialState:
     @pytest.mark.parametrize("model", _shipped_civ_models())
     async def test_dispatches_all_queries(self, radio, model: str) -> None:
         radio._profile = resolve_radio_profile(model=model)
-        queries = build_state_queries(radio._profile, set(radio._profile.capabilities))
+        queries = build_state_queries(radio._profile)
         assert queries, f"{model}: initial/periodic acquisition must not be empty"
         poller = object.__new__(RadioPoller)
         poller._profile = radio._profile


### PR DESCRIPTION
## What and why

`Linear: MOR-2244`

`src/rigplane/runtime/_state_queries.py: build_state_queries` accepted
`capabilities` and `is_serial`, but after MOR-1983 (#3020, merge
`3683b297`) rewrote query membership to come from the profile's own
field-level acquisition capabilities, neither parameter was read in the
function body (`_ = capabilities, is_serial`). The re-export at
`rigplane._state_queries` makes the signature public. Owner ruling
2026-09-02: remove both parameters.

This PR removes them, updates the two production callers
(`runtime/radio_initial_state.py: fetch_initial_state`,
`web/radio_poller.py: RadioPoller._build_state_queries`) and every test
call site, deletes the now-false docstring/module-comment sentences that
named the removed parameters, and pins the breaking change with a test
that calling with either as a keyword now raises `TypeError`.

## Step-1 evidence (commands run, with output)

**`git grep -n "build_state_queries" -- src tests`** — every definition
and call site (run against the pre-change tree):

```
src/rigplane/runtime/_state_queries.py:223:def build_state_queries(
src/rigplane/runtime/radio_initial_state.py:39:    from ._state_queries import build_state_queries
src/rigplane/runtime/radio_initial_state.py:48:        queries = build_state_queries(
src/rigplane/web/radio_poller.py:116:    build_state_queries,
src/rigplane/web/radio_poller.py:688:        self._STATE_QUERIES = self._build_state_queries()
src/rigplane/web/radio_poller.py:1293:    def _build_state_queries(self) -> list[AcquisitionQuery]:
src/rigplane/web/radio_poller.py:1294:        result: list[AcquisitionQuery] = build_state_queries(
src/rigplane/web/radio_poller.py:1341:            # ``build_state_queries`` emits MAIN because it runs at connect,
tests/test_radio_poller_coverage.py:4081:    ``build_state_queries`` runs at connect, before any 0x27 0x12 response
tests/test_state_queries.py: 25 call expressions (AST count at the base; 31 substring hits) (helpers, TestBuildStateQueries,
    TestScopeReceiverSelector, TestFetchInitialState — all listed in full
    in the implementation trace)
tests/test_vox_tone_state.py:332,372,373,393,394: test names/docstrings
    only, no direct call
```

Two production callers found: `radio_initial_state.py: fetch_initial_state`
and `radio_poller.py: RadioPoller._build_state_queries`. Both passed
`capabilities`/`is_serial` positionally/by keyword and neither used the
return value differently based on them — confirmed by reading the callee
body, which discarded both (`_ = capabilities, is_serial`) before this PR.

**`git grep -n "is_serial\|capabilities" -- src/rigplane/runtime/_state_queries.py src/rigplane/_state_queries.py`**:

```
src/rigplane/runtime/_state_queries.py:225:    capabilities: set[str],
src/rigplane/runtime/_state_queries.py:227:    is_serial: bool = False,
src/rigplane/runtime/_state_queries.py:235:    capabilities:
src/rigplane/runtime/_state_queries.py:237:        from the profile's field-level acquisition capabilities.
src/rigplane/runtime/_state_queries.py:238:    is_serial:
src/rigplane/runtime/_state_queries.py:247:    _ = capabilities, is_serial
```

`src/rigplane/_state_queries.py` is a `sys.modules`-alias shim (`from
rigplane.runtime._state_queries import *` + `sys.modules[__name__] =
_canonical`), so it carries no separate signature to grep for — confirmed
by reading the file.

`local-extensions/` does not exist in this worktree (`ls local-extensions`
→ "No such file or directory"), so there is no caller there to check.

## Callers that surprised me

None. Both production callers discarded the values before this change
(the callee's own `_ = capabilities, is_serial` line proves it), and no
test in the file relied on either argument changing `build_state_queries`'
output — `test_legacy_arguments_do_not_override_profile_declarations`
(now replaced) existed specifically to assert that passing different
`capabilities`/`is_serial` values produced *identical* output.

## Test evidence

Targeted run (`uv run pytest tests/test_state_queries.py
tests/test_radio_poller_coverage.py tests/test_vox_tone_state.py -q
--tb=short`): **365 passed, 0 failed.**

Mutation check: reinstated the pre-change signature shape (the real pre-change signature had `capabilities: set[str]` as a required positional; the verifier also killed the test with that exact form)
(`def build_state_queries(profile, capabilities=None, *,
is_serial=False):`) and re-ran the new pinning test alone — it failed
with `Failed: DID NOT RAISE <class 'TypeError'>`, confirming the test
discriminates the exact regression the change removes. Restored the file
from the pre-mutation copy and reran the full targeted suite (365
passed) before this commit.

`uv run ruff check src/ tests/` — all checks passed.
`uv run ruff format src/ tests/` — 715 files already formatted (0 diff
beyond this change).
`uv run lint-imports` — 5 contracts kept, 0 broken.

## Diff

`git diff origin/main --stat` (merge-base `3287fcd9`, since `main` gained
one unrelated commit after this branch was cut):

```
 docs/CHANGELOG.md                           | 12 +++++
 src/rigplane/runtime/_state_queries.py      | 14 +-----
 src/rigplane/runtime/radio_initial_state.py | 10 ++--
 src/rigplane/web/radio_poller.py            |  6 +--
 tests/test_state_queries.py                 | 74 ++++++++++++-----------------
 5 files changed, 48 insertions(+), 68 deletions(-)
```

## Full suite

Not run here — CI (`quick.yml`) runs the standard pytest suite on this
PR; only the targeted files above were run locally per the task's
instruction to avoid a full local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

