### PR TITLE
fix: log the initial sweep as queries sent, not "ok"

### DIFF
--- a/src/rigplane/runtime/radio_initial_state.py
+++ b/src/rigplane/runtime/radio_initial_state.py
@@ -55,7 +55,7 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
             len(queries),
             gap * 1000,
         )
-        ok = 0
+        sent = 0
         for query in queries:
             try:
                 if query.receiver is not None:
@@ -74,14 +74,21 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
                         data=query.data,
                         wait_response=False,
                     )
-                ok += 1
-            except Exception:
-                pass  # non-fatal; regular polling will retry
+                sent += 1
+            except Exception as exc:
+                # non-fatal; regular polling will retry
+                logger.debug(
+                    "initial state query failed: command=0x%02X sub=%s data=%s (%s)",
+                    query.command,
+                    "None" if query.sub is None else f"0x{query.sub:02X}",
+                    query.data.hex(),
+                    type(exc).__name__,
+                )
             await asyncio.sleep(gap)
 
         logger.info(
-            "initial state fetch done (%d/%d ok)",
-            ok,
+            "initial state fetch sent %d/%d queries",
+            sent,
             len(queries),
         )
     except Exception:

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import replace
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call, patch
@@ -991,3 +992,63 @@ class TestFetchInitialState:
         assert radio._initial_state_fetched is True
         assert call_count > 0
         assert sleep.await_count == call_count
+
+    @pytest.mark.asyncio
+    async def test_summary_log_names_sends_not_ok(self, radio, caplog) -> None:
+        """MOR-2224: send_civ is called with wait_response=False, so the sweep
+        never learns whether the radio replied — the summary must say what
+        was measured (queries sent), not the unchecked word "ok"."""
+        queries = build_state_queries(radio._profile)
+        with patch(
+            "rigplane.runtime.radio_initial_state.asyncio.sleep", new=AsyncMock()
+        ):
+            with caplog.at_level(
+                logging.INFO, logger="rigplane.runtime.radio_initial_state"
+            ):
+                await radio._fetch_initial_state()
+
+        summary_records = [
+            r
+            for r in caplog.records
+            if r.getMessage().startswith("initial state fetch sent")
+        ]
+        assert len(summary_records) == 1
+        message = summary_records[0].getMessage()
+        assert "ok" not in message.split()
+        assert (
+            message == f"initial state fetch sent {len(queries)}/{len(queries)} queries"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_failure_logs_the_failing_query_and_continues(
+        self, radio, caplog
+    ) -> None:
+        radio._profile = resolve_radio_profile(model="IC-7300")
+        queries = build_state_queries(radio._profile)
+        failing = queries[0]
+
+        call_count = 0
+
+        async def flaky_send(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("transient error")
+
+        radio.send_civ = flaky_send
+        with patch(
+            "rigplane.runtime.radio_initial_state.asyncio.sleep", new=AsyncMock()
+        ):
+            with caplog.at_level(
+                logging.DEBUG, logger="rigplane.runtime.radio_initial_state"
+            ):
+                await radio._fetch_initial_state()
+
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(debug_records) == 1
+        message = debug_records[0].getMessage()
+        assert f"command=0x{failing.command:02X}" in message
+        assert "RuntimeError" in message
+        # the sweep continues past the failure: every query is still attempted
+        assert call_count == len(queries)
+        assert radio._initial_state_fetched is True


### PR DESCRIPTION
## What and why

`fetch_initial_state` in `src/rigplane/runtime/radio_initial_state.py` sent
each CI-V state query with `wait_response=False` and incremented a counter
named `ok` whenever `send_civ` returned without raising — no reply was ever
checked. The final `logger.info` then reported "(%d/%d ok)", which reads as
a verified-success count but was only "the send call didn't raise."

Fix: rename the counter to `sent` and reword the summary log to
`"initial state fetch sent %d/%d queries"`, which matches what is actually
measured. The per-query `except Exception: pass` also swallowed the
exception with no record of which query failed; it now logs the query
(command/sub/data) and the exception type at `DEBUG`, still non-fatal —
the sweep is otherwise unchanged: no awaiting or counting of replies
(that is MOR-1972, and this change does not touch it), and
`build_state_queries` / byte resolution are untouched.

Linear: MOR-2224

## Before (fetch_initial_state at origin/main, commit 7387c84e)

```python
async def fetch_initial_state(radio: IcomRadio) -> None:
    """Fetch full radio state once to populate RadioState.

    Iterates through all state queries built from the radio profile and
    sends each as a fire-and-forget CI-V read.  On completion sets
    ``_initial_state_fetched = True``.

    This is non-fatal: failures are logged but do not raise.
    """
    from ._state_queries import build_state_queries

    try:
        is_serial = not radio._profile.has_lan
        gap = (
            radio._INITIAL_STATE_GAP_SERIAL
            if is_serial
            else radio._INITIAL_STATE_GAP_LAN
        )
        queries = build_state_queries(radio._profile)
        if not queries:
            radio._initial_state_fetched = True
            return

        logger.info(
            "initial state fetch (%d queries, gap=%.0fms)...",
            len(queries),
            gap * 1000,
        )
        ok = 0
        for query in queries:
            try:
                if query.receiver is not None:
                    inner = bytes([query.receiver, query.command])
                    if query.sub is not None:
                        inner += bytes([query.sub])
                    await radio.send_civ(
                        0x29,
                        data=inner + query.data,
                        wait_response=False,
                    )
                else:
                    await radio.send_civ(
                        query.command,
                        sub=query.sub,
                        data=query.data,
                        wait_response=False,
                    )
                ok += 1
            except Exception:
                pass  # non-fatal; regular polling will retry
            await asyncio.sleep(gap)

        logger.info(
            "initial state fetch done (%d/%d ok)",
            ok,
            len(queries),
        )
    except Exception:
        logger.warning(
            "initial state fetch failed",
            exc_info=True,
        )
    finally:
        radio._initial_state_fetched = True
```

## Tests

Added two tests to `tests/test_state_queries.py::TestFetchInitialState`:
- `test_summary_log_names_sends_not_ok` — asserts the final `INFO` log
  message is exactly `"initial state fetch sent {N}/{N} queries"` and
  contains no `"ok"` token.
- `test_send_failure_logs_the_failing_query_and_continues` — makes the
  first `send_civ` call raise `RuntimeError`, asserts a single `DEBUG`
  record names that query's command byte and the exception class, and
  that every remaining query is still attempted (`call_count == len(queries)`).

Commands and results:
```
uv run pytest tests/test_state_queries.py -q --tb=short --timeout=300 --timeout-method=thread
79 passed in 0.54s

uv run ruff check src/ tests/
All checks passed!

uv run ruff format --check src/ tests/
715 files already formatted

uv run lint-imports
Contracts: 5 kept, 0 broken.
```

## Mutation check

Reverted the log-wording change only (kept the counter variable name and
the debug-logging addition) — restored `"initial state fetch done (%d/%d ok)"`
in place of `"initial state fetch sent %d/%d queries"` — and reran the two
new tests. `test_summary_log_names_sends_not_ok` failed as expected
(`assert 0 == 1`, no record matched the `"initial state fetch sent"`
prefix); `test_send_failure_logs_the_failing_query_and_continues` stayed
green, since it covers the separate debug-logging property, not the
wording. Reverted the mutation, reapplied the intended fix; `git diff`
against the merge base shows only the intended change (verified above).

## Diff stat

```
$ git diff $(git merge-base origin/main HEAD) --stat
 src/rigplane/runtime/radio_initial_state.py | 19 ++++++---
 tests/test_state_queries.py                 | 61 +++++++++++++++++++++++++++++
 2 files changed, 74 insertions(+), 6 deletions(-)
```

full suite: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
