### PR TITLE
fix: make managed ForceOff cleanup non-blocking

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, replace
 from enum import StrEnum
-from typing import Protocol
+from typing import Any, Protocol
 
 from rigplane.runtime.managed_tx_config import (
     ManagedTxTotConfig,
     ManagedTxTotConfigStore,
 )
 from rigplane.runtime.managed_tx_effect_lane import ManagedTxEffectLane
-from rigplane.runtime.managed_tx_fence import TxAbortFence
+from rigplane.runtime.managed_tx_fence import TxAbortFence, TxAbortResult
 from rigplane.runtime.managed_tx_state import (
     AbortOperation,
     ActuationOperation,
@@ -100,6 +100,8 @@ class ManagedTxAuthority:
         self._lane = lane
         self._config_store = config_store
         self._abort_fence = abort_fence
+        self._pending_abort_cleanup: list[Coroutine[Any, Any, TxAbortResult]] = []
+        self._abort_cleanup: set[asyncio.Task[TxAbortResult]] = set()
         self._clock = clock or time.monotonic
         self._wakeup = wakeup or _EventWakeup(self._clock)
         self._attempt_timeout = attempt_timeout_seconds
@@ -223,10 +225,11 @@ class ManagedTxAuthority:
                 self._shutdown_termination = termination
                 transition = self._force_off_locked()
                 self._wakeup.wake()
-                task = asyncio.create_task(
-                    self._complete_shutdown(transition, retire_provider, termination)
-                )
-                self._shutdown_task = task
+        if task is None:
+            task = asyncio.create_task(
+                self._complete_shutdown(transition, retire_provider, termination)
+            )
+            self._shutdown_task = task
         return await asyncio.shield(task)
 
     async def close(self) -> None:
@@ -239,6 +242,7 @@ class ManagedTxAuthority:
         termination: asyncio.Event,
     ) -> ShutdownResult:
         try:
+            self._start_abort_cleanup()
             drain = asyncio.create_task(
                 self._wait_for_release_or_termination(termination)
             )
@@ -261,6 +265,7 @@ class ManagedTxAuthority:
                 async with self._lock:
                     scheduler = self._scheduler_task
                 await self._stop_scheduler(scheduler)
+                await self._cancel_abort_cleanup()
                 return ShutdownResult.TERMINATED
 
             async with self._lock:
@@ -287,9 +292,9 @@ class ManagedTxAuthority:
         self, termination: asyncio.Event
     ) -> bool:
         async with self._lock:
-            if self._state_is_clean_locked():
+            if self._state_is_clean_locked() and not self._abort_cleanup:
                 return True
-        drained = asyncio.create_task(self._release_drained.wait())
+        drained = asyncio.create_task(self._wait_for_clean_release())
         terminated = asyncio.create_task(termination.wait())
         try:
             done, _ = await asyncio.wait(
@@ -298,7 +303,7 @@ class ManagedTxAuthority:
             async with self._lock:
                 if self._terminated:
                     return False
-                if self._state_is_clean_locked():
+                if drained in done and self._state_is_clean_locked():
                     return True
                 if terminated in done:
                     self._terminated = True
@@ -309,6 +314,35 @@ class ManagedTxAuthority:
                 if not waiter.done():
                     waiter.cancel()
             await asyncio.gather(drained, terminated, return_exceptions=True)
+
+    async def _wait_for_clean_release(self) -> None:
+        while True:
+            await self._release_drained.wait()
+            await self._finish_abort_cleanup()
+            if self._release_drained.is_set():
+                return
+
+    def _start_abort_cleanup(self) -> None:
+        pending, self._pending_abort_cleanup = self._pending_abort_cleanup, []
+        for cleanup in pending:
+            task = asyncio.create_task(cleanup)
+            self._abort_cleanup.add(task)
+            task.add_done_callback(self._abort_cleanup.discard)
+
+    async def _finish_abort_cleanup(self) -> None:
+        self._start_abort_cleanup()
+        while self._abort_cleanup:
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in tuple(self._abort_cleanup))
+            )
+            self._start_abort_cleanup()
+
+    async def _cancel_abort_cleanup(self) -> None:
+        self._start_abort_cleanup()
+        tasks = tuple(self._abort_cleanup)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _dispose_clean(self, *, from_shutdown: bool) -> None:
         async with self._lock:
@@ -321,6 +355,7 @@ class ManagedTxAuthority:
             self._closing = True
             scheduler = self._scheduler_task
         await self._stop_scheduler(scheduler)
+        await self._finish_abort_cleanup()
         async with self._lock:
             self._closed = True
             self._closing = False
@@ -394,6 +429,7 @@ class ManagedTxAuthority:
 
     def _force_off_locked(self) -> ManagedTxTransition:
         self._retry_due = None
+        self._pending_abort_cleanup.append(self._abort_fence.force_off())
         return self._reduce_locked(
             ForceOff(self._provider_generation, self._attempt_id_locked())
         )
@@ -411,10 +447,9 @@ class ManagedTxAuthority:
         self, effects: tuple[ManagedTxEffect, ...], *, full_force: bool
     ) -> None:
         while True:
+            self._start_abort_cleanup()
             deadline = self._clock() + self._attempt_timeout
             events: list[ManagedTxEvent] = []
-            if full_force:
-                await self._abort_fence.force_off()
             for effect in effects:
                 if full_force:
                     aborts = [

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -332,6 +332,10 @@ class ManagedTxAuthority:
     async def _finish_abort_cleanup(self) -> None:
         self._start_abort_cleanup()
         while self._abort_cleanup:
+            for task in tuple(self._abort_cleanup):
+                if task.done():
+                    self._abort_cleanup.discard(task)
+                    task.result()
             await asyncio.gather(
                 *(asyncio.shield(task) for task in tuple(self._abort_cleanup))
             )

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -346,7 +346,7 @@ class ManagedTxAuthority:
 
     async def _dispose_clean(self, *, from_shutdown: bool) -> None:
         async with self._lock:
-            if self._closed or self._closing:
+            if self._closed:
                 return
             if not self._state_is_clean_locked():
                 raise RuntimeError("managed TX disposal requires clean RX state")

--- a/src/rigplane/runtime/managed_tx_effect_lane.py
+++ b/src/rigplane/runtime/managed_tx_effect_lane.py
@@ -55,10 +55,6 @@ class _Claim:
     isolation: tuple[asyncio.Task[None], ...] = ()
 
 
-async def _ignore_poison(_: int) -> None:
-    return None
-
-
 class ManagedTxEffectLane:
     """Claim, prioritize, and normalize managed actuator attempts."""
 
@@ -71,7 +67,7 @@ class ManagedTxEffectLane:
     ) -> None:
         self._actuator = actuator
         self._clock = clock or time.monotonic
-        self._poison_generation = poison_generation or _ignore_poison
+        self._poison_generation = poison_generation
         self._lock = asyncio.Lock()
         self._on_lane = asyncio.Lock()
         self._claims: dict[_ClaimKey, _Claim] = {}
@@ -197,6 +193,7 @@ class ManagedTxEffectLane:
         async with self._lock:
             if claim.result.done():
                 return
+            isolation_pending = any(not task.done() for task in claim.isolation)
             claim.started = True
             claim.provider = asyncio.create_task(
                 self._actuator.actuate(claim.token, claim.operation)
@@ -226,9 +223,12 @@ class ManagedTxEffectLane:
             )
             return
         if result is ActuationResult.ACCEPTED and claim.isolation:
-            if isolation_error := await self._await_isolation(
+            isolation_error = await self._await_isolation(
                 claim.isolation, claim.deadline
-            ):
+            )
+            if isolation_error is None and isolation_pending:
+                isolation_error = "release preceded ON isolation"
+            if isolation_error:
                 result = ActuationResult.UNCERTAIN
                 await self._finish(claim, _Outcome(result, isolation_error))
                 return
@@ -253,7 +253,7 @@ class ManagedTxEffectLane:
                 return
             self._claims.pop((claim.token, claim.operation), None)
             if poison:
-                isolation = self._isolate_locked(claim.token.provider_generation)
+                isolation = self._isolate_locked(claim)
         if isolation is not None:
             await self._await_isolation((isolation,), claim.deadline)
         async with self._lock:
@@ -291,16 +291,34 @@ class ManagedTxEffectLane:
         )
         claim.result.set_result(_Outcome(result, after if claim.started else before))
         if claim.started and claim.operation in _ON_OPERATIONS:
-            return self._isolate_locked(claim.token.provider_generation)
+            return self._isolate_locked(claim)
         return None
 
-    def _isolate_locked(self, provider_generation: int) -> asyncio.Task[None]:
-        if self._isolation is not None and self._isolation[0] == provider_generation:
+    def _isolate_locked(self, claim: _Claim) -> asyncio.Task[None]:
+        provider_generation = claim.token.provider_generation
+        if (
+            self._poison_generation is not None
+            and self._isolation is not None
+            and self._isolation[0] == provider_generation
+        ):
             return self._isolation[1]
-        task = asyncio.ensure_future(self._poison_generation(provider_generation))
+        previous = None if self._isolation is None else self._isolation[1]
+        task = asyncio.create_task(self._isolate_provider(claim, previous))
         task.add_done_callback(self._harvest)
         self._isolation = (provider_generation, task)
         return task
+
+    async def _isolate_provider(
+        self, claim: _Claim, previous: asyncio.Task[None] | None
+    ) -> None:
+        if self._poison_generation is not None:
+            await self._poison_generation(claim.token.provider_generation)
+        else:
+            assert claim.provider is not None
+            pending: list[asyncio.Future[Any]] = [asyncio.shield(claim.provider)]
+            if previous is not None:
+                pending.append(asyncio.shield(previous))
+            await asyncio.gather(*pending, return_exceptions=True)
 
     async def _await_isolation(
         self, tasks: tuple[asyncio.Task[None], ...], deadline: float

--- a/src/rigplane/runtime/managed_tx_fence.py
+++ b/src/rigplane/runtime/managed_tx_fence.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import asyncio
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
 from inspect import isawaitable
+from typing import Any
 
 
 Cancellation = Callable[[], Awaitable[None] | None]
@@ -55,16 +57,29 @@ class TxAbortFence:
     def remove(self, token: TxAbortToken) -> bool:
         return self._cancellations.pop(token, None) is not None
 
-    async def force_off(self) -> TxAbortResult:
+    def force_off(self) -> Coroutine[Any, Any, TxAbortResult]:
+        """Invalidate immediately; await the returned coroutine to finish cleanup."""
         self._epoch += 1
         cancellations = tuple(self._cancellations.items())
         self._cancellations.clear()
-        failures: list[TxAbortFailure] = []
-        for token, cancellation in cancellations:
+        return self._cancel(self._epoch, cancellations)
+
+    @staticmethod
+    async def _cancel(
+        epoch: int, cancellations: tuple[tuple[TxAbortToken, Cancellation], ...]
+    ) -> TxAbortResult:
+        async def cancel_one(
+            token: TxAbortToken, cancellation: Cancellation
+        ) -> TxAbortFailure | None:
             try:
                 result = cancellation()
                 if isawaitable(result):
                     await result
             except BaseException as error:
-                failures.append(TxAbortFailure(token, error))
-        return TxAbortResult(self._epoch, tuple(failures))
+                return TxAbortFailure(token, error)
+            return None
+
+        failures = await asyncio.gather(
+            *(cancel_one(token, cancellation) for token, cancellation in cancellations)
+        )
+        return TxAbortResult(epoch, tuple(failure for failure in failures if failure))

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -6,6 +6,8 @@ import pytest
 
 from rigplane.runtime.managed_tx_authority import ManagedTxAuthority, ShutdownResult
 from rigplane.runtime.managed_tx_config import ManagedTxTotConfig
+from rigplane.runtime.managed_tx_effect_lane import ManagedTxEffectLane
+from rigplane.runtime.managed_tx_fence import TxAbortFence
 from rigplane.runtime.managed_tx_state import (
     AbortFailed,
     AbortOperation,
@@ -863,3 +865,173 @@ async def test_ten_thousand_idempotent_commands_keep_one_scheduler() -> None:
     assert not hasattr(managed, "observed_ptt")
     await managed.force_off()
     await managed.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry", ["force_off", "shutdown", "offline_shutdown"])
+async def test_real_fence_releases_before_cleanup_and_shutdown_waits_for_cleanup(
+    entry: str,
+) -> None:
+    fence = TxAbortFence()
+    old = fence.issue()
+    cleanup_started, finish_cleanup = asyncio.Event(), asyncio.Event()
+    off_written = asyncio.Event()
+    writes: list[bool] = []
+    retired: list[int] = []
+
+    class Actuator:
+        async def actuate(self, token, operation):
+            assert not fence.is_current(old)
+            state = (await managed.snapshot()).state
+            assert state.intent.kind is ManagedTxIntentKind.RX
+            if operation is ActuationOperation.FORCE_RECEIVE:
+                writes.append(False)
+                off_written.set()
+            return ActuationResult.ACCEPTED
+
+    async def cleanup() -> None:
+        assert (await managed.snapshot()).state.intent.kind is ManagedTxIntentKind.RX
+        cleanup_started.set()
+        await finish_cleanup.wait()
+
+    fence.register(old, cleanup)
+    managed = ManagedTxAuthority(
+        ManagedTxEffectLane(Actuator()),
+        FakeConfigStore(None),
+        fence,
+        provider_generation=None if entry == "offline_shutdown" else 7,
+    )
+    task = asyncio.create_task(
+        managed.force_off()
+        if entry == "force_off"
+        else managed.shutdown(
+            retire_provider=lambda generation: _append_async(retired, generation),
+            termination=asyncio.Event(),
+        )
+    )
+    try:
+        if entry == "offline_shutdown":
+            while not (await managed.snapshot()).state.release_required:
+                await asyncio.sleep(0)
+            assert not fence.is_current(old)
+            await managed.provider_available(8)
+        await asyncio.wait_for(cleanup_started.wait(), 1)
+        await asyncio.wait_for(off_written.wait(), 1)
+        assert writes == [False]
+        if entry == "force_off":
+            assert (
+                await asyncio.wait_for(asyncio.shield(task), 1)
+                is ManagedTxOutcome.ACCEPTED
+            )
+            assert not (await managed.snapshot()).state.release_required
+        else:
+            assert not task.done() and retired == []
+    finally:
+        finish_cleanup.set()
+        await task
+        await managed.close()
+    assert retired == (
+        [] if entry == "force_off" else [8 if entry == "offline_shutdown" else 7]
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_termination_cancels_owned_cleanup_without_waiting_for_gate() -> None:
+    fence = TxAbortFence()
+    started, stopped, never, termination = (asyncio.Event() for _ in range(4))
+
+    async def cleanup() -> None:
+        started.set()
+        try:
+            await never.wait()
+        finally:
+            stopped.set()
+
+    fence.register(fence.issue(), cleanup)
+    managed = ManagedTxAuthority(
+        FakeLane(), FakeConfigStore(None), fence, provider_generation=None
+    )
+    task = asyncio.create_task(
+        managed.shutdown(
+            retire_provider=lambda _: asyncio.sleep(0), termination=termination
+        )
+    )
+    try:
+        await asyncio.wait_for(started.wait(), 1)
+        termination.set()
+        assert (
+            await asyncio.wait_for(asyncio.shield(task), 1) is ShutdownResult.TERMINATED
+        )
+        assert stopped.is_set() and not never.is_set()
+        assert (await managed.snapshot()).state.release_required
+    finally:
+        never.set()
+        await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_isolation", [False, True])
+async def test_late_physical_on_retains_debt_until_a_fresh_off(
+    with_isolation: bool,
+) -> None:
+    clock, wakeup = FakeClock(), FakeWakeup()
+    started, allow_late_on, late_on, off_written = (
+        asyncio.Event() for _ in range(4)
+    )
+    writes: list[tuple[str, EffectToken]] = []
+
+    class Actuator:
+        async def actuate(self, token, operation):
+            if operation is ActuationOperation.TRANSMIT_ON:
+                started.set()
+                try:
+                    await allow_late_on.wait()
+                except asyncio.CancelledError:
+                    await allow_late_on.wait()
+                writes.append(("ON", token))
+                late_on.set()
+            elif operation is ActuationOperation.FORCE_RECEIVE:
+                writes.append(("OFF", token))
+                off_written.set()
+            return ActuationResult.ACCEPTED
+
+    async def isolate(generation: int) -> None:
+        await late_on.wait()
+
+    lane = ManagedTxEffectLane(
+        Actuator(), clock=clock, poison_generation=isolate if with_isolation else None
+    )
+    managed = ManagedTxAuthority(
+        lane,
+        FakeConfigStore(None),
+        TxAbortFence(),
+        provider_generation=7,
+        clock=clock,
+        wakeup=wakeup,
+        retry_delay_seconds=2,
+    )
+    await managed._stop_scheduler(managed._scheduler_task)
+    on = asyncio.create_task(managed.transmit_on())
+    await asyncio.wait_for(started.wait(), 1)
+    off = asyncio.create_task(managed.force_off())
+    try:
+        await asyncio.wait_for(off_written.wait(), 1)
+        allow_late_on.set()
+        await asyncio.wait_for(late_on.wait(), 1)
+        await asyncio.wait_for(asyncio.gather(on, off), 1)
+        state = (await managed.snapshot()).state
+        assert state.release_required
+        assert state.last_actuation.result is ActuationResult.UNCERTAIN
+        assert [value for value, _ in writes] == ["OFF", "ON"]
+        assert managed._retry_due is not None
+        clock.now = managed._retry_due
+        await managed._process_due()
+        assert [value for value, _ in writes] == ["OFF", "ON", "OFF"]
+        assert writes[0][1] != writes[-1][1]
+        assert not (await managed.snapshot()).state.release_required
+    finally:
+        allow_late_on.set()
+        await asyncio.gather(on, off)
+        if (await managed.snapshot()).state.release_required:
+            await managed.force_off()
+        await managed.close()

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -854,6 +854,38 @@ async def test_close_disposes_clean_scheduler_idempotently_without_effects() -> 
 
 
 @pytest.mark.asyncio
+async def test_cleanup_drain_reaps_done_task_before_queued_discard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed, _, _, _, fence, _ = authority()
+    await managed._stop_scheduler(managed._scheduler_task)
+    managed._pending_abort_cleanup.append(fence.force_off())
+    managed._start_abort_cleanup()
+    (cleanup,) = managed._abort_cleanup
+    gather = asyncio.gather
+
+    def bounded_gather(*tasks, **kwargs):
+        assert not tasks or not all(
+            isinstance(task, asyncio.Future) and task.done() for task in tasks
+        ), "drain awaited completed owned cleanup before queued discard"
+        return gather(*tasks, **kwargs)
+
+    async def drain() -> None:
+        assert cleanup.done() and cleanup in managed._abort_cleanup
+        with monkeypatch.context() as patch:
+            patch.setattr(asyncio, "gather", bounded_gather)
+            await managed._finish_abort_cleanup()
+        assert not managed._abort_cleanup
+
+    try:
+        await asyncio.create_task(drain())
+    finally:
+        cleanup.result()
+        managed._abort_cleanup.discard(cleanup)
+        await asyncio.wait_for(managed.close(), 1)
+
+
+@pytest.mark.asyncio
 async def test_ten_thousand_idempotent_commands_keep_one_scheduler() -> None:
     managed, _, _, _, _, lane = authority()
     scheduler = managed._scheduler_task

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -928,6 +928,8 @@ async def test_real_fence_releases_before_cleanup_and_shutdown_waits_for_cleanup
             assert not task.done() and retired == []
     finally:
         finish_cleanup.set()
+        if (await managed.snapshot()).provider_generation is None:
+            await managed.provider_available(8)
         await task
         await managed.close()
     assert retired == (

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -1079,6 +1079,54 @@ async def test_late_physical_on_retains_debt_until_a_fresh_off(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", ["termination", "late_on", "late_on_isolated"])
+async def test_startup_wait_failure_leaves_no_pending_tasks(
+    scenario: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    before = asyncio.all_tasks()
+    captured: dict[str, object] = {}
+    wait_for = asyncio.wait_for
+    task = None
+
+    async def fail_startup(awaitable, timeout):
+        if asyncio.current_task() is task and not captured:
+            frame = task.get_coro().cr_frame
+            assert frame is not None
+            assert awaitable.cr_code is asyncio.Event.wait.__code__
+            assert awaitable.cr_frame.f_locals["self"] is frame.f_locals["started"]
+            captured.update(frame.f_locals)
+            awaitable.close()
+            raise TimeoutError("injected startup wait failure")
+        return await wait_for(awaitable, timeout)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(asyncio, "wait_for", fail_startup)
+        task = asyncio.create_task(
+            test_shutdown_termination_cancels_owned_cleanup_without_waiting_for_gate()
+            if scenario == "termination"
+            else test_late_physical_on_retains_debt_until_a_fresh_off(
+                scenario == "late_on_isolated"
+            )
+        )
+        try:
+            done, _ = await asyncio.wait((task,), timeout=0.2)
+            assert captured, "startup fault did not reach the intended Event.wait"
+            assert task in done, "startup failure stranded scenario teardown"
+            with pytest.raises(TimeoutError, match="injected startup wait failure"):
+                task.result()
+            assert not (asyncio.all_tasks() - before), "startup failure leaked tasks"
+        finally:
+            for value in captured.values():
+                if isinstance(value, asyncio.Event):
+                    value.set()
+            pending = asyncio.all_tasks() - before
+            for pending_task in pending:
+                pending_task.cancel()
+            if pending:
+                await asyncio.wait(pending, timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_repeated_force_off_and_retry_leave_cleanup_owned_until_close() -> None:
     fence, clock = TxAbortFence(), FakeClock()
     cleanup_started, finish_cleanup = asyncio.Event(), asyncio.Event()

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -82,14 +82,16 @@ class FakeConfigStore:
 FenceOrderLog = list[tuple[str, object] | tuple[str]]
 
 
-class FakeFence:
+class FakeFence(TxAbortFence):
     def __init__(self, log: FenceOrderLog | None = None) -> None:
+        super().__init__()
         self.calls = 0
         self.log: FenceOrderLog = log if log is not None else []
 
-    async def force_off(self) -> None:
+    def force_off(self):
         self.calls += 1
         self.log.append(("fence",))
+        return super().force_off()
 
 
 class FakeLane:
@@ -1037,3 +1039,64 @@ async def test_late_physical_on_retains_debt_until_a_fresh_off(
         if (await managed.snapshot()).state.release_required:
             await managed.force_off()
         await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_repeated_force_off_and_retry_leave_cleanup_owned_until_close() -> None:
+    fence, clock = TxAbortFence(), FakeClock()
+    cleanup_started, finish_cleanup = asyncio.Event(), asyncio.Event()
+    calls: list[EffectToken] = []
+
+    class Actuator:
+        async def actuate(self, token, operation):
+            if operation is ActuationOperation.FORCE_RECEIVE:
+                calls.append(token)
+                if len(calls) == 1:
+                    return ActuationResult.REJECTED
+            return ActuationResult.ACCEPTED
+
+    async def cleanup() -> None:
+        cleanup_started.set()
+        await finish_cleanup.wait()
+
+    fence.register(fence.issue(), cleanup)
+    managed = ManagedTxAuthority(
+        ManagedTxEffectLane(Actuator(), clock=clock),
+        FakeConfigStore(None),
+        fence,
+        provider_generation=7,
+        clock=clock,
+    )
+    await managed._stop_scheduler(managed._scheduler_task)
+    try:
+        await asyncio.wait_for(managed.force_off(), 1)
+        await asyncio.wait_for(cleanup_started.wait(), 1)
+        assert managed._retry_due is not None
+        clock.now = managed._retry_due
+        await managed._process_due()
+        assert not (await managed.snapshot()).state.release_required
+        await managed.force_off()
+        assert len(set(calls)) == 3 and fence.epoch == 2
+        closing = asyncio.create_task(managed.close())
+        await asyncio.sleep(0)
+        assert not closing.done()
+    finally:
+        finish_cleanup.set()
+        await managed.close()
+    await closing
+
+
+@pytest.mark.asyncio
+async def test_ptt_up_does_not_cancel_unrelated_registered_work() -> None:
+    fence = TxAbortFence()
+    token = fence.issue()
+    cancelled: list[bool] = []
+    fence.register(token, lambda: cancelled.append(True))
+    managed = ManagedTxAuthority(
+        FakeLane(), FakeConfigStore(None), fence, provider_generation=7
+    )
+    await managed.ptt_down("owner")
+    assert await managed.ptt_up("other") is ManagedTxOutcome.REJECTED
+    assert await managed.ptt_up("owner") is ManagedTxOutcome.ACCEPTED
+    assert fence.is_current(token) and cancelled == []
+    await managed.close()

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -940,7 +940,9 @@ async def test_real_fence_releases_before_cleanup_and_shutdown_waits_for_cleanup
 
 
 @pytest.mark.asyncio
-async def test_shutdown_termination_cancels_owned_cleanup_without_waiting_for_gate() -> None:
+async def test_shutdown_termination_cancels_owned_cleanup_without_waiting_for_gate() -> (
+    None
+):
     fence = TxAbortFence()
     started, stopped, never, termination = (asyncio.Event() for _ in range(4))
 
@@ -979,9 +981,7 @@ async def test_late_physical_on_retains_debt_until_a_fresh_off(
     with_isolation: bool,
 ) -> None:
     clock, wakeup = FakeClock(), FakeWakeup()
-    started, allow_late_on, late_on, off_written = (
-        asyncio.Event() for _ in range(4)
-    )
+    started, allow_late_on, late_on, off_written = (asyncio.Event() for _ in range(4))
     writes: list[tuple[str, EffectToken]] = []
 
     class Actuator:
@@ -1100,3 +1100,39 @@ async def test_ptt_up_does_not_cancel_unrelated_registered_work() -> None:
     assert await managed.ptt_up("owner") is ManagedTxOutcome.ACCEPTED
     assert fence.is_current(token) and cancelled == []
     await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_can_be_rejoined_until_cleanup_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fence = TxAbortFence()
+    finish_cleanup, closing = asyncio.Event(), asyncio.Event()
+    fence.register(fence.issue(), finish_cleanup.wait)
+    managed = ManagedTxAuthority(
+        FakeLane(), FakeConfigStore(None), fence, provider_generation=7
+    )
+    await managed.force_off()
+    finish = managed._finish_abort_cleanup
+
+    async def tracked_finish() -> None:
+        closing.set()
+        await finish()
+
+    monkeypatch.setattr(managed, "_finish_abort_cleanup", tracked_finish)
+    first = asyncio.create_task(managed.close())
+    second = None
+    try:
+        await asyncio.wait_for(closing.wait(), 1)
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        second = asyncio.create_task(managed.close())
+        await asyncio.sleep(0)
+        assert not second.done()
+    finally:
+        finish_cleanup.set()
+        await asyncio.gather(first, return_exceptions=True)
+        if second is not None:
+            await second
+    assert managed._closed and not managed._closing

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -930,9 +930,14 @@ async def test_real_fence_releases_before_cleanup_and_shutdown_waits_for_cleanup
             assert not task.done() and retired == []
     finally:
         finish_cleanup.set()
+        if entry == "force_off" and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            await managed.force_off()
         if (await managed.snapshot()).provider_generation is None:
             await managed.provider_available(8)
-        await task
+        if not task.cancelled():
+            await task
         await managed.close()
     assert retired == (
         [] if entry == "force_off" else [8 if entry == "offline_shutdown" else 7]
@@ -1127,6 +1132,8 @@ async def test_cancelled_close_can_be_rejoined_until_cleanup_finishes(
         first.cancel()
         with pytest.raises(asyncio.CancelledError):
             await first
+        with pytest.raises(RuntimeError, match="closed"):
+            await managed.ptt_down("owner")
         second = asyncio.create_task(managed.close())
         await asyncio.sleep(0)
         assert not second.done()

--- a/tests/test_managed_tx_authority.py
+++ b/tests/test_managed_tx_authority.py
@@ -1008,8 +1008,9 @@ async def test_shutdown_termination_cancels_owned_cleanup_without_waiting_for_ga
         assert stopped.is_set() and not never.is_set()
         assert (await managed.snapshot()).state.release_required
     finally:
+        termination.set()
         never.set()
-        await task
+        await asyncio.wait_for(task, 1)
 
 
 @pytest.mark.asyncio
@@ -1053,9 +1054,10 @@ async def test_late_physical_on_retains_debt_until_a_fresh_off(
     )
     await managed._stop_scheduler(managed._scheduler_task)
     on = asyncio.create_task(managed.transmit_on())
-    await asyncio.wait_for(started.wait(), 1)
-    off = asyncio.create_task(managed.force_off())
+    off = None
     try:
+        await asyncio.wait_for(started.wait(), 1)
+        off = asyncio.create_task(managed.force_off())
         await asyncio.wait_for(off_written.wait(), 1)
         allow_late_on.set()
         await asyncio.wait_for(late_on.wait(), 1)
@@ -1072,10 +1074,11 @@ async def test_late_physical_on_retains_debt_until_a_fresh_off(
         assert not (await managed.snapshot()).state.release_required
     finally:
         allow_late_on.set()
-        await asyncio.gather(on, off)
-        if (await managed.snapshot()).state.release_required:
-            await managed.force_off()
-        await managed.close()
+        await asyncio.wait_for(asyncio.gather(on, *(() if off is None else (off,))), 1)
+        state = (await managed.snapshot()).state
+        if state.release_required or state.intent.kind is not ManagedTxIntentKind.RX:
+            await asyncio.wait_for(managed.force_off(), 1)
+        await asyncio.wait_for(managed.close(), 1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_effect_lane.py
+++ b/tests/test_managed_tx_effect_lane.py
@@ -266,11 +266,9 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
         assert not force.done() and not on_release.is_set()
         isolated.set()
     forced = await asyncio.wait_for(force, 0.2)
-    expected = (
-        ActuationResult.ACCEPTED if mode == "success" else ActuationResult.UNCERTAIN
-    )
-    assert forced.result is expected
+    assert forced.result is ActuationResult.UNCERTAIN
     errors = {
+        "success": "release preceded ON isolation",
         "failure": "isolation failed",
         "deadline": "isolation deadline expired",
         "cancel": "CancelledError",
@@ -282,6 +280,9 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
     if not preexisting:
         assert (await on).result is ActuationResult.UNCERTAIN
     on_release.set()
+    if mode == "success":
+        retry = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="retry")
+        assert (await settle(lane, retry)).result is ActuationResult.ACCEPTED
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_effect_lane.py
+++ b/tests/test_managed_tx_effect_lane.py
@@ -225,6 +225,7 @@ async def test_force_receive_bypasses_and_poisons_inflight_on() -> None:
         ("success", False),
         ("failure", False),
         ("success", True),
+        ("already_isolated", True),
         ("deadline", False),
         ("cancel", False),
     ],
@@ -235,6 +236,7 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
     actuator = FakeActuator()
     on_started, on_release = asyncio.Event(), asyncio.Event()
     isolation_started, isolated = asyncio.Event(), asyncio.Event()
+    off_started = asyncio.Event()
 
     async def isolate(_: int) -> None:
         isolation_started.set()
@@ -244,45 +246,66 @@ async def test_force_receive_awaits_isolation_and_maps_failure(
             raise asyncio.CancelledError
         await isolated.wait()
 
+    async def force_receive() -> ActuationResult:
+        off_started.set()
+        return ActuationResult.ACCEPTED
+
     actuator.actions[ActuationOperation.PTT_ON] = blocking_action(
         on_started, on_release, resist_cancellation=True
     )
+    actuator.actions[ActuationOperation.FORCE_RECEIVE] = force_receive
     lane = ManagedTxEffectLane(actuator, poison_generation=isolate)
     on = asyncio.create_task(settle(lane, effect(attempt="on")))
-    await asyncio.wait_for(on_started.wait(), 0.2)
-    if preexisting:
-        on.cancel()
-        assert (await on).error == "attempt cancelled after dispatch"
-        await asyncio.wait_for(isolation_started.wait(), 0.2)
-    force = asyncio.create_task(
-        settle(
-            lane,
-            effect(ActuationOperation.FORCE_RECEIVE, attempt="off"),
-            0.01 if mode == "deadline" else 1,
+    force = None
+    try:
+        await asyncio.wait_for(on_started.wait(), 0.2)
+        if preexisting:
+            on.cancel()
+            assert (await on).error == "attempt cancelled after dispatch"
+            await asyncio.wait_for(isolation_started.wait(), 0.2)
+        if mode == "already_isolated":
+            isolated.set()
+            assert lane._isolation is not None
+            await asyncio.wait_for(asyncio.shield(lane._isolation[1]), 0.2)
+        force = asyncio.create_task(
+            settle(
+                lane,
+                effect(ActuationOperation.FORCE_RECEIVE, attempt="off"),
+                0.01 if mode == "deadline" else 1,
+            )
         )
-    )
-    await asyncio.wait_for(isolation_started.wait(), 0.2)
-    if mode == "success":
-        assert not force.done() and not on_release.is_set()
+        await asyncio.wait_for(isolation_started.wait(), 0.2)
+        if mode == "success":
+            await asyncio.wait_for(off_started.wait(), 0.2)
+            assert not force.done() and not on_release.is_set()
+            isolated.set()
+        forced = await asyncio.wait_for(force, 0.2)
+        assert forced.result is (
+            ActuationResult.ACCEPTED
+            if mode == "already_isolated"
+            else ActuationResult.UNCERTAIN
+        )
+        errors = {
+            "success": "release preceded ON isolation",
+            "failure": "isolation failed",
+            "deadline": "isolation deadline expired",
+            "cancel": "CancelledError",
+        }
+        assert forced.error == errors.get(mode)
+        if mode == "deadline":
+            assert lane._isolation is not None and not lane._isolation[1].cancelled()
         isolated.set()
-    forced = await asyncio.wait_for(force, 0.2)
-    assert forced.result is ActuationResult.UNCERTAIN
-    errors = {
-        "success": "release preceded ON isolation",
-        "failure": "isolation failed",
-        "deadline": "isolation deadline expired",
-        "cancel": "CancelledError",
-    }
-    assert forced.error == errors.get(mode)
-    if mode == "deadline":
-        assert lane._isolation is not None and not lane._isolation[1].cancelled()
-    isolated.set()
-    if not preexisting:
-        assert (await on).result is ActuationResult.UNCERTAIN
-    on_release.set()
-    if mode == "success":
-        retry = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="retry")
-        assert (await settle(lane, retry)).result is ActuationResult.ACCEPTED
+        if not preexisting:
+            assert (await on).result is ActuationResult.UNCERTAIN
+        if mode in ("success", "already_isolated"):
+            retry = effect(ActuationOperation.FORCE_RECEIVE, epoch=4, attempt="retry")
+            assert (await settle(lane, retry)).result is ActuationResult.ACCEPTED
+    finally:
+        isolated.set()
+        on_release.set()
+        await asyncio.wait_for(
+            asyncio.gather(on, *(() if force is None else (force,))), 1
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_fence.py
+++ b/tests/test_managed_tx_fence.py
@@ -125,3 +125,48 @@ def test_another_fence_cannot_accept_this_fences_token() -> None:
     assert another.is_current(token) is False
     with pytest.raises(ValueError, match="current token"):
         another.register(token, lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_force_off_invalidates_at_call_and_keeps_each_batch_epoch() -> None:
+    fence = TxAbortFence()
+    old = fence.issue()
+    called: list[int] = []
+    fence.register(old, lambda: called.append(1))
+    first = fence.force_off()
+    try:
+        assert not fence.is_current(old)
+        assert called == []
+        second = await fence.force_off()
+        assert second.epoch == 2
+    finally:
+        result = await first
+    assert result.epoch == 1
+    assert called == [1]
+
+
+@pytest.mark.asyncio
+async def test_held_cleanup_does_not_starve_other_cancellations() -> None:
+    fence = TxAbortFence()
+    held, other, release = asyncio.Event(), asyncio.Event(), asyncio.Event()
+
+    async def first() -> None:
+        held.set()
+        await release.wait()
+
+    async def second() -> None:
+        other.set()
+        raise RuntimeError("cleanup failed")
+
+    fence.register(fence.issue(), first)
+    fence.register(fence.issue(), second)
+    cleanup = asyncio.create_task(fence.force_off())
+    try:
+        await asyncio.wait_for(held.wait(), 1)
+        await asyncio.wait_for(other.wait(), 1)
+        assert not cleanup.done()
+    finally:
+        release.set()
+        result = await cleanup
+    assert len(result.failures) == 1
+    assert str(result.failures[0].error) == "cleanup failed"


### PR DESCRIPTION
## Scope

Implements the owner-approved foundation correction tracked by [MOR-2230](https://linear.app/morozsm/issue/MOR-2230). Canonical contract/archive merged in [#3040](https://github.com/rigplane/rigplane-core/pull/3040).

- Invalidate the existing runtime abort fence at ForceOff, launch owned cancellation cleanup outside the authority lock, and dispatch urgent OFF without waiting for unrelated cleanup.
- Retain release debt if OFF starts before an old ON is isolated; require a fresh current-token OFF. No isolation callback means waiting for the actual displaced provider task.
- Reap completed cleanup directly during drain; keep cancelled close rejoinable without reopening ingress. PTT_UP stays owner-local.
- Pin bounded startup-failure cleanup and actual OFF-entry/isolation order with deterministic tests.

`TxAbortFence.force_off()` deliberately changes timing: invalidation occurs at call time; the returned coroutine performs cleanup when awaited. The awaited `TxAbortResult` shape remains, but API timing is not unchanged.

Production composition/actuators/producer wiring remain MOR-2165/MOR-2168. Fake write-order tests are not RF or hardware evidence. Buffered radio CW/tune stop semantics and effective provider isolation remain backend responsibilities. No new authority, watchdog, timer, flag, or public phase.

## Current source and review

Exact head: `509e9d2c4743e507bddac317ad8a79c779de24f5`.

[Independent exact-head code PASS](https://github.com/rigplane/rigplane-core/pull/3043#issuecomment-5516368943). The reviewer did not author code and returned the verdict before waiting for CI. All pre-merge verification is complete; see final evidence below. Draft status was cleared before guarded merge; merge and post-merge verification are complete.

Scope: six files, **567 additions / 63 deletions / 630 changed lines** against `7387c84ebfecaf1404f0e45357c2a575c07adf7b`. The 600-line soft threshold is exceeded solely for deterministic lifecycle/failure-path regressions and unconditional test cleanup reindentation; no new product layer. Within 10-file/1000-line hard ceiling. The additional runtime drain correction is four lines. Owner approved the additional bounded correction/review cycle on 2026-09-02 at20:48UTC.

## Verification

All execution was on Mini through the normal Actions queue. No local tests, syntax/import checks, formatters, lint, type checks, or hardware operations.

- Baseline exact main7387: [quick33673346140](https://github.com/rigplane/rigplane-core/actions/runs/33673346140): 14572 passed,218 skipped,16xfailed. Its skipped full run is not evidence.
- Initial tests-first [RED33675731865](https://github.com/rigplane/rigplane-core/actions/runs/33675731865):7failed/71passed. [Close-cancellation RED33676682165](https://github.com/rigplane/rigplane-core/actions/runs/33676682165):1expected failure before the close-rejoin correction.
- Additional tests-only source1ff4926f, production unchanged from03ce: [RED33682311812](https://github.com/rigplane/rigplane-core/actions/runs/33682311812), job100421522515, mm-build-core-2. Bounded structural/failure-path tests:3.11.16 four intended failures;3.12.14 and3.13.15 one intended drain failure each. The separate unmocked process printed verified done/owned/discard-pending ordering:3.11 completed,3.12/3.13 hit the external5s timeout(rc124) without DRAINED. Diagnostic job success means expected RED matched, not passing product tests.
- Current source509e: [GREEN33682679094](https://github.com/rigplane/rigplane-core/actions/runs/33682679094), job100422706392, mm-build-core-2, proof2c3a40fc. **86passed each on Python3.11.16/3.12.14/3.13.15**, with the same unmocked ordering completing(rc0/DRAINED) on all three. RuffPASS;715files formatted; import contracts5kept/0broken; mypy26files clean. Proof differs from reviewed source only in diagnostic workflow/files, excluded here.
- Current normal [full matrix33682968602](https://github.com/rigplane/rigplane-core/actions/runs/33682968602), required PR quick and final independent mutation evidence passed at source509e; detailed results follow below.

## Preserved failure history and limits

Old source03ce's focused81tests/quick were green, but [full33677324740](https://github.com/rigplane/rigplane-core/actions/runs/33677324740) FAILED: Python3.13 had5failed/14578passed/218skipped/16xfailed; four authority workers did not terminate and one lane fixture had an unjustified UNCERTAIN assertion. Python3.12 was cancelled and3.11 never ran; capture passed. Independent review changed to BLOCKED. The source-specific defects have now been corrected; the isolated drain reproduction does not prove that it caused each earlier worker crash.

First partial [mutation33677261145](https://github.com/rigplane/rigplane-core/actions/runs/33677261145): control7PASS and M1 killed with its expected failure, then M2 patch application failed; M2–M4 never ran. Corrected old proof [33677846875](https://github.com/rigplane/rigplane-core/actions/runs/33677846875) was cancelled while queued after03ce became BLOCKED: zero executed tests. Neither is final mutation acceptance. Earlier incomplete RED and masked formatter failure likewise are not counted as passing gates.

## Search before write

Read the canonical ADR, source definitions/consumer sets and live Linear acceptance before changes. Checked active PR/file ownership at base7387 and again for this correction; no overlap in owned files. Existing TxAbortFence, effect lane, provider isolation and debt/retry remain canonical. Complete Mini RED preceded production edits. No new consumer of the retiring observed-RF interlock.

Required pre-push command and literal output at this head:

```text
git grep -n 'tx_interlock' -- src/rigplane/core/command_dispatch.py 'src/rigplane/runtime/command*.py' src/rigplane/web/handlers/control.py
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1732:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1982:            decision = evaluate_tx_interlock(
```

Three existing handler references are unchanged. Zero matches in command_dispatch.py or the runtime command selection.


## Final verification and regression comparison

Normal full [33682968602](https://github.com/rigplane/rigplane-core/actions/runs/33682968602) completed SUCCESS at source509e. Python3.11.16,3.12.14,3.13.15 each passed **14588 tests**,218skipped,16xfailed (66.90/65.52/64.65s). All frontend matrix runs passed385files/8342tests; i18n/type/build/web Ruff/type/import gates passed. Capture:64captures,0invalid, artifact9867117108.

Exact-head PR quick [33682918461](https://github.com/rigplane/rigplane-core/actions/runs/33682918461) passed14589/220/16. It tested merge ref`ab21e0f12cbaa884c58c0a6b2aa787707384a8e5` (source509e+basebb74), not source alone. Reconciliation:
- Source full:14572 baseline+16newcases=14588.
- PR quick:14572+16source+3upstream−2existing static-index skips=14589.
- Upstream additions: `test_summary_log_names_sends_not_ok`, `test_send_failure_logs_the_failing_query_and_continues`, `test_direct_tx_frequency_max_age_falls_back_without_state_acquisition`.
- Existing skipped web tests: `test_root_returns_html` and `test_static_index_has_cache_control`, requiring built static index. No changed managed-TX case was skipped.

## Final mutation evidence

Immutable proof`037a3a183cc626d4f292d2428638775f78c8dfa3` has source/tests identical to509e. Both first execution and the one independently dispatched repeat of [run33683259804](https://github.com/rigplane/rigplane-core/actions/runs/33683259804) passed their diagnostic acceptance on Python3.13.15. The verifier read actual assertion context and all seven artifact members, not only counts.

| Intentional defect | First / independent repeat | Intended failure |
|---|---|---|
| M1 Await cleanup before OFF |1RED /1RED| `off_written.wait()` timeout after cleanup had started |
| M2 Defer synchronous invalidation |2RED /2RED| Old token incorrectly remains current, direct fence and offline shutdown |
| M3 Clear debt after early OFF |2RED /2RED| Release debt incorrectly cleared after late ON, both isolation modes |
| M4 Await callback under authority lock |1RED /1RED| `cleanup_started.wait()` timeout; callback blocked in snapshot reentry |
| M5 Rely only on queued discard |1RED /1RED| Completed-owned-task drain tripwire |

Each attempt: **12 control PASS before and12PASS after**, pytest rc1 for each mutation (not external timeout), reverse-patch and source-diff restoration confirmed.

- First: [job100424580097](https://github.com/rigplane/rigplane-core/actions/runs/33683259804/job/100424580097), Mini2; artifact9867147656 was fully read before repeating.
- Independent repeat: [job100426110380](https://github.com/rigplane/rigplane-core/actions/runs/33683259804/job/100426110380), Mini1; [artifact9867291757](https://github.com/rigplane/rigplane-core/actions/runs/33683259804/artifacts/9867291757). Artifact API now retains the attempt2 archive; attempt1 remains in job history.
- M5 is bounded structural RED. The separate unmocked RED/GREEN provides the actual spin reproduction. Neither asserts hardware/RF proof or direct causation of historical worker crashes.

Coordinator applied the independent reviewer's required body corrections: current exact head,630-line scope, actual completed evidence, preserved failed/cancelled history, and explicit production/RF boundary.



## Merge and post-merge

Merged2026-09-02T21:15:48Z as `6801f66da43b4a2d7b1dd06072205efb404df644`. [Post-merge main quick33684149854](https://github.com/rigplane/rigplane-core/actions/runs/33684149854) passed14589tests,220skipped,16xfailed, plus Ruff/format/import gates. All six scoped files equal the reviewed509e source. Merged tree`a92a5a18a2c5681211d8c1005e7af729968249da` equals PR quick's tested merge-refab21e0f tree. MOR-2230 and provider-neutral foundation MOR-2166 are Done; production integration and the TX epic remain open.

