### PR TITLE
fix: derive the tx_target observation max_age from one profile-aware source

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -61,6 +61,7 @@ from rigplane.core.state_pipeline_contracts import (
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.scope import ScopeFrame
 from rigplane.core.types import CivFrame, Mode, bcd_decode
+from rigplane.runtime._state_queries import tx_target_max_age
 from rigplane.runtime.meter_cal import interpolate_meter
 
 if TYPE_CHECKING:
@@ -2729,10 +2730,11 @@ class CivRuntime:
             (path.scope.value, path.family.value, path.name)
         )
         if path == FieldPath.global_("tx_state", "tx_target"):
-            acquisition = getattr(self._host._profile, "state_acquisition", None)
-            if acquisition is not None:
-                policy_ttl = acquisition.policy_for(path).freshness_ttl_seconds
-                max_age = policy_ttl
+            # MOR-2223: single source shared with
+            # ``RadioPoller._tx_target_max_age`` — see
+            # ``tx_target_max_age``'s docstring for the fail-open rationale
+            # this TTL exists to prevent.
+            max_age = tx_target_max_age(self._host._profile)
         return Observation(
             path=path,
             value=value,

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -255,3 +255,48 @@ def build_state_queries(profile: RadioProfile) -> list[AcquisitionQuery]:
         seen.add(query)
         queries.append(query)
     return queries
+
+
+_TX_TARGET_PATH = FieldPath.global_("tx_state", "tx_target")
+
+# Fallback for the derived tx_target field's own freshness TTL when a
+# profile has no [state_acquisition] block at all (MOR-1496 review R3, F1
+# follow-up). Renamed from ``_TX_TARGET_MIN_MAX_AGE`` (MOR-1501, #2422
+# review) — despite the "MIN" naming this is a straight substitute, not a
+# ``max()``-clamped floor: when a profile has no acquisition policy at all
+# there is no computed TTL to clamp against, so ``tx_target_max_age`` swaps
+# this value in outright. ``4 * fast_interval`` alone is not a defensible
+# TX-gate horizon: on a LAN profile (25ms fast interval) that floors to
+# 0.1s, which the verifier measured causing 6.6 stale-transitions/s on an
+# idle IC-705 (no [state_acquisition] block). Matches the concrete 3.0s
+# ``freshness_ttl_seconds`` IC-7300's own ``[state_acquisition]`` block
+# already uses for this same field via ``policy_for`` — not the unrelated
+# generic ``AcquisitionPolicy`` dataclass default (15.0s, calibrated for
+# slower-changing fields, not a TX gate).
+_TX_TARGET_FALLBACK_MAX_AGE: float = 3.0
+
+
+def tx_target_max_age(profile: RadioProfile) -> float:
+    """TTL for the derived ``global.tx_state.tx_target`` field (MOR-2223).
+
+    Without a finite max_age, ``StateStore.mark_stale_due`` skips the field
+    forever (it only ages entries with ``max_age`` set — see its own
+    docstring), so a stale input would silently freeze ``tx_target`` at its
+    last FRESH value instead of degrading — a fail-open on a TX gate.
+    Single source for both ``RadioPoller._tx_target_max_age`` (the poller's
+    own republish check) and ``CivRuntime._observation`` (the value the
+    field is actually stamped with when a CI-V response derives it): the two
+    used to compute this independently, and only one of the two fell back to
+    a finite value when the profile had no ``[state_acquisition]`` block.
+
+    Reuses the profile's declared TTL for this path — ``policy_for`` falls
+    back to ``default_policy`` for any path with no declared capability
+    (3.0s on IC-7300) — falling back to ``_TX_TARGET_FALLBACK_MAX_AGE`` when
+    the profile has no ``state_acquisition`` block, or when the resolved
+    policy leaves ``freshness_ttl_seconds`` unset.
+    """
+    acquisition = profile.state_acquisition
+    if acquisition is None:
+        return _TX_TARGET_FALLBACK_MAX_AGE
+    ttl = acquisition.policy_for(_TX_TARGET_PATH).freshness_ttl_seconds
+    return ttl if ttl is not None else _TX_TARGET_FALLBACK_MAX_AGE

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -116,6 +116,7 @@ from .._state_queries import (
     build_state_queries,
 )
 from ..profiles import RadioProfile, resolve_radio_profile
+from ..runtime._state_queries import tx_target_max_age
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..runtime.tx_interlock import (
     DeferredTxCommandLane,
@@ -235,22 +236,6 @@ _WEB_IMMEDIATE_BLOCK_FAMILIES = (
     TxInterlockCommandFamily.PTT_ON,
 )
 
-
-# Fallback for the derived tx_target field's own freshness TTL when a
-# profile has no [state_acquisition] block at all (MOR-1496 review R3, F1
-# follow-up). Renamed from ``_TX_TARGET_MIN_MAX_AGE`` (MOR-1501, #2422
-# review) — despite the "MIN" naming this is a straight substitute, not a
-# ``max()``-clamped floor: when a profile has no acquisition policy at all
-# there is no computed TTL to clamp against, so ``_tx_target_max_age`` swaps
-# this value in outright. ``4 * self._fast_interval`` alone is not a
-# defensible TX-gate horizon: on a LAN profile (``_FAST_INTERVAL`` = 25ms)
-# that floors to 0.1s, which the verifier measured causing 6.6
-# stale-transitions/s on an idle IC-705 (no [state_acquisition] block).
-# Matches the concrete 3.0s ``freshness_ttl_seconds`` IC-7300's own
-# ``[state_acquisition]`` block already uses for this same field via
-# ``policy_for`` — not the unrelated generic ``AcquisitionPolicy`` dataclass
-# default (15.0s, calibrated for slower-changing fields, not a TX gate).
-_TX_TARGET_FALLBACK_MAX_AGE: float = 3.0
 
 _KEY_ACCEPTED = frozenset({TxOutcome.ACCEPTED, TxOutcome.IDEMPOTENT})  # lease is ours
 
@@ -4084,30 +4069,19 @@ class RadioPoller:
         )
 
     def _tx_target_max_age(self) -> float:
-        """TTL for the derived ``tx_target`` field itself (review R2, F1).
+        """TTL for the derived ``tx_target`` field itself (MOR-2223).
 
-        Without this, ``StateStore.mark_stale_due`` skips the field forever
-        (it only ages entries with ``max_age`` set — see its own docstring),
-        so a stale input would silently freeze ``tx_target`` at its last
-        FRESH value instead of degrading, a fail-open on a TX gate. Reuses
-        this profile's default acquisition TTL — ``policy_for`` falls back
-        to ``default_policy`` for any path with no declared capability (3.0s
-        on IC-7300) — which needs no capability declaration for
-        ``tx_target`` itself; see :meth:`_publish_tx_target` for why that
-        declaration must never exist. Falls back to
-        ``_TX_TARGET_FALLBACK_MAX_AGE`` (a fixed default, not a bare multiple
-        of the poll loop's own fast interval — see that constant's comment)
-        if a profile has no acquisition policy at all.
+        Delegates to :func:`tx_target_max_age`, the single source shared
+        with ``CivRuntime._observation`` — see that function's docstring for
+        the fail-open rationale and the fallback it applies. Needs no
+        capability declaration for ``tx_target`` itself; see
+        :meth:`_publish_tx_target` for why that declaration must never
+        exist.
         """
-        acquisition = self._profile.state_acquisition
-        ttl = (
-            None
-            if acquisition is None
-            else acquisition.policy_for(
-                FieldPath.global_("tx_state", "tx_target")
-            ).freshness_ttl_seconds
-        )
-        return ttl if ttl is not None else _TX_TARGET_FALLBACK_MAX_AGE
+        # mypy --strict src/rigplane/web's own follow_imports=skip means the
+        # cross-package call resolves to Any; float(...) makes the strict
+        # return-type explicit rather than suppressing the check.
+        return float(tx_target_max_age(self._profile))
 
     def _publish_tx_target(self) -> None:
         """Recompute and, if changed or stale, republish tx_target (MOR-1496).

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -31,6 +31,7 @@ Covers missing lines:
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import time
 from collections.abc import Generator
 from typing import Any
@@ -4186,6 +4187,26 @@ def test_update_radio_state_tx_freq_monitor_decodes_transmit_frequency_not_boole
     )
     with pytest.raises(KeyError):
         snapshot.field("global.tx_state.tx_freq_monitor")
+
+
+def test_direct_tx_frequency_max_age_falls_back_without_state_acquisition(
+    radio_with_state: IcomRadio,
+) -> None:
+    """MOR-2223: with no [state_acquisition] block on the profile, the
+    directed 1C/03 response still gets a finite max_age on tx_target — the
+    shared fallback — instead of aging forever (StateStore.mark_stale_due
+    only ages entries with max_age set)."""
+    radio_with_state._profile = dataclasses.replace(
+        radio_with_state._profile, state_acquisition=None
+    )
+    frame = parse_civ_frame(bytes.fromhex("FE FE E0 98 1C 03 00 00 10 07 00 FD"))
+    radio_with_state._civ_runtime._update_state_cache_from_frame(frame)
+
+    field = radio_with_state._state_store.snapshot().field("global.tx_state.tx_target")
+    assert field.value == KnownTxTarget(
+        receiver="MAIN", slot=None, frequency_hz=7_100_000
+    )
+    assert field.max_age == 3.0
 
 
 def test_direct_tx_frequency_coexists_with_ic7300_derived_target() -> None:


### PR DESCRIPTION
Linear: MOR-2223

Same value — the freshness TTL/max_age for the derived
`global.tx_state.tx_target` field — was derived twice with different
fallbacks (found by a mechanism audit at 3683b297).

Site 1, `web/radio_poller.py: RadioPoller._tx_target_max_age` (at merge-base
b197b09a):

```python
    def _tx_target_max_age(self) -> float:
        """TTL for the derived ``tx_target`` field itself (review R2, F1).

        Without this, ``StateStore.mark_stale_due`` skips the field forever
        (it only ages entries with ``max_age`` set — see its own docstring),
        so a stale input would silently freeze ``tx_target`` at its last
        FRESH value instead of degrading, a fail-open on a TX gate. Reuses
        this profile's default acquisition TTL — ``policy_for`` falls back
        to ``default_policy`` for any path with no declared capability (3.0s
        on IC-7300) — which needs no capability declaration for
        ``tx_target`` itself; see :meth:`_publish_tx_target` for why that
        declaration must never exist. Falls back to
        ``_TX_TARGET_FALLBACK_MAX_AGE`` (a fixed default, not a bare multiple
        of the poll loop's own fast interval — see that constant's comment)
        if a profile has no acquisition policy at all.
        """
        acquisition = self._profile.state_acquisition
        ttl = (
            None
            if acquisition is None
            else acquisition.policy_for(
                FieldPath.global_("tx_state", "tx_target")
            ).freshness_ttl_seconds
        )
        return ttl if ttl is not None else _TX_TARGET_FALLBACK_MAX_AGE
```

Site 2, `runtime/_civ_rx.py: CivRuntime._observation` (added by PR #3020, at
merge-base b197b09a):

```python
        max_age = _OBSERVATION_MAX_AGE_SECONDS.get(
            (path.scope.value, path.family.value, path.name)
        )
        if path == FieldPath.global_("tx_state", "tx_target"):
            acquisition = getattr(self._host._profile, "state_acquisition", None)
            if acquisition is not None:
                policy_ttl = acquisition.policy_for(path).freshness_ttl_seconds
                max_age = policy_ttl
```

Site 1 falls back to `3.0` when the profile has no `[state_acquisition]`
block. Site 2 does not: `max_age` stays `None`, and `StateStore.mark_stale_due`
only ages entries with `max_age` set, so the field never ages — a fail-open
on a TX gate, reachable only with an unsolicited/echoed `1C 03` frame on a
caller-supplied profile without `[state_acquisition]` (all shipped CI-V
rigs have the block).

## Search before write

Searched `git grep -n "freshness_ttl_seconds\|max_age" -- src/rigplane/runtime
src/rigplane/core src/rigplane/profiles` and `git grep -n "policy_for" --
src/rigplane`. Nearest existing thing: `core/observation_adapter.py:
ProviderObservationAdapter.observation`, which does the same
`profile.policy_for(path).freshness_ttl_seconds` lookup — but its `profile`
field is typed `RadioAcquisitionProfile` (non-optional, used by other
backends' observation adapters, e.g. `backends/rigctld_client/observations.py`)
and it has no fallback for a profile with no acquisition block at all or a
policy with `freshness_ttl_seconds=None`, which is exactly what both
MOR-2223 sites need. Nothing else in `runtime/`, `core/`, or `profiles/`
combines "TTL for a field path" with "fallback when the profile has no
`state_acquisition`". Added one function.

## Fix

Added `runtime/_state_queries.py: tx_target_max_age(profile)` — the lowest
layer both callers already import (`web/radio_poller.py` already imports
`build_state_queries` from this module via the `.._state_queries` shim;
`runtime/_civ_rx.py` is a sibling module in the same package). Both call
sites now delegate to it; the `3.0` fallback constant lives in exactly one
place. `RadioPoller._tx_target_max_age`'s docstring sentences that duplicated
the fail-open rationale were deleted (not rewritten) in favor of pointing at
the new function's docstring, which keeps that rationale. The `_civ_rx.py`
site's `getattr(..., "state_acquisition", None)` defensive lookup was
removed — the host's `_profile` is declared `RadioProfile` in the
`CivRuntimeHost` protocol, and the shared function's own parameter type
already commits to that.

## Test and mutation

New test: `tests/test_civ_rx_coverage.py:
test_direct_tx_frequency_max_age_falls_back_without_state_acquisition`.
Builds an IC-7610 profile with `state_acquisition=None`
(`dataclasses.replace(radio_with_state._profile, state_acquisition=None)`,
the same pattern `tests/test_radio_poller_coverage.py` already uses), feeds
`FE FE E0 98 1C 03 00 00 10 07 00 FD` through
`CivRuntime._update_state_cache_from_frame`, and asserts the stored
`global.tx_state.tx_target` observation has `max_age == 3.0`.

Mutation: in `tx_target_max_age`, changed `return
_TX_TARGET_FALLBACK_MAX_AGE` (the `acquisition is None` branch) to `return
None`, reinstating exactly the bug MOR-2223 describes for the no-acquisition
case.
- `uv run pytest tests/test_civ_rx_coverage.py -k
  test_direct_tx_frequency_max_age_falls_back_without_state_acquisition`:
  1 failed (`assert None == 3.0`) — kill confirmed.
- `uv run pytest tests/test_radio_poller_coverage.py -k
  test_tx_target_max_age_floors_fallback_for_profile_without_acquisition`
  (pre-existing test covering the other call site through the same shared
  function): 1 failed (`assert None == 3.0`) — kill confirmed on both call
  sites.
- Reverted the mutation by re-editing the exact line back (not
  `git checkout`, since the fix itself was still uncommitted at that point);
  confirmed no `MUTATION` marker remains via `grep -rn MUTATION src/ tests/`
  restricted to files this PR touches.
- Reran both tests green: `uv run pytest tests/test_civ_rx_coverage.py
  tests/test_civ_rx_dispatch_golden.py tests/test_civ_rx_mixin_host.py
  tests/test_civ_rx_short_frame_robustness.py
  tests/test_radio_poller_coverage.py tests/test_state_pipeline_contracts.py`:
  915 passed.

## Gates

- `uv run ruff check src/ tests/`: all checks passed.
- `uv run ruff format src/ tests/`: 1 file reformatted (line-length
  collapse in the new test), then clean.
- `uv run lint-imports`: 5 kept, 0 broken.
- `uv run mypy --strict src/rigplane/web`: 1 error initially
  (`no-any-return` on `_tx_target_max_age` — the module's
  `follow_imports = "skip"` resolves the cross-package call to `Any`),
  fixed with an explicit `float(...)` wrap; success after, 26 source files.

```
$ git diff b197b09a5f4f718ba95f91c50e22c7421e0441e7 --stat
 src/rigplane/runtime/_civ_rx.py        | 10 ++++---
 src/rigplane/runtime/_state_queries.py | 45 +++++++++++++++++++++++++++++
 src/rigplane/web/radio_poller.py       | 52 +++++++++-------------------------
 tests/test_civ_rx_coverage.py          | 21 ++++++++++++++
 4 files changed, 85 insertions(+), 43 deletions(-)
```

full suite: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
