### PR TITLE
feat(segmentline): mount the peer-split glass inside the LCD shell

### DIFF
--- a/frontend/src/__tests__/presentation-switch-resources.component.test.ts
+++ b/frontend/src/__tests__/presentation-switch-resources.component.test.ts
@@ -212,9 +212,10 @@ const SKIN_PLAN: Record<SkinId, readonly AppResource[]> = {
   'lcd-cockpit': ['audio-fft'],
   'lcd-scope': ['audio-fft'],
   'mobile': ['hardware-scope'],
-  // MOR-2155: same reasoning as `dual-receiver-cockpit` above — the minimal
-  // shell mounts no scope panel of either kind.
-  'peer-split': [],
+  // MOR-2153 PR-1: `peer-split` now mounts the LCD shell, reusing
+  // `RightSidebar`'s `AudioSpectrumPanel` — the same `audio-fft` producer
+  // `lcd-cockpit`/`lcd-scope` already demand it for.
+  'peer-split': ['audio-fft'],
   'sdr-test': ['hardware-scope', 'audio-fft'],
 };
 

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -18,6 +18,7 @@
   import { applyModeDefault } from '$lib/stores/tuning.svelte';
   import AmberCockpit from '../panels/lcd/AmberCockpit.svelte';
   import AmberScope from '../panels/lcd/AmberScope.svelte';
+  import PeerSplitLayout from '../../skins/segmentline/PeerSplitLayout.svelte';
   import LcdContrastControl from '../panels/lcd/LcdContrastControl.svelte';
   import LcdDisplayModeControl from '../panels/lcd/LcdDisplayModeControl.svelte';
   import { getLcdDisplayMode } from '$lib/stores/lcd-display-mode.svelte';
@@ -30,10 +31,10 @@
   import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
   import { getKeyboardHandlers } from '$lib/runtime/adapters/panel-adapters';
 
-  // Twin-skin variant selector (#887). Default preserves today's behavior.
-  // `scope` currently falls through to cockpit until C-PR1 (#895) delivers
-  // a dedicated AmberScope component.
-  let { variant = 'cockpit' }: { variant?: 'cockpit' | 'scope' } = $props();
+  // Twin-skin variant selector (#887), widened to three by MOR-2153 PR-1.
+  // Default preserves today's behavior. `scope` currently falls through to
+  // cockpit until C-PR1 (#895) delivers a dedicated AmberScope component.
+  let { variant = 'cockpit' }: { variant?: 'cockpit' | 'scope' | 'peer-split' } = $props();
 
   let radioState = $derived(runtime.state);
   let keyboardConfig = $derived(getKeyboardConfig());
@@ -82,7 +83,7 @@
     </div>
 
     <main class="content-center">
-      <div class="lcd-slot">
+      <div class="lcd-slot" data-lcd-variant={variant}>
         <div
           class="lcd-frame lcd-mode-{displayMode}"
           data-lcd-variant={variant}
@@ -90,6 +91,8 @@
         >
           {#if variant === 'scope'}
             <AmberScope />
+          {:else if variant === 'peer-split'}
+            <PeerSplitLayout />
           {:else}
             <AmberCockpit />
           {/if}
@@ -102,15 +105,25 @@
     </main>
 
     <!-- MOR-1092: the LCD's VFO facts and TX action are owned by the semantic
-         surfaces (MOR-1063/1064), wired exactly once by SemanticRadioSurfaces
-         — no new TX path. The legacy TX panel is suppressed on BOTH sidebars
-         (a cross-sidebar drag can move it), and VfoControlPanel drops the two
-         facts the surface now presents. The amber glass keeps its legacy
-         presentation for this slice; MOR-1162 redesigns it. -->
+         surfaces (MOR-1063/1064). For `cockpit`/`scope`, wired exactly once
+         here by SemanticRadioSurfaces — no new TX path. `peer-split`'s glass
+         (`PeerSplitLayout.svelte`) mounts its own `SemanticRadioSurfaces
+         strips="dual"` instead, so this slot is suppressed for that variant
+         (MOR-2153 PR-1) — each SemanticRadioSurfaces instance takes a
+         distinct TX-lease `sourceId` from its own module-level counter
+         (`components-v2/wiring/SemanticRadioSurfaces.svelte`), so two
+         mounted instances would not crash, just silently duplicate the TX
+         affordance. The legacy TX panel is suppressed on BOTH sidebars for
+         every variant (a cross-sidebar drag can move it), and
+         VfoControlPanel drops the two facts the surface now presents. The
+         amber glass (`cockpit`/`scope`) keeps its legacy presentation for
+         this slice; MOR-1162 redesigns it. -->
     <div class="content-right">
-      <div class="semantic-slot">
-        <SemanticRadioSurfaces />
-      </div>
+      {#if variant !== 'peer-split'}
+        <div class="semantic-slot">
+          <SemanticRadioSurfaces />
+        </div>
+      {/if}
       <VfoControlPanel hideVfoFacts />
       <RightSidebar hideTxPanel />
     </div>
@@ -217,6 +230,18 @@
     max-height: 100%;
   }
 
+  /* `peer-split`'s glass (`PeerSplitLayout.svelte`) is a fixed 1280x540
+     native stage (`ScaledStage nativeW={1280} nativeH={540}`), not the
+     fluid 16/7.5 the amber cockpit/scope variants were tuned for — 1280/540
+     ≈ 2.370 vs 16/7.5 ≈ 2.133. Matching the slot to the glass's own ratio
+     means the frame hits `ScaledStage`'s max-scale-1 clamp on both axes at
+     once instead of one axis being starved by a mismatched frame shape,
+     which minimises the dead space the fixed-native model already produces
+     (see the centring rule below) rather than adding to it. */
+  .lcd-slot[data-lcd-variant='peer-split'] {
+    aspect-ratio: 1280 / 540;
+  }
+
   .lcd-frame {
     flex: 1;
     min-height: 0;
@@ -225,6 +250,27 @@
     background: var(--v2-bg-card);
     border: 1px solid var(--v2-border-darker);
     border-radius: 4px;
+  }
+
+  /* Centres `PeerSplitLayout`'s ScaledStage-wrapped glass inside `.lcd-frame`.
+     `ScaledStage`'s own `.scaled-stage-holder` (primitives/stage/
+     ScaledStage.svelte) never centres its child — read directly: no
+     display:flex/align-items/justify-content on that class — so this reaches
+     in via :global() rather than editing the shared primitive. It only
+     changes how the holder lays out its OWN child; the holder's own box is
+     untouched, so ScaledStage's ResizeObserver measurement is unaffected.
+
+     Exact only when the computed scale is 1 (native fits inside the frame —
+     the common desktop case this rule targets, given the aspect-ratio match
+     above): ScaledStage's `transform-origin: top left` means a scale < 1
+     still leaves a bottom-right-skewed remainder, because the transform
+     shrinks the (now flex-centred) box toward its own corner, not its
+     centre. Fixing that fully needs a centred transform-origin inside
+     ScaledStage itself — a separate decision, out of scope here. */
+  .lcd-frame[data-lcd-variant='peer-split'] :global(.scaled-stage-holder) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
 </style>

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -237,7 +237,7 @@
      means the frame hits `ScaledStage`'s max-scale-1 clamp on both axes at
      once instead of one axis being starved by a mismatched frame shape,
      which minimises the dead space the fixed-native model already produces
-     (see the centring rule below) rather than adding to it. */
+     rather than adding to it. */
   .lcd-slot[data-lcd-variant='peer-split'] {
     aspect-ratio: 1280 / 540;
   }
@@ -251,26 +251,4 @@
     border: 1px solid var(--v2-border-darker);
     border-radius: 4px;
   }
-
-  /* Centres `PeerSplitLayout`'s ScaledStage-wrapped glass inside `.lcd-frame`.
-     `ScaledStage`'s own `.scaled-stage-holder` (primitives/stage/
-     ScaledStage.svelte) never centres its child — read directly: no
-     display:flex/align-items/justify-content on that class — so this reaches
-     in via :global() rather than editing the shared primitive. It only
-     changes how the holder lays out its OWN child; the holder's own box is
-     untouched, so ScaledStage's ResizeObserver measurement is unaffected.
-
-     Exact only when the computed scale is 1 (native fits inside the frame —
-     the common desktop case this rule targets, given the aspect-ratio match
-     above): ScaledStage's `transform-origin: top left` means a scale < 1
-     still leaves a bottom-right-skewed remainder, because the transform
-     shrinks the (now flex-centred) box toward its own corner, not its
-     centre. Fixing that fully needs a centred transform-origin inside
-     ScaledStage itself — a separate decision, out of scope here. */
-  .lcd-frame[data-lcd-variant='peer-split'] :global(.scaled-stage-holder) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
 </style>

--- a/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
@@ -47,11 +47,11 @@ describe('the peer-split entrypoint is registered in the real registry', () => {
   // `segmentline/PeerSplitLayout.svelte` to the LCD-shell wrapper
   // `lcd-peer-split/LcdPeerSplitSkin.svelte` — the manifest declares no
   // opinion on which component sits behind the SkinId, only that one does.
-  // `PeerSplitLayout.svelte`'s own reachability is covered by the next test
-  // below (`declares a compiled loader`), which pins `peerSplitLayout.loader`
-  // — a real function built from `segmentline-declarations.ts`'s own
-  // `import()` of that file — so dropping the direct-loader claim here is
-  // not a loss of coverage.
+  // `PeerSplitLayout.svelte`'s own reachability is pinned separately, by
+  // `loader-identity-inventory.test.ts`'s `EXPECTED_LOADER_SPECIFIER['peer-split']`
+  // — not by the next test below (`declares a compiled loader`), which only
+  // asserts `typeof peerSplitLayout.loader === 'function'` and cannot tell
+  // that loader from one pointing at any other loadable module.
   it('keeps a `peer-split` key in the skin registry loader table', () => {
     const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
     expect(registrySource).toMatch(/'peer-split':\s*\(\)\s*=>\s*import\(/);

--- a/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
@@ -41,12 +41,20 @@ describe('the peer-split entrypoint is registered in the real registry', () => {
     expect(peerSplitLayout.id).toBe('peer-split');
   });
 
-  // Kills: a manifest id that drifts from the SkinId PeerSplitLayout.svelte
-  // actually loads under. The manifest is only an entrypoint declaration if
-  // the two agree.
-  it('shares its id with the skin registry loader PeerSplitLayout.svelte resolves under', () => {
+  // Kills: removing or renaming the 'peer-split' key in SKIN_LOADERS — the
+  // manifest id would then have no addressable skin to activate under. Not
+  // pinned: which module the key imports. MOR-2153 PR-1 retargeted it from
+  // `segmentline/PeerSplitLayout.svelte` to the LCD-shell wrapper
+  // `lcd-peer-split/LcdPeerSplitSkin.svelte` — the manifest declares no
+  // opinion on which component sits behind the SkinId, only that one does.
+  // `PeerSplitLayout.svelte`'s own reachability is covered by the next test
+  // below (`declares a compiled loader`), which pins `peerSplitLayout.loader`
+  // — a real function built from `segmentline-declarations.ts`'s own
+  // `import()` of that file — so dropping the direct-loader claim here is
+  // not a loss of coverage.
+  it('keeps a `peer-split` key in the skin registry loader table', () => {
     const registrySource = readFileSync('src/skins/registry.ts', 'utf8');
-    expect(registrySource).toMatch(/'peer-split':\s*\(\)\s*=>\s*import\(['"]\.\/segmentline\/PeerSplitLayout\.svelte['"]\)/);
+    expect(registrySource).toMatch(/'peer-split':\s*\(\)\s*=>\s*import\(/);
   });
 
   // Kills: a manifest that declares no compiled loader at all.

--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -38,27 +38,28 @@
  *    `?raw`-imported it as a text fixture — so it now gets a real mount pin
  *    instead (below), the same way `lcd-cockpit`/`lcd-scope` do.
  *
- * `lcd-cockpit`/`lcd-scope` get a real mount pin for the first time here.
- * Both wrappers are zero-prop and hardcode a `variant` literal into
- * `LcdLayout`; the `variant` prop's shape
- * (`variant?: 'cockpit' | 'scope'`) is already pinned on LcdLayout itself by
+ * `lcd-cockpit`/`lcd-scope`/`peer-split` get a real mount pin for the first
+ * time here. All three wrappers are zero-prop and hardcode a `variant`
+ * literal into `LcdLayout`; the `variant` prop's shape
+ * (`variant?: 'cockpit' | 'scope' | 'peer-split'`) is already pinned on
+ * LcdLayout itself by
  * `components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts`
  * and `...autostep-lifecycle.isolated.test.ts` — nothing here duplicates
- * that. This file pins only the two wrappers' half: that each forwards its
- * own literal down, not LcdLayout's behavior for either value.
+ * that. This file pins only each wrapper's half: that it forwards its own
+ * literal down, not LcdLayout's behavior for any value. `peer-split`
+ * (MOR-2153 PR-1) moved into this bucket from a standalone
+ * `SemanticRadioSurfaces`-mount pin once its entry component became
+ * `lcd-peer-split/LcdPeerSplitSkin.svelte` — a wrapper of the same shape as
+ * `LcdCockpitSkin.svelte`/`LcdScopeSkin.svelte` — rather than
+ * `skins/segmentline/PeerSplitLayout.svelte` directly; the duplicate-surface
+ * risk that move creates is pinned separately, in
+ * `skins/lcd-peer-split/__tests__/LcdPeerSplitSkin.component.test.ts`.
  *
  * `mobile` gets a real mount pin the same way: `MobileSkin.svelte` is a
  * zero-prop delegate straight to `MobileRadioLayout`, so its pin mocks
  * `MobileRadioLayout.svelte` (the same technique as the `RadioLayout`/
  * `LcdLayout` mocks above) and asserts that loading `mobile` actually
  * mounts it.
- *
- * `peer-split` (MOR-2155) gets the same real-mount treatment: its entry
- * component (`skins/segmentline/PeerSplitLayout.svelte`) is a zero-prop
- * delegate straight to `SemanticRadioSurfaces` with `strips="dual"`, so its
- * pin mocks `SemanticRadioSurfaces.svelte` and asserts the `strips` value
- * actually forwarded — the same `variant`-forwarding shape the LCD wrappers
- * pin above, one prop earlier in the chain.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { mount, unmount } from 'svelte';
@@ -66,9 +67,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SkinId } from '../registry';
 
 const mountedSkinIds = vi.hoisted(() => [] as SkinId[]);
-const mountedLcdVariants = vi.hoisted(() => [] as Array<'cockpit' | 'scope'>);
+const mountedLcdVariants = vi.hoisted(() => [] as Array<'cockpit' | 'scope' | 'peer-split'>);
 const mobileLayoutMounts = vi.hoisted(() => ({ count: 0 }));
-const mountedStrips = vi.hoisted(() => [] as Array<'single' | 'dual'>);
 
 vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
   default: (_anchor: unknown, props: { skinId?: SkinId }) => {
@@ -77,7 +77,7 @@ vi.mock('../../components-v2/layout/RadioLayout.svelte', () => ({
 }));
 
 vi.mock('../../components-v2/layout/LcdLayout.svelte', () => ({
-  default: (_anchor: unknown, props: { variant?: 'cockpit' | 'scope' }) => {
+  default: (_anchor: unknown, props: { variant?: 'cockpit' | 'scope' | 'peer-split' }) => {
     if (props.variant) mountedLcdVariants.push(props.variant);
   },
 }));
@@ -90,14 +90,6 @@ vi.mock('../../components-v2/layout/MobileRadioLayout.svelte', () => ({
   },
 }));
 
-// PeerSplitLayout takes no props (`<SemanticRadioSurfaces strips="dual" />`);
-// what is worth pinning is the `strips` literal it forwards.
-vi.mock('../../components-v2/wiring/SemanticRadioSurfaces.svelte', () => ({
-  default: (_anchor: unknown, props: { strips?: 'single' | 'dual' }) => {
-    mountedStrips.push(props.strips ?? 'single');
-  },
-}));
-
 import { loadSkin } from '../registry';
 
 const components: Record<string, unknown>[] = [];
@@ -107,14 +99,12 @@ afterEach(() => {
   mountedSkinIds.length = 0;
   mountedLcdVariants.length = 0;
   mobileLayoutMounts.count = 0;
-  mountedStrips.length = 0;
 });
 
 type EntrypointCoverage =
   | { readonly kind: 'radio-layout' }
-  | { readonly kind: 'lcd-layout'; readonly variant: 'cockpit' | 'scope' }
+  | { readonly kind: 'lcd-layout'; readonly variant: 'cockpit' | 'scope' | 'peer-split' }
   | { readonly kind: 'mobile-layout' }
-  | { readonly kind: 'semantic-radio-surfaces'; readonly strips: 'single' | 'dual' }
   | { readonly kind: 'covered-elsewhere'; readonly testFile: string; readonly entryComponentFile: string };
 
 /**
@@ -132,7 +122,7 @@ const SKIN_ENTRYPOINT_COVERAGE: Readonly<Record<SkinId, EntrypointCoverage>> = {
     entryComponentFile: 'DualReceiverCockpit.svelte',
   },
   mobile: { kind: 'mobile-layout' },
-  'peer-split': { kind: 'semantic-radio-surfaces', strips: 'dual' },
+  'peer-split': { kind: 'lcd-layout', variant: 'peer-split' },
 };
 
 const allSkinIds = Object.keys(SKIN_ENTRYPOINT_COVERAGE) as SkinId[];
@@ -145,11 +135,6 @@ const lcdLayoutCases = allSkinIds.flatMap((id) => {
 });
 
 const mobileLayoutSkinIds = allSkinIds.filter((id) => SKIN_ENTRYPOINT_COVERAGE[id].kind === 'mobile-layout');
-
-const semanticRadioSurfacesCases = allSkinIds.flatMap((id) => {
-  const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
-  return coverage.kind === 'semantic-radio-surfaces' ? [[id, coverage.strips] as const] : [];
-});
 
 const coveredElsewhereCases = allSkinIds.flatMap((id) => {
   const coverage = SKIN_ENTRYPOINT_COVERAGE[id];
@@ -169,9 +154,9 @@ describe('desktop skin entrypoints', () => {
 });
 
 describe('LCD skin entrypoints', () => {
-  // Kills: LcdCockpitSkin/LcdScopeSkin forwarding the wrong `variant`
-  // literal to LcdLayout, forwarding the other skin's literal, or dropping
-  // the prop entirely (the guard in the mock above then leaves
+  // Kills: LcdCockpitSkin/LcdScopeSkin/LcdPeerSplitSkin forwarding the wrong
+  // `variant` literal to LcdLayout, forwarding a different wrapper's literal,
+  // or dropping the prop entirely (the guard in the mock above then leaves
   // mountedLcdVariants empty, which also fails the equality below).
   it.each(lcdLayoutCases)('forwards variant to LcdLayout (%s -> %s)', async (skinId, variant) => {
     const Component = await loadSkin(skinId);
@@ -189,21 +174,6 @@ describe('mobile skin entrypoint', () => {
     const target = document.createElement('div');
     components.push(mount(Component, { target }));
     expect(mobileLayoutMounts.count).toBe(1);
-  });
-});
-
-describe('semantic-radio-surfaces skin entrypoint', () => {
-  // Kills: PeerSplitLayout mounting SemanticRadioSurfaces with the wrong
-  // `strips` literal, forwarding a different skin's value, or dropping the
-  // prop (the mock's `?? 'single'` fallback then makes the equality fail for
-  // this table's `'dual'` case).
-  it.each(semanticRadioSurfacesCases)('mounts SemanticRadioSurfaces with its own strips value (%s -> %s)', async (
-    skinId, strips,
-  ) => {
-    const Component = await loadSkin(skinId);
-    const target = document.createElement('div');
-    components.push(mount(Component, { target }));
-    expect(mountedStrips).toEqual([strips]);
   });
 });
 

--- a/frontend/src/skins/__tests__/entrypoints.test.ts
+++ b/frontend/src/skins/__tests__/entrypoints.test.ts
@@ -40,12 +40,14 @@
  *
  * `lcd-cockpit`/`lcd-scope`/`peer-split` get a real mount pin for the first
  * time here. All three wrappers are zero-prop and hardcode a `variant`
- * literal into `LcdLayout`; the `variant` prop's shape
- * (`variant?: 'cockpit' | 'scope' | 'peer-split'`) is already pinned on
- * LcdLayout itself by
+ * literal into `LcdLayout`; LcdLayout's own handling of the `cockpit`/`scope`
+ * members is already pinned by
  * `components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts`
- * and `...autostep-lifecycle.isolated.test.ts` — nothing here duplicates
- * that. This file pins only each wrapper's half: that it forwards its own
+ * and `...autostep-lifecycle.isolated.test.ts` (neither mounts `peer-split`)
+ * — nothing here duplicates that. LcdLayout's `peer-split` handling is
+ * pinned separately, by `skins/lcd-peer-split/__tests__/
+ * LcdPeerSplitSkin.component.test.ts` (cited again below). This file pins
+ * only each wrapper's half: that it forwards its own
  * literal down, not LcdLayout's behavior for any value. `peer-split`
  * (MOR-2153 PR-1) moved into this bucket from a standalone
  * `SemanticRadioSurfaces`-mount pin once its entry component became

--- a/frontend/src/skins/__tests__/registry.test.ts
+++ b/frontend/src/skins/__tests__/registry.test.ts
@@ -52,7 +52,7 @@ vi.mock('../desktop-v2/DesktopSkin.svelte', () => lazyImports['desktop-v2']());
 vi.mock('../lcd-cockpit/LcdCockpitSkin.svelte', () => lazyImports['lcd-cockpit']());
 vi.mock('../lcd-scope/LcdScopeSkin.svelte', () => lazyImports['lcd-scope']());
 vi.mock('../mobile/MobileSkin.svelte', () => lazyImports['mobile']());
-vi.mock('../segmentline/PeerSplitLayout.svelte', () => lazyImports['peer-split']());
+vi.mock('../lcd-peer-split/LcdPeerSplitSkin.svelte', () => lazyImports['peer-split']());
 vi.mock('../sdr-test/SdrTestSkin.svelte', () => lazyImports['sdr-test']());
 vi.mock('../dual-receiver-cockpit/DualReceiverCockpit.svelte', () => lazyImports['dual-receiver-cockpit']());
 
@@ -221,7 +221,11 @@ describe('presentation resource plan', () => {
   const EXPECTED_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
     'desktop-v2': ['audio-fft', 'hardware-scope'],
     'dual-receiver-cockpit': [],
-    'peer-split': [],
+    // MOR-2153 PR-1: `peer-split` mounts the LCD shell (`LcdLayout`
+    // variant="peer-split"), which reuses `RightSidebar`'s
+    // `AudioSpectrumPanel`-behind-`hasAudioFft()` — same producer
+    // `lcd-cockpit`/`lcd-scope` already demand `audio-fft` for.
+    'peer-split': ['audio-fft'],
     'sdr-test': ['audio-fft', 'hardware-scope'],
     'lcd-cockpit': ['audio-fft'],
     'lcd-scope': ['audio-fft'],

--- a/frontend/src/skins/lcd-peer-split/LcdPeerSplitSkin.svelte
+++ b/frontend/src/skins/lcd-peer-split/LcdPeerSplitSkin.svelte
@@ -1,0 +1,10 @@
+<!--
+  LCD Peer Split Skin — mounts the LCD shell around the peer-split glass.
+  Thin wrapper that mounts LcdLayout with variant="peer-split".
+  Part of MOR-2153 (PR-1): the skin id `peer-split` is unchanged in this PR.
+-->
+<script lang="ts">
+  import LcdLayout from '../../components-v2/layout/LcdLayout.svelte';
+</script>
+
+<LcdLayout variant="peer-split" />

--- a/frontend/src/skins/lcd-peer-split/__tests__/LcdPeerSplitSkin.component.test.ts
+++ b/frontend/src/skins/lcd-peer-split/__tests__/LcdPeerSplitSkin.component.test.ts
@@ -1,0 +1,188 @@
+/**
+ * MOR-2153 PR-1 — `LcdPeerSplitSkin` mounts the LCD shell (`LcdLayout`
+ * variant="peer-split") around the peer-split glass (`PeerSplitLayout`),
+ * where `AmberCockpit`/`AmberScope` sit for `cockpit`/`scope`.
+ *
+ * Mock set copied from
+ * `components-v2/layout/__tests__/LcdLayout.command-bus-migration.isolated.test.ts`,
+ * the existing proof that this exact set mounts a REAL `LcdLayout` — and,
+ * for `cockpit`/`scope`, a REAL `SemanticRadioSurfaces` inside it — without
+ * throwing. `peer-split` additionally mounts a REAL `PeerSplitLayout` (its
+ * own `ScaledStage` needs the same `ResizeObserver` stub already present
+ * here) and, inside it, a SECOND real `SemanticRadioSurfaces` — which is
+ * exactly the collision this file's last test pins.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+vi.mock('../../../lib/local-extensions/LocalExtensionsHost.svelte', async () => {
+  const stub = await import('../../../components-v2/layout/__tests__/SpectrumPanelStub.svelte');
+  return { default: stub.default };
+});
+vi.mock('$lib/stores/layout.svelte', () => ({
+  useLcdLayout: vi.fn(() => true),
+  getLayoutMode: vi.fn(() => 'peer-split'),
+  cycleLayoutMode: vi.fn(),
+  setLayoutMode: vi.fn(),
+}));
+vi.mock('$lib/stores/tuning.svelte', () => ({ applyModeDefault: vi.fn() }));
+vi.mock('$lib/stores/lcd-display-mode.svelte', () => ({
+  getLcdDisplayMode: vi.fn(() => 'clean'),
+  setLcdDisplayMode: vi.fn(),
+  LCD_DISPLAY_MODES: ['clean', 'vintage', 'crt', 'flicker'],
+}));
+vi.mock('$lib/stores/connection.svelte', () => ({
+  getConnectionStatus: vi.fn(() => ({ connected: false })),
+  getWsConnected: vi.fn(() => false),
+  getRadioPowerOn: vi.fn(() => null),
+  getRadioStatus: vi.fn(() => 'disconnected'),
+  getRadioLinkState: vi.fn(() => 'disconnected'),
+  isScopeConnected: vi.fn(() => false),
+  isAudioConnected: vi.fn(() => false),
+  getRigConnected: vi.fn(() => false),
+  getRadioReady: vi.fn(() => false),
+  getRadioHealth: vi.fn(() => null),
+  markScopeFrame: vi.fn(),
+}));
+
+const rt = vi.hoisted(() => ({ state: null as unknown }));
+
+vi.mock('$lib/runtime', () => ({
+  runtime: {
+    get state() { return rt.state; },
+    caps: null,
+    connectionStatus: 'disconnected',
+    radioPowerOn: null,
+    connection: { status: 'disconnected', radioPowerOn: null },
+    audio: { rxEnabled: false, txEnabled: false, volume: 50, muted: false },
+    connectionAudio: false,
+    defaultScopeStatus: {
+      source: null, available: false, resourceSelected: false, demand: 0,
+      lifecycle: 'inactive', transport: 'disconnected', frameSeen: false,
+    },
+    scope: { hardwareScopeConnected: false, registerPresentationDriver: vi.fn(), subscribe: vi.fn(() => () => {}) },
+    bootstrap: vi.fn(async () => vi.fn()),
+  },
+  presentationResources: {
+    acquire: vi.fn(() => ({ resource: 'x', consumer: 'x' })),
+    release: vi.fn(),
+    configure: vi.fn(),
+    snapshot: vi.fn(() => ({ demand: 0, health: 'inactive' })),
+  },
+}));
+
+vi.mock('$lib/runtime/tx-controller/app-host', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/runtime/tx-controller/app-host')>();
+  return {
+    ...actual,
+    getAppTxController: () => ({
+      snapshot: () => ({ phase: 'idle', intent: null, guard: null, radioTx: 'off', txRisk: 'none', mayOwnKey: false, fault: null }),
+      subscribe: () => () => {},
+      start: vi.fn(),
+      setIntent: vi.fn(),
+      release: vi.fn(),
+      resetFault: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('$lib/stores/capabilities.svelte', () => ({
+  hasTx: vi.fn(() => true),
+  hasDualReceiver: vi.fn(() => false),
+  hasAudio: vi.fn(() => false),
+  hasSpectrum: vi.fn(() => false),
+  hasAnyScope: vi.fn(() => false),
+  isAudioFftScope: vi.fn(() => false),
+  hasAudioFft: vi.fn(() => false),
+  getScopeSource: vi.fn(() => null),
+  hasCapability: vi.fn(() => false),
+  vfoLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'MAIN' : 'SUB')),
+  receiverLabel: vi.fn((id: 'MAIN' | 'SUB') => id),
+  vfoSlotLabel: vi.fn((slot: 'A' | 'B') => (slot === 'A' ? 'VFO A' : 'VFO B')),
+  getCapabilities: vi.fn(() => ({ freqRanges: [], modes: [], filters: [] })),
+  setCapabilities: vi.fn(),
+  getAgcModes: vi.fn(() => [0, 1, 2, 3]),
+  getAgcLabels: vi.fn(() => ({ 0: 'OFF', 1: 'FAST', 2: 'MID', 3: 'SLOW' })),
+  getSupportedModes: vi.fn(() => ['USB', 'LSB', 'CW', 'AM', 'FM']),
+  getSupportedFilters: vi.fn(() => ['FIL1', 'FIL2', 'FIL3']),
+  getAttValues: vi.fn(() => [0, 10, 20]),
+  getAttLabels: vi.fn(() => ({ 0: '0dB', 10: '10dB', 20: '20dB' })),
+  getPreValues: vi.fn(() => [0, 1, 2]),
+  getPreLabels: vi.fn(() => ({ 0: 'OFF', 1: 'PRE1', 2: 'PRE2' })),
+  getKeyboardConfig: vi.fn(() => null),
+  getVfoScheme: vi.fn(() => 'ab'),
+  getAntennaCount: vi.fn(() => 1),
+  getSmeterCalibration: vi.fn(() => null),
+  getSmeterRedline: vi.fn(() => null),
+  getMeterCalibration: vi.fn(() => null),
+  getMeterRedline: vi.fn(() => null),
+  getControlRange: vi.fn(() => ({ min: 0, max: 255 })),
+}));
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+import LcdPeerSplitSkin from '../LcdPeerSplitSkin.svelte';
+
+let components: ReturnType<typeof mount>[] = [];
+
+function mountSkin() {
+  const t = document.createElement('div');
+  document.body.appendChild(t);
+  const component = mount(LcdPeerSplitSkin, { target: t });
+  flushSync();
+  components.push(component);
+  return t;
+}
+
+beforeEach(() => {
+  components = [];
+  rt.state = null;
+});
+
+afterEach(() => {
+  components.forEach((c) => unmount(c));
+  document.body.innerHTML = '';
+  rt.state = null;
+});
+
+describe('LcdPeerSplitSkin (MOR-2153 PR-1)', () => {
+  it('renders the LCD shell without throwing', () => {
+    const t = mountSkin();
+    expect(t.querySelector('.lcd-layout')).not.toBeNull();
+  });
+
+  it('mounts shell chrome (status bar, both sidebars), not a bare glass', () => {
+    const t = mountSkin();
+    expect(t.querySelector('.status-bar')).not.toBeNull();
+    expect(t.querySelector('.left-sidebar')).not.toBeNull();
+    expect(t.querySelector('.right-sidebar')).not.toBeNull();
+  });
+
+  it('mounts the peer-split glass inside .lcd-frame, where AmberCockpit sits for lcd-cockpit', () => {
+    const t = mountSkin();
+    const frame = t.querySelector('.lcd-frame[data-lcd-variant="peer-split"]');
+    expect(frame).not.toBeNull();
+    expect(frame!.querySelector('[data-testid="peer-split-glass"]')).not.toBeNull();
+  });
+
+  // Collision 1 (PR-1 brief): LcdLayout's `.content-right` mounts
+  // SemanticRadioSurfaces for cockpit/scope; PeerSplitLayout's own glass
+  // mounts a SECOND SemanticRadioSurfaces (`strips="dual"`) unconditionally.
+  // Mounting the glass inside the unmodified shell would give the operator
+  // two TX affordances — counted here, not asserted as a boolean, because
+  // each instance takes a distinct TX-lease `sourceId` and neither crashes.
+  //
+  // MUTATION KILLED: reverting LcdLayout's `{#if variant !== 'peer-split'}`
+  // guard around `.content-right`'s `<SemanticRadioSurfaces />` back to
+  // unconditional reproduces the exact duplicate this test exists to catch
+  // — observed red (2 instances) against that reverted guard, green (1)
+  // against the guarded version committed here.
+  it('mounts exactly one SemanticRadioSurfaces instance, not two', () => {
+    const t = mountSkin();
+    expect(t.querySelectorAll('[data-testid="semantic-radio-surfaces"]').length).toBe(1);
+  });
+});

--- a/frontend/src/skins/registry.ts
+++ b/frontend/src/skins/registry.ts
@@ -70,9 +70,9 @@ export function resolveSkinId(ctx: SkinResolutionContext): SkinId {
  * Skins are code-split — only the active skin is loaded.
  *
  * Each LCD variant has its own wrapper that mounts `LcdLayout` with the
- * appropriate `variant` prop — this is how the cockpit/scope selection
- * reaches LcdLayout (registry → skin wrapper → LcdLayout). The legacy
- * `amber-lcd` alias is accepted via `normalizeLayoutMode`'s
+ * appropriate `variant` prop — this is how the cockpit/scope/peer-split
+ * selection reaches LcdLayout (registry → skin wrapper → LcdLayout). The
+ * legacy `amber-lcd` alias is accepted via `normalizeLayoutMode`'s
  * `LEGACY_LAYOUT_ALIASES` table.
  */
 const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
@@ -88,8 +88,12 @@ const SKIN_LOADERS: Record<SkinId, () => Promise<{ default: Component }>> = {
   'mobile': () => import('./mobile/MobileSkin.svelte'),
   // MOR-2155 made `peer-split` addressable and loadable; MOR-2152 (see the
   // `resolveSkinId` branch below) is what makes a forced 'peer-split'
-  // preference actually resolve to it.
-  'peer-split': () => import('./segmentline/PeerSplitLayout.svelte'),
+  // preference actually resolve to it. MOR-2153 PR-1 retargeted the loader
+  // from the bare glass (`segmentline/PeerSplitLayout.svelte`) to the LCD
+  // shell wrapper: `lcd-peer-split/LcdPeerSplitSkin.svelte` mounts
+  // `LcdLayout` with `variant="peer-split"`, which renders the glass inside
+  // the shell rather than loading it standalone.
+  'peer-split': () => import('./lcd-peer-split/LcdPeerSplitSkin.svelte'),
   'sdr-test': () => import('./sdr-test/SdrTestSkin.svelte'),
 };
 
@@ -107,9 +111,13 @@ export async function loadSkin(id: SkinId): Promise<Component> {
  *
  * Read off the actual component trees:
  * - `hardware-scope` — `SpectrumPanel`, mounted by the desktop/sdr-test and
- *   mobile layouts; the LCD layouts have none.
- * - `audio-fft` — `AudioSpectrumPanel` (right sidebar, desktop/sdr-test/LCD)
- *   and `AmberCockpit` / `AmberScope` (LCD); the mobile layout has none.
+ *   mobile layouts; the LCD layouts (including `peer-split`, MOR-2153 PR-1)
+ *   have none.
+ * - `audio-fft` — `AudioSpectrumPanel` (right sidebar, desktop/sdr-test/LCD,
+ *   `RightSidebar.svelte` behind `hasAudioFft()`) and `AmberCockpit` /
+ *   `AmberScope` (LCD `cockpit`/`scope`); `peer-split` demands it purely
+ *   through the same `RightSidebar` it now shares with `cockpit`/`scope` —
+ *   its own glass mounts no audio-FFT surface. The mobile layout has none.
  *
  * `rx-audio` is deliberately absent: its lease is held by the runtime
  * (`setRxLive`), not by a presentation subtree, so it already survives a swap.
@@ -128,12 +136,14 @@ const SKIN_RESOURCE_PLAN: Record<SkinId, readonly AppResource[]> = {
   'lcd-cockpit': ['audio-fft'],
   'lcd-scope': ['audio-fft'],
   'mobile': ['hardware-scope'],
-  // Empty by construction, same reasoning as `dual-receiver-cockpit` above:
-  // the dual composition mounts neither SpectrumPanel nor AudioSpectrumPanel,
-  // and membership only permits bridging, so naming a resource this tree
-  // cannot consume would be a presentation manufacturing a live service (v3
-  // ADR invariant 12).
-  'peer-split': [],
+  // MOR-2153 PR-1: `peer-split` now mounts the LCD shell (`LcdLayout`
+  // variant="peer-split"), which reuses `RightSidebar` unmodified — the
+  // same `AudioSpectrumPanel`-behind-`hasAudioFft()` producer `lcd-cockpit`/
+  // `lcd-scope` already demand `audio-fft` for. No component in the tree
+  // mounts `SpectrumPanel`, so `hardware-scope` stays absent. Matches
+  // `lcd-cockpit`/`lcd-scope` below, re-derived from this shared shell
+  // rather than copied from them.
+  'peer-split': ['audio-fft'],
   'sdr-test': ['hardware-scope', 'audio-fft'],
 };
 


### PR DESCRIPTION
The `peer-split` skin loaded a bare instrument glass with no application chrome.
It now loads the LCD shell — status bar, sidebars, keyboard handling, control
strip — with the peer-split glass mounted where `AmberCockpit` sits for
`lcd-cockpit`.

The skin id `peer-split` is deliberately unchanged here. Renaming it to
`lcd-peer-split` is a follow-up PR; keeping the id fixed is what holds this
change inside the guardrail, since every exhaustive `Record<SkinId, …>` in the
tree would otherwise have to move with it.

## ⚠️ Merge instruction — the commit subjects name the wrong ticket

Both commits carry `MOR-2153` in their subject. That is wrong twice over: a
ticket id does not belong in a commit subject, and MOR-2153 is the earlier
chassis ticket, not this work. A default squash would concatenate those
messages into the merge commit and attach this PR to someone else's ticket.

The head is fixed by an Agent Review directive, so the commits cannot be
reworded without invalidating it. Control the squash message at merge instead:

```
gh pr merge --squash \
  --subject "feat(segmentline): mount the peer-split glass inside the LCD shell" \
  --body-file <a file containing this section's replacement text>
```

Do not merge with a bare `--squash`.

## Why this is one unit of work

Eight files crosses the six-file soft threshold, so this needs saying. Every
file besides `LcdLayout.svelte` and its new `LcdPeerSplitSkin.svelte` wrapper is
a mechanical consequence of that one component gaining a third variant: the
resource-plan entry that reusing `RightSidebar` makes true, two further copies
of that same table (`presentation-switch-resources.component.test.ts`,
`registry.test.ts`), the entrypoint-coverage entry that now matches
`lcd-cockpit`/`lcd-scope`'s shape, and the manifest-registration test that had
pinned the pre-existing loader's module path as a stand-in for the id-agreement
invariant it actually names. Nothing unrelated rode along.

## The three collisions the change had to resolve

**Duplicate surfaces.** `LcdLayout` mounts `SemanticRadioSurfaces` in
`.content-right`; the glass mounts its own. Mounting the glass in the unmodified
shell would give the operator two transmit affordances — silently, not loudly,
since each instance takes a distinct TX-lease `sourceId` from `surfaceSeq`.
`.content-right`'s instance is now suppressed for this variant only.

**Resource plan.** `SKIN_RESOURCE_PLAN['peer-split']` moves from `[]` to
`['audio-fft']`, re-derived by reading the tree: `RightSidebar.svelte` mounts
`AudioSpectrumPanel` behind `hasAudioFft()`, and nothing in the tree mounts
`SpectrumPanel`. Verified by enumerating every resource-acquire call site in the
repository, not by copying `lcd-cockpit`'s value.

**Frame shape.** `.lcd-slot` gets `aspect-ratio: 1280 / 540` for this variant
against the shared `16 / 7.5`, so the frame matches the glass's own native
ratio. Measured: vertical dead space falls from 137px to 69px at 1920×1080 and
from 44px to 0 at 1440×900, with the stage's layout box never leaving
1280×540.

## Verification

Mac mini, full frontend suite: **386 files / 8347 tests passing**, eslint clean,
`svelte-check` 0 errors 0 warnings. Baseline at the merge base `3287fcd9` was
385 / 8342. The +5 is fully accounted for: 4 from the new test file, and 1
auto-generated by `mor1099-unmounted-svelte-census.test.ts`, whose `it.each`
derives its cases by walking the filesystem — `.svelte` files under
`frontend/src/skins` go 7 → 8.

The single-instance pin was mutation-killed in both directions: reverting the
guard to unconditional fails it with `expected 2 to be 1`, and a
behaviour-preserving reordering of the variant branches leaves it green.

Measured live in a browser at 1920×1080 against this branch:
`document.documentElement.dataset.designLanguage` is `segmentline` — activating
through `App.svelte`'s fallback, since the stored preference was `studioline`,
so activation does not depend on the operator having chosen it.
`--dl-segmentline-glass` computes to `#c8a030` and the glass's own
`background-color` to `rgb(200, 160, 48)`, the same colour. Exactly one
`[data-testid="semantic-radio-surfaces"]`, with ancestor chain
`semantic-surfaces → peer-split-glass → scaled-stage → scaled-stage-holder →
peer-split-holder → lcd-frame → lcd-slot → content-center`, and `.semantic-slot`
absent — so the shell's instance is the one that went, not the glass's.

## What is NOT verified

**Component-level segmentline styling.** There is no radio backend on the
machine used, the app ran offline, and `.rx-tx-surface`, `.vfo-freq` and
`.digit` are absent from the DOM entirely under those conditions. Only the
language's activation and its tokens reaching the glass container are
established. This change does not claim the skin "renders correctly" or that
segmentline "styles the surfaces".

**No test covers the frame's CSS.** A grep across the test tree finds no
assertion reaching this geometry; jsdom computes no layout, so it cannot. The
first round of this PR added a flex centring rule that reflowed and clipped the
fixed-native stage at every viewport where the scale is below 1 — 68px off the
top at 1440×900, a viewport `segmentline-registration.test.ts` declares
supported — and it was caught by measurement in a headless browser, not by the
suite. The rule was removed rather than repaired: correct centring needs a
centred `transform-origin` inside `ScaledStage`, a shared primitive and a
separate decision.

## Follow-ups, not addressed here

- `ScaledStage.svelte` should carry `flex-shrink: 0` on `.scaled-stage`, which
  would make the whole class of ancestor-imposed reflow unrepresentable instead
  of leaving one instance detectable. Shared primitive, own blast radius, own
  ticket.
- `loader-identity-inventory.test.ts` hard-codes
  `EXPECTED_LOADER_SPECIFIER['peer-split']` as the glass's own path; the rename
  PR will hit it.
- `presentation/layout-mode.ts`'s `'peer-split'` doc line still points the
  reader at `PeerSplitLayout.svelte` as what the preference forces.
- `LcdLayout.svelte` now holds the first *value* import from `skins/` into
  `components-v2/`. No eslint boundary forbids it, but the glass now rides in
  whatever chunk `LcdLayout` lands in, which `lcd-cockpit`/`lcd-scope` also
  pull.

Linear: MOR-2243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
