### PR TITLE
fix: preserve rigctld result codes

### DIFF
--- a/src/rigplane/backends/rigctld_client/transport.py
+++ b/src/rigplane/backends/rigctld_client/transport.py
@@ -21,6 +21,18 @@ _ERROR_HINTS = {
 }
 
 
+class RigctldCommandError(CommandError):
+    """A nonzero ``RPRT`` result from external ``rigctld``."""
+
+    def __init__(self, command: str, code: int) -> None:
+        self.command = command
+        self.code = code
+        hint = _ERROR_HINTS.get(code, "command failed")
+        super().__init__(
+            f"External rigctld command {command!r} failed with RPRT {code} ({hint})."
+        )
+
+
 class RigctldTransport:
     """Serialized line-oriented TCP client for external ``rigctld``."""
 
@@ -140,7 +152,7 @@ class RigctldTransport:
                 line = await self._read_line(command)
                 if line.startswith("RPRT "):
                     code = _parse_rprt(line, command)
-                    if code < 0:
+                    if code != 0:
                         _raise_rprt(command, code)
                     raise CommandError(
                         f"External rigctld returned status {line!r} for query "
@@ -195,7 +207,7 @@ class RigctldTransport:
                     line = raw.decode("latin-1").rstrip("\r\n")
 
         code = _parse_rprt(line, command)
-        if code < 0:
+        if code != 0:
             _raise_rprt(command, code)
 
     async def _write_line(self, command: str) -> None:
@@ -271,7 +283,4 @@ def _parse_rprt(line: str, command: str) -> int:
 
 
 def _raise_rprt(command: str, code: int) -> None:
-    hint = _ERROR_HINTS.get(code, "command failed")
-    raise CommandError(
-        f"External rigctld command {command!r} failed with RPRT {code} ({hint})."
-    )
+    raise RigctldCommandError(command, code)

--- a/tests/test_rigctld_client_backend.py
+++ b/tests/test_rigctld_client_backend.py
@@ -122,6 +122,28 @@ async def test_transport_timeout_eof_malformed_and_negative_rprt() -> None:
             await transport.close()
 
 
+@pytest.mark.parametrize("code", [0, -1, -5, -6, -8, -37, 1])
+async def test_transport_command_accepts_only_rprt_zero_and_preserves_failure_code(
+    code: int,
+) -> None:
+    behavior = FakeRigctldBehavior(
+        malformed_responses={"F": f"RPRT {code}\n".encode("ascii")}
+    )
+    async with FakeRigctldServer(behavior=behavior) as server:
+        transport = RigctldTransport(host=server.host, port=server.port)
+        await transport.connect()
+        try:
+            if code == 0:
+                await transport.command("F 14074000")
+            else:
+                with pytest.raises(CommandError) as exc_info:
+                    await transport.command("F 14074000")
+                assert exc_info.value.command == "F 14074000"
+                assert exc_info.value.code == code
+        finally:
+            await transport.close()
+
+
 @pytest.mark.parametrize(
     "failure",
     "stale_eof stale_oserror resync_eof resync_oserror read_timeout "


### PR DESCRIPTION
Linear: MOR-2165 (bounded prerequisite; does not close the parent).

## Change
Only RPRT 0 completes a canonical rigctld setter successfully. Nonzero responses preserve the command and numeric status in a backend-local CommandError subtype. This does not classify every protocol failure as definitive rejection, add authority state, or connect production transmit adapters.

Search-before-write: inspected RigctldTransport.command, query, _parse_rprt and _raise_rprt, their canonical backend callers and the existing fake transport tests. No existing structured RPRT error was found; the existing fake supports the required response cases.

## Evidence
Baseline main 2de582f352e70103c575bae0b7326172b98c391c: Mini quick 33684826860 SUCCESS, 14591 passed / 218 skipped / 16 xfailed.

RED source 2567cf3fcaff88702277518bf1a2718986d9f690: proof run 33686344674 on Mini, 6 failed / 32 passed. Five negative-code cases lost structured evidence; positive RPRT 1 did not raise.
GREEN source 1f97f0c155a068c040a3c6025a5fc45c411ef066: proof run 33686566344 on Mini, 38 passed. Normal full matrix 33686698017 SUCCESS at this source: each Python 3.11/3.12/3.13 reports 14598 passed / 218 skipped / 16 xfailed; frontend 8347 passed and capture harness passed. Required quick 33686706936 SUCCESS: 14596 passed / 220 skipped / 16 xfailed; the two extra skips are existing web static-index tests (TestHttpEndpoints.test_root_returns_html and TestCacheControl.test_static_index_has_cache_control). Ruff/format/import gates pass.

Independent code PASS at exact head, followed by independent mutation repeats: M1 run33686756955 attempt2 / job100437058179 / artifact9868688802 restores code < 0 and yields exactly 1 failed / 37 passed (positive code incorrectly accepted). M2 run33687144697 attempt2 / job100439166085 / artifact9868812904 removes self.code and yields exactly 6 failed / 32 passed (nonzero status evidence missing). Zero/nearby controls stay green. Mutants are isolated proof checkouts; reviewed product remains clean. Query-specific structured-field assertions are not claimed by these command-path mutations. Proof-only workflow overrides are not part of this PR; normal full.yml is unchanged.

## Scope and compatibility
2 files, 37 additions / 6 deletions, measured with git diff --stat against 2de582f. Existing CommandError catches remain compatible. No profile, wire command, RF-admission or runtime lifecycle changes. No hardware validation claimed. All project execution/validation is on Mini only.

Required pre-push grep (unchanged existing consumers; zero command_dispatch.py and runtime command hits):
```
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1732:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1982:            decision = evaluate_tx_interlock(
```
Command: git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py src/rigplane/runtime/command*.py src/rigplane/web/handlers/control.py

