### PR TITLE
fix: relabel the peer-split skin picker entry to LCD Peer Split

### DIFF
--- a/frontend/src/components-v2/layout/StatusBar.svelte
+++ b/frontend/src/components-v2/layout/StatusBar.svelte
@@ -110,7 +110,7 @@
     { value: 'standard', label: 'Standard' },
     { value: 'lcd-cockpit', label: 'LCD Cockpit' },
     { value: 'lcd-scope', label: 'LCD Scope' },
-    { value: 'peer-split', label: 'Peer Split' },
+    { value: 'peer-split', label: 'LCD Peer Split' },
     { value: 'sdr-test', label: 'SDR Screen (test)' },
   ];
 

--- a/frontend/src/components-v2/layout/__tests__/StatusBar.skin-options.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/StatusBar.skin-options.test.ts
@@ -34,10 +34,10 @@ describe('StatusBar skinOptions (MOR-1257 F1)', () => {
   // sync pins (which fail `npm run check` on a missing key), an omitted skin
   // here compiles cleanly and just leaves the id unreachable through the
   // picker. This is that missing guard for `peer-split`.
-  it('lists peer-split with a Peer Split label', () => {
+  it('lists peer-split with an LCD Peer Split label', () => {
     const source = readFileSync('src/components-v2/layout/StatusBar.svelte', 'utf8');
     const match = source.match(/const skinOptions[^=]*=\s*\[([\s\S]*?)\n\s*\];/);
     expect(match, 'expected to find the skinOptions array literal').not.toBeNull();
-    expect(match![1]).toMatch(/\{\s*value:\s*'peer-split',\s*label:\s*'Peer Split'\s*\}/);
+    expect(match![1]).toMatch(/\{\s*value:\s*'peer-split',\s*label:\s*'LCD Peer Split'\s*\}/);
   });
 });


### PR DESCRIPTION
The skin picker's entry for the peer-split skin now reads **LCD Peer Split**.
The stored value stays exactly `peer-split`.

## Why the label and not the id

This started as a rename of the skin id `peer-split` → `lcd-peer-split`. A
builder stopped and disproved that plan rather than implementing it, which was
the right call: the premise it rested on — mine — was false.

`designLanguageActivation(manifest, layoutId)` in
`presentation/workspace/activation.ts` matches `entry.layoutId === layoutId`,
and `App.svelte` passes the resolved **`SkinId`** into that parameter. The
parameter is merely *named* `layoutId`, and `presentation/languages/
declarations.ts`'s own header says so in as many words. `App.svelte` separately
does `getLayout(skinId)` against the layout-manifest map. So the skin id and the
manifest id are one id space in practice: renaming one requires renaming the
other plus the design-language compatibility entry.

Demonstrated, not argued — renaming only in `skins/registry.ts` and running the
existing `design-language-activation.component.test.ts` fails all three of its
cases with `expected undefined to be 'segmentline'`. The mechanical rename alone
then came to 11 files against a 10-file hard ceiling.

Since `value` and `label` are independent in `skinOptions`, the operator-visible
outcome is identical for two lines instead of fourteen files, with no alias, no
migration, and no persisted preference orphaned.

## What changed

`components-v2/layout/StatusBar.svelte` — the label literal only:

    { value: 'peer-split', label: 'Peer Split' }
    { value: 'peer-split', label: 'LCD Peer Split' }

`components-v2/layout/__tests__/StatusBar.skin-options.test.ts` — the guard's
regex and the test's name follow.

## Verification

`git diff --word-diff=plain` resolves the change to sub-line granularity and
confirms every edited byte falls inside the label string: `value: 'peer-split',`
is untouched text, not a coincidentally identical retype. That matters because
`value` is what persists in an operator's workspace.

`skinOptions` has exactly one production consumer — `StatusBar.svelte`'s
`{#each}` renders `<option value={opt.value}>{opt.label}</option>`, and
`handleSkinChange` reads `ev.currentTarget.value`. Nothing does a reverse lookup
by label.

The guard was mutation-tested on a scratch copy, restoring from `git show` and
asserting the target pattern is present before each edit so a silent no-op
cannot fake a green:

| mutation | result |
|---|---|
| control | 3 passed |
| entry removed | 1 failed |
| `value` → `lcd-peer-split`, **label held byte-identical** | 1 failed |
| label reverted to `Peer Split` | 1 failed |
| unrelated `SDR Screen (test)` relabelled | 3 passed |
| array order swapped | 3 passed |

The third row is the one that matters: the guard discriminates on the entry's
presence and its `value`, not only on label text, and the two benign rows show
it does not redden on correct work.

Mini suite: 386 files / 8347 tests passing, eslint clean, `svelte-check` 0
errors 0 warnings — identical to the recorded baseline at `2de582f3`, which is
what a string-literal change must produce.

## Left alone deliberately

`presentation/layouts/segmentline-declarations.ts` carries its own
`displayName: 'Peer Split'`. It is not touched. `displayName` is declared in
manifests, typed in the two `contract.ts` files, and read by no `.svelte` file
anywhere — the layout validator's `TOP_LEVEL_KEYS` checks that the key is
present, never its value. It reaches no UI, so the two names cannot visibly
disagree.

Linear: MOR-2243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
