### PR TITLE
fix(stage): make ancestor-imposed reflow unrepresentable and give the stage an anchor

### DIFF
--- a/frontend/src/primitives/stage/ScaledStage.svelte
+++ b/frontend/src/primitives/stage/ScaledStage.svelte
@@ -3,10 +3,21 @@
 
   Renders `children` at a declared native size (`nativeW` x `nativeH`),
   measures its own host box with `ResizeObserver`, and applies ONE uniform
-  `transform: scale(...)` (see `stage-scale.ts`), anchored to the top-left
-  corner, never growing past its authored size. Nothing inside the stage
-  reflows in response to the host resizing — only the transform on the
-  stage element changes.
+  `transform: scale(...)` (see `stage-scale.ts`), anchored by default to the
+  top-left corner — or, via the `anchor` prop, kept centred in the host at
+  every scale by an added `translate()` computed from that same scale (see
+  `computeStageCenterOffset`) — never growing past its authored size.
+  Nothing inside the stage reflows in response to the host resizing — only
+  the transform on the stage element changes.
+
+  MOR-2251: `flex-shrink: 0` on `.scaled-stage` (below) makes one specific
+  way that guarantee could be broken mechanically impossible, rather than
+  relying on this paragraph: an ancestor rule that turns this element into
+  a flex item — e.g. a `display: flex` re-added to `.scaled-stage-holder`,
+  the exact shape of the MOR-2153 F1 defect — can no longer shrink it off
+  its authored size. It does not block every conceivable override; see the
+  property's own comment for what was checked about the equivalent grid
+  case.
 
   CHROME MUST BE A SIBLING OF THE STAGE, NEVER A CHILD. `transform: scale()`
   establishes a new containing block for `position: fixed` descendants, and
@@ -28,31 +39,54 @@
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { computeStageScale, type StageBox } from './stage-scale';
+  import { computeStageCenterOffset, computeStageScale, type StageBox } from './stage-scale';
 
   interface Props {
     /** Native (authored) width of the stage content, in CSS pixels. */
     nativeW: number;
     /** Native (authored) height of the stage content, in CSS pixels. */
     nativeH: number;
+    /**
+     * Where the scaled box sits inside the measured host box. `'top-left'`
+     * (the default) preserves today's behaviour exactly: the box stays
+     * pinned to the holder's top-left corner at every scale, no translate.
+     * `'center'` adds a translate — computed from the same `scale`, so it
+     * stays exact at every scale, not only scale 1 — that keeps the box's
+     * own center coincident with the host's, regardless of the host's
+     * layout mode (flex, grid, or plain flow): it depends only on the
+     * measured host box, not on how an ancestor positioned it.
+     */
+    anchor?: 'top-left' | 'center';
     children: Snippet;
   }
 
-  let { nativeW, nativeH, children }: Props = $props();
+  let { nativeW, nativeH, anchor = 'top-left', children }: Props = $props();
 
   let holder: HTMLDivElement | undefined = $state();
   let scale = $state(1);
+  let offsetX = $state(0);
+  let offsetY = $state(0);
+
+  // `anchor === 'top-left'` ignores `offsetX`/`offsetY` entirely (see
+  // `transform` below), so the default's rendered `transform` string is
+  // byte-identical to before this prop existed — no `translate()` prefix.
+  let transform = $derived(
+    anchor === 'center' ? `translate(${offsetX}px, ${offsetY}px) scale(${scale})` : `scale(${scale})`,
+  );
 
   $effect(() => {
     if (!holder) return;
 
     const native: StageBox = { width: nativeW, height: nativeH };
 
-    // Writes only to `scale` — never back onto `holder` (MOR-2147, see file
-    // header). `scale` is written but never read inside this effect.
+    // Writes only to `scale`/`offsetX`/`offsetY` — never back onto `holder`
+    // (MOR-2147, see file header).
     const measure = (host: StageBox) => {
       if (host.width <= 0 || host.height <= 0) return;
       scale = computeStageScale(host, native);
+      const offset = computeStageCenterOffset(host, native, scale);
+      offsetX = offset.x;
+      offsetY = offset.y;
     };
 
     const box = holder.getBoundingClientRect();
@@ -72,12 +106,7 @@
 </script>
 
 <div class="scaled-stage-holder" bind:this={holder}>
-  <div
-    class="scaled-stage"
-    style:width="{nativeW}px"
-    style:height="{nativeH}px"
-    style:transform="scale({scale})"
-  >
+  <div class="scaled-stage" style:width="{nativeW}px" style:height="{nativeH}px" style:transform>
     {@render children()}
   </div>
 </div>
@@ -92,5 +121,20 @@
 
   .scaled-stage {
     transform-origin: top left;
+    /* MOR-2251: makes the MOR-2153 defect class unrepresentable rather than
+       patching the one instance of it. Any ancestor that turns this element
+       into a flex item — including a `display: flex` re-added to its own
+       `.scaled-stage-holder`, the exact shape of the deleted rule this
+       guards against — can no longer shrink it off its native size.
+       Verified NOT to be needed for the equivalent grid case: a headless
+       Chrome probe (four ancestor variants: `place-items: center`, no
+       `place-items` at all, an explicit `1fr` track, and `place-items:
+       stretch`) found a grid item that declares an explicit width/height,
+       as this element always does via the `style:width`/`style:height`
+       above, is never shrunk by grid's stretch defaults — those fall back
+       to `start` positioning at the item's own size once a definite
+       preferred size is present, so `flex-shrink` (a no-op outside a flex
+       formatting context) has nothing to correct there. */
+    flex-shrink: 0;
   }
 </style>

--- a/frontend/src/primitives/stage/ScaledStage.svelte
+++ b/frontend/src/primitives/stage/ScaledStage.svelte
@@ -80,11 +80,20 @@
     const native: StageBox = { width: nativeW, height: nativeH };
 
     // Writes only to `scale`/`offsetX`/`offsetY` — never back onto `holder`
-    // (MOR-2147, see file header).
+    // (MOR-2147, see file header). `scale` is written but never READ as
+    // `$state` inside this effect: `computeStageCenterOffset` takes the
+    // local `nextScale` below instead of the `scale` binding. Reading
+    // `scale` here would register it as a dependency of this effect, and
+    // since the write just above just changed it, the effect would
+    // self-invalidate and re-run once per mount — tearing down and
+    // reconstructing the `ResizeObserver` below for no observable benefit
+    // (the re-run recomputes the same scale from the same unchanged host
+    // box). Regression found by an independent verifier on this branch.
     const measure = (host: StageBox) => {
       if (host.width <= 0 || host.height <= 0) return;
-      scale = computeStageScale(host, native);
-      const offset = computeStageCenterOffset(host, native, scale);
+      const nextScale = computeStageScale(host, native);
+      scale = nextScale;
+      const offset = computeStageCenterOffset(host, native, nextScale);
       offsetX = offset.x;
       offsetY = offset.y;
     };

--- a/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
+++ b/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
@@ -18,6 +18,7 @@
  * `getBoundingClientRect`), so this file is named `*.isolated.test.ts` per
  * the pool-membership convention in `vite.config.ts`.
  */
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mount, unmount, flushSync, type Snippet } from 'svelte';
 import ScaledStage from '../ScaledStage.svelte';
@@ -243,5 +244,47 @@ describe('ScaledStage — anchor prop (MOR-2251)', () => {
     // now inside a 300x100 host: 200px leftover width (100 each side), 0
     // leftover height.
     expect(readTransform(target)).toBe('translate(100px, 0px) scale(0.5)');
+  });
+});
+
+describe('ScaledStage — .scaled-stage declares flex-shrink: 0 (MOR-2251)', () => {
+  // This is a TEXT pin on the component's own <style> block, the same
+  // idiom `PeerSplitLayout.component.test.ts`'s `declarationsFor` uses
+  // (read that file before touching this one). It verifies the
+  // declaration SURVIVES in source; it cannot verify the BEHAVIOUR the
+  // declaration produces, because jsdom computes no layout at all — a
+  // finding both this file's own `getBoundingClientRect`/`offsetWidth`
+  // probe and `PeerSplitLayout.component.test.ts`'s file header establish
+  // independently (that file: "this Vitest/jsdom config injects no
+  // component <style> during a mount ... every element's getComputedStyle
+  // reads the UA default regardless of what any <style> block declares").
+  // A comment claiming this test proves the stage cannot reflow would be
+  // false. What it does prove: the declaration is the ENTIRE mechanism —
+  // no other property makes `.scaled-stage` shrink-proof, and the grid
+  // case (see the property's own comment in ScaledStage.svelte) needs no
+  // second declaration — so deleting this line is the only regression path
+  // for this fix, and this pin fails exactly on that deletion.
+  const source = readFileSync('src/primitives/stage/ScaledStage.svelte', 'utf8');
+  const styleBlock = source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
+  const css = styleBlock.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  function declarationsFor(selector: string): Record<string, string> {
+    for (const [, selectorList, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      for (const candidate of selectorList.split(',')) {
+        if (candidate.trim() !== selector) continue;
+        const declarations: Record<string, string> = {};
+        for (const declaration of body.split(';')) {
+          const colon = declaration.indexOf(':');
+          if (colon > 0) declarations[declaration.slice(0, colon).trim()] = declaration.slice(colon + 1).trim();
+        }
+        return declarations;
+      }
+    }
+    throw new Error(`no rule for selector "${selector}" in ScaledStage.svelte's <style> block`);
+  }
+
+  it('declares flex-shrink: 0', () => {
+    const stage = declarationsFor('.scaled-stage');
+    expect(stage['flex-shrink']).toBe('0');
   });
 });

--- a/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
+++ b/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
@@ -199,6 +199,24 @@ describe('ScaledStage — measure/write regression (MOR-2147)', () => {
   });
 });
 
+describe('ScaledStage — measure() does not self-trigger its own effect', () => {
+  // Regression pin: `measure()` used to read the `scale` `$state` binding as
+  // the third argument to `computeStageCenterOffset`, right after writing
+  // it. That read registers `scale` as a dependency of the enclosing
+  // `$effect`, and since the write just above just changed it, the effect
+  // invalidated and re-ran itself once per mount — tearing down the first
+  // `ResizeObserver` and constructing a second one. `FakeResizeObserver`
+  // (declared above, shared with the MOR-2147 describe block) already
+  // records every instance constructed; this test reuses that same list
+  // rather than adding a second stub.
+  it('constructs exactly one ResizeObserver per mount', () => {
+    containerSize = { width: 100, height: 100 };
+    mountStage(200, 200);
+
+    expect(FakeResizeObserver.instances.length).toBe(1);
+  });
+});
+
 describe('ScaledStage — anchor prop (MOR-2251)', () => {
   it('defaults to top-left: the transform is exactly `scale(n)`, with no translate() prefix', () => {
     // Exact-string check, not the `readScale` regex above: a regex match on

--- a/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
+++ b/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
@@ -125,12 +125,12 @@ const noopChildren = ((_anchor: unknown) => ({
 
 /** Mounts `ScaledStage` at the given native size inside the current
  *  `containerSize`, and captures the holder element for later resizes. */
-function mountStage(nativeW: number, nativeH: number): HTMLElement {
+function mountStage(nativeW: number, nativeH: number, opts?: { anchor?: 'top-left' | 'center' }): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
   const component = mount(ScaledStage, {
     target,
-    props: { nativeW, nativeH, children: noopChildren },
+    props: { nativeW, nativeH, anchor: opts?.anchor, children: noopChildren },
   });
   flushSync();
   components.push(component);
@@ -144,6 +144,14 @@ function readScale(target: HTMLElement): number {
   const transform = stage?.style.transform ?? '';
   const match = transform.match(/scale\(([-\d.]+)\)/);
   return match ? Number(match[1]) : NaN;
+}
+
+/** Reads the raw `transform` inline style, for tests that care about the
+ *  exact string (whether a `translate()` prefix is present at all), not
+ *  just the scale factor. */
+function readTransform(target: HTMLElement): string {
+  const stage = target.querySelector<HTMLElement>('.scaled-stage');
+  return stage?.style.transform ?? '';
 }
 
 /** Resizes the fake "parent" and, only if the holder's modeled box actually
@@ -187,5 +195,53 @@ describe('ScaledStage — measure/write regression (MOR-2147)', () => {
     resizeContainer(100, 20);
 
     expect(readScale(target)).toBeLessThan(0.5);
+  });
+});
+
+describe('ScaledStage — anchor prop (MOR-2251)', () => {
+  it('defaults to top-left: the transform is exactly `scale(n)`, with no translate() prefix', () => {
+    // Exact-string check, not the `readScale` regex above: a regex match on
+    // `scale(...)` inside the string would still pass even if the default
+    // accidentally grew a `translate(0px, 0px)` prefix, which is exactly the
+    // "default preserves today's behaviour" claim this test exists to pin.
+    containerSize = { width: 100, height: 100 };
+    const target = mountStage(200, 200);
+    expect(readTransform(target)).toBe('scale(0.5)');
+  });
+
+  it('anchor="top-left" (explicit) matches the default: no translate() prefix', () => {
+    containerSize = { width: 100, height: 100 };
+    const target = mountStage(200, 200, { anchor: 'top-left' });
+    expect(readTransform(target)).toBe('scale(0.5)');
+  });
+
+  it('anchor="center" at scale 1 with a host that already matches native is a no-op translate (scale-1 control)', () => {
+    // Every other case here is below scale 1; without this control there is
+    // no evidence the offset formula also degrades correctly at scale 1.
+    containerSize = { width: 200, height: 200 };
+    const target = mountStage(200, 200, { anchor: 'center' });
+    expect(readTransform(target)).toBe('translate(0px, 0px) scale(1)');
+  });
+
+  it('anchor="center" centers a shrunk stage inside a larger host', () => {
+    // native 200x200, host 300x300 -> scale stays capped at 1 (host is
+    // bigger on both axes), so the 200x200 box has 100px of leftover space
+    // per axis to split evenly: translate(50px, 50px).
+    containerSize = { width: 300, height: 300 };
+    const target = mountStage(200, 200, { anchor: 'center' });
+    expect(readTransform(target)).toBe('translate(50px, 50px) scale(1)');
+  });
+
+  it('anchor="center" recomputes the translate as the host resizes asymmetrically', () => {
+    containerSize = { width: 100, height: 100 };
+    const target = mountStage(200, 200, { anchor: 'center' });
+    // scale 0.5 -> scaled box 100x100 exactly fills the 100x100 host.
+    expect(readTransform(target)).toBe('translate(0px, 0px) scale(0.5)');
+
+    resizeContainer(300, 100);
+    // scale = min(300/200, 100/200, 1) = 0.5 -> scaled box stays 100x100,
+    // now inside a 300x100 host: 200px leftover width (100 each side), 0
+    // leftover height.
+    expect(readTransform(target)).toBe('translate(100px, 0px) scale(0.5)');
   });
 });

--- a/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
+++ b/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeStageScale, MAX_STAGE_SCALE } from '../stage-scale';
+import { computeStageCenterOffset, computeStageScale, MAX_STAGE_SCALE } from '../stage-scale';
 
 describe('computeStageScale', () => {
   it('is width-constrained when the host is relatively narrow', () => {
@@ -57,5 +57,34 @@ describe('computeStageScale', () => {
       const scale = computeStageScale({ width: 640, height: 540 }, { width: 1280, height: 540 });
       expect(scale).toBe(0.5);
     });
+  });
+});
+
+describe('computeStageCenterOffset', () => {
+  it('returns zero offset when the scaled box exactly fills the host (scale 1, matching size)', () => {
+    // Scale-1 control: a centred box that already fills its host needs no
+    // shift — the formula must degrade to a no-op here, not just at some
+    // shrunk scale.
+    const offset = computeStageCenterOffset({ width: 200, height: 200 }, { width: 200, height: 200 }, 1);
+    expect(offset).toEqual({ x: 0, y: 0 });
+  });
+
+  it('splits the leftover host space evenly on both axes for a square shrink', () => {
+    // native 200x200 at scale 0.5 -> 100x100 scaled box inside a 300x300
+    // host: 200px of leftover space per axis, 100px on each side.
+    const offset = computeStageCenterOffset({ width: 300, height: 300 }, { width: 200, height: 200 }, 0.5);
+    expect(offset).toEqual({ x: 100, y: 100 });
+  });
+
+  it('computes independent offsets per axis for a non-square host (letterboxing)', () => {
+    // native 1280x540 at scale 0.5 -> 640x270 scaled box. Host 1000x400:
+    // leftover width 360 (180 each side), leftover height 130 (65 each side).
+    const offset = computeStageCenterOffset({ width: 1000, height: 400 }, { width: 1280, height: 540 }, 0.5);
+    expect(offset).toEqual({ x: 180, y: 65 });
+  });
+
+  it('returns zero offset for a degenerate (unmeasured) host', () => {
+    const offset = computeStageCenterOffset({ width: 0, height: 0 }, { width: 200, height: 200 }, 0);
+    expect(offset).toEqual({ x: 0, y: 0 });
   });
 });

--- a/frontend/src/primitives/stage/stage-scale.ts
+++ b/frontend/src/primitives/stage/stage-scale.ts
@@ -33,3 +33,26 @@ export function computeStageScale(host: StageBox, native: StageBox): number {
   const fitHeight = host.height / native.height;
   return Math.min(fitWidth, fitHeight, MAX_STAGE_SCALE);
 }
+
+export interface StageOffset {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Returns the `translate()` offset (in host-box CSS pixels) that keeps a
+ * `scale`d `native` box centred inside `host`, for `ScaledStage`'s `anchor:
+ * 'center'` prop (see that component's file header). The stage element sits
+ * at `host`'s top-left corner before any transform, so — applied AFTER
+ * `scale` in the same `transform` list, per CSS's composition order — this
+ * offset shifts the already-shrunk box by half the leftover space on each
+ * axis, independent of the host's own layout mode (flex, grid, or plain
+ * flow): it depends only on the measured `host` box, not on how an ancestor
+ * positioned it.
+ */
+export function computeStageCenterOffset(host: StageBox, native: StageBox, scale: number): StageOffset {
+  return {
+    x: (host.width - native.width * scale) / 2,
+    y: (host.height - native.height * scale) / 2,
+  };
+}


### PR DESCRIPTION
`ScaledStage` renders content at a declared native size and applies one uniform
`transform: scale()`. Its header states that nothing inside the stage reflows in
response to the host resizing. Until now nothing enforced that: `.scaled-stage`
carries inline `width`/`height` and no `flex-shrink`, so any ancestor that made
it a flex item shrank the box and the authored content reflowed.

That is not hypothetical. It happened during MOR-2243 PR-1 and shipped as far as
review: a flex-centring rule on the holder cost 68px off the top of the
instrument face at 1440×900, 52px at 1512×982, 101px at 1280×800 — 1440×900
being a viewport `segmentline-registration.test.ts` declares supported. The rule
was removed there rather than repaired. This makes the class unrepresentable.

## Three parts

**`flex-shrink: 0` on `.scaled-stage`.** Measured in headless Chrome, with the
probe reading the component's *current* `<style>` block at run time rather than
a hand-copied approximation: with the declaration the stage keeps its 1280×540
layout box at 1280×800, 1440×900, 1512×982 and a scale-1 control at 1920×1080;
without it, width collapses to 804 / 964 / 1036 at the three sub-scale-1 hosts.

**The grid case needs nothing.** Seven ancestor variants probed — `place-items:
center`, no `place-items`, an explicit `1fr` track, `place-items: stretch`, each
with and without the declaration: a grid item with a definite preferred size is
never shrunk. No second declaration was added, because none could be justified.
(Narrowing, established during review: grid does *displace* such an item at a
scale-1 host — offset 81, 34 — it merely reads as zero below scale 1. No code
depends on that half; displacement is what the anchor prop below is for.)

**An `anchor?: 'top-left' | 'center'` prop**, default `'top-left'`, implemented
as a translate computed from the same scale rather than a `transform-origin`
change, so it does not depend on ancestor CSS and is exact at every scale — not
only at scale 1, which is where the PR-1 attempt was correct and nowhere else.
No consumer is changed; the default's rendered transform string is byte-identical
to before, asserted as an exact string rather than by the previous regex, which
would have tolerated a stray `translate(0px, 0px)` prefix.

## A self-invalidating effect, found in review

The first draft of the anchor work assigned `scale` and then read it back on the
next line to compute the offset — inside the effect's tracking context. That
registered `scale` as a dependency of the effect it was written in, so the write
re-ran the effect once per mount, tearing down and reconstructing the
`ResizeObserver`. Counted: base 1 observer, that draft 2, and 2 again after a
resize.

It converged and never malfunctioned, but it was a regression in a shared
primitive that nothing detected. Fixed by computing into a local and assigning
from it.

The comment deleted in that draft — "`scale` is written but never read inside
this effect" — had documented precisely the invariant the change broke. The
original wording was recovered from history rather than reinvented.

## What the checks actually catch

**The declaration pin** reads `ScaledStage.svelte`'s raw `<style>` text and
asserts `.scaled-stage` declares `flex-shrink: 0`. Deleting the line fails that
one test and nothing else.

Its limits, established by measurement and stated so nobody over-trusts it: the
declaration **is defeasible from outside**. A consumer `:global()` reach-in — the
idiom `PeerSplitLayout.svelte` already uses — compiles to a three-class selector
and outranks the component's own two-class rule regardless of source order, so
`flex-shrink: 1` from a consumer defeats it with the declaration fully present.
The pin is worth having because it catches source-level edits to this file and is
the only CI-visible guard here, not because it closes every path.

**The observer-count pin** asserts exactly one `ResizeObserver` per mount, using
the test file's existing stub rather than a second mechanism. Four mutations were
run against it: reverting to the original defect reddens it; a bare `void scale;`
somewhere else entirely in the same function **also** reddens it — so it enforces
the constraint generally, not the one call site that produced this bug; and two
semantics-preserving edits (renaming the local, reordering the offset
assignments) leave it green.

That second result matters beyond this PR: the constraint that previously lived
only in a comment is now machine-checked, and the comment is no longer
load-bearing on its own.

## Not done, and why

The ticket asked for a component test wrapping the stage in flex and grid
holders. It cannot be written in this harness: mounting the real component gives
`document.styleSheets.length === 0` and `getComputedStyle(stage).flexShrink ===
''`, because Svelte's compiled `<style>` is never injected — independently
documented in `PeerSplitLayout.component.test.ts`'s own header. The test was
written, observed to fail for the wrong reason, and deleted rather than left
green by construction.

The headless probe is not committed either: `quick.yml` runs `npx vitest run` at
line 138 and `npx playwright install chromium` at line 151, a later step, so a
Chromium-launching test would find no binary. The consequence is stated plainly
rather than papered over — there is no behavioural guard in CI here, only the two
source-level pins above.

## Blast radius

Against `origin/main` = `21814f3c`, `ScaledStage` has **one** production importer
(`skins/segmentline/PeerSplitLayout.svelte:19`) and one test importer; eleven
further files name it without importing it. Shared by design and by intent —
several manifests declare `stageSizing` awaiting it — but one component at
runtime today.

## Numbers

Mini suite at this head: **386 files / 8358 tests**, eslint clean, `svelte-check`
0 errors 0 warnings. The branch's own base `21814f3c` measured 386 / 8347, so
+11, no file added — 4 pure-arithmetic, 5 anchor-wiring, 1 declaration pin, 1
observer-count pin.

`main` moved to `4cbd5ba4` after this branch was cut. `git merge-tree
--write-tree` is clean and `git log 21814f3c..4cbd5ba4 -- frontend/src/primitives/stage/`
is empty, so the branch was not rebased. CI merges against the newer main and
will therefore report different absolute totals than the figures above, which are
stated against the base they were measured on.

Linear: MOR-2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
