### PR TITLE
refactor: send every acquisition query through one runtime wire-frame function

### DIFF
--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -46,7 +46,10 @@ from ..radio_protocol import (
     StateStoreCapable,
 )
 from ..runtime._civ_rx import _OBSERVATION_MAX_AGE_SECONDS
-from ..runtime._state_queries import acquisition_query_resolver_for_profile
+from ..runtime._state_queries import (
+    acquisition_query_resolver_for_profile,
+    wire_parts_for_query,
+)
 from ..startup_checks import assert_radio_startup_ready
 from . import audit as _audit  # noqa: TID251
 from .circuit_breaker import CircuitBreaker, CircuitState  # noqa: TID251
@@ -567,28 +570,25 @@ class RigctldServer:
     ) -> None:
         """Send a single acquisition-scheduler CI-V state query.
 
-        The lossless query envelope keeps the CI-V sub-command, payload data,
-        and optional cmd29 receiver route separate.
+        Wire-frame assembly (cmd29 wrap, 0x27 scope-receiver substitution)
+        is shared with the other two acquisition senders via
+        ``wire_parts_for_query``; the live scope receiver comes from the
+        radio's own ``RadioState`` mirror, matching what the web sender
+        (``RadioPoller._send_one_state_query``) and the initial fetch
+        (``runtime.radio_initial_state.fetch_initial_state``) read.
         """
         radio = self._radio
         if not isinstance(radio, CivCommandCapable):
             raise _AcquisitionExecutorUnavailable(
                 "radio does not support CI-V state acquisition sends"
             )
-        if query.receiver is not None:
-            inner = bytes([query.receiver, query.command])
-            if query.sub is not None:
-                inner += bytes([query.sub])
-            await radio.send_civ(
-                0x29,
-                data=inner + query.data,
-                wait_response=False,
-            )
-            return
+        command, sub, data = wire_parts_for_query(
+            query, self._radio.radio_state.scope_controls.receiver
+        )
         await radio.send_civ(
-            query.command,
-            sub=query.sub,
-            data=query.data,
+            command,
+            sub=sub,
+            data=data,
             wait_response=False,
         )
 

--- a/src/rigplane/runtime/_state_queries.py
+++ b/src/rigplane/runtime/_state_queries.py
@@ -116,6 +116,30 @@ def acquisition_query_from_wire_tuple(
     return AcquisitionQuery(command, sub=sub, data=data, receiver=receiver)
 
 
+def wire_parts_for_query(
+    query: AcquisitionQuery,
+    scope_receiver: int,
+) -> tuple[int, int | None, bytes]:
+    """Compute the wire ``(command, sub, data)`` for one acquisition query.
+
+    cmd29-wraps a receiver-routed query, and substitutes *scope_receiver*
+    into byte 0 of a 0x27 selector-form read (``query.sub`` in
+    ``SCOPE_RECEIVER_SELECTOR_SUBS`` and ``query.data`` non-empty).
+    """
+    if query.receiver is not None:
+        inner = bytes([query.receiver, query.command])
+        if query.sub is not None:
+            inner += bytes([query.sub])
+        return 0x29, None, inner + query.data
+    if (
+        query.command == 0x27
+        and query.sub in SCOPE_RECEIVER_SELECTOR_SUBS
+        and query.data
+    ):
+        return query.command, query.sub, bytes([scope_receiver]) + query.data[1:]
+    return query.command, query.sub, query.data
+
+
 def acquisition_query_resolver_for_profile(
     profile: RadioProfile,
 ) -> AcquisitionQueryResolver:

--- a/src/rigplane/runtime/radio_initial_state.py
+++ b/src/rigplane/runtime/radio_initial_state.py
@@ -36,7 +36,7 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
 
     This is non-fatal: failures are logged but do not raise.
     """
-    from ._state_queries import build_state_queries
+    from ._state_queries import build_state_queries, wire_parts_for_query
 
     try:
         is_serial = not radio._profile.has_lan
@@ -58,22 +58,15 @@ async def fetch_initial_state(radio: IcomRadio) -> None:
         sent = 0
         for query in queries:
             try:
-                if query.receiver is not None:
-                    inner = bytes([query.receiver, query.command])
-                    if query.sub is not None:
-                        inner += bytes([query.sub])
-                    await radio.send_civ(
-                        0x29,
-                        data=inner + query.data,
-                        wait_response=False,
-                    )
-                else:
-                    await radio.send_civ(
-                        query.command,
-                        sub=query.sub,
-                        data=query.data,
-                        wait_response=False,
-                    )
+                command, sub, data = wire_parts_for_query(
+                    query, radio.radio_state.scope_controls.receiver
+                )
+                await radio.send_civ(
+                    command,
+                    sub=sub,
+                    data=data,
+                    wait_response=False,
+                )
                 sent += 1
             except Exception as exc:
                 # non-fatal; regular polling will retry

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -76,7 +76,6 @@ from .._queue_pressure import PRESSURE_THRESHOLD
 from ..commands._frame import decode_wire_tuple
 from ..commands.command_map import CommandMap
 from ..commands.commander import Priority
-from ..commands.scope import SCOPE_RECEIVER_SELECTOR_SUBS
 from ..core.command_service import (
     CommandService,
 )
@@ -111,7 +110,10 @@ from ..core.tx_target import (
     TxTarget,
     UnknownTxTarget,
 )
-from .._state_queries import acquisition_query_resolver_for_profile
+from .._state_queries import (
+    acquisition_query_resolver_for_profile,
+    wire_parts_for_query,
+)
 from ..profiles import RadioProfile, resolve_radio_profile
 from ..runtime._state_queries import tx_target_max_age
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
@@ -1287,60 +1289,26 @@ class RadioPoller:
         response still arrives via the CI-V RX path.
 
         The lossless query envelope keeps the CI-V sub-command, payload data,
-        and optional cmd29 receiver route separate.
+        and optional cmd29 receiver route separate. Wire-frame assembly
+        (cmd29 wrap, 0x27 scope-receiver substitution) is shared with the
+        other two acquisition senders via ``wire_parts_for_query``.
+
+        Scope control queries need receiver prefix (00=MAIN, 01=SUB).
+        ``build_state_queries`` emits MAIN because it runs at connect, before
+        the radio has said which scope is selected; where the poller has
+        state to read the live selection from, that replaces the default.
         """
-        if query.receiver is not None:
-            inner = bytes([query.receiver, query.command])
-            if query.sub is None:
-                await self._civ(
-                    0x29,
-                    data=inner + query.data,
-                    priority=priority,
-                    wait_dispatch=False,
-                )
-            else:
-                await self._civ(
-                    0x29,
-                    data=inner + bytes([query.sub]) + query.data,
-                    priority=priority,
-                    wait_dispatch=False,
-                )
-        elif (
-            query.command == 0x27
-            and query.sub in SCOPE_RECEIVER_SELECTOR_SUBS
-            and query.data
-        ):
-            # Scope control queries need receiver prefix (00=MAIN, 01=SUB).
-            # ``build_state_queries`` emits MAIN because it runs at connect,
-            # before the radio has said which scope is selected; where the
-            # poller has state to read the live selection from, that
-            # replaces the default.
-            scope_rx = 0
-            if self._radio_state:
-                scope_rx = self._radio_state.scope_controls.receiver
-            await self._civ(
-                query.command,
-                sub=query.sub,
-                data=bytes([scope_rx]) + query.data[1:],
-                priority=priority,
-                wait_dispatch=False,
-            )
-        elif query.sub is None:
-            await self._civ(
-                query.command,
-                sub=None,
-                data=query.data,
-                priority=priority,
-                wait_dispatch=False,
-            )
-        else:
-            await self._civ(
-                query.command,
-                sub=query.sub,
-                data=query.data,
-                priority=priority,
-                wait_dispatch=False,
-            )
+        scope_rx = 0
+        if self._radio_state:
+            scope_rx = self._radio_state.scope_controls.receiver
+        command, sub, data = wire_parts_for_query(query, scope_rx)
+        await self._civ(
+            command,
+            sub=sub,
+            data=data,
+            priority=priority,
+            wait_dispatch=False,
+        )
 
     # Per-getter timeout for scope-control fetches.  The IC-7610 scope stream
     # (~225 pkt/s) sometimes drops individual control responses; a long wait

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -110,12 +110,12 @@ from ..core.tx_target import (
     TxTarget,
     UnknownTxTarget,
 )
-from .._state_queries import (
+from ..profiles import RadioProfile, resolve_radio_profile
+from ..runtime._state_queries import (
     acquisition_query_resolver_for_profile,
+    tx_target_max_age,
     wire_parts_for_query,
 )
-from ..profiles import RadioProfile, resolve_radio_profile
-from ..runtime._state_queries import tx_target_max_age
 from ..runtime.managed_tx_ingress import bind_managed_tx, refuse_key_without_owner
 from ..runtime.tx_interlock import (
     DeferredTxCommandLane,

--- a/tests/test_profiles_routing.py
+++ b/tests/test_profiles_routing.py
@@ -169,7 +169,7 @@ def _count_self_civ_call_sites() -> int:
 
 
 def test_radio_poller_raw_civ_call_count_is_pinned() -> None:
-    """Ratchet: exactly 10 raw ``self._civ(...)`` sites remain.
+    """Ratchet: exactly 6 raw ``self._civ(...)`` sites remain.
 
     The 8 hand-rolled ``self._civ(0x07, ...)`` VFO-switch frames that used
     to live in ``SetFreq``/``SetMode`` (the ``receiver!=0`` fallback dance
@@ -180,12 +180,19 @@ def test_radio_poller_raw_civ_call_count_is_pinned() -> None:
     ``SwitchScopeReceiver`` was the 11th (MOR-2106): it now resolves
     ``set_scope_main_sub`` through ``_send_cmd`` instead of building
     ``0x27 0x12`` as a literal in ``_execute`` -- reusing ``_send_cmd``'s
-    existing two call sites below rather than adding a new one. The 10
-    that remain:
+    existing two call sites below rather than adding a new one.
+    ``_send_one_state_query`` used to hold 5 of its own branches (cmd29
+    wrap x2, the scope-receiver rewrite, and a sub-is-None/sub-is-set
+    split that only differed in whether ``sub=None`` was spelled out) --
+    those collapsed into the one call below when the wire-frame assembly
+    moved into the shared ``runtime._state_queries.wire_parts_for_query``,
+    also used by ``RigctldServer._send_one_state_query`` and
+    ``runtime.radio_initial_state.fetch_initial_state``. The 6 that
+    remain:
 
     - ``_send_cmd``: 2 — cmd29-wrapped vs. plain generic command dispatch.
-    - ``_send_one_state_query``: 5 — selected/unselected freq/mode state
-      reads plus the scope-receiver default read.
+    - ``_send_one_state_query``: 1 — dispatches whatever
+      ``wire_parts_for_query`` resolved.
     - ``_execute``: 2 — the BSR band-switch stored-freq read and
       ``SelectVfo``'s scope-follow (0x27 0x12).
     - ``_send_query``: 1 — the meter poll read.
@@ -193,7 +200,7 @@ def test_radio_poller_raw_civ_call_count_is_pinned() -> None:
     Changing this literal deliberately means recounting the real call
     sites above, not just editing the number.
     """
-    assert _count_self_civ_call_sites() == 10
+    assert _count_self_civ_call_sites() == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -33,6 +33,7 @@ from rigplane.core.acquisition_scheduler import (
     RadioStateModelService,
     StateFreshnessService,
 )
+from rigplane.core.radio_state import RadioState
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     FieldAvailability,
@@ -162,6 +163,12 @@ class _ProfiledStandaloneRadio:
         self.radio_ready = True
         self.control_connected = True
         self.get_freq = AsyncMock(return_value=14_090_000)
+        self._radio_state = RadioState()
+
+    @property
+    def radio_state(self) -> RadioState:
+        """Match the ``Radio`` protocol's required ``radio_state`` member."""
+        return self._radio_state
 
 
 class _CivProfiledStandaloneRadio(_ProfiledStandaloneRadio):

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -403,6 +403,19 @@ async def test_web_scope_receiver_rewrite_preserves_data_suffix() -> None:
 
 
 @pytest.mark.asyncio
+async def test_web_scope_receiver_none_radio_state_falls_back_to_main() -> None:
+    """Pins ``poller._radio_state is None`` -> substituted byte 0 == 0.
+
+    ``_send_through_web`` sets ``poller._radio_state = None`` when
+    ``scope_receiver`` is omitted (see its own default), so this exercises
+    the fallback branch directly rather than relying on an unexercised
+    default value.
+    """
+    query = acquisition_query(0x27, sub=0x14, data=b"\x00\xaa\xbb")
+    assert await _send_through_web(query) == (0x27, 0x14, b"\x00\xaa\xbb")
+
+
+@pytest.mark.asyncio
 async def test_all_senders_substitute_live_scope_receiver_on_0x27() -> None:
     query = acquisition_query(0x27, sub=0x14, data=b"\x00\xaa\xbb")
     expected = (0x27, 0x14, b"\x01\xaa\xbb")

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -28,6 +28,7 @@ from rigplane.rigctld.server import RigctldServer
 from rigplane.runtime import _state_queries as state_queries_module
 from rigplane.runtime._state_queries import build_state_queries
 from rigplane.runtime._state_queries import acquisition_query_resolver_for_profile
+from rigplane.runtime._state_queries import wire_parts_for_query
 from rigplane.runtime.radio_initial_state import fetch_initial_state
 from rigplane.web.radio_poller import RadioPoller
 from _acquisition_query_helpers import (
@@ -256,13 +257,20 @@ class _RecordingCivRadio:
         self.options.append((wait_response, priority, wait_dispatch))
 
 
-async def _send_through_initial(query: AcquisitionQueryCase) -> _FrameParts:
+async def _send_through_initial(
+    query: AcquisitionQueryCase,
+    *,
+    scope_receiver: int = 0,
+) -> _FrameParts:
     radio = _RecordingCivRadio()
     radio._profile = SimpleNamespace(has_lan=True)
     radio.capabilities = set()
     radio._INITIAL_STATE_GAP_SERIAL = 0.0
     radio._INITIAL_STATE_GAP_LAN = 0.0
     radio._initial_state_fetched = False
+    radio.radio_state = SimpleNamespace(
+        scope_controls=SimpleNamespace(receiver=scope_receiver),
+    )
     with patch.object(
         state_queries_module, "build_state_queries", return_value=[query]
     ):
@@ -297,8 +305,15 @@ async def _send_through_web(
     )
 
 
-async def _send_through_rigctld(query: AcquisitionQueryCase) -> _FrameParts:
+async def _send_through_rigctld(
+    query: AcquisitionQueryCase,
+    *,
+    scope_receiver: int = 0,
+) -> _FrameParts:
     radio = _RecordingCivRadio()
+    radio.radio_state = SimpleNamespace(
+        scope_controls=SimpleNamespace(receiver=scope_receiver),
+    )
     server = object.__new__(RigctldServer)
     server._radio = radio
     await RigctldServer._send_one_state_query(server, query)  # noqa: SLF001
@@ -385,6 +400,30 @@ async def test_web_scope_receiver_rewrite_preserves_data_suffix() -> None:
         0x14,
         b"\x01\xaa\xbb",
     )
+
+
+@pytest.mark.asyncio
+async def test_all_senders_substitute_live_scope_receiver_on_0x27() -> None:
+    query = acquisition_query(0x27, sub=0x14, data=b"\x00\xaa\xbb")
+    expected = (0x27, 0x14, b"\x01\xaa\xbb")
+    assert await _send_through_initial(query, scope_receiver=1) == expected
+    assert await _send_through_web(query, scope_receiver=1) == expected
+    assert await _send_through_rigctld(query, scope_receiver=1) == expected
+
+
+def test_wire_parts_for_query_cmd29_wraps_receiver_sub_and_data() -> None:
+    query = acquisition_query(0x1A, sub=0x05, data=b"\x01\x91", receiver=1)
+    assert wire_parts_for_query(query, 0) == (0x29, None, b"\x01\x1a\x05\x01\x91")
+
+
+def test_wire_parts_for_query_substitutes_live_scope_receiver_on_0x27() -> None:
+    query = acquisition_query(0x27, sub=0x14, data=b"\x00\xaa\xbb")
+    assert wire_parts_for_query(query, 1) == (0x27, 0x14, b"\x01\xaa\xbb")
+
+
+def test_wire_parts_for_query_passes_through_non_scope_selector_query() -> None:
+    query = acquisition_query(0x1A, sub=0x05, data=b"\x01\x91")
+    assert wire_parts_for_query(query, 1) == (0x1A, 0x05, b"\x01\x91")
 
 
 @pytest.mark.asyncio
@@ -847,6 +886,9 @@ class TestFetchInitialState:
             profile = resolve_radio_profile(model="IC-7610")
             r._profile = profile
             r._initial_state_fetched = False
+            r._radio_state = SimpleNamespace(
+                scope_controls=SimpleNamespace(receiver=0),
+            )
             r.send_civ = AsyncMock()
             return r
 
@@ -867,6 +909,7 @@ class TestFetchInitialState:
                 expected_calls.append(
                     call(
                         0x29,
+                        sub=None,
                         data=inner + query.data,
                         wait_response=False,
                     )


### PR DESCRIPTION
Linear: MOR-2222 (slice A of two)

## What

One pure function, `runtime/_state_queries.py: wire_parts_for_query(query, scope_receiver)`, turns an `AcquisitionQuery` into `(command, sub, data)`: cmd29 wrapping for receiver-routed queries, and the `0x27` selector-form substitution (data byte 0 ← the live scope receiver) for subs in `SCOPE_RECEIVER_SELECTOR_SUBS`. The three senders delegate to it and lose their own branching:

- `web/radio_poller.py: RadioPoller._send_one_state_query` — behaviour unchanged (it already substituted the live receiver from `self._radio_state`; 0 when `None`).
- `rigctld/server.py: RigctldServer._send_one_state_query` — previously sent `query.data` verbatim, i.e. always MAIN for scope-control reads; now reads `self._radio.radio_state.scope_controls.receiver` (`radio_state` is a required property of the `Radio` protocol, so no fallback is needed).
- `runtime/radio_initial_state.py: fetch_initial_state` — same as rigctld, now reads `radio.radio_state.scope_controls.receiver`.

Receiver source is the `RadioState.scope_controls.receiver` mirror, the one every existing reader uses; the StateStore field `scope_controls.global.display.receiver` is a different, unsynced source (set only after a `0x27` reply is observed) and is deliberately not read here.

## Why

The scheduler resolver hardcodes byte 0 to `SCOPE_SELECTOR_MAIN`; only the web sender overwrote it. On the combined web+rigctld deployment both executors drain one scheduler with different senders, so a rigctld-issued scope read on a dual-scope radio with SUB selected read MAIN's value into the receiver-agnostic field (MOR-2222). Bench (IC-7300): selector-form reads are answered with scope output off; no-selector reads are NAKed.

## Tests

- `tests/test_state_queries.py`: `_send_through_initial` / `_send_through_rigctld` gain the `scope_receiver=` plumbing `_send_through_web` had; new `test_all_senders_substitute_live_scope_receiver_on_0x27` (`0x27 0x14 00 aa bb` with receiver 1 → `01 aa bb` from all three senders); three unit tests of the pure function (cmd29, 0x27, pass-through).
- `tests/test_profiles_routing.py`: `test_radio_poller_raw_civ_call_count_is_pinned` ratchet 10 → 6 raw `self._civ(...)` sites (the five branches of `_send_one_state_query` collapsed into one delegation).
- Mutations (run and restored): rigctld bypassing the function → the parity tests fail at the rigctld assertion only; dropping the substitution inside the function → the 0x27 case fails for all three senders and `test_web_scope_receiver_rewrite_preserves_data_suffix` fails.

## Size

6 files, +131/−96: at the soft threshold. One unit of work because the function has no meaning without all three delegations (a shared sender with one caller is the duplication this PR removes), and the ratchet test must move with the poller's collapsed branches.

Slice B (the scope subsystem owns the reads; `polling_only` entries leave the rig TOMLs; slow refresh while enabled) waits for the owner's three decisions on MOR-2222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
