### PR TITLE
docs: the coordinating session may grant the file-count exception under the owner's delegation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,7 @@ number crosses that guardrail.
 
 | Guardrail | Value | Effect |
 |---|---|---|
-| **Hard ceiling** | 10 files · 1000 changed lines | Do not cross; decompose first (`/decompose-issue`). Not author-waivable — only the owner grants an exception, in the PR, before merge. |
+| **Hard ceiling** | 10 files · 1000 changed lines | Do not cross; decompose first (`/decompose-issue`). Not author-waivable — the owner grants an exception, or the coordinating session does under the owner's delegation of 2026-09-03 (file count only; the line ceiling stays the owner's); either way the exception is recorded as the first line of the PR body before merge, with the count stated as `N code + M regenerated baselines = K files` (the PR's file list at the head, PNGs included). |
 | **Soft threshold** | 6 files · 600 changed lines | Forbids nothing; the PR body must say why this is one unit of work. |
 | New abstractions/layers | forbidden unless issue requires | |
 | Speculative improvements | forbidden | |


### PR DESCRIPTION
One sentence in the Guardrails table of CLAUDE.md records the owner's delegation of 2026-09-03 00:49 UTC (in chat: «наделяю тебя правом давать исключения. Давай мудро, там где это имеет смысл»): the coordinating session may grant the 10-file hard-ceiling exception; the 1000-line ceiling stays the owner's; every exception is recorded as the first line of the PR body with the file count including regenerated baselines. Raised because a peer session correctly refused to act on a delegation relayed in chat while the checked-in rule names the owner only.

This PR changes a rule, so the owner merges it in person; no agent directive is sought.

🤖 Generated with [Claude Code](https://claude.com/claude-code)