### PR TITLE
fix: remove undocumented IC-7300 and FTX-1 profile entries

### DIFF
--- a/rigs/ftx1.toml
+++ b/rigs/ftx1.toml
@@ -966,37 +966,6 @@ set_apf        = { cat = { write = "CO02{val:04d};" } }
 get_apf_freq   = { cat = { read = "CO03;", parse = "CO03{val:04d};" } }
 set_apf_freq   = { cat = { write = "CO03{val:04d};" } }
 
-# ── Clarifier Reset ──
-reset_clarifier = { cat = { write = "RC;" } }
-
-# ── Memory / TX band edge / selected-VFO (absent, D2 MOR-2008 batch 4) ──
-# Protocol mismatch, not a documentation gap: [protocol] type is
-# "yaesu_cat" above, every entry in this table is a { cat = ... } spec,
-# and profiles/rig_loader.py: RigConfig.to_command_map keeps only the
-# CI-V half of CommandSpec -- none of these 16 canonical CI-V key names
-# can be declared under the [opcode, sub]-array syntax at all on this
-# profile. The FTX-1 CAT manual documents an analogous memory-channel
-# family under different ASCII commands (MC/MR/MW/MA/MB) and this
-# profile's own get_freq_sub under a different name for the
-# selected/unselected-VFO idea -- both out of Group B's scope, noted only
-# so nobody double-declares them here.
-get_memory_mode      = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio (tests/command_map_parity_uncovered.txt: cat-only FTX-1)" }
-set_memory_mode      = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-memory_write         = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-memory_to_vfo        = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-memory_clear         = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_memory_contents  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-set_memory_contents  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_bsr              = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-set_bsr              = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_tx_band_count    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_tx_band_edge     = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_selected_freq    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_unselected_freq  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_selected_mode    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-get_unselected_mode  = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-set_selected_mode    = { absent = "protocol mismatch: [protocol] type = \"yaesu_cat\", no CI-V command table on this radio" }
-
 [tx_policy]
 # Measured on the bench (MOR-1912): a controlled write-during-transmit
 # battery sent to the FTX-1 while an operator held a front-panel key. Mode

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1011,23 +1011,9 @@ get_tx_band_count = [0x1E, 0x00]          # source: IC-7300 Advanced Manual (11a
 get_tx_band_edge = [0x1E, 0x01]           # source: IC-7300 Advanced Manual (11a) p.19-7 (detail p.19-9)
 
 # ── VFO ──
-get_vfo = [0x07]
 set_vfo = [0x07]
 get_split = [0x0F]
 set_split = [0x0F]
-# Single receiver: no dual_watch, no main/sub band select, no main/sub tracking (D2, MOR-2014)
-get_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only" }
-# set_dual_watch_off/set_dual_watch_on (not the bare set_dual_watch the
-# pre-migration fallback resolved -- MOR-2007 ruling 1 split the setter key)
-set_dual_watch_off = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only" }
-set_dual_watch_on = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only" }
-# MOR-2117: the bare name dispatches to set_dual_watch_on/set_dual_watch_off
-# above, both already absent for the same reason -- without this row,
-# supports_command answered True for a name the profile otherwise denies.
-set_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table = 00/01/A0/B0 only; dispatches to set_dual_watch_on/set_dual_watch_off, both declared absent above" }
-get_main_sub_band = { absent = "IC-7300 Advanced Manual (11a) command table p.19-3: 0x07 table has no 0xD2" }
-get_main_sub_tracking = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x16 family has no 0x5E" }
-set_main_sub_tracking = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x16 family has no 0x5E" }
 
 # ── Tuning ──
 get_tuning_step = [0x10]
@@ -1040,23 +1026,6 @@ get_preamp = [0x16, 0x02]
 set_preamp = [0x16, 0x02]
 get_ip_plus = [0x16, 0x65]
 set_ip_plus = [0x16, 0x65]
-get_digisel = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x16 family has no 0x4E" }
-set_digisel = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x16 family has no 0x4E" }
-get_digisel_shift = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family has no 0x13" }
-set_digisel_shift = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family has no 0x13" }
-
-# ── Antenna ──
-# MOR-2118: no 0x12 antenna-select command on this radio.
-# - Manual: IC-7300 Advanced Manual (11a) CI-V command table pp.19-3..19-8 --
-#   no 0x12 row (table runs 11* attenuator then 13 speech); no ANT1/ANT2/
-#   "antenna select" anywhere in the document; one physical [ANT] connector.
-# - Bench, 2026-09-01, remote testbed, /dev/cu.usbserial-143310 @115200, addr
-#   0x94: 12 00, 12, and 12 01 each NAK'd (fe fe e0 94 fa fd); 03 answered
-#   fe fe e0 94 03 00 80 23 07 00 fd (DATA) before and after.
-get_antenna = { absent = "IC-7300 Advanced Manual (11a) CI-V command table pp.19-3..19-8: no 0x12 row, no ANT1/ANT2 selection documented, one physical [ANT] connector; bench 2026-09-01 addr 0x94: 12 00/12/12 01 each NAK'd, 03 answered DATA before and after" }
-set_antenna = { absent = "IC-7300 Advanced Manual (11a) CI-V command table pp.19-3..19-8: no 0x12 row, no ANT1/ANT2 selection documented, one physical [ANT] connector; bench 2026-09-01 addr 0x94: 12 00/12/12 01 each NAK'd, 03 answered DATA before and after" }
-get_rx_antenna_ant2 = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no 0x16 0x53 row; single antenna jack" }
-set_rx_antenna_ant2 = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no 0x16 0x53 row; single antenna jack" }
 
 # ── Audio / AF ──
 get_af_level = [0x14, 0x01]
@@ -1065,8 +1034,6 @@ get_rf_gain = [0x14, 0x02]
 set_rf_gain = [0x14, 0x02]
 get_squelch = [0x14, 0x03]
 set_squelch = [0x14, 0x03]
-get_af_mute = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no 1A 09 row (read row-by-row)" }
-set_af_mute = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no 1A 09 row (read row-by-row)" }
 
 # ── DSP / Noise (NB, NR, Notch, APF, Twin Peak) ──
 get_nb = [0x16, 0x22]
@@ -1085,8 +1052,6 @@ get_notch_filter = [0x14, 0x0D]           # Notch position 0-255
 set_notch_filter = [0x14, 0x0D]
 get_manual_notch_width = [0x16, 0x57]     # 0=WIDE, 1=MID, 2=NAR
 set_manual_notch_width = [0x16, 0x57]
-get_apf_type_level = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family skips 04/05" }
-set_apf_type_level = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family skips 04/05" }
 get_twin_peak_filter = [0x16, 0x4F]
 set_twin_peak_filter = [0x16, 0x4F]
 
@@ -1112,8 +1077,6 @@ get_rf_power = [0x14, 0x0A]
 set_rf_power = [0x14, 0x0A]
 get_mic_gain = [0x14, 0x0B]
 set_mic_gain = [0x14, 0x0B]
-get_drive_gain = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family has no 0x14" }
-set_drive_gain = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: 0x14 family has no 0x14" }
 get_compressor = [0x16, 0x44]
 set_compressor = [0x16, 0x44]
 get_compressor_level = [0x14, 0x0E]
@@ -1162,7 +1125,6 @@ set_tuner_status = [0x1C, 0x01]
 # ── Meters ──
 get_s_meter = [0x15, 0x02]
 get_s_meter_sql_status = [0x15, 0x01]
-get_s_meter_sql_status_04 = [0x15, 0x04]
 get_various_squelch = [0x15, 0x05]
 get_overflow_status = [0x15, 0x07]
 get_power_meter = [0x15, 0x11]
@@ -1188,7 +1150,6 @@ set_data_mode = [0x1A, 0x06]
 
 # ── Scope ──
 get_scope_wave = [0x27, 0x00]
-set_scope_wave = [0x27, 0x00]
 scope_on = [0x27, 0x10]
 scope_off = [0x27, 0x10]
 scope_data_output = [0x27, 0x11]
@@ -1208,11 +1169,6 @@ get_scope_during_tx = [0x27, 0x1B]
 get_scope_center_type = [0x27, 0x1C]
 get_scope_vbw = [0x27, 0x1D]
 get_scope_fixed_edge = [0x27, 0x1E]
-# MOR-2105: the 0x27 sub-command table (IC-7300 Advanced Manual (11a)
-# pp.19-7..19-8) runs 1E then 20 -- no 1F row. Live bench: scope_rbw.set
-# timed out with no answer, consistent with an unimplemented command.
-get_scope_rbw = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-7..19-8: 0x27 sub-command table runs 1E then 20, no 1F row" }
-set_scope_rbw = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-7..19-8: 0x27 sub-command table runs 1E then 20, no 1F row" }
 
 # ── Scan ──
 scan_start = [0x0E]
@@ -1224,7 +1180,6 @@ scan_set_resume = [0x0E]                  # source: IC-7300 Advanced Manual (11a
 # ── System / Power ──
 power_on = [0x18]
 power_off = [0x18]
-get_powerstat = { absent = "IC-7300 Advanced Manual (11a) p.19-4: 0x18 rows carry no read marker; live bench 2026-08-30: bare 0x18 query answered NAK(FA)" }
 get_transceiver_id = [0x19, 0x00]
 set_speech = [0x13]
 get_dial_lock = [0x16, 0x50]
@@ -1389,18 +1344,10 @@ get_acc1_mod_level = [0x1A, 0x05, 0x00, 0x64]
 set_acc1_mod_level = [0x1A, 0x05, 0x00, 0x64]
 get_usb_mod_level = [0x1A, 0x05, 0x00, 0x65]
 set_usb_mod_level = [0x1A, 0x05, 0x00, 0x65]
-# No LAN hardware on the IC-7300 (D2, MOR-2014)
-get_lan_mod_level = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no LAN hardware, no LAN row anywhere in the table" }
-set_lan_mod_level = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-2..19-8: no LAN hardware, no LAN row anywhere in the table" }
 get_data_off_mod_input = [0x1A, 0x05, 0x00, 0x66]
 set_data_off_mod_input = [0x1A, 0x05, 0x00, 0x66]
 get_data1_mod_input = [0x1A, 0x05, 0x00, 0x67]
 set_data1_mod_input = [0x1A, 0x05, 0x00, 0x67]
-# DATA-input family stops at DATA1 -- no DATA2/DATA3 split on IC-7300 (D2, MOR-2014)
-get_data2_mod_input = { absent = "IC-7300 Advanced Manual (11a) command table p.19-5: DATA-input family has only 0066/0067, no DATA1/2/3 split" }
-set_data2_mod_input = { absent = "IC-7300 Advanced Manual (11a) command table p.19-5: DATA-input family has only 0066/0067, no DATA1/2/3 split" }
-get_data3_mod_input = { absent = "IC-7300 Advanced Manual (11a) command table p.19-5: DATA-input family has only 0066/0067, no DATA1/2/3 split" }
-set_data3_mod_input = { absent = "IC-7300 Advanced Manual (11a) command table p.19-5: DATA-input family has only 0066/0067, no DATA1/2/3 split" }
 get_civ_transceive = [0x1A, 0x05, 0x00, 0x71]
 set_civ_transceive = [0x1A, 0x05, 0x00, 0x71]
 # MOR-2118: measured 2026-09-01 14:39-14:41 UTC, remote testbed. Owner
@@ -1426,10 +1373,6 @@ get_utc_offset = [0x1A, 0x05, 0x00, 0x96]
 set_utc_offset = [0x1A, 0x05, 0x00, 0x96]
 get_quick_split = [0x1A, 0x05, 0x00, 0x30]  # source: IC-7300 Advanced Manual (11a) p.19-4, control 0030 "quick split set" (the old hardcoded fallback sent 0x33, split lock, not this address)
 set_quick_split = [0x1A, 0x05, 0x00, 0x30]  # source: IC-7300 Advanced Manual (11a) p.19-4, control 0030 "quick split set" (the old hardcoded fallback sent 0x33, split lock, not this address)
-# Full 1A 05 submenu has no dual-watch item -- 0032 is FM split offset on this
-# radio (D2, MOR-2014)
-get_quick_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-7: full 1A 05 submenu has no dual-watch item; 0032 on this radio is FM split offset" }
-set_quick_dual_watch = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-7: full 1A 05 submenu has no dual-watch item; 0032 on this radio is FM split offset" }
 get_dash_ratio = [0x1A, 0x05, 0x01, 0x61]  # source: IC-7300 Advanced Manual (11a) command table p.19-6, control 0161 (28..45); live bench 2026-08-30: read of 1A 05 01 61 answered 30
 set_dash_ratio = [0x1A, 0x05, 0x01, 0x61]  # source: IC-7300 Advanced Manual (11a) command table p.19-6, control 0161 (28..45); live bench 2026-08-30: read of 1A 05 01 61 answered 30
 get_nb_depth = [0x1A, 0x05, 0x01, 0x89]
@@ -1438,14 +1381,6 @@ get_nb_width = [0x1A, 0x05, 0x01, 0x90]
 set_nb_width = [0x1A, 0x05, 0x01, 0x90]
 get_vox_delay = [0x1A, 0x05, 0x01, 0x91]     # 0-20 (0.0-2.0 sec)
 set_vox_delay = [0x1A, 0x05, 0x01, 0x91]     # 0-20 (0.0-2.0 sec)
-# MOR-2190 temporary fail-closed overrides: these are direct findings from the
-# official manual, not inherited unsupported markers. The explicit entries
-# keep the profile's negative knowledge inspectable while replacement APIs are
-# deliberately deferred.
-get_scope_marker_position = { absent = "IC-7300 Advanced Manual (11a) command table p.19-4: 1A 05 0040 is Speech Speed (00=Low, 01=High), not scope marker position" }
-set_scope_marker_position = { absent = "IC-7300 Advanced Manual (11a) command table p.19-4: 1A 05 0040 is Speech Speed (00=Low, 01=High), not scope marker position" }
-get_ref_adjust = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-5: 1A 05 0070 is external-keypad RTTY Memory; reference frequency is 0058 with 0000..0255 domain" }
-set_ref_adjust = { absent = "IC-7300 Advanced Manual (11a) command table pp.19-4..19-5: 1A 05 0070 is external-keypad RTTY Memory; reference frequency is 0058 with 0000..0255 domain" }
 
 [protocol]
 type = "civ"

--- a/tests/command_map_parity_uncovered.txt
+++ b/tests/command_map_parity_uncovered.txt
@@ -27,7 +27,7 @@
 # execute. Every number here is re-measured and asserted by that
 # test. Regenerate, do not edit.
 census	builders_compared	0
-census	cat_only_profiles	0
+census	cat_only_profiles	1
 census	dual_implementation_sites	0
 census	frames_diverged	0
 census	frames_identical	0
@@ -36,6 +36,7 @@ census	profile_builder_map_gaps	0
 census	profiles	8
 census	public_builders	241
 census	sites_compared	0
+cat-only	FTX-1	109
 requires-map	antenna.py:get_antenna_1
 requires-map	antenna.py:get_antenna_2
 requires-map	antenna.py:get_rx_antenna_ant1

--- a/tests/profile_command_coverage_gaps.txt
+++ b/tests/profile_command_coverage_gaps.txt
@@ -3,21 +3,21 @@
 #   gap     <command-map key>   <profiles missing it, comma sep.>
 # One 'gap' row per key: neither declared nor declared absent for
 # every profile named, unless its contracted optional capability is
-# omitted -- D1's state 3. Fails on a pair missing here
-# or a row no longer a gap -- delete it, never keep it. Fill a gap
-# via { absent = "<source>" } (plan §8.1 D2) or a real command-byte
-# entry in the profile's own TOML. Regenerate, do not hand-edit.
+# omitted. Includes intentional manual-only omissions (MOR-2257).
+# Fails on an unlisted pair or a stale row; membership changes
+# require review. Not manual completeness or execution evidence.
+# Regenerate, do not hand-edit.
 census	civ_profiles	6
-census	distinct_gap_keys	144
-census	profile_key_gaps	294
+census	distinct_gap_keys	145
+census	profile_key_gaps	327
 census	public_builders	241
 gap	get_acc1_mod_level	X6100,X6200
-gap	get_af_mute	X6100,X6200
+gap	get_af_mute	IC-7300,X6100,X6200
 gap	get_agc_time_constant	X6100,X6200
 gap	get_alc	X6100,X6200
-gap	get_antenna	X6100,X6200
+gap	get_antenna	IC-7300,X6100,X6200
 gap	get_anti_vox_gain	X6100,X6200
-gap	get_apf_type_level	X6100,X6200
+gap	get_apf_type_level	IC-7300,X6100,X6200
 gap	get_break_in_delay	X6100,X6200
 gap	get_civ_output_ant	X6100,X6200
 gap	get_civ_transceive	X6100,X6200
@@ -25,20 +25,20 @@ gap	get_comp_meter	X6100,X6200
 gap	get_compressor_level	X6100,X6200
 gap	get_dash_ratio	X6100,X6200
 gap	get_data1_mod_input	X6100,X6200
-gap	get_data2_mod_input	X6100,X6200
-gap	get_data3_mod_input	X6100,X6200
+gap	get_data2_mod_input	IC-7300,X6100,X6200
+gap	get_data3_mod_input	IC-7300,X6100,X6200
 gap	get_data_mode	X6100,X6200
 gap	get_data_off_mod_input	X6100,X6200
-gap	get_digisel	X6100,X6200
-gap	get_digisel_shift	X6100,X6200
-gap	get_drive_gain	X6100,X6200
-gap	get_dual_watch	X6100,X6200
+gap	get_digisel	IC-7300,X6100,X6200
+gap	get_digisel_shift	IC-7300,X6100,X6200
+gap	get_drive_gain	IC-7300,X6100,X6200
+gap	get_dual_watch	IC-7300,X6100,X6200
 gap	get_filter_shape	X6100,X6200
 gap	get_id_meter	X6100,X6200
 gap	get_ip_plus	X6100,X6200
-gap	get_lan_mod_level	X6100,X6200
-gap	get_main_sub_band	X6100,X6200
-gap	get_main_sub_tracking	X6100,X6200
+gap	get_lan_mod_level	IC-7300,X6100,X6200
+gap	get_main_sub_band	IC-7300,X6100,X6200
+gap	get_main_sub_tracking	IC-7300,X6100,X6200
 gap	get_manual_notch_width	X6100,X6200
 gap	get_memory_mode	IC-705,IC-7300,IC-7610,IC-9700
 gap	get_monitor	X6100,X6200
@@ -48,16 +48,16 @@ gap	get_notch_filter	X6100,X6200
 gap	get_overflow_status	X6100,X6200
 gap	get_pbt_inner	X6100,X6200
 gap	get_pbt_outer	X6100,X6200
-gap	get_powerstat	IC-705,IC-7610,X6100,X6200
-gap	get_quick_dual_watch	X6100,X6200
+gap	get_powerstat	IC-705,IC-7300,IC-7610,X6100,X6200
+gap	get_quick_dual_watch	IC-7300,X6100,X6200
 gap	get_quick_split	X6100,X6200
-gap	get_ref_adjust	X6100,X6200
+gap	get_ref_adjust	IC-7300,X6100,X6200
 gap	get_repeater_tone	X6100,X6200
 gap	get_repeater_tsql	X6100,X6200
 gap	get_rit_frequency	X6100,X6200
 gap	get_rit_status	X6100,X6200
 gap	get_rit_tx_status	X6100,X6200
-gap	get_rx_antenna_ant2	X6100,X6200
+gap	get_rx_antenna_ant2	IC-7300,X6100,X6200
 gap	get_s_meter_sql_status	X6100,X6200
 gap	get_scope_center_type	X6100,X6200
 gap	get_scope_during_tx	X6100,X6200
@@ -66,7 +66,7 @@ gap	get_scope_fixed_edge	X6100,X6200
 gap	get_scope_hold	X6100,X6200
 gap	get_scope_main_sub	X6100,X6200
 gap	get_scope_mode	X6100,X6200
-gap	get_scope_rbw	X6100,X6200
+gap	get_scope_rbw	IC-7300,X6100,X6200
 gap	get_scope_ref	X6100,X6200
 gap	get_scope_single_dual	X6100,X6200
 gap	get_scope_span	X6100,X6200
@@ -84,6 +84,7 @@ gap	get_twin_peak_filter	X6100,X6200
 gap	get_usb_mod_level	X6100,X6200
 gap	get_utc_offset	X6100,X6200
 gap	get_various_squelch	X6100,X6200
+gap	get_vfo	IC-7300
 gap	get_vox_delay	X6100,X6200
 gap	get_vox_gain	X6100,X6200
 gap	get_xfc_status	X6100,X6200
@@ -99,31 +100,31 @@ gap	scope_off	X6100,X6200
 gap	scope_on	X6100,X6200
 gap	send_cw	X6100,X6200
 gap	set_acc1_mod_level	X6100,X6200
-gap	set_af_mute	X6100,X6200
+gap	set_af_mute	IC-7300,X6100,X6200
 gap	set_agc_time_constant	X6100,X6200
-gap	set_antenna	X6100,X6200
+gap	set_antenna	IC-7300,X6100,X6200
 gap	set_anti_vox_gain	X6100,X6200
-gap	set_apf_type_level	X6100,X6200
+gap	set_apf_type_level	IC-7300,X6100,X6200
 gap	set_break_in_delay	X6100,X6200
 gap	set_civ_output_ant	X6100,X6200
 gap	set_civ_transceive	X6100,X6200
 gap	set_compressor_level	X6100,X6200
 gap	set_dash_ratio	X6100,X6200
 gap	set_data1_mod_input	X6100,X6200
-gap	set_data2_mod_input	X6100,X6200
-gap	set_data3_mod_input	X6100,X6200
+gap	set_data2_mod_input	IC-7300,X6100,X6200
+gap	set_data3_mod_input	IC-7300,X6100,X6200
 gap	set_data_mode	X6100,X6200
 gap	set_data_off_mod_input	X6100,X6200
-gap	set_digisel	X6100,X6200
-gap	set_digisel_shift	X6100,X6200
-gap	set_drive_gain	X6100,X6200
-gap	set_dual_watch_off	X6100,X6200
-gap	set_dual_watch_on	X6100,X6200
+gap	set_digisel	IC-7300,X6100,X6200
+gap	set_digisel_shift	IC-7300,X6100,X6200
+gap	set_drive_gain	IC-7300,X6100,X6200
+gap	set_dual_watch_off	IC-7300,X6100,X6200
+gap	set_dual_watch_on	IC-7300,X6100,X6200
 gap	set_filter_shape	X6100,X6200
 gap	set_filter_width	X6100,X6200
 gap	set_ip_plus	X6100,X6200
-gap	set_lan_mod_level	X6100,X6200
-gap	set_main_sub_tracking	X6100,X6200
+gap	set_lan_mod_level	IC-7300,X6100,X6200
+gap	set_main_sub_tracking	IC-7300,X6100,X6200
 gap	set_manual_notch_width	X6100,X6200
 gap	set_monitor	X6100,X6200
 gap	set_nb_depth	X6100,X6200
@@ -131,15 +132,15 @@ gap	set_nb_width	X6100,X6200
 gap	set_notch_filter	X6100,X6200
 gap	set_pbt_inner	X6100,X6200
 gap	set_pbt_outer	X6100,X6200
-gap	set_quick_dual_watch	X6100,X6200
+gap	set_quick_dual_watch	IC-7300,X6100,X6200
 gap	set_quick_split	X6100,X6200
-gap	set_ref_adjust	X6100,X6200
+gap	set_ref_adjust	IC-7300,X6100,X6200
 gap	set_repeater_tone	X6100,X6200
 gap	set_repeater_tsql	X6100,X6200
 gap	set_rit_frequency	X6100,X6200
 gap	set_rit_status	X6100,X6200
 gap	set_rit_tx_status	X6100,X6200
-gap	set_rx_antenna_ant2	X6100,X6200
+gap	set_rx_antenna_ant2	IC-7300,X6100,X6200
 gap	set_scope_main_sub	IC-7300,X6100,X6200
 gap	set_selected_mode	IC-7300,IC-7610,IC-9700
 gap	set_ssb_tx_bandwidth	X6100,X6200

--- a/tests/reverse_command_index_census.txt
+++ b/tests/reverse_command_index_census.txt
@@ -16,7 +16,7 @@
 # Regenerate the same way after an intentional profile/command change --
 # do not hand-edit.
 IC-705	242	126	227
-IC-7300	323	182	279
+IC-7300	320	181	275
 IC-7610	216	129	169
 IC-9700	228	136	181
 X6100	67	42	50

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -150,7 +150,7 @@ def test_ic7300_removed_apf_getters_resolve_none() -> None:
 
     assert profile.command_map is not None
     assert not profile.command_map.has("get_audio_peak_filter")
-    assert "get_apf_type_level" in profile.absent_command_names
+    assert not profile.command_map.has("get_apf_type_level")
     assert executor.query_for_path(audio_peak) is None
     assert executor.query_for_path(apf_level) is None
     assert profile.state_acquisition is not None

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -9,7 +9,6 @@ import pytest
 
 from rigplane.command_spec import AbsentCommandSpec, CatCommandSpec, CivCommandSpec
 from rigplane.rig_loader import RigLoadError, load_rig
-from test_rig_loader import TestFtx1DeclaresAbsentCommands as _Ftx1AbsentPin
 from test_rig_loader import TestIc7610DeclaresAbsentCommands as _Ic7610AbsentPin
 from test_rig_loader import TestTx500DeclaresAbsentCommands as _Tx500AbsentPin
 from test_rig_loader import TestX6100DeclaresAbsentCommands as _X6100AbsentPin
@@ -423,15 +422,14 @@ class TestBackwardCompatibility:
     def _assert_loads_except_declared_absent(
         self, toml_name: str, expected_absent: frozenset[str], live_spec_type: type
     ) -> None:
-        """Shared body for the four MOR-2008 batch 4 checks below: every
+        """Shared body for the four profile checks below: every
         command in ``rig.commands`` is *live_spec_type* except the pinned
         absent set, discriminating both directions the same way
         ``test_ic7610_loads_civ_except_the_declared_absent_tone_tsql_family``
         above does -- a row silently becoming absent, or an absent row
         silently reverting to live, fails regardless of which name moves.
-        Generalized to four callers (X6200/X6100: ``CivCommandSpec``;
-        FTX-1/TX-500: ``CatCommandSpec``) rather than duplicated a fourth
-        and fifth time, per the rule of three.
+        X6200/X6100 retain CI-V specs; FTX-1/TX-500 retain CAT specs.
+        FTX-1's manual-only policy requires an empty absent set.
         """
         rigs_dir = Path(__file__).resolve().parent.parent / "rigs"
         p = rigs_dir / toml_name
@@ -456,8 +454,7 @@ class TestBackwardCompatibility:
             if isinstance(spec, AbsentCommandSpec)
         }
         assert actually_absent == expected_absent, (
-            f"{toml_name}'s AbsentCommandSpec entries drifted from its own "
-            "TestXDeclaresAbsentCommands._EXPECTED_ABSENT pin"
+            f"{toml_name}'s AbsentCommandSpec entries drifted from its expected set"
         )
 
     def test_x6200_loads_civ_except_the_declared_absent_group_b_family(self) -> None:
@@ -476,17 +473,14 @@ class TestBackwardCompatibility:
             "x6100.toml", _X6100AbsentPin._EXPECTED_ABSENT, CivCommandSpec
         )
 
-    def test_ftx1_loads_cat_except_the_declared_absent_group_b_family(self) -> None:
-        """MOR-2008 batch 4: FTX-1 declares all 16 Group B canonical keys
-        absent (protocol mismatch -- [protocol] type = "yaesu_cat") --
-        everything else in its ``[commands]`` table is CatCommandSpec.
-        """
+    def test_ftx1_loads_only_cat_specs_without_absent_markers(self) -> None:
+        """MOR-2257: every retained FTX-1 declaration is a CAT spec."""
         self._assert_loads_except_declared_absent(
-            "ftx1.toml", _Ftx1AbsentPin._EXPECTED_ABSENT, CatCommandSpec
+            "ftx1.toml", frozenset(), CatCommandSpec
         )
 
     def test_tx500_loads_cat_except_the_declared_absent_group_b_family(self) -> None:
-        """Sibling of the FTX-1 check above ([protocol] type = "kenwood_cat")."""
+        """TX-500 retains its protocol-mismatch absent markers."""
         self._assert_loads_except_declared_absent(
             "tx500.toml", _Tx500AbsentPin._EXPECTED_ABSENT, CatCommandSpec
         )

--- a/tests/test_ftx1_radio.py
+++ b/tests/test_ftx1_radio.py
@@ -1244,10 +1244,17 @@ async def test_set_clarifier_freq(connected_radio):
 
 
 @pytest.mark.asyncio
-async def test_reset_clarifier(connected_radio):
+@pytest.mark.parametrize("receiver", [0, 1])
+async def test_reset_clarifier_is_undeclared_before_transport(
+    connected_radio, receiver
+):
     connected_radio._transport.write = AsyncMock()
-    await connected_radio.reset_clarifier()
-    connected_radio._transport.write.assert_called_once_with("RC;")
+    connected_radio._transport.query = AsyncMock()
+    with pytest.raises(CommandError, match="reset_clarifier.*not found in profile"):
+        await connected_radio.reset_clarifier(receiver=receiver)
+    assert not connected_radio.supports_command("reset_clarifier")
+    connected_radio._transport.write.assert_not_awaited()
+    connected_radio._transport.query.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_profile_command_coverage.py
+++ b/tests/test_profile_command_coverage.py
@@ -1,10 +1,8 @@
-"""State-3 guard for D1 (plan §4 Step 4,
-``docs/plans/2026-08-29-profile-driven-command-bytes.md`` §8.1): a CI-V
-profile that neither declares a command-map key nor records it as absent
-leaves that name in the state D1 says "must not exist at release" --
-reached at runtime it falls back to logging and refusing (pinned by
-``tests/test_undeclared_command_policy.py``); this is the guard that keeps
-that fallback from firing in production.
+"""Census of shared CI-V builder keys omitted by shipped profiles.
+
+Missing declarations refuse at runtime. This baseline records omissions,
+including intentional manual-only omissions in IC-7300 (MOR-2257); it is
+neither manufacturer completeness nor an implementation-success verdict.
 
 Method, shared with ``tests/test_command_map_parity.py`` (the parity
 harness) per the plan's own instruction to derive keys "the way the parity
@@ -33,17 +31,7 @@ command-map key -- deduplicated by key, per the plan's own phrasing
 ("enumerate every public builder KEY") -- with the profiles missing that
 key comma-separated on the row, the same compact shape
 ``tests/command_map_parity_uncovered.txt``'s own ``gap`` rows use. The
-baseline started large by construction (D2, plan §8.1: at that point no rig
-TOML used the ``{ absent = "<source>" }`` spelling at all). Which profiles
-have since been filled with it used to be tracked by
-``tests/test_rig_loader.py::TestNoShippedProfileUsesAbsentSpellingYet``,
-narrowed as each profile's own D2 pass landed; MOR-2008 batch 4's
-``ftx1.toml``/``tx500.toml`` pass was the last shipped profile to be
-filled, narrowing that pin's parametrize set to empty, so it was deleted
-per its own docstring's contingency rather than kept as a vacuous test.
-Each profile's per-model ``TestXDeclaresAbsentCommands`` class in that same
-file is the durable record now, not restated here; this file's baseline is
-meant to shrink only, never grow silently.
+baseline must change explicitly when profile membership changes.
 
 That baseline measures declaration completeness only: absent markers are not
 manual proof, and an omitted optional capability is the authority for excluding
@@ -1040,10 +1028,10 @@ def _render(report: _Report) -> str:
         "#   gap     <command-map key>   <profiles missing it, comma sep.>",
         "# One 'gap' row per key: neither declared nor declared absent for",
         "# every profile named, unless its contracted optional capability is",
-        "# omitted -- D1's state 3. Fails on a pair missing here",
-        "# or a row no longer a gap -- delete it, never keep it. Fill a gap",
-        '# via { absent = "<source>" } (plan §8.1 D2) or a real command-byte',
-        "# entry in the profile's own TOML. Regenerate, do not hand-edit.",
+        "# omitted. Includes intentional manual-only omissions (MOR-2257).",
+        "# Fails on an unlisted pair or a stale row; membership changes",
+        "# require review. Not manual completeness or execution evidence.",
+        "# Regenerate, do not hand-edit.",
     ]
     rows = [f"census\t{name}\t{n}" for name, n in sorted(report.census.items())]
     rows += [
@@ -1236,10 +1224,22 @@ def test_ic7300_scope_wave_inbound_uses_profile_reverse_index(
     assert finding.reachability is _ExecutionReachability.UNKNOWN
 
 
-def test_declared_absent_marker_does_not_hide_existing_code_route(
-    implementation_report: _ImplementationReport,
-) -> None:
-    finding = implementation_report.find("icom_ic7300", "command", "get_powerstat")
+def _synthetic_absent_powerstat_config() -> typing.Any:
+    config = _civ_rigs()["IC-7300"]
+    return replace(
+        config,
+        commands={
+            **config.commands,
+            "get_powerstat": AbsentCommandSpec("synthetic test absence"),
+        },
+    )
+
+
+def test_declared_absent_marker_does_not_hide_existing_code_route() -> None:
+    report = implementation_completeness_report(
+        {"synthetic": _synthetic_absent_powerstat_config()}, repo_root=REPO_ROOT
+    )
+    finding = report.find("icom_ic7300", "command", "get_powerstat")
 
     assert finding.declared_absent
     assert finding.relation is _DeclarationRelation.IMPLEMENTED
@@ -1311,7 +1311,7 @@ def test_reverse_census_rejects_unused_mismatch_evidence() -> None:
 
 
 def test_reverse_census_preserves_absent_and_rejects_false_evidence() -> None:
-    profile = discover_rigs(RIGS_DIR)["IC-7300"].to_profile()
+    profile = _synthetic_absent_powerstat_config().to_profile()
     (absent,) = reverse_implementation_census(profile, ("get_powerstat",))
 
     assert absent.relation is _DeclarationRelation.ABSENT

--- a/tests/test_rig_ic7300.py
+++ b/tests/test_rig_ic7300.py
@@ -316,14 +316,12 @@ class TestCapabilities:
 class TestWrongManualBindingsFailClosed:
     """MOR-2190: direct official-manual corrections, not inherited markers."""
 
-    def test_all_four_names_are_explicitly_absent_and_unbound(self, profile, cmdmap):
+    def test_all_four_wrong_names_are_undeclared_and_unbound(self, profile, cmdmap):
         assert len(_WRONG_MANUAL_BINDINGS) == 4
-        for name, (wrong_wire, semantic) in _WRONG_MANUAL_BINDINGS.items():
+        for name, (wrong_wire, _) in _WRONG_MANUAL_BINDINGS.items():
             assert name not in profile.command_names
-            assert name in profile.absent_command_names
-            source = profile.absent_command_sources[name]
-            assert source.startswith("IC-7300 Advanced Manual (11a)")
-            assert semantic in source
+            assert name not in profile.absent_command_names
+            assert name not in profile.absent_command_sources
             assert not cmdmap.has(name), f"{name} still serializes {wrong_wire!r}"
 
     def test_all_four_names_are_unsupported_by_the_shipped_radio(self, profile):
@@ -350,7 +348,7 @@ class TestWrongManualBindingsFailClosed:
         visited: set[str] = set()
         for name, args in _PUBLIC_FAIL_BEFORE_WIRE_CALLS.items():
             visited.add(name)
-            with pytest.raises(CommandError, match="declared absent by this profile"):
+            with pytest.raises(CommandError, match="not declared by this profile"):
                 await getattr(radio, name)(*args)
 
         assert visited == set(_PUBLIC_FAIL_BEFORE_WIRE_CALLS)
@@ -476,8 +474,8 @@ class TestCommandOverrides:
     def test_get_s_meter_sql_status(self, cmdmap):
         assert cmdmap.get("get_s_meter_sql_status") == (0x15, 0x01)
 
-    def test_get_s_meter_sql_status_04(self, cmdmap):
-        assert cmdmap.get("get_s_meter_sql_status_04") == (0x15, 0x04)
+    def test_undocumented_s_meter_sql_status_04_is_not_bound(self, cmdmap):
+        assert not cmdmap.has("get_s_meter_sql_status_04")
 
     def test_get_split_opcode(self, cmdmap):
         assert cmdmap.get("get_split") == (0x0F,)

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import textwrap
 from decimal import Decimal
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
@@ -2753,64 +2754,16 @@ class TestFilterShapeDomainDeclaredOrCapabilityAbsent:
             assert rig.filter_shape_labels == {"0": "SHARP", "1": "SOFT"}, name
 
 
-# MOR-2005 step 4a landed only the ``{ absent = "<source>" }`` spelling
-# itself (plan `docs/plans/2026-08-29-profile-driven-command-bytes.md`
-# §8.1 D1/D2) — it did not fill any profile with it. D2's filling work was
-# separate, ticket-tracked, later work: MOR-2014 filled ``ic7300.toml``
-# (27 commands, D2 documentary + live-bench verdicts), MOR-2015 filled
-# ``ic9700.toml`` (26 commands, D2 documentary verdicts against the
-# IC-9700 CI-V Reference Guide), MOR-2016 filled ``ic705.toml`` (24
-# commands, D2 documentary verdicts against the IC-705 CI-V Reference
-# Guide), MOR-2008 batch 2 filled ``ic7610.toml`` (8 commands, the
-# repeater-tone/TSQL/tone-freq/TSQL-freq family, promoting a comment-only
-# D1 state 3 to a formal state 2 row grounded in a live-bench readback
-# rather than a documentary source), MOR-2008 batch 3 filled
-# ``x6100.toml``/``x6200.toml`` (6 commands each, the vox/break-in/
-# manual-notch family, promoting a comment-only D1 state 3 to a formal
-# state 2 row grounded in the V1.0.6 documentary table rather than a live
-# capture), and MOR-2008 batch 4 added 11 more each to ``x6100.toml``/
-# ``x6200.toml`` (the memory.py/tx_band.py Group B family, same V1.0.6
-# documentary grounding) plus filled ``ftx1.toml``/``tx500.toml`` (16
-# commands each, all 16 Group B canonical keys, grounded in protocol
-# mismatch rather than a documentary or live source). This was the last
-# shipped profile to be filled: a
-# ``TestNoShippedProfileUsesAbsentSpellingYet`` pin used to sit here,
-# narrowed as each profile's own D2 pass landed and deleted, per its own
-# docstring's contingency, once MOR-2008 batch 4's pass narrowed its
-# parametrize set to empty rather than leave a vacuous test collecting
-# zero cases. Each profile's own ``TestXDeclaresAbsentCommands`` class
-# below is the durable per-model record now.
+# Manual-only membership and other-model absent-schema pins are separate.
 
 
-class TestIc7300DeclaresAbsentCommands:
-    """MOR-2014 (D2): IC-7300 is the first shipped profile to use the
-    ``{ absent = "<source>" }`` spelling, for the commands the IC-7300
-    Advanced Manual (11a) command table (pp.19-2..19-8) confirms have no
-    row on this radio -- 27 at D2 time; MOR-2007 ruling 1 later split
-    ``set_dual_watch`` into ``set_dual_watch_off``/``set_dual_watch_on``
-    (+1, to 28), then MOR-2008 batch 1 deleted the dead bare
-    ``quick_dual_watch`` entry alongside the bare ``quick_split`` row it
-    was declared next to (-1, back to 27 -- a different 27 than D2's, not
-    the same set reverted), then MOR-2105 part 1 (2026-09-01) added
-    ``get_scope_rbw``/``set_scope_rbw`` (+2, to 29), then the same day
-    MOR-2118 added ``get_antenna``/``set_antenna`` (no 0x12 row on this
-    radio) and MOR-2117 added the bare ``set_dual_watch`` (dispatches to
-    the two split names above, already absent, but was itself in neither
-    list) (+3, to 32), then MOR-2190 replaced six proven-wrong positive
-    bindings with direct official-manual absent entries (+6, to 38), then
-    MOR-2246 deleted the misnamed ``get_tx_freq_monitor``/
-    ``set_tx_freq_monitor`` pair entirely rather than leave it declared
-    absent (-2, to 36 -- the current count, per ``len(_EXPECTED_ABSENT)``).
-    Pinned by name, not just count, so a future D2 pass on another command
-    can't silently swap one of these for a different one and still pass a
-    bare-count check.
-    """
+class TestIc7300ManualOnlyCommands:
+    """MOR-2257: retain the 11a profile names, without negative markers."""
 
-    _EXPECTED_ABSENT = frozenset(
+    _REMOVED_NAMES = frozenset(
         {
             "get_af_mute",
             "set_af_mute",
-            # MOR-2118: no 0x12 antenna-select command on this radio.
             "get_antenna",
             "set_antenna",
             "get_apf_type_level",
@@ -2828,10 +2781,6 @@ class TestIc7300DeclaresAbsentCommands:
             "get_dual_watch",
             "set_dual_watch_off",
             "set_dual_watch_on",
-            # MOR-2117: bare "set_dual_watch" dispatches to the two split
-            # names above (MOR-2007 ruling 1 split the setter key), which
-            # were already absent -- the bare name itself was in neither
-            # list, so supports_command answered True for it.
             "set_dual_watch",
             "get_lan_mod_level",
             "set_lan_mod_level",
@@ -2841,30 +2790,59 @@ class TestIc7300DeclaresAbsentCommands:
             "get_powerstat",
             "get_quick_dual_watch",
             "set_quick_dual_watch",
-            # MOR-2190: direct IC-7300 Advanced Manual (11a) findings.
             "get_ref_adjust",
             "set_ref_adjust",
-            # Bare "quick_dual_watch" removed here (MOR-2008 batch 1): no
-            # builder resolved it, only get_/set_quick_dual_watch above do.
             "get_rx_antenna_ant2",
             "set_rx_antenna_ant2",
-            # MOR-2105: IC-7300 Advanced Manual (11a) 0x27 sub-command table
-            # (pp.19-7..19-8) runs 1E then 20 -- no 1F row.
             "get_scope_rbw",
             "set_scope_rbw",
             "get_scope_marker_position",
             "set_scope_marker_position",
+            "get_vfo",
+            "get_s_meter_sql_status_04",
+            "set_scope_wave",
         }
     )
 
-    def test_absent_command_names_match(self):
-        profile = load_rig(RIGS_DIR / "ic7300.toml").to_profile()
-        assert profile.absent_command_names == self._EXPECTED_ABSENT
+    def test_exact_retained_membership(self):
+        _assert_manual_only_membership(
+            "ic7300.toml",
+            320,
+            "61f58222a9bbb632db9146d17c60a2b339fe0f188bb14288139168656f7c0fea",
+            self._REMOVED_NAMES,
+        )
 
-    def test_absent_commands_excluded_from_command_map(self):
-        cmd_map = load_rig(RIGS_DIR / "ic7300.toml").to_command_map()
-        for name in self._EXPECTED_ABSENT:
-            assert not cmd_map.has(name), f"{name} declared absent but still in map"
+    def test_removed_names_have_no_callable_fallback(self):
+        from rigplane.runtime.radio import CoreRadio
+
+        profile = load_rig(RIGS_DIR / "ic7300.toml").to_profile()
+        radio = CoreRadio("127.0.0.1", profile=profile)
+        for name in self._REMOVED_NAMES:
+            assert not profile.supports_command(name), name
+            assert not radio.supports_command(name), name
+
+    @pytest.mark.parametrize("name", ["get_vfo", "get_digisel", "get_lan_mod_level"])
+    def test_missing_bound_builder_refuses(self, name):
+        from rigplane.core.exceptions import CommandError
+        from rigplane.runtime.radio import CoreRadio
+
+        radio = CoreRadio(
+            "127.0.0.1", profile=load_rig(RIGS_DIR / "ic7300.toml").to_profile()
+        )
+        with pytest.raises(CommandError, match="not declared by this profile"):
+            getattr(radio._commands, name)(to_addr=0x94)  # noqa: SLF001
+
+
+def _assert_manual_only_membership(filename, count, names_digest, removed_names):
+    config = load_rig(RIGS_DIR / filename)
+    profile = config.to_profile()
+    assert not profile.absent_command_names
+    assert not profile.absent_command_sources
+    assert not (config.commands.keys() & removed_names)
+    assert len(config.commands) == len(profile.command_names) == count
+    # Exact retained name set, not a count-only pin or a runtime command registry.
+    names = "\n".join(sorted(profile.command_names)).encode()
+    assert sha256(names).hexdigest() == names_digest
 
 
 class TestIc9700DeclaresAbsentCommands:
@@ -3135,27 +3113,7 @@ class TestX6100DeclaresAbsentCommands(_X6DeclaresAbsentCommands):
 
 
 class _CatOnlyDeclaresAllGroupBAbsent:
-    """Shared body for the FTX-1/TX-500 absent-command pin (MOR-2008
-    batch 4): both cat-only profiles formally declare all 16 Group B
-    canonical keys (memory.py's 9, tx_band.py's 2, freq.py's 5) absent,
-    grounded in protocol mismatch rather than a documentary or live
-    source -- ``[protocol] type`` is not ``"civ"`` on either profile,
-    every ``[commands]`` entry is a ``{ cat = ... }`` spec, and
-    ``profiles/rig_loader.py: RigConfig.to_command_map`` keeps only the
-    CI-V half of ``CommandSpec``, so none of these 16 CI-V-array key names
-    could ever be declared present here regardless of what either radio's
-    own CAT dialect documents.
-
-    Adding these formal rows removes both profiles from
-    ``tests/test_command_map_parity.py``'s own ``cat_only_profiles``
-    census/``cat-only`` rows -- that classification means literally "every
-    ``[commands]`` entry is ``CatCommandSpec``", which a declared-absent
-    row (a third spec type) no longer satisfies, even though both profiles
-    remain cat-only in every functional sense (``[protocol] type``
-    unchanged, ``CommandMap`` still empty). See
-    ``tests/command_map_parity_uncovered.txt``'s regenerated diff in this
-    batch's PR body.
-    """
+    """TX-500 retains its existing CI-V protocol-mismatch markers."""
 
     _EXPECTED_ABSENT = frozenset(
         {
@@ -3189,8 +3147,48 @@ class _CatOnlyDeclaresAllGroupBAbsent:
             assert not cmd_map.has(name), f"{name} declared absent but still in map"
 
 
-class TestFtx1DeclaresAbsentCommands(_CatOnlyDeclaresAllGroupBAbsent):
-    _TOML_NAME = "ftx1.toml"
+class TestFtx1ManualOnlyCommands:
+    """MOR-2257: retain CAT 2508-C names; RC has no row in that edition."""
+
+    _REMOVED_NAMES = frozenset(
+        {
+            "get_memory_mode",
+            "set_memory_mode",
+            "memory_write",
+            "memory_to_vfo",
+            "memory_clear",
+            "get_memory_contents",
+            "set_memory_contents",
+            "get_bsr",
+            "set_bsr",
+            "get_tx_band_count",
+            "get_tx_band_edge",
+            "get_selected_freq",
+            "get_unselected_freq",
+            "get_selected_mode",
+            "get_unselected_mode",
+            "set_selected_mode",
+            "reset_clarifier",
+        }
+    )
+
+    def test_exact_retained_membership(self):
+        _assert_manual_only_membership(
+            "ftx1.toml",
+            109,
+            "c96e82758aa2b96fba77c63824bf958584be0ce607bc4f9ec858f80789a3b9da",
+            self._REMOVED_NAMES,
+        )
+
+    def test_removed_names_have_no_callable_fallback(self):
+        from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+
+        config = load_rig(RIGS_DIR / "ftx1.toml")
+        profile = config.to_profile()
+        radio = YaesuCatRadio("/dev/null", profile=config)
+        for name in self._REMOVED_NAMES:
+            assert not profile.supports_command(name), name
+            assert not radio.supports_command(name), name
 
 
 class TestTx500DeclaresAbsentCommands(_CatOnlyDeclaresAllGroupBAbsent):

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -216,7 +216,7 @@ def test_acquisition_profile_resolver_six_profile_census_and_exact_declared_byte
                 census["missing"] += 1
                 assert resolver(path) is None
 
-    assert census == Counter(agree=302, diverge=4, absent=23, missing=67)
+    assert census == Counter(agree=302, diverge=4, absent=17, missing=73)
 
 
 def test_acquisition_profile_resolver_relative_vfo_and_refusal_rules() -> None:

--- a/tests/test_undeclared_command_policy.py
+++ b/tests/test_undeclared_command_policy.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import pathlib
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -195,30 +196,12 @@ class TestCoreRadioWiring:
 
     @pytest.mark.asyncio
     async def test_migrated_getter_refuses_through_expect_shape(self) -> None:
-        """MOR-2006: a config.py getter's reply-shape lookup refuses too.
-
-        ``runtime/radio.py: CoreRadio.get_lan_mod_level`` calls
-        ``self._expect_shape(get_lan_mod_level)`` (-> ``self._commands.
-        expect``) before it ever builds or sends a frame. When this test
-        was first written, IC-7300 declared no ``get_lan_mod_level`` entry
-        and did not record it absent either -- state 3. MOR-2014 (D2) has
-        since declared it absent (no LAN hardware on this radio; no LAN
-        row anywhere in the Advanced Manual's command table) -- state 2
-        now, same refusal shape, still previously unpinned at the public
-        async-method level (every other case in this file calls
-        ``radio._commands.<builder>`` directly). This one calls the public
-        method itself, which ``tests/test_response_shape_from_profile.py``
-        (the keystone) deliberately never does -- it skips a profile/getter
-        pair the map omits rather than asserting a refusal.
-        """
+        """A missing IC-7300 LAN command refuses before transport dispatch."""
         profile = self._ic7300_profile()
         assert "get_lan_mod_level" not in profile.command_names
-        assert "get_lan_mod_level" in profile.absent_command_names, (
-            "fixture assumption: MOR-2014 (D2) declared IC-7300's "
-            "get_lan_mod_level absent -- if a later D2 pass instead fills "
-            "it with real bytes, this test needs a different undeclared "
-            "config.py getter/profile pair"
-        )
+        assert "get_lan_mod_level" not in profile.absent_command_names
         radio = CoreRadio("127.0.0.1", profile=profile)
+        radio._send_civ_expect = AsyncMock()  # noqa: SLF001
         with pytest.raises(CommandError, match="not supported by this radio"):
             await radio.get_lan_mod_level()
+        radio._send_civ_expect.assert_not_awaited()  # noqa: SLF001


### PR DESCRIPTION
Owner-approved file-count exception: 10 code + 3 regenerated baselines = 13 files; 496 changed lines, within the 1000-line ceiling.

## Summary

Fixes MOR-2257: https://linear.app/morozsm/issue/MOR-2257/ic-7300-ftx-1-remove-profile-entries-absent-from-the-supplied-manuals

Remove 52 explicit-absent records and four undocumented positive declarations from IC-7300 and FTX-1. IC removes get_vfo, get_s_meter_sql_status_04, set_scope_wave; FTX removes reset_clarifier (RC). Source editions: IC-7300 Advanced Manual 11a and FTX-1 CAT 2508-C. Retained inventories: IC 320 positive / 0 absent; FTX 109 / 0.

All other 429 original positive specs and non-command profile metadata are unchanged. Missing entries remain unsupported and refuse before transport writes. No runtime code or other-model profiles changed. Documented-but-undeclared alternatives remain gaps; this does not claim full execution coverage or hardware verification.

## Validation

- Tests-first: six expected failures before cleanup; seven real mutation classes detected and restored.
- Independent original-head verification: exact 56 removals, all 429 retained specs unchanged, 60 mutation cases detected. This proof carries forward only because both profile files are unchanged in the follow-up.
- First full Actions 33701352711 exposed three test assertion dependencies and one collection import error, so its initial review PASS was superseded BLOCKED. These were real omissions, not flakes.
- Follow-up reproduces that RED, fixes exactly four test/census dependencies, and passes the combined 11-file focused set: 1129 passed, 1 skipped. No validation skip or restored absent markers.
- Coordinator global ruff and format checks passed; strict web mypy passed on unchanged source.
- Fresh independent review and all PR checks PASS at bb5bd71977bba8e7de69b12440056f68ce0d319d. Complete Python suite in Tests (quick), Actions 33701977077: 14615 passed, 220 skipped, 16 xfailed, 5 warnings in 66.61s. Full suites run through the normal Actions queue per the owner contract, not locally.
- Baseline Actions 33697962674: 14605 passed, 218 skipped, 16 xfailed. Not a result of this PR.
- No hardware access.

## Approved scope exception

13 files, 496 changed lines. Owner explicitly approved the 13-file exception in the active task on 2026-09-03 00:56 UTC; recorded in https://github.com/rigplane/rigplane-core/pull/3061#issuecomment-5518669826. The 1000-line ceiling remains. The extra files are old test fixtures and derived census expectations that depend on the removed declarations. All-model gates remain enabled; no architecture change or unrelated runtime work.

The prior audit remains historical evidence. The separately delivered HTML/Markdown revision distinguishes that historical audit from this cleanup and its exact-head verification; the documents are dated snapshots, not a live main-status display.
