### PR TITLE
feat: publish the scope mode and span from the spectrum stream into the scope-control fields

### DIFF
--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -292,6 +292,7 @@ from .scope import (
     scope_set_speed,
     scope_set_vbw,
     scope_single_dual,
+    span_index_for_hz,
 )
 
 # --- cw.py ---
@@ -595,6 +596,7 @@ __all__ = [
     "scope_set_mode",
     "get_scope_span",
     "scope_set_span",
+    "span_index_for_hz",
     "get_scope_ref",
     "scope_set_ref",
     "get_scope_speed",

--- a/src/rigplane/commands/__init__.py
+++ b/src/rigplane/commands/__init__.py
@@ -292,7 +292,6 @@ from .scope import (
     scope_set_speed,
     scope_set_vbw,
     scope_single_dual,
-    span_index_for_hz,
 )
 
 # --- cw.py ---
@@ -596,7 +595,6 @@ __all__ = [
     "scope_set_mode",
     "get_scope_span",
     "scope_set_span",
-    "span_index_for_hz",
     "get_scope_ref",
     "scope_set_ref",
     "get_scope_speed",

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -964,6 +964,31 @@ def parse_scope_mode_response(
     return _decode_scope_value(frame, sub, minimum=0, maximum=3, command=command)
 
 
+def span_index_for_hz(hz: int) -> int | None:
+    """Return the scope-span preset index (0-7) for an exact Hz match.
+
+    Single source of truth for the Hz<->span-index mapping: reused (never
+    duplicated) by both ``parse_scope_span_response`` below -- the 0x15
+    reply-path decoder -- and the waveform-stream span derivation
+    (``runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation``,
+    MOR-2222/MOR-2256). ``_SCOPE_SPAN_PRESETS_HZ`` is a hardcoded module
+    constant, not profile-declared data; moving it into per-profile TOML
+    is tracked separately as MOR-2257 rather than duplicated here or
+    invented as new profile schema for this change.
+
+    Returns ``None`` on no exact match -- callers decide whether that is
+    an error (the reply path still raises, unchanged) or a silent no-op
+    (the stream derivation publishes nothing). No tolerance: ``hz`` comes
+    from ``bcd_decode``, which round-trips losslessly to an exact integer,
+    so an exact-match table lookup is the correct comparison, not a
+    nearest-value one.
+    """
+    try:
+        return _SCOPE_SPAN_PRESETS_HZ.index(hz)
+    except ValueError:
+        return None
+
+
 def parse_scope_span_response(
     frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_SPAN
 ) -> tuple[int | None, int]:
@@ -972,10 +997,9 @@ def parse_scope_span_response(
     if len(payload) == 1:
         return receiver, _validate_scope_range("scope span", payload[0], 0, 7)
     hz = bcd_decode(payload)
-    try:
-        span = _SCOPE_SPAN_PRESETS_HZ.index(hz)
-    except ValueError as exc:
-        raise ValueError(f"Unknown scope span frequency {hz}") from exc
+    span = span_index_for_hz(hz)
+    if span is None:
+        raise ValueError(f"Unknown scope span frequency {hz}")
     return receiver, span
 
 

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -964,7 +964,7 @@ def parse_scope_mode_response(
     return _decode_scope_value(frame, sub, minimum=0, maximum=3, command=command)
 
 
-def span_index_for_hz(hz: int) -> int | None:
+def _span_index_for_hz(hz: int) -> int | None:
     """Return the scope-span preset index (0-7) for an exact Hz match.
 
     Single source of truth for the Hz<->span-index mapping: reused (never
@@ -973,7 +973,7 @@ def span_index_for_hz(hz: int) -> int | None:
     (``runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation``,
     MOR-2222/MOR-2256). ``_SCOPE_SPAN_PRESETS_HZ`` is a hardcoded module
     constant, not profile-declared data; moving it into per-profile TOML
-    is tracked separately as MOR-2257 rather than duplicated here or
+    is tracked separately as MOR-2258 rather than duplicated here or
     invented as new profile schema for this change.
 
     Returns ``None`` on no exact match -- callers decide whether that is
@@ -982,6 +982,18 @@ def span_index_for_hz(hz: int) -> int | None:
     from ``bcd_decode``, which round-trips losslessly to an exact integer,
     so an exact-match table lookup is the correct comparison, not a
     nearest-value one.
+
+    Underscore-prefixed although it has a caller outside this module
+    (``_civ_rx.py`` imports it directly, ``from rigplane.commands.scope
+    import _span_index_for_hz``): a public, non-``parse_*`` name with no
+    ``cmd_map`` parameter is exactly what
+    ``test_command_map_parity.py: _hardcode_only_builders`` inventories as
+    a byte-emitting command builder outside its parity sweep, and this
+    function builds no CI-V frame at all -- it is a pure Hz<->index
+    lookup. #3063 hit that census mismatch when this was public
+    (``span_index_for_hz``); the leading underscore is what excludes it
+    (that helper's own function-level filter, independent of whether
+    ``commands/__init__.py`` re-exports the name).
     """
     try:
         return _SCOPE_SPAN_PRESETS_HZ.index(hz)
@@ -997,7 +1009,7 @@ def parse_scope_span_response(
     if len(payload) == 1:
         return receiver, _validate_scope_range("scope span", payload[0], 0, 7)
     hz = bcd_decode(payload)
-    span = span_index_for_hz(hz)
+    span = _span_index_for_hz(hz)
     if span is None:
         raise ValueError(f"Unknown scope span frequency {hz}")
     return receiver, span

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -45,9 +45,9 @@ from rigplane.commands import (
     parse_scope_span_response,
     parse_scope_speed_response,
     parse_scope_vbw_response,
-    span_index_for_hz,
 )
 from rigplane.commands.levels import _cw_pitch_from_level, _key_speed_from_level
+from rigplane.commands.scope import _span_index_for_hz
 from rigplane.core.exceptions import ConnectionError, TimeoutError
 from rigplane.core.tx_safety import ProviderPttObservation, RadioTx
 from rigplane.core.tx_target import KnownTxTarget
@@ -3276,26 +3276,47 @@ class CivRuntime:
         scope's own reads own them now. The waveform stream (``0x27``/
         ``0x00``) is the one unsolicited source that keeps ``mode`` current
         while it runs, so this republishes it — once per change, not once
-        per frame, since the stream runs at up to ~15 fps. ``span`` is
-        republished the same way by ``_publish_scope_span_observation``
-        below (MOR-2256, derived through the profile's span-preset table,
-        not a raw frequency). ``edge``/``fixed_edge`` are NOT republished:
-        ``edge`` is a preset index 1-4 with no frame-carried source, and
+        per frame, since the stream runs at up to ~15 fps. ``mode`` is
+        validated against its documented 0-3 range (``ScopeFrame.mode``'s
+        own docstring; the reply path can never produce anything else) —
+        an out-of-range value publishes nothing. ``span`` is republished
+        the same way by ``_publish_scope_span_observation`` below
+        (MOR-2256, derived through the span-preset table, not a raw
+        frequency). ``edge``/``fixed_edge`` are NOT republished: ``edge``
+        is a preset index 1-4 with no frame-carried source, and
         ``fixed_edge`` a preset-table record (range_index/edge/start/end)
         with no declared table of legal values to derive it from — those
         stay display-only, carried to the web through the spectrum stream
         itself (``ScopeFrame``), not the StateStore.
+
+        The observation is bound to the store's CURRENT provider
+        generation before ``apply`` — mirroring
+        ``_apply_state_store_observations``'s own pattern below — because
+        ``Observation.provider_generation`` defaults to 0 and
+        ``StateStore.apply``/``_is_current_observation`` silently rejects
+        anything that does not match ``advance_generation``'s bump on
+        connect (#3063 review: a connected radio's stream observations
+        were dropped from the moment of connect onward). The
+        change-detect cache is updated only AFTER ``apply`` runs, not
+        before: caching first would mean a rejected value is never
+        retried once the stream sees that same value again.
         """
+        if not 0 <= scope_frame.mode <= 3:
+            return
         last_modes = self._host._scope_stream_last_mode
         if last_modes.get(receiver) == scope_frame.mode:
             return
-        last_modes[receiver] = scope_frame.mode
-        observation = self._observation(
-            FieldPath.scope_control("display", "mode"),
-            scope_frame.mode,
-            frame=frame,
+        store_provider_generation = self._host._state_store.provider_generation
+        observation = _replace_dataclass(
+            self._observation(
+                FieldPath.scope_control("display", "mode"),
+                scope_frame.mode,
+                frame=frame,
+            ),
+            provider_generation=store_provider_generation,
         )
         changeset = self._host._state_store.apply(observation)
+        last_modes[receiver] = scope_frame.mode
         self._record_scheduler_result_for_observation(observation, changeset)
         self._notify_state_store_changed(changeset)
 
@@ -3304,18 +3325,28 @@ class CivRuntime:
     ) -> None:
         """Emit a change-detected ``scope_controls.global.display.span`` write.
 
-        Center mode only (``scope_frame.mode == 0``): the frame's displayed
-        width (``end_freq_hz - start_freq_hz``) is matched EXACTLY against
+        Center mode only (``scope_frame.mode == 0``). Per the IC-7610
+        CI-V reference (p.14, "Scope waveform data") and the IC-7300
+        manual, the frame's center-mode payload carries the center
+        frequency and the SPAN value itself — the same value the ``0x27
+        0x15`` span table encodes — not half of it.
+        ``rigplane.scope._ReceiverState.feed`` turns that pair into edges
+        via ``center - span``, ``center + span``, so ``end_freq_hz -
+        start_freq_hz == 2 * span``. The span to look up is therefore
+        ``(end_freq_hz - start_freq_hz) / 2``, computed with an
+        exact-division check (a remainder means this width did not come
+        from that doubling and is untrustworthy) — not the raw
+        difference, which is off by 2x (#3063 review, verified against
+        both manuals). Matched EXACTLY against
         ``commands/scope.py: _SCOPE_SPAN_PRESETS_HZ`` via the shared
-        ``span_index_for_hz`` helper — the same lookup
+        ``_span_index_for_hz`` helper — the same lookup
         ``parse_scope_span_response`` (the 0x15 reply path) uses, so the
-        stream and a typed-getter reply always agree on what index a given
-        Hz value maps to (MOR-2256). No match -> publish nothing, and do
-        not clear whatever the field last held: ``hz`` here is exact
-        (``bcd_decode`` round-trips losslessly to an integer, so no
-        tolerance is needed or wanted), so a non-matching width is either
-        drift outside the eight documented presets or an unexpected
-        source, not something to overwrite a confirmed value with a guess.
+        stream and a typed-getter reply always agree on what index a
+        given Hz value maps to (MOR-2256). No match -> publish nothing,
+        and do not clear whatever the field last held: a non-matching
+        width is either drift outside the eight documented presets or an
+        unexpected source, not something to overwrite a confirmed value
+        with a guess.
 
         Fixed mode (``scope_frame.mode != 0``) publishes nothing: unlike
         span, there is no declared table of legal (start_hz, end_hz) pairs
@@ -3326,24 +3357,35 @@ class CivRuntime:
         enumerable data. Publishing here would mean guessing which preset
         is active, which MOR-2256 rules out. Moving the span table into
         per-profile data (rather than reusing the existing hardcoded
-        ``commands/scope.py`` constant) is tracked separately as MOR-2257.
+        ``commands/scope.py`` constant) is tracked separately as
+        MOR-2258.
+
+        Same generation-binding and cache-after-apply ordering as
+        ``_publish_scope_mode_observation`` above — see its docstring.
         """
         if scope_frame.mode != 0:
             return
         width_hz = scope_frame.end_freq_hz - scope_frame.start_freq_hz
-        span = span_index_for_hz(width_hz)
+        if width_hz % 2 != 0:
+            return
+        span_hz = width_hz // 2
+        span = _span_index_for_hz(span_hz)
         if span is None:
             return
         last_spans = self._host._scope_stream_last_span
         if last_spans.get(receiver) == span:
             return
-        last_spans[receiver] = span
-        observation = self._observation(
-            FieldPath.scope_control("display", "span"),
-            span,
-            frame=frame,
+        store_provider_generation = self._host._state_store.provider_generation
+        observation = _replace_dataclass(
+            self._observation(
+                FieldPath.scope_control("display", "span"),
+                span,
+                frame=frame,
+            ),
+            provider_generation=store_provider_generation,
         )
         changeset = self._host._state_store.apply(observation)
+        last_spans[receiver] = span
         self._record_scheduler_result_for_observation(observation, changeset)
         self._notify_state_store_changed(changeset)
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -3289,6 +3289,15 @@ class CivRuntime:
         stay display-only, carried to the web through the spectrum stream
         itself (``ScopeFrame``), not the StateStore.
 
+        Unlike ``_publish_scope_span_observation`` below, this does NOT
+        need an ``out_of_range`` guard: ``mode`` (``ScopeFrame.mode``)
+        comes from ``raw_payload[2]``, decoded in
+        ``rigplane.scope._ReceiverState.feed`` before the OOR check, and
+        is unaffected by it -- only ``start_freq_hz``/``end_freq_hz``
+        (which this method never reads) are left as raw, unexpanded
+        values when ``out_of_range`` is set (#3063 review, second round;
+        checked, confirmed not applicable here).
+
         The observation is bound to the store's CURRENT provider
         generation before ``apply`` — mirroring
         ``_apply_state_store_observations``'s own pattern below — because
@@ -3297,9 +3306,14 @@ class CivRuntime:
         anything that does not match ``advance_generation``'s bump on
         connect (#3063 review: a connected radio's stream observations
         were dropped from the moment of connect onward). The
-        change-detect cache is updated only AFTER ``apply`` runs, not
-        before: caching first would mean a rejected value is never
-        retried once the stream sees that same value again.
+        change-detect cache is updated only when ``apply`` reports the
+        observation ACCEPTED -- ``changeset.observed_paths`` non-empty,
+        the same signal ``StateStore._apply_one``/``_empty_changeset``
+        use to distinguish a written observation from a rejected one --
+        not merely after the call returns (#3063 review, second round):
+        caching on every call, accepted or not, would mean a rejected
+        value is never retried once the stream reports that same value
+        again.
         """
         if not 0 <= scope_frame.mode <= 3:
             return
@@ -3316,7 +3330,8 @@ class CivRuntime:
             provider_generation=store_provider_generation,
         )
         changeset = self._host._state_store.apply(observation)
-        last_modes[receiver] = scope_frame.mode
+        if changeset.observed_paths:
+            last_modes[receiver] = scope_frame.mode
         self._record_scheduler_result_for_observation(observation, changeset)
         self._notify_state_store_changed(changeset)
 
@@ -3325,19 +3340,31 @@ class CivRuntime:
     ) -> None:
         """Emit a change-detected ``scope_controls.global.display.span`` write.
 
-        Center mode only (``scope_frame.mode == 0``). Per the IC-7610
-        CI-V reference (p.14, "Scope waveform data") and the IC-7300
-        manual, the frame's center-mode payload carries the center
-        frequency and the SPAN value itself — the same value the ``0x27
-        0x15`` span table encodes — not half of it.
-        ``rigplane.scope._ReceiverState.feed`` turns that pair into edges
-        via ``center - span``, ``center + span``, so ``end_freq_hz -
+        Center mode only (``scope_frame.mode == 0``) AND in-range
+        (``scope_frame.out_of_range`` is False): when a waveform frame's
+        OOR flag is set, ``rigplane.scope._ReceiverState.feed`` returns
+        BEFORE the center-mode edge expansion (``center - span``/
+        ``center + span``) — ``start_freq_hz``/``end_freq_hz`` are then
+        the raw, unexpanded [center, span] pair, not edges, so
+        ``end_freq_hz - start_freq_hz`` is ``span - center``, not
+        ``2 * span`` (#3063 review, second round: a center-450kHz/
+        span-500kHz OOR frame computed index 3 instead of 7 before this
+        guard). Publishing from an OOR frame at all would also be
+        publishing a span the operator cannot currently see confirmed on
+        screen, which the mode/span republish exists to avoid guessing.
+
+        Per the IC-7610 CI-V reference (p.14, "Scope waveform data") and
+        the IC-7300 manual, an in-range center-mode payload carries the
+        center frequency and the SPAN value itself — the same value the
+        ``0x27 0x15`` span table encodes — not half of it.
+        ``_ReceiverState.feed`` turns that pair into edges via
+        ``center - span``, ``center + span``, so ``end_freq_hz -
         start_freq_hz == 2 * span``. The span to look up is therefore
         ``(end_freq_hz - start_freq_hz) / 2``, computed with an
         exact-division check (a remainder means this width did not come
         from that doubling and is untrustworthy) — not the raw
-        difference, which is off by 2x (#3063 review, verified against
-        both manuals). Matched EXACTLY against
+        difference, which is off by 2x (#3063 review, first round,
+        verified against both manuals). Matched EXACTLY against
         ``commands/scope.py: _SCOPE_SPAN_PRESETS_HZ`` via the shared
         ``_span_index_for_hz`` helper — the same lookup
         ``parse_scope_span_response`` (the 0x15 reply path) uses, so the
@@ -3360,10 +3387,10 @@ class CivRuntime:
         ``commands/scope.py`` constant) is tracked separately as
         MOR-2258.
 
-        Same generation-binding and cache-after-apply ordering as
-        ``_publish_scope_mode_observation`` above — see its docstring.
+        Same generation-binding and cache-after-ACCEPTED-apply ordering
+        as ``_publish_scope_mode_observation`` above — see its docstring.
         """
-        if scope_frame.mode != 0:
+        if scope_frame.mode != 0 or scope_frame.out_of_range:
             return
         width_hz = scope_frame.end_freq_hz - scope_frame.start_freq_hz
         if width_hz % 2 != 0:
@@ -3385,7 +3412,8 @@ class CivRuntime:
             provider_generation=store_provider_generation,
         )
         changeset = self._host._state_store.apply(observation)
-        last_spans[receiver] = span
+        if changeset.observed_paths:
+            last_spans[receiver] = span
         self._record_scheduler_result_for_observation(observation, changeset)
         self._notify_state_store_changed(changeset)
 

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -45,6 +45,7 @@ from rigplane.commands import (
     parse_scope_span_response,
     parse_scope_speed_response,
     parse_scope_vbw_response,
+    span_index_for_hz,
 )
 from rigplane.commands.levels import _cw_pitch_from_level, _key_speed_from_level
 from rigplane.core.exceptions import ConnectionError, TimeoutError
@@ -1600,6 +1601,9 @@ class CivRuntime:
             scope_frame = self._host._scope_assembler.feed(frame.data[1:], receiver)
             if scope_frame is not None:
                 self._publish_scope_mode_observation(
+                    scope_frame, receiver=receiver, frame=frame
+                )
+                self._publish_scope_span_observation(
                     scope_frame, receiver=receiver, frame=frame
                 )
                 self._publish_scope_frame(scope_frame)
@@ -3272,13 +3276,15 @@ class CivRuntime:
         scope's own reads own them now. The waveform stream (``0x27``/
         ``0x00``) is the one unsolicited source that keeps ``mode`` current
         while it runs, so this republishes it — once per change, not once
-        per frame, since the stream runs at up to ~15 fps. Only ``mode`` is
-        republished: edge/span frequencies have no existing scope-control
-        field to land in (``edge`` is a preset index 1-4, ``fixed_edge`` a
-        preset-table record with its own range_index/edge/start/end shape)
-        and MOR-2222 deliberately does not invent one — those stay
-        display-only, carried to the web through the spectrum stream itself
-        (``ScopeFrame``), not the StateStore.
+        per frame, since the stream runs at up to ~15 fps. ``span`` is
+        republished the same way by ``_publish_scope_span_observation``
+        below (MOR-2256, derived through the profile's span-preset table,
+        not a raw frequency). ``edge``/``fixed_edge`` are NOT republished:
+        ``edge`` is a preset index 1-4 with no frame-carried source, and
+        ``fixed_edge`` a preset-table record (range_index/edge/start/end)
+        with no declared table of legal values to derive it from — those
+        stay display-only, carried to the web through the spectrum stream
+        itself (``ScopeFrame``), not the StateStore.
         """
         last_modes = self._host._scope_stream_last_mode
         if last_modes.get(receiver) == scope_frame.mode:
@@ -3287,6 +3293,54 @@ class CivRuntime:
         observation = self._observation(
             FieldPath.scope_control("display", "mode"),
             scope_frame.mode,
+            frame=frame,
+        )
+        changeset = self._host._state_store.apply(observation)
+        self._record_scheduler_result_for_observation(observation, changeset)
+        self._notify_state_store_changed(changeset)
+
+    def _publish_scope_span_observation(
+        self, scope_frame: ScopeFrame, *, receiver: int, frame: CivFrame
+    ) -> None:
+        """Emit a change-detected ``scope_controls.global.display.span`` write.
+
+        Center mode only (``scope_frame.mode == 0``): the frame's displayed
+        width (``end_freq_hz - start_freq_hz``) is matched EXACTLY against
+        ``commands/scope.py: _SCOPE_SPAN_PRESETS_HZ`` via the shared
+        ``span_index_for_hz`` helper — the same lookup
+        ``parse_scope_span_response`` (the 0x15 reply path) uses, so the
+        stream and a typed-getter reply always agree on what index a given
+        Hz value maps to (MOR-2256). No match -> publish nothing, and do
+        not clear whatever the field last held: ``hz`` here is exact
+        (``bcd_decode`` round-trips losslessly to an integer, so no
+        tolerance is needed or wanted), so a non-matching width is either
+        drift outside the eight documented presets or an unexpected
+        source, not something to overwrite a confirmed value with a guess.
+
+        Fixed mode (``scope_frame.mode != 0``) publishes nothing: unlike
+        span, there is no declared table of legal (start_hz, end_hz) pairs
+        to match a fixed-mode frame's edges against —
+        ``_SCOPE_FIXED_EDGE_RANGE_STARTS_HZ`` only maps a start_hz to a
+        *band*, not to a specific stored (range, edge) preset, and a
+        preset's actual edges are radio-side user-configured memory, not
+        enumerable data. Publishing here would mean guessing which preset
+        is active, which MOR-2256 rules out. Moving the span table into
+        per-profile data (rather than reusing the existing hardcoded
+        ``commands/scope.py`` constant) is tracked separately as MOR-2257.
+        """
+        if scope_frame.mode != 0:
+            return
+        width_hz = scope_frame.end_freq_hz - scope_frame.start_freq_hz
+        span = span_index_for_hz(width_hz)
+        if span is None:
+            return
+        last_spans = self._host._scope_stream_last_span
+        if last_spans.get(receiver) == span:
+            return
+        last_spans[receiver] = span
+        observation = self._observation(
+            FieldPath.scope_control("display", "span"),
+            span,
             frame=frame,
         )
         changeset = self._host._state_store.apply(observation)

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -1599,6 +1599,9 @@ class CivRuntime:
             )
             scope_frame = self._host._scope_assembler.feed(frame.data[1:], receiver)
             if scope_frame is not None:
+                self._publish_scope_mode_observation(
+                    scope_frame, receiver=receiver, frame=frame
+                )
                 self._publish_scope_frame(scope_frame)
             return
 
@@ -3258,6 +3261,37 @@ class CivRuntime:
         recorder = getattr(self._host, "_state_diagnostics", None)
         if isinstance(recorder, StateDiagnosticsRecorder):
             recorder.record(kind, source, **details)
+
+    def _publish_scope_mode_observation(
+        self, scope_frame: ScopeFrame, *, receiver: int, frame: CivFrame
+    ) -> None:
+        """Emit a change-detected ``scope_controls.global.display.mode`` write.
+
+        MOR-2222 moved the ``scope_controls.global.display.*`` paths out of
+        the acquisition cadence (no more periodic ``0x27`` polls): the
+        scope's own reads own them now. The waveform stream (``0x27``/
+        ``0x00``) is the one unsolicited source that keeps ``mode`` current
+        while it runs, so this republishes it — once per change, not once
+        per frame, since the stream runs at up to ~15 fps. Only ``mode`` is
+        republished: edge/span frequencies have no existing scope-control
+        field to land in (``edge`` is a preset index 1-4, ``fixed_edge`` a
+        preset-table record with its own range_index/edge/start/end shape)
+        and MOR-2222 deliberately does not invent one — those stay
+        display-only, carried to the web through the spectrum stream itself
+        (``ScopeFrame``), not the StateStore.
+        """
+        last_modes = self._host._scope_stream_last_mode
+        if last_modes.get(receiver) == scope_frame.mode:
+            return
+        last_modes[receiver] = scope_frame.mode
+        observation = self._observation(
+            FieldPath.scope_control("display", "mode"),
+            scope_frame.mode,
+            frame=frame,
+        )
+        changeset = self._host._state_store.apply(observation)
+        self._record_scheduler_result_for_observation(observation, changeset)
+        self._notify_state_store_changed(changeset)
 
     def _publish_scope_frame(self, frame: ScopeFrame) -> None:
         """Publish a complete scope frame to callback and bounded queue."""

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -454,6 +454,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         # stream, per receiver (0=MAIN, 1=SUB) — lets the stream
         # change-detect before writing to the StateStore.
         self._scope_stream_last_mode: dict[int, int] = {}
+        # MOR-2256: last scope-display span index published from the
+        # waveform stream (center mode only), per receiver -- same
+        # change-detect purpose as _scope_stream_last_mode above.
+        self._scope_stream_last_span: dict[int, int] = {}
         # Raw CI-V pipe listeners (MOR-164): receive inbound on-wire frame bytes.
         self._raw_civ_listeners: list[Callable[[bytes], Any]] = []
         # External CAT-session ownership (MOR-166 slice 2): when True, cooperating

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -450,6 +450,10 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         self._audio_session: Any = None
         self._scope_assembler: ScopeAssembler = ScopeAssembler()
         self._scope_callback: Callable[[ScopeFrame], Any] | None = None
+        # MOR-2222: last scope-display mode published from the waveform
+        # stream, per receiver (0=MAIN, 1=SUB) — lets the stream
+        # change-detect before writing to the StateStore.
+        self._scope_stream_last_mode: dict[int, int] = {}
         # Raw CI-V pipe listeners (MOR-164): receive inbound on-wire frame bytes.
         self._raw_civ_listeners: list[Callable[[bytes], Any]] = []
         # External CAT-session ownership (MOR-166 slice 2): when True, cooperating

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -122,8 +122,12 @@ def _make_scope_waveform_frame(
     """Build a single-packet (LAN-style, seq=seqMax=1) ``0x27``/``0x00``
     waveform frame, per ``rigplane.scope._ReceiverState.feed``'s sequence-1
     layout: ``[receiver, seq_bcd, seqMax_bcd, mode, start(5), end(5), oor,
-    pixels...]``. ``mode`` != 0 so the assembler does not remap start/end
-    into center +/- bandwidth (only mode 0 does that).
+    pixels...]``. For ``mode == 0`` (center) the assembler remaps
+    ``start_hz``/``end_hz`` as ``[center_freq, half_span]`` into real edges
+    (``center - half_span``, ``center + half_span``) -- pass ``start_hz``
+    as the center frequency and ``end_hz`` as the half-span in that case.
+    For any other mode both are used as literal edge frequencies,
+    unremapped.
     """
     raw_payload = (
         bytes([0x01, 0x01, mode])
@@ -3973,13 +3977,19 @@ async def test_scope_waveform_mode_unchanged_emits_no_observation(
     assert apply_spy.call_count == 0
 
 
-async def test_scope_waveform_frame_never_emits_edge_or_span_observation(
+async def test_scope_waveform_fixed_mode_emits_no_span_edge_or_fixed_edge(
     radio: IcomRadio,
 ) -> None:
-    """MOR-2222: the waveform stream republishes ``mode`` only — edge/span
-    frequencies have no existing scope-control field to land in (``edge``
-    is a preset index, ``fixed_edge`` a preset-table record) and this slice
-    deliberately does not invent one. Guards the "do not invent" rule."""
+    """MOR-2222/MOR-2256: a fixed-mode (``mode != 0``) waveform frame
+    republishes nothing beyond ``mode`` itself. ``edge`` has no
+    frame-carried source at all. ``fixed_edge`` has no declared table of
+    legal (start_hz, end_hz) pairs to match a frame's edges against
+    (``_SCOPE_FIXED_EDGE_RANGE_STARTS_HZ`` maps a start_hz to a band, not
+    to a specific stored preset) — MOR-2256 rules out guessing which
+    preset is active. ``span`` is center-mode-only by construction
+    (``_publish_scope_span_observation`` returns immediately when
+    ``scope_frame.mode != 0``), so a fixed-mode frame never reaches its
+    exact-match lookup regardless of width."""
     with _spy_state_store_apply(radio) as apply_spy:
         frame = _make_scope_waveform_frame(
             mode=1, start_hz=14_000_000, end_hz=14_350_000
@@ -3990,6 +4000,70 @@ async def test_scope_waveform_frame_never_emits_edge_or_span_observation(
     assert "scope_controls.global.display.edge" not in applied_paths
     assert "scope_controls.global.display.span" not in applied_paths
     assert "scope_controls.global.display.fixed_edge" not in applied_paths
+
+
+async def test_scope_waveform_center_mode_span_match_emits_one_observation(
+    radio: IcomRadio,
+) -> None:
+    """MOR-2256: a center-mode frame whose displayed width
+    (``end_freq_hz - start_freq_hz``) exactly equals a declared span
+    preset publishes exactly one ``span`` observation carrying that
+    preset's index (the same representation ``parse_scope_span_response``
+    stores for the 0x15 reply path). Width = 2 * half_span (the raw
+    payload's "end" field, per ``rigplane.scope._ReceiverState.feed``'s
+    center-mode adjustment) = 2 * 1250 = 2500 Hz, matching
+    ``_SCOPE_SPAN_PRESETS_HZ[0]``."""
+    with _spy_state_store_apply(radio) as apply_spy:
+        frame = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=1_250)
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    span_calls = [
+        call
+        for call in apply_spy.call_args_list
+        if str(call.args[0].path) == "scope_controls.global.display.span"
+    ]
+    assert len(span_calls) == 1
+    assert span_calls[0].args[0].value == 0
+
+    field = radio._state_store.snapshot().field("scope_controls.global.display.span")
+    assert field.value == 0
+    assert field.freshness is FreshnessState.FRESH
+
+
+async def test_scope_waveform_center_mode_unknown_width_emits_no_span(
+    radio: IcomRadio,
+) -> None:
+    """MOR-2256: a center-mode frame whose width has no exact match in
+    ``_SCOPE_SPAN_PRESETS_HZ`` publishes nothing — not a nearest-value
+    guess. Width = 2 * 999 = 1998 Hz, which is not one of the eight
+    declared presets (2500/5000/10000/25000/50000/100000/250000/500000)."""
+    with _spy_state_store_apply(radio) as apply_spy:
+        frame = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=999)
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    applied_paths = {str(call.args[0].path) for call in apply_spy.call_args_list}
+    assert "scope_controls.global.display.span" not in applied_paths
+
+
+async def test_scope_waveform_center_mode_span_unchanged_emits_no_second_observation(
+    radio: IcomRadio,
+) -> None:
+    """MOR-2256: two consecutive center-mode frames with the same matching
+    width publish exactly one ``span`` observation total, not one per
+    frame — mirrors ``test_scope_waveform_mode_unchanged_emits_no_observation``."""
+    first = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=1_250)
+    await radio._civ_runtime._route_civ_frame(first, generation=radio._civ_epoch)
+
+    with _spy_state_store_apply(radio) as apply_spy:
+        second = _make_scope_waveform_frame(mode=0, start_hz=14_100_000, end_hz=1_250)
+        await radio._civ_runtime._route_civ_frame(second, generation=radio._civ_epoch)
+
+    span_calls = [
+        call
+        for call in apply_spy.call_args_list
+        if str(call.args[0].path) == "scope_controls.global.display.span"
+    ]
+    assert span_calls == []
 
 
 def test_scope_control_observations_project_public(radio: IcomRadio) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -124,22 +124,32 @@ def _make_scope_waveform_frame(
     mode: int,
     start_hz: int = 14_000_000,
     end_hz: int = 14_350_000,
+    oor: bool = False,
 ) -> CivFrame:
     """Build a single-packet (LAN-style, seq=seqMax=1) ``0x27``/``0x00``
     waveform frame, per ``rigplane.scope._ReceiverState.feed``'s sequence-1
     layout: ``[receiver, seq_bcd, seqMax_bcd, mode, start(5), end(5), oor,
-    pixels...]``. For ``mode == 0`` (center) the assembler remaps
-    ``start_hz``/``end_hz`` as ``[center_freq, half_span]`` into real edges
-    (``center - half_span``, ``center + half_span``) -- pass ``start_hz``
-    as the center frequency and ``end_hz`` as the half-span in that case.
-    For any other mode both are used as literal edge frequencies,
+    pixels...]``.
+
+    When ``oor`` is False and ``mode == 0`` (center), the assembler
+    remaps ``start_hz``/``end_hz`` as ``[center_freq, span]`` into real
+    edges (``center - span``, ``center + span``) -- pass ``start_hz`` as
+    the center frequency and ``end_hz`` as the SPAN value itself (per the
+    IC-7610 CI-V reference p.14 / IC-7300 manual: the raw field carries
+    the same value the ``0x27 0x15`` span table encodes, not half of
+    it). For any other mode both are used as literal edge frequencies,
     unremapped.
+
+    When ``oor`` is True, ``_ReceiverState.feed`` returns BEFORE that
+    center-mode remap regardless of ``mode`` -- ``start_hz``/``end_hz``
+    below are passed straight through as ``ScopeFrame.start_freq_hz``/
+    ``end_freq_hz`` unmodified (raw ``[center, span]``, not edges).
     """
     raw_payload = (
         bytes([0x01, 0x01, mode])
         + bcd_encode(start_hz)
         + bcd_encode(end_hz)
-        + bytes([0x00])  # out_of_range = False
+        + bytes([0x01 if oor else 0x00])
         + b"\x00"  # one pixel byte
     )
     return _make_frame(cmd=0x27, sub=0x00, data=bytes([receiver]) + raw_payload)
@@ -4126,6 +4136,93 @@ async def test_scope_waveform_mode_observation_survives_connect_generation(
 
     field = radio._state_store.snapshot().field("scope_controls.global.display.mode")
     assert field.value == 2
+    assert field.freshness is FreshnessState.FRESH
+
+
+async def test_scope_waveform_out_of_range_center_frame_emits_no_span(
+    radio: IcomRadio,
+) -> None:
+    """#3063 review, second round: ``_ReceiverState.feed`` returns BEFORE
+    the center-mode edge expansion when the frame's out-of-range flag is
+    set, so ``ScopeFrame.start_freq_hz``/``end_freq_hz`` are then the
+    raw, unexpanded ``[center, span]`` pair, not real edges. The
+    verifier's example: center 450 kHz, span 500 kHz (matching
+    ``_SCOPE_SPAN_PRESETS_HZ[7]``), OOR set -- computing
+    ``end_freq_hz - start_freq_hz`` as if these were edges gives
+    ``500_000 - 450_000 == 50_000``, halved to 25_000, which wrongly
+    matches index 3 (``_SCOPE_SPAN_PRESETS_HZ[3] == 25_000``) instead of
+    publishing nothing."""
+    with _spy_state_store_apply(radio) as apply_spy:
+        frame = _make_scope_waveform_frame(
+            mode=0, start_hz=450_000, end_hz=500_000, oor=True
+        )
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    applied_paths = {str(call.args[0].path) for call in apply_spy.call_args_list}
+    assert "scope_controls.global.display.span" not in applied_paths
+
+
+async def test_scope_waveform_span_observation_survives_connect_generation(
+    radio: IcomRadio,
+) -> None:
+    """#3063 review, second round: the same connect-generation gap as
+    ``test_scope_waveform_mode_observation_survives_connect_generation``
+    above, but for the span path -- only the mode path had this test
+    before this round."""
+    store_generation = radio._state_store.begin_provider_generation()  # noqa: SLF001
+    assert store_generation != 0
+
+    frame = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=5_000)
+    await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    field = radio._state_store.snapshot().field("scope_controls.global.display.span")
+    assert field.value == 1  # _SCOPE_SPAN_PRESETS_HZ.index(5000)
+    assert field.freshness is FreshnessState.FRESH
+
+
+async def test_scope_waveform_span_rejected_apply_retries_on_next_frame(
+    radio: IcomRadio,
+) -> None:
+    """#3063 review, second round: the per-receiver change-detect cache
+    (``_scope_stream_last_span``) must only remember a value once
+    ``StateStore.apply`` actually accepted it -- signaled by
+    ``changeset.observed_paths`` being non-empty, the same distinction
+    ``StateStore._apply_one``/``_empty_changeset`` use internally.
+    Forces the first attempt to be rejected (``StateStore.apply`` mocked
+    to return an empty ``ChangeSet`` once), then feeds the identical
+    frame again with ``apply`` unmocked: if the cache had been written on
+    the rejected attempt, this second, otherwise-identical frame would be
+    treated as "unchanged" and skipped -- the field would never land.
+    """
+    original_apply = StateStore.apply
+    store = radio._state_store
+    empty_changeset = store._empty_changeset()  # noqa: SLF001
+    span_path = "scope_controls.global.display.span"
+    rejected = {"done": False}
+
+    def _reject_span_once(observation: Observation) -> Any:
+        # A mode=0 frame also publishes ``mode`` -- only the span
+        # observation's OWN first apply call should be rejected, not
+        # whichever observation happens to reach apply() first.
+        if not rejected["done"] and str(observation.path) == span_path:
+            rejected["done"] = True
+            return empty_changeset
+        return original_apply(store, observation)
+
+    frame = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=10_000)
+
+    with patch.object(StateStore, "apply", side_effect=_reject_span_once):
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+    assert rejected["done"], "test setup did not exercise the span apply call"
+
+    with pytest.raises(KeyError):
+        radio._state_store.snapshot().field("scope_controls.global.display.span")
+
+    second = _make_scope_waveform_frame(mode=0, start_hz=14_050_000, end_hz=10_000)
+    await radio._civ_runtime._route_civ_frame(second, generation=radio._civ_epoch)
+
+    field = radio._state_store.snapshot().field("scope_controls.global.display.span")
+    assert field.value == 2  # _SCOPE_SPAN_PRESETS_HZ.index(10000)
     assert field.freshness is FreshnessState.FRESH
 
 

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -43,7 +43,13 @@ from test_radio import MockTransport, _wrap_civ_in_udp
 
 from rigplane import IC_7610_ADDR
 from rigplane.runtime._civ_rx import CIV_HEADER_SIZE
-from rigplane.commands import CONTROLLER_ADDR, build_civ_frame, parse_civ_frame
+from rigplane.commands import (
+    CONTROLLER_ADDR,
+    build_civ_frame,
+    parse_civ_frame,
+    parse_scope_span_response,
+)
+from rigplane.commands.scope import _SCOPE_SPAN_PRESETS_HZ
 from rigplane.commands.tone import _encode_tone_freq
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
@@ -4002,19 +4008,34 @@ async def test_scope_waveform_fixed_mode_emits_no_span_edge_or_fixed_edge(
     assert "scope_controls.global.display.fixed_edge" not in applied_paths
 
 
-async def test_scope_waveform_center_mode_span_match_emits_one_observation(
-    radio: IcomRadio,
+@pytest.mark.parametrize("preset_index", range(len(_SCOPE_SPAN_PRESETS_HZ)))
+async def test_scope_waveform_center_mode_span_matches_reply_path_parity(
+    radio: IcomRadio, preset_index: int
 ) -> None:
-    """MOR-2256: a center-mode frame whose displayed width
-    (``end_freq_hz - start_freq_hz``) exactly equals a declared span
-    preset publishes exactly one ``span`` observation carrying that
-    preset's index (the same representation ``parse_scope_span_response``
-    stores for the 0x15 reply path). Width = 2 * half_span (the raw
-    payload's "end" field, per ``rigplane.scope._ReceiverState.feed``'s
-    center-mode adjustment) = 2 * 1250 = 2500 Hz, matching
-    ``_SCOPE_SPAN_PRESETS_HZ[0]``."""
+    """MOR-2256/#3063: a center-mode frame built the way the radio
+    actually encodes it publishes the same span index the 0x27/0x15
+    reply path decodes for the identical preset value -- parity over all
+    eight declared presets.
+
+    Per the IC-7610 CI-V reference (p.14, "Scope waveform data") and the
+    IC-7300 manual, the raw payload's center-mode fields are the center
+    frequency and the SPAN value itself (the same value the 0x27/0x15
+    span table encodes), not half of it -- so ``end_hz`` below is a real
+    preset value, not an invented half-span. Both this stream path and
+    the reply path resolve through the same ``_span_index_for_hz``
+    helper against ``_SCOPE_SPAN_PRESETS_HZ``, so parity here also
+    guards against the two drifting apart in the future.
+    """
+    preset_hz = _SCOPE_SPAN_PRESETS_HZ[preset_index]
+
+    reply_frame = _make_frame(cmd=0x27, sub=0x15, data=b"\x00" + bcd_encode(preset_hz))
+    _receiver, expected_index = parse_scope_span_response(reply_frame)
+    assert expected_index == preset_index  # sanity: table order is the index
+
     with _spy_state_store_apply(radio) as apply_spy:
-        frame = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=1_250)
+        frame = _make_scope_waveform_frame(
+            mode=0, start_hz=14_000_000, end_hz=preset_hz
+        )
         await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
 
     span_calls = [
@@ -4023,20 +4044,22 @@ async def test_scope_waveform_center_mode_span_match_emits_one_observation(
         if str(call.args[0].path) == "scope_controls.global.display.span"
     ]
     assert len(span_calls) == 1
-    assert span_calls[0].args[0].value == 0
+    assert span_calls[0].args[0].value == expected_index
 
     field = radio._state_store.snapshot().field("scope_controls.global.display.span")
-    assert field.value == 0
+    assert field.value == expected_index
     assert field.freshness is FreshnessState.FRESH
 
 
 async def test_scope_waveform_center_mode_unknown_width_emits_no_span(
     radio: IcomRadio,
 ) -> None:
-    """MOR-2256: a center-mode frame whose width has no exact match in
-    ``_SCOPE_SPAN_PRESETS_HZ`` publishes nothing — not a nearest-value
-    guess. Width = 2 * 999 = 1998 Hz, which is not one of the eight
-    declared presets (2500/5000/10000/25000/50000/100000/250000/500000)."""
+    """MOR-2256: a center-mode frame whose (correctly-decoded) span has
+    no exact match in ``_SCOPE_SPAN_PRESETS_HZ`` publishes nothing — not
+    a nearest-value guess. 999 Hz is not one of the eight declared
+    presets (2500/5000/10000/25000/50000/100000/250000/500000); ``end_hz``
+    here is the raw span field itself (see the parity test above for the
+    encoding), so no doubling/halving is involved in choosing this value."""
     with _spy_state_store_apply(radio) as apply_spy:
         frame = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=999)
         await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
@@ -4049,13 +4072,13 @@ async def test_scope_waveform_center_mode_span_unchanged_emits_no_second_observa
     radio: IcomRadio,
 ) -> None:
     """MOR-2256: two consecutive center-mode frames with the same matching
-    width publish exactly one ``span`` observation total, not one per
+    span publish exactly one ``span`` observation total, not one per
     frame — mirrors ``test_scope_waveform_mode_unchanged_emits_no_observation``."""
-    first = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=1_250)
+    first = _make_scope_waveform_frame(mode=0, start_hz=14_000_000, end_hz=2_500)
     await radio._civ_runtime._route_civ_frame(first, generation=radio._civ_epoch)
 
     with _spy_state_store_apply(radio) as apply_spy:
-        second = _make_scope_waveform_frame(mode=0, start_hz=14_100_000, end_hz=1_250)
+        second = _make_scope_waveform_frame(mode=0, start_hz=14_100_000, end_hz=2_500)
         await radio._civ_runtime._route_civ_frame(second, generation=radio._civ_epoch)
 
     span_calls = [
@@ -4064,6 +4087,46 @@ async def test_scope_waveform_center_mode_span_unchanged_emits_no_second_observa
         if str(call.args[0].path) == "scope_controls.global.display.span"
     ]
     assert span_calls == []
+
+
+async def test_scope_waveform_mode_out_of_range_emits_no_observation(
+    radio: IcomRadio,
+) -> None:
+    """#3063 review: ``ScopeFrame.mode`` is documented 0-3 (the reply
+    path -- ``_decode_scope_value(minimum=0, maximum=3)`` -- can never
+    produce anything else); a corrupted/unexpected 0x27/0x00 frame
+    claiming mode 255 must not be written to the StateStore."""
+    with _spy_state_store_apply(radio) as apply_spy:
+        frame = _make_scope_waveform_frame(mode=255)
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    applied_paths = {str(call.args[0].path) for call in apply_spy.call_args_list}
+    assert "scope_controls.global.display.mode" not in applied_paths
+
+
+async def test_scope_waveform_mode_observation_survives_connect_generation(
+    radio: IcomRadio,
+) -> None:
+    """#3063 review: on a connected radio, ``advance_generation("connect")``
+    (via ``_control_phase.py``) bumps the StateStore's provider generation
+    away from 0 through ``begin_provider_generation()``. Before this fix,
+    ``_publish_scope_mode_observation`` applied an ``Observation`` whose
+    ``provider_generation`` defaulted to 0 (unbound), so
+    ``StateStore._is_current_observation`` rejected every stream
+    observation from the moment of connect onward -- the field never
+    updated. Simulates that bump directly (mirrors
+    ``test_relative_vfo_ingress_bootstraps_then_transceive_patches_immediately``'s
+    own ``begin_provider_generation()`` call) and asserts the field is
+    written anyway."""
+    store_generation = radio._state_store.begin_provider_generation()  # noqa: SLF001
+    assert store_generation != 0
+
+    frame = _make_scope_waveform_frame(mode=2)
+    await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    field = radio._state_store.snapshot().field("scope_controls.global.display.mode")
+    assert field.value == 2
+    assert field.freshness is FreshnessState.FRESH
 
 
 def test_scope_control_observations_project_public(radio: IcomRadio) -> None:

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -34,6 +34,7 @@ import asyncio
 import dataclasses
 import time
 from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -68,7 +69,7 @@ from rigplane.profiles import resolve_radio_profile
 from rigplane.radio import IcomRadio
 from rigplane.radio_state import RadioState
 from rigplane.scope import ScopeFrame
-from rigplane.core.state_store import FreshnessState, StateSnapshot
+from rigplane.core.state_store import FreshnessState, StateSnapshot, StateStore
 from rigplane.types import CivFrame, Mode, ScopeFixedEdge, bcd_encode
 from rigplane.web.radio_poller import CommandQueue, RadioPoller
 
@@ -109,6 +110,50 @@ def _make_frame(
         data=data,
         receiver=receiver,
     )
+
+
+def _make_scope_waveform_frame(
+    *,
+    receiver: int = 0,
+    mode: int,
+    start_hz: int = 14_000_000,
+    end_hz: int = 14_350_000,
+) -> CivFrame:
+    """Build a single-packet (LAN-style, seq=seqMax=1) ``0x27``/``0x00``
+    waveform frame, per ``rigplane.scope._ReceiverState.feed``'s sequence-1
+    layout: ``[receiver, seq_bcd, seqMax_bcd, mode, start(5), end(5), oor,
+    pixels...]``. ``mode`` != 0 so the assembler does not remap start/end
+    into center +/- bandwidth (only mode 0 does that).
+    """
+    raw_payload = (
+        bytes([0x01, 0x01, mode])
+        + bcd_encode(start_hz)
+        + bcd_encode(end_hz)
+        + bytes([0x00])  # out_of_range = False
+        + b"\x00"  # one pixel byte
+    )
+    return _make_frame(cmd=0x27, sub=0x00, data=bytes([receiver]) + raw_payload)
+
+
+@contextmanager
+def _spy_state_store_apply(radio: IcomRadio) -> Generator[MagicMock, None, None]:
+    """Spy on ``StateStore.apply`` calls made through ``radio``.
+
+    ``StateStore`` uses ``__slots__`` (no ``apply`` slot), so an
+    instance-level ``patch.object(radio._state_store, "apply", ...)`` fails
+    with "attribute is read-only" — this patches the class method instead,
+    with a wrapper that still calls through to the real implementation
+    bound to ``radio``'s own store.
+    """
+    original_apply = StateStore.apply
+    store = radio._state_store
+
+    def _call_through(observation: Observation) -> Any:
+        return original_apply(store, observation)
+
+    spy = MagicMock(side_effect=_call_through)
+    with patch.object(StateStore, "apply", spy):
+        yield spy
 
 
 def _bcd2(value: int) -> bytes:
@@ -3874,9 +3919,77 @@ def test_scope_control_observation_backed(
 
 
 def test_scope_waterfall_data_emits_no_observations(radio: IcomRadio) -> None:
-    """0x27 sub 0x00 (waterfall pixel data) must never reach the StateStore."""
+    """0x27 sub 0x00 never decodes via ``_observations_from_frame`` — the
+    typed-getter response path (`_scope_control_observations`) is only
+    reached for subs 0x12-0x1F; ``_route_civ_frame`` short-circuits sub
+    0x00 before that dispatch (see that function's docstring).
+
+    MOR-2222 adds a separate, later path — the waveform-stream mode
+    republish in ``_route_civ_frame`` / `_publish_scope_mode_observation` —
+    that *does* write ``scope_controls.global.display.mode`` from sub 0x00
+    frames. That path is not exercised through
+    ``_observations_from_frame`` and is covered instead by
+    ``test_scope_waveform_mode_change_emits_single_observation`` below.
+    """
     frame = _make_frame(cmd=0x27, sub=0x00, data=b"\x00\x01\x01" + b"\x00" * 16)
     assert radio._civ_runtime._observations_from_frame(frame) == ()
+
+
+async def test_scope_waveform_mode_change_emits_single_observation(
+    radio: IcomRadio,
+) -> None:
+    """MOR-2222: a waveform frame with a changed mode publishes exactly one
+    ``scope_controls.global.display.mode`` StateStore observation."""
+    with _spy_state_store_apply(radio) as apply_spy:
+        frame = _make_scope_waveform_frame(mode=1)
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    mode_calls = [
+        call
+        for call in apply_spy.call_args_list
+        if str(call.args[0].path) == "scope_controls.global.display.mode"
+    ]
+    assert len(mode_calls) == 1
+    assert mode_calls[0].args[0].value == 1
+
+    field = radio._state_store.snapshot().field("scope_controls.global.display.mode")
+    assert field.value == 1
+    assert field.freshness is FreshnessState.FRESH
+
+
+async def test_scope_waveform_mode_unchanged_emits_no_observation(
+    radio: IcomRadio,
+) -> None:
+    """MOR-2222: a second waveform frame with the same mode is a no-op —
+    the stream change-detects before writing, since it runs at up to
+    ~15 fps and every write would otherwise thrash the StateStore."""
+    first = _make_scope_waveform_frame(mode=1)
+    await radio._civ_runtime._route_civ_frame(first, generation=radio._civ_epoch)
+
+    with _spy_state_store_apply(radio) as apply_spy:
+        second = _make_scope_waveform_frame(mode=1)
+        await radio._civ_runtime._route_civ_frame(second, generation=radio._civ_epoch)
+
+    assert apply_spy.call_count == 0
+
+
+async def test_scope_waveform_frame_never_emits_edge_or_span_observation(
+    radio: IcomRadio,
+) -> None:
+    """MOR-2222: the waveform stream republishes ``mode`` only — edge/span
+    frequencies have no existing scope-control field to land in (``edge``
+    is a preset index, ``fixed_edge`` a preset-table record) and this slice
+    deliberately does not invent one. Guards the "do not invent" rule."""
+    with _spy_state_store_apply(radio) as apply_spy:
+        frame = _make_scope_waveform_frame(
+            mode=1, start_hz=14_000_000, end_hz=14_350_000
+        )
+        await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
+
+    applied_paths = {str(call.args[0].path) for call in apply_spy.call_args_list}
+    assert "scope_controls.global.display.edge" not in applied_paths
+    assert "scope_controls.global.display.span" not in applied_paths
+    assert "scope_controls.global.display.fixed_edge" not in applied_paths
 
 
 def test_scope_control_observations_project_public(radio: IcomRadio) -> None:


### PR DESCRIPTION
Linear: MOR-2222 (slice B-a and B-b of the owner's reorder; the cadence removal, B-c, is blocked by MOR-2256)

## What

The `0x27 0x00` spectrum waveform frame already carries the scope mode and the edge frequencies (`scope/__init__.py: _ReceiverState.feed`), but `runtime/_civ_rx.py: CivRxMixin._publish_scope_frame` published nothing to the StateStore: `_route_civ_frame` short-circuits sub `0x00` into the assembler, so `_scope_control_observations` never sees it. Two change-detected publications are added on that path, per receiver:

- `scope_controls.global.display.mode` from the frame's mode byte (same 0–3 scale the `0x27 0x14` reply path stores);
- `scope_controls.global.display.span`, in centre mode, from `end − start` matched exactly against the span presets through one shared helper `commands/scope.py: span_index_for_hz` — the same table `parse_scope_span_response` already depends on (`_SCOPE_SPAN_PRESETS_HZ`; moving it into the rig profiles is MOR-2258, whose first PR is stacked on this one). No match publishes nothing. Fixed mode publishes nothing: no profile declares an edge-preset table, and the `edge`/`fixed_edge` fields are preset records, not Hz pairs, so no field is invented.

Nothing is removed. The acquisition cadence over the 49 `polling_only` scope-control entries stays until MOR-2256 lands, so the web sees a superset of today (owner: the scope and its settings work fully today and must not regress).

## Why

Owner decisions on MOR-2222 (2026-09-03): the scope subsystem owns its settings; no periodic refresh; front-panel changes reach the web through the stream. Mode and span are the two settings the stream determines.

## Tests

`tests/test_civ_rx_coverage.py`: a waveform frame with a changed mode → one `mode` observation; unchanged → none; a frame never emits `edge`/`span`-from-edges observations (guard for the do-not-invent rule); centre frame whose width equals a preset → one `span` observation (index representation); unknown width → none; unchanged → one total; fixed mode → none. Mutations run and restored: drop the mode publication → red; drop the change detection → red; inject an `edge` observation → red; drop the span publication → red; loosen the helper to nearest-match → the no-match test red.

## Size

5 files, +315 −6. Under both guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
