### PR TITLE
feat(presentation): declare the peer-split instrument group and read its canvas once

### DIFF
--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -28,6 +28,18 @@ import { readWorkspace } from '../src/presentation/workspace/contract';
 import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../src/presentation/workspace/resolution';
 import DualReceiverCockpit from '../src/skins/dual-receiver-cockpit/DualReceiverCockpit.svelte';
 import PeerSplitLayout from '../src/skins/segmentline/PeerSplitLayout.svelte';
+// MOR-2253 slice 1 F1 (verifier BLOCKED): this is the harness's own mount of
+// the peer-split glass, the one other production/harness call site besides
+// `components-v2/layout/LcdLayout.svelte` — that file passes canvasW/canvasH
+// as required props now; this one did not, and mounted with an implicit
+// `undefined` for both, which `ScaledStage` cannot guard against (`NaN`
+// compares false against `<= 0`) and Svelte's `style:` directive drops
+// silently rather than writing `"undefinedpx"`. Sourced from the group
+// declaration, not literals: this file sits outside `src/`, where the
+// "declared once" contour scan (`presentation/groups/__tests__/
+// contract.test.ts`) does not reach, so a literal here would be invisible
+// to the very guard this slice exists to add.
+import { peerSplitGlassGroup } from '../src/presentation/groups/declarations';
 import ReferenceLayout from './ReferenceLayout.svelte';
 import {
   runAssertions, styleProbe, tokenSnapshot, type AssertionOptions,
@@ -175,12 +187,18 @@ const context = plan === null
   : new Map<unknown, unknown>([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]);
 
 document.title = `MOR-1070 · ${fixture.id}`;
-mount(
-  fixture.layout === 'reference' ? ReferenceLayout
-    : fixture.layout === 'peer-split' ? PeerSplitLayout
-      : DualReceiverCockpit,
-  { target: document.getElementById('app')!, context },
-);
+const target = document.getElementById('app')!;
+// `peer-split` needs its own mount call: it is the only one of the three
+// with required props (canvasW/canvasH, see the import comment above), and
+// `mount()`'s Props parameter cannot be inferred correctly across a single
+// call shared with two components that take none.
+if (fixture.layout === 'peer-split') {
+  mount(PeerSplitLayout, {
+    target, context, props: { canvasW: peerSplitGlassGroup.canvas.w, canvasH: peerSplitGlassGroup.canvas.h },
+  });
+} else {
+  mount(fixture.layout === 'reference' ? ReferenceLayout : DualReceiverCockpit, { target, context });
+}
 flushSync();
 
 declare global {

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -30,11 +30,33 @@
   import StatusBar from './StatusBar.svelte';
   import SemanticRadioSurfaces from '../wiring/SemanticRadioSurfaces.svelte';
   import { getKeyboardHandlers } from '$lib/runtime/adapters/panel-adapters';
+  import { peerSplitLayout } from '../../presentation/layouts/segmentline-declarations';
+  import { getGroup } from '../../presentation/groups/contract';
 
   // Twin-skin variant selector (#887), widened to three by MOR-2153 PR-1.
   // Default preserves today's behavior. `scope` currently falls through to
   // cockpit until C-PR1 (#895) delivers a dedicated AmberScope component.
   let { variant = 'cockpit' }: { variant?: 'cockpit' | 'scope' | 'peer-split' } = $props();
+
+  // MOR-2253 slice 1: the peer-split glass's canvas comes from the
+  // `peer-split-glass` instrument group, resolved through the `peer-split`
+  // manifest's zone reference — never a hardcoded group id here (instrument-
+  // group ADR §4: "the variant branch resolves the group through the
+  // manifest instead of hardcoding an id"). `undefined` when no zone names a
+  // group, or the named group is not registered/fixed-native (defensive; no
+  // such case exists among registered layouts today).
+  const peerSplitGroupId = peerSplitLayout.zones.find((zone) => zone.group !== undefined)?.group;
+  const peerSplitGroup = peerSplitGroupId ? getGroup(peerSplitGroupId) : undefined;
+  // Gates BOTH the glass mount below and the right-sidebar suppression
+  // (MOR-2153 PR-1's former `variant === 'peer-split'` check) on the same
+  // value, so a resolution failure (unreachable today — see above) falls
+  // back to the cockpit center AND keeps its usual SemanticRadioSurfaces
+  // slot, rather than losing the VFO/TX affordance entirely.
+  let peerSplitCanvas = $derived(
+    variant === 'peer-split' && peerSplitGroup && peerSplitGroup.scaling.mode === 'fixed-native'
+      ? peerSplitGroup.canvas
+      : undefined,
+  );
 
   let radioState = $derived(runtime.state);
   let keyboardConfig = $derived(getKeyboardConfig());
@@ -91,8 +113,8 @@
         >
           {#if variant === 'scope'}
             <AmberScope />
-          {:else if variant === 'peer-split'}
-            <PeerSplitLayout />
+          {:else if peerSplitCanvas}
+            <PeerSplitLayout canvasW={peerSplitCanvas.w} canvasH={peerSplitCanvas.h} />
           {:else}
             <AmberCockpit />
           {/if}
@@ -108,8 +130,9 @@
          surfaces (MOR-1063/1064). For `cockpit`/`scope`, wired exactly once
          here by SemanticRadioSurfaces — no new TX path. `peer-split`'s glass
          (`PeerSplitLayout.svelte`) mounts its own `SemanticRadioSurfaces
-         strips="dual"` instead, so this slot is suppressed for that variant
-         (MOR-2153 PR-1) — each SemanticRadioSurfaces instance takes a
+         strips="dual"` instead, so this slot is suppressed whenever that
+         glass actually mounts (`peerSplitCanvas`, MOR-2153 PR-1 / MOR-2253
+         slice 1) — each SemanticRadioSurfaces instance takes a
          distinct TX-lease `sourceId` from its own module-level counter
          (`components-v2/wiring/SemanticRadioSurfaces.svelte`), so two
          mounted instances would not crash, just silently duplicate the TX
@@ -119,7 +142,7 @@
          amber glass (`cockpit`/`scope`) keeps its legacy presentation for
          this slice; MOR-1162 redesigns it. -->
     <div class="content-right">
-      {#if variant !== 'peer-split'}
+      {#if !peerSplitCanvas}
         <div class="semantic-slot">
           <SemanticRadioSurfaces />
         </div>

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -105,7 +105,11 @@
     </div>
 
     <main class="content-center">
-      <div class="lcd-slot" data-lcd-variant={variant}>
+      <div
+        class="lcd-slot"
+        data-lcd-variant={variant}
+        style:aspect-ratio={peerSplitCanvas ? `${peerSplitCanvas.w} / ${peerSplitCanvas.h}` : undefined}
+      >
         <div
           class="lcd-frame lcd-mode-{displayMode}"
           data-lcd-variant={variant}
@@ -253,17 +257,26 @@
     max-height: 100%;
   }
 
-  /* `peer-split`'s glass (`PeerSplitLayout.svelte`) is a fixed 1280x540
-     native stage (`ScaledStage nativeW={1280} nativeH={540}`), not the
-     fluid 16/7.5 the amber cockpit/scope variants were tuned for — 1280/540
-     ≈ 2.370 vs 16/7.5 ≈ 2.133. Matching the slot to the glass's own ratio
-     means the frame hits `ScaledStage`'s max-scale-1 clamp on both axes at
-     once instead of one axis being starved by a mismatched frame shape,
-     which minimises the dead space the fixed-native model already produces
-     rather than adding to it. */
-  .lcd-slot[data-lcd-variant='peer-split'] {
-    aspect-ratio: 1280 / 540;
-  }
+  /* `peer-split`'s glass (`PeerSplitLayout.svelte`) is a fixed-native stage
+     sized from `peerSplitCanvas` (script above), not the fluid 16/7.5 the
+     amber cockpit/scope variants were tuned for. Matching the slot to the
+     glass's own ratio means the frame hits `ScaledStage`'s max-scale-1 clamp
+     on both axes at once instead of one axis being starved by a mismatched
+     frame shape, which minimises the dead space the fixed-native model
+     already produces rather than adding to it.
+
+     MOR-2253 slice 1 F2 (verifier BLOCKED): this used to be a static rule
+     here — `.lcd-slot[data-lcd-variant='peer-split'] { aspect-ratio: 1280 /
+     540; }` — a SECOND live restatement of the canvas `SEGMENTLINE_GLASS_
+     STAGE` already resolves by reference 150-odd lines above, invisible to
+     the "declared once" contour scan (neither an import of the stage
+     primitive nor a fixed-native sizing literal appears in this file, which
+     is exactly what let a plain CSS number slip past it once already).
+     Replaced with the `style:aspect-ratio` binding on the element above,
+     computed from the same `peerSplitCanvas` the glass mount itself uses —
+     one JS value, not two independent numbers. `undefined` (any variant but
+     `peer-split`) makes Svelte's `style:` directive omit the inline
+     property entirely, so the base rule below applies unchanged. */
 
   .lcd-frame {
     flex: 1;

--- a/frontend/src/presentation/groups/__tests__/contract.test.ts
+++ b/frontend/src/presentation/groups/__tests__/contract.test.ts
@@ -249,3 +249,49 @@ describe('the native canvas is declared exactly once in production source (ADR �
     expect(readFileSync(file, 'utf8')).not.toMatch(NATIVE_CANVAS_LITERAL);
   });
 });
+
+// MOR-2253 slice 1 F1 (verifier BLOCKED, fixed in b994382e): `fixtures/
+// main.ts` mounts `PeerSplitLayout` directly, the harness's own registration
+// path outside every inventory test and outside both tsconfigs — it has no
+// automated guard at all, and its correctness rested on two manual browser
+// measurements. This pin closes that: a textual check that the mount
+// sources canvasW/canvasH from `peerSplitGlassGroup`, never from a literal,
+// since a literal here is exactly what would be invisible to the "declared
+// once" contour scan above (`fixtures/` sits outside `src/`, where that scan
+// roots).
+describe('the fixture harness sources the peer-split canvas from the group (ADR §4 / F1)', () => {
+  // Comments stripped first — same idiom as `presentation/workspace/
+  // __tests__/purity.isolated.test.ts: code()` and `skins/segmentline/
+  // __tests__/PeerSplitLayout.component.test.ts`'s CSS stripper: a naive
+  // text search would match a comment DESCRIBING the sourcing rule instead
+  // of code that actually obeys it — the exact class of mistake that pulled
+  // `LcdLayout.svelte` into this file's own derived contour two cycles ago.
+  const fixtureSource = readFileSync('fixtures/main.ts', 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  // Narrowed to the `mount(PeerSplitLayout, ...)` call itself, not the whole
+  // file: a `1280`/`540` written for an unrelated reason elsewhere in this
+  // file (there is none today, but nothing stops one) must not mask what
+  // this call site actually passes.
+  const mountCall = fixtureSource.match(/mount\(PeerSplitLayout[\s\S]*?\}\);/)?.[0];
+
+  it('sources canvasW/canvasH from peerSplitGlassGroup.canvas, never a literal', () => {
+    // Kills: the `mount(PeerSplitLayout, ...)` call site disappearing or
+    // being renamed past what this pin's own regex recognizes — silent
+    // green from a pin that stopped finding anything would be worse than a
+    // loud failure.
+    expect(mountCall, 'no mount(PeerSplitLayout, ...) call found in fixtures/main.ts').toBeDefined();
+    // Kills: MUTATION 1 (verifier-specified) — dropping `props` from that
+    // mount call entirely, reproducing the exact defect a verifier caught
+    // live (canvasW/canvasH undefined, ScaledStage's guard cannot catch NaN).
+    expect(mountCall).toMatch(/canvasW:\s*peerSplitGlassGroup\.canvas\.w\b/);
+    expect(mountCall).toMatch(/canvasH:\s*peerSplitGlassGroup\.canvas\.h\b/);
+    // Kills: MUTATION 2 (verifier-specified, "the one that matters") —
+    // reverting the sourced values to literals (`canvasW: 1280, canvasH:
+    // 540`). Already implied by the two matches above failing to match a
+    // literal, but checked directly here too, as its own named condition
+    // with its own failure mode: a literal at this call site is precisely
+    // what the "declared once" guard above cannot see.
+    expect(mountCall).not.toMatch(/\b1280\b|\b540\b/);
+  });
+});

--- a/frontend/src/presentation/groups/__tests__/contract.test.ts
+++ b/frontend/src/presentation/groups/__tests__/contract.test.ts
@@ -1,0 +1,251 @@
+/**
+ * MOR-2253 slice 1 — `InstrumentGroup` v1 schema, validator, and compiled
+ * registry (`../contract.ts`), mirroring `../../layouts/__tests__/
+ * manifest-shape.test.ts` and `registry.test.ts` at the scale this slice's
+ * four-field schema needs. Each test's doc line names the mutation it
+ * exists to kill.
+ *
+ * Also carries the TEXTUAL half of the "declared once" guard the
+ * instrument-group ADR (`docs/plans/2026-09-02-instrument-group-adr.md` §4)
+ * requires: the native canvas a `fixed-native` group declares must be the
+ * ONE place `1280`/`540`/`0.5` are written as literals in production source
+ * (scanning the derived contour of files that could still smuggle a
+ * duplicate literal in). The STRUCTURAL half — every manifest zone that
+ * references a group agrees with that group's own canvas/minScale — lives
+ * in `../../layouts/__tests__/segmentline-registration.test.ts` instead (see
+ * the comment above that file's own describe block for why).
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { isValidLanguageId } from '../../languages/contract';
+import {
+  registerGroup, getGroup, listGroupIds, validateInstrumentGroup, GroupValidationError,
+  type InstrumentGroup,
+} from '../contract';
+// Triggers real registration side effects, same pattern `../../layouts/
+// __tests__/registry.test.ts` uses (`import { sdrTestLayout } from
+// '../declarations'`): importing the barrels is what populates the shared
+// registries, not merely defining the manifest/group objects.
+import { peerSplitGlassGroup } from '../declarations';
+
+function validGroup(overrides: Partial<InstrumentGroup> = {}): InstrumentGroup {
+  return {
+    schemaVersion: 1,
+    id: 'test-group',
+    canvas: { w: 800, h: 600 },
+    scaling: { mode: 'fixed-native', minScale: 0.4 },
+    ...overrides,
+  };
+}
+
+describe('naming policy (reused from ../../languages/contract.ts, not reimplemented)', () => {
+  // Kills: swapping isValidProductId for a no-op/always-true check.
+  it.each(['icom-modern', 'yaesu-field', 'japanese-sdr', 'ic-7610'])(
+    'rejects the vendor/geographic-marker id "%s"',
+    (id) => {
+      expect(() => validateInstrumentGroup(validGroup({ id }))).toThrow(GroupValidationError);
+    },
+  );
+
+  it('is literally the shared function, not a duplicate', () => {
+    expect(isValidLanguageId('japanese-sdr')).toBe(false);
+  });
+});
+
+describe('versioned (v1) shape', () => {
+  // Kills: dropping the schemaVersion check entirely.
+  it('rejects a group with the wrong schemaVersion', () => {
+    const group = { ...validGroup(), schemaVersion: 2 as 1 };
+    expect(() => validateInstrumentGroup(group)).toThrow(/schemaVersion/);
+  });
+
+  it('accepts schemaVersion 1', () => {
+    expect(() => validateInstrumentGroup(validGroup())).not.toThrow();
+  });
+});
+
+describe('canvas', () => {
+  // Kills: accepting a canvas with a non-positive or non-finite dimension.
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])('rejects a canvas with w=%s', (w) => {
+    expect(() => validateInstrumentGroup(validGroup({ canvas: { w, h: 600 } }))).toThrow(/canvas/);
+  });
+
+  // Kills: accepting an extra key on canvas (e.g. a smuggled `d`/`z` field).
+  it('rejects a canvas with an extra key', () => {
+    const group = validGroup({ canvas: { w: 800, h: 600, extra: 1 } as unknown as InstrumentGroup['canvas'] });
+    expect(() => validateInstrumentGroup(group)).toThrow(/canvas/);
+  });
+});
+
+describe('scaling', () => {
+  it('accepts fixed-native scaling with a positive minScale', () => {
+    expect(() => validateInstrumentGroup(validGroup({ scaling: { mode: 'fixed-native', minScale: 0.5 } })))
+      .not.toThrow();
+  });
+
+  it('accepts reflow scaling', () => {
+    expect(() => validateInstrumentGroup(validGroup({ scaling: { mode: 'reflow' } }))).not.toThrow();
+  });
+
+  // Kills: dropping the positive-finite check on minScale.
+  it('rejects a non-positive minScale', () => {
+    const group = validGroup({ scaling: { mode: 'fixed-native', minScale: 0 } });
+    expect(() => validateInstrumentGroup(group)).toThrow(/minScale/);
+  });
+
+  // Kills: accepting a fixed-native scaling object that also carries a
+  // reflow-shaped (or any extra) key.
+  it('rejects fixed-native scaling with an extra key', () => {
+    const poisoned = { mode: 'fixed-native', minScale: 0.5, extra: true } as unknown as InstrumentGroup['scaling'];
+    expect(() => validateInstrumentGroup(validGroup({ scaling: poisoned }))).toThrow(/scaling/);
+  });
+
+  // Kills: accepting a reflow scaling object that also carries minScale.
+  it('rejects reflow scaling with an extra key', () => {
+    const poisoned = { mode: 'reflow', minScale: 0.5 } as unknown as InstrumentGroup['scaling'];
+    expect(() => validateInstrumentGroup(validGroup({ scaling: poisoned }))).toThrow(/scaling/);
+  });
+
+  it('rejects an unknown scaling.mode', () => {
+    const poisoned = { mode: 'stretch' } as unknown as InstrumentGroup['scaling'];
+    expect(() => validateInstrumentGroup(validGroup({ scaling: poisoned }))).toThrow(/mode/);
+  });
+});
+
+describe('capability-fork and module-path rejection (ADR §3: a new guard needed for a separate group node)', () => {
+  // Kills: no capability-shaped-key scan wired into validateInstrumentGroup —
+  // the layouts scan (`findCapabilityLikeKey`) only ever runs over a
+  // LayoutManifest, never a group.
+  it('rejects a group with a top-level capabilities-shaped key', () => {
+    const group = { ...validGroup(), capabilities: ['CW'] };
+    expect(() => validateInstrumentGroup(group as never)).toThrow(/capability-shaped key/);
+  });
+
+  // Kills: findModulePathLikeValue never wired in, or its regex loosened to
+  // miss a real relative-import-shaped string riding in `id`.
+  it('rejects a module-path-shaped value riding in id', () => {
+    const group = validGroup({ id: '../evil/path' });
+    expect(() => validateInstrumentGroup(group)).toThrow(/module-path-shaped value/);
+  });
+
+  // Kills: unknown-top-level-key rejection missing or checking a subset.
+  it('rejects a group with an extra unknown top-level key', () => {
+    const group = { ...validGroup(), extraField: 'nope' };
+    expect(() => validateInstrumentGroup(group as never)).toThrow(/unknown top-level key/);
+  });
+});
+
+describe('compiled registry — count-agnostic, same shape as ../../layouts/contract.ts', () => {
+  it('registers a hypothetical extra group the same way as peer-split-glass', () => {
+    const before = listGroupIds().length;
+    registerGroup(validGroup({ id: 'hypothetical-group' }));
+    expect(listGroupIds().length).toBe(before + 1);
+    expect(getGroup('hypothetical-group')?.id).toBe('hypothetical-group');
+  });
+
+  // Kills: registerGroup silently overwriting instead of rejecting a second
+  // registration.
+  it('rejects re-registering an already-registered id', () => {
+    registerGroup(validGroup({ id: 'duplicate-test-group' }));
+    expect(() => registerGroup(validGroup({ id: 'duplicate-test-group' }))).toThrow(GroupValidationError);
+    expect(() => registerGroup(validGroup({ id: 'duplicate-test-group' }))).toThrow(/already registered/);
+  });
+
+  it('returns undefined for an id that was never registered', () => {
+    expect(getGroup('never-registered-group-xyz')).toBeUndefined();
+  });
+});
+
+describe('the peer-split-glass real registration proof', () => {
+  // Kills: declarations.ts defining the group but never calling
+  // registerGroup — the resolution below would then read undefined.
+  it('registers peer-split-glass through the real registry', () => {
+    expect(getGroup('peer-split-glass')).toBe(peerSplitGlassGroup);
+    expect(peerSplitGlassGroup.scaling.mode).toBe('fixed-native');
+  });
+});
+
+// The structural half of the "declared once" guard — every manifest zone
+// referencing a group agrees with that group's own canvas/minScale — lives
+// in `../../layouts/__tests__/segmentline-registration.test.ts` instead of
+// here: it must read the layout manifest's own MOR-1160 stage-sizing field,
+// and `../../layouts/__tests__/stage-sizing-boundary.test.ts`'s own MOR-1247
+// tripwire fails any file OUTSIDE `presentation/layouts/` whose source names
+// that field's identifier at all — a file under `presentation/groups/
+// __tests__/` is exactly such a file (found by running the check here once
+// and reading the tripwire red; module load registers both registries the
+// same way either location would).
+
+describe('the native canvas is declared exactly once in production source (ADR §4)', () => {
+  const SRC_ROOT = 'src';
+  // The two objects the ADR (§4) names as entitled to their own literal:
+  // `LCD_NATIVE_STAGE` (a coincidence with the glass's numbers, not a shared
+  // declaration — `lcd-cockpit`/`lcd-scope` are not groups yet) and this
+  // module's own declaration file (where the literal legitimately lives).
+  const ENTITLED = new Set([
+    path.join(SRC_ROOT, 'presentation', 'layouts', 'lcd-declarations.ts'),
+    path.join(SRC_ROOT, 'presentation', 'groups', 'declarations.ts'),
+  ]);
+  const NATIVE_CANVAS_LITERAL = /\b1280\b|\b540\b|\b0\.5\b/;
+
+  function collectSourceFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...collectSourceFiles(full));
+      else if (full.endsWith('.ts') || full.endsWith('.svelte')) out.push(full);
+    }
+    return out;
+  }
+
+  // Excludes `__tests__` from the derivation, same reason `skins/__tests__/
+  // mor1099-unmounted-svelte-census.test.ts` excludes it from its own
+  // importer-candidate set: a test fixture can carry the same numbers for an
+  // unrelated reason (`../../layouts/__tests__/manifest-shape.test.ts`'s
+  // `minScale: 0` negative case; `registry.test.ts`'s four viewport-fallback
+  // fixtures) and would read identically to a real declaration under a
+  // text-level scan, hiding a real duplicate behind its own test's prose.
+  function isProductionFile(file: string): boolean {
+    return !file.split(path.sep).includes('__tests__');
+  }
+
+  function derivedContour(): string[] {
+    return collectSourceFiles(SRC_ROOT)
+      .filter(isProductionFile)
+      .filter((file) => !ENTITLED.has(file))
+      .filter((file) => {
+        const text = readFileSync(file, 'utf8');
+        return /import ScaledStage/.test(text) || /mode:\s*'fixed-native'/.test(text);
+      })
+      .sort();
+  }
+
+  // A file entering or leaving this set changes what the textual scan below
+  // covers — pinned so the set cannot silently drift out from under it.
+  // Four files, not the three `9a737997` (pre-this-slice) derived: `../
+  // contract.ts` matches the same way `../../layouts/contract.ts` already
+  // did — via `GroupScaling`'s own `readonly mode: 'fixed-native'` TYPE
+  // literal, not a value — and carries zero 1280/540/0.5 literals, same as
+  // its layouts sibling.
+  const HAND_WRITTEN_CONTOUR = [
+    path.join(SRC_ROOT, 'presentation', 'groups', 'contract.ts'),
+    path.join(SRC_ROOT, 'presentation', 'layouts', 'contract.ts'),
+    path.join(SRC_ROOT, 'presentation', 'layouts', 'segmentline-declarations.ts'),
+    path.join(SRC_ROOT, 'skins', 'segmentline', 'PeerSplitLayout.svelte'),
+  ].sort();
+
+  // Kills: the derivation rule (import ScaledStage OR declare a layout's own
+  // `fixed-native` stage-sizing value, minus the entitled files) drifting
+  // away from what this suite actually scans below.
+  it('the derivation rule yields exactly the hand-written contour', () => {
+    expect(derivedContour()).toEqual(HAND_WRITTEN_CONTOUR);
+  });
+
+  // Kills: PeerSplitLayout.svelte or segmentline-declarations.ts reverting to
+  // a literal 1280/540/0.5 instead of reading the group by reference —
+  // MUTATION TARGET (see the PR body for the observed red/green cycle).
+  it.each(HAND_WRITTEN_CONTOUR)('%s declares no native-canvas literal', (file) => {
+    expect(readFileSync(file, 'utf8')).not.toMatch(NATIVE_CANVAS_LITERAL);
+  });
+});

--- a/frontend/src/presentation/groups/contract.ts
+++ b/frontend/src/presentation/groups/contract.ts
@@ -34,11 +34,6 @@ export interface InstrumentGroup {
   readonly scaling: GroupScaling;
 }
 
-/** A registered group's id — kebab-case, same naming policy as a layout id.
- *  Used by `../layouts/contract.ts: LayoutZone.group` to reference a group
- *  by id rather than importing it. */
-export type GroupId = string;
-
 const TOP_LEVEL_KEYS: readonly PropertyKey[] = ['schemaVersion', 'id', 'canvas', 'scaling'];
 const CANVAS_KEYS: readonly PropertyKey[] = ['w', 'h'];
 const FIXED_NATIVE_SCALING_KEYS: readonly PropertyKey[] = ['mode', 'minScale'];

--- a/frontend/src/presentation/groups/contract.ts
+++ b/frontend/src/presentation/groups/contract.ts
@@ -1,0 +1,162 @@
+/**
+ * Instrument group v1 schema, runtime validator, and compiled registry
+ * (MOR-2253 slice 1) — the separate `InstrumentGroup` node the instrument-
+ * group ADR's decided shape (b) calls for
+ * (`docs/plans/2026-09-02-instrument-group-adr.md` §5/§10.2), mirroring
+ * `../layouts/contract.ts` (MOR-1066). A group declares the canvas an
+ * instrument's fixed-native stage is authored against and how that canvas
+ * scales into whatever mounts it.
+ *
+ * `members`, `look` and `zone` from the ADR's illustrative schema (§4) are
+ * NOT declared here: the owner ruling this slice implements is "a field is
+ * declared only if it has a production reader", and none of those three has
+ * one yet (see the PR body for why each is deferred).
+ */
+import { isValidLanguageId as isValidProductId } from '../languages/contract';
+
+export interface GroupCanvas {
+  readonly w: number;
+  readonly h: number;
+}
+
+/** `fixed-native` mirrors `../layouts/contract.ts`'s `FixedNativeSizing` axis
+ *  (MOR-1160) at the group level — the shell mounts the instrument's
+ *  `ScaledStage` at `canvas.w`x`canvas.h`. `reflow` means no stage at all:
+ *  the mounting container's own CSS decides (ADR §4, owner decision 6). */
+export type GroupScaling =
+  | { readonly mode: 'fixed-native'; readonly minScale: number }
+  | { readonly mode: 'reflow' };
+
+export interface InstrumentGroup {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly canvas: GroupCanvas;
+  readonly scaling: GroupScaling;
+}
+
+/** A registered group's id — kebab-case, same naming policy as a layout id.
+ *  Used by `../layouts/contract.ts: LayoutZone.group` to reference a group
+ *  by id rather than importing it. */
+export type GroupId = string;
+
+const TOP_LEVEL_KEYS: readonly PropertyKey[] = ['schemaVersion', 'id', 'canvas', 'scaling'];
+const CANVAS_KEYS: readonly PropertyKey[] = ['w', 'h'];
+const FIXED_NATIVE_SCALING_KEYS: readonly PropertyKey[] = ['mode', 'minScale'];
+const REFLOW_SCALING_KEYS: readonly PropertyKey[] = ['mode'];
+
+export class GroupValidationError extends Error {}
+
+/** Exact-OWN-keys discipline — same idiom as `../layouts/contract.ts:
+ *  hasExactPlainKeys` (MOR-1072 review precedent). Not imported from there:
+ *  that function is module-private, and this codebase already carries one
+ *  independent copy of the idiom per contract module (`../languages/
+ *  contract.ts` has its own inlined copy too) rather than a shared helper. */
+function hasExactPlainKeys(value: object, keys: readonly PropertyKey[]): boolean {
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Reflect.ownKeys(value).every((k) => keys.includes(k));
+}
+
+/**
+ * Same JSON.stringify-replacer idiom as `../layouts/contract.ts:
+ * findCapabilityLikeKey` — required here because that scan only ever runs
+ * over a `LayoutManifest` (ADR §3's boundary-sentence guard table: "No
+ * capability facts in a declaration" needs a new guard once a group is a
+ * separate node).
+ */
+const FORBIDDEN_KEY_MARKERS = ['capability', 'capabilities', 'radiomodel', 'vendor', 'manufacturer', 'firmware'];
+function findCapabilityLikeKey(group: InstrumentGroup): string | null {
+  let hit: string | null = null;
+  JSON.stringify(group, (key, value) => {
+    if (!hit && FORBIDDEN_KEY_MARKERS.some((m) => key.toLowerCase().includes(m))) hit = key;
+    return value;
+  });
+  return hit;
+}
+
+/** Same idiom as `../layouts/contract.ts: findModulePathLikeValue` — the
+ *  ADR §3 guard table's "No module paths in a declaration" row, also needing
+ *  a new guard for the same reason as the capability scan above. */
+const MODULE_PATH_VALUE_PATTERN = /^(\.{1,2}\/|\$lib\/|src\/|\/)/;
+function findModulePathLikeValue(group: InstrumentGroup): string | null {
+  let hit: string | null = null;
+  JSON.stringify(group, (key, value) => {
+    if (!hit && typeof value === 'string' && MODULE_PATH_VALUE_PATTERN.test(value)) hit = key;
+    return value;
+  });
+  return hit;
+}
+
+function validateCanvas(id: string, canvas: GroupCanvas): string | null {
+  if (!hasExactPlainKeys(canvas, CANVAS_KEYS)) {
+    return `Group "${id}" canvas must declare only w/h.`;
+  }
+  if (!(typeof canvas.w === 'number' && Number.isFinite(canvas.w) && canvas.w > 0
+    && typeof canvas.h === 'number' && Number.isFinite(canvas.h) && canvas.h > 0)) {
+    return `Group "${id}" canvas requires positive finite w/h.`;
+  }
+  return null;
+}
+
+function validateScaling(id: string, scaling: GroupScaling): string | null {
+  if (scaling.mode === 'reflow') {
+    if (!hasExactPlainKeys(scaling, REFLOW_SCALING_KEYS)) {
+      return `Group "${id}" reflow scaling must declare only mode.`;
+    }
+    return null;
+  }
+  if (scaling.mode === 'fixed-native') {
+    if (!hasExactPlainKeys(scaling, FIXED_NATIVE_SCALING_KEYS)) {
+      return `Group "${id}" fixed-native scaling must declare only mode/minScale.`;
+    }
+    if (!(typeof scaling.minScale === 'number' && Number.isFinite(scaling.minScale) && scaling.minScale > 0)) {
+      return `Group "${id}" fixed-native scaling requires a positive finite minScale.`;
+    }
+    return null;
+  }
+  return `Group "${id}" scaling.mode must be 'fixed-native' | 'reflow'.`;
+}
+
+/** Throws with a descriptive message if `group` violates the v1 contract. */
+export function validateInstrumentGroup(group: InstrumentGroup): void {
+  const id = group.id;
+  const capabilityHit = findCapabilityLikeKey(group);
+  const modulePathHit = findModulePathLikeValue(group);
+  // Same ordering discipline as `../layouts/contract.ts:
+  // validateLayoutManifest` — the capability/module-path scan runs first, so
+  // a poisoned group dies on that message even when another field is also
+  // malformed.
+  const problem =
+    (capabilityHit && `Group "${id}" references a capability-shaped key "${capabilityHit}".`) ||
+    (modulePathHit && `Group "${id}" references a module-path-shaped value at key "${modulePathHit}" — groups hold stable IDs, not paths.`) ||
+    (!hasExactPlainKeys(group, TOP_LEVEL_KEYS) &&
+      `Group "${id}" has unknown top-level key(s) — only [${TOP_LEVEL_KEYS.join(', ')}] are allowed.`) ||
+    (group.schemaVersion !== 1 && `Group "${id}" schemaVersion must be 1.`) ||
+    (!isValidProductId(id) && `Group id "${id}" fails naming policy: kebab-case, no vendor/geographic marker.`) ||
+    validateCanvas(id, group.canvas) ||
+    validateScaling(id, group.scaling);
+  if (problem) throw new GroupValidationError(problem);
+}
+
+// ── Compiled registry. Count-agnostic: any group passing validation
+// registers, same as ../layouts/contract.ts.
+
+const registry = new Map<string, InstrumentGroup>();
+
+/** Validates then registers `group`. Rejects a duplicate ID, same rationale
+ *  as `../layouts/contract.ts: registerLayout`. */
+export function registerGroup(group: InstrumentGroup): void {
+  validateInstrumentGroup(group);
+  if (registry.has(group.id)) {
+    throw new GroupValidationError(`Group id "${group.id}" is already registered.`);
+  }
+  registry.set(group.id, group);
+}
+
+export function getGroup(id: string): InstrumentGroup | undefined {
+  return registry.get(id);
+}
+
+export function listGroupIds(): readonly string[] {
+  return Array.from(registry.keys());
+}

--- a/frontend/src/presentation/groups/declarations.ts
+++ b/frontend/src/presentation/groups/declarations.ts
@@ -1,0 +1,23 @@
+/**
+ * MOR-2253 slice 1 — `peer-split-glass`, the first `InstrumentGroup`
+ * (instrument-group ADR §9/§10.8's migration order starts with peer-split).
+ * Absorbs the native-canvas duplication (ADR §4, F2) between
+ * `../layouts/segmentline-declarations.ts`'s `SEGMENTLINE_GLASS_STAGE` and
+ * `../../skins/segmentline/PeerSplitLayout.svelte`'s own former
+ * `NATIVE_W`/`NATIVE_H` constants — both now read this declaration by
+ * reference instead of repeating the numbers.
+ *
+ * Declared directly here rather than in its own per-family file: this is the
+ * first group, the same shape `../layouts/declarations.ts` used for its own
+ * first manifest (`sdrTestLayout`) before later families split out.
+ */
+import { registerGroup, type InstrumentGroup } from './contract';
+
+export const peerSplitGlassGroup = {
+  schemaVersion: 1,
+  id: 'peer-split-glass',
+  canvas: { w: 1280, h: 540 },
+  scaling: { mode: 'fixed-native', minScale: 0.5 },
+} as const satisfies InstrumentGroup;
+
+registerGroup(peerSplitGlassGroup);

--- a/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
@@ -17,7 +17,7 @@ import {
   getLayout, listLayoutIds, resolveLayoutForTopology, resolveLayoutForViewport,
   TOPOLOGY_CLASSES,
 } from '../contract';
-import { getGroup } from '../../groups/contract';
+import { getGroup, listGroupIds } from '../../groups/contract';
 // Deliberately through the shared aggregation entry, not `../segmentline-
 // declarations` directly: it pins that `declarations.ts` really registers
 // `peerSplitLayout` (nothing else does), and keeps this fast-pool file on
@@ -131,6 +131,46 @@ describe('the native canvas value equals the group the zone references (ADR §4)
       expect(manifest.stageSizing.nativeW).toBe(group!.canvas.w);
       expect(manifest.stageSizing.nativeH).toBe(group!.canvas.h);
       expect(manifest.stageSizing.minScale).toBe(group!.scaling.minScale);
+    }
+  });
+});
+
+// ADR §7's registry-derived-inventory shape, applied to the reverse
+// reference itself: `validateZones` (`../contract.ts`) checks `zone.surfaces`
+// against `SEMANTIC_SURFACE_NAMES`, but `zone.group` is checked against
+// nothing there — it is a plain `string` (ADR §4's own precedent: `id`/
+// `zone` are both undecorated `string` in the illustrative schema), so a
+// typo'd or stale id silently resolves to `undefined` at runtime with no
+// validator to catch it. Not validated inside `../contract.ts` itself: that
+// would need a VALUE import of the groups registry, and a type-only import
+// of it already pulled `presentation/groups/contract.ts` into the workspace
+// purity closure (MOR-1077/78/79) once already — this test is the guard
+// instead, kept as a test-only cross-registry read.
+//
+// Both sides are derived, never hand-listed: the declared side walks every
+// registered manifest's zones (not just peer-split's), and the registered
+// side is `listGroupIds()` itself — so a future group-referencing zone or a
+// renamed group id needs no matching edit here.
+describe('every zone-declared group id resolves in the registry (ADR §7 inventory shape)', () => {
+  // Kills: a `zone.group` value that names an id no `InstrumentGroup` ever
+  // registers (a typo, or a stale id left behind by a rename on one side
+  // only) — `validateZones` has no bounded-vocabulary check for this field,
+  // so nothing else in the manifest contract would catch it.
+  it('every zone-declared group id is in listGroupIds()', () => {
+    const declaredGroupIds = listLayoutIds()
+      .map((id) => getLayout(id)!)
+      .flatMap((manifest) => manifest.zones)
+      .map((zone) => zone.group)
+      .filter((group): group is string => group !== undefined);
+
+    // Kills: the whole check vacuously passing because no manifest zone
+    // actually declares a group.
+    expect(declaredGroupIds.length).toBeGreaterThan(0);
+
+    const registeredGroupIds = listGroupIds();
+    for (const groupId of declaredGroupIds) {
+      expect(registeredGroupIds, `zone declares group "${groupId}", which listGroupIds() does not contain`)
+        .toContain(groupId);
     }
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
@@ -14,9 +14,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import {
-  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
+  getLayout, listLayoutIds, resolveLayoutForTopology, resolveLayoutForViewport,
   TOPOLOGY_CLASSES,
 } from '../contract';
+import { getGroup } from '../../groups/contract';
 // Deliberately through the shared aggregation entry, not `../segmentline-
 // declarations` directly: it pins that `declarations.ts` really registers
 // `peerSplitLayout` (nothing else does), and keeps this fast-pool file on
@@ -25,6 +26,10 @@ import {
 // module graph (and a phantom "layout not registered") happens. See
 // vite.config.ts #771 and `sdr-registration.test.ts`'s identical note.
 import { peerSplitLayout } from '../declarations';
+// MOR-2253 slice 1: the zone's `group` reference, read back from the same
+// declaration the manifest points at rather than a hand-typed literal id, so
+// a future rename of `peer-split-glass` cannot silently desync this pin.
+import { peerSplitGlassGroup } from '../../groups/declarations';
 // MOR-2151 review round: a new zone id has no guard of its own in this
 // ticket's files — it was caught only by `workspace/__tests__/contract.
 // test.ts`'s cross-file derivation (`WORKSPACE_ZONE_IDS` must equal the set
@@ -68,7 +73,9 @@ describe('declared semantic zones (minimal registration — MOR-2151)', () => {
   // shipping the archived draft's richer zone set (ten zones, three of them
   // all naming `vfo` alone) instead of this slice's single minimal zone.
   it('mounts vfo + rxTx in exactly one zone, under the stable `peer-columns` id', () => {
-    expect(peerSplitLayout.zones).toEqual([{ id: 'peer-columns', surfaces: ['vfo', 'rxTx'] }]);
+    expect(peerSplitLayout.zones).toEqual([
+      { id: 'peer-columns', surfaces: ['vfo', 'rxTx'], group: peerSplitGlassGroup.id },
+    ]);
     expect([...peerSplitLayout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
 
@@ -82,6 +89,48 @@ describe('declared semantic zones (minimal registration — MOR-2151)', () => {
   it('declares its zone id in the workspace zone-id registry', () => {
     for (const zone of peerSplitLayout.zones) {
       expect(WORKSPACE_ZONE_IDS as readonly string[]).toContain(zone.id);
+    }
+  });
+});
+
+// The structural half of the instrument-group ADR's "declared once" guard
+// (`docs/plans/2026-09-02-instrument-group-adr.md` §4): every manifest zone
+// referencing a group must agree with that group's own canvas/minScale. Read
+// back out of the shared registries (never hardcoding 1280/540/0.5 itself),
+// so a manifest and its referenced group disagreeing is what turns this red.
+//
+// Lives here rather than beside the group's own validator/registry tests
+// (`../../groups/__tests__/contract.test.ts`) because it must read
+// `LayoutManifest.stageSizing`, and `./stage-sizing-boundary.test.ts`'s own
+// MOR-1247 tripwire fails any file OUTSIDE `presentation/layouts/` that
+// names `stageSizing` at all — a file under `presentation/groups/__tests__/`
+// is exactly such a file (found by running the check there once and reading
+// the tripwire red).
+describe('the native canvas value equals the group the zone references (ADR §4)', () => {
+  // Kills: retargeting a manifest's stageSizing to a group by NAME
+  // (zone.group) without also retargeting its actual nativeW/nativeH/
+  // minScale VALUES to come from that same group — the two could drift
+  // independently.
+  it('every zone referencing a group agrees with that group\'s own canvas and minScale', () => {
+    const referencingZones = listLayoutIds()
+      .map((id) => getLayout(id)!)
+      .flatMap((manifest) => manifest.zones.map((zone) => ({ manifest, zone })))
+      .filter(({ zone }) => zone.group !== undefined);
+
+    // Kills: the whole check vacuously passing because no manifest zone
+    // actually references a group (e.g. the reference wiring never lands).
+    expect(referencingZones.length).toBeGreaterThan(0);
+
+    for (const { manifest, zone } of referencingZones) {
+      const group = getGroup(zone.group!);
+      expect(group, `zone "${zone.id}" on layout "${manifest.id}" references unregistered group "${zone.group}"`)
+        .toBeDefined();
+      expect(manifest.stageSizing.mode).toBe('fixed-native');
+      expect(group!.scaling.mode).toBe('fixed-native');
+      if (manifest.stageSizing.mode !== 'fixed-native' || group!.scaling.mode !== 'fixed-native') continue;
+      expect(manifest.stageSizing.nativeW).toBe(group!.canvas.w);
+      expect(manifest.stageSizing.nativeH).toBe(group!.canvas.h);
+      expect(manifest.stageSizing.minScale).toBe(group!.scaling.minScale);
     }
   });
 });

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -12,6 +12,7 @@
  */
 import type { Component } from 'svelte';
 import { isValidLanguageId as isValidProductId } from '../languages/contract';
+import type { GroupId } from '../groups/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
@@ -50,6 +51,16 @@ export type TopologyClass = (typeof TOPOLOGY_CLASSES)[number];
 export interface LayoutZone {
   readonly id: string;
   readonly surfaces: readonly SemanticSurfaceName[];
+  /**
+   * MOR-2253 slice 1 — the `InstrumentGroup` (`../groups/contract.ts`)
+   * mounted in this zone, resolved by id rather than importing the group
+   * (the manifest stays a declaration, never a value pulled in from another
+   * presentation module). Optional: most zones mount bare semantic surfaces
+   * with no group. `validateZones` below checks only `id`/`surfaces` — this
+   * field is not exact-key-checked (no `hasExactPlainKeys` call touches a
+   * zone object), so adding it needed no validator change.
+   */
+  readonly group?: GroupId;
 }
 
 /**
@@ -77,7 +88,15 @@ export interface LayoutManifest {
   readonly schemaVersion: 1;
   readonly id: string;
   readonly displayName: string;
-  readonly loader: () => Promise<{ default: Component }>;
+  // `Component<any>`, not the bare `Component` (implicitly `Component<{}>`):
+  // MOR-2253 slice 1 gave `PeerSplitLayout.svelte` required `canvasW`/
+  // `canvasH` props (its former native-size constants, now the shell's
+  // job), and `Props` is checked contravariantly here — a loader whose
+  // component requires props is not assignable to one requiring none. The
+  // validator only ever checks `typeof manifest.loader === 'function'`
+  // (below), never the loaded component's prop shape, so this widens
+  // nothing this contract actually enforces.
+  readonly loader: () => Promise<{ default: Component<any> }>;
   readonly zones: readonly LayoutZone[];
   readonly compatibleTopologies: readonly TopologyClass[];
   readonly requiredSemanticSurfaces: readonly SemanticSurfaceName[];

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -12,7 +12,6 @@
  */
 import type { Component } from 'svelte';
 import { isValidLanguageId as isValidProductId } from '../languages/contract';
-import type { GroupId } from '../groups/contract';
 
 /** Semantic surfaces a layout may mount (MOR-1062/1065 reference vertical;
  *  `txAux` added by MOR-1265, `meters` by MOR-1273, `rxAudio` by MOR-1279,
@@ -52,15 +51,20 @@ export interface LayoutZone {
   readonly id: string;
   readonly surfaces: readonly SemanticSurfaceName[];
   /**
-   * MOR-2253 slice 1 — the `InstrumentGroup` (`../groups/contract.ts`)
-   * mounted in this zone, resolved by id rather than importing the group
-   * (the manifest stays a declaration, never a value pulled in from another
-   * presentation module). Optional: most zones mount bare semantic surfaces
-   * with no group. `validateZones` below checks only `id`/`surfaces` — this
-   * field is not exact-key-checked (no `hasExactPlainKeys` call touches a
-   * zone object), so adding it needed no validator change.
+   * MOR-2253 slice 1 — the id of the `InstrumentGroup` (`../groups/
+   * contract.ts`) mounted in this zone. A plain `string`, not an imported
+   * `GroupId` type alias: `presentation/workspace/__tests__/purity.isolated
+   * .test.ts` and its two siblings (MOR-1077/78/79) pin this file's own
+   * import closure by hand, and even a type-only import of `../groups/
+   * contract` would pull that module into it — a real edge this manifest
+   * contract does not need, since the id is only ever compared as a string
+   * (`getGroup` in `../groups/contract.ts` also takes a bare `string`).
+   * Optional: most zones mount bare semantic surfaces with no group.
+   * `validateZones` below checks only `id`/`surfaces` — this field is not
+   * exact-key-checked (no `hasExactPlainKeys` call touches a zone object),
+   * so adding it needed no validator change.
    */
-  readonly group?: GroupId;
+  readonly group?: string;
 }
 
 /**

--- a/frontend/src/presentation/layouts/segmentline-declarations.ts
+++ b/frontend/src/presentation/layouts/segmentline-declarations.ts
@@ -31,14 +31,24 @@
  *      collapsed to the one minimal zone below.
  */
 import { registerLayout, type LayoutManifest } from './contract';
+import { peerSplitGlassGroup } from '../groups/declarations';
 
 /**
- * The `segmentline` family's canonical glass, matching the LCD family's own
- * `LCD_NATIVE_STAGE` (`lcd-declarations.ts`) — same 1280x540 native size and
- * 0.5 `minScale`, per `docs/plans/2026-09-01-segmentline-peer-split.md` §9.
+ * The `segmentline` family's canonical glass. Its native size and minScale
+ * are the `peer-split-glass` instrument group's own declaration
+ * (`../groups/declarations.ts`, MOR-2253 slice 1), read by reference here —
+ * this used to duplicate `PeerSplitLayout.svelte`'s own `NATIVE_W`/
+ * `NATIVE_H` constants as a second, independent literal (instrument-group
+ * ADR §4, F2); both now point at the one group declaration instead.
+ * `LCD_NATIVE_STAGE` (`lcd-declarations.ts`) happens to agree with this
+ * group's numbers, but stays its own separate literal (ADR §4): `lcd-
+ * cockpit`/`lcd-scope` are not groups until a later migration slice.
  */
 const SEGMENTLINE_GLASS_STAGE = {
-  mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
+  mode: 'fixed-native',
+  nativeW: peerSplitGlassGroup.canvas.w,
+  nativeH: peerSplitGlassGroup.canvas.h,
+  minScale: peerSplitGlassGroup.scaling.minScale,
 } as const;
 
 export const peerSplitLayout: LayoutManifest = {
@@ -50,8 +60,11 @@ export const peerSplitLayout: LayoutManifest = {
   // `<SemanticRadioSurfaces strips="dual" />` (MOR-2155). The dual
   // composition hardcodes its own `primary-vfo`/`secondary-vfo`/`global`/
   // `rx-tx` DOM zone ids regardless of what a manifest declares here (spec
-  // §4) — this id is a manifest-level label, not a DOM binding.
-  zones: [{ id: 'peer-columns', surfaces: ['vfo', 'rxTx'] }],
+  // §4) — this id is a manifest-level label, not a DOM binding. `group`
+  // (MOR-2253 slice 1) is the reverse reference the instrument-group ADR §4
+  // adds: the shell resolves `peer-split-glass` through this zone instead of
+  // hardcoding the group id.
+  zones: [{ id: 'peer-columns', surfaces: ['vfo', 'rxTx'], group: peerSplitGlassGroup.id }],
   // FTX-1's `2/ab_shared` topology is one of these two; a single-receiver
   // radio has nothing to put in a second column (spec §2).
   compatibleTopologies: ['2/ab_shared', '2/main_sub'],

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -19,14 +19,20 @@
   import ScaledStage from '../../primitives/stage/ScaledStage.svelte';
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
 
-  /** Matches `SEGMENTLINE_GLASS_STAGE` in
-   *  `presentation/layouts/segmentline-declarations.ts` — duplicated here
-   *  because `ScaledStage` takes `nativeW`/`nativeH` as props and reads no
-   *  manifest (the manifest's own native-size declaration stays
-   *  declaration-only outside `presentation/layouts/` per MOR-1247; see
-   *  that file's own header). */
-  const NATIVE_W = 1280;
-  const NATIVE_H = 540;
+  /**
+   * Canvas size comes from the shell (`components-v2/layout/LcdLayout.svelte`),
+   * which resolves it from the `peer-split-glass` instrument group through
+   * the `peer-split` manifest's zone reference (MOR-2253 slice 1). This
+   * replaces this component's own former `NATIVE_W`/`NATIVE_H` constants,
+   * which duplicated `SEGMENTLINE_GLASS_STAGE` in `presentation/layouts/
+   * segmentline-declarations.ts` as a second, independent literal
+   * (instrument-group ADR §4, F2).
+   */
+  interface Props {
+    canvasW: number;
+    canvasH: number;
+  }
+  let { canvasW, canvasH }: Props = $props();
 
   /** Wall-clock only — see the file header. `Date`, not radio state. */
   function clockLabel(date: Date): { utc: string; local: string } {
@@ -46,7 +52,7 @@
 </script>
 
 <div class="peer-split-holder">
-  <ScaledStage nativeW={NATIVE_W} nativeH={NATIVE_H}>
+  <ScaledStage nativeW={canvasW} nativeH={canvasH}>
     <div class="peer-split-glass" data-testid="peer-split-glass">
       <div class="peer-split-clock" data-testid="peer-split-clock" aria-label="Clock">
         <span data-testid="peer-split-clock-utc">{clock.utc}</span>

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -188,10 +188,18 @@ let target: HTMLDivElement;
 let component: ReturnType<typeof mount> | null = null;
 const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T | null;
 
+// MOR-2253 slice 1: canvas size is now a required prop from the shell
+// (`components-v2/layout/LcdLayout.svelte`), not a component-local constant —
+// 1280x540 hardcoded here matches this file's own pinned assertion below
+// (`.scaled-stage`'s inline `1280px`/`540px`), same as `../../../presentation/
+// layouts/__tests__/manifest-shape.test.ts` hardcodes the same numbers for
+// its own, unrelated fixture reasons (a `__tests__` file, excluded from the
+// production "declared once" scan in `presentation/groups/__tests__/
+// contract.test.ts`).
 function render(): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(PeerSplitLayout, { target });
+  component = mount(PeerSplitLayout, { target, props: { canvasW: 1280, canvasH: 540 } });
   flushSync();
 }
 


### PR DESCRIPTION
The peer-split glass's native canvas — 1280×540 — was declared in two places
that had to agree and nothing checked: `SEGMENTLINE_GLASS_STAGE` in the layout
manifest, and `NATIVE_W`/`NATIVE_H` inside the component. This makes it one
declaration, read by reference, and adds the guards that keep it one.

It is the first slice of the instrument-group work: a `presentation/groups/`
module with a contract, a validator and a registry, and `peer-split` declared as
the first group.

## The slice is smaller than the ticket title, deliberately

The owner's rule is that **a field is declared only if it has a production
reader**. Applied honestly, that cut the schema from ADR §4 down to what has one:

| Declared | Reader |
|---|---|
| `id` | the registry, and `LayoutZone.group` resolving through `getGroup` |
| `canvas {w,h}` | the shell, which passes them to `ScaledStage` as `nativeW`/`nativeH` |
| `scaling.mode` | the shell — `fixed-native` mounts the stage, `reflow` mounts none |
| `schemaVersion` | validated only, the same status `LayoutManifest.schemaVersion` already has |

Deferred, each because nothing reads it yet:

- **`members`** — checked rather than assumed: `LcdLayout.svelte`'s peer-split
  handling is one boolean plus the glass mount, and `LcdPeerSplitSkin.svelte` is
  a ten-line wrapper. There is no shell-level surface list for `members` to
  become the source of. The list that does exist is `zones[].surfaces` in the
  layout manifest, already read by the wiring — moving that is the F5 work, not
  this slice.
- **`look`** — the glass reads `--dl-segmentline-*` tokens straight from CSS;
  nothing would resolve declared token names.
- **`zone` on the group** — the glass is mounted by the shell's variant branch,
  not by a zone lookup.

The reverse reference *is* here: `LayoutZone` gains an optional `group?: string`,
so the shell resolves the group through the manifest rather than a literal id.
Plain `string` matches ADR §4, which declares these ids as strings.

## `minScale` is declared without a live reader, knowingly

Its only chain is group → `stageSizing.minScale` → `fitsViewport`, and
`fitsViewport` has **no production caller today** — verified, not assumed:
`git grep -n "resolveLayoutForViewport\|fitsViewport" -- frontend/src` excluding
tests returns only its definition and internal calls. So the number has no
reader now, and had none before this slice either.

Its reader arrives with **MOR-2259** — `ScaledStage` honouring `minScale`, which
today it does not: `computeStageScale` has no lower clamp, so the stage shrinks
without limit and the number describes a behaviour that has never existed.
MOR-2254, which deletes the dead viewport half, is blocked on MOR-2259 so the
field cannot be orphaned in between.

Worth carrying into MOR-2259: `0.5` is reachable in practice — at a 1280×800
viewport the achievable scale for this canvas is 0.624, and it falls under 0.5
below roughly 1150px of width — so that ticket should carry the measurement
establishing the number, not only the implementation honouring it.

## The three sites, and what happened to each

| Site | Before | After |
|---|---|---|
| `skins/segmentline/PeerSplitLayout.svelte` | `NATIVE_W`/`NATIVE_H` | canvas arrives as props |
| `presentation/layouts/segmentline-declarations.ts` | literal `nativeW`/`nativeH`/`minScale` | same object, values by reference |
| `presentation/layouts/lcd-declarations.ts` | `LCD_NATIVE_STAGE` | **unchanged, deliberately** |

`LCD_NATIVE_STAGE` stays because `lcd-cockpit`/`lcd-scope` are not groups until a
later slice. Its numbers coinciding with the glass's is two different objects
agreeing, not one declaration.

A fourth site was found during review and removed rather than excused:
`LcdLayout.svelte` carried `aspect-ratio: 1280 / 540`, a live restatement of the
same canvas in the file that resolves it by reference 150 lines above. It is now
computed inline from the group. For the other variants the expression is
`undefined` and Svelte emits no `style` attribute at all, so nothing can shadow
their base `16/7.5` rule — measured, not inferred.

## Guards, and what each does not cover

**Structural** — every zone referencing a group agrees with that group's canvas,
by importing both declarations rather than comparing literals. Carries an
anti-vacuity assertion so it cannot pass on an empty set.

**Textual** — a scan for `1280`/`540`/`0.5` over a contour that is **derived**
from disk and then compared against a hand-written list, so the two cannot
drift. `__tests__` is excluded deliberately: the invariant is about production
declarations, and test fixtures use the same numbers for unrelated purposes —
`manifest-shape.test.ts` exercises the validator with them, including a
`minScale: 0` negative case. The exclusion carries its reason in the test and
cites `mor1099-unmounted-svelte-census.test.ts` as precedent so nobody removes it
as an oversight.

**Its known limit, stated because the test's name is broader than its reach:**
the contour keys on implementation markers — importing `ScaledStage`, or the
text `mode: 'fixed-native'` — not on whether a file expresses the canvas. That is
exactly how `LcdLayout.svelte`'s CSS declaration survived the first review round.
It catches files by marker, not by meaning.

**Dangling reference** — every zone declaring a `group` names an id the registry
has, both sides derived from the barrels. This lives in a test rather than
`validateZones` because validating it there needs a *value* import of the groups
registry into `presentation/layouts/contract.ts`, and a type-only import already
reddened three workspace purity tests that pin that module's transitive closure
exactly.

**Fixture harness** — `fixtures/main.ts` mounts the glass and is covered by no
static gate: it is outside both tsconfigs, not built by `npm run build`, and
`peer-split-chassis` is not in `visual-baselines.spec.ts`'s hand-listed fixture
array. A missing-props mount there was found in review and would have shipped
green; the stage lost its box entirely, measured at 1440×861 instead of 1280×540
in a real browser. Fixed, and pinned by a textual assertion that the mount
sources its canvas from the group rather than from literals — literals in that
file are invisible to the contour scan, which roots at `src/`.

## D4, established here as ADR §9 asks

`LayoutManifest.loader` is invoked exactly once in the tree, in
`components-v2/layout/__tests__/semantic-lcd-migration.component.test.ts`, for a
different manifest, in a test. Every production load goes through `SKIN_LOADERS`
via `loadSkin`/`resolveSkinId` from `App.svelte`. Nothing was deleted here; the
deletion is a separate ticket with this as its fact.

## Numbers

Mini suite: **387 files / 8400 tests**, eslint clean, `svelte-check` 0 errors 0
warnings. Baseline at the merge base `9a737997` was 386 / 8367 — one new test
file and 33 tests.

10 code + 0 regenerated baselines = **10 files**, 754 changed lines. At the
file ceiling, not over it; well under the line ceiling. One unit of work: two
files are the group node and its declaration, and every other file is either a
site that stops restating the canvas or a guard over that.

Linear: MOR-2253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
