### PR TITLE
chore: pin the builder role to opus

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -1,7 +1,7 @@
 ---
 name: builder
 description: Implementation from a prepared spec — code changes, tests, mechanical refactors inside an approved plan. Not for exploratory design decisions; those belong to the coordinator or researcher.
-model: sonnet
+model: opus
 ---
 
 You are a builder executing a prepared specification. Expect every claim you

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ a coordinator: it plans and dispatches, and does not implement. The
 implementation agent never reviews its own work (Language & Git above).
 
 Subagent roles with pinned models live in `.claude/agents/`: `scout` (haiku,
-read-only status/fact collection), `builder` (sonnet, implementation from a
+read-only status/fact collection), `builder` (opus, implementation from a
 spec), `verifier` (opus, independent review and gate verdicts), `researcher`
 (sonnet, read-only exploration with synthesis), `auditor` (opus, read-only
 adjudication of audits — mechanism duplication, displacement across layer


### PR DESCRIPTION
Owner decision 2026-09-03 01:44 UTC («строители на Opus»). Two lines: `.claude/agents/builder.md` frontmatter `model: sonnet` → `model: opus`, and the matching word in CLAUDE.md's subagent-roles paragraph. Measured by the reviewer over the 27 PRs opened 2026-09-02 19:11 → 2026-09-03 01:37 UTC: 54 review directives, 2.0 rounds per PR on average; the 13 PRs that drew at least one BLOCKED averaged 3.0. The defects those rounds found were ones the builder could have caught (a test fake without a required protocol member, stream observations unbound from the store generation, a scope span decoded at twice its encoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)