### PR TITLE
feat: declare the scope span presets in the rig profiles; the stream derivation reads them

### DIFF
--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -221,6 +221,27 @@ freshness_ttl_seconds = 4.0
 reconciliation_priority = "command_response"
 ```
 
+## `[scope]` — Panoramic Scope Settings
+
+Optional section. Reference-level range and span presets for the panoramic
+scope, where the radio supports one.
+
+| Field             | Type    | Required | Description                                              |
+|-------------------|---------|----------|-----------------------------------------------------------|
+| `ref_min_db`      | float   | no       | Minimum scope reference level, dB.                         |
+| `ref_max_db`      | float   | no       | Maximum scope reference level, dB.                         |
+| `ref_step_db`     | float   | no       | Scope reference level step size, dB.                       |
+| `span_presets_hz` | int[]   | no       | Scope span presets in Hz, index-ordered (index 0-7 matches the CI-V `0x27 0x15` span code the radio itself uses). Must be non-empty and strictly ascending. |
+
+`span_presets_hz` is what the waveform-stream span derivation
+(`runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation`,
+MOR-2256) resolves a frame's displayed width to a span index against. The
+0x15 reply-path decoder/encoder (`commands/scope.py:
+parse_scope_span_response`/`scope_set_span`) still use the hardcoded
+`_SCOPE_SPAN_PRESETS_HZ` constant as of this field's introduction — a
+follow-up threads them onto this same declared list and removes the
+constant, so there is exactly one source instead of two.
+
 ## `[attenuator]` — Attenuator Steps
 
 Optional section. Defines available attenuator values for the radio.

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -33,6 +33,15 @@ tx_codec = "PCM_1CH_16BIT"
 browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 
+[scope]
+# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
+# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
+# 0x15 reply path/SET builder in this PR; a follow-up threads this field
+# through them and deletes the constant). Read directly by the
+# waveform-stream span derivation
+# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
+span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
+
 # ── Capabilities ─────────────────────────────────────────────────
 
 [capabilities]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -30,6 +30,15 @@ data_len_max = 475
 [audio]
 codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 
+[scope]
+# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
+# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
+# 0x15 reply path/SET builder in this PR; a follow-up threads this field
+# through them and deletes the constant). Read directly by the
+# waveform-stream span derivation
+# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
+span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
+
 # ── Capabilities ─────────────────────────────────────────────────
 # Feature tags determine which UI panels and controls are rendered.
 # Grouped by functional area.

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -40,6 +40,13 @@ data_len_max = 689
 ref_min_db = -30.0
 ref_max_db = 10.0
 ref_step_db = 0.5
+# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
+# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
+# 0x15 reply path/SET builder in this PR; a follow-up threads this field
+# through them and deletes the constant). Read directly by the
+# waveform-stream span derivation
+# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
+span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
 
 # ── Capabilities ─────────────────────────────────────────────────
 # Feature tags determine which UI panels and controls are rendered.

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -30,6 +30,15 @@ tx_codec = "PCM_1CH_16BIT"
 browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 
+[scope]
+# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
+# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
+# 0x15 reply path/SET builder in this PR; a follow-up threads this field
+# through them and deletes the constant). Read directly by the
+# waveform-stream span derivation
+# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
+span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
+
 # ── Capabilities ─────────────────────────────────────────────────
 # Feature tags determine which UI panels and controls are rendered.
 # Grouped by functional area.

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -964,17 +964,21 @@ def parse_scope_mode_response(
     return _decode_scope_value(frame, sub, minimum=0, maximum=3, command=command)
 
 
-def _span_index_for_hz(hz: int) -> int | None:
-    """Return the scope-span preset index (0-7) for an exact Hz match.
+def _span_index_for_hz(hz: int, presets: tuple[int, ...]) -> int | None:
+    """Return the span-preset index (0-7) of ``hz`` within ``presets``.
 
     Single source of truth for the Hz<->span-index mapping: reused (never
     duplicated) by both ``parse_scope_span_response`` below -- the 0x15
     reply-path decoder -- and the waveform-stream span derivation
     (``runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation``,
-    MOR-2222/MOR-2256). ``_SCOPE_SPAN_PRESETS_HZ`` is a hardcoded module
-    constant, not profile-declared data; moving it into per-profile TOML
-    is tracked separately as MOR-2258 rather than duplicated here or
-    invented as new profile schema for this change.
+    MOR-2256). ``presets`` is caller-supplied rather than a module
+    constant: MOR-2258 declares the eight Icom CI-V span values as
+    ``profiles.RadioProfile.scope_span_presets_hz`` (``rigs/*.toml``:
+    ``[scope].span_presets_hz``), which the stream derivation now reads
+    and passes here. ``parse_scope_span_response`` below still passes the
+    module-level ``_SCOPE_SPAN_PRESETS_HZ`` explicitly as of this change
+    (a follow-up threads it onto the profile-declared list too and
+    removes the constant, leaving exactly one source instead of two).
 
     Returns ``None`` on no exact match -- callers decide whether that is
     an error (the reply path still raises, unchanged) or a silent no-op
@@ -996,7 +1000,7 @@ def _span_index_for_hz(hz: int) -> int | None:
     ``commands/__init__.py`` re-exports the name).
     """
     try:
-        return _SCOPE_SPAN_PRESETS_HZ.index(hz)
+        return list(presets).index(hz)
     except ValueError:
         return None
 
@@ -1009,7 +1013,7 @@ def parse_scope_span_response(
     if len(payload) == 1:
         return receiver, _validate_scope_range("scope span", payload[0], 0, 7)
     hz = bcd_decode(payload)
-    span = _span_index_for_hz(hz)
+    span = _span_index_for_hz(hz, _SCOPE_SPAN_PRESETS_HZ)
     if span is None:
         raise ValueError(f"Unknown scope span frequency {hz}")
     return receiver, span

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -411,6 +411,13 @@ class RadioProfile:
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
+    # MOR-2258: scope span presets (Hz), index-ordered to match the CI-V
+    # 0x27/0x15 span code. Single source for the waveform-stream span
+    # derivation (runtime/_civ_rx.py:
+    # CivRuntime._publish_scope_span_observation, MOR-2256); a follow-up
+    # threads it through commands/scope.py: parse_scope_span_response /
+    # scope_set_span too and removes their hardcoded constant.
+    scope_span_presets_hz: tuple[int, ...] = ()
     # Per-profile RX codec preference override (#797). When non-None, the first
     # entry is used as the initial ``audio_codec`` for radios created under this
     # profile (unless the caller passes an explicit non-default value). Values

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -568,6 +568,7 @@ class RigConfig:
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
+    scope_span_presets_hz: tuple[int, ...] = ()
     codec_preference: tuple[str, ...] | None = None
     tx_codec: str | None = None
     default_sample_rate_hz: int | None = None
@@ -782,6 +783,7 @@ class RigConfig:
             scope_ref_min_db=self.scope_ref_min_db,
             scope_ref_max_db=self.scope_ref_max_db,
             scope_ref_step_db=self.scope_ref_step_db,
+            scope_span_presets_hz=self.scope_span_presets_hz,
             codec_preference=self.codec_preference,
             tx_codec=self.tx_codec,
             default_sample_rate_hz=self.default_sample_rate_hz,
@@ -2117,6 +2119,7 @@ def load_rig(path: Path) -> RigConfig:
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
+    scope_span_presets_hz: tuple[int, ...] = ()
     if scope_section:
         scope_ref_min_db = (
             float(scope_section["ref_min_db"])
@@ -2133,6 +2136,20 @@ def load_rig(path: Path) -> RigConfig:
             if "ref_step_db" in scope_section
             else None
         )
+        if "span_presets_hz" in scope_section:
+            raw_span_presets = scope_section["span_presets_hz"]
+            if not raw_span_presets:
+                raise RigLoadError(
+                    f"{filename}: [scope].span_presets_hz must be a non-empty array"
+                )
+            scope_span_presets_hz = tuple(int(v) for v in raw_span_presets)
+            if any(
+                scope_span_presets_hz[i] >= scope_span_presets_hz[i + 1]
+                for i in range(len(scope_span_presets_hz) - 1)
+            ):
+                raise RigLoadError(
+                    f"{filename}: [scope].span_presets_hz must be strictly ascending"
+                )
 
     # Parse attenuator/preamp/agc (optional sections)
     att_section = data.get("attenuator", {})
@@ -2452,6 +2469,7 @@ def load_rig(path: Path) -> RigConfig:
         scope_ref_min_db=scope_ref_min_db,
         scope_ref_max_db=scope_ref_max_db,
         scope_ref_step_db=scope_ref_step_db,
+        scope_span_presets_hz=scope_span_presets_hz,
         codec_preference=codec_preference,
         tx_codec=tx_codec,
         default_sample_rate_hz=default_sample_rate_hz,

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -3364,16 +3364,21 @@ class CivRuntime:
         exact-division check (a remainder means this width did not come
         from that doubling and is untrustworthy) — not the raw
         difference, which is off by 2x (#3063 review, first round,
-        verified against both manuals). Matched EXACTLY against
-        ``commands/scope.py: _SCOPE_SPAN_PRESETS_HZ`` via the shared
+        verified against both manuals). Matched EXACTLY against this
+        profile's declared ``scope_span_presets_hz`` (``rigs/*.toml``:
+        ``[scope].span_presets_hz``, MOR-2258) via the shared
         ``_span_index_for_hz`` helper — the same lookup
-        ``parse_scope_span_response`` (the 0x15 reply path) uses, so the
-        stream and a typed-getter reply always agree on what index a
-        given Hz value maps to (MOR-2256). No match -> publish nothing,
-        and do not clear whatever the field last held: a non-matching
-        width is either drift outside the eight documented presets or an
-        unexpected source, not something to overwrite a confirmed value
-        with a guess.
+        ``parse_scope_span_response`` (the 0x15 reply path) uses against
+        the module-level ``_SCOPE_SPAN_PRESETS_HZ`` constant as of
+        MOR-2258 (a follow-up threads that path onto this same
+        profile-declared list too), so the stream and a typed-getter
+        reply agree on what index a given Hz value maps to. No match ->
+        publish nothing, and do not clear whatever the field last held:
+        a non-matching span is either drift outside the declared presets
+        or an unexpected source, not something to overwrite a confirmed
+        value with a guess. A profile with no declared presets (empty
+        tuple) never matches, so this is a silent no-op for any rig that
+        hasn't declared ``[scope].span_presets_hz``.
 
         Fixed mode (``scope_frame.mode != 0``) publishes nothing: unlike
         span, there is no declared table of legal (start_hz, end_hz) pairs
@@ -3382,10 +3387,7 @@ class CivRuntime:
         *band*, not to a specific stored (range, edge) preset, and a
         preset's actual edges are radio-side user-configured memory, not
         enumerable data. Publishing here would mean guessing which preset
-        is active, which MOR-2256 rules out. Moving the span table into
-        per-profile data (rather than reusing the existing hardcoded
-        ``commands/scope.py`` constant) is tracked separately as
-        MOR-2258.
+        is active, which MOR-2256 rules out.
 
         Same generation-binding and cache-after-ACCEPTED-apply ordering
         as ``_publish_scope_mode_observation`` above — see its docstring.
@@ -3396,7 +3398,8 @@ class CivRuntime:
         if width_hz % 2 != 0:
             return
         span_hz = width_hz // 2
-        span = _span_index_for_hz(span_hz)
+        presets = self._host._profile.scope_span_presets_hz
+        span = _span_index_for_hz(span_hz, presets)
         if span is None:
             return
         last_spans = self._host._scope_stream_last_span

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1902,6 +1902,83 @@ class TestCodecPreference:
             load_rig(p)
 
 
+# ── [scope].span_presets_hz (MOR-2258) ──────────────────────────
+
+
+_SHIPPED_SCOPE_RIGS = ("ic7300.toml", "ic705.toml", "ic9700.toml", "ic7610.toml")
+_EXPECTED_SPAN_PRESETS_HZ = (
+    2500,
+    5000,
+    10000,
+    25000,
+    50000,
+    100000,
+    250000,
+    500000,
+)
+
+
+class TestScopeSpanPresets:
+    """[scope].span_presets_hz parsing, validation, and shipped-profile parity.
+
+    MOR-2258: the waveform-stream span derivation
+    (``runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation``)
+    reads ``RadioProfile.scope_span_presets_hz`` -- this is the field's
+    only production reader in this change; the 0x15 reply-path decoder/
+    encoder (``commands/scope.py: parse_scope_span_response``/
+    ``scope_set_span``) still use the hardcoded ``_SCOPE_SPAN_PRESETS_HZ``
+    module constant, unchanged (a follow-up threads them onto this field
+    too and removes the constant).
+    """
+
+    def test_defaults_to_empty_tuple_when_undeclared(self, tmp_path):
+        p = _write_toml(tmp_path, _MINIMAL_TOML)
+        rig = load_rig(p)
+        assert rig.scope_span_presets_hz == ()
+        assert rig.to_profile().scope_span_presets_hz == ()
+
+    def test_parses_declared_presets(self, tmp_path):
+        toml = _MINIMAL_TOML + "\n[scope]\nspan_presets_hz = [2500, 5000, 10000]\n"
+        p = _write_toml(tmp_path, toml)
+        rig = load_rig(p)
+        assert rig.scope_span_presets_hz == (2500, 5000, 10000)
+        assert rig.to_profile().scope_span_presets_hz == (2500, 5000, 10000)
+
+    def test_rejects_empty_array(self, tmp_path):
+        toml = _MINIMAL_TOML + "\n[scope]\nspan_presets_hz = []\n"
+        p = _write_toml(tmp_path, toml)
+        with pytest.raises(
+            RigLoadError, match=r"\[scope\]\.span_presets_hz must be a non-empty"
+        ):
+            load_rig(p)
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            "[500000, 250000, 100000]",  # descending
+            "[2500, 2500, 5000]",  # duplicate (not strictly ascending)
+        ],
+    )
+    def test_rejects_non_ascending(self, tmp_path, declaration):
+        toml = _MINIMAL_TOML + f"\n[scope]\nspan_presets_hz = {declaration}\n"
+        p = _write_toml(tmp_path, toml)
+        with pytest.raises(
+            RigLoadError, match=r"\[scope\]\.span_presets_hz must be strictly ascending"
+        ):
+            load_rig(p)
+
+    @pytest.mark.parametrize("name", _SHIPPED_SCOPE_RIGS)
+    def test_shipped_scope_rig_declares_the_eight_icom_presets(self, name):
+        """Every shipped scope-capable profile declares the same eight
+        Icom CI-V span presets (span code 0-7 -> Hz) that
+        ``commands/scope.py: _SCOPE_SPAN_PRESETS_HZ`` hardcodes -- this is
+        the parity a follow-up PR relies on when it removes that constant
+        in favor of this field."""
+        rig = load_rig(RIGS_DIR / name)
+        assert rig.scope_span_presets_hz == _EXPECTED_SPAN_PRESETS_HZ
+        assert rig.to_profile().scope_span_presets_hz == _EXPECTED_SPAN_PRESETS_HZ
+
+
 class TestAudioPolicy:
     """Per-profile [audio] codec and sample-rate policy (#1470)."""
 


### PR DESCRIPTION
Linear: MOR-2258 (PR A of 2)

## What

`rigs/ic7300.toml`, `ic705.toml`, `ic9700.toml`, `ic7610.toml` declare `[scope].span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]`; `rigs/_schema.md` documents the key; `profiles/rig_loader.py` parses it into `RadioProfile.scope_span_presets_hz: tuple[int, ...]` (non-empty, strictly ascending; default `()`). The stream derivation (`runtime/_civ_rx.py`, from #3063) reads the profile's list and passes it to `commands/scope.py: _span_index_for_hz(hz, presets)` — the field has a production reader in this PR. `parse_scope_span_response` passes the module constant `_SCOPE_SPAN_PRESETS_HZ` explicitly (one changed line; behaviour identical over the reviewer's 906-input enumeration) and the SET encoder is untouched; PR B threads them onto the profile and deletes the constant.

## Why

Owner rule: everything radio-specific lives in the profile (MOR-2258; the owner: «Да, перенос нужен»). Today the only span table is a hardcoded constant in the command builders.

## Tests

`tests/test_rig_loader.py`: parse, default-empty, non-empty and strictly-ascending rejections, and a parity row per shipped scope profile against the constant's eight values. Mutations (reviewer re-run): drop the ascending check → red; drop the non-empty check → red; change one preset in `ic7300.toml` (25000 → 24000) → the parity row red; `presets = ()` in the derivation → 10 red. Note: replacing the profile read with the module constant leaves the suite green — today the two tables are equal, so only mutating the constant itself (which reddens the parity row) distinguishes them; the profile becomes the sole source in PR B.

## Size

10 files, +186 −22: at the file ceiling, not over. One unit because the field must land with its reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)