### PR TITLE
refactor: read the external rigctld poll intervals from the acquisition profile

### DIFF
--- a/src/rigplane/backends/rigctld_client/observations.py
+++ b/src/rigplane/backends/rigctld_client/observations.py
@@ -26,6 +26,7 @@ Clock = Callable[[], float]
 __all__ = [
     "RigctldClientObservationAdapter",
     "build_external_rigctld_acquisition_profile",
+    "resolve_external_rigctld_poll_intervals",
 ]
 
 _FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
@@ -178,6 +179,28 @@ def build_external_rigctld_acquisition_profile(
             _NR: _SLOW_CONTROL_POLICY,
         },
     )
+
+
+def resolve_external_rigctld_poll_intervals(
+    profile: RadioAcquisitionProfile,
+) -> tuple[float, float]:
+    """Return the (medium, slow) poll periods ``profile`` declares, in seconds."""
+    medium = _require_cadence(profile.default_policy, label="default policy")
+    # Witness path for the slow loop: ``_RF_GAIN`` and ``_AF_LEVEL`` hold the
+    # same policy but ``RigctldClientObservationAdapter.read_freq_mode_controls``
+    # also reads them on the medium loop, so their cadence does not describe the
+    # slow period. ``_PREAMP`` is read on a cadence only by ``read_slow_controls``.
+    slow = _require_cadence(profile.policy_for(_PREAMP), label=str(_PREAMP))
+    return medium, slow
+
+
+def _require_cadence(policy: AcquisitionPolicy, *, label: str) -> float:
+    cadence = policy.cadence_seconds
+    if cadence is None:
+        raise ValueError(
+            f"{label}: cadence_seconds is required to derive a poll period"
+        )
+    return cadence
 
 
 @dataclass(slots=True)

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -80,8 +80,8 @@ class RigctldClientObservationPoller:
         radio: "RigctldClientRadio",
         callback: Callable[[Sequence["Observation"]], None],
         *,
-        medium_interval: float = 2.0,
-        slow_interval: float = 30.0,
+        medium_interval: float,
+        slow_interval: float,
         command_queue: "CommandQueue | None" = None,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
@@ -670,10 +670,22 @@ class RigctldClientRadio:
         command_queue: "CommandQueue | None" = None,
     ) -> RigctldClientObservationPoller:
         """Construct a backend-neutral observation poller for Web startup."""
+        from .observations import (
+            build_external_rigctld_acquisition_profile,
+            resolve_external_rigctld_poll_intervals,
+        )
+
+        medium_interval, slow_interval = resolve_external_rigctld_poll_intervals(
+            build_external_rigctld_acquisition_profile(
+                vfo_supported=self._vfo_supported
+            )
+        )
         return RigctldClientObservationPoller(
             self,
             callback=callback,
             command_queue=command_queue,
+            medium_interval=medium_interval,
+            slow_interval=slow_interval,
         )
 
     async def get_freq(self, receiver: int = 0) -> int:

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -27,6 +28,7 @@ from rigplane.backends.rigctld_client.radio import RigctldClientObservationPolle
 from rigplane.backends.rigctld_client.observations import (
     RigctldClientObservationAdapter,
     build_external_rigctld_acquisition_profile,
+    resolve_external_rigctld_poll_intervals,
 )
 from rigplane.core.acquisition_scheduler import AcquisitionScheduler, AcquisitionStatus
 from rigplane.core.capabilities import CAP_POWER_CONTROL, CAP_TX
@@ -47,6 +49,11 @@ from rigplane.core.state_pipeline_contracts import (
 )
 from rigplane.core.state_store import FreshnessClock, StateStore
 from rigplane.exceptions import CommandError
+
+
+_MEDIUM_INTERVAL, _SLOW_INTERVAL = resolve_external_rigctld_poll_intervals(
+    build_external_rigctld_acquisition_profile(vfo_supported=True)
+)
 
 
 def _clock() -> float:
@@ -450,6 +457,8 @@ async def test_observation_poller_discards_expectation_when_readback_unavailable
                 callback=lambda _observations: None,
                 command_queue=queue,
                 clock=clock.now,
+                medium_interval=_MEDIUM_INTERVAL,
+                slow_interval=_SLOW_INTERVAL,
             )
 
             await poller._drain_commands()  # noqa: SLF001
@@ -655,6 +664,8 @@ async def test_observation_poller_correlates_slow_control_after_overlay_ttl_edge
                 callback=observations.extend,
                 command_queue=queue,
                 clock=lambda: clock.advance(0.01),
+                medium_interval=_MEDIUM_INTERVAL,
+                slow_interval=_SLOW_INTERVAL,
             )
 
             await poller._poll_medium()  # noqa: SLF001
@@ -1068,3 +1079,66 @@ async def test_ptt_and_slow_control_reads_cover_declared_rigctld_capabilities() 
             assert all(item.max_age == 120.0 for item in observations[1:])
         finally:
             await radio.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_rigctld_client_observation_poller_intervals_come_from_the_acquisition_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with FakeRigctldServer() as server:
+        radio = RigctldClientRadio(host=server.host, port=server.port)
+        await radio.connect()
+        try:
+            declared = build_external_rigctld_acquisition_profile(vfo_supported=True)
+            preamp = FieldPath.receiver("main", "operator_controls", "preamp")
+            # 3.5 and 41.0 replace the 2.0 and 30.0 this profile declares, so
+            # the assertion below fails if either loop period comes from
+            # anywhere but the profile.
+            retuned = replace(
+                declared,
+                default_policy=replace(declared.default_policy, cadence_seconds=3.5),
+                field_policies={
+                    path: (
+                        replace(policy, cadence_seconds=41.0)
+                        if path == preamp
+                        else policy
+                    )
+                    for path, policy in declared.field_policies.items()
+                },
+            )
+            monkeypatch.setattr(
+                "rigplane.backends.rigctld_client.observations"
+                ".build_external_rigctld_acquisition_profile",
+                lambda **_kwargs: retuned,
+            )
+            poller = radio.create_observation_poller(
+                callback=lambda _observations: None
+            )
+            started: list[tuple[str, float]] = []
+
+            def _record_loop(poll: object, interval: float) -> object:
+                started.append((getattr(poll, "__name__", repr(poll)), interval))
+                return asyncio.sleep(0)
+
+            monkeypatch.setattr(poller, "_run_loop", _record_loop)
+
+            await poller.start()
+            await poller.stop()
+
+            assert started == [
+                ("_poll_medium", retuned.default_policy.cadence_seconds),
+                ("_poll_slow", retuned.policy_for(preamp).cadence_seconds),
+            ]
+        finally:
+            await radio.disconnect()
+
+
+def test_external_rigctld_poll_intervals_reject_a_cadence_free_policy() -> None:
+    declared = build_external_rigctld_acquisition_profile(vfo_supported=True)
+    cadence_free = replace(
+        declared,
+        default_policy=replace(declared.default_policy, cadence_seconds=None),
+    )
+
+    with pytest.raises(ValueError, match="cadence_seconds is required"):
+        resolve_external_rigctld_poll_intervals(cadence_free)


### PR DESCRIPTION
`RigctldClientObservationPoller` carried its two loop periods as literal constructor defaults (`medium_interval: float = 2.0`, `slow_interval: float = 30.0`), duplicating the cadences that `observations.py: build_external_rigctld_acquisition_profile` already declares, with nothing keeping the two copies equal. `radio.py: RigctldClientRadio.create_observation_poller` — the sole production construction site — now builds that profile once and resolves both periods from it through the new `observations.py: resolve_external_rigctld_poll_intervals`. Wire behaviour is unchanged: same two loops, same 2.0 s / 30.0 s periods, same paths per loop, same observations in the same order.

Linear: MOR-2266

The slow period is read from the policy the profile assigns to `receiver.main.operator_controls.preamp`, not from `rf_gain`/`af_level`: those two carry the same slow policy but `observations.py: RigctldClientObservationAdapter.read_freq_mode_controls` also reads them on the medium loop, so their cadence does not describe the slow period.

## New test, red before the change

`tests/test_rigctld_client_observation_adapter.py: test_rigctld_client_observation_poller_intervals_come_from_the_acquisition_profile` monkeypatches the profile builder to declare 3.5 s / 41.0 s, then records what `start()` hands to `_run_loop`. Run against the tree with the resolver present but `create_observation_poller` unchanged:

```
>               assert started == [
                    ("_poll_medium", retuned.default_policy.cadence_seconds),
                    ("_poll_slow", retuned.policy_for(preamp).cadence_seconds),
                ]
E               AssertionError: assert [('_poll_medi..._slow', 30.0)] == [('_poll_medi..._slow', 41.0)]
E
E                 At index 0 diff: ('_poll_medium', 2.0) != ('_poll_medium', 3.5)
E                 Use -v to get more diff

tests/test_rigctld_client_observation_adapter.py:1118: AssertionError
=========================== short test summary info ============================
FAILED tests/test_rigctld_client_observation_adapter.py::test_rigctld_client_observation_poller_intervals_come_from_the_acquisition_profile
================== 1 failed, 1 passed, 28 deselected in 0.08s ==================
```

## Green after the change

```
$ uv run pytest tests/test_rigctld_client_observation_adapter.py -q --tb=short
collected 30 items

tests/test_rigctld_client_observation_adapter.py ....................... [ 76%]
.......                                                                  [100%]

============================== 30 passed in 0.37s ==============================
```

## Mutation check

Reinstated the exact removed bug — literal `= 2.0` / `= 30.0` defaults back on the constructor and the two keyword arguments dropped from `create_observation_poller` — and re-ran the file: `1 failed, 29 passed`, the one failure being the new test with the same `2.0 != 3.5` diff. The tree was restored from a pre-mutation copy of `radio.py` and `git diff` re-inspected before the final runs.

## Gates

```
$ uv run pytest tests/test_rigctld_client_observation_adapter.py -q --tb=short
30 passed in 0.37s

$ uv run pytest tests/tx_observation_fakes.py tests/test_rigctld_client_backend.py tests/test_mor2161_command_dispatch.py tests/test_profile_command_coverage.py tests/contracts/test_tx_observation_conformance.py -q --tb=short
232 passed in 37.36s

$ uv run pytest tests/test_security_headers.py tests/test_web_server_coverage.py tests/test_yaesu_cat_poller.py -q --tb=short
272 passed in 16.37s

$ uv run ruff check src/ tests/
All checks passed!

$ uv run ruff format src/ tests/
715 files left unchanged

$ uv run lint-imports
Contracts: 5 kept, 0 broken.

$ uv run mypy --strict src/rigplane/web
Success: no issues found in 26 source files

$ uv run mypy src/
Found 8 errors in 7 files (checked 303 source files)
```

The whole-tree `mypy src/` run is advisory and ungated; its 8 errors are all in files this change does not touch, and none are in `backends/rigctld_client/`. The full pytest suite was not run locally (laptop policy); CI quick covers it.

## Size

```
$ git diff --stat origin/main...HEAD
 .../backends/rigctld_client/observations.py        | 23 +++++++
 src/rigplane/backends/rigctld_client/radio.py      | 16 ++++-
 tests/test_rigctld_client_observation_adapter.py   | 74 ++++++++++++++++++++++
 3 files changed, 111 insertions(+), 2 deletions(-)
```

3 files, 113 changed lines.

## Type narrowing

`AcquisitionPolicy.cadence_seconds` is `float | None`. I did not add a fallback literal. `resolve_external_rigctld_poll_intervals` delegates to a private `_require_cadence` that raises `ValueError` when a policy declares no cadence, and `test_external_rigctld_poll_intervals_reject_a_cadence_free_policy` pins that raise against a profile built with `cadence_seconds=None` — deleting the raise fails that test. The raise cannot fire from today's single production call site, because the profile this package builds always pins both cadences; it exists because the function's parameter type admits a profile that does not, and it is the same shape as the existing `observations.py: RigctldClientObservationAdapter._require_radio`.

Two direct `RigctldClientObservationPoller(...)` constructions in the test file (the ones that inject a fake clock, which `create_observation_poller` does not accept) now pass module-level constants resolved from the same profile, so no test restates 2.0 or 30.0 either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
