### PR TITLE
refactor: the rig profile is the sole source of the scope span presets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+- **`rigplane.commands.parse_scope_span_response` and
+  `rigplane.commands.scope_set_span` require the span-preset table as an
+  argument (MOR-2258).** The module constant that held the eight Icom
+  CI-V span values (span code 0-7 -> Hz) inside
+  `src/rigplane/commands/scope.py` is deleted; the table now lives only in
+  `rigs/*.toml` (`[scope].span_presets_hz`) and reaches these two
+  functions as `RadioProfile.scope_span_presets_hz`, passed in by the
+  caller because `commands/` may not import `profiles/`
+  (`.importlinter`). `parse_scope_span_response` takes it as a second
+  positional parameter, `scope_set_span` as a required keyword-only
+  `presets=`; both raise `TypeError` if it is omitted. The legal span
+  index range is now `0..len(presets) - 1` rather than a fixed `0..7`.
+  Every caller in this repository (`runtime/_civ_rx.py: CivRuntime`,
+  `runtime/_scope_runtime.py: ScopeRuntimeMixin`) reads the resolved
+  profile and passes it; an external caller must do the same. At this
+  commit every shipped profile that declares `get_scope_span`
+  (`ic7300`, `ic705`, `ic7610`, `ic9700`) also declares
+  `[scope].span_presets_hz` with the same eight values, so no shipped
+  radio changes behaviour.
 - **The `rigctld` `RadioPoller` is deleted.** Removed: `rigplane.rigctld.poller`
   (the module, its `RadioPoller` class, `_mode_to_hamlib_str`,
   `_get_mode_reader`, and `_STATS_LOG_INTERVAL`) and its `## RadioPoller`

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -233,14 +233,14 @@ scope, where the radio supports one.
 | `ref_step_db`     | float   | no       | Scope reference level step size, dB.                       |
 | `span_presets_hz` | int[]   | no       | Scope span presets in Hz, index-ordered (index 0-7 matches the CI-V `0x27 0x15` span code the radio itself uses). Must be non-empty and strictly ascending. |
 
-`span_presets_hz` is what the waveform-stream span derivation
-(`runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation`,
-MOR-2256) resolves a frame's displayed width to a span index against. The
-0x15 reply-path decoder/encoder (`commands/scope.py:
-parse_scope_span_response`/`scope_set_span`) still use the hardcoded
-`_SCOPE_SPAN_PRESETS_HZ` constant as of this field's introduction — a
-follow-up threads them onto this same declared list and removes the
-constant, so there is exactly one source instead of two.
+`span_presets_hz` is the only place these values live. The
+waveform-stream span derivation (`runtime/_civ_rx.py:
+CivRuntime._publish_scope_span_observation`) resolves a frame's displayed
+width to a span index against it, and the 0x15 reply-path decoder/encoder
+(`commands/scope.py: parse_scope_span_response`/`scope_set_span`) take it
+as an argument — `commands/` may not import `profiles/`, so the runtime
+reads the resolved profile and passes the list in. A profile that omits
+this key therefore decodes and encodes no span at all.
 
 ## `[attenuator]` — Attenuator Steps
 

--- a/rigs/ic705.toml
+++ b/rigs/ic705.toml
@@ -34,12 +34,6 @@ browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 
 [scope]
-# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
-# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
-# 0x15 reply path/SET builder in this PR; a follow-up threads this field
-# through them and deletes the constant). Read directly by the
-# waveform-stream span derivation
-# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
 span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
 
 # ── Capabilities ─────────────────────────────────────────────────

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -31,12 +31,6 @@ data_len_max = 475
 codec_preference = ["PCM_1CH_16BIT", "ULAW_1CH"]
 
 [scope]
-# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
-# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
-# 0x15 reply path/SET builder in this PR; a follow-up threads this field
-# through them and deletes the constant). Read directly by the
-# waveform-stream span derivation
-# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
 span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
 
 # ── Capabilities ─────────────────────────────────────────────────

--- a/rigs/ic7610.toml
+++ b/rigs/ic7610.toml
@@ -40,12 +40,6 @@ data_len_max = 689
 ref_min_db = -30.0
 ref_max_db = 10.0
 ref_step_db = 0.5
-# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
-# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
-# 0x15 reply path/SET builder in this PR; a follow-up threads this field
-# through them and deletes the constant). Read directly by the
-# waveform-stream span derivation
-# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
 span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
 
 # ── Capabilities ─────────────────────────────────────────────────

--- a/rigs/ic9700.toml
+++ b/rigs/ic9700.toml
@@ -31,12 +31,6 @@ browser_rx_transport = "auto"
 browser_rx_transcode_to_opus = true
 
 [scope]
-# Icom CI-V scope span presets: code 0-7 -> Hz, same table as
-# commands/scope.py: _SCOPE_SPAN_PRESETS_HZ (still the source used by the
-# 0x15 reply path/SET builder in this PR; a follow-up threads this field
-# through them and deletes the constant). Read directly by the
-# waveform-stream span derivation
-# (runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation, MOR-2256).
 span_presets_hz = [2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000]
 
 # ── Capabilities ─────────────────────────────────────────────────

--- a/src/rigplane/commands/scope.py
+++ b/src/rigplane/commands/scope.py
@@ -78,16 +78,6 @@ if TYPE_CHECKING:
     from ..types import CivFrame
 
 
-_SCOPE_SPAN_PRESETS_HZ: tuple[int, ...] = (
-    2_500,
-    5_000,
-    10_000,
-    25_000,
-    50_000,
-    100_000,
-    250_000,
-    500_000,
-)
 _SCOPE_FIXED_EDGE_RANGE_STARTS_HZ: tuple[int, ...] = (
     50_000_000,
     28_000_000,
@@ -540,10 +530,22 @@ def scope_set_span(
     from_addr: int = CONTROLLER_ADDR,
     *,
     cmd_map: CommandMap,
+    presets: tuple[int, ...],
     receiver: int | None = None,
 ) -> bytes:
-    _validate_scope_range("scope span", span, 0, 7)
-    span_hz = _SCOPE_SPAN_PRESETS_HZ[span]
+    """Build the 0x27 0x15 SET frame for span-preset index *span*.
+
+    ``presets`` is the radio's declared span table
+    (``profiles.RadioProfile.scope_span_presets_hz``, from ``rigs/*.toml``
+    ``[scope].span_presets_hz``), supplied by the caller because
+    ``commands/`` may not import ``profiles/`` (``.importlinter``). It is
+    the only source of both the legal index range and the Hz value put on
+    the wire, so a profile that declares no presets rejects every index
+    through the same ``_validate_scope_range`` error every other
+    out-of-range span raises.
+    """
+    _validate_scope_range("scope span", span, 0, len(presets) - 1)
+    span_hz = presets[span]
     span_bcd = bcd_encode(span_hz)
     return _build_from_map(
         cmd_map,
@@ -972,13 +974,11 @@ def _span_index_for_hz(hz: int, presets: tuple[int, ...]) -> int | None:
     reply-path decoder -- and the waveform-stream span derivation
     (``runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation``,
     MOR-2256). ``presets`` is caller-supplied rather than a module
-    constant: MOR-2258 declares the eight Icom CI-V span values as
+    constant: the span table is
     ``profiles.RadioProfile.scope_span_presets_hz`` (``rigs/*.toml``:
-    ``[scope].span_presets_hz``), which the stream derivation now reads
-    and passes here. ``parse_scope_span_response`` below still passes the
-    module-level ``_SCOPE_SPAN_PRESETS_HZ`` explicitly as of this change
-    (a follow-up threads it onto the profile-declared list too and
-    removes the constant, leaving exactly one source instead of two).
+    ``[scope].span_presets_hz``), and ``commands/`` may not import
+    ``profiles/`` (``.importlinter``), so every caller reads it off the
+    resolved profile and passes it in.
 
     Returns ``None`` on no exact match -- callers decide whether that is
     an error (the reply path still raises, unchanged) or a silent no-op
@@ -1006,14 +1006,30 @@ def _span_index_for_hz(hz: int, presets: tuple[int, ...]) -> int | None:
 
 
 def parse_scope_span_response(
-    frame: CivFrame, *, command: int = _CMD_SCOPE, sub: int = _SUB_SCOPE_SPAN
+    frame: CivFrame,
+    presets: tuple[int, ...],
+    *,
+    command: int = _CMD_SCOPE,
+    sub: int = _SUB_SCOPE_SPAN,
 ) -> tuple[int | None, int]:
+    """Decode a 0x27 0x15 span reply into ``(receiver, span index)``.
+
+    ``presets`` is the radio's declared span table -- see
+    ``scope_set_span`` above for why it is a parameter and not a module
+    constant. Both reply shapes are bounded by it: the one-byte form is
+    already an index and is range-checked against ``len(presets)``, and
+    the five-byte BCD form is matched exactly against the table by
+    ``_span_index_for_hz``. No match raises ``ValueError``, unchanged --
+    a profile that declares no presets therefore decodes no span at all.
+    """
     data = _parse_scope_frame(frame, sub, command=command)
     receiver, payload = _split_scope_receiver_prefix(data, expected_lengths=(1, 5))
     if len(payload) == 1:
-        return receiver, _validate_scope_range("scope span", payload[0], 0, 7)
+        return receiver, _validate_scope_range(
+            "scope span", payload[0], 0, len(presets) - 1
+        )
     hz = bcd_decode(payload)
-    span = _span_index_for_hz(hz, _SCOPE_SPAN_PRESETS_HZ)
+    span = _span_index_for_hz(hz, presets)
     if span is None:
         raise ValueError(f"Unknown scope span frequency {hz}")
     return receiver, span

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -412,11 +412,12 @@ class RadioProfile:
     scope_ref_max_db: float | None = None
     scope_ref_step_db: float | None = None
     # MOR-2258: scope span presets (Hz), index-ordered to match the CI-V
-    # 0x27/0x15 span code. Single source for the waveform-stream span
-    # derivation (runtime/_civ_rx.py:
-    # CivRuntime._publish_scope_span_observation, MOR-2256); a follow-up
-    # threads it through commands/scope.py: parse_scope_span_response /
-    # scope_set_span too and removes their hardcoded constant.
+    # 0x27/0x15 span code. Sole source of the Hz<->index mapping: read by
+    # the waveform-stream span derivation (runtime/_civ_rx.py:
+    # CivRuntime._publish_scope_span_observation) and passed into
+    # commands/scope.py: parse_scope_span_response / scope_set_span,
+    # which take it as a parameter because commands/ may not import
+    # profiles/ (.importlinter).
     scope_span_presets_hz: tuple[int, ...] = ()
     # Per-profile RX codec preference override (#797). When non-None, the first
     # entry is used as the initial ``audio_codec`` for radios created under this

--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -2582,7 +2582,9 @@ class CivRuntime:
             receiver, mode = parse_scope_mode_response(frame)
             pairs.append(("mode", mode))
         elif frame.sub == 0x15:
-            receiver, span = parse_scope_span_response(frame)
+            receiver, span = parse_scope_span_response(
+                frame, self._host._profile.scope_span_presets_hz
+            )
             pairs.append(("span", span))
         elif frame.sub == 0x16:
             receiver, edge = parse_scope_edge_response(frame)
@@ -3170,7 +3172,9 @@ class CivRuntime:
                 scope.receiver = receiver
             scope.mode = mode
         elif frame.sub == 0x15:
-            receiver, span = parse_scope_span_response(frame)
+            receiver, span = parse_scope_span_response(
+                frame, self._host._profile.scope_span_presets_hz
+            )
             if receiver is not None:
                 scope.receiver = receiver
             scope.span = span
@@ -3369,9 +3373,7 @@ class CivRuntime:
         ``[scope].span_presets_hz``, MOR-2258) via the shared
         ``_span_index_for_hz`` helper — the same lookup
         ``parse_scope_span_response`` (the 0x15 reply path) uses against
-        the module-level ``_SCOPE_SPAN_PRESETS_HZ`` constant as of
-        MOR-2258 (a follow-up threads that path onto this same
-        profile-declared list too), so the stream and a typed-getter
+        the same profile-declared list, so the stream and a typed-getter
         reply agree on what index a given Hz value maps to. No match ->
         publish nothing, and do not clear whatever the field last held:
         a non-matching span is either drift outside the declared presets

--- a/src/rigplane/runtime/_scope_runtime.py
+++ b/src/rigplane/runtime/_scope_runtime.py
@@ -295,7 +295,12 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
             label="get_scope_span",
         )
         command, sub, _ = self._expect_shape(get_scope_span)
-        rx_hint, span = parse_scope_span_response(resp, command=command, sub=sub)
+        rx_hint, span = parse_scope_span_response(
+            resp,
+            self._profile.scope_span_presets_hz,
+            command=command,
+            sub=sub,
+        )
         self._apply_scope_receiver_hint(rx_hint)
         self._scope_controls().span = span
         return span
@@ -306,7 +311,10 @@ class ScopeRuntimeMixin(_MixinBase):  # type: ignore[misc]
         receiver = self._scope_controls().receiver
         await self._send_civ_raw(
             self._commands.scope_set_span(
-                span, to_addr=self._radio_addr, receiver=receiver
+                span,
+                to_addr=self._radio_addr,
+                presets=self._profile.scope_span_presets_hz,
+                receiver=receiver,
             ),
             wait_response=False,
         )

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -49,7 +49,6 @@ from rigplane.commands import (
     parse_civ_frame,
     parse_scope_span_response,
 )
-from rigplane.commands.scope import _SCOPE_SPAN_PRESETS_HZ
 from rigplane.commands.tone import _encode_tone_freq
 from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
@@ -82,6 +81,14 @@ from rigplane.web.radio_poller import CommandQueue, RadioPoller
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+# The eight Icom CI-V scope span presets the ``radio`` fixture's IC-7610
+# profile declares (``rigs/ic7610.toml``: ``[scope].span_presets_hz``).
+# ``test_span_presets_match_the_fixture_profile`` below is what ties this
+# literal to that profile, so a profile edit cannot silently leave these
+# parametrisations testing a table no radio uses.
+_SPAN_PRESETS_HZ = (2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000)
 
 
 @pytest.fixture  # type: ignore[untyped-decorator]
@@ -4018,7 +4025,7 @@ async def test_scope_waveform_fixed_mode_emits_no_span_edge_or_fixed_edge(
     assert "scope_controls.global.display.fixed_edge" not in applied_paths
 
 
-@pytest.mark.parametrize("preset_index", range(len(_SCOPE_SPAN_PRESETS_HZ)))
+@pytest.mark.parametrize("preset_index", range(len(_SPAN_PRESETS_HZ)))
 async def test_scope_waveform_center_mode_span_matches_reply_path_parity(
     radio: IcomRadio, preset_index: int
 ) -> None:
@@ -4033,13 +4040,15 @@ async def test_scope_waveform_center_mode_span_matches_reply_path_parity(
     span table encodes), not half of it -- so ``end_hz`` below is a real
     preset value, not an invented half-span. Both this stream path and
     the reply path resolve through the same ``_span_index_for_hz``
-    helper against ``_SCOPE_SPAN_PRESETS_HZ``, so parity here also
-    guards against the two drifting apart in the future.
+    helper against the profile's declared ``scope_span_presets_hz``, so
+    parity here also guards against the two drifting apart in the future.
     """
-    preset_hz = _SCOPE_SPAN_PRESETS_HZ[preset_index]
+    preset_hz = _SPAN_PRESETS_HZ[preset_index]
 
     reply_frame = _make_frame(cmd=0x27, sub=0x15, data=b"\x00" + bcd_encode(preset_hz))
-    _receiver, expected_index = parse_scope_span_response(reply_frame)
+    _receiver, expected_index = parse_scope_span_response(
+        reply_frame, radio._profile.scope_span_presets_hz
+    )
     assert expected_index == preset_index  # sanity: table order is the index
 
     with _spy_state_store_apply(radio) as apply_spy:
@@ -4061,12 +4070,20 @@ async def test_scope_waveform_center_mode_span_matches_reply_path_parity(
     assert field.freshness is FreshnessState.FRESH
 
 
+def test_span_presets_match_the_fixture_profile(radio: IcomRadio) -> None:
+    """``_SPAN_PRESETS_HZ`` above -- which parametrises the
+    parity test and annotates the expected indices below -- is the table
+    the ``radio`` fixture's own profile declares, not a second copy that
+    could drift from ``rigs/ic7610.toml``."""
+    assert radio._profile.scope_span_presets_hz == _SPAN_PRESETS_HZ
+
+
 async def test_scope_waveform_center_mode_unknown_width_emits_no_span(
     radio: IcomRadio,
 ) -> None:
     """MOR-2256: a center-mode frame whose (correctly-decoded) span has
-    no exact match in ``_SCOPE_SPAN_PRESETS_HZ`` publishes nothing — not
-    a nearest-value guess. 999 Hz is not one of the eight declared
+    no exact match in the profile's ``scope_span_presets_hz`` publishes
+    nothing — not a nearest-value guess. 999 Hz is not one of the eight declared
     presets (2500/5000/10000/25000/50000/100000/250000/500000); ``end_hz``
     here is the raw span field itself (see the parity test above for the
     encoding), so no doubling/halving is involved in choosing this value."""
@@ -4147,10 +4164,10 @@ async def test_scope_waveform_out_of_range_center_frame_emits_no_span(
     set, so ``ScopeFrame.start_freq_hz``/``end_freq_hz`` are then the
     raw, unexpanded ``[center, span]`` pair, not real edges. The
     verifier's example: center 450 kHz, span 500 kHz (matching
-    ``_SCOPE_SPAN_PRESETS_HZ[7]``), OOR set -- computing
+    the largest declared preset), OOR set -- computing
     ``end_freq_hz - start_freq_hz`` as if these were edges gives
     ``500_000 - 450_000 == 50_000``, halved to 25_000, which wrongly
-    matches index 3 (``_SCOPE_SPAN_PRESETS_HZ[3] == 25_000``) instead of
+    matches index 3 (the fourth declared preset is 25_000 Hz) instead of
     publishing nothing."""
     with _spy_state_store_apply(radio) as apply_spy:
         frame = _make_scope_waveform_frame(
@@ -4176,7 +4193,7 @@ async def test_scope_waveform_span_observation_survives_connect_generation(
     await radio._civ_runtime._route_civ_frame(frame, generation=radio._civ_epoch)
 
     field = radio._state_store.snapshot().field("scope_controls.global.display.span")
-    assert field.value == 1  # _SCOPE_SPAN_PRESETS_HZ.index(5000)
+    assert field.value == 1  # _SPAN_PRESETS_HZ.index(5000)
     assert field.freshness is FreshnessState.FRESH
 
 
@@ -4222,7 +4239,7 @@ async def test_scope_waveform_span_rejected_apply_retries_on_next_frame(
     await radio._civ_runtime._route_civ_frame(second, generation=radio._civ_epoch)
 
     field = radio._state_store.snapshot().field("scope_controls.global.display.span")
-    assert field.value == 2  # _SCOPE_SPAN_PRESETS_HZ.index(10000)
+    assert field.value == 2  # _SPAN_PRESETS_HZ.index(10000)
     assert field.freshness is FreshnessState.FRESH
 
 

--- a/tests/test_command_map_parity.py
+++ b/tests/test_command_map_parity.py
@@ -278,14 +278,13 @@ def _hardcode_only_builders() -> frozenset[Key]:
     return frozenset(found)
 
 
-def _values_for(fn: typing.Any, param: inspect.Parameter) -> tuple[typing.Any, ...]:
-    """Probe values for *param*, derived from its annotation alone."""
-    try:
-        annotation = eval(param.annotation, fn.__globals__)  # noqa: S307
-    except Exception:
-        return ()
-    args = typing.get_args(annotation)
-    types = list(args) if args else [annotation]
+def _scalar_values_for(types: list[typing.Any]) -> tuple[typing.Any, ...]:
+    """Probe values for a parameter whose annotation resolved to *types*.
+
+    Split out of :func:`_values_for` so the tuple branch there can reuse
+    the same ladders for a tuple's ELEMENT type instead of a second,
+    independent copy that could disagree with this one.
+    """
     members = [
         member
         for candidate in types
@@ -303,6 +302,33 @@ def _values_for(fn: typing.Any, param: inspect.Parameter) -> tuple[typing.Any, .
     if int in types:
         return _INTS + _FREQS
     return ()
+
+
+def _values_for(fn: typing.Any, param: inspect.Parameter) -> tuple[typing.Any, ...]:
+    """Probe values for *param*, derived from its annotation alone."""
+    try:
+        annotation = eval(param.annotation, fn.__globals__)  # noqa: S307
+    except Exception:
+        return ()
+    if typing.get_origin(annotation) is tuple:
+        # A tuple parameter wants a SEQUENCE of its element type, not one
+        # element. Without this branch ``get_args`` flattens
+        # ``tuple[int, ...]`` into ``[int, Ellipsis]`` and the scalar
+        # ladder below hands the builder a bare ``0``, which every use of
+        # the parameter as a sequence rejects -- the builder then reports
+        # as unsynthesisable for a reason that is about this file, not
+        # about the builder. Longest candidate first, so a builder that
+        # indexes into the sequence with one of its OTHER synthesised
+        # arguments has room for the index values in ``_INTS``.
+        elements = _scalar_values_for(
+            [arg for arg in typing.get_args(annotation) if arg is not Ellipsis]
+        )
+        if not elements:
+            return ()
+        return (elements, elements[:2], elements[:1])
+    args = typing.get_args(annotation)
+    types = list(args) if args else [annotation]
+    return _scalar_values_for(types)
 
 
 def _requires_cmd_map(fn: typing.Any) -> bool:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -44,6 +44,15 @@ from _command_test_helpers import bind_default_addr_globals, bind_default_addr_m
 
 RIG_DIR = Path(__file__).resolve().parents[1] / "rigs"
 
+# The eight Icom CI-V scope span presets (span code 0-7 -> Hz), copied
+# verbatim from the module constant `commands/scope.py` held at c23d8cbd
+# -- the commit before this change deleted it. Written out here rather
+# than imported so these tests pin the decoded/encoded values against a
+# table this file owns, independent of whatever any profile happens to
+# declare -- ``TestScopeSpanPresets`` in ``test_rig_loader.py`` is what
+# asserts the shipped profiles still declare exactly these.
+_SPAN_PRESETS_HZ = (2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000)
+
 _ORIGINAL_COMMANDS = {
     name: getattr(raw_commands, name) for name in raw_commands.__all__
 }
@@ -1520,7 +1529,7 @@ class TestAdvancedScopeParsers:
         from rigplane.types import bcd_encode
 
         frame = CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x00" + bcd_encode(250_000))
-        receiver, span = parse_scope_span_response(frame)
+        receiver, span = parse_scope_span_response(frame, _SPAN_PRESETS_HZ)
         assert receiver == 0
         assert span == 6
 
@@ -1587,7 +1596,7 @@ class TestAdvancedScopeParsers:
         from rigplane.commands import parse_scope_span_response
 
         frame = CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x05")
-        receiver, span = parse_scope_span_response(frame)
+        receiver, span = parse_scope_span_response(frame, _SPAN_PRESETS_HZ)
         assert receiver is None
         assert span == 5
 
@@ -1707,7 +1716,7 @@ class TestAdvancedScopeValidation:
         from rigplane.commands import scope_set_span
 
         with pytest.raises(ValueError, match="scope span must be 0-7"):
-            scope_set_span(-1, cmd_map=cmd_map)
+            scope_set_span(-1, cmd_map=cmd_map, presets=_SPAN_PRESETS_HZ)
 
     def test_scope_set_edge_rejects_zero(self, cmd_map) -> None:
         from rigplane.commands import scope_set_edge
@@ -3062,3 +3071,136 @@ class TestFallbackAuditRemoved:
         text = layer_md.read_text()
         assert "_fallback_audit" not in text
         assert "Charter exception: Step 1 measurement hook" not in text
+
+
+class TestScopeSpanPresetsAreCallerSupplied:
+    """The span table reaches `commands/scope.py` as an argument, not as a
+    module constant.
+
+    ``commands/`` may not import ``profiles/`` (``.importlinter``), so
+    ``parse_scope_span_response`` and ``scope_set_span`` take the presets
+    as a parameter and every caller reads
+    ``RadioProfile.scope_span_presets_hz`` off the resolved profile.
+    """
+
+    @pytest.fixture()
+    def cmd_map(self):
+        return load_rig(RIG_DIR / "ic7610.toml").to_command_map()
+
+    @pytest.mark.parametrize("index", range(len(_SPAN_PRESETS_HZ)))
+    def test_decode_and_encode_match_the_pre_change_outputs(
+        self, cmd_map, index: int
+    ) -> None:
+        """Every preset decodes to its index and encodes back to its BCD
+        payload, matching the outputs recorded at c23d8cbd (the commit
+        before the constant was deleted) by calling the then-current
+        ``parse_scope_span_response``/``scope_set_span`` over all eight
+        presets. The eight ``encode=`` frames recorded there are the eight
+        ``expected_frame`` values below."""
+        from rigplane.commands import parse_scope_span_response, scope_set_span
+        from rigplane.types import bcd_encode
+
+        hz = _SPAN_PRESETS_HZ[index]
+
+        reply = CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x00" + bcd_encode(hz))
+        assert parse_scope_span_response(reply, _SPAN_PRESETS_HZ) == (0, index)
+
+        # to_addr is bound to IC_7610_ADDR module-wide by
+        # bind_default_addr_module above, matching the recorded frames.
+        expected_frame = bytes.fromhex("fefe98e02715") + bcd_encode(hz) + b"\xfd"
+        assert (
+            scope_set_span(index, cmd_map=cmd_map, presets=_SPAN_PRESETS_HZ)
+            == expected_frame
+        )
+
+    @pytest.mark.parametrize("preset_hz", _SPAN_PRESETS_HZ)
+    @pytest.mark.parametrize("offset", ["minus1", "plus1", "half", "double"])
+    def test_near_miss_widths_decode_exactly_as_before(
+        self, preset_hz: int, offset: str
+    ) -> None:
+        """Each preset +/-1 Hz, halved and doubled: an exact table member
+        decodes to its own index (the table is roughly 2x-spaced, so some
+        halves and doubles ARE other presets), and anything else raises.
+        Both branches were recorded at c23d8cbd over these same 32 inputs
+        and are reproduced here."""
+        from rigplane.commands import parse_scope_span_response
+        from rigplane.types import bcd_encode
+
+        value = {
+            "minus1": preset_hz - 1,
+            "plus1": preset_hz + 1,
+            "half": preset_hz // 2,
+            "double": preset_hz * 2,
+        }[offset]
+        frame = CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x00" + bcd_encode(value))
+
+        if value in _SPAN_PRESETS_HZ:
+            assert parse_scope_span_response(frame, _SPAN_PRESETS_HZ) == (
+                0,
+                _SPAN_PRESETS_HZ.index(value),
+            )
+        else:
+            with pytest.raises(
+                ValueError, match=f"Unknown scope span frequency {value}"
+            ):
+                parse_scope_span_response(frame, _SPAN_PRESETS_HZ)
+
+    def test_a_different_preset_table_moves_the_decoded_index(self) -> None:
+        """The presets argument -- not any table inside `commands/scope.py`
+        -- decides the index. 25000 Hz is index 3 in the shipped table and
+        index 1 in this one; the SET encoder follows the same table."""
+        from rigplane.commands import parse_scope_span_response
+        from rigplane.types import bcd_encode
+
+        other = (10_000, 25_000, 100_000)
+        frame = CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x00" + bcd_encode(25_000))
+
+        assert parse_scope_span_response(frame, _SPAN_PRESETS_HZ) == (0, 3)
+        assert parse_scope_span_response(frame, other) == (0, 1)
+
+    def test_a_different_preset_table_moves_the_encoded_payload(self, cmd_map) -> None:
+        from rigplane.commands import scope_set_span
+        from rigplane.types import bcd_encode
+
+        other = (10_000, 25_000, 100_000)
+        frame = scope_set_span(1, cmd_map=cmd_map, presets=other)
+        assert frame[6:11] == bcd_encode(25_000)
+
+    def test_a_shorter_table_bounds_both_directions(self, cmd_map) -> None:
+        """The legal index range comes from the table's length, in the
+        one-byte reply branch as well as in the SET encoder."""
+        from rigplane.commands import parse_scope_span_response, scope_set_span
+
+        other = (10_000, 25_000, 100_000)
+        with pytest.raises(ValueError, match="scope span must be 0-2"):
+            scope_set_span(3, cmd_map=cmd_map, presets=other)
+        with pytest.raises(ValueError, match="scope span must be 0-2"):
+            parse_scope_span_response(CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x03"), other)
+
+    def test_a_profile_declaring_no_presets_decodes_and_encodes_nothing(
+        self, cmd_map
+    ) -> None:
+        """``RadioProfile.scope_span_presets_hz`` defaults to ``()``. Both
+        directions then refuse through the errors they already raised --
+        the BCD branch's "Unknown scope span frequency" and
+        ``_validate_scope_range``'s message -- rather than a new sentinel.
+        No shipped profile is in this state: at this commit the four rigs
+        declaring ``get_scope_span`` (ic7300, ic705, ic7610, ic9700) are
+        exactly the four declaring ``[scope].span_presets_hz``.
+        ``test_rig_loader.py: TestScopeSpanPresets`` pins the values those
+        four declare, not that correspondence."""
+        from rigplane.commands import parse_scope_span_response, scope_set_span
+        from rigplane.types import bcd_encode
+
+        frame = CivFrame(0xE0, 0x98, 0x27, 0x15, b"\x00" + bcd_encode(25_000))
+        with pytest.raises(ValueError, match="Unknown scope span frequency 25000"):
+            parse_scope_span_response(frame, ())
+        with pytest.raises(ValueError, match="scope span must be 0--1"):
+            scope_set_span(0, cmd_map=cmd_map, presets=())
+
+    def test_shipped_ic7610_profile_supplies_the_same_table(self) -> None:
+        """The presets the production caller passes are the ones these
+        tests pin: `runtime/_scope_runtime.py: ScopeRuntimeMixin` reads
+        ``self._profile.scope_span_presets_hz``."""
+        rig = load_rig(RIG_DIR / "ic7610.toml")
+        assert rig.to_profile().scope_span_presets_hz == _SPAN_PRESETS_HZ

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1921,14 +1921,13 @@ _EXPECTED_SPAN_PRESETS_HZ = (
 class TestScopeSpanPresets:
     """[scope].span_presets_hz parsing, validation, and shipped-profile parity.
 
-    MOR-2258: the waveform-stream span derivation
-    (``runtime/_civ_rx.py: CivRuntime._publish_scope_span_observation``)
-    reads ``RadioProfile.scope_span_presets_hz`` -- this is the field's
-    only production reader in this change; the 0x15 reply-path decoder/
-    encoder (``commands/scope.py: parse_scope_span_response``/
-    ``scope_set_span``) still use the hardcoded ``_SCOPE_SPAN_PRESETS_HZ``
-    module constant, unchanged (a follow-up threads them onto this field
-    too and removes the constant).
+    MOR-2258: ``RadioProfile.scope_span_presets_hz`` is the sole source of
+    the Hz<->span-index mapping. It is read by the waveform-stream span
+    derivation (``runtime/_civ_rx.py:
+    CivRuntime._publish_scope_span_observation``) and passed into the 0x15
+    reply-path decoder/encoder (``commands/scope.py:
+    parse_scope_span_response``/``scope_set_span``), which take it as a
+    parameter because ``commands/`` may not import ``profiles/``.
     """
 
     def test_defaults_to_empty_tuple_when_undeclared(self, tmp_path):
@@ -1970,10 +1969,7 @@ class TestScopeSpanPresets:
     @pytest.mark.parametrize("name", _SHIPPED_SCOPE_RIGS)
     def test_shipped_scope_rig_declares_the_eight_icom_presets(self, name):
         """Every shipped scope-capable profile declares the same eight
-        Icom CI-V span presets (span code 0-7 -> Hz) that
-        ``commands/scope.py: _SCOPE_SPAN_PRESETS_HZ`` hardcodes -- this is
-        the parity a follow-up PR relies on when it removes that constant
-        in favor of this field."""
+        Icom CI-V span presets (span code 0-7 -> Hz)."""
         rig = load_rig(RIGS_DIR / name)
         assert rig.scope_span_presets_hz == _EXPECTED_SPAN_PRESETS_HZ
         assert rig.to_profile().scope_span_presets_hz == _EXPECTED_SPAN_PRESETS_HZ

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -789,7 +789,8 @@ class TestScopeCommandBuilders:
         assert frame[6] == 0x02
 
     def test_scope_set_span(self, cmd_map) -> None:
-        frame = scope_set_span(3, cmd_map=cmd_map)  # index 3 = 25000 Hz
+        presets = load_rig(RIG_DIR / "ic7610.toml").scope_span_presets_hz
+        frame = scope_set_span(3, cmd_map=cmd_map, presets=presets)  # 25000 Hz
         assert frame[4] == 0x27
         assert frame[5] == 0x15
         # BCD-encoded 25000 Hz (little-endian): 00 50 02 00 00


### PR DESCRIPTION
Coordinator-granted hard-ceiling exception under the owner's delegation of 2026-09-03 (CLAUDE.md Guardrails): 15 code + 0 regenerated baselines = 15 files (11 Python/test/doc files and the four rig profiles whose comment named the deleted constant), one change — deleting the constant falsified the identical six-line comment in the four scope profiles, which is deleted with it.

Linear: MOR-2258 (PR B of 2; PR A was #3069, merged c23d8cbd)

## What

`_SCOPE_SPAN_PRESETS_HZ` is deleted from `commands/scope.py`. `parse_scope_span_response(frame, presets, *, command, sub)` and `scope_set_span(span, to_addr, ..., *, cmd_map, presets, receiver)` take the table from their callers: `runtime/_civ_rx.py` (both decode sites: `_scope_control_observations` and `_handle_27` sub 0x15) and `runtime/_scope_runtime.py` (`get_scope_span` / `set_scope_span`) pass `profile.scope_span_presets_hz`; `commands/` still imports nothing from `profiles/` (`lint-imports` 5 kept / 0 broken). The legal span index range is now `0..len(presets)-1` in both directions instead of the literal `0..7` (the one place the spec was widened: leaving `7` would have kept a second silent copy of "there are eight presets"). `rigs/_schema.md`, `profiles/__init__.py` and the four profiles lose the prose the deletion falsified. Changelog row under breaking changes: both names are in `rigplane.commands.__all__`, `scope_set_span` also on the top-level namespace.

## Tests

`tests/test_commands.py` `TestScopeSpanPresetsAreCallerSupplied`: 8 decode/encode parity cases against outcomes recorded at c23d8cbd, 32 near-miss inputs (±1, half, double: 10 land on a neighbouring preset, 22 raise), a profile whose presets differ moves the decoded index, a shorter table, an empty table (decodes and encodes nothing). `tests/test_civ_rx_coverage.py`, `tests/test_scope.py`, `tests/test_rig_loader.py` updated to pass presets / drop the constant's name. Mutations (run, restored): a hardcoded 8-value table inside the parser ignoring `presets` → 2 red incl. the profile-differs test; `presets` defaulted and dropped at `get_scope_span` → `tests/test_radio.py::TestAdvancedScopeControls::test_get_scope_variants_update_radio_state[get_scope_span-…]` red (mypy cannot see it; `runtime/` is not a strict gate); a load-valid alteration of two `ic7300.toml` presets → PR A's parity row red (a plain swap is rejected earlier by the ascending check).

`git grep -n "_SCOPE_SPAN_PRESETS_HZ"` over the whole tree is empty.

## Size

15 files, +305 −101 (exception above; the 15th is tests/test_command_map_parity.py: the command-binding drift guard synthesises builder arguments from annotations and offered a bare int for a tuple-typed parameter, so it reported scope_set_span as unsynthesisable — it now builds candidate tuples from the element type; a builder with an unsynthesisable argument still fails loudly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
