### PR TITLE
feat(stage): floor the fixed-native scale and scroll only while the floor holds

### DIFF
--- a/frontend/fixtures/main.ts
+++ b/frontend/fixtures/main.ts
@@ -194,7 +194,13 @@ const target = document.getElementById('app')!;
 // call shared with two components that take none.
 if (fixture.layout === 'peer-split') {
   mount(PeerSplitLayout, {
-    target, context, props: { canvasW: peerSplitGlassGroup.canvas.w, canvasH: peerSplitGlassGroup.canvas.h },
+    target,
+    context,
+    props: {
+      canvasW: peerSplitGlassGroup.canvas.w,
+      canvasH: peerSplitGlassGroup.canvas.h,
+      minScale: peerSplitGlassGroup.scaling.minScale,
+    },
   });
 } else {
   mount(fixture.layout === 'reference' ? ReferenceLayout : DualReceiverCockpit, { target, context });

--- a/frontend/src/components-v2/layout/LcdLayout.svelte
+++ b/frontend/src/components-v2/layout/LcdLayout.svelte
@@ -52,9 +52,13 @@
   // value, so a resolution failure (unreachable today — see above) falls
   // back to the cockpit center AND keeps its usual SemanticRadioSurfaces
   // slot, rather than losing the VFO/TX affordance entirely.
-  let peerSplitCanvas = $derived(
+  //
+  // MOR-2259 carries the group's `minScale` down the same path as its
+  // canvas: one resolved object, so the floor cannot be plumbed from a
+  // different source than the size it floors.
+  let peerSplitStage = $derived(
     variant === 'peer-split' && peerSplitGroup && peerSplitGroup.scaling.mode === 'fixed-native'
-      ? peerSplitGroup.canvas
+      ? { canvas: peerSplitGroup.canvas, minScale: peerSplitGroup.scaling.minScale }
       : undefined,
   );
 
@@ -108,7 +112,7 @@
       <div
         class="lcd-slot"
         data-lcd-variant={variant}
-        style:aspect-ratio={peerSplitCanvas ? `${peerSplitCanvas.w} / ${peerSplitCanvas.h}` : undefined}
+        style:aspect-ratio={peerSplitStage ? `${peerSplitStage.canvas.w} / ${peerSplitStage.canvas.h}` : undefined}
       >
         <div
           class="lcd-frame lcd-mode-{displayMode}"
@@ -117,8 +121,12 @@
         >
           {#if variant === 'scope'}
             <AmberScope />
-          {:else if peerSplitCanvas}
-            <PeerSplitLayout canvasW={peerSplitCanvas.w} canvasH={peerSplitCanvas.h} />
+          {:else if peerSplitStage}
+            <PeerSplitLayout
+              canvasW={peerSplitStage.canvas.w}
+              canvasH={peerSplitStage.canvas.h}
+              minScale={peerSplitStage.minScale}
+            />
           {:else}
             <AmberCockpit />
           {/if}
@@ -135,7 +143,7 @@
          here by SemanticRadioSurfaces — no new TX path. `peer-split`'s glass
          (`PeerSplitLayout.svelte`) mounts its own `SemanticRadioSurfaces
          strips="dual"` instead, so this slot is suppressed whenever that
-         glass actually mounts (`peerSplitCanvas`, MOR-2153 PR-1 / MOR-2253
+         glass actually mounts (`peerSplitStage`, MOR-2153 PR-1 / MOR-2253
          slice 1) — each SemanticRadioSurfaces instance takes a
          distinct TX-lease `sourceId` from its own module-level counter
          (`components-v2/wiring/SemanticRadioSurfaces.svelte`), so two
@@ -146,7 +154,7 @@
          amber glass (`cockpit`/`scope`) keeps its legacy presentation for
          this slice; MOR-1162 redesigns it. -->
     <div class="content-right">
-      {#if !peerSplitCanvas}
+      {#if !peerSplitStage}
         <div class="semantic-slot">
           <SemanticRadioSurfaces />
         </div>
@@ -258,7 +266,7 @@
   }
 
   /* `peer-split`'s glass (`PeerSplitLayout.svelte`) is a fixed-native stage
-     sized from `peerSplitCanvas` (script above), not the fluid 16/7.5 the
+     sized from `peerSplitStage` (script above), not the fluid 16/7.5 the
      amber cockpit/scope variants were tuned for. Matching the slot to the
      glass's own ratio means the frame hits `ScaledStage`'s max-scale-1 clamp
      on both axes at once instead of one axis being starved by a mismatched
@@ -273,7 +281,7 @@
      primitive nor a fixed-native sizing literal appears in this file, which
      is exactly what let a plain CSS number slip past it once already).
      Replaced with the `style:aspect-ratio` binding on the element above,
-     computed from the same `peerSplitCanvas` the glass mount itself uses —
+     computed from the same `peerSplitStage` the glass mount itself uses —
      one JS value, not two independent numbers. `undefined` (any variant but
      `peer-split`) makes Svelte's `style:` directive omit the inline
      property entirely, so the base rule below applies unchanged. */

--- a/frontend/src/primitives/stage/ScaledStage.svelte
+++ b/frontend/src/primitives/stage/ScaledStage.svelte
@@ -57,15 +57,29 @@
      * measured host box, not on how an ancestor positioned it.
      */
     anchor?: 'top-left' | 'center';
+    /**
+     * Lower bound on the computed scale, in the same ratio units as the
+     * scale itself. Omitted (the default), there is no floor and the stage
+     * shrinks to whatever fits, which is what every consumer got before
+     * this prop existed. Given, the stage stops shrinking at this ratio and
+     * the holder scrolls the part that no longer fits (owner decision
+     * relayed 2026-09-02: an operator at a small window is better served by
+     * controls too large to fit than by a face too small to read).
+     */
+    minScale?: number;
     children: Snippet;
   }
 
-  let { nativeW, nativeH, anchor = 'top-left', children }: Props = $props();
+  let { nativeW, nativeH, anchor = 'top-left', minScale, children }: Props = $props();
 
   let holder: HTMLDivElement | undefined = $state();
   let scale = $state(1);
   let offsetX = $state(0);
   let offsetY = $state(0);
+  /** Whether `minScale` is currently raising the scale above the fit — i.e.
+   *  whether the stage is painted larger than the measured host box. Gates
+   *  the holder's `overflow`; see the markup below. */
+  let floorActive = $state(false);
 
   // `anchor === 'top-left'` ignores `offsetX`/`offsetY` entirely (see
   // `transform` below), so the default's rendered `transform` string is
@@ -79,8 +93,9 @@
 
     const native: StageBox = { width: nativeW, height: nativeH };
 
-    // Writes only to `scale`/`offsetX`/`offsetY` — never back onto `holder`
-    // (MOR-2147, see file header). `scale` is written but never READ as
+    // Writes only to `scale`/`offsetX`/`offsetY`/`floorActive` — never back
+    // onto `holder`'s size (MOR-2147, see file header). `scale` and
+    // `floorActive` are written but never READ as
     // `$state` inside this effect: `computeStageCenterOffset` takes the
     // local `nextScale` below instead of the `scale` binding. Reading
     // `scale` here would register it as a dependency of this effect, and
@@ -91,8 +106,10 @@
     // box). Regression found by an independent verifier on this branch.
     const measure = (host: StageBox) => {
       if (host.width <= 0 || host.height <= 0) return;
-      const nextScale = computeStageScale(host, native);
+      const fit = computeStageScale(host, native);
+      const nextScale = computeStageScale(host, native, minScale);
       scale = nextScale;
+      floorActive = nextScale > fit;
       const offset = computeStageCenterOffset(host, native, nextScale);
       offsetX = offset.x;
       offsetY = offset.y;
@@ -114,7 +131,20 @@
   });
 </script>
 
-<div class="scaled-stage-holder" bind:this={holder}>
+<!-- `overflow` is gated on the floor here rather than declared in the
+     `<style>` block below: `auto` only while the floor is holding the stage
+     past this box, so that overflow stays reachable, and `hidden` otherwise.
+     Unconditional `auto` is not inert when the floor is idle. The scrollable
+     area is the UNTRANSFORMED layout box of `.scaled-stage`, which the
+     inline width/height below hold at the native size at every scale — so
+     it overflows the host at every scale below 1. Measured in Chrome
+     on `LcdLayout variant="peer-split"` at a 1280x800 viewport: an 802x337
+     holder with a 1280x540 scroll area, scrollable 478x203 past a stage the
+     fit had already sized to fit it (scale 0.624, painted 799x337).
+     `hidden` takes away the scrollbars and the wheel path, not the area:
+     with the gate in place the same holder still reports `scrollWidth`/
+     `scrollHeight` 1280x540 and still scrolls 478x203 from script. -->
+<div class="scaled-stage-holder" style:overflow={floorActive ? 'auto' : 'hidden'} bind:this={holder}>
   <div class="scaled-stage" style:width="{nativeW}px" style:height="{nativeH}px" style:transform>
     {@render children()}
   </div>
@@ -125,7 +155,8 @@
     position: relative;
     width: 100%;
     height: 100%;
-    overflow: hidden;
+    /* No `overflow` here on purpose — it is an inline, floor-gated value on
+       the element itself. See the comment above the markup. */
   }
 
   .scaled-stage {

--- a/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
+++ b/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
@@ -126,12 +126,16 @@ const noopChildren = ((_anchor: unknown) => ({
 
 /** Mounts `ScaledStage` at the given native size inside the current
  *  `containerSize`, and captures the holder element for later resizes. */
-function mountStage(nativeW: number, nativeH: number, opts?: { anchor?: 'top-left' | 'center' }): HTMLElement {
+function mountStage(
+  nativeW: number,
+  nativeH: number,
+  opts?: { anchor?: 'top-left' | 'center'; minScale?: number },
+): HTMLElement {
   const target = document.createElement('div');
   document.body.appendChild(target);
   const component = mount(ScaledStage, {
     target,
-    props: { nativeW, nativeH, anchor: opts?.anchor, children: noopChildren },
+    props: { nativeW, nativeH, anchor: opts?.anchor, minScale: opts?.minScale, children: noopChildren },
   });
   flushSync();
   components.push(component);
@@ -304,5 +308,110 @@ describe('ScaledStage — .scaled-stage declares flex-shrink: 0 (MOR-2251)', () 
   it('declares flex-shrink: 0', () => {
     const stage = declarationsFor('.scaled-stage');
     expect(stage['flex-shrink']).toBe('0');
+  });
+});
+
+describe('ScaledStage — the minScale floor (MOR-2259)', () => {
+  it('holds the floor when the host is too small for the fit', () => {
+    containerSize = { width: 320, height: 135 };
+    const target = mountStage(1280, 540, { minScale: 0.5 });
+    expect(readTransform(target)).toBe('scale(0.5)');
+  });
+
+  it('omitting minScale leaves the same host at the unfloored fit, exactly', () => {
+    // The default-preservation control, one mount apart from the floored
+    // case above: same host, same native size, no floor prop.
+    containerSize = { width: 320, height: 135 };
+    const target = mountStage(1280, 540);
+    expect(readTransform(target)).toBe('scale(0.25)');
+  });
+
+  it('releases the floor once the host grows enough to fit above it', () => {
+    containerSize = { width: 320, height: 135 };
+    const target = mountStage(1280, 540, { minScale: 0.5 });
+    expect(readTransform(target)).toBe('scale(0.5)');
+
+    resizeContainer(960, 405);
+
+    expect(readTransform(target)).toBe('scale(0.75)');
+  });
+
+  it('anchor="center" translates to the host origin while the floor is active', () => {
+    // native 1280x540 held at 0.5 is a 640x270 box in a 524x221 host — it
+    // overflows on both axes, so centring has nothing to split and the box
+    // must start at the origin for the overflow to be scrollable.
+    containerSize = { width: 524, height: 221 };
+    const target = mountStage(1280, 540, { anchor: 'center', minScale: 0.5 });
+    expect(readTransform(target)).toBe('translate(0px, 0px) scale(0.5)');
+  });
+});
+
+describe('ScaledStage — the holder scrolls only while the floor clamps (MOR-2259)', () => {
+  // NOT the TEXT-pin idiom above: `overflow` is an inline value the
+  // component computes per measured host box, so jsdom exposes the real
+  // decision on `holder.style.overflow` even though it lays nothing out.
+  //
+  // What jsdom cannot show is the consequence — whether Chrome then
+  // reserves a scroll area. The two host boxes below are the ones Chrome
+  // actually gave `.scaled-stage-holder` under `LcdLayout
+  // variant="peer-split"`: 802x337 at a 1280x800 viewport, 522x219 at
+  // 1000x800. Each test asserts the geometry that makes `overflow`
+  // load-bearing at that host — the stage's inline layout box exceeds the
+  // host either way, so `hidden` versus `auto` is the whole difference —
+  // alongside the value itself. A pin on the value alone would have passed
+  // against the unconditional `overflow: auto` this replaces.
+  const NATIVE_W = 1280;
+  const NATIVE_H = 540;
+  const FLOOR = 0.5;
+
+  const holderOf = (target: HTMLElement) => target.querySelector<HTMLElement>('.scaled-stage-holder')!;
+  const stageOf = (target: HTMLElement) => target.querySelector<HTMLElement>('.scaled-stage')!;
+
+  it('a host the painted stage already fits inside gets `hidden`', () => {
+    containerSize = { width: 802, height: 337 };
+    const target = mountStage(NATIVE_W, NATIVE_H, { minScale: FLOOR });
+
+    // The floor is idle here: height is the binding axis and its ratio is
+    // above the floor, so the scale is that ratio exactly.
+    expect(readScale(target)).toBe(337 / NATIVE_H);
+    expect(readScale(target)).toBeGreaterThan(FLOOR);
+    // The untransformed layout box still overflows the host on both axes...
+    expect(parseFloat(stageOf(target).style.width)).toBeGreaterThan(802);
+    expect(parseFloat(stageOf(target).style.height)).toBeGreaterThan(337);
+    // ...while the painted box does not: its height equals the host's by the
+    // equality above, and its width is short of it.
+    expect(readScale(target) * NATIVE_W).toBeLessThan(802);
+
+    expect(holderOf(target).style.overflow).toBe('hidden');
+  });
+
+  it('a host the floored stage overflows gets `auto`', () => {
+    containerSize = { width: 522, height: 219 };
+    const target = mountStage(NATIVE_W, NATIVE_H, { minScale: FLOOR });
+
+    expect(readScale(target)).toBe(FLOOR);
+    // The painted box is larger than the host on both axes, so the part
+    // outside it is only reachable if the holder scrolls.
+    expect(readScale(target) * NATIVE_W).toBeGreaterThan(522);
+    expect(readScale(target) * NATIVE_H).toBeGreaterThan(219);
+
+    expect(holderOf(target).style.overflow).toBe('auto');
+  });
+
+  it('follows the host box rather than being fixed at mount', () => {
+    containerSize = { width: 522, height: 219 };
+    const target = mountStage(NATIVE_W, NATIVE_H, { minScale: FLOOR });
+    expect(holderOf(target).style.overflow).toBe('auto');
+
+    resizeContainer(802, 337);
+
+    expect(holderOf(target).style.overflow).toBe('hidden');
+  });
+
+  it('with no floor declared, even a host far too small for the fit gets `hidden`', () => {
+    containerSize = { width: 100, height: 100 };
+    const target = mountStage(NATIVE_W, NATIVE_H);
+
+    expect(holderOf(target).style.overflow).toBe('hidden');
   });
 });

--- a/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
+++ b/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
@@ -88,3 +88,63 @@ describe('computeStageCenterOffset', () => {
     expect(offset).toEqual({ x: 0, y: 0 });
   });
 });
+
+describe('computeStageScale — the minScale floor (MOR-2259)', () => {
+  // Every case here uses the 1280x540 canvas `presentation/groups/
+  // declarations.ts` declares, at its declared 0.5 floor.
+  it('returns minScale when the achievable fit is below it', () => {
+    // host 320x135 fits 0.25x on both axes; the floor overrides it.
+    const scale = computeStageScale({ width: 320, height: 135 }, { width: 1280, height: 540 }, 0.5);
+    expect(scale).toBe(0.5);
+  });
+
+  it('returns the fit, not the floor, when the fit is above it', () => {
+    // host 960x405 fits 0.75x on both axes — the floor must not raise this.
+    const scale = computeStageScale({ width: 960, height: 405 }, { width: 1280, height: 540 }, 0.5);
+    expect(scale).toBe(0.75);
+  });
+
+  it('still caps at MAX_STAGE_SCALE with a floor given', () => {
+    const scale = computeStageScale({ width: 4000, height: 4000 }, { width: 1280, height: 540 }, 0.5);
+    expect(scale).toBe(MAX_STAGE_SCALE);
+  });
+
+  it('omitting minScale leaves the unfloored fit, to the exact value', () => {
+    // The default-preservation proof: the same host/native the floored case
+    // above turns into 0.5 must still be exactly 0.25 with no floor given.
+    const scale = computeStageScale({ width: 320, height: 135 }, { width: 1280, height: 540 });
+    expect(scale).toBe(0.25);
+  });
+
+  it('a degenerate native size returns 0 even with a floor given', () => {
+    expect(computeStageScale({ width: 320, height: 135 }, { width: 0, height: 540 }, 0.5)).toBe(0);
+    expect(computeStageScale({ width: 320, height: 135 }, { width: 1280, height: 0 }, 0.5)).toBe(0);
+  });
+
+  it('an unmeasured (zero) host with a floor given returns the floor', () => {
+    // Stated rather than assumed: the floor is applied to the fit, and a
+    // zero-size host fits at 0. `ScaledStage.svelte`'s `measure()` returns
+    // early on a non-positive host box, so this input does not reach the
+    // component; pinned here so the pure function's answer is a decision
+    // and not a side effect nobody wrote down.
+    expect(computeStageScale({ width: 0, height: 0 }, { width: 1280, height: 540 }, 0.5)).toBe(0.5);
+  });
+});
+
+describe('computeStageCenterOffset — clamped at the host origin (MOR-2259)', () => {
+  it('clamps both axes to zero when the floored stage is larger than the host', () => {
+    // native 1280x540 held at scale 0.5 -> a 640x270 box inside a 524x221
+    // host. Unclamped the halves are (524-640)/2 = -58 and (221-270)/2 =
+    // -24.5, which would push the overflow past the scroll container's
+    // start edge.
+    const offset = computeStageCenterOffset({ width: 524, height: 221 }, { width: 1280, height: 540 }, 0.5);
+    expect(offset).toEqual({ x: 0, y: 0 });
+  });
+
+  it('clamps per axis: the overflowing axis goes to zero, the other stays centred', () => {
+    // Same 640x270 scaled box in an 800x221 host: 160px of leftover width
+    // (80 each side) survives, while the height overflows and clamps.
+    const offset = computeStageCenterOffset({ width: 800, height: 221 }, { width: 1280, height: 540 }, 0.5);
+    expect(offset).toEqual({ x: 80, y: 0 });
+  });
+});

--- a/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
+++ b/frontend/src/primitives/stage/__tests__/stage-scale.test.ts
@@ -109,6 +109,21 @@ describe('computeStageScale — the minScale floor (MOR-2259)', () => {
     expect(scale).toBe(MAX_STAGE_SCALE);
   });
 
+  it('caps a floor declared ABOVE MAX_STAGE_SCALE instead of letting it lift the stage', () => {
+    // The case above cannot see this: a 0.5 floor is below the cap, so it
+    // passes whichever order the two are applied in. Flooring last —
+    // `Math.max(Math.min(fit, MAX), minScale)` — returns the floor itself
+    // here, i.e. the stage rendered at twice its authored size, which is
+    // the guarantee `MAX_STAGE_SCALE` and `ScaledStage.svelte`'s header
+    // both state.
+    expect(computeStageScale({ width: 4000, height: 4000 }, { width: 1280, height: 540 }, 2))
+      .toBe(MAX_STAGE_SCALE);
+    // Same ordering, but with a host far too small for the fit, so the
+    // floor is the binding term before the cap rather than after it.
+    expect(computeStageScale({ width: 100, height: 100 }, { width: 1280, height: 540 }, 1.5))
+      .toBe(MAX_STAGE_SCALE);
+  });
+
   it('omitting minScale leaves the unfloored fit, to the exact value', () => {
     // The default-preservation proof: the same host/native the floored case
     // above turns into 0.5 must still be exactly 0.25 with no floor given.

--- a/frontend/src/primitives/stage/stage-scale.ts
+++ b/frontend/src/primitives/stage/stage-scale.ts
@@ -20,9 +20,10 @@ export const MAX_STAGE_SCALE = 1;
 
 /**
  * Returns the uniform scale factor that fits `native` inside `host` — the
- * shorter of the two axis ratios wins — capped at `MAX_STAGE_SCALE` so the
- * stage never grows past its authored size, and floored at `minScale` when
- * the caller declares one.
+ * shorter of the two axis ratios wins — floored at `minScale` when the
+ * caller declares one, then capped at `MAX_STAGE_SCALE`. The cap is applied
+ * LAST, so it wins: a `minScale` above `MAX_STAGE_SCALE` returns
+ * `MAX_STAGE_SCALE`, never the floor.
  *
  * With no `minScale`, the result is the unfloored fit for every input,
  * including 0 for a host that has not been measured yet (zero-size box). A
@@ -34,7 +35,11 @@ export function computeStageScale(host: StageBox, native: StageBox, minScale?: n
   const fitWidth = host.width / native.width;
   const fitHeight = host.height / native.height;
   const fit = Math.min(fitWidth, fitHeight, MAX_STAGE_SCALE);
-  return minScale === undefined ? fit : Math.max(fit, minScale);
+  if (minScale === undefined) return fit;
+  // `Math.min` outermost: flooring an already-capped fit can exceed the cap
+  // again, which is how a caller's floor above 1 would render the stage
+  // larger than its authored size.
+  return Math.min(Math.max(fit, minScale), MAX_STAGE_SCALE);
 }
 
 export interface StageOffset {

--- a/frontend/src/primitives/stage/stage-scale.ts
+++ b/frontend/src/primitives/stage/stage-scale.ts
@@ -5,10 +5,9 @@
  * never larger than its authored size. Kept here, DOM-free, so the formula
  * is unit-tested without mounting a component.
  *
- * This primitive does not resolve a minimum viable size (no `minScale`) —
- * that decision belongs to the layout-resolution module under
- * `presentation/layouts/`, which this file deliberately does not import,
- * keeping the primitive free of the layout contract.
+ * The minimum viable scale is not resolved here: it arrives as an optional
+ * argument, so this file still imports nothing at all — no layout and no
+ * group contract.
  */
 
 export interface StageBox {
@@ -22,16 +21,20 @@ export const MAX_STAGE_SCALE = 1;
 /**
  * Returns the uniform scale factor that fits `native` inside `host` — the
  * shorter of the two axis ratios wins — capped at `MAX_STAGE_SCALE` so the
- * stage never grows past its authored size.
+ * stage never grows past its authored size, and floored at `minScale` when
+ * the caller declares one.
  *
- * Returns 0 for a host that has not been measured yet (zero-size box) or a
- * degenerate native size (zero width or height).
+ * With no `minScale`, the result is the unfloored fit for every input,
+ * including 0 for a host that has not been measured yet (zero-size box). A
+ * degenerate native size (zero width or height) returns 0 whether or not a
+ * floor is given. `stage-scale.test.ts` pins each of those three cases.
  */
-export function computeStageScale(host: StageBox, native: StageBox): number {
+export function computeStageScale(host: StageBox, native: StageBox, minScale?: number): number {
   if (native.width <= 0 || native.height <= 0) return 0;
   const fitWidth = host.width / native.width;
   const fitHeight = host.height / native.height;
-  return Math.min(fitWidth, fitHeight, MAX_STAGE_SCALE);
+  const fit = Math.min(fitWidth, fitHeight, MAX_STAGE_SCALE);
+  return minScale === undefined ? fit : Math.max(fit, minScale);
 }
 
 export interface StageOffset {
@@ -49,10 +52,16 @@ export interface StageOffset {
  * axis, independent of the host's own layout mode (flex, grid, or plain
  * flow): it depends only on the measured `host` box, not on how an ancestor
  * positioned it.
+ *
+ * Each axis is clamped at 0. A `minScale` floor can hold the scaled box
+ * LARGER than `host`, where half the leftover is negative and would place
+ * the box's start edge before the host's origin. Clamped, the box starts at
+ * the origin instead. `stage-scale.test.ts` pins the both-axes and the
+ * per-axis case.
  */
 export function computeStageCenterOffset(host: StageBox, native: StageBox, scale: number): StageOffset {
   return {
-    x: (host.width - native.width * scale) / 2,
-    y: (host.height - native.height * scale) / 2,
+    x: Math.max(0, (host.width - native.width * scale) / 2),
+    y: Math.max(0, (host.height - native.height * scale) / 2),
   };
 }

--- a/frontend/src/skins/segmentline/PeerSplitLayout.svelte
+++ b/frontend/src/skins/segmentline/PeerSplitLayout.svelte
@@ -20,9 +20,10 @@
   import SemanticRadioSurfaces from '../../components-v2/wiring/SemanticRadioSurfaces.svelte';
 
   /**
-   * Canvas size comes from the shell (`components-v2/layout/LcdLayout.svelte`),
-   * which resolves it from the `peer-split-glass` instrument group through
-   * the `peer-split` manifest's zone reference (MOR-2253 slice 1). This
+   * Canvas size and scale floor come from the shell (`components-v2/layout/
+   * LcdLayout.svelte`), which resolves them from the `peer-split-glass`
+   * instrument group through the `peer-split` manifest's zone reference
+   * (MOR-2253 slice 1, MOR-2259). This
    * replaces this component's own former `NATIVE_W`/`NATIVE_H` constants,
    * which duplicated `SEGMENTLINE_GLASS_STAGE` in `presentation/layouts/
    * segmentline-declarations.ts` as a second, independent literal
@@ -31,8 +32,11 @@
   interface Props {
     canvasW: number;
     canvasH: number;
+    /** The group's own `scaling.minScale`, resolved by the same shell and
+     *  handed to `ScaledStage` as its scale floor (MOR-2259). */
+    minScale: number;
   }
-  let { canvasW, canvasH }: Props = $props();
+  let { canvasW, canvasH, minScale }: Props = $props();
 
   /** Wall-clock only — see the file header. `Date`, not radio state. */
   function clockLabel(date: Date): { utc: string; local: string } {
@@ -52,7 +56,7 @@
 </script>
 
 <div class="peer-split-holder">
-  <ScaledStage nativeW={canvasW} nativeH={canvasH}>
+  <ScaledStage nativeW={canvasW} nativeH={canvasH} {minScale}>
     <div class="peer-split-glass" data-testid="peer-split-glass">
       <div class="peer-split-clock" data-testid="peer-split-clock" aria-label="Clock">
         <span data-testid="peer-split-clock-utc">{clock.utc}</span>

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -199,7 +199,7 @@ const q = <T extends HTMLElement>(sel: string) => target.querySelector(sel) as T
 function render(): void {
   target = document.createElement('div');
   document.body.appendChild(target);
-  component = mount(PeerSplitLayout, { target, props: { canvasW: 1280, canvasH: 540 } });
+  component = mount(PeerSplitLayout, { target, props: { canvasW: 1280, canvasH: 540, minScale: 0.5 } });
   flushSync();
 }
 
@@ -381,5 +381,25 @@ describe('the glass bezel keeps its own CSS after the chassis class it used to w
   it('subgrids the channel strips onto the chassis columns instead of a separately-computed split', () => {
     const strips = declarationsFor('.peer-split-glass :global(.channel-strips.channel-strips)');
     expect(strips['grid-template-columns']).toBe('subgrid');
+  });
+});
+
+describe('the glass forwards the shell-resolved scale floor to its stage (MOR-2259)', () => {
+  // A SOURCE pin, not a behavioural one: jsdom computes no layout, so
+  // `ScaledStage`'s `measure()` sees a 0x0 holder and returns before the
+  // floor can influence anything observable here (the same limit this
+  // file's header and `../../../primitives/stage/__tests__/
+  // ScaledStage.isolated.test.ts`'s `flex-shrink` pin both record). The
+  // floor's arithmetic is pinned in `stage-scale.test.ts`; what is pinned
+  // here is the one link those tests cannot see — that this component
+  // actually hands its `minScale` prop on rather than accepting it and
+  // dropping it.
+  const source = readFileSync('src/skins/segmentline/PeerSplitLayout.svelte', 'utf8');
+  const markup = source.replace(/<script[\s\S]*?<\/script>/, '').replace(/<style>[\s\S]*?<\/style>/, '');
+
+  it('passes minScale to ScaledStage in the markup', () => {
+    const tag = markup.match(/<ScaledStage[^>]*>/)?.[0];
+    expect(tag, 'no <ScaledStage ...> tag found in PeerSplitLayout.svelte markup').toBeDefined();
+    expect(tag).toMatch(/\{minScale\}|minScale=/);
   });
 });


### PR DESCRIPTION
`computeStageScale` had no floor: a fixed-native stage shrank without limit, so
every `minScale` declared in the tree described a behaviour that had never
existed. This gives it one.

`minScale` becomes an optional prop on `ScaledStage`, passed down from the
group's `scaling.minScale` exactly as `canvas` already is. The computed scale
never goes below it. **With no prop, behaviour is exactly today's** — no floor —
so consumers that pass nothing are untouched, asserted by exact value rather
than by pattern.

The owner chose scroll over letterbox: the glass scales as one down to the
minimum — which is defined as the *minimally sensible size* — and below that it
stays at that scale while the holder scrolls, rather than shrinking further into
unreadability.

## The overflow is gated, and why that is not cosmetic

The obvious implementation — set the holder to `overflow: auto` — is wrong, and
the measurement that caught it is worth stating because the reasoning that
produced it is a trap.

Chrome computes a scroll container's scrolling area from the descendant's
**untransformed layout box**. `.scaled-stage` carries inline `width: 1280px;
height: 540px` at every scale; the scale is a `transform`. So the scrolling area
is 1280×540 always, and `auto` offers scrolling at every scale below 1 — not
only when the floor is active.

Measured in the real app at **1280×800**, a viewport where the floor is inactive
and the whole glass fits: the holder reported `scrollWidth/Height 1280×540`
against `client 802×337`. Scrolled to the end, the glass sat in the frame's
corner with roughly 60% of the frame blank and a scrollbar along the bottom.
That viewport is one of this change's own *controls* — the naive version would
have shipped a visible defect exactly where we were checking for its absence.

So `overflow` is computed from whether the floor is actually clamping: `auto`
while it is, `hidden` otherwise. `hidden` is what `main` already had, so at the
controls this build computes what `main` computes; the only delta is `auto` under
an active floor.

## What the gate does and does not change

**Does:** the scrollbars and the wheel path. In an isolated control,
`mouse.wheel(0, 300)` scrolls the `auto` box by 300 and the `hidden` box by 0.
That is the pin.

**Does not:** `scrollWidth − clientWidth`. It reads 1280/802 at the controls with
the gate, without it, and on `main` today, because `hidden` is still a scroll
container over the same oversized layout box. Only **MOR-2270** removes that,
with a wrapper sized `native × scale` so the layout box equals the painted box;
MOR-2251's `flex-shrink: 0` and its declaration pin move there. This PR masks
that area rather than removing it, and says so rather than implying otherwise.

## Measurements

Real app, `LcdLayout variant="peer-split"`, four viewports:

| viewport | overflow | scale | host | reachable |
|---|---|---|---|---|
| 1000×800 | `auto` | 0.5 (floored) | 522×219 | max scroll [758, 321]; glass needs [118, 51] |
| 1100×800 | `auto` | 0.5 (floored) | 622×261 | — |
| 1280×800 | `hidden` | 0.624421 | 802×337 | **control** |
| 1440×900 | `hidden` | 0.749421 | 962×405 | **control** |

The controls reproduce MOR-2251's numbers unchanged: stage layout box 1280×540,
clipped-top 0.

**Correcting the arithmetic used to choose these viewports.** The centre column
is `viewportWidth − 476` exactly, verified at all four. But `.lcd-frame`'s 1px
border takes the holder to `centre − 2`, which makes **height** the binding axis
rather than the two axis ratios being equal, so the predicted scales were ~0.4%
high. Measured: 0.5, 0.5, 0.624421, 0.749421.

## An honest limit on the instrument

The intended discriminator was reserved scrollbar space — 15×15 versus 0×0,
which an earlier probe did measure. On the browser available for this round
(macOS Chrome, overlay scrollbars) it reads 0×0 in every configuration, and
neither `--disable-features=OverlayScrollbar` nor `::-webkit-scrollbar` sizing
changed that. Rather than claim a flip that was not observed, the pin uses the
wheel path, which does discriminate on this instrument.

## Wheel behaviour, established rather than assumed

An earlier draft of this PR said the wheel did not scroll the holder. **That was
a sampling artefact** — one gesture, always at the holder centre. The stage is
wheel-scrollable. Corrected here rather than left standing.

What happens is that an inner scroll container takes the first gesture.
`div.semantic-surfaces` sits between the wheel target and the holder and carries
21px of its own vertical overflow (scroll 1248x529 against client 1248x508), so
Chrome scrolls it first; once exhausted, chaining is normal:

    wheel 1: holder [0,0]    semantic-surfaces [0,21]
    wheel 2: holder [0,150]  semantic-surfaces [0,21]
    wheel 3: holder [0,300]  semantic-surfaces [0,21]

Established with CDP `DOMDebugger.getEventListeners` across the chain from
hit-test target to `window` at three points over the glass, per-element scroll
capture around each gesture, a fresh page per row to separate region from
gesture history, and a subtree sweep for wheel listeners and scroll containers.
The rule is `.semantic-surfaces { overflow: auto }` in
`components-v2/wiring/SemanticRadioSurfaces.svelte`, from `01832b75` — older
than this work.

**No handler consumes the wheel on that path**: zero `wheel` listeners on the
chain at all three points, `defaultPrevented` false at `window` throughout.

A separate, deliberate conflict does exist and is not a defect: sixteen
`span.digit` elements carry non-passive wheel listeners
(`primitives/frequency/FrequencyDisplayInteractive.svelte`, `handleWheel`) which
return early unless that digit is the selected one, per MOR-1639. Measured:
unarmed, the wheel chains and the holder runs to its limit; armed by a
deliberate click, `defaultPrevented` is true and nothing scrolls.

So the operator-facing statement is: **the stage scrolls, after the wheel passes
whichever inner scroller is under the pointer.** At 1000x800 that is one gesture
over most of the glass, but `.meters-surface` overflows by 263px — an order of
magnitude more than `.semantic-surfaces` — so a wheel over the meters costs
several gestures first. Two of the three inner scrollers are declared by the
peer-split glass itself; none were changed here. Improving that is the inner
scrollers' problem, not `ScaledStage`'s.

Scrollbars stay unreliable on macOS: overlay, gutter 0x0 in every configuration
on the browser available for this round.

Not asserted: over an unarmed digit, a diagonal wheel did not move the holder
across three gestures while a vertical wheel at the same point scrolled it to
its limit, with `defaultPrevented` false throughout. Chrome behaviour under a
non-passive listener, or an artefact of synthesised diagonal input — not
established either way, and it does not affect the statement above.

All of this is the fixture harness with stubbed runtime seams: real component
tree, real CSS, real listeners, fixture data.

## Numbers

`npm run check` 0 errors 0 warnings; `npx eslint src` clean. Eight mutations all
observed red, including restoring unconditional `auto` — the exact defect above —
which kills all four new pins, and inverting the gate, which kills the same four.

8 code + 0 regenerated baselines = **8 files**, 317 changed lines. Over the
6-file soft threshold, under the ceiling. One unit of work: the floor, the gate
it requires, the prop that carries the number down, and the pins over each.

Linear: MOR-2259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
