### PR TITLE
test: run the proxy start/stop test on an ephemeral port and report why the task ended

### DIFF
--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,10 +1,75 @@
 """Tests for the UDP relay proxy."""
 
 import asyncio
+import contextlib
+import logging
+import socket
 
 import pytest
 
 from rigplane.proxy import _RelayProtocol, run_proxy
+
+_LISTEN_HOST = "127.0.0.1"
+
+# run_proxy binds base_port, base_port+1 and base_port+2 — one per entry of
+# its `labels` list — so reserving a single ephemeral port is not enough.
+_RELAY_PORTS = 3
+
+_PORT_SEARCH_ATTEMPTS = 20
+
+# Logged by run_proxy once all relay endpoints are bound.
+_STARTED_LOG_PREFIX = "Proxy started"
+
+
+def _udp_bind_error(port: int) -> OSError | None:
+    """Bind and release a UDP socket on ``port``; return the error, if any."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.bind((_LISTEN_HOST, port))
+    except OSError as exc:
+        return exc
+    finally:
+        probe.close()
+    return None
+
+
+def _reserve_consecutive_udp_ports(count: int) -> int:
+    """Return a base port with ``count`` consecutive free UDP ports.
+
+    The probes are released before returning, so this does not hold the
+    ports against another process; it only avoids the fixed port that every
+    concurrent copy of this test aimed at (MOR-2271).
+    """
+    for _ in range(_PORT_SEARCH_ATTEMPTS):
+        probes: list[socket.socket] = []
+        try:
+            head = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            probes.append(head)
+            head.bind((_LISTEN_HOST, 0))
+            base = int(head.getsockname()[1])
+            if base + count - 1 > 65535:
+                continue
+            for offset in range(1, count):
+                follower = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                probes.append(follower)
+                follower.bind((_LISTEN_HOST, base + offset))
+        except OSError:
+            continue
+        finally:
+            for probe in probes:
+                probe.close()
+        return base
+    raise RuntimeError(
+        f"no run of {count} free UDP ports on {_LISTEN_HOST} "
+        f"after {_PORT_SEARCH_ATTEMPTS} attempts"
+    )
+
+
+def _why_it_ended(task: asyncio.Task[None]) -> str:
+    """Describe a finished task's outcome for an assertion message."""
+    if task.cancelled():
+        return "cancelled"
+    return repr(task.exception())
 
 
 class TestRelayProtocol:
@@ -98,14 +163,53 @@ class TestRelayProtocol:
         assert relay.client_addr is None
 
 
+# MUTATIONS that kill this test, each run in this worktree on 2026-09-02:
+#   * `base_port = 59001` (the fixed port this test used before MOR-2271),
+#     with two pytest processes started concurrently -> one of the two fails
+#     in each of 3 repetitions.
+#   * delete the "Proxy started" logger.info from run_proxy -> the readiness
+#     wait below times out after 5 s.
+#   * delete `t.close()` from run_proxy's finally -> "still bound after
+#     run_proxy was cancelled".
 @pytest.mark.asyncio
-async def test_run_proxy_starts_and_stops() -> None:
-    """run_proxy can be started and cancelled."""
-    task = asyncio.create_task(run_proxy("192.168.1.100", "127.0.0.1", 59001))
-    await asyncio.sleep(0.1)
-    assert not task.done()
-    task.cancel()
+async def test_run_proxy_starts_and_stops(caplog: pytest.LogCaptureFixture) -> None:
+    """run_proxy binds its relay ports and releases them when cancelled."""
+    caplog.set_level(logging.INFO, logger="rigplane.runtime.proxy")
+    base_port = _reserve_consecutive_udp_ports(_RELAY_PORTS)
+    ports = [base_port + offset for offset in range(_RELAY_PORTS)]
+
+    task = asyncio.create_task(run_proxy("192.168.1.100", _LISTEN_HOST, base_port))
     try:
-        await task
-    except asyncio.CancelledError:
-        pass
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 5.0
+        while not any(
+            record.getMessage().startswith(_STARTED_LOG_PREFIX)
+            for record in caplog.records
+        ):
+            if task.done():
+                raise AssertionError(
+                    f"run_proxy ended before reporting startup on {ports}: "
+                    f"{_why_it_ended(task)}"
+                )
+            if loop.time() > deadline:
+                raise AssertionError(
+                    f"run_proxy did not report startup on {ports} within 5s"
+                )
+            await asyncio.sleep(0.01)
+
+        assert not task.done(), (
+            f"run_proxy ended after reporting startup: {_why_it_ended(task)}"
+        )
+        for port in ports:
+            assert _udp_bind_error(port) is not None, (
+                f"run_proxy reported startup but left port {port} unbound"
+            )
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    for port in ports:
+        assert _udp_bind_error(port) is None, (
+            f"port {port} still bound after run_proxy was cancelled"
+        )


### PR DESCRIPTION
## Summary

Linear: MOR-2271

`tests/test_proxy.py::test_run_proxy_starts_and_stops` bound the fixed UDP port 59001, slept 0.1 s and asserted the task was still running. On 2026-09-03 02:41 UTC the `Tests (full matrix)` 3.12 job on `main` failed that assertion. The host now has two `build` runners (`gh api /repos/rigplane/rigplane-core/actions/runners`: `mm-build-core-1`, `mm-build-core-2`), so two pytest suites can run on it at once. In the failing attempt 2 (`gh run view 33707723403 --attempt 2`) the run's jobs were split across both runners, and other workflows' `quick` and full-matrix runs overlapped the failing minute; in attempt 1, `test (3.13)` on core-1 overlapped `test (3.11)` on core-2, two legs of one matrix running pytest concurrently. Every suite on the host executes this test, so any two suites can both bind 59001. The old assertion's headline was `assert not True`, with the cause reachable only through pytest's `+ where` chain.

## What changed (one file, `tests/test_proxy.py`)

- The test reserves three consecutive free UDP ports (bind `("127.0.0.1", 0)`, bind the two followers, release all three) instead of 59001.
- The fixed sleep is replaced by a bounded 5 s wait on `run_proxy`'s own `"Proxy started"` log record via `caplog`; every iteration checks `task.done()` and puts `task.exception()` into the failure message.
- Two assertions the old test lacked: the three ports are bound while the proxy runs, and free again after cancel.
- Cleanup in `try/finally`; if the task died of a real exception, `await task` re-raises it into the report.

No production change: `run_proxy` cannot report a bound port (returns `None`, transports are local), so the test acquires the ports itself.

## Evidence (macOS, Python 3.13.5, measured by the builder in the worktree)

- Instrument check: a plain UDP bind on a port held by `create_datagram_endpoint` fails with `OSError 48` and succeeds after `close()`.
- Old test, two concurrent pytest processes, 5 reps: one of the two fails in 5/5 with `assert not True`.
- Mutation A (restore `base_port = 59001` in the new test), 3 reps: one of the two fails in 3/3, message now `run_proxy ended before reporting startup on [59001, 59002, 59003]: OSError(48, 'Address already in use')`.
- New test, same concurrent pair, 5 reps: green 5/5; `-n 2` on the file 3/3 green.
- Mutation B (delete the `"Proxy started"` log line in `run_proxy`): the readiness wait times out with its own message. Mutation C (delete `t.close()` in `run_proxy`'s `finally`): `port N still bound after run_proxy was cancelled`. Both reverted before commit.
- Mutation D (pre-bind `base_port+1` before starting): the re-raised `OSError` with its traceback is the headline under `--tb=short`.

Paths that can end the task before readiness, from reading `run_proxy`: the three `create_datagram_endpoint` binds (`OSError`, `gaierror`, `PermissionError`) and the two `add_signal_handler` calls (`RuntimeError` off the main thread, `NotImplementedError` on a proactor loop). The radio address is only used in `sendto`; nothing resolves or connects to it at startup.

## Class sweep

grep over `tests/` for `.bind((`, `local_addr=(`, `create_datagram_endpoint`, `create_server`, `start_server`, `open_connection` and for `*port* = <4-5 digit literal>`: every other real-socket site already uses port 0 and reads it back from `getsockname()`. The remaining literals are a fake object's attribute (`test_diagnostics_contributors_batch2.py`) and the radio's own protocol port in the hardware-gated integration scripts. The grep matches the call line and named assignments only; a port computed indirectly above a bind would be missed.

## Residual

The reserved ports are released before `run_proxy` binds them, so a foreign process can still take one in that gap; closing it would require `run_proxy` to accept pre-bound sockets, which this ticket excludes.

## Gates

`uv run pytest tests/test_proxy.py -q` 5 passed, repeated 5×; `ruff check` and `ruff format --check` clean; `lint-imports` 5 kept / 0 broken. Suite record: the `quick` run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
