### PR TITLE
feat: the design language declares BarGauge's zone palette

### DIFF
--- a/frontend/src/components-v2/meters/BarGauge.svelte
+++ b/frontend/src/components-v2/meters/BarGauge.svelte
@@ -13,6 +13,14 @@
     value: number;         // 0–1 normalized
     label: string;         // 'Po' | 'SWR' | 'ALC' | 'COMP'
     displayValue: string;  // '35W' | '1.2' | '-8'
+    /**
+     * Segment palette. MOR-2255 gave this prop a real writer:
+     * `semantic/MetersSurface.svelte` passes the active design language's own
+     * `MeterDisplay.zones`. The `DEFAULT_ZONES` default below stays and is not
+     * dead — it is the "no design language active" fallback, the same role
+     * `DEFAULT_METER_DISPLAY` (`./meter-display.ts`) plays for
+     * `LinearSMeter.svelte`'s `display` prop.
+     */
     zones?: readonly Zone[];
     compact?: boolean;
     showPeak?: boolean;    // MOR-1282: optional peak-hold marker

--- a/frontend/src/components-v2/meters/__tests__/LinearSMeter.display.test.ts
+++ b/frontend/src/components-v2/meters/__tests__/LinearSMeter.display.test.ts
@@ -4,6 +4,7 @@ import type { ComponentProps } from 'svelte';
 import type { Capabilities } from '$lib/types/capabilities';
 import { clearCapabilities, setCapabilities } from '$lib/stores/capabilities.svelte';
 import LinearSMeter from '../LinearSMeter.svelte';
+import { DEFAULT_ZONES } from '../bar-gauge-utils';
 
 // Minimal calibration table with an S9 knot — enough for `getS9Raw()` to
 // resolve to a real anchor (raw 130) and for `rawToSegments` to place it at
@@ -69,8 +70,11 @@ function segmentRects(target: HTMLElement): SVGRectElement[] {
 // "no language tone supplied" value `DEFAULT_METER_DISPLAY` uses — so
 // `activeColor`/`dimColor` still take the untouched gradient/hex path these
 // tests already pin.
+// MOR-2255 added the required `zones` field; `LinearSMeter` reads none of it,
+// so every literal below carries `DEFAULT_ZONES` — the same value
+// `DEFAULT_METER_DISPLAY` uses — purely to satisfy the type.
 const geometry = (segmentCount: number, segmentGapPx: number) => (
-  { segmentCount, segmentGapPx, toneBelowS9: '', toneAboveS9: '' }
+  { segmentCount, segmentGapPx, toneBelowS9: '', toneAboveS9: '', zones: DEFAULT_ZONES }
 );
 
 describe('LinearSMeter display prop', () => {
@@ -257,7 +261,7 @@ describe('LinearSMeter display prop', () => {
     function activeFillAt(toneBelowS9: string, toneAboveS9: string, index: number): string | null {
       const target = mountMeter({
         value: 60,
-        display: { segmentCount: 20, segmentGapPx: 1, toneBelowS9, toneAboveS9 },
+        display: { segmentCount: 20, segmentGapPx: 1, toneBelowS9, toneAboveS9, zones: DEFAULT_ZONES },
       });
       const dim = segmentRects(target)[index];
       const active = dim.nextElementSibling as SVGRectElement | null;
@@ -273,7 +277,7 @@ describe('LinearSMeter display prop', () => {
       function firstToneAboveIndex(toneBelowS9: string, toneAboveS9: string): number {
         const target = mountMeter({
           value: 60,
-          display: { segmentCount: 20, segmentGapPx: 1, toneBelowS9, toneAboveS9 },
+          display: { segmentCount: 20, segmentGapPx: 1, toneBelowS9, toneAboveS9, zones: DEFAULT_ZONES },
         });
         const rects = segmentRects(target);
         return rects.findIndex((dim) => (dim.nextElementSibling as SVGRectElement | null)?.getAttribute('fill') === toneAboveS9);

--- a/frontend/src/components-v2/meters/meter-display.ts
+++ b/frontend/src/components-v2/meters/meter-display.ts
@@ -1,4 +1,5 @@
 import type { MeterDisplay } from '../../presentation/languages/contract';
+import { DEFAULT_ZONES } from './bar-gauge-utils';
 
 /**
  * LinearSMeter's default segment geometry — 20 segments, 1px gap — matching
@@ -8,7 +9,13 @@ import type { MeterDisplay } from '../../presentation/languages/contract';
  * must render byte-identical to the pre-MOR-2250 gradient/hex fill, so
  * `LinearSMeter` treats an empty tone string the same as "no language
  * supplied one" and never paints it.
+ *
+ * MOR-2255 made `zones` a required `MeterDisplay` field. `LinearSMeter` — the
+ * only consumer of this constant — never reads it; it is `DEFAULT_ZONES`
+ * itself, the same fallback `BarGauge`'s own `zones` prop defaults to, so this
+ * default cannot disagree with that one.
  */
 export const DEFAULT_METER_DISPLAY: MeterDisplay = {
   segmentCount: 20, segmentGapPx: 1, toneBelowS9: '', toneAboveS9: '',
+  zones: DEFAULT_ZONES,
 };

--- a/frontend/src/presentation/languages/contract.ts
+++ b/frontend/src/presentation/languages/contract.ts
@@ -51,11 +51,30 @@ export function isValidLanguageId(id: string): boolean {
 /** Required groups: typography, geometry, meters, frequency, motion, focus ring, RX/TX. Density and renderer slots are manifest-level, not tokens. */
 export interface StateFeedbackTokens { readonly idle: string; readonly active: string; readonly tuning: string }
 
+/**
+ * One band of a bar gauge's zone palette: `end` is the normalized 0..1
+ * position the band runs to, `color` the CSS color its segments take.
+ *
+ * Structurally the same shape as `components-v2/meters/bar-gauge-utils.ts`'s
+ * own `Zone`, declared here rather than imported from there because the
+ * dependency runs the other way: `components-v2/meters/meter-display.ts`
+ * imports this module, and no file under `presentation/` imports
+ * `components-v2/`.
+ */
+export interface Zone {
+  readonly end: number;
+  readonly color: string;
+}
+
 export interface MeterDisplay {
   readonly segmentCount: number; // integer >= 1
   readonly segmentGapPx: number; // >= 0
   readonly toneBelowS9: string; // CSS color, segments below the S9 crossover
   readonly toneAboveS9: string; // CSS color, segments at/above the S9 crossover
+  /** MOR-2255: bar-gauge zone palette, ordered low→high `end`; never empty —
+   *  `getSegmentZone` falls back to the LAST entry, which an empty array
+   *  cannot supply. */
+  readonly zones: readonly Zone[];
 }
 
 export const REQUIRED_TOKEN_GROUPS = [

--- a/frontend/src/presentation/languages/fieldline/meters-renderer.ts
+++ b/frontend/src/presentation/languages/fieldline/meters-renderer.ts
@@ -14,7 +14,22 @@
  * carries a fractional fill and a sub-pixel peak; a segment ladder quantises
  * both, so a reading is legible as a COUNT at arm's length with gloves on.
  */
-import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+import type { DesignLanguageTokens, RendererViewModel, Zone } from '../contract';
+
+/**
+ * MOR-2255 (slice A): fieldline's bar-gauge zone palette. These three values
+ * are the ones `BarGauge` already draws — `DEFAULT_ZONES` in
+ * `components-v2/meters/bar-gauge-utils.ts` — so wiring the palette through
+ * this seam changes no pixel. Giving each language its own palette is a
+ * separate ticket. The literal is repeated in `studioline` and `segmentline`
+ * rather than shared through a constant (coordinator ruling, MOR-2255): a
+ * language declares its own data.
+ */
+export const FIELDLINE_METER_ZONES: readonly Zone[] = [
+  { end: 0.6, color: '#14A665' },
+  { end: 0.8, color: '#F2CF4A' },
+  { end: 1.0, color: '#F14C42' },
+];
 
 /** Few enough to count at a glance, coarse enough to read in sunlight. */
 export const FIELDLINE_SEGMENT_COUNT = 12;
@@ -58,6 +73,9 @@ export interface FieldlineMeter {
    */
   readonly toneBelowS9: string;
   readonly toneAboveS9: string;
+  /** MOR-2255: `FIELDLINE_METER_ZONES`, the `MeterDisplay` field `BarGauge`
+   *  colors its segments from. */
+  readonly zones: readonly Zone[];
   readonly scaleTicks: readonly number[];
   readonly unknown: boolean;
 }
@@ -108,6 +126,7 @@ export function renderMeter(
     litCount,
     toneBelowS9: tokens.rx.active,
     toneAboveS9: tokens.tx.tuning,
+    zones: FIELDLINE_METER_ZONES,
     scaleTicks: FIELDLINE_SCALE_TICKS,
     unknown: value === null,
   };

--- a/frontend/src/presentation/languages/segmentline/meters-renderer.ts
+++ b/frontend/src/presentation/languages/segmentline/meters-renderer.ts
@@ -25,7 +25,22 @@
  * which already snap rather than animate under prefers-reduced-motion; a
  * second loop here would be an unaudited one.
  */
-import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+import type { DesignLanguageTokens, RendererViewModel, Zone } from '../contract';
+
+/**
+ * MOR-2255 (slice A): segmentline's bar-gauge zone palette. These three values
+ * are the ones `BarGauge` already draws — `DEFAULT_ZONES` in
+ * `components-v2/meters/bar-gauge-utils.ts` — so wiring the palette through
+ * this seam changes no pixel. Giving each language its own palette is a
+ * separate ticket. The literal is repeated in `studioline` and `fieldline`
+ * rather than shared through a constant (coordinator ruling, MOR-2255): a
+ * language declares its own data.
+ */
+export const SEGMENTLINE_METER_ZONES: readonly Zone[] = [
+  { end: 0.6, color: '#14A665' },
+  { end: 0.8, color: '#F2CF4A' },
+  { end: 1.0, color: '#F14C42' },
+];
 
 /** Above this fraction of full scale the family marks the track hot. */
 export const HOT_THRESHOLD = 0.8;
@@ -65,6 +80,11 @@ export interface SegmentlineMeter {
    */
   readonly toneBelowS9: string;
   readonly toneAboveS9: string;
+  /** MOR-2255: `SEGMENTLINE_METER_ZONES`, the `MeterDisplay` field `BarGauge`
+   *  colors its segments from. Emitted on BOTH return paths below — an
+   *  unobserved reading still declares the palette, exactly as it already
+   *  declares `segmentCount`/`segmentGapPx`/the tone pair. */
+  readonly zones: readonly Zone[];
 }
 
 const finite = (fields: RendererViewModel['fields'], key: string): number | null => {
@@ -84,6 +104,7 @@ export function renderMeter(
       kind: 'segmentline-meter', unknown: true, hot: false,
       segmentCount: SEGMENTLINE_SEGMENT_COUNT, segmentGapPx,
       toneBelowS9: tokens.rx.active, toneAboveS9: tokens.tx.tuning,
+      zones: SEGMENTLINE_METER_ZONES,
     };
   }
 
@@ -96,5 +117,6 @@ export function renderMeter(
     segmentGapPx,
     toneBelowS9: tokens.rx.active,
     toneAboveS9: tokens.tx.tuning,
+    zones: SEGMENTLINE_METER_ZONES,
   };
 }

--- a/frontend/src/presentation/languages/studioline/meters-renderer.ts
+++ b/frontend/src/presentation/languages/studioline/meters-renderer.ts
@@ -6,7 +6,22 @@
  * the pixel width. Ballistics are NOT here: smoothing is a per-grammar
  * tuning applied at the smoother (MOR-977 §1.1), not a renderer behaviour.
  */
-import type { DesignLanguageTokens, RendererViewModel } from '../contract';
+import type { DesignLanguageTokens, RendererViewModel, Zone } from '../contract';
+
+/**
+ * MOR-2255 (slice A): studioline's bar-gauge zone palette. These three values
+ * are the ones `BarGauge` already draws — `DEFAULT_ZONES` in
+ * `components-v2/meters/bar-gauge-utils.ts` — so wiring the palette through
+ * this seam changes no pixel. Giving each language its own palette is a
+ * separate ticket. The literal is repeated in `fieldline` and `segmentline`
+ * rather than shared through a constant (coordinator ruling, MOR-2255): a
+ * language declares its own data.
+ */
+export const STUDIOLINE_METER_ZONES: readonly Zone[] = [
+  { end: 0.6, color: '#14A665' },
+  { end: 0.8, color: '#F2CF4A' },
+  { end: 1.0, color: '#F14C42' },
+];
 
 /**
  * Peak-hold: a 1px tick, in contrast with `fieldline`'s whole-segment hold —
@@ -49,6 +64,9 @@ export interface StudiolineMeter {
    */
   readonly toneBelowS9: string;
   readonly toneAboveS9: string;
+  /** MOR-2255: `STUDIOLINE_METER_ZONES`, the `MeterDisplay` field `BarGauge`
+   *  colors its segments from. */
+  readonly zones: readonly Zone[];
   readonly peakWidthPx: number;
   readonly unknown: boolean;
 }
@@ -76,6 +94,7 @@ export function renderMeter(
     overTone: tokens.tx.tuning,
     toneBelowS9: tokens.rx.active,
     toneAboveS9: tokens.tx.tuning,
+    zones: STUDIOLINE_METER_ZONES,
     peakWidthPx: PEAK_TICK_WIDTH_PX,
     unknown: value === null,
   };

--- a/frontend/src/semantic/MetersSurface.svelte
+++ b/frontend/src/semantic/MetersSurface.svelte
@@ -170,6 +170,10 @@
    * meter passes `null` and stays unknown rather than reading as zero (rule 3).
    * Annotations only — availability, relevance and the gauge itself remain this
    * surface's decisions.
+   *
+   * MOR-2255: this single call also supplies the `BarGauge` tiles' `zones` —
+   * the slot is called ONCE per render (see `display` below) and read twice,
+   * never once per gauge.
    */
   const signalDisplay = (f: MeterField): ReturnType<typeof renderSlot> =>
     renderSlot('meters', { value: observed(f) ? sLevel(rawOf(f)) : null, max: 1, s9: sLevel(0) });
@@ -188,6 +192,18 @@
    *  risk R3): a radio that reports no meters gets no empty dock, and no zone
    *  schema had to learn about it. */
   let meters = $derived(view.meters);
+
+  /**
+   * The active design language's `meters` descriptor for this render, or
+   * `null` when no language is active, the language declares no `meters`
+   * renderer, or its descriptor is missing the `MeterDisplay` quintet.
+   *
+   * MOR-2255: hoisted out of the S-meter branch so the S-meter tile
+   * (`attributes` + `display`) and every `BarGauge` tile (`display.zones`)
+   * read the SAME descriptor from ONE `renderSlot` call. Each consumer falls
+   * back to its own component default when this is `null`.
+   */
+  let display = $derived(meters ? signalDisplay(meters.signal) : null);
 
   /** The COMP gate is the MOR-1244 `txAux.compressor` FACT, deliberately NOT
    *  `meters.compression.availability`: a radio can keep reporting a
@@ -211,7 +227,6 @@
     </p>
 
     {#if present(meters.signal)}
-      {@const display = signalDisplay(meters.signal)}
       <div
         class="meter-tile" data-meter-tile data-meter="signal" data-testid="meter-signal"
         data-relevant={meters.signal.relevant} data-observed={observed(meters.signal)}
@@ -249,7 +264,15 @@
           role="group" aria-label={`${label} meter`}
         >
           {#if isObserved}
-            <BarGauge value={level(raw)} {label} displayValue={format(raw)} compact {showPeak} {fault} />
+            <!-- MOR-2255: `zones` comes from the SAME `display` descriptor
+                 the S-meter above reads, so every gauge on this surface is
+                 painted by one language. `undefined` (no language, or a
+                 descriptor without the quintet) falls back to `BarGauge`'s
+                 own `DEFAULT_ZONES`. -->
+            <BarGauge
+              value={level(raw)} {label} displayValue={format(raw)} compact {showPeak} {fault}
+              zones={display?.display?.zones}
+            />
           {:else}
             <span class="meter-unknown">{label} ?</span>
           {/if}

--- a/frontend/src/semantic/__tests__/design-language-wiring.component.test.ts
+++ b/frontend/src/semantic/__tests__/design-language-wiring.component.test.ts
@@ -37,7 +37,7 @@ import { flushSync, mount, unmount } from 'svelte';
 import MetersSurface from '../MetersSurface.svelte';
 import RxTxSurface from '../RxTxSurface.svelte';
 import VfoSurface from '../VfoSurface.svelte';
-import { topologyFixtures, withMeters } from '../fixtures/topologies';
+import { topologyFixtures, withMeters, withTxAux } from '../fixtures/topologies';
 import type { RadioViewModel } from '../radio-view-model';
 import type { TxAuthoritySnapshot } from '../rx-tx-surface';
 import {
@@ -47,6 +47,10 @@ import { validManifest } from '../../presentation/languages/__tests__/fixtures';
 import { STUDIOLINE_TOKENS } from '../../presentation/languages/studioline/tokens';
 import { FIELDLINE_TOKENS } from '../../presentation/languages/fieldline/tokens';
 import { SEGMENTLINE_TOKENS } from '../../presentation/languages/segmentline/tokens';
+import { STUDIOLINE_METER_ZONES } from '../../presentation/languages/studioline/meters-renderer';
+import { FIELDLINE_METER_ZONES } from '../../presentation/languages/fieldline/meters-renderer';
+import { SEGMENTLINE_METER_ZONES } from '../../presentation/languages/segmentline/meters-renderer';
+import { DEFAULT_ZONES, dimColor } from '../../components-v2/meters/bar-gauge-utils';
 import { renderSlot } from '../design-language-renderers';
 
 const VIEW: RadioViewModel = topologyFixtures['2/main_sub'];
@@ -379,16 +383,19 @@ describe('MOR-2214 — the meters slot supplies LinearSMeter\'s segment geometry
     expect(renderSlot('meters', reading)?.display).toEqual({
       segmentCount: 20, segmentGapPx: 1,
       toneBelowS9: STUDIOLINE_TOKENS.rx.active, toneAboveS9: STUDIOLINE_TOKENS.tx.tuning,
+      zones: STUDIOLINE_METER_ZONES,
     });
     activate('fieldline');
     expect(renderSlot('meters', reading)?.display).toEqual({
       segmentCount: 12, segmentGapPx: 3,
       toneBelowS9: FIELDLINE_TOKENS.rx.active, toneAboveS9: FIELDLINE_TOKENS.tx.tuning,
+      zones: FIELDLINE_METER_ZONES,
     });
     activate('segmentline');
     expect(renderSlot('meters', reading)?.display).toEqual({
       segmentCount: 20, segmentGapPx: 3,
       toneBelowS9: SEGMENTLINE_TOKENS.rx.active, toneAboveS9: SEGMENTLINE_TOKENS.tx.tuning,
+      zones: SEGMENTLINE_METER_ZONES,
     });
     activate(null);
     expect(renderSlot('meters', reading)).toBeNull();
@@ -411,6 +418,154 @@ describe('MOR-2214 — the meters slot supplies LinearSMeter\'s segment geometry
         - (Number(seg0.getAttribute('x')) + Number(seg0.getAttribute('width')));
       expect(gap).toBe(1);
     });
+  });
+});
+
+// ── MOR-2255 (slice A) — the meters slot supplies BarGauge's zone palette ──
+//
+// THE TRAP THIS BLOCK EXISTS FOR. Slice A deliberately makes all three
+// product languages declare the SAME three zones `BarGauge` already draws
+// (`DEFAULT_ZONES`). So `expect(zones).toEqual(DEFAULT_ZONES)` passes
+// identically whether the wiring works or whether every gauge is still
+// silently falling back to its own prop default — it cannot tell the two
+// apart. The discrimination below is a fourth, DIFFERENT palette declared by
+// a test-only language: only a real path from the language's descriptor to
+// `BarGauge`'s `zones` prop can make those colors appear in the DOM.
+
+describe('MOR-2255 — the language\'s zones reach every BarGauge tile', () => {
+  /** Fully-observed meters plus a compressor that is ON, so all FIVE
+   *  `METER_BARS` tiles mount — `compression` included, which has no visual
+   *  baseline of its own (its fixture leaves `compressorOn` unset) and is
+   *  therefore covered by this test and nothing else. */
+  const barsView: RadioViewModel = (() => {
+    const withAux = withTxAux(withMeters(VIEW, 'receiving'));
+    return {
+      ...withAux,
+      txAux: {
+        ...withAux.txAux!,
+        compressor: {
+          reading: { status: 'known', value: true },
+          availability: { structural: true, operational: true },
+        },
+      },
+    };
+  })();
+
+  /** Every `METER_BARS` field that renders through `BarGauge`. */
+  const BAR_FIELDS = ['power', 'alc', 'drainCurrent', 'drainVoltage', 'compression'] as const;
+
+  /** A palette no product language declares — a different LENGTH and different
+   *  colors, so neither the sequence nor any single fill can coincide with
+   *  `DEFAULT_ZONES`. */
+  const PROBE_ZONES = [
+    { end: 0.5, color: '#0A0B0C' },
+    { end: 1.0, color: '#FAFBFC' },
+  ] as const;
+
+  registerDesignLanguage({
+    ...validManifest(),
+    id: 'zonedline',
+    renderers: {
+      meters: () => ({
+        kind: 'zonedline-meter',
+        segmentCount: 20, segmentGapPx: 1,
+        toneBelowS9: '#0A0B0C', toneAboveS9: '#FAFBFC',
+        zones: PROBE_ZONES,
+      }),
+    },
+  });
+
+  /**
+   * The hex `fill` of every segment rect in one `BarGauge` tile, in DOM
+   * order. Filtering on a leading `#` keeps exactly the zone-painted rects:
+   * the container, the track and the peak marker all fill from
+   * `var(--v2-…)`, and only `dimColor(zone.color)` / `zone.color` are literal
+   * hex. Read this way rather than off the ACTIVE rects because the smoother
+   * has not advanced at `flushSync` time, so a tile can legitimately have
+   * none.
+   */
+  function tileSegmentFills(language: string | null, field: string): string[] {
+    activate(language);
+    let fills: string[] = [];
+    withMounted(MetersSurface, { view: barsView }, (root) => {
+      const tile = root.querySelector<HTMLElement>(`[data-testid="meter-${field}"]`);
+      expect(tile, `no tile rendered for meter-${field}`).not.toBeNull();
+      fills = [...tile!.querySelectorAll('rect')]
+        .map((rect) => rect.getAttribute('fill') ?? '')
+        .filter((fill) => fill.startsWith('#'));
+    });
+    return fills;
+  }
+
+  it.each(BAR_FIELDS)(
+    '%s: a language declaring a DIFFERENT palette repaints the tile', (field) => {
+      // MUTATION KILLED: dropping `zones={display?.display?.zones}` from the
+      // `<BarGauge>` mount in `MetersSurface.svelte` (or passing
+      // `DEFAULT_ZONES` there instead). Either leaves the tile on the
+      // component's own fallback, making this equal to the no-language
+      // rendering — which is precisely what the equal-valued product
+      // languages cannot detect.
+      const bare = tileSegmentFills(null, field);
+      const probed = tileSegmentFills('zonedline', field);
+
+      expect(bare.length).toBeGreaterThan(0);
+      expect(probed).not.toEqual(bare);
+      // Positive: the probe language's own colors, dimmed by `BarGauge`'s own
+      // `dimColor`, are what the tile is painted with.
+      expect(probed).toContain(dimColor(PROBE_ZONES[0].color));
+      expect(probed).toContain(dimColor(PROBE_ZONES[1].color));
+      // Negative: not one segment is still on the fallback palette.
+      for (const zone of DEFAULT_ZONES) expect(probed).not.toContain(dimColor(zone.color));
+    });
+
+  it.each(['studioline', 'fieldline', 'segmentline'])(
+    '%s: renders the bar tiles byte-identically to the no-language fallback (slice A)', (id) => {
+      // Slice A ships the WIRING only. Every product language declares the
+      // same three zones `BarGauge` already drew, so activating one must
+      // change no fill anywhere — this is the pin that the visual baselines
+      // under `fixtures/approved-baselines/` need no regeneration.
+      for (const field of BAR_FIELDS) {
+        expect(tileSegmentFills(id, field)).toEqual(tileSegmentFills(null, field));
+      }
+    });
+
+  it('all three product languages declare exactly the DEFAULT_ZONES values', () => {
+    // The value half of the pin above, read off the declarations themselves
+    // rather than off the DOM.
+    for (const zones of [STUDIOLINE_METER_ZONES, FIELDLINE_METER_ZONES, SEGMENTLINE_METER_ZONES]) {
+      expect(zones).toEqual(DEFAULT_ZONES);
+    }
+  });
+
+  it('a descriptor with no zones, or empty zones, yields no display at all', () => {
+    // MUTATION KILLED: widening `renderSlot`'s check to four fields again, or
+    // accepting `zones: []` — which `getSegmentZone` cannot serve, since its
+    // fallback is the array's LAST entry.
+    const quartet = {
+      kind: 'partial-meter', segmentCount: 20, segmentGapPx: 1,
+      toneBelowS9: '#111111', toneAboveS9: '#222222',
+    };
+    registerDesignLanguage({
+      ...validManifest(), id: 'zonelessline', renderers: { meters: () => quartet },
+    });
+    registerDesignLanguage({
+      ...validManifest(), id: 'emptyzoneline', renderers: { meters: () => ({ ...quartet, zones: [] }) },
+    });
+    const reading = { value: 0.5, max: 1, s9: 0.6 };
+
+    activate('zonelessline');
+    expect(renderSlot('meters', reading)?.display).toBeNull();
+    activate('emptyzoneline');
+    expect(renderSlot('meters', reading)?.display).toBeNull();
+  });
+
+  it('the zones array never leaks into the DOM as a data-dl-* annotation', () => {
+    // F3's array rule, pinned for THIS field: a palette is private geometry,
+    // and serialising it would put per-language data in the attribute
+    // contract — and change the rendered markup this slice must not touch.
+    activate('studioline');
+    const attributes = renderSlot('meters', { value: 0.5, max: 1, s9: 0.6 })!.attributes;
+    expect(Object.keys(attributes).filter((key) => key.includes('zone'))).toEqual([]);
   });
 });
 

--- a/frontend/src/semantic/design-language-renderers.ts
+++ b/frontend/src/semantic/design-language-renderers.ts
@@ -41,14 +41,15 @@
  *                   assistive-tech-neutral tests can observe them. Nested
  *                   objects and arrays are skipped rather than serialised —
  *                   a family's private geometry stays private.
- *   `display`     — MOR-2214/MOR-2250: the same structural check as
- *                   `text`/`attributes`, narrowed to the one shape a shipped
- *                   gauge component (`LinearSMeter`) already knows how to
- *                   consume: `segmentCount`/`segmentGapPx` (numeric) plus
- *                   `toneBelowS9`/`toneAboveS9` (string). A descriptor
- *                   missing any of the four, or typed wrong, yields `null`
- *                   — this is not a `meters`-slot special case, it is the
- *                   same "structural shape present or absent" test as the
+ *   `display`     — MOR-2214/MOR-2250/MOR-2255: the same structural check as
+ *                   `text`/`attributes`, narrowed to the one shape the shipped
+ *                   gauge components (`LinearSMeter`, `BarGauge`) already know
+ *                   how to consume: `segmentCount`/`segmentGapPx` (numeric),
+ *                   `toneBelowS9`/`toneAboveS9` (string) and `zones` (a
+ *                   non-empty array of `{end: number, color: string}`). A
+ *                   descriptor missing any of the five, or typed wrong, yields
+ *                   `null` — this is not a `meters`-slot special case, it is
+ *                   the same "structural shape present or absent" test as the
  *                   other two readings, applied to a different set of field
  *                   names.
  *
@@ -58,6 +59,7 @@
 import {
   getDesignLanguage, resolveRenderer,
   type DesignLanguageManifest, type MeterDisplay, type RendererSlotName, type RendererViewModel,
+  type Zone,
 } from '../presentation/languages/contract';
 // Side-effect import: the registry is populated by the declarations module,
 // which is otherwise imported only by its own tests. Importing the DECLARATIONS
@@ -87,9 +89,9 @@ export interface RendererDisplay {
   /** `data-dl-*` display annotations, ready to spread onto an element. */
   readonly attributes: Readonly<Record<string, string>>;
   /**
-   * MOR-2214/MOR-2250: the descriptor's `segmentCount`/`segmentGapPx`/
-   * `toneBelowS9`/`toneAboveS9` quartet, or `null` when any one is absent or
-   * mistyped. See the file doc comment above.
+   * MOR-2214/MOR-2250/MOR-2255: the descriptor's `segmentCount`/
+   * `segmentGapPx`/`toneBelowS9`/`toneAboveS9`/`zones` quintet, or `null`
+   * when any one is absent or mistyped. See the file doc comment above.
    */
   readonly display: MeterDisplay | null;
 }
@@ -115,6 +117,13 @@ function annotate(descriptor: Record<string, unknown>): Record<string, string> {
   return out;
 }
 
+/** MOR-2255: a non-empty array of well-typed `{end, color}` bands. */
+function isZoneArray(value: unknown): value is readonly Zone[] {
+  return Array.isArray(value) && value.length > 0 && value.every((zone) =>
+    typeof zone === 'object' && zone !== null
+    && typeof (zone as Zone).end === 'number' && typeof (zone as Zone).color === 'string');
+}
+
 /**
  * Renders `fields` through the active language's renderer for `slot`.
  *
@@ -136,9 +145,11 @@ export function renderSlot(slot: RendererSlotName, fields: RendererFields): Rend
     attributes: annotate(descriptor),
     display: typeof descriptor.segmentCount === 'number' && typeof descriptor.segmentGapPx === 'number'
       && typeof descriptor.toneBelowS9 === 'string' && typeof descriptor.toneAboveS9 === 'string'
+      && isZoneArray(descriptor.zones)
       ? {
         segmentCount: descriptor.segmentCount, segmentGapPx: descriptor.segmentGapPx,
         toneBelowS9: descriptor.toneBelowS9, toneAboveS9: descriptor.toneAboveS9,
+        zones: descriptor.zones,
       }
       : null,
   };


### PR DESCRIPTION
## Summary

Linear: MOR-2255, Slice A only (each design language declaring its OWN distinct zone palette is a separate, deferred ticket — an aesthetic decision without a physical reference, not this PR's call to make)

`BarGauge.svelte` draws 5 of the remaining `METER_BARS` tiles (`power`/`alc`/`drainCurrent`/`drainVoltage`/`compression`). It has a `zones` prop, but its only real caller (`MetersSurface.svelte`) never passed it — every tile silently fell back to the component's own hardcoded `DEFAULT_ZONES` (3 static zones: green to 0.6, yellow to 0.8, red to 1.0). This PR wires it to the active design language, the same architecture MOR-2214/MOR-2250 used for the S-meter's tone — but this slice makes NO visual change: all three languages declare the exact same 3 zones `BarGauge` already draws today. The point is the mechanism, not a new look.

## What this PR does

- `contract.ts`: `MeterDisplay` gains a 5th required field, `zones: readonly Zone[]` (new `Zone{end, color}` interface, structurally identical to `bar-gauge-utils.ts`'s own `Zone` but re-declared rather than imported — no PRODUCTION file under `presentation/` imports from `components-v2/`, and the dependency runs the other way, so importing would invert it; two test files do cross that boundary, which doesn't bear on the production-code reasoning above).
- `design-language-renderers.ts`: `renderSlot()`'s all-or-nothing structural check widens 4→5 fields (`isZoneArray` requires a non-empty array — `getSegmentZone`'s fallback is the array's last entry, which an empty array can't supply).
- `studioline`/`fieldline`/`segmentline` renderers: each declares `zones` with the identical literal 3-value array matching today's `DEFAULT_ZONES` exactly.
- `MetersSurface.svelte`: the `display = renderSlot(...)` call (previously local to the S-meter's `{#if present(meters.signal)}` block) is hoisted to the component level so both the S-meter tile AND every `<BarGauge>` mount read the SAME single call — one `renderSlot` per render, never once per gauge. `<BarGauge>` gains `zones={display?.display?.zones}` — the real writer.
- `BarGauge.svelte`: `zones` prop keeps its `= DEFAULT_ZONES` default. This is NOT a leftover — it's the documented "no design language active" fallback, exactly parallel to `LinearSMeter`'s `display = DEFAULT_METER_DISPLAY`.
- `meter-display.ts`: `DEFAULT_METER_DISPLAY` gains `zones: DEFAULT_ZONES` (forced by the field becoming required; `LinearSMeter` reads none of it — same "no language" sentinel value `BarGauge`'s own default uses, so the two fallbacks can't disagree).

## The four places holding the identical 3-zone value

Per the coordinator's explicit requirement — these must not silently drift apart, and a test pins that they don't:
1. `studioline/meters-renderer.ts` → `STUDIOLINE_METER_ZONES`
2. `fieldline/meters-renderer.ts` → `FIELDLINE_METER_ZONES`
3. `segmentline/meters-renderer.ts` → `SEGMENTLINE_METER_ZONES`
4. `bar-gauge-utils.ts` → `DEFAULT_ZONES` (component fallback, unchanged)

`design-language-wiring.component.test.ts`'s `all three product languages declare exactly the DEFAULT_ZONES values` test asserts all three language constants `toEqual(DEFAULT_ZONES)`. The literal is duplicated three times rather than extracted into a shared constant — a deliberate coordinator ruling: these are language DATA declarations, not code, and each language declares its own.

## The discrimination problem, and how it's solved

Slice A intentionally makes the language-sourced zones EQUAL in value to the fallback. A naive test asserting `zones toEqual(DEFAULT_ZONES)` would pass whether the wiring works or every tile is still silently defaulting — it can't tell the two apart. Solved with technique **(b) — mutation, via a DOM-level probe**, not reference-identity: a test-only language (`zonedline`) declares a genuinely different palette (different length, different colors: `#0A0B0C`/`#FAFBFC` vs the product 3-zone set), and the test reads the actual hex `fill` attributes painted on every `BarGauge` tile's segment rects. Reference identity was rejected — it proves the prop received the right object, not that the palette reached the paint; reading the DOM proves both.

**Mutation-kill (the one that matters):** removing `zones={display?.display?.zones}` from the `<BarGauge>` mount (equivalent to passing `DEFAULT_ZONES` directly, since that literal *is* the prop's own default) — 5 of 47 tests in the touched files failed, one per `METER_BARS` field including `compression`. Reverted, `git diff` clean.

A second mutation-kill on the structural gate itself: widening `renderSlot`'s check back to accept a display without `zones` (or with `|| true`) — 1 test failed (`a descriptor with no zones, or empty zones, yields no display at all`). Reverted, clean.

## COMP field note

`compression`'s `BarGauge` tile never renders in any existing visual baseline (`fixtures/catalog.ts`'s `withMeters` deliberately leaves `compressorOn` unset, so the tile never appears in any capture). This PR's wiring test explicitly sets the compressor ON so all 5 `METER_BARS` tiles mount, including `compression`; no new visual fixture was added, per the coordinator's instruction. The tile's general rendering already has coverage in `MetersSurface.test.ts` — this PR's test is specifically the ONLY coverage for compression's zones-from-language wiring, not for the tile's existence.

## What this PR does NOT do

- No per-language zone palette (all three declare the literal SAME 3 values) — that's the deferred follow-up ticket.
- No visual change anywhere — `frontend/fixtures/approved-baselines/` is untouched, byte-for-byte, and a dedicated test (`renders the bar tiles byte-identically to the no-language fallback`, parametrized over all 3 product languages × 5 fields) pins that activating any product language changes not one segment fill.
- `bar-gauge-utils.ts` (`DEFAULT_ZONES`, `getSegmentZone`, `Zone`, and their existing unit tests) — untouched.

## Guardrails — at the hard file ceiling, not over it

10 files, +307/−20 = 327 changed lines (`git diff --numstat origin/main...HEAD`). AT the 10-file hard ceiling (not over — no exception needed), well under the 1000-line half. Over the 6-file soft threshold, justification: two of the ten (`meter-display.ts`, `LinearSMeter.display.test.ts`) are mechanical fallout from `zones` becoming a *required* `MeterDisplay` field — the tree does not typecheck without updating them, and they cannot be split into a follow-up PR without leaving this one in a broken intermediate state. The remaining eight are the wiring itself (contract, gate, 3 renderers, `BarGauge`, `MetersSurface`, the discrimination test file) — none lands coherently without the others.

- No ticket id in branch name (`codex/bargauge-zones`) — the commit subject does carry the `feat(MOR-2255):` prefix, per this repo's established commit-message convention (an earlier version of this line wrongly claimed the subject was clean too; corrected here).
- `bar-gauge-utils.ts` untouched — still generic, `DEFAULT_ZONES`/`getSegmentZone` unchanged.
- No baseline PNGs touched.

## Tests

- `design-language-wiring.component.test.ts`: existing per-language `renderSlot(...).display` checks extended to the 5-field shape; new `MOR-2255` describe block — DOM-level discrimination via the `zonedline` probe (parametrized over all 5 `METER_BARS` fields), byte-identical pin for all 3 product languages, the 4-value-agreement pin, the empty/missing-zones rejection pin, and a pin that `zones` never leaks into `data-dl-*` annotations.
- `LinearSMeter.display.test.ts`: 3 pre-existing `display` literals gain `zones: DEFAULT_ZONES` (type-only fallout — `LinearSMeter` reads none of it, assertions otherwise untouched).

## Gate results

- Local targeted run (`npx vitest run src/semantic src/components-v2/meters src/presentation/languages`): 74 files, 2118 tests, all passing (before and after each mutation-kill). `npx eslint` on all 10 touched files: silent. `npm run check`: 0 errors, 0 warnings.
- Verified independently (not just trusting the builder's report): read all 10 diffs myself, re-ran the same targeted suite myself (2118/2118), re-ran `npm run check` myself (0/0), confirmed no baseline PNGs are in the diff.
- CI: pending.

## Status

PASSED independent review at exact head `50f2fc0cb8063151679189468d83e1fa67867261`. CI green (`quick`, `visual`, `grep-gate`, `Update Agent Review Gate status`). Reviewer independently reproduced both load-bearing claims (byte-identical rendering across all three languages; the discrimination test genuinely discriminates, confirmed via 3 separate mutation-kills) rather than trusting the PR's own tests. Not merging — merge authority is with the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

