### PR TITLE
docs(release): take the pre-tag suite record from CI instead of a local full run

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,7 +31,9 @@ User-facing prompts in Russian. Commits / CHANGELOG / tags / release notes in En
 
 ## Step 2 — Pre-flight checks
 
-Match `publish.yml`'s `validate` job exactly so green pre-flight = green publish. Run sequentially. STOP on first failure.
+Pre-flight covers every gate in `publish.yml`'s `validate` job: frontend (2g),
+ruff (2d), mypy (2f), import-linter (2e), pytest (2h). Run sequentially. STOP on
+first failure.
 
 ```bash
 # 2a. Clean tree
@@ -46,8 +48,8 @@ git branch --show-current
 Not `main` → warn, ask confirmation.
 
 ```bash
-# 2c. Sync deps (all extras, MOR-1978: installs the same extras as
-# publish.yml's validate job, so 2h below is not narrower than release CI)
+# 2c. Sync deps (all extras, MOR-1978: the same set publish.yml's
+# validate job installs)
 uv sync --all-extras
 ```
 
@@ -77,9 +79,47 @@ npm run build
 cd ..
 ```
 
+### 2h. Python tests — read the record, do not run the suite
+
+The suite record for a head is that head's `quick.yml` run, and the full suite
+is not run on the laptop or the remote testbed for a head CI has run (CLAUDE.md
+§Testing, §Agent working rules). 2a requires a clean tree and 2b expects
+`main`, so the head being released is `main`'s current head and its run is the
+one `quick.yml`'s `push: branches: [main]` trigger produced. A bump prepared on
+a branch reads that branch's PR run instead — `quick.yml` triggers on
+`pull_request: branches: [main]` too.
+
 ```bash
-# 2h. Python tests
-uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread
+gh run list --workflow "Tests (quick)" --branch main --limit 5
+gh run view <id>
+```
+
+The `Run tests` step must be green, not skipped: `quick.yml` gates it on
+`steps.filter.outputs.core`, so a run whose `core` filter did not match is
+green with no suite result. Then confirm that run's commit still covers HEAD —
+the `core` filter's own paths:
+
+```bash
+git diff --name-only <run-sha>..HEAD -- src tests frontend rigs contracts \
+  pyproject.toml uv.lock .importlinter .github/scripts .github/workflows
+```
+
+Non-empty output → that run is not the record for this head. Stop and get a run
+at the head being released.
+
+**Interpreter matrix before the tag.** `quick.yml` pins `UV_PYTHON: "3.11"`.
+`publish.yml`'s `validate` matrix is `["3.12", "3.13"]` — 3.11 is dropped there
+(see the comment on that matrix) — and it runs on `release: published`, so it
+first reports after the tag and the GitHub Release exist. Its failure does stop
+PyPI: `build` needs `validate` and `publish` needs `build`. What it cannot undo
+is the tag and the Release, which is the last block of Error recovery below. So
+dispatching `full.yml`'s 3.11/3.12/3.13 matrix before tagging is a safety net,
+not redundant coverage — it moves a 3.12/3.13 failure to before the tag exists:
+
+```bash
+gh workflow run "Tests (full matrix)" --ref main
+gh run list --workflow "Tests (full matrix)" --limit 3   # find the dispatched run
+gh run watch <id>
 ```
 
 ```bash
@@ -252,5 +292,5 @@ git revert HEAD  # or git push --force-with-lease (dangerous; ask first)
 ## Notes for the operator
 
 - This skill replaces the old global `Release icom-lan` slash command (`.claude/commands/release.md`), which had stale references to `src/icom_lan/__init__.py` (a shim, never canonical), `RELEASE_NOTES.md` (no longer used), `CLAUDE.md` Version row (no longer exists), and root `CHANGELOG.md` (symlink — must edit `docs/CHANGELOG.md`).
-- Match `publish.yml`'s `validate` job exactly. If CI's validate gate changes, update Step 2.
+- If `publish.yml`'s `validate` gate changes, update Step 2.
 - For Pro releases (Tauri shell), use the `release` skill in `rigplane-pro` (different beast — single-tag-then-handoff to operator's Mac terminal, not single-shot publish).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -84,28 +84,37 @@ cd ..
 The suite record for a head is that head's `quick.yml` run, and the full suite
 is not run on the laptop or the remote testbed for a head CI has run (CLAUDE.md
 §Testing, §Agent working rules). 2a requires a clean tree and 2b expects
-`main`, so the head being released is `main`'s current head and its run is the
+`main`, so the head under test here is `main`'s current HEAD, and its run is the
 one `quick.yml`'s `push: branches: [main]` trigger produced. A bump prepared on
 a branch reads that branch's PR run instead — `quick.yml` triggers on
 `pull_request: branches: [main]` too.
 
 ```bash
-gh run list --workflow "Tests (quick)" --branch main --limit 5
-gh run view <id>
+gh run list --workflow "Tests (quick)" --branch main --limit 5 \
+  --json databaseId,headSha,conclusion,createdAt
+gh run view <id> --json jobs \
+  --jq '.jobs[].steps[] | select(.name=="Run tests") | .conclusion'
 ```
 
-The `Run tests` step must be green, not skipped: `quick.yml` gates it on
-`steps.filter.outputs.core`, so a run whose `core` filter did not match is
-green with no suite result. Then confirm that run's commit still covers HEAD —
-the `core` filter's own paths:
+The second command must print `success`. `quick.yml` gates `Run tests` on
+`steps.filter.outputs.core`, so on a run whose `core` filter did not match it
+prints `skipped` while the run's own conclusion is still `success` — the run's
+conclusion is not the suite's. Then confirm that run's commit still covers HEAD
+— the `core` filter's own paths:
 
 ```bash
 git diff --name-only <run-sha>..HEAD -- src tests frontend rigs contracts \
   pyproject.toml uv.lock .importlinter .github/scripts .github/workflows
 ```
 
-Non-empty output → that run is not the record for this head. Stop and get a run
-at the head being released.
+Non-empty output → that run is not the record for HEAD. Stop and get a run at
+HEAD.
+
+The check is against HEAD, not against the commit that gets tagged: Step 6
+commits the Step 5 edits on top of HEAD, so the released commit is HEAD plus a
+`pyproject.toml` version line and a `docs/CHANGELOG.md` entry. `pyproject.toml`
+is in the pathspec above, so that commit is a different head, with its own
+`quick` run when it lands.
 
 **Interpreter matrix before the tag.** `quick.yml` pins `UV_PYTHON: "3.11"`.
 `publish.yml`'s `validate` matrix is `["3.12", "3.13"]` — 3.11 is dropped there
@@ -128,7 +137,9 @@ uv build && rm -rf dist/
 ```
 
 ```bash
-# 2j. Optional regression check (.claude/commands/regression-check.md)
+# 2j. Optional regression check (.claude/commands/regression-check.md).
+# Its step 1 reads "the run on its draft PR", which a release cut from
+# `main` does not have; 2h above is the record in that case.
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

`.claude/skills/release/SKILL.md` step 2h was an imperative local full-suite run
(`uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread`).
Since #3077, CLAUDE.md makes the suite record for a head that head's `quick.yml`
run and forbids the full suite on the laptop or the remote testbed for a head CI
has run. 2h now reads that run, and gives the pre-tag matrix dispatch as an
explicit option.

Linear: MOR-2272

## What the pre-edit reading established

Read at this head: the whole release skill, `docs/internals/github-project-workflow.md`,
and `.github/workflows/{quick,full,publish}.yml`.

**The release flow opens no version-bump PR of its own.** Step 5 edits
`pyproject.toml` and `docs/CHANGELOG.md`; Step 6 commits (`chore(release): bump
to NEW`) and tags; Step 7 pushes with `git push --follow-tags`. There is no
`gh pr create` anywhere in the skill, so no PR-triggered `quick` run is created
by the flow itself. Two things follow, and 2h is written on them:

- Pre-flight (Step 2) runs before the bump commit exists, on a tree that 2a
  requires clean and 2b expects to be `main`. So the head 2h tests is `main`'s
  current HEAD, and `quick.yml`'s `push: branches: [main]` trigger is what
  produced its run. 2h names that run, and names the branch-PR case
  (`pull_request: branches: [main]`) as the alternative rather than assuming it.
  It is *not* the commit that gets tagged: Step 6 stages `pyproject.toml` and
  `docs/CHANGELOG.md` on top of HEAD, so the released commit is HEAD+1 and is a
  different head with its own `quick` run. (Corrected at 19799b70 — the first
  push said "the head being released is `main`'s current head", which is false
  and made 2h's stop-criterion unsatisfiable, since `pyproject.toml` is inside
  the `core` pathspec 2h quotes.)
- `quick.yml`'s `Run tests` step is gated on `steps.filter.outputs.core`, so a
  run whose `core` filter did not match is `skipped` while the run's own
  conclusion is still `success`. 2h therefore reads the step conclusion, not
  the run's, and then confirms the run's commit still covers HEAD across the
  `core` filter's own path list. Both commands verified against live runs:

  ```
  $ gh run view 33713470857 --json jobs \
      --jq '.jobs[].steps[] | select(.name=="Run tests") | .conclusion'
  skipped     # the #3077 merge (1989959b) — no core path changed
  $ gh run view 33713028333 --json jobs \
      --jq '.jobs[].steps[] | select(.name=="Run tests") | .conclusion'
  success     # a6ab594d (#3075) — src/ changed
  ```

  `gh run list --workflow "Tests (quick)" --branch main --limit 5 --json
  databaseId,headSha,conclusion,createdAt` reports 33713470857's conclusion as
  `success`, which is exactly the run-level green that misleads. (Corrected at
  19799b70 — the first push used a bare `gh run view <id>`, which prints jobs
  only and cannot distinguish the two.)

**`publish.yml`'s `validate` job does not run the 3.11/3.12/3.13 matrix.** Its
matrix is `["3.12", "3.13"]`; the comment above it records 3.11 being dropped on
2026-05-05. It triggers on `release: published`, so it first reports after the
tag and the GitHub Release exist. `build` needs `validate` and `publish` needs
`build`, so a red validate does stop PyPI — but not the tag and Release, whose
removal is this skill's last Error-recovery block. A pre-tag
`gh workflow run "Tests (full matrix)"` (`full.yml`, matrix 3.11/3.12/3.13,
`workflow_dispatch`) is therefore a **safety net, not redundant**: it moves a
3.12/3.13 failure to before the tag exists. 2h says exactly that.

`docs/internals/github-project-workflow.md` adds no release-specific PR step; it
states the general protected-`main`, PR, verifier and exact-head gate rules.

## Sentences deleted rather than corrected

- Step 2 header: "Match `publish.yml`'s `validate` job exactly so green
  pre-flight = green publish." Replaced by the gate-to-step mapping actually
  read off `validate`'s steps (frontend → 2g, ruff → 2d, mypy → 2f,
  import-linter → 2e, pytest → 2h).
- Operator notes: "Match `publish.yml`'s `validate` job exactly." Removed; the
  actionable half ("If `publish.yml`'s `validate` gate changes, update Step 2")
  stays.
- 2c comment clause "so 2h below is not narrower than release CI" — false once
  2h stops running the suite. The remaining claim is `publish.yml`'s own
  `uv sync --all-extras`.

## Checks

`.github/scripts/check-doc-citations.sh --check-links` → exit 0
("clean (2 grandfathered dead link(s), repo-wide *.md scope)").
`.github/scripts/check-doc-citations.sh` → exit 0.

```
$ git grep -n "pytest tests/" -- .claude/ CLAUDE.md AGENTS.md
CLAUDE.md:11:uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread  # the suite quick.yml runs (it omits -q); locally, for single files
CLAUDE.md:12:uv run pytest tests/ -q --tb=short                    # serial, incl. integration hooks (profiling/hardware only)

$ git grep -nE "before push|full test suite|full suite" -- .claude/skills/release/
.claude/skills/release/SKILL.md:84:The suite record for a head is that head's `quick.yml` run, and the full suite
```

2j's comment also records that `regression-check.md` step 1 reads "the run on
its draft PR", which a release cut from `main` does not have (folded in at
19799b70).

No `pytest tests/` invocation remains under `.claude/`. Sweeping the class with
`git grep -n "uv run pytest" -- .claude/` leaves three targeted invocations —
`agents/verifier.md:37`, `commands/generate-tests.md:33`, `commands/refactor.md:54`
— all single-file or explicit-path runs, which CLAUDE.md §Agent working rules
permits ("Single test files may run locally; the full suite may not").
One instance left unfixed and outside this change's scope: `CLAUDE.md:12`
(`uv run pytest tests/ -q --tb=short`) is a whole-suite invocation whose comment
scopes it to "profiling/hardware only" but does not carry the
single-files-only caveat that #3077 added to line 11.

No test suite was run for this change (docs only, and the suite record rule this
PR is implementing forbids a local full run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

