### PR TITLE
refactor: delete the dead viewport/topology half of the layouts contract

### DIFF
--- a/frontend/src/presentation/layouts/__tests__/cockpit-responsive-composition.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-responsive-composition.test.ts
@@ -110,13 +110,7 @@ describe('the declared reflow breakpoints and the shell agree, in both direction
 });
 
 describe('portrait-mobile ruling: STACK, not exclude', () => {
-  // The ruling, pinned at the manifest end. A fluid layout has no arithmetic
-  // exclusion from a portrait phone the way a fixed-native one does, and the
-  // two ways to build one back (a viewport consumer of the frozen sizing
-  // field, or a second mobile behavior state machine) are both banned. Kills:
-  // repurposing `fallbackLayoutId` as a viewport escape hatch, which would
-  // also silently break MOR-1068's frozen topology table.
-  it('stays fluid, and keeps a TOPOLOGY fallback rather than a viewport one', () => {
+  it('stays fluid and keeps its fallback', () => {
     expect(dualReceiverCockpitLayout.stageSizing.mode).toBe('fluid');
     expect(dualReceiverCockpitLayout.fallbackLayoutId).toBe('sdr-test');
   });

--- a/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cockpit-topology-adaptation.test.ts
@@ -1,23 +1,13 @@
 /**
- * MOR-1068 — the dual-receiver cockpit's ADAPTATION POLICY across all four
- * canonical topology pairs, resolved through the REAL registry (MOR-1066),
- * plus the two gaps the MOR-1067 adversarial verification handed to this
- * ticket: F8 (SkinId reachability) and the fixture-level survival of
+ * MOR-1068 — the two gaps the MOR-1067 adversarial verification handed to
+ * this ticket: F8 (SkinId reachability) and the fixture-level survival of
  * `scope=false + audioFft=true` as operational audio-scope availability.
- *
- * The DOM half of the policy (what the shell actually renders, and the F6
- * manifest-zone <-> DOM binding) lives in
- * `skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component.test.ts`
- * — that tree needs the isolated jsdom pool; this file is pure.
  *
  * Each test's doc line names the mutation it exists to kill.
  */
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import {
-  getLayout, resolveLayoutForTopology, supportsTopology,
-  TOPOLOGY_CLASSES, type LayoutManifest, type TopologyClass,
-} from '../contract';
+import { getLayout, type LayoutManifest } from '../contract';
 // Barrel-only import, never '../dual-receiver-cockpit' — a direct manifest
 // import would fire `registerLayout` from this test file, masking a
 // `declarations.ts` that no longer wires the cockpit into the app, and under
@@ -41,51 +31,7 @@ import { isLayoutManifest } from './manifest-guard';
 import { forReceiver, receiversOf } from '../../../components-v2/wiring/dual-receiver-strips';
 import { topologyFixtures, withAudioOnlyScope } from '../../../semantic/fixtures/topologies';
 
-/**
- * The frozen policy table. Column 3 is what `compatibleTopologies` must say;
- * column 2 is what a consumer asking for the cockpit ACTUALLY gets. The two
- * single-receiver pairs degrade by resolution (one validated hop to the
- * all-topology `sdr-test`), never by mounting a cockpit whose second strip
- * has nothing to put in it.
- */
-const POLICY: readonly (readonly [TopologyClass, string, boolean])[] = [
-  ['1/single', 'sdr-test', false],
-  ['1/ab', 'sdr-test', false],
-  ['2/ab_shared', 'dual-receiver-cockpit', true],
-  ['2/main_sub', 'dual-receiver-cockpit', true],
-];
-
 const FIXTURE_IDS = ['1/single', '1/ab', '2/ab_shared', '2/main_sub'] as const;
-
-describe('the four-pair adaptation policy, through the real registry', () => {
-  // Kills: widening compatibleTopologies to a single-receiver pair (the
-  // cockpit would then mount with an empty second strip), or narrowing it
-  // away from a dual pair (a real dual-receiver radio would silently lose
-  // the layout built for it — the MOR-1067 F1 mirror: live presenting as
-  // absent).
-  it.each(POLICY)('%s resolves to "%s" (declared-compatible: %s)', (topology, expectedId, mounts) => {
-    expect(supportsTopology(dualReceiverCockpitLayout, topology)).toBe(mounts);
-    expect(resolveLayoutForTopology('dual-receiver-cockpit', topology)?.id).toBe(expectedId);
-  });
-
-  // Kills: dropping `fallbackLayoutId`, or pointing it at a layout that does
-  // not itself cover the refused pairs — resolution would return undefined
-  // and a single-receiver radio would get NO layout at all.
-  it('leaves no canonical topology unresolvable', () => {
-    for (const topology of TOPOLOGY_CLASSES) {
-      expect(resolveLayoutForTopology('dual-receiver-cockpit', topology)).toBeDefined();
-    }
-  });
-
-  // Kills: a fallback that is decoration rather than policy. Whatever the
-  // cockpit refuses, the declared fallback must actually support.
-  it('the declared fallback covers exactly the pairs the cockpit refuses', () => {
-    const refused = TOPOLOGY_CLASSES.filter((t) => !supportsTopology(dualReceiverCockpitLayout, t));
-    expect(refused).toEqual(['1/single', '1/ab']);
-    expect(dualReceiverCockpitLayout.fallbackLayoutId).toBe('sdr-test');
-    for (const topology of refused) expect(supportsTopology(sdrTestLayout, topology)).toBe(true);
-  });
-});
 
 describe('degrade honesty: the strip slicing never invents a receiver', () => {
   // Kills: hardcoding two strips. Read against all four approved fixtures,

--- a/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/desktop-v2-registration.test.ts
@@ -10,10 +10,7 @@
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import {
-  declaredSurfaces, getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
-  TOPOLOGY_CLASSES,
-} from '../contract';
+import { declaredSurfaces, getLayout } from '../contract';
 // Barrel-only, never '../desktop-declarations' directly — the M7 lesson
 // (registry.test.ts's "dual-receiver-cockpit registration barrel proof",
 // restated on every family since): a direct manifest import fires
@@ -21,9 +18,6 @@ import {
 // longer wires desktop-v2 into the app, and under the fast pool's
 // `isolate: false` it would leak the registration into sibling files.
 import { desktopV2Layout } from '../declarations';
-
-/** iPhone-class portrait — the viewport the LCD family fails arithmetically. */
-const PORTRAIT_MOBILE = { width: 390, height: 844 };
 
 describe('the desktop-v2 entrypoint is registered in the real registry', () => {
   // Kills: desktop-declarations.ts defining the manifest but never calling
@@ -137,16 +131,6 @@ describe('loader identity — pins the real desktop-v2 entrypoint (verify.md N1)
   });
 });
 
-describe('topology honesty', () => {
-  // Kills: under-declaring the topology set. VfoHeader renders VfoOps
-  // (A/B swap/equal) unconditionally and branches DualVfoDisplay vs a
-  // single-receiver VfoPanel on hasDualReceiver(), so every canonical class
-  // resolves to desktop-v2 itself, never to a fallback (it declares none).
-  it.each(TOPOLOGY_CLASSES)('resolves itself on the %s topology', (topology) => {
-    expect(resolveLayoutForTopology('desktop-v2', topology)?.id).toBe('desktop-v2');
-  });
-});
-
 describe('MOR-1160 sizing axis — desktop-v2 stays fluid, mirroring sdr-test', () => {
   // Kills: silently switching desktop-v2 onto the fixed-native stage the LCD
   // family owns, or recording a breakpoint set that disagrees with
@@ -154,23 +138,11 @@ describe('MOR-1160 sizing axis — desktop-v2 stays fluid, mirroring sdr-test', 
   it('declares fluid sizing with no breakpoints', () => {
     expect(desktopV2Layout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
   });
-
-  // Kills: fitsViewport gating a fluid layout on a breakpoint instead of
-  // always fitting (contract: breakpoints are reflow hints, not a hard gate
-  // in v1).
-  it.each([
-    ['desktop', { width: 1440, height: 900 }],
-    ['portrait phone', PORTRAIT_MOBILE],
-  ])('resolves itself on a %s viewport', (_label, viewport) => {
-    expect(resolveLayoutForViewport('desktop-v2', viewport)?.id).toBe('desktop-v2');
-  });
 });
 
 describe('no fallback family', () => {
   // Kills: adding a fallbackLayoutId that has nothing to do — desktop-v2
-  // supports every canonical topology and fluid sizing never fails a
-  // viewport, so any hop off it would be unreachable and would only mask a
-  // real resolution failure.
+  // declares every canonical topology and fluid sizing.
   it('declares no fallback', () => {
     expect(desktopV2Layout.fallbackLayoutId).toBeNull();
   });

--- a/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dual-receiver-cockpit.test.ts
@@ -1,19 +1,15 @@
 /**
  * MOR-1067 — the dual-receiver-cockpit manifest, exercised through the REAL
- * registry (not a fixture stand-in): registration shape, topology gating
- * (single-receiver topologies must fall back, never mount the cockpit), and
- * the MOR-1160 chrome-fluid sizing axis. Each test's doc line names the
- * mutation it exists to kill.
+ * registry (not a fixture stand-in): registration shape. Each test's doc line
+ * names the mutation it exists to kill.
  */
 import { describe, it, expect } from 'vitest';
-import { fitsViewport, getLayout, resolveLayoutForTopology, resolveLayoutForViewport } from '../contract';
+import { getLayout } from '../contract';
 // The manifest comes through the BARREL, never from '../dual-receiver-cockpit'
 // directly. A direct import would fire `registerLayout` from inside this test
 // file and mask a `declarations.ts` that no longer wires the cockpit into the
 // app at all — and under the fast pool's `isolate: false` it would leak that
-// registration into sibling test files too (the MOR-1092 lesson). Importing
-// the barrel also registers 'sdr-test', this manifest's fallbackLayoutId
-// target, which the fallback tests below need.
+// registration into sibling test files too (the MOR-1092 lesson).
 import { dualReceiverCockpitLayout } from '../declarations';
 
 describe('the dual-receiver-cockpit real registration', () => {
@@ -39,40 +35,5 @@ describe('the dual-receiver-cockpit real registration', () => {
 
   it('has a compiled Svelte loader', async () => {
     expect(typeof dualReceiverCockpitLayout.loader).toBe('function');
-  });
-});
-
-describe('topology gating (manifest topology classes + fallback resolution)', () => {
-  // Kills: compatibleTopologies including a single-receiver class, or the
-  // manifest omitting a safe fallback — either way a single-receiver radio
-  // would end up mounting a shell with an empty/fabricated second strip.
-  it.each(['1/single', '1/ab'] as const)(
-    'does NOT mount for single-receiver topology "%s" — falls back to sdr-test instead',
-    (topology) => {
-      const resolved = resolveLayoutForTopology('dual-receiver-cockpit', topology);
-      expect(resolved?.id).not.toBe('dual-receiver-cockpit');
-      expect(resolved?.id).toBe('sdr-test');
-    },
-  );
-
-  it.each(['2/ab_shared', '2/main_sub'] as const)(
-    'mounts for its declared dual-receiver topology "%s"',
-    (topology) => {
-      expect(resolveLayoutForTopology('dual-receiver-cockpit', topology)?.id).toBe('dual-receiver-cockpit');
-    },
-  );
-});
-
-describe('MOR-1160 sizing axis: chrome stays fluid', () => {
-  // This shell composes only VFO/RX-TX status text today — no fixed-native
-  // instrument glass — so it must fit any viewport, unlike a fixed-native
-  // layout that fails below minScale.
-  it('fits an arbitrarily small viewport (fluid never gates on viewport)', () => {
-    expect(fitsViewport(dualReceiverCockpitLayout, { width: 1, height: 1 })).toBe(true);
-  });
-
-  it('resolveLayoutForViewport returns the cockpit itself, never a fallback, at any size', () => {
-    expect(resolveLayoutForViewport('dual-receiver-cockpit', { width: 1, height: 1 })?.id)
-      .toBe('dual-receiver-cockpit');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/lcd-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/lcd-registration.test.ts
@@ -4,18 +4,15 @@
  * fixture registry and not a stub loader.
  *
  * What this file is for: the manifest is the only place the LCD entrypoints
- * declare their identity, the semantic zones they mount, the topologies they
- * survive, and the MOR-1160 sizing axis. Every claim below is read back out
+ * declare their identity, the semantic zones they mount and the MOR-1160
+ * sizing axis. Every claim below is read back out
  * of the shared registry rather than off the exported object, so a manifest
  * that is written but never registered fails here. Each test's doc line names
  * the mutation it exists to kill.
  */
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import {
-  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
-  TOPOLOGY_CLASSES, type LayoutManifest,
-} from '../contract';
+import { getLayout, type LayoutManifest } from '../contract';
 // Deliberately through the shared aggregation entry, not `../lcd-declarations`
 // directly: it pins that `declarations.ts` really pulls the LCD family in
 // (nothing else does), and it keeps this fast-pool file on the SAME module
@@ -29,9 +26,6 @@ const LCD_LAYOUTS: readonly (readonly [string, LayoutManifest])[] = [
   ['lcd-cockpit', lcdCockpitLayout],
   ['lcd-scope', lcdScopeLayout],
 ];
-
-/** iPhone-class portrait: min(390/1280, 844/540) ≈ 0.30, below minScale. */
-const PORTRAIT_MOBILE = { width: 390, height: 844 };
 
 describe('the LCD entrypoints are registered in the real registry', () => {
   // Kills: lcd-declarations.ts defining the manifests but never calling
@@ -72,17 +66,6 @@ describe('declared semantic zones (what the migrated LCD actually mounts)', () =
   });
 });
 
-describe('topology honesty', () => {
-  // Kills: under-declaring the topology set. Both LCD variants render VFO A
-  // unconditionally and gate the second receiver on `hasDualReceiver`, so
-  // every canonical class resolves to the layout itself, never to a fallback.
-  it.each(LCD_LAYOUTS)('"%s" resolves itself on all four canonical topologies', (id, _manifest) => {
-    for (const topology of TOPOLOGY_CLASSES) {
-      expect(resolveLayoutForTopology(id, topology)?.id).toBe(id);
-    }
-  });
-});
-
 describe('MOR-1160 sizing axis — the LCD is the fixed-native archetype', () => {
   // Kills: leaving the LCD on `fluid`, or drifting off the native stage size
   // MOR-1160 froze for the incoming LCD directions (1280x540).
@@ -90,18 +73,6 @@ describe('MOR-1160 sizing axis — the LCD is the fixed-native archetype', () =>
     expect(manifest.stageSizing).toEqual({
       mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
     });
-  });
-
-  it.each(LCD_LAYOUTS)('"%s" resolves on a desktop viewport', (id) => {
-    expect(resolveLayoutForViewport(id, { width: 1440, height: 900 })?.id).toBe(id);
-    expect(resolveLayoutForViewport(id, { width: 1280, height: 540 })?.id).toBe(id);
-  });
-
-  // Kills: minScale set to 0 (or the mode flipped to fluid), which would let
-  // a fixed-native LCD resolve on portrait mobile. MOR-1160 constraint 4:
-  // the exclusion is arithmetic, never a mobile-detection branch.
-  it.each(LCD_LAYOUTS)('"%s" is excluded from portrait mobile arithmetically', (id) => {
-    expect(resolveLayoutForViewport(id, PORTRAIT_MOBILE)).toBeUndefined();
   });
 });
 
@@ -113,20 +84,5 @@ describe('fallback behaviour inside the LCD family', () => {
     expect(lcdScopeLayout.fallbackLayoutId).toBe('lcd-cockpit');
     expect(lcdCockpitLayout.fallbackLayoutId).toBeNull();
     expect(getLayout(lcdScopeLayout.fallbackLayoutId!)).toBe(lcdCockpitLayout);
-  });
-
-  // Kills: returning the fallback without re-applying the criterion (the
-  // MOR-1066 F1 bug), applied to the real LCD pair. Both variants share one
-  // native stage, so a viewport that fails the scope variant fails the
-  // cockpit too — resolution must report "unresolvable", not hand back a
-  // sibling that fails the same gate.
-  it('does not hand back the cockpit for a viewport that fails it too', () => {
-    expect(resolveLayoutForViewport('lcd-scope', PORTRAIT_MOBILE)).toBeUndefined();
-  });
-
-  // The fallback is a real hop, not decoration: it resolves when the
-  // criterion is satisfiable.
-  it('resolves the scope variant itself while the viewport fits', () => {
-    expect(resolveLayoutForViewport('lcd-scope', { width: 1440, height: 900 })?.id).toBe('lcd-scope');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
@@ -62,15 +62,12 @@ describe('declared semantic zone (what the migrated mobile shell mounts)', () =>
 });
 
 describe('MOR-1160 sizing axis — mobile is the fluid side', () => {
-  // Kills: declaring mobile `fixed-native`. Mobile chrome reflows; it is not
-  // an instrument stage scaled as one letterboxed block, and a native stage
-  // here would make the phone shell fail its own minScale gate.
+  // Kills: declaring mobile `fixed-native`.
   it('declares fluid sizing with the one breakpoint the layout implements', () => {
     expect(mobileLayout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [500] });
   });
 
-  // Kills: giving mobile a fallback it does not need. Mobile declares fluid
-  // sizing, so it has no viewport gate to fail.
+  // Kills: giving mobile a fallback it does not need.
   it('declares no fallback', () => {
     expect(mobileLayout.fallbackLayoutId).toBeNull();
   });

--- a/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/mobile-registration.test.ts
@@ -4,33 +4,23 @@
  * MOR-1092 LCD registration proof.
  *
  * What this file is for: the manifest is the only place the mobile entrypoint
- * declares its identity, the semantic zone it mounts, the topologies it
- * survives, and its MOR-1160 sizing assignment. Mobile is the FLUID side of
- * that axis — the counterpart to the LCD's fixed-native stage — and it is the
- * one layout a portrait phone can always resolve, which is what makes it the
- * only viable destination for a fixed-native layout's fallback hop off that
- * viewport. Every claim below is read back out of the shared registry rather
- * than off the exported object, so a manifest that is written but never
- * registered fails here. Each test's doc line names the mutation it kills.
+ * declares its identity, the semantic zone it mounts and its MOR-1160 sizing
+ * assignment. Mobile is the FLUID side of that axis — the counterpart to the
+ * LCD's fixed-native stage. Every claim below is read back out of the shared
+ * registry rather than off the exported object, so a manifest that is written
+ * but never registered fails here. Each test's doc line names the mutation it
+ * kills.
  */
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import {
-  getLayout, registerLayout, resolveLayoutForTopology, resolveLayoutForViewport,
-  fitsViewport, TOPOLOGY_CLASSES, type LayoutManifest,
-} from '../contract';
+import { getLayout } from '../contract';
 // Deliberately through the shared aggregation entry, not `../mobile-declarations`
 // directly: it pins that `declarations.ts` really pulls the mobile family in
 // (nothing else does), and it keeps this fast-pool file on the SAME module
 // entry point as `registry.test.ts` / `lcd-registration.test.ts` — under
 // `isolate: false` a second entry into a module that registers at import time
 // is how a split module graph (and a phantom "layout not registered") happens.
-import { mobileLayout, lcdCockpitLayout, lcdScopeLayout } from '../declarations';
-
-/** iPhone-class portrait — the viewport the LCD family fails arithmetically. */
-const PORTRAIT_MOBILE = { width: 390, height: 844 };
-/** The same handset rotated: what `isLandscape` in MobileRadioLayout sees. */
-const LANDSCAPE_MOBILE = { width: 844, height: 390 };
+import { mobileLayout } from '../declarations';
 
 describe('the mobile entrypoint is registered in the real registry', () => {
   // Kills: mobile-declarations.ts defining the manifest but never calling
@@ -71,16 +61,6 @@ describe('declared semantic zone (what the migrated mobile shell mounts)', () =>
   });
 });
 
-describe('topology honesty', () => {
-  // Kills: under-declaring the topology set. The mobile shell renders VFO A
-  // unconditionally and gates the MAIN/SUB receiver selector and the SUB
-  // readout on `hasDualReceiver`, so every canonical class resolves to the
-  // layout itself, never to a fallback.
-  it.each(TOPOLOGY_CLASSES)('resolves itself on the %s topology', (topology) => {
-    expect(resolveLayoutForTopology('mobile', topology)?.id).toBe('mobile');
-  });
-});
-
 describe('MOR-1160 sizing axis — mobile is the fluid side', () => {
   // Kills: declaring mobile `fixed-native`. Mobile chrome reflows; it is not
   // an instrument stage scaled as one letterboxed block, and a native stage
@@ -89,73 +69,9 @@ describe('MOR-1160 sizing axis — mobile is the fluid side', () => {
     expect(mobileLayout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [500] });
   });
 
-  // Kills: flipping mobile to a mode with a viewport gate. `fluid` always
-  // fits (contract: breakpoints are reflow hints, not a hard gate in v1), and
-  // that is precisely why mobile is resolvable where the LCD stage is not.
-  it.each([
-    ['portrait phone', PORTRAIT_MOBILE],
-    ['landscape phone', LANDSCAPE_MOBILE],
-    ['desktop', { width: 1440, height: 900 }],
-  ])('resolves itself on a %s viewport', (_label, viewport) => {
-    expect(fitsViewport(mobileLayout, viewport)).toBe(true);
-    expect(resolveLayoutForViewport('mobile', viewport)?.id).toBe('mobile');
-  });
-
-  // Kills: giving mobile a fallback it does not need. Mobile is the terminal
-  // destination — it fits every viewport, so a hop off it is unreachable code
-  // and a hop TO somewhere else would hide a real resolution failure.
-  it('declares no fallback, because it never fails a viewport', () => {
+  // Kills: giving mobile a fallback it does not need. Mobile declares fluid
+  // sizing, so it has no viewport gate to fail.
+  it('declares no fallback', () => {
     expect(mobileLayout.fallbackLayoutId).toBeNull();
-  });
-});
-
-describe('portrait-mobile exclusion of fixed-native layouts, and the hop off it', () => {
-  // The exclusion case this fallback machinery exists for, asserted read-only
-  // against the LCD family (MOR-1092 owns those manifests). An iPhone-class
-  // 390x844 achieves min(390/1280, 844/540) ~= 0.30 against minScale 0.5.
-  it.each([
-    ['lcd-cockpit', lcdCockpitLayout],
-    ['lcd-scope', lcdScopeLayout],
-  ])('excludes fixed-native "%s" from portrait mobile while mobile fits', (_id, manifest) => {
-    expect(fitsViewport(manifest, PORTRAIT_MOBILE)).toBe(false);
-    expect(fitsViewport(mobileLayout, PORTRAIT_MOBILE)).toBe(true);
-  });
-
-  // The LCD family names only its own sibling, which shares the same native
-  // stage — so it correctly dead-ends at `undefined` rather than handing back
-  // a layout that fails the same gate (MOR-1066 review cycle 1, F1). Pinned
-  // here so registering a fluid `mobile` alongside it cannot be mistaken for
-  // having silently changed LCD resolution.
-  it('leaves the LCD family unresolvable on portrait mobile (no LCD fallback rewiring)', () => {
-    expect(resolveLayoutForViewport('lcd-scope', PORTRAIT_MOBILE)).toBeUndefined();
-    expect(resolveLayoutForViewport('lcd-cockpit', PORTRAIT_MOBILE)).toBeUndefined();
-  });
-
-  // Kills: the registration that looks right but cannot actually terminate a
-  // hop — a `mobile` manifest that itself failed the viewport, or a validator
-  // that returned the fallback WITHOUT re-applying the criterion. Registering
-  // a probe is the count-agnostic idiom `registry.test.ts` already uses.
-  it('is a viable fallback destination: a fixed-native layout hops to it off portrait mobile', () => {
-    const probe: LayoutManifest = {
-      schemaVersion: 1,
-      id: 'mobile-hop-probe',
-      displayName: 'Mobile Hop Probe',
-      loader: mobileLayout.loader,
-      zones: [{ id: 'main', surfaces: ['vfo', 'rxTx'] }],
-      compatibleTopologies: ['1/single'],
-      requiredSemanticSurfaces: ['vfo', 'rxTx'],
-      stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
-      fallbackLayoutId: 'mobile',
-    };
-    registerLayout(probe);
-
-    // Fails its own gate on the phone, and the ONE validated hop lands on
-    // mobile — which passes the same criterion it was fetched to satisfy.
-    expect(fitsViewport(probe, PORTRAIT_MOBILE)).toBe(false);
-    expect(resolveLayoutForViewport('mobile-hop-probe', PORTRAIT_MOBILE)?.id).toBe('mobile');
-    // On a viewport it fits, the probe still resolves to itself — the hop is
-    // a fallback, not an unconditional redirect to mobile.
-    expect(resolveLayoutForViewport('mobile-hop-probe', { width: 1440, height: 900 })?.id)
-      .toBe('mobile-hop-probe');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -1,14 +1,12 @@
 /**
  * MOR-1066 compiled registry: count-agnostic registration, lookup by id,
- * duplicate-ID rejection, missing-loader rejection, the sdr-test real
- * registration proof, topology fallback resolution, and MOR-1160 viewport
- * (fixed-native/minScale) fallback resolution. Each test's doc line names
- * the mutation it exists to kill.
+ * duplicate-ID rejection, missing-loader rejection and the sdr-test real
+ * registration proof. Each test's doc line names the mutation it exists to
+ * kill.
  */
 import { describe, it, expect } from 'vitest';
 import {
-  registerLayout, getLayout, listLayoutIds, resolveLayoutForTopology,
-  resolveLayoutForViewport, LayoutValidationError,
+  registerLayout, getLayout, listLayoutIds, LayoutValidationError,
 } from '../contract';
 import { sdrTestLayout } from '../declarations';
 import { validLayoutManifest } from './fixtures';
@@ -71,106 +69,5 @@ describe('missing loaders', () => {
 describe('lookup by id', () => {
   it('returns undefined for an id that was never registered', () => {
     expect(getLayout('never-registered-layout-xyz')).toBeUndefined();
-  });
-});
-
-describe('unsupported topology + fallback resolution (single fallback hop)', () => {
-  it('resolves the primary layout when it declares the requested topology', () => {
-    registerLayout(validLayoutManifest({ id: 'topo-primary', compatibleTopologies: ['1/single', '2/main_sub'] }));
-    expect(resolveLayoutForTopology('topo-primary', '2/main_sub')?.id).toBe('topo-primary');
-  });
-
-  // Kills: resolveLayoutForTopology ignoring compatibleTopologies and
-  // always returning the primary manifest.
-  it('falls back to fallbackLayoutId when the primary does not declare the topology', () => {
-    registerLayout(validLayoutManifest({ id: 'topo-fallback-target', compatibleTopologies: ['1/ab'] }));
-    registerLayout(validLayoutManifest({
-      id: 'topo-fallback-primary', compatibleTopologies: ['1/single'], fallbackLayoutId: 'topo-fallback-target',
-    }));
-    expect(resolveLayoutForTopology('topo-fallback-primary', '1/ab')?.id).toBe('topo-fallback-target');
-  });
-
-  it('returns undefined when unsupported and there is no fallback', () => {
-    registerLayout(validLayoutManifest({ id: 'topo-no-fallback', compatibleTopologies: ['1/single'] }));
-    expect(resolveLayoutForTopology('topo-no-fallback', '2/main_sub')).toBeUndefined();
-  });
-});
-
-describe('fallback re-validation (review cycle 1, F1)', () => {
-  // Kills: resolveFallback returning getLayout(fallbackLayoutId) without
-  // re-applying the criterion. Before the fix this returned `f1-self-ref`
-  // itself — a layout that does NOT support the requested topology.
-  it('a self-referential fallback under an unsupported topology resolves to undefined, not itself', () => {
-    registerLayout(validLayoutManifest({
-      id: 'f1-self-ref', compatibleTopologies: ['1/single'], fallbackLayoutId: 'f1-self-ref',
-    }));
-    expect(resolveLayoutForTopology('f1-self-ref', '2/main_sub')).toBeUndefined();
-  });
-
-  // Kills the same bug via a two-hop chain: before the fix, the middle
-  // layout (which itself does not support the topology) was returned
-  // unvalidated because only the primary's support was ever checked.
-  it('a two-hop chain (a -> b -> c) does not return b when only c supports the topology', () => {
-    registerLayout(validLayoutManifest({ id: 'f1-chain-c', compatibleTopologies: ['1/ab'] }));
-    registerLayout(validLayoutManifest({
-      id: 'f1-chain-b', compatibleTopologies: ['1/single'], fallbackLayoutId: 'f1-chain-c',
-    }));
-    registerLayout(validLayoutManifest({
-      id: 'f1-chain-a', compatibleTopologies: ['2/main_sub'], fallbackLayoutId: 'f1-chain-b',
-    }));
-    // v1 takes exactly one hop, so this must NOT silently return b (which
-    // does not support '1/ab') and must NOT chase through to c either.
-    const resolved = resolveLayoutForTopology('f1-chain-a', '1/ab');
-    expect(resolved?.id).not.toBe('f1-chain-b');
-    expect(resolved).toBeUndefined();
-  });
-
-  // Kills: resolveLayoutForViewport returning a fixed-native fallback
-  // without checking IT against minScale too — defeats the MOR-1160
-  // portrait-mobile exclusion for the fallback layout itself.
-  it('a fixed-native fallback that itself fails minScale resolves to undefined, not the fallback', () => {
-    registerLayout(validLayoutManifest({
-      id: 'f1-vp-fallback', stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
-    }));
-    registerLayout(validLayoutManifest({
-      id: 'f1-vp-primary',
-      stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
-      fallbackLayoutId: 'f1-vp-fallback',
-    }));
-    // Same tiny viewport fails minScale for both primary and fallback.
-    const resolved = resolveLayoutForViewport('f1-vp-primary', { width: 100, height: 100 });
-    expect(resolved).toBeUndefined();
-  });
-});
-
-describe('viewport resolution (MOR-1160 sizing)', () => {
-  it('a fixed-native layout resolves when the achievable scale meets minScale', () => {
-    registerLayout(validLayoutManifest({
-      id: 'fixed-fit-test', stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
-    }));
-    expect(resolveLayoutForViewport('fixed-fit-test', { width: 1280, height: 540 })?.id).toBe('fixed-fit-test');
-  });
-
-  // Kills: fitsViewport matching breakpoints instead of comparing scale to
-  // minScale for a fixed-native layout (the MOR-1066 comment's explicit ask).
-  it('falls back below minScale — portrait mobile is excluded arithmetically, no special-cased branch', () => {
-    registerLayout(validLayoutManifest({
-      id: 'fixed-portrait-fallback', stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
-    }));
-    registerLayout(validLayoutManifest({
-      id: 'fixed-portrait-primary',
-      stageSizing: { mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5 },
-      fallbackLayoutId: 'fixed-portrait-fallback',
-    }));
-    // iPhone-class portrait viewport: min(390/1280, 844/540) ≈ 0.30 < 0.5.
-    const resolved = resolveLayoutForViewport('fixed-portrait-primary', { width: 390, height: 844 });
-    expect(resolved?.id).toBe('fixed-portrait-fallback');
-  });
-
-  it('a fluid layout always fits — breakpoints are reflow hints, not a hard gate', () => {
-    registerLayout(validLayoutManifest({
-      id: 'fluid-always-fits', stageSizing: { mode: 'fluid', responsiveBreakpoints: [600] },
-    }));
-    expect(resolveLayoutForViewport('fluid-always-fits', { width: 100, height: 100 })?.id).toBe('fluid-always-fits');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -6,19 +6,16 @@
  * `registry.test.ts` already pins the bare registration fact ("the sdr-test
  * real registration proof") as MOR-1066's acceptance evidence. This file is
  * the entrypoint's OWN focused suite, mirroring the shape
- * `lcd-registration.test.ts` (MOR-1092) uses for its family: topology
- * honesty across all four canonical classes, the sizing axis, and — because
- * sdr-test has no sibling to fall back to — that it declares none. Every
- * claim is read back out of the shared registry rather than off the
- * exported object, so a manifest that is written but never registered fails
- * here. Each test's doc line names the mutation it exists to kill.
+ * `lcd-registration.test.ts` (MOR-1092) uses for its family: the sizing
+ * axis, and — because sdr-test has no sibling to fall back to — that it
+ * declares none. Every claim is read back out of the shared registry rather
+ * than off the exported object, so a manifest that is written but never
+ * registered fails here. Each test's doc line names the mutation it exists
+ * to kill.
  */
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import {
-  getLayout, resolveLayoutForTopology, resolveLayoutForViewport,
-  TOPOLOGY_CLASSES,
-} from '../contract';
+import { getLayout } from '../contract';
 // Deliberately through the shared aggregation entry, not `../declarations`'
 // module-scope side effect alone: importing the named export pins that
 // `declarations.ts` really registers `sdrTestLayout` (nothing else does),
@@ -77,30 +74,12 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
   });
 });
 
-describe('topology honesty', () => {
-  // Kills: under-declaring the topology set. RadioLayout renders the deck
-  // unconditionally and SemanticRadioSurfaces itself branches on the live
-  // topology fixture (`semantic-desktop-migration.component.test.ts` proves
-  // all four render safely), so every canonical class resolves to sdr-test
-  // itself, never to a fallback.
-  it('resolves itself on all four canonical topologies', () => {
-    for (const topology of TOPOLOGY_CLASSES) {
-      expect(resolveLayoutForTopology('sdr-test', topology)?.id).toBe('sdr-test');
-    }
-  });
-});
-
 describe('MOR-1160 sizing axis — sdr-test stays fluid', () => {
   // Kills: silently switching sdr-test onto the fixed-native stage the LCD
   // family owns — sdr-test is a reflowing desktop layout, not a native-scaled
   // instrument glass.
   it('declares fluid sizing with no breakpoints', () => {
     expect(sdrTestLayout.stageSizing).toEqual({ mode: 'fluid', responsiveBreakpoints: [] });
-  });
-
-  it('resolves on both a desktop and an iPhone-class portrait viewport — fluid never gates', () => {
-    expect(resolveLayoutForViewport('sdr-test', { width: 1440, height: 900 })?.id).toBe('sdr-test');
-    expect(resolveLayoutForViewport('sdr-test', { width: 390, height: 844 })?.id).toBe('sdr-test');
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts
@@ -4,19 +4,16 @@
  * fixture registry and not a stub loader.
  *
  * Mirrors `sdr-registration.test.ts` (MOR-1093)'s shape for a single
- * manifest with no sibling family: topology honesty, the sizing axis, and
- * — because this slice ships one minimal zone, not the finished
- * composition — that the declared zone is exactly `vfo`+`rxTx`. Every claim
+ * manifest with no sibling family: the sizing axis, and — because this slice
+ * ships one minimal zone, not the finished composition — that the declared
+ * zone is exactly `vfo`+`rxTx`. Every claim
  * is read back out of the shared registry rather than off the exported
  * object, so a manifest that is written but never registered fails here.
  * Each test's doc line names the mutation it exists to kill.
  */
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import {
-  getLayout, listLayoutIds, resolveLayoutForTopology, resolveLayoutForViewport,
-  TOPOLOGY_CLASSES,
-} from '../contract';
+import { getLayout, listLayoutIds } from '../contract';
 import { getGroup, listGroupIds } from '../../groups/contract';
 // Deliberately through the shared aggregation entry, not `../segmentline-
 // declarations` directly: it pins that `declarations.ts` really registers
@@ -175,30 +172,6 @@ describe('every zone-declared group id resolves in the registry (ADR §7 invento
   });
 });
 
-describe('topology honesty', () => {
-  // Kills: widening compatibleTopologies to a single-receiver pair — the
-  // dual composition PeerSplitLayout.svelte mounts has nothing to put in a
-  // second column for those.
-  it('resolves itself on the two dual-receiver topologies', () => {
-    expect(resolveLayoutForTopology('peer-split', '2/ab_shared')?.id).toBe('peer-split');
-    expect(resolveLayoutForTopology('peer-split', '2/main_sub')?.id).toBe('peer-split');
-  });
-
-  // Kills: narrowing away from a single-receiver pair's declared fallback —
-  // resolution would return undefined and a single-receiver radio would get
-  // no layout at all from this entrypoint.
-  it('falls back to lcd-cockpit on the two single-receiver topologies', () => {
-    expect(resolveLayoutForTopology('peer-split', '1/single')?.id).toBe('lcd-cockpit');
-    expect(resolveLayoutForTopology('peer-split', '1/ab')?.id).toBe('lcd-cockpit');
-  });
-
-  it('leaves no canonical topology unresolvable', () => {
-    for (const topology of TOPOLOGY_CLASSES) {
-      expect(resolveLayoutForTopology('peer-split', topology)).toBeDefined();
-    }
-  });
-});
-
 describe('sizing axis — peer-split shares the LCD family\'s fixed-native glass', () => {
   // Kills: drifting off the 1280x540/0.5 stage `docs/plans/2026-09-01-
   // segmentline-peer-split.md` §9 declares for this family.
@@ -206,16 +179,6 @@ describe('sizing axis — peer-split shares the LCD family\'s fixed-native glass
     expect(peerSplitLayout.stageSizing).toEqual({
       mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
     });
-  });
-
-  it('resolves on a desktop viewport', () => {
-    expect(resolveLayoutForViewport('peer-split', { width: 1440, height: 900 })?.id).toBe('peer-split');
-  });
-
-  // Kills: minScale set to 0 (or the mode flipped to fluid), which would let
-  // a fixed-native peer-split resolve on portrait mobile.
-  it('is excluded from portrait mobile arithmetically', () => {
-    expect(resolveLayoutForViewport('peer-split', { width: 390, height: 844 })).toBeUndefined();
   });
 });
 
@@ -225,13 +188,5 @@ describe('fallback to lcd-cockpit (MOR-2151 correction — the archived draft na
   it('declares lcd-cockpit as its one fallback hop', () => {
     expect(peerSplitLayout.fallbackLayoutId).toBe('lcd-cockpit');
     expect(getLayout(peerSplitLayout.fallbackLayoutId!)).toBeDefined();
-  });
-
-  // Kills: returning the fallback without re-applying the criterion — both
-  // layouts share the same native stage, so a viewport that fails peer-split
-  // fails lcd-cockpit too; resolution must report "unresolvable", not hand
-  // back a sibling that fails the same gate.
-  it('does not hand back lcd-cockpit for a viewport that fails it too', () => {
-    expect(resolveLayoutForViewport('peer-split', { width: 390, height: 844 })).toBeUndefined();
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/stage-sizing-boundary.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/stage-sizing-boundary.test.ts
@@ -1,29 +1,17 @@
 /**
- * MOR-1247 guard: `stageSizing` (the manifest field) and `fitsViewport` (the
- * function that reads it) are frozen declaration-only until the ScaledStage
- * primitive (MOR-1160 constraint 1) exists to mechanically enforce the
- * policy.
+ * MOR-1247 guard: `stageSizing` (the manifest field) stays declaration-only
+ * outside `presentation/layouts/`.
  *
  * This is a TEXTUAL TRIPWIRE, not a security boundary — it catches a file
  * outside this directory whose source contains the literal identifier
- * `stageSizing` or `fitsViewport`, which is what an ordinary import/read
- * looks like. Known, accepted evasions: computed-key access (building the
- * property/import name from concatenated substrings so the literal
- * identifier never appears contiguously in source), and an aliased
- * re-export from inside `layouts/` (e.g. `export { fitsViewport as
- * checkFit } from './contract'` here, consumed externally as `checkFit` —
- * the external file's source never contains the literal name either). Both
- * take deliberate effort to construct; this scan's job is to catch the
- * ordinary case, not to withstand someone trying to route around it.
- *
- * This is NOT expressible as an eslint import-boundary rule (the
- * `../../../__tests__/architecture-boundaries.test.ts` pattern): both names
- * are legitimate exports of `../contract` that other files in THIS directory
- * use freely, and eslint's `no-restricted-imports` bans a module specifier,
- * not a named read from an otherwise-legal import. Proof that the scan
- * catches an ordinary violation (temporary violation -> red -> reverted ->
- * green, sha256-verified) is recorded in the MOR-1247 build report, not
- * committed here.
+ * `stageSizing`, which is what an ordinary import/read looks like. Known,
+ * accepted evasion: computed-key access (building the property name from
+ * concatenated substrings so the literal identifier never appears
+ * contiguously in source). It takes deliberate effort to construct; this
+ * scan's job is to catch the ordinary case, not to withstand someone trying
+ * to route around it. Proof that the scan catches an ordinary violation
+ * (temporary violation -> red -> reverted -> green, sha256-verified) is
+ * recorded in the MOR-1247 build report, not committed here.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
@@ -32,7 +20,7 @@ import path from 'node:path';
 const SRC_ROOT = 'src';
 const LAYOUTS_DIR = path.join(SRC_ROOT, 'presentation', 'layouts') + path.sep;
 const SOURCE_EXTENSIONS = new Set(['.ts', '.svelte']);
-const GUARDED_NAMES = [/\bstageSizing\b/, /\bfitsViewport\b/];
+const GUARDED_NAMES = [/\bstageSizing\b/];
 
 function collectSourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -44,8 +32,8 @@ function collectSourceFiles(dir: string): string[] {
   return out;
 }
 
-describe('stageSizing/fitsViewport stay declaration-only outside layouts/ (MOR-1247)', () => {
-  it('no file outside presentation/layouts/ names stageSizing or fitsViewport', () => {
+describe('stageSizing stays declaration-only outside layouts/ (MOR-1247)', () => {
+  it('no file outside presentation/layouts/ names stageSizing', () => {
     const offenders = collectSourceFiles(SRC_ROOT)
       .filter((file) => !file.startsWith(LAYOUTS_DIR))
       .filter((file) => GUARDED_NAMES.some((re) => re.test(readFileSync(file, 'utf8'))));

--- a/frontend/src/presentation/layouts/contract.ts
+++ b/frontend/src/presentation/layouts/contract.ts
@@ -70,7 +70,7 @@ export interface LayoutZone {
 /**
  * Sizing axis (MOR-1160, frozen 2026-07-29): `fluid` reflows on declared
  * breakpoints; `fixed-native` scales as one block by
- * `min(w/nativeW, h/nativeH)`, letterboxed, falling back below `minScale`.
+ * `min(w/nativeW, h/nativeH)`, letterboxed.
  * Structurally exclusive at the type level (`FixedNativeSizing` has no
  * `responsiveBreakpoints` slot); the runtime validator enforces the same
  * exclusion against untyped input. See `LayoutManifest.stageSizing` below for
@@ -278,27 +278,6 @@ export function listLayoutIds(): readonly string[] {
   return Array.from(registry.keys());
 }
 
-/** Resolves `manifest.fallbackLayoutId` and re-applies `criterion` to the
- *  fallback itself — a fallback that also fails the criterion (or points
- *  back at `manifest`) is not returned; the caller gets `undefined`, a typed
- *  "unresolvable" signal, not a layout that silently fails what it was
- *  fetched to satisfy (review cycle 1, F1: a self-referential or two-hop
- *  fallback, or a fixed-native fallback that itself fails minScale, used to
- *  come back unvalidated). v1 takes exactly one hop — it does not chase a
- *  chain — but that one hop must still pass. */
-function resolveFallback(
-  manifest: LayoutManifest,
-  criterion: (candidate: LayoutManifest) => boolean,
-): LayoutManifest | undefined {
-  if (!manifest.fallbackLayoutId || manifest.fallbackLayoutId === manifest.id) return undefined;
-  const fallback = getLayout(manifest.fallbackLayoutId);
-  return fallback && criterion(fallback) ? fallback : undefined;
-}
-
-export function supportsTopology(manifest: LayoutManifest, topology: TopologyClass): boolean {
-  return manifest.compatibleTopologies.includes(topology);
-}
-
 /**
  * MOR-1313 — every semantic surface `manifest`'s DECLARED ZONES mount, as one
  * flat set. The zone schema is untouched (risk R3): this derives entirely from
@@ -325,36 +304,4 @@ export function declaredSurfaces(
     for (const surface of zone.surfaces) declared.add(surface);
   }
   return declared;
-}
-
-/** Resolves `id` against `topology`, falling back to `fallbackLayoutId` only
- *  when the fallback itself also supports `topology`. */
-export function resolveLayoutForTopology(id: string, topology: TopologyClass): LayoutManifest | undefined {
-  const manifest = getLayout(id);
-  if (!manifest) return undefined;
-  if (supportsTopology(manifest, topology)) return manifest;
-  return resolveFallback(manifest, (candidate) => supportsTopology(candidate, topology));
-}
-
-export interface Viewport { readonly width: number; readonly height: number }
-
-/** `fluid` always fits — breakpoints are reflow hints, not a hard gate in
- *  v1. `fixed-native` compares the achievable uniform scale against
- *  `minScale` (MOR-1160) instead of matching a breakpoint: a portrait
- *  mobile viewport fails this arithmetically (small height vs. a wide
- *  native design), with no separate mobile-detection branch. */
-export function fitsViewport(manifest: LayoutManifest, viewport: Viewport): boolean {
-  if (manifest.stageSizing.mode === 'fluid') return true;
-  const { nativeW, nativeH, minScale } = manifest.stageSizing;
-  return Math.min(viewport.width / nativeW, viewport.height / nativeH) >= minScale;
-}
-
-/** Same fallback path as `resolveLayoutForTopology` — falling below
- *  `minScale` triggers the normal fallback resolution (re-checked against
- *  the same viewport), not a special case and not an unvalidated return. */
-export function resolveLayoutForViewport(id: string, viewport: Viewport): LayoutManifest | undefined {
-  const manifest = getLayout(id);
-  if (!manifest) return undefined;
-  if (fitsViewport(manifest, viewport)) return manifest;
-  return resolveFallback(manifest, (candidate) => fitsViewport(candidate, viewport));
 }

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -164,10 +164,7 @@ export const desktopV2Layout: LayoutManifest = {
   stageSizing: { mode: 'fluid', responsiveBreakpoints: [] },
   /**
    * No fallback: terminal by construction, same reasoning as `mobile` and
-   * `lcd-cockpit`. `compatibleTopologies` above covers all four canonical
-   * classes (no topology ever fails), and `fluid` sizing always fits a
-   * viewport (`fitsViewport`) — so a fallback hop would be unreachable and
-   * would only mask a real failure, never resolve one.
+   * `lcd-cockpit`.
    */
   fallbackLayoutId: null,
 };

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -5,20 +5,11 @@
  * — `declarations.ts` carries only the one registration import — so this
  * and MOR-1092's LCD entrypoints never touch the same lines.
  *
- * MOR-1068 — the frozen adaptation policy across the four canonical pairs
- * (pinned in `__tests__/cockpit-topology-adaptation.test.ts`):
+ * MOR-1068 — `compatibleTopologies` declares the two dual-receiver pairs
+ * only: a single-receiver radio has nothing to put in a second strip, and an
+ * empty column is a claim about the radio.
  *
- *   1/single, 1/ab  FALL BACK. `compatibleTopologies` excludes them, so
- *                   `resolveLayoutForTopology` takes the one validated hop to
- *                   the all-topology `sdr-test` (MOR-976 "degrades safely").
- *                   A single-receiver radio has nothing to put in a second
- *                   strip, and an empty column is a claim about the radio.
- *   2/ab_shared     MOUNTS. One unslotted VFO per receiver; `selectionPoolSize`
- *                   keeps the receiver-selection control present even though
- *                   each per-receiver slice holds a single VFO.
- *   2/main_sub      MOUNTS. Slotted A/B per receiver, two tiles per strip.
- *
- * DEGRADE is the third arm and belongs to the shell, not the declaration: a
+ * DEGRADE belongs to the shell, not the declaration: a
  * declared-compatible topology whose second receiver was never observed
  * renders ONE strip and no `secondary-vfo` zone. Nothing fabricates a SUB
  * (`receiversOf` reads `view.vfos`), the radio-wide row still renders exactly
@@ -27,21 +18,6 @@
  * `stageSizing: fluid` encodes the MOR-1160 chrome-fluid half of the sizing
  * axis: this shell composes only VFO/RX-TX status text today (no fixed-native
  * instrument glass yet), so it always fits, at any viewport.
- *
- * MOR-1069 — the PORTRAIT-MOBILE RULING, stated rather than defaulted.
- *
- * A `fixed-native` layout is excluded from a portrait phone arithmetically:
- * the achievable uniform scale drops under `minScale` and resolution takes the
- * one validated hop to a fluid fallback. A `fluid` layout has no such
- * exclusion — it fits every viewport by construction — so this cockpit DOES
- * reach portrait mobile, and it reaches it deliberately. It is not a silent
- * default: restoring an exclusion would need either a viewport consumer of the
- * frozen sizing field (banned while the ScaledStage primitive does not exist —
- * `__tests__/stage-sizing-boundary.test.ts`) or a second mobile behavior state
- * machine (banned by MOR-1069's owned area). So the ruling is STACK, NOT
- * EXCLUDE: on a portrait phone the cockpit composes as a single column with
- * touch-sized controls, and `fallbackLayoutId` stays a TOPOLOGY fallback
- * (`sdr-test`, MOR-1068's frozen table), never a viewport one.
  */
 import { registerLayout, type LayoutManifest } from './contract';
 

--- a/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
+++ b/frontend/src/presentation/layouts/dual-receiver-cockpit.ts
@@ -11,13 +11,7 @@
  *
  * DEGRADE belongs to the shell, not the declaration: a
  * declared-compatible topology whose second receiver was never observed
- * renders ONE strip and no `secondary-vfo` zone. Nothing fabricates a SUB
- * (`receiversOf` reads `view.vfos`), the radio-wide row still renders exactly
- * once, and the single TX authority is untouched in every arm.
- *
- * `stageSizing: fluid` encodes the MOR-1160 chrome-fluid half of the sizing
- * axis: this shell composes only VFO/RX-TX status text today (no fixed-native
- * instrument glass yet), so it always fits, at any viewport.
+ * renders ONE strip and no `secondary-vfo` zone.
  */
 import { registerLayout, type LayoutManifest } from './contract';
 

--- a/frontend/src/presentation/layouts/lcd-declarations.ts
+++ b/frontend/src/presentation/layouts/lcd-declarations.ts
@@ -16,10 +16,7 @@ import { registerLayout, type LayoutManifest } from './contract';
 /**
  * MOR-1160: the incoming LCD directions are authored on a 1280x540 native
  * stage and scaled as one uniform, letterboxed block — the LCD glass is the
- * archetype instrument surface. `minScale` 0.5 is what excludes portrait
- * mobile arithmetically (constraint 4): an iPhone-class 390x844 viewport
- * achieves min(390/1280, 844/540) ~= 0.30 and fails, with no
- * mobile-detection branch anywhere in the resolution path.
+ * archetype instrument surface.
  */
 const LCD_NATIVE_STAGE = {
   mode: 'fixed-native', nativeW: 1280, nativeH: 540, minScale: 0.5,
@@ -61,9 +58,6 @@ export const lcdCockpitLayout: LayoutManifest = {
 /**
  * The scope-dominant variant names the cockpit as its single fallback hop:
  * the cockpit is where the persisted `amber-lcd` preference already routes.
- * The registry re-validates that hop, so a viewport below the shared
- * `minScale` resolves to `undefined` rather than silently landing on a
- * sibling that fails the same gate (MOR-1066 review cycle 1, F1).
  */
 export const lcdScopeLayout: LayoutManifest = {
   schemaVersion: 1,

--- a/frontend/src/presentation/layouts/mobile-declarations.ts
+++ b/frontend/src/presentation/layouts/mobile-declarations.ts
@@ -53,8 +53,6 @@ export const mobileLayout: LayoutManifest = {
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],
   stageSizing: MOBILE_FLUID_SIZING,
-  // Terminal by construction: a fluid layout never fails a viewport, so a hop
-  // off mobile would be unreachable and would only mask a real failure.
   fallbackLayoutId: null,
 };
 

--- a/frontend/src/presentation/layouts/mobile-declarations.ts
+++ b/frontend/src/presentation/layouts/mobile-declarations.ts
@@ -19,10 +19,7 @@ import { registerLayout, type LayoutManifest } from './contract';
 /**
  * MOR-1160, fluid side. Mobile chrome reflows; it is not an instrument stage
  * scaled as one letterboxed block, so it declares no native size and no
- * `minScale` — and therefore always fits (`fitsViewport`: breakpoints are
- * reflow hints, not a hard gate in v1). That is what makes mobile the only
- * viable destination for a fixed-native layout's one validated fallback hop
- * off a portrait phone, where the LCD stage fails arithmetically.
+ * `minScale`.
  *
  * The single breakpoint is the one reflow the shell actually implements:
  * `MobileRadioLayout` switches to its spectrum-dominant landscape arrangement


### PR DESCRIPTION
Coordinator-granted hard-ceiling exception under the owner's delegation of 2026-09-03: 15 code + 0 regenerated baselines = 15 files — one change: the dead viewport/topology half of the layouts contract and every sentence that described it

## Summary

ADR MOR-2249 decision D1. `frontend/src/presentation/layouts/contract.ts` loses its viewport and topology resolution half — `fitsViewport`, `resolveLayoutForViewport`, `resolveLayoutForTopology`, `supportsTopology`, the module-private `resolveFallback`, and the `Viewport` interface those two resolvers were the only referents of — along with the test cases that exercised them and the comment sentences that named or described them. No production code called any of them; the change is a deletion, not a behaviour change.

`Linear: MOR-2254`

## `listLayoutIds` is kept, against the ticket's list

It has two real readers in `frontend/src/presentation/layouts/__tests__/segmentline-registration.test.ts` (lines 112 and 157) that are not tests of it: the MOR-2253 canvas/`minScale` agreement check and the ADR §7 zone-group-id inventory. Per the coordinator (2026-09-03), the ticket's census predates MOR-2253 slice 1, which is what gave the function those readers — a function with a consumer is not dead. Deleting it would have meant rewriting two live guards, which this change does not do.

## `minScale` keeps its readers

`fitsViewport` used to be the only behavioural reader of `LayoutManifest.stageSizing.minScale`, so this was checked before deleting it (D3 keep):

- `InstrumentGroup.scaling.minScale` → `components-v2/layout/LcdLayout.svelte` (`peerSplitGroup.scaling.minScale`) → `skins/segmentline/PeerSplitLayout.svelte` (`minScale` prop) → `primitives/stage/ScaledStage.svelte` → `computeStageScale` in `primitives/stage/stage-scale.ts`. Live path, MOR-2259.
- `LayoutManifest.stageSizing.minScale` is read by `validateSizing` in `contract.ts`, and compared against the group's value by the segmentline guard named above.

Neither becomes an orphan.

## Census

Run at the explicit ref. `-P` is required: the same command with `-E` returns 0 lines and no error, so a `\b` census with `-E` is silently empty. Control: the identical `-P` grep for `minScale` returns 104 lines.

```
git grep -n -P '\b(fitsViewport|resolveLayoutForViewport|resolveLayoutForTopology|supportsTopology|resolveFallback|listLayoutIds)\b' origin/main -- frontend/
```

94 matching lines, classified:

| Class | Lines |
|---|---|
| `contract.ts` definitions | 6 |
| `contract.ts` internal calls | 4 |
| `contract.ts` comment | 1 |
| `presentation/layouts/__tests__/` (imports, assertions, comments) | 79 |
| comments in `desktop-declarations.ts`, `mobile-declarations.ts`, `dual-receiver-cockpit.ts` | 3 |
| outside `presentation/layouts/` | 1 |

The single hit outside `presentation/layouts/` is `components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts:555`, which lists `'resolveLayoutForViewport'` as a string in a `not.toContain` array — not a caller. Left as it is, per the coordinator. There is no `local-extensions/` directory in this repo (`ls` → no such file). No dynamic/string access exists either: the same names searched in quotes match only documents and that one `not.toContain` entry.

## `stage-sizing-boundary.test.ts`

Its `GUARDED_NAMES` was `[/\bstageSizing\b/, /\bfitsViewport\b/]`; it is now `[/\bstageSizing\b/]`, with the describe/it titles and the header comment narrowed to match. The `fitsViewport` entry is deleted because it can no longer discriminate — after this change the identifier occurs nowhere under `frontend/src/`, so no file could ever trip it. Both halves were checked by mutation rather than by reading:

- **Reinstate the bug the surviving half guards:** appended `// stageSizing` to `src/primitives/stage/stage-scale.ts` (a file outside `presentation/layouts/`) → the test went **red** (1 failed). The surviving entry still discriminates.
- **Control on the deleted half:** with that mutation reverted, restored `/\bfitsViewport\b/` to `GUARDED_NAMES` → **green**. The entry cannot fail on anything, which is the reason for removing it rather than a loss of coverage.

The tree was restored after both; `git status` and `git diff HEAD` are empty and the diff contains no trace of either mutation.

## Prose

Sentences that described the removed resolution mechanism without naming any deleted identifier are deleted, not reworded (coordinator decision, 2026-09-03): the MOR-1069 portrait-mobile ruling paragraph in `dual-receiver-cockpit.ts`, the `LCD_NATIVE_STAGE` and `lcdScopeLayout` sentences in `lcd-declarations.ts`, and the "DOM half of the policy" sentence in `__tests__/cockpit-topology-adaptation.test.ts`. Where deleting a named sentence left its neighbour dangling, the neighbour went too.

One passage is a replacement rather than a deletion: the MOR-1068 policy table in `dual-receiver-cockpit.ts` became one sentence about what `compatibleTopologies` declares, because pure deletion left the following paragraph without an antecedent. That sentence states only what `compatibleTopologies` of the same file declares (`compatibleTopologies: ['2/ab_shared', '2/main_sub']`), read to confirm it.

The two sentences that still described the removed table (`dual-receiver-cockpit.ts`: "…untouched in every arm", "…so it always fits, at any viewport") were deleted whole at 978620ae by the coordinator, not trimmed (CLAUDE.md §Testing: delete before you narrow).

## Size

15 code + 0 regenerated baselines = 15 files. `git diff --stat origin/main...HEAD`: 61 insertions, 597 deletions. No visual baselines changed — the commit contains no image files.

## Gates run

- `npx vitest run src/presentation/layouts src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts` → **28 files, 322 tests, all passed**. Baseline at `origin/main` with the same selection: 28 files, 376 tests. Delta −54 test cases, all of them exercising the deleted resolvers; no test file lost entirely.
- `npm run check` (svelte-check + tsc) → `4634 FILES 0 ERRORS 0 WARNINGS`.
- `npx eslint` over all 14 changed files → exit 0, no output.
- Full frontend suite: left to `quick` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




Round 1 review (BLOCKED at 978620ae) found four more sentences describing the removed viewport gate, one of them added by this change; all four were deleted whole at 549dcd0d by the coordinator (mobile-registration.test.ts ×2, mobile-declarations.ts, cockpit-responsive-composition.test.ts, whose one test title carrying the dead TOPOLOGY-vs-viewport distinction was shortened to what it asserts). The change no longer claims to have removed "every" such sentence; the check `git grep -n -i -P "fails a viewport|viewport gate|arithmetic exclusion|frozen topology table|never fails|viewport escape|minScale gate" -- frontend/src/presentation/layouts` is empty at the head. Stat at 549dcd0d: 15 files, 61 insertions, 597 deletions.
