### PR TITLE
fix: one freshness tick driver per service instance

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -1609,6 +1609,7 @@ class StateFreshnessService:
     PRIME_REDERIVE_INTERVAL_SECONDS: float = 30.0
 
     __slots__ = (
+        "_driver_lock",
         "_interval_seconds",
         "_next_prime_monotonic",
         "_on_delta",
@@ -1632,6 +1633,7 @@ class StateFreshnessService:
         # -inf so the first tick always primes immediately, regardless of
         # what monotonic clock value the caller starts at.
         self._next_prime_monotonic = float("-inf")
+        self._driver_lock: asyncio.Lock = asyncio.Lock()
 
     def tick(self, *, now: float | None = None) -> SnapshotDelta:
         """Advance stale fields once and queue reconciliation through scheduler.
@@ -1709,12 +1711,26 @@ class StateFreshnessService:
         self._next_prime_monotonic = now + interval
 
     async def run(self) -> None:
-        """Run the periodic freshness loop until cancelled by the host."""
+        """Run the periodic freshness loop until cancelled by the host.
+
+        At most one loop ticks per instance. In combined mode
+        (``rigplane web --rigctld``) both seats are built over one radio and
+        share this service through it, then each starts its own driver task
+        over it (``web/web_startup.py: start_web_server`` and
+        ``rigctld/server.py: RigctldServer._start_state_freshness_task``,
+        whose guard sees only its own server instance). A concurrent second
+        call waits on the driver lock instead of ticking, and takes the loop
+        over if the driving call ends first, so cancelling one seat's task
+        does not stop the surviving seat's decay. Pinned by
+        ``test_second_run_does_not_add_a_second_ticking_loop`` and
+        ``test_freshness_driving_survives_the_first_seat_stopping``.
+        """
 
         try:
-            while True:
-                await asyncio.sleep(self._interval_seconds)
-                self.tick()
+            async with self._driver_lock:
+                while True:
+                    await asyncio.sleep(self._interval_seconds)
+                    self.tick()
         except asyncio.CancelledError:
             pass
 

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -3464,11 +3464,9 @@ async def test_second_run_does_not_add_a_second_ticking_loop() -> None:
 async def test_freshness_driving_survives_the_first_seat_stopping() -> None:
     """The waiting seat drives once the driving seat's task is cancelled.
 
-    Combined mode tears the two seats down in a fixed order
-    (``cli/__init__.py``: the web server's ``stop`` runs first, the embedded
-    rigctld's ``stop`` in the ``finally``), but nothing makes that order the
-    same as the start order. Ticking must therefore outlive whichever task
-    is cancelled first, and must end once both are cancelled.
+    Each seat cancels only its own task, so ticking must outlive whichever
+    task is cancelled first -- either seat can be the one holding the loop --
+    and must end once both are cancelled.
     """
 
     interval = 0.02

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -3461,20 +3461,27 @@ async def test_second_run_does_not_add_a_second_ticking_loop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_freshness_driving_survives_the_first_seat_stopping() -> None:
-    """The waiting seat drives once the driving seat's task is cancelled.
+@pytest.mark.parametrize(
+    "cancel_web_first", [True, False], ids=["web-first", "rigctld-first"]
+)
+async def test_freshness_driving_survives_the_first_seat_stopping(
+    cancel_web_first: bool,
+) -> None:
+    """Ticking outlives the first cancellation, in either order.
 
-    Each seat cancels only its own task, so ticking must outlive whichever
-    task is cancelled first -- either seat can be the one holding the loop --
-    and must end once both are cancelled.
+    One of the two tasks holds the loop and the other waits for it.
+    Cancelling in both orders covers both roles without the test having to
+    depend on which task took which. Whichever goes first, the survivor
+    keeps ticking; once both are cancelled, nothing ticks.
     """
 
     interval = 0.02
     service = StateFreshnessService(store=StateStore(), interval_seconds=interval)
 
     with _recorded_freshness_ticks() as stamps:
-        first = asyncio.create_task(service.run(), name="web-state-freshness")
-        second = asyncio.create_task(service.run(), name="rigctld-state-freshness")
+        web = asyncio.create_task(service.run(), name="web-state-freshness")
+        rigctld = asyncio.create_task(service.run(), name="rigctld-state-freshness")
+        first, second = (web, rigctld) if cancel_web_first else (rigctld, web)
         try:
             await asyncio.sleep(interval * 4)
             first.cancel()
@@ -3482,14 +3489,14 @@ async def test_freshness_driving_survives_the_first_seat_stopping() -> None:
 
             after_first_stop = len(stamps)
             await asyncio.sleep(interval * 4)
-            assert len(stamps) > after_first_stop, "ticking stopped with a seat live"
+            assert len(stamps) > after_first_stop, "ticking stopped with a task live"
 
             second.cancel()
             await asyncio.gather(second, return_exceptions=True)
             after_both_stopped = len(stamps)
             await asyncio.sleep(interval * 4)
-            assert len(stamps) == after_both_stopped, "ticking outlived both seats"
+            assert len(stamps) == after_both_stopped, "ticking outlived both tasks"
         finally:
-            first.cancel()
-            second.cancel()
-            await asyncio.gather(first, second, return_exceptions=True)
+            web.cancel()
+            rigctld.cancel()
+            await asyncio.gather(web, rigctld, return_exceptions=True)

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+import contextlib
+import time
+from collections.abc import Iterable, Iterator
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -35,7 +38,12 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
-from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
+from rigplane.core.state_store import (
+    FreshnessClock,
+    FreshnessState,
+    SnapshotDelta,
+    StateStore,
+)
 from rigplane.commands.command_map import CommandMap
 from rigplane.profiles import get_radio_profile
 from rigplane.runtime._state_queries import acquisition_query_from_wire_tuple
@@ -3399,3 +3407,91 @@ async def test_ic7300_executor_preserves_dedupe_for_plain_profile_route() -> Non
         assert power not in result.sent_paths
 
     assert sent == [acquisition_query(0x16, sub=0x44)]
+
+
+@contextlib.contextmanager
+def _recorded_freshness_ticks() -> Iterator[list[float]]:
+    """Record a monotonic timestamp for every ``StateFreshnessService.tick``."""
+
+    stamps: list[float] = []
+    real_tick = StateFreshnessService.tick
+
+    def _tick(
+        service: StateFreshnessService, *, now: float | None = None
+    ) -> SnapshotDelta:
+        stamps.append(time.monotonic())
+        return real_tick(service, now=now)
+
+    with patch.object(StateFreshnessService, "tick", _tick):
+        yield stamps
+
+
+@pytest.mark.asyncio
+async def test_second_run_does_not_add_a_second_ticking_loop() -> None:
+    """Two concurrent ``run()`` calls on one service tick as one loop.
+
+    Combined mode (``rigplane web --rigctld``) shares a single
+    ``StateFreshnessService`` between the two seats and each seat starts its
+    own driver task over it (``web/web_startup.py: start_web_server`` and
+    ``rigctld/server.py: RigctldServer._start_state_freshness_task``).
+
+    The discriminator is the gap between consecutive ticks, not their count.
+    ``asyncio.sleep`` does not return early, so one loop leaves at least
+    ``interval_seconds`` between ticks however loaded the host is; two loops
+    started back to back share a sleep phase and tick in closely spaced
+    pairs, which drives the minimum gap towards zero.
+    """
+
+    interval = 0.02
+    service = StateFreshnessService(store=StateStore(), interval_seconds=interval)
+
+    with _recorded_freshness_ticks() as stamps:
+        first = asyncio.create_task(service.run(), name="web-state-freshness")
+        second = asyncio.create_task(service.run(), name="rigctld-state-freshness")
+        try:
+            await asyncio.sleep(interval * 12)
+        finally:
+            first.cancel()
+            second.cancel()
+            await asyncio.gather(first, second, return_exceptions=True)
+
+    assert len(stamps) >= 3
+    gaps = [later - earlier for earlier, later in zip(stamps, stamps[1:])]
+    assert min(gaps) >= interval * 0.9, f"ticks overlapped: gaps={gaps}"
+
+
+@pytest.mark.asyncio
+async def test_freshness_driving_survives_the_first_seat_stopping() -> None:
+    """The waiting seat drives once the driving seat's task is cancelled.
+
+    Combined mode tears the two seats down in a fixed order
+    (``cli/__init__.py``: the web server's ``stop`` runs first, the embedded
+    rigctld's ``stop`` in the ``finally``), but nothing makes that order the
+    same as the start order. Ticking must therefore outlive whichever task
+    is cancelled first, and must end once both are cancelled.
+    """
+
+    interval = 0.02
+    service = StateFreshnessService(store=StateStore(), interval_seconds=interval)
+
+    with _recorded_freshness_ticks() as stamps:
+        first = asyncio.create_task(service.run(), name="web-state-freshness")
+        second = asyncio.create_task(service.run(), name="rigctld-state-freshness")
+        try:
+            await asyncio.sleep(interval * 4)
+            first.cancel()
+            await asyncio.gather(first, return_exceptions=True)
+
+            after_first_stop = len(stamps)
+            await asyncio.sleep(interval * 4)
+            assert len(stamps) > after_first_stop, "ticking stopped with a seat live"
+
+            second.cancel()
+            await asyncio.gather(second, return_exceptions=True)
+            after_both_stopped = len(stamps)
+            await asyncio.sleep(interval * 4)
+            assert len(stamps) == after_both_stopped, "ticking outlived both seats"
+        finally:
+            first.cancel()
+            second.cancel()
+            await asyncio.gather(first, second, return_exceptions=True)

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -586,14 +586,18 @@ class TestLifecycle:
     ) -> None:
         """Both seats over one radio produce one ticking freshness loop.
 
-        Reproduces combined mode's shape (``rigplane web --rigctld``): the web
-        seat attaches store, model service, scheduler and freshness service to
-        the radio (``web/server.py: WebServer._bootstrap_state_acquisition``)
-        and starts ``web-state-freshness``
-        (``web/web_startup.py: start_web_server``); ``RigctldServer.start``
-        then reuses the attached service and starts ``rigctld-state-freshness``
-        over that same instance. The web HTTP listener is not started -- the
-        web seat's whole contribution to the shared service is that one task.
+        Reproduces combined mode's shape (``rigplane web --rigctld``). The
+        radio carries the store it owns, plus the services the web seat
+        attaches to it in
+        ``web/server.py: WebServer._bootstrap_state_acquisition`` -- among
+        them the freshness service and its scheduler, which are the two this
+        test needs. The web seat's ``web-state-freshness`` task
+        (``web/web_startup.py: start_web_server``) runs over that service;
+        ``RigctldServer.start`` then takes its reuse branch and starts
+        ``rigctld-state-freshness`` over the same instance.
+
+        The web HTTP listener is not started: the web seat's whole
+        contribution to *this defect* is that one task.
 
         The discriminator is the gap between consecutive ticks: one loop
         leaves at least ``interval_seconds`` between them, two loops started

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -590,8 +590,8 @@ class TestLifecycle:
         radio carries the store it owns, plus the services the web seat
         attaches to it in
         ``web/server.py: WebServer._bootstrap_state_acquisition`` -- among
-        them the freshness service and its scheduler, which are the two this
-        test needs. The web seat's ``web-state-freshness`` task
+        them the freshness service and its scheduler. The web seat's
+        ``web-state-freshness`` task
         (``web/web_startup.py: start_web_server``) runs over that service;
         ``RigctldServer.start`` then takes its reuse branch and starts
         ``rigctld-state-freshness`` over the same instance.

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -581,6 +581,79 @@ class TestLifecycle:
             state_model_service=model_service,
         )
 
+    async def test_combined_seats_drive_the_shared_service_once(
+        self, cfg: RigctldConfig
+    ) -> None:
+        """Both seats over one radio produce one ticking freshness loop.
+
+        Reproduces combined mode's shape (``rigplane web --rigctld``): the web
+        seat attaches store, model service, scheduler and freshness service to
+        the radio (``web/server.py: WebServer._bootstrap_state_acquisition``)
+        and starts ``web-state-freshness``
+        (``web/web_startup.py: start_web_server``); ``RigctldServer.start``
+        then reuses the attached service and starts ``rigctld-state-freshness``
+        over that same instance. The web HTTP listener is not started -- the
+        web seat's whole contribution to the shared service is that one task.
+
+        The discriminator is the gap between consecutive ticks: one loop
+        leaves at least ``interval_seconds`` between them, two loops started
+        back to back tick in closely spaced pairs.
+        """
+
+        interval = 0.02
+        store = StateStore()
+        freq = FieldPath.active("main", "freq_mode", "freq_hz")
+        scheduler = AcquisitionScheduler(profile=_acquisition_profile(freq))
+        model_service = RadioStateModelService(store=store, scheduler=scheduler)
+        freshness_service = StateFreshnessService(
+            store=store, scheduler=scheduler, interval_seconds=interval
+        )
+        radio = _ProfiledStandaloneRadio(
+            profile=type(
+                "Profile",
+                (),
+                {"state_acquisition": _acquisition_profile(freq)},
+            )()
+        )
+        radio.state_store = store
+        radio.state_model_service = model_service
+        radio._state_freshness_service = freshness_service
+        radio._acquisition_scheduler = scheduler
+        fake_server = _FakeAsyncServer()
+
+        stamps: list[float] = []
+        real_tick = StateFreshnessService.tick
+
+        def _tick(service: StateFreshnessService, *, now: float | None = None) -> Any:
+            stamps.append(time.monotonic())
+            return real_tick(service, now=now)
+
+        with (
+            patch(
+                "rigplane.rigctld.server.asyncio.start_server",
+                new=AsyncMock(return_value=fake_server),
+            ),
+            patch("rigplane.rigctld.handler.RigctldHandler"),
+            patch.object(StateFreshnessService, "tick", _tick),
+        ):
+            web_task = asyncio.get_running_loop().create_task(
+                freshness_service.run(), name="web-state-freshness"
+            )
+            srv = RigctldServer(radio, cfg)
+            try:
+                await srv.start()
+                assert srv._state_freshness_service is freshness_service
+                assert srv._state_store_freshness_task is not None
+                await asyncio.sleep(interval * 12)
+            finally:
+                await srv.stop()
+                web_task.cancel()
+                await asyncio.gather(web_task, return_exceptions=True)
+
+        assert len(stamps) >= 3
+        gaps = [later - earlier for earlier, later in zip(stamps, stamps[1:])]
+        assert min(gaps) >= interval * 0.9, f"ticks overlapped: gaps={gaps}"
+
     async def test_standalone_fallback_store_begin_and_detach_each_advance_once(
         self, cfg: RigctldConfig
     ) -> None:


### PR DESCRIPTION
## The defect

In combined mode (`rigplane web --rigctld`) both servers are built over the same radio object and the freshness service is deliberately shared through it: `web/server.py: WebServer._bootstrap_state_acquisition` attaches the service and the scheduler to the radio, and `rigctld/server.py: RigctldServer._bootstrap_state_acquisition` reads them back via `RigctldServer._radio_state_freshness_service` and takes the reuse branch. Sharing is intended.

What is not intended: each seat then starts its **own** driver task over that one instance — `web-state-freshness` from `web/web_startup.py: start_web_server`, and `rigctld-state-freshness` from `rigctld/server.py: RigctldServer._start_state_freshness_task`, whose only guard is `self._state_store_freshness_task is not None`, an attribute of the `RigctldServer` instance that the web seat never touches. Two `asyncio.Task`s then run `StateFreshnessService.run()` on one instance.

Evidence it is real, measured on unchanged `run()` (see the red run below): the tick timestamps alternate between gaps of ~3e-5 s and ~0.021 s at a declared `interval_seconds` of 0.02 — two loops created back to back share a sleep phase and tick in near-simultaneous pairs. 22 ticks landed in the window where one loop produces 11.

Consequences are as recorded on the ticket and were not re-derived here: no duplicate wire traffic and no duplicate WebSocket frames, but the full store scan in `core/state_store.py: StateStore.mark_stale_due` runs twice as often and the effective interval is half of what the code declares. Not a regression — it dates to the state-pipeline migration.

## What changed and why the guard is in the service

`core/acquisition_scheduler.py: StateFreshnessService` gains a per-instance `asyncio.Lock`, and `run()` holds it around the ticking loop. A concurrent second call waits on the lock instead of ticking, and takes the loop over if the driving call ends first.

The guard sits in the service, not in either server, for two reasons: it makes the invariant provable without constructing two servers, so the primary pin drives the service directly; and it makes the behaviour independent of which seat starts first, which is otherwise an ordering fact in `cli/__init__.py`. A guard in either server would have to know about the other.

**No change to either server.** Neither `create_task` call site nor either `stop` path needed one — a waiting task is cancellable exactly like a driving one, and both seats already swallow `CancelledError` around their `await task`.

### Shutdown, both orders

I read both `stop` paths before choosing. `web/web_startup.py: stop_web_server` and `rigctld/server.py: RigctldServer.stop` each cancel their own task and set it to `None`; `run()` swallows `CancelledError` either way, so the `async with` releases the lock on the way out.

* **Web's task stops first** (this is the order `cli/__init__.py` uses today: `RigctldServer.start` runs before `WebServer.serve_forever`, and `rigctld_server.stop()` runs in the `finally` after the web server has stopped). Whichever of the two holds the lock, the survivor is left driving: if web was the waiter its cancellation changes nothing, and if web was the driver it releases the lock and rigctld's parked task takes over. rigctld's own `stop` then ends the ticking.
* **Rigctld's task stops first.** Symmetric, by the same mechanism.
* **Both stopped.** No task remains to acquire the lock, so nothing ticks. Pinned.

The "second call returns immediately" alternative fails exactly here: it would leave the surviving seat with no driver whenever the owner stopped first. That is the mutation that kills the handover pin below.

## Red before, green after

Primary pin, against unchanged `run()`:

```
tests/test_acquisition_scheduler.py:3460: in test_second_run_does_not_add_a_second_ticking_loop
    assert min(gaps) >= interval * 0.9, f"ticks overlapped: gaps={gaps}"
E   AssertionError: ticks overlapped: gaps=[3.2458221539855e-05, 0.021129791857674718, 2.6667024940252304e-05, 0.020247458014637232, 3.795791417360306e-05, 0.02106991712935269, 3.229198046028614e-05, 0.02118170796893537, 5.2042072638869286e-05, 0.02101875003427267, 3.204098902642727e-05, 0.021068000001832843, 3.312481567263603e-05, 0.021144125144928694, 3.470899537205696e-05, 0.021088165929540992, 4.883413203060627e-05, 0.021059040911495686, 2.837507054209709e-05, 0.021073083858937025, 3.2833078876137733e-05]
E   assert 2.6667024940252304e-05 >= (0.02 * 0.9)
=========================== short test summary info ============================
FAILED tests/test_acquisition_scheduler.py::test_second_run_does_not_add_a_second_ticking_loop
================== 1 failed, 1 passed, 94 deselected in 0.70s ==================
```

After the change:

```
tests/test_acquisition_scheduler.py ..                                   [100%]
======================= 2 passed, 94 deselected in 0.66s =======================
```

### Mutation testing

The pins were checked against two deliberately wrong implementations. Both were reverted before the gate runs below; `git diff origin/main...HEAD` carries no trace of either.

**Mutation 1 — `run()` restored to its original unguarded body** (behaviourally the unchanged code; only the unused lock attribute remained). This is also the red evidence for the combined-mode pin, which was written after the fix:

```
FAILED tests/test_acquisition_scheduler.py::test_second_run_does_not_add_a_second_ticking_loop
FAILED tests/test_rigctld_server.py::TestLifecycle::test_combined_seats_drive_the_shared_service_once
================= 2 failed, 1 passed, 150 deselected in 1.03s ==================
```

with `min(gaps) == 1.5e-05` on the combined-mode pin.

**Mutation 2 — the plausible wrong fix**, `if self._driver_lock.locked(): return` in front of the loop, i.e. the second call returns instead of waiting:

```
E   AssertionError: ticking stopped with a seat live
    assert 3 > 3
/…/tests/test_acquisition_scheduler.py:3487: AssertionError: ticking stopped with a seat live
=========================== short test summary info ============================
FAILED tests/test_acquisition_scheduler.py::test_freshness_driving_survives_the_first_seat_stopping
================= 1 failed, 2 passed, 150 deselected in 1.20s ==================
```

So each of the three tests is killed by at least one mutation, and the handover pin — which is green before this change as well as after — is killed by the wrong fix it exists to exclude.

Why the discriminator is a gap and not a count: `asyncio.sleep` does not return early, so one loop leaves at least `interval_seconds` between ticks however loaded the host is. A count-based threshold would go green under load with the bug still present; a minimum-gap threshold cannot, because load pushes single-loop gaps up, not down.

## Combined-mode pin: judgement

Achievable, and added: `tests/test_rigctld_server.py::TestLifecycle::test_combined_seats_drive_the_shared_service_once`. The radio carries the store it owns, plus the services the web seat attaches to it in `web/server.py: WebServer._bootstrap_state_acquisition` — among them the freshness service and its scheduler. It starts the `web-state-freshness` task over that service, then runs `RigctldServer.start()` — which takes the reuse branch, asserts `srv._state_freshness_service is freshness_service`, and starts `rigctld-state-freshness` over the same instance — and applies the same minimum-gap assertion. It reuses the existing `_ProfiledStandaloneRadio` / `_FakeAsyncServer` doubles and the patched `asyncio.start_server` already used by the neighbouring lifecycle tests.

What it deliberately does not do is stand up a real `WebServer` and its aiohttp listener. The web seat's entire contribution to this defect is one `create_task(service.run(), name="web-state-freshness")` line; binding a second real port to reproduce that line would add fixture, not evidence, and the assertion available at that level would be no stronger than the one this test already makes. The test's docstring says so.

## Gates

Run at `13745eda`, in the worktree, on Python 3.14.7 locally (CI quick runs 3.11):

| Command | Result |
|---|---|
| `uv run pytest tests/test_acquisition_scheduler.py tests/test_state_store.py tests/test_rigctld_server.py tests/test_web_server_coverage.py tests/test_cli.py tests/test_serial_backend_smoke.py tests/test_lifecycle_diagnostics.py -q --tb=short` | `502 passed, 24 warnings in 7.34s` |
| `uv run ruff check src/ tests/` | `All checks passed!` |
| `uv run ruff format src/ tests/` | `710 files already formatted` |
| `uv run lint-imports` | `Contracts: 5 kept, 0 broken.` |
| `uv run mypy --strict src/rigplane/web` | `Success: no issues found in 26 source files` |

The full suite was not run locally; CI quick on this PR covers it.

## Diff

```
$ git diff --stat origin/main...HEAD
 src/rigplane/core/acquisition_scheduler.py |  24 +++++--
 tests/test_acquisition_scheduler.py        | 105 ++++++++++++++++++++++++++++-
 tests/test_rigctld_server.py               |  77 +++++++++++++++++++++
 3 files changed, 200 insertions(+), 6 deletions(-)
```

3 files, 206 changed lines — inside both the soft threshold (6 files / 600 lines) and the hard ceiling.

## Review round 2 — docstring correction (`73a0bc5b`)

Review found one false sentence in the combined-mode pin's docstring: it said the web seat attaches *store*, model service, scheduler and freshness service to the radio. It does not attach a store. `web/server.py: WebServer._bootstrap_state_acquisition` setattrs exactly `state_model_service`, `_state_freshness_service`, `_acquisition_scheduler` and `_meter_observation_coalescer`; the radio owns its store (`runtime/radio.py: IcomRadio`, exposed read-only as `state_store`), and the only site that attaches a store to a radio is `rigctld/server.py: RigctldServer._attach_state_acquisition_services`. The sentence gave the rigctld seat's behaviour to the web seat. Corrected in the docstring and above in this body.

Two more from sweeping the same class across this branch's prose:

* the same docstring's "the web seat's whole contribution to the shared service is that one task" — true only of *this defect*, since the web seat also constructs the service. Qualifier restored.
* the handover pin's docstring asserted a teardown order read out of `cli/__init__.py` that no test pins. It was replaced at the time with "each seat cancels only its own task" — **withdrawn**: round 3 found that sentence unpinned in the same way, since the test calls no `stop`, and deleted it outright rather than relocating it. See round 3 below.

No code changed in that commit, so the mechanism evidence above still stands at `13745eda`. Gates re-run at `73a0bc5b` over the two touched test files: `153 passed`, `ruff check` clean, `ruff format --check` clean.

## Review round 3 — a census in the correction itself (`31d3ef2c`)

Round 2's replacement wrote a fresh falsehood into the sentence it fixed: "among them the freshness service and its scheduler, **which are the two this test needs**". The test needs three. `rigctld/server.py: RigctldServer._bootstrap_state_acquisition` gates its reuse branch on `self._state_model_service is not None`, so without that attachment rigctld builds its own service and the test stops exercising the shared instance at all. `among them` was the right construction; `the two` turned a subset back into a census. Deleted, not rewritten.

Two more docstring claims went out with it, both in the handover pin:

* "Each seat cancels only its own task" — true of the servers, but that test calls no `stop`, so nothing pinned it. Deleted.
* "Either seat can be the one holding the loop" — true, but only one direction ran, and the untested direction is the one production takes: the CLI starts rigctld first and stops it last, so the first cancellation lands on the *parked* task. Rather than delete the sentence, the test is now parametrised over both cancellation orders, so the claim describes what runs.

**Which direction discriminates, measured not assumed.** Under mutation 2 (`if locked(): return`) only `[web-first]` — cancelling the task holding the loop — goes red:

```
FAILED tests/test_acquisition_scheduler.py::test_freshness_driving_survives_the_first_seat_stopping[web-first]
================= 1 failed, 1 passed, 152 deselected in 5.01s ==================
```

`[rigctld-first]` passes under that mutation: cancelling a task that already returned is a no-op. It is kept because it covers the production order, not because it discriminates. Recording that asymmetry rather than implying both cases are pins.

`src/` is untouched by rounds 2 and 3 — `git diff 13745eda..HEAD -- src/` is empty — so every mechanism result established at `13745eda` still stands.

Gates re-run at `31d3ef2c`: targeted pytest `503 passed`, `ruff check` clean, `ruff format --check` clean, `lint-imports` `Contracts: 5 kept, 0 broken.`, `mypy --strict src/rigplane/web` clean.

## Test delta

Relative to the branch point: **3 test functions added, 0 removed**, all three in the two test files this PR touches (2 in `tests/test_acquisition_scheduler.py`, 1 in `tests/test_rigctld_server.py`). One of them is parametrised over two cancellation orders, so the suite collects **4 new cases**. No absolute suite figure is claimed — `main` moves under branches.

Measured by collection at `31d3ef2c`, not inferred from suite totals — `pytest --collect-only` over the two touched files yields exactly these four new cases:

```
test_second_run_does_not_add_a_second_ticking_loop
test_freshness_driving_survives_the_first_seat_stopping[web-first]
test_freshness_driving_survives_the_first_seat_stopping[rigctld-first]
test_combined_seats_drive_the_shared_service_once
```

and `git diff origin/main...HEAD -- tests/` deletes two lines, both of them `import` statements this branch extends (`collections.abc` and `rigplane.core.state_store`). No test is removed or renamed.

**The absolute CI totals cannot carry this claim, and I am not using them for it.** `main` moved under the branch while review was in progress: the merge base is still `1989959b`, but `origin/main` is now `07cfa4ff`, and that commit touches `src/` and `tests/`. So quick's `14691 passed, 220 skipped, 16 xfailed` at this head (run `33718245149`) is measured against a different `main` than the `14684` baseline (run `33713028333`, at `a6ab594d`) and than the `14687` at `13745eda` (run `33715999207`). The differences between those three numbers are not all attributable to this branch, and I have not attempted to decompose them.

Linear: MOR-2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
