### PR TITLE
test: use a zone id every manifest can share as the generic workspace fixture

### DIFF
--- a/frontend/src/presentation/workspace/__tests__/contract.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/contract.test.ts
@@ -253,10 +253,10 @@ describe('decision 1 — `auto` is first class and resolution is deferred', () =
 
 describe('decisions 5 and 6 — zone constraints', () => {
   it('drops an unknown zone id and an unknown surface id', () => {
-    const result = readWorkspace({ ...VALID, visibleSurfaces: { 'no-such-zone': ['vfo'], main: ['vfo', 'nope'] } });
-    expect(result.workspace.visibleSurfaces).toEqual({ main: ['vfo'] });
+    const result = readWorkspace({ ...VALID, visibleSurfaces: { 'no-such-zone': ['vfo'], 'receiver-deck': ['vfo', 'nope'] } });
+    expect(result.workspace.visibleSurfaces).toEqual({ 'receiver-deck': ['vfo'] });
     expect(result.rejections).toContainEqual({ field: 'visibleSurfaces.no-such-zone', reason: 'unknown-id' });
-    expect(result.rejections).toContainEqual({ field: 'visibleSurfaces.main', reason: 'unknown-id' });
+    expect(result.rejections).toContainEqual({ field: 'visibleSurfaces.receiver-deck', reason: 'unknown-id' });
   });
 
   it('rejects the same surface claimed by two zones — the cross-zone move shape', () => {
@@ -266,8 +266,8 @@ describe('decisions 5 and 6 — zone constraints', () => {
   });
 
   it('preserves within-zone order — reordering is the whole point of the field', () => {
-    const result = readWorkspace({ ...VALID, zoneOrder: { main: ['rxTx', 'vfo'] } });
-    expect(result.workspace.zoneOrder.main).toEqual(['rxTx', 'vfo']);
+    const result = readWorkspace({ ...VALID, zoneOrder: { 'receiver-deck': ['rxTx', 'vfo'] } });
+    expect(result.workspace.zoneOrder['receiver-deck']).toEqual(['rxTx', 'vfo']);
   });
 
   it('a malformed zone map degrades to empty rather than throwing', () => {

--- a/frontend/src/presentation/workspace/__tests__/store.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/store.test.ts
@@ -254,12 +254,12 @@ describe('semantic actions go through the validator (MOR-1079)', () => {
     setDesignLanguage('fieldline');
     setTheme('lcd-warm');
     setZoneVisibleSurfaces('rx-tx', ['rxTx']);
-    setZoneOrder('main', ['vfo', 'meters']);
+    setZoneOrder('receiver-deck', ['vfo', 'meters']);
     setPinnedCommands(['set_compressor']);
 
     expect(getWorkspace()).toMatchObject({
       layout: 'lcd-cockpit', designLanguage: 'fieldline', theme: 'lcd-warm',
-      visibleSurfaces: { 'rx-tx': ['rxTx'] }, zoneOrder: { main: ['vfo', 'meters'] },
+      visibleSurfaces: { 'rx-tx': ['rxTx'] }, zoneOrder: { 'receiver-deck': ['vfo', 'meters'] },
       pinnedCommands: ['set_compressor'],
     });
     expect(stored(storage).theme).toBe('lcd-warm');
@@ -279,10 +279,10 @@ describe('semantic actions go through the validator (MOR-1079)', () => {
   });
 
   it('rejects a cross-zone duplicate rather than persisting it', () => {
-    setZoneOrder('main', ['vfo']);
+    setZoneOrder('receiver-deck', ['vfo']);
     setZoneOrder('rx-tx', ['vfo']);
 
-    expect(getWorkspace().zoneOrder).toEqual({ main: ['vfo'], 'rx-tx': [] });
+    expect(getWorkspace().zoneOrder).toEqual({ 'receiver-deck': ['vfo'], 'rx-tx': [] });
     expect(getWorkspaceNotice()?.rejections).toContainEqual({ field: 'zoneOrder.rx-tx', reason: 'cross-zone' });
   });
 
@@ -312,12 +312,12 @@ describe('resetWorkspace (MOR-1080)', () => {
   it('restores every typed field to the frozen defaults and returns the prior snapshot', () => {
     setTheme('nord', true);
     setLayout('lcd-scope');
-    setZoneOrder('main', ['vfo']);
+    setZoneOrder('receiver-deck', ['vfo']);
 
     const previous = resetWorkspace();
 
     expect(getWorkspace()).toEqual(DEFAULT_WORKSPACE);
-    expect(previous).toMatchObject({ theme: 'nord', layout: 'lcd-scope', zoneOrder: { main: ['vfo'] } });
+    expect(previous).toMatchObject({ theme: 'nord', layout: 'lcd-scope', zoneOrder: { 'receiver-deck': ['vfo'] } });
     expect(stored(storage).theme).toBe('default');
   });
 

--- a/frontend/src/presentation/workspace/__tests__/workspace-compatibility-verification.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/workspace-compatibility-verification.test.ts
@@ -500,12 +500,12 @@ describe('MOR-1083 class 3 — corrupt and partial stored state', () => {
     const storage = new LedgerStorage();
     storage.map.set(WORKSPACE_STORAGE_KEY, JSON.stringify({
       version: 1,
-      zoneOrder: { main: ['vfo', 'rxTx'], 'rx-tx': ['vfo'] },
+      zoneOrder: { 'receiver-deck': ['vfo', 'rxTx'], 'rx-tx': ['vfo'] },
     }));
 
     initWorkspaceStore(storage);
 
-    expect(getWorkspace().zoneOrder).toEqual({ main: ['vfo', 'rxTx'], 'rx-tx': [] });
+    expect(getWorkspace().zoneOrder).toEqual({ 'receiver-deck': ['vfo', 'rxTx'], 'rx-tx': [] });
     expect(getWorkspaceNotice()?.rejections).toContainEqual({ field: 'zoneOrder.rx-tx', reason: 'cross-zone' });
   });
 
@@ -640,8 +640,8 @@ describe('MOR-1083 class 5 — export / import round trip', () => {
     setLayout('lcd-scope');
     setDesignLanguage('fieldline');
     setDensity('compact');
-    setZoneVisibleSurfaces('main', ['vfo', 'rxTx']);
-    setZoneOrder('main', ['rxTx', 'vfo']);
+    setZoneVisibleSurfaces('receiver-deck', ['vfo', 'rxTx']);
+    setZoneOrder('receiver-deck', ['rxTx', 'vfo']);
     setPinnedCommands(['set_compressor', 'set_monitor']);
 
     const first = JSON.stringify(exportWorkspace());
@@ -794,8 +794,8 @@ function exerciseStore(): void {
   setTheme('crt-green', true);
   setDesignLanguage('fieldline');
   setDensity('compact');
-  setZoneVisibleSurfaces('main', ['vfo', 'rxTx']);
-  setZoneOrder('main', ['rxTx', 'vfo']);
+  setZoneVisibleSurfaces('receiver-deck', ['vfo', 'rxTx']);
+  setZoneOrder('receiver-deck', ['rxTx', 'vfo']);
   setPinnedCommands(['set_compressor']);
 }
 


### PR DESCRIPTION
3 code + 0 regenerated baselines = 3 files

Linear: MOR-2231 (preparatory — no behaviour change)

## Why

Three workspace suites used `'main'` as their stand-in for "some valid zone id".
`'main'` is declared by exactly one manifest — `sdr-test` — so it is not a shared
id at all. `presentation/workspace/__tests__/contract.test.ts` pins
`WORKSPACE_ZONE_IDS` to be **exactly** the union of every registered manifest's
zone ids, so renaming `sdr-test`'s `main` zone forces `'main'` out of that list
and breaks these three files on both TypeScript (`WorkspaceZoneId`) and
assertions — for a reason unrelated to what they test.

Measured on this worktree at `d61c37bf`, with the rename applied as a throwaway
probe and then reverted: `npm run check` reported 8 errors in 3 files and
`vitest` failed 8 files / 15 tests. Moving the generic fixture out of the way
first is what keeps the follow-up inside the file-count guardrail.

## What changed

`'main'` → `'receiver-deck'` as the generic zone-id fixture in:

- `frontend/src/presentation/workspace/__tests__/contract.test.ts`
- `frontend/src/presentation/workspace/__tests__/store.test.ts`
- `frontend/src/presentation/workspace/__tests__/workspace-compatibility-verification.test.ts`

`'receiver-deck'` is declared by `desktop-v2`, so it stays a `WORKSPACE_ZONE_IDS`
member independently of `sdr-test`, and it is already listed in
`workspace-compatibility-verification.test.ts`'s `FROZEN_VOCABULARY`. No source
file changes; `WORKSPACE_ZONE_IDS` itself is untouched, so `'main'` remains a
legal id here. Each cross-zone-duplicate case still names two distinct zones
(`receiver-deck` vs `rx-tx`; `contract.test.ts`'s own case uses
`primary-vfo`/`secondary-vfo` and was not touched).

## Not migrated, deliberately

`preferences-adoption.test.ts` and
`components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts` also
say `'main'`, but there it is the real `sdrTestLayout` manifest's own zone id,
read back through `plan(sdrTestLayout, …)` / `planFor(sdrTestLayout, …)`. A
shared id would be inert in those assertions, so they follow the manifest rather
than this fixture.

## Evidence

- `npx vitest run` on the three changed files: **3 files / 174 tests passed**.
- `npm run check`: **0 errors, 0 warnings** (4634 files).
- `npx eslint` on the three changed files: clean (exit 0).
- **Mutation**: removing `'receiver-deck'` from `WORKSPACE_ZONE_IDS` fails **7
  tests across all three files** — so the migrated id is validated through the
  zone allow-list rather than passing vacuously. Mutation reverted; `git diff`
  against the commit shows only the three test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
