### PR TITLE
fix(stage): make the stage's layout box equal what it paints

### DIFF
--- a/frontend/src/primitives/stage/ScaledStage.svelte
+++ b/frontend/src/primitives/stage/ScaledStage.svelte
@@ -10,14 +10,13 @@
   Nothing inside the stage reflows in response to the host resizing — only
   the transform on the stage element changes.
 
-  MOR-2251: `flex-shrink: 0` on `.scaled-stage` (below) makes one specific
-  way that guarantee could be broken mechanically impossible, rather than
-  relying on this paragraph: an ancestor rule that turns this element into
-  a flex item — e.g. a `display: flex` re-added to `.scaled-stage-holder`,
-  the exact shape of the MOR-2153 F1 defect — can no longer shrink it off
-  its authored size. It does not block every conceivable override; see the
-  property's own comment for what was checked about the equivalent grid
-  case.
+  THREE ELEMENTS, IN THIS ORDER (MOR-2270). The holder scrolls; the wrapper
+  carries the PAINTED size (`native x scale`); the stage carries the NATIVE
+  size and the transform. Chrome computes a scroll container's scrolling
+  area from its descendants' UNTRANSFORMED layout boxes, so the wrapper —
+  not the stage — is what holds that area down to what is actually painted.
+  The readings behind this are in the MOR-2270 block in
+  `__tests__/ScaledStage.isolated.test.ts`.
 
   CHROME MUST BE A SIBLING OF THE STAGE, NEVER A CHILD. `transform: scale()`
   establishes a new containing block for `position: fixed` descendants, and
@@ -76,10 +75,6 @@
   let scale = $state(1);
   let offsetX = $state(0);
   let offsetY = $state(0);
-  /** Whether `minScale` is currently raising the scale above the fit — i.e.
-   *  whether the stage is painted larger than the measured host box. Gates
-   *  the holder's `overflow`; see the markup below. */
-  let floorActive = $state(false);
 
   // `anchor === 'top-left'` ignores `offsetX`/`offsetY` entirely (see
   // `transform` below), so the default's rendered `transform` string is
@@ -93,23 +88,20 @@
 
     const native: StageBox = { width: nativeW, height: nativeH };
 
-    // Writes only to `scale`/`offsetX`/`offsetY`/`floorActive` — never back
-    // onto `holder`'s size (MOR-2147, see file header). `scale` and
-    // `floorActive` are written but never READ as
-    // `$state` inside this effect: `computeStageCenterOffset` takes the
-    // local `nextScale` below instead of the `scale` binding. Reading
-    // `scale` here would register it as a dependency of this effect, and
-    // since the write just above just changed it, the effect would
-    // self-invalidate and re-run once per mount — tearing down and
+    // Writes only to `scale`/`offsetX`/`offsetY` — never back onto
+    // `holder`'s size (MOR-2147, see file header). `scale` is written but
+    // never READ as `$state` inside this effect: `computeStageCenterOffset`
+    // takes the local `nextScale` below instead of the `scale` binding.
+    // Reading `scale` here would register it as a dependency of this
+    // effect, and since the write just above just changed it, the effect
+    // would self-invalidate and re-run once per mount — tearing down and
     // reconstructing the `ResizeObserver` below for no observable benefit
     // (the re-run recomputes the same scale from the same unchanged host
     // box). Regression found by an independent verifier on this branch.
     const measure = (host: StageBox) => {
       if (host.width <= 0 || host.height <= 0) return;
-      const fit = computeStageScale(host, native);
       const nextScale = computeStageScale(host, native, minScale);
       scale = nextScale;
-      floorActive = nextScale > fit;
       const offset = computeStageCenterOffset(host, native, nextScale);
       offsetX = offset.x;
       offsetY = offset.y;
@@ -131,22 +123,11 @@
   });
 </script>
 
-<!-- `overflow` is gated on the floor here rather than declared in the
-     `<style>` block below: `auto` only while the floor is holding the stage
-     past this box, so that overflow stays reachable, and `hidden` otherwise.
-     Unconditional `auto` is not inert when the floor is idle. The scrollable
-     area is the UNTRANSFORMED layout box of `.scaled-stage`, which the
-     inline width/height below hold at the native size at every scale — so
-     it overflows the host at every scale below 1. Measured in Chrome
-     on `LcdLayout variant="peer-split"` at a 1280x800 viewport: an 802x337
-     holder with a 1280x540 scroll area, scrollable 478x203 past a stage the
-     fit had already sized to fit it (scale 0.624, painted 799x337).
-     `hidden` takes away the scrollbars and the wheel path, not the area:
-     with the gate in place the same holder still reports `scrollWidth`/
-     `scrollHeight` 1280x540 and still scrolls 478x203 from script. -->
-<div class="scaled-stage-holder" style:overflow={floorActive ? 'auto' : 'hidden'} bind:this={holder}>
-  <div class="scaled-stage" style:width="{nativeW}px" style:height="{nativeH}px" style:transform>
-    {@render children()}
+<div class="scaled-stage-holder" bind:this={holder}>
+  <div class="scaled-stage-box" style:width="{nativeW * scale}px" style:height="{nativeH * scale}px">
+    <div class="scaled-stage" style:width="{nativeW}px" style:height="{nativeH}px" style:transform>
+      {@render children()}
+    </div>
   </div>
 </div>
 
@@ -155,26 +136,22 @@
     position: relative;
     width: 100%;
     height: 100%;
-    /* No `overflow` here on purpose — it is an inline, floor-gated value on
-       the element itself. See the comment above the markup. */
+    overflow: auto;
+  }
+
+  .scaled-stage-box {
+    /* MOR-2251's declaration, moved here by MOR-2270: `flex-shrink` applies
+       to a flex ITEM, and the holder's child is now this element.
+       It is NOT what resists a `display: flex` re-added to
+       `.scaled-stage-holder` — MEASURED on this shape, the element keeps
+       its declared size there with the declaration defeated
+       (`flex-shrink: 1`) just as with it, because the stage inside raises
+       the automatic minimum size above the painted width. The declaration
+       binds once something also sets `min-width`/`min-height: 0` here. */
+    flex-shrink: 0;
   }
 
   .scaled-stage {
     transform-origin: top left;
-    /* MOR-2251: makes the MOR-2153 defect class unrepresentable rather than
-       patching the one instance of it. Any ancestor that turns this element
-       into a flex item — including a `display: flex` re-added to its own
-       `.scaled-stage-holder`, the exact shape of the deleted rule this
-       guards against — can no longer shrink it off its native size.
-       Verified NOT to be needed for the equivalent grid case: a headless
-       Chrome probe (four ancestor variants: `place-items: center`, no
-       `place-items` at all, an explicit `1fr` track, and `place-items:
-       stretch`) found a grid item that declares an explicit width/height,
-       as this element always does via the `style:width`/`style:height`
-       above, is never shrunk by grid's stretch defaults — those fall back
-       to `start` positioning at the item's own size once a definite
-       preferred size is present, so `flex-shrink` (a no-op outside a flex
-       formatting context) has nothing to correct there. */
-    flex-shrink: 0;
   }
 </style>

--- a/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
+++ b/frontend/src/primitives/stage/__tests__/ScaledStage.isolated.test.ts
@@ -269,7 +269,7 @@ describe('ScaledStage — anchor prop (MOR-2251)', () => {
   });
 });
 
-describe('ScaledStage — .scaled-stage declares flex-shrink: 0 (MOR-2251)', () => {
+describe('ScaledStage — .scaled-stage-box declares flex-shrink: 0 (MOR-2251, moved by MOR-2270)', () => {
   // This is a TEXT pin on the component's own <style> block, the same
   // idiom `PeerSplitLayout.component.test.ts`'s `declarationsFor` uses
   // (read that file before touching this one). It verifies the
@@ -281,11 +281,11 @@ describe('ScaledStage — .scaled-stage declares flex-shrink: 0 (MOR-2251)', () 
   // component <style> during a mount ... every element's getComputedStyle
   // reads the UA default regardless of what any <style> block declares").
   // A comment claiming this test proves the stage cannot reflow would be
-  // false. What it does prove: the declaration is the ENTIRE mechanism —
-  // no other property makes `.scaled-stage` shrink-proof, and the grid
-  // case (see the property's own comment in ScaledStage.svelte) needs no
-  // second declaration — so deleting this line is the only regression path
-  // for this fix, and this pin fails exactly on that deletion.
+  // false.
+  //
+  // MOR-2270 moved the declaration from `.scaled-stage` to the wrapper:
+  // `flex-shrink` only ever applies to a flex ITEM, and the holder's child
+  // is now `.scaled-stage-box`, not `.scaled-stage`.
   const source = readFileSync('src/primitives/stage/ScaledStage.svelte', 'utf8');
   const styleBlock = source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? '';
   const css = styleBlock.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -305,9 +305,17 @@ describe('ScaledStage — .scaled-stage declares flex-shrink: 0 (MOR-2251)', () 
     throw new Error(`no rule for selector "${selector}" in ScaledStage.svelte's <style> block`);
   }
 
-  it('declares flex-shrink: 0', () => {
-    const stage = declarationsFor('.scaled-stage');
-    expect(stage['flex-shrink']).toBe('0');
+  it('declares flex-shrink: 0 on the wrapper', () => {
+    const box = declarationsFor('.scaled-stage-box');
+    expect(box['flex-shrink']).toBe('0');
+  });
+
+  it('the holder declares overflow: auto in the stylesheet, not per measurement', () => {
+    // MOR-2270 removed the MOR-2259 inline gate. `auto` is now a plain
+    // stylesheet declaration; `mountsNoInlineOverflow` below pins the other
+    // half — that no inline value is written back onto the element.
+    const holder = declarationsFor('.scaled-stage-holder');
+    expect(holder.overflow).toBe('auto');
   });
 });
 
@@ -346,72 +354,100 @@ describe('ScaledStage — the minScale floor (MOR-2259)', () => {
   });
 });
 
-describe('ScaledStage — the holder scrolls only while the floor clamps (MOR-2259)', () => {
-  // NOT the TEXT-pin idiom above: `overflow` is an inline value the
-  // component computes per measured host box, so jsdom exposes the real
-  // decision on `holder.style.overflow` even though it lays nothing out.
+describe('ScaledStage — the wrapper carries the painted size (MOR-2270)', () => {
+  // The scrolling area of `.scaled-stage-holder` is computed from its
+  // descendants' UNTRANSFORMED layout boxes — MEASURED in Chrome 152, not
+  // reasoned from the spec: an 802x337 holder over a single 1280x540 child
+  // scaled 0.624421 reports `scrollWidth`/`scrollHeight` 1280x540, under
+  // `overflow: auto` and `overflow: hidden` alike; the same holder over a
+  // wrapper sized 799.259x337.187 (native x scale) with that same scaled
+  // child inside reports 802x337, i.e. exactly its client box. That is what
+  // this wrapper is for, and it is the part jsdom cannot show: it lays
+  // nothing out, so what is pinned below is the input Chrome's computation
+  // reads — the wrapper's own declared box — not the scrolling area it
+  // produces.
   //
-  // What jsdom cannot show is the consequence — whether Chrome then
-  // reserves a scroll area. The two host boxes below are the ones Chrome
-  // actually gave `.scaled-stage-holder` under `LcdLayout
-  // variant="peer-split"`: 802x337 at a 1280x800 viewport, 522x219 at
-  // 1000x800. Each test asserts the geometry that makes `overflow`
-  // load-bearing at that host — the stage's inline layout box exceeds the
-  // host either way, so `hidden` versus `auto` is the whole difference —
-  // alongside the value itself. A pin on the value alone would have passed
-  // against the unconditional `overflow: auto` this replaces.
+  // The two host boxes are the ones `LcdLayout variant="peer-split"` gives
+  // this holder in a real browser, re-derived for MOR-2270 rather than
+  // trusted from MOR-2259: client 802x337 at a 1280x800 viewport, client
+  // 522x219 at 1000x800.
   const NATIVE_W = 1280;
   const NATIVE_H = 540;
   const FLOOR = 0.5;
 
   const holderOf = (target: HTMLElement) => target.querySelector<HTMLElement>('.scaled-stage-holder')!;
+  const boxOf = (target: HTMLElement) => target.querySelector<HTMLElement>('.scaled-stage-box')!;
   const stageOf = (target: HTMLElement) => target.querySelector<HTMLElement>('.scaled-stage')!;
 
-  it('a host the painted stage already fits inside gets `hidden`', () => {
+  it('sizes the wrapper to native x scale while the stage keeps its native box', () => {
     containerSize = { width: 802, height: 337 };
     const target = mountStage(NATIVE_W, NATIVE_H, { minScale: FLOOR });
 
     // The floor is idle here: height is the binding axis and its ratio is
     // above the floor, so the scale is that ratio exactly.
-    expect(readScale(target)).toBe(337 / NATIVE_H);
-    expect(readScale(target)).toBeGreaterThan(FLOOR);
-    // The untransformed layout box still overflows the host on both axes...
-    expect(parseFloat(stageOf(target).style.width)).toBeGreaterThan(802);
-    expect(parseFloat(stageOf(target).style.height)).toBeGreaterThan(337);
-    // ...while the painted box does not: its height equals the host's by the
-    // equality above, and its width is short of it.
-    expect(readScale(target) * NATIVE_W).toBeLessThan(802);
+    const scale = readScale(target);
+    expect(scale).toBe(337 / NATIVE_H);
+    expect(scale).toBeGreaterThan(FLOOR);
 
-    expect(holderOf(target).style.overflow).toBe('hidden');
+    // The wrapper is the painted box...
+    expect(boxOf(target).style.width).toBe(`${NATIVE_W * scale}px`);
+    expect(boxOf(target).style.height).toBe(`${NATIVE_H * scale}px`);
+    // ...and it fits inside the host on both axes, which is what makes the
+    // holder's `overflow: auto` inert at this host.
+    expect(NATIVE_W * scale).toBeLessThanOrEqual(802);
+    expect(NATIVE_H * scale).toBeLessThanOrEqual(337);
+
+    // ...while the stage inside it keeps the native box the transform scales.
+    expect(stageOf(target).style.width).toBe(`${NATIVE_W}px`);
+    expect(stageOf(target).style.height).toBe(`${NATIVE_H}px`);
+    expect(stageOf(target).style.transform).toBe(`scale(${scale})`);
   });
 
-  it('a host the floored stage overflows gets `auto`', () => {
+  it('sizes the wrapper past the host on both axes while the floor clamps', () => {
     containerSize = { width: 522, height: 219 };
     const target = mountStage(NATIVE_W, NATIVE_H, { minScale: FLOOR });
 
     expect(readScale(target)).toBe(FLOOR);
-    // The painted box is larger than the host on both axes, so the part
-    // outside it is only reachable if the holder scrolls.
-    expect(readScale(target) * NATIVE_W).toBeGreaterThan(522);
-    expect(readScale(target) * NATIVE_H).toBeGreaterThan(219);
-
-    expect(holderOf(target).style.overflow).toBe('auto');
+    // The wrapper is larger than the host on both axes, so the part outside
+    // it is only reachable because the holder scrolls.
+    expect(boxOf(target).style.width).toBe(`${NATIVE_W * FLOOR}px`);
+    expect(boxOf(target).style.height).toBe(`${NATIVE_H * FLOOR}px`);
+    expect(NATIVE_W * FLOOR).toBeGreaterThan(522);
+    expect(NATIVE_H * FLOOR).toBeGreaterThan(219);
   });
 
   it('follows the host box rather than being fixed at mount', () => {
     containerSize = { width: 522, height: 219 };
     const target = mountStage(NATIVE_W, NATIVE_H, { minScale: FLOOR });
-    expect(holderOf(target).style.overflow).toBe('auto');
+    expect(boxOf(target).style.width).toBe(`${NATIVE_W * FLOOR}px`);
 
     resizeContainer(802, 337);
 
-    expect(holderOf(target).style.overflow).toBe('hidden');
+    const scale = readScale(target);
+    expect(boxOf(target).style.width).toBe(`${NATIVE_W * scale}px`);
+    expect(boxOf(target).style.height).toBe(`${NATIVE_H * scale}px`);
   });
 
-  it('with no floor declared, even a host far too small for the fit gets `hidden`', () => {
+  it('writes no inline overflow onto the holder — the MOR-2259 gate is gone', () => {
     containerSize = { width: 100, height: 100 };
     const target = mountStage(NATIVE_W, NATIVE_H);
 
-    expect(holderOf(target).style.overflow).toBe('hidden');
+    expect(holderOf(target).style.overflow).toBe('');
+  });
+
+  it('nests holder > wrapper > stage, each with exactly one child', () => {
+    // The transform must stay INSIDE the wrapper: a wrapper below the
+    // transform, or the two merged back into one element, both restore the
+    // untransformed 1280x540 layout box as the holder's scrolling area.
+    containerSize = { width: 802, height: 337 };
+    const target = mountStage(NATIVE_W, NATIVE_H);
+
+    const holder = holderOf(target);
+    const box = boxOf(target);
+    const stage = stageOf(target);
+    expect(holder.children.length).toBe(1);
+    expect(holder.firstElementChild).toBe(box);
+    expect(box.firstElementChild).toBe(stage);
+    expect(box.style.transform).toBe('');
   });
 });

--- a/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
+++ b/frontend/src/skins/segmentline/__tests__/PeerSplitLayout.component.test.ts
@@ -382,6 +382,25 @@ describe('the glass bezel keeps its own CSS after the chassis class it used to w
     const strips = declarationsFor('.peer-split-glass :global(.channel-strips.channel-strips)');
     expect(strips['grid-template-columns']).toBe('subgrid');
   });
+
+  // This file's `:global(.scaled-stage-holder)` rule gives the holder
+  // `flex: 1` so it claims the flex line instead of content-sizing to zero
+  // (see that rule's own comment). `flex` applies to a flex ITEM only, so
+  // the rule is load-bearing only while the holder is a DIRECT child of
+  // `.peer-split-holder`. The selector is a descendant combinator: it would
+  // keep matching, while silently doing nothing, if `ScaledStage` ever grew
+  // an element ABOVE its holder. MOR-2270 added a wrapper INSIDE the
+  // holder, which leaves this intact — this pin is what makes the next
+  // restructuring say so instead of collapsing the glass quietly.
+  it('keeps ScaledStage\'s holder a direct child of .peer-split-holder', () => {
+    render();
+    const outer = q<HTMLElement>('.peer-split-holder');
+    const holder = q<HTMLElement>('.scaled-stage-holder');
+    expect(outer).not.toBeNull();
+    expect(holder).not.toBeNull();
+    expect(holder!.parentElement).toBe(outer);
+    expect(declarationsFor('.peer-split-holder :global(.scaled-stage-holder)').flex).toBe('1');
+  });
 });
 
 describe('the glass forwards the shell-resolved scale floor to its stage (MOR-2259)', () => {


### PR DESCRIPTION
`.scaled-stage` carried the native size and was scaled by a `transform`.
Chrome computes a scroll container's scrolling area from its descendants'
**untransformed** layout boxes, so `.scaled-stage-holder` reserved the native
area at every scale. MOR-2259 gated `overflow` to hide that; this removes the
gate and fixes the area itself.

## Shape

    holder   .scaled-stage-holder   100%/100%, position: relative, overflow: auto (unconditional)
      NEW    .scaled-stage-box      inline width/height = native x scale, flex-shrink: 0
        stage .scaled-stage         inline width/height = native, transform-origin: top left,
                                    inline transform = scale

## Measurements

Real shell (`LcdPeerSplitSkin` -> `LcdLayout variant="peer-split"`) over the
fixtures stubs, Chrome 152, four viewports. **Control** = a hand-built holder
carrying the **pre-change** structure at that point's own measured host box.

| viewport | holder client | scale | floor | wrapper | holder scroll area | control (pre-change) |
|---|---|---|---|---|---|---|
| 1280x800 | 802x337 | 0.624421 | idle | 799.259x337.188 | **802x337 = client** | 1280x540 |
| 1440x900 | 962x405 | 0.749421 | idle | 959.259x404.688 | **962x405 = client** | 1280x540 |
| 1100x800 | 622x261 | 0.5 | **ACTIVE** | 640x270 | 640x270 | 1280x540 |
| 1000x800 | 522x219 | 0.5 | **ACTIVE** | 640x270 | 640x270 | 1280x540 |

The control reports an oversized area at all four host boxes, so the instrument
can see the defect. Acceptance met where it applies: at the floor-idle
viewports the scrolling area now **equals** the client box.

### Finding against the brief's table: 1100x800 is floor-ACTIVE

The brief listed 1100x800 as scale 0.483 / floor inactive, i.e. three no-floor
points. Measured, the holder there is 622x261.25, so the unfloored fit is
min(0.4859, 0.4838) = **0.4838** — below the group's `minScale` 0.5 — and
`computeStageScale` floors it to 0.5. 0.483 is the *fit*; the *applied* scale
is 0.5 and the floor is holding. **Two** of the four points are floor-idle, not
three. Nothing else in the brief depends on the count.

### Wheel, with the inner scrollers present

`.semantic-surfaces` (scrollHeight 531 / clientHeight 508) and
`.meters-surface` sit inside the transformed subtree.

- Floor-idle viewports: vertical wheel over the holder centre scrolls
  `.semantic-surfaces` to 22.5 and leaves the holder at 0; horizontal leaves it
  at 0; a scripted `scrollTop/Left = 9999` also yields 0/0. The holder has
  nothing to scroll, so unconditional `auto` is inert there — no change from
  the `hidden` it replaces.
- Floor-active viewports: gesture 1 goes to the inner scroller (22.5 of 23),
  gesture 2 scrolls the holder to its maximum (51 at 1000x800), gestures 3-6
  change nothing. The floored overflow is reachable; that is the same
  "absorbed, then chaining" shape MOR-2259 recorded.

### Grid, re-established on the new two-element shape

MOR-2251's grid conclusion was measured on the single-element shape, so it was
re-run against the wrapper: four ancestor variants (`place-items: center`, no
`place-items`, an explicit `1fr` track, `place-items: stretch`), with and
without the declaration. The wrapper keeps 799.258x337.188 in all eight. The
"without" arm sets `flex-shrink: 1` explicitly — clearing only the inline
property would leave the class rule in force and make the arm vacuous.

### `flex-shrink: 0` is not what resists a flex ancestor here

Positive control on the real wrapper, flex ancestor 300x200:

| case | result |
|---|---|
| as shipped (`flex-shrink: 0`) | 799.258 x 337.188 |
| declaration defeated (`flex-shrink: 1`) | 799.258 x 337.188 |
| `flex-shrink: 1` + `min-width: 0` | **300** x 337.188 |
| `flex-shrink: 0` + `min-width: 0` | 799.258 x 337.188 |
| column, `flex-shrink: 1` + `min-height: 0` | 799.258 x **200** |

The stage inside raises the wrapper's automatic minimum size above the painted
width, so the wrapper holds its declared size with the declaration defeated.
The declaration binds only once something also sets `min-width`/`min-height: 0`.
MOR-2251's "makes the defect class unrepresentable" wording does **not**
transfer to this shape; the property's comment now records what was measured
instead of carrying the old claim forward. The declaration is kept — it is the
correct placement, and it does bind in the `min-*: 0` case.

## Reddened pins, and why each was correct

| pin | why it reddened | disposition |
|---|---|---|
| `.scaled-stage declares flex-shrink: 0` (MOR-2251) | the declaration moved to the wrapper | **moved** to `.scaled-stage-box`, plus its comment corrected |
| 4x MOR-2259 `overflow` gate tests | the gate and `floorActive` are gone; `style.overflow` is now `''` | **deleted**, replaced by five wrapper-geometry pins |

The four gate tests asserted the inline value the gate wrote. With `overflow`
now a stylesheet declaration there is no inline value to assert, so they were
replaced rather than adapted: the replacements pin the wrapper's declared box
(the input Chrome's scrolling-area computation reads) and a text pin on the
holder's `overflow: auto`.

## Mutations run

| mutation | killed |
|---|---|
| delete `flex-shrink: 0` from `.scaled-stage-box` | `declares flex-shrink: 0 on the wrapper` (1) |
| wrapper sized at `native` instead of `native x scale` (reinstates the bug) | 3 wrapper-geometry tests |
| an element inserted ABOVE the holder in `ScaledStage` | `keeps ScaledStage's holder a direct child of .peer-split-holder` (1) |
| delete `flex: 1` from the consumer's `:global()` rule | the same pin (1) |

The last two matter because that pin passes both before and after this change;
without a mutation it would be a pin that cannot discriminate.

## New pin on the consumer's `:global()` dependency

`PeerSplitLayout.svelte` reaches into the primitive with
`.peer-split-holder :global(.scaled-stage-holder) { flex: 1 }`. `flex` applies
to a flex ITEM, so the rule is load-bearing only while the holder is a DIRECT
child — a descendant combinator would keep matching while silently doing
nothing if the primitive ever grew an element above its holder. Pinned in
`PeerSplitLayout.component.test.ts`.

## Out of scope, unchanged

`computeStageCenterOffset`, its clamp and their pins are untouched (holder-level
centring is separate). The "CHROME MUST BE A SIBLING OF THE STAGE" contract is
unaffected: the transform stays on `.scaled-stage` and `children` still render
inside it, so the containing block for `position: fixed` descendants is
unchanged.

## Noted, not fixed

- `ScaledStage.isolated.test.ts` hard-codes `containerSize = { width: 802, height: 337 }`
  as a jsdom fixture with a comment saying it came from the real app at
  1280x800. It is hand-measured with no standing check — if the shell's sidebar
  widths change it goes stale silently and the test keeps passing against a
  fiction. This PR re-derived both host boxes (802x337.188 and 522x219.063) but
  did not add a check.
- `declarationsFor` in both test files slices the component with
  `/<style>([\s\S]*?)<\/style>/`. The pre-change `ScaledStage.svelte` contained
  the literal `<style>` inside a markup comment, so the regex matched there and
  the helper parsed the wrong text — visible in this branch's TDD red run as
  "no rule for selector .scaled-stage-holder" against a file that plainly
  declares it. This change removes that comment, so the slice is correct again,
  but the fragility remains in both copies of the helper.