### PR TITLE
fix: declare tone and TSQL frequency as acquisition-observable

### DIFF
--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -271,6 +271,20 @@ command_response_observable = [
     "global.operator_controls.key_speed",
     "global.operator_controls.cw_pitch",
     "receiver.main.operator_toggles.twin_peak_filter",
+    # MOR-2234 group B: CTCSS tone / TSQL tone frequency (0x1B 0x00 / 0x1B
+    # 0x01). ``[commands]`` below declares get_tone_freq/get_tsql_freq,
+    # ``runtime/_state_queries.py: acquisition_query_resolver_for_profile``
+    # resolves both through _RECEIVER_CONTROL_GETTERS, and
+    # ``runtime/_civ_rx.py: CivRuntime._observations_from_frame`` decodes the
+    # 0x1B replies -- but neither path was in ANY list here, so
+    # ``capability_for`` returned the default UNKNOWN and neither
+    # ``due_requests`` nor ``prime_unobserved`` ever asked for them.
+    # Non-polling membership, not polling_only: reached by prime_unobserved
+    # off the matching field_policies entries below, and refreshed on
+    # command response. Pinned by
+    # test_ic7300_real_profile_primes_tone_and_tsql_freq_and_sends_1b_reads.
+    "receiver.main.operator_controls.tone_freq",
+    "receiver.main.operator_controls.tsql_freq",
 ]
 supported_controls = [
     "receiver.main.active.freq_mode.freq_hz",
@@ -653,6 +667,21 @@ reconciliation_priority = "command_response"
 adaptive_decay = false
 
 [state_acquisition.field_policies."receiver.main.operator_toggles.twin_peak_filter"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+# MOR-2234 group B: tone/TSQL frequency join the same non-polling
+# command_response membership as the CW keyer setpoints above, and copy
+# their 25.0s cadence/TTL pair verbatim.
+[state_acquisition.field_policies."receiver.main.operator_controls.tone_freq"]
+cadence_seconds = 25.0
+freshness_ttl_seconds = 25.0
+reconciliation_priority = "command_response"
+adaptive_decay = false
+
+[state_acquisition.field_policies."receiver.main.operator_controls.tsql_freq"]
 cadence_seconds = 25.0
 freshness_ttl_seconds = 25.0
 reconciliation_priority = "command_response"

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -2161,11 +2161,11 @@ def test_state_freshness_service_ic7300_non_polling_populate_completes_within_25
 ):
     """MOR-1501 acceptance criterion.
 
-    Simulates the real IC-7300 acquisition profile's 22 non-polling
+    Simulates the real IC-7300 acquisition profile's 24 non-polling
     ``field_policies`` fields populating from a cold connect (empty store).
     Before adaptive pacing, the flat 30s re-derivation interval combined
     with the unchanged 5-field burst cap gave this profile a ~120s tail
-    (``ceil(22 / 5) == 5`` waves, 30s apart), even though each field's true
+    (five 5-field-capped waves, 30s apart), even though each field's true
     CI-V round-trip cost is ~1.1s — the interval, not the serial link, was
     the bottleneck. With the 5s adaptive interval the same 5 waves complete
     in ~20-25s. This drives the scheduler/service pair directly (no real
@@ -2190,9 +2190,10 @@ def test_state_freshness_service_ic7300_non_polling_populate_completes_within_25
     # (MOR-1501) — guards against silent membership drift changing the
     # shape of this regression test without anyone noticing. MOR-2144 removes
     # only the unsupported APF path; the supported NB level stays scheduled.
+    # MOR-2234 adds tone_freq/tsql_freq, taking the count from 22 to 24.
     assert apf_path not in acquisition.field_policies
     assert nb_level_path in acquisition.field_policies
-    assert len(non_polling_paths) == 22
+    assert len(non_polling_paths) == 24
 
     clock = FreshnessClock(start=2000.0)
     store = StateStore(freshness_clock=clock)
@@ -3124,6 +3125,55 @@ def test_ic7300_real_profile_vox_delay_is_primed_and_executor_builds_multibyte_f
     execution = asyncio.run(executor.execute(request, already_sent_paths=frozenset()))
     assert execution.failed_paths == ()
     assert acquisition_query(0x1A, sub=0x05, data=b"\x01\x91") in sent
+
+
+def test_ic7300_real_profile_primes_tone_and_tsql_freq_and_sends_1b_reads() -> None:
+    """MOR-2234 group B: the scheduler must actually ask for tone/TSQL freq.
+
+    ``rigs/ic7300.toml`` declares ``get_tone_freq``/``get_tsql_freq`` and
+    ``runtime/_civ_rx.py`` decodes the ``0x1B`` replies, but neither path
+    appeared in any ``[state_acquisition.capabilities]`` list, so
+    ``capability_for`` returned the default UNKNOWN and no acquisition
+    mechanism ever reached them. Driving the real scheduler over a full
+    round-robin sweep of ``field_policies`` must queue both paths and the
+    CI-V executor must emit their declared ``1B 00`` / ``1B 01`` reads.
+    """
+
+    acquisition = load_rig(RIGS_DIR / "ic7300.toml").to_profile().state_acquisition
+    assert acquisition is not None
+
+    tone_freq = FieldPath.receiver("main", "operator_controls", "tone_freq")
+    tsql_freq = FieldPath.receiver("main", "operator_controls", "tsql_freq")
+    for path in (tone_freq, tsql_freq):
+        capability = acquisition.capability_for(path)
+        assert capability.is_unavailable is False
+        assert capability.can_poll is False
+        assert capability.command_response_observable is True
+
+    clock = FreshnessClock(start=400.0)
+    scheduler = AcquisitionScheduler(profile=acquisition, clock=clock)
+
+    # prime_unobserved caps each call at a burst limit and advances a
+    # round-robin cursor, so one call need not reach every policy field.
+    # len(field_policies) calls bound a full sweep from any start offset.
+    request_by_path: dict[FieldPath, Any] = {}
+    for _ in range(len(acquisition.field_policies)):
+        for request in scheduler.prime_unobserved(observed_paths=()):
+            for path in request.paths:
+                request_by_path.setdefault(path, request)
+    assert {tone_freq, tsql_freq} <= set(request_by_path)
+
+    # Both paths coalesce into one request (same scope/family/receiver/
+    # method/policy key), so one execution covers them.
+    request = request_by_path[tone_freq]
+    assert request_by_path[tsql_freq] is request
+    assert request.acquisition_method == "command_response"
+
+    executor, sent = recording_executor(get_radio_profile("IC-7300"))
+    execution = asyncio.run(executor.execute(request, already_sent_paths=frozenset()))
+    assert execution.failed_paths == ()
+    assert acquisition_query(0x1B, sub=0x00, receiver=0) in sent
+    assert acquisition_query(0x1B, sub=0x01, receiver=0) in sent
 
 
 def test_ic7610_real_profile_vfo_global_query_for_path() -> None:


### PR DESCRIPTION
`Linear: MOR-2234` (group B from the ticket's comment).

## The defect, and the evidence it is real

`receiver.main.operator_controls.tone_freq` and `.tsql_freq` are never observed on the IC-7300. Every mechanism below the declaration is present:

* `rigs/ic7300.toml` `[commands]` declares `get_tone_freq = [0x1B, 0x00]` / `get_tsql_freq = [0x1B, 0x01]`;
* `runtime/_state_queries.py: acquisition_query_resolver_for_profile` resolves both through `_RECEIVER_CONTROL_GETTERS`;
* `runtime/_civ_rx.py: CivRuntime._observations_from_frame` decodes the `0x1B` family onto those two paths.

What was missing is the declaration: neither path appeared in any list under `[state_acquisition.capabilities]`, so `core/state_acquisition_policy.py: RadioAcquisitionProfile.capability_for` returned its default `UNKNOWN` capability, and nothing ever asked.

Measured by driving the real scheduler against the loaded profile at the parent commit (`0e9795fa`), with positive controls in the same runs so a zero is not just a broken instrument:

```
field_policies=56 primed_paths=22
control vox_delay primed: True
tone_freq primed: False
tsql_freq primed: False
due_requests over 9 min: 37 paths; tone=False tsql=False
control af_level polled: True
```

## What was declared, and the TTL followed

Both paths added to `command_response_observable`, each with a `[state_acquisition.field_policies]` entry of `cadence_seconds = 25.0`, `freshness_ttl_seconds = 25.0`, `reconciliation_priority = "command_response"`, `adaptive_decay = false`.

The TTL is copied verbatim from this profile's existing non-polling `command_response` group — `global.operator_controls.cw_pitch`, `key_speed`, `break_in_delay` and the rest of the MOR-1483/1491/1492/1493 membership, all of which already declare exactly that 25.0/25.0 pair. Read from `rigs/ic7300.toml` itself; no number was invented.

The field policy is load-bearing, not decoration: `core/acquisition_scheduler.py: AcquisitionScheduler.prime_unobserved` iterates `field_policies`, so a capability with no policy entry is still never reached (mutation 2 below).

## Owner decision recorded

The choice between `command_response_observable` (+ field policy) and a `polling_only` cadence for these two fields was made by the implementer, not by the owner, and is open to reversal. Reasoning: these are setpoints, and a cadence would spend wire time on this profile's serial budget re-reading a value that only a write changes; `prime_unobserved` plus command-response refresh is what "never observed" needs fixing to. Promoting them to `polling_only` later is a one-line profile edit.

A difference I observed and raised, since resolved, and which does **not** bear on this choice: `rigs/ftx1.toml` declares these same two field paths `polling_only` with `cadence_seconds = 30.0` / `freshness_ttl_seconds = 120.0`. That is not a competing answer to the same question. The CI-V resolver `runtime/_state_queries.py: acquisition_query_resolver_for_profile` returns `None` for both paths on ftx1 — visible as `resolvable = 0` in the census table below — so the ftx1 entry is a Yaesu-CAT declaration (CAT `CN`, one shared tone for TONE and TSQL) and this one is a CI-V declaration. Two transports, two sets of per-radio data; no inconsistency to reconcile. Raising it was right, but it does not weigh against the capability class chosen here, and the number that settles it was already in my own census table, which I failed to read.

What remains open for the owner is the narrower question the heading names: whether `command_response_observable` or `polling_only` is the right class for these two fields **on the IC-7300**.

## Cross-profile census

Enumerated over the 8 shipped profiles (`rigs/*.toml` minus `_keyboard-default.toml`, the same directory-driven definition `tests/test_rig_loader.py` uses). The candidate path domain is **derived from the resolver's own getter tables** (`_RECEIVER_CONTROL_GETTERS`, `_RECEIVER_TOGGLE_GETTERS`, `_GLOBAL_*_GETTERS`, `_SCOPE_CONTROL_GETTERS`, freq_mode names) rather than hand-written, and the script asserts the domain is non-empty per profile. Script and commands:

```
# builder presence per profile
git grep -n "tone_freq\|tsql_freq" -- rigs/
# resolvable-but-undeclared per profile: an ad-hoc script run under
# `uv run python` from a scratch path (not tracked here); its core is:
```

Census script core (run at the parent commit and again at head):

```python
resolve = acquisition_query_resolver_for_profile(profile)
declared = {c.path for c in profile.state_acquisition.capabilities}
gaps = [p for p in candidate_paths(profile) if resolve(p) is not None and p not in declared]
```

Result at the parent commit:

| profile | provider | candidates | resolvable | declared | resolvable & undeclared |
|---|---|---|---|---|---|
| ftx1 | yaesu_cat | 120 | 0 | 55 | 0 |
| ic705 | icom_civ | 81 | 74 | 37 | 37 |
| ic7300 | icom_civ | 81 | 71 | 65 | 6 |
| ic7610 | icom_civ | 120 | 105 | 93 | 12 |
| ic9700 | icom_civ | 120 | 107 | 36 | 71 |
| tx500 | — | — | — | — | no `[state_acquisition]` block |
| x6100 | xiegu_civ | 81 | 30 | 5 | 26 |
| x6200 | xiegu_civ | 81 | 30 | 8 | 24 |

### tone_freq / tsql_freq specifically, across all 8 profiles

| profile | builder | resolves | ingress decode | declared | verdict |
|---|---|---|---|---|---|
| ic7300 | yes | yes | yes | **no** | **fixed here** |
| ic705 | yes | yes | yes | no | same shape — left unfixed, see below |
| ic9700 | yes | yes | yes | no | same shape — left unfixed, see below |
| ic7610 | **no** — `get_tone_freq`/`get_tsql_freq` declared `absent` | no | n/a | no | **differs**: the profile records a live-bench readback (MOR-660/661/682, re-checked MOR-2017) where these replies decoded to garbage (16.5 Hz) on this radio. Declaring them would be wrong. |
| ftx1 | CAT `CN` | **no** — CI-V resolver returns `None` for both | yes (Yaesu-CAT ingress) | **yes**, `polling_only` 30.0/120.0 | not in the CI-V class; declared on the Yaesu-CAT path, a separate question |
| x6100 | no | no | n/a | no | not in class |
| x6200 | no | no | n/a | no | not in class; the profile's own comment records RMVR tone checks timing out |
| tx500 | no | no | n/a | no | not in class; no `[state_acquisition]` block at all |

### Instances found and deliberately left unfixed

* **`tone_freq`/`tsql_freq` on `ic705` and `ic9700`.** Identical in shape for these two paths. Left unfixed because the gap there is not one-field residue: those profiles have 37 and 71 resolvable-but-undeclared paths respectively (50% and 34% declared), i.e. the acquisition programme was never completed for them, which is a different and much larger piece of work. Fixing only tone/TSQL there would be exactly the "one instance fixed, siblings left" pattern, at a scale this PR cannot cover, and neither radio is on the bench. IC-7300 is at 65/71 declared (92%) and is the radio the ticket's bench evidence comes from.
* **`ipplus`, `repeater_tone`, `repeater_tsql`, `unselected…filter_num` on `ic7300`** — the remaining 4 of the 6, dropping to 4 after this change. The first three are the same shape (builder + resolver + `_civ_rx.py` decode branch, no declaration) and are outside this ticket's group B, which names exactly `tone_freq` and `tsql_freq`. `repeater_tone`/`repeater_tsql` additionally carry the IC-7610 bench warning above, so declaring them on any radio wants its own evidence rather than a copy of this one.

Not established: whether the 4 remaining IC-7300 paths and the ic705/ic9700 sets are wholly the same defect or several. I did not measure that.

## Red, then green

The pin is `test_ic7300_real_profile_primes_tone_and_tsql_freq_and_sends_1b_reads` in `tests/test_acquisition_scheduler.py`. It instantiates the real `AcquisitionScheduler` on the loaded profile, drives `prime_unobserved` over a full round-robin sweep, and asserts both paths are queued **and** that the CI-V executor emits the declared `1B 00` / `1B 01` reads — dispatch, not the presence of a TOML key.

Red at the parent commit:

```
tests/test_acquisition_scheduler.py F                                    [100%]
____ test_ic7300_real_profile_primes_tone_and_tsql_freq_and_sends_1b_reads _____
tests/test_acquisition_scheduler.py:3148: in test_...
    assert capability.is_unavailable is False
E   AssertionError: assert True is False
E    +  where True = FieldCapability(... diagnostic='receiver.main.operator_controls.tone_freq: missing capability metadata').is_unavailable
======================= 1 failed, 94 deselected in 0.88s =======================
```

Green after the profile edit: `1 passed, 94 deselected in 6.92s`.

### Mutations run

* **Mutation 1 — remove the two `command_response_observable` entries, keep the field policies** (reinstates the exact bug). Killed the test at the declaration assertion; and, checked separately with the assertions stripped, the dispatch half dies too: `tone primed: False | tsql primed: False` with `control vox_delay primed: True` and `policy present for tone: True`. So the dispatch assertion discriminates rather than restating the edit.
* **Mutation 2 — remove the two `field_policies` blocks, keep the capability entries.** Killed the test at the **dispatch** assertion `assert {tone_freq, tsql_freq} <= set(request_by_path)` (line 3164 at branch head `32fc749e`) — the declaration assertions passed. This is the half a TOML-key test could not have caught.

Tree restored from a `shutil.copyfile` snapshot after each mutation; `git status` shows only the two intended files.

### One pre-existing guard updated

`test_state_freshness_service_ic7300_non_polling_populate_completes_within_25s` pins the profile's non-polling `field_policies` membership count. 22 → 24. Its `<= 25.0s` populate assertion still holds unchanged (`ceil(24 / 5)` is still 5 waves). The stale `ceil(22 / 5) == 5` arithmetic in its docstring was removed. Counts do remain in it — the opening `24` and `five 5-field-capped waves`. The `24` is pinned by the same `== 24` assertion, so it cannot drift silently; the `five 5-field-capped waves` phrase also depends on the prime burst limit, which that assertion does not check.

## Gates

```
uv run pytest tests/test_acquisition_scheduler.py tests/test_rig_loader.py \
  tests/test_profiles_routing.py tests/test_state_acquisition_policy.py -q --tb=short
                                          504 passed, 1 skipped, 1 warning in 17.84s
uv run ruff check src/ tests/             All checks passed!
uv run ruff format src/ tests/            710 files left unchanged
uv run lint-imports                       Contracts: 5 kept, 0 broken.
```

I also ran the 11 other test files that mention `state_acquisition` / `field_policies` / `capability_for` / `prime_unobserved`: **1373 passed, 1 xfailed, 1 failed**. The one failure is `tests/architecture/test_ui_radio_control_contract.py::test_authority_boundary_and_ten_class_adversarial_corpus_pass`, and it is unrelated: it shells out to `npx vitest` and failed on a 5000 ms `testTimeout` inside `frontend/src/__tests__/architecture-boundaries.test.ts` (`rejects the first hop of a two-file writer facade`) under 10-way parallel load. The same file passes on its own, serially and with `-n auto`. This diff touches no frontend file.

CI quick on this PR (run 33718494485): **14688 passed, 220 skipped, 16 xfailed** in 68.24s.

The delta this branch is responsible for is **1 test added, 0 removed**, in `tests/test_acquisition_scheduler.py`. The absolute count is not comparable to the `14684 passed` figure recorded against `a6ab594d`: this branch is cut from `0e9795fa`, so `main` moved in between and the remaining difference is not attributable here.

## Diffstat

```
$ git diff --stat origin/main...HEAD
 rigs/ic7300.toml                    | 29 +++++++++++++++++++
 tests/test_acquisition_scheduler.py | 56 +++++++++++++++++++++++++++++++++++--
 2 files changed, 82 insertions(+), 3 deletions(-)
```

2 files, 85 changed lines — under both the soft (6 / 600) and hard (10 / 1000) guardrails.

`Linear: MOR-2234`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Post-merge corrections to this body

Three corrections from the review, applied after merge; the code is unchanged.

1. **Mutation 2's line number.** This body originally said line 3163. The assertion is at **3164** at branch head `32fc749e` (verified by fetching the blob at that SHA). My 3163 came from the pytest output of the mutation run itself, which was accurate for the tree at that moment and went stale one step later: the membership-count fix added `# MOR-2234 adds tone_freq/tsql_freq…` at line 2193, shifting everything below it down by one. A measurement carried across a tree edit without being retaken. (For reference, the same assertion is at 3172 in merged `main` at `e0558fea`, where other PRs shifted it further — which is why the assertion text, not a line number, is the durable referent.)
2. **The docstring claim was narrowed, not made true.** Corrected in place above. The original sentence claimed the rewording "does not carry a count that rots"; only the arithmetic expression was removed, and two counts remain.
3. **The ftx1 framing was overstated.** This body originally offered the ftx1 `polling_only` declaration as "counter-evidence the owner should weigh". The review established that the CI-V resolver returns `None` for both paths on ftx1, so the two declarations answer different questions and the ftx1 one does not bear on the IC-7300 capability choice. Corrected in place above, along with the ftx1 row of the tone/TSQL table. The `Owner decision recorded` heading stands: the narrower question of which capability class these belong in on the IC-7300 is still open.

