### PR TITLE
refactor: share receiver level normalizers in command dispatch

### DIFF
--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -112,6 +112,61 @@ def _repeater_shift_target(params: Mapping[str, Any]) -> FieldPath:
     )
 
 
+def _raw_int_level_from_param(value: Any) -> int:
+    """Coerce a raw-only level command param (MOR-1579).
+
+    ``set_rf_gain``/``set_sql``/``set_squelch``: both the web frontend
+    (``radio-intents.ts`` declares ``'integer'``) and the documented
+    HTTP/WS command catalog agree the wire value is always a raw 0-255
+    integer, never a normalized float. Dispatch on the JSON *type*, not
+    magnitude — a value in ``[0, 1]`` used to be silently reinterpreted as
+    normalized (MOR-1579's headline bug: raw level ``1`` became raw
+    ``255``). A non-int or an out-of-range int is a caller bug, not an
+    alternate encoding, so it raises instead of being coerced.
+
+    This value feeds both the StateStore readback expectation (via
+    :func:`_expected_value_for_path`) *and*, on the ``public_api`` sync
+    ingress (:mod:`rigplane.runtime.sync`), the actual value sent to the
+    radio (``_SyncCommandExecutor`` reads ``intent.params["squelch"]``
+    directly) — so this function is the actuation path there, not just
+    bookkeeping.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"level {value!r} must be a raw integer 0-255, not {type(value).__name__}"
+        )
+    if not (0 <= value <= 255):
+        raise ValueError(f"level {value!r} is out of the raw 0-255 domain")
+    return int(value)
+
+
+def _af_level_from_param(value: Any) -> int:
+    """Coerce ``set_af_level``'s type-dispatched level param (MOR-1579).
+
+    Two documented wire contracts coexist for this one intent: the
+    HTTP/WS command catalog (``docs/api/command-catalog.md``) declares
+    ``level: int`` on the raw 0-255 scale (see the live-hardware
+    validation recipe's ``level:35`` example, which expects raw BCD
+    ``0035``); the web frontend (``radio-intents.ts`` declares
+    ``'normalized'``) sends a JSON float in 0.0-1.0. Dispatch on JSON
+    type, never magnitude: an int is always raw, a float is always
+    normalized, matching MOR-334's original coercion for float input
+    while restoring int input to a true no-op. Out-of-domain values for
+    either type raise rather than being reinterpreted as the other.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"level {value!r} must be an int or a normalized float")
+    if isinstance(value, int):
+        if not (0 <= value <= 255):
+            raise ValueError(f"level {value!r} is out of the raw 0-255 domain")
+        return value
+    if isinstance(value, float):
+        if not (0.0 <= value <= 1.0):
+            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
+        return max(0, min(255, round(value * 255)))
+    raise ValueError(f"level {value!r} must be an int or a normalized float")
+
+
 _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
     {
         "set_repeater_shift": CommandDescriptor(

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -15,6 +15,10 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Protocol
 
 from rigplane.core.acquisition_scheduler import AcquisitionPriority, AcquisitionStatus
+from rigplane.core.command_dispatch import (
+    _af_level_from_param as _af_level_from_param,
+    _raw_int_level_from_param as _raw_int_level_from_param,
+)
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import (
     ChangeSet,
@@ -877,61 +881,6 @@ def _expected_value_for_path(intent: CommandIntent, path: FieldPath) -> Any:
 
 def _should_normalize_level_expectation(name: str, path: FieldPath) -> bool:
     return _NORMALIZED_LEVEL_EXPECTATION_COMMANDS.get(name) == path.name
-
-
-def _raw_int_level_from_param(value: Any) -> int:
-    """Coerce a raw-only level command param (MOR-1579).
-
-    ``set_rf_gain``/``set_sql``/``set_squelch``: both the web frontend
-    (``radio-intents.ts`` declares ``'integer'``) and the documented
-    HTTP/WS command catalog agree the wire value is always a raw 0-255
-    integer, never a normalized float. Dispatch on the JSON *type*, not
-    magnitude — a value in ``[0, 1]`` used to be silently reinterpreted as
-    normalized (MOR-1579's headline bug: raw level ``1`` became raw
-    ``255``). A non-int or an out-of-range int is a caller bug, not an
-    alternate encoding, so it raises instead of being coerced.
-
-    This value feeds both the StateStore readback expectation (via
-    :func:`_expected_value_for_path`) *and*, on the ``public_api`` sync
-    ingress (:mod:`rigplane.runtime.sync`), the actual value sent to the
-    radio (``_SyncCommandExecutor`` reads ``intent.params["squelch"]``
-    directly) — so this function is the actuation path there, not just
-    bookkeeping.
-    """
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(
-            f"level {value!r} must be a raw integer 0-255, not {type(value).__name__}"
-        )
-    if not (0 <= value <= 255):
-        raise ValueError(f"level {value!r} is out of the raw 0-255 domain")
-    return int(value)
-
-
-def _af_level_from_param(value: Any) -> int:
-    """Coerce ``set_af_level``'s type-dispatched level param (MOR-1579).
-
-    Two documented wire contracts coexist for this one intent: the
-    HTTP/WS command catalog (``docs/api/command-catalog.md``) declares
-    ``level: int`` on the raw 0-255 scale (see the live-hardware
-    validation recipe's ``level:35`` example, which expects raw BCD
-    ``0035``); the web frontend (``radio-intents.ts`` declares
-    ``'normalized'``) sends a JSON float in 0.0-1.0. Dispatch on JSON
-    type, never magnitude: an int is always raw, a float is always
-    normalized, matching MOR-334's original coercion for float input
-    while restoring int input to a true no-op. Out-of-domain values for
-    either type raise rather than being reinterpreted as the other.
-    """
-    if isinstance(value, bool):
-        raise ValueError(f"level {value!r} must be an int or a normalized float")
-    if isinstance(value, int):
-        if not (0 <= value <= 255):
-            raise ValueError(f"level {value!r} is out of the raw 0-255 domain")
-        return value
-    if isinstance(value, float):
-        if not (0.0 <= value <= 1.0):
-            raise ValueError(f"level {value!r} is out of the normalized 0.0-1.0 domain")
-        return max(0, min(255, round(value * 255)))
-    raise ValueError(f"level {value!r} must be an int or a normalized float")
 
 
 def _power_level_expectation_from_param(


### PR DESCRIPTION
Owner: [MOR-2154](https://linear.app/morozsm/issue/MOR-2154); prerequisite for #3081, coordinated with MOR-2161.

Move the two existing receiver-level numeric helpers into core command_dispatch and retain import/re-export compatibility through command_service. Function bodies and numeric behavior are unchanged. No descriptor activation, receiver admission, queue/drain change, lifecycle change, or test change is included.

Scope: two files, +59/-55 = 114 changed lines. This prerequisite keeps the complete dependent AF/RF/squelch cut and all its tests under the hard 10-file/1000-line PR limit.

Independent code-only review passed at fe026ad3fe52217f17d6a8cf94094a5eef7a5ad7; exact-head normal CI remains required before merge. Only Git/source inspection ran locally. Formatter diagnostic is pinned to this exact source in a separate diagnostic branch; no diagnostic workflow change is part of this PR. No hardware or manual SSH execution.