### PR TITLE
test: prepare serial links for write completion

### DIFF
--- a/tests/serial_stub.py
+++ b/tests/serial_stub.py
@@ -127,6 +127,13 @@ class DeterministicSerialCivLink:
     async def send(self, frame: bytes) -> None:
         self.sent_frames.append(self._codec.encode(frame))
 
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
+
     def push_incoming_chunk(self, chunk: bytes) -> None:
         self._incoming_chunks.put_nowait(chunk)
 

--- a/tests/test_audio_scope_dispatch.py
+++ b/tests/test_audio_scope_dispatch.py
@@ -22,6 +22,7 @@ PCM tap exactly as the live audio pipeline does.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -35,6 +36,7 @@ from rigplane.audio.backend import (
 from rigplane.audio.usb_driver import UsbAudioDriver
 from rigplane.backends.ic705.serial import Ic705SerialRadio
 from rigplane.capabilities import CAP_AUDIO, CAP_SCOPE
+from rigplane.exceptions import CommandError
 from rigplane.radio import IcomRadio
 from rigplane.scope import ScopeFrame
 from rigplane.types import AudioCodec
@@ -115,6 +117,13 @@ class _FakeSerialCivLink:
 
     async def send(self, frame: bytes) -> None:
         _ = frame
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         await asyncio.sleep(0.0 if timeout is None else min(timeout, 0.0))

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
@@ -22,6 +23,7 @@ from rigplane.backends.icom7610.drivers.contracts import (
     CivLink,
     SessionDriver,
 )
+from rigplane.exceptions import CommandError
 
 
 class TestBackendConfigValidation:
@@ -194,6 +196,13 @@ class TestContracts:
         class _Civ:
             async def send(self, frame: bytes) -> None:
                 return None
+
+            async def send_written(
+                self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+            ) -> None:
+                if is_current is not None and not is_current():
+                    raise CommandError("Serial CI-V write is no longer current.")
+                await self.send(frame)
 
             async def receive(self, timeout: float | None = None) -> bytes | None:
                 return frame if (frame := b"x") else None

--- a/tests/test_icom7610_serial_radio.py
+++ b/tests/test_icom7610_serial_radio.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -174,6 +175,13 @@ class _FakeSerialCivLink:
         send_no = len(self.sent_frames)
         for response in self._responses_by_send.pop(send_no, []):
             self._responses.put_nowait(response)
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         if not self.connected:

--- a/tests/test_managed_tx_assembly.py
+++ b/tests/test_managed_tx_assembly.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -405,6 +405,13 @@ class _FakeCivLink:
 
     async def send(self, frame: bytes) -> None:  # pragma: no cover
         return None
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         return None  # pragma: no cover

--- a/tests/test_serial_backend_smoke.py
+++ b/tests/test_serial_backend_smoke.py
@@ -7,6 +7,7 @@ import base64
 import hashlib
 import json
 import struct
+from collections.abc import Callable
 
 import pytest
 
@@ -18,6 +19,7 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
+from rigplane.exceptions import CommandError
 from serial_stub import SerialMockRadio
 from rigplane.rigctld.contract import RigctldConfig
 from rigplane.rigctld.server import RigctldServer
@@ -48,6 +50,13 @@ class _FakeSerialCivLink:
     async def send(self, frame: bytes) -> None:
         _ = frame
         return None
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         await asyncio.sleep(0.02 if timeout is None else min(timeout, 0.02))

--- a/tests/test_usb_audio_channel_clamp_mor238.py
+++ b/tests/test_usb_audio_channel_clamp_mor238.py
@@ -17,6 +17,7 @@ path with its ``codec_preference`` removed.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 
 import pytest
 
@@ -28,6 +29,7 @@ from rigplane.audio.backend import (
 )
 from rigplane.audio.usb_driver import UsbAudioDriver
 from rigplane.backends.ic705.serial import Ic705SerialRadio
+from rigplane.exceptions import CommandError
 from rigplane.types import AudioCodec
 
 
@@ -130,6 +132,13 @@ class _FakeSerialCivLink:
 
     async def send(self, frame: bytes) -> None:
         _ = frame
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         await asyncio.sleep(0.02 if timeout is None else min(timeout, 0.02))

--- a/tests/test_x6200_rx_audio_mor236.py
+++ b/tests/test_x6200_rx_audio_mor236.py
@@ -15,6 +15,7 @@ reproduces PortAudio's channel-count rejection.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 
 import pytest
 
@@ -28,6 +29,7 @@ from rigplane.audio.usb_driver import UsbAudioDriver
 from rigplane.backends.config import SerialBackendConfig
 from rigplane.backends.factory import create_radio
 from rigplane.backends.ic705.serial import Ic705SerialRadio
+from rigplane.exceptions import CommandError
 from rigplane.types import AudioCodec
 from rigplane.web.handlers import AudioBroadcaster
 from rigplane.web.protocol import AUDIO_CODEC_PCM16, AUDIO_HEADER_SIZE
@@ -118,6 +120,13 @@ class _FakeSerialCivLink:
 
     async def send(self, frame: bytes) -> None:
         _ = frame
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         await asyncio.sleep(0.02 if timeout is None else min(timeout, 0.02))

--- a/tests/tx_observation_fakes.py
+++ b/tests/tx_observation_fakes.py
@@ -65,6 +65,7 @@ from rigplane.backends.yaesu_cat import YaesuCatRadio
 from rigplane.backends.yaesu_cat.transport import CatCommandRejected, CatTimeoutError
 from rigplane.commands import CONTROLLER_ADDR, build_civ_frame
 from rigplane.core.tx_observation import TxStateReading
+from rigplane.exceptions import CommandError
 from rigplane.radio import IcomRadio
 
 # ---------------------------------------------------------------------------
@@ -182,6 +183,13 @@ class ScriptedCivLink:
             reply = civ_transmit_state_reply(self.answer, self.radio_addr)
             if reply is not None:
                 self._replies.put_nowait(reply)
+
+    async def send_written(
+        self, frame: bytes, *, is_current: Callable[[], bool] | None = None
+    ) -> None:
+        if is_current is not None and not is_current():
+            raise CommandError("Serial CI-V write is no longer current.")
+        await self.send(frame)
 
     async def receive(self, timeout: float | None = None) -> bytes | None:
         if not self.connected:


### PR DESCRIPTION
## Scope

Mechanical test-contract prerequisite for [MOR-2165](https://linear.app/morozsm/issue/MOR-2165/tx-authority-profile-backed-normalized-transmit-actuators-for-icom) and serial write-completion draft #3091. Existing fake serial links gain `send_written(frame, *, is_current=None)` wrappers that reject a stale supplied predicate and delegate to each fake's existing `send`. Guard exceptions propagate.

No production changes, no existing assertions removed, and no existing send behavior rewritten. These wrappers are test doubles, not evidence of physical write/drain completion. The separately reviewed serial tests exercise that boundary against the actual link/writer queue.

Search-before-write: inventoried all serial link fakes/constructors and their existing `send` implementations before adding the same required test interface. Reuse each fake's existing send/log behavior; no new fake framework.

## Size

9 test files, +76/-1 (77 changed lines). The six-file soft threshold is exceeded because one protocol test-interface addition must cover nine existing fake definitions. Splitting those definitions further would not create an independent behavior change. The 10-file/1000-line hard ceiling is respected; separating this preparation from the four-file serial implementation prevents a 13-file combined PR.

## Verification

- Current source `35d6d8ea29c24171ba3612b8fa9603c830537708`, a normal merge of accepted main `d1aa77607802b646d828b78aec23d47161f1d4b6` into original reviewed fake source `bdabcdb34623e302ee7daa56b24f49fce196ec8f`.
- Independent code review PASS at the current exact head: all nine fake files remain byte-identical, with no production delta against main. Current tree `cd4775bfd546f57f312be9aa0c6a4a1dc74b4228` matches the already verified green quick checkout `8be6fc05dc4382c72c11481f2b434f6ac1d32fa0`.
- First quick `33721979072`: 14737 passed / 220 skipped / 16 xfailed; lint/format/imports passed. It tested the combined tree, not the original branch alone.
- First manual full `33722137415` tested the older original source on base de2a and FAILED: Python3.11 had 1 GC diagnostic failure / 14726 passed / 218 skipped / 16 xfailed; the other two Python jobs were cancelled. It is not a full PASS and was not rerun unchanged.
- Current-head quick `33722719759`: SUCCESS, 14737 passed / 220 skipped / 16 xfailed / 4 warnings; GC diagnostic passed, lint/format/imports passed.
- Current-head full `33722716648`: SUCCESS at exact source `35d6d8ea29c24171ba3612b8fa9603c830537708`. Python 3.11/3.12/3.13 each: 14739 passed / 218 skipped / 16 xfailed. Frontend each: 8405 tests / 388 files passed; web mypy: 26 files clean; import contracts: 5 kept / 0 broken. Capture harness passed. Actual checkout SHA was verified in all three Python jobs. This is the new accepted-base tree, not a retry of the failed old source. All project execution occurred only on Mini through Actions.
- Earlier main GC diagnostic failures are separately recorded in MOR-1469. Subsequent main e0558feac7cfb0431b5f95d4dad70b0c370647de quick33721525456 passed; no GC warning/test is changed here.
- No hardware evidence or application authority cutover is claimed.

## Required legacy-consumer search before push

```sh
git grep -n 'tx_interlock' -- src/rigplane/core/command_dispatch.py 'src/rigplane/runtime/command*.py' src/rigplane/web/handlers/control.py
```

Whole-source output:

```text
src/rigplane/web/handlers/control.py:32:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1728:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1967:            decision = evaluate_tx_interlock(
```

Zero hits in command_dispatch.py and runtime command files. Three existing Web references are unchanged, and no consumer is added.
