### PR TITLE
fix: give tone and TSQL frequency observations a finite freshness TTL

### DIFF
--- a/src/rigplane/runtime/_civ_rx.py
+++ b/src/rigplane/runtime/_civ_rx.py
@@ -100,6 +100,14 @@ _OBSERVATION_MAX_AGE_SECONDS: dict[tuple[str, str, str], float] = {
     ("receiver", "operator_controls", "rf_gain"): 10.0,
     ("receiver", "operator_controls", "pbt_inner"): 10.0,
     ("receiver", "operator_controls", "pbt_outer"): 10.0,
+    # MOR-2234 follow-up: declaring these observable in ``rigs/ic7300.toml``
+    # left them with no entry here, so ``_observation`` gave them
+    # ``max_age=None`` and ``state_store.py: StateStore.mark_stale_due``
+    # never aged them. The TTL is that profile's declared
+    # ``freshness_ttl_seconds``, pinned by
+    # ``test_tone_and_tsql_freq_observations_can_go_stale``.
+    ("receiver", "operator_controls", "tone_freq"): 25.0,
+    ("receiver", "operator_controls", "tsql_freq"): 25.0,
     ("global", "slow_state", "active"): 5.0,
     ("global", "tx_state", "ptt"): 1.0,
     ("global", "tx_state", "rit_on"): 10.0,

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -2119,6 +2119,8 @@ def _expected_value_control_max_age(store_path: str) -> float | None:
         return 10.0
     if store_path == "global.operator_controls.power_level":
         return 30.0
+    if store_path.endswith(".tone_freq") or store_path.endswith(".tsql_freq"):
+        return 25.0
     return None
 
 
@@ -2687,6 +2689,64 @@ def test_meter_value_survives_freshness_window_between_live_arrivals(
     )
     assert payload["main"]["sMeter"] == -4
     assert payload["main"]["sMeter"] != -54  # the calibrated S0 floor
+
+
+@pytest.mark.parametrize(
+    ("sub", "name"),
+    [
+        (0x00, "tone_freq"),
+        (0x01, "tsql_freq"),
+    ],
+)
+def test_tone_and_tsql_freq_observations_can_go_stale(
+    radio: IcomRadio, sub: int, name: str
+) -> None:
+    """MOR-2234 follow-up: a declared-observable path still needs a TTL here.
+
+    ``_observation`` reads ``max_age`` from ``_OBSERVATION_MAX_AGE_SECONDS``
+    with no default, and ``state_store.py: StateStore.mark_stale_due`` skips
+    any entry whose ``max_age`` is ``None``. With no table entry this path
+    was observed once and then reported ``FRESH`` for the lifetime of the
+    process, whatever the front panel did afterwards.
+
+    Fail-without: the observation carries ``max_age=None`` and the field is
+    still ``FRESH`` past the TTL ``rigs/ic7300.toml`` declares for it.
+    """
+
+    stored = FieldPath.receiver("0", "operator_controls", name)
+    # The TTL is not a literal here: it is read from the IC-7300 profile,
+    # which is what declared this path observable (e0558fea).
+    declared_ttl = (
+        resolve_radio_profile(model="IC-7300")
+        .state_acquisition.field_policies[
+            FieldPath.receiver("main", "operator_controls", name)
+        ]
+        .freshness_ttl_seconds
+    )
+
+    observed_at = 500.0
+    with patch("rigplane.runtime._civ_rx.time.monotonic", return_value=observed_at):
+        radio._civ_runtime._apply_state_store_observations(
+            _make_frame(cmd=0x1B, sub=sub, data=_encode_tone_freq(88.5), receiver=0x00)
+        )
+    assert radio._state_store.snapshot().field(str(stored)).value == 8850
+
+    # Inside the declared TTL the value is still the radio's truth.
+    radio._state_store.mark_stale_due(now=observed_at + declared_ttl - 0.1)
+    assert radio._state_store.snapshot().field(str(stored)).freshness is (
+        FreshnessState.FRESH
+    )
+
+    # Past it, the freshness driver must be able to retire the value and ask
+    # for it again.
+    delta = radio._state_store.mark_stale_due(now=observed_at + declared_ttl + 0.1)
+    assert radio._state_store.snapshot().field(str(stored)).freshness is (
+        FreshnessState.STALE
+    )
+    assert [t.path for t in delta.freshness] == [stored]
+    assert [(r.path, r.max_age) for r in delta.reconciliation_requests] == [
+        (stored, declared_ttl)
+    ]
 
 
 def test_same_value_coalesced_meter_flush_completes_scheduler_request(


### PR DESCRIPTION
## The defect, and that we shipped it tonight

`e0558fea` (merged tonight) declared `receiver.main.operator_controls.tone_freq`
and `tsql_freq` as `command_response_observable` in `rigs/ic7300.toml`, with a
field policy each. That fixed "never observed" — but it moved both paths to
**observed once and never decays**. A value read at connect reported `FRESH` for
the lifetime of the process, whatever the front panel did afterwards. Better
than nothing, still wrong, and ours.

## Chain, verified against this tree rather than taken on report

Each link checked by reading the file named:

1. `rigs/ic7300.toml` — `git show e0558fea -- rigs/ic7300.toml` shows both paths
   added to `command_response_observable` and a `[state_acquisition.field_policies]`
   table for each.
2. `runtime/_civ_rx.py: CivRuntime._observation` — takes `max_age` from the
   module-level `_OBSERVATION_MAX_AGE_SECONDS` via
   `_OBSERVATION_MAX_AGE_SECONDS.get((path.scope.value, path.family.value, path.name))`:
   a plain `dict.get`, no default, so a miss yields `None`.
3. `_OBSERVATION_MAX_AGE_SECONDS` at `origin/main` — parsed the literal with
   `ast.literal_eval` and diffed the key set; neither `tone_freq` nor
   `tsql_freq` was present.
4. `core/state_store.py: StateStore.mark_stale_due` — `if entry.max_age is None:
   continue`, for any entry not already in the relative-VFO `relative_due` set.
5. The observations do exist: `runtime/_civ_rx.py` maps `0x1B` sub `0x00`/`0x01`
   to `("receiver", "operator_controls", "tone_freq"/"tsql_freq")` via
   `_OBSERVABLE_CMD1B_FIELDS` and builds them in `_observations_from_frame`.

## The TTL, read out of the profile

`rigs/ic7300.toml` declares `freshness_ttl_seconds = 25.0` for both
`[state_acquisition.field_policies."receiver.main.operator_controls.tone_freq"]`
and `...tsql_freq`. Read two ways, both agreeing: `tomllib.load` on the file, and
`resolve_radio_profile(model="IC-7300").state_acquisition.field_policies[...]`.
No disagreement with the value the task named, so nothing else moved.

## Key shape

Checked against the neighbouring entries rather than assumed: every key in
`_OBSERVATION_MAX_AGE_SECONDS` is `(scope, family, name)` — e.g.
`("receiver", "operator_controls", "pbt_outer")`, `("receiver", "meters", "s_meter")`.
The receiver id is not part of the key, so one entry covers main and sub.

## Red, then green

New pin `tests/test_civ_rx_coverage.py: test_tone_and_tsql_freq_observations_can_go_stale`.
It feeds a real `0x1B` reply, reads the TTL from the IC-7300 profile instead of
hardcoding it, then asserts the entry is still `FRESH` just inside that TTL and
that `mark_stale_due` retires it **and** emits a reconciliation request just past
it — the eligibility half, not a dict-has-a-key restatement of the edit.

**Mutation A — both table entries deleted**, final test text, whole file
(`uv run pytest tests/test_civ_rx_coverage.py -q --tb=line`). Mutation applied
over a `shutil.copyfile` backup and restored the same way:

```
FAILED tests/test_civ_rx_coverage.py::test_value_control_observation_value[receiver.0.operator_controls.tone_freq]
FAILED tests/test_civ_rx_coverage.py::test_value_control_observation_value[receiver.0.operator_controls.tsql_freq]
FAILED tests/test_civ_rx_coverage.py::test_tone_and_tsql_freq_observations_can_go_stale[0-tone_freq]
FAILED tests/test_civ_rx_coverage.py::test_tone_and_tsql_freq_observations_can_go_stale[1-tsql_freq]
======================== 4 failed, 385 passed in 1.59s =========================
```

failing at the staleness assertion, not the key lookup:

```
tests/test_civ_rx_coverage.py:2743: AssertionError: assert <FreshnessState.FRESH: 'fresh'> is <FreshnessState.STALE: 'stale'>
```

**Mutation B — both table entries present but at `250.0` instead of `25.0`**,
whole file (`uv run pytest tests/test_civ_rx_coverage.py -q --tb=no`):

```
======================== 4 failed, 385 passed in 1.64s =========================
```

so the pin binds to the profile's number, not merely to "finite".

> An earlier revision of this body reported `1 failed, 1 passed` for mutation B.
> That figure was real but came from mutating only the `tone_freq` entry **and**
> narrowing the run with `-k test_tone_and_tsql_freq_observations_can_go_stale` —
> a selection the body did not state, so the number did not reproduce from the
> command as written. The figure above is both entries mutated, whole file.

Green after restore: `525 passed, 1 warning in 2.77s` over the three named files.

## Inverse check

`_OBSERVATION_MAX_AGE_SECONDS` was parsed with `ast.literal_eval` at
`origin/main` and at this head, and the key sets diffed:

```
added   : [('receiver', 'operator_controls', 'tone_freq'), ('receiver', 'operator_controls', 'tsql_freq')]
removed : []
changed : []
```

Nothing else acquired a TTL. Specifically, `tx_target`, `filter_num` and
`data_mode` are absent from the table both before and after, so `tx_target`
still gets its TTL from the `tx_target_max_age(self._host._profile)` branch below
the lookup in `_observation`, and `filter_num`/`data_mode` still carry
`max_age=None` and reach staleness only through the relative-VFO retention path
(`relative_due` in `mark_stale_due`).

## The second file in the diff

`tests/test_civ_rx_coverage.py: _expected_value_control_max_age` is a
hand-maintained mirror of the runtime table (it does not name the table, which is
why a grep on the symbol does not find it). It returned `None` for these paths and
went red on the parametrised `test_value_control_observation_value` cases as soon
as the entries landed. Updated in place, keeping the file's existing convention of
an independently hand-written expectation rather than deriving it from the table
under test — deriving it would make the assertion restate the table. The mirror is
asserted *equal* to the live value, so it cannot drift silently, only loudly;
mutation A above is what demonstrates that, since its first two failures are the
mirror rows reddening.

## Sweeping the `.max_age` assertion class

Every `.max_age` occurrence in `tests/test_civ_rx_coverage.py` was attributed to
its enclosing top-level function by walking the file's AST, rather than read off a
grep by eye. The pre-existing sites are:

| Function | Shape |
|---|---|
| `test_slow_state_toggle_observation_backed` | `max_age is None` |
| `test_scope_control_observation_backed` | `max_age is None` |
| `test_value_control_observation_value` | `== _expected_value_control_max_age(...)` |
| `test_civ_projected_active_rit_xit_fields_become_stale` | `all(... is not None)` |
| `test_update_radio_state_direct_tx_frequency_stamps_profile_declared_max_age` | `== 8.0` |
| `test_direct_tx_frequency_max_age_falls_back_without_state_acquisition` | `== 3.0` |
| `test_direct_tx_frequency_coexists_with_ic7300_derived_target` | `== 3.0` |

Only `test_value_control_observation_value` covers a tone/TSQL path; the other six
cover slow-state, scope-control, RIT/XIT and `tx_target`, and all stayed green.
The three `tx_target` rows are a second, independent confirmation of the inverse
check above: they pin `tx_target`'s TTL to the profile branch at 8.0/3.0 and did
not move.

> An earlier revision of this body named only two of these groups and presented
> that as the complete in-file enumeration. It was short by
> `test_scope_control_observation_backed` and the three `tx_target` functions. The
> conclusion is unchanged; the enumeration behind it was not complete, and is now
> derived mechanically.

Outside that file, the `.max_age` sites belong to the Yaesu CAT adapter, the
rigctld client observation adapter, and scheduler request TTLs — none of which
read `_OBSERVATION_MAX_AGE_SECONDS`. The direct readers of that table
(`rigctld/server.py`, `tests/test_rigctld_ptt_reread.py`,
`tests/integration/_ptt_reread_fixtures.py`, and one site in
`test_civ_rx_coverage.py`) index `ptt` and `s_meter` only.

## Sibling class — recorded, deliberately not fixed here

tone/tsql are not the only paths on this profile in this state. Enumerating
`rigs/ic7300.toml`'s field policies against the module table — every policy whose
capability is `command_response_observable`, not pollable and not unavailable,
then checking `(scope, family, name)` membership in `_OBSERVATION_MAX_AGE_SECONDS`
— gives, at this head:

```
non-polling command_response group  : 24
  of those WITH a table entry       : 7
  of those WITHOUT a table entry    : 17
```

Each of those 17 declares `freshness_ttl_seconds = 25.0` that the table still
ignores, so each is immortal today exactly as tone/tsql were:
`break_in`, `break_in_delay`, `cw_pitch`, `key_speed`, `vox_delay`, `monitor_on`,
`vox_on`, `filter_width`, `agc_time_constant`, `filter_shape`,
`manual_notch_width`, `nb_level`, `notch_filter`, `nr_level`, `auto_notch`,
`manual_notch`, `twin_peak_filter`.

Seven of them (`cw_pitch`, `key_speed`, `vox_delay`, `filter_width`,
`agc_time_constant`, `nb_level`, `nr_level`) are actively pinned as
`max_age is None` today by `_expected_value_control_max_age`'s fallthrough, so
whoever fixes them retires a green assertion first.

Separately, five paths that *do* have a table entry carry a table TTL that
disagrees with the profile's declared 25.0 (`rit_freq`, `rit_on`, `rit_tx`,
`pbt_inner`, `pbt_outer`, all 10.0 in the table). Shorter than declared, so they
decay sooner rather than never — recorded, not a defect claim.

None of this is fixed here: it needs a per-path judgement, since the slow-state
and scope-control families are immortal *by design* with comments saying so.
Recorded against the epic's slice 4.

I did not establish, for any of the 17, that `_civ_rx` actually emits an
observation for it — a path nothing observes has the "never observed" defect
rather than the immortality one. That is part of the per-path judgement slice 4
owes.

## Two findings from the independent review, attributed to it

Not my measurements — recorded here because they bear on what this change buys:

- The fix restores a real refresh cycle rather than a label. For a
  `command_response_observable` field, `prime_unobserved` drops the path once it
  lands its first observation, and `due_requests` only cadence-polls
  `polling=True` capabilities — so reconciliation through `mark_stale_due` was the
  only remaining route to a re-read, and the missing TTL had severed it.
- The cross-profile effect is harmless, checked rather than assumed: other CI-V
  models now carry 25.0 instead of `None` for the same frames, and for profiles
  that do not declare the path the reconciliation resolves UNAVAILABLE without
  emitting a frame.

## Stopgap, not an endorsement

This is a stopgap inside a mechanism the programme is removing: per the task
brief, MOR-2260 slice 4 moves this whole table into the profiles. I have not
independently verified that ticket. Two rows are deliberately the smallest change
that stops shipping an immortal field tonight. Nothing general was built.

## Gates

| Gate | Result |
|---|---|
| `uv run pytest tests/test_civ_rx_coverage.py tests/test_state_store.py tests/test_acquisition_scheduler.py -q --tb=short` | 525 passed, 1 warning |
| `uv run ruff check src/ tests/` | All checks passed |
| `uv run ruff format src/ tests/` | 711 files left unchanged |
| `uv run lint-imports` | Contracts: 5 kept, 0 broken |

The full suite was not run locally, by instruction; `quick.yml` is the record of
that run.

## Size

```
$ git diff --stat origin/main...HEAD
 src/rigplane/runtime/_civ_rx.py |  8 ++++++
 tests/test_civ_rx_coverage.py   | 60 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 68 insertions(+)
```

Relative to the guardrail collections: 2 files against a 6-file soft threshold and
a 10-file hard ceiling; 68 changed lines against a 600-line soft threshold and a
1000-line hard ceiling. Under both thresholds on both counts.

Linear: MOR-2234
