### PR TITLE
feat: host the SDR face's vfo and rxTx in declared zone elements

### DIFF
--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -69,10 +69,10 @@
   // its legacy twin does NOT also render; a surface no zone declares keeps its
   // legacy presentation untouched.
   //
-  // Both resolving families declare the full pair, so both are fully semantic:
-  // `sdr-test` through one zone (`main: [vfo, rxTx]`) and `desktop-v2` through
-  // two (`receiver-deck: [vfo]` + `rx-tx: [rxTx]`, MOR-1266), which is what
-  // puts desktop-v2 on the v3 path.
+  // Both resolving families declare the full pair, so both are fully semantic.
+  // Since MOR-2231 both also split it across the same two zone ids
+  // (`receiver-deck: [vfo]` + `rx-tx: [rxTx]`, MOR-1266 on desktop-v2), which
+  // is why the `regions` prop below cannot be derived from the manifest.
   //
   // The MANIFEST is the authority, deliberately NOT the resolved surface plan
   // (`useSurfacePlan`, MOR-1082): the workspace may subtract a surface from a
@@ -290,8 +290,19 @@
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
 
   <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
+    <!--
+      MOR-2231 — `regions` below asks the semantic vertical for a zone ELEMENT
+      around `vfo` and `rxTx`. The predicate is SKIN IDENTITY, not a manifest
+      reading: both resolving families now declare `receiver-deck` and
+      `rx-tx`, so nothing in the manifest tells the face that wants the hosts
+      from the one that does not. A later batch replaces it.
+
+      Outside the `{#if}` because the guard in
+      `presentation/layouts/__tests__/forward-declaration-inventory.test.ts`
+      separates `{#if semanticDeck}` from the mount by `\s*` only.
+    -->
     {#if semanticDeck}
-      <SemanticRadioSurfaces />
+      <SemanticRadioSurfaces regions={skinId === 'sdr-test'} />
     {:else}
       <VfoHeader
         {mainVfo}

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -14,8 +14,8 @@
  * What decides (1) is no longer a skin id but the ACTIVE layout manifest's zone
  * declarations, so the last two describes below render the matrix itself: a
  * declared surface is semantic and its legacy twin is gone; a surface no zone
- * declares keeps its legacy presentation. `sdr-test` — one zone declaring both
- * — is the degenerate all-semantic case.
+ * declares keeps its legacy presentation. `sdr-test` declares both, so it is
+ * the all-semantic case.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
@@ -146,7 +146,7 @@ import {
 // DualReceiverCockpit.component.test.ts` uses it: a real registered manifest to
 // derive the probes below from. RadioLayout.svelte already pulls this module in
 // (its side-effect registry import), so this adds no registration of its own.
-import { desktopV2Layout } from '../../../presentation/layouts/declarations';
+import { desktopV2Layout, sdrTestLayout } from '../../../presentation/layouts/declarations';
 // MOR-1367 (S8): the zone-ELEMENT assertions need the resolved plan in context
 // — see `renderWithPlan` in the S8 describe for why `render()` cannot show one.
 import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../../../presentation/workspace/resolution';
@@ -361,8 +361,7 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
  * MOR-1313 — desktop-v2 resolves through the v3 path.
  *
  * Its manifest splits the pair across TWO zones (`receiver-deck: [vfo]`,
- * `rx-tx: [rxTx]`) where sdr-test uses one, so the same rendered outcome
- * arriving from a different zone shape is the proof that suppression is
+ * `rx-tx: [rxTx]`), so suppression covering both twins is what proves it is
  * derived per zone rather than per skin.
  */
 describe('desktop-v2 resolves through the v3 path (MOR-1313)', () => {
@@ -452,6 +451,67 @@ describe('desktop-v2 resolves through the v3 path (MOR-1313)', () => {
     expect(render('desktop-v2').querySelector('.radio-layout.semantic-deck')).not.toBeNull();
     expect(render('desktop-v2').querySelector('.radio-layout.sdr-test')).toBeNull();
     expect(render('sdr-test').querySelector('.radio-layout.semantic-deck.sdr-test')).not.toBeNull();
+  });
+});
+
+/**
+ * MOR-2231 (step 1, batch 1) — the SDR face's two zone HOSTS.
+ *
+ * `sdrTestLayout` splits the pair into `receiver-deck: [vfo]` + `rx-tx:
+ * [rxTx]`, reusing desktop-v2's ids, and `RadioLayout` asks
+ * `SemanticRadioSurfaces` for the wrapper elements on that face alone
+ * (`regions={skinId === 'sdr-test'}`).
+ *
+ * Why the second `it` is the one that earns this block: BOTH manifests now
+ * declare zones owning `vfo` and `rxTx`, so `zoneOwning()` answers non-null on
+ * either face and the PLAN cannot be what separates them. Only the `regions`
+ * prop can, and until this test existed nothing in `frontend/src` inspected
+ * the SHAPE of desktop-v2's rendered subtree at all.
+ *
+ * Both mounts hand the plan in through context for the reason `renderWithPlan`
+ * in the S8 describe records: a standalone `RadioLayout` mount leaves
+ * `useSurfacePlan()` at `NO_PLAN`, and every zone wrapper then disappears
+ * whatever the manifest declares.
+ */
+describe('vfo and rxTx gain zone hosts on the SDR face only (MOR-2231)', () => {
+  function renderZoned(skinId: SkinId, manifest: LayoutManifest): HTMLElement {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = resolveSurfacePlan(manifest, DEFAULT_WORKSPACE);
+    mounted.push(mount(RadioLayout, {
+      target,
+      props: { skinId },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    }));
+    flushSync();
+    return target;
+  }
+
+  // MUTATION KILLED: leaving `vfo`/`rxTx` outside `zoned()`, or declaring the
+  // split zones without routing the surfaces through them — the manifest would
+  // name two hosts the DOM never builds.
+  it('hosts each sdr-test surface in the zone element its manifest declares', () => {
+    const t = renderZoned('sdr-test', sdrTestLayout);
+    expect(t.querySelector('[data-zone-id="receiver-deck"] [data-testid="vfo-surface"]'))
+      .not.toBeNull();
+    expect(t.querySelector('[data-zone-id="rx-tx"] [data-testid="rx-tx-surface"]'))
+      .not.toBeNull();
+  });
+
+  // MUTATION KILLED: passing `regions` unconditionally (or letting `zoned()`
+  // take `vfo`/`rxTx` on every face), which would wrap desktop-v2's two
+  // surfaces too. That is the byte-identity claim this batch rests on, and
+  // this is the only assertion in the suite that can refuse it.
+  it('leaves the desktop-v2 surfaces bare, with no zone element around either', () => {
+    const t = renderZoned('desktop-v2', desktopV2Layout);
+    const vfo = t.querySelector('[data-testid="vfo-surface"]');
+    const rxTx = t.querySelector('[data-testid="rx-tx-surface"]');
+    expect(vfo).not.toBeNull();
+    expect(rxTx).not.toBeNull();
+    expect(vfo!.closest('.surface-zone')).toBeNull();
+    expect(rxTx!.closest('.surface-zone')).toBeNull();
+    expect(t.querySelector('[data-zone-id="receiver-deck"]')).toBeNull();
+    expect(t.querySelector('[data-zone-id="rx-tx"]')).toBeNull();
   });
 });
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -72,8 +72,8 @@
   import { guardRadioViewModel } from './radio-view-model-guard';
 
   /**
-   * `'single'` (default) is the exact pre-MOR-1067 markup — sdr-test's
-   * behavior is untouched. `'dual'` is the dual-receiver-cockpit's per-
+   * `'single'` (default) is the pre-MOR-1067 composition, wrapped per zone
+   * when `regions` says so. `'dual'` is the dual-receiver-cockpit's per-
    * receiver channel strips (MOR-1067): still ONE shared RxTxSurface and
    * ONE TX lease below — ONLY the VFO half splits, so there is still exactly
    * one authoritative key/unkey action surface regardless of `strips`.
@@ -89,8 +89,21 @@
    */
   interface Props {
     strips?: 'single' | 'dual';
+    regions?: boolean;
   }
-  let { strips = 'single' }: Props = $props();
+  /**
+   * MOR-2231 — `regions` routes `vfo`/`rxTx` through the generic `zoned()`
+   * path in the SINGLE composition, so each gains the zone element its
+   * layout's plan names. `false` renders both exactly as before: no wrapper,
+   * no `data-zone-id`. Only `RadioLayout.svelte` passes it; the four other
+   * mount sites (`LcdLayout`, `MobileRadioLayout`, `DualReceiverCockpit`,
+   * `PeerSplitLayout`) take the default.
+   *
+   * A PROP rather than a plan lookup because the plan cannot answer the
+   * question: `desktop-v2` and `sdr-test` declare the same two zone ids, so
+   * `zoneOwning()` returns non-null on both faces.
+   */
+  let { strips = 'single', regions = false }: Props = $props();
 
   /**
    * MOR-1082 — the workspace's per-zone `visibleSurfaces`/`zoneOrder`, resolved
@@ -854,8 +867,8 @@
     the dual composition, where it is a real, bound zone element the
     cockpit's responsive rules can place — an inert wrapper cannot be a
     grid/flex item, so "leave it inert" was not an option once the zone had
-    to move between arrangements. The single/default path (sdr-test / LCD /
-    mobile) renders the surface bare again, and that element shape is
+    to move between arrangements. The single/default path renders the surface
+    bare wherever `regions` is unset (MOR-2231), and that element shape is
     re-pinned in `__tests__/semantic-rx-tx-wiring.component.test.ts`.
 
     The snippet is deliberate: it keeps exactly ONE `<RxTxSurface>` tag in
@@ -967,11 +980,12 @@
     the layout's arrangement can place; undeclared → bare by default, exactly
     as before — unless the caller passes `allowBare={false}` (MOR-2150 below).
 
-    Deliberately NOT applied to `vfo`/`rxTx`: those carry per-receiver slicing,
-    the `showVfoList`/`showRadioWideFacts` split and the R6 TX-adjacent alerts,
-    none of which a uniform wrapper can express. Genericity is applied where it
-    is honest; the two bespoke arrangements stay bespoke and are documented as
-    such rather than forced through this path.
+    `vfo`/`rxTx` reach it only through the single composition's `regions`
+    branch (MOR-2231), and only for the WRAPPER. Their bodies stay bespoke
+    snippets — per-receiver slicing, the `showVfoList`/`showRadioWideFacts`
+    split and the R6 TX-adjacent alerts are arrangements no uniform wrapper can
+    express, which is why the DUAL composition still builds its own
+    `.rx-tx-zone` rather than calling this.
 
     `present` is the surface's OWN structural gate, hoisted to the wrap
     decision. Without it a declared zone would render as an empty `<div>` for a
@@ -1437,20 +1451,31 @@
     {@render zoned('scopeControls', view?.scopeControls !== undefined, scopeControlsSurface, false)}
   {:else}
     <!--
-      Single/default path (sdr-test / LCD / mobile): no bound zone exists
-      here (MOR-1069), so containment is not possible — the alerts keep
-      their pre-MOR-1258 position and order, unchanged.
+      Single/default path (sdr-test / LCD / mobile). No zone CONTAINS the
+      alerts here (MOR-1069 — the dual composition's `.rx-tx-zone` has no twin
+      on this path), so they keep their pre-MOR-1258 position and order,
+      unchanged.
 
-      MOR-1082: the layout's single zone mounts both `vfo` and `rxTx`
-      (sdr-test `main`, LCD `control-column`, mobile `portrait-deck`), so this
-      is where a per-zone reorder actually lands. `singleOrder` is the plan
-      flattened in zone-declaration order and falls back to the composed order
-      whenever no plan is resolved — an unresolved plan renders exactly the
-      sequence this path renders today.
+      MOR-1082: `singleOrder` is the plan flattened in zone-declaration order,
+      falling back to the composed order whenever no plan is resolved — so an
+      unresolved plan renders exactly the sequence this path renders today, and
+      a per-zone reorder lands here. On a layout whose zones hold one surface
+      each that flattening is what ORDERS the zones; on one whose single zone
+      mounts both (LCD `control-column`, mobile `portrait-deck`) it is what
+      reorders within it.
+
+      MOR-2231: `regions` decides whether each of the two gets the zone element
+      its plan names. Unset — every mount that predates that ticket — renders
+      them exactly as before: no wrapper, no `data-zone-id`.
     -->
     {#each singleOrder as surface (surface)}
-      {#if surface === 'vfo'}{@render vfoSurface()}
-      {:else if surface === 'rxTx'}{@render rxTxSurface()}{/if}
+      {#if surface === 'vfo'}
+        {#if regions}{@render zoned('vfo', view !== null, vfoSurface)}
+        {:else}{@render vfoSurface()}{/if}
+      {:else if surface === 'rxTx'}
+        {#if regions}{@render zoned('rxTx', view !== null, rxTxSurface)}
+        {:else}{@render rxTxSurface()}{/if}
+      {/if}
     {/each}
     <!-- MOR-1784: `singleOrder` ends in `rxTx` in every shipped layout
          (`SINGLE_COMPOSITION`, and a plan can only reorder or subtract), so

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -95,9 +95,17 @@
    * MOR-2231 — `regions` routes `vfo`/`rxTx` through the generic `zoned()`
    * path in the SINGLE composition, so each gains the zone element its
    * layout's plan names. `false` renders both exactly as before: no wrapper,
-   * no `data-zone-id`. Only `RadioLayout.svelte` passes it; the four other
-   * mount sites (`LcdLayout`, `MobileRadioLayout`, `DualReceiverCockpit`,
-   * `PeerSplitLayout`) take the default.
+   * no `data-zone-id`.
+   *
+   * `RadioLayout.svelte` is the only site that passes it. Five take the
+   * default, and `regions` is read on three of them — `LcdLayout`,
+   * `MobileRadioLayout` and `frontend/fixtures/ReferenceLayout.svelte` —
+   * because it is read only in the `{:else}` single branch.
+   * `DualReceiverCockpit` and `PeerSplitLayout` mount `strips="dual"`, where
+   * it is never evaluated. (Enumerated with `git grep -n
+   * "<SemanticRadioSurfaces" -- .`, unscoped: a path-scoped search cannot see
+   * `frontend/fixtures/`, which is how an earlier revision of this comment
+   * came to name four.)
    *
    * A PROP rather than a plan lookup because the plan cannot answer the
    * question: `desktop-v2` and `sdr-test` declare the same two zone ids, so
@@ -867,9 +875,12 @@
     the dual composition, where it is a real, bound zone element the
     cockpit's responsive rules can place — an inert wrapper cannot be a
     grid/flex item, so "leave it inert" was not an option once the zone had
-    to move between arrangements. The single/default path renders the surface
-    bare wherever `regions` is unset (MOR-2231), and that element shape is
-    re-pinned in `__tests__/semantic-rx-tx-wiring.component.test.ts`.
+    to move between arrangements. `__tests__/semantic-rx-tx-wiring.component.test.ts`
+    re-pins that bare shape under NO_PLAN: it supplies no surface plan, so
+    `zoneOwning()` is null and the surface renders bare there whatever
+    `regions` says. The plan-resolved `regions === false` case is a separate
+    claim, pinned in `semantic-desktop-migration.component.test.ts` by
+    `leaves the desktop-v2 surfaces bare, with no zone element around either`.
 
     The snippet is deliberate: it keeps exactly ONE `<RxTxSurface>` tag in
     this file, so single TX authority stays a property of the SOURCE rather

--- a/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
+++ b/frontend/src/components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts
@@ -166,7 +166,7 @@ import SemanticRadioSurfaces from '../SemanticRadioSurfaces.svelte';
 // MOR-1082: the REAL manifests, through the app-wide registration barrel, and
 // the REAL resolution seam — the plans below are what App would hand down.
 import {
-  desktopV2Layout, dualReceiverCockpitLayout, sdrTestLayout,
+  desktopV2Layout, dualReceiverCockpitLayout, mobileLayout, sdrTestLayout,
 } from '../../../presentation/layouts/declarations';
 import { readWorkspace } from '../../../presentation/workspace/contract';
 import {
@@ -598,11 +598,13 @@ describe('MOR-1082 — the semantic vertical consults the resolved surface plan'
   });
 
   it('reorders the single composition from the zone that mounts both surfaces', () => {
-    // sdr-test's `main` zone declares ['vfo', 'rxTx']; the operator flipped it.
+    // `mobile`'s `portrait-deck` zone declares ['vfo', 'rxTx']; the operator
+    // flipped it. Read from `mobile` since MOR-2231 split sdr-test's pair into
+    // `receiver-deck` + `rx-tx`, leaving it no zone that mounts both.
     // MUTATION KILLED: ignoring `zoneOrder` in the single composition, or
     // hard-coding the VFO-before-RX/TX sequence.
-    render({ strips: 'single' }, planFor(sdrTestLayout, {
-      zoneOrder: { main: ['rxTx', 'vfo'] },
+    render({ strips: 'single' }, planFor(mobileLayout, {
+      zoneOrder: { 'portrait-deck': ['rxTx', 'vfo'] },
     }));
 
     expect(surfaceOrder()).toEqual(['rx-tx-surface', 'vfo-surface']);

--- a/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/forward-declaration-inventory.test.ts
@@ -78,10 +78,16 @@ const peerSplitShellSource = readFileSync('src/skins/segmentline/PeerSplitLayout
  * Deliberately NOT `true`: a prober that ignores both halves would report a
  * DOM-backed inventory for a shell that had gone back to a hardcoded id, or for
  * a manifest that had dropped its VFO zone.
+ *
+ * MOR-2231 widened the mount pattern to accept ATTRIBUTES on the tag (the
+ * `regions` prop, which decides only whether `vfo`/`rxTx` gain a zone element
+ * — never whether the semantic vertical mounts). What this half asserts is
+ * unchanged: the mount is the first thing inside `{#if semanticDeck}`, and
+ * `semanticDeck` is the manifest-derived gate the line above pins.
  */
 const shellResolvesThroughManifest =
   /let declared = \$derived\(declaredSurfaces\(getLayout\(skinId\)\)\);/.test(radioLayoutSource)
-  && /\{#if semanticDeck\}\s*<SemanticRadioSurfaces \/>/.test(radioLayoutSource);
+  && /\{#if semanticDeck\}\s*<SemanticRadioSurfaces[^>]*\/>/.test(radioLayoutSource);
 const sharedShellMounts = (manifest: LayoutManifest): boolean =>
   shellResolvesThroughManifest && manifest.zones.some((z) => z.surfaces.includes('vfo'));
 

--- a/frontend/src/presentation/layouts/__tests__/registry.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/registry.test.ts
@@ -15,7 +15,8 @@ describe('the sdr-test real registration proof', () => {
   // Kills: declarations.ts never actually calling registerLayout.
   it('registers sdr-test, mounting the live vfo + rxTx zones, with no change to SdrTestSkin.svelte behavior', () => {
     expect(getLayout('sdr-test')).toBe(sdrTestLayout);
-    expect(sdrTestLayout.zones).toContainEqual({ id: 'main', surfaces: ['vfo', 'rxTx'] });
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'receiver-deck', surfaces: ['vfo'] });
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'rx-tx', surfaces: ['rxTx'] });
     expect(typeof sdrTestLayout.loader).toBe('function');
   });
 });

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -55,19 +55,24 @@ describe('the sdr-test entrypoint is registered in the real registry', () => {
 });
 
 describe('declared semantic zones (what the migrated entrypoint actually mounts)', () => {
-  // Kills: declaring a surface the layout does not mount, or dropping rxTx
+  // MOR-2231 (step 1, batch 1): the pair is split across the two zone ids
+  // `desktop-v2` already uses, so both faces name the same hosts and
+  // `SemanticRadioSurfaces` can build a real element for each.
+  // Kills: declaring a surface the layout does not mount, dropping rxTx
   // (which would let sdr-test keep the legacy sidebar TX panel as its only
-  // TX owner).
-  it('mounts vfo + rxTx in one zone', () => {
-    expect(sdrTestLayout.zones).toContainEqual({ id: 'main', surfaces: ['vfo', 'rxTx'] });
+  // TX owner), or folding the pair back into one zone.
+  it('mounts vfo and rxTx in their own zones', () => {
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'receiver-deck', surfaces: ['vfo'] });
+    expect(sdrTestLayout.zones).toContainEqual({ id: 'rx-tx', surfaces: ['rxTx'] });
     expect([...sdrTestLayout.requiredSemanticSurfaces].sort()).toEqual(['rxTx', 'vfo']);
   });
 
   // MOR-1346: `meters` joins as its own zone (the desktop-v2/MOR-1341 shape),
   // which is what lets RadioLayout's existing `semanticMeters` gate retire
   // the legacy `<MetersDockPanel>` here too. Kills: folding `meters` into
-  // `main` instead (a persisted `main` visibility preference predating this
-  // zone could then silently hide it) or leaving it undeclared again.
+  // another zone (a persisted visibility preference recorded for that zone
+  // before `meters` joined it could then silently hide it) or leaving it
+  // undeclared again.
   it('mounts meters in its own zone, not required', () => {
     expect(sdrTestLayout.zones).toContainEqual({ id: 'meters', surfaces: ['meters'] });
     expect(sdrTestLayout.requiredSemanticSurfaces).not.toContain('meters');

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -18,18 +18,24 @@ export const sdrTestLayout: LayoutManifest = {
   id: 'sdr-test',
   displayName: 'SDR Test',
   loader: () => import('../../skins/sdr-test/SdrTestSkin.svelte'),
-  // MOR-1346: `meters` joins as its own zone, the same shape every optional
-  // surface graduates through on `desktop-v2` (`desktop-declarations.ts`'s
-  // one-zone-per-surface pattern) — never merged into `main`, so a persisted
-  // `visibleSurfaces.main` preference recorded before this zone existed
-  // cannot silently hide it (`resolveZone`'s allow-list intersection would
-  // otherwise treat an unlisted new member as hidden). Declaring it is what
-  // lets RadioLayout.svelte's existing `semanticMeters` gate
-  // (`declared.has('meters')`) retire `<MetersDockPanel>` here too — the
+  // MOR-1346: `meters` is its own zone, never merged into another one, so a
+  // persisted `visibleSurfaces` entry recorded for a zone before `meters`
+  // joined it cannot silently hide it (`resolveZone`'s allow-list
+  // intersection would otherwise treat an unlisted new member as hidden).
+  // Declaring it is what lets RadioLayout.svelte's existing `semanticMeters`
+  // gate (`declared.has('meters')`) retire `<MetersDockPanel>` here too — the
   // same S5/MOR-1341 mechanism `desktop-v2` already uses, not a second one.
   // Not `required`: the semantic surface self-gates on `view.meters`.
+  //
+  // MOR-2231 (step 1, batch 1): `vfo` and `rxTx` split out of the former
+  // single `main` zone into `receiver-deck` and `rx-tx` — the ids
+  // `desktop-declarations.ts` already uses — so this face names one host per
+  // surface and `SemanticRadioSurfaces` can build a real element for each
+  // (its `regions` prop, passed from `RadioLayout.svelte`). Every zone here is
+  // now one-surface, the shape `desktop-v2` has used since MOR-1266.
   zones: [
-    { id: 'main', surfaces: ['vfo', 'rxTx'] },
+    { id: 'receiver-deck', surfaces: ['vfo'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
     { id: 'meters', surfaces: ['meters'] },
   ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -25,13 +25,13 @@ import { registerLayout, type LayoutManifest } from './contract';
  * names the area the sidebars' legacy `<TxPanel>` used to occupy. Since
  * MOR-1313 both declarations are what actually decides the rendered tree.
  *
- * Neither is bound to a `data-zone-id` element in the single composition —
- * unlike the dual-receiver-cockpit's `rx-tx` zone, which IS
- * (`SemanticRadioSurfaces.svelte`, `strips="dual"`). That stays deliberate:
- * MOR-1069 established that a zone element exists only where an arrangement
- * must place it, and the single composition places nothing. The zone ids are
- * read here as DECLARATIONS — what this layout mounts where — which is exactly
- * what per-zone suppression consumes.
+ * Neither is bound to a `data-zone-id` element on THIS layout: the single
+ * composition builds those two wrappers only when its `regions` prop is set,
+ * and `RadioLayout.svelte` sets it for `sdr-test` alone (MOR-2231). MOR-1069
+ * is why — a zone element exists only where an arrangement must place it, and
+ * nothing here places these yet. The zone ids are read here as DECLARATIONS —
+ * what this layout mounts where — which is exactly what per-zone suppression
+ * consumes.
  */
 const DESKTOP_V2_ZONES = [
   { id: 'receiver-deck', surfaces: ['vfo'] },

--- a/frontend/src/presentation/layouts/desktop-declarations.ts
+++ b/frontend/src/presentation/layouts/desktop-declarations.ts
@@ -25,13 +25,13 @@ import { registerLayout, type LayoutManifest } from './contract';
  * names the area the sidebars' legacy `<TxPanel>` used to occupy. Since
  * MOR-1313 both declarations are what actually decides the rendered tree.
  *
- * Neither is bound to a `data-zone-id` element on THIS layout: the single
- * composition builds those two wrappers only when its `regions` prop is set,
- * and `RadioLayout.svelte` sets it for `sdr-test` alone (MOR-2231). MOR-1069
- * is why — a zone element exists only where an arrangement must place it, and
- * nothing here places these yet. The zone ids are read here as DECLARATIONS —
- * what this layout mounts where — which is exactly what per-zone suppression
- * consumes.
+ * Neither is bound to a `data-zone-id` element in the single composition —
+ * unlike the dual-receiver-cockpit's `rx-tx` zone, which IS
+ * (`SemanticRadioSurfaces.svelte`, `strips="dual"`). That stays deliberate:
+ * MOR-1069 established that a zone element exists only where an arrangement
+ * must place it, and the single composition places nothing. The zone ids are
+ * read here as DECLARATIONS — what this layout mounts where — which is exactly
+ * what per-zone suppression consumes.
  */
 const DESKTOP_V2_ZONES = [
   { id: 'receiver-deck', surfaces: ['vfo'] },

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -137,8 +137,11 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
       // MOR-1336 (S4): the cockpit now declares a tx-aux zone too.
       ['tx-aux', ['txAux']],
     ]);
-    // MOR-1346: `meters` joined as sdr-test's own second zone.
-    expect([...plan(sdrTestLayout)]).toEqual([['main', ['vfo', 'rxTx']], ['meters', ['meters']]]);
+    // MOR-1346: `meters` joined as sdr-test's own zone. MOR-2231: `vfo` and
+    // `rxTx` each hold one too, under the ids `desktop-v2` already uses.
+    expect([...plan(sdrTestLayout)]).toEqual([
+      ['receiver-deck', ['vfo']], ['rx-tx', ['rxTx']], ['meters', ['meters']],
+    ]);
   });
 
   it('applies ONE contract to every layout family — mobile does not fork', () => {
@@ -186,22 +189,25 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
     // The contract already refuses a duplicate across zones on READ; the
     // adoption must not open a second door. `txAux` is a real surface id that
     // no shipped zone declares, so naming it is the purest cross-zone probe.
-    const moved = plan(sdrTestLayout, {
-      visibleSurfaces: { main: ['vfo', 'rxTx', 'txAux'] },
-      zoneOrder: { main: ['txAux', 'rxTx', 'vfo'] },
+    const moved = plan(mobileLayout, {
+      visibleSurfaces: { 'portrait-deck': ['vfo', 'rxTx', 'txAux'] },
+      zoneOrder: { 'portrait-deck': ['txAux', 'rxTx', 'vfo'] },
     });
-    expect(moved.get('main')).toEqual(['rxTx', 'vfo']);
-    expect(moved.get('main')).not.toContain('txAux');
+    expect(moved.get('portrait-deck')).toEqual(['rxTx', 'vfo']);
+    expect(moved.get('portrait-deck')).not.toContain('txAux');
   });
 
   it('reorders within a zone, and normalizes a partial or padded order', () => {
-    expect(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }).get('main'))
+    // `mobile`'s `portrait-deck` since MOR-2231: reordering WITHIN a zone
+    // needs a zone that declares more than one surface, and sdr-test's pair
+    // now lives in two.
+    expect(plan(mobileLayout, { zoneOrder: { 'portrait-deck': ['rxTx', 'vfo'] } }).get('portrait-deck'))
       .toEqual(['rxTx', 'vfo']);
     // Partial: what the operator named leads, the rest follows in DECLARED order.
-    expect(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx'] } }).get('main'))
+    expect(plan(mobileLayout, { zoneOrder: { 'portrait-deck': ['rxTx'] } }).get('portrait-deck'))
       .toEqual(['rxTx', 'vfo']);
     // An order naming nothing the zone declares is inert, never destructive.
-    expect(plan(sdrTestLayout, { zoneOrder: { main: ['meters'] } }).get('main'))
+    expect(plan(mobileLayout, { zoneOrder: { 'portrait-deck': ['meters'] } }).get('portrait-deck'))
       .toEqual(['vfo', 'rxTx']);
   });
 
@@ -266,7 +272,7 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   });
 
   it('flattens the plan in zone-declaration order, deduped', () => {
-    // MOR-1346: sdr-test's own `meters` zone flattens in behind `main`.
+    // MOR-1346/2231: sdr-test's three zones flatten in declaration order.
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx', 'meters']);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
@@ -283,8 +289,12 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
     // is the counterpart that would catch a double mount.
     expect(compositionSurfaces(plan(desktopV2Layout), FALLBACK))
       .toEqual(['vfo', 'rxTx', 'txAux', 'meters', 'scopeDisplay', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan', 'rxAudio', 'dsp', 'cwKeyer', 'scopeControls']);
-    expect(compositionSurfaces(plan(sdrTestLayout, { zoneOrder: { main: ['rxTx', 'vfo'] } }), FALLBACK))
-      .toEqual(['rxTx', 'vfo', 'meters']);
+    // A within-zone reorder reaches the flattened composition — on `mobile`,
+    // which still declares both surfaces in one zone (MOR-2231 split
+    // sdr-test's).
+    expect(compositionSurfaces(
+      plan(mobileLayout, { zoneOrder: { 'portrait-deck': ['rxTx', 'vfo'] } }), FALLBACK,
+    )).toEqual(['rxTx', 'vfo']);
   });
 
   it('never composes to nothing — an empty plan yields the fallback', () => {

--- a/frontend/src/presentation/workspace/contract.ts
+++ b/frontend/src/presentation/workspace/contract.ts
@@ -55,8 +55,13 @@ export const WORKSPACE_THEME_IDS = [
 ] as const;
 export type WorkspaceThemeId = (typeof WORKSPACE_THEME_IDS)[number];
 
-/** Every zone id declared by a registered layout manifest (decisions 5 and 6). */
-export const WORKSPACE_ZONE_IDS = ['main', 'receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'scope-controls', 'peer-columns'] as const;
+/** Every zone id declared by a registered layout manifest (decisions 5 and 6).
+ *  Derived by hand, and checked against the live union by
+ *  `__tests__/contract.test.ts`'s "zone ids are exactly the zones every
+ *  registered layout manifest declares". `main` left with MOR-2231, which
+ *  split sdr-test's only zone into `receiver-deck` + `rx-tx`; no other
+ *  manifest declared it. */
+export const WORKSPACE_ZONE_IDS = ['receiver-deck', 'rx-tx', 'primary-vfo', 'secondary-vfo', 'global', 'portrait-deck', 'control-column', 'tx-aux', 'meters', 'scope-display', 'filter', 'rf-front-end', 'band', 'antenna', 'rit-xit-scan', 'rx-audio', 'dsp', 'cw-keyer', 'scope-controls', 'peer-columns'] as const;
 export type WorkspaceZoneId = (typeof WORKSPACE_ZONE_IDS)[number];
 
 /** Decision 7: command-bus intent names (`set_compressor`), never module paths. */


### PR DESCRIPTION
Linear: MOR-2231 (step 1, batch 1)

Base: branched from `origin/main` at `d1aa77607802b646d828b78aec23d47161f1d4b6`.

## What lands

1. `sdrTestLayout.zones` splits its single `main` zone into
   `receiver-deck: [vfo]` + `rx-tx: [rxTx]`, reusing the ids `desktop-v2` has
   declared since MOR-1266. `meters` is unchanged.
2. `SemanticRadioSurfaces.svelte` gains one prop, `regions` (boolean, default
   `false`). When true, the single composition renders `vfo`/`rxTx` through the
   existing generic `zoned()` path, so each gains
   `<div class="surface-zone" data-zone-id="…">`. When false the rendered tree
   is what it was.
3. `RadioLayout.svelte` passes `regions={skinId === 'sdr-test'}`. The four other
   mount sites (`LcdLayout`, `MobileRadioLayout`, `DualReceiverCockpit`,
   `PeerSplitLayout`) pass nothing and take the default.

## The predicate is skin identity, not manifest-derived

`regions={skinId === 'sdr-test'}` reads the skin id. That is deliberate, and it
is the honest expression of the current state: after (1), **both** resolving
families declare `receiver-deck` and `rx-tx`, so `zoneOwning()` answers non-null
on either face and there is nothing in the manifests for a derived predicate to
key on. Neither manifest carries the full five-region vocabulary yet. A later
batch replaces this predicate once one does.

## `.surface-zone` CSS — what it actually carries

Read from `SemanticRadioSurfaces.svelte`'s own `<style>` block:

```css
.surface-zone { display: flex; flex-direction: column; gap: 8px; }
```

Not `display: contents` — MOR-1336 removed that deliberately, so that a declared
zone is a real box an arrangement can place.

What I checked, and what I did not: the parent `.semantic-surfaces` is itself
`display:flex; flex-direction:column; gap:8px`; each wrapper holds exactly one
child, so its own `gap` is inert; the wrapper count and order match the former
bare-child count and order, so the parent's 8px gap falls in the same places;
and both surface roots (`.vfo-surface`, `.rx-tx-surface`) are content-sized
column flexboxes with no `height`, `width` or `flex` of their own. `grep` over
`src` for `semantic-surfaces` finds no child-combinator or `nth-child` rule
anywhere; the only external rule is `PeerSplitLayout.svelte`'s
`:global(.semantic-surfaces.semantic-surfaces)`, which targets the root itself
and belongs to a skin that mounts `strips="dual"`.

On that reading I expect no geometry change on the SDR face. **I did not measure
it.** The jsdom pool injects no stylesheet, so a computed-style assertion there
would be meaningless, and I ran no browser. Read "no visual change on sdr-test"
as an inspection of the CSS, not an observation.

## How the `{#each}` chain was adapted

`vfo`/`rxTx` render from `{#each singleOrder}` with an `{#if}` chain, not as
independent blocks, so a `zoned(surface, present, body)` call could not simply be
appended alongside the other surfaces. The adaptation branches inside each arm:

```svelte
{#each singleOrder as surface (surface)}
  {#if surface === 'vfo'}
    {#if regions}{@render zoned('vfo', view !== null, vfoSurface)}
    {:else}{@render vfoSurface()}{/if}
  {:else if surface === 'rxTx'}
    {#if regions}{@render zoned('rxTx', view !== null, rxTxSurface)}
    {:else}{@render rxTxSurface()}{/if}
  {/if}
{/each}
```

`view !== null` is the `present` argument because that is exactly the structural
gate both snippet bodies already carry (`{#if view}`); without it a declared zone
would render as an empty `<div>` while the view model is still null — the "empty
promise" zone that `zoned()`'s `present` parameter exists to prevent.

I considered factoring the repeated `{#if regions}` into a local snippet and did
not: it would have exactly two call sites, and the rule of three governs
inventing a generalisation for two. The duplication is four lines and local.

## Deliberately NOT in this batch

The five-region `grid-template-areas` (`vfo-deck` / `left` / `centre-top` /
`right` / `meters-strip`) and the meters-strip host are out of scope, narrowed
from the ticket sketch by the coordinating session: with three of fourteen
surfaces zoned, a five-region grid would have nothing to place, and this repo
forbids landing a mechanism with no reachable effect.

## The mutation result for the desktop test

The test that earns this PR is `leaves the desktop-v2 surfaces bare, with no
zone element around either` — the first assertion in `frontend/src` that
inspects the shape of desktop-v2's rendered subtree at all.

**M1 — the mutation that discriminates.** Changed the call site to
`<SemanticRadioSurfaces regions={true} />`, reinstating exactly the bug this
change avoids, and re-ran the file:

```
FAIL  vfo and rxTx gain zone hosts on the SDR face only (MOR-2231) >
      leaves the desktop-v2 surfaces bare, with no zone element around either
AssertionError: expected <div …(2)>…(1)</div> to be null
Test Files  1 failed (1)
```

One failure, and it is that test. Reverted; both source files' SHA-256 match
their pre-mutation values (`eb89902e…`, `80ebacfe…`), and `git diff` carries no
trace of either mutation.

**M2 — the suggested mutation, reported because it does NOT discriminate.**
Flipping the prop's *default* from `false` to `true` leaves the desktop test
green, because `RadioLayout` passes `regions` explicitly and an explicit prop
beats a default. Under M2 I also ran `semantic-rx-tx-wiring`,
`semantic-tx-aux-wiring` and `semantic-lcd-migration`: all three green. So the
default value itself is covered by none of those four files — the mounts that
take it either use the dual branch or resolve no plan. Anyone reaching for the
default flip as a mutation probe would get a false negative.

## Two properties recorded, not fixed — named so they stay findable

Neither is a defect in this change. Both are facts about what the tests here can
and cannot defend, written down so nobody has to re-derive them. No pin is added
for either: the PR is at the file ceiling.

### 1. The `regions` default is defended by nothing

`regions` defaults to `false`, and **nothing I ran fails if that default
becomes `true`** — mutation M2 above.

`git grep -n "<SemanticRadioSurfaces" -- .` (unscoped) returns six mounts.
`RadioLayout.svelte` is the only one that passes `regions`. Of the five taking
the default, it is *read* on three, because it is read only in the `{:else}`
single branch:

| mount | takes default | `regions` read? |
|---|---|---|
| `RadioLayout.svelte` | no — passes it | yes |
| `LcdLayout.svelte` | yes | yes |
| `MobileRadioLayout.svelte` | yes | yes |
| `frontend/fixtures/ReferenceLayout.svelte` | yes | yes |
| `DualReceiverCockpit.svelte` | yes | no — `strips="dual"` |
| `PeerSplitLayout.svelte` | yes | no — `strips="dual"` |

An earlier revision of this section and of the prop's own comment named *four*
others and listed the two dual mounts instead of `ReferenceLayout` — wrong in
both directions. Corrected in `efaad5e1`; the cause was scoping the search to
`frontend/src`, which cannot reach `frontend/fixtures/`.

`ReferenceLayout` is the consequential one: `fixtures/main.ts` resolves a real
`desktopV2Layout` default-workspace plan for every `reference` fixture, so
`zoneOwning()` is non-null there and a flipped default would wrap both surfaces
in the pixel-diff harness. **Whether that would redden `visual.yml` is
undetermined and coupled to the `.surface-zone` reading above**: if the wrapper
is geometry-neutral as I read it, the captures would not move and the gate
would not catch it; if it is not, the gate would catch it *and* this PR has a
visual change I failed to name. I could not settle it — Playwright is not
runnable on the machine this was built on. The two claims stand or fall
together, which is the most useful thing to know about either.

Bounded: "nothing fails" covers the four files I ran under M2
(`semantic-desktop-migration`, `semantic-rx-tx-wiring`, `semantic-tx-aux-wiring`,
`semantic-lcd-migration`). I did not run the suite under M2.

### 1b. The `present` gate on the two new `zoned()` calls is unpinned

Replacing `view !== null` with `true` in both calls leaves
`semantic-desktop-migration` at 82/82 and `RadioLayout.isolated` at 46/46
(mutation M3, run here, reverted, file hash restored to `eeed586d…`). That
mutation produces the empty-promise zone MOR-1069 forbids and that this file's
own `zoned()` comment says `present` exists to prevent — a `<div
data-zone-id>` wrapping nothing, reachable on `sdr-test` before the view model
arrives. The code is correct; the guard is absent. Recorded, not pinned: the PR
is at the file ceiling.

### 2. The predicate is pinned at both reachable inputs — and nothing pins that there are two

`git grep -n "<RadioLayout" HEAD -- frontend/src`, run at this PR's head,
returns exactly two mounts:

```
frontend/src/skins/desktop-v2/DesktopSkin.svelte:19:<RadioLayout skinId="desktop-v2" />
frontend/src/skins/sdr-test/SdrTestSkin.svelte:40:<RadioLayout skinId="sdr-test" />
```

A control, since a two-element result is negative-shaped and a silent
mismatch would look the same: the identical pattern against `<LcdLayout`,
counted the same way, returns five occurrences across four files — so the
search discriminates rather than matching nothing. (Counted with
`git grep -n … | wc -l`. Not `git grep -c`, which prints one row per file with
a per-file count, and is easy to misread as the occurrence count itself.)
`RadioLayout`'s own prop default is `skinId = 'desktop-v2'`, which coincides
with one of the two.

The one apparent third input is not one. `no-such-layout` appears in four test
files, always cast (`as SkinId`) rather than declared, and it cannot reach this
mount: `semanticDeck` is `declared.has('vfo')` over `getLayout(skinId)`, which
is empty for an unregistered id, so `<SemanticRadioSurfaces>` never mounts and
`regions` is never evaluated. That branch is itself pinned, by this file's
`an undeclared layout keeps its legacy presentation (MOR-1313)` describe.

So the reachable input space for `skinId` at this mount is
`{desktop-v2, sdr-test}`, and tests (a) and (b) pin both members. Over reachable
inputs the pair is exhaustive: a predicate differing from
`skinId === 'sdr-test'` only on ids that never arrive cannot produce a defect.

**What is unguarded is the premise, not the predicate.** These two tests are
complete *because the input space has two members*, and nothing asserts that it
has two. A third `<RadioLayout skinId="…" />` — what a new desktop family would
add — widens the space they were complete over, and nothing reddens at the
moment completeness is lost. The guard is sound; its soundness rests on a fact
outside it that nothing watches.

## Why this is one unit of work (10 files, over the 6-file soft threshold)

The manifest split, the DOM host, the source-text guard in
`forward-declaration-inventory.test.ts` and five existing pins that read
sdr-test's zones all break the moment any one of them lands alone. The split is
not separable from its consumers.

10 files, 265 changed lines against the base — at the file ceiling, under the
line ceiling.

## Scope: four files beyond the planned set

Sweeping every reference to sdr-test's `main` zone turned up pins the plan did
not name, each red on the manifest split alone:

- `presentation/layouts/__tests__/registry.test.ts` — a second
  `toContainEqual({ id: 'main', … })` pin; updated in place.
- `presentation/workspace/__tests__/preferences-adoption.test.ts` — 4 failures.
  Three exercise reordering *within* a zone holding two surfaces and used
  sdr-test as the fixture; they now read `mobile`'s `portrait-deck`, which still
  declares both. The fourth is the manifest-verbatim expectation, updated.
- `components-v2/wiring/__tests__/semantic-tx-aux-wiring.component.test.ts` —
  `reorders the single composition from the zone that mounts both surfaces`,
  moved to `portrait-deck` for the same reason.

`lcd-cockpit`/`lcd-scope` (`control-column`), `mobile` (`portrait-deck`) and
`peer-split` (`peer-columns`) all still declare both surfaces in one zone, so no
mechanism was lost — only sdr-test stopped being an example of it.

A fourth was **found by CI, not by my sweep** (second commit):

- `presentation/workspace/contract.ts` — `WORKSPACE_ZONE_IDS`, a hand-maintained
  allow-list that `workspace/__tests__/contract.test.ts` requires to equal the
  union of every zone id the barrel's manifests declare. `main` had no live
  owner left. Removed; no other manifest declared it, and nothing persists a
  `main` zone key **in source** (`grep` for `main: [` / `'main': [` over
  `src/presentation`, `src/components-v2`, `src/lib` returns nothing).

**Withdrawal.** Commit `2dd4d087`'s message says "nothing persists a `main`
zone key". That is false and is withdrawn here. `WorkspaceSettingsPanel.svelte`
calls `setZoneVisibleSurfaces`/`setZoneOrder`, which reach `persistWorkspace`
over `defaultStorage()` — `localStorage` — and `main` was a live sdr-test zone
until this branch, so a real browser profile can hold one. A source grep
establishes what the code writes today; it cannot establish what a user's
storage already contains, and I stated the narrow result as the broad one. The
runtime consequence is benign rather than absent: `pickZoneMap` allow-lists
against `WORKSPACE_ZONE_IDS`, so a stored `main` key is now dropped with an
`unknown-id` rejection recorded, not applied and not fatal. The commit message
cannot be corrected without a force-push, which is not authorised; the
coordinating session supplies an explicit squash body at merge.

Why the sweep missed it, stated plainly: my zone-context grep required a
lowercase `zone` on the line, and the only zone word on that line is the
uppercase identifier `WORKSPACE_ZONE_IDS`. Re-run with `-i`, the same grep
returns exactly one hand-maintained list — this one. Every other `'main'` it
reports is a synthetic fixture manifest with its own local zone, none of which
reference `sdrTestLayout`.

## Prose left knowingly false — two instances, reported not fixed

Neither is fixed here, by the coordinating session's ruling: this PR is at the
10-file hard ceiling, and prose is reviewed separately from code, so folding two
doc edits into a change already at the limit would trade reviewability for
tidiness. The exact false clauses:

1. `frontend/src/skins/sdr-test/SdrTestSkin.svelte` — sdr-test *"declares the
   VFO/RX-TX pair in one zone (`main: [vfo, rxTx]`)"*. It declares them in two,
   `receiver-deck` and `rx-tx`. The same comment further down calls `meters`
   *"its own zone rather than folded into `main`"*; there is no `main` to fold
   into any more.
2. `frontend/src/presentation/layouts/desktop-declarations.ts` — *"a zone
   element exists only where an arrangement must place it, and the single
   composition places nothing."* The single composition now places two, on
   `sdr-test`.
3. `docs/plans/2026-08-06-settings-modal-boundary.md` — sdr-test *"declares
   exactly one zone, `{ id: 'main', surfaces: ['vfo', 'rxTx'] }`"*, and later
   *"declare `vfo` in its one zone"*. The **count** was already false before
   this PR (MOR-1346 added the `meters` zone, making two); this PR newly
   falsifies the **literal**. Both clauses go.

A follow-up should **delete** these clauses, not rewrite them: a missing
sentence sends the next reader to the code, a wrong one stops them looking, and
a corrected sentence can be wrong again. Note for anyone reading the two commits
here — `d92cbd96` contained a *rewrite* of clause 2 and `2dd4d087` reverted it;
the follow-up should delete the clause rather than restore that rewrite.

The class was enumerated with `grep -rn` over `*.ts`/`*.svelte`/`*.md` for
`sdrTestLayout`, `` sdr-test `main` `` and `` `main: [vfo `` repo-wide, plus a
**case-insensitive** zone-context sweep for the `main` string (the corrected
sweep — see the Scope section for what the first, case-sensitive one missed).
Everything else those find is a synthetic fixture that builds its own manifest
with a locally-named `main` zone (the declarability tests, `manifest-shape`,
`declared-surfaces`, `fixtures.ts` — none reference `sdrTestLayout`), or is
fixed here.

## Gates

Per the constraint on the machine this was built on, no test *suite* was run
locally — only individually named files, one `npx vitest run <file>` at a time.
No Playwright, no pytest; nothing under `src/rigplane/` is touched.

| file | result |
|---|---|
| `semantic-desktop-migration.component.test.ts` | 82 passed |
| `semantic-tx-aux-wiring.component.test.ts` | 45 passed |
| `forward-declaration-inventory.test.ts` | 4 passed |
| `registry.test.ts` | 6 passed |
| `sdr-registration.test.ts` | 7 passed |
| `preferences-adoption.test.ts` | 24 passed |
| `workspace/contract.test.ts` | 52 passed |
| `segmentline-registration.test.ts` (the other `WORKSPACE_ZONE_IDS` reader) | 9 passed |
| `workspace/store.test.ts` | 26 passed |
| `workspace/legacy-readers.test.ts` | 18 passed |

273 passed, 0 failed. Full CI covers the rest — and did: the first push was red
on `workspace/contract.test.ts` alone, which is what commit 2 fixes.

- `npx eslint <the changed files>` — exit 0, no output.
- `npx tsc --noEmit -p tsconfig.json` exits 0 in 0.6s, but that config is
  `{"files": [], "references": [...]}` and checks **nothing** — reported so
  nobody reads it as a passing type gate. The real gate is the repo's own
  `npm run check`
  (`svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json`),
  and it is clean: `svelte-check found 0 errors and 0 warnings`, `tsc` exit 0.

## REGCHECK baseline

`git diff --name-only 2426b434..origin/main -- frontend/` is empty (re-checked
against `origin/main` at `3c997a9d`, which has moved since branch time but with
no `frontend/` changes), so the recorded baseline — run 33719158349 on
`2426b434`, frontend 388 test files / 8405 tests — has not expired.

The first push's CI run reported **388 test files / 8407 tests**: file count
unchanged, test count up by exactly the 2 tests this PR adds, with the single
failure being the `WORKSPACE_ZONE_IDS` drift that commit 2 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




