### PR TITLE
fix: admit structural ATT receiver routes across providers (MOR-2154)

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -661,7 +661,12 @@ class RigctldClientRadio:
 
     def supports_command(self, command: str, *, receiver: int | None = None) -> bool:
         if receiver is not None and (
-            command not in {"set_af_level", "set_rf_gain", "set_squelch"}
+            command not in {
+                "set_af_level",
+                "set_rf_gain",
+                "set_squelch",
+                "set_attenuator_level",
+            }
             or isinstance(receiver, bool)
             or not isinstance(receiver, int)
             or receiver != 0

--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -661,7 +661,8 @@ class RigctldClientRadio:
 
     def supports_command(self, command: str, *, receiver: int | None = None) -> bool:
         if receiver is not None and (
-            command not in {
+            command
+            not in {
                 "set_af_level",
                 "set_rf_gain",
                 "set_squelch",

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -738,12 +738,21 @@ class YaesuCatRadio:
             "set_af_level",
             "set_rf_gain",
             "set_squelch",
+            "set_attenuator_level",
         }:
             return False
         try:
             key = self._receiver_level_write_key(command, receiver)
         except (TypeError, ValueError):
             return False
+        if command == "set_attenuator_level":
+            if (
+                receiver != 0
+                or not self.profile.supports_capability("attenuator")
+                or not callable(getattr(self, "set_attenuator", None))
+            ):
+                return False
+            key = "set_attenuator"
         return self._has_write_command(key)
 
     def _receiver_level_write_key(self, command: str, receiver: int) -> str:

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -273,10 +273,12 @@ class Radio(Protocol):
         through their own backend command inventory.
 
         ``receiver=None`` retains name-only support. An explicit receiver
-        opts into target admission for ``set_af_level``, ``set_rf_gain`` and
-        ``set_squelch``: it must be an integer (not bool) in the provider's
-        topology with an executable write route. Other commands return False
-        for this opt-in query; their name-only support is unchanged.
+        opts into target admission for ``set_af_level``, ``set_rf_gain``,
+        ``set_squelch`` and ``set_attenuator_level``: it must be an integer
+        (not bool) in the provider's topology with an executable write route.
+        This is structural eligibility, not current-frequency applicability.
+        Other commands return False for this opt-in query; their name-only
+        support is unchanged.
         """
         ...
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -346,7 +346,8 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             return supported
         if (
             not supported
-            or command not in {
+            or command
+            not in {
                 "set_af_level",
                 "set_rf_gain",
                 "set_squelch",

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -346,15 +346,36 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
             return supported
         if (
             not supported
-            or command not in {"set_af_level", "set_rf_gain", "set_squelch"}
+            or command not in {
+                "set_af_level",
+                "set_rf_gain",
+                "set_squelch",
+                "set_attenuator_level",
+            }
             or isinstance(receiver, bool)
             or not isinstance(receiver, int)
             or not self._profile.supports_receiver(receiver)
             or not callable(getattr(self, command, None))
-            or not self._profile.supports_capability(command.removeprefix("set_"))
+            or not self._profile.supports_capability(
+                "attenuator"
+                if command == "set_attenuator_level"
+                else command.removeprefix("set_")
+            )
         ):
             return False
         try:
+            if command == "set_attenuator_level":
+                command_map = self._profile.command_map
+                if (
+                    not self._profile.att_values
+                    or command_map is None
+                    or not command_map.has("set_attenuator")
+                ):
+                    return False
+                self._require_cmd29_route(
+                    0x11, None, receiver=receiver, operation=command
+                )
+                return True
             return self._level_command29(command, receiver=receiver) is not None
         except CommandError:
             return False

--- a/tests/test_receiver_command_admission.py
+++ b/tests/test_receiver_command_admission.py
@@ -27,6 +27,14 @@ class CatSink:
         self.writes.append(command)
 
 
+class RigctldCommandSink:
+    def __init__(self):
+        self.calls = []
+
+    async def command(self, command):
+        self.calls.append(command)
+
+
 def yaesu(config=None):
     radio = YaesuCatRadio("/dev/null", profile=config or load_rig(RIGS / "ftx1.toml"))
     radio._transport = CatSink()
@@ -282,7 +290,7 @@ async def test_attenuator_receiver_admission_matches_provider_route(
             )
         )
     else:
-        sink = CatSink()
+        sink = RigctldCommandSink()
         radio = RigctldClientRadio(host="127.0.0.1", transport=sink)
 
     try:
@@ -291,7 +299,7 @@ async def test_attenuator_receiver_admission_matches_provider_route(
         if provider == "ftx1":
             assert radio._transport.writes == []
         elif provider == "rigctld":
-            assert sink.writes == []
+            assert sink.calls == []
         if expected:
             if provider == "ic7300":
                 await radio.set_attenuator_level(20, receiver=receiver)
@@ -306,7 +314,7 @@ async def test_attenuator_receiver_admission_matches_provider_route(
                 assert radio._transport.writes == ["RA01;"]
             else:
                 await radio.set_attenuator_level(6, receiver=receiver)
-                assert sink.writes == ["L ATT 6"]
+                assert sink.calls == ["L ATT 6"]
     finally:
         if provider.startswith("ic"):
             radio._connected = False

--- a/tests/test_receiver_command_admission.py
+++ b/tests/test_receiver_command_admission.py
@@ -81,7 +81,7 @@ async def test_ftx1_single_receiver_topology_rejects_existing_sub_template(comma
     assert radio._transport.writes == []
 
 
-@pytest.mark.parametrize("command", LEVELS)
+@pytest.mark.parametrize("command", (*LEVELS, "set_attenuator_level"))
 @pytest.mark.parametrize("receiver", [-1, 2, True, False, 0.0, "0"])
 def test_invalid_receiver_query_is_false(command, receiver):
     for radio in (icom(), yaesu(), RigctldClientRadio(host="127.0.0.1")):
@@ -195,23 +195,192 @@ def test_icom_admission_honors_setter_profile_requirements(command, missing):
 )
 def test_name_only_is_unchanged_and_receiver_admission_is_opt_in(factory):
     radio = factory()
-    for command in (*LEVELS, "get_freq", "set_preamp", "unknown", "set_af_level_sub"):
+    for command in (
+        *LEVELS,
+        "set_attenuator",
+        "set_attenuator_level",
+        "set_att",
+        "get_freq",
+        "set_preamp",
+        "unknown",
+        "set_af_level_sub",
+    ):
         assert radio.supports_command(command) == radio.supports_command(
             command, receiver=None
         )
     assert radio.supports_command("get_freq")
-    for command in ("get_freq", "set_preamp", "unknown", "set_af_level_sub"):
+    assert not radio.supports_command("set_att")
+    assert radio.supports_command("set_attenuator")
+    assert radio.supports_command("set_attenuator_level")
+    for command in (
+        "get_freq",
+        "set_preamp",
+        "unknown",
+        "set_af_level_sub",
+        "set_attenuator",
+        "set_att",
+    ):
         assert not radio.supports_command(command, receiver=0)
         assert not radio.supports_command(command, receiver=1)
     if isinstance(radio, YaesuCatRadio):
         assert not any(radio.supports_command(f"{command}_sub") for command in LEVELS)
 
 
-@pytest.mark.parametrize("command", LEVELS)
+@pytest.mark.parametrize("command", (*LEVELS, "set_attenuator_level"))
 def test_non_callable_level_cannot_be_receiver_admitted(command):
     for radio in (icom(), yaesu(), RigctldClientRadio(host="127.0.0.1")):
         setattr(radio, command, None)
         assert not radio.supports_command(command, receiver=0)
+
+
+@pytest.mark.parametrize(
+    ("provider", "receiver", "expected"),
+    [
+        ("ic7300", 0, True),
+        ("ic7300", 1, False),
+        ("ic7610", 0, True),
+        ("ic7610", 1, True),
+        ("ftx1", 0, True),
+        ("ftx1", 1, False),
+        ("rigctld", 0, True),
+        ("rigctld", 1, False),
+    ],
+    ids=(
+        "ic7300-main",
+        "ic7300-sub",
+        "ic7610-main",
+        "ic7610-sub",
+        "ftx1-main",
+        "ftx1-sub",
+        "rigctld-main",
+        "rigctld-sub",
+    ),
+)
+async def test_attenuator_receiver_admission_matches_provider_route(
+    provider, receiver, expected
+):
+    writes = []
+    if provider.startswith("ic"):
+        config = load_rig(RIGS / f"{provider}.toml")
+        radio = icom(config)
+
+        async def write(frame, wait_response=True):
+            writes.append(frame)
+
+        radio._connected = True
+        radio._civ_transport = object()
+        radio._send_civ_raw = write
+    elif provider == "ftx1":
+        config = load_rig(RIGS / "ftx1.toml")
+        radio = yaesu(
+            replace(
+                config,
+                commands={
+                    **config.commands,
+                    "set_attenuator_sub": CatCommandSpec(write="RA1{state};"),
+                },
+            )
+        )
+    else:
+        sink = CatSink()
+        radio = RigctldClientRadio(host="127.0.0.1", transport=sink)
+
+    try:
+        assert radio.supports_command("set_attenuator_level", receiver=receiver) == expected
+        assert writes == []
+        if provider == "ftx1":
+            assert radio._transport.writes == []
+        elif provider == "rigctld":
+            assert sink.writes == []
+        if expected:
+            if provider == "ic7300":
+                await radio.set_attenuator_level(20, receiver=receiver)
+                assert writes == [bytes([0xFE, 0xFE, 0x94, 0xE0, 0x11, 0x20, 0xFD])]
+            elif provider == "ic7610":
+                await radio.set_attenuator_level(3, receiver=receiver)
+                assert writes == [
+                    bytes([0xFE, 0xFE, 0x98, 0xE0, 0x29, receiver, 0x11, 0x03, 0xFD])
+                ]
+            elif provider == "ftx1":
+                await radio.set_attenuator_level(1, receiver=receiver)
+                assert radio._transport.writes == ["RA01;"]
+            else:
+                await radio.set_attenuator_level(6, receiver=receiver)
+                assert sink.writes == ["L ATT 6"]
+    finally:
+        if provider.startswith("ic"):
+            radio._connected = False
+
+
+@pytest.mark.parametrize(
+    "defect", ["entry", "read_only", "capability", "primitive", "delegate"]
+)
+def test_ftx1_attenuator_admission_requires_an_executable_main_route(defect):
+    config = load_rig(RIGS / "ftx1.toml")
+    assert yaesu(config).supports_command("set_attenuator_level", receiver=0)
+    commands = dict(config.commands)
+    capabilities = config.capabilities
+    if defect == "entry":
+        del commands["set_attenuator"]
+    elif defect == "read_only":
+        commands["set_attenuator"] = CatCommandSpec(read="RA0;")
+    elif defect == "capability":
+        capabilities = tuple(cap for cap in capabilities if cap != "attenuator")
+    radio = yaesu(replace(config, commands=commands, capabilities=capabilities))
+    if defect == "primitive":
+        radio.set_attenuator_level = None
+    elif defect == "delegate":
+        radio.set_attenuator = None
+    assert not radio.supports_command("set_attenuator_level", receiver=0)
+    assert not radio.supports_command("set_attenuator_level", receiver=1)
+
+
+@pytest.mark.parametrize(
+    "defect", ["command", "capability", "no_domain", "empty_domain", "route", "primitive"]
+)
+def test_ic7610_attenuator_admission_honors_setter_profile_requirements(defect):
+    config = load_rig(RIGS / "ic7610.toml")
+    intact = icom(config)
+    assert intact.supports_command("set_attenuator_level", receiver=0)
+    assert intact.supports_command("set_attenuator_level", receiver=1)
+    if defect == "command":
+        config = replace(
+            config,
+            commands={
+                key: value for key, value in config.commands.items() if key != "set_attenuator"
+            },
+        )
+    elif defect == "capability":
+        config = replace(
+            config,
+            capabilities=tuple(cap for cap in config.capabilities if cap != "attenuator"),
+        )
+    elif defect == "no_domain":
+        config = replace(config, att_values=None)
+    elif defect == "empty_domain":
+        config = replace(config, att_values=())
+    elif defect == "route":
+        config = replace(config, cmd29_routes=())
+    radio = icom(config)
+    if defect == "primitive":
+        radio.set_attenuator_level = None
+    assert radio.supports_command("set_attenuator_level", receiver=0) == (
+        defect == "route"
+    )
+    assert not radio.supports_command("set_attenuator_level", receiver=1)
+
+
+def test_ftx1_attenuator_admission_is_stateless_and_never_writes():
+    radio = yaesu()
+
+    class PoisonState:
+        def __getattribute__(self, name):
+            raise AssertionError(f"receiver admission read legacy state: {name}")
+
+    radio._state = PoisonState()
+    assert radio.supports_command("set_attenuator_level", receiver=0)
+    assert not radio.supports_command("set_attenuator_level", receiver=1)
+    assert radio._transport.writes == []
 
 
 @pytest.mark.parametrize("command", LEVELS)

--- a/tests/test_receiver_command_admission.py
+++ b/tests/test_receiver_command_admission.py
@@ -294,7 +294,10 @@ async def test_attenuator_receiver_admission_matches_provider_route(
         radio = RigctldClientRadio(host="127.0.0.1", transport=sink)
 
     try:
-        assert radio.supports_command("set_attenuator_level", receiver=receiver) == expected
+        assert (
+            radio.supports_command("set_attenuator_level", receiver=receiver)
+            == expected
+        )
         assert writes == []
         if provider == "ftx1":
             assert radio._transport.writes == []
@@ -344,7 +347,8 @@ def test_ftx1_attenuator_admission_requires_an_executable_main_route(defect):
 
 
 @pytest.mark.parametrize(
-    "defect", ["command", "capability", "no_domain", "empty_domain", "route", "primitive"]
+    "defect",
+    ["command", "capability", "no_domain", "empty_domain", "route", "primitive"],
 )
 def test_ic7610_attenuator_admission_honors_setter_profile_requirements(defect):
     config = load_rig(RIGS / "ic7610.toml")
@@ -355,13 +359,17 @@ def test_ic7610_attenuator_admission_honors_setter_profile_requirements(defect):
         config = replace(
             config,
             commands={
-                key: value for key, value in config.commands.items() if key != "set_attenuator"
+                key: value
+                for key, value in config.commands.items()
+                if key != "set_attenuator"
             },
         )
     elif defect == "capability":
         config = replace(
             config,
-            capabilities=tuple(cap for cap in config.capabilities if cap != "attenuator"),
+            capabilities=tuple(
+                cap for cap in config.capabilities if cap != "attenuator"
+            ),
         )
     elif defect == "no_domain":
         config = replace(config, att_values=None)


### PR DESCRIPTION
## Scope
MOR-2154: https://linear.app/morozsm/issue/MOR-2154

ATT-only prerequisite for canonical command delivery. Extend existing supports_command("set_attenuator_level", receiver=...) structural admission in Icom, Yaesu CAT and external rigctld, plus the existing protocol docstring.

Icom validates actual capability/domain/profile command and existing literal 0x11 cmd29 route; MAIN fallback remains supported when cmd29 is absent. Yaesu requires MAIN, the actual primitive and state delegate, capability and executable set_attenuator write template. rigctld retains MAIN-only admission. Name-only queries, AF/RF/SQL, aliases and PRE behavior are unchanged.

No Web descriptor activation, setters, profiles, current-frequency policy, PRE, transport or PTT changes. Structural eligibility does not promise active-band applicability or physical effect. Zero additional Web operation groups are claimed.

## Evidence
- Base: 936a2c45707bacc04f4ab016504feeccbdd5c142.
- Final head: 62acf98dd2dc6ea7e4cca0e04c1b184e582d2b01. Five files / 246 changed lines (235 additions, 11 deletions).
- Test-only 991df986511f8adb765be6102bf2d3df27643302: ordinary Actions 33727378878 produced exactly 17 expected ATT admission assertion failures, 14808 passed, 220 skipped, 16 xfailed. All 10 new negative controls and three existing name-only controls passed.
- Tests are byte-identical to that RED head. Product code adds 53 changed lines across four files.
- Actions-only formatter artifacts 33727187327 and 33727926404 were applied exactly and reverse-checked. No local project execution.
- Independent source review of e51aaa9f passed; final formatted-head review and normal GREEN pending. No merge acceptance claimed yet.

## Boundaries
No hardware/RF validation. No public interface/signature changes, no Web activation, no dynamic frequency policy. Independent exact-head PASS, normal checks, guarded merge and post-merge verification remain required.