### PR TITLE
docs: drop a doc citation pointing past end of radio_poller.py

### DIFF
--- a/.github/scripts/doc-citation-baseline.txt
+++ b/.github/scripts/doc-citation-baseline.txt
@@ -583,7 +583,6 @@ docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:2246
 docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:255-263
 docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:2839
 docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:3702-3711
-docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:4024
 docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:718-722
 docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:723
 docs/plans/2026-08-20-transmit-authority.md	radio_poller.py:818

--- a/docs/plans/2026-08-20-transmit-authority.md
+++ b/docs/plans/2026-08-20-transmit-authority.md
@@ -947,7 +947,7 @@ question qualitatively.
 
 **The connect-time bootstrap exemption is retained — and it does not reach the
 seat this design creates. OPEN (Q15, raised 2026-08-21, not decided.)** The one
-`connection_epoch_bootstrap` exemption (`radio_poller.py:4024`) exists
+`connection_epoch_bootstrap` exemption exists
 because RF/VFO truth is structurally unobservable until that first
 `SelectVfo` lands. A previous draft claimed the solicited read dissolves it;
 it does not — vfo-select is HAZARD, whose read-failure direction is


### PR DESCRIPTION
## Why this is urgent, and not about any one work line

The doc-citation gate's dangling-floor check is red on `main`'s current
state. That workflow is path-filtered on `**/*.md`, so it runs — and fails —
on **every pull request that touches any `.md` file**, whatever that PR is
about. The failure is not caused by, and does not belong to, whichever
branch happens to trip it. This PR clears it for everyone.

Before this change, on `main` at `ed2dc5a4`:

```
$ .github/scripts/check-doc-citations.sh --check-dangling
::error::doc-citation-baseline.txt entries are dangling (cited file/line does not
resolve, see DANGLING-CITATION FLOOR above) and not yet grandfathered in the
dangling-floor baseline:
  docs/plans/2026-08-20-transmit-authority.md: 'radio_poller.py:4024' -- line 4024
  past EOF of 'src/rigplane/web/radio_poller.py' with 4005 lines.
```

## What shortened the file

Commit `3c997a9d` — "route receiver levels through canonical command
dispatch" (#3081) — shortened `src/rigplane/web/radio_poller.py` from
**4054** lines to **4005** lines. Measured directly at that commit and its
parent:

```
$ git show 3c997a9d~1:src/rigplane/web/radio_poller.py | wc -l
    4054
$ git show 3c997a9d:src/rigplane/web/radio_poller.py | wc -l
    4005
```

The file is still 4005 lines at `ed2dc5a4`, so the grandfathered citation
`radio_poller.py:4024` now points 19 lines past end-of-file.

## The citation is deleted, not repointed

The symbol the sentence names, `connection_epoch_bootstrap`, **does not
exist anywhere in `src/rigplane/`** — not at the current head, and not at
`d1aa7760` either:

```
$ git grep -c "connection_epoch_bootstrap" HEAD -- src/rigplane/       # no output, exit 1
$ git grep -c "connection_epoch_bootstrap" d1aa7760 -- src/rigplane/   # no output, exit 1
```

That empty result is a measurement rather than a broken search, because the
control matches:

```
$ git grep -ln "connection.epoch" HEAD -- src/rigplane/
HEAD:src/rigplane/web/radio_poller.py
HEAD:src/rigplane/web/server.py
```

So `connection_epoch_bootstrap` is a concept name in prose, not an
identifier, and the line number was its only pointer into the code. No
correct target can be established, and this repository's delete-before-narrow
ruling settles what to do about that: a missing citation sends the reader to
the code, while a wrong one stops them looking, and a corrected citation that
is also wrong is worse than the original it replaced. Inventing a
plausible-looking replacement line number is precisely the failure mode this
gate exists to catch.

Worth flagging for the owning work line, though it is deliberately **not**
acted on here: `tests/test_radio_poller_tx_interlock.py` contains
`test_connection_epoch_bootstrap_exemption_is_absent_from_production`, which
asserts `"connection_epoch_bootstrap" not in source` for the poller module.
Whether the surrounding sentence should still claim the exemption exists is a
content question for that line, not a citation repair.

## Scope

Only the `(radio_poller.py:4024)` parenthetical is removed. The document's
prose is otherwise untouched — the file belongs to the transmit-authority
work line, and this is a citation repair, not a content edit. The word-diff
is a single substitution on one line:

```
`connection_epoch_bootstrap` exemption [-(`radio_poller.py:4024`)-] exists
```

Two other places in the same document mention `4024` (a bare `:4024` in the
table at line 131, and a comma-joined list `radio_poller.py:2246,2256-2257,4024`
at line 1415). Neither is touched, and neither needs to be: running the gate's
own `PATTERN` regex over the file shows line 950 is the only line that yields
the citation string `radio_poller.py:4024` — the bare form has no path, and
the regex stops at the first comma, yielding only `radio_poller.py:2246` from
the list. The half-fix mutation below confirms this independently.

The baseline shrinks by exactly one entry. `--regenerate` reported
`removed 1, added 0`, and `git diff --numstat` on the baseline is `0 1` —
zero additions, one deletion. The separate dangling baseline needed no change
(`--check-dangling --regenerate` reported `removed 0, added 0`), because this
citation was never grandfathered there. The diff touches exactly two files.

## Class sweep

The instruction was to check every line-citation in the baseline, not just
fix the one instance. Method: an independent classifier reading the 839
`(docfile, citation)` pairs from `doc-citation-baseline.txt` at
`origin/main`, reimplementing the script's documented resolution rule — split
path from max cited line, resolve candidate files from `git ls-tree` by exact
match **or** `/`-suffix match, and classify `OK` / `PAST_EOF` / `MISSING`.
Line counts were taken from the blobs at that ref.

A count is meaningless without its counting rule, so both rules are given:

| Counting rule | Total | Already grandfathered | Not grandfathered |
|---|---|---|---|
| `PAST_EOF` only (file exists, cited line beyond its length) | 10 | 9 | **1** |
| `PAST_EOF` + `MISSING` (no candidate file at all) | 60 | 59 | **1** |

Either way, exactly **one** citation is newly dangling and not yet
grandfathered — `radio_poller.py:4024`, the one this PR removes. No second
new dangling citation exists, so no second decision arises.

Note on the instrument: the first version of this classifier reported *two*
new entries, disagreeing with the gate script. The extra one,
`CHANGELOG.md:525-530`, was my classifier's bug, not a real finding — it
short-circuited on the exact-match candidate instead of taking the union with
suffix matches. Root `CHANGELOG.md` is a symlink (git mode `120000`) to
`docs/CHANGELOG.md`, which has 2625 lines and covers line 530. With the
classifier corrected to take the union, it agrees with the gate script on
both the new set and the empty no-longer-dangling set.

## Verification

All six checks the workflow runs, at the pushed head, invoked with properly
separated arguments:

| # | Invocation | Result |
|---|---|---|
| 1 | `check-doc-citations.sh` | clean (838 grandfathered citations) |
| 2 | `--check-links` | clean (2 grandfathered dead links, repo-wide `*.md`) |
| 3 | `--check-dangling` | clean (59 grandfathered dangling citations) |
| 4 | `--check-growth <merge-base>` | baseline did not grow |
| 5 | `--check-links --check-growth <merge-base>` | baseline did not grow |
| 6 | `--check-dangling --check-growth <merge-base>` | baseline did not grow |

The citation count moved 839 to 838, and the growth checks confirm the
baseline shrank rather than grew.

The link half passes. It also prints a courtesy notice that 2 grandfathered
links no longer appear broken; by that gate's deliberate design a
disappearing link entry is a note and never a failure, so this is pre-existing
on `main` and is not tidied here.

Two mutations were run to confirm the gate actually discriminates, and the
tree was restored afterwards (`git status` clean, diff unchanged):

- Restoring **both** files to `origin/main` reinstates the exact bug: check 3
  fails with the original past-EOF error.
- Restoring **only** the document, keeping the shrunk baseline, fails check 1
  with `docs/plans/2026-08-20-transmit-authority.md:950: new citation
  'radio_poller.py:4024'` — naming line 950 and confirming it is the sole
  source of that citation string.

No test suite was run: this change touches one prose line and one baseline
line, and the gate's own shell script is the thing under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
