### PR TITLE
refactor: the freshness tick owns the meter flush and the cadence call

### DIFF
--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -1680,6 +1680,11 @@ class StateFreshnessService:
         (or over a radio with no coalescer) does nothing here.
         """
 
+        # ``web/server.py: WebServer.__init__`` builds a service with no radio
+        # and ``web/web_startup.py: start_web_server`` ticks it whether or not
+        # the bootstrap replaced it, so None reaches here in a radio-less web
+        # process. ``getattr`` below would tolerate None too; this returns on
+        # the documented case rather than falling through it.
         radio = self._radio
         if radio is None:
             return

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
@@ -54,6 +55,8 @@ __all__ = [
     "provider_uses_civ_acquisition",
 ]
 
+
+logger = logging.getLogger(__name__)
 
 AcquisitionMethod = Literal["poll", "command_response", "wait_for_unsolicited"]
 
@@ -1608,6 +1611,7 @@ class StateFreshnessService:
         "_interval_seconds",
         "_next_prime_monotonic",
         "_on_delta",
+        "_radio",
         "_scheduler",
         "_store",
     )
@@ -1619,10 +1623,12 @@ class StateFreshnessService:
         scheduler: AcquisitionScheduler | None = None,
         interval_seconds: float = 0.05,
         on_delta: Callable[[SnapshotDelta], None] | None = None,
+        radio: object | None = None,
     ) -> None:
         _validate_positive(interval_seconds, label="interval_seconds")
         self._store = store
         self._scheduler = scheduler
+        self._radio = radio
         self._interval_seconds = interval_seconds
         self._on_delta = on_delta
         # -inf so the first tick always primes immediately, regardless of
@@ -1633,11 +1639,11 @@ class StateFreshnessService:
     def tick(self, *, now: float | None = None) -> SnapshotDelta:
         """Advance freshness once and drive the profile's acquisition cadence.
 
-        One tick re-primes never-observed fields, ages the store, queues
-        the reconciliations that ageing produced, and calls
-        :meth:`AcquisitionScheduler.due_requests` (when a scheduler was
-        wired) with the transmit fact :func:`derive_tx_active` reads from
-        the same store.
+        One tick releases due meter samples, re-primes never-observed
+        fields, ages the store, queues the reconciliations that ageing
+        produced, and calls :meth:`AcquisitionScheduler.due_requests` (when
+        a scheduler was wired) with the transmit fact
+        :func:`derive_tx_active` reads from the same store.
 
         Invariant: ``now`` (explicit or defaulted) must come from the same
         monotonic domain as ``self._next_prime_monotonic`` — callers that
@@ -1648,6 +1654,7 @@ class StateFreshnessService:
         """
 
         timestamp = time.monotonic() if now is None else now
+        self.flush_due_meter_samples(now=timestamp)
         self._reprime_unobserved_if_due(now=timestamp)
         delta = self._store.mark_stale_due(now=now)
         for request in delta.reconciliation_requests:
@@ -1661,6 +1668,35 @@ class StateFreshnessService:
         if (delta.freshness or delta.reconciliation_requests) and self._on_delta:
             self._on_delta(delta)
         return delta
+
+    def flush_due_meter_samples(self, *, now: float | None = None) -> None:
+        """Release meter samples whose coalescing window has elapsed.
+
+        :class:`MeterObservationCoalescer` holds a burst's samples until one
+        ages past the window, and the flush that runs on arrival uses that
+        sample's own timestamp — so the newest sample of a burst is never due
+        on arrival and needs a clock-driven release. Reached through the
+        radio the service was constructed with; a service built without one
+        (or over a radio with no coalescer) does nothing here.
+        """
+
+        radio = self._radio
+        if radio is None:
+            return
+        coalescer = getattr(radio, "_meter_observation_coalescer", None)
+        if not isinstance(coalescer, MeterObservationCoalescer):
+            return
+        runtime = getattr(radio, "_civ_runtime", None)
+        flush_due = getattr(runtime, "flush_due_meter_observations", None)
+        if not callable(flush_due):
+            return
+        try:
+            flush_due(now=time.monotonic() if now is None else now)
+        except Exception:
+            # The freshness loop must survive a failing flush: run() only
+            # catches CancelledError, so an exception here would stop the
+            # decay of every field.
+            logger.debug("state freshness: meter flush failed", exc_info=True)
 
     def _reprime_unobserved_if_due(self, *, now: float) -> None:
         """Re-derive the never-observed-field prime at an adaptive interval.

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -28,6 +28,7 @@ from ..core.acquisition_scheduler import (
     AcquisitionRequest,
     AcquisitionScheduler,
     AcquisitionQuery,
+    MeterObservationCoalescer,
     RadioStateModelService,
     StateFreshnessService,
     civ_acquisition_executor_for_provider,
@@ -362,6 +363,12 @@ class RigctldServer:
             ("_acquisition_scheduler", scheduler),
             ("state_model_service", model_service),
             ("_state_freshness_service", freshness_service),
+            # MOR-2280 F14: standalone rigctld coalesces meter bursts as the
+            # web seat does. ``_bootstrap_state_acquisition`` returns before
+            # calling this when the radio already carries a
+            # ``state_model_service``, so a coalescer another seat attached
+            # over the same radio is never replaced here.
+            ("_meter_observation_coalescer", MeterObservationCoalescer()),
         ):
             try:
                 setattr(self._radio, name, value)
@@ -405,6 +412,7 @@ class RigctldServer:
         freshness_service = StateFreshnessService(
             store=self._state_store,
             scheduler=scheduler,
+            radio=self._radio,
         )
         self._acquisition_scheduler = scheduler
         self._state_model_service = model_service

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -85,6 +85,7 @@ from ..core.acquisition_scheduler import (
     AcquisitionRequest,
     AcquisitionScheduler,
     civ_acquisition_executor_for_provider,
+    derive_tx_active,
 )
 from ..core.state_pipeline_contracts import (
     CommandIntent,
@@ -3478,11 +3479,22 @@ class RadioPoller:
         if scheduler is None:
             return
         now = time.monotonic()
-        # MOR-2280: this drain no longer calls ``due_requests``. The profile's
-        # cadence is emitted by ``StateFreshnessService.tick``, which derives
-        # the transmit fact with ``derive_tx_active`` over the same canonical
-        # ``global.tx_state.ptt``. Both seats now reach the cadence through
-        # that one driver; this method dispatches what it finds queued.
+        # MOR-2280: this drain no longer calls ``due_requests`` -- the
+        # profile's cadence is emitted by ``StateFreshnessService.tick``, and
+        # this method dispatches what it finds queued.
+        #
+        # It must still refresh the cached transmit fact, which that call used
+        # to keep current. This loop drains every 0.025 s (LAN) against a
+        # 0.05 s tick, so most drains land BETWEEN ticks; gating on the fact
+        # the last tick left would miss a de-key by up to one tick and send
+        # the tx_only group (power/SWR/ALC/comp) during confirmed RX -- the
+        # MOR-1525 SWR-flap loop. Same ``derive_tx_active`` over the same
+        # canonical store as the tick's own cadence call and as
+        # ``RigctldServer._drain_state_acquisition_once``, so the writers
+        # cannot disagree about one store state. See note_tx_active()'s
+        # docstring, and
+        # test_drain_between_ticks_gates_tx_only_on_the_fact_as_of_the_drain.
+        scheduler.note_tx_active(derive_tx_active(self._state_store))
         # MOR-1533: dispatch must use the tx_active-gated view. Crediting an
         # already-sent answer (runtime._civ_rx) uses the unfiltered
         # pending_requests() instead, so an answer landing after de-key is

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -84,7 +84,6 @@ from ..core.acquisition_scheduler import (
     AcquisitionQuery,
     AcquisitionRequest,
     AcquisitionScheduler,
-    MeterObservationCoalescer,
     civ_acquisition_executor_for_provider,
 )
 from ..core.state_pipeline_contracts import (
@@ -3430,19 +3429,6 @@ class RadioPoller:
 
         self._request_post_write_readback(cmd)
 
-    def _flush_due_meter_observations(self) -> None:
-        coalescer = getattr(self._radio, "_meter_observation_coalescer", None)
-        if not isinstance(coalescer, MeterObservationCoalescer):
-            return
-        runtime = getattr(self._radio, "_civ_runtime", None)
-        flush_due = getattr(runtime, "flush_due_meter_observations", None)
-        if not callable(flush_due):
-            return
-        try:
-            flush_due(now=time.monotonic())
-        except Exception:
-            logger.debug("radio-poller: meter coalescer flush failed", exc_info=True)
-
     def _acquisition_request_expired(
         self,
         request: AcquisitionRequest,
@@ -3492,30 +3478,11 @@ class RadioPoller:
         if scheduler is None:
             return
         now = time.monotonic()
-        # MOR-1525: gate tx_only cadence membership (TX/PA meters: power, SWR,
-        # ALC, comp) on the CANONICAL ``global.tx_state.ptt`` observation, not
-        # the legacy RadioState.ptt mirror the MOR-1485 comment above used to
-        # justify. The mirror was live-proven to desync from the canonical
-        # fact: after a TX it stayed True while the StateStore's own
-        # observation had already flipped False in RX, so the tx_only group
-        # kept polling at ~1s cadence during confirmed RX (operator-visible
-        # as the SWR readout flapping 0<->1, MOR-1525). Read the same field
-        # ``build_public_state_payload_from_snapshot`` serves to the UI, so
-        # this can never disagree with what the operator is shown. Fail
-        # closed: unobserved/stale/unknown ptt -> tx_active False, so
-        # tx_only meters stay idle rather than spuriously poll — the honest
-        # direction when the fact isn't known.
-        try:
-            ptt_field = self._state_store.snapshot().field(
-                FieldPath.global_("tx_state", "ptt")
-            )
-        except KeyError:
-            tx_active = False
-        else:
-            tx_active = ptt_field.freshness is FreshnessState.FRESH and bool(
-                ptt_field.value
-            )
-        scheduler.due_requests(now=now, tx_active=tx_active)
+        # MOR-2280: this drain no longer calls ``due_requests``. The profile's
+        # cadence is emitted by ``StateFreshnessService.tick``, which derives
+        # the transmit fact with ``derive_tx_active`` over the same canonical
+        # ``global.tx_state.ptt``. Both seats now reach the cadence through
+        # that one driver; this method dispatches what it finds queued.
         # MOR-1533: dispatch must use the tx_active-gated view. Crediting an
         # already-sent answer (runtime._civ_rx) uses the unfiltered
         # pending_requests() instead, so an answer landing after de-key is
@@ -3658,7 +3625,6 @@ class RadioPoller:
                 )
 
     async def _send_query(self) -> None:
-        self._flush_due_meter_observations()
         if self._acquisition_scheduler is not None:
             await self._send_scheduler_requests()
             return

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -1033,6 +1033,7 @@ class WebServer:
             store=self.command_state_store,
             scheduler=scheduler,
             on_delta=self._on_state_freshness_delta,
+            radio=radio,
         )
         coalescer = MeterObservationCoalescer()
         self._state_freshness_service = freshness_service

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Iterable, Iterator
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -3623,3 +3624,110 @@ def test_both_tx_active_writers_agree_over_one_store(
         gate_after_each.append(len(scheduler.dispatchable_requests()))
 
     assert gate_after_each == [expected_dispatchable, expected_dispatchable]
+
+
+# ---------------------------------------------------------------------------
+# MOR-2280: the wall-clock meter flush moved from ``RadioPoller._send_query``
+# into the freshness tick, and standalone rigctld gained the coalescer it
+# releases from (F14, pinned in tests/test_rigctld_server.py).
+# ---------------------------------------------------------------------------
+
+
+def _radio_with_coalescer(
+    coalescer: MeterObservationCoalescer, store: StateStore
+) -> SimpleNamespace:
+    """A radio double exposing the two attributes the flush reaches through."""
+
+    return SimpleNamespace(
+        _meter_observation_coalescer=coalescer,
+        _civ_runtime=SimpleNamespace(
+            flush_due_meter_observations=lambda *, now: coalescer.flush_due(
+                store, now=now
+            )
+        ),
+    )
+
+
+def test_freshness_tick_releases_a_meter_sample_once_its_window_elapses() -> None:
+    """The tick is what releases a burst's last sample.
+
+    ``flush_due`` only releases a path whose latest pending sample has aged
+    past its window, and the flush on arrival runs at that sample's own
+    timestamp — so the newest sample of a burst is never due on arrival. Some
+    clock-driven caller has to release it; since MOR-2280 that caller is the
+    tick.
+    """
+
+    store = StateStore()
+    swr = FieldPath.global_("meters", "swr")
+    coalescer = MeterObservationCoalescer()
+    radio = _radio_with_coalescer(coalescer, store)
+    coalescer.record(
+        _observation(swr, 1.4, at=100.0), MeterCoalescingPolicy(window_seconds=0.2)
+    )
+    service = StateFreshnessService(store=store, radio=radio)
+
+    # Inside the window: held, and the store has never seen the path.
+    service.tick(now=100.1)
+    with pytest.raises(KeyError):
+        store.snapshot().field(swr)
+
+    # Past the window: the tick's own clock releases it into the store.
+    service.tick(now=100.3)
+
+    assert store.snapshot().field(swr).value == 1.4
+
+
+def test_freshness_tick_passes_its_own_timestamp_to_the_meter_flush() -> None:
+    """The flush is driven by the tick's clock, not by ``time.monotonic()``.
+
+    A flush that took its own reading would release on wall-clock time while
+    every other effect of the tick used the caller's ``now`` — the two
+    timescales the tick's docstring requires to be one.
+    """
+
+    store = StateStore()
+    seen: list[float] = []
+    radio = SimpleNamespace(
+        _meter_observation_coalescer=MeterObservationCoalescer(),
+        _civ_runtime=SimpleNamespace(
+            flush_due_meter_observations=lambda *, now: seen.append(now)
+        ),
+    )
+    service = StateFreshnessService(store=store, radio=radio)
+
+    service.tick(now=812.5)
+
+    assert seen == [812.5]
+
+
+def test_freshness_tick_survives_a_failing_meter_flush() -> None:
+    """A raising flush must not stop freshness decay.
+
+    ``run()`` catches only ``CancelledError``, so an exception escaping the
+    flush would end the loop and leave every field frozen at its last state.
+    """
+
+    store = StateStore()
+    radio = SimpleNamespace(
+        _meter_observation_coalescer=MeterObservationCoalescer(),
+        _civ_runtime=SimpleNamespace(
+            flush_due_meter_observations=_raise_on_flush,
+        ),
+    )
+    service = StateFreshnessService(store=store, radio=radio)
+
+    assert service.tick(now=900.0) is not None
+
+
+def _raise_on_flush(*, now: float) -> None:
+    raise RuntimeError(f"flush failed at {now}")
+
+
+def test_freshness_service_without_a_radio_does_not_flush() -> None:
+    """The ``radio`` argument is optional; every other test builds one without it."""
+
+    store = StateStore()
+    service = StateFreshnessService(store=store)
+
+    assert service.tick(now=100.0) is not None

--- a/tests/test_acquisition_scheduler.py
+++ b/tests/test_acquisition_scheduler.py
@@ -3682,8 +3682,7 @@ def test_freshness_tick_passes_its_own_timestamp_to_the_meter_flush() -> None:
     """The flush is driven by the tick's clock, not by ``time.monotonic()``.
 
     A flush that took its own reading would release on wall-clock time while
-    every other effect of the tick used the caller's ``now`` — the two
-    timescales the tick's docstring requires to be one.
+    the caller drove the rest of the tick from a seeded clock.
     """
 
     store = StateStore()
@@ -3705,7 +3704,7 @@ def test_freshness_tick_survives_a_failing_meter_flush() -> None:
     """A raising flush must not stop freshness decay.
 
     ``run()`` catches only ``CancelledError``, so an exception escaping the
-    flush would end the loop and leave every field frozen at its last state.
+    flush would end the loop that ages the store.
     """
 
     store = StateStore()
@@ -3724,8 +3723,14 @@ def _raise_on_flush(*, now: float) -> None:
     raise RuntimeError(f"flush failed at {now}")
 
 
-def test_freshness_service_without_a_radio_does_not_flush() -> None:
-    """The ``radio`` argument is optional; every other test builds one without it."""
+def test_freshness_service_without_a_radio_still_ticks() -> None:
+    """``radio`` is optional because a production path leaves it unset.
+
+    ``web/server.py: WebServer.__init__`` builds this service before
+    ``WebServer._bootstrap_state_acquisition`` runs, without a radio; that
+    bootstrap returns without replacing it when no radio is attached, and
+    ``web/web_startup.py: start_web_server`` starts the driver task either way.
+    """
 
     store = StateStore()
     service = StateFreshnessService(store=store)

--- a/tests/test_civ_rx_coverage.py
+++ b/tests/test_civ_rx_coverage.py
@@ -55,6 +55,7 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionScheduler,
     AcquisitionStatus,
     MeterObservationCoalescer,
+    StateFreshnessService,
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -2386,6 +2387,12 @@ async def test_scheduler_active_freq_mode_request_completes_from_civ_rx_loop(
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    # MOR-2280: the cadence call left the poller for
+    # ``StateFreshnessService.tick``; the drain sends what it finds queued.
+    StateFreshnessService(
+        store=poller._state_store,  # noqa: SLF001
+        scheduler=scheduler,
+    ).tick()
     await poller._send_query()  # noqa: SLF001
 
     assert scheduler.pending_requests()[0].paths == (path,)

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -597,16 +597,16 @@ async def test_scheduler_due_request_timeout_is_terminal_not_resent_each_tick() 
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
-    # Each cycle takes exactly two ``time.monotonic()`` readings: the
-    # ``derive_tx_active`` snapshot inside ``_tick_cadence`` (no
-    # ``tx_state.ptt`` observation exists here, so it reads False whatever the
-    # value) and the drain's own timestamp. ``now`` is passed explicitly to
-    # the cadence call so the pair stays two readings, not three.
+    # How many ``time.monotonic()`` readings one cycle takes is an
+    # implementation detail of the drain -- it changed twice while MOR-2280 was
+    # in flight. Drive a settable clock rather than a fixed sequence, so this
+    # test fails on the cadence behaviour it is about and not on a read count.
+    clock = {"t": 100.0}
     with patch(
-        "rigplane.web.radio_poller.time.monotonic",
-        side_effect=(100.0, 100.0, 101.1, 101.1, 101.2, 101.2),
+        "rigplane.web.radio_poller.time.monotonic", side_effect=lambda: clock["t"]
     ):
         for cycle_now in (100.0, 101.1, 101.2):
+            clock["t"] = cycle_now
             _tick_cadence(poller, now=cycle_now)
             await poller._send_query()  # noqa: SLF001
 
@@ -6255,9 +6255,18 @@ def test_scan_facts_seed_labelled_command_response_not_poll_response() -> None:
 # ``RadioPoller`` for ``StateFreshnessService.tick``. The frames below were
 # recorded from one drain cycle at ``e5fd5c8a`` (the merge base of this
 # change) by printing ``_drain_cycle_wire_frames`` before the poller was
-# touched, and are asserted unchanged after it. The test drives the tick and
-# then the poller, which is what production does in both trees, so it is the
-# same cycle either side of the move.
+# touched, and are asserted unchanged after it.
+#
+# Scope, and it is narrower than "web parity" sounds: this drives ONE tick
+# immediately followed by ONE drain. Production interleaves a 0.05 s tick
+# (``StateFreshnessService.__init__``'s ``interval_seconds``) with a 0.025 s
+# LAN / 0.100 s serial drain (``_FAST_INTERVAL`` / ``_FAST_INTERVAL_SERIAL``),
+# so most drains land BETWEEN ticks. An earlier revision of this change leaked
+# a ``tx_only`` read during RX in exactly that ordering, and this pin could not
+# see it: the ordering it fixes is the one where the cached transmit fact is
+# never stale. Between-ticks is
+# ``test_drain_between_ticks_gates_tx_only_on_the_fact_as_of_the_drain``.
+# A pin that fixes an interleaving says nothing about the ones it excludes.
 # ---------------------------------------------------------------------------
 
 #: ``(command, sub, data)`` of every frame one IC-7300 drain cycle emits.
@@ -6344,3 +6353,83 @@ async def test_web_cadence_wire_frames_unchanged_when_due_requests_moves_to_the_
         assert call_.kwargs["priority"] is Priority.BACKGROUND
         assert call_.kwargs["wait_response"] is False
         assert call_.kwargs["wait_dispatch"] is False
+
+
+def _reconciliation_only_tx_only_profile(path: FieldPath) -> RadioAcquisitionProfile:
+    """One ``tx_only`` meter with no poll cadence of its own."""
+
+    return RadioAcquisitionProfile(
+        provider="icom_civ",
+        capabilities=(FieldCapability(path=path, command_response_observable=True),),
+        default_policy=AcquisitionPolicy(),
+        field_policies={path: AcquisitionPolicy(tx_only=True)},
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_between_ticks_gates_tx_only_on_the_fact_as_of_the_drain() -> None:
+    """MOR-1525 leak: a drain landing between two ticks must re-read the fact.
+
+    The poller drains every 0.025 s (LAN) against a 0.05 s tick, so most drains
+    land between ticks. If the drain gates on the cached fact the last tick
+    left, a de-key that happened after that tick is invisible and the
+    ``tx_only`` group is dispatched during confirmed RX -- the SWR-flap loop.
+    Base ``e5fd5c8a`` sent 0 such reads because its drain called
+    ``due_requests`` with a drain-time derivation; this asserts the same 0.
+    """
+
+    radio = _make_radio(active="MAIN")
+    power = FieldPath.global_("meters", "power")
+    scheduler = AcquisitionScheduler(
+        profile=_reconciliation_only_tx_only_profile(power)
+    )
+    radio._acquisition_scheduler = scheduler
+    executor = _InjectedAcquisitionExecutor()
+
+    store = StateStore()
+    ptt = FieldPath.global_("tx_state", "ptt")
+    now = time.monotonic()
+    store.apply(
+        Observation(
+            path=ptt,
+            value=True,
+            source=SourceMetadata(source="poll_response", provider="icom_civ"),
+            timestamp_monotonic=now,
+            max_age=1000.0,
+        )
+    )
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        state_store=store,
+        acquisition_executor=executor,
+    )
+
+    # Tick while transmitting, and queue the tx_only reconciliation it gates.
+    _tick_cadence(poller)
+    scheduler.ensure_fresh(
+        power,
+        max_age=2.0,
+        priority=AcquisitionPriority.RECONCILIATION,
+        reason="stale",
+    )
+
+    # De-key AFTER that tick. The next tick is up to 50 ms away; the drain is
+    # not.
+    store.apply(
+        Observation(
+            path=ptt,
+            value=False,
+            source=SourceMetadata(source="poll_response", provider="icom_civ"),
+            timestamp_monotonic=now + 0.001,
+            max_age=1000.0,
+        )
+    )
+
+    await poller._send_scheduler_requests()  # noqa: SLF001
+
+    assert executor.calls == [], (
+        "tx_only request reached the wire during confirmed RX -- the drain "
+        "gated on the previous tick's transmit fact, not the drain's"
+    )

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -21,7 +21,8 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionPriority,
     AcquisitionScheduler,
     AcquisitionStatus,
-    MeterObservationCoalescer,
+    StateFreshnessService,
+    derive_tx_active,
 )
 from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
@@ -223,6 +224,25 @@ class _InjectedAcquisitionExecutor:
         )
 
 
+def _tick_cadence(poller: RadioPoller, *, now: float | None = None) -> None:
+    """Queue the profile cadence the way ``StateFreshnessService.tick`` does.
+
+    MOR-2280 moved the ``due_requests`` call out of ``RadioPoller``: the web
+    drain now dispatches whatever the freshness tick queued. Tests whose
+    subject is the drain call this instead of building a service, over the
+    poller's own canonical store — the store the production service is built
+    on — so the ``tx_active`` the scheduler sees is derived by the same
+    ``derive_tx_active`` the tick uses.
+    """
+
+    scheduler = poller._acquisition_scheduler  # noqa: SLF001
+    assert scheduler is not None
+    scheduler.due_requests(
+        now=time.monotonic() if now is None else now,
+        tx_active=derive_tx_active(poller._state_store),  # noqa: SLF001
+    )
+
+
 def _make_radio(active: str = "MAIN", *, model: str = "IC-7610") -> MagicMock:
     profile = resolve_radio_profile(model=model)
     radio = MagicMock()
@@ -418,7 +438,9 @@ async def test_scheduler_due_request_sends_supported_civ_query_once() -> None:
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_awaited_once_with(
@@ -444,6 +466,7 @@ async def test_x6200_scheduler_due_request_sends_civ_query_from_profile() -> Non
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     assert radio.send_civ.await_count == 4
@@ -492,6 +515,7 @@ async def test_xiegu_civ_scheduler_due_request_uses_civ_executor() -> None:
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_awaited_once_with(
@@ -516,6 +540,7 @@ async def test_ic7300_profile_scheduler_emits_only_passive_exact_wire_reads() ->
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
     assert poller._acquisition_scheduler is scheduler  # noqa: SLF001
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_any_await(
@@ -572,19 +597,18 @@ async def test_scheduler_due_request_timeout_is_terminal_not_resent_each_tick() 
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    # Each cycle takes exactly two ``time.monotonic()`` readings: the
+    # ``derive_tx_active`` snapshot inside ``_tick_cadence`` (no
+    # ``tx_state.ptt`` observation exists here, so it reads False whatever the
+    # value) and the drain's own timestamp. ``now`` is passed explicitly to
+    # the cadence call so the pair stays two readings, not three.
     with patch(
         "rigplane.web.radio_poller.time.monotonic",
-        # MOR-1525: each ``_send_scheduler_requests`` cycle now also reads
-        # the canonical PTT observation via ``StateStore.snapshot()``, which
-        # takes its own ``time.monotonic()`` reading. The extra reads are
-        # harmless duplicates of the cycle's own timestamp (no
-        # ``tx_state.ptt`` observation exists in this test, so tx_active
-        # stays False regardless of their exact value).
         side_effect=(100.0, 100.0, 101.1, 101.1, 101.2, 101.2),
     ):
-        await poller._send_query()  # noqa: SLF001
-        await poller._send_query()  # noqa: SLF001
-        await poller._send_query()  # noqa: SLF001
+        for cycle_now in (100.0, 101.1, 101.2):
+            _tick_cadence(poller, now=cycle_now)
+            await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_awaited_once()
     assert scheduler.pending_requests() == ()
@@ -664,6 +688,7 @@ async def test_credited_in_flight_request_is_cleared_and_does_not_expire() -> No
     )
 
     with patch("rigplane.web.radio_poller.time.monotonic", return_value=500.0):
+        _tick_cadence(poller)
         await poller._send_scheduler_requests()  # noqa: SLF001
     assert len(poller._acquisition_in_flight) == 1  # noqa: SLF001
     request = scheduler.pending_requests()[0]
@@ -685,6 +710,7 @@ async def test_credited_in_flight_request_is_cleared_and_does_not_expire() -> No
 
     # Next cycle clears the in-flight entry; no timeout failure is recorded.
     with patch("rigplane.web.radio_poller.time.monotonic", return_value=500.1):
+        _tick_cadence(poller)
         await poller._send_scheduler_requests()  # noqa: SLF001
     assert poller._acquisition_in_flight == {}  # noqa: SLF001
     assert scheduler.diagnostics()["failedRequestCount"] == 0
@@ -738,6 +764,7 @@ async def test_healthy_link_false_timeout_does_not_decay_freq_mode_cadence() -> 
     with patch("rigplane.web.radio_poller.time.monotonic", side_effect=_now):
         # Cycle 1: send.
         radio._last_civ_data_received = clock["t"] - 0.1
+        _tick_cadence(poller)
         await poller._send_scheduler_requests()  # noqa: SLF001
         request = scheduler.pending_requests()[0]
         clock["t"] += 3.0
@@ -745,6 +772,7 @@ async def test_healthy_link_false_timeout_does_not_decay_freq_mode_cadence() -> 
         # Cycle 2: deadline fires while healthy → suppressed within grace, no
         # re-send (executor still called exactly once).
         radio._last_civ_data_received = clock["t"] - 0.1
+        _tick_cadence(poller)
         await poller._send_scheduler_requests()  # noqa: SLF001
         assert len(executor.calls) == 1
 
@@ -769,6 +797,7 @@ async def test_healthy_link_false_timeout_does_not_decay_freq_mode_cadence() -> 
 
         # Next cycle clears the in-flight + grace bookkeeping.
         radio._last_civ_data_received = clock["t"] - 0.1
+        _tick_cadence(poller)
         await poller._send_scheduler_requests()  # noqa: SLF001
 
     assert poller._acquisition_in_flight == {}  # noqa: SLF001
@@ -831,6 +860,7 @@ async def test_healthy_link_uncredited_request_is_resent_and_eventually_fails() 
     with patch("rigplane.web.radio_poller.time.monotonic", side_effect=_now):
         for _ in range(6):
             radio._last_civ_data_received = clock["t"] - 0.1
+            _tick_cadence(poller)
             await poller._send_scheduler_requests()  # noqa: SLF001
             clock["t"] += step
 
@@ -865,6 +895,7 @@ async def test_scheduler_request_execution_uses_injected_executor_not_web_mappin
         acquisition_executor=executor,
     )
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
@@ -902,6 +933,7 @@ async def test_non_icom_scheduler_without_executor_fails_instead_of_web_civ_send
         ),  # type: ignore[arg-type]
     )
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
@@ -937,7 +969,9 @@ async def test_scheduler_active_freq_mode_requests_use_receiver_payload(
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_awaited_once_with(
@@ -967,7 +1001,9 @@ async def test_scheduler_unknown_query_mapping_is_recorded_and_failed() -> None:
         ),  # type: ignore[arg-type]
     )
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
@@ -989,6 +1025,7 @@ async def test_scheduler_ptt_request_uses_ic705_declared_getter() -> None:
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_awaited_once_with(
@@ -1020,6 +1057,7 @@ async def test_scheduler_ptt_without_profile_getter_fails_closed() -> None:
     radio._acquisition_scheduler = scheduler
     poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
 
+    _tick_cadence(poller)
     await poller._send_query()  # noqa: SLF001
 
     radio.send_civ.assert_not_awaited()
@@ -1592,18 +1630,6 @@ async def test_execute_set_freq_without_scheduler_does_not_raise() -> None:
 
 
 @pytest.mark.asyncio
-async def test_poller_flushes_due_meter_coalescer_on_query_tick() -> None:
-    radio = _make_radio(active="MAIN")
-    radio._meter_observation_coalescer = MeterObservationCoalescer()
-    radio._civ_runtime = SimpleNamespace(flush_due_meter_observations=MagicMock())
-    poller = RadioPoller(radio, CommandQueue(), radio_state=RadioState())
-
-    await poller._send_query()  # noqa: SLF001
-
-    radio._civ_runtime.flush_due_meter_observations.assert_called_once()
-
-
-@pytest.mark.asyncio
 async def test_scheduler_polling_does_not_starve_user_command_queue() -> None:
     order: list[str] = []
     radio = _make_radio(active="MAIN")
@@ -1621,6 +1647,7 @@ async def test_scheduler_polling_does_not_starve_user_command_queue() -> None:
     queue.put_ordered(SetFreq(14_074_000))
     poller = RadioPoller(radio, queue, radio_state=RadioState())
     _seed_fresh_rx(poller)
+    _tick_cadence(poller)
 
     async def _stop_after_first_wait(*args: object, **kwargs: object) -> None:
         raise asyncio.CancelledError
@@ -4373,6 +4400,7 @@ async def test_poll_demand_does_not_pile_duplicates() -> None:
     # Run many cycles WITHOUT delivering any response (scheduler clears
     # in-flight only on response, so an undelivered group must not re-queue).
     for _ in range(6):
+        _tick_cadence(poller)
         await poller._send_scheduler_requests()  # noqa: SLF001
 
     # Exactly one request stays pending (the single cadence group), and the
@@ -4394,6 +4422,11 @@ async def test_poll_demand_does_not_pile_duplicates() -> None:
 # tx_only meter group (power/SWR/ALC/comp) kept polling at ~1s cadence
 # during confirmed RX -- operator-visible as the SWR readout flapping 0<->1
 # between a fresh poll (1.0) and the TTL-stale race (2.0s).
+#
+# MOR-2280 moved the derivation itself out of the poller into
+# ``derive_tx_active``, which the freshness tick calls; ``_tick_cadence``
+# below is that call. What these tests assert -- canonical fact, not mirror
+# -- is unchanged.
 # ---------------------------------------------------------------------------
 
 
@@ -4403,8 +4436,8 @@ class _TxActiveSpyScheduler(AcquisitionScheduler):
     ``AcquisitionScheduler`` is a ``__slots__`` class, so its bound method
     cannot be monkeypatched on an instance -- subclassing (which regains a
     ``__dict__``) is the direct way to observe exactly what
-    ``_send_scheduler_requests`` derived and passed through, independent of
-    the scheduler's own (separately tested) tx_only gating behavior.
+    ``derive_tx_active`` produced for the cadence call, independent of the
+    scheduler's own (separately tested) tx_only gating behavior.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -4457,6 +4490,7 @@ async def test_tx_active_ignores_stuck_mirror_when_canonical_reads_false() -> No
 
     poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
 
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
 
     assert scheduler.tx_active_calls == [False]
@@ -4485,6 +4519,7 @@ async def test_tx_active_true_when_canonical_observation_is_true() -> None:
 
     poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
 
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
 
     assert scheduler.tx_active_calls == [True]
@@ -4511,6 +4546,7 @@ async def test_tx_active_false_when_canonical_ptt_unobserved() -> None:
 
     poller = RadioPoller(radio, CommandQueue(), radio_state=state, state_store=store)
 
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
 
     assert scheduler.tx_active_calls == [False]
@@ -4548,6 +4584,7 @@ async def test_tx_active_stops_tx_only_group_when_canonical_ptt_de_keys() -> Non
     )
 
     # TX cycle: the tx_only group is due and sent.
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
     assert scheduler.tx_active_calls == [True]
     assert len(scheduler.pending_requests()) == 1
@@ -4564,6 +4601,7 @@ async def test_tx_active_stops_tx_only_group_when_canonical_ptt_de_keys() -> Non
     )
 
     # Next drain: tx_active must read False and no NEW tx_only work is sent.
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
     assert scheduler.tx_active_calls == [True, False]
     assert len(executor.calls) == 1  # unchanged -- no re-send while de-keyed
@@ -4615,6 +4653,7 @@ async def test_drain_withholds_tx_only_reconciliation_when_canonical_ptt_is_rx()
         reason="stale",
     )
 
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
 
     assert executor.calls == [], (
@@ -4632,6 +4671,7 @@ async def test_drain_withholds_tx_only_reconciliation_when_canonical_ptt_is_rx()
             timestamp_monotonic=time.monotonic(),
         )
     )
+    _tick_cadence(poller)
     await poller._send_scheduler_requests()  # noqa: SLF001
 
     assert any(
@@ -6208,3 +6248,99 @@ def test_scan_facts_seed_labelled_command_response_not_poll_response() -> None:
     for name in ("scanning", "scan_resume_mode"):
         field = store.snapshot().field(FieldPath.global_("slow_state", name))
         assert field.source.source != "poll_response"
+
+
+# ---------------------------------------------------------------------------
+# MOR-2280 web parity. The cadence call and the wall-clock meter flush left
+# ``RadioPoller`` for ``StateFreshnessService.tick``. The frames below were
+# recorded from one drain cycle at ``e5fd5c8a`` (the merge base of this
+# change) by printing ``_drain_cycle_wire_frames`` before the poller was
+# touched, and are asserted unchanged after it. The test drives the tick and
+# then the poller, which is what production does in both trees, so it is the
+# same cycle either side of the move.
+# ---------------------------------------------------------------------------
+
+#: ``(command, sub, data)`` of every frame one IC-7300 drain cycle emits.
+_IC7300_DRAIN_CYCLE_FRAMES: tuple[tuple[int, int | None, bytes], ...] = (
+    (0x1C, 0x00, b""),
+    (0x25, None, b"\x00"),
+    (0x26, None, b"\x00"),
+    (0x15, 0x02, b""),
+    (0x14, 0x02, b""),
+    (0x14, 0x03, b""),
+    (0x0F, None, b""),
+    (0x14, 0x01, b""),
+    (0x16, 0x12, b""),
+    (0x16, 0x22, b""),
+    (0x16, 0x40, b""),
+    (0x25, None, b"\x01"),
+    (0x26, None, b"\x01"),
+    (0x11, None, b""),
+    (0x16, 0x02, b""),
+    (0x14, 0x0E, b""),
+    (0x14, 0x0A, b""),
+    (0x1C, 0x01, b""),
+    (0x16, 0x44, b""),
+    (0x14, 0x17, b""),
+    (0x14, 0x0B, b""),
+    (0x14, 0x15, b""),
+    (0x14, 0x16, b""),
+    (0x16, 0x45, b""),
+    (0x16, 0x46, b""),
+    (0x1A, 0x05, b"\x01\x91"),
+    (0x1A, 0x03, b""),
+    (0x16, 0x56, b""),
+    (0x27, 0x1C, b""),
+    (0x27, 0x13, b""),
+    (0x27, 0x1B, b""),
+    (0x27, 0x16, b"\x00"),
+    (0x27, 0x1E, b"\x01\x01"),
+    (0x27, 0x17, b"\x00"),
+    (0x27, 0x14, b"\x00"),
+    (0x27, 0x12, b""),
+    (0x27, 0x19, b"\x00"),
+    (0x27, 0x15, b"\x00"),
+    (0x27, 0x1A, b"\x00"),
+    (0x27, 0x1D, b"\x00"),
+    (0x15, 0x16, b""),
+    (0x15, 0x15, b""),
+)
+
+
+def _drain_cycle_wire_frames(
+    radio: MagicMock,
+) -> tuple[tuple[int, int | None, bytes], ...]:
+    """``(command, sub, data)`` of every ``send_civ`` await, in order."""
+
+    return tuple(
+        (call_.args[0], call_.kwargs.get("sub"), call_.kwargs.get("data"))
+        for call_ in radio.send_civ.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_web_cadence_wire_frames_unchanged_when_due_requests_moves_to_the_tick() -> (
+    None
+):
+    radio = _make_radio(active="MAIN", model="IC-7300")
+    profile = resolve_radio_profile(model="IC-7300")
+    assert profile.state_acquisition is not None
+    store = StateStore()
+    scheduler = AcquisitionScheduler(profile=profile.state_acquisition)
+    radio._acquisition_scheduler = scheduler
+    poller = RadioPoller(
+        radio, CommandQueue(), radio_state=RadioState(), state_store=store
+    )
+    service = StateFreshnessService(store=store, scheduler=scheduler)
+
+    with patch("rigplane.web.radio_poller.time.monotonic", return_value=100.0):
+        service.tick(now=100.0)
+        await poller._send_query()  # noqa: SLF001
+
+    assert _drain_cycle_wire_frames(radio) == _IC7300_DRAIN_CYCLE_FRAMES
+    # The dispatch envelope is uniform across the cycle, so it is asserted
+    # once per frame rather than repeated in the table above.
+    for call_ in radio.send_civ.await_args_list:
+        assert call_.kwargs["priority"] is Priority.BACKGROUND
+        assert call_.kwargs["wait_response"] is False
+        assert call_.kwargs["wait_dispatch"] is False

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -30,6 +30,7 @@ from rigplane.core.acquisition_scheduler import (
     AcquisitionScheduler,
     AcquisitionStatus,
     IcomCivAcquisitionExecutor,
+    MeterObservationCoalescer,
     RadioStateModelService,
     StateFreshnessService,
     derive_tx_active,
@@ -39,6 +40,7 @@ from rigplane.core.state_acquisition_policy import (
     AcquisitionPolicy,
     FieldAvailability,
     FieldCapability,
+    MeterCoalescingPolicy,
     RadioAcquisitionProfile,
 )
 from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
@@ -2266,3 +2268,83 @@ class TestWsjtxCompatPrewarm:
         await srv._wsjtx_compat_prewarm()
 
         mock_radio.set_data_mode.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# MOR-2280 F14: standalone rigctld attaches the meter coalescer only the web
+# seat used to build, and the freshness tick releases what it holds.
+# ---------------------------------------------------------------------------
+
+
+def _coalescing_swr_profile(swr: FieldPath) -> RadioAcquisitionProfile:
+    return RadioAcquisitionProfile(
+        provider="test_provider",
+        capabilities=(FieldCapability(path=swr, command_response_observable=True),),
+        field_policies={
+            swr: AcquisitionPolicy(
+                cadence_seconds=None,
+                freshness_ttl_seconds=2.0,
+                meter_coalescing=MeterCoalescingPolicy(window_seconds=0.2),
+            ),
+        },
+    )
+
+
+def _meter_observation(path: FieldPath, value: object, *, at: float) -> Observation:
+    return Observation(
+        path=path,
+        value=value,
+        source=SourceMetadata(source="poll_response", provider="test_provider"),
+        timestamp_monotonic=at,
+        max_age=2.0,
+    )
+
+
+async def test_standalone_rigctld_coalesces_meter_bursts_and_the_tick_releases_them(
+    cfg: RigctldConfig,
+) -> None:
+    """MOR-2280 F14. This is a behaviour change for the standalone seat.
+
+    ``CivRuntime._record_coalesced_meter_observation`` coalesces only if the
+    radio carries a ``MeterObservationCoalescer``; standalone rigctld attached
+    none, so it returned False for every meter sample and nothing was ever
+    held. Bootstrapping the standalone server now attaches one, and the
+    freshness tick is what releases the held sample into the store.
+    """
+
+    from rigplane.runtime._civ_rx import CivRuntime
+
+    swr = FieldPath.global_("meters", "swr")
+    radio = _ProfiledStandaloneRadio(
+        profile=type(
+            "Profile", (), {"state_acquisition": _coalescing_swr_profile(swr)}
+        )()
+    )
+    srv = RigctldServer(radio, cfg)
+    srv._bootstrap_state_acquisition()
+
+    coalescer = getattr(radio, "_meter_observation_coalescer", None)
+    assert isinstance(coalescer, MeterObservationCoalescer)
+
+    runtime = CivRuntime(radio)
+    radio._civ_runtime = runtime
+
+    # First sample: nothing stored yet, so it is not a burst and applies.
+    assert runtime._record_coalesced_meter_observation(
+        _meter_observation(swr, 1.1, at=500.0)
+    )
+    assert radio._state_store.snapshot().field(swr).value == 1.1
+
+    # Second sample, inside the window: held by the coalescer, not applied.
+    assert runtime._record_coalesced_meter_observation(
+        _meter_observation(swr, 1.9, at=500.05)
+    )
+    assert radio._state_store.snapshot().field(swr).value == 1.1
+    assert coalescer.diagnostics()["pendingSampleCount"] == 1
+
+    # The tick releases it once the window has elapsed.
+    assert srv._state_freshness_service is not None
+    srv._state_freshness_service.tick(now=500.3)
+
+    assert radio._state_store.snapshot().field(swr).value == 1.9
+    assert coalescer.diagnostics()["pendingSampleCount"] == 0


### PR DESCRIPTION
## Post-merge evidence correction — 2026-09-03

The mandatory PR-body corrections from independent review comment5523220440
were still outstanding when this PR merged as870f83b86b2722b1176e4260352b81bdf1c4a458.
The coordinator corrected the presentation below after merge. Code-only PASS
at aa8bc3a965836374dca1ae1d058ceb9bf7b73873 remains; this note does not claim those
metadata obligations were satisfied before merge. Accepted Git history is not
rewritten, and overbroad parity/current-count claims in older prose or squash
text must not be used as proof.

Second and final PR of the tick part of MOR-2280, cut from the merged head of
#3097 (`e5fd5c8a`). #3097 gave `StateFreshnessService.tick` the cadence call and
one shared `derive_tx_active`; this removes the web poller's now-redundant
copies of both and moves the wall-clock meter flush to the same driver.

Linear: MOR-2280

## What changes

* `web/radio_poller.py: RadioPoller._flush_due_meter_observations` deleted, with
  its call in `RadioPoller._send_query`.
* `RadioPoller._send_scheduler_requests` no longer calls `due_requests`, and the
  `tx_active` derivation inlined there is gone — the tick derives it through
  `core/acquisition_scheduler.py: derive_tx_active`.
* `core/acquisition_scheduler.py: StateFreshnessService` gains
  `flush_due_meter_samples` and a `radio=` constructor argument;
  `StateFreshnessService.tick` calls it with the tick's own timestamp.
* `web/server.py: WebServer._bootstrap_state_acquisition` and
  `rigctld/server.py: RigctldServer._bootstrap_state_acquisition` pass `radio=`.
* **`RigctldServer._attach_state_acquisition_services` attaches a
  `MeterObservationCoalescer`** — see "Behaviour change" below.

## Behaviour change: standalone rigctld now coalesces meter bursts (F14)

This is the one part of the PR that is not a move. Only
`WebServer._bootstrap_state_acquisition` built a `MeterObservationCoalescer`
before, so on the standalone rigctld seat
`runtime/_civ_rx.py: CivRuntime._record_coalesced_meter_observation` found none,
returned `False`, and every sample of a meter burst was applied to the store.
It now finds one, holds sub-window samples, and the freshness tick releases them.

Pinned by `tests/test_rigctld_server.py:
test_standalone_rigctld_coalesces_meter_bursts_and_the_tick_releases_them`,
which bootstraps the standalone server and drives the real
`CivRuntime._record_coalesced_meter_observation`: the first sample applies, a
second inside the window is held rather than stored, and
`StateFreshnessService.tick` past the window releases it. Deleting the attach
line reddens that test and nothing else in the five gate files.

## A regression this PR introduced, and fixed

Caught by independent review at `a1a34bee`, present since `897f4f6a`. Removing
the poller's `due_requests` call removed the only thing refreshing the
scheduler's cached `_tx_active` on the web path. `RadioPoller` drains every
0.025 s (`_FAST_INTERVAL`, LAN) or 0.100 s (`_FAST_INTERVAL_SERIAL`) against a
0.05 s tick, so most drains land **between** ticks and gated on the previous
tick's transmit fact. A de-key landing after a tick was invisible for up to one
tick, and the `tx_only` group went out during confirmed RX — MOR-1525's
symptom, on the four fields `rigs/ic7300.toml` declares `tx_only`: power, SWR,
ALC, comp.

Measured as a base-versus-head differential, not argued — one tick while
transmitting, de-key, then drain, run against both trees (`git archive
e5fd5c8a` into a separate directory, selected by `PYTHONPATH`, with a tree
marker asserting which source file was actually imported):

| tree | drain refreshes via | TX-only reads sent during RX |
|---|---|---|
| base `e5fd5c8a` | `due_requests` | **0** |
| `a1a34bee` | *nothing* | **1** ← leak |
| `aa8bc3a9` | `note_tx_active` | **0** |

`RadioPoller._send_scheduler_requests` now calls
`note_tx_active(derive_tx_active(...))`, which is what
`core/acquisition_scheduler.py: AcquisitionScheduler.note_tx_active`'s own
docstring already required of a drain, and what
`RigctldServer._drain_state_acquisition_once` has done since #3097. The seats
are symmetric again.

**Why the parity pin missed it, which is the part worth keeping.** That pin
drives one tick immediately followed by one drain — the single interleaving in
which the cached fact is never stale — and its comment claimed that ordering
"is what production does". That sentence is what made a one-ordering
measurement read as whole-seat parity. It is corrected in place, and the pin
now names the interleaving it excludes and the test that covers it. A pin that
fixes an interleaving says nothing about the ones it excludes.

## Controlled semantic-call parity

`tests/test_radio_poller_coverage.py:
test_web_cadence_wire_frames_unchanged_when_due_requests_moves_to_the_tick`
asserts the ordered `(command, sub, data)` of all 42 `send_civ` frames one
IC-7300 drain cycle emits, plus the uniform dispatch envelope. The expected
table was recorded by printing the captured frames against the tree at
`e5fd5c8a` **before** `radio_poller.py` was touched, and holds unchanged after.
The test fixes one controlled tick-then-drain ordering in both trees. It proves
42 ordered semantic send_civ(command, sub, data) calls in that scenario, not
serialized wire bytes or production task ordering. The author reported stable
ordering under PYTHONHASHSEED 0, 1, 12345 and 99999; this is not independently
replayed Mini evidence.

## One production caller

```
$ grep -rn "\.due_requests(" src/rigplane/
src/rigplane/core/acquisition_scheduler.py:1664:            scheduler.due_requests(
```

That line is inside `StateFreshnessService.tick`. Control on the same pattern:
`grep -rn "\.due_requests(" tests/ | wc -l` → 51, so the pattern does match
calls rather than silently matching nothing.

## Author-reported mutation evidence

The table below is retained as the author's report. Its source/run bindings
were not independently replayed by the PTT reviewer; it is not a substitute
for Mini CI or the independent exact-head code verdict.

Each mutation was applied alone to the finished tree and the five gate files
were run; the tree was restored between mutations and `git diff` confirmed clean
of them before the final run.

| Mutation | Result |
|---|---|
| M1 — `RadioPoller._send_scheduler_requests` dispatches `reversed(dispatchable_requests())` (a frame moves) | 1 failed, 959 passed — only the parity pin |
| M2 — `StateFreshnessService.tick` stops calling `flush_due_meter_samples` | 3 failed, 957 passed — both tick-flush pins and the F14 pin's release leg |
| M3 — the coalescer attach removed from `RigctldServer._attach_state_acquisition_services` | 1 failed, 959 passed — only the F14 pin |
| M4 — the drain-time `note_tx_active` refresh removed (the regression below) | 1 failed, 959 passed — only the between-ticks pin |
| **Control** — the flush moved later within `tick`, to after `mark_stale_due` | **960 passed, 0 failed** |

The control is what separates these pins from ones that merely fail when
something is broken: they redden on a behaviour change and stay green on an edit
that changes only how the code is written.

Correction: the control as first run had a second half — materialising `pending`
through a comprehension — which is a semantic no-op and demonstrates nothing. It
is dropped from the claim. The intra-tick reordering is the real control: it
genuinely changes when the flush runs relative to ageing, and the suite tolerates
it, which is the property being shown.

## Historical test-migration inventory

The counts below describe the earlier migration inventory, before the final
between-ticks regression added another function/callsite. They are not a
complete census of the final aa8bc3a9 head.

**22 test functions collecting 28 cases** relied on the drain queueing its own
cadence through `poller._send_query()` / `poller._send_scheduler_requests()`.
Counting rules, one per quantity:

* 21 functions in `tests/test_radio_poller_coverage.py` — top-level `test_*`
  functions whose AST source segment contains `_tick_cadence(` — collecting
  **24** cases under `pytest --collect-only -q -k <those names>`. Exactly one of
  them is parametrised, into 4 cases.
* 1 function in `tests/test_civ_rx_coverage.py`, collecting **4** cases, which
  drives `StateFreshnessService(...).tick()` directly instead.
* Separately, `grep -c "^\s*_tick_cadence(" tests/test_radio_poller_coverage.py`
  → **29**: call sites, not cases. Some functions drain more than once.

They now queue the cadence explicitly through `_tick_cadence`, a helper that
makes the same `due_requests` call the tick makes, over the poller's own
canonical store. One test asserted deleted behaviour and
is removed by name: `test_poller_flushes_due_meter_coalescer_on_query_tick`; its
subject is now covered by the four `StateFreshnessService` flush tests in
`tests/test_acquisition_scheduler.py`.

Historical gate-file net before the final between-ticks regression: 954 → 959
(+6 added, −1 deleted). Do not use that historical total as final-head evidence.

## Historical author-reported local gates

These rows are preserved as historical reports, not independently verified
current-head Mini results. The 959 count predates the added between-ticks test.

| Command | Result |
|---|---|
| `uv run pytest tests/test_radio_poller_coverage.py tests/test_civ_rx_coverage.py tests/test_acquisition_scheduler.py tests/test_rigctld_server.py tests/test_web_server_coverage.py -q --tb=short` | `959 passed, 25 warnings` (baseline at `e5fd5c8a`, same command: `954 passed`) |
| `uv run ruff check src/ tests/` | `All checks passed!` |
| `uv run ruff format --check src/ tests/` | `712 files already formatted` |
| `uv run lint-imports` | `Contracts: 5 kept, 0 broken.` |
| `uv run mypy --strict src/rigplane/web` | `Success: no issues found in 26 source files` |

The previous claim that every row was re-derived at aa8bc3a9 is withdrawn:
it conflicts with the retained 959 total and the newer 960-case mutation
table. Individual local source/run bindings remain unverified by the PTT
reviewer. Independently inspected normal Mini quick33735296743 at aa8bc3a9
passed 14855 tests / 218 skipped / 15 xfailed / 8 warnings, including the new
between-ticks regression; this does not independently reproduce the local
mutation claims.

Blast-radius check beyond the gate list — the four other test files that name
`_send_query`, `StateFreshnessService(` or `_bootstrap_state_acquisition`
(`test_profiles_routing.py`, `test_civ_transaction_ownership.py`,
`test_rigctld_handler.py`, `test_state_store.py`): `439 passed`. The full suite
is left to CI quick on this PR.

## Ordering, now settled

The PR previously left open whether web always bootstraps first in combined
mode. Independent review settled it: web-first, rigctld defers at its early
return; rigctld-first, `WebServer._bootstrap_state_acquisition` has no early
return and overwrites the whole attach set. One coalescer either way, by two
different mechanisms. `RigctldServer._attach_state_acquisition_services` has
exactly one caller (`grep -rn "_attach_state_acquisition_services"
src/rigplane/` → the definition plus one call, inside
`RigctldServer._bootstrap_state_acquisition` after that early return), which is
what the comment on the attach line claims.

## Size

8 files, 595 changed lines (525 insertions + 70 deletions, `git diff --stat
e5fd5c8a` at `aa8bc3a9`). Over the 6-file soft threshold, just under it on
lines, and inside the 10/1000 hard ceiling. It is one unit of work because the deletions and
the additions are the same move: the poller's flush and cadence call cannot be
removed unless the tick already makes them, and the four test files are the
callers of exactly those two removed call sites.


