### PR TITLE
feat: expose pure optional ATT observation projection (MOR-2154)

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -895,6 +895,9 @@ class RigctldClientRadio:
         line = (await self._transport.query("l ATT", response_lines=1))[0]
         return _parse_int_level(line, "attenuator")
 
+    def project_attenuator_observation_value(self, db: int) -> int:
+        return db
+
     async def set_attenuator_level(self, db: int, receiver: int = 0) -> None:
         self._require_main_receiver(receiver, "set_attenuator_level")
         await self._transport.command(f"L ATT {int(db)}")

--- a/src/rigplane/backends/yaesu_cat/radio.py
+++ b/src/rigplane/backends/yaesu_cat/radio.py
@@ -1411,6 +1411,9 @@ class YaesuCatRadio:
         """
         await self._write("set_attenuator", state=str(int(state)))
 
+    def project_attenuator_observation_value(self, db: int) -> int:
+        return int(db > 0)
+
     async def set_attenuator_level(self, db: int, receiver: int = 0) -> None:
         """Set attenuator by dB level.
 

--- a/src/rigplane/core/radio_protocol.py
+++ b/src/rigplane/core/radio_protocol.py
@@ -94,6 +94,7 @@ __all__ = [
     "AdvancedControlCapable",
     "DspControlCapable",
     "AntennaControlCapable",
+    "AttenuatorObservationProjectable",
     "CwControlCapable",
     "VoiceControlCapable",
     "SystemControlCapable",
@@ -1682,6 +1683,15 @@ class DspControlCapable(Protocol):
 
     async def get_nb_width(self, receiver: int = 0) -> int:
         """Get NB width (0-255)."""
+        ...
+
+
+@runtime_checkable
+class AttenuatorObservationProjectable(Protocol):
+    """Optional projection from a bound ATT input to its observation value."""
+
+    def project_attenuator_observation_value(self, db: int) -> int:
+        """Project an already-bound integer without validation or I/O."""
         ...
 
 

--- a/src/rigplane/runtime/radio.py
+++ b/src/rigplane/runtime/radio.py
@@ -3991,6 +3991,9 @@ class CoreRadio(ScopeRuntimeMixin, AudioRuntimeMixin, DualRxRuntimeMixin):
         """Read attenuator state (compat wrapper)."""
         return (await self.get_attenuator_level(receiver)) > 0
 
+    def project_attenuator_observation_value(self, db: int) -> int:
+        return db
+
     async def set_attenuator_level(
         self, db: int, receiver: int = RECEIVER_MAIN
     ) -> None:

--- a/tests/test_attenuator_observation_projection.py
+++ b/tests/test_attenuator_observation_projection.py
@@ -1,0 +1,142 @@
+"""Pure provider projection for a bound attenuator observation value."""
+
+from inspect import iscoroutinefunction, signature
+from pathlib import Path
+
+import pytest
+
+import rigplane.core.radio_protocol as canonical_radio_protocol
+import rigplane.radio_protocol as compatibility_radio_protocol
+from rigplane.backends.rigctld_client.radio import RigctldClientRadio
+from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
+from rigplane.profiles.rig_loader import load_rig
+from rigplane.runtime.radio import CoreRadio
+
+RIGS = Path(__file__).parents[1] / "rigs"
+PROJECTION_METHOD = "project_attenuator_observation_value"
+PROJECTION_PROTOCOL = "AttenuatorObservationProjectable"
+
+
+def icom(rig_name):
+    return CoreRadio("127.0.0.1", profile=load_rig(RIGS / rig_name).to_profile())
+
+
+def yaesu():
+    return YaesuCatRadio("/dev/null", profile=load_rig(RIGS / "ftx1.toml"))
+
+
+def rigctld():
+    return RigctldClientRadio(host="127.0.0.1")
+
+
+@pytest.mark.parametrize(
+    ("provider", "factory", "db", "expected"),
+    [
+        ("ic7300", lambda: icom("ic7300.toml"), -7, -7),
+        ("ic7300", lambda: icom("ic7300.toml"), 0, 0),
+        ("ic7300", lambda: icom("ic7300.toml"), 1, 1),
+        ("ic7300", lambda: icom("ic7300.toml"), 20, 20),
+        ("ic7300", lambda: icom("ic7300.toml"), 48, 48),
+        ("ic7610", lambda: icom("ic7610.toml"), -7, -7),
+        ("ic7610", lambda: icom("ic7610.toml"), 0, 0),
+        ("ic7610", lambda: icom("ic7610.toml"), 1, 1),
+        ("ic7610", lambda: icom("ic7610.toml"), 20, 20),
+        ("ic7610", lambda: icom("ic7610.toml"), 48, 48),
+        ("ftx1", yaesu, -7, 0),
+        ("ftx1", yaesu, 0, 0),
+        ("ftx1", yaesu, 1, 1),
+        ("ftx1", yaesu, 20, 1),
+        ("ftx1", yaesu, 48, 1),
+        ("rigctld", rigctld, -7, -7),
+        ("rigctld", rigctld, 0, 0),
+        ("rigctld", rigctld, 1, 1),
+        ("rigctld", rigctld, 20, 20),
+        ("rigctld", rigctld, 48, 48),
+    ],
+    ids=(
+        "ic7300-minus-seven",
+        "ic7300-zero",
+        "ic7300-one",
+        "ic7300-twenty",
+        "ic7300-forty-eight",
+        "ic7610-minus-seven",
+        "ic7610-zero",
+        "ic7610-one",
+        "ic7610-twenty",
+        "ic7610-forty-eight",
+        "ftx1-minus-seven",
+        "ftx1-zero",
+        "ftx1-one",
+        "ftx1-twenty",
+        "ftx1-forty-eight",
+        "rigctld-minus-seven",
+        "rigctld-zero",
+        "rigctld-one",
+        "rigctld-twenty",
+        "rigctld-forty-eight",
+    ),
+)
+def test_attenuator_projection_preserves_provider_representation(
+    provider, factory, db, expected
+):
+    result = getattr(factory(), PROJECTION_METHOD)(db)
+    assert type(result) is int
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("provider", "provider_class", "expected"),
+    [
+        ("icom", CoreRadio, 20),
+        ("ftx1", YaesuCatRadio, 1),
+        ("rigctld", RigctldClientRadio, 20),
+    ],
+    ids=("icom", "ftx1", "rigctld"),
+)
+def test_attenuator_projection_is_synchronous_and_stateless(
+    provider, provider_class, expected
+):
+    method = getattr(provider_class, PROJECTION_METHOD)
+    assert not iscoroutinefunction(method)
+    assert tuple(signature(method).parameters) == ("self", "db")
+
+    class PoisonSelf:
+        def __getattribute__(self, name):
+            raise AssertionError(f"projection read state through self: {name}")
+
+        def __setattr__(self, name, value):
+            raise AssertionError(f"projection mutated self: {name}")
+
+    result = method(PoisonSelf(), 20)
+    assert type(result) is int
+    assert result == expected
+
+
+def test_attenuator_projection_protocol_and_compatibility_export():
+    assert PROJECTION_PROTOCOL in canonical_radio_protocol.__all__
+    protocol = getattr(canonical_radio_protocol, PROJECTION_PROTOCOL)
+    assert getattr(compatibility_radio_protocol, PROJECTION_PROTOCOL) is protocol
+    assert isinstance(icom("ic7300.toml"), protocol)
+    assert isinstance(icom("ic7610.toml"), protocol)
+    assert isinstance(yaesu(), protocol)
+    assert isinstance(rigctld(), protocol)
+
+    class MinimalProjection:
+        def project_attenuator_observation_value(self, db: int) -> int:
+            return db
+
+    assert isinstance(MinimalProjection(), protocol)
+    assert not isinstance(object(), protocol)
+
+
+@pytest.mark.parametrize(
+    ("name", "protocol"),
+    [
+        ("Radio", canonical_radio_protocol.Radio),
+        ("AntennaControlCapable", canonical_radio_protocol.AntennaControlCapable),
+        ("AdvancedControlCapable", canonical_radio_protocol.AdvancedControlCapable),
+    ],
+    ids=("radio", "antenna", "advanced"),
+)
+def test_projection_does_not_expand_existing_protocols(name, protocol):
+    assert PROJECTION_METHOD not in dir(protocol), name


### PR DESCRIPTION
## Scope
MOR-2154: https://linear.app/morozsm/issue/MOR-2154

Add the separate optional runtime-checkable AttenuatorObservationProjectable capability: project_attenuator_observation_value(db: int) -> int. Icom and external rigctld retain the bound integer; Yaesu maps positive input to ON=1 and nonpositive input to OFF=0. The result is an expected observation representation, never confirmation of physical state.

No receiver argument, coercion, validation timing change, state/frequency/connection access, I/O, mutation, setter/query change, or new requirement on existing broad runtime-checkable protocols. Existing compatibility shim reexports the canonical module. No caller, Web descriptor, registry, state schema or calibration layer is introduced.

## Exact evidence
- Source head710822a1aa5a3fbfbdc2ed1e2308a98fbfc131da; baseed2dc5a46823e99c770650584ddd92c4e646c637.
- Product patch exactly4files /19 additions; entire PR5files /161 additions, no deletions.
- Test head18812d54e64a1ba4a2b5c14c9c583475187ec848 is frozen byte-identically in final source.
- Ordinary RED33730280416 checked test head merged onto416869cb:24 expected missing-method/protocol failures,14823 passed,220 skipped,15 xfailed. Three broad-protocol negative controls passed; no unrelated failure.
- Test formatter33730148840: Ruff0.15.2 exit0, empty patch. Product patch source-reviewed; normal final CI and exact-head review pending.
- Read-only Git reverse patch check and whitespace checks passed. No local project execution.

## Acceptance and leases
Product source is immutable; four WRITE leases are being returned now, before CI acceptance. Any later product correction requires reacquisition. Independent exact-head PASS, normal GREEN, guarded merge and post-main truth remain required. No hardware/RF evidence; no new Web group is activated by this prerequisite.