### PR TITLE
feat: host the SDR face's five control families in declared zone elements

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1145,6 +1145,16 @@ describe('a stored order naming every legacy panelId cannot resurrect a declared
   // order, mounted where nothing is declared, renders every one of the same
   // ten ids normally. Deleting them from the shared literal would have been
   // wrong for this shape, not just untested for it.
+  //
+  // MOR-2231 (step 1, batch 2) MOVED THIS PROBE off `sdr-test`. That face was
+  // never the "declares nothing" layout the title names — it declared `vfo`,
+  // `rxTx` and `meters`, none of which gates any of the ten — and it stopped
+  // being usable here the moment it declared `filter`, `rfFrontEnd`, `band`,
+  // `antenna` and `ritXitScan`, which retire six of the ten on that face. The
+  // unregistered id is the honest control and the one the title already
+  // described: `declaredSurfaces` resolves it to the empty set, so every
+  // legacy twin survives. It is the same `'no-such-layout'` probe the
+  // "an undeclared layout keeps its legacy presentation" describe above uses.
   it('the identical stored order renders all ten ids on a layout that declares nothing', () => {
     localStorage.setItem('rigplane:panel-order', JSON.stringify(
       ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band', 'antenna', 'scan']));
@@ -1152,7 +1162,7 @@ describe('a stored order naming every legacy panelId cannot resurrect a declared
       ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory']));
     h.caps = { ...(capsFor('2/main_sub') as object), antennas: 2 } as Capabilities;
     vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
-    const t = render('sdr-test');
+    const t = render('no-such-layout' as SkinId);
     const ids = new Set([...t.querySelectorAll('[data-panel-id]')]
       .map((el) => el.getAttribute('data-panel-id')));
     for (const id of RETIRED_ON_DESKTOP_V2) {

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -516,6 +516,218 @@ describe('vfo and rxTx gain zone hosts on the SDR face only (MOR-2231)', () => {
 });
 
 /**
+ * MOR-2231 (step 1, batch 2) — the SDR face's five control families, at the
+ * RENDER level.
+ *
+ * `sdrTestLayout` declares `filter`, `rf-front-end`, `band`, `antenna` and
+ * `rit-xit-scan`. That has two effects and this describe pins both, because
+ * until it existed the batch's PRINCIPAL effect was asserted nowhere: the
+ * manifest tests prove what is declared, not what the declaration does to the
+ * screen.
+ *
+ *   1. ZONE HOSTS. Each surface already mounted on this face BARE, through the
+ *      single composition's `zoned()` calls (`allowBare` defaults true), so the
+ *      declaration moves it inside a `[data-zone-id]` element. Read against a
+ *      resolved plan — `zoneOwning()` reads the PLAN, so a standalone mount
+ *      shows no wrapper whatever the manifest says (the S5 asymmetry
+ *      `renderWithPlan` in the S8 describe records).
+ *   2. SUPPRESSION. `declared.has(<surface>)` retires the legacy twins, which
+ *      reads the MANIFEST and so needs no plan.
+ *
+ * THE CONTROL IS A REGISTERED MANIFEST, NOT AN ARGUMENT. `PRE_BATCH_2` below
+ * is `sdr-test`'s zone list from before this batch. Suppression derives from
+ * `getLayout(skinId)` — the REGISTRY — so passing a different manifest object
+ * to a render helper could not have produced the "before" state; only a
+ * separately registered id can. It differs from `sdr-test` in exactly the
+ * dimension under test and nothing else.
+ */
+describe("the SDR face's five control families are zone-owned (MOR-2231, batch 2)", () => {
+  const LEFT_ALL = ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band',
+    'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+  const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
+
+  /** Same shape the S8 describe uses, for the same reason: without a real HAM
+   *  grid the band split pin would only ever be about the tab strip. */
+  const HAM_RANGES = [{
+    start: 1_800_000, end: 30_000_000, label: 'HF',
+    bands: [
+      { name: '40m', start: 7_000_000, end: 7_300_000, default: 7_100_000 },
+      { name: '20m', start: 14_000_000, end: 14_350_000, default: 14_225_000, bsrCode: 5 },
+    ],
+  }];
+
+  /** `sdr-test`'s zones as they stood BEFORE this batch — the "before" half of
+   *  every row below, registered so it is a real mount. */
+  const PRE_BATCH_2 = 'sdr-pre-batch-2-probe' as SkinId;
+  const PRE_BATCH_2_MANIFEST = probeManifest(PRE_BATCH_2, [
+    { id: 'receiver-deck', surfaces: ['vfo'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
+    { id: 'meters', surfaces: ['meters'] },
+  ], ['vfo', 'rxTx']);
+  registerLayout(PRE_BATCH_2_MANIFEST);
+
+  /** zone id → the surface testid it must own. */
+  const FIVE = [
+    ['filter', 'filter-surface'],
+    ['rf-front-end', 'rf-front-end-surface'],
+    ['band', 'band-surface'],
+    ['antenna', 'antenna-surface'],
+    ['rit-xit-scan', 'ritxit-scan-surface'],
+  ] as const;
+
+  /**
+   * The eight legacy hosts these five declarations UNMOUNT on this face. BAND
+   * is deliberately absent: it is retired by PROP, never by mount (S10 §4a),
+   * and has its own row below.
+   */
+  const RETIRED = [
+    ['left sidebar MODE', '.left-sidebar [data-panel-id="mode"]'],
+    ['left sidebar FILTER', '.left-sidebar [data-panel-id="filter"]'],
+    ['left sidebar RF FRONT END', '.left-sidebar [data-panel-id="rf-front-end"]'],
+    ['left sidebar RIT / XIT', '.left-sidebar [data-panel-id="rit-xit"]'],
+    ['left sidebar SCAN', '.left-sidebar [data-panel-id="scan"]'],
+    ['left sidebar ANTENNA', '.left-sidebar [data-panel-id="antenna"]'],
+    ['settings modal RF FRONT END', '[data-panel-id="desktop-rf"]'],
+    ['settings modal RIT / XIT', '[data-panel-id="desktop-rit"]'],
+  ] as const;
+
+  /** Opens the settings modal — two of the eight retired hosts live there. */
+  function renderAll(skinId: SkinId): HTMLElement {
+    const target = render(skinId);
+    (target.querySelector('.settings-btn') as HTMLElement | null)?.click();
+    flushSync();
+    return target;
+  }
+
+  /** The zone-ELEMENT half needs the resolved plan in context — see the S8
+   *  describe's `renderWithPlan` for why `render()` alone cannot show one.
+   *  Takes the manifest, so the control resolves ITS OWN plan. */
+  function renderWithPlan(skinId: SkinId, manifest: LayoutManifest): HTMLElement {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = resolveSurfacePlan(manifest, DEFAULT_WORKSPACE);
+    mounted.push(mount(RadioLayout, {
+      target, props: { skinId },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    }));
+    flushSync();
+    return target;
+  }
+
+  const texts = (root: Element | null, selector: string) =>
+    [...(root?.querySelectorAll(selector) ?? [])].map((el) => el.textContent?.trim());
+
+  beforeEach(() => {
+    // A radio that fires all five evidence gates. Each field is here because a
+    // named gate in `radio-view-model-adapter.ts` reads it, and a fixture that
+    // missed one would make this whole describe pass vacuously:
+    //   `deriveModeFilter`   — non-empty `caps.modes` OR `caps.filters`;
+    //   `deriveRfFrontEnd`   — any of preamp/attenuator/rf_gain/squelch/
+    //                          digisel/ip_plus;
+    //   `deriveBand`         — non-empty `caps.freqRanges`;
+    //   `deriveAntenna`      — `caps.antennas > 1`;
+    //   `deriveRitXit`       — a `rit`/`xit` capability tag;
+    //   `deriveScan`         — scanning/scanType/scanResumeMode in state.
+    // The first two are this batch's additions to the S8 fixture; without them
+    // `filter-surface` and `rf-front-end-surface` never render at all, which is
+    // how the first draft of this describe failed.
+    h.caps = {
+      ...(capsFor('2/main_sub') as object),
+      antennas: 2,
+      capabilities: ['scope', 'audio', 'tx', 'dual_rx', 'rit', 'xit',
+        'preamp', 'attenuator', 'rf_gain'],
+      modes: ['LSB', 'USB', 'CW'],
+      filters: ['FIL1', 'FIL2', 'FIL3'],
+      freqRanges: HAM_RANGES,
+    } as Capabilities;
+    h.state = {
+      ...(liveState() as object),
+      scanning: false, scanType: 0x34, scanResumeMode: 1,
+      txAntenna: 1, rxAntenna1: 0, ritOn: false, ritTx: false, ritFreq: 0,
+    };
+    // The legacy `BandSelector` reads its HAM grid from the capabilities STORE,
+    // not from `runtime.caps` — without this the grid is empty and the band
+    // pin below would only ever be about the tab strip.
+    vi.mocked(getCapabilities).mockReturnValue(
+      { freqRanges: HAM_RANGES, modes: ['LSB', 'USB', 'CW'], filters: ['FIL1', 'FIL2', 'FIL3'] } as never,
+    );
+    vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
+    vi.mocked(hasAnyScope).mockReturnValue(true);
+    localStorage.setItem('rigplane:panel-order', JSON.stringify(LEFT_ALL));
+    localStorage.setItem('rigplane:right-panel-order', JSON.stringify(RIGHT_ALL));
+  });
+
+  afterEach(() => {
+    vi.mocked(getCapabilities).mockReturnValue({ freqRanges: [], modes: [], filters: [] } as never);
+    vi.mocked(hasAnyScope).mockReturnValue(false);
+    localStorage.clear();
+  });
+
+  // NON-VACUITY, half one: under this fixture the "before" face really does
+  // render all five surfaces AND all eight legacy hosts. Without this row every
+  // suppression pin below could pass because nothing ever rendered.
+  it('the pre-batch manifest renders all five surfaces and all eight legacy hosts', () => {
+    const t = renderAll(PRE_BATCH_2);
+    for (const [, testid] of FIVE) {
+      expect(t.querySelector(`[data-testid="${testid}"]`), testid).not.toBeNull();
+    }
+    for (const [host, selector] of RETIRED) {
+      expect(t.querySelector(selector), host).not.toBeNull();
+    }
+  });
+
+  // NON-VACUITY, half two: on the "before" face those five surfaces mount BARE.
+  // This is the state the declaration replaces, and the row that makes the zone
+  // assertions below a change rather than a restatement.
+  it.each(FIVE)('%s: the pre-batch manifest mounts its surface bare, in no zone', (zoneId, testid) => {
+    const t = renderWithPlan(PRE_BATCH_2, PRE_BATCH_2_MANIFEST);
+    const el = t.querySelector(`[data-testid="${testid}"]`);
+    expect(el, testid).not.toBeNull();
+    expect(el!.closest('.surface-zone')).toBeNull();
+    expect(t.querySelector(`[data-zone-id="${zoneId}"]`)).toBeNull();
+  });
+
+  // EFFECT 1 — each declared zone binds a real element that OWNS its surface,
+  // and there is no second bare mount beside it.
+  it.each(FIVE)('%s: sdr-test hosts its surface inside the declared zone element', (zoneId, testid) => {
+    const t = renderWithPlan('sdr-test', sdrTestLayout);
+    const el = t.querySelector(`[data-testid="${testid}"]`);
+    expect(el, `${testid} on screen`).not.toBeNull();
+    // Containment read from the SURFACE upward, not "some element with this id
+    // exists somewhere": the surface's own wrapper must be the declared zone.
+    const zone = el!.closest('.surface-zone');
+    expect(zone, `${testid} inside a zone element`).not.toBeNull();
+    expect(zone!.getAttribute('data-zone-id')).toBe(zoneId);
+    expect(t.querySelectorAll(`[data-testid="${testid}"]`).length).toBe(1);
+  });
+
+  // EFFECT 2 — the batch's principal effect. Each of the eight legacy hosts is
+  // gone on `sdr-test`, under the identical fixture that renders all eight on
+  // the pre-batch face.
+  it.each(RETIRED)('[%s] is unmounted on sdr-test', (host, selector) => {
+    expect(renderAll('sdr-test').querySelector(selector), host).toBeNull();
+  });
+
+  // THE BAND ASYMMETRY (S10 §4a) — the one family that is NOT unmounted, which
+  // is why it is not a `RETIRED` row. Both `BandSelector` mounts survive and
+  // keep the broadcast presets they alone host; only the HAM half goes.
+  it('drops the HAM half of both BandSelector mounts and keeps the BAND panel', () => {
+    const t = renderAll('sdr-test');
+    for (const [host, root] of [
+      ['left sidebar', t.querySelector('.left-sidebar [data-panel-id="band"]')],
+      ['settings modal', t.querySelector('[data-panel-id="desktop-vfo-ops"]')],
+    ] as const) {
+      expect(root, `${host} still hosts BandSelector`).not.toBeNull();
+      expect(texts(root, '.band-tab'), `${host} tabs`).toEqual(['LW/MW', 'SWL']);
+    }
+    // Zero HAM tabs anywhere, and the semantic replacement is on screen.
+    expect([...t.querySelectorAll('.band-tab')].filter((b) => b.textContent?.trim() === 'HAM').length)
+      .toBe(0);
+    expect(t.querySelectorAll('[data-testid="band-choices"]').length).toBe(1);
+  });
+});
+
+/**
  * The other half of the matrix. Suppression is derived from the manifest, so
  * an id no manifest is registered under declares nothing — and every legacy
  * twin must survive untouched. This is the branch that keeps the shared v2

--- a/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/antenna-declarability.test.ts
@@ -49,7 +49,10 @@ describe('antenna is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare an antenna zone (MOR-1367)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_ANTENNA = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's legacy twins through the `declared.has(...)` channel.
+  const DECLARES_ANTENNA = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -58,8 +58,12 @@ describe('band is a declarable semantic surface', () => {
 describe('exactly the reviewed manifests declare a band zone (MOR-1367)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
   // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
-  // review this literal exists to force: the same declaration retires that
-  // face's legacy twins through the `declared.has(...)` channel.
+  // review this literal exists to force. UNLIKE the other four families in that
+  // batch, this declaration UNMOUNTS NOTHING: `declared.has('band')` feeds the
+  // `hamBands={!declared.has('band')}` PROP (S10 §4a), so both `BandSelector`
+  // mounts on that face drop their HAM tab and HAM grid while the BAND panel
+  // itself keeps rendering — it is the only production host of the broadcast
+  // presets. Measured on the rendered face, not inferred from the channel.
   const DECLARES_BAND = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface

--- a/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/band-declarability.test.ts
@@ -57,7 +57,10 @@ describe('band is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a band zone (MOR-1367)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_BAND = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's legacy twins through the `declared.has(...)` channel.
+  const DECLARES_BAND = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/filter-declarability.test.ts
@@ -47,7 +47,10 @@ describe('filter is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a filter zone (MOR-1366)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_FILTER = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's legacy twins through the `declared.has(...)` channel.
+  const DECLARES_FILTER = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rf-front-end-declarability.test.ts
@@ -53,7 +53,10 @@ describe('rfFrontEnd is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare an rfFrontEnd zone (MOR-1366)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_RF_FRONT_END = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's legacy twins through the `declared.has(...)` channel.
+  const DECLARES_RF_FRONT_END = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/ritxit-scan-declarability.test.ts
@@ -46,7 +46,10 @@ describe('ritXitScan is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a ritXitScan zone (MOR-1367)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_RITXIT_SCAN = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 2) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's legacy twins through the `declared.has(...)` channel.
+  const DECLARES_RITXIT_SCAN = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -77,6 +77,30 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
     expect(sdrTestLayout.zones).toContainEqual({ id: 'meters', surfaces: ['meters'] });
     expect(sdrTestLayout.requiredSemanticSurfaces).not.toContain('meters');
   });
+
+  // MOR-2231 (step 1, batch 2) — the five control families, each alone in a
+  // zone carrying the id `desktop-declarations.ts` already uses.
+  //
+  // Kills: declaring one of the five under a DRIFTED zone id, folding two of
+  // them into one zone, dropping one, or making one `required`. The id drift
+  // is the mutation worth a dedicated pin, because it is the one the
+  // suppression channel cannot catch: `LeftSidebar`/`RadioLayout` retire the
+  // legacy twins on `declared.has(<surface>)`, which reads the SURFACE name
+  // and never the zone id — so a drifted id would still retire the twin while
+  // naming a host no arrangement can bind, and the face would lose the panel
+  // without gaining a placed surface.
+  it.each([
+    ['filter', 'filter'],
+    ['rfFrontEnd', 'rf-front-end'],
+    ['band', 'band'],
+    ['antenna', 'antenna'],
+    ['ritXitScan', 'rit-xit-scan'],
+  ] as const)('mounts %s alone in the stable `%s` zone, not required', (surface, zoneId) => {
+    const owning = sdrTestLayout.zones.filter((z) => z.surfaces.includes(surface));
+    expect(owning).toHaveLength(1);
+    expect(owning[0]).toEqual({ id: zoneId, surfaces: [surface] });
+    expect(sdrTestLayout.requiredSemanticSurfaces).not.toContain(surface);
+  });
 });
 
 describe('MOR-1160 sizing axis — sdr-test stays fluid', () => {

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -33,10 +33,32 @@ export const sdrTestLayout: LayoutManifest = {
   // surface and `SemanticRadioSurfaces` can build a real element for each
   // (its `regions` prop, passed from `RadioLayout.svelte`). Every zone here is
   // now one-surface, the shape `desktop-v2` has used since MOR-1266.
+  //
+  // MOR-2231 (step 1, batch 2): `filter`, `rfFrontEnd`, `band`, `antenna` and
+  // `ritXitScan` join, under the ids `desktop-declarations.ts` already uses.
+  // Each already mounted here BARE, through the single composition's `zoned()`
+  // calls in `SemanticRadioSurfaces.svelte` (whose `allowBare` defaults true),
+  // so declaring the zone gives it a `data-zone-id` host. Declaring it ALSO
+  // activates the MOR-1364 suppression channel on this face: `LeftSidebar`'s
+  // RF FRONT END, MODE, FILTER, RIT / XIT, ANTENNA and SCAN panels and the
+  // settings modal's `desktop-rf` and `desktop-rit` sections stop rendering,
+  // and both `BandSelector` mounts drop their HAM half through
+  // `hamBands={!declared.has('band')}`. That retirement is the point, not a
+  // side effect — the same move MOR-1366/1367 made for `desktop-v2`, closing a
+  // double presentation that was live on this face.
+  //
+  // None is `required`, matching `desktop-v2`: each surface self-gates on its
+  // own `view.*` group, so a radio whose evidence gate declined the group must
+  // still resolve this layout.
   zones: [
     { id: 'receiver-deck', surfaces: ['vfo'] },
     { id: 'rx-tx', surfaces: ['rxTx'] },
     { id: 'meters', surfaces: ['meters'] },
+    { id: 'filter', surfaces: ['filter'] },
+    { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
+    { id: 'band', surfaces: ['band'] },
+    { id: 'antenna', surfaces: ['antenna'] },
+    { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
   ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -137,10 +137,13 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
       // MOR-1336 (S4): the cockpit now declares a tx-aux zone too.
       ['tx-aux', ['txAux']],
     ]);
-    // MOR-1346: `meters` joined as sdr-test's own zone. MOR-2231: `vfo` and
-    // `rxTx` each hold one too, under the ids `desktop-v2` already uses.
+    // MOR-1346: `meters` joined as sdr-test's own zone. MOR-2231 batch 1: `vfo`
+    // and `rxTx` each hold one too, under the ids `desktop-v2` already uses;
+    // batch 2 adds the five control families, same one-surface-per-zone shape.
     expect([...plan(sdrTestLayout)]).toEqual([
       ['receiver-deck', ['vfo']], ['rx-tx', ['rxTx']], ['meters', ['meters']],
+      ['filter', ['filter']], ['rf-front-end', ['rfFrontEnd']], ['band', ['band']],
+      ['antenna', ['antenna']], ['rit-xit-scan', ['ritXitScan']],
     ]);
   });
 
@@ -272,8 +275,10 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   });
 
   it('flattens the plan in zone-declaration order, deduped', () => {
-    // MOR-1346/2231: sdr-test's three zones flatten in declaration order.
-    expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual(['vfo', 'rxTx', 'meters']);
+    // MOR-1346/2231: sdr-test's eight zones flatten in declaration order.
+    expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual([
+      'vfo', 'rxTx', 'meters', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
+    ]);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)
     // scope-display zone, the MOR-1366 (S7) filter/rf-front-end zones, the


### PR DESCRIPTION
Linear: MOR-2231

Base (merge base): `bca43d687c6e5e49492483f2501914b0f0c6f1dd`. Head: `efce5c3cd822a178044e23982e01e6a27fcafb24`.

## Read this first: the declarations retire eight legacy panels

`sdrTestLayout` gains five zones — `filter`, `rf-front-end`, `band`, `antenna`, `rit-xit-scan` — reusing desktop-v2's stable ids. The wrappers are the small half of this change.

The large half: `declaredSurfaces(getLayout(skinId))` feeds a live suppression channel keyed on the **surface name**, so declaring these zones retires the legacy twins on the SDR face. Enumerated by reading every `declared.has(` occurrence in the tree (`git grep -n -i -F "declared.has(" --`, no path scope; control `git grep -c -F "declared" --` matched 20+ files, so the instrument was not silently empty):

| File | Guard | Effect on `sdr-test` |
|---|---|---|
| `LeftSidebar.svelte` | `!declared.has('filter')` | MODE panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('filter')` | FILTER panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('rfFrontEnd')` | RF FRONT END panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('ritXitScan')` | RIT / XIT panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('ritXitScan')` | SCAN panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('antenna')` | ANTENNA panel unmounts (also gated `caps.antennas > 1`) |
| `RadioLayout.svelte` | `!declared.has('rfFrontEnd')` | settings modal `desktop-rf` section unmounts |
| `RadioLayout.svelte` | `!declared.has('ritXitScan')` | settings modal `desktop-rit` section unmounts |
| `LeftSidebar.svelte` + `RadioLayout.svelte` | `hamBands={!declared.has('band')}` | both `BandSelector` mounts drop their HAM half — **the panel itself keeps rendering** |

Eight unmounts, plus the band prop change on two mounts. `band` is the one asymmetric case: it is retired by prop, never by mount, because `BandSelector` is the only production host of the LW/MW + SWL broadcast presets.

**This is intended, not incidental.** All five surfaces already mounted on this face bare, through the single composition's `zoned()` calls (`allowBare` defaults true), while their legacy twins kept rendering — the double presentation `docs/validation/desktop-v2-v3-parity.md` records as item P15. After this change there is one presentation of each instead of two, the same move the S7 and S8 rework slices made for `desktop-v2`.

**What gets worse, and for how long.** Placement. The five surfaces sit in the receiver deck rather than in columns until the region grid lands, so the face is crowded. They remain reachable: `.receiver-deck` is `overflow: hidden`, but `.semantic-surfaces` inside it is `height: 100%; overflow: auto`, so the deck scrolls. `sdr-test` is picker-selectable, labelled `(test)`, and is not the default face.

## The five declarability literals

Each of `{filter,rf-front-end,band,antenna,ritxit-scan}-declarability.test.ts` holds a hand-written `DECLARES_<SURFACE>` literal and asserts the derived declaring set matches it exactly. Each grew `'sdr-test'` beside `'desktop-v2'` — by hand, which is what the literal exists to force. Without the edit each file fails its census assertion. Their `it.each(DECLARES_*)` case then covers the new face automatically, asserting `zone.id` and `zone.surfaces` for it.

The explanatory comment added beside those five literals is **not** identical across them. The `band` copy says what actually happens there — the declaration unmounts nothing, it flips `hamBands` while the BAND panel keeps rendering. The shared "retires that face's legacy twins" wording is true of the other four and would have been false in the `band` file; the parity document had to correct this same miscount once already, as its P22 entry.

Two further guards the declarations falsify, not in the original scope note:

- `preferences-adoption.test.ts` — the `plan(sdrTestLayout)` zone-list equality and the `compositionSurfaces(...)` flattening, both of which enumerate the manifest's zones exactly.
- `semantic-desktop-migration.component.test.ts` — the S11 control asserting a stored order still renders all ten legacy panel ids used **`sdr-test`** as its "declares nothing" layout. It never was that (it already declared `vfo`, `rxTx`, `meters`), and it now declares five of the ten families. The probe moves to the unregistered `no-such-layout` id the sibling describe block already uses — the control its own title always described. Found by running the file, not by reading it; a source sweep had missed it.

## The render-level pin

Manifest tests prove what is declared, not what the declaration does to the screen, so `semantic-desktop-migration.component.test.ts` gains a describe that mounts the real shell and asserts both effects — 20 cases, taking that file from 82 to 102.

- **Zone hosts.** Each of the five surfaces is inside the `[data-zone-id]` element its manifest names, and is the only instance. Read from the surface *upward* (`el.closest('.surface-zone')`, then its `data-zone-id`), so the claim is containment rather than "an element with that id exists somewhere on the page". Run against a resolved plan, because `zoneOwning()` reads the plan, not the manifest.
- **Suppression.** Each of the eight legacy hosts is absent on `sdr-test`, under the identical fixture.
- **The band asymmetry.** Its own row: both `BandSelector` mounts survive with `['LW/MW', 'SWL']` tabs, zero HAM tabs anywhere, and `band-choices` on screen once.

**The control is a registered manifest, not an argument.** Suppression derives from `getLayout(skinId)` — the registry — so handing a different manifest object to a render helper could not have produced the "before" state; only a separately registered id can. `sdr-pre-batch-2-probe` carries this face's pre-batch zone list and differs from `sdr-test` in exactly the dimension under test. Two non-vacuity rows run against it: all five surfaces and all eight legacy hosts render there, and the five mount **bare, in no zone**.

The fixture extends the S8 one with `caps.modes`, `caps.filters` and the preamp/attenuator/rf_gain tags, because `deriveModeFilter` and `deriveRfFrontEnd` gate on those. Without them `filter-surface` and `rf-front-end-surface` never render, which is how the first draft of this describe failed rather than passing vacuously. Each fixture field is commented with the named adapter gate that reads it.

## Mutations

**Round 1 — zone-id drift** (pins the manifest claim). `{ id: 'rf-front-end' }` → `{ id: 'rf-frontend' }` in `declarations.ts`; plausible because `rf-frontend` is the real `dataPanel` value on that same panel. Reachability established first: the filter selects the zone by `surfaces.includes('rfFrontEnd')`, untouched by the mutation, and the next line reads the mutated `id`; `toEqual` compares it by exact string equality. Three files reddened — `sdr-registration.test.ts` (1 failed | 11 passed, `expected { id: 'rf-frontend', …(1) } to deeply equal { id: 'rf-front-end', …(1) }`, with the other four parametrised cases green, so the parametrisation discriminates per case), `rf-front-end-declarability.test.ts` (1 failed | 13 passed, `expected 'rf-frontend' to be 'rf-front-end'`), and `workspace/__tests__/contract.test.ts` (1 failed | 51 passed, on the zone-id union).

**Round 2a — suppression reinstated** (pins the batch's principal effect). Removed `&& !declared.has('ritXitScan')` from the RIT / XIT guard in `LeftSidebar.svelte`, reinstating exactly the double presentation this batch removes. The new row `[left sidebar RIT / XIT] is unmounted on sdr-test` failed with `expected <div …(4)>…(2)</div> to be null`. **`[left sidebar SCAN]` stayed green** — it shares the predicate but is a separate guard, so the rows discriminate individually rather than all dying together. Five pre-existing `desktop-v2` tests also died, the guard being shared across skins.

**Round 2b — one zone dropped** (pins both new halves at once). Removed `{ id: 'filter', surfaces: ['filter'] }` from `sdrTestLayout`. Exactly three rows died, and only those: `filter: sdr-test hosts its surface inside the declared zone element` (`filter-surface inside a zone element: expected null not to be null`), `[left sidebar MODE] is unmounted on sdr-test`, and `[left sidebar FILTER] is unmounted on sdr-test`. The pre-batch control rows and the other four families stayed green.

All mutations reverted. `declarations.ts` back to sha256 `fe6bd236…ba272` and `LeftSidebar.svelte` to `1f0a9a36…ab72`, both byte-identical to their pre-mutation state; `git status` shows no trace, and an unscoped `git grep -F "rf-frontend" --` returns only six pre-existing legitimate hits (the `dataPanel` attribute, `rf-frontend-utils` imports, a comment), which double as the control proving that search matches.

## `REFERENCE_ZONE_IDS`

Non-blocking, and for a stronger reason than "the ids happen to be in the set". `fixtures/assertions.ts` builds `REFERENCE_ZONE_IDS` from **`desktopV2Layout.zones`**, filtering out only `receiver-deck` and `rx-tx`. It never reads `sdrTestLayout`. All five ids are desktop-v2 zone ids and survive that filter, so they were already in the set — and because the set does not consult this manifest at all, this change cannot move the fixture harness in either direction.

## Text-readers of `SemanticRadioSurfaces.svelte`: seven, not six

Not edited here, but enumerated because the set is discoverable and enumerated by nothing, and successive sweeps have undercounted it. Method: `comm -12` of two unscoped listings — `git grep -l -F "readFileSync" --` against `git grep -l -i -F "SemanticRadioSurfaces" --` — then a direct `git grep -n -i -E "readFileSync\(.*SemanticRadioSurfaces|SemanticRadioSurfaces\.svelte'" --`, then `grep -n readFileSync` on each candidate to confirm it reads *that path* rather than merely importing the component.

1. `src/components-v2/layout/__tests__/semantic-mobile-migration.component.test.ts`
2. `src/components-v2/wiring/__tests__/radio-view-model-guard.test.ts`
3. `src/components-v2/wiring/__tests__/tx-aux-command-bus.isolated.test.ts`
4. `src/components-v2/wiring/__tests__/vfo-ops-command-bus.isolated.test.ts`
5. `src/lib/runtime/adapters/__tests__/semantic-surface-handler-binder.isolated.test.ts`
6. `src/presentation/layouts/__tests__/cockpit-responsive-composition.test.ts` (via its `WIRING_PATH` const)
7. `src/presentation/layouts/__tests__/zone-ownership-coverage.test.ts`

Excluded deliberately: `MobileRadioLayout.honesty.isolated.test.ts` (`vi.mock`, not a text read); `fixtures/capture.mjs` and `vite.fixtures.config.ts` (not tests — a path in a list, and a build-config resolve).

## Why nine files is one unit of work

Past the 6-file soft threshold, inside the 10-file / 1000-line ceiling: **9 files, 312 changed lines**, re-derived at the pushed head against the merge base. The unit is the manifest edit plus every guard it falsifies plus the render-level pin for the effect it produces — each is false or unproven the moment another lands alone. Splitting the declarations from the five census literals would push a knowingly-red commit; splitting either from the two `preferences-adoption` guards or the S11 control probe would do the same; and landing eight unmounts on a picker-selectable skin with no test that reddens when they stop happening is what the pin exists to prevent.

## Verification

No test suite was run on this machine (owner's radio workstation). Every run was `npx vitest run <one named file>`, one file per vitest invocation, sequentially.

**42 distinct test files run, all green.** The selection was derived, not eyeballed: `git grep -l -i -E "sdrtestlayout|sdr-test" -- frontend/src | grep -E "\.test\.ts$"` lists **36** test files at this head, and `comm -12` against the list of files actually run shows the intersection is **36** — none unrun. The remaining 6 of the 42 name neither string and were added for the zone-id union, the sidebar, and the sibling LCD/mobile/peer-split suites. (An earlier revision of this body said "34 files … covering every file that names `sdrTestLayout` or `sdr-test`"; the count was wrong and the coverage claim was unverified. Both are now derived by the commands above.)

Largest runs: `semantic-desktop-migration.component.test.ts` 102/102, `VfoSurface.test.ts` 129/129, `workspace-compatibility-verification.test.ts` 96/96, `architecture-boundaries.test.ts` 92/92.

- `npx eslint` on all nine changed files — exit 0, no output.
- `npm run check` (`svelte-check` + `tsc -p tsconfig.node.json`) — exit 0, `4634 FILES 0 ERRORS 0 WARNINGS`.
- No Python gates: nothing under `src/rigplane/`.

**Negative claims are bounded to what was actually run.** "Nothing else fails" means those 42 named files, not the suite. The full frontend suite runs in CI on this PR.

The REGCHECK baseline named in the batch brief (388 test files / 8407 tests at `416869cb`) had **expired** before this work started: `git diff --name-only 416869cb..origin/main -- frontend/` is non-empty — `bca43d68` touched seven frontend files. Compare against CI on this PR's own merge base instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
