### PR TITLE
fix: report Yaesu post-write transport failures

### DIFF
--- a/src/rigplane/backends/yaesu_cat/transport.py
+++ b/src/rigplane/backends/yaesu_cat/transport.py
@@ -326,8 +326,6 @@ class YaesuCatTransport:
                 line = await self.readline(timeout=drain_timeout)
             except CatTimeoutError:
                 break  # Silence — buffer is clean
-            except CatTransportError:
-                break  # Port error — bail out
             drained += 1
             if line == "?":
                 self._stats.record_error(f"rejected: {command}")

--- a/tests/test_yaesu_cat_transport.py
+++ b/tests/test_yaesu_cat_transport.py
@@ -177,6 +177,44 @@ class TestYaesuCatTransport:
 
         assert writer.written == [b"CT002;"]
 
+    @pytest.mark.parametrize("failure_stage", ["writer-drain", "response-drain"])
+    async def test_write_propagates_io_failure_without_resetting_error_count(
+        self,
+        mock_serial_connection: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        failure_stage: str,
+    ) -> None:
+        reader = FakeStreamReader([])
+        writer = FakeStreamWriter()
+        io_error = OSError("serial I/O failed")
+        failed_io = AsyncMock(side_effect=io_error)
+        if failure_stage == "writer-drain":
+            monkeypatch.setattr(writer, "drain", failed_io)
+            error_prefix = "Write"
+        else:
+            monkeypatch.setattr(reader, "readuntil", failed_io)
+            error_prefix = "Read"
+        mock_serial_connection.open_serial_connection = AsyncMock(
+            return_value=(reader, writer)
+        )
+
+        transport = YaesuCatTransport(device="/dev/test")
+        await transport.connect()
+
+        with pytest.raises(
+            CatTransportError, match=f"{error_prefix} failed: serial I/O failed"
+        ) as caught:
+            await transport.write("TX0;")
+
+        assert type(caught.value) is CatTransportError
+        assert caught.value.__cause__ is io_error
+        assert writer.written == [b"TX0;"]
+        failed_io.assert_awaited_once()
+        assert transport.stats.errors == 1
+        assert transport.stats.consecutive_errors == 1
+        assert transport.stats.timeouts == 0
+        assert transport.stats.writes == (0 if failure_stage == "writer-drain" else 1)
+
     async def test_readline_returns_response_without_terminator(
         self, mock_serial_connection: Any
     ) -> None:


### PR DESCRIPTION
## Scope

Planning owner: MOR-2165. This is a small prerequisite in the existing canonical Yaesu write path, not managed actuation or application cutover.

Search-before-write: traced YaesuCatRadio.set_ptt → existing _write/profile formatter → YaesuCatTransport.write → _drain_responses. Non-timeout read errors are currently swallowed and followed by record_success. Reuse this path; no new authority, retry, queue, session layer or formatter.

## Current candidate and review

Integrated candidate890b365a1ad98593cf5b71ea07f4414e6a4d8943 combines reviewed3e0ef8080d70544ab4812d34905408771a27716a with accepted main9e72ba86543ae429593540517fc3beace93314c6. Both owned blobs unchanged; all other tracked paths exactly match accepted main. Two files,+38/-2=40changedlines. Fresh independent exact-head PASS: https://github.com/rigplane/rigplane-core/pull/3106#issuecomment-5523469683 . Integrated-head CI independently VERIFIED GREEN: quick33738009039=14855PASS/220skip/15xfail/6warnings; full33738004817 each Python3.11/3.12/3.13=14857PASS/218skip/15xfail,warnings6/2/2. All18Yaesu cases and the earlier failing WebSocket-precondition case PASS in all4runs. Full PASS sets identical and accepted9e72 baseline plus exactly2new Yaesu rows; quick differs only by2expected static-page skips. Actual quickcheckout488c40cabbf124f49d50120173d4692fc73bed69 has candidate-identical treee769497541cbbee54a68a05373ca9fba6d39d45f; allfulljobs checkout890. Every fullleg frontend8437tests/388files,svelte0errors0warnings,mypy26/imports5/0PASS; capture65/0invalid,artifact9886708120. Raw evidence /var/tmp/yaesu-integrated-ci.36UY6T. PR marked ready; coordinator still performs fresh exact-head/current-main merge guards.

Previous candidate quick33737198055 FAILED: sole old tests/test_web_server.py::TestHalfOpenWsReaper::test_saturated_peer_reaper_not_wedged at2561, CALL setup-precondition buffer0 versus >4096 before reaper creation.14854PASS/220skip/15xfail/6warnings; all18Yaesu casesPASS. Actual quickcheckout ecc481157246263137a401e810f488d1032cc744 merges3e0 over accepted870f83(#3103); counts reconciled by node IDs. The failing file is untouched by both changes. No proven flake/rootcause and no reaper-hang finding. Failure count1 remains; base integration does not reset it.

Previous full33737192850 independently VERIFIED GREEN at exact3e0: each Python14851PASS/218skip/15xfail, warnings5/2/2; all18focusedPASS, every baseline PASS node retained with exactly2new cases. Each leg frontend8407tests/388files,mypy26/imports5/0PASS; capture65/0invalid. It neither clears the failed quick nor verifies the newly integrated tree. No unchanged rerun was performed; new-head checks follow accepted-base integration. Reviewer-required PR-body corrections applied.

## Tests-first evidence

Tests-only source12f18aa8d816185df3452249639c5acfb771cb0a, based on accepted2819e452ebc251a238ccdf39d936cc8ee93dba0a. Independent TEST DESIGN READY; production src tree unchanged. One test file,+38lines.

Independently VALIDATED RED, normal Mini quick33736663092: exactly TestYaesuCatTransport::test_write_propagates_io_failure_without_resetting_error_count[response-drain] at tests/test_yaesu_cat_transport.py:204, CALL Failed:DID NOT RAISE CatTransportError. The writer-drain row is a positive control of existing behavior. Measured focused file:1FAIL+17PASS; whole suite1FAIL/14848PASS/220skip/15xfail/6warnings. All14847accepted-baseline PASS nodes retained. No unrelated failures, setup/teardown errors or timeouts. Ruff/imports/golden PASS; frontend/mypy SKIPPED. Actual merge3508e66012781e2a24a7707299a284529d05f1ba has source-identical tree20d635132831ea2ab91af00418bf4e606a09caff. The test exercises synchronous fake write then a failing awaited I/O, checking original OSError chaining, TX0 bytes, single error accounting and no success reset.

Recorded accepted-main whole-suite quick33731434798:14847PASS/220skip/15xfail/6warnings. First normal full33735935714 independently VERIFIED GREEN at exact main2819: each Python3.11/3.12/3.13 has14849PASS/218skip/15xfail (warnings6/2/1), all three PASS-node sets equal. Two built static-index cases explain quick's two additional skips. Each leg frontend8407tests/388files, typecheck0errors, mypy26files and imports5/0PASS; capture65/0invalid. Raw evidence: /var/tmp/yaesu-baseline-full-evidence.clGhzo; capture artifact9885988046. All execution only Mini via ordinary Actions. No local project tooling.

## Implemented minimal repair

Removed only the two-line non-timeout CatTransportError catch in _drain_responses. Preserved quiet CatTimeoutError completion, typed ? rejection, canonical framing, public signatures, existing lock and counters. Actual scope two files/40changedlines. Test blob remains byte-identical to validated RED12f. Restoring this deleted catch exactly recreates the tested failing parent: bounded falsification evidence, no separate harness/replay claim.

Automatic failure isolation, close/join/session replacement, reconnect and priority/managed adapter changes are excluded. The broader isolation proposal was rejected before implementation because disconnecting after one error can strand the current reconnect owner below its five-error threshold. That integration must be resolved with the existing poller owner, not another retry loop.

Public behavior correction: a real post-write read/port failure will raise the existing CatTransportError instead of returning false success. No wire-format/API-signature change and no RF/ACK guarantee.

## Required pre-push legacy-consumer search

Command: git grep -n tx_interlock -- src/rigplane/core/command_dispatch.py src/rigplane/runtime/command\\*.py src/rigplane/web/handlers/control.py

    src/rigplane/web/handlers/control.py:30:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
    src/rigplane/web/handlers/control.py:1737:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
    src/rigplane/web/handlers/control.py:1976:            decision = evaluate_tx_interlock(

Zero hits in command_dispatch.py and runtime command files. Three existing Web hits unchanged. No new consumer.
