### PR TITLE
feat: host the SDR face's right-column control families in declared zone elements

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -292,8 +292,12 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
     expect(t.querySelector('.content-right .right-sidebar')).not.toBeNull();
     expect(t.querySelector('.center-column .spectrum-slot')).not.toBeNull();
     expect(t.querySelector('.spectrum-panel-stub')).not.toBeNull();
-    // Non-TX sidebar panels are untouched by the TX suppression.
-    expect(t.querySelector('[data-panel-id="rx-audio"]')).not.toBeNull();
+    // A non-TX sidebar panel is untouched by the TX suppression. `rx-audio`
+    // used to stand here beside `memory` and left the list in MOR-2231 batch 3,
+    // which declares that surface: the panel now retires on the `declared`
+    // channel, so it can no longer witness anything about `hideTxPanel`.
+    // `memory` still can — neither sidebar puts any `declared.has(...)` guard
+    // on it, so no manifest can retire it.
     expect(t.querySelector('[data-panel-id="memory"]')).not.toBeNull();
   });
 
@@ -301,9 +305,16 @@ describe('the migrated desktop layout owns VFO/TX through the semantic surfaces'
   // branch, which also guards CW. The suppression is TX-panel-scoped by
   // construction, but nothing pinned it — `hasCapability` is mocked false
   // everywhere else in this file, so the CW block never renders to be checked.
+  //
+  // Runs on the `vfo`-only probe, not on `sdr-test`: MOR-2231 batch 3 declares
+  // `cwKeyer` there, so `CwPanel` now retires on the `declared` channel and
+  // `sdr-test` can no longer separate the two suppressions. The probe restores
+  // exactly the configuration the mutation needs — `semanticDeck` true, so
+  // `hideTxPanel` is on, and no `cw-keyer` zone, so only the TX branch could
+  // remove the CW panel.
   it('keeps the CW panel, which shares the sidebar\'s TX branch', () => {
     vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
-    const t = render('sdr-test');
+    const t = render(VFO_ONLY);
     expect(t.querySelector('[data-panel-id="cw"]')).not.toBeNull();
     expect(t.querySelector('[data-panel-id="tx"]')).toBeNull();
   });
@@ -724,6 +735,228 @@ describe("the SDR face's five control families are zone-owned (MOR-2231, batch 2
     expect([...t.querySelectorAll('.band-tab')].filter((b) => b.textContent?.trim() === 'HAM').length)
       .toBe(0);
     expect(t.querySelectorAll('[data-testid="band-choices"]').length).toBe(1);
+  });
+});
+
+/**
+ * MOR-2231 (step 1, batch 3) — the SDR face's RIGHT-COLUMN families, at the
+ * RENDER level. Same two effects and the same shape as the batch-2 describe
+ * above; only the families and the odd-one-out differ.
+ *
+ * `sdrTestLayout` declares `rx-audio`, `dsp`, `cw-keyer` and `tx-aux`.
+ *
+ *   1. ZONE HOSTS. All four already mounted on this face BARE, through the
+ *      single composition's `zoned()` calls (each takes the default
+ *      `allowBare`), so the declaration moves each inside a `[data-zone-id]`
+ *      element. Read against a resolved plan — `zoneOwning()` reads the PLAN.
+ *   2. SUPPRESSION, for THREE of the four. `declared.has(<surface>)` retires
+ *      ten legacy hosts, which reads the MANIFEST and so needs no plan.
+ *
+ * `txAux` IS THE ODD ONE OUT, and more sharply than `band` was in batch 2:
+ * `band` at least flips a prop, while no `declared.has('txAux')` predicate
+ * exists on any host, so declaring `tx-aux` retires nothing whatever. That is
+ * a negative, so it gets a row that can actually fail: the last case reads the
+ * whole panel inventory before and after and asserts the delta is EXACTLY the
+ * ten hosts below — an eleventh retirement, from a `txAux` guard added later,
+ * reddens it. The inventory covers the two sidebars and the settings modal,
+ * which with `StatusBar` (it reads only `scopeDisplay`) and `SpectrumPanel`
+ * (only `scopeControls`) are every consumer `RadioLayout` hands `declared` to.
+ *
+ * THE CONTROL IS A REGISTERED MANIFEST, for the reason the batch-2 describe
+ * states: suppression derives from `getLayout(skinId)`, so only a separately
+ * registered id can produce the "before" state.
+ */
+describe("the SDR face's right-column families are zone-owned (MOR-2231, batch 3)", () => {
+  const LEFT_ALL = ['rf-front-end', 'mode', 'filter', 'agc', 'rit-xit', 'band',
+    'antenna', 'scan', 'rx-audio', 'dsp', 'tx', 'cw', 'memory'];
+  const RIGHT_ALL = ['rx-audio', 'audio-scope', 'dsp', 'tx', 'cw', 'memory'];
+
+  /** `sdr-test`'s zones as they stood BEFORE this batch — the "before" half of
+   *  every row below, registered so it is a real mount. */
+  const PRE_BATCH_3 = 'sdr-pre-batch-3-probe' as SkinId;
+  const PRE_BATCH_3_MANIFEST = probeManifest(PRE_BATCH_3, [
+    { id: 'receiver-deck', surfaces: ['vfo'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
+    { id: 'meters', surfaces: ['meters'] },
+    { id: 'filter', surfaces: ['filter'] },
+    { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
+    { id: 'band', surfaces: ['band'] },
+    { id: 'antenna', surfaces: ['antenna'] },
+    { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
+  ], ['vfo', 'rxTx']);
+  registerLayout(PRE_BATCH_3_MANIFEST);
+
+  /** zone id → the surface testid it must own. */
+  const FOUR = [
+    ['rx-audio', 'rx-audio-surface'],
+    ['dsp', 'dsp-surface'],
+    ['cw-keyer', 'cw-keyer-surface'],
+    ['tx-aux', 'tx-aux-surface'],
+  ] as const;
+
+  /**
+   * The ten legacy hosts these declarations UNMOUNT on this face, as
+   * [label, container, panelId] so the selector and the inventory key below are
+   * both DERIVED from one list rather than hand-written twice. `tx-aux` is
+   * deliberately absent: it retires nothing, and the delta row is its pin.
+   *
+   * `AgcPanel` and the modal's `desktop-agc` are here under `dsp`, not a zone
+   * of their own: `DspSurface` owns the AGC leaf (5A/MOR-1290).
+   */
+  const RETIRED = [
+    ['left sidebar RX AUDIO', '.left-sidebar', 'rx-audio'],
+    ['right sidebar RX AUDIO', '.right-sidebar', 'rx-audio'],
+    ['left sidebar AGC', '.left-sidebar', 'agc'],
+    ['left sidebar DSP', '.left-sidebar', 'dsp'],
+    ['right sidebar DSP', '.right-sidebar', 'dsp'],
+    ['left sidebar CW', '.left-sidebar', 'cw'],
+    ['right sidebar CW', '.right-sidebar', 'cw'],
+    ['settings modal DSP', '.settings-modal', 'desktop-dsp'],
+    ['settings modal AGC', '.settings-modal', 'desktop-agc'],
+    ['settings modal CW', '.settings-modal', 'desktop-cw'],
+  ] as const;
+
+  const sel = (scope: string, panelId: string) => `${scope} [data-panel-id="${panelId}"]`;
+
+  /** Every legacy panel on screen, scoped by the container that owns it —
+   *  `rx-audio`/`dsp`/`cw` exist in BOTH sidebars, so a bare id set would
+   *  collapse the two halves of each pair into one entry. */
+  const inventory = (t: HTMLElement): string[] =>
+    ['.left-sidebar', '.right-sidebar', '.settings-modal']
+      .flatMap((scope) => [...t.querySelectorAll(`${scope} [data-panel-id]`)]
+        .map((el) => `${scope} ${el.getAttribute('data-panel-id')}`))
+      .sort();
+
+  /** Opens the settings modal — three of the ten retired hosts live there. */
+  function renderAll(skinId: SkinId): HTMLElement {
+    const target = render(skinId);
+    (target.querySelector('.settings-btn') as HTMLElement | null)?.click();
+    flushSync();
+    return target;
+  }
+
+  /** The zone-ELEMENT half needs the resolved plan in context — see the S8
+   *  describe's `renderWithPlan`. Takes the manifest, so the control resolves
+   *  ITS OWN plan. */
+  function renderWithPlan(skinId: SkinId, manifest: LayoutManifest): HTMLElement {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = resolveSurfacePlan(manifest, DEFAULT_WORKSPACE);
+    mounted.push(mount(RadioLayout, {
+      target, props: { skinId },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    }));
+    flushSync();
+    return target;
+  }
+
+  beforeEach(() => {
+    // A radio that fires all four evidence gates. Every tag is here because a
+    // NAMED gate in `radio-view-model-adapter.ts` reads it; a fixture that
+    // missed one would make this whole describe pass vacuously, which is the
+    // failure the batch-2 draft nearly shipped:
+    //   `deriveRxAudio` — a non-null audio snapshot (the harness's fixed
+    //                     `runtime.audio`) AND one of af_level / audio /
+    //                     dual_rx / MOD-input routing;
+    //   `deriveDsp`     — any of nr / nb / notch / agc;
+    //   `deriveCwKeyer` — the `cw` tag, and nothing else (break_in and apf
+    //                     only populate leaves once that gate has opened);
+    //   `deriveTxAux`   — the `tx` tag `capsFor` already supplies, PLUS
+    //                     evidence: any of tuner / vox / compressor / monitor
+    //                     / drive_gain, or an observed TX-aux state field.
+    h.caps = {
+      ...(capsFor('2/main_sub') as object),
+      capabilities: [
+        'scope', 'audio', 'tx', 'dual_rx',
+        'af_level',
+        'nr', 'nb', 'notch', 'agc',
+        'cw', 'break_in', 'apf',
+        'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
+      ],
+    } as Capabilities;
+    // The legacy CW panels read the capabilities STORE, not `runtime.caps`;
+    // without this they never mount and their two rows would assert nothing.
+    vi.mocked(hasCapability).mockImplementation((tag: string) => tag === 'cw');
+    localStorage.setItem('rigplane:panel-order', JSON.stringify(LEFT_ALL));
+    localStorage.setItem('rigplane:right-panel-order', JSON.stringify(RIGHT_ALL));
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  // NON-VACUITY, half one: under this fixture the "before" face really does
+  // render all four surfaces AND all ten legacy hosts. Presence is asserted
+  // FIRST, so a dead evidence gate fails here rather than passing silently
+  // through every suppression row below.
+  it('the pre-batch manifest renders all four surfaces and all ten legacy hosts', () => {
+    const t = renderAll(PRE_BATCH_3);
+    for (const [, testid] of FOUR) {
+      expect(t.querySelector(`[data-testid="${testid}"]`), testid).not.toBeNull();
+    }
+    for (const [host, scope, panelId] of RETIRED) {
+      expect(t.querySelector(sel(scope, panelId)), host).not.toBeNull();
+    }
+  });
+
+  // NON-VACUITY, half two: on the "before" face those four surfaces mount BARE.
+  // This is the state the declaration replaces, and the row that makes the zone
+  // assertions below a change rather than a restatement.
+  it.each(FOUR)('%s: the pre-batch manifest mounts its surface bare, in no zone', (zoneId, testid) => {
+    const t = renderWithPlan(PRE_BATCH_3, PRE_BATCH_3_MANIFEST);
+    const el = t.querySelector(`[data-testid="${testid}"]`);
+    expect(el, testid).not.toBeNull();
+    expect(el!.closest('.surface-zone')).toBeNull();
+    expect(t.querySelector(`[data-zone-id="${zoneId}"]`)).toBeNull();
+  });
+
+  // EFFECT 1 — each declared zone binds a real element that OWNS its surface,
+  // and there is no second bare mount beside it.
+  it.each(FOUR)('%s: sdr-test hosts its surface inside the declared zone element', (zoneId, testid) => {
+    const t = renderWithPlan('sdr-test', sdrTestLayout);
+    const el = t.querySelector(`[data-testid="${testid}"]`);
+    expect(el, `${testid} on screen`).not.toBeNull();
+    // Containment read from the SURFACE upward, not "some element with this id
+    // exists somewhere": the surface's own wrapper must be the declared zone.
+    const zone = el!.closest('.surface-zone');
+    expect(zone, `${testid} inside a zone element`).not.toBeNull();
+    expect(zone!.getAttribute('data-zone-id')).toBe(zoneId);
+    expect(t.querySelectorAll(`[data-testid="${testid}"]`).length).toBe(1);
+  });
+
+  // EFFECT 2 — the batch's principal effect. Each of the ten legacy hosts is
+  // gone on `sdr-test`, under the identical fixture that renders all ten on the
+  // pre-batch face. `CwKeyerSurface` becoming the SOLE break-in affordance is
+  // the safety-critical half (MOR-1310), so its presence is pinned separately
+  // below rather than left to follow from `CwPanel`'s absence.
+  it.each(RETIRED)('[%s] is unmounted on sdr-test', (host, scope, panelId) => {
+    expect(renderAll('sdr-test').querySelector(sel(scope, panelId)), host).toBeNull();
+  });
+
+  // THE TX-AUX ASYMMETRY — the family that retires NOTHING, given a row that
+  // can fail. The panel inventory loses exactly the ten hosts above and gains
+  // none, so a `declared.has('txAux')` guard added to either sidebar or to the
+  // settings modal would redden this even though every row above stays green.
+  it('declaring tx-aux retires nothing: the inventory delta is exactly the ten', () => {
+    const before = inventory(renderAll(PRE_BATCH_3));
+    const after = inventory(renderAll('sdr-test'));
+    expect(before.length).toBeGreaterThan(RETIRED.length);
+    expect(before.filter((p) => !after.includes(p)))
+      .toEqual(RETIRED.map(([, scope, panelId]) => `${scope} ${panelId}`).sort());
+    expect(after.filter((p) => !before.includes(p))).toEqual([]);
+    // ...and the surface it DOES place is on screen exactly once, which is the
+    // whole of what this declaration buys.
+    expect(after.filter((p) => p.endsWith(' tx-aux'))).toEqual([]);
+    expect(renderAll('sdr-test').querySelectorAll('[data-testid="tx-aux-surface"]').length).toBe(1);
+  });
+
+  // SAFETY-CRITICAL (MOR-1310), stated positively. `CwPanel` is gone from both
+  // sidebars and the modal, so `CwKeyerSurface` is now the only break-in
+  // affordance on this face — zero would be worse than the double it replaces.
+  it('leaves CwKeyerSurface as the sole break-in affordance, and one key authority', () => {
+    const t = renderAll('sdr-test');
+    expect(t.querySelectorAll('[data-testid="cw-keyer-surface"]').length).toBe(1);
+    expect(t.querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
   });
 });
 

--- a/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/cw-keyer-declarability.test.ts
@@ -53,13 +53,19 @@ describe('cwKeyer is a declarable semantic surface', () => {
 describe('exactly the reviewed manifests declare a cwKeyer zone (MOR-1368)', () => {
   /**
    * The literal — extend by hand, with a layout review, never silently. This
-   * is the SAFETY-CRITICAL one: `desktop-v2` is the only family reviewed for
-   * it, and the dual-receiver cockpit stays OFF the list deliberately. Its
-   * MOR-1069 tab-order assertion is written against the zones it declares
-   * today, so adding `cwKeyer` there would put break-in controls in the
-   * cockpit with no updated sequence pin.
+   * is the SAFETY-CRITICAL one: declaring the zone makes `CwKeyerSurface` that
+   * face's SOLE break-in affordance, so the review has to establish that the
+   * surface really mounts there and not merely that `CwPanel` goes away.
+   * MOR-2231 (step 1, batch 3) added `sdr-test` on that basis — the surface is
+   * asserted present, count 1, in
+   * `components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts`.
+   *
+   * The dual-receiver cockpit stays OFF the list deliberately. Its MOR-1069
+   * tab-order assertion is written against the zones it declares today, so
+   * adding `cwKeyer` there would put break-in controls in the cockpit with no
+   * updated sequence pin.
    */
-  const DECLARES_CW_KEYER = ['desktop-v2'];
+  const DECLARES_CW_KEYER = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/dsp-declarability.test.ts
@@ -43,7 +43,13 @@ describe('dsp is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a dsp zone (MOR-1368)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_DSP = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 3) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force. This is the WIDEST of that batch's
+  // four: on that face the declaration retires five legacy hosts at once —
+  // `DspPanel` in both sidebars, `AgcPanel` in the left one, and the settings
+  // modal's `desktop-dsp` AND `desktop-agc` sections — because `DspSurface`
+  // owns the AGC leaf (5A/MOR-1290) and AGC has no zone of its own.
+  const DECLARES_DSP = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/rx-audio-declarability.test.ts
@@ -50,7 +50,11 @@ describe('rxAudio is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare an rxAudio zone (MOR-1368)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_RX_AUDIO = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 3) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's RX AUDIO panel in BOTH sidebars through the `declared.has(...)`
+  // channel. It retires no settings-modal section — this family has none.
+  const DECLARES_RX_AUDIO = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -98,8 +98,7 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
     // MOR-2231 (step 1, batch 3) — the right column's four, same shape. The id
     // drift argument above applies unchanged to `rxAudio`/`dsp`/`cwKeyer`. It
     // does NOT apply to `txAux`: no `declared.has('txAux')` predicate exists,
-    // so a drifted id there loses the host without retiring anything, and this
-    // row is the only guard that would catch it.
+    // so a drifted id there loses the host without retiring anything.
     ['rxAudio', 'rx-audio'],
     ['dsp', 'dsp'],
     ['cwKeyer', 'cw-keyer'],

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -95,6 +95,15 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
     ['band', 'band'],
     ['antenna', 'antenna'],
     ['ritXitScan', 'rit-xit-scan'],
+    // MOR-2231 (step 1, batch 3) — the right column's four, same shape. The id
+    // drift argument above applies unchanged to `rxAudio`/`dsp`/`cwKeyer`. It
+    // does NOT apply to `txAux`: no `declared.has('txAux')` predicate exists,
+    // so a drifted id there loses the host without retiring anything, and this
+    // row is the only guard that would catch it.
+    ['rxAudio', 'rx-audio'],
+    ['dsp', 'dsp'],
+    ['cwKeyer', 'cw-keyer'],
+    ['txAux', 'tx-aux'],
   ] as const)('mounts %s alone in the stable `%s` zone, not required', (surface, zoneId) => {
     const owning = sdrTestLayout.zones.filter((z) => z.surfaces.includes(surface));
     expect(owning).toHaveLength(1);

--- a/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/tx-aux-declarability.test.ts
@@ -52,7 +52,13 @@ describe('txAux is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a txAux zone (MOR-1336)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_TX_AUX = ['desktop-v2', 'dual-receiver-cockpit'];
+  // MOR-2231 (step 1, batch 3) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force. UNLIKE the other three families in
+  // that batch, this declaration RETIRES NOTHING: no `declared.has('txAux')`
+  // predicate exists on any host, so the zone only places `TxAuxSurface`.
+  // The sidebars' `<TxPanel>` is a different channel (`hideTxPanel`, which
+  // follows the semantic deck for R9), already suppressed on that face.
+  const DECLARES_TX_AUX = ['desktop-v2', 'dual-receiver-cockpit', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -47,6 +47,27 @@ export const sdrTestLayout: LayoutManifest = {
   // side effect — the same move MOR-1366/1367 made for `desktop-v2`, closing a
   // double presentation that was live on this face.
   //
+  // MOR-2231 (step 1, batch 3): `rxAudio`, `dsp`, `cwKeyer` and `txAux` join,
+  // under the ids `desktop-declarations.ts` already uses. Each already mounted
+  // here BARE, through the single composition's `zoned()` calls in
+  // `SemanticRadioSurfaces.svelte` (all four take the default `allowBare`), so
+  // declaring the zone gives it a `data-zone-id` host.
+  //
+  // THREE of the four also activate the MOR-1364 suppression channel on this
+  // face, and that retirement is the point rather than a side effect:
+  // `LeftSidebar`'s RX AUDIO, AGC, DSP and CW panels, `RightSidebar`'s RX
+  // AUDIO, DSP and CW panels, and the settings modal's `desktop-dsp`,
+  // `desktop-agc` and `desktop-cw` sections stop rendering. `AgcPanel` retires
+  // with `dsp` rather than on a zone of its own, because `DspSurface` owns the
+  // AGC leaf (5A/MOR-1290) — the same move MOR-1368 (S9) made for `desktop-v2`.
+  //
+  // `txAux` is the EXCEPTION, and a sharper one than batch 2's `band`: `band`
+  // at least flips a prop, while no `declared.has('txAux')` predicate exists
+  // anywhere, so this declaration retires nothing at all and only places the
+  // surface. The sidebars' `<TxPanel>` is a different channel (`hideTxPanel`,
+  // which follows the semantic DECK for R9) and batch 1's `vfo` zone already
+  // suppressed it here.
+  //
   // None is `required`, matching `desktop-v2`: each surface self-gates on its
   // own `view.*` group, so a radio whose evidence gate declined the group must
   // still resolve this layout.
@@ -59,6 +80,10 @@ export const sdrTestLayout: LayoutManifest = {
     { id: 'band', surfaces: ['band'] },
     { id: 'antenna', surfaces: ['antenna'] },
     { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
+    { id: 'rx-audio', surfaces: ['rxAudio'] },
+    { id: 'dsp', surfaces: ['dsp'] },
+    { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+    { id: 'tx-aux', surfaces: ['txAux'] },
   ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -139,11 +139,14 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
     ]);
     // MOR-1346: `meters` joined as sdr-test's own zone. MOR-2231 batch 1: `vfo`
     // and `rxTx` each hold one too, under the ids `desktop-v2` already uses;
-    // batch 2 adds the five control families, same one-surface-per-zone shape.
+    // batch 2 adds the five control families and batch 3 the right column's
+    // four, all the same one-surface-per-zone shape.
     expect([...plan(sdrTestLayout)]).toEqual([
       ['receiver-deck', ['vfo']], ['rx-tx', ['rxTx']], ['meters', ['meters']],
       ['filter', ['filter']], ['rf-front-end', ['rfFrontEnd']], ['band', ['band']],
       ['antenna', ['antenna']], ['rit-xit-scan', ['ritXitScan']],
+      ['rx-audio', ['rxAudio']], ['dsp', ['dsp']], ['cw-keyer', ['cwKeyer']],
+      ['tx-aux', ['txAux']],
     ]);
   });
 
@@ -275,9 +278,10 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   });
 
   it('flattens the plan in zone-declaration order, deduped', () => {
-    // MOR-1346/2231: sdr-test's eight zones flatten in declaration order.
+    // MOR-1346/2231: sdr-test's twelve zones flatten in declaration order.
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual([
       'vfo', 'rxTx', 'meters', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
+      'rxAudio', 'dsp', 'cwKeyer', 'txAux',
     ]);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)


### PR DESCRIPTION
Linear: MOR-2231

Base (merge base): `9e72ba86543ae429593540517fc3beace93314c6`. Head: `28bfb566436db7e92251498bcab0c9893190bf74`.

**Review round 2** (`50d03e0a` → `28bfb566`): a comment-only deletion. `sdr-registration.test.ts`'s zone-id comment claimed that row was "the only guard that would catch" a drifted `tx-aux` id. False, and refuted by the commit it shipped in — drifting the id reddens five named tests in five files, three of the four extra guards having been created or extended by this very change (`tx-aux-declarability`'s parametrised row is one of the +4 cases the `DECLARES_TX_AUX` edit adds). Deleted rather than narrowed: a correct version would have to name the other four and would then be longer than the row it guards. `git diff` for that commit carries no non-comment line; `sdr-registration.test.ts` 16/16, unchanged. The clause appears in no commit message and nowhere else in this body.

## Read this first: the declarations retire ten legacy panels, and one of the four retires nothing

`sdrTestLayout` gains four zones — `rx-audio`, `dsp`, `cw-keyer`, `tx-aux` — reusing desktop-v2's stable ids. The wrappers are the small half.

The large half: `declaredSurfaces(getLayout(skinId))` feeds a live suppression channel keyed on the **surface name**, so declaring these zones retires the legacy twins on the SDR face. Enumerated by reading every `declared.has(` occurrence in the tree (`git grep -n -i -F "declared.has(" --`, no path scope), then by **reading `LeftSidebar.svelte`, `RightSidebar.svelte`, `StatusBar.svelte` and `RadioLayout.svelte` in full** rather than trusting the grep — a guard split across two lines is invisible to any single-line pattern. Control: `git grep -l -F "declared" --` matched 367 files, so the instrument was not silently empty.

| File | Guard | Effect on `sdr-test` |
|---|---|---|
| `LeftSidebar.svelte` | `!declared.has('rxAudio')` | RX AUDIO panel unmounts |
| `RightSidebar.svelte` | `!declared.has('rxAudio')` | RX AUDIO panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('dsp')` | AGC panel unmounts |
| `LeftSidebar.svelte` | `!declared.has('dsp')` | DSP panel unmounts |
| `RightSidebar.svelte` | `!declared.has('dsp')` | DSP panel unmounts |
| `RadioLayout.svelte` | `!declared.has('dsp')` | settings modal `desktop-dsp` unmounts |
| `RadioLayout.svelte` | `!declared.has('dsp')` | settings modal `desktop-agc` unmounts |
| `LeftSidebar.svelte` | `!declared.has('cwKeyer')` | CW panel unmounts (also gated `hasCapability('cw')`) |
| `RightSidebar.svelte` | `!declared.has('cwKeyer')` | CW panel unmounts (also gated `hasCapability('cw')`) |
| `RadioLayout.svelte` | `!declared.has('cwKeyer')` | settings modal `desktop-cw` unmounts |
| — | **no predicate exists** | **`txAux` retires nothing** |

Ten unmounts across three families. `AgcPanel` and `desktop-agc` retire under `dsp` rather than a zone of their own, because `DspSurface` owns the AGC leaf (5A/MOR-1290).

**`txAux` is the odd one out, and more sharply than `band` was in batch 2.** `band` at least flips a prop (`hamBands`); `txAux` has no `declared.has('txAux')` predicate anywhere in the tree, so declaring `tx-aux` retires nothing whatever and only places the surface. The sidebars' `<TxPanel>` is a different channel — `hideTxPanel={semanticRxTx}`, which follows the semantic *deck* for R9 — and batch 1's `vfo` declaration already suppressed it here. The brief predicted at least one family would behave unlike the others; it did, and the comment beside the `tx-aux` literal says so instead of repeating the shared wording, the mistake batch 2's P22 entry records.

**This is intended, not incidental.** All four surfaces already mounted on this face bare, through the single composition's `zoned()` calls (all four take the default `allowBare`), while their legacy twins kept rendering — the double presentation `docs/validation/desktop-v2-v3-parity.md` records as item P15. After this change there is one presentation of each, the same move MOR-1368 (S9) made for `desktop-v2`.

**What gets worse, and for how long.** Placement, exactly as in batch 2: the four surfaces join the receiver deck rather than a right column until the region grid lands. They remain reachable — `.semantic-surfaces` is `height: 100%; overflow: auto` inside the deck's `overflow: hidden`. `sdr-test` is picker-selectable, labelled `(test)`, and is not the default face.

## The four declarability literals

Each of `{rx-audio,dsp,cw-keyer,tx-aux}-declarability.test.ts` holds a hand-written `DECLARES_<SURFACE>` literal and asserts the derived declaring set matches it exactly. Each grew `'sdr-test'` by hand, which is what the literal exists to force; without the edit each file fails its census assertion. `DECLARES_TX_AUX` goes to three entries, not two — `dual-receiver-cockpit` has declared that zone since MOR-1336.

The comment beside each literal states that family's actual effect, not a shared formula: `rx-audio` retires two sidebar panels and no modal section (it has none); `dsp` is the widest at five hosts; `tx-aux` retires nothing.

`cw-keyer-declarability.test.ts`'s literal docstring said "`desktop-v2` is the only family reviewed for it". This change falsifies that sentence, so it is rewritten rather than left standing, and the rewrite states the review criterion that actually matters for a safety-critical surface — that `CwKeyerSurface` is asserted **present**, count 1, not merely that `CwPanel` went away.

Two further guards the declarations falsify, both in `preferences-adoption.test.ts`: the `plan(sdrTestLayout)` zone-list equality and the `compositionSurfaces(...)` flattening, each of which enumerates the manifest's zones exactly.

`REFERENCE_ZONE_IDS` (`fixtures/assertions.ts`) is unmoved for the reason batch 2 gave: it is built from `desktopV2Layout.zones` and never reads `sdrTestLayout`, so this manifest cannot move it in either direction. All four ids are already in `WORKSPACE_ZONE_IDS` (`presentation/workspace/contract.ts`), which is why the zone-id union test needed no edit — it was still run.

## The render-level pin

Manifest tests prove what is declared, not what the declaration does to the screen, so `semantic-desktop-migration.component.test.ts` gains a describe in the same shape as batch 2's — **21 cases, taking that file from 102 to 123**.

- **Zone hosts** (4). Each surface is inside the `[data-zone-id]` element its manifest names, and is the only instance. Read from the surface *upward* (`el.closest('.surface-zone')`, then its `data-zone-id`), so the claim is containment rather than "an element with that id exists somewhere". Run against a resolved plan, because `zoneOwning()` reads the plan, not the manifest.
- **Suppression** (10). Each legacy host is absent on `sdr-test`, under the identical fixture that renders all ten on the pre-batch face.
- **Non-vacuity** (5). One row asserts all four surfaces *and* all ten hosts render on the control; four assert the surfaces mount **bare, in no zone** there.
- **The `txAux` asymmetry** (1). A negative needs a row that can fail, so this one reads the whole panel inventory before and after and asserts the delta is **exactly** the ten hosts, with nothing gained. The inventory is scoped per container (`rx-audio`/`dsp`/`cw` exist in *both* sidebars, so a bare id set would collapse each pair) and covers both sidebars plus the settings modal — which, with `StatusBar` (reads only `scopeDisplay`) and `SpectrumPanel` (only `scopeControls`), are every consumer `RadioLayout` hands `declared` to.
- **Safety** (1). `CwKeyerSurface` present, count 1, and exactly one key/unkey authority. Zero break-in affordances would be worse than the double this replaces, so it is asserted positively rather than inferred from `CwPanel`'s absence.

**The control is a registered manifest, not an argument.** Suppression derives from `getLayout(skinId)`, so handing a different manifest object to a render helper could not produce the "before" state; only a separately registered id can. `sdr-pre-batch-3-probe` carries this face's batch-2 zone list and differs from `sdr-test` in exactly the dimension under test.

**The fixture names the gate that reads each field**, because the batch-2 draft nearly shipped a describe where two of five surfaces never rendered: `deriveRxAudio` (a non-null audio snapshot *and* one of af_level/audio/dual_rx), `deriveDsp` (nr/nb/notch/agc), `deriveCwKeyer` (the `cw` tag alone), `deriveTxAux` (the `tx` tag plus evidence — tuner/vox/compressor/monitor/drive_gain). Presence is asserted **first**, so a dead gate fails rather than passing silently.

## Two pre-existing guards the declarations falsified

Both were found by **running** the file, not by reading it — a source sweep had missed both, exactly as in batch 2.

- `leaves the rest of the layout intact` used `[data-panel-id="rx-audio"]` as its witness for "non-TX sidebar panels are untouched by the TX suppression". That panel now retires on the `declared` channel, so it can no longer witness anything about `hideTxPanel`. The line is **deleted** rather than repointed at another panel that is also partly touched: `memory` remains as the witness, and it is the honest one — neither sidebar puts any `declared.has(...)` guard on it, established by reading both files in full.
- `keeps the CW panel, which shares the sidebar's TX branch` now runs on the `vfo`-only probe instead of `sdr-test`. Its stated purpose is killing a mutation that widens `hideTxPanel` to the sidebar's whole `showTx` branch; `sdr-test` now declares `cwKeyer`, so it can no longer separate the two suppressions. The probe restores exactly the configuration that mutation needs — `semanticDeck` true, no `cw-keyer` zone.

## Mutations

Each was checked for reachability and for whether the assertion can distinguish its two values before it was run.

**A — one zone dropped.** Removed `{ id: 'dsp', surfaces: ['dsp'] }` from `sdrTestLayout`. Reachable: with the zone gone `zoneOwning('dsp')` returns null, `allowBare` is true, so the surface renders bare and `closest('.surface-zone')` is null; and `declared.has('dsp')` goes false, so the five hosts mount. **Exactly 7 rows died and only those** — `7 failed | 116 passed (123)`:

```
dsp: sdr-test hosts its surface inside the declared zone element
  AssertionError: dsp-surface inside a zone element: expected null not to be null
[left sidebar AGC] / [left sidebar DSP] / [right sidebar DSP] /
[settings modal DSP] / [settings modal AGC] is unmounted on sdr-test
  AssertionError: left sidebar AGC: expected <div …(4)>…(2)</div> to be null
declaring tx-aux retires nothing: the inventory delta is exactly the ten
  AssertionError: expected [ '.left-sidebar cw', …(4) ] to deeply equal [ '.left-sidebar agc', …(9) ]
```

The `rx-audio`, `cw-keyer` and `tx-aux` zone-host rows and their five retirement rows stayed green, so the parametrisation discriminates per case rather than dying together.

**B — one guard stripped.** Removed `&& !declared.has('cwKeyer')` from `RightSidebar.svelte`, reinstating exactly the double presentation this batch removes. `6 failed | 117 passed (123)`. `[right sidebar CW] is unmounted on sdr-test` failed with `right sidebar CW: expected <div …(4)>…(2)</div> to be null`, and **`[left sidebar CW]` and `[settings modal CW]` stayed green** — they share the predicate but are separate guards, so the rows discriminate individually. The `tx-aux` delta row also died (9 gone, not 10), and four pre-existing `desktop-v2` tests died, the guard being shared across skins.

**C — the mutation the `txAux` row exists for.** A negative claim is worth nothing unless something can falsify it, so this adds `&& !declared.has('txAux')` to `LeftSidebar`'s MEMORY panel — a reachable host under this fixture, since `memory` is in the seeded left order. `2 failed | 121 passed (123)`. The delta row died with `expected [ '.left-sidebar agc', …(10) ] to deeply equal [ '.left-sidebar agc', …(9) ]` — eleven gone instead of ten — while **all ten `RETIRED` rows and all four zone-host rows stayed green**. That is the point: no other row in this batch can see a `txAux` guard, and this one does.

All mutations reverted with `git checkout --`. `declarations.ts` is back to sha256 `823ef76b…c011`, `RightSidebar.svelte` to `9fd736d7…6781` and `LeftSidebar.svelte` to `1f0a9a36…ab72`, each byte-identical to its pre-mutation state; `git status` showed only the intended test file. An unscoped `git grep -F "declared.has('txAux')" --` returns five hits, all of them prose in this PR's own comments and none a guard, with `git grep -c -F "declared.has('cwKeyer')" -- .../RightSidebar.svelte` returning 1 as the control that the search matches real guards.

## The question this batch's evidence does not ask

Every row above asks **"is this element in the tree?"** — present, absent, or inside which wrapper. Not one asks **"can the operator still do what the deleted panel did?"**

That gap is load-bearing here in a way it was not in batch 2. This change deletes ten controls-bearing panels on the promise that three semantic surfaces cover them, and the strongest thing it establishes about that promise is `querySelectorAll('[data-testid="cw-keyer-surface"]').length === 1`. If `CwKeyerSurface` rendered a break-in toggle wired to nothing, or wired to a different field than `CwPanel`'s was, every one of the 21 cases would still be green, `npm run check` would still be clean, and the SDR face would have silently lost break-in control — the exact MOR-1310 hazard the safety row is named after, arriving through the door that row does not watch. Presence is not parity, and this batch only ever measures presence.

The artifact that *does* ask the question is `docs/validation/desktop-v2-v3-parity.md`. Two things about it: it is prose, read by no test or script (`git grep -l -F "desktop-v2-v3-parity" --` returns only other documents and the doc-citation baselines; the control `control-feedback-debt-baseline`, which *is* read by `src/__tests__/control-feedback-debt-baseline.test.ts`, shows what an executable one looks like) — and it was written for `desktop-v2`, not for this face. Its P15 entry, which is specifically about `sdr-test`, batch 2 already recorded as rotted. So the one place this question is asked is a hand-maintained document, known stale for this face, that nothing evaluates.

I am not proposing to fix that here — it is outside this batch and would be a different kind of work. I am naming it because it is the thing that stays true and wrong with everything above satisfied.

## Why eight files is one unit of work

Past the 6-file soft threshold, inside the 10-file / 1000-line ceiling: **8 files, 320 changed lines** (306 insertions, 14 deletions), re-derived with `git diff --shortstat 9e72ba86..28bfb566` at the pushed head. The unit is the manifest edit plus every guard it falsifies plus the pin for the effect it produces — each is red or unproven the moment another lands alone. Splitting the declarations from the four census literals would push a knowingly-red commit; so would splitting either from the two `preferences-adoption` guards; and landing ten unmounts on a picker-selectable skin with no test that reddens when they stop happening is what the pin exists to prevent.

## Verification

No test suite was run on this machine (owner's radio workstation). Every run was `npx vitest run <one named file>`, one file per vitest invocation, sequentially.

**60 distinct test files run, all green.** The selection was derived, not eyeballed: `git grep -l -i -E "sdrtestlayout|sdr-test" -- 'frontend/src/**/*.test.ts'` lists **40** files at this head, and all 40 were run. A second list of **20** covers the zone-id union, both sidebars, the four families' own wiring suites, the sibling registrations and the peer-split/mobile suites; `comm -12` of the two lists is empty, so 60 is a true union and not a double count. Every changed test file appears in one of them.

Largest runs: `semantic-desktop-migration.component.test.ts` 123/123, `VfoSurface.test.ts` 129/129, `workspace-compatibility-verification.test.ts` 96/96, `architecture-boundaries.test.ts` 92/92, `panel-props.test.ts` 77/77, `workspace/__tests__/contract.test.ts` 52/52.

**One methodological correction worth recording**, because it produced a false green for a few minutes: the first sweep loop was written `for f in $FILES`, and this shell is **zsh**, which does not word-split unquoted parameters. Vitest therefore ran once against a 40-line blob, and the failure grep printed `(none)` — a clean result from an instrument that had tested nothing. The numbers above come from the rewritten loop (`while IFS= read -r f`), whose per-file summary lines are the evidence that it ran 40 times.

- `npx eslint` on all eight changed files — exit 0, zero bytes of output.
- `npm run check` (`svelte-check` + `tsc -p tsconfig.node.json`) — exit 0, `4634 FILES 0 ERRORS 0 WARNINGS`.
- No Python gates: nothing under `src/rigplane/`.

Both exit codes were re-measured with output redirected to a file rather than piped to `tail`: `cmd | tail` reports `tail`'s status, so the first reading of "exit 0" was the pipe answering, not the linter. The eslint reading carries a control — a deliberately broken file returns 2 — so a nonzero exit is reachable through that invocation.

**Negative claims are bounded to what was actually run.** "Nothing else fails" means those 60 named files, not the suite. The full frontend suite runs in CI on this PR.

**REGCHECK.** Baseline is `quick` on `main` at this PR's own merge base `9e72ba86` — run `33737366308`, success, frontend **388 test files / 8437 tests passed**. `main` has since advanced to `9618ef4f`, but `git diff --name-only 9e72ba86..origin/main -- frontend/` is **empty** (that commit touches only `src/rigplane/backends/yaesu_cat/transport.py` and its test), so the baseline is still current for the frontend.

Head: `quick` on `50d03e0a` — run `33739465608`, success, frontend **388 test files / 8466 tests passed**. **Delta +29 tests, 0 files, 0 failures.** The round-2 commit on top of it is comment-only, so those counts stand at `28bfb566`; its own `quick` run is the confirmation.

I predicted +21 and was wrong, so here is the counting rule for the other 8. The pin contributes 21. Four `it.each(DECLARES_*)` cases each gained one entry when their literal grew by `'sdr-test'` — `rx-audio`, `dsp`, `cw-keyer`, `tx-aux` — which is +4; `sdr-registration.test.ts`'s parametrised zone-id row gained four entries, which is +4. 21 + 4 + 4 = 29, and 8437 + 29 = 8466 exactly. The file count is unchanged because this change creates no test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

