### PR TITLE
feat: give the SDR face's centre-top surfaces their declared zones

### DIFF
--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -974,9 +974,8 @@ describe("the SDR face's right-column families are zone-owned (MOR-2231, batch 3
  *      plan: `zoneOwning()` reads the PLAN.
  *   2. SUPPRESSION for ONE of the two, and a PROP for the other.
  *
- * `scopeDisplay` retires exactly ONE host, and it is the first twin on this
- * face that is neither a sidebar panel nor a settings-modal section:
- * `StatusBar`'s scope indicator, `!declared.has('scopeDisplay')`. Its own
+ * `scopeDisplay` retires exactly ONE host: `StatusBar`'s scope indicator,
+ * `!declared.has('scopeDisplay')`. Its own
  * render gate is `hasAnyScope()`, which this file mocks FALSE by default — so
  * the fixture below turns it on. Without that the suppression row would pass
  * on an absence it did not cause.
@@ -1038,12 +1037,13 @@ describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () 
   const SPECTRUM = '.content-center .spectrum-panel-stub';
 
   /**
-   * Every legacy host `declared` can reach on this face: the two sidebars and
-   * the settings modal by `data-panel-id` (scoped per container, since
-   * `rx-audio`/`dsp`/`cw` exist in both sidebars), plus the two hosts this
-   * batch is about, which carry no `data-panel-id` of their own. With
-   * `StatusBar`, `LeftSidebar`, `RightSidebar` and `SpectrumPanel` that is
-   * every consumer `RadioLayout` hands `declared` to.
+   * FIVE selectors, and no more: `[data-panel-id]` inside each of the two
+   * sidebars and the settings modal (scoped per container, since
+   * `rx-audio`/`dsp`/`cw` exist in both sidebars), plus this batch's own two
+   * hosts, which carry no `data-panel-id`. It is NOT an inventory of
+   * everywhere `declared` reaches - it does not scan `.bottom-dock`, the
+   * legacy VFO header, or the status bar's other indicators, so a guard
+   * placed on any of those is invisible here.
    */
   const hosts = (t: HTMLElement): string[] => [
     ...['.left-sidebar', '.right-sidebar', '.settings-modal'].flatMap(
@@ -1142,10 +1142,13 @@ describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () 
     expect(t.querySelector(SPECTRUM)!.getAttribute('data-hide-scope-controls')).toBe('true');
   });
 
-  // THE ASYMMETRY, given a row that can fail. Both declarations together lose
-  // EXACTLY one host and gain none, so a `declared.has('scopeControls')` mount
-  // gate added anywhere `declared` reaches — or a second `scopeDisplay` guard —
-  // reddens this even though every row above stays green.
+  // THE ASYMMETRY, given a row that can fail. Over the five selectors `hosts()`
+  // scans — and only those — both declarations together lose EXACTLY one entry
+  // and gain none, so a `declared.has('scopeControls')` mount gate added to a
+  // sidebar panel, a settings-modal section or the spectrum panel reddens this
+  // even though every row above stays green. A guard placed on a host `hosts()`
+  // does not scan does not: the batch-3 delta row forty lines above names its
+  // own three containers for the same reason.
   it('the host delta is exactly the status bar scope indicator', () => {
     const before = hosts(renderAll(PRE_BATCH_4));
     const after = hosts(renderAll('sdr-test'));

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -1041,9 +1041,11 @@ describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () 
    * sidebars and the settings modal (scoped per container, since
    * `rx-audio`/`dsp`/`cw` exist in both sidebars), plus this batch's own two
    * hosts, which carry no `data-panel-id`. It is NOT an inventory of
-   * everywhere `declared` reaches - it does not scan `.bottom-dock`, the
-   * legacy VFO header, or the status bar's other indicators, so a guard
-   * placed on any of those is invisible here.
+   * everywhere `declared` reaches: it does not scan `.bottom-dock`
+   * (`MetersDockPanel`, retired on `declared.has('meters')`), the legacy VFO
+   * header (`declared.has('vfo')`), the status bar's other indicators, or
+   * `BandSelector`'s `hamBands={!declared.has('band')}` prop. `BEFORE_HOSTS`
+   * below pins what it does find.
    */
   const hosts = (t: HTMLElement): string[] => [
     ...['.left-sidebar', '.right-sidebar', '.settings-modal'].flatMap(
@@ -1142,17 +1144,30 @@ describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () 
     expect(t.querySelector(SPECTRUM)!.getAttribute('data-hide-scope-controls')).toBe('true');
   });
 
-  // THE ASYMMETRY, given a row that can fail. Over the five selectors `hosts()`
-  // scans — and only those — both declarations together lose EXACTLY one entry
-  // and gain none, so a `declared.has('scopeControls')` mount gate added to a
-  // sidebar panel, a settings-modal section or the spectrum panel reddens this
-  // even though every row above stays green. A guard placed on a host `hosts()`
-  // does not scan does not: the batch-3 delta row forty lines above names its
-  // own three containers for the same reason.
+  // THE ASYMMETRY, given a row that can fail — and given an explicit statement
+  // of how far it can see, because the reach is much smaller than "everywhere
+  // `declared` goes". Under this fixture `hosts()` finds exactly the seven
+  // entries below: batches 2 and 3 already retired most sidebar panels, and
+  // the rest of each sidebar's DEFAULT order never mounts here. So the first
+  // assertion pins the reachable set itself. A `declared.has('scopeControls')`
+  // mount gate placed on one of these seven reddens the delta; one placed
+  // anywhere else — the status bar's other indicators, `.bottom-dock`, the
+  // legacy VFO header, or a sidebar panel this fixture never renders — is
+  // INVISIBLE to this row. Both directions are measured, not argued.
+  const BEFORE_HOSTS = [
+    '.left-sidebar band',
+    '.right-sidebar memory',
+    '.settings-modal desktop-language',
+    '.settings-modal desktop-vfo-ops',
+    '.settings-modal desktop-workspace',
+    'content-center spectrum-panel',
+    'status-bar scope-indicator',
+  ];
+
   it('the host delta is exactly the status bar scope indicator', () => {
     const before = hosts(renderAll(PRE_BATCH_4));
     const after = hosts(renderAll('sdr-test'));
-    expect(before.length).toBeGreaterThan(1);
+    expect(before).toEqual(BEFORE_HOSTS);
     expect(before.filter((p) => !after.includes(p))).toEqual(['status-bar scope-indicator']);
     expect(after.filter((p) => !before.includes(p))).toEqual([]);
   });

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -961,6 +961,206 @@ describe("the SDR face's right-column families are zone-owned (MOR-2231, batch 3
 });
 
 /**
+ * MOR-2231 (step 1, batch 4) — the SDR face's CENTRE-TOP pair, at the RENDER
+ * level, and the last two of the fourteen. Same two effects as the batch-2 and
+ * batch-3 describes above, but here BOTH families depart from that shape.
+ *
+ * `sdrTestLayout` declares `scope-display` and `scope-controls`.
+ *
+ *   1. ZONE HOSTS. Both already mounted on this face BARE, through the single
+ *      composition's `zoned()` calls — both take the default `allowBare` on
+ *      THAT path (the dual composition passes `false` for `scopeControls`,
+ *      which is the cockpit's path, not this one). Read against a resolved
+ *      plan: `zoneOwning()` reads the PLAN.
+ *   2. SUPPRESSION for ONE of the two, and a PROP for the other.
+ *
+ * `scopeDisplay` retires exactly ONE host, and it is the first twin on this
+ * face that is neither a sidebar panel nor a settings-modal section:
+ * `StatusBar`'s scope indicator, `!declared.has('scopeDisplay')`. Its own
+ * render gate is `hasAnyScope()`, which this file mocks FALSE by default — so
+ * the fixture below turns it on. Without that the suppression row would pass
+ * on an absence it did not cause.
+ *
+ * `scopeControls` unmounts NOTHING. Unlike `txAux` a predicate does exist, but
+ * it is a PROP: `RadioLayout` forwards
+ * `hideScopeControls={declared.has('scopeControls')}` to `SpectrumPanel`, which
+ * keeps rendering. That is batch 2's `band` shape, reached through the CENTRE
+ * column's `{#if hasSpectrum()}` rather than a sidebar's `drag.order`. WHICH
+ * toolbar controls that prop removes is proved in
+ * `SpectrumToolbar.component.test.ts`'s S6b-1 pins, not here: this file mocks
+ * `SpectrumPanel` with a stub that only records the prop.
+ *
+ * THE FIXTURE NAMES THE GATE THAT READS EACH FIELD — and the two gates read
+ * DIFFERENT fields of the same capabilities object, which is why one fixture
+ * satisfying one of them proves nothing about the other:
+ *   `deriveScopeControls` — `hasCap(caps, 'scope')`, the `capabilities` ARRAY;
+ *   `deriveScopeDisplay`  — `hasAnyScopeCap(caps)`, the `scope` BOOLEAN (or
+ *                           `scopeSource === 'audio_fft'`), AND a non-null
+ *                           scope-display snapshot.
+ * `capsFor('2/main_sub')` supplies both capability shapes and the harness's
+ * fixed `runtime.defaultScopeStatus` supplies the snapshot, so no extra caps
+ * fixture is needed here. Presence is still asserted FIRST, because a fixture
+ * that satisfied only one gate would leave half this describe vacuous.
+ *
+ * THE CONTROL IS A REGISTERED MANIFEST, for the reason the batch-2 describe
+ * states: suppression derives from `getLayout(skinId)`, so only a separately
+ * registered id can produce the "before" state.
+ */
+describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () => {
+  /** `sdr-test`'s zones as they stood BEFORE this batch — the "before" half of
+   *  every row below, registered so it is a real mount. */
+  const PRE_BATCH_4 = 'sdr-pre-batch-4-probe' as SkinId;
+  const PRE_BATCH_4_MANIFEST = probeManifest(PRE_BATCH_4, [
+    { id: 'receiver-deck', surfaces: ['vfo'] },
+    { id: 'rx-tx', surfaces: ['rxTx'] },
+    { id: 'meters', surfaces: ['meters'] },
+    { id: 'filter', surfaces: ['filter'] },
+    { id: 'rf-front-end', surfaces: ['rfFrontEnd'] },
+    { id: 'band', surfaces: ['band'] },
+    { id: 'antenna', surfaces: ['antenna'] },
+    { id: 'rit-xit-scan', surfaces: ['ritXitScan'] },
+    { id: 'rx-audio', surfaces: ['rxAudio'] },
+    { id: 'dsp', surfaces: ['dsp'] },
+    { id: 'cw-keyer', surfaces: ['cwKeyer'] },
+    { id: 'tx-aux', surfaces: ['txAux'] },
+  ], ['vfo', 'rxTx']);
+  registerLayout(PRE_BATCH_4_MANIFEST);
+
+  /** zone id → the surface testid it must own. */
+  const TWO = [
+    ['scope-display', 'scope-display-surface'],
+    ['scope-controls', 'scope-controls-surface'],
+  ] as const;
+
+  /** The `scopeDisplay` twin: the status bar's own scope indicator. */
+  const SCOPE_INDICATOR = '.status-indicators [title^="Scope WebSocket"]';
+  /** The `scopeControls` twin's host — mocked by `SpectrumPanelStub`. */
+  const SPECTRUM = '.content-center .spectrum-panel-stub';
+
+  /**
+   * Every legacy host `declared` can reach on this face: the two sidebars and
+   * the settings modal by `data-panel-id` (scoped per container, since
+   * `rx-audio`/`dsp`/`cw` exist in both sidebars), plus the two hosts this
+   * batch is about, which carry no `data-panel-id` of their own. With
+   * `StatusBar`, `LeftSidebar`, `RightSidebar` and `SpectrumPanel` that is
+   * every consumer `RadioLayout` hands `declared` to.
+   */
+  const hosts = (t: HTMLElement): string[] => [
+    ...['.left-sidebar', '.right-sidebar', '.settings-modal'].flatMap(
+      (scope) => [...t.querySelectorAll(`${scope} [data-panel-id]`)]
+        .map((el) => `${scope} ${el.getAttribute('data-panel-id')}`),
+    ),
+    ...(t.querySelector(SCOPE_INDICATOR) ? ['status-bar scope-indicator'] : []),
+    ...(t.querySelector(SPECTRUM) ? ['content-center spectrum-panel'] : []),
+  ].sort();
+
+  /** Opens the settings modal — the inventory above reads it. */
+  function renderAll(skinId: SkinId): HTMLElement {
+    const target = render(skinId);
+    (target.querySelector('.settings-btn') as HTMLElement | null)?.click();
+    flushSync();
+    return target;
+  }
+
+  /** The zone-ELEMENT half needs the resolved plan in context. Takes the
+   *  manifest, so the control resolves ITS OWN plan. */
+  function renderWithPlan(skinId: SkinId, manifest: LayoutManifest): HTMLElement {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = resolveSurfacePlan(manifest, DEFAULT_WORKSPACE);
+    mounted.push(mount(RadioLayout, {
+      target, props: { skinId },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    }));
+    flushSync();
+    return target;
+  }
+
+  beforeEach(() => {
+    // The status bar's scope indicator gates on `hasAnyScope()` BEFORE it
+    // consults `declared`, and this file mocks that false by default. Without
+    // this line the indicator is absent on both faces and its suppression row
+    // asserts an absence this batch did not cause.
+    vi.mocked(hasAnyScope).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.mocked(hasAnyScope).mockReturnValue(false);
+  });
+
+  // NON-VACUITY, half one: under this fixture the "before" face really renders
+  // both surfaces AND both legacy hosts. Presence FIRST, so a dead view-model
+  // gate fails here rather than passing silently through the rows below.
+  it('the pre-batch manifest renders both surfaces and both legacy hosts', () => {
+    const t = renderAll(PRE_BATCH_4);
+    for (const [, testid] of TWO) {
+      expect(t.querySelector(`[data-testid="${testid}"]`), testid).not.toBeNull();
+    }
+    expect(t.querySelector(SCOPE_INDICATOR), 'status bar scope indicator').not.toBeNull();
+    expect(t.querySelector(SPECTRUM), 'spectrum panel').not.toBeNull();
+    expect(t.querySelector(SPECTRUM)!.getAttribute('data-hide-scope-controls')).toBe('false');
+  });
+
+  // NON-VACUITY, half two: on the "before" face both surfaces mount BARE. This
+  // is the state the declaration replaces, and what makes the zone assertions
+  // below a change rather than a restatement.
+  it.each(TWO)('%s: the pre-batch manifest mounts its surface bare, in no zone', (zoneId, testid) => {
+    const t = renderWithPlan(PRE_BATCH_4, PRE_BATCH_4_MANIFEST);
+    const el = t.querySelector(`[data-testid="${testid}"]`);
+    expect(el, testid).not.toBeNull();
+    expect(el!.closest('.surface-zone')).toBeNull();
+    expect(t.querySelector(`[data-zone-id="${zoneId}"]`)).toBeNull();
+  });
+
+  // EFFECT 1 — each declared zone binds a real element that OWNS its surface,
+  // and there is no second bare mount beside it.
+  it.each(TWO)('%s: sdr-test hosts its surface inside the declared zone element', (zoneId, testid) => {
+    const t = renderWithPlan('sdr-test', sdrTestLayout);
+    const el = t.querySelector(`[data-testid="${testid}"]`);
+    expect(el, `${testid} on screen`).not.toBeNull();
+    // Containment read from the SURFACE upward, not "some element with this id
+    // exists somewhere": the surface's own wrapper must be the declared zone.
+    const zone = el!.closest('.surface-zone');
+    expect(zone, `${testid} inside a zone element`).not.toBeNull();
+    expect(zone!.getAttribute('data-zone-id')).toBe(zoneId);
+    expect(t.querySelectorAll(`[data-testid="${testid}"]`).length).toBe(1);
+  });
+
+  // EFFECT 2a — the batch's ONE unmount, under the identical fixture that
+  // renders the indicator on the pre-batch face.
+  it('[status bar scope indicator] is unmounted on sdr-test', () => {
+    expect(renderAll('sdr-test').querySelector(SCOPE_INDICATOR)).toBeNull();
+  });
+
+  // EFFECT 2b — the other mechanism. `scope-controls` unmounts nothing: its
+  // host keeps rendering and only the prop flips. A mutation turning that prop
+  // into a mount gate reddens the first assertion; one dropping the forward
+  // reddens the second.
+  it('keeps the spectrum panel mounted on sdr-test and flips hideScopeControls', () => {
+    const t = renderAll('sdr-test');
+    expect(t.querySelectorAll(SPECTRUM).length).toBe(1);
+    expect(t.querySelector(SPECTRUM)!.getAttribute('data-hide-scope-controls')).toBe('true');
+  });
+
+  // THE ASYMMETRY, given a row that can fail. Both declarations together lose
+  // EXACTLY one host and gain none, so a `declared.has('scopeControls')` mount
+  // gate added anywhere `declared` reaches — or a second `scopeDisplay` guard —
+  // reddens this even though every row above stays green.
+  it('the host delta is exactly the status bar scope indicator', () => {
+    const before = hosts(renderAll(PRE_BATCH_4));
+    const after = hosts(renderAll('sdr-test'));
+    expect(before.length).toBeGreaterThan(1);
+    expect(before.filter((p) => !after.includes(p))).toEqual(['status-bar scope-indicator']);
+    expect(after.filter((p) => !before.includes(p))).toEqual([]);
+  });
+
+  // R9: the last two zones in the vocabulary add no key/unkey authority.
+  it('adds no key authority with the centre-top pair declared', () => {
+    expect(renderAll('sdr-test').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+  });
+});
+
+/**
  * The other half of the matrix. Suppression is derived from the manifest, so
  * an id no manifest is registered under declares nothing — and every legacy
  * twin must survive untouched. This is the branch that keeps the shared v2

--- a/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-controls-declarability.test.ts
@@ -7,10 +7,15 @@
  * deliberately does not touch any manifest, and it adds no design-language
  * renderer slot (that set was frozen by MOR-1072).
  *
- * MOR-1370 flips the second half, on `desktop-v2` ONLY: the cockpit manifest
- * is deliberately untouched (S5 precedent, restated by 12B/MOR-1365 for the
- * sibling `scopeDisplay` zone), so `scopeControls` stays undeclared — and
- * therefore unmounted, per the MOR-1304 canon — everywhere else. The
+ * MOR-1370 flipped the second half on `desktop-v2`; MOR-2231 (step 1, batch 4)
+ * adds `sdr-test`. The cockpit manifest stays deliberately untouched (S5
+ * precedent, restated by 12B/MOR-1365 for the sibling `scopeDisplay` zone), so
+ * `scopeControls` stays undeclared — and therefore unmounted, per the MOR-1304
+ * canon — THERE. Not "everywhere else": that reading only ever held on the dual
+ * composition, whose `zoned('scopeControls', …, false)` call withholds the body
+ * when no zone owns the surface. The single composition takes the default
+ * `allowBare`, so the surface mounts bare on every undeclaring face it serves.
+ * The
  * inventory below is a LITERAL of who declares it, mirroring
  * `scope-display-declarability.test.ts`'s post-S6a shape. This is the LAST
  * surface in the whole MOR-1262 vocabulary to graduate:
@@ -60,7 +65,13 @@ describe('scopeControls is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a scopeControls zone (MOR-1370)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_SCOPE_CONTROLS = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 4) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force. Like `band` and unlike the rest of
+  // that step, this declaration UNMOUNTS NOTHING: its one consumer is a PROP,
+  // `hideScopeControls={declared.has('scopeControls')}`, which `RadioLayout`
+  // forwards to a `SpectrumPanel` that keeps rendering and drops the
+  // toolbar's fact-backed half.
+  const DECLARES_SCOPE_CONTROLS = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -60,8 +60,7 @@ describe('exactly the reviewed manifests declare a scopeDisplay zone (MOR-1365)'
   // review this literal exists to force: the same declaration retires that
   // face's status-bar scope indicator through the `declared.has(...)` channel
   // (`StatusBar.svelte`'s `{#if hasAnyScope() && !declared.has('scopeDisplay')}`).
-  // That is the only host it retires, and it is the first twin on this face
-  // that is neither a sidebar panel nor a settings-modal section.
+  // That is the only host it retires.
   const DECLARES_SCOPE_DISPLAY = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface

--- a/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/scope-display-declarability.test.ts
@@ -7,9 +7,10 @@
  * added no design-language renderer slot (that set was frozen by MOR-1072 —
  * adding one would be a language-contract change this slice must not make).
  *
- * MOR-1365 flips the second half, on `desktop-v2` ONLY: the cockpit manifest
- * is deliberately untouched (S5 precedent), so `scopeDisplay` keeps mounting
- * bare there. The inventory below is a LITERAL of who declares it, mirroring
+ * MOR-1365 flipped the second half on `desktop-v2`; MOR-2231 (step 1, batch 4)
+ * adds `sdr-test`. The cockpit manifest stays deliberately untouched (S5
+ * precedent), so `scopeDisplay` keeps mounting bare there. The inventory below
+ * is a LITERAL of who declares it, mirroring
  * `meters-declarability.test.ts`'s post-S5 shape.
  *
  * Same three pins as `tx-aux-declarability.test.ts` / `meters-declarability.test.ts`
@@ -55,7 +56,13 @@ describe('scopeDisplay is a declarable semantic surface', () => {
 
 describe('exactly the reviewed manifests declare a scopeDisplay zone (MOR-1365)', () => {
   /** The literal — extend by hand, with a layout review, never silently. */
-  const DECLARES_SCOPE_DISPLAY = ['desktop-v2'];
+  // MOR-2231 (step 1, batch 4) added `sdr-test`, by hand and with the layout
+  // review this literal exists to force: the same declaration retires that
+  // face's status-bar scope indicator through the `declared.has(...)` channel
+  // (`StatusBar.svelte`'s `{#if hasAnyScope() && !declared.has('scopeDisplay')}`).
+  // That is the only host it retires, and it is the first twin on this face
+  // that is neither a sidebar panel nor a settings-modal section.
+  const DECLARES_SCOPE_DISPLAY = ['desktop-v2', 'sdr-test'];
 
   // [id, manifest] pairs derived from the barrel's export surface
   // (MOR-2061) — never hand-listed. See `manifest-guard.ts`.

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -104,6 +104,14 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
     ['dsp', 'dsp'],
     ['cwKeyer', 'cw-keyer'],
     ['txAux', 'tx-aux'],
+    // MOR-2231 (step 1, batch 4) — the centre-top pair completes the fourteen.
+    // The id-drift argument applies to `scopeDisplay` unchanged. It applies to
+    // `scopeControls` too, but through a PROP rather than a mount gate:
+    // `hideScopeControls={declared.has('scopeControls')}` would still go true
+    // under a drifted id, so the toolbar's fact-backed half would still retire
+    // while the surface named a host no arrangement can bind.
+    ['scopeDisplay', 'scope-display'],
+    ['scopeControls', 'scope-controls'],
   ] as const)('mounts %s alone in the stable `%s` zone, not required', (surface, zoneId) => {
     const owning = sdrTestLayout.zones.filter((z) => z.surfaces.includes(surface));
     expect(owning).toHaveLength(1);

--- a/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
+++ b/frontend/src/presentation/layouts/__tests__/sdr-registration.test.ts
@@ -98,7 +98,8 @@ describe('declared semantic zones (what the migrated entrypoint actually mounts)
     // MOR-2231 (step 1, batch 3) — the right column's four, same shape. The id
     // drift argument above applies unchanged to `rxAudio`/`dsp`/`cwKeyer`. It
     // does NOT apply to `txAux`: no `declared.has('txAux')` predicate exists,
-    // so a drifted id there loses the host without retiring anything.
+    // so a drifted id there names a host no arrangement can bind without
+    // retiring anything.
     ['rxAudio', 'rx-audio'],
     ['dsp', 'dsp'],
     ['cwKeyer', 'cw-keyer'],

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -68,6 +68,33 @@ export const sdrTestLayout: LayoutManifest = {
   // which follows the semantic DECK for R9) and batch 1's `vfo` zone already
   // suppressed it here.
   //
+  // MOR-2231 (step 1, batch 4): `scopeDisplay` and `scopeControls` join, under
+  // the ids `desktop-declarations.ts` already uses. That completes the
+  // fourteen — every name in `SEMANTIC_SURFACE_NAMES` (`contract.ts`) now has
+  // a zone here. Both already mounted BARE through the single composition's
+  // `zoned()` calls in `SemanticRadioSurfaces.svelte` (both take the default
+  // `allowBare` on that path), so declaring the zone gives each a
+  // `data-zone-id` host.
+  //
+  // The two differ in what else the declaration does, and NEITHER matches the
+  // batch-3 shape:
+  //
+  //   `scopeDisplay` retires ONE host, and it is the first on this face that
+  //   is neither a sidebar panel nor a settings-modal section: `StatusBar`'s
+  //   scope indicator, `{#if hasAnyScope() && !declared.has('scopeDisplay')}`.
+  //   The twin is capability-gated on `hasAnyScope()`, so a radio with neither
+  //   a hardware scope nor an audio-FFT source has no indicator to retire.
+  //
+  //   `scopeControls` retires NO host — the `band` shape rather than the
+  //   `txAux` one, since a predicate does exist. Its only consumer is a PROP:
+  //   `RadioLayout.svelte` forwards `hideScopeControls={declared.has(
+  //   'scopeControls')}` to `SpectrumPanel`, which keeps mounting and drops
+  //   the toolbar's twelve fact-backed `scopeControls.*` leaves (the eight
+  //   client-side view options are never gated on it, S10 category (b)). The
+  //   host is the CENTRE column's legacy spectrum panel, inside
+  //   `{#if hasSpectrum()}` — a different mechanism from the sidebars'
+  //   `drag.order.includes(...)` mount gates.
+  //
   // None is `required`, matching `desktop-v2`: each surface self-gates on its
   // own `view.*` group, so a radio whose evidence gate declined the group must
   // still resolve this layout.
@@ -84,6 +111,8 @@ export const sdrTestLayout: LayoutManifest = {
     { id: 'dsp', surfaces: ['dsp'] },
     { id: 'cw-keyer', surfaces: ['cwKeyer'] },
     { id: 'tx-aux', surfaces: ['txAux'] },
+    { id: 'scope-display', surfaces: ['scopeDisplay'] },
+    { id: 'scope-controls', surfaces: ['scopeControls'] },
   ],
   compatibleTopologies: ['1/single', '1/ab', '2/ab_shared', '2/main_sub'],
   requiredSemanticSurfaces: ['vfo', 'rxTx'],

--- a/frontend/src/presentation/layouts/declarations.ts
+++ b/frontend/src/presentation/layouts/declarations.ts
@@ -79,9 +79,8 @@ export const sdrTestLayout: LayoutManifest = {
   // The two differ in what else the declaration does, and NEITHER matches the
   // batch-3 shape:
   //
-  //   `scopeDisplay` retires ONE host, and it is the first on this face that
-  //   is neither a sidebar panel nor a settings-modal section: `StatusBar`'s
-  //   scope indicator, `{#if hasAnyScope() && !declared.has('scopeDisplay')}`.
+  //   `scopeDisplay` retires ONE host: `StatusBar`'s scope indicator,
+  //   `{#if hasAnyScope() && !declared.has('scopeDisplay')}`.
   //   The twin is capability-gated on `hasAnyScope()`, so a radio with neither
   //   a hardware scope nor an audio-FFT source has no indicator to retire.
   //

--- a/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
+++ b/frontend/src/presentation/workspace/__tests__/preferences-adoption.test.ts
@@ -139,14 +139,15 @@ describe('MOR-1082 — the surface plan starts from what the manifest declares',
     ]);
     // MOR-1346: `meters` joined as sdr-test's own zone. MOR-2231 batch 1: `vfo`
     // and `rxTx` each hold one too, under the ids `desktop-v2` already uses;
-    // batch 2 adds the five control families and batch 3 the right column's
-    // four, all the same one-surface-per-zone shape.
+    // batch 2 adds the five control families, batch 3 the right column's four
+    // and batch 4 the centre-top pair, all the same one-surface-per-zone shape.
     expect([...plan(sdrTestLayout)]).toEqual([
       ['receiver-deck', ['vfo']], ['rx-tx', ['rxTx']], ['meters', ['meters']],
       ['filter', ['filter']], ['rf-front-end', ['rfFrontEnd']], ['band', ['band']],
       ['antenna', ['antenna']], ['rit-xit-scan', ['ritXitScan']],
       ['rx-audio', ['rxAudio']], ['dsp', ['dsp']], ['cw-keyer', ['cwKeyer']],
-      ['tx-aux', ['txAux']],
+      ['tx-aux', ['txAux']], ['scope-display', ['scopeDisplay']],
+      ['scope-controls', ['scopeControls']],
     ]);
   });
 
@@ -278,10 +279,10 @@ describe('MOR-1082 — the single-composition order comes from the same plan', (
   });
 
   it('flattens the plan in zone-declaration order, deduped', () => {
-    // MOR-1346/2231: sdr-test's twelve zones flatten in declaration order.
+    // MOR-1346/2231: sdr-test's fourteen zones flatten in declaration order.
     expect(compositionSurfaces(plan(sdrTestLayout), FALLBACK)).toEqual([
       'vfo', 'rxTx', 'meters', 'filter', 'rfFrontEnd', 'band', 'antenna', 'ritXitScan',
-      'rxAudio', 'dsp', 'cwKeyer', 'txAux',
+      'rxAudio', 'dsp', 'cwKeyer', 'txAux', 'scopeDisplay', 'scopeControls',
     ]);
     // desktop-v2 spreads the same two surfaces over two zones, plus its own
     // MOR-1336 (S4) tx-aux zone, MOR-1341 (S5) meters zone, MOR-1365 (S6a)


### PR DESCRIPTION
Linear: MOR-2231

Base (merge base): `d350d6570549a3f713b91f427074d2c77b65f051`. Head: `247de30391ad1a7d9e8ec857aedf8916004114f9`.

**Review round 2** (`3ef6bfe0` → `247de303`): two prose claims deleted, and the replacement for one of them measured rather than asserted. Details under *Round 2* below. Every mechanical result in this body was reproduced independently at `3ef6bfe0` and is unchanged.

## Read this first: the two centre-top surfaces behave differently from each other, and neither like batch 3

`sdrTestLayout` gains `scope-display` and `scope-controls`, reusing desktop-v2's stable ids. That completes the fourteen — checked by comparing `SEMANTIC_SURFACE_NAMES` against the manifest's flattened zone list **as sets**: 14 names, 14 zones, 14 surfaces, sets equal, every zone holding exactly one surface.

Both already mounted on this face BARE: the single composition's `zoned()` calls take the default `allowBare` for both (`SemanticRadioSurfaces.svelte`, the `{:else}` branch). The dual composition passes `allowBare=false` for `scopeControls` — that is the cockpit's path, not this one, and it is untouched.

**The suppression enumeration.** Every occurrence of `declared.has(` in the tree, by `git grep -n -F "declared.has(" --` with **no path scope and no filter**, then by **reading** `RadioLayout.svelte`, `StatusBar.svelte`, `LeftSidebar.svelte`, `RightSidebar.svelte`, `SpectrumPanel.svelte` and `SpectrumToolbar.svelte` rather than trusting the grep — a guard split across two lines matches no single-line pattern. Then, separately, every occurrence of the two surface NAMES (`git grep -l -F "scopeDisplay" --` / `"scopeControls" --`, unscoped), filtered by reading, since any guard must name its surface.

Controls on the same instrument: `git grep -l -F "declared" --` matched **369** files, so the search was not silently empty; `git grep -l -F "scopeDisplayZZZ" --` exited **1**, so an absent term really reports absence.

| Surface | Consumer | Mechanism | Hosts unmounted |
|---|---|---|---|
| `scopeDisplay` | `StatusBar.svelte` — `{#if hasAnyScope() && !declared.has('scopeDisplay')}` | mount gate | **1** — the status-bar scope indicator |
| `scopeControls` | `RadioLayout.svelte` — `hideScopeControls={declared.has('scopeControls')}` | **prop** | **0** |

Exactly one `declared` consumer each. No other file reads either surface name off `declared`.

## Both are odd ones out, in different ways

**`scopeDisplay`** retires exactly one host: the status-bar scope indicator. Its own render gate is `hasAnyScope()`, a capability — so a radio with neither a hardware scope nor an audio-FFT source has no indicator to retire in the first place.

**`scopeControls`** retires nothing by mount. Unlike batch 3's `txAux` a predicate does exist; unlike everything else it is a **prop**. `SpectrumPanel` keeps rendering and drops the toolbar's twelve fact-backed `scopeControls.*` leaves, the eight client-side view options staying unconditional (S10 category (b)). That is batch 2's `band` shape — but reached through the CENTRE column's `{#if hasSpectrum()}`, a different mechanism from the sidebars' `drag.order.includes(...)` mount gates. Which controls the prop actually removes is proven in `SpectrumToolbar.component.test.ts`'s S6b-1 pins; this file mocks `SpectrumPanel` with a stub that records the prop, so what it can pin is the forward.

## The two gates read different fields of the same object

This is why the fixture names the gate that reads each field, and why presence is asserted first:

- `deriveScopeControls` gates on `hasCap(caps, 'scope')` — the `capabilities` **array**;
- `deriveScopeDisplay` gates on `hasAnyScopeCap(caps)` — the `scope` **boolean** (or `scopeSource === 'audio_fft'`) — **and** a non-null scope-display snapshot.

A fixture satisfying one proves nothing about the other. `capsFor('2/main_sub')` supplies both shapes and the harness's fixed `runtime.defaultScopeStatus` supplies the snapshot. Separately, `hasAnyScope()` is mocked **false** by default in this file, so the describe turns it on: without that the status-bar indicator never renders on either face and its suppression row asserts an absence this batch did not cause.

## The pin

`semantic-desktop-migration.component.test.ts` gains a describe in the established shape — **9 cases, taking that file from 123 to 132** (both counts measured, the 123 by restoring the file to its base version and running it).

- **Zone hosts** (2). Each surface is inside the `[data-zone-id]` element its manifest names, read from the surface *upward* (`el.closest('.surface-zone')`, then its `data-zone-id`), and is the only instance. Run against a resolved plan, because `zoneOwning()` reads the plan.
- **Non-vacuity** (3). One row asserts both surfaces AND both legacy hosts render on the control, presence first; two assert the surfaces mount bare, in no zone, there.
- **Suppression** (1). The status-bar scope indicator is gone on `sdr-test`, under the identical fixture that renders it on the control.
- **The prop, not a mount** (1). The spectrum panel is still on screen exactly once and its `hideScopeControls` flipped `false` → `true`.
- **The host delta** (1). Over the seven hosts `hosts()` actually finds under this fixture — now pinned as `BEFORE_HOSTS` — both declarations together lose EXACTLY one entry and gain none. That set is the row's whole reach, and the comment says so; see *Round 2*.
- **R9** (1). Still exactly one key/unkey authority.

The control is a registered manifest (`sdr-pre-batch-4-probe`), not an argument: suppression derives from `getLayout(skinId)`, so only a separately registered id can produce the "before" state.

## Mutations — destructive direction

Each was checked for reachability, and for whether the assertion can distinguish its two values, before it was run. Both values of every assertion below were observed in the green run.

**A — one zone dropped.** Removed `{ id: 'scope-display', surfaces: ['scopeDisplay'] }`. Reachable: `zoneOwning('scopeDisplay')` then returns null and `allowBare` defaults true, so the surface renders bare; and `declared.has('scopeDisplay')` goes false, remounting the indicator. **`3 failed | 129 passed (132)`** — exactly the three predicted rows:

```
× scope-display: sdr-test hosts its surface inside the declared zone element
  AssertionError: scope-display-surface inside a zone element: expected null not to be null
× [status bar scope indicator] is unmounted on sdr-test
  AssertionError: expected <span …(4)>…(2)</span> to be null
× the host delta is exactly the status bar scope indicator
  AssertionError: expected [] to deeply equal [ 'status-bar scope-indicator' ]
```

Both `scope-controls` rows stayed green, so the parametrisation discriminates per case. Fan-out across the other guards under the same mutation: `scope-display-declarability` `1 failed | 12 passed (13)`, `sdr-registration` `1 failed | 17 passed (18)`, `preferences-adoption` `2 failed | 22 passed (24)` — eight rows in four files.

**B — the suppression guard stripped.** `{#if hasAnyScope() && !declared.has('scopeDisplay')}` → `{#if hasAnyScope()}`, reinstating exactly the double presentation this batch removes. **`3 failed | 129 passed (132)`**: the unmount row and the delta row died, plus the pre-existing `suppresses the status bar scope indicator on real desktop-v2` (shared guard). **Both zone-host rows stayed green** — they read the manifest, not the guard, so the two effects are pinned separately rather than dying together.

**C — the mutation the `scopeControls` claim exists for.** A "unmounts nothing" claim is worth nothing unless something can falsify it, so this made it unmount something: `{#if hasSpectrum()}` → `{#if hasSpectrum() && !declared.has('scopeControls')}`. **`5 failed | 127 passed (132)`**. The prop row died with `expected +0 to be 1` and the delta row with `expected [ …(2) ] to deeply equal [ 'status-bar scope-indicator' ]`, plus three pre-existing rows that assert the spectrum panel exists. **All four other batch-4 rows stayed green**, including both zone hosts and the `scopeDisplay` unmount.

**D — the prop forward dropped.** `hideScopeControls={declared.has('scopeControls')}` → `{false}`. **`2 failed | 130 passed (132)`**: only the prop row (`expected 'false' to be 'true'`), plus the pre-existing desktop-v2 row. **The delta row stayed green**, correctly — the panel still mounts. C and D together show the two `scopeControls` claims are pinned independently: C kills both, D kills only the prop one.

## Mutation — reverse direction

Batch 3's review added this and batch 3 had not run it. A behaviour-preserving refactor at the same two sites must leave the pin green:

- `StatusBar.svelte`: conjunct order swapped to `{#if !declared.has('scopeDisplay') && hasAnyScope()}` — boolean-equivalent, both operands pure;
- `RadioLayout.svelte`: the predicate extracted to `let semanticScopeControls = $derived(declared.has('scopeControls'));` and passed as the prop.

**`132 passed (132)`.** Also green under the refactor: `RadioLayout.isolated.test.ts` 46/46, `forward-declaration-inventory.test.ts` 4/4, `desktop-v2-registration.test.ts` 10/10, `StatusBar.radio-link-chip.component.test.ts` 1/1 — the three that read `RadioLayout.svelte` as TEXT included, since a text pin is the thing a refactor is most likely to redden for the wrong reason.

**Restoration.** All mutations reverted with `git checkout --`. `declarations.ts` is back to sha256 `c88525bc…a841b`, `StatusBar.svelte` to `a02324cb…ef5fa`, `RadioLayout.svelte` to `f6b386cc…9e42aa`, each byte-identical to the hashes recorded before the first mutation; `git status --porcelain` is empty and `git diff --stat` is empty.

**One procedural error worth recording.** The first attempt at mutation B ran against the wrong tree: `git checkout --` restoring `declarations.ts` after mutation A discarded the batch-4 edit as well, because that edit was still uncommitted. The run reported `6 failed` and I discarded it rather than reporting it — the extra failures were the reverted declaration, not the mutation. The work was committed first and every mutation above was then run against the committed tree, where `git checkout --` restores the intended state exactly.

## Round 2 — two deletions, and one replacement that had to be measured

Both blocked claims were prose reaching past the measurement. Neither changed a result.

**B1 — "the first twin on this face that is neither a sidebar panel nor a settings-modal section."** False, and refuted by two merged tests inside the very file this batch edits: `MetersDockPanel` in `.bottom-dock` retires on `declared.has('meters')` (`drops the legacy meters dock…` against `keeps the dock for a layout that declares vfo but not meters`), and `VfoHeader` retires on `declared.has('vfo')` (`renders none of the legacy VFO/TX presentation it replaces`). Both predate batch 1; neither is a sidebar panel or a modal section. Deleted from all three code sites, from this body, and from the commit message — the load-bearing half, "retires exactly ONE host", is true and pinned, and the clause carried no load anywhere it appeared.

**B2 — the delta row's "a mount gate added anywhere `declared` reaches would redden this."** False: `hosts()` reads five selectors and `declared` reaches more, so the guard was narrower than its name. The reviewer proved it by gating the status bar's control-link indicator on `!declared.has('scopeControls')` — a real host vanishes on `sdr-test` and the file reports **132 passed (132)**. Batch 3's sibling row forty lines above had it right ("added to either sidebar or to the settings modal"); this change widened a true sentence into a false one and should have copied the wording already there.

**The replacement was itself unmeasured, so it is now pinned instead of described.** A diagnostic dump of `hosts()` under this describe's fixture returns exactly seven entries:

```
.left-sidebar band            .settings-modal desktop-vfo-ops
.right-sidebar memory         .settings-modal desktop-workspace
.settings-modal desktop-language
content-center spectrum-panel   status-bar scope-indicator
```

Batches 2 and 3 already retired most sidebar panels, and the rest of each sidebar's DEFAULT order never mounts here because this describe seeds no panel order. That set replaces a `length > 1` check as `BEFORE_HOSTS`, so the row's reach is mechanical, and the comment names the hosts it cannot see (`.bottom-dock`, the legacy VFO header, the status bar's other indicators, `BandSelector`'s `hamBands` prop).

**Bounded in both directions by mutation:**

**E — a gate INSIDE the pinned set.** `!declared.has('scopeControls')` on `RightSidebar`'s MEMORY panel. **`5 failed | 127 passed (132)`**; the delta row died with `expected [ '.right-sidebar memory', …(1) ] to deeply equal [ 'status-bar scope-indicator' ]`.

**F — the reviewer's mutation, a gate OUTSIDE it.** The same gate on the status bar's control-link indicator. **`132 passed (132)`** — reproduced exactly. The comment now states this rather than implying the opposite.

**A first attempt at E proved nothing, and is recorded because it looks like evidence.** It gated `LeftSidebar`'s MEMORY panel and survived — but `memory` is not in the left sidebar's default order, so under this fixture the gate was unreachable and never evaluated. A surviving mutation reads as a weak test when it is really a bad mutation; the reachability check belonged before the run, not after it.

**Two further claims in the same comment block, same class, also deleted.** `hosts()` was described as "every legacy host `declared` can reach on this face" — it omits `.bottom-dock` and the legacy VFO header; and `StatusBar`/`LeftSidebar`/`RightSidebar`/`SpectrumPanel` was called "every consumer `RadioLayout` hands `declared` to" — it omits `BandSelector`, which takes `hamBands={!declared.has('band')}`, the identical shape to the `hideScopeControls` prop the sentence did name.

## The other guards this change falsified

- **Two declarability literals.** `DECLARES_SCOPE_DISPLAY` and `DECLARES_SCOPE_CONTROLS` each grew `'sdr-test'` by hand, which is what the literal exists to force: restoring either file to its base version and running it gives `1 failed | 12 passed (13)`, the census row failing against the new manifest.
- **Two `preferences-adoption.test.ts` guards** — the `plan(sdrTestLayout)` zone-list equality and the `compositionSurfaces(...)` flattening. Restoring that file to its base version gives `2 failed | 22 passed (24)`.
- **Two file-header sentences**, in the same two declarability suites, said these surfaces were declared on `desktop-v2` **ONLY**. Rewritten rather than left standing, following the precedent batch 3 set for `cw-keyer-declarability.test.ts`. The `scope-controls` rewrite also narrows a second clause — "stays undeclared and therefore unmounted everywhere else" only ever held on the dual composition, whose `zoned('scopeControls', …, false)` withholds the body; the single composition takes the default `allowBare`.
- `WORKSPACE_ZONE_IDS` needed no edit: `scope-display` and `scope-controls` were already there from desktop-v2. `REFERENCE_ZONE_IDS` is built from `desktopV2Layout.zones` and never reads `sdrTestLayout`, so this manifest cannot move it either way.

## Swept, found, and deliberately NOT fixed here

Fixing two header sentences raised the question of how wide that class is. Enumerated over every `*declarability.test.ts` by comparing each file's header against its own literal:

**Nine files carry the sentence "flips the second half, on `desktop-v2` ONLY" while their own `DECLARES_*` literal, further down the same file, reads `['desktop-v2', 'sdr-test']`** — antenna, band, cw-keyer, dsp, filter, meters, rf-front-end, ritxit-scan, rx-audio. Each was falsified by MOR-1346, batch 2 or batch 3, and none by this change. Left unfixed: they fall outside this batch's spec and outside a six-file diff. This is the derived-list-beside-handwritten-list shape — the false claim sits in the same file as the literal that refutes it.

Two further items found and left alone, both outside the diff:

- `semantic-desktop-migration.component.test.ts`'s own file header says "No fixture here declares a scope capability, so this stays on its pre-1312 path regardless of these fixed defaults." That is false at HEAD: `capsFor()` sets both `scope: true` and `'scope'` in the capabilities array, and every `beforeEach` uses it — which is precisely why this batch's surfaces render at all.
- This batch adds a third near-identical `renderWithPlan` helper to that file (batches 2 and 3 have their own). Collapsing them would touch both earlier describes, so it is left for a change whose scope covers them.

## Verification

No test suite was run on this machine (owner's radio workstation). Every run was `npx vitest run <one named file>`, one file per invocation.

**96 distinct test files run, all green.** The selection was derived, not eyeballed: `git grep -l -i -E "sdrtestlayout|sdr-test" -- 'frontend/src/**/*.test.ts'` gives **42** files, and a second list keyed on this batch's own subject (`scopedisplay|scopecontrols|scope-display|scope-controls|hidescopecontrols|hasAnyScope`) gives **79**; the union is **96** and the overlap **25**, so 42 + 79 − 25 = 96 is a true union and not a double count. The results file has 96 lines, every one `rc=0`, none `NO-SUMMARY` — that line count is the evidence the loop ran 96 times rather than once against a blob.

Largest: `semantic-desktop-migration.component.test.ts` 132/132, `VfoSurface.test.ts` 129/129, `panel-commands.intent.isolated.test.ts` 114/114, `workspace-compatibility-verification.test.ts` 96/96, `architecture-boundaries.test.ts` 92/92, `SpectrumPanel.component.test.ts` 88/88, `SpectrumToolbar.component.test.ts` 86/86.

**A methodological correction, because it produced a clean-looking result from an instrument that had measured nothing.** The first sweep extracted each run's summary with `grep -E "^ *Tests +"`, and every one of the 32 files it had already run came back `NO-SUMMARY` — vitest writes ANSI escapes between `Tests` and the count, so the anchor could never match. The numbers above come from the rewritten extractor (`sed 's/\x1b\[[0-9;]*m//g'` first), which was verified on a file whose count was already known before the sweep was re-run.

- `npx eslint` on all six changed files — **exit 0, zero bytes of output**, read from a redirected file rather than a pipe (`cmd | tail` reports `tail`'s status). Carries its own control: a first control using `any` also returned 0 and therefore established nothing, so it was replaced with a forbidden `$lib/runtime` import under `src/presentation/`, which returns **exit 1** with a `no-restricted-imports` error — so a nonzero exit, and rule evaluation rather than only parsing, is reachable through this exact invocation.
- `npm run check` (`svelte-check` + `tsc -p tsconfig.node.json`) — **exit 0**, `4634 FILES 0 ERRORS 0 WARNINGS`.
- No Python gates: nothing under `src/rigplane/` changed.

**Negative claims here are bounded to those 96 named files, not to the suite.** The full frontend suite runs in CI on this PR.

## REGCHECK

Baseline is `quick` on `main` at this PR's own merge base `d350d657` — run **33743796615**, success, frontend **388 test files / 8466 tests passed**. `origin/main` is still `d350d657`, so `git diff --name-only <base>..origin/main -- frontend/` is empty and the baseline is current by identity rather than by argument.

Head: `quick` on `247de303` — run **33749740868**, success, frontend **388 test files / 8479 tests passed**. **Delta +13 tests, 0 files, 0 failures.** The round-1 head `3ef6bfe0` (run 33745818088) reported the same 8479, which is the check that round 2 added no case: `BEFORE_HOSTS` replaced an assertion inside an existing test.

**Predicted +13, measured +13.** The counting rule, each "before" measured by restoring that file to its base version and running it, not carried forward from batch 3's body:

| File | before | after | delta | why |
|---|---:|---:|---:|---|
| `semantic-desktop-migration.component.test.ts` | 123 | 132 | +9 | the pin |
| `sdr-registration.test.ts` | 16 | 18 | +2 | its `it.each` gains two entries |
| `scope-display-declarability.test.ts` | 13 | 14 | +1 | `it.each(DECLARES_SCOPE_DISPLAY)` gains one entry |
| `scope-controls-declarability.test.ts` | 13 | 14 | +1 | same |
| `preferences-adoption.test.ts` | 24 | 24 | +0 | both edits are inside existing cases |

9 + 2 + 1 + 1 + 0 = 13, and 8466 + 13 = 8479 exactly. The file count is unchanged because this change creates no test file.

## Size

**6 files, 303 changed lines** (288 insertions, 15 deletions), re-derived with `git diff --name-only` and `--shortstat` between `d350d657` and the pushed head `247de303`. Inside the hard ceiling (10 / 1000); at the soft file threshold of six, well under its 600-line half. The unit is the manifest edit plus every guard it falsifies plus the pin for the effect it produces — splitting the declarations from the two census literals would push a knowingly-red commit, and so would splitting either from the two `preferences-adoption` guards.

## The question this batch's evidence does not ask

Not batch 3's two (presence is not parity, now MOR-2291; and capability-blind suppression against a capability-gated replacement). Three candidates for a third were checked against the code and **refuted**, which is worth recording because each produced a coherent-sounding argument first:

1. *A workspace subtraction can now hide these surfaces while their legacy twins stay retired.* False on this face: `zoneOwning()` returns null for an emptied zone and the single composition's default `allowBare` then renders the surface **bare**. A subtraction un-zones; it does not remove.
2. *The retirement and the replacement read different capability holders, so they can disagree.* False: `runtime.caps` is a getter returning `getCapabilities()` — the same module-level store object `hasAnyScope()` reads.
3. *`hasSpectrum()` reads `caps.scope` while `deriveScopeControls` reads the `capabilities` array, so the legacy half could retire with nothing replacing it.* Two different fields, but not reachable: `server.py` emits `"scope": "scope" in caps` and `"capabilities": sorted(caps)` from one set in one payload, so they agree by construction.

The one that survives:

**Every zone-host row in batches 2, 3 and 4 compares a probe id against `sdr-test`, and those two ids differ in TWO dimensions, not one.** The zone list is the intended one. The other is `regions`, which `RadioLayout` derives from the skin id — `regions={skinId === 'sdr-test'}` — so it is `false` on every probe and `true` on `sdr-test`. The confound is inert today: `regions` is read at exactly two places in `SemanticRadioSurfaces`' single composition, around `vfo` and `rxTx`, and none of the eleven surfaces these three batches cover is one of those. So every row currently reads a one-variable result — by luck of which surfaces are involved, and nothing anywhere asserts it.

That is exactly what stays true and wrong. Batch 5 is the batch that changes `regions` (`RadioLayout`'s own comment beside it says "A later batch replaces it"). The moment `regions` widens, or another surface moves behind it, the "mounts its surface bare, in no zone" rows start passing because `regions` was false on the control, and the "hosts its surface inside the declared zone element" rows because `regions` was true — both green, both now measuring the prop instead of the declaration. Batch 2's describe already asserts the opposite in prose: "It differs from `sdr-test` in exactly the dimension under test and nothing else." That sentence is false today, and this batch inherits the control shape it describes. Batch 1's describe is the one that got it right, and it did so by holding the zone list constant and varying only `regions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
