### PR TITLE
refactor(MOR-2293): one AcquisitionDrain, with rigctld as its first seat

### DIFF
--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -1,0 +1,221 @@
+"""One acquisition drain for the seats that dispatch scheduler requests.
+
+MOR-2293 (slice 3 of MOR-2260). ``AcquisitionScheduler`` decides what needs
+reading; a drain turns its ``dispatchable_requests()`` into backend sends,
+keeps the in-flight ledger, and reports what came back. The web poller and
+the rigctld seat each grew their own copy of that loop.
+
+Injected, because the seats differ deliberately:
+
+* ``expired`` — rigctld expires a dispatched request at the earlier of its
+  enqueue deadline and ``sent_at + timeout``; the web poller measures from
+  the send and its own comment calls the ``min`` form a false timeout.
+* ``dispatchable`` — which pending requests this seat may put on the wire
+  this pass. rigctld stands the profile cadence down while an external CAT
+  session owns the byte stream; no deadline rule can express that.
+
+The reporting hooks are injected for the same reason: the seats record
+different diagnostic sources and different executor-failure reasons.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable, MutableMapping, Sequence
+from typing import Protocol
+
+from .acquisition_scheduler import (
+    AcquisitionExecutor,
+    AcquisitionRequest,
+    AcquisitionScheduler,
+    derive_tx_active,
+)
+from .state_pipeline_contracts import FieldPath
+from .state_store import StateStore
+
+__all__ = [
+    "AcquisitionDrain",
+    "AcquisitionExpiryPolicy",
+    "InFlightLedger",
+]
+
+#: request id -> (paths already sent for it, monotonic time of that send).
+InFlightLedger = MutableMapping[str, tuple[frozenset[FieldPath], float]]
+
+
+class AcquisitionExpiryPolicy(Protocol):
+    """The seat's rule for a request that has already been dispatched."""
+
+    def __call__(
+        self,
+        request: AcquisitionRequest,
+        *,
+        sent_at: float,
+        now: float,
+    ) -> bool: ...
+
+
+class AcquisitionFailureReport(Protocol):
+    def __call__(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        reason: str,
+        failed_paths: tuple[FieldPath, ...] | frozenset[FieldPath],
+        now: float,
+    ) -> None: ...
+
+
+class AcquisitionExecutorMissingReport(Protocol):
+    def __call__(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        now: float,
+    ) -> None: ...
+
+
+class AcquisitionExecutorErrorReport(Protocol):
+    def __call__(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        error: BaseException,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> None: ...
+
+
+class AcquisitionSentReport(Protocol):
+    def __call__(
+        self,
+        request: AcquisitionRequest,
+        *,
+        paths: tuple[FieldPath, ...],
+        pending_request_count: int,
+    ) -> None: ...
+
+
+class AcquisitionDrain:
+    """Dispatch one pass over the scheduler's dispatchable requests."""
+
+    def __init__(
+        self,
+        *,
+        scheduler: Callable[[], AcquisitionScheduler | None],
+        executor: Callable[[], AcquisitionExecutor | None],
+        store: Callable[[], StateStore | None],
+        in_flight: InFlightLedger,
+        expired: AcquisitionExpiryPolicy,
+        dispatchable: Callable[
+            [Sequence[AcquisitionRequest]], Sequence[AcquisitionRequest]
+        ],
+        report_failure: AcquisitionFailureReport,
+        report_executor_missing: AcquisitionExecutorMissingReport,
+        report_executor_error: AcquisitionExecutorErrorReport,
+        report_sent: AcquisitionSentReport,
+    ) -> None:
+        self._scheduler = scheduler
+        self._executor = executor
+        self._store = store
+        self._in_flight = in_flight
+        self._expired = expired
+        self._dispatchable = dispatchable
+        self._report_failure = report_failure
+        self._report_executor_missing = report_executor_missing
+        self._report_executor_error = report_executor_error
+        self._report_sent = report_sent
+
+    async def run_once(self) -> None:
+        scheduler = self._scheduler()
+        if scheduler is None:
+            return
+        now = time.monotonic()
+        store = self._store()
+        # MOR-1532: keep the scheduler's tx_active cache current on this drain
+        # path too. Same ``derive_tx_active`` over the same canonical store as
+        # the freshness tick's own cadence call, so the two writers cannot
+        # disagree about one store state.
+        scheduler.note_tx_active(False if store is None else derive_tx_active(store))
+        # MOR-1533: dispatch must use the tx_active-gated view; crediting an
+        # already-sent answer (runtime._civ_rx, driven by the radio's own CI-V
+        # pump) uses the unfiltered pending_requests() instead, so an answer
+        # landing after de-key is never blinded by this gate.
+        pending = scheduler.dispatchable_requests()
+        pending_ids = {request.id for request in pending}
+        for request_id in tuple(self._in_flight):
+            if request_id not in pending_ids:
+                del self._in_flight[request_id]
+
+        # Eligibility is asked once per pass, over the unfiltered pending view
+        # above: a request the seat declines to send is still pending, and its
+        # ledger entry must survive the pass.
+        for request in self._dispatchable(pending):
+            sent_paths: frozenset[FieldPath] = frozenset()
+            existing = self._in_flight.get(request.id)
+            if existing is not None:
+                sent_paths, sent_at = existing
+                if self._expired(request, sent_at=sent_at, now=now):
+                    self._report_failure(
+                        scheduler,
+                        request,
+                        reason="acquisition_request_timeout",
+                        failed_paths=sent_paths or frozenset(request.paths),
+                        now=now,
+                    )
+                    self._in_flight.pop(request.id, None)
+                    continue
+                sent_paths = sent_paths.intersection(request.paths)
+
+            if all(path in sent_paths for path in request.paths):
+                continue
+
+            executor = self._executor()
+            if executor is None:
+                self._report_executor_missing(scheduler, request, now=now)
+                continue
+
+            try:
+                result = await executor.execute(
+                    request,
+                    already_sent_paths=sent_paths,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._report_executor_error(
+                    scheduler,
+                    request,
+                    error=exc,
+                    sent_paths=sent_paths,
+                    now=now,
+                )
+                self._in_flight.pop(request.id, None)
+                continue
+
+            failed_paths = tuple(result.failed_paths)
+            if failed_paths:
+                self._report_failure(
+                    scheduler,
+                    request,
+                    reason=result.failure_reason or "acquisition_request_failed",
+                    failed_paths=failed_paths,
+                    now=now,
+                )
+
+            newly_sent = tuple(result.sent_paths)
+            if newly_sent:
+                self._in_flight[request.id] = (sent_paths.union(newly_sent), now)
+                self._report_sent(
+                    request,
+                    paths=newly_sent,
+                    # MOR-1533: dispatchable_requests(), matching this drain's
+                    # own dispatch view -- not the unfiltered
+                    # pending_requests(), which would also count entries this
+                    # drain will never send (withheld tx_only hints).
+                    pending_request_count=len(scheduler.dispatchable_requests()),
+                )

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -19,11 +19,11 @@ import datetime
 import inspect
 import logging
 import time
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
+from ..core.acquisition_drain import AcquisitionDrain
 from ..core.acquisition_scheduler import (
-    AcquisitionExecutionResult,
     AcquisitionExecutor,
     AcquisitionRequest,
     AcquisitionScheduler,
@@ -32,7 +32,6 @@ from ..core.acquisition_scheduler import (
     RadioStateModelService,
     StateFreshnessService,
     civ_acquisition_executor_for_provider,
-    derive_tx_active,
     provider_uses_civ_acquisition,
 )
 from ..profiles import RadioProfile
@@ -161,6 +160,7 @@ class RigctldServer:
         self._acquisition_executor: AcquisitionExecutor | None = None
         self._state_acquisition_drain_task: asyncio.Task[None] | None = None
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
+        self._acquisition_drain: AcquisitionDrain | None = None
         self._state_diagnostics = getattr(radio, "_state_diagnostics", None)
         # Per-client sliding window for rate limiting: client_id → timestamps
         self._rate_windows: dict[int, list[float]] = {}
@@ -557,147 +557,123 @@ class RigctldServer:
             link_healthy=False,
         )
 
-    async def _drain_state_acquisition_once(self) -> None:
-        scheduler = self._acquisition_scheduler
-        if scheduler is None:
-            return
-        now = time.monotonic()
-        # A Hamlib bridge owns the byte stream; the cadence reads this seat
-        # gained must not pollute it (MOR-166 slice 2). The deleted PTT
-        # re-read stood down on this exact flag. ``is True``, matching every
-        # sibling poller, so a duck-typed radio never quiesces by accident.
+    def _dispatchable_this_pass(
+        self,
+        pending: Sequence[AcquisitionRequest],
+    ) -> Sequence[AcquisitionRequest]:
+        """Return the requests this seat may put on the wire this pass.
+
+        A Hamlib bridge owns the byte stream; the cadence reads this seat
+        gained must not pollute it (MOR-166 slice 2). The deleted PTT
+        re-read stood down on this exact flag. ``is True``, matching every
+        sibling poller, so a duck-typed radio never quiesces by accident.
+
+        Only a request whose ``reasons`` is exactly the profile cadence
+        stands down; a client read that coalesced into it carries a second
+        reason and still reaches the wire.
+        """
+
         external_cat_owns_wire = (
             getattr(self._radio, "external_cat_session_active", False) is True
         )
-        store = self._state_store
-        # MOR-1532: keep the scheduler's tx_active cache current on this
-        # drain path too. Same ``derive_tx_active`` over the same canonical
-        # store as the freshness tick's own cadence call, so the two writers
-        # cannot disagree about one store state.
-        scheduler.note_tx_active(False if store is None else derive_tx_active(store))
-        # MOR-1533: dispatch must use the tx_active-gated view; crediting an
-        # already-sent answer (runtime._civ_rx, driven by this radio's own
-        # CI-V pump) uses the unfiltered pending_requests() instead, so an
-        # answer landing after de-key is never blinded by this gate.
-        pending = scheduler.dispatchable_requests()
-        pending_ids = {request.id for request in pending}
-        for request_id in tuple(self._acquisition_in_flight):
-            if request_id not in pending_ids:
-                del self._acquisition_in_flight[request_id]
+        if not external_cat_owns_wire:
+            return pending
+        return tuple(
+            request
+            for request in pending
+            if request.reasons != (_POLICY_CADENCE_REASON,)
+        )
 
-        for request in pending:
-            if external_cat_owns_wire and request.reasons == (_POLICY_CADENCE_REASON,):
-                continue
-            sent_paths: frozenset[FieldPath] = frozenset()
-            sent_at = 0.0
-            existing = self._acquisition_in_flight.get(request.id)
-            if existing is not None:
-                sent_paths, sent_at = existing
-                if self._acquisition_request_expired(
-                    request,
-                    sent_at=sent_at,
-                    now=now,
-                ):
-                    self._record_acquisition_failure(
-                        scheduler,
-                        request,
-                        reason="acquisition_request_timeout",
-                        failed_paths=sent_paths or frozenset(request.paths),
-                        now=now,
-                    )
-                    self._acquisition_in_flight.pop(request.id, None)
-                    continue
-                sent_paths = sent_paths.intersection(request.paths)
+    def _report_acquisition_executor_missing(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        now: float,
+    ) -> None:
+        if self._provider_uses_civ_executor(request.provider) and not isinstance(
+            self._radio, CivCommandCapable
+        ):
+            reason = "acquisition_executor_unavailable"
+        else:
+            reason = "acquisition_executor_missing"
+        self._record_acquisition_failure(
+            scheduler,
+            request,
+            reason=reason,
+            failed_paths=request.paths,
+            now=now,
+            kind=reason,
+        )
 
-            if all(path in sent_paths for path in request.paths):
-                continue
+    def _report_acquisition_executor_error(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        error: BaseException,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> None:
+        failed_paths = tuple(path for path in request.paths if path not in sent_paths)
+        unavailable = isinstance(error, _AcquisitionExecutorUnavailable)
+        reason = (
+            "acquisition_executor_unavailable"
+            if unavailable
+            else "acquisition_executor_error"
+        )
+        self._record_acquisition_failure(
+            scheduler,
+            request,
+            reason=reason,
+            failed_paths=failed_paths or request.paths,
+            now=now,
+            kind=reason if unavailable else "acquisition_request_failed",
+            error=str(error),
+            error_type=type(error).__name__,
+        )
 
-            executor = self._acquisition_executor
-            if executor is None:
-                if self._provider_uses_civ_executor(
-                    request.provider
-                ) and not isinstance(self._radio, CivCommandCapable):
-                    reason = "acquisition_executor_unavailable"
-                    kind = reason
-                else:
-                    reason = "acquisition_executor_missing"
-                    kind = reason
-                self._record_acquisition_failure(
-                    scheduler,
-                    request,
-                    reason=reason,
-                    failed_paths=request.paths,
-                    now=now,
-                    kind=kind,
-                )
-                continue
+    def _report_acquisition_sent(
+        self,
+        request: AcquisitionRequest,
+        *,
+        paths: tuple[FieldPath, ...],
+        pending_request_count: int,
+    ) -> None:
+        self._record_state_diagnostic(
+            "acquisition_request_sent",
+            "rigctld.server",
+            request_id=request.id,
+            paths=[str(path) for path in paths],
+            pending_request_count=pending_request_count,
+        )
 
-            try:
-                result: AcquisitionExecutionResult = await executor.execute(
-                    request,
-                    already_sent_paths=sent_paths,
-                )
-            except asyncio.CancelledError:
-                raise
-            except _AcquisitionExecutorUnavailable as exc:
-                failed_paths = tuple(
-                    path for path in request.paths if path not in sent_paths
-                )
-                self._record_acquisition_failure(
-                    scheduler,
-                    request,
-                    reason="acquisition_executor_unavailable",
-                    failed_paths=failed_paths or request.paths,
-                    now=now,
-                    kind="acquisition_executor_unavailable",
-                    error=str(exc),
-                    error_type=type(exc).__name__,
-                )
-                self._acquisition_in_flight.pop(request.id, None)
-                continue
-            except Exception as exc:
-                failed_paths = tuple(
-                    path for path in request.paths if path not in sent_paths
-                )
-                self._record_acquisition_failure(
-                    scheduler,
-                    request,
-                    reason="acquisition_executor_error",
-                    failed_paths=failed_paths or request.paths,
-                    now=now,
-                    error=str(exc),
-                    error_type=type(exc).__name__,
-                )
-                self._acquisition_in_flight.pop(request.id, None)
-                continue
-            failed_paths = tuple(result.failed_paths)
-            if failed_paths:
-                reason = result.failure_reason or "acquisition_request_failed"
-                self._record_acquisition_failure(
-                    scheduler,
-                    request,
-                    reason=reason,
-                    failed_paths=failed_paths,
-                    now=now,
-                )
+    def _state_acquisition_drain(self) -> AcquisitionDrain:
+        """Return this seat's drain, built on first use.
 
-            newly_sent = tuple(result.sent_paths)
-            if newly_sent:
-                self._acquisition_in_flight[request.id] = (
-                    sent_paths.union(newly_sent),
-                    now,
-                )
-                self._record_state_diagnostic(
-                    "acquisition_request_sent",
-                    "rigctld.server",
-                    request_id=request.id,
-                    paths=[str(path) for path in newly_sent],
-                    # MOR-1533: dispatchable_requests(), matching this
-                    # drain's own dispatch view -- not the unfiltered
-                    # pending_requests(), which would also count entries
-                    # this drain will never send (withheld tx_only hints).
-                    pending_request_count=len(scheduler.dispatchable_requests()),
-                )
+        Scheduler, executor and store are read through callables:
+        ``_bootstrap_state_acquisition`` attaches them after construction.
+        """
+
+        drain = self._acquisition_drain
+        if drain is None:
+            drain = AcquisitionDrain(
+                scheduler=lambda: self._acquisition_scheduler,
+                executor=lambda: self._acquisition_executor,
+                store=lambda: self._state_store,
+                in_flight=self._acquisition_in_flight,
+                expired=self._acquisition_request_expired,
+                dispatchable=self._dispatchable_this_pass,
+                report_failure=self._record_acquisition_failure,
+                report_executor_missing=self._report_acquisition_executor_missing,
+                report_executor_error=self._report_acquisition_executor_error,
+                report_sent=self._report_acquisition_sent,
+            )
+            self._acquisition_drain = drain
+        return drain
+
+    async def _drain_state_acquisition_once(self) -> None:
+        await self._state_acquisition_drain().run_once()
 
     async def start(self) -> None:
         """Start the TCP listener and initialise the command handler."""

--- a/tests/test_acquisition_drain.py
+++ b/tests/test_acquisition_drain.py
@@ -1,0 +1,361 @@
+"""Tests for src/rigplane/core/acquisition_drain.py (MOR-2293).
+
+Everything that differs between the two dispatching seats reaches the drain
+as an injected collaborator, so these tests drive it with stubs and assert
+on what those collaborators were handed. The seats' own behaviour is pinned
+in ``tests/test_rigctld_server.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from rigplane.core.acquisition_drain import AcquisitionDrain
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionExecutionResult,
+    AcquisitionPriority,
+    AcquisitionRequest,
+)
+from rigplane.core.state_acquisition_policy import AcquisitionPolicy
+from rigplane.core.state_pipeline_contracts import FieldPath
+from rigplane.rigctld.server import RigctldServer
+from rigplane.web.radio_poller import RadioPoller
+
+_FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
+_MODE = FieldPath.active("main", "freq_mode", "mode")
+
+
+def _request(
+    *,
+    request_id: str = "acq-1",
+    paths: tuple[FieldPath, ...] = (_FREQ,),
+    reasons: tuple[str, ...] = ("policy-cadence",),
+    deadline: float = 100.0,
+    max_age: float = 1.0,
+    timeout: float | None = None,
+) -> AcquisitionRequest:
+    return AcquisitionRequest(
+        id=request_id,
+        paths=paths,
+        priority=AcquisitionPriority.BACKGROUND,
+        reason=reasons[0],
+        reasons=reasons,
+        requested_at_monotonic=0.0,
+        deadline_monotonic=deadline,
+        max_age=max_age,
+        timeout=timeout,
+        provider="icom_civ",
+        acquisition_method="poll",
+        policy=AcquisitionPolicy(),
+        capability_ids=tuple(str(path) for path in paths),
+    )
+
+
+def _never_expired(request: AcquisitionRequest, *, sent_at: float, now: float) -> bool:
+    return False
+
+
+def _always_expired(request: AcquisitionRequest, *, sent_at: float, now: float) -> bool:
+    return True
+
+
+class _StubScheduler:
+    """Only the two methods the drain calls on a scheduler."""
+
+    def __init__(self, pending: tuple[AcquisitionRequest, ...]) -> None:
+        self.pending = pending
+        self.tx_active_calls: list[bool] = []
+
+    def note_tx_active(self, tx_active: bool) -> None:
+        self.tx_active_calls.append(tx_active)
+
+    def dispatchable_requests(self) -> tuple[AcquisitionRequest, ...]:
+        return self.pending
+
+
+class _StubExecutor:
+    def __init__(
+        self,
+        *,
+        result: AcquisitionExecutionResult | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self.result = result or AcquisitionExecutionResult(sent_paths=(_FREQ,))
+        self.error = error
+        self.calls: list[tuple[AcquisitionRequest, frozenset[FieldPath]]] = []
+
+    async def execute(
+        self,
+        request: AcquisitionRequest,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> AcquisitionExecutionResult:
+        self.calls.append((request, already_sent_paths))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _Reports:
+    """Collects everything the drain hands back to its seat."""
+
+    def __init__(self) -> None:
+        self.failures: list[tuple[str, str, frozenset[FieldPath]]] = []
+        self.executor_missing: list[str] = []
+        self.executor_errors: list[tuple[str, str]] = []
+        self.sent: list[tuple[str, tuple[FieldPath, ...], int]] = []
+
+    def failure(
+        self,
+        scheduler: Any,
+        request: AcquisitionRequest,
+        *,
+        reason: str,
+        failed_paths: Any,
+        now: float,
+    ) -> None:
+        self.failures.append((request.id, reason, frozenset(failed_paths)))
+
+    def missing(
+        self, scheduler: Any, request: AcquisitionRequest, *, now: float
+    ) -> None:
+        self.executor_missing.append(request.id)
+
+    def error(
+        self,
+        scheduler: Any,
+        request: AcquisitionRequest,
+        *,
+        error: BaseException,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> None:
+        self.executor_errors.append((request.id, type(error).__name__))
+
+    def sent_report(
+        self,
+        request: AcquisitionRequest,
+        *,
+        paths: tuple[FieldPath, ...],
+        pending_request_count: int,
+    ) -> None:
+        self.sent.append((request.id, paths, pending_request_count))
+
+
+def _drain(
+    *,
+    scheduler: _StubScheduler,
+    reports: _Reports,
+    expired: Any = _never_expired,
+    in_flight: dict[str, tuple[frozenset[FieldPath], float]] | None = None,
+    executor: _StubExecutor | None = None,
+    dispatchable: Any = None,
+) -> AcquisitionDrain:
+    return AcquisitionDrain(
+        scheduler=lambda: cast(Any, scheduler),
+        executor=lambda: cast(Any, executor),
+        store=lambda: None,
+        in_flight=in_flight if in_flight is not None else {},
+        expired=expired,
+        dispatchable=dispatchable if dispatchable is not None else (lambda pend: pend),
+        report_failure=reports.failure,
+        report_executor_missing=reports.missing,
+        report_executor_error=reports.error,
+        report_sent=reports.sent_report,
+    )
+
+
+class TestAcquisitionDrainExpiry:
+    async def test_an_expired_request_is_reported_and_dropped_from_flight(
+        self,
+    ) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        in_flight = {request.id: (frozenset({_FREQ}), 10.0)}
+        executor = _StubExecutor()
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            expired=_always_expired,
+            in_flight=in_flight,
+            executor=executor,
+        )
+
+        await drain.run_once()
+
+        assert reports.failures == [
+            (request.id, "acquisition_request_timeout", frozenset({_FREQ}))
+        ]
+        assert in_flight == {}
+        assert executor.calls == [], "a timed-out request must not be re-sent"
+
+    async def test_a_late_dispatched_request_expires_for_rigctld_but_not_for_web(
+        self,
+    ) -> None:
+        """The injected expiry rule is load-bearing, not decoration.
+
+        rigctld expires a dispatched request at the earlier of its enqueue
+        deadline and ``sent_at + timeout``; the web poller expires it
+        ``max_age`` (or ``timeout``) seconds after the SEND, and its own
+        comment calls the ``min`` form a false timeout. A request that sat
+        queued past its enqueue deadline and was answered half a second
+        after dispatch separates them.
+        """
+
+        request = _request(deadline=1.0, max_age=1.0, timeout=None)
+        rigctld_expired = RigctldServer._acquisition_request_expired  # noqa: SLF001
+        web_expired = RadioPoller._acquisition_request_expired  # noqa: SLF001
+
+        assert rigctld_expired(request, sent_at=5.0, now=5.5) is True
+        assert web_expired(cast(Any, None), request, sent_at=5.0, now=5.5) is False
+
+        # Control: once the send-relative window itself elapses the two rules
+        # agree, so the split above is the rule and not the fixture.
+        assert rigctld_expired(request, sent_at=5.0, now=6.5) is True
+        assert web_expired(cast(Any, None), request, sent_at=5.0, now=6.5) is True
+
+
+class TestAcquisitionDrainDispatchEligibility:
+    async def test_an_ineligible_request_is_not_sent_but_keeps_its_ledger_entry(
+        self,
+    ) -> None:
+        """Eligibility gates dispatch only.
+
+        Ledger pruning runs over the unfiltered pending view, so a request
+        the seat declines to send this pass is not mistaken for one the
+        scheduler has completed.
+        """
+
+        cadence = _request(request_id="acq-cadence")
+        on_demand = _request(
+            request_id="acq-user", reasons=("policy-cadence", "user_read")
+        )
+        scheduler = _StubScheduler((cadence, on_demand))
+        reports = _Reports()
+        executor = _StubExecutor()
+        in_flight = {cadence.id: (frozenset({_FREQ}), 10.0)}
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            in_flight=in_flight,
+            executor=executor,
+            dispatchable=lambda pending: tuple(
+                request for request in pending if request.reasons != ("policy-cadence",)
+            ),
+        )
+
+        await drain.run_once()
+
+        assert [call[0].id for call in executor.calls] == ["acq-user"]
+        assert cadence.id in in_flight, (
+            "the cadence request is still pending; declining to send it this "
+            "pass must not evict its in-flight record"
+        )
+
+
+class TestAcquisitionDrainExecutor:
+    async def test_missing_executor_is_reported_and_nothing_is_sent(self) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        drain = _drain(scheduler=scheduler, reports=reports, executor=None)
+
+        await drain.run_once()
+
+        assert reports.executor_missing == [request.id]
+        assert reports.sent == []
+
+    async def test_executor_exception_is_reported_and_the_ledger_entry_dropped(
+        self,
+    ) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        in_flight = {request.id: (frozenset(), 10.0)}
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            in_flight=in_flight,
+            executor=_StubExecutor(error=RuntimeError("port closed")),
+        )
+
+        await drain.run_once()
+
+        assert reports.executor_errors == [(request.id, "RuntimeError")]
+        assert in_flight == {}
+
+    async def test_executor_cancellation_propagates(self) -> None:
+        """Cancellation is the drain task stopping, not a request failing."""
+
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            executor=_StubExecutor(error=asyncio.CancelledError()),
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await drain.run_once()
+        assert reports.executor_errors == []
+
+    async def test_sent_paths_accumulate_and_the_sent_report_counts_dispatchable(
+        self,
+    ) -> None:
+        request = _request(paths=(_FREQ, _MODE))
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            in_flight=in_flight,
+            executor=_StubExecutor(
+                result=AcquisitionExecutionResult(
+                    sent_paths=(_FREQ,),
+                    failed_paths=(_MODE,),
+                    failure_reason="no_civ_query_mapping",
+                )
+            ),
+        )
+
+        await drain.run_once()
+
+        assert reports.sent == [(request.id, (_FREQ,), 1)]
+        assert in_flight[request.id][0] == frozenset({_FREQ})
+        assert reports.failures == [
+            (request.id, "no_civ_query_mapping", frozenset({_MODE}))
+        ]
+
+
+class TestAcquisitionDrainLedger:
+    async def test_a_request_the_scheduler_no_longer_pends_is_pruned(self) -> None:
+        scheduler = _StubScheduler(())
+        reports = _Reports()
+        in_flight = {"acq-gone": (frozenset({_FREQ}), 10.0)}
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            expired=_always_expired,
+            in_flight=in_flight,
+        )
+
+        await drain.run_once()
+
+        assert in_flight == {}
+        assert reports.failures == [], "a credited request is not a failure"
+
+    async def test_tx_active_is_refreshed_from_the_store_every_pass(self) -> None:
+        """MOR-1532: the drain, not the seat, keeps the cached fact current."""
+
+        scheduler = _StubScheduler(())
+        drain = _drain(scheduler=scheduler, reports=_Reports())
+
+        await drain.run_once()
+
+        assert scheduler.tx_active_calls == [False]

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -16,6 +16,7 @@ import asyncio
 import time
 from collections.abc import AsyncIterator
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -58,6 +59,7 @@ from rigplane.rigctld.contract import (
     RigctldResponse,
 )
 from rigplane.rigctld.server import RigctldServer, run_rigctld_server
+from rigplane.web.radio_poller import RadioPoller
 from rigplane.profiles import resolve_radio_profile
 from rigplane.types import Mode
 
@@ -2348,3 +2350,164 @@ async def test_standalone_rigctld_coalesces_meter_bursts_and_the_tick_releases_t
 
     assert radio._state_store.snapshot().field(swr).value == 1.9
     assert coalescer.diagnostics()["pendingSampleCount"] == 0
+
+
+# ---------------------------------------------------------------------------
+# State-acquisition drain policies (MOR-2293)
+# ---------------------------------------------------------------------------
+
+
+class _SilentAcquisitionExecutor:
+    """Reports every path as sent and never answers — a lost read."""
+
+    def __init__(self) -> None:
+        self.calls: list[AcquisitionRequest] = []
+
+    async def execute(
+        self,
+        request: AcquisitionRequest,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> AcquisitionExecutionResult:
+        self.calls.append(request)
+        return AcquisitionExecutionResult(
+            sent_paths=tuple(
+                path for path in request.paths if path not in already_sent_paths
+            )
+        )
+
+
+class TestStateAcquisitionDrainPolicies:
+    """The two collaborators the shared ``AcquisitionDrain`` takes."""
+
+    async def test_a_timed_out_request_is_terminal_even_on_a_healthy_civ_link(
+        self, cfg: RigctldConfig
+    ) -> None:
+        """rigctld does NOT get MOR-874's healthy-link grace.
+
+        The web poller holds a healthy-link expiry in flight and withholds
+        it from the scheduler's failure accounting; rigctld reports every
+        timeout with ``link_healthy=False`` — the MOR-874 comment at
+        ``_record_acquisition_failure`` says so on purpose.
+
+        The radio is given the attributes the web probe reads, and the probe
+        itself is asked (unbound, on this radio) to confirm it calls the
+        link healthy: without that control this test would also pass on a
+        radio that looks broken to both seats.
+        """
+
+        freq = FieldPath.active("main", "freq_mode", "freq_hz")
+        radio = _ProfiledStandaloneRadio(
+            profile=type(
+                "Profile", (), {"state_acquisition": _acquisition_profile(freq)}
+            )()
+        )
+        executor = _SilentAcquisitionExecutor()
+        radio._acquisition_executor = executor
+        recorder = StateDiagnosticsRecorder(enabled=True)
+        radio._state_diagnostics = recorder
+
+        fake_now = [1000.0]
+        with patch("time.monotonic", side_effect=lambda: fake_now[0]):
+            srv = RigctldServer(radio, cfg)
+            srv._bootstrap_state_acquisition()
+            scheduler = srv._acquisition_scheduler
+            service = srv._state_freshness_service
+            assert scheduler is not None
+            assert service is not None
+
+            service.tick(now=fake_now[0])
+            await srv._drain_state_acquisition_once()
+            assert executor.calls, "nothing was dispatched, so nothing can time out"
+            assert srv._acquisition_in_flight != {}
+
+            # Well past every deadline the queued request carries, with the
+            # link demonstrably alive: a CI-V frame landed this instant.
+            fake_now[0] += 3600.0
+            radio._civ_recovering = False
+            radio._last_civ_data_received = fake_now[0]
+            radio._civ_ready_idle_timeout = 2.0
+            probe = RadioPoller._civ_link_healthy  # noqa: SLF001
+            assert probe(cast(Any, SimpleNamespace(_radio=radio)), now=fake_now[0]), (
+                "premise failed: the web poller's own probe does not call this "
+                "link healthy, so this test would not detect the grace"
+            )
+
+            await srv._drain_state_acquisition_once()
+
+        assert srv._acquisition_in_flight == {}, (
+            "the timed-out request stayed in flight — rigctld picked up the "
+            "MOR-874 healthy-link grace"
+        )
+        assert scheduler.diagnostics()["failureCountByReason"] == {
+            "acquisition_request_timeout": 1
+        }, (
+            "the scheduler did not count the timeout — it was reported with "
+            "link_healthy=True, which is the web seat's grace, not rigctld's rule"
+        )
+        timeouts = [
+            event
+            for event in recorder.events()
+            if event.details.get("reason") == "acquisition_request_timeout"
+        ]
+        assert len(timeouts) == 1
+        assert "grace_expired" not in timeouts[0].details
+
+    async def test_external_cat_stand_down_selects_on_reasons_not_on_the_request(
+        self, cfg: RigctldConfig
+    ) -> None:
+        """The dispatch-eligibility filter stays as narrow as it is today.
+
+        It drops a request whose ``reasons`` is exactly
+        ``("policy-cadence",)`` and nothing else: a cadence request a client
+        read coalesced into carries a second reason and must survive, and so
+        must background work queued under another reason
+        (``prime_unobserved``).
+        """
+
+        ptt = FieldPath.global_("tx_state", "ptt")
+        profile = resolve_radio_profile(model="IC-7300")
+        clock = FreshnessClock(start=time.monotonic() + 60.0)
+        store = StateStore(freshness_clock=clock)
+        radio = _CadenceRecordingRadio(profile=profile, store=store, clock=clock)
+        srv = RigctldServer(radio, cfg)
+        srv._bootstrap_state_acquisition()
+        scheduler = srv._acquisition_scheduler
+        service = srv._state_freshness_service
+        assert scheduler is not None
+        assert service is not None
+
+        service.tick(now=clock.now())
+        queued = scheduler.ensure_fresh(
+            (ptt,),
+            max_age=1.0,
+            priority=AcquisitionPriority.USER,
+            reason="user_read",
+        )
+        assert queued.status is AcquisitionStatus.QUEUED
+        pending = scheduler.dispatchable_requests()
+        cadence_only = tuple(
+            request for request in pending if request.reasons == ("policy-cadence",)
+        )
+        coalesced = tuple(
+            request
+            for request in pending
+            if "policy-cadence" in request.reasons and "user_read" in request.reasons
+        )
+        assert cadence_only, "fixture queued no cadence-only request"
+        assert coalesced, "fixture queued no coalesced client read"
+
+        radio.external_cat_session_active = False
+        assert srv._dispatchable_this_pass(pending) == pending
+
+        radio.external_cat_session_active = True
+        filtered_ids = {request.id for request in srv._dispatchable_this_pass(pending)}
+        assert filtered_ids.isdisjoint({request.id for request in cadence_only}), (
+            "the cadence did not stand down while an external CAT session owns the wire"
+        )
+        for request in coalesced:
+            assert request.id in filtered_ids, (
+                "a client read that coalesced into the standing cadence "
+                "request was swallowed by the external-CAT stand-down"
+            )
+        assert len(filtered_ids) == len(pending) - len(cadence_only)


### PR DESCRIPTION
Part 3a of MOR-2293 (slice 3 of epic MOR-2260). Introduces `core/acquisition_drain.py` and migrates the rigctld seat onto it. The web poller keeps its own drain; part 3b migrates it.

## Why this is one unit of work

4 files, 999 changed lines — over the 6-file/600-line soft threshold, one line under the hard ceiling. A module with no caller is an orphan under `CLAUDE.md`'s scope discipline and proves nothing about the abstraction, so the new class and its first seat land together. The two test files are the coverage that makes the migration checkable; splitting them out would land the change unpinned.

## What is injected, and why two collaborators rather than one

- **Expiry rule.** rigctld expires a dispatched request at the earlier of its enqueue deadline and `sent_at + timeout` (`RigctldServer._acquisition_request_expired`, unchanged and passed in as-is). The web poller measures from the send, and its own comment calls the `min` form a false timeout under load. Both must remain expressible.
- **Dispatch eligibility.** `RigctldServer._dispatchable_this_pass` stands the profile cadence down while an external CAT session owns the byte stream. That decides *whether to send*, not *when to give up*; no expiry rule can express it. The filter drops only a request whose `reasons` is exactly `("policy-cadence",)` — a wider version of this guard cost a blocked review once, and the narrowness is now pinned twice.

Four reporting hooks are injected as well, because the seats record different diagnostic sources and different reasons for a missing or failing executor.

**MOR-874's healthy-link grace is not modelled.** An earlier revision of this PR carried a non-terminal expiry verdict for it. It had no production caller here and was cut: 3b adds that path together with the web poller that calls it, and with web's real requirements in hand.

## rigctld behaviour preserved exactly

Including the two divergences from the web seat that carry no comment and no test on either side, both left alone deliberately:

- rigctld catches executor exceptions (`_AcquisitionExecutorUnavailable` and generic `Exception`) and records a diagnostic; the web drain has no `try/except`.
- rigctld's CI-V sends pass neither `priority` nor `wait_dispatch`, so they fall through to `send_civ`'s `Priority.NORMAL` / `wait_dispatch=True` — where the web sender uses `Priority.BACKGROUND, wait_dispatch=False` (MOR-497i/ii). Very likely wrong for rigctld; it is a live behaviour change to a shipping seat and belongs in its own change with its own pin.

Also unchanged: the `acquisition_executor_unavailable` / `_missing` split and the flat 0.05 s drain cadence. `_drain_state_acquisition_once` survives as a one-line delegator, so all three existing call sites in `tests/test_rigctld_server.py` are untouched — that file is +163/−0.

## New coverage

- **rigctld does not get MOR-874's healthy-link grace.** Nothing pinned this before: `git grep -E "MOR-874|link_healthy" 9618ef4f -- tests/test_rigctld_server.py` finds nothing, while the same grep against `tests/test_radio_poller_coverage.py` at the same ref finds 6 — the control that makes the empty result mean something. The new test gives the radio the attributes web's own probe reads and asserts (unbound, on that radio) that the probe calls the link healthy, so the test cannot pass on a radio that merely looks broken to both seats.
- **The two expiry rules are distinguishable**, with a control at the point where they agree again.
- **The eligibility filter selects on `reasons`**, not on the request: a coalesced client read survives an external-CAT stand-down.

## Gates (at `289348e8`)

- `uv run pytest tests/ -n auto -q --tb=short --timeout=300 --timeout-method=thread`, run **locally in the branch worktree** → **14862 passed, 224 skipped, 15 xfailed**, 0 failures.
- The same suite in **CI quick at this exact head** → **14866 passed, 220 skipped, 15 xfailed**, 0 failures. Same total of 15086 collected either way; the four-test difference is environment-dependent skipping, not a behavioural delta. CI is the measurement of record — the local line is kept only to say what the author actually ran.
- `uv run ruff check src/ tests/` → clean. `uv run ruff format --check src/ tests/` → 715 files already formatted.
- `uv run lint-imports` → 5 contracts kept, 0 broken.
- `uv run mypy --strict src/rigplane/web` → no issues in 26 files.
- Parity set (8 named tests) → 8 passed, none modified.

## Mutation evidence

Re-derived at this head. Each mutation applied alone and reverted; every new test has at least one edit that reddens it.

| mutation | tests killed |
|---|---|
| rigctld reports timeouts with `link_healthy=True` | `test_a_timed_out_request_is_terminal_even_on_a_healthy_civ_link` |
| eligibility widened to `_POLICY_CADENCE_REASON in request.reasons` | `test_external_cat_stand_down_selects_on_reasons_not_on_the_request` + existing `test_external_cat_session_stands_the_cadence_down_but_not_a_user_read` |
| rigctld's expiry rule replaced by web's send-relative rule | `test_a_late_dispatched_request_expires_for_rigctld_but_not_for_web` |
| an expired request keeps its ledger entry | `test_an_expired_request_is_reported_and_dropped_from_flight`, `test_a_timed_out_request_is_terminal_even_on_a_healthy_civ_link` |
| ledger pruned against the dispatch-filtered view | `test_an_ineligible_request_is_not_sent_but_keeps_its_ledger_entry` |
| missing executor skipped silently | `test_missing_executor_is_reported_and_nothing_is_sent` + 2 existing rigctld tests |
| `except BaseException: continue` around the executor | `test_executor_exception_is_reported_and_the_ledger_entry_dropped`, `test_executor_cancellation_propagates` |
| `_report_sent` call deleted | `test_sent_paths_accumulate_and_the_sent_report_counts_dispatchable` |
| ledger never pruned | `test_a_request_the_scheduler_no_longer_pends_is_pruned` |
| `note_tx_active` not called | `test_tx_active_is_refreshed_from_the_store_every_pass` |

**How two of these were nearly recorded as false negatives.** An earlier batched run reported the `except BaseException` mutation and the `_report_sent` mutation as killing *nothing*. Both results were artifacts of the harness, not of the tests: the first swallowed `CancelledError`, which hung the rigctld suite until `pytest-timeout` killed the process before any `FAILED` line could print; the second was a patch that produced a `SyntaxError`, so the module never imported and the run ended in a collection error. A run that cannot emit a `FAILED` line reports "killed nothing" for the same reason whether the test is worthless or the harness is broken. Re-running each mutation in isolation, with the summary line read rather than only the `FAILED` lines, is what separated them. The `except BaseException` row above is measured against `tests/test_acquisition_drain.py` alone for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

