### PR TITLE
refactor(MOR-2293): migrate the web poller's drain onto AcquisitionDrain

### DIFF
--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -16,6 +16,13 @@ Injected, because the seats differ deliberately:
 
 The reporting hooks are injected for the same reason: the seats record
 different diagnostic sources and different executor-failure reasons.
+
+Two hooks are optional, and rigctld injects neither. ``report_expiry`` lets
+a seat report a fired deadline itself and answer whether the request is
+finished with: MOR-874's healthy-link grace holds a web request in flight so
+a late answer can still credit it, where rigctld's every timeout is
+terminal. ``on_forget`` names the request ids the drain drops from the
+ledger, which is what keeps the web seat's grace clock from outliving them.
 """
 
 from __future__ import annotations
@@ -37,6 +44,7 @@ from .state_store import StateStore
 __all__ = [
     "AcquisitionDrain",
     "AcquisitionExpiryPolicy",
+    "AcquisitionExpiryReport",
     "InFlightLedger",
 ]
 
@@ -90,6 +98,19 @@ class AcquisitionExecutorErrorReport(Protocol):
     ) -> None: ...
 
 
+class AcquisitionExpiryReport(Protocol):
+    """Report one fired deadline; return whether it ends the request."""
+
+    def __call__(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> bool: ...
+
+
 class AcquisitionSentReport(Protocol):
     def __call__(
         self,
@@ -118,6 +139,8 @@ class AcquisitionDrain:
         report_executor_missing: AcquisitionExecutorMissingReport,
         report_executor_error: AcquisitionExecutorErrorReport,
         report_sent: AcquisitionSentReport,
+        report_expiry: AcquisitionExpiryReport | None = None,
+        on_forget: Callable[[str], None] | None = None,
     ) -> None:
         self._scheduler = scheduler
         self._executor = executor
@@ -129,6 +152,36 @@ class AcquisitionDrain:
         self._report_executor_missing = report_executor_missing
         self._report_executor_error = report_executor_error
         self._report_sent = report_sent
+        self._report_expiry = report_expiry
+        self._on_forget = on_forget
+
+    def _forget(self, request_id: str) -> None:
+        """Drop one ledger entry and tell the seat it is gone."""
+
+        self._in_flight.pop(request_id, None)
+        if self._on_forget is not None:
+            self._on_forget(request_id)
+
+    def _expiry_is_terminal(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> bool:
+        if self._report_expiry is not None:
+            return self._report_expiry(
+                scheduler, request, sent_paths=sent_paths, now=now
+            )
+        self._report_failure(
+            scheduler,
+            request,
+            reason="acquisition_request_timeout",
+            failed_paths=sent_paths or frozenset(request.paths),
+            now=now,
+        )
+        return True
 
     async def run_once(self) -> None:
         scheduler = self._scheduler()
@@ -149,7 +202,7 @@ class AcquisitionDrain:
         pending_ids = {request.id for request in pending}
         for request_id in tuple(self._in_flight):
             if request_id not in pending_ids:
-                del self._in_flight[request_id]
+                self._forget(request_id)
 
         # Eligibility is asked once per pass, over the unfiltered pending view
         # above: a request the seat declines to send is still pending, and its
@@ -160,15 +213,14 @@ class AcquisitionDrain:
             if existing is not None:
                 sent_paths, sent_at = existing
                 if self._expired(request, sent_at=sent_at, now=now):
-                    self._report_failure(
-                        scheduler,
-                        request,
-                        reason="acquisition_request_timeout",
-                        failed_paths=sent_paths or frozenset(request.paths),
-                        now=now,
-                    )
-                    self._in_flight.pop(request.id, None)
-                    continue
+                    # A seat may hold the request in flight instead (MOR-874).
+                    # Falling through then re-sends only what never went out,
+                    # which is what the intersection below leaves.
+                    if self._expiry_is_terminal(
+                        scheduler, request, sent_paths=sent_paths, now=now
+                    ):
+                        self._forget(request.id)
+                        continue
                 sent_paths = sent_paths.intersection(request.paths)
 
             if all(path in sent_paths for path in request.paths):
@@ -194,7 +246,7 @@ class AcquisitionDrain:
                     sent_paths=sent_paths,
                     now=now,
                 )
-                self._in_flight.pop(request.id, None)
+                self._forget(request.id)
                 continue
 
             failed_paths = tuple(result.failed_paths)

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3596,23 +3596,29 @@ class RadioPoller:
         sent_paths: frozenset[FieldPath],
         now: float,
     ) -> None:
-        """Record a send that raised, and re-raise what ``_run`` acts on.
+        """Record a send that raised, then re-raise it unchanged.
 
         Before MOR-2293 this seat had no ``try/except`` here, so every
         executor exception reached the per-``_send_query`` handlers in
-        ``_run``. Those are not merely a log: a connection or timeout error
-        is how ``_run`` learns the link is down (its backoff branch, MOR-1440's
-        dead-serial-link branch, and the reconnection probe that clears the
-        backoff on a ``_send_query()`` that returns). Once a scheduler is
-        attached ``_send_query`` has no other body, so swallowing these would
-        make that probe always succeed. They are recorded here and re-raised;
-        raising also skips the drain's forget step, leaving the ledger entry
-        exactly as the pre-change code left it. Pinned by
-        test_send_query_still_raises_a_dead_link_error_out_of_the_drain.
+        ``_run``. Those are not merely a log: they are how ``_run`` learns the
+        link is down — its ``(ConnectionError, RadioConnectionError)`` backoff
+        branch, MOR-1440's branch for any exception raised while the radio is
+        disconnected, and the reconnection probe that clears the backoff on a
+        ``_send_query()`` that returns. Once a scheduler is attached
+        ``_send_query`` has no other body, so swallowing anything here would
+        make that probe always succeed and announce a restored connection to a
+        radio that is still down.
 
-        Anything else is recorded and swallowed — the shared drain's rule —
-        which is this migration's one behaviour change on this path. Pinned
-        by test_executor_exception_is_recorded_and_drops_the_in_flight_entry.
+        So every exception is recorded and re-raised, with no type list: which
+        exceptions can reach here is decided by call sites downstream of
+        ``_civ``, and a list kept in this file would neither derive from them
+        nor redden when they change. Raising also skips the drain's forget
+        step, leaving the ledger entry exactly as the pre-change code left it.
+        Pinned by
+        test_send_query_still_raises_any_executor_failure_out_of_the_drain.
+
+        What the migration adds over the pre-change path is this diagnostic
+        and the scheduler failure report; what it takes away is nothing.
         """
 
         failed_paths = (
@@ -3635,14 +3641,7 @@ class RadioPoller:
             failed_paths=failed_paths,
             now=now,
         )
-        # The same two pairs ``_run`` itself matches on, one line apart, for
-        # the queued-command path (``(TimeoutError, RigplaneTimeoutError)``)
-        # and for ``_send_query`` (``(ConnectionError, RadioConnectionError)``).
-        if isinstance(
-            error,
-            (ConnectionError, RadioConnectionError, TimeoutError, RigplaneTimeoutError),
-        ):
-            raise error
+        raise error
 
     def _report_acquisition_sent(
         self,

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -77,6 +77,7 @@ from ..commands.commander import Priority
 from ..core.command_service import (
     CommandService,
 )
+from ..core.acquisition_drain import AcquisitionDrain
 from ..core.command_dispatch import execute_command_intent
 from ..core.acquisition_scheduler import (
     AcquisitionExecutor,
@@ -85,7 +86,6 @@ from ..core.acquisition_scheduler import (
     AcquisitionRequest,
     AcquisitionScheduler,
     civ_acquisition_executor_for_provider,
-    derive_tx_active,
 )
 from ..core.state_pipeline_contracts import (
     CommandIntent,
@@ -605,6 +605,7 @@ class RadioPoller:
         )
         self._acquisition_executor = acquisition_executor
         self._acquisition_in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
+        self._acquisition_drain: AcquisitionDrain | None = None
         # MOR-874: monotonic time of the FIRST healthy-link deadline expiry per
         # in-flight request id. Seeds the bounded grace window
         # (``_ACQUISITION_HEALTHY_GRACE_SECONDS``) after which a still-uncredited
@@ -3474,167 +3475,216 @@ class RadioPoller:
             ready_timeout = 2.0
         return (now - float(last_civ)) <= float(ready_timeout)
 
-    async def _send_scheduler_requests(self) -> None:
-        scheduler = self._acquisition_scheduler
-        if scheduler is None:
-            return
-        now = time.monotonic()
-        # MOR-2280: this drain no longer calls ``due_requests`` -- the
-        # profile's cadence is emitted by ``StateFreshnessService.tick``, and
-        # this method dispatches what it finds queued.
-        #
-        # It must still refresh the cached transmit fact, which that call used
-        # to keep current. This loop drains every 0.025 s (LAN) against a
-        # 0.05 s tick, so most drains land BETWEEN ticks; gating on the fact
-        # the last tick left would miss a de-key by up to one tick and send
-        # the tx_only group (power/SWR/ALC/comp) during confirmed RX -- the
-        # MOR-1525 SWR-flap loop. Same ``derive_tx_active`` over the same
-        # canonical store as the tick's own cadence call and as
-        # ``RigctldServer._drain_state_acquisition_once``, so the writers
-        # cannot disagree about one store state. See note_tx_active()'s
-        # docstring, and
-        # test_drain_between_ticks_gates_tx_only_on_the_fact_as_of_the_drain.
-        scheduler.note_tx_active(derive_tx_active(self._state_store))
-        # MOR-1533: dispatch must use the tx_active-gated view. Crediting an
-        # already-sent answer (runtime._civ_rx) uses the unfiltered
-        # pending_requests() instead, so an answer landing after de-key is
-        # never blinded by this gate -- see dispatchable_requests()'s
-        # docstring.
-        pending = scheduler.dispatchable_requests()
-        pending_ids = {request.id for request in pending}
-        for request_id in tuple(self._acquisition_in_flight):
-            if request_id not in pending_ids:
-                del self._acquisition_in_flight[request_id]
-                # MOR-874: request left flight (credited / dropped) — drop its
-                # grace bookkeeping so the map never leaks.
-                self._acquisition_healthy_grace_started.pop(request_id, None)
+    def _record_acquisition_failure(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        reason: str,
+        failed_paths: tuple[FieldPath, ...] | frozenset[FieldPath],
+        now: float,
+    ) -> None:
+        self._record_state_diagnostic(
+            "acquisition_request_failed",
+            "web.radio_poller",
+            request_id=request.id,
+            paths=[str(path) for path in failed_paths],
+            reason=reason,
+            provider=request.provider,
+        )
+        scheduler.record_acquisition_failure(
+            request,
+            reason=reason,
+            failed_paths=failed_paths,
+            now=now,
+        )
 
-        for request in pending:
-            sent_paths: frozenset[FieldPath] = frozenset()
-            sent_at = 0.0
-            existing = self._acquisition_in_flight.get(request.id)
-            if existing is not None:
-                sent_paths, sent_at = existing
-                if self._acquisition_request_expired(
-                    request,
-                    sent_at=sent_at,
-                    now=now,
-                ):
-                    # MOR-874: when the deadline fires but the CI-V link is
-                    # healthy, this is (usually) a false timeout — the radio
-                    # answered and the deadline raced under load. Suppress the
-                    # false-timeout -> adaptive-decay chain and keep the request
-                    # in flight so the returning observation can credit it.
-                    #
-                    # But the health gate reads the GLOBAL last-CI-V timestamp,
-                    # so under external-CAT load it reads healthy ~permanently;
-                    # a request whose specific answer is genuinely lost would
-                    # then be pinned forever. Bound the suppression with a grace
-                    # window: once it elapses with the request still uncredited,
-                    # fall back to a REAL timeout (drop it so the scheduler
-                    # re-queues/re-sends and normal failure accounting/decay
-                    # applies).
-                    link_healthy = self._civ_link_healthy(now=now)
-                    grace_expired = False
-                    if link_healthy:
-                        grace_started = self._acquisition_healthy_grace_started.get(
-                            request.id
-                        )
-                        if grace_started is None:
-                            self._acquisition_healthy_grace_started[request.id] = now
-                            grace_started = now
-                        if now - grace_started >= _ACQUISITION_HEALTHY_GRACE_SECONDS:
-                            grace_expired = True
-                    # Treat a grace-expired healthy expiry exactly like an
-                    # unhealthy one: count it, drop it, let cadence advance.
-                    timeout_is_real = (not link_healthy) or grace_expired
-                    self._record_state_diagnostic(
-                        "acquisition_request_failed",
-                        "web.radio_poller",
-                        request_id=request.id,
-                        paths=[str(path) for path in request.paths],
-                        reason="acquisition_request_timeout",
-                        link_healthy=link_healthy,
-                        grace_expired=grace_expired,
-                    )
-                    scheduler.record_acquisition_failure(
-                        request,
-                        reason="acquisition_request_timeout",
-                        failed_paths=sent_paths or frozenset(request.paths),
-                        now=now,
-                        link_healthy=not timeout_is_real,
-                    )
-                    if timeout_is_real:
-                        self._acquisition_in_flight.pop(request.id, None)
-                        self._acquisition_healthy_grace_started.pop(request.id, None)
-                        continue
-                    # Healthy link, still within grace: leave in flight, skip
-                    # re-send this cycle (no extra CI-V traffic — important not
-                    # to compete with external CAT).
-                    sent_paths = sent_paths.intersection(request.paths)
-                    if all(path in sent_paths for path in request.paths):
-                        continue
-                else:
-                    sent_paths = sent_paths.intersection(request.paths)
+    def _report_acquisition_expiry(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> bool:
+        """Report one fired deadline; return whether it ends the request.
 
-            if all(path in sent_paths for path in request.paths):
-                continue
+        MOR-874: when the deadline fires but the CI-V link is healthy, this
+        is (usually) a false timeout — the radio answered and the deadline
+        raced under load. Suppress the false-timeout -> adaptive-decay chain
+        and keep the request in flight so the returning observation can
+        credit it.
 
-            executor = self._acquisition_executor
-            if executor is None:
-                self._record_state_diagnostic(
-                    "acquisition_executor_missing",
-                    "web.radio_poller",
-                    request_id=request.id,
-                    paths=[str(path) for path in request.paths],
-                    provider=request.provider,
-                )
-                scheduler.record_acquisition_failure(
-                    request,
-                    reason="acquisition_executor_missing",
-                    now=now,
-                )
-                continue
+        But the health gate reads the GLOBAL last-CI-V timestamp, so under
+        external-CAT load it reads healthy ~permanently; a request whose
+        specific answer is genuinely lost would then be pinned forever. Bound
+        the suppression with a grace window: once it elapses with the request
+        still uncredited, fall back to a REAL timeout (drop it so the
+        scheduler re-queues/re-sends and normal failure accounting/decay
+        applies).
 
-            result = await executor.execute(
-                request,
-                already_sent_paths=sent_paths,
+        rigctld injects no expiry report and keeps every timeout terminal —
+        see ``RigctldServer._record_acquisition_failure``'s MOR-874 comment
+        and test_a_timed_out_request_is_terminal_even_on_a_healthy_civ_link.
+        """
+
+        link_healthy = self._civ_link_healthy(now=now)
+        grace_expired = False
+        if link_healthy:
+            grace_started = self._acquisition_healthy_grace_started.get(request.id)
+            if grace_started is None:
+                self._acquisition_healthy_grace_started[request.id] = now
+                grace_started = now
+            if now - grace_started >= _ACQUISITION_HEALTHY_GRACE_SECONDS:
+                grace_expired = True
+        # Treat a grace-expired healthy expiry exactly like an unhealthy one:
+        # count it, drop it, let cadence advance.
+        timeout_is_real = (not link_healthy) or grace_expired
+        self._record_state_diagnostic(
+            "acquisition_request_failed",
+            "web.radio_poller",
+            request_id=request.id,
+            paths=[str(path) for path in request.paths],
+            reason="acquisition_request_timeout",
+            link_healthy=link_healthy,
+            grace_expired=grace_expired,
+        )
+        scheduler.record_acquisition_failure(
+            request,
+            reason="acquisition_request_timeout",
+            failed_paths=sent_paths or frozenset(request.paths),
+            now=now,
+            link_healthy=not timeout_is_real,
+        )
+        return timeout_is_real
+
+    def _forget_acquisition_grace(self, request_id: str) -> None:
+        """Drop the grace clock of a request the drain dropped (MOR-874).
+
+        Called wherever ``AcquisitionDrain`` removes a ledger entry, so the
+        map never outlives the flight it tracks.
+        """
+
+        self._acquisition_healthy_grace_started.pop(request_id, None)
+
+    def _report_acquisition_executor_missing(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        now: float,
+    ) -> None:
+        self._record_state_diagnostic(
+            "acquisition_executor_missing",
+            "web.radio_poller",
+            request_id=request.id,
+            paths=[str(path) for path in request.paths],
+            provider=request.provider,
+        )
+        scheduler.record_acquisition_failure(
+            request,
+            reason="acquisition_executor_missing",
+            now=now,
+        )
+
+    def _report_acquisition_executor_error(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        error: BaseException,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> None:
+        """Record a send that raised, instead of letting it leave the drain.
+
+        Before MOR-2293 this seat had no ``try/except`` here and the
+        exception unwound to ``_run``'s catch-all: no diagnostic, no failure
+        accounting, and the rest of the pass skipped. Pinned by
+        test_executor_exception_is_recorded_and_drops_the_in_flight_entry.
+        """
+
+        failed_paths = (
+            tuple(path for path in request.paths if path not in sent_paths)
+            or request.paths
+        )
+        self._record_state_diagnostic(
+            "acquisition_request_failed",
+            "web.radio_poller",
+            request_id=request.id,
+            paths=[str(path) for path in failed_paths],
+            reason="acquisition_executor_error",
+            provider=request.provider,
+            error=str(error),
+            error_type=type(error).__name__,
+        )
+        scheduler.record_acquisition_failure(
+            request,
+            reason="acquisition_executor_error",
+            failed_paths=failed_paths,
+            now=now,
+        )
+
+    def _report_acquisition_sent(
+        self,
+        request: AcquisitionRequest,
+        *,
+        paths: tuple[FieldPath, ...],
+        pending_request_count: int,
+    ) -> None:
+        self._record_state_diagnostic(
+            "acquisition_request_sent",
+            "web.radio_poller",
+            request_id=request.id,
+            paths=[str(path) for path in paths],
+            pending_request_count=pending_request_count,
+        )
+
+    def _state_acquisition_drain(self) -> AcquisitionDrain:
+        """Return this seat's drain, built on first use.
+
+        Scheduler and executor are read through callables: both are resolved
+        during ``__init__`` but the scheduler may also be attached to the
+        radio afterwards.
+
+        This seat sends everything the scheduler hands it. Its external-CAT
+        stand-down is the whole-iteration ``continue`` in ``_run``, which
+        holds back queued commands as well as reads, so no dispatch filter
+        belongs here.
+        """
+
+        drain = self._acquisition_drain
+        if drain is None:
+            drain = AcquisitionDrain(
+                scheduler=lambda: self._acquisition_scheduler,
+                executor=lambda: self._acquisition_executor,
+                store=lambda: self._state_store,
+                in_flight=self._acquisition_in_flight,
+                expired=self._acquisition_request_expired,
+                dispatchable=lambda pending: pending,
+                report_failure=self._record_acquisition_failure,
+                report_executor_missing=self._report_acquisition_executor_missing,
+                report_executor_error=self._report_acquisition_executor_error,
+                report_sent=self._report_acquisition_sent,
+                report_expiry=self._report_acquisition_expiry,
+                on_forget=self._forget_acquisition_grace,
             )
-            newly_sent = tuple(result.sent_paths)
-            failed_paths = tuple(result.failed_paths)
-            if failed_paths:
-                reason = result.failure_reason or "acquisition_request_failed"
-                self._record_state_diagnostic(
-                    "acquisition_request_failed",
-                    "web.radio_poller",
-                    request_id=request.id,
-                    paths=[str(path) for path in failed_paths],
-                    reason=reason,
-                    provider=request.provider,
-                )
-                scheduler.record_acquisition_failure(
-                    request,
-                    reason=reason,
-                    failed_paths=failed_paths,
-                    now=now,
-                )
+            self._acquisition_drain = drain
+        return drain
 
-            if newly_sent:
-                self._acquisition_in_flight[request.id] = (
-                    sent_paths.union(newly_sent),
-                    now,
-                )
-                self._record_state_diagnostic(
-                    "acquisition_request_sent",
-                    "web.radio_poller",
-                    request_id=request.id,
-                    paths=[str(path) for path in newly_sent],
-                    # MOR-1533: dispatchable_requests(), matching this
-                    # drain's own dispatch view -- not the unfiltered
-                    # pending_requests(), which would also count entries
-                    # this drain will never send (withheld tx_only hints).
-                    pending_request_count=len(scheduler.dispatchable_requests()),
-                )
+    async def _send_scheduler_requests(self) -> None:
+        # MOR-2280: this seat does not call ``due_requests`` -- the profile's
+        # cadence is emitted by ``StateFreshnessService.tick`` and a pass
+        # dispatches what it finds queued. The drain refreshes the cached
+        # transmit fact itself, which that call used to keep current: ``_run``
+        # waits at most ``_fast_interval`` (0.025 s on LAN) between passes
+        # against the freshness service's 0.05 s tick, so a pass usually lands
+        # BETWEEN ticks, and gating on the fact the last tick left would miss
+        # a de-key by up to one tick and send the tx_only group
+        # (power/SWR/ALC/comp) during confirmed RX -- the MOR-1525 SWR-flap
+        # loop. See
+        # test_drain_between_ticks_gates_tx_only_on_the_fact_as_of_the_drain.
+        await self._state_acquisition_drain().run_once()
 
     async def _send_query(self) -> None:
         if self._acquisition_scheduler is not None:

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3596,12 +3596,23 @@ class RadioPoller:
         sent_paths: frozenset[FieldPath],
         now: float,
     ) -> None:
-        """Record a send that raised, instead of letting it leave the drain.
+        """Record a send that raised, and re-raise what ``_run`` acts on.
 
-        Before MOR-2293 this seat had no ``try/except`` here and the
-        exception unwound to ``_run``'s catch-all: no diagnostic, no failure
-        accounting, and the rest of the pass skipped. Pinned by
-        test_executor_exception_is_recorded_and_drops_the_in_flight_entry.
+        Before MOR-2293 this seat had no ``try/except`` here, so every
+        executor exception reached the per-``_send_query`` handlers in
+        ``_run``. Those are not merely a log: a connection or timeout error
+        is how ``_run`` learns the link is down (its backoff branch, MOR-1440's
+        dead-serial-link branch, and the reconnection probe that clears the
+        backoff on a ``_send_query()`` that returns). Once a scheduler is
+        attached ``_send_query`` has no other body, so swallowing these would
+        make that probe always succeed. They are recorded here and re-raised;
+        raising also skips the drain's forget step, leaving the ledger entry
+        exactly as the pre-change code left it. Pinned by
+        test_send_query_still_raises_a_dead_link_error_out_of_the_drain.
+
+        Anything else is recorded and swallowed — the shared drain's rule —
+        which is this migration's one behaviour change on this path. Pinned
+        by test_executor_exception_is_recorded_and_drops_the_in_flight_entry.
         """
 
         failed_paths = (
@@ -3624,6 +3635,14 @@ class RadioPoller:
             failed_paths=failed_paths,
             now=now,
         )
+        # The same two pairs ``_run`` itself matches on, one line apart, for
+        # the queued-command path (``(TimeoutError, RigplaneTimeoutError)``)
+        # and for ``_send_query`` (``(ConnectionError, RadioConnectionError)``).
+        if isinstance(
+            error,
+            (ConnectionError, RadioConnectionError, TimeoutError, RigplaneTimeoutError),
+        ):
+            raise error
 
     def _report_acquisition_sent(
         self,

--- a/tests/test_acquisition_drain.py
+++ b/tests/test_acquisition_drain.py
@@ -102,11 +102,28 @@ class _StubExecutor:
 class _Reports:
     """Collects everything the drain hands back to its seat."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, expiry_is_terminal: bool = True) -> None:
         self.failures: list[tuple[str, str, frozenset[FieldPath]]] = []
         self.executor_missing: list[str] = []
         self.executor_errors: list[tuple[str, str]] = []
         self.sent: list[tuple[str, tuple[FieldPath, ...], int]] = []
+        self.expiries: list[tuple[str, frozenset[FieldPath]]] = []
+        self.forgotten: list[str] = []
+        self._expiry_is_terminal = expiry_is_terminal
+
+    def expiry(
+        self,
+        scheduler: Any,
+        request: AcquisitionRequest,
+        *,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> bool:
+        self.expiries.append((request.id, sent_paths))
+        return self._expiry_is_terminal
+
+    def forget(self, request_id: str) -> None:
+        self.forgotten.append(request_id)
 
     def failure(
         self,
@@ -153,6 +170,7 @@ def _drain(
     in_flight: dict[str, tuple[frozenset[FieldPath], float]] | None = None,
     executor: _StubExecutor | None = None,
     dispatchable: Any = None,
+    seat_expiry: bool = False,
 ) -> AcquisitionDrain:
     return AcquisitionDrain(
         scheduler=lambda: cast(Any, scheduler),
@@ -165,6 +183,8 @@ def _drain(
         report_executor_missing=reports.missing,
         report_executor_error=reports.error,
         report_sent=reports.sent_report,
+        report_expiry=reports.expiry if seat_expiry else None,
+        on_forget=reports.forget,
     )
 
 
@@ -359,3 +379,172 @@ class TestAcquisitionDrainLedger:
         await drain.run_once()
 
         assert scheduler.tx_active_calls == [False]
+
+
+class TestAcquisitionDrainSeatOwnedExpiry:
+    """The non-terminal expiry seam, whose caller is MOR-874's grace (3b).
+
+    A seat may report a fired deadline itself and say the request is not
+    finished with: the web poller holds a healthy-link expiry in flight so a
+    late answer can still credit it. A seat that injects no ``report_expiry``
+    keeps the terminal rule pinned in ``TestAcquisitionDrainExpiry``.
+    """
+
+    async def test_a_non_terminal_expiry_keeps_the_ledger_entry(self) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports(expiry_is_terminal=False)
+        in_flight = {request.id: (frozenset({_FREQ}), 10.0)}
+        executor = _StubExecutor()
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            expired=_always_expired,
+            in_flight=in_flight,
+            executor=executor,
+            seat_expiry=True,
+        )
+
+        await drain.run_once()
+
+        assert reports.expiries == [(request.id, frozenset({_FREQ}))]
+        assert in_flight == {request.id: (frozenset({_FREQ}), 10.0)}
+        assert reports.forgotten == []
+        assert executor.calls == [], "every path was already sent; nothing to re-send"
+        assert reports.failures == [], (
+            "the seat reported this expiry itself; the drain must not also "
+            "report it through the ordinary failure hook"
+        )
+
+    async def test_a_non_terminal_expiry_still_sends_the_paths_never_dispatched(
+        self,
+    ) -> None:
+        """Holding a request in flight is not the same as skipping the pass.
+
+        Only the paths already on the wire are withheld. This is the branch
+        the terminal rule cannot reach, because it ``continue``s first.
+        """
+
+        request = _request(paths=(_FREQ, _MODE))
+        scheduler = _StubScheduler((request,))
+        reports = _Reports(expiry_is_terminal=False)
+        in_flight = {request.id: (frozenset({_FREQ}), 10.0)}
+        executor = _StubExecutor(result=AcquisitionExecutionResult(sent_paths=(_MODE,)))
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            expired=_always_expired,
+            in_flight=in_flight,
+            executor=executor,
+            seat_expiry=True,
+        )
+
+        await drain.run_once()
+
+        assert [call[1] for call in executor.calls] == [frozenset({_FREQ})]
+        assert in_flight[request.id][0] == frozenset({_FREQ, _MODE})
+
+    async def test_a_terminal_seat_expiry_drops_the_entry_without_a_second_report(
+        self,
+    ) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports(expiry_is_terminal=True)
+        in_flight = {request.id: (frozenset({_FREQ}), 10.0)}
+        executor = _StubExecutor()
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            expired=_always_expired,
+            in_flight=in_flight,
+            executor=executor,
+            seat_expiry=True,
+        )
+
+        await drain.run_once()
+
+        assert in_flight == {}
+        assert reports.forgotten == [request.id]
+        assert reports.failures == []
+        assert executor.calls == [], "a timed-out request must not be re-sent"
+
+
+class TestAcquisitionDrainForgetHook:
+    """``on_forget`` fires wherever the drain drops a ledger entry.
+
+    The web seat keeps a second per-request map (the MOR-874 grace clock)
+    alongside the ledger; an entry the drain drops for any reason must not
+    leave a stale clock behind. Each drop site is exercised separately
+    because they are three different statements in ``run_once``.
+    """
+
+    async def test_a_pruned_request_is_forgotten(self) -> None:
+        scheduler = _StubScheduler(())
+        reports = _Reports()
+        in_flight = {"acq-gone": (frozenset({_FREQ}), 10.0)}
+        drain = _drain(scheduler=scheduler, reports=reports, in_flight=in_flight)
+
+        await drain.run_once()
+
+        assert reports.forgotten == ["acq-gone"]
+
+    async def test_a_timed_out_request_is_forgotten(self) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        in_flight = {request.id: (frozenset({_FREQ}), 10.0)}
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            expired=_always_expired,
+            in_flight=in_flight,
+            executor=_StubExecutor(),
+        )
+
+        await drain.run_once()
+
+        assert reports.forgotten == [request.id]
+
+    async def test_a_request_whose_executor_raised_is_forgotten(self) -> None:
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        in_flight = {request.id: (frozenset(), 10.0)}
+        drain = _drain(
+            scheduler=scheduler,
+            reports=reports,
+            in_flight=in_flight,
+            executor=_StubExecutor(error=RuntimeError("port closed")),
+        )
+
+        await drain.run_once()
+
+        assert reports.forgotten == [request.id]
+
+    async def test_a_seat_that_injects_no_forget_hook_still_drains(self) -> None:
+        """rigctld injects neither new hook; the default must be inert."""
+
+        request = _request()
+        scheduler = _StubScheduler((request,))
+        reports = _Reports()
+        in_flight = {request.id: (frozenset({_FREQ}), 10.0)}
+        drain = AcquisitionDrain(
+            scheduler=lambda: cast(Any, scheduler),
+            executor=lambda: cast(Any, _StubExecutor()),
+            store=lambda: None,
+            in_flight=in_flight,
+            expired=_always_expired,
+            dispatchable=lambda pending: pending,
+            report_failure=reports.failure,
+            report_executor_missing=reports.missing,
+            report_executor_error=reports.error,
+            report_sent=reports.sent_report,
+        )
+
+        await drain.run_once()
+
+        assert in_flight == {}
+        assert reports.failures == [
+            (request.id, "acquisition_request_timeout", frozenset({_FREQ}))
+        ]
+        assert reports.forgotten == []

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -35,6 +35,7 @@ from rigplane.core.state_pipeline_contracts import (
     Observation,
     SourceMetadata,
 )
+from rigplane.core.state_diagnostics import StateDiagnosticsRecorder
 from rigplane.core.radio_protocol import RelativeVfoState
 from rigplane.core.state_store import FreshnessClock, FreshnessState, StateStore
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
@@ -877,6 +878,67 @@ async def test_healthy_link_uncredited_request_is_resent_and_eventually_fails() 
         rid in {r.id for r in scheduler.pending_requests()}
         for rid in poller._acquisition_healthy_grace_started  # noqa: SLF001
     )
+
+
+class _RaisingAcquisitionExecutor:
+    """Executor whose send fails the way a closed transport does."""
+
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+        self.calls = 0
+
+    async def execute(
+        self,
+        request: object,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> object:
+        self.calls += 1
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_executor_exception_is_recorded_and_drops_the_in_flight_entry() -> None:
+    """MOR-2293 3b: a raising executor no longer escapes the web drain.
+
+    Before the shared ``AcquisitionDrain``, this seat had no ``try/except``
+    around ``executor.execute``: the exception unwound to ``_run``'s
+    catch-all, nothing was recorded, the scheduler counted no failure, and
+    the drain never reached the rest of the pass. The shared drain catches
+    it, records a diagnostic, reports the failure and drops the ledger
+    entry. This pins the new behaviour, which the migration chose.
+    """
+
+    radio = _healthy_radio(last_civ=300.0)
+    first = FieldPath.receiver("main", "meters", "s_meter")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(first))
+    radio._acquisition_scheduler = scheduler
+    executor = _RaisingAcquisitionExecutor(RuntimeError("port closed"))
+    recorder = StateDiagnosticsRecorder(enabled=True)
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        acquisition_executor=executor,
+        diagnostics=recorder,
+    )
+    with patch("rigplane.web.radio_poller.time.monotonic", return_value=300.0):
+        _tick_cadence(poller, now=300.0)
+        await poller._send_scheduler_requests()  # noqa: SLF001
+
+    assert executor.calls == 1
+    failures = [
+        event
+        for event in recorder.events()
+        if event.details.get("reason") == "acquisition_executor_error"
+    ]
+    assert len(failures) == 1, "the executor exception was not recorded at all"
+    assert failures[0].details["error_type"] == "RuntimeError"
+    assert failures[0].details["error"] == "port closed"
+    assert scheduler.diagnostics()["failureCountByReason"] == {
+        "acquisition_executor_error": 1
+    }
+    assert poller._acquisition_in_flight == {}  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -881,67 +881,6 @@ async def test_healthy_link_uncredited_request_is_resent_and_eventually_fails() 
     )
 
 
-class _RaisingAcquisitionExecutor:
-    """Executor whose send fails the way a closed transport does."""
-
-    def __init__(self, error: BaseException) -> None:
-        self.error = error
-        self.calls = 0
-
-    async def execute(
-        self,
-        request: object,
-        *,
-        already_sent_paths: frozenset[FieldPath],
-    ) -> object:
-        self.calls += 1
-        raise self.error
-
-
-@pytest.mark.asyncio
-async def test_executor_exception_is_recorded_and_drops_the_in_flight_entry() -> None:
-    """MOR-2293 3b: a raising executor no longer escapes the web drain.
-
-    Before the shared ``AcquisitionDrain``, this seat had no ``try/except``
-    around ``executor.execute``: the exception unwound to ``_run``'s
-    catch-all, nothing was recorded, the scheduler counted no failure, and
-    the drain never reached the rest of the pass. The shared drain catches
-    it, records a diagnostic, reports the failure and drops the ledger
-    entry. This pins the new behaviour, which the migration chose.
-    """
-
-    radio = _healthy_radio(last_civ=300.0)
-    first = FieldPath.receiver("main", "meters", "s_meter")
-    scheduler = AcquisitionScheduler(profile=_acquisition_profile(first))
-    radio._acquisition_scheduler = scheduler
-    executor = _RaisingAcquisitionExecutor(RuntimeError("port closed"))
-    recorder = StateDiagnosticsRecorder(enabled=True)
-    poller = RadioPoller(
-        radio,
-        CommandQueue(),
-        radio_state=RadioState(),
-        acquisition_executor=executor,
-        diagnostics=recorder,
-    )
-    with patch("rigplane.web.radio_poller.time.monotonic", return_value=300.0):
-        _tick_cadence(poller, now=300.0)
-        await poller._send_scheduler_requests()  # noqa: SLF001
-
-    assert executor.calls == 1
-    failures = [
-        event
-        for event in recorder.events()
-        if event.details.get("reason") == "acquisition_executor_error"
-    ]
-    assert len(failures) == 1, "the executor exception was not recorded at all"
-    assert failures[0].details["error_type"] == "RuntimeError"
-    assert failures[0].details["error"] == "port closed"
-    assert scheduler.diagnostics()["failureCountByReason"] == {
-        "acquisition_executor_error": 1
-    }
-    assert poller._acquisition_in_flight == {}  # noqa: SLF001
-
-
 class _SwitchableAcquisitionExecutor:
     """Sends one path per pass, or raises once armed with an error."""
 
@@ -976,27 +915,35 @@ class _SwitchableAcquisitionExecutor:
             RigplaneTimeoutError("CI-V transport recovery timed out"),
             RigplaneTimeoutError,
         ),
+        (RuntimeError("something nobody listed"), RuntimeError),
     ],
     ids=[
         "builtin-connection",
         "rigplane-connection",
         "builtin-timeout",
         "rigplane-timeout",
+        "outside-any-list",
     ],
 )
 @pytest.mark.asyncio
-async def test_send_query_still_raises_a_dead_link_error_out_of_the_drain(
+async def test_send_query_still_raises_any_executor_failure_out_of_the_drain(
     error: BaseException, expected: type[BaseException]
 ) -> None:
-    """``_send_query`` must keep raising the errors ``_run``'s backoff reads.
+    """An executor failure must still reach ``_run``, whatever its type.
 
     ``_run`` has no other way to learn the link is down: the
     ``(ConnectionError, RadioConnectionError)`` branch that raises ``_backoff``,
-    MOR-1440's dead-serial-link branch, and the reconnection probe that clears
-    ``_backoff`` and logs ``connection restored`` all key off whether
-    ``_send_query()`` raised. Once a scheduler is attached ``_send_query`` has
-    no other body, so a drain that swallowed these would make the probe always
-    succeed and announce a restored connection to a dead radio.
+    MOR-1440's dead-serial-link branch (any exception plus a disconnected
+    radio), and the reconnection probe that clears ``_backoff`` and logs
+    ``connection restored`` all key off whether ``_send_query()`` raised. Once a
+    scheduler is attached ``_send_query`` has no other body, so a drain that
+    swallowed these would make the probe always succeed and announce a restored
+    connection to a dead radio.
+
+    The ``outside-any-list`` case is the criterion, not a bonus: what must
+    propagate is *an executor failure*, not four enumerated types. A type list
+    here would be a hand-maintained list at a boundary that nothing derives and
+    nothing reddens when a new raise site appears downstream.
 
     Deliberately does NOT mock ``_send_query``: the two existing backoff tests
     replace it with an ``AsyncMock``, so they pin ``_run``'s handlers and cannot
@@ -1034,11 +981,16 @@ async def test_send_query_still_raises_a_dead_link_error_out_of_the_drain(
     # Recorded on the way out -- the migration's addition -- and the ledger
     # entry survives, because raising skips the drain's forget step exactly as
     # the pre-change code left it untouched.
-    assert [
-        event.details["error_type"]
+    reported = [
+        event.details
         for event in recorder.events()
         if event.details.get("reason") == "acquisition_executor_error"
-    ] == [type(error).__name__]
+    ]
+    assert [d["error_type"] for d in reported] == [type(error).__name__]
+    assert [d["error"] for d in reported] == [str(error)]
+    assert scheduler.diagnostics()["failureCountByReason"] == {
+        "acquisition_executor_error": 1
+    }
     assert poller._acquisition_in_flight == ledger  # noqa: SLF001
 
 

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -48,6 +48,7 @@ from rigplane.core.command_service import (
 from rigplane.core.exceptions import TimeoutError as RigplaneTimeoutError
 from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.exceptions import CommandError
+from rigplane.exceptions import ConnectionError as RadioConnectionError
 from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.runtime._state_queries import build_state_queries
@@ -939,6 +940,106 @@ async def test_executor_exception_is_recorded_and_drops_the_in_flight_entry() ->
         "acquisition_executor_error": 1
     }
     assert poller._acquisition_in_flight == {}  # noqa: SLF001
+
+
+class _SwitchableAcquisitionExecutor:
+    """Sends one path per pass, or raises once armed with an error."""
+
+    def __init__(self) -> None:
+        self.error: BaseException | None = None
+        self.calls = 0
+
+    async def execute(
+        self,
+        request: object,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> object:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        unsent = [p for p in getattr(request, "paths") if p not in already_sent_paths]
+        return SimpleNamespace(
+            sent_paths=(unsent[0],),
+            failed_paths=(),
+            failure_reason="",
+        )
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (ConnectionError("link down"), ConnectionError),
+        (RadioConnectionError("link down"), RadioConnectionError),
+        (TimeoutError("civ response timed out"), TimeoutError),
+        (
+            RigplaneTimeoutError("CI-V transport recovery timed out"),
+            RigplaneTimeoutError,
+        ),
+    ],
+    ids=[
+        "builtin-connection",
+        "rigplane-connection",
+        "builtin-timeout",
+        "rigplane-timeout",
+    ],
+)
+@pytest.mark.asyncio
+async def test_send_query_still_raises_a_dead_link_error_out_of_the_drain(
+    error: BaseException, expected: type[BaseException]
+) -> None:
+    """``_send_query`` must keep raising the errors ``_run``'s backoff reads.
+
+    ``_run`` has no other way to learn the link is down: the
+    ``(ConnectionError, RadioConnectionError)`` branch that raises ``_backoff``,
+    MOR-1440's dead-serial-link branch, and the reconnection probe that clears
+    ``_backoff`` and logs ``connection restored`` all key off whether
+    ``_send_query()`` raised. Once a scheduler is attached ``_send_query`` has
+    no other body, so a drain that swallowed these would make the probe always
+    succeed and announce a restored connection to a dead radio.
+
+    Deliberately does NOT mock ``_send_query``: the two existing backoff tests
+    replace it with an ``AsyncMock``, so they pin ``_run``'s handlers and cannot
+    see it stop raising.
+    """
+
+    radio = _healthy_radio(last_civ=300.0)
+    first = FieldPath.receiver("main", "meters", "s_meter")
+    second = FieldPath.receiver("main", "meters", "po_meter")
+    scheduler = AcquisitionScheduler(profile=_acquisition_profile(first, second))
+    radio._acquisition_scheduler = scheduler
+    executor = _SwitchableAcquisitionExecutor()
+    recorder = StateDiagnosticsRecorder(enabled=True)
+    poller = RadioPoller(
+        radio,
+        CommandQueue(),
+        radio_state=RadioState(),
+        acquisition_executor=executor,
+        diagnostics=recorder,
+    )
+
+    with patch("rigplane.web.radio_poller.time.monotonic", return_value=300.0):
+        # Pass 1 leaves a real, partially-sent ledger entry -- written by the
+        # drain, not seeded here, so the state under test is one production
+        # can reach.
+        _tick_cadence(poller, now=300.0)
+        await poller._send_query()  # noqa: SLF001
+        ledger = dict(poller._acquisition_in_flight)  # noqa: SLF001
+        assert ledger, "pass 1 dispatched nothing, so pass 2 proves nothing"
+
+        executor.error = error
+        with pytest.raises(expected):
+            await poller._send_query()  # noqa: SLF001
+
+    # Recorded on the way out -- the migration's addition -- and the ledger
+    # entry survives, because raising skips the drain's forget step exactly as
+    # the pre-change code left it untouched.
+    assert [
+        event.details["error_type"]
+        for event in recorder.events()
+        if event.details.get("reason") == "acquisition_executor_error"
+    ] == [type(error).__name__]
+    assert poller._acquisition_in_flight == ledger  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part 3b of MOR-2293 (slice 3 of MOR-2260). Part 3a (`3125c6d4`, #3109) introduced
`core/acquisition_drain.py` and migrated the rigctld seat; this migrates the web
poller's drain onto the same class.

## What changed

- `RadioPoller._send_scheduler_requests` is now a one-line delegator onto
  `AcquisitionDrain.run_once`, the shape 3a landed for
  `RigctldServer._drain_state_acquisition_once`. Its body — 161 lines at the
  merge base, measured by `ast` over the method — becomes six hook methods on
  `RadioPoller` plus a lazy drain builder.
- `AcquisitionDrain` gains two **optional** parameters, `report_expiry` and
  `on_forget`. rigctld injects neither and `rigctld/server.py` is untouched.

## The grace seam: what web needed vs what 3a cut

3a cut `ExpiredRequest.terminal`, a `details` payload and a `forget(request_id)`
hook as orphans. Designing against web's actual requirement, the shape that fits
is **two of those three, and one of them differently**:

- **`terminal`** — needed, but not as a value returned by the expiry *policy*.
  The web expiry rule (`_acquisition_request_expired`) had to stay byte-identical
  so "the rule is unchanged" is checkable by diff, and the cross-seat pin
  `test_a_late_dispatched_request_expires_for_rigctld_but_not_for_web` calls it
  unbound and asserts `is True`/`is False`. So terminality lives in a separate
  hook, `report_expiry`, which both reports the fired deadline and answers
  whether the request is finished with.
- **`details`** — **not needed.** Because `report_expiry` is the seat's own
  method, web's `link_healthy`/`grace_expired` detail set never has to cross the
  drain's boundary, and rigctld's `provider` detail set is untouched. A `details`
  payload on `report_failure` would have forced a signature change on
  `RigctldServer._record_acquisition_failure`.
- **`forget(request_id)`** — needed, as `on_forget`. Web keeps a second
  per-request map beside the ledger (`_acquisition_healthy_grace_started`),
  pruned at all three places the drain drops a ledger entry.

MOR-874's grace therefore reaches the drain as policy data through injected
hooks, not as a `web`-vs-`rigctld` branch inside it. rigctld still reports every
timeout with `link_healthy=False`; 3a's pin
`test_a_timed_out_request_is_terminal_even_on_a_healthy_civ_link` is unchanged
and green, and mutation M3 shows it discriminates.

## Executor exceptions — the part this PR got wrong twice, and what settled it

**The first version carried a false claim and it caused a real regression.** It
said the pre-change web seat let an executor exception escape `_run`'s catch-all
*silently*. The second half of that (no diagnostic, no failure accounting) is
true; "silently" is false, and that word is the whole defect.

Once a scheduler is attached, `_send_query` has no body but the drain. So with
the shared drain catching `Exception`, `_send_query` could no longer raise — and
three things in `RadioPoller._run` key off exactly that:

- the `(ConnectionError, RadioConnectionError)` branch that raises `_backoff`
  0.5 s → 5 s,
- MOR-1440's branch: any exception raised while `radio.connected` is False,
- the reconnection probe that clears `_backoff` and logs
  `radio-poller: connection restored` when `_send_query()` returns.

The probe was the worst: it would always succeed, announcing a restored
connection to a radio still down.

The **second** version re-raised a four-type tuple. That restored the observed
shapes but narrowed the rule, and a type list at this boundary is
hand-maintained: nothing derives it from the raise sites downstream of `_civ`,
and nothing reddens when those change.

**Current shape.** `RadioPoller._report_acquisition_executor_error` records the
diagnostic and the scheduler failure, then re-raises **whatever** it caught, with
no type list. `_run` therefore sees exactly what it saw before this migration,
including its own distinction between a connection error (always back off) and
any other exception (back off only when the radio is already disconnected).
Raising also skips the drain's `_forget`, so the ledger entry survives.

**Net against the pre-change path: the diagnostic and the scheduler failure
report are added; nothing is taken away.**

Two facts worth keeping even though no type check depends on them any more:

- **MOR-1440's "bare TimeoutError" is rigplane's, not the builtin, and
  rigplane's does not subclass it.** `runtime/_civ_rx.py` raises it at the CI-V
  transport recovery gate (`raise TimeoutError("CI-V transport recovery timed
  out")`) under `from rigplane.core.exceptions import ConnectionError,
  TimeoutError`. Anyone writing a type check here later will need this.
- A per-path failure unrelated to the link (a malformed query for one field) does
  **not** trigger a whole-poller backoff, before or after: `_run` gates
  non-connection exceptions on `not radio.connected`, so on a healthy link it
  logs at debug and falls through. The behaviour is parity-equal, not merely
  parity-acceptable.

### What the pin reddens on

`test_send_query_still_raises_any_executor_failure_out_of_the_drain`, five
parametrised cases, drives the **injected executor** and asserts what a caller of
`_send_query` observes. Its criterion is *an executor failure reaches `_run`* —
not four enumerated types — which is why one case (`outside-any-list`) uses a
bare `RuntimeError`.

It reddens on exactly two things, and on nothing else in the suite:

- **M7**, deleting the `raise` entirely, kills **all five** cases.
- **M8**, narrowing back to the previous head's four-type tuple, kills **exactly
  the `outside-any-list` case**.

It deliberately does **not** mock `_send_query`. The two existing backoff tests
do (`poller._send_query = AsyncMock(side_effect=...)`), so they pin `_run`'s
handlers and are structurally incapable of noticing that `_send_query` stopped
raising. That is why a fully green suite missed this for a whole review cycle.
The ledger state it asserts on is written by the drain in a real first pass, not
seeded.

The web-side test that asserted an executor exception was swallowed and its
ledger entry dropped is **deleted** — it pinned behaviour this PR no longer has.
Its unique assertions (the recorded error message, the scheduler's failure count)
moved into the pin.

### Sweep of the class, not the instance

What else in `RadioPoller._run` depended on an exception the drain now catches?
The drain's `try` wraps exactly one expression, `await executor.execute(...)`;
everything else in `run_once` is outside it. Web's only production path into the
drain is `_send_query` → `_send_scheduler_requests` (`grep` over `src/`: two
`_send_query()` call sites, both in `_run`; `_acquisition_executor` has no other
call site in `web/`).

Enumerated by AST over every `ast.Try` node in `_run`: **9 blocks, 2 of which
call `_send_query`** — the reconnection probe and the main send, i.e. the
reported instance and nothing more. The other seven guard `_fetch_nb_controls`,
`_fetch_mod_inputs`, `_seed_scan_facts_at_connect`, `_execute_queued_entry` (the
command queue, a different path), `_refresh_mod_inputs_on_data_mode_change`,
`_publish_tx_target`, and the task-level handler. None reaches the drain, and
nothing from `_send_query` ever reached the task-level handler either, since both
inner blocks already catch `Exception`.

**Control for that negative:** the same AST query does find `_send_query` in
exactly the two blocks the review named, so it can detect the shape it is looking
for.

## Explicitly not in this PR

- The two seats keep **separate** in-flight ledgers. Sharing one is part 3c.
- **MOR-2292 is not fixed here** and its single-dispatch pin does not land here.
- rigctld's `send_civ` still passes neither `priority` nor `wait_dispatch`;
  web's `_send_one_state_query` still passes `Priority.BACKGROUND,
  wait_dispatch=False` (MOR-497i/ii). Untouched.
- Web's poll-loop external-CAT guard stays the whole-iteration `continue` in
  `_run`; it is not routed through the drain's dispatch-eligibility hook, and web
  passes an identity `dispatchable`.

## Size — soft threshold crossed on lines, not on files

**762 changed lines across 4 files**, measured at this head against the **merge
base `3125c6d4`** (`git diff --numstat 3125c6d4...HEAD`): 63/11
`core/acquisition_drain.py`, 225/157 `web/radio_poller.py`, 190/1
`tests/test_acquisition_drain.py`, 115/0 `tests/test_radio_poller_coverage.py`.
Over the 600-line soft threshold, under the 1000-line hard ceiling, and under the
6-file half of both.

The merge base must be named, not assumed: `main` has advanced past it with
unrelated frontend commits, so a two-dot `git diff origin/main` for this branch
reports files and lines that belong to other people's work. Only the three-dot
figure above describes this branch.

**Why this is one unit of work at over 600 lines.** The three pieces cannot land
separately in either order. The drain's new seam (`report_expiry`, `on_forget`)
has no caller without the web migration — that is exactly why 3a cut it as an
orphan, and `CLAUDE.md`'s scope discipline forbids landing it again with nothing
calling it. The web migration cannot preserve MOR-874's healthy-link grace
without that seam, because the shared drain's only expiry rule is terminal.
Splitting them lands either a hook nothing calls or a web seat that has silently
lost the grace — and the grace is MOR-874 itself, the ticket this epic exists to
keep fixed. The line count is dominated by tests: 306 of the 762
changed lines are in the two test files (+305/−1), not new mechanism.

## Parity set

All eight parity tests plus 3a's rigctld-grace pin are **unchanged and green**.
`git diff 3125c6d4...HEAD -- tests/` deletes exactly one line across the whole
tree: `_Reports.__init__`'s signature in `tests/test_acquisition_drain.py`. All
**18** `_send_scheduler_requests` call sites in
`tests/test_radio_poller_coverage.py` are untouched (+115/−0), matching 3a's
outcome on the other seat. (The count was published as 20 and corrected on
review: it is 18 at `3125c6d4`, 19 at `13aae790` where this PR briefly added
one, and 18 here now that head deleted it. "Untouched" became true at this head;
20 was never true at any head.)

`RadioPoller._acquisition_request_expired` and `RadioPoller._civ_link_healthy`
are byte-identical to the merge base, checked by comparing
`ast.get_source_segment` for each against
`git show 3125c6d4:src/rigplane/web/radio_poller.py`.
`_acquisition_request_expired` is 1026 characters / 1028 UTF-8 bytes;
`_civ_link_healthy` is 970 of each.

## Gates

CI `quick` at this head (run 33754804063): **pass — 14892 passed, 218 skipped, 15
xfailed**. This is the measurement of record. Absolute CI counts are not
comparable across heads on this PR: a PR run tests the merge with whatever `main`
currently is, and `main` gained tests while this branch was open.

Local, on a macOS laptop under `uv run` (Python 3.11), at this head:

| gate | result |
| -- | -- |
| `ruff check src/ tests/` | All checks passed |
| `ruff format --check src/ tests/` | 715 files already formatted |
| `lint-imports` | Contracts: 5 kept, 0 broken |
| `mypy --strict src/rigplane/web` | Success: no issues found in 26 source files |
| `pytest tests/ -n auto` | 14872 passed, 224 skipped, 15 xfailed, **2 failed** |

**The two local failures are this host, not this branch, and the evidence is that
the failure set changed while the tree did not.** Two full runs of an identical
tree failed different pairs: run 1 `test_ic7610_main_emits_0xD0` +
`test_authority_boundary_and_ten_class_adversarial_corpus_pass`, run 2
`test_command_queue_processing_latency` + the same architecture test. Load average
was ~18 on this machine; the architecture test shells out to `npx vitest` from
inside an already-parallel pytest run, and the other two are a latency assertion
and a timing-sensitive frame test. Every one of them passes in isolation
(19 passed). An earlier version of this paragraph said neither failing file
references `radio_poller` at all; that was **refuted on review** —
`tests/test_civ_command_profiling.py`, which hosts
`test_command_queue_processing_latency`, imports `CommandQueue` and
`SetAntenna1` from `rigplane.web.radio_poller` inside that test's body. The
host-flake conclusion stands on independent evidence — neither imported name is
touched by this PR, the failing set changed between two runs of an identical
tree, and `quick` is green at this exact head — but the sentence was false as
written and is corrected rather than deleted, because the conclusion it
supported is still being relied on.

Local counts reconcile exactly: baseline **14862 passed** measured the same way
in a separate worktree at `3125c6d4`, plus the **+12** tests this PR nets (8 in
the first commit, 5 parametrised cases added, 1 test deleted) = 14874, which is
the 14872 passed + 2 load-flaky failures above.

## Mutation evidence

Re-derived in full at head `73ef677a` — no row carried over from an earlier head.
Each run covers `tests/test_acquisition_drain.py`,
`tests/test_radio_poller_coverage.py` and `tests/test_rigctld_server.py` (334
tests), and each printed a summary line, so a zero-kill row would be a real
survivor rather than a broken harness.

| # | mutation | tests killed |
| -- | -- | -- |
| M1 | drain treats every expiry as terminal (the pre-3b rule) | 3 — both non-terminal drain pins + `test_healthy_link_uncredited_request_is_resent_and_eventually_fails` |
| M2 | `on_forget` never called | 6 — the four `TestAcquisitionDrainForgetHook` tests, `test_a_terminal_seat_expiry_drops_the_entry_without_a_second_report`, and both web MOR-874 parity tests |
| M3 | default (no `report_expiry`) expiry becomes non-terminal — rigctld picks up the grace | 4, incl. 3a's pin `test_a_timed_out_request_is_terminal_even_on_a_healthy_civ_link` |
| M4 | web's grace removed: `link_healthy=False` **and** `return True` | 1 |
| M4b | only `link_healthy=False`; terminality untouched | 2 |
| M4c | only `return True`; scheduler flag untouched | 1 (a different one) |
| M5 | drain raises before reporting — no diagnostic at all | 8 |
| M6 | web expiry replaced by rigctld's `min(deadline, sent_at+window)` | 2 |
| **M7** | **`raise` deleted — executor failures swallowed again** | **5 — every case of the pin, and nothing else** |
| **M8** | **narrowed back to the four-type tuple (the previous head)** | **1 — exactly `outside-any-list`** |

On M4: the review's non-blocking note said this row measured **2** kills, not 1. I
re-ran it and measured 1, so I decomposed it rather than adopt either number.
M4's two halves **mask each other**: `link_healthy=False` alone kills 2, `return
True` alone kills 1, and both together make every timeout an ordinary terminal
timeout — which is what the uncredited-request test expects to happen eventually,
so that test passes. The review's figure is right for M4b; mine was right for the
mutation I described. The decomposition is better evidence than either row, and a
reusable caveat: a two-part mutation can be less lethal than each of its parts.

**Converse probes** — correct-but-different rewrites that must stay green, so the
table reads as discrimination rather than reaction:

| # | rewrite | result |
| -- | -- | -- |
| C1+C2 | `_forget` as membership-test + `del` with the hook via a local; web's grace clock via `setdefault` | 334 passed |
| C3+C4 | expiry branch through a `terminal` local and `is not False`; the re-raise as a bare `raise` instead of `raise error` | 334 passed |

After the last run both source files were compared byte-for-byte against their
pre-mutation snapshots, and `git status` was clean against `73ef677a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

