### PR TITLE
feat: add a workflow_dispatch route to re-pin visual baselines

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -90,9 +90,19 @@ jobs:
       # of the pixel-diff step (their conditions are mutually exclusive),
       # writing into frontend/fixtures/approved-baselines/ via that config's
       # `snapshotPathTemplate`.
+      #
+      # `=all` is load-bearing: the bare `--update-snapshots` flag selects
+      # mode `changed`, which is comparator-gated and so writes nothing for
+      # exactly the sub-floor change this route exists to re-pin. Mode `all`
+      # skips the comparator and rewrites every baseline whose raw bytes
+      # differ from the freshly-rendered capture. That includes the
+      # same-tree antialiasing noise fixtures/approved-baselines/README.md
+      # records (3-123 differing pixels per capture), so the tradeoff is
+      # accepted deliberately: each dispatch re-pins every capture rather
+      # than only the ones that actually changed.
       - name: Regenerate approved baselines
         if: github.event.inputs.regenerate == 'true'
-        run: cd frontend && npm run test:e2e:visual -- --update-snapshots
+        run: cd frontend && npm run test:e2e:visual -- --update-snapshots=all
 
       # always(): upload whatever the step above wrote even if it exited
       # non-zero, so a partial re-pin is still downloadable.

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -22,6 +22,12 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/visual.yml"
+  workflow_dispatch:
+    inputs:
+      regenerate:
+        description: "Re-pin baselines on the Linux runner, upload as artifact"
+        type: boolean
+        default: false
 
 concurrency:
   group: visual-${{ github.workflow }}-${{ github.ref }}
@@ -59,6 +65,7 @@ jobs:
       # Linux baseline re-pin.
       - name: Pixel-diff vs approved baselines
         id: visual
+        if: github.event.inputs.regenerate != 'true'
         run: cd frontend && npm run test:e2e:visual
 
       # Keep failure diagnostics available even though the pixel step is
@@ -74,3 +81,25 @@ jobs:
       - name: Annotate failure
         if: always() && steps.visual.outcome == 'failure'
         run: echo "::error::Visual pixel-diff failed. See the visual-diff-report artifact."
+
+      # MOR-2296 — manual re-pin route. A visual change small enough to stay
+      # under the comparator floor (`COMPARATOR` in
+      # playwright.visual.config.ts) leaves the pixel-diff step green, so the
+      # `steps.visual.outcome == 'failure'` diff-report upload above never
+      # fires and there is no Linux-rendered PNG to pull. This runs INSTEAD
+      # of the pixel-diff step (their conditions are mutually exclusive),
+      # writing into frontend/fixtures/approved-baselines/ via that config's
+      # `snapshotPathTemplate`.
+      - name: Regenerate approved baselines
+        if: github.event.inputs.regenerate == 'true'
+        run: cd frontend && npm run test:e2e:visual -- --update-snapshots
+
+      # always(): upload whatever the step above wrote even if it exited
+      # non-zero, so a partial re-pin is still downloadable.
+      - name: Upload regenerated baselines
+        if: always() && github.event.inputs.regenerate == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated-baselines
+          path: frontend/fixtures/approved-baselines/
+          retention-days: 14


### PR DESCRIPTION
## Summary

Linear: MOR-2296. Infrastructure only — draft, not for merge until the owner picks this approach over the alternative (SSH regeneration on the Mac mini build host).

`.github/workflows/visual.yml`'s only artifact route (`visual-diff-report`, on `steps.visual.outcome == 'failure'`) can't produce a fresh Linux baseline for a change small enough to sit under the pixel-diff comparator's floor — the job passes even when the baseline is stale, so no failure-triggered artifact is ever generated. Found via PR #3089 (MOR-2231 step 3): 8 of 12 desktop baselines were stale after a real code fix, and `visual` stayed green throughout because the affected region (a 26×22px badge) never crossed the `~1024px` floor `approved-baselines/README.md` documents.

## What this PR does

- New `workflow_dispatch` input, `regenerate` (boolean, default `false`).
- When set: runs `npm run test:e2e:visual -- --update-snapshots=all` instead of the normal pixel-diff comparison (the two run steps are mutually exclusive via `if:`), then uploads `frontend/fixtures/approved-baselines/` (PNGs + `manifest.json`) as an artifact unconditionally (`if: always()`).
- Zero change to the existing `pull_request`-triggered behavior (this workflow has no `push` trigger — its own header comment says so, "PR-ONLY GAP": corrected here, an earlier version of this body wrongly claimed one): `github.event.inputs` is `null` on `pull_request`, so the pixel-diff step's new `if:` condition evaluates true and it runs exactly as before, keeping its implicit `success()` gate.

## A real bug the builder caught before it shipped

The obvious `inputs.regenerate == 'true'` comparison would have been silently wrong: GitHub's `inputs` context preserves booleans as booleans (unlike `github.event.inputs`, which stringifies them), so `true == 'true'` coerces to a numeric comparison and is always false — the regenerate path would never have fired, and every dispatch would have silently run the normal (stale-baseline) pixel-diff instead. Fixed by using `github.event.inputs.regenerate`, whose value genuinely is the string `'true'`.

## Verification

- `actionlint .github/workflows/visual.yml`: one finding, the pre-existing `[self-hosted, linux, build]` custom runner label — confirmed present identically on `origin/main` and in `full.yml`/`quick.yml`, not introduced by this PR.
- `yamllint -d relaxed`: one pre-existing line-length warning (an untouched line); nothing new.
- PyYAML structural parse of the full file — no errors.
- `--update-snapshots`'s output directory confirmed correct via `playwright.visual.config.ts`'s `snapshotPathTemplate: 'fixtures/approved-baselines/{arg}{ext}'` and `manifest.json`'s per-run rewrite in `global-teardown.ts` — the uploaded directory is the complete committable set.
- Verified independently before push: read the full diff myself, re-ran `actionlint` myself with the same result.

**Not verified — cannot be, without merging:** `workflow_dispatch` only surfaces for workflow files on the default branch, so the dispatch path itself has never actually run. No local Actions runner exists to exercise it. Confidence rests on the two GitHub-documented behaviors cited above (the input-type coercion rule, the default `success()` gate when a step's own `if:` doesn't include one), not on an observed execution.

## Fix cycle — round-1 review found the bare `--update-snapshots` flag defeats the PR's own purpose

Independent review at `6757ecaa` BLOCKED: Playwright 1.58.2's bare `--update-snapshots` flag resolves to mode `changed` (its documented preset), which is comparator-gated — it will NOT rewrite a baseline that's stale but still passes the pixel-diff comparator, which is exactly the class of change (sub-`~1024px`-floor) this whole PR exists to fix. Only mode `all` bypasses the comparator and force-rewrites on a raw byte comparison. Reviewer reproduced this with a 3-run A/B/control test against this repo's exact Playwright build and comparator settings before blocking.

Fixed at `c0a0f197`: changed to `--update-snapshots=all`, and rewrote the step's own comment to state the real tradeoff plainly rather than hide it — `=all` rewrites EVERY baseline whose bytes differ from a fresh render, including the 3-123px same-tree antialiasing noise `approved-baselines/README.md` documents as normal, so a dispatch produces a full re-pin of every capture, not a minimal diff of just what changed. That's accepted deliberately, not a side effect.

Also corrected in this update: this body's "push" claim (removed, no such trigger exists — see above).

## Guardrails

1 file, 39 lines added, 0 removed (two commits, `6757ecaa` + `c0a0f197`) — well under both thresholds. No ticket id in branch name; commit subjects carry `feat(MOR-2296):`/`fix(MOR-2296):` per convention.

## Status

PASSED independent review at exact head `c0a0f1972a1e7e086baf8a6ef7d903b8aae0fa01` (round 2). Reviewer independently re-derived the `=all`-bypasses-comparator claim from Playwright 1.58.2's own source (not round 1's citation), ran the real comparator against real PNGs at this repo's exact constants (sub-floor change: differing bytes, comparator still passes, `changed` writes nothing, `all` rewrites), confirmed no `push` trigger via YAML parse, confirmed `actionlint` unchanged, confirmed CI green, confirmed the `visual` job's step conclusions show the pixel-diff path genuinely ran unmodified on this PR's own trigger. Owner approved this approach 2026-09-03; SSH-to-mini alternative closed.

Merging now with an explicit squash body (this repo squashes with `COMMIT_MESSAGES`, and an earlier commit's own message describes the pre-fix bare flag — the explicit body here is the corrected record). Next: trigger `regenerate` on `main` to produce a fresh Linux-provenance baseline artifact, use it to clear PR #3089's 8 stale baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


