### PR TITLE
test: type-check the frontend test harness in npm run check

### DIFF
--- a/frontend/fixtures/capture.mjs
+++ b/frontend/fixtures/capture.mjs
@@ -526,14 +526,12 @@ try {
       tokens,
       paint,
     });
-    // eslint-disable-next-line no-console
     console.log(
       `${passed ? 'PASS' : 'FAIL'}  ${spec.name}`
       + `  (${assertions.filter((a) => a.ok).length}/${assertions.length} assertions)`,
     );
     if (!passed) {
       for (const a of assertions.filter((x) => !x.ok)) {
-        // eslint-disable-next-line no-console
         console.log(`        ✗ ${a.name}: ${a.detail}`);
       }
       for (const e of consoleErrors) console.log(`        ✗ console: ${e}`);
@@ -623,6 +621,5 @@ const manifest = {
   captures,
 };
 writeFileSync(path.join(OUT, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
-// eslint-disable-next-line no-console
 console.log(`\n${captures.length} captures → ${OUT}  (${failures} invalid)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/frontend/fixtures/catalog.ts
+++ b/frontend/fixtures/catalog.ts
@@ -835,9 +835,7 @@ const REFERENCE_SELECT_GATING_OVERRIDE: Readonly<Record<string, Pick<Expectation
  * `audioRuntimeFixture`'s inline literal) already always sets `expect`; the
  * parameter type now says so, closing the gap rather than asserting past
  * it. Verified with a scratch tsconfig adding `fixtures/**\/*.ts` to
- * `include` (fixtures/ is otherwise typechecked by nothing —
- * `tsconfig.app.json` includes only `src/**`): HEAD reports 1 error here,
- * this fix reports 0.
+ * `include`: HEAD reports 1 error here, this fix reports 0.
  */
 function toReferenceFixture(f: Fixture & { expect: Expectation }): Fixture {
   return {

--- a/frontend/fixtures/harness-state.ts
+++ b/frontend/fixtures/harness-state.ts
@@ -2,9 +2,8 @@
  * MOR-1070 — mutable holders the aliased fixture stubs read.
  *
  * VERIFICATION-ONLY TOOLING. Nothing under `src/` imports this file; it lives
- * outside `src/` on purpose so `eslint src/`, `svelte-check --tsconfig
- * tsconfig.app.json` (include: `src/**`) and `vitest` (include:
- * `src/ ** /*.test.ts`) all ignore it. The production tree is byte-unchanged.
+ * outside `src/` on purpose so `eslint src/` and `vitest` (include:
+ * `src/ ** /*.test.ts`) both ignore it. The production tree is byte-unchanged.
  *
  * The cockpit reaches live state through exactly four seams
  * (`$lib/runtime`, `$lib/runtime/tx-controller/app-host`,

--- a/frontend/fixtures/ptt-main.ts
+++ b/frontend/fixtures/ptt-main.ts
@@ -2,7 +2,7 @@
  * MOR-1088 — mobile PTT gesture / orientation-swap safety harness.
  *
  * VERIFICATION-ONLY TOOLING (mirrors the MOR-1070/1087 fixture doctrine:
- * outside `src/`, unread by `tsconfig.app.json`/`eslint src/`/`vitest`).
+ * outside `src/`, unread by `eslint src/`/`vitest`).
  *
  * WHY THIS EXISTS. The MOR-1070/1085/1087 cockpit harness stubs
  * `$lib/runtime/tx-controller/app-host` entirely (`fixtures/stubs/app-host.ts`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json && tsc -p tsconfig.harness.json",
     "lint": "eslint src/",
     "lint:boundaries": "eslint src/components-v2/panels/ src/components-v2/layout/ src/presentation/",
     "i18n:check": "node scripts/i18n-check.mjs",

--- a/frontend/tests/e2e/i18n/i18n-visual.spec.ts
+++ b/frontend/tests/e2e/i18n/i18n-visual.spec.ts
@@ -537,7 +537,7 @@ async function assertProductionLanguageCss(page: Page, item: ProductionLanguageC
       fieldline: rules.some((rule) => rule.includes('--dl-fieldline-surface')),
       productionCss: [...document.styleSheets]
         .map((sheet) => sheet.href)
-        .some((href) => /\/assets\/[^/]+-[\w-]+\.css$/.test(href)),
+        .some((href) => href !== null && /\/assets\/[^/]+-[\w-]+\.css$/.test(href)),
     };
   })).toEqual({ studioline: true, fieldline: true, productionCss: true });
 }

--- a/frontend/tsconfig.harness.json
+++ b/frontend/tsconfig.harness.json
@@ -1,0 +1,17 @@
+{
+  /**
+   * Type-checks `tests/**`, which `tsconfig.app.json` (include: `src/**`)
+   * and `tsconfig.node.json` (include: `vite.config.ts`) both leave out.
+   *
+   * Reached only via the explicit `tsc -p` in `package.json`'s `check`
+   * script: `tsconfig.json` is `"files": []`, and its `references` are not
+   * followed without `tsc --build`, which nothing here runs.
+   */
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.harness.tsbuildinfo",
+    "allowJs": false,
+    "checkJs": false
+  },
+  "include": ["src/**/*.d.ts", "tests/**/*.ts"]
+}

--- a/frontend/tsconfig.harness.json
+++ b/frontend/tsconfig.harness.json
@@ -6,9 +6,7 @@
    */
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.harness.tsbuildinfo",
-    "allowJs": false,
-    "checkJs": false
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.harness.tsbuildinfo"
   },
   "include": ["src/**/*.d.ts", "fixtures/**/*.ts", "tests/**/*.ts"]
 }

--- a/frontend/tsconfig.harness.json
+++ b/frontend/tsconfig.harness.json
@@ -1,9 +1,5 @@
 {
   /**
-   * Type-checks `fixtures/**` and `tests/**`, which `tsconfig.app.json`
-   * (include: `src/**`) and `tsconfig.node.json` (include: `vite.config.ts`)
-   * both leave out.
-   *
    * Reached only via the explicit `tsc -p` in `package.json`'s `check`
    * script: `tsconfig.json` is `"files": []`, and its `references` are not
    * followed without `tsc --build`, which nothing here runs.

--- a/frontend/tsconfig.harness.json
+++ b/frontend/tsconfig.harness.json
@@ -1,7 +1,8 @@
 {
   /**
-   * Type-checks `tests/**`, which `tsconfig.app.json` (include: `src/**`)
-   * and `tsconfig.node.json` (include: `vite.config.ts`) both leave out.
+   * Type-checks `fixtures/**` and `tests/**`, which `tsconfig.app.json`
+   * (include: `src/**`) and `tsconfig.node.json` (include: `vite.config.ts`)
+   * both leave out.
    *
    * Reached only via the explicit `tsc -p` in `package.json`'s `check`
    * script: `tsconfig.json` is `"files": []`, and its `references` are not
@@ -13,5 +14,5 @@
     "allowJs": false,
     "checkJs": false
   },
-  "include": ["src/**/*.d.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.d.ts", "fixtures/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Put the frontend test harness under type checking, in the gate CI already runs.

Linear: MOR-2287

## Why this is one unit of work — and why it is 7 files, over the soft threshold

A new tsconfig, one line of wiring, one type error the new config surfaces, comment text in three files that the new config makes misleading, and three dead lint directives in a fourth.

The soft threshold is 6 files, so here is the reason, and it is not uniform across the seven. The type fix exists only because the config surfaces it — landing the config without it lands a red gate. The three comment edits exist only because the config falsifies what those comments say, and leaving a stale "nothing type-checks this directory" behind the change that starts type-checking it is exactly the failure this repository treats as worse than no comment at all; splitting them off would mean deliberately merging known-false prose and hoping the follow-up lands.

The seventh file, `fixtures/capture.mjs`, is the weakest of the seven and should be named as such: its three dead lint directives are **independent cleanup**, not something this change falsifies. The config includes only `.ts`/`.d.ts` and the program contains zero `.mjs`, so those directives were dead before this PR for an unrelated reason and are dead after it for the same one. They are here because they were found while establishing that the three directives were not a special case; a reviewer who wants them in their own PR is not wrong.

No eslint configuration is touched, and no production behaviour changes.

## The three facts this rests on, each with its command

**1. No tsconfig included `fixtures/` or `tests/` before this change.** At the merge base:

```
$ git show e2ef9342:frontend/tsconfig.app.json  | grep '"include"'
  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
$ git show e2ef9342:frontend/tsconfig.node.json | grep '"include"'
  "include": ["vite.config.ts"]
$ git show e2ef9342:frontend/tsconfig.json      | grep '"files"'
  "files": [],
```

With one qualifier, because the include arrays are not the whole story — exactly one harness file already entered the app config's graph:

```
$ npx tsc -p tsconfig.app.json --listFilesOnly --noEmit | grep '/frontend/tests/'
tests/e2e/i18n/fixtures.ts
```

It is imported by `src/lib/types/__tests__/i18n-visual-fixture.contract.test.ts`, which sits under `src/`. Every other file in both directories was reached by no configuration.

**2. `npm run check` is what CI runs**, in `.github/workflows/quick.yml`, step `Frontend install + check + tests + build`, gated on the `frontend` path filter:

```
cd frontend
npm ci
npm run i18n:check
npm run check
npx vitest run
npm run build
```

Wiring the new config into `check` rather than into `tsconfig.json`'s `references` is deliberate, and measured: `tsconfig.json` is `{"files": [], "references": [...]}` and compiles nothing — `npx tsc -p tsconfig.json --listFilesOnly --noEmit` emits 0 lines, while the same command against `tsconfig.app.json` emits 847. References are not followed without `tsc --build`, which nothing here runs, so a `references` entry would have been inert decoration.

**3. Size, against the merge base** rather than a two-dot diff with `main`:

```
$ git diff --shortstat $(git merge-base HEAD origin/main)..HEAD
 7 files changed, 18 insertions(+), 12 deletions(-)
```

## What changed

- **New `frontend/tsconfig.harness.json`**, extending `tsconfig.app.json`, `include: ["src/**/*.d.ts", "fixtures/**/*.ts", "tests/**/*.ts"]`. The `src/**/*.d.ts` entry earns its place by measurement: removing it takes the program from 70 files to 68, losing `src/types/pwa.d.ts` and `src/types/webcodecs.d.ts`. It changes no error count today. It was checked twice, at two different include scopes, because the fixtures drag in ~52 `src/` modules as imports and those might have pulled the ambient files in anyway — they do not.
- **`check` gains `&& tsc -p tsconfig.harness.json`.**
- **One type error fixed**, in `tests/e2e/i18n/i18n-visual.spec.ts`: `[...document.styleSheets].map((sheet) => sheet.href)` yields `(string | null)[]`, and the `.some()` predicate took `string`. Guarded with `href !== null &&`. Behaviour equivalence was measured, not argued — old and new predicates run over `[null, "/assets/index-a1b2c3.css", "https://x/assets/main-DEADBEEF.css", "/other/x.css", ""]` agree on all five, `null → false` both ways.
- **Three `// eslint-disable-next-line no-console` directives deleted** from `fixtures/capture.mjs`. `npx eslint fixtures/capture.mjs` reports all three as `Unused eslint-disable directive (no problems were reported from 'no-console')`, and `no-console` is enabled nowhere in `frontend/eslint.config.js`. Deleted rather than repaired: there is no rule to repair them against.
- **Comment text deleted in three harness files**, because this change falsifies it. They were not equally false, and the difference decided what went:
  - `fixtures/catalog.ts` was the only flatly false one — a parenthetical asserting "fixtures/ is otherwise typechecked by nothing". After this change it is.
  - `fixtures/harness-state.ts` and `fixtures/ptt-main.ts` name specific invocations (`svelte-check --tsconfig tsconfig.app.json`, `tsconfig.app.json`) that **remain literally true** — this adds a separate `tsc -p` leg and changes neither. What stops being true is what the sentences are *for*: a reader takes them to mean nothing type-checks the directory. The type-checking clause is deleted from each; the `eslint src/` and `vitest` clauses stay, still true and still doing their job.

## Verification

```
$ npm run check          # config wired, before the type fix — exit 2
COMPLETED 4634 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
tests/e2e/i18n/i18n-visual.spec.ts(540,61): error TS2345: Argument of type 'string | null'
  is not assignable to parameter of type 'string'.

$ npm run check          # after — exit 0
COMPLETED 4634 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

Exactly one error, which is the point: a new gate has to be shown failing on something real before being shown to pass. `npm run lint` is exit 0 and unchanged.

**Adding the fixtures produced 0 errors — and 0 errors is also what a glob matching nothing produces**, so it was controlled rather than trusted. `npx tsc -p tsconfig.harness.json --listFilesOnly --noEmit` goes from 12 non-`node_modules` files to 70. All 11 `fixtures/**/*.ts` are present — `find fixtures -name '*.ts' | wc -l` is 11, matched exactly — along with all 6 under `tests/`, 0 `.mjs`, and ~52 `src/` modules the fixtures import.

**Two mutations, to show the new leg discriminates rather than merely exiting 0.** Both were killed with `svelte-check` staying at `0 ERRORS`, so the kill is attributable to the new leg and not the pre-existing one:

1. A type error appended to `tests/e2e/visual/global-teardown.ts` — a file no configuration reached before — dies as `error TS2322`.
2. The same in `fixtures/stubs/runtime.ts` — the fixtures half — dies the same way.

Reverting the null guard restores the original TS2345. All mutations were reverted; `git diff` at this head is clean.

Baseline for comparison: `quick.yml` run 33757305626 on `main` at `6b091811`, green, with its frontend block confirmed executed step by step — a path-filtered skip also reports success, so a run's overall conclusion is not by itself evidence that anything ran. Nothing under `frontend/**` changed between that commit and this branch's base.

## Known gap this does not close, now measured

`fixtures/ReferenceLayout.svelte` is still type-checked by nothing. `.svelte` imports resolve through svelte's ambient `declare module '*.svelte'`, so no component enters the program, and `svelte-check` runs only over `src/**`. This is measured, not inferred: a deliberate type error injected into that file's `<script lang="ts">` block **survives** `npm run check` — all three legs stay green. `find fixtures -name '*.svelte'` returns exactly one file, so that is the whole population, not a sample. Closing it needs a second `svelte-check` invocation, which is a separate decision.

## Deliberately not here

- **eslint.** No workflow runs eslint over the tree at all — `grep -rhoE "npm run [a-z0-9:_-]+" .github/` returns `build`, `check`, `i18n:check`, `test:e2e:visual`, `test:e2e:i18n` and nothing else — so widening any glob would not lint anything until that is settled. That is MOR-2043, a blocker of MOR-1102, where the owner has now chosen the fix and the sequencing.

  An earlier draft of this body put a number on what widening would cost. It is withdrawn: the figure depends entirely on which rule blocks you re-point at the harness, and two defensible widenings give two different answers. That makes it a number without a counting rule, which is not a number. The measurement belongs in MOR-2043 with its method stated, not here.
- **The two `.mjs` capture drivers.** Type-checking them costs 83 errors, for plain JavaScript that CI already executes on every run through the blocking `capture.mjs` step.
- **15 further dead `eslint-disable` directives** elsewhere in the tree, enumerated while checking that these three were not a special case. They sit in blocks that set `reportUnusedDisableDirectives: 'off'`, so removing them means touching `eslint.config.js`, which this change does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
