### PR TITLE
feat(MOR-2231): lay the sdr-test semantic surfaces out as five regions

### DIFF
--- a/frontend/fixtures/assertions.ts
+++ b/frontend/fixtures/assertions.ts
@@ -125,11 +125,7 @@ const TEXT_CONTRAST_FLOOR: Readonly<Record<string, number>> = {
  * Module scope, computed once: importing the manifest directly is what
  * keeps this immune to that trap — the alternative, a hardcoded zone-id
  * list here, would need a human to remember to touch it on every future
- * S-slice. `receiver-deck`/`rx-tx` are excluded: `SemanticRadioSurfaces
- * .svelte`'s `zoned()` snippet is deliberately never applied to `vfo`/
- * `rxTx` (MOR-1069 — "a zone element exists only where an arrangement must
- * place it, and the single composition places nothing"), a structural fact
- * about the wiring component, not a zone list that goes stale.
+ * S-slice.
  *
  * A SET, not an order: measured live against a real resolved plan (see the
  * MOR-1379 build report), the single composition's `{#each singleOrder}` +

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -272,19 +272,46 @@
   });
 </script>
 
+{#snippet sdrRegionContent()}
+  <section class="content-row">
+    <div class="content-left">
+      <LeftSidebar hideTxPanel={semanticRxTx} {declared} />
+    </div>
+
+    <main class="content-center center-column">
+      {#if hasSpectrum()}
+        <div class="spectrum-slot">
+          <div class="spectrum-frame">
+            <SpectrumPanel hideSourceControls={true} hideScopeControls={declared.has('scopeControls')} />
+          </div>
+        </div>
+      {/if}
+    </main>
+
+    <div class="content-right">
+      <RightSidebar hideTxPanel={semanticRxTx} {declared} />
+    </div>
+  </section>
+{/snippet}
+
 {#if skinId === 'mobile'}
   <MobileRadioLayout />
 {:else if skinId === 'lcd-cockpit'}
   <LcdLayout variant="cockpit" />
 {:else if skinId === 'lcd-scope'}
   <LcdLayout variant="scope" />
+{:else if skinId === 'sdr-test' && semanticDeck}
+  <div class="radio-layout sdr-test semantic-deck">
+    <StatusBar onSettings={() => (settingsOpen = true)} {declared} />
+    <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
+
+    <section class="receiver-deck" bind:this={receiverDeckElement} style={receiverDeckStyle}>
+      {#if semanticDeck}
+        <SemanticRadioSurfaces regions={true} regionContent={sdrRegionContent} />
+      {/if}
+    </section>
+  </div>
 {:else}
-<!--
-  `sdr-test` stays a pure IDENTITY hook (which entrypoint is on screen);
-  `semantic-deck` is the PRESENTATIONAL one — the taller deck row and the
-  wide-viewport promotion below belong to the semantic deck, not to one skin id,
-  now that a second family resolves into it (MOR-1313).
--->
 <div class="radio-layout" class:sdr-test={skinId === 'sdr-test'} class:semantic-deck={semanticDeck}>
   <StatusBar onSettings={() => (settingsOpen = true)} {declared} />
   <KeyboardHandler config={keyboardConfig} onAction={keyboardHandlers.dispatch} />
@@ -542,20 +569,12 @@
     deck was rejected — and deck sizing from a resolved canvas is MOR-2231
     step 2.
 
-    The two direct children of the wiring root that are never wrapped in a
-    `.surface-zone` (`txFaultRecovery`, `txAdjacentAlerts`) get rows 8 and 9.
-    Without a placement they auto-place into an implicit row below the meters
-    strip. Both self-hide completely, so an absent one collapses its row.
+    The direct status children and shell content receive explicit tracks beside
+    the fourteen zone boxes.
   */
   .radio-layout.sdr-test {
     grid-template-columns: 228px minmax(0, 1fr) 228px;
-    grid-template-rows: 28px auto auto auto auto auto auto auto auto auto;
-    /* Every row is content-sized, so the face is taller than the viewport with
-       fourteen surfaces on screen (measured: ~2.2x a 1000px-high viewport at
-       1920 wide). An `fr` row cannot help — there is no free space to
-       distribute, and the one this rule first carried collapsed to 0px and let
-       its items overlap the rows below. Scrolling the face is what keeps every
-       surface reachable; fitting it is deck sizing, MOR-2231 step 2. */
+    grid-template-rows: auto 28px repeat(9, auto);
     overflow-y: auto;
   }
   .radio-layout.sdr-test > .receiver-deck,
@@ -567,40 +586,41 @@
     align-self: start;
     min-width: 0;
   }
-  .radio-layout.sdr-test > :global(.status-bar) { grid-area: 1 / 1 / 2 / -1; }
+  .radio-layout.sdr-test > :global(.control-link-lost) { grid-area: 1 / 1 / 2 / -1; }
+  .radio-layout.sdr-test > :global(.status-bar) { grid-area: 2 / 1 / 3 / -1; }
   /* vfo-deck */
-  .radio-layout.sdr-test :global([data-zone-id='receiver-deck']) { grid-area: 2 / 1 / 3 / -1; }
+  .radio-layout.sdr-test :global([data-zone-id='receiver-deck']) { grid-area: 3 / 1 / 4 / -1; }
   /* left */
-  .radio-layout.sdr-test :global([data-zone-id='rf-front-end']) { grid-area: 3 / 1; }
-  .radio-layout.sdr-test :global([data-zone-id='filter']) { grid-area: 4 / 1; }
-  .radio-layout.sdr-test :global([data-zone-id='band']) { grid-area: 5 / 1; }
-  .radio-layout.sdr-test :global([data-zone-id='antenna']) { grid-area: 6 / 1; }
-  .radio-layout.sdr-test :global([data-zone-id='rit-xit-scan']) { grid-area: 7 / 1; }
+  .radio-layout.sdr-test :global([data-zone-id='rf-front-end']) { grid-area: 4 / 1 / 5 / 2; }
+  .radio-layout.sdr-test :global([data-zone-id='filter']) { grid-area: 5 / 1 / 6 / 2; }
+  .radio-layout.sdr-test :global([data-zone-id='band']) { grid-area: 6 / 1 / 7 / 2; }
+  .radio-layout.sdr-test :global([data-zone-id='antenna']) { grid-area: 7 / 1 / 8 / 2; }
+  .radio-layout.sdr-test :global([data-zone-id='rit-xit-scan']) { grid-area: 8 / 1 / 9 / 2; }
   /* centre-top, above the legacy spectrum this face keeps */
-  .radio-layout.sdr-test :global([data-zone-id='scope-controls']) { grid-area: 3 / 2; }
-  .radio-layout.sdr-test :global([data-zone-id='scope-display']) { grid-area: 4 / 2; }
-  .radio-layout.sdr-test > .content-row {
-    grid-area: 5 / 2 / 8 / 3;
+  .radio-layout.sdr-test :global([data-zone-id='scope-controls']) { grid-area: 4 / 2 / 5 / 3; }
+  .radio-layout.sdr-test :global([data-zone-id='scope-display']) { grid-area: 5 / 2 / 6 / 3; }
+  .radio-layout.sdr-test :global(.semantic-surfaces > .content-row) {
+    grid-area: 6 / 2 / 9 / 3;
     /* A floor, not a measurement: the legacy spectrum canvas has no intrinsic
        height, so a content-sized row collapses it to nothing. */
     min-height: 320px;
   }
   /* right */
-  .radio-layout.sdr-test :global([data-zone-id='rx-audio']) { grid-area: 3 / 3; }
-  .radio-layout.sdr-test :global([data-zone-id='dsp']) { grid-area: 4 / 3; }
-  .radio-layout.sdr-test :global([data-zone-id='cw-keyer']) { grid-area: 5 / 3; }
-  .radio-layout.sdr-test :global([data-zone-id='tx-aux']) { grid-area: 6 / 3; }
-  .radio-layout.sdr-test :global([data-zone-id='rx-tx']) { grid-area: 7 / 3; }
+  .radio-layout.sdr-test :global([data-zone-id='rx-audio']) { grid-area: 4 / 3 / 5 / 4; }
+  .radio-layout.sdr-test :global([data-zone-id='dsp']) { grid-area: 5 / 3 / 6 / 4; }
+  .radio-layout.sdr-test :global([data-zone-id='cw-keyer']) { grid-area: 6 / 3 / 7 / 4; }
+  .radio-layout.sdr-test :global([data-zone-id='tx-aux']) { grid-area: 7 / 3 / 8 / 4; }
+  .radio-layout.sdr-test :global([data-zone-id='rx-tx']) { grid-area: 8 / 3 / 9 / 4; }
   /* the two zone-less status plates */
   .radio-layout.sdr-test :global(.semantic-surfaces > .tx-fault-recovery) {
-    grid-area: 8 / 1 / 9 / -1;
+    grid-area: 9 / 1 / 10 / -1;
   }
   .radio-layout.sdr-test :global(.semantic-surfaces > .mod-input-tx-warning) {
-    grid-area: 9 / 1 / 10 / -1;
+    grid-area: 10 / 1 / 11 / -1;
   }
   /* meters-strip. Full width, and deliberately no `flex-direction` here: how
      the meters lay out inside their own box is not this grid's business. */
-  .radio-layout.sdr-test :global([data-zone-id='meters']) { grid-area: 10 / 1 / 11 / -1; }
+  .radio-layout.sdr-test :global([data-zone-id='meters']) { grid-area: 11 / 1 / 12 / -1; }
 
   .radio-layout, .radio-layout.semantic-deck {
     height: 100vh;
@@ -725,23 +745,26 @@
        fifth place, which is what the batch's browser probe measured. */
     .radio-layout.sdr-test {
       grid-template-columns: minmax(0, 1fr);
-      grid-template-rows: 28px repeat(17, auto);
+      grid-template-rows: auto 28px repeat(17, auto);
     }
-    .radio-layout.sdr-test :global([data-zone-id='scope-controls']) { grid-area: 8 / 1; }
-    .radio-layout.sdr-test :global([data-zone-id='scope-display']) { grid-area: 9 / 1; }
-    .radio-layout.sdr-test > .content-row { grid-area: 10 / 1; min-height: 660px; }
-    .radio-layout.sdr-test :global([data-zone-id='rx-audio']) { grid-area: 11 / 1; }
-    .radio-layout.sdr-test :global([data-zone-id='dsp']) { grid-area: 12 / 1; }
-    .radio-layout.sdr-test :global([data-zone-id='cw-keyer']) { grid-area: 13 / 1; }
-    .radio-layout.sdr-test :global([data-zone-id='tx-aux']) { grid-area: 14 / 1; }
-    .radio-layout.sdr-test :global([data-zone-id='rx-tx']) { grid-area: 15 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='scope-controls']) { grid-area: 9 / 1 / 10 / -1; }
+    .radio-layout.sdr-test :global([data-zone-id='scope-display']) { grid-area: 10 / 1 / 11 / -1; }
+    .radio-layout.sdr-test :global(.semantic-surfaces > .content-row) {
+      grid-area: 11 / 1 / 12 / -1;
+      min-height: 660px;
+    }
+    .radio-layout.sdr-test :global([data-zone-id='rx-audio']) { grid-area: 12 / 1 / 13 / -1; }
+    .radio-layout.sdr-test :global([data-zone-id='dsp']) { grid-area: 13 / 1 / 14 / -1; }
+    .radio-layout.sdr-test :global([data-zone-id='cw-keyer']) { grid-area: 14 / 1 / 15 / -1; }
+    .radio-layout.sdr-test :global([data-zone-id='tx-aux']) { grid-area: 15 / 1 / 16 / -1; }
+    .radio-layout.sdr-test :global([data-zone-id='rx-tx']) { grid-area: 16 / 1 / 17 / -1; }
     .radio-layout.sdr-test :global(.semantic-surfaces > .tx-fault-recovery) {
-      grid-area: 16 / 1;
+      grid-area: 17 / 1 / 18 / -1;
     }
     .radio-layout.sdr-test :global(.semantic-surfaces > .mod-input-tx-warning) {
-      grid-area: 17 / 1;
+      grid-area: 18 / 1 / 19 / -1;
     }
-    .radio-layout.sdr-test :global([data-zone-id='meters']) { grid-area: 18 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='meters']) { grid-area: 19 / 1 / 20 / -1; }
 
     .content-row {
       grid-template-columns: 1fr;

--- a/frontend/src/components-v2/layout/RadioLayout.svelte
+++ b/frontend/src/components-v2/layout/RadioLayout.svelte
@@ -492,13 +492,18 @@
     display: grid;
     grid-template-rows: 28px 200px minmax(0, 1fr) auto;
   }
-  .radio-layout.semantic-deck {
+  .radio-layout.semantic-deck:not(.sdr-test) {
     grid-template-rows: 28px 280px minmax(0, 1fr) auto;
   }
+  /* MOR-2231 (step 1, batch 5): `:not(.sdr-test)` on this rule and on the
+     promotion below hands the SDR face over to its own grid further down,
+     without relying on source order to break a specificity tie. No other
+     face can carry that class (`class:sdr-test={skinId === 'sdr-test'}`
+     above), so this changes nothing for `desktop-v2`. */
   /* Wide-viewport promotion: sidebars move up to flank the VFO row.
      Below 1680px we keep the stacked layout (VFO full-width, sidebars below). */
   @media (min-width: 1680px) {
-    .radio-layout.semantic-deck {
+    .radio-layout.semantic-deck:not(.sdr-test) {
       grid-template-columns: 228px minmax(0, 1fr) 228px;
       grid-template-rows: 28px 280px minmax(0, 1fr) auto;
       grid-template-areas:
@@ -507,17 +512,96 @@
         "left   center right"
         "dock   dock   dock";
     }
-    .radio-layout.semantic-deck > :global(.status-bar) { grid-area: status; }
-    .radio-layout.semantic-deck > .receiver-deck { grid-area: deck; }
-    .radio-layout.semantic-deck > .bottom-dock { grid-area: dock; }
+    .radio-layout.semantic-deck:not(.sdr-test) > :global(.status-bar) { grid-area: status; }
+    .radio-layout.semantic-deck:not(.sdr-test) > .receiver-deck { grid-area: deck; }
+    .radio-layout.semantic-deck:not(.sdr-test) > .bottom-dock { grid-area: dock; }
     /* Flatten content-row so its children become direct grid items. */
-    .radio-layout.semantic-deck > .content-row {
+    .radio-layout.semantic-deck:not(.sdr-test) > .content-row {
       display: contents;
     }
-    .radio-layout.semantic-deck > .content-row > .content-left { grid-area: left; }
-    .radio-layout.semantic-deck > .content-row > .content-right { grid-area: right; }
-    .radio-layout.semantic-deck > .content-row > .content-center { grid-area: center; }
+    .radio-layout.semantic-deck:not(.sdr-test) > .content-row > .content-left { grid-area: left; }
+    .radio-layout.semantic-deck:not(.sdr-test) > .content-row > .content-right { grid-area: right; }
+    .radio-layout.semantic-deck:not(.sdr-test) > .content-row > .content-center { grid-area: center; }
   }
+
+  /*
+    MOR-2231 (step 1, batch 5) — the SDR face's fourteen zones, laid out as
+    five regions: the VFO deck full width under the status bar, a left control
+    column, a centre column whose top holds the scope pair and whose body keeps
+    the legacy spectrum, a right column ending in the RX/TX authority, and a
+    full-width meters strip at the bottom.
+
+    MECHANISM. `.receiver-deck` and the wiring root both become
+    `display: contents`, so the `[data-zone-id]` boxes are direct grid items of
+    `.radio-layout` and this shell places each one. Five named grid AREAS would
+    not do it: fourteen items assigned to five areas land in five rectangles and
+    stack. The regions are what the explicit per-zone placement RENDERS as.
+
+    `display: contents` also drops `.receiver-deck`'s `overflow: hidden`, so
+    nothing clips the semantic column any more. That is deliberate — the clipped
+    deck was rejected — and deck sizing from a resolved canvas is MOR-2231
+    step 2.
+
+    The two direct children of the wiring root that are never wrapped in a
+    `.surface-zone` (`txFaultRecovery`, `txAdjacentAlerts`) get rows 8 and 9.
+    Without a placement they auto-place into an implicit row below the meters
+    strip. Both self-hide completely, so an absent one collapses its row.
+  */
+  .radio-layout.sdr-test {
+    grid-template-columns: 228px minmax(0, 1fr) 228px;
+    grid-template-rows: 28px auto auto auto auto auto auto auto auto auto;
+    /* Every row is content-sized, so the face is taller than the viewport with
+       fourteen surfaces on screen (measured: ~2.2x a 1000px-high viewport at
+       1920 wide). An `fr` row cannot help — there is no free space to
+       distribute, and the one this rule first carried collapsed to 0px and let
+       its items overlap the rows below. Scrolling the face is what keeps every
+       surface reachable; fitting it is deck sizing, MOR-2231 step 2. */
+    overflow-y: auto;
+  }
+  .radio-layout.sdr-test > .receiver-deck,
+  .radio-layout.sdr-test :global(.semantic-surfaces) {
+    display: contents;
+  }
+  /* Zones size to their content; the centre column's spectrum takes the slack. */
+  .radio-layout.sdr-test :global(.semantic-surfaces > [data-zone-id]) {
+    align-self: start;
+    min-width: 0;
+  }
+  .radio-layout.sdr-test > :global(.status-bar) { grid-area: 1 / 1 / 2 / -1; }
+  /* vfo-deck */
+  .radio-layout.sdr-test :global([data-zone-id='receiver-deck']) { grid-area: 2 / 1 / 3 / -1; }
+  /* left */
+  .radio-layout.sdr-test :global([data-zone-id='rf-front-end']) { grid-area: 3 / 1; }
+  .radio-layout.sdr-test :global([data-zone-id='filter']) { grid-area: 4 / 1; }
+  .radio-layout.sdr-test :global([data-zone-id='band']) { grid-area: 5 / 1; }
+  .radio-layout.sdr-test :global([data-zone-id='antenna']) { grid-area: 6 / 1; }
+  .radio-layout.sdr-test :global([data-zone-id='rit-xit-scan']) { grid-area: 7 / 1; }
+  /* centre-top, above the legacy spectrum this face keeps */
+  .radio-layout.sdr-test :global([data-zone-id='scope-controls']) { grid-area: 3 / 2; }
+  .radio-layout.sdr-test :global([data-zone-id='scope-display']) { grid-area: 4 / 2; }
+  .radio-layout.sdr-test > .content-row {
+    grid-area: 5 / 2 / 8 / 3;
+    /* A floor, not a measurement: the legacy spectrum canvas has no intrinsic
+       height, so a content-sized row collapses it to nothing. */
+    min-height: 320px;
+  }
+  /* right */
+  .radio-layout.sdr-test :global([data-zone-id='rx-audio']) { grid-area: 3 / 3; }
+  .radio-layout.sdr-test :global([data-zone-id='dsp']) { grid-area: 4 / 3; }
+  .radio-layout.sdr-test :global([data-zone-id='cw-keyer']) { grid-area: 5 / 3; }
+  .radio-layout.sdr-test :global([data-zone-id='tx-aux']) { grid-area: 6 / 3; }
+  .radio-layout.sdr-test :global([data-zone-id='rx-tx']) { grid-area: 7 / 3; }
+  /* the two zone-less status plates */
+  .radio-layout.sdr-test :global(.semantic-surfaces > .tx-fault-recovery) {
+    grid-area: 8 / 1 / 9 / -1;
+  }
+  .radio-layout.sdr-test :global(.semantic-surfaces > .mod-input-tx-warning) {
+    grid-area: 9 / 1 / 10 / -1;
+  }
+  /* meters-strip. Full width, and deliberately no `flex-direction` here: how
+     the meters lay out inside their own box is not this grid's business. */
+  .radio-layout.sdr-test :global([data-zone-id='meters']) { grid-area: 10 / 1 / 11 / -1; }
+
   .radio-layout, .radio-layout.semantic-deck {
     height: 100vh;
     background:
@@ -632,6 +716,32 @@
     .radio-layout {
       grid-template-rows: 28px auto minmax(0, auto) auto auto;
     }
+
+    /* MOR-2231 (step 1, batch 5): the SDR face's explicit narrow answer. One
+       column, with each region kept whole and in region order — deck, left,
+       centre-top, spectrum, right, status plates, meters. Left keeps rows 3-7,
+       so only the centre and right groups move. Falling back to source order
+       here would interleave left and right and float the meters strip up to
+       fifth place, which is what the batch's browser probe measured. */
+    .radio-layout.sdr-test {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: 28px repeat(17, auto);
+    }
+    .radio-layout.sdr-test :global([data-zone-id='scope-controls']) { grid-area: 8 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='scope-display']) { grid-area: 9 / 1; }
+    .radio-layout.sdr-test > .content-row { grid-area: 10 / 1; min-height: 660px; }
+    .radio-layout.sdr-test :global([data-zone-id='rx-audio']) { grid-area: 11 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='dsp']) { grid-area: 12 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='cw-keyer']) { grid-area: 13 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='tx-aux']) { grid-area: 14 / 1; }
+    .radio-layout.sdr-test :global([data-zone-id='rx-tx']) { grid-area: 15 / 1; }
+    .radio-layout.sdr-test :global(.semantic-surfaces > .tx-fault-recovery) {
+      grid-area: 16 / 1;
+    }
+    .radio-layout.sdr-test :global(.semantic-surfaces > .mod-input-tx-warning) {
+      grid-area: 17 / 1;
+    }
+    .radio-layout.sdr-test :global([data-zone-id='meters']) { grid-area: 18 / 1; }
 
     .content-row {
       grid-template-columns: 1fr;

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -137,6 +137,7 @@ vi.mock('$lib/stores/capabilities.svelte', () => ({
 }));
 
 import RadioLayout from '../RadioLayout.svelte';
+import SemanticRadioSurfaces from '../../wiring/SemanticRadioSurfaces.svelte';
 import { getCapabilities, hasAnyScope, hasCapability } from '$lib/stores/capabilities.svelte';
 import { topologyFixtures, type TopologyFixtureId } from '../../../semantic/fixtures/topologies';
 import {
@@ -1175,6 +1176,148 @@ describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () 
   // R9: the last two zones in the vocabulary add no key/unkey authority.
   it('adds no key authority with the centre-top pair declared', () => {
     expect(renderAll('sdr-test').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+  });
+});
+/**
+ * MOR-2231 (step 1, batch 5) — the SDR face's fourteen zones laid out as five
+ * regions.
+ *
+ * WHAT THIS FILE CAN AND CANNOT SEE. The mechanism is CSS: under the SDR
+ * branch `.receiver-deck` and the wiring root both become `display: contents`,
+ * so the zone boxes are direct grid items of `.radio-layout` and the shell
+ * places each one. jsdom under this vitest config carries no stylesheets at
+ * all, so no row below can observe `display: contents`, a grid track, or a
+ * region boundary. Geometry is measured in a real engine instead (three
+ * viewport widths, recorded in the PR). What is left for jsdom is the two
+ * halves the CSS rests on: the DECLARATION reaching the DOM as a zone element
+ * (rows 1-2), and every declared zone actually being named by a placement rule
+ * (row 5) — an unplaced grid item is what the batch's browser probe measured
+ * landing in an implicit row below the meters strip.
+ *
+ * THE CONTROL DIFFERS IN EXACTLY ONE DIMENSION: the `regions` prop. Both sides
+ * resolve the SAME plan from the SAME `sdrTestLayout`, and neither mounts
+ * `RadioLayout`, so no CSS class differs either. That matters here and not
+ * before: `RadioLayout.svelte` derives `regions` and `class:sdr-test` from the
+ * same `skinId === 'sdr-test'` predicate, so a control routed through the shell
+ * cannot vary one without the other — and this batch is what makes the class
+ * load-bearing.
+ */
+describe("the SDR face's zones are placed as five regions (MOR-2231, batch 5)", () => {
+  /** The vertical alone, so `regions` is the only thing that varies. */
+  function renderVertical(regions: boolean, workspace = DEFAULT_WORKSPACE): HTMLElement {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const plan = resolveSurfacePlan(sdrTestLayout, workspace);
+    mounted.push(mount(SemanticRadioSurfaces, {
+      target,
+      props: { regions },
+      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+    }));
+    flushSync();
+    return target;
+  }
+
+  /** An imported/persisted workspace that hides `dsp` in its own zone. `dsp`
+   *  is not in `requiredSemanticSurfaces`, so `resolveSurfacePlan` does not
+   *  force it back and the zone resolves empty — the one reachable way to make
+   *  `zoneOwning()` answer null on this face. */
+  const DSP_HIDDEN = { ...DEFAULT_WORKSPACE, visibleSurfaces: { dsp: [] } };
+
+  // `deriveDsp` opens on any of nr / nb / notch / agc; without one the surface
+  // never renders and both subtraction rows below would pass vacuously — the
+  // failure the first draft of this describe actually hit.
+  beforeEach(() => {
+    h.caps = {
+      ...(capsFor('2/main_sub') as object),
+      capabilities: ['scope', 'audio', 'tx', 'dual_rx', 'nr', 'nb', 'notch', 'agc'],
+    } as Capabilities;
+  });
+
+  // NON-VACUITY for the two subtraction rows: with nothing subtracted this
+  // fixture really does render `dsp`, inside its declared zone.
+  it('renders dsp inside its declared zone with nothing subtracted', () => {
+    const t = renderVertical(true);
+    expect(t.querySelector('[data-zone-id="dsp"] [data-testid="dsp-surface"]')).not.toBeNull();
+  });
+
+  // MUTATION KILLED: dropping `regions` from the `zoned()` route for `vfo`/
+  // `rxTx`. Nothing else separates these two rows.
+  it('hosts vfo and rxTx in their declared zone elements when regions is set', () => {
+    const t = renderVertical(true);
+    expect(t.querySelector('[data-zone-id="receiver-deck"] [data-testid="vfo-surface"]'))
+      .not.toBeNull();
+    expect(t.querySelector('[data-zone-id="rx-tx"] [data-testid="rx-tx-surface"]'))
+      .not.toBeNull();
+  });
+
+  // The control for the row above: same plan, same manifest, same component,
+  // `regions` flipped and nothing else.
+  it('renders vfo and rxTx bare when regions is unset', () => {
+    const t = renderVertical(false);
+    const vfo = t.querySelector('[data-testid="vfo-surface"]');
+    const rxTx = t.querySelector('[data-testid="rx-tx-surface"]');
+    expect(vfo).not.toBeNull();
+    expect(rxTx).not.toBeNull();
+    expect(vfo!.closest('.surface-zone')).toBeNull();
+    expect(rxTx!.closest('.surface-zone')).toBeNull();
+    expect(t.querySelector('[data-zone-id="receiver-deck"]')).toBeNull();
+    expect(t.querySelector('[data-zone-id="rx-tx"]')).toBeNull();
+  });
+
+  // MUTATION KILLED: dropping `allowBare={!regions}` from the twelve optional
+  // `zoned()` calls on the single path. Under the shipped configuration that
+  // argument is never reached (every surface has a zone), so a subtraction is
+  // the only state that can tell the two apart.
+  it('drops a subtracted surface entirely when regions is set', () => {
+    const t = renderVertical(true, DSP_HIDDEN);
+    expect(t.querySelector('[data-zone-id="dsp"]')).toBeNull();
+    expect(t.querySelector('[data-testid="dsp-surface"]')).toBeNull();
+  });
+
+  // The control: without `regions` the same subtraction still renders the
+  // surface bare, which is the pre-batch behaviour every other face keeps.
+  it('still renders a subtracted surface bare when regions is unset', () => {
+    const t = renderVertical(false, DSP_HIDDEN);
+    const dsp = t.querySelector('[data-testid="dsp-surface"]');
+    expect(dsp).not.toBeNull();
+    expect(dsp!.closest('.surface-zone')).toBeNull();
+  });
+
+  /**
+   * The stylesheet half, read as a DERIVED list against the manifest rather
+   * than a hand-kept one: a zone declared with no placement rule becomes an
+   * auto-placed grid item, which is the failure the browser probe measured for
+   * the two status plates. This cannot see whether the placement is CORRECT —
+   * only that every declared zone has one.
+   */
+  const RADIO_LAYOUT_SOURCE = readFileSync('src/components-v2/layout/RadioLayout.svelte', 'utf8');
+  const placementFor = (id: string): RegExpMatchArray[] => [...RADIO_LAYOUT_SOURCE.matchAll(
+    new RegExp(`\\.radio-layout\\.sdr-test[^{]*\\[data-zone-id='${id}'\\][^{]*\\{[^}]*grid-area`, 'g'),
+  )];
+
+  it('names every declared sdr-test zone in a placement rule', () => {
+    // Non-vacuity: the same reader finds nothing for a zone id this manifest
+    // does not declare, so a match above is evidence and not an artifact.
+    expect(placementFor('primary-vfo')).toEqual([]);
+    const unplaced = sdrTestLayout.zones.map((z) => z.id).filter((id) => placementFor(id).length === 0);
+    expect(unplaced).toEqual([]);
+  });
+
+  // The two direct children of the wiring root that are never wrapped in a
+  // `.surface-zone` — `txFaultRecovery` and `txAdjacentAlerts` — need a
+  // placement of their own for the same reason. Both class names are read back
+  // out of the components that render them, so a rename cannot leave a dead
+  // selector behind.
+  it('names both zone-less status plates in a placement rule', () => {
+    for (const [cls, source] of [
+      ['tx-fault-recovery', 'src/components-v2/wiring/SemanticRadioSurfaces.svelte'],
+      ['mod-input-tx-warning', 'src/components-v2/panels/ModInputTxWarning.svelte'],
+    ] as const) {
+      expect(readFileSync(source, 'utf8'), cls).toContain(`class="${cls}"`);
+      expect(RADIO_LAYOUT_SOURCE, cls).toMatch(
+        new RegExp(`\\.radio-layout\\.sdr-test[^{]*\\.${cls}\\)[^{]*\\{[^}]*grid-area`),
+      );
+    }
   });
 });
 

--- a/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
+++ b/frontend/src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts
@@ -18,7 +18,7 @@
  * the all-semantic case.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
+import { createRawSnippet, flushSync, mount, unmount, type Snippet } from 'svelte';
 import { readFileSync } from 'fs';
 import type { Capabilities } from '$lib/types/capabilities';
 import type { SkinId } from '../../../skins/registry';
@@ -151,7 +151,7 @@ import { desktopV2Layout, sdrTestLayout } from '../../../presentation/layouts/de
 // MOR-1367 (S8): the zone-ELEMENT assertions need the resolved plan in context
 // — see `renderWithPlan` in the S8 describe for why `render()` cannot show one.
 import { resolveSurfacePlan, SURFACE_PLAN_CONTEXT_KEY } from '../../../presentation/workspace/resolution';
-import { DEFAULT_WORKSPACE } from '../../../presentation/workspace/contract';
+import { DEFAULT_WORKSPACE, readWorkspace } from '../../../presentation/workspace/contract';
 
 /**
  * MOR-1313 fix round — PARTIALLY DECLARING manifests, the quadrants no shipped
@@ -1178,117 +1178,152 @@ describe("the SDR face's centre-top pair is zone-owned (MOR-2231, batch 4)", () 
     expect(renderAll('sdr-test').querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
   });
 });
-/**
- * MOR-2231 (step 1, batch 5) — the SDR face's fourteen zones laid out as five
- * regions.
- *
- * WHAT THIS FILE CAN AND CANNOT SEE. The mechanism is CSS: under the SDR
- * branch `.receiver-deck` and the wiring root both become `display: contents`,
- * so the zone boxes are direct grid items of `.radio-layout` and the shell
- * places each one. jsdom under this vitest config carries no stylesheets at
- * all, so no row below can observe `display: contents`, a grid track, or a
- * region boundary. Geometry is measured in a real engine instead (three
- * viewport widths, recorded in the PR). What is left for jsdom is the two
- * halves the CSS rests on: the DECLARATION reaching the DOM as a zone element
- * (rows 1-2), and every declared zone actually being named by a placement rule
- * (row 5) — an unplaced grid item is what the batch's browser probe measured
- * landing in an implicit row below the meters strip.
- *
- * THE CONTROL DIFFERS IN EXACTLY ONE DIMENSION: the `regions` prop. Both sides
- * resolve the SAME plan from the SAME `sdrTestLayout`, and neither mounts
- * `RadioLayout`, so no CSS class differs either. That matters here and not
- * before: `RadioLayout.svelte` derives `regions` and `class:sdr-test` from the
- * same `skinId === 'sdr-test'` predicate, so a control routed through the shell
- * cannot vary one without the other — and this batch is what makes the class
- * load-bearing.
- */
+/** MOR-2231 (step 1, batch 5): SDR semantic source order and grid inventory. */
 describe("the SDR face's zones are placed as five regions (MOR-2231, batch 5)", () => {
-  /** The vertical alone, so `regions` is the only thing that varies. */
-  function renderVertical(regions: boolean, workspace = DEFAULT_WORKSPACE): HTMLElement {
+  type Workspace = typeof DEFAULT_WORKSPACE;
+  const sentinel = createRawSnippet(() => ({
+    render: () => '<section data-testid="region-content-sentinel"></section>',
+  }));
+
+  function renderVertical(
+    regions: boolean,
+    workspace: Workspace | null = DEFAULT_WORKSPACE,
+    regionContent?: Snippet,
+  ): HTMLElement {
     const target = document.createElement('div');
     document.body.appendChild(target);
-    const plan = resolveSurfacePlan(sdrTestLayout, workspace);
+    const context = workspace === null
+      ? undefined
+      : new Map([[SURFACE_PLAN_CONTEXT_KEY, () => resolveSurfacePlan(sdrTestLayout, workspace)]]);
     mounted.push(mount(SemanticRadioSurfaces, {
       target,
-      props: { regions },
-      context: new Map([[SURFACE_PLAN_CONTEXT_KEY, () => plan]]),
+      props: { regions, regionContent },
+      context,
     }));
     flushSync();
     return target;
   }
 
-  /** An imported/persisted workspace that hides `dsp` in its own zone. `dsp`
-   *  is not in `requiredSemanticSurfaces`, so `resolveSurfacePlan` does not
-   *  force it back and the zone resolves empty — the one reachable way to make
-   *  `zoneOwning()` answer null on this face. */
-  const DSP_HIDDEN = { ...DEFAULT_WORKSPACE, visibleSurfaces: { dsp: [] } };
+  const OPTIONAL = [
+    ['tx-aux', 'tx-aux-surface'],
+    ['meters', 'meters-surface'],
+    ['rx-audio', 'rx-audio-surface'],
+    ['filter', 'filter-surface'],
+    ['dsp', 'dsp-surface'],
+    ['rf-front-end', 'rf-front-end-surface'],
+    ['band', 'band-surface'],
+    ['antenna', 'antenna-surface'],
+    ['rit-xit-scan', 'ritxit-scan-surface'],
+    ['cw-keyer', 'cw-keyer-surface'],
+    ['scope-display', 'scope-display-surface'],
+    ['scope-controls', 'scope-controls-surface'],
+  ] as const;
 
-  // `deriveDsp` opens on any of nr / nb / notch / agc; without one the surface
-  // never renders and both subtraction rows below would pass vacuously — the
-  // failure the first draft of this describe actually hit.
   beforeEach(() => {
     h.caps = {
       ...(capsFor('2/main_sub') as object),
-      capabilities: ['scope', 'audio', 'tx', 'dual_rx', 'nr', 'nb', 'notch', 'agc'],
+      antennas: 2,
+      capabilities: [
+        'scope', 'audio', 'tx', 'dual_rx', 'rit', 'xit', 'preamp', 'attenuator',
+        'rf_gain', 'af_level', 'nr', 'nb', 'notch', 'agc', 'cw', 'break_in',
+        'apf', 'tuner', 'vox', 'compressor', 'monitor', 'drive_gain',
+      ],
+      modes: ['LSB', 'USB', 'CW'],
+      filters: ['FIL1', 'FIL2', 'FIL3'],
+      freqRanges: [{
+        start: 1_800_000, end: 30_000_000, label: 'HF',
+        bands: [{ name: '20m', start: 14_000_000, end: 14_350_000, default: 14_225_000 }],
+      }],
     } as Capabilities;
+    const state = liveState() as { main: Record<string, unknown> };
+    h.state = {
+      ...state,
+      main: { ...state.main, sMeter: 120 },
+      scanning: false, scanType: 0x34, scanResumeMode: 1,
+      txAntenna: 1, rxAntenna1: 0, ritOn: false, ritTx: false, ritFreq: 0,
+    };
   });
 
-  // NON-VACUITY for the two subtraction rows: with nothing subtracted this
-  // fixture really does render `dsp`, inside its declared zone.
-  it('renders dsp inside its declared zone with nothing subtracted', () => {
-    const t = renderVertical(true);
-    expect(t.querySelector('[data-zone-id="dsp"] [data-testid="dsp-surface"]')).not.toBeNull();
+  it('uses the SDR region sequence while regions=false keeps the previous surface sequence', () => {
+    const zoned = renderVertical(true, DEFAULT_WORKSPACE, sentinel)
+      .querySelector('[data-testid="semantic-radio-surfaces"]')!;
+    expect([...zoned.children].map((el) =>
+      el.getAttribute('data-zone-id')
+        ?? (el.matches('.content-row, [data-testid="region-content-sentinel"]') ? 'content-row' : null),
+    ).filter(Boolean)).toEqual([
+      'receiver-deck', 'rf-front-end', 'filter', 'band', 'antenna', 'rit-xit-scan',
+      'scope-controls', 'scope-display', 'content-row', 'rx-audio', 'dsp', 'cw-keyer',
+      'tx-aux', 'rx-tx', 'meters',
+    ]);
+    expect(zoned.querySelectorAll('[data-testid="region-content-sentinel"]').length).toBe(1);
+    expect(zoned.querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+
+    const bare = renderVertical(false, DEFAULT_WORKSPACE, sentinel)
+      .querySelector('[data-testid="semantic-radio-surfaces"]')!;
+    expect([...bare.children].map((el) => el.getAttribute('data-testid')
+      ?? el.querySelector('[data-testid$="-surface"]')?.getAttribute('data-testid')).filter(Boolean)).toEqual([
+      'vfo-surface', 'rx-tx-surface', 'tx-aux-surface', 'meters-surface',
+      'rx-audio-surface', 'filter-surface', 'dsp-surface', 'rf-front-end-surface',
+      'band-surface', 'antenna-surface', 'ritxit-scan-surface', 'cw-keyer-surface',
+      'scope-display-surface', 'scope-controls-surface',
+    ]);
+    expect(bare.querySelector('[data-testid="region-content-sentinel"]')).toBeNull();
+    expect(bare.querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
   });
 
-  // MUTATION KILLED: dropping `regions` from the `zoned()` route for `vfo`/
-  // `rxTx`. Nothing else separates these two rows.
-  it('hosts vfo and rxTx in their declared zone elements when regions is set', () => {
-    const t = renderVertical(true);
-    expect(t.querySelector('[data-zone-id="receiver-deck"] [data-testid="vfo-surface"]'))
+  it.each(OPTIONAL)('%s subtraction removes its SDR host and body but keeps the old bare fallback',
+    (zoneId, testid) => {
+      const present = renderVertical(true);
+      expect(present.querySelector(`[data-zone-id="${zoneId}"] [data-testid="${testid}"]`), testid)
+        .not.toBeNull();
+
+      const hidden = {
+        ...DEFAULT_WORKSPACE,
+        visibleSurfaces: { [zoneId]: [] },
+      } as Workspace;
+      const zoned = renderVertical(true, hidden);
+      expect(zoned.querySelector(`[data-zone-id="${zoneId}"]`)).toBeNull();
+      expect(zoned.querySelector(`[data-testid="${testid}"]`)).toBeNull();
+
+      const bare = renderVertical(false, hidden).querySelector(`[data-testid="${testid}"]`);
+      expect(bare).not.toBeNull();
+      expect(bare!.closest('.surface-zone')).toBeNull();
+    });
+
+  it('keeps available surfaces bare without a plan and restores required imported surfaces', () => {
+    const noPlan = renderVertical(true, null);
+    expect(noPlan.querySelectorAll('[data-zone-id]').length).toBe(0);
+    for (const [, testid] of OPTIONAL) {
+      expect(noPlan.querySelector(`[data-testid="${testid}"]`), testid).not.toBeNull();
+    }
+    expect(noPlan.querySelector('[data-testid="vfo-surface"]')).not.toBeNull();
+    expect(noPlan.querySelector('[data-testid="rx-tx-surface"]')).not.toBeNull();
+
+    const imported = readWorkspace({
+      ...DEFAULT_WORKSPACE,
+      visibleSurfaces: { 'receiver-deck': [], 'rx-tx': [], dsp: [] },
+    });
+    expect(imported.rejections).toEqual([]);
+    const restored = renderVertical(true, imported.workspace as Workspace);
+    expect(restored.querySelector('[data-zone-id="receiver-deck"] [data-testid="vfo-surface"]'))
       .not.toBeNull();
-    expect(t.querySelector('[data-zone-id="rx-tx"] [data-testid="rx-tx-surface"]'))
+    expect(restored.querySelector('[data-zone-id="rx-tx"] [data-testid="rx-tx-surface"]'))
       .not.toBeNull();
+    expect(restored.querySelector('[data-testid="dsp-surface"]')).toBeNull();
   });
 
-  // The control for the row above: same plan, same manifest, same component,
-  // `regions` flipped and nothing else.
-  it('renders vfo and rxTx bare when regions is unset', () => {
-    const t = renderVertical(false);
-    const vfo = t.querySelector('[data-testid="vfo-surface"]');
-    const rxTx = t.querySelector('[data-testid="rx-tx-surface"]');
-    expect(vfo).not.toBeNull();
-    expect(rxTx).not.toBeNull();
-    expect(vfo!.closest('.surface-zone')).toBeNull();
-    expect(rxTx!.closest('.surface-zone')).toBeNull();
-    expect(t.querySelector('[data-zone-id="receiver-deck"]')).toBeNull();
-    expect(t.querySelector('[data-zone-id="rx-tx"]')).toBeNull();
-  });
-
-  // MUTATION KILLED: dropping `allowBare={!regions}` from the twelve optional
-  // `zoned()` calls on the single path. Under the shipped configuration that
-  // argument is never reached (every surface has a zone), so a subtraction is
-  // the only state that can tell the two apart.
-  it('drops a subtracted surface entirely when regions is set', () => {
-    const t = renderVertical(true, DSP_HIDDEN);
-    expect(t.querySelector('[data-zone-id="dsp"]')).toBeNull();
-    expect(t.querySelector('[data-testid="dsp-surface"]')).toBeNull();
-  });
-
-  // The control: without `regions` the same subtraction still renders the
-  // surface bare, which is the pre-batch behaviour every other face keeps.
-  it('still renders a subtracted surface bare when regions is unset', () => {
-    const t = renderVertical(false, DSP_HIDDEN);
-    const dsp = t.querySelector('[data-testid="dsp-surface"]');
-    expect(dsp).not.toBeNull();
-    expect(dsp!.closest('.surface-zone')).toBeNull();
+  it('mounts the SDR shell content and semantic authority once', () => {
+    const shell = render('sdr-test');
+    expect(shell.querySelectorAll('.content-row').length).toBe(1);
+    expect(shell.querySelectorAll('[data-testid="semantic-radio-surfaces"]').length).toBe(1);
+    expect(shell.querySelectorAll(KEY_AUTHORITIES).length).toBe(1);
+    const root = shell.querySelector('[data-testid="semantic-radio-surfaces"]')!;
+    expect(root.querySelector('.content-row')).not.toBeNull();
   });
 
   /**
-   * The stylesheet half, read as a DERIVED list against the manifest rather
-   * than a hand-kept one: a zone declared with no placement rule becomes an
-   * auto-placed grid item, which is the failure the browser probe measured for
-   * the two status plates. This cannot see whether the placement is CORRECT —
-   * only that every declared zone has one.
+   * This source inventory detects missing placement selectors. Track and
+   * rectangle correctness is exercised by the browser acceptance probe.
    */
   const RADIO_LAYOUT_SOURCE = readFileSync('src/components-v2/layout/RadioLayout.svelte', 'utf8');
   const placementFor = (id: string): RegExpMatchArray[] => [...RADIO_LAYOUT_SOURCE.matchAll(
@@ -1303,21 +1338,83 @@ describe("the SDR face's zones are placed as five regions (MOR-2231, batch 5)", 
     expect(unplaced).toEqual([]);
   });
 
-  // The two direct children of the wiring root that are never wrapped in a
-  // `.surface-zone` — `txFaultRecovery` and `txAdjacentAlerts` — need a
-  // placement of their own for the same reason. Both class names are read back
-  // out of the components that render them, so a rename cannot leave a dead
-  // selector behind.
-  it('names both zone-less status plates in a placement rule', () => {
+  it('names every non-zone in-flow box in a placement rule', () => {
     for (const [cls, source] of [
+      ['control-link-lost', 'src/components-v2/layout/StatusBar.svelte'],
+      ['status-bar', 'src/components-v2/layout/StatusBar.svelte'],
+      ['content-row', 'src/components-v2/layout/RadioLayout.svelte'],
       ['tx-fault-recovery', 'src/components-v2/wiring/SemanticRadioSurfaces.svelte'],
       ['mod-input-tx-warning', 'src/components-v2/panels/ModInputTxWarning.svelte'],
     ] as const) {
       expect(readFileSync(source, 'utf8'), cls).toContain(`class="${cls}"`);
-      expect(RADIO_LAYOUT_SOURCE, cls).toMatch(
-        new RegExp(`\\.radio-layout\\.sdr-test[^{]*\\.${cls}\\)[^{]*\\{[^}]*grid-area`),
-      );
+      expect(RADIO_LAYOUT_SOURCE, cls).toMatch(new RegExp(
+        `\\.radio-layout\\.sdr-test[^{]*\\.${cls}(?:\\)|\\b)[^{]*\\{[^}]*grid-area`,
+      ));
     }
+  });
+
+  /**
+   * These declarations are deliberately pinned separately from the browser
+   * probe. Source assertions make every row assignment a cheap changed-file
+   * regression and mutation target; the browser remains authoritative for
+   * computed tracks, rectangles, viewport visibility and overlap.
+   */
+  const WIDE_PLACEMENTS = [
+    ["> :global(.control-link-lost)", '1 / 1 / 2 / -1'],
+    ["> :global(.status-bar)", '2 / 1 / 3 / -1'],
+    [":global([data-zone-id='receiver-deck'])", '3 / 1 / 4 / -1'],
+    [":global([data-zone-id='rf-front-end'])", '4 / 1 / 5 / 2'],
+    [":global([data-zone-id='filter'])", '5 / 1 / 6 / 2'],
+    [":global([data-zone-id='band'])", '6 / 1 / 7 / 2'],
+    [":global([data-zone-id='antenna'])", '7 / 1 / 8 / 2'],
+    [":global([data-zone-id='rit-xit-scan'])", '8 / 1 / 9 / 2'],
+    [":global([data-zone-id='scope-controls'])", '4 / 2 / 5 / 3'],
+    [":global([data-zone-id='scope-display'])", '5 / 2 / 6 / 3'],
+    [":global(.semantic-surfaces > .content-row)", '6 / 2 / 9 / 3'],
+    [":global([data-zone-id='rx-audio'])", '4 / 3 / 5 / 4'],
+    [":global([data-zone-id='dsp'])", '5 / 3 / 6 / 4'],
+    [":global([data-zone-id='cw-keyer'])", '6 / 3 / 7 / 4'],
+    [":global([data-zone-id='tx-aux'])", '7 / 3 / 8 / 4'],
+    [":global([data-zone-id='rx-tx'])", '8 / 3 / 9 / 4'],
+    [":global(.semantic-surfaces > .tx-fault-recovery)", '9 / 1 / 10 / -1'],
+    [":global(.semantic-surfaces > .mod-input-tx-warning)", '10 / 1 / 11 / -1'],
+    [":global([data-zone-id='meters'])", '11 / 1 / 12 / -1'],
+  ] as const;
+
+  const NARROW_OVERRIDES = [
+    [":global([data-zone-id='scope-controls'])", '9 / 1 / 10 / -1'],
+    [":global([data-zone-id='scope-display'])", '10 / 1 / 11 / -1'],
+    [":global(.semantic-surfaces > .content-row)", '11 / 1 / 12 / -1'],
+    [":global([data-zone-id='rx-audio'])", '12 / 1 / 13 / -1'],
+    [":global([data-zone-id='dsp'])", '13 / 1 / 14 / -1'],
+    [":global([data-zone-id='cw-keyer'])", '14 / 1 / 15 / -1'],
+    [":global([data-zone-id='tx-aux'])", '15 / 1 / 16 / -1'],
+    [":global([data-zone-id='rx-tx'])", '16 / 1 / 17 / -1'],
+    [":global(.semantic-surfaces > .tx-fault-recovery)", '17 / 1 / 18 / -1'],
+    [":global(.semantic-surfaces > .mod-input-tx-warning)", '18 / 1 / 19 / -1'],
+    [":global([data-zone-id='meters'])", '19 / 1 / 20 / -1'],
+  ] as const;
+
+  function expectPlacement(source: string, selector: string, area: string): void {
+    expect(source).toContain(`.radio-layout.sdr-test ${selector}`);
+    const rule = source.slice(source.indexOf(`.radio-layout.sdr-test ${selector}`));
+    expect(rule.slice(0, rule.indexOf('}') + 1)).toContain(`grid-area: ${area}`);
+  }
+
+  it('pins the wide warning, chrome, region, notice and meter row declarations', () => {
+    const wide = RADIO_LAYOUT_SOURCE.slice(0, RADIO_LAYOUT_SOURCE.indexOf('@media (max-width: 1024px)'));
+    expect(wide).toContain('grid-template-columns: 228px minmax(0, 1fr) 228px');
+    expect(wide).toContain('grid-template-rows: auto 28px repeat(9, auto)');
+    expect(wide).toContain('min-height: 320px');
+    for (const [selector, area] of WIDE_PLACEMENTS) expectPlacement(wide, selector, area);
+  });
+
+  it('pins every declaration that changes at the narrow breakpoint', () => {
+    const narrow = RADIO_LAYOUT_SOURCE.slice(RADIO_LAYOUT_SOURCE.indexOf('@media (max-width: 1024px)'));
+    expect(narrow).toContain('grid-template-columns: minmax(0, 1fr)');
+    expect(narrow).toContain('grid-template-rows: auto 28px repeat(17, auto)');
+    expect(narrow).toContain('min-height: 660px');
+    for (const [selector, area] of NARROW_OVERRIDES) expectPlacement(narrow, selector, area);
   });
 });
 

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -135,6 +135,22 @@
     return zoneShowsSurface(surfacePlan(), zoneId, surface);
   }
   /**
+   * MOR-2231 (step 1, batch 5) — whether the single composition's OPTIONAL
+   * surfaces may still render outside a zone. See their render sites below.
+   *
+   * `regions` means the caller lays the zone boxes out as grid items, so a
+   * surface reaching that path with no zone would be an unplaced item. The
+   * reachable way for `zoneOwning()` to answer null there is a workspace
+   * SUBTRACTION that emptied the zone (an imported or persisted document;
+   * `resolveSurfacePlan` force-restores anything in `requiredSemanticSurfaces`).
+   *
+   * A mount with NO plan at all is excluded deliberately: no zone element
+   * exists then for ANY surface, so there is no arrangement to be unplaced
+   * beside — withholding the body would cost a readout and prevent nothing.
+   * That is also the condition every standalone mount of this component is in.
+   */
+  let allowBareSurfaces = $derived(!regions || surfacePlan() === null);
+  /**
    * MOR-1336 (v3-rework S4) — the DECLARED zone that mounts `surface`, or
    * `null` when no zone does.
    *
@@ -1494,20 +1510,32 @@
          the column — while still rendering unconditionally, so a fault raised
          by any lease source keeps a way out even if `rxTx` is absent. -->
     {@render txFaultRecovery()}
-    {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface)}
-    {@render zoned('meters', view?.meters !== undefined, metersSurface)}
-    {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface)}
-    {@render zoned('filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface)}
-    {@render zoned('dsp', view?.dsp !== undefined, dspSurface)}
-    {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface)}
-    {@render zoned('band', view?.band !== undefined, bandSurface)}
-    {@render zoned('antenna', view?.antenna !== undefined, antennaSurface)}
+    <!-- MOR-2231 (step 1, batch 5): the twelve OPTIONAL surfaces take
+         `allowBareSurfaces` (see its declaration above) instead of the bare
+         default. `vfo`/`rxTx` above keep the default: they are in
+         `requiredSemanticSurfaces`, which `resolveSurfacePlan` force-restores,
+         so no plan can leave either without a zone. -->
+    {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface, allowBareSurfaces)}
+    {@render zoned('meters', view?.meters !== undefined, metersSurface, allowBareSurfaces)}
+    {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface, allowBareSurfaces)}
+    {@render zoned(
+      'filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface,
+      allowBareSurfaces,
+    )}
+    {@render zoned('dsp', view?.dsp !== undefined, dspSurface, allowBareSurfaces)}
+    {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface, allowBareSurfaces)}
+    {@render zoned('band', view?.band !== undefined, bandSurface, allowBareSurfaces)}
+    {@render zoned('antenna', view?.antenna !== undefined, antennaSurface, allowBareSurfaces)}
     {@render zoned(
       'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
+      allowBareSurfaces,
     )}
-    {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface)}
-    {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface)}
-    {@render zoned('scopeControls', view?.scopeControls !== undefined, scopeControlsSurface)}
+    {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface, allowBareSurfaces)}
+    {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface, allowBareSurfaces)}
+    {@render zoned(
+      'scopeControls', view?.scopeControls !== undefined, scopeControlsSurface,
+      allowBareSurfaces,
+    )}
     {@render txAdjacentAlerts()}
   {/if}
 </div>

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -164,17 +164,9 @@
    * by `manifest.zones`, so the plan's KEY SET is exactly the active layout's
    * declared-zone set. App already computes it; this only consults it.
    *
-   * `null` → the caller renders BARE, byte-identical to the pre-S4 DOM. That is
-   * MOR-1069 enforced by construction: a zone element exists only where a
-   * layout actually declared one, never as an empty promise.
-   *
-   * LIMITATION, recorded rather than hidden: the plan is POST-subtraction, so
-   * "no zone declares this" and "a zone declared it and the workspace hid it"
-   * are indistinguishable here, and both render bare. That matches today
-   * exactly (these surfaces consult no plan at all before this slice), so no
-   * force-show is introduced and nothing regresses — but the workspace still
-   * cannot hide a zoned optional surface. Fixing that needs `SurfacePlan` to
-   * carry declaration and visibility separately (own ticket).
+   * A `null` result renders bare only when the caller permits that fallback.
+   * The ordered SDR caller below rejects it for a resolved plan, so workspace
+   * subtraction removes both zone and body; a no-plan mount keeps the body.
    */
   function zoneOwning(surface: SemanticSurfaceName): string | null {
     const plan = surfacePlan();
@@ -984,22 +976,10 @@
     declined renders the pre-1265 element shape exactly (pinned in
     `__tests__/semantic-tx-aux-wiring.component.test.ts`).
 
-    CORRECTION: the sentences that stood here described a bare, unzoned mount
-    in BOTH compositions because `'txAux'` was merely DECLARABLE. That held
-    only until MOR-1336 (S4), which routed this surface through the generic
-    `zoned()` path below AND declared the zone on both sides of the
-    composition split — `desktop-declarations.ts` (single, the flagship skin)
-    and `dual-receiver-cockpit.ts` (dual) each carry
-    `{ id: 'tx-aux', surfaces: ['txAux'] }`. It renders bare wherever
-    `zoneOwning()` finds no zone carrying it: under a layout that declares no
-    `tx-aux` zone, on a standalone mount that resolves no plan, OR when a
-    workspace subtraction has emptied the zone — see `zoneOwning`'s own
-    LIMITATION note above, which records that the plan is POST-subtraction and
-    that this last case is indistinguishable from the first two here.
-    `view?.txAux` (rather than the caller
-    nesting this under `{#if view}`) keeps the same "never renders while
-    view is null" behavior now that the surrounding structure changed
-    around it (MOR-1258).
+    The generic `zoned()` path owns placement. In the ordered SDR branch, a
+    resolved plan can subtract both the `tx-aux` host and body; a no-plan mount
+    keeps the available surface bare. `view?.txAux` keeps the surface absent
+    while the view is null.
   -->
   <!--
     MOR-1336 — the ONE zone-aware mount path, applied uniformly to every
@@ -1406,8 +1386,8 @@
     `skins/dual-receiver-cockpit/__tests__/DualReceiverCockpit.component
     .test.ts`'s MOR-2150 describe block. No longer bare under `desktop-v2`,
     which declared this zone in MOR-1370 (S6b-2) as the last surface in the
-    vocabulary to graduate; still bare under the single-composition layouts
-    that declare none (`sdr-test`/`mobile`/`lcd-*`).
+    vocabulary to graduate. `sdr-test` also declares this zone; the remaining
+    single-composition layouts (`mobile`/`lcd-*`) keep their existing bare path.
   -->
   {#snippet scopeControlsSurface()}
     {#if view?.scopeControls}

--- a/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
+++ b/frontend/src/components-v2/wiring/SemanticRadioSurfaces.svelte
@@ -90,6 +90,7 @@
   interface Props {
     strips?: 'single' | 'dual';
     regions?: boolean;
+    regionContent?: Snippet;
   }
   /**
    * MOR-2231 — `regions` routes `vfo`/`rxTx` through the generic `zoned()`
@@ -111,7 +112,7 @@
    * question: `desktop-v2` and `sdr-test` declare the same two zone ids, so
    * `zoneOwning()` returns non-null on both faces.
    */
-  let { strips = 'single', regions = false }: Props = $props();
+  let { strips = 'single', regions = false, regionContent }: Props = $props();
 
   /**
    * MOR-1082 — the workspace's per-zone `visibleSurfaces`/`zoneOrder`, resolved
@@ -147,7 +148,6 @@
    * A mount with NO plan at all is excluded deliberately: no zone element
    * exists then for ANY surface, so there is no arrangement to be unplaced
    * beside — withholding the body would cost a readout and prevent nothing.
-   * That is also the condition every standalone mount of this component is in.
    */
   let allowBareSurfaces = $derived(!regions || surfacePlan() === null);
   /**
@@ -1477,6 +1477,38 @@
     {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface)}
     {@render zoned('scopeControls', view?.scopeControls !== undefined, scopeControlsSurface, false)}
   {:else}
+    {#if regions}
+      {#if singleOrder.includes('vfo')}
+        {@render zoned('vfo', view !== null, vfoSurface)}
+      {/if}
+      {@render zoned('rfFrontEnd', view?.rfFrontEnd !== undefined, rfFrontEndSurface, allowBareSurfaces)}
+      {@render zoned(
+        'filter', view?.modeFilter !== undefined || view?.filterPassband !== undefined, filterSurface,
+        allowBareSurfaces,
+      )}
+      {@render zoned('band', view?.band !== undefined, bandSurface, allowBareSurfaces)}
+      {@render zoned('antenna', view?.antenna !== undefined, antennaSurface, allowBareSurfaces)}
+      {@render zoned(
+        'ritXitScan', view?.ritXit !== undefined || view?.scan !== undefined, ritXitScanSurface,
+        allowBareSurfaces,
+      )}
+      {@render zoned(
+        'scopeControls', view?.scopeControls !== undefined, scopeControlsSurface,
+        allowBareSurfaces,
+      )}
+      {@render zoned('scopeDisplay', view?.scopeDisplay !== undefined, scopeDisplaySurface, allowBareSurfaces)}
+      {#if regionContent}{@render regionContent()}{/if}
+      {@render zoned('rxAudio', view?.rxAudio !== undefined, rxAudioSurface, allowBareSurfaces)}
+      {@render zoned('dsp', view?.dsp !== undefined, dspSurface, allowBareSurfaces)}
+      {@render zoned('cwKeyer', view?.cwKeyer !== undefined, cwKeyerSurface, allowBareSurfaces)}
+      {@render zoned('txAux', view?.txAux !== undefined, txAuxSurface, allowBareSurfaces)}
+      {#if singleOrder.includes('rxTx')}
+        {@render zoned('rxTx', view !== null, rxTxSurface)}
+      {/if}
+      {@render txFaultRecovery()}
+      {@render txAdjacentAlerts()}
+      {@render zoned('meters', view?.meters !== undefined, metersSurface, allowBareSurfaces)}
+    {:else}
     <!--
       Single/default path (sdr-test / LCD / mobile). No zone CONTAINS the
       alerts here (MOR-1069 — the dual composition's `.rx-tx-zone` has no twin
@@ -1491,17 +1523,17 @@
       mounts both (LCD `control-column`, mobile `portrait-deck`) it is what
       reorders within it.
 
-      MOR-2231: `regions` decides whether each of the two gets the zone element
-      its plan names. Unset — every mount that predates that ticket — renders
-      them exactly as before: no wrapper, no `data-zone-id`.
+      This branch keeps the pre-MOR-2231 single/default sequence with bare
+      required surfaces when `regions` is unset.
     -->
     {#each singleOrder as surface (surface)}
       {#if surface === 'vfo'}
-        {#if regions}{@render zoned('vfo', view !== null, vfoSurface)}
-        {:else}{@render vfoSurface()}{/if}
+        {@render vfoSurface()}
       {:else if surface === 'rxTx'}
-        {#if regions}{@render zoned('rxTx', view !== null, rxTxSurface)}
-        {:else}{@render rxTxSurface()}{/if}
+        <!-- Preserve the pre-region compiled anchor topology on this literal path. -->
+        {#if !regions}
+          {@render rxTxSurface()}
+        {/if}
       {/if}
     {/each}
     <!-- MOR-1784: `singleOrder` ends in `rxTx` in every shipped layout
@@ -1537,6 +1569,7 @@
       allowBareSurfaces,
     )}
     {@render txAdjacentAlerts()}
+    {/if}
   {/if}
 </div>
 

--- a/frontend/src/skins/sdr-test/SdrTestSkin.svelte
+++ b/frontend/src/skins/sdr-test/SdrTestSkin.svelte
@@ -9,8 +9,7 @@
   because RadioLayout is where the v3 resolution happens: since MOR-1313 it
   reads THIS entrypoint's manifest and suppresses, per declared zone, the
   legacy twin of every semantic surface the manifest mounts. `sdr-test`
-  declares the VFO/RX-TX pair in one zone (`main: [vfo, rxTx]`), so the
-  semantic surfaces replace `<VfoHeader>` and the sidebars' `<TxPanel>` does
+  declares the VFO/RX-TX pair, so the semantic surfaces replace `<VfoHeader>` and the sidebars' `<TxPanel>` does
   not render (MOR-1065). Why the TX twin follows the deck rather than its
   own zone declaration is the R9 key/unkey argument on RadioLayout's
   `declared` / `semanticRxTx` derivations, and is not repeated here.


### PR DESCRIPTION
MOR-2231 step 1, batch 5 places the fourteen existing `sdr-test` semantic surfaces into a full-width receiver deck, left controls, centre scope, right RX/TX controls, notices, and bottom meters strip. It also suppresses optional bare surfaces when a persisted workspace subtracts their zone. The final deck indicator row and canvas sizing remain separate queued work.

**Fresh independent exact-head review passed at `04833ee5f14a01c8fda21234f41b50e73f9ec9e8`: [verdict](https://github.com/rigplane/rigplane-core/pull/3115#issuecomment-5530590853).** This head addresses the findings from the [initial blocked review](https://github.com/rigplane/rigplane-core/pull/3115#issuecomment-5527345429) and [follow-up exact-head review](https://github.com/rigplane/rigplane-core/pull/3115#issuecomment-5530296306): the existing control-link-loss warning now owns the first SDR grid row, SDR DOM and Tab order follow deck → left → scope → content → right → notices → meters, and inaccurate source prose was removed. This body records, but does not replace, the independent verdict.

The exact diff against merge base `b08f8a1297a3057a3486ec522fb7c5d75f44ae91` is 5 files, +481/-72 = 553 changed lines. This is within the 6-file/600-line soft threshold and 10-file/1000-line hard ceiling. The grid placement, ordered semantic branch, shell-content snippet, optional-surface guard, and focused component contract form one change.

The SDR shell flattens `.receiver-deck` and `.semantic-surfaces` with `display: contents` and explicitly places the resulting boxes. The existing `StatusBar` warning is unchanged and is placed above the 28px status bar. The shell-owned `.content-row` is injected once between scope and right-side semantic surfaces. One existing `SemanticRadioSurfaces` mount and one existing `RxTxSurface` authority remain. The shell scrolls, and final viewport-height fitting is not claimed here.

Mac mini correction-tree evidence:
- Focused command: `./node_modules/.bin/vitest run src/components-v2/layout/__tests__/semantic-desktop-migration.component.test.ts -t "batch 5" --reporter=verbose` — 19 passed, 132 skipped.
- Browser geometry and real Tab probes cover 1920x1000 and 900x1000 with disconnected neither/both notices, connected warning removal, and the 1024/1025 breakpoint. The warning is visible in row 1, the status bar is row 2, the deck is row 3, and notice/meter rows retain their explicit order.
- Raw `#app.innerHTML` is identical across corrected/prior/base inputs for desktop-v2, lcd-cockpit, lcd-scope, mobile, and ReferenceLayout. Desktop-v2 geometry is identical at 1920/1440/900 under deterministic animation suppression.
- The auditable Mac mini ledger at `/Users/moroz/Projects/mor2231-batch5-check.mrIzA1/repo/.claude/workflow/component-mutations-detailed.json` records all 17 component mutations with exact file, corrected line and branch context, stable call-site identity and occurrence counts, exact before/after diff, exact command, exit code, and the failing assertion/output. Its retained driver is `/Users/moroz/Projects/mor2231-batch5-check.mrIzA1/repo/.claude/workflow/component-mutations-detailed.mjs`. All twelve optional SDR calls, old SDR order, omitted content, and both required-surface guards failed their named assertions; the legitimate-equivalent `allowBare` control and exact restored-tree rerun passed. Browser controls rejected missing and wrong warning placement, old focus order, and omitted content, then passed on the restored tree.
- The pinned comparison method that overrode `requestAnimationFrame` timed out twice. Verification switched to a fresh bounded Vite process per pinned input; the final raw-DOM, geometry, source-restoration, and focused-test runs passed. No visual baselines were regenerated.

The previous-head quick and visual runs do not verify this new SHA. Current required checks and fresh independent review remain separate gates; passing local/Mac mini evidence does not override them.

Linear: MOR-2231. After batch 5 acceptance: MOR-2299 indicator row, MOR-2298 SDR baselines, then the three-topology canvas measurement and deck sizing.