### PR TITLE
docs(MOR-2297): delete the stale macOS-regen sentence from approved-baselines/README.md

### DIFF
--- a/frontend/fixtures/approved-baselines/README.md
+++ b/frontend/fixtures/approved-baselines/README.md
@@ -91,6 +91,4 @@ git status fixtures/approved-baselines/
 git add frontend/fixtures/approved-baselines/
 ```
 
-This local flow produces macOS baselines — fine for everyday intentional-change PRs during the rework series (see Batching, above), but NOT the procedure for the pre-blocking Linux re-pin (see Platform note, above).
-
 `manifest.json` regenerates every run (`tests/e2e/visual/global-teardown.ts`), recording the commit, platform, and tool versions behind the committed set — commit it with the PNGs. Its `commit`/`commitShort` fields are read at run time, so when the regeneration is part of the commit being made, they necessarily record that commit's PARENT (the manifest can't know its own future commit hash) — this is documented, honest behaviour, not a bug. A PR that intentionally changes cockpit/PTT visuals MUST include regenerated baselines + `manifest.json`, reviewed as an image diff, not waved through — and when the change is a **regeneration** (as opposed to a from-scratch capture), the PR description must state which captures are expected to change and why, so the reviewer is confirming a named expectation rather than rubber-stamping N changed PNGs.


### PR DESCRIPTION
Linear: MOR-2297

Deletes one sentence from `frontend/fixtures/approved-baselines/README.md`, the paragraph that followed the `## Updating baselines (intentional change)` code fence:

> This local flow produces macOS baselines — fine for everyday intentional-change PRs during the rework series (see Batching, above), but NOT the procedure for the pre-blocking Linux re-pin (see Platform note, above).

## Why deleted, not reworded

It contradicts the same file's **Platform note** section, which states `.github/workflows/visual.yml` is now blocking and gives the "Regenerating from Linux (required for a future platform re-pin — do NOT do this on macOS)" recipe; `manifest.json` records the regeneration platform. A macOS-local regen flow being "fine for everyday intentional-change PRs" is not a nuance under a blocking gate — it is simply wrong, and it sits two sections below the doctrine it contradicts.

Per `CLAUDE.md` § Testing, "Delete before you narrow; never weaken": a false claim in prose is deleted, because a missing sentence sends the reader to the code while a wrong one convinces them they need not look.

## Diff

```diff
diff --git a/frontend/fixtures/approved-baselines/README.md b/frontend/fixtures/approved-baselines/README.md
index be7f8f52..c585f2ef 100644
--- a/frontend/fixtures/approved-baselines/README.md
+++ b/frontend/fixtures/approved-baselines/README.md
@@ -91,6 +91,4 @@ git status fixtures/approved-baselines/
 git add frontend/fixtures/approved-baselines/
 ```

-This local flow produces macOS baselines — fine for everyday intentional-change PRs during the rework series (see Batching, above), but NOT the procedure for the pre-blocking Linux re-pin (see Platform note, above).
-
 `manifest.json` regenerates every run (`tests/e2e/visual/global-teardown.ts`), recording the commit, platform, and tool versions behind the committed set — commit it with the PNGs. [...]
```

(The `manifest.json` line is unchanged and truncated here for readability; `git diff --stat` is `1 file changed, 2 deletions(-)` — the sentence and its trailing blank line.)

## Scope

Documentation only. No code, no test, no baseline PNG, no `manifest.json` change. No file/LOC guardrail is near its threshold (1 file, 2 changed lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
