### PR TITLE
docs(MOR-2290): require BLOCKED when a verdict admits an unrun decisive check

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -50,6 +50,9 @@ Rules:
   rather than trusting the transcript. Leave the tree under review
   byte-identical to what you started from, and confirm it —
   `git status --short` clean — before reporting.
+- A verdict whose own text says that a mutation, reproduction or comparison
+  this file requires was not actually run is itself a blocking defect: issue
+  BLOCKED, never PASS.
 - When the input space is small enough to enumerate exactly — a resolver or
   lookup table with a bounded number of combinations — diff every output
   between the pre-change and post-change code over the whole space instead of


### PR DESCRIPTION
Linear: MOR-2290

Adds one sentence to `.claude/agents/verifier.md`, as a new bullet immediately
after the mutation bullet ("Do not accept a new or changed test on its
reading…", which ends "…before reporting"):

> A verdict whose own text says that a mutation, reproduction or comparison
> this file requires was not actually run is itself a blocking defect: issue
> BLOCKED, never PASS.

That location, because the loophole being closed is the one opened by skipping
exactly the step the preceding bullet mandates: a verdict that writes "ran out
of time to run the mutation, but the code looks right — PASS". Placing it as
the next bullet keeps the rule adjacent to the requirement it enforces and
inside the same "how you establish a finding" run of bullets, rather than in
the PASS/BLOCKED case-by-case section, whose three cases (diff / commit message
/ PR body) classify where a *defect in the change* lands — a different question
from what a verdict may admit about itself. The wording is deliberately
general ("mutation, reproduction or comparison this file requires") so it also
covers the enumeration, equality-capability, and reproduce-measurements bullets
that follow.

Scope confirmation, re-derived at the pushed head `5c5a08f8` against merge base
`8565b1e7` (`git diff --numstat 8565b1e7 HEAD` → `3	0	.claude/agents/verifier.md`):
1 file, 3 added lines, 0 deleted — a pure addition of the one sentence, wrapped
over three lines; no other file, line, or wording changed. Well inside both
guardrails.

Checks run locally:

- `.github/scripts/check-doc-citations.sh` → clean (838 grandfathered citations)
- `.github/scripts/check-doc-citations.sh --check-links` → clean (2 grandfathered
  dead links, repo-wide `*.md` scope). It also reported that 2 grandfathered
  links no longer appear broken; that is pre-existing and not required for the
  check to pass.
- `uv run pytest tests/test_claude_instruction_paths.py -q` → 8 passed. That is
  the only test file that reads `.claude/agents/*.md`
  (`grep -rln "verifier.md\|\.claude/agents" tests/`); it checks that referenced
  agent-role paths exist, and this sentence adds no path reference, so it cannot
  discriminate this change either way — it is reported as a no-regression check,
  not as evidence for the change.

No mutation test was run: the change adds no code and no test covers the prose
content of agent definition files, so there is nothing to reinstate. The full
pytest suite was not run locally — the change touches no Python; `quick.yml` on
this PR is the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
