### PR TITLE
docs: use explicit all mode for baseline updates

### DIFF
--- a/frontend/fixtures/approved-baselines/README.md
+++ b/frontend/fixtures/approved-baselines/README.md
@@ -85,7 +85,7 @@ Do not regenerate this set on macOS for the pre-blocking re-pin — that reprodu
 
 ```bash
 cd frontend
-npm run test:e2e:visual -- --update-snapshots
+npm run test:e2e:visual -- --update-snapshots=all
 git status fixtures/approved-baselines/
 # Open each changed PNG — confirm the diff is the change you intended.
 git add frontend/fixtures/approved-baselines/


### PR DESCRIPTION
Use explicit `--update-snapshots=all` in the documented intentional-baseline update command, matching the regenerate route already shipped in `.github/workflows/visual.yml`.

This completes the second accepted item after #3116 removed the contradictory macOS-regeneration sentence. The Linux provenance requirement remains in place.

Validation: reviewed the complete one-line README change against the shipped workflow command; `git diff --check` passes. One file, one insertion and one deletion. No baseline image or manifest changes.

Linear: MOR-2297
