### PR TITLE
test: stabilize cadence clock and await CW completion

### DIFF
--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -738,42 +738,16 @@ class TestLifecycle:
         tick_interval = 0.05
         window = 1.2
         steps = round(window / tick_interval)
+        ticks_per_cadence = round(declared_cadence / tick_interval)
+        cycle_start = clock.now()
         for step in range(steps):
-            diagnostic_step = step in (5, 6, 7)
-            if diagnostic_step:
-                now = clock.now()
-                due = scheduler.diagnostics()["cadenceByPath"][str(ptt)][
-                    "nextDueMonotonic"
-                ]
-                pending_before = tuple(
-                    request.id
-                    for request in scheduler.pending_requests()
-                    if ptt in request.paths
-                )
-                sends_before = sum(
-                    (command, sub) == (0x1C, 0x00)
-                    for _, command, sub in radio.civ_sends
-                )
+            tick_in_cycle = step % ticks_per_cadence
+            if step and tick_in_cycle == 0:
+                cycle_start += declared_cadence
+            target = cycle_start + tick_in_cycle * tick_interval
+            clock.advance(target - clock.now())
             service.tick(now=clock.now())
-            if diagnostic_step:
-                pending_after_tick = tuple(
-                    request.id
-                    for request in scheduler.pending_requests()
-                    if ptt in request.paths
-                )
             await srv._drain_state_acquisition_once()
-            if diagnostic_step:
-                sends_after = sum(
-                    (command, sub) == (0x1C, 0x00)
-                    for _, command, sub in radio.civ_sends
-                )
-                print(
-                    f"CADENCE_DIAG step={step} now={now!r} due={due!r} "
-                    f"due_minus_now={due - now!r} "
-                    f"pending_before={pending_before!r} "
-                    f"pending_after_tick={pending_after_tick!r} "
-                    f"sends_before={sends_before} sends_after={sends_after}"
-                )
             # Stand in for the CI-V ingress that credits an answered read;
             # without it the request stays queued and the cadence group is
             # deduped out forever, so only the first poll would ever show.
@@ -795,7 +769,6 @@ class TestLifecycle:
                     )
                 )
                 scheduler.record_acquisition_result(request, change_set)
-            clock.advance(tick_interval)
 
         ptt_sends = [
             at for at, command, sub in radio.civ_sends if (command, sub) == (0x1C, 0x00)

--- a/tests/test_rigctld_server.py
+++ b/tests/test_rigctld_server.py
@@ -738,9 +738,42 @@ class TestLifecycle:
         tick_interval = 0.05
         window = 1.2
         steps = round(window / tick_interval)
-        for _ in range(steps):
+        for step in range(steps):
+            diagnostic_step = step in (5, 6, 7)
+            if diagnostic_step:
+                now = clock.now()
+                due = scheduler.diagnostics()["cadenceByPath"][str(ptt)][
+                    "nextDueMonotonic"
+                ]
+                pending_before = tuple(
+                    request.id
+                    for request in scheduler.pending_requests()
+                    if ptt in request.paths
+                )
+                sends_before = sum(
+                    (command, sub) == (0x1C, 0x00)
+                    for _, command, sub in radio.civ_sends
+                )
             service.tick(now=clock.now())
+            if diagnostic_step:
+                pending_after_tick = tuple(
+                    request.id
+                    for request in scheduler.pending_requests()
+                    if ptt in request.paths
+                )
             await srv._drain_state_acquisition_once()
+            if diagnostic_step:
+                sends_after = sum(
+                    (command, sub) == (0x1C, 0x00)
+                    for _, command, sub in radio.civ_sends
+                )
+                print(
+                    f"CADENCE_DIAG step={step} now={now!r} due={due!r} "
+                    f"due_minus_now={due - now!r} "
+                    f"pending_before={pending_before!r} "
+                    f"pending_after_tick={pending_after_tick!r} "
+                    f"sends_before={sends_before} sends_after={sends_after}"
+                )
             # Stand in for the CI-V ingress that credits an answered read;
             # without it the request stays queued and the cadence group is
             # deduped out forever, so only the first poll would ever show.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -3840,9 +3840,12 @@ class TestSwitchScopeReceiver:
         poller = RadioPoller(radio, StateCache(), queue, radio_state=RadioState())
 
         poller.start()
-        queue.put(SetCwPitch(600))
-        await asyncio.sleep(0.03)
-        poller.stop()
+        reply = asyncio.get_running_loop().create_future()
+        queue.put_ordered(SetCwPitch(600), future=reply)
+        try:
+            await asyncio.wait_for(reply, timeout=2.0)
+        finally:
+            poller.stop()
 
         radio.set_cw_pitch.assert_awaited_once_with(600)
         assert poller._radio_state is not None


### PR DESCRIPTION
The standalone rigctld cadence test could miss the declared 0.3-second deadline because repeated 0.05-second fake-clock increments accumulated differently from the scheduler's deadline. Anchor each test tick to its cadence cycle while retaining all 24 samples and the original cadence/count assertions.

The CW test now awaits the existing queued command's caller future and stops the poller in `finally`, replacing its fixed 30ms sleep. The setter and confirmed `cw_pitch == 600` assertions remain unchanged. The final change touches only these two tests (+14/-5); temporary diagnostic instrumentation is removed.

Validation on Mac mini: nine bounded phases exercised the same two original nodes, with 14 PASS and four expected failures at the original assertions. Early/late polling and premature/mismatched CW readback were detected; legitimate equivalents and restored source passed. Each phase ended with the original process group absent and the exact source restored. Independent final code and proof adjudication passed. The current-head normal quick run remains a separate required gate.

Linear: MOR-2163; baseline coordination with MOR-2269.
