### PR TITLE
fix: encode profile-declared CI-V value variants (MOR-2265)

### DIFF
--- a/docs/api/rig-loader.md
+++ b/docs/api/rig-loader.md
@@ -98,7 +98,7 @@ class RigConfig:
     vfo_sub_select: tuple[int, ...] | None
     vfo_swap: tuple[int, ...] | None
     freq_ranges: tuple[dict, ...]
-    commands: dict[str, tuple[int, ...]]     # may be empty for non-CI-V
+    commands: dict[str, CommandSpec]         # may be empty for non-CI-V
     cmd29_routes: tuple[tuple[int, int | None], ...]
     spectrum: dict[str, int] | None
     att_values: tuple[int, ...] | None
@@ -133,6 +133,18 @@ profile.supports_capability("digisel")  # False — IC-7300 lacks DIGI-SEL
 #### `.to_command_map()` → `CommandMap`
 
 Build a `CommandMap` from this config's commands (base commands + overrides merged).
+CI-V entries may also carry value-specific complete wire tuples while retaining
+one command name:
+
+```toml
+[commands]
+set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00, 0x00], "1" = [0x1A, 0x06, 0x01, 0x01] } }
+```
+
+The loader requires the exact two-key descriptor, canonical decimal integer
+variant keys, unique valid byte arrays, and variants that strictly extend the
+base prefix. Existing CI-V arrays, CAT specifications, declared-absent entries,
+and command overrides remain compatible.
 
 ```python
 cfg = load_rig(Path("rigs/ic7610.toml"))
@@ -149,10 +161,18 @@ len(cmd_map)                 # ~150 commands
 
 ```python
 class CommandMap:
-    def __init__(self, commands: dict[str, tuple[int, ...]]) -> None: ...
+    def __init__(
+        self,
+        commands: dict[str, tuple[int, ...]],
+        *,
+        value_variants: dict[str, dict[int, tuple[int, ...]]] | None = None,
+    ) -> None: ...
 ```
 
 Immutable lookup mapping command names to CI-V wire byte tuples.
+Value variants are immutable private per-name data: `.get()`, `.has()`,
+iteration, length, and representation continue to describe only base entries.
+Equality and hashing include both base entries and value variants.
 See [`docs/api/commands.md`](commands.md) for usage with command builder functions.
 
 #### `.get(name)` → `tuple[int, ...]`

--- a/rigs/_schema.md
+++ b/rigs/_schema.md
@@ -512,6 +512,22 @@ get_af_level = [0x14, 0x01] # Command + sub-command
 
 All byte values must be integers in the range `0x00`–`0xFF`.
 
+When one semantic value selects a complete model-specific wire tuple, use the
+additive `bytes` + `value_variants` descriptor under that same command name:
+
+```toml
+set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00, 0x00], "1" = [0x1A, 0x06, 0x01, 0x01] } }
+```
+
+`bytes` is the non-empty base tuple. `value_variants` is a non-empty table
+whose keys are canonical decimal integers and whose values are unique,
+non-empty byte arrays. Every variant must strictly extend and start with the
+base tuple. The descriptor accepts exactly these two keys. The loader retains
+the variants behind the one command-map entry, so command discovery, map
+iteration, and reverse lookup continue to see only the base command name and
+tuple. Builders that opt into semantic-value selection reject values absent
+from the table; profiles using the original byte-array form are unchanged.
+
 ### Format 2: CAT Command Spec (Yaesu/Kenwood)
 
 For `yaesu_cat` and `kenwood_cat` protocols, commands are inline tables with a
@@ -553,7 +569,8 @@ read/write commands, or a verb like `ptt_on`, `scope_on`, `send_cw`.
 ### `[commands.overrides]` — Model-Specific Overrides
 
 Commands in this sub-table override the defaults for a specific radio model.
-Same format as `[commands]`: CI-V byte arrays or CAT inline tables.
+Same format as `[commands]`: CI-V byte arrays, CI-V value-variant descriptors,
+or CAT inline tables.
 
 ## Additional Parameterized Sections
 

--- a/rigs/_schema_v2.md
+++ b/rigs/_schema_v2.md
@@ -105,6 +105,23 @@ selector byte, or a constant payload byte. Only a value the caller
 supplies at the call site (e.g. a level to encode) is appended on top of
 the tuple.
 
+One existing command may instead declare complete wire tuples selected by a
+semantic integer value:
+
+```toml
+[commands]
+set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00, 0x00], "1" = [0x1A, 0x06, 0x01, 0x01] } }
+```
+
+The inline descriptor contains exactly `bytes` and `value_variants`. The base
+and every variant are non-empty arrays of bytes; the variant table is
+non-empty, uses canonical decimal integer keys, has unique values, and every
+variant strictly extends the base prefix. `RigConfig.to_command_map` carries
+the variant table without adding command names. `_build_from_map` selects a
+complete variant only for builders that pass a semantic value, rejects an
+undeclared value, and does not combine a selected variant with appended data.
+Legacy byte-array entries keep their existing append behavior.
+
 Every CI-V profile in `rigs/` that declares `ptt_on`/`ptt_off` carries the
 full three-byte prefix, payload byte included —
 `ptt_on = [0x1C, 0x00, 0x01]`, `ptt_off = [0x1C, 0x00, 0x00]` — so

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1178,11 +1178,7 @@ set_tsql_freq = [0x1B, 0x01]
 
 # ── Data Mode ──
 get_data_mode = [0x1A, 0x06]
-set_data_mode = [0x1A, 0x06]
-# IC-7300 Advanced Manual (11a) p.19-10: DATA OFF and DATA1 each carry
-# their matching filter selector in the SET payload.
-set_data_mode_off = [0x1A, 0x06, 0x00, 0x00]
-set_data_mode_data1 = [0x1A, 0x06, 0x01, 0x01]
+set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00, 0x00], "1" = [0x1A, 0x06, 0x01, 0x01] } }
 
 # ── Scope ──
 get_scope_wave = [0x27, 0x00]

--- a/rigs/ic7300.toml
+++ b/rigs/ic7300.toml
@@ -1179,6 +1179,10 @@ set_tsql_freq = [0x1B, 0x01]
 # ── Data Mode ──
 get_data_mode = [0x1A, 0x06]
 set_data_mode = [0x1A, 0x06]
+# IC-7300 Advanced Manual (11a) p.19-10: DATA OFF and DATA1 each carry
+# their matching filter selector in the SET payload.
+set_data_mode_off = [0x1A, 0x06, 0x00, 0x00]
+set_data_mode_data1 = [0x1A, 0x06, 0x01, 0x01]
 
 # ── Scope ──
 get_scope_wave = [0x27, 0x00]

--- a/src/rigplane/commands/_frame.py
+++ b/src/rigplane/commands/_frame.py
@@ -388,6 +388,7 @@ def _build_from_map(
     data: bytes | None = None,
     receiver: int = RECEIVER_MAIN,
     command29: bool = False,
+    value: int | None = None,
 ) -> bytes:
     """Build a CI-V frame using wire bytes from a CommandMap.
 
@@ -395,7 +396,16 @@ def _build_from_map(
     it returns are prepended to *data*, and only what the caller passes as
     *data* is appended after them.
     """
-    wire = cmd_map.get(name)
+    if cmd_map._has_value_variants(name):
+        if data is not None:
+            raise ValueError(
+                f"Command {name!r} cannot combine a value variant with appended data"
+            )
+        if value is None:
+            raise ValueError(f"Command {name!r} requires a declared value")
+        wire = cmd_map._get_value_variant(name, value)
+    else:
+        wire = cmd_map.get(name)
     command, sub, prefix = decode_wire_tuple(wire)
     if prefix:
         data = prefix + data if data else prefix

--- a/src/rigplane/commands/command_map.py
+++ b/src/rigplane/commands/command_map.py
@@ -119,6 +119,10 @@ class CommandMap:
             )
         )
 
+    def __deepcopy__(self, memo: dict[int, object]) -> CommandMap:
+        """Return this immutable map when snapshot code deep-copies a radio."""
+        return self
+
 
 @dataclass(frozen=True, slots=True)
 class ReverseLookupResult:

--- a/src/rigplane/commands/command_map.py
+++ b/src/rigplane/commands/command_map.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from types import MappingProxyType
 
 from ._frame import decode_wire_tuple
 
@@ -38,10 +39,23 @@ class CommandMap:
         list(cm)            # ["af_gain", "rf_gain"]
     """
 
-    __slots__ = ("_commands",)
+    __slots__ = ("_commands", "_value_variants")
 
-    def __init__(self, commands: dict[str, tuple[int, ...]]) -> None:
+    def __init__(
+        self,
+        commands: dict[str, tuple[int, ...]],
+        *,
+        value_variants: dict[str, dict[int, tuple[int, ...]]] | None = None,
+    ) -> None:
         self._commands: dict[str, tuple[int, ...]] = dict(commands)
+        self._value_variants = MappingProxyType(
+            {
+                name: MappingProxyType(
+                    {value: tuple(wire) for value, wire in variants.items()}
+                )
+                for name, variants in (value_variants or {}).items()
+            }
+        )
 
     def get(self, name: str) -> tuple[int, ...]:
         """Return wire bytes for *name*, or raise ``KeyError``."""
@@ -56,6 +70,17 @@ class CommandMap:
     def has(self, name: str) -> bool:
         """Return ``True`` if *name* is a known command."""
         return name in self._commands
+
+    def _has_value_variants(self, name: str) -> bool:
+        """Return whether *name* has semantic-value-specific wire tuples."""
+        return bool(self._value_variants.get(name))
+
+    def _get_value_variant(self, name: str, value: int) -> tuple[int, ...]:
+        """Return the complete wire tuple declared for *value*."""
+        variants = self._value_variants.get(name)
+        if variants is None or value not in variants:
+            raise ValueError(f"Command {name!r} value {value} is not declared")
+        return variants[value]
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._commands)
@@ -78,10 +103,21 @@ class CommandMap:
         """
         if not isinstance(other, CommandMap):
             return NotImplemented
-        return self._commands == other._commands
+        return (
+            self._commands == other._commands
+            and self._value_variants == other._value_variants
+        )
 
     def __hash__(self) -> int:
-        return hash(frozenset(self._commands.items()))
+        return hash(
+            (
+                frozenset(self._commands.items()),
+                frozenset(
+                    (name, frozenset(variants.items()))
+                    for name, variants in self._value_variants.items()
+                ),
+            )
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/rigplane/commands/command_spec.py
+++ b/src/rigplane/commands/command_spec.py
@@ -5,7 +5,9 @@ Supports both CI-V (wire bytes) and Yaesu CAT (text templates) in a unified sche
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
 
 __all__ = [
     "CivCommandSpec",
@@ -26,6 +28,22 @@ class CivCommandSpec:
 
     bytes: tuple[int, ...]
     """CI-V wire bytes (e.g., (0x03,) for get_freq)."""
+
+    value_variants: Mapping[int, tuple[int, ...]] = field(default_factory=dict)
+    """Optional complete wire tuples selected by an integer semantic value."""
+
+    def __post_init__(self) -> None:
+        """Detach and freeze the optional nested variant mapping."""
+        object.__setattr__(
+            self,
+            "value_variants",
+            MappingProxyType(
+                {key: tuple(wire) for key, wire in self.value_variants.items()}
+            ),
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.bytes, frozenset(self.value_variants.items())))
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/rigplane/commands/command_spec.py
+++ b/src/rigplane/commands/command_spec.py
@@ -5,8 +5,8 @@ Supports both CI-V (wire bytes) and Yaesu CAT (text templates) in a unified sche
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
-from dataclasses import dataclass, field
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 
 __all__ = [
     "CivCommandSpec",
@@ -14,33 +14,6 @@ __all__ = [
     "AbsentCommandSpec",
     "CommandSpec",
 ]
-
-
-class _ValueVariants(Mapping[int, tuple[int, ...]]):
-    """Small immutable mapping that remains safe under snapshot deepcopy."""
-
-    __slots__ = ("_items",)
-
-    def __init__(self, source: Mapping[int, tuple[int, ...]]) -> None:
-        self._items = tuple((key, tuple(wire)) for key, wire in source.items())
-
-    def __getitem__(self, key: int) -> tuple[int, ...]:
-        for candidate, wire in self._items:
-            if candidate == key:
-                return wire
-        raise KeyError(key)
-
-    def __iter__(self) -> Iterator[int]:
-        return (key for key, _ in self._items)
-
-    def __len__(self) -> int:
-        return len(self._items)
-
-    def __deepcopy__(self, memo: dict[int, object]) -> _ValueVariants:
-        return self
-
-    def __hash__(self) -> int:
-        return hash(frozenset(self._items))
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,19 +28,25 @@ class CivCommandSpec:
     bytes: tuple[int, ...]
     """CI-V wire bytes (e.g., (0x03,) for get_freq)."""
 
-    value_variants: Mapping[int, tuple[int, ...]] = field(default_factory=dict)
-    """Optional complete wire tuples selected by an integer semantic value."""
+    value_variants: (
+        tuple[tuple[int, tuple[int, ...]], ...] | Mapping[int, Iterable[int]]
+    ) = ()
+    """Optional ``(semantic value, complete wire tuple)`` pairs.
+
+    Mapping inputs are accepted for convenient construction, then detached
+    into a tuple-only representation so dataclass projections remain immutable,
+    deepcopy-safe, and JSON-safe.
+    """
 
     def __post_init__(self) -> None:
-        """Detach and freeze the optional nested variant mapping."""
+        """Detach and freeze the optional nested variant input."""
+        source = self.value_variants
+        items = source.items() if isinstance(source, Mapping) else source
         object.__setattr__(
             self,
             "value_variants",
-            _ValueVariants(self.value_variants),
+            tuple(sorted((key, tuple(wire)) for key, wire in items)),
         )
-
-    def __hash__(self) -> int:
-        return hash((self.bytes, frozenset(self.value_variants.items())))
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/rigplane/commands/command_spec.py
+++ b/src/rigplane/commands/command_spec.py
@@ -5,9 +5,8 @@ Supports both CI-V (wire bytes) and Yaesu CAT (text templates) in a unified sche
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
-from types import MappingProxyType
 
 __all__ = [
     "CivCommandSpec",
@@ -15,6 +14,33 @@ __all__ = [
     "AbsentCommandSpec",
     "CommandSpec",
 ]
+
+
+class _ValueVariants(Mapping[int, tuple[int, ...]]):
+    """Small immutable mapping that remains safe under snapshot deepcopy."""
+
+    __slots__ = ("_items",)
+
+    def __init__(self, source: Mapping[int, tuple[int, ...]]) -> None:
+        self._items = tuple((key, tuple(wire)) for key, wire in source.items())
+
+    def __getitem__(self, key: int) -> tuple[int, ...]:
+        for candidate, wire in self._items:
+            if candidate == key:
+                return wire
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[int]:
+        return (key for key, _ in self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __deepcopy__(self, memo: dict[int, object]) -> _ValueVariants:
+        return self
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self._items))
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,9 +63,7 @@ class CivCommandSpec:
         object.__setattr__(
             self,
             "value_variants",
-            MappingProxyType(
-                {key: tuple(wire) for key, wire in self.value_variants.items()}
-            ),
+            _ValueVariants(self.value_variants),
         )
 
     def __hash__(self) -> int:

--- a/src/rigplane/commands/mode.py
+++ b/src/rigplane/commands/mode.py
@@ -147,6 +147,24 @@ def set_data_mode(
     mode_value = int(on) if isinstance(on, bool) else int(on)
     if not 0 <= mode_value <= 3:
         raise ValueError(f"DATA mode must be 0-3, got {mode_value}")
+
+    variant_keys = {
+        0: "set_data_mode_off",
+        1: "set_data_mode_data1",
+    }
+    if any(cmd_map.has(key) for key in variant_keys.values()):
+        variant_key = variant_keys.get(mode_value)
+        if variant_key is None or not cmd_map.has(variant_key):
+            raise ValueError(f"DATA mode {mode_value} is not declared by this profile")
+        return _build_from_map(
+            cmd_map,
+            variant_key,
+            to_addr=to_addr,
+            from_addr=from_addr,
+            receiver=receiver,
+            command29=(receiver != RECEIVER_MAIN),
+        )
+
     return _build_from_map(
         cmd_map,
         "set_data_mode",

--- a/src/rigplane/commands/mode.py
+++ b/src/rigplane/commands/mode.py
@@ -148,31 +148,19 @@ def set_data_mode(
     if not 0 <= mode_value <= 3:
         raise ValueError(f"DATA mode must be 0-3, got {mode_value}")
 
-    variant_keys = {
-        0: "set_data_mode_off",
-        1: "set_data_mode_data1",
-    }
-    if any(cmd_map.has(key) for key in variant_keys.values()):
-        variant_key = variant_keys.get(mode_value)
-        if variant_key is None or not cmd_map.has(variant_key):
-            raise ValueError(f"DATA mode {mode_value} is not declared by this profile")
-        return _build_from_map(
-            cmd_map,
-            variant_key,
-            to_addr=to_addr,
-            from_addr=from_addr,
-            receiver=receiver,
-            command29=(receiver != RECEIVER_MAIN),
-        )
-
     return _build_from_map(
         cmd_map,
         "set_data_mode",
         to_addr=to_addr,
         from_addr=from_addr,
-        data=bytes([mode_value]),
+        data=(
+            None
+            if cmd_map._has_value_variants("set_data_mode")
+            else bytes([mode_value])
+        ),
         receiver=receiver,
         command29=(receiver != RECEIVER_MAIN),
+        value=mode_value,
     )
 
 

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -807,10 +807,13 @@ class RigConfig:
         .test_absent_name_excluded_from_command_map`).
         """
         civ_commands: dict[str, tuple[int, ...]] = {}
+        value_variants: dict[str, dict[int, tuple[int, ...]]] = {}
         for name, spec in self.commands.items():
             if isinstance(spec, CivCommandSpec):
                 civ_commands[name] = spec.bytes
-        return CommandMap(civ_commands)
+                if spec.value_variants:
+                    value_variants[name] = dict(spec.value_variants)
+        return CommandMap(civ_commands, value_variants=value_variants)
 
 
 def _parse_keyboard_binding(
@@ -978,6 +981,63 @@ def _parse_command_value(
                 f"got {value!r}"
             )
         return CivCommandSpec(bytes=tuple(value))
+
+    # Additive CI-V descriptor: one public command name with complete wire
+    # tuples selected by an integer semantic value.
+    if isinstance(value, dict) and ({"bytes", "value_variants"} & set(value)):
+        prefix = f"{filename}: [commands].{command_name}"
+        if set(value) != {"bytes", "value_variants"}:
+            raise RigLoadError(
+                f"{prefix} value-variant descriptor must contain exactly "
+                "bytes and value_variants"
+            )
+
+        base_raw = value["bytes"]
+        if not isinstance(base_raw, list) or not base_raw:
+            raise RigLoadError(f"{prefix}.bytes must be a non-empty byte array")
+        if any(
+            isinstance(byte, bool) or not isinstance(byte, int) for byte in base_raw
+        ):
+            raise RigLoadError(f"{prefix}.bytes must contain only integers")
+        if any(not 0 <= byte <= 0xFF for byte in base_raw):
+            raise RigLoadError(f"{prefix}.bytes must contain only values 0..255")
+        base = tuple(base_raw)
+
+        variants_raw = value["value_variants"]
+        if not isinstance(variants_raw, dict) or not variants_raw:
+            raise RigLoadError(f"{prefix}.value_variants must be a non-empty table")
+
+        variants: dict[int, tuple[int, ...]] = {}
+        seen_wires: set[tuple[int, ...]] = set()
+        for raw_key, wire_raw in variants_raw.items():
+            variant_path = f"{prefix}.value_variants.{raw_key}"
+            try:
+                semantic_value = int(raw_key)
+            except (TypeError, ValueError):
+                semantic_value = 0
+            if not isinstance(raw_key, str) or str(semantic_value) != raw_key:
+                raise RigLoadError(
+                    f"{variant_path} key must be a canonical decimal integer"
+                )
+            if not isinstance(wire_raw, list) or not wire_raw:
+                raise RigLoadError(f"{variant_path} must be a non-empty byte array")
+            if any(
+                isinstance(byte, bool) or not isinstance(byte, int) for byte in wire_raw
+            ):
+                raise RigLoadError(f"{variant_path} must contain only integers")
+            if any(not 0 <= byte <= 0xFF for byte in wire_raw):
+                raise RigLoadError(f"{variant_path} must contain only values 0..255")
+            wire = tuple(wire_raw)
+            if len(wire) <= len(base) or wire[: len(base)] != base:
+                raise RigLoadError(
+                    f"{variant_path} must strictly extend and prefix-match "
+                    f"{prefix}.bytes"
+                )
+            if wire in seen_wires:
+                raise RigLoadError(f"{variant_path} duplicates another variant value")
+            variants[semantic_value] = wire
+            seen_wires.add(wire)
+        return CivCommandSpec(bytes=base, value_variants=variants)
 
     # Format 3: declared-absent (dict with 'absent' key, MOR-2005 step 4a)
     if isinstance(value, dict) and "absent" in value:

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
+import json
 import textwrap
 from pathlib import Path
 
@@ -131,7 +133,55 @@ class TestCivCommandSpec:
     """Tests for CI-V command specifications (existing format)."""
 
     def test_legacy_constructor_defaults_to_no_value_variants(self):
-        assert CivCommandSpec(bytes=(0x03,)).value_variants == {}
+        spec = CivCommandSpec(bytes=(0x03,))
+
+        assert spec.value_variants == ()
+        projection = dataclasses.asdict(spec)
+        assert projection == {"bytes": (0x03,), "value_variants": ()}
+        assert json.loads(json.dumps(projection)) == {
+            "bytes": [0x03],
+            "value_variants": [],
+        }
+        assert copy.deepcopy(spec) == spec
+
+    def test_populated_value_variants_have_json_safe_detached_projection(self):
+        variants = {
+            0: [0x1A, 0x06, 0x00, 0x00],
+            1: [0x1A, 0x06, 0x01, 0x01],
+        }
+        spec = CivCommandSpec(bytes=(0x1A, 0x06), value_variants=variants)
+
+        variants[0][3] = 0xFF
+        variants[2] = [0x1A, 0x06, 0x02, 0x02]
+
+        expected = (
+            (0, (0x1A, 0x06, 0x00, 0x00)),
+            (1, (0x1A, 0x06, 0x01, 0x01)),
+        )
+        assert spec.value_variants == expected
+        projection = dataclasses.asdict(spec)
+        assert projection == {
+            "bytes": (0x1A, 0x06),
+            "value_variants": expected,
+        }
+        assert json.loads(json.dumps(projection)) == {
+            "bytes": [0x1A, 0x06],
+            "value_variants": [
+                [0, [0x1A, 0x06, 0x00, 0x00]],
+                [1, [0x1A, 0x06, 0x01, 0x01]],
+            ],
+        }
+        assert copy.deepcopy(spec) == spec
+        assert hash(copy.deepcopy(spec)) == hash(spec)
+        reordered = CivCommandSpec(
+            bytes=(0x1A, 0x06),
+            value_variants={
+                1: [0x1A, 0x06, 0x01, 0x01],
+                0: [0x1A, 0x06, 0x00, 0x00],
+            },
+        )
+        assert reordered == spec
+        assert hash(reordered) == hash(spec)
 
     def test_load_civ_commands(self, tmp_path):
         """CI-V commands load as CivCommandSpec."""
@@ -189,13 +239,13 @@ class TestCivCommandSpec:
         spec = rig.commands["set_data_mode"]
         assert isinstance(spec, CivCommandSpec)
         assert spec.bytes == (0x1A, 0x06)
-        assert spec.value_variants == {
-            0: (0x1A, 0x06, 0x00, 0x00),
-            1: (0x1A, 0x06, 0x01, 0x01),
-        }
+        assert spec.value_variants == (
+            (0, (0x1A, 0x06, 0x00, 0x00)),
+            (1, (0x1A, 0x06, 0x01, 0x01)),
+        )
         with pytest.raises(TypeError):
-            spec.value_variants[0] = (0x1A, 0x06, 0x00)  # type: ignore[index]
-        assert copy.deepcopy(spec.value_variants) is spec.value_variants
+            spec.value_variants[0] = (0, (0x1A, 0x06, 0x00))  # type: ignore[index]
+        assert copy.deepcopy(spec.value_variants) == spec.value_variants
 
     @pytest.mark.parametrize(
         ("declaration", "path"),

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -129,6 +129,9 @@ get_mode = { cat = { read = "MD0;" } }
 class TestCivCommandSpec:
     """Tests for CI-V command specifications (existing format)."""
 
+    def test_legacy_constructor_defaults_to_no_value_variants(self):
+        assert CivCommandSpec(bytes=(0x03,)).value_variants == {}
+
     def test_load_civ_commands(self, tmp_path):
         """CI-V commands load as CivCommandSpec."""
         p = _write_toml(tmp_path, _MINIMAL_CIV_TOML)
@@ -174,6 +177,84 @@ class TestCivCommandSpec:
 
         with pytest.raises(RigLoadError, match="must be all integers"):
             load_rig(p)
+
+    def test_value_variants_load_as_one_immutable_civ_spec(self, tmp_path):
+        toml = (
+            _MINIMAL_CIV_TOML
+            + '\nset_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00, 0x00], "1" = [0x1A, 0x06, 0x01, 0x01] } }\n'
+        )
+        rig = load_rig(_write_toml(tmp_path, toml, "variants.toml"))
+
+        spec = rig.commands["set_data_mode"]
+        assert isinstance(spec, CivCommandSpec)
+        assert spec.bytes == (0x1A, 0x06)
+        assert spec.value_variants == {
+            0: (0x1A, 0x06, 0x00, 0x00),
+            1: (0x1A, 0x06, 0x01, 0x01),
+        }
+        with pytest.raises(TypeError):
+            spec.value_variants[0] = (0x1A, 0x06, 0x00)  # type: ignore[index]
+
+    @pytest.mark.parametrize(
+        ("declaration", "path"),
+        [
+            (
+                "set_data_mode = { bytes = [0x1A, 0x06], value_variants = {} }",
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants",
+            ),
+            (
+                'set_data_mode = { bytes = [], value_variants = { "0" = [0x1A, 0x06, 0x00] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.bytes",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "01" = [0x1A, 0x06, 0x01] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants\.01",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, true] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants\.0",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x100] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants\.0",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants\.0",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x07, 0x00] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants\.0",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00], "1" = [0x1A, 0x06, 0x00] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode\.value_variants\.1",
+            ),
+            (
+                'set_data_mode = { bytes = [0x1A, 0x06], value_variants = { "0" = [0x1A, 0x06, 0x00] }, extra = true }',
+                r"variants\.toml: \[commands\]\.set_data_mode",
+            ),
+            (
+                "set_data_mode = { bytes = [0x1A, 0x06] }",
+                r"variants\.toml: \[commands\]\.set_data_mode",
+            ),
+            (
+                'set_data_mode = { cat = { write = "DM{mode};" }, bytes = [0x1A, 0x06] }',
+                r"variants\.toml: \[commands\]\.set_data_mode",
+            ),
+            (
+                'set_data_mode = { value_variants = { "0" = [0x1A, 0x06, 0x00] } }',
+                r"variants\.toml: \[commands\]\.set_data_mode",
+            ),
+        ],
+    )
+    def test_invalid_value_variant_shapes_name_the_exact_profile_path(
+        self, tmp_path: Path, declaration: str, path: str
+    ) -> None:
+        toml = _MINIMAL_CIV_TOML + "\n" + declaration + "\n"
+
+        with pytest.raises(RigLoadError, match=path):
+            load_rig(_write_toml(tmp_path, toml, "variants.toml"))
 
 
 class TestCatCommandSpec:

--- a/tests/test_command_spec.py
+++ b/tests/test_command_spec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import textwrap
 from pathlib import Path
 
@@ -194,6 +195,7 @@ class TestCivCommandSpec:
         }
         with pytest.raises(TypeError):
             spec.value_variants[0] = (0x1A, 0x06, 0x00)  # type: ignore[index]
+        assert copy.deepcopy(spec.value_variants) is spec.value_variants
 
     @pytest.mark.parametrize(
         ("declaration", "path"),

--- a/tests/test_ic7300_data_mode_contract.py
+++ b/tests/test_ic7300_data_mode_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from rigplane.commands import set_data_mode
+from rigplane.commands._frame import _build_from_map
 from rigplane.commands.bound import BoundCommands
 from rigplane.commands.command_map import CommandMap
 from rigplane.profiles import resolve_radio_profile
@@ -16,7 +17,12 @@ from rigplane.web.server import WebServer
 
 
 def _without(command_map: CommandMap, name: str) -> CommandMap:
-    return CommandMap({key: command_map.get(key) for key in command_map if key != name})
+    commands = {key: command_map.get(key) for key in command_map}
+    variants = {
+        1: (0x1A, 0x06, 0x01, 0x01),
+    }
+    assert name == "0"
+    return CommandMap(commands, value_variants={"set_data_mode": variants})
 
 
 def test_ic7300_data_off_has_documented_filter_byte() -> None:
@@ -43,12 +49,69 @@ def test_ic7300_data1_uses_documented_filter_one() -> None:
     ) == bytes.fromhex("fefe94e01a060101fd")
 
 
+def test_ic7300_exposes_one_command_name_for_all_data_values() -> None:
+    profile = resolve_radio_profile(model="IC-7300")
+
+    assert profile.supports_command("set_data_mode")
+    assert not profile.supports_command("set_data_mode_off")
+    assert not profile.supports_command("set_data_mode_data1")
+    assert len(profile.command_names) == 320
+    assert len(profile.command_map) == 320
+    assert list(profile.command_map).count("set_data_mode") == 1
+    assert all(not name.startswith("set_data_mode_") for name in profile.command_map)
+
+
 def test_declared_data_domain_fails_closed_when_variant_is_removed() -> None:
     profile = resolve_radio_profile(model="IC-7300")
-    without_off = _without(profile.command_map, "set_data_mode_off")
+    without_off = _without(profile.command_map, "0")
 
     with pytest.raises(ValueError, match="not declared"):
         BoundCommands(without_off).set_data_mode(0, to_addr=profile.civ_addr)
+
+
+@pytest.mark.parametrize(
+    ("variants", "expected"),
+    [
+        (
+            {
+                0: (0x1A, 0x06, 0x00),
+                1: (0x1A, 0x06, 0x01, 0x01),
+            },
+            "fefe94e01a0600fd",
+        ),
+        (
+            {
+                0: (0x1A, 0x06, 0x00, 0x00),
+                1: (0x1A, 0x06, 0x01, 0x02),
+            },
+            "fefe94e01a060102fd",
+        ),
+    ],
+)
+def test_wire_output_tracks_the_declared_variant_bytes(
+    variants: dict[int, tuple[int, ...]], expected: str
+) -> None:
+    value = 0 if expected.endswith("0600fd") else 1
+    command_map = CommandMap(
+        {"set_data_mode": (0x1A, 0x06)},
+        value_variants={"set_data_mode": variants},
+    )
+
+    assert set_data_mode(value, to_addr=0x94, cmd_map=command_map) == bytes.fromhex(
+        expected
+    )
+
+
+def test_variant_builder_requires_value_and_forbids_appended_data() -> None:
+    command_map = CommandMap(
+        {"set_x": (0x1A, 0x06)},
+        value_variants={"set_x": {0: (0x1A, 0x06, 0x00, 0x00)}},
+    )
+
+    with pytest.raises(ValueError, match="requires a declared value"):
+        _build_from_map(command_map, "set_x", to_addr=0x94)
+    with pytest.raises(ValueError, match="cannot combine"):
+        _build_from_map(command_map, "set_x", to_addr=0x94, value=0, data=b"\xff")
 
 
 @pytest.mark.parametrize("mode", range(4))
@@ -65,6 +128,10 @@ def test_data_mode_rejects_values_outside_the_legacy_wire_domain() -> None:
         set_data_mode(
             4, to_addr=0x94, cmd_map=CommandMap({"set_data_mode": (0x1A, 0x06)})
         )
+
+    profile = resolve_radio_profile(model="IC-7300")
+    with pytest.raises(ValueError, match="0-3"):
+        BoundCommands(profile.command_map).set_data_mode(4, to_addr=profile.civ_addr)
 
 
 @pytest.mark.asyncio

--- a/tests/test_ic7300_data_mode_contract.py
+++ b/tests/test_ic7300_data_mode_contract.py
@@ -1,0 +1,104 @@
+"""IC-7300 DATA-mode profile wire/domain contract (MOR-2265)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rigplane.commands import set_data_mode
+from rigplane.commands.bound import BoundCommands
+from rigplane.commands.command_map import CommandMap
+from rigplane.profiles import resolve_radio_profile
+from rigplane.radio import IcomRadio
+from rigplane.types import CivFrame
+from rigplane.web.handlers.control import ControlHandler
+from rigplane.web.radio_poller import RadioPoller
+from rigplane.web.server import WebServer
+
+
+def _without(command_map: CommandMap, name: str) -> CommandMap:
+    return CommandMap({key: command_map.get(key) for key in command_map if key != name})
+
+
+def test_ic7300_data_off_has_documented_filter_byte() -> None:
+    profile = resolve_radio_profile(model="IC-7300")
+
+    assert BoundCommands(profile.command_map).set_data_mode(
+        0, to_addr=profile.civ_addr
+    ) == bytes.fromhex("fefe94e01a060000fd")
+
+
+@pytest.mark.parametrize("mode", [2, 3])
+def test_ic7300_refuses_undeclared_data_variants(mode: int) -> None:
+    profile = resolve_radio_profile(model="IC-7300")
+
+    with pytest.raises(ValueError, match="not declared"):
+        BoundCommands(profile.command_map).set_data_mode(mode, to_addr=profile.civ_addr)
+
+
+def test_ic7300_data1_uses_documented_filter_one() -> None:
+    profile = resolve_radio_profile(model="IC-7300")
+
+    assert BoundCommands(profile.command_map).set_data_mode(
+        True, to_addr=profile.civ_addr
+    ) == bytes.fromhex("fefe94e01a060101fd")
+
+
+def test_declared_data_domain_fails_closed_when_variant_is_removed() -> None:
+    profile = resolve_radio_profile(model="IC-7300")
+    without_off = _without(profile.command_map, "set_data_mode_off")
+
+    with pytest.raises(ValueError, match="not declared"):
+        BoundCommands(without_off).set_data_mode(0, to_addr=profile.civ_addr)
+
+
+@pytest.mark.parametrize("mode", range(4))
+def test_profiles_without_data_variants_keep_legacy_domain(mode: int) -> None:
+    command_map = CommandMap({"set_data_mode": (0x1A, 0x06)})
+
+    assert set_data_mode(mode, to_addr=0x94, cmd_map=command_map) == bytes(
+        [0xFE, 0xFE, 0x94, 0xE0, 0x1A, 0x06, mode, 0xFD]
+    )
+
+
+def test_data_mode_rejects_values_outside_the_legacy_wire_domain() -> None:
+    with pytest.raises(ValueError, match="0-3"):
+        set_data_mode(
+            4, to_addr=0x94, cmd_map=CommandMap({"set_data_mode": (0x1A, 0x06)})
+        )
+
+
+@pytest.mark.asyncio
+async def test_control_queue_poller_core_radio_bound_commands_send_data_off() -> None:
+    profile = resolve_radio_profile(model="IC-7300")
+    radio = IcomRadio("192.0.2.1", model=profile.model)
+    radio._connected = True  # noqa: SLF001 -- inert transport boundary for this route test
+    radio._civ_runtime._connected = True  # noqa: SLF001 -- same runtime ownership flag
+    radio._civ_transport = object()  # type: ignore[assignment] # noqa: SLF001
+    sent: list[bytes] = []
+
+    async def send(civ_frame: bytes, **_: object) -> CivFrame:
+        sent.append(civ_frame)
+        return CivFrame(0xE0, profile.civ_addr, 0xFB)
+
+    radio._send_civ_expect = send  # type: ignore[method-assign] # noqa: SLF001
+    server = WebServer(radio)
+    handler = ControlHandler(_Ws(), radio, "test", profile.model, server=server)
+    await handler._enqueue_command("set_data_mode", {"mode": 0})  # noqa: SLF001
+    entry = server.command_queue.drain_entries()
+    assert len(entry) == 1
+
+    poller = RadioPoller(
+        radio, server.command_queue, state_store=server.command_state_store
+    )
+    try:
+        await poller._execute(entry[0].command)  # noqa: SLF001
+        assert sent == [bytes.fromhex("fefe94e01a060000fd")]
+    finally:
+        radio._connected = False  # noqa: SLF001
+        radio._civ_runtime._connected = False  # noqa: SLF001
+        radio._civ_transport = None  # noqa: SLF001
+
+
+class _Ws:
+    async def send_text(self, _: str) -> None:
+        pass

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -130,6 +130,52 @@ class TestCommandMapEquality:
         b = CommandMap({"ptt_on": (0x1C, 0x00)})
         assert hash(a) == hash(b)
 
+    def test_value_variants_participate_in_equality_and_hashing(self) -> None:
+        commands = {"set_data_mode": (0x1A, 0x06)}
+        variants = {
+            "set_data_mode": {
+                0: (0x1A, 0x06, 0x00, 0x00),
+                1: (0x1A, 0x06, 0x01, 0x01),
+            }
+        }
+        same = CommandMap(commands, value_variants=variants)
+        equal = CommandMap(commands, value_variants=variants)
+        changed = CommandMap(
+            commands,
+            value_variants={
+                "set_data_mode": {
+                    0: (0x1A, 0x06, 0x00, 0x00),
+                    1: (0x1A, 0x06, 0x01, 0x02),
+                }
+            },
+        )
+
+        assert same == equal
+        assert hash(same) == hash(equal)
+        assert same != changed
+        assert hash(same) != hash(changed)
+
+    def test_value_variant_storage_is_copied_and_not_exposed_by_iteration(
+        self,
+    ) -> None:
+        values = {0: (0x1A, 0x06, 0x00, 0x00)}
+        variants = {"set_data_mode": values}
+        command_map = CommandMap(
+            {"set_data_mode": (0x1A, 0x06)}, value_variants=variants
+        )
+        values[0] = (0x1A, 0x06, 0x00)
+        variants["extra"] = {1: (0x00, 0x01)}
+
+        assert list(command_map) == ["set_data_mode"]
+        assert len(command_map) == 1
+        assert command_map.get("set_data_mode") == (0x1A, 0x06)
+        assert command_map._get_value_variant("set_data_mode", 0) == (
+            0x1A,
+            0x06,
+            0x00,
+            0x00,
+        )
+
 
 class TestBoundCommandsGetattr:
     def test_returns_builder_with_map_applied(self) -> None:

--- a/tests/test_profile_command_binding.py
+++ b/tests/test_profile_command_binding.py
@@ -33,6 +33,7 @@ profile's map, plain or empty.
 
 from __future__ import annotations
 
+import copy
 import functools
 import inspect
 import itertools
@@ -175,6 +176,7 @@ class TestCommandMapEquality:
             0x00,
             0x00,
         )
+        assert copy.deepcopy(command_map) is command_map
 
 
 class TestBoundCommandsGetattr:

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -102,6 +102,20 @@ class TestLoadRig:
         rig = load_rig(p)
         assert rig.model == "IC-7300"
 
+    def test_command_override_reuses_value_variant_parser(self, tmp_path):
+        toml = _MINIMAL_TOML.replace(
+            "[commands.overrides]\n",
+            '[commands.overrides]\nset_freq = { bytes = [0x05], value_variants = { "7" = [0x05, 0x07] } }\n',
+        )
+
+        rig = load_rig(_write_toml(tmp_path, toml, "override.toml"))
+        command_map = rig.to_command_map()
+
+        assert command_map.get("set_freq") == (0x05,)
+        assert command_map._get_value_variant("set_freq", 7) == (0x05, 0x07)
+        assert set(command_map) == {"get_freq", "set_freq"}
+        assert len(command_map) == 2
+
     def test_tx_interlock_tightening_defaults_empty(self, tmp_path):
         rig = load_rig(_write_toml(tmp_path, _MINIMAL_TOML))
 


### PR DESCRIPTION
Guardrail exception (coordinator-authorized): 13 code + 0 regenerated baselines = 13 files; the 1000-line ceiling remains in force.

## Summary

- retain one public `set_data_mode` operation and one profile command name
- define generic nested `value_variants` under that existing command and carry immutable per-value full wire tuples through `CivCommandSpec` and `CommandMap`
- keep the public `CivCommandSpec` dataclass projection immutable, deepcopy-safe, input-alias-safe, and JSON-safe by normalizing variants to plain tuple pairs
- emit IC-7300 DATA OFF exactly as `fefe94e01a060000fd` and DATA1 exactly as `fefe94e01a060101fd`
- constrain the variant-backed IC-7300 domain to declared values 0 and 1: values 2 and 3 are refused before framing or wire I/O, and mode 4 remains invalid
- preserve legacy DATA values 0 through 3 for profiles without variants
- keep `command_names` and introspection at the single `set_data_mode` operation and leave the reverse-command index and 320/181/275 census with overlap 20 unchanged

## Design and review corrections

An independent design review BLOCKED the initial synthetic-key design. The historical wrong-design commit remains in branch history, but later commits replace it with the authorized generic nested `value_variants` architecture.

Independent verifier comment 5530460790 then BLOCKED head `e5f60679109f1e5e902563da0d4f6c4784ef3cc9` because the private `_ValueVariants` carrier made `dataclasses.asdict` output opaque to `json.dumps`, including for legacy empty constructors. Pre-drift head `60106c69bcebbbd918fb250eb05739e6336c22e7` removed that carrier, normalized copied input to plain immutable tuple pairs, and added empty and populated JSON, deepcopy, alias isolation, equality, hash, and carrier regressions. Independent comment 5530582931 reviewed that exact head PASS with no mandatory correction.

Main then advanced to UI-only commit `3c223e26609e786f4bc744eb1e16956d77e1caf2`. Its five changed frontend paths were disjoint from this PR. The branch was rebased without conflict; current head `35e77dca1b79001037d4bac83a465e0a97f42ccf`, tree `f1c02cc977d351bb5d1db69f6e61c5d96a7a60e1`, preserves the same 13-path net diff on the new base. The older exact-head review directive and Actions evidence are intentionally treated as pre-drift evidence until refreshed for this head.

## Verification chronology

- Mini handle 53606: initial exact-head attempt passed focused tests but the full suite failed 1 test with 15011 passed, 224 skipped, and 15 xfailed. The failure was the `MappingProxyType` deepcopy defect; this was not green evidence.
- Mini handle 96771: after the deepcopy correction, pre-rebase exact head `458a270e278f50ae730c3af15cb6d7114d126c8d` passed focused 949 passed and 1 skipped; full 15012 passed, 224 skipped, 15 xfailed, 6 warnings; ruff check and format passed; import-linter kept 5 contracts and broke 0.
- Mini handle 51379: post-rebase exact head `e5f60679109f1e5e902563da0d4f6c4784ef3cc9` passed focused 949 passed and 1 skipped; full 15060 passed, 224 skipped, 15 xfailed, 1 warning; ruff check and format passed; import-linter kept 5 contracts and broke 0.
- Mini Bash 5.1 handle 98688: that head passed all six citation, link, dangling, and growth gates. The Mini host Bash 3.2 cannot execute the associative-array doc script.
- Mini handle 59921: pre-drift corrected head `60106c69bcebbbd918fb250eb05739e6336c22e7`, tree `16e004c7974b4c91c6c2dc97503a177d3766619a`, passed focused 950 passed and 1 skipped; full 15078 passed, 224 skipped, 15 xfailed, 1 warning; ruff check passed; ruff format reported 718 files already formatted; import-linter kept 5 contracts and broke 0.
- Mini Bash 5.1 handle 6957: the same pre-drift corrected head passed all six citation, link, dangling, and growth gates against base `34c71f53223add498ff9d3ed96bc6668459a02b1`.
- Actions full-matrix run 33793308752: pre-drift head `60106c69bcebbbd918fb250eb05739e6336c22e7` passed the capture harness and Python 3.11, 3.12, and 3.13 jobs, including frontend, web boundary, import-linter, and full pytest steps. This run completed before the UI-only base drift and is not presented as current-head coverage.
- Local tests-first regression on the pre-drift corrected head: command-spec focus moved from 3 failed and 35 passed to 38 passed; focused five passed 950 and skipped 1; focused ruff, format, and diff checks passed.

## Scope

The final net PR diff remains the authorized 13 paths, 568 additions and 11 deletions, with no census files. This adds no provider, constructor, ingress, UI, PTT, ATT, Q1, or Q2 paths. No hardware or TX was used. This child is linked only to MOR-2265 and does not close parent MOR-2262 or MOR-2161.

Linear: https://linear.app/morozsm/issue/MOR-2265/ic-7300-encode-data-off-filter-byte-and-enforce-the-profile-data-mode

The PR remains draft. Fresh exact-head review and required Actions coverage for `35e77dca1b79001037d4bac83a465e0a97f42ccf` are pending after the rebase; no current-head Agent Review or overall CI green claim is made here.