### PR TITLE
Reuse shared queue execution in provider pollers

### DIFF
--- a/src/rigplane/backends/rigctld_client/radio.py
+++ b/src/rigplane/backends/rigctld_client/radio.py
@@ -25,7 +25,10 @@ from ...core.state_pipeline_contracts import (
 )
 from ...core.tx_observation import TxStateReading
 from ...radio_state import RadioState
-from ...runtime._poller_types import canonicalize_level_command
+from ...runtime._poller_types import (
+    canonicalize_level_command,
+    execute_command_queue_entry,
+)
 from ...runtime.callable_support import supports_explicit_callable
 from ...runtime.managed_tx_state import (
     AbortOperation,
@@ -234,14 +237,9 @@ class RigctldClientObservationPoller:
             return ()
 
         successful: list["CommandQueueEntry"] = []
-        for entry in self._command_queue.drain_entries():
+
+        async def execute_entry(entry: "CommandQueueEntry") -> None:
             cmd = entry.command
-            if entry.future is not None and entry.future.cancelled():
-                logger.debug(
-                    "rigctld-client observation poller: skipping cancelled command %s",
-                    type(cmd).__name__,
-                )
-                continue
             capture = self._capture_provider_generation
             correlation = _readback_correlation_for_entry(
                 entry,
@@ -250,16 +248,28 @@ class RigctldClientObservationPoller:
             )
             try:
                 await self._execute_command(cmd)
-                successful.append(entry)
-                self._track_readback_entry(cmd, correlation)
-                if entry.future is not None and not entry.future.done():
-                    entry.future.set_result(None)
             except Exception as exc:
                 if correlation is not None:
                     self._finish_readbacks((correlation,), "rejected")
                 self._mark_queued_command_failed(entry, exc)
-                if entry.future is not None and not entry.future.done():
-                    entry.future.set_exception(exc)
+                raise
+            successful.append(entry)
+            self._track_readback_entry(cmd, correlation)
+
+        for _ in range(self._command_queue.pending_count):
+            entry = self._command_queue.take_entry()
+            if entry is None:
+                break
+            cmd = entry.command
+            if entry.future is not None and entry.future.cancelled():
+                logger.debug(
+                    "rigctld-client observation poller: skipping cancelled command %s",
+                    type(cmd).__name__,
+                )
+                continue
+            try:
+                await execute_command_queue_entry(entry, execute_entry)
+            except Exception:
                 logger.warning(
                     "rigctld-client observation poller: command %s failed",
                     type(cmd).__name__,

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -35,11 +35,15 @@ from rigplane.core.state_acquisition_policy import RadioAcquisitionProfile
 from rigplane.core.state_pipeline_contracts import CommandIntent, FieldPath
 from rigplane.core.tx_observation import OBSERVED_PTT_PATH
 from rigplane.core.tx_target import KnownTxTarget, UnknownTxTarget
-from rigplane.runtime._poller_types import canonicalize_level_command
+from rigplane.runtime._poller_types import (
+    canonicalize_level_command,
+    execute_command_queue_entry,
+)
 from rigplane.runtime.tx_interlock import (
     DeferredTxCommandLane,
     RfState,
     TxInterlockDeferredOutcome,
+    TxInterlockDecision,
     TxInterlockDisposition,
     TxInterlockDispositionOverrides,
     classify_tx_interlock,
@@ -684,7 +688,7 @@ class YaesuCatPoller:
         transition = self._deferred_tx_lane.observe(
             rf_state=self._current_rf_state(), now=now
         )
-        entries: list[CommandQueueEntry] = []
+        released: list[CommandQueueEntry] = []
         if (
             transition is not None
             and transition.outcome is not TxInterlockDeferredOutcome.HELD
@@ -694,19 +698,16 @@ class YaesuCatPoller:
             if entry is not None:
                 if transition.outcome is TxInterlockDeferredOutcome.RELEASED:
                     if self._deferred_release_is_live(entry):
-                        entries.append(entry)
+                        released.append(entry)
                 else:
                     self._finish_deferred_entry(entry, superseded=False)
-        if self._command_queue.has_commands:
-            entries.extend(self._command_queue.drain_entries())
-        for entry in entries:
+
+        pending_count = self._command_queue.pending_count
+
+        def stage_entry(
+            entry: CommandQueueEntry,
+        ) -> TxInterlockDecision | Exception | None:
             cmd = entry.command
-            if entry.future is not None and entry.future.cancelled():
-                logger.debug(
-                    "YaesuCatPoller: skipping cancelled queued command %s",
-                    type(cmd).__name__,
-                )
-                continue
             now = time.monotonic()
             rf_state = self._current_rf_state()
             transition = None
@@ -729,15 +730,7 @@ class YaesuCatPoller:
                         disposition_overrides=overrides,
                     )
             except Exception as exc:
-                self._mark_queued_command_failed(entry, exc)
-                if entry.future is not None and not entry.future.done():
-                    entry.future.set_exception(exc)
-                logger.warning(
-                    "YaesuCatPoller: command %s failed policy validation",
-                    type(cmd).__name__,
-                    exc_info=True,
-                )
-                continue
+                return exc
             if transition is not None:
                 held = self._deferred_tx_lane.observe(rf_state=RfState.TX, now=now)
                 if held is None:
@@ -759,8 +752,17 @@ class YaesuCatPoller:
                         ),
                     )
                 self._emit_deferred_entry_held(entry, expires_at=held.expires_at)
-                continue
+                return None
+            return decision
+
+        async def finish_entry(
+            entry: CommandQueueEntry,
+            decision: TxInterlockDecision | Exception,
+        ) -> None:
+            cmd = entry.command
             try:
+                if isinstance(decision, BaseException):
+                    raise decision
                 if (
                     decision.disposition is TxInterlockDisposition.DEFER
                     and not decision.allowed
@@ -768,17 +770,42 @@ class YaesuCatPoller:
                     raise CommandError(decision.reason)
                 await self._execute_command(cmd)
                 self._track_receiver_select_readback(entry)
-                if entry.future is not None and not entry.future.done():
-                    entry.future.set_result(None)
             except Exception as exc:
                 self._mark_queued_command_failed(entry, exc)
-                if entry.future is not None and not entry.future.done():
-                    entry.future.set_exception(exc)
-                logger.warning(
-                    "YaesuCatPoller: command %s failed",
+                raise
+
+        async def process_entry(entry: CommandQueueEntry) -> None:
+            cmd = entry.command
+            if entry.future is not None and entry.future.cancelled():
+                logger.debug(
+                    "YaesuCatPoller: skipping cancelled queued command %s",
                     type(cmd).__name__,
+                )
+                return
+            decision = stage_entry(entry)
+            if decision is None:
+                return
+            policy_error = isinstance(decision, BaseException)
+            try:
+                await execute_command_queue_entry(
+                    entry,
+                    lambda claimed: finish_entry(claimed, decision),
+                )
+            except Exception:
+                logger.warning(
+                    "YaesuCatPoller: command %s failed%s",
+                    type(cmd).__name__,
+                    " policy validation" if policy_error else "",
                     exc_info=True,
                 )
+
+        for entry in released:
+            await process_entry(entry)
+        for _ in range(pending_count):
+            entry = self._command_queue.take_entry()
+            if entry is None:
+                break
+            await process_entry(entry)
 
     def _deferred_release_is_live(self, entry: CommandQueueEntry) -> bool:
         reason = None

--- a/tests/test_canonical_receiver_levels.py
+++ b/tests/test_canonical_receiver_levels.py
@@ -69,14 +69,25 @@ def _path(monkeypatch, backend="yaesu", config="ftx1"):
     shared = AsyncMock(wraps=module.execute_command_intent)
     monkeypatch.setattr(module, "execute_command_intent", shared)
     entries = []
-    drain_entries = server.command_queue.drain_entries
+    if backend == "icom":
+        drain_entries = server.command_queue.drain_entries
 
-    def capture_entries():
-        drained = drain_entries()
-        entries.extend(drained)
-        return drained
+        def capture_entries():
+            drained = drain_entries()
+            entries.extend(drained)
+            return drained
 
-    monkeypatch.setattr(server.command_queue, "drain_entries", capture_entries)
+        monkeypatch.setattr(server.command_queue, "drain_entries", capture_entries)
+    else:
+        take_entry = server.command_queue.take_entry
+
+        def capture_entry():
+            entry = take_entry()
+            if entry is not None:
+                entries.append(entry)
+            return entry
+
+        monkeypatch.setattr(server.command_queue, "take_entry", capture_entry)
 
     async def drain():
         if backend == "icom":

--- a/tests/test_rigctld_client_observation_adapter.py
+++ b/tests/test_rigctld_client_observation_adapter.py
@@ -72,6 +72,36 @@ class _NoopCommandExecutor:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["cancel", "replace", "error", "readback"])
+async def test_rigctld_drain_claims_live_pending_finite_turn(mode, monkeypatch):
+    from test_command_queue_execution import assert_live_pending_turn
+
+    queue = CommandQueue()
+    radio = RigctldClientRadio(host="127.0.0.1", port=4532)
+    poller = RigctldClientObservationPoller(
+        radio, lambda _: None, medium_interval=1, slow_interval=1, command_queue=queue
+    )
+
+    def install_readback(note):
+        original = poller._track_readback_entry
+
+        def track(command, correlation):
+            original(command, correlation)
+            if command == SetFreq(1):
+                note()
+
+        monkeypatch.setattr(poller, "_track_readback_entry", track)
+
+    await assert_live_pending_turn(
+        queue,
+        poller._drain_commands,
+        lambda leaf: monkeypatch.setattr(poller, "_execute_command", leaf),
+        mode=mode,
+        install_readback=install_readback,
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_reads_emit_hamlib_observations() -> None:
     async with FakeRigctldServer() as server:
         radio = RigctldClientRadio(host=server.host, port=server.port)

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -1098,6 +1098,34 @@ def _set_fresh_ptt_observation(poller: YaesuCatPoller, *, active: bool) -> None:
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["cancel", "replace", "error", "readback"])
+async def test_yaesu_drain_claims_live_pending_finite_turn(mode, monkeypatch):
+    from test_command_queue_execution import assert_live_pending_turn
+
+    queue = CommandQueue()
+    poller = YaesuCatPoller(make_radio(), command_queue=queue)
+    _set_fresh_ptt_observation(poller, active=False)
+
+    def install_readback(note):
+        original = poller._track_receiver_select_readback
+
+        def track(entry):
+            original(entry)
+            if entry.command == SetFreq(1):
+                note()
+
+        monkeypatch.setattr(poller, "_track_receiver_select_readback", track)
+
+    await assert_live_pending_turn(
+        queue,
+        poller._drain_commands,
+        lambda leaf: monkeypatch.setattr(poller, "_execute_command", leaf),
+        mode=mode,
+        install_readback=install_readback,
+    )
+
+
 async def _drain_with_ptt(
     poller: YaesuCatPoller,
     clock: list[float],
@@ -1115,6 +1143,37 @@ async def _drain_with_ptt(
             poller._current_tx_target_generation()  # noqa: SLF001
         )
     await poller._drain_commands()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_yaesu_releases_held_entry_before_finite_current_turn(monkeypatch):
+    clock, queue, seen = [20.0], CommandQueue(), []
+    monkeypatch.setattr(
+        "rigplane.backends.yaesu_cat.poller.time.monotonic", lambda: clock[0]
+    )
+    poller = YaesuCatPoller(make_radio(), command_queue=queue)
+    reply = asyncio.get_running_loop().create_future()
+    held = SetSplit(True)
+
+    async def leaf(command):
+        seen.append(command)
+        if command == SetFreq(1):
+            queue.put_ordered(SetFreq(3))
+
+    monkeypatch.setattr(poller, "_execute_command", leaf)
+    queue.put_ordered(held, future=reply)
+    try:
+        await _drain_with_ptt(poller, clock, 20.0, True)
+        await _drain_with_ptt(poller, clock, 20.1, False)
+        assert not reply.done()
+        queue.put_ordered(SetFreq(1))
+        queue.put_ordered(SetFreq(2))
+        await _drain_with_ptt(poller, clock, 21.1, False)
+        assert seen == [held, SetFreq(1), SetFreq(2)]
+        assert reply.result() is None
+        assert [e.command for e in queue.drain_entries()] == [SetFreq(3)]
+    finally:
+        reply.cancel()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Make the external rigctld and Yaesu command drains claim a finite live-pending turn through the existing `CommandQueue.pending_count` / `take_entry()` API.
- Route each claimed terminal operation through the existing `execute_command_queue_entry()` lifetime kernel.
- Keep provider-local policy, deferred-release ordering, failure hooks, and readback correlation at their existing seats.
- Update the canonical receiver-level fixture to capture the provider consumers' real `take_entry()` claim while retaining its Icom `drain_entries()` capture.

Linear owner: MOR-2269. This is the accepted Q2 consumer slice from decomposition comment `779705a9-5c2a-42c9-ba35-7b5542b5f868`, after Q1 and the Yaesu producer landed.

## Scope and boundaries

Exact immutable head `9be501ff5353371d00ba791baba87c366e6c1794` has tree `64eb5b26cbed91b1d217fd738709bdd59abed961` and parents `1667cae1e2548b66731ce18010d4c49b0afa5a3d` plus acquisition integration parent `309f51deb889a0761bb6b8d52cd3836feff5dfc5`. The current-main relative diff remains exactly 5 files, +184/-47 = 231 changed lines. No guardrail exception is needed.

This change does not modify Web/server, CommandQueue, CommandService, authority, adapter, ingress, hardware, other-provider, README, or audit paths. It adds no queue, authority, epoch, registry, watchdog, observed-RF admission rule, or compatibility kernel. It makes no managed-ON or hardware claim.

## Verification

- Pre-edit focused baseline: 196 passed.
- Tests-first RED: 8 failed / 1 passed across the nine new Q2 cases; every failure was the live-pending assertion against the old materialized snapshot.
- Initial focused GREEN: 205 passed in the two Q2 test files.
- Mutation: replacing both live claims with `drain_entries()` reproduced exactly 8 failures / 1 positive-control pass; the mutation was restored before the final GREEN run.
- Quick `33792685578` at the first product head: 15047 passed and 11 fixture-capture failures. All failures were in `tests/test_canonical_receiver_levels.py`; its helper wrapped only `drain_entries()`, so the new real `take_entry()` claims were not appended to `path.entries`. Ruff, import-linter, and all validation dry-runs passed in that run.
- After the fixture-only correction: 243 passed across the fixture file and both Q2 test files; the independent verifier repeated the fixture file as 38 passed.
- `uv run ruff check` and `uv run ruff format --check` on the five changed files: pass.
- Import smoke for both changed source modules: pass.
- `git diff --check`: pass.
- Sole final natural quick `33797455615` completed SUCCESS on exact head `9be501ff5353371d00ba791baba87c366e6c1794`. Superseded queued quicks were cancelled and were not rerun.

A scoped advisory mypy invocation reports six existing errors in unchanged lines of these two backend files; the only new missing-annotation result seen during implementation was corrected before the first published head. This PR does not touch Web paths relative to current main, so the required quick workflow's strict Web mypy block is not selected by the Q2 diff.

## Required pre-push searches

- `git diff -U0 | rg 'tx_interlock|ManagedTx|authority|epoch|watchdog|observed'` found only the added import-line context for the existing `TxInterlockDecision` type; no new safety mechanism or observed-RF policy was added.
- `rg 'execute_command_queue_entry|pending_count|take_entry|drain_entries'` over both changed source files confirms both consumers call the existing public Q1 kernel and live-claim API; neither production drain calls `drain_entries()`.
