### PR TITLE
Share acquisition claim ownership across drain seats

### DIFF
--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -157,13 +157,48 @@ class AcquisitionDrain:
         self._on_forget = on_forget
         self._claimant = self if claimant is None else claimant
 
-    def _forget(self, scheduler: AcquisitionScheduler, request_id: str) -> None:
+    def _forget_ledger(self, request_id: str) -> None:
         """Drop one ledger entry and tell the seat it is gone."""
 
-        scheduler.release_claim(request_id, claimant=self._claimant)
         self._in_flight.pop(request_id, None)
         if self._on_forget is not None:
             self._on_forget(request_id)
+
+    def _forget(
+        self,
+        scheduler: AcquisitionScheduler,
+        request_id: str,
+        *,
+        provider_generation: int,
+    ) -> None:
+        scheduler.release_claim(
+            request_id,
+            claimant=self._claimant,
+            provider_generation=provider_generation,
+        )
+        self._forget_ledger(request_id)
+
+    def _claim_is_current(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        store: StateStore | None,
+        provider_generation: int,
+    ) -> bool:
+        current_store = self._store()
+        return (
+            current_store is store
+            and (
+                current_store is None
+                or current_store.provider_generation == provider_generation
+            )
+            and scheduler.claim_is_current(
+                request,
+                claimant=self._claimant,
+                provider_generation=provider_generation,
+            )
+        )
 
     def _expiry_is_terminal(
         self,
@@ -205,7 +240,7 @@ class AcquisitionDrain:
         pending_ids = {request.id for request in pending}
         for request_id in tuple(self._in_flight):
             if request_id not in pending_ids:
-                self._forget(scheduler, request_id)
+                self._forget_ledger(request_id)
 
         # Eligibility is asked once per pass, over the unfiltered pending view
         # above: a request the seat declines to send is still pending, and its
@@ -215,6 +250,13 @@ class AcquisitionDrain:
             if not scheduler.try_claim(
                 request,
                 claimant=self._claimant,
+                provider_generation=provider_generation,
+            ):
+                continue
+            if not self._claim_is_current(
+                scheduler,
+                request,
+                store=store,
                 provider_generation=provider_generation,
             ):
                 continue
@@ -230,7 +272,11 @@ class AcquisitionDrain:
                     if self._expiry_is_terminal(
                         scheduler, request, sent_paths=sent_paths, now=now
                     ):
-                        self._forget(scheduler, request.id)
+                        self._forget(
+                            scheduler,
+                            request.id,
+                            provider_generation=provider_generation,
+                        )
                         continue
                 sent_paths = sent_paths.intersection(request.paths)
 
@@ -242,7 +288,11 @@ class AcquisitionDrain:
                 try:
                     self._report_executor_missing(scheduler, request, now=now)
                 finally:
-                    self._forget(scheduler, request.id)
+                    self._forget(
+                        scheduler,
+                        request.id,
+                        provider_generation=provider_generation,
+                    )
                 continue
 
             try:
@@ -251,9 +301,26 @@ class AcquisitionDrain:
                     already_sent_paths=sent_paths,
                 )
             except asyncio.CancelledError:
-                self._forget(scheduler, request.id)
+                if self._claim_is_current(
+                    scheduler,
+                    request,
+                    store=store,
+                    provider_generation=provider_generation,
+                ):
+                    self._forget(
+                        scheduler,
+                        request.id,
+                        provider_generation=provider_generation,
+                    )
                 raise
             except Exception as exc:
+                if not self._claim_is_current(
+                    scheduler,
+                    request,
+                    store=store,
+                    provider_generation=provider_generation,
+                ):
+                    raise
                 # The Web reporter completes the scheduler request before it
                 # re-raises, retaining that seat's in-flight expiry record.
                 self._report_executor_error(
@@ -263,20 +330,19 @@ class AcquisitionDrain:
                     sent_paths=sent_paths,
                     now=now,
                 )
-                self._forget(scheduler, request.id)
+                self._forget(
+                    scheduler,
+                    request.id,
+                    provider_generation=provider_generation,
+                )
                 continue
 
-            current_store = self._store()
-            generation_is_current = current_store is store and (
-                current_store is None
-                or current_store.provider_generation == provider_generation
-            )
-            if not generation_is_current or not scheduler.claim_is_current(
+            if not self._claim_is_current(
+                scheduler,
                 request,
-                claimant=self._claimant,
+                store=store,
                 provider_generation=provider_generation,
             ):
-                self._forget(scheduler, request.id)
                 continue
 
             failed_paths = tuple(result.failed_paths)

--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -254,16 +254,16 @@ class AcquisitionDrain:
                 self._forget(scheduler, request.id)
                 raise
             except Exception as exc:
-                try:
-                    self._report_executor_error(
-                        scheduler,
-                        request,
-                        error=exc,
-                        sent_paths=sent_paths,
-                        now=now,
-                    )
-                finally:
-                    self._forget(scheduler, request.id)
+                # The Web reporter completes the scheduler request before it
+                # re-raises, retaining that seat's in-flight expiry record.
+                self._report_executor_error(
+                    scheduler,
+                    request,
+                    error=exc,
+                    sent_paths=sent_paths,
+                    now=now,
+                )
+                self._forget(scheduler, request.id)
                 continue
 
             current_store = self._store()

--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -267,12 +267,9 @@ class AcquisitionDrain:
                 continue
 
             current_store = self._store()
-            generation_is_current = (
-                current_store is store
-                and (
-                    current_store is None
-                    or current_store.provider_generation == provider_generation
-                )
+            generation_is_current = current_store is store and (
+                current_store is None
+                or current_store.provider_generation == provider_generation
             )
             if not generation_is_current or not scheduler.claim_is_current(
                 request,

--- a/src/rigplane/core/acquisition_drain.py
+++ b/src/rigplane/core/acquisition_drain.py
@@ -141,6 +141,7 @@ class AcquisitionDrain:
         report_sent: AcquisitionSentReport,
         report_expiry: AcquisitionExpiryReport | None = None,
         on_forget: Callable[[str], None] | None = None,
+        claimant: object | None = None,
     ) -> None:
         self._scheduler = scheduler
         self._executor = executor
@@ -154,10 +155,12 @@ class AcquisitionDrain:
         self._report_sent = report_sent
         self._report_expiry = report_expiry
         self._on_forget = on_forget
+        self._claimant = self if claimant is None else claimant
 
-    def _forget(self, request_id: str) -> None:
+    def _forget(self, scheduler: AcquisitionScheduler, request_id: str) -> None:
         """Drop one ledger entry and tell the seat it is gone."""
 
+        scheduler.release_claim(request_id, claimant=self._claimant)
         self._in_flight.pop(request_id, None)
         if self._on_forget is not None:
             self._on_forget(request_id)
@@ -202,12 +205,20 @@ class AcquisitionDrain:
         pending_ids = {request.id for request in pending}
         for request_id in tuple(self._in_flight):
             if request_id not in pending_ids:
-                self._forget(request_id)
+                self._forget(scheduler, request_id)
 
         # Eligibility is asked once per pass, over the unfiltered pending view
         # above: a request the seat declines to send is still pending, and its
         # ledger entry must survive the pass.
         for request in self._dispatchable(pending):
+            provider_generation = 0 if store is None else store.provider_generation
+            if not scheduler.try_claim(
+                request,
+                claimant=self._claimant,
+                provider_generation=provider_generation,
+            ):
+                continue
+
             sent_paths: frozenset[FieldPath] = frozenset()
             existing = self._in_flight.get(request.id)
             if existing is not None:
@@ -219,7 +230,7 @@ class AcquisitionDrain:
                     if self._expiry_is_terminal(
                         scheduler, request, sent_paths=sent_paths, now=now
                     ):
-                        self._forget(request.id)
+                        self._forget(scheduler, request.id)
                         continue
                 sent_paths = sent_paths.intersection(request.paths)
 
@@ -228,7 +239,10 @@ class AcquisitionDrain:
 
             executor = self._executor()
             if executor is None:
-                self._report_executor_missing(scheduler, request, now=now)
+                try:
+                    self._report_executor_missing(scheduler, request, now=now)
+                finally:
+                    self._forget(scheduler, request.id)
                 continue
 
             try:
@@ -237,16 +251,35 @@ class AcquisitionDrain:
                     already_sent_paths=sent_paths,
                 )
             except asyncio.CancelledError:
+                self._forget(scheduler, request.id)
                 raise
             except Exception as exc:
-                self._report_executor_error(
-                    scheduler,
-                    request,
-                    error=exc,
-                    sent_paths=sent_paths,
-                    now=now,
+                try:
+                    self._report_executor_error(
+                        scheduler,
+                        request,
+                        error=exc,
+                        sent_paths=sent_paths,
+                        now=now,
+                    )
+                finally:
+                    self._forget(scheduler, request.id)
+                continue
+
+            current_store = self._store()
+            generation_is_current = (
+                current_store is store
+                and (
+                    current_store is None
+                    or current_store.provider_generation == provider_generation
                 )
-                self._forget(request.id)
+            )
+            if not generation_is_current or not scheduler.claim_is_current(
+                request,
+                claimant=self._claimant,
+                provider_generation=provider_generation,
+            ):
+                self._forget(scheduler, request.id)
                 continue
 
             failed_paths = tuple(result.failed_paths)

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -444,11 +444,21 @@ class AcquisitionScheduler:
             and existing.provider_generation == provider_generation
         )
 
-    def release_claim(self, request_id: str, *, claimant: object) -> None:
+    def release_claim(
+        self,
+        request_id: str,
+        *,
+        claimant: object,
+        provider_generation: int,
+    ) -> None:
         """Release a request flight only when ``claimant`` still owns it."""
 
         existing = self._claims_by_request_id.get(request_id)
-        if existing is not None and existing.claimant is claimant:
+        if (
+            existing is not None
+            and existing.claimant is claimant
+            and existing.provider_generation == provider_generation
+        ):
             del self._claims_by_request_id[request_id]
 
     def ensure_fresh(

--- a/src/rigplane/core/acquisition_scheduler.py
+++ b/src/rigplane/core/acquisition_scheduler.py
@@ -220,6 +220,12 @@ class _CadenceState:
 
 
 @dataclass(frozen=True, slots=True)
+class _AcquisitionClaim:
+    claimant: object
+    provider_generation: int
+
+
+@dataclass(frozen=True, slots=True)
 class _PendingCadenceUpdate:
     request_id: str
     semantic_changed: bool
@@ -342,6 +348,7 @@ class AcquisitionScheduler:
     __slots__ = (
         "_clock",
         "_cadence_by_key",
+        "_claims_by_request_id",
         "_deferred",
         "_external_cat_owner",
         "_external_cat_paused",
@@ -367,6 +374,7 @@ class AcquisitionScheduler:
         self._requests_by_key: dict[_AcquisitionRequestKey, AcquisitionRequest] = {}
         self._deferred: dict[_AcquisitionRequestKey, _PendingEnsureFresh] = {}
         self._cadence_by_key: dict[_AcquisitionRequestKey, _CadenceState] = {}
+        self._claims_by_request_id: dict[str, _AcquisitionClaim] = {}
         self._pending_cadence_by_key: dict[
             _AcquisitionRequestKey,
             _PendingCadenceUpdate,
@@ -399,6 +407,49 @@ class AcquisitionScheduler:
 
         provider: str = self._profile.provider
         return provider
+
+    def try_claim(
+        self,
+        request: AcquisitionRequest,
+        *,
+        claimant: object,
+        provider_generation: int,
+    ) -> bool:
+        """Atomically bind one pending request flight to its dispatch seat."""
+
+        existing = self._claims_by_request_id.get(request.id)
+        if existing is None or provider_generation > existing.provider_generation:
+            self._claims_by_request_id[request.id] = _AcquisitionClaim(
+                claimant=claimant,
+                provider_generation=provider_generation,
+            )
+            return True
+        if provider_generation < existing.provider_generation:
+            return False
+        return existing.claimant is claimant
+
+    def claim_is_current(
+        self,
+        request: AcquisitionRequest,
+        *,
+        claimant: object,
+        provider_generation: int,
+    ) -> bool:
+        """Return whether this seat still owns the request flight."""
+
+        existing = self._claims_by_request_id.get(request.id)
+        return (
+            existing is not None
+            and existing.claimant is claimant
+            and existing.provider_generation == provider_generation
+        )
+
+    def release_claim(self, request_id: str, *, claimant: object) -> None:
+        """Release a request flight only when ``claimant`` still owns it."""
+
+        existing = self._claims_by_request_id.get(request_id)
+        if existing is not None and existing.claimant is claimant:
+            del self._claims_by_request_id[request_id]
 
     def ensure_fresh(
         self,
@@ -846,6 +897,7 @@ class AcquisitionScheduler:
                     )
             else:
                 del self._requests_by_key[key]
+                self._claims_by_request_id.pop(request.id, None)
 
         base_cadence = request.policy.cadence_seconds
         if base_cadence is None:
@@ -945,6 +997,7 @@ class AcquisitionScheduler:
                 )
             else:
                 del self._requests_by_key[key]
+                self._claims_by_request_id.pop(request.id, None)
                 self._pending_cadence_by_key.pop(key, None)
 
         if request.policy.cadence_seconds is None:
@@ -986,6 +1039,7 @@ class AcquisitionScheduler:
 
         return {
             "queuedRequestCount": len(self._requests_by_key),
+            "claimedRequestCount": len(self._claims_by_request_id),
             # MOR-1533 (3): the subset of queuedRequestCount currently
             # withheld by the MOR-1531 tx_only/tx_active gate -- see
             # dispatchable_requests() -- distinguished from "backlog".
@@ -1013,6 +1067,7 @@ class AcquisitionScheduler:
             if not self._must_defer_for_external_cat(request.paths):
                 continue
             del self._requests_by_key[key]
+            self._claims_by_request_id.pop(request.id, None)
             self._defer(
                 key,
                 _PendingEnsureFresh(

--- a/src/rigplane/rigctld/server.py
+++ b/src/rigplane/rigctld/server.py
@@ -688,6 +688,7 @@ class RigctldServer:
                 report_executor_missing=self._report_acquisition_executor_missing,
                 report_executor_error=self._report_acquisition_executor_error,
                 report_sent=self._report_acquisition_sent,
+                claimant=self,
             )
             self._acquisition_drain = drain
         return drain

--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -3696,6 +3696,7 @@ class RadioPoller:
                 report_sent=self._report_acquisition_sent,
                 report_expiry=self._report_acquisition_expiry,
                 on_forget=self._forget_acquisition_grace,
+                claimant=self,
             )
             self._acquisition_drain = drain
         return drain

--- a/tests/test_acquisition_drain.py
+++ b/tests/test_acquisition_drain.py
@@ -68,12 +68,46 @@ class _StubScheduler:
     def __init__(self, pending: tuple[AcquisitionRequest, ...]) -> None:
         self.pending = pending
         self.tx_active_calls: list[bool] = []
+        self.claimant_by_request: dict[str, object] = {}
+        self.claim_generation_by_request: dict[str, int] = {}
 
     def note_tx_active(self, tx_active: bool) -> None:
         self.tx_active_calls.append(tx_active)
 
     def dispatchable_requests(self) -> tuple[AcquisitionRequest, ...]:
         return self.pending
+
+    def try_claim(
+        self,
+        request: AcquisitionRequest,
+        *,
+        claimant: object,
+        provider_generation: int,
+    ) -> bool:
+        existing = self.claimant_by_request.get(request.id)
+        if existing is not None and existing is not claimant:
+            return False
+        self.claimant_by_request[request.id] = claimant
+        self.claim_generation_by_request[request.id] = provider_generation
+        return True
+
+    def claim_is_current(
+        self,
+        request: AcquisitionRequest,
+        *,
+        claimant: object,
+        provider_generation: int,
+    ) -> bool:
+        return (
+            self.claimant_by_request.get(request.id) is claimant
+            and self.claim_generation_by_request.get(request.id) == provider_generation
+        )
+
+    def release_claim(self, request_id: str, *, claimant: object) -> None:
+        if self.claimant_by_request.get(request_id) is not claimant:
+            return
+        self.claimant_by_request.pop(request_id, None)
+        self.claim_generation_by_request.pop(request_id, None)
 
 
 class _StubExecutor:

--- a/tests/test_acquisition_drain.py
+++ b/tests/test_acquisition_drain.py
@@ -103,8 +103,17 @@ class _StubScheduler:
             and self.claim_generation_by_request.get(request.id) == provider_generation
         )
 
-    def release_claim(self, request_id: str, *, claimant: object) -> None:
-        if self.claimant_by_request.get(request_id) is not claimant:
+    def release_claim(
+        self,
+        request_id: str,
+        *,
+        claimant: object,
+        provider_generation: int,
+    ) -> None:
+        if (
+            self.claimant_by_request.get(request_id) is not claimant
+            or self.claim_generation_by_request.get(request_id) != provider_generation
+        ):
             return
         self.claimant_by_request.pop(request_id, None)
         self.claim_generation_by_request.pop(request_id, None)

--- a/tests/test_combined_acquisition_drain.py
+++ b/tests/test_combined_acquisition_drain.py
@@ -1,0 +1,491 @@
+"""Cross-seat acquisition-flight contracts for MOR-2292.
+
+Web and rigctld retain separate drains and seat policies.  These tests pin the
+shared scheduler as the one atomic owner of request-flight identity when both
+seats are attached to the same radio services.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import pytest
+
+from rigplane.core.acquisition_drain import AcquisitionDrain
+from rigplane.core.acquisition_scheduler import (
+    AcquisitionExecutionResult,
+    AcquisitionPriority,
+    AcquisitionRequest,
+    AcquisitionScheduler,
+    AcquisitionStatus,
+)
+from rigplane.core.state_acquisition_policy import (
+    AcquisitionPolicy,
+    FieldCapability,
+    RadioAcquisitionProfile,
+)
+from rigplane.core.state_pipeline_contracts import (
+    ChangeSet,
+    FieldPath,
+    Observation,
+    SourceMetadata,
+)
+from rigplane.core.state_store import StateStore
+
+_FREQ = FieldPath.active("main", "freq_mode", "freq_hz")
+_MODE = FieldPath.active("main", "freq_mode", "mode")
+_PTT = FieldPath.global_("tx_state", "ptt")
+_SWR = FieldPath.global_("meters", "swr")
+
+
+def _profile(
+    *paths: FieldPath,
+    field_policies: dict[FieldPath, AcquisitionPolicy] | None = None,
+) -> RadioAcquisitionProfile:
+    return RadioAcquisitionProfile(
+        provider="icom_civ",
+        capabilities=tuple(FieldCapability(path=path, polling=True) for path in paths),
+        default_policy=AcquisitionPolicy(),
+        field_policies=field_policies or {},
+    )
+
+
+def _queued(
+    scheduler: AcquisitionScheduler,
+    path: FieldPath = _FREQ,
+    *,
+    priority: AcquisitionPriority = AcquisitionPriority.USER,
+    reason: str = "combined-seat-test",
+) -> AcquisitionRequest:
+    result = scheduler.ensure_fresh(
+        path,
+        max_age=5.0,
+        priority=priority,
+        reason=reason,
+    )
+    assert result.status is AcquisitionStatus.QUEUED
+    assert result.request is not None
+    return result.request
+
+
+def _settlement() -> ChangeSet:
+    return ChangeSet(
+        revision=0,
+        freshness_revision=0,
+        observation_seq=0,
+        changes=(),
+        timestamp_monotonic=10.0,
+        sources=(
+            SourceMetadata(
+                source="poll_response",
+                provider="combined-seat-test",
+                transport="fake",
+            ),
+        ),
+    )
+
+
+@dataclass
+class _Reports:
+    seat: str
+    expiries: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    sent: list[tuple[str, tuple[FieldPath, ...]]] = field(default_factory=list)
+    forgotten: list[str] = field(default_factory=list)
+    propagate_executor_error: bool = False
+
+    def failure(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        reason: str,
+        failed_paths: tuple[FieldPath, ...] | frozenset[FieldPath],
+        now: float,
+    ) -> None:
+        self.failures.append(reason)
+        scheduler.record_acquisition_failure(
+            request,
+            reason=reason,
+            failed_paths=failed_paths,
+            now=now,
+            link_healthy=False,
+        )
+
+    def missing(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        now: float,
+    ) -> None:
+        self.failure(
+            scheduler,
+            request,
+            reason="acquisition_executor_missing",
+            failed_paths=request.paths,
+            now=now,
+        )
+
+    def error(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        error: BaseException,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> None:
+        self.errors.append(str(error))
+        scheduler.record_acquisition_failure(
+            request,
+            reason="acquisition_executor_error",
+            failed_paths=tuple(path for path in request.paths if path not in sent_paths),
+            now=now,
+            link_healthy=False,
+        )
+        if self.propagate_executor_error:
+            raise error
+
+    def sent_report(
+        self,
+        request: AcquisitionRequest,
+        *,
+        paths: tuple[FieldPath, ...],
+        pending_request_count: int,
+    ) -> None:
+        self.sent.append((request.id, paths))
+
+    def expiry(
+        self,
+        scheduler: AcquisitionScheduler,
+        request: AcquisitionRequest,
+        *,
+        sent_paths: frozenset[FieldPath],
+        now: float,
+    ) -> bool:
+        self.expiries.append(request.id)
+        self.failure(
+            scheduler,
+            request,
+            reason="acquisition_request_timeout",
+            failed_paths=sent_paths or frozenset(request.paths),
+            now=now,
+        )
+        return True
+
+    def forget(self, request_id: str) -> None:
+        self.forgotten.append(request_id)
+
+
+class _Executor:
+    def __init__(
+        self,
+        seat: str,
+        entries: list[str],
+        *,
+        release: asyncio.Event | None = None,
+        error: BaseException | None = None,
+        before_await: Callable[[], None] | None = None,
+    ) -> None:
+        self.seat = seat
+        self.entries = entries
+        self.release = release
+        self.error = error
+        self.before_await = before_await
+        self.calls: list[tuple[AcquisitionRequest, frozenset[FieldPath]]] = []
+
+    async def execute(
+        self,
+        request: AcquisitionRequest,
+        *,
+        already_sent_paths: frozenset[FieldPath],
+    ) -> AcquisitionExecutionResult:
+        self.entries.append(self.seat)
+        self.calls.append((request, already_sent_paths))
+        if self.before_await is not None:
+            self.before_await()
+        if self.release is not None:
+            await self.release.wait()
+        if self.error is not None:
+            raise self.error
+        return AcquisitionExecutionResult(
+            sent_paths=tuple(path for path in request.paths if path not in already_sent_paths)
+        )
+
+
+def _drain(
+    scheduler: AcquisitionScheduler,
+    store: StateStore,
+    executor: _Executor,
+    reports: _Reports,
+    *,
+    in_flight: dict[str, tuple[frozenset[FieldPath], float]] | None = None,
+    expired: Callable[..., bool] | None = None,
+) -> AcquisitionDrain:
+    return AcquisitionDrain(
+        scheduler=lambda: scheduler,
+        executor=lambda: executor,
+        store=lambda: store,
+        in_flight={} if in_flight is None else in_flight,
+        expired=(lambda request, *, sent_at, now: False)
+        if expired is None
+        else expired,
+        dispatchable=lambda pending: pending,
+        report_failure=reports.failure,
+        report_executor_missing=reports.missing,
+        report_executor_error=reports.error,
+        report_sent=reports.sent_report,
+        report_expiry=reports.expiry,
+        on_forget=reports.forget,
+    )
+
+
+@pytest.mark.parametrize("winning_seat", ["web", "rigctld"])
+async def test_shared_scheduler_allows_one_seat_to_enter_executor_before_release(
+    winning_seat: str,
+) -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    request = _queued(scheduler)
+    store = StateStore()
+    release = asyncio.Event()
+    entries: list[str] = []
+    loser = "rigctld" if winning_seat == "web" else "web"
+    winning_reports = _Reports(winning_seat)
+    losing_reports = _Reports(loser)
+    winner = _drain(
+        scheduler,
+        store,
+        _Executor(winning_seat, entries, release=release),
+        winning_reports,
+    )
+    losing_executor = _Executor(loser, entries)
+    losing = _drain(scheduler, store, losing_executor, losing_reports)
+
+    winning_task = asyncio.create_task(winner.run_once())
+    try:
+        while not entries:
+            await asyncio.sleep(0)
+        await losing.run_once()
+        assert entries == [winning_seat], "both seats entered one shared request"
+        assert losing_executor.calls == []
+    finally:
+        release.set()
+        await winning_task
+
+    scheduler.record_acquisition_result(request, _settlement())
+    assert scheduler.pending_requests() == ()
+    assert winning_reports.sent == [(request.id, (_FREQ,))]
+    assert losing_reports.sent == []
+
+
+async def test_claim_exists_before_the_executor_reaches_its_first_await() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    _queued(scheduler)
+    store = StateStore()
+    checked: list[bool] = []
+
+    def assert_claimed() -> None:
+        assert scheduler.diagnostics()["claimedRequestCount"] == 1
+        checked.append(True)
+
+    executor = _Executor("web", [], before_await=assert_claimed)
+    await _drain(scheduler, store, executor, _Reports("web")).run_once()
+    assert checked == [True]
+
+
+async def test_independent_schedulers_remain_independent_control() -> None:
+    entries: list[str] = []
+    for seat in ("web", "rigctld"):
+        scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+        _queued(scheduler)
+        await _drain(
+            scheduler,
+            StateStore(),
+            _Executor(seat, entries),
+            _Reports(seat),
+        ).run_once()
+    assert entries == ["web", "rigctld"]
+
+
+async def test_winning_seat_owns_coalesced_path_growth() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ, _MODE))
+    request = _queued(scheduler, _FREQ)
+    store = StateStore()
+    entries: list[str] = []
+    web_executor = _Executor("web", entries)
+    rigctld_executor = _Executor("rigctld", entries)
+    web = _drain(scheduler, store, web_executor, _Reports("web"))
+    rigctld = _drain(scheduler, store, rigctld_executor, _Reports("rigctld"))
+
+    await web.run_once()
+    grown = _queued(scheduler, _MODE, reason="coalesced-mode")
+    assert grown.id == request.id
+    assert grown.paths == (_FREQ, _MODE)
+
+    await rigctld.run_once()
+    await web.run_once()
+
+    assert rigctld_executor.calls == []
+    assert [call[1] for call in web_executor.calls] == [
+        frozenset(),
+        frozenset({_FREQ}),
+    ]
+    assert entries == ["web", "web"]
+
+
+async def test_only_winning_seat_applies_expiry_and_forget_policy() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    request = _queued(scheduler)
+    store = StateStore()
+    winner_reports = _Reports("web")
+    loser_reports = _Reports("rigctld")
+    in_flight: dict[str, tuple[frozenset[FieldPath], float]] = {}
+    winner = _drain(
+        scheduler,
+        store,
+        _Executor("web", []),
+        winner_reports,
+        in_flight=in_flight,
+        expired=lambda request, *, sent_at, now: bool(in_flight),
+    )
+    loser_executor = _Executor("rigctld", [])
+    loser = _drain(scheduler, store, loser_executor, loser_reports)
+
+    await winner.run_once()
+    await loser.run_once()
+    await winner.run_once()
+
+    assert loser_executor.calls == []
+    assert winner_reports.expiries == [request.id]
+    assert winner_reports.forgotten == [request.id]
+    assert loser_reports.expiries == []
+    assert scheduler.diagnostics()["claimedRequestCount"] == 0
+
+
+async def test_cancellation_releases_claim_for_the_other_seat() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    _queued(scheduler)
+    store = StateStore()
+    first = _drain(
+        scheduler,
+        store,
+        _Executor("web", [], error=asyncio.CancelledError()),
+        _Reports("web"),
+    )
+    second_executor = _Executor("rigctld", [])
+    second = _drain(scheduler, store, second_executor, _Reports("rigctld"))
+
+    with pytest.raises(asyncio.CancelledError):
+        await first.run_once()
+    assert scheduler.diagnostics()["claimedRequestCount"] == 0
+    await second.run_once()
+    assert len(second_executor.calls) == 1
+
+
+async def test_web_propagated_executor_failure_releases_claim() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    _queued(scheduler)
+    store = StateStore()
+    error = RuntimeError("web send failed")
+    web_reports = _Reports("web", propagate_executor_error=True)
+    web = _drain(
+        scheduler,
+        store,
+        _Executor("web", [], error=error),
+        web_reports,
+    )
+
+    with pytest.raises(RuntimeError, match="web send failed") as caught:
+        await web.run_once()
+    assert caught.value is error
+    assert scheduler.diagnostics()["claimedRequestCount"] == 0
+
+    # The failure callback completed this request. A newly queued request must
+    # be claimable by the other seat rather than inheriting the dead flight.
+    _queued(scheduler, reason="retry-after-web-error")
+    rigctld_executor = _Executor("rigctld", [])
+    await _drain(
+        scheduler,
+        store,
+        rigctld_executor,
+        _Reports("rigctld"),
+    ).run_once()
+    assert len(rigctld_executor.calls) == 1
+
+
+async def test_provider_replacement_rejects_old_executor_settlement() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    request = _queued(scheduler)
+    store = StateStore()
+    release = asyncio.Event()
+    entries: list[str] = []
+    old_reports = _Reports("web")
+    new_reports = _Reports("rigctld")
+    old = _drain(
+        scheduler,
+        store,
+        _Executor("web", entries, release=release),
+        old_reports,
+    )
+    new = _drain(
+        scheduler,
+        store,
+        _Executor("rigctld", entries),
+        new_reports,
+    )
+
+    old_task = asyncio.create_task(old.run_once())
+    try:
+        while not entries:
+            await asyncio.sleep(0)
+        assert store.begin_provider_generation() == 1
+        await new.run_once()
+    finally:
+        release.set()
+        await old_task
+
+    assert entries == ["web", "rigctld"]
+    assert old_reports.sent == [], "old-generation executor result settled"
+    assert new_reports.sent == [(request.id, (_FREQ,))]
+
+
+async def test_pending_but_not_dispatchable_request_is_not_claimed() -> None:
+    policy = AcquisitionPolicy(tx_only=True)
+    scheduler = AcquisitionScheduler(
+        profile=_profile(_SWR, field_policies={_SWR: policy})
+    )
+    _queued(
+        scheduler,
+        _SWR,
+        priority=AcquisitionPriority.RECONCILIATION,
+        reason="stale",
+    )
+    rx_store = StateStore()
+    executor = _Executor("web", [])
+    await _drain(scheduler, rx_store, executor, _Reports("web")).run_once()
+
+    assert len(scheduler.pending_requests()) == 1
+    assert scheduler.dispatchable_requests() == ()
+    assert executor.calls == []
+    assert scheduler.diagnostics()["claimedRequestCount"] == 0
+
+    tx_store = StateStore()
+    tx_store.apply(
+        Observation(
+            path=_PTT,
+            value=True,
+            source=SourceMetadata(
+                source="poll_response",
+                provider="combined-seat-test",
+                transport="fake",
+            ),
+            timestamp_monotonic=1.0,
+            max_age=100.0,
+        )
+    )
+    await _drain(scheduler, tx_store, executor, _Reports("rigctld")).run_once()
+    assert len(executor.calls) == 1

--- a/tests/test_combined_acquisition_drain.py
+++ b/tests/test_combined_acquisition_drain.py
@@ -80,7 +80,7 @@ def _settlement() -> ChangeSet:
         sources=(
             SourceMetadata(
                 source="poll_response",
-                provider="combined-seat-test",
+                provider="combined_seat_test",
                 transport="fake",
             ),
         ),
@@ -537,7 +537,7 @@ async def test_pending_but_not_dispatchable_request_is_not_claimed() -> None:
             value=True,
             source=SourceMetadata(
                 source="poll_response",
-                provider="combined-seat-test",
+                provider="combined_seat_test",
                 transport="fake",
             ),
             timestamp_monotonic=1.0,

--- a/tests/test_combined_acquisition_drain.py
+++ b/tests/test_combined_acquisition_drain.py
@@ -457,6 +457,59 @@ async def test_provider_replacement_rejects_old_executor_settlement() -> None:
     assert new_reports.sent == [(request.id, (_FREQ,))]
 
 
+async def test_old_executor_error_cannot_delete_replacement_generation_claim() -> None:
+    scheduler = AcquisitionScheduler(profile=_profile(_FREQ))
+    request = _queued(scheduler)
+    store = StateStore()
+    old_release = asyncio.Event()
+    replacement_release = asyncio.Event()
+    entries: list[str] = []
+    old_error = RuntimeError("old Web executor failed")
+    old_reports = _Reports("web", propagate_executor_error=True)
+    replacement_reports = _Reports("rigctld")
+    old = _drain(
+        scheduler,
+        store,
+        _Executor("web", entries, release=old_release, error=old_error),
+        old_reports,
+    )
+    replacement = _drain(
+        scheduler,
+        store,
+        _Executor("rigctld", entries, release=replacement_release),
+        replacement_reports,
+    )
+
+    old_task = asyncio.create_task(old.run_once())
+    while entries != ["web"]:
+        await asyncio.sleep(0)
+    assert store.begin_provider_generation() == 1
+    replacement_task = asyncio.create_task(replacement.run_once())
+    while entries != ["web", "rigctld"]:
+        await asyncio.sleep(0)
+
+    old_release.set()
+    with pytest.raises(RuntimeError, match="old Web executor failed") as caught:
+        await old_task
+    assert caught.value is old_error
+    assert scheduler.pending_requests() == (request,)
+    assert scheduler.diagnostics()["claimedRequestCount"] == 1
+
+    intruder = _Executor("extra", entries)
+    await _drain(
+        scheduler,
+        store,
+        intruder,
+        _Reports("extra"),
+    ).run_once()
+    assert intruder.calls == []
+
+    replacement_release.set()
+    await replacement_task
+    assert replacement_reports.sent == [(request.id, (_FREQ,))]
+    scheduler.record_acquisition_result(request, _settlement())
+
+
 async def test_pending_but_not_dispatchable_request_is_not_claimed() -> None:
     policy = AcquisitionPolicy(tx_only=True)
     scheduler = AcquisitionScheduler(

--- a/tests/test_combined_acquisition_drain.py
+++ b/tests/test_combined_acquisition_drain.py
@@ -143,7 +143,9 @@ class _Reports:
         scheduler.record_acquisition_failure(
             request,
             reason="acquisition_executor_error",
-            failed_paths=tuple(path for path in request.paths if path not in sent_paths),
+            failed_paths=tuple(
+                path for path in request.paths if path not in sent_paths
+            ),
             now=now,
             link_healthy=False,
         )
@@ -213,7 +215,9 @@ class _Executor:
         if self.error is not None:
             raise self.error
         return AcquisitionExecutionResult(
-            sent_paths=tuple(path for path in request.paths if path not in already_sent_paths)
+            sent_paths=tuple(
+                path for path in request.paths if path not in already_sent_paths
+            )
         )
 
 


### PR DESCRIPTION
## Scope

MOR-2292 acquisition3c. The existing AcquisitionScheduler owns one atomic request-flight claim shared by the existing Web and rigctld drain seats. Each seat keeps its distinct expiry, filtering, error, priority, and diagnostic policy.

## RED evidence

Initial shared-flight RED: https://github.com/rigplane/rigplane-core/actions/runs/33792961775 at test-only head `79f093ba6c78390f495637905aef284796fd00cd`.

Result: 9 failed, 15050 passed, 220 skipped, 15 xfailed. The primary Web-first and rigctld-first interleavings both failed exactly with `both seats entered one shared request`; the remaining new failures were the intended absent claim, ownership, release, and provider-generation contracts. Ruff, import-linter, and validation gates passed.

Independent review then found a stale-error terminal-path race. Isolated RED: https://github.com/rigplane/rigplane-core/actions/runs/33795981777 at `a919b3aec3e63457926542a4b7c4721f7111432f`.

Result: exactly 1 failed, 15077 passed, 218 skipped, 15 xfailed. The sole failure was `test_old_executor_error_cannot_delete_replacement_generation_claim`: a generation-zero Web error deleted the pending generation-one rigctld replacement.

No product fix preceded either valid RED.

## Implementation

- Claim synchronously before the first executor await.
- Bind the flight to the winning seat across coalesced path growth.
- Keep pending existence distinct from dispatch eligibility.
- Require captured StateStore identity/generation and the current scheduler claim before any post-await terminal mutation, error reporting, failure settlement, or sent reporting.
- Make release token-specific to request id, claimant identity, and provider generation.
- Let only a newer provider generation supersede an older claim.
- Re-raise a stale executor error without reporting, settling, or releasing the replacement generation.
- Preserve current-generation cancellation/error behavior and the Web seat local in-flight expiry policy.
- Clear claims when the scheduler completes, fails, or externally defers the request.

No second scheduler, queue, drain, authority, epoch, or background coordinator was added.

## GREEN evidence

Final head: `287cacbdaed022196d739da8f0545d25a97e5cdd`

Natural Mac Mini quick: https://github.com/rigplane/rigplane-core/actions/runs/33796609265

Result: 15078 passed, 218 skipped, 15 xfailed, 6 warnings. Ruff, import-linter, three validation gates, frontend build/tests, visual smoke, fixture capture, Web boundary type check, and pytest all passed.

No local project test, import, parser, formatter, lint, or project script was run.

## Diff budget and limitation

Against current main `3090b5db7b0ce589c9dd77725d778fb2303a1a14`: exactly six approved files, 759 insertions and 5 deletions, 764 changed lines, below the hard 1000-line cap. The greater-than-600 size is the focused combined-seat interleaving module and narrow drain test support; product changes remain within the four approved existing product files.

Explicit limitation: this contract cannot guarantee physical-wire exactly-once behavior after a partial send or cancellation.

## Required pre-push TX interlock check

```text
30:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
1736:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
1975:            decision = evaluate_tx_interlock(
```
