### PR TITLE
feat: route attenuator commands through canonical binder

### DIFF
--- a/src/rigplane/core/command_dispatch.py
+++ b/src/rigplane/core/command_dispatch.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from functools import partial
 from types import MappingProxyType
@@ -74,6 +74,7 @@ class DispatchQueue(Protocol):
 
 Binder = Callable[[Mapping[str, Any]], dict[str, Any]]
 TargetBuilder = Callable[[Mapping[str, Any]], FieldPath]
+ExpectationProjector = Callable[[Any, Mapping[str, Any]], dict[str, Any]]
 
 
 class DescriptorTxPolicy(StrEnum):
@@ -93,9 +94,11 @@ class CommandDescriptor:
     target: TargetBuilder
     argument_names: tuple[str, ...]
     tx_policy: DescriptorTxPolicy
+    public_names: tuple[str, ...]
     timeout: float = 10.0
     queue_policy: Literal["ordered", "coalesced"] = "ordered"
     receiver_aware: bool = False
+    project_expectation: ExpectationProjector | None = None
 
     def result(self, intent: CommandIntent) -> dict[str, Any]:
         return {name: intent.params[name] for name in self.argument_names}
@@ -192,6 +195,36 @@ def _level_target(field: str, params: Mapping[str, Any]) -> FieldPath:
     return FieldPath.receiver(str(params["receiver"]), "operator_controls", field)
 
 
+def _bind_attenuator(params: Mapping[str, Any]) -> dict[str, Any]:
+    raw_db = params["level"] if "level" in params else params.get("db", 0)
+    db = int(raw_db)
+    return {
+        "db": db,
+        "att": db,
+        "receiver": int(params.get("receiver", 0)),
+    }
+
+
+def _attenuator_target(params: Mapping[str, Any]) -> FieldPath:
+    return FieldPath.receiver(str(params["receiver"]), "operator_controls", "att")
+
+
+def _project_attenuator_expectation(
+    radio: Any, params: Mapping[str, Any]
+) -> dict[str, Any]:
+    projector = getattr(radio, "project_attenuator_observation_value", None)
+    if not callable(projector):
+        raise CommandError(
+            "active radio does not provide attenuator observation projection"
+        )
+    projected = projector(params["db"])
+    if type(projected) is not int:
+        raise CommandError("attenuator observation projection must return an exact int")
+    normalized = dict(params)
+    normalized["att"] = projected
+    return normalized
+
+
 _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
     {
         "set_repeater_shift": CommandDescriptor(
@@ -201,6 +234,7 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             target=_repeater_shift_target,
             argument_names=("direction", "receiver"),
             tx_policy=DescriptorTxPolicy.TX_SAFE,
+            public_names=("set_repeater_shift",),
         ),
         "set_af_level": CommandDescriptor(
             name="set_af_level",
@@ -209,6 +243,7 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             target=partial(_level_target, "af_level"),
             argument_names=("level", "receiver"),
             tx_policy=DescriptorTxPolicy.ALWAYS_PASS,
+            public_names=("set_af_level",),
             queue_policy="coalesced",
             receiver_aware=True,
         ),
@@ -219,6 +254,7 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             target=partial(_level_target, "rf_gain"),
             argument_names=("level", "receiver"),
             tx_policy=DescriptorTxPolicy.ALWAYS_PASS,
+            public_names=("set_rf_gain",),
             queue_policy="coalesced",
             receiver_aware=True,
         ),
@@ -229,8 +265,21 @@ _COMMAND_DESCRIPTORS: Mapping[str, CommandDescriptor] = MappingProxyType(
             target=partial(_level_target, "squelch"),
             argument_names=("level", "receiver"),
             tx_policy=DescriptorTxPolicy.ALWAYS_PASS,
+            public_names=("set_sql", "set_squelch"),
             queue_policy="coalesced",
             receiver_aware=True,
+        ),
+        "set_att": CommandDescriptor(
+            name="set_att",
+            method_name="set_attenuator_level",
+            bind=_bind_attenuator,
+            target=_attenuator_target,
+            argument_names=("db", "receiver"),
+            tx_policy=DescriptorTxPolicy.ALWAYS_PASS,
+            public_names=("set_att", "set_attenuator"),
+            queue_policy="coalesced",
+            receiver_aware=True,
+            project_expectation=_project_attenuator_expectation,
         ),
     }
 )
@@ -261,7 +310,17 @@ def command_descriptors() -> Mapping[str, CommandDescriptor]:
 
 
 def command_descriptor(name: str) -> CommandDescriptor | None:
-    return _COMMAND_DESCRIPTORS.get("set_squelch" if name == "set_sql" else name)
+    descriptor = _COMMAND_DESCRIPTORS.get(name)
+    if descriptor is not None:
+        return descriptor
+    return next(
+        (
+            descriptor
+            for descriptor in _COMMAND_DESCRIPTORS.values()
+            if name in descriptor.public_names or name == descriptor.method_name
+        ),
+        None,
+    )
 
 
 def enqueue_command_intent(
@@ -337,7 +396,7 @@ def bind_command_intent(
     target = descriptor.target(normalized)
     return CommandIntent(
         id=command_id or f"{source}-{time.monotonic_ns()}",
-        name=descriptor.name,
+        name=descriptor.method_name,
         params=normalized,
         source=source,
         target=target,
@@ -369,13 +428,20 @@ def prepare_command_intent(
         timeout=descriptor.timeout,
     )
     supported = (
-        radio.supports_command(descriptor.name, receiver=intent.params["receiver"])
+        radio.supports_command(
+            descriptor.method_name, receiver=intent.params["receiver"]
+        )
         if descriptor.receiver_aware
-        else radio.supports_command(descriptor.name)
+        else radio.supports_command(descriptor.method_name)
     )
     if not supported:
         raise CommandUnsupportedError(
-            f"command {descriptor.name!r} is not supported by active profile"
+            f"command {descriptor.method_name!r} is not supported by active profile"
+        )
+    if descriptor.project_expectation is not None:
+        intent = replace(
+            intent,
+            params=descriptor.project_expectation(radio, intent.params),
         )
     return intent
 

--- a/src/rigplane/core/command_service.py
+++ b/src/rigplane/core/command_service.py
@@ -1179,15 +1179,6 @@ def command_intent_from_request(
         normalized["ptt"] = True
     elif command_name == "ptt_off":
         normalized["ptt"] = False
-    elif command_name in ("set_att", "set_attenuator", "set_attenuator_level"):
-        raw_value = (
-            normalized["db"]
-            if "db" in normalized
-            else normalized["level"]
-            if "level" in normalized
-            else normalized["value"]
-        )
-        normalized["att"] = int(raw_value)
     elif command_name == "set_preamp":
         raw_value = (
             normalized["level"] if "level" in normalized else normalized["value"]

--- a/src/rigplane/web/handlers/control.py
+++ b/src/rigplane/web/handlers/control.py
@@ -48,7 +48,6 @@ from ..radio_poller import (  # noqa: TID251
     SetAntenna1,
     SetAntenna2,
     SetApf,
-    SetAttenuator,
     SetAutoNotch,
     SetBand,
     SetCompressor,
@@ -2555,13 +2554,6 @@ class ControlHandler:
         radio: "Radio | None",
     ) -> dict[str, Any] | None:
         match name:
-            case "set_att" | "set_attenuator":
-                db = int(params.get("level", params.get("db", 0)))
-                rx = int(params.get("receiver", 0))
-                self._ensure_capability("attenuator", name)
-                self._ensure_receiver_supported(rx)
-                q.put(SetAttenuator(db, receiver=rx))
-                return {"db": db, "receiver": rx}
             case "set_preamp":
                 level = int(params["level"])
                 rx = int(params.get("receiver", 0))

--- a/tests/test_handlers_coverage.py
+++ b/tests/test_handlers_coverage.py
@@ -14,6 +14,8 @@ from rigplane.audio.bus import AudioBus
 from rigplane.backends.yaesu_cat.radio import YaesuCatRadio
 from rigplane.profiles import resolve_radio_profile
 from rigplane.audio.route import AudioConfigSource, AudioStreamContract
+from rigplane.core.command_dispatch import CommandUnsupportedError
+from rigplane.core.exceptions import CommandError
 from rigplane.core.radio_protocol import AudioCapable
 from rigplane.core.state_pipeline_contracts import (
     CommandIntent,
@@ -51,7 +53,6 @@ from rigplane.web.radio_poller import (
     SelectVfo,
     SetAgc,
     SetAgcTimeConstant,
-    SetAttenuator,
     SetAutoNotch,
     SetBand,
     SetCompressor,
@@ -199,6 +200,7 @@ def _capable_radio() -> SimpleNamespace:
         stop_cw_text=AsyncMock(),
         set_attenuator=AsyncMock(),
         set_attenuator_level=AsyncMock(),
+        project_attenuator_observation_value=lambda db: int(db),
         get_attenuator_level=AsyncMock(return_value=0),
         set_preamp=AsyncMock(),
         get_preamp=AsyncMock(return_value=0),
@@ -335,6 +337,31 @@ class _QueueRecorder:
                 "command_service": command_service,
             }
         )
+
+
+class _AttenuatorIngressRadio:
+    def __init__(
+        self,
+        *,
+        model: str = "IC-7610",
+        projection: object = None,
+        admitted_receiver: int | None = 0,
+    ) -> None:
+        self.profile = resolve_radio_profile(model=model)
+        self.model = self.profile.model
+        self.capabilities = set(self.profile.capabilities)
+        self.projection_calls: list[int] = []
+        self.support_calls: list[tuple[str, int | None]] = []
+        self._projection = projection if projection is not None else (lambda db: db)
+        self._admitted_receiver = admitted_receiver
+
+    def supports_command(self, command: str, *, receiver: int | None = None) -> bool:
+        self.support_calls.append((command, receiver))
+        return receiver == self._admitted_receiver
+
+    def project_attenuator_observation_value(self, db: int) -> int:
+        self.projection_calls.append(db)
+        return self._projection(db)
 
 
 def _assert_canonical_level_intent(
@@ -606,15 +633,15 @@ def _scope_frame() -> ScopeFrame:
         (
             "set_att",
             {"db": 12, "receiver": 1},
-            SetAttenuator,
-            {"db": 12, "receiver": 1},
+            CommandIntent,
+            {"db": 12, "att": 12, "receiver": 1},
             {"db": 12, "receiver": 1},
         ),
         (
             "set_attenuator",
             {"db": 12, "receiver": 1},
-            SetAttenuator,
-            {"db": 12, "receiver": 1},
+            CommandIntent,
+            {"db": 12, "att": 12, "receiver": 1},
             {"db": 12, "receiver": 1},
         ),
         (
@@ -804,6 +831,14 @@ async def test_enqueue_command_variants(
     assert len(queue.items) == 1
     cmd = queue.items[0]
     if expected_type is CommandIntent:
+        if name in ("set_att", "set_attenuator"):
+            assert cmd.name == "set_attenuator_level"
+            for key, value in expected_attrs.items():
+                assert cmd.params[key] == value
+            assert cmd.target == FieldPath.receiver(
+                str(expected_attrs["receiver"]), "operator_controls", "att"
+            )
+            return
         field = {
             "set_af_level": "af_level",
             "set_rf_gain": "rf_gain",
@@ -819,6 +854,132 @@ async def test_enqueue_command_variants(
     assert isinstance(cmd, expected_type)
     for key, value in expected_attrs.items():
         assert getattr(cmd, key) == value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "params", "expected_db"),
+    [
+        ("set_att", {"level": 20, "db": 3, "receiver": 0}, 20),
+        ("set_attenuator", {"db": 6, "receiver": 0}, 6),
+        ("set_att", {"level": 3, "receiver": 0}, 3),
+        ("set_attenuator", {"receiver": 0}, 0),
+        ("set_att", {"value": 99, "receiver": 0}, 0),
+    ],
+    ids=("level-wins", "db-only", "level-only", "missing-defaults-zero", "value-only"),
+)
+async def test_att_web_aliases_bind_one_canonical_intent(
+    name: str, params: dict[str, object], expected_db: int
+) -> None:
+    queue = _QueueRecorder()
+    radio = _AttenuatorIngressRadio()
+    handler = _control_handler(radio=radio, server=SimpleNamespace(command_queue=queue))
+
+    result = await handler._enqueue_command(name, params)
+
+    assert result == {"db": expected_db, "receiver": 0}
+    assert len(queue.items) == 1
+    intent = queue.items[0]
+    assert isinstance(intent, CommandIntent)
+    assert intent.name == "set_attenuator_level"
+    assert intent.params["db"] == expected_db
+    assert intent.params["att"] == expected_db
+    assert intent.params["receiver"] == 0
+    assert intent.target == FieldPath.receiver("0", "operator_controls", "att")
+    assert radio.projection_calls == [expected_db]
+    assert radio.support_calls == [("set_attenuator_level", 0)]
+    assert queue.metadata[0]["future"] is None
+
+
+@pytest.mark.asyncio
+async def test_att_web_projection_uses_provider_native_expectation() -> None:
+    queue = _QueueRecorder()
+    radio = _AttenuatorIngressRadio(model="FTX-1", projection=lambda db: int(db > 0))
+    handler = _control_handler(radio=radio, server=SimpleNamespace(command_queue=queue))
+
+    result = await handler._enqueue_command("set_attenuator", {"db": 20})
+
+    assert result == {"db": 20, "receiver": 0}
+    intent = queue.items[0]
+    assert isinstance(intent, CommandIntent)
+    assert intent.params["db"] == 20
+    assert intent.params["att"] == 1
+    assert type(intent.params["att"]) is int
+    assert radio.projection_calls == [20]
+    service = handler._command_service  # noqa: SLF001
+    session_id = intent.params.get("session_id")
+    assert intent.source == "websocket"
+    assert isinstance(session_id, str)
+    overlays = service.pending_overlays(
+        source=intent.source,
+        session_id=session_id,
+        command_id=intent.id,
+        path=intent.target,
+    )
+    expectations = service.readback_expectations(
+        source=intent.source,
+        session_id=session_id,
+        command_id=intent.id,
+    )
+    assert len(overlays) == 1
+    assert len(expectations) == 1
+    for item in (*overlays, *expectations):
+        assert item.source == intent.source
+        assert item.session_id == session_id
+        assert item.command_id == intent.id
+        assert item.path == intent.target
+        assert type(item.value) is int
+        assert item.value == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "projection",
+    [None, lambda db: True, lambda db: 1.0],
+    ids=("missing", "bool-result", "float-result"),
+)
+async def test_att_web_refuses_missing_or_non_integer_projection(
+    projection: object,
+) -> None:
+    queue = _QueueRecorder()
+    radio = _AttenuatorIngressRadio(projection=projection)
+    if projection is None:
+        radio.project_attenuator_observation_value = None
+    handler = _control_handler(radio=radio, server=SimpleNamespace(command_queue=queue))
+
+    with pytest.raises(CommandError):
+        await handler._enqueue_command("set_att", {"db": 20})
+
+    assert queue.items == []
+    assert handler._command_service.lifecycle_events() == ()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_att_web_explicit_none_receiver_fails_before_enqueue() -> None:
+    queue = _QueueRecorder()
+    handler = _control_handler(
+        radio=_AttenuatorIngressRadio(), server=SimpleNamespace(command_queue=queue)
+    )
+
+    with pytest.raises(TypeError):
+        await handler._enqueue_command("set_att", {"db": 20, "receiver": None})
+
+    assert queue.items == []
+
+
+@pytest.mark.asyncio
+async def test_att_web_sub_refusal_happens_before_queue_effects() -> None:
+    queue = _QueueRecorder()
+    radio = _AttenuatorIngressRadio(model="FTX-1", admitted_receiver=0)
+    handler = _control_handler(radio=radio, server=SimpleNamespace(command_queue=queue))
+
+    with pytest.raises(CommandUnsupportedError):
+        await handler._enqueue_command("set_att", {"db": 20, "receiver": 1})
+
+    assert queue.items == []
+    assert radio.projection_calls == []
+    assert radio.support_calls == [("set_attenuator_level", 1)]
+    assert handler._command_service.lifecycle_events() == ()  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/test_mor2161_command_dispatch.py
+++ b/tests/test_mor2161_command_dispatch.py
@@ -597,6 +597,7 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
         "set_af_level",
         "set_rf_gain",
         "set_squelch",
+        "set_att",
     }
     descriptor = command_descriptors()["set_repeater_shift"]
     assert descriptor.tx_policy is DescriptorTxPolicy.TX_SAFE
@@ -605,6 +606,45 @@ def test_descriptor_is_the_only_migrated_name_source() -> None:
     )
     assert policy_field.default is MISSING
     assert "set_repeater_shift" in ControlHandler._COMMANDS  # noqa: SLF001
+    attenuator = command_descriptors()["set_att"]
+    assert attenuator.name == "set_att"
+    assert attenuator.method_name == "set_attenuator_level"
+    assert attenuator.argument_names == ("db", "receiver")
+    assert attenuator.queue_policy == "coalesced"
+    assert attenuator.receiver_aware
+    assert attenuator.public_names == ("set_att", "set_attenuator")
+    assert command_descriptors()["set_squelch"].public_names == (
+        "set_sql",
+        "set_squelch",
+    )
+    assert "set_att" in ControlHandler._COMMANDS  # noqa: SLF001
+    assert "set_attenuator" in ControlHandler._COMMANDS  # noqa: SLF001
+    assert "set_attenuator_level" not in ControlHandler._COMMANDS  # noqa: SLF001
+    assert "set_preamp" in ControlHandler._COMMANDS  # noqa: SLF001
     assert not hasattr(runtime_types, "SetRepeaterShift")
     assert not hasattr(_poller_types, "SetRepeaterShift")
     assert not hasattr(radio_poller, "SetRepeaterShift")
+
+
+@pytest.mark.parametrize(
+    ("params", "expected_db"),
+    [
+        ({"db": 20, "level": 3, "value": 1, "receiver": 1}, 3),
+        ({"level": 6, "value": 1}, 6),
+        ({"db": 12, "value": 1}, 12),
+        ({"value": 1}, 0),
+        ({}, 0),
+    ],
+    ids=("level-wins", "level-only", "db-only", "value-is-not-an-alias", "default"),
+)
+def test_att_helper_uses_public_precedence_through_canonical_binding(
+    params: dict[str, int], expected_db: int
+) -> None:
+    from rigplane.core.command_service import command_intent_from_request
+
+    intent = command_intent_from_request("set_att", params, source="public_api")
+
+    assert intent.name == "set_attenuator_level"
+    assert intent.params["db"] == expected_db
+    assert intent.params["att"] == expected_db
+    assert intent.params["receiver"] == params.get("receiver", 0)


### PR DESCRIPTION
Linear: MOR-2154 (primary owner)
Related: MOR-2263, MOR-2161

## Summary
- Route public Web and command-dispatch ATT ingress through one canonical `set_att` descriptor and binder.
- Keep `set_attenuator` as a compatibility alias; `level` takes precedence when both `level` and `db` are supplied.
- Preserve normalized/backend `db` while projecting ATT observation expectations through the provider contract.
- Remove the legacy Web-specific ATT queue path.

## Validation
- Focused ATT handler and command-dispatch tests passed on Mac mini before delivery.
- `git diff origin/main...HEAD --check` passes.

Hardware restoration is outside this PR.