### PR TITLE
fix(#2284): align FTX-1 example profile capabilities

### DIFF
--- a/rigs/examples/ftx1.toml
+++ b/rigs/examples/ftx1.toml
@@ -22,17 +22,6 @@ variant = "yaesu_enhanced"   # Yaesu extensions on top of CI-V
 # Yaesu uses CI-V framing but different sub-commands and data encoding
 # Key difference: mode registers are hex-string based (0x01-0x0I)
 
-[spectrum]
-seq_max = 0
-amp_max = 255
-data_len_max = 850
-modes = [
-    "3dss_center", "3dss_cursor", "3dss_fixed",
-    "center_expand", "center_normal", "center_expand2",
-    "cursor_expand", "cursor_normal", "cursor_expand2",
-    "fixed_expand", "fixed_normal",
-]
-
 # ═══ Layer 1: CAPABILITIES ═══════════════════════════════════════
 
 [capabilities]
@@ -68,8 +57,6 @@ features = [
     "tuner",
     # Metering
     "meters",
-    # Scope
-    "scope",
     # Tone
     "repeater_tone",
     "tsql",


### PR DESCRIPTION
## Summary
- remove the contradictory `spectrum` table from `rigs/examples/ftx1.toml`
- remove the unsupported `scope` capability from the example profile

## Scope and ownership
- Implements Linear MOR-2284 under the existing owner ruling recorded in Linear.
- Exact one-file scope: `rigs/examples/ftx1.toml`.
- No behavior change; this is example/profile consistency only.
- Does not retire legacy paths and does not close or satisfy MOR-1413 or MOR-2232.

## Evidence
- Local RED: `uv run python -c ...` asserted the example had `spectrum` and `scope` while `rigs/ftx1.toml` had neither.
- Local GREEN: TOML parse/assertion passed; example/live both omit `spectrum` and `scope`; `git diff --check` passed; changed paths exactly `rigs/examples/ftx1.toml`.
- Mac mini isolated exact-head verification: pending in this draft PR.