### PR TITLE
fix(MOR-1841): refuse profileless poller fallback

### DIFF
--- a/src/rigplane/web/radio_poller.py
+++ b/src/rigplane/web/radio_poller.py
@@ -1166,9 +1166,9 @@ class RadioPoller:
                 return resolve_radio_profile(model=raw_model)
         except KeyError:
             pass
-        if "dual_rx" in self._caps:
-            return resolve_radio_profile(model="IC-7610")
-        return resolve_radio_profile(model="IC-7300")
+        raise NotImplementedError(
+            "radio-poller unsupported: unknown profile-less radio"
+        )
 
     def _vfo_command_profile(self, command: str) -> RadioProfile:
         """Resolve the exact profile allowed to declare a VFO primitive."""

--- a/tests/test_radio_poller_coverage.py
+++ b/tests/test_radio_poller_coverage.py
@@ -2178,53 +2178,33 @@ async def test_execute_event_emitting_commands_and_vfo_paths() -> None:
         await poller._execute(SwitchScopeReceiver(2))  # noqa: SLF001
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("command", [VfoSwap, VfoEqualize])
-@pytest.mark.parametrize("queued", [False, True], ids=("direct", "queued"))
-async def test_unknown_profileless_vfo_commands_fail_before_mutation(
-    command: type[VfoSwap] | type[VfoEqualize], queued: bool
+@pytest.mark.parametrize("capabilities", [set(), {"dual_rx"}], ids=("empty", "dual_rx"))
+def test_unknown_profileless_radio_refuses_construction_before_any_wire_or_mutation(
+    capabilities: set[str],
 ) -> None:
-    """Unknown profile-less VFO commands must never inherit a foreign primitive."""
+    """An unknown radio cannot inherit either Icom profile during setup."""
     radio = _make_radio()
     radio.profile = None
     radio.model = "Unknown Rig"
-    radio.capabilities = {"dual_rx"}
+    radio.capabilities = capabilities
+    radio.set_vfo = AsyncMock()
+    radio.select_receiver = AsyncMock()
     radio.swap_vfo_ab = AsyncMock()
     radio.equalize_vfo_ab = AsyncMock()
-    poller = RadioPoller(radio, CommandQueue())
+    radio.swap_main_sub = AsyncMock()
+    radio.equalize_main_sub = AsyncMock()
 
-    if queued:
-        _seed_fresh_rx(poller)
-        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        poller._queue.put_ordered(command(), future=future)  # noqa: SLF001
-        poller.start()
-        with pytest.raises(NotImplementedError, match="unknown.*profile"):
-            await asyncio.wait_for(future, timeout=1)
-        poller.stop()
-    else:
-        with pytest.raises(NotImplementedError, match="unknown.*profile"):
-            await poller._execute(command())  # noqa: SLF001
+    with pytest.raises(NotImplementedError, match="unknown.*profile"):
+        RadioPoller(radio, CommandQueue())
 
+    radio.set_freq.assert_not_awaited()
+    radio.send_civ.assert_not_awaited()
+    radio.set_vfo.assert_not_awaited()
+    radio.select_receiver.assert_not_awaited()
     radio.swap_vfo_ab.assert_not_awaited()
     radio.equalize_vfo_ab.assert_not_awaited()
     radio.swap_main_sub.assert_not_awaited()
     radio.equalize_main_sub.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_unknown_profileless_set_freq_keeps_base_receiver_guard() -> None:
-    """Unknown profile-less non-VFO commands retain the base fallback behavior."""
-    radio = _make_radio()
-    radio.profile = None
-    radio.model = "Unknown Rig"
-    radio.capabilities = set()
-    poller = RadioPoller(radio, CommandQueue())
-
-    with pytest.raises(CommandError, match="receiver=1"):
-        await poller._execute(SetFreq(14_074_000, receiver=1))  # noqa: SLF001
-
-    radio.set_freq.assert_not_awaited()
-    radio.send_civ.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -34,6 +34,7 @@ from rigplane.core.state_pipeline_contracts import (
     SourceMetadata,
 )
 from rigplane.core.state_store import StateStore
+from rigplane.profiles import resolve_radio_profile
 from rigplane.radio_state import RadioState
 from rigplane.rigctld.state_cache import StateCache
 from rigplane.scope import ScopeFrame
@@ -320,6 +321,10 @@ def _add_scope_capable_attrs(radio: MagicMock) -> MagicMock:
     radio.capabilities = (
         {*raw_capabilities, "scope"} if isinstance(raw_capabilities, set) else {"scope"}
     )
+    raw_model = radio.__dict__.get("model")
+    model = raw_model if isinstance(raw_model, str) else "IC-7300"
+    radio.profile = resolve_radio_profile(model=model)
+    radio.model = radio.profile.model
     radio.on_scope_data = MagicMock()
     radio.scope_stream = MagicMock()
     radio.enable_scope = AsyncMock()


### PR DESCRIPTION
## Summary
- refuse poller construction when a radio has neither a `RadioProfile` nor an exact registered model profile
- retain exact registered-model compatibility and direct profile command-map binding
- bind anonymous scope lifecycle MagicMock fixtures to the explicit IC-7300 profile while preserving an explicit model (including IC-7610)

## Root cause and scope
MOR-1841. The original natural quick at `f521e21` found 15 scope lifecycle/reconnect failures: `_add_scope_capable_attrs` built anonymous non-dual test doubles, which now correctly refuse profile-less construction. This follow-up changes only that test fixture; it adds no production fallback. The historical broad-swallow command-map loader hazard was already retired on the base. No hardware or full-suite claim.

## Evidence
- original exact-head review and failing quick are stale after this update
- local focused scope lifecycle/reconnect/generation/broadcast and MOR-1841 profileless controls: 28 passed
- Mini exact-head direct focused chain: CPython 3.11.15, exit 0; covered the four scope groups, selected profileless controls, ruff, format check, and diff-check
- diff is limited to `src/rigplane/web/radio_poller.py`, `tests/test_radio_poller_coverage.py`, and `tests/test_web_server.py`

No full matrix was manually dispatched.