### PR TITLE
Separate managed TX admission from provider settlement

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -625,9 +625,7 @@ class ManagedTxAuthority:
             self._require_ingress_open_locked()
             transition, full_force = self._transition_locked(action, owner)
             if transition is None:
-                transition = ManagedTxTransition(
-                    self._state, ManagedTxOutcome.REJECTED
-                )
+                transition = ManagedTxTransition(self._state, ManagedTxOutcome.REJECTED)
             self._wakeup.wake()
 
         async def settle() -> tuple[ManagedTxTransition, ActuationSettled | None]:

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -9,6 +9,7 @@ from enum import StrEnum
 from functools import partial
 from typing import Any, Protocol
 
+from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.runtime.managed_tx_config import (
     ManagedTxTotConfig,
     ManagedTxTotConfigStore,
@@ -72,12 +73,42 @@ class ManagedTxProjection:
     provider_generation: int | None
 
 
+_SubmissionCompletion = asyncio.Task[
+    tuple[ManagedTxTransition, ActuationSettled | None]
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTxSubmission:
+    """Accepted or rejected intent plus its separately owned actuation result."""
+
+    transition: ManagedTxTransition
+    _completion: _SubmissionCompletion
+
+    @property
+    def outcome(self) -> ManagedTxOutcome:
+        return self.transition.outcome
+
+    @property
+    def settlement_done(self) -> bool:
+        return self._completion.done()
+
+    async def wait_settlement(self) -> ActuationSettled | None:
+        """Join provider settlement without transferring cancellation ownership."""
+        _transition, settlement = await asyncio.shield(self._completion)
+        return settlement
+
+
 class ShutdownResult(StrEnum):
     DRAINED = "drained"
     TERMINATED = "terminated"
 
 
 _ProviderRetirement = Callable[[int], Awaitable[None]]
+
+_ANTENNA_WRITE_NAMES = frozenset(
+    {"set_antenna", "set_antenna_1", "set_antenna_2", "set_rx_antenna"}
+)
 
 
 class ManagedTxAuthority:
@@ -104,6 +135,7 @@ class ManagedTxAuthority:
         self._abort_fence = abort_fence
         self._pending_abort_cleanup: list[Coroutine[Any, Any, TxAbortResult]] = []
         self._abort_cleanup: set[asyncio.Task[TxAbortResult]] = set()
+        self._settlement_tasks: set[_SubmissionCompletion] = set()
         self._clock = clock or time.monotonic
         self._wakeup = wakeup or _EventWakeup(self._clock)
         self._attempt_timeout = attempt_timeout_seconds
@@ -127,17 +159,52 @@ class ManagedTxAuthority:
         self._scheduler_task = asyncio.create_task(self._scheduler())
 
     async def ptt_down(self, owner: str) -> ManagedTxOutcome:
-        transition, _ = await (await self.submit_ptt(True, owner))
-        return transition.outcome
+        """Compatibility helper which deliberately drains provider settlement."""
+        submission = await self.submit_ptt(True, owner)
+        await submission.wait_settlement()
+        return submission.outcome
 
     async def ptt_up(self, owner: str) -> ManagedTxOutcome:
-        transition, _ = await (await self.submit_ptt(False, owner))
-        return transition.outcome
+        """Compatibility helper which deliberately drains provider settlement."""
+        submission = await self.submit_ptt(False, owner)
+        await submission.wait_settlement()
+        return submission.outcome
 
     async def submit_ptt(
         self, on: bool, owner: str, *, ready: asyncio.Future[Any] | None = None
-    ) -> asyncio.Task[tuple[ManagedTxTransition, ActuationSettled | None]]:
-        """Return an owned operation; OFF waits for admission, not settlement."""
+    ) -> ManagedTxSubmission:
+        """Return after owner-scoped admission, before provider settlement."""
+        worker, admitted = self._begin_ptt_operation(on, owner, ready=ready)
+        try:
+            transition = await asyncio.shield(admitted)
+        except asyncio.CancelledError:
+            worker.cancel()
+            await self._drain_cancelled(worker)
+            raise
+        return ManagedTxSubmission(transition, worker)
+
+    async def _start_ptt_operation(
+        self, on: bool, owner: str, *, ready: asyncio.Future[Any] | None = None
+    ) -> _SubmissionCompletion:
+        """Compatibility seam for internal pre-admission cancellation tests.
+
+        Production ingress must use :meth:`submit_ptt`; this returns the private
+        operation task which the abort fence may cancel before admission.
+        """
+        worker, admitted = self._begin_ptt_operation(on, owner, ready=ready)
+        if not on:
+            try:
+                await asyncio.shield(admitted)
+            except asyncio.CancelledError:
+                worker.cancel()
+                await self._drain_cancelled(worker)
+                raise
+        return worker
+
+    def _begin_ptt_operation(
+        self, on: bool, owner: str, *, ready: asyncio.Future[Any] | None = None
+    ) -> tuple[_SubmissionCompletion, asyncio.Future[ManagedTxTransition]]:
+        """Build the one cancellable operation and its admission signal."""
         if type(on) is not bool or type(owner) is not str:
             raise TypeError("PTT requires a bool and a builtin str owner")
         if not owner:
@@ -146,8 +213,8 @@ class ManagedTxAuthority:
             raise TypeError("PTT readiness must be an existing Future or Task")
         generation = self._provider_generation
         token = self._abort_fence.issue() if on else None
-        admitted: asyncio.Future[None] | None = (
-            None if on else asyncio.get_running_loop().create_future()
+        admitted: asyncio.Future[ManagedTxTransition] = (
+            asyncio.get_running_loop().create_future()
         )
         if not on:
             self._cancel_pending_ptt(owner)
@@ -178,8 +245,8 @@ class ManagedTxAuthority:
                     execution = asyncio.create_task(
                         self._execute(transition.effects, full_force=full_force)
                     )
-                    if admitted is not None and not admitted.done():
-                        admitted.set_result(None)
+                    if not admitted.done():
+                        admitted.set_result(transition)
                 return transition, await asyncio.shield(execution)
             except asyncio.CancelledError:
                 if execution is not None:
@@ -192,15 +259,16 @@ class ManagedTxAuthority:
             if token is not None:
                 self._abort_fence.remove(token)
             error = None if task.cancelled() else task.exception()
-            if admitted is not None and not admitted.done():
+            if not admitted.done():
                 if task.cancelled():
                     admitted.cancel()
                 elif error is not None:
                     admitted.set_exception(error)
                 else:
-                    admitted.set_result(None)
+                    admitted.set_result(task.result()[0])
 
         worker = asyncio.create_task(run())
+        self._own_submission(worker)
         worker.add_done_callback(finished)
         if token is not None:
 
@@ -212,18 +280,21 @@ class ManagedTxAuthority:
             except BaseException:
                 worker.cancel()
                 raise
-        if admitted is not None:
-            try:
-                await admitted
-            except asyncio.CancelledError:
-                worker.cancel()
-                await self._drain_cancelled(worker)
-                raise
-        return worker
+        return worker, admitted
 
     def _cancel_pending_ptt(self, owner: str) -> None:
         self._pending_abort_cleanup.append(self._abort_fence.cancel_scope(owner))
         self._start_abort_cleanup()
+
+    def _own_submission(self, task: _SubmissionCompletion) -> None:
+        self._settlement_tasks.add(task)
+
+        def finished(owned: _SubmissionCompletion) -> None:
+            self._settlement_tasks.discard(owned)
+            if not owned.cancelled():
+                owned.exception()
+
+        task.add_done_callback(finished)
 
     @staticmethod
     async def _drain_cancelled(task: asyncio.Task[Any]) -> None:
@@ -238,10 +309,40 @@ class ManagedTxAuthority:
             task.exception()
 
     async def transmit_on(self) -> ManagedTxOutcome:
-        return await self._ingress("transmit_on")
+        """Compatibility helper which deliberately drains provider settlement."""
+        submission = await self.submit_transmit_on()
+        await submission.wait_settlement()
+        return submission.outcome
 
     async def force_off(self) -> ManagedTxOutcome:
-        return await self._ingress("force_off")
+        """Compatibility helper which deliberately drains provider settlement."""
+        submission = await self.submit_force_off()
+        await submission.wait_settlement()
+        return submission.outcome
+
+    async def submit_transmit_on(self) -> ManagedTxSubmission:
+        """Return the latched-ON admission separately from provider settlement."""
+        return await self._submit_ingress("transmit_on")
+
+    async def submit_force_off(self) -> ManagedTxSubmission:
+        """Advance the abort fence and return before provider settlement."""
+        return await self._submit_ingress("force_off")
+
+    async def admit_managed_write(self, intent: CommandIntent) -> bool:
+        """Apply the sole managed-intent relay policy without altering ``intent``."""
+        if not isinstance(intent, CommandIntent):
+            raise TypeError("managed write admission requires a CommandIntent")
+        async with self._lock:
+            managed_tx = self._state.intent.kind is not ManagedTxIntentKind.RX
+            if not managed_tx:
+                return True
+            if intent.name in _ANTENNA_WRITE_NAMES:
+                return False
+            if intent.name == "set_tuner_status":
+                return intent.params.get("value") == 0
+            if intent.name == "set_func" and intent.params.get("func") == "TUNER":
+                return intent.params.get("on") is False
+            return True
 
     def is_effect_current(
         self, token: EffectToken, operation: ActuationOperation | AbortOperation
@@ -419,7 +520,11 @@ class ManagedTxAuthority:
         self, termination: asyncio.Event
     ) -> bool:
         async with self._lock:
-            if self._state_is_clean_locked() and not self._abort_cleanup:
+            if (
+                self._state_is_clean_locked()
+                and not self._abort_cleanup
+                and not self._pending_settlements_locked()
+            ):
                 return True
         drained = asyncio.create_task(self._wait_for_clean_release())
         terminated = asyncio.create_task(termination.wait())
@@ -430,7 +535,11 @@ class ManagedTxAuthority:
             async with self._lock:
                 if self._terminated:
                     return False
-                if drained in done and self._state_is_clean_locked():
+                if (
+                    drained in done
+                    and self._state_is_clean_locked()
+                    and not self._pending_settlements_locked()
+                ):
                     return True
                 if terminated in done:
                     self._terminated = True
@@ -446,6 +555,14 @@ class ManagedTxAuthority:
         while True:
             await self._release_drained.wait()
             await self._finish_abort_cleanup()
+            async with self._lock:
+                settlements = self._pending_settlements_locked()
+            if settlements:
+                await asyncio.gather(
+                    *(asyncio.shield(task) for task in settlements),
+                    return_exceptions=True,
+                )
+                continue
             if self._release_drained.is_set():
                 return
 
@@ -481,6 +598,10 @@ class ManagedTxAuthority:
                 return
             if not self._state_is_clean_locked():
                 raise RuntimeError("managed TX disposal requires clean RX state")
+            if self._pending_settlements_locked():
+                raise RuntimeError(
+                    "managed TX disposal requires settled provider operations"
+                )
             if self._shutting_down and not from_shutdown:
                 raise RuntimeError("managed TX shutdown is in progress")
             self._closing = True
@@ -497,15 +618,28 @@ class ManagedTxAuthority:
         with contextlib.suppress(asyncio.CancelledError):
             await scheduler
 
-    async def _ingress(self, action: str, owner: str | None = None) -> ManagedTxOutcome:
+    async def _submit_ingress(
+        self, action: str, owner: str | None = None
+    ) -> ManagedTxSubmission:
         async with self._lock:
             self._require_ingress_open_locked()
             transition, full_force = self._transition_locked(action, owner)
+            if transition is None:
+                transition = ManagedTxTransition(
+                    self._state, ManagedTxOutcome.REJECTED
+                )
             self._wakeup.wake()
-        if transition is None:
-            return ManagedTxOutcome.REJECTED
-        await self._execute(transition.effects, full_force=full_force)
-        return transition.outcome
+
+        async def settle() -> tuple[ManagedTxTransition, ActuationSettled | None]:
+            result = await self._execute(
+                transition.effects,
+                full_force=full_force,
+            )
+            return transition, result
+
+        completion = asyncio.create_task(settle())
+        self._own_submission(completion)
+        return ManagedTxSubmission(transition, completion)
 
     def _transition_locked(
         self, action: str, owner: str | None
@@ -728,3 +862,6 @@ class ManagedTxAuthority:
             and not self._state.release_required
             and self._state.pending_effect is None
         )
+
+    def _pending_settlements_locked(self) -> tuple[_SubmissionCompletion, ...]:
+        return tuple(task for task in self._settlement_tasks if not task.done())

--- a/tests/test_managed_tx_ingress_admission.py
+++ b/tests/test_managed_tx_ingress_admission.py
@@ -73,7 +73,9 @@ def track(rig, task):
 
 async def submit(rig, on, owner, *, ready=None):
     async with asyncio.timeout(1):
-        return track(rig, await rig.managed.submit_ptt(on, owner, ready=ready))
+        return track(
+            rig, await rig.managed._start_ptt_operation(on, owner, ready=ready)
+        )
 
 
 async def checkpoint():

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -80,6 +81,52 @@ async def test_receipt_keeps_settlement_owned_when_a_waiter_is_cancelled() -> No
     finally:
         provider_release.set()
         await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_owned_settlement_before_provider_retirement() -> None:
+    managed, _, _, _, _, lane = authority()
+    provider_release = lane.block_next()
+    retired: list[int] = []
+
+    async def retire(generation: int) -> None:
+        retired.append(generation)
+
+    receipt = await asyncio.wait_for(managed.submit_transmit_on(), 0.2)
+    await asyncio.wait_for(lane.started.get(), 0.2)
+    shutdown = asyncio.create_task(
+        managed.shutdown(retire_provider=retire, termination=asyncio.Event())
+    )
+    try:
+        effect = await asyncio.wait_for(lane.started.get(), 0.2)
+        assert effect.operation is ActuationOperation.FORCE_RECEIVE
+        await asyncio.sleep(0)
+        assert not shutdown.done() and retired == []
+
+        provider_release.set()
+        await asyncio.wait_for(receipt.wait_settlement(), 0.2)
+        await asyncio.wait_for(shutdown, 0.2)
+        assert retired == [7]
+        assert not managed._settlement_tasks
+    finally:
+        provider_release.set()
+        if not shutdown.done():
+            shutdown.cancel()
+        await asyncio.gather(shutdown, return_exceptions=True)
+        if not managed._closed:
+            await finish(managed)
+
+
+def test_private_ptt_operation_has_no_production_consumer() -> None:
+    source = Path(__file__).parents[1] / "src"
+    authority_path = source / "rigplane/runtime/managed_tx_authority.py"
+    consumers = [
+        path.relative_to(source).as_posix()
+        for path in source.rglob("*.py")
+        if path != authority_path
+        and "_start_ptt_operation" in path.read_text(encoding="utf-8")
+    ]
+    assert consumers == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -1,0 +1,190 @@
+import asyncio
+
+import pytest
+
+from rigplane.core.state_pipeline_contracts import CommandIntent
+from rigplane.runtime.managed_tx_authority import ManagedTxAuthority
+from rigplane.runtime.managed_tx_state import (
+    ActuationOperation,
+    ActuationResult,
+    ManagedTxIntentKind,
+    ManagedTxOutcome,
+)
+from test_managed_tx_authority import authority
+
+
+def intent(name: str, **params: object) -> CommandIntent:
+    return CommandIntent(f"test-{name}", name, params, "test")
+
+
+async def finish(managed: ManagedTxAuthority) -> None:
+    state = (await managed.snapshot()).state
+    if state.release_required or state.intent.kind is not ManagedTxIntentKind.RX:
+        await managed.force_off()
+    await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_ptt_receipt_waits_for_predecessor_and_not_provider_settlement() -> None:
+    managed, _, _, _, _, lane = authority()
+    predecessor = asyncio.get_running_loop().create_future()
+    provider_release = lane.block_next()
+    admission = asyncio.create_task(
+        managed.submit_ptt(True, "owner", ready=predecessor)
+    )
+    try:
+        await asyncio.sleep(0)
+        assert not admission.done() and not lane.effects
+
+        predecessor.set_result(None)
+        receipt = await asyncio.wait_for(admission, 0.2)
+        effect = await asyncio.wait_for(lane.started.get(), 0.2)
+        assert receipt.transition.outcome is ManagedTxOutcome.ACCEPTED
+        assert effect.operation is ActuationOperation.PTT_ON
+        assert not receipt.settlement_done
+        assert (await managed.snapshot()).state.intent.kind is ManagedTxIntentKind.PTT
+
+        provider_release.set()
+        settled = await asyncio.wait_for(receipt.wait_settlement(), 0.2)
+        assert settled is not None and settled.result is ActuationResult.ACCEPTED
+    finally:
+        predecessor.cancel()
+        provider_release.set()
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_receipt_keeps_settlement_owned_when_a_waiter_is_cancelled() -> None:
+    managed, _, _, _, _, lane = authority()
+    provider_release = lane.block_next()
+    try:
+        receipt = await asyncio.wait_for(managed.submit_transmit_on(), 0.2)
+        await asyncio.wait_for(lane.started.get(), 0.2)
+        assert receipt.transition.outcome is ManagedTxOutcome.ACCEPTED
+        assert not receipt.settlement_done
+        assert len(managed._settlement_tasks) == 1
+
+        waiter = asyncio.create_task(receipt.wait_settlement())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert not receipt.settlement_done
+        assert len(managed._settlement_tasks) == 1
+
+        provider_release.set()
+        settled = await asyncio.wait_for(receipt.wait_settlement(), 0.2)
+        assert settled is not None and settled.result is ActuationResult.ACCEPTED
+        assert receipt.settlement_done
+        assert not managed._settlement_tasks
+    finally:
+        provider_release.set()
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_force_off_receipt_changes_state_and_fence_before_settlement() -> None:
+    managed, _, _, _, fence, lane = authority()
+    try:
+        assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+        old_epoch = fence.epoch
+        provider_release = lane.block_next()
+
+        receipt = await asyncio.wait_for(managed.submit_force_off(), 0.2)
+        effect = await asyncio.wait_for(lane.started.get(), 0.2)
+        state = (await managed.snapshot()).state
+        assert receipt.transition.outcome is ManagedTxOutcome.ACCEPTED
+        assert effect.operation is ActuationOperation.FORCE_RECEIVE
+        assert state.intent.kind is ManagedTxIntentKind.RX
+        assert state.release_required and fence.epoch == old_epoch + 1
+        assert not receipt.settlement_done
+
+        provider_release.set()
+        await asyncio.wait_for(receipt.wait_settlement(), 0.2)
+        assert not (await managed.snapshot()).state.release_required
+    finally:
+        for gate in lane.gates:
+            if gate is not None:
+                gate.set()
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_ptt_up_receipt_remains_owner_local() -> None:
+    managed, _, _, _, _, lane = authority()
+    try:
+        assert await managed.ptt_down("owner-a") is ManagedTxOutcome.ACCEPTED
+
+        rejected = await managed.submit_ptt(False, "owner-b")
+        assert rejected.transition.outcome is ManagedTxOutcome.REJECTED
+        assert await rejected.wait_settlement() is None
+        held = (await managed.snapshot()).state
+        assert held.intent.kind is ManagedTxIntentKind.PTT
+        assert held.intent.owner_token == "owner-a"
+
+        provider_release = lane.block_next()
+        accepted = await asyncio.wait_for(
+            managed.submit_ptt(False, "owner-a"), 0.2
+        )
+        assert accepted.transition.outcome is ManagedTxOutcome.ACCEPTED
+        assert (await managed.snapshot()).state.intent.kind is ManagedTxIntentKind.RX
+        assert not accepted.settlement_done
+        provider_release.set()
+        await asyncio.wait_for(accepted.wait_settlement(), 0.2)
+    finally:
+        for gate in lane.gates:
+            if gate is not None:
+                gate.set()
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_managed_write_policy_uses_intent_not_observed_ptt() -> None:
+    managed, _, _, _, _, _ = authority()
+    antenna_observed_on = intent(
+        "set_antenna_1", on=True, observed_ptt="on", receiver=0
+    )
+    antenna_observed_off = intent(
+        "set_antenna_1", on=True, observed_ptt="off", receiver=0
+    )
+    try:
+        assert await managed.admit_managed_write(antenna_observed_on)
+        assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+        assert not await managed.admit_managed_write(antenna_observed_on)
+        assert not await managed.admit_managed_write(antenna_observed_off)
+    finally:
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "admitted"),
+    [
+        (intent("set_band", band="20m"), True),
+        (intent("set_freq", freq_hz=14_200_000, receiver=1), True),
+        (intent("set_mode", mode="USB", width=2400, receiver=1), True),
+        (intent("set_vfo", vfo="VFOB"), True),
+        (intent("set_split_vfo", on=True, tx_vfo="VFOB"), True),
+        (intent("set_antenna_1", on=True), False),
+        (intent("set_antenna_2", on=False), False),
+        (intent("set_rx_antenna", enabled=True), False),
+        (intent("set_tuner_status", value=1), False),
+        (intent("set_tuner_status", value=2), False),
+        (intent("set_tuner_status", value=0), True),
+        (intent("set_func", func="TUNER", on=True), False),
+        (intent("set_func", func="TUNER", on=False), True),
+        (intent("force_off"), True),
+        (intent("set_rf_gain", level=117, receiver=1), True),
+    ],
+)
+async def test_managed_write_policy_is_the_single_relay_family_decision(
+    command: CommandIntent, admitted: bool
+) -> None:
+    managed, _, _, _, _, _ = authority()
+    before = command.to_dict()
+    try:
+        assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+        assert await managed.admit_managed_write(command) is admitted
+        assert command.to_dict() == before
+    finally:
+        await finish(managed)

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -88,8 +88,10 @@ async def test_shutdown_drains_owned_settlement_before_provider_retirement() -> 
     managed, _, _, _, _, lane = authority()
     provider_release = lane.block_next()
     retired: list[int] = []
+    retire_started = asyncio.Event()
 
     async def retire(generation: int) -> None:
+        retire_started.set()
         retired.append(generation)
 
     receipt = await asyncio.wait_for(managed.submit_transmit_on(), 0.2)
@@ -101,7 +103,8 @@ async def test_shutdown_drains_owned_settlement_before_provider_retirement() -> 
         effect = await asyncio.wait_for(lane.started.get(), 0.2)
         assert effect.operation is ActuationOperation.FORCE_RECEIVE
         assert not receipt.settlement_done
-        await asyncio.sleep(0)
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(retire_started.wait(), 0.02)
         assert not shutdown.done() and retired == []
 
         provider_release.set()

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -100,6 +100,7 @@ async def test_shutdown_drains_owned_settlement_before_provider_retirement() -> 
     try:
         effect = await asyncio.wait_for(lane.started.get(), 0.2)
         assert effect.operation is ActuationOperation.FORCE_RECEIVE
+        assert not receipt.settlement_done
         await asyncio.sleep(0)
         assert not shutdown.done() and retired == []
 
@@ -134,6 +135,7 @@ async def test_force_off_receipt_changes_state_and_fence_before_settlement() -> 
     managed, _, _, _, fence, lane = authority()
     try:
         assert await managed.transmit_on() is ManagedTxOutcome.ACCEPTED
+        await asyncio.wait_for(lane.started.get(), 0.2)
         old_epoch = fence.epoch
         provider_release = lane.block_next()
 
@@ -170,9 +172,7 @@ async def test_ptt_up_receipt_remains_owner_local() -> None:
         assert held.intent.owner_token == "owner-a"
 
         provider_release = lane.block_next()
-        accepted = await asyncio.wait_for(
-            managed.submit_ptt(False, "owner-a"), 0.2
-        )
+        accepted = await asyncio.wait_for(managed.submit_ptt(False, "owner-a"), 0.2)
         assert accepted.transition.outcome is ManagedTxOutcome.ACCEPTED
         assert (await managed.snapshot()).state.intent.kind is ManagedTxIntentKind.RX
         assert not accepted.settlement_done


### PR DESCRIPTION
## Linear owner

[MOR-2306 — Correct ManagedTxAuthority admission/settlement contract and relay admission seat](https://linear.app/rigplane/issue/MOR-2306)

## Why

The accepted TX ADR requires command admission to return before asynchronous provider settlement. The authority also needs to own the bounded settlement lifetime and the single managed-intent relay decision without creating another executor, queue, RF-state gate, watchdog, target ID, provider generation, or public phase enum.

## Search before write

Before implementation and again before publication, the lane searched the existing authority, ingress, command service, interlock, lifecycle, and provider paths. The implementation reuses `ManagedTxAuthority`, `CommandIntent`, the existing effect lane, abort fence, reducer, and shutdown lifecycle. It adds no second authority or scheduler.

The required pre-push interlock search at the rebased head was:

```text
$ git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py 'src/rigplane/runtime/command*.py' src/rigplane/web/handlers/control.py
src/rigplane/web/handlers/control.py:30:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1736:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1975:            decision = evaluate_tx_interlock(
```

There are zero hits in `core/command_dispatch.py` and `runtime/command*.py`; the three existing Web hits are unchanged retirement inventory, not new consumers.

## Contract

- `await authority.submit_ptt(on, owner, ready=predecessor)` returns a `ManagedTxSubmission` after owner-scoped admission and predecessor completion, before provider settlement.
- Managed ingress responds from `receipt.outcome` / `receipt.transition`; it must not await `receipt.wait_settlement()` before responding.
- `submit_transmit_on()` and `submit_force_off()` expose the same receipt contract.
- Diagnostics and lifecycle code may inspect `settlement_done` or await `wait_settlement()` without acquiring cancellation ownership.
- `ManagedTxAuthority` retains only pending settlement tasks and graceful shutdown drains them before provider retirement.
- `_start_ptt_operation` is a private test-only seam for the pre-admission cancellation/fence contract. A guard test proves it has no production consumer.
- `admit_managed_write(original_command_intent)` is a decision only: band/frequency/mode/VFO/split pass; antenna and tuner engage/start refuse only while managed intent is held; tuner OFF and ForceOff pass. It does not inspect observed PTT, translate, mutate, enqueue, or execute the intent.
- Compatibility helpers (`ptt_down`, `ptt_up`, `transmit_on`, `force_off`) deliberately continue to drain settlement.

## Scope

Exactly three files, 407 insertions / 30 deletions:

```text
164  29  src/rigplane/runtime/managed_tx_authority.py
3     1  tests/test_managed_tx_ingress_admission.py
240   0  tests/test_managed_tx_submission_contract.py
```

No state reducer, rigctld/Web ingress, provider/backend, composition root, frontend, acquisition, interlock retirement, or hardware path changed.

## TDD and Mac Mini evidence

RED at `6be24fa1d297c1e1284ef242385e4545f1ac77b4`:

- focused run `33804541200`, artifact `9912381526`
- 20 collected / 20 failed, all discriminating contract failures; no collection, setup, or environment failure.

Final pre-rebase GREEN content at `5c037750af64c58d67259738694b9ef68d96ca1d`:

- focused run `33806326450`, artifact `9913057351`
- 95 collected / 95 passed
- Ruff lint passed; all three leased files already formatted; no Vitest.

Byte-restored Mini mutations:

- admission waits for settlement: `5974b669ce2004d0dde865a07ffda43a479a4d60`, run `33805918186` — 1/1 failed by timeout.
- authority loses settlement ownership: `67731f4a2fa81407bf67104cc9f7116b8e9ed733`, run `33805968648` — ownership assertion failed.
- observed PTT influences admission: `f5f270ebbbc471f63d5be8552c697a203a38ef4f`, run `33806025566` — 1/1 failed.
- tuner engage/OFF rules inverted: `06e7d2e05b686987c1aba2e4345f267fc365e054`, run `33806073772` — 5/15 failed.
- stale old settlement clears current debt: `68ebbef23e6615580eeef27c7f64094c3437121f`, run `33806151924` — 1/1 failed.
- shutdown loses settlement ownership: `5a64927eab1087f024d40addebd8805177f78b2b`, run `33806367480` — 1/1 failed because provider retirement began before prior settlement.

Every mutation was restored byte-for-byte. The final mutation restore tree matched the final GREEN tree.

All pytest, Ruff checks, and mutation carriers ran on the Mac Mini self-hosted runner. No local test suite, type check, project import check, hardware command, PTT, TUNE, or TX was run. Mechanical formatting only touched the leased files.

## Rebase evidence

Rebased mechanically onto `43591aaa7ac5a482d239b08dd9caba3a4b4fd365`. The base delta touched none of the three leased paths. Their blob IDs remained exactly:

```text
c8bef6432f639315f6630212dfa37b59a2c3f2c5  src/rigplane/runtime/managed_tx_authority.py
4cd302dc2ca27654e1390de2797c0b27e2e05b00  tests/test_managed_tx_submission_contract.py
b26bd07fb650c675231ab912393eda14914cfc35  tests/test_managed_tx_ingress_admission.py
```

The rebased head still requires normal exact-head CI and a fresh independent `Agent Review: PASS <40-hex head>` before merge. This PR makes no hardware or production-cutover claim.
