### PR TITLE
ci: add base-controlled gate observation harness

### DIFF
--- a/.github/scripts/base-controlled-gates-v1.test.js
+++ b/.github/scripts/base-controlled-gates-v1.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
@@ -15,7 +17,7 @@ function readTarget(relative) {
   return fs.readFileSync(path.join(TARGET_ROOT, relative), 'utf8');
 }
 
-function topologyErrors({quick, review, worker}) {
+function topologyErrors({quick, review, worker, migration}) {
   const errors = [];
   if (!quick.includes('\n  pull_request_target:\n') || quick.includes('\n  pull_request:\n')) {
     errors.push('quick controller must use only pull_request_target');
@@ -37,11 +39,11 @@ function topologyErrors({quick, review, worker}) {
   if (!review.includes("path: '.github/scripts/agent-review-gate.js', ref: baseSha")) {
     errors.push('review controller must fetch parser at exact base SHA');
   }
-  if (!quick.includes("context: 'quick-v2'")) {
-    errors.push('quick controller must publish only the v2 context');
+  if (!quick.includes("context: 'quick-v2-observe'")) {
+    errors.push('quick controller must publish only the observation context');
   }
-  if (!review.includes("context: 'Agent Review Gate v2'")) {
-    errors.push('review controller must publish only the v2 context');
+  if (!review.includes("context: 'Agent Review Gate v2 observe'")) {
+    errors.push('review controller must publish only the observation context');
   }
   if (!quick.includes('name: Read-only quick v2 worker')) {
     errors.push('quick controller must retain the isolated worker');
@@ -69,16 +71,27 @@ function topologyErrors({quick, review, worker}) {
   if (!workerJob.includes('rev-list --parents -n 1 HEAD')) {
     errors.push('worker must bind the merge commit to exact parents');
   }
-  for (const critical of [
-    '.github/scripts/agent-review-gate.js',
-    '.github/scripts/base-controlled-gates-v1.test.js',
-    '.github/scripts/base-gate-policy-v1.js',
-    '.github/scripts/quick-v2-worker-v1.sh',
-    '.github/workflows/agent-review-gate-v2.yml',
-    '.github/workflows/quick-v2.yml',
+  if (
+    !quick.includes("initialPull.head.repo?.full_name === `${owner}/${repo}`") ||
+    !workerJob.includes("needs.admit.outputs.same_repo == 'true'") ||
+    (quick.match(/currentBase\.commit\.sha !== baseSha/gu) ?? []).length !== 2
+  ) {
+    errors.push('quick observation must withhold forks and reject stale main');
+  }
+  if (!review.includes('currentBase.commit.sha !== baseSha')) {
+    errors.push('review observation must reject stale main');
+  }
+  if (!worker.includes('.github/scripts/verify-immutable-controls-v1.sh')) {
+    errors.push('worker must invoke the Git-object immutable-control verifier');
+  }
+  for (const requiredText of [
+    'must never be configured as required checks',
+    'distinct from GitHub Actions app ID `15368`',
+    '"strict": true',
+    'switch protection back to the still-running legacy contexts **before**',
   ]) {
-    if (!worker.includes(critical)) {
-      errors.push(`immutable worker manifest is missing ${critical}`);
+    if (!migration.includes(requiredText)) {
+      errors.push(`migration contract is missing: ${requiredText}`);
     }
   }
   return errors;
@@ -132,6 +145,7 @@ test('candidate v2 topology retains base control and isolated permissions', () =
     quick: readTarget('.github/workflows/quick-v2.yml'),
     review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
     worker: readTarget('.github/scripts/quick-v2-worker-v1.sh'),
+    migration: readTarget('docs/internals/base-controlled-required-gates.md'),
   };
   assert.deepEqual(topologyErrors(sources), []);
 });
@@ -141,6 +155,7 @@ test('topology contract catches self-green workflow and helper mutations', () =>
     quick: readTarget('.github/workflows/quick-v2.yml'),
     review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
     worker: readTarget('.github/scripts/quick-v2-worker-v1.sh'),
+    migration: readTarget('docs/internals/base-controlled-required-gates.md'),
   };
   const workerStart = sources.quick.indexOf('  worker:\n');
   const writeEnabledWorker =
@@ -155,9 +170,63 @@ test('topology contract catches self-green workflow and helper mutations', () =>
     {...sources, quick: sources.quick.replace('persist-credentials: false', 'persist-credentials: true')},
     {...sources, quick: writeEnabledWorker},
     {...sources, review: sources.review.replace('ref: baseSha', 'ref: github.workflow_sha')},
-    {...sources, worker: sources.worker.replace('.github/workflows/quick-v2.yml', '.github/workflows/quick.yml')},
+    {...sources, worker: sources.worker.replace('verify-immutable-controls-v1.sh', 'true')},
+    {...sources, quick: sources.quick.replace("needs.admit.outputs.same_repo == 'true'", 'true')},
+    {...sources, quick: sources.quick.replace('currentBase.commit.sha !== baseSha', 'false')},
+    {...sources, migration: sources.migration.replace('"strict": true', '"strict": false')},
   ];
   for (const mutant of mutants) {
     assert.notDeepEqual(topologyErrors(mutant), []);
+  }
+});
+
+test('immutable-control verifier rejects chmod and symlink mutations', () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'rigplane-gate-mode-'));
+  const trusted = path.join(sandbox, 'trusted');
+  const target = path.join(sandbox, 'target');
+  const critical = [
+    '.github/scripts/agent-review-gate.js',
+    '.github/scripts/base-controlled-gates-v1.test.js',
+    '.github/scripts/base-gate-policy-v1.js',
+    '.github/scripts/quick-v2-worker-v1.sh',
+    '.github/scripts/verify-immutable-controls-v1.sh',
+    '.github/workflows/agent-review-gate-v2.yml',
+    '.github/workflows/quick-v2.yml',
+  ];
+  const git = (repo, ...args) => childProcess.execFileSync(
+    'git', ['-C', repo, ...args], {stdio: 'ignore'},
+  );
+  const commit = (repo, message) => {
+    git(repo, 'add', '-A');
+    git(repo, '-c', 'user.name=Gate Contract', '-c', 'user.email=gate@example.invalid', 'commit', '-m', message);
+  };
+  try {
+    for (const repo of [trusted, target]) {
+      fs.mkdirSync(repo, {recursive: true});
+      git(repo, 'init');
+      for (const relative of critical) {
+        const destination = path.join(repo, relative);
+        fs.mkdirSync(path.dirname(destination), {recursive: true});
+        fs.copyFileSync(path.join(CONTROL_ROOT, relative), destination);
+        fs.chmodSync(destination, relative.endsWith('.sh') ? 0o755 : 0o644);
+      }
+      commit(repo, 'trusted controls');
+    }
+    const verifier = path.join(CONTROL_ROOT, '.github/scripts/verify-immutable-controls-v1.sh');
+    childProcess.execFileSync(verifier, [trusted, target], {stdio: 'ignore'});
+
+    const parser = path.join(target, '.github/scripts/agent-review-gate.js');
+    fs.chmodSync(parser, 0o755);
+    commit(target, 'chmod mutation');
+    assert.throws(() => childProcess.execFileSync(verifier, [trusted, target], {stdio: 'ignore'}));
+
+    git(target, 'checkout', 'HEAD^', '--', '.');
+    commit(target, 'restore controls');
+    fs.unlinkSync(parser);
+    fs.symlinkSync('base-gate-policy-v1.js', parser);
+    commit(target, 'symlink mutation');
+    assert.throws(() => childProcess.execFileSync(verifier, [trusted, target], {stdio: 'ignore'}));
+  } finally {
+    fs.rmSync(sandbox, {recursive: true, force: true});
   }
 });

--- a/.github/scripts/base-controlled-gates-v1.test.js
+++ b/.github/scripts/base-controlled-gates-v1.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const CONTROL_ROOT = path.resolve(__dirname, '..', '..');
+const TARGET_ROOT = process.env.GATE_TARGET_ROOT
+  ? path.resolve(process.env.GATE_TARGET_ROOT)
+  : CONTROL_ROOT;
+const policy = require(path.join(CONTROL_ROOT, '.github/scripts/base-gate-policy-v1.js'));
+
+function readTarget(relative) {
+  return fs.readFileSync(path.join(TARGET_ROOT, relative), 'utf8');
+}
+
+function topologyErrors({quick, review, worker}) {
+  const errors = [];
+  if (!quick.includes('\n  pull_request_target:\n') || quick.includes('\n  pull_request:\n')) {
+    errors.push('quick controller must use only pull_request_target');
+  }
+  if (!review.includes('\n  pull_request_target:\n') || review.includes('\n  pull_request:\n')) {
+    errors.push('review controller must use pull_request_target for PR events');
+  }
+  for (const [name, source] of [['quick', quick], ['review', review]]) {
+    if (source.includes('github.workflow_sha') || source.includes('secrets.')) {
+      errors.push(`${name} controller may not use candidate workflow refs or secrets`);
+    }
+  }
+  if (!quick.includes("path: '.github/scripts/base-gate-policy-v1.js'")) {
+    errors.push('quick controller must fetch versioned policy');
+  }
+  if (!quick.includes('ref: baseSha')) {
+    errors.push('quick controller must fetch policy at exact base SHA');
+  }
+  if (!review.includes("path: '.github/scripts/agent-review-gate.js', ref: baseSha")) {
+    errors.push('review controller must fetch parser at exact base SHA');
+  }
+  if (!quick.includes("context: 'quick-v2'")) {
+    errors.push('quick controller must publish only the v2 context');
+  }
+  if (!review.includes("context: 'Agent Review Gate v2'")) {
+    errors.push('review controller must publish only the v2 context');
+  }
+  if (!quick.includes('name: Read-only quick v2 worker')) {
+    errors.push('quick controller must retain the isolated worker');
+  }
+  const workerStart = quick.indexOf('  worker:\n');
+  const publishStart = quick.indexOf('  publish:\n');
+  const workerJob = quick.slice(workerStart, publishStart);
+  if (
+    workerStart === -1 ||
+    publishStart === -1 ||
+    !workerJob.includes('permissions:\n      contents: read') ||
+    workerJob.includes('statuses: write') ||
+    workerJob.includes('pull-requests: write') ||
+    workerJob.includes('issues: write')
+  ) {
+    errors.push('worker must retain its read-only job token');
+  }
+  if (!workerJob.includes('persist-credentials: false')) {
+    errors.push('candidate checkout must not persist credentials');
+  }
+  if (!workerJob.includes('rev-list --parents -n 1 HEAD')) {
+    errors.push('worker must bind the merge commit to exact parents');
+  }
+  for (const critical of [
+    '.github/scripts/agent-review-gate.js',
+    '.github/scripts/base-controlled-gates-v1.test.js',
+    '.github/scripts/base-gate-policy-v1.js',
+    '.github/scripts/quick-v2-worker-v1.sh',
+    '.github/workflows/agent-review-gate-v2.yml',
+    '.github/workflows/quick-v2.yml',
+  ]) {
+    if (!worker.includes(critical)) {
+      errors.push(`immutable worker manifest is missing ${critical}`);
+    }
+  }
+  return errors;
+}
+
+test('trusted policy rejects adversarial paths and fails unknown roots into core', () => {
+  const docs = policy.classifyPullFiles(
+    [
+      {filename: 'docs/guide.md'},
+      {filename: 'frontend/README.MD'},
+      {filename: 'mkdocs.yml'},
+    ],
+    3,
+  );
+  assert.deepEqual(docs, {core: false, frontend: false, ci: false, docs: true});
+
+  for (const filename of [
+    'docs',
+    '.claude',
+    'frontend/README.rſt',
+    'frontend/README.md\n',
+    'frontend/README.rst\r\n',
+  ]) {
+    const result = policy.classifyPullFiles([{filename}], 1);
+    assert.equal(result.docs, false, filename);
+    assert.equal(result.core || result.frontend || result.ci, true, filename);
+  }
+  assert.deepEqual(policy.classifyPullFiles([{filename: 'CODEOWNERS'}], 1), {
+    core: true,
+    frontend: false,
+    ci: false,
+    docs: false,
+  });
+  assert.deepEqual(
+    policy.classifyPullFiles([
+      {filename: 'docs/new.md', previous_filename: 'src/rigplane/radio.py'},
+    ], 1),
+    {core: true, frontend: false, ci: false, docs: false},
+  );
+});
+
+test('trusted policy fails closed on incomplete, capped, and invalid metadata', () => {
+  assert.throws(() => policy.classifyPullFiles([{filename: 'docs/a.md'}], 2));
+  assert.throws(() => policy.classifyPullFiles([{filename: 'docs/a.md'}], 3000));
+  assert.throws(() => policy.classifyPullFiles([{filename: '../README.md'}], 1));
+  assert.throws(() => policy.assertSha('refs/pull/1/merge', 'head'));
+});
+
+test('candidate v2 topology retains base control and isolated permissions', () => {
+  const sources = {
+    quick: readTarget('.github/workflows/quick-v2.yml'),
+    review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
+    worker: readTarget('.github/scripts/quick-v2-worker-v1.sh'),
+  };
+  assert.deepEqual(topologyErrors(sources), []);
+});
+
+test('topology contract catches self-green workflow and helper mutations', () => {
+  const sources = {
+    quick: readTarget('.github/workflows/quick-v2.yml'),
+    review: readTarget('.github/workflows/agent-review-gate-v2.yml'),
+    worker: readTarget('.github/scripts/quick-v2-worker-v1.sh'),
+  };
+  const workerStart = sources.quick.indexOf('  worker:\n');
+  const writeEnabledWorker =
+    sources.quick.slice(0, workerStart) +
+    sources.quick.slice(workerStart).replace(
+      '      contents: read\n',
+      '      contents: read\n      statuses: write\n',
+    );
+  const mutants = [
+    {...sources, quick: sources.quick.replace('pull_request_target:', 'pull_request:')},
+    {...sources, quick: sources.quick.replace('ref: baseSha', 'ref: github.workflow_sha')},
+    {...sources, quick: sources.quick.replace('persist-credentials: false', 'persist-credentials: true')},
+    {...sources, quick: writeEnabledWorker},
+    {...sources, review: sources.review.replace('ref: baseSha', 'ref: github.workflow_sha')},
+    {...sources, worker: sources.worker.replace('.github/workflows/quick-v2.yml', '.github/workflows/quick.yml')},
+  ];
+  for (const mutant of mutants) {
+    assert.notDeepEqual(topologyErrors(mutant), []);
+  }
+});

--- a/.github/scripts/base-controlled-gates-v1.test.js
+++ b/.github/scripts/base-controlled-gates-v1.test.js
@@ -59,8 +59,12 @@ function topologyErrors({quick, review, worker}) {
   ) {
     errors.push('worker must retain its read-only job token');
   }
-  if (!workerJob.includes('persist-credentials: false')) {
-    errors.push('candidate checkout must not persist credentials');
+  const nonPersistedCredentials = workerJob.match(/persist-credentials: false/gu) ?? [];
+  if (
+    nonPersistedCredentials.length !== 2 ||
+    workerJob.includes('persist-credentials: true')
+  ) {
+    errors.push('both control and candidate checkouts must not persist credentials');
   }
   if (!workerJob.includes('rev-list --parents -n 1 HEAD')) {
     errors.push('worker must bind the merge commit to exact parents');

--- a/.github/scripts/base-gate-policy-v1.js
+++ b/.github/scripts/base-gate-policy-v1.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const DOC_SUFFIXES = new Set(['.md', '.rst']);
+const DOC_EXACT = new Set([
+  '.github/scripts/doc-citation-baseline.txt',
+  '.github/scripts/doc-citation-dangling-baseline.txt',
+  '.github/scripts/doc-link-baseline.txt',
+  'AUTHORS',
+  'COPYING',
+  'LICENSE',
+  'LICENSE.txt',
+  'NOTICE',
+  'mkdocs.yml',
+]);
+const CORE_EXACT = new Set(['.importlinter', 'pyproject.toml', 'uv.lock']);
+const CI_EXACT = new Set(['tests/test_ci_path_filters.py']);
+
+function assertSha(value, label) {
+  if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
+    throw new Error(`${label} must be an exact lowercase commit SHA`);
+  }
+  return value;
+}
+
+function pathParts(path) {
+  if (
+    typeof path !== 'string' ||
+    path.length === 0 ||
+    path.startsWith('/') ||
+    path.includes('\\') ||
+    path.includes('\0')
+  ) {
+    throw new Error(`invalid repository path: ${JSON.stringify(path)}`);
+  }
+  const parts = path.split('/');
+  if (parts.some((part) => part.length === 0 || part === '.' || part === '..')) {
+    throw new Error(`invalid repository path: ${JSON.stringify(path)}`);
+  }
+  return parts;
+}
+
+function isDocumentation(path) {
+  const parts = pathParts(path);
+  const dot = path.lastIndexOf('.');
+  const suffix = dot === -1 ? '' : path.slice(dot).toLowerCase();
+  return (
+    (parts.length > 1 && (parts[0] === 'docs' || parts[0] === '.claude')) ||
+    DOC_SUFFIXES.has(suffix) ||
+    DOC_EXACT.has(path)
+  );
+}
+
+function isCiControl(path) {
+  const parts = pathParts(path);
+  return (
+    CI_EXACT.has(path) ||
+    (parts.length >= 2 &&
+      parts[0] === '.github' &&
+      (parts[1] === 'scripts' || parts[1] === 'workflows') &&
+      !isDocumentation(path))
+  );
+}
+
+function isFrontend(path) {
+  const parts = pathParts(path);
+  return (
+    !isDocumentation(path) &&
+    (parts[0] === 'frontend' ||
+      (parts[0] === 'src' && parts[1] === 'rigplane' && parts[2] === 'web'))
+  );
+}
+
+function isCore(path) {
+  const parts = pathParts(path);
+  return (
+    !isDocumentation(path) &&
+    !isCiControl(path) &&
+    (['src', 'tests', 'rigs', 'contracts'].includes(parts[0]) ||
+      CORE_EXACT.has(path))
+  );
+}
+
+function classifyPullFiles(files, changedFiles) {
+  if (!Number.isSafeInteger(changedFiles) || changedFiles <= 0 || changedFiles >= 3000) {
+    throw new Error('pull request changed_files count is outside the trusted range');
+  }
+  if (!Array.isArray(files) || files.length !== changedFiles) {
+    throw new Error('pull request file enumeration is incomplete');
+  }
+
+  const paths = [];
+  for (const file of files) {
+    if (file === null || typeof file !== 'object') {
+      throw new Error('pull request file entry is invalid');
+    }
+    paths.push(file.filename);
+    if (file.previous_filename !== undefined) {
+      paths.push(file.previous_filename);
+    }
+  }
+  const unique = [...new Set(paths)];
+  unique.forEach(pathParts);
+  if (unique.length === 0) {
+    throw new Error('pull request contains no classifiable paths');
+  }
+
+  const docs = unique.every(isDocumentation);
+  const ci = unique.some(isCiControl);
+  const frontend = unique.some(isFrontend);
+  let core = unique.some(isCore);
+  const hasUnknown = unique.some(
+    (path) =>
+      !isDocumentation(path) &&
+      !isCiControl(path) &&
+      !isFrontend(path) &&
+      !isCore(path),
+  );
+  // Unknown non-documentation roots receive the broad Python/core carrier.
+  // This is deliberately allocation-heavy rather than allowing an uncovered
+  // path to publish success.
+  core ||= hasUnknown;
+
+  if (!docs && !core && !frontend && !ci) {
+    throw new Error('non-documentation change selected no substantive carrier');
+  }
+  return {core, frontend, ci, docs};
+}
+
+module.exports = {
+  assertSha,
+  classifyPullFiles,
+  isDocumentation,
+};

--- a/.github/scripts/quick-path-filters.test.py
+++ b/.github/scripts/quick-path-filters.test.py
@@ -22,9 +22,17 @@ DOCS_PATHS_JS = ROOT / ".github" / "scripts" / "docs-only-paths.js"
 VISUAL_YML = ROOT / ".github" / "workflows" / "visual.yml"
 DOC_CITATION_YML = ROOT / ".github" / "workflows" / "doc-citation-gate.yml"
 REBRAND_YML = ROOT / ".github" / "workflows" / "rebrand-gate.yml"
+BASE_GATES_TEST = ROOT / ".github" / "scripts" / "base-controlled-gates-v1.test.js"
 
 
 class QuickPathFilterContractTest(unittest.TestCase):
+    def test_base_controlled_gate_contracts(self) -> None:
+        subprocess.run(
+            ["node", "--test", str(BASE_GATES_TEST)],
+            cwd=ROOT,
+            check=True,
+        )
+
     def quick_ignore_blocks(self) -> list[list[str]]:
         blocks: list[list[str]] = []
         lines = QUICK_YML.read_text(encoding="utf-8").splitlines()

--- a/.github/scripts/quick-v2-worker-v1.sh
+++ b/.github/scripts/quick-v2-worker-v1.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: $0 CONTROL_ROOT TARGET_ROOT CORE FRONTEND CI" >&2
+  exit 2
+fi
+
+control_root=$1
+target_root=$2
+core=$3
+frontend=$4
+ci=$5
+
+for value in "$core" "$frontend" "$ci"; do
+  if [[ "$value" != true && "$value" != false ]]; then
+    echo "route inputs must be literal true or false" >&2
+    exit 2
+  fi
+done
+if [[ "$core" != true && "$frontend" != true && "$ci" != true ]]; then
+  echo "non-documentation worker received no substantive carrier" >&2
+  exit 2
+fi
+
+critical_controls=(
+  .github/scripts/agent-review-gate.js
+  .github/scripts/base-controlled-gates-v1.test.js
+  .github/scripts/base-gate-policy-v1.js
+  .github/scripts/quick-v2-worker-v1.sh
+  .github/workflows/agent-review-gate-v2.yml
+  .github/workflows/quick-v2.yml
+)
+for path in "${critical_controls[@]}"; do
+  cmp -- "$control_root/$path" "$target_root/$path"
+done
+
+if [[ "$ci" == true ]]; then
+  node --test "$control_root/.github/scripts/agent-review-gate.test.js"
+  GATE_TARGET_ROOT="$target_root" \
+    node --test "$control_root/.github/scripts/base-controlled-gates-v1.test.js"
+  python3 "$target_root/.github/scripts/run-focused-checks.test.py"
+  python3 "$target_root/.github/scripts/quick-path-filters.test.py"
+  python3 -m py_compile "$target_root"/.github/scripts/*.py
+fi
+
+cd "$target_root"
+export UV_PYTHON=3.11
+
+if [[ "$core" == true ]]; then
+  uv python install 3.11
+  uv sync --all-extras
+  uv run ruff check src/ tests/
+  uv run ruff format --check src/ tests/
+  uv run lint-imports
+  uv run rigplane --model IC-7610 validate --provider native --dry-run \
+    --gate tests/golden/validation/ic7610.dry-run.json
+  uv run rigplane --model X6200 validate --provider native --dry-run \
+    --gate tests/golden/validation/x6200.dry-run.json
+  uv run rigplane --model FTX-1 validate --provider native --dry-run \
+    --gate tests/golden/validation/ftx1.dry-run.json
+fi
+
+if [[ "$frontend" == true ]]; then
+  (
+    cd frontend
+    npm ci
+    npm run i18n:check
+    npm run check
+    npx vitest run
+    npm run build
+  )
+  rm -f src/rigplane/web/static
+  mkdir -p src/rigplane/web/static
+  cp -r frontend/dist/* src/rigplane/web/static/
+  (
+    cd frontend
+    npx playwright install chromium
+    npm run test:e2e:i18n
+  )
+  node frontend/fixtures/capture.mjs
+fi
+
+if [[ "$core" == true && "$frontend" == true ]]; then
+  uv run mypy --strict src/rigplane/web
+fi
+
+if [[ "$core" == true ]]; then
+  set +e
+  uv run pytest tests/ -n auto --tb=short --timeout=300 --timeout-method=thread \
+    | tee pytest-output.txt
+  test_rc=${PIPESTATUS[0]}
+  set -e
+  exit "$test_rc"
+fi

--- a/.github/scripts/quick-v2-worker-v1.sh
+++ b/.github/scripts/quick-v2-worker-v1.sh
@@ -23,17 +23,8 @@ if [[ "$core" != true && "$frontend" != true && "$ci" != true ]]; then
   exit 2
 fi
 
-critical_controls=(
-  .github/scripts/agent-review-gate.js
-  .github/scripts/base-controlled-gates-v1.test.js
-  .github/scripts/base-gate-policy-v1.js
-  .github/scripts/quick-v2-worker-v1.sh
-  .github/workflows/agent-review-gate-v2.yml
-  .github/workflows/quick-v2.yml
-)
-for path in "${critical_controls[@]}"; do
-  cmp -- "$control_root/$path" "$target_root/$path"
-done
+"$control_root/.github/scripts/verify-immutable-controls-v1.sh" \
+  "$control_root" "$target_root"
 
 if [[ "$ci" == true ]]; then
   node --test "$control_root/.github/scripts/agent-review-gate.test.js"

--- a/.github/scripts/verify-immutable-controls-v1.sh
+++ b/.github/scripts/verify-immutable-controls-v1.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 CONTROL_ROOT TARGET_ROOT" >&2
+  exit 2
+fi
+
+control_root=$1
+target_root=$2
+
+declare -A expected_modes=(
+  [.github/scripts/agent-review-gate.js]=100644
+  [.github/scripts/base-controlled-gates-v1.test.js]=100644
+  [.github/scripts/base-gate-policy-v1.js]=100644
+  [.github/scripts/quick-v2-worker-v1.sh]=100755
+  [.github/scripts/verify-immutable-controls-v1.sh]=100755
+  [.github/workflows/agent-review-gate-v2.yml]=100644
+  [.github/workflows/quick-v2.yml]=100644
+)
+
+for path in "${!expected_modes[@]}"; do
+  control_entry=$(git -C "$control_root" ls-tree HEAD -- "$path")
+  target_entry=$(git -C "$target_root" ls-tree HEAD -- "$path")
+  expected_prefix="${expected_modes[$path]} blob "
+  if [[ -z "$control_entry" || "$control_entry" != "$expected_prefix"* ]]; then
+    echo "trusted immutable control has unexpected Git type or mode: $path" >&2
+    exit 1
+  fi
+  if [[ "$target_entry" != "$control_entry" ]]; then
+    echo "immutable control content, type, or mode changed: $path" >&2
+    echo "trusted: $control_entry" >&2
+    echo "target:  ${target_entry:-missing}" >&2
+    exit 1
+  fi
+done

--- a/.github/workflows/agent-review-gate-v2.yml
+++ b/.github/workflows/agent-review-gate-v2.yml
@@ -1,0 +1,104 @@
+name: Agent Review Gate v2 base-controlled
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, edited]
+  issue_comment:
+    types: [created, edited, deleted]
+
+concurrency:
+  group: agent-review-gate-v2-${{ github.event.issue.pull_request && github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Trusted review result publisher
+    if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Evaluate comments with the exact trusted base parser
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const pullNumber = context.payload.pull_request?.number ?? context.payload.issue?.number;
+            let headSha = context.payload.pull_request?.head?.sha ?? '';
+            const targetUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const publishFailure = async (description) => {
+              if (/^[0-9a-f]{40}$/u.test(headSha)) {
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: headSha, state: 'failure',
+                  context: 'Agent Review Gate v2', description,
+                  target_url: targetUrl,
+                });
+              }
+            };
+            try {
+              const {data: initialPull} = await github.rest.pulls.get({
+                owner, repo, pull_number: pullNumber,
+              });
+              headSha = initialPull.head.sha;
+              const baseSha = initialPull.base.sha;
+              if (!/^[0-9a-f]{40}$/u.test(headSha) || !/^[0-9a-f]{40}$/u.test(baseSha)) {
+                throw new Error('pull request head or base is not an exact SHA');
+              }
+              const [{data: commit}, comments, {data: parserFile}] = await Promise.all([
+                github.rest.repos.getCommit({owner, repo, ref: headSha}),
+                github.paginate(github.rest.issues.listComments, {
+                  owner, repo, issue_number: pullNumber, per_page: 100,
+                }),
+                github.rest.repos.getContent({
+                  owner, repo, path: '.github/scripts/agent-review-gate.js', ref: baseSha,
+                }),
+              ]);
+              if (
+                Array.isArray(parserFile) ||
+                parserFile.type !== 'file' ||
+                parserFile.encoding !== 'base64' ||
+                typeof parserFile.content !== 'string'
+              ) {
+                throw new Error('trusted base review parser content is invalid');
+              }
+              const parserModule = {exports: {}};
+              new Function(
+                'module', 'exports',
+                Buffer.from(parserFile.content, 'base64').toString('utf8'),
+              )(parserModule, parserModule.exports);
+              const {evaluateReviewGate, buildCommitStatus} = parserModule.exports;
+              if (typeof evaluateReviewGate !== 'function' || typeof buildCommitStatus !== 'function') {
+                throw new Error('trusted base review parser exports are invalid');
+              }
+              const committedAt = new Date(
+                commit.commit.committer?.date ??
+                commit.commit.author?.date ??
+                initialPull.updated_at,
+              );
+              const result = evaluateReviewGate({comments, headSha, committedAt});
+              const status = buildCommitStatus({
+                owner, repo, headSha, targetUrl, result,
+              });
+              status.context = 'Agent Review Gate v2';
+
+              const {data: currentPull} = await github.rest.pulls.get({
+                owner, repo, pull_number: pullNumber,
+              });
+              if (currentPull.head.sha !== headSha || currentPull.base.sha !== baseSha) {
+                status.state = 'failure';
+                status.description = 'PR head or base changed during review evaluation.';
+              }
+              await github.rest.repos.createCommitStatus(status);
+              if (status.state !== 'success') {
+                core.notice(`Agent Review Gate v2 denied: ${result.passCount} PASS, ${result.blockedCount} BLOCKED, ${result.malformedBlockedCount} malformed BLOCKED.`);
+              }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              await publishFailure('Agent Review Gate v2 evaluation failed closed.');
+              core.setFailed(`Agent Review Gate v2 evaluation failed closed: ${message}`);
+            }

--- a/.github/workflows/agent-review-gate-v2.yml
+++ b/.github/workflows/agent-review-gate-v2.yml
@@ -1,4 +1,4 @@
-name: Agent Review Gate v2 base-controlled
+name: Agent Review Gate v2 observation
 
 on:
   pull_request_target:
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Trusted review result publisher
+    name: Trusted review observation publisher
     if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -35,7 +35,7 @@ jobs:
               if (/^[0-9a-f]{40}$/u.test(headSha)) {
                 await github.rest.repos.createCommitStatus({
                   owner, repo, sha: headSha, state: 'failure',
-                  context: 'Agent Review Gate v2', description,
+                  context: 'Agent Review Gate v2 observe', description,
                   target_url: targetUrl,
                 });
               }
@@ -48,6 +48,15 @@ jobs:
               const baseSha = initialPull.base.sha;
               if (!/^[0-9a-f]{40}$/u.test(headSha) || !/^[0-9a-f]{40}$/u.test(baseSha)) {
                 throw new Error('pull request head or base is not an exact SHA');
+              }
+              if (initialPull.base.ref !== 'main') {
+                throw new Error('observation controller only accepts the main base branch');
+              }
+              const {data: baseBranch} = await github.rest.repos.getBranch({
+                owner, repo, branch: initialPull.base.ref,
+              });
+              if (baseBranch.commit.sha !== baseSha) {
+                throw new Error('pull request base is not the current main head');
               }
               const [{data: commit}, comments, {data: parserFile}] = await Promise.all([
                 github.rest.repos.getCommit({owner, repo, ref: headSha}),
@@ -84,21 +93,26 @@ jobs:
               const status = buildCommitStatus({
                 owner, repo, headSha, targetUrl, result,
               });
-              status.context = 'Agent Review Gate v2';
+              status.context = 'Agent Review Gate v2 observe';
 
-              const {data: currentPull} = await github.rest.pulls.get({
-                owner, repo, pull_number: pullNumber,
-              });
-              if (currentPull.head.sha !== headSha || currentPull.base.sha !== baseSha) {
+              const [{data: currentPull}, {data: currentBase}] = await Promise.all([
+                github.rest.pulls.get({owner, repo, pull_number: pullNumber}),
+                github.rest.repos.getBranch({owner, repo, branch: 'main'}),
+              ]);
+              if (
+                currentPull.head.sha !== headSha ||
+                currentPull.base.sha !== baseSha ||
+                currentBase.commit.sha !== baseSha
+              ) {
                 status.state = 'failure';
-                status.description = 'PR head or base changed during review evaluation.';
+                status.description = 'PR head or current main changed during review observation.';
               }
               await github.rest.repos.createCommitStatus(status);
               if (status.state !== 'success') {
-                core.notice(`Agent Review Gate v2 denied: ${result.passCount} PASS, ${result.blockedCount} BLOCKED, ${result.malformedBlockedCount} malformed BLOCKED.`);
+                core.notice(`Agent Review Gate v2 observation denied: ${result.passCount} PASS, ${result.blockedCount} BLOCKED, ${result.malformedBlockedCount} malformed BLOCKED.`);
               }
             } catch (error) {
               const message = error instanceof Error ? error.message : String(error);
-              await publishFailure('Agent Review Gate v2 evaluation failed closed.');
-              core.setFailed(`Agent Review Gate v2 evaluation failed closed: ${message}`);
+              await publishFailure('Agent Review Gate v2 observation evaluation failed closed.');
+              core.setFailed(`Agent Review Gate v2 observation evaluation failed closed: ${message}`);
             }

--- a/.github/workflows/quick-v2.yml
+++ b/.github/workflows/quick-v2.yml
@@ -1,0 +1,222 @@
+name: Tests (quick v2 base-controlled)
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, edited]
+
+concurrency:
+  group: quick-v2-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  admit:
+    name: Trusted quick admission
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    outputs:
+      pull_number: ${{ steps.admit.outputs.pull_number }}
+      head_sha: ${{ steps.admit.outputs.head_sha }}
+      base_sha: ${{ steps.admit.outputs.base_sha }}
+      core: ${{ steps.admit.outputs.core }}
+      frontend: ${{ steps.admit.outputs.frontend }}
+      ci: ${{ steps.admit.outputs.ci }}
+      docs: ${{ steps.admit.outputs.docs }}
+      ready: ${{ steps.admit.outputs.ready }}
+    steps:
+      - name: Capture exact PR state with trusted base policy
+        id: admit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            let headSha = context.payload.pull_request.head.sha;
+            const targetUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const publish = async (state, description) => {
+              if (/^[0-9a-f]{40}$/u.test(headSha)) {
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: headSha, state, context: 'quick-v2',
+                  description, target_url: targetUrl,
+                });
+              }
+            };
+            try {
+              const {data: initialPull} = await github.rest.pulls.get({
+                owner, repo, pull_number: pullNumber,
+              });
+              headSha = initialPull.head.sha;
+              const baseSha = initialPull.base.sha;
+              await publish('pending', initialPull.draft
+                ? 'Waiting for the pull request to become ready.'
+                : 'Trusted base controller admitted this exact PR state.');
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: pullNumber, per_page: 100,
+              });
+              const {data: policyFile} = await github.rest.repos.getContent({
+                owner, repo,
+                path: '.github/scripts/base-gate-policy-v1.js',
+                ref: baseSha,
+              });
+              if (
+                Array.isArray(policyFile) ||
+                policyFile.type !== 'file' ||
+                policyFile.encoding !== 'base64' ||
+                typeof policyFile.content !== 'string'
+              ) {
+                throw new Error('trusted base gate policy content is invalid');
+              }
+              const policyModule = {exports: {}};
+              new Function(
+                'module', 'exports',
+                Buffer.from(policyFile.content, 'base64').toString('utf8'),
+              )(policyModule, policyModule.exports);
+              const {assertSha, classifyPullFiles} = policyModule.exports;
+              if (typeof assertSha !== 'function' || typeof classifyPullFiles !== 'function') {
+                throw new Error('trusted base gate policy exports are invalid');
+              }
+              assertSha(headSha, 'head');
+              assertSha(baseSha, 'base');
+              const routes = classifyPullFiles(files, initialPull.changed_files);
+
+              const {data: currentPull} = await github.rest.pulls.get({
+                owner, repo, pull_number: pullNumber,
+              });
+              if (currentPull.head.sha !== headSha || currentPull.base.sha !== baseSha) {
+                throw new Error('pull request head or base changed during admission');
+              }
+              const outputs = {
+                pull_number: String(pullNumber),
+                head_sha: headSha,
+                base_sha: baseSha,
+                core: String(routes.core),
+                frontend: String(routes.frontend),
+                ci: String(routes.ci),
+                docs: String(routes.docs),
+                ready: String(!initialPull.draft),
+              };
+              for (const [name, value] of Object.entries(outputs)) {
+                core.setOutput(name, value);
+              }
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              await publish('failure', 'Trusted quick admission failed closed.');
+              core.setFailed(`Trusted quick admission failed closed: ${message}`);
+            }
+
+  worker:
+    name: Read-only quick v2 worker
+    needs: admit
+    if: >-
+      needs.admit.result == 'success' &&
+      needs.admit.outputs.ready == 'true' &&
+      needs.admit.outputs.docs != 'true'
+    runs-on: [self-hosted, linux, build]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact trusted base controls
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.admit.outputs.base_sha }}
+          path: control
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Check out candidate merge without credentials
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ needs.admit.outputs.pull_number }}/merge
+          path: target
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Bind candidate merge to exact admitted head and base
+        env:
+          EXPECTED_HEAD: ${{ needs.admit.outputs.head_sha }}
+          EXPECTED_BASE: ${{ needs.admit.outputs.base_sha }}
+        run: |
+          read -r merge_sha first_parent second_parent extra < <(git -C target rev-list --parents -n 1 HEAD)
+          test -n "$merge_sha"
+          test "$first_parent" = "$EXPECTED_BASE"
+          test "$second_parent" = "$EXPECTED_HEAD"
+          test -z "${extra:-}"
+
+      - name: Run immutable base-controlled quick carrier
+        run: >-
+          control/.github/scripts/quick-v2-worker-v1.sh
+          control target
+          ${{ needs.admit.outputs.core }}
+          ${{ needs.admit.outputs.frontend }}
+          ${{ needs.admit.outputs.ci }}
+
+      - name: Upload frontend failure diagnostics
+        if: always() && needs.admit.outputs.frontend == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: quick-v2-frontend-${{ needs.admit.outputs.head_sha }}
+          path: |
+            target/frontend/tests/e2e/i18n/.output/
+            target/frontend/playwright-report/
+            target/frontend/fixtures-baselines/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  publish:
+    name: Trusted quick result publisher
+    needs: [admit, worker]
+    if: always() && needs.admit.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Publish exact-head quick-v2 status
+        uses: actions/github-script@v7
+        env:
+          PULL_NUMBER: ${{ needs.admit.outputs.pull_number }}
+          ADMITTED_HEAD: ${{ needs.admit.outputs.head_sha }}
+          ADMITTED_BASE: ${{ needs.admit.outputs.base_sha }}
+          READY: ${{ needs.admit.outputs.ready }}
+          DOCS: ${{ needs.admit.outputs.docs }}
+          WORKER_RESULT: ${{ needs.worker.result }}
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const pullNumber = Number(process.env.PULL_NUMBER);
+            const headSha = process.env.ADMITTED_HEAD;
+            const baseSha = process.env.ADMITTED_BASE;
+            const targetUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const {data: currentPull} = await github.rest.pulls.get({
+              owner, repo, pull_number: pullNumber,
+            });
+            let state = 'failure';
+            let description = 'Quick v2 failed closed.';
+            if (currentPull.head.sha !== headSha || currentPull.base.sha !== baseSha) {
+              description = 'PR head or base changed after quick-v2 admission.';
+            } else if (process.env.READY !== 'true') {
+              state = 'pending';
+              description = 'Waiting for the pull request to become ready.';
+            } else if (process.env.DOCS === 'true') {
+              state = 'success';
+              description = 'Trusted base policy selected documentation-only review.';
+            } else if (process.env.WORKER_RESULT === 'success') {
+              state = 'success';
+              description = 'Base-controlled quick carrier passed for exact head and base.';
+            } else {
+              description = `Base-controlled quick carrier ended ${process.env.WORKER_RESULT}.`;
+            }
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: headSha, state, context: 'quick-v2',
+              description, target_url: targetUrl,
+            });
+            if (state === 'failure') {
+              core.setFailed(description);
+            }

--- a/.github/workflows/quick-v2.yml
+++ b/.github/workflows/quick-v2.yml
@@ -1,4 +1,4 @@
-name: Tests (quick v2 base-controlled)
+name: Tests (quick v2 observation)
 
 on:
   pull_request_target:
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   admit:
-    name: Trusted quick admission
+    name: Trusted quick observation admission
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -27,6 +27,7 @@ jobs:
       ci: ${{ steps.admit.outputs.ci }}
       docs: ${{ steps.admit.outputs.docs }}
       ready: ${{ steps.admit.outputs.ready }}
+      same_repo: ${{ steps.admit.outputs.same_repo }}
     steps:
       - name: Capture exact PR state with trusted base policy
         id: admit
@@ -40,7 +41,7 @@ jobs:
             const publish = async (state, description) => {
               if (/^[0-9a-f]{40}$/u.test(headSha)) {
                 await github.rest.repos.createCommitStatus({
-                  owner, repo, sha: headSha, state, context: 'quick-v2',
+                  owner, repo, sha: headSha, state, context: 'quick-v2-observe',
                   description, target_url: targetUrl,
                 });
               }
@@ -51,9 +52,21 @@ jobs:
               });
               headSha = initialPull.head.sha;
               const baseSha = initialPull.base.sha;
+              if (initialPull.base.ref !== 'main') {
+                throw new Error('observation controller only accepts the main base branch');
+              }
+              const {data: baseBranch} = await github.rest.repos.getBranch({
+                owner, repo, branch: initialPull.base.ref,
+              });
+              if (baseBranch.commit.sha !== baseSha) {
+                throw new Error('pull request base is not the current main head');
+              }
+              const sameRepo = initialPull.head.repo?.full_name === `${owner}/${repo}`;
               await publish('pending', initialPull.draft
                 ? 'Waiting for the pull request to become ready.'
-                : 'Trusted base controller admitted this exact PR state.');
+                : sameRepo
+                  ? 'Trusted base observation admitted this exact PR state.'
+                  : 'Fork observation is metadata-only; worker execution is withheld.');
 
               const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner, repo, pull_number: pullNumber, per_page: 100,
@@ -84,10 +97,15 @@ jobs:
               assertSha(baseSha, 'base');
               const routes = classifyPullFiles(files, initialPull.changed_files);
 
-              const {data: currentPull} = await github.rest.pulls.get({
-                owner, repo, pull_number: pullNumber,
-              });
-              if (currentPull.head.sha !== headSha || currentPull.base.sha !== baseSha) {
+              const [{data: currentPull}, {data: currentBase}] = await Promise.all([
+                github.rest.pulls.get({owner, repo, pull_number: pullNumber}),
+                github.rest.repos.getBranch({owner, repo, branch: 'main'}),
+              ]);
+              if (
+                currentPull.head.sha !== headSha ||
+                currentPull.base.sha !== baseSha ||
+                currentBase.commit.sha !== baseSha
+              ) {
                 throw new Error('pull request head or base changed during admission');
               }
               const outputs = {
@@ -99,6 +117,7 @@ jobs:
                 ci: String(routes.ci),
                 docs: String(routes.docs),
                 ready: String(!initialPull.draft),
+                same_repo: String(sameRepo),
               };
               for (const [name, value] of Object.entries(outputs)) {
                 core.setOutput(name, value);
@@ -115,7 +134,8 @@ jobs:
     if: >-
       needs.admit.result == 'success' &&
       needs.admit.outputs.ready == 'true' &&
-      needs.admit.outputs.docs != 'true'
+      needs.admit.outputs.docs != 'true' &&
+      needs.admit.outputs.same_repo == 'true'
     runs-on: [self-hosted, linux, build]
     timeout-minutes: 15
     permissions:
@@ -160,7 +180,7 @@ jobs:
         if: always() && needs.admit.outputs.frontend == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: quick-v2-frontend-${{ needs.admit.outputs.head_sha }}
+          name: quick-v2-observe-frontend-${{ needs.admit.outputs.head_sha }}
           path: |
             target/frontend/tests/e2e/i18n/.output/
             target/frontend/playwright-report/
@@ -169,16 +189,17 @@ jobs:
           retention-days: 14
 
   publish:
-    name: Trusted quick result publisher
+    name: Trusted quick observation publisher
     needs: [admit, worker]
     if: always() && needs.admit.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
+      contents: read
       pull-requests: read
       statuses: write
     steps:
-      - name: Publish exact-head quick-v2 status
+      - name: Publish exact-head quick-v2-observe status
         uses: actions/github-script@v7
         env:
           PULL_NUMBER: ${{ needs.admit.outputs.pull_number }}
@@ -186,6 +207,7 @@ jobs:
           ADMITTED_BASE: ${{ needs.admit.outputs.base_sha }}
           READY: ${{ needs.admit.outputs.ready }}
           DOCS: ${{ needs.admit.outputs.docs }}
+          SAME_REPO: ${{ needs.admit.outputs.same_repo }}
           WORKER_RESULT: ${{ needs.worker.result }}
         with:
           script: |
@@ -194,16 +216,23 @@ jobs:
             const headSha = process.env.ADMITTED_HEAD;
             const baseSha = process.env.ADMITTED_BASE;
             const targetUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const {data: currentPull} = await github.rest.pulls.get({
-              owner, repo, pull_number: pullNumber,
-            });
+            const [{data: currentPull}, {data: currentBase}] = await Promise.all([
+              github.rest.pulls.get({owner, repo, pull_number: pullNumber}),
+              github.rest.repos.getBranch({owner, repo, branch: 'main'}),
+            ]);
             let state = 'failure';
-            let description = 'Quick v2 failed closed.';
-            if (currentPull.head.sha !== headSha || currentPull.base.sha !== baseSha) {
-              description = 'PR head or base changed after quick-v2 admission.';
+            let description = 'Quick v2 observation failed closed.';
+            if (
+              currentPull.head.sha !== headSha ||
+              currentPull.base.sha !== baseSha ||
+              currentBase.commit.sha !== baseSha
+            ) {
+              description = 'PR head or current main changed after quick-v2 observation admission.';
             } else if (process.env.READY !== 'true') {
               state = 'pending';
               description = 'Waiting for the pull request to become ready.';
+            } else if (process.env.SAME_REPO !== 'true') {
+              description = 'Fork code was not executed on the shared self-hosted worker.';
             } else if (process.env.DOCS === 'true') {
               state = 'success';
               description = 'Trusted base policy selected documentation-only review.';
@@ -214,7 +243,7 @@ jobs:
               description = `Base-controlled quick carrier ended ${process.env.WORKER_RESULT}.`;
             }
             await github.rest.repos.createCommitStatus({
-              owner, repo, sha: headSha, state, context: 'quick-v2',
+              owner, repo, sha: headSha, state, context: 'quick-v2-observe',
               description, target_url: targetUrl,
             });
             if (state === 'failure') {

--- a/docs/internals/base-controlled-required-gates.md
+++ b/docs/internals/base-controlled-required-gates.md
@@ -1,9 +1,7 @@
 # Base-controlled gate observation and authority migration
 
-Issue [#3136](https://github.com/rigplane/rigplane-core/issues/3136) records a
-circular trust boundary: a pull request can currently modify the same
-`pull_request` workflow or helper that publishes its required `quick` or
-`Agent Review Gate` success.
+Issue [#3136](https://github.com/rigplane/rigplane-core/issues/3136) records a circular trust boundary: a pull request can
+modify the same `pull_request` workflow or helper that publishes its required `quick` or `Agent Review Gate` success.
 
 ## Stage 1 is observation-only
 
@@ -20,28 +18,18 @@ required checks**:
 | `quick-v2-observe` | base-owned observation workflow | same-repository PRs only, read-only self-hosted job | no |
 | `Agent Review Gate v2 observe` | base-owned API-only observation workflow | none | no |
 
-GitHub branch protection can bind a status/check to a context and an app ID,
-but every workflow in this repository publishes as the same GitHub Actions app
-ID `15368`. A candidate-controlled workflow can therefore publish either
-observation context with the same identity. Context plus app ID does not prove
-which workflow or helper made the decision. Renaming these statuses to
-`*-observe` makes their non-authoritative role explicit; no protection-switch
-command targets them.
+GitHub branch protection can bind a status/check to a context and app ID, but every repository workflow publishes as
+GitHub Actions app ID `15368`. A candidate-controlled workflow can publish either observation context with the same
+identity. Context plus app ID does not prove which workflow made the decision. The `*-observe` names make their
+non-authoritative role explicit; no protection-switch command targets them.
 
-The quick observation controller reads complete PR file metadata through the
-API, loads its policy from the exact PR base SHA, and requires that SHA to equal
-the live `main` branch head. Documentation-only changes remain API-only. A
-same-repository code/CI PR uses a separate job with `contents: read`, no
-persisted checkout credential, no referenced secrets, and no privileged
-candidate command. Before candidate execution, the job proves that the merge
-commit parents equal the admitted base and head. The hosted publisher rereads
-both the PR and live `main` before it can publish success.
+The quick observation controller reads complete PR file metadata, loads policy from the exact PR base SHA, and requires
+that SHA to equal live `main`. Documentation-only changes remain API-only. Same-repository code/CI uses a separate job
+with `contents: read`, no persisted credential, referenced secrets, or privileged candidate command. Before candidate
+execution, it proves the merge parents equal the admitted base and head. The hosted publisher rereads PR and `main`.
 
-Fork PRs never execute on the shared self-hosted runner. Their metadata is
-classified on GitHub-hosted infrastructure, the worker is skipped, and the
-observation status fails with an explicit fork-withheld description. Promotion
-cannot occur until a separately isolated fork execution path exists or policy
-explicitly keeps fork PRs non-mergeable.
+Fork PRs never execute on the shared self-hosted runner. Hosted infrastructure classifies their metadata, skips the
+worker, and fails observation explicitly. Promotion requires an isolated fork path or a policy keeping forks unmergeable.
 
 The worker uses `git ls-tree` to compare object ID, object type, and file mode
 for every immutable control. This rejects content edits, deletion, regular-file
@@ -62,19 +50,13 @@ Promotion requires a separate `RigPlane Gatekeeper` GitHub App and controller
 with all of these properties:
 
 1. Its installation app ID is distinct from GitHub Actions app ID `15368`.
-2. Its private key and decision state live outside this repository and outside
-   GitHub Actions secrets. Repository workflows cannot request its token.
+2. Its private key and state live outside this repository and Actions secrets; repository workflows cannot request it.
 3. It alone publishes final `quick-v3` and `Agent Review Gate v3` statuses.
-4. It records the PR number, exact head, exact live `main` SHA, worker run ID,
-   workflow path/SHA, and an externally generated correlation nonce before
-   dispatch. It accepts only the run it dispatched from trusted default-branch
-   controls and rereads head plus live `main` before success.
-5. Same-repository code may use the read-only worker after merge-parent
-   verification. Fork code must use an isolated ephemeral/hosted worker with no
-   repository secrets or write token; otherwise Gatekeeper publishes failure.
-6. Failures, cancellation, missing/capped file metadata, stale head/base,
-   ambiguous/multiple results, and publisher/API errors all publish failure or
-   leave the required status unsatisfied.
+4. Before dispatch it records PR, head, live `main`, run ID, workflow path/SHA, and an external nonce. It accepts only
+   that trusted-default-branch run and rereads head plus `main` before success.
+5. Same-repository code may use the read-only worker after merge-parent verification. Fork code uses an isolated
+   ephemeral/hosted worker without repository secrets or write token; otherwise Gatekeeper publishes failure.
+6. Failure, cancellation, incomplete metadata, stale state, ambiguity, and API errors fail or leave status unsatisfied.
 
 A repository ruleset-required workflow controlled from a separate locked
 repository is an acceptable alternative only if GitHub enforces that exact
@@ -83,21 +65,12 @@ it. Ordinary context/app-ID branch protection is not that mechanism.
 
 ## Observation and promotion checklist
 
-1. Merge stage 1 through the existing required contexts. Do not change branch
-   protection in the stage-1 PR.
-2. Observe `*-observe` on a docs-only PR and a same-repository code/CI PR.
-   Verify routing, exact head/current-base binding, mode/type mutation failures,
-   and a single expected observation result.
-3. Exercise failure, cancellation, head/base advance, incomplete/capped API
-   metadata, and a public fork. Confirm no fork worker allocation and no stale
-   success.
-4. Install and independently audit Gatekeeper (or the enforced external
-   required workflow). Record its distinct app ID and prove repository Actions
-   cannot mint its statuses.
-5. Observe `quick-v3` and `Agent Review Gate v3` from that authority on docs,
-   code/CI, failure, cancellation, stale-base, and isolated-fork cases.
-6. Read the live protection payload and substitute the observed dedicated app
-   ID below. Refuse the switch if it is missing or equals `15368`:
+1. Merge stage 1 through existing required contexts without changing protection.
+2. Observe `*-observe` on docs-only and same-repository code/CI, checking routing, binding, mutations, and result count.
+3. Exercise failure, cancellation, base advance, incomplete/capped metadata, and a fork; require no fork worker or stale success.
+4. Audit Gatekeeper or the enforced external workflow; record its distinct app ID and prove Actions cannot mint status.
+5. Observe `quick-v3` and `Agent Review Gate v3` on docs, code, failure, cancellation, stale-base, and isolated-fork cases.
+6. Read protection and substitute the observed app ID below; refuse the switch if it is missing or equals `15368`:
 
    ```bash
    gatekeeper_app_id='<DEDICATED_GATEKEEPER_APP_ID>'

--- a/docs/internals/base-controlled-required-gates.md
+++ b/docs/internals/base-controlled-required-gates.md
@@ -1,0 +1,111 @@
+# Base-controlled required-gate migration
+
+Issue [#3136](https://github.com/rigplane/rigplane-core/issues/3136) removes a
+circular trust boundary: a pull request can currently modify the same
+`pull_request` workflow or helper that publishes its required `quick` or
+`Agent Review Gate` success.
+
+## Stage 1 topology
+
+Stage 1 adds two non-required contexts and leaves branch protection unchanged.
+
+| Context | Trusted producer | Candidate execution | Stage 1 required |
+| --- | --- | --- | --- |
+| `quick` | legacy `quick.yml` or docs-only API publisher | legacy PR workflow | yes, app 15368 |
+| `Agent Review Gate` | legacy PR/comment workflow | API-only, but legacy PR source is candidate-controlled | yes, app 15368 |
+| `quick-v2` | base-owned `pull_request_target` controller | separate self-hosted job with `contents: read`, no persisted credential, and no referenced secrets | no |
+| `Agent Review Gate v2` | base-owned `pull_request_target`/comment controller | none; API metadata only | no |
+
+The v2 quick controller reads complete pull-request file metadata through the
+API, fetches its versioned policy from the exact PR base SHA, and records the
+exact head and base. Documentation-only changes finish on a GitHub-hosted
+API-only path. Other ready changes use the existing build-tier carrier after
+checking out `refs/pull/<number>/merge` without persisted credentials and
+verifying that its first and second parents are the admitted base and head.
+Only the later GitHub-hosted publisher has `statuses: write`; it rereads the PR
+before publishing success.
+
+The review v2 controller fetches the review parser from the exact PR base SHA,
+reads comments through the API, and rereads the PR before publishing. Neither
+controller evaluates code from the candidate revision in a write-token job.
+Fork PRs follow the same API and merge-ref path with a read-only worker token.
+
+These security controls are immutable in place:
+
+- `.github/workflows/quick-v2.yml`
+- `.github/workflows/agent-review-gate-v2.yml`
+- `.github/scripts/base-controlled-gates-v1.test.js`
+- `.github/scripts/base-gate-policy-v1.js`
+- `.github/scripts/quick-v2-worker-v1.sh`
+- `.github/scripts/agent-review-gate.js`
+
+The base-owned worker compares each candidate file byte-for-byte with the
+trusted base before running candidate CI controls. A PR cannot weaken the
+controller, publisher, policy, worker, or parser that evaluates it. A future
+gate change must add a new version and non-required context, observe it, and
+switch protection separately; it must not edit these controls in place while
+v2 is required.
+
+## Promotion checklist
+
+1. Merge stage 1 through the existing required `quick` and
+   `Agent Review Gate` contexts. Do not change branch protection in that PR.
+2. Observe a natural documentation-only PR. Confirm exactly one `quick-v2`
+   commit status from GitHub Actions app ID `15368`, no v2 self-hosted worker,
+   an exact head/base binding, and the expected review-v2 failure then success
+   around a fresh exact-head review directive.
+3. Observe a natural code or CI-control PR. Confirm the base-controlled worker
+   runs, its token is read-only, its merge parents equal the admitted base and
+   head, and exactly one final `quick-v2` status is published by app `15368`.
+4. Independently exercise and record a failing carrier, a superseded/cancelled
+   run, a head or base race, and a fork PR. Failure and stale-state cases must
+   never publish success; the fork must run with no secrets and no write token.
+5. Recheck the live branch-protection payload and the observed status app IDs.
+   Only then replace the required checks in one separate coordinator action:
+
+   ```bash
+   gh api --method PATCH \
+     repos/rigplane/rigplane-core/branches/main/protection/required_status_checks \
+     --input - <<'JSON'
+   {
+     "strict": false,
+     "checks": [
+       {"context": "Agent Review Gate v2", "app_id": 15368},
+       {"context": "quick-v2", "app_id": 15368}
+     ]
+   }
+   JSON
+   ```
+
+6. Immediately read branch protection back and open or update a harmless PR to
+   confirm both new required contexts resolve. Keep the legacy producers in
+   place during this confirmation.
+7. In stage 2, after the rule switch is proven, retire the legacy publishers,
+   candidate-controlled admission helpers, and duplicated old contexts in a
+   separate reviewed PR.
+
+## Rollback and lockout recovery
+
+If either v2 context is absent, ambiguous, stale, or published by an unexpected
+app, restore the old required checks before changing workflow code:
+
+```bash
+gh api --method PATCH \
+  repos/rigplane/rigplane-core/branches/main/protection/required_status_checks \
+  --input - <<'JSON'
+{
+  "strict": false,
+  "checks": [
+    {"context": "Agent Review Gate", "app_id": 15368},
+    {"context": "quick", "app_id": 15368}
+  ]
+}
+JSON
+```
+
+Read the protection payload back after rollback. Because stage 1 does not
+remove or rename the old producers, this restores the pre-migration merge path
+without a workflow commit. If stage 2 has already retired them, first restore
+the old protection payload under administrator authority, then revert the
+stage-2 retirement through an ordinary PR; do not manufacture statuses or
+temporarily accept an unbound context.

--- a/docs/internals/base-controlled-required-gates.md
+++ b/docs/internals/base-controlled-required-gates.md
@@ -1,100 +1,137 @@
-# Base-controlled required-gate migration
+# Base-controlled gate observation and authority migration
 
-Issue [#3136](https://github.com/rigplane/rigplane-core/issues/3136) removes a
+Issue [#3136](https://github.com/rigplane/rigplane-core/issues/3136) records a
 circular trust boundary: a pull request can currently modify the same
 `pull_request` workflow or helper that publishes its required `quick` or
 `Agent Review Gate` success.
 
-## Stage 1 topology
+## Stage 1 is observation-only
 
-Stage 1 adds two non-required contexts and leaves branch protection unchanged.
+Stage 1 leaves branch protection and the legacy publishers unchanged. The two
+new commit-status contexts are telemetry and **must never be configured as
+required checks**:
 
-| Context | Trusted producer | Candidate execution | Stage 1 required |
+**Promotion prohibition: `*-observe` must never be configured as required checks.**
+
+| Context | Producer | Candidate execution | Required |
 | --- | --- | --- | --- |
-| `quick` | legacy `quick.yml` or docs-only API publisher | legacy PR workflow | yes, app 15368 |
-| `Agent Review Gate` | legacy PR/comment workflow | API-only, but legacy PR source is candidate-controlled | yes, app 15368 |
-| `quick-v2` | base-owned `pull_request_target` controller | separate self-hosted job with `contents: read`, no persisted credential, and no referenced secrets | no |
-| `Agent Review Gate v2` | base-owned `pull_request_target`/comment controller | none; API metadata only | no |
+| `quick` | legacy workflow or docs-only publisher | legacy PR workflow | yes, app 15368 |
+| `Agent Review Gate` | legacy PR/comment workflow | API-only, with candidate-controlled PR source | yes, app 15368 |
+| `quick-v2-observe` | base-owned observation workflow | same-repository PRs only, read-only self-hosted job | no |
+| `Agent Review Gate v2 observe` | base-owned API-only observation workflow | none | no |
 
-The v2 quick controller reads complete pull-request file metadata through the
-API, fetches its versioned policy from the exact PR base SHA, and records the
-exact head and base. Documentation-only changes finish on a GitHub-hosted
-API-only path. Other ready changes use the existing build-tier carrier after
-checking out `refs/pull/<number>/merge` without persisted credentials and
-verifying that its first and second parents are the admitted base and head.
-Only the later GitHub-hosted publisher has `statuses: write`; it rereads the PR
-before publishing success.
+GitHub branch protection can bind a status/check to a context and an app ID,
+but every workflow in this repository publishes as the same GitHub Actions app
+ID `15368`. A candidate-controlled workflow can therefore publish either
+observation context with the same identity. Context plus app ID does not prove
+which workflow or helper made the decision. Renaming these statuses to
+`*-observe` makes their non-authoritative role explicit; no protection-switch
+command targets them.
 
-The review v2 controller fetches the review parser from the exact PR base SHA,
-reads comments through the API, and rereads the PR before publishing. Neither
-controller evaluates code from the candidate revision in a write-token job.
-Fork PRs follow the same API and merge-ref path with a read-only worker token.
+The quick observation controller reads complete PR file metadata through the
+API, loads its policy from the exact PR base SHA, and requires that SHA to equal
+the live `main` branch head. Documentation-only changes remain API-only. A
+same-repository code/CI PR uses a separate job with `contents: read`, no
+persisted checkout credential, no referenced secrets, and no privileged
+candidate command. Before candidate execution, the job proves that the merge
+commit parents equal the admitted base and head. The hosted publisher rereads
+both the PR and live `main` before it can publish success.
 
-These security controls are immutable in place:
+Fork PRs never execute on the shared self-hosted runner. Their metadata is
+classified on GitHub-hosted infrastructure, the worker is skipped, and the
+observation status fails with an explicit fork-withheld description. Promotion
+cannot occur until a separately isolated fork execution path exists or policy
+explicitly keeps fork PRs non-mergeable.
+
+The worker uses `git ls-tree` to compare object ID, object type, and file mode
+for every immutable control. This rejects content edits, deletion, regular-file
+to symlink changes, and executable-bit changes:
 
 - `.github/workflows/quick-v2.yml`
 - `.github/workflows/agent-review-gate-v2.yml`
 - `.github/scripts/base-controlled-gates-v1.test.js`
 - `.github/scripts/base-gate-policy-v1.js`
 - `.github/scripts/quick-v2-worker-v1.sh`
+- `.github/scripts/verify-immutable-controls-v1.sh`
 - `.github/scripts/agent-review-gate.js`
 
-The base-owned worker compares each candidate file byte-for-byte with the
-trusted base before running candidate CI controls. A PR cannot weaken the
-controller, publisher, policy, worker, or parser that evaluates it. A future
-gate change must add a new version and non-required context, observe it, and
-switch protection separately; it must not edit these controls in place while
-v2 is required.
+## Unique authority required before promotion
 
-## Promotion checklist
+In-repository GitHub Actions cannot provide a unique required-status authority.
+Promotion requires a separate `RigPlane Gatekeeper` GitHub App and controller
+with all of these properties:
 
-1. Merge stage 1 through the existing required `quick` and
-   `Agent Review Gate` contexts. Do not change branch protection in that PR.
-2. Observe a natural documentation-only PR. Confirm exactly one `quick-v2`
-   commit status from GitHub Actions app ID `15368`, no v2 self-hosted worker,
-   an exact head/base binding, and the expected review-v2 failure then success
-   around a fresh exact-head review directive.
-3. Observe a natural code or CI-control PR. Confirm the base-controlled worker
-   runs, its token is read-only, its merge parents equal the admitted base and
-   head, and exactly one final `quick-v2` status is published by app `15368`.
-4. Independently exercise and record a failing carrier, a superseded/cancelled
-   run, a head or base race, and a fork PR. Failure and stale-state cases must
-   never publish success; the fork must run with no secrets and no write token.
-5. Recheck the live branch-protection payload and the observed status app IDs.
-   Only then replace the required checks in one separate coordinator action:
+1. Its installation app ID is distinct from GitHub Actions app ID `15368`.
+2. Its private key and decision state live outside this repository and outside
+   GitHub Actions secrets. Repository workflows cannot request its token.
+3. It alone publishes final `quick-v3` and `Agent Review Gate v3` statuses.
+4. It records the PR number, exact head, exact live `main` SHA, worker run ID,
+   workflow path/SHA, and an externally generated correlation nonce before
+   dispatch. It accepts only the run it dispatched from trusted default-branch
+   controls and rereads head plus live `main` before success.
+5. Same-repository code may use the read-only worker after merge-parent
+   verification. Fork code must use an isolated ephemeral/hosted worker with no
+   repository secrets or write token; otherwise Gatekeeper publishes failure.
+6. Failures, cancellation, missing/capped file metadata, stale head/base,
+   ambiguous/multiple results, and publisher/API errors all publish failure or
+   leave the required status unsatisfied.
+
+A repository ruleset-required workflow controlled from a separate locked
+repository is an acceptable alternative only if GitHub enforces that exact
+workflow identity and candidate repository workflows cannot satisfy or replace
+it. Ordinary context/app-ID branch protection is not that mechanism.
+
+## Observation and promotion checklist
+
+1. Merge stage 1 through the existing required contexts. Do not change branch
+   protection in the stage-1 PR.
+2. Observe `*-observe` on a docs-only PR and a same-repository code/CI PR.
+   Verify routing, exact head/current-base binding, mode/type mutation failures,
+   and a single expected observation result.
+3. Exercise failure, cancellation, head/base advance, incomplete/capped API
+   metadata, and a public fork. Confirm no fork worker allocation and no stale
+   success.
+4. Install and independently audit Gatekeeper (or the enforced external
+   required workflow). Record its distinct app ID and prove repository Actions
+   cannot mint its statuses.
+5. Observe `quick-v3` and `Agent Review Gate v3` from that authority on docs,
+   code/CI, failure, cancellation, stale-base, and isolated-fork cases.
+6. Read the live protection payload and substitute the observed dedicated app
+   ID below. Refuse the switch if it is missing or equals `15368`:
 
    ```bash
-   gh api --method PATCH \
-     repos/rigplane/rigplane-core/branches/main/protection/required_status_checks \
-     --input - <<'JSON'
-   {
-     "strict": false,
-     "checks": [
-       {"context": "Agent Review Gate v2", "app_id": 15368},
-       {"context": "quick-v2", "app_id": 15368}
+   gatekeeper_app_id='<DEDICATED_GATEKEEPER_APP_ID>'
+   test -n "$gatekeeper_app_id"
+   test "$gatekeeper_app_id" != 15368
+   jq -n --argjson app_id "$gatekeeper_app_id" '{
+     strict: true,
+     checks: [
+       {context: "Agent Review Gate v3", app_id: $app_id},
+       {context: "quick-v3", app_id: $app_id}
      ]
-   }
-   JSON
+   }' | gh api --method PATCH \
+     repos/rigplane/rigplane-core/branches/main/protection/required_status_checks \
+     --input -
    ```
 
-6. Immediately read branch protection back and open or update a harmless PR to
-   confirm both new required contexts resolve. Keep the legacy producers in
-   place during this confirmation.
-7. In stage 2, after the rule switch is proven, retire the legacy publishers,
-   candidate-controlled admission helpers, and duplicated old contexts in a
-   separate reviewed PR.
+7. Read protection back, confirm `strict: true`, exact contexts, and the
+   dedicated app ID, then validate a harmless PR. The `*-observe` contexts
+   remain non-required.
 
-## Rollback and lockout recovery
+## Rollback and retirement ordering
 
-If either v2 context is absent, ambiguous, stale, or published by an unexpected
-app, restore the old required checks before changing workflow code:
+Legacy producers must remain enabled while the first Gatekeeper generation is
+promoted. If Gatekeeper fails, switch protection back to the still-running
+legacy contexts **before** disabling or editing any v3 publisher:
+
+Rollback invariant: switch protection back to the still-running legacy contexts **before** disabling a v3 publisher.
 
 ```bash
 gh api --method PATCH \
   repos/rigplane/rigplane-core/branches/main/protection/required_status_checks \
   --input - <<'JSON'
 {
-  "strict": false,
+  "strict": true,
   "checks": [
     {"context": "Agent Review Gate", "app_id": 15368},
     {"context": "quick", "app_id": 15368}
@@ -103,9 +140,14 @@ gh api --method PATCH \
 JSON
 ```
 
-Read the protection payload back after rollback. Because stage 1 does not
-remove or rename the old producers, this restores the pre-migration merge path
-without a workflow commit. If stage 2 has already retired them, first restore
-the old protection payload under administrator authority, then revert the
-stage-2 retirement through an ordinary PR; do not manufacture statuses or
-temporarily accept an unbound context.
+Read protection back and prove both legacy contexts resolve on a current-base
+PR. Only then repair or disable v3. This restores availability with the known
+legacy trust limitation; it is an emergency rollback, not completion of
+#3136.
+
+Stage 2 may mark legacy contexts non-required but must keep their producers
+running for rollback. Deletion is a later stage and is prohibited until a
+previous, independently operated Gatekeeper generation is still running and
+observed as a non-required rollback target. The required-check switch always
+precedes removal of the generation being retired, so protection can never
+require a context whose producer has disappeared.


### PR DESCRIPTION
## Problem and safe stage-1 outcome

Required `quick` and `Agent Review Gate` decisions currently run from candidate-controlled `pull_request` workflow/helper revisions. A PR can therefore change the mechanism that publishes its own required success.

This PR now provides an additive **observation harness**, not promotable required contexts. Review established that branch protection can bind a context to GitHub Actions app ID `15368`, but every repository workflow shares that identity. An untrusted candidate workflow could therefore mint the same app-bound context. The in-repository statuses are renamed `quick-v2-observe` and `Agent Review Gate v2 observe`, remain non-required, and are explicitly prohibited from promotion.

A separately installed `RigPlane Gatekeeper` GitHub App, with a distinct app ID and credentials/state outside repository Actions, is required before protection can move. The migration document defines authoritative `quick-v3` and `Agent Review Gate v3` statuses, externally correlated dispatch/run evidence, isolated fork execution, and a `strict: true` switch. A locked external required-workflow mechanism is acceptable only if GitHub enforces its exact identity.

## Observation behavior

- Both controllers run from `pull_request_target` and fetch policy/parser code from the exact captured base SHA.
- They require the captured base SHA to equal the live `main` head both before work and before any success.
- Documentation-only routing is complete/count-bounded and API-only.
- Same-repository code/CI changes use a separate self-hosted worker with `contents: read`, no persisted checkout credential, no referenced secrets, and no privileged candidate command.
- Public fork code never runs on the shared self-hosted worker. Fork metadata is handled on GitHub-hosted infrastructure and the observation status fails explicitly.
- The worker proves the candidate merge parents equal the admitted base/head.
- `git ls-tree` equality checks object ID, object type, and file mode for every immutable control, rejecting content edits, deletion, chmod changes, and regular-file/symlink changes.
- No candidate code executes in a job with `statuses: write`.

## Bootstrap and existing protection

This stage does not change branch protection, remove a legacy producer, or merge itself. Existing requirements remain `quick` and `Agent Review Gate`, app ID `15368`. Newly added `pull_request_target` workflows do not execute from their own candidate branch; observation starts only after merge.

## Verification

Focused local CI-control checks only:

- Base-controlled adversarial contracts: 5/5 passed, including chmod and symlink mutants.
- Quick path/event contracts: 8/8 passed.
- Agent Review parser contracts: 20/20 passed.
- YAML parse, Node/Python/shell syntax, and `git diff --check`: passed.
- `actionlint`: only the existing repository-specific unknown custom runner label warning for `build`.

No pytest, Vitest, Playwright, full, visual, or hardware suite was run locally. The exact diff is 8 files and 991 changed lines, within the repository hard ceiling. Natural exact-head CI passed at `2695d88969b587f2c35976cead0cd839acb608fc`: Tests (quick) run `33813559177` completed successfully with review parser 20/20, focused workflow 3/3, base-controlled adversarial contracts 5/5, quick path/event contracts 8/8, and Python control compilation. API-only docs classifier run `33813558339` correctly withheld synthetic `quick` for the CI diff. Legacy review run `33813559266` published the expected failure status pending a fresh independent exact-head verdict.

## Promotion and rollback

`docs/internals/base-controlled-required-gates.md` records the enforced sequence:

1. Merge this observation-only stage under legacy protection.
2. Exercise docs, same-repository code/CI, fork withholding, failures, cancellation, stale-base, and metadata caps.
3. Install and independently audit the distinct external Gatekeeper authority and isolated fork runner.
4. Observe its `quick-v3` and `Agent Review Gate v3` results, prove the app ID is not `15368`, then switch with `strict: true` in a separate coordinator action.
5. Keep legacy producers running during initial promotion. On rollback, switch required checks back to those live producers before disabling or editing v3.
6. Do not delete a producer generation until an independently operated previous generation is already observed as a rollback target.

Addresses the correction findings on #3136 without claiming that ordinary repository Actions can uniquely authorize a required context.
