### PR TITLE
fix: scope Yaesu clarifier polling by capability (MOR-2311)

### DIFF
--- a/src/rigplane/backends/yaesu_cat/observations.py
+++ b/src/rigplane/backends/yaesu_cat/observations.py
@@ -111,10 +111,8 @@ _ACTIVE_INDEX_TO_STR = {0: "MAIN", 1: "SUB"}
 # controls (CAT ``CF000``/``CF001``): ``rit_on``/``rit_tx`` are global tx_state
 # bools (RX/TX clarifier flags), ``rit_freq`` is the global operator-control
 # signed Hz offset. Emitted in the global TX-control lane alongside split/VOX,
-# gated on the ``rit`` runtime capability, mirroring the legacy poller's
-# ``"rit" in caps`` gate and its single ``get_clarifier``/``get_clarifier_freq``
-# read pair. The signed Hz offset is emitted on the device scale (cross-vendor
-# calibration is MOR-453).
+# gated independently on the ``rit`` and ``xit`` runtime capabilities. The
+# signed Hz offset is shared and emitted when either capability is declared.
 _RIT_ON = FieldPath.global_("tx_state", "rit_on")
 _RIT_TX = FieldPath.global_("tx_state", "rit_tx")
 _RIT_FREQ = FieldPath.global_("operator_controls", "rit_freq")
@@ -1071,18 +1069,16 @@ class YaesuObservationAdapter:
                     adapter.observation(_SPLIT, value, native_id="read_split")
                 )
         # Clarifier RIT/XIT (MOR-454) — GLOBAL slow-changing operator/TX
-        # controls (CAT ``CF000``/``CF001``), gated on the ``rit`` runtime
-        # capability, mirroring the legacy poller's ``"rit" in caps`` gate. The
-        # ``rit_on``/``rit_tx`` flags come from a single ``read_clarifier`` read
-        # (rx,tx), and ``rit_freq`` from a single ``read_clarifier_freq`` read —
-        # exactly the poller's read pair, never an extra query. The signed Hz
-        # offset is emitted on the device scale (cross-vendor calibration is
-        # MOR-453); each emission is gated independently by per-field policy.
-        if self._has_runtime_capability("rit"):
+        # controls (CAT ``CF000``/``CF001``). The status read is shared when
+        # either capability is declared; each flag is emitted only for its
+        # declared capability. The frequency is shared too.
+        has_rit = self._has_runtime_capability("rit")
+        has_xit = self._has_runtime_capability("xit")
+        if has_rit or has_xit:
             ok, clar = await self._safe_read("clarifier", self.radio.read_clarifier(0))
             if ok and clar is not None:
                 rx_clar, tx_clar = clar
-                if self._can_poll(_RIT_ON):
+                if has_rit and self._can_poll(_RIT_ON):
                     observations.append(
                         adapter.observation(
                             _RIT_ON,
@@ -1090,7 +1086,7 @@ class YaesuObservationAdapter:
                             native_id="read_clarifier",
                         )
                     )
-                if self._can_poll(_RIT_TX):
+                if has_xit and self._can_poll(_RIT_TX):
                     observations.append(
                         adapter.observation(
                             _RIT_TX,

--- a/src/rigplane/backends/yaesu_cat/poller.py
+++ b/src/rigplane/backends/yaesu_cat/poller.py
@@ -1475,11 +1475,13 @@ class YaesuCatPoller:
                 logger.debug("YaesuCatPoller: get_if_shift failed", exc_info=True)
 
         # -- Clarifier (RIT/XIT) --
-        if "rit" in caps:
+        if "rit" in caps or "xit" in caps:
             try:
                 rx_clar, tx_clar = await radio.get_clarifier()
-                state.rit_on = rx_clar
-                state.rit_tx = tx_clar
+                if "rit" in caps:
+                    state.rit_on = rx_clar
+                if "xit" in caps:
+                    state.rit_tx = tx_clar
                 state.rit_freq = await radio.get_clarifier_freq()
             except NotImplementedError:
                 pass

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -215,6 +215,7 @@ class _SideEffectingYaesuRadio:
         "vox",
         "compressor",
         "rit",
+        "xit",
         "tuner",
         "dial_lock",
         "cw",

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -56,6 +56,7 @@ def _make_radio() -> MagicMock:
         "notch",
         "split",
         "rit",
+        "xit",
         "tuner",
         "dial_lock",
         "cw",
@@ -1237,6 +1238,63 @@ async def test_tx_controls_poll_skips_fields_without_matching_runtime_capability
     radio.read_cw_pitch.assert_not_awaited()
     radio.read_break_in.assert_not_awaited()
     radio.read_break_in_delay.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("capabilities", "expected_paths"),
+    [
+        (
+            {"rit"},
+            {
+                "global.tx_state.rit_on",
+                "global.operator_controls.rit_freq",
+            },
+        ),
+        (
+            {"xit"},
+            {
+                "global.tx_state.rit_tx",
+                "global.operator_controls.rit_freq",
+            },
+        ),
+        (
+            {"rit", "xit"},
+            {
+                "global.tx_state.rit_on",
+                "global.tx_state.rit_tx",
+                "global.operator_controls.rit_freq",
+            },
+        ),
+        (set(), set()),
+    ],
+)
+async def test_tx_controls_poll_scopes_clarifier_state_to_declared_capabilities(
+    capabilities: set[str], expected_paths: set[str]
+) -> None:
+    radio = _make_radio()
+    radio.capabilities = capabilities
+    adapter = YaesuObservationAdapter(
+        radio,
+        profile=_profile_state_acquisition(),
+        clock=_clock,
+    )
+
+    observations = await adapter.poll_tx_controls()
+
+    clarifier_observations = {
+        str(item.path): item.value
+        for item in observations
+        if str(item.path).startswith("global.tx_state.rit_")
+        or str(item.path) == "global.operator_controls.rit_freq"
+    }
+    assert set(clarifier_observations) == expected_paths
+    if capabilities:
+        radio.read_clarifier.assert_awaited_once()
+        radio.read_clarifier_freq.assert_awaited_once()
+    else:
+        radio.read_clarifier.assert_not_awaited()
+        radio.read_clarifier_freq.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_cat_observation_adapter.py
+++ b/tests/test_yaesu_cat_observation_adapter.py
@@ -1110,11 +1110,8 @@ async def test_tx_controls_poll_emits_global_setpoints() -> None:
         # split (MOR-446) is a global tx_state bool, gated on the ``split``
         # capability — mirroring the legacy poller's ``"split" in caps`` gate.
         ("global.tx_state.split", True),
-        # Clarifier RIT/XIT (MOR-454): global tx_state bools + global
-        # operator-control signed Hz offset, gated on the ``rit`` capability —
-        # mirroring the legacy poller's ``"rit" in caps`` gate. A single
-        # ``read_clarifier`` read feeds both flags; ``read_clarifier_freq``
-        # feeds the signed offset on the device scale.
+        # Clarifier RIT/XIT (MOR-454): independently declared global tx_state
+        # flags plus the shared global operator-control signed offset.
         ("global.tx_state.rit_on", True),
         ("global.tx_state.rit_tx", False),
         ("global.operator_controls.rit_freq", -250),
@@ -1228,7 +1225,7 @@ async def test_tx_controls_poll_skips_fields_without_matching_runtime_capability
     radio.read_vox.assert_not_awaited()
     # split is dropped: the ``split`` runtime cap is absent here.
     radio.read_split.assert_not_awaited()
-    # RIT/XIT is dropped: the ``rit`` runtime cap is absent here (MOR-454).
+    # RIT/XIT is dropped: neither runtime capability is present (MOR-454).
     radio.read_clarifier.assert_not_awaited()
     radio.read_clarifier_freq.assert_not_awaited()
     # Tuner + dial-lock are dropped: ``tuner``/``dial_lock`` caps absent (MOR-455).
@@ -1389,9 +1386,8 @@ async def test_adapter_uses_read_only_yaesu_paths_when_getters_mutate_state() ->
         ("global.operator_controls.compressor_level", 25),
         ("global.tx_state.vox_on", True),
         # split is skipped: this radio lacks the ``split`` runtime cap.
-        # Clarifier RIT/XIT (MOR-454): gated on the ``rit`` cap (present here);
-        # a single ``read_clarifier`` feeds both flags, ``read_clarifier_freq``
-        # the signed Hz offset — none of which mutate legacy state.
+        # Clarifier RIT/XIT (MOR-454): both capabilities are present; shared
+        # clarifier reads do not mutate legacy state.
         ("global.tx_state.rit_on", True),
         ("global.tx_state.rit_tx", False),
         ("global.operator_controls.rit_freq", -250),

--- a/tests/test_yaesu_cat_poller.py
+++ b/tests/test_yaesu_cat_poller.py
@@ -667,6 +667,7 @@ def make_radio(
         "compressor",
         "cw",
         "rit",
+        "xit",
         "tuner",
         "meters",
         "repeater_tone",
@@ -2480,6 +2481,41 @@ async def test_observation_poller_uses_read_only_paths_when_getters_mutate_state
     assert radio.radio_state.split is False
     assert radio.radio_state.active == "MAIN"
     assert radio.radio_state.vfo_select == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        ({"rit"}, (True, True, -250)),
+        ({"xit"}, (False, False, -250)),
+        ({"rit", "xit"}, (True, False, -250)),
+        (set(), (False, True, 123)),
+    ],
+)
+async def test_legacy_slow_poll_scopes_clarifier_state_to_declared_capabilities(
+    capabilities: set[str], expected: tuple[bool, bool, int]
+) -> None:
+    radio = make_radio(clarifier=(True, False), clarifier_freq=-250)
+    radio.capabilities = capabilities
+    radio.radio_state.rit_on = False
+    radio.radio_state.rit_tx = True
+    radio.radio_state.rit_freq = 123
+    poller = YaesuCatPoller(radio)
+
+    await poller._poll_slow()  # noqa: SLF001
+
+    assert (
+        radio.radio_state.rit_on,
+        radio.radio_state.rit_tx,
+        radio.radio_state.rit_freq,
+    ) == expected
+    if capabilities:
+        radio.get_clarifier.assert_awaited_once()
+        radio.get_clarifier_freq.assert_awaited_once()
+    else:
+        radio.get_clarifier.assert_not_awaited()
+        radio.get_clarifier_freq.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaesu_web_projection.py
+++ b/tests/test_yaesu_web_projection.py
@@ -184,6 +184,7 @@ def _make_radio() -> MagicMock:
         "notch",
         "split",
         "rit",
+        "xit",
         "tuner",
         "dial_lock",
         "cw",


### PR DESCRIPTION
Linear: MOR-2311

Base-integrated head: `edcf7e4793060765caaab145fbcfc50c603cea9d`

Scope: Yaesu observation-adapter and legacy polling treat declared `rit` and `xit` independently: shared clarifier reads occur when either is declared; only declared RIT/XIT flags publish; the shared frequency publishes once. Tests pin RIT-only, XIT-only, both, and neither in both paths.

Correction: natural quick 33814908736 failed three Yaesu web-projection RIT cases (3 failed, 15140 passed, 220 skipped, 15 xfailed). The projection fixture declared only `rit` while asserting both RIT and XIT public facts, contradicting the FTX-1 profile and MOR-2311 independent-capability semantics. `tests/test_yaesu_web_projection.py` now explicitly declares `xit`; no production polling logic changed.

Static evidence for correction head: changed-file Ruff check, Ruff format check, and Python compilation passed. No test suite, focused carrier, browser, or hardware check was rerun.

Evidence boundary: no command execution, setters, profiles, Web admission, PTT/TX authority, provider wire encoding, or hardware behavior changed.