### PR TITLE
feat: publish RX antenna topology capability (MOR-2310)

### DIFF
--- a/frontend/src/lib/types/__tests__/capabilities.antenna-topology.test.ts
+++ b/frontend/src/lib/types/__tests__/capabilities.antenna-topology.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { Capabilities } from '../capabilities';
+import { validateCapabilities } from '../capabilities';
+
+const baseCapabilities = {
+  model: 'Test Radio',
+  scope: false,
+  audio: false,
+  tx: false,
+  capabilities: [],
+  receivers: 1,
+  vfoScheme: 'ab' as const,
+  freqRanges: [],
+  modes: [],
+  filters: [],
+  audioConfig: { sampleRate: 48_000, channels: 1, codecs: ['pcm'] },
+  webrtc: { available: false, enabled: false },
+  txBands: null,
+};
+
+const optionalContract: Pick<Capabilities, 'hasRxAntenna'> = {};
+void optionalContract;
+
+describe('RX antenna topology capability', () => {
+  it.each([true, false])('accepts explicit boolean value %s', (hasRxAntenna) => {
+    const payload = { ...baseCapabilities, hasRxAntenna };
+    expect(validateCapabilities(payload)).toBe(payload);
+  });
+
+  it('keeps the additive field optional for older servers', () => {
+    expect(validateCapabilities(baseCapabilities)).toBe(baseCapabilities);
+  });
+
+  it('rejects a non-boolean value when the field is present', () => {
+    expect(() => validateCapabilities({ ...baseCapabilities, hasRxAntenna: 1 })).toThrow(
+      /Invalid capabilities payload at \$\.hasRxAntenna: expected a boolean/,
+    );
+  });
+});

--- a/frontend/src/lib/types/capabilities.ts
+++ b/frontend/src/lib/types/capabilities.ts
@@ -183,6 +183,7 @@ export interface Capabilities {
   dataModeLabels?: Record<string, string>;
   keyboard?: KeyboardConfig | null;
   antennas?: number;      // Number of antenna ports
+  hasRxAntenna?: boolean;
   scopeSource?: string | null;  // "hardware", "audio_fft", or null
   audioFftAvailable?: boolean;  // true when audio FFT scope is available (even with hardware scope)
   scopeConfig?: ScopeConfig;
@@ -447,6 +448,9 @@ export function validateCapabilities(value: unknown): Capabilities {
   requireBoolean(raw.tx, '$.tx');
   requireStringArray(raw.capabilities, '$.capabilities');
   requireInteger(raw.receivers, '$.receivers', true);
+  if (Object.prototype.hasOwnProperty.call(raw, 'hasRxAntenna')) {
+    requireBoolean(raw.hasRxAntenna, '$.hasRxAntenna');
+  }
 
   const txAudioFields = [
     'audioTx',

--- a/src/rigplane/profiles/__init__.py
+++ b/src/rigplane/profiles/__init__.py
@@ -407,6 +407,7 @@ class RadioProfile:
     rules: tuple[RuleSpec, ...] = ()
     keyboard: KeyboardConfig | None = None
     antenna_tx_count: int = 1
+    antenna_has_rx_ant: bool = False
     transceiver_count: int = 1
     scope_ref_min_db: float | None = None
     scope_ref_max_db: float | None = None

--- a/src/rigplane/profiles/rig_loader.py
+++ b/src/rigplane/profiles/rig_loader.py
@@ -779,6 +779,7 @@ class RigConfig:
             rules=self.rules,
             keyboard=self.keyboard,
             antenna_tx_count=self.antenna_tx_count,
+            antenna_has_rx_ant=self.antenna_has_rx_ant,
             transceiver_count=self.transceiver_count,
             scope_ref_min_db=self.scope_ref_min_db,
             scope_ref_max_db=self.scope_ref_max_db,

--- a/src/rigplane/web/server.py
+++ b/src/rigplane/web/server.py
@@ -3038,6 +3038,7 @@ class WebServer:
                     "agcLabels": profile.agc_labels,
                     "rfSqlControlModel": profile.rf_sql_control_model,
                     "antennas": profile.antenna_tx_count,
+                    "hasRxAntenna": profile.antenna_has_rx_ant,
                     "dataModeCount": profile.data_mode_count,
                     "dataModeLabels": profile.data_mode_labels,
                     "keyboard": _serialize_keyboard_config(profile),
@@ -3533,6 +3534,7 @@ class WebServer:
                 "jitterCeilingMs": get_audio_rx_jitter_ceiling_ms(),
             },
             "antennas": profile.antenna_tx_count,
+            "hasRxAntenna": profile.antenna_has_rx_ant,
             "webrtc": {
                 "available": webrtc_available(),
                 "enabled": self._config.webrtc_enabled,

--- a/tests/test_rig_loader.py
+++ b/tests/test_rig_loader.py
@@ -1392,6 +1392,23 @@ class TestToProfile:
         assert profile.supports_command("get_antenna") is False
         assert profile.supports_command("set_antenna") is False
 
+    @pytest.mark.parametrize(
+        ("filename", "tx_count", "has_rx_antenna"),
+        [
+            ("ic705.toml", 1, True),
+            ("ic7610.toml", 2, True),
+            ("ic7300.toml", 1, False),
+            ("ic9700.toml", 1, False),
+        ],
+    )
+    def test_antenna_topology_propagates_to_profile(
+        self, filename: str, tx_count: int, has_rx_antenna: bool
+    ):
+        profile = load_rig(RIGS_DIR / filename).to_profile()
+
+        assert profile.antenna_tx_count == tx_count
+        assert profile.antenna_has_rx_ant is has_rx_antenna
+
     def test_capabilities_frozenset(self):
         profile = load_rig(TEMPLATE_PATH).to_profile()
         assert isinstance(profile.capabilities, frozenset)

--- a/tests/test_web_api_contract.py
+++ b/tests/test_web_api_contract.py
@@ -69,6 +69,10 @@ scheme = "ab"
 
 [commands.overrides]
 
+[antenna]
+tx_count = 2
+has_rx_ant = true
+
 [controls.identity]
 mapping = "identity"
 raw_min = -2
@@ -141,6 +145,8 @@ async def test_control_domains_round_trip_through_both_capability_endpoints(
     """The shared JSON is derived only by loading TOML into a RadioProfile."""
     profile = _golden_profile(tmp_path)
     assert profile.controls == _golden_controls()
+    assert profile.antenna_tx_count == 2
+    assert profile.antenna_has_rx_ant is True
     radio = SimpleNamespace(
         model=profile.model,
         profile=profile,
@@ -161,7 +167,12 @@ async def test_control_domains_round_trip_through_both_capability_endpoints(
             if path == "/api/v1/info"
             else payload["controls"]
         )
+        capability_payload = (
+            payload["capabilities"] if path == "/api/v1/info" else payload
+        )
         assert controls == _golden_controls()
+        assert capability_payload["antennas"] == 2
+        assert capability_payload["hasRxAntenna"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_capability_guards.py
+++ b/tests/test_web_capability_guards.py
@@ -523,6 +523,40 @@ class TestCapabilitiesEndpoint:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
+        ("tx_count", "has_rx_antenna", "has_rx_actuator"),
+        [
+            (2, False, True),
+            (1, True, False),
+        ],
+    )
+    async def test_capabilities_keeps_antenna_topology_and_actuator_independent(
+        self, tx_count: int, has_rx_antenna: bool, has_rx_actuator: bool
+    ):
+        radio = _make_radio("IC-7610")
+        capabilities = set(radio.profile.capabilities)
+        if has_rx_actuator:
+            capabilities.add("rx_antenna")
+        else:
+            capabilities.discard("rx_antenna")
+        radio.profile = replace(
+            radio.profile,
+            antenna_tx_count=tx_count,
+            antenna_has_rx_ant=has_rx_antenna,
+            capabilities=frozenset(capabilities),
+        )
+        radio.capabilities = capabilities
+        srv = WebServer(radio)
+        writer = _FakeWriter()
+
+        await srv._serve_capabilities(writer)  # noqa: SLF001
+
+        data = _parse_json_body(writer)
+        assert data["antennas"] == tx_count
+        assert data["hasRxAntenna"] is has_rx_antenna
+        assert ("rx_antenna" in data["capabilities"]) is has_rx_actuator
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
         ("model", "expected"),
         [
             ("IC-705", {"vfo_swap", "vfo_equalize"}),


### PR DESCRIPTION
Soft-threshold rationale: 8 files form one config-to-profile-to-two-Web-endpoints-to-frontend-validator contract, with each layer covered in its existing focused test surface.

Linear: https://linear.app/morozsm/issue/MOR-2310/preserve-antennahas-rx-ant-through-radioprofile-and-public-capability

## Scope
- add additive `RadioProfile.antenna_has_rx_ant` and preserve parsed `[antenna].has_rx_ant`
- publish explicit `hasRxAntenna` through `/api/v1/info.capabilities` and `/api/v1/capabilities`
- keep TX antenna count, RX-jack topology, and `rx_antenna` actuator tagging independent
- type the frontend field as optional and validate it when present
- pin IC-705, IC-7610, IC-7300, and IC-9700 discriminants

## Exact candidate
- base: `bc4817b1437db6b089d8dc62a258d709cda1d17e`
- head: `7e75bb50568dc73891eebbbe8959cb756957a396`
- base refresh: normal merge of disjoint PR #3139; `git diff --name-only origin/main...HEAD` remains the same 8 MOR-2310 files

## Focused evidence
- targeted Ruff check/format: clean
- `uv run mypy --strict src/rigplane/web`: 26 source files clean
- `npm --prefix frontend run check`: 0 errors, 0 warnings
- targeted frontend ESLint: clean
- local owner-rule deviation (recorded once; not repeated): backend focused pytest 443 passed / 1 skipped and frontend Vitest 4 passed were run before the coordinator correction limiting local work to static checks
- single Mac mini carrier run `33813740937` succeeded against implementation SHA `6b0a03cd52dd0732d67db6d0d3516addab007354`: pytest, Ruff check/format, and Vitest all returned 0
- PR #3139 was path-disjoint and all eight reviewed MOR-2310 file blobs are byte-identical after the normal merge; no extra carrier was dispatched
- independent exact-head review: PASS at `7e75bb50568dc73891eebbbe8959cb756957a396` (https://github.com/rigplane/rigplane-core/pull/3141#issuecomment-5533115632)

## Evidence boundary
No antenna command, UI rendering, PTT/TX authority, provider write, hardware, full-suite, visual, or browser behavior is changed or claimed. Exact-head natural quick `33814433474` and visual run `33814433710` completed successfully; independent exact-head review is complete.
