### PR TITLE
fix: register managed PTT submissions before scheduling

### DIFF
--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -171,10 +171,31 @@ class ManagedTxAuthority:
         return submission.outcome
 
     async def submit_ptt(
-        self, on: bool, owner: str, *, ready: asyncio.Future[Any] | None = None
+        self,
+        on: bool,
+        owner: str,
+        *,
+        ready: asyncio.Future[Any] | None = None,
+        _registered: asyncio.Future[None] | None = None,
     ) -> ManagedTxSubmission:
-        """Return after owner-scoped admission, before provider settlement."""
-        worker, admitted = self._begin_ptt_operation(on, owner, ready=ready)
+        """Acknowledge pending membership, then return after admission."""
+        if _registered is not None:
+            if not isinstance(_registered, asyncio.Future):
+                raise TypeError("PTT registration acknowledgement must be a Future")
+            if _registered.done():
+                raise ValueError("PTT registration acknowledgement must be pending")
+        try:
+            worker, admitted = self._begin_ptt_operation(on, owner, ready=ready)
+        except asyncio.CancelledError:
+            if _registered is not None:
+                _registered.cancel()
+            raise
+        except BaseException as error:
+            if _registered is not None:
+                _registered.set_exception(error)
+            raise
+        if _registered is not None:
+            _registered.set_result(None)
         try:
             transition = await asyncio.shield(admitted)
         except asyncio.CancelledError:

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -170,39 +170,46 @@ class ManagedTxAuthority:
         await submission.wait_settlement()
         return submission.outcome
 
-    async def submit_ptt(
+    def submit_ptt(
         self,
         on: bool,
         owner: str,
         *,
         ready: asyncio.Future[Any] | None = None,
         _registered: asyncio.Future[None] | None = None,
-    ) -> ManagedTxSubmission:
-        """Acknowledge pending membership, then return after admission."""
+    ) -> asyncio.Task[ManagedTxSubmission]:
+        """Start an owned submission and acknowledge its pending membership."""
         if _registered is not None:
             if not isinstance(_registered, asyncio.Future):
                 raise TypeError("PTT registration acknowledgement must be a Future")
             if _registered.done():
                 raise ValueError("PTT registration acknowledgement must be pending")
-        try:
+
+        async def submit() -> ManagedTxSubmission:
             worker, admitted = self._begin_ptt_operation(on, owner, ready=ready)
-        except asyncio.CancelledError:
             if _registered is not None:
-                _registered.cancel()
-            raise
-        except BaseException as error:
-            if _registered is not None:
-                _registered.set_exception(error)
-            raise
+                _registered.set_result(None)
+            try:
+                transition = await asyncio.shield(admitted)
+            except asyncio.CancelledError:
+                worker.cancel()
+                await self._drain_cancelled(worker)
+                raise
+            return ManagedTxSubmission(transition, worker)
+
+        submission = asyncio.create_task(submit())
         if _registered is not None:
-            _registered.set_result(None)
-        try:
-            transition = await asyncio.shield(admitted)
-        except asyncio.CancelledError:
-            worker.cancel()
-            await self._drain_cancelled(worker)
-            raise
-        return ManagedTxSubmission(transition, worker)
+
+            def settle_unstarted(task: asyncio.Task[ManagedTxSubmission]) -> None:
+                if _registered.done():
+                    return
+                if task.cancelled():
+                    _registered.cancel()
+                elif error := task.exception():
+                    _registered.set_exception(error)
+
+            submission.add_done_callback(settle_unstarted)
+        return submission
 
     async def _start_ptt_operation(
         self, on: bool, owner: str, *, ready: asyncio.Future[Any] | None = None

--- a/src/rigplane/runtime/managed_tx_authority.py
+++ b/src/rigplane/runtime/managed_tx_authority.py
@@ -170,25 +170,36 @@ class ManagedTxAuthority:
         await submission.wait_settlement()
         return submission.outcome
 
-    def submit_ptt(
+    async def submit_ptt(
         self,
         on: bool,
         owner: str,
         *,
         ready: asyncio.Future[Any] | None = None,
-        _registered: asyncio.Future[None] | None = None,
+    ) -> ManagedTxSubmission:
+        """Return admission after starting the authority-owned submission."""
+        return await self.start_ptt_submission(on, owner, ready=ready)
+
+    def start_ptt_submission(
+        self,
+        on: bool,
+        owner: str,
+        *,
+        ready: asyncio.Future[Any] | None = None,
     ) -> asyncio.Task[ManagedTxSubmission]:
-        """Start an owned submission and acknowledge its pending membership."""
-        if _registered is not None:
-            if not isinstance(_registered, asyncio.Future):
-                raise TypeError("PTT registration acknowledgement must be a Future")
-            if _registered.done():
-                raise ValueError("PTT registration acknowledgement must be pending")
+        """Start a managed-ingress submission with membership installed.
+
+        Unlike :meth:`submit_ptt`, this synchronous seam guarantees that the
+        authority's canonical fence membership exists before it returns.
+        """
+        started = asyncio.get_running_loop().create_future()
+        worker, admitted = self._begin_ptt_operation(
+            on, owner, ready=ready, _started=started
+        )
 
         async def submit() -> ManagedTxSubmission:
-            worker, admitted = self._begin_ptt_operation(on, owner, ready=ready)
-            if _registered is not None:
-                _registered.set_result(None)
+            if not started.done():
+                started.set_result(None)
             try:
                 transition = await asyncio.shield(admitted)
             except asyncio.CancelledError:
@@ -198,17 +209,14 @@ class ManagedTxAuthority:
             return ManagedTxSubmission(transition, worker)
 
         submission = asyncio.create_task(submit())
-        if _registered is not None:
 
-            def settle_unstarted(task: asyncio.Task[ManagedTxSubmission]) -> None:
-                if _registered.done():
-                    return
-                if task.cancelled():
-                    _registered.cancel()
-                elif error := task.exception():
-                    _registered.set_exception(error)
+        def own_submission(task: asyncio.Task[ManagedTxSubmission]) -> None:
+            if task.cancelled():
+                worker.cancel()
+            else:
+                task.exception()
 
-            submission.add_done_callback(settle_unstarted)
+        submission.add_done_callback(own_submission)
         return submission
 
     async def _start_ptt_operation(
@@ -230,7 +238,12 @@ class ManagedTxAuthority:
         return worker
 
     def _begin_ptt_operation(
-        self, on: bool, owner: str, *, ready: asyncio.Future[Any] | None = None
+        self,
+        on: bool,
+        owner: str,
+        *,
+        ready: asyncio.Future[Any] | None = None,
+        _started: asyncio.Future[None] | None = None,
     ) -> tuple[_SubmissionCompletion, asyncio.Future[ManagedTxTransition]]:
         """Build the one cancellable operation and its admission signal."""
         if type(on) is not bool or type(owner) is not str:
@@ -250,6 +263,8 @@ class ManagedTxAuthority:
         async def run() -> tuple[ManagedTxTransition, ActuationSettled | None]:
             execution: asyncio.Task[ActuationSettled | None] | None = None
             try:
+                if _started is not None:
+                    await asyncio.wait((_started,))
                 if on and ready is not None:
                     await asyncio.wait((ready,))
                 async with self._lock:

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import inspect
 from pathlib import Path
 
@@ -130,6 +131,10 @@ async def test_ignored_closed_start_task_is_owned_but_await_still_raises() -> No
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert ignored.done() and not unhandled
+        del ignored
+        gc.collect()
+        await asyncio.sleep(0)
+        assert not unhandled
 
         awaited = managed.start_ptt_submission(True, "awaited")
         with pytest.raises(RuntimeError, match="closed") as raised:

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -1,11 +1,11 @@
 import asyncio
+import inspect
 from pathlib import Path
 
 import pytest
 
 from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.runtime.managed_tx_authority import ManagedTxAuthority
-from rigplane.runtime.managed_tx_fence import TxAbortFence
 from rigplane.runtime.managed_tx_state import (
     ActuationOperation,
     ActuationResult,
@@ -26,43 +26,28 @@ async def finish(managed: ManagedTxAuthority) -> None:
     await managed.close()
 
 
-class MembershipAck(asyncio.Future[None]):
-    def __init__(self, fence: TxAbortFence, owner: str) -> None:
-        super().__init__()
-        self._fence = fence
-        self._owner = owner
-
-    def set_result(self, result: None) -> None:
-        assert any(
-            scope == self._owner
-            for _cancellation, scope in self._fence._cancellations.values()
-        )
-        super().set_result(result)
+async def wait_for_submission_cleanup(managed: ManagedTxAuthority) -> None:
+    for _ in range(10):
+        if not managed._abort_fence._cancellations and not managed._settlement_tasks:
+            return
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
-async def test_ptt_registration_ack_precedes_ready_and_closes_owner_cancel_race() -> (
-    None
-):
+async def test_submit_ptt_remains_a_coroutine_accepted_by_create_task() -> None:
     managed, _, _, _, fence, lane = authority()
     ready = asyncio.get_running_loop().create_future()
-    registered = MembershipAck(fence, "owner")
-    admission = managed.submit_ptt(
-        True,
-        "owner",
-        ready=ready,
-        _registered=registered,
-    )
+    assert inspect.iscoroutinefunction(ManagedTxAuthority.submit_ptt)
+    coroutine = managed.submit_ptt(True, "owner", ready=ready)
+    assert inspect.iscoroutine(coroutine)
+    admission = asyncio.create_task(coroutine)
     try:
-        await asyncio.wait_for(asyncio.shield(registered), 0.2)
-        assert not ready.done() and not admission.done() and not lane.effects
-
-        release = await asyncio.wait_for(managed.submit_ptt(False, "owner"), 0.2)
-        assert release.outcome is ManagedTxOutcome.REJECTED
-        assert await release.wait_settlement() is None
-        with pytest.raises(asyncio.CancelledError):
-            await asyncio.wait_for(admission, 0.2)
-        assert not lane.effects
+        await asyncio.sleep(0)
+        assert fence._cancellations and not lane.effects
+        admission.cancel()
+        await asyncio.gather(admission, return_exceptions=True)
+        await wait_for_submission_cleanup(managed)
+        assert not fence._cancellations and not managed._settlement_tasks
     finally:
         ready.cancel()
         await asyncio.gather(admission, return_exceptions=True)
@@ -70,57 +55,115 @@ async def test_ptt_registration_ack_precedes_ready_and_closes_owner_cancel_race(
 
 
 @pytest.mark.asyncio
-async def test_ptt_registration_ack_settles_on_pre_registration_error() -> None:
-    managed, _, _, _, _, _ = authority()
-    registered = asyncio.get_running_loop().create_future()
+async def test_unawaited_submit_ptt_coroutine_is_inert() -> None:
+    managed, _, _, _, fence, lane = authority()
+    ready = asyncio.get_running_loop().create_future()
+    pending = managed.submit_ptt(True, "owner", ready=ready)
     try:
-        with pytest.raises(TypeError) as submission_error:
-            await managed.submit_ptt(  # type: ignore[arg-type]
-                True,
-                7,
-                _registered=registered,
-            )
-        with pytest.raises(TypeError) as registration_error:
-            await asyncio.wait_for(registered, 0.2)
-        assert registration_error.value is submission_error.value
+        assert inspect.iscoroutine(pending)
+        assert not fence._cancellations and not managed._settlement_tasks
+        pending.close()
+        ready.set_result(None)
+        await asyncio.sleep(0)
+        assert not lane.effects
     finally:
+        if isinstance(pending, asyncio.Task):
+            pending.cancel()
+            await asyncio.gather(pending, return_exceptions=True)
+        elif inspect.iscoroutine(pending):
+            pending.close()
+        if not ready.done():
+            ready.cancel()
         await finish(managed)
 
 
 @pytest.mark.asyncio
-async def test_ptt_registration_ack_settles_on_pre_registration_cancel(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    managed, _, _, _, _, _ = authority()
-    registered = asyncio.get_running_loop().create_future()
-
-    def cancel_before_registration(*_args: object, **_kwargs: object) -> None:
-        raise asyncio.CancelledError
-
-    monkeypatch.setattr(managed, "_begin_ptt_operation", cancel_before_registration)
+async def test_start_ptt_submission_registers_membership_before_return() -> None:
+    managed, _, _, _, fence, lane = authority()
+    ready = asyncio.get_running_loop().create_future()
+    submission = None
     try:
-        with pytest.raises(asyncio.CancelledError):
-            await managed.submit_ptt(True, "owner", _registered=registered)
-        assert registered.cancelled()
+        submission = managed.start_ptt_submission(True, "owner", ready=ready)
+        assert isinstance(submission, asyncio.Task)
+        assert any(
+            scope == "owner"
+            for _cancellation, scope in fence._cancellations.values()
+        )
+        assert len(managed._settlement_tasks) == 1
+        assert not ready.done() and not lane.effects
     finally:
+        if submission is not None:
+            submission.cancel()
+            await asyncio.gather(submission, return_exceptions=True)
+        ready.cancel()
+        await wait_for_submission_cleanup(managed)
         await finish(managed)
 
 
 @pytest.mark.asyncio
-async def test_ptt_registration_ack_settles_when_submission_never_starts() -> None:
-    managed, _, _, _, _, _ = authority()
-    registered = asyncio.get_running_loop().create_future()
-    pending = managed.submit_ptt(True, "owner", _registered=registered)
-    submission = (
-        pending if isinstance(pending, asyncio.Task) else asyncio.create_task(pending)
-    )
+async def test_start_ptt_immediate_cancel_drains_before_ready_can_run() -> None:
+    managed, _, _, _, fence, lane = authority()
+    ready = asyncio.get_running_loop().create_future()
+    submission = managed.start_ptt_submission(True, "owner", ready=ready)
     submission.cancel()
+    ready.set_result(None)
     try:
         await asyncio.gather(submission, return_exceptions=True)
-        assert registered.cancelled()
+        await wait_for_submission_cleanup(managed)
+        assert not fence._cancellations
+        assert not managed._settlement_tasks
+        assert not lane.effects
     finally:
-        if not registered.done():
-            registered.cancel()
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_ignored_closed_start_task_is_owned_but_await_still_raises() -> None:
+    managed, _, _, _, fence, _ = authority()
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    unhandled: list[dict[str, object]] = []
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+    try:
+        await managed.close()
+        ignored = managed.start_ptt_submission(True, "ignored")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert ignored.done() and not unhandled
+
+        awaited = managed.start_ptt_submission(True, "awaited")
+        with pytest.raises(RuntimeError, match="closed") as raised:
+            await awaited
+        assert raised.value is awaited.exception()
+        await wait_for_submission_cleanup(managed)
+        assert not fence._cancellations and not managed._settlement_tasks
+        assert not unhandled
+    finally:
+        loop.set_exception_handler(previous_handler)
+        await managed.close()
+
+
+@pytest.mark.asyncio
+async def test_same_owner_t0_cancels_started_t1_before_ready() -> None:
+    managed, _, _, _, fence, lane = authority()
+    ready = asyncio.get_running_loop().create_future()
+    t1 = managed.start_ptt_submission(True, "owner", ready=ready)
+    try:
+        assert fence._cancellations and not lane.effects
+        t0 = managed.start_ptt_submission(False, "owner")
+        release = await asyncio.wait_for(t0, 0.2)
+        assert release.outcome is ManagedTxOutcome.REJECTED
+        assert await release.wait_settlement() is None
+        with pytest.raises(asyncio.CancelledError):
+            await t1
+        ready.set_result(None)
+        await wait_for_submission_cleanup(managed)
+        assert not fence._cancellations and not managed._settlement_tasks
+        assert not lane.effects
+    finally:
+        if not ready.done():
+            ready.cancel()
+        await asyncio.gather(t1, return_exceptions=True)
         await finish(managed)
 
 
@@ -129,7 +172,9 @@ async def test_ptt_receipt_waits_for_predecessor_and_not_provider_settlement() -
     managed, _, _, _, _, lane = authority()
     predecessor = asyncio.get_running_loop().create_future()
     provider_release = lane.block_next()
-    admission = managed.submit_ptt(True, "owner", ready=predecessor)
+    admission = asyncio.create_task(
+        managed.submit_ptt(True, "owner", ready=predecessor)
+    )
     try:
         await asyncio.sleep(0)
         assert not admission.done() and not lane.effects

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -47,13 +47,11 @@ async def test_ptt_registration_ack_precedes_ready_and_closes_owner_cancel_race(
     managed, _, _, _, fence, lane = authority()
     ready = asyncio.get_running_loop().create_future()
     registered = MembershipAck(fence, "owner")
-    admission = asyncio.create_task(
-        managed.submit_ptt(
-            True,
-            "owner",
-            ready=ready,
-            _registered=registered,
-        )
+    admission = managed.submit_ptt(
+        True,
+        "owner",
+        ready=ready,
+        _registered=registered,
     )
     try:
         await asyncio.wait_for(asyncio.shield(registered), 0.2)
@@ -131,9 +129,7 @@ async def test_ptt_receipt_waits_for_predecessor_and_not_provider_settlement() -
     managed, _, _, _, _, lane = authority()
     predecessor = asyncio.get_running_loop().create_future()
     provider_release = lane.block_next()
-    admission = asyncio.create_task(
-        managed.submit_ptt(True, "owner", ready=predecessor)
-    )
+    admission = managed.submit_ptt(True, "owner", ready=predecessor)
     try:
         await asyncio.sleep(0)
         assert not admission.done() and not lane.effects

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -83,7 +83,7 @@ async def test_ptt_registration_ack_settles_on_pre_registration_error() -> None:
                 _registered=registered,
             )
         with pytest.raises(TypeError) as registration_error:
-            await registered
+            await asyncio.wait_for(registered, 0.2)
         assert registration_error.value is submission_error.value
     finally:
         await finish(managed)

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -5,6 +5,7 @@ import pytest
 
 from rigplane.core.state_pipeline_contracts import CommandIntent
 from rigplane.runtime.managed_tx_authority import ManagedTxAuthority
+from rigplane.runtime.managed_tx_fence import TxAbortFence
 from rigplane.runtime.managed_tx_state import (
     ActuationOperation,
     ActuationResult,
@@ -23,6 +24,88 @@ async def finish(managed: ManagedTxAuthority) -> None:
     if state.release_required or state.intent.kind is not ManagedTxIntentKind.RX:
         await managed.force_off()
     await managed.close()
+
+
+class MembershipAck(asyncio.Future[None]):
+    def __init__(self, fence: TxAbortFence, owner: str) -> None:
+        super().__init__()
+        self._fence = fence
+        self._owner = owner
+
+    def set_result(self, result: None) -> None:
+        assert any(
+            scope == self._owner
+            for _cancellation, scope in self._fence._cancellations.values()
+        )
+        super().set_result(result)
+
+
+@pytest.mark.asyncio
+async def test_ptt_registration_ack_precedes_ready_and_closes_owner_cancel_race() -> (
+    None
+):
+    managed, _, _, _, fence, lane = authority()
+    ready = asyncio.get_running_loop().create_future()
+    registered = MembershipAck(fence, "owner")
+    admission = asyncio.create_task(
+        managed.submit_ptt(
+            True,
+            "owner",
+            ready=ready,
+            _registered=registered,
+        )
+    )
+    try:
+        await asyncio.wait_for(asyncio.shield(registered), 0.2)
+        assert not ready.done() and not admission.done() and not lane.effects
+
+        release = await asyncio.wait_for(managed.submit_ptt(False, "owner"), 0.2)
+        assert release.outcome is ManagedTxOutcome.REJECTED
+        assert await release.wait_settlement() is None
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(admission, 0.2)
+        assert not lane.effects
+    finally:
+        ready.cancel()
+        await asyncio.gather(admission, return_exceptions=True)
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_ptt_registration_ack_settles_on_pre_registration_error() -> None:
+    managed, _, _, _, _, _ = authority()
+    registered = asyncio.get_running_loop().create_future()
+    try:
+        with pytest.raises(TypeError) as submission_error:
+            await managed.submit_ptt(  # type: ignore[arg-type]
+                True,
+                7,
+                _registered=registered,
+            )
+        with pytest.raises(TypeError) as registration_error:
+            await registered
+        assert registration_error.value is submission_error.value
+    finally:
+        await finish(managed)
+
+
+@pytest.mark.asyncio
+async def test_ptt_registration_ack_settles_on_pre_registration_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed, _, _, _, _, _ = authority()
+    registered = asyncio.get_running_loop().create_future()
+
+    def cancel_before_registration(*_args: object, **_kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(managed, "_begin_ptt_operation", cancel_before_registration)
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await managed.submit_ptt(True, "owner", _registered=registered)
+        assert registered.cancelled()
+    finally:
+        await finish(managed)
 
 
 @pytest.mark.asyncio

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -109,6 +109,24 @@ async def test_ptt_registration_ack_settles_on_pre_registration_cancel(
 
 
 @pytest.mark.asyncio
+async def test_ptt_registration_ack_settles_when_submission_never_starts() -> None:
+    managed, _, _, _, _, _ = authority()
+    registered = asyncio.get_running_loop().create_future()
+    pending = managed.submit_ptt(True, "owner", _registered=registered)
+    submission = (
+        pending if isinstance(pending, asyncio.Task) else asyncio.create_task(pending)
+    )
+    submission.cancel()
+    try:
+        await asyncio.gather(submission, return_exceptions=True)
+        assert registered.cancelled()
+    finally:
+        if not registered.done():
+            registered.cancel()
+        await finish(managed)
+
+
+@pytest.mark.asyncio
 async def test_ptt_receipt_waits_for_predecessor_and_not_provider_settlement() -> None:
     managed, _, _, _, _, lane = authority()
     predecessor = asyncio.get_running_loop().create_future()

--- a/tests/test_managed_tx_submission_contract.py
+++ b/tests/test_managed_tx_submission_contract.py
@@ -87,8 +87,7 @@ async def test_start_ptt_submission_registers_membership_before_return() -> None
         submission = managed.start_ptt_submission(True, "owner", ready=ready)
         assert isinstance(submission, asyncio.Task)
         assert any(
-            scope == "owner"
-            for _cancellation, scope in fence._cancellations.values()
+            scope == "owner" for _cancellation, scope in fence._cancellations.values()
         )
         assert len(managed._settlement_tasks) == 1
         assert not ready.done() and not lane.effects
@@ -128,8 +127,10 @@ async def test_ignored_closed_start_task_is_owned_but_await_still_raises() -> No
     try:
         await managed.close()
         ignored = managed.start_ptt_submission(True, "ignored")
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        for _ in range(10):
+            if ignored.done():
+                break
+            await asyncio.sleep(0)
         assert ignored.done() and not unhandled
         del ignored
         gc.collect()


### PR DESCRIPTION
## Summary
- preserve the coroutine contract of `submit_ptt`
- add one synchronous `start_ptt_submission` seam that installs canonical fence membership before returning
- keep cancellation, wrapper error retrieval, provider settlement, and shutdown ownership inside the existing `ManagedTxAuthority`

Linear owner: MOR-2306.

## Architecture
Both entry seams converge on the existing `_begin_ptt_operation`. This adds no queue, registry, worker authority, watchdog, target id, or acknowledgement protocol. There remains one `TxAbortFence`, one authority lock, one settlement registry, and one provider-effect lane.

MOR-2269 contract after merge: call `start_ptt_submission` exactly once and retain that Task. Authority cancellation or `REJECTED` wins over later validation success. Validation failure cancels and awaits the same Task. Never resubmit ON.

## Search before write
Searched the authority, submission contract, ingress admission tests, every in-tree `submit_ptt` caller, `TxAbortFence` ownership, settlement ownership, provider replacement, and shutdown paths before implementation. No existing synchronous registration seam covered the same contract.

## TDD and Mini evidence
- RED head `1119b9d29b708957e0f39cd877068b06b07a2c71`, run `33811212536`: 6/6 intended discriminants failed.
- GREEN head `e038e35204a410d59ed2b3cfcd4b013d7c85ee7f`, run `33811798589`: 101/101 passed; Ruff check and format passed.
- Mutation A `f4301d06647d27ccaa598a1c2fef0b746e0760ee`, run `33812152932`: moving begin after scheduling failed synchronous-membership proof.
- Mutation B `052346339076aecd2dda86f7a59ce8d08cae586c`, run `33812196744`: removing prestart cancellation ownership left fence/settlement state and failed.
- Mutation C `4782d29f5126553575ec6d2135166bace1389af2`, run `33812224943`: removing wrapper exception retrieval produced the exact unhandled-task failure.
- Mutation D `fa0d0ca9824b54dd5bcfddb0a25a74194bee24c0`, run `33812283848`: making public submit eager failed coroutine and inertness proofs.
- Restored mutation tree `f86b515833c96c77cd813a06992f1ca53e2d4798` is byte-identical to GREEN.

All project execution was on Mac Mini. No hardware or TX action was performed.

## Independent review
Three independent read-only reviews returned PASS on exact head `e038e35204a410d59ed2b3cfcd4b013d7c85ee7f`: code/API/concurrency, architecture/single-mechanism, and liveness/cancellation.

## Required pre-push tx_interlock grep
Command:
```
git grep -n "tx_interlock" -- src/rigplane/core/command_dispatch.py src/rigplane/runtime/command\*.py src/rigplane/web/handlers/control.py
```
Output at exact head:
```
src/rigplane/web/handlers/control.py:30:from ...runtime.tx_interlock import RfState, evaluate_tx_interlock
src/rigplane/web/handlers/control.py:1736:        decision = evaluate_tx_interlock(command, rf_state=rf_state)
src/rigplane/web/handlers/control.py:1975:            decision = evaluate_tx_interlock(
```
Zero hits in `command_dispatch.py` and runtime command files. Existing Web control hits are unchanged and remain in the MOR-2172 retirement inventory.

## Scope
Exactly 2 files, +202/-11. No public SDK, CLI, config, rigctld wire, or hardware behavior is cut over by this PR alone.
